### PR TITLE
feat(todo): dag/vecka/månad-vy + deadline-färgkodning (#88)

### DIFF
--- a/src/app/todo/_client.tsx
+++ b/src/app/todo/_client.tsx
@@ -13,25 +13,41 @@
  * Events visas read-only (skapas via integrationer; ej CRUD här).
  */
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Calendar, CheckSquare, Square, Clock, MapPin, Trash2, Pencil, Plus } from "lucide-react";
 import { EntityLink } from "@/lib/client/demo/entity-link";
 import { trpc } from "@/lib/client/trpc";
 import { Modal } from "@/components/ui/modal";
+import { deadlineColor, type DeadlineColor } from "@/lib/shared/deadline-color";
+import { rangeForView, shiftAnchor, viewRangeLabel, groupByDay, type TodoView } from "@/lib/client/todo/todo-views";
 
 const TASK_STATUS_LABELS: Record<string, string> = { TODO: "Att göra", IN_PROGRESS: "Pågår", DONE: "Klar" };
 const TASK_PRIORITY_LABELS: Record<string, string> = { LOW: "Låg", MEDIUM: "Medium", HIGH: "Hög" };
 const EVENT_KIND_LABELS: Record<string, string> = { appointment: "Möte", deadline: "Frist" };
 
+// Vänster-kant-färg per deadline-status (#88). border-transparent när ingen
+// färg så radhöjden inte hoppar mellan färgad/ofärgad.
+const DEADLINE_BORDER: Record<DeadlineColor, string> = {
+  green: "border-l-4 border-green-500",
+  yellow: "border-l-4 border-amber-500",
+  red: "border-l-4 border-red-500",
+};
+const VIEW_LABELS: Record<TodoView, string> = { day: "Dag", week: "Vecka", month: "Månad" };
+const VIEW_PREF_KEY = "ava.todo.view";
+
+function readStoredView(): TodoView {
+  if (typeof localStorage === "undefined") return "day";
+  const v = localStorage.getItem(VIEW_PREF_KEY);
+  return v === "week" || v === "month" ? v : "day";
+}
+
 function startOfDay(d: Date): Date { const x = new Date(d); x.setHours(0, 0, 0, 0); return x; }
-function endOfDay(d: Date): Date { const x = new Date(d); x.setHours(23, 59, 59, 999); return x; }
 function toInputDate(d: Date): string {
   // Använd LOKAL-datum (inte UTC) — annars visar input fel dag för användare
   // öster om UTC innan kl 02:00 lokalt (toISOString → UTC → föregående dag).
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
 function fromInputDate(s: string): Date { const [y, m, day] = s.split("-").map(Number); return new Date(y ?? 1970, (m ?? 1) - 1, day ?? 1); }
-function shiftDays(d: Date, n: number): Date { const x = new Date(d); x.setDate(x.getDate() + n); return x; }
 
 interface TaskForm {
   id?: string;
@@ -57,15 +73,21 @@ function emptyForm(defaultDate: Date): TaskForm {
 /* eslint-disable max-lines-per-function, complexity -- JSX-tung med dag/user-väljare + lista + modal-CRUD */
 export default function TodoClient() {
   const [day, setDay] = useState<Date>(() => startOfDay(new Date()));
+  const [view, setView] = useState<TodoView>(() => readStoredView());
   const [userId, setUserId] = useState<string>("");
   const [modalState, setModalState] = useState<{ mode: "create" | "edit"; form: TaskForm } | null>(null);
+
+  useEffect(() => {
+    try { localStorage.setItem(VIEW_PREF_KEY, view); } catch { /* pref ej kritisk */ }
+  }, [view]);
+  const now = new Date();
 
   const users = trpc.user.list.useQuery();
   const me = trpc.user.current.useQuery();
   const effectiveUserId = userId || me.data?.id;
   const isOwn = !userId || userId === me.data?.id;
 
-  const range = useMemo(() => ({ from: startOfDay(day), to: endOfDay(day) }), [day]);
+  const range = useMemo(() => rangeForView(view, day), [view, day]);
   const items = trpc.todo.list.useQuery(
     { from: range.from, to: range.to, ...(effectiveUserId ? { userId: effectiveUserId } : {}) },
     // Gate på me.data → demo-runtime hydrerar users asynkront; utan gate
@@ -82,7 +104,7 @@ export default function TodoClient() {
   const updateTaskStatus = trpc.task.update.useMutation({ onSuccess: refresh });
   const deleteTask = trpc.task.delete.useMutation({ onSuccess: refresh });
 
-  const dayLabel = day.toLocaleDateString("sv-SE", { weekday: "long", day: "numeric", month: "long" });
+  const periodLabel = viewRangeLabel(view, day);
 
   function submitForm(): void {
     if (!modalState) return;
@@ -104,11 +126,25 @@ export default function TodoClient() {
   return (
     <div className="p-6 space-y-4">
       <header className="flex flex-wrap items-center justify-between gap-3">
-        <h1 className="text-2xl font-bold">Att göra <span className="ml-2 text-base font-normal text-gray-500">{dayLabel}</span></h1>
+        <h1 className="text-2xl font-bold">Att göra <span className="ml-2 text-base font-normal text-gray-500 capitalize">{periodLabel}</span></h1>
         <div className="flex items-center gap-2">
-          <button onClick={() => setDay((d) => shiftDays(d, -1))} className="px-3 py-1.5 text-sm border rounded hover:bg-gray-50">← Igår</button>
+          {/* Vy-växel Dag/Vecka/Månad (#88) */}
+          <div role="group" aria-label="Vy" className="inline-flex rounded border overflow-hidden">
+            {(["day", "week", "month"] as const).map((v) => (
+              <button
+                key={v}
+                type="button"
+                aria-pressed={view === v}
+                onClick={() => setView(v)}
+                className={`px-3 py-1.5 text-sm ${view === v ? "bg-blue-600 text-white" : "bg-white hover:bg-gray-50"}`}
+              >
+                {VIEW_LABELS[v]}
+              </button>
+            ))}
+          </div>
+          <button onClick={() => setDay((d) => shiftAnchor(view, d, -1))} aria-label="Föregående" className="px-3 py-1.5 text-sm border rounded hover:bg-gray-50">←</button>
           <button onClick={() => setDay(startOfDay(new Date()))} className="px-3 py-1.5 text-sm border rounded hover:bg-gray-50">Idag</button>
-          <button onClick={() => setDay((d) => shiftDays(d, 1))} className="px-3 py-1.5 text-sm border rounded hover:bg-gray-50">Imorgon →</button>
+          <button onClick={() => setDay((d) => shiftAnchor(view, d, 1))} aria-label="Nästa" className="px-3 py-1.5 text-sm border rounded hover:bg-gray-50">→</button>
           <input
             type="date"
             value={toInputDate(day)}
@@ -134,34 +170,28 @@ export default function TodoClient() {
         </select>
       </div>
 
-      <TodoList
-        items={items.data ?? []}
-        isLoading={items.isLoading}
-        isOwn={isOwn}
-        onToggle={(it) => {
-          if (it.status === "DONE") {
-            updateTaskStatus.mutate({ id: it.id, status: "TODO" });
-          } else {
-            completeTask.mutate({ id: it.id });
-          }
-        }}
-        onEdit={(it) => {
-          setModalState({
+      {(() => {
+        const handlers = {
+          isOwn,
+          now,
+          onToggle: (it: TodoRow) => {
+            if (it.status === "DONE") updateTaskStatus.mutate({ id: it.id, status: "TODO" });
+            else completeTask.mutate({ id: it.id });
+          },
+          onEdit: (it: TodoRow) => setModalState({
             mode: "edit",
             form: {
-              id: it.id,
-              title: it.title,
-              description: "",
-              priority: "MEDIUM",
+              id: it.id, title: it.title, description: "", priority: "MEDIUM",
               dueAt: new Date(it.at).toISOString().slice(0, 16),
               matterId: it.matter?.id ?? "",
             },
-          });
-        }}
-        onDelete={(it) => {
-          if (confirm(`Ta bort "${it.title}"?`)) deleteTask.mutate({ id: it.id });
-        }}
-      />
+          }),
+          onDelete: (it: TodoRow) => { if (confirm(`Ta bort "${it.title}"?`)) deleteTask.mutate({ id: it.id }); },
+        };
+        const data = items.data ?? [];
+        if (view === "day") return <TodoList items={data} isLoading={items.isLoading} {...handlers} />;
+        return <GroupedTodoList items={data} isLoading={items.isLoading} {...handlers} />;
+      })()}
 
       <Modal open={!!modalState} title={modalState?.mode === "edit" ? "Ändra Att-göra" : "Ny Att-göra"} onClose={() => setModalState(null)} widthClass="max-w-xl">
         {modalState && (
@@ -197,19 +227,42 @@ interface ListProps {
   items: TodoRow[];
   isLoading: boolean;
   isOwn: boolean;
+  now: Date;
   onToggle: (it: TodoRow) => void;
   onEdit: (it: TodoRow) => void;
   onDelete: (it: TodoRow) => void;
 }
 
-function TodoList({ items, isLoading, isOwn, onToggle, onEdit, onDelete }: ListProps) {
+function TodoList({ items, isLoading, isOwn, now, onToggle, onEdit, onDelete }: ListProps) {
   if (isLoading) return <p className="text-sm text-gray-400">Laddar…</p>;
-  if (items.length === 0) return <p className="text-sm text-gray-500">Inget på agendan denna dag.</p>;
+  if (items.length === 0) return <p className="text-sm text-gray-500">Inget på agendan denna period.</p>;
 
   return (
     <ul className="divide-y divide-gray-200 bg-white border border-gray-200 rounded-lg overflow-hidden">
-      {items.map((it) => <TodoLi key={`${it.source}-${it.id}`} it={it} isOwn={isOwn} onToggle={onToggle} onEdit={onEdit} onDelete={onDelete} />)}
+      {items.map((it) => <TodoLi key={`${it.source}-${it.id}`} it={it} isOwn={isOwn} now={now} onToggle={onToggle} onEdit={onEdit} onDelete={onDelete} />)}
     </ul>
+  );
+}
+
+/** Vecka/månad: gruppera per dag med datum-rubrik. Återanvänder rad-renderingen. */
+function GroupedTodoList({ items, isLoading, isOwn, now, onToggle, onEdit, onDelete }: ListProps) {
+  if (isLoading) return <p className="text-sm text-gray-400">Laddar…</p>;
+  if (items.length === 0) return <p className="text-sm text-gray-500">Inget på agendan denna period.</p>;
+
+  const groups = groupByDay(items);
+  return (
+    <div className="space-y-4">
+      {groups.map((g) => (
+        <section key={g.key}>
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-1 capitalize">
+            {g.day.toLocaleDateString("sv-SE", { weekday: "long", day: "numeric", month: "long" })}
+          </h2>
+          <ul className="divide-y divide-gray-200 bg-white border border-gray-200 rounded-lg overflow-hidden">
+            {g.items.map((it) => <TodoLi key={`${it.source}-${it.id}`} it={it} isOwn={isOwn} now={now} onToggle={onToggle} onEdit={onEdit} onDelete={onDelete} />)}
+          </ul>
+        </section>
+      ))}
+    </div>
   );
 }
 
@@ -249,16 +302,23 @@ function TodoIcon({ it, onToggle, isOwn }: { it: TodoRow; onToggle: (it: TodoRow
 interface LiProps {
   it: TodoRow;
   isOwn: boolean;
+  now: Date;
   onToggle: (it: TodoRow) => void;
   onEdit: (it: TodoRow) => void;
   onDelete: (it: TodoRow) => void;
 }
 
-function TodoLi({ it, isOwn, onToggle, onEdit, onDelete }: LiProps) {
+function TodoLi({ it, isOwn, now, onToggle, onEdit, onDelete }: LiProps) {
   const isDone = it.source === "task" && it.status === "DONE";
   const editable = isOwn && it.source === "task";
+  // Deadline-färg endast för uppgifter (events har egen tidslogik). #88
+  const color = it.source === "task" ? deadlineColor(it.at, now, { done: isDone }) : null;
+  const borderClass = color ? DEADLINE_BORDER[color] : "border-l-4 border-transparent";
   return (
-    <li className={`flex items-center gap-3 px-4 py-3 hover:bg-gray-50 ${isDone ? "opacity-60" : ""}`}>
+    <li
+      data-deadline={color ?? "none"}
+      className={`flex items-center gap-3 px-4 py-3 hover:bg-gray-50 ${borderClass} ${isDone ? "opacity-60" : ""}`}
+    >
       <TodoIcon it={it} onToggle={onToggle} isOwn={isOwn} />
       <span className="font-mono text-xs text-gray-500 w-28 shrink-0">{timeLabelFor(it)}</span>
       {editable ? (

--- a/src/lib/client/todo/todo-views.ts
+++ b/src/lib/client/todo/todo-views.ts
@@ -1,0 +1,103 @@
+/**
+ * Ren vy-logik för todo-listans dag/vecka/månad-växling (#88).
+ *
+ * Ingen React — bara datum-matematik + gruppering, så gränsfallen (vecka
+ * börjar måndag, månadsgränser, navigering per vy) kan enhetstestas isolerat.
+ * Allt i LOKAL tid (samma konvention som resten av todo/kalender-UI:t).
+ */
+
+export type TodoView = "day" | "week" | "month";
+
+export interface DateRange {
+  from: Date;
+  to: Date;
+}
+
+function startOfDay(d: Date): Date {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
+}
+
+function endOfDay(d: Date): Date {
+  const x = new Date(d);
+  x.setHours(23, 59, 59, 999);
+  return x;
+}
+
+/** Måndag som veckostart (sv-SE/ISO-8601). */
+function startOfWeek(d: Date): Date {
+  const x = startOfDay(d);
+  const dow = (x.getDay() + 6) % 7; // mån=0 … sön=6
+  x.setDate(x.getDate() - dow);
+  return x;
+}
+
+function startOfMonth(d: Date): Date {
+  return startOfDay(new Date(d.getFullYear(), d.getMonth(), 1));
+}
+
+/** Tidsintervallet [from, to] som en vy täcker kring `anchor`. */
+export function rangeForView(view: TodoView, anchor: Date): DateRange {
+  if (view === "day") return { from: startOfDay(anchor), to: endOfDay(anchor) };
+  if (view === "week") {
+    const from = startOfWeek(anchor);
+    const to = endOfDay(new Date(from.getFullYear(), from.getMonth(), from.getDate() + 6));
+    return { from, to };
+  }
+  const from = startOfMonth(anchor);
+  const to = endOfDay(new Date(anchor.getFullYear(), anchor.getMonth() + 1, 0)); // sista dagen i månaden
+  return { from, to };
+}
+
+/** Flytta ankaret en vy-enhet framåt (`dir=1`) eller bakåt (`dir=-1`). */
+export function shiftAnchor(view: TodoView, anchor: Date, dir: -1 | 1): Date {
+  const x = new Date(anchor);
+  if (view === "day") x.setDate(x.getDate() + dir);
+  else if (view === "week") x.setDate(x.getDate() + 7 * dir);
+  else x.setMonth(x.getMonth() + dir);
+  return startOfDay(x);
+}
+
+/** Läsbar etikett för aktuell vy-period (sv-SE). */
+export function viewRangeLabel(view: TodoView, anchor: Date): string {
+  if (view === "day") {
+    return anchor.toLocaleDateString("sv-SE", { weekday: "long", day: "numeric", month: "long" });
+  }
+  if (view === "month") {
+    return anchor.toLocaleDateString("sv-SE", { month: "long", year: "numeric" });
+  }
+  const { from, to } = rangeForView("week", anchor);
+  const f = from.toLocaleDateString("sv-SE", { day: "numeric", month: "short" });
+  const t = to.toLocaleDateString("sv-SE", { day: "numeric", month: "short" });
+  return `${f} – ${t}`;
+}
+
+export interface DayGroup<T> {
+  /** Dagens startdatum (lokal midnatt). */
+  day: Date;
+  /** Stabil nyckel `YYYY-MM-DD` (lokal). */
+  key: string;
+  items: T[];
+}
+
+function localDayKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+/**
+ * Gruppera tidsordnade poster per kalenderdag (lokal). Bevarar inkommande
+ * ordning inom varje grupp; grupperna sorteras kronologiskt.
+ */
+export function groupByDay<T extends { at: Date | string }>(items: T[]): DayGroup<T>[] {
+  const map = new Map<string, DayGroup<T>>();
+  for (const item of items) {
+    const at = item.at instanceof Date ? item.at : new Date(item.at);
+    const day = startOfDay(at);
+    const key = localDayKey(day);
+    const group = map.get(key);
+    if (group) group.items.push(item);
+    else map.set(key, { day, key, items: [item] });
+  }
+  return [...map.values()].sort((a, b) => a.day.getTime() - b.day.getTime());
+}

--- a/src/lib/shared/deadline-color.ts
+++ b/src/lib/shared/deadline-color.ts
@@ -1,0 +1,51 @@
+/**
+ * `deadlineColor` — ren, ramverks-agnostisk färgkodning av en uppgifts
+ * återstående tid till sin deadline (#88).
+ *
+ * Färgskala (baserat på `dueAt - now`):
+ *   - **grön:**  ≥ 7 dagar kvar
+ *   - **gul:**   2–7 dagar kvar (`2d ≤ kvar < 7d`)
+ *   - **röd:**   < 2 dagar kvar — inklusive **förfallen** (kvar < 0)
+ *   - **null (neutral):** ingen `dueAt`, eller uppgiften är klar (DONE)
+ *
+ * Gränsfallen är låsta med `<`: exakt 7 dygn → grön, exakt 2 dygn → gul.
+ * Bor i `shared/` (ingen UI-/server-koppling) så den kan enhetstestas
+ * isolerat och återanvändas av både todo-vyn och ev. dashboard-widgets.
+ */
+
+export type DeadlineColor = "green" | "yellow" | "red";
+
+const DAY_MS = 86_400_000;
+const RED_WITHIN_MS = 2 * DAY_MS;
+const YELLOW_WITHIN_MS = 7 * DAY_MS;
+
+export interface DeadlineColorOpts {
+  /** Klar uppgift (status DONE) → ingen färg. */
+  done?: boolean;
+}
+
+/** Tolka `dueAt` → giltig epoch-ms, eller `null` (saknad/ogiltig). */
+function toValidMs(dueAt: Date | string | null | undefined): number | null {
+  if (dueAt == null || dueAt === "") return null;
+  const ms = (dueAt instanceof Date ? dueAt : new Date(dueAt)).getTime();
+  return Number.isNaN(ms) ? null : ms;
+}
+
+/**
+ * Returnera deadline-färgen för `dueAt` relativt `now`, eller `null` när
+ * ingen färg ska visas (saknad deadline eller klar uppgift).
+ */
+export function deadlineColor(
+  dueAt: Date | string | null | undefined,
+  now: Date,
+  opts: DeadlineColorOpts = {},
+): DeadlineColor | null {
+  if (opts.done) return null;
+  const ms = toValidMs(dueAt);
+  if (ms === null) return null;
+
+  const remaining = ms - now.getTime();
+  if (remaining < RED_WITHIN_MS) return "red"; // < 2 dygn, inkl. förfallen
+  if (remaining < YELLOW_WITHIN_MS) return "yellow"; // 2–7 dygn
+  return "green"; // ≥ 7 dygn
+}

--- a/test/unit/components/todo-views.test.tsx
+++ b/test/unit/components/todo-views.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * Vy-render-test för todo-listan (#88): vy-växel finns och fungerar, och
+ * uppgifter färgkodas mot sin deadline via data-deadline-attributet.
+ * (Färg- och vy-LOGIKEN är enhetstestad separat i deadline-color/todo-views.)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { render, screen, fireEvent } from "@testing-library/react";
+import TodoClient from "@/app/todo/_client";
+
+const DAY = 86_400_000;
+interface Row {
+  id: string; source: "task" | "event"; title: string; at: Date; endAt: Date | null;
+  allDay: boolean; status: string | null; kind: string | null; location: string | null;
+  matter: { id: string; matterNumber: string; title: string } | null;
+}
+const todoQuery = { data: [] as Row[], isLoading: false };
+
+const row = (over: Partial<Row> = {}): Row => ({
+  id: "t1", source: "task", title: "Uppgift", at: new Date(Date.now() + DAY),
+  endAt: null, allDay: false, status: "TODO", kind: null, location: null, matter: null, ...over,
+});
+
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: {
+    useUtils: () => ({ todo: { list: { invalidate: vi.fn() } } }),
+    user: {
+      list: { useQuery: () => ({ data: { users: [{ id: "u1", name: "Anna" }] } }) },
+      current: { useQuery: () => ({ data: { id: "u1", role: "LAWYER" } }) },
+    },
+    todo: { list: { useQuery: () => todoQuery } },
+    matter: { list: { useQuery: () => ({ data: { matters: [] } }) } },
+    task: {
+      create: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      update: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      complete: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      delete: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+    },
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  todoQuery.data = [];
+  todoQuery.isLoading = false;
+  localStorage.clear();
+});
+
+describe("TodoClient — vyer + deadline-färg (#88)", () => {
+  it("renderar vy-växeln Dag/Vecka/Månad", () => {
+    render(<TodoClient />);
+    expect(screen.getByRole("button", { name: "Dag" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Vecka" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Månad" })).toBeInTheDocument();
+  });
+
+  it("dag-vyn är förvald (aria-pressed)", () => {
+    render(<TodoClient />);
+    expect(screen.getByRole("button", { name: "Dag" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("klick på Vecka byter aktiv vy", () => {
+    render(<TodoClient />);
+    fireEvent.click(screen.getByRole("button", { name: "Vecka" }));
+    expect(screen.getByRole("button", { name: "Vecka" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Dag" })).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("uppgift med nära deadline färgkodas röd, avlägsen grön", () => {
+    todoQuery.data = [
+      row({ id: "soon", title: "Brådskande", at: new Date(Date.now() + DAY) }),       // < 2d → röd
+      row({ id: "later", title: "Senare", at: new Date(Date.now() + 20 * DAY) }),      // ≥ 7d → grön
+    ];
+    const { container } = render(<TodoClient />);
+    const reds = container.querySelectorAll('[data-deadline="red"]');
+    const greens = container.querySelectorAll('[data-deadline="green"]');
+    expect(reds.length).toBe(1);
+    expect(greens.length).toBe(1);
+  });
+
+  it("klar uppgift (DONE) får ingen deadline-färg", () => {
+    todoQuery.data = [row({ id: "done", status: "DONE", at: new Date(Date.now() + DAY) })];
+    const { container } = render(<TodoClient />);
+    expect(container.querySelectorAll('[data-deadline="red"]').length).toBe(0);
+    expect(container.querySelectorAll('[data-deadline="none"]').length).toBe(1);
+  });
+});

--- a/test/unit/lib/deadline-color.test.ts
+++ b/test/unit/lib/deadline-color.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Lås gränsfallen för deadline-färgkodningen (#88).
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { deadlineColor } from "@/lib/shared/deadline-color";
+
+const NOW = new Date("2026-06-10T12:00:00.000Z");
+const DAY = 86_400_000;
+const at = (msFromNow: number): Date => new Date(NOW.getTime() + msFromNow);
+
+describe("deadlineColor", () => {
+  it("grön när ≥ 7 dagar kvar", () => {
+    expect(deadlineColor(at(8 * DAY), NOW)).toBe("green");
+    expect(deadlineColor(at(30 * DAY), NOW)).toBe("green");
+  });
+
+  it("grön exakt vid 7-dygnsgränsen (≥, inte <)", () => {
+    expect(deadlineColor(at(7 * DAY), NOW)).toBe("green");
+  });
+
+  it("gul när 2–7 dagar kvar", () => {
+    expect(deadlineColor(at(5 * DAY), NOW)).toBe("yellow");
+    expect(deadlineColor(at(7 * DAY - 1), NOW)).toBe("yellow");
+  });
+
+  it("gul exakt vid 2-dygnsgränsen (2d är inte < 2d)", () => {
+    expect(deadlineColor(at(2 * DAY), NOW)).toBe("yellow");
+  });
+
+  it("röd när < 2 dagar kvar", () => {
+    expect(deadlineColor(at(2 * DAY - 1), NOW)).toBe("red");
+    expect(deadlineColor(at(1 * DAY), NOW)).toBe("red");
+    expect(deadlineColor(at(60 * 1000), NOW)).toBe("red");
+  });
+
+  it("röd när förfallen (dueAt passerat)", () => {
+    expect(deadlineColor(at(-1), NOW)).toBe("red");
+    expect(deadlineColor(at(-5 * DAY), NOW)).toBe("red");
+  });
+
+  it("null när ingen dueAt", () => {
+    expect(deadlineColor(null, NOW)).toBeNull();
+    expect(deadlineColor(undefined, NOW)).toBeNull();
+    expect(deadlineColor("", NOW)).toBeNull();
+  });
+
+  it("null när uppgiften är klar (DONE), oavsett deadline", () => {
+    expect(deadlineColor(at(-5 * DAY), NOW, { done: true })).toBeNull();
+    expect(deadlineColor(at(1 * DAY), NOW, { done: true })).toBeNull();
+  });
+
+  it("accepterar ISO-sträng (demo-projektionens datumformat)", () => {
+    expect(deadlineColor(at(1 * DAY).toISOString(), NOW)).toBe("red");
+    expect(deadlineColor(at(10 * DAY).toISOString(), NOW)).toBe("green");
+  });
+
+  it("null vid ogiltigt datum (defensivt, kraschar inte)", () => {
+    expect(deadlineColor("inte-ett-datum", NOW)).toBeNull();
+  });
+});

--- a/test/unit/lib/todo-views.test.ts
+++ b/test/unit/lib/todo-views.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Lås vy-logiken för todo dag/vecka/månad (#88) — gränsfall i lokal tid.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import {
+  rangeForView,
+  shiftAnchor,
+  viewRangeLabel,
+  groupByDay,
+} from "@/lib/client/todo/todo-views";
+
+// Onsdag 2026-06-10 (lokal). Veckan mån–sön = 2026-06-08 … 2026-06-14.
+const WED = new Date(2026, 5, 10, 14, 30);
+
+describe("rangeForView", () => {
+  it("dag: midnatt → 23:59 samma dag", () => {
+    const { from, to } = rangeForView("day", WED);
+    expect(from.getHours()).toBe(0);
+    expect(from.getDate()).toBe(10);
+    expect(to.getDate()).toBe(10);
+    expect(to.getHours()).toBe(23);
+  });
+
+  it("vecka: måndag → söndag", () => {
+    const { from, to } = rangeForView("week", WED);
+    expect(from.getDate()).toBe(8); // måndag
+    expect(from.getDay()).toBe(1);
+    expect(to.getDate()).toBe(14); // söndag
+    expect(to.getDay()).toBe(0);
+  });
+
+  it("vecka: söndag hör till föregående måndag-vecka", () => {
+    const sun = new Date(2026, 5, 14, 9, 0);
+    const { from, to } = rangeForView("week", sun);
+    expect(from.getDate()).toBe(8);
+    expect(to.getDate()).toBe(14);
+  });
+
+  it("månad: 1:a → sista dagen", () => {
+    const { from, to } = rangeForView("month", WED);
+    expect(from.getDate()).toBe(1);
+    expect(from.getMonth()).toBe(5);
+    expect(to.getDate()).toBe(30); // juni har 30 dagar
+    expect(to.getMonth()).toBe(5);
+  });
+});
+
+describe("shiftAnchor", () => {
+  it("dag ±1", () => {
+    expect(shiftAnchor("day", WED, 1).getDate()).toBe(11);
+    expect(shiftAnchor("day", WED, -1).getDate()).toBe(9);
+  });
+  it("vecka ±7 dagar", () => {
+    expect(shiftAnchor("week", WED, 1).getDate()).toBe(17);
+    expect(shiftAnchor("week", WED, -1).getDate()).toBe(3);
+  });
+  it("månad ±1 månad", () => {
+    expect(shiftAnchor("month", WED, 1).getMonth()).toBe(6);
+    expect(shiftAnchor("month", WED, -1).getMonth()).toBe(4);
+  });
+});
+
+describe("viewRangeLabel", () => {
+  it("ger en icke-tom etikett per vy", () => {
+    expect(viewRangeLabel("day", WED)).toContain("juni");
+    expect(viewRangeLabel("month", WED)).toContain("juni");
+    expect(viewRangeLabel("week", WED)).toMatch(/–/);
+  });
+});
+
+describe("groupByDay", () => {
+  it("grupperar per kalenderdag och sorterar kronologiskt", () => {
+    const items = [
+      { at: new Date(2026, 5, 10, 9, 0), id: "b" },
+      { at: new Date(2026, 5, 8, 15, 0), id: "a" },
+      { at: new Date(2026, 5, 10, 18, 0), id: "c" },
+    ];
+    const groups = groupByDay(items);
+    expect(groups.map((g) => g.key)).toEqual(["2026-06-08", "2026-06-10"]);
+    expect(groups[1]!.items.map((i) => i.id)).toEqual(["b", "c"]); // bevarad ordning
+  });
+
+  it("hanterar ISO-strängar (demo-projektionens datumformat)", () => {
+    const groups = groupByDay([{ at: new Date(2026, 5, 9, 12).toISOString(), id: "x" }]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.key).toBe("2026-06-09");
+  });
+
+  it("tom in → tom ut", () => {
+    expect(groupByDay([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Vad

Att-göra-listan (`src/app/todo/`) får **vy-växel** (Dag/Vecka/Månad) och **deadline-färgkodning**.

### Färgkodning
Ren helper `deadlineColor(dueAt, now, { done })` i `src/lib/shared/`:
- 🟢 **grön:** ≥ 7 dagar kvar
- 🟡 **gul:** 2–7 dagar kvar
- 🔴 **röd:** < 2 dagar kvar (inkl. **förfallen**)
- **neutral (null):** ingen `dueAt`, eller uppgift i DONE

Gränsfallen låsta med `<` (exakt 7d → grön, exakt 2d → gul) och enhetstestade.

### Vyer
Ren vy-logik i `src/lib/client/todo/todo-views.ts` (enhetstestad):
- `rangeForView` — dag / vecka (mån–sön) / månad (1:a–sista)
- `shiftAnchor` — föregående/nästa per vy
- `viewRangeLabel`, `groupByDay`

UI: segmenterad vy-växel (persisterad i localStorage), generisk ←/→-navigering per vy. **Dag** = platt lista; **vecka/månad** = grupperat per dag med datum-rubrik. Varje uppgiftsrad får vänster-kantfärg + `data-deadline`-attribut.

## Test
- `deadline-color.test.ts` — alla gränsfall (≥7/2–7/<2/förfallen/ingen dueAt/DONE/ISO-sträng/ogiltigt datum).
- `todo-views.test.ts` — range-gränser (vecka mån–sön, söndag-edge, månadslängd), shiftAnchor, groupByDay.
- `todo-views.test.tsx` (komponent) — vy-växeln renderas + byter aktiv vy; rader färgkodas röd/grön; DONE → ingen färg.

## Checks (lokalt, speglar CI)
- ✅ `typecheck` + `lint` (complexity ≤ 8) + `deps:check` + `knip` + `duplicates`
- ✅ `test:cov` — 2379 pass, rader 82.10% / funktioner 79.03% (golv 76/77)
- ✅ `build:demo` (static export grön — app-ändring)

Stänger #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)