### PR TITLE
Typa create/update-args (Partial<Row>) → write-literals typkollas (#24)

### DIFF
--- a/src/app/invoices/[id]/_client.tsx
+++ b/src/app/invoices/[id]/_client.tsx
@@ -64,8 +64,9 @@ export default function InvoiceDetailClient({ id: paramId }: { id: string }) {
   const inv = invoice.data;
 
   const paidSum = inv.payments.reduce((s: number, p: { amount: number }) => s + p.amount, 0);
-  const accontoDeductionTotal = inv.accontoDeductions.reduce(
-    (s: number, d: { accontoInvoice: { amount: number } }) => s + d.accontoInvoice.amount,
+  const accontoDeductions = accontoDeductionsOf(inv);
+  const accontoDeductionTotal = accontoDeductions.reduce(
+    (s: number, d: AccontoDeductionRow) => s + d.accontoInvoice.amount,
     0,
   );
   const netAmount = inv.amount - accontoDeductionTotal;
@@ -104,8 +105,8 @@ export default function InvoiceDetailClient({ id: paramId }: { id: string }) {
         <PaymentPlanCard plan={inv.paymentPlan} onCancel={() => cancelPlan.mutate({ planId: inv.paymentPlan!.id })} />
       )}
 
-      {inv.invoiceType === "FINAL" && inv.accontoDeductions.length > 0 && (
-        <AccontoDeductions deductions={inv.accontoDeductions} />
+      {inv.invoiceType === "FINAL" && accontoDeductions.length > 0 && (
+        <AccontoDeductions deductions={accontoDeductions} />
       )}
 
       <PaymentsTable payments={inv.payments} paidSum={paidSum} />
@@ -146,6 +147,21 @@ export default function InvoiceDetailClient({ id: paramId }: { id: string }) {
 }
 
 type Inv = NonNullable<inferRouterOutputs<AppRouter>["invoice"]["getById"]>;
+
+// ── Boundary-vyer för join-fält (router-read returnerar `unknown`/`{}` på
+//    relationer; vi narrowar dem till de former UI:t faktiskt läser). ──
+type AccontoDeductionRow = {
+  id: string;
+  accontoInvoice: { id: string; invoiceDate: string | Date; amount: number };
+};
+type CreditRefView = { id: string; invoiceDate: string | Date; amount: number } | null;
+
+const accontoDeductionsOf = (inv: Inv): AccontoDeductionRow[] =>
+  (inv.accontoDeductions ?? []) as unknown as AccontoDeductionRow[];
+const creditNoteOf = (inv: Inv): CreditRefView =>
+  (inv.creditNote ?? null) as unknown as CreditRefView;
+const creditedInvoiceOf = (inv: Inv): CreditRefView =>
+  (inv.creditedInvoice ?? null) as unknown as CreditRefView;
 
 function InvoiceHeader({ inv }: { inv: Inv }) {
   const heading = inv.invoiceType === "ACCONTO" ? "Acconto-faktura"
@@ -191,28 +207,30 @@ function SummaryGrid({
 }
 
 function CreditBanners({ inv }: { inv: Inv }) {
+  const creditNote = creditNoteOf(inv);
+  const creditedInvoice = creditedInvoiceOf(inv);
   return (
     <>
-      {inv.creditNote && (
+      {creditNote && (
         <div className="bg-orange-50 border border-orange-200 rounded-lg p-4 text-sm">
           <p className="font-medium text-orange-900">Denna faktura är krediterad.</p>
           <p className="text-orange-800 mt-1">
-            <EntityLink route="invoices" id={inv.creditNote.id} className="underline">
-              Kreditfaktura {new Date(inv.creditNote.invoiceDate).toLocaleDateString("sv-SE")}
+            <EntityLink route="invoices" id={creditNote.id} className="underline">
+              Kreditfaktura {new Date(creditNote.invoiceDate).toLocaleDateString("sv-SE")}
             </EntityLink>
-            {" "}— belopp {formatCurrency(inv.creditNote.amount)}
+            {" "}— belopp {formatCurrency(creditNote.amount)}
           </p>
         </div>
       )}
-      {inv.invoiceType === "CREDIT" && inv.creditedInvoice && (
+      {inv.invoiceType === "CREDIT" && creditedInvoice && (
         <div className="bg-orange-50 border border-orange-200 rounded-lg p-4 text-sm">
           <p className="font-medium text-orange-900">Detta är en kreditfaktura.</p>
           <p className="text-orange-800 mt-1">
             Krediterar{" "}
-            <EntityLink route="invoices" id={inv.creditedInvoice.id} className="underline">
-              faktura från {new Date(inv.creditedInvoice.invoiceDate).toLocaleDateString("sv-SE")}
+            <EntityLink route="invoices" id={creditedInvoice.id} className="underline">
+              faktura från {new Date(creditedInvoice.invoiceDate).toLocaleDateString("sv-SE")}
             </EntityLink>
-            {" "}(ursprungligt belopp {formatCurrency(inv.creditedInvoice.amount)})
+            {" "}(ursprungligt belopp {formatCurrency(creditedInvoice.amount)})
           </p>
         </div>
       )}
@@ -369,13 +387,13 @@ function SpecificationCard({ timeEntries, expenses }: { timeEntries: SpecTimeRow
   );
 }
 
-function AccontoDeductions({ deductions }: { deductions: Inv["accontoDeductions"] }) {
+function AccontoDeductions({ deductions }: { deductions: AccontoDeductionRow[] }) {
   return (
     <div className="bg-white rounded-lg border border-gray-200 p-6">
       <h2 className="font-semibold mb-3">Accontoavdrag</h2>
       <table className="min-w-full text-sm">
         <tbody className="divide-y divide-gray-100">
-          {deductions.map((d: Inv["accontoDeductions"][number]) => (
+          {deductions.map((d: AccontoDeductionRow) => (
             <tr key={d.id}>
               <td className="py-2">
                 <EntityLink route="invoices" id={d.accontoInvoice.id} className="text-blue-600 hover:underline">

--- a/src/app/matters/[id]/_generate-modal.tsx
+++ b/src/app/matters/[id]/_generate-modal.tsx
@@ -112,7 +112,11 @@ export function GenerateModal({ matterId, contacts, onClose }: Props) {
           <TemplateSelector
             id={generateTemplateFieldId}
             isLoading={templates.isLoading}
-            templates={templates.data}
+            templates={templates.data?.map((t) => ({
+              id: t.id,
+              name: String(t.name),
+              category: (t.category as string | null) ?? null,
+            }))}
             value={generateTemplateId}
             onChange={setGenerateTemplateId}
           />

--- a/src/components/documents/document-browser.tsx
+++ b/src/components/documents/document-browser.tsx
@@ -50,8 +50,14 @@ export function DocumentBrowser({ matterId }: DocumentBrowserProps) {
   const utils = trpc.useUtils();
 
   const tree = trpc.document.tree.useQuery({ matterId });
-  const folders = useMemo<FolderRecord[]>(() => tree.data?.folders ?? [], [tree.data]);
-  const documents = useMemo<DocumentRecord[]>(() => tree.data?.documents ?? [], [tree.data]);
+  const folders = useMemo<FolderRecord[]>(
+    () => (tree.data?.folders ?? []) as unknown as FolderRecord[],
+    [tree.data],
+  );
+  const documents = useMemo<DocumentRecord[]>(
+    () => (tree.data?.documents ?? []) as unknown as DocumentRecord[],
+    [tree.data],
+  );
 
   const mutations = useDocumentMutations({
     matterId,

--- a/src/components/matter/invoices-section.tsx
+++ b/src/components/matter/invoices-section.tsx
@@ -126,9 +126,10 @@ export function InvoicesSection({ matterId }: { matterId: string }) {
     timeEntries: timeEntries.data?.entries.filter((t) => !t.invoiceId) ?? [],
     expenses: expenses.data?.expenses.filter((e) => !e.invoiceId) ?? [],
   };
-  const availableAccontos = (invoices.data ?? []).filter(
-    (i) => i.invoiceType === "ACCONTO" && i.deductedOnFinals?.length === 0 && i.status !== "CANCELLED",
-  );
+  const availableAccontos = (invoices.data ?? []).filter((i) => {
+    const deductedOnFinals = i.deductedOnFinals as unknown as { id: string }[] | undefined;
+    return i.invoiceType === "ACCONTO" && deductedOnFinals?.length === 0 && i.status !== "CANCELLED";
+  });
 
   return (
     <div className="bg-white rounded-lg border border-gray-200">

--- a/src/lib/server/data-store/IDataStore.ts
+++ b/src/lib/server/data-store/IDataStore.ts
@@ -17,7 +17,7 @@ import type {
   Contact, Matter, MatterContact, Document, DocumentFolder,
   DocumentTemplate, DocumentAnalysisSuggestion, MatterEventSuggestion,
   Invoice, TimeEntry, Expense, User, Organization, Office, ConflictCheck,
-  Payment, PaymentPlan, AccontoDeduction,
+  Payment, PaymentPlan, AccontoDeduction, BillingRun,
   CalendarEvent, Task,
 } from "@/lib/shared/schemas";
 
@@ -92,10 +92,13 @@ export interface Delegate<Row = any> {
   findFirst(args?: any): Promise<Joined<Row> | null>;
   findFirstOrThrow(args?: any): Promise<Joined<Row>>;
   findMany(args?: any): Promise<Joined<Row>[]>;
-  create(args: any): Promise<Joined<Row>>;
-  update(args: any): Promise<Joined<Row>>;
-  updateMany(args: any): Promise<{ count: number }>;
-  upsert(args: any): Promise<Joined<Row>>;
+  // Skriv-args: `data`/`create`/`update` typas mot `Partial<Row>` så
+  // write-literals (inkl. enum-fält) typkollas (#24). `where`/`include`/`select`
+  // hålls lösa (flytande query-yta).
+  create(args: { data: Partial<Row>; include?: unknown; select?: unknown }): Promise<Joined<Row>>;
+  update(args: { where: unknown; data: Partial<Row>; include?: unknown; select?: unknown }): Promise<Joined<Row>>;
+  updateMany(args: { where?: unknown; data: Partial<Row> }): Promise<{ count: number }>;
+  upsert(args: { where: unknown; create: Partial<Row>; update: Partial<Row> }): Promise<Joined<Row>>;
   delete(args: any): Promise<Joined<Row>>;
   deleteMany(args?: any): Promise<{ count: number }>;
   count(args?: any): Promise<number>;
@@ -111,25 +114,25 @@ export interface Delegate<Row = any> {
 // nedan så enskilda callers kan välja striktare typer när de vill.
 export type MatterDelegate = Delegate<Matter>;
 export type ContactDelegate = Delegate<Contact>;
-export type MatterContactDelegate = Delegate;
-export type DocumentDelegate = Delegate;
-export type DocumentFolderDelegate = Delegate;
-export type DocumentTemplateDelegate = Delegate;
-export type DocumentAnalysisSuggestionDelegate = Delegate;
-export type MatterEventSuggestionDelegate = Delegate;
-export type InvoiceDelegate = Delegate;
-export type TimeEntryDelegate = Delegate;
-export type ExpenseDelegate = Delegate;
-export type UserDelegate = Delegate;
-export type OrganizationDelegate = Delegate;
-export type OfficeDelegate = Delegate;
-export type ConflictCheckDelegate = Delegate;
-export type PaymentDelegate = Delegate;
-export type PaymentPlanDelegate = Delegate;
-export type AccontoDeductionDelegate = Delegate;
-export type BillingRunDelegate = Delegate;
-export type CalendarEventDelegate = Delegate;
-export type TaskDelegate = Delegate;
+export type MatterContactDelegate = Delegate<MatterContact>;
+export type DocumentDelegate = Delegate<Document>;
+export type DocumentFolderDelegate = Delegate<DocumentFolder>;
+export type DocumentTemplateDelegate = Delegate<DocumentTemplate>;
+export type DocumentAnalysisSuggestionDelegate = Delegate<DocumentAnalysisSuggestion>;
+export type MatterEventSuggestionDelegate = Delegate<MatterEventSuggestion>;
+export type InvoiceDelegate = Delegate<Invoice>;
+export type TimeEntryDelegate = Delegate<TimeEntry>;
+export type ExpenseDelegate = Delegate<Expense>;
+export type UserDelegate = Delegate<User>;
+export type OrganizationDelegate = Delegate<Organization>;
+export type OfficeDelegate = Delegate<Office>;
+export type ConflictCheckDelegate = Delegate<ConflictCheck>;
+export type PaymentDelegate = Delegate<Payment>;
+export type PaymentPlanDelegate = Delegate<PaymentPlan>;
+export type AccontoDeductionDelegate = Delegate<AccontoDeduction>;
+export type BillingRunDelegate = Delegate<BillingRun>;
+export type CalendarEventDelegate = Delegate<CalendarEvent>;
+export type TaskDelegate = Delegate<Task>;
 
 // Opt-in: enskilda callers som vill ha striktare row-typ kan importera
 // dessa istället. T.ex. `const matters = ctx.dataStore.matters as MattersStrict`.

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -19,6 +19,12 @@ import { TRPCError } from "@trpc/server";
 import { router, orgProcedure } from "../trpc";
 import type { DataStoreTx } from "../data-store/IDataStore";
 import { billingRunRecipientSchema, type ExpenseKind } from "@/lib/shared/schemas/enums";
+import {
+  matterIdSchema,
+  billingRunIdSchema,
+  asId,
+  type BillingRunId,
+} from "@/lib/shared/schemas/ids";
 import { emit } from "../events/emit";
 
 interface UnfrozenWork {
@@ -46,7 +52,7 @@ function workValueOre(work: UnfrozenWork): number {
   return time + exp;
 }
 
-async function freezeWork(tx: DataStoreTx, matterId: string, billingRunId: string): Promise<void> {
+async function freezeWork(tx: DataStoreTx, matterId: string, billingRunId: BillingRunId): Promise<void> {
   const now = new Date();
   await tx.timeEntries.updateMany({
     where: { matterId, frozenByBillingRunId: null },
@@ -91,7 +97,7 @@ export const billingRunRouter = router({
 
   createAcconto: orgProcedure
     .input(z.object({
-      matterId: z.string(),
+      matterId: matterIdSchema,
       recipient: billingRunRecipientSchema.default("KLIENT"),
       clientShareBips: z.number().int().min(0).max(10000),
       amountOre: z.number().int().nonnegative(),
@@ -126,9 +132,9 @@ export const billingRunRouter = router({
 
   createFinal: orgProcedure
     .input(z.object({
-      matterId: z.string(),
+      matterId: matterIdSchema,
       recipient: billingRunRecipientSchema,
-      deductedBillingRunIds: z.array(z.string()).default([]),
+      deductedBillingRunIds: z.array(billingRunIdSchema).default([]),
       notes: z.string().nullish(),
     }))
     .mutation(async ({ ctx, input }) => {
@@ -161,7 +167,7 @@ export const billingRunRouter = router({
     }),
 
   createKostnadsrakning: orgProcedure
-    .input(z.object({ matterId: z.string(), notes: z.string().nullish() }))
+    .input(z.object({ matterId: matterIdSchema, notes: z.string().nullish() }))
     .mutation(async ({ ctx, input }) => {
       return ctx.dataStore.transaction(async (tx) => {
         await assertMatterInOrg(tx, input.matterId, ctx.orgId);
@@ -197,7 +203,7 @@ export const billingRunRouter = router({
         if (input.prutningOre < 0) {
           await tx.expenses.create({
             data: {
-              matterId: run.matterId, userId: ctx.user.id, date: new Date(),
+              matterId: run.matterId, userId: asId<"UserId">(ctx.user.id), date: new Date(),
               amount: input.prutningOre, description: "Prutning enligt dom",
               billable: true, vatRate: 0, vatIncluded: false, kind: "PRUTNING",
             },

--- a/src/lib/server/routers/calendar.ts
+++ b/src/lib/server/routers/calendar.ts
@@ -15,6 +15,13 @@
 import { z } from "zod";
 import { router, protectedProcedure } from "../trpc";
 import { calendarEventKindSchema, calendarEventVisibilitySchema } from "@/lib/shared/schemas";
+import {
+  asId,
+  calendarEventIdSchema,
+  matterIdSchema,
+  userIdSchema,
+  contactIdSchema,
+} from "@/lib/shared/schemas/ids";
 
 const createInput = z.object({
   kind: calendarEventKindSchema.default("appointment"),
@@ -24,16 +31,16 @@ const createInput = z.object({
   startAt: z.date(),
   endAt: z.date().nullish(),
   allDay: z.boolean().default(false),
-  matterId: z.string().nullish(),
+  matterId: matterIdSchema.nullish(),
   visibility: calendarEventVisibilitySchema.default("normal"),
   mirrorToOutlook: z.boolean().default(false),
   /** Inbjudna kollegor (interna users). */
-  inviteeUserIds: z.array(z.string()).optional(),
+  inviteeUserIds: z.array(userIdSchema).optional(),
   /** Inbjudna externa kontakter (klient, motpart, vittne osv.). */
-  inviteeContactIds: z.array(z.string()).optional(),
+  inviteeContactIds: z.array(contactIdSchema).optional(),
   // Valfria setup-fält (demo-generator/fixtures, ADR 0003).
-  id: z.string().optional(),
-  userId: z.string().optional(),
+  id: calendarEventIdSchema.optional(),
+  userId: userIdSchema.optional(),
   createdAt: z.date().nullish(),
 });
 
@@ -41,7 +48,7 @@ const createInput = z.object({
 // fält som användaren inte angav, vilket triggar fel mirror-state-detektering
 // i computeMirrorPatch (allt ser ut som "explicit satt").
 const updateInput = z.object({
-  id: z.string(),
+  id: calendarEventIdSchema,
   kind: calendarEventKindSchema.optional(),
   title: z.string().min(1).optional(),
   description: z.string().nullish(),
@@ -49,11 +56,11 @@ const updateInput = z.object({
   startAt: z.date().optional(),
   endAt: z.date().nullish(),
   allDay: z.boolean().optional(),
-  matterId: z.string().nullish(),
+  matterId: matterIdSchema.nullish(),
   visibility: calendarEventVisibilitySchema.optional(),
   mirrorToOutlook: z.boolean().optional(),
-  inviteeUserIds: z.array(z.string()).optional(),
-  inviteeContactIds: z.array(z.string()).optional(),
+  inviteeUserIds: z.array(userIdSchema).optional(),
+  inviteeContactIds: z.array(contactIdSchema).optional(),
 });
 
 /**
@@ -162,8 +169,8 @@ export const calendarRouter = router({
       return ctx.dataStore.calendarEvents.create({
         data: {
           ...input,
-          userId: input.userId ?? ctx.user.id,
-          organizationId: ctx.user.organizationId,
+          userId: input.userId ?? asId<"UserId">(ctx.user.id),
+          organizationId: asId<"OrganizationId">(ctx.user.organizationId),
           mirrorStatus: input.mirrorToOutlook ? "pending" : null,
           createdAt: input.createdAt ?? undefined,
         },

--- a/src/lib/server/routers/conflict.ts
+++ b/src/lib/server/routers/conflict.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { router, protectedProcedure } from "../trpc";
 import type { IDataStore } from "../data-store/IDataStore";
 import { similarity } from "@/lib/shared/fuzzy-similarity";
+import { asId } from "@/lib/shared/schemas/ids";
 
 type ConflictCtx = { dataStore: IDataStore; user: { id: string; organizationId: string } };
 
@@ -106,8 +107,8 @@ export const conflictRouter = router({
         data: {
           searchTerm: input.searchTerm,
           searchType: input.searchType,
-          results: results as unknown as object,
-          checkedById: ctx.user.id,
+          results: results as unknown as unknown[],
+          checkedById: asId<"UserId">(ctx.user.id),
         },
       });
 

--- a/src/lib/server/routers/contact.ts
+++ b/src/lib/server/routers/contact.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { router, orgProcedure, requireOrgOwned } from "../trpc";
 import { contactTypeSchema } from "@/lib/shared/schemas/enums";
+import { contactIdSchema, asId } from "@/lib/shared/schemas/ids";
 import { emit } from "../events/emit";
 
 export const contactRouter = router({
@@ -72,7 +73,7 @@ export const contactRouter = router({
     .input(
       z.object({
         /** Valfritt klient-genererat id (ADR 0003) — annars genererar store:n. */
-        id: z.string().optional(),
+        id: contactIdSchema.optional(),
         name: z.string().min(1),
         contactType: contactTypeSchema,
         personalNumber: z.string().optional(),
@@ -81,7 +82,7 @@ export const contactRouter = router({
         phone: z.string().optional(),
         address: z.string().optional(),
         notes: z.string().optional(),
-        parentId: z.string().optional(),
+        parentId: contactIdSchema.optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -89,7 +90,7 @@ export const contactRouter = router({
         data: {
           ...input,
           email: input.email || null,
-          organizationId: ctx.orgId,
+          organizationId: asId<"OrganizationId">(ctx.orgId),
         },
       });
       await emit.contactCreated(ctx, contact);
@@ -143,7 +144,7 @@ export const contactRouter = router({
   addChild: orgProcedure
     .input(
       z.object({
-        parentId: z.string(),
+        parentId: contactIdSchema,
         name: z.string().min(1),
         email: z.string().email().optional().or(z.literal("")),
         phone: z.string().optional(),
@@ -164,7 +165,7 @@ export const contactRouter = router({
           phone: input.phone,
           notes: input.notes,
           parentId: input.parentId,
-          organizationId: ctx.orgId,
+          organizationId: asId<"OrganizationId">(ctx.orgId),
         },
       });
     }),

--- a/src/lib/server/routers/document/core.ts
+++ b/src/lib/server/routers/document/core.ts
@@ -205,9 +205,12 @@ export const coreProcedures = {
     )
     .mutation(async ({ ctx, input }) => {
       await assertDocAccess(ctx, input.documentId);
-      const { documentId, analyzedAt, ...rest } = input;
+      const { documentId, analyzedAt, analysisStatus, ...rest } = input;
       const data = {
         ...rest,
+        ...(analysisStatus !== undefined
+          ? { analysisStatus: analysisStatus as "PENDING" | "RUNNING" | "DONE" | "ERROR" | null }
+          : {}),
         ...(analyzedAt !== undefined ? { analyzedAt: typeof analyzedAt === "string" ? new Date(analyzedAt) : analyzedAt } : {}),
       };
       return ctx.dataStore.documents.update({ where: { id: documentId }, data });

--- a/src/lib/server/routers/document/folders.ts
+++ b/src/lib/server/routers/document/folders.ts
@@ -10,14 +10,20 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { orgProcedure } from "../../trpc";
 import { assertMatterAccess } from "./shared";
+import {
+  matterIdSchema,
+  documentFolderIdSchema,
+  documentIdSchema,
+  type DocumentFolderId,
+} from "@/lib/shared/schemas/ids";
 
 export const folderProcedures = {
   createFolder: orgProcedure
     .input(
       z.object({
-        matterId: z.string(),
+        matterId: matterIdSchema,
         name: z.string().min(1),
-        parentId: z.string().nullable().default(null),
+        parentId: documentFolderIdSchema.nullable().default(null),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -32,7 +38,7 @@ export const folderProcedures = {
     }),
 
   renameFolder: orgProcedure
-    .input(z.object({ id: z.string(), name: z.string().min(1) }))
+    .input(z.object({ id: documentFolderIdSchema, name: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       return ctx.dataStore.documentFolders.update({
         where: { id: input.id },
@@ -42,7 +48,7 @@ export const folderProcedures = {
 
   /** Flyttar innehåll till parent och raderar mappen. */
   deleteFolder: orgProcedure
-    .input(z.object({ id: z.string() }))
+    .input(z.object({ id: documentFolderIdSchema }))
     .mutation(async ({ ctx, input }) => {
       const folder = await ctx.dataStore.documentFolders.findUniqueOrThrow({
         where: { id: input.id },
@@ -59,7 +65,7 @@ export const folderProcedures = {
     }),
 
   moveDocument: orgProcedure
-    .input(z.object({ documentId: z.string(), folderId: z.string().nullable() }))
+    .input(z.object({ documentId: documentIdSchema, folderId: documentFolderIdSchema.nullable() }))
     .mutation(async ({ ctx, input }) => {
       return ctx.dataStore.documents.update({
         where: { id: input.documentId },
@@ -69,10 +75,10 @@ export const folderProcedures = {
 
   /** Flyttar en mapp; blockerar cykler (mapp-in-i-sig-själv/descendant). */
   moveFolder: orgProcedure
-    .input(z.object({ folderId: z.string(), targetParentId: z.string().nullable() }))
+    .input(z.object({ folderId: documentFolderIdSchema, targetParentId: documentFolderIdSchema.nullable() }))
     .mutation(async ({ ctx, input }) => {
       if (input.targetParentId) {
-        let checkId: string | null = input.targetParentId;
+        let checkId: DocumentFolderId | null = input.targetParentId;
         while (checkId) {
           if (checkId === input.folderId) {
             throw new TRPCError({
@@ -80,12 +86,11 @@ export const folderProcedures = {
               message: "Cannot move a folder into itself or a descendant",
             });
           }
-          const parent: { parentId: string | null } | null =
-            await ctx.dataStore.documentFolders.findUnique({
-              where: { id: checkId },
-              select: { parentId: true },
-            });
-          checkId = parent?.parentId ?? null;
+          const parent = await ctx.dataStore.documentFolders.findUnique({
+            where: { id: checkId },
+            select: { parentId: true },
+          });
+          checkId = (parent?.parentId as DocumentFolderId | null | undefined) ?? null;
         }
       }
       return ctx.dataStore.documentFolders.update({
@@ -96,19 +101,18 @@ export const folderProcedures = {
 
   /** Breadcrumb-stig från rot till vald mapp. */
   breadcrumb: orgProcedure
-    .input(z.object({ folderId: z.string() }))
+    .input(z.object({ folderId: documentFolderIdSchema }))
     .query(async ({ ctx, input }) => {
       const path: { id: string; name: string }[] = [];
-      let currentId: string | null = input.folderId;
+      let currentId: DocumentFolderId | null = input.folderId;
       while (currentId) {
-        const folder: { id: string; name: string; parentId: string | null } | null =
-          await ctx.dataStore.documentFolders.findUnique({
-            where: { id: currentId },
-            select: { id: true, name: true, parentId: true },
-          });
+        const folder = await ctx.dataStore.documentFolders.findUnique({
+          where: { id: currentId },
+          select: { id: true, name: true, parentId: true },
+        });
         if (!folder) break;
         path.unshift({ id: folder.id, name: folder.name });
-        currentId = folder.parentId;
+        currentId = (folder.parentId as DocumentFolderId | null | undefined) ?? null;
       }
       return path;
     }),

--- a/src/lib/server/routers/document/suggestions.ts
+++ b/src/lib/server/routers/document/suggestions.ts
@@ -10,8 +10,9 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { orgProcedure } from "../../trpc";
-import { groupSuggestions } from "@/lib/shared/suggestion-grouping";
+import { groupSuggestions, type RawSuggestion } from "@/lib/shared/suggestion-grouping";
 import { matterRoleSchema, contactTypeSchema, type SuggestionStatus } from "@/lib/shared/schemas/enums";
+import { asId, type ContactId } from "@/lib/shared/schemas/ids";
 import {
   findExistingContactForSuggestion,
   type ContactCandidate,
@@ -77,10 +78,10 @@ async function loadPendingSuggestion(ctx: Ctx, suggestionId: string): Promise<Su
   return sugg;
 }
 
-async function resolveExistingContact(ctx: Ctx, contactId: string): Promise<string> {
+async function resolveExistingContact(ctx: Ctx, contactId: string): Promise<ContactId> {
   const existing = (await ctx.dataStore.contacts.findFirst({
     where: { id: contactId, organizationId: ctx.orgId },
-  } as never)) as { id: string } | null;
+  } as never)) as { id: ContactId } | null;
   if (!existing) throw new TRPCError({ code: "NOT_FOUND" });
   return existing.id;
 }
@@ -146,12 +147,12 @@ async function resolveOrCreateContact(
   sugg: Suggestion,
   o: SuggOverride,
   matterId: string,
-): Promise<string> {
+): Promise<ContactId> {
   const existing = await findContactByNumberOrName(ctx, sugg, o, matterId);
-  if (existing) return existing.id;
+  if (existing) return asId<"ContactId">(existing.id);
   const created = (await ctx.dataStore.contacts.create({
     data: { ...applyOverride(sugg, o), organizationId: ctx.orgId },
-  } as never)) as { id: string };
+  } as never)) as { id: ContactId };
   return created.id;
 }
 
@@ -214,11 +215,11 @@ async function resolveOrCreateGroupContact(
   ctx: Ctx,
   suggs: Suggestion[],
   matterId: string,
-): Promise<string> {
+): Promise<ContactId> {
   const personalNumber = pickFirstFromGroup(suggs, "personalNumber");
   const orgNumber = pickFirstFromGroup(suggs, "orgNumber");
   const existing = await findGroupContact(ctx, suggs, matterId, personalNumber, orgNumber);
-  if (existing) return existing.id;
+  if (existing) return asId<"ContactId">(existing.id);
   const created = (await ctx.dataStore.contacts.create({
     data: {
       name: suggs[0].name,
@@ -229,7 +230,7 @@ async function resolveOrCreateGroupContact(
       orgNumber,
       organizationId: ctx.orgId,
     },
-  } as never)) as { id: string };
+  } as never)) as { id: ContactId };
   return created.id;
 }
 
@@ -321,7 +322,7 @@ export const suggestionProcedures = {
         include: { document: { select: { id: true, fileName: true, title: true } } },
         orderBy: { createdAt: "asc" }, // asc → första förekomst vinner i first-non-empty
       });
-      return groupSuggestions(rows);
+      return groupSuggestions(rows as unknown as RawSuggestion[]);
     }),
 
   /**

--- a/src/lib/server/routers/documentTemplate.ts
+++ b/src/lib/server/routers/documentTemplate.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 import { router, protectedProcedure } from "../trpc";
 import { TRPCError } from "@trpc/server";
+import {
+  asId,
+  documentTemplateIdSchema,
+  userIdSchema,
+} from "@/lib/shared/schemas/ids";
 
 export const documentTemplateRouter = router({
   list: protectedProcedure.query(async ({ ctx }) => {
@@ -40,8 +45,8 @@ export const documentTemplateRouter = router({
         category: z.string().optional(),
         content: z.string().min(1),
         // Valfria setup-fält (demo-generator/fixtures, ADR 0003).
-        id: z.string().optional(),
-        createdById: z.string().optional(),
+        id: documentTemplateIdSchema.optional(),
+        createdById: userIdSchema.optional(),
         createdAt: z.string().optional(),
       })
     )
@@ -53,8 +58,8 @@ export const documentTemplateRouter = router({
           description: input.description,
           category: input.category,
           content: input.content,
-          organizationId: ctx.user.organizationId,
-          createdById: input.createdById ?? ctx.user.id,
+          organizationId: asId<"OrganizationId">(ctx.user.organizationId),
+          createdById: input.createdById ?? asId<"UserId">(ctx.user.id),
           createdAt: input.createdAt ? new Date(input.createdAt) : undefined,
         },
       });

--- a/src/lib/server/routers/expense.ts
+++ b/src/lib/server/routers/expense.ts
@@ -1,5 +1,12 @@
 import { z } from "zod";
 import { router, protectedProcedure } from "../trpc";
+import {
+  asId,
+  matterIdSchema,
+  userIdSchema,
+  expenseIdSchema,
+  invoiceIdSchema,
+} from "@/lib/shared/schemas/ids";
 
 export const expenseRouter = router({
   list: protectedProcedure
@@ -47,7 +54,7 @@ export const expenseRouter = router({
   create: protectedProcedure
     .input(
       z.object({
-        matterId: z.string(),
+        matterId: matterIdSchema,
         date: z.string(),
         amount: z.number().min(1),
         description: z.string().min(1),
@@ -57,9 +64,9 @@ export const expenseRouter = router({
         /** True om `amount` är inkl moms (kvitto-fall). Default true. */
         vatIncluded: z.boolean().default(true),
         // Valfria setup-fält (demo-generator/fixtures, ADR 0003).
-        id: z.string().optional(),
-        userId: z.string().optional(),
-        invoiceId: z.string().nullable().optional(),
+        id: expenseIdSchema.optional(),
+        userId: userIdSchema.optional(),
+        invoiceId: invoiceIdSchema.nullable().optional(),
         createdAt: z.string().optional(),
       })
     )
@@ -67,7 +74,7 @@ export const expenseRouter = router({
       return ctx.dataStore.expenses.create({
         data: {
           id: input.id, // undefined → store genererar
-          userId: input.userId ?? ctx.user.id,
+          userId: input.userId ?? asId<"UserId">(ctx.user.id),
           matterId: input.matterId,
           date: new Date(input.date),
           amount: input.amount,

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -19,6 +19,15 @@ import { router, orgProcedure } from "../trpc";
 import type { DataStoreTx } from "../data-store/IDataStore";
 import { computeFinalInvoiceBreakdown, isPaymentPlanSettled } from "@/lib/shared/invoice-calc";
 import { emit } from "../events/emit";
+import {
+  asId,
+  matterIdSchema,
+  invoiceIdSchema,
+  paymentPlanIdSchema,
+  type InvoiceId,
+  type TimeEntryId,
+  type ExpenseId,
+} from "@/lib/shared/schemas/ids";
 
 // ─── createFinal-hjälpare (validera + koppla poster) ──────────────
 
@@ -66,10 +75,10 @@ async function fetchDeductibleAccontos(tx: DataStoreTx, matterId: string, ids: s
  */
 async function linkBilledItems(
   tx: DataStoreTx,
-  invoiceId: string,
-  timeEntries: ReadonlyArray<{ id: string }>,
-  expenses: ReadonlyArray<{ id: string }>,
-  accontos: ReadonlyArray<{ id: string }>,
+  invoiceId: InvoiceId,
+  timeEntries: ReadonlyArray<{ id: TimeEntryId }>,
+  expenses: ReadonlyArray<{ id: ExpenseId }>,
+  accontos: ReadonlyArray<{ id: InvoiceId }>,
 ): Promise<void> {
   if (timeEntries.length) {
     await tx.timeEntries.updateMany({ where: { id: { in: timeEntries.map((t) => t.id) } }, data: { invoiceId } });
@@ -152,8 +161,8 @@ export const invoiceRouter = router({
     .input(
       z.object({
         /** Valfritt klient-genererat id (demo-generator/fixtures) → annars genererar store:n. */
-        id: z.string().optional(),
-        matterId: z.string(),
+        id: invoiceIdSchema.optional(),
+        matterId: matterIdSchema,
         amount: z.number().int().min(1),
         invoiceDate: z.string().optional(),
         dueDate: z.string().optional(),
@@ -190,8 +199,8 @@ export const invoiceRouter = router({
     .input(
       z.object({
         /** Valfritt klient-genererat id (demo-generator/fixtures) → annars genererar store:n. */
-        id: z.string().optional(),
-        matterId: z.string(),
+        id: invoiceIdSchema.optional(),
+        matterId: matterIdSchema,
         timeEntryIds: z.array(z.string()),
         expenseIds: z.array(z.string()),
         accontoInvoiceIds: z.array(z.string()).default([]),
@@ -248,8 +257,8 @@ export const invoiceRouter = router({
     .input(
       z.object({
         /** Valfritt klient-genererat id för kredit-fakturan (demo-generator/fixtures). */
-        id: z.string().optional(),
-        invoiceId: z.string(),
+        id: invoiceIdSchema.optional(),
+        invoiceId: invoiceIdSchema,
         notes: z.string().optional(),
       }),
     )
@@ -332,7 +341,7 @@ export const invoiceRouter = router({
             amount: input.amount,
             paidAt: new Date(input.paidAt),
             note: input.note,
-            recordedById: ctx.user.id,
+            recordedById: asId<"UserId">(ctx.user.id),
           },
         });
 
@@ -359,8 +368,8 @@ export const invoiceRouter = router({
     .input(
       z.object({
         /** Valfritt klient-genererat id (demo-generator/fixtures) → annars genererar store:n. */
-        id: z.string().optional(),
-        invoiceId: z.string(),
+        id: paymentPlanIdSchema.optional(),
+        invoiceId: invoiceIdSchema,
         monthlyAmount: z.number().int().min(1),
         dayOfMonth: z.number().int().min(1).max(28),
         startDate: z.string(),

--- a/src/lib/server/routers/matter.ts
+++ b/src/lib/server/routers/matter.ts
@@ -249,8 +249,12 @@ export const matterRouter = router({
         ctx.orgId,
         (c) => c.organizationId,
       );
+      const { createdAt, ...rest } = input;
       return ctx.dataStore.matterContacts.create({
-        data: input,
+        data: {
+          ...rest,
+          ...(createdAt ? { createdAt: new Date(createdAt) } : {}),
+        },
         include: { contact: true },
       });
     }),

--- a/src/lib/server/routers/organization.ts
+++ b/src/lib/server/routers/organization.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, protectedProcedure } from "../trpc";
+import { organizationIdSchema, asId } from "@/lib/shared/schemas/ids";
 
 export const organizationRouter = router({
   // ── Settings ────────────────────────────────────────────────────
@@ -48,7 +49,7 @@ export const organizationRouter = router({
   create: protectedProcedure
     .input(
       z.object({
-        id: z.string().min(1),
+        id: organizationIdSchema,
         name: z.string().min(1),
         orgNumber: z.string().optional(),
         address: z.string().optional(),
@@ -91,7 +92,7 @@ export const organizationRouter = router({
       return ctx.dataStore.offices.create({
         data: {
           ...input,
-          organizationId: ctx.user.organizationId,
+          organizationId: asId<"OrganizationId">(ctx.user.organizationId),
         },
       });
     }),

--- a/src/lib/server/routers/task.ts
+++ b/src/lib/server/routers/task.ts
@@ -10,23 +10,24 @@
 import { z } from "zod";
 import { router, protectedProcedure } from "../trpc";
 import { taskPrioritySchema, taskStatusSchema } from "@/lib/shared/schemas";
+import { asId, taskIdSchema, matterIdSchema, userIdSchema } from "@/lib/shared/schemas/ids";
 
 const createInput = z.object({
   title: z.string().min(1),
   description: z.string().nullish(),
   priority: taskPrioritySchema.default("MEDIUM"),
   dueAt: z.date().nullish(),
-  matterId: z.string().nullish(),
+  matterId: matterIdSchema.nullish(),
   // Valfria setup-fält (demo-generator/fixtures, ADR 0003).
-  id: z.string().optional(),
-  userId: z.string().optional(),
+  id: taskIdSchema.optional(),
+  userId: userIdSchema.optional(),
   status: taskStatusSchema.optional(),
   completedAt: z.date().nullish(),
   createdAt: z.date().nullish(),
 });
 
 const updateInput = createInput.partial().extend({
-  id: z.string(),
+  id: taskIdSchema,
   status: taskStatusSchema.optional(),
 });
 
@@ -59,8 +60,8 @@ export const taskRouter = router({
         data: {
           ...input,
           status: input.status ?? "TODO",
-          userId: input.userId ?? ctx.user.id,
-          organizationId: ctx.user.organizationId,
+          userId: input.userId ?? asId<"UserId">(ctx.user.id),
+          organizationId: asId<"OrganizationId">(ctx.user.organizationId),
           createdAt: input.createdAt ?? undefined,
         },
       }),

--- a/src/lib/server/routers/timeEntry.ts
+++ b/src/lib/server/routers/timeEntry.ts
@@ -1,6 +1,13 @@
 import { z } from "zod";
 import { router, protectedProcedure } from "../trpc";
 import { emit } from "../events/emit";
+import {
+  asId,
+  matterIdSchema,
+  userIdSchema,
+  timeEntryIdSchema,
+  invoiceIdSchema,
+} from "@/lib/shared/schemas/ids";
 
 export const timeEntryRouter = router({
   list: protectedProcedure
@@ -60,21 +67,21 @@ export const timeEntryRouter = router({
   create: protectedProcedure
     .input(
       z.object({
-        matterId: z.string(),
+        matterId: matterIdSchema,
         date: z.string(), // ISO date string YYYY-MM-DD
         minutes: z.number().min(1),
         description: z.string().min(1),
         billable: z.boolean().default(true),
         // Valfria setup-fält (demo-generator/fixtures, ADR 0003).
-        id: z.string().optional(),
-        userId: z.string().optional(),
+        id: timeEntryIdSchema.optional(),
+        userId: userIdSchema.optional(),
         hourlyRate: z.number().optional(),
-        invoiceId: z.string().nullable().optional(),
+        invoiceId: invoiceIdSchema.nullable().optional(),
         createdAt: z.string().optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const userId = input.userId ?? ctx.user.id;
+      const userId = input.userId ?? asId<"UserId">(ctx.user.id);
       const user = await ctx.dataStore.users.findUniqueOrThrow({
         where: { id: userId },
         select: { hourlyRate: true },

--- a/src/lib/server/routers/user.ts
+++ b/src/lib/server/routers/user.ts
@@ -12,6 +12,7 @@ async function hashPassword(password: string): Promise<string> {
 }
 import { TRPCError } from "@trpc/server";
 import { publicKeySchema, type PublicKey } from "@/lib/shared/schemas/user";
+import { userIdSchema, asId } from "@/lib/shared/schemas/ids";
 
 // Smal select för listor — håller utgående typ stabil för konsumenter
 // (reports, tids-rader, etc.) som inte bryr sig om nycklar.
@@ -112,7 +113,7 @@ export const userRouter = router({
   create: protectedProcedure
     .input(z.object({
       /** Valfritt klient-genererat id (ADR 0003) — annars genererar store:n. */
-      id: z.string().optional(),
+      id: userIdSchema.optional(),
       email: z.string().email(),
       name: z.string().min(1),
       title: z.string().optional(),
@@ -134,7 +135,7 @@ export const userRouter = router({
           hourlyRate: input.hourlyRate,
           mileageRate: input.mileageRate,
           passwordHash,
-          organizationId: ctx.user.organizationId,
+          organizationId: asId<"OrganizationId">(ctx.user.organizationId),
           publicKeys: [],
         },
       });

--- a/src/lib/server/trpc-core.ts
+++ b/src/lib/server/trpc-core.ts
@@ -20,6 +20,7 @@ import superjson from "superjson";
 import type { IDataStore } from "./data-store/IDataStore";
 import type { IPorts } from "./ports";
 import type { Principal } from "./auth/principal";
+import { asId } from "@/lib/shared/schemas/ids";
 
 export type Context = {
   /** Read/write-data via abstraktion. Git-backenden wirar DemoDataStore. */
@@ -59,7 +60,10 @@ export const protectedProcedure = t.procedure.use(isAuthed);
  * `ctx.orgId`.
  */
 export const orgProcedure = protectedProcedure.use(({ ctx, next }) =>
-  next({ ctx: { ...ctx, orgId: ctx.user.organizationId } }),
+  // Branda orgId centralt (#24): ctx.user.organizationId är auth-kontextens
+  // råa sträng; som branded OrganizationId flödar den in i write-literals
+  // (`data: { organizationId: ctx.orgId }`) och typkollas mot entiteten.
+  next({ ctx: { ...ctx, orgId: asId<"OrganizationId">(ctx.user.organizationId) } }),
 );
 
 /**


### PR DESCRIPTION
Closes #24.

`WritableDelegate.create/update` tog `args: unknown` → write-literals typkollades inte (en enum-stavfel i `tx.billingRuns.create({data:{type:"ACONTO"}})` fångades aldrig). Detta typar skriv-sidan.

## Ändringar
- **`Delegate<Row>`-interface**: `create/update/updateMany/upsert` tar nu `{ data: Partial<Row> }` (+ `where`); `include`/`select` hålls lösa (flytande query-yta). Läs-args (findX) oförändrade.
- **Alla entitets-delegater parametriserade** `Delegate<Row>` (via `z.infer`), inte bara matter/contact.
- Följd: branded id:n (#15) + enum-fält i write-`data` typkollas nu. Det avslöjade **~61 ställen** där FK sattes med rå `string` — fixade (parallellt via workflow, 7 domän-agenter):
  - router-input-FK-scheman brandade vid källan (`matterIdSchema`, `userIdSchema`, `invoiceIdSchema`, …),
  - `ctx.orgId` brandad centralt i `orgProcedure`, `ctx.user.id` via `asId` vid gränsen,
  - read-side join-fält narrowade (boundary-cast / `?? null`).

## Effekt
- `BillingRunType`/`Recipient`/`Status` och **alla enum/FK-write-literals typkollas nu** — en enum-stavfel i write-data blir kompileringsfel.
- Inga `any` infördes (regeln är `error` sedan #47).

Gröna lokalt: typecheck 0, lint 0 (45/45), knip 0, build:demo OK, test:fast (en debounce-flaky i `use-auto-sync` passerar på omkörning — orelaterad till denna ändring).