### PR TITLE
docs(adr): spika server-som-git-peer som Accepterad (ADR 0005, #73)

### DIFF
--- a/docs/adr/0005-server-som-git-peer.md
+++ b/docs/adr/0005-server-som-git-peer.md
@@ -1,6 +1,6 @@
 # ADR 0005 — Tunn server som git-peer: integrationer + alltid-på-jobb utan att offra local-first
 
-- **Status:** Föreslagen (skiss — riktning ej spikad)
+- **Status:** Accepterad
 - **Datum:** 2026-06-07
 - **Beslutsfattare:** Ulrik Sjölin
 - **Berör:** server-topologi, integrationer (Fortnox/mail), regelmotor-runtime, payment-scan, git-sync, deploy-modeller

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,8 +17,8 @@
 >   strategi: app-genererad UUIDv7 (klient-/offline-genererad, native `uuid` i PG).
 > - [ADR 0004](./adr/0004-schemaversion-och-versionsgrind.md) — `schemaVersion`
 >   i `.ava/meta.json` + versionsgrind vid hydrering (datamodell-evolution).
-> - [ADR 0005](./adr/0005-server-som-git-peer.md) — **(föreslagen)** tunn server
->   som git-peer: integrationer + alltid-på-jobb utan att offra local-first.
+> - [ADR 0005](./adr/0005-server-som-git-peer.md) — tunn server som git-peer:
+>   integrationer + alltid-på-jobb utan att offra local-first.
 
 ## Tre lager
 


### PR DESCRIPTION
Beslutet spikat → ADR 0005 Status **Föreslagen → Accepterad**; tar bort `(föreslagen)`-markeringen i architecture.md-länken. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)