### PR TITLE
refactor(ui): bryt ut pure logik ur DataTable + firma-settings-panel (#62)

### DIFF
--- a/src/components/settings/firma-settings-net.ts
+++ b/src/components/settings/firma-settings-net.ts
@@ -1,0 +1,72 @@
+/**
+ * `firma-settings-net` — nätverks-/validerings-helpers för `FirmaSettingsPanel`
+ * (#62): GitHub-token-/repo-validering + OAuth-/CORS-proxy-tester. Pure med
+ * injektbar `fetchFn` (testas isolerat), utbrutna ur den React-tunga panelen
+ * (SRP). Re-exporteras från `firma-settings-panel` för bakåtkompatibilitet.
+ */
+import type { FirmaTier } from "@/lib/client/firma/firma-config";
+
+export interface TokenValidationResult { status: "valid" | "invalid"; msg: string }
+
+/**
+ * Pure validator — testas separat utan komponent. `fetchFn` injicerbar
+ * för tester (default = globalThis.fetch).
+ */
+export async function validateGithubToken(
+  args: { token: string; tier: FirmaTier; repo: string; fetchFn?: typeof fetch },
+): Promise<TokenValidationResult> {
+  const fetchFn = args.fetchFn ?? globalThis.fetch.bind(globalThis);
+  if (!args.token) return { status: "invalid", msg: "Tom token" };
+  const res = await fetchFn("https://api.github.com/user", {
+    headers: { Authorization: `Bearer ${args.token}`, Accept: "application/vnd.github+json" },
+  });
+  if (!res.ok) return { status: "invalid", msg: `GitHub avvisade: ${res.status} ${res.statusText}` };
+  const user = await res.json() as { login: string };
+  if (!args.repo || args.tier !== "github") return { status: "valid", msg: `✓ @${user.login}` };
+  return validateRepoAccess({ token: args.token, repo: args.repo, login: user.login, fetchFn });
+}
+
+async function validateRepoAccess(args: {
+  token: string; repo: string; login: string; fetchFn: typeof fetch;
+}): Promise<TokenValidationResult> {
+  const parsed = args.repo.match(/^([^/]+)\/([^/.]+)/);
+  if (!parsed) return { status: "valid", msg: `✓ @${args.login}` };
+  const r = await args.fetchFn(`https://api.github.com/repos/${parsed[1]}/${parsed[2]}`, {
+    headers: { Authorization: `Bearer ${args.token}`, Accept: "application/vnd.github+json" },
+  });
+  if (!r.ok) return { status: "invalid", msg: `Ingen åtkomst till ${parsed[1]}/${parsed[2]}: ${r.status}` };
+  const repoInfo = await r.json() as { permissions?: { push?: boolean } };
+  const canPush = repoInfo.permissions?.push === true;
+  return { status: "valid", msg: `✓ @${args.login} — ${canPush ? "kan pusha" : "endast läsning"}` };
+}
+
+export interface ProxyTestResult { ok: boolean; msg: string }
+
+/** Pure tester av OAuth-proxy:n. `fetchFn` injicerbar för tester. */
+export async function testOAuthProxy(url: string, fetchFn?: typeof fetch): Promise<ProxyTestResult> {
+  if (!url) return { ok: false, msg: "Saknar URL" };
+  const fn = fetchFn ?? globalThis.fetch.bind(globalThis);
+  try {
+    const res = await fn(`${url.replace(/\/+$/, "")}/device/code`, { method: "POST" });
+    if (!res.ok) return { ok: false, msg: `Proxy svarade ${res.status} ${res.statusText}` };
+    const data = await res.json() as { user_code?: string; error?: string };
+    if (data.user_code) return { ok: true, msg: `✓ Proxy svarar (test-kod: ${data.user_code})` };
+    return { ok: false, msg: `Oväntat svar: ${data.error ?? JSON.stringify(data).slice(0, 80)}` };
+  } catch (e) {
+    return { ok: false, msg: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+/** Pure tester av CORS-proxy mot ava-demo-repots refs-endpoint. */
+export async function testCorsProxy(url: string, fetchFn?: typeof fetch): Promise<ProxyTestResult> {
+  const fn = fetchFn ?? globalThis.fetch.bind(globalThis);
+  const effective = url || "https://cors.isomorphic-git.org";
+  try {
+    const target = `${effective.replace(/\/+$/, "")}/github.com/ulrik-s/ava-demo/info/refs?service=git-upload-pack`;
+    const res = await fn(target, { method: "GET" });
+    if (res.ok) return { ok: true, msg: `✓ Proxy svarar (${res.status})` };
+    return { ok: false, msg: `Proxy svarade ${res.status} ${res.statusText}` };
+  } catch (e) {
+    return { ok: false, msg: `✗ ${e instanceof Error ? e.message : String(e)}` };
+  }
+}

--- a/src/components/settings/firma-settings-panel.tsx
+++ b/src/components/settings/firma-settings-panel.tsx
@@ -22,6 +22,12 @@ import { type FirmaConfig, type FirmaTier, inferTier, saveFirmaConfig, resetToDe
 import { loadAuthSettings, saveAuthSettings } from "@/lib/client/auth/use-auth-mode";
 import { loadOAuthConfig, saveOAuthConfig, isOAuthConfigured } from "@/lib/client/auth/oauth-config";
 import { WebOAuthDeviceFlow } from "./web-oauth-device-flow";
+// Nätverks-/validerings-helpers bor i firma-settings-net.ts (#62). Re-exporteras
+// så importörer + tester fortsätter peka på "@/components/settings/firma-settings-panel".
+import { validateGithubToken, testOAuthProxy, testCorsProxy } from "./firma-settings-net";
+import type { ProxyTestResult } from "./firma-settings-net";
+export { validateGithubToken, testOAuthProxy, testCorsProxy } from "./firma-settings-net";
+export type { TokenValidationResult, ProxyTestResult } from "./firma-settings-net";
 
 interface Props {
   initial: FirmaConfig;
@@ -327,39 +333,6 @@ export function FooterButtons(props: {
 // ─── Auth-token-sektion ───────────────────────────────────────────────────
 
 type TokenStatus = "untested" | "checking" | "valid" | "invalid";
-export interface TokenValidationResult { status: Exclude<TokenStatus, "untested" | "checking">; msg: string }
-
-/**
- * Pure validator — testas separat utan komponent. `fetchFn` injicerbar
- * för tester (default = globalThis.fetch).
- */
-export async function validateGithubToken(
-  args: { token: string; tier: FirmaTier; repo: string; fetchFn?: typeof fetch },
-): Promise<TokenValidationResult> {
-  const fetchFn = args.fetchFn ?? globalThis.fetch.bind(globalThis);
-  if (!args.token) return { status: "invalid", msg: "Tom token" };
-  const res = await fetchFn("https://api.github.com/user", {
-    headers: { Authorization: `Bearer ${args.token}`, Accept: "application/vnd.github+json" },
-  });
-  if (!res.ok) return { status: "invalid", msg: `GitHub avvisade: ${res.status} ${res.statusText}` };
-  const user = await res.json() as { login: string };
-  if (!args.repo || args.tier !== "github") return { status: "valid", msg: `✓ @${user.login}` };
-  return validateRepoAccess({ token: args.token, repo: args.repo, login: user.login, fetchFn });
-}
-
-async function validateRepoAccess(args: {
-  token: string; repo: string; login: string; fetchFn: typeof fetch;
-}): Promise<TokenValidationResult> {
-  const parsed = args.repo.match(/^([^/]+)\/([^/.]+)/);
-  if (!parsed) return { status: "valid", msg: `✓ @${args.login}` };
-  const r = await args.fetchFn(`https://api.github.com/repos/${parsed[1]}/${parsed[2]}`, {
-    headers: { Authorization: `Bearer ${args.token}`, Accept: "application/vnd.github+json" },
-  });
-  if (!r.ok) return { status: "invalid", msg: `Ingen åtkomst till ${parsed[1]}/${parsed[2]}: ${r.status}` };
-  const repoInfo = await r.json() as { permissions?: { push?: boolean } };
-  const canPush = repoInfo.permissions?.push === true;
-  return { status: "valid", msg: `✓ @${args.login} — ${canPush ? "kan pusha" : "endast läsning"}` };
-}
 
 export function AuthTokenSection(props: {
   tier: FirmaTier;
@@ -513,23 +486,6 @@ function OAuthConfigFields(props: {
 
 // ─── OAuth-proxy-test ─────────────────────────────────────────────────────
 
-export interface ProxyTestResult { ok: boolean; msg: string }
-
-/** Pure tester av OAuth-proxy:n. `fetchFn` injicerbar för tester. */
-export async function testOAuthProxy(url: string, fetchFn?: typeof fetch): Promise<ProxyTestResult> {
-  if (!url) return { ok: false, msg: "Saknar URL" };
-  const fn = fetchFn ?? globalThis.fetch.bind(globalThis);
-  try {
-    const res = await fn(`${url.replace(/\/+$/, "")}/device/code`, { method: "POST" });
-    if (!res.ok) return { ok: false, msg: `Proxy svarade ${res.status} ${res.statusText}` };
-    const data = await res.json() as { user_code?: string; error?: string };
-    if (data.user_code) return { ok: true, msg: `✓ Proxy svarar (test-kod: ${data.user_code})` };
-    return { ok: false, msg: `Oväntat svar: ${data.error ?? JSON.stringify(data).slice(0, 80)}` };
-  } catch (e) {
-    return { ok: false, msg: e instanceof Error ? e.message : String(e) };
-  }
-}
-
 export function ProxyTestButton({ url }: { url: string }) {
   const [busy, setBusy] = useState(false);
   const [result, setResult] = useState<ProxyTestResult | null>(null);
@@ -574,20 +530,6 @@ const CORS_PROXY_PREFABS: Array<{ url: string; label: string; warning?: string }
     warning: "Alternativ publik proxy.",
   },
 ];
-
-/** Pure tester av CORS-proxy mot ava-demo-repots refs-endpoint. */
-export async function testCorsProxy(url: string, fetchFn?: typeof fetch): Promise<ProxyTestResult> {
-  const fn = fetchFn ?? globalThis.fetch.bind(globalThis);
-  const effective = url || "https://cors.isomorphic-git.org";
-  try {
-    const target = `${effective.replace(/\/+$/, "")}/github.com/ulrik-s/ava-demo/info/refs?service=git-upload-pack`;
-    const res = await fn(target, { method: "GET" });
-    if (res.ok) return { ok: true, msg: `✓ Proxy svarar (${res.status})` };
-    return { ok: false, msg: `Proxy svarade ${res.status} ${res.statusText}` };
-  } catch (e) {
-    return { ok: false, msg: `✗ ${e instanceof Error ? e.message : String(e)}` };
-  }
-}
 
 export function CorsProxyField({ value, onChange }: { value: string; onChange: (v: string) => void }) {
   const [testing, setTesting] = useState(false);

--- a/src/components/ui/data-table-logic.ts
+++ b/src/components/ui/data-table-logic.ts
@@ -1,0 +1,187 @@
+/**
+ * `data-table-logic` — ramverks-agnostisk kärna för `DataTable` (#62): typer +
+ * pure sort-/filter-/group-/prefs-funktioner, utbrutna ur den React-tunga
+ * `data-table.tsx` (SRP + testbarhet). Komponenten re-exporterar dessa så
+ * importörer (och tester) fortsätter peka på `@/components/ui/data-table`.
+ */
+import type * as React from "react";
+
+export type SortDir = "asc" | "desc";
+
+export interface Column<T> {
+  key: string;
+  label: string;
+  render: (row: T) => React.ReactNode;
+  /** Pure-data-värde för sortering (default = render-output som sträng). */
+  sortValue?: (row: T) => string | number | Date | null;
+  /** Värde som filter-text matchas mot (default: sortValue eller render-output). */
+  filterValue?: (row: T) => string;
+  /** Värde som används vid groupering (default: filterValue eller sortValue). */
+  groupValue?: (row: T) => string;
+  /** Sorterbar? Default: false. När `sortable: true` aktiveras filter + group
+   *  automatiskt (kan stängas av per kolumn med `filterable: false` /
+   *  `groupable: false`). */
+  sortable?: boolean;
+  /** Explicit override — default ärver från `sortable`. */
+  filterable?: boolean;
+  /** Explicit override — default ärver från `sortable`. */
+  groupable?: boolean;
+  defaultWidth?: number;
+  align?: "left" | "right" | "center";
+  hideable?: boolean;
+  /** Kolumnen finns i katalogen men är inte visad förrän användaren explicit
+   *  väljer "+ Visa kolumn → <denna>". Använd för fält som är intressanta
+   *  ibland men skulle göra default-vyn för bred (createdAt, IDs, etc.). */
+  defaultHidden?: boolean;
+  /** Summa-funktion: returnerar innehållet för footer-cellen i denna kolumn.
+   *  Om någon kolumn har summary auto-renderas en footer-rad (filtrerade
+   *  rader) + en summa-rad per grupp vid gruppering. Caller styr formatering
+   *  (currency, minutes, etc.) genom return-värdet. */
+  summary?: (rows: T[]) => React.ReactNode;
+}
+
+/** En kolumn räknas som filterbar/grupperbar om `sortable` är satt och
+ *  flaggorna inte explicit slagits av. */
+export function isFilterable<T>(col: Column<T>): boolean {
+  return col.filterable ?? Boolean(col.sortable);
+}
+export function isGroupable<T>(col: Column<T>): boolean {
+  return col.groupable ?? Boolean(col.sortable);
+}
+
+export interface DataTablePrefs {
+  // Fälten får genuint vara explicit `undefined`: `update`/`patch` nollställer
+  // en pref genom att sätta nyckeln till `undefined` (se kommentar vid `update`).
+  sortBy?: string | undefined;
+  sortDir?: SortDir | undefined;
+  /** Synlig kolumn-ordning. Saknade kolumner appendas i komponent-defaultordning. */
+  order?: string[] | undefined;
+  /** Per-kolumn-överrides. */
+  columns?: Array<{ key: string; width?: number; hidden?: boolean }> | undefined;
+  /** Per-kolumn-key filter-text (case-insensitive substring-match). */
+  filters?: Record<string, string> | undefined;
+  /** Kolumn-key att gruppera på. Hela tabellen presenteras då i sektioner. */
+  groupBy?: string | undefined;
+}
+
+const PREF_KEYS = ["sortBy", "sortDir", "order", "columns", "filters", "groupBy"] as const;
+
+export function mergePrefs(user: DataTablePrefs | null | undefined, org: DataTablePrefs | null | undefined): DataTablePrefs {
+  const out: DataTablePrefs = {};
+  for (const k of PREF_KEYS) {
+    const v = user?.[k] ?? org?.[k];
+    if (v !== undefined) (out as Record<string, unknown>)[k] = v;
+  }
+  return out;
+}
+
+function coerce(v: unknown): string | number | null {
+  if (v == null) return null;
+  if (v instanceof Date) return v.getTime();
+  if (typeof v === "number") return v;
+  return String(v).toLowerCase();
+}
+
+function nullCmp(a: string | number | null, b: string | number | null, dir: SortDir): number {
+  if (a == null && b == null) return 0;
+  return a == null ? (dir === "asc" ? 1 : -1) : (dir === "asc" ? -1 : 1);
+}
+
+function compareValues(a: unknown, b: unknown, dir: SortDir): number {
+  const ac = coerce(a);
+  const bc = coerce(b);
+  if (ac == null || bc == null) return nullCmp(ac, bc, dir);
+  if (typeof ac === "number" && typeof bc === "number") return dir === "asc" ? ac - bc : bc - ac;
+  const as = String(ac);
+  const bs = String(bc);
+  return dir === "asc" ? as.localeCompare(bs, "sv") : bs.localeCompare(as, "sv");
+}
+
+export function sortRows<T>(rows: T[], columns: Column<T>[], sortBy?: string, sortDir?: SortDir): T[] {
+  if (!sortBy || !sortDir) return rows;
+  const col = columns.find((c) => c.key === sortBy);
+  if (!col?.sortable) return rows;
+  const valueOf = col.sortValue ?? ((r: T) => String(col.render(r) ?? ""));
+  return [...rows].sort((a, b) => compareValues(valueOf(a), valueOf(b), sortDir));
+}
+
+function columnValueAsString<T>(col: Column<T>, row: T): string {
+  if (col.filterValue) return col.filterValue(row);
+  if (col.sortValue) {
+    const v = col.sortValue(row);
+    if (v == null) return "";
+    if (v instanceof Date) return v.toLocaleDateString("sv-SE");
+    return String(v);
+  }
+  return String(col.render(row) ?? "");
+}
+
+export function filterRows<T>(rows: T[], columns: Column<T>[], filters?: Record<string, string>): T[] {
+  const active = Object.entries(filters ?? {}).filter(([, v]) => v && String(v).trim() !== "");
+  if (active.length === 0) return rows;
+  const colByKey = new Map(columns.map((c) => [c.key, c]));
+  return rows.filter((r) => active.every(([key, text]) => {
+    const col = colByKey.get(key);
+    if (!col) return true;
+    return columnValueAsString(col, r).toLowerCase().includes(String(text).toLowerCase());
+  }));
+}
+
+export interface RowGroup<T> { group: string | null; rows: T[] }
+
+export function groupRows<T>(rows: T[], columns: Column<T>[], groupBy?: string): RowGroup<T>[] {
+  if (!groupBy) return [{ group: null, rows }];
+  const col = columns.find((c) => c.key === groupBy);
+  if (!col) return [{ group: null, rows }];
+  const valueOf = col.groupValue ?? ((r: T) => columnValueAsString(col, r));
+  const groups = new Map<string, T[]>();
+  for (const r of rows) {
+    const k = valueOf(r) || "(tomt)";
+    const list = groups.get(k);
+    if (list) list.push(r);
+    else groups.set(k, [r]);
+  }
+  return Array.from(groups.entries()).map(([group, gRows]) => ({ group, rows: gRows }));
+}
+
+/** En kolumn är dold om user explicit satt { hidden: true }, ELLER om
+ *  defaultHidden=true och user inte explicit visat den. */
+export function isColumnHidden<T>(col: Column<T>, prefs: DataTablePrefs): boolean {
+  const override = (prefs.columns ?? []).find((c) => c.key === col.key);
+  if (override?.hidden !== undefined) return override.hidden;
+  return Boolean(col.defaultHidden);
+}
+
+export function visibleColumns<T>(columns: Column<T>[], prefs: DataTablePrefs): Column<T>[] {
+  const visible = columns.filter((c) => !isColumnHidden(c, prefs));
+  if (!prefs.order?.length) return visible;
+  const idx = new Map(prefs.order.map((k, i) => [k, i] as const));
+  return [...visible].sort((a, b) => (idx.get(a.key) ?? Number.MAX_SAFE_INTEGER) - (idx.get(b.key) ?? Number.MAX_SAFE_INTEGER));
+}
+
+function hasActiveFilter(filters?: Record<string, string>): boolean {
+  return Object.values(filters ?? {}).some((v) => v != null && String(v).trim() !== "");
+}
+
+function hasColumnOverride(cols?: Array<{ hidden?: boolean; width?: number }>): boolean {
+  return (cols ?? []).some((c) => c.hidden || c.width !== undefined);
+}
+
+export function hasOverrides(prefs: DataTablePrefs): boolean {
+  if (prefs.sortBy || prefs.groupBy) return true;
+  if (hasActiveFilter(prefs.filters)) return true;
+  if (hasColumnOverride(prefs.columns)) return true;
+  return Boolean(prefs.order && prefs.order.length > 0);
+}
+
+export function hasSummary<T>(columns: Column<T>[]): boolean {
+  return columns.some((c) => c.summary !== undefined);
+}
+
+export function buildSummaryContent<T>(columns: Column<T>[], rows: T[]): Partial<Record<string, React.ReactNode>> {
+  const out: Partial<Record<string, React.ReactNode>> = {};
+  for (const c of columns) {
+    if (c.summary) out[c.key] = c.summary(rows);
+  }
+  return out;
+}

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -19,63 +19,18 @@
 import { useMemo, useRef, useState } from "react";
 import { trpc } from "@/lib/client/trpc";
 
-export type SortDir = "asc" | "desc";
-
-export interface Column<T> {
-  key: string;
-  label: string;
-  render: (row: T) => React.ReactNode;
-  /** Pure-data-värde för sortering (default = render-output som sträng). */
-  sortValue?: (row: T) => string | number | Date | null;
-  /** Värde som filter-text matchas mot (default: sortValue eller render-output). */
-  filterValue?: (row: T) => string;
-  /** Värde som används vid groupering (default: filterValue eller sortValue). */
-  groupValue?: (row: T) => string;
-  /** Sorterbar? Default: false. När `sortable: true` aktiveras filter + group
-   *  automatiskt (kan stängas av per kolumn med `filterable: false` /
-   *  `groupable: false`). */
-  sortable?: boolean;
-  /** Explicit override — default ärver från `sortable`. */
-  filterable?: boolean;
-  /** Explicit override — default ärver från `sortable`. */
-  groupable?: boolean;
-  defaultWidth?: number;
-  align?: "left" | "right" | "center";
-  hideable?: boolean;
-  /** Kolumnen finns i katalogen men är inte visad förrän användaren explicit
-   *  väljer "+ Visa kolumn → <denna>". Använd för fält som är intressanta
-   *  ibland men skulle göra default-vyn för bred (createdAt, IDs, etc.). */
-  defaultHidden?: boolean;
-  /** Summa-funktion: returnerar innehållet för footer-cellen i denna kolumn.
-   *  Om någon kolumn har summary auto-renderas en footer-rad (filtrerade
-   *  rader) + en summa-rad per grupp vid gruppering. Caller styr formatering
-   *  (currency, minutes, etc.) genom return-värdet. */
-  summary?: (rows: T[]) => React.ReactNode;
-}
-
-/** En kolumn räknas som filterbar/grupperbar om `sortable` är satt och
- *  flaggorna inte explicit slagits av. */
-export function isFilterable<T>(col: Column<T>): boolean {
-  return col.filterable ?? Boolean(col.sortable);
-}
-export function isGroupable<T>(col: Column<T>): boolean {
-  return col.groupable ?? Boolean(col.sortable);
-}
-
-export interface DataTablePrefs {
-  // Fälten får genuint vara explicit `undefined`: `update`/`patch` nollställer
-  // en pref genom att sätta nyckeln till `undefined` (se kommentar vid `update`).
-  sortBy?: string | undefined;
-  sortDir?: SortDir | undefined;
-  /** Synlig kolumn-ordning. Saknade kolumner appendas i komponent-defaultordning. */
-  order?: string[] | undefined;
-  /** Per-kolumn-överrides. */
-  columns?: Array<{ key: string; width?: number; hidden?: boolean }> | undefined;
-  /** Per-kolumn-key filter-text (case-insensitive substring-match). */
-  filters?: Record<string, string> | undefined;
-  /** Kolumn-key att gruppera på. Hela tabellen presenteras då i sektioner. */
-  groupBy?: string | undefined;
-}
+// Pure logik + typer bor i `data-table-logic.ts` (#62, SRP). Re-exporteras här
+// så importörer + tester fortsätter peka på "@/components/ui/data-table".
+import type { SortDir, Column, DataTablePrefs, RowGroup } from "./data-table-logic";
+import {
+  isFilterable, isGroupable, mergePrefs, sortRows, filterRows, groupRows,
+  isColumnHidden, visibleColumns, hasOverrides, hasSummary, buildSummaryContent,
+} from "./data-table-logic";
+export type { SortDir, Column, DataTablePrefs, RowGroup } from "./data-table-logic";
+export {
+  isFilterable, isGroupable, mergePrefs, sortRows, filterRows, groupRows,
+  isColumnHidden, visibleColumns, hasOverrides, hasSummary, buildSummaryContent,
+} from "./data-table-logic";
 
 type FooterFn<T> = (rows: T[]) => Partial<Record<string, React.ReactNode>>;
 
@@ -91,130 +46,8 @@ interface Props<T> {
   footer?: FooterFn<T>;
 }
 
-const PREF_KEYS = ["sortBy", "sortDir", "order", "columns", "filters", "groupBy"] as const;
-
-export function mergePrefs(user: DataTablePrefs | null | undefined, org: DataTablePrefs | null | undefined): DataTablePrefs {
-  const out: DataTablePrefs = {};
-  for (const k of PREF_KEYS) {
-    const v = user?.[k] ?? org?.[k];
-    if (v !== undefined) (out as Record<string, unknown>)[k] = v;
-  }
-  return out;
-}
-
-function coerce(v: unknown): string | number | null {
-  if (v == null) return null;
-  if (v instanceof Date) return v.getTime();
-  if (typeof v === "number") return v;
-  return String(v).toLowerCase();
-}
-
-function nullCmp(a: string | number | null, b: string | number | null, dir: SortDir): number {
-  if (a == null && b == null) return 0;
-  return a == null ? (dir === "asc" ? 1 : -1) : (dir === "asc" ? -1 : 1);
-}
-
-function compareValues(a: unknown, b: unknown, dir: SortDir): number {
-  const ac = coerce(a);
-  const bc = coerce(b);
-  if (ac == null || bc == null) return nullCmp(ac, bc, dir);
-  if (typeof ac === "number" && typeof bc === "number") return dir === "asc" ? ac - bc : bc - ac;
-  const as = String(ac);
-  const bs = String(bc);
-  return dir === "asc" ? as.localeCompare(bs, "sv") : bs.localeCompare(as, "sv");
-}
-
-export function sortRows<T>(rows: T[], columns: Column<T>[], sortBy?: string, sortDir?: SortDir): T[] {
-  if (!sortBy || !sortDir) return rows;
-  const col = columns.find((c) => c.key === sortBy);
-  if (!col?.sortable) return rows;
-  const valueOf = col.sortValue ?? ((r: T) => String(col.render(r) ?? ""));
-  return [...rows].sort((a, b) => compareValues(valueOf(a), valueOf(b), sortDir));
-}
-
-function columnValueAsString<T>(col: Column<T>, row: T): string {
-  if (col.filterValue) return col.filterValue(row);
-  if (col.sortValue) {
-    const v = col.sortValue(row);
-    if (v == null) return "";
-    if (v instanceof Date) return v.toLocaleDateString("sv-SE");
-    return String(v);
-  }
-  return String(col.render(row) ?? "");
-}
-
-export function filterRows<T>(rows: T[], columns: Column<T>[], filters?: Record<string, string>): T[] {
-  const active = Object.entries(filters ?? {}).filter(([, v]) => v && String(v).trim() !== "");
-  if (active.length === 0) return rows;
-  const colByKey = new Map(columns.map((c) => [c.key, c]));
-  return rows.filter((r) => active.every(([key, text]) => {
-    const col = colByKey.get(key);
-    if (!col) return true;
-    return columnValueAsString(col, r).toLowerCase().includes(String(text).toLowerCase());
-  }));
-}
-
-export interface RowGroup<T> { group: string | null; rows: T[] }
-
-export function groupRows<T>(rows: T[], columns: Column<T>[], groupBy?: string): RowGroup<T>[] {
-  if (!groupBy) return [{ group: null, rows }];
-  const col = columns.find((c) => c.key === groupBy);
-  if (!col) return [{ group: null, rows }];
-  const valueOf = col.groupValue ?? ((r: T) => columnValueAsString(col, r));
-  const groups = new Map<string, T[]>();
-  for (const r of rows) {
-    const k = valueOf(r) || "(tomt)";
-    const list = groups.get(k);
-    if (list) list.push(r);
-    else groups.set(k, [r]);
-  }
-  return Array.from(groups.entries()).map(([group, gRows]) => ({ group, rows: gRows }));
-}
-
-/** En kolumn är dold om user explicit satt { hidden: true }, ELLER om
- *  defaultHidden=true och user inte explicit visat den. */
-export function isColumnHidden<T>(col: Column<T>, prefs: DataTablePrefs): boolean {
-  const override = (prefs.columns ?? []).find((c) => c.key === col.key);
-  if (override?.hidden !== undefined) return override.hidden;
-  return Boolean(col.defaultHidden);
-}
-
-export function visibleColumns<T>(columns: Column<T>[], prefs: DataTablePrefs): Column<T>[] {
-  const visible = columns.filter((c) => !isColumnHidden(c, prefs));
-  if (!prefs.order?.length) return visible;
-  const idx = new Map(prefs.order.map((k, i) => [k, i] as const));
-  return [...visible].sort((a, b) => (idx.get(a.key) ?? Number.MAX_SAFE_INTEGER) - (idx.get(b.key) ?? Number.MAX_SAFE_INTEGER));
-}
-
 function widthOf<T>(col: Column<T>, prefs: DataTablePrefs): number | undefined {
   return prefs.columns?.find((c) => c.key === col.key)?.width ?? col.defaultWidth;
-}
-
-function hasActiveFilter(filters?: Record<string, string>): boolean {
-  return Object.values(filters ?? {}).some((v) => v != null && String(v).trim() !== "");
-}
-
-function hasColumnOverride(cols?: Array<{ hidden?: boolean; width?: number }>): boolean {
-  return (cols ?? []).some((c) => c.hidden || c.width !== undefined);
-}
-
-export function hasOverrides(prefs: DataTablePrefs): boolean {
-  if (prefs.sortBy || prefs.groupBy) return true;
-  if (hasActiveFilter(prefs.filters)) return true;
-  if (hasColumnOverride(prefs.columns)) return true;
-  return Boolean(prefs.order && prefs.order.length > 0);
-}
-
-export function hasSummary<T>(columns: Column<T>[]): boolean {
-  return columns.some((c) => c.summary !== undefined);
-}
-
-export function buildSummaryContent<T>(columns: Column<T>[], rows: T[]): Partial<Record<string, React.ReactNode>> {
-  const out: Partial<Record<string, React.ReactNode>> = {};
-  for (const c of columns) {
-    if (c.summary) out[c.key] = c.summary(rows);
-  }
-  return out;
 }
 
 export function DataTable<T>({ prefKey, columns, data, rowKey, onRowClick, emptyMessage, footer }: Props<T>) {


### PR DESCRIPTION
Fixar #62. Behåller publik API via re-exports → **inga importörer eller tester ändras**.

## Vad
- **`data-table.tsx` (814 → 647 rad)**: pure typer (`Column`, `DataTablePrefs`, `SortDir`, `RowGroup`) + `sortRows`/`filterRows`/`groupRows`/`mergePrefs`/`visibleColumns`/… flyttade till nya **`data-table-logic.ts` (187 rad)**. Komponenten + dess ~25 sub-komponenter blir kvar; den tungt testade, ramverks-agnostiska kärnan får ett eget hem (SRP).
- **`firma-settings-panel.tsx` (652 → 594 rad)**: GitHub-token-/repo-validering + OAuth-/CORS-proxy-tester flyttade till nya **`firma-settings-net.ts` (72 rad)**. Panelen var redan uppdelad i sub-komponenter; nätverkslogiken separeras nu från React.

## Viktig avvikelse från issue-premissen
Filerna var **redan lint-rena** — `max-lines-per-function` gäller per *funktion*, inte per *fil*, och dessa stora filer består av många små (redan utbrutna) funktioner/komponenter. De fanns **inte** i `eslint-suppressions.json`, så det finns ingen baseline att pruna via `yarn lint:prune`. Värdet här är **modul-kohesion/SRP + navigerbarhet**, inte lint-skuld.

## Verifierat (full CI-spegel lokalt)
`yarn typecheck` ✓ · `yarn lint --max-warnings 0` ✓ · `yarn knip` ✓ · `yarn deps:check` ✓ · `yarn duplicates` ✓ · `yarn test:fast` ✓ (**2262**, oförändrat — beteende-bevarande; data-table/firma-settings-panel-testerna gröna via re-exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)