### PR TITLE
feat(server-runtime): körbar entry + paketering för git-peer-loopen (#118)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@
 # production
 /build
 
+# server-runtime — kompilerade binärer (bun build --compile, #118)
+/dist/
+
 # misc
 .DS_Store
 *.pem

--- a/docs/server-runtime.md
+++ b/docs/server-runtime.md
@@ -1,0 +1,76 @@
+# Server-runtime (git-peer)
+
+> ADR 0005 fas 1. Bygger på #115 (läs) + #116 (skriv) + #117 (pull→act→push) och
+> är den körbara artefakten från #118.
+
+Server-runtimen är en **git-peer**, inte en dataägare (ADR 0005): den klonar
+`firma.git`, kör mutationer mot sin egen working copy och pushar tillbaka —
+exakt samma roll som en browser-klient. Den är komplementet som gör
+integrationer (Fortnox, mail, regler) möjliga utan att bryta local-first-USP:n:
+är servern nere köas integrationer, appen fungerar ändå.
+
+## Köra
+
+Config läses ur miljövariabler. Bara tre är obligatoriska:
+
+| Env | Default | Beskrivning |
+|-----|---------|-------------|
+| `AVA_SR_REPO_URL` | — (obligatorisk) | remote-url till `firma.git` (`file://`, `https://`, `ssh`) |
+| `AVA_SR_WORK_DIR` | — (obligatorisk) | katalog för working-copy:n (klonas hit om tom) |
+| `AVA_SR_ORG_ID` | — (obligatorisk) | org-id för den self-deklarerade principalen |
+| `AVA_SR_BRANCH` | `main` | branch att synka mot |
+| `AVA_SR_REMOTE` | `origin` | git-remote-namn |
+| `AVA_SR_POLL_INTERVAL_MS` | `15000` | polling-intervall |
+| `AVA_SR_MAX_RETRIES` | `3` | push-försök vid konflikt per cykel |
+| `AVA_SR_PRINCIPAL_ID` / `_EMAIL` / `_NAME` / `_ROLE` | `server-runtime` / … / `ADMIN` | principal + git-författare |
+
+> **Git-creds** tas av systemets git-config/credential-helper (SSH-agent,
+> HTTPS-helper) — precis som `NodeGitOps`/`cloneWorkingCopy`. Inga hemligheter
+> skickas via env.
+
+```sh
+# Direkt via bun
+AVA_SR_REPO_URL=https://host/git/firma.git \
+AVA_SR_WORK_DIR=/srv/ava/wc \
+AVA_SR_ORG_ID=byra-1 \
+  bun run server-runtime
+
+# En enda tick + avsluta (cron / smoke-test)
+… bun run server-runtime --once
+
+# Hjälp
+bun run server-runtime --help
+```
+
+## Lägen
+
+- **sync** (inget connector-`job` inkopplat ännu): varje tick gör `fetch` +
+  hård reset till remote — håller working-copy:n à jour, pushar inget (inga
+  tomma commits). Servern är en nyttig à-jour-peer redan innan första
+  connectorn finns.
+- **cykel** (när ett `job` injiceras, kommande #80/#82): varje tick kör en
+  konflikt-säker `runPeerCycle` (pull → act → push, CAS-retry vid
+  `NonFastForward`).
+
+## Paketering
+
+```sh
+bun run server-runtime:build   # → dist/server-runtime/ava-server-runtime-<os>-<arch>
+```
+
+`bun build --compile` paketerar hela tRPC-grafen + git-peer-runtimen till en
+fristående binär per server-plattform (darwin/linux), samma mönster som
+helper-appen. Binären behöver bara system-`git` + git-creds vid körning.
+
+## Kod
+
+| Modul | Ansvar |
+|-------|--------|
+| `src/lib/server/local-first/server-runtime-config.ts` | env → validerad `RuntimeConfig` (zod) |
+| `src/lib/server/local-first/peer-loop.ts` | `PeerLoop` — periodisk drivare (sync/cykel) |
+| `src/lib/server/local-first/server-runtime.ts` | `startServerRuntime` — clone-if-absent + start |
+| `src/bin/server-runtime.ts` | körbar entry (argv + signaler) |
+| `tooling/scripts/build-server-runtime.ts` | cross-compile till binärer |
+
+Deploy/drift (service-registrering, webhook-skydd, secrets-vault) ligger i
+#81 / #79 — utanför #118:s scope.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "demo:serve": "bash tooling/scripts/demo-serve.sh",
     "demo:serve:fast": "SKIP_BUILD=1 bash tooling/scripts/demo-serve.sh",
     "seed:local": "bun tooling/scripts/seed-firma-local.ts",
+    "server-runtime": "bun src/bin/server-runtime.ts",
+    "server-runtime:build": "bun tooling/scripts/build-server-runtime.ts",
     "start": "next start",
     "tier3:up": "docker compose -f tooling/docker/docker-compose.yml up -d --build",
     "tier3:down": "docker compose -f tooling/docker/docker-compose.yml down",

--- a/src/bin/server-runtime.ts
+++ b/src/bin/server-runtime.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env bun
+/**
+ * Server-runtime D (#118, ADR 0005 fas 1) — körbar entry.
+ *
+ * Den fristående artefakten som kör pull→act→push-loopen mot en konfigurerad
+ * `firma.git` (#77:s "Klar när"). Körs via `bun src/bin/server-runtime.ts`
+ * eller som kompilerad binär (`bun run server-runtime:build`, se
+ * `tooling/scripts/build-server-runtime.ts`).
+ *
+ * All logik bor i testbara moduler (`server-runtime-config`,
+ * `server-runtime`, `peer-loop`); den här filen är bara argv + signaler +
+ * process-livscykel — medvetet tunn (samma mönster som helper-app/src/main.ts).
+ *
+ * Config läses ur miljövariabler (se ENV_KEYS); git-creds tas av systemets
+ * git-config/credential-helper — inga hemligheter via env.
+ */
+
+import { ENV_KEYS, loadRuntimeConfig } from "@/lib/server/local-first/server-runtime-config";
+import { startServerRuntime } from "@/lib/server/local-first/server-runtime";
+
+const HELP = `ava server-runtime (ADR 0005 fas 1)
+
+Kör en pull→act→push-loop mot en konfigurerad firma.git. Utan en connector
+körs loopen i sync-läge (håller working-copy:n à jour; pushar inget).
+
+Användning:
+  bun src/bin/server-runtime.ts [--once] [--help]
+
+Flaggor:
+  --once    Kör en enda tick och avsluta (för cron/smoke-test).
+  --help    Visa denna hjälp.
+
+Miljövariabler:
+  ${ENV_KEYS.repoUrl}        (obligatorisk)  remote-url till firma.git
+  ${ENV_KEYS.workDir}        (obligatorisk)  katalog för working-copy:n
+  ${ENV_KEYS.organizationId}          (obligatorisk)  org-id för principalen
+  ${ENV_KEYS.branch}           (default main)
+  ${ENV_KEYS.remote}           (default origin)
+  ${ENV_KEYS.pollIntervalMs}  (default 15000)
+  ${ENV_KEYS.maxRetries}       (default 3)
+  ${ENV_KEYS.principalId} / ${ENV_KEYS.principalEmail} / ${ENV_KEYS.principalName} / ${ENV_KEYS.principalRole}
+`;
+
+function log(msg: string): void {
+  console.log(`[server-runtime] ${msg}`);
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  if (argv.includes("--help")) {
+    process.stdout.write(HELP);
+    return;
+  }
+
+  const config = loadRuntimeConfig();
+  const loop = await startServerRuntime(config);
+
+  if (argv.includes("--once")) {
+    await loop.tickOnce();
+    loop.stop();
+    return;
+  }
+
+  for (const sig of ["SIGTERM", "SIGINT"] as const) {
+    process.on(sig, () => {
+      log(`${sig} — stoppar`);
+      loop.stop();
+      process.exit(0);
+    });
+  }
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`[server-runtime] startfel: ${String(err)}\n`);
+  process.exitCode = 1;
+});

--- a/src/lib/server/local-first/peer-loop.ts
+++ b/src/lib/server/local-first/peer-loop.ts
@@ -1,0 +1,124 @@
+/**
+ * Server-runtime D (#118, ADR 0005 fas 1) — peer-loopen.
+ *
+ * `PeerLoop` är den periodiska drivaren ovanpå primitiven i #117
+ * (`runPeerCycle`). Den speglar `SyncLoop`-designen (local-first-klienten):
+ * loopen vet bara HUR ofta den ska ticka — vad som händer per tick är
+ * injicerat.
+ *
+ * Två lägen per tick:
+ *   - **cykel** (när ett `job` är satt): kör en konflikt-säker
+ *     pull→act→push-cykel via `runPeerCycle`. Det är hit framtida connectorer
+ *     (#80 regler/schemaläggare, #82 Fortnox) kopplar in sina mutationer.
+ *   - **sync** (när inget `job` finns ännu): håll bara working-copy:n à jour
+ *     med remote (fetch + reset). Ingen push → inga tomma commits. Servern är
+ *     en nyttig, à-jour git-peer redan innan första connectorn finns.
+ *
+ * Felhantering (som `SyncLoop`): en krasch i en tick loggas men tar inte ner
+ * loopen — nästa tick försöker igen.
+ */
+
+import { NodeGitOps } from "./node-git-ops";
+import {
+  runPeerCycle,
+  type PeerAct,
+  type PeerCycleResult,
+  type RunPeerCycleOpts,
+} from "./server-peer";
+
+const DEFAULT_INTERVAL_MS = 15_000;
+
+/** En mutation att köra per tick (connector-arbetet). */
+export interface PeerJob {
+  act: PeerAct;
+  message: string;
+}
+
+export type RunCycle = (
+  dir: string,
+  act: PeerAct,
+  message: string,
+  opts: RunPeerCycleOpts,
+) => Promise<PeerCycleResult>;
+
+export type SyncOnce = (dir: string, opts: RunPeerCycleOpts) => Promise<void>;
+
+export interface PeerLoopDeps {
+  /** Working-copy-katalogen peern arbetar i. */
+  dir: string;
+  /** Vidarebefordras till `runPeerCycle`/sync (principal, branch, remote, maxRetries). */
+  cycleOpts: RunPeerCycleOpts;
+  /** Polling-intervall i ms. Default 15s. */
+  intervalMs?: number;
+  /** Sätts → cykel-läge; utelämnas → sync-läge. */
+  job?: PeerJob;
+  log?: (msg: string) => void;
+  /** Injicerbara seams för test. */
+  runCycle?: RunCycle;
+  syncOnce?: SyncOnce;
+}
+
+export type PeerLoopTick =
+  | { mode: "cycle"; result: PeerCycleResult }
+  | { mode: "sync" }
+  | { mode: "error"; error: unknown };
+
+/** Standard sync-tick: fetch + hård reset till remote. Ingen push. */
+async function defaultSyncOnce(dir: string, opts: RunPeerCycleOpts): Promise<void> {
+  const author = opts.author ?? { name: opts.principal.name, email: opts.principal.email };
+  const git = new NodeGitOps(dir, author.name, author.email, opts.remote ?? "origin", opts.branch ?? "main");
+  await git.fetch();
+  await git.resetHardToRemote();
+}
+
+export class PeerLoop {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private readonly intervalMs: number;
+  private readonly log: (msg: string) => void;
+  private readonly runCycle: RunCycle;
+  private readonly syncOnce: SyncOnce;
+
+  constructor(private readonly deps: PeerLoopDeps) {
+    this.intervalMs = deps.intervalMs ?? DEFAULT_INTERVAL_MS;
+    this.log = deps.log ?? ((msg) => console.log(`[server-runtime] ${msg}`));
+    this.runCycle = deps.runCycle ?? runPeerCycle;
+    this.syncOnce = deps.syncOnce ?? defaultSyncOnce;
+  }
+
+  /** Starta polling. Idempotent — andra anrop är no-op om redan startad. */
+  start(): void {
+    if (this.timer) return;
+    this.log(`peer-loop startar (intervall ${this.intervalMs} ms, läge ${this.deps.job ? "cykel" : "sync"})`);
+    this.timer = setInterval(() => {
+      void this.tickOnce().catch((err) => this.log(`tick kastade: ${String(err)}`));
+    }, this.intervalMs);
+  }
+
+  /** Stoppa polling. */
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /**
+   * En explicit tick. Exponerad så tester kan driva loopen deterministiskt
+   * utan fake timers, och så entryn kan köra en enda cykel (`--once`).
+   */
+  async tickOnce(): Promise<PeerLoopTick> {
+    const { job, dir, cycleOpts } = this.deps;
+    try {
+      if (job) {
+        const result = await this.runCycle(dir, job.act, job.message, cycleOpts);
+        this.log(result.pushed ? `pushade (${result.attempts} försök)` : `push misslyckades: ${result.reason ?? "okänt"}`);
+        return { mode: "cycle", result };
+      }
+      await this.syncOnce(dir, cycleOpts);
+      return { mode: "sync" };
+    } catch (error) {
+      this.log(`tick-fel: ${String(error)}`);
+      return { mode: "error", error };
+    }
+  }
+}

--- a/src/lib/server/local-first/server-runtime-config.ts
+++ b/src/lib/server/local-first/server-runtime-config.ts
@@ -1,0 +1,98 @@
+/**
+ * Server-runtime D (#118, ADR 0005 fas 1) — körbar konfiguration.
+ *
+ * Läser runtime-konfigen ur miljövariabler (12-factor) och validerar med zod,
+ * så den körbara entryn (`src/bin/server-runtime.ts`) bara behöver anropa
+ * {@link loadRuntimeConfig} och få ett färdigvaliderat, typat objekt.
+ *
+ * Inga hemligheter här: git-creds tas av systemets git-config/credential-
+ * helper (SSH-agent, HTTPS-helper), precis som `NodeGitOps`/`cloneWorkingCopy`
+ * redan förutsätter. Vi skickar alltså aldrig lösenord/tokens via env.
+ */
+
+import { z } from "zod";
+
+const DEFAULT_POLL_INTERVAL_MS = 15_000;
+const DEFAULT_MAX_RETRIES = 3;
+
+export const runtimeConfigSchema = z.object({
+  /** Remote-url till firma.git (file://, https:// eller ssh). */
+  repoUrl: z.string().min(1),
+  /** Katalog för server-peerns egna working copy (klonas hit om tom). */
+  workDir: z.string().min(1),
+  /** Branch att synka mot. */
+  branch: z.string().min(1).default("main"),
+  /** Git-remote-namn. */
+  remote: z.string().min(1).default("origin"),
+  /** Polling-intervall för peer-loopen, i ms. */
+  pollIntervalMs: z.coerce.number().int().positive().default(DEFAULT_POLL_INTERVAL_MS),
+  /** Max push-försök vid NonFastForward-konflikt per cykel. */
+  maxRetries: z.coerce.number().int().positive().default(DEFAULT_MAX_RETRIES),
+  /**
+   * Self-deklarerad principal (git-backenden har ingen ACL, ADR 0001). Blir
+   * också git-författare för commits. Bara `organizationId` är obligatorisk;
+   * övriga fält har körbara defaults.
+   */
+  principal: z.object({
+    id: z.string().min(1).default("server-runtime"),
+    email: z.string().min(1).default("server-runtime@ava.local"),
+    name: z.string().min(1).default("AVA Server-runtime"),
+    role: z.string().min(1).default("ADMIN"),
+    organizationId: z.string().min(1),
+  }),
+});
+
+export type RuntimeConfig = z.infer<typeof runtimeConfigSchema>;
+
+/** Env-nyckel → schemats fält. Single source of truth för dokumentation + parse. */
+export const ENV_KEYS = {
+  repoUrl: "AVA_SR_REPO_URL",
+  workDir: "AVA_SR_WORK_DIR",
+  branch: "AVA_SR_BRANCH",
+  remote: "AVA_SR_REMOTE",
+  pollIntervalMs: "AVA_SR_POLL_INTERVAL_MS",
+  maxRetries: "AVA_SR_MAX_RETRIES",
+  principalId: "AVA_SR_PRINCIPAL_ID",
+  principalEmail: "AVA_SR_PRINCIPAL_EMAIL",
+  principalName: "AVA_SR_PRINCIPAL_NAME",
+  principalRole: "AVA_SR_PRINCIPAL_ROLE",
+  organizationId: "AVA_SR_ORG_ID",
+} as const;
+
+/** Läs en env-nyckel; tom sträng behandlas som ej satt (→ schemats default slår in). */
+function read(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  const value = env[key];
+  return value === undefined || value === "" ? undefined : value;
+}
+
+function formatIssues(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => `  - ${issue.path.join(".") || "(rot)"}: ${issue.message}`)
+    .join("\n");
+}
+
+/**
+ * Bygg och validera runtime-konfigen ur miljövariabler. Kastar med en läsbar
+ * sammanställning av alla fel (inte bara det första) om något saknas/är fel.
+ */
+export function loadRuntimeConfig(env: NodeJS.ProcessEnv = process.env): RuntimeConfig {
+  const parsed = runtimeConfigSchema.safeParse({
+    repoUrl: read(env, ENV_KEYS.repoUrl),
+    workDir: read(env, ENV_KEYS.workDir),
+    branch: read(env, ENV_KEYS.branch),
+    remote: read(env, ENV_KEYS.remote),
+    pollIntervalMs: read(env, ENV_KEYS.pollIntervalMs),
+    maxRetries: read(env, ENV_KEYS.maxRetries),
+    principal: {
+      id: read(env, ENV_KEYS.principalId),
+      email: read(env, ENV_KEYS.principalEmail),
+      name: read(env, ENV_KEYS.principalName),
+      role: read(env, ENV_KEYS.principalRole),
+      organizationId: read(env, ENV_KEYS.organizationId),
+    },
+  });
+  if (!parsed.success) {
+    throw new Error(`Ogiltig server-runtime-konfig:\n${formatIssues(parsed.error)}`);
+  }
+  return parsed.data;
+}

--- a/src/lib/server/local-first/server-runtime.ts
+++ b/src/lib/server/local-first/server-runtime.ts
@@ -1,0 +1,75 @@
+/**
+ * Server-runtime D (#118, ADR 0005 fas 1) — composition root.
+ *
+ * Knyter ihop config (#118), klon-primitiven (#117) och peer-loopen till en
+ * startbar runtime. `startServerRuntime` är den enda funktion den körbara
+ * entryn (`src/bin/server-runtime.ts`) behöver — den är dessutom
+ * dependency-injection-bar så tester kan köra den utan riktig git.
+ */
+
+import { access } from "node:fs/promises";
+import { join } from "node:path";
+
+import { cloneWorkingCopy, type CloneWorkingCopyOpts } from "./server-peer";
+import { PeerLoop, type PeerJob, type PeerLoopDeps } from "./peer-loop";
+import type { RuntimeConfig } from "./server-runtime-config";
+
+export interface StartServerRuntimeDeps {
+  /** Klon-funktion (default: `cloneWorkingCopy`). */
+  clone?: (opts: CloneWorkingCopyOpts) => Promise<void>;
+  /** Avgör om `dir` redan är en git-working-copy (default: kollar `.git`). */
+  isGitRepo?: (dir: string) => Promise<boolean>;
+  /** Connector-mutationen per tick. Utelämnas → loopen kör i sync-läge. */
+  job?: PeerJob;
+  log?: (msg: string) => void;
+}
+
+async function defaultIsGitRepo(dir: string): Promise<boolean> {
+  try {
+    await access(join(dir, ".git"));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Bygg PeerLoop-deps ur config + valfria seams (utan att skicka undefined). */
+function buildLoopDeps(config: RuntimeConfig, deps: StartServerRuntimeDeps): PeerLoopDeps {
+  return {
+    dir: config.workDir,
+    cycleOpts: {
+      principal: config.principal,
+      branch: config.branch,
+      remote: config.remote,
+      maxRetries: config.maxRetries,
+    },
+    intervalMs: config.pollIntervalMs,
+    ...(deps.job ? { job: deps.job } : {}),
+    ...(deps.log ? { log: deps.log } : {}),
+  };
+}
+
+/**
+ * Starta server-runtimen: klona `firma.git` om working-copy:n saknas (annars
+ * återanvänd den befintliga), och starta peer-loopen. Returnerar loopen så
+ * caller kan `stop()`:a den (signal-hantering, `--once`, test).
+ */
+export async function startServerRuntime(
+  config: RuntimeConfig,
+  deps: StartServerRuntimeDeps = {},
+): Promise<PeerLoop> {
+  const clone = deps.clone ?? cloneWorkingCopy;
+  const isGitRepo = deps.isGitRepo ?? defaultIsGitRepo;
+  const log = deps.log ?? ((msg) => console.log(`[server-runtime] ${msg}`));
+
+  if (await isGitRepo(config.workDir)) {
+    log(`återanvänder working-copy: ${config.workDir}`);
+  } else {
+    log(`klonar ${config.repoUrl} → ${config.workDir} (branch ${config.branch})`);
+    await clone({ url: config.repoUrl, dir: config.workDir, branch: config.branch });
+  }
+
+  const loop = new PeerLoop(buildLoopDeps(config, deps));
+  loop.start();
+  return loop;
+}

--- a/test/unit/server/local-first/peer-loop.test.ts
+++ b/test/unit/server/local-first/peer-loop.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Test för server-runtime D (#118) — PeerLoop.
+ *
+ * Driver loopen deterministiskt via `tickOnce()` med injicerade seams
+ * (`runCycle`/`syncOnce`), så ingen riktig git behövs här. Verifierar
+ * cykel-läge, sync-läge, felresiliens och start/stop-idempotens.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+
+import { PeerLoop, type PeerLoopDeps } from "@/lib/server/local-first/peer-loop";
+import type { PeerCycleResult } from "@/lib/server/local-first/server-peer";
+import type { Principal } from "@/lib/server/auth/principal";
+
+const PRINCIPAL: Principal = {
+  id: "server-runtime",
+  email: "sr@ava.local",
+  name: "SR",
+  role: "ADMIN",
+  organizationId: "org-1",
+};
+
+function baseDeps(over: Partial<PeerLoopDeps> = {}): PeerLoopDeps {
+  return {
+    dir: "/wc",
+    cycleOpts: { principal: PRINCIPAL },
+    intervalMs: 60_000,
+    log: () => {},
+    ...over,
+  };
+}
+
+describe("PeerLoop (#118)", () => {
+  it("sync-läge: kör syncOnce när inget job är satt", async () => {
+    const calls: string[] = [];
+    const loop = new PeerLoop(baseDeps({
+      syncOnce: async (dir) => { calls.push(dir); },
+      runCycle: async () => { throw new Error("ska inte anropas i sync-läge"); },
+    }));
+    const tick = await loop.tickOnce();
+    expect(tick.mode).toBe("sync");
+    expect(calls).toEqual(["/wc"]);
+  });
+
+  it("cykel-läge: kör runCycle med jobbets act + message", async () => {
+    const seen: { message?: string } = {};
+    const result: PeerCycleResult = { pushed: true, attempts: 1 };
+    const loop = new PeerLoop(baseDeps({
+      job: { act: async () => {}, message: "feat: x" },
+      runCycle: async (_dir, _act, message) => { seen.message = message; return result; },
+      syncOnce: async () => { throw new Error("ska inte anropas i cykel-läge"); },
+    }));
+    const tick = await loop.tickOnce();
+    expect(tick).toEqual({ mode: "cycle", result });
+    expect(seen.message).toBe("feat: x");
+  });
+
+  it("felresiliens: en kastande tick blir mode 'error', inte ett rejected promise", async () => {
+    const boom = new Error("nätverk nere");
+    const loop = new PeerLoop(baseDeps({
+      syncOnce: async () => { throw boom; },
+    }));
+    const tick = await loop.tickOnce();
+    expect(tick).toEqual({ mode: "error", error: boom });
+  });
+
+  it("start() är idempotent och stop() rensar timern", async () => {
+    let ticks = 0;
+    const loop = new PeerLoop(baseDeps({
+      intervalMs: 5,
+      syncOnce: async () => { ticks += 1; },
+    }));
+    loop.start();
+    loop.start(); // andra anropet är no-op (ingen andra timer)
+    await new Promise((r) => setTimeout(r, 30));
+    loop.stop();
+    const after = ticks;
+    expect(after).toBeGreaterThan(0);
+    await new Promise((r) => setTimeout(r, 20));
+    // Inga fler ticks efter stop().
+    expect(ticks).toBe(after);
+  });
+});

--- a/test/unit/server/local-first/server-runtime-config.test.ts
+++ b/test/unit/server/local-first/server-runtime-config.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Test för server-runtime D (#118) — config-parsing ur env.
+ *
+ * Verifierar: obligatoriska fält, defaults, tal-coercion och att alla fel
+ * samlas i ett läsbart kast.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+
+import { loadRuntimeConfig } from "@/lib/server/local-first/server-runtime-config";
+
+const MINIMAL: Record<string, string> = {
+  AVA_SR_REPO_URL: "file:///srv/firma.git",
+  AVA_SR_WORK_DIR: "/srv/wc",
+  AVA_SR_ORG_ID: "org-1",
+};
+
+describe("loadRuntimeConfig (#118)", () => {
+  it("parsar minimal env och fyller i defaults", () => {
+    const cfg = loadRuntimeConfig(MINIMAL);
+    expect(cfg.repoUrl).toBe("file:///srv/firma.git");
+    expect(cfg.workDir).toBe("/srv/wc");
+    expect(cfg.branch).toBe("main");
+    expect(cfg.remote).toBe("origin");
+    expect(cfg.pollIntervalMs).toBe(15_000);
+    expect(cfg.maxRetries).toBe(3);
+    expect(cfg.principal).toEqual({
+      id: "server-runtime",
+      email: "server-runtime@ava.local",
+      name: "AVA Server-runtime",
+      role: "ADMIN",
+      organizationId: "org-1",
+    });
+  });
+
+  it("respekterar override och coerce:ar tal-strängar", () => {
+    const cfg = loadRuntimeConfig({
+      ...MINIMAL,
+      AVA_SR_BRANCH: "develop",
+      AVA_SR_REMOTE: "upstream",
+      AVA_SR_POLL_INTERVAL_MS: "5000",
+      AVA_SR_MAX_RETRIES: "7",
+      AVA_SR_PRINCIPAL_ID: "bot-1",
+      AVA_SR_PRINCIPAL_EMAIL: "bot@firma.se",
+      AVA_SR_PRINCIPAL_NAME: "Robot",
+      AVA_SR_PRINCIPAL_ROLE: "LAWYER",
+    });
+    expect(cfg.branch).toBe("develop");
+    expect(cfg.remote).toBe("upstream");
+    expect(cfg.pollIntervalMs).toBe(5_000);
+    expect(cfg.maxRetries).toBe(7);
+    expect(cfg.principal.id).toBe("bot-1");
+    expect(cfg.principal.role).toBe("LAWYER");
+  });
+
+  it("behandlar tom sträng som ej satt (default slår in)", () => {
+    const cfg = loadRuntimeConfig({ ...MINIMAL, AVA_SR_BRANCH: "" });
+    expect(cfg.branch).toBe("main");
+  });
+
+  it("kastar när repoUrl saknas (med fält i meddelandet)", () => {
+    const { AVA_SR_REPO_URL: _omit, ...rest } = MINIMAL;
+    expect(() => loadRuntimeConfig(rest)).toThrow(/repoUrl/);
+  });
+
+  it("kastar när organizationId saknas", () => {
+    const { AVA_SR_ORG_ID: _omit, ...rest } = MINIMAL;
+    expect(() => loadRuntimeConfig(rest)).toThrow(/organizationId/);
+  });
+
+  it("kastar på ogiltigt intervall (negativt / icke-numeriskt)", () => {
+    expect(() => loadRuntimeConfig({ ...MINIMAL, AVA_SR_POLL_INTERVAL_MS: "-1" })).toThrow(/pollIntervalMs/);
+    expect(() => loadRuntimeConfig({ ...MINIMAL, AVA_SR_MAX_RETRIES: "abc" })).toThrow(/maxRetries/);
+  });
+
+  it("samlar flera fel i ett kast", () => {
+    expect(() => loadRuntimeConfig({})).toThrow(/repoUrl[\s\S]*workDir|workDir[\s\S]*repoUrl/);
+  });
+});

--- a/test/unit/server/local-first/server-runtime.test.ts
+++ b/test/unit/server/local-first/server-runtime.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Test för server-runtime D (#118) — startServerRuntime mot riktig git.
+ *
+ * Verifierar composition-root:en end-to-end:
+ *   1. klon-om-saknas: tom workDir → klonar firma.git.
+ *   2. återanvänd: befintlig working-copy klonas inte om.
+ *   3. sync-läge (inget job): en tick hämtar remote-ändringar till working-copy:n.
+ *   4. cykel-läge (job): en tick kör mutation + pushar till remote.
+ *
+ * Kräver system-`git` (som server-peer.test.ts) — hoppas annars över.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import { mkdtemp, rm, readdir, mkdir, writeFile, access } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execSync, spawnSync } from "node:child_process";
+
+import { startServerRuntime } from "@/lib/server/local-first/server-runtime";
+import type { RuntimeConfig } from "@/lib/server/local-first/server-runtime-config";
+import { CURRENT_SCHEMA_VERSION } from "@/lib/shared/schema-version";
+
+const PRINCIPAL: RuntimeConfig["principal"] = {
+  id: "server-runtime",
+  email: "sr@ava.local",
+  name: "AVA Server-runtime",
+  role: "ADMIN",
+  organizationId: "test-org",
+};
+
+const hasGit = (): boolean => spawnSync("git", ["--version"], { stdio: "ignore" }).status === 0;
+const suite = hasGit() ? describe : describe.skip;
+const GID = `-c user.email=t@x -c user.name=t`;
+
+function cfg(over: Partial<RuntimeConfig>): RuntimeConfig {
+  return {
+    repoUrl: "",
+    workDir: "",
+    branch: "main",
+    remote: "origin",
+    pollIntervalMs: 600_000, // högt → interval-timern firar inte under testet
+    maxRetries: 3,
+    principal: PRINCIPAL,
+    ...over,
+  };
+}
+
+suite("startServerRuntime (#118)", () => {
+  let root: string;
+  let bare: string;
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), "ava-sr-"));
+    bare = join(root, "firma.git");
+    execSync(`git init --bare --quiet --initial-branch=main "${bare}"`);
+    const seed = join(root, "_seed");
+    execSync(`git clone --quiet "${bare}" "${seed}"`);
+    await mkdir(join(seed, ".ava"), { recursive: true });
+    await writeFile(join(seed, ".ava/meta.json"), JSON.stringify({ schemaVersion: CURRENT_SCHEMA_VERSION }));
+    execSync(`git -C "${seed}" ${GID} add -A`);
+    execSync(`git -C "${seed}" ${GID} commit --quiet -m seed`);
+    execSync(`git -C "${seed}" push --quiet origin main`);
+    await rm(seed, { recursive: true, force: true });
+  });
+
+  afterAll(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  async function freshWorkDir(name: string): Promise<string> {
+    return join(await mkdtemp(join(root, `${name}-`)), "wc");
+  }
+
+  const exists = (p: string): Promise<boolean> => access(p).then(() => true, () => false);
+
+  /** En konkurrent pushar en ny fil till remote. */
+  function competitorPush(fileName: string): void {
+    const c = join(root, "_competitor");
+    spawnSync("rm", ["-rf", c]);
+    execSync(`git clone --quiet "${bare}" "${c}"`);
+    execSync(`bash -c 'echo hej > "${c}/${fileName}"'`);
+    execSync(`git -C "${c}" ${GID} add -A`);
+    execSync(`git -C "${c}" ${GID} commit --quiet -m competitor`);
+    execSync(`git -C "${c}" push --quiet origin main`);
+    spawnSync("rm", ["-rf", c]);
+  }
+
+  it("klonar firma.git när working-copy:n saknas", async () => {
+    const workDir = await freshWorkDir("clone");
+    const loop = await startServerRuntime(cfg({ repoUrl: bare, workDir }));
+    loop.stop();
+    expect(await exists(join(workDir, ".git"))).toBe(true);
+    expect(await exists(join(workDir, ".ava/meta.json"))).toBe(true);
+  });
+
+  it("återanvänder en befintlig working-copy (klonar inte om)", async () => {
+    const workDir = await freshWorkDir("reuse");
+    const first = await startServerRuntime(cfg({ repoUrl: bare, workDir }));
+    first.stop();
+    // En andra start mot samma dir får INTE klona om — injicera en clone som kastar.
+    const second = await startServerRuntime(cfg({ repoUrl: bare, workDir }), {
+      clone: async () => { throw new Error("clone borde inte anropas för befintlig wc"); },
+    });
+    second.stop();
+    expect(await exists(join(workDir, ".git"))).toBe(true);
+  });
+
+  it("sync-läge: en tick hämtar remote-ändringar in i working-copy:n", async () => {
+    const workDir = await freshWorkDir("sync");
+    const loop = await startServerRuntime(cfg({ repoUrl: bare, workDir }));
+    competitorPush("nyfil.txt");
+    const tick = await loop.tickOnce();
+    loop.stop();
+    expect(tick.mode).toBe("sync");
+    expect(await exists(join(workDir, "nyfil.txt"))).toBe(true);
+  });
+
+  it("cykel-läge: en tick kör mutation + pushar till remote", async () => {
+    const workDir = await freshWorkDir("cycle");
+    const loop = await startServerRuntime(cfg({ repoUrl: bare, workDir }), {
+      job: {
+        act: async (caller) => {
+          await caller.contacts.create({ id: "c-sr", name: "SR Klient", contactType: "COMPANY" });
+        },
+        message: "feat: lägg till c-sr via server-runtime",
+      },
+    });
+    const tick = await loop.tickOnce();
+    loop.stop();
+    expect(tick.mode).toBe("cycle");
+    if (tick.mode === "cycle") expect(tick.result.pushed).toBe(true);
+    // Remote har kontakten (verifiera via en throwaway clone).
+    const v = join(root, "_verify");
+    spawnSync("rm", ["-rf", v]);
+    execSync(`git clone --quiet "${bare}" "${v}"`);
+    const contacts = await readdir(join(v, "contacts")).catch(() => [] as string[]);
+    spawnSync("rm", ["-rf", v]);
+    expect(contacts).toContain("c-sr.json");
+  });
+});

--- a/tooling/scripts/build-server-runtime.ts
+++ b/tooling/scripts/build-server-runtime.ts
@@ -1,0 +1,49 @@
+/**
+ * Server-runtime D (#118, ADR 0005 fas 1) — paketering.
+ *
+ * Cross-compile:ar den körbara entryn (`src/bin/server-runtime.ts`) till
+ * fristående binärer, en per server-plattform — samma `bun build --compile`-
+ * mönster som helper-app/build.ts (ADR 0005 §Språk: standalone-binär ur TS).
+ *
+ * Kör: `bun run server-runtime:build` (eller `bun tooling/scripts/build-server-runtime.ts`).
+ *
+ * Binären bär hela tRPC-grafen + git-peer-runtimen; git-creds tas vid körning
+ * av systemets git-config/credential-helper (inga hemligheter bakas in).
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdir, rm } from "node:fs/promises";
+
+const OUT_DIR = "dist/server-runtime";
+const ENTRY = "src/bin/server-runtime.ts";
+
+// Server-plattformar (deploy = linux; darwin för lokal drift/dev). Windows
+// utelämnas — server-runtimen är en alltid-på Unix-tjänst.
+const TARGETS = [
+  { target: "bun-darwin-arm64", out: "ava-server-runtime-darwin-arm64" },
+  { target: "bun-darwin-x64", out: "ava-server-runtime-darwin-x64" },
+  { target: "bun-linux-x64", out: "ava-server-runtime-linux-x64" },
+  { target: "bun-linux-arm64", out: "ava-server-runtime-linux-arm64" },
+] as const;
+
+function buildOne(target: string, out: string): void {
+  const res = spawnSync(
+    "bun",
+    ["build", ENTRY, "--compile", `--target=${target}`, "--outfile", `${OUT_DIR}/${out}`],
+    { stdio: "inherit" },
+  );
+  if (res.status !== 0) throw new Error(`build misslyckades för ${target} (exit ${res.status ?? "signal"})`);
+  console.log(`✓ ${out}`);
+}
+
+async function main(): Promise<void> {
+  console.log(`Bygger ava-server-runtime →  ${OUT_DIR}/`);
+  await rm(OUT_DIR, { recursive: true, force: true });
+  await mkdir(OUT_DIR, { recursive: true });
+  for (const { target, out } of TARGETS) {
+    buildOne(target, out);
+  }
+  console.log(`Klart: ${TARGETS.length} binärer i ${OUT_DIR}/`);
+}
+
+await main();


### PR DESCRIPTION
Closes #118.

Server-runtime **del D** (ADR 0005 fas 1) — den fristående artefakten som kör
pull→act→push-loopen mot en konfigurerad `firma.git`. Bygger ovanpå
#115/#116/#117 (läs/skriv/cykel) och uppfyller #77:s "Klar när".

## Vad som tillkommer
| Modul | Ansvar |
|-------|--------|
| `server-runtime-config.ts` | env → validerad `RuntimeConfig` (zod) |
| `peer-loop.ts` | `PeerLoop` — periodisk drivare (sync/cykel), felresilient |
| `server-runtime.ts` | `startServerRuntime` — clone-if-absent + start |
| `src/bin/server-runtime.ts` | tunn körbar entry (`--once`/`--help`, signaler) |
| `tooling/scripts/build-server-runtime.ts` | `bun build --compile` → binärer/plattform |

`bun run server-runtime [--once|--help]` + `bun run server-runtime:build`.
Doc: `docs/server-runtime.md`.

## Design
- **Två lägen.** Utan en connector körs loopen i **sync-läge** (fetch + reset,
  ingen push → inga tomma commits) — servern är en nyttig à-jour-peer redan
  innan #80/#82 finns. Ett injicerat `job` växlar till **cykel-läge** via
  `runPeerCycle` (CAS-retry vid `NonFastForward`).
- **Inga hemligheter via env.** Bara `AVA_SR_REPO_URL` / `AVA_SR_WORK_DIR` /
  `AVA_SR_ORG_ID` är obligatoriska; git-creds tas av systemets git-config/
  credential-helper (som `NodeGitOps`).
- **Samma kvalitetsregler** som resten (eslint ≤8, dep-cruiser, knip, coverage).
  Logiken bor i testbara moduler; bin-entryn är medvetet tunn (helper-app-mönstret).

## Scope-gräns
Drift/deploy (service-registrering, webhook-skydd, secrets-vault) ligger i
#81 / #79 — utanför #118.

## Verifiering
- Enhet (config-parsing, PeerLoop sync/cykel/fel/idempotens) + integration mot
  **riktig git** (klon-om-saknas, återanvänd, sync-hämtning, cykel-push) gröna.
- Entryn kör end-to-end (clone + sync + exit), full config-felrapport, exit 1.
- `bun build --compile` lyckas (191 moduler, ~64 MB) och binären kör.
- `bun run test:all` grönt (static + unit/coverage + e2e round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)