### PR TITLE
feat(billing): WriteOff-schema + id + registry (ADR 0007 1/5)

### DIFF
--- a/src/lib/shared/demo-source.ts
+++ b/src/lib/shared/demo-source.ts
@@ -35,6 +35,7 @@ export interface DemoSource {
   paymentPlanReminders?: readonly Record<string, unknown>[];
   accontoDeductions?: readonly Record<string, unknown>[];
   billingRuns?: readonly Record<string, unknown>[];
+  writeOffs?: readonly Record<string, unknown>[];
   calendarEvents?: readonly Record<string, unknown>[];
   tasks?: readonly Record<string, unknown>[];
   userPreferences?: readonly Record<string, unknown>[];

--- a/src/lib/shared/schemas/billing.ts
+++ b/src/lib/shared/schemas/billing.ts
@@ -19,6 +19,7 @@ import {
   paymentPlanReminderIdSchema,
   accontoDeductionIdSchema,
   billingRunIdSchema,
+  writeOffIdSchema,
   matterIdSchema,
   userIdSchema,
 } from "./ids";
@@ -129,6 +130,26 @@ export const paymentSchema = z.object({
 }).passthrough();
 
 export type Payment = z.infer<typeof paymentSchema>;
+
+/**
+ * WriteOff — konstaterad kundförlust mot en faktura ([ADR 0007]). `amount` i öre
+ * (= återstoden vid avskrivningstillfället). Egen daterad post, symmetrisk med
+ * `Payment` — sanningskällan; `Invoice.status = BAD_DEBT` härleds av projektionen
+ * (#137). Lagras i `write-offs/<id>.json`.
+ *
+ * [ADR 0007]: ../../../../docs/adr/0007-kundfordringar-konstaterad-kundforlust.md
+ */
+export const writeOffSchema = z.object({
+  id: writeOffIdSchema,
+  invoiceId: invoiceIdSchema,
+  amount: z.number().int(),
+  writtenOffAt: dateLike,
+  reason: z.string().nullish(),
+  recordedById: userIdSchema,
+  createdAt: dateLike,
+}).passthrough();
+
+export type WriteOff = z.infer<typeof writeOffSchema>;
 
 /**
  * PaymentPlan — avbetalningsplan kopplad 1:1 till en Invoice. När den är

--- a/src/lib/shared/schemas/ids.ts
+++ b/src/lib/shared/schemas/ids.ts
@@ -77,6 +77,9 @@ export type AccontoDeductionId = z.infer<typeof accontoDeductionIdSchema>;
 export const billingRunIdSchema = brandedId<"BillingRunId">();
 export type BillingRunId = z.infer<typeof billingRunIdSchema>;
 
+export const writeOffIdSchema = brandedId<"WriteOffId">();
+export type WriteOffId = z.infer<typeof writeOffIdSchema>;
+
 export const documentTemplateIdSchema = brandedId<"DocumentTemplateId">();
 export type DocumentTemplateId = z.infer<typeof documentTemplateIdSchema>;
 

--- a/src/lib/shared/schemas/index.ts
+++ b/src/lib/shared/schemas/index.ts
@@ -32,6 +32,7 @@ import {
   paymentPlanReminderSchema,
   accontoDeductionSchema,
   billingRunSchema,
+  writeOffSchema,
 } from "./billing";
 import { documentTemplateSchema, conflictCheckSchema } from "./misc";
 import { calendarEventSchema, taskSchema } from "./calendar";
@@ -183,6 +184,12 @@ export const ENTITY_REGISTRY: Record<string, EntityEntry> = {
     gitPrefix: "billing-runs",
     sourceKey: "billingRuns",
   },
+  writeOff: {
+    schema: writeOffSchema,
+    gitPath: p((id) => `write-offs/${id}.json`),
+    gitPrefix: "write-offs",
+    sourceKey: "writeOffs",
+  },
   documentTemplate: {
     schema: documentTemplateSchema,
     gitPath: p((id) => `.ava/templates/${id}.json`),
@@ -228,7 +235,7 @@ export type EntityName =
   | "organization" | "office" | "user" | "contact" | "matter" | "matterContact"
   | "document" | "documentFolder" | "documentAnalysisSuggestion" | "matterEventSuggestion"
   | "timeEntry" | "expense" | "invoice" | "payment" | "paymentPlan"
-  | "paymentPlanReminder" | "accontoDeduction" | "billingRun"
+  | "paymentPlanReminder" | "accontoDeduction" | "billingRun" | "writeOff"
   | "documentTemplate" | "conflictCheck"
   | "calendarEvent" | "task"
   | "userPreference" | "orgPreference";

--- a/test/unit/lib/firma/hydrate-working-copy.test.ts
+++ b/test/unit/lib/firma/hydrate-working-copy.test.ts
@@ -64,6 +64,30 @@ describe("hydrateWorkingCopy", () => {
     expect(src.matters ?? []).toHaveLength(0);
   });
 
+  it("round-trip: writeOff write-back → hydrate (ADR 0007)", async () => {
+    const fsa = makeFakeFsa();
+    const writeBack = makeFsaWriteBack({ handle: fsa.root });
+    await writeBack({ entity: "invoice", kind: "create", row: { id: "inv1", matterId: "m1", amount: 1000, status: "SENT" } });
+    await writeBack({ entity: "writeOff", kind: "create", row: { id: "wo1", invoiceId: "inv1", amount: 1000, writtenOffAt: new Date("2026-05-01T00:00:00.000Z"), reason: "Konkurs", recordedById: "u1" } });
+
+    const src = await hydrateWorkingCopy(fsa.root);
+    expect(src.writeOffs).toHaveLength(1);
+    const wo = src.writeOffs![0] as { invoiceId: string; amount: number; writtenOffAt: unknown };
+    expect(wo.invoiceId).toBe("inv1");
+    expect(wo.amount).toBe(1000);
+    expect(wo.writtenOffAt).toBeInstanceOf(Date);
+  });
+
+  it("gammalt repo utan write-offs/ → ingen krasch, writeOffs tom (ADR 0007)", async () => {
+    const fsa = makeFakeFsa();
+    const writeBack = makeFsaWriteBack({ handle: fsa.root });
+    await writeBack({ entity: "invoice", kind: "create", row: { id: "inv1", matterId: "m1", amount: 1000 } });
+
+    const src = await hydrateWorkingCopy(fsa.root);
+    expect(src.writeOffs ?? []).toHaveLength(0);
+    expect(src.invoices).toHaveLength(1);
+  });
+
   it("migrate-on-read: repoVersion=1 strippar invoice-`type` (ADR 0004)", async () => {
     const fsa = makeFakeFsa();
     const writeBack = makeFsaWriteBack({ handle: fsa.root });

--- a/test/unit/shared/schemas/registry.test.ts
+++ b/test/unit/shared/schemas/registry.test.ts
@@ -17,6 +17,7 @@ import {
   paymentPlanSchema,
   taskSchema,
   userSchema,
+  writeOffSchema,
 } from "@/lib/shared/schemas";
 
 describe("ENTITY_REGISTRY", () => {
@@ -24,6 +25,14 @@ describe("ENTITY_REGISTRY", () => {
     expect(ENTITY_NAMES.length).toBeGreaterThanOrEqual(21);
     expect(ENTITY_NAMES).toContain("calendarEvent");
     expect(ENTITY_NAMES).toContain("task");
+  });
+
+  it("writeOff: i registry:t med flat gitPath write-offs/<id>.json (ADR 0007)", () => {
+    expect(ENTITY_NAMES).toContain("writeOff");
+    const entry = ENTITY_REGISTRY.writeOff!;
+    expect(entry.gitPath("wo-1", {})).toBe("write-offs/wo-1.json");
+    expect(entry.gitPrefix).toBe("write-offs");
+    expect(entry.sourceKey).toBe("writeOffs");
   });
 
   it("calendar + task: gitPath flat (inte per-user-mapp)", () => {
@@ -110,6 +119,17 @@ describe("schemas — minimal valid input", () => {
       paidAt: "2026-05-24", recordedById: "u-1", createdAt: now,
     });
     expect(p.amount).toBe(50000);
+  });
+
+  it("writeOffSchema kräver invoiceId + amount + writtenOffAt + recordedById (ADR 0007)", () => {
+    expect(() => writeOffSchema.parse({ id: "wo-1" })).toThrow();
+    const wo = writeOffSchema.parse({
+      id: "wo-1", invoiceId: "i-1", amount: 70000,
+      writtenOffAt: "2026-05-24", reason: "Konkurs", recordedById: "u-1", createdAt: now,
+    });
+    expect(wo.amount).toBe(70000);
+    expect(wo.writtenOffAt).toBeInstanceOf(Date);
+    expect(wo.reason).toBe("Konkurs");
   });
 
   it("paymentPlanSchema validerar dayOfMonth-range (1-28)", () => {

--- a/tooling/scripts/generate-demo-manifest.ts
+++ b/tooling/scripts/generate-demo-manifest.ts
@@ -35,7 +35,7 @@ const DEFAULT_SCAN_PATHS = [
   // tasks, avbetalningsplaner eller jäv-historik.
   "calendar", "tasks",
   "payment-plans", "payment-plan-reminders", "payments",
-  "acconto-deductions", "billing-runs", "conflict-checks", "offices",
+  "acconto-deductions", "billing-runs", "write-offs", "conflict-checks", "offices",
 ];
 
 async function listProjectionFiles(root: string, dir: string): Promise<string[]> {


### PR DESCRIPTION
Första arbetspaketet för [ADR 0007](docs/adr/0007-kundfordringar-konstaterad-kundforlust.md) — issue #136 (epic #141).

Inför **WriteOff** som egen daterad post (sanningskälla för konstaterad kundförlust), symmetrisk med `Payment`. Lagras i `write-offs/<id>.json`.

## Ändringar
- `ids.ts`: `writeOffIdSchema` + `WriteOffId` (branded)
- `billing.ts`: `writeOffSchema` (invoiceId, amount, writtenOffAt, reason, recordedById, createdAt)
- `index.ts`: `ENTITY_REGISTRY`-post `writeOff` + `EntityName`-union
- `demo-source.ts`: `writeOffs?`-nyckel
- Tester: registry-path, schema-parse, hydrate-round-trip + "gammalt repo utan write-offs/ kraschar ej"

## Avvikelse från issue-texten: ingen schemaVersion-bump
En ny entitet är **rent additiv** (bärs av `.passthrough()` + registry per [ADR 0004](docs/adr/0004-schemaversion-och-versionsgrind.md)). En bump kräver en migrate-on-read-kedja och skulle få äldre kod att felaktigt kasta `IncompatibleSchemaVersionError` på nya repon. Acceptanskriteriet (gammalt repo utan `write-offs/` kraschar ej) uppfylls strukturellt (hydreraren `continue`:ar på saknad prefix) och täcks nu av test.

## Ej i scope (separata PR)
Projektion/härledd `BAD_DEBT` (#137), tRPC-mutation (#138), migrering (#139), rapporter (#140).

## Verifierat
`bun run test:all` grönt end-to-end (249s): static (inkl. knip-gate) + unit (coverage) + 18 e2e passed.

CODEOWNERS: berör `src/lib/shared/schemas/`.

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)