### PR TITLE
chore(ts): noImplicitOverride + noFallthroughCasesInSwitch (#7)

### DIFF
--- a/src/components/ui/render-error-boundary.tsx
+++ b/src/components/ui/render-error-boundary.tsx
@@ -11,13 +11,13 @@ import { Component, type ReactNode } from "react";
 interface State { error: Error | null; componentStack: string | null }
 
 export class RenderErrorBoundary extends Component<{ children: ReactNode }, State> {
-  state: State = { error: null, componentStack: null };
+  override state: State = { error: null, componentStack: null };
   static getDerivedStateFromError(error: Error): State { return { error, componentStack: null }; }
-  componentDidCatch(error: Error, info: { componentStack: string }) {
+  override componentDidCatch(error: Error, info: { componentStack: string }) {
     console.error("[render-error]", error.message, "\nComponentStack:", info.componentStack);
     this.setState({ componentStack: info.componentStack });
   }
-  render() {
+  override render() {
     if (this.state.error) {
       return (
         <div className="m-4 p-4 bg-red-50 border-l-4 border-red-400 text-red-900 text-xs font-mono">

--- a/src/lib/server/data-store/in-memory/writable-delegate.ts
+++ b/src/lib/server/data-store/in-memory/writable-delegate.ts
@@ -64,7 +64,7 @@ export class WritableDelegate<T extends Record<string, unknown>> extends ReadOnl
     return this.wopts.collection();
   }
 
-  async create(args: unknown): Promise<never> {
+  override async create(args: unknown): Promise<never> {
     const a = args as { data: Partial<T> };
     const id = (a.data as { id?: string }).id ?? (this.wopts.generateId ?? genId)();
     const row = {
@@ -82,7 +82,7 @@ export class WritableDelegate<T extends Record<string, unknown>> extends ReadOnl
     return enriched as never;
   }
 
-  async update(args: unknown): Promise<never> {
+  override async update(args: unknown): Promise<never> {
     const a = args as { where: { id: string }; data: Partial<T> };
     const idx = this.collection.findIndex((r) => (r as { id?: string }).id === a.where.id);
     if (idx < 0) throw new Error(`Hittade inte ${this.wopts.entity} med id=${a.where.id}`);
@@ -94,7 +94,7 @@ export class WritableDelegate<T extends Record<string, unknown>> extends ReadOnl
     return enriched as never;
   }
 
-  async delete(args: unknown): Promise<never> {
+  override async delete(args: unknown): Promise<never> {
     const a = args as { where: { id: string } };
     const idx = this.collection.findIndex((r) => (r as { id?: string }).id === a.where.id);
     if (idx < 0) throw new Error(`Hittade inte ${this.wopts.entity} med id=${a.where.id}`);
@@ -104,7 +104,7 @@ export class WritableDelegate<T extends Record<string, unknown>> extends ReadOnl
     return removed as never;
   }
 
-  async updateMany(args: unknown): Promise<never> {
+  override async updateMany(args: unknown): Promise<never> {
     const a = args as { where?: Record<string, unknown>; data: Partial<T> };
     const matches = await this.findMany({ where: a.where });
     let count = 0;
@@ -115,7 +115,7 @@ export class WritableDelegate<T extends Record<string, unknown>> extends ReadOnl
     return { count } as never;
   }
 
-  async deleteMany(args: unknown): Promise<never> {
+  override async deleteMany(args: unknown): Promise<never> {
     const a = args as { where?: Record<string, unknown> };
     const matches = await this.findMany({ where: a.where });
     let count = 0;
@@ -126,7 +126,7 @@ export class WritableDelegate<T extends Record<string, unknown>> extends ReadOnl
     return { count } as never;
   }
 
-  async upsert(args: unknown): Promise<never> {
+  override async upsert(args: unknown): Promise<never> {
     const a = args as { where: { id: string }; create: Partial<T>; update: Partial<T> };
     const existing = await this.findUnique({ where: { id: a.where.id } });
     const result = existing

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,11 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
+    // Extra korrekthetsflaggor (#7). noUncheckedIndexedAccess (~519 fel) och
+    // exactOptionalPropertyTypes (~61, mest tooling) skjuts upp till en ratchet
+    // — se uppföljnings-issue.
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
     // TS6: matcha 7.0:s (Go-native) typordning → mindre diff vid den migreringen.
     "stableTypeOrdering": true,
     // TS6: default blev [] (drar inte längre in alla @types/* → snabbare).


### PR DESCRIPTION
Löser **#7** (ratchet-stil — adopterar de genomförbara flaggorna nu).

Mätte felomfånget per flagga:
| Flagga | Fel | Beslut |
|---|---|---|
| `noImplicitOverride` | 9 (override saknades) | ✅ fixat + på |
| `noFallthroughCasesInSwitch` | 0 | ✅ på |
| `noUncheckedIndexedAccess` | ~519 (319 i tester) | → **#32** (för stort för ett svep) |
| `exactOptionalPropertyTypes` | ~61 (mest tooling) | → **#32** |

De 9 `override`-fixarna: `render-error-boundary` (state/componentDidCatch/render) + `writable-delegate` (create/update/delete/updateMany/deleteMany/upsert).

## Verifiering
typecheck · lint ≤50 · deps:check 0/0 · knip gating 0 · test:fast **2170 gröna** · next build OK.

Closes #7