### PR TITLE
feat(schema): schemaVersion + versionsgrind vid hydrering (ADR 0004, #8)

### DIFF
--- a/src/lib/client/demo/demo-meta.ts
+++ b/src/lib/client/demo/demo-meta.ts
@@ -9,6 +9,10 @@
  */
 import { DEMO_META_PATH } from "../../../../tooling/demo-config";
 import { resolveGhPagesUrl } from "@/lib/shared/gh-pages-url";
+import {
+  assertRepoSchemaCompatible,
+  parseSchemaVersion,
+} from "@/lib/shared/schema-version";
 
 export interface DemoMetaUser {
   /** UUID — principalId som /login sparar i firma-config. */
@@ -20,6 +24,8 @@ export interface DemoMetaUser {
 }
 
 export interface DemoMeta {
+  /** Datamodellens version (ADR 0004). Saknas i repon byggda före grinden. */
+  schemaVersion?: number;
   /** UUID på orgen. */
   organizationId: string;
   organizationName: string;
@@ -54,6 +60,9 @@ export async function loadDemoMeta(
   }
   const json = await res.json() as unknown;
   const meta = validate(json, url);
+  // Versionsgrind (ADR 0004): vägra ett repo som är nyare än koden förstår,
+  // INNAN user-/org-data används. Saknad version → baslinje (v1) → OK.
+  assertRepoSchemaCompatible(meta.schemaVersion);
   cache = { url, data: meta };
   return meta;
 }
@@ -76,7 +85,11 @@ function validate(json: unknown, url: string): DemoMeta {
   if (!Array.isArray(o.users) || o.users.length === 0) {
     throw new Error(`meta.json från ${url} saknar users`);
   }
+  const schemaVersion = parseSchemaVersion(o.schemaVersion);
   return {
+    // exactOptionalPropertyTypes: utelämna nyckeln helt när den saknas
+    // istället för att sätta `undefined`.
+    ...(schemaVersion !== undefined ? { schemaVersion } : {}),
     organizationId: requireString(o.organizationId, `meta.json från ${url} saknar organizationId`),
     organizationName: requireString(o.organizationName, `meta.json från ${url} saknar organizationName`),
     users: o.users.map((u, i) => validateUser(u, url, i)),

--- a/src/lib/client/firma/load-self-hosted-source.ts
+++ b/src/lib/client/firma/load-self-hosted-source.ts
@@ -19,6 +19,11 @@ import { resolveCorsProxy } from "@/lib/client/sync/cors-proxy";
 import { hydrateWorkingCopy } from "./hydrate-working-copy";
 import { setDocumentContent } from "@/lib/client/demo/document-content-cache";
 import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import {
+  assertRepoSchemaCompatible,
+  parseSchemaVersion,
+} from "@/lib/shared/schema-version";
+import { DEMO_META_PATH } from "../../../../tooling/demo-config";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 
 export interface CurrentUser {
@@ -76,6 +81,10 @@ export async function loadSelfHostedSource(deps: LoadSelfHostedDeps): Promise<De
     });
   }
 
+  // Versionsgrind (ADR 0004): vägra ett repo som är nyare än koden förstår,
+  // FÖRE hydrering. Saknad/ogiltig meta → baslinje (v1) → fortsätt.
+  assertRepoSchemaCompatible(await readWorkingCopySchemaVersion(fs));
+
   const source = await hydrateWorkingCopy(deps.handle);
   // Ladda extraherad dokumenttext (documents/text/<id>.txt) från OPFS in i
   // content-cache:n så fritext-sök hittar PDF/DOCX-innehåll EFTER en
@@ -87,6 +96,24 @@ export async function loadSelfHostedSource(deps: LoadSelfHostedDeps): Promise<De
     await ensureCurrentUser(fs, source, deps.currentUser);
   }
   return source;
+}
+
+/**
+ * Läs `schemaVersion` ur den klonade working copy:ns `.ava/meta.json`. Saknad
+ * fil (repo seedat före grinden) eller trasig JSON → `undefined`, vilket
+ * grinden tolkar som v1-baslinje. Kastar aldrig själv.
+ */
+async function readWorkingCopySchemaVersion(
+  fs: FsaIsoGitAdapter,
+): Promise<number | undefined> {
+  try {
+    const raw = JSON.parse(
+      (await fs.readFile(`/${DEMO_META_PATH}`, "utf8")) as string,
+    ) as { schemaVersion?: unknown };
+    return parseSchemaVersion(raw.schemaVersion);
+  } catch {
+    return undefined;
+  }
 }
 
 /** Läs documents/text/<id>.txt ur OPFS → content-cache (för fritext-sök). */

--- a/src/lib/server/local-first/demo-loader.ts
+++ b/src/lib/server/local-first/demo-loader.ts
@@ -27,6 +27,11 @@ import type { MemFs } from "./mem-fs";
 import { ProjectionHydrator } from "./projection-writer";
 import type { ProjectionRegistry } from "./projections/registry";
 import { ENTITY_REGISTRY } from "@/lib/shared/schemas";
+import {
+  assertRepoSchemaCompatible,
+  parseSchemaVersion,
+} from "@/lib/shared/schema-version";
+import { DEMO_META_PATH } from "../../../../tooling/demo-config";
 
 export type DemoCloneFn = (fs: MemFs, url: string) => Promise<void>;
 
@@ -63,6 +68,10 @@ export class DemoLoader {
     this.hydrated.clear();
 
     await this.deps.cloneFn(this.deps.fs, url);
+
+    // Versionsgrind (ADR 0004): vägra ett repo som är nyare än koden förstår,
+    // FÖRE hydrering. Saknad/ogiltig meta → baslinje (v1) → fortsätt.
+    assertRepoSchemaCompatible(await this.readRepoSchemaVersion());
 
     const hydrator = new ProjectionHydrator(this.deps.fs, this.deps.registry);
     const result: LoadResult = { url, entities: {}, totalCount: 0, errors: [] };
@@ -129,6 +138,23 @@ export class DemoLoader {
   }
 
   // ── interna ──────────────────────────────────────────────────
+
+  /**
+   * Läs `schemaVersion` ur det klonade repots `.ava/meta.json`. Saknad fil
+   * (repo byggt före grinden) eller trasig JSON → `undefined`, vilket grinden
+   * tolkar som v1-baslinje. Kastar aldrig själv — bara grinden får vägra.
+   */
+  private async readRepoSchemaVersion(): Promise<number | undefined> {
+    try {
+      if (!(await this.deps.fs.exists(DEMO_META_PATH))) return undefined;
+      const raw = JSON.parse(await this.deps.fs.readFile(DEMO_META_PATH)) as {
+        schemaVersion?: unknown;
+      };
+      return parseSchemaVersion(raw.schemaVersion);
+    } catch {
+      return undefined;
+    }
+  }
 
   private async clearFs(): Promise<void> {
     // Rensa allt — ny demo-laddning ska inte ärva tidigare data

--- a/src/lib/shared/schema-version.ts
+++ b/src/lib/shared/schema-version.ts
@@ -1,0 +1,69 @@
+/**
+ * Datamodellens version + versionsgrind ([ADR 0004]).
+ *
+ * Git-backenden lagrar all data i ANVÄNDARENS repo. En godtycklig kombination
+ * av kod-version och data-version kan därför mötas vid hydrering. Det här är
+ * den enda kopplingen mellan dem:
+ *
+ *   - `CURRENT_SCHEMA_VERSION` — vilken datamodell den här koden skriver/läser.
+ *   - `assertRepoSchemaCompatible` — grinden som körs efter klon, FÖRE hydrering.
+ *
+ * Ramverks-agnostisk (ren TS): körs i alla lager och i build-scripten.
+ *
+ * [ADR 0004]: ../../../docs/adr/0004-schemaversion-och-versionsgrind.md
+ */
+
+/**
+ * Datamodellens version. **Bumpa BARA vid en BRYTANDE schemaändring** (rename,
+ * typbyte, fält som blir obligatoriskt) — och para alltid en bump med en
+ * migrate-on-read-kedja. Additiva optionella fält bärs av schemats
+ * `.passthrough()` och kräver ingen bump.
+ */
+export const CURRENT_SCHEMA_VERSION = 1;
+
+/**
+ * Repots datamodell är NYARE än den här koden förstår. Att fortsätta vore
+ * farligt: en gammal kod-version skulle passthrough-droppa fält den inte
+ * känner till och skriva tillbaka en stympad rad → tyst datakorruption.
+ */
+export class IncompatibleSchemaVersionError extends Error {
+  constructor(
+    readonly repoVersion: number,
+    readonly codeVersion: number,
+  ) {
+    super(
+      `Repot skrevs av en nyare AVA-version (schemaVersion ${repoVersion}) än ` +
+        `den här (${codeVersion}). Uppdatera AVA innan du öppnar repot.`,
+    );
+    this.name = "IncompatibleSchemaVersionError";
+  }
+}
+
+/**
+ * Tolka ett rått `schemaVersion`-värde (typiskt ur `.ava/meta.json`). Saknat
+ * eller ogiltigt → `undefined` (grinden tolkar det som baslinje, se nedan).
+ */
+export function parseSchemaVersion(raw: unknown): number | undefined {
+  return typeof raw === "number" && Number.isInteger(raw) && raw > 0
+    ? raw
+    : undefined;
+}
+
+/**
+ * Versionsgrind. Kör efter klon/läsning av repots `schemaVersion`, INNAN
+ * domänen ser någon rad. Fyra fall ([ADR 0004]):
+ *
+ *   - saknas (`undefined`) → tolka som v1-baslinje (repon skapade före ADR:t) → OK
+ *   - repo === kod         → OK
+ *   - repo  <  kod         → OK (migrate-on-read lyfter raderna i en senare fas)
+ *   - repo  >  kod         → kasta {@link IncompatibleSchemaVersionError}
+ */
+export function assertRepoSchemaCompatible(
+  repoVersion: number | undefined,
+  codeVersion: number = CURRENT_SCHEMA_VERSION,
+): void {
+  const v = repoVersion ?? 1;
+  if (v > codeVersion) {
+    throw new IncompatibleSchemaVersionError(v, codeVersion);
+  }
+}

--- a/test/scripts/write-demo-meta.test.ts
+++ b/test/scripts/write-demo-meta.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect } from "vitest";
 import { buildDemoMeta } from "../../tooling/scripts/write-demo-meta";
 import { createIdTranslator } from "../../tooling/demo-generator/id-translator";
 import { isUuid } from "../../src/lib/shared/uuid";
+import { CURRENT_SCHEMA_VERSION } from "../../src/lib/shared/schema-version";
 
 const FIXED_NOW = new Date("2026-05-31T10:00:00.000Z");
 
@@ -60,5 +61,10 @@ describe("buildDemoMeta", () => {
   it("title är optional", () => {
     const noTitle = seed({ users: [{ id: "u-x", name: "X", email: "x@ava", role: "ADMIN" }] });
     expect(buildDemoMeta(noTitle, createIdTranslator(), FIXED_NOW).users[0]!.title).toBeUndefined();
+  });
+
+  it("stämplar schemaVersion = CURRENT_SCHEMA_VERSION (ADR 0004)", () => {
+    expect(buildDemoMeta(seed(), createIdTranslator(), FIXED_NOW).schemaVersion)
+      .toBe(CURRENT_SCHEMA_VERSION);
   });
 });

--- a/test/unit/lib/client/demo-meta.test.ts
+++ b/test/unit/lib/client/demo-meta.test.ts
@@ -80,4 +80,20 @@ describe("loadDemoMeta", () => {
     await expect(loadDemoMeta("ulrik-s/ava", mockFetch(bad)))
       .rejects.toThrow(/saknar id/);
   });
+
+  it("versionsgrind: vägrar ett demo-repo nyare än koden (ADR 0004)", async () => {
+    await expect(loadDemoMeta("ulrik-s/ava", mockFetch({ ...VALID_META, schemaVersion: 9999 })))
+      .rejects.toThrow(/nyare AVA-version/);
+  });
+
+  it("versionsgrind: parsar schemaVersion när den finns", async () => {
+    const meta = await loadDemoMeta("ulrik-s/ava", mockFetch({ ...VALID_META, schemaVersion: 1 }));
+    expect(meta.schemaVersion).toBe(1);
+  });
+
+  it("versionsgrind: tom schemaVersion → undefined (baslinje), laddar ändå", async () => {
+    const meta = await loadDemoMeta("ulrik-s/ava", mockFetch(VALID_META));
+    expect(meta.schemaVersion).toBeUndefined();
+    expect(meta.organizationId).toBe("demo-firma-ab");
+  });
 });

--- a/test/unit/lib/firma/load-self-hosted-source.test.ts
+++ b/test/unit/lib/firma/load-self-hosted-source.test.ts
@@ -28,6 +28,31 @@ describe("loadSelfHostedSource", () => {
     expect(src.matters).toHaveLength(1);
   });
 
+  it("versionsgrind: vägrar en working copy nyare än koden (ADR 0004)", async () => {
+    const fsa = makeFakeFsa();
+    const { FsaIsoGitAdapter } = await import("@/lib/client/fsa/fs-adapter");
+    const fs = new FsaIsoGitAdapter(fsa.root);
+    await fs.writeFile("/.git/HEAD", "ref: refs/heads/main\n");
+    await fs.writeFile("/.ava/meta.json", JSON.stringify({ schemaVersion: 9999 }));
+
+    await expect(loadSelfHostedSource({
+      handle: fsa.root, repo: "http://localhost:8080/git/firma.git", clone: vi.fn(),
+    })).rejects.toThrow(/nyare AVA-version/);
+  });
+
+  it("versionsgrind: working copy utan meta.json laddar (baslinje v1)", async () => {
+    const fsa = makeFakeFsa();
+    const wb = makeFsaWriteBack({ handle: fsa.root });
+    await wb({ entity: "matter", kind: "create", row: { id: "m1", organizationId: "o1", title: "T" } });
+    const { FsaIsoGitAdapter } = await import("@/lib/client/fsa/fs-adapter");
+    await new FsaIsoGitAdapter(fsa.root).writeFile("/.git/HEAD", "ref: refs/heads/main\n");
+
+    const src = await loadSelfHostedSource({
+      handle: fsa.root, repo: "http://localhost:8080/git/firma.git", clone: vi.fn(),
+    });
+    expect(src.matters).toHaveLength(1);
+  });
+
   it("provisionerar current-user om den saknas", async () => {
     const fsa = makeFakeFsa();
     const { FsaIsoGitAdapter } = await import("@/lib/client/fsa/fs-adapter");

--- a/test/unit/lib/shared/schema-version.test.ts
+++ b/test/unit/lib/shared/schema-version.test.ts
@@ -1,0 +1,66 @@
+/**
+ * `schema-version` — datamodellens version + versionsgrinden (ADR 0004).
+ * Testen lockar fast grindens fyra fall och den defensiva parsningen.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  CURRENT_SCHEMA_VERSION,
+  IncompatibleSchemaVersionError,
+  assertRepoSchemaCompatible,
+  parseSchemaVersion,
+} from "@/lib/shared/schema-version";
+
+describe("parseSchemaVersion", () => {
+  it("accepterar positiva heltal", () => {
+    expect(parseSchemaVersion(1)).toBe(1);
+    expect(parseSchemaVersion(7)).toBe(7);
+  });
+
+  it("avvisar saknat/ogiltigt → undefined", () => {
+    expect(parseSchemaVersion(undefined)).toBeUndefined();
+    expect(parseSchemaVersion(null)).toBeUndefined();
+    expect(parseSchemaVersion("1")).toBeUndefined();
+    expect(parseSchemaVersion(0)).toBeUndefined();
+    expect(parseSchemaVersion(-3)).toBeUndefined();
+    expect(parseSchemaVersion(1.5)).toBeUndefined();
+    expect(parseSchemaVersion(NaN)).toBeUndefined();
+  });
+});
+
+describe("assertRepoSchemaCompatible", () => {
+  it("OK när repo == kod", () => {
+    expect(() => assertRepoSchemaCompatible(2, 2)).not.toThrow();
+  });
+
+  it("OK när repo < kod (migrate-on-read i senare fas)", () => {
+    expect(() => assertRepoSchemaCompatible(1, 3)).not.toThrow();
+  });
+
+  it("OK när version saknas → tolkas som v1-baslinje", () => {
+    expect(() => assertRepoSchemaCompatible(undefined, 1)).not.toThrow();
+    expect(() => assertRepoSchemaCompatible(undefined, 5)).not.toThrow();
+  });
+
+  it("VÄGRAR när repo > kod (skydd mot tyst datakorruption)", () => {
+    expect(() => assertRepoSchemaCompatible(2, 1)).toThrow(IncompatibleSchemaVersionError);
+    expect(() => assertRepoSchemaCompatible(2, 1)).toThrow(/nyare AVA-version/);
+  });
+
+  it("felet bär både repo- och kod-version", () => {
+    try {
+      assertRepoSchemaCompatible(9, 4);
+      expect.unreachable("skulle ha kastat");
+    } catch (err) {
+      expect(err).toBeInstanceOf(IncompatibleSchemaVersionError);
+      expect((err as IncompatibleSchemaVersionError).repoVersion).toBe(9);
+      expect((err as IncompatibleSchemaVersionError).codeVersion).toBe(4);
+    }
+  });
+
+  it("default codeVersion = CURRENT_SCHEMA_VERSION", () => {
+    expect(() => assertRepoSchemaCompatible(CURRENT_SCHEMA_VERSION)).not.toThrow();
+    expect(() => assertRepoSchemaCompatible(CURRENT_SCHEMA_VERSION + 1)).toThrow(
+      IncompatibleSchemaVersionError,
+    );
+  });
+});

--- a/test/unit/server/local-first/demo-loader.test.ts
+++ b/test/unit/server/local-first/demo-loader.test.ts
@@ -93,6 +93,38 @@ describe("DemoLoader", () => {
     spy.mockRestore();
   });
 
+  it("versionsgrind: vägrar ett repo som är nyare än koden (ADR 0004)", async () => {
+    const fs = new MemFs();
+    const cloneFn = async (target: MemFs) => {
+      await target.writeFile(".ava/meta.json", JSON.stringify({ schemaVersion: 9999 }));
+      await target.writeFile("matters/active/m1.json", sampleMatter);
+    };
+    const loader = new DemoLoader({ fs, registry: buildDefaultRegistry(), cloneFn });
+    await expect(loader.loadDemo("https://example/too-new.git"))
+      .rejects.toThrow(/nyare AVA-version/);
+  });
+
+  it("versionsgrind: laddar normalt när schemaVersion saknas (baslinje v1)", async () => {
+    const fs = new MemFs();
+    const cloneFn = async (target: MemFs) => {
+      await target.writeFile("matters/active/m1.json", sampleMatter);
+    };
+    const loader = new DemoLoader({ fs, registry: buildDefaultRegistry(), cloneFn });
+    const result = await loader.loadDemo("https://example/legacy.git");
+    expect(result.entities.matter).toBe(1);
+  });
+
+  it("versionsgrind: trasig meta.json ignoreras (→ baslinje, laddar ändå)", async () => {
+    const fs = new MemFs();
+    const cloneFn = async (target: MemFs) => {
+      await target.writeFile(".ava/meta.json", "{ trasig json");
+      await target.writeFile("matters/active/m1.json", sampleMatter);
+    };
+    const loader = new DemoLoader({ fs, registry: buildDefaultRegistry(), cloneFn });
+    const result = await loader.loadDemo("https://example/corrupt-meta.git");
+    expect(result.entities.matter).toBe(1);
+  });
+
   it("flera demo-laddningar overskriver ren (data återställs varje load)", async () => {
     const fs = new MemFs();
     let counter = 0;

--- a/tooling/scripts/write-demo-meta.ts
+++ b/tooling/scripts/write-demo-meta.ts
@@ -15,6 +15,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { DEMO_META_PATH } from "../demo-config";
 import type { IdTranslator } from "../demo-generator/id-translator";
+import { CURRENT_SCHEMA_VERSION } from "../../src/lib/shared/schema-version";
 
 export interface DemoMetaUser {
   /** UUID — det `principalId` som /login sparar i firma-config. */
@@ -26,6 +27,8 @@ export interface DemoMetaUser {
 }
 
 export interface DemoMeta {
+  /** Datamodellens version (ADR 0004) — versionsgrinden vid hydrering läser den. */
+  schemaVersion: number;
   /** UUID på orgen — matchar det som persisteras i datat. */
   organizationId: string;
   organizationName: string;
@@ -61,6 +64,7 @@ export function buildDemoMeta(seed: SeedShape, translator: IdTranslator, now: Da
   }
 
   return {
+    schemaVersion: CURRENT_SCHEMA_VERSION,
     organizationId: translator.toUuid(orgRawId),
     organizationName: orgName,
     users,


### PR DESCRIPTION
**PR 1 av #8** — datamodell-evolution, enligt [ADR 0004](https://github.com/ulrik-s/ava/blob/main/docs/adr/0004-schemaversion-och-versionsgrind.md). Inga migreringar än; **låser v1 som baslinje** och installerar grinden så att framtida brytande ändringar fångas innan de korrumperar användardata.

## Vad
- **`src/lib/shared/schema-version.ts`** (ny, ramverks-agnostisk):
  - `CURRENT_SCHEMA_VERSION = 1`
  - `assertRepoSchemaCompatible(repoVersion?, codeVersion?)` — grindens fyra fall: saknas → v1-baslinje · `==` OK · `<` OK (migrate-on-read i senare fas) · `>` → kastar `IncompatibleSchemaVersionError`
  - `parseSchemaVersion(raw)` — defensiv tolkning (saknat/ogiltigt → `undefined`)
- **Skriver `schemaVersion`** i demo-byggets `.ava/meta.json` (`write-demo-meta.ts`). Verifierat end-to-end: `out/.ava/meta.json` får `schemaVersion: 1` och ligger i `manifest.json` → klonas in i MemFs.
- **Grind vid båda hydrerings-choke-points**, efter klon / före hydrering:
  - Demo: `DemoLoader.loadDemo` läser `.ava/meta.json` ur MemFs.
  - Self-hosted: `loadSelfHostedSource` läser ur FSA working copy.
  - Login: `loadDemoMeta` grindar också → ett för-nytt demo-repo ger ett tydligt fel istället för stympad data.
  - Saknad/trasig meta → baslinje (v1), grinden kastar aldrig själv.

## Varför self-hosted-seeds inte stämplas än
Ostämplade repon är v1 per `absent → v1`-regeln — exakt vad ADR:t avser för PR 1. Stämpling hör till write-path/PR 2 när migreringar finns.

## Avgränsning (kvar enligt ADR:ts fasning)
- **PR 2:** migrate-on-read-ramverk + första migration (issuets "klar när").
- **PR 3:** versionera event-payloads.

## Verifierat lokalt
- `yarn typecheck` ✓ · `yarn lint --max-warnings 0` ✓ · `yarn knip` ✓
- `yarn test:fast` ✓ — **2212** tester (+16 nya: grindens fyra fall, för-nytt repo vägras i demo + self-hosted, saknad/trasig meta laddar, stämpel skrivs)
- `yarn build:demo` ✓ — `out/.ava/meta.json` → `schemaVersion: 1`, i manifest

> Branchen är rebasead på main inkl. #54 (lint-ventil) + #55 (ADR 0004).

🤖 Generated with [Claude Code](https://claude.com/claude-code)