### PR TITLE
refactor(types): wire in unused domain types + consolidate PublicKey

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -14,14 +14,7 @@ import { trpc } from "@/lib/client/trpc";
 import { User, KeyRound, Plus, Trash2 } from "lucide-react";
 import { IntegrationsSection } from "@/components/settings/integrations-section";
 import { KeypairManager } from "@/components/settings/keypair-manager";
-
-interface PublicKey {
-  fingerprint: string;
-  type: "ssh-ed25519" | "ssh-rsa" | "ssh-ecdsa" | "gpg";
-  publicKey: string;
-  comment?: string;
-  addedAt: string;
-}
+import type { PublicKey } from "@/lib/shared/schemas/user";
 
 export default function ProfilePage() {
   const me = trpc.user.current.useQuery();

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -18,7 +18,7 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, orgProcedure } from "../trpc";
 import type { DataStoreTx } from "../data-store/IDataStore";
-import { billingRunRecipientSchema } from "@/lib/shared/schemas/enums";
+import { billingRunRecipientSchema, type ExpenseKind } from "@/lib/shared/schemas/enums";
 import { emit } from "../events/emit";
 
 interface UnfrozenWork {
@@ -32,7 +32,7 @@ async function fetchUnfrozenWork(tx: DataStoreTx, matterId: string): Promise<Unf
   }) as Array<{ id: string; minutes: number; hourlyRate: number; billable: boolean }>;
   const ex = await tx.expenses.findMany({
     where: { matterId, frozenByBillingRunId: null },
-  }) as Array<{ id: string; amount: number; billable: boolean; kind?: string }>;
+  }) as Array<{ id: string; amount: number; billable: boolean; kind?: ExpenseKind }>;
   return { timeEntries: te, expenses: ex.filter((e) => e.kind !== "PRUTNING") };
 }
 

--- a/src/lib/server/routers/document/suggestions.ts
+++ b/src/lib/server/routers/document/suggestions.ts
@@ -11,7 +11,7 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { orgProcedure } from "../../trpc";
 import { groupSuggestions } from "@/lib/shared/suggestion-grouping";
-import { matterRoleSchema, contactTypeSchema } from "@/lib/shared/schemas/enums";
+import { matterRoleSchema, contactTypeSchema, type SuggestionStatus } from "@/lib/shared/schemas/enums";
 import {
   findExistingContactForSuggestion,
   type ContactCandidate,
@@ -50,7 +50,7 @@ type SuggOverride = {
 };
 type Suggestion = {
   id: string;
-  status: string;
+  status: SuggestionStatus;
   role: string;
   name: string;
   contactType: string;

--- a/src/lib/server/routers/paymentPlan.ts
+++ b/src/lib/server/routers/paymentPlan.ts
@@ -18,9 +18,9 @@
 
 import { z } from "zod";
 import { router, protectedProcedure, orgProcedure, TRPCError } from "../trpc";
-import { paymentPlanStatusSchema, reminderTypeSchema } from "@/lib/shared/schemas";
+import { paymentPlanStatusSchema, reminderTypeSchema, type PaymentPlanStatus } from "@/lib/shared/schemas";
 
-type Plan = { id: string; status: string; invoiceId: string };
+type Plan = { id: string; status: PaymentPlanStatus; invoiceId: string };
 
 export const paymentPlanRouter = router({
   list: orgProcedure

--- a/src/lib/server/routers/user.ts
+++ b/src/lib/server/routers/user.ts
@@ -11,6 +11,7 @@ async function hashPassword(password: string): Promise<string> {
   return `placeholder:${password.length}-chars`;
 }
 import { TRPCError } from "@trpc/server";
+import { publicKeySchema, type PublicKey } from "@/lib/shared/schemas/user";
 
 // Smal select för listor — håller utgående typ stabil för konsumenter
 // (reports, tids-rader, etc.) som inte bryr sig om nycklar.
@@ -32,22 +33,6 @@ const USER_PROFILE_SELECT = {
   publicKeys: true,
 } as const;
 
-const PublicKeySchema = z.object({
-  fingerprint: z.string(),
-  type: z.enum(["ssh-ed25519", "ssh-rsa", "ssh-ecdsa", "gpg"]),
-  publicKey: z.string(),
-  comment: z.string().optional(),
-  addedAt: z.string(),
-});
-
-interface UserPublicKey {
-  fingerprint: string;
-  type: string;
-  publicKey: string;
-  comment?: string;
-  addedAt: string;
-}
-
 export interface UserProfile {
   id: string;
   email: string;
@@ -57,7 +42,7 @@ export interface UserProfile {
   hourlyRate: number | null;
   mileageRate: number | null;
   createdAt: Date;
-  publicKeys: UserPublicKey[];
+  publicKeys: PublicKey[];
 }
 
 function assertAdmin(ctx: { user: { role: string; id: string } }): void {
@@ -196,7 +181,7 @@ export const userRouter = router({
    * detta åt andra — nyckeln är användarens egendom.
    */
   addKey: protectedProcedure
-    .input(PublicKeySchema)
+    .input(publicKeySchema)
     .mutation(async ({ ctx, input }) => {
       const u = await ctx.dataStore.users.findUniqueOrThrow({
         where: { id: ctx.user.id, organizationId: ctx.user.organizationId },

--- a/src/lib/shared/schemas/user.ts
+++ b/src/lib/shared/schemas/user.ts
@@ -7,7 +7,7 @@ import { userRoleSchema } from "./enums";
  * azureOid, lastLoginAt) lever bara i självhostade installationer.
  */
 
-const publicKeySchema = z.object({
+export const publicKeySchema = z.object({
   fingerprint: z.string(),
   type: z.enum(["ssh-ed25519", "ssh-rsa", "ssh-ecdsa", "gpg"]),
   publicKey: z.string(),


### PR DESCRIPTION
Löser **#3**. Utredningen (read-only, godkänd) visade att merparten av de flaggade typerna borde användas — typsäkerhet tappades via lösa `as`-cast:ar och lokala omdeklarationer.

## Wire-in (typsäkerhet tillkommer)
- **ExpenseKind** — `billingRun.ts` cast `kind?: string` → `kind?: ExpenseKind`.
- **PaymentPlanStatus** — `paymentPlan.ts` `Plan.status: string` → typen.
- **SuggestionStatus** — `suggestions.ts` `Suggestion.status: string` → typen.
- **PublicKey** — konsoliderade **3** definitioner (delad typ + profil-sidans lokala `interface` + user-routerns `PublicKeySchema`/`UserPublicKey` med `type: string`) till den delade `publicKeySchema`/`PublicKey`. Exporterar nu schemat. DRY + `type: string` → enum.

knip flaggar inte längre någon av de 4 typerna.

## Utbrutet (kunde inte wire:as här)
- **BillingRunType/Recipient/Status** → **#24**: läs-sidan är redan inferrad-säker, men skriv-literals (`create({ data: { type: "ACCONTO" }})`) typkollas inte p.g.a. `DemoDataStore.create(args: unknown)`. Kräver att data-storens create/update typas → eget issue.
- **UserPreference/OrgPreference** → **#22** (vilande DataTable-pref-flöde), **ReminderType** → **#23** (vilande påminnelse-flöde). Inte Settings/Profil-data.

## Verifiering (allt grönt)
typecheck · lint --max-warnings 50 · deps:check 0/0 · knip gating 0 · test:fast **2170 gröna** · next build OK.

Closes #3