### PR TITLE
docs(readme): lägg prominent live-demo-länk högst upp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # AVA — CRM för svenska advokatbyråer
 
+### ▶ **[Prova live-demon → ulrik-s.github.io/ava](https://ulrik-s.github.io/ava/)**
+
+*(Read-only — ändringar lever bara i din flik.)*
+
 > **USP**: Svenska byråer, svenska tjänster. **Din data, du bestämmer.**
 > Browser är runtime. Servern är så tunn det går.
 


### PR DESCRIPTION
README:ns demo-sektion sa "surfa till den deployade demon" men saknade själva URL:en. Lägger en **fet H3-länk direkt under titeln**:

```md
### ▶ **[Prova live-demon → ulrik-s.github.io/ava](https://ulrik-s.github.io/ava/)**
*(Read-only — ändringar lever bara i din flik.)*
```

URL verifierad via GitHub Pages API (`repos/ulrik-s/ava/pages` → `https://ulrik-s.github.io/ava/`). Docs-only.