### PR TITLE
fix(reports): låt Kundfordringar följa rapport-perioden (ADR 0007 #4 uppdaterat)

### DIFF
--- a/docs/adr/0007-kundfordringar-konstaterad-kundforlust.md
+++ b/docs/adr/0007-kundfordringar-konstaterad-kundforlust.md
@@ -50,6 +50,8 @@ Vi modellerar kundfordringar som **daterade, immutabla händelser** (event-sourc
 
 4. **Livstid som primär vy.** Rubriktalet är ett löpande totalsaldo ("allt fram till nu"). Det eliminerar restatement-problematik helt: upptäcks en gammal faktura vara dålig idag, bokas write-offen **idag** och livstids-nettot sjunker idag — rätt, utan dubbelräkning, utan retroaktiv redigering av utställandet.
 
+   > **Ändring 2026-06-09 (#158):** Rapport-panelen `Kundfordringar` följer nu i stället **rapport-perioden**, scopad på fakturor utställda i perioden (`invoiceDate ∈ [from,to]`) — samma nyckel som billed-panelen. Skälet: panelen sitter på en sida med periodväljare, och en livstidsvy bredvid period-paneler var förvirrande för användaren. Per-faktura-partitionen består (betalningar/krediteringar/avskrivningar räknas mot periodens fakturor). Den rena aggregeringen (`computeArBridge`/`computeAging`) är oförändrad; periodfiltret läggs ovanpå via `scopeArToPeriod`.
+
 5. **Vakt för räkna-en-gång.** En `WriteOff` får bara skapas när utestående > 0. Full avskrivning → härledd status `BAD_DEBT` → vidare write-offs avvisas.
 
 6. **Sammanställningen presenteras som två kompletterande vyer:**

--- a/src/app/reports/_ar-summary.tsx
+++ b/src/app/reports/_ar-summary.tsx
@@ -23,13 +23,13 @@ function Row({ label, value, kind = "normal" }: { label: string; value: number; 
   );
 }
 
-export function ArSummarySection() {
-  const q = trpc.reports.arSummary.useQuery();
+export function ArSummarySection({ from, to }: { from: string; to: string }) {
+  const q = trpc.reports.arSummary.useQuery({ from, to });
 
   return (
     <section className="bg-white rounded-lg border border-gray-200 p-6">
       <h2 className="font-semibold text-gray-900 mb-1">Kundfordringar</h2>
-      <p className="text-sm text-gray-500 mb-4">Livstid — fakturerat, inbetalt och konstaterad kundförlust.</p>
+      <p className="text-sm text-gray-500 mb-4">Fakturor utställda i perioden — fakturerat, inbetalt och konstaterad kundförlust.</p>
 
       {q.isLoading && <p className="text-sm text-gray-500">Laddar…</p>}
       {q.data && (

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -129,7 +129,7 @@ export default function ReportsPage() {
 
       <div className="flex-1 overflow-y-auto min-h-0 -mx-4 sm:-mx-6 lg:-mx-8 px-4 sm:px-6 lg:px-8">
         <div className="mb-6">
-          <ArSummarySection />
+          <ArSummarySection from={from} to={to} />
         </div>
 
         {report.isLoading && (

--- a/src/lib/server/routers/reports.ts
+++ b/src/lib/server/routers/reports.ts
@@ -5,7 +5,7 @@ import {
   type BilledInvoiceInput,
   type FrozenWorkInput,
 } from "@/lib/shared/billed-per-lawyer";
-import { computeArBridge, computeAging } from "@/lib/shared/ar-summary";
+import { computeArBridge, computeAging, scopeArToPeriod } from "@/lib/shared/ar-summary";
 
 /**
  * Advokat-fokuserade rapporter: användaren väljer period (from/to) och
@@ -459,25 +459,35 @@ export const reportsRouter = router({
    * Bygger på WriteOff-posterna (#136–139) → konstaterad kundförlust är en
    * daterad sanning, inte en härledd updatedAt-gissning.
    */
-  arSummary: protectedProcedure.query(async ({ ctx }) => {
-    const orgScope = { matter: { organizationId: ctx.user.organizationId } };
-    const invoices = await ctx.dataStore.invoices.findMany({
-      where: orgScope,
-      select: { id: true, amount: true, status: true, invoiceType: true, creditedInvoiceId: true, dueDate: true, dueAt: true },
-    });
-    const ids = (invoices as Array<{ id: string }>).map((i) => i.id);
-    const [payments, writeOffs] = await Promise.all([
-      ctx.dataStore.payments.findMany({ where: { invoiceId: { in: ids } }, select: { invoiceId: true, amount: true } }),
-      ctx.dataStore.writeOffs.findMany({ where: { invoiceId: { in: ids } }, select: { invoiceId: true, amount: true } }),
-    ]);
+  arSummary: protectedProcedure
+    .input(z.object({ from: z.string(), to: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const fromDate = new Date(input.from);
+      const toDate = new Date(input.to);
+      toDate.setUTCHours(23, 59, 59, 999);
+      const orgScope = { matter: { organizationId: ctx.user.organizationId } };
+      const invoices = await ctx.dataStore.invoices.findMany({
+        where: orgScope,
+        select: { id: true, amount: true, status: true, invoiceType: true, creditedInvoiceId: true, invoiceDate: true, dueDate: true, dueAt: true },
+      });
+      const ids = (invoices as Array<{ id: string }>).map((i) => i.id);
+      const [payments, writeOffs] = await Promise.all([
+        ctx.dataStore.payments.findMany({ where: { invoiceId: { in: ids } }, select: { invoiceId: true, amount: true } }),
+        ctx.dataStore.writeOffs.findMany({ where: { invoiceId: { in: ids } }, select: { invoiceId: true, amount: true } }),
+      ]);
 
-    const now = new Date();
-    const inv = invoices as Record<string, unknown>[];
-    const pay = payments as Record<string, unknown>[];
-    const wo = writeOffs as Record<string, unknown>[];
-    return {
-      bridge: computeArBridge(inv, pay, wo, now),
-      aging: computeAging(inv, pay, wo, now),
-    };
-  }),
+      // Scopa till fakturor utställda i perioden (ADR 0007 #4, uppdaterat) så
+      // panelen följer rapport-filtret som de övriga rapporterna.
+      const scoped = scopeArToPeriod(
+        invoices as Record<string, unknown>[],
+        payments as Record<string, unknown>[],
+        writeOffs as Record<string, unknown>[],
+        { from: fromDate, to: toDate },
+      );
+      const now = new Date();
+      return {
+        bridge: computeArBridge(scoped.invoices, scoped.payments, scoped.writeOffs, now),
+        aging: computeAging(scoped.invoices, scoped.payments, scoped.writeOffs, now),
+      };
+    }),
 });

--- a/src/lib/shared/ar-summary.ts
+++ b/src/lib/shared/ar-summary.ts
@@ -93,6 +93,46 @@ export function perInvoiceOutstanding(
   return out;
 }
 
+export interface ArPeriod {
+  from: Date;
+  to: Date;
+}
+
+function issueDateOf(inv: Row): Date | null {
+  return coerceDateOrNull(inv.invoiceDate ?? inv.issuedAt);
+}
+
+/**
+ * Scopa kundfordrings-datat till fakturor UTSTÄLLDA i perioden (invoiceDate ∈
+ * [from,to]) — samma nyckel som billed-panelen. Betalningar, krediteringar och
+ * avskrivningar tas med för dessa fakturor (oavsett egen datering) så per-faktura-
+ * partitionen består. CREDIT-fakturor följer med om de krediterar en periodfaktura.
+ */
+export function scopeArToPeriod(
+  invoices: readonly Row[],
+  payments: readonly Row[],
+  writeOffs: readonly Row[],
+  period: ArPeriod,
+): { invoices: Row[]; payments: Row[]; writeOffs: Row[] } {
+  const fromMs = period.from.getTime();
+  const toMs = period.to.getTime();
+  const periodIds = new Set<string>();
+  for (const inv of invoices) {
+    if (inv.invoiceType === "CREDIT") continue;
+    const d = issueDateOf(inv);
+    if (d && d.getTime() >= fromMs && d.getTime() <= toMs) periodIds.add(String(inv.id ?? ""));
+  }
+  const belongs = (inv: Row): boolean =>
+    inv.invoiceType === "CREDIT"
+      ? periodIds.has(String(inv.creditedInvoiceId ?? ""))
+      : periodIds.has(String(inv.id ?? ""));
+  return {
+    invoices: invoices.filter(belongs),
+    payments: payments.filter((p) => periodIds.has(String(p.invoiceId ?? ""))),
+    writeOffs: writeOffs.filter((w) => periodIds.has(String(w.invoiceId ?? ""))),
+  };
+}
+
 export interface ArBridge {
   fakturerat: number;
   krediterat: number;

--- a/test/unit/app/reports/ar-summary.test.tsx
+++ b/test/unit/app/reports/ar-summary.test.tsx
@@ -21,7 +21,7 @@ beforeEach(() => {
 describe("ArSummarySection", () => {
   it("visar laddningsläge", () => {
     arQuery.isLoading = true;
-    render(<ArSummarySection />);
+    render(<ArSummarySection from="2026-01-01" to="2026-06-30" />);
     expect(screen.getByText("Laddar…")).toBeInTheDocument();
   });
 
@@ -40,7 +40,7 @@ describe("ArSummarySection", () => {
         { label: ">90 dagar", amount: 300_00 },
       ],
     };
-    render(<ArSummarySection />);
+    render(<ArSummarySection from="2026-01-01" to="2026-06-30" />);
     expect(screen.getByText("Kundfordringar")).toBeInTheDocument();
     expect(screen.getByText("Fakturerat (brutto)")).toBeInTheDocument();
     expect(screen.getByText("= Utestående fordran")).toBeInTheDocument();
@@ -60,7 +60,7 @@ describe("ArSummarySection", () => {
         { label: "61–90 dagar", amount: 0 }, { label: ">90 dagar", amount: 0 },
       ],
     };
-    render(<ArSummarySection />);
+    render(<ArSummarySection from="2026-01-01" to="2026-06-30" />);
     expect(screen.getByText("Inga förfallna fakturor.")).toBeInTheDocument();
   });
 });

--- a/test/unit/lib/ar-summary.test.ts
+++ b/test/unit/lib/ar-summary.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from "vitest-compat";
-import { computeArBridge, computeAging } from "@/lib/shared/ar-summary";
+import { computeArBridge, computeAging, scopeArToPeriod } from "@/lib/shared/ar-summary";
 
 const NOW = new Date("2026-06-01T00:00:00Z");
 const daysAgo = (n: number) => new Date(NOW.getTime() - n * 86_400_000).toISOString();
@@ -51,6 +51,35 @@ describe("computeArBridge", () => {
 
   it("utestående delas i ej förfallet / förfallet", () => {
     expect(bridge.ejForfallet + bridge.forfallet).toBe(bridge.utestaende);
+  });
+});
+
+describe("scopeArToPeriod", () => {
+  const PERIOD = { from: new Date("2026-06-01T00:00:00Z"), to: new Date("2026-06-30T23:59:59Z") };
+  const invoices = [
+    { id: "in", status: "SENT", invoiceType: "STANDARD", amount: 100_00, invoiceDate: "2026-06-10" }, // i perioden
+    { id: "out", status: "SENT", invoiceType: "STANDARD", amount: 200_00, invoiceDate: "2026-04-10" }, // utanför
+    { id: "cred", status: "SENT", invoiceType: "CREDIT", creditedInvoiceId: "in", amount: -10_00, invoiceDate: "2026-07-05" }, // krediterar periodfaktura (senare datum)
+  ];
+  const payments = [
+    { invoiceId: "in", amount: 30_00 },
+    { invoiceId: "out", amount: 50_00 },
+  ];
+  const writeOffs = [{ invoiceId: "out", amount: 5_00 }];
+
+  it("behåller bara fakturor utställda i perioden + deras krediteringar/betalningar", () => {
+    const s = scopeArToPeriod(invoices, payments, writeOffs, PERIOD);
+    expect(s.invoices.map((i) => i.id).sort()).toEqual(["cred", "in"]); // periodfaktura + dess kredit
+    expect(s.payments).toEqual([{ invoiceId: "in", amount: 30_00 }]);
+    expect(s.writeOffs).toEqual([]); // writeOff hörde till "out" (utanför)
+  });
+
+  it("bryggan på scopad data räknar bara periodens fakturor", () => {
+    const s = scopeArToPeriod(invoices, payments, writeOffs, PERIOD);
+    const b = computeArBridge(s.invoices, s.payments, s.writeOffs, new Date("2026-07-01T00:00:00Z"));
+    expect(b.fakturerat).toBe(100_00); // bara "in"
+    expect(b.krediterat).toBe(10_00);
+    expect(b.inbetalt).toBe(30_00);
   });
 });
 


### PR DESCRIPTION
Issue #158 — Kundfordrings-panelen räknade på **livstid** men sitter på en sida med periodväljare → förvirrande (och överlappade visuellt med "Fakturerat per advokat").

## Ändring
Panelen scopas nu på **fakturor utställda i perioden** (`invoiceDate ∈ [from,to]`) — samma nyckel som billed-panelen.

- **`scopeArToPeriod()`** (ar-summary.ts, ren + testbar): behåller periodens fakturor + deras krediteringar/betalningar/avskrivningar → per-faktura-partitionen består.
- `reports.arSummary` tar `from`/`to`; `ArSummarySection` tar props; sidan skickar perioden.
- Underrubrik: "Fakturor utställda i perioden …".
- **ADR 0007 #4**: daterad ändringsnot (livstid → period).

## Begreppsklargörande ("vad gäller?")
- **Fakturerat (per advokat)** = en advokats *andel* (attribution per advokat+period).
- **Kundfordringar** = byråns *totala* fordringsställning i perioden. Relaterade men olika aggregeringar.

## Verifierat
`bun run test:all` grönt end-to-end.

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)