### PR TITLE
feat(ui): flytta Jävskontroll överst i sidomenyn (#89)

### DIFF
--- a/src/components/shell/sidebar.tsx
+++ b/src/components/shell/sidebar.tsx
@@ -23,6 +23,8 @@ export function signOutLocally(): void {
 }
 
 const navigation = [
+  // Jävskontroll överst — första steget i ärendehantering, mest framträdande (#89).
+  { name: "Jävskontroll", href: "/conflicts", icon: "🔍" },
   { name: "Dashboard", href: "/", icon: "📊" },
   { name: "Att göra", href: "/todo", icon: "✅" },
   { name: "Kontakter", href: "/contacts", icon: "👤" },
@@ -30,7 +32,6 @@ const navigation = [
   { name: "Dokumentsök", href: "/search", icon: "📄" },
   { name: "Dokumentmallar", href: "/templates", icon: "📝" },
   { name: "Tidregistrering", href: "/time", icon: "⏱️" },
-  { name: "Jävskontroll", href: "/conflicts", icon: "🔍" },
   { name: "Rapporter", href: "/reports", icon: "📈" },
   { name: "Fakturor", href: "/invoices", icon: "💰" },
   { name: "Avbetalningar", href: "/payment-plans", icon: "📅" },

--- a/test/unit/components/sidebar.test.tsx
+++ b/test/unit/components/sidebar.test.tsx
@@ -39,6 +39,15 @@ describe("Sidebar", () => {
     expect(screen.getAllByText("Användare")[0]).toBeInTheDocument();
   });
 
+  it("visar Jävskontroll överst, före Dashboard (#89)", () => {
+    render(<Sidebar />);
+    const texts = screen.getAllByRole("link").map((l) => l.textContent ?? "");
+    const jav = texts.findIndex((t) => t.includes("Jävskontroll"));
+    const dash = texts.findIndex((t) => t.includes("Dashboard"));
+    expect(jav).toBeGreaterThanOrEqual(0);
+    expect(jav).toBeLessThan(dash);
+  });
+
   it("markerar dashboard som aktiv när pathname=/", () => {
     pathnameMock.mockReturnValue("/");
     render(<Sidebar />);


### PR DESCRIPTION
Jävskontrollen är första steget i ärendehantering → flyttad till första nav-posten i `sidebar.tsx` (före Dashboard). Nytt sidebar-test låser ordningen (Jävskontroll före Dashboard).

Verifierat: sidebar-test + typecheck + lint + `build:demo` + `test:cov` gröna. Closes #89.