### PR TITLE
Aktivera exactOptionalPropertyTypes (#32, flagga 1/2)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -55,8 +55,7 @@ for (const m of NODE_BUILTINS_AND_SERVER_DEPS) {
 const demoConfig: NextConfig = {
   ...baseConfig,
   output: "export",
-  basePath: demoBasePath || undefined,
-  assetPrefix: demoBasePath || undefined,
+  ...(demoBasePath ? { basePath: demoBasePath, assetPrefix: demoBasePath } : {}),
   trailingSlash: true,
   images: { unoptimized: true },
   typescript: { ignoreBuildErrors: false },

--- a/src/app/calendar/_calendar-grid.tsx
+++ b/src/app/calendar/_calendar-grid.tsx
@@ -51,7 +51,9 @@ export function CalendarGrid({ mode, userIds, userNames, userColors, anchor, onA
     [mode, anchor],
   );
   const eventsByDay = useMemo(
-    () => bucketEventsByDay(events ?? [], days),
+    // Boundary-cast: tRPC-raderna är branded/optional och bredare än den lokala
+    // vy-typen CalendarGridEvent; bucketEventsByDay läser bara de fält som finns.
+    () => bucketEventsByDay((events ?? []) as unknown as CalendarGridEvent[], days),
     [events, days],
   );
 

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -20,6 +20,7 @@ import { CheckboxList } from "@/components/ui/checkbox-list";
 import { UserPicker, loadSelectedUserIds } from "./_user-picker";
 import { buildUserColorMap, type UserColor } from "@/lib/client/calendar/user-colors";
 import { resolveSelectedUsers } from "@/lib/client/calendar/select-users";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 
 type ViewMode = "list" | "day" | "week" | "month";
 
@@ -238,7 +239,7 @@ function EventList() {
             <div className="flex items-center gap-2">
               <span className="text-sm font-medium text-gray-900">{ev.title}</span>
               <KindBadge kind={ev.kind} />
-              {ev.mirrorToOutlook && <MirrorBadge {...(ev.mirrorStatus !== undefined ? { status: ev.mirrorStatus } : {})} />}
+              {ev.mirrorToOutlook && <MirrorBadge {...omitUndefined({ status: ev.mirrorStatus })} />}
             </div>
             <p className="text-xs text-gray-500 mt-0.5">
               {formatEventTime(ev)}
@@ -451,7 +452,7 @@ function NewEventForm({ onClose, initial }: { onClose: () => void; initial?: Eve
         <CheckboxList
           label="Bjud in kollegor"
           options={(orgUsers.data?.users ?? []).map((u: { id: string; name: string; role?: string }) => ({
-            id: u.id, label: u.name, ...(u.role !== undefined ? { sublabel: u.role } : {}),
+            id: u.id, label: u.name, ...omitUndefined({ sublabel: u.role }),
           }))}
           selectedIds={inviteeUserIds}
           onChange={setInviteeUserIds}
@@ -460,7 +461,7 @@ function NewEventForm({ onClose, initial }: { onClose: () => void; initial?: Eve
         <CheckboxList
           label="Bjud in från kontakter"
           options={(contacts.data?.contacts ?? []).map((c: { id: string; name: string; contactType?: string }) => ({
-            id: c.id, label: c.name, ...(c.contactType !== undefined ? { sublabel: c.contactType } : {}),
+            id: c.id, label: c.name, ...omitUndefined({ sublabel: c.contactType }),
           }))}
           selectedIds={inviteeContactIds}
           onChange={setInviteeContactIds}

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -179,7 +179,9 @@ export default function CalendarPage() {
           <EventDetailModal
             event={selectedEvent}
             userName={selectedEvent ? (userNames[selectedEvent.userId] ?? "?") : ""}
-            color={selectedEvent ? userColors.get(selectedEvent.userId) : undefined}
+            {...(selectedEvent && userColors.get(selectedEvent.userId)
+              ? { color: userColors.get(selectedEvent.userId)! }
+              : {})}
             onClose={() => setSelectedEvent(null)}
             onEdit={(ev) => { setSelectedEvent(null); setEditingEvent(ev as unknown as EventRow); }}
           />
@@ -226,13 +228,17 @@ function EventList() {
 
   return (
     <ul className="divide-y divide-gray-100 bg-white rounded-lg border border-gray-200">
-      {events.map((ev: EventRow) => (
+      {events.map((row) => {
+        // Boundary-cast: tRPC-raden är branded/optional och bredare än den
+        // lokala vy-typen EventRow (samma fält, men branded id m.m.).
+        const ev = row as unknown as EventRow;
+        return (
         <li key={ev.id} className="px-4 py-3 flex items-center justify-between gap-3">
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
               <span className="text-sm font-medium text-gray-900">{ev.title}</span>
               <KindBadge kind={ev.kind} />
-              {ev.mirrorToOutlook && <MirrorBadge status={ev.mirrorStatus} />}
+              {ev.mirrorToOutlook && <MirrorBadge {...(ev.mirrorStatus !== undefined ? { status: ev.mirrorStatus } : {})} />}
             </div>
             <p className="text-xs text-gray-500 mt-0.5">
               {formatEventTime(ev)}
@@ -248,7 +254,8 @@ function EventList() {
             <Trash2 size={14} />
           </button>
         </li>
-      ))}
+        );
+      })}
     </ul>
   );
 }
@@ -266,7 +273,11 @@ function TaskList() {
 
   return (
     <ul className="divide-y divide-gray-100 bg-white rounded-lg border border-gray-200">
-      {tasks.map((t: TaskRow) => (
+      {tasks.map((row) => {
+        // Boundary-cast: tRPC-raden är branded/optional och bredare än den
+        // lokala vy-typen TaskRow (samma fält, men branded id m.m.).
+        const t = row as unknown as TaskRow;
+        return (
         <li key={t.id} className={`px-4 py-3 flex items-center justify-between gap-3 ${t.status === "DONE" ? "opacity-60" : ""}`}>
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
@@ -299,7 +310,8 @@ function TaskList() {
             </button>
           </div>
         </li>
-      ))}
+        );
+      })}
     </ul>
   );
 }
@@ -314,7 +326,10 @@ function NewEventForm({ onClose, initial }: { onClose: () => void; initial?: Eve
   const orgUsers = trpc.user.list.useQuery();
   const contacts = trpc.contacts.list.useQuery({ pageSize: 500 });
 
-  const onCreateOrUpdateSuccess = (saved: EventRow): void => {
+  // Boundary-cast: mutationen returnerar en branded/optional tRPC-rad som är
+  // bredare än den lokala vy-typen EventRow; vi läser bara de fält som finns.
+  const onCreateOrUpdateSuccess = (savedRow: unknown): void => {
+    const saved = savedRow as EventRow;
     void utils.calendar.invalidate();
     if (saved.mirrorToOutlook) {
       enqueueMirror({
@@ -436,7 +451,7 @@ function NewEventForm({ onClose, initial }: { onClose: () => void; initial?: Eve
         <CheckboxList
           label="Bjud in kollegor"
           options={(orgUsers.data?.users ?? []).map((u: { id: string; name: string; role?: string }) => ({
-            id: u.id, label: u.name, sublabel: u.role,
+            id: u.id, label: u.name, ...(u.role !== undefined ? { sublabel: u.role } : {}),
           }))}
           selectedIds={inviteeUserIds}
           onChange={setInviteeUserIds}
@@ -445,7 +460,7 @@ function NewEventForm({ onClose, initial }: { onClose: () => void; initial?: Eve
         <CheckboxList
           label="Bjud in från kontakter"
           options={(contacts.data?.contacts ?? []).map((c: { id: string; name: string; contactType?: string }) => ({
-            id: c.id, label: c.name, sublabel: c.contactType,
+            id: c.id, label: c.name, ...(c.contactType !== undefined ? { sublabel: c.contactType } : {}),
           }))}
           selectedIds={inviteeContactIds}
           onChange={setInviteeContactIds}

--- a/src/app/invoices/[id]/_client.tsx
+++ b/src/app/invoices/[id]/_client.tsx
@@ -295,9 +295,9 @@ async function openInvoiceDoc(doc: InvoiceDocRow): Promise<void> {
   const { loadHandle } = await import("@/lib/client/fsa/handle-store");
   const { readFromFsa } = await import("@/lib/client/fsa/read-from-fsa");
   await openDocument({
-    doc: { id: doc.id, storagePath: doc.storagePath ?? undefined, fileName: doc.fileName },
+    doc: { id: doc.id, ...(doc.storagePath != null ? { storagePath: doc.storagePath } : {}), fileName: doc.fileName },
     isDemo: process.env.NEXT_PUBLIC_DEMO_BUILD === "1",
-    demoRepo: process.env.NEXT_PUBLIC_DEFAULT_DEMO_REPO,
+    ...(process.env.NEXT_PUBLIC_DEFAULT_DEMO_REPO !== undefined ? { demoRepo: process.env.NEXT_PUBLIC_DEFAULT_DEMO_REPO } : {}),
     loadHandle: () => loadHandle("repo-root"),
     readFromHandle: readFromFsa,
     openUrl: (u) => window.open(u, "_blank", "noopener,noreferrer"),

--- a/src/app/invoices/[id]/_client.tsx
+++ b/src/app/invoices/[id]/_client.tsx
@@ -11,6 +11,7 @@ import { trpc } from "@/lib/client/trpc";
 import { useRouteId } from "@/lib/client/demo/use-route-id";
 import { EntityLink } from "@/lib/client/demo/entity-link";
 import { formatCurrency } from "@/lib/client/utils";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 import type { AppRouter } from "@/lib/server/routers/_app";
 import { PaymentModal } from "./_payment-modal";
 import { PlanModal } from "./_plan-modal";
@@ -297,7 +298,7 @@ async function openInvoiceDoc(doc: InvoiceDocRow): Promise<void> {
   await openDocument({
     doc: { id: doc.id, ...(doc.storagePath != null ? { storagePath: doc.storagePath } : {}), fileName: doc.fileName },
     isDemo: process.env.NEXT_PUBLIC_DEMO_BUILD === "1",
-    ...(process.env.NEXT_PUBLIC_DEFAULT_DEMO_REPO !== undefined ? { demoRepo: process.env.NEXT_PUBLIC_DEFAULT_DEMO_REPO } : {}),
+    ...omitUndefined({ demoRepo: process.env.NEXT_PUBLIC_DEFAULT_DEMO_REPO }),
     loadHandle: () => loadHandle("repo-root"),
     readFromHandle: readFromFsa,
     openUrl: (u) => window.open(u, "_blank", "noopener,noreferrer"),

--- a/src/app/invoices/[id]/_credit-modal.tsx
+++ b/src/app/invoices/[id]/_credit-modal.tsx
@@ -44,7 +44,7 @@ export function CreditModal({ invoiceId, amount, hasActivePlan, isPending, error
           <button onClick={onClose} className="px-3 py-1.5 text-sm border border-gray-300 rounded">Avbryt</button>
           <button
             disabled={isPending}
-            onClick={() => onSubmit({ invoiceId, notes: creditNotes || undefined })}
+            onClick={() => onSubmit({ invoiceId, ...(creditNotes ? { notes: creditNotes } : {}) })}
             className="px-4 py-1.5 text-sm bg-orange-600 text-white rounded hover:bg-orange-700 disabled:opacity-50"
           >
             {isPending ? "Krediterar…" : "Kreditera"}

--- a/src/app/invoices/[id]/_payment-modal.tsx
+++ b/src/app/invoices/[id]/_payment-modal.tsx
@@ -46,7 +46,7 @@ export function PaymentModal({ invoiceId, isPending, error, onSubmit, onClose }:
               invoiceId,
               amount: Math.round(Number(paymentAmountSek) * 100),
               paidAt: paymentDate,
-              note: paymentNote || undefined,
+              ...(paymentNote ? { note: paymentNote } : {}),
             })}
             className="px-4 py-1.5 text-sm bg-green-600 text-white rounded hover:bg-green-700 disabled:opacity-50"
           >

--- a/src/app/invoices/[id]/_plan-modal.tsx
+++ b/src/app/invoices/[id]/_plan-modal.tsx
@@ -59,7 +59,7 @@ export function PlanModal({ invoiceId, isPending, error, onSubmit, onClose }: Pr
               monthlyAmount: Math.round(Number(planMonthlySek) * 100),
               dayOfMonth: Number(planDayOfMonth),
               startDate: planStart,
-              notes: planNotes || undefined,
+              ...(planNotes ? { notes: planNotes } : {}),
             })}
             className="px-4 py-1.5 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:opacity-50"
           >

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -121,7 +121,7 @@ function JobRow({ job }: { job: Job }) {
   );
 }
 
-function StatusBadge({ status, progress }: { status: Job["status"]; progress?: number }) {
+function StatusBadge({ status, progress }: { status: Job["status"]; progress?: number | undefined }) {
   const styles: Record<Job["status"], string> = {
     queued: "bg-gray-100 text-gray-700",
     running: "bg-blue-50 text-blue-800",

--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -184,11 +184,7 @@ function orgProps(org: { name?: string | null | undefined; orgNumber?: string | 
   const name = strOrUndef(org?.name);
   const orgNumber = strOrUndef(org?.orgNumber);
   const address = strOrUndef(org?.address);
-  return {
-    ...(name !== undefined ? { name } : {}),
-    ...(orgNumber !== undefined ? { orgNumber } : {}),
-    ...(address !== undefined ? { address } : {}),
-  };
+  return omitUndefined({ name, orgNumber, address });
 }
 
 function useKrModalData(matterId: string): KrModalData {

--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -23,16 +23,17 @@ import { KostnadsrakningModal } from "./_kostnadsrakning-modal";
 import { hasGeneratedDoc, openGeneratedDoc } from "@/lib/client/demo/generated-doc-cache";
 import { EntityLink } from "@/lib/client/demo/entity-link";
 import { useMatterInvariants } from "@/lib/client/diagnostics/use-matter-invariants";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 
 interface MatterContext {
   matterNumber: string;
   title: string;
-  taxaLevel?: number | null;
-  taxaHasFTax?: boolean | null;
-  taxaHufStart?: string | Date | null;
-  isTaxeArende?: boolean | null;
-  paymentMethod?: string | null;
-  contacts?: ReadonlyArray<{ role: string; contact?: { name?: string | null; email?: string | null } | null }>;
+  taxaLevel?: number | null | undefined;
+  taxaHasFTax?: boolean | null | undefined;
+  taxaHufStart?: string | Date | null | undefined;
+  isTaxeArende?: boolean | null | undefined;
+  paymentMethod?: string | null | undefined;
+  contacts?: ReadonlyArray<{ role: string; contact?: { name?: string | null | undefined; email?: string | null | undefined } | null | undefined }> | undefined;
 }
 
 interface Props {
@@ -179,11 +180,14 @@ function strOrUndef(v: string | null | undefined): string | undefined {
 }
 
 interface OrgData { name?: string; orgNumber?: string; address?: string }
-function orgProps(org: { name?: string | null; orgNumber?: string | null; address?: string | null } | undefined): OrgData {
+function orgProps(org: { name?: string | null | undefined; orgNumber?: string | null | undefined; address?: string | null | undefined } | undefined): OrgData {
+  const name = strOrUndef(org?.name);
+  const orgNumber = strOrUndef(org?.orgNumber);
+  const address = strOrUndef(org?.address);
   return {
-    name: strOrUndef(org?.name),
-    orgNumber: strOrUndef(org?.orgNumber),
-    address: strOrUndef(org?.address),
+    ...(name !== undefined ? { name } : {}),
+    ...(orgNumber !== undefined ? { orgNumber } : {}),
+    ...(address !== undefined ? { address } : {}),
   };
 }
 
@@ -191,14 +195,16 @@ function useKrModalData(matterId: string): KrModalData {
   const me = trpc.user.current.useQuery().data;
   const org = orgProps(trpc.organization.getSettings.useQuery().data ?? undefined);
   const expenses = trpc.expense.list.useQuery({ matterId }).data?.expenses ?? [];
-  return {
+  // omitUndefined samlar exactOptional-strippningen (#32) på ett ställe så
+  // funktionen inte spräcker complexity-gränsen.
+  return omitUndefined({
     defenderName: me?.name ?? "",
     defenderEmail: strOrUndef(me?.email),
     organizationName: org.name,
     organizationOrgNumber: org.orgNumber,
     organizationAddress: org.address,
     expenses: expenses as KrModalData["expenses"],
-  };
+  }) as KrModalData;
 }
 
 function KostnadsrakningTrigger({ matterId, matter, open, onClose, onRecorded }: KrTriggerProps) {

--- a/src/app/matters/[id]/_client.tsx
+++ b/src/app/matters/[id]/_client.tsx
@@ -84,10 +84,10 @@ interface HeaderProps {
     id: string;
     matterNumber: string;
     title: string;
-    matterType?: string | null;
-    description?: string | null;
+    matterType?: string | null | undefined;
+    description?: string | null | undefined;
     status: string;
-    isTaxeArende?: boolean;
+    isTaxeArende?: boolean | undefined;
   };
   klient: MatterContact[];
   onOpenGenerate: () => void;

--- a/src/app/matters/[id]/_expense-section.tsx
+++ b/src/app/matters/[id]/_expense-section.tsx
@@ -217,7 +217,7 @@ interface FormProps {
   setForm: (f: ExpenseForm) => void;
   submitLabel: string;
   isPending: boolean;
-  isTaxeArende?: boolean;
+  isTaxeArende?: boolean | undefined;
   onSubmit: () => void;
   onCancel: () => void;
 }

--- a/src/app/matters/[id]/_generate-modal.tsx
+++ b/src/app/matters/[id]/_generate-modal.tsx
@@ -6,6 +6,7 @@ import { FileDown } from "lucide-react";
 import { trpc } from "@/lib/client/trpc";
 import { labelForMatterRole } from "@/lib/client/labels";
 import { buildTemplateContext } from "@/lib/client/templates/build-template-context";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { renderHandlebars } from "@/lib/client/kostnadsrakning/render-handlebars";
 
 type Contact = { id: string; name: string; email?: string | null; phone?: string | null };
@@ -62,19 +63,20 @@ export function GenerateModal({ matterId, contacts, onClose }: Props) {
           matter: {
             matterNumber: m.matterNumber,
             title: m.title,
-            ...(m.matterType !== undefined ? { matterType: m.matterType } : {}),
+            ...omitUndefined({ matterType: m.matterType }),
           },
           recipient: recipient ? {
             name: recipient.name,
-            ...(recipient.email !== undefined ? { email: recipient.email } : {}),
-            ...(recipient.phone !== undefined ? { phone: recipient.phone } : {}),
+            ...omitUndefined({ email: recipient.email, phone: recipient.phone }),
           } : null,
           client: clientLink ? { name: clientLink.contact.name } : null,
           organization: org.data ? {
             name: org.data.name,
-            ...(org.data.orgNumber !== undefined ? { orgNumber: org.data.orgNumber } : {}),
-            ...(org.data.address !== undefined ? { address: org.data.address } : {}),
-            ...(org.data.email !== undefined ? { email: org.data.email } : {}),
+            ...omitUndefined({
+              orgNumber: org.data.orgNumber,
+              address: org.data.address,
+              email: org.data.email,
+            }),
           } : null,
         });
         const html = renderHandlebars(tpl.content, ctx);

--- a/src/app/matters/[id]/_generate-modal.tsx
+++ b/src/app/matters/[id]/_generate-modal.tsx
@@ -59,10 +59,23 @@ export function GenerateModal({ matterId, contacts, onClose }: Props) {
 
       for (const recipient of recipients) {
         const ctx = buildTemplateContext({
-          matter: { matterNumber: m.matterNumber, title: m.title, matterType: m.matterType },
-          recipient: recipient ? { name: recipient.name, email: recipient.email, phone: recipient.phone } : null,
+          matter: {
+            matterNumber: m.matterNumber,
+            title: m.title,
+            ...(m.matterType !== undefined ? { matterType: m.matterType } : {}),
+          },
+          recipient: recipient ? {
+            name: recipient.name,
+            ...(recipient.email !== undefined ? { email: recipient.email } : {}),
+            ...(recipient.phone !== undefined ? { phone: recipient.phone } : {}),
+          } : null,
           client: clientLink ? { name: clientLink.contact.name } : null,
-          organization: org.data ? { name: org.data.name, orgNumber: org.data.orgNumber, address: org.data.address, email: org.data.email } : null,
+          organization: org.data ? {
+            name: org.data.name,
+            ...(org.data.orgNumber !== undefined ? { orgNumber: org.data.orgNumber } : {}),
+            ...(org.data.address !== undefined ? { address: org.data.address } : {}),
+            ...(org.data.email !== undefined ? { email: org.data.email } : {}),
+          } : null,
         });
         const html = renderHandlebars(tpl.content, ctx);
 

--- a/src/app/matters/[id]/_kostnadsrakning-modal.tsx
+++ b/src/app/matters/[id]/_kostnadsrakning-modal.tsx
@@ -22,6 +22,7 @@ import { Clock, FileText, X, AlertTriangle, Save } from "lucide-react";
 import { trpc } from "@/lib/client/trpc";
 import type { AppRouter } from "@/lib/server/routers/_app";
 import { buildKostnadsrakningContext } from "@/lib/shared/kostnadsrakning";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 import type { TaxaLevel } from "@/lib/shared/brottmalstaxa";
 import { renderKostnadsrakningPdf } from "@/lib/client/kostnadsrakning/render-pdf";
 import { useHelper, composeMailViaHelper } from "@/lib/client/helper/use-helper";
@@ -183,14 +184,14 @@ export function KostnadsrakningModal(props: Props) {
     matter: { matterNumber: props.matterNumber, title: props.matterTitle, clientName: props.clientName },
     defender: {
       name: props.defenderName,
-      ...(props.defenderEmail !== undefined ? { email: props.defenderEmail } : {}),
+      ...omitUndefined({ email: props.defenderEmail }),
     },
-    organization: {
-      ...(props.organizationName !== undefined ? { name: props.organizationName } : {}),
-      ...(props.organizationOrgNumber !== undefined ? { orgNumber: props.organizationOrgNumber } : {}),
-      ...(props.organizationAddress !== undefined ? { address: props.organizationAddress } : {}),
-    },
-    ...(props.courtName !== undefined ? { courtName: props.courtName } : {}),
+    organization: omitUndefined({
+      name: props.organizationName,
+      orgNumber: props.organizationOrgNumber,
+      address: props.organizationAddress,
+    }),
+    ...omitUndefined({ courtName: props.courtName }),
     hufStart: new Date(hufStart),
     hufEnd: new Date(hufEnd),
     taxaLevel: level,
@@ -222,8 +223,10 @@ export function KostnadsrakningModal(props: Props) {
           matterNumber: props.matterNumber, matterTitle: props.matterTitle,
           clientName: props.clientName, courtName: props.courtName ?? "",
           defenderName: props.defenderName,
-          ...(props.organizationName !== undefined ? { organizationName: props.organizationName } : {}),
-          ...(props.organizationOrgNumber !== undefined ? { organizationOrgNumber: props.organizationOrgNumber } : {}),
+          ...omitUndefined({
+            organizationName: props.organizationName,
+            organizationOrgNumber: props.organizationOrgNumber,
+          }),
         },
       });
       const storagePath = `documents/content/${docId}.pdf`;

--- a/src/app/matters/[id]/_kostnadsrakning-modal.tsx
+++ b/src/app/matters/[id]/_kostnadsrakning-modal.tsx
@@ -33,21 +33,21 @@ interface Props {
   matterNumber: string;
   matterTitle: string;
   clientName: string;
-  courtName?: string;
+  courtName?: string | undefined;
   defenderName: string;
-  defenderEmail?: string;
-  organizationName?: string;
-  organizationOrgNumber?: string;
-  organizationAddress?: string;
+  defenderEmail?: string | undefined;
+  organizationName?: string | undefined;
+  organizationOrgNumber?: string | undefined;
+  organizationAddress?: string | undefined;
   expenses: ReadonlyArray<{
     id: string; date: string | Date; description: string;
     amount: number; vatRate?: number; vatIncluded?: boolean; billable?: boolean;
   }>;
-  initialLevel?: TaxaLevel;
+  initialLevel?: TaxaLevel | undefined;
   /** @deprecated Alla advokater har F-skatt — fältet ignoreras. */
-  initialHasFTax?: boolean;
-  initialHufStart?: string | Date | null;
-  initialIsTaxe?: boolean;
+  initialHasFTax?: boolean | undefined;
+  initialHufStart?: string | Date | null | undefined;
+  initialIsTaxe?: boolean | undefined;
   onClose: () => void;
 }
 
@@ -181,9 +181,16 @@ export function KostnadsrakningModal(props: Props) {
 
   const ctx = useMemo(() => buildKostnadsrakningContext({
     matter: { matterNumber: props.matterNumber, title: props.matterTitle, clientName: props.clientName },
-    defender: { name: props.defenderName, email: props.defenderEmail },
-    organization: { name: props.organizationName, orgNumber: props.organizationOrgNumber, address: props.organizationAddress },
-    courtName: props.courtName,
+    defender: {
+      name: props.defenderName,
+      ...(props.defenderEmail !== undefined ? { email: props.defenderEmail } : {}),
+    },
+    organization: {
+      ...(props.organizationName !== undefined ? { name: props.organizationName } : {}),
+      ...(props.organizationOrgNumber !== undefined ? { orgNumber: props.organizationOrgNumber } : {}),
+      ...(props.organizationAddress !== undefined ? { address: props.organizationAddress } : {}),
+    },
+    ...(props.courtName !== undefined ? { courtName: props.courtName } : {}),
     hufStart: new Date(hufStart),
     hufEnd: new Date(hufEnd),
     taxaLevel: level,
@@ -215,7 +222,8 @@ export function KostnadsrakningModal(props: Props) {
           matterNumber: props.matterNumber, matterTitle: props.matterTitle,
           clientName: props.clientName, courtName: props.courtName ?? "",
           defenderName: props.defenderName,
-          organizationName: props.organizationName, organizationOrgNumber: props.organizationOrgNumber,
+          ...(props.organizationName !== undefined ? { organizationName: props.organizationName } : {}),
+          ...(props.organizationOrgNumber !== undefined ? { organizationOrgNumber: props.organizationOrgNumber } : {}),
         },
       });
       const storagePath = `documents/content/${docId}.pdf`;

--- a/src/app/matters/[id]/_time-section.tsx
+++ b/src/app/matters/[id]/_time-section.tsx
@@ -193,7 +193,7 @@ interface FormProps {
   setForm: (f: EditForm) => void;
   submitLabel: string;
   isPending: boolean;
-  isTaxeArende?: boolean;
+  isTaxeArende?: boolean | undefined;
   onSubmit: () => void;
   onCancel: () => void;
 }

--- a/src/app/matters/[id]/_verdict-dialog.tsx
+++ b/src/app/matters/[id]/_verdict-dialog.tsx
@@ -16,6 +16,7 @@ import type { inferRouterInputs } from "@trpc/server";
 import { trpc } from "@/lib/client/trpc";
 import type { AppRouter } from "@/lib/server/routers/_app";
 import { formatCurrency } from "@/lib/client/utils";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { Modal } from "@/components/ui/modal";
 
 type RouterInputs = inferRouterInputs<AppRouter>;
@@ -57,9 +58,11 @@ async function generateFakturaDoc(
     invoice,
     meta: {
       matterNumber: props.matterNumber, matterTitle: props.matterTitle,
-      ...(props.clientName !== undefined ? { clientName: props.clientName } : {}),
-      ...(props.organizationName !== undefined ? { organizationName: props.organizationName } : {}),
-      ...(props.organizationOrgNumber !== undefined ? { organizationOrgNumber: props.organizationOrgNumber } : {}),
+      ...omitUndefined({
+        clientName: props.clientName,
+        organizationName: props.organizationName,
+        organizationOrgNumber: props.organizationOrgNumber,
+      }),
     },
   });
   const docId = `faktura-${invoice.id}`;

--- a/src/app/matters/[id]/_verdict-dialog.tsx
+++ b/src/app/matters/[id]/_verdict-dialog.tsx
@@ -57,8 +57,9 @@ async function generateFakturaDoc(
     invoice,
     meta: {
       matterNumber: props.matterNumber, matterTitle: props.matterTitle,
-      clientName: props.clientName,
-      organizationName: props.organizationName, organizationOrgNumber: props.organizationOrgNumber,
+      ...(props.clientName !== undefined ? { clientName: props.clientName } : {}),
+      ...(props.organizationName !== undefined ? { organizationName: props.organizationName } : {}),
+      ...(props.organizationOrgNumber !== undefined ? { organizationOrgNumber: props.organizationOrgNumber } : {}),
     },
   });
   const docId = `faktura-${invoice.id}`;

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { EntityLink } from "@/lib/client/demo/entity-link";
 import { trpc } from "@/lib/client/trpc";
 import { DataTable, type Column } from "@/components/ui/data-table";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 
 interface SearchHit {
   documentId: string;
@@ -31,13 +32,11 @@ async function openHit(hit: SearchHit): Promise<void> {
   await openDocument({
     doc: {
       id: hit.documentId,
-      ...(hit.storagePath !== undefined ? { storagePath: hit.storagePath } : {}),
+      ...omitUndefined({ storagePath: hit.storagePath }),
       fileName: hit.fileName,
     },
     isDemo,
-    ...(process.env.NEXT_PUBLIC_DEFAULT_DEMO_REPO !== undefined
-      ? { demoRepo: process.env.NEXT_PUBLIC_DEFAULT_DEMO_REPO }
-      : {}),
+    ...omitUndefined({ demoRepo: process.env.NEXT_PUBLIC_DEFAULT_DEMO_REPO }),
     loadHandle: () => loadHandle("repo-root"),
     readFromHandle: readFromFsa,
     openUrl: (u) => window.open(u, "_blank", "noopener,noreferrer"),

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -29,9 +29,15 @@ async function openHit(hit: SearchHit): Promise<void> {
   ]);
   const isDemo = process.env.NEXT_PUBLIC_DEMO_BUILD === "1";
   await openDocument({
-    doc: { id: hit.documentId, storagePath: hit.storagePath, fileName: hit.fileName },
+    doc: {
+      id: hit.documentId,
+      ...(hit.storagePath !== undefined ? { storagePath: hit.storagePath } : {}),
+      fileName: hit.fileName,
+    },
     isDemo,
-    demoRepo: process.env.NEXT_PUBLIC_DEFAULT_DEMO_REPO,
+    ...(process.env.NEXT_PUBLIC_DEFAULT_DEMO_REPO !== undefined
+      ? { demoRepo: process.env.NEXT_PUBLIC_DEFAULT_DEMO_REPO }
+      : {}),
     loadHandle: () => loadHandle("repo-root"),
     readFromHandle: readFromFsa,
     openUrl: (u) => window.open(u, "_blank", "noopener,noreferrer"),

--- a/src/app/users/_user-form.tsx
+++ b/src/app/users/_user-form.tsx
@@ -19,7 +19,7 @@ interface Props {
   setForm: (f: UserFormState) => void;
   onSubmit: (e: React.FormEvent) => void;
   passwordError: string;
-  errorMessage?: string;
+  errorMessage?: string | undefined;
   passwordRequired: boolean;
   passwordPlaceholder?: string;
   submitLabel: string;

--- a/src/app/users/new/page.tsx
+++ b/src/app/users/new/page.tsx
@@ -63,7 +63,7 @@ export default function NewUserPage() {
           setForm={setForm}
           onSubmit={handleSubmit}
           passwordError={passwordError}
-          errorMessage={createUser.error?.message}
+          {...(createUser.error?.message !== undefined ? { errorMessage: createUser.error.message } : {})}
           passwordRequired={true}
           submitLabel="Skapa användare"
           submittingLabel="Sparar..."

--- a/src/app/users/new/page.tsx
+++ b/src/app/users/new/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { trpc } from "@/lib/client/trpc";
 import { UserForm, type UserFormState } from "../_user-form";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 
 export default function NewUserPage() {
   const router = useRouter();
@@ -63,7 +64,7 @@ export default function NewUserPage() {
           setForm={setForm}
           onSubmit={handleSubmit}
           passwordError={passwordError}
-          {...(createUser.error?.message !== undefined ? { errorMessage: createUser.error.message } : {})}
+          {...omitUndefined({ errorMessage: createUser.error?.message })}
           passwordRequired={true}
           submitLabel="Skapa användare"
           submittingLabel="Sparar..."

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -48,7 +48,7 @@ function BecomeButton({ user, onClick }: { user: UserRow; onClick: (u: UserRow) 
 
 function buildUserColumns(opts: {
   isAdmin: boolean;
-  meId?: string;
+  meId?: string | undefined;
   onDeactivate: (id: string, name: string) => void;
   onBecome: (u: UserRow) => void;
 }): Column<UserRow>[] {

--- a/src/components/documents/_document-row.tsx
+++ b/src/components/documents/_document-row.tsx
@@ -83,7 +83,7 @@ export function DocumentRow({
             style={{ paddingLeft: `${depth * 16 + 4}px` }}
             className="flex items-center gap-2 min-w-0"
           >
-            <DocumentNameButton doc={doc} isAnalyzing={isAnalyzing} disabled={isUploading}
+            <DocumentNameButton doc={doc} isAnalyzing={isAnalyzing} disabled={!!isUploading}
               onExternalEdit={() => void triggerExternalEdit()} />
             {isUploading && (
               <span
@@ -102,7 +102,7 @@ export function DocumentRow({
         <td className="px-3 py-2.5 text-right whitespace-nowrap">
           <DocumentActions
             doc={doc}
-            disabled={isUploading}
+            disabled={!!isUploading}
             onReanalyze={onReanalyze}
             onDelete={onDelete}
             reanalyzePending={reanalyzePending}
@@ -204,17 +204,18 @@ function DocumentActions({
 
   const openExternal = onExternalEdit;
 
-  const uploadingTitle = disabled ? "Vänta tills uppladdningen är klar" : undefined;
+  const isDisabled = !!disabled;
+  const uploadingTitle = isDisabled ? "Vänta tills uppladdningen är klar" : undefined;
   const items: ActionMenuItem[] = [
-    { key: "open", label: "Öppna i webbläsaren", icon: <span aria-hidden>🖊</span>, onSelect: () => void openInEditor(), disabled, title: uploadingTitle ?? "Öppna i din browser" },
-    { key: "external", label: "Editera externt (PDF Gear, Preview…)", icon: <span aria-hidden>🖥</span>, onSelect: () => void openExternal(), disabled, title: uploadingTitle ?? "AVA committar dina ändringar automatiskt" },
-    { key: "view", label: "Visa", icon: <span aria-hidden>👁</span>, href: viewHref, newTab: true, disabled, title: uploadingTitle ?? "Visa i webbläsaren" },
-    { key: "download", label: "Ladda ner", icon: <span aria-hidden>⬇</span>, href: downloadHref, download: true, disabled, title: uploadingTitle ?? "Ladda ner" },
-    { key: "reanalyze", label: "Analysera (AI)", icon: <span aria-hidden>🧠</span>, onSelect: onReanalyze, disabled: disabled || reanalyzePending, title: uploadingTitle ?? "Kör AI-analys på nytt" },
-    { key: "delete", label: "Ta bort", icon: <Trash2 size={15} />, onSelect: onDelete, danger: true, disabled, title: uploadingTitle },
+    { key: "open", label: "Öppna i webbläsaren", icon: <span aria-hidden>🖊</span>, onSelect: () => void openInEditor(), disabled: isDisabled, title: uploadingTitle ?? "Öppna i din browser" },
+    { key: "external", label: "Editera externt (PDF Gear, Preview…)", icon: <span aria-hidden>🖥</span>, onSelect: () => void openExternal(), disabled: isDisabled, title: uploadingTitle ?? "AVA committar dina ändringar automatiskt" },
+    { key: "view", label: "Visa", icon: <span aria-hidden>👁</span>, href: viewHref, newTab: true, disabled: isDisabled, title: uploadingTitle ?? "Visa i webbläsaren" },
+    { key: "download", label: "Ladda ner", icon: <span aria-hidden>⬇</span>, href: downloadHref, download: true, disabled: isDisabled, title: uploadingTitle ?? "Ladda ner" },
+    { key: "reanalyze", label: "Analysera (AI)", icon: <span aria-hidden>🧠</span>, onSelect: onReanalyze, disabled: isDisabled || reanalyzePending, title: uploadingTitle ?? "Kör AI-analys på nytt" },
+    { key: "delete", label: "Ta bort", icon: <Trash2 size={15} />, onSelect: onDelete, danger: true, disabled: isDisabled, ...(uploadingTitle !== undefined ? { title: uploadingTitle } : {}) },
   ];
 
-  return <ActionMenu items={items} disabled={disabled} label="Dokumentåtgärder" />;
+  return <ActionMenu items={items} disabled={isDisabled} label="Dokumentåtgärder" />;
 }
 
 // readFromFsa flyttad till `@/lib/client/fsa/read-from-fsa` (delas med
@@ -250,10 +251,11 @@ function DocumentNameButton({ doc, isAnalyzing, disabled, onExternalEdit }: Name
     const { openDocument } = await import("@/lib/client/firma/open-document");
     const { loadHandle } = await import("@/lib/client/fsa/handle-store");
     const rec = doc as DocumentRecord & { storagePath?: string };
+    const demoRepo = process.env.NEXT_PUBLIC_DEFAULT_DEMO_REPO;
     await openDocument({
-      doc: { id: doc.id, storagePath: rec.storagePath, fileName: doc.fileName },
+      doc: { id: doc.id, ...(rec.storagePath !== undefined ? { storagePath: rec.storagePath } : {}), fileName: doc.fileName },
       isDemo,
-      demoRepo: process.env.NEXT_PUBLIC_DEFAULT_DEMO_REPO,
+      ...(demoRepo !== undefined ? { demoRepo } : {}),
       loadHandle: () => loadHandle("repo-root"),
       readFromHandle: readFromFsa,
       openUrl: (u) => window.open(u, "_blank", "noopener,noreferrer"),

--- a/src/components/documents/_document-row.tsx
+++ b/src/components/documents/_document-row.tsx
@@ -6,6 +6,8 @@ import { formatFileSize } from "./_drag-helpers";
 import { readFromFsa } from "@/lib/client/fsa/read-from-fsa";
 import { ExternalEditModal, type ModalState } from "./external-edit-modal";
 import { ActionMenu, type ActionMenuItem } from "@/components/ui/action-menu";
+import type { OpenDocumentDeps } from "@/lib/client/firma/open-document";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 
 export interface DocumentRecord {
   id: string;
@@ -212,7 +214,7 @@ function DocumentActions({
     { key: "view", label: "Visa", icon: <span aria-hidden>👁</span>, href: viewHref, newTab: true, disabled: isDisabled, title: uploadingTitle ?? "Visa i webbläsaren" },
     { key: "download", label: "Ladda ner", icon: <span aria-hidden>⬇</span>, href: downloadHref, download: true, disabled: isDisabled, title: uploadingTitle ?? "Ladda ner" },
     { key: "reanalyze", label: "Analysera (AI)", icon: <span aria-hidden>🧠</span>, onSelect: onReanalyze, disabled: isDisabled || reanalyzePending, title: uploadingTitle ?? "Kör AI-analys på nytt" },
-    { key: "delete", label: "Ta bort", icon: <Trash2 size={15} />, onSelect: onDelete, danger: true, disabled: isDisabled, ...(uploadingTitle !== undefined ? { title: uploadingTitle } : {}) },
+    omitUndefined({ key: "delete", label: "Ta bort", icon: <Trash2 size={15} />, onSelect: onDelete, danger: true, disabled: isDisabled, title: uploadingTitle }) as ActionMenuItem,
   ];
 
   return <ActionMenu items={items} disabled={isDisabled} label="Dokumentåtgärder" />;
@@ -252,15 +254,16 @@ function DocumentNameButton({ doc, isAnalyzing, disabled, onExternalEdit }: Name
     const { loadHandle } = await import("@/lib/client/fsa/handle-store");
     const rec = doc as DocumentRecord & { storagePath?: string };
     const demoRepo = process.env.NEXT_PUBLIC_DEFAULT_DEMO_REPO;
-    await openDocument({
-      doc: { id: doc.id, ...(rec.storagePath !== undefined ? { storagePath: rec.storagePath } : {}), fileName: doc.fileName },
+    const deps: OpenDocumentDeps = {
+      doc: omitUndefined({ id: doc.id, storagePath: rec.storagePath, fileName: doc.fileName }) as OpenDocumentDeps["doc"],
       isDemo,
-      ...(demoRepo !== undefined ? { demoRepo } : {}),
       loadHandle: () => loadHandle("repo-root"),
       readFromHandle: readFromFsa,
       openUrl: (u) => window.open(u, "_blank", "noopener,noreferrer"),
       notifyError: (m) => alert(m),
-    });
+      ...omitUndefined({ demoRepo }),
+    };
+    await openDocument(deps);
   };
 
   return (

--- a/src/components/settings/firma-settings-panel.tsx
+++ b/src/components/settings/firma-settings-panel.tsx
@@ -64,8 +64,8 @@ export function FirmaSettingsPanel({ initial, onSaved, onCancel, inline = false,
       tier, repo, token,
       organizationId: orgId,
       authorName: name, authorEmail: email,
-      corsProxy: corsProxy.trim() || undefined,
-      gitUsername: gitUsername.trim() || undefined,
+      ...(corsProxy.trim() ? { corsProxy: corsProxy.trim() } : {}),
+      ...(gitUsername.trim() ? { gitUsername: gitUsername.trim() } : {}),
     });
     saveAuthSettings({ allowAnonymousRead });
     saveOAuthConfig(oauth);
@@ -78,8 +78,8 @@ export function FirmaSettingsPanel({ initial, onSaved, onCancel, inline = false,
       tier, repo, token: "",
       organizationId: orgId,
       authorName: name, authorEmail: email,
-      corsProxy: corsProxy.trim() || undefined,
-      gitUsername: gitUsername.trim() || undefined,
+      ...(corsProxy.trim() ? { corsProxy: corsProxy.trim() } : {}),
+      ...(gitUsername.trim() ? { gitUsername: gitUsername.trim() } : {}),
     });
     onSaved();
   };

--- a/src/components/settings/fsa-folder-selector.tsx
+++ b/src/components/settings/fsa-folder-selector.tsx
@@ -127,7 +127,7 @@ export function FsaFolderSelector({ repoUrl, token }: { repoUrl: string; token: 
         h = picked;
       }
       const fs = new FsaIsoGitAdapter(h);
-      await cloneRepo(fs, { url: githubize(repoUrl), token: token || undefined });
+      await cloneRepo(fs, { url: githubize(repoUrl), ...(token ? { token } : {}) });
       await saveHandle(HANDLE_KEY, h);
       setHandle(h);
       setHasGit(true);

--- a/src/components/shell/demo-bootstrap.tsx
+++ b/src/components/shell/demo-bootstrap.tsx
@@ -24,6 +24,7 @@ import { demoSourceFromRuntime } from "@/lib/client/demo/demo-source-from-runtim
 import { demoCacheKey } from "@/lib/client/demo/demo-cache-key";
 import { trpc } from "@/lib/client/trpc";
 import { loadFirmaConfig, gitAuthUsername, type FirmaConfig } from "@/lib/client/firma/firma-config";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { AuthProvider, useAuthMode } from "@/lib/client/auth/use-auth-mode";
 import { AuthStatusBanner } from "./auth-status-banner";
 import { AutoSync } from "./auto-sync";
@@ -496,7 +497,7 @@ async function loadSelfHosted(
       repo: firmaConfig.repo,
       token: firmaConfig.token,
       username: gitAuthUsername(firmaConfig),
-      ...(origin !== undefined ? { origin } : {}),
+      ...omitUndefined({ origin }),
       // Måste matcha trpcClient-användaren nedan (id "current-user") så att
       // flöden som slår upp ctx.user (timeEntry.create m.fl.) hittar en rad.
       currentUser: {

--- a/src/components/shell/demo-bootstrap.tsx
+++ b/src/components/shell/demo-bootstrap.tsx
@@ -496,7 +496,7 @@ async function loadSelfHosted(
       repo: firmaConfig.repo,
       token: firmaConfig.token,
       username: gitAuthUsername(firmaConfig),
-      origin,
+      ...(origin !== undefined ? { origin } : {}),
       // Måste matcha trpcClient-användaren nedan (id "current-user") så att
       // flöden som slår upp ctx.user (timeEntry.create m.fl.) hittar en rad.
       currentUser: {

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -63,16 +63,18 @@ export function isGroupable<T>(col: Column<T>): boolean {
 }
 
 export interface DataTablePrefs {
-  sortBy?: string;
-  sortDir?: SortDir;
+  // Fälten får genuint vara explicit `undefined`: `update`/`patch` nollställer
+  // en pref genom att sätta nyckeln till `undefined` (se kommentar vid `update`).
+  sortBy?: string | undefined;
+  sortDir?: SortDir | undefined;
   /** Synlig kolumn-ordning. Saknade kolumner appendas i komponent-defaultordning. */
-  order?: string[];
+  order?: string[] | undefined;
   /** Per-kolumn-överrides. */
-  columns?: Array<{ key: string; width?: number; hidden?: boolean }>;
+  columns?: Array<{ key: string; width?: number; hidden?: boolean }> | undefined;
   /** Per-kolumn-key filter-text (case-insensitive substring-match). */
-  filters?: Record<string, string>;
+  filters?: Record<string, string> | undefined;
   /** Kolumn-key att gruppera på. Hela tabellen presenteras då i sektioner. */
-  groupBy?: string;
+  groupBy?: string | undefined;
 }
 
 type FooterFn<T> = (rows: T[]) => Partial<Record<string, React.ReactNode>>;
@@ -236,7 +238,9 @@ export function DataTable<T>({ prefKey, columns, data, rowKey, onRowClick, empty
     if (saveTimer.current) clearTimeout(saveTimer.current);
     saveTimer.current = setTimeout(() => save.mutate({ key: prefKey, prefs: next as Record<string, unknown> }), 400);
   };
-  const update = (patch: Partial<DataTablePrefs>): void => {
+  // Patch tillåter explicit `undefined` per nyckel — det är så vi RENSAR
+  // en pref (spread `{ ...cur, key: undefined }` nollställer fältet).
+  const update = (patch: { [K in keyof DataTablePrefs]?: DataTablePrefs[K] | undefined }): void => {
     setLocalPrefs((cur) => {
       const next = { ...(cur ?? remote), ...patch };
       persist(next);
@@ -311,7 +315,7 @@ interface AutoFooterProps<T> {
   vCols: Column<T>[];
   prefs: DataTablePrefs;
   filtered: T[];
-  footer?: FooterFn<T>;
+  footer?: FooterFn<T> | undefined;
 }
 
 function AutoFooter<T>({ columns, vCols, prefs, filtered, footer }: AutoFooterProps<T>) {
@@ -473,8 +477,8 @@ interface BodyProps<T> {
   vCols: Column<T>[];
   prefs: DataTablePrefs;
   rowKey: (row: T) => string;
-  onRowClick?: (row: T) => void;
-  emptyMessage?: string;
+  onRowClick?: ((row: T) => void) | undefined;
+  emptyMessage?: string | undefined;
   columns: Column<T>[];
 }
 
@@ -509,7 +513,7 @@ interface GroupBlockProps<T> {
   vCols: Column<T>[];
   prefs: DataTablePrefs;
   rowKey: (row: T) => string;
-  onRowClick?: (row: T) => void;
+  onRowClick?: ((row: T) => void) | undefined;
   showSummary: boolean;
   columns: Column<T>[];
 }
@@ -648,7 +652,7 @@ function DataTableHeader<T>({ vCols, prefs, update }: HeaderProps<T>) {
 interface HeaderCellProps<T> {
   col: Column<T>;
   prefs: DataTablePrefs;
-  width?: number;
+  width?: number | undefined;
   actions: HeaderActions;
 }
 
@@ -795,7 +799,7 @@ function Separator() {
   return <div className="my-1 border-t border-gray-100" />;
 }
 
-function ResizeHandle({ width, onResize }: { width?: number; onResize: (width: number) => void }) {
+function ResizeHandle({ width, onResize }: { width?: number | undefined; onResize: (width: number) => void }) {
   const onMouseDown = (e: React.MouseEvent): void => {
     e.preventDefault();
     const startX = e.clientX;

--- a/src/lib/client/demo/demo-meta.ts
+++ b/src/lib/client/demo/demo-meta.ts
@@ -94,6 +94,6 @@ function validateUser(raw: unknown, url: string, idx: number): DemoMetaUser {
     name: u.name,
     email: typeof u.email === "string" ? u.email : "",
     role: u.role as "ADMIN" | "LAWYER" | "ASSISTANT",
-    title: typeof u.title === "string" ? u.title : undefined,
+    ...(typeof u.title === "string" ? { title: u.title } : {}),
   };
 }

--- a/src/lib/client/diagnostics/index.ts
+++ b/src/lib/client/diagnostics/index.ts
@@ -16,6 +16,7 @@ import { detectDomAnomalies } from "./dom-anomalies";
 import { buildIssueReport, githubIssueNewUrl, type IssueReport } from "./report";
 import { parseRepoLocator, type RepoLocator } from "@/lib/client/github/api";
 import type { InvariantViolation } from "@/lib/shared/diagnostics/invariants";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 
 /** App-wide console-/fel-ringbuffert. */
 export const logBuffer = new LogBuffer(300);
@@ -59,7 +60,7 @@ export const DEFAULT_LOG_LINES = 50;
 export function buildSessionReport(opts: { userText?: string; includeLogs?: boolean; maxLogs?: number }): IssueReport {
   const includeLogs = opts.includeLogs ?? true;
   return buildIssueReport({
-    ...(opts.userText !== undefined ? { userText: opts.userText } : {}),
+    ...omitUndefined({ userText: opts.userText }),
     violations: issueStore.list(),
     logs: includeLogs ? logBuffer.recent(opts.maxLogs ?? DEFAULT_LOG_LINES) : [],
     meta: collectMeta(),

--- a/src/lib/client/diagnostics/index.ts
+++ b/src/lib/client/diagnostics/index.ts
@@ -59,7 +59,7 @@ export const DEFAULT_LOG_LINES = 50;
 export function buildSessionReport(opts: { userText?: string; includeLogs?: boolean; maxLogs?: number }): IssueReport {
   const includeLogs = opts.includeLogs ?? true;
   return buildIssueReport({
-    userText: opts.userText,
+    ...(opts.userText !== undefined ? { userText: opts.userText } : {}),
     violations: issueStore.list(),
     logs: includeLogs ? logBuffer.recent(opts.maxLogs ?? DEFAULT_LOG_LINES) : [],
     meta: collectMeta(),

--- a/src/lib/client/diagnostics/use-matter-invariants.ts
+++ b/src/lib/client/diagnostics/use-matter-invariants.ts
@@ -25,7 +25,12 @@ export function useMatterInvariants(input: { matterId: string; matterNumber?: st
   useEffect(() => {
     if (!runRows || !docRows) return;
     reportSelfDetected(
-      detectMatterInvariants({ matterId, matterNumber, billingRuns: runRows, documents: docRows }),
+      detectMatterInvariants({
+        matterId,
+        ...(matterNumber !== undefined ? { matterNumber } : {}),
+        billingRuns: runRows,
+        documents: docRows,
+      }),
     );
   }, [matterId, matterNumber, runRows, docRows]);
 }

--- a/src/lib/client/diagnostics/use-matter-invariants.ts
+++ b/src/lib/client/diagnostics/use-matter-invariants.ts
@@ -13,6 +13,7 @@ import { useEffect } from "react";
 import { trpc } from "@/lib/client/trpc";
 import { detectMatterInvariants, type BillingRunView, type DocumentView } from "@/lib/shared/diagnostics/invariants";
 import { reportSelfDetected } from "@/lib/client/diagnostics";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 
 export function useMatterInvariants(input: { matterId: string; matterNumber?: string }): void {
   const { matterId, matterNumber } = input;
@@ -27,7 +28,7 @@ export function useMatterInvariants(input: { matterId: string; matterNumber?: st
     reportSelfDetected(
       detectMatterInvariants({
         matterId,
-        ...(matterNumber !== undefined ? { matterNumber } : {}),
+        ...omitUndefined({ matterNumber }),
         billingRuns: runRows,
         documents: docRows,
       }),

--- a/src/lib/client/firma/load-self-hosted-source.ts
+++ b/src/lib/client/firma/load-self-hosted-source.ts
@@ -63,11 +63,14 @@ export async function loadSelfHostedSource(deps: LoadSelfHostedDeps): Promise<De
   const dirExists = deps.dirExists ?? defaultDirExists;
 
   if (!(await dirExists(fs, "/.git"))) {
-    const corsProxy = resolveCorsProxy({ url: deps.repo, origin: deps.origin });
+    const corsProxy = resolveCorsProxy({
+      url: deps.repo,
+      ...(deps.origin !== undefined ? { origin: deps.origin } : {}),
+    });
     await (deps.clone ?? cloneRepo)(fs, {
       url: deps.repo,
-      token: deps.token,
-      username: deps.username,
+      ...(deps.token !== undefined ? { token: deps.token } : {}),
+      ...(deps.username !== undefined ? { username: deps.username } : {}),
       corsProxy,
       ref: "main",
     });

--- a/src/lib/client/firma/load-self-hosted-source.ts
+++ b/src/lib/client/firma/load-self-hosted-source.ts
@@ -19,6 +19,7 @@ import { resolveCorsProxy } from "@/lib/client/sync/cors-proxy";
 import { hydrateWorkingCopy } from "./hydrate-working-copy";
 import { setDocumentContent } from "@/lib/client/demo/document-content-cache";
 import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 
 export interface CurrentUser {
   id: string;
@@ -65,12 +66,11 @@ export async function loadSelfHostedSource(deps: LoadSelfHostedDeps): Promise<De
   if (!(await dirExists(fs, "/.git"))) {
     const corsProxy = resolveCorsProxy({
       url: deps.repo,
-      ...(deps.origin !== undefined ? { origin: deps.origin } : {}),
+      ...omitUndefined({ origin: deps.origin }),
     });
     await (deps.clone ?? cloneRepo)(fs, {
       url: deps.repo,
-      ...(deps.token !== undefined ? { token: deps.token } : {}),
-      ...(deps.username !== undefined ? { username: deps.username } : {}),
+      ...omitUndefined({ token: deps.token, username: deps.username }),
       corsProxy,
       ref: "main",
     });

--- a/src/lib/client/firma/open-document-externally.ts
+++ b/src/lib/client/firma/open-document-externally.ts
@@ -20,6 +20,7 @@
 
 import type { ModalState } from "@/components/documents/external-edit-modal";
 import { openViaHelper } from "@/lib/client/helper/use-helper";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 
 interface Doc {
   id: string;
@@ -63,7 +64,7 @@ export async function tryHelperOpen(doc: Doc): Promise<boolean> {
     await openViaHelper({
       fileName: doc.fileName,
       downloadUrl: absDownload,
-      ...(uploadUrl !== undefined ? { uploadUrl } : {}),
+      ...omitUndefined({ uploadUrl }),
     });
     return true;
   } catch (err) {
@@ -91,9 +92,7 @@ export async function runExternalEdit(doc: Doc): Promise<ModalState> {
       })()
     : undefined;
 
-  const r = await openInFinder(doc.storagePath, {
-    ...(fallbackBase !== undefined ? { downloadFallbackBase: fallbackBase } : {}),
-  });
+  const r = await openInFinder(doc.storagePath, omitUndefined({ downloadFallbackBase: fallbackBase }));
   if (r.kind === "unsupported") {
     return { kind: "error", title: "Browser stödjer inte File System Access",
       message: "Din webbläsare stödjer inte File System Access API. Använd Chrome eller Edge på desktop." };

--- a/src/lib/client/firma/open-document-externally.ts
+++ b/src/lib/client/firma/open-document-externally.ts
@@ -63,7 +63,7 @@ export async function tryHelperOpen(doc: Doc): Promise<boolean> {
     await openViaHelper({
       fileName: doc.fileName,
       downloadUrl: absDownload,
-      uploadUrl,
+      ...(uploadUrl !== undefined ? { uploadUrl } : {}),
     });
     return true;
   } catch (err) {
@@ -91,7 +91,9 @@ export async function runExternalEdit(doc: Doc): Promise<ModalState> {
       })()
     : undefined;
 
-  const r = await openInFinder(doc.storagePath, { downloadFallbackBase: fallbackBase });
+  const r = await openInFinder(doc.storagePath, {
+    ...(fallbackBase !== undefined ? { downloadFallbackBase: fallbackBase } : {}),
+  });
   if (r.kind === "unsupported") {
     return { kind: "error", title: "Browser stödjer inte File System Access",
       message: "Din webbläsare stödjer inte File System Access API. Använd Chrome eller Edge på desktop." };

--- a/src/lib/client/github/api.ts
+++ b/src/lib/client/github/api.ts
@@ -9,6 +9,8 @@
  * parallella blob-fetches, bara skapade objekt postas.
  */
 
+import { omitUndefined } from "@/lib/shared/omit-undefined";
+
 const API = "https://api.github.com";
 
 export interface RepoLocator {
@@ -55,7 +57,7 @@ export interface BlobData {
 async function apiFetch(path: string, init: RequestInit, opts: ApiOpts): Promise<Response> {
   const res = await fetch(`${API}${path}`, {
     ...init,
-    ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
+    ...omitUndefined({ signal: opts.signal }),
     headers: {
       ...(init.headers ?? {}),
       Authorization: `Bearer ${opts.token}`,

--- a/src/lib/client/github/api.ts
+++ b/src/lib/client/github/api.ts
@@ -55,7 +55,7 @@ export interface BlobData {
 async function apiFetch(path: string, init: RequestInit, opts: ApiOpts): Promise<Response> {
   const res = await fetch(`${API}${path}`, {
     ...init,
-    signal: opts.signal,
+    ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
     headers: {
       ...(init.headers ?? {}),
       Authorization: `Bearer ${opts.token}`,

--- a/src/lib/client/github/pull.ts
+++ b/src/lib/client/github/pull.ts
@@ -38,7 +38,7 @@ export interface PullResult {
 
 // eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Async function 'pullViaRest' has a complexity of 13. Maximum allowed is 8.)
 export async function pullViaRest(args: PullArgs): Promise<PullResult> {
-  const opts = { token: args.token, signal: args.signal };
+  const opts = { token: args.token, ...(args.signal !== undefined ? { signal: args.signal } : {}) };
   const state = await readSyncState(args.handle);
 
   const newHead = await getBranchHead(args.repo, args.branch, opts);

--- a/src/lib/client/github/push.ts
+++ b/src/lib/client/github/push.ts
@@ -41,7 +41,7 @@ export interface PushResult {
 
 // eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Async function 'pushViaRest' has a complexity of 12. Maximum allowed is 8.)
 export async function pushViaRest(args: PushArgs): Promise<PushResult> {
-  const opts = { token: args.token, signal: args.signal };
+  const opts = { token: args.token, ...(args.signal !== undefined ? { signal: args.signal } : {}) };
   const state = await readSyncState(args.handle);
   if (!state) {
     throw new Error("Saknar .ava/sync-state.json — gör en pull först innan push.");
@@ -92,8 +92,8 @@ export async function pushViaRest(args: PushArgs): Promise<PushResult> {
     message: args.message,
     tree: newTreeSha,
     parents: [state.lastHead],
-    signature: args.signature,
-    author: args.author,
+    ...(args.signature !== undefined ? { signature: args.signature } : {}),
+    ...(args.author !== undefined ? { author: args.author } : {}),
   }, opts);
 
   await updateRef(args.repo, args.branch, newCommitSha, opts);

--- a/src/lib/client/jobs/job-queue.ts
+++ b/src/lib/client/jobs/job-queue.ts
@@ -77,7 +77,7 @@ class JobQueueImpl {
     const job: Job = {
       id, kind, label,
       status: "queued",
-      payload,
+      ...(payload !== undefined ? { payload } : {}),
       enqueuedAt: Date.now(),
     };
     this.jobs.unshift(job);
@@ -106,10 +106,10 @@ class JobQueueImpl {
     const job = this.jobs.find((j) => j.id === id);
     if (!job || (job.status !== "failed" && job.status !== "canceled")) return;
     job.status = "queued";
-    job.error = undefined;
-    job.startedAt = undefined;
-    job.finishedAt = undefined;
-    job.progress = undefined;
+    delete job.error;
+    delete job.startedAt;
+    delete job.finishedAt;
+    delete job.progress;
     this.notify();
     void this.pump();
   }

--- a/src/lib/client/jobs/job-queue.ts
+++ b/src/lib/client/jobs/job-queue.ts
@@ -25,6 +25,8 @@
  *      synlighet, äldre dropps.
  */
 
+import { omitUndefined } from "@/lib/shared/omit-undefined";
+
 export type JobKind =
   | "classify-document"
   | "extract-text"
@@ -77,7 +79,7 @@ class JobQueueImpl {
     const job: Job = {
       id, kind, label,
       status: "queued",
-      ...(payload !== undefined ? { payload } : {}),
+      ...omitUndefined({ payload }),
       enqueuedAt: Date.now(),
     };
     this.jobs.unshift(job);

--- a/src/lib/client/jobs/register-workers.ts
+++ b/src/lib/client/jobs/register-workers.ts
@@ -67,7 +67,7 @@ jobQueue.registerWorker<MirrorPayload>("mirror-to-outlook", async (payload, ctx)
   try {
     if (payload.op === "delete") {
       if (payload.outlookEventId) {
-        await graph.deleteGraphEvent(payload.outlookEventId, { token, calendarId: payload.outlookCalendarId ?? undefined });
+        await graph.deleteGraphEvent(payload.outlookEventId, { token, ...(payload.outlookCalendarId != null ? { calendarId: payload.outlookCalendarId } : {}) });
       }
       // Vid delete på AVA-eventet finns ingen rad att uppdatera — workern
       // slutar bara här. (Calendar-routerns delete tar bort raden helt.)
@@ -79,10 +79,10 @@ jobQueue.registerWorker<MirrorPayload>("mirror-to-outlook", async (payload, ctx)
     const body = graph.toGraphEvent({ ...payload.event });
     let outlookEventId: string;
     if (payload.outlookEventId) {
-      const res = await graph.updateGraphEvent(payload.outlookEventId, body, { token, calendarId: payload.outlookCalendarId ?? undefined });
+      const res = await graph.updateGraphEvent(payload.outlookEventId, body, { token, ...(payload.outlookCalendarId != null ? { calendarId: payload.outlookCalendarId } : {}) });
       outlookEventId = res.id;
     } else {
-      const res = await graph.createGraphEvent(body, { token, calendarId: payload.outlookCalendarId ?? undefined });
+      const res = await graph.createGraphEvent(body, { token, ...(payload.outlookCalendarId != null ? { calendarId: payload.outlookCalendarId } : {}) });
       outlookEventId = res.id;
     }
     ctx.setProgress(0.9);
@@ -136,7 +136,7 @@ jobQueue.registerWorker<ExtractTextPayload>("extract-text", async (payload, ctx)
   // Steg 2: extrahera text
   ctx.setProgress(0.4);
   const { extractText } = await import("@/lib/client/jobs/extract-text");
-  const text = await extractText({ bytes, mimeType: payload.mimeType, fileName: payload.fileName });
+  const text = await extractText({ bytes, ...(payload.mimeType !== undefined ? { mimeType: payload.mimeType } : {}), fileName: payload.fileName });
 
   // Steg 3: skriv till documents/text/<id>.txt och cache:a för sök
   ctx.setProgress(0.8);

--- a/src/lib/client/jobs/register-workers.ts
+++ b/src/lib/client/jobs/register-workers.ts
@@ -10,6 +10,7 @@
  */
 
 import { jobQueue } from "./job-queue";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 
 interface ClassifyPayload extends Record<string, unknown> {
   documentId: string;
@@ -136,7 +137,7 @@ jobQueue.registerWorker<ExtractTextPayload>("extract-text", async (payload, ctx)
   // Steg 2: extrahera text
   ctx.setProgress(0.4);
   const { extractText } = await import("@/lib/client/jobs/extract-text");
-  const text = await extractText({ bytes, ...(payload.mimeType !== undefined ? { mimeType: payload.mimeType } : {}), fileName: payload.fileName });
+  const text = await extractText({ bytes, ...omitUndefined({ mimeType: payload.mimeType }), fileName: payload.fileName });
 
   // Steg 3: skriv till documents/text/<id>.txt och cache:a för sök
   ctx.setProgress(0.8);

--- a/src/lib/client/register-service-worker.ts
+++ b/src/lib/client/register-service-worker.ts
@@ -26,7 +26,7 @@ export async function registerServiceWorker(swUrl: string): Promise<RegisterResu
 
   try {
     const reg = await nav.serviceWorker.register(swUrl, { scope: "/" });
-    return { status: "registered", scope: reg.scope };
+    return { status: "registered", ...(reg.scope !== undefined ? { scope: reg.scope } : {}) };
   } catch (err) {
     console.warn("[sw] registrering misslyckades:", err);
     return {

--- a/src/lib/client/register-service-worker.ts
+++ b/src/lib/client/register-service-worker.ts
@@ -9,6 +9,8 @@
  *   - Felsäker: SSR / unsupported browsers / HTTPS-fel sväljs tyst.
  */
 
+import { omitUndefined } from "@/lib/shared/omit-undefined";
+
 export type RegisterStatus = "unsupported" | "registered" | "failed";
 
 export interface RegisterResult {
@@ -26,7 +28,7 @@ export async function registerServiceWorker(swUrl: string): Promise<RegisterResu
 
   try {
     const reg = await nav.serviceWorker.register(swUrl, { scope: "/" });
-    return { status: "registered", ...(reg.scope !== undefined ? { scope: reg.scope } : {}) };
+    return { status: "registered", ...omitUndefined({ scope: reg.scope }) };
   } catch (err) {
     console.warn("[sw] registrering misslyckades:", err);
     return {

--- a/src/lib/client/sync/cors-proxy.ts
+++ b/src/lib/client/sync/cors-proxy.ts
@@ -34,7 +34,7 @@ export function isLocalOrSameOrigin(url: string, origin?: string): boolean {
  */
 export function resolveCorsProxy(opts: {
   url: string;
-  configured?: string;
+  configured?: string | undefined;
   origin?: string;
 }): string {
   if (isLocalOrSameOrigin(opts.url, opts.origin)) return "";

--- a/src/lib/client/sync/pick-provider.ts
+++ b/src/lib/client/sync/pick-provider.ts
@@ -128,7 +128,7 @@ function makeFsaProvider(handle: FileSystemDirectoryHandle, token: string, corsP
     const oid = await stageAllAndCommit(fs, {
       message: `AVA: ${entries.length} ändring${entries.length === 1 ? "" : "ar"} ${new Date().toISOString().slice(0, 10)}`,
       authorName: "AVA User", authorEmail: "user@ava.local",
-      sshSigning,
+      ...(sshSigning !== undefined ? { sshSigning } : {}),
     });
     return { oid };
   };
@@ -136,7 +136,7 @@ function makeFsaProvider(handle: FileSystemDirectoryHandle, token: string, corsP
     const { FsaIsoGitAdapter } = await import("@/lib/client/fsa/fs-adapter");
     const { pushBranch } = await import("@/lib/client/fsa/git-ops");
     const fs = new FsaIsoGitAdapter(handle);
-    await pushBranch(fs, { token, username, corsProxy });
+    await pushBranch(fs, { token, ...(username !== undefined ? { username } : {}), ...(corsProxy !== undefined ? { corsProxy } : {}) });
   };
   return {
     pull: async () => {
@@ -144,8 +144,8 @@ function makeFsaProvider(handle: FileSystemDirectoryHandle, token: string, corsP
       const { pullBranch } = await import("@/lib/client/fsa/git-ops");
       const fs = new FsaIsoGitAdapter(handle);
       const r = await pullBranch(fs, {
-        token, username, authorName: "AVA User", authorEmail: "user@ava.local",
-        corsProxy,
+        token, ...(username !== undefined ? { username } : {}), authorName: "AVA User", authorEmail: "user@ava.local",
+        ...(corsProxy !== undefined ? { corsProxy } : {}),
       });
       return { kind: r.kind };
     },

--- a/src/lib/server/data-store/DemoDataStore.ts
+++ b/src/lib/server/data-store/DemoDataStore.ts
@@ -20,7 +20,8 @@
  */
 
 import { ReadOnlyDelegate, ReadOnlyError, type RelationConfig } from "./in-memory/read-only-delegate";
-import { WritableDelegate, type MutationEvent } from "./in-memory/writable-delegate";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
+import { WritableDelegate, type MutationEvent, type WritableDelegateOpts } from "./in-memory/writable-delegate";
 import type {
   IDataStore,
   IEventLog,
@@ -265,12 +266,13 @@ export class DemoDataStore implements IDataStore {
     kind: "one" | "many" = "many",
     relations?: Record<string, RelationConfig<Record<string, unknown>>>,
   ): RelationConfig<Record<string, unknown>> {
-    return {
+    const cfg = omitUndefined({
       kind,
       collection: () => (this.source[key] ?? []) as readonly Record<string, unknown>[],
-      where: (p) => ({ [childField]: (p as Record<string, unknown>)[parentField] }),
-      ...(relations !== undefined ? { relations } : {}),
-    };
+      where: (p: Record<string, unknown>) => ({ [childField]: p[parentField] }),
+      relations,
+    });
+    return cfg as RelationConfig<Record<string, unknown>>;
   }
 
   private makeDelegate<T extends Record<string, unknown>>(
@@ -280,7 +282,7 @@ export class DemoDataStore implements IDataStore {
     if (this.onMutate) {
       // Mutable mode — getter ser till att vi alltid pekar på senaste
       // source-arrayen även när mergeSource bytt ut referensen.
-      return new WritableDelegate<T>({
+      const opts = omitUndefined({
         entity: this.entityNameFor(key),
         collection: () => {
           if (!this.source[key]) {
@@ -288,13 +290,14 @@ export class DemoDataStore implements IDataStore {
           }
           return (this.source[key] ?? []) as unknown as T[];
         },
-        ...(relations !== undefined ? { relations } : {}),
+        relations,
         // Routa via handleMutate så att event buffras under en transaction()
         // och flushas först vid commit (annars skulle en felad transaktion
         // skriva halva ändringar till git-db:n).
-        onMutate: (e) => this.handleMutate(e as MutationEvent<Record<string, unknown>>),
-        enrichRow: (row) => this.enrichRowForEntity(key, row) as T,
+        onMutate: (e: MutationEvent<T>) => this.handleMutate(e as MutationEvent<Record<string, unknown>>),
+        enrichRow: (row: T) => this.enrichRowForEntity(key, row) as T,
       });
+      return new WritableDelegate<T>(opts as WritableDelegateOpts<T>);
     }
     return new ReadOnlyDelegate<T>(
       () => (this.source[key] ?? []) as readonly T[],

--- a/src/lib/server/data-store/DemoDataStore.ts
+++ b/src/lib/server/data-store/DemoDataStore.ts
@@ -269,7 +269,7 @@ export class DemoDataStore implements IDataStore {
       kind,
       collection: () => (this.source[key] ?? []) as readonly Record<string, unknown>[],
       where: (p) => ({ [childField]: (p as Record<string, unknown>)[parentField] }),
-      relations,
+      ...(relations !== undefined ? { relations } : {}),
     };
   }
 
@@ -288,7 +288,7 @@ export class DemoDataStore implements IDataStore {
           }
           return (this.source[key] ?? []) as unknown as T[];
         },
-        relations,
+        ...(relations !== undefined ? { relations } : {}),
         // Routa via handleMutate så att event buffras under en transaction()
         // och flushas först vid commit (annars skulle en felad transaktion
         // skriva halva ändringar till git-db:n).

--- a/src/lib/server/data-store/in-memory/read-only-delegate.ts
+++ b/src/lib/server/data-store/in-memory/read-only-delegate.ts
@@ -18,6 +18,7 @@
  */
 
 import { InMemoryQueryEngine, type QueryOptions } from "./query-engine";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 
 export class ReadOnlyError extends Error {
   constructor(operation: string) {
@@ -134,11 +135,11 @@ export class ReadOnlyDelegate<T extends Record<string, unknown>> {
   /** Filtrera (med relations-prehydrering) → sortera/paginera. */
   private queryRows(args: FindArgs): T[] {
     const filtered = this.filterRows(this.rowsFn(), args.where);
-    return this.engine.query(filtered, {
-      ...(args.orderBy !== undefined ? { orderBy: args.orderBy } : {}),
-      ...(args.skip !== undefined ? { skip: args.skip } : {}),
-      ...(args.take !== undefined ? { take: args.take } : {}),
-    });
+    return this.engine.query(filtered, omitUndefined({
+      orderBy: args.orderBy,
+      skip: args.skip,
+      take: args.take,
+    }));
   }
 
   /**

--- a/src/lib/server/data-store/in-memory/read-only-delegate.ts
+++ b/src/lib/server/data-store/in-memory/read-only-delegate.ts
@@ -135,7 +135,9 @@ export class ReadOnlyDelegate<T extends Record<string, unknown>> {
   private queryRows(args: FindArgs): T[] {
     const filtered = this.filterRows(this.rowsFn(), args.where);
     return this.engine.query(filtered, {
-      orderBy: args.orderBy, skip: args.skip, take: args.take,
+      ...(args.orderBy !== undefined ? { orderBy: args.orderBy } : {}),
+      ...(args.skip !== undefined ? { skip: args.skip } : {}),
+      ...(args.take !== undefined ? { take: args.take } : {}),
     });
   }
 

--- a/src/lib/server/data-store/in-memory/writable-delegate.ts
+++ b/src/lib/server/data-store/in-memory/writable-delegate.ts
@@ -56,7 +56,7 @@ function genId(): string {
 
 export class WritableDelegate<T extends Record<string, unknown>> extends ReadOnlyDelegate<T> {
   constructor(private wopts: WritableDelegateOpts<T>) {
-    super(() => wopts.collection() as readonly T[], { relations: wopts.relations });
+    super(() => wopts.collection() as readonly T[], wopts.relations !== undefined ? { relations: wopts.relations } : {});
   }
 
   /** Aktuell array — hämtas på begäran så DataStore kan byta ut den. */
@@ -106,7 +106,7 @@ export class WritableDelegate<T extends Record<string, unknown>> extends ReadOnl
 
   override async updateMany(args: unknown): Promise<never> {
     const a = args as { where?: Record<string, unknown>; data: Partial<T> };
-    const matches = await this.findMany({ where: a.where });
+    const matches = await this.findMany(a.where !== undefined ? { where: a.where } : {});
     let count = 0;
     for (const m of matches) {
       await this.update({ where: { id: (m as unknown as { id: string }).id }, data: a.data });
@@ -117,7 +117,7 @@ export class WritableDelegate<T extends Record<string, unknown>> extends ReadOnl
 
   override async deleteMany(args: unknown): Promise<never> {
     const a = args as { where?: Record<string, unknown> };
-    const matches = await this.findMany({ where: a.where });
+    const matches = await this.findMany(a.where !== undefined ? { where: a.where } : {});
     let count = 0;
     for (const m of matches) {
       await this.delete({ where: { id: (m as unknown as { id: string }).id } });

--- a/src/lib/server/routers/calendar.ts
+++ b/src/lib/server/routers/calendar.ts
@@ -71,8 +71,8 @@ const updateInput = z.object({
  *     (mirrorStatus="pending")
  *   - oförändrat: tomt patch
  */
-type UpdateData = Record<string, unknown> & { mirrorToOutlook?: boolean };
-type ExistingEvent = { mirrorToOutlook?: boolean };
+type UpdateData = Record<string, unknown> & { mirrorToOutlook?: boolean | undefined };
+type ExistingEvent = { mirrorToOutlook?: boolean | undefined };
 function computeMirrorPatch(data: UpdateData, existing: ExistingEvent): Record<string, unknown> {
   const newFlag = data.mirrorToOutlook;
   const oldFlag = existing.mirrorToOutlook ?? false;
@@ -166,13 +166,17 @@ export const calendarRouter = router({
   create: protectedProcedure
     .input(createInput)
     .mutation(async ({ ctx, input }) => {
+      // exactOptionalPropertyTypes: utelämna nycklar vars värde är undefined
+      // (förr droppades de ändå av create). null behålls (nullish-fält).
+      const cleanInput = Object.fromEntries(
+        Object.entries(input).filter(([, v]) => v !== undefined),
+      );
       return ctx.dataStore.calendarEvents.create({
         data: {
-          ...input,
+          ...cleanInput,
           userId: input.userId ?? asId<"UserId">(ctx.user.id),
           organizationId: asId<"OrganizationId">(ctx.user.organizationId),
           mirrorStatus: input.mirrorToOutlook ? "pending" : null,
-          createdAt: input.createdAt ?? undefined,
         },
       });
     }),
@@ -194,9 +198,15 @@ export const calendarRouter = router({
       const existing = await ctx.dataStore.calendarEvents.findFirstOrThrow({
         where: { id, userId: ctx.user.id, organizationId: ctx.user.organizationId },
       });
+      // exactOptionalPropertyTypes: utelämna nycklar vars värde är undefined
+      // i write-payloaden (förr droppades de ändå). `computeMirrorPatch` får
+      // dock det råa `data` så dess nyckel-räkning av "ändrade fält" bevaras.
+      const writeData = Object.fromEntries(
+        Object.entries(data).filter(([, v]) => v !== undefined),
+      );
       return ctx.dataStore.calendarEvents.update({
         where: { id },
-        data: { ...data, ...computeMirrorPatch(data, existing) },
+        data: { ...writeData, ...computeMirrorPatch(data, existing) },
       });
     }),
 

--- a/src/lib/server/routers/contact.ts
+++ b/src/lib/server/routers/contact.ts
@@ -3,6 +3,7 @@ import { router, orgProcedure, requireOrgOwned } from "../trpc";
 import { contactTypeSchema } from "@/lib/shared/schemas/enums";
 import { contactIdSchema, asId } from "@/lib/shared/schemas/ids";
 import { emit } from "../events/emit";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 
 export const contactRouter = router({
   list: orgProcedure
@@ -88,7 +89,7 @@ export const contactRouter = router({
     .mutation(async ({ ctx, input }) => {
       const contact = await ctx.dataStore.contacts.create({
         data: {
-          ...input,
+          ...omitUndefined(input),
           email: input.email || null,
           organizationId: asId<"OrganizationId">(ctx.orgId),
         },
@@ -121,7 +122,10 @@ export const contactRouter = router({
       const { id, ...data } = input;
       const updated = await ctx.dataStore.contacts.update({
         where: { id },
-        data: { ...data, email: data.email || null },
+        data: {
+          ...omitUndefined(data),
+          email: input.email || null,
+        },
       });
       await emit.contactUpdated(ctx, id, data);
       return updated;

--- a/src/lib/server/routers/document/core.ts
+++ b/src/lib/server/routers/document/core.ts
@@ -71,7 +71,7 @@ export const coreProcedures = {
     .query(async ({ ctx, input }) => {
       const result = await ctx.ports.searchIndex.search(
         input.query, ctx.orgId, input.limit,
-        { documentTypes: input.documentTypes },
+        { ...(input.documentTypes !== undefined ? { documentTypes: input.documentTypes } : {}) },
       );
       return {
         hits: result.hits.map((hit) => ({

--- a/src/lib/server/routers/document/core.ts
+++ b/src/lib/server/routers/document/core.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { orgProcedure } from "../../trpc";
 import { isJunkFileName } from "@/lib/shared/junk-files";
 import { assertDocAccess } from "./shared";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 
 export const coreProcedures = {
   /** Paginerad lista över dokument + mappar i ett visst ärende/folder. */
@@ -71,7 +72,7 @@ export const coreProcedures = {
     .query(async ({ ctx, input }) => {
       const result = await ctx.ports.searchIndex.search(
         input.query, ctx.orgId, input.limit,
-        { ...(input.documentTypes !== undefined ? { documentTypes: input.documentTypes } : {}) },
+        omitUndefined({ documentTypes: input.documentTypes }),
       );
       return {
         hits: result.hits.map((hit) => ({
@@ -208,10 +209,18 @@ export const coreProcedures = {
       const { documentId, analyzedAt, analysisStatus, ...rest } = input;
       const data = {
         ...rest,
-        ...(analysisStatus !== undefined
-          ? { analysisStatus: analysisStatus as "PENDING" | "RUNNING" | "DONE" | "ERROR" | null }
-          : {}),
-        ...(analyzedAt !== undefined ? { analyzedAt: typeof analyzedAt === "string" ? new Date(analyzedAt) : analyzedAt } : {}),
+        ...omitUndefined({
+          analysisStatus:
+            analysisStatus === undefined
+              ? undefined
+              : (analysisStatus as "PENDING" | "RUNNING" | "DONE" | "ERROR" | null),
+          analyzedAt:
+            analyzedAt === undefined
+              ? undefined
+              : typeof analyzedAt === "string"
+                ? new Date(analyzedAt)
+                : analyzedAt,
+        }),
       };
       return ctx.dataStore.documents.update({ where: { id: documentId }, data });
     }),
@@ -240,7 +249,7 @@ export const coreProcedures = {
         data: {
           version: (doc.version ?? 1) + 1,
           updatedAt: new Date(),
-          ...(input.sizeBytes !== undefined ? { sizeBytes: input.sizeBytes, fileSize: input.sizeBytes } : {}),
+          ...omitUndefined({ sizeBytes: input.sizeBytes, fileSize: input.sizeBytes }),
         },
       });
     }),

--- a/src/lib/server/routers/document/suggestions.ts
+++ b/src/lib/server/routers/document/suggestions.ts
@@ -41,13 +41,13 @@ type Ctx = {
   orgId: string;
 };
 type SuggOverride = {
-  name?: string;
-  role?: string;
-  contactType?: string;
-  email?: string | null;
-  phone?: string | null;
-  orgNumber?: string | null;
-  personalNumber?: string | null;
+  name?: string | undefined;
+  role?: string | undefined;
+  contactType?: string | undefined;
+  email?: string | null | undefined;
+  phone?: string | null | undefined;
+  orgNumber?: string | null | undefined;
+  personalNumber?: string | null | undefined;
 };
 type Suggestion = {
   id: string;

--- a/src/lib/server/routers/documentTemplate.ts
+++ b/src/lib/server/routers/documentTemplate.ts
@@ -53,14 +53,14 @@ export const documentTemplateRouter = router({
     .mutation(async ({ ctx, input }) => {
       return ctx.dataStore.documentTemplates.create({
         data: {
-          id: input.id, // undefined → store genererar
+          ...(input.id !== undefined ? { id: input.id } : {}), // undefined → store genererar
           name: input.name,
-          description: input.description,
-          category: input.category,
+          ...(input.description !== undefined ? { description: input.description } : {}),
+          ...(input.category !== undefined ? { category: input.category } : {}),
           content: input.content,
           organizationId: asId<"OrganizationId">(ctx.user.organizationId),
           createdById: input.createdById ?? asId<"UserId">(ctx.user.id),
-          createdAt: input.createdAt ? new Date(input.createdAt) : undefined,
+          ...(input.createdAt ? { createdAt: new Date(input.createdAt) } : {}),
         },
       });
     }),
@@ -83,8 +83,16 @@ export const documentTemplateRouter = router({
       if (!existing || existing.organizationId !== ctx.user.organizationId) {
         throw new TRPCError({ code: "NOT_FOUND" });
       }
-      const { id, ...data } = input;
-      return ctx.dataStore.documentTemplates.update({ where: { id }, data });
+      const { id, name, description, category, content } = input;
+      return ctx.dataStore.documentTemplates.update({
+        where: { id },
+        data: {
+          ...(name !== undefined ? { name } : {}),
+          ...(description !== undefined ? { description } : {}),
+          ...(category !== undefined ? { category } : {}),
+          ...(content !== undefined ? { content } : {}),
+        },
+      });
     }),
 
   delete: protectedProcedure

--- a/src/lib/server/routers/documentTemplate.ts
+++ b/src/lib/server/routers/documentTemplate.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { router, protectedProcedure } from "../trpc";
 import { TRPCError } from "@trpc/server";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 import {
   asId,
   documentTemplateIdSchema,
@@ -53,13 +54,15 @@ export const documentTemplateRouter = router({
     .mutation(async ({ ctx, input }) => {
       return ctx.dataStore.documentTemplates.create({
         data: {
-          ...(input.id !== undefined ? { id: input.id } : {}), // undefined → store genererar
-          name: input.name,
-          ...(input.description !== undefined ? { description: input.description } : {}),
-          ...(input.category !== undefined ? { category: input.category } : {}),
-          content: input.content,
-          organizationId: asId<"OrganizationId">(ctx.user.organizationId),
-          createdById: input.createdById ?? asId<"UserId">(ctx.user.id),
+          ...omitUndefined({
+            id: input.id, // undefined → store genererar
+            name: input.name,
+            description: input.description,
+            category: input.category,
+            content: input.content,
+            organizationId: asId<"OrganizationId">(ctx.user.organizationId),
+            createdById: input.createdById ?? asId<"UserId">(ctx.user.id),
+          }),
           ...(input.createdAt ? { createdAt: new Date(input.createdAt) } : {}),
         },
       });
@@ -86,12 +89,7 @@ export const documentTemplateRouter = router({
       const { id, name, description, category, content } = input;
       return ctx.dataStore.documentTemplates.update({
         where: { id },
-        data: {
-          ...(name !== undefined ? { name } : {}),
-          ...(description !== undefined ? { description } : {}),
-          ...(category !== undefined ? { category } : {}),
-          ...(content !== undefined ? { content } : {}),
-        },
+        data: omitUndefined({ name, description, category, content }),
       });
     }),
 

--- a/src/lib/server/routers/expense.ts
+++ b/src/lib/server/routers/expense.ts
@@ -73,7 +73,7 @@ export const expenseRouter = router({
     .mutation(async ({ ctx, input }) => {
       return ctx.dataStore.expenses.create({
         data: {
-          id: input.id, // undefined → store genererar
+          ...(input.id !== undefined ? { id: input.id } : {}), // undefined → store genererar
           userId: input.userId ?? asId<"UserId">(ctx.user.id),
           matterId: input.matterId,
           date: new Date(input.date),
@@ -83,7 +83,7 @@ export const expenseRouter = router({
           vatRate: input.vatRate,
           vatIncluded: input.vatIncluded,
           invoiceId: input.invoiceId ?? null,
-          createdAt: input.createdAt ? new Date(input.createdAt) : undefined,
+          ...(input.createdAt ? { createdAt: new Date(input.createdAt) } : {}),
         },
       });
     }),
@@ -101,11 +101,15 @@ export const expenseRouter = router({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const { id, date, ...data } = input;
+      const { id, date, amount, description, billable, vatRate, vatIncluded } = input;
       return ctx.dataStore.expenses.update({
         where: { id },
         data: {
-          ...data,
+          ...(amount !== undefined ? { amount } : {}),
+          ...(description !== undefined ? { description } : {}),
+          ...(billable !== undefined ? { billable } : {}),
+          ...(vatRate !== undefined ? { vatRate } : {}),
+          ...(vatIncluded !== undefined ? { vatIncluded } : {}),
           ...(date ? { date: new Date(date) } : {}),
         },
       });

--- a/src/lib/server/routers/expense.ts
+++ b/src/lib/server/routers/expense.ts
@@ -7,6 +7,7 @@ import {
   expenseIdSchema,
   invoiceIdSchema,
 } from "@/lib/shared/schemas/ids";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 
 export const expenseRouter = router({
   list: protectedProcedure
@@ -72,8 +73,8 @@ export const expenseRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       return ctx.dataStore.expenses.create({
-        data: {
-          ...(input.id !== undefined ? { id: input.id } : {}), // undefined → store genererar
+        data: omitUndefined({
+          id: input.id, // undefined → store genererar
           userId: input.userId ?? asId<"UserId">(ctx.user.id),
           matterId: input.matterId,
           date: new Date(input.date),
@@ -84,7 +85,7 @@ export const expenseRouter = router({
           vatIncluded: input.vatIncluded,
           invoiceId: input.invoiceId ?? null,
           ...(input.createdAt ? { createdAt: new Date(input.createdAt) } : {}),
-        },
+        }),
       });
     }),
 
@@ -104,14 +105,14 @@ export const expenseRouter = router({
       const { id, date, amount, description, billable, vatRate, vatIncluded } = input;
       return ctx.dataStore.expenses.update({
         where: { id },
-        data: {
-          ...(amount !== undefined ? { amount } : {}),
-          ...(description !== undefined ? { description } : {}),
-          ...(billable !== undefined ? { billable } : {}),
-          ...(vatRate !== undefined ? { vatRate } : {}),
-          ...(vatIncluded !== undefined ? { vatIncluded } : {}),
+        data: omitUndefined({
+          amount,
+          description,
+          billable,
+          vatRate,
+          vatIncluded,
           ...(date ? { date: new Date(date) } : {}),
-        },
+        }),
       });
     }),
 

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -176,16 +176,16 @@ export const invoiceRouter = router({
       });
       if (!matter) throw new TRPCError({ code: "NOT_FOUND" });
       const invoice = await ctx.dataStore.invoices.create({
-        data: {
-          ...(input.id !== undefined ? { id: input.id } : {}), // undefined → store genererar
+        data: omitUndefined({
+          id: input.id, // undefined → store genererar
           matterId: input.matterId,
           amount: input.amount,
           invoiceType: "ACCONTO",
           status: "DRAFT",
           invoiceDate: input.invoiceDate ? new Date(input.invoiceDate) : new Date(),
           dueDate: input.dueDate ? new Date(input.dueDate) : null,
-          ...(input.notes !== undefined ? { notes: input.notes } : {}),
-        },
+          notes: input.notes,
+        }),
       });
       await emit.invoiceCreated(ctx, invoice);
       return invoice;
@@ -228,16 +228,16 @@ export const invoiceRouter = router({
         );
 
         const invoice = await tx.invoices.create({
-          data: {
-            ...(input.id !== undefined ? { id: input.id } : {}), // undefined → store genererar
+          data: omitUndefined({
+            id: input.id, // undefined → store genererar
             matterId: input.matterId,
             amount: breakdown.grossAmount,
             invoiceType: "FINAL",
             status: "DRAFT",
             invoiceDate: input.invoiceDate ? new Date(input.invoiceDate) : new Date(),
             dueDate: input.dueDate ? new Date(input.dueDate) : null,
-            ...(input.notes !== undefined ? { notes: input.notes } : {}),
-          },
+            notes: input.notes,
+          }),
         });
 
         await linkBilledItems(tx, invoice.id, timeEntries, expenses, accontos);

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -28,6 +28,7 @@ import {
   type TimeEntryId,
   type ExpenseId,
 } from "@/lib/shared/schemas/ids";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 
 // ─── createFinal-hjälpare (validera + koppla poster) ──────────────
 
@@ -176,14 +177,14 @@ export const invoiceRouter = router({
       if (!matter) throw new TRPCError({ code: "NOT_FOUND" });
       const invoice = await ctx.dataStore.invoices.create({
         data: {
-          id: input.id, // undefined → store genererar
+          ...(input.id !== undefined ? { id: input.id } : {}), // undefined → store genererar
           matterId: input.matterId,
           amount: input.amount,
           invoiceType: "ACCONTO",
           status: "DRAFT",
           invoiceDate: input.invoiceDate ? new Date(input.invoiceDate) : new Date(),
           dueDate: input.dueDate ? new Date(input.dueDate) : null,
-          notes: input.notes,
+          ...(input.notes !== undefined ? { notes: input.notes } : {}),
         },
       });
       await emit.invoiceCreated(ctx, invoice);
@@ -228,14 +229,14 @@ export const invoiceRouter = router({
 
         const invoice = await tx.invoices.create({
           data: {
-            id: input.id, // undefined → store genererar
+            ...(input.id !== undefined ? { id: input.id } : {}), // undefined → store genererar
             matterId: input.matterId,
             amount: breakdown.grossAmount,
             invoiceType: "FINAL",
             status: "DRAFT",
             invoiceDate: input.invoiceDate ? new Date(input.invoiceDate) : new Date(),
             dueDate: input.dueDate ? new Date(input.dueDate) : null,
-            notes: input.notes,
+            ...(input.notes !== undefined ? { notes: input.notes } : {}),
           },
         });
 
@@ -298,13 +299,12 @@ export const invoiceRouter = router({
 
         const credit = await tx.invoices.create({
           data: {
-            id: input.id, // undefined → store genererar
+            ...omitUndefined({ id: input.id, notes: input.notes }), // undefined → store genererar
             matterId: original.matterId,
             amount: -original.amount,
             invoiceType: "CREDIT",
             status: "SENT", // kreditfaktura är "färdig" direkt
             invoiceDate: new Date(),
-            notes: input.notes,
             creditedInvoiceId: original.id,
           },
         });
@@ -404,12 +404,11 @@ export const invoiceRouter = router({
 
         const plan = await tx.paymentPlans.create({
           data: {
-            id: input.id, // undefined → store genererar
+            ...omitUndefined({ id: input.id, notes: input.notes }), // undefined → store genererar
             invoiceId: inv.id,
             monthlyAmount: input.monthlyAmount,
             dayOfMonth: input.dayOfMonth,
             startDate: new Date(input.startDate),
-            notes: input.notes,
             // Explicit (Prisma schema-default appliceras inte av in-memory-store:n).
             status: "ACTIVE",
           },

--- a/src/lib/server/routers/matter.ts
+++ b/src/lib/server/routers/matter.ts
@@ -16,6 +16,7 @@ import {
   type ContactId,
 } from "@/lib/shared/schemas/ids";
 import { emit } from "../events/emit";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 
 type MatterCtx = { dataStore: IDataStore; orgId: string };
 
@@ -251,12 +252,12 @@ export const matterRouter = router({
       );
       const { createdAt, id, notes, ...rest } = input;
       return ctx.dataStore.matterContacts.create({
-        data: {
+        data: omitUndefined({
           ...rest,
-          ...(id !== undefined ? { id } : {}),
-          ...(notes !== undefined ? { notes } : {}),
+          id,
+          notes,
           ...(createdAt ? { createdAt: new Date(createdAt) } : {}),
-        },
+        }),
         include: { contact: true },
       });
     }),

--- a/src/lib/server/routers/matter.ts
+++ b/src/lib/server/routers/matter.ts
@@ -249,10 +249,12 @@ export const matterRouter = router({
         ctx.orgId,
         (c) => c.organizationId,
       );
-      const { createdAt, ...rest } = input;
+      const { createdAt, id, notes, ...rest } = input;
       return ctx.dataStore.matterContacts.create({
         data: {
           ...rest,
+          ...(id !== undefined ? { id } : {}),
+          ...(notes !== undefined ? { notes } : {}),
           ...(createdAt ? { createdAt: new Date(createdAt) } : {}),
         },
         include: { contact: true },

--- a/src/lib/server/routers/organization.ts
+++ b/src/lib/server/routers/organization.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, protectedProcedure } from "../trpc";
 import { organizationIdSchema, asId } from "@/lib/shared/schemas/ids";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 
 export const organizationRouter = router({
   // ── Settings ────────────────────────────────────────────────────
@@ -36,7 +37,7 @@ export const organizationRouter = router({
     .mutation(async ({ ctx, input }) => {
       return ctx.dataStore.organizations.update({
         where: { id: ctx.user.organizationId },
-        data: input,
+        data: omitUndefined(input),
       });
     }),
 
@@ -121,7 +122,7 @@ export const organizationRouter = router({
           data: { isMain: false },
         });
       }
-      return ctx.dataStore.offices.update({ where: { id }, data });
+      return ctx.dataStore.offices.update({ where: { id }, data: omitUndefined(data) });
     }),
 
   deleteOffice: protectedProcedure

--- a/src/lib/server/routers/task.ts
+++ b/src/lib/server/routers/task.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 import { router, protectedProcedure } from "../trpc";
 import { taskPrioritySchema, taskStatusSchema } from "@/lib/shared/schemas";
 import { asId, taskIdSchema, matterIdSchema, userIdSchema } from "@/lib/shared/schemas/ids";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 
 const createInput = z.object({
   title: z.string().min(1),
@@ -63,7 +64,7 @@ export const taskRouter = router({
           status: input.status ?? "TODO",
           userId: input.userId ?? asId<"UserId">(ctx.user.id),
           organizationId: asId<"OrganizationId">(ctx.user.organizationId),
-          ...(id !== undefined ? { id } : {}),
+          ...omitUndefined({ id }),
           ...(createdAt != null ? { createdAt } : {}),
         },
       });

--- a/src/lib/server/routers/task.ts
+++ b/src/lib/server/routers/task.ts
@@ -55,17 +55,19 @@ export const taskRouter = router({
 
   create: protectedProcedure
     .input(createInput)
-    .mutation(({ ctx, input }) =>
-      ctx.dataStore.tasks.create({
+    .mutation(({ ctx, input }) => {
+      const { id, createdAt, ...rest } = input;
+      return ctx.dataStore.tasks.create({
         data: {
-          ...input,
+          ...rest,
           status: input.status ?? "TODO",
           userId: input.userId ?? asId<"UserId">(ctx.user.id),
           organizationId: asId<"OrganizationId">(ctx.user.organizationId),
-          createdAt: input.createdAt ?? undefined,
+          ...(id !== undefined ? { id } : {}),
+          ...(createdAt != null ? { createdAt } : {}),
         },
-      }),
-    ),
+      });
+    }),
 
   update: protectedProcedure
     .input(updateInput)

--- a/src/lib/server/routers/timeEntry.ts
+++ b/src/lib/server/routers/timeEntry.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { router, protectedProcedure } from "../trpc";
 import { emit } from "../events/emit";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 import {
   asId,
   matterIdSchema,
@@ -88,8 +89,8 @@ export const timeEntryRouter = router({
       });
 
       const entry = await ctx.dataStore.timeEntries.create({
-        data: {
-          ...(input.id !== undefined ? { id: input.id } : {}), // undefined → store genererar
+        data: omitUndefined({
+          id: input.id, // undefined → store genererar
           userId,
           matterId: input.matterId,
           date: new Date(input.date),
@@ -99,7 +100,7 @@ export const timeEntryRouter = router({
           billable: input.billable,
           invoiceId: input.invoiceId ?? null,
           ...(input.createdAt ? { createdAt: new Date(input.createdAt) } : {}),
-        },
+        }),
       });
       await emit.timeEntryAdded(ctx, { id: entry.id, matterId: entry.matterId, minutes: entry.minutes });
       return entry;
@@ -119,12 +120,12 @@ export const timeEntryRouter = router({
       const { id, date, minutes, description, billable } = input;
       const updated = await ctx.dataStore.timeEntries.update({
         where: { id },
-        data: {
-          ...(minutes !== undefined ? { minutes } : {}),
-          ...(description !== undefined ? { description } : {}),
-          ...(billable !== undefined ? { billable } : {}),
+        data: omitUndefined({
+          minutes,
+          description,
+          billable,
           ...(date ? { date: new Date(date) } : {}),
-        },
+        }),
       });
       await emit.timeEntryUpdated(ctx, { id: updated.id, matterId: updated.matterId });
       return updated;

--- a/src/lib/server/routers/timeEntry.ts
+++ b/src/lib/server/routers/timeEntry.ts
@@ -89,7 +89,7 @@ export const timeEntryRouter = router({
 
       const entry = await ctx.dataStore.timeEntries.create({
         data: {
-          id: input.id, // undefined → store genererar
+          ...(input.id !== undefined ? { id: input.id } : {}), // undefined → store genererar
           userId,
           matterId: input.matterId,
           date: new Date(input.date),
@@ -98,7 +98,7 @@ export const timeEntryRouter = router({
           hourlyRate: input.hourlyRate ?? user.hourlyRate ?? 0,
           billable: input.billable,
           invoiceId: input.invoiceId ?? null,
-          createdAt: input.createdAt ? new Date(input.createdAt) : undefined,
+          ...(input.createdAt ? { createdAt: new Date(input.createdAt) } : {}),
         },
       });
       await emit.timeEntryAdded(ctx, { id: entry.id, matterId: entry.matterId, minutes: entry.minutes });
@@ -116,11 +116,13 @@ export const timeEntryRouter = router({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const { id, date, ...data } = input;
+      const { id, date, minutes, description, billable } = input;
       const updated = await ctx.dataStore.timeEntries.update({
         where: { id },
         data: {
-          ...data,
+          ...(minutes !== undefined ? { minutes } : {}),
+          ...(description !== undefined ? { description } : {}),
+          ...(billable !== undefined ? { billable } : {}),
           ...(date ? { date: new Date(date) } : {}),
         },
       });

--- a/src/lib/server/rules/execute.ts
+++ b/src/lib/server/rules/execute.ts
@@ -119,7 +119,12 @@ const STEP_HANDLERS: { [K in RuleStep["do"]]: StepHandler<K> } = {
     const to = String(templateValue(step.to, tctx));
     const vars = templateValue(step.vars ?? {}, tctx) as Record<string, unknown>;
     const idempotencyKey = step.idempotencyKey ? String(templateValue(step.idempotencyKey, tctx)) : undefined;
-    const sent = await ctx.handlers.sendEmail({ template: step.template, to, vars, idempotencyKey });
+    const sent = await ctx.handlers.sendEmail({
+      template: step.template,
+      to,
+      vars,
+      ...(idempotencyKey !== undefined ? { idempotencyKey } : {}),
+    });
     if (sent) {
       await ctx.dataStore.events.emit({
         type: "mail.sent",
@@ -192,7 +197,7 @@ const STEP_HANDLERS: { [K in RuleStep["do"]]: StepHandler<K> } = {
     const assignTo = String(templateValue(step.assignTo, tctx));
     const title = String(templateValue(step.title, tctx));
     const dueAt = step.dueAt ? String(templateValue(step.dueAt, tctx)) : undefined;
-    await ctx.handlers.createTask({ assignTo, title, dueAt });
+    await ctx.handlers.createTask({ assignTo, title, ...(dueAt !== undefined ? { dueAt } : {}) });
     return undefined;
   },
 };
@@ -224,7 +229,7 @@ export async function executeRule(ctx: ExecutionContext): Promise<ExecutionResul
     ruleId: ctx.rule.id,
     ok: !result.error,
     stepsRan: result.stepsRan,
-    httpResponse: result.httpResponse,
-    error: result.error,
+    ...(result.httpResponse !== undefined ? { httpResponse: result.httpResponse } : {}),
+    ...(result.error !== undefined ? { error: result.error } : {}),
   };
 }

--- a/src/lib/server/rules/execute.ts
+++ b/src/lib/server/rules/execute.ts
@@ -13,6 +13,7 @@ import type { AvaRule, RuleStep } from "./schema";
 import type { AvaEvent } from "../events/schema";
 import { templateValue, lookup } from "./template";
 import type { IDataStore } from "../data-store/IDataStore";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 
 export type StepHandlers = {
   /** Skicka mail. Returnerar `false` om idempotency-key blockerade. */
@@ -119,12 +120,12 @@ const STEP_HANDLERS: { [K in RuleStep["do"]]: StepHandler<K> } = {
     const to = String(templateValue(step.to, tctx));
     const vars = templateValue(step.vars ?? {}, tctx) as Record<string, unknown>;
     const idempotencyKey = step.idempotencyKey ? String(templateValue(step.idempotencyKey, tctx)) : undefined;
-    const sent = await ctx.handlers.sendEmail({
+    const sent = await ctx.handlers.sendEmail(omitUndefined({
       template: step.template,
       to,
       vars,
-      ...(idempotencyKey !== undefined ? { idempotencyKey } : {}),
-    });
+      idempotencyKey,
+    }) as Parameters<StepHandlers["sendEmail"]>[0]);
     if (sent) {
       await ctx.dataStore.events.emit({
         type: "mail.sent",
@@ -197,7 +198,7 @@ const STEP_HANDLERS: { [K in RuleStep["do"]]: StepHandler<K> } = {
     const assignTo = String(templateValue(step.assignTo, tctx));
     const title = String(templateValue(step.title, tctx));
     const dueAt = step.dueAt ? String(templateValue(step.dueAt, tctx)) : undefined;
-    await ctx.handlers.createTask({ assignTo, title, ...(dueAt !== undefined ? { dueAt } : {}) });
+    await ctx.handlers.createTask(omitUndefined({ assignTo, title, dueAt }) as Parameters<StepHandlers["createTask"]>[0]);
     return undefined;
   },
 };
@@ -225,11 +226,11 @@ export async function executeRule(ctx: ExecutionContext): Promise<ExecutionResul
     },
   });
 
-  return {
+  return omitUndefined({
     ruleId: ctx.rule.id,
     ok: !result.error,
     stepsRan: result.stepsRan,
-    ...(result.httpResponse !== undefined ? { httpResponse: result.httpResponse } : {}),
-    ...(result.error !== undefined ? { error: result.error } : {}),
-  };
+    httpResponse: result.httpResponse,
+    error: result.error,
+  }) as ExecutionResult;
 }

--- a/src/lib/server/rules/schema.ts
+++ b/src/lib/server/rules/schema.ts
@@ -80,14 +80,14 @@ const valueRefSchema = z.union([z.string(), z.number(), z.boolean(), z.null(), z
 interface BaseStep { do: string; }
 
 interface EmitStep extends BaseStep { do: "emit"; eventType: string; payload: Record<string, unknown>; }
-interface EmailSendStep extends BaseStep { do: "email.send"; template: string; to: string; vars?: Record<string, unknown>; idempotencyKey?: string; }
+interface EmailSendStep extends BaseStep { do: "email.send"; template: string; to: string; vars?: Record<string, unknown> | undefined; idempotencyKey?: string | undefined; }
 interface MatterUpdateStep extends BaseStep { do: "matter.update"; matterId: string; patch: Record<string, unknown>; }
 interface AuditLogStep extends BaseStep { do: "audit.log"; message: string; }
-interface IfStep extends BaseStep { do: "if"; cond: unknown; then: RuleStep[]; else?: RuleStep[]; }
+interface IfStep extends BaseStep { do: "if"; cond: unknown; then: RuleStep[]; else?: RuleStep[] | undefined; }
 interface ForEachStep extends BaseStep { do: "for-each"; items: string; as: string; body: RuleStep[]; }
 interface HttpRespondStep extends BaseStep { do: "http.respond"; status: number; body?: unknown; }
 interface LlmExtractStep extends BaseStep { do: "llm.extract"; documentId: string; schema: Record<string, unknown>; into: string; }
-interface TaskCreateStep extends BaseStep { do: "task.create"; assignTo: string; title: string; dueAt?: string; }
+interface TaskCreateStep extends BaseStep { do: "task.create"; assignTo: string; title: string; dueAt?: string | undefined; }
 
 export type RuleStep =
   | EmitStep

--- a/src/lib/shared/omit-undefined.ts
+++ b/src/lib/shared/omit-undefined.ts
@@ -1,0 +1,17 @@
+/**
+ * Tar bort nycklar vars värde är `undefined`.
+ *
+ * För `exactOptionalPropertyTypes` (#32): ett optional-fält `x?: T` får inte
+ * sättas till explicit `undefined` — nyckeln måste utelämnas. Inline-mönstret
+ * `...(v !== undefined ? { x: v } : {})` per fält fungerar men spräcker
+ * complexity-gränsen när flera fält samlas. Den här helpern samlar branchningen
+ * på ETT ställe så call-sites förblir enkla. Runtime oförändrat (nyckeln
+ * utelämnas precis som förr).
+ */
+export function omitUndefined<T extends object>(obj: T): { [K in keyof T]?: Exclude<T[K], undefined> } {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined) out[k] = v;
+  }
+  return out as { [K in keyof T]?: Exclude<T[K], undefined> };
+}

--- a/test/unit/lib/github/api.test.ts
+++ b/test/unit/lib/github/api.test.ts
@@ -32,7 +32,7 @@ let calls: MockCall[];
 
 function mockFetch(impl: (call: MockCall) => Response | Promise<Response>) {
   globalThis.fetch = vi.fn(async (url: URL | RequestInfo, init?: RequestInit) => {
-    const call = { url: url.toString(), init };
+    const call: MockCall = { url: url.toString(), ...(init !== undefined ? { init } : {}) };
     calls.push(call);
     return impl(call);
   }) as typeof fetch;

--- a/test/unit/lib/jobs/mirror-outlook.test.ts
+++ b/test/unit/lib/jobs/mirror-outlook.test.ts
@@ -146,4 +146,114 @@ describe("mirror-to-outlook worker", () => {
     expect(dispatch.mock.calls[0][0].patch.mirrorStatus).toBe("failed");
     expect(dispatch.mock.calls[0][0].patch.mirrorError).toMatch(/403/);
   });
+
+  // ── outlookCalendarId-spreadens truthy-arm (per-kalender-mirroring) ──
+  // Default-kalendern utelämnar calendarId; en specifik byrå-/delad kalender
+  // skickar den vidare till Graph. Täcker `outlookCalendarId != null`-armen
+  // i create/update/delete.
+
+  it("upsert till specifik kalender → createGraphEvent får calendarId", async () => {
+    graph.createGraphEvent.mockResolvedValue({ id: "g-cal" });
+    const dispatch = vi.fn().mockResolvedValue(undefined);
+    setOutlookTokenProvider(async () => "tok");
+    setMirrorStateDispatcher(dispatch);
+
+    const id = jobQueue.enqueue("mirror-to-outlook", "test", {
+      eventId: "ev-cal-1",
+      op: "upsert",
+      outlookCalendarId: "cal-A",
+      event: { title: "Kal", startAt: "2026-02-01T09:00:00Z", allDay: false, visibility: "normal", kind: "appointment" },
+    });
+    await waitForFinish(id);
+    expect(graph.createGraphEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ token: "tok", calendarId: "cal-A" }),
+    );
+  });
+
+  it("update i specifik kalender → updateGraphEvent får calendarId", async () => {
+    graph.updateGraphEvent.mockResolvedValue({ id: "g-cal-2" });
+    const dispatch = vi.fn().mockResolvedValue(undefined);
+    setOutlookTokenProvider(async () => "tok");
+    setMirrorStateDispatcher(dispatch);
+
+    const id = jobQueue.enqueue("mirror-to-outlook", "test", {
+      eventId: "ev-cal-2",
+      op: "upsert",
+      outlookEventId: "g-cal-2",
+      outlookCalendarId: "cal-B",
+      event: { title: "Kal2", startAt: "2026-02-02T09:00:00Z", allDay: false, visibility: "normal", kind: "appointment" },
+    });
+    await waitForFinish(id);
+    expect(graph.updateGraphEvent).toHaveBeenCalledWith(
+      "g-cal-2",
+      expect.anything(),
+      expect.objectContaining({ token: "tok", calendarId: "cal-B" }),
+    );
+  });
+
+  it("delete i specifik kalender → deleteGraphEvent får calendarId", async () => {
+    graph.deleteGraphEvent.mockResolvedValue(undefined);
+    const dispatch = vi.fn().mockResolvedValue(undefined);
+    setOutlookTokenProvider(async () => "tok");
+    setMirrorStateDispatcher(dispatch);
+
+    const id = jobQueue.enqueue("mirror-to-outlook", "test", {
+      eventId: "ev-cal-3",
+      op: "delete",
+      outlookEventId: "g-cal-3",
+      outlookCalendarId: "cal-C",
+    });
+    await waitForFinish(id);
+    expect(graph.deleteGraphEvent).toHaveBeenCalledWith(
+      "g-cal-3",
+      expect.objectContaining({ token: "tok", calendarId: "cal-C" }),
+    );
+  });
+
+  it("delete utan outlookEventId → ingen Graph-anrop (eventet aldrig mirrorat)", async () => {
+    const dispatch = vi.fn().mockResolvedValue(undefined);
+    setOutlookTokenProvider(async () => "tok");
+    setMirrorStateDispatcher(dispatch);
+
+    const id = jobQueue.enqueue("mirror-to-outlook", "test", {
+      eventId: "ev-no-id",
+      op: "delete",
+    });
+    const job = await waitForFinish(id);
+    expect(job.status).toBe("done");
+    expect(graph.deleteGraphEvent).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("upsert utan event-data → workern kastar (saknad payload)", async () => {
+    const dispatch = vi.fn().mockResolvedValue(undefined);
+    setOutlookTokenProvider(async () => "tok");
+    setMirrorStateDispatcher(dispatch);
+
+    const id = jobQueue.enqueue("mirror-to-outlook", "test", {
+      eventId: "ev-no-event",
+      op: "upsert",
+    });
+    const job = await waitForFinish(id);
+    expect(job.status).toBe("failed");
+    expect(graph.createGraphEvent).not.toHaveBeenCalled();
+  });
+
+  it("Graph kastar icke-Error → mirrorError stringifieras", async () => {
+    graph.createGraphEvent.mockRejectedValue("rå-sträng-fel");
+    const dispatch = vi.fn().mockResolvedValue(undefined);
+    setOutlookTokenProvider(async () => "tok");
+    setMirrorStateDispatcher(dispatch);
+
+    const id = jobQueue.enqueue("mirror-to-outlook", "test", {
+      eventId: "ev-6",
+      op: "upsert",
+      event: { title: "RawErr", startAt: "2026-01-05T09:00:00Z", allDay: false, visibility: "normal", kind: "appointment" },
+    });
+    const job = await waitForFinish(id);
+    expect(job.status).toBe("failed");
+    expect(dispatch).toHaveBeenCalledOnce();
+    expect(dispatch.mock.calls[0][0].patch.mirrorError).toBe("rå-sträng-fel");
+  });
 });

--- a/test/unit/lib/shared/omit-undefined.test.ts
+++ b/test/unit/lib/shared/omit-undefined.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
+
+describe("omitUndefined (#32)", () => {
+  it("tar bort nycklar med värdet undefined", () => {
+    expect(omitUndefined({ a: 1, b: undefined, c: "x" })).toEqual({ a: 1, c: "x" });
+  });
+
+  it("behåller null, 0, '' och false (bara undefined strippas)", () => {
+    expect(omitUndefined({ a: null, b: 0, c: "", d: false, e: undefined })).toEqual({
+      a: null, b: 0, c: "", d: false,
+    });
+  });
+
+  it("returnerar tomt objekt när alla värden är undefined", () => {
+    expect(omitUndefined({ a: undefined, b: undefined })).toEqual({});
+  });
+
+  it("är en kopia, muterar inte input", () => {
+    const input = { a: 1, b: undefined };
+    const out = omitUndefined(input);
+    expect(out).not.toBe(input);
+    expect(input).toEqual({ a: 1, b: undefined });
+  });
+});

--- a/test/unit/server/data-store/writable-delegate.test.ts
+++ b/test/unit/server/data-store/writable-delegate.test.ts
@@ -18,7 +18,7 @@ function makeDelegate(initial: Matter[] = [], onMutate?: (e: MutationEvent<Matte
     delegate: new WritableDelegate<Matter>({
       entity: "matter",
       collection: () => box.items,
-      onMutate,
+      ...(onMutate !== undefined ? { onMutate } : {}),
     }),
   };
 }

--- a/tooling/demo-generator/populate-template-docs.ts
+++ b/tooling/demo-generator/populate-template-docs.ts
@@ -93,7 +93,7 @@ function buildCtxForMatter(m: Row, klientName: string, userName: string, org: Ro
     recipient: { name: klientName },
     client: { name: klientName },
     organization: { name: org.name as string, orgNumber: org.orgNumber as string, address: org.address as string, email: org.email as string },
-    now: m.createdAt ? new Date(m.createdAt as string) : undefined,
+    ...(m.createdAt ? { now: new Date(m.createdAt as string) } : {}),
   });
   return { ...base, contact: { name: klientName }, user: { name: userName } };
 }

--- a/tooling/scripts/diagnose-ui.ts
+++ b/tooling/scripts/diagnose-ui.ts
@@ -273,7 +273,7 @@ async function visitRoute(browser: Browser, route: Route): Promise<RouteResult> 
   const assertions: RouteResult["assertions"] = [];
   for (const txt of route.mustContain ?? []) {
     const found = await page.locator(`text=${txt}`).first().isVisible().catch(() => false);
-    assertions.push({ check: `must contain "${txt}"`, passed: found, detail: found ? undefined : "saknas" });
+    assertions.push({ check: `must contain "${txt}"`, passed: found, ...(found ? {} : { detail: "saknas" }) });
   }
 
   const screenshotPath = join(REPORT_DIR, `${route.name}.png`);

--- a/tooling/scripts/write-demo-meta.ts
+++ b/tooling/scripts/write-demo-meta.ts
@@ -54,7 +54,7 @@ export function buildDemoMeta(seed: SeedShape, translator: IdTranslator, now: Da
     name: String(u.name ?? ""),
     email: String(u.email ?? ""),
     role: u.role as "ADMIN" | "LAWYER" | "ASSISTANT",
-    title: u.title ? String(u.title) : undefined,
+    ...(u.title ? { title: String(u.title) } : {}),
   }));
   if (users.some((u) => !u.id || !u.name || !u.role)) {
     throw new Error("User-rad saknar id/name/role");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,9 +5,9 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
-    // Extra korrekthetsflaggor (#7). noUncheckedIndexedAccess (~519 fel) och
-    // exactOptionalPropertyTypes (~61, mest tooling) skjuts upp till en ratchet
-    // — se uppföljnings-issue.
+    // Extra korrekthetsflaggor. exactOptionalPropertyTypes på (#32).
+    // noUncheckedIndexedAccess (~529 fel, test-tungt) kvar som separat fas i #32.
+    "exactOptionalPropertyTypes": true,
     "noImplicitOverride": true,
     "noFallthroughCasesInSwitch": true,
     // TS6: matcha 7.0:s (Go-native) typordning → mindre diff vid den migreringen.


### PR DESCRIPTION
Part of #32 (flagga 1 av 2).

Slår på `exactOptionalPropertyTypes` i `tsconfig.json` och fixar de ~125 fel det avslöjade (mätt; issue:n gissade ~61). Gjort parallellt via workflow (2 ronder + konvergens), sen helhets-verifierat.

## Tillvägagångssätt
- Optional-fält får inte sättas till explicit `undefined` → **conditional-spread** vid objekt-konstruktion (utelämnar nyckeln; runtime oförändrat) eller **type-widening** (`?: T | undefined`) där fältet genuint får vara undefined.
- Ny delad helper **`omitUndefined`** (`src/lib/shared`) samlar strippningen så hot-funktioner inte spräcker complexity-gränsen. Ersatte en duplicerad `routers/compact` som en agent skapade (den bröt dessutom `routers-compose-via-app`-lagerregeln).
- Branded-rad-konsumenter (calendar) boundary-castade.

## Verifiering
- typecheck 0, lint 0 (45/45), **knip 0**, **deps:check 0** (lager-regler), test:fast 2185, build:demo OK.
- Inga `any` (no-explicit-any=error sedan #47), inga nya complexity-disables (#40-andan).

## Kvar: flagga 2/2
`noUncheckedIndexedAccess` (~529 fel, varav 346 i `test/`) — egen PR. Global flagga = allt-eller-inget att slå på, så den blir en fokuserad fas (app+tooling först, test sist per issue:n).