### PR TITLE
feat(events): migrate-on-read för event-payloads (ADR 0004 fas 3, #58)

### DIFF
--- a/docs/adr/0004-schemaversion-och-versionsgrind.md
+++ b/docs/adr/0004-schemaversion-och-versionsgrind.md
@@ -124,12 +124,16 @@ append-only event-loggen, där historiska payloads aldrig skrivs om.
 
 ## Fasning
 
-1. **PR 1 (nu):** `schemaVersion` i `.ava/meta.json` + `CURRENT_SCHEMA_VERSION`-
-   konstant + grinden (alla fyra fall). Ingen migreringskedja än. Test:
+1. **PR 1 ✅ (#54/#56):** `schemaVersion` i `.ava/meta.json` +
+   `CURRENT_SCHEMA_VERSION`-konstant + grinden (alla fyra fall). Test:
    `repo > kod` vägrar; saknad version tolkas som v1.
-2. **PR 2:** migrate-on-read-ramverket + första riktiga migrationen som proof
-   (issuets "klar när": versionsgrind + minst en testad migrationskedja).
-3. **PR 3:** versionera event-payloads (`events/schema.ts`).
+2. **PR 2 ✅ (#57):** migrate-on-read-ramverket + första migrationen (invoice
+   v1→v2: legacy `type` borttaget). `CURRENT_SCHEMA_VERSION` 1→2.
+3. **PR 3 ✅ (#58):** migrate-on-read för event-payloads — `migrateEventPayload`
+   (keyat på event-typ + version) körs i `EventLogProjection.deserializeLine`.
+   `repoSchemaVersion` trådas via `FilesystemEventLog` (default CURRENT tills den
+   skrivbara event-loggen wire:as in i runtimen). Första event-migration:
+   `invoice.created`/`invoice.sent`-payloadens `type` → `invoiceType`.
 
 ## Öppna frågor
 

--- a/src/lib/server/local-first/filesystem-event-log.ts
+++ b/src/lib/server/local-first/filesystem-event-log.ts
@@ -31,10 +31,17 @@ import { EventLogProjection } from "./projections/event-log";
 type Listener = (event: AvaEvent) => void | Promise<void>;
 
 export class FilesystemEventLog implements IEventLog {
-  private projection = new EventLogProjection();
+  private projection: EventLogProjection;
   private listeners: Set<Listener> = new Set();
 
-  constructor(private fs: IFileSystem) {}
+  /**
+   * @param repoSchemaVersion repots datamodell-version (ADR 0004) för
+   *   migrate-on-read av äldre event-payloads vid läsning (#58). Default =
+   *   CURRENT (ingen migration).
+   */
+  constructor(private fs: IFileSystem, repoSchemaVersion?: number) {
+    this.projection = new EventLogProjection(repoSchemaVersion);
+  }
 
   async emit(input: EmitInput): Promise<AvaEvent> {
     const event: AvaEvent = avaEventSchema.parse({

--- a/src/lib/server/local-first/projections/event-log.ts
+++ b/src/lib/server/local-first/projections/event-log.ts
@@ -15,11 +15,32 @@
 import { avaEventSchema, type AvaEvent } from "../../events/schema";
 import { JsonLinesProjection } from "./base";
 import { dayBucketPath } from "./time-bucket";
+import { CURRENT_SCHEMA_VERSION } from "@/lib/shared/schema-version";
+import { migrateEventPayload } from "@/lib/shared/schema-migrations";
 
 export class EventLogProjection extends JsonLinesProjection<AvaEvent> {
-  constructor() { super(avaEventSchema); }
+  /**
+   * @param repoSchemaVersion repots datamodell-version (ADR 0004). Event-
+   *   payloads lyfts migrate-on-read från den upp till
+   *   {@link CURRENT_SCHEMA_VERSION} vid läsning (#58). Default = CURRENT
+   *   (ingen migration — för skrivvägen + repon i aktuell version).
+   */
+  constructor(private repoSchemaVersion: number = CURRENT_SCHEMA_VERSION) {
+    super(avaEventSchema);
+  }
 
   pathFor(event: AvaEvent): string {
     return dayBucketPath("events", new Date(event.ts));
+  }
+
+  /**
+   * Parsa JSONL-raden och migrera payloaden till aktuell datamodell (#58).
+   * Payloaden är fri `z.record` → migreringen körs EFTER parse (parse avvisar
+   * aldrig payload-form). No-op när repot redan är i aktuell version.
+   */
+  override deserializeLine(raw: string): AvaEvent {
+    const event = super.deserializeLine(raw);
+    if (this.repoSchemaVersion >= CURRENT_SCHEMA_VERSION) return event;
+    return { ...event, payload: migrateEventPayload(event.type, event.payload, this.repoSchemaVersion) };
   }
 }

--- a/src/lib/shared/schema-migrations.ts
+++ b/src/lib/shared/schema-migrations.ts
@@ -74,3 +74,45 @@ export function migrateRawJson(
   const migrated = migrateRow(entity, parsed as Record<string, unknown>, fromVersion, toVersion);
   return JSON.stringify(migrated);
 }
+
+// ── Event-payloads (#58) ─────────────────────────────────────────────────────
+// Den append-only event-loggen skrivs ALDRIG om, så historiska payloads ligger
+// kvar i sitt ursprungsformat för evigt. Migrate-on-read normaliserar dem vid
+// läsning (FilesystemEventLog → EventLogProjection), keyat på event-typ + version.
+// Payloads är fria `z.record` → migrationen kan köra EFTER zod-parse (parse
+// avvisar aldrig payload-form), till skillnad från entiteterna ovan.
+
+/** Lyfter en event-payload exakt ETT versionssteg för en given event-typ. */
+export type EventPayloadMigration = (payload: Record<string, unknown>) => Record<string, unknown>;
+
+/** Byt legacy-`type` → `invoiceType` om den finns (jfr entitets-migrationen i
+ *  v1→v2, PR #57). No-op när `type` saknas eller `invoiceType` redan finns. */
+function renameInvoiceType(payload: Record<string, unknown>): Record<string, unknown> {
+  if (!("type" in payload) || "invoiceType" in payload) return payload;
+  const { type, ...rest } = payload;
+  return { ...rest, invoiceType: type };
+}
+
+/** `EVENT_MIGRATIONS[type][n]` lyfter en payload för `type` från v`n` → v`n+1`. */
+const EVENT_MIGRATIONS: Record<string, Record<number, EventPayloadMigration>> = {
+  "invoice.created": { 1: renameInvoiceType },
+  "invoice.sent": { 1: renameInvoiceType },
+};
+
+/**
+ * Kedja en event-payload (för `eventType`) från `fromVersion` upp till
+ * `toVersion`. Ren funktion; saknad post → identitet.
+ */
+export function migrateEventPayload(
+  eventType: string,
+  payload: Record<string, unknown>,
+  fromVersion: number,
+  toVersion: number = CURRENT_SCHEMA_VERSION,
+): Record<string, unknown> {
+  let current = payload;
+  for (let v = fromVersion; v < toVersion; v++) {
+    const step = EVENT_MIGRATIONS[eventType]?.[v];
+    if (step) current = step(current);
+  }
+  return current;
+}

--- a/test/unit/lib/shared/schema-migration.test.ts
+++ b/test/unit/lib/shared/schema-migration.test.ts
@@ -4,7 +4,7 @@
  * de defensiva fallen i sträng-wrappern.
  */
 import { describe, it, expect } from "vitest";
-import { migrateRow, migrateRawJson } from "@/lib/shared/schema-migrations";
+import { migrateRow, migrateRawJson, migrateEventPayload } from "@/lib/shared/schema-migrations";
 import { CURRENT_SCHEMA_VERSION } from "@/lib/shared/schema-version";
 
 describe("migrateRow — invoice v1→v2 (stripa legacy `type`)", () => {
@@ -56,5 +56,32 @@ describe("migrateRawJson — sträng-wrapper", () => {
     const raw = JSON.stringify({ id: "i", type: "FINAL" });
     expect(migrateRawJson("invoice", raw, 2, 2)).toBe(raw);
     expect(migrateRawJson("invoice", raw, CURRENT_SCHEMA_VERSION, CURRENT_SCHEMA_VERSION)).toBe(raw);
+  });
+});
+
+describe("migrateEventPayload — event-payloads (#58)", () => {
+  it("invoice.created v1→v2: renamear `type` → `invoiceType`, behåller övrigt", () => {
+    const out = migrateEventPayload("invoice.created", { invoiceId: "i", type: "FINAL", amount: 1000 }, 1, 2);
+    expect(out).toMatchObject({ invoiceId: "i", invoiceType: "FINAL", amount: 1000 });
+    expect(out).not.toHaveProperty("type");
+  });
+
+  it("invoice.sent omfattas av samma migration", () => {
+    expect(migrateEventPayload("invoice.sent", { type: "ACCONTO" }, 1, 2).invoiceType).toBe("ACCONTO");
+  });
+
+  it("no-op när invoiceType redan finns", () => {
+    const p = { invoiceType: "STANDARD", type: "FINAL" };
+    expect(migrateEventPayload("invoice.created", p, 1, 2)).toBe(p);
+  });
+
+  it("identitet för event-typ utan migration", () => {
+    const p = { matterNumber: "2026-0001" };
+    expect(migrateEventPayload("matter.created", p, 1, 2)).toBe(p);
+  });
+
+  it("no-op när from === to", () => {
+    const p = { type: "FINAL" };
+    expect(migrateEventPayload("invoice.created", p, 2, 2)).toBe(p);
   });
 });

--- a/test/unit/server/local-first/filesystem-event-log.test.ts
+++ b/test/unit/server/local-first/filesystem-event-log.test.ts
@@ -102,3 +102,36 @@ describe("FilesystemEventLog — query", () => {
 });
 
 import { vi } from "vitest";
+
+describe("FilesystemEventLog — migrate-on-read (#58)", () => {
+  // Skriv en v1-event-rad (payload bär legacy `type`) direkt till loggen.
+  function writeV1InvoiceEvent(fs: InMemoryFileSystem) {
+    const line = JSON.stringify({
+      id: "0190a000-0000-7000-8000-000000000001",
+      ts: "2026-01-02T10:00:00.000Z",
+      type: "invoice.created", source: "ui",
+      actor: { kind: "user", id: "anna" },
+      payload: { invoiceId: "inv-1", type: "FINAL", amount: 1000 },
+    });
+    return fs.writeFile("events/2026/01/02.jsonl", line + "\n");
+  }
+
+  it("repoSchemaVersion=1 → invoice-payloadens `type` normaliseras till `invoiceType`", async () => {
+    const fs = new InMemoryFileSystem();
+    await writeV1InvoiceEvent(fs);
+    const log = new FilesystemEventLog(fs, 1);
+    const [event] = await log.query({ type: "invoice.created" });
+    expect(event!.payload.invoiceType).toBe("FINAL");
+    expect(event!.payload).not.toHaveProperty("type");
+    expect(event!.payload.amount).toBe(1000); // övriga fält orörda
+  });
+
+  it("default (CURRENT) → ingen migration, payload orörd", async () => {
+    const fs = new InMemoryFileSystem();
+    await writeV1InvoiceEvent(fs);
+    const log = new FilesystemEventLog(fs); // ingen version → CURRENT
+    const [event] = await log.query({ type: "invoice.created" });
+    expect(event!.payload).toHaveProperty("type", "FINAL");
+    expect(event!.payload).not.toHaveProperty("invoiceType");
+  });
+});


### PR DESCRIPTION
Fixar #58 — sista fasen av datamodell-evolutionen ([ADR 0004](../blob/main/docs/adr/0004-schemaversion-och-versionsgrind.md), bågen från #8).

Den append-only event-loggen skrivs **aldrig** om → historiska payloads ligger i ursprungsformat för evigt. Migrate-on-read normaliserar dem vid läsning.

## Vad
- **`migrateEventPayload(type, payload, from, to)`** i `schema-migrations.ts` — keyat på event-typ + version, kedjad. Payloads är fria `z.record`, så migreringen körs **efter** zod-parse (parse avvisar aldrig payload-form — till skillnad från entiteterna som migreras före parse).
- **`EventLogProjection.deserializeLine`**: ny `repoSchemaVersion`-param (default `CURRENT`) → migrerar payloaden vid läsning. Trådas via `FilesystemEventLog`.
- **Första event-migration (v1→v2):** `invoice.created`/`invoice.sent`-payloadens legacy `type` → `invoiceType` (samma rename som entiteten i #57, koherent med `schemaVersion = 2`).

## Avgränsning (ärlig)
`FilesystemEventLog` är **ännu inte inkopplad i en skrivbar runtime** (demo-backendens `events.emit` kastar `ReadOnlyError`), så `repoVersion` defaultar till `CURRENT` (no-op) tills den skrivbara event-loggen wire:as in. Hooket + ramverket + en testad migration finns på plats — vilket är issuets "klar när".

## Verifierat
`yarn typecheck` ✓ · `yarn lint --max-warnings 0` ✓ · `yarn knip` ✓ · `yarn test:fast` ✓ (**2269**, +7). ADR 0004 fas 3 markerad klar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)