### PR TITLE
feat(schema): migrate-on-read-ramverk + första migrationen (invoice type, #8)

### DIFF
--- a/src/lib/client/firma/hydrate-working-copy.ts
+++ b/src/lib/client/firma/hydrate-working-copy.ts
@@ -14,6 +14,8 @@ import { FsaIsoGitAdapter } from "@/lib/client/fsa/fs-adapter";
 import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
 import { prebakeJoins } from "@/lib/client/demo/prebake-joins";
 import { ENTITY_REGISTRY, ENTITY_NAMES, type EntityName } from "@/lib/shared/schemas";
+import { CURRENT_SCHEMA_VERSION } from "@/lib/shared/schema-version";
+import { migrateRow } from "@/lib/shared/schema-migrations";
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
 
@@ -54,21 +56,28 @@ async function readJsonDir(
  * varna i konsolen men släpp igenom rådatan så vi inte kraschar på legacy-
  * filer. (Strikt validering kan slås på via env-flagga senare.)
  */
-function validateRow(entity: EntityName, row: Record<string, unknown>): Record<string, unknown> {
+function validateRow(
+  entity: EntityName,
+  row: Record<string, unknown>,
+  repoVersion: number,
+): Record<string, unknown> {
+  // Migrate-on-read (ADR 0004): lyft raden till aktuell datamodell före parse.
+  const migrated = migrateRow(entity, row, repoVersion);
   const schema = ENTITY_REGISTRY[entity]!.schema;
-  const result = schema.safeParse(row);
+  const result = schema.safeParse(migrated);
   if (!result.success) {
     console.warn(
-      `[hydrate] ${entity}/${String(row.id ?? "?")} schema-validering misslyckades:`,
+      `[hydrate] ${entity}/${String(migrated.id ?? "?")} schema-validering misslyckades:`,
       result.error.issues.slice(0, 3),
     );
-    return row;
+    return migrated;
   }
   return result.data as Record<string, unknown>;
 }
 
 export async function hydrateWorkingCopy(
   root: FileSystemDirectoryHandle,
+  repoSchemaVersion: number = CURRENT_SCHEMA_VERSION,
 ): Promise<DemoSource> {
   const fs = new FsaIsoGitAdapter(root);
   const out: DemoSource = {};
@@ -76,7 +85,7 @@ export async function hydrateWorkingCopy(
     const { gitPrefix, sourceKey } = ENTITY_REGISTRY[entity]!;
     const rows = await readJsonDir(fs, gitPrefix);
     if (!rows.length) continue;
-    const validated = rows.map((r) => validateRow(entity, r));
+    const validated = rows.map((r) => validateRow(entity, r, repoSchemaVersion));
     (out as Record<string, readonly unknown[]>)[sourceKey] = validated;
   }
   return prebakeJoins(out);

--- a/src/lib/client/firma/load-self-hosted-source.ts
+++ b/src/lib/client/firma/load-self-hosted-source.ts
@@ -83,9 +83,11 @@ export async function loadSelfHostedSource(deps: LoadSelfHostedDeps): Promise<De
 
   // Versionsgrind (ADR 0004): vägra ett repo som är nyare än koden förstår,
   // FÖRE hydrering. Saknad/ogiltig meta → baslinje (v1) → fortsätt.
-  assertRepoSchemaCompatible(await readWorkingCopySchemaVersion(fs));
+  const repoVersion = (await readWorkingCopySchemaVersion(fs)) ?? 1;
+  assertRepoSchemaCompatible(repoVersion);
 
-  const source = await hydrateWorkingCopy(deps.handle);
+  // Migrate-on-read: lyft äldre rader till aktuell datamodell vid hydrering.
+  const source = await hydrateWorkingCopy(deps.handle, repoVersion);
   // Ladda extraherad dokumenttext (documents/text/<id>.txt) från OPFS in i
   // content-cache:n så fritext-sök hittar PDF/DOCX-innehåll EFTER en
   // sid-navigering (cache:n är in-memory + nollställs vid full page-load;

--- a/src/lib/server/local-first/demo-loader.ts
+++ b/src/lib/server/local-first/demo-loader.ts
@@ -71,9 +71,11 @@ export class DemoLoader {
 
     // Versionsgrind (ADR 0004): vägra ett repo som är nyare än koden förstår,
     // FÖRE hydrering. Saknad/ogiltig meta → baslinje (v1) → fortsätt.
-    assertRepoSchemaCompatible(await this.readRepoSchemaVersion());
+    const repoVersion = await this.resolveRepoVersion();
+    assertRepoSchemaCompatible(repoVersion);
 
-    const hydrator = new ProjectionHydrator(this.deps.fs, this.deps.registry);
+    // Migrate-on-read: lyft äldre rader till aktuell datamodell vid hydrering.
+    const hydrator = new ProjectionHydrator(this.deps.fs, this.deps.registry, repoVersion);
     const result: LoadResult = { url, entities: {}, totalCount: 0, errors: [] };
 
     // Per-path hydration: fel på en fil hoppas över och loggas, andra
@@ -117,7 +119,9 @@ export class DemoLoader {
   async replaceEntitiesFromFs(): Promise<void> {
     this.hydrated.clear();
     const { ProjectionHydrator } = await import("./projection-writer");
-    const hydrator = new ProjectionHydrator(this.deps.fs, this.deps.registry);
+    const hydrator = new ProjectionHydrator(
+      this.deps.fs, this.deps.registry, await this.resolveRepoVersion(),
+    );
     for (const entity of this.deps.registry.entities()) {
       for (const prefix of this.knownPrefixes(entity)) {
         const items = await this.deps.fs.listDir(prefix);
@@ -154,6 +158,11 @@ export class DemoLoader {
     } catch {
       return undefined;
     }
+  }
+
+  /** Repots version, med saknad/ogiltig → v1-baslinje (för migrate-on-read). */
+  private async resolveRepoVersion(): Promise<number> {
+    return (await this.readRepoSchemaVersion()) ?? 1;
   }
 
   private async clearFs(): Promise<void> {

--- a/src/lib/server/local-first/projection-writer.ts
+++ b/src/lib/server/local-first/projection-writer.ts
@@ -23,6 +23,8 @@
 
 import type { IFileSystem } from "./file-system";
 import type { ProjectionRegistry } from "./projections/registry";
+import { CURRENT_SCHEMA_VERSION } from "@/lib/shared/schema-version";
+import { migrateRawJson } from "@/lib/shared/schema-migrations";
 
 export class ProjectionWriter {
   constructor(
@@ -61,9 +63,16 @@ export interface HydrateResult {
 }
 
 export class ProjectionHydrator {
+  /**
+   * @param repoSchemaVersion repots datamodell-version (ADR 0004). Rader lyfts
+   *   migrate-on-read från den upp till {@link CURRENT_SCHEMA_VERSION} före
+   *   parse. Default = CURRENT (ingen migration — för call-sites som hydrerar
+   *   data skriven av nuvarande kod, t.ex. live-sync).
+   */
   constructor(
     private fs: IFileSystem,
     private registry: ProjectionRegistry,
+    private repoSchemaVersion: number = CURRENT_SCHEMA_VERSION,
   ) {}
 
   /**
@@ -78,7 +87,11 @@ export class ProjectionHydrator {
     if (!entry) return null;
     if (!(await this.fs.exists(path))) return null;
     const raw = await this.fs.readFile(path);
-    const data = entry.projection.deserialize(raw);
+    // Migrate-on-read (ADR 0004): lyft rå-raden till aktuell datamodell FÖRE
+    // deserialize — annars skulle `mergeRawAfterParse` flätta tillbaka de
+    // borttagna legacy-fälten från rå-json:en.
+    const migrated = migrateRawJson(entry.entity, raw, this.repoSchemaVersion);
+    const data = entry.projection.deserialize(migrated);
     return { entity: entry.entity, data, path };
   }
 

--- a/src/lib/server/local-first/projections/invoice.ts
+++ b/src/lib/server/local-first/projections/invoice.ts
@@ -17,7 +17,8 @@ export const invoiceSchema = z.object({
   amountInclVat: z.number().optional(),
   invoiceNumber: z.string().optional(),
   invoiceType: z.enum(["STANDARD", "ACCONTO", "FINAL", "CREDIT"]).optional(),
-  type: z.enum(["ACCONTO", "FINAL", "CREDIT"]).optional(), // legacy-namn
+  // Legacy-aliaset `type` togs bort i schemaVersion 2 (migrate-on-read strippar
+  // det vid hydrering, ADR 0004). `invoiceType` är kanoniskt.
   status: z.enum(["DRAFT", "SENT", "PAID", "CANCELLED", "BAD_DEBT", "INSTALLMENT_PLAN"]).default("DRAFT"),
   invoiceDate: z.coerce.date().nullable().optional(),
   issuedAt: z.coerce.date().nullable().optional(),

--- a/src/lib/shared/schema-migrations.ts
+++ b/src/lib/shared/schema-migrations.ts
@@ -1,0 +1,76 @@
+/**
+ * Migrate-on-read ([ADR 0004]) — lyfter rå-rader från ett äldre repos
+ * `schemaVersion` upp till {@link CURRENT_SCHEMA_VERSION} INNAN zod-parsern
+ * ser dem. Körs i hydreringsvägen (både `ProjectionHydrator` och
+ * `hydrateWorkingCopy`), efter att versionsgrinden släppt igenom repot.
+ *
+ * Varför migrate-on-READ (inte on-clone): den append-only event-loggen skrivs
+ * aldrig om, så historiska rader måste kunna läsas i gammalt format för alltid.
+ *
+ * Att lägga till en migration:
+ *   1. Bumpa `CURRENT_SCHEMA_VERSION` (N → N+1) i `schema-version.ts`.
+ *   2. Lägg en post `MIGRATIONS[entity][N]` som lyfter EN rad ett steg (N→N+1).
+ *   3. Kedjan körs automatiskt (v1→v2→v3…) för repon som ligger flera steg bak.
+ *
+ * [ADR 0004]: ../../../docs/adr/0004-schemaversion-och-versionsgrind.md
+ */
+import { CURRENT_SCHEMA_VERSION } from "./schema-version";
+
+/** Lyfter en rå rad exakt ETT versionssteg (from → from+1). Ren funktion. */
+export type RowMigration = (row: Record<string, unknown>) => Record<string, unknown>;
+
+/**
+ * `MIGRATIONS[entity][n]` lyfter en `entity`-rad från schemaVersion `n` till
+ * `n+1`. Saknad post → identitet (entiteten ändrades inte i det steget).
+ */
+const MIGRATIONS: Record<string, Record<number, RowMigration>> = {
+  // invoice v1 → v2: ta bort det döda legacy-aliaset `type`. Fältet döptes om
+  // till `invoiceType` (routrar + UI använder uteslutande `invoiceType`); `type`
+  // skrevs bara av seed:en och lästes av ingen. Migrationen avlägsnar det så att
+  // projection-schemat kan sluta tolerera det (eliminerar en `.passthrough()`-
+  // workaround, jfr ADR 0004 §"bump-policy").
+  invoice: {
+    1: ({ type: _legacyType, ...rest }) => rest,
+  },
+};
+
+/**
+ * Kedja en rå rad från `fromVersion` upp till `toVersion`. Rör inte raden om
+ * den redan är aktuell (from === to) eller saknar migrationer för stegen.
+ */
+export function migrateRow(
+  entity: string,
+  row: Record<string, unknown>,
+  fromVersion: number,
+  toVersion: number = CURRENT_SCHEMA_VERSION,
+): Record<string, unknown> {
+  let current = row;
+  for (let v = fromVersion; v < toVersion; v++) {
+    const step = MIGRATIONS[entity]?.[v];
+    if (step) current = step(current);
+  }
+  return current;
+}
+
+/**
+ * Sträng-wrappern som hydratorn använder: parsa, migrera (om det är ett
+ * objekt), och re-serialisera. Trasig JSON / icke-objekt returneras oförändrat
+ * så att den nedströms deserialize:n kastar precis som förr.
+ */
+export function migrateRawJson(
+  entity: string,
+  raw: string,
+  fromVersion: number,
+  toVersion: number = CURRENT_SCHEMA_VERSION,
+): string {
+  if (fromVersion >= toVersion) return raw;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return raw;
+  const migrated = migrateRow(entity, parsed as Record<string, unknown>, fromVersion, toVersion);
+  return JSON.stringify(migrated);
+}

--- a/src/lib/shared/schema-version.ts
+++ b/src/lib/shared/schema-version.ts
@@ -16,10 +16,14 @@
 /**
  * Datamodellens version. **Bumpa BARA vid en BRYTANDE schemaändring** (rename,
  * typbyte, fält som blir obligatoriskt) — och para alltid en bump med en
- * migrate-on-read-kedja. Additiva optionella fält bärs av schemats
- * `.passthrough()` och kräver ingen bump.
+ * migrate-on-read-kedja i `schema-migrations.ts`. Additiva optionella fält bärs
+ * av schemats `.passthrough()` och kräver ingen bump.
+ *
+ * Historik:
+ *   - v1: baslinje (ADR 0004, PR 1).
+ *   - v2: invoice — döda legacy-aliaset `type` borttaget (→ `invoiceType`).
  */
-export const CURRENT_SCHEMA_VERSION = 1;
+export const CURRENT_SCHEMA_VERSION = 2;
 
 /**
  * Repots datamodell är NYARE än den här koden förstår. Att fortsätta vore

--- a/test/unit/lib/firma/hydrate-working-copy.test.ts
+++ b/test/unit/lib/firma/hydrate-working-copy.test.ts
@@ -63,4 +63,24 @@ describe("hydrateWorkingCopy", () => {
     const src = await hydrateWorkingCopy(fsa.root);
     expect(src.matters ?? []).toHaveLength(0);
   });
+
+  it("migrate-on-read: repoVersion=1 strippar invoice-`type` (ADR 0004)", async () => {
+    const fsa = makeFakeFsa();
+    const writeBack = makeFsaWriteBack({ handle: fsa.root });
+    await writeBack({ entity: "invoice", kind: "create", row: { id: "inv1", matterId: "m1", invoiceType: "STANDARD", type: "FINAL", amount: 1 } });
+
+    const src = await hydrateWorkingCopy(fsa.root, 1);
+    const inv = src.invoices![0] as Record<string, unknown>;
+    expect(inv.invoiceType).toBe("STANDARD");
+    expect(inv).not.toHaveProperty("type");
+  });
+
+  it("ingen migration när repoVersion = CURRENT (default) — `type` bevaras", async () => {
+    const fsa = makeFakeFsa();
+    const writeBack = makeFsaWriteBack({ handle: fsa.root });
+    await writeBack({ entity: "invoice", kind: "create", row: { id: "inv1", matterId: "m1", type: "FINAL", amount: 1 } });
+
+    const src = await hydrateWorkingCopy(fsa.root); // default = CURRENT
+    expect((src.invoices![0] as Record<string, unknown>)).toHaveProperty("type");
+  });
 });

--- a/test/unit/lib/shared/schema-migration.test.ts
+++ b/test/unit/lib/shared/schema-migration.test.ts
@@ -1,0 +1,60 @@
+/**
+ * `schema-migrations` — migrate-on-read (ADR 0004). Testen lockar fast den
+ * första migrationen (invoice v1→v2: stripa legacy-`type`), kedjningen och
+ * de defensiva fallen i sträng-wrappern.
+ */
+import { describe, it, expect } from "vitest";
+import { migrateRow, migrateRawJson } from "@/lib/shared/schema-migrations";
+import { CURRENT_SCHEMA_VERSION } from "@/lib/shared/schema-version";
+
+describe("migrateRow — invoice v1→v2 (stripa legacy `type`)", () => {
+  const v1Invoice = { id: "inv-1", invoiceType: "STANDARD", type: "FINAL", status: "PAID" };
+
+  it("tar bort `type` men behåller övriga fält", () => {
+    const out = migrateRow("invoice", v1Invoice, 1, 2);
+    expect(out).not.toHaveProperty("type");
+    expect(out).toMatchObject({ id: "inv-1", invoiceType: "STANDARD", status: "PAID" });
+  });
+
+  it("kedjar v1 → CURRENT (default toVersion)", () => {
+    expect(migrateRow("invoice", v1Invoice, 1)).not.toHaveProperty("type");
+  });
+
+  it("no-op när raden redan är aktuell (from === to)", () => {
+    const v2 = { id: "inv-1", invoiceType: "STANDARD" };
+    expect(migrateRow("invoice", v2, 2, 2)).toBe(v2);
+  });
+
+  it("rör inte en redan migrerad rad utan `type`", () => {
+    const v2 = { id: "inv-1", invoiceType: "FINAL" };
+    expect(migrateRow("invoice", v2, 1, 2)).toEqual(v2);
+  });
+
+  it("identitet för entiteter utan migration", () => {
+    const row = { id: "m1", title: "X" };
+    expect(migrateRow("matter", row, 1, 2)).toBe(row);
+  });
+});
+
+describe("migrateRawJson — sträng-wrapper", () => {
+  it("migrerar ett objekt och re-serialiserar", () => {
+    const out = JSON.parse(migrateRawJson("invoice", JSON.stringify({ id: "i", type: "FINAL", invoiceType: "STANDARD" }), 1, 2));
+    expect(out).not.toHaveProperty("type");
+    expect(out.invoiceType).toBe("STANDARD");
+  });
+
+  it("returnerar trasig JSON oförändrad (deserialize får kasta som förr)", () => {
+    expect(migrateRawJson("invoice", "{ trasig", 1, 2)).toBe("{ trasig");
+  });
+
+  it("returnerar icke-objekt (array/scalar) oförändrat", () => {
+    expect(migrateRawJson("invoice", "[1,2,3]", 1, 2)).toBe("[1,2,3]");
+    expect(migrateRawJson("invoice", "42", 1, 2)).toBe("42");
+  });
+
+  it("no-op när from >= to (rör inte strängen)", () => {
+    const raw = JSON.stringify({ id: "i", type: "FINAL" });
+    expect(migrateRawJson("invoice", raw, 2, 2)).toBe(raw);
+    expect(migrateRawJson("invoice", raw, CURRENT_SCHEMA_VERSION, CURRENT_SCHEMA_VERSION)).toBe(raw);
+  });
+});

--- a/test/unit/server/local-first/demo-loader.test.ts
+++ b/test/unit/server/local-first/demo-loader.test.ts
@@ -104,6 +104,24 @@ describe("DemoLoader", () => {
       .rejects.toThrow(/nyare AVA-version/);
   });
 
+  it("migrate-on-read: v1-repo → invoice-`type` strippas vid hydrering (ADR 0004)", async () => {
+    const fs = new MemFs();
+    const cloneFn = async (target: MemFs) => {
+      await target.writeFile(".ava/meta.json", JSON.stringify({ schemaVersion: 1 }));
+      await target.writeFile("invoices/inv-1.json", JSON.stringify({
+        id: "inv-1", matterId: "m1", invoiceType: "STANDARD", type: "FINAL",
+        status: "PAID", organizationId: "demo-org",
+      }));
+    };
+    const loader = new DemoLoader({ fs, registry: buildDefaultRegistry(), cloneFn });
+    await loader.loadDemo("https://example/v1.git");
+
+    const invoice = loader.entities().invoice![0] as Record<string, unknown>;
+    expect(invoice.id).toBe("inv-1");
+    expect(invoice.invoiceType).toBe("STANDARD");
+    expect(invoice).not.toHaveProperty("type"); // legacy-aliaset borta
+  });
+
   it("versionsgrind: laddar normalt när schemaVersion saknas (baslinje v1)", async () => {
     const fs = new MemFs();
     const cloneFn = async (target: MemFs) => {

--- a/tooling/scripts/seed-data.ts
+++ b/tooling/scripts/seed-data.ts
@@ -346,8 +346,9 @@ export function buildSeed(opts: BuildSeedOpts = {}): SeedDataset {
       organizationId: orgId,
       matterId: matter.id,
       invoiceNumber: `${new Date().getFullYear()}-${String(i + 1).padStart(4, "0")}`,
-      // Projection-schema kräver "type"; tRPC/UI använder gamla "invoiceType"
-      type: "FINAL",
+      // `invoiceType` är kanoniskt. Legacy-aliaset `type` skrivs inte längre
+      // (borttaget i schemaVersion 2 — migrate-on-read strippar det ur äldre
+      // repon vid hydrering, ADR 0004).
       invoiceType: "STANDARD",
       status,
       // Båda fältnamnen — UI använder gamla `amount`/`invoiceDate`/`dueDate`,


### PR DESCRIPTION
**PR 2 av #8** — datamodell-evolution, [ADR 0004](https://github.com/ulrik-s/ava/blob/main/docs/adr/0004-schemaversion-och-versionsgrind.md). Uppfyller issuets formella **"klar när"**: versionsgrind (PR 1) **+ minst en migrationskedja som finns och är testad**.

## Ramverk — `src/lib/shared/schema-migrations.ts`
- `MIGRATIONS[entity][n]` lyfter en rå-rad **ett** steg (`n → n+1`); `migrateRow` kedjar `v1→v2→…` upp till `CURRENT_SCHEMA_VERSION`. Rena objekt-transformer.
- `migrateRawJson` — strängwrapper för hydratorn; trasig JSON / icke-objekt passerar oförändrat så nedströms `deserialize` kastar precis som förr.
- Körs **före** zod-parse i **båda** hydrerings-vägarna:
  - `ProjectionHydrator.hydratePath` (demo) — ny `repoSchemaVersion`-param (default `CURRENT`). Måste migrera **före** `deserialize`, annars flätar `mergeRawAfterParse` tillbaka de borttagna fälten ur rå-json:en.
  - `hydrateWorkingCopy`/`validateRow` (self-hosted) — ny `repoSchemaVersion`-param.
- `repoVersion` trådas från `.ava/meta.json` (PR 1:s gate-läsning) in i hydratorn.

## Första migrationen v1 → v2 — invoice `type`
En **genuin, lossless** legacy-rename: fältet `type` döptes om till `invoiceType`. Routrar + UI använder uteslutande `invoiceType`; `type` skrevs bara av seed och **lästes av ingen** (verifierat). Migrationen strippar det, jag tar bort det ur invoice-projektionen (**eliminerar en `.passthrough()`-workaround** — ADR:ts motiverande exempel) och ur seed-data. `CURRENT_SCHEMA_VERSION` `1 → 2`.

> Jag valde medvetet denna framför de billing-semantiska kandidaterna: `invoiceId` är **live** (skrivs av `invoice.ts`, läses av `reports.ts` — inte vestigial), och `type`/`invoiceType` dubbelskrivning med olika värden är en domänfråga. Den döda `type`-aliasen är den enda säkra, otvetydiga.

## Avgränsning
Live-sync-hydratorn defaultar till `CURRENT` (data den hydrerar skrevs av nuvarande kod). Stämpling av repo-versionen vid första write hör till en uppföljning; migrate-on-read är idempotent så ostämplade repon migreras vid varje läsning (ofarligt).

## Verifierat lokalt
- `yarn typecheck` ✓ · `yarn lint --max-warnings 0` ✓ · `yarn knip` ✓
- `yarn test:fast` ✓ — **2224** (+12: `migrateRow`/`migrateRawJson` kedjning/no-op/defensiva fall, demo-loader v1-repo strippar `type`, hydrate-working-copy `repoVersion=1` strippar / default bevarar)
- `yarn build:demo` ✓ — `meta.schemaVersion = 2`, inga invoice-`type` i utdata

Stänger #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)