### PR TITLE
chore(coverage): höj golvet strax under faktisk efter #61 (#43)

### DIFF
--- a/docs/quality.md
+++ b/docs/quality.md
@@ -61,14 +61,14 @@ Initial baslinje-tröskel — höj efterhand som tester läggs till. Tröskeln f
 | Branches | 18 % | 70 % |
 | Statements | 25 % | 60 % |
 
-Aktuell baslinje (~2224 tester över ~240 testfiler):
+Aktuell baslinje (~2300 tester över ~254 testfiler; #43, strax under faktisk):
 
-| Mått | Tröskel (vitest-config) |
-|---|---|
-| Statements | 70.5 % |
-| Lines | 72.5 % |
-| Functions | 68.1 % |
-| Branches | 64.1 % |
+| Mått | Tröskel (vitest-config) | Faktisk |
+|---|---|---|
+| Statements | 72.9 % | 72.99 % |
+| Lines | 75.2 % | 75.27 % |
+| Functions | 69.5 % | 69.59 % |
+| Branches | 66.1 % | 66.26 % |
 
 Coverage-rapporten skrivs till `reports/coverage/` (HTML, lcov, json-summary, text).
 

--- a/tooling/config/vitest.config.ts
+++ b/tooling/config/vitest.config.ts
@@ -59,6 +59,9 @@ export default defineConfig({
       //   - 2207 tester (2026-06-05, efter #3–#7): Stmts 70.60% Br 64.21%
       //       Func 68.18% Lines 72.87% → golvet förankrat med decimaler precis
       //       under faktisk (≥0.07 marginal > observerad ~0.03 run-variation).
+      //   - 2300 tester (2026-06-07, efter #61): Stmts 72.99% Br 66.26%
+      //       Func 69.59% Lines 75.27% (identiskt Node 22/24) → golvet höjt
+      //       till 72.9/75.2/69.5/66.1 (#43).
       //
       // Mål: 95% överallt. Kvarstående gap = i huvudsak fat React-komponenter
       // (firma-settings-panel, fsa-folder-selector, keypair-manager,
@@ -66,10 +69,10 @@ export default defineConfig({
       // som kräver mer test-infrastruktur. Multi-session-arbete. Trösklarna
       // ligger strax under faktisk siffra → varje borttaget test syns som rött.
       thresholds: {
-        statements: 70.5,
-        lines: 72.5,
-        functions: 68.1,
-        branches: 64.1,
+        statements: 72.9,
+        lines: 75.2,
+        functions: 69.5,
+        branches: 66.1,
       },
     },
     projects: [


### PR DESCRIPTION
Fixar #43.

#61 lyfte faktisk täckning (2300 tester): **Stmts 72.99 % · Br 66.26 % · Func 69.59 % · Lines 75.27 %** — verifierat identiskt på Node 22 *och* Node 24 (`n exec 24`), så ingen instrumenterings-drift att gardera mot.

Per projektets "gates only tighten"-princip höjs golvet:

| Mått | Tidigare | Nytt | Faktisk |
|---|---|---|---|
| Statements | 70.5 | **72.9** | 72.99 |
| Lines | 72.5 | **75.2** | 75.27 |
| Functions | 68.1 | **69.5** | 69.59 |
| Branches | 64.1 | **66.1** | 66.26 |

Branches (issuets fokus) +2.0. Marginal ≥0.07 (> run-variation ~0.03). Tröskel-historik + `docs/quality.md`-tabellen uppdaterade.

`yarn test:cov` ✓ (golvet passerar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)