### PR TITLE
feat(ui): flytta Ärenden direkt under Jävskontroll i sidomenyn (#125)

### DIFF
--- a/src/components/shell/sidebar.tsx
+++ b/src/components/shell/sidebar.tsx
@@ -24,11 +24,12 @@ export function signOutLocally(): void {
 
 const navigation = [
   // Jävskontroll överst — första steget i ärendehantering, mest framträdande (#89).
+  // Ärenden direkt under — kärnan i det dagliga arbetet.
   { name: "Jävskontroll", href: "/conflicts", icon: "🔍" },
+  { name: "Ärenden", href: "/matters", icon: "📁" },
   { name: "Dashboard", href: "/", icon: "📊" },
   { name: "Att göra", href: "/todo", icon: "✅" },
   { name: "Kontakter", href: "/contacts", icon: "👤" },
-  { name: "Ärenden", href: "/matters", icon: "📁" },
   { name: "Dokumentsök", href: "/search", icon: "📄" },
   { name: "Dokumentmallar", href: "/templates", icon: "📝" },
   { name: "Tidregistrering", href: "/time", icon: "⏱️" },

--- a/test/unit/components/sidebar.test.tsx
+++ b/test/unit/components/sidebar.test.tsx
@@ -39,13 +39,15 @@ describe("Sidebar", () => {
     expect(screen.getAllByText("Användare")[0]).toBeInTheDocument();
   });
 
-  it("visar Jävskontroll överst, före Dashboard (#89)", () => {
+  it("visar Jävskontroll överst, sedan Ärenden, före Dashboard (#89)", () => {
     render(<Sidebar />);
     const texts = screen.getAllByRole("link").map((l) => l.textContent ?? "");
     const jav = texts.findIndex((t) => t.includes("Jävskontroll"));
+    const arenden = texts.findIndex((t) => t.includes("Ärenden"));
     const dash = texts.findIndex((t) => t.includes("Dashboard"));
     expect(jav).toBeGreaterThanOrEqual(0);
-    expect(jav).toBeLessThan(dash);
+    expect(arenden).toBe(jav + 1);
+    expect(arenden).toBeLessThan(dash);
   });
 
   it("markerar dashboard som aktiv när pathname=/", () => {


### PR DESCRIPTION
Closes #125.

Flyttar **Ärenden** upp till plats 2 i sidomenyn (`src/components/shell/sidebar.tsx`), direkt under Jävskontroll och ovanför Dashboard — kärnan i det dagliga arbetet.

Ny ordning: Jävskontroll → Ärenden → Dashboard → Att göra → Kontakter → …

Ordningstestet (`test/unit/components/sidebar.test.tsx`) förstärks att låsa Jävskontroll → Ärenden → Dashboard. Alla 11 sidebar-tester gröna lokalt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)