### PR TITLE
fix(invoices): recordPayment validerar partition-invarianten (ADR 0007)

### DIFF
--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -18,7 +18,7 @@ import { TRPCError } from "@trpc/server";
 import { router, orgProcedure } from "../trpc";
 import type { DataStoreTx } from "../data-store/IDataStore";
 import { computeFinalInvoiceBreakdown, isPaymentPlanSettled } from "@/lib/shared/invoice-calc";
-import { computeInvoiceLedger, deriveInvoiceStatus } from "@/lib/shared/write-off-calc";
+import { computeInvoiceLedger, deriveInvoiceStatus, invoicePartitionViolation } from "@/lib/shared/write-off-calc";
 import type { InvoiceStatus } from "@/lib/shared/schemas/enums";
 import { emit } from "../events/emit";
 import {
@@ -116,9 +116,9 @@ async function gatherInvoiceLedger(
 ): Promise<{ paid: number; credited: number; writtenOff: number; ledger: ReturnType<typeof computeInvoiceLedger> }> {
   const paid = (inv.payments ?? []).reduce((s, p) => s + p.amount, 0);
   const credits = await tx.invoices.findMany({ where: { creditedInvoiceId: inv.id, matter: { organizationId: orgId } } });
-  const credited = (credits as ReadonlyArray<{ amount: number }>).reduce((s, c) => s + Math.abs(c.amount), 0);
+  const credited = ((credits ?? []) as ReadonlyArray<{ amount: number }>).reduce((s, c) => s + Math.abs(c.amount), 0);
   const existing = await tx.writeOffs.findMany({ where: { invoiceId: inv.id } });
-  const writtenOff = (existing as ReadonlyArray<{ amount: number }>).reduce((s, w) => s + w.amount, 0);
+  const writtenOff = ((existing ?? []) as ReadonlyArray<{ amount: number }>).reduce((s, w) => s + w.amount, 0);
   return { paid, credited, writtenOff, ledger: computeInvoiceLedger(inv.amount, paid, credited, writtenOff) };
 }
 
@@ -383,6 +383,16 @@ export const invoiceRouter = router({
           include: { paymentPlan: true, payments: true },
         });
         if (!inv) throw new TRPCError({ code: "NOT_FOUND" });
+
+        // Konsistens-skydd (ADR 0007): en betalning får inte översumera fakturan
+        // (betalt + krediterat + avskrivet > belopp → utestående < 0). Validera
+        // FÖRE skapandet så vi inte lämnar en partition-brytande rad.
+        const { paid, credited, writtenOff } = await gatherInvoiceLedger(tx, ctx.orgId, inv);
+        const afterLedger = computeInvoiceLedger(inv.amount, paid + input.amount, credited, writtenOff);
+        const violation = invoicePartitionViolation(inv.amount, afterLedger);
+        if (violation) {
+          throw new TRPCError({ code: "BAD_REQUEST", message: `Betalningen kan inte registreras: ${violation}` });
+        }
 
         const payment = await tx.payments.create({
           data: {

--- a/test/unit/server/routers/invoice.test.ts
+++ b/test/unit/server/routers/invoice.test.ts
@@ -71,6 +71,11 @@ beforeEach(() => {
   mockPrisma.$transaction.mockImplementation(
     <T,>(fn: (tx: typeof mockPrisma) => Promise<T>) => fn(mockPrisma),
   );
+  // Säkra defaults så gatherInvoiceLedger (krediterings-/writeOff-frågor i
+  // recordPayment/writeOff) inte ärver en annan tests mockResolvedValue
+  // (clearAllMocks rensar call-data men inte implementationer).
+  mockPrisma.invoice.findMany.mockResolvedValue([]);
+  mockPrisma.writeOff.findMany.mockResolvedValue([]);
 });
 
 const MATTER_A = { id: "matter-1", organizationId: "org-a", matterNumber: "2026-0001", title: "T" };
@@ -330,6 +335,20 @@ describe("invoice.recordPayment", () => {
         paidAt: "2026-05-15",
       }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(mockPrisma.payment.create).not.toHaveBeenCalled();
+  });
+
+  it("avvisar översummerande betalning (partition-invariant, ADR 0007)", async () => {
+    mockPrisma.invoice.findFirst.mockResolvedValue({
+      id: "inv-1", amount: 1_000_000, status: "SENT", paymentPlan: null,
+      payments: [{ amount: 900_000 }],
+    });
+    mockPrisma.invoice.findMany.mockResolvedValue([]); // inga krediteringar
+    mockPrisma.writeOff.findMany.mockResolvedValue([]); // inget avskrivet
+
+    // utestående = 100 000; försök betala 200 000 → utestående < 0
+    await expect(makeCaller().recordPayment({ invoiceId: "inv-1", amount: 200_000, paidAt: "2026-05-15" }))
+      .rejects.toMatchObject({ code: "BAD_REQUEST" });
     expect(mockPrisma.payment.create).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Issue #156 — extra konsistens-skydd: `invoice.recordPayment` validerar betalningen mot kundfordrings-ledgern.

## Ändring
En betalning som skulle **översumera** fakturan (betalt + krediterat + avskrivet > belopp → utestående < 0) avvisas med `BAD_REQUEST` **innan** Payment skapas. Validering via `gatherInvoiceLedger` + `computeInvoiceLedger` + `invoicePartitionViolation`.

- `gatherInvoiceLedger` defensiv (`?? []`) → robust mot mock + verkligt datalager.
- Test: översummerande betalning → BAD_REQUEST, ingen Payment skapad. Full betalning av utestående → OK.
- `beforeEach` sätter säkra `findMany`-defaults (skydd mot mock-läckage mellan tester).

## Verifierat
`bun run test:all` grönt end-to-end (38 invoice-router-tester + 18 e2e).

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)