### PR TITLE
Eliminera sista any + ratcha no-explicit-any till error (#47, fas 2)

### DIFF
--- a/src/lib/client/llm/web-llm-extractor.ts
+++ b/src/lib/client/llm/web-llm-extractor.ts
@@ -21,6 +21,7 @@
  *     separat för testbarhet utan att behöva instansiera WebGPU.
  */
 
+import type { MLCEngine } from "@mlc-ai/web-llm";
 import type { ExtractionResult, ExtractionSchema, FieldType, ILlmExtractor } from "@/lib/server/llm/llm-extractor";
 import type { LlmModelId } from "./llm-config";
 
@@ -36,11 +37,8 @@ export interface WebLlmExtractorOpts {
   onProgress?: (p: ProgressEvent) => void;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type MLCEngineLike = any;
-
 export class WebLlmExtractor implements ILlmExtractor {
-  private engine: MLCEngineLike | null = null;
+  private engine: MLCEngine | null = null;
   private ready = false;
   private warmupPromise: Promise<void> | null = null;
 

--- a/src/lib/server/data-store/IDataStore.ts
+++ b/src/lib/server/data-store/IDataStore.ts
@@ -51,11 +51,13 @@ export interface ClaimOpts {
 //   type MatterRow = z.infer<typeof matterSchema>
 //   export type MatterDelegate = Delegate<MatterRow>
 
-// `any` är medvetet här under transitionsperioden — Prisma:s genererade
-// delegate-typer hade exakta `where`/`select`/`include`-typer som vi inte
-// kan återskapa utan en massiv router-omskrivning. Routrarna har egna
-// `as`-casts där de behöver striktare typer; för övriga callers funkar
-// `any` likt det gjorde med Prisma's flytande generics.
+// ENDA kvarvarande `no-explicit-any`-undantaget i src efter #47. `args: any`
+// på delegate-metoderna är den flytande Prisma-stil-query-ytan (where/select/
+// include) som inte går att typa exakt utan en massiv router-omskrivning —
+// det egna query-typsystemet spåras separat. `no-explicit-any` är `error`
+// överallt annars (ratchet); detta block är det medvetna, dokumenterade
+// undantaget. Returtyperna är däremot typade (`Joined<Row>`, #39) så branded
+// id:n flödar ut även om query-INPUT förblir `any` här.
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 /**
@@ -224,10 +226,10 @@ export interface IDataStore {
    * Escape-hatch för komplexa frågor. Throwing-proxy i demo-store —
    * existerande callers (t.ex. fuzzy-name-search i conflict.ts) får
    * "ej implementerat"-fel om de anropas i ren git-modell. Refaktorera
-   * dem ett-i-taget till in-memory-implementations.
+   * dem ett-i-taget till in-memory-implementations. `unknown` (inte `any`):
+   * callers måste narrowa/casta medvetet — ingen tyst spridning.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  readonly raw: any;
+  readonly raw: unknown;
 
   /**
    * Kör `fn` i en transaktion. In-memory snapshot/rollback — alla

--- a/src/lib/server/routers/user.ts
+++ b/src/lib/server/routers/user.ts
@@ -65,8 +65,7 @@ export const userRouter = router({
     try {
       const u = await ctx.dataStore.users.findUniqueOrThrow({
         where: { id: ctx.user.id, organizationId: ctx.user.organizationId },
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        select: USER_PROFILE_SELECT as any,
+        select: USER_PROFILE_SELECT,
       }) as unknown as UserProfile;
       return { ...u, publicKeys: Array.isArray(u.publicKeys) ? u.publicKeys : [] };
     } catch (_e) {
@@ -137,8 +136,7 @@ export const userRouter = router({
           passwordHash,
           organizationId: ctx.user.organizationId,
           publicKeys: [],
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } as any,
+        },
       });
     }),
 
@@ -185,8 +183,7 @@ export const userRouter = router({
     .mutation(async ({ ctx, input }) => {
       const u = await ctx.dataStore.users.findUniqueOrThrow({
         where: { id: ctx.user.id, organizationId: ctx.user.organizationId },
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        select: { publicKeys: true } as any,
+        select: { publicKeys: true },
       }) as unknown as { publicKeys?: unknown[] };
       const keys = Array.isArray(u.publicKeys) ? u.publicKeys : [];
       if (keys.some((k) => (k as { fingerprint: string }).fingerprint === input.fingerprint)) {
@@ -203,8 +200,7 @@ export const userRouter = router({
     .mutation(async ({ ctx, input }) => {
       const u = await ctx.dataStore.users.findUniqueOrThrow({
         where: { id: ctx.user.id, organizationId: ctx.user.organizationId },
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        select: { publicKeys: true } as any,
+        select: { publicKeys: true },
       }) as unknown as { publicKeys?: unknown[] };
       const keys = (Array.isArray(u.publicKeys) ? u.publicKeys : []).filter(
         (k) => (k as { fingerprint: string }).fingerprint !== input.fingerprint,

--- a/tooling/config/eslint.config.mjs
+++ b/tooling/config/eslint.config.mjs
@@ -46,6 +46,10 @@ const eslintConfig = defineConfig([
       // → backar mekaniskt upp dependency-cruiser-regeln "UI importerar server
       // type-only" på källnivå (#9).
       "@typescript-eslint/consistent-type-imports": "error",
+      // Ratchet (#47): all `any` eliminerad i src utom datalagrets flytande
+      // query-yta (IDataStore.ts, block-disabled + dokumenterad). Skärper från
+      // next/typescript:s `warn` → `error` så NYA `any` blockerar CI.
+      "@typescript-eslint/no-explicit-any": "error",
       // Promise-säkerhet: oavsiktligt obevakade promises, async-callbacks i
       // synkron/void-kontext, och `await` på icke-thenables är vanliga
       // buggkällor som bara typinfo kan upptäcka (#9).


### PR DESCRIPTION
Closes #47.

Fas 2 (efter periferin i #48). Tar de sista `any`:en och slår på ratchet:en.

## Ändringar
- **`user.ts`**: 4 redundanta `as any` borttagna (delegate-params är redan `any`, så casten gjorde inget).
- **`web-llm-extractor.ts`**: `engine` typad som `MLCEngine` (type-only-import från `@mlc-ai/web-llm`, erased vid runtime → SSR-säker) i st f `type MLCEngineLike = any`.
- **`IDataStore.ts`**: `raw: any` → `unknown` (inga callers; tvingar medveten cast).
- **eslint**: `@typescript-eslint/no-explicit-any` `warn` → **`error`** — NYA `any` blockerar nu CI.

## Slutläge
- `no-explicit-any`-disables i `src/`: **7 → 1**.
- Det enda kvarvarande `any`:t är datalagrets flytande Prisma-stil-query-yta (`args: any` i `IDataStore.ts`, where/select/include) — block-disabled + dokumenterad, omöjlig att typa exakt utan ett eget query-typsystem. Returtyperna är typade (#39) så branded id:n flödar ut ändå.
- Uppfyller #47:s klar-kriterium ("0 disables — *eller varje kvarvarande enskilt motiverat*") + ratchet till `error`.

## Hela #47 (fas 1 + 2)
`any`-disables i src: **41 → 1**. Allt utom den dokumenterade query-motorn borta, och ratchet:en hindrar regression.

Gröna lokalt: typecheck 0, lint 0 (45/45), knip 0, test:fast 2184, build:demo OK.