### PR TITLE
fix(routers): org-/matter-scoping på expense/timeEntry mutations + billingRun-avdrag (#60)

### DIFF
--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -142,7 +142,7 @@ export const billingRunRouter = router({
         await assertMatterInOrg(tx, input.matterId, ctx.orgId);
         const work = await fetchUnfrozenWork(tx, input.matterId);
         const value = workValueOre(work);
-        const deductionOre = await sumDeductions(tx, input.deductedBillingRunIds);
+        const deductionOre = await sumDeductions(tx, input.matterId, input.deductedBillingRunIds);
         const finalAmount = Math.max(0, value - deductionOre);
         const invoice = await tx.invoices.create({
           data: {
@@ -227,8 +227,23 @@ export const billingRunRouter = router({
     }),
 });
 
-async function sumDeductions(tx: DataStoreTx, ids: ReadonlyArray<string>): Promise<number> {
+async function sumDeductions(
+  tx: DataStoreTx,
+  matterId: string,
+  ids: ReadonlyArray<string>,
+): Promise<number> {
   if (ids.length === 0) return 0;
-  const runs = await tx.billingRuns.findMany({ where: { id: { in: ids } } });
+  // Säkerhet (#60): avdragsposterna måste tillhöra SAMMA ärende och vara
+  // ACCONTO-körningar — annars kunde en FINAL dra av främmande/fel-typade
+  // billing-runs och förvanska beloppet. Kasta om någon id inte matchar.
+  const runs = await tx.billingRuns.findMany({
+    where: { id: { in: ids }, matterId, type: "ACCONTO" },
+  });
+  if (runs.length !== ids.length) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Någon avdragspost tillhör inte detta ärende eller är ingen ACCONTO-körning.",
+    });
+  }
   return runs.reduce((sum, r) => sum + ((r as { amountOre: number }).amountOre ?? 0), 0);
 }

--- a/src/lib/server/routers/expense.ts
+++ b/src/lib/server/routers/expense.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { router, protectedProcedure } from "../trpc";
+import { router, protectedProcedure, orgProcedure, TRPCError } from "../trpc";
 import {
   asId,
   matterIdSchema,
@@ -89,7 +89,7 @@ export const expenseRouter = router({
       });
     }),
 
-  update: protectedProcedure
+  update: orgProcedure
     .input(
       z.object({
         id: z.string(),
@@ -102,6 +102,12 @@ export const expenseRouter = router({
       })
     )
     .mutation(async ({ ctx, input }) => {
+      // Säkerhet (#60): verifiera org-ägarskap (via matter, samma scopning som
+      // `list`) INNAN update. NOT_FOUND vid mismatch — läcker inte existens.
+      const owned = await ctx.dataStore.expenses.findFirst({
+        where: { id: input.id, matter: { organizationId: ctx.orgId } },
+      });
+      if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
       const { id, date, amount, description, billable, vatRate, vatIncluded } = input;
       return ctx.dataStore.expenses.update({
         where: { id },
@@ -116,9 +122,13 @@ export const expenseRouter = router({
       });
     }),
 
-  delete: protectedProcedure
+  delete: orgProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
+      const owned = await ctx.dataStore.expenses.findFirst({
+        where: { id: input.id, matter: { organizationId: ctx.orgId } },
+      });
+      if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
       return ctx.dataStore.expenses.delete({ where: { id: input.id } });
     }),
 });

--- a/src/lib/server/routers/timeEntry.ts
+++ b/src/lib/server/routers/timeEntry.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { router, protectedProcedure } from "../trpc";
+import { router, protectedProcedure, orgProcedure, TRPCError } from "../trpc";
 import { emit } from "../events/emit";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import {
@@ -106,7 +106,7 @@ export const timeEntryRouter = router({
       return entry;
     }),
 
-  update: protectedProcedure
+  update: orgProcedure
     .input(
       z.object({
         id: z.string(),
@@ -117,6 +117,12 @@ export const timeEntryRouter = router({
       })
     )
     .mutation(async ({ ctx, input }) => {
+      // Säkerhet (#60): org-ägarskap via matter (samma scopning som `list`)
+      // INNAN update. NOT_FOUND vid mismatch.
+      const owned = await ctx.dataStore.timeEntries.findFirst({
+        where: { id: input.id, matter: { organizationId: ctx.orgId } },
+      });
+      if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
       const { id, date, minutes, description, billable } = input;
       const updated = await ctx.dataStore.timeEntries.update({
         where: { id },
@@ -131,9 +137,13 @@ export const timeEntryRouter = router({
       return updated;
     }),
 
-  delete: protectedProcedure
+  delete: orgProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
+      const owned = await ctx.dataStore.timeEntries.findFirst({
+        where: { id: input.id, matter: { organizationId: ctx.orgId } },
+      });
+      if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
       const entry = await ctx.dataStore.timeEntries.delete({ where: { id: input.id } });
       await emit.timeEntryDeleted(ctx, entry.id, entry.matterId);
       return entry;

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -72,6 +72,14 @@ describe("billingRun.createFinal", () => {
     expect(fin.run.amountOre).toBe(400000);
     expect(fin.run.deductedBillingRunIds).toEqual([acc.run.id]);
   });
+
+  it("vägrar avdrag mot okänt/fel-scopat billing-run-id (#60)", async () => {
+    const { caller } = makeCaller({ workMinutes: 120 });
+    await expect(caller.billingRun.createFinal({
+      matterId: "m-1", recipient: "KLIENT",
+      deductedBillingRunIds: ["br-finns-ej"],
+    })).rejects.toThrow(/tillhör inte detta ärende|ACCONTO/);
+  });
 });
 
 describe("billingRun.createKostnadsrakning", () => {

--- a/test/unit/server/routers/expense.test.ts
+++ b/test/unit/server/routers/expense.test.ts
@@ -1,9 +1,8 @@
 /**
  * Test för expenseRouter — list/create/update/delete.
  *
- * Notering: routern saknar fortfarande explicit org-scoping på update/delete,
- * vilket är en känd luka som täcks separat i issue. Tester här verifierar
- * nuvarande beteende plus pekar ut säkerhetsbristerna med skip:ade fall.
+ * update/delete org-scopas via matter (#60): `findFirst` med
+ * `matter: { organizationId }` innan mutation, NOT_FOUND vid mismatch.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -13,6 +12,7 @@ import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
 const mockPrisma = {
   expense: {
     findMany: vi.fn(),
+    findFirst: vi.fn(),
     count: vi.fn(),
     aggregate: vi.fn(),
     create: vi.fn(),
@@ -35,6 +35,8 @@ beforeEach(() => {
   mockPrisma.expense.findMany.mockResolvedValue([]);
   mockPrisma.expense.count.mockResolvedValue(0);
   mockPrisma.expense.aggregate.mockResolvedValue({ _sum: { amount: 0 } });
+  // Default: utlägget tillhör anropande org (happy path för update/delete).
+  mockPrisma.expense.findFirst.mockResolvedValue({ id: "e1" });
 });
 
 describe("expense.list", () => {
@@ -117,6 +119,21 @@ describe("expense.update", () => {
     expect(args.data.date).toBeUndefined();
     expect(args.data.description).toBe("Ny");
   });
+
+  it("scopar ägarkollen via matter.organizationId (#60)", async () => {
+    mockPrisma.expense.update.mockResolvedValue({});
+    await makeCaller("org-a").update({ id: "e1", description: "X" });
+    expect(mockPrisma.expense.findFirst).toHaveBeenCalledWith({
+      where: { id: "e1", matter: { organizationId: "org-a" } },
+    });
+  });
+
+  it("NOT_FOUND när utlägget inte tillhör org (#60) — och update körs ej", async () => {
+    mockPrisma.expense.findFirst.mockResolvedValue(null);
+    await expect(makeCaller("org-b").update({ id: "e1", description: "X" }))
+      .rejects.toThrow(/NOT_FOUND/);
+    expect(mockPrisma.expense.update).not.toHaveBeenCalled();
+  });
 });
 
 describe("expense.delete", () => {
@@ -124,5 +141,12 @@ describe("expense.delete", () => {
     mockPrisma.expense.delete.mockResolvedValue({});
     await makeCaller().delete({ id: "e1" });
     expect(mockPrisma.expense.delete).toHaveBeenCalledWith({ where: { id: "e1" } });
+  });
+
+  it("NOT_FOUND när utlägget inte tillhör org (#60) — och delete körs ej", async () => {
+    mockPrisma.expense.findFirst.mockResolvedValue(null);
+    await expect(makeCaller("org-b").delete({ id: "e1" }))
+      .rejects.toThrow(/NOT_FOUND/);
+    expect(mockPrisma.expense.delete).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/server/routers/timeEntry.test.ts
+++ b/test/unit/server/routers/timeEntry.test.ts
@@ -9,6 +9,7 @@ import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
 const mockPrisma = {
   timeEntry: {
     findMany: vi.fn(),
+    findFirst: vi.fn(),
     count: vi.fn(),
     aggregate: vi.fn(),
     create: vi.fn(),
@@ -34,6 +35,8 @@ beforeEach(() => {
   mockPrisma.timeEntry.findMany.mockResolvedValue([]);
   mockPrisma.timeEntry.count.mockResolvedValue(0);
   mockPrisma.timeEntry.aggregate.mockResolvedValue({ _sum: { minutes: 0 } });
+  // Default: posten tillhör anropande org (happy path för update/delete, #60).
+  mockPrisma.timeEntry.findFirst.mockResolvedValue({ id: "t1", matterId: "m1" });
 });
 
 describe("timeEntry.list", () => {
@@ -119,6 +122,21 @@ describe("timeEntry.update", () => {
     expect(data.description).toBe("Nytt");
     expect(data.minutes).toBeUndefined();
   });
+
+  it("scopar ägarkollen via matter.organizationId (#60)", async () => {
+    mockPrisma.timeEntry.update.mockResolvedValue({});
+    await makeCaller("org-a").update({ id: "t1", description: "X" });
+    expect(mockPrisma.timeEntry.findFirst).toHaveBeenCalledWith({
+      where: { id: "t1", matter: { organizationId: "org-a" } },
+    });
+  });
+
+  it("NOT_FOUND när posten inte tillhör org (#60) — update körs ej", async () => {
+    mockPrisma.timeEntry.findFirst.mockResolvedValue(null);
+    await expect(makeCaller("org-b").update({ id: "t1", description: "X" }))
+      .rejects.toThrow(/NOT_FOUND/);
+    expect(mockPrisma.timeEntry.update).not.toHaveBeenCalled();
+  });
 });
 
 describe("timeEntry.delete", () => {
@@ -126,6 +144,13 @@ describe("timeEntry.delete", () => {
     mockPrisma.timeEntry.delete.mockResolvedValue({});
     await makeCaller().delete({ id: "t1" });
     expect(mockPrisma.timeEntry.delete).toHaveBeenCalledWith({ where: { id: "t1" } });
+  });
+
+  it("NOT_FOUND när posten inte tillhör org (#60) — delete körs ej", async () => {
+    mockPrisma.timeEntry.findFirst.mockResolvedValue(null);
+    await expect(makeCaller("org-b").delete({ id: "t1" }))
+      .rejects.toThrow(/NOT_FOUND/);
+    expect(mockPrisma.timeEntry.delete).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Fixar #60.

`expense`/`timeEntry` `update`+`delete` körde `where: { id }` **utan** ägarkoll (till skillnad från `contact.ts`), och `billingRun.sumDeductions` scopade inte de avdragna körningarna. **Ingen aktiv läcka** i dagens single-tenant git-backend (ett repo = en byrå), men en konsistens-/korrekthetslucka och blockerare för Backend B (ACL, [ADR 0001](../blob/main/docs/adr/0001-pluggbar-backend-bakom-idatastore.md)).

## Fix
- **expense + timeEntry**: `update`/`delete` → `orgProcedure`; verifierar ägarskap via `findFirst({ where: { id, matter: { organizationId: ctx.orgId } } })` (samma scopning som `list`) **innan** mutation, `NOT_FOUND` vid mismatch (läcker inte existens).
- **billingRun.sumDeductions**: tar nu `matterId` och filtrerar `{ id: {in}, matterId, type: "ACCONTO" }`; kastar `BAD_REQUEST` om någon id inte matchar → hindrar avdrag mot främmande/fel-typade körningar som förvanskar slutbeloppet.

## Tester (+7)
- expense/timeEntry: scopning anropas med rätt `where`, och `NOT_FOUND` när posten inte tillhör org (mutation körs ej).
- billingRun: avdrag mot okänt id avvisas; befintligt ACCONTO-avdrag fungerar fortf.

## Verifierat
`yarn typecheck` ✓ · `yarn lint --max-warnings 0` ✓ · `yarn test:fast` ✓ (2231)

🤖 Generated with [Claude Code](https://claude.com/claude-code)