### PR TITLE
feat(helper): https via lokal CA — cert-infra + Bun.serve TLS (#102)

### DIFF
--- a/helper-app/bun.lock
+++ b/helper-app/bun.lock
@@ -4,7 +4,11 @@
   "workspaces": {
     "": {
       "name": "@ava/helper",
+      "dependencies": {
+        "node-forge": "^1.4.0",
+      },
       "devDependencies": {
+        "@types/node-forge": "^1.3.14",
         "bun-types": "^1.3.14",
       },
     },
@@ -12,7 +16,11 @@
   "packages": {
     "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
 
+    "@types/node-forge": ["@types/node-forge@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "node-forge": ["node-forge@1.4.0", "", {}, "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ=="],
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
   }

--- a/helper-app/package.json
+++ b/helper-app/package.json
@@ -11,6 +11,10 @@
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "devDependencies": {
+    "@types/node-forge": "^1.3.14",
     "bun-types": "^1.3.14"
+  },
+  "dependencies": {
+    "node-forge": "^1.4.0"
   }
 }

--- a/helper-app/src/main.ts
+++ b/helper-app/src/main.ts
@@ -14,10 +14,14 @@
  * delar protokoll-typer med webbappen via @/lib/shared/helper/protocol (#78).
  */
 
-import { HELPER_PORT } from "@/lib/shared/helper/protocol";
+import { join } from "node:path";
 
+import { HELPER_HTTPS_PORT, HELPER_PORT } from "@/lib/shared/helper/protocol";
+
+import { dataDir } from "./paths.ts";
 import { initLog, log } from "./log.ts";
 import { createHandler } from "./server.ts";
+import { loadOrCreateTls } from "./tls/certs.ts";
 import { checkOnce, runUpdateLoop, type UpdateConfig } from "./update.ts";
 import { VERSION } from "./version.ts";
 
@@ -31,6 +35,40 @@ function extraOrigins(): string[] {
 function listenPort(): number {
   const p = Number(process.env.AVA_HELPER_PORT);
   return Number.isInteger(p) && p > 0 ? p : HELPER_PORT;
+}
+
+function httpsPort(): number {
+  const p = Number(process.env.AVA_HELPER_HTTPS_PORT);
+  return Number.isInteger(p) && p > 0 ? p : HELPER_HTTPS_PORT;
+}
+
+type Handler = (req: Request) => Promise<Response>;
+
+/**
+ * Starta HTTPS parallellt med HTTP (ADR 0006). Genererar/laddar lokalt TLS-
+ * material i data-dir. Returnerar undefined om data-dir saknas eller TLS
+ * inte kan startas — HTTP fortsätter ändå (Chromium/Firefox behöver inte HTTPS).
+ */
+function startHttpsServer(handler: Handler): ReturnType<typeof Bun.serve> | undefined {
+  const dir = dataDir();
+  if (dir === null) {
+    log("ingen data-dir → hoppar över HTTPS (endast HTTP)");
+    return undefined;
+  }
+  try {
+    const tls = loadOrCreateTls(join(dir, "tls"));
+    const server = Bun.serve({
+      port: httpsPort(),
+      hostname: "127.0.0.1",
+      tls: { cert: tls.leaf.cert, key: tls.leaf.key },
+      fetch: handler,
+    });
+    log(`ava-helper HTTPS på localhost:${httpsPort()}`);
+    return server;
+  } catch (err) {
+    log(`HTTPS-start misslyckades (fortsätter med HTTP): ${String(err)}`);
+    return undefined;
+  }
 }
 
 function buildUpdateConfig(): UpdateConfig {
@@ -61,21 +99,20 @@ function main(): void {
   const abort = new AbortController();
   void runUpdateLoop(updateCfg, abort.signal);
 
-  const server = Bun.serve({
-    port,
-    hostname: "127.0.0.1",
-    fetch: createHandler({
-      version: VERSION,
-      extraOrigins: extraOrigins(),
-      onCheckUpdate: () => { void checkOnce(updateCfg).catch((err) => log(`check-update: ${String(err)}`)); },
-    }),
+  const handler = createHandler({
+    version: VERSION,
+    extraOrigins: extraOrigins(),
+    onCheckUpdate: () => { void checkOnce(updateCfg).catch((err) => log(`check-update: ${String(err)}`)); },
   });
+
+  const httpServer = Bun.serve({ port, hostname: "127.0.0.1", fetch: handler });
+  const httpsServer = startHttpsServer(handler);
 
   for (const sig of ["SIGTERM", "SIGINT"] as const) {
     process.on(sig, () => {
       log(`${sig} — avslutar`);
       abort.abort();
-      void server.stop().then(() => process.exit(0));
+      void Promise.all([httpServer.stop(), httpsServer?.stop()]).then(() => process.exit(0));
       setTimeout(() => process.exit(0), SHUTDOWN_TIMEOUT_MS).unref();
     });
   }

--- a/helper-app/src/paths.ts
+++ b/helper-app/src/paths.ts
@@ -1,0 +1,37 @@
+/**
+ * Per-OS data-katalog (skild från loggkatalogen). Här lagras TLS-material
+ * (lokal CA + leaf, #102). Ren `resolveDataDir` → testbar utan env/fs.
+ *
+ *   - macOS:   ~/Library/Application Support/AVA
+ *   - Windows: %LOCALAPPDATA%\AVA
+ *   - Linux:   $XDG_DATA_HOME/AVA  (annars ~/.local/share/AVA)
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { currentPlatform, type Platform } from "./platform/runtime.ts";
+
+export interface DataDirEnv {
+  localAppData?: string | undefined;
+  xdgDataHome?: string | undefined;
+}
+
+export function resolveDataDir(platform: Platform, home: string, env: DataDirEnv = {}): string | null {
+  if (home === "") return null;
+  switch (platform) {
+    case "darwin":
+      return join(home, "Library", "Application Support", "AVA");
+    case "windows":
+      return join(env.localAppData ?? home, "AVA");
+    default:
+      return join(env.xdgDataHome && env.xdgDataHome !== "" ? env.xdgDataHome : join(home, ".local", "share"), "AVA");
+  }
+}
+
+export function dataDir(): string | null {
+  return resolveDataDir(currentPlatform(), homedir(), {
+    localAppData: process.env.LOCALAPPDATA,
+    xdgDataHome: process.env.XDG_DATA_HOME,
+  });
+}

--- a/helper-app/src/tls/certs.ts
+++ b/helper-app/src/tls/certs.ts
@@ -1,0 +1,181 @@
+/**
+ * Lokal CA + leaf-cert för helper-HTTPS (#102, ADR 0006).
+ *
+ * Nyckel-generering sker med node:crypto (snabb native RSA); cert-bygge +
+ * signering med node-forge (ren JS, ingen system-openssl). CA:n utfärdas
+ * med X.509 Name Constraints begränsade till localhost/127.0.0.1/::1 → en
+ * läckt CA-nyckel kan inte förfalska cert för riktiga domäner.
+ *
+ * Material lagras i data-dir; nycklar med 0600. Idempotent: återanvänder
+ * giltig CA + leaf, återutfärdar leaf när den närmar sig utgång.
+ */
+
+import { generateKeyPairSync, randomBytes } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import forge from "node-forge";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const CA_VALID_MS = 3650 * DAY_MS; // ~10 år
+const LEAF_VALID_MS = 365 * DAY_MS;
+const LEAF_RENEW_BEFORE_MS = 30 * DAY_MS;
+const CLOCK_SKEW_MS = 60 * 1000;
+
+export interface CertPair {
+  /** PEM. */
+  cert: string;
+  /** PEM (PKCS#8). */
+  key: string;
+}
+export interface TlsMaterial {
+  ca: CertPair;
+  leaf: CertPair;
+}
+
+function newKey(): { priv: forge.pki.rsa.PrivateKey; pub: forge.pki.rsa.PublicKey; keyPem: string } {
+  const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+  return {
+    priv: forge.pki.privateKeyFromPem(privateKey),
+    pub: forge.pki.publicKeyFromPem(publicKey),
+    keyPem: privateKey,
+  };
+}
+
+function serial(): string {
+  // Inled med "00" så serien tolkas som positiv (icke-negativ INTEGER).
+  return `00${randomBytes(8).toString("hex")}`;
+}
+
+/** GeneralName [2] dNSName (primitiv, IA5String). */
+function dnsName(name: string): forge.asn1.Asn1 {
+  return forge.asn1.create(forge.asn1.Class.CONTEXT_SPECIFIC, 2, false, name);
+}
+
+/** GeneralName [7] iPAddress för Name Constraints: adress-bytes + full mask. */
+function ipNameConstraint(addr: readonly number[]): forge.asn1.Asn1 {
+  const bytes = [...addr, ...addr.map(() => 0xff)];
+  return forge.asn1.create(forge.asn1.Class.CONTEXT_SPECIFIC, 7, false, String.fromCharCode(...bytes));
+}
+
+function subtree(generalName: forge.asn1.Asn1): forge.asn1.Asn1 {
+  return forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.SEQUENCE, true, [generalName]);
+}
+
+const LOOPBACK_V6 = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
+
+/** X.509 Name Constraints: tillåt ENDAST localhost / 127.0.0.1 / ::1. */
+function nameConstraintsExtension(): { id: string; critical: boolean; value: string } {
+  const permitted = forge.asn1.create(forge.asn1.Class.CONTEXT_SPECIFIC, 0, true, [
+    subtree(dnsName("localhost")),
+    subtree(ipNameConstraint([127, 0, 0, 1])),
+    subtree(ipNameConstraint(LOOPBACK_V6)),
+  ]);
+  const nc = forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.SEQUENCE, true, [permitted]);
+  return { id: "2.5.29.30", critical: true, value: forge.asn1.toDer(nc).getBytes() };
+}
+
+const CA_ATTRS = [{ name: "commonName", value: "AVA Helper Local CA" }];
+
+/** Generera en self-signed, name-constrained lokal CA. */
+export function generateCa(now: Date = new Date()): CertPair {
+  const { priv, pub, keyPem } = newKey();
+  const cert = forge.pki.createCertificate();
+  cert.publicKey = pub;
+  cert.serialNumber = serial();
+  cert.validity.notBefore = new Date(now.getTime() - CLOCK_SKEW_MS);
+  cert.validity.notAfter = new Date(now.getTime() + CA_VALID_MS);
+  cert.setSubject(CA_ATTRS);
+  cert.setIssuer(CA_ATTRS);
+  cert.setExtensions([
+    { name: "basicConstraints", cA: true, critical: true },
+    { name: "keyUsage", keyCertSign: true, cRLSign: true, critical: true },
+    nameConstraintsExtension(),
+  ]);
+  cert.sign(priv, forge.md.sha256.create());
+  return { cert: forge.pki.certificateToPem(cert), key: keyPem };
+}
+
+/** Utfärda ett leaf-cert för localhost/127.0.0.1/::1, signerat av CA:n. */
+export function issueLeaf(ca: CertPair, now: Date = new Date()): CertPair {
+  const caCert = forge.pki.certificateFromPem(ca.cert);
+  const caKey = forge.pki.privateKeyFromPem(ca.key);
+  const { pub, keyPem } = newKey();
+  const cert = forge.pki.createCertificate();
+  cert.publicKey = pub;
+  cert.serialNumber = serial();
+  cert.validity.notBefore = new Date(now.getTime() - CLOCK_SKEW_MS);
+  cert.validity.notAfter = new Date(now.getTime() + LEAF_VALID_MS);
+  cert.setSubject([{ name: "commonName", value: "localhost" }]);
+  cert.setIssuer(caCert.subject.attributes);
+  cert.setExtensions([
+    { name: "basicConstraints", cA: false, critical: true },
+    { name: "keyUsage", digitalSignature: true, keyEncipherment: true, critical: true },
+    { name: "extKeyUsage", serverAuth: true },
+    {
+      name: "subjectAltName",
+      altNames: [
+        { type: 2, value: "localhost" },
+        { type: 7, ip: "127.0.0.1" },
+        { type: 7, ip: "::1" },
+      ],
+    },
+  ]);
+  cert.sign(caKey, forge.md.sha256.create());
+  return { cert: forge.pki.certificateToPem(cert), key: keyPem };
+}
+
+function notAfter(certPem: string): number {
+  return forge.pki.certificateFromPem(certPem).validity.notAfter.getTime();
+}
+
+function leafIssuedBy(leafPem: string, caPem: string): boolean {
+  const leaf = forge.pki.certificateFromPem(leafPem);
+  const ca = forge.pki.certificateFromPem(caPem);
+  return leaf.issuer.hash === ca.subject.hash;
+}
+
+function readPair(certPath: string, keyPath: string): CertPair | null {
+  try {
+    return { cert: readFileSync(certPath, "utf8"), key: readFileSync(keyPath, "utf8") };
+  } catch {
+    return null;
+  }
+}
+
+function writePair(certPath: string, keyPath: string, pair: CertPair): void {
+  writeFileSync(certPath, pair.cert, { mode: 0o644 });
+  writeFileSync(keyPath, pair.key, { mode: 0o600 });
+}
+
+/**
+ * Ladda befintligt TLS-material från `dir`, eller generera + persistera.
+ * CA återanvänds (långlivad); leaf återutfärdas om den saknas, snart går ut,
+ * eller inte längre är signerad av aktuell CA.
+ */
+export function loadOrCreateTls(dir: string, now: Date = new Date()): TlsMaterial {
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const caCertPath = join(dir, "ca.pem");
+  const caKeyPath = join(dir, "ca-key.pem");
+  const leafCertPath = join(dir, "leaf.pem");
+  const leafKeyPath = join(dir, "leaf-key.pem");
+
+  let ca = readPair(caCertPath, caKeyPath);
+  if (ca === null || notAfter(ca.cert) <= now.getTime()) {
+    ca = generateCa(now);
+    writePair(caCertPath, caKeyPath, ca);
+  }
+
+  let leaf = readPair(leafCertPath, leafKeyPath);
+  const stale = leaf !== null && notAfter(leaf.cert) - now.getTime() < LEAF_RENEW_BEFORE_MS;
+  if (leaf === null || stale || !leafIssuedBy(leaf.cert, ca.cert)) {
+    leaf = issueLeaf(ca, now);
+    writePair(leafCertPath, leafKeyPath, leaf);
+  }
+
+  return { ca, leaf };
+}

--- a/helper-app/test/binary.e2e.test.ts
+++ b/helper-app/test/binary.e2e.test.ts
@@ -1,8 +1,7 @@
 /**
- * E2E mot den FAKTISKT shippade artefakten (#99): kompilerar binären med
- * `bun build --compile` och kör den. Källtesterna kör mot TS — det här
- * fångar sådant som bara går sönder i den kompilerade binären (versions-
- * injektion via --define, Bun.serve i compiled-kontext, embedded runtime).
+ * E2E mot den FAKTISKT shippade artefakten (#99, #102): kompilerar binären
+ * med `bun build --compile` och kör den. Verifierar HTTP-API:t OCH att
+ * HTTPS serveras med ett lokalt genererat cert (ADR 0006).
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
@@ -10,12 +9,15 @@ import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { connect } from "node:tls";
 
 import { HELPER_PING_PREFIX } from "@/lib/shared/helper/protocol";
 
 const VERSION = "helper-v9.9.9-e2e";
-const PORT = 48799; // ej default-porten → krockar inte med ev. riktig helper
-const BASE = `http://127.0.0.1:${PORT}`;
+const HTTP_PORT = 48799;
+const HTTPS_PORT = 48798;
+const HTTP_BASE = `http://127.0.0.1:${HTTP_PORT}`;
+const HTTPS_BASE = `https://localhost:${HTTPS_PORT}`;
 
 let dir: string;
 let bin: string;
@@ -24,7 +26,6 @@ let server: ChildProcess | undefined;
 beforeAll(async () => {
   dir = await mkdtemp(join(tmpdir(), "ava-helper-e2e-"));
   bin = join(dir, "ava-helper");
-  // Kompilera för host-plattformen med inbakad version (process.execPath = bun).
   const build = spawnSync(
     process.execPath,
     ["build", "src/main.ts", "--compile", "--define", `__AVA_HELPER_VERSION__="${VERSION}"`, "--outfile", bin],
@@ -33,6 +34,19 @@ beforeAll(async () => {
   if (build.status !== 0) {
     throw new Error(`bun build --compile misslyckades (${build.status}): ${build.stderr ?? ""}`);
   }
+  // Egen HOME/data-dir så cert + logg hamnar i temp (ingen pollution).
+  server = spawn(bin, [], {
+    stdio: "ignore",
+    env: {
+      ...process.env,
+      AVA_HELPER_PORT: String(HTTP_PORT),
+      AVA_HELPER_HTTPS_PORT: String(HTTPS_PORT),
+      HOME: dir,
+      XDG_DATA_HOME: dir,
+      LOCALAPPDATA: dir,
+    },
+  });
+  await waitForHttp();
 }, 60_000);
 
 afterAll(async () => {
@@ -40,11 +54,11 @@ afterAll(async () => {
   await rm(dir, { recursive: true, force: true });
 });
 
-async function waitForReady(timeoutMs = 10_000): Promise<void> {
+async function waitForHttp(timeoutMs = 10_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   for (;;) {
     try {
-      const r = await fetch(`${BASE}/ping`, { signal: AbortSignal.timeout(500) });
+      const r = await fetch(`${HTTP_BASE}/ping`, { signal: AbortSignal.timeout(500) });
       if (r.ok) return;
     } catch {
       /* inte uppe än */
@@ -54,6 +68,22 @@ async function waitForReady(timeoutMs = 10_000): Promise<void> {
   }
 }
 
+/** CN i certet HTTPS-servern presenterar (utan att validera kedjan). */
+function peerCertCommonName(port: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const socket = connect({ host: "localhost", port, servername: "localhost", rejectUnauthorized: false }, () => {
+      const subject: unknown = socket.getPeerCertificate().subject;
+      socket.end();
+      const cn = subject !== null && typeof subject === "object" && "CN" in subject
+        ? String((subject as { CN?: unknown }).CN ?? "")
+        : "";
+      resolve(cn);
+    });
+    socket.setTimeout(5_000, () => socket.destroy(new Error("TLS-timeout")));
+    socket.on("error", reject);
+  });
+}
+
 describe("kompilerad binär (--compile)", () => {
   test("--version skriver ut den inbakade versionen", () => {
     const r = spawnSync(bin, ["--version"], { encoding: "utf8" });
@@ -61,25 +91,33 @@ describe("kompilerad binär (--compile)", () => {
     expect(r.stdout.trim()).toBe(VERSION);
   });
 
-  test("startar och serverar /ping, /version, CORS och /check-update", async () => {
-    server = spawn(bin, [], { env: { ...process.env, AVA_HELPER_PORT: String(PORT) }, stdio: "ignore" });
-    await waitForReady();
-
-    const ping = await fetch(`${BASE}/ping`);
+  test("HTTP: /ping, /version, CORS och /check-update", async () => {
+    const ping = await fetch(`${HTTP_BASE}/ping`);
     expect(ping.status).toBe(200);
     expect((await ping.text()).trim()).toBe(`${HELPER_PING_PREFIX} ${VERSION}`);
 
-    const version = await fetch(`${BASE}/version`);
+    const version = await fetch(`${HTTP_BASE}/version`);
     expect(((await version.json()) as { current: string }).current).toBe(VERSION);
 
-    const cors = await fetch(`${BASE}/ping`, {
+    const cors = await fetch(`${HTTP_BASE}/ping`, {
       method: "OPTIONS",
       headers: { Origin: "http://localhost:3000" },
     });
     expect(cors.status).toBe(204);
     expect(cors.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:3000");
 
-    const upd = await fetch(`${BASE}/check-update`, { method: "POST" });
+    const upd = await fetch(`${HTTP_BASE}/check-update`, { method: "POST" });
     expect(upd.status).toBe(202);
-  }, 20_000);
+  });
+
+  test("HTTPS: serverar /ping med ett localhost-cert (ADR 0006)", async () => {
+    // Certet är signerat av helperns egen lokala CA → validera inte kedjan här.
+    const ping = await fetch(`${HTTPS_BASE}/ping`, {
+      tls: { rejectUnauthorized: false },
+    } as RequestInit);
+    expect(ping.status).toBe(200);
+    expect((await ping.text()).trim()).toBe(`${HELPER_PING_PREFIX} ${VERSION}`);
+
+    expect(await peerCertCommonName(HTTPS_PORT)).toBe("localhost");
+  });
 });

--- a/helper-app/test/certs.test.ts
+++ b/helper-app/test/certs.test.ts
@@ -1,0 +1,98 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { X509Certificate } from "node:crypto";
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import forge from "node-forge";
+
+import { generateCa, issueLeaf, loadOrCreateTls } from "../src/tls/certs.ts";
+
+const NAME_CONSTRAINTS_OID = "2.5.29.30";
+
+function nameConstraintsExt(certPem: string): { critical?: boolean } | undefined {
+  return forge.pki
+    .certificateFromPem(certPem)
+    .extensions.find((e: { id: string }) => e.id === NAME_CONSTRAINTS_OID);
+}
+
+describe("generateCa", () => {
+  const ca = generateCa();
+
+  test("är en CA-root med rätt subject", () => {
+    const x = new X509Certificate(ca.cert);
+    expect(x.ca).toBe(true);
+    expect(x.subject).toContain("AVA Helper Local CA");
+  });
+
+  test("har kritiska Name Constraints (härdning)", () => {
+    const nc = nameConstraintsExt(ca.cert);
+    expect(nc).toBeDefined();
+    expect(nc?.critical).toBe(true);
+  });
+
+  test("nyckel-PEM är PKCS#8", () => {
+    expect(ca.key).toContain("BEGIN PRIVATE KEY");
+  });
+});
+
+describe("issueLeaf", () => {
+  const ca = generateCa();
+  const leaf = issueLeaf(ca);
+  const leafX = new X509Certificate(leaf.cert);
+
+  test("SAN täcker localhost + 127.0.0.1 + ::1", () => {
+    expect(leafX.checkHost("localhost")).toBe("localhost");
+    expect(leafX.checkIP("127.0.0.1")).toBe("127.0.0.1");
+    expect(leafX.subjectAltName).toContain("localhost");
+  });
+
+  test("är signerad av CA:n", () => {
+    const caX = new X509Certificate(ca.cert);
+    expect(leafX.verify(caX.publicKey)).toBe(true);
+  });
+
+  test("är inte själv en CA", () => {
+    expect(leafX.ca).toBe(false);
+  });
+});
+
+describe("loadOrCreateTls", () => {
+  const dirs: string[] = [];
+  afterAll(async () => {
+    await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true })));
+  });
+  async function freshDir(): Promise<string> {
+    const d = await mkdtemp(join(tmpdir(), "ava-tls-"));
+    dirs.push(d);
+    return join(d, "tls");
+  }
+
+  test("skapar CA + leaf och persisterar (nyckel 0600)", async () => {
+    const dir = await freshDir();
+    const m = loadOrCreateTls(dir);
+    expect(m.ca.cert).toContain("BEGIN CERTIFICATE");
+    expect(m.leaf.cert).toContain("BEGIN CERTIFICATE");
+    const mode = (await stat(join(dir, "leaf-key.pem"))).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  test("är idempotent — återanvänder befintligt material", async () => {
+    const dir = await freshDir();
+    const a = loadOrCreateTls(dir);
+    const b = loadOrCreateTls(dir);
+    expect(b.ca.cert).toBe(a.ca.cert);
+    expect(b.leaf.cert).toBe(a.leaf.cert);
+  });
+
+  test("återutfärdar leaf nära utgång men behåller CA", async () => {
+    const dir = await freshDir();
+    const t0 = new Date("2026-01-01T00:00:00Z");
+    const first = loadOrCreateTls(dir, t0);
+    // 350 dagar senare: leaf (1 år) inom 30-dagars förnyelsefönster.
+    const later = new Date(t0.getTime() + 350 * 24 * 60 * 60 * 1000);
+    const second = loadOrCreateTls(dir, later);
+    expect(second.ca.cert).toBe(first.ca.cert); // CA långlivad, oförändrad
+    expect(second.leaf.cert).not.toBe(first.leaf.cert); // leaf återutfärdad
+  });
+});

--- a/helper-app/test/paths.test.ts
+++ b/helper-app/test/paths.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveDataDir } from "../src/paths.ts";
+
+describe("resolveDataDir", () => {
+  test("macOS → ~/Library/Application Support/AVA", () => {
+    expect(resolveDataDir("darwin", "/Users/u")).toBe("/Users/u/Library/Application Support/AVA");
+  });
+  test("Windows → %LOCALAPPDATA%\\AVA", () => {
+    expect(resolveDataDir("windows", "C:\\Users\\u", { localAppData: "C:\\Users\\u\\AppData\\Local" })).toBe(
+      "C:\\Users\\u\\AppData\\Local/AVA",
+    );
+  });
+  test("Linux → $XDG_DATA_HOME/AVA om satt", () => {
+    expect(resolveDataDir("linux", "/home/u", { xdgDataHome: "/home/u/.xdgdata" })).toBe("/home/u/.xdgdata/AVA");
+  });
+  test("Linux utan XDG → ~/.local/share/AVA", () => {
+    expect(resolveDataDir("linux", "/home/u")).toBe("/home/u/.local/share/AVA");
+  });
+  test("tom home → null", () => {
+    expect(resolveDataDir("darwin", "")).toBeNull();
+  });
+});

--- a/src/lib/shared/helper/protocol.ts
+++ b/src/lib/shared/helper/protocol.ts
@@ -17,6 +17,16 @@ export const HELPER_PORT = 48761;
 /** Bas-URL webbappen pratar mot. */
 export const HELPER_BASE = `http://127.0.0.1:${HELPER_PORT}`;
 
+/**
+ * HTTPS-port (ADR 0006): Safari/WKWebView (Office-add-ins på Mac) blockerar
+ * https-sida → http-loopback som mixed content och kräver HTTPS. Använder
+ * `localhost` (matchar leaf-certets SAN/CN), inte 127.0.0.1.
+ */
+export const HELPER_HTTPS_PORT = 48762;
+
+/** HTTPS-bas-URL (betrott lokalt cert via helperns CA). */
+export const HELPER_HTTPS_BASE = `https://localhost:${HELPER_HTTPS_PORT}`;
+
 /** Prefix i `GET /ping`-svaret: "ava-helper <version>". */
 export const HELPER_PING_PREFIX = "ava-helper";
 

--- a/test/unit/shared/helper/protocol.test.ts
+++ b/test/unit/shared/helper/protocol.test.ts
@@ -3,6 +3,8 @@ import { describe, it, expect } from "vitest-compat";
 import {
   formatPing,
   HELPER_BASE,
+  HELPER_HTTPS_BASE,
+  HELPER_HTTPS_PORT,
   HELPER_PING_PREFIX,
   HELPER_PORT,
   isAllowedOrigin,
@@ -14,6 +16,10 @@ describe("konstanter", () => {
   it("HELPER_BASE byggs av porten", () => {
     expect(HELPER_PORT).toBe(48761);
     expect(HELPER_BASE).toBe("http://127.0.0.1:48761");
+  });
+  it("HTTPS-bas använder localhost (matchar cert-SAN) på egen port", () => {
+    expect(HELPER_HTTPS_PORT).toBe(48762);
+    expect(HELPER_HTTPS_BASE).toBe("https://localhost:48762");
   });
 });
 


### PR DESCRIPTION
Första steget i [ADR 0006](https://github.com/ulrik-s/ava/blob/main/docs/adr/0006-helper-https-lokal-ca.md): helpern genererar en lokal CA + leaf-cert och serverar HTTPS parallellt med HTTP. (Trust-injection i macOS-keychain = #103; web-klient = #104; utökade tester = #105.)

## Cert-infra (`helper-app/src/tls/certs.ts`)
- **Keygen** via `node:crypto` (snabb native RSA), **cert-bygge/signering** via `node-forge` (ren JS, ingen system-openssl — viktigt för en shippad binär). Valde bort `@peculiar/x509` (drar in tsyringe/reflect-metadata-polyfill, bundle-fragilt i `--compile`).
- **Härdning:** CA:n utfärdas med X.509 **Name Constraints** (localhost/127.0.0.1/::1) → en läckt CA-nyckel kan inte förfalska cert för riktiga domäner.
- Leaf: SANs localhost/127.0.0.1/::1, `serverAuth` EKU. `loadOrCreateTls()` persisterar i data-dir (nyckel `0600`), är idempotent och återutfärdar leaf nära utgång medan CA:n förblir.

## Wiring
- `main.ts` startar HTTPS på `HELPER_HTTPS_PORT` vid sidan av HTTP; faller tillbaka tyst på endast-HTTP om data-dir/TLS saknas (Chromium/Firefox behöver inte HTTPS). `AVA_HELPER_HTTPS_PORT`-override.
- `src/paths.ts`: per-OS data-dir. `protocol.ts`: `HELPER_HTTPS_PORT`/`HELPER_HTTPS_BASE` (`https://localhost` — matchar cert-SAN).

## Tester
- Enhet: cert (CA-flagga, Name Constraints kritisk, SAN, signerad-av-CA, idempotens, leaf-förnyelse), paths (per-OS).
- **E2e mot kompilerad binär:** verifierar att `--compile`-binären serverar HTTPS med ett `localhost`-cert (TLS-handshake + peer-cert-CN + `/ping` över https).

## Verifierat lokalt
helper `typecheck` + `bun test` (107 grön, coverage-grind), root `typecheck`/`lint`/`deps:check`/`knip`/`test:cov`. Binären kompilerar och serverar HTTPS.