### PR TITLE
feat(invoices): bankgiro-OCR-referens på kundfakturor (#182)

### DIFF
--- a/src/app/invoices/[id]/_client.tsx
+++ b/src/app/invoices/[id]/_client.tsx
@@ -221,6 +221,7 @@ function InvoiceHeader({ inv }: { inv: Inv }) {
     : inv.invoiceType === "CREDIT" ? "Kreditfaktura"
     : "Faktura";
   const invoiceNumber = (inv as { invoiceNumber?: string | null }).invoiceNumber;
+  const ocrReference = (inv as { ocrReference?: string | null }).ocrReference;
   return (
     <div>
       <EntityLink route="matters" id={inv.matter.id} className="text-sm text-blue-600 hover:underline">← {inv.matter.matterNumber} {inv.matter.title}</EntityLink>
@@ -229,6 +230,7 @@ function InvoiceHeader({ inv }: { inv: Inv }) {
         {invoiceNumber && <span className="ml-3 text-base font-normal text-gray-700">{invoiceNumber}</span>}
         <span className="ml-3 text-sm font-normal text-gray-500">{new Date(inv.invoiceDate).toLocaleDateString("sv-SE")}</span>
       </h1>
+      {ocrReference && <p className="text-sm text-gray-500 mt-1">OCR: <span className="font-mono">{ocrReference}</span></p>}
     </div>
   );
 }

--- a/src/lib/client/kostnadsrakning/render-faktura-pdf.ts
+++ b/src/lib/client/kostnadsrakning/render-faktura-pdf.ts
@@ -14,6 +14,8 @@ export interface FakturaInput {
   invoice: {
     amount: number; // öre
     invoiceNumber?: string | null;
+    /** Bankgiro-OCR (#182). Null på kostnadsräkningar/CREDIT → raden utelämnas. */
+    ocrReference?: string | null;
     invoiceDate?: string | Date | null;
   };
   meta: {
@@ -24,6 +26,17 @@ export interface FakturaInput {
     organizationName?: string;
     organizationOrgNumber?: string;
   };
+}
+
+type LineFn = (text: string, opts?: { size?: number; b?: boolean; gap?: number; gray?: boolean }) => void;
+
+/** Identitetsraderna under rubriken (fakturanr, datum, mottagare, klient). */
+function drawIdentityLines(line: LineFn, input: FakturaInput): void {
+  const date = input.invoice.invoiceDate ? new Date(input.invoice.invoiceDate).toLocaleDateString("sv-SE") : "";
+  if (input.invoice.invoiceNumber) line(`Fakturanr: ${input.invoice.invoiceNumber}`);
+  if (date) line(`Fakturadatum: ${date}`);
+  if (input.meta.recipient) line(`Mottagare: ${input.meta.recipient}`);
+  if (input.meta.clientName) line(`Klient: ${input.meta.clientName}`);
 }
 
 export async function renderFakturaPdf(input: FakturaInput): Promise<Uint8Array> {
@@ -51,17 +64,14 @@ export async function renderFakturaPdf(input: FakturaInput): Promise<Uint8Array>
   if (input.meta.organizationOrgNumber) line(`Org.nr ${input.meta.organizationOrgNumber}`, { size: 9 });
   y -= 8;
   line(`Mål ${input.meta.matterNumber} — ${input.meta.matterTitle}`, { size: 11, b: true, gap: 16 });
-  const date = input.invoice.invoiceDate ? new Date(input.invoice.invoiceDate).toLocaleDateString("sv-SE") : "";
-  if (input.invoice.invoiceNumber) line(`Fakturanr: ${input.invoice.invoiceNumber}`);
-  if (date) line(`Fakturadatum: ${date}`);
-  if (input.meta.recipient) line(`Mottagare: ${input.meta.recipient}`);
-  if (input.meta.clientName) line(`Klient: ${input.meta.clientName}`);
+  drawIdentityLines(line, input);
   y -= 10;
   page.drawLine({ start: { x: M, y }, end: { x: RIGHT, y }, thickness: 0.5, color: rgb(0.7, 0.7, 0.7) });
   y -= 26;
   page.drawText("Att betala", { x: M, y, size: 12, font: bold });
   page.drawText(formatCurrency(input.invoice.amount), { x: RIGHT - 130, y, size: 14, font: bold });
   y -= 28;
+  if (input.invoice.ocrReference) line(`OCR-referens: ${input.invoice.ocrReference}`, { size: 11, b: true, gap: 16 });
   line("Belopp enligt domstolens beslut / fakturaunderlag.", { size: 9, gray: true });
 
   return pdf.save();

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -18,6 +18,7 @@ import { TRPCError } from "@trpc/server";
 import { router, orgProcedure } from "../trpc";
 import type { DataStoreTx } from "../data-store/IDataStore";
 import { computeFinalInvoiceBreakdown, isPaymentPlanSettled } from "@/lib/shared/invoice-calc";
+import { ocrFromInvoiceNumber } from "@/lib/shared/ocr-reference";
 import { computeInvoiceLedger, deriveInvoiceStatus, invoicePartitionViolation } from "@/lib/shared/write-off-calc";
 import type { InvoiceStatus } from "@/lib/shared/schemas/enums";
 import { emit } from "../events/emit";
@@ -238,11 +239,15 @@ export const invoiceRouter = router({
         where: { id: input.matterId, organizationId: ctx.orgId },
       });
       if (!matter) throw new TRPCError({ code: "NOT_FOUND" });
+      const accontoNumber = await nextInvoiceNumber(ctx.dataStore.invoices, ctx.orgId);
       const invoice = await ctx.dataStore.invoices.create({
         data: omitUndefined({
           id: input.id, // undefined → store genererar
           matterId: input.matterId,
-          invoiceNumber: await nextInvoiceNumber(ctx.dataStore.invoices, ctx.orgId),
+          invoiceNumber: accontoNumber,
+          // Kundfaktura → Bankgiro-OCR (#182). Kostnadsräkningar (billingRun-
+          // flödet) och CREDIT får ingen OCR — betalas inte med OCR.
+          ocrReference: ocrFromInvoiceNumber(accontoNumber),
           amount: input.amount,
           invoiceType: "ACCONTO",
           status: "DRAFT",
@@ -291,11 +296,13 @@ export const invoiceRouter = router({
           accontos.map((a) => ({ id: a.id, amount: a.amount })),
         );
 
+        const finalNumber = await nextInvoiceNumber(tx.invoices, ctx.orgId);
         const invoice = await tx.invoices.create({
           data: omitUndefined({
             id: input.id, // undefined → store genererar
             matterId: input.matterId,
-            invoiceNumber: await nextInvoiceNumber(tx.invoices, ctx.orgId),
+            invoiceNumber: finalNumber,
+            ocrReference: ocrFromInvoiceNumber(finalNumber), // kundfaktura → OCR (#182)
             amount: breakdown.grossAmount,
             invoiceType: "FINAL",
             status: "DRAFT",

--- a/src/lib/shared/ocr-reference.ts
+++ b/src/lib/shared/ocr-reference.ts
@@ -1,0 +1,63 @@
+/**
+ * Bankgiro-OCR-referens för kundfakturor (#182).
+ *
+ * En OCR-referens är helt numerisk och avslutas med en mod-10-kontrollsiffra
+ * (Luhn). Vi använder Bankgirots "hårda" variant med längdsiffra: näst sista
+ * siffran är (totala längden mod 10), sista är kontrollsiffran. Det är den
+ * variant Bankgirots OCR-kontroll kan validera strikt (längd + checksiffra).
+ *
+ * Kärnan härleds ur fakturanumret `F-YYYY-NNNN` (#167) → `YYYYNNNN` (8
+ * siffror) → + längdsiffra + kontrollsiffra = 10 siffror. Deterministisk:
+ * samma faktura ger alltid samma OCR.
+ *
+ * VIKTIGT (domän): OCR genereras BARA för vanliga kundfakturor
+ * (ACCONTO/FINAL). Kostnadsräkningar till domstol får INGEN OCR —
+ * Domstolsverket betalar mot målnummer/ärendereferens i fri text (#173/#175).
+ * Kreditfakturor betalas inte av kund → ingen OCR.
+ */
+
+/** Luhn/mod-10-kontrollsiffra för en siffersträng (utan kontrollsiffran). */
+export function mod10CheckDigit(digits: string): number {
+  if (!/^\d+$/.test(digits)) throw new Error(`mod10CheckDigit kräver enbart siffror, fick "${digits}"`);
+  let sum = 0;
+  // Luhn: vikta växelvis 2,1,2,… från höger (positionen närmast kontrollsiffran väger 2).
+  for (let i = 0; i < digits.length; i++) {
+    const digit = Number(digits[digits.length - 1 - i]);
+    const weighted = i % 2 === 0 ? digit * 2 : digit;
+    sum += weighted > 9 ? weighted - 9 : weighted;
+  }
+  return (10 - (sum % 10)) % 10;
+}
+
+/**
+ * Bygg en komplett OCR-referens ur en numerisk kärna: kärna + längdsiffra +
+ * mod-10-kontrollsiffra. Längdsiffran = (total längd inkl. längd- och
+ * kontrollsiffra) mod 10 — Bankgirots variant med längdkontroll.
+ */
+export function buildOcrReference(core: string): string {
+  if (!/^\d+$/.test(core)) throw new Error(`OCR-kärnan måste vara numerisk, fick "${core}"`);
+  const lengthDigit = (core.length + 2) % 10;
+  const body = core + String(lengthDigit);
+  return body + String(mod10CheckDigit(body));
+}
+
+/** Validera en OCR-referens (längdsiffra + mod-10-kontrollsiffra). */
+export function isValidOcrReference(ocr: string): boolean {
+  if (!/^\d{4,25}$/.test(ocr)) return false;
+  const body = ocr.slice(0, -1);
+  if (mod10CheckDigit(body) !== Number(ocr[ocr.length - 1])) return false;
+  return Number(ocr[ocr.length - 2]) === ocr.length % 10;
+}
+
+/**
+ * Härled OCR-referensen ur ett fakturanummer på formen `F-YYYY-NNNN` (#167):
+ * sifferdelarna konkateneras (`YYYYNNNN`) och byggs på med längd- +
+ * kontrollsiffra. Returnerar null för fakturor utan (parsbart) nummer —
+ * t.ex. kostnadsräkningar till domstol, som inte ska ha OCR.
+ */
+export function ocrFromInvoiceNumber(invoiceNumber: string | null | undefined): string | null {
+  if (!invoiceNumber) return null;
+  const core = invoiceNumber.replace(/\D/g, "");
+  if (core.length === 0) return null;
+  return buildOcrReference(core);
+}

--- a/src/lib/shared/schemas/billing.ts
+++ b/src/lib/shared/schemas/billing.ts
@@ -108,6 +108,10 @@ export const invoiceSchema = z.object({
   /** Per-byrå löpande fakturanummer (F-YYYY-NNNN), genereras vid skapande.
    *  Nullish: legacy-fakturor saknar nummer → UI faller tillbaka på datum. */
   invoiceNumber: z.string().nullish(),
+  /** Bankgiro-OCR (mod-10 + längdsiffra, #182), härledd ur fakturanumret vid
+   *  skapande. BARA kundfakturor (ACCONTO/FINAL) — kostnadsräkningar till
+   *  domstol och CREDIT har null (betalas inte med OCR, jfr #173/#175). */
+  ocrReference: z.string().nullish(),
   fortnoxId: z.string().nullish(),
   invoiceDate: dateLike,
   dueDate: optionalDateLike,

--- a/test/unit/lib/shared/ocr-reference.test.ts
+++ b/test/unit/lib/shared/ocr-reference.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Test för Bankgiro-OCR-referensen (#182): mod-10-kontrollsiffra (Luhn),
+ * längdsiffra och härledning ur fakturanummer (F-YYYY-NNNN, #167).
+ */
+
+import { describe, it, expect } from "vitest-compat";
+
+import {
+  mod10CheckDigit,
+  buildOcrReference,
+  isValidOcrReference,
+  ocrFromInvoiceNumber,
+} from "@/lib/shared/ocr-reference";
+
+describe("mod10CheckDigit (Luhn)", () => {
+  // Kända Luhn-vektorer: kontrollsiffran som gör hela strängen Luhn-giltig.
+  it("kända vektorer", () => {
+    expect(mod10CheckDigit("7992739871")).toBe(3); // klassisk exempelvektor
+    expect(mod10CheckDigit("1212121212")).toBe(5);
+    expect(mod10CheckDigit("0")).toBe(0);
+    expect(mod10CheckDigit("9")).toBe(1); // 9*2=18 → 18-9=9 → (10-9)%10 = 1
+  });
+
+  it("kastar på icke-siffror", () => {
+    expect(() => mod10CheckDigit("12a4")).toThrow(/siffror/);
+    expect(() => mod10CheckDigit("")).toThrow(/siffror/);
+  });
+});
+
+describe("buildOcrReference", () => {
+  it("bygger kärna + längdsiffra + kontrollsiffra", () => {
+    const ocr = buildOcrReference("20260001");
+    expect(ocr).toHaveLength(10);
+    expect(ocr.startsWith("20260001")).toBe(true);
+    expect(ocr[8]).toBe("0"); // längdsiffra: 10 % 10 = 0
+    expect(isValidOcrReference(ocr)).toBe(true);
+  });
+
+  it("deterministisk: samma kärna → samma OCR", () => {
+    expect(buildOcrReference("20260001")).toBe(buildOcrReference("20260001"));
+  });
+
+  it("kastar på icke-numerisk kärna", () => {
+    expect(() => buildOcrReference("F-2026")).toThrow(/numerisk/);
+  });
+});
+
+describe("isValidOcrReference", () => {
+  it("accepterar byggda referenser och förkastar manipulerade", () => {
+    const ocr = buildOcrReference("20260042");
+    expect(isValidOcrReference(ocr)).toBe(true);
+    // Flippa kontrollsiffran → ogiltig.
+    const last = Number(ocr[ocr.length - 1]);
+    const tampered = ocr.slice(0, -1) + String((last + 1) % 10);
+    expect(isValidOcrReference(tampered)).toBe(false);
+  });
+
+  it("förkastar fel längdsiffra, icke-siffror och för korta", () => {
+    expect(isValidOcrReference("123")).toBe(false);
+    expect(isValidOcrReference("abc1234567")).toBe(false);
+    // Giltig checksiffra men fel längdsiffra: bygg om med fel längdsiffra.
+    const core = "2026000199"; // 10 tecken: kärna+fel längdsiffra(9)
+    const fake = core + String(mod10CheckDigit(core));
+    expect(fake).toHaveLength(11);
+    expect(isValidOcrReference(fake)).toBe(false); // längdsiffra 9 ≠ 11 % 10
+  });
+});
+
+describe("ocrFromInvoiceNumber", () => {
+  it("härleder ur F-YYYY-NNNN", () => {
+    const ocr = ocrFromInvoiceNumber("F-2026-0001");
+    expect(ocr).not.toBeNull();
+    expect(ocr).toBe(buildOcrReference("20260001"));
+    expect(isValidOcrReference(ocr as string)).toBe(true);
+  });
+
+  it("null för saknat/icke-parsbart nummer (kostnadsräkningar har inget)", () => {
+    expect(ocrFromInvoiceNumber(null)).toBeNull();
+    expect(ocrFromInvoiceNumber(undefined)).toBeNull();
+    expect(ocrFromInvoiceNumber("")).toBeNull();
+    expect(ocrFromInvoiceNumber("UTAN-NUMMER-")).toBeNull();
+  });
+});

--- a/test/unit/server/routers/invoice.test.ts
+++ b/test/unit/server/routers/invoice.test.ts
@@ -16,6 +16,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
 import { invoiceRouter } from "@/lib/server/routers/invoice";
 import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
+import { ocrFromInvoiceNumber, isValidOcrReference } from "@/lib/shared/ocr-reference";
 
 // ─── Mock prisma ─────────────────────────────────────────────────
 
@@ -725,5 +726,38 @@ describe("invoice.createCredit", () => {
       where: { id: "pp1" },
       data: { status: "CANCELLED" },
     });
+  });
+});
+
+// ─── OCR-referens (#182) ─────────────────────────────────────────
+
+describe("OCR-referens på kundfakturor (#182)", () => {
+  it("createAcconto sätter ocrReference härledd ur fakturanumret", async () => {
+    mockPrisma.matter.findFirst.mockResolvedValue(MATTER_A);
+    mockPrisma.invoice.findFirst.mockResolvedValue(null); // nextInvoiceNumber: första
+    mockPrisma.invoice.create.mockResolvedValue({ id: "inv-1", invoiceType: "ACCONTO", amount: 100 });
+
+    await makeCaller().createAcconto({ matterId: "matter-1", amount: 100 });
+
+    const data = mockPrisma.invoice.create.mock.calls[0]?.[0]?.data as {
+      invoiceNumber?: string; ocrReference?: string;
+    };
+    expect(data.invoiceNumber).toBeTruthy();
+    expect(data.ocrReference).toBe(ocrFromInvoiceNumber(data.invoiceNumber));
+    expect(isValidOcrReference(data.ocrReference as string)).toBe(true);
+  });
+
+  it("createCredit sätter INGEN ocrReference (krediter betalas inte med OCR)", async () => {
+    mockPrisma.invoice.findFirst.mockResolvedValue({
+      id: "inv-1", matterId: "m1", invoiceType: "STANDARD", status: "SENT",
+      amount: 1000, creditNote: null, paymentPlan: null,
+    });
+    mockPrisma.invoice.create.mockResolvedValue({ id: "credit-1", invoiceType: "CREDIT", amount: -1000 });
+    mockPrisma.invoice.update.mockResolvedValue({});
+
+    await makeCaller().createCredit({ invoiceId: "inv-1" });
+
+    const data = mockPrisma.invoice.create.mock.calls[0]?.[0]?.data as { ocrReference?: string };
+    expect(data.ocrReference).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #182.

Förutsättning (precursor) för camt-avprickningen #181: kundfakturor bär nu en **Bankgiro-OCR-referens** härledd ur fakturanumret (#167), så inkommande betalningars OCR har något att matcha mot — och kunden får OCR:en på fakturan.

## Ändringar
- **`src/lib/shared/ocr-reference.ts`** (pure, testbar): mod-10/Luhn-kontrollsiffra + Bankgirots variant med längdsiffra. `F-2026-0001` → `20260001` + längdsiffra + checksiffra = 10 siffror. Deterministisk. Validator (`isValidOcrReference`) ingår.
- **invoiceSchema:** additivt `ocrReference`-fält (ADR 0004 passthrough — ingen schemaVersion-bump).
- **Tilldelning:** `createAcconto`/`createFinal` sätter OCR ur fakturanumret. **Undantag (per issue-kravet):** kostnadsräknings-flödet (billingRun → `registerVerdict`) och `createCredit` får **ingen** OCR — Domstolsverket betalar mot målnummer/ärendereferens i fri text (#173/#175), och kreditfakturor betalas inte.
- **PDF:** `renderFakturaPdf` skriver `OCR-referens: NNNN…` i betalningssektionen när den finns (utelämnas för domstol/kredit). Identitetsraderna utbrutna i hjälpfunktion (komplexitet ≤8, ratchet-step).
- **UI:** faktura-detaljen visar OCR under rubriken.

## Test
- Kontrollsiffre-vektorer (kända Luhn-värden), längdsiffra, manipulationsskydd, härledning ur `F-YYYY-NNNN`, null-fall (saknat/icke-parsbart nummer).
- Router: ACCONTO får giltig OCR kopplad till sitt fakturanummer; CREDIT får ingen.

## Verifiering
`bun run test:all` grönt (static + unit/coverage + e2e round-trip, 307s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)