### PR TITLE
feat(server): hydrera domän-entiteter ur git working copy (#115)

### DIFF
--- a/src/lib/server/local-first/server-working-copy.ts
+++ b/src/lib/server/local-first/server-working-copy.ts
@@ -1,0 +1,44 @@
+/**
+ * Server-sidig hydrering av domän-entiteter ur en git working copy på disk
+ * (#115, ADR 0005 fas 1 — läs-vägen). Till skillnad från browser-vägen
+ * (OPFS + isomorphic-git via MemFs) använder servern native node-fs
+ * (`NodeFileSystem`). Samma projektions-/migrate-on-read-logik
+ * (`ProjectionHydrator`, ADR 0004) — bara en annan IFileSystem-implementation.
+ *
+ * Detta är första byggstenen i server-runtime:n: när entiteterna är hydrerade
+ * kan de matas in i en `DemoDataStore` + `buildContext` + tRPC-caller (nästa
+ * slice). Servern är en git-peer, inte dataägare.
+ */
+
+import { CURRENT_SCHEMA_VERSION, parseSchemaVersion } from "@/lib/shared/schema-version";
+
+import { DEMO_META_PATH } from "../../../../tooling/demo-config";
+import type { IFileSystem } from "./file-system";
+import { NodeFileSystem } from "./node-fs";
+import { ProjectionHydrator } from "./projection-writer";
+import { buildDefaultRegistry } from "./projections/default-registry";
+
+/** Läs repots datamodell-version ur .ava/meta.json (default = aktuell kod-version). */
+async function repoSchemaVersion(fs: IFileSystem): Promise<number> {
+  try {
+    if (!(await fs.exists(DEMO_META_PATH))) return CURRENT_SCHEMA_VERSION;
+    const raw = JSON.parse(await fs.readFile(DEMO_META_PATH)) as { schemaVersion?: unknown };
+    return parseSchemaVersion(raw.schemaVersion) ?? CURRENT_SCHEMA_VERSION;
+  } catch {
+    return CURRENT_SCHEMA_VERSION;
+  }
+}
+
+/**
+ * Hydrera alla domän-entiteter ur en git working copy på `dir`. Returnerar
+ * entiteter grupperade per projektions-namn (t.ex. `matter`, `contact`).
+ */
+export async function hydrateEntitiesFromWorkingCopy(dir: string): Promise<Record<string, unknown[]>> {
+  const fs: IFileSystem = new NodeFileSystem(dir);
+  const hydrator = new ProjectionHydrator(fs, buildDefaultRegistry(), await repoSchemaVersion(fs));
+  const entities: Record<string, unknown[]> = {};
+  await hydrator.hydrateAll((entity, data) => {
+    (entities[entity] ??= []).push(data);
+  });
+  return entities;
+}

--- a/test/unit/server/local-first/server-working-copy.test.ts
+++ b/test/unit/server/local-first/server-working-copy.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Test för server-sidig hydrering ur en git working copy på disk (#115).
+ *
+ * Bygger en working copy med exakt samma data som demo-bygget (`buildSeed`
+ * + `seedToFiles`), skriver den som JSON-filer till en temp-katalog via
+ * native node-fs, och verifierar att `hydrateEntitiesFromWorkingCopy()`
+ * läser tillbaka kärn-entiteterna (matter/contact/user) med rätt antal och
+ * fält. Detta är server-spegeln av browserns OPFS-clone-hydrering — samma
+ * `ProjectionHydrator`, bara `NodeFileSystem` istället för MemFs.
+ *
+ * `seed-hydration.test.ts` bevisar redan att VARJE seed-fil parsar med sin
+ * projektion; här bevisar vi disk-rundturen (skriv → läs via node-fs).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest-compat";
+import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { buildSeed, seedToFiles } from "../../../../tooling/scripts/seed-data";
+import { hydrateEntitiesFromWorkingCopy } from "@/lib/server/local-first/server-working-copy";
+import { CURRENT_SCHEMA_VERSION } from "@/lib/shared/schema-version";
+
+/** Skriv alla seed-filer + .ava/meta.json till `dir` som en äkta working copy. */
+async function writeWorkingCopy(
+  dir: string,
+  seed: ReturnType<typeof buildSeed>,
+  schemaVersion: number = CURRENT_SCHEMA_VERSION,
+): Promise<void> {
+  for (const { path, data } of seedToFiles(seed)) {
+    const abs = join(dir, path);
+    await mkdir(dirname(abs), { recursive: true });
+    await writeFile(abs, JSON.stringify(data, null, 2), "utf8");
+  }
+  const metaAbs = join(dir, ".ava/meta.json");
+  await mkdir(dirname(metaAbs), { recursive: true });
+  await writeFile(metaAbs, JSON.stringify({ schemaVersion }), "utf8");
+}
+
+describe("hydrateEntitiesFromWorkingCopy", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "ava-swc-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("hydrerar kärn-entiteter (matter/contact/user) med rätt antal", async () => {
+    const seed = buildSeed({ orgId: "test-org" });
+    await writeWorkingCopy(dir, seed);
+
+    const entities = await hydrateEntitiesFromWorkingCopy(dir);
+
+    expect(entities.matter?.length).toBe(seed.matters.length);
+    expect(entities.contact?.length).toBe(seed.contacts.length);
+    expect(entities.user?.length).toBe(seed.users.length);
+  });
+
+  it("bevarar fält genom projektion-deserialisering", async () => {
+    const seed = buildSeed({ orgId: "test-org" });
+    await writeWorkingCopy(dir, seed);
+
+    const entities = await hydrateEntitiesFromWorkingCopy(dir);
+
+    const matter = (entities.matter ?? []).find(
+      (m) => (m as { id?: unknown }).id === seed.matters[0]!.id,
+    ) as { organizationId?: unknown; matterNumber?: unknown } | undefined;
+    expect(matter).toBeDefined();
+    expect(matter!.organizationId).toBe("test-org");
+    expect(matter!.matterNumber).toBe(seed.matters[0]!.matterNumber);
+  });
+
+  it("returnerar tomt för en working copy utan datafiler", async () => {
+    await mkdir(join(dir, ".ava"), { recursive: true });
+    await writeFile(
+      join(dir, ".ava/meta.json"),
+      JSON.stringify({ schemaVersion: CURRENT_SCHEMA_VERSION }),
+      "utf8",
+    );
+
+    const entities = await hydrateEntitiesFromWorkingCopy(dir);
+
+    expect(entities.matter ?? []).toHaveLength(0);
+    expect(entities.contact ?? []).toHaveLength(0);
+  });
+
+  it("faller tillbaka på aktuell schema-version när meta.json saknas", async () => {
+    const seed = buildSeed({ orgId: "test-org" });
+    // Skriv data men INGEN .ava/meta.json
+    for (const { path, data } of seedToFiles(seed)) {
+      const abs = join(dir, path);
+      await mkdir(dirname(abs), { recursive: true });
+      await writeFile(abs, JSON.stringify(data), "utf8");
+    }
+
+    const entities = await hydrateEntitiesFromWorkingCopy(dir);
+
+    // Data skriven av nuvarande kod hydreras utan migration.
+    expect(entities.matter?.length).toBe(seed.matters.length);
+    expect(entities.user?.length).toBe(seed.users.length);
+  });
+});


### PR DESCRIPTION
## Vad

Första byggstenen i server-runtime:n (#77-epiken, ADR 0005 fas 1 — **läs-vägen**).

`hydrateEntitiesFromWorkingCopy(dir)` läser en git working copy från disk via native node-fs (`NodeFileSystem`) och kör **samma** projektions- + migrate-on-read-logik (`ProjectionHydrator`, ADR 0004) som browser-vägen använder mot OPFS/MemFs — bara en annan `IFileSystem`-implementation. Servern är en git-peer, inte dataägare.

## Varför så liten slice

#77 (server-runtime keystone) är dekomponerad i fyra slices för att hålla varje PR grön och granskbar:
- **#115 (denna):** läs-vägen — hydrera entiteter ur working copy.
- #116: mata in i `DemoDataStore` + `buildContext` + tRPC-caller (query-vägen).
- #117: clone + pull-act-push.
- #118: entry-point + paketering.

## Test

`test/unit/server/local-first/server-working-copy.test.ts` — bygger en working copy med exakt demo-datat (`buildSeed` + `seedToFiles`), skriver den som JSON via node-fs och verifierar disk-rundturen: kärn-entiteter (matter/contact/user) hydreras med rätt antal + bevarade fält, tom working copy ger tomt, och meta.json-fallback fungerar. Kompletterar `seed-hydration.test.ts` (som redan bevisar att varje seed-fil parsar).

## Checks (lokalt, speglar CI)

- ✅ `typecheck` (fresh, ingen tsbuildinfo-cache)
- ✅ `lint` + `deps:check` + `knip` + `duplicates`
- ✅ `test:cov` — 2343 pass, rader 78.14% / funktioner 78.75% (golv 76/77)

🤖 Generated with [Claude Code](https://claude.com/claude-code)