### PR TITLE
Typa matter/contact-delegates → branded ids flödar till router-output (#39)

### DIFF
--- a/src/app/contacts/page.tsx
+++ b/src/app/contacts/page.tsx
@@ -192,7 +192,7 @@ function ContactsContent() {
         </select>
       </div>
 
-      <ContactsTable rows={contacts.data?.contacts ?? []} />
+      <ContactsTable rows={(contacts.data?.contacts ?? []) as ContactRow[]} />
       {contacts.data && contacts.data.pages > 1 && (
         <div className="px-6 py-3 mt-2 bg-white border border-gray-200 rounded-lg flex items-center justify-between">
           <p className="text-sm text-gray-500">Sida {page} av {contacts.data.pages} ({contacts.data.total} totalt)</p>

--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -25,7 +25,7 @@ import { useMatterInvariants } from "@/lib/client/diagnostics/use-matter-invaria
 interface MatterContext {
   matterNumber: string;
   title: string;
-  taxaLevel?: 1 | 2 | 3 | 4 | null;
+  taxaLevel?: number | null;
   taxaHasFTax?: boolean | null;
   taxaHufStart?: string | Date | null;
   isTaxeArende?: boolean | null;
@@ -214,7 +214,7 @@ function KostnadsrakningTrigger({ matterId, matter, open, onClose, onRecorded }:
       clientName={clientOf(matter)}
       courtName={courtOf(matter)}
       {...data}
-      initialLevel={matter.taxaLevel ?? undefined}
+      initialLevel={(matter.taxaLevel ?? undefined) as 1 | 2 | 3 | 4 | undefined}
       initialHasFTax={matter.taxaHasFTax ?? undefined}
       initialHufStart={matter.taxaHufStart ?? undefined}
       initialIsTaxe={matter.isTaxeArende ?? undefined}

--- a/src/app/matters/[id]/_client.tsx
+++ b/src/app/matters/[id]/_client.tsx
@@ -47,8 +47,8 @@ export default function MatterDetailClient({ id: paramId }: { id: string }) {
         <PaymentMethodCard
           matterId={id}
           paymentMethod={m.paymentMethod}
-          paymentMethodNote={m.paymentMethodNote}
-          paymentMethodDecidedAt={m.paymentMethodDecidedAt}
+          paymentMethodNote={m.paymentMethodNote ?? null}
+          paymentMethodDecidedAt={m.paymentMethodDecidedAt ?? null}
         />
       </div>
 

--- a/src/lib/server/data-store/IDataStore.ts
+++ b/src/lib/server/data-store/IDataStore.ts
@@ -59,12 +59,30 @@ export interface ClaimOpts {
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 /**
- * Output-typ för en delegate-fråga. `Row` är basraden (från Zod-schemat),
- * `& { [k: string]: any }` lägger till en index-signatur för att rymma
- * `include`-joinade fält (matter.contacts, contact.matterLinks, ...) utan
- * att behöva typ-deklarera varje möjlig kombination.
+ * Kända relations-/join-fält som `include` kan lägga på en rad.
+ *
+ * Uppräknade som optional `any` — INTE en `[k: string]: any`-index-signatur —
+ * eftersom en string-index-signatur tvättar bort Row:s EGNA fälttyper (särskilt
+ * branded id:n, [[ids]]) till `any` i intersektionen. Med en uppräkning behåller
+ * `Joined<Matter>["id"]` sin `MatterId`-typ, medan joinade fält fortsatt är `any`
+ * (vi typar inte de exakta include-formerna här — det vore router-omskrivningen).
  */
-export type Joined<Row> = Row & { [key: string]: any };
+export interface JoinedRelations {
+  matter?: any; contact?: any; contacts?: any; matterLinks?: any;
+  children?: any; parent?: any; documents?: any; document?: any;
+  timeEntries?: any; expenses?: any; payments?: any; invoice?: any;
+  folder?: any; paymentPlan?: any; billingRun?: any; reminders?: any;
+  accontoInvoice?: any; finalInvoice?: any; creditNote?: any;
+  uploadedBy?: any; recordedBy?: any; createdBy?: any; checkedBy?: any;
+  user?: any; emails?: any; _count?: any;
+}
+
+/**
+ * Output-typ för en delegate-fråga: basraden (`Row`, från Zod-schemat) plus
+ * de optionella relations-fälten. Se `JoinedRelations` för varför det inte är
+ * en index-signatur (branded id:n skulle annars tvättas bort till `any`).
+ */
+export type Joined<Row> = Row & JoinedRelations;
 
 export interface Delegate<Row = any> {
   findUnique(args: any): Promise<Joined<Row> | null>;
@@ -89,8 +107,8 @@ export interface Delegate<Row = any> {
 // och kallar (förväntar `null`-only), samt relation-joins (matter.contacts)
 // som inte finns i bas-schemat. Tighten har gjorts opt-in via TypedDelegate
 // nedan så enskilda callers kan välja striktare typer när de vill.
-export type MatterDelegate = Delegate;
-export type ContactDelegate = Delegate;
+export type MatterDelegate = Delegate<Matter>;
+export type ContactDelegate = Delegate<Contact>;
 export type MatterContactDelegate = Delegate;
 export type DocumentDelegate = Delegate;
 export type DocumentFolderDelegate = Delegate;

--- a/test/unit/server/branded-id-router-output.test.ts
+++ b/test/unit/server/branded-id-router-output.test.ts
@@ -1,0 +1,50 @@
+/**
+ * #39 — branded id:n ska nå ända ut till tRPC-router-output, inte tvättas bort
+ * till `any` vid `Joined<Row>`-gränsen i datalagret.
+ *
+ * Detta är ett TYP-NIVÅ-kontrakt: assertions:erna nedan verifieras av
+ * `yarn typecheck` (include: **\/*.ts). Om en delegate åter-typas till
+ * `Delegate<any>`, eller `Joined` återinför en `[k: string]: any`-index-
+ * signatur, blir `.id` `any` igen → dessa rader blir röda. Runtime-testet
+ * finns bara så vitest räknar filen.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { inferRouterOutputs } from "@trpc/server";
+import type { AppRouter } from "@/lib/server/routers/_app";
+import type { MatterId, ContactId } from "@/lib/shared/schemas/ids";
+
+type Out = inferRouterOutputs<AppRouter>;
+
+// `0 extends (1 & T)` är sant ENDAST för `any` — fångar wash-out-regression.
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type Assert<T extends true> = T;
+
+// matter.getById().id är MatterId (och INTE any/plain string).
+type _matterId = Assert<
+  IsAny<Out["matter"]["getById"]["id"]> extends true
+    ? false
+    : Out["matter"]["getById"]["id"] extends MatterId
+      ? true
+      : false
+>;
+
+// contact.getById().id är ContactId (och INTE any/plain string).
+type _contactId = Assert<
+  IsAny<Out["contacts"]["getById"]["id"]> extends true
+    ? false
+    : Out["contacts"]["getById"]["id"] extends ContactId
+      ? true
+      : false
+>;
+
+// Korsbrand: en MatterId får INTE vara assignable till ContactId-utdata.
+type _distinct = Assert<Out["matter"]["getById"]["id"] extends ContactId ? false : true>;
+
+describe("branded id:n når router-output (#39)", () => {
+  it("är ett typ-nivå-kontrakt som verifieras av tsc", () => {
+    // De faktiska assertions:erna är typerna ovan; om de inte håller blir
+    // `yarn typecheck` rött. Här bekräftar vi bara att filen körs.
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
Part of #39 (kärnan — se nedan om vad som återstår).

Branded id-typerna (#15) tvättades bort till `any` vid `Joined<Row>`-gränsen i datalagret, pga en `[k: string]: any`-index-signatur. Det här löser upp det.

## Ändringar
- **`Joined<Row>`** räknar nu upp kända relations-fält (`JoinedRelations`, optional `any`) i stället för en string-index-signatur. En string-index-signatur tvättar bort Row:s egna fälttyper till `any` i intersektionen; en uppräkning bevarar dem (branded id:n överlever) medan joinade fält förblir `any`.
- **`MatterDelegate` / `ContactDelegate`** typade som `Delegate<Matter>` / `Delegate<Contact>`.
- **Typ-nivå-kontraktstest** (`test/unit/server/branded-id-router-output.test.ts`): asserterar att `matter.getById().id` är `MatterId` och `contacts.getById().id` är `ContactId` (och INTE `any`/plain string). Regression-vakt — om delegaterna åter-washas blir `yarn typecheck` rött.
- **Legacy schema-mismatcher** som typningen avslöjade: nullish→null-coalescing (`paymentMethodNote`/`-DecidedAt`), `taxaLevel` number-vs-literal, `ContactRow._count`-boundary-cast.

## Klar-kriterier (#39)
- ✅ Minst matter + contact har typade delegates.
- ✅ Branded ids syns i router-output (bevisat av kontraktstestet).
- ✅ typecheck + test:fast (2184) gröna; lint + knip(@error) gröna.
- ⏳ **Återstår:** minska implementation-`any` i DemoDataStore:s generiska motor (where/data/include-params är `any` i Prisma-stil). Det är en egen, större refaktor — föreslår en följd-issue, därför **Part of** och inte **Closes**.

Landar via PR enligt #16-flödet.