### PR TITLE
feat(billing): migrera legacy-BAD_DEBT → WriteOff + demo-seed (ADR 0007 4/5)

### DIFF
--- a/src/lib/shared/demo-source.ts
+++ b/src/lib/shared/demo-source.ts
@@ -13,6 +13,8 @@
  * `shared-must-be-framework-agnostic`.
  */
 
+import { synthesizeBadDebtWriteOffs } from "./write-off-migration";
+
 /** Demo-data per entitet. Saknade entiteter får tom array. */
 export interface DemoSource {
   matters?: readonly Record<string, unknown>[];
@@ -90,5 +92,17 @@ export function prebakeJoins(source: DemoSource): DemoSource {
     }) as readonly Record<string, unknown>[];
   }
 
+  applyBadDebtWriteOffMigration(out);
   return out;
+}
+
+/**
+ * Migrate-on-read (ADR 0007): ge legacy-BAD_DEBT-fakturor en daterad WriteOff.
+ * Idempotent — hoppar fakturor som redan har en (inkl. seedens explicita).
+ */
+function applyBadDebtWriteOffMigration(out: DemoSource): void {
+  const synthetic = synthesizeBadDebtWriteOffs(out.invoices ?? [], out.payments ?? [], out.writeOffs ?? []);
+  if (synthetic.length) {
+    out.writeOffs = [...(out.writeOffs ?? []), ...synthetic] as readonly Record<string, unknown>[];
+  }
 }

--- a/src/lib/shared/write-off-migration.ts
+++ b/src/lib/shared/write-off-migration.ts
@@ -1,0 +1,90 @@
+/**
+ * Migrate-on-read ([ADR 0004] + [ADR 0007]): syntetisera en WriteOff-post för
+ * varje faktura med legacy-status `BAD_DEBT` som saknar en. Gamla repon satte
+ * bara statusflaggan via `setStatus` (utan daterad post); rapporterna (#140)
+ * läser `WriteOff.writtenOffAt`, så de behöver en post även för historisk data.
+ *
+ * **Idempotent:** hoppar fakturor som redan har en WriteOff → kör i prebakeJoins
+ * (delad källnivå-post-process) varje hydrering utan att duplicera.
+ *
+ * Heuristik: `writtenOffAt` uppskattas till `updatedAt` (≈ när BAD_DEBT sattes,
+ * samma val som gamla `reports.ts`), med fallback dueDate → invoiceDate →
+ * createdAt. Beloppet = återstoden (`amount − betalt − krediterat`).
+ *
+ * [ADR 0004]: ../../../docs/adr/0004-schemaversion-och-versionsgrind.md
+ * [ADR 0007]: ../../../docs/adr/0007-kundfordringar-konstaterad-kundforlust.md
+ */
+
+import { computeInvoiceLedger } from "./write-off-calc";
+
+type Row = Record<string, unknown>;
+
+/** Stabil markör så migrerade poster går att känna igen (och filtrera bort). */
+export const MIGRATION_RECORDED_BY = "system:bad-debt-migration";
+const MIGRATION_REASON = "Migrerad från BAD_DEBT-status (ADR 0007)";
+
+/** Summera `amount` per `invoiceId` över en rad-uppsättning (payments). */
+function paidByInvoiceId(payments: readonly Row[]): Map<string, number> {
+  const m = new Map<string, number>();
+  for (const p of payments) {
+    const id = String(p.invoiceId ?? "");
+    if (id) m.set(id, (m.get(id) ?? 0) + Number(p.amount ?? 0));
+  }
+  return m;
+}
+
+/** Summera krediterat per ursprungsfaktura (CREDIT-fakturors absolutbelopp). */
+function creditedByInvoiceId(invoices: readonly Row[]): Map<string, number> {
+  const m = new Map<string, number>();
+  for (const inv of invoices) {
+    if (inv.invoiceType !== "CREDIT") continue;
+    const target = String(inv.creditedInvoiceId ?? "");
+    if (target) m.set(target, (m.get(target) ?? 0) + Math.abs(Number(inv.amount ?? 0)));
+  }
+  return m;
+}
+
+/** Uppskatta avskrivnings-tidpunkt ur fakturans datum-fält (mest specifikt först). */
+function estimateWrittenOffAt(inv: Row): unknown {
+  return inv.updatedAt ?? inv.dueDate ?? inv.dueAt ?? inv.invoiceDate ?? inv.issuedAt ?? inv.createdAt ?? null;
+}
+
+/** Bygg den syntetiska WriteOff-raden för en BAD_DEBT-faktura, eller null om inget återstår. */
+function migratedWriteOffFor(inv: Row, id: string, paid: Map<string, number>, credited: Map<string, number>): Row | null {
+  const ledger = computeInvoiceLedger(Number(inv.amount ?? 0), paid.get(id) ?? 0, credited.get(id) ?? 0, 0);
+  if (ledger.outstanding <= 0) return null;
+  const at = estimateWrittenOffAt(inv);
+  return {
+    id: `wo-migrated-${id}`,
+    invoiceId: id,
+    amount: ledger.outstanding,
+    writtenOffAt: at,
+    reason: MIGRATION_REASON,
+    recordedById: MIGRATION_RECORDED_BY,
+    createdAt: at,
+    migrated: true,
+  };
+}
+
+/**
+ * Returnerar de syntetiska WriteOff-rader som ska läggas till (en per
+ * BAD_DEBT-faktura utan befintlig WriteOff och med utestående > 0).
+ */
+export function synthesizeBadDebtWriteOffs(
+  invoices: readonly Row[],
+  payments: readonly Row[],
+  writeOffs: readonly Row[],
+): Row[] {
+  const haveWriteOff = new Set(writeOffs.map((w) => String(w.invoiceId ?? "")));
+  const paid = paidByInvoiceId(payments);
+  const credited = creditedByInvoiceId(invoices);
+
+  const out: Row[] = [];
+  for (const inv of invoices) {
+    const id = String(inv.id ?? "");
+    if (inv.status !== "BAD_DEBT" || !id || haveWriteOff.has(id)) continue;
+    const row = migratedWriteOffFor(inv, id, paid, credited);
+    if (row) out.push(row);
+  }
+  return out;
+}

--- a/test/unit/lib/write-off-migration.test.ts
+++ b/test/unit/lib/write-off-migration.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tester för write-off-migration (ADR 0007): migrate-on-read av legacy-BAD_DEBT
+ * → syntetisk WriteOff. Fokus: korrekt belopp/datum + idempotens.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { synthesizeBadDebtWriteOffs, MIGRATION_RECORDED_BY } from "@/lib/shared/write-off-migration";
+
+const inv = (over: Record<string, unknown> = {}) => ({
+  id: "inv-1", status: "BAD_DEBT", amount: 100_00, invoiceType: "STANDARD",
+  updatedAt: "2026-05-01T00:00:00Z", dueDate: "2026-04-01T00:00:00Z", ...over,
+});
+
+describe("synthesizeBadDebtWriteOffs", () => {
+  it("BAD_DEBT utan WriteOff → syntetisk WriteOff på återstoden", () => {
+    const out = synthesizeBadDebtWriteOffs([inv()], [{ invoiceId: "inv-1", amount: 30_00 }], []);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      invoiceId: "inv-1", amount: 70_00, recordedById: MIGRATION_RECORDED_BY, migrated: true,
+    });
+    // writtenOffAt uppskattas till updatedAt (senaste mutationsdatum)
+    expect(out[0]!.writtenOffAt).toBe("2026-05-01T00:00:00Z");
+  });
+
+  it("idempotent: faktura som redan har en WriteOff hoppas", () => {
+    const existing = [{ invoiceId: "inv-1", amount: 70_00 }];
+    const out = synthesizeBadDebtWriteOffs([inv()], [{ invoiceId: "inv-1", amount: 30_00 }], existing);
+    expect(out).toEqual([]);
+  });
+
+  it("idempotent: kör två gånger (mata in förra rundans output) → inget nytt", () => {
+    const payments = [{ invoiceId: "inv-1", amount: 30_00 }];
+    const round1 = synthesizeBadDebtWriteOffs([inv()], payments, []);
+    const round2 = synthesizeBadDebtWriteOffs([inv()], payments, round1);
+    expect(round1).toHaveLength(1);
+    expect(round2).toEqual([]);
+  });
+
+  it("drar av krediteringar (CREDIT-faktura) från återstoden", () => {
+    const invoices = [inv(), { id: "cred-1", invoiceType: "CREDIT", creditedInvoiceId: "inv-1", amount: -20_00 }];
+    const out = synthesizeBadDebtWriteOffs(invoices, [{ invoiceId: "inv-1", amount: 30_00 }], []);
+    // 10000 − 3000 betalt − 2000 krediterat = 5000 återstår
+    expect(out[0]!.amount).toBe(50_00);
+  });
+
+  it("ingen återstod (fullt betald BAD_DEBT) → ingen WriteOff", () => {
+    const out = synthesizeBadDebtWriteOffs([inv()], [{ invoiceId: "inv-1", amount: 100_00 }], []);
+    expect(out).toEqual([]);
+  });
+
+  it("icke-BAD_DEBT-fakturor rörs inte", () => {
+    const out = synthesizeBadDebtWriteOffs([inv({ status: "SENT" }), inv({ id: "inv-2", status: "PAID" })], [], []);
+    expect(out).toEqual([]);
+  });
+
+  it("fallback-datum när updatedAt saknas → dueDate", () => {
+    const out = synthesizeBadDebtWriteOffs([inv({ updatedAt: undefined })], [], []);
+    expect(out[0]!.writtenOffAt).toBe("2026-04-01T00:00:00Z");
+  });
+});

--- a/tooling/demo-generator/populate-billing.ts
+++ b/tooling/demo-generator/populate-billing.ts
@@ -26,6 +26,7 @@ export interface BillingResult {
   paymentPlans: number;
   credits: number;
   reminders: number;
+  writeOffs: number;
 }
 
 interface Ctx {
@@ -150,10 +151,24 @@ async function scenarioDraft(ctx: Ctx, matterId: string, daysAgo: number): Promi
   ctx.res.invoices++; // lämnas DRAFT
 }
 
+/** Delbetald faktura → konstaterad kundförlust på återstoden (ADR 0007). */
+async function scenarioWriteOff(ctx: Ctx, matterId: string | undefined, daysAgo: number): Promise<void> {
+  if (!matterId) return;
+  const inv = await finalSent(ctx, matterId, daysAgo);
+  const part = Math.floor(inv.amount / 4);
+  if (part > 0) {
+    await ctx.c.invoice.recordPayment({ invoiceId: inv.id, amount: part, paidAt: isoDaysAgo(daysAgo - 15), note: "Delbetalning" });
+    ctx.res.payments++;
+  }
+  // writeOff skriver av återstoden → daterad WriteOff-post + härledd BAD_DEBT.
+  await ctx.c.invoice.writeOff({ invoiceId: inv.id, reason: "Klient försatt i konkurs", writtenOffAt: isoDaysAgo(daysAgo - 30) });
+  ctx.res.writeOffs++;
+}
+
 export async function populateBilling(caller: GeneratorCaller, seed: SeedDataset): Promise<BillingResult> {
   const ctx: Ctx = {
     c: caller as AnyCaller,
-    res: { invoices: 0, payments: 0, paymentPlans: 0, credits: 0, reminders: 0 },
+    res: { invoices: 0, payments: 0, paymentPlans: 0, credits: 0, reminders: 0, writeOffs: 0 },
     time: groupIds(arr(seed, "timeEntries"), "matterId"),
     exp: groupIds(arr(seed, "expenses"), "matterId"),
   };
@@ -177,6 +192,7 @@ export async function populateBilling(caller: GeneratorCaller, seed: SeedDataset
   await scenarioCompletedPlan(ctx, next(), 200);
   await scenarioCancelledPlan(ctx, next(), 55);
   await scenarioCredit(ctx, next(), 35);
+  await scenarioWriteOff(ctx, next(), 80); // konstaterad kundförlust (ADR 0007)
   for (const id of billable.slice(i)) await scenarioDraft(ctx, id, 20); // resten → DRAFT
 
   return ctx.res;

--- a/tooling/scripts/build-demo-repo.ts
+++ b/tooling/scripts/build-demo-repo.ts
@@ -52,7 +52,7 @@ async function main(): Promise<void> {
     ".ava/organizations", ".ava/users", ".ava/templates",
     "offices", "contacts", "matters/active", "matter-contacts",
     "documents", "document-folders",
-    "time-entries", "expenses", "invoices", "payments",
+    "time-entries", "expenses", "invoices", "payments", "write-offs",
     "calendar", "tasks", "conflict-checks",
     "payment-plans", "payment-plan-reminders",
   ];


### PR DESCRIPTION
Fjärde arbetspaketet för [ADR 0007](docs/adr/0007-kundfordringar-konstaterad-kundforlust.md) — issue #139 (epic #141).

## Migrate-on-read
`synthesizeBadDebtWriteOffs` syntetiserar en **daterad WriteOff** för varje `BAD_DEBT`-faktura som saknar en — körs i `prebakeJoins` (delad källnivå-post-process för båda hydreringsvägarna, ADR 0004-stil). **Idempotent**: hoppar fakturor som redan har en WriteOff. Belopp = återstoden (`amount − betalt − krediterat`); `writtenOffAt` uppskattas till `updatedAt` (samma heuristik som gamla `reports.ts`), fallback dueDate→invoiceDate→createdAt.

## Demo-seed
`scenarioWriteOff` i `populate-billing.ts`: delbetalning → `invoice.writeOff` via tRPC → en **riktig** `write-offs/<id>.json` i demon (verifierat: 785 625 öre avskrivet). `build-demo-repo` purgar `write-offs/` mellan bygg.

> Not: buildSeed-arrayerna replayas inte av generatorn (billing skapas via API-flöden, inte pre-bakade rader), så kundförlust-exemplet lades i generator-scenariot — inte i `seed-data.ts`.

## Tester
7 migrerings-tester: synthesis, **idempotens** (×2, inkl. mata in förra rundans output), krediterings-avdrag, fullt betald → ingen, icke-BAD_DEBT orörd, datum-fallback. Helpers för complexity ≤ 8.

## Verifierat
`bun run build:demo` → `write-offs/<id>.json` skapas; `bun run test:all` grönt end-to-end (static + unit + 18 e2e).

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)