### PR TITLE
fix(lint): hook-deps (#5) + ta bort dubbel-export-alias (#4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,11 @@ jobs:
       - run: corepack enable
       - run: yarn install --immutable
       - run: yarn typecheck
-      # Ratchet: lint får ha HÖGST 50 warnings (dagens nivå). Nya warnings →
+      # Ratchet: lint får ha HÖGST 46 warnings (dagens nivå). Nya warnings →
       # rött bygge. Driv ned baseline:n över tid (mål: 0). Errors fällde redan.
-      # (Sänkt 86→50: no-unused-vars utrensad + ^_-ignore i eslint-configen.)
-      - run: yarn lint --max-warnings 50
+      # (86→50: no-unused-vars + ^_-ignore. 50→46: react-hooks/exhaustive-deps
+      #  åtgärdade (#5) + en complexity-TODO som löste sig på köpet.)
+      - run: yarn lint --max-warnings 46
       - run: yarn deps:check
       # Gating: fäller på strukturfynd (döda filer, oanvända/olistade deps).
       # Export-/typ-fynd är "warn" i knip.json (rådgivande) tills #3/#4 städat dem.

--- a/src/app/contacts/[id]/_client.tsx
+++ b/src/app/contacts/[id]/_client.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { EntityLink } from "@/lib/client/demo/entity-link";
 import { trpc } from "@/lib/client/trpc";
-import { labelForContactType, labelForMatterRole, contactTypes } from "@/lib/client/labels";
+import { labelForContactType, labelForMatterRole, contactTypeOptions } from "@/lib/client/labels";
 import { useRouteId } from "@/lib/client/demo/use-route-id";
 
 // eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Function 'ContactDetailClient' has a complexity of 22. Maximum allowed is 8.)
@@ -104,7 +104,7 @@ export default function ContactDetailClient({ id: paramId }: { id: string }) {
                 <select id={editTypeId} value={editForm.contactType}
                   onChange={(e) => setEditForm({ ...editForm, contactType: e.target.value })}
                   className="w-full rounded border border-gray-300 px-3 py-2 text-sm">
-                  {contactTypes.map((t) => <option key={t.value} value={t.value}>{t.label}</option>)}
+                  {contactTypeOptions.map((t) => <option key={t.value} value={t.value}>{t.label}</option>)}
                 </select>
               </div>
               <div>

--- a/src/app/contacts/page.tsx
+++ b/src/app/contacts/page.tsx
@@ -4,7 +4,7 @@ import { Suspense, useId, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { EntityLink } from "@/lib/client/demo/entity-link";
 import { trpc } from "@/lib/client/trpc";
-import { labelForContactType, contactTypes } from "@/lib/client/labels";
+import { labelForContactType, contactTypeOptions } from "@/lib/client/labels";
 import { useIsReadOnly } from "@/lib/client/demo/demo-mode-context";
 import { DataTable, type Column } from "@/components/ui/data-table";
 
@@ -115,7 +115,7 @@ function ContactsContent() {
               <select id={typeId} value={form.contactType}
                 onChange={(e) => setForm({ ...form, contactType: e.target.value })}
                 className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm">
-                {contactTypes.map((t) => (
+                {contactTypeOptions.map((t) => (
                   <option key={t.value} value={t.value}>{t.label}</option>
                 ))}
               </select>
@@ -186,7 +186,7 @@ function ContactsContent() {
           onChange={(e) => { setTypeFilter(e.target.value); setPage(1); }}
           className="rounded-lg border border-gray-300 px-3 py-2 text-sm">
           <option value="">Alla typer</option>
-          {contactTypes.map((t) => (
+          {contactTypeOptions.map((t) => (
             <option key={t.value} value={t.value}>{t.label}</option>
           ))}
         </select>

--- a/src/app/matters/[id]/_contacts-section.tsx
+++ b/src/app/matters/[id]/_contacts-section.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { EntityLink } from "@/lib/client/demo/entity-link";
 import { trpc } from "@/lib/client/trpc";
-import { labelForMatterRole, matterRoles, contactTypes } from "@/lib/client/labels";
+import { labelForMatterRole, matterRoleOptions, contactTypeOptions } from "@/lib/client/labels";
 import { DataTable, type Column } from "@/components/ui/data-table";
 
 type Contact = {
@@ -202,7 +202,7 @@ function ExistingContactForm({
         <select value={form.role}
           onChange={(e) => setForm({ ...form, role: e.target.value })}
           className="rounded border border-gray-300 px-3 py-1.5 text-sm">
-          {matterRoles.map((r) => <option key={r.value} value={r.value}>{r.label}</option>)}
+          {matterRoleOptions.map((r) => <option key={r.value} value={r.value}>{r.label}</option>)}
         </select>
       </div>
       <button type="submit" disabled={isPending}
@@ -246,12 +246,12 @@ function NewContactForm({
         <select value={form.role}
           onChange={(e) => setForm({ ...form, role: e.target.value })}
           className="rounded border border-gray-300 px-3 py-1.5 text-sm">
-          {matterRoles.map((r) => <option key={r.value} value={r.value}>{r.label}</option>)}
+          {matterRoleOptions.map((r) => <option key={r.value} value={r.value}>{r.label}</option>)}
         </select>
         <select value={form.contactType}
           onChange={(e) => setForm({ ...form, contactType: e.target.value })}
           className="rounded border border-gray-300 px-3 py-1.5 text-sm">
-          {contactTypes.map((t) => <option key={t.value} value={t.value}>{t.label}</option>)}
+          {contactTypeOptions.map((t) => <option key={t.value} value={t.value}>{t.label}</option>)}
         </select>
         <input type="text" placeholder={form.contactType === "PERSON" ? "Personnummer" : "Orgnummer"}
           value={form.contactType === "PERSON" ? form.personalNumber : form.orgNumber}

--- a/src/app/matters/[id]/_kostnadsrakning-modal.tsx
+++ b/src/app/matters/[id]/_kostnadsrakning-modal.tsx
@@ -187,7 +187,7 @@ export function KostnadsrakningModal(props: Props) {
     isTaxeArende: isTaxe,
     expenses: props.expenses,
     timeEntries: ((timeEntries.data?.entries ?? []) as Array<{ id: string; date: string | Date; description: string; minutes: number; billable: boolean }>),
-  }), [hufStart, hufEnd, level, isTaxe, props, timeEntries.data]);
+  }), [hufStart, hufEnd, level, isTaxe, hasFTax, props, timeEntries.data]);
 
   useEffect(() => {
     const h = (e: KeyboardEvent) => { if (e.key === "Escape") props.onClose(); };

--- a/src/components/documents/document-browser.tsx
+++ b/src/components/documents/document-browser.tsx
@@ -15,7 +15,6 @@ interface DocumentBrowserProps {
   matterId: string;
 }
 
-// eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Function 'DocumentBrowser' has a complexity of 9. Maximum allowed is 8.)
 export function DocumentBrowser({ matterId }: DocumentBrowserProps) {
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
     if (typeof window === "undefined") return "list";
@@ -47,8 +46,8 @@ export function DocumentBrowser({ matterId }: DocumentBrowserProps) {
   const utils = trpc.useUtils();
 
   const tree = trpc.document.tree.useQuery({ matterId });
-  const folders: FolderRecord[] = tree.data?.folders ?? [];
-  const documents: DocumentRecord[] = tree.data?.documents ?? [];
+  const folders = useMemo<FolderRecord[]>(() => tree.data?.folders ?? [], [tree.data]);
+  const documents = useMemo<DocumentRecord[]>(() => tree.data?.documents ?? [], [tree.data]);
 
   const mutations = useDocumentMutations({
     matterId,

--- a/src/components/shell/demo-bootstrap.tsx
+++ b/src/components/shell/demo-bootstrap.tsx
@@ -349,6 +349,10 @@ export function DemoBootstrap({ children }: { children: ReactNode }) {
       }
     })();
     return () => { cancelled = true; };
+    // Mount-only bootstrap: ska köras en gång. Att lägga firmaConfig/source/
+    // refs som deps skulle re-trigga hela demo-clonen; refs + queryClient är
+    // stabila och behöver inte vara deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Hydrerings-grind: identisk markup på server + klientens första render.

--- a/src/lib/client/labels.ts
+++ b/src/lib/client/labels.ts
@@ -132,5 +132,3 @@ export const CREDIT_RISK_LABELS: Record<CreditRisk, string> = {
 
 export const matterRoleLabels = MATTER_ROLE_LABELS;
 export const contactTypeLabels = CONTACT_TYPE_LABELS;
-export const matterRoles = matterRoleOptions;
-export const contactTypes = contactTypeOptions;

--- a/test/unit/lib/labels.test.ts
+++ b/test/unit/lib/labels.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { matterRoleLabels, matterRoles, contactTypeLabels, contactTypes } from "@/lib/client/labels";
+import { matterRoleLabels, matterRoleOptions, contactTypeLabels, contactTypeOptions } from "@/lib/client/labels";
 
 describe("matterRoleLabels", () => {
   it("använder 'Klient' (inte 'Huvudman') som label för KLIENT", () => {
@@ -23,19 +23,19 @@ describe("matterRoleLabels", () => {
   });
 });
 
-describe("matterRoles (dropdown-lista)", () => {
+describe("matterRoleOptions (dropdown-lista)", () => {
   it("har KLIENT som första valbara roll", () => {
-    expect(matterRoles[0]).toEqual({ value: "KLIENT", label: "Klient" });
+    expect(matterRoleOptions[0]).toEqual({ value: "KLIENT", label: "Klient" });
   });
 
   it("innehåller inget objekt med value === HUVUDMAN", () => {
     // Cast to string — TS vet redan att "HUVUDMAN" inte finns (typen har
     // skalbort det), men testet dokumenterar invarianten mot runtime-data.
-    expect(matterRoles.some((r) => (r.value as string) === "HUVUDMAN")).toBe(false);
+    expect(matterRoleOptions.some((r) => (r.value as string) === "HUVUDMAN")).toBe(false);
   });
 
   it("listan matchar labels-mappen i både value och label", () => {
-    for (const { value, label } of matterRoles) {
+    for (const { value, label } of matterRoleOptions) {
       expect(matterRoleLabels[value]).toBe(label);
     }
   });
@@ -48,8 +48,8 @@ describe("contactTypeLabels", () => {
     expect(contactTypeLabels.LAW_FIRM).toBe("Advokatbyrå");
   });
 
-  it("contactTypes-listan matchar labels-mappen", () => {
-    for (const { value, label } of contactTypes) {
+  it("contactTypeOptions-listan matchar labels-mappen", () => {
+    for (const { value, label } of contactTypeOptions) {
       expect(contactTypeLabels[value]).toBe(label);
     }
   });


### PR DESCRIPTION
Löser **#4** och **#5**.

## #5 — react-hooks/exhaustive-deps (4 varningar, potentiella buggar)
- **`_kostnadsrakning-modal`** — `useMemo` saknade dep `hasFTax` → stale värde. Lade till den.
- **`document-browser`** — `folders`/`documents` (`?? []`) nyskapades varje render och användes i nedströms-`useMemo`. Wrappade i egna `useMemo`. *Bonus:* sänkte `DocumentBrowser`s komplexitet 9→8, så en `eslint-disable complexity`-TODO kunde tas bort.
- **`demo-bootstrap`** — avsiktligt mount-only bootstrap (tom dep-array + `cancelled`-flagga). Att lägga deps skulle re-trigga hela demo-clonen → motiverad `eslint-disable-next-line`.

## #4 — dubbel-export-alias i `labels.ts`
`matterRoles`/`contactTypes` var alias för `matterRoleOptions`/`contactTypeOptions`. Migrerade anroparna och tog bort aliasen.

## Ratchet
`--max-warnings` 50 → **46**.

## Verifiering
typecheck · lint ≤46 (0 errors, 0 exhaustive-deps) · deps:check 0/0 · knip gating 0 · test:fast **2170 gröna** · next build OK.

Closes #4
Closes #5