### PR TITLE
test: täck kritiska otestade klient-paths (demo-bootstrap, keypair, oauth, fsa) (#61)

### DIFF
--- a/src/components/settings/fsa-folder-selector.tsx
+++ b/src/components/settings/fsa-folder-selector.tsx
@@ -228,7 +228,7 @@ export function FsaFolderSelector({ repoUrl, token }: { repoUrl: string; token: 
  *   - "git@github.com:u/r"   → https://github.com/u/r.git
  *   - "https://…"             → som-är
  */
-function githubize(input: string): string {
+export function githubize(input: string): string {
   if (/^https?:\/\//.test(input)) return input;
   const sshMatch = input.match(/^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/);
   if (sshMatch) return `https://github.com/${sshMatch[1]}/${sshMatch[2]}.git`;

--- a/src/components/shell/demo-bootstrap.tsx
+++ b/src/components/shell/demo-bootstrap.tsx
@@ -41,7 +41,7 @@ type Status = "loading" | "ready" | "error";
 
 type GateDecision = "continue" | "skip-ready" | "redirect-login" | "skip-loading";
 
-function pathSkipsAuth(p: string): boolean {
+export function pathSkipsAuth(p: string): boolean {
   return /\/(demo|login)\/?$/.test(p);
 }
 
@@ -52,7 +52,7 @@ function redirectToLogin(): void {
 
 /** Avgör om DemoBootstrap-useEffect ska köras vidare eller kortsluta.
  *  Bryts ut för att hålla useEffect under cyklomatisk komplexitet 8. */
-function checkBootstrapGate(firmaConfig: FirmaConfig): GateDecision {
+export function checkBootstrapGate(firmaConfig: FirmaConfig): GateDecision {
   if (typeof window === "undefined") return "continue";
   if (pathSkipsAuth(window.location.pathname)) return "skip-ready";
   if (firmaConfig.tier === "demo" && !firmaConfig.principalId) {
@@ -126,14 +126,14 @@ interface DocMeta { id: string; fileName?: string; storagePath?: string; mimeTyp
 type StashFn = (id: string, bytes: Uint8Array, mimeType: string, fileName: string) => void;
 
 /** base64 → bytes (för event-transport av binärt dokument-innehåll). */
-function base64ToBytes(b64: string): Uint8Array {
+export function base64ToBytes(b64: string): Uint8Array {
   const bin = atob(b64);
   const out = new Uint8Array(bin.length);
   for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
   return out;
 }
 
-function inferDocMime(file: string, meta: DocMeta | undefined): string {
+export function inferDocMime(file: string, meta: DocMeta | undefined): string {
   if (meta?.mimeType) return meta.mimeType;
   if (file.endsWith(".pdf")) return "application/pdf";
   return file.endsWith(".html") ? "text/html; charset=utf-8" : "application/octet-stream";

--- a/test/unit/components/demo-bootstrap-helpers.test.tsx
+++ b/test/unit/components/demo-bootstrap-helpers.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Tester för demo-bootstrap:ens pure beslut-/transform-helpers (#61).
+ * Själva useEffect-orkestreringen är effekt-tung; här låses den testbara
+ * kärnan: bootstrap-grinden, auth-skip-mönstret och dokument-helpers.
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  pathSkipsAuth,
+  checkBootstrapGate,
+  inferDocMime,
+  base64ToBytes,
+} from "@/components/shell/demo-bootstrap";
+import type { FirmaConfig } from "@/lib/client/firma/firma-config";
+
+const baseConfig: FirmaConfig = {
+  tier: "demo", repo: "u/r", token: "", organizationId: "org",
+  principalId: "p1", authorName: "A", authorEmail: "a@b",
+};
+// Variant utan principalId (exactOptionalPropertyTypes: nyckeln utelämnas helt).
+const { principalId: _omit, ...noPrincipal } = baseConfig;
+
+function setLocation(pathname: string, search = ""): () => void {
+  const original = window.location;
+  const replace = vi.fn();
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { pathname, search, replace },
+  });
+  return () => Object.defineProperty(window, "location", { configurable: true, value: original });
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("pathSkipsAuth", () => {
+  it.each([["/demo", true], ["/demo/", true], ["/login", true], ["/login/", true],
+    ["/matters", false], ["/", false], ["/demos", false]])(
+    "%s → %s", (p, expected) => expect(pathSkipsAuth(p as string)).toBe(expected),
+  );
+});
+
+describe("checkBootstrapGate", () => {
+  it("skip-ready på /demo- och /login-sidor", () => {
+    const restore = setLocation("/login/");
+    expect(checkBootstrapGate(baseConfig)).toBe("skip-ready");
+    restore();
+  });
+
+  it("redirect-login när demo-tier saknar principalId", () => {
+    const restore = setLocation("/matters");
+    const decision = checkBootstrapGate(noPrincipal);
+    expect(decision).toBe("redirect-login");
+    expect(window.location.replace).toHaveBeenCalledWith(expect.stringContaining("/login/"));
+    restore();
+  });
+
+  it("skip-loading när ?nodata finns", () => {
+    const restore = setLocation("/matters", "?nodata");
+    expect(checkBootstrapGate(baseConfig)).toBe("skip-loading");
+    restore();
+  });
+
+  it("continue i normalfallet (inloggad, vanlig sida)", () => {
+    const restore = setLocation("/matters");
+    expect(checkBootstrapGate(baseConfig)).toBe("continue");
+    restore();
+  });
+
+  it("self-hosted utan principalId redirectar INTE (bara demo-tier gör det)", () => {
+    const restore = setLocation("/matters");
+    expect(checkBootstrapGate({ ...noPrincipal, tier: "self-hosted" }))
+      .toBe("continue");
+    restore();
+  });
+});
+
+describe("inferDocMime", () => {
+  it("föredrar metans mimeType", () => {
+    expect(inferDocMime("x.bin", { id: "1", mimeType: "image/png" })).toBe("image/png");
+  });
+  it("härleder pdf/html, annars octet-stream", () => {
+    expect(inferDocMime("a.pdf", undefined)).toBe("application/pdf");
+    expect(inferDocMime("a.html", undefined)).toBe("text/html; charset=utf-8");
+    expect(inferDocMime("a.docx", undefined)).toBe("application/octet-stream");
+  });
+});
+
+describe("base64ToBytes", () => {
+  it("avkodar base64 → bytes (round-trip mot btoa)", () => {
+    const bytes = base64ToBytes(btoa("hej"));
+    expect(Array.from(bytes)).toEqual([104, 101, 106]); // h,e,j
+  });
+  it("tom sträng → tom array", () => {
+    expect(base64ToBytes("").length).toBe(0);
+  });
+});

--- a/test/unit/components/fsa-folder-selector.test.tsx
+++ b/test/unit/components/fsa-folder-selector.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * Tester för `FsaFolderSelector` (#61): pure `githubize`-normalisering +
+ * "stöds inte"-grenarna (Firefox/Safari/övrig) som inte kräver riktig FSA.
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { FsaFolderSelector, githubize } from "@/components/settings/fsa-folder-selector";
+
+// handle-store importeras dynamiskt i komponenten; mocka den så vi styr
+// FSA-stöd utan riktig browser-API.
+const isFsaSupported = vi.fn();
+vi.mock("@/lib/client/fsa/handle-store", () => ({
+  isFsaSupported: () => isFsaSupported(),
+  loadHandle: vi.fn(async () => null),
+  saveHandle: vi.fn(async () => {}),
+  deleteHandle: vi.fn(async () => {}),
+  ensureReadWrite: vi.fn(async () => true),
+}));
+
+describe("githubize", () => {
+  it("kortform user/repo → https .git", () => {
+    expect(githubize("ulrik-s/ava")).toBe("https://github.com/ulrik-s/ava.git");
+  });
+  it("ssh-form → https .git", () => {
+    expect(githubize("git@github.com:u/r")).toBe("https://github.com/u/r.git");
+    expect(githubize("git@github.com:u/r.git")).toBe("https://github.com/u/r.git");
+  });
+  it("https lämnas orört", () => {
+    expect(githubize("https://git.firma.se/data.git")).toBe("https://git.firma.se/data.git");
+  });
+});
+
+describe("FsaFolderSelector — stöds inte", () => {
+  const originalUA = navigator.userAgent;
+  beforeEach(() => { vi.clearAllMocks(); isFsaSupported.mockReturnValue(false); });
+  afterEach(() => {
+    Object.defineProperty(navigator, "userAgent", { configurable: true, value: originalUA });
+  });
+
+  function setUA(ua: string) {
+    Object.defineProperty(navigator, "userAgent", { configurable: true, value: ua });
+  }
+
+  it("Firefox → Firefox-specifikt meddelande", async () => {
+    setUA("Mozilla/5.0 Firefox/130.0");
+    render(<FsaFolderSelector repoUrl="" token="" />);
+    await waitFor(() => expect(screen.getByText(/Firefox stöder inte/)).toBeInTheDocument());
+  });
+
+  it("Safari → Safari-specifikt meddelande", async () => {
+    setUA("Mozilla/5.0 (Macintosh) Version/17.0 Safari/605");
+    render(<FsaFolderSelector repoUrl="" token="" />);
+    await waitFor(() => expect(screen.getByText(/Safari stöder inte/)).toBeInTheDocument());
+  });
+
+  it("övrig webbläsare → generiskt meddelande", async () => {
+    setUA("SomeOtherBrowser/1.0");
+    render(<FsaFolderSelector repoUrl="" token="" />);
+    await waitFor(() => expect(screen.getByText(/Den här webbläsaren stöder inte/)).toBeInTheDocument());
+  });
+});
+
+describe("FsaFolderSelector — stöds, ingen mapp vald", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isFsaSupported.mockReturnValue(true);
+  });
+
+  it("visar val-/klona-knappar", async () => {
+    render(<FsaFolderSelector repoUrl="ulrik-s/ava" token="t" />);
+    await waitFor(() => expect(screen.getByText("Välj befintlig mapp")).toBeInTheDocument());
+    expect(screen.getByText("Klona repo hit")).toBeInTheDocument();
+  });
+});

--- a/test/unit/components/keypair-manager.test.tsx
+++ b/test/unit/components/keypair-manager.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Tester för `KeypairManager` (#61). WebCrypto-Ed25519 finns inte i jsdom, så
+ * krypto-lagret (`ed25519-keypair`/`ssh-format`) mockas — testen verifierar
+ * komponentens orkestrering: stöd-check, generera → visa nyckel, lägg-till.
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { KeypairManager } from "@/components/settings/keypair-manager";
+import { isEd25519Supported, generateKeypair, loadKeypair } from "@/lib/client/keys/ed25519-keypair";
+
+vi.mock("@/lib/client/keys/ed25519-keypair", () => ({
+  isEd25519Supported: vi.fn(async () => true),
+  loadKeypair: vi.fn(async () => null),
+  generateKeypair: vi.fn(async () => ({ rawPublicKey: new Uint8Array([1, 2, 3]) })),
+  saveKeypair: vi.fn(async () => {}),
+  deleteKeypair: vi.fn(async () => {}),
+}));
+vi.mock("@/lib/client/keys/ssh-format", () => ({
+  buildSshPublicKey: () => "ssh-ed25519 AAAATEST anna@mac",
+  sshFingerprint: async () => "SHA256:fakefingerprint",
+}));
+vi.mock("@/lib/client/github/register-ssh-key", () => ({ registerSshKeyOnGithub: vi.fn(async () => {}) }));
+vi.mock("@/lib/client/firma/firma-config", () => ({ loadFirmaConfig: () => ({ token: "ghp_x" }) }));
+
+const mockSupported = vi.mocked(isEd25519Supported);
+const mockGenerate = vi.mocked(generateKeypair);
+const mockLoad = vi.mocked(loadKeypair);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSupported.mockResolvedValue(true);
+  mockLoad.mockResolvedValue(null);
+  mockGenerate.mockResolvedValue({ rawPublicKey: new Uint8Array([1, 2, 3]) } as never);
+});
+
+describe("KeypairManager", () => {
+  it("visar amber-meddelande när Ed25519 inte stöds", async () => {
+    mockSupported.mockResolvedValue(false);
+    render(<KeypairManager onAddToProfile={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText(/stöder inte WebCrypto Ed25519/)).toBeInTheDocument());
+  });
+
+  it("stöds + ingen nyckel → visar generera-knapp", async () => {
+    render(<KeypairManager onAddToProfile={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("Generera nytt nyckelpar")).toBeInTheDocument());
+  });
+
+  it("generera → skapar par, visar SSH-nyckel + fingerprint", async () => {
+    render(<KeypairManager onAddToProfile={vi.fn()} />);
+    await waitFor(() => screen.getByText("Generera nytt nyckelpar"));
+    fireEvent.click(screen.getByText("Generera nytt nyckelpar"));
+    await waitFor(() => expect(mockGenerate).toHaveBeenCalled());
+    expect(await screen.findByDisplayValue(/ssh-ed25519 AAAATEST/)).toBeInTheDocument();
+    expect(screen.getByText(/SHA256:fakefingerprint/)).toBeInTheDocument();
+  });
+
+  it("'Lägg till i min profil' anropar onAddToProfile med nyckel + fingerprint", async () => {
+    const onAdd = vi.fn();
+    render(<KeypairManager onAddToProfile={onAdd} />);
+    await waitFor(() => screen.getByText("Generera nytt nyckelpar"));
+    fireEvent.click(screen.getByText("Generera nytt nyckelpar"));
+    const addBtn = await screen.findByText("Lägg till i min profil");
+    fireEvent.click(addBtn);
+    expect(onAdd).toHaveBeenCalledWith(expect.objectContaining({
+      sshPublicKey: expect.stringContaining("ssh-ed25519"),
+      fingerprint: "SHA256:fakefingerprint",
+    }));
+  });
+});

--- a/test/unit/components/web-oauth-device-flow.test.tsx
+++ b/test/unit/components/web-oauth-device-flow.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * Tester för `WebOAuthDeviceFlow` state-machine (#61): requesting → waiting,
+ * fel-grenen, avbryt, och token-polling → onComplete.
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { WebOAuthDeviceFlow } from "@/components/settings/web-oauth-device-flow";
+
+vi.mock("@/lib/client/auth/oauth-config", () => ({
+  loadOAuthConfig: () => ({ proxyUrl: "https://proxy.test", clientId: "cid" }),
+}));
+
+const realFetch = globalThis.fetch;
+afterEach(() => { globalThis.fetch = realFetch; vi.useRealTimers(); vi.clearAllMocks(); });
+
+const deviceCode = {
+  device_code: "dev-123", user_code: "WXYZ-9876",
+  verification_uri: "https://github.com/login/device", expires_in: 900, interval: 5,
+};
+
+function mockFetch(handler: (url: string) => unknown) {
+  globalThis.fetch = vi.fn(async (url: string | URL | Request) =>
+    new Response(JSON.stringify(handler(String(url))), { status: 200 }),
+  ) as typeof fetch;
+}
+
+describe("WebOAuthDeviceFlow", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("requesting → waiting: visar user_code + verification_uri", async () => {
+    mockFetch(() => deviceCode);
+    render(<WebOAuthDeviceFlow onComplete={vi.fn()} onCancel={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("WXYZ-9876")).toBeInTheDocument());
+    expect(screen.getByText(/github.com\/login\/device/)).toBeInTheDocument();
+  });
+
+  it("fel vid device/code → error-grenen + Stäng-knapp", async () => {
+    globalThis.fetch = vi.fn(async () => new Response("nope", { status: 500 })) as typeof fetch;
+    render(<WebOAuthDeviceFlow onComplete={vi.fn()} onCancel={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("Inloggning misslyckades")).toBeInTheDocument());
+    expect(screen.getByText("Stäng")).toBeInTheDocument();
+  });
+
+  it("Avbryt anropar onCancel", async () => {
+    mockFetch(() => deviceCode);
+    const onCancel = vi.fn();
+    render(<WebOAuthDeviceFlow onComplete={vi.fn()} onCancel={onCancel} />);
+    await waitFor(() => screen.getByText("Avbryt"));
+    fireEvent.click(screen.getByText("Avbryt"));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("pollar /token efter interval och anropar onComplete vid access_token", async () => {
+    vi.useFakeTimers();
+    const fetchSpy = vi.fn(async (url: string | URL | Request) =>
+      new Response(JSON.stringify(String(url).endsWith("/token") ? { access_token: "tok-abc" } : deviceCode), { status: 200 }),
+    );
+    globalThis.fetch = fetchSpy as typeof fetch;
+    const onComplete = vi.fn();
+    render(<WebOAuthDeviceFlow onComplete={onComplete} onCancel={vi.fn()} />);
+    // Stegvis: flush mount/cfg/device-code → waiting, fira sedan poll-timern.
+    for (let i = 0; i < 4; i++) await vi.advanceTimersByTimeAsync(5001);
+    const calledToken = fetchSpy.mock.calls.some(([u]) => String(u).endsWith("/token"));
+    expect(calledToken).toBe(true);
+    expect(onComplete).toHaveBeenCalledWith("tok-abc");
+  });
+});


### PR DESCRIPTION
Fixar #61.

**+31 tester** för fyra tidigare **0%-täckta** komponenter. Strategi (samma som `firma-settings-panel`): exportera pure helpers + testa direkt, render-testa resten med mockade beroenden.

| Komponent | Täckning |
|---|---|
| `demo-bootstrap` | Bootstrap-**grinden** `checkBootstrapGate` (skip-ready / redirect-login / skip-loading / continue + self-hosted-grenen), `pathSkipsAuth`, `inferDocMime`, `base64ToBytes` — exporterade + enhetstestade. |
| `web-oauth-device-flow` | State-machine: requesting→waiting (user_code visas), device/code-fel→error+Stäng, Avbryt→onCancel, token-polling→onComplete. |
| `keypair-manager` | WebCrypto-lagret mockas (jsdom saknar Ed25519): stöd-check, generera→visar SSH-nyckel+fingerprint, "Lägg till i profil"→`onAddToProfile`. |
| `fsa-folder-selector` | `githubize` (kort/ssh/https) exporterad + testad; "stöds inte"-grenarna (Firefox/Safari/övrig) + val-/klona-knappar. |

Endast testkod + tre små helper-exports (`knip` OK — används av tester). Höjer faktisk coverage; ratchet-trösklarna lämnas oförändrade (#43/#27 äger höjningen).

## Verifierat
`yarn typecheck` ✓ · `yarn lint --max-warnings 0` ✓ · `yarn knip` ✓ · `yarn test:fast` ✓ (**2262**, +31)

🤖 Generated with [Claude Code](https://claude.com/claude-code)