### PR TITLE
test(helper): full kedje-validering + cert-egenskaper; fixa name-constraint (#105)

### DIFF
--- a/docs/adr/0006-helper-https-lokal-ca.md
+++ b/docs/adr/0006-helper-https-lokal-ca.md
@@ -25,7 +25,7 @@ Två vägar ger ett betrott cert:
 Vi väljer **B — lokal CA (mkcert-stil)**, av-scopad till **macOS** (enda plattformen där en webview kräver det).
 
 1. **Cert-infra (helpern).** Vid första körning genererar helpern en **lokal CA** (root cert + nyckel, lagrade i data-dir med `0600`) och ett **leaf-cert** för `localhost`/`127.0.0.1`/`::1`, signerat av CA:n. Helpern serverar **HTTPS parallellt med HTTP** (`Bun.serve({ tls })`); HTTP-porten lever kvar för Chromium/Firefox.
-2. **Härdning — Name Constraints.** CA:n utfärdas med X.509 *Name Constraints* som begränsar den till `localhost`/`127.0.0.1`. En läckt CA-nyckel kan då **inte** förfalska cert för riktiga domäner — bara för loopback (där en angripare ändå behöver lokal åtkomst). Detta är striktare än vad `mkcert` gör som standard.
+2. **Härdning — Name Constraints.** CA:n utfärdas med X.509 *Name Constraints* som begränsar den till `dNSName: localhost`. En läckt CA-nyckel kan då **inte** förfalska cert för riktiga domäner (*.com etc.) — den verkliga risken. Striktare än vad `mkcert` gör som standard. (Implementationsnotis, #105: iPAddress-constraints utelämnades — BoringSSL/Bun m.fl. avvisar kedjan med "unsupported name constraint type" på iPAddress-subtrees. IP-SANs blir därmed obegränsade, vilket är acceptabelt.)
 3. **Trust-injection — endast macOS.** CA-roten installeras i macOS-keychain (`security add-trusted-cert`) som en del av install-macos-flödet. Det kostar **en engångs-auktoriseringsprompt** (TouchID/lösenord). Avinstallation tar bort den.
 4. **Web-klienten.** På WebKit/Safari pratar klienten mot `https://localhost:<port>`; på Chromium/Firefox duger HTTP-loopback som idag. Ping-logiken provar HTTPS och faller tillbaka på HTTP.
 

--- a/helper-app/src/tls/certs.ts
+++ b/helper-app/src/tls/certs.ts
@@ -56,24 +56,22 @@ function dnsName(name: string): forge.asn1.Asn1 {
   return forge.asn1.create(forge.asn1.Class.CONTEXT_SPECIFIC, 2, false, name);
 }
 
-/** GeneralName [7] iPAddress för Name Constraints: adress-bytes + full mask. */
-function ipNameConstraint(addr: readonly number[]): forge.asn1.Asn1 {
-  const bytes = [...addr, ...addr.map(() => 0xff)];
-  return forge.asn1.create(forge.asn1.Class.CONTEXT_SPECIFIC, 7, false, String.fromCharCode(...bytes));
-}
-
 function subtree(generalName: forge.asn1.Asn1): forge.asn1.Asn1 {
   return forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.SEQUENCE, true, [generalName]);
 }
 
-const LOOPBACK_V6 = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
-
-/** X.509 Name Constraints: tillåt ENDAST localhost / 127.0.0.1 / ::1. */
+/**
+ * X.509 Name Constraints: tillåt ENDAST dNSName `localhost`. Det säkrar det
+ * kritiska — en läckt CA-nyckel kan inte signera cert för riktiga domäner
+ * (*.com etc.). iPAddress-constraints utelämnas MEDVETET: BoringSSL (Bun) och
+ * flera andra verifierare avvisar kedjan med "unsupported name constraint
+ * type" på iPAddress-subtrees, vilket skulle bryta hela HTTPS-flödet. IP-SANs
+ * (127.0.0.1/::1) blir därmed obegränsade, vilket är acceptabelt (domän-
+ * förfalskning är den verkliga risken, inte loopback-IP).
+ */
 function nameConstraintsExtension(): { id: string; critical: boolean; value: string } {
   const permitted = forge.asn1.create(forge.asn1.Class.CONTEXT_SPECIFIC, 0, true, [
     subtree(dnsName("localhost")),
-    subtree(ipNameConstraint([127, 0, 0, 1])),
-    subtree(ipNameConstraint(LOOPBACK_V6)),
   ]);
   const nc = forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.SEQUENCE, true, [permitted]);
   return { id: "2.5.29.30", critical: true, value: forge.asn1.toDer(nc).getBytes() };

--- a/helper-app/test/binary.e2e.test.ts
+++ b/helper-app/test/binary.e2e.test.ts
@@ -6,12 +6,14 @@
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { connect } from "node:tls";
 
 import { HELPER_PING_PREFIX } from "@/lib/shared/helper/protocol";
+import { resolveDataDir } from "../src/paths.ts";
+import { currentPlatform } from "../src/platform/runtime.ts";
 
 const VERSION = "helper-v9.9.9-e2e";
 const HTTP_PORT = 48799;
@@ -110,14 +112,27 @@ describe("kompilerad binär (--compile)", () => {
     expect(upd.status).toBe(202);
   });
 
-  test("HTTPS: serverar /ping med ett localhost-cert (ADR 0006)", async () => {
-    // Certet är signerat av helperns egen lokala CA → validera inte kedjan här.
-    const ping = await fetch(`${HTTPS_BASE}/ping`, {
-      tls: { rejectUnauthorized: false },
-    } as RequestInit);
+  test("HTTPS: leaf-certet kedjar till helperns lokala CA (full validering)", async () => {
+    // Läs helperns egen CA ur data-dir (temp-HOME) och använd som trust-anchor
+    // → bevisar att leaf:et faktiskt validerar mot CA:n (inte bara att TLS svarar).
+    const dataRoot = resolveDataDir(currentPlatform(), dir, { localAppData: dir, xdgDataHome: dir });
+    if (dataRoot === null) throw new Error("kunde inte härleda data-dir");
+    const ca = await readFile(join(dataRoot, "tls", "ca.pem"), "utf8");
+
+    const ping = await fetch(`${HTTPS_BASE}/ping`, { tls: { ca } } as RequestInit);
     expect(ping.status).toBe(200);
     expect((await ping.text()).trim()).toBe(`${HELPER_PING_PREFIX} ${VERSION}`);
-
     expect(await peerCertCommonName(HTTPS_PORT)).toBe("localhost");
+  });
+
+  test("HTTPS: avvisas utan helperns CA (självsignerad → ej betrodd)", async () => {
+    // Utan CA i trust-store ska kedje-valideringen fela (mixed-trust-skydd).
+    let rejected = false;
+    try {
+      await fetch(`${HTTPS_BASE}/ping`);
+    } catch {
+      rejected = true;
+    }
+    expect(rejected).toBe(true);
   });
 });

--- a/helper-app/test/certs.test.ts
+++ b/helper-app/test/certs.test.ts
@@ -96,3 +96,23 @@ describe("loadOrCreateTls", () => {
     expect(second.leaf.cert).not.toBe(first.leaf.cert); // leaf återutfärdad
   });
 });
+
+describe("cert-egenskaper", () => {
+  const now = new Date("2026-01-01T00:00:00Z");
+  const ca = generateCa(now);
+  const leaf = issueLeaf(ca, now);
+  const years = (ms: number): number => ms / (365 * 24 * 60 * 60 * 1000);
+
+  test("leaf har serverAuth EKU", () => {
+    // node X509Certificate.keyUsage exponerar extended key usage-OID:erna.
+    expect(new X509Certificate(leaf.cert).keyUsage).toContain("1.3.6.1.5.5.7.3.1");
+  });
+
+  test("giltighetsfönster: CA långlivad (~10 år), leaf kortlivad (~1 år)", () => {
+    const caTo = new X509Certificate(ca.cert).validToDate.getTime();
+    const leafTo = new X509Certificate(leaf.cert).validToDate.getTime();
+    expect(years(caTo - now.getTime())).toBeGreaterThan(9);
+    expect(years(leafTo - now.getTime())).toBeGreaterThan(0.9);
+    expect(years(leafTo - now.getTime())).toBeLessThan(1.1);
+  });
+});


### PR DESCRIPTION
Sista biten i epic #101. **Det starkare e2e:t fångade en riktig bugg.**

## Buggen
Full kedje-validering visade att leaf-certet **inte validerade mot CA:n** — `unsupported name constraint type`. De **iPAddress** Name Constraints jag la i #102 avvisas av BoringSSL (Bun) och sannolikt fler verifierare. #102:s e2e dolde det med `rejectUnauthorized: false`. I produktion hade hela HTTPS-flödet (inkl. Safari) brutits.

## Fixen
`certs.ts`: begränsa Name Constraints till **`dNSName: localhost`**. Det säkrar det kritiska (en läckt CA-nyckel kan inte förfalska cert för riktiga domäner) och kedjan validerar i alla testade stackar. IP-SANs blir obegränsade — acceptabelt, domänförfalskning är den verkliga risken.

## Tester (#105:s scope)
- **`binary.e2e`**: full kedje-validering — hämtar `/ping` över HTTPS med helperns egna `ca.pem` som trust-anchor (bevisar att leaf kedjar till CA), + att anrop **utan** CA avvisas.
- **`certs`**: `serverAuth`-EKU, giltighetsfönster (CA ~10 år / leaf ~1 år).
- **ADR 0006**: implementationsnotis om dNSName-only.

119 helper-tester gröna + coverage-grind; root-gates gröna (endast helper-app + docs ändrat).

**Stänger epic #101** (helper-HTTPS): #102 cert+TLS, #103 macOS-trust, #104 web-klient, #105 tester. Kvarvarande härdning spårad separat: #110 (signaturverifiering), #86 (notarisering).