### PR TITLE
fix(reports): billed-rapport läser writtenOffAt från WriteOff-poster (ADR 0007)

### DIFF
--- a/src/lib/server/routers/reports.ts
+++ b/src/lib/server/routers/reports.ts
@@ -89,14 +89,27 @@ function buildFrozenWork(
   return out;
 }
 
-function toInvoiceInputs(invoices: RawInvoice[]): BilledInvoiceInput[] {
+/** invoiceId → senaste avskrivnings-tidpunkt ur WriteOff-posterna (ADR 0007). */
+function writtenOffDates(writeOffs: Array<{ invoiceId?: string; writtenOffAt?: unknown }>): Map<string, Date> {
+  const m = new Map<string, Date>();
+  for (const w of writeOffs) {
+    if (!w.invoiceId) continue;
+    const d = coerceDate(w.writtenOffAt);
+    const cur = m.get(w.invoiceId);
+    if (!cur || d.getTime() > cur.getTime()) m.set(w.invoiceId, d);
+  }
+  return m;
+}
+
+function toInvoiceInputs(invoices: RawInvoice[], writtenOff: Map<string, Date>): BilledInvoiceInput[] {
   return invoices.map((i) => ({
     id: i.id,
     amountOre: i.amount,
     invoiceDate: coerceDate(i.invoiceDate),
     status: i.status,
-    // Avskrivnings-tidpunkt: invoice.updatedAt vid BAD_DEBT (#90-beslut).
-    writtenOffAt: i.status === "BAD_DEBT" ? coerceDate(i.updatedAt) : null,
+    // Avskrivnings-tidpunkt från WriteOff-posten (ADR 0007); fallback till
+    // updatedAt-heuristiken (#90) för ev. BAD_DEBT-faktura utan post.
+    writtenOffAt: writtenOff.get(i.id) ?? (i.status === "BAD_DEBT" ? coerceDate(i.updatedAt) : null),
   }));
 }
 
@@ -381,7 +394,7 @@ export const reportsRouter = router({
       const prevPeriod = previousCalendarMonth(fromDate);
       const orgScope = { matter: { organizationId: ctx.user.organizationId } };
 
-      const [user, invoices, billingRuns, timeEntries] = await Promise.all([
+      const [user, invoices, billingRuns, timeEntries, writeOffs] = await Promise.all([
         ctx.dataStore.users.findFirst({
           where: { id: input.userId, organizationId: ctx.user.organizationId },
           select: { id: true, name: true },
@@ -398,6 +411,7 @@ export const reportsRouter = router({
           where: { ...orgScope, billable: true },
           select: { userId: true, minutes: true, hourlyRate: true, invoiceId: true, frozenByBillingRunId: true },
         }),
+        ctx.dataStore.writeOffs.findMany({ select: { invoiceId: true, writtenOffAt: true } }),
       ]);
 
       if (!user) return null;
@@ -407,7 +421,7 @@ export const reportsRouter = router({
 
       const result = billedPerLawyer({
         userId: input.userId,
-        invoices: toInvoiceInputs(invoices as RawInvoice[]),
+        invoices: toInvoiceInputs(invoices as RawInvoice[], writtenOffDates(writeOffs as Array<{ invoiceId?: string; writtenOffAt?: unknown }>)),
         frozenWork: buildFrozenWork(timeEntries as RawTimeEntry[], runToInvoice),
         period: { from: fromDate, to: toDate },
         prevPeriod,

--- a/test/unit/server/routers/reports-billed.test.ts
+++ b/test/unit/server/routers/reports-billed.test.ts
@@ -13,6 +13,7 @@ const mockPrisma = {
   invoice: { findMany: vi.fn() },
   billingRun: { findMany: vi.fn() },
   timeEntry: { findMany: vi.fn() },
+  writeOff: { findMany: vi.fn() },
 };
 
 function makeCaller(orgId = "org-a") {
@@ -32,6 +33,7 @@ beforeEach(() => {
   mockPrisma.invoice.findMany.mockResolvedValue([]);
   mockPrisma.billingRun.findMany.mockResolvedValue([]);
   mockPrisma.timeEntry.findMany.mockResolvedValue([]);
+  mockPrisma.writeOff.findMany.mockResolvedValue([]);
 });
 
 const te = (o: Record<string, unknown> = {}) => ({
@@ -97,5 +99,19 @@ describe("reports.billed", () => {
     expect(res?.prevPeriod).toEqual({ from: "2026-05-01", to: "2026-05-31" });
     // Den avskrivna (utfärdad i mars) syns inte i periodens billed-lista.
     expect(res?.invoices.map((i) => i.id)).toEqual(["billed"]);
+  });
+
+  it("writtenOffAt tas från WriteOff-posten, inte invoice.updatedAt (ADR 0007)", async () => {
+    // updatedAt i juni (utanför maj-perioden) men WriteOff-posten daterad i maj
+    // → avdraget ska ske → bevisar att posten styr, inte updatedAt-hacket.
+    mockPrisma.invoice.findMany.mockResolvedValue([
+      { id: "wo", amount: 40_000, status: "BAD_DEBT", invoiceDate: new Date("2026-03-01"), updatedAt: new Date("2026-06-20"), matter: { matterNumber: "B", title: "B" } },
+    ]);
+    mockPrisma.timeEntry.findMany.mockResolvedValue([te({ invoiceId: "wo" })]);
+    mockPrisma.writeOff.findMany.mockResolvedValue([
+      { invoiceId: "wo", writtenOffAt: new Date("2026-05-10") },
+    ]);
+    const res = await makeCaller().billed({ ...JUNE, userId: "u1" });
+    expect(res?.writeOffOre).toBe(40_000);
   });
 });


### PR DESCRIPTION
Issue #151 — ersätter #90-hacket (`writtenOffAt = invoice.updatedAt` vid BAD_DEBT) med faktiska WriteOff-posters `writtenOffAt`.

## Ändringar
- billed-queryn hämtar `writeOffs` parallellt (Promise.all).
- `writtenOffDates()` bygger `invoiceId → senaste writtenOffAt`.
- `toInvoiceInputs` använder kartan; **updatedAt-fallback bevaras** för ev. BAD_DEBT-faktura utan post.

Fungerar för både nya WriteOffs och migrerade legacy-BAD_DEBT (synthesisen från #139 körs i hydreringen → datalagret har posten även för gammal data).

## Tester
Befintliga billed-tester gröna (fallback täcker dem). Nytt test: `invoice.updatedAt` i juni men WriteOff-post i maj → avdraget sker → bevisar att **posten** styr, inte updatedAt.

## Verifierat
`bun run test:all` grönt end-to-end.

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)