### PR TITLE
Gör knip äkta grön + ratcha exports/types till error (#42)

### DIFF
--- a/src/lib/client/labels.ts
+++ b/src/lib/client/labels.ts
@@ -54,7 +54,10 @@ export function labelForMatterRole(role: string): string {
   return (MATTER_ROLE_LABELS as Record<string, string>)[role] ?? role;
 }
 
-/** Runtime-guard — användbar när DB-data kommer in som rå sträng. */
+/**
+ * Runtime-guard — användbar när DB-data kommer in som rå sträng.
+ * @public — avsedd hjälpfunktion (ännu ej konsumerad internt).
+ */
 export function isMatterRole(v: unknown): v is MatterRole {
   return typeof v === "string" && v in MATTER_ROLE_LABELS;
 }
@@ -75,6 +78,10 @@ export function labelForContactType(type: string): string {
   return (CONTACT_TYPE_LABELS as Record<string, string>)[type] ?? type;
 }
 
+/**
+ * Runtime-guard — motsvarar `isMatterRole` för kontakt-typer.
+ * @public — avsedd hjälpfunktion (ännu ej konsumerad internt).
+ */
 export function isContactType(v: unknown): v is ContactType {
   return typeof v === "string" && v in CONTACT_TYPE_LABELS;
 }

--- a/src/lib/client/pwa-cache-strategy.ts
+++ b/src/lib/client/pwa-cache-strategy.ts
@@ -62,5 +62,6 @@ export function shouldCacheResponse(res: ResponseLike): boolean {
 /**
  * Versionerad cache-namespace. Bumpa när vi vill invalidera alla
  * gamla cacher (t.ex. brytande SW-uppdatering).
+ * @public — avsedd cache-versionsinfra (ännu ej inkopplad i SW-flödet).
  */
 export const CACHE_VERSION = "ava-v1";

--- a/src/lib/shared/kostnadsrakning-template.ts
+++ b/src/lib/shared/kostnadsrakning-template.ts
@@ -15,6 +15,7 @@
 
 export const KOSTNADSRAKNING_TEMPLATE_NAME = "Kostnadsräkning till rätten";
 export const KOSTNADSRAKNING_TEMPLATE_CATEGORY = "Kostnadsräkning";
+/** @public — del av den symmetriska mall-namn/kategori-uppsättningen (NAME-varianten ännu ej konsumerad). */
 export const KOSTNADSRAKNING_ICKE_TAXA_TEMPLATE_NAME = "Kostnadsräkning (icke-taxa)";
 export const KOSTNADSRAKNING_ICKE_TAXA_TEMPLATE_CATEGORY = "Kostnadsräkning (icke-taxa)";
 

--- a/tooling/config/knip.json
+++ b/tooling/config/knip.json
@@ -10,7 +10,14 @@
     "test/scripts/*.test.ts",
     "next.config.{ts,js,mjs}",
     "postcss.config.{js,mjs}",
-    "src/lib/shared/schemas/ids.ts"
+
+    "src/lib/shared/schemas/*.ts",
+    "src/lib/server/data-store/IDataStore.ts",
+    "src/lib/server/ports.ts",
+    "src/lib/server/events/schema.ts",
+    "src/lib/server/rules/schema.ts",
+    "src/lib/server/trpc.ts",
+    "src/lib/server/trpc-core.ts"
   ],
   "project": [
     "src/**/*.{ts,tsx}",
@@ -19,6 +26,7 @@
   "ignore": [
     "tooling/scripts/oauth-proxy/**"
   ],
+  "ignoreExportsUsedInFile": true,
   "ignoreDependencies": [
     "tailwindcss",
     "@commitlint/cli"
@@ -36,8 +44,8 @@
     "unlisted": "error",
     "unresolved": "error",
     "binaries": "error",
-    "exports": "warn",
-    "types": "warn",
+    "exports": "error",
+    "types": "error",
     "nsExports": "warn",
     "nsTypes": "warn",
     "enumMembers": "warn",


### PR DESCRIPTION
Closes #42.

`yarn knip` gick från 50 oanvända exports + 77 typer (severity `warn` — brus som dolde äkta död kod) till **0 fynd vid `error`-severity**.

## Tillvägagångssätt (inget avsiktligt API raderat)
- **entry**-deklarerar kontrakt-/API-moduler i `knip.json` (`src/lib/shared/schemas/*`, `IDataStore.ts`, `ports.ts`, `events/schema.ts`, `rules/schema.ts`, `trpc.ts`, `trpc-core.ts`) — deras exports ÄR den publika ytan.
- **`ignoreExportsUsedInFile: true`** — en export som används i sin egen fil är inte död kod, bara onödigt exponerad. Detta rensade ~120 typ/interface-API:n som bara saknade cross-modul-import (t.ex. en hooks return-typ). knip flaggar nu bara *helt oreferererad* kod = den äkta dödkods-ratchet:en.
- **`@public`** på 4 avsiktligt-men-ännu-ej-konsumerade symboler: `isMatterRole`, `isContactType` (runtime-guards), `CACHE_VERSION` (SW-cache-infra), `KOSTNADSRAKNING_ICKE_TAXA_TEMPLATE_NAME` (symmetrisk mall-namn-uppsättning).
- Flippar `rules.exports` + `rules.types`: `warn` → **`error`**.

## Klar-kriterier (issue #42)
- ✅ `yarn knip` = 0 fynd utan `--no-exit-code` (verifierat lokalt, exit 0).
- ✅ `exports` + `types` står på `error`.
- ✅ Inget avsiktligt API raderat — typecheck + lint + test:fast (2184) gröna lokalt.

Landar via PR enligt #16-flödet.