### PR TITLE
Aktivera noUncheckedIndexedAccess (#32, flagga 2/2)

### DIFF
--- a/src/app/calendar/_calendar-grid.tsx
+++ b/src/app/calendar/_calendar-grid.tsx
@@ -176,7 +176,7 @@ export function weekDays(anchor: Date): Date[] {
 
 export function weekRange(anchor: Date): { from: Date; to: Date } {
   const days = weekDays(anchor);
-  return { from: days[0], to: endOfDay(days[6]) };
+  return { from: days[0]!, to: endOfDay(days[6]!) };
 }
 
 export function monthGridDays(anchor: Date): Date[] {
@@ -189,7 +189,7 @@ export function monthGridDays(anchor: Date): Date[] {
 
 export function monthRange(anchor: Date): { from: Date; to: Date } {
   const days = monthGridDays(anchor);
-  return { from: days[0], to: endOfDay(days[days.length - 1]) };
+  return { from: days[0]!, to: endOfDay(days[days.length - 1]!) };
 }
 
 function endOfDay(d: Date): Date {

--- a/src/app/calendar/_day-view.tsx
+++ b/src/app/calendar/_day-view.tsx
@@ -190,7 +190,7 @@ export function layoutEventsForDay(events: readonly DayEvent[]): LaidOutEvent[] 
     const start = new Date(ev.startAt);
     const end = ev.endAt ? new Date(ev.endAt) : new Date(start.getTime() + 30 * 60_000); // default 30 min
     let col = 0;
-    while (col < colEnds.length && colEnds[col].getTime() > start.getTime()) col++;
+    while (col < colEnds.length && colEnds[col]!.getTime() > start.getTime()) col++;
     if (col === colEnds.length) colEnds.push(end);
     else colEnds[col] = end;
     assigned.push({ ev, col, start, end });

--- a/src/app/matters/[id]/_client.tsx
+++ b/src/app/matters/[id]/_client.tsx
@@ -115,7 +115,7 @@ function MatterHeader({ matter: m, klient, onOpenGenerate }: HeaderProps) {
           <p className="text-sm font-mono text-gray-500">{m.matterNumber}</p>
           <h1 className="text-2xl font-bold text-gray-900 mt-1">{m.title}</h1>
           <p className="text-sm text-gray-500 mt-1">
-            {klient.length > 0 && klient[0].contact && (
+            {klient[0]?.contact && (
               <>Klient: <EntityLink route="contacts" id={klient[0].contact.id} className="text-blue-600 hover:underline">{klient[0].contact.name}</EntityLink></>
             )}
             {m.matterType && <>{klient.length > 0 ? " · " : ""}{m.matterType}</>}

--- a/src/app/matters/[id]/_expense-section.tsx
+++ b/src/app/matters/[id]/_expense-section.tsx
@@ -37,7 +37,7 @@ interface Expense {
 
 function initialForm(): ExpenseForm {
   return {
-    date: new Date().toISOString().split("T")[0],
+    date: new Date().toISOString().split("T")[0]!,
     amount: 0,
     description: "",
     billable: true,
@@ -48,7 +48,7 @@ function initialForm(): ExpenseForm {
 
 function toForm(e: Expense): ExpenseForm {
   return {
-    date: new Date(e.date).toISOString().split("T")[0],
+    date: new Date(e.date).toISOString().split("T")[0]!,
     amount: e.amount / 100,
     description: e.description,
     billable: e.billable,

--- a/src/app/matters/[id]/_kostnadsrakning-modal.tsx
+++ b/src/app/matters/[id]/_kostnadsrakning-modal.tsx
@@ -116,7 +116,7 @@ async function recordDocument(opts: RecordDocOpts): Promise<void> {
 
 function bytesToBase64(bytes: Uint8Array): string {
   let bin = "";
-  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  for (const byte of bytes) bin += String.fromCharCode(byte);
   return btoa(bin);
 }
 

--- a/src/app/matters/[id]/_time-section.tsx
+++ b/src/app/matters/[id]/_time-section.tsx
@@ -40,7 +40,7 @@ function fmtDateTime(v: Date | string | null | undefined): string {
 
 function toEditForm(entry: TimeEntryRow): EditForm {
   return {
-    date: new Date(entry.date).toISOString().split("T")[0],
+    date: new Date(entry.date).toISOString().split("T")[0]!,
     minutes: entry.minutes,
     description: entry.description ?? "",
     billable: entry.billable,
@@ -48,7 +48,7 @@ function toEditForm(entry: TimeEntryRow): EditForm {
 }
 
 function emptyForm(): EditForm {
-  return { date: new Date().toISOString().split("T")[0], minutes: 30, description: "", billable: true };
+  return { date: new Date().toISOString().split("T")[0]!, minutes: 30, description: "", billable: true };
 }
 
 // eslint-disable-next-line max-lines-per-function -- TODO: refactor (struktur är tabular: kolumndefs + 2 modaler)

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -311,11 +311,11 @@ async function parseSshPublicKey(raw: string): Promise<{ type: PublicKey["type"]
     "ecdsa-sha2-nistp384": "ssh-ecdsa",
     "ecdsa-sha2-nistp521": "ssh-ecdsa",
   };
-  const type = typeMap[parts[0]];
+  const type = typeMap[parts[0]!];
   if (!type) return null;
   // Riktig SHA-256-fingerprint via crypto.subtle på den base64-decodade
   // wire-format-blob:n. För Ed25519 är decodad blob 51 bytes (4+11+4+32).
-  const blob = base64ToBytes(parts[1]);
+  const blob = base64ToBytes(parts[1]!);
   const digest = await crypto.subtle.digest("SHA-256", blob.buffer as ArrayBuffer);
   const fp = "SHA256:" + bytesToBase64(new Uint8Array(digest)).replace(/=+$/, "");
   const comment = parts.slice(2).join(" ");
@@ -331,6 +331,6 @@ function base64ToBytes(b64: string): Uint8Array {
 
 function bytesToBase64(bytes: Uint8Array): string {
   let s = "";
-  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]!);
   return btoa(s);
 }

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -31,8 +31,9 @@ function PaymentBadge({ method }: { method: string }) {
 // eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Function 'ReportsPage' has a complexity of 10. Maximum allowed is 8.)
 export default function ReportsPage() {
   const now = new Date();
-  const firstOfYear = new Date(now.getFullYear(), 0, 1).toISOString().split("T")[0];
-  const today = now.toISOString().split("T")[0];
+  // split("T") ger alltid minst ett element → [0] är aldrig undefined.
+  const firstOfYear = new Date(now.getFullYear(), 0, 1).toISOString().split("T")[0]!;
+  const today = now.toISOString().split("T")[0]!;
 
   const [from, setFrom] = useState(firstOfYear);
   const [to, setTo] = useState(today);

--- a/src/app/time/page.tsx
+++ b/src/app/time/page.tsx
@@ -96,7 +96,7 @@ export default function TimePage() {
   const descriptionFieldId = useId();
   const [form, setForm] = useState({
     matterId: "",
-    date: new Date().toISOString().split("T")[0],
+    date: new Date().toISOString().split("T")[0]!,
     minutes: 30,
     description: "",
     billable: true,
@@ -106,7 +106,7 @@ export default function TimePage() {
     onSuccess: () => {
       void utils.timeEntry.list.invalidate();
       setShowForm(false);
-      setForm({ matterId: "", date: new Date().toISOString().split("T")[0], minutes: 30, description: "", billable: true });
+      setForm({ matterId: "", date: new Date().toISOString().split("T")[0]!, minutes: 30, description: "", billable: true });
     },
   });
 

--- a/src/app/todo/_client.tsx
+++ b/src/app/todo/_client.tsx
@@ -30,7 +30,7 @@ function toInputDate(d: Date): string {
   // öster om UTC innan kl 02:00 lokalt (toISOString → UTC → föregående dag).
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
-function fromInputDate(s: string): Date { const [y, m, day] = s.split("-").map(Number); return new Date(y, (m ?? 1) - 1, day ?? 1); }
+function fromInputDate(s: string): Date { const [y, m, day] = s.split("-").map(Number); return new Date(y ?? 1970, (m ?? 1) - 1, day ?? 1); }
 function shiftDays(d: Date, n: number): Date { const x = new Date(d); x.setDate(x.getDate() + n); return x; }
 
 interface TaskForm {

--- a/src/lib/client/auth/github-auth.ts
+++ b/src/lib/client/auth/github-auth.ts
@@ -49,16 +49,16 @@ export function parseRepoUrl(input: string): ParsedRepo | null {
 
   // https://github.com/user/repo[.git]
   const httpsMatch = trimmed.match(/^https?:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?$/);
-  if (httpsMatch) return { owner: httpsMatch[1], repo: httpsMatch[2] };
+  if (httpsMatch) return { owner: httpsMatch[1]!, repo: httpsMatch[2]! };
 
   // git@github.com:user/repo[.git]
   const sshMatch = trimmed.match(/^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/);
-  if (sshMatch) return { owner: sshMatch[1], repo: sshMatch[2] };
+  if (sshMatch) return { owner: sshMatch[1]!, repo: sshMatch[2]! };
 
   // user/repo (kortform)
   const shortMatch = trimmed.match(/^([^/\s]+)\/([^/\s]+?)(?:\.git)?$/);
   if (shortMatch && !trimmed.startsWith("http") && !trimmed.includes("@")) {
-    return { owner: shortMatch[1], repo: shortMatch[2] };
+    return { owner: shortMatch[1]!, repo: shortMatch[2]! };
   }
   return null;
 }

--- a/src/lib/client/calendar/user-colors.ts
+++ b/src/lib/client/calendar/user-colors.ts
@@ -53,8 +53,8 @@ export function hashString(s: string): number {
 }
 
 export function colorForUserId(userId: string): UserColor {
-  if (!userId) return PALETTE[PALETTE.length - 1]; // slate fallback
-  return PALETTE[hashString(userId) % PALETTE.length];
+  if (!userId) return PALETTE[PALETTE.length - 1]!; // slate fallback
+  return PALETTE[hashString(userId) % PALETTE.length]!;
 }
 
 /**
@@ -74,7 +74,7 @@ export function colorForUserId(userId: string): UserColor {
 export function buildUserColorMap(userIds: readonly string[]): Map<string, UserColor> {
   const sorted = [...userIds].sort();
   const out = new Map<string, UserColor>();
-  sorted.forEach((id, i) => out.set(id, PALETTE[i % PALETTE.length]));
+  sorted.forEach((id, i) => out.set(id, PALETTE[i % PALETTE.length]!));
   return out;
 }
 

--- a/src/lib/client/demo/persist-generated-doc.ts
+++ b/src/lib/client/demo/persist-generated-doc.ts
@@ -19,7 +19,7 @@ import { stashGeneratedDoc } from "./generated-doc-cache";
 
 function bytesToBase64(bytes: Uint8Array): string {
   let bin = "";
-  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]!);
   return btoa(bin);
 }
 

--- a/src/lib/client/demo/use-route-id.ts
+++ b/src/lib/client/demo/use-route-id.ts
@@ -33,7 +33,7 @@ function effectivePathname(pathname: string): string {
   if (!pathname.split("/").filter(Boolean).includes(SHELL_PARAM)) return pathname;
   const m = window.location.hash.match(/(?:^#|&)orig=([^&]+)/);
   if (!m) return pathname;
-  try { return decodeURIComponent(m[1]); } catch { return pathname; }
+  try { return decodeURIComponent(m[1]!); } catch { return pathname; }
 }
 
 export function useRouteId(offsetFromEnd = 0): string | null {

--- a/src/lib/client/diagnostics/report.ts
+++ b/src/lib/client/diagnostics/report.ts
@@ -45,7 +45,7 @@ function buildTitle(input: ReportInput): string {
   const firstLine = input.userText?.split("\n")[0]?.trim();
   if (firstLine) return `[AVA] ${firstLine}`.slice(0, 120);
   if (input.violations && input.violations.length > 0) {
-    return `[AVA] Självupptäckt: ${input.violations[0].code}`;
+    return `[AVA] Självupptäckt: ${input.violations[0]!.code}`;
   }
   return "[AVA] Felrapport";
 }

--- a/src/lib/client/firma/hydrate-working-copy.ts
+++ b/src/lib/client/firma/hydrate-working-copy.ts
@@ -55,7 +55,7 @@ async function readJsonDir(
  * filer. (Strikt validering kan slås på via env-flagga senare.)
  */
 function validateRow(entity: EntityName, row: Record<string, unknown>): Record<string, unknown> {
-  const schema = ENTITY_REGISTRY[entity].schema;
+  const schema = ENTITY_REGISTRY[entity]!.schema;
   const result = schema.safeParse(row);
   if (!result.success) {
     console.warn(
@@ -73,7 +73,7 @@ export async function hydrateWorkingCopy(
   const fs = new FsaIsoGitAdapter(root);
   const out: DemoSource = {};
   for (const entity of ENTITY_NAMES) {
-    const { gitPrefix, sourceKey } = ENTITY_REGISTRY[entity];
+    const { gitPrefix, sourceKey } = ENTITY_REGISTRY[entity]!;
     const rows = await readJsonDir(fs, gitPrefix);
     if (!rows.length) continue;
     const validated = rows.map((r) => validateRow(entity, r));

--- a/src/lib/client/fsa/download-to-fsa.ts
+++ b/src/lib/client/fsa/download-to-fsa.ts
@@ -36,14 +36,14 @@ export async function downloadToFsa(input: DownloadInput): Promise<DownloadResul
   // Navigera/skapa kataloger
   let dir: FileSystemDirectoryHandle = input.root;
   for (let i = 0; i < parts.length - 1; i++) {
-    dir = await dir.getDirectoryHandle(parts[i], { create: true });
+    dir = await dir.getDirectoryHandle(parts[i]!, { create: true });
   }
 
   const res = await fetchFn(input.url);
   if (!res.ok) throw new Error(`downloadToFsa: HTTP ${res.status} från ${input.url}`);
   const bytes = new Uint8Array(await res.arrayBuffer());
 
-  const fileHandle = await dir.getFileHandle(parts[parts.length - 1], { create: true });
+  const fileHandle = await dir.getFileHandle(parts[parts.length - 1]!, { create: true });
   const writable = await fileHandle.createWritable();
   await writable.write(bytes);
   await writable.close();

--- a/src/lib/client/fsa/open-in-finder.ts
+++ b/src/lib/client/fsa/open-in-finder.ts
@@ -57,7 +57,7 @@ export async function openInFinder(storagePath: string, opts: OpenInFinderOpts =
   let dir: FileSystemDirectoryHandle = root;
   for (let i = 0; i < parts.length - 1; i++) {
     try {
-      dir = await dir.getDirectoryHandle(parts[i]);
+      dir = await dir.getDirectoryHandle(parts[i]!);
     } catch {
       return { kind: "file-not-found", path: storagePath };
     }
@@ -65,7 +65,7 @@ export async function openInFinder(storagePath: string, opts: OpenInFinderOpts =
   let fileHandle: FileSystemFileHandle;
   let justDownloaded = false;
   try {
-    fileHandle = await dir.getFileHandle(parts[parts.length - 1]);
+    fileHandle = await dir.getFileHandle(parts[parts.length - 1]!);
   } catch {
     // Demo-mode fallback: filen finns inte i user:s lokala mapp men på GH
     // Pages. Lazy-download + skriv hit, sen returnera handle till nya filen.

--- a/src/lib/client/fsa/preload-documents.ts
+++ b/src/lib/client/fsa/preload-documents.ts
@@ -98,11 +98,13 @@ export async function preloadAllDocuments(opts: PreloadOpts): Promise<PreloadRes
 
 async function fileExists(root: FileSystemDirectoryHandle, relativePath: string): Promise<boolean> {
   const parts = relativePath.replace(/^\/+/, "").split("/").filter(Boolean);
+  const fileName = parts[parts.length - 1];
+  if (fileName === undefined) return false; // tom sökväg → finns inte
   let dir: FileSystemDirectoryHandle = root;
   for (let i = 0; i < parts.length - 1; i++) {
-    try { dir = await dir.getDirectoryHandle(parts[i]); }
+    try { dir = await dir.getDirectoryHandle(parts[i]!); }
     catch { return false; }
   }
-  try { await dir.getFileHandle(parts[parts.length - 1]); return true; }
+  try { await dir.getFileHandle(fileName); return true; }
   catch { return false; }
 }

--- a/src/lib/client/fsa/read-from-fsa.ts
+++ b/src/lib/client/fsa/read-from-fsa.ts
@@ -12,11 +12,11 @@ export async function readFromFsa(handle: FileSystemDirectoryHandle, path: strin
   if (parts.length === 0) return null;
   let dir: FileSystemDirectoryHandle = handle;
   for (let i = 0; i < parts.length - 1; i++) {
-    try { dir = await dir.getDirectoryHandle(parts[i]); }
+    try { dir = await dir.getDirectoryHandle(parts[i]!); }
     catch { return null; }
   }
   try {
-    const fh = await dir.getFileHandle(parts[parts.length - 1]);
+    const fh = await dir.getFileHandle(parts[parts.length - 1]!);
     return await fh.getFile();
   } catch { return null; }
 }

--- a/src/lib/client/fsa/upload-document.ts
+++ b/src/lib/client/fsa/upload-document.ts
@@ -37,7 +37,7 @@ function defaultGenerateId(): string {
 
 function extFromFile(file: File): string {
   const m = file.name.match(/\.([a-zA-Z0-9]+)$/);
-  return m ? m[1].toLowerCase() : "bin";
+  return m?.[1] ? m[1].toLowerCase() : "bin";
 }
 
 export async function uploadDocumentToFsa(opts: UploadOptions): Promise<UploadResult> {

--- a/src/lib/client/github/api.ts
+++ b/src/lib/client/github/api.ts
@@ -192,7 +192,7 @@ export async function updateRef(
 
 function bytesToBase64(bytes: Uint8Array): string {
   let s = "";
-  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]!);
   return btoa(s);
 }
 
@@ -213,9 +213,9 @@ export function parseRepoLocator(input: string): RepoLocator | null {
   const trimmed = input.trim().replace(/\.git$/, "");
   // Försök matcha github.com-prefixet först
   const ghMatch = trimmed.match(/github\.com[/:]([^/]+)\/([^/\s]+)$/);
-  if (ghMatch) return { owner: ghMatch[1], repo: ghMatch[2] };
+  if (ghMatch) return { owner: ghMatch[1]!, repo: ghMatch[2]! };
   // Annars: kortform "owner/repo" utan host
   const shortMatch = trimmed.match(/^([^/\s:]+)\/([^/\s]+)$/);
-  if (shortMatch) return { owner: shortMatch[1], repo: shortMatch[2] };
+  if (shortMatch) return { owner: shortMatch[1]!, repo: shortMatch[2]! };
   return null;
 }

--- a/src/lib/client/github/fsa-walker.ts
+++ b/src/lib/client/github/fsa-walker.ts
@@ -50,11 +50,12 @@ async function walk(dir: FileSystemDirectoryHandle, prefix: string, out: WalkedF
  */
 export async function writeFile(handle: FileSystemDirectoryHandle, path: string, bytes: Uint8Array): Promise<void> {
   const segments = path.split("/").filter((s) => s.length > 0);
+  const fileName = segments[segments.length - 1];
+  if (fileName === undefined) throw new Error(`writeFile: tom sökväg "${path}"`);
   let dir = handle;
   for (let i = 0; i < segments.length - 1; i++) {
-    dir = await dir.getDirectoryHandle(segments[i], { create: true });
+    dir = await dir.getDirectoryHandle(segments[i]!, { create: true });
   }
-  const fileName = segments[segments.length - 1];
   const fh = await dir.getFileHandle(fileName, { create: true });
   const writable = await (fh as FileSystemFileHandle & {
     createWritable: () => Promise<FileSystemWritableFileStream>;
@@ -68,15 +69,17 @@ export async function writeFile(handle: FileSystemDirectoryHandle, path: string,
  */
 export async function deleteFile(handle: FileSystemDirectoryHandle, path: string): Promise<void> {
   const segments = path.split("/").filter((s) => s.length > 0);
+  const fileName = segments[segments.length - 1];
+  if (fileName === undefined) return; // tom sökväg → inget att radera
   let dir = handle;
   for (let i = 0; i < segments.length - 1; i++) {
     try {
-      dir = await dir.getDirectoryHandle(segments[i]);
+      dir = await dir.getDirectoryHandle(segments[i]!);
     } catch {
       return; // mellanliggande katalog saknas → filen finns inte
     }
   }
   try {
-    await dir.removeEntry(segments[segments.length - 1]);
+    await dir.removeEntry(fileName);
   } catch { /* fil saknas redan */ }
 }

--- a/src/lib/client/github/git-blob-hash.ts
+++ b/src/lib/client/github/git-blob-hash.ts
@@ -25,8 +25,8 @@ export async function gitBlobSha1(content: Uint8Array): Promise<string> {
 
 function hexEncode(bytes: Uint8Array): string {
   let s = "";
-  for (let i = 0; i < bytes.length; i++) {
-    s += bytes[i].toString(16).padStart(2, "0");
+  for (const byte of bytes) {
+    s += byte.toString(16).padStart(2, "0");
   }
   return s;
 }

--- a/src/lib/client/github/pull.ts
+++ b/src/lib/client/github/pull.ts
@@ -116,8 +116,9 @@ async function parallelLimit<T>(
   let i = 0;
   const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
     while (i < items.length) {
-      const idx = i++;
-      await fn(items[idx]);
+      const item = items[i++];
+      if (item === undefined) continue;
+      await fn(item);
     }
   });
   await Promise.all(workers);

--- a/src/lib/client/github/push.ts
+++ b/src/lib/client/github/push.ts
@@ -131,7 +131,7 @@ async function parallelLimit<T>(
   const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
     while (i < items.length) {
       const idx = i++;
-      await fn(items[idx]);
+      await fn(items[idx]!);
     }
   });
   await Promise.all(workers);

--- a/src/lib/client/jobs/register-workers.ts
+++ b/src/lib/client/jobs/register-workers.ts
@@ -125,11 +125,11 @@ jobQueue.registerWorker<ExtractTextPayload>("extract-text", async (payload, ctx)
   const parts = payload.storagePath.replace(/^\/+/, "").split("/");
   let dir: FileSystemDirectoryHandle = handle;
   for (let i = 0; i < parts.length - 1; i++) {
-    try { dir = await dir.getDirectoryHandle(parts[i]); }
+    try { dir = await dir.getDirectoryHandle(parts[i]!); }
     catch { console.warn("[extract-text] saknad katalog:", parts[i]); return; }
   }
   let fileHandle: FileSystemFileHandle;
-  try { fileHandle = await dir.getFileHandle(parts[parts.length - 1]); }
+  try { fileHandle = await dir.getFileHandle(parts[parts.length - 1]!); }
   catch { console.warn("[extract-text] saknad fil:", payload.storagePath); return; }
   const file = await fileHandle.getFile();
   const bytes = new Uint8Array(await file.arrayBuffer());

--- a/src/lib/client/keys/ssh-format.ts
+++ b/src/lib/client/keys/ssh-format.ts
@@ -64,6 +64,6 @@ function writeUint32Be(buf: Uint8Array, offset: number, value: number): void {
 
 function base64Encode(bytes: Uint8Array): string {
   let s = "";
-  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]!);
   return btoa(s);
 }

--- a/src/lib/client/keys/sshsig.ts
+++ b/src/lib/client/keys/sshsig.ts
@@ -144,6 +144,6 @@ function armor(wire: Uint8Array): string {
 
 function base64Encode(bytes: Uint8Array): string {
   let s = "";
-  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]!);
   return btoa(s);
 }

--- a/src/lib/client/kostnadsrakning/render-pdf.ts
+++ b/src/lib/client/kostnadsrakning/render-pdf.ts
@@ -38,6 +38,17 @@
 import type { KostnadsrakningResult } from "@/lib/shared/kostnadsrakning";
 import type { PDFPage, PDFFont } from "pdf-lib";
 
+/** En formaterad utläggsrad i templateContext.expenseLines (se
+ *  kostnadsrakning.ts buildTemplateContext) — alla fält är required strings. */
+interface ExpenseRow {
+  date: string;
+  description: string;
+  vatRateLabel: string;
+  exclVatFormatted: string;
+  vatFormatted: string;
+  inclVatFormatted: string;
+}
+
 export interface RenderInput {
   result: KostnadsrakningResult;
   meta: {
@@ -124,8 +135,10 @@ export async function renderKostnadsrakningPdf(input: RenderInput): Promise<Uint
     y -= 22;
   }
 
-  // Utlägg
-  const lines = (c.expenseLines as Array<Record<string, string>>) ?? [];
+  // Utlägg. Precis lokal radtyp (alla fält required strings) i st.f.
+  // Record<string,string> — annars ger noUncheckedIndexedAccess `string |
+  // undefined` per fält och tvingar fram döda `?? ""`-fallbacks.
+  const lines = (c.expenseLines as ExpenseRow[] | undefined) ?? [];
   if (lines.length > 0) {
     page.drawText("Utlägg", { x: MARGIN, y, size: 11, font: bold });
     y -= 14;

--- a/src/lib/server/data-store/in-memory/writable-delegate.ts
+++ b/src/lib/server/data-store/in-memory/writable-delegate.ts
@@ -85,9 +85,10 @@ export class WritableDelegate<T extends Record<string, unknown>> extends ReadOnl
   override async update(args: unknown): Promise<never> {
     const a = args as { where: { id: string }; data: Partial<T> };
     const idx = this.collection.findIndex((r) => (r as { id?: string }).id === a.where.id);
-    if (idx < 0) throw new Error(`Hittade inte ${this.wopts.entity} med id=${a.where.id}`);
-    const prev = { ...this.collection[idx] };
-    const updated = { ...this.collection[idx], ...a.data, updatedAt: new Date() } as T;
+    const current = this.collection[idx];
+    if (idx < 0 || current === undefined) throw new Error(`Hittade inte ${this.wopts.entity} med id=${a.where.id}`);
+    const prev = { ...current };
+    const updated = { ...current, ...a.data, updatedAt: new Date() } as T;
     const enriched = this.wopts.enrichRow ? this.wopts.enrichRow(updated) : updated;
     this.collection[idx] = enriched;
     await this.wopts.onMutate?.({ entity: this.wopts.entity, kind: "update", row: enriched, previous: prev });
@@ -97,8 +98,8 @@ export class WritableDelegate<T extends Record<string, unknown>> extends ReadOnl
   override async delete(args: unknown): Promise<never> {
     const a = args as { where: { id: string } };
     const idx = this.collection.findIndex((r) => (r as { id?: string }).id === a.where.id);
-    if (idx < 0) throw new Error(`Hittade inte ${this.wopts.entity} med id=${a.where.id}`);
     const removed = this.collection[idx];
+    if (idx < 0 || removed === undefined) throw new Error(`Hittade inte ${this.wopts.entity} med id=${a.where.id}`);
     this.collection.splice(idx, 1);
     await this.wopts.onMutate?.({ entity: this.wopts.entity, kind: "delete", row: removed });
     return removed as never;

--- a/src/lib/server/events/uuid7.ts
+++ b/src/lib/server/events/uuid7.ts
@@ -25,9 +25,9 @@ export function uuidv7(): string {
   bytes[5] = ts & 0xff;
 
   // Version 7 i byte 6 (de fyra mest signifikanta bitarna)
-  bytes[6] = (bytes[6] & 0x0f) | 0x70;
+  bytes[6] = (bytes[6]! & 0x0f) | 0x70;
   // RFC 4122 variant i byte 8 (de två mest signifikanta bitarna)
-  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
 
   const hex = bytes.toString("hex");
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;

--- a/src/lib/server/local-first/filesystem-claim-store.ts
+++ b/src/lib/server/local-first/filesystem-claim-store.ts
@@ -103,7 +103,7 @@ export class FilesystemClaimStore implements IClaimStore {
       // Iterera baklänges — vi vill ha senaste matchande raden
       for (let i = lines.length - 1; i >= 0; i--) {
         try {
-          const row = this.projection.deserializeLine(lines[i]);
+          const row = this.projection.deserializeLine(lines[i]!);
           if (row.claimId === claimId) return row;
         } catch {
           // Trasig rad — hoppa över, robust mot partial writes

--- a/src/lib/server/local-first/in-memory-git-ops.ts
+++ b/src/lib/server/local-first/in-memory-git-ops.ts
@@ -34,7 +34,7 @@ export class InMemoryGitOps implements IGitOps {
     private readonly fs: InMemoryFileSystem = new InMemoryFileSystem(),
     private readonly remote: SharedRemote = makeSharedRemote(),
   ) {
-    this.knownRemoteHash = remote.commits[remote.commits.length - 1].hash;
+    this.knownRemoteHash = remote.commits[remote.commits.length - 1]!.hash;
     this.localCommits = [...remote.commits];
     // Initial sync: applicera remote head:s working tree (om någon)
     this.applyWorkingTree(this.knownRemoteHash);
@@ -54,15 +54,15 @@ export class InMemoryGitOps implements IGitOps {
   }
 
   async fetch(): Promise<void> {
-    this.knownRemoteHash = this.remote.commits[this.remote.commits.length - 1].hash;
+    this.knownRemoteHash = this.remote.commits[this.remote.commits.length - 1]!.hash;
   }
 
   async remoteHead(): Promise<GitCommit> {
-    return this.remote.commits[this.remote.commits.length - 1];
+    return this.remote.commits[this.remote.commits.length - 1]!;
   }
 
   async localHead(): Promise<GitCommit> {
-    return this.localCommits[this.localCommits.length - 1];
+    return this.localCommits[this.localCommits.length - 1]!;
   }
 
   async pendingCommitsAhead(): Promise<GitCommit[]> {
@@ -85,7 +85,7 @@ export class InMemoryGitOps implements IGitOps {
   async push(): Promise<PushResult> {
     // CAS: remote-headen vi senast såg måste fortfarande vara den
     // aktuella remote-headen, annars NonFastForward.
-    const currentRemoteHead = this.remote.commits[this.remote.commits.length - 1].hash;
+    const currentRemoteHead = this.remote.commits[this.remote.commits.length - 1]!.hash;
     if (currentRemoteHead !== this.knownRemoteHash) {
       return { ok: false, reason: "NonFastForward" };
     }
@@ -93,7 +93,7 @@ export class InMemoryGitOps implements IGitOps {
     this.remote.commits.push(...pending);
     // Snapshot:a vår working tree mot senaste commit-hashen så att
     // andra klienter kan pulla in den vid fetch+reset.
-    const newHead = this.remote.commits[this.remote.commits.length - 1];
+    const newHead = this.remote.commits[this.remote.commits.length - 1]!;
     this.remote.workingTrees.set(newHead.hash, this.fs.snapshot());
     this.knownRemoteHash = newHead.hash;
     return { ok: true };
@@ -101,7 +101,7 @@ export class InMemoryGitOps implements IGitOps {
 
   async resetHardToRemote(): Promise<void> {
     this.localCommits = [...this.remote.commits];
-    this.knownRemoteHash = this.remote.commits[this.remote.commits.length - 1].hash;
+    this.knownRemoteHash = this.remote.commits[this.remote.commits.length - 1]!.hash;
     this.applyWorkingTree(this.knownRemoteHash);
   }
 

--- a/src/lib/server/local-first/isomorphic-git-ops.ts
+++ b/src/lib/server/local-first/isomorphic-git-ops.ts
@@ -117,7 +117,9 @@ export class IsomorphicGitOps implements IGitOps {
       author: { name: this.deps.authorName, email: this.deps.authorEmail },
     });
     const log = await git.log({ fs: this.fs.nodeFs(), dir: this.dir, ref: oid, depth: 1 });
-    return this.toCommit(log[0]);
+    const head = log[0];
+    if (!head) throw new Error("IsomorphicGitOps: commit gav ingen log-post");
+    return this.toCommit(head);
   }
 
   // eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Async method 'push' has a complexity of 9. Maximum allowed is 8.)
@@ -198,7 +200,9 @@ export class IsomorphicGitOps implements IGitOps {
   private async headOf(ref: string): Promise<GitCommit> {
     const oid = await git.resolveRef({ fs: this.fs.nodeFs(), dir: this.dir, ref });
     const log = await git.log({ fs: this.fs.nodeFs(), dir: this.dir, ref: oid, depth: 1 });
-    return this.toCommit(log[0]);
+    const head = log[0];
+    if (!head) throw new Error(`IsomorphicGitOps: hittade ingen commit för ref ${ref}`);
+    return this.toCommit(head);
   }
 
   private toCommit(entry: { oid: string; commit: { message: string; author: { name: string; timestamp: number } } }): GitCommit {

--- a/src/lib/server/local-first/node-git-ops.ts
+++ b/src/lib/server/local-first/node-git-ops.ts
@@ -116,8 +116,9 @@ export class NodeGitOps implements IGitOps {
   private async headOf(ref: string): Promise<GitCommit> {
     const { stdout } = await this.run(["log", "-1", ref, `--format=${FORMAT}`]);
     const commits = this.parseLog(stdout);
-    if (!commits.length) throw new Error(`Inget HEAD för ${ref}`);
-    return commits[0];
+    const head = commits[0];
+    if (!head) throw new Error(`Inget HEAD för ${ref}`);
+    return head;
   }
 
   private parseLog(stdout: string): GitCommit[] {
@@ -126,7 +127,7 @@ export class NodeGitOps implements IGitOps {
       .map((line) => line.trim())
       .filter(Boolean)
       .map((line) => {
-        const [hash, message, author, ts] = line.split("|");
+        const [hash = "", message = "", author = "", ts = ""] = line.split("|");
         return { hash, message, author, ts };
       });
   }

--- a/src/lib/server/routers/document/suggestions.ts
+++ b/src/lib/server/routers/document/suggestions.ts
@@ -216,14 +216,16 @@ async function resolveOrCreateGroupContact(
   suggs: Suggestion[],
   matterId: string,
 ): Promise<ContactId> {
+  const first = suggs[0];
+  if (!first) throw new TRPCError({ code: "NOT_FOUND" });
   const personalNumber = pickFirstFromGroup(suggs, "personalNumber");
   const orgNumber = pickFirstFromGroup(suggs, "orgNumber");
   const existing = await findGroupContact(ctx, suggs, matterId, personalNumber, orgNumber);
   if (existing) return asId<"ContactId">(existing.id);
   const created = (await ctx.dataStore.contacts.create({
     data: {
-      name: suggs[0].name,
-      contactType: suggs[0].contactType,
+      name: first.name,
+      contactType: first.contactType,
       email: pickFirstFromGroup(suggs, "email"),
       phone: pickFirstFromGroup(suggs, "phone"),
       personalNumber,
@@ -256,10 +258,12 @@ async function findGroupContact(
     where: { matterId },
     include: { contact: true },
   } as never)) as Array<{ contact: ContactCandidate }>;
+  const first = suggs[0];
+  if (!first) return null;
   const dedup = findExistingContactForSuggestion(
     {
-      name: suggs[0].name,
-      contactType: suggs[0].contactType,
+      name: first.name,
+      contactType: first.contactType,
       personalNumber: null,
       orgNumber: null,
     },
@@ -399,7 +403,9 @@ export const suggestionProcedures = {
     )
     .mutation(async ({ ctx, input }) => {
       const suggs = await loadPendingGroup(ctx, input.suggestionIds);
-      const matterId = suggs[0].document.matterId;
+      const first = suggs[0];
+      if (!first) throw new TRPCError({ code: "NOT_FOUND" });
+      const matterId = first.document.matterId;
 
       const contactId = input.existingContactId
         ? await resolveExistingContact(ctx, input.existingContactId)

--- a/src/lib/server/routers/matter.ts
+++ b/src/lib/server/routers/matter.ts
@@ -64,7 +64,7 @@ async function nextMatterNumber(ctx: MatterCtx): Promise<string> {
     where: { organizationId: ctx.orgId, matterNumber: { startsWith: `${year}-` } },
     orderBy: { matterNumber: "desc" },
   });
-  const seq = last ? parseInt(last.matterNumber.split("-")[1], 10) + 1 : 1;
+  const seq = last ? parseInt(last.matterNumber.split("-")[1] ?? "0", 10) + 1 : 1;
   return `${year}-${seq.toString().padStart(4, "0")}`;
 }
 

--- a/src/lib/server/routers/timeEntry.ts
+++ b/src/lib/server/routers/timeEntry.ts
@@ -183,12 +183,12 @@ export const timeEntryRouter = router({
       // Group by user
       const byUser: Record<string, { name: string; totalMinutes: number; billableMinutes: number; entries: typeof entries }> = {};
       for (const entry of entries) {
-        if (!byUser[entry.userId]) {
-          byUser[entry.userId] = { name: entry.user.name, totalMinutes: 0, billableMinutes: 0, entries: [] };
-        }
-        byUser[entry.userId].totalMinutes += entry.minutes;
-        if (entry.billable) byUser[entry.userId].billableMinutes += entry.minutes;
-        byUser[entry.userId].entries.push(entry);
+        const bucket = byUser[entry.userId] ??= {
+          name: entry.user.name, totalMinutes: 0, billableMinutes: 0, entries: [],
+        };
+        bucket.totalMinutes += entry.minutes;
+        if (entry.billable) bucket.billableMinutes += entry.minutes;
+        bucket.entries.push(entry);
       }
 
       return { byUser, totalEntries: entries.length };

--- a/src/lib/server/rules/execute.ts
+++ b/src/lib/server/rules/execute.ts
@@ -76,8 +76,10 @@ function errMessage(err: unknown): string {
 async function runSteps(steps: RuleStep[], ctx: ExecutionContext, depth = 0, loopBindings?: Record<string, unknown>): Promise<{ stepsRan: number; httpResponse?: { status: number; body?: unknown }; error?: { step: number; message: string } }> {
   let ran = 0;
   for (let i = 0; i < steps.length; i++) {
+    // i < steps.length → in-bounds; assertion undviker en extra gren (complexity ≤ 8).
+    const step = steps[i]!;
     try {
-      const subResult = await runStep(steps[i], ctx, depth, loopBindings);
+      const subResult = await runStep(step, ctx, depth, loopBindings);
       ran++;
       if (subResult?.httpResponse) return { stepsRan: ran, httpResponse: subResult.httpResponse };
       ran += subResult?.nestedRan ?? 0;

--- a/src/lib/server/rules/template.ts
+++ b/src/lib/server/rules/template.ts
@@ -42,7 +42,7 @@ const FILTERS: Record<string, (v: unknown) => unknown> = {
 export function template(input: string, ctx: Record<string, unknown>): unknown {
   const SINGLE = /^\{\{\s*([^}]+?)\s*\}\}$/;
   const single = input.match(SINGLE);
-  if (single) return resolveOne(single[1], ctx);
+  if (single) return resolveOne(single[1] ?? "", ctx);
 
   return input.replace(/\{\{\s*([^}]+?)\s*\}\}/g, (_m, expr) => {
     const v = resolveOne(expr, ctx);
@@ -51,7 +51,7 @@ export function template(input: string, ctx: Record<string, unknown>): unknown {
 }
 
 function resolveOne(expr: string, ctx: Record<string, unknown>): unknown {
-  const [pathRaw, ...filters] = expr.split("|").map((s) => s.trim());
+  const [pathRaw = "", ...filters] = expr.split("|").map((s) => s.trim());
   let v = lookup(ctx, pathRaw);
   for (const f of filters) {
     const fn = FILTERS[f];

--- a/src/lib/shared/brottmalstaxa.ts
+++ b/src/lib/shared/brottmalstaxa.ts
@@ -190,6 +190,14 @@ export function computeBrottmalstaxa(opts: ComputeOpts): TaxaResult {
   const idx = level - 1;
   const e = row.ersattning[idx];
   const g = row.gransvarde[idx];
+  if (e === undefined || g === undefined) {
+    // Inte väntat — idx härleds ur validerad nivå (1-4), men defensiv
+    return {
+      kind: "invalid-input", intervalLabel: "", level,
+      ersattningExclVat: 0, gransvardeExclVat: 0,
+      notes: ["Hittade ingen taxa-rad för angiven nivå."],
+    };
+  }
 
   const ersattning = hasFTax ? e : applyNoFTaxFactor(e);
   const gransvarde = hasFTax ? g : applyNoFTaxFactor(g);

--- a/src/lib/shared/uuid-derive.ts
+++ b/src/lib/shared/uuid-derive.ts
@@ -39,8 +39,8 @@ export function uuidv5(name: string, namespace: string): string {
 
   const hash = sha1(input);
   const bytes = hash.slice(0, 16);
-  bytes[6] = (bytes[6] & 0x0f) | 0x50; // version 5
-  bytes[8] = (bytes[8] & 0x3f) | 0x80; // RFC 4122-variant
+  bytes[6] = (bytes[6]! & 0x0f) | 0x50; // version 5
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80; // RFC 4122-variant
   return bytesToUuid(bytes);
 }
 
@@ -73,7 +73,7 @@ function uuidToBytes(uuid: string): Uint8Array {
 function bytesToUuid(bytes: Uint8Array): string {
   const hex: string[] = [];
   for (let i = 0; i < 16; i++) {
-    hex.push(HEX[(bytes[i] >> 4) & 0x0f] + HEX[bytes[i] & 0x0f]);
+    hex.push(HEX[(bytes[i]! >> 4) & 0x0f]! + HEX[bytes[i]! & 0x0f]!);
   }
   const h = hex.join("");
   return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`;
@@ -95,10 +95,10 @@ function sha1(data: Uint8Array): Uint8Array {
     const w = new Uint32Array(80);
     for (let i = 0; i < 16; i++) {
       const off = chunkStart + i * 4;
-      w[i] = (padded[off] << 24) | (padded[off + 1] << 16) | (padded[off + 2] << 8) | padded[off + 3];
+      w[i] = (padded[off]! << 24) | (padded[off + 1]! << 16) | (padded[off + 2]! << 8) | padded[off + 3]!;
     }
     for (let i = 16; i < 80; i++) {
-      w[i] = rotl(w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16], 1);
+      w[i] = rotl(w[i - 3]! ^ w[i - 8]! ^ w[i - 14]! ^ w[i - 16]!, 1);
     }
     let a = h0, b = h1, c = h2, d = h3, e = h4;
     for (let i = 0; i < 80; i++) {
@@ -107,7 +107,7 @@ function sha1(data: Uint8Array): Uint8Array {
       else if (i < 40) { f = b ^ c ^ d;          k = 0x6ed9eba1; }
       else if (i < 60) { f = (b & c) | (b & d) | (c & d); k = 0x8f1bbcdc; }
       else             { f = b ^ c ^ d;          k = 0xca62c1d6; }
-      const temp = (rotl(a, 5) + f + e + k + w[i]) >>> 0;
+      const temp = (rotl(a, 5) + f + e + k + w[i]!) >>> 0;
       e = d; d = c; c = rotl(b, 30); b = a; a = temp;
     }
     h0 = (h0 + a) >>> 0; h1 = (h1 + b) >>> 0; h2 = (h2 + c) >>> 0;
@@ -138,10 +138,10 @@ function padMessage(data: Uint8Array): Uint8Array {
 function wordsToBytes(words: number[]): Uint8Array {
   const out = new Uint8Array(words.length * 4);
   for (let i = 0; i < words.length; i++) {
-    out[i * 4] = (words[i] >>> 24) & 0xff;
-    out[i * 4 + 1] = (words[i] >>> 16) & 0xff;
-    out[i * 4 + 2] = (words[i] >>> 8) & 0xff;
-    out[i * 4 + 3] = words[i] & 0xff;
+    out[i * 4] = (words[i]! >>> 24) & 0xff;
+    out[i * 4 + 1] = (words[i]! >>> 16) & 0xff;
+    out[i * 4 + 2] = (words[i]! >>> 8) & 0xff;
+    out[i * 4 + 3] = words[i]! & 0xff;
   }
   return out;
 }

--- a/src/lib/shared/uuid.ts
+++ b/src/lib/shared/uuid.ts
@@ -19,7 +19,7 @@ function getCrypto(): Crypto {
 
 function format(bytes: Uint8Array): string {
   const hex: string[] = [];
-  for (let i = 0; i < 16; i++) hex.push(bytes[i].toString(16).padStart(2, "0"));
+  for (let i = 0; i < 16; i++) hex.push(bytes[i]!.toString(16).padStart(2, "0"));
   const h = hex.join("");
   return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`;
 }
@@ -38,8 +38,8 @@ export function uuidv7(now: number = Date.now()): string {
   const bytes = new Uint8Array(16);
   writeTimestamp(bytes, now);
   getCrypto().getRandomValues(bytes.subarray(6));
-  bytes[6] = (bytes[6] & 0x0f) | 0x70; // version 7
-  bytes[8] = (bytes[8] & 0x3f) | 0x80; // RFC 4122-variant
+  bytes[6] = (bytes[6]! & 0x0f) | 0x70; // version 7
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80; // RFC 4122-variant
   return format(bytes);
 }
 

--- a/test/integration/seed-smoke.test.ts
+++ b/test/integration/seed-smoke.test.ts
@@ -194,7 +194,7 @@ describe("Seed-data smoke — varje meny-sida körs mot riktig DemoDataStore", (
   it("nested where via matter.organizationId hittar dokument (assertDocAccess)", async () => {
     const trpc = makeCaller();
     const matters = await trpc.matter.list({ page: 1, pageSize: 1, status: "ACTIVE" });
-    const matterId = matters.matters[0].id;
+    const matterId = matters.matters[0]!.id;
     // Skapa ett färskt dokument via document.register-flödet
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const reg = (trpc.document as unknown as { register: any }).register;

--- a/test/scripts/demo-generator-documents.test.ts
+++ b/test/scripts/demo-generator-documents.test.ts
@@ -49,8 +49,8 @@ describe("populateDocuments — metadata via API", () => {
     });
 
     expect(writes).toHaveLength(1);
-    expect(writes[0].path).toBe("documents/content/doc-1.pdf");
-    expect(writes[0].size).toBeGreaterThan(0); // riktig PDF genererad
-    expect(captured[0].sizeBytes).toBe(writes[0].size); // storlek från genererade bytes
+    expect(writes[0]!.path).toBe("documents/content/doc-1.pdf");
+    expect(writes[0]!.size).toBeGreaterThan(0); // riktig PDF genererad
+    expect(captured[0].sizeBytes).toBe(writes[0]!.size); // storlek från genererade bytes
   });
 });

--- a/test/scripts/demo-generator-template-docs.test.ts
+++ b/test/scripts/demo-generator-template-docs.test.ts
@@ -38,12 +38,12 @@ describe("populateTemplateDocs — mall → ärende", () => {
 
     expect(count).toBe(1);
     expect(writes).toHaveLength(1);
-    expect(writes[0].path).toBe("documents/content/gendoc-m-test-tpl-fullmakt.html");
+    expect(writes[0]!.path).toBe("documents/content/gendoc-m-test-tpl-fullmakt.html");
     // Mallen renderad med ärendets kontext — inga kvarvarande {{...}}.
-    expect(writes[0].html).toContain("Klient AB");
-    expect(writes[0].html).toContain("Anna Advokat");
-    expect(writes[0].html).toContain("2026-0099");
-    expect(writes[0].html).not.toContain("{{");
+    expect(writes[0]!.html).toContain("Klient AB");
+    expect(writes[0]!.html).toContain("Anna Advokat");
+    expect(writes[0]!.html).toContain("2026-0099");
+    expect(writes[0]!.html).not.toContain("{{");
 
     expect(docs).toHaveLength(1);
     expect(docs[0].matterId).toBe("m-test"); // hamnar i ärendet

--- a/test/scripts/id-translator.test.ts
+++ b/test/scripts/id-translator.test.ts
@@ -107,10 +107,10 @@ describe("translateSeed", () => {
       meta: { count: 2 }, // non-array key
     };
     const out = translateSeed(seed, t);
-    expect(out.users[0].id).toBe(t.toUuid("u-anna"));
-    expect(out.matters[0].id).toBe(t.toUuid("m-1"));
-    expect(out.matters[0].klientId).toBe(t.toUuid("c-1"));
-    expect(out.users[0].name).toBe("Anna");
+    expect(out.users[0]!.id).toBe(t.toUuid("u-anna"));
+    expect(out.matters[0]!.id).toBe(t.toUuid("m-1"));
+    expect(out.matters[0]!.klientId).toBe(t.toUuid("c-1"));
+    expect(out.users[0]!.name).toBe("Anna");
     expect(out.meta).toEqual({ count: 2 });
   });
 
@@ -121,6 +121,6 @@ describe("translateSeed", () => {
       tasks: [{ id: "t-1", userId: "u-anna" }],
     };
     const out = translateSeed(seed, t);
-    expect(out.tasks[0].userId).toBe(out.users[0].id);
+    expect(out.tasks[0]!.userId).toBe(out.users[0]!.id);
   });
 });

--- a/test/scripts/populate-unbilled-time.test.ts
+++ b/test/scripts/populate-unbilled-time.test.ts
@@ -24,7 +24,7 @@ describe("populateUnbilledTime", () => {
   it("skapar 2-3 entries per aktivt ärende (alla utan invoiceId)", async () => {
     const { target, seed } = await runTarget();
     // Populera org+users+contacts+matters först så timeEntry.create hittar dem
-    await target.caller.organization.create({ id: String(seed.organizations[0].id), name: "X" });
+    await target.caller.organization.create({ id: String(seed.organizations[0]!.id), name: "X" });
     for (const u of seed.users) {
       await target.caller.user.create({
         id: String(u.id), email: String(u.email), name: String(u.name),

--- a/test/scripts/write-demo-meta.test.ts
+++ b/test/scripts/write-demo-meta.test.ts
@@ -32,9 +32,9 @@ describe("buildDemoMeta", () => {
   it("user.id är UUID (deterministiskt från seed-id)", () => {
     const t = createIdTranslator();
     const meta = buildDemoMeta(seed(), t, FIXED_NOW);
-    expect(isUuid(meta.users[0].id)).toBe(true);
-    expect(meta.users[0].id).toBe(t.toUuid("u-anna"));
-    expect(meta.users[0].name).toBe("Anna Advokat");
+    expect(isUuid(meta.users[0]!.id)).toBe(true);
+    expect(meta.users[0]!.id).toBe(t.toUuid("u-anna"));
+    expect(meta.users[0]!.name).toBe("Anna Advokat");
   });
 
   it("inkluderar deterministisk buildAt (ISO 8601)", () => {
@@ -59,6 +59,6 @@ describe("buildDemoMeta", () => {
 
   it("title är optional", () => {
     const noTitle = seed({ users: [{ id: "u-x", name: "X", email: "x@ava", role: "ADMIN" }] });
-    expect(buildDemoMeta(noTitle, createIdTranslator(), FIXED_NOW).users[0].title).toBeUndefined();
+    expect(buildDemoMeta(noTitle, createIdTranslator(), FIXED_NOW).users[0]!.title).toBeUndefined();
   });
 });

--- a/test/unit/app/calendar/calendar-grid-helpers.test.tsx
+++ b/test/unit/app/calendar/calendar-grid-helpers.test.tsx
@@ -52,8 +52,8 @@ describe("weekDays", () => {
   it("returnerar 7 dagar måndag→söndag som täcker ankaret", () => {
     const days = weekDays(new Date(2026, 0, 7)); // onsdag
     expect(days).toHaveLength(7);
-    expect(toKey(days[0])).toBe("2026-01-05"); // måndag
-    expect(toKey(days[6])).toBe("2026-01-11"); // söndag
+    expect(toKey(days[0]!)).toBe("2026-01-05"); // måndag
+    expect(toKey(days[6]!)).toBe("2026-01-11"); // söndag
   });
 });
 
@@ -61,15 +61,15 @@ describe("monthGridDays", () => {
   it("returnerar 42 dagar för en månad och startar på måndag", () => {
     const days = monthGridDays(new Date(2026, 0, 15));
     expect(days).toHaveLength(42);
-    expect(mondayWeekday(days[0])).toBe(0);
+    expect(mondayWeekday(days[0]!)).toBe(0);
     // 1 januari 2026 är en torsdag → grid:en ska börja på måndagen innan
-    expect(toKey(days[0])).toBe("2025-12-29");
+    expect(toKey(days[0]!)).toBe("2025-12-29");
   });
 
   it("hanterar månader som börjar på måndag (ingen padding före)", () => {
     // 2026-06-01 är en måndag
     const days = monthGridDays(new Date(2026, 5, 10));
-    expect(toKey(days[0])).toBe("2026-06-01");
+    expect(toKey(days[0]!)).toBe("2026-06-01");
   });
 });
 

--- a/test/unit/app/calendar/day-view-helpers.test.tsx
+++ b/test/unit/app/calendar/day-view-helpers.test.tsx
@@ -42,8 +42,8 @@ describe("layoutEventsForDay", () => {
       ev({ startAt: new Date(2026, 3, 15, 10), endAt: new Date(2026, 3, 15, 11) }),
     ]);
     expect(out).toHaveLength(1);
-    expect(out[0].leftPct).toBe(0);
-    expect(out[0].widthPct).toBe(100);
+    expect(out[0]!.leftPct).toBe(0);
+    expect(out[0]!.widthPct).toBe(100);
   });
 
   it("två overlappande events → två kolumner med 50% var", () => {
@@ -75,7 +75,7 @@ describe("layoutEventsForDay", () => {
       ev({ startAt: new Date(2026, 3, 15, 10), endAt: null }),
     ]);
     const { hourHeight } = dayBounds();
-    expect(out[0].height).toBeCloseTo(hourHeight * 0.5, 3);
+    expect(out[0]!.height).toBeCloseTo(hourHeight * 0.5, 3);
   });
 
   it("top beräknas relativt DAY_START_HOUR", () => {
@@ -83,6 +83,6 @@ describe("layoutEventsForDay", () => {
     const out = layoutEventsForDay([
       ev({ startAt: new Date(2026, 3, 15, startHour + 2, 0), endAt: new Date(2026, 3, 15, startHour + 3, 0) }),
     ]);
-    expect(out[0].top).toBeCloseTo(2 * hourHeight, 3);
+    expect(out[0]!.top).toBeCloseTo(2 * hourHeight, 3);
   });
 });

--- a/test/unit/app/contacts/[id]/page.test.tsx
+++ b/test/unit/app/contacts/[id]/page.test.tsx
@@ -145,7 +145,7 @@ describe("ContactDetailPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /Redigera/i }));
     fireEvent.click(screen.getByRole("button", { name: /^Spara$/i }));
     expect(updateMutate).toHaveBeenCalledTimes(1);
-    expect(updateMutate.mock.calls[0][0]).toMatchObject({ id: "c1", name: "Anna Andersson" });
+    expect(updateMutate.mock.calls[0]![0]).toMatchObject({ id: "c1", name: "Anna Andersson" });
   });
 
   it("delete-knapp kallar delete efter confirm", async () => {
@@ -175,7 +175,7 @@ describe("ContactDetailPage", () => {
     fireEvent.change(screen.getByPlaceholderText(/Namn \*/), { target: { value: "Cecilia" } });
     fireEvent.click(screen.getByRole("button", { name: /^Lägg till$/i }));
     expect(addChildMutate).toHaveBeenCalledTimes(1);
-    expect(addChildMutate.mock.calls[0][0]).toMatchObject({ parentId: "c1", name: "Cecilia" });
+    expect(addChildMutate.mock.calls[0]![0]).toMatchObject({ parentId: "c1", name: "Cecilia" });
   });
 
   it("Avbryt vid redigering återgår till visningsläget", async () => {
@@ -194,7 +194,7 @@ describe("ContactDetailPage", () => {
     const emailInput = screen.getByDisplayValue("anna@x.se") as HTMLInputElement;
     fireEvent.change(emailInput, { target: { value: "ny@x.se" } });
     fireEvent.click(screen.getByRole("button", { name: /^Spara$/i }));
-    expect(updateMutate.mock.calls[0][0].email).toBe("ny@x.se");
+    expect(updateMutate.mock.calls[0]![0].email).toBe("ny@x.se");
   });
 
   it("delete avbryts när confirm returnerar false", async () => {
@@ -237,7 +237,7 @@ describe("ContactDetailPage", () => {
     fireEvent.change(screen.getByLabelText(/^Adress$/) as HTMLInputElement, { target: { value: "Lillgatan" } });
     fireEvent.change(screen.getByLabelText(/Anteckningar/) as HTMLTextAreaElement, { target: { value: "ny" } });
     fireEvent.click(screen.getByRole("button", { name: /^Spara$/i }));
-    const arg = updateMutate.mock.calls[0][0];
+    const arg = updateMutate.mock.calls[0]![0];
     expect(arg.name).toBe("Annika");
     expect(arg.phone).toBe("070-9");
     expect(arg.address).toBe("Lillgatan");
@@ -255,7 +255,7 @@ describe("ContactDetailPage", () => {
     fireEvent.change(screen.getByPlaceholderText(/Roll\/anteckning/) as HTMLInputElement, { target: { value: "VD" } });
     fireEvent.click(screen.getByRole("button", { name: /^Lägg till$/i }));
     expect(addChildMutate).toHaveBeenCalled();
-    expect(addChildMutate.mock.calls[0][0]).toMatchObject({
+    expect(addChildMutate.mock.calls[0]![0]).toMatchObject({
       parentId: "c1", name: "C", email: "c@x.se", phone: "07", notes: "VD",
     });
   });

--- a/test/unit/app/contacts/page.test.tsx
+++ b/test/unit/app/contacts/page.test.tsx
@@ -92,10 +92,10 @@ describe("ContactsPage", () => {
     render(<ContactsPage />);
     fireEvent.click(screen.getByRole("button", { name: /\+ Ny kontakt/i }));
     const inputs = screen.getAllByRole("textbox") as HTMLInputElement[];
-    fireEvent.change(inputs[0], { target: { value: "Cecilia C" } });
+    fireEvent.change(inputs[0]!, { target: { value: "Cecilia C" } });
     fireEvent.click(screen.getByRole("button", { name: /Spara kontakt/i }));
     expect(createMutate).toHaveBeenCalled();
-    expect(createMutate.mock.calls[0][0].name).toBe("Cecilia C");
+    expect(createMutate.mock.calls[0]![0].name).toBe("Cecilia C");
   });
 
   it("byter mellan PERSON och COMPANY visar olika nummer-fält", () => {
@@ -114,7 +114,7 @@ describe("ContactsPage", () => {
     expect(screen.getByRole("button", { name: /Spara kontakt/i })).toBeInTheDocument();
     // Det finns två "Avbryt" — top-headerns toggle och form Avbryt
     const cancelButtons = screen.getAllByRole("button", { name: /Avbryt/i });
-    fireEvent.click(cancelButtons[cancelButtons.length - 1]);
+    fireEvent.click(cancelButtons[cancelButtons.length - 1]!);
     expect(screen.queryByRole("button", { name: /Spara kontakt/i })).not.toBeInTheDocument();
   });
 

--- a/test/unit/app/invoices/[id]/page.test.tsx
+++ b/test/unit/app/invoices/[id]/page.test.tsx
@@ -188,11 +188,11 @@ describe("InvoiceDetailPage", () => {
       await waitFor(() => screen.getByRole("button", { name: /Registrera betalning/i })),
     );
     const numbers = screen.getAllByRole("spinbutton") as HTMLInputElement[];
-    fireEvent.change(numbers[0], { target: { value: "5000" } });
+    fireEvent.change(numbers[0]!, { target: { value: "5000" } });
     const sparaBtns = screen.getAllByRole("button", { name: /^Spara$/i });
-    fireEvent.click(sparaBtns[sparaBtns.length - 1]);
+    fireEvent.click(sparaBtns[sparaBtns.length - 1]!);
     expect(stubs.recordPayment.mutate).toHaveBeenCalled();
-    expect(stubs.recordPayment.mutate.mock.calls[0][0]).toMatchObject({
+    expect(stubs.recordPayment.mutate.mock.calls[0]![0]).toMatchObject({
       invoiceId: "i1",
       amount: 500000,
     });
@@ -204,7 +204,7 @@ describe("InvoiceDetailPage", () => {
       await waitFor(() => screen.getByRole("button", { name: /Registrera betalning/i })),
     );
     const cancels = screen.getAllByRole("button", { name: /Avbryt/i });
-    fireEvent.click(cancels[0]);
+    fireEvent.click(cancels[0]!);
     expect(screen.queryByRole("heading", { name: /Registrera betalning/i })).not.toBeInTheDocument();
   });
 
@@ -214,10 +214,10 @@ describe("InvoiceDetailPage", () => {
       await waitFor(() => screen.getByRole("button", { name: /Skapa avbetalningsplan/i })),
     );
     const numberInputs = screen.getAllByRole("spinbutton") as HTMLInputElement[];
-    fireEvent.change(numberInputs[0], { target: { value: "1000" } });
+    fireEvent.change(numberInputs[0]!, { target: { value: "1000" } });
     fireEvent.click(screen.getByRole("button", { name: /Skapa plan/i }));
     expect(stubs.createPaymentPlan.mutate).toHaveBeenCalled();
-    expect(stubs.createPaymentPlan.mutate.mock.calls[0][0]).toMatchObject({
+    expect(stubs.createPaymentPlan.mutate.mock.calls[0]![0]).toMatchObject({
       invoiceId: "i1",
       monthlyAmount: 100000,
     });
@@ -241,7 +241,7 @@ describe("InvoiceDetailPage", () => {
     const noteArea = screen.getByPlaceholderText(/anledning/i) as HTMLTextAreaElement;
     fireEvent.change(noteArea, { target: { value: "Felaktig fakturering" } });
     const krediteraBtns = screen.getAllByRole("button", { name: /Kreditera/i });
-    fireEvent.click(krediteraBtns[krediteraBtns.length - 1]);
+    fireEvent.click(krediteraBtns[krediteraBtns.length - 1]!);
     expect(stubs.createCredit.mutate).toHaveBeenCalledWith({
       invoiceId: "i1",
       notes: "Felaktig fakturering",
@@ -361,7 +361,7 @@ describe("InvoiceDetailPage", () => {
     );
     expect(screen.getByRole("heading", { name: /Kreditera faktura/i })).toBeInTheDocument();
     const cancels = screen.getAllByRole("button", { name: /Avbryt/i });
-    fireEvent.click(cancels[0]);
+    fireEvent.click(cancels[0]!);
     expect(screen.queryByRole("heading", { name: /Kreditera faktura/i })).not.toBeInTheDocument();
   });
 
@@ -372,7 +372,7 @@ describe("InvoiceDetailPage", () => {
     );
     expect(screen.getByRole("heading", { name: /Skapa avbetalningsplan/i })).toBeInTheDocument();
     const cancels = screen.getAllByRole("button", { name: /Avbryt/i });
-    fireEvent.click(cancels[0]);
+    fireEvent.click(cancels[0]!);
     expect(screen.queryByRole("heading", { name: /Skapa avbetalningsplan/i })).not.toBeInTheDocument();
   });
 
@@ -398,7 +398,7 @@ describe("InvoiceDetailPage", () => {
     expect(notes.value).toBe("Avbetalningsplan");
 
     fireEvent.click(screen.getByRole("button", { name: /Skapa plan/i }));
-    const arg = stubs.createPaymentPlan.mutate.mock.calls[0][0];
+    const arg = stubs.createPaymentPlan.mutate.mock.calls[0]![0];
     expect(arg.monthlyAmount).toBe(150000);
     expect(arg.dayOfMonth).toBe(15);
     expect(arg.startDate).toBe("2026-06-01");
@@ -426,7 +426,7 @@ describe("InvoiceDetailPage", () => {
     //    snarare än att navigera. Verifiera rätt dokument-id.
     fireEvent.click(docEl);
     await waitFor(() => expect(openDocumentMock).toHaveBeenCalledTimes(1));
-    const deps = openDocumentMock.mock.calls[0][0] as { doc: { id: string; fileName: string }; openUrl: unknown };
+    const deps = openDocumentMock.mock.calls[0]![0] as { doc: { id: string; fileName: string }; openUrl: unknown };
     expect(deps.doc).toMatchObject({ id: "faktura-i1", fileName: "Faktura 2026-0001.pdf" });
     expect(typeof deps.openUrl).toBe("function");
   });
@@ -443,8 +443,8 @@ describe("InvoiceDetailPage", () => {
     const amount = screen.getByLabelText(/^Belopp/) as HTMLInputElement;
     fireEvent.change(amount, { target: { value: "100" } });
     const sparaBtns = screen.getAllByRole("button", { name: /^Spara$/i });
-    fireEvent.click(sparaBtns[sparaBtns.length - 1]);
-    const arg = stubs.recordPayment.mutate.mock.calls[0][0];
+    fireEvent.click(sparaBtns[sparaBtns.length - 1]!);
+    const arg = stubs.recordPayment.mutate.mock.calls[0]![0];
     expect(arg.paidAt).toBe("2026-04-20");
     expect(arg.note).toBe("Banköverföring");
     expect(arg.amount).toBe(10000);

--- a/test/unit/app/matters/[id]/page.test.tsx
+++ b/test/unit/app/matters/[id]/page.test.tsx
@@ -301,7 +301,7 @@ describe("MatterDetailPage", () => {
     fireEvent.change(nameInput, { target: { value: "Bertil Berg" } });
     fireEvent.click(screen.getByRole("button", { name: /Skapa & lägg till/i }));
     expect(stubs.addNewContact.mutate).toHaveBeenCalled();
-    const arg = stubs.addNewContact.mutate.mock.calls[0][0];
+    const arg = stubs.addNewContact.mutate.mock.calls[0]![0];
     expect(arg.name).toBe("Bertil Berg");
     expect(arg.matterId).toBe("m1");
   });
@@ -310,7 +310,7 @@ describe("MatterDetailPage", () => {
     renderPage();
     await waitFor(() => screen.getByText("2026-0001"));
     const removeButtons = screen.getAllByRole("button", { name: /^Ta bort$/i });
-    fireEvent.click(removeButtons[0]);
+    fireEvent.click(removeButtons[0]!);
     expect(stubs.removeContact.mutate).toHaveBeenCalledWith({ matterContactId: "mc1" });
   });
 
@@ -322,7 +322,7 @@ describe("MatterDetailPage", () => {
     fireEvent.change(desc, { target: { value: "Mejl och telefon" } });
     fireEvent.click(screen.getByRole("button", { name: /^Spara$/i }));
     expect(stubs.createTimeEntry.mutate).toHaveBeenCalled();
-    const arg = stubs.createTimeEntry.mutate.mock.calls[0][0];
+    const arg = stubs.createTimeEntry.mutate.mock.calls[0]![0];
     expect(arg.matterId).toBe("m1");
     expect(arg.description).toBe("Mejl och telefon");
     expect(arg.billable).toBe(true);
@@ -348,7 +348,7 @@ describe("MatterDetailPage", () => {
     fireEvent.change(numberInput, { target: { value: "150" } });
     fireEvent.click(screen.getByRole("button", { name: /^Spara$/i }));
     expect(stubs.createExpense.mutate).toHaveBeenCalled();
-    const arg = stubs.createExpense.mutate.mock.calls[0][0];
+    const arg = stubs.createExpense.mutate.mock.calls[0]![0];
     expect(arg.amount).toBe(15000); // SEK → öre
     expect(arg.description).toBe("Domstolsavgift");
   });
@@ -391,7 +391,7 @@ describe("MatterDetailPage", () => {
     await waitFor(() => expect(screen.getByText("Domstolsavgift")).toBeInTheDocument());
     const removes = screen.getAllByRole("button", { name: /^Ta bort$/i });
     // sista Ta bort-knappen är på utläggsraden
-    fireEvent.click(removes[removes.length - 1]);
+    fireEvent.click(removes[removes.length - 1]!);
     expect(stubs.deleteExpense.mutate).toHaveBeenCalledWith({ id: "e1" });
     confirmSpy.mockRestore();
   });
@@ -448,7 +448,7 @@ describe("MatterDetailPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /Generera dokument/i }));
     expect(screen.getByText(/Välj mall/i)).toBeInTheDocument();
     const avbrytButtons = screen.getAllByRole("button", { name: /Avbryt/i });
-    fireEvent.click(avbrytButtons[avbrytButtons.length - 1]);
+    fireEvent.click(avbrytButtons[avbrytButtons.length - 1]!);
     expect(screen.queryByText(/Välj mall/i)).not.toBeInTheDocument();
   });
 
@@ -462,7 +462,7 @@ describe("MatterDetailPage", () => {
     fireEvent.change(select, { target: { value: "c2" } });
     fireEvent.click(screen.getByRole("button", { name: /^Lägg till$/i }));
     expect(stubs.addContact.mutate).toHaveBeenCalled();
-    const arg = stubs.addContact.mutate.mock.calls[0][0];
+    const arg = stubs.addContact.mutate.mock.calls[0]![0];
     expect(arg.contactId).toBe("c2");
     expect(arg.matterId).toBe("m1");
   });

--- a/test/unit/app/matters/page.test.tsx
+++ b/test/unit/app/matters/page.test.tsx
@@ -107,10 +107,10 @@ describe("MattersPage", () => {
     render(<MattersPage />);
     fireEvent.click(screen.getByRole("button", { name: /\+ Nytt ärende/i }));
     const inputs = screen.getAllByRole("textbox") as HTMLInputElement[];
-    fireEvent.change(inputs[0], { target: { value: "Tvist Karlsson" } });
+    fireEvent.change(inputs[0]!, { target: { value: "Tvist Karlsson" } });
     fireEvent.click(screen.getByRole("button", { name: /Skapa ärende/i }));
     expect(createMatterMutate).toHaveBeenCalled();
-    expect(createMatterMutate.mock.calls[0][0].title).toBe("Tvist Karlsson");
+    expect(createMatterMutate.mock.calls[0]![0].title).toBe("Tvist Karlsson");
   });
 
   it("ändrar status-filter", () => {

--- a/test/unit/app/reports/page.test.tsx
+++ b/test/unit/app/reports/page.test.tsx
@@ -147,8 +147,8 @@ describe("ReportsPage", () => {
   it("byter period via from/to-input", () => {
     const { container } = render(<ReportsPage />);
     const inputs = container.querySelectorAll('input[type="date"]');
-    fireEvent.change(inputs[0], { target: { value: "2026-03-01" } });
-    fireEvent.change(inputs[1], { target: { value: "2026-04-01" } });
+    fireEvent.change(inputs[0]!, { target: { value: "2026-03-01" } });
+    fireEvent.change(inputs[1]!, { target: { value: "2026-04-01" } });
     expect((inputs[0] as HTMLInputElement).value).toBe("2026-03-01");
     expect((inputs[1] as HTMLInputElement).value).toBe("2026-04-01");
   });
@@ -184,7 +184,7 @@ describe("ReportsPage", () => {
     // Vänta på att fetch anropas
     await new Promise((r) => setTimeout(r, 0));
     expect(fetchMock).toHaveBeenCalled();
-    const url = fetchMock.mock.calls[0][0] as string;
+    const url = fetchMock.mock.calls[0]![0] as string;
     expect(url).toContain("/api/reports/excel?");
     expect(url).toContain("userIds=u1");
   });

--- a/test/unit/app/settings/page.test.tsx
+++ b/test/unit/app/settings/page.test.tsx
@@ -141,9 +141,9 @@ describe("SettingsPage", () => {
     // Det finns två "Spara"-knappar (en för office-formuläret, en för kontaktuppgifter).
     // Office-formuläret renderas först → välj första.
     const saveButtons = screen.getAllByRole("button", { name: /^Spara/i });
-    fireEvent.click(saveButtons[0]);
+    fireEvent.click(saveButtons[0]!);
     await waitFor(() => expect(addOfficeMutate).toHaveBeenCalled());
-    expect(addOfficeMutate.mock.calls[0][0]).toMatchObject({ name: "Göteborg" });
+    expect(addOfficeMutate.mock.calls[0]![0]).toMatchObject({ name: "Göteborg" });
   });
 
   it("listar existerande kontor", () => {
@@ -198,10 +198,10 @@ describe("SettingsPage", () => {
     const editBtn = screen.getByRole("button", { name: /Redigera/i });
     fireEvent.click(editBtn);
     // Edit-formulär nu öppen — spara-knapp finns
-    const saveBtn = screen.getAllByRole("button", { name: /^Spara/i })[0];
+    const saveBtn = screen.getAllByRole("button", { name: /^Spara/i })[0]!;
     fireEvent.click(saveBtn);
     await waitFor(() => expect(updateOfficeMutate).toHaveBeenCalled());
-    expect(updateOfficeMutate.mock.calls[0][0]).toMatchObject({ id: "o1", name: "Stockholm" });
+    expect(updateOfficeMutate.mock.calls[0]![0]).toMatchObject({ id: "o1", name: "Stockholm" });
   });
 
   it("anropar deleteOffice när Ta bort klickas", () => {

--- a/test/unit/app/templates/page.test.tsx
+++ b/test/unit/app/templates/page.test.tsx
@@ -110,7 +110,7 @@ describe("TemplatesPage", () => {
     expect(screen.getByText(/Ta bort mall\?/i)).toBeInTheDocument();
     // Click confirm (the second "Ta bort" button in the dialog)
     const removeButtons = screen.getAllByRole("button", { name: /Ta bort/i });
-    fireEvent.click(removeButtons[removeButtons.length - 1]);
+    fireEvent.click(removeButtons[removeButtons.length - 1]!);
     expect(deleteMutate).toHaveBeenCalledWith({ id: "t1" });
   });
 

--- a/test/unit/app/time/page.test.tsx
+++ b/test/unit/app/time/page.test.tsx
@@ -102,7 +102,7 @@ describe("TimePage", () => {
     fireEvent.change(desc, { target: { value: "Klientmöte" } });
     fireEvent.click(screen.getByRole("button", { name: /^Spara$/i }));
     expect(createMutate).toHaveBeenCalled();
-    const arg = createMutate.mock.calls[0][0];
+    const arg = createMutate.mock.calls[0]![0];
     expect(arg.matterId).toBe("m1");
     expect(arg.description).toBe("Klientmöte");
     expect(arg.billable).toBe(true);

--- a/test/unit/app/users/[id]/page.test.tsx
+++ b/test/unit/app/users/[id]/page.test.tsx
@@ -101,7 +101,7 @@ describe("EditUserPage", () => {
     await screen.findByRole("heading", { name: /Redigera användare/i });
     fireEvent.click(screen.getByRole("button", { name: /^Spara$/i }));
     expect(updateMutate).toHaveBeenCalledTimes(1);
-    expect(updateMutate.mock.calls[0][0]).toMatchObject({
+    expect(updateMutate.mock.calls[0]![0]).toMatchObject({
       id: "u1",
       name: "Anna",
       email: "anna@x.se",
@@ -122,8 +122,8 @@ describe("EditUserPage", () => {
     renderPage();
     await screen.findByRole("heading", { name: /Redigera användare/i });
     const passwordInputs = document.querySelectorAll('input[type="password"]');
-    fireEvent.change(passwordInputs[0], { target: { value: "abc" } });
-    fireEvent.change(passwordInputs[1], { target: { value: "xyz" } });
+    fireEvent.change(passwordInputs[0]!, { target: { value: "abc" } });
+    fireEvent.change(passwordInputs[1]!, { target: { value: "xyz" } });
     fireEvent.click(screen.getByRole("button", { name: /^Spara$/i }));
     expect(screen.getByText(/matchar inte/i)).toBeInTheDocument();
     expect(updateMutate).not.toHaveBeenCalled();
@@ -138,7 +138,7 @@ describe("EditUserPage", () => {
     const hourlyInput = screen.getByDisplayValue("2500") as HTMLInputElement;
     fireEvent.change(hourlyInput, { target: { value: "3000" } });
     fireEvent.click(screen.getByRole("button", { name: /^Spara$/i }));
-    const arg = updateMutate.mock.calls[0][0];
+    const arg = updateMutate.mock.calls[0]![0];
     expect(arg.role).toBe("ADMIN");
     expect(arg.hourlyRate).toBe(3000);
   });
@@ -147,10 +147,10 @@ describe("EditUserPage", () => {
     renderPage();
     await screen.findByRole("heading", { name: /Redigera användare/i });
     const passwordInputs = document.querySelectorAll('input[type="password"]');
-    fireEvent.change(passwordInputs[0], { target: { value: "samelpass" } });
-    fireEvent.change(passwordInputs[1], { target: { value: "samelpass" } });
+    fireEvent.change(passwordInputs[0]!, { target: { value: "samelpass" } });
+    fireEvent.change(passwordInputs[1]!, { target: { value: "samelpass" } });
     fireEvent.click(screen.getByRole("button", { name: /^Spara$/i }));
-    expect(updateMutate.mock.calls[0][0].password).toBe("samelpass");
+    expect(updateMutate.mock.calls[0]![0].password).toBe("samelpass");
   });
 
   it("delete avbryts när confirm ger false", async () => {

--- a/test/unit/app/users/new/page.test.tsx
+++ b/test/unit/app/users/new/page.test.tsx
@@ -47,11 +47,11 @@ describe("NewUserPage", () => {
     const { container } = render(<NewUserPage />);
     const inputs = container.querySelectorAll("input");
     // name, title, email, hourlyRate, mileageRate, password, confirm
-    fireEvent.change(inputs[0], { target: { value: "Anna" } });
+    fireEvent.change(inputs[0]!, { target: { value: "Anna" } });
     fireEvent.change(container.querySelector('input[type="email"]')!, { target: { value: "anna@x.se" } });
     const passwordInputs = container.querySelectorAll('input[type="password"]');
-    fireEvent.change(passwordInputs[0], { target: { value: "abc123" } });
-    fireEvent.change(passwordInputs[1], { target: { value: "different" } });
+    fireEvent.change(passwordInputs[0]!, { target: { value: "abc123" } });
+    fireEvent.change(passwordInputs[1]!, { target: { value: "different" } });
     fireEvent.click(screen.getByRole("button", { name: /Skapa användare/i }));
     expect(screen.getByText(/matchar inte/i)).toBeInTheDocument();
     expect(createMutate).not.toHaveBeenCalled();
@@ -59,14 +59,14 @@ describe("NewUserPage", () => {
 
   it("anropar create-mutation med formdata vid submit", () => {
     const { container } = render(<NewUserPage />);
-    fireEvent.change(container.querySelectorAll("input")[0], { target: { value: "Anna" } });
+    fireEvent.change(container.querySelectorAll("input")[0]!, { target: { value: "Anna" } });
     fireEvent.change(container.querySelector('input[type="email"]')!, { target: { value: "anna@x.se" } });
     const passwordInputs = container.querySelectorAll('input[type="password"]');
-    fireEvent.change(passwordInputs[0], { target: { value: "secret" } });
-    fireEvent.change(passwordInputs[1], { target: { value: "secret" } });
+    fireEvent.change(passwordInputs[0]!, { target: { value: "secret" } });
+    fireEvent.change(passwordInputs[1]!, { target: { value: "secret" } });
     fireEvent.click(screen.getByRole("button", { name: /Skapa användare/i }));
     expect(createMutate).toHaveBeenCalledTimes(1);
-    expect(createMutate.mock.calls[0][0]).toMatchObject({
+    expect(createMutate.mock.calls[0]![0]).toMatchObject({
       name: "Anna",
       email: "anna@x.se",
       role: "LAWYER",
@@ -88,29 +88,29 @@ describe("NewUserPage", () => {
 
   it("byter roll till ADMIN och submittar", () => {
     const { container } = render(<NewUserPage />);
-    fireEvent.change(container.querySelectorAll("input")[0], { target: { value: "B" } });
+    fireEvent.change(container.querySelectorAll("input")[0]!, { target: { value: "B" } });
     fireEvent.change(container.querySelector('input[type="email"]')!, { target: { value: "b@x.se" } });
     const role = screen.getByRole("combobox") as HTMLSelectElement;
     fireEvent.change(role, { target: { value: "ADMIN" } });
     const passwords = container.querySelectorAll('input[type="password"]');
-    fireEvent.change(passwords[0], { target: { value: "pp" } });
-    fireEvent.change(passwords[1], { target: { value: "pp" } });
+    fireEvent.change(passwords[0]!, { target: { value: "pp" } });
+    fireEvent.change(passwords[1]!, { target: { value: "pp" } });
     fireEvent.click(screen.getByRole("button", { name: /Skapa användare/i }));
-    expect(createMutate.mock.calls[0][0].role).toBe("ADMIN");
+    expect(createMutate.mock.calls[0]![0].role).toBe("ADMIN");
   });
 
   it("ändrar timtaxa och milersättning", () => {
     const { container } = render(<NewUserPage />);
     const numberInputs = container.querySelectorAll('input[type="number"]');
-    fireEvent.change(numberInputs[0], { target: { value: "3500" } });
-    fireEvent.change(numberInputs[1], { target: { value: "3.50" } });
-    fireEvent.change(container.querySelectorAll("input")[0], { target: { value: "X" } });
+    fireEvent.change(numberInputs[0]!, { target: { value: "3500" } });
+    fireEvent.change(numberInputs[1]!, { target: { value: "3.50" } });
+    fireEvent.change(container.querySelectorAll("input")[0]!, { target: { value: "X" } });
     fireEvent.change(container.querySelector('input[type="email"]')!, { target: { value: "x@x.se" } });
     const passwords = container.querySelectorAll('input[type="password"]');
-    fireEvent.change(passwords[0], { target: { value: "pp" } });
-    fireEvent.change(passwords[1], { target: { value: "pp" } });
+    fireEvent.change(passwords[0]!, { target: { value: "pp" } });
+    fireEvent.change(passwords[1]!, { target: { value: "pp" } });
     fireEvent.click(screen.getByRole("button", { name: /Skapa användare/i }));
-    const arg = createMutate.mock.calls[0][0];
+    const arg = createMutate.mock.calls[0]![0];
     expect(arg.hourlyRate).toBe(3500);
   });
 });

--- a/test/unit/components/document-browser.test.tsx
+++ b/test/unit/components/document-browser.test.tsx
@@ -394,7 +394,7 @@ describe("DocumentBrowser", () => {
     await import("@testing-library/react").then(({ waitFor }) =>
       waitFor(() => expect(alertSpy).toHaveBeenCalled(), { timeout: 1000 }),
     );
-    expect(alertSpy.mock.calls[0][0]).toMatch(/working copy/i);
+    expect(alertSpy.mock.calls[0]![0]).toMatch(/working copy/i);
     alertSpy.mockRestore();
   });
 

--- a/test/unit/components/error-report-button.test.tsx
+++ b/test/unit/components/error-report-button.test.tsx
@@ -48,7 +48,7 @@ describe("ErrorReportButton", () => {
     fireEvent.click(screen.getByRole("button", { name: /Öppna GitHub-issue/ }));
 
     expect(openSpy).toHaveBeenCalledTimes(1);
-    const url = openSpy.mock.calls[0][0] as string;
+    const url = openSpy.mock.calls[0]![0] as string;
     expect(url).toContain("github.com/ulrik-s/ava/issues/new");
     const body = new URL(url).searchParams.get("body") ?? "";
     expect(decodeURIComponent(body)).toContain("Det small");
@@ -62,7 +62,7 @@ describe("ErrorReportButton", () => {
     fireEvent.click(screen.getByRole("button", { name: "Rapportera fel" }));
     fireEvent.click(screen.getByRole("button", { name: /Kopiera/ }));
     await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
-    expect(writeText.mock.calls[0][0]).toContain("[AVA]");
+    expect(writeText.mock.calls[0]![0]).toContain("[AVA]");
   });
 
   it("rensar upptäckta fel från dialogen", () => {

--- a/test/unit/components/firma-settings-panel.test.tsx
+++ b/test/unit/components/firma-settings-panel.test.tsx
@@ -189,7 +189,7 @@ describe("testOAuthProxy", () => {
     const r = await testOAuthProxy("https://proxy.local/", fetchFn);
     expect(r.ok).toBe(true);
     expect(r.msg).toContain("ABCD-1234");
-    expect(String((fetchFn.mock.calls as unknown as unknown[][])[0][0])).toBe("https://proxy.local/device/code");
+    expect(String((fetchFn.mock.calls as unknown as unknown[][])[0]![0])).toBe("https://proxy.local/device/code");
   });
 
   it("returnerar ok=false vid 500", async () => {
@@ -218,7 +218,7 @@ describe("testCorsProxy", () => {
   it("använder default-proxy när value är tom", async () => {
     const fetchFn = vi.fn(async () => ({ ok: true, status: 200 } as Response));
     await testCorsProxy("", fetchFn);
-    expect(String((fetchFn.mock.calls as unknown as unknown[][])[0][0])).toContain("cors.isomorphic-git.org");
+    expect(String((fetchFn.mock.calls as unknown as unknown[][])[0]![0])).toContain("cors.isomorphic-git.org");
   });
 
   it("returnerar ok när proxy svarar 200", async () => {
@@ -236,7 +236,7 @@ describe("testCorsProxy", () => {
   it("strippar trailing slashes innan path-konkatenering", async () => {
     const fetchFn = vi.fn(async () => ({ ok: true } as Response));
     await testCorsProxy("https://proxy/", fetchFn);
-    expect(String((fetchFn.mock.calls as unknown as unknown[][])[0][0])).not.toMatch(/proxy\/\/github/);
+    expect(String((fetchFn.mock.calls as unknown as unknown[][])[0]![0])).not.toMatch(/proxy\/\/github/);
   });
 });
 

--- a/test/unit/components/invoices-section.test.tsx
+++ b/test/unit/components/invoices-section.test.tsx
@@ -127,7 +127,7 @@ describe("InvoicesSection", () => {
     render(<InvoicesSection matterId="m1" />);
     fireEvent.click(screen.getByRole("button", { name: /\+ Acconto/i }));
     const inputs = screen.getAllByRole("spinbutton");
-    fireEvent.change(inputs[0], { target: { value: "5000" } });
+    fireEvent.change(inputs[0]!, { target: { value: "5000" } });
     fireEvent.click(screen.getByRole("button", { name: /^Skapa$/ }));
     expect(createAccontoMutate).toHaveBeenCalledWith(
       expect.objectContaining({ matterId: "m1", amount: 500000 }),
@@ -146,7 +146,7 @@ describe("InvoicesSection", () => {
     fireEvent.click(screen.getByRole("button", { name: /\+ Acconto/i }));
     expect(screen.getByText("Ny acconto-faktura")).toBeInTheDocument();
     const cancels = screen.getAllByRole("button", { name: /Avbryt/i });
-    fireEvent.click(cancels[0]);
+    fireEvent.click(cancels[0]!);
     expect(screen.queryByText("Ny acconto-faktura")).not.toBeInTheDocument();
   });
 
@@ -268,7 +268,7 @@ describe("InvoicesSection", () => {
     fireEvent.click(screen.getByRole("button", { name: /\+ Slutfaktura/i }));
     expect(screen.getByRole("heading", { name: /Skapa slutfaktura/ })).toBeInTheDocument();
     const cancels = screen.getAllByRole("button", { name: /Avbryt/i });
-    fireEvent.click(cancels[0]);
+    fireEvent.click(cancels[0]!);
     expect(screen.queryByRole("heading", { name: /Skapa slutfaktura/ })).not.toBeInTheDocument();
   });
 
@@ -280,9 +280,9 @@ describe("InvoicesSection", () => {
     const note = screen.getByLabelText(/Notering/) as HTMLTextAreaElement;
     fireEvent.change(note, { target: { value: "Förskott Q2" } });
     const inputs = screen.getAllByRole("spinbutton");
-    fireEvent.change(inputs[0], { target: { value: "1000" } });
+    fireEvent.change(inputs[0]!, { target: { value: "1000" } });
     fireEvent.click(screen.getByRole("button", { name: /^Skapa$/ }));
-    const arg = createAccontoMutate.mock.calls[0][0];
+    const arg = createAccontoMutate.mock.calls[0]![0];
     expect(arg.dueDate).toBe("2026-05-15");
     expect(arg.notes).toBe("Förskott Q2");
   });
@@ -336,10 +336,10 @@ describe("InvoicesSection", () => {
     expect(screen.getByText(/Acconto 2026-03-01/)).toBeInTheDocument();
     // Kryssa för tidspost + acconto-avdrag
     const checkboxes = screen.getAllByRole("checkbox") as HTMLInputElement[];
-    fireEvent.click(checkboxes[0]); // time entry
-    fireEvent.click(checkboxes[1]); // acconto
+    fireEvent.click(checkboxes[0]!); // time entry
+    fireEvent.click(checkboxes[1]!); // acconto
     fireEvent.click(screen.getByRole("button", { name: /Skapa slutfaktura/ }));
-    const arg = createFinalMutate.mock.calls[0][0];
+    const arg = createFinalMutate.mock.calls[0]![0];
     expect(arg.accontoInvoiceIds).toEqual(["ac1"]);
   });
 });

--- a/test/unit/components/matter-combobox.test.tsx
+++ b/test/unit/components/matter-combobox.test.tsx
@@ -64,6 +64,6 @@ describe("MatterCombobox", () => {
     const { container } = render(<MatterCombobox matters={MATTERS} value="" onChange={vi.fn()} label="Ärende" />);
     const options = container.querySelectorAll("datalist option");
     expect(options.length).toBe(3);
-    expect(options[0].getAttribute("value")).toBe("2026-0001 — Vårdnadstvist Andersson");
+    expect(options[0]!.getAttribute("value")).toBe("2026-0001 — Vårdnadstvist Andersson");
   });
 });

--- a/test/unit/components/sidebar.test.tsx
+++ b/test/unit/components/sidebar.test.tsx
@@ -64,7 +64,7 @@ describe("Sidebar", () => {
       tier: "demo", token: "ghp_x", principalId: "u-uuid",
     }));
     render(<Sidebar />);
-    const logout = screen.getAllByText("Logga ut")[0];
+    const logout = screen.getAllByText("Logga ut")[0]!;
     fireEvent.click(logout);
     const stored = JSON.parse(localStorage.getItem("ava.firma") ?? "{}");
     expect(stored.token).toBeUndefined();
@@ -87,7 +87,7 @@ describe("Sidebar", () => {
     expect(screen.getAllByText("Logga ut").length).toBeGreaterThanOrEqual(2);
     // Klicka på en länk i drawern
     const links = screen.getAllByRole("link", { name: /Kontakter/ });
-    fireEvent.click(links[0]);
+    fireEvent.click(links[0]!);
     // Drawer borde nu vara stängd
     expect(screen.getAllByText("Logga ut").length).toBe(1);
   });

--- a/test/unit/components/template-editor.test.tsx
+++ b/test/unit/components/template-editor.test.tsx
@@ -50,7 +50,7 @@ describe("TemplateEditor", () => {
     );
     const inputs = screen.getAllByRole("textbox") as HTMLInputElement[];
     // namnfält
-    fireEvent.change(inputs[0], { target: { value: "  Mitt avtal  " } });
+    fireEvent.change(inputs[0]!, { target: { value: "  Mitt avtal  " } });
     fireEvent.click(screen.getByRole("button", { name: /Spara mall/i }));
     expect(onSave).toHaveBeenCalledWith({
       name: "Mitt avtal",
@@ -85,12 +85,12 @@ describe("TemplateEditor", () => {
   it("klick på en variabel infogar tagg i editorn", () => {
     render(<TemplateEditor onSave={onSave} onCancel={onCancel} />);
     fireEvent.click(screen.getByRole("button", { name: /Variabler/i }));
-    const variable = screen.getAllByText("{{matter.matterNumber}}")[0];
+    const variable = screen.getAllByText("{{matter.matterNumber}}")[0]!;
     fireEvent.click(variable.closest("div")!);
     const textareas = screen.getAllByRole("textbox").filter(
       (el) => el.tagName === "TEXTAREA",
     ) as HTMLTextAreaElement[];
-    const editor = textareas[0];
+    const editor = textareas[0]!;
     expect(editor.value).toContain("{{matter.matterNumber}}");
   });
 

--- a/test/unit/lib/client/demo-meta.test.ts
+++ b/test/unit/lib/client/demo-meta.test.ts
@@ -36,7 +36,7 @@ describe("loadDemoMeta", () => {
     const meta = await loadDemoMeta("ulrik-s/ava", mockFetch(VALID_META));
     expect(meta.organizationId).toBe("demo-firma-ab");
     expect(meta.users).toHaveLength(2);
-    expect(meta.users[0].id).toBe("u-anna");
+    expect(meta.users[0]!.id).toBe("u-anna");
   });
 
   it("fetchar med cache:'no-store' så reset/deploy ger färsk meta", async () => {

--- a/test/unit/lib/components/data-table-helpers.test.ts
+++ b/test/unit/lib/components/data-table-helpers.test.ts
@@ -50,8 +50,8 @@ describe("groupRows", () => {
   it("returnerar 1 grupp utan label när groupBy saknas", () => {
     const g = groupRows(rows, cols);
     expect(g).toHaveLength(1);
-    expect(g[0].group).toBeNull();
-    expect(g[0].rows).toHaveLength(3);
+    expect(g[0]!.group).toBeNull();
+    expect(g[0]!.rows).toHaveLength(3);
   });
 
   it("grupperar rader på vald kolumn", () => {
@@ -63,14 +63,14 @@ describe("groupRows", () => {
 
   it("ignorerar okänd groupBy-key", () => {
     const g = groupRows(rows, cols, "okand");
-    expect(g[0].group).toBeNull();
-    expect(g[0].rows).toHaveLength(3);
+    expect(g[0]!.group).toBeNull();
+    expect(g[0]!.rows).toHaveLength(3);
   });
 
   it("tomt groupValue → label '(tomt)'", () => {
     const blank = [{ id: "x", name: "", status: "Aktiv", amount: 0 }];
     const g = groupRows(blank, cols, "name");
-    expect(g[0].group).toBe("(tomt)");
+    expect(g[0]!.group).toBe("(tomt)");
   });
 });
 

--- a/test/unit/lib/diagnostics/issue-store.test.ts
+++ b/test/unit/lib/diagnostics/issue-store.test.ts
@@ -17,7 +17,7 @@ describe("IssueStore", () => {
     const s = new IssueStore();
     expect(s.report([v()])).toBe(1);
     expect(s.count()).toBe(1);
-    expect(s.list()[0].code).toBe("KR_PENDING_NO_DOC");
+    expect(s.list()[0]!.code).toBe("KR_PENDING_NO_DOC");
   });
 
   it("dedupar på code + context", () => {

--- a/test/unit/lib/diagnostics/use-matter-invariants.test.tsx
+++ b/test/unit/lib/diagnostics/use-matter-invariants.test.tsx
@@ -35,7 +35,7 @@ describe("useMatterInvariants", () => {
     docsResult = { data: { documents: [] } };
     renderHook(() => useMatterInvariants({ matterId: "m-1", matterNumber: "2026-1" }));
     expect(issueStore.count()).toBe(1);
-    expect(issueStore.list()[0].code).toBe("KR_PENDING_NO_DOC");
+    expect(issueStore.list()[0]!.code).toBe("KR_PENDING_NO_DOC");
   });
 
   it("rapporterar inget när KR-dokument finns", () => {

--- a/test/unit/lib/firma/open-document.test.ts
+++ b/test/unit/lib/firma/open-document.test.ts
@@ -37,7 +37,7 @@ describe("openDocument", () => {
       openUrl,
       notifyError: vi.fn(),
     });
-    expect(openUrl.mock.calls[0][0]).toContain("ulrik-s.github.io/ava-demo");
+    expect(openUrl.mock.calls[0]![0]).toContain("ulrik-s.github.io/ava-demo");
   });
 
   it("self-hosted utan handle → notifyError, ingen URL öppnad", async () => {
@@ -53,7 +53,7 @@ describe("openDocument", () => {
     });
     expect(result).toBe("error");
     expect(notifyError).toHaveBeenCalled();
-    expect(notifyError.mock.calls[0][0]).toMatch(/working copy/i);
+    expect(notifyError.mock.calls[0]![0]).toMatch(/working copy/i);
     expect(openUrl).not.toHaveBeenCalled();
   });
 
@@ -69,8 +69,8 @@ describe("openDocument", () => {
       notifyError,
     });
     expect(result).toBe("error");
-    expect(notifyError.mock.calls[0][0]).toMatch(/disk/i);
-    expect(notifyError.mock.calls[0][0]).toContain("documents/content/doc-1.md");
+    expect(notifyError.mock.calls[0]![0]).toMatch(/disk/i);
+    expect(notifyError.mock.calls[0]![0]).toContain("documents/content/doc-1.md");
   });
 
   it("self-hosted med fil → skapar blob-URL och öppnar", async () => {
@@ -140,7 +140,7 @@ describe("openDocument", () => {
       openUrl,
       notifyError: vi.fn(),
     });
-    expect(openUrl.mock.calls[0][0]).toContain("/documents/naked");
+    expect(openUrl.mock.calls[0]![0]).toContain("/documents/naked");
   });
 });
 

--- a/test/unit/lib/fsa/external-edit-tracker.test.ts
+++ b/test/unit/lib/fsa/external-edit-tracker.test.ts
@@ -64,7 +64,7 @@ describe("ExternalEditTracker", () => {
 
     await vi.advanceTimersByTimeAsync(400);  // debounce-fönstret löper ut
     expect(onCommit).toHaveBeenCalledTimes(1);
-    const arg = onCommit.mock.calls[0][0];
+    const arg = onCommit.mock.calls[0]![0];
     expect(arg.docId).toBe("doc-1");
     expect(arg.saves).toBe(1);
     expect(Array.from(new Uint8Array(arg.bytes))).toEqual([2]);
@@ -90,8 +90,8 @@ describe("ExternalEditTracker", () => {
 
     await vi.advanceTimersByTimeAsync(500);
     expect(onCommit).toHaveBeenCalledTimes(1);
-    expect(onCommit.mock.calls[0][0].saves).toBe(3);
-    expect(Array.from(new Uint8Array(onCommit.mock.calls[0][0].bytes))).toEqual([4]);
+    expect(onCommit.mock.calls[0]![0].saves).toBe(3);
+    expect(Array.from(new Uint8Array(onCommit.mock.calls[0]![0].bytes))).toEqual([4]);
 
     tracker.dispose();
   });
@@ -107,7 +107,7 @@ describe("ExternalEditTracker", () => {
     await tracker.flushNow("doc-1");
 
     expect(onCommit).toHaveBeenCalledTimes(1);
-    expect(onCommit.mock.calls[0][0].saves).toBe(1);
+    expect(onCommit.mock.calls[0]![0].saves).toBe(1);
     tracker.dispose();
   });
 

--- a/test/unit/lib/fsa/read-document.test.tsx
+++ b/test/unit/lib/fsa/read-document.test.tsx
@@ -17,11 +17,11 @@ async function readFromFsa(handle: FileSystemDirectoryHandle, path: string): Pro
   if (parts.length === 0) return null;
   let dir: FileSystemDirectoryHandle = handle;
   for (let i = 0; i < parts.length - 1; i++) {
-    try { dir = await dir.getDirectoryHandle(parts[i]); }
+    try { dir = await dir.getDirectoryHandle(parts[i]!); }
     catch { return null; }
   }
   try {
-    const fh = await dir.getFileHandle(parts[parts.length - 1]);
+    const fh = await dir.getFileHandle(parts[parts.length - 1]!);
     return await fh.getFile();
   } catch { return null; }
 }

--- a/test/unit/lib/github/api.test.ts
+++ b/test/unit/lib/github/api.test.ts
@@ -86,8 +86,8 @@ describe("getBranchHead", () => {
   it("returnerar sha från /git/ref/heads/<branch>", async () => {
     mockFetch(() => jsonRes({ object: { sha: "abc123" } }));
     expect(await getBranchHead(REPO, "main", OPTS)).toBe("abc123");
-    expect(calls[0].url).toBe("https://api.github.com/repos/ulrik-s/ava/git/ref/heads/main");
-    expect((calls[0].init?.headers as Record<string, string>)?.Authorization).toBe("Bearer ghp_test");
+    expect(calls[0]!.url).toBe("https://api.github.com/repos/ulrik-s/ava/git/ref/heads/main");
+    expect((calls[0]!.init?.headers as Record<string, string>)?.Authorization).toBe("Bearer ghp_test");
   });
 
   it("kastar med statusText + body.message vid fel", async () => {
@@ -98,7 +98,7 @@ describe("getBranchHead", () => {
   it("URL-encodar branch-namn", async () => {
     mockFetch(() => jsonRes({ object: { sha: "x" } }));
     await getBranchHead(REPO, "feature/foo bar", OPTS);
-    expect(calls[0].url).toContain("feature%2Ffoo%20bar");
+    expect(calls[0]!.url).toContain("feature%2Ffoo%20bar");
   });
 });
 
@@ -111,13 +111,13 @@ describe("getCommit + getTreeRecursive + getBlob", () => {
     };
     mockFetch(() => jsonRes(commit));
     expect(await getCommit(REPO, "abc", OPTS)).toEqual(commit);
-    expect(calls[0].url).toContain("/git/commits/abc");
+    expect(calls[0]!.url).toContain("/git/commits/abc");
   });
 
   it("getTreeRecursive lägger till ?recursive=1", async () => {
     mockFetch(() => jsonRes({ sha: "t", truncated: false, tree: [] }));
     await getTreeRecursive(REPO, "treesha", OPTS);
-    expect(calls[0].url).toContain("/git/trees/treesha?recursive=1");
+    expect(calls[0]!.url).toContain("/git/trees/treesha?recursive=1");
   });
 
   it("getBlob returnerar fil-innehåll i base64", async () => {
@@ -132,7 +132,7 @@ describe("createBlob", () => {
     mockFetch(() => jsonRes({ sha: "newblob" }));
     const sha = await createBlob(REPO, new TextEncoder().encode("hej"), OPTS);
     expect(sha).toBe("newblob");
-    const body = JSON.parse(calls[0].init!.body as string);
+    const body = JSON.parse(calls[0]!.init!.body as string);
     expect(body.encoding).toBe("base64");
     expect(body.content).toBe(btoa("hej"));
   });
@@ -144,7 +144,7 @@ describe("createTree", () => {
     await createTree(REPO, "basesha", [
       { path: "a.json", mode: "100644", type: "blob", sha: "blob1" },
     ], OPTS);
-    const body = JSON.parse(calls[0].init!.body as string);
+    const body = JSON.parse(calls[0]!.init!.body as string);
     expect(body.base_tree).toBe("basesha");
     expect(body.tree).toHaveLength(1);
   });
@@ -152,7 +152,7 @@ describe("createTree", () => {
   it("utelämnar base_tree när det är null (rena trädet)", async () => {
     mockFetch(() => jsonRes({ sha: "newtree" }));
     await createTree(REPO, null, [], OPTS);
-    const body = JSON.parse(calls[0].init!.body as string);
+    const body = JSON.parse(calls[0]!.init!.body as string);
     expect(body).not.toHaveProperty("base_tree");
   });
 
@@ -161,7 +161,7 @@ describe("createTree", () => {
     await createTree(REPO, "base", [
       { path: "removed.json", mode: "100644", type: "blob", sha: null },
     ], OPTS);
-    const body = JSON.parse(calls[0].init!.body as string);
+    const body = JSON.parse(calls[0]!.init!.body as string);
     expect(body.tree[0].sha).toBeNull();
   });
 });
@@ -173,7 +173,7 @@ describe("createCommit", () => {
       message: "Add foo", tree: "treesha", parents: ["parent1"],
     }, OPTS);
     expect(sha).toBe("newcommit");
-    const body = JSON.parse(calls[0].init!.body as string);
+    const body = JSON.parse(calls[0]!.init!.body as string);
     expect(body.message).toBe("Add foo");
     expect(body.parents).toEqual(["parent1"]);
   });
@@ -185,7 +185,7 @@ describe("createCommit", () => {
       signature: "-----BEGIN SSH SIGNATURE-----...",
       author: { name: "Anna", email: "anna@firma.se" },
     }, OPTS);
-    const body = JSON.parse(calls[0].init!.body as string);
+    const body = JSON.parse(calls[0]!.init!.body as string);
     expect(body.signature).toContain("BEGIN SSH SIGNATURE");
     expect(body.author.name).toBe("Anna");
   });
@@ -195,9 +195,9 @@ describe("updateRef", () => {
   it("PATCH:ar refs/heads/<branch> med ny sha", async () => {
     mockFetch(() => jsonRes({}));
     await updateRef(REPO, "main", "newsha", OPTS);
-    expect(calls[0].url).toContain("/git/refs/heads/main");
-    expect(calls[0].init?.method).toBe("PATCH");
-    const body = JSON.parse(calls[0].init!.body as string);
+    expect(calls[0]!.url).toContain("/git/refs/heads/main");
+    expect(calls[0]!.init?.method).toBe("PATCH");
+    const body = JSON.parse(calls[0]!.init!.body as string);
     expect(body.sha).toBe("newsha");
     expect(body.force).toBe(false);
   });
@@ -205,7 +205,7 @@ describe("updateRef", () => {
   it("skickar force=true när opts.force = true", async () => {
     mockFetch(() => jsonRes({}));
     await updateRef(REPO, "main", "x", { ...OPTS, force: true });
-    const body = JSON.parse(calls[0].init!.body as string);
+    const body = JSON.parse(calls[0]!.init!.body as string);
     expect(body.force).toBe(true);
   });
 

--- a/test/unit/lib/github/fsa-walker.test.ts
+++ b/test/unit/lib/github/fsa-walker.test.ts
@@ -51,7 +51,7 @@ describe("walkFsa", () => {
     await writeFile(fsa.root, "logos/firma.png", bytes);
     const files = await walkFsa(fsa.root);
     expect(files).toHaveLength(1);
-    expect(files[0].bytes).toEqual(bytes);
+    expect(files[0]!.bytes).toEqual(bytes);
   });
 });
 

--- a/test/unit/lib/github/pull.test.ts
+++ b/test/unit/lib/github/pull.test.ts
@@ -44,7 +44,7 @@ function mockGitHub(responses: MockResponses): typeof fetch {
     }
     const blobMatch = u.match(/\/git\/blobs\/([^/]+)$/);
     if (blobMatch) {
-      const sha = blobMatch[1];
+      const sha = blobMatch[1]!;
       const b = responses.blobs?.[sha] ?? { content: btoa("default"), encoding: "base64" as const };
       return json({ sha, size: 0, ...b });
     }

--- a/test/unit/lib/github/push.test.ts
+++ b/test/unit/lib/github/push.test.ts
@@ -114,13 +114,13 @@ describe("pushViaRest", () => {
     ]);
 
     // Commit-body har rätt message + parent + tree
-    const commitBody = calls[2].body as { message: string; tree: string; parents: string[] };
+    const commitBody = calls[2]!.body as { message: string; tree: string; parents: string[] };
     expect(commitBody.message).toBe("feat: add new");
     expect(commitBody.tree).toBe("tree-1");
     expect(commitBody.parents).toEqual(["parent"]);
 
     // Tree-entries: bara nya filen (existing inte ändrat → ingen entry)
-    const treeBody = calls[1].body as { base_tree: string; tree: Array<{ path: string; sha: string }> };
+    const treeBody = calls[1]!.body as { base_tree: string; tree: Array<{ path: string; sha: string }> };
     expect(treeBody.base_tree).toBe("base-tree");
     expect(treeBody.tree.map((e) => e.path)).toEqual(["new.json"]);
   });

--- a/test/unit/lib/helper/use-helper.test.tsx
+++ b/test/unit/lib/helper/use-helper.test.tsx
@@ -45,7 +45,7 @@ describe("openViaHelper", () => {
     global.fetch = fetchMock;
     await openViaHelper({ fileName: "x.pdf", downloadUrl: "https://example.com/x" });
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const call = fetchMock.mock.calls[0];
+    const call = fetchMock.mock.calls[0]!;
     expect(call[0]).toBe("http://127.0.0.1:48761/open");
     expect(call[1].method).toBe("POST");
     expect(JSON.parse(call[1].body)).toMatchObject({ fileName: "x.pdf" });

--- a/test/unit/lib/jobs/analyze-flow.test.tsx
+++ b/test/unit/lib/jobs/analyze-flow.test.tsx
@@ -50,11 +50,11 @@ describe("classify-document worker — full dispatch", () => {
     await waitForStatus(id, "done");
 
     expect(dispatched).toHaveLength(1);
-    expect(dispatched[0].documentId).toBe("d-1");
-    expect(dispatched[0].kind).toBe("STAMNING");
+    expect(dispatched[0]!.documentId).toBe("d-1");
+    expect(dispatched[0]!.kind).toBe("STAMNING");
     // CRITICAL: UI:n förlitar sig på dessa för att stoppa "analyseras..."
-    expect(dispatched[0].analyzedAt).toBeDefined();
-    expect(dispatched[0].analysisStatus).toBe("DONE");
+    expect(dispatched[0]!.analyzedAt).toBeDefined();
+    expect(dispatched[0]!.analysisStatus).toBe("DONE");
     setAnalyzeDispatcher(null);
   });
 
@@ -67,7 +67,7 @@ describe("classify-document worker — full dispatch", () => {
     });
     await waitForStatus(id, "done");
 
-    expect(dispatched[0].kind).toBe("OKLASSIFICERAT");
+    expect(dispatched[0]!.kind).toBe("OKLASSIFICERAT");
     setAnalyzeDispatcher(null);
   });
 
@@ -80,9 +80,9 @@ describe("classify-document worker — full dispatch", () => {
     });
     await waitForStatus(id, "done");
 
-    expect(dispatched[0].kind).toBe("OKLASSIFICERAT");
+    expect(dispatched[0]!.kind).toBe("OKLASSIFICERAT");
     // Även om vi inte kunde klassa, ska analysen markeras som körd
-    expect(dispatched[0].analyzedAt).toBeDefined();
+    expect(dispatched[0]!.analyzedAt).toBeDefined();
     setAnalyzeDispatcher(null);
   });
 

--- a/test/unit/lib/jobs/mirror-outlook.test.ts
+++ b/test/unit/lib/jobs/mirror-outlook.test.ts
@@ -66,8 +66,8 @@ describe("mirror-to-outlook worker", () => {
     await waitForFinish(id);
 
     expect(dispatch).toHaveBeenCalledOnce();
-    expect(dispatch.mock.calls[0][0].patch.mirrorStatus).toBe("failed");
-    expect(dispatch.mock.calls[0][0].patch.mirrorError).toMatch(/Office 365/);
+    expect(dispatch.mock.calls[0]![0].patch.mirrorStatus).toBe("failed");
+    expect(dispatch.mock.calls[0]![0].patch.mirrorError).toMatch(/Office 365/);
     expect(graph.createGraphEvent).not.toHaveBeenCalled();
   });
 
@@ -87,7 +87,7 @@ describe("mirror-to-outlook worker", () => {
     expect(graph.createGraphEvent).toHaveBeenCalledOnce();
     expect(graph.updateGraphEvent).not.toHaveBeenCalled();
     expect(dispatch).toHaveBeenCalledOnce();
-    const patch = dispatch.mock.calls[0][0].patch;
+    const patch = dispatch.mock.calls[0]![0].patch;
     expect(patch.outlookEventId).toBe("g-new");
     expect(patch.mirrorStatus).toBe("synced");
   });
@@ -108,7 +108,7 @@ describe("mirror-to-outlook worker", () => {
     expect(job.status).toBe("done");
     expect(graph.updateGraphEvent).toHaveBeenCalledOnce();
     expect(graph.createGraphEvent).not.toHaveBeenCalled();
-    expect(dispatch.mock.calls[0][0].patch.outlookEventId).toBe("g-existing");
+    expect(dispatch.mock.calls[0]![0].patch.outlookEventId).toBe("g-existing");
   });
 
   it("delete med outlookEventId → deleteGraphEvent, ingen state-dispatch", async () => {
@@ -143,8 +143,8 @@ describe("mirror-to-outlook worker", () => {
     const job = await waitForFinish(id);
     expect(job.status).toBe("failed");
     expect(dispatch).toHaveBeenCalledOnce();
-    expect(dispatch.mock.calls[0][0].patch.mirrorStatus).toBe("failed");
-    expect(dispatch.mock.calls[0][0].patch.mirrorError).toMatch(/403/);
+    expect(dispatch.mock.calls[0]![0].patch.mirrorStatus).toBe("failed");
+    expect(dispatch.mock.calls[0]![0].patch.mirrorError).toMatch(/403/);
   });
 
   // ── outlookCalendarId-spreadens truthy-arm (per-kalender-mirroring) ──
@@ -254,6 +254,6 @@ describe("mirror-to-outlook worker", () => {
     const job = await waitForFinish(id);
     expect(job.status).toBe("failed");
     expect(dispatch).toHaveBeenCalledOnce();
-    expect(dispatch.mock.calls[0][0].patch.mirrorError).toBe("rå-sträng-fel");
+    expect(dispatch.mock.calls[0]![0].patch.mirrorError).toBe("rå-sträng-fel");
   });
 });

--- a/test/unit/lib/keys/ssh-format.test.ts
+++ b/test/unit/lib/keys/ssh-format.test.ts
@@ -29,7 +29,7 @@ describe("buildSshPublicKey", () => {
 
   it("base64-blob:n är 68 chars (50 bytes wire format → 68 base64)", () => {
     const s = buildSshPublicKey(ZERO_PUBKEY);
-    const b64 = s.split(" ")[1];
+    const b64 = s.split(" ")[1]!;
     expect(b64.length).toBe(68);
   });
 });

--- a/test/unit/lib/keys/sshsig.test.ts
+++ b/test/unit/lib/keys/sshsig.test.ts
@@ -47,7 +47,7 @@ describe("sshsigSign", () => {
     const magic = new TextDecoder().decode(bytes.slice(0, 6));
     expect(magic).toBe("SSHSIG");
     // Nästa 4 bytes: uint32be version
-    const version = (bytes[6] << 24) | (bytes[7] << 16) | (bytes[8] << 8) | bytes[9];
+    const version = (bytes[6]! << 24) | (bytes[7]! << 16) | (bytes[8]! << 8) | bytes[9]!;
     expect(version).toBe(1);
   });
 

--- a/test/unit/lib/kostnadsrakning/render-faktura-pdf.test.ts
+++ b/test/unit/lib/kostnadsrakning/render-faktura-pdf.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect } from "vitest";
 import { renderFakturaPdf } from "@/lib/client/kostnadsrakning/render-faktura-pdf";
 
-const head = (b: Uint8Array) => String.fromCharCode(b[0], b[1], b[2], b[3]);
+const head = (b: Uint8Array) => String.fromCharCode(b[0]!, b[1]!, b[2]!, b[3]!);
 
 describe("renderFakturaPdf", () => {
   it("producerar en faktura-PDF med alla fält", async () => {

--- a/test/unit/lib/kostnadsrakning/render-pdf.test.ts
+++ b/test/unit/lib/kostnadsrakning/render-pdf.test.ts
@@ -8,7 +8,7 @@ import { buildKostnadsrakningContext } from "@/lib/shared/kostnadsrakning";
 import { renderKostnadsrakningPdf } from "@/lib/client/kostnadsrakning/render-pdf";
 
 function pdfHeader(bytes: Uint8Array): string {
-  return String.fromCharCode(bytes[0], bytes[1], bytes[2], bytes[3]);
+  return String.fromCharCode(bytes[0]!, bytes[1]!, bytes[2]!, bytes[3]!);
 }
 
 describe("renderKostnadsrakningPdf", () => {

--- a/test/unit/lib/llm/active-llm.test.tsx
+++ b/test/unit/lib/llm/active-llm.test.tsx
@@ -83,7 +83,7 @@ describe("subscribeLlmProgress", () => {
     await downloadActiveModel();
     // initial + "Förbereder…" + "Klar" + ev. interna events
     expect(seen.length).toBeGreaterThanOrEqual(2);
-    expect(seen[seen.length - 1].progress).toBe(1);
+    expect(seen[seen.length - 1]!.progress).toBe(1);
     unsub();
   });
 });

--- a/test/unit/lib/shared/uuid.test.ts
+++ b/test/unit/lib/shared/uuid.test.ts
@@ -14,12 +14,12 @@ describe("uuidv7", () => {
 
   it("har version 7 (nibble efter andra bindestrecket)", () => {
     // 8-4-4-4-12 → versionsnibblen är första tecknet i tredje gruppen
-    const v = uuidv7().split("-")[2][0];
+    const v = uuidv7().split("-")[2]![0];
     expect(v).toBe("7");
   });
 
   it("har RFC-variant (8/9/a/b i fjärde gruppen)", () => {
-    const variant = uuidv7().split("-")[3][0];
+    const variant = uuidv7().split("-")[3]![0];
     expect(["8", "9", "a", "b"]).toContain(variant);
   });
 

--- a/test/unit/lib/suggestion-grouping.test.ts
+++ b/test/unit/lib/suggestion-grouping.test.ts
@@ -67,8 +67,8 @@ describe("groupSuggestions — deduplicering", () => {
     ]);
 
     expect(groups).toHaveLength(1);
-    expect(groups[0].suggestionIds).toEqual(["s1", "s2"]);
-    expect(groups[0].documents).toHaveLength(2);
+    expect(groups[0]!.suggestionIds).toEqual(["s1", "s2"]);
+    expect(groups[0]!.documents).toHaveLength(2);
   });
 
   it("slår samman samma person med flera roller i samma dokument", () => {
@@ -78,8 +78,8 @@ describe("groupSuggestions — deduplicering", () => {
     ]);
 
     expect(groups).toHaveLength(1);
-    expect(groups[0].roles).toEqual(["KLIENT", "VITTNE"]);
-    expect(groups[0].suggestionIds).toEqual(["s1", "s2"]);
+    expect(groups[0]!.roles).toEqual(["KLIENT", "VITTNE"]);
+    expect(groups[0]!.suggestionIds).toEqual(["s1", "s2"]);
   });
 
   it("dedupar på exakt samma dokument-id", () => {
@@ -88,8 +88,8 @@ describe("groupSuggestions — deduplicering", () => {
       sug({ id: "s2", personalNumber: "19850315-1234", role: "VITTNE", document: { id: "d1", fileName: "a.pdf", title: null } }),
     ]);
 
-    expect(groups[0].documents).toHaveLength(1);
-    expect(groups[0].roles).toEqual(["KLIENT", "VITTNE"]);
+    expect(groups[0]!.documents).toHaveLength(1);
+    expect(groups[0]!.roles).toEqual(["KLIENT", "VITTNE"]);
   });
 
   it("separerar olika personer", () => {
@@ -108,7 +108,7 @@ describe("groupSuggestions — deduplicering", () => {
     ]);
 
     expect(groups).toHaveLength(1);
-    expect(groups[0].roles).toEqual(["MOTPARTSOMBUD", "OMBUD"]);
+    expect(groups[0]!.roles).toEqual(["MOTPARTSOMBUD", "OMBUD"]);
   });
 
   it("slår samman på normaliserat namn när ID saknas", () => {
@@ -118,7 +118,7 @@ describe("groupSuggestions — deduplicering", () => {
     ]);
 
     expect(groups).toHaveLength(1);
-    expect(groups[0].roles).toEqual(["KLIENT", "VITTNE"]);
+    expect(groups[0]!.roles).toEqual(["KLIENT", "VITTNE"]);
   });
 });
 
@@ -131,8 +131,8 @@ describe("groupSuggestions — attribut tas från första icke-tomma", () => {
       sug({ id: "s2", personalNumber: "19850315-1234", email: "anna@example.se", phone: "0701234567" }),
     ]);
 
-    expect(groups[0].email).toBe("anna@example.se");
-    expect(groups[0].phone).toBe("0701234567");
+    expect(groups[0]!.email).toBe("anna@example.se");
+    expect(groups[0]!.phone).toBe("0701234567");
   });
 
   it("behåller första icke-tomma värdet när båda dokumenten har värden", () => {
@@ -141,7 +141,7 @@ describe("groupSuggestions — attribut tas från första icke-tomma", () => {
       sug({ id: "s2", personalNumber: "19850315-1234", email: "anna@new.se" }),
     ]);
 
-    expect(groups[0].email).toBe("anna@old.se");
+    expect(groups[0]!.email).toBe("anna@old.se");
   });
 
   it("samlar distinkta anteckningar", () => {
@@ -151,7 +151,7 @@ describe("groupSuggestions — attribut tas från första icke-tomma", () => {
       sug({ id: "s3", personalNumber: "19850315-1234", notes: "Nämnd som klient" }), // dup
     ]);
 
-    expect(groups[0].notes).toEqual(["Nämnd som klient", "Nämnd som vittne"]);
+    expect(groups[0]!.notes).toEqual(["Nämnd som klient", "Nämnd som vittne"]);
   });
 
   it("undviker dubbel-roller", () => {
@@ -160,7 +160,7 @@ describe("groupSuggestions — attribut tas från första icke-tomma", () => {
       sug({ id: "s2", role: "KLIENT", personalNumber: "19850315-1234" }),
     ]);
 
-    expect(groups[0].roles).toEqual(["KLIENT"]);
+    expect(groups[0]!.roles).toEqual(["KLIENT"]);
   });
 });
 

--- a/test/unit/lib/template-recipients.test.ts
+++ b/test/unit/lib/template-recipients.test.ts
@@ -61,7 +61,7 @@ describe("resolveRecipients", () => {
   it("faller tillbaka på rå roll-sträng om ingen label finns", () => {
     const links = [link({ contactId: "c1", role: "UNKNOWN_ROLE" })];
     const result = resolveRecipients(["c1"], links, "m1");
-    expect(result[0].data.roleLabel).toBe("UNKNOWN_ROLE");
+    expect(result[0]!.data.roleLabel).toBe("UNKNOWN_ROLE");
   });
 
   it("bevarar ordningen från recipientIds (inte från links)", () => {
@@ -100,8 +100,8 @@ describe("resolveRecipients", () => {
     const links = [link({ contactId: "c1" })];
     const result = resolveRecipients(["c1", "c1"], links, "m1");
     expect(result).toHaveLength(2);
-    expect(result[0].contactId).toBe("c1");
-    expect(result[1].contactId).toBe("c1");
+    expect(result[0]!.contactId).toBe("c1");
+    expect(result[1]!.contactId).toBe("c1");
   });
 
   it("hanterar flera länkar för samma kontakt genom att ta första matchen", () => {
@@ -113,7 +113,7 @@ describe("resolveRecipients", () => {
     ];
     const result = resolveRecipients(["c1"], links, "m1");
     expect(result).toHaveLength(1);
-    expect(result[0].data.role).toBe("KLIENT");
+    expect(result[0]!.data.role).toBe("KLIENT");
   });
 });
 

--- a/test/unit/server/adapters/demo-document-analyzer.test.ts
+++ b/test/unit/server/adapters/demo-document-analyzer.test.ts
@@ -23,7 +23,7 @@ describe("demoDocumentAnalyzer", () => {
     const jobs = jobQueue.list();
     const classifyJobs = jobs.filter((j) => j.kind === "classify-document");
     expect(classifyJobs.length).toBe(1);
-    expect(classifyJobs[0].payload).toMatchObject({ documentId: "d-test-1" });
+    expect(classifyJobs[0]!.payload).toMatchObject({ documentId: "d-test-1" });
   });
 
   it("jobb-label innehåller en del av documentId så användaren känner igen det", async () => {

--- a/test/unit/server/adapters/demo-search-index.test.ts
+++ b/test/unit/server/adapters/demo-search-index.test.ts
@@ -32,13 +32,13 @@ describe("searchDocuments", () => {
   it("matchar mot documentType", () => {
     const r = searchDocuments(docs, matters, "stämning", "org-1", 20);
     expect(r.hits.length).toBeGreaterThan(0);
-    expect(r.hits[0].id).toBe("d-1");
+    expect(r.hits[0]!.id).toBe("d-1");
   });
 
   it("matchar mot summary", () => {
     const r = searchDocuments(docs, matters, "Eriksson", "org-1", 20);
     expect(r.hits.length).toBe(1);
-    expect(r.hits[0].id).toBe("d-3");
+    expect(r.hits[0]!.id).toBe("d-3");
   });
 
   it("filtrerar bort dokument från annan org", () => {
@@ -68,8 +68,8 @@ describe("searchDocuments", () => {
 
   it("inkluderar matter-info i resultat", () => {
     const r = searchDocuments(docs, matters, "Stämningsansökan", "org-1", 20);
-    expect(r.hits[0].matterNumber).toBe("2026-001");
-    expect(r.hits[0].matterTitle).toBe("Vårdnad");
+    expect(r.hits[0]!.matterNumber).toBe("2026-001");
+    expect(r.hits[0]!.matterTitle).toBe("Vårdnad");
   });
 
   it("respekterar limit", () => {
@@ -82,7 +82,7 @@ describe("searchDocuments", () => {
     // "vårdnad" finns i d-1.fileName + d-1.summary + d-2.summary
     // d-1 ska ranka högst eftersom det har träff i både fileName + summary
     const r = searchDocuments(docs, matters, "vårdnad", "org-1", 20);
-    expect(r.hits[0].id).toBe("d-1");
+    expect(r.hits[0]!.id).toBe("d-1");
   });
 
   it("hittar ord som ENDAST finns i dokumentinnehåll (content-cache)", () => {
@@ -90,9 +90,9 @@ describe("searchDocuments", () => {
     setDocumentContent("d-3", "BRF beslutar avslag pga att skadan inte är dokumenterad.");
     const r = searchDocuments(docs, matters, "skadan", "org-1", 20);
     expect(r.hits.length).toBe(1);
-    expect(r.hits[0].id).toBe("d-3");
+    expect(r.hits[0]!.id).toBe("d-3");
     // Snippet ska innehålla kontext runt query
-    expect(r.hits[0]._formatted?.content).toContain("skadan");
+    expect(r.hits[0]!._formatted?.content).toContain("skadan");
   });
 
   it("content-träff genererar snippet med ellipsis runt query", () => {
@@ -103,7 +103,7 @@ describe("searchDocuments", () => {
     );
     const r = searchDocuments(docs, matters, "target", "org-1", 20);
     expect(r.hits.length).toBe(1);
-    const snippet = r.hits[0]._formatted?.content ?? "";
+    const snippet = r.hits[0]!._formatted?.content ?? "";
     expect(snippet).toContain("TARGET");
     expect(snippet).toMatch(/^…/);
     expect(snippet).toMatch(/…$/);
@@ -112,7 +112,7 @@ describe("searchDocuments", () => {
   it("kombinerar metadata- + content-träff (boost-summa)", () => {
     setDocumentContent("d-1", "innehåller också vårdnad-text");
     const r = searchDocuments(docs, matters, "vårdnad", "org-1", 20);
-    expect(r.hits[0].id).toBe("d-1");
+    expect(r.hits[0]!.id).toBe("d-1");
     // d-1 har: fileName(2) + summary(1) + content(1) + meta(1) = 5
     // d-2 har: summary(1) + meta(1) = 2
   });

--- a/test/unit/server/data-store/count-without-include.test.ts
+++ b/test/unit/server/data-store/count-without-include.test.ts
@@ -40,9 +40,9 @@ describe("_count utan explicit include", () => {
     }) as Array<{ _count: { documents: number; timeEntries: number; contacts: number } }>;
 
     expect(rows).toHaveLength(1);
-    expect(rows[0]._count.documents).toBe(2);   // d-1, d-2 (inte d-3 → annan matter)
-    expect(rows[0]._count.timeEntries).toBe(1);
-    expect(rows[0]._count.contacts).toBe(1);
+    expect(rows[0]!._count.documents).toBe(2);   // d-1, d-2 (inte d-3 → annan matter)
+    expect(rows[0]!._count.timeEntries).toBe(1);
+    expect(rows[0]!._count.contacts).toBe(1);
   });
 
   it("räknar 0 korrekt när inga relationer finns", async () => {
@@ -53,8 +53,8 @@ describe("_count utan explicit include", () => {
       where: { organizationId: ORG },
       include: { _count: { select: { documents: true, timeEntries: true } } },
     }) as Array<{ _count: { documents: number; timeEntries: number } }>;
-    expect(rows[0]._count.documents).toBe(0);
-    expect(rows[0]._count.timeEntries).toBe(0);
+    expect(rows[0]!._count.documents).toBe(0);
+    expect(rows[0]!._count.timeEntries).toBe(0);
   });
 
   it("count + samtidig include av annan relation fungerar ihop", async () => {
@@ -66,7 +66,7 @@ describe("_count utan explicit include", () => {
         _count: { select: { documents: true } },
       },
     }) as Array<{ contacts: unknown[]; _count: { documents: number } }>;
-    expect(Array.isArray(rows[0].contacts)).toBe(true);
-    expect(rows[0]._count.documents).toBe(2);
+    expect(Array.isArray(rows[0]!.contacts)).toBe(true);
+    expect(rows[0]!._count.documents).toBe(2);
   });
 });

--- a/test/unit/server/data-store/demo-data-store-writable.test.ts
+++ b/test/unit/server/data-store/demo-data-store-writable.test.ts
@@ -47,8 +47,8 @@ describe("DemoDataStore writable", () => {
     type MatterWithContacts = { contacts: Array<{ contact: { name: string } }> };
     const matter = m as unknown as MatterWithContacts;
     expect(matter.contacts).toHaveLength(1);
-    expect(matter.contacts[0].contact).toBeDefined();
-    expect(matter.contacts[0].contact.name).toBe("Anna");
+    expect(matter.contacts[0]!.contact).toBeDefined();
+    expect(matter.contacts[0]!.contact.name).toBe("Anna");
   });
 
   // Regressionsskydd: tidigare mappade `entityNameFor` bara 8 nycklar och
@@ -68,7 +68,7 @@ describe("DemoDataStore writable", () => {
   ])("mutation på %s emit:ar entity-namn '%s'", async (key, expected) => {
     const events: MutationEvent<Record<string, unknown>>[] = [];
     const ds = new DemoDataStore({}, (e) => { events.push(e); });
-    const delegate = (ds as unknown as Record<string, { create: (a: unknown) => Promise<unknown> }>)[key];
+    const delegate = (ds as unknown as Record<string, { create: (a: unknown) => Promise<unknown> }>)[key]!;
     await delegate.create({ data: { id: "x1", organizationId: "o1" } });
     expect(events.at(-1)!.entity).toBe(expected);
   });
@@ -90,7 +90,7 @@ describe("DemoDataStore writable", () => {
     type MatterWithContacts = { contacts: Array<{ contact: { name: string } }> };
     const matter = m as unknown as MatterWithContacts;
     expect(matter.contacts).toHaveLength(1);
-    expect(matter.contacts[0].contact).toBeDefined();
-    expect(matter.contacts[0].contact.name).toBe("Anna");
+    expect(matter.contacts[0]!.contact).toBeDefined();
+    expect(matter.contacts[0]!.contact.name).toBe("Anna");
   });
 });

--- a/test/unit/server/data-store/in-memory/query-engine.test.ts
+++ b/test/unit/server/data-store/in-memory/query-engine.test.ts
@@ -70,7 +70,7 @@ describe("InMemoryQueryEngine — where", () => {
   it("equals (implicit) matchar exakt", () => {
     const r = engine.query(rows, { where: { id: "2" } });
     expect(r).toHaveLength(1);
-    expect(r[0].id).toBe("2");
+    expect(r[0]!.id).toBe("2");
   });
 
   it("nested object equality", () => {
@@ -86,7 +86,7 @@ describe("InMemoryQueryEngine — where", () => {
   it("contains med mode insensitive", () => {
     const r = engine.query(rows, { where: { name: { contains: "DELTA", mode: "insensitive" } } });
     expect(r).toHaveLength(1);
-    expect(r[0].id).toBe("4");
+    expect(r[0]!.id).toBe("4");
   });
 
   it("startsWith", () => {

--- a/test/unit/server/data-store/writable-delegate.test.ts
+++ b/test/unit/server/data-store/writable-delegate.test.ts
@@ -45,7 +45,7 @@ describe("WritableDelegate", () => {
     const onMutate = vi.fn();
     const { box, delegate } = makeDelegate(initial, onMutate);
     await delegate.update({ where: { id: "m1" }, data: { title: "Ny" } });
-    expect(box.items[0].title).toBe("Ny");
+    expect(box.items[0]!.title).toBe("Ny");
     expect(onMutate).toHaveBeenCalledWith(expect.objectContaining({ kind: "update" }));
   });
 
@@ -61,6 +61,11 @@ describe("WritableDelegate", () => {
     await delegate.delete({ where: { id: "m1" } });
     expect(box.items).toHaveLength(0);
     expect(onMutate).toHaveBeenCalledWith(expect.objectContaining({ kind: "delete" }));
+  });
+
+  it("delete på okänt id kastar", async () => {
+    const { delegate } = makeDelegate([]);
+    await expect(delegate.delete({ where: { id: "missing" } })).rejects.toThrow(/Hittade inte/);
   });
 
   it("findMany ser ny data efter create", async () => {
@@ -83,7 +88,7 @@ describe("WritableDelegate", () => {
     box.items = [{ id: "fresh", title: "Loaded", organizationId: "o1" }];
     const all = await delegate.findMany({});
     expect((all as Matter[])).toHaveLength(1);
-    expect((all as Matter[])[0].title).toBe("Loaded");
+    expect((all as Matter[])[0]!.title).toBe("Loaded");
 
     // Mutation efter byte muterar nya array:n
     await delegate.create({ data: { id: "m2", title: "Added after", organizationId: "o1" } });

--- a/test/unit/server/events/emit.test.ts
+++ b/test/unit/server/events/emit.test.ts
@@ -18,7 +18,7 @@ describe("emit-helpers", () => {
   it("matterCreated skickar rätt payload + matterId", async () => {
     const { ctx, emitFn } = makeCtx();
     await emit.matterCreated(ctx, { id: "m1", matterNumber: "2026-0001", title: "X" });
-    const arg = emitFn.mock.calls[0][0] as Record<string, unknown>;
+    const arg = emitFn.mock.calls[0]![0] as Record<string, unknown>;
     expect(arg.type).toBe("matter.created");
     expect(arg.matterId).toBe("m1");
     expect(arg.actor).toEqual({ kind: "user", id: "anna" });
@@ -29,7 +29,7 @@ describe("emit-helpers", () => {
   it("matterStatusChanged loggar from + to", async () => {
     const { ctx, emitFn } = makeCtx();
     await emit.matterStatusChanged(ctx, "m1", "ACTIVE", "ARCHIVED");
-    const arg = emitFn.mock.calls[0][0] as Record<string, unknown>;
+    const arg = emitFn.mock.calls[0]![0] as Record<string, unknown>;
     expect(arg.type).toBe("matter.status_changed");
     expect(arg.payload).toEqual({ from: "ACTIVE", to: "ARCHIVED" });
   });
@@ -37,7 +37,7 @@ describe("emit-helpers", () => {
   it("invoicePaymentReceived inkluderar amount", async () => {
     const { ctx, emitFn } = makeCtx();
     await emit.invoicePaymentReceived(ctx, "inv-1", "m1", 5000);
-    const arg = emitFn.mock.calls[0][0] as Record<string, unknown>;
+    const arg = emitFn.mock.calls[0]![0] as Record<string, unknown>;
     expect(arg.type).toBe("invoice.payment_received");
     expect(arg.payload).toEqual({ invoiceId: "inv-1", amount: 5000 });
   });
@@ -45,7 +45,7 @@ describe("emit-helpers", () => {
   it("timeEntryAdded inkluderar minutes och matterId", async () => {
     const { ctx, emitFn } = makeCtx();
     await emit.timeEntryAdded(ctx, { id: "t1", matterId: "m1", minutes: 90 });
-    const arg = emitFn.mock.calls[0][0] as Record<string, unknown>;
+    const arg = emitFn.mock.calls[0]![0] as Record<string, unknown>;
     expect(arg.type).toBe("time-entry.added");
     expect(arg.matterId).toBe("m1");
     expect(arg.payload).toEqual({ entryId: "t1", minutes: 90 });

--- a/test/unit/server/llm/llm-extractor.test.ts
+++ b/test/unit/server/llm/llm-extractor.test.ts
@@ -74,8 +74,8 @@ describe("StubExtractor", () => {
     await e.extract("text-1", schema);
     await e.extract("text-2", schema);
     expect(e.calls).toHaveLength(2);
-    expect(e.calls[0].text).toBe("text-1");
-    expect(e.calls[1].text).toBe("text-2");
+    expect(e.calls[0]!.text).toBe("text-1");
+    expect(e.calls[1]!.text).toBe("text-2");
   });
 
   it("kan konfigureras att kasta för fel-tester", async () => {

--- a/test/unit/server/local-first/demo-loader.test.ts
+++ b/test/unit/server/local-first/demo-loader.test.ts
@@ -63,7 +63,7 @@ describe("DemoLoader", () => {
 
     const all = loader.entities();
     expect(all.matter).toHaveLength(1);
-    expect((all.matter[0] as { matterNumber: string }).matterNumber).toBe("2026-0001");
+    expect((all.matter![0] as { matterNumber: string }).matterNumber).toBe("2026-0001");
     expect(all.contact).toHaveLength(1);
   });
 
@@ -109,9 +109,9 @@ describe("DemoLoader", () => {
     const loader = new DemoLoader({ fs, registry: buildDefaultRegistry(), cloneFn });
 
     await loader.loadDemo("a.git");
-    expect((loader.entities().matter[0] as { matterNumber: string }).matterNumber).toBe("demo-1");
+    expect((loader.entities().matter![0] as { matterNumber: string }).matterNumber).toBe("demo-1");
 
     await loader.loadDemo("a.git");
-    expect((loader.entities().matter[0] as { matterNumber: string }).matterNumber).toBe("demo-2");
+    expect((loader.entities().matter![0] as { matterNumber: string }).matterNumber).toBe("demo-2");
   });
 });

--- a/test/unit/server/local-first/demo-runtime-persistence.test.ts
+++ b/test/unit/server/local-first/demo-runtime-persistence.test.ts
@@ -28,7 +28,7 @@ describe("DemoRuntime — persistens", () => {
     });
     await rt.loadDemo("https://x/demo.git");
     expect(spy).toHaveBeenCalledTimes(1);
-    const saved = spy.mock.calls[0][0];
+    const saved = spy.mock.calls[0]![0];
     expect(saved["matters/active/m1.json"]).toBeDefined();
   });
 

--- a/test/unit/server/local-first/filesystem-event-log.test.ts
+++ b/test/unit/server/local-first/filesystem-event-log.test.ts
@@ -79,7 +79,7 @@ describe("FilesystemEventLog — query", () => {
     await log.emit({ type: "matter.updated", source: "ui", actor: { kind: "user", id: "anna" }, payload: {} });
     const events = await log.query({});
     expect(events).toHaveLength(2);
-    expect(events[0].ts <= events[1].ts).toBe(true);
+    expect(events[0]!.ts <= events[1]!.ts).toBe(true);
   });
 
   it("filtrerar på type", async () => {
@@ -88,7 +88,7 @@ describe("FilesystemEventLog — query", () => {
     await log.emit({ type: "contact.created", source: "ui", actor: { kind: "user", id: "anna" }, payload: {} });
     const matters = await log.query({ type: "matter.created" });
     expect(matters).toHaveLength(1);
-    expect(matters[0].type).toBe("matter.created");
+    expect(matters[0]!.type).toBe("matter.created");
   });
 
   it("filtrerar på matterId", async () => {
@@ -97,7 +97,7 @@ describe("FilesystemEventLog — query", () => {
     await log.emit({ type: "matter.updated", source: "ui", actor: { kind: "user", id: "anna" }, payload: {}, matterId: "m2" });
     const m1Events = await log.query({ matterId: "m1" });
     expect(m1Events).toHaveLength(1);
-    expect(m1Events[0].matterId).toBe("m1");
+    expect(m1Events[0]!.matterId).toBe("m1");
   });
 });
 

--- a/test/unit/server/local-first/projection-writer.test.ts
+++ b/test/unit/server/local-first/projection-writer.test.ts
@@ -134,7 +134,7 @@ describe("ProjectionHydrator — hydrate-on-pull", () => {
     const callback = vi.fn();
     await hydrator.hydrateChanges(["matters/active/m1.json"], callback);
     expect(callback).toHaveBeenCalledTimes(1);
-    expect((callback.mock.calls[0][1] as { id: string }).id).toBe("matter-1");
+    expect((callback.mock.calls[0]![1] as { id: string }).id).toBe("matter-1");
   });
 
   it("hydrateChanges hoppar över okända paths utan att kasta", async () => {

--- a/test/unit/server/local-first/sync-loop.integration.test.ts
+++ b/test/unit/server/local-first/sync-loop.integration.test.ts
@@ -86,7 +86,7 @@ skipIfNoGit("SyncLoop — integration mot riktig git", () => {
     expect(result.changedPaths).toContain("matters/active/m1.json");
     expect(result.hydrated).toBe(1);
     expect(onHydrated).toHaveBeenCalledTimes(1);
-    const [entity, data] = onHydrated.mock.calls[0];
+    const [entity, data] = onHydrated.mock.calls[0]!;
     expect(entity).toBe("matter");
     expect((data as { id: string }).id).toBe("m1");
   });

--- a/test/unit/server/local-first/sync-loop.test.ts
+++ b/test/unit/server/local-first/sync-loop.test.ts
@@ -65,7 +65,7 @@ describe("SyncLoop — tickOnce", () => {
     expect(result.hadChanges).toBe(true);
     expect(result.changedPaths).toContain("matters/active/matter-1.json");
     expect(onHydrated).toHaveBeenCalledTimes(1);
-    const [entity, data] = onHydrated.mock.calls[0];
+    const [entity, data] = onHydrated.mock.calls[0]!;
     expect(entity).toBe("matter");
     expect((data as { id: string }).id).toBe("matter-1");
   });

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -145,6 +145,6 @@ describe("billingRun.list / byId", () => {
     await caller.billingRun.createAcconto({ matterId: "m-1", clientShareBips: 2000, amountOre: 50000 });
     const { runs } = await caller.billingRun.list({ matterId: "m-1" });
     expect(runs).toHaveLength(1);
-    expect(runs[0].type).toBe("ACCONTO");
+    expect(runs[0]!.type).toBe("ACCONTO");
   });
 });

--- a/test/unit/server/routers/calendar.test.ts
+++ b/test/unit/server/routers/calendar.test.ts
@@ -145,7 +145,7 @@ describe("calendar.create", () => {
       title: "Privat möte",
       startAt: new Date(),
     });
-    const arg = mockPrisma.calendarEvent.create.mock.calls[0][0] as { data: { mirrorStatus: string | null } };
+    const arg = mockPrisma.calendarEvent.create.mock.calls[0]![0] as { data: { mirrorStatus: string | null } };
     expect(arg.data.mirrorStatus).toBeNull();
   });
 
@@ -159,7 +159,7 @@ describe("calendar.create", () => {
   it("default kind=appointment + allDay=false + visibility=normal", async () => {
     mockPrisma.calendarEvent.create.mockResolvedValue({ id: "x" });
     await makeCaller().create({ title: "Möte", startAt: new Date() });
-    const arg = mockPrisma.calendarEvent.create.mock.calls[0][0] as { data: { kind: string; allDay: boolean; visibility: string } };
+    const arg = mockPrisma.calendarEvent.create.mock.calls[0]![0] as { data: { kind: string; allDay: boolean; visibility: string } };
     expect(arg.data.kind).toBe("appointment");
     expect(arg.data.allDay).toBe(false);
     expect(arg.data.visibility).toBe("normal");
@@ -182,7 +182,7 @@ describe("calendar.update", () => {
     });
     mockPrisma.calendarEvent.update.mockResolvedValue({});
     await makeCaller().update({ id: "e1", mirrorToOutlook: true });
-    const arg = mockPrisma.calendarEvent.update.mock.calls[0][0] as { data: { mirrorStatus: string } };
+    const arg = mockPrisma.calendarEvent.update.mock.calls[0]![0] as { data: { mirrorStatus: string } };
     expect(arg.data.mirrorStatus).toBe("pending");
   });
 
@@ -192,7 +192,7 @@ describe("calendar.update", () => {
     });
     mockPrisma.calendarEvent.update.mockResolvedValue({});
     await makeCaller().update({ id: "e1", mirrorToOutlook: false });
-    const arg = mockPrisma.calendarEvent.update.mock.calls[0][0] as { data: { mirrorStatus: string | null; outlookEventId: string | null } };
+    const arg = mockPrisma.calendarEvent.update.mock.calls[0]![0] as { data: { mirrorStatus: string | null; outlookEventId: string | null } };
     expect(arg.data.mirrorStatus).toBeNull();
     expect(arg.data.outlookEventId).toBeNull();
   });
@@ -203,7 +203,7 @@ describe("calendar.update", () => {
     });
     mockPrisma.calendarEvent.update.mockResolvedValue({});
     await makeCaller().update({ id: "e1", title: "Nytt namn" });
-    const arg = mockPrisma.calendarEvent.update.mock.calls[0][0] as { data: { mirrorStatus: string } };
+    const arg = mockPrisma.calendarEvent.update.mock.calls[0]![0] as { data: { mirrorStatus: string } };
     expect(arg.data.mirrorStatus).toBe("pending");
   });
 });

--- a/test/unit/server/routers/conflict.test.ts
+++ b/test/unit/server/routers/conflict.test.ts
@@ -59,8 +59,8 @@ describe("conflict.check", () => {
       searchType: "personalNumber",
     });
     expect(res.matchCount).toBe(1);
-    expect(res.results[0].contactName).toBe("Anna");
-    expect(res.results[0].klient).toBe("Klient Klientsson");
+    expect(res.results[0]!.contactName).toBe("Anna");
+    expect(res.results[0]!.klient).toBe("Klient Klientsson");
   });
 
   it("hittar kontakter via fuzzy namn-sökning (bigram-Jaccard)", async () => {
@@ -83,8 +83,8 @@ describe("conflict.check", () => {
       searchType: "name",
     });
     expect(res.matchCount).toBe(1);
-    expect(res.results[0].contactName).toBe("Anna Andersson");
-    expect(res.results[0].klient).toBe("Klienten");
+    expect(res.results[0]!.contactName).toBe("Anna Andersson");
+    expect(res.results[0]!.klient).toBe("Klienten");
   });
 
   it("filtrerar bort matchningar under similarity-tröskeln", async () => {

--- a/test/unit/server/routers/contact.test.ts
+++ b/test/unit/server/routers/contact.test.ts
@@ -59,7 +59,7 @@ describe("contact.list", () => {
 
   it("bygger OR-sökning på namn/personnr/orgnr/epost", async () => {
     await makeCaller().list({ search: "Anna" });
-    const args = mockPrisma.contact.findMany.mock.calls[0][0];
+    const args = mockPrisma.contact.findMany.mock.calls[0]![0];
     expect(args.where.OR).toHaveLength(4);
   });
 
@@ -97,7 +97,7 @@ describe("contact.create", () => {
       contactType: "PERSON",
       email: "",
     });
-    const args = mockPrisma.contact.create.mock.calls[0][0];
+    const args = mockPrisma.contact.create.mock.calls[0]![0];
     expect(args.data.email).toBeNull();
   });
 
@@ -158,7 +158,7 @@ describe("contact.addChild", () => {
     mockPrisma.contact.findUnique.mockResolvedValue(C);
     mockPrisma.contact.create.mockResolvedValue({ id: "child" });
     await makeCaller().addChild({ parentId: "c1", name: "Anställd" });
-    const args = mockPrisma.contact.create.mock.calls[0][0];
+    const args = mockPrisma.contact.create.mock.calls[0]![0];
     expect(args.data.parentId).toBe("c1");
     expect(args.data.contactType).toBe("PERSON");
     expect(args.data.organizationId).toBe("org-a");

--- a/test/unit/server/routers/document.events.test.ts
+++ b/test/unit/server/routers/document.events.test.ts
@@ -51,7 +51,7 @@ describe("document.events — lista tidpunkter för ärende", () => {
     const result = await makeCaller("org-a").events({ matterId: "mat-1" });
 
     expect(result).toHaveLength(1);
-    expect(result[0].title).toBe("Huvudförhandling");
+    expect(result[0]!.title).toBe("Huvudförhandling");
     expect(mockPrisma.matterEventSuggestion.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({

--- a/test/unit/server/routers/document/core.test.ts
+++ b/test/unit/server/routers/document/core.test.ts
@@ -92,7 +92,7 @@ describe("document.tree", () => {
     const res = await makeCaller().tree({ matterId: "m1" });
     expect(res.folders).toHaveLength(1);
     expect(res.documents).toHaveLength(1);
-    expect(res.documents[0].fileName).toBe("real.pdf");
+    expect(res.documents[0]!.fileName).toBe("real.pdf");
   });
 });
 
@@ -115,8 +115,8 @@ describe("document.search", () => {
     const res = await makeCaller("org-a").search({ query: "test" });
     expect(mockPorts.searchIndex.search).toHaveBeenCalledWith("test", "org-a", 20, { documentTypes: undefined });
     expect(res.totalHits).toBe(1);
-    expect(res.hits[0].documentId).toBe("d1");
-    expect(res.hits[0].highlight).toContain("highlighted");
+    expect(res.hits[0]!.documentId).toBe("d1");
+    expect(res.hits[0]!.highlight).toContain("highlighted");
   });
 
   it("returnerar tom highlight när _formatted saknas", async () => {
@@ -134,7 +134,7 @@ describe("document.search", () => {
     } as never);
 
     const res = await makeCaller().search({ query: "x" });
-    expect(res.hits[0].highlight).toBe("");
+    expect(res.hits[0]!.highlight).toBe("");
   });
 
   it("kräver query min(1)", async () => {

--- a/test/unit/server/routers/document/folders.test.ts
+++ b/test/unit/server/routers/document/folders.test.ts
@@ -129,7 +129,7 @@ describe("document.moveDocument", () => {
   it("flyttar till rot (folderId=null)", async () => {
     mockPrisma.document.update.mockResolvedValue({});
     await makeCaller().moveDocument({ documentId: "d1", folderId: null });
-    expect(mockPrisma.document.update.mock.calls[0][0].data.folderId).toBeNull();
+    expect(mockPrisma.document.update.mock.calls[0]![0].data.folderId).toBeNull();
   });
 });
 

--- a/test/unit/server/routers/document/suggestions.test.ts
+++ b/test/unit/server/routers/document/suggestions.test.ts
@@ -55,7 +55,7 @@ describe("document.pendingSuggestions", () => {
     ]);
     const result = await makeCaller().pendingSuggestions({ matterId: "m1" });
     expect(result).toHaveLength(1);
-    const args = mockPrisma.documentAnalysisSuggestion.findMany.mock.calls[0][0];
+    const args = mockPrisma.documentAnalysisSuggestion.findMany.mock.calls[0]![0];
     expect(args.where.status).toBe("PENDING");
     expect(args.where.document.matterId).toBe("m1");
     expect(args.where.document.matter.organizationId).toBe("org-a");
@@ -222,7 +222,7 @@ describe("document.acceptSuggestion", () => {
     const res = await makeCaller().acceptSuggestion({ suggestionId: "s1" });
     expect(res.contactId).toBe("c-new");
     expect(mockPrisma.contact.create).toHaveBeenCalled();
-    const data = mockPrisma.contact.create.mock.calls[0][0].data;
+    const data = mockPrisma.contact.create.mock.calls[0]![0].data;
     expect(data.name).toBe("Helt Ny");
     expect(data.email).toBe("ny@x.se");
     expect(data.organizationId).toBe("org-a");
@@ -249,10 +249,10 @@ describe("document.acceptSuggestion", () => {
       suggestionId: "s1",
       override: { name: "Override Name", role: "MOTPART", email: "o@e.se" },
     });
-    const data = mockPrisma.contact.create.mock.calls[0][0].data;
+    const data = mockPrisma.contact.create.mock.calls[0]![0].data;
     expect(data.name).toBe("Override Name");
     expect(data.email).toBe("o@e.se");
-    const link = mockPrisma.matterContact.create.mock.calls[0][0].data;
+    const link = mockPrisma.matterContact.create.mock.calls[0]![0].data;
     expect(link.role).toBe("MOTPART");
   });
 
@@ -512,7 +512,7 @@ describe("document.acceptSuggestionGroup", () => {
 
     const res = await makeCaller().acceptSuggestionGroup({ suggestionIds: ["a", "b"] });
     expect(res.contactId).toBe("c-created");
-    const data = mockPrisma.contact.create.mock.calls[0][0].data;
+    const data = mockPrisma.contact.create.mock.calls[0]![0].data;
     expect(data.email).toBe("first@e.se");
     expect(data.phone).toBe("070-x");
   });

--- a/test/unit/server/routers/documentTemplate.test.ts
+++ b/test/unit/server/routers/documentTemplate.test.ts
@@ -49,7 +49,7 @@ describe("documentTemplate.list", () => {
     mockPrisma.documentTemplate.findMany.mockResolvedValue([TEMPLATE_A]);
     const result = await makeCaller("org-a").list();
     expect(result).toHaveLength(1);
-    expect(result[0].name).toBe("Uppdragsavtal");
+    expect(result[0]!.name).toBe("Uppdragsavtal");
   });
 
   it("queries with the correct organizationId filter", async () => {

--- a/test/unit/server/routers/expense.test.ts
+++ b/test/unit/server/routers/expense.test.ts
@@ -78,7 +78,7 @@ describe("expense.create", () => {
       amount: 50000,
       description: "Resa",
     });
-    const args = mockPrisma.expense.create.mock.calls[0][0];
+    const args = mockPrisma.expense.create.mock.calls[0]![0];
     expect(args.data.userId).toBe("u-9");
     expect(args.data.date).toBeInstanceOf(Date);
     expect(args.data.amount).toBe(50000);
@@ -92,7 +92,7 @@ describe("expense.create", () => {
       amount: 100,
       description: "X",
     });
-    expect(mockPrisma.expense.create.mock.calls[0][0].data.billable).toBe(true);
+    expect(mockPrisma.expense.create.mock.calls[0]![0].data.billable).toBe(true);
   });
 
   it("validerar belopp > 0", async () => {
@@ -106,14 +106,14 @@ describe("expense.update", () => {
   it("konverterar date-sträng om angiven", async () => {
     mockPrisma.expense.update.mockResolvedValue({});
     await makeCaller().update({ id: "e1", date: "2026-05-01" });
-    const args = mockPrisma.expense.update.mock.calls[0][0];
+    const args = mockPrisma.expense.update.mock.calls[0]![0];
     expect(args.data.date).toBeInstanceOf(Date);
   });
 
   it("rör inte date när ej angiven", async () => {
     mockPrisma.expense.update.mockResolvedValue({});
     await makeCaller().update({ id: "e1", description: "Ny" });
-    const args = mockPrisma.expense.update.mock.calls[0][0];
+    const args = mockPrisma.expense.update.mock.calls[0]![0];
     expect(args.data.date).toBeUndefined();
     expect(args.data.description).toBe("Ny");
   });

--- a/test/unit/server/routers/invoice.demo-store.test.ts
+++ b/test/unit/server/routers/invoice.demo-store.test.ts
@@ -164,7 +164,7 @@ describe("invoiceRouter mot riktig DemoDataStore", () => {
     };
     expect(res.paymentPlan?.id).toBe("pp1"); // 1:1 → objekt, inte array
     expect(res.payments).toHaveLength(1);
-    expect(res.payments[0].recordedBy?.name).toBe("Anna"); // nested include
+    expect(res.payments[0]!.recordedBy?.name).toBe("Anna"); // nested include
   });
 });
 

--- a/test/unit/server/routers/matter.test.ts
+++ b/test/unit/server/routers/matter.test.ts
@@ -113,7 +113,7 @@ describe("matter.list", () => {
     mockPrisma.matter.count.mockResolvedValue(0);
 
     await makeCaller().list({});
-    const where = mockPrisma.matter.findMany.mock.calls[0][0].where;
+    const where = mockPrisma.matter.findMany.mock.calls[0]![0].where;
     expect(where).not.toHaveProperty("timeEntries");
   });
 
@@ -122,7 +122,7 @@ describe("matter.list", () => {
     mockPrisma.matter.count.mockResolvedValue(0);
 
     await makeCaller().list({ search: "Berg" });
-    const callArgs = mockPrisma.matter.findMany.mock.calls[0][0];
+    const callArgs = mockPrisma.matter.findMany.mock.calls[0]![0];
     expect(callArgs.where.OR).toBeDefined();
     expect(callArgs.where.OR).toHaveLength(3);
   });
@@ -243,7 +243,7 @@ describe("matter.update", () => {
       paymentMethod: "RATTSHJALP",
       paymentMethodDecidedAt: "2026-03-02",
     });
-    const args = mockPrisma.matter.update.mock.calls[0][0];
+    const args = mockPrisma.matter.update.mock.calls[0]![0];
     expect(args.data.paymentMethodDecidedAt).toBeInstanceOf(Date);
     expect((args.data.paymentMethodDecidedAt as Date).toISOString()).toContain("2026-03-02");
   });
@@ -253,7 +253,7 @@ describe("matter.update", () => {
     mockPrisma.matter.update.mockResolvedValue(MATTER_A);
 
     await makeCaller().update({ id: "matter-1", paymentMethodDecidedAt: null });
-    const args = mockPrisma.matter.update.mock.calls[0][0];
+    const args = mockPrisma.matter.update.mock.calls[0]![0];
     expect(args.data.paymentMethodDecidedAt).toBeNull();
   });
 

--- a/test/unit/server/routers/organization.test.ts
+++ b/test/unit/server/routers/organization.test.ts
@@ -194,10 +194,10 @@ describe("organization — komplett flöde: registrera huvudkontor och filial", 
     const list = await makeCaller("org-a").listOffices();
 
     expect(list).toHaveLength(2);
-    expect(list[0].isMain).toBe(true);
-    expect(list[0].name).toBe("Stockholm");
-    expect(list[1].isMain).toBe(false);
-    expect(list[1].name).toBe("Göteborg");
+    expect(list[0]!.isMain).toBe(true);
+    expect(list[0]!.name).toBe("Stockholm");
+    expect(list[1]!.isMain).toBe(false);
+    expect(list[1]!.name).toBe("Göteborg");
 
     // Verify the query filters on org and orders by isMain desc, then name asc
     expect(mockPrisma.office.findMany).toHaveBeenCalledWith({

--- a/test/unit/server/routers/paymentPlan.test.ts
+++ b/test/unit/server/routers/paymentPlan.test.ts
@@ -40,7 +40,7 @@ describe("paymentPlan.recordReminder", () => {
 
     expect(res.planId).toBe("pp-1");
     expect(res.dueMonth).toBe("2026-03");
-    const arg = mockPrisma.paymentPlanReminder.create.mock.calls[0][0] as { data: Record<string, unknown> };
+    const arg = mockPrisma.paymentPlanReminder.create.mock.calls[0]![0] as { data: Record<string, unknown> };
     expect(arg.data.id).toBe("ppr-1");
     expect(arg.data.type).toBe("DUE");
     expect(arg.data.sentAt).toBeInstanceOf(Date);
@@ -52,7 +52,7 @@ describe("paymentPlan.recordReminder", () => {
       ({ data }: { data: Record<string, unknown> }) => Promise.resolve({ ...data }),
     );
     await makeCaller().recordReminder({ planId: "pp-1", dueMonth: "2026-04", type: "OVERDUE" });
-    const arg = mockPrisma.paymentPlanReminder.create.mock.calls[0][0] as { data: Record<string, unknown> };
+    const arg = mockPrisma.paymentPlanReminder.create.mock.calls[0]![0] as { data: Record<string, unknown> };
     expect(arg.data.sentAt).toBeInstanceOf(Date);
   });
 

--- a/test/unit/server/routers/reports.test.ts
+++ b/test/unit/server/routers/reports.test.ts
@@ -68,10 +68,10 @@ describe("reports.perLawyer", () => {
     });
     expect(res).not.toBeNull();
     expect(res!.matters).toHaveLength(1);
-    expect(res!.matters[0].totalMinutes).toBe(90);
-    expect(res!.matters[0].billableMinutes).toBe(60);
-    expect(res!.matters[0].workValueOre).toBe(60 / 60 * 3000); // 60 min × 3000 öre/h (hourlyRate ÄR öre)
-    expect(res!.matters[0].expenseOre).toBe(50000);
+    expect(res!.matters[0]!.totalMinutes).toBe(90);
+    expect(res!.matters[0]!.billableMinutes).toBe(60);
+    expect(res!.matters[0]!.workValueOre).toBe(60 / 60 * 3000); // 60 min × 3000 öre/h (hourlyRate ÄR öre)
+    expect(res!.matters[0]!.expenseOre).toBe(50000);
   });
 
   it("totals summerar alla ärenden", async () => {
@@ -112,7 +112,7 @@ describe("reports.perLawyer", () => {
       from: "2026-01-01", to: "2026-12-31", userId: "u1",
     });
     expect(res!.unbilled.rows).toHaveLength(1);
-    expect(res!.unbilled.rows[0].timeOre).toBe(30 / 60 * 1000); // hourlyRate ÄR öre
+    expect(res!.unbilled.rows[0]!.timeOre).toBe(30 / 60 * 1000); // hourlyRate ÄR öre
   });
 
   it("ignorerar non-billable i workValueOre och unbilled", async () => {
@@ -124,9 +124,9 @@ describe("reports.perLawyer", () => {
     const res = await makeCaller().perLawyer({
       from: "2026-01-01", to: "2026-12-31", userId: "u1",
     });
-    expect(res!.matters[0].totalMinutes).toBe(60);
-    expect(res!.matters[0].billableMinutes).toBe(0);
-    expect(res!.matters[0].workValueOre).toBe(0);
+    expect(res!.matters[0]!.totalMinutes).toBe(60);
+    expect(res!.matters[0]!.billableMinutes).toBe(0);
+    expect(res!.matters[0]!.workValueOre).toBe(0);
     expect(res!.unbilled.rows).toHaveLength(0);
   });
 
@@ -139,7 +139,7 @@ describe("reports.perLawyer", () => {
     const res = await makeCaller().perLawyer({
       from: "2026-01-01", to: "2026-12-31", userId: "u1",
     });
-    expect(res!.matters[0].paymentMethod).toBe("RATTSHJALP");
-    expect(res!.matters[0].paymentMethodNote).toBe("Diarienr X");
+    expect(res!.matters[0]!.paymentMethod).toBe("RATTSHJALP");
+    expect(res!.matters[0]!.paymentMethodNote).toBe("Diarienr X");
   });
 });

--- a/test/unit/server/routers/task.test.ts
+++ b/test/unit/server/routers/task.test.ts
@@ -42,13 +42,13 @@ describe("task.list", () => {
 
   it("filtrerar på status", async () => {
     await makeCaller().list({ status: "DONE" });
-    const arg = mockPrisma.task.findMany.mock.calls[0][0] as { where: { status: string } };
+    const arg = mockPrisma.task.findMany.mock.calls[0]![0] as { where: { status: string } };
     expect(arg.where.status).toBe("DONE");
   });
 
   it("filtrerar på matterId", async () => {
     await makeCaller().list({ matterId: "m-1" });
-    const arg = mockPrisma.task.findMany.mock.calls[0][0] as { where: { matterId: string } };
+    const arg = mockPrisma.task.findMany.mock.calls[0]![0] as { where: { matterId: string } };
     expect(arg.where.matterId).toBe("m-1");
   });
 });
@@ -86,7 +86,7 @@ describe("task.update", () => {
     mockPrisma.task.findFirstOrThrow.mockResolvedValue({ id: "t-1" });
     mockPrisma.task.update.mockResolvedValue({});
     await makeCaller().update({ id: "t-1", status: "DONE" });
-    const arg = mockPrisma.task.update.mock.calls[0][0] as { data: { completedAt: Date } };
+    const arg = mockPrisma.task.update.mock.calls[0]![0] as { data: { completedAt: Date } };
     expect(arg.data.completedAt).toBeInstanceOf(Date);
   });
 
@@ -94,7 +94,7 @@ describe("task.update", () => {
     mockPrisma.task.findFirstOrThrow.mockResolvedValue({ id: "t-1" });
     mockPrisma.task.update.mockResolvedValue({});
     await makeCaller().update({ id: "t-1", status: "TODO" });
-    const arg = mockPrisma.task.update.mock.calls[0][0] as { data: { completedAt: Date | null } };
+    const arg = mockPrisma.task.update.mock.calls[0]![0] as { data: { completedAt: Date | null } };
     expect(arg.data.completedAt).toBeNull();
   });
 });
@@ -104,7 +104,7 @@ describe("task.complete", () => {
     mockPrisma.task.findFirstOrThrow.mockResolvedValue({ id: "t-1" });
     mockPrisma.task.update.mockResolvedValue({});
     await makeCaller().complete({ id: "t-1" });
-    const arg = mockPrisma.task.update.mock.calls[0][0] as { data: { status: string; completedAt: Date } };
+    const arg = mockPrisma.task.update.mock.calls[0]![0] as { data: { status: string; completedAt: Date } };
     expect(arg.data.status).toBe("DONE");
     expect(arg.data.completedAt).toBeInstanceOf(Date);
   });

--- a/test/unit/server/routers/timeEntry.test.ts
+++ b/test/unit/server/routers/timeEntry.test.ts
@@ -48,7 +48,7 @@ describe("timeEntry.list", () => {
 
   it("filtrerar på matterId och userId", async () => {
     await makeCaller().list({ matterId: "m1", userId: "u9" });
-    const w = mockPrisma.timeEntry.findMany.mock.calls[0][0].where;
+    const w = mockPrisma.timeEntry.findMany.mock.calls[0]![0].where;
     expect(w.matterId).toBe("m1");
     expect(w.userId).toBe("u9");
   });
@@ -57,7 +57,7 @@ describe("timeEntry.list", () => {
     const from = new Date("2026-01-01");
     const to = new Date("2026-12-31");
     await makeCaller().list({ from, to });
-    const w = mockPrisma.timeEntry.findMany.mock.calls[0][0].where;
+    const w = mockPrisma.timeEntry.findMany.mock.calls[0]![0].where;
     expect(w.date.gte).toBe(from);
     expect(w.date.lte).toBe(to);
   });
@@ -79,7 +79,7 @@ describe("timeEntry.create", () => {
       minutes: 90,
       description: "Möte",
     });
-    const args = mockPrisma.timeEntry.create.mock.calls[0][0];
+    const args = mockPrisma.timeEntry.create.mock.calls[0]![0];
     expect(args.data.userId).toBe("u-9");
     expect(args.data.hourlyRate).toBe(3000);
     expect(args.data.minutes).toBe(90);
@@ -95,7 +95,7 @@ describe("timeEntry.create", () => {
       minutes: 30,
       description: "X",
     });
-    expect(mockPrisma.timeEntry.create.mock.calls[0][0].data.hourlyRate).toBe(0);
+    expect(mockPrisma.timeEntry.create.mock.calls[0]![0].data.hourlyRate).toBe(0);
   });
 
   it("validerar minutes > 0", async () => {
@@ -109,13 +109,13 @@ describe("timeEntry.update", () => {
   it("konverterar date-sträng till Date", async () => {
     mockPrisma.timeEntry.update.mockResolvedValue({});
     await makeCaller().update({ id: "t1", date: "2026-03-15" });
-    expect(mockPrisma.timeEntry.update.mock.calls[0][0].data.date).toBeInstanceOf(Date);
+    expect(mockPrisma.timeEntry.update.mock.calls[0]![0].data.date).toBeInstanceOf(Date);
   });
 
   it("uppdaterar bara skickade fält", async () => {
     mockPrisma.timeEntry.update.mockResolvedValue({});
     await makeCaller().update({ id: "t1", description: "Nytt" });
-    const data = mockPrisma.timeEntry.update.mock.calls[0][0].data;
+    const data = mockPrisma.timeEntry.update.mock.calls[0]![0].data;
     expect(data.description).toBe("Nytt");
     expect(data.minutes).toBeUndefined();
   });
@@ -154,10 +154,10 @@ describe("timeEntry.report", () => {
       to: "2026-12-31",
     });
     expect(res.totalEntries).toBe(3);
-    expect(res.byUser["u1"].name).toBe("Anna");
-    expect(res.byUser["u1"].totalMinutes).toBe(90);
-    expect(res.byUser["u1"].billableMinutes).toBe(60);
-    expect(res.byUser["u2"].totalMinutes).toBe(45);
+    expect(res.byUser["u1"]!.name).toBe("Anna");
+    expect(res.byUser["u1"]!.totalMinutes).toBe(90);
+    expect(res.byUser["u1"]!.billableMinutes).toBe(60);
+    expect(res.byUser["u2"]!.totalMinutes).toBe(45);
   });
 
   it("filtrerar på userIds-array när angiven", async () => {
@@ -167,7 +167,7 @@ describe("timeEntry.report", () => {
       to: "2026-12-31",
       userIds: ["u1", "u2"],
     });
-    const w = mockPrisma.timeEntry.findMany.mock.calls[0][0].where;
+    const w = mockPrisma.timeEntry.findMany.mock.calls[0]![0].where;
     expect(w.userId).toEqual({ in: ["u1", "u2"] });
   });
 
@@ -178,7 +178,7 @@ describe("timeEntry.report", () => {
       to: "2026-12-31",
       userId: "u1",
     });
-    const w = mockPrisma.timeEntry.findMany.mock.calls[0][0].where;
+    const w = mockPrisma.timeEntry.findMany.mock.calls[0]![0].where;
     expect(w.userId).toBe("u1");
   });
 
@@ -190,7 +190,7 @@ describe("timeEntry.report", () => {
       userId: "u1",
       userIds: ["u2", "u3"],
     });
-    const w = mockPrisma.timeEntry.findMany.mock.calls[0][0].where;
+    const w = mockPrisma.timeEntry.findMany.mock.calls[0]![0].where;
     expect(w.userId).toEqual({ in: ["u2", "u3"] });
   });
 
@@ -201,7 +201,7 @@ describe("timeEntry.report", () => {
       to: "2026-12-31",
       matterId: "m1",
     });
-    const w = mockPrisma.timeEntry.findMany.mock.calls[0][0].where;
+    const w = mockPrisma.timeEntry.findMany.mock.calls[0]![0].where;
     expect(w.matterId).toBe("m1");
   });
 });

--- a/test/unit/server/routers/todo.test.ts
+++ b/test/unit/server/routers/todo.test.ts
@@ -43,10 +43,10 @@ describe("todo.list", () => {
 
     const items = await makeCaller().list({ from: FROM, to: TO });
     expect(items.map((i) => i.id)).toEqual(["e1", "t1"]); // sortert på tid (09 före 16)
-    expect(items[0].source).toBe("event");
-    expect(items[1].source).toBe("task");
-    expect(items[0].location).toBe("Kontor");
-    expect(items[1].status).toBe("TODO");
+    expect(items[0]!.source).toBe("event");
+    expect(items[1]!.source).toBe("task");
+    expect(items[0]!.location).toBe("Kontor");
+    expect(items[1]!.status).toBe("TODO");
   });
 
   it("kastar NOT_FOUND när userId inte är i org:en", async () => {
@@ -62,7 +62,7 @@ describe("todo.list", () => {
     // redan autentiserad). Användare-kollen körs bara vid kollegial look-up.
     expect(mockPrisma.user.findFirst).not.toHaveBeenCalled();
     // Och tasks-frågan körs ändå med rätt userId.
-    const taskQ = mockPrisma.task.findMany.mock.calls[0][0] as { where: { userId: string } };
+    const taskQ = mockPrisma.task.findMany.mock.calls[0]![0] as { where: { userId: string } };
     expect(taskQ.where.userId).toBe("u1");
   });
 });

--- a/test/unit/server/routers/user.test.ts
+++ b/test/unit/server/routers/user.test.ts
@@ -42,7 +42,7 @@ describe("user.list", () => {
   it("returnerar bara säkra fält (inte passwordHash)", async () => {
     mockPrisma.user.findMany.mockResolvedValue([]);
     await makeCaller().list();
-    const args = mockPrisma.user.findMany.mock.calls[0][0];
+    const args = mockPrisma.user.findMany.mock.calls[0]![0];
     expect(args.select.passwordHash).toBeUndefined();
     expect(args.select.email).toBe(true);
     expect(args.select.name).toBe(true);
@@ -69,7 +69,7 @@ describe("user.create", () => {
       name: "Ny",
       password: "hemligt-lösenord",
     });
-    const args = mockPrisma.user.create.mock.calls[0][0];
+    const args = mockPrisma.user.create.mock.calls[0]![0];
     expect(args.data.passwordHash).toBeDefined();
     expect(args.data.passwordHash).not.toBe("hemligt-lösenord"); // bcrypt
     expect(args.data.email).toBe("ny@test.se");
@@ -79,14 +79,14 @@ describe("user.create", () => {
   it("tillåter användare utan lösenord (Microsoft-only)", async () => {
     mockPrisma.user.create.mockResolvedValue({ id: "new" });
     await makeCaller().create({ email: "x@y.se", name: "Y" });
-    const args = mockPrisma.user.create.mock.calls[0][0];
+    const args = mockPrisma.user.create.mock.calls[0]![0];
     expect(args.data.passwordHash).toBeNull();
   });
 
   it("default-role är LAWYER", async () => {
     mockPrisma.user.create.mockResolvedValue({});
     await makeCaller().create({ email: "x@y.se", name: "Y" });
-    const args = mockPrisma.user.create.mock.calls[0][0];
+    const args = mockPrisma.user.create.mock.calls[0]![0];
     expect(args.data.role).toBe("LAWYER");
   });
 
@@ -105,7 +105,7 @@ describe("user.update", () => {
   it("hashar lösenord när password skickas", async () => {
     mockPrisma.user.update.mockResolvedValue({ id: "u1" });
     await makeCaller().update({ id: "u1", password: "nytt-hemligt-pwd" });
-    const args = mockPrisma.user.update.mock.calls[0][0];
+    const args = mockPrisma.user.update.mock.calls[0]![0];
     expect(args.data.passwordHash).toBeDefined();
     expect(args.data.password).toBeUndefined();
   });
@@ -113,7 +113,7 @@ describe("user.update", () => {
   it("uppdaterar utan att röra passwordHash om password ej skickas", async () => {
     mockPrisma.user.update.mockResolvedValue({});
     await makeCaller().update({ id: "u1", name: "Nytt namn" });
-    const args = mockPrisma.user.update.mock.calls[0][0];
+    const args = mockPrisma.user.update.mock.calls[0]![0];
     expect(args.data.passwordHash).toBeUndefined();
     expect(args.data.name).toBe("Nytt namn");
   });
@@ -121,7 +121,7 @@ describe("user.update", () => {
   it("scopar where på organizationId", async () => {
     mockPrisma.user.update.mockResolvedValue({});
     await makeCaller().update({ id: "u1", name: "X" });
-    const args = mockPrisma.user.update.mock.calls[0][0];
+    const args = mockPrisma.user.update.mock.calls[0]![0];
     expect(args.where).toEqual({ id: "u1", organizationId: "org-a" });
   });
 });
@@ -194,7 +194,7 @@ describe("user.addKey / removeKey", () => {
       fingerprint: "SHA256:abc", type: "ssh-ed25519", publicKey: "ssh-ed25519 AAAA",
       addedAt: "2026-05-21T00:00:00Z",
     });
-    const call = mockPrisma.user.update.mock.calls[0][0];
+    const call = mockPrisma.user.update.mock.calls[0]![0];
     expect(call.data.publicKeys).toHaveLength(1);
     expect(call.data.publicKeys[0].fingerprint).toBe("SHA256:abc");
   });
@@ -219,7 +219,7 @@ describe("user.addKey / removeKey", () => {
     });
     mockPrisma.user.update.mockResolvedValue({});
     await makeCallerWithRole("LAWYER", "u1").removeKey({ fingerprint: "SHA256:a" });
-    const call = mockPrisma.user.update.mock.calls[0][0];
+    const call = mockPrisma.user.update.mock.calls[0]![0];
     expect(call.data.publicKeys).toHaveLength(1);
     expect(call.data.publicKeys[0].fingerprint).toBe("SHA256:b");
   });

--- a/test/unit/server/search-document-type-filter.test.ts
+++ b/test/unit/server/search-document-type-filter.test.ts
@@ -31,7 +31,7 @@ describe("searchDocuments — documentTypes-filter", () => {
   it("filter ['Dom'] returnerar bara dom-träffar", () => {
     const r = searchDocuments(docs, matters, "tvist", ORG, 50, { documentTypes: ["Dom"] });
     expect(r.hits).toHaveLength(1);
-    expect(r.hits[0].id).toBe("d2");
+    expect(r.hits[0]!.id).toBe("d2");
   });
 
   it("filter ['Dom', 'Yttrande'] inkluderar båda", () => {

--- a/test/unit/shared/brottmalstaxa.test.ts
+++ b/test/unit/shared/brottmalstaxa.test.ts
@@ -124,13 +124,13 @@ describe("Tabellintegritet", () => {
 
   it("intervallen är sammanhängande (ingen lucka)", () => {
     for (let i = 1; i < BROTTMALSTAXA_TABLE.length; i++) {
-      expect(BROTTMALSTAXA_TABLE[i].fromMin).toBe(BROTTMALSTAXA_TABLE[i - 1].toMin + 1);
+      expect(BROTTMALSTAXA_TABLE[i]!.fromMin).toBe(BROTTMALSTAXA_TABLE[i - 1]!.toMin + 1);
     }
   });
 
   it("täcker exakt 0 till TAXA_MAX_MINUTES", () => {
-    expect(BROTTMALSTAXA_TABLE[0].fromMin).toBe(0);
-    expect(BROTTMALSTAXA_TABLE[BROTTMALSTAXA_TABLE.length - 1].toMin).toBe(TAXA_MAX_MINUTES);
+    expect(BROTTMALSTAXA_TABLE[0]!.fromMin).toBe(0);
+    expect(BROTTMALSTAXA_TABLE[BROTTMALSTAXA_TABLE.length - 1]!.toMin).toBe(TAXA_MAX_MINUTES);
   });
 
   it("ersättning ökar monotont per nivå inom varje intervall", () => {
@@ -143,14 +143,14 @@ describe("Tabellintegritet", () => {
 
   it("ersättning ökar monotont mellan intervaller (nivå 1)", () => {
     for (let i = 1; i < BROTTMALSTAXA_TABLE.length; i++) {
-      expect(BROTTMALSTAXA_TABLE[i].ersattning[0]).toBeGreaterThan(BROTTMALSTAXA_TABLE[i - 1].ersattning[0]);
+      expect(BROTTMALSTAXA_TABLE[i]!.ersattning[0]).toBeGreaterThan(BROTTMALSTAXA_TABLE[i - 1]!.ersattning[0]!);
     }
   });
 
   it("gränsvärdet är alltid större än ersättningen", () => {
     for (const r of BROTTMALSTAXA_TABLE) {
       for (let lvl = 0; lvl < 4; lvl++) {
-        expect(r.gransvarde[lvl]).toBeGreaterThan(r.ersattning[lvl]);
+        expect(r.gransvarde[lvl]).toBeGreaterThan(r.ersattning[lvl]!);
       }
     }
   });

--- a/test/unit/shared/diagnostics/invariants.test.ts
+++ b/test/unit/shared/diagnostics/invariants.test.ts
@@ -18,10 +18,10 @@ describe("detectMatterInvariants — KR_PENDING_NO_DOC", () => {
   it("flaggar pending kostnadsräkning utan KR-dokument", () => {
     const v = detectMatterInvariants(input({ billingRuns: [pendingKr], documents: [] }));
     expect(v).toHaveLength(1);
-    expect(v[0].code).toBe("KR_PENDING_NO_DOC");
-    expect(v[0].severity).toBe("error");
-    expect(v[0].context).toMatchObject({ matterId: "m-1", billingRunId: "br-1", matterNumber: "2026-0001" });
-    expect(v[0].message).toContain("2026-0001");
+    expect(v[0]!.code).toBe("KR_PENDING_NO_DOC");
+    expect(v[0]!.severity).toBe("error");
+    expect(v[0]!.context).toMatchObject({ matterId: "m-1", billingRunId: "br-1", matterNumber: "2026-0001" });
+    expect(v[0]!.message).toContain("2026-0001");
   });
 
   it("flaggar inte när ett KR-dokument finns i ärendet", () => {
@@ -66,8 +66,8 @@ describe("detectMatterInvariants — KR_PENDING_NO_DOC", () => {
 
   it("faller tillbaka på matterId i meddelandet när matterNumber saknas", () => {
     const v = detectMatterInvariants({ matterId: "m-x", billingRuns: [pendingKr], documents: [] });
-    expect(v[0].message).toContain("m-x");
-    expect(v[0].context.matterNumber).toBeUndefined();
+    expect(v[0]!.message).toContain("m-x");
+    expect(v[0]!.context.matterNumber).toBeUndefined();
   });
 
   it("returnerar tomt för ett ärende utan billing-runs", () => {

--- a/test/unit/shared/kostnadsrakning.test.ts
+++ b/test/unit/shared/kostnadsrakning.test.ts
@@ -142,7 +142,7 @@ describe("templateContext — formaterad data för Handlebars", () => {
 
   it("expenseLines har formaterade belopp + vatRateLabel", () => {
     const lines = (r.templateContext.expenseLines as Array<Record<string, unknown>>);
-    expect(lines[0].vatRateLabel).toBe("6 %");
-    expect(lines[0].inclVatFormatted).toMatch(/450,00\s+kr/);
+    expect(lines[0]!.vatRateLabel).toBe("6 %");
+    expect(lines[0]!.inclVatFormatted).toMatch(/450,00\s+kr/);
   });
 });

--- a/test/unit/shared/schemas/registry.test.ts
+++ b/test/unit/shared/schemas/registry.test.ts
@@ -27,13 +27,13 @@ describe("ENTITY_REGISTRY", () => {
   });
 
   it("calendar + task: gitPath flat (inte per-user-mapp)", () => {
-    expect(ENTITY_REGISTRY.calendarEvent.gitPath("e-1", { userId: "u-1" })).toBe("calendar/e-1.json");
-    expect(ENTITY_REGISTRY.task.gitPath("t-1", { userId: "u-1" })).toBe("tasks/t-1.json");
+    expect(ENTITY_REGISTRY.calendarEvent!.gitPath("e-1", { userId: "u-1" })).toBe("calendar/e-1.json");
+    expect(ENTITY_REGISTRY.task!.gitPath("t-1", { userId: "u-1" })).toBe("tasks/t-1.json");
   });
 
   it("varje entry har schema + gitPath + gitPrefix + sourceKey", () => {
     for (const name of ENTITY_NAMES) {
-      const entry = ENTITY_REGISTRY[name];
+      const entry = ENTITY_REGISTRY[name]!;
       expect(entry.schema).toBeDefined();
       expect(typeof entry.gitPath).toBe("function");
       expect(entry.gitPrefix).toBeTruthy();
@@ -42,19 +42,19 @@ describe("ENTITY_REGISTRY", () => {
   });
 
   it("gitPath:s första argument används i resultatet (för rader utan email-style key)", () => {
-    expect(ENTITY_REGISTRY.matter.gitPath("m-1", {})).toBe("matters/active/m-1.json");
-    expect(ENTITY_REGISTRY.contact.gitPath("c-1", {})).toBe("contacts/c-1.json");
-    expect(ENTITY_REGISTRY.invoice.gitPath("i-1", {})).toBe("invoices/i-1.json");
+    expect(ENTITY_REGISTRY.matter!.gitPath("m-1", {})).toBe("matters/active/m-1.json");
+    expect(ENTITY_REGISTRY.contact!.gitPath("c-1", {})).toBe("contacts/c-1.json");
+    expect(ENTITY_REGISTRY.invoice!.gitPath("i-1", {})).toBe("invoices/i-1.json");
   });
 
   it("user-pathen använder email om satt, annars id", () => {
-    expect(ENTITY_REGISTRY.user.gitPath("u-1", { email: "anna@firma.se" })).toBe(".ava/users/anna@firma.se.json");
-    expect(ENTITY_REGISTRY.user.gitPath("u-1", {})).toBe(".ava/users/u-1.json");
+    expect(ENTITY_REGISTRY.user!.gitPath("u-1", { email: "anna@firma.se" })).toBe(".ava/users/anna@firma.se.json");
+    expect(ENTITY_REGISTRY.user!.gitPath("u-1", {})).toBe(".ava/users/u-1.json");
   });
 
   it("organisation + offices i registry:t", () => {
-    expect(ENTITY_REGISTRY.organization.gitPath("o-1", {})).toBe(".ava/organizations/o-1.json");
-    expect(ENTITY_REGISTRY.office.gitPath("off-1", {})).toBe("offices/off-1.json");
+    expect(ENTITY_REGISTRY.organization!.gitPath("o-1", {})).toBe(".ava/organizations/o-1.json");
+    expect(ENTITY_REGISTRY.office!.gitPath("off-1", {})).toBe("offices/off-1.json");
   });
 });
 

--- a/tooling/demo-generator/populate-unbilled-time.ts
+++ b/tooling/demo-generator/populate-unbilled-time.ts
@@ -61,10 +61,10 @@ export async function populateUnbilledTime(caller: GeneratorCaller, seed: SeedDa
 
   let count = 0;
   for (let mi = 0; mi < activeMatters.length; mi++) {
-    const matter = activeMatters[mi];
+    const matter = activeMatters[mi]!;
     const n = entriesPerMatter(mi);
     for (let j = 0; j < n; j++) {
-      const user = users[(mi + j) % users.length];
+      const user = users[(mi + j) % users.length]!;
       await createFreshEntry(c, user, matter, j + 1, mi * 3 + j);
       count++;
     }

--- a/tooling/scripts/build-demo-repo.ts
+++ b/tooling/scripts/build-demo-repo.ts
@@ -30,7 +30,7 @@ import { buildSeed } from "./seed-data";
 
 function parseDirArg(): string {
   const idx = process.argv.indexOf("--dir");
-  return idx > 0 && process.argv[idx + 1] ? process.argv[idx + 1] : "./demo-repo";
+  return idx > 0 && process.argv[idx + 1] ? process.argv[idx + 1]! : "./demo-repo";
 }
 
 async function main(): Promise<void> {

--- a/tooling/scripts/diagnose-ui.ts
+++ b/tooling/scripts/diagnose-ui.ts
@@ -131,7 +131,7 @@ function serveOut(): Server {
         join(OUT_DIR, `${url}.html`),
         join(OUT_DIR, "404.html"),
       ];
-      const filePath = candidates.find((p) => existsSync(p) && statSync(p).isFile()) ?? candidates[candidates.length - 1];
+      const filePath = candidates.find((p) => existsSync(p) && statSync(p).isFile()) ?? candidates[candidates.length - 1]!;
       const data = await readFile(filePath);
       const ext = filePath.slice(filePath.lastIndexOf("."));
       res.writeHead(200, { "Content-Type": MIME[ext] ?? "application/octet-stream", "Cache-Control": "no-store" });
@@ -286,7 +286,7 @@ async function visitRoute(browser: Browser, route: Route): Promise<RouteResult> 
     const found = await collectDetailLinks(page, route.detailHrefPattern, max);
     await page.close();
     for (let i = 0; i < found.length; i++) {
-      items.push(await visitDetail(browser, route.name, baseUrl, found[i], i + 1));
+      items.push(await visitDetail(browser, route.name, baseUrl, found[i]!, i + 1));
     }
   } else {
     await page.close();

--- a/tooling/scripts/seed-data.ts
+++ b/tooling/scripts/seed-data.ts
@@ -249,6 +249,8 @@ export function buildSeed(opts: BuildSeedOpts = {}): SeedDataset {
     for (let i = 0; i < fmt.count; i++) {
       const matter = MATTERS[i % MATTERS.length];
       const k = docKinds[i % docKinds.length];
+      const uploader = users[i % users.length];
+      if (!matter || !k || !uploader) continue;
       const id = `doc-${fmt.ext}-${String(i + 1).padStart(2, "0")}`;
       const daysAgo = (docSeq * 2) + 3;
       docSeq++;
@@ -259,7 +261,7 @@ export function buildSeed(opts: BuildSeedOpts = {}): SeedDataset {
         sizeBytes: 0, // fylls i av seed-script efter att binärfilen genererats
         fileSize: 0,  // dito (UI använder fileSize, schema sizeBytes)
         storagePath: `documents/content/${id}.${fmt.ext}`, version: 1,
-        uploadedById: users[i % users.length].id,
+        uploadedById: uploader.id,
         title: `${k.baseName} ${matter.matterNumber}`,
         documentType: k.type,
         summary: `${k.type} för ärende ${matter.matterNumber} — ${matter.title}. Skapat som demo-data med svenska tecken (å, ä, ö).`,
@@ -278,6 +280,7 @@ export function buildSeed(opts: BuildSeedOpts = {}): SeedDataset {
     for (let j = 0; j < count; j++) {
       teSeq++;
       const user = users[(mi + j) % users.length];
+      if (!user) continue;
       const daysAgo = (teSeq * 2) + 1;
       out.timeEntries.push({
         id: `te-${String(teSeq).padStart(3, "0")}`,
@@ -311,6 +314,7 @@ export function buildSeed(opts: BuildSeedOpts = {}): SeedDataset {
       exSeq++;
       const user = users[(mi + j) % users.length];
       const cat = cats[exSeq % cats.length];
+      if (!user || !cat) continue;
       const daysAgo = (exSeq * 3) + 2;
       out.expenses.push({
         id: `ex-${String(exSeq).padStart(3, "0")}`,
@@ -328,6 +332,7 @@ export function buildSeed(opts: BuildSeedOpts = {}): SeedDataset {
   const statuses: Array<"DRAFT" | "SENT" | "PAID" | "INSTALLMENT_PLAN"> = ["DRAFT", "SENT", "PAID", "INSTALLMENT_PLAN"];
   for (let i = 0; i < 12; i++) {
     const matter = MATTERS[i % MATTERS.length];
+    if (!matter) continue;
     const daysAgo = (i * 7) + 5;
     const amountInclVat = 80_000 + (i * 23_000);
     // 25 % moms baked-in: exklusiv-belopp = inkl / 1.25 (avrundat till örestal)
@@ -394,6 +399,7 @@ export function buildSeed(opts: BuildSeedOpts = {}): SeedDataset {
   let paymentSeq = 0;
   for (let i = 0; i < planTargets.length; i++) {
     const p = planTargets[i];
+    if (!p) continue;
     const planId = `pp-${String(i + 1).padStart(3, "0")}`;
     out.paymentPlans.push({
       id: planId,
@@ -488,6 +494,7 @@ export function buildSeed(opts: BuildSeedOpts = {}): SeedDataset {
     const t = tpl[i % tpl.length];
     const matter = MATTERS[i % MATTERS.length];
     const userId = ASSIGN_USERS[i % ASSIGN_USERS.length];
+    if (!t || !matter) continue;
     const daysOffset = (i % 14) - 5; // -5..+8 dagar runt idag
     const start = isoDate(daysOffset, 9 + (i % 4) * 2);
     const endAt = t.hoursLong > 0 ? new Date(start.getTime() + t.hoursLong * 3600_000) : null;
@@ -536,8 +543,9 @@ export function buildSeed(opts: BuildSeedOpts = {}): SeedDataset {
       const title = taskTitles[taskSeq % taskTitles.length];
       const status = taskStatusPool[taskSeq % taskStatusPool.length];
       const dueOffset = userTaskOffsets[j];
-      const dueAt = isoDate(dueOffset, [9, 11, 14, 16][j % 4]);
-      dueAt.setMinutes([0, 15, 30, 45][j % 4]);
+      if (!matter || dueOffset === undefined) continue;
+      const dueAt = isoDate(dueOffset, [9, 11, 14, 16][j % 4] ?? 9);
+      dueAt.setMinutes([0, 15, 30, 45][j % 4] ?? 0);
       const createdOffset = -((taskSeq * 3) % 30 + 1);
       out.tasks.push({
         id: `task-${String(taskSeq + 1).padStart(3, "0")}`,
@@ -584,8 +592,10 @@ export function buildSeed(opts: BuildSeedOpts = {}): SeedDataset {
     { id: "cc-05", searchTerm: "Folksam", searchType: "name" as const },
   ];
   for (let i = 0; i < cc.length; i++) {
+    const c = cc[i];
+    if (!c) continue;
     out.conflictChecks.push({
-      id: cc[i].id, searchTerm: cc[i].searchTerm, searchType: cc[i].searchType,
+      id: c.id, searchTerm: c.searchTerm, searchType: c.searchType,
       results: [], checkedById: currentUserId, createdAt: isoDate(-(i * 3 + 1)),
     });
   }
@@ -708,6 +718,7 @@ export function seedToFiles(dataset: SeedDataset): Array<{ path: string; data: R
   const out: Array<{ path: string; data: Record<string, unknown> }> = [];
   for (const [key, entityName] of entityKeys) {
     const entry = ENTITY_REGISTRY[entityName];
+    if (!entry) continue;
     for (const row of dataset[key]) {
       const data = row as Record<string, unknown>;
       const path = entry.gitPath(data.id as string, data);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,9 +5,10 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
-    // Extra korrekthetsflaggor. exactOptionalPropertyTypes på (#32).
-    // noUncheckedIndexedAccess (~529 fel, test-tungt) kvar som separat fas i #32.
+    // Extra korrekthetsflaggor (#32). Båda på: indexerad access och
+    // optional-fält ger nu T | undefined och måste smalnas innan bruk.
     "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
     "noFallthroughCasesInSwitch": true,
     // TS6: matcha 7.0:s (Go-native) typordning → mindre diff vid den migreringen.


### PR DESCRIPTION
Sista flaggan i #32-ratchet:en. `noUncheckedIndexedAccess` på → all indexerad access (`arr[i]`, `obj[key]`, `Record`-lookups, regex-grupper, `.split()`-resultat) ger nu `T | undefined`.

## Vad

- **530 fel åtgärdade över 133 filer** via narrowing: early-return-guards i loopar, `??`-defaults, och non-null-assertions där index är bevisbart in-bounds (`for i < length`, etc.).
- Inga `any`/casts/`eslint-disable` för no-explicit-any. Ren typ-smalning, semantik oförändrad.
- Fan-out: 14 parallella agenter över disjunkta fil-bins, därefter manuell verifiering + coverage-städning.

## Coverage

Strikthet lägger till defensiva grenar (5229 → 5262) vilket naturligt späder branch-%. Återställt över floor (64.1) via **äkta förbättringar, inte gaming**:
- `render-pdf.ts`: precis `ExpenseRow`-typ ersätter lat `Record<string,string>`-cast → 8 döda `?? ""`-fallbacks bort (fälten är alltid required strings).
- `reports/page.tsx`: `.split("T")[0]!` (split ger alltid `[0]`) → 2 döda grenar bort.
- `execute.ts`: `steps[i]!` i loop → complexity tillbaka ≤ 8.
- Nytt test: `WritableDelegate.delete` på okänt id kastar.

Kvarvarande otäckta nya grenar är defensiva fail-fast-guards (NOT_FOUND, no-HEAD) — delvis onåbara dubbel-guards; lämnade orörda hellre än att ta bort skydd för en metrik.

## Verifiering (Node 24 = CI)

- `tsc --noEmit`: **0 fel**
- `lint --max-warnings 45`: **0 fel**, 45 varningar (== cap, oförändrat mot main)
- `test:cov`: **2233 gröna**, branches **64.12%** (3374/5262 ≥ 64.1)

Lokal darwin-Node24 ger identiska branch-siffror som CI-ubuntu-Node24 (bevisat i #52), så lokala siffrorna = CI:s.

Stänger #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)