### PR TITLE
feat(reports): kundfordrings-brygga + åldersanalys (ADR 0007 5/5)

### DIFF
--- a/src/app/reports/_ar-summary.tsx
+++ b/src/app/reports/_ar-summary.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+/**
+ * Kundfordrings-sammanställning (ADR 0007), livstid: brygga (waterfall) +
+ * åldersanalys. Konsumerar `reports.arSummary` (WriteOff-baserad konstaterad
+ * kundförlust). Fristående komponent så reports/page.tsx hålls hanterbar.
+ */
+
+import { trpc } from "@/lib/client/trpc";
+import { formatCurrency } from "@/lib/client/utils";
+
+function Row({ label, value, kind = "normal" }: { label: string; value: number; kind?: "normal" | "subtotal" | "result" | "sub" }) {
+  const cls =
+    kind === "result" ? "font-semibold text-gray-900 border-t-2 border-gray-300"
+    : kind === "subtotal" ? "font-medium text-gray-800 border-t border-gray-200"
+    : kind === "sub" ? "text-gray-500 text-sm"
+    : "text-gray-700";
+  return (
+    <div className={`flex items-center justify-between py-1.5 ${cls}`}>
+      <span className={kind === "sub" ? "pl-4" : ""}>{label}</span>
+      <span className="tabular-nums">{formatCurrency(value)}</span>
+    </div>
+  );
+}
+
+export function ArSummarySection() {
+  const q = trpc.reports.arSummary.useQuery();
+
+  return (
+    <section className="bg-white rounded-lg border border-gray-200 p-6">
+      <h2 className="font-semibold text-gray-900 mb-1">Kundfordringar</h2>
+      <p className="text-sm text-gray-500 mb-4">Livstid — fakturerat, inbetalt och konstaterad kundförlust.</p>
+
+      {q.isLoading && <p className="text-sm text-gray-500">Laddar…</p>}
+      {q.data && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+          {/* Kundfordrings-brygga */}
+          <div>
+            <h3 className="text-sm font-medium text-gray-600 mb-2">Brygga</h3>
+            <Row label="Fakturerat (brutto)" value={q.data.bridge.fakturerat} />
+            <Row label="− Krediterat / nedsatt" value={-q.data.bridge.krediterat} />
+            <Row label="= Justerat fakturerat" value={q.data.bridge.justerat} kind="subtotal" />
+            <Row label="− Inbetalt" value={-q.data.bridge.inbetalt} />
+            <Row label="− Konstaterad kundförlust" value={-q.data.bridge.konstateradKundforlust} />
+            <Row label="= Utestående fordran" value={q.data.bridge.utestaende} kind="subtotal" />
+            <Row label="varav ej förfallet" value={q.data.bridge.ejForfallet} kind="sub" />
+            <Row label="varav förfallet" value={q.data.bridge.forfallet} kind="sub" />
+            <Row label="Netto realiserat" value={q.data.bridge.nettoRealiserat} kind="result" />
+          </div>
+
+          {/* Åldersanalys */}
+          <div>
+            <h3 className="text-sm font-medium text-gray-600 mb-2">Åldersanalys (förfallna fakturor)</h3>
+            {q.data.aging.every((b) => b.amount === 0) ? (
+              <p className="text-sm text-gray-500">Inga förfallna fakturor.</p>
+            ) : (
+              q.data.aging.map((b) => (
+                <div key={b.label} className="flex items-center justify-between py-1.5 text-gray-700">
+                  <span>{b.label}</span>
+                  <span className="tabular-nums">{formatCurrency(b.amount)}</span>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -8,6 +8,7 @@ import { formatMinutes, formatCurrency } from "@/lib/client/utils";
 import { labelForPaymentMethod, creditRiskFor, CREDIT_RISK_LABELS, type CreditRisk } from "@/lib/client/labels";
 import type { AppRouter } from "@/lib/server/routers/_app";
 import { DataTable, type Column } from "@/components/ui/data-table";
+import { ArSummarySection } from "./_ar-summary";
 
 const RISK_BADGE_CLASSES: Record<CreditRisk, string> = {
   LOW: "bg-green-50 text-green-700 border-green-200",
@@ -127,6 +128,10 @@ export default function ReportsPage() {
       </div>
 
       <div className="flex-1 overflow-y-auto min-h-0 -mx-4 sm:-mx-6 lg:-mx-8 px-4 sm:px-6 lg:px-8">
+        <div className="mb-6">
+          <ArSummarySection />
+        </div>
+
         {report.isLoading && (
           <p className="text-sm text-gray-500">Laddar rapport...</p>
         )}

--- a/src/lib/server/routers/reports.ts
+++ b/src/lib/server/routers/reports.ts
@@ -5,6 +5,7 @@ import {
   type BilledInvoiceInput,
   type FrozenWorkInput,
 } from "@/lib/shared/billed-per-lawyer";
+import { computeArBridge, computeAging } from "@/lib/shared/ar-summary";
 
 /**
  * Advokat-fokuserade rapporter: användaren väljer period (from/to) och
@@ -438,4 +439,31 @@ export const reportsRouter = router({
         netOre: result.netOre,
       };
     }),
+
+  /**
+   * Kundfordrings-sammanställning (ADR 0007), LIVSTID: brygga + åldersanalys.
+   * Bygger på WriteOff-posterna (#136–139) → konstaterad kundförlust är en
+   * daterad sanning, inte en härledd updatedAt-gissning.
+   */
+  arSummary: protectedProcedure.query(async ({ ctx }) => {
+    const orgScope = { matter: { organizationId: ctx.user.organizationId } };
+    const invoices = await ctx.dataStore.invoices.findMany({
+      where: orgScope,
+      select: { id: true, amount: true, status: true, invoiceType: true, creditedInvoiceId: true, dueDate: true, dueAt: true },
+    });
+    const ids = (invoices as Array<{ id: string }>).map((i) => i.id);
+    const [payments, writeOffs] = await Promise.all([
+      ctx.dataStore.payments.findMany({ where: { invoiceId: { in: ids } }, select: { invoiceId: true, amount: true } }),
+      ctx.dataStore.writeOffs.findMany({ where: { invoiceId: { in: ids } }, select: { invoiceId: true, amount: true } }),
+    ]);
+
+    const now = new Date();
+    const inv = invoices as Record<string, unknown>[];
+    const pay = payments as Record<string, unknown>[];
+    const wo = writeOffs as Record<string, unknown>[];
+    return {
+      bridge: computeArBridge(inv, pay, wo, now),
+      aging: computeAging(inv, pay, wo, now),
+    };
+  }),
 });

--- a/src/lib/shared/ar-summary.ts
+++ b/src/lib/shared/ar-summary.ts
@@ -1,0 +1,171 @@
+/**
+ * Kundfordrings-sammanställning ([ADR 0007]) — ren aggregering, inga DB-anrop.
+ * Allt i öre (Int). Livstid som primär vy (inget periodfönster).
+ *
+ * Bygger på partition-invarianten (#137): per faktura
+ *   amount = betalt + krediterat + avskrivet + utestående
+ * så aggregerat:
+ *   Fakturerat − Krediterat − Inbetalt − Konstaterad kundförlust = Σ Utestående
+ *   Netto realiserat = Fakturerat − Krediterat − Konstaterad kundförlust
+ *                    = Inbetalt + Utestående
+ *
+ * Två vyer delar samma per-faktura-ledger:
+ *   - kundfordrings-brygga (waterfall)
+ *   - åldersanalys (förfallna fakturors utestående i dag-hinkar)
+ *
+ * [ADR 0007]: ../../../docs/adr/0007-kundfordringar-konstaterad-kundforlust.md
+ */
+
+import { computeInvoiceLedger } from "./write-off-calc";
+
+type Row = Record<string, unknown>;
+
+/** Status som räknas som "utställd" (fakturerat). DRAFT/CANCELLED exkluderas. */
+const ISSUED_STATUSES = new Set(["SENT", "PAID", "BAD_DEBT", "INSTALLMENT_PLAN"]);
+
+function num(v: unknown): number {
+  return typeof v === "number" ? v : Number(v ?? 0);
+}
+
+function coerceDateOrNull(v: unknown): Date | null {
+  if (v instanceof Date) return v;
+  if (typeof v === "string" || typeof v === "number") {
+    const d = new Date(v);
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+  return null;
+}
+
+/** Summera `amount` per `key`-värde över rader. */
+function sumAmountByKey(rows: readonly Row[], key: string): Map<string, number> {
+  const m = new Map<string, number>();
+  for (const r of rows) {
+    const k = String(r[key] ?? "");
+    if (k) m.set(k, (m.get(k) ?? 0) + num(r.amount));
+  }
+  return m;
+}
+
+/** Krediterat per ursprungsfaktura (CREDIT-fakturors absolutbelopp). */
+function creditedByInvoice(invoices: readonly Row[]): Map<string, number> {
+  const m = new Map<string, number>();
+  for (const inv of invoices) {
+    if (inv.invoiceType !== "CREDIT") continue;
+    const target = String(inv.creditedInvoiceId ?? "");
+    if (target) m.set(target, (m.get(target) ?? 0) + Math.abs(num(inv.amount)));
+  }
+  return m;
+}
+
+export interface InvoiceOutstanding {
+  invoiceId: string;
+  outstanding: number;
+  dueDate: Date | null;
+}
+
+/** Utestående för EN utställd icke-CREDIT-faktura, annars null. */
+function outstandingForInvoice(
+  inv: Row,
+  paid: Map<string, number>,
+  credited: Map<string, number>,
+  written: Map<string, number>,
+): InvoiceOutstanding | null {
+  if (!ISSUED_STATUSES.has(String(inv.status)) || inv.invoiceType === "CREDIT") return null;
+  const id = String(inv.id ?? "");
+  const ledger = computeInvoiceLedger(num(inv.amount), paid.get(id) ?? 0, credited.get(id) ?? 0, written.get(id) ?? 0);
+  return { invoiceId: id, outstanding: ledger.outstanding, dueDate: coerceDateOrNull(inv.dueDate ?? inv.dueAt) };
+}
+
+/** Per utställd (icke-CREDIT) faktura: utestående + förfallodatum. */
+export function perInvoiceOutstanding(
+  invoices: readonly Row[],
+  payments: readonly Row[],
+  writeOffs: readonly Row[],
+): InvoiceOutstanding[] {
+  const paid = sumAmountByKey(payments, "invoiceId");
+  const credited = creditedByInvoice(invoices);
+  const written = sumAmountByKey(writeOffs, "invoiceId");
+  const out: InvoiceOutstanding[] = [];
+  for (const inv of invoices) {
+    const row = outstandingForInvoice(inv, paid, credited, written);
+    if (row) out.push(row);
+  }
+  return out;
+}
+
+export interface ArBridge {
+  fakturerat: number;
+  krediterat: number;
+  justerat: number;
+  inbetalt: number;
+  konstateradKundforlust: number;
+  utestaende: number;
+  ejForfallet: number;
+  forfallet: number;
+  nettoRealiserat: number;
+}
+
+/** Kundfordrings-bryggan (waterfall), livstid. */
+export function computeArBridge(
+  invoices: readonly Row[],
+  payments: readonly Row[],
+  writeOffs: readonly Row[],
+  now: Date,
+): ArBridge {
+  const issued = invoices.filter((i) => ISSUED_STATUSES.has(String(i.status)) && i.invoiceType !== "CREDIT");
+  const fakturerat = issued.reduce((s, i) => s + num(i.amount), 0);
+  const krediterat = invoices
+    .filter((i) => i.invoiceType === "CREDIT")
+    .reduce((s, i) => s + Math.abs(num(i.amount)), 0);
+  const inbetalt = payments.reduce((s, p) => s + num(p.amount), 0);
+  const konstateradKundforlust = writeOffs.reduce((s, w) => s + num(w.amount), 0);
+
+  const justerat = fakturerat - krediterat;
+  const utestaende = justerat - inbetalt - konstateradKundforlust;
+  const nettoRealiserat = justerat - konstateradKundforlust;
+
+  const ledgers = perInvoiceOutstanding(invoices, payments, writeOffs);
+  let ejForfallet = 0;
+  for (const l of ledgers) {
+    if (l.outstanding <= 0) continue;
+    if (l.dueDate && l.dueDate.getTime() >= now.getTime()) ejForfallet += l.outstanding;
+  }
+  const forfallet = utestaende - ejForfallet;
+
+  return { fakturerat, krediterat, justerat, inbetalt, konstateradKundforlust, utestaende, ejForfallet, forfallet, nettoRealiserat };
+}
+
+export interface AgingBucket {
+  /** Människoläsbar etikett, t.ex. "0–30 dagar". */
+  label: string;
+  /** Utestående belopp i hinken (öre). */
+  amount: number;
+}
+
+const AGING_EDGES = [30, 60, 90] as const;
+const AGING_LABELS = ["0–30 dagar", "31–60 dagar", "61–90 dagar", ">90 dagar"] as const;
+
+function bucketIndexForDaysOverdue(days: number): number {
+  if (days <= AGING_EDGES[0]) return 0;
+  if (days <= AGING_EDGES[1]) return 1;
+  if (days <= AGING_EDGES[2]) return 2;
+  return 3;
+}
+
+/** Åldersanalys: förfallna fakturors utestående i dag-hinkar (synliggör eftersläpningen). */
+export function computeAging(
+  invoices: readonly Row[],
+  payments: readonly Row[],
+  writeOffs: readonly Row[],
+  now: Date,
+): AgingBucket[] {
+  const amounts: [number, number, number, number] = [0, 0, 0, 0];
+  for (const l of perInvoiceOutstanding(invoices, payments, writeOffs)) {
+    if (l.outstanding <= 0 || !l.dueDate) continue;
+    const days = Math.floor((now.getTime() - l.dueDate.getTime()) / 86_400_000);
+    if (days <= 0) continue; // ej förfallet
+    const idx = bucketIndexForDaysOverdue(days);
+    amounts[idx] = (amounts[idx] ?? 0) + l.outstanding;
+  }
+  return AGING_LABELS.map((label, i) => ({ label, amount: amounts[i] ?? 0 }));
+}

--- a/test/unit/app/reports/ar-summary.test.tsx
+++ b/test/unit/app/reports/ar-summary.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * Test för ArSummarySection (ADR 0007): brygga + åldersanalys renderas.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest-compat";
+import { render, screen } from "@testing-library/react";
+
+const arQuery = { data: undefined as Record<string, unknown> | undefined, isLoading: false };
+
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: { reports: { arSummary: { useQuery: () => arQuery } } },
+}));
+
+import { ArSummarySection } from "@/app/reports/_ar-summary";
+
+beforeEach(() => {
+  arQuery.data = undefined;
+  arQuery.isLoading = false;
+});
+
+describe("ArSummarySection", () => {
+  it("visar laddningsläge", () => {
+    arQuery.isLoading = true;
+    render(<ArSummarySection />);
+    expect(screen.getByText("Laddar…")).toBeInTheDocument();
+  });
+
+  it("renderar bryggan + åldersanalysen", () => {
+    arQuery.data = {
+      bridge: {
+        fakturerat: 1_700_00, krediterat: 100_00, justerat: 1_600_00,
+        inbetalt: 850_00, konstateradKundforlust: 150_00,
+        utestaende: 600_00, ejForfallet: 200_00, forfallet: 400_00,
+        nettoRealiserat: 1_450_00,
+      },
+      aging: [
+        { label: "0–30 dagar", amount: 100_00 },
+        { label: "31–60 dagar", amount: 0 },
+        { label: "61–90 dagar", amount: 0 },
+        { label: ">90 dagar", amount: 300_00 },
+      ],
+    };
+    render(<ArSummarySection />);
+    expect(screen.getByText("Kundfordringar")).toBeInTheDocument();
+    expect(screen.getByText("Fakturerat (brutto)")).toBeInTheDocument();
+    expect(screen.getByText("= Utestående fordran")).toBeInTheDocument();
+    expect(screen.getByText("Netto realiserat")).toBeInTheDocument();
+    expect(screen.getByText("0–30 dagar")).toBeInTheDocument();
+    expect(screen.getByText(">90 dagar")).toBeInTheDocument();
+  });
+
+  it("visar 'inga förfallna' när alla hinkar är 0", () => {
+    arQuery.data = {
+      bridge: {
+        fakturerat: 0, krediterat: 0, justerat: 0, inbetalt: 0, konstateradKundforlust: 0,
+        utestaende: 0, ejForfallet: 0, forfallet: 0, nettoRealiserat: 0,
+      },
+      aging: [
+        { label: "0–30 dagar", amount: 0 }, { label: "31–60 dagar", amount: 0 },
+        { label: "61–90 dagar", amount: 0 }, { label: ">90 dagar", amount: 0 },
+      ],
+    };
+    render(<ArSummarySection />);
+    expect(screen.getByText("Inga förfallna fakturor.")).toBeInTheDocument();
+  });
+});

--- a/test/unit/app/reports/page.test.tsx
+++ b/test/unit/app/reports/page.test.tsx
@@ -28,6 +28,7 @@ vi.mock("@/lib/client/trpc", () => ({
     reports: {
       perLawyer: { useQuery: () => reportQuery },
       billed: { useQuery: () => billedQuery },
+      arSummary: { useQuery: () => ({ data: undefined, isLoading: false }) },
     },
     prefs: {
       get: { useQuery: () => ({ data: undefined, isLoading: false }) },

--- a/test/unit/lib/ar-summary.test.ts
+++ b/test/unit/lib/ar-summary.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tester för ar-summary (ADR 0007): kundfordrings-brygga + åldersanalys.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { computeArBridge, computeAging } from "@/lib/shared/ar-summary";
+
+const NOW = new Date("2026-06-01T00:00:00Z");
+const daysAgo = (n: number) => new Date(NOW.getTime() - n * 86_400_000).toISOString();
+const daysAhead = (n: number) => new Date(NOW.getTime() + n * 86_400_000).toISOString();
+
+describe("computeArBridge", () => {
+  const invoices = [
+    { id: "i1", status: "SENT", invoiceType: "STANDARD", amount: 1_000_00, dueDate: daysAgo(10) },
+    { id: "i2", status: "PAID", invoiceType: "STANDARD", amount: 500_00, dueDate: daysAgo(40) },
+    { id: "i3", status: "BAD_DEBT", invoiceType: "STANDARD", amount: 200_00, dueDate: daysAgo(120) },
+    { id: "i4", status: "DRAFT", invoiceType: "STANDARD", amount: 999_00, dueDate: daysAhead(5) }, // exkluderas
+    { id: "cred", status: "SENT", invoiceType: "CREDIT", creditedInvoiceId: "i1", amount: -100_00 },
+  ];
+  const payments = [
+    { invoiceId: "i1", amount: 300_00 },
+    { invoiceId: "i2", amount: 500_00 }, // i2 fullt betald
+    { invoiceId: "i3", amount: 50_00 }, // i3 delbetald
+  ];
+  const writeOffs = [{ invoiceId: "i3", amount: 150_00 }]; // i3 återstod avskriven
+
+  const bridge = computeArBridge(invoices, payments, writeOffs, NOW);
+
+  it("fakturerat = Σ utställda icke-CREDIT (DRAFT exkluderad)", () => {
+    expect(bridge.fakturerat).toBe(1_000_00 + 500_00 + 200_00); // 1 700 00
+  });
+
+  it("krediterat = Σ abs(CREDIT)", () => {
+    expect(bridge.krediterat).toBe(100_00);
+  });
+
+  it("inbetalt + konstaterad kundförlust", () => {
+    expect(bridge.inbetalt).toBe(850_00);
+    expect(bridge.konstateradKundforlust).toBe(150_00);
+  });
+
+  it("invariant: justerat − inbetalt − förlust = utestående", () => {
+    expect(bridge.justerat).toBe(bridge.fakturerat - bridge.krediterat);
+    expect(bridge.utestaende).toBe(bridge.justerat - bridge.inbetalt - bridge.konstateradKundforlust);
+  });
+
+  it("netto realiserat = fakturerat − krediterat − konstaterad förlust (= inbetalt + utestående)", () => {
+    expect(bridge.nettoRealiserat).toBe(bridge.fakturerat - bridge.krediterat - bridge.konstateradKundforlust);
+    expect(bridge.nettoRealiserat).toBe(bridge.inbetalt + bridge.utestaende);
+  });
+
+  it("utestående delas i ej förfallet / förfallet", () => {
+    expect(bridge.ejForfallet + bridge.forfallet).toBe(bridge.utestaende);
+  });
+});
+
+describe("computeAging", () => {
+  const invoices = [
+    { id: "a", status: "SENT", invoiceType: "STANDARD", amount: 100_00, dueDate: daysAgo(10) }, // 0–30
+    { id: "b", status: "SENT", invoiceType: "STANDARD", amount: 200_00, dueDate: daysAgo(45) }, // 31–60
+    { id: "c", status: "SENT", invoiceType: "STANDARD", amount: 300_00, dueDate: daysAgo(75) }, // 61–90
+    { id: "d", status: "SENT", invoiceType: "STANDARD", amount: 400_00, dueDate: daysAgo(200) }, // >90
+    { id: "e", status: "SENT", invoiceType: "STANDARD", amount: 500_00, dueDate: daysAhead(10) }, // ej förfallet
+  ];
+
+  it("buckar förfallna fakturors utestående mot dueDate", () => {
+    const aging = computeAging(invoices, [], [], NOW);
+    expect(aging.map((b) => b.amount)).toEqual([100_00, 200_00, 300_00, 400_00]);
+    expect(aging.map((b) => b.label)).toEqual(["0–30 dagar", "31–60 dagar", "61–90 dagar", ">90 dagar"]);
+  });
+
+  it("betald/avskriven återstod räknas inte i aging", () => {
+    const aging = computeAging(
+      [{ id: "a", status: "SENT", invoiceType: "STANDARD", amount: 100_00, dueDate: daysAgo(10) }],
+      [{ invoiceId: "a", amount: 100_00 }], // fullt betald → outstanding 0
+      [],
+      NOW,
+    );
+    expect(aging.every((b) => b.amount === 0)).toBe(true);
+  });
+});


### PR DESCRIPTION
Sista arbetspaketet för [ADR 0007](docs/adr/0007-kundfordringar-konstaterad-kundforlust.md) — issue #140 (epic #141). Slutför kundfordrings-feature:n.

Sammanställnings-UI (livstid) som konsumerar WriteOff-posterna → **konstaterad kundförlust är en daterad sanning**, inte en `updatedAt`-gissning.

## Ändringar
- **`ar-summary.ts`** (ren aggregering, bygger på #137:s `computeInvoiceLedger`):
  - `computeArBridge`: Fakturerat − Krediterat = Justerat; − Inbetalt − Förlust = Utestående (ej förfallet/förfallet); **Netto realiserat = Fakturerat − Krediterat − Förlust = Inbetalt + Utestående** (invariant-konsekvent).
  - `computeAging`: förfallna fakturors utestående i 0–30 / 31–60 / 61–90 / >90-hinkar mot `dueDate`.
- **`reports.arSummary`**-query (org-scoped: invoices + payments + writeOffs).
- **`ArSummarySection`**-komponent under /reports (waterfall-brygga + åldersanalys), fristående så den komplexa `reports/page.tsx` hålls hanterbar.

## Tester (11 nya)
Aggregering: invariant (netto realiserat = fakturerat − krediterat − förlust = inbetalt + utestående), aging mot `dueDate`, betald/avskriven räknas ej. Komponent: render + laddning + tom-läge. `page.test` mock utökad med `arSummary`.

## Verifierat
`bun run test:all` grönt end-to-end (static + unit + 18 e2e). Demon visar nu kundförlust-exemplet (#139) i bryggan.

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)