### PR TITLE
refactor(templates): use full handlebars library (static import)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@trpc/server": "^11.17.0",
     "clsx": "^2.1.1",
     "cron-parser": "^5.5.0",
+    "handlebars": "^4.7.9",
     "html-to-docx": "^1.8.0",
     "isomorphic-git": "^1.38.4",
     "json-logic-js": "^2.0.5",

--- a/src/lib/client/kostnadsrakning/render-handlebars.ts
+++ b/src/lib/client/kostnadsrakning/render-handlebars.ts
@@ -1,168 +1,20 @@
 "use client";
 
 /**
- * `renderHandlebars` — minimal Handlebars-kompatibel template-renderer
- * för AVA:s mallar (kostnadsräkning, byrå-egna dokumentmallar).
+ * `renderHandlebars` — renderar en Handlebars-mall mot en kontext med det
+ * **fulla** `handlebars`-biblioteket, **statiskt importerat** (inga dynamiska
+ * imports). Bundle-storlek är underordnat full mall-fidelitet.
  *
- * Stöder:
- *   - `{{var}}` / `{{ var }}` / `{{var.nested}}` (path-lookup, trim:ar mellanrum)
- *   - `{{#if x}}…{{else}}…{{/if}}` (truthy + else-gren)
- *   - `{{#each list}}…{{/each}}` (item blir aktuell scope, parent-fallback)
- *   - `{{list.length}}`
- *   - godtycklig nästling av if/each
+ * Ersatte tidigare en egen mini-renderer (bara `{{var}}`/`{{#if}}`/`{{#each}}`).
+ * Full Handlebars ger helpers, partials, `{{{oescapat}}}`, kommentarer m.m.
+ * som byrå-författade mallar kan behöva.
  *
- * Arkitektur (SOLID — separata ansvar):
- *   1. `tokenize` → text- + mustache-tokens
- *   2. `parse`    → AST med korrekt block-nästling (stack-baserat)
- *   3. `renderNodes` → ren rendering mot scope
- *
- * Custom mini-renderer istället för full `handlebars`-bundle (~50 KB).
- * Pure, ingen DOM. Lätt att testa.
+ * OBS standard-Handlebars-semantik: parent-scope inuti `{{#each}}` nås via
+ * `{{../var}}` (den gamla mini-renderern gjorde det implicit).
  */
 
-interface Scope {
-  readonly value: unknown;
-  readonly parent?: Scope;
-}
-
-// ── AST ──────────────────────────────────────────────────────────────
-type Node =
-  | { kind: "text"; text: string }
-  | { kind: "var"; path: string }
-  | { kind: "if"; path: string; then: Node[]; else: Node[] }
-  | { kind: "each"; path: string; body: Node[] };
-
-type Token =
-  | { t: "text"; v: string }
-  | { t: "var"; v: string }
-  | { t: "if"; v: string }
-  | { t: "each"; v: string }
-  | { t: "else" }
-  | { t: "endif" }
-  | { t: "endeach" };
+import Handlebars from "handlebars";
 
 export function renderHandlebars(template: string, context: Record<string, unknown>): string {
-  const nodes = parse(tokenize(template));
-  return renderNodes(nodes, { value: context });
-}
-
-// ── 1. Tokenize ──────────────────────────────────────────────────────
-function tokenize(src: string): Token[] {
-  const tokens: Token[] = [];
-  const re = /\{\{([\s\S]*?)\}\}/g;
-  let last = 0;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(src)) !== null) {
-    if (m.index > last) tokens.push({ t: "text", v: src.slice(last, m.index) });
-    tokens.push(classify(m[1].trim()));
-    last = m.index + m[0].length;
-  }
-  if (last < src.length) tokens.push({ t: "text", v: src.slice(last) });
-  return tokens;
-}
-
-function classify(inner: string): Token {
-  if (inner === "else") return { t: "else" };
-  if (inner === "/if") return { t: "endif" };
-  if (inner === "/each") return { t: "endeach" };
-  const ifM = inner.match(/^#if\s+(.+)$/);
-  if (ifM) return { t: "if", v: ifM[1].trim() };
-  const eachM = inner.match(/^#each\s+(.+)$/);
-  if (eachM) return { t: "each", v: eachM[1].trim() };
-  return { t: "var", v: inner };
-}
-
-// ── 2. Parse → AST ───────────────────────────────────────────────────
-function parse(tokens: Token[]): Node[] {
-  let pos = 0;
-
-  // eslint-disable-next-line complexity
-  function parseUntil(stop: ("endif" | "endeach" | "else")[]): { nodes: Node[]; stopped: Token | null } {
-    const nodes: Node[] = [];
-    while (pos < tokens.length) {
-      const tok = tokens[pos];
-      if ((tok.t === "endif" || tok.t === "endeach" || tok.t === "else") && stop.includes(tok.t)) {
-        return { nodes, stopped: tok };
-      }
-      pos++;
-      if (tok.t === "text") nodes.push({ kind: "text", text: tok.v });
-      else if (tok.t === "var") nodes.push({ kind: "var", path: tok.v });
-      else if (tok.t === "if") {
-        const thenBranch = parseUntil(["else", "endif"]);
-        let elseNodes: Node[] = [];
-        if (thenBranch.stopped?.t === "else") {
-          pos++; // konsumera else
-          elseNodes = parseUntil(["endif"]).nodes;
-        }
-        pos++; // konsumera /if
-        nodes.push({ kind: "if", path: tok.v, then: thenBranch.nodes, else: elseNodes });
-      } else if (tok.t === "each") {
-        const body = parseUntil(["endeach"]).nodes;
-        pos++; // konsumera /each
-        nodes.push({ kind: "each", path: tok.v, body });
-      }
-      // ensamma else/endif/endeach utanför block ignoreras
-    }
-    return { nodes, stopped: null };
-  }
-
-  return parseUntil([]).nodes;
-}
-
-// ── 3. Render ────────────────────────────────────────────────────────
-// eslint-disable-next-line complexity
-function renderNodes(nodes: Node[], scope: Scope): string {
-  let out = "";
-  for (const n of nodes) {
-    if (n.kind === "text") out += n.text;
-    else if (n.kind === "var") {
-      const v = lookup(scope, n.path);
-      out += v == null ? "" : escapeHtml(String(v));
-    } else if (n.kind === "if") {
-      out += isTruthy(lookup(scope, n.path))
-        ? renderNodes(n.then, scope)
-        : renderNodes(n.else, scope);
-    } else if (n.kind === "each") {
-      const list = lookup(scope, n.path);
-      if (Array.isArray(list)) {
-        for (const item of list) out += renderNodes(n.body, { value: item, parent: scope });
-      }
-    }
-  }
-  return out;
-}
-
-// ── Scope-lookup ─────────────────────────────────────────────────────
-function lookup(scope: Scope | undefined, key: string): unknown {
-  if (!scope) return undefined;
-  const local = resolveInValue(scope.value, key);
-  if (local !== undefined) return local;
-  return lookup(scope.parent, key);
-}
-
-function resolveInValue(value: unknown, key: string): unknown {
-  const parts = key.split(".");
-  let cur: unknown = value;
-  for (const p of parts) {
-    if (cur == null) return undefined;
-    if (Array.isArray(cur) && p === "length") cur = cur.length;
-    else if (typeof cur === "object") cur = (cur as Record<string, unknown>)[p];
-    else return undefined;
-  }
-  return cur;
-}
-
-function isTruthy(v: unknown): boolean {
-  if (v == null || v === false || v === 0 || v === "") return false;
-  if (Array.isArray(v) && v.length === 0) return false;
-  return true;
-}
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
+  return Handlebars.compile(template)(context);
 }

--- a/test/unit/lib/kostnadsrakning/render-handlebars-else.test.ts
+++ b/test/unit/lib/kostnadsrakning/render-handlebars-else.test.ts
@@ -52,8 +52,8 @@ describe("renderHandlebars — nästling", () => {
     expect(out).toBe("a:+ b:- ");
   });
 
-  it("each med inre variabel + parent-scope-lookup", () => {
-    const tpl = "{{#each lines}}{{desc}} ({{currency}}){{/each}}";
+  it("each med inre variabel + parent-scope-lookup (../)", () => {
+    const tpl = "{{#each lines}}{{desc}} ({{../currency}}){{/each}}";
     const out = renderHandlebars(tpl, { currency: "SEK", lines: [{ desc: "Taxi" }, { desc: "Tåg" }] });
     expect(out).toBe("Taxi (SEK)Tåg (SEK)");
   });

--- a/test/unit/lib/kostnadsrakning/render-handlebars.test.ts
+++ b/test/unit/lib/kostnadsrakning/render-handlebars.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tester för mini-Handlebars-renderaren.
+ * Tester för renderHandlebars (fulla handlebars-biblioteket).
  */
 
 import { describe, it, expect } from "vitest";
@@ -21,7 +21,7 @@ describe("renderHandlebars", () => {
 
   it("escapar HTML i värden", () => {
     expect(renderHandlebars("{{x}}", { x: "<script>alert('xss')</script>" }))
-      .toBe("&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;");
+      .toBe("&lt;script&gt;alert(&#x27;xss&#x27;)&lt;/script&gt;");
   });
 
   it("{{#if}} visar block när truthy", () => {
@@ -61,8 +61,8 @@ describe("renderHandlebars", () => {
     expect(renderHandlebars("{{items.length}} st", { items: [1, 2, 3] })).toBe("3 st");
   });
 
-  it("parent-scope-lookup i each", () => {
-    const tpl = "{{#each items}}{{title}}-{{ownerName}};{{/each}}";
+  it("parent-scope-lookup i each (../)", () => {
+    const tpl = "{{#each items}}{{title}}-{{../ownerName}};{{/each}}";
     const out = renderHandlebars(tpl, {
       ownerName: "Anna",
       items: [{ title: "X" }, { title: "Y" }],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3073,6 +3073,7 @@ __metadata:
     dependency-cruiser: "npm:^17.4.3"
     eslint: "npm:^10"
     eslint-config-next: "npm:16.2.7"
+    handlebars: "npm:^4.7.9"
     html-to-docx: "npm:^1.8.0"
     husky: "npm:^9.1.7"
     isomorphic-git: "npm:^1.38.4"
@@ -4941,6 +4942,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"handlebars@npm:^4.7.9":
+  version: 4.7.9
+  resolution: "handlebars@npm:4.7.9"
+  dependencies:
+    minimist: "npm:^1.2.5"
+    neo-async: "npm:^2.6.2"
+    source-map: "npm:^0.6.1"
+    uglify-js: "npm:^3.1.4"
+    wordwrap: "npm:^1.0.0"
+  dependenciesMeta:
+    uglify-js:
+      optional: true
+  bin:
+    handlebars: bin/handlebars
+  checksum: 10c0/22f8105a7e68e81aff2662bb434edf05f757d21d850731d71cec886d69c10cd33d3c43e34b2892968ec62de8241611851d3d0674c8ef324ea3e01dc66262faa9
+  languageName: node
+  linkType: hard
+
 "has-bigints@npm:^1.0.2":
   version: 1.1.0
   resolution: "has-bigints@npm:1.1.0"
@@ -6395,6 +6414,13 @@ __metadata:
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
   checksum: 10c0/f5f9a7974bfb28a91afafa254b197f0f22c684d4a1731763dda960d2c8e375b36c7d690e0d9dc8fba774c537af14a7e979129bca23d88d052fbeb9466955e447
+  languageName: node
+  linkType: hard
+
+"neo-async@npm:^2.6.2":
+  version: 2.6.2
+  resolution: "neo-async@npm:2.6.2"
+  checksum: 10c0/c2f5a604a54a8ec5438a342e1f356dff4bc33ccccdb6dc668d94fe8e5eccfc9d2c2eea6064b0967a767ba63b33763f51ccf2cd2441b461a7322656c1f06b3f5d
   languageName: node
   linkType: hard
 
@@ -8004,6 +8030,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "source-map@npm:0.6.1"
+  checksum: 10c0/ab55398007c5e5532957cb0beee2368529618ac0ab372d789806f5718123cc4367d57de3904b4e6a4170eb5a0b0f41373066d02ca0735a0c4d75c7d328d3e011
+  languageName: node
+  linkType: hard
+
 "spark-md5@npm:^3.0.2":
   version: 3.0.2
   resolution: "spark-md5@npm:3.0.2"
@@ -8643,6 +8676,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uglify-js@npm:^3.1.4":
+  version: 3.19.3
+  resolution: "uglify-js@npm:3.19.3"
+  bin:
+    uglifyjs: bin/uglifyjs
+  checksum: 10c0/83b0a90eca35f778e07cad9622b80c448b6aad457c9ff8e568afed978212b42930a95f9e1be943a1ffa4258a3340fbb899f41461131c05bb1d0a9c303aed8479
+  languageName: node
+  linkType: hard
+
 "unbash@npm:^3.0.0":
   version: 3.0.0
   resolution: "unbash@npm:3.0.0"
@@ -9197,6 +9239,13 @@ __metadata:
   version: 1.2.5
   resolution: "word-wrap@npm:1.2.5"
   checksum: 10c0/e0e4a1ca27599c92a6ca4c32260e8a92e8a44f4ef6ef93f803f8ed823f486e0889fc0b93be4db59c8d51b3064951d25e43d434e95dc8c960cc3a63d65d00ba20
+  languageName: node
+  linkType: hard
+
+"wordwrap@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "wordwrap@npm:1.0.0"
+  checksum: 10c0/7ed2e44f3c33c5c3e3771134d2b0aee4314c9e49c749e37f464bf69f2bcdf0cbf9419ca638098e2717cff4875c47f56a007532f6111c3319f557a2ca91278e92
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Löser **#20**. Per önskemål: fulla handlebars-biblioteket, **statisk import, inga dynamiska imports**, bundle-storlek underordnat.

## Ändringar
- `render-handlebars.ts`: ~169-raders egen mini-renderer → `Handlebars.compile(tpl)(ctx)` (statisk `import Handlebars from "handlebars"`). Samma publika signatur, så alla anropare är oförändrade.
- Återinför `handlebars`-dependency (togs bort i #2 när mini-renderern inte använde paketet).
- 3 tester uppdaterade från mini-renderns icke-standard-quirks → standard-Handlebars: HTML-escape `&#39;`→`&#x27;`; parent-scope i `{{#each}}` via `{{../var}}` (mini-renderern gjorde det implicit).

## Skarp rendering opåverkad
Kostnadsräknings-mallens `{{#each expenseLines/timeLines}}`-block använder bara item-lokala fält (`{{expenseSummary.*}}` ligger utanför, i `<tfoot>`), så standard-Handlebars renderar identiskt.

## Verifiering (allt grönt)
typecheck · lint --max-warnings 50 · deps:check 0/0 · knip gating 0 · test:fast **2170 gröna** · next build OK.

Closes #20