### PR TITLE
feat(payment-plans): visa utestående via ledger (ADR 0007)

### DIFF
--- a/src/app/payment-plans/[id]/_client.tsx
+++ b/src/app/payment-plans/[id]/_client.tsx
@@ -5,6 +5,7 @@ import { trpc } from "@/lib/client/trpc";
 import { useRouteId } from "@/lib/client/demo/use-route-id";
 import { EntityLink } from "@/lib/client/demo/entity-link";
 import { formatCurrency } from "@/lib/client/utils";
+import { computeInvoiceLedger } from "@/lib/shared/write-off-calc";
 import { ArrowLeft, Ban, Wallet } from "lucide-react";
 
 const STATUS_LABEL: Record<string, string> = {
@@ -140,6 +141,19 @@ export default function PaymentPlanDetailClient({ id: paramId }: { id: string })
                 <span className="font-mono">{p.invoice ? formatCurrency(p.invoice.amount) : ""}</span>
               </span>
             </div>
+            {p.invoice && (
+              <div className="mt-1 text-xs flex justify-end gap-1">
+                <span className="text-gray-500">Utestående:</span>
+                <span className="font-mono font-semibold text-gray-900">
+                  {formatCurrency(computeInvoiceLedger(
+                    p.invoice.amount,
+                    (p.invoice.payments ?? []).reduce((s, x) => s + x.amount, 0),
+                    0,
+                    ((p.invoice as { writeOffs?: Array<{ amount: number }> }).writeOffs ?? []).reduce((s, w) => s + w.amount, 0),
+                  ).outstanding)}
+                </span>
+              </div>
+            )}
           </>
         )}
       </section>

--- a/src/app/payment-plans/page.tsx
+++ b/src/app/payment-plans/page.tsx
@@ -11,6 +11,7 @@ import { Wallet, Search } from "lucide-react";
 import { trpc } from "@/lib/client/trpc";
 import { shellPath } from "@/lib/client/demo/entity-href";
 import { formatCurrency } from "@/lib/client/utils";
+import { computeInvoiceLedger } from "@/lib/shared/write-off-calc";
 import { DataTable, type Column } from "@/components/ui/data-table";
 
 type Status = "ACTIVE" | "COMPLETED" | "CANCELLED";
@@ -34,6 +35,7 @@ interface PlanRow {
   invoice?: {
     amount?: number;
     payments?: Array<{ amount: number }>;
+    writeOffs?: Array<{ amount: number }>;
     matter?: {
       matterNumber?: string;
       title?: string;
@@ -48,6 +50,12 @@ function paidOf(p: PlanRow): number {
 
 function totalOf(p: PlanRow): number {
   return p.invoice?.amount ?? 0;
+}
+
+/** Utestående via ledgern (ADR 0007): total − inbetalt − avskrivet. */
+function outstandingOf(p: PlanRow): number {
+  const writtenOff = (p.invoice?.writeOffs ?? []).reduce((s, w) => s + w.amount, 0);
+  return computeInvoiceLedger(totalOf(p), paidOf(p), 0, writtenOff).outstanding;
 }
 
 const planColumns: Column<PlanRow>[] = [
@@ -76,6 +84,9 @@ const planColumns: Column<PlanRow>[] = [
   { key: "total", label: "Totalt", sortable: true, align: "right",
     sortValue: (p) => totalOf(p),
     render: (p) => <span className="font-mono text-sm">{formatCurrency(totalOf(p))}</span> },
+  { key: "outstanding", label: "Utestående", sortable: true, align: "right",
+    sortValue: (p) => outstandingOf(p),
+    render: (p) => <span className="font-mono text-sm">{formatCurrency(outstandingOf(p))}</span> },
   { key: "pct", label: "Andel", sortable: true, align: "right",
     sortValue: (p) => totalOf(p) > 0 ? paidOf(p) / totalOf(p) : 0,
     render: (p) => {

--- a/src/lib/server/routers/paymentPlan.ts
+++ b/src/lib/server/routers/paymentPlan.ts
@@ -109,6 +109,8 @@ export const paymentPlanRouter = router({
               },
               // Inkludera payments så list-vyn kan visa progress (X av Y betalt)
               payments: { orderBy: { paidAt: "desc" } },
+              // + writeOffs så utestående kan beräknas via ledgern (ADR 0007).
+              writeOffs: true,
             },
           },
         },
@@ -146,6 +148,7 @@ export const paymentPlanRouter = router({
                 },
               },
               payments: { orderBy: { paidAt: "desc" } },
+              writeOffs: true,
             },
           },
           reminders: { orderBy: { sentAt: "desc" } },

--- a/test/unit/app/payment-plans/page.test.tsx
+++ b/test/unit/app/payment-plans/page.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * Test för PaymentPlansPage — utestående-kolumnen (ADR 0007): total − inbetalt
+ * − avskrivet via ledgern.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest-compat";
+import { render, screen } from "@testing-library/react";
+
+const listQuery = { data: undefined as unknown[] | undefined, isLoading: false };
+
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: {
+    useUtils: () => ({ prefs: { get: { invalidate: vi.fn() } } }),
+    user: {
+      current: { useQuery: () => ({ data: { id: "u1", role: "LAWYER" } }) },
+      list: { useQuery: () => ({ data: { users: [] } }) },
+    },
+    paymentPlan: { list: { useQuery: () => listQuery } },
+    prefs: {
+      get: { useQuery: () => ({ data: undefined, isLoading: false }) },
+      save: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      clear: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      setOrgDefault: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      clearOrgDefault: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+    },
+  },
+}));
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
+import PaymentPlansPage from "@/app/payment-plans/page";
+
+beforeEach(() => {
+  listQuery.data = undefined;
+  listQuery.isLoading = false;
+});
+
+describe("PaymentPlansPage — utestående", () => {
+  it("visar utestående = total − inbetalt − avskrivet", () => {
+    listQuery.data = [
+      {
+        id: "pp1", status: "ACTIVE", monthlyAmount: 10_000, dayOfMonth: 15,
+        invoice: {
+          amount: 100_000,
+          payments: [{ amount: 30_000 }],
+          writeOffs: [{ amount: 20_000 }],
+          matter: { matterNumber: "2026-0001", title: "Tvist", contacts: [{ contact: { id: "c1", name: "Anna" } }] },
+        },
+      },
+    ];
+    render(<PaymentPlansPage />);
+    // 100 000 − 30 000 betalt − 20 000 avskrivet = 50 000 öre = 500 kr utestående
+    expect(screen.getByText("Utestående")).toBeInTheDocument();
+    // formatCurrency(50000) → "500,00 kr" (sv-SE). Matcha siffran robust.
+    expect(screen.getByText(/500,00/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Issue #152 (sista UI-paketet) — avbetalningsplan-vyerna visar fakturans faktiska **utestående** via ledgern.

## Ändringar
- `paymentPlan.list` + `getById` inkluderar `writeOffs` i invoice-includen.
- **Listan**: ny "Utestående"-kolumn = total − inbetalt − avskrivet (`computeInvoiceLedger`).
- **Detaljsidan**: utestående-rad under betalnings-progressen.
- Komponenttest för utestående-kolumnen.

## Verifierat
`bun run test:all` grönt end-to-end.

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)