### PR TITLE
refactor(ui): byt etikett "Dashboard" → "Startsida" överallt

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -48,7 +48,7 @@ export default function Dashboard() {
     <div>
       <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
+          <h1 className="text-2xl font-bold text-gray-900">Startsida</h1>
           <p className="text-sm text-gray-500 capitalize">{dayLabel(ymd)}</p>
         </div>
         <DaySwitcher ymd={ymd} onChange={setYmd} />

--- a/src/components/shell/sidebar.tsx
+++ b/src/components/shell/sidebar.tsx
@@ -25,7 +25,7 @@ export function signOutLocally(): void {
 const navigation = [
   // Jävskontroll överst — första steget i ärendehantering, mest framträdande (#89).
   { name: "Jävskontroll", href: "/conflicts", icon: "🔍" },
-  { name: "Dashboard", href: "/", icon: "📊" },
+  { name: "Startsida", href: "/", icon: "📊" },
   { name: "Att göra", href: "/todo", icon: "✅" },
   { name: "Kontakter", href: "/contacts", icon: "👤" },
   { name: "Ärenden", href: "/matters", icon: "📁" },

--- a/src/components/ui/feature-unavailable.tsx
+++ b/src/components/ui/feature-unavailable.tsx
@@ -24,7 +24,7 @@ export function FeatureUnavailable({ title, description }: Props) {
         <p className="text-xs text-amber-800">
           Den här sidan kräver auth/server-funktionalitet som demo-deployen
           inte har. I full-deploy (Tier 2/3) — se{" "}
-          <Link href="/" className="underline">Dashboard</Link> för att gå
+          <Link href="/" className="underline">Startsida</Link> för att gå
           tillbaka till de delar som fungerar:
         </p>
         <ul className="mt-3 text-xs text-amber-800 space-y-1">

--- a/test/e2e/demo-smoke.spec.ts
+++ b/test/e2e/demo-smoke.spec.ts
@@ -15,7 +15,7 @@ import { test, expect } from "@playwright/test";
 const BASE = process.env.AVA_DEMO_BASE_URL ?? "https://ulrik-s.github.io/ava";
 
 const ROUTES = [
-  { path: "/", expectText: /Dashboard|AVA/i },
+  { path: "/", expectText: /Startsida|AVA/i },
   { path: "/demo/", expectText: /AVA Demo|Vill du prova/i },
   { path: "/matters/", expectText: /Ärenden|Nytt ärende/i },
   { path: "/contacts/", expectText: /Kontakter/i },

--- a/test/unit/app/page.test.tsx
+++ b/test/unit/app/page.test.tsx
@@ -35,7 +35,7 @@ beforeEach(() => {
 describe("Dashboard", () => {
   it("renderar rubrik + tre paneler", () => {
     render(<Dashboard />);
-    expect(screen.getByRole("heading", { name: /Dashboard/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Startsida/i })).toBeInTheDocument();
     expect(screen.getByText(/Att göra/i)).toBeInTheDocument();
     expect(screen.getByText(/Tidrapportering/i)).toBeInTheDocument();
     expect(screen.getByText(/Senaste ärenden/i)).toBeInTheDocument();

--- a/test/unit/components/app-shell.test.tsx
+++ b/test/unit/components/app-shell.test.tsx
@@ -27,8 +27,8 @@ describe("AppShell", () => {
   it("renderar Sidebar med användarnamn när tillgängligt", () => {
     currentQuery.data = { name: "Anna Advokat" };
     render(<AppShell>barn</AppShell>);
-    // Sidebar har länkar för varje nav-item — "Dashboard" är första
-    expect(screen.getAllByText("Dashboard").length).toBeGreaterThan(0);
+    // Sidebar har länkar för varje nav-item — "Startsida" är första
+    expect(screen.getAllByText("Startsida").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Anna Advokat").length).toBeGreaterThan(0);
   });
 

--- a/test/unit/components/sidebar.test.tsx
+++ b/test/unit/components/sidebar.test.tsx
@@ -31,7 +31,7 @@ describe("Sidebar", () => {
   it("renderar alla huvudlänkar", () => {
     render(<Sidebar />);
     // Mobile + desktop visar samma — så vi får dubbletter; firstMatch räcker
-    expect(screen.getAllByText("Dashboard")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("Startsida")[0]).toBeInTheDocument();
     expect(screen.getAllByText("Kontakter")[0]).toBeInTheDocument();
     expect(screen.getAllByText("Ärenden")[0]).toBeInTheDocument();
     expect(screen.getAllByText("Tidregistrering")[0]).toBeInTheDocument();
@@ -39,11 +39,11 @@ describe("Sidebar", () => {
     expect(screen.getAllByText("Användare")[0]).toBeInTheDocument();
   });
 
-  it("visar Jävskontroll överst, före Dashboard (#89)", () => {
+  it("visar Jävskontroll överst, före Startsida (#89)", () => {
     render(<Sidebar />);
     const texts = screen.getAllByRole("link").map((l) => l.textContent ?? "");
     const jav = texts.findIndex((t) => t.includes("Jävskontroll"));
-    const dash = texts.findIndex((t) => t.includes("Dashboard"));
+    const dash = texts.findIndex((t) => t.includes("Startsida"));
     expect(jav).toBeGreaterThanOrEqual(0);
     expect(jav).toBeLessThan(dash);
   });
@@ -51,7 +51,7 @@ describe("Sidebar", () => {
   it("markerar dashboard som aktiv när pathname=/", () => {
     pathnameMock.mockReturnValue("/");
     render(<Sidebar />);
-    const dashboardLinks = screen.getAllByRole("link", { name: /Dashboard/ });
+    const dashboardLinks = screen.getAllByRole("link", { name: /Startsida/ });
     // Minst en aktiv (har bg-blue-50 i className)
     expect(dashboardLinks.some((l) => l.className.includes("bg-blue-50"))).toBe(true);
   });


### PR DESCRIPTION
Byter den användarvända etiketten **"Dashboard" → "Startsida"** överallt i UI:t.

## Ändringar
- `src/components/shell/sidebar.tsx` — nav-etikett
- `src/app/page.tsx` — `<h1>` på startsidan
- `src/components/ui/feature-unavailable.tsx` — länktext tillbaka till startsidan
- Tester uppdaterade: `sidebar`, `page`, `app-shell`, `demo-smoke` (e2e)

Interna identifierare (React-komponenten `Dashboard`, importnamn) lämnas orörda — endast synlig text ändras.

## Verifierat lokalt
- `bun run quality:fast` ✅ (2295 tester, typecheck + lint)
- `bun run build:demo` ✅ (GH Pages-export)

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)