### PR TITLE
feat(payment): payment-scan — generera DUE/OVERDUE-påminnelser (#23)

### DIFF
--- a/src/lib/server/events/emit.ts
+++ b/src/lib/server/events/emit.ts
@@ -41,6 +41,17 @@ function emitUser(ctx: EmitCtx, type: EventType, payload: Record<string, unknown
   });
 }
 
+/** Bygg payload + emit för en system-initierad händelse (payment-scan m.fl.). */
+function emitSystem(ctx: EmitCtx, type: EventType, payload: Record<string, unknown>, matterId?: string) {
+  return safeEmit(ctx, {
+    type,
+    source: "system",
+    actor: { kind: "system", id: "payment-scan" },
+    matterId,
+    payload,
+  });
+}
+
 export const emit = {
   // ── matter ─────────────────────────────────────────────────────
   matterCreated: (ctx: EmitCtx, matter: { id: string; matterNumber: string; title: string }) =>
@@ -107,6 +118,13 @@ export const emit = {
       organizationId: string;
     },
   ) => emitUser(ctx, "kostnadsrakning.generated", payload, matterId),
+
+  // ── payment-plan-påminnelser (payment-scan, #23) ───────────────
+  paymentDue: (ctx: EmitCtx, payload: Record<string, unknown>, matterId?: string) =>
+    emitSystem(ctx, "payment.due", payload, matterId),
+
+  paymentOverdue: (ctx: EmitCtx, payload: Record<string, unknown>, matterId?: string) =>
+    emitSystem(ctx, "payment.overdue", payload, matterId),
 
   // ── user / generic ─────────────────────────────────────────────
   userAction: (ctx: EmitCtx, payload: Record<string, unknown>) =>

--- a/src/lib/server/routers/paymentPlan.ts
+++ b/src/lib/server/routers/paymentPlan.ts
@@ -19,8 +19,66 @@
 import { z } from "zod";
 import { router, protectedProcedure, orgProcedure, TRPCError } from "../trpc";
 import { paymentPlanStatusSchema, reminderTypeSchema, type PaymentPlanStatus } from "@/lib/shared/schemas";
+import { emit } from "../events/emit";
+import {
+  computeDueReminders,
+  type PlanForScan,
+  type ReminderKind,
+} from "@/lib/shared/payment-reminders";
 
 type Plan = { id: string; status: PaymentPlanStatus; invoiceId: string };
+
+/** Joinad plan-rad (IDataStore:s query-yta är otypad — vi formar lokalt). */
+interface JoinedPlan {
+  id: string;
+  status: string;
+  monthlyAmount: number;
+  dayOfMonth: number;
+  startDate: Date | string;
+  invoice?: {
+    amount?: number;
+    payments?: Array<{ amount?: number }>;
+    matter?: {
+      id?: string;
+      matterNumber?: string;
+      title?: string;
+      contacts?: Array<{ contact?: { name?: string; email?: string | null } }>;
+    };
+  };
+  reminders?: Array<{ dueMonth: string; type: ReminderKind }>;
+}
+
+function sumPaidOre(payments?: Array<{ amount?: number }>): number {
+  return (payments ?? []).reduce((sum, p) => sum + (p.amount ?? 0), 0);
+}
+
+type Matter = NonNullable<NonNullable<JoinedPlan["invoice"]>["matter"]>;
+
+/** KLIENT-kontaktens namn/email för påminnelse-payloaden (tom om saknas). */
+function resolveRecipient(matter: Matter): { email: string; name: string } {
+  const client = matter.contacts?.[0]?.contact ?? {};
+  return { email: client.email ?? "", name: client.name ?? "" };
+}
+
+function toPlanForScan(p: JoinedPlan): PlanForScan {
+  const inv = p.invoice ?? {};
+  const matter: Matter = inv.matter ?? {};
+  const recipient = resolveRecipient(matter);
+  return {
+    planId: p.id,
+    status: p.status,
+    monthlyAmount: p.monthlyAmount,
+    dayOfMonth: p.dayOfMonth,
+    startDate: new Date(p.startDate),
+    invoiceTotalOre: inv.amount ?? 0,
+    paidOre: sumPaidOre(inv.payments),
+    matterId: matter.id ?? "",
+    matterNumber: matter.matterNumber ?? "",
+    matterTitle: matter.title ?? "",
+    recipientEmail: recipient.email,
+    recipientName: recipient.name,
+  };
+}
 
 export const paymentPlanRouter = router({
   list: orgProcedure
@@ -152,5 +210,61 @@ export const paymentPlanRouter = router({
           sentAt: input.sentAt ? new Date(input.sentAt) : new Date(),
         },
       });
+    }),
+
+  /**
+   * Payment-scan (#23): scanna org:ens aktiva planer och generera DUE/OVERDUE-
+   * påminnelser. Ren beslutslogik i `computeDueReminders`; här gör vi I/O —
+   * hämtar planer (joinade), loggar varje påminnelse (`paymentPlanReminders`)
+   * och emittar `payment.due`/`payment.overdue` (via `emit`, read-only-säkert).
+   * Idempotent: redan loggade (plan, månad, typ) hoppas över i kärnan.
+   *
+   * `asOf` (valfri ISO) injicerar "nu" för deterministiska tester/fixtures
+   * (samma mönster som `recordReminder.sentAt`, ADR 0003); annars `new Date()`.
+   */
+  scanDueReminders: orgProcedure
+    .input(z.object({ asOf: z.string().datetime().optional() }).optional())
+    .mutation(async ({ ctx, input }) => {
+      const now = input?.asOf ? new Date(input.asOf) : new Date();
+      const plans = await ctx.dataStore.paymentPlans.findMany({
+        where: { status: "ACTIVE", invoice: { matter: { organizationId: ctx.orgId } } },
+        include: {
+          invoice: {
+            include: {
+              payments: true,
+              matter: {
+                include: {
+                  contacts: {
+                    where: { role: "KLIENT" },
+                    include: { contact: { select: { id: true, name: true, email: true } } },
+                    take: 1,
+                  },
+                },
+              },
+            },
+          },
+          reminders: true,
+        },
+      }) as unknown as JoinedPlan[];
+
+      const logged = plans.flatMap((p) =>
+        (p.reminders ?? []).map((r) => ({ planId: p.id, dueMonth: r.dueMonth, type: r.type })),
+      );
+      const planned = computeDueReminders(plans.map(toPlanForScan), now, logged);
+
+      for (const r of planned) {
+        await ctx.dataStore.paymentPlanReminders.create({
+          data: { planId: r.planId, dueMonth: r.dueMonth, type: r.type, sentAt: now },
+        });
+        if (r.type === "DUE") await emit.paymentDue(ctx, r.payload, r.matterId);
+        else await emit.paymentOverdue(ctx, r.payload, r.matterId);
+      }
+
+      return {
+        scanned: plans.length,
+        planned: planned.length,
+        due: planned.filter((p) => p.type === "DUE").length,
+        overdue: planned.filter((p) => p.type === "OVERDUE").length,
+      };
     }),
 });

--- a/src/lib/shared/payment-reminders.ts
+++ b/src/lib/shared/payment-reminders.ts
@@ -1,0 +1,139 @@
+/**
+ * Payment-scan — ren kärna för avbetalningsplaners påminnelse-generering (#23).
+ *
+ * Givet aktiva planer + dagens datum + redan loggade påminnelser → besluta
+ * vilka `payment.due`/`payment.overdue`-händelser som ska emittas (och loggas
+ * via `paymentPlan.recordReminder`). Ren funktion → trivialt testbar; all
+ * I/O (hämta planer, emit, logga) sker i `paymentPlan.scanDueReminders`.
+ *
+ * Semantik (beslutad i #23):
+ *   - **remaining** = `invoiceTotalOre − paidOre`. `remaining ≤ 0` → planen är
+ *     i praktiken betald → ingen påminnelse.
+ *   - **DUE**: innevarande månads installment. Skickas när `today ≥ dayOfMonth`
+ *     och ingen DUE redan loggats för (plan, innevarande YYYY-MM).
+ *   - **OVERDUE**: föregående månad (vars förfallodag passerat) med
+ *     `remaining > 0` och ingen OVERDUE redan loggad för den månaden. Endast
+ *     föregående månad eskaleras — ingen backfill av äldre månader (undviker
+ *     spam-flod vid första scan).
+ *   - **Företräde**: OVERDUE går före DUE — är klienten redan efter skickar vi
+ *     inte också en vänlig DUE samma scan. Max EN påminnelse per plan/scan.
+ *   - Idempotens: `(planId, dueMonth, type)` mot påminnelse-loggen.
+ *
+ * Per-installment-"betalt" spåras inte (betalningar bokförs mot fakturan, inte
+ * per månad) → `remaining > 0` är grinden, enligt produktbeslut i #23.
+ */
+
+export type ReminderKind = "DUE" | "OVERDUE";
+
+/** En aktiv plan med allt kärnan behöver för beslut + payload. */
+export interface PlanForScan {
+  planId: string;
+  status: string;
+  monthlyAmount: number; // öre/månad
+  dayOfMonth: number; // 1–28
+  startDate: Date;
+  invoiceTotalOre: number; // fakturans totalbelopp
+  paidOre: number; // summa registrerade betalningar
+  matterId: string;
+  matterNumber: string;
+  matterTitle: string;
+  recipientEmail: string;
+  recipientName: string;
+}
+
+/** Redan loggad påminnelse (idempotens-nyckel). */
+export interface LoggedReminder {
+  planId: string;
+  dueMonth: string; // "YYYY-MM"
+  type: ReminderKind;
+}
+
+/** En påminnelse som ska skickas: loggas + emittas av anroparen. */
+export interface PlannedReminder {
+  planId: string;
+  matterId: string;
+  dueMonth: string; // "YYYY-MM"
+  type: ReminderKind;
+  eventType: "payment.due" | "payment.overdue";
+  idempotencyKey: string;
+  remainingOre: number;
+  /** Payload-kontraktet som starter-rules 1b/1c läser. */
+  payload: Record<string, unknown>;
+}
+
+function monthKey(year: number, monthIndex0: number): string {
+  return `${year}-${String(monthIndex0 + 1).padStart(2, "0")}`;
+}
+
+function plannedFor(plan: PlanForScan, dueMonth: string, type: ReminderKind, remainingOre: number): PlannedReminder {
+  const eventType = type === "DUE" ? "payment.due" : "payment.overdue";
+  return {
+    planId: plan.planId,
+    matterId: plan.matterId,
+    dueMonth,
+    type,
+    eventType,
+    idempotencyKey: `${eventType}:${plan.planId}:${dueMonth}`,
+    remainingOre,
+    payload: {
+      planId: plan.planId,
+      dueMonth,
+      recipientEmail: plan.recipientEmail,
+      recipientName: plan.recipientName,
+      matterNumber: plan.matterNumber,
+      matterTitle: plan.matterTitle,
+      invoiceAmount: plan.invoiceTotalOre,
+      monthlyAmount: plan.monthlyAmount,
+      dayOfMonth: plan.dayOfMonth,
+      remainingAmount: remainingOre,
+      idempotencyKey: `${eventType}:${plan.planId}:${dueMonth}`,
+    },
+  };
+}
+
+/**
+ * Beslut för EN plan: OVERDUE (föregående månad) före DUE (innevarande). Null
+ * om inget ska skickas.
+ */
+function decideForPlan(plan: PlanForScan, now: Date, logged: Set<string>): PlannedReminder | null {
+  const remaining = plan.invoiceTotalOre - plan.paidOre;
+  if (plan.status !== "ACTIVE" || remaining <= 0) return null;
+
+  const startIdx = plan.startDate.getUTCFullYear() * 12 + plan.startDate.getUTCMonth();
+  const curIdx = now.getUTCFullYear() * 12 + now.getUTCMonth();
+  const curMonth = monthKey(now.getUTCFullYear(), now.getUTCMonth());
+
+  // OVERDUE: föregående månad (om planen fanns då) — eskalera obetald.
+  const prevIdx = curIdx - 1;
+  if (prevIdx >= startIdx) {
+    const prevMonth = monthKey(Math.floor(prevIdx / 12), prevIdx % 12);
+    if (!logged.has(`${plan.planId}:${prevMonth}:OVERDUE`)) {
+      return plannedFor(plan, prevMonth, "OVERDUE", remaining);
+    }
+  }
+
+  // DUE: innevarande månad när förfallodagen passerat.
+  if (curIdx >= startIdx && now.getUTCDate() >= plan.dayOfMonth
+      && !logged.has(`${plan.planId}:${curMonth}:DUE`)) {
+    return plannedFor(plan, curMonth, "DUE", remaining);
+  }
+  return null;
+}
+
+/**
+ * Scanna planer och returnera påminnelser att skicka (max en per plan). Ren
+ * funktion: anroparen loggar + emittar resultatet.
+ */
+export function computeDueReminders(
+  plans: readonly PlanForScan[],
+  now: Date,
+  logged: readonly LoggedReminder[],
+): PlannedReminder[] {
+  const loggedSet = new Set(logged.map((r) => `${r.planId}:${r.dueMonth}:${r.type}`));
+  const out: PlannedReminder[] = [];
+  for (const plan of plans) {
+    const decision = decideForPlan(plan, now, loggedSet);
+    if (decision) out.push(decision);
+  }
+  return out;
+}

--- a/test/unit/lib/shared/payment-reminders.test.ts
+++ b/test/unit/lib/shared/payment-reminders.test.ts
@@ -1,0 +1,81 @@
+/**
+ * `payment-reminders` — ren scan-kärna (#23). Låser DUE/OVERDUE-semantiken,
+ * remaining-grinden, företrädet och idempotensen.
+ */
+import { describe, it, expect } from "vitest";
+import { computeDueReminders, type PlanForScan, type LoggedReminder } from "@/lib/shared/payment-reminders";
+
+function plan(over: Partial<PlanForScan> = {}): PlanForScan {
+  return {
+    planId: "pp-1", status: "ACTIVE", monthlyAmount: 50000, dayOfMonth: 10,
+    startDate: new Date("2026-01-15T00:00:00Z"),
+    invoiceTotalOre: 600000, paidOre: 0,
+    matterId: "m-1", matterNumber: "2026-0001", matterTitle: "Tvist",
+    recipientEmail: "klient@example.se", recipientName: "Klient AB",
+    ...over,
+  };
+}
+
+const NONE: LoggedReminder[] = [];
+
+describe("computeDueReminders — DUE", () => {
+  // Plan startad innevarande månad → ingen föregående månad → isolerar DUE-vägen.
+  const thisMonth = () => plan({ startDate: new Date("2026-03-01T00:00:00Z") });
+
+  it("DUE för innevarande månad när today >= dayOfMonth", () => {
+    const out = computeDueReminders([thisMonth()], new Date("2026-03-10T09:00:00Z"), NONE);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.type).toBe("DUE");
+    expect(out[0]!.dueMonth).toBe("2026-03");
+    expect(out[0]!.eventType).toBe("payment.due");
+    expect(out[0]!.idempotencyKey).toBe("payment.due:pp-1:2026-03");
+    expect(out[0]!.payload).toMatchObject({ recipientEmail: "klient@example.se", monthlyAmount: 50000, remainingAmount: 600000 });
+  });
+
+  it("ingen DUE före dayOfMonth", () => {
+    expect(computeDueReminders([thisMonth()], new Date("2026-03-05T09:00:00Z"), NONE)).toHaveLength(0);
+  });
+
+  it("idempotens: redan loggad DUE → ingen ny", () => {
+    const logged: LoggedReminder[] = [{ planId: "pp-1", dueMonth: "2026-03", type: "DUE" }];
+    expect(computeDueReminders([thisMonth()], new Date("2026-03-10T09:00:00Z"), logged)).toHaveLength(0);
+  });
+});
+
+describe("computeDueReminders — OVERDUE", () => {
+  it("OVERDUE för föregående månad, går före DUE", () => {
+    const out = computeDueReminders([plan()], new Date("2026-03-10T09:00:00Z"), NONE);
+    // plan startade 2026-01 → föregående månad (2026-02) eskaleras före DUE.
+    // (NONE-loggen ⇒ OVERDUE vinner företräde.)
+    expect(out[0]!.type).toBe("OVERDUE");
+    expect(out[0]!.dueMonth).toBe("2026-02");
+    expect(out[0]!.eventType).toBe("payment.overdue");
+  });
+
+  it("ingen backfill: plan startad innevarande månad → ingen OVERDUE", () => {
+    const p = plan({ startDate: new Date("2026-03-01T00:00:00Z") });
+    const out = computeDueReminders([p], new Date("2026-03-10T09:00:00Z"), NONE);
+    expect(out[0]!.type).toBe("DUE"); // bara innevarande månad
+  });
+
+  it("loggad OVERDUE för föreg. månad → faller igenom till DUE", () => {
+    const logged: LoggedReminder[] = [{ planId: "pp-1", dueMonth: "2026-02", type: "OVERDUE" }];
+    const out = computeDueReminders([plan()], new Date("2026-03-10T09:00:00Z"), logged);
+    expect(out[0]!.type).toBe("DUE");
+    expect(out[0]!.dueMonth).toBe("2026-03");
+  });
+});
+
+describe("computeDueReminders — grindar", () => {
+  it("remaining <= 0 (betald) → ingen påminnelse", () => {
+    expect(computeDueReminders([plan({ paidOre: 600000 })], new Date("2026-03-10T09:00:00Z"), NONE)).toHaveLength(0);
+  });
+  it("ej ACTIVE → ingen påminnelse", () => {
+    expect(computeDueReminders([plan({ status: "CANCELLED" })], new Date("2026-03-10T09:00:00Z"), NONE)).toHaveLength(0);
+    expect(computeDueReminders([plan({ status: "COMPLETED" })], new Date("2026-03-10T09:00:00Z"), NONE)).toHaveLength(0);
+  });
+  it("remaining beräknas som total − betalt", () => {
+    const out = computeDueReminders([plan({ paidOre: 100000 })], new Date("2026-03-10T09:00:00Z"), [{ planId: "pp-1", dueMonth: "2026-02", type: "OVERDUE" }]);
+    expect(out[0]!.payload.remainingAmount).toBe(500000);
+  });
+});

--- a/test/unit/server/routers/payment-scan.test.ts
+++ b/test/unit/server/routers/payment-scan.test.ts
@@ -1,0 +1,78 @@
+/**
+ * `paymentPlan.scanDueReminders` (#23) — end-to-end mot riktig DemoDataStore.
+ * Verifierar DUE/OVERDUE-generering, att påminnelser loggas, och idempotens.
+ */
+import { describe, it, expect } from "vitest";
+import { appRouter } from "@/lib/server/routers/_app";
+import { DemoDataStore } from "@/lib/server/data-store/DemoDataStore";
+import { buildContext } from "@/lib/server/build-context";
+import { noopPorts } from "@/lib/server/adapters/noop-ports";
+import type { Principal } from "@/lib/server/auth/principal";
+
+const PRINCIPAL: Principal = { id: "u-1", email: "a@x", name: "Anna", role: "ADMIN", organizationId: "org-1" };
+
+function makeCaller(opts: { startDate: string; paidOre?: number }) {
+  const ds = new DemoDataStore({
+    organizations: [{ id: "org-1", name: "Byrå AB" }],
+    matters: [{ id: "m-1", organizationId: "org-1", matterNumber: "2026-0001", title: "Tvist", status: "ACTIVE", createdAt: new Date() }],
+    contacts: [{ id: "c-1", organizationId: "org-1", name: "Klient AB", email: "klient@example.se" }],
+    matterContacts: [{ id: "mc-1", matterId: "m-1", contactId: "c-1", role: "KLIENT" }],
+    invoices: [{ id: "inv-1", organizationId: "org-1", matterId: "m-1", amount: 600000, invoiceType: "STANDARD", status: "INSTALLMENT_PLAN", invoiceDate: new Date() }],
+    payments: opts.paidOre != null ? [{ id: "pay-1", invoiceId: "inv-1", amount: opts.paidOre, paidAt: new Date() }] : [],
+    paymentPlans: [{ id: "pp-1", invoiceId: "inv-1", monthlyAmount: 50000, dayOfMonth: 10, startDate: opts.startDate, status: "ACTIVE", createdAt: new Date() }],
+  }, async () => { /* writable noop */ });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return { ds, caller: appRouter.createCaller(buildContext({ dataStore: ds, ports: noopPorts, principal: PRINCIPAL }) as any) };
+}
+
+describe("paymentPlan.scanDueReminders", () => {
+  it("genererar DUE för innevarande månad + loggar påminnelsen", async () => {
+    const { ds, caller } = makeCaller({ startDate: "2026-03-01" });
+    const res = await caller.paymentPlan.scanDueReminders({ asOf: "2026-03-10T09:00:00.000Z" });
+    expect(res).toMatchObject({ scanned: 1, planned: 1, due: 1, overdue: 0 });
+    const reminders = await ds.paymentPlanReminders.findMany({ where: { planId: "pp-1" } });
+    expect(reminders).toHaveLength(1);
+    expect(reminders[0]).toMatchObject({ planId: "pp-1", dueMonth: "2026-03", type: "DUE" });
+  });
+
+  it("genererar OVERDUE för föregående månad (eskalering)", async () => {
+    const { caller } = makeCaller({ startDate: "2026-01-15" });
+    const res = await caller.paymentPlan.scanDueReminders({ asOf: "2026-03-10T09:00:00.000Z" });
+    expect(res).toMatchObject({ planned: 1, overdue: 1, due: 0 });
+  });
+
+  it("idempotent: andra scan samma dag genererar inga nya", async () => {
+    const { caller } = makeCaller({ startDate: "2026-03-01" });
+    await caller.paymentPlan.scanDueReminders({ asOf: "2026-03-10T09:00:00.000Z" });
+    const second = await caller.paymentPlan.scanDueReminders({ asOf: "2026-03-10T09:00:00.000Z" });
+    expect(second.planned).toBe(0);
+  });
+
+  it("betald plan (remaining <= 0) → inga påminnelser", async () => {
+    const { caller } = makeCaller({ startDate: "2026-03-01", paidOre: 600000 });
+    const res = await caller.paymentPlan.scanDueReminders({ asOf: "2026-03-10T09:00:00.000Z" });
+    expect(res.planned).toBe(0);
+  });
+
+  it("före dayOfMonth (och ingen föreg. månad) → inga påminnelser", async () => {
+    const { caller } = makeCaller({ startDate: "2026-03-01" });
+    const res = await caller.paymentPlan.scanDueReminders({ asOf: "2026-03-05T09:00:00.000Z" });
+    expect(res.planned).toBe(0);
+  });
+
+  it("saknad KLIENT-kontakt → scannar ändå (tom recipient i payloaden)", async () => {
+    // Ingen matterContact/KLIENT → resolveRecipient faller tillbaka på "".
+    const ds = new DemoDataStore({
+      organizations: [{ id: "org-1", name: "Byrå AB" }],
+      matters: [{ id: "m-1", organizationId: "org-1", matterNumber: "2026-0001", title: "Tvist", status: "ACTIVE", createdAt: new Date() }],
+      invoices: [{ id: "inv-1", organizationId: "org-1", matterId: "m-1", amount: 600000, invoiceType: "STANDARD", status: "INSTALLMENT_PLAN", invoiceDate: new Date() }],
+      paymentPlans: [{ id: "pp-1", invoiceId: "inv-1", monthlyAmount: 50000, dayOfMonth: 10, startDate: "2026-03-01", status: "ACTIVE", createdAt: new Date() }],
+    }, async () => { /* noop */ });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const caller = appRouter.createCaller(buildContext({ dataStore: ds, ports: noopPorts, principal: PRINCIPAL }) as any);
+    const res = await caller.paymentPlan.scanDueReminders({ asOf: "2026-03-10T09:00:00.000Z" });
+    expect(res).toMatchObject({ planned: 1, due: 1 });
+    const reminders = await ds.paymentPlanReminders.findMany({ where: { planId: "pp-1" } });
+    expect(reminders[0]).toMatchObject({ type: "DUE" });
+  });
+});


### PR DESCRIPTION
Fixar #23. **Djup-genomgång gjordes först** (verifierat): regelmotorn är vilande scaffolding (importeras ingenstans utanför `rules/`+tester; `DemoDataStore.onNewEvent` är no-op; rules 1b/1c är `enabled:false`). Därför valdes — i samråd — den **pragmatiska direkt-servicen** framför att koppla in hela motorn, och **OVERDUE = remaining > 0 mot fakturan**.

## Vad
- **`src/lib/shared/payment-reminders.ts`** — ren kärna `computeDueReminders(plans, now, logged)`:
  - DUE = innevarande månad när `today ≥ dayOfMonth`.
  - OVERDUE = föregående månad, grindad av `remaining = invoiceTotal − betalt > 0` (per-installment-betalt spåras inte → produktbeslut). OVERDUE har **företräde**; max en påminnelse/plan/scan; **ingen backfill** av äldre månader.
  - Idempotent mot `(planId, dueMonth, type)` via påminnelse-loggen.
- **`paymentPlan.scanDueReminders`** (orgProcedure) — hämtar aktiva planer (joinade), kör kärnan, loggar varje påminnelse (`paymentPlanReminders`) + emittar `payment.due`/`payment.overdue` via `emit` (read-only-säkert). `asOf` injicerar "nu" för deterministiska tester.
- **`emit.paymentDue`/`paymentOverdue`** (source=system).

## Avgränsning (medvetet — för att undvika missförstånd)
Proceduren är **anropbar men ännu inte automatiskt triggad**. Triggern (browser-open-job à la `mirror-outlook`, eller en manuell "Skicka påminnelser"-knapp) är nästa tunna steg och förutsätter beslutet om den vilande regelmotorn. I demo-backenden är event-loggen read-only (emit sväljs); påminnelserna loggas. Mail-reglerna 1b/1c är `enabled:false` tills motorn wire:as.

## Verifierat
`yarn typecheck` ✓ · `yarn lint --max-warnings 0` ✓ · `yarn knip` ✓ · `yarn test:fast` ✓ (**2283**, +14). Coverage **steg** till 73.19/66.42/69.83/75.45 (över #43-golvet). 15 tester (kärna + procedur e2e mot riktig DemoDataStore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)