### PR TITLE
feat(reports): klickbara ärende- + faktura-länkar i Kundfordringar-raderna

### DIFF
--- a/src/app/reports/_ar-summary.tsx
+++ b/src/app/reports/_ar-summary.tsx
@@ -9,6 +9,7 @@
 import type { inferRouterOutputs } from "@trpc/server";
 import { trpc } from "@/lib/client/trpc";
 import type { AppRouter } from "@/lib/server/routers/_app";
+import { EntityLink } from "@/lib/client/demo/entity-link";
 import { formatCurrency } from "@/lib/client/utils";
 
 function Row({ label, value, kind = "normal" }: { label: string; value: number; kind?: "normal" | "subtotal" | "result" | "sub" }) {
@@ -83,7 +84,7 @@ function ArSummaryBody({ data }: { data: ArData }) {
   );
 }
 
-interface ArRow { id: string; invoiceDate: string; matterNumber: string; title: string; fakturerat: number; inbetalt: number; avskrivet: number; utestaende: number }
+interface ArRow { id: string; invoiceDate: string; matterId: string; matterNumber: string; title: string; fakturerat: number; inbetalt: number; avskrivet: number; utestaende: number }
 
 function ArInvoiceTable({ rows }: { rows: readonly ArRow[] }) {
   return (
@@ -101,18 +102,33 @@ function ArInvoiceTable({ rows }: { rows: readonly ArRow[] }) {
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-100">
-          {rows.map((r) => (
-            <tr key={r.id}>
-              <td className="py-1.5 whitespace-nowrap font-mono text-xs">{new Date(r.invoiceDate).toLocaleDateString("sv-SE")}</td>
-              <td className="py-1.5 text-gray-700">{r.matterNumber}{r.title ? ` — ${r.title}` : ""}</td>
-              <td className="py-1.5 text-right font-mono">{formatCurrency(r.fakturerat)}</td>
-              <td className="py-1.5 text-right font-mono text-gray-600">{formatCurrency(r.inbetalt)}</td>
-              <td className="py-1.5 text-right font-mono text-red-700">{r.avskrivet > 0 ? `−${formatCurrency(r.avskrivet)}` : "—"}</td>
-              <td className="py-1.5 text-right font-mono font-medium">{formatCurrency(r.utestaende)}</td>
-            </tr>
-          ))}
+          {rows.map((r) => <ArInvoiceRow key={r.id} r={r} />)}
         </tbody>
       </table>
     </div>
+  );
+}
+
+function ArInvoiceRow({ r }: { r: ArRow }) {
+  const matterLabel = `${r.matterNumber}${r.title ? ` — ${r.title}` : ""}`;
+  return (
+    <tr>
+      <td className="py-1.5 whitespace-nowrap font-mono text-xs">
+        <EntityLink route="invoices" id={r.id} className="text-blue-600 hover:underline">
+          {new Date(r.invoiceDate).toLocaleDateString("sv-SE")}
+        </EntityLink>
+      </td>
+      <td className="py-1.5">
+        {r.matterId ? (
+          <EntityLink route="matters" id={r.matterId} className="text-gray-700 hover:underline">{matterLabel}</EntityLink>
+        ) : (
+          <span className="text-gray-700">{matterLabel}</span>
+        )}
+      </td>
+      <td className="py-1.5 text-right font-mono">{formatCurrency(r.fakturerat)}</td>
+      <td className="py-1.5 text-right font-mono text-gray-600">{formatCurrency(r.inbetalt)}</td>
+      <td className="py-1.5 text-right font-mono text-red-700">{r.avskrivet > 0 ? `−${formatCurrency(r.avskrivet)}` : "—"}</td>
+      <td className="py-1.5 text-right font-mono font-medium">{formatCurrency(r.utestaende)}</td>
+    </tr>
   );
 }

--- a/src/lib/server/routers/reports.ts
+++ b/src/lib/server/routers/reports.ts
@@ -138,6 +138,33 @@ function previousCalendarMonth(periodStart: Date): { from: Date; to: Date } {
 
 // ─── Router ──────────────────────────────────────────────────────────
 
+/** Per-faktura-rader för Kundfordrings-tabellen (slår ihop "Fakturerat"-tabellen). */
+interface ArRowMeta { invoiceDate: string; matterId: string; matterNumber: string; title: string }
+const EMPTY_AR_META: ArRowMeta = { invoiceDate: "", matterId: "", matterNumber: "", title: "" };
+
+/** Förresolva faktura-metadata (datum + ärende) per id — håller rad-mappningen trivial. */
+function arMetaById(invoices: Record<string, unknown>[]): Map<string, ArRowMeta> {
+  const m = new Map<string, ArRowMeta>();
+  for (const inv of invoices as Array<{ id?: string; invoiceDate?: unknown; matter?: { id?: string; matterNumber?: string; title?: string } | null }>) {
+    const mt = inv.matter ?? {};
+    m.set(String(inv.id ?? ""), {
+      invoiceDate: coerceDate(inv.invoiceDate).toISOString(),
+      matterId: mt.id ?? "",
+      matterNumber: mt.matterNumber ?? "",
+      title: mt.title ?? "",
+    });
+  }
+  return m;
+}
+
+function arRowsFrom(scoped: { invoices: Record<string, unknown>[]; payments: Record<string, unknown>[]; writeOffs: Record<string, unknown>[] }) {
+  const meta = arMetaById(scoped.invoices);
+  return perInvoiceRows(scoped.invoices, scoped.payments, scoped.writeOffs).map((r) => {
+    const m = meta.get(r.invoiceId) ?? EMPTY_AR_META;
+    return { id: r.invoiceId, ...m, fakturerat: r.amount, inbetalt: r.paid, avskrivet: r.writtenOff, utestaende: r.outstanding };
+  });
+}
+
 export const reportsRouter = router({
   /**
    * Advokatrapport: en advokat, en period, tre delrapporter.
@@ -484,7 +511,7 @@ export const reportsRouter = router({
         select: {
           id: true, amount: true, status: true, invoiceType: true, creditedInvoiceId: true,
           invoiceDate: true, dueDate: true, dueAt: true,
-          matter: { select: { matterNumber: true, title: true } },
+          matter: { select: { id: true, matterNumber: true, title: true } },
         },
       });
       const ids = (invoices as Array<{ id: string }>).map((i) => i.id);
@@ -521,28 +548,10 @@ export const reportsRouter = router({
       }
 
       const now = new Date();
-      // Per-faktura-rader (slår ihop "Fakturerat"-tabellen in i Kundfordringar).
-      const meta = new Map(
-        (scoped.invoices as Array<{ id?: string; invoiceDate?: unknown; matter?: { matterNumber?: string; title?: string } | null }>)
-          .map((i) => [String(i.id ?? ""), { invoiceDate: i.invoiceDate, matter: i.matter }]),
-      );
-      const rows = perInvoiceRows(scoped.invoices, scoped.payments, scoped.writeOffs).map((r) => {
-        const m = meta.get(r.invoiceId);
-        return {
-          id: r.invoiceId,
-          invoiceDate: coerceDate(m?.invoiceDate).toISOString(),
-          matterNumber: m?.matter?.matterNumber ?? "",
-          title: m?.matter?.title ?? "",
-          fakturerat: r.amount,
-          inbetalt: r.paid,
-          avskrivet: r.writtenOff,
-          utestaende: r.outstanding,
-        };
-      });
       return {
         bridge: computeArBridge(scoped.invoices, scoped.payments, scoped.writeOffs, now),
         aging: computeAging(scoped.invoices, scoped.payments, scoped.writeOffs, now),
-        rows,
+        rows: arRowsFrom(scoped),
       };
     }),
 });

--- a/test/unit/app/reports/ar-summary.test.tsx
+++ b/test/unit/app/reports/ar-summary.test.tsx
@@ -40,7 +40,7 @@ describe("ArSummarySection", () => {
         { label: ">90 dagar", amount: 300_00 },
       ],
       rows: [
-        { id: "i1", invoiceDate: "2026-03-10", matterNumber: "2026-0001", title: "Tvist", fakturerat: 100_00, inbetalt: 30_00, avskrivet: 0, utestaende: 70_00 },
+        { id: "i1", invoiceDate: "2026-03-10", matterId: "m1", matterNumber: "2026-0001", title: "Tvist", fakturerat: 100_00, inbetalt: 30_00, avskrivet: 0, utestaende: 70_00 },
       ],
     };
     render(<ArSummarySection from="2026-01-01" to="2026-06-30" />);
@@ -52,7 +52,11 @@ describe("ArSummarySection", () => {
     expect(screen.getByText(">90 dagar")).toBeInTheDocument();
     // per-faktura-tabellen (sammanslagen från "Fakturerat"-panelen)
     expect(screen.getByText("Per faktura")).toBeInTheDocument();
-    expect(screen.getByText(/2026-0001 — Tvist/)).toBeInTheDocument();
+    // ärendet är klickbart → /matters, fakturadatumet → /invoices
+    const matterLink = screen.getByRole("link", { name: /2026-0001 — Tvist/ });
+    expect(matterLink.getAttribute("href")).toContain("matters");
+    const invoiceLink = screen.getByRole("link", { name: /2026-03-10/ });
+    expect(invoiceLink.getAttribute("href")).toContain("invoices");
   });
 
   it("visar 'inga förfallna' när alla hinkar är 0", () => {


### PR DESCRIPTION
Issue #165 — per-faktura-tabellen under Rapporter → Kundfordringar har nu klickbara rader.

## Ändring
- **Ärende-cellen** → länkar till ärendet (`EntityLink route="matters"`).
- **Datum-cellen** → länkar till fakturan (`EntityLink route="invoices"`), soft-nav (undviker #418).
- `arSummary`-rows får `matterId` (matter.id i select).
- `ArInvoiceTable` → utbruten `ArInvoiceRow`; `arRowsFrom`/`arMetaById` utbrutna i reports.ts (complexity ≤ 8).

## Not om "fakturanummer"
AVA-fakturor har **inget kanoniskt fakturanummer** — varken mutationerna (`createFinal` m.fl.) eller demo-generatorn sätter `invoiceNumber`. Invoice-listan använder därför **datumet** som fakturans klickbara identitet, och jag följer samma konvention här. Vill man ha riktiga fakturanummer är det en separat feature.

## Verifierat
`bun run test:all` grönt; komponenttest: ärende-länk → /matters, datum-länk → /invoices.

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)