### PR TITLE
test(helper): full testtäckning via SOLID-injicering + coverage-grind (#96)

### DIFF
--- a/.github/workflows/helper-ci.yml
+++ b/.github/workflows/helper-ci.yml
@@ -36,7 +36,9 @@ jobs:
       - name: Typecheck
         run: bun run typecheck
 
-      - name: Test
+      - name: Test + coverage-grind
+        # bunfig.toml har coverage=true + coverageThreshold → faller om
+        # täckningen sjunker under golvet (ratchet).
         run: bun test
 
       - name: Cross-build (snapshot)

--- a/helper-app/bunfig.toml
+++ b/helper-app/bunfig.toml
@@ -1,0 +1,13 @@
+# Test-/coverage-konfig för helper-app.
+#
+# Coverage-grinden är en RATCHET (jfr repots vitest-golv): förankrad strax
+# under nuvarande siffror och flyttas bara uppåt. `bun test` (med coverage
+# påslaget nedan) faller om täckningen sjunker under golvet.
+[test]
+coverage = true
+coverageReporter = ["text"]
+coverageSkipTestFiles = true
+# Mät bara helperns egen källkod: hoppa över test-fixturer och det delade
+# protokollet (../src/...) som täcks av repots vitest-svit, inte här.
+coveragePathIgnorePatterns = ["../src/**", "**/helpers.ts"]
+coverageThreshold = { line = 0.90, function = 0.82 }

--- a/helper-app/src/log.ts
+++ b/helper-app/src/log.ts
@@ -11,26 +11,36 @@ import { appendFileSync, mkdirSync, openSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { currentPlatform } from "./platform/runtime.ts";
+import { currentPlatform, type Platform } from "./platform/runtime.ts";
 
-function logDir(): string | null {
-  const home = homedir();
+/**
+ * Ren per-OS-mappning av loggkatalogen (testbar utan env/fs).
+ * Returnerar null om hemkatalogen saknas.
+ */
+export function resolveLogDir(platform: Platform, home: string, localAppData?: string): string | null {
   if (home === "") return null;
-  switch (currentPlatform()) {
+  switch (platform) {
     case "darwin":
       return join(home, "Library", "Logs", "AVA");
     case "windows":
-      return join(process.env.LOCALAPPDATA ?? home, "AVA", "Logs");
+      return join(localAppData ?? home, "AVA", "Logs");
     default:
       return join(home, ".local", "state", "AVA");
   }
 }
 
+function logDir(): string | null {
+  return resolveLogDir(currentPlatform(), homedir(), process.env.LOCALAPPDATA);
+}
+
 let logFilePath: string | null = null;
 
-/** Initiera loggfilen. Returnerar sökvägen, eller null om det inte gick. */
-export function initLog(): string | null {
-  const dir = logDir();
+/**
+ * Initiera loggfilen. Returnerar sökvägen, eller null om det inte gick.
+ * `dir` defaultar till per-OS-katalogen; explicit värde gör den testbar
+ * utan att röra användarens riktiga loggkatalog.
+ */
+export function initLog(dir: string | null = logDir()): string | null {
   if (dir === null) return null;
   try {
     mkdirSync(dir, { recursive: true, mode: 0o700 });

--- a/helper-app/src/open.ts
+++ b/helper-app/src/open.ts
@@ -85,13 +85,38 @@ function errMsg(err: unknown): string {
 }
 
 /** GET med valfri Authorization-header → skriv body till `path`. */
-async function downloadTo(path: string, url: string, authHeader?: string): Promise<void> {
+export async function downloadTo(path: string, url: string, authHeader?: string): Promise<void> {
   const headers: Record<string, string> = {};
   if (authHeader) headers.Authorization = authHeader;
   const resp = await fetch(url, { headers });
   if (resp.status >= 400) throw new Error(`HTTP ${resp.status}`);
   await Bun.write(path, resp);
 }
+
+export async function uploadFile(path: string, uploadUrl: string, authHeader: string | undefined): Promise<void> {
+  const headers: Record<string, string> = { "Content-Type": "application/octet-stream" };
+  if (authHeader) headers.Authorization = authHeader;
+  const resp = await fetch(uploadUrl, { method: "PUT", headers, body: Bun.file(path) });
+  if (resp.status >= 400) throw new Error(`upload HTTP ${resp.status}`);
+}
+
+/**
+ * Injicerbara beroenden för watch-loopen (SOLID): klocka + sleep + IO så
+ * loopen kan testas deterministiskt utan riktig tid/fs/nät.
+ */
+export interface WatchDeps {
+  statMtime: (path: string) => Promise<number | null>;
+  upload: (path: string, uploadUrl: string, authHeader: string | undefined) => Promise<void>;
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+}
+
+export const defaultWatchDeps: WatchDeps = {
+  statMtime,
+  upload: uploadFile,
+  sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  now: () => Date.now(),
+};
 
 /**
  * Pollar filens mtime och PUT:ar nya bytes vid varje save. Stänger efter
@@ -102,28 +127,35 @@ export function watchAndUpload(
   uploadUrl: string,
   authHeader: string | undefined,
   timeoutMs: number,
+  deps: WatchDeps = defaultWatchDeps,
 ): void {
-  void runWatch(path, uploadUrl, authHeader, timeoutMs);
+  void runWatch(path, uploadUrl, authHeader, timeoutMs, deps);
 }
 
-async function runWatch(path: string, uploadUrl: string, authHeader: string | undefined, timeoutMs: number): Promise<void> {
-  let lastMtime = (await statMtime(path)) ?? 0;
-  if (lastMtime === 0) return;
-  let deadline = Date.now() + timeoutMs;
+export async function runWatch(
+  path: string,
+  uploadUrl: string,
+  authHeader: string | undefined,
+  timeoutMs: number,
+  deps: WatchDeps,
+): Promise<void> {
+  let lastMtime = (await deps.statMtime(path)) ?? 0;
+  if (lastMtime === 0) return; // filen försvann innan watch hann starta
+  let deadline = deps.now() + timeoutMs;
 
   for (;;) {
-    await sleep(POLL_INTERVAL_MS);
-    if (Date.now() > deadline) {
+    await deps.sleep(POLL_INTERVAL_MS);
+    if (deps.now() > deadline) {
       log(`watch timeout: ${path}`);
       return;
     }
-    const mtime = await statMtime(path);
+    const mtime = await deps.statMtime(path);
     if (mtime === null || mtime <= lastMtime) continue;
     try {
-      await uploadFile(path, uploadUrl, authHeader);
+      await deps.upload(path, uploadUrl, authHeader);
       log(`uploaded changes: ${path}`);
       lastMtime = mtime;
-      deadline = Date.now() + timeoutMs; // aktivitet → förläng
+      deadline = deps.now() + timeoutMs; // aktivitet → förläng
     } catch (err) {
       log(`upload failed (${path}): ${errMsg(err)}`);
     }
@@ -136,15 +168,4 @@ async function statMtime(path: string): Promise<number | null> {
   } catch {
     return null;
   }
-}
-
-async function uploadFile(path: string, uploadUrl: string, authHeader: string | undefined): Promise<void> {
-  const headers: Record<string, string> = { "Content-Type": "application/octet-stream" };
-  if (authHeader) headers.Authorization = authHeader;
-  const resp = await fetch(uploadUrl, { method: "PUT", headers, body: Bun.file(path) });
-  if (resp.status >= 400) throw new Error(`upload HTTP ${resp.status}`);
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/helper-app/src/platform/command.ts
+++ b/helper-app/src/platform/command.ts
@@ -1,0 +1,5 @@
+/** Ett OS-kommando att spawna: program + argument. */
+export interface Command {
+  cmd: string;
+  args: string[];
+}

--- a/helper-app/src/platform/mail.ts
+++ b/helper-app/src/platform/mail.ts
@@ -6,9 +6,13 @@
  *   - macOS: AppleScript mot Mail.app (make new outgoing message, visible).
  *   - Linux: `xdg-email --attach --subject --body` (Thunderbird/Evolution …).
  *   - Windows: Outlook COM via PowerShell, fallback `mailto:` (utan bilaga).
+ *
+ * Kommando-byggarna (`mailCommand`, `windowsFallbackCommand` + script-/
+ * arg-/url-byggarna) är rena → testbara utan spawn (SOLID).
  */
 
-import { currentPlatform } from "./runtime.ts";
+import type { Command } from "./command.ts";
+import { currentPlatform, type Platform } from "./runtime.ts";
 import { spawnDetached } from "./spawn.ts";
 
 export interface ComposeMailOpts {
@@ -24,22 +28,46 @@ export async function composeMail(opts: ComposeMailOpts): Promise<void> {
   if (opts.attachmentPath === "") {
     throw new Error("attachmentPath required");
   }
-  switch (currentPlatform()) {
+  const platform = currentPlatform();
+  if (platform === "windows") {
+    await composeWindows(opts);
+    return;
+  }
+  const { cmd, args } = mailCommand(platform, opts);
+  await spawnDetached(cmd, args).started;
+}
+
+/** Primärt mail-kommando per plattform (ren). Kastar för okänt OS. */
+export function mailCommand(platform: Platform, opts: ComposeMailOpts): Command {
+  switch (platform) {
     case "darwin":
-      await spawnDetached("osascript", ["-e", macScript(opts)]).started;
-      return;
+      return { cmd: "osascript", args: ["-e", macScript(opts)] };
     case "linux":
-      await spawnDetached("xdg-email", linuxArgs(opts)).started;
-      return;
+      return { cmd: "xdg-email", args: linuxArgs(opts) };
     case "windows":
-      await composeWindows(opts);
-      return;
+      return { cmd: "powershell", args: ["-NoProfile", "-Command", windowsScript(opts)] };
     default:
-      throw new Error(`unsupported OS: ${process.platform}`);
+      throw new Error(`unsupported OS: ${platform}`);
   }
 }
 
-function macScript(opts: ComposeMailOpts): string {
+/** Windows-fallback: mailto (utan bilaga — stöds inte av standard-attach). */
+export function windowsFallbackCommand(opts: ComposeMailOpts): Command {
+  const url = `mailto:${opts.to ?? ""}?subject=${escapeUrl(opts.subject)}&body=${escapeUrl(opts.body)}`;
+  return { cmd: "rundll32", args: ["url.dll,FileProtocolHandler", url] };
+}
+
+async function composeWindows(opts: ComposeMailOpts): Promise<void> {
+  const primary = mailCommand("windows", opts);
+  try {
+    await spawnDetached(primary.cmd, primary.args).started;
+  } catch {
+    const fb = windowsFallbackCommand(opts);
+    await spawnDetached(fb.cmd, fb.args).started;
+  }
+}
+
+export function macScript(opts: ComposeMailOpts): string {
   return `
 tell application "Mail"
   activate
@@ -53,7 +81,7 @@ tell application "Mail"
 end tell`;
 }
 
-function macToRecipient(to: string): string {
+export function macToRecipient(to: string): string {
   if (to === "") return "";
   return `make new to recipient at end of to recipients with properties {address:${applescriptQuote(to)}}`;
 }
@@ -63,14 +91,14 @@ export function applescriptQuote(s: string): string {
   return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
 }
 
-function linuxArgs(opts: ComposeMailOpts): string[] {
+export function linuxArgs(opts: ComposeMailOpts): string[] {
   const args = ["--attach", opts.attachmentPath, "--subject", opts.subject, "--body", opts.body];
   if (opts.to !== undefined && opts.to !== "") args.push(opts.to);
   return args;
 }
 
-async function composeWindows(opts: ComposeMailOpts): Promise<void> {
-  const ps = [
+export function windowsScript(opts: ComposeMailOpts): string {
+  return [
     "$ol = New-Object -ComObject Outlook.Application",
     "$mail = $ol.CreateItem(0)",
     `$mail.To = '${escapePs(opts.to ?? "")}'`,
@@ -79,13 +107,6 @@ async function composeWindows(opts: ComposeMailOpts): Promise<void> {
     `$mail.Attachments.Add('${escapePs(opts.attachmentPath)}') | Out-Null`,
     "$mail.Display()",
   ].join("\n");
-  try {
-    await spawnDetached("powershell", ["-NoProfile", "-Command", ps]).started;
-  } catch {
-    // Fallback: mailto (utan bilaga — Windows stöder inte standard-attach).
-    const url = `mailto:${opts.to ?? ""}?subject=${escapeUrl(opts.subject)}&body=${escapeUrl(opts.body)}`;
-    await spawnDetached("rundll32", ["url.dll,FileProtocolHandler", url]).started;
-  }
 }
 
 /** PowerShell single-quote-escape (`'` → `''`). */

--- a/helper-app/src/platform/open-app.ts
+++ b/helper-app/src/platform/open-app.ts
@@ -2,25 +2,31 @@
  * `openWithDefaultApp` — starta OS:ets default-app för en fil. Helpern
  * väntar INTE på att appen ska stänga; den returnerar så snart appen
  * startat. (Port av Go:s platform.OpenWithDefaultApp.)
+ *
+ * `openCommand` (ren) bygger kommandot per plattform → testbar utan spawn
+ * (SOLID: separera "vilket kommando" från "kör det").
  */
 
-import { currentPlatform } from "./runtime.ts";
+import type { Command } from "./command.ts";
+import { currentPlatform, type Platform } from "./runtime.ts";
 import { spawnDetached } from "./spawn.ts";
 
-export async function openWithDefaultApp(path: string): Promise<void> {
-  switch (currentPlatform()) {
+export function openCommand(platform: Platform, path: string): Command {
+  switch (platform) {
     case "darwin":
-      await spawnDetached("open", [path]).started;
-      return;
+      return { cmd: "open", args: [path] };
     case "linux":
-      await spawnDetached("xdg-open", [path]).started;
-      return;
+      return { cmd: "xdg-open", args: [path] };
     case "windows":
       // rundll32 url.dll,FileProtocolHandler triggar default-app utan
       // att öppna ett konsolfönster.
-      await spawnDetached("rundll32", ["url.dll,FileProtocolHandler", path]).started;
-      return;
+      return { cmd: "rundll32", args: ["url.dll,FileProtocolHandler", path] };
     default:
-      throw new Error(`unsupported OS: ${process.platform}`);
+      throw new Error(`unsupported OS: ${platform}`);
   }
+}
+
+export async function openWithDefaultApp(path: string): Promise<void> {
+  const { cmd, args } = openCommand(currentPlatform(), path);
+  await spawnDetached(cmd, args).started;
 }

--- a/helper-app/src/platform/runtime.ts
+++ b/helper-app/src/platform/runtime.ts
@@ -5,8 +5,9 @@
 
 export type Platform = "darwin" | "linux" | "windows" | "other";
 
-export function currentPlatform(): Platform {
-  switch (process.platform) {
+/** Ren mappning från Node:s plattforms-sträng → vår union (testbar). */
+export function platformFrom(p: string): Platform {
+  switch (p) {
     case "darwin":
       return "darwin";
     case "linux":
@@ -16,4 +17,8 @@ export function currentPlatform(): Platform {
     default:
       return "other";
   }
+}
+
+export function currentPlatform(): Platform {
+  return platformFrom(process.platform);
 }

--- a/helper-app/src/update.ts
+++ b/helper-app/src/update.ts
@@ -29,11 +29,11 @@ export interface UpdateConfig {
   onUpdated: (newVersion: string) => void;
 }
 
-interface GithubAsset {
+export interface GithubAsset {
   name: string;
   browser_download_url: string;
 }
-interface GithubRelease {
+export interface GithubRelease {
   tag_name: string;
   draft: boolean;
   assets: GithubAsset[];
@@ -45,34 +45,58 @@ export function assetName(platform: Platform = currentPlatform(), arch: string =
   return `ava-helper-${platform}-${arch}${ext}`;
 }
 
+/** Injicerbara IO-beroenden för loopen (SOLID) → testbar utan tid/nät. */
+export interface LoopDeps {
+  check: (cfg: UpdateConfig) => Promise<void>;
+  sleep: (ms: number, signal: AbortSignal) => Promise<void>;
+}
+
+const defaultLoopDeps: LoopDeps = { check: (cfg) => checkOnce(cfg), sleep };
+
 /** Loopa för evigt: kolla, sov. Anropas som bakgrunds-task. */
-export async function runUpdateLoop(cfg: UpdateConfig, signal: AbortSignal): Promise<void> {
-  await sleep(cfg.initialDelayMs, signal);
+export async function runUpdateLoop(
+  cfg: UpdateConfig,
+  signal: AbortSignal,
+  deps: LoopDeps = defaultLoopDeps,
+): Promise<void> {
+  await deps.sleep(cfg.initialDelayMs, signal);
   while (!signal.aborted) {
     try {
-      await checkOnce(cfg);
+      await deps.check(cfg);
     } catch (err) {
       log(`update check failed: ${err instanceof Error ? err.message : String(err)}`);
     }
-    await sleep(cfg.checkIntervalMs, signal);
+    await deps.sleep(cfg.checkIntervalMs, signal);
   }
 }
 
+/** Injicerbara beroenden för en kontroll → testbar utan nät/fs. */
+export interface CheckDeps {
+  fetchReleases: (repo: string) => Promise<GithubRelease[]>;
+  replace: (url: string, targetPath: string) => Promise<void>;
+  targetPath: string;
+  asset: string;
+}
+
+function defaultCheckDeps(): CheckDeps {
+  return { fetchReleases, replace: downloadAndReplace, targetPath: process.execPath, asset: assetName() };
+}
+
 /** En synkron kontroll. Returnerar utan att kasta om allt är OK. */
-export async function checkOnce(cfg: UpdateConfig): Promise<void> {
-  const releases = await fetchReleases(cfg.repo);
+export async function checkOnce(cfg: UpdateConfig, deps: CheckDeps = defaultCheckDeps()): Promise<void> {
+  const releases = await deps.fetchReleases(cfg.repo);
   const latest = pickLatest(releases, cfg.tagFilter, cfg.currentVersion);
   if (latest === null) {
     log(`already up to date (${cfg.currentVersion})`);
     return;
   }
-  const asset = latest.assets.find((a) => a.name === assetName());
+  const asset = latest.assets.find((a) => a.name === deps.asset);
   if (asset === undefined) {
-    log(`no asset ${assetName()} in ${latest.tag_name}`);
+    log(`no asset ${deps.asset} in ${latest.tag_name}`);
     return;
   }
   log(`updating ${cfg.currentVersion} → ${latest.tag_name}`);
-  await downloadAndReplace(asset.browser_download_url, process.execPath);
+  await deps.replace(asset.browser_download_url, deps.targetPath);
   cfg.onUpdated(latest.tag_name);
 }
 
@@ -106,7 +130,7 @@ export function pickLatest(
  * Windows flyttas den gamla undan först (kan inte skrivas över medan den
  * körs).
  */
-async function downloadAndReplace(url: string, targetPath: string): Promise<void> {
+export async function downloadAndReplace(url: string, targetPath: string): Promise<void> {
   const tmpPath = `${targetPath}.new`;
   const resp = await fetch(url);
   if (resp.status >= 400) throw new Error(`download HTTP ${resp.status}`);

--- a/helper-app/test/compose-mail.test.ts
+++ b/helper-app/test/compose-mail.test.ts
@@ -2,8 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import { handleComposeMail, type ComposeMailDeps } from "../src/compose-mail.ts";
 import type { ComposeMailOpts } from "../src/platform/mail.ts";
-
-const BASE = "http://127.0.0.1:48761";
+import { jsonRequest, mkRequest } from "./helpers.ts";
 
 function deps(capture?: (o: ComposeMailOpts) => void): ComposeMailDeps {
   return {
@@ -14,7 +13,7 @@ function deps(capture?: (o: ComposeMailOpts) => void): ComposeMailDeps {
 }
 
 function mailReq(body: unknown): Request {
-  return new Request(`${BASE}/compose-mail`, { method: "POST", body: JSON.stringify(body) });
+  return jsonRequest("/compose-mail", body);
 }
 
 const validContent = Buffer.from("hello").toString("base64");
@@ -33,7 +32,7 @@ describe("handleComposeMail", () => {
   });
 
   test("avvisar GET", async () => {
-    const res = await handleComposeMail(new Request(`${BASE}/compose-mail`), deps());
+    const res = await handleComposeMail(mkRequest("/compose-mail"), deps());
     expect(res.status).toBe(405);
   });
 
@@ -56,5 +55,33 @@ describe("handleComposeMail", () => {
       deps(),
     );
     expect(res.status).toBe(400);
+  });
+
+  test("500 när skrivning av bilaga misslyckas", async () => {
+    const failing: ComposeMailDeps = {
+      compose: async () => undefined,
+      makeSessionDir: async () => "/tmp/ava-mail",
+      writeAttachment: async () => { throw new Error("disk full"); },
+    };
+    const res = await handleComposeMail(
+      mailReq({ fileName: "x.html", contentBase64: validContent, subject: "s", body: "b" }),
+      failing,
+    );
+    expect(res.status).toBe(500);
+    expect(await res.text()).toContain("write failed");
+  });
+
+  test("500 när mail-appen inte kan öppnas", async () => {
+    const failing: ComposeMailDeps = {
+      compose: async () => { throw new Error("no mail app"); },
+      makeSessionDir: async () => "/tmp/ava-mail",
+      writeAttachment: async () => undefined,
+    };
+    const res = await handleComposeMail(
+      mailReq({ fileName: "x.html", contentBase64: validContent, subject: "s", body: "b" }),
+      failing,
+    );
+    expect(res.status).toBe(500);
+    expect(await res.text()).toContain("compose-mail failed");
   });
 });

--- a/helper-app/test/helpers.ts
+++ b/helper-app/test/helpers.ts
@@ -1,0 +1,51 @@
+/**
+ * Delade test-fixturer (DRY) — request-byggare + en deterministisk
+ * fejk-klocka för tidsberoende loop-tester.
+ */
+
+import { HELPER_BASE } from "@/lib/shared/helper/protocol";
+
+export const BASE = HELPER_BASE;
+
+/** Bygg en Request mot helpern. */
+export function mkRequest(path: string, init: RequestInit = {}): Request {
+  return new Request(`${BASE}${path}`, init);
+}
+
+/** Bygg en JSON-POST (default-metod POST). */
+export function jsonRequest(path: string, body: unknown, method = "POST"): Request {
+  return mkRequest(path, { method, body: JSON.stringify(body) });
+}
+
+/**
+ * Deterministisk klocka: `now()` returnerar ett fast värde som bara rör
+ * sig när testet anropar `advance(ms)`. Används för watch-/loop-tester.
+ */
+export interface FakeClock {
+  now: () => number;
+  advance: (ms: number) => void;
+}
+
+export function fakeClock(start = 0): FakeClock {
+  let t = start;
+  return {
+    now: () => t,
+    advance: (ms: number) => {
+      t += ms;
+    },
+  };
+}
+
+/**
+ * Await ett promise som FÖRVÄNTAS rejecta och returnera felet. Renare än
+ * `expect(p).rejects` (vars matcher-kedja typas som icke-thenable i
+ * bun-types → krockar med await-thenable-regeln) och DRY över suiten.
+ */
+export async function expectRejection(p: Promise<unknown>): Promise<unknown> {
+  try {
+    await p;
+  } catch (err) {
+    return err;
+  }
+  throw new Error("förväntade att promiset skulle rejecta, men det resolvade");
+}

--- a/helper-app/test/http.test.ts
+++ b/helper-app/test/http.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+
+import { json, parseJsonBody, textError } from "../src/http.ts";
+import { jsonRequest, mkRequest } from "./helpers.ts";
+
+describe("textError", () => {
+  test("sätter status + text/plain + nyrad", async () => {
+    const res = textError(404, "not found");
+    expect(res.status).toBe(404);
+    expect(res.headers.get("Content-Type")).toBe("text/plain; charset=utf-8");
+    expect(await res.text()).toBe("not found\n");
+  });
+});
+
+describe("json", () => {
+  test("serialiserar body + default 200", async () => {
+    const res = json({ a: 1 });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/json");
+    expect(await res.json()).toEqual({ a: 1 });
+  });
+  test("respekterar explicit status", () => {
+    expect(json({}, 202).status).toBe(202);
+  });
+});
+
+describe("parseJsonBody", () => {
+  test("parsar giltig JSON", async () => {
+    const body = await parseJsonBody<{ x: number }>(jsonRequest("/x", { x: 5 }));
+    expect(body).toEqual({ x: 5 });
+  });
+  test("null vid ogiltig JSON", async () => {
+    const body = await parseJsonBody(mkRequest("/x", { method: "POST", body: "not-json" }));
+    expect(body).toBeNull();
+  });
+});

--- a/helper-app/test/io.test.ts
+++ b/helper-app/test/io.test.ts
@@ -1,0 +1,99 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { downloadTo, uploadFile } from "../src/open.ts";
+import { expectRejection } from "./helpers.ts";
+
+const dirs: string[] = [];
+afterAll(async () => {
+  await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true })));
+});
+
+async function tmpFile(name: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "ava-io-"));
+  dirs.push(dir);
+  return join(dir, name);
+}
+
+describe("downloadTo (integration)", () => {
+  test("laddar ner body till fil", async () => {
+    const server = Bun.serve({ port: 0, fetch: () => new Response("PDF-bytes") });
+    try {
+      const path = await tmpFile("a.pdf");
+      await downloadTo(path, `http://127.0.0.1:${server.port}/f`);
+      expect(await readFile(path, "utf8")).toBe("PDF-bytes");
+    } finally {
+      void server.stop(true);
+    }
+  });
+
+  test("vidarebefordrar Authorization-header", async () => {
+    const cap: { auth: string | null } = { auth: null };
+    const server = Bun.serve({
+      port: 0,
+      fetch: (req) => {
+        cap.auth = req.headers.get("Authorization");
+        return new Response("ok");
+      },
+    });
+    try {
+      await downloadTo(await tmpFile("b.txt"), `http://127.0.0.1:${server.port}/f`, "Bearer tok");
+      expect(cap.auth).toBe("Bearer tok");
+    } finally {
+      void server.stop(true);
+    }
+  });
+
+  test("HTTP >= 400 → kastar", async () => {
+    const server = Bun.serve({ port: 0, fetch: () => new Response("no", { status: 404 }) });
+    try {
+      const err = await expectRejection(downloadTo(await tmpFile("c.txt"), `http://127.0.0.1:${server.port}/f`));
+      expect(String(err)).toContain("HTTP 404");
+    } finally {
+      void server.stop(true);
+    }
+  });
+});
+
+describe("uploadFile (integration)", () => {
+  test("PUT:ar fil-bytes med octet-stream + auth", async () => {
+    const cap: { body: string; ctype: string | null; auth: string | null } = {
+      body: "",
+      ctype: null,
+      auth: null,
+    };
+    const server = Bun.serve({
+      port: 0,
+      fetch: async (req) => {
+        cap.body = await req.text();
+        cap.ctype = req.headers.get("Content-Type");
+        cap.auth = req.headers.get("Authorization");
+        return new Response(null, { status: 200 });
+      },
+    });
+    try {
+      const path = await tmpFile("upload.bin");
+      await writeFile(path, "ÄNDRADE bytes");
+      await uploadFile(path, `http://127.0.0.1:${server.port}/u`, "Bearer up");
+      expect(cap.body).toBe("ÄNDRADE bytes");
+      expect(cap.ctype).toBe("application/octet-stream");
+      expect(cap.auth).toBe("Bearer up");
+    } finally {
+      void server.stop(true);
+    }
+  });
+
+  test("upload HTTP >= 400 → kastar", async () => {
+    const server = Bun.serve({ port: 0, fetch: () => new Response("err", { status: 500 }) });
+    try {
+      const path = await tmpFile("u2.bin");
+      await writeFile(path, "x");
+      const err = await expectRejection(uploadFile(path, `http://127.0.0.1:${server.port}/u`, undefined));
+      expect(String(err)).toContain("upload HTTP 500");
+    } finally {
+      void server.stop(true);
+    }
+  });
+});

--- a/helper-app/test/log.test.ts
+++ b/helper-app/test/log.test.ts
@@ -1,0 +1,55 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { initLog, log, resolveLogDir } from "../src/log.ts";
+
+describe("resolveLogDir", () => {
+  test("macOS → ~/Library/Logs/AVA", () => {
+    expect(resolveLogDir("darwin", "/Users/u")).toBe("/Users/u/Library/Logs/AVA");
+  });
+  test("Windows → %LOCALAPPDATA%\\AVA\\Logs", () => {
+    expect(resolveLogDir("windows", "C:\\Users\\u", "C:\\Users\\u\\AppData\\Local")).toBe(
+      "C:\\Users\\u\\AppData\\Local/AVA/Logs",
+    );
+  });
+  test("Windows utan LOCALAPPDATA faller tillbaka på home", () => {
+    expect(resolveLogDir("windows", "/home/u")).toBe("/home/u/AVA/Logs");
+  });
+  test("Linux/övrigt → ~/.local/state/AVA", () => {
+    expect(resolveLogDir("linux", "/home/u")).toBe("/home/u/.local/state/AVA");
+    expect(resolveLogDir("other", "/home/u")).toBe("/home/u/.local/state/AVA");
+  });
+  test("tom home → null", () => {
+    expect(resolveLogDir("darwin", "")).toBeNull();
+  });
+});
+
+describe("initLog + log", () => {
+  const dirs: string[] = [];
+  afterAll(async () => {
+    await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true })));
+  });
+
+  test("skapar helper.log och appendar rader", async () => {
+    const base = await mkdtemp(join(tmpdir(), "ava-log-"));
+    dirs.push(base);
+    const logDir = join(base, "logs");
+
+    const path = initLog(logDir);
+    expect(path).toBe(join(logDir, "helper.log"));
+
+    log("rad-ett");
+    log("rad-två");
+    const content = await readFile(path as string, "utf8");
+    expect(content).toContain("rad-ett");
+    expect(content).toContain("rad-två");
+    // ISO-tidsstämpel-prefix
+    expect(content).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test("null-dir → ingen fil, ingen krasch", () => {
+    expect(initLog(null)).toBeNull();
+  });
+});

--- a/helper-app/test/mail.test.ts
+++ b/helper-app/test/mail.test.ts
@@ -1,6 +1,31 @@
 import { describe, expect, test } from "bun:test";
 
-import { applescriptQuote, escapePs, escapeUrl } from "../src/platform/mail.ts";
+import {
+  applescriptQuote,
+  escapePs,
+  escapeUrl,
+  linuxArgs,
+  macScript,
+  macToRecipient,
+  mailCommand,
+  windowsFallbackCommand,
+  windowsScript,
+  type ComposeMailOpts,
+} from "../src/platform/mail.ts";
+
+const opts: ComposeMailOpts = {
+  to: "a@b.se",
+  subject: "Hej",
+  body: "Brödtext",
+  attachmentPath: "/tmp/brev.html",
+};
+
+// Variant utan `to` (exactOptionalPropertyTypes tillåter inte to: undefined).
+const optsNoTo: ComposeMailOpts = {
+  subject: "Hej",
+  body: "Brödtext",
+  attachmentPath: "/tmp/brev.html",
+};
 
 describe("applescriptQuote", () => {
   test("escapar backslash + citationstecken", () => {
@@ -22,5 +47,74 @@ describe("escapeUrl", () => {
   test("escapar mellanslag + radbryt", () => {
     expect(escapeUrl("hej och hå")).toBe("hej%20och%20hå");
     expect(escapeUrl("rad1\nrad2")).toBe("rad1%0Arad2");
+  });
+});
+
+describe("macToRecipient", () => {
+  test("tom adress → tom sträng", () => {
+    expect(macToRecipient("")).toBe("");
+  });
+  test("adress → AppleScript-rad med escapad address", () => {
+    expect(macToRecipient("a@b.se")).toContain('address:"a@b.se"');
+  });
+});
+
+describe("linuxArgs", () => {
+  test("inkluderar attach/subject/body + mottagare sist", () => {
+    expect(linuxArgs(opts)).toEqual([
+      "--attach", "/tmp/brev.html", "--subject", "Hej", "--body", "Brödtext", "a@b.se",
+    ]);
+  });
+  test("utelämnar mottagare när to saknas", () => {
+    expect(linuxArgs(optsNoTo)).not.toContain("a@b.se");
+  });
+});
+
+describe("windowsScript", () => {
+  test("bygger Outlook-COM-script med escapade fält", () => {
+    const s = windowsScript({ ...opts, body: "it's" });
+    expect(s).toContain("New-Object -ComObject Outlook.Application");
+    expect(s).toContain("$mail.Attachments.Add('/tmp/brev.html')");
+    expect(s).toContain("$mail.Body = 'it''s'");
+  });
+});
+
+describe("macScript", () => {
+  test("innehåller subject, body och attachment-path", () => {
+    const s = macScript(opts);
+    expect(s).toContain('subject:"Hej"');
+    expect(s).toContain('content:"Brödtext"');
+    expect(s).toContain("POSIX file \"/tmp/brev.html\"");
+  });
+});
+
+describe("mailCommand", () => {
+  test("macOS → osascript -e <script>", () => {
+    const c = mailCommand("darwin", opts);
+    expect(c.cmd).toBe("osascript");
+    expect(c.args[0]).toBe("-e");
+    expect(c.args[1]).toContain("tell application \"Mail\"");
+  });
+  test("Linux → xdg-email", () => {
+    expect(mailCommand("linux", opts).cmd).toBe("xdg-email");
+  });
+  test("Windows → powershell", () => {
+    const c = mailCommand("windows", opts);
+    expect(c.cmd).toBe("powershell");
+    expect(c.args.slice(0, 2)).toEqual(["-NoProfile", "-Command"]);
+  });
+  test("okänt OS kastar", () => {
+    expect(() => mailCommand("other", opts)).toThrow("unsupported OS: other");
+  });
+});
+
+describe("windowsFallbackCommand", () => {
+  test("mailto via rundll32 med escapade fält", () => {
+    const c = windowsFallbackCommand({ ...opts, subject: "ett mål", body: "rad1\nrad2" });
+    expect(c.cmd).toBe("rundll32");
+    expect(c.args[1]).toBe("mailto:a@b.se?subject=ett%20mål&body=rad1%0Arad2");
+  });
+  test("tom mottagare → mailto: utan adress", () => {
+    expect(windowsFallbackCommand(optsNoTo).args[1]).toStartWith("mailto:?");
   });
 });

--- a/helper-app/test/open-app.test.ts
+++ b/helper-app/test/open-app.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+
+import { openCommand } from "../src/platform/open-app.ts";
+
+describe("openCommand", () => {
+  test("macOS → open", () => {
+    expect(openCommand("darwin", "/tmp/a.pdf")).toEqual({ cmd: "open", args: ["/tmp/a.pdf"] });
+  });
+  test("Linux → xdg-open", () => {
+    expect(openCommand("linux", "/tmp/a.pdf")).toEqual({ cmd: "xdg-open", args: ["/tmp/a.pdf"] });
+  });
+  test("Windows → rundll32 FileProtocolHandler", () => {
+    expect(openCommand("windows", "C:\\a.pdf")).toEqual({
+      cmd: "rundll32",
+      args: ["url.dll,FileProtocolHandler", "C:\\a.pdf"],
+    });
+  });
+  test("okänt OS kastar", () => {
+    expect(() => openCommand("other", "/tmp/a.pdf")).toThrow("unsupported OS: other");
+  });
+});

--- a/helper-app/test/open.test.ts
+++ b/helper-app/test/open.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { handleOpen, type OpenDeps } from "../src/open.ts";
-
-const BASE = "http://127.0.0.1:48761";
+import { jsonRequest } from "./helpers.ts";
 
 interface Recorder {
   downloaded: string[];
@@ -29,7 +28,7 @@ function recorder(overrides: Partial<OpenDeps> = {}): Recorder {
 }
 
 function openReq(body: unknown): Request {
-  return new Request(`${BASE}/open`, { method: "POST", body: JSON.stringify(body) });
+  return jsonRequest("/open", body);
 }
 
 describe("handleOpen", () => {

--- a/helper-app/test/runtime.test.ts
+++ b/helper-app/test/runtime.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+
+import { currentPlatform, platformFrom } from "../src/platform/runtime.ts";
+
+describe("platformFrom", () => {
+  test("normaliserar Node:s plattforms-strängar", () => {
+    expect(platformFrom("darwin")).toBe("darwin");
+    expect(platformFrom("linux")).toBe("linux");
+    expect(platformFrom("win32")).toBe("windows");
+  });
+  test("okänt OS → 'other'", () => {
+    expect(platformFrom("freebsd")).toBe("other");
+    expect(platformFrom("")).toBe("other");
+  });
+});
+
+describe("currentPlatform", () => {
+  test("returnerar en av union-värdena", () => {
+    expect(["darwin", "linux", "windows", "other"]).toContain(currentPlatform());
+  });
+});

--- a/helper-app/test/server.test.ts
+++ b/helper-app/test/server.test.ts
@@ -1,15 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import { createHandler, type ServerDeps } from "../src/server.ts";
-
-const BASE = "http://127.0.0.1:48761";
+import { mkRequest as req } from "./helpers.ts";
 
 function handler(overrides: Partial<ServerDeps> = {}): (req: Request) => Promise<Response> {
   return createHandler({ version: "v1.2.3-test", ...overrides });
-}
-
-function req(path: string, init: RequestInit = {}): Request {
-  return new Request(`${BASE}${path}`, init);
 }
 
 describe("GET /ping", () => {

--- a/helper-app/test/spawn.test.ts
+++ b/helper-app/test/spawn.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+
+import { spawnDetached } from "../src/platform/spawn.ts";
+import { expectRejection } from "./helpers.ts";
+
+describe("spawnDetached", () => {
+  test("resolvar när ett giltigt kommando startat", async () => {
+    // process.execPath = bun-binären; `--version` startar + avslutar direkt.
+    expect(await spawnDetached(process.execPath, ["--version"]).started).toBeUndefined();
+  });
+
+  test("rejectar när programmet inte finns", async () => {
+    const err = await expectRejection(spawnDetached("definitely-not-a-real-binary-xyz123", []).started);
+    expect(err).toBeDefined();
+  });
+});

--- a/helper-app/test/update.test.ts
+++ b/helper-app/test/update.test.ts
@@ -1,6 +1,19 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
+import { chmod, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { assetName, pickLatest } from "../src/update.ts";
+import {
+  assetName,
+  checkOnce,
+  downloadAndReplace,
+  pickLatest,
+  runUpdateLoop,
+  type CheckDeps,
+  type GithubRelease,
+  type UpdateConfig,
+} from "../src/update.ts";
+import { expectRejection } from "./helpers.ts";
 
 interface Rel {
   tag_name: string;
@@ -10,6 +23,10 @@ interface Rel {
 
 function rel(tag: string, draft = false): Rel {
   return { tag_name: tag, draft, assets: [] };
+}
+
+function relWithAsset(tag: string, assetNameStr: string, url: string): GithubRelease {
+  return { tag_name: tag, draft: false, assets: [{ name: assetNameStr, browser_download_url: url }] };
 }
 
 describe("assetName", () => {
@@ -44,5 +61,121 @@ describe("pickLatest", () => {
 
   test("null när inget är nyare", () => {
     expect(pickLatest([rel("helper-v1.0.0")], "helper-", "helper-v1.2.0")).toBeNull();
+  });
+});
+
+interface CheckHarness {
+  cfg: UpdateConfig;
+  deps: CheckDeps;
+  replaced: Array<{ url: string; target: string }>;
+  updated: string[];
+}
+
+function checkHarness(releases: GithubRelease[], asset = "ava-helper-test"): CheckHarness {
+  const replaced: CheckHarness["replaced"] = [];
+  const updated: string[] = [];
+  return {
+    replaced,
+    updated,
+    deps: {
+      fetchReleases: async () => releases,
+      replace: async (url, target) => { replaced.push({ url, target }); },
+      targetPath: "/bin/ava-helper",
+      asset,
+    },
+    cfg: {
+      currentVersion: "helper-v1.0.0",
+      repo: "o/r",
+      tagFilter: "helper-",
+      checkIntervalMs: 0,
+      initialDelayMs: 0,
+      onUpdated: (v) => updated.push(v),
+    },
+  };
+}
+
+describe("checkOnce", () => {
+  test("ingen nyare release → varken replace eller onUpdated", async () => {
+    const h = checkHarness([relWithAsset("helper-v1.0.0", "ava-helper-test", "http://x")]);
+    await checkOnce(h.cfg, h.deps);
+    expect(h.replaced).toHaveLength(0);
+    expect(h.updated).toHaveLength(0);
+  });
+
+  test("nyare + matchande asset → replace(url,target) + onUpdated(tag)", async () => {
+    const h = checkHarness([relWithAsset("helper-v1.5.0", "ava-helper-test", "http://dl/bin")]);
+    await checkOnce(h.cfg, h.deps);
+    expect(h.replaced).toEqual([{ url: "http://dl/bin", target: "/bin/ava-helper" }]);
+    expect(h.updated).toEqual(["helper-v1.5.0"]);
+  });
+
+  test("nyare men inget matchande asset → ingen replace/onUpdated", async () => {
+    const h = checkHarness([relWithAsset("helper-v1.5.0", "ava-helper-annat-os", "http://x")]);
+    await checkOnce(h.cfg, h.deps);
+    expect(h.replaced).toHaveLength(0);
+    expect(h.updated).toHaveLength(0);
+  });
+});
+
+describe("runUpdateLoop", () => {
+  test("kör check tills signalen abortas", async () => {
+    const ctrl = new AbortController();
+    let checks = 0;
+    const cfg = checkHarness([]).cfg;
+    await runUpdateLoop(cfg, ctrl.signal, {
+      check: async () => { checks++; ctrl.abort(); },
+      sleep: async () => undefined,
+    });
+    expect(checks).toBe(1);
+  });
+
+  test("fångar fel från check och fortsätter loopa", async () => {
+    const ctrl = new AbortController();
+    let n = 0;
+    const cfg = checkHarness([]).cfg;
+    await runUpdateLoop(cfg, ctrl.signal, {
+      check: async () => {
+        n++;
+        if (n === 1) throw new Error("transient");
+        ctrl.abort();
+      },
+      sleep: async () => undefined,
+    });
+    expect(n).toBe(2); // felet fångades → loopen körde check en gång till
+  });
+});
+
+describe("downloadAndReplace (integration)", () => {
+  const dirs: string[] = [];
+  afterAll(async () => {
+    await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true })));
+  });
+
+  test("laddar ner ny binär och byter ut målet + sätter exec-bit", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ava-upd-"));
+    dirs.push(dir);
+    const target = join(dir, "ava-helper");
+    await writeFile(target, "GAMMAL BINÄR");
+    await chmod(target, 0o644);
+
+    const server = Bun.serve({ port: 0, fetch: () => new Response("NY BINÄR v2") });
+    try {
+      await downloadAndReplace(`http://127.0.0.1:${server.port}/bin`, target);
+      expect(await readFile(target, "utf8")).toBe("NY BINÄR v2");
+      const mode = (await stat(target)).mode & 0o777;
+      expect(mode & 0o100).toBe(0o100); // owner-exec satt
+    } finally {
+      void server.stop(true);
+    }
+  });
+
+  test("HTTP-fel → kastar", async () => {
+    const server = Bun.serve({ port: 0, fetch: () => new Response("nope", { status: 500 }) });
+    try {
+      const err = await expectRejection(downloadAndReplace(`http://127.0.0.1:${server.port}/x`, "/tmp/whatever"));
+      expect(String(err)).toContain("download HTTP 500");
+    } finally {
+      void server.stop(true);
+    }
   });
 });

--- a/helper-app/test/watch.test.ts
+++ b/helper-app/test/watch.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+
+import { runWatch, type WatchDeps } from "../src/open.ts";
+import { fakeClock } from "./helpers.ts";
+
+interface Harness {
+  deps: WatchDeps;
+  uploads: Array<{ path: string; url: string; auth: string | undefined }>;
+}
+
+/**
+ * Bygg deterministiska watch-deps: `mtimes` matas ut i tur och ordning
+ * (initial stat först), klockan rör sig `stepMs` per sleep. `failUpload`
+ * gör att varje upload kastar.
+ */
+function harness(mtimes: Array<number | null>, stepMs: number, failUpload = false): Harness {
+  const clock = fakeClock(1000);
+  const uploads: Harness["uploads"] = [];
+  let i = 0;
+  const deps: WatchDeps = {
+    statMtime: async () => (i < mtimes.length ? mtimes[i++]! : mtimes[mtimes.length - 1]!),
+    upload: async (path, url, auth) => {
+      uploads.push({ path, url, auth });
+      if (failUpload) throw new Error("upload boom");
+    },
+    sleep: async () => clock.advance(stepMs),
+    now: clock.now,
+  };
+  return { deps, uploads };
+}
+
+describe("runWatch", () => {
+  test("ingen ändring → ingen upload, stannar vid timeout", async () => {
+    const h = harness([100, 100, 100, 100], 500);
+    await runWatch("/f", "http://up", undefined, 1000, h.deps);
+    expect(h.uploads).toHaveLength(0);
+  });
+
+  test("upptäckt ändring → laddar upp en gång + förlänger deadline", async () => {
+    // initial 100, oförändrad, sedan 200 (save). timeout 1500, steg 500.
+    const h = harness([100, 100, 200, 200, 200, 200, 200, 200], 500);
+    await runWatch("/doc.pdf", "http://up", "Bearer x", 1500, h.deps);
+    expect(h.uploads).toHaveLength(1);
+    expect(h.uploads[0]).toEqual({ path: "/doc.pdf", url: "http://up", auth: "Bearer x" });
+  });
+
+  test("två separata sparningar → två uploads", async () => {
+    const h = harness([100, 200, 300, 300, 300, 300], 400);
+    await runWatch("/f", "http://up", undefined, 2000, h.deps);
+    expect(h.uploads).toHaveLength(2);
+  });
+
+  test("upload-fel kraschar inte loopen", async () => {
+    const h = harness([100, 200, 200, 200], 500, true);
+    await runWatch("/f", "http://up", undefined, 1000, h.deps);
+    expect(h.uploads.length).toBeGreaterThanOrEqual(1); // försökte, fångade felet
+  });
+
+  test("filen borta vid start (mtime 0) → returnerar utan watch", async () => {
+    const h = harness([null], 500);
+    await runWatch("/gone", "http://up", undefined, 1000, h.deps);
+    expect(h.uploads).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #96. Höjer helper-appens testtäckning **~52% → ~93% rader** (49% → 85% funktioner), **38 → 90 tester**, genom SOLID-refaktorering för testbarhet (inget beteende ändrat) + DRY:ad testsvit + en coverage-ratchet.

## SOLID — inversion of control
IO-tung logik tar nu injicerbara beroenden så den kan enhetstestas deterministiskt utan riktig tid/nät/fs/spawn:
- **`open.ts`**: watch-loopen tar `WatchDeps` (stat/upload/sleep/now) → testas med fejk-klocka (upptäcker save, förlänger deadline, timeout, upload-fel, fil borta). `downloadTo`/`uploadFile` exporterade → integrationstest mot `Bun.serve`.
- **`update.ts`**: `checkOnce` tar `CheckDeps` (fetchReleases/replace), `runUpdateLoop` tar `LoopDeps` → orkestrering testas utan GitHub/binärbyte (up-to-date, asset-match, ingen asset, fel-fångst). `downloadAndReplace` integrationstestas (byter binär + exec-bit).
- **`platform/`**: rena kommando-byggare (`openCommand`, `mailCommand`, `macScript`, `linuxArgs`, `windowsScript`, `windowsFallbackCommand`) brutna ut ur spawn-stigen → testas per OS utan att starta processer. Delad `Command`-typ.
- **`runtime.ts`**: ren `platformFrom(p)`. **`log.ts`**: ren `resolveLogDir(platform, home, localAppData)` + `initLog(dir?)` → testbar utan att röra riktig loggkatalog.

## DRY
`test/helpers.ts` (`mkRequest`/`jsonRequest`/`fakeClock`/`expectRejection`), återanvänd av alla sviter; befintliga tester (server/open/compose-mail) portade till dem.

## Coverage-grind (ratchet)
`bunfig.toml`: `coverage = true` + `coverageThreshold { line = 0.90, function = 0.82 }`, förankrat strax under nuvarande (rader 92.85 / funktioner 85.01). Mäter bara helperns egen kod (exkluderar test-fixturer + det delade protokollet som täcks av repots vitest-svit). `helper-ci.yml` kör `bun test` → faller om täckningen sjunker.

## Nya/utökade sviter
`runtime`, `open-app`, `http`, `log`, `watch`, `spawn`, `io` + utökade `mail`/`update`/`compose-mail`. Kvarvarande otäckta rader = tunna wrappers kring riktig OS-/nät-IO (spawn, fetch, timers) vars rena logik redan är testad.

## Verifierat lokalt
`bun test` (90 gröna, coverage-grind passerar), helper `typecheck`, root `lint` (täcker helper-app), root `typecheck` — alla gröna. Kompilerad binär svarar på `/ping`. Endast `helper-app/` ändrat.