### PR TITLE
fix(e2e): härda tier3-readiness mot flaky CI (#131)

### DIFF
--- a/test/e2e/round-trip/round-trip.spec.ts
+++ b/test/e2e/round-trip/round-trip.spec.ts
@@ -150,8 +150,9 @@ async function createMatterAndOpen(page: Page, title: string, client: string): P
   await page.getByLabel(/^Titel/).fill(title);
   // Vänta tills klient-optionen hydratiserats i dropdownen (kontakten skrevs
   // i föregående sid-session → läses tillbaka ur OPFS vid omladdning).
+  // 30s (var 20s): OPFS-hydreringen kan vara långsam på en lastad CI-runner (#131).
   const klient = page.getByLabel(/Klient/);
-  await expect(klient.locator("option", { hasText: client })).toHaveCount(1, { timeout: 20_000 });
+  await expect(klient.locator("option", { hasText: client })).toHaveCount(1, { timeout: 30_000 });
   await klient.selectOption({ label: client });
   await page.getByLabel(/Ärendetyp/).fill("Testtyp");
   await page.getByRole("button", { name: /Skapa ärende/i }).click();

--- a/tooling/docker/docker-compose.yml
+++ b/tooling/docker/docker-compose.yml
@@ -49,8 +49,15 @@ services:
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1/ava/"]
       interval: 10s
-      timeout: 3s
-      retries: 5
+      # timeout 10s (var 3s): en wget kan ta >3s på en lastad CI-runner.
+      timeout: 10s
+      # retries 10 (var 5): tål fler transienta misslyckanden innan unhealthy.
+      retries: 10
+      # start_period: misslyckade checks under bootstrap (htpasswd + git-seed +
+      # nginx-start) räknas INTE mot retries → containern markeras inte unhealthy
+      # under uppstart, vilket annars fick `docker compose up --wait` att avbryta
+      # med exit 1 i CI:s e2e-jobb (#131). Räknas inte mot --wait-timeout.
+      start_period: 40s
 
   # ─── (Valbar) Auth-server med invite-token-UI ──────────────
   # Default off — bara för kunder som vill ha self-service-provisionering


### PR DESCRIPTION
Fixar #131 — återkommande flakighet i E2E-jobbet (git round-trip).

## Två fel-lägen

### Mode A — `docker compose up --wait` exit 1 fast web servade 200
Web-healthchecken saknade `start_period`, hade snäv `timeout: 3s` och bara `retries: 5` → containern kunde markeras **unhealthy** under bootstrap/CI-last, vilket fick `--wait` att avbryta. Fix (`docker-compose.yml`):
- `start_period: 40s` — misslyckade checks under bootstrap (htpasswd + git-seed + nginx) räknas inte mot retries.
- `timeout: 3s → 10s`, `retries: 5 → 10`.

### Mode B — Klient-dropdownens option hann inte hydreras (OPFS) inom 20s
Höjt till 30s (`round-trip.spec.ts`).

## Verifierat lokalt
- `down -v && up --build --wait` → web **healthy på 6s** (Mode A-fixen).
- `round-trip` **18 passed**, 1 skipped (med höjd timeout).
- typecheck + lint gröna.

## Ärlighet
Detta är **probabilistisk hardening** — flakighet kan inte bevisas borta lokalt (CI-timing-beroende). `start_period` adresserar dock Mode A:s rotorsak (premature unhealthy). Övervaka CI-stabilitet; om Mode B återkommer är nästa steg en reload-retry i testet.

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)