### PR TITLE
feat(reports): slå samman Fakturerat-panelen in i Kundfordringar

### DIFF
--- a/src/app/reports/_ar-summary.tsx
+++ b/src/app/reports/_ar-summary.tsx
@@ -6,7 +6,9 @@
  * kundförlust). Fristående komponent så reports/page.tsx hålls hanterbar.
  */
 
+import type { inferRouterOutputs } from "@trpc/server";
 import { trpc } from "@/lib/client/trpc";
+import type { AppRouter } from "@/lib/server/routers/_app";
 import { formatCurrency } from "@/lib/client/utils";
 
 function Row({ label, value, kind = "normal" }: { label: string; value: number; kind?: "normal" | "subtotal" | "result" | "sub" }) {
@@ -23,49 +25,94 @@ function Row({ label, value, kind = "normal" }: { label: string; value: number; 
   );
 }
 
+type ArData = NonNullable<inferRouterOutputs<AppRouter>["reports"]["arSummary"]>;
+
 export function ArSummarySection({ from, to, userId, lawyerName }: { from: string; to: string; userId?: string; lawyerName?: string }) {
   const q = trpc.reports.arSummary.useQuery({ from, to, ...(userId ? { userId } : {}) });
+  const suffix = userId && lawyerName ? ` — andel för ${lawyerName}` : "";
 
   return (
     <section className="bg-white rounded-lg border border-gray-200 p-6">
       <h2 className="font-semibold text-gray-900 mb-1">Kundfordringar</h2>
       <p className="text-sm text-gray-500 mb-4">
-        Fakturor utställda i perioden{userId && lawyerName ? ` — andel för ${lawyerName}` : ""} — fakturerat, inbetalt och konstaterad kundförlust.
+        Fakturor utställda i perioden{suffix} — fakturerat, inbetalt och konstaterad kundförlust.
       </p>
 
       {q.isLoading && <p className="text-sm text-gray-500">Laddar…</p>}
-      {q.data && (
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-          {/* Kundfordrings-brygga */}
-          <div>
-            <h3 className="text-sm font-medium text-gray-600 mb-2">Brygga</h3>
-            <Row label="Fakturerat (brutto)" value={q.data.bridge.fakturerat} />
-            <Row label="− Krediterat / nedsatt" value={-q.data.bridge.krediterat} />
-            <Row label="= Justerat fakturerat" value={q.data.bridge.justerat} kind="subtotal" />
-            <Row label="− Inbetalt" value={-q.data.bridge.inbetalt} />
-            <Row label="− Konstaterad kundförlust" value={-q.data.bridge.konstateradKundforlust} />
-            <Row label="= Utestående fordran" value={q.data.bridge.utestaende} kind="subtotal" />
-            <Row label="varav ej förfallet" value={q.data.bridge.ejForfallet} kind="sub" />
-            <Row label="varav förfallet" value={q.data.bridge.forfallet} kind="sub" />
-            <Row label="Netto realiserat" value={q.data.bridge.nettoRealiserat} kind="result" />
-          </div>
-
-          {/* Åldersanalys */}
-          <div>
-            <h3 className="text-sm font-medium text-gray-600 mb-2">Åldersanalys (förfallna fakturor)</h3>
-            {q.data.aging.every((b) => b.amount === 0) ? (
-              <p className="text-sm text-gray-500">Inga förfallna fakturor.</p>
-            ) : (
-              q.data.aging.map((b) => (
-                <div key={b.label} className="flex items-center justify-between py-1.5 text-gray-700">
-                  <span>{b.label}</span>
-                  <span className="tabular-nums">{formatCurrency(b.amount)}</span>
-                </div>
-              ))
-            )}
-          </div>
-        </div>
-      )}
+      {q.data && <ArSummaryBody data={q.data} />}
     </section>
+  );
+}
+
+function ArSummaryBody({ data }: { data: ArData }) {
+  return (
+    <>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        {/* Kundfordrings-brygga */}
+        <div>
+          <h3 className="text-sm font-medium text-gray-600 mb-2">Brygga</h3>
+          <Row label="Fakturerat (brutto)" value={data.bridge.fakturerat} />
+          <Row label="− Krediterat / nedsatt" value={-data.bridge.krediterat} />
+          <Row label="= Justerat fakturerat" value={data.bridge.justerat} kind="subtotal" />
+          <Row label="− Inbetalt" value={-data.bridge.inbetalt} />
+          <Row label="− Konstaterad kundförlust" value={-data.bridge.konstateradKundforlust} />
+          <Row label="= Utestående fordran" value={data.bridge.utestaende} kind="subtotal" />
+          <Row label="varav ej förfallet" value={data.bridge.ejForfallet} kind="sub" />
+          <Row label="varav förfallet" value={data.bridge.forfallet} kind="sub" />
+          <Row label="Netto realiserat" value={data.bridge.nettoRealiserat} kind="result" />
+        </div>
+
+        {/* Åldersanalys */}
+        <div>
+          <h3 className="text-sm font-medium text-gray-600 mb-2">Åldersanalys (förfallna fakturor)</h3>
+          {data.aging.every((b) => b.amount === 0) ? (
+            <p className="text-sm text-gray-500">Inga förfallna fakturor.</p>
+          ) : (
+            data.aging.map((b) => (
+              <div key={b.label} className="flex items-center justify-between py-1.5 text-gray-700">
+                <span>{b.label}</span>
+                <span className="tabular-nums">{formatCurrency(b.amount)}</span>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+
+      {data.rows.length > 0 && <ArInvoiceTable rows={data.rows} />}
+    </>
+  );
+}
+
+interface ArRow { id: string; invoiceDate: string; matterNumber: string; title: string; fakturerat: number; inbetalt: number; avskrivet: number; utestaende: number }
+
+function ArInvoiceTable({ rows }: { rows: readonly ArRow[] }) {
+  return (
+    <div className="mt-6 overflow-x-auto">
+      <h3 className="text-sm font-medium text-gray-600 mb-2">Per faktura</h3>
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="text-left text-xs text-gray-500 border-b border-gray-200">
+            <th className="py-1.5 font-normal">Fakturadatum</th>
+            <th className="py-1.5 font-normal">Ärende</th>
+            <th className="py-1.5 font-normal text-right">Fakturerat</th>
+            <th className="py-1.5 font-normal text-right">Inbetalt</th>
+            <th className="py-1.5 font-normal text-right">Avskrivet</th>
+            <th className="py-1.5 font-normal text-right">Utestående</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100">
+          {rows.map((r) => (
+            <tr key={r.id}>
+              <td className="py-1.5 whitespace-nowrap font-mono text-xs">{new Date(r.invoiceDate).toLocaleDateString("sv-SE")}</td>
+              <td className="py-1.5 text-gray-700">{r.matterNumber}{r.title ? ` — ${r.title}` : ""}</td>
+              <td className="py-1.5 text-right font-mono">{formatCurrency(r.fakturerat)}</td>
+              <td className="py-1.5 text-right font-mono text-gray-600">{formatCurrency(r.inbetalt)}</td>
+              <td className="py-1.5 text-right font-mono text-red-700">{r.avskrivet > 0 ? `−${formatCurrency(r.avskrivet)}` : "—"}</td>
+              <td className="py-1.5 text-right font-mono font-medium">{formatCurrency(r.utestaende)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }

--- a/src/app/reports/_ar-summary.tsx
+++ b/src/app/reports/_ar-summary.tsx
@@ -23,13 +23,15 @@ function Row({ label, value, kind = "normal" }: { label: string; value: number; 
   );
 }
 
-export function ArSummarySection({ from, to }: { from: string; to: string }) {
-  const q = trpc.reports.arSummary.useQuery({ from, to });
+export function ArSummarySection({ from, to, userId, lawyerName }: { from: string; to: string; userId?: string; lawyerName?: string }) {
+  const q = trpc.reports.arSummary.useQuery({ from, to, ...(userId ? { userId } : {}) });
 
   return (
     <section className="bg-white rounded-lg border border-gray-200 p-6">
       <h2 className="font-semibold text-gray-900 mb-1">Kundfordringar</h2>
-      <p className="text-sm text-gray-500 mb-4">Fakturor utställda i perioden — fakturerat, inbetalt och konstaterad kundförlust.</p>
+      <p className="text-sm text-gray-500 mb-4">
+        Fakturor utställda i perioden{userId && lawyerName ? ` — andel för ${lawyerName}` : ""} — fakturerat, inbetalt och konstaterad kundförlust.
+      </p>
 
       {q.isLoading && <p className="text-sm text-gray-500">Laddar…</p>}
       {q.data && (

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -55,10 +55,6 @@ export default function ReportsPage() {
     { from, to, userId },
     { enabled: !!userId },
   );
-  const billed = trpc.reports.billed.useQuery(
-    { from, to, userId },
-    { enabled: !!userId },
-  );
 
   async function handleExport() {
     const params = new URLSearchParams({ from, to });
@@ -150,8 +146,6 @@ export default function ReportsPage() {
             <UnbilledTable report={report.data} />
           </>
         )}
-
-        {billed.data && <BilledReport report={billed.data} />}
       </div>
     </div>
   );
@@ -366,63 +360,6 @@ function UnbilledTable({ report }: { report: Report }) {
           />
         </>
       )}
-    </div>
-  );
-}
-
-// ─── 4. Fakturerat per advokat och period (#90) ──────────────────────
-
-type BilledReportData = NonNullable<inferRouterOutputs<AppRouter>["reports"]["billed"]>;
-type BilledRow = BilledReportData["invoices"][number];
-
-function fmtDate(iso: string): string {
-  return new Date(iso).toLocaleDateString("sv-SE", { year: "numeric", month: "short", day: "numeric" });
-}
-
-const billedColumns: Column<BilledRow>[] = [
-  { key: "invoiceDate", label: "Fakturadatum", sortable: true, sortValue: (r) => r.invoiceDate,
-    render: (r) => <span className="font-mono text-xs">{fmtDate(r.invoiceDate)}</span> },
-  { key: "matter", label: "Ärende", sortable: true, sortValue: (r) => r.matterNumber,
-    render: (r) => <span className="text-gray-700">{r.matterNumber}{r.title ? ` — ${r.title}` : ""}</span> },
-  { key: "amountOre", label: "Fakturabelopp", sortable: true, align: "right", sortValue: (r) => r.amountOre,
-    summary: (rs) => <span className="font-mono">{formatCurrency(rs.reduce((s, r) => s + r.amountOre, 0))}</span>,
-    render: (r) => <span className="font-mono text-gray-600">{formatCurrency(r.amountOre)}</span> },
-  { key: "shareOre", label: "Andel advokat", sortable: true, align: "right", sortValue: (r) => r.shareOre,
-    summary: (rs) => <strong className="font-mono">{formatCurrency(rs.reduce((s, r) => s + r.shareOre, 0))}</strong>,
-    render: (r) => <strong className="font-mono">{formatCurrency(r.shareOre)}</strong> },
-];
-
-function BilledReport({ report }: { report: BilledReportData }) {
-  return (
-    <div className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
-      <h2 className="text-lg font-semibold text-gray-900 mb-1">Fakturerat — {report.user.name}</h2>
-      <p className="text-xs text-gray-500 mb-4">
-        Fakturor som gått ut under perioden, attribuerade proportionellt mot advokatens andel
-        av debiterad tid. Avdrag avser fakturor avskrivna föregående period ({report.prevPeriod.from} – {report.prevPeriod.to}).
-      </p>
-
-      <div className="flex flex-wrap gap-6 text-sm mb-5">
-        <div>
-          <div className="text-gray-500 text-xs uppercase">Fakturerat</div>
-          <div className="font-mono font-medium text-gray-900">{formatCurrency(report.billedOre)}</div>
-        </div>
-        <div>
-          <div className="text-gray-500 text-xs uppercase">− Avskrivet (förra perioden)</div>
-          <div className="font-mono font-medium text-red-700">−{formatCurrency(report.writeOffOre)}</div>
-        </div>
-        <div>
-          <div className="text-gray-500 text-xs uppercase">Netto-fakturerat</div>
-          <div className="font-mono font-semibold text-gray-900">{formatCurrency(report.netOre)}</div>
-        </div>
-      </div>
-
-      <DataTable
-        prefKey="list.reports-billed"
-        columns={billedColumns}
-        data={report.invoices}
-        rowKey={(r) => r.id}
-        emptyMessage="Inga utgångna fakturor för advokaten under perioden."
-      />
     </div>
   );
 }

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -9,6 +9,7 @@ import { labelForPaymentMethod, creditRiskFor, CREDIT_RISK_LABELS, type CreditRi
 import type { AppRouter } from "@/lib/server/routers/_app";
 import { DataTable, type Column } from "@/components/ui/data-table";
 import { ArSummarySection } from "./_ar-summary";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
 
 const RISK_BADGE_CLASSES: Record<CreditRisk, string> = {
   LOW: "bg-green-50 text-green-700 border-green-200",
@@ -129,7 +130,12 @@ export default function ReportsPage() {
 
       <div className="flex-1 overflow-y-auto min-h-0 -mx-4 sm:-mx-6 lg:-mx-8 px-4 sm:px-6 lg:px-8">
         <div className="mb-6">
-          <ArSummarySection from={from} to={to} />
+          <ArSummarySection
+            from={from}
+            to={to}
+            userId={userId}
+            {...omitUndefined({ lawyerName: users.data?.users.find((u) => u.id === userId)?.name })}
+          />
         </div>
 
         {report.isLoading && (

--- a/src/lib/server/routers/reports.ts
+++ b/src/lib/server/routers/reports.ts
@@ -5,7 +5,7 @@ import {
   type BilledInvoiceInput,
   type FrozenWorkInput,
 } from "@/lib/shared/billed-per-lawyer";
-import { computeArBridge, computeAging, scopeArToPeriod, attributeArToLawyer } from "@/lib/shared/ar-summary";
+import { computeArBridge, computeAging, scopeArToPeriod, attributeArToLawyer, perInvoiceRows } from "@/lib/shared/ar-summary";
 
 /**
  * Advokat-fokuserade rapporter: användaren väljer period (from/to) och
@@ -481,7 +481,11 @@ export const reportsRouter = router({
       const orgScope = { matter: { organizationId: ctx.user.organizationId } };
       const invoices = await ctx.dataStore.invoices.findMany({
         where: orgScope,
-        select: { id: true, amount: true, status: true, invoiceType: true, creditedInvoiceId: true, invoiceDate: true, dueDate: true, dueAt: true },
+        select: {
+          id: true, amount: true, status: true, invoiceType: true, creditedInvoiceId: true,
+          invoiceDate: true, dueDate: true, dueAt: true,
+          matter: { select: { matterNumber: true, title: true } },
+        },
       });
       const ids = (invoices as Array<{ id: string }>).map((i) => i.id);
       const [payments, writeOffs] = await Promise.all([
@@ -517,9 +521,28 @@ export const reportsRouter = router({
       }
 
       const now = new Date();
+      // Per-faktura-rader (slår ihop "Fakturerat"-tabellen in i Kundfordringar).
+      const meta = new Map(
+        (scoped.invoices as Array<{ id?: string; invoiceDate?: unknown; matter?: { matterNumber?: string; title?: string } | null }>)
+          .map((i) => [String(i.id ?? ""), { invoiceDate: i.invoiceDate, matter: i.matter }]),
+      );
+      const rows = perInvoiceRows(scoped.invoices, scoped.payments, scoped.writeOffs).map((r) => {
+        const m = meta.get(r.invoiceId);
+        return {
+          id: r.invoiceId,
+          invoiceDate: coerceDate(m?.invoiceDate).toISOString(),
+          matterNumber: m?.matter?.matterNumber ?? "",
+          title: m?.matter?.title ?? "",
+          fakturerat: r.amount,
+          inbetalt: r.paid,
+          avskrivet: r.writtenOff,
+          utestaende: r.outstanding,
+        };
+      });
       return {
         bridge: computeArBridge(scoped.invoices, scoped.payments, scoped.writeOffs, now),
         aging: computeAging(scoped.invoices, scoped.payments, scoped.writeOffs, now),
+        rows,
       };
     }),
 });

--- a/src/lib/server/routers/reports.ts
+++ b/src/lib/server/routers/reports.ts
@@ -5,7 +5,7 @@ import {
   type BilledInvoiceInput,
   type FrozenWorkInput,
 } from "@/lib/shared/billed-per-lawyer";
-import { computeArBridge, computeAging, scopeArToPeriod } from "@/lib/shared/ar-summary";
+import { computeArBridge, computeAging, scopeArToPeriod, attributeArToLawyer } from "@/lib/shared/ar-summary";
 
 /**
  * Advokat-fokuserade rapporter: användaren väljer period (from/to) och
@@ -87,6 +87,19 @@ function buildFrozenWork(
     out.push({ invoiceId, userId: te.userId, workOre: Math.round((te.minutes / 60) * te.hourlyRate) });
   }
   return out;
+}
+
+/** invoiceId → advokatens andel (userWork/totalWork ∈ [0,1]) ur frysta tidsposter. */
+function lawyerShareRatios(frozenWork: FrozenWorkInput[], userId: string): Map<string, number> {
+  const total = new Map<string, number>();
+  const user = new Map<string, number>();
+  for (const fw of frozenWork) {
+    total.set(fw.invoiceId, (total.get(fw.invoiceId) ?? 0) + fw.workOre);
+    if (fw.userId === userId) user.set(fw.invoiceId, (user.get(fw.invoiceId) ?? 0) + fw.workOre);
+  }
+  const ratio = new Map<string, number>();
+  for (const [inv, t] of total) if (t > 0) ratio.set(inv, (user.get(inv) ?? 0) / t);
+  return ratio;
 }
 
 /** invoiceId → senaste avskrivnings-tidpunkt ur WriteOff-posterna (ADR 0007). */
@@ -460,7 +473,7 @@ export const reportsRouter = router({
    * daterad sanning, inte en härledd updatedAt-gissning.
    */
   arSummary: protectedProcedure
-    .input(z.object({ from: z.string(), to: z.string() }))
+    .input(z.object({ from: z.string(), to: z.string(), userId: z.string().optional() }))
     .query(async ({ ctx, input }) => {
       const fromDate = new Date(input.from);
       const toDate = new Date(input.to);
@@ -478,12 +491,31 @@ export const reportsRouter = router({
 
       // Scopa till fakturor utställda i perioden (ADR 0007 #4, uppdaterat) så
       // panelen följer rapport-filtret som de övriga rapporterna.
-      const scoped = scopeArToPeriod(
+      let scoped = scopeArToPeriod(
         invoices as Record<string, unknown>[],
         payments as Record<string, unknown>[],
         writeOffs as Record<string, unknown>[],
         { from: fromDate, to: toDate },
       );
+
+      // Filtrera på vald advokat: attribuera proportionellt mot advokatens
+      // frysta arbetsvärde per faktura (samma modell som "Fakturerat per advokat").
+      if (input.userId) {
+        const [billingRuns, timeEntries] = await Promise.all([
+          ctx.dataStore.billingRuns.findMany({ where: orgScope, select: { id: true, invoiceId: true } }),
+          ctx.dataStore.timeEntries.findMany({
+            where: { ...orgScope, billable: true },
+            select: { userId: true, minutes: true, hourlyRate: true, invoiceId: true, frozenByBillingRunId: true },
+          }),
+        ]);
+        const runToInvoice = new Map<string, string>();
+        for (const r of billingRuns as Array<{ id: string; invoiceId?: string }>) {
+          if (r.invoiceId) runToInvoice.set(r.id, r.invoiceId);
+        }
+        const ratios = lawyerShareRatios(buildFrozenWork(timeEntries as RawTimeEntry[], runToInvoice), input.userId);
+        scoped = attributeArToLawyer(scoped.invoices, scoped.payments, scoped.writeOffs, ratios);
+      }
+
       const now = new Date();
       return {
         bridge: computeArBridge(scoped.invoices, scoped.payments, scoped.writeOffs, now),

--- a/src/lib/shared/ar-summary.ts
+++ b/src/lib/shared/ar-summary.ts
@@ -133,6 +133,35 @@ export function scopeArToPeriod(
   };
 }
 
+/**
+ * Attribuera kundfordrings-datat till EN advokat: skala varje fakturas belopp
+ * (och dess betalningar/krediteringar/avskrivningar) med advokatens andel
+ * (`userWork / totalWork` per faktura, ∈ [0,1]). Droppar fakturor utan andel.
+ *
+ * Samma attributions-modell som "Fakturerat per advokat" (#90), generaliserad
+ * till hela bryggan. Partitionen består eftersom ALLA komponenter skalas med
+ * samma andel per faktura. CREDIT-fakturor ärver andelen från fakturan de krediterar.
+ */
+export function attributeArToLawyer(
+  invoices: readonly Row[],
+  payments: readonly Row[],
+  writeOffs: readonly Row[],
+  ratioByInvoice: ReadonlyMap<string, number>,
+): { invoices: Row[]; payments: Row[]; writeOffs: Row[] } {
+  const ratioForInvoice = (inv: Row): number =>
+    inv.invoiceType === "CREDIT"
+      ? ratioByInvoice.get(String(inv.creditedInvoiceId ?? "")) ?? 0
+      : ratioByInvoice.get(String(inv.id ?? "")) ?? 0;
+  const ratioByRow = (row: Row): number => ratioByInvoice.get(String(row.invoiceId ?? "")) ?? 0;
+  const scaled = (row: Row, ratio: number): Row => ({ ...row, amount: Math.round(num(row.amount) * ratio) });
+
+  return {
+    invoices: invoices.flatMap((i) => { const r = ratioForInvoice(i); return r > 0 ? [scaled(i, r)] : []; }),
+    payments: payments.flatMap((p) => { const r = ratioByRow(p); return r > 0 ? [scaled(p, r)] : []; }),
+    writeOffs: writeOffs.flatMap((w) => { const r = ratioByRow(w); return r > 0 ? [scaled(w, r)] : []; }),
+  };
+}
+
 export interface ArBridge {
   fakturerat: number;
   krediterat: number;

--- a/src/lib/shared/ar-summary.ts
+++ b/src/lib/shared/ar-summary.ts
@@ -57,40 +57,46 @@ function creditedByInvoice(invoices: readonly Row[]): Map<string, number> {
   return m;
 }
 
-export interface InvoiceOutstanding {
+export interface ArInvoiceLedgerRow {
   invoiceId: string;
+  /** Fakturabelopp (efter ev. advokat-attribution). */
+  amount: number;
+  paid: number;
+  credited: number;
+  writtenOff: number;
   outstanding: number;
   dueDate: Date | null;
 }
 
-/** Utestående för EN utställd icke-CREDIT-faktura, annars null. */
-function outstandingForInvoice(
+/** Full ledger-rad för EN utställd icke-CREDIT-faktura, annars null. */
+function invoiceLedgerRow(
   inv: Row,
   paid: Map<string, number>,
   credited: Map<string, number>,
   written: Map<string, number>,
-): InvoiceOutstanding | null {
+): ArInvoiceLedgerRow | null {
   if (!ISSUED_STATUSES.has(String(inv.status)) || inv.invoiceType === "CREDIT") return null;
   const id = String(inv.id ?? "");
-  const ledger = computeInvoiceLedger(num(inv.amount), paid.get(id) ?? 0, credited.get(id) ?? 0, written.get(id) ?? 0);
-  return { invoiceId: id, outstanding: ledger.outstanding, dueDate: coerceDateOrNull(inv.dueDate ?? inv.dueAt) };
+  const p = paid.get(id) ?? 0;
+  const c = credited.get(id) ?? 0;
+  const w = written.get(id) ?? 0;
+  const ledger = computeInvoiceLedger(num(inv.amount), p, c, w);
+  return { invoiceId: id, amount: num(inv.amount), paid: p, credited: c, writtenOff: w, outstanding: ledger.outstanding, dueDate: coerceDateOrNull(inv.dueDate ?? inv.dueAt) };
 }
 
-/** Per utställd (icke-CREDIT) faktura: utestående + förfallodatum. */
-export function perInvoiceOutstanding(
+/** Per utställd (icke-CREDIT) faktura: full ledger (belopp/betalt/krediterat/avskrivet/utestående). */
+export function perInvoiceRows(
   invoices: readonly Row[],
   payments: readonly Row[],
   writeOffs: readonly Row[],
-): InvoiceOutstanding[] {
+): ArInvoiceLedgerRow[] {
   const paid = sumAmountByKey(payments, "invoiceId");
   const credited = creditedByInvoice(invoices);
   const written = sumAmountByKey(writeOffs, "invoiceId");
-  const out: InvoiceOutstanding[] = [];
-  for (const inv of invoices) {
-    const row = outstandingForInvoice(inv, paid, credited, written);
-    if (row) out.push(row);
-  }
-  return out;
+  return invoices.flatMap((inv) => {
+    const row = invoiceLedgerRow(inv, paid, credited, written);
+    return row ? [row] : [];
+  });
 }
 
 export interface ArPeriod {
@@ -193,7 +199,7 @@ export function computeArBridge(
   const utestaende = justerat - inbetalt - konstateradKundforlust;
   const nettoRealiserat = justerat - konstateradKundforlust;
 
-  const ledgers = perInvoiceOutstanding(invoices, payments, writeOffs);
+  const ledgers = perInvoiceRows(invoices, payments, writeOffs);
   let ejForfallet = 0;
   for (const l of ledgers) {
     if (l.outstanding <= 0) continue;
@@ -229,7 +235,7 @@ export function computeAging(
   now: Date,
 ): AgingBucket[] {
   const amounts: [number, number, number, number] = [0, 0, 0, 0];
-  for (const l of perInvoiceOutstanding(invoices, payments, writeOffs)) {
+  for (const l of perInvoiceRows(invoices, payments, writeOffs)) {
     if (l.outstanding <= 0 || !l.dueDate) continue;
     const days = Math.floor((now.getTime() - l.dueDate.getTime()) / 86_400_000);
     if (days <= 0) continue; // ej förfallet

--- a/test/unit/app/reports/ar-summary.test.tsx
+++ b/test/unit/app/reports/ar-summary.test.tsx
@@ -39,6 +39,9 @@ describe("ArSummarySection", () => {
         { label: "61–90 dagar", amount: 0 },
         { label: ">90 dagar", amount: 300_00 },
       ],
+      rows: [
+        { id: "i1", invoiceDate: "2026-03-10", matterNumber: "2026-0001", title: "Tvist", fakturerat: 100_00, inbetalt: 30_00, avskrivet: 0, utestaende: 70_00 },
+      ],
     };
     render(<ArSummarySection from="2026-01-01" to="2026-06-30" />);
     expect(screen.getByText("Kundfordringar")).toBeInTheDocument();
@@ -47,6 +50,9 @@ describe("ArSummarySection", () => {
     expect(screen.getByText("Netto realiserat")).toBeInTheDocument();
     expect(screen.getByText("0–30 dagar")).toBeInTheDocument();
     expect(screen.getByText(">90 dagar")).toBeInTheDocument();
+    // per-faktura-tabellen (sammanslagen från "Fakturerat"-panelen)
+    expect(screen.getByText("Per faktura")).toBeInTheDocument();
+    expect(screen.getByText(/2026-0001 — Tvist/)).toBeInTheDocument();
   });
 
   it("visar 'inga förfallna' när alla hinkar är 0", () => {
@@ -59,6 +65,7 @@ describe("ArSummarySection", () => {
         { label: "0–30 dagar", amount: 0 }, { label: "31–60 dagar", amount: 0 },
         { label: "61–90 dagar", amount: 0 }, { label: ">90 dagar", amount: 0 },
       ],
+      rows: [],
     };
     render(<ArSummarySection from="2026-01-01" to="2026-06-30" />);
     expect(screen.getByText("Inga förfallna fakturor.")).toBeInTheDocument();

--- a/test/unit/app/reports/page.test.tsx
+++ b/test/unit/app/reports/page.test.tsx
@@ -49,18 +49,6 @@ beforeEach(() => {
   billedQuery.isLoading = false;
 });
 
-const sampleBilled = {
-  user: { id: "u1", name: "Anna" },
-  period: { from: "2026-06-01", to: "2026-06-30" },
-  prevPeriod: { from: "2026-05-01", to: "2026-05-31" },
-  invoices: [
-    { id: "i1", invoiceDate: "2026-06-15T00:00:00.000Z", amountOre: 100000, shareOre: 75000, matterNumber: "2026-0001", title: "Tvist" },
-  ],
-  billedOre: 75000,
-  writeOffOre: 10000,
-  netOre: 65000,
-};
-
 const sampleReport = {
   user: { id: "u1", name: "Anna" },
   totals: {
@@ -209,17 +197,4 @@ describe("ReportsPage", () => {
     expect(url).toContain("userIds=u1");
   });
 
-  it("renderar Fakturerat-rapporten med netto + fakturarad (#90)", () => {
-    billedQuery.data = sampleBilled;
-    render(<ReportsPage />);
-    expect(screen.getByText(/Fakturerat — Anna/)).toBeInTheDocument();
-    expect(screen.getByText("Netto-fakturerat")).toBeInTheDocument();
-    // Fakturaraden syns (ärendenummer).
-    expect(screen.getByText(/2026-0001/)).toBeInTheDocument();
-  });
-
-  it("visar inte Fakturerat-rapporten innan data finns", () => {
-    render(<ReportsPage />);
-    expect(screen.queryByText(/Fakturerat —/)).toBeNull();
-  });
 });

--- a/test/unit/lib/ar-summary.test.ts
+++ b/test/unit/lib/ar-summary.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from "vitest-compat";
-import { computeArBridge, computeAging, scopeArToPeriod } from "@/lib/shared/ar-summary";
+import { computeArBridge, computeAging, scopeArToPeriod, attributeArToLawyer } from "@/lib/shared/ar-summary";
 
 const NOW = new Date("2026-06-01T00:00:00Z");
 const daysAgo = (n: number) => new Date(NOW.getTime() - n * 86_400_000).toISOString();
@@ -80,6 +80,33 @@ describe("scopeArToPeriod", () => {
     expect(b.fakturerat).toBe(100_00); // bara "in"
     expect(b.krediterat).toBe(10_00);
     expect(b.inbetalt).toBe(30_00);
+  });
+});
+
+describe("attributeArToLawyer", () => {
+  const invoices = [
+    { id: "a", status: "SENT", invoiceType: "STANDARD", amount: 100_00, dueDate: "2026-05-01" },
+    { id: "b", status: "SENT", invoiceType: "STANDARD", amount: 200_00, dueDate: "2026-05-01" }, // ej i ratio → droppas
+    { id: "cred", status: "SENT", invoiceType: "CREDIT", creditedInvoiceId: "a", amount: -40_00 },
+  ];
+  const payments = [{ invoiceId: "a", amount: 40_00 }, { invoiceId: "b", amount: 10_00 }];
+  const writeOffs = [{ invoiceId: "a", amount: 0 }];
+  const ratios = new Map<string, number>([["a", 0.5]]); // advokaten gjorde 50 % av "a"
+
+  it("skalar fakturans + dess raders belopp med andelen; droppar 0-andel", () => {
+    const s = attributeArToLawyer(invoices, payments, writeOffs, ratios);
+    expect(s.invoices.map((i) => [i.id, i.amount])).toEqual([["a", 50_00], ["cred", -20_00]]); // b borta
+    expect(s.payments).toEqual([{ invoiceId: "a", amount: 20_00 }]); // b:s betalning borta
+  });
+
+  it("bryggan på attribuerad data = advokatens andel", () => {
+    const s = attributeArToLawyer(invoices, payments, writeOffs, ratios);
+    const b = computeArBridge(s.invoices, s.payments, s.writeOffs, new Date("2026-06-01T00:00:00Z"));
+    expect(b.fakturerat).toBe(50_00); // 50 % av 100 00
+    expect(b.krediterat).toBe(20_00); // 50 % av kreditnotan
+    expect(b.inbetalt).toBe(20_00);
+    // invariant består
+    expect(b.utestaende).toBe(b.justerat - b.inbetalt - b.konstateradKundforlust);
   });
 });
 


### PR DESCRIPTION
Issue #162 — "Fakturerat" och "Kundfordringar" överlappade; nu **en panel**.

## Ändring
Kundfordringar-panelen visar nu brygga + åldersanalys + en **per-faktura-tabell**: Fakturadatum, Ärende, Fakturerat, Inbetalt, Avskrivet, Utestående (attribuerade till vald advokat). Den separata "Fakturerat per advokat"-panelen är borttagen, liksom **"− Avskrivet (förra perioden)"**.

- **`perInvoiceRows()`** (ar-summary.ts): full per-faktura-ledger (belopp/betalt/krediterat/avskrivet/utestående), exporterad; ersätter `perInvoiceOutstanding`.
- `reports.arSummary` returnerar `rows` (attribuerade per advokat) + matter-info.
- `ArSummarySection`: per-faktura-tabell (utbruten `ArSummaryBody`/`ArInvoiceTable` för complexity ≤ 8).
- `BilledReport`-panelen + `billedColumns` borttagna ur reports-sidan.

## Not
`reports.billed`-queryn + `billedPerLawyer` finns kvar i backend (nåbar via routern, knip-OK) men används inte längre i UI:t — ren dead-endpoint-städning kan göras som uppföljning.

## Verifierat
`bun run test:all` grönt end-to-end (perInvoiceRows + komponent-tester + 18 e2e).

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)