### PR TITLE
chore(lint): typ-medveten ESLint — consistent-type-imports + promise-säkerhet (#9)

### DIFF
--- a/src/app/calendar/_event-detail-modal.tsx
+++ b/src/app/calendar/_event-detail-modal.tsx
@@ -48,7 +48,7 @@ export function EventDetailModal({ event, userName, color, onClose, onAfterDelet
   const orgContacts = trpc.contacts.list.useQuery({ pageSize: 500 }, { enabled: !!event });
   const del = trpc.calendar.delete.useMutation({
     onSuccess: () => {
-      utils.calendar.invalidate();
+      void utils.calendar.invalidate();
       onAfterDelete?.();
       onClose();
     },

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -315,7 +315,7 @@ function NewEventForm({ onClose, initial }: { onClose: () => void; initial?: Eve
   const contacts = trpc.contacts.list.useQuery({ pageSize: 500 });
 
   const onCreateOrUpdateSuccess = (saved: EventRow): void => {
-    utils.calendar.invalidate();
+    void utils.calendar.invalidate();
     if (saved.mirrorToOutlook) {
       enqueueMirror({
         eventId: saved.id,
@@ -473,7 +473,7 @@ function NewEventForm({ onClose, initial }: { onClose: () => void; initial?: Eve
 function NewTaskForm({ onClose }: { onClose: () => void }) {
   const utils = trpc.useUtils();
   const create = trpc.task.create.useMutation({
-    onSuccess: () => { utils.task.list.invalidate(); onClose(); },
+    onSuccess: () => { void utils.task.list.invalidate(); onClose(); },
   });
   const [title, setTitle] = useState("");
   const [priority, setPriority] = useState<"LOW" | "MEDIUM" | "HIGH">("MEDIUM");

--- a/src/app/contacts/[id]/_client.tsx
+++ b/src/app/contacts/[id]/_client.tsx
@@ -35,21 +35,21 @@ export default function ContactDetailClient({ id: paramId }: { id: string }) {
 
   const updateContact = trpc.contacts.update.useMutation({
     onSuccess: () => {
-      utils.contacts.getById.invalidate({ id });
+      void utils.contacts.getById.invalidate({ id });
       setEditing(false);
     },
   });
 
   const deleteContact = trpc.contacts.delete.useMutation({
     onSuccess: () => {
-      utils.contacts.list.invalidate();
+      void utils.contacts.list.invalidate();
       router.push("/contacts");
     },
   });
 
   const addChild = trpc.contacts.addChild.useMutation({
     onSuccess: () => {
-      utils.contacts.getById.invalidate({ id });
+      void utils.contacts.getById.invalidate({ id });
       setShowChildForm(false);
       setChildForm({ name: "", email: "", phone: "", notes: "" });
     },

--- a/src/app/contacts/page.tsx
+++ b/src/app/contacts/page.tsx
@@ -62,7 +62,7 @@ function ContactsContent() {
 
   const createContact = trpc.contacts.create.useMutation({
     onSuccess: () => {
-      utils.contacts.list.invalidate();
+      void utils.contacts.list.invalidate();
       setShowForm(false);
       setForm({ name: "", contactType: "PERSON", personalNumber: "", orgNumber: "", email: "", phone: "", address: "", notes: "" });
     },

--- a/src/app/invoices/[id]/_client.tsx
+++ b/src/app/invoices/[id]/_client.tsx
@@ -40,8 +40,8 @@ export default function InvoiceDetailClient({ id: paramId }: { id: string }) {
   const [error, setError] = useState<string | null>(null);
 
   const refetchAll = () => {
-    utils.invoice.getById.invalidate({ id });
-    utils.invoice.list.invalidate();
+    void utils.invoice.getById.invalidate({ id });
+    void utils.invoice.list.invalidate();
   };
 
   const recordPayment = trpc.invoice.recordPayment.useMutation({

--- a/src/app/matters/[id]/_contacts-section.tsx
+++ b/src/app/matters/[id]/_contacts-section.tsx
@@ -51,15 +51,15 @@ export function ContactsSection({ matterId, contacts }: Props) {
 
   const addContact = trpc.matter.addContact.useMutation({
     onSuccess: () => {
-      utils.matter.getById.invalidate({ id: matterId });
+      void utils.matter.getById.invalidate({ id: matterId });
       setExistingContactForm({ contactId: "", role: "MOTPART", notes: "" });
     },
   });
 
   const addNewContact = trpc.matter.addNewContact.useMutation({
     onSuccess: () => {
-      utils.matter.getById.invalidate({ id: matterId });
-      utils.contacts.list.invalidate();
+      void utils.matter.getById.invalidate({ id: matterId });
+      void utils.contacts.list.invalidate();
       setShowContactForm(false);
       setNewContactForm({
         name: "",

--- a/src/app/matters/[id]/_expense-section.tsx
+++ b/src/app/matters/[id]/_expense-section.tsx
@@ -99,9 +99,9 @@ export function ExpenseSection({ matterId, isTaxeArende }: Props) {
     setForm(initialForm());
   }
 
-  const createExpense = trpc.expense.create.useMutation({ onSuccess: () => { utils.expense.list.invalidate({ matterId }); resetClose(); } });
-  const updateExpense = trpc.expense.update.useMutation({ onSuccess: () => { utils.expense.list.invalidate({ matterId }); resetClose(); } });
-  const deleteExpense = trpc.expense.delete.useMutation({ onSuccess: () => utils.expense.list.invalidate({ matterId }) });
+  const createExpense = trpc.expense.create.useMutation({ onSuccess: () => { void utils.expense.list.invalidate({ matterId }); resetClose(); } });
+  const updateExpense = trpc.expense.update.useMutation({ onSuccess: () => { void utils.expense.list.invalidate({ matterId }); resetClose(); } });
+  const deleteExpense = trpc.expense.delete.useMutation({ onSuccess: () => void utils.expense.list.invalidate({ matterId }) });
 
   function startEdit(e: Expense): void {
     setEditingId(e.id);

--- a/src/app/matters/[id]/_generate-modal.tsx
+++ b/src/app/matters/[id]/_generate-modal.tsx
@@ -94,7 +94,7 @@ export function GenerateModal({ matterId, contacts, onClose }: Props) {
           mimeType: "text/html; charset=utf-8", sizeBytes: bytes.byteLength, storagePath,
         });
       }
-      utils.document.tree.invalidate({ matterId });
+      void utils.document.tree.invalidate({ matterId });
       onClose();
     } catch (e) {
       setGenerateError(e instanceof Error ? e.message : "Okänt fel");
@@ -137,7 +137,7 @@ export function GenerateModal({ matterId, contacts, onClose }: Props) {
             Avbryt
           </button>
           <button
-            onClick={handleGenerate}
+            onClick={() => void handleGenerate()}
             disabled={!generateTemplateId || generating}
             className="flex items-center gap-1.5 px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
           >

--- a/src/app/matters/[id]/_kostnadsrakning-modal.tsx
+++ b/src/app/matters/[id]/_kostnadsrakning-modal.tsx
@@ -388,7 +388,7 @@ export function KostnadsrakningModal(props: Props) {
           </button>
           <button
             type="button"
-            onClick={generate}
+            onClick={() => void generate()}
             disabled={generating || hufMin <= 0}
             className="w-full sm:w-auto px-6 py-3.5 bg-indigo-600 text-white text-base font-semibold rounded-lg shadow hover:bg-indigo-700 disabled:opacity-50 inline-flex items-center justify-center gap-2 touch-manipulation order-1 sm:order-2"
           >

--- a/src/app/matters/[id]/_time-section.tsx
+++ b/src/app/matters/[id]/_time-section.tsx
@@ -62,7 +62,7 @@ export function TimeSection({ matterId, isTaxeArende }: Props) {
 
   const createTimeEntry = trpc.timeEntry.create.useMutation({
     onSuccess: () => {
-      utils.timeEntry.list.invalidate({ matterId });
+      void utils.timeEntry.list.invalidate({ matterId });
       setShowCreate(false);
       setCreateForm(emptyForm());
     },
@@ -70,7 +70,7 @@ export function TimeSection({ matterId, isTaxeArende }: Props) {
 
   const updateTimeEntry = trpc.timeEntry.update.useMutation({
     onSuccess: () => {
-      utils.timeEntry.list.invalidate({ matterId });
+      void utils.timeEntry.list.invalidate({ matterId });
       setEditingId(null);
       setEditForm(null);
     },

--- a/src/app/matters/page.tsx
+++ b/src/app/matters/page.tsx
@@ -79,7 +79,7 @@ function MattersContent() {
 
   const createMatter = trpc.matter.create.useMutation({
     onSuccess: () => {
-      utils.matter.list.invalidate();
+      void utils.matter.list.invalidate();
       setShowForm(false);
     },
   });

--- a/src/app/payment-plans/[id]/_client.tsx
+++ b/src/app/payment-plans/[id]/_client.tsx
@@ -25,8 +25,8 @@ export default function PaymentPlanDetailClient({ id: paramId }: { id: string })
   const utils = trpc.useUtils();
   const cancel = trpc.paymentPlan.cancel.useMutation({
     onSuccess: () => {
-      utils.paymentPlan.getById.invalidate({ id });
-      utils.paymentPlan.list.invalidate();
+      void utils.paymentPlan.getById.invalidate({ id });
+      void utils.paymentPlan.list.invalidate();
     },
   });
 

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -111,7 +111,7 @@ export default function ReportsPage() {
             </select>
           </div>
           <button
-            onClick={handleExport}
+            onClick={() => void handleExport()}
             disabled={!userId || !report.data}
             className="px-4 py-2 border border-gray-300 text-gray-700 text-sm font-medium rounded-lg hover:bg-gray-50 disabled:opacity-50"
           >

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -33,10 +33,10 @@ function OfficesSection() {
   const { data: offices = [], isLoading } = trpc.organization.listOffices.useQuery();
 
   const addOffice = trpc.organization.addOffice.useMutation({
-    onSuccess: () => { utils.organization.listOffices.invalidate(); setAdding(false); setForm(emptyOffice()); },
+    onSuccess: () => { void utils.organization.listOffices.invalidate(); setAdding(false); setForm(emptyOffice()); },
   });
   const updateOffice = trpc.organization.updateOffice.useMutation({
-    onSuccess: () => { utils.organization.listOffices.invalidate(); setEditingId(null); },
+    onSuccess: () => { void utils.organization.listOffices.invalidate(); setEditingId(null); },
   });
   const deleteOffice = trpc.organization.deleteOffice.useMutation({
     onSuccess: () => utils.organization.listOffices.invalidate(),
@@ -223,7 +223,7 @@ export default function SettingsPage() {
 
   const updateSettings = trpc.organization.updateSettings.useMutation({
     onSuccess: () => {
-      utils.organization.getSettings.invalidate();
+      void utils.organization.getSettings.invalidate();
       setSaved(true);
       setTimeout(() => setSaved(false), 2500);
     },
@@ -370,7 +370,7 @@ export default function SettingsPage() {
               className="hidden"
               onChange={(e) => {
                 const file = e.target.files?.[0];
-                if (file) handleLogoUpload(file);
+                if (file) void handleLogoUpload(file);
                 e.target.value = "";
               }}
             />
@@ -384,7 +384,7 @@ export default function SettingsPage() {
             </button>
             {logoUrl && (
               <button
-                onClick={handleLogoDelete}
+                onClick={() => void handleLogoDelete()}
                 disabled={logoLoading}
                 className="flex items-center gap-2 px-3 py-1.5 text-sm border border-red-200 text-red-600 rounded hover:bg-red-50 disabled:opacity-50"
               >

--- a/src/app/templates/[id]/edit/_edit-client.tsx
+++ b/src/app/templates/[id]/edit/_edit-client.tsx
@@ -17,8 +17,8 @@ export default function EditTemplateClient({ id: paramId }: { id: string }) {
 
   const update = trpc.documentTemplate.update.useMutation({
     onSuccess: () => {
-      utils.documentTemplate.list.invalidate();
-      utils.documentTemplate.getById.invalidate({ id });
+      void utils.documentTemplate.list.invalidate();
+      void utils.documentTemplate.getById.invalidate({ id });
       router.push("/templates");
     },
   });

--- a/src/app/templates/new/page.tsx
+++ b/src/app/templates/new/page.tsx
@@ -10,7 +10,7 @@ export default function NewTemplatePage() {
 
   const create = trpc.documentTemplate.create.useMutation({
     onSuccess: () => {
-      utils.documentTemplate.list.invalidate();
+      void utils.documentTemplate.list.invalidate();
       router.push("/templates");
     },
   });

--- a/src/app/templates/page.tsx
+++ b/src/app/templates/page.tsx
@@ -26,7 +26,7 @@ export default function TemplatesPage() {
 
   const deleteTemplate = trpc.documentTemplate.delete.useMutation({
     onSuccess: () => {
-      utils.documentTemplate.list.invalidate();
+      void utils.documentTemplate.list.invalidate();
       setConfirmDelete(null);
     },
   });

--- a/src/app/time/page.tsx
+++ b/src/app/time/page.tsx
@@ -104,7 +104,7 @@ export default function TimePage() {
 
   const createTimeEntry = trpc.timeEntry.create.useMutation({
     onSuccess: () => {
-      utils.timeEntry.list.invalidate();
+      void utils.timeEntry.list.invalidate();
       setShowForm(false);
       setForm({ matterId: "", date: new Date().toISOString().split("T")[0], minutes: 30, description: "", billable: true });
     },

--- a/src/app/todo/_client.tsx
+++ b/src/app/todo/_client.tsx
@@ -76,8 +76,8 @@ export default function TodoClient() {
   const utils = trpc.useUtils();
 
   const refresh = () => utils.todo.list.invalidate();
-  const createTask = trpc.task.create.useMutation({ onSuccess: () => { refresh(); setModalState(null); } });
-  const updateTask = trpc.task.update.useMutation({ onSuccess: () => { refresh(); setModalState(null); } });
+  const createTask = trpc.task.create.useMutation({ onSuccess: () => { void refresh(); setModalState(null); } });
+  const updateTask = trpc.task.update.useMutation({ onSuccess: () => { void refresh(); setModalState(null); } });
   const completeTask = trpc.task.complete.useMutation({ onSuccess: refresh });
   const updateTaskStatus = trpc.task.update.useMutation({ onSuccess: refresh });
   const deleteTask = trpc.task.delete.useMutation({ onSuccess: refresh });

--- a/src/app/users/[id]/_edit-client.tsx
+++ b/src/app/users/[id]/_edit-client.tsx
@@ -54,15 +54,15 @@ export default function EditUserClient({ id: paramId }: { id: string }) {
 
   const updateUser = trpc.user.update.useMutation({
     onSuccess: () => {
-      utils.user.list.invalidate();
-      utils.user.getById.invalidate({ id });
+      void utils.user.list.invalidate();
+      void utils.user.getById.invalidate({ id });
       router.push("/users");
     },
   });
 
   const deleteUser = trpc.user.delete.useMutation({
     onSuccess: () => {
-      utils.user.list.invalidate();
+      void utils.user.list.invalidate();
       router.push("/users");
     },
   });

--- a/src/app/users/new/page.tsx
+++ b/src/app/users/new/page.tsx
@@ -24,7 +24,7 @@ export default function NewUserPage() {
 
   const createUser = trpc.user.create.useMutation({
     onSuccess: () => {
-      utils.user.list.invalidate();
+      void utils.user.list.invalidate();
       router.push("/users");
     },
   });

--- a/src/components/documents/_document-row.tsx
+++ b/src/components/documents/_document-row.tsx
@@ -84,7 +84,7 @@ export function DocumentRow({
             className="flex items-center gap-2 min-w-0"
           >
             <DocumentNameButton doc={doc} isAnalyzing={isAnalyzing} disabled={isUploading}
-              onExternalEdit={triggerExternalEdit} />
+              onExternalEdit={() => void triggerExternalEdit()} />
             {isUploading && (
               <span
                 className="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded bg-amber-100 text-amber-800"
@@ -206,8 +206,8 @@ function DocumentActions({
 
   const uploadingTitle = disabled ? "Vänta tills uppladdningen är klar" : undefined;
   const items: ActionMenuItem[] = [
-    { key: "open", label: "Öppna i webbläsaren", icon: <span aria-hidden>🖊</span>, onSelect: openInEditor, disabled, title: uploadingTitle ?? "Öppna i din browser" },
-    { key: "external", label: "Editera externt (PDF Gear, Preview…)", icon: <span aria-hidden>🖥</span>, onSelect: openExternal, disabled, title: uploadingTitle ?? "AVA committar dina ändringar automatiskt" },
+    { key: "open", label: "Öppna i webbläsaren", icon: <span aria-hidden>🖊</span>, onSelect: () => void openInEditor(), disabled, title: uploadingTitle ?? "Öppna i din browser" },
+    { key: "external", label: "Editera externt (PDF Gear, Preview…)", icon: <span aria-hidden>🖥</span>, onSelect: () => void openExternal(), disabled, title: uploadingTitle ?? "AVA committar dina ändringar automatiskt" },
     { key: "view", label: "Visa", icon: <span aria-hidden>👁</span>, href: viewHref, newTab: true, disabled, title: uploadingTitle ?? "Visa i webbläsaren" },
     { key: "download", label: "Ladda ner", icon: <span aria-hidden>⬇</span>, href: downloadHref, download: true, disabled, title: uploadingTitle ?? "Ladda ner" },
     { key: "reanalyze", label: "Analysera (AI)", icon: <span aria-hidden>🧠</span>, onSelect: onReanalyze, disabled: disabled || reanalyzePending, title: uploadingTitle ?? "Kör AI-analys på nytt" },
@@ -264,7 +264,7 @@ function DocumentNameButton({ doc, isAnalyzing, disabled, onExternalEdit }: Name
   return (
     <button
       type="button"
-      onClick={onClick}
+      onClick={() => void onClick()}
       disabled={disabled}
       className="flex items-start gap-2 text-blue-600 hover:underline text-left disabled:opacity-50 disabled:cursor-not-allowed disabled:no-underline"
       title={disabled ? "Laddar upp — vänta tills filen är registrerad" : (doc.summary || "Öppna i extern app (PDFGear för PDF)")}

--- a/src/components/documents/document-browser.tsx
+++ b/src/components/documents/document-browser.tsx
@@ -263,7 +263,7 @@ export function DocumentBrowser({ matterId }: DocumentBrowserProps) {
         showNewFolder={() => setShowNewFolder(true)}
         uploading={uploading}
         fileInputRef={fileInputRef}
-        onUpload={handleFileUpload}
+        onUpload={(e) => { void handleFileUpload(e); }}
         viewMode={viewMode}
         onChangeViewMode={changeViewMode}
       />
@@ -477,10 +477,10 @@ function useDocumentMutations({
   const invalidate = () => utils.document.tree.invalidate({ matterId });
 
   const createFolder = trpc.document.createFolder.useMutation({
-    onSuccess: () => { invalidate(); setShowNewFolder(false); },
+    onSuccess: () => { void invalidate(); setShowNewFolder(false); },
   });
   const renameFolder = trpc.document.renameFolder.useMutation({
-    onSuccess: () => { invalidate(); setRenamingFolderId(null); },
+    onSuccess: () => { void invalidate(); setRenamingFolderId(null); },
   });
   const deleteFolder = trpc.document.deleteFolder.useMutation({ onSuccess: invalidate });
   const moveDocument = trpc.document.moveDocument.useMutation({ onSuccess: invalidate });
@@ -544,23 +544,25 @@ function pollAnalysis({
   const maxAttempts = 24; // 24 × 5s = 120s
   const before = documents.find((d) => d.id === documentId);
   const refresh = () => {
-    utils.document.tree.invalidate({ matterId });
-    utils.document.pendingSuggestionsGrouped.invalidate({ matterId });
-    utils.document.pendingSuggestions.invalidate({ matterId });
-    utils.matter.getById.invalidate({ id: matterId });
+    void utils.document.tree.invalidate({ matterId });
+    void utils.document.pendingSuggestionsGrouped.invalidate({ matterId });
+    void utils.document.pendingSuggestions.invalidate({ matterId });
+    void utils.matter.getById.invalidate({ id: matterId });
   };
-  const interval = setInterval(async () => {
-    attempts++;
-    await refresh();
-    const fresh = await utils.document.tree.fetch({ matterId });
-    const doc = fresh.documents.find((d) => d.id === documentId);
-    const changed = doc && before && (
-      (doc.analyzedAt ? new Date(doc.analyzedAt).getTime() : 0) >
-      (before.analyzedAt ? new Date(before.analyzedAt).getTime() : 0)
-    );
-    if (changed || attempts >= maxAttempts) {
-      clearInterval(interval);
-      clearAnalyzing();
-    }
+  const interval = setInterval(() => {
+    void (async () => {
+      attempts++;
+      refresh();
+      const fresh = await utils.document.tree.fetch({ matterId });
+      const doc = fresh.documents.find((d) => d.id === documentId);
+      const changed = doc && before && (
+        (doc.analyzedAt ? new Date(doc.analyzedAt).getTime() : 0) >
+        (before.analyzedAt ? new Date(before.analyzedAt).getTime() : 0)
+      );
+      if (changed || attempts >= maxAttempts) {
+        clearInterval(interval);
+        clearAnalyzing();
+      }
+    })();
   }, 5000);
 }

--- a/src/components/llm/llm-settings-card.tsx
+++ b/src/components/llm/llm-settings-card.tsx
@@ -118,7 +118,7 @@ export function LlmSettingsCard() {
           <div className="flex items-center gap-3">
             <button
               type="button"
-              onClick={onDownload}
+              onClick={() => void onDownload()}
               disabled={downloading}
               className="inline-flex items-center gap-2 px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
             >

--- a/src/components/matter/events-panel.tsx
+++ b/src/components/matter/events-panel.tsx
@@ -97,7 +97,7 @@ export function EventsPanel({ matterId }: EventsPanelProps) {
                   title="Ladda ner .ics-fil — öppna den för att lägga till i Kalender"
                   onClick={() => {
                     // optimistic — server also marks accepted
-                    setTimeout(() => utils.document.events.invalidate({ matterId }), 500);
+                    setTimeout(() => { void utils.document.events.invalidate({ matterId }); }, 500);
                   }}
                 >
                   📅 Lägg i kalender

--- a/src/components/matter/invoices-section.tsx
+++ b/src/components/matter/invoices-section.tsx
@@ -90,7 +90,7 @@ export function InvoicesSection({ matterId }: { matterId: string }) {
 
   const createAcconto = trpc.invoice.createAcconto.useMutation({
     onSuccess: () => {
-      utils.invoice.list.invalidate({ matterId });
+      void utils.invoice.list.invalidate({ matterId });
       setShowAcconto(false);
       setError(null);
     },
@@ -98,9 +98,9 @@ export function InvoicesSection({ matterId }: { matterId: string }) {
   });
   const createFinal = trpc.invoice.createFinal.useMutation({
     onSuccess: () => {
-      utils.invoice.list.invalidate({ matterId });
-      utils.timeEntry.list.invalidate({ matterId });
-      utils.expense.list.invalidate({ matterId });
+      void utils.invoice.list.invalidate({ matterId });
+      void utils.timeEntry.list.invalidate({ matterId });
+      void utils.expense.list.invalidate({ matterId });
       setShowFinal(false);
       setError(null);
     },

--- a/src/components/matter/payment-method-card.tsx
+++ b/src/components/matter/payment-method-card.tsx
@@ -53,7 +53,7 @@ export function PaymentMethodCard({
   const utils = trpc.useUtils();
   const update = trpc.matter.update.useMutation({
     onSuccess: () => {
-      utils.matter.getById.invalidate({ id: matterId });
+      void utils.matter.getById.invalidate({ id: matterId });
       setEditing(false);
     },
   });

--- a/src/components/matter/suggestions-panel.tsx
+++ b/src/components/matter/suggestions-panel.tsx
@@ -14,9 +14,9 @@ export function SuggestionsPanel({ matterId }: SuggestionsPanelProps) {
   const [busyKey, setBusyKey] = useState<string | null>(null);
 
   const invalidateAll = () => {
-    utils.document.pendingSuggestionsGrouped.invalidate({ matterId });
-    utils.document.pendingSuggestions.invalidate({ matterId });
-    utils.matter.getById.invalidate({ id: matterId });
+    void utils.document.pendingSuggestionsGrouped.invalidate({ matterId });
+    void utils.document.pendingSuggestions.invalidate({ matterId });
+    void utils.matter.getById.invalidate({ id: matterId });
   };
 
   const acceptGroup = trpc.document.acceptSuggestionGroup.useMutation({

--- a/src/components/shell/demo-bootstrap.tsx
+++ b/src/components/shell/demo-bootstrap.tsx
@@ -312,7 +312,7 @@ export function DemoBootstrap({ children }: { children: ReactNode }) {
       }
     };
 
-    (async () => {
+    void (async () => {
       try {
         // Persisterad slab (inkl. ev. runtime-mutationer) finns? Använd den och
         // klona INTE över den — annars skrivs användarens ändringar bort. Ny

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -252,13 +252,13 @@ export function DataTable<T>({ prefKey, columns, data, rowKey, onRowClick, empty
 
   const resetPersonal = (): void => {
     setLocalPrefs({});
-    clear.mutate({ key: prefKey }, { onSuccess: () => utils.prefs.get.invalidate({ key: prefKey }) });
+    clear.mutate({ key: prefKey }, { onSuccess: () => { void utils.prefs.get.invalidate({ key: prefKey }); } });
   };
   const saveAsOrgDefault = (): void => {
-    setOrg.mutate({ key: prefKey, prefs: prefs as Record<string, unknown> }, { onSuccess: () => utils.prefs.get.invalidate({ key: prefKey }) });
+    setOrg.mutate({ key: prefKey, prefs: prefs as Record<string, unknown> }, { onSuccess: () => { void utils.prefs.get.invalidate({ key: prefKey }); } });
   };
   const removeOrgDefault = (): void => {
-    clearOrg.mutate({ key: prefKey }, { onSuccess: () => utils.prefs.get.invalidate({ key: prefKey }) });
+    clearOrg.mutate({ key: prefKey }, { onSuccess: () => { void utils.prefs.get.invalidate({ key: prefKey }); } });
   };
 
   return (

--- a/src/lib/client/demo/in-process-link.ts
+++ b/src/lib/client/demo/in-process-link.ts
@@ -22,7 +22,7 @@ export function inProcessLink(ctx: Context): TRPCLink<AppRouter> {
 
   return () => ({ op }) =>
     observable((observer) => {
-      (async () => {
+      void (async () => {
         try {
           const fn = resolvePath(caller, op.path);
           const result = await fn(op.input);

--- a/src/lib/client/fsa/git-ops.ts
+++ b/src/lib/client/fsa/git-ops.ts
@@ -13,9 +13,11 @@
  *     `Access-Control-Allow-Origin: *`.
  */
 
-import { FsaIsoGitAdapter } from "./fs-adapter";
+import type { FsaIsoGitAdapter } from "./fs-adapter";
 import { sshToHttps } from "./url-rewrite";
 import { DEFAULT_CORS_PROXY } from "@/lib/client/sync/cors-proxy";
+import type * as IsomorphicGit from "isomorphic-git";
+import type * as IsomorphicGitHttp from "isomorphic-git/http/web";
 
 export interface CloneOptions {
   url: string;
@@ -48,11 +50,11 @@ function normalizeProxy(p: string | undefined): string | undefined {
   return p ?? DEFAULT_CORS_PROXY;
 }
 
-async function loadIsoGit(): Promise<typeof import("isomorphic-git")> {
+async function loadIsoGit(): Promise<typeof IsomorphicGit> {
   return import("isomorphic-git");
 }
 
-async function loadHttp(): Promise<typeof import("isomorphic-git/http/web")> {
+async function loadHttp(): Promise<typeof IsomorphicGitHttp> {
   return import("isomorphic-git/http/web");
 }
 

--- a/src/lib/client/kostnadsrakning/render-pdf.ts
+++ b/src/lib/client/kostnadsrakning/render-pdf.ts
@@ -36,6 +36,7 @@
  */
 
 import type { KostnadsrakningResult } from "@/lib/shared/kostnadsrakning";
+import type { PDFPage, PDFFont } from "pdf-lib";
 
 export interface RenderInput {
   result: KostnadsrakningResult;
@@ -172,12 +173,12 @@ export async function renderKostnadsrakningPdf(input: RenderInput): Promise<Uint
   return pdf.save();
 }
 
-function drawRow(page: import("pdf-lib").PDFPage, y: number, font: import("pdf-lib").PDFFont, label: string, value: string): void {
+function drawRow(page: PDFPage, y: number, font: PDFFont, label: string, value: string): void {
   page.drawText(label, { x: 50, y, size: 10, font });
   page.drawText(value, { x: 50 + 350, y, size: 10, font });
 }
 
-function drawTableHeader(page: import("pdf-lib").PDFPage, y: number, font: import("pdf-lib").PDFFont): void {
+function drawTableHeader(page: PDFPage, y: number, font: PDFFont): void {
   page.drawText("Datum", { x: 50, y, size: 8, font });
   page.drawText("Beskrivning", { x: 50 + 70, y, size: 8, font });
   page.drawText("Sats", { x: 50 + 250, y, size: 8, font });

--- a/src/lib/shared/schemas/index.ts
+++ b/src/lib/shared/schemas/index.ts
@@ -12,7 +12,7 @@
  * single source of truth för "vad finns i git-db:n och vart skrivs det".
  */
 
-import { z } from "zod";
+import type { z } from "zod";
 import { organizationSchema, officeSchema } from "./organization";
 import { userSchema } from "./user";
 import { contactSchema } from "./contact";

--- a/test/e2e/kebab-verify.spec.ts
+++ b/test/e2e/kebab-verify.spec.ts
@@ -16,7 +16,7 @@
  * Mot localhost måste demo-läge tvingas (localhost defaultar self-hosted).
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 
 const BASE = process.env.AVA_DEMO_BASE_URL ?? "https://ulrik-s.github.io/ava";
 const isLocal = /localhost|127\.0\.0\.1/.test(BASE);
@@ -32,7 +32,7 @@ test.beforeEach(async ({ page }) => {
   }, BASE);
 });
 
-async function gotoMatter(page: import("@playwright/test").Page) {
+async function gotoMatter(page: Page) {
   await page.goto(`${BASE}/matters/m-001-vardnad/`);
   await page.getByLabel("Dokumentåtgärder").first().waitFor({ timeout: 25_000 });
   await page.waitForTimeout(1500); // demo-bootstrap invalidateQueries settle

--- a/test/scripts/populate-unbilled-time.test.ts
+++ b/test/scripts/populate-unbilled-time.test.ts
@@ -46,7 +46,7 @@ describe("populateUnbilledTime", () => {
 
   it("returnerar 0 om inga aktiva ärenden finns", async () => {
     const { target } = await runTarget();
-    const emptySeed = { ...await (await runTarget()).seed, matters: [], users: [] };
+    const emptySeed = { ...(await runTarget()).seed, matters: [], users: [] };
     const count = await populateUnbilledTime(target.caller, emptySeed as never);
     expect(count).toBe(0);
   });

--- a/test/unit/lib/llm/classify-document.test.ts
+++ b/test/unit/lib/llm/classify-document.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, vi } from "vitest";
 import { classifyDocument, guessFromFilename, KNOWN_KINDS } from "@/lib/client/llm/classify-document";
-import { NoopExtractor, StubExtractor } from "@/lib/server/llm/llm-extractor";
+import { NoopExtractor, StubExtractor, type ILlmExtractor } from "@/lib/server/llm/llm-extractor";
 
 describe("guessFromFilename (heuristik)", () => {
   it("matchar svenska och engelska varianter", () => {
@@ -60,7 +60,7 @@ describe("classifyDocument", () => {
   });
 
   it("LLM kastar → fall back på heuristik (graceful)", async () => {
-    const x: import("@/lib/server/llm/llm-extractor").ILlmExtractor = {
+    const x: ILlmExtractor = {
       isReady: () => true,
       warmup: async () => {},
       extract: vi.fn(async () => { throw new Error("WebGPU bortkopplat"); }),

--- a/test/unit/server/local-first/demo-runtime.test.ts
+++ b/test/unit/server/local-first/demo-runtime.test.ts
@@ -11,10 +11,11 @@
 
 import { describe, it, expect, vi } from "vitest";
 import { DemoRuntime } from "@/lib/server/local-first/demo-runtime";
+import type { MemFs } from "@/lib/server/local-first/mem-fs";
 
 describe("DemoRuntime", () => {
   it("loadDemo populerar in-memory listor som UI:t kan läsa", async () => {
-    const cloneFn = vi.fn(async (fs: import("@/lib/server/local-first/mem-fs").MemFs) => {
+    const cloneFn = vi.fn(async (fs: MemFs) => {
       await fs.writeFile("matters/active/m1.json", JSON.stringify({
         id: "m1", matterNumber: "2026-0001", title: "Demo-ärende",
         status: "ACTIVE", organizationId: "demo",
@@ -33,7 +34,7 @@ describe("DemoRuntime", () => {
   });
 
   it("matters().list returnerar alla ärenden", async () => {
-    const cloneFn = async (fs: import("@/lib/server/local-first/mem-fs").MemFs) => {
+    const cloneFn = async (fs: MemFs) => {
       for (let i = 1; i <= 3; i++) {
         await fs.writeFile(`matters/active/m${i}.json`, JSON.stringify({
           id: `m${i}`, matterNumber: `2026-000${i}`, title: `T${i}`,
@@ -54,7 +55,7 @@ describe("DemoRuntime", () => {
 
   it("ny load ersätter tidigare data", async () => {
     let counter = 0;
-    const cloneFn = async (fs: import("@/lib/server/local-first/mem-fs").MemFs) => {
+    const cloneFn = async (fs: MemFs) => {
       counter++;
       await fs.writeFile("matters/active/m.json", JSON.stringify({
         id: "m", matterNumber: `v${counter}`, title: "x",

--- a/tooling/config/eslint.config.mjs
+++ b/tooling/config/eslint.config.mjs
@@ -26,8 +26,36 @@ const eslintConfig = defineConfig([
     settings: { react: { version: "19.2" } },
   },
   {
+    // Typ-medveten linting (#9). projectService låter typescript-eslint hitta
+    // närmaste tsconfig.json per fil → ger typinfo till reglerna nedan.
+    // Kostar lint-tid (~14s → ~21s) men möjliggör enforcement-golv som rent
+    // syntaktiska regler inte kan uttrycka. tsconfigRootDir = repo-rot eftersom
+    // ESLint annars förankrar mot tooling/config/.
+    files: ["**/*.{ts,tsx,mts}"],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname + "/../..",
+      },
+    },
+  },
+  {
     files: ["**/*.{ts,tsx}"],
     rules: {
+      // consistent-type-imports tvingar `import type` för type-only-importer
+      // → backar mekaniskt upp dependency-cruiser-regeln "UI importerar server
+      // type-only" på källnivå (#9).
+      "@typescript-eslint/consistent-type-imports": "error",
+      // Promise-säkerhet: oavsiktligt obevakade promises, async-callbacks i
+      // synkron/void-kontext, och `await` på icke-thenables är vanliga
+      // buggkällor som bara typinfo kan upptäcka (#9).
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-misused-promises": "error",
+      "@typescript-eslint/await-thenable": "error",
+      // Utvärderade men uppskjutna (#9): no-unnecessary-condition (~105 brott)
+      // och strict-boolean-expressions (~529) är för stora för ett svep —
+      // ratchas per katalog i uppföljnings-issue. Typinfon ovan är redan på, så
+      // de tillkommer utan extra parser-overhead när de aktiveras.
       // Underscore-prefix = avsiktligt oanvänd (signaturkrav, framtida bruk).
       // Skiljer medvetna platshållare från faktiskt bortglömd kod.
       "@typescript-eslint/no-unused-vars": [

--- a/tooling/scripts/diagnose-ui.ts
+++ b/tooling/scripts/diagnose-ui.ts
@@ -120,7 +120,7 @@ const MIME: Record<string, string> = {
 };
 
 function serveOut(): Server {
-  const server = createServer(async (req, res) => {
+  const server = createServer((req, res) => { void (async () => {
     try {
       let url = new URL(req.url ?? "/", `http://localhost:${PORT}`).pathname;
       if (url.startsWith(BASE_PATH)) url = url.slice(BASE_PATH.length);
@@ -139,7 +139,7 @@ function serveOut(): Server {
     } catch (e) {
       res.writeHead(500); res.end(String(e));
     }
-  });
+  })(); });
   server.listen(PORT);
   return server;
 }


### PR DESCRIPTION
Löser #9. Aktiverar typ-medveten linting (`parserOptions.projectService`) och fyra enforcement-regler som höjer golvet på sätt rent syntaktiska regler inte kan.

## Påslagna regler & åtgärdade brott

| Regel | Brott | Åtgärd |
|---|---|---|
| `consistent-type-imports` | 13 | inline `import().Type`-annoteringar → top-level `import type`; **dynamiska `import()`-anrop bevarade** (ingen bundle-effekt) |
| `no-floating-promises` | 51 | `void`-prefix på obevakade promises (mest `invalidate()` i `onSuccess`) |
| `no-misused-promises` | 16 | async-handlers i void-kontext → `() => void fn()` (matchar 25 befintliga `onClick`-wrappar) |
| `await-thenable` | 2 | onödiga `await` på icke-thenables borttagna |

**`consistent-type-imports`** är huvudnumret: tvingar `import type` på källnivå → backar mekaniskt upp dependency-cruiser-regeln "UI importerar server type-only".

## Uppskjutet (ratchet)

De två `(utvärdera)`-reglerna i #9 är för stora för ett svep — samma mönster som strikta TS-flaggor i #7/#32:

- `no-unnecessary-condition` (~105 brott)
- `strict-boolean-expressions` (~529 brott)

Typinfon är redan på, så de tillkommer utan extra parser-overhead när de ratchas per katalog. Beslutet är dokumenterat i `eslint.config.mjs`. **Förslag:** öppna en uppföljnings-issue för dessa.

## Kostnad

Lint ~14s → ~21s (typinfo). Acceptabelt för CI.

## Verifiering

- `yarn lint`: **0 errors** (45 oförändrade pre-existerande warnings)
- `yarn typecheck`: rent
- `yarn test:fast`: **2170 tester gröna**
- `yarn build:demo`: OK (96 HTML-filer, 500 entiteter i manifest)

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)