### PR TITLE
feat(helper-client): välj https-endpoint på Safari/WebKit, fallback http (#104)

### DIFF
--- a/src/lib/client/firma/open-document-externally.ts
+++ b/src/lib/client/firma/open-document-externally.ts
@@ -29,7 +29,6 @@ interface Doc {
 }
 
 const DEFAULT_DEMO_REPO_FALLBACK = "ulrik-s/ava-demo";
-const HELPER_BASE = "http://127.0.0.1:48761";
 
 /**
  * Försök öppna via AVA Helper (1-klicks-flow). Returnerar true om
@@ -45,13 +44,8 @@ const HELPER_BASE = "http://127.0.0.1:48761";
  * AVA-backend som körs (git-http eller REST). Helpern är tier-agnostisk.
  */
 export async function tryHelperOpen(doc: Doc): Promise<boolean> {
-  // Snabb ping — om helpern inte kör, fail-fast och låt fallback ta över
-  try {
-    await fetch(`${HELPER_BASE}/ping`, { signal: AbortSignal.timeout(300) });
-  } catch {
-    return false;
-  }
-  // Beräkna download/upload-URLs. För git-tier serverar nginx (eller
+  // openViaHelper löser transporten (https→http, ADR 0006) och kastar om
+  // helpern saknas → vi fångar och faller tillbaka. Beräkna download/upload-URLs. För git-tier serverar nginx (eller
   // demo-build) filerna under storagePath. För Postgres-tier blir det
   // /api/documents/<id>/download. Vi använder befintliga konstruktioner.
   const isDemo = process.env.NEXT_PUBLIC_DEMO_BUILD === "1";

--- a/src/lib/client/helper/use-helper.ts
+++ b/src/lib/client/helper/use-helper.ts
@@ -6,15 +6,21 @@
  * kan delegera "öppna dokument externt" till helpern (1-klicks-flow)
  * eller falla tillbaka till den befintliga download/modal-vägen.
  *
- * Helpern lyssnar på 127.0.0.1:48761 (se [[helper-app/README.md]]).
- * Request-/response-former + URL delas med själva helper-binären via
- * `@/lib/shared/helper/protocol` (#78) så sidorna aldrig glider isär.
+ * Transport (ADR 0006): helpern serverar både HTTP (127.0.0.1) och HTTPS
+ * (localhost, betrott lokalt cert). Safari/WKWebView (Office-add-ins på Mac)
+ * blockerar https-sida → http-loopback som mixed content, så vi PROVAR HTTPS
+ * först och faller tillbaka på HTTP (Chromium/Firefox där loopback redan är
+ * secure context). Den fungerande basen cachas.
+ *
+ * Request-/response-former + URL:er delas med själva helper-binären via
+ * `@/lib/shared/helper/protocol` (#78).
  */
 
 import { useEffect, useState } from "react";
 
 import {
   HELPER_BASE,
+  HELPER_HTTPS_BASE,
   parsePingVersion,
   type ComposeMailRequest,
   type HelperOpenRequest,
@@ -23,24 +29,56 @@ import {
 
 export type { HelperStatus };
 
+// HTTPS först (Safari kräver det), sedan HTTP (Chromium/Firefox).
+const PROBE_ORDER = [HELPER_HTTPS_BASE, HELPER_BASE] as const;
+let cachedBase: string | undefined;
+
+async function pingText(base: string, timeoutMs = 500): Promise<string | null> {
+  try {
+    const r = await fetch(`${base}/ping`, { signal: AbortSignal.timeout(timeoutMs) });
+    return r.ok ? await r.text() : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pinga helpern och returnera fungerande transport + version. En cachad bas
+ * provas direkt (bekräftar liveness); annars provas PROBE_ORDER. En miss
+ * cachas INTE — helpern kan startas senare, så nästa anrop provar om.
+ */
+async function probeHelper(): Promise<{ base: string; version: string | null } | null> {
+  const bases = cachedBase !== undefined ? [cachedBase] : PROBE_ORDER;
+  for (const base of bases) {
+    const text = await pingText(base);
+    if (text !== null) {
+      cachedBase = base;
+      return { base, version: parsePingVersion(text) };
+    }
+  }
+  cachedBase = undefined; // cachad bas svarar inte längre → prova om nästa gång
+  return null;
+}
+
+/** Den transport (https/http) helpern svarar på, eller null. */
+export async function resolveHelperBase(): Promise<string | null> {
+  return (await probeHelper())?.base ?? null;
+}
+
+/** Endast för tester: nollställ transport-cachen. */
+export function resetHelperBaseCache(): void {
+  cachedBase = undefined;
+}
+
 export function useHelper(): HelperStatus {
   const [status, setStatus] = useState<HelperStatus>({ version: undefined, checked: false });
 
   useEffect(() => {
     let cancelled = false;
     async function ping(): Promise<void> {
-      try {
-        const r = await fetch(`${HELPER_BASE}/ping`, {
-          signal: AbortSignal.timeout(500),
-        });
-        if (!r.ok) throw new Error(`HTTP ${r.status}`);
-        const text = await r.text();
-        if (cancelled) return;
-        setStatus({ version: parsePingVersion(text), checked: true });
-      } catch {
-        if (cancelled) return;
-        setStatus({ version: null, checked: true });
-      }
+      const probe = await probeHelper();
+      if (cancelled) return;
+      setStatus({ version: probe?.version ?? null, checked: true });
     }
     void ping();
     return () => { cancelled = true; };
@@ -49,18 +87,25 @@ export function useHelper(): HelperStatus {
   return status;
 }
 
+/** Fetch mot helpern på den upplösta transporten; null om helpern saknas. */
+async function helperFetch(path: string, init: RequestInit): Promise<Response | null> {
+  const base = await resolveHelperBase();
+  return base === null ? null : fetch(`${base}${path}`, init);
+}
+
 /**
  * `openViaHelper` — skickar `POST /open` till helpern. AVA-webbappen
  * konstruerar absolute download/upload-URLs baserat på vilken backend
  * som körs (git-http eller REST).
  */
 export async function openViaHelper(input: HelperOpenRequest): Promise<void> {
-  const r = await fetch(`${HELPER_BASE}/open`, {
+  const r = await helperFetch("/open", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(input),
     signal: AbortSignal.timeout(10_000),
   });
+  if (r === null) throw new Error("AVA Helper inte tillgänglig");
   if (!r.ok) {
     throw new Error(`helper /open: HTTP ${r.status} ${await r.text()}`);
   }
@@ -68,10 +113,10 @@ export async function openViaHelper(input: HelperOpenRequest): Promise<void> {
 
 /** Trigga omedelbar self-update-kontroll. */
 export async function triggerHelperUpdateCheck(): Promise<void> {
-  await fetch(`${HELPER_BASE}/check-update`, {
+  await helperFetch("/check-update", {
     method: "POST",
     signal: AbortSignal.timeout(2_000),
-  }).catch(() => { /* tyst — best-effort */ });
+  }).catch(() => null);
 }
 
 /**
@@ -81,18 +126,18 @@ export async function triggerHelperUpdateCheck(): Promise<void> {
  * Mail.app på macOS, xdg-email på Linux, COM på Windows).
  *
  * Returnerar true om helpern accepterade requesten, false om något
- * gick fel (404 = helper kör äldre version utan endpoint, network
- * error, etc.) så caller kan logga + falla tillbaka tyst.
+ * gick fel (helper saknas, 404 = äldre version, network error, etc.)
+ * så caller kan logga + falla tillbaka tyst.
  */
 export async function composeMailViaHelper(input: ComposeMailRequest): Promise<boolean> {
   try {
-    const r = await fetch(`${HELPER_BASE}/compose-mail`, {
+    const r = await helperFetch("/compose-mail", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(input),
       signal: AbortSignal.timeout(10_000),
     });
-    return r.ok;
+    return r?.ok ?? false;
   } catch {
     return false;
   }

--- a/test/unit/lib/helper/open-externally.test.tsx
+++ b/test/unit/lib/helper/open-externally.test.tsx
@@ -4,11 +4,13 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
 import { tryHelperOpen, shouldPreferExternalEdit } from "@/lib/client/firma/open-document-externally";
+import { resetHelperBaseCache } from "@/lib/client/helper/use-helper";
 
 const originalFetch = global.fetch;
 beforeEach(() => {
   vi.restoreAllMocks();
   global.fetch = originalFetch;
+  resetHelperBaseCache();
 });
 
 describe("shouldPreferExternalEdit", () => {

--- a/test/unit/lib/helper/use-helper.test.tsx
+++ b/test/unit/lib/helper/use-helper.test.tsx
@@ -1,17 +1,36 @@
 /**
- * Tests för useHelper() — mockar fetch mot localhost:48761.
+ * Tests för useHelper() + transport-resolution (https→http, ADR 0006).
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
 import { render, screen, waitFor } from "@testing-library/react";
-import { useHelper, openViaHelper } from "@/lib/client/helper/use-helper";
+import {
+  useHelper,
+  openViaHelper,
+  triggerHelperUpdateCheck,
+  resetHelperBaseCache,
+} from "@/lib/client/helper/use-helper";
 
+const HTTPS = "https://localhost:48762";
+const HTTP = "http://127.0.0.1:48761";
 const originalFetch = global.fetch;
 
 beforeEach(() => {
   vi.restoreAllMocks();
   global.fetch = originalFetch;
+  resetHelperBaseCache();
 });
+
+/** fetch-mock som svarar per URL-fragment; okända URL:er rejectar. */
+function routeFetch(routes: Array<[string, () => Response]>): ReturnType<typeof vi.fn> {
+  return vi.fn((url: string | URL) => {
+    const u = String(url);
+    for (const [frag, make] of routes) {
+      if (u.includes(frag)) return Promise.resolve(make());
+    }
+    return Promise.reject(new Error(`unmocked: ${u}`));
+  });
+}
 
 function Probe(): React.ReactElement {
   const s = useHelper();
@@ -19,51 +38,77 @@ function Probe(): React.ReactElement {
   return <p>{s.version ?? "absent"}</p>;
 }
 
-describe("useHelper", () => {
-  it("returnerar version-strängen när helpern svarar", async () => {
-    global.fetch = vi.fn().mockResolvedValueOnce(new Response("ava-helper v1.2.3\n", { status: 200 }));
+describe("useHelper / transport", () => {
+  it("använder HTTPS när den svarar (Safari-vägen)", async () => {
+    const fetchMock = routeFetch([[`${HTTPS}/ping`, () => new Response("ava-helper v1.2.3\n", { status: 200 })]]);
+    global.fetch = fetchMock;
     render(<Probe />);
     await waitFor(() => expect(screen.getByText("v1.2.3")).toBeInTheDocument());
+    // HTTPS provades först och räckte → ingen HTTP-ping.
+    expect(fetchMock.mock.calls.every(([u]: [string]) => String(u).startsWith(HTTPS))).toBe(true);
   });
 
-  it("returnerar null när /ping inte svarar (helper inte installerad)", async () => {
+  it("faller tillbaka på HTTP när HTTPS inte svarar (Chromium)", async () => {
+    const fetchMock = routeFetch([[`${HTTP}/ping`, () => new Response("ava-helper v2.0.0\n", { status: 200 })]]);
+    global.fetch = fetchMock; // HTTPS-pingen rejectar (ej mockad) → HTTP
+    render(<Probe />);
+    await waitFor(() => expect(screen.getByText("v2.0.0")).toBeInTheDocument());
+  });
+
+  it("null när varken https eller http svarar", async () => {
     global.fetch = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
     render(<Probe />);
     await waitFor(() => expect(screen.getByText("absent")).toBeInTheDocument());
   });
 
-  it("returnerar null vid trasig response-text", async () => {
-    global.fetch = vi.fn().mockResolvedValueOnce(new Response("garbage", { status: 200 }));
+  it("null vid trasig ping-text", async () => {
+    global.fetch = routeFetch([[`${HTTPS}/ping`, () => new Response("garbage", { status: 200 })]]);
     render(<Probe />);
     await waitFor(() => expect(screen.getByText("absent")).toBeInTheDocument());
   });
 });
 
 describe("openViaHelper", () => {
-  it("POST:ar /open med JSON och kastar vid fel", async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce(new Response("", { status: 200 }));
+  it("POST:ar /open på den upplösta basen (HTTPS)", async () => {
+    const fetchMock = routeFetch([
+      [`${HTTPS}/ping`, () => new Response("ava-helper v1\n", { status: 200 })],
+      [`${HTTPS}/open`, () => new Response("", { status: 200 })],
+    ]);
     global.fetch = fetchMock;
     await openViaHelper({ fileName: "x.pdf", downloadUrl: "https://example.com/x" });
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const call = fetchMock.mock.calls[0]!;
-    expect(call[0]).toBe("http://127.0.0.1:48761/open");
-    expect(call[1].method).toBe("POST");
-    expect(JSON.parse(call[1].body)).toMatchObject({ fileName: "x.pdf" });
+    const openCall = fetchMock.mock.calls.find(([u]: [string]) => String(u).endsWith("/open"))!;
+    expect(openCall[0]).toBe(`${HTTPS}/open`);
+    expect(openCall[1].method).toBe("POST");
+    expect(JSON.parse(openCall[1].body)).toMatchObject({ fileName: "x.pdf" });
   });
 
   it("kastar vid 4xx-respons", async () => {
-    global.fetch = vi.fn().mockResolvedValueOnce(new Response("oops", { status: 400 }));
+    global.fetch = routeFetch([
+      [`${HTTPS}/ping`, () => new Response("ava-helper v1\n", { status: 200 })],
+      [`${HTTPS}/open`, () => new Response("oops", { status: 400 })],
+    ]);
     await expect(openViaHelper({ fileName: "x.pdf", downloadUrl: "u" })).rejects.toThrow(/HTTP 400/);
+  });
+
+  it("kastar 'inte tillgänglig' när helpern saknas", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("down"));
+    await expect(openViaHelper({ fileName: "x.pdf", downloadUrl: "u" })).rejects.toThrow(/inte tillgänglig/);
   });
 });
 
 describe("triggerHelperUpdateCheck", () => {
-  it("anropar /check-update tyst (sväljer fel)", async () => {
-    const { triggerHelperUpdateCheck } = await import("@/lib/client/helper/use-helper");
-    const fetchMock = vi.fn().mockRejectedValue(new Error("net"));
+  it("anropar /check-update på upplöst bas", async () => {
+    const fetchMock = routeFetch([
+      [`${HTTP}/ping`, () => new Response("ava-helper v1\n", { status: 200 })],
+      [`${HTTP}/check-update`, () => new Response("", { status: 202 })],
+    ]);
     global.fetch = fetchMock;
-    // Ska INTE kasta även om fetch misslyckas
+    await triggerHelperUpdateCheck();
+    expect(fetchMock.mock.calls.some(([u]: [string]) => String(u) === `${HTTP}/check-update`)).toBe(true);
+  });
+
+  it("sväljer fel tyst när helpern saknas", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("net"));
     await expect(triggerHelperUpdateCheck()).resolves.toBeUndefined();
-    expect(fetchMock).toHaveBeenCalledWith("http://127.0.0.1:48761/check-update", expect.objectContaining({ method: "POST" }));
   });
 });


### PR DESCRIPTION
Steg 3 i [ADR 0006](https://github.com/ulrik-s/ava/blob/main/docs/adr/0006-helper-https-lokal-ca.md): webbklienten använder nu helperns HTTPS-transport där det krävs.

## Beteende
- **Probe https→http, cachad.** `probeHelper()` provar `HELPER_HTTPS_BASE` (Safari/WKWebView kräver det — mixed-content-block annars), faller tillbaka på `HELPER_BASE` (Chromium/Firefox där loopback redan är secure context). Fungerande bas cachas; en **miss cachas inte** (helpern kan startas efter sidladdning).
- Alla helper-anrop (`useHelper`/`openViaHelper`/`triggerHelperUpdateCheck`/`composeMailViaHelper`) går via `helperFetch()` på den upplösta basen. `useHelper` får versionen direkt ur proben (ingen dubbel-ping).
- `tryHelperOpen` lutar sig på `openViaHelper`s resolution (tog bort den hårdkodade `http://127.0.0.1:48761`-pingen).

## Tester
Nya/uppdaterade: https-väg, http-fallback, ingen-helper, trasig ping-text; `/open` + `/check-update` mot upplöst bas; `resetHelperBaseCache()` för testisolering (bun delar modul-state). Root `typecheck`/`lint`/`deps:check`/`knip`/`test:cov` gröna.

Del av epic #101. Sista biten kvar: #105 (utökade tester).

> Notera: själva "Safari litar på certet"-kedjan kräver #103:s keychain-install + manuell Mac-verifiering; den här PR:en är klientlogiken som väljer rätt transport.