### PR TITLE
feat(billing): kundfordrings-ledger + härledd status + partition-invariant (ADR 0007 2/5)

### DIFF
--- a/src/lib/shared/write-off-calc.ts
+++ b/src/lib/shared/write-off-calc.ts
@@ -1,0 +1,86 @@
+/**
+ * Ren kundfordrings-matematik för en faktura ([ADR 0007]). Inga DB-anrop —
+ * allt testbart utan mockning. Alla belopp i öre (Int).
+ *
+ * **Partition-invarianten** (varje faktura-krona ligger i exakt en hink):
+ *
+ *   amount = Σ Payment + Σ Credit(abs) + Σ WriteOff + Utestående
+ *
+ * `WriteOff` = konstaterad kundförlust (egen daterad post, #136). `outstanding`
+ * är resten (`amount − paid − credited − writtenOff`) — definieras som hinken
+ * som tar upp slacket, så ekvationen håller per konstruktion. De *meningsfulla*
+ * felen är negativa hinkar och översummering (outstanding < 0), som
+ * {@link invoicePartitionViolation} fångar.
+ *
+ * Status **härleds** ur ledgern — sätts inte manuellt ([ADR 0007]).
+ *
+ * Konsumeras av mutation-vakten (#138) och rapportvyerna (#140).
+ *
+ * [ADR 0007]: ../../../docs/adr/0007-kundfordringar-konstaterad-kundforlust.md
+ */
+
+import type { InvoiceStatus } from "@/lib/shared/schemas/enums";
+
+export interface InvoiceLedger {
+  /** Summa registrerade inbetalningar (öre, ≥ 0). */
+  paid: number;
+  /** Summa krediteringar/nedsättningar (öre, absolutbelopp, ≥ 0). */
+  credited: number;
+  /** Summa konstaterad kundförlust (öre, ≥ 0). */
+  writtenOff: number;
+  /** Återstår att driva in: `amount − paid − credited − writtenOff`. */
+  outstanding: number;
+}
+
+/**
+ * Bygg fakturans ledger ur de tre avräknings-hinkarna. `outstanding` är resten.
+ * Negativ `outstanding` (översummering) klampas INTE — det är ett invariant-brott
+ * som {@link invoicePartitionViolation} ska larma på, inte dölja.
+ */
+export function computeInvoiceLedger(
+  amount: number,
+  paid: number,
+  credited: number,
+  writtenOff: number,
+): InvoiceLedger {
+  return { paid, credited, writtenOff, outstanding: amount - paid - credited - writtenOff };
+}
+
+/**
+ * Härled fakturans effektiva status ur ledgern.
+ *
+ * - `DRAFT`/`CANCELLED` är livscykel-tillstånd som inte följer av ledgern → behålls.
+ * - Konstaterad kundförlust vinner: skrevs något av OCH inget återstår → `BAD_DEBT`.
+ * - Inget återstår (fullt betald/krediterad) → `PAID`.
+ * - Annars behåll inbetalnings-/plan-tillståndet (`SENT`/`INSTALLMENT_PLAN`).
+ */
+export function deriveInvoiceStatus(stored: InvoiceStatus, ledger: InvoiceLedger): InvoiceStatus {
+  if (stored === "DRAFT" || stored === "CANCELLED") return stored;
+  if (ledger.writtenOff > 0 && ledger.outstanding <= 0) return "BAD_DEBT";
+  if (ledger.outstanding <= 0) return "PAID";
+  return stored;
+}
+
+/**
+ * Verifiera partition-invarianten. Returnerar ett människoläsbart felmeddelande
+ * vid brott, annars `null`.
+ *
+ *   - någon hink negativ (paid/credited/writtenOff)
+ *   - översummering: paid + credited + writtenOff > amount  (outstanding < 0)
+ *   - partition bruten: hinkarna summerar inte till amount (skyddar mot en
+ *     handhopsatt ledger där outstanding inte är resten)
+ */
+export function invoicePartitionViolation(amount: number, ledger: InvoiceLedger): string | null {
+  const { paid, credited, writtenOff, outstanding } = ledger;
+  if (paid < 0 || credited < 0 || writtenOff < 0) {
+    return `Negativ avräkningshink (betalt=${paid}, krediterat=${credited}, avskrivet=${writtenOff}).`;
+  }
+  if (outstanding < 0) {
+    return `Översummerat: betalt+krediterat+avskrivet (${paid + credited + writtenOff}) överstiger ` +
+      `fakturabeloppet (${amount}) med ${-outstanding} öre.`;
+  }
+  if (paid + credited + writtenOff + outstanding !== amount) {
+    return `Partition bruten: ${paid}+${credited}+${writtenOff}+${outstanding} ≠ ${amount}.`;
+  }
+  return null;
+}

--- a/test/unit/lib/write-off-calc.test.ts
+++ b/test/unit/lib/write-off-calc.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tester för write-off-calc (ADR 0007): partition-invariant + härledd status.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import {
+  computeInvoiceLedger,
+  deriveInvoiceStatus,
+  invoicePartitionViolation,
+  type InvoiceLedger,
+} from "@/lib/shared/write-off-calc";
+import type { InvoiceStatus } from "@/lib/shared/schemas/enums";
+
+describe("computeInvoiceLedger", () => {
+  it("outstanding = amount − paid − credited − writtenOff", () => {
+    const l = computeInvoiceLedger(100_00, 30_00, 0, 0);
+    expect(l.outstanding).toBe(70_00);
+  });
+
+  it("delbetald sedan avskriven återstod → outstanding 0", () => {
+    // faktura 100, betalt 30, avskrivet återstoden 70
+    const l = computeInvoiceLedger(100_00, 30_00, 0, 70_00);
+    expect(l).toEqual({ paid: 30_00, credited: 0, writtenOff: 70_00, outstanding: 0 });
+  });
+
+  it("översummering ger negativ outstanding (klampas ej)", () => {
+    const l = computeInvoiceLedger(100_00, 80_00, 0, 70_00);
+    expect(l.outstanding).toBe(-50_00);
+  });
+});
+
+describe("deriveInvoiceStatus", () => {
+  const ledger = (amount: number, paid: number, credited: number, writtenOff: number): InvoiceLedger =>
+    computeInvoiceLedger(amount, paid, credited, writtenOff);
+
+  it("avskriven återstod (writtenOff>0, outstanding≤0) → BAD_DEBT", () => {
+    expect(deriveInvoiceStatus("SENT", ledger(100_00, 30_00, 0, 70_00))).toBe("BAD_DEBT");
+  });
+
+  it("fullt betald (outstanding≤0, inget avskrivet) → PAID", () => {
+    expect(deriveInvoiceStatus("SENT", ledger(100_00, 100_00, 0, 0))).toBe("PAID");
+    expect(deriveInvoiceStatus("INSTALLMENT_PLAN", ledger(100_00, 100_00, 0, 0))).toBe("PAID");
+  });
+
+  it("krediterad i sin helhet → PAID (inget avskrivet)", () => {
+    expect(deriveInvoiceStatus("SENT", ledger(100_00, 0, 100_00, 0))).toBe("PAID");
+  });
+
+  it("delbetald men fortfarande utestående → behåller stored", () => {
+    expect(deriveInvoiceStatus("SENT", ledger(100_00, 30_00, 0, 0))).toBe("SENT");
+    expect(deriveInvoiceStatus("INSTALLMENT_PLAN", ledger(100_00, 30_00, 0, 0))).toBe("INSTALLMENT_PLAN");
+  });
+
+  it("DRAFT/CANCELLED härleds inte (behålls oavsett ledger)", () => {
+    for (const s of ["DRAFT", "CANCELLED"] as InvoiceStatus[]) {
+      expect(deriveInvoiceStatus(s, ledger(100_00, 100_00, 0, 0))).toBe(s);
+      expect(deriveInvoiceStatus(s, ledger(100_00, 0, 0, 100_00))).toBe(s);
+    }
+  });
+});
+
+describe("invoicePartitionViolation", () => {
+  it("giltig partition → null", () => {
+    expect(invoicePartitionViolation(100_00, computeInvoiceLedger(100_00, 30_00, 0, 70_00))).toBeNull();
+    expect(invoicePartitionViolation(100_00, computeInvoiceLedger(100_00, 0, 0, 0))).toBeNull();
+  });
+
+  it("översummering (outstanding < 0) → violation", () => {
+    const v = invoicePartitionViolation(100_00, computeInvoiceLedger(100_00, 80_00, 0, 70_00));
+    expect(v).toMatch(/Översummerat/);
+  });
+
+  it("negativ hink → violation", () => {
+    const v = invoicePartitionViolation(100_00, { paid: -1, credited: 0, writtenOff: 0, outstanding: 100_01 });
+    expect(v).toMatch(/Negativ avräkningshink/);
+  });
+
+  it("handhopsatt ledger där outstanding inte är resten → partition bruten", () => {
+    const v = invoicePartitionViolation(100_00, { paid: 10_00, credited: 0, writtenOff: 0, outstanding: 10_00 });
+    expect(v).toMatch(/Partition bruten/);
+  });
+});


### PR DESCRIPTION
Andra arbetspaketet för [ADR 0007](docs/adr/0007-kundfordringar-konstaterad-kundforlust.md) — issue #137 (epic #141).

Ren kundfordrings-matematik i `src/lib/shared/write-off-calc.ts` (inga DB-anrop, allt i öre):

- **`computeInvoiceLedger`** — partition: `amount = betalt + krediterat + avskrivet + utestående`. `outstanding` är resten (klampas ej negativ).
- **`deriveInvoiceStatus`** — härleder status: avskriven återstod (writtenOff>0, outstanding≤0) → `BAD_DEBT`; inget kvar → `PAID`; annars behåll `SENT`/`INSTALLMENT_PLAN`. `DRAFT`/`CANCELLED` är livscykel → behålls. **Sätts inte manuellt** (ADR 0007).
- **`invoicePartitionViolation`** — invariant-validering: fångar översummering (`outstanding<0`) + negativa hinkar.

## Scope-not
WriteOff-*delegaten* (CRUD/query mot datalagret) hör till #138, så det finns ingen live router-/projektions-konsument än. Funktionerna konsumeras därför av sina enhetstester (knip-entry-punkter) tills #138:s mutation-vakt och #140:s rapporter wirar in dem mot riktig data. Detta är den rena logiken hela kedjan vilar på.

## Verifierat
`bun run test:all` grönt end-to-end: static (inkl. knip — inga oanvända exports) + unit (12 nya write-off-calc-tester, coverage) + 18 e2e passed.

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)