### PR TITLE
feat(billing): invoice.writeOff-mutation + WriteOff-delegat (ADR 0007 3/5)

### DIFF
--- a/src/lib/server/data-store/DemoDataStore.ts
+++ b/src/lib/server/data-store/DemoDataStore.ts
@@ -43,6 +43,7 @@ import type {
   OfficeDelegate,
   ConflictCheckDelegate,
   PaymentDelegate,
+  WriteOffDelegate,
   PaymentPlanDelegate,
   AccontoDeductionDelegate,
   BillingRunDelegate,
@@ -74,6 +75,7 @@ export class DemoDataStore implements IDataStore {
   readonly offices: OfficeDelegate;
   readonly conflictChecks: ConflictCheckDelegate;
   readonly payments: PaymentDelegate;
+  readonly writeOffs: WriteOffDelegate;
   readonly paymentPlans: PaymentPlanDelegate;
   readonly paymentPlanReminders: Delegate;
   readonly accontoDeductions: AccontoDeductionDelegate;
@@ -201,6 +203,7 @@ export class DemoDataStore implements IDataStore {
       checkedBy: this.rel("users", "id", "checkedById", "one"),
     }) as unknown as ConflictCheckDelegate;
     this.payments = this.makeDelegate("payments") as unknown as PaymentDelegate;
+    this.writeOffs = this.makeDelegate("writeOffs") as unknown as WriteOffDelegate;
     // invoice (+ nested matter) krävs för cancelPaymentPlan:s where
     // `invoice: { matter: { organizationId } }`.
     this.paymentPlans = this.makeDelegate("paymentPlans", {
@@ -329,6 +332,7 @@ export class DemoDataStore implements IDataStore {
       offices: "office",
       conflictChecks: "conflictCheck",
       payments: "payment",
+      writeOffs: "writeOff",
       paymentPlans: "paymentPlan",
       paymentPlanReminders: "paymentPlanReminder",
       accontoDeductions: "accontoDeduction",
@@ -400,6 +404,7 @@ export class DemoDataStore implements IDataStore {
       offices: this.offices,
       conflictChecks: this.conflictChecks,
       payments: this.payments,
+      writeOffs: this.writeOffs,
       paymentPlans: this.paymentPlans,
       accontoDeductions: this.accontoDeductions,
       billingRuns: this.billingRuns,

--- a/src/lib/server/data-store/IDataStore.ts
+++ b/src/lib/server/data-store/IDataStore.ts
@@ -17,7 +17,7 @@ import type {
   Contact, Matter, MatterContact, Document, DocumentFolder,
   DocumentTemplate, DocumentAnalysisSuggestion, MatterEventSuggestion,
   Invoice, TimeEntry, Expense, User, Organization, Office, ConflictCheck,
-  Payment, PaymentPlan, AccontoDeduction, BillingRun,
+  Payment, PaymentPlan, AccontoDeduction, BillingRun, WriteOff,
   CalendarEvent, Task,
 } from "@/lib/shared/schemas";
 
@@ -128,6 +128,7 @@ export type OrganizationDelegate = Delegate<Organization>;
 export type OfficeDelegate = Delegate<Office>;
 export type ConflictCheckDelegate = Delegate<ConflictCheck>;
 export type PaymentDelegate = Delegate<Payment>;
+export type WriteOffDelegate = Delegate<WriteOff>;
 export type PaymentPlanDelegate = Delegate<PaymentPlan>;
 export type AccontoDeductionDelegate = Delegate<AccontoDeduction>;
 export type BillingRunDelegate = Delegate<BillingRun>;
@@ -181,6 +182,7 @@ export interface DataStoreTx {
   offices: OfficeDelegate;
   conflictChecks: ConflictCheckDelegate;
   payments: PaymentDelegate;
+  writeOffs: WriteOffDelegate;
   paymentPlans: PaymentPlanDelegate;
   accontoDeductions: AccontoDeductionDelegate;
   billingRuns: BillingRunDelegate;
@@ -216,6 +218,7 @@ export interface IDataStore {
   readonly offices: OfficeDelegate;
   readonly conflictChecks: ConflictCheckDelegate;
   readonly payments: PaymentDelegate;
+  readonly writeOffs: WriteOffDelegate;
   readonly paymentPlans: PaymentPlanDelegate;
   readonly paymentPlanReminders: Delegate;
   readonly accontoDeductions: AccontoDeductionDelegate;

--- a/src/lib/server/events/emit.ts
+++ b/src/lib/server/events/emit.ts
@@ -96,6 +96,9 @@ export const emit = {
   invoicePaymentReceived: (ctx: EmitCtx, invoiceId: string, matterId: string, amount: number) =>
     emitUser(ctx, "invoice.payment_received", { invoiceId, amount }, matterId),
 
+  invoiceWrittenOff: (ctx: EmitCtx, invoiceId: string, matterId: string, amount: number) =>
+    emitUser(ctx, "invoice.written_off", { invoiceId, amount }, matterId),
+
   // ── time-entry ─────────────────────────────────────────────────
   timeEntryAdded: (ctx: EmitCtx, entry: { id: string; matterId: string; minutes: number }) =>
     emitUser(ctx, "time-entry.added", { entryId: entry.id, minutes: entry.minutes }, entry.matterId),

--- a/src/lib/server/events/schema.ts
+++ b/src/lib/server/events/schema.ts
@@ -40,6 +40,7 @@ export const EVENT_TYPES = [
   "invoice.sent",
   "invoice.payment_received",
   "invoice.overdue",
+  "invoice.written_off",
   // payment-plan (avbetalningsplaner) — driver av påminnelser
   "payment.due",
   "payment.overdue",

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -18,6 +18,8 @@ import { TRPCError } from "@trpc/server";
 import { router, orgProcedure } from "../trpc";
 import type { DataStoreTx } from "../data-store/IDataStore";
 import { computeFinalInvoiceBreakdown, isPaymentPlanSettled } from "@/lib/shared/invoice-calc";
+import { computeInvoiceLedger, deriveInvoiceStatus } from "@/lib/shared/write-off-calc";
+import type { InvoiceStatus } from "@/lib/shared/schemas/enums";
 import { emit } from "../events/emit";
 import {
   asId,
@@ -90,6 +92,52 @@ async function linkBilledItems(
   for (const a of accontos) {
     await tx.accontoDeductions.create({ data: { finalInvoiceId: invoiceId, accontoInvoiceId: a.id } });
   }
+}
+
+// ─── writeOff-helpers (ADR 0007) — håller mutationen under complexity ≤ 8 ──
+
+/** Avvisa avskrivning av en faktura som inte är utställd. Returnerar den smala fakturan. */
+function ensureWritableOff<T extends { status?: string } | null>(inv: T): NonNullable<T> {
+  if (!inv) throw new TRPCError({ code: "NOT_FOUND" });
+  if (inv.status === "DRAFT" || inv.status === "CANCELLED") {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Endast utställda fakturor kan skrivas av (ej DRAFT/CANCELLED).",
+    });
+  }
+  return inv as NonNullable<T>;
+}
+
+/** Summera fakturans avräkningshinkar (betalt/krediterat/avskrivet) → ledger. */
+async function gatherInvoiceLedger(
+  tx: DataStoreTx,
+  orgId: string,
+  inv: { id: string; amount: number; payments?: ReadonlyArray<{ amount: number }> },
+): Promise<{ paid: number; credited: number; writtenOff: number; ledger: ReturnType<typeof computeInvoiceLedger> }> {
+  const paid = (inv.payments ?? []).reduce((s, p) => s + p.amount, 0);
+  const credits = await tx.invoices.findMany({ where: { creditedInvoiceId: inv.id, matter: { organizationId: orgId } } });
+  const credited = (credits as ReadonlyArray<{ amount: number }>).reduce((s, c) => s + Math.abs(c.amount), 0);
+  const existing = await tx.writeOffs.findMany({ where: { invoiceId: inv.id } });
+  const writtenOff = (existing as ReadonlyArray<{ amount: number }>).reduce((s, w) => s + w.amount, 0);
+  return { paid, credited, writtenOff, ledger: computeInvoiceLedger(inv.amount, paid, credited, writtenOff) };
+}
+
+/** Lös avskrivningsbeloppet mot utestående (default = hela återstoden) + vakt. */
+function resolveWriteOffAmount(outstanding: number, requested?: number): number {
+  if (outstanding <= 0) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Inget utestående att skriva av — fakturan är redan reglerad eller avskriven.",
+    });
+  }
+  const amount = requested ?? outstanding;
+  if (amount > outstanding) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: `Avskrivningsbeloppet (${amount} öre) överstiger utestående (${outstanding} öre).`,
+    });
+  }
+  return amount;
 }
 
 const invoiceTypeSchema = z.enum(["STANDARD", "ACCONTO", "FINAL"]);
@@ -444,7 +492,67 @@ export const invoiceRouter = router({
       });
     }),
 
-  /** Manuell statusändring för DRAFT→SENT, SENT→CANCELLED, SENT→BAD_DEBT. */
+  /**
+   * Boka en konstaterad kundförlust (ADR 0007). Skapar en daterad WriteOff-post
+   * (sanningskällan) och persisterar härledd `BAD_DEBT` när återstoden stängs.
+   *
+   * Vakt (räkna-en-gång): endast utställda fakturor med utestående > 0; en redan
+   * reglerad/avskriven faktura (outstanding ≤ 0) avvisas → en "dålig" faktura
+   * räknas exakt en gång. Avskrivningsbeloppet får inte överstiga utestående.
+   *
+   * `amount` default = hela återstoden (`amount − betalt − krediterat − redan avskrivet`).
+   */
+  writeOff: orgProcedure
+    .input(
+      z.object({
+        invoiceId: z.string(),
+        amount: z.number().int().min(1).optional(),
+        reason: z.string().optional(),
+        writtenOffAt: z.string().optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      return ctx.dataStore.transaction(async (tx) => {
+        const inv = ensureWritableOff(
+          await tx.invoices.findFirst({
+            where: { id: input.invoiceId, matter: { organizationId: ctx.orgId } },
+            include: { payments: true },
+          }),
+        );
+
+        const { paid, credited, writtenOff, ledger } = await gatherInvoiceLedger(tx, ctx.orgId, inv);
+        const amount = resolveWriteOffAmount(ledger.outstanding, input.amount);
+
+        const writeOff = await tx.writeOffs.create({
+          data: {
+            invoiceId: inv.id,
+            amount,
+            writtenOffAt: input.writtenOffAt ? new Date(input.writtenOffAt) : new Date(),
+            ...omitUndefined({ reason: input.reason }),
+            recordedById: asId<"UserId">(ctx.user.id),
+          },
+        });
+
+        // Härled status efter avskrivningen och persistera om återstoden stängdes.
+        const after = computeInvoiceLedger(inv.amount, paid, credited, writtenOff + amount);
+        const derived = deriveInvoiceStatus(inv.status as InvoiceStatus, after);
+        if (derived !== inv.status) {
+          await tx.invoices.update({ where: { id: inv.id }, data: { status: derived } });
+        }
+
+        await emit.invoiceWrittenOff(ctx, inv.id, inv.matterId, amount);
+        return { writeOff, outstanding: after.outstanding, status: derived };
+      });
+    }),
+
+  /**
+   * Manuell statusändring för DRAFT→SENT, SENT→CANCELLED, SENT→BAD_DEBT.
+   *
+   * BAD_DEBT via `setStatus` är LEGACY (sätter bara flaggan, ingen daterad post).
+   * ADR 0007:s väg är `writeOff` ovan, som skapar en WriteOff-post + härleder
+   * status. UI-knappen "Kundförlust" byts till `writeOff` separat; tills dess
+   * lever båda vägarna (gamla BAD_DEBT-rader migreras i #139).
+   */
   setStatus: orgProcedure
     .input(
       z.object({

--- a/test/unit/server/helpers/mock-data-store.ts
+++ b/test/unit/server/helpers/mock-data-store.ts
@@ -30,6 +30,7 @@ export interface MockDataStore {
   offices: unknown;
   conflictChecks: unknown;
   payments: unknown;
+  writeOffs: unknown;
   paymentPlans: unknown;
   paymentPlanReminders: unknown;
   accontoDeductions: unknown;
@@ -71,6 +72,7 @@ export function dataStoreFromMockPrisma(mockPrisma: Record<string, unknown>): Mo
       offices: mockPrisma.office,
       conflictChecks: mockPrisma.conflictCheck,
       payments: mockPrisma.payment,
+      writeOffs: mockPrisma.writeOff,
       paymentPlans: mockPrisma.paymentPlan,
       paymentPlanReminders: mockPrisma.paymentPlanReminder,
       accontoDeductions: mockPrisma.invoiceAccontoDeduction,
@@ -96,6 +98,7 @@ export function dataStoreFromMockPrisma(mockPrisma: Record<string, unknown>): Mo
     offices: mockPrisma.office,
     conflictChecks: mockPrisma.conflictCheck,
     payments: mockPrisma.payment,
+    writeOffs: mockPrisma.writeOff,
     paymentPlans: mockPrisma.paymentPlan,
     paymentPlanReminders: mockPrisma.paymentPlanReminder,
     accontoDeductions: mockPrisma.invoiceAccontoDeduction,

--- a/test/unit/server/routers/invoice.test.ts
+++ b/test/unit/server/routers/invoice.test.ts
@@ -43,6 +43,10 @@ const mockPrisma = {
   payment: {
     create: vi.fn(),
   },
+  writeOff: {
+    findMany: vi.fn(),
+    create: vi.fn(),
+  },
   paymentPlan: {
     create: vi.fn(),
     update: vi.fn(),
@@ -436,6 +440,69 @@ describe("invoice.cancelPaymentPlan", () => {
       makeCaller("org-b").cancelPaymentPlan({ planId: "plan-1" }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
     expect(mockPrisma.paymentPlan.update).not.toHaveBeenCalled();
+  });
+});
+
+// ─── writeOff (ADR 0007) ─────────────────────────────────────────
+
+describe("invoice.writeOff", () => {
+  it("delbetald → avskriven återstod: skapar WriteOff + härleder BAD_DEBT", async () => {
+    mockPrisma.invoice.findFirst.mockResolvedValue({
+      id: "inv-1", matterId: "matter-1", amount: 100_000, status: "SENT",
+      payments: [{ amount: 30_000 }],
+    });
+    mockPrisma.invoice.findMany.mockResolvedValue([]); // inga krediteringar
+    mockPrisma.writeOff.findMany.mockResolvedValue([]); // inget avskrivet än
+    mockPrisma.writeOff.create.mockResolvedValue({ id: "wo-1", invoiceId: "inv-1", amount: 70_000 });
+    mockPrisma.invoice.update.mockResolvedValue({ id: "inv-1", status: "BAD_DEBT" });
+
+    const res = await makeCaller().writeOff({ invoiceId: "inv-1", reason: "Konkurs" });
+
+    // amount defaultar till återstoden (100000 − 30000 = 70000)
+    expect(mockPrisma.writeOff.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ invoiceId: "inv-1", amount: 70_000, reason: "Konkurs" }) }),
+    );
+    expect(res.outstanding).toBe(0);
+    expect(res.status).toBe("BAD_DEBT");
+    expect(mockPrisma.invoice.update).toHaveBeenCalledWith({
+      where: { id: "inv-1" }, data: { status: "BAD_DEBT" },
+    });
+  });
+
+  it("räkna en gång: redan avskriven faktura (outstanding 0) → BAD_REQUEST", async () => {
+    mockPrisma.invoice.findFirst.mockResolvedValue({
+      id: "inv-1", matterId: "matter-1", amount: 100_000, status: "BAD_DEBT",
+      payments: [],
+    });
+    mockPrisma.invoice.findMany.mockResolvedValue([]);
+    mockPrisma.writeOff.findMany.mockResolvedValue([{ amount: 100_000 }]); // hela redan avskrivet
+
+    await expect(makeCaller().writeOff({ invoiceId: "inv-1" })).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(mockPrisma.writeOff.create).not.toHaveBeenCalled();
+  });
+
+  it("avskrivningsbelopp > utestående → BAD_REQUEST", async () => {
+    mockPrisma.invoice.findFirst.mockResolvedValue({
+      id: "inv-1", matterId: "matter-1", amount: 100_000, status: "SENT", payments: [{ amount: 60_000 }],
+    });
+    mockPrisma.invoice.findMany.mockResolvedValue([]);
+    mockPrisma.writeOff.findMany.mockResolvedValue([]);
+
+    // utestående = 40000; försök skriva av 50000
+    await expect(makeCaller().writeOff({ invoiceId: "inv-1", amount: 50_000 })).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(mockPrisma.writeOff.create).not.toHaveBeenCalled();
+  });
+
+  it("DRAFT-faktura kan inte skrivas av → BAD_REQUEST", async () => {
+    mockPrisma.invoice.findFirst.mockResolvedValue({
+      id: "inv-1", matterId: "matter-1", amount: 100_000, status: "DRAFT", payments: [],
+    });
+    await expect(makeCaller().writeOff({ invoiceId: "inv-1" })).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("okänd faktura → NOT_FOUND", async () => {
+    mockPrisma.invoice.findFirst.mockResolvedValue(null);
+    await expect(makeCaller().writeOff({ invoiceId: "nope" })).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 });
 


### PR DESCRIPTION
Tredje arbetspaketet för [ADR 0007](docs/adr/0007-kundfordringar-konstaterad-kundforlust.md) — issue #138 (epic #141).

Bokar en **konstaterad kundförlust** som daterad WriteOff-post (sanningskällan) och härleder/persisterar `BAD_DEBT` när återstoden stängs.

## Ändringar
- **WriteOff-delegat** i `IDataStore` + `DemoDataStore` (fält, `makeDelegate`, `entityNameFor`, `txView`).
- **`invoice.writeOff`**-mutation: beräknar utestående via #137:s `computeInvoiceLedger`, vaktar (`utestående > 0` → **räkna-en-gång**, ej DRAFT/CANCELLED, belopp ≤ utestående), skapar WriteOff, persisterar härledd status (`deriveInvoiceStatus`), emittar `invoice.written_off` via **`safeEmit`-helpern** (aldrig `events.emit` direkt — read-only-fällan).
- Ny event-typ `invoice.written_off` + `emit.invoiceWrittenOff`.
- Guard-logik utbruten i helpers (`ensureWritableOff`/`gatherInvoiceLedger`/`resolveWriteOffAmount`) för complexity ≤ 8.

## Tester
5 integrationstester: delbetald→avskriven återstod → BAD_DEBT + WriteOff skapad; **dubbel writeOff avvisas** (outstanding 0); översummering; DRAFT; NOT_FOUND. `mock-data-store`-helpern får `writeOffs`-delegat.

## Scope-not
`setStatus`-BAD_DEBT behålls som **legacy** (UI-knappen "Kundförlust" byts till `writeOff` separat; gamla BAD_DEBT-rader migreras i #139). Avvikelse från issue-ns `writeOff.create`-ordval: lagt som `invoice.writeOff` (symmetriskt med `invoice.recordPayment` — Payment har ingen egen router).

## Verifierat
`bun run test:all` grönt end-to-end: static (inkl. complexity-gate som fångade ett komplexitetsfel lokalt) + unit (37 invoice-tester) + 18 e2e passed.

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)