### PR TITLE
ci(workflows): bumpa GitHub Actions till Node 24-native (#169)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,6 @@ on:
   pull_request:
   workflow_dispatch: # för on-demand e2e (git round-trip)
 
-# Opta in GitHub Actions runtime på Node 24. Annars kör checkout/setup-node/
-# upload-artifact på Node 20 som tvångsbyts 2026-06-16 och EOL:ar 2026-09-16
-# (deprecation-varning i loggen). Detta är skilt från setup-node:s node-version
-# nedan (= Node:n som tool-binärerna tsc/eslint/vitest/next kör under via shebang).
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 # Bun (#91) är pakethanterare + script-runner. setup-bun ger `bun` på PATH
 # (kör `bun install --frozen-lockfile` + `bun run X` + `bun *.ts`-scripten);
 # setup-node behålls för att tool-binärerna (tsc/eslint/vitest/next/playwright)
@@ -32,10 +25,10 @@ jobs:
     if: github.event_name == 'pull_request'
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # commitlint behöver hela historiken för --from..--to
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
@@ -50,8 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
@@ -72,7 +65,7 @@ jobs:
       - run: bun run duplicates
       - name: Upload jscpd report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: jscpd-report
           path: reports/jscpd/
@@ -85,8 +78,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
@@ -97,7 +90,7 @@ jobs:
       - run: bun run test:cov
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: coverage/
@@ -114,8 +107,8 @@ jobs:
     env:
       CI: "true"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
@@ -152,7 +145,7 @@ jobs:
         run: docker compose -f tooling/docker/docker-compose.yml down -v
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           # round-trip-konfigen skriver till reports/playwright-round-trip/

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -24,10 +24,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 

--- a/.github/workflows/helper-ci.yml
+++ b/.github/workflows/helper-ci.yml
@@ -23,7 +23,7 @@ jobs:
         working-directory: helper-app
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/helper-release.yml
+++ b/.github/workflows/helper-release.yml
@@ -20,7 +20,7 @@ jobs:
         working-directory: helper-app
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
Stänger #169.

## Bakgrund
GitHub-loggarna varnar för att `actions/checkout@v4`, `actions/setup-node@v4`
och `actions/upload-artifact@v4` kör på Node 20 — som tvångsbyttes till Node 24
2026-06-16 och EOL:ar 2026-09-16.

## Ändring
- Bumpar de tre flaggade actionsen till sina Node24-native majors överallt:
  `checkout@v6`, `setup-node@v6`, `upload-artifact@v7`
  (ci.yml, deploy-demo.yml, helper-ci.yml, helper-release.yml).
- Tar bort `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`-workarounden ur `ci.yml` —
  alla dess actions är nu Node24-native, så env-flaggan är obsolet.

## Scope-beslut
`deploy-demo.yml` behåller `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` tills vidare:
dess GitHub-Pages-actions (`configure-pages@v5`, `upload-pages-artifact@v3`,
`deploy-pages@v4`) kör fortfarande Node 20 och var inte med i den rapporterade
varningen. Deploy-flödet valideras inte av PR-CI (push-trigger mot live-demon),
så jag rör inte dem i samma PR — blind risk mot live-demon.

## Verifiering
`bun run test:all` grönt lokalt (static + unit/coverage + e2e round-trip, 266s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)