### PR TITLE
feat(server): klona firma.git + konflikt-säker pull→act→push-loop (#117)

### DIFF
--- a/src/lib/server/local-first/server-peer.ts
+++ b/src/lib/server/local-first/server-peer.ts
@@ -1,0 +1,115 @@
+/**
+ * Server-runtime C (#117, ADR 0005 fas 1) — git-peer-loopen.
+ *
+ * Servern är en git-PEER, inte en dataägare: den klonar `firma.git`, kör
+ * mutationer mot sin egen working copy och pushar tillbaka. Detta är
+ * komplementet till läs-vägen (#115) + skriv-vägen (#116) och uppfyller
+ * #77:s "Klar när".
+ *
+ * Konflikt-säkerhet (ADR 0002): pushen är CAS (`NodeGitOps.push` returnerar
+ * `NonFastForward` om remote drivit fram). Vid konflikt synkar vi till
+ * remote, RE-hydrerar och kör `act` igen ovanpå senaste remote-state. Eftersom
+ * skrivningarna är nyckel-baserade (samma entitets-id → samma fil, overwrite)
+ * är en omkörning idempotent — inga dubbletter, ingen clobber av andras rader.
+ *
+ * Native git (subprocess) snarare än isomorphic-git: git-creds tas via
+ * systemets git-config/credential-helper (SSH-agent, HTTPS-helper), precis
+ * som `NodeGitOps` redan förutsätter.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import { NodeGitOps } from "./node-git-ops";
+import type { GitCommit, PushResult } from "./git-ops";
+import {
+  openServerWorkingCopy,
+  type OpenServerWorkingCopyOpts,
+  type ServerWorkingCopy,
+} from "./server-working-copy";
+
+const execFileP = promisify(execFile);
+
+export interface CloneWorkingCopyOpts {
+  /** Remote-url till firma.git (file://, https:// eller ssh). */
+  url: string;
+  /** Mål-katalog för working-copy:n (måste vara tom/ej existerande). */
+  dir: string;
+  /** Branch att checka ut. Default: remote-default (oftast main). */
+  branch?: string;
+}
+
+/**
+ * Klona `firma.git` till `dir` via system-git. Git-creds hanteras av
+ * systemets git-config/credential-helper — vi skickar inga hemligheter här.
+ */
+export async function cloneWorkingCopy(opts: CloneWorkingCopyOpts): Promise<void> {
+  const args = ["clone", "--quiet"];
+  if (opts.branch) args.push("--branch", opts.branch);
+  args.push(opts.url, opts.dir);
+  await execFileP("git", args);
+}
+
+/** En körbar mutation mot peer-clonens tRPC-caller. */
+export type PeerAct = (caller: ServerWorkingCopy["caller"]) => Promise<void>;
+
+export interface RunPeerCycleOpts extends OpenServerWorkingCopyOpts {
+  /** Max antal försök vid push-konflikt (NonFastForward). Default 3. */
+  maxRetries?: number;
+}
+
+export interface PeerCycleResult {
+  /** Lyckades pushen (ev. efter retries)? */
+  pushed: boolean;
+  /** Antal försök som kördes. */
+  attempts: number;
+  /** Commit:en som pushades (när `pushed`). */
+  commit?: GitCommit;
+  /** Anledning vid misslyckande (sista pushens reason). */
+  reason?: PushResult["reason"];
+}
+
+/**
+ * Kör en konflikt-säker pull → act → push-cykel mot working-copy:n på `dir`.
+ *
+ * Per försök:
+ *   1. `fetch` + `resetHardToRemote` — börja från senaste remote (kastar en
+ *      ev. misslyckad lokal commit från föregående försök).
+ *   2. öppna en FÄRSK `ServerWorkingCopy` (hydrerar ovanpå remote-state).
+ *   3. kör `act(caller)` → write-back skriver filer → `commit(message)`.
+ *   4. `push`. Lyckas → klart. `NonFastForward` → nytt försök. Annat
+ *      (nätverk/okänt) → avbryt.
+ *
+ * `act` MÅSTE vara idempotent/additiv (nyckla mot entitets-id) så en omkörning
+ * efter konflikt inte dubblerar — det är konflikt-säkerheten (ADR 0002).
+ */
+export async function runPeerCycle(
+  dir: string,
+  act: PeerAct,
+  message: string,
+  opts: RunPeerCycleOpts,
+): Promise<PeerCycleResult> {
+  const maxRetries = opts.maxRetries ?? 3;
+  const author = opts.author ?? { name: opts.principal.name, email: opts.principal.email };
+  const gitOps = new NodeGitOps(dir, author.name, author.email, opts.remote ?? "origin", opts.branch ?? "main");
+
+  let reason: PushResult["reason"];
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    // Synka till remote innan vi agerar (CAS-startpunkt).
+    await gitOps.fetch();
+    await gitOps.resetHardToRemote();
+
+    // Färsk hydrering ovanpå senaste remote → act → commit.
+    const wc = await openServerWorkingCopy(dir, opts);
+    await act(wc.caller);
+    const commit = await wc.commit(message);
+
+    const result = await gitOps.push();
+    if (result.ok) return { pushed: true, attempts: attempt, commit };
+
+    reason = result.reason;
+    // Bara NonFastForward är värt att försöka igen; nätverk/okänt avbryter.
+    if (result.reason !== "NonFastForward") break;
+  }
+  return { pushed: false, attempts: maxRetries, reason };
+}

--- a/test/unit/server/local-first/server-peer.test.ts
+++ b/test/unit/server/local-first/server-peer.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Test för server-runtime C — git-peer-loopen (#117, uppfyller #77:s "Klar när").
+ *
+ * Servern klonar firma.git, kör en mutation mot sin clone och pushar
+ * konflikt-säkert tillbaka. Verifierar:
+ *   1. happy path: clone → pull-act-push → remote har den nya raden (1 försök).
+ *   2. konflikt-säkerhet: en konkurrent pushar mellan vår reset och vår push
+ *      → CAS-pushen failar → cykeln synkar, re-agerar (idempotent) och pushar
+ *      → remote har BÅDA ändringarna (additivt, ingen clobber).
+ *
+ * Kräver system-`git` (samma som node-git-ops.test.ts) — hoppas annars över.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest-compat";
+import { mkdtemp, rm, readdir, mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execSync, spawnSync } from "node:child_process";
+import { cloneWorkingCopy, runPeerCycle } from "@/lib/server/local-first/server-peer";
+import { CURRENT_SCHEMA_VERSION } from "@/lib/shared/schema-version";
+import type { Principal } from "@/lib/server/auth/principal";
+
+const ADMIN: Principal = {
+  id: "current-user",
+  email: "anna@firma.local",
+  name: "Anna Advokat",
+  role: "ADMIN",
+  organizationId: "test-org",
+};
+
+const hasGit = (): boolean => spawnSync("git", ["--version"], { stdio: "ignore" }).status === 0;
+const suite = hasGit() ? describe : describe.skip;
+
+const GID = `-c user.email=t@x -c user.name=t`;
+
+suite("server-peer — klona + pull→act→push (#117)", () => {
+  let root: string;
+  let bare: string;
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), "ava-peer-"));
+    bare = join(root, "firma.git");
+    execSync(`git init --bare --quiet --initial-branch=main "${bare}"`);
+    // Seeda en minimal firma.git (bara meta.json) via en throwaway clone.
+    const seed = join(root, "_seed");
+    execSync(`git clone --quiet "${bare}" "${seed}"`);
+    await mkdir(join(seed, ".ava"), { recursive: true });
+    await writeFile(join(seed, ".ava/meta.json"), JSON.stringify({ schemaVersion: CURRENT_SCHEMA_VERSION }));
+    execSync(`git -C "${seed}" ${GID} add -A`);
+    execSync(`git -C "${seed}" ${GID} commit --quiet -m seed`);
+    execSync(`git -C "${seed}" push --quiet origin main`);
+    await rm(seed, { recursive: true, force: true });
+  });
+
+  afterAll(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  /** Lista filer på en path i remote (via en throwaway clone). */
+  async function remoteFiles(sub: string): Promise<string[]> {
+    const v = join(root, `_verify-${sub.replace(/\W/g, "")}`);
+    await rm(v, { recursive: true, force: true });
+    execSync(`git clone --quiet "${bare}" "${v}"`);
+    const files = await readdir(join(v, sub)).catch(() => [] as string[]);
+    await rm(v, { recursive: true, force: true });
+    return files;
+  }
+
+  /** Simulera en konkurrerande peer som pushar en additiv ändring. */
+  function competitorPush(fileName: string): void {
+    const c = join(root, "_competitor");
+    rmrf(c);
+    execSync(`git clone --quiet "${bare}" "${c}"`);
+    execSync(`bash -c 'echo race > "${c}/${fileName}"'`);
+    execSync(`git -C "${c}" ${GID} add -A`);
+    execSync(`git -C "${c}" ${GID} commit --quiet -m competitor`);
+    execSync(`git -C "${c}" push --quiet origin main`);
+    rmrf(c);
+  }
+
+  function rmrf(p: string): void {
+    spawnSync("rm", ["-rf", p]);
+  }
+
+  let peerDir: string;
+  beforeEach(async () => {
+    // Klona till en färsk under-katalog (git clone skapar `peer/` själv).
+    peerDir = join(await mkdtemp(join(root, "peerparent-")), "peer");
+    await cloneWorkingCopy({ url: bare, dir: peerDir });
+  });
+
+  it("happy path: klonar, kör mutation, pushar (1 försök)", async () => {
+    const res = await runPeerCycle(
+      peerDir,
+      async (caller) => { await caller.contacts.create({ id: "c-happy", name: "Glad Klient", contactType: "COMPANY" }); },
+      "feat: lägg till c-happy via peer",
+      { principal: ADMIN },
+    );
+    expect(res.pushed).toBe(true);
+    expect(res.attempts).toBe(1);
+    // Remote har nu kontakten.
+    expect(await remoteFiles("contacts")).toContain("c-happy.json");
+  });
+
+  it("konflikt-säkert: konkurrent-push mellan reset och push → retry + additivt resultat", async () => {
+    let raced = false;
+    const res = await runPeerCycle(
+      peerDir,
+      async (caller) => {
+        await caller.contacts.create({ id: "c-peer", name: "Peer Klient", contactType: "PERSON" });
+        // Bara på första försöket: en konkurrent driver fram remote EFTER vår
+        // reset men FÖRE vår push → vår CAS-push blir NonFastForward.
+        if (!raced) {
+          raced = true;
+          competitorPush("competitor.txt");
+        }
+      },
+      "feat: lägg till c-peer via peer",
+      { principal: ADMIN, maxRetries: 3 },
+    );
+
+    expect(res.pushed).toBe(true);
+    expect(res.attempts).toBe(2); // ett misslyckat + ett lyckat
+    // Additivt: remote har BÅDE konkurrentens fil OCH vår kontakt.
+    const rootFiles = await remoteFiles(".");
+    expect(rootFiles).toContain("competitor.txt");
+    const contacts = await remoteFiles("contacts");
+    // Exakt EN c-peer-fil — idempotent, ingen dubblett (t.ex. "c-peer (1).json").
+    expect(contacts.filter((f) => f.includes("c-peer"))).toEqual(["c-peer.json"]);
+  });
+});


### PR DESCRIPTION
## Vad

**Uppfyller #77:s "Klar när"** — server-runtime C (ADR 0005 fas 1, peer-loopen). Bygger på läs- (#115) + skriv-vägen (#116).

Servern är en git-**peer**, inte dataägare:

- `cloneWorkingCopy({ url, dir, branch? })` — klonar `firma.git` via system-git. Git-creds via systemets git-config/credential-helper (SSH-agent, HTTPS-helper) — inga hemligheter i koden.
- `runPeerCycle(dir, act, message, opts)` — konflikt-säker cykel. Per försök:
  1. `fetch` + `resetHardToRemote` (CAS-startpunkt, kastar ev. misslyckad lokal commit)
  2. öppna en **färsk** `ServerWorkingCopy` (hydrera ovanpå senaste remote)
  3. `act(caller)` → write-back skriver filer → `commit(message)`
  4. `push`. `NonFastForward` → nytt försök ovanpå den nya remoten; nätverk/okänt → avbryt.

## Konflikt-säkerhet (ADR 0002)

Pushen är CAS (`NodeGitOps.push` → `NonFastForward` när remote drivit fram). Vid konflikt synkar cykeln till remote och kör `act` **igen** ovanpå senaste state. Eftersom write-back är nyckel-baserad (samma entitets-id → samma fil, overwrite) är omkörningen **idempotent** — inga dubbletter, ingen clobber av en annan peers rader.

## Test

`test/unit/server/local-first/server-peer.test.ts` (kräver system-`git`, annars skip):

1. **Happy path:** clone → pull-act-push → remote har den nya kontakten (1 försök).
2. **Konflikt-säkerhet:** en konkurrent pushar mellan vår reset och vår push → CAS-pushen failar → cykeln synkar, re-agerar och pushar (2 försök). Remote har **båda** ändringarna additivt + exakt EN `c-peer.json` (idempotent).

## Checks (lokalt, speglar CI)

- ✅ `typecheck` (fresh) + `lint` + `deps:check` (no violations) + `knip` + `duplicates`
- ✅ `test:cov` (`--parallel=2`, som CI) — 2353 pass, rader 82.28% / funktioner 79.43% (golv 76/77)

Stänger #117 och avslutar #77-epikens kärna. Kvar: #118 (körbar entry + paketering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)