### PR TITLE
docs(readme): jurist-vänlig landningssida (tekniskt under 'För utvecklare')

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,69 @@
-# AVA — CRM för svenska advokatbyråer
+# AVA — ärendehantering för svenska advokat- och juristbyråer
 
-### ▶ **[Prova live-demon → ulrik-s.github.io/ava](https://ulrik-s.github.io/ava/)**
+### ▶ **[Prova AVA direkt i webbläsaren → ulrik-s.github.io/ava](https://ulrik-s.github.io/ava/)**
 
-*(Read-only — ändringar lever bara i din flik.)*
+AVA samlar byråns vardag på ett ställe — ärenden, klienter, kalender,
+tidregistrering, fakturor och kostnadsräkningar — anpassat efter svensk
+juridik.
 
-> **USP**: Svenska byråer, svenska tjänster. **Din data, du bestämmer.**
-> Browser är runtime. Servern är så tunn det går.
+**Demon kräver ingen inloggning och ingen installation.** Den öppnas direkt
+i webbläsaren med exempeldata från en påhittad byrå. Klicka runt fritt: allt
+är skrivskyddat, inget sparas och inget påverkar någon riktig data. Stäng
+fliken så är allt borta.
+
+> 🔒 **Din data, du bestämmer.** När en byrå kör AVA på riktigt ligger
+> uppgifterna i byråns *eget* arkiv. Det finns ingen molntjänst som kan
+> stängas av, och känslig klientinformation lämnar aldrig datorn — byggt med
+> advokatsekretessen i åtanke.
+
+## Vad du kan prova
+
+- **Ärenden** — lägg upp ärenden med klient, motpart, ombud och domstol, och
+  samla alla handlingar per ärende.
+- **Kontaktregister** — personer, företag, domstolar, myndigheter,
+  försäkringsbolag och andra byråer på ett ställe.
+- **Kalender & uppgifter** — dag-, vecka- och månadsvy per medarbetare, med
+  att göra-listor.
+- **Tid & utlägg** — registrera arbetad tid och utlägg per ärende, markera
+  vad som är debiterbart och ta ut periodrapporter.
+- **Fakturor & avbetalningsplaner** — acconto- och slutfakturor, kreditering,
+  betalningshistorik och avbetalningsplaner med påminnelser.
+- **Kostnadsräkningar** — för brottmål (brottmålstaxa) och uppdrag med
+  rättshjälp, rättsskydd eller offentlig försvarare.
+- **Jävskontroll** — sök på namn och personnummer mot alla ärendens parter
+  innan du tar ett uppdrag.
+- **Dokumentmallar** — generera färdiga handlingar (fullmakt, stämnings­
+  ansökan, kostnadsräkning …) från byråns egna mallar.
+- **AI (helt valfritt)** — en språkmodell som körs *lokalt i webbläsaren* kan
+  föreslå hur uppladdade dokument ska sorteras. Inget skickas vidare.
+
+> Allt ovan är förifyllt med exempeldata i demon så att du kan se hur det
+> hänger ihop. I skarp drift sparas dina ändringar löpande i byråns arkiv.
+
+## Därför AVA
+
+- **Svensk juridisk vardag** — roller, betalningssätt (rättshjälp/rättsskydd/
+  offentlig försvarare) och kostnadsräkningar som faktiskt passar en svensk byrå.
+- **Datasuveränitet** — byrån äger sin information fullt ut. Ingen
+  inlåsning i en tjänst som kan försvinna.
+- **Sekretess by design** — klientuppgifter stannar på byråns egna system.
+- **Spårbarhet** — varje ändring loggas med vem och när, vilket ger ett
+  tydligt revisionsspår.
+
+---
+
+## För utvecklare
+
+> Allt nedanför vänder sig till den som ska köra, bygga eller vidareutveckla
+> AVA. Som slutanvändare behöver du bara länken högst upp.
+
+AVA är "git-first": **webbläsaren är runtime**, och all data lagras som JSON +
+binärfiler i ett git-repo. Servern är så tunn det går. Två driftlägen:
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │  Browser-app (Next.js 16 + tRPC, in-memory DemoDataStore)  │
-│  ├─ Demo-mode: läser från GitHub Pages CDN                  │
+│  ├─ Demo-mode: läser från GitHub Pages CDN (read-only)      │
 │  └─ Self-hosted: clone:ar git-repo till OPFS, push:ar       │
 └─────────────────────────────────────────────────────────────┘
                           ▲ HTTPS
@@ -18,34 +71,22 @@
 │  Server (val 1 av 2)                                        │
 │  ├─ GitHub Pages: statiska filer (app + data)               │
 │  └─ Linux/docker: nginx + git-http-backend + sshd           │
-│     (inget custom kod-skikt att underhålla)                 │
 └─────────────────────────────────────────────────────────────┘
 ```
 
-## Funktioner
+### Arkitektur i kort
 
-| Modul | Innehåll |
-|---|---|
-| **Ärenden** | CRUD, klient + motpart + domstol, dokumentträd, generera dokument från Handlebars-mall |
-| **Kontakter** | Personer, företag, domstolar, försäkringsbolag, advokatbyråer, myndigheter |
-| **Kalender** | Multi-user med färgkod, dag/vecka/månadsvy, Outlook-mirror (opt-in via O365-connector) |
-| **Tasks** | TODO/IN_PROGRESS/DONE per advokat |
-| **Tid + utlägg** | Per-ärende registrering, debiterbar-flagga, periodrapporter |
-| **Fakturor** | DRAFT/SENT/PAID/INSTALLMENT_PLAN, acconto/slutfaktura/credit, betalningshistorik |
-| **Avbetalningsplaner** | ACTIVE/COMPLETED/CANCELLED, progress-vy, reminders |
-| **Dokument** | PDF/DOCX uppladdning + text-extraktion + fulltextsök (wildcards `*`) |
-| **Mallar** | Handlebars-baserade dokumentmallar |
-| **Jävskontroll** | Fuzzy namnsök + personnummer-substring mot alla matter-contacts |
-| **AI (opt-in)** | In-browser LLM (Llama 3.2 via WebGPU) för dokumentklassificering |
-| **Användare** | 5+ per byrå, ADMIN/LAWYER/ASSISTANT-roller |
+- **Ingen databas**. All data är JSON-rader + binärfiler i ett git-repo.
+- **Ingen NextAuth, ingen Prisma, ingen Tauri**.
+- **Browsern pratar inte med en backend** — tRPC-routrar körs in-process.
+- **Git smart-HTTP** är enda lager mellan browser och server-disk (via `isomorphic-git`).
+- **OPFS** (Origin Private File System) håller en lokal working copy.
+- **Single source of truth för seed-data**: `tooling/scripts/seed-data.ts` — samma
+  fabrik bygger docker-firma.git OCH gh-pages-demon.
 
-## Kom igång
+Detaljer: [`docs/architecture.md`](./docs/architecture.md).
 
-### Demo (GitHub Pages)
-
-Surfa till den deployade demon. Det är read-only — ändringar lever bara i fliken.
-
-Bygg + deploya egen demo:
+### Bygg + deploya demon
 
 ```bash
 yarn install
@@ -71,7 +112,6 @@ docker compose -f tooling/docker/docker-compose.yml logs web | grep "Admin-token
 
 # 5. Lägg till fler advokater
 tooling/scripts/add-user.sh anna@firma.se
-tooling/scripts/add-user.sh bjorn@firma.se
 ```
 
 Se [`docs/auth.md`](./docs/auth.md) för auth-modellen.
@@ -83,7 +123,6 @@ yarn install
 docker compose -f tooling/docker/docker-compose.yml up -d
 yarn dev
 # Browser: http://localhost:3000
-# (firma-config defaultar till http://localhost:8080/git/firma.git)
 ```
 
 ### Seed-data för byrån
@@ -91,41 +130,24 @@ yarn dev
 ```bash
 yarn seed:local
 # → pushar 5 users, 17 contacts, 15 matters, 40 PDF/DOCX,
-#   7 avbetalningsplaner, 20 payments, 25 kalender-events
-#   till docker-firma.git
+#   7 avbetalningsplaner, 20 payments, 25 kalender-events till docker-firma.git
 ```
 
-## Arkitektur i kort
-
-- **Ingen databas**. All data är JSON-rader + binärfiler i ett git-repo.
-- **Ingen NextAuth, ingen Prisma, ingen Tauri**. Pivot bort från dessa.
-- **Browser pratar inte med en backend** — tRPC routrar körs in-process via `demo-trpc-link`.
-- **Git smart-HTTP** är enda lager mellan browser och server-disk. Allt via `isomorphic-git`.
-- **OPFS** (Origin Private File System) håller en lokal working copy. Inga fil-väljardialoger.
-- **Single source of truth för seed-data**: `tooling/scripts/seed-data.ts`. Samma fabrik bygger docker firma.git OCH gh-pages-demon.
-
-Detaljer: [`docs/architecture.md`](./docs/architecture.md).
-
-## Test + kvalitet
+### Test + kvalitet
 
 ```bash
-yarn test:fast           # ~1646 tester, ~14s
+yarn test:fast           # ~2200 tester
 yarn typecheck           # tsc --noEmit
-yarn lint                # eslint
+yarn lint                # eslint (flat config)
+yarn deps:check          # dependency-cruiser (lagergränser)
+yarn knip                # död kod / oanvända deps
 yarn round-trip          # E2E mot docker (kräver docker upp)
 ```
 
 Se [`docs/quality.md`](./docs/quality.md) för verktyg och tröskelvärden.
 
-## Deploy
+### Deploy
 
 - [`docs/deploy-demo.md`](./docs/deploy-demo.md) — CI auto-seedad demo på GitHub Pages
 - [`docs/deploy-tier3-self-hosted.md`](./docs/deploy-tier3-self-hosted.md) — Linux + docker-stack åt en byrå
 - [`docs/auth.md`](./docs/auth.md) — htpasswd-baserad auth + PAT-rotation
-
-## Skiljemål från andra CRM:er
-
-- **Svensk domän**: matter-roller, betalningsmetoder (rättshjälp/rättsskydd/offentlig försvarare), BankID-redo
-- **Data-suveränitet**: byrån äger git-repot. Vi äger ingen tjänst som kan stängas av åt dem.
-- **Offline-AI**: LLM kör i browsern, dokument lämnar aldrig maskinen
-- **Audit-vänligt**: varje state-ändring är en signerad git-commit med författare + tidsstämpel


### PR DESCRIPTION
README:n var en utvecklar-README, men används som **landningssida för slutanvändare (jurister)** som får demolänken. Den var för teknisk för den publiken.

## Omstrukturering
- **Topp i klarspråk för jurister:** vad AVA är, en **"Vad du kan prova"**-lista i domäntermer (ärenden, kalender, tid & utlägg, fakturor, kostnadsräkningar, jävskontroll, dokumentmallar, valfri lokal AI) utan teknisk jargong, plus **sekretess/datasuveränitet** som säljpoäng (advokatsekretess).
- **"Därför AVA"** — kort om svensk juridisk domän, datasuveränitet, sekretess, spårbarhet.
- **Allt tekniskt flyttat ner under `## För utvecklare`** (arkitektur + diagram, bygg/deploy, self-hosted, dev-server, seed, test, deploy) — bevarat, inte borttaget.
- Demolänken kvar högst upp.

Docs-only.