### PR TITLE
refactor(profile): extract ProfileBasicsSection — ratchet-steg (#6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,11 @@ jobs:
       - run: corepack enable
       - run: yarn install --immutable
       - run: yarn typecheck
-      # Ratchet: lint får ha HÖGST 46 warnings (dagens nivå). Nya warnings →
+      # Ratchet: lint får ha HÖGST 45 warnings (dagens nivå). Nya warnings →
       # rött bygge. Driv ned baseline:n över tid (mål: 0). Errors fällde redan.
-      # (86→50: no-unused-vars + ^_-ignore. 50→46: react-hooks/exhaustive-deps
-      #  åtgärdade (#5) + en complexity-TODO som löste sig på köpet.)
-      - run: yarn lint --max-warnings 46
+      # (86→50: no-unused-vars + ^_-ignore. 50→46: exhaustive-deps (#5).
+      #  46→45: ProfileBasicsSection utbruten ur ProfilePage (#6, pågående ratchet).)
+      - run: yarn lint --max-warnings 45
       - run: yarn deps:check
       # Gating: fäller på strukturfynd (döda filer, oanvända/olistade deps).
       # Export-/typ-fynd är "warn" i knip.json (rådgivande) tills #3/#4 städat dem.

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -62,53 +62,14 @@ export default function ProfilePage() {
         </p>
       </div>
 
-      {/* Basinfo */}
-      <section className="bg-white border border-gray-200 rounded-lg p-5 mb-5">
-        <h2 className="font-semibold text-gray-900 mb-3">Dina uppgifter</h2>
-        <div className="space-y-3 text-sm">
-          <Field label="Namn">
-            <input
-              type="text"
-              value={form.name}
-              onChange={(e) => setForm({ ...form, name: e.target.value })}
-              className="w-full border border-gray-300 rounded px-2 py-1.5 text-sm"
-            />
-          </Field>
-          <Field label="Titel">
-            <input
-              type="text"
-              value={form.title}
-              onChange={(e) => setForm({ ...form, title: e.target.value })}
-              placeholder="t.ex. Advokat / Biträdande jurist"
-              className="w-full border border-gray-300 rounded px-2 py-1.5 text-sm"
-            />
-          </Field>
-          <Field label="E-post">
-            <input
-              type="email"
-              value={form.email}
-              onChange={(e) => setForm({ ...form, email: e.target.value })}
-              className="w-full border border-gray-300 rounded px-2 py-1.5 text-sm"
-            />
-          </Field>
-          <Field label="Roll">
-            <div className="text-sm text-gray-700">{u.role}
-              <span className="text-xs text-gray-400 ml-2">(ändras av admin)</span>
-            </div>
-          </Field>
-        </div>
-        <div className="mt-4 flex items-center gap-3">
-          <button
-            type="button"
-            onClick={saveProfile}
-            disabled={updateUser.isPending}
-            className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
-          >
-            {updateUser.isPending ? "Sparar…" : "Spara"}
-          </button>
-          {updateUser.error && <span className="text-xs text-red-600">{updateUser.error.message}</span>}
-        </div>
-      </section>
+      <ProfileBasicsSection
+        form={form}
+        setForm={setForm}
+        role={u.role}
+        onSave={saveProfile}
+        saving={updateUser.isPending}
+        saveError={updateUser.error?.message ?? null}
+      />
 
       {/* Publika nycklar */}
       <KeysSection
@@ -131,6 +92,66 @@ export default function ProfilePage() {
       {/* Anslutna tjänster (O365, Google, …) */}
       <IntegrationsSection />
     </div>
+  );
+}
+
+type ProfileForm = { name: string; title: string; email: string };
+
+function ProfileBasicsSection({ form, setForm, role, onSave, saving, saveError }: {
+  form: ProfileForm;
+  setForm: React.Dispatch<React.SetStateAction<ProfileForm>>;
+  role: string;
+  onSave: () => void;
+  saving: boolean;
+  saveError: string | null;
+}) {
+  return (
+    <section className="bg-white border border-gray-200 rounded-lg p-5 mb-5">
+      <h2 className="font-semibold text-gray-900 mb-3">Dina uppgifter</h2>
+      <div className="space-y-3 text-sm">
+        <Field label="Namn">
+          <input
+            type="text"
+            value={form.name}
+            onChange={(e) => setForm({ ...form, name: e.target.value })}
+            className="w-full border border-gray-300 rounded px-2 py-1.5 text-sm"
+          />
+        </Field>
+        <Field label="Titel">
+          <input
+            type="text"
+            value={form.title}
+            onChange={(e) => setForm({ ...form, title: e.target.value })}
+            placeholder="t.ex. Advokat / Biträdande jurist"
+            className="w-full border border-gray-300 rounded px-2 py-1.5 text-sm"
+          />
+        </Field>
+        <Field label="E-post">
+          <input
+            type="email"
+            value={form.email}
+            onChange={(e) => setForm({ ...form, email: e.target.value })}
+            className="w-full border border-gray-300 rounded px-2 py-1.5 text-sm"
+          />
+        </Field>
+        <Field label="Roll">
+          <div className="text-sm text-gray-700">{role}
+            <span className="text-xs text-gray-400 ml-2">(ändras av admin)</span>
+          </div>
+        </Field>
+      </div>
+      <div className="mt-4 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={saving}
+          className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+        >
+          {saving ? "Sparar…" : "Spara"}
+        </button>
+        {saveError && <span className="text-xs text-red-600">{saveError}</span>}
+      </div>
+    </section>
   );
 }
 


### PR DESCRIPTION
Ett **ratchet-steg** mot #6 (max-lines-per-function → 0). #6 är inneboende inkrementellt (~35 funktioner över ~30 filer); detta är ett säkert, verifierat steg snarare än en riskabel mass-refaktorering.

- Bröt ut "Dina uppgifter"-formuläret ur `ProfilePage` till `ProfileBasicsSection` (identisk markup, bara props) → `ProfilePage` under 100-radersgränsen.
- Lint-ratchet **46 → 45**.

Resten av de långa funktionerna (`buildSeed` 435, `ContactDetailClient`, `NewEventForm` …) städas inkrementellt med samma mönster — en/få per PR, alltid grönt. #6 hålls öppen som spårning av ratchet:en.

## Verifiering
typecheck · lint ≤45 · 2170 tester gröna · next build OK.

Part of #6