### PR TITLE
chore(deps): fler dependency-cruiser fitness-regler (#10)

### DIFF
--- a/docs/quality.md
+++ b/docs/quality.md
@@ -90,9 +90,33 @@ Coverage-rapporten skrivs till `reports/coverage/` (HTML, lcov, json-summary, te
 
 Hårda regler (severity `error`):
 
+_Hygien_
+
 - **`no-circular`** — inga cirkulära imports
 - **`no-test-imports-from-prod`** — produktionskod får inte importera testfiler
 - **`no-non-package-json`** — varje `import` måste finnas i `package.json`
+
+_Lager- & kompositionsgränser (fitness functions)_
+
+- **`shared-must-not-import-up`** — `src/lib/shared` får inte bero på `client/`
+  eller `server/` (delad kod hör hemma neråt, inte uppåt).
+- **`shared-must-be-framework-agnostic`** — `src/lib/shared` får inte importera
+  `react`/`react-dom`/`next`/`@trpc`; det är ramverks-agnostisk domänkod som
+  körs i alla lager.
+- **`server-contracts-must-not-import-client`** — server-routrar/domänlogik får
+  inte importera `client/` (undantag: git-backendens egen wiring i
+  `adapters/`, `local-first/`).
+- **`ui-imports-server-by-type-only`** — UI-lagret får bara `import type` från
+  `server/` (tRPC-kontraktet); värde-importer endast i composition-root.
+- **`no-git-cache-in-contracts`** — kontrakt-lagret + framtida Postgres-backend
+  får inte importera git-backendens cache/sök-internals (gå via
+  `IPorts.searchIndex`, [ADR 0001](./adr/0001-pluggbar-backend-bakom-idatastore.md)).
+- **`routers-compose-via-app`** — tRPC-routrar får inte importera varandra;
+  komponera top-level-routrar i `routers/_app.ts`.
+- **`router-internals-private`** — en routers interna procedurgrupper i en
+  subdir (t.ex. `routers/document/`) är privata: bara kompositionsfilen
+  (`document.ts`) + syskon inom subdir:en får importera dem. Inga djupa
+  cross-module-importer.
 
 `src/server/db` finns inte längre (Prisma borta), så `ui-not-direct-prisma`-
 regeln är obsolet.

--- a/tooling/config/dependency-cruiser.cjs
+++ b/tooling/config/dependency-cruiser.cjs
@@ -149,6 +149,64 @@ module.exports = {
         dependencyTypesNot: ["type-only"],
       },
     },
+    {
+      // Lager-gräns (docs/architecture.md §"Tre lager"): `shared` är delad
+      // domänkod (Zod-scheman, rena helpers) som körs i ALLA lager — server,
+      // klient, tester, build-skript. Den måste därför vara framework-agnostisk:
+      // ingen import av react/next/@trpc. Ramverks-beroende kod hör hemma i
+      // client/ (UI) eller server/ (tRPC), inte i shared/. (`shared-must-not-
+      // import-up` vaktar grannskapet — egna lager; den här vaktar uppåt mot
+      // npm-ramverken.) node_modules-löven react/react-dom/next/@trpc hålls
+      // kvar i grafen av exclude-undantaget längst ned just för denna regel.
+      name: "shared-must-be-framework-agnostic",
+      severity: "error",
+      comment:
+        "src/lib/shared får inte importera react/react-dom/next/@trpc. Det är " +
+        "framework-agnostisk delad domänkod (scheman, helpers) — lägg " +
+        "ramverks-beroende kod i client/ eller server/.",
+      from: { path: "^src/lib/shared/" },
+      to: { path: "node_modules/(react|react-dom|next|@trpc)(/|$)" },
+    },
+    {
+      // Kompositions-disciplin: varje top-level-router (`routers/<x>.ts`)
+      // exporterar EN `xRouter` och komponeras ihop i `_app.ts`. Routrar får
+      // inte importera varandra — det skapar implicit koppling, cykler och gör
+      // att de inte längre går att resonera om/testa isolerat. Delad
+      // domänlogik hör hemma i shared/ eller server-interna helpers, inte i en
+      // grann-router. `_app.ts` är undantaget — det ÄR kompositionsroten.
+      // (Subdir-filer som routers/document/core.ts är INTE top-level-routrar;
+      // de matchar inte to-mönstret nedan och får komponeras fritt inom sin
+      // modul — den gränsen vaktas av `router-internals-private`.)
+      name: "routers-compose-via-app",
+      severity: "error",
+      comment:
+        "tRPC-routrar får inte importera varandra. Komponera top-level-routrar " +
+        "i routers/_app.ts; dela domänlogik via shared/ eller server-interna " +
+        "helpers, inte via en grann-router.",
+      from: {
+        path: "^src/lib/server/routers/",
+        pathNot: "^src/lib/server/routers/_app\\.ts$",
+      },
+      to: { path: "^src/lib/server/routers/[^/]+\\.ts$" },
+    },
+    {
+      // Inga djupa cross-module-importer: en router som splittas i flera filer
+      // lägger sina interna delar i en subdir (`routers/document/` →
+      // core/folders/suggestions/events/shared). Den publika ytan är
+      // kompositionsfilen `document.ts` (exporterar `documentRouter`); de
+      // interna procedurgrupperna är privata. Bara `document.ts` + syskon inom
+      // `document/` får importera dem — alla andra ska konsumera documentRouter
+      // via _app, inte djupimportera interna grupper. Samma mönster gäller
+      // varje framtida `routers/<x>/`-submodul (lägg till en rad per submodul).
+      name: "router-internals-private",
+      severity: "error",
+      comment:
+        "Djup cross-module-import förbjuden: routers/document/ är document-" +
+        "routerns privata procedurgrupper. Bara document.ts (+ syskon i " +
+        "document/) får importera dem; andra moduler går via documentRouter/_app.",
+      from: { pathNot: "^src/lib/server/routers/document(/|\\.ts$)" },
+      to: { path: "^src/lib/server/routers/document/" },
+    },
   ],
   options: {
     // Följ type-only-imports (`import type`). Utan detta räknas inte type-
@@ -161,7 +219,11 @@ module.exports = {
     exclude: {
       path: [
         "(^|/)\\.next(/|$)",
-        "(^|/)node_modules(/|$)",
+        // node_modules utesluts ur grafen UTOM react/react-dom/next/@trpc.
+        // De fyra hålls kvar som (icke-traverserade, via doNotFollow ovan)
+        // löv-noder så att `shared-must-be-framework-agnostic` kan path-matcha
+        // kanten src/lib/shared → ramverk. Övriga paket exkluderas som förr.
+        "(^|/)node_modules/(?!(react|react-dom|next|@trpc)(/|$))",
         "(^|/)reports(/|$)",
         "(^|/)storage(/|$)",
         "(^|/)src/shared/generated(/|$)",


### PR DESCRIPTION
Löser #10 — bygger vidare på de befintliga lager-reglerna i `tooling/config/dependency-cruiser.cjs` med tre nya fitness functions.

## Nya regler (severity `error`)

| Regel | Vad den vaktar |
|-------|----------------|
| `shared-must-be-framework-agnostic` | `src/lib/shared/` får inte importera `react`/`react-dom`/`next`/`@trpc` — ramverks-agnostisk delad domänkod. |
| `routers-compose-via-app` | tRPC-routrar får inte importera varandra; komposition sker i `routers/_app.ts`. |
| `router-internals-private` | `routers/document/` är document-routerns privata procedurgrupper — bara `document.ts` + syskon i `document/` får djupimportera dem (inga djupa cross-module-importer). |

## Implementationsdetalj

`node_modules` uteslöts tidigare helt ur grafen, vilket gör att kanter till npm-paket inte går att path-matcha. Exclude-mönstret ändrat till en negativ lookahead som släpper igenom **just** `react`/`react-dom`/`next`/`@trpc` som icke-traverserade löv-noder — resten av `node_modules` exkluderas som förr. Det är vad som gör `shared-must-be-framework-agnostic` möjlig utan att vidga grafen i onödan (581 → 591 moduler).

## Verifiering

- ✅ `yarn deps:check` grön mot nuvarande kod (591 moduler, 1336 deps, 0 violations) — inga kodfixar behövdes.
- ✅ Varje regel verifierad att den **fångar** överträdelser via temporära probe-filer (shared→react, router→router, utomstående→`document/core`).
- 📄 `docs/quality.md` uppdaterad: listar nu hela lager-/fitness-regeluppsättningen (var tidigare inaktuell — saknade även de befintliga reglerna).

## Acceptanskriterier (#10)

- [x] `shared` framework-agnostiskt — förbjud `react`/`next`/`@trpc` i `src/lib/shared/`
- [x] Routrar får inte importera andra routrar — komposition via `_app.ts`
- [x] Inga djupa cross-module-imports — publik yta tvingas (router-submodul-internals privata)
- [x] Reglerna gröna mot nuvarande kod och dokumenterade

🤖 Generated with [Claude Code](https://claude.com/claude-code)