### PR TITLE
feat(helper): macOS keychain trust-injection av lokal CA (#103)

### DIFF
--- a/helper-app/README.md
+++ b/helper-app/README.md
@@ -67,11 +67,16 @@ Script:en kopierar binären till user-writable plats, registrerar
 service-units och startar processen. Inga sudo/admin-rättigheter
 behövs.
 
+På **macOS** installerar scriptet även helperns lokala CA i login-keychain
+(`ava-helper --install-trust`) så Safari/WKWebView (Office-add-ins) litar på
+HTTPS-loopback-certet — det ger en engångs-auktoriseringsprompt (ADR 0006).
+Chrome/Edge/Firefox + Windows/Linux behöver inte detta (HTTP-loopback funkar).
+
 ## Avinstallera
 
 | OS | Kommando |
 |---|---|
-| macOS | `launchctl unload -w ~/Library/LaunchAgents/se.ava.helper.plist && rm "$_"` |
+| macOS | `~/Library/Application\ Support/AVA/ava-helper --uninstall-trust; launchctl unload -w ~/Library/LaunchAgents/se.ava.helper.plist && rm "$_"` |
 | Linux | `systemctl --user disable --now ava-helper` |
 | Windows | `schtasks /delete /tn "AVA Helper" /f` |
 

--- a/helper-app/service/install-macos.sh
+++ b/helper-app/service/install-macos.sh
@@ -38,6 +38,13 @@ sed "s|/Users/CURRENT_USER|$HOME|g" "$PLIST_SRC" > "$PLIST_TARGET"
 launchctl unload "$PLIST_TARGET" 2>/dev/null || true
 launchctl load -w "$PLIST_TARGET"
 
+# Installera helperns lokala CA i login-keychain så Safari/WKWebView litar på
+# HTTPS-loopback-certet (ADR 0006). Kräver en engångs-auktoriseringsprompt.
+# Misslyckas tyst → HTTP funkar ändå i Chrome/Edge/Firefox.
+echo "→ Installerar lokal CA i keychain (Safari/Office-add-in på Mac)…"
+"$BIN_DIR/ava-helper" --install-trust || \
+  echo "⚠ Kunde inte installera CA-trust automatiskt — Safari kan kräva manuell trust."
+
 # Verifiera
 sleep 1
 if curl -s --max-time 2 http://127.0.0.1:48761/ping >/dev/null; then

--- a/helper-app/src/main.ts
+++ b/helper-app/src/main.ts
@@ -22,6 +22,7 @@ import { dataDir } from "./paths.ts";
 import { initLog, log } from "./log.ts";
 import { createHandler } from "./server.ts";
 import { loadOrCreateTls } from "./tls/certs.ts";
+import { installCaTrust, removeCaTrust } from "./tls/trust.ts";
 import { checkOnce, runUpdateLoop, type UpdateConfig } from "./update.ts";
 import { VERSION } from "./version.ts";
 
@@ -40,6 +41,25 @@ function listenPort(): number {
 function httpsPort(): number {
   const p = Number(process.env.AVA_HELPER_HTTPS_PORT);
   return Number.isInteger(p) && p > 0 ? p : HELPER_HTTPS_PORT;
+}
+
+/** `--install-trust` / `--uninstall-trust`: lägg/ta bort CA i macOS-keychain. */
+function handleTrust(action: "install" | "uninstall"): void {
+  const dir = dataDir();
+  if (dir === null) {
+    process.stderr.write("ingen data-dir tillgänglig\n");
+    process.exitCode = 1;
+    return;
+  }
+  const tlsDir = join(dir, "tls");
+  loadOrCreateTls(tlsDir); // säkerställ att CA finns
+  const caPath = join(tlsDir, "ca.pem");
+  const res = action === "install" ? installCaTrust(caPath) : removeCaTrust(caPath);
+  const label = `CA-trust ${action}`;
+  process.stdout.write(
+    res.skipped ? `${label}: hoppad (${res.reason ?? ""})\n` : `${label}: ${res.ok ? "ok" : "misslyckades"}\n`,
+  );
+  if (!res.ok && !res.skipped) process.exitCode = 1;
 }
 
 type Handler = (req: Request) => Promise<Response>;
@@ -88,6 +108,14 @@ function buildUpdateConfig(): UpdateConfig {
 function main(): void {
   if (process.argv.includes("--version")) {
     process.stdout.write(`${VERSION}\n`);
+    return;
+  }
+  if (process.argv.includes("--install-trust")) {
+    handleTrust("install");
+    return;
+  }
+  if (process.argv.includes("--uninstall-trust")) {
+    handleTrust("uninstall");
     return;
   }
 

--- a/helper-app/src/tls/certs.ts
+++ b/helper-app/src/tls/certs.ts
@@ -79,7 +79,10 @@ function nameConstraintsExtension(): { id: string; critical: boolean; value: str
   return { id: "2.5.29.30", critical: true, value: forge.asn1.toDer(nc).getBytes() };
 }
 
-const CA_ATTRS = [{ name: "commonName", value: "AVA Helper Local CA" }];
+/** CN på den lokala CA:n — används av trust-install/-uninstall (#103). */
+export const CA_COMMON_NAME = "AVA Helper Local CA";
+
+const CA_ATTRS = [{ name: "commonName", value: CA_COMMON_NAME }];
 
 /** Generera en self-signed, name-constrained lokal CA. */
 export function generateCa(now: Date = new Date()): CertPair {

--- a/helper-app/src/tls/trust.ts
+++ b/helper-app/src/tls/trust.ts
@@ -1,0 +1,82 @@
+/**
+ * macOS trust-injection av helperns lokala CA (#103, ADR 0006). Lägger
+ * CA-roten i användarens login-keychain så Safari/WKWebView litar på
+ * leaf-certet. ENDAST macOS — Chromium/Firefox/Windows-WebView2 hedrar
+ * loopback-secure-context och behöver ingen trust.
+ *
+ * Kommando-byggarna är rena (testbara); `security`-anropen går via en
+ * injicerbar runner. Den faktiska keychain-mutationen kräver en interaktiv
+ * auktoriseringsprompt och kan inte CI-testas — verifieras manuellt på Mac.
+ */
+
+import { spawnSync } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { currentPlatform, type Platform } from "../platform/runtime.ts";
+import { CA_COMMON_NAME } from "./certs.ts";
+
+export interface Runner {
+  (cmd: string, args: readonly string[]): { status: number | null };
+}
+
+const defaultRunner: Runner = (cmd, args) => {
+  const r = spawnSync(cmd, [...args], { stdio: "inherit" });
+  return { status: r.status };
+};
+
+export function loginKeychain(home: string): string {
+  return join(home, "Library", "Keychains", "login.keychain-db");
+}
+
+// ─── Rena kommando-argument (security ...) ───────────────────────────
+export function addTrustedArgs(caCertPath: string, keychain: string): string[] {
+  // Användar-domän (inget -d → ingen sudo); -r trustRoot = betrodd rot.
+  return ["add-trusted-cert", "-r", "trustRoot", "-k", keychain, caCertPath];
+}
+export function verifyCertArgs(caCertPath: string): string[] {
+  return ["verify-cert", "-c", caCertPath];
+}
+export function removeTrustArgs(caCertPath: string): string[] {
+  return ["remove-trusted-cert", caCertPath];
+}
+export function deleteCertArgs(): string[] {
+  return ["delete-certificate", "-c", CA_COMMON_NAME, "-t"];
+}
+
+export interface TrustDeps {
+  platform?: Platform;
+  run?: Runner;
+  keychain?: string;
+}
+export interface TrustResult {
+  ok: boolean;
+  skipped: boolean;
+  reason?: string;
+}
+
+/** Installera CA-roten som betrodd (idempotent). */
+export function installCaTrust(caCertPath: string, deps: TrustDeps = {}): TrustResult {
+  const platform = deps.platform ?? currentPlatform();
+  if (platform !== "darwin") {
+    return { ok: false, skipped: true, reason: `trust-injection stöds bara på macOS (är: ${platform})` };
+  }
+  const run = deps.run ?? defaultRunner;
+  const keychain = deps.keychain ?? loginKeychain(homedir());
+  if (run("security", verifyCertArgs(caCertPath)).status === 0) {
+    return { ok: true, skipped: true, reason: "redan betrott" };
+  }
+  return { ok: run("security", addTrustedArgs(caCertPath, keychain)).status === 0, skipped: false };
+}
+
+/** Ta bort CA-roten ur trust-store + keychain. */
+export function removeCaTrust(caCertPath: string, deps: TrustDeps = {}): TrustResult {
+  const platform = deps.platform ?? currentPlatform();
+  if (platform !== "darwin") {
+    return { ok: false, skipped: true, reason: `endast macOS (är: ${platform})` };
+  }
+  const run = deps.run ?? defaultRunner;
+  run("security", removeTrustArgs(caCertPath));
+  run("security", deleteCertArgs());
+  return { ok: true, skipped: false };
+}

--- a/helper-app/test/trust.test.ts
+++ b/helper-app/test/trust.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  addTrustedArgs,
+  deleteCertArgs,
+  installCaTrust,
+  loginKeychain,
+  removeCaTrust,
+  removeTrustArgs,
+  verifyCertArgs,
+  type Runner,
+} from "../src/tls/trust.ts";
+
+/** Mock-runner: status per `security`-subkommando + inspelade anrop. */
+function recorder(statuses: Record<string, number> = {}): { run: Runner; subcommands: () => string[] } {
+  const calls: string[][] = [];
+  const run: Runner = (cmd, args) => {
+    calls.push([cmd, ...args]);
+    return { status: statuses[args[0] ?? ""] ?? 0 };
+  };
+  return { run, subcommands: () => calls.map((c) => c[1] ?? "") };
+}
+
+describe("kommando-argument", () => {
+  test("addTrustedArgs: betrodd rot i angiven keychain", () => {
+    expect(addTrustedArgs("/p/ca.pem", "/kc.db")).toEqual([
+      "add-trusted-cert", "-r", "trustRoot", "-k", "/kc.db", "/p/ca.pem",
+    ]);
+  });
+  test("verify/remove/delete", () => {
+    expect(verifyCertArgs("/p/ca.pem")).toEqual(["verify-cert", "-c", "/p/ca.pem"]);
+    expect(removeTrustArgs("/p/ca.pem")).toEqual(["remove-trusted-cert", "/p/ca.pem"]);
+    expect(deleteCertArgs()).toEqual(["delete-certificate", "-c", "AVA Helper Local CA", "-t"]);
+  });
+  test("loginKeychain-sökväg", () => {
+    expect(loginKeychain("/Users/u")).toBe("/Users/u/Library/Keychains/login.keychain-db");
+  });
+});
+
+describe("installCaTrust", () => {
+  test("hoppas över på icke-macOS", () => {
+    const rec = recorder();
+    const res = installCaTrust("/p/ca.pem", { platform: "linux", run: rec.run });
+    expect(res).toEqual({ ok: false, skipped: true, reason: "trust-injection stöds bara på macOS (är: linux)" });
+    expect(rec.subcommands()).toHaveLength(0);
+  });
+
+  test("idempotent: redan betrott → hoppar add", () => {
+    const rec = recorder({ "verify-cert": 0 });
+    const res = installCaTrust("/p/ca.pem", { platform: "darwin", run: rec.run, keychain: "/kc.db" });
+    expect(res.ok).toBe(true);
+    expect(res.skipped).toBe(true);
+    expect(rec.subcommands()).toEqual(["verify-cert"]);
+  });
+
+  test("inte betrott → kör add-trusted-cert", () => {
+    const rec = recorder({ "verify-cert": 1, "add-trusted-cert": 0 });
+    const res = installCaTrust("/p/ca.pem", { platform: "darwin", run: rec.run, keychain: "/kc.db" });
+    expect(res).toEqual({ ok: true, skipped: false });
+    expect(rec.subcommands()).toEqual(["verify-cert", "add-trusted-cert"]);
+  });
+
+  test("add misslyckas → ok=false", () => {
+    const rec = recorder({ "verify-cert": 1, "add-trusted-cert": 1 });
+    expect(installCaTrust("/p/ca.pem", { platform: "darwin", run: rec.run }).ok).toBe(false);
+  });
+});
+
+describe("removeCaTrust", () => {
+  test("hoppas över på icke-macOS", () => {
+    expect(removeCaTrust("/p/ca.pem", { platform: "windows", run: recorder().run }).skipped).toBe(true);
+  });
+  test("macOS: tar bort trust + cert", () => {
+    const rec = recorder();
+    const res = removeCaTrust("/p/ca.pem", { platform: "darwin", run: rec.run });
+    expect(res.ok).toBe(true);
+    expect(rec.subcommands()).toEqual(["remove-trusted-cert", "delete-certificate"]);
+  });
+});


### PR DESCRIPTION
Steg 2 i [ADR 0006](https://github.com/ulrik-s/ava/blob/main/docs/adr/0006-helper-https-lokal-ca.md): lägger helperns lokala CA (från #102) i användarens login-keychain så **Safari/WKWebView** (Office-add-ins på Mac) litar på HTTPS-loopback-certet.

## Implementation
- **`src/tls/trust.ts`**: rena `security`-kommando-byggare (`add-trusted-cert` / `verify-cert` / `remove-trusted-cert` / `delete-certificate`) + `installCaTrust`/`removeCaTrust` med **OS-guard (endast macOS)** och injicerbar runner. Idempotent — hoppar `add` om certet redan verifieras.
- **`main.ts`**: `--install-trust` / `--uninstall-trust` subkommandon (säkerställer CA via `loadOrCreateTls`, kör trust-op, sätter exit-kod).
- **`install-macos.sh`** kör `--install-trust` efter launchctl-load (engångs-auktoriseringsprompt). README beskriver prompten + avinstall.

Endast macOS — Chromium/Firefox/Windows-WebView2 hedrar loopback-secure-context och behöver ingen trust.

## Tester & verifiering
Enhetstester: kommando-konstruktion, idempotens, OS-guard, install/remove-flöde (injicerad runner — **ingen riktig keychain-mutation**). 116 helper-tester gröna + coverage-grind.

> ⚠️ **Brasklapp:** själva keychain-installationen kräver en interaktiv auth-prompt och kan inte köras i CI (linux) eller automatiseras säkert. Logiken är testad; den faktiska "litar Safari på certet?"-verifieringen är **manuell på en Mac** (kör `install-macos.sh`, öppna `https://localhost:48762/ping` i Safari).

Del av epic #101. Kvar: #104 (web-klient väljer https på Safari), #105 (utökade tester).