### PR TITLE
feat(reports): filtrera Kundfordringar på vald advokat (andels-attribution)

### DIFF
--- a/src/app/reports/_ar-summary.tsx
+++ b/src/app/reports/_ar-summary.tsx
@@ -23,13 +23,15 @@ function Row({ label, value, kind = "normal" }: { label: string; value: number; 
   );
 }
 
-export function ArSummarySection({ from, to }: { from: string; to: string }) {
-  const q = trpc.reports.arSummary.useQuery({ from, to });
+export function ArSummarySection({ from, to, userId, lawyerName }: { from: string; to: string; userId?: string; lawyerName?: string }) {
+  const q = trpc.reports.arSummary.useQuery({ from, to, ...(userId ? { userId } : {}) });
 
   return (
     <section className="bg-white rounded-lg border border-gray-200 p-6">
       <h2 className="font-semibold text-gray-900 mb-1">Kundfordringar</h2>
-      <p className="text-sm text-gray-500 mb-4">Fakturor utställda i perioden — fakturerat, inbetalt och konstaterad kundförlust.</p>
+      <p className="text-sm text-gray-500 mb-4">
+        Fakturor utställda i perioden{userId && lawyerName ? ` — andel för ${lawyerName}` : ""} — fakturerat, inbetalt och konstaterad kundförlust.
+      </p>
 
       {q.isLoading && <p className="text-sm text-gray-500">Laddar…</p>}
       {q.data && (

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -9,6 +9,7 @@ import { labelForPaymentMethod, creditRiskFor, CREDIT_RISK_LABELS, type CreditRi
 import type { AppRouter } from "@/lib/server/routers/_app";
 import { DataTable, type Column } from "@/components/ui/data-table";
 import { ArSummarySection } from "./_ar-summary";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 
 const RISK_BADGE_CLASSES: Record<CreditRisk, string> = {
   LOW: "bg-green-50 text-green-700 border-green-200",
@@ -129,7 +130,12 @@ export default function ReportsPage() {
 
       <div className="flex-1 overflow-y-auto min-h-0 -mx-4 sm:-mx-6 lg:-mx-8 px-4 sm:px-6 lg:px-8">
         <div className="mb-6">
-          <ArSummarySection from={from} to={to} />
+          <ArSummarySection
+            from={from}
+            to={to}
+            userId={userId}
+            {...omitUndefined({ lawyerName: users.data?.users.find((u) => u.id === userId)?.name })}
+          />
         </div>
 
         {report.isLoading && (

--- a/src/lib/server/routers/reports.ts
+++ b/src/lib/server/routers/reports.ts
@@ -5,7 +5,7 @@ import {
   type BilledInvoiceInput,
   type FrozenWorkInput,
 } from "@/lib/shared/billed-per-lawyer";
-import { computeArBridge, computeAging, scopeArToPeriod } from "@/lib/shared/ar-summary";
+import { computeArBridge, computeAging, scopeArToPeriod, attributeArToLawyer } from "@/lib/shared/ar-summary";
 
 /**
  * Advokat-fokuserade rapporter: användaren väljer period (from/to) och
@@ -87,6 +87,19 @@ function buildFrozenWork(
     out.push({ invoiceId, userId: te.userId, workOre: Math.round((te.minutes / 60) * te.hourlyRate) });
   }
   return out;
+}
+
+/** invoiceId → advokatens andel (userWork/totalWork ∈ [0,1]) ur frysta tidsposter. */
+function lawyerShareRatios(frozenWork: FrozenWorkInput[], userId: string): Map<string, number> {
+  const total = new Map<string, number>();
+  const user = new Map<string, number>();
+  for (const fw of frozenWork) {
+    total.set(fw.invoiceId, (total.get(fw.invoiceId) ?? 0) + fw.workOre);
+    if (fw.userId === userId) user.set(fw.invoiceId, (user.get(fw.invoiceId) ?? 0) + fw.workOre);
+  }
+  const ratio = new Map<string, number>();
+  for (const [inv, t] of total) if (t > 0) ratio.set(inv, (user.get(inv) ?? 0) / t);
+  return ratio;
 }
 
 /** invoiceId → senaste avskrivnings-tidpunkt ur WriteOff-posterna (ADR 0007). */
@@ -460,7 +473,7 @@ export const reportsRouter = router({
    * daterad sanning, inte en härledd updatedAt-gissning.
    */
   arSummary: protectedProcedure
-    .input(z.object({ from: z.string(), to: z.string() }))
+    .input(z.object({ from: z.string(), to: z.string(), userId: z.string().optional() }))
     .query(async ({ ctx, input }) => {
       const fromDate = new Date(input.from);
       const toDate = new Date(input.to);
@@ -478,12 +491,31 @@ export const reportsRouter = router({
 
       // Scopa till fakturor utställda i perioden (ADR 0007 #4, uppdaterat) så
       // panelen följer rapport-filtret som de övriga rapporterna.
-      const scoped = scopeArToPeriod(
+      let scoped = scopeArToPeriod(
         invoices as Record<string, unknown>[],
         payments as Record<string, unknown>[],
         writeOffs as Record<string, unknown>[],
         { from: fromDate, to: toDate },
       );
+
+      // Filtrera på vald advokat: attribuera proportionellt mot advokatens
+      // frysta arbetsvärde per faktura (samma modell som "Fakturerat per advokat").
+      if (input.userId) {
+        const [billingRuns, timeEntries] = await Promise.all([
+          ctx.dataStore.billingRuns.findMany({ where: orgScope, select: { id: true, invoiceId: true } }),
+          ctx.dataStore.timeEntries.findMany({
+            where: { ...orgScope, billable: true },
+            select: { userId: true, minutes: true, hourlyRate: true, invoiceId: true, frozenByBillingRunId: true },
+          }),
+        ]);
+        const runToInvoice = new Map<string, string>();
+        for (const r of billingRuns as Array<{ id: string; invoiceId?: string }>) {
+          if (r.invoiceId) runToInvoice.set(r.id, r.invoiceId);
+        }
+        const ratios = lawyerShareRatios(buildFrozenWork(timeEntries as RawTimeEntry[], runToInvoice), input.userId);
+        scoped = attributeArToLawyer(scoped.invoices, scoped.payments, scoped.writeOffs, ratios);
+      }
+
       const now = new Date();
       return {
         bridge: computeArBridge(scoped.invoices, scoped.payments, scoped.writeOffs, now),

--- a/src/lib/shared/ar-summary.ts
+++ b/src/lib/shared/ar-summary.ts
@@ -133,6 +133,35 @@ export function scopeArToPeriod(
   };
 }
 
+/**
+ * Attribuera kundfordrings-datat till EN advokat: skala varje fakturas belopp
+ * (och dess betalningar/krediteringar/avskrivningar) med advokatens andel
+ * (`userWork / totalWork` per faktura, ∈ [0,1]). Droppar fakturor utan andel.
+ *
+ * Samma attributions-modell som "Fakturerat per advokat" (#90), generaliserad
+ * till hela bryggan. Partitionen består eftersom ALLA komponenter skalas med
+ * samma andel per faktura. CREDIT-fakturor ärver andelen från fakturan de krediterar.
+ */
+export function attributeArToLawyer(
+  invoices: readonly Row[],
+  payments: readonly Row[],
+  writeOffs: readonly Row[],
+  ratioByInvoice: ReadonlyMap<string, number>,
+): { invoices: Row[]; payments: Row[]; writeOffs: Row[] } {
+  const ratioForInvoice = (inv: Row): number =>
+    inv.invoiceType === "CREDIT"
+      ? ratioByInvoice.get(String(inv.creditedInvoiceId ?? "")) ?? 0
+      : ratioByInvoice.get(String(inv.id ?? "")) ?? 0;
+  const ratioByRow = (row: Row): number => ratioByInvoice.get(String(row.invoiceId ?? "")) ?? 0;
+  const scaled = (row: Row, ratio: number): Row => ({ ...row, amount: Math.round(num(row.amount) * ratio) });
+
+  return {
+    invoices: invoices.flatMap((i) => { const r = ratioForInvoice(i); return r > 0 ? [scaled(i, r)] : []; }),
+    payments: payments.flatMap((p) => { const r = ratioByRow(p); return r > 0 ? [scaled(p, r)] : []; }),
+    writeOffs: writeOffs.flatMap((w) => { const r = ratioByRow(w); return r > 0 ? [scaled(w, r)] : []; }),
+  };
+}
+
 export interface ArBridge {
   fakturerat: number;
   krediterat: number;

--- a/test/unit/lib/ar-summary.test.ts
+++ b/test/unit/lib/ar-summary.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from "vitest-compat";
-import { computeArBridge, computeAging, scopeArToPeriod } from "@/lib/shared/ar-summary";
+import { computeArBridge, computeAging, scopeArToPeriod, attributeArToLawyer } from "@/lib/shared/ar-summary";
 
 const NOW = new Date("2026-06-01T00:00:00Z");
 const daysAgo = (n: number) => new Date(NOW.getTime() - n * 86_400_000).toISOString();
@@ -80,6 +80,33 @@ describe("scopeArToPeriod", () => {
     expect(b.fakturerat).toBe(100_00); // bara "in"
     expect(b.krediterat).toBe(10_00);
     expect(b.inbetalt).toBe(30_00);
+  });
+});
+
+describe("attributeArToLawyer", () => {
+  const invoices = [
+    { id: "a", status: "SENT", invoiceType: "STANDARD", amount: 100_00, dueDate: "2026-05-01" },
+    { id: "b", status: "SENT", invoiceType: "STANDARD", amount: 200_00, dueDate: "2026-05-01" }, // ej i ratio → droppas
+    { id: "cred", status: "SENT", invoiceType: "CREDIT", creditedInvoiceId: "a", amount: -40_00 },
+  ];
+  const payments = [{ invoiceId: "a", amount: 40_00 }, { invoiceId: "b", amount: 10_00 }];
+  const writeOffs = [{ invoiceId: "a", amount: 0 }];
+  const ratios = new Map<string, number>([["a", 0.5]]); // advokaten gjorde 50 % av "a"
+
+  it("skalar fakturans + dess raders belopp med andelen; droppar 0-andel", () => {
+    const s = attributeArToLawyer(invoices, payments, writeOffs, ratios);
+    expect(s.invoices.map((i) => [i.id, i.amount])).toEqual([["a", 50_00], ["cred", -20_00]]); // b borta
+    expect(s.payments).toEqual([{ invoiceId: "a", amount: 20_00 }]); // b:s betalning borta
+  });
+
+  it("bryggan på attribuerad data = advokatens andel", () => {
+    const s = attributeArToLawyer(invoices, payments, writeOffs, ratios);
+    const b = computeArBridge(s.invoices, s.payments, s.writeOffs, new Date("2026-06-01T00:00:00Z"));
+    expect(b.fakturerat).toBe(50_00); // 50 % av 100 00
+    expect(b.krediterat).toBe(20_00); // 50 % av kreditnotan
+    expect(b.inbetalt).toBe(20_00);
+    // invariant består
+    expect(b.utestaende).toBe(b.justerat - b.inbetalt - b.konstateradKundforlust);
   });
 });
 


### PR DESCRIPTION
Issue #160 — Kundfordringar-panelen följer nu advokat-menyn (du valde "filtrera panelen på vald advokat").

## Ändring
Panelen visar **vald advokats andel** av bryggan/åldersanalysen, proportionellt mot advokatens frysta arbetsvärde per faktura — **samma attribution som "Fakturerat per advokat"** (#90), så siffrorna är konsekventa mellan panelerna.

- **`attributeArToLawyer()`** (ar-summary.ts, ren + testad): skalar varje fakturas + dess betalningar/krediteringar/avskrivningar med andelen (`userWork/totalWork`), droppar 0-andel; CREDIT ärver andelen från krediterad faktura. **Partition-invarianten består** (allt skalas med samma andel per faktura).
- `reports.arSummary` tar `userId?`; bygger andelar ur frysta tidsposter (samma `buildFrozenWork` som billed) och attribuerar den period-scopade datan.
- `ArSummarySection` + sidan skickar `userId` + advokatnamn; underrubriken anger vald advokat.

## Not
Panelen blir nu **per vald advokat** (byrå-total finns inte i denna vy). Ett framtida "Alla advokater"-val kan läggas till om du vill ha byrå-totalen tillbaka — säg till.

## Verifierat
`bun run test:all` grönt end-to-end (attribution-tester + komponent + 18 e2e). Fakturerat i panelen = billed-panelens billedOre för samma advokat/period.

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)