### PR TITLE
feat(invoices): per-byrå fakturanummer (F-YYYY-NNNN) + visning

### DIFF
--- a/src/app/invoices/[id]/_client.tsx
+++ b/src/app/invoices/[id]/_client.tsx
@@ -220,11 +220,13 @@ function InvoiceHeader({ inv }: { inv: Inv }) {
     : inv.invoiceType === "FINAL" ? "Slutfaktura"
     : inv.invoiceType === "CREDIT" ? "Kreditfaktura"
     : "Faktura";
+  const invoiceNumber = (inv as { invoiceNumber?: string | null }).invoiceNumber;
   return (
     <div>
       <EntityLink route="matters" id={inv.matter.id} className="text-sm text-blue-600 hover:underline">← {inv.matter.matterNumber} {inv.matter.title}</EntityLink>
       <h1 className="text-2xl font-bold mt-2">
         {heading}
+        {invoiceNumber && <span className="ml-3 text-base font-normal text-gray-700">{invoiceNumber}</span>}
         <span className="ml-3 text-sm font-normal text-gray-500">{new Date(inv.invoiceDate).toLocaleDateString("sv-SE")}</span>
       </h1>
     </div>

--- a/src/app/invoices/page.tsx
+++ b/src/app/invoices/page.tsx
@@ -32,6 +32,7 @@ function statusBadgeClass(status: string): string {
 
 interface InvoiceRow {
   id: string;
+  invoiceNumber?: string | null;
   invoiceDate: string | Date;
   invoiceType: string;
   status: string;
@@ -40,6 +41,13 @@ interface InvoiceRow {
 }
 
 const invoiceColumns: Column<InvoiceRow>[] = [
+  { key: "invoiceNumber", label: "Fakturanr", sortable: true, sortValue: (i) => i.invoiceNumber ?? "",
+    render: (i) => (
+      <EntityLink route="invoices" id={i.id} className="text-blue-600 hover:underline font-mono text-xs">
+        {i.invoiceNumber || "—"}
+      </EntityLink>
+    ),
+  },
   { key: "invoiceDate", label: "Datum", sortable: true, sortValue: (i) => new Date(i.invoiceDate),
     // EntityLink soft-navigerar till __shell__?id (ingen omladdning). Runtime-
     // skapade faktura-id:n finns inte i generateStaticParams, så en Next-Link

--- a/src/app/reports/_ar-summary.tsx
+++ b/src/app/reports/_ar-summary.tsx
@@ -84,7 +84,7 @@ function ArSummaryBody({ data }: { data: ArData }) {
   );
 }
 
-interface ArRow { id: string; invoiceDate: string; matterId: string; matterNumber: string; title: string; fakturerat: number; inbetalt: number; avskrivet: number; utestaende: number }
+interface ArRow { id: string; invoiceNumber: string; invoiceDate: string; matterId: string; matterNumber: string; title: string; fakturerat: number; inbetalt: number; avskrivet: number; utestaende: number }
 
 function ArInvoiceTable({ rows }: { rows: readonly ArRow[] }) {
   return (
@@ -93,6 +93,7 @@ function ArInvoiceTable({ rows }: { rows: readonly ArRow[] }) {
       <table className="min-w-full text-sm">
         <thead>
           <tr className="text-left text-xs text-gray-500 border-b border-gray-200">
+            <th className="py-1.5 font-normal">Fakturanr</th>
             <th className="py-1.5 font-normal">Fakturadatum</th>
             <th className="py-1.5 font-normal">Ärende</th>
             <th className="py-1.5 font-normal text-right">Fakturerat</th>
@@ -115,9 +116,10 @@ function ArInvoiceRow({ r }: { r: ArRow }) {
     <tr>
       <td className="py-1.5 whitespace-nowrap font-mono text-xs">
         <EntityLink route="invoices" id={r.id} className="text-blue-600 hover:underline">
-          {new Date(r.invoiceDate).toLocaleDateString("sv-SE")}
+          {r.invoiceNumber || new Date(r.invoiceDate).toLocaleDateString("sv-SE")}
         </EntityLink>
       </td>
+      <td className="py-1.5 whitespace-nowrap font-mono text-xs text-gray-500">{new Date(r.invoiceDate).toLocaleDateString("sv-SE")}</td>
       <td className="py-1.5">
         {r.matterId ? (
           <EntityLink route="matters" id={r.matterId} className="text-gray-700 hover:underline">{matterLabel}</EntityLink>

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -140,6 +140,20 @@ function resolveWriteOffAmount(outstanding: number, requested?: number): number 
   return amount;
 }
 
+/** Nästa lediga fakturanummer (F-YYYY-NNNN) för org:en. Speglar nextMatterNumber. */
+async function nextInvoiceNumber(
+  invoices: { findFirst: (args: unknown) => Promise<unknown> },
+  orgId: string,
+): Promise<string> {
+  const prefix = `F-${new Date().getFullYear()}-`;
+  const last = (await invoices.findFirst({
+    where: { matter: { organizationId: orgId }, invoiceNumber: { startsWith: prefix } },
+    orderBy: { invoiceNumber: "desc" },
+  })) as { invoiceNumber?: string | null } | null;
+  const seq = last?.invoiceNumber ? parseInt(last.invoiceNumber.slice(prefix.length), 10) + 1 : 1;
+  return `${prefix}${seq.toString().padStart(4, "0")}`;
+}
+
 const invoiceTypeSchema = z.enum(["STANDARD", "ACCONTO", "FINAL"]);
 const invoiceStatusSchema = z.enum([
   "DRAFT",
@@ -228,6 +242,7 @@ export const invoiceRouter = router({
         data: omitUndefined({
           id: input.id, // undefined → store genererar
           matterId: input.matterId,
+          invoiceNumber: await nextInvoiceNumber(ctx.dataStore.invoices, ctx.orgId),
           amount: input.amount,
           invoiceType: "ACCONTO",
           status: "DRAFT",
@@ -280,6 +295,7 @@ export const invoiceRouter = router({
           data: omitUndefined({
             id: input.id, // undefined → store genererar
             matterId: input.matterId,
+            invoiceNumber: await nextInvoiceNumber(tx.invoices, ctx.orgId),
             amount: breakdown.grossAmount,
             invoiceType: "FINAL",
             status: "DRAFT",
@@ -350,6 +366,7 @@ export const invoiceRouter = router({
           data: {
             ...omitUndefined({ id: input.id, notes: input.notes }), // undefined → store genererar
             matterId: original.matterId,
+            invoiceNumber: await nextInvoiceNumber(tx.invoices, ctx.orgId),
             amount: -original.amount,
             invoiceType: "CREDIT",
             status: "SENT", // kreditfaktura är "färdig" direkt

--- a/src/lib/server/routers/reports.ts
+++ b/src/lib/server/routers/reports.ts
@@ -139,15 +139,16 @@ function previousCalendarMonth(periodStart: Date): { from: Date; to: Date } {
 // ─── Router ──────────────────────────────────────────────────────────
 
 /** Per-faktura-rader för Kundfordrings-tabellen (slår ihop "Fakturerat"-tabellen). */
-interface ArRowMeta { invoiceDate: string; matterId: string; matterNumber: string; title: string }
-const EMPTY_AR_META: ArRowMeta = { invoiceDate: "", matterId: "", matterNumber: "", title: "" };
+interface ArRowMeta { invoiceNumber: string; invoiceDate: string; matterId: string; matterNumber: string; title: string }
+const EMPTY_AR_META: ArRowMeta = { invoiceNumber: "", invoiceDate: "", matterId: "", matterNumber: "", title: "" };
 
-/** Förresolva faktura-metadata (datum + ärende) per id — håller rad-mappningen trivial. */
+/** Förresolva faktura-metadata (nummer + datum + ärende) per id — håller rad-mappningen trivial. */
 function arMetaById(invoices: Record<string, unknown>[]): Map<string, ArRowMeta> {
   const m = new Map<string, ArRowMeta>();
-  for (const inv of invoices as Array<{ id?: string; invoiceDate?: unknown; matter?: { id?: string; matterNumber?: string; title?: string } | null }>) {
+  for (const inv of invoices as Array<{ id?: string; invoiceNumber?: string | null; invoiceDate?: unknown; matter?: { id?: string; matterNumber?: string; title?: string } | null }>) {
     const mt = inv.matter ?? {};
     m.set(String(inv.id ?? ""), {
+      invoiceNumber: inv.invoiceNumber ?? "",
       invoiceDate: coerceDate(inv.invoiceDate).toISOString(),
       matterId: mt.id ?? "",
       matterNumber: mt.matterNumber ?? "",
@@ -510,7 +511,7 @@ export const reportsRouter = router({
         where: orgScope,
         select: {
           id: true, amount: true, status: true, invoiceType: true, creditedInvoiceId: true,
-          invoiceDate: true, dueDate: true, dueAt: true,
+          invoiceNumber: true, invoiceDate: true, dueDate: true, dueAt: true,
           matter: { select: { id: true, matterNumber: true, title: true } },
         },
       });

--- a/src/lib/shared/schemas/billing.ts
+++ b/src/lib/shared/schemas/billing.ts
@@ -105,6 +105,9 @@ export const invoiceSchema = z.object({
   amount: z.number().int(),
   status: invoiceStatusSchema.default("DRAFT"),
   invoiceType: invoiceTypeSchema.default("STANDARD"),
+  /** Per-byrå löpande fakturanummer (F-YYYY-NNNN), genereras vid skapande.
+   *  Nullish: legacy-fakturor saknar nummer → UI faller tillbaka på datum. */
+  invoiceNumber: z.string().nullish(),
   fortnoxId: z.string().nullish(),
   invoiceDate: dateLike,
   dueDate: optionalDateLike,

--- a/test/unit/app/reports/ar-summary.test.tsx
+++ b/test/unit/app/reports/ar-summary.test.tsx
@@ -40,7 +40,7 @@ describe("ArSummarySection", () => {
         { label: ">90 dagar", amount: 300_00 },
       ],
       rows: [
-        { id: "i1", invoiceDate: "2026-03-10", matterId: "m1", matterNumber: "2026-0001", title: "Tvist", fakturerat: 100_00, inbetalt: 30_00, avskrivet: 0, utestaende: 70_00 },
+        { id: "i1", invoiceNumber: "F-2026-0001", invoiceDate: "2026-03-10", matterId: "m1", matterNumber: "2026-0001", title: "Tvist", fakturerat: 100_00, inbetalt: 30_00, avskrivet: 0, utestaende: 70_00 },
       ],
     };
     render(<ArSummarySection from="2026-01-01" to="2026-06-30" />);
@@ -55,7 +55,8 @@ describe("ArSummarySection", () => {
     // ärendet är klickbart → /matters, fakturadatumet → /invoices
     const matterLink = screen.getByRole("link", { name: /2026-0001 — Tvist/ });
     expect(matterLink.getAttribute("href")).toContain("matters");
-    const invoiceLink = screen.getByRole("link", { name: /2026-03-10/ });
+    // fakturanumret är den klickbara faktura-identiteten
+    const invoiceLink = screen.getByRole("link", { name: /F-2026-0001/ });
     expect(invoiceLink.getAttribute("href")).toContain("invoices");
   });
 


### PR DESCRIPTION
Issue #167 — AVA-fakturor saknade kanoniskt fakturanummer. Inför en sekventiell **per-byrå nummerserie `F-YYYY-NNNN`** (prefix skiljer från ärendenummer).

## Ändring
- **Schema:** `invoiceNumber` kanoniskt på Invoice (nullish → legacy faller tillbaka).
- **Generering:** `nextInvoiceNumber()` (speglar `nextMatterNumber`) i `createAcconto`/`createFinal`/`createCredit`. Demo-fakturorna får numret automatiskt via mutationerna (verifierat: `F-2026-0005` m.fl. i `out/invoices/`).
- **Visning:** faktura-detalj-header, fakturalistan (ny **Fakturanr**-kolumn, klickbar) och Kundfordringar-tabellen (**Fakturanr** = klickbar faktura-identitet). Legacy utan nummer → datum/"—" utan krasch.

## Verifierat
`bun run test:all` grönt end-to-end (den fixade test:all fångade en kolumn-namnkrock lokalt först → "Faktura"→"Fakturanr").

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)