### PR TITLE
Eliminera all `any` i periferin (#47, fas 1)

### DIFF
--- a/src/app/calendar/_day-view.tsx
+++ b/src/app/calendar/_day-view.tsx
@@ -38,8 +38,7 @@ interface DayViewProps {
   userNames: Readonly<Record<string, string>>;
   userColors?: Map<string, UserColor>;
   /** Klick på event → öppna detalj-modal i parent. */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onSelectEvent?: (ev: any) => void;
+  onSelectEvent?: (ev: DayEvent) => void;
 }
 
 const HOUR_HEIGHT = 48; // px per timme

--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -12,7 +12,9 @@
  * öppnar verdict-dialogen (sätter prutning + skapar faktura).
  */
 import { useState } from "react";
+import type { inferRouterOutputs } from "@trpc/server";
 import { trpc } from "@/lib/client/trpc";
+import type { AppRouter } from "@/lib/server/routers/_app";
 import { formatCurrency } from "@/lib/client/utils";
 import { BILLING_RUN_TYPE_LABELS, BILLING_RUN_STATUS_LABELS } from "@/lib/shared/schemas/enums";
 import { BillingDialog } from "./_billing-dialog";
@@ -51,10 +53,11 @@ interface BillingRunRow {
 
 interface KrDocInfo { id: string; fileName: string }
 
+type DocumentListOutput = inferRouterOutputs<AppRouter>["document"]["list"];
+
 function findKrDocument(matterId: string, run: BillingRunRow): KrDocInfo | null {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const docs = trpc.document.list.useQuery({ matterId, folderId: null, pageSize: 100 }).data as any;
-  const list = (docs?.documents ?? []) as Array<{ id: string; fileName: string; documentType?: string | null; createdAt?: string | Date }>;
+  const docs: DocumentListOutput | undefined = trpc.document.list.useQuery({ matterId, folderId: null, pageSize: 100 }).data;
+  const list = docs?.documents ?? [];
   const kostn = list.filter((d) => d.documentType === "Kostnadsräkning");
   if (kostn.length === 0) return null;
   // Senaste KR-dokumentet skapat innan/samtidigt med billing-run:n —

--- a/src/app/matters/[id]/_kostnadsrakning-modal.tsx
+++ b/src/app/matters/[id]/_kostnadsrakning-modal.tsx
@@ -17,8 +17,10 @@
  */
 
 import { useEffect, useMemo, useState } from "react";
+import type { inferRouterInputs } from "@trpc/server";
 import { Clock, FileText, X, AlertTriangle, Save } from "lucide-react";
 import { trpc } from "@/lib/client/trpc";
+import type { AppRouter } from "@/lib/server/routers/_app";
 import { buildKostnadsrakningContext } from "@/lib/shared/kostnadsrakning";
 import type { TaxaLevel } from "@/lib/shared/brottmalstaxa";
 import { renderKostnadsrakningPdf } from "@/lib/client/kostnadsrakning/render-pdf";
@@ -61,15 +63,18 @@ function defaultStart(stored?: string | Date | null): string {
   return toDatetimeLocalValue(d);
 }
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
+type RouterInputs = inferRouterInputs<AppRouter>;
+type DocListFilter = RouterInputs["document"]["list"];
+type DocTreeFilter = RouterInputs["document"]["tree"];
+
 interface RecordDocOpts {
-  recordKostn: { mutateAsync: (i: any) => Promise<unknown> };
+  recordKostn: { mutateAsync: (i: RouterInputs["kostnadsrakning"]["record"]) => Promise<unknown> };
   utils: {
     document: {
-      list: { invalidate: (filter?: any) => Promise<unknown> };
+      list: { invalidate: (filter?: DocListFilter) => Promise<unknown> };
       tree: {
-        invalidate: (filter?: any) => Promise<unknown>;
-        refetch: (filter?: any) => Promise<unknown>;
+        invalidate: (filter?: DocTreeFilter) => Promise<unknown>;
+        refetch: (filter?: DocTreeFilter) => Promise<unknown>;
       };
     };
   };
@@ -81,7 +86,6 @@ interface RecordDocOpts {
   totalInclVat: number;
   huvudforhandlingMinutes: number;
 }
-/* eslint-enable @typescript-eslint/no-explicit-any */
 
 async function recordDocument(opts: RecordDocOpts): Promise<void> {
   // Steg 1 MÅSTE lyckas. Om mutationen kastar propagerar vi felet så att

--- a/src/app/matters/[id]/_verdict-dialog.tsx
+++ b/src/app/matters/[id]/_verdict-dialog.tsx
@@ -12,9 +12,13 @@
  * det är vad advokaten skriver in.
  */
 import { useState } from "react";
+import type { inferRouterInputs } from "@trpc/server";
 import { trpc } from "@/lib/client/trpc";
+import type { AppRouter } from "@/lib/server/routers/_app";
 import { formatCurrency } from "@/lib/client/utils";
 import { Modal } from "@/components/ui/modal";
+
+type RouterInputs = inferRouterInputs<AppRouter>;
 
 interface Props {
   billingRunId: string;
@@ -28,10 +32,15 @@ interface Props {
   onClose: () => void;
 }
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-type RegisterMut = { mutateAsync: (i: any) => Promise<unknown> };
-type DocUtils = { document: { tree: { invalidate: (f?: any) => Promise<unknown>; refetch: (f?: any) => Promise<unknown> }; list: { invalidate: (f?: any) => Promise<unknown> } } };
-/* eslint-enable @typescript-eslint/no-explicit-any */
+type RegisterMut = { mutateAsync: (i: RouterInputs["document"]["register"]) => Promise<unknown> };
+type TreeFilter = RouterInputs["document"]["tree"];
+type ListFilter = RouterInputs["document"]["list"];
+type DocUtils = {
+  document: {
+    tree: { invalidate: (f?: TreeFilter) => Promise<unknown>; refetch: (f?: TreeFilter) => Promise<unknown> };
+    list: { invalidate: (f?: ListFilter) => Promise<unknown> };
+  };
+};
 
 /**
  * Generera ett faktura-DOKUMENT (PDF) ur den nyss skapade invoice-entiteten och

--- a/src/components/documents/document-browser.tsx
+++ b/src/components/documents/document-browser.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useState, useRef, useCallback, useMemo } from "react";
+import type { inferRouterInputs } from "@trpc/server";
 import { trpc } from "@/lib/client/trpc";
+import type { AppRouter } from "@/lib/server/routers/_app";
 import { FolderRow, type FolderRecord } from "./_folder-row";
 import { DocumentRow, type DocumentRecord } from "./_document-row";
 import { NewFolderForm } from "./_new-folder-form";
@@ -10,6 +12,8 @@ import { DocumentsListView } from "./_documents-list-view";
 
 type ViewMode = "tree" | "list";
 const VIEW_MODE_KEY = "ava.documents.viewMode";
+
+type RegisterInput = inferRouterInputs<AppRouter>["document"]["register"];
 
 interface DocumentBrowserProps {
   matterId: string;
@@ -487,12 +491,8 @@ function useDocumentMutations({
   const moveFolder = trpc.document.moveFolder.useMutation({ onSuccess: invalidate });
   const deleteDocument = trpc.document.delete.useMutation({ onSuccess: invalidate });
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const registerMutation = (trpc.document as any).register.useMutation({ onSuccess: invalidate });
-  const createFromFsa = async (input: {
-    id: string; matterId: string; fileName: string;
-    mimeType: string; sizeBytes: number; storagePath: string;
-  }) => {
+  const registerMutation = trpc.document.register.useMutation({ onSuccess: invalidate });
+  const createFromFsa = async (input: RegisterInput) => {
     await registerMutation.mutateAsync(input);
   };
 

--- a/src/components/settings/fsa-folder-selector.tsx
+++ b/src/components/settings/fsa-folder-selector.tsx
@@ -13,6 +13,7 @@
 
 import { useEffect, useState } from "react";
 import { FolderOpen } from "lucide-react";
+import type { FsClient } from "isomorphic-git";
 
 const HANDLE_KEY = "repo-root";
 
@@ -59,8 +60,7 @@ export function FsaFolderSelector({ repoUrl, token }: { repoUrl: string; token: 
           const git = await import("isomorphic-git");
           const fsAdapter = new FsaIsoGitAdapter(h);
           await git.resolveRef({
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            fs: fsAdapter as any,
+            fs: fsAdapter as unknown as FsClient,
             dir: "/",
             ref: "HEAD",
           });

--- a/src/components/shell/demo-bootstrap.tsx
+++ b/src/components/shell/demo-bootstrap.tsx
@@ -16,6 +16,7 @@ import { DemoRuntime } from "@/lib/server/local-first/demo-runtime";
 import { createGhPagesCloneFn } from "@/lib/server/local-first/gh-pages-loader";
 import { OpfsPersistence } from "@/lib/server/local-first/persistence";
 import { DemoDataStore, type DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import type { MutationEvent } from "@/lib/server/data-store/in-memory/writable-delegate";
 import { GitBackendRuntime } from "@/lib/client/backend/git-backend-runtime";
 import { GitAuthProvider } from "@/lib/server/auth/git-auth-provider";
 import { DemoModeProvider } from "@/lib/client/demo/demo-mode-context";
@@ -71,7 +72,7 @@ function useRefBox<T>(initial: T): { current: T } {
   return box;
 }
 
-type WriteBackEvent = { entity: string; kind: string; row: Record<string, unknown>; previous?: Record<string, unknown> };
+type WriteBackEvent = MutationEvent<Record<string, unknown>>;
 
 /** Returnera en skrivbar FSA-handle om en finns (self-hosted, eller demo med
  *  vald mapp). Läses fräsch ur IndexedDB — mappen kan ha valts efter mount. */
@@ -92,8 +93,7 @@ async function resolveFsaHandle(fsaRef: { current: FileSystemDirectoryHandle | n
 /** Skriv mutationen till FSA-working-copyn + notifiera AutoSync. */
 async function writeViaFsa(handle: FileSystemDirectoryHandle, event: WriteBackEvent): Promise<void> {
   const { makeFsaWriteBack } = await import("@/lib/client/firma/fsa-write-back");
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  await makeFsaWriteBack({ handle })(event as any);
+  await makeFsaWriteBack({ handle })(event);
   if (typeof window !== "undefined") window.dispatchEvent(new CustomEvent("ava:data-changed"));
 }
 
@@ -109,8 +109,7 @@ async function writeViaSlab(
     writeFile: (p: string, d: string) => rt.writeFile(p, d),
     unlink: (p: string) => rt.deleteFile(p),
   };
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  await makeWriteBack(slabFs)(event as any);
+  await makeWriteBack(slabFs)(event);
   if (persistTimer.current) clearTimeout(persistTimer.current);
   persistTimer.current = setTimeout(() => { void rt.persist(); }, 600);
 }
@@ -385,8 +384,7 @@ export function DemoBootstrap({ children }: { children: ReactNode }) {
 
 interface TreeProps {
   firmaConfig: FirmaConfig;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  trpcClient: any;
+  trpcClient: ReturnType<typeof trpc.createClient>;
   queryClient: QueryClient;
   status: Status;
   errorMsg: string | null;

--- a/src/lib/client/fsa/fs-adapter.ts
+++ b/src/lib/client/fsa/fs-adapter.ts
@@ -19,6 +19,15 @@
  *   - Recursive mkdir hanteras manuellt eftersom FSA inte har det.
  */
 
+/**
+ * `FileSystemDirectoryHandle.entries()` är en del av File System Access API
+ * men saknas i den lib.dom-version vi kompilerar mot. Vi beskriver bara den
+ * delen vi använder (async-iteration över [namn, handle]-par).
+ */
+interface DirectoryHandleWithEntries {
+  entries(): AsyncIterableIterator<[string, FileSystemHandle]>;
+}
+
 interface IsoFsStat {
   type: "file" | "dir";
   mode: number;
@@ -108,11 +117,17 @@ export class FsaIsoGitAdapter {
     const fh = await dir.getFileHandle(filename, { create: true });
     const writable = await fh.createWritable();
     try {
-      const body = typeof data === "string"
-        ? new TextEncoder().encode(data)
-        : new Uint8Array(data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength));
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await writable.write(body as any);
+      // `FileSystemWriteChunkType` kräver en `ArrayBuffer`-backad vy
+      // (`BufferSource`), så vi kopierar in i en fräsch `Uint8Array`
+      // vars buffer garanterat är en `ArrayBuffer` (inte SharedArrayBuffer).
+      let body: Uint8Array<ArrayBuffer>;
+      if (typeof data === "string") {
+        body = new TextEncoder().encode(data);
+      } else {
+        body = new Uint8Array(data.byteLength);
+        body.set(data);
+      }
+      await writable.write(body);
     } finally {
       await writable.close();
     }
@@ -131,10 +146,10 @@ export class FsaIsoGitAdapter {
     let dir: FileSystemDirectoryHandle;
     try { dir = await resolveDir(this.root, parts); } catch { throw enoent(path); }
     const names: string[] = [];
-    // `entries()` finns på FileSystemDirectoryHandle men saknas i vissa
-    // TS-libs. Casta för iteration.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    for await (const [name] of (dir as any).entries()) names.push(name as string);
+    // `entries()` finns på FileSystemDirectoryHandle men saknas i vår
+    // lib.dom-version. Narrow till en lokal vy istället för `any`.
+    const iterable = dir as unknown as DirectoryHandleWithEntries;
+    for await (const [name] of iterable.entries()) names.push(name);
     return names;
   }
 

--- a/src/lib/client/fsa/git-ops.ts
+++ b/src/lib/client/fsa/git-ops.ts
@@ -17,7 +17,17 @@ import type { FsaIsoGitAdapter } from "./fs-adapter";
 import { sshToHttps } from "./url-rewrite";
 import { DEFAULT_CORS_PROXY } from "@/lib/client/sync/cors-proxy";
 import type * as IsomorphicGit from "isomorphic-git";
+import type { FsClient } from "isomorphic-git";
 import type * as IsomorphicGitHttp from "isomorphic-git/http/web";
+
+/**
+ * `FsaIsoGitAdapter` exponerar `promises`-API:t som isomorphic-git
+ * förväntar sig (`PromiseFsClient`). Den här hjälpfunktionen ger en
+ * typad vy så att vi slipper `fs as any` vid varje git-anrop.
+ */
+function asFsClient(fs: FsaIsoGitAdapter): FsClient {
+  return fs;
+}
 
 export interface CloneOptions {
   url: string;
@@ -69,8 +79,7 @@ async function resolveRemoteHttpsUrl(
   const git = await loadIsoGit();
   try {
     const url = await git.getConfig({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      fs: fs as any,
+      fs: asFsClient(fs),
       dir: "/",
       path: `remote.${remote}.url`,
     });
@@ -102,8 +111,7 @@ export async function cloneRepo(
   //   3. checkout ref med force (skriver över ev. half-applied files)
   try {
     await git.clone({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      fs: fs as any,
+      fs: asFsClient(fs),
       http,
       dir: "/",
       url: opts.url,
@@ -121,15 +129,13 @@ export async function cloneRepo(
   }
 
   await git.setConfig({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    fs: fs as any,
+    fs: asFsClient(fs),
     dir: "/",
     path: "remote.origin.url",
     value: opts.url,
   });
   await git.fetch({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    fs: fs as any,
+    fs: asFsClient(fs),
     http,
     dir: "/",
     url: opts.url,
@@ -140,8 +146,7 @@ export async function cloneRepo(
     onAuth,
   });
   await git.checkout({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    fs: fs as any,
+    fs: asFsClient(fs),
     dir: "/",
     ref,
     force: true,
@@ -154,8 +159,7 @@ export async function statusMatrix(fs: FsaIsoGitAdapter): Promise<GitStatusEntry
   // statusMatrix returnerar tupler [filepath, HEAD, WORKDIR, STAGE]
   // där 0=missing, 1=existerar, 2=ändrad, 3=ny stage.
   const matrix = await git.statusMatrix({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    fs: fs as any,
+    fs: asFsClient(fs),
     dir: "/",
   });
   const entries: GitStatusEntry[] = [];
@@ -193,22 +197,19 @@ export async function stageAllAndCommit(
 ): Promise<string> {
   const git = await loadIsoGit();
   const matrix = await git.statusMatrix({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    fs: fs as any,
+    fs: asFsClient(fs),
     dir: "/",
   });
   for (const [filepath, , workdir] of matrix) {
     if (workdir === 0) {
       await git.remove({
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        fs: fs as any,
+        fs: asFsClient(fs),
         dir: "/",
         filepath,
       });
     } else {
       await git.add({
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        fs: fs as any,
+        fs: asFsClient(fs),
         dir: "/",
         filepath,
       });
@@ -228,8 +229,7 @@ export async function stageAllAndCommit(
     });
   }
   const oid = await git.commit({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    fs: fs as any,
+    fs: asFsClient(fs),
     dir: "/",
     message: args.message,
     author: { name: args.authorName, email: args.authorEmail },
@@ -248,8 +248,7 @@ export async function pushBranch(
   // hanterar inte SSH i browser).
   const url = opts.url ?? (await resolveRemoteHttpsUrl(fs, remoteName)) ?? undefined;
   await git.push({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    fs: fs as any,
+    fs: asFsClient(fs),
     http: httpMod.default ?? httpMod,
     dir: "/",
     remote: remoteName,
@@ -267,15 +266,13 @@ export async function pullBranch(
   const git = await loadIsoGit();
   const httpMod = await loadHttp();
   const before = await git.resolveRef({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    fs: fs as any,
+    fs: asFsClient(fs),
     dir: "/",
     ref: "HEAD",
   });
   const url = opts.url ?? (await resolveRemoteHttpsUrl(fs, "origin")) ?? undefined;
   await git.pull({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    fs: fs as any,
+    fs: asFsClient(fs),
     http: httpMod.default ?? httpMod,
     dir: "/",
     url,
@@ -286,8 +283,7 @@ export async function pullBranch(
     onAuth: () => ({ username: opts.username || "x-access-token", password: opts.token }),
   });
   const after = await git.resolveRef({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    fs: fs as any,
+    fs: asFsClient(fs),
     dir: "/",
     ref: "HEAD",
   });

--- a/src/lib/client/jobs/extract-text.ts
+++ b/src/lib/client/jobs/extract-text.ts
@@ -67,9 +67,10 @@ async function toBytes(input: Uint8Array | ArrayBuffer | Blob): Promise<Uint8Arr
 
 async function extractFromPdf(bytes: Uint8Array): Promise<string> {
   try {
-    // Använd legacy-build för max-kompabilitet (Node test-env + jsdom)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const pdfjs = await import("pdfjs-dist/legacy/build/pdf.mjs") as any;
+    // Använd legacy-build för max-kompabilitet (Node test-env + jsdom).
+    // Legacy-buildens pdf.d.mts re-exporterar pdfjs-dists egna typer, så
+    // importen är fullt typad utan cast.
+    const pdfjs = await import("pdfjs-dist/legacy/build/pdf.mjs");
     // pdfjs i browser kräver workerSrc; vi använder samma legacy-fil
     // som worker för enkelhet (slower men funkar utan extra-konfig)
     if (pdfjs.GlobalWorkerOptions && !pdfjs.GlobalWorkerOptions.workerSrc) {
@@ -92,8 +93,9 @@ async function extractFromPdf(bytes: Uint8Array): Promise<string> {
     for (let i = 1; i <= doc.numPages; i++) {
       const page = await doc.getPage(i);
       const content = await page.getTextContent();
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const pageText = (content.items as any[])
+      // content.items: Array<TextItem | TextMarkedContent>; "str" finns bara
+      // på TextItem, så `in`-narrowing väljer rätt variant.
+      const pageText = content.items
         .map((item) => ("str" in item ? item.str : ""))
         .join(" ");
       parts.push(pageText);

--- a/src/lib/client/keys/sign-commit.ts
+++ b/src/lib/client/keys/sign-commit.ts
@@ -15,7 +15,20 @@
  */
 
 import type { FsaIsoGitAdapter } from "@/lib/client/fsa/fs-adapter";
+import type { FsClient } from "isomorphic-git";
+import type * as IsomorphicGit from "isomorphic-git";
 import { sshsigSign } from "./sshsig";
+
+/** Det dynamiskt importerade isomorphic-git-modulnamespacet. */
+type IsoGit = typeof IsomorphicGit;
+
+/**
+ * `FsaIsoGitAdapter` implementerar `PromiseFsClient` (via `promises`),
+ * så den kan användas direkt som isomorphic-git:s `FsClient`.
+ */
+function asFsClient(fs: FsaIsoGitAdapter): FsClient {
+  return fs;
+}
 
 export interface SignCommitArgs {
   fs: FsaIsoGitAdapter;
@@ -34,8 +47,7 @@ export async function signGitCommit(args: SignCommitArgs): Promise<string> {
   const git = await import("isomorphic-git");
 
   // 1. Skriv aktuellt index till tree-objekt
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const fs = args.fs as any;
+  const fs = asFsClient(args.fs);
   const treeOid = await writeTreeFromIndex(git, fs, dir);
 
   // 2. Hämta nuvarande HEAD som parent (om finns)
@@ -95,8 +107,7 @@ export async function signGitCommit(args: SignCommitArgs): Promise<string> {
     fs, dir,
     type: "commit",
     // isomorphic-git accepterar string för commit-objekt
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    object: signedText as any,
+    object: signedText,
     format: "content",
   });
 
@@ -139,14 +150,18 @@ function buildCommitText(a: CommitTextArgs): string {
  * fall back till `git.commit({dryRun:true})` för att få tree-oid:n.
  */
 async function writeTreeFromIndex(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  git: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fs: any,
+  git: IsoGit,
+  fs: FsClient,
   dir: string,
 ): Promise<string> {
-  if (typeof git.writeTree === "function") {
-    return git.writeTree({ fs, dir }) as Promise<string>;
+  // `writeTree` anropas här utan `tree`-argument: vi förlitar oss på att
+  // funktionen (om den finns) skriver tree:t från index. Det matchar inte
+  // den publika typsignaturen, så vi feature-detekterar via en smal vy.
+  const writeTreeFromIndexFn = (
+    git as unknown as { writeTree?: (args: { fs: FsClient; dir: string }) => Promise<string> }
+  ).writeTree;
+  if (typeof writeTreeFromIndexFn === "function") {
+    return writeTreeFromIndexFn({ fs, dir });
   }
   // Fallback: kör en dry-run-commit för att få tree-oid:n
   const fakeCommit = await git.commit({
@@ -157,6 +172,8 @@ async function writeTreeFromIndex(
   });
   // Sedan läs tree:n från det skapade commit-objektet
   const obj = await git.readObject({ fs, dir, oid: fakeCommit });
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (obj.object as any).tree;
+  if (obj.format === "parsed" && obj.type === "commit") {
+    return obj.object.tree;
+  }
+  throw new Error("Oväntat objektformat vid läsning av dry-run-commit");
 }

--- a/src/lib/server/routers/todo.ts
+++ b/src/lib/server/routers/todo.ts
@@ -13,6 +13,8 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, orgProcedure } from "../trpc";
+import type { Task, CalendarEvent } from "@/lib/shared/schemas";
+import type { Joined } from "../data-store/IDataStore";
 
 export interface TodoItem {
   id: string;
@@ -72,15 +74,13 @@ export const todoRouter = router({
       // och behöll förra resultatet → tom dashboard).
       const toDate = (v: unknown): Date => v instanceof Date ? v : new Date(v as string);
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const taskItems: TodoItem[] = (tasks as any[]).map((t) => ({
+      const taskItems: TodoItem[] = tasks.map((t: Joined<Task>) => ({
         id: t.id, source: "task", title: t.title, description: t.description ?? null,
         at: toDate(t.dueAt), endAt: null, allDay: false,
         status: t.status, priority: t.priority, kind: null, location: null,
         matter: t.matter ?? null, userId: t.userId,
       }));
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const eventItems: TodoItem[] = (events as any[]).map((e) => ({
+      const eventItems: TodoItem[] = events.map((e: Joined<CalendarEvent>) => ({
         id: e.id, source: "event", title: e.title, description: e.description ?? null,
         at: toDate(e.startAt), endAt: e.endAt ? toDate(e.endAt) : null, allDay: e.allDay ?? false,
         status: null, priority: null, kind: e.kind, location: e.location ?? null,


### PR DESCRIPTION
Part of #47 (fas 1 av 2 — se nedan).

Avtypar de ~30 perifera `any`:en i 8 oberoende fil-kluster (gjort parallellt via en multi-agent-workflow, sen helhets-verifierat). Inga runtime-ändringar, inga `eslint-disable ... no-explicit-any` kvar i dessa filer.

## Kluster
- **iso-git-interop** (`git-ops.ts` 14×, `sign-commit.ts` 5×): `FsaIsoGitAdapter` är redan strukturellt en `PromiseFsClient` (via `get promises()`), så `fs as any`-casten var onödiga — typade som `FsClient`. `fs-adapter.ts`: lib.dom-typer + `unknown`+narrowing för FSA `entries()`-luckan.
- **pdfjs** (`extract-text.ts`): bibliotekets egna typer (`pdf.d.mts`) räcker; `"str" in item` narrowar `TextItem`.
- **tRPC-shims** (`verdict-dialog`, `kostnadsrakning-modal`, `billing-panel`, `document-browser`): `inferRouterInputs/Outputs<AppRouter>` istället för hand-rullade `(i: any)`-shims.
- **UI/router** (`day-view`, `fsa-folder-selector`, `demo-bootstrap`, `todo`): precisa typer / `unknown`+narrowing.

## Effekt
- `no-explicit-any`-disables i `src/`: **41 → 7**.
- Gröna lokalt: typecheck 0, lint 0 (45/45), knip 0 (@error), test:fast 2184, build:demo OK.

## Återstår (fas 2, separat PR)
De kvarvarande 7 disablesen = datalagrets generiska `Delegate`-motor (`args: any` för where/data/include) + `user.ts`-selects + `web-llm-extractor.ts`. Det är #47-kärnan ("massive rewrite") som jag designar separat.