### PR TITLE
chore(lint): ge max-lines-cap en ventil via eslint bulk-suppressions (#41)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,11 +53,12 @@ jobs:
       - run: corepack enable
       - run: yarn install --immutable
       - run: yarn typecheck
-      # Ratchet: lint får ha HÖGST 45 warnings (dagens nivå). Nya warnings →
-      # rött bygge. Driv ned baseline:n över tid (mål: 0). Errors fällde redan.
-      # (86→50: no-unused-vars + ^_-ignore. 50→46: exhaustive-deps (#5).
-      #  46→45: ProfileBasicsSection utbruten ur ProfilePage (#6, pågående ratchet).)
-      - run: yarn lint --max-warnings 45
+      # Ratchet med ventil (#41): struktur-reglerna (max-lines/-depth/-params/
+      # -nested-callbacks + complexity) är `error`. Befintlig skuld ligger i
+      # eslint-suppressions.json (43 poster); --max-warnings 0 fäller alla NYA
+      # warnings OCH oavsedda warning-regler. Skulden betas av via `yarn
+      # lint:prune` när en lång funktion bryts ut. Se docs/quality.md.
+      - run: yarn lint --max-warnings 0
       - run: yarn deps:check
       # Gating: fäller på strukturfynd (döda filer, oanvända/olistade deps).
       # Export-/typ-fynd är "warn" i knip.json (rådgivande) tills #3/#4 städat dem.

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -72,12 +72,46 @@ Coverage-rapporten skrivs till `reports/coverage/` (HTML, lcov, json-summary, te
 
 ### Komplexitet (`yarn lint`)
 
-| Mått | Gräns |
-|---|---|
-| Cyclomatic complexity per funktion | 8 (error) |
-| Maxdjup (nested blocks) | 4 |
-| Rader per funktion | 100 (200 i `tooling/scripts/`) |
-| Parametrar per funktion | 5 |
+Alla struktur-regler är `error` (inte `warn`). CI kör `yarn lint --max-warnings 0`.
+
+| Mått | Gräns | Nivå |
+|---|---|---|
+| Cyclomatic complexity per funktion | 8 | error |
+| Maxdjup (nested blocks) | 4 | error |
+| Rader per funktion | 100 (200 i `tooling/scripts/`) | error |
+| Parametrar per funktion | 5 | error |
+| Nästade callbacks | 4 | error |
+
+#### max-lines-cap & ventil (#41)
+
+Tidigare låg lint på `--max-warnings 45` med struktur-reglerna som `warn` —
+**noll marginal** (45/45). En orelaterad ny funktion > 100 rader rödfärgade
+bygget tills den bröts ut, och den delade budgeten gjorde att vilken ny warning
+som helst kunde spränga taket. Den frös skulden utan att beta av den.
+
+Nu: struktur-reglerna är `error` och dagens skuld (43 brott) ligger som en
+**baseline** i [`eslint-suppressions.json`](../eslint-suppressions.json) i
+repo-roten — ESLint 10:s inbyggda
+[bulk-suppressions](https://eslint.org/docs/latest/use/suppressions). Det ger:
+
+- **Ventil** — orelaterat arbete blockeras aldrig av gammal skuld. Det finns
+  ingen delad warning-budget kvar att spränga; bara *nya* brott fäller bygget.
+- **Hårdare ratchet** — en ny funktion > 100 rader (eller för djup/för många
+  parametrar) är ett `error`, inte en warning bland 45.
+- **Mekanisk nedtrappning mot 0** — när en lång funktion bryts ut kör man
+  `yarn lint:prune` som tar bort dess post ur baseline:n. Filen krymper i git;
+  diffen visar exakt vilken skuld som betats. Posterna får **bara** minska.
+
+Arbetsflöde:
+
+```bash
+yarn lint:prune     # efter en refaktorering: ta bort betalda poster ur baseline
+yarn lint:suppress  # ENDAST om en helt ny, oundviklig long-fn måste in (motivera i PR)
+```
+
+`yarn lint:suppress` lägger till i baseline:n och ska behandlas som en
+ratchet-loosening — undvik den; bryt hellre ut funktionen. Antalet poster i
+`eslint-suppressions.json` är skuldräknaren (mål: 0).
 
 ### Duplikat (`yarn duplicates`)
 

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,0 +1,185 @@
+{
+  "src/app/calendar/_event-detail-modal.tsx": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/app/calendar/page.tsx": {
+    "max-lines-per-function": {
+      "count": 2
+    }
+  },
+  "src/app/contacts/[id]/_client.tsx": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/app/contacts/page.tsx": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/app/demo/_demo-client.tsx": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/app/matters/[id]/_expense-section.tsx": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/app/matters/[id]/_kostnadsrakning-modal.tsx": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/app/matters/page.tsx": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/app/payment-plans/[id]/_client.tsx": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/app/profile/page.tsx": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/app/search/page.tsx": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/app/settings/page.tsx": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/app/setup/page.tsx": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/app/templates/page.tsx": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/app/time/page.tsx": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/app/users/[id]/_edit-client.tsx": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/components/documents/_document-row.tsx": {
+    "max-depth": {
+      "count": 1
+    }
+  },
+  "src/components/documents/document-browser.tsx": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/components/documents/external-edit-modal.tsx": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/components/llm/llm-settings-card.tsx": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/components/matter/invoices-section.tsx": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/components/matter/payment-method-card.tsx": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/components/settings/fsa-folder-selector.tsx": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/components/settings/keypair-manager.tsx": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/components/settings/web-oauth-device-flow.tsx": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/components/shell/demo-bootstrap.tsx": {
+    "max-lines-per-function": {
+      "count": 1
+    },
+    "max-params": {
+      "count": 1
+    }
+  },
+  "src/components/shell/sidebar.tsx": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/lib/client/kostnadsrakning/render-pdf.ts": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/lib/client/sync/use-auto-sync.ts": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/lib/server/adapters/demo-search-index.ts": {
+    "max-params": {
+      "count": 1
+    }
+  },
+  "src/lib/server/data-store/DemoDataStore.ts": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/lib/server/local-first/demo-loader.ts": {
+    "max-depth": {
+      "count": 4
+    }
+  },
+  "src/lib/server/local-first/filesystem-event-log.ts": {
+    "max-depth": {
+      "count": 3
+    }
+  },
+  "src/lib/server/routers/reports.ts": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "src/lib/shared/kostnadsrakning.ts": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  },
+  "tooling/scripts/seed-data.ts": {
+    "max-lines-per-function": {
+      "count": 1
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "tier3:restart": "docker compose -f tooling/docker/docker-compose.yml restart web",
     "tier3:logs": "docker compose -f tooling/docker/docker-compose.yml logs -f",
     "lint": "eslint --config tooling/config/eslint.config.mjs",
+    "lint:suppress": "eslint --config tooling/config/eslint.config.mjs --suppress-all",
+    "lint:prune": "eslint --config tooling/config/eslint.config.mjs --prune-suppressions",
     "commitlint": "commitlint --config tooling/config/commitlint.config.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest --config tooling/config/vitest.config.ts",

--- a/tooling/config/commitlint.config.mjs
+++ b/tooling/config/commitlint.config.mjs
@@ -1,5 +1,7 @@
 // Commitlint-konfiguration — enforcar Conventional Commits.
 // Körs lokalt av .husky/commit-msg och i CI (PR-titel) via `yarn commitlint`.
-export default {
+const config = {
   extends: ['@commitlint/config-conventional'],
 };
+
+export default config;

--- a/tooling/config/eslint.config.mjs
+++ b/tooling/config/eslint.config.mjs
@@ -3,15 +3,20 @@ import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
 
 /**
- * ESLint-konfiguration med extra regler för kodkvalitet:
- *   - complexity: cyklomatisk komplexitet ≤ 8 per funktion (HARD error)
+ * ESLint-konfiguration med extra regler för kodkvalitet (alla HARD error):
+ *   - complexity: cyklomatisk komplexitet ≤ 8 per funktion
  *   - max-depth: max 4 nivåer av nästade block
- *   - max-lines-per-function: 80 rader (mjuk gräns)
+ *   - max-lines-per-function: 100 rader (200 i tooling/scripts/)
  *   - max-params: 5 parametrar per funktion
+ *   - max-nested-callbacks: max 4 nästade callbacks
  *
- * Befintliga funktioner som överskrider 8 har explicita `eslint-disable`
- * + TODO så CI blockerar NYA brott. Se Task #6 i docs/roundtrip-handoff.md
- * för refaktoreringskö.
+ * Struktur-reglerna är `error`, inte `warn`: CI körs med `--max-warnings 0`
+ * så NYA brott blockerar bygget. Befintlig skuld ligger som en baseline i
+ * `eslint-suppressions.json` (genererad via `yarn lint:suppress`, en
+ * ESLint-10-bulk-suppression) — den fungerar som ventil så orelaterat arbete
+ * aldrig blockeras av gammal skuld, och betas av mekaniskt: när en lång
+ * funktion refaktoreras kör `yarn lint:prune` bort dess post och filen krymper
+ * i git. Se docs/quality.md ("max-lines-cap & ventil") och #41.
  */
 const eslintConfig = defineConfig([
   ...nextVitals,
@@ -72,13 +77,13 @@ const eslintConfig = defineConfig([
         },
       ],
       complexity: ["error", { max: 8 }],
-      "max-depth": ["warn", 4],
+      "max-depth": ["error", 4],
       "max-lines-per-function": [
-        "warn",
+        "error",
         { max: 100, skipBlankLines: true, skipComments: true, IIFEs: true },
       ],
-      "max-params": ["warn", 5],
-      "max-nested-callbacks": ["warn", 4],
+      "max-params": ["error", 5],
+      "max-nested-callbacks": ["error", 4],
     },
   },
   {
@@ -93,7 +98,7 @@ const eslintConfig = defineConfig([
     // Scripts har naturligt mer setup-kod.
     files: ["tooling/scripts/**/*.ts"],
     rules: {
-      "max-lines-per-function": ["warn", { max: 200 }],
+      "max-lines-per-function": ["error", { max: 200 }],
     },
   },
   globalIgnores([

--- a/tooling/scripts/oauth-proxy/cloudflare-worker.ts
+++ b/tooling/scripts/oauth-proxy/cloudflare-worker.ts
@@ -51,7 +51,7 @@ interface Env {
 
 const SCOPES = "repo,user:email";
 
-export default {
+const worker = {
   async fetch(request: Request, env: Env): Promise<Response> {
     const cors = corsHeaders(env);
     if (request.method === "OPTIONS") return new Response(null, { headers: cors });
@@ -66,6 +66,8 @@ export default {
     }
   },
 };
+
+export default worker;
 
 function corsHeaders(env: Env): Record<string, string> {
   return {


### PR DESCRIPTION
Fixar #41.

## Problem
Lint låg på `--max-warnings 45` med struktur-reglerna (`max-lines-per-function`, `max-depth`, `max-params`) som `warn` — **exakt 45/45, noll marginal**. En orelaterad ny funktion > 100 rader rödfärgade CI tills den bröts ut, och den delade warning-budgeten gjorde att vilken ny warning som helst kunde spränga taket. Ratchet:en frös skulden utan att beta av den.

## Lösning — ventil + hårdare ratchet + mekanisk nedtrappning
- **Promota** struktur-reglerna `warn` → `error` (likt `complexity` som redan var `error`), inkl. `max-nested-callbacks`.
- **Baseline** dagens 43 brott i `eslint-suppressions.json` (ESLint 10:s inbyggda [bulk-suppressions](https://eslint.org/docs/latest/use/suppressions)) → orelaterat arbete blockeras **aldrig** av gammal skuld.
- **CI**: `--max-warnings 45` → `--max-warnings 0`. Nya brott är `error` och fäller bygget direkt.
- **Nedtrappning**: `yarn lint:prune` krymper baseline:n när en lång funktion bryts ut (mål: 0). `yarn lint:suppress` regenererar (behandlas som en ratchet-loosening — undvik).
- Fixar de 2 sista kvarvarande warnings (`import/no-anonymous-default-export` i commitlint-config + cloudflare-worker) så taket faktiskt blir 0.
- Dokumenterar strategin i `docs/quality.md` ("max-lines-cap & ventil").

## Klar när (från issue)
- [x] Dokumenterad cap-strategi i `docs/quality.md`.
- [x] CI har marginal (delad budget borta) **och** en mekanisk nedtrappning (`lint:prune`).

## Verifierat lokalt
- `yarn typecheck` ✓ (efter `rm tsconfig.tsbuildinfo`)
- `yarn lint --max-warnings 0` ✓ (43 brott baselinade, 0 kvarvarande)
- `yarn test:fast` ✓ (2196 tester)
- Ratchet bekräftad: en ny 120-raders funktion ger `error` → exit 1.
- `yarn lint:prune` idempotent när ingen skuld betats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)