### PR TITLE
feat(payments): importera camt-betalfil + flexibel avprickning mot fakturor (#181)

### DIFF
--- a/src/app/invoices/page.tsx
+++ b/src/app/invoices/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { trpc } from "@/lib/client/trpc";
 import { formatCurrency } from "@/lib/client/utils";
 import { EntityLink } from "@/lib/client/demo/entity-link";
@@ -84,7 +85,12 @@ export default function InvoicesPage() {
 
   return (
     <div>
-      <h1 className="text-2xl font-bold text-gray-900 mb-6">Fakturor</h1>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">Fakturor</h1>
+        <Link href="/payments/import" className="text-sm text-blue-600 hover:underline">
+          Importera betalfil →
+        </Link>
+      </div>
       {invoices.isLoading ? (
         <div className="bg-white rounded-lg border border-gray-200 p-6">
           <p className="text-sm text-gray-400">Laddar…</p>

--- a/src/app/payments/import/page.tsx
+++ b/src/app/payments/import/page.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+/**
+ * Betalfils-import (#181): ladda upp en camt.054/053-fil (SEB/Bankgirot,
+ * "Kontohändelser via fil") → parsa → matcha mot fakturor (OCR #182,
+ * fakturanummer, fri text) → förhandsgranska → bokför via recordPayment.
+ *
+ * Logiken bor i `@/lib/shared/payments/` (camt-parse + match-payments, pure
+ * och enhetstestade) — sidan är bara filläsning + förhandsgranskning + knapp.
+ * Omatchade transaktioner visas med orsak (granskningskön v1, jfr #175).
+ */
+
+import { useMemo, useState } from "react";
+import { trpc } from "@/lib/client/trpc";
+import { formatCurrency } from "@/lib/client/utils";
+import { EntityLink } from "@/lib/client/demo/entity-link";
+import { parseCamtXml, type CamtFile } from "@/lib/shared/payments/camt-parse";
+import {
+  matchTransactions,
+  type InvoiceCandidate,
+  type MatchOutcome,
+  type BookablePayment,
+} from "@/lib/shared/payments/match-payments";
+
+interface InvoiceRowData {
+  id: string;
+  invoiceNumber?: string | null;
+  ocrReference?: string | null;
+  amount: number;
+  payments?: Array<{ reference?: string | null }>;
+}
+
+function toCandidates(rows: readonly InvoiceRowData[]): InvoiceCandidate[] {
+  return rows.map((r) => ({
+    id: r.id,
+    invoiceNumber: r.invoiceNumber ?? null,
+    ocrReference: r.ocrReference ?? null,
+    amount: r.amount,
+    paymentReferences: (r.payments ?? []).map((p) => p.reference).filter((x): x is string => !!x),
+  }));
+}
+
+const MATCHED_BY_LABEL: Record<BookablePayment["matchedBy"], string> = {
+  ocr: "OCR",
+  invoiceNumber: "Fakturanr",
+  freetext: "Fri text",
+};
+
+const REASON_LABEL: Record<string, string> = {
+  "ingen-träff": "Ingen träff — koppla manuellt",
+  tvetydig: "Tvetydig (flera fakturor träffas)",
+  dubblett: "Redan importerad",
+  debet: "Debet-post (ej inbetalning)",
+};
+
+export default function PaymentImportPage() {
+  const [xml, setXml] = useState("");
+  const [doneMsg, setDoneMsg] = useState<string | null>(null);
+  const invoices = trpc.invoice.list.useQuery({});
+  const utils = trpc.useUtils();
+  const recordPayment = trpc.invoice.recordPayment.useMutation();
+
+  const parsed = useMemo((): { file?: CamtFile; error?: string } => {
+    if (!xml.trim()) return {};
+    try {
+      return { file: parseCamtXml(xml) };
+    } catch (e) {
+      return { error: e instanceof Error ? e.message : String(e) };
+    }
+  }, [xml]);
+
+  const outcome = useMemo((): MatchOutcome | null => {
+    if (!parsed.file || !invoices.data) return null;
+    return matchTransactions(parsed.file.transactions, toCandidates(invoices.data as InvoiceRowData[]));
+  }, [parsed.file, invoices.data]);
+
+  const labels = useMemo((): Record<string, string> => {
+    const out: Record<string, string> = {};
+    for (const r of (invoices.data ?? []) as InvoiceRowData[]) out[r.id] = r.invoiceNumber ?? r.id;
+    return out;
+  }, [invoices.data]);
+
+  const book = async (bookable: BookablePayment[]): Promise<void> => {
+    let ok = 0;
+    for (const b of bookable) {
+      await recordPayment.mutateAsync({
+        invoiceId: b.invoiceId,
+        amount: b.amountOre,
+        paidAt: b.tx.valueDate ?? new Date().toISOString().slice(0, 10),
+        note: b.tx.debtorName ? `Betalfils-import — ${b.tx.debtorName}` : "Betalfils-import",
+        reference: b.reference,
+      });
+      ok += 1;
+    }
+    await utils.invoice.list.invalidate();
+    setDoneMsg(`${ok} betalning${ok === 1 ? "" : "ar"} bokförda.`);
+    setXml("");
+  };
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold text-gray-900 mb-2">Importera betalfil</h1>
+      <p className="text-sm text-gray-500 mb-6">
+        camt.054/053 (SEB/Bankgirot &quot;Kontohändelser via fil&quot;) — matchas mot OCR, fakturanummer eller fri text.
+      </p>
+      {doneMsg && <p className="mb-4 text-sm text-green-700 bg-green-50 rounded p-3">{doneMsg}</p>}
+      <FilePicker onXml={(s) => { setDoneMsg(null); setXml(s); }} xml={xml} />
+      {parsed.error && <p className="mt-4 text-sm text-red-700">Kunde inte läsa filen: {parsed.error}</p>}
+      {outcome && (
+        <ImportPreview outcome={outcome} labels={labels} busy={recordPayment.isPending} onBook={() => void book(outcome.bookable)} />
+      )}
+    </div>
+  );
+}
+
+function FilePicker({ onXml, xml }: { onXml: (s: string) => void; xml: string }) {
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6 space-y-3">
+      <label className="block text-sm font-medium text-gray-700">
+        Välj camt-fil (XML)
+        <input
+          type="file"
+          accept=".xml,text/xml"
+          className="block mt-2 text-sm"
+          onChange={(e) => {
+            const f = e.target.files?.[0];
+            if (f) void f.text().then(onXml);
+          }}
+        />
+      </label>
+      <details>
+        <summary className="text-xs text-gray-500 cursor-pointer">…eller klistra in filinnehållet</summary>
+        <textarea
+          aria-label="camt-XML"
+          className="mt-2 w-full h-32 border border-gray-200 rounded p-2 font-mono text-xs"
+          value={xml}
+          onChange={(e) => onXml(e.target.value)}
+        />
+      </details>
+    </div>
+  );
+}
+
+function ImportPreview({ outcome, labels, busy, onBook }: { outcome: MatchOutcome; labels: Record<string, string>; busy: boolean; onBook: () => void }) {
+  const sum = outcome.bookable.reduce((s, b) => s + b.amountOre, 0);
+  return (
+    <div className="mt-6 space-y-6">
+      <section className="bg-white rounded-lg border border-gray-200 p-6">
+        <h2 className="font-semibold text-gray-900 mb-3">Matchade betalningar ({outcome.bookable.length})</h2>
+        {outcome.bookable.length === 0 ? (
+          <p className="text-sm text-gray-500">Inga matchade betalningar i filen.</p>
+        ) : (
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs text-gray-500 border-b border-gray-200">
+                <th className="py-1.5 font-normal">Faktura</th>
+                <th className="py-1.5 font-normal">Matchad via</th>
+                <th className="py-1.5 font-normal">Betalare</th>
+                <th className="py-1.5 font-normal">Datum</th>
+                <th className="py-1.5 font-normal text-right">Belopp</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {outcome.bookable.map((b) => <BookableRow key={b.reference} b={b} label={labels[b.invoiceId] ?? b.invoiceId} />)}
+            </tbody>
+          </table>
+        )}
+        {outcome.bookable.length > 0 && (
+          <div className="mt-4 flex items-center justify-between">
+            <span className="text-sm text-gray-600">Summa: <span className="font-mono font-medium">{formatCurrency(sum)}</span></span>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={onBook}
+              className="bg-blue-600 text-white text-sm font-medium rounded px-4 py-2 hover:bg-blue-700 disabled:opacity-50"
+            >
+              {busy ? "Bokför…" : `Bokför ${outcome.bookable.length} betalningar`}
+            </button>
+          </div>
+        )}
+      </section>
+      {outcome.unmatched.length > 0 && (
+        <section className="bg-white rounded-lg border border-gray-200 p-6">
+          <h2 className="font-semibold text-gray-900 mb-3">Kräver granskning ({outcome.unmatched.length})</h2>
+          <ul className="space-y-1.5 text-sm">
+            {outcome.unmatched.map((u) => (
+              <li key={u.tx.reference} className="flex items-center justify-between">
+                <span className="text-gray-700">
+                  {u.tx.debtorName ?? "Okänd betalare"}
+                  <span className="ml-2 text-xs text-gray-400">{u.tx.freeTexts.join(" · ") || u.tx.structuredRefs.map((r) => r.ref).join(" · ")}</span>
+                </span>
+                <span className="flex items-center gap-3">
+                  <span className="font-mono">{formatCurrency(u.tx.amountOre)}</span>
+                  <span className="text-xs rounded-full px-2 py-0.5 bg-amber-100 text-amber-700">{REASON_LABEL[u.reason] ?? u.reason}</span>
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function BookableRow({ b, label }: { b: BookablePayment; label: string }) {
+  return (
+    <tr>
+      <td className="py-1.5">
+        <EntityLink route="invoices" id={b.invoiceId} className="text-blue-600 hover:underline font-mono text-xs">
+          {label}
+        </EntityLink>
+      </td>
+      <td className="py-1.5">
+        <span className="text-[10px] rounded-full px-2 py-0.5 font-medium bg-green-100 text-green-700">{MATCHED_BY_LABEL[b.matchedBy]}</span>
+      </td>
+      <td className="py-1.5 text-gray-600">{b.tx.debtorName ?? "—"}</td>
+      <td className="py-1.5 font-mono text-xs text-gray-500">{b.tx.valueDate ?? "—"}</td>
+      <td className="py-1.5 text-right font-mono">{formatCurrency(b.amountOre)}</td>
+    </tr>
+  );
+}

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -398,6 +398,8 @@ export const invoiceRouter = router({
         amount: z.number().int().min(1),
         paidAt: z.string(),
         note: z.string().optional(),
+        /** Extern betalningsreferens (camt-import #181) — för idempotent re-import. */
+        reference: z.string().optional(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -424,6 +426,7 @@ export const invoiceRouter = router({
             amount: input.amount,
             paidAt: new Date(input.paidAt),
             note: input.note,
+            reference: input.reference,
             recordedById: asId<"UserId">(ctx.user.id),
           },
         });

--- a/src/lib/shared/payments/camt-parse.ts
+++ b/src/lib/shared/payments/camt-parse.ts
@@ -1,0 +1,172 @@
+/**
+ * ISO 20022 camt-parser för betalfils-import (#181, jfr spike #164).
+ *
+ * Läser SEB:s/Bankgirots återrapportering av inkomna kundbetalningar:
+ *   - camt.054 (BkToCstmrDbtCdtNtfctn) — löpande debit/credit-aviseringar.
+ *   - camt.053 (BkToCstmrStmt) — kontoutdrag end-of-day.
+ *
+ * Struktur: `Ntry` (bokförd kontohändelse) → `NtryDtls` → `TxDtls[]` — en
+ * samlad insättning (t.ex. domstol som betalar flera kostnadsräkningar i en
+ * betalning) itemiseras av banken i flera `TxDtls`, var och en med eget
+ * belopp + egen remittance-info. Parsern MÅSTE därför iterera `TxDtls`, inte
+ * bara läsa entry-totalen (#175).
+ *
+ * Referenser per transaktion:
+ *   - STRUKTURERADE (`RmtInf/Strd`): OCR (`CdtrRefInf/Ref`) eller
+ *     dokumentnummer (`RfrdDocInf/Nb`), ofta med eget delbelopp
+ *     (`RfrdDocAmt/RmtdAmt`) — en TxDtls kan betala flera fakturor.
+ *   - FRI TEXT (`RmtInf/Ustrd`): målnummer/ärendereferens/fakturanr i
+ *     löptext (#175) + `EndToEndId`.
+ *
+ * Använder DOMParser (browser-nativ; happy-dom i bun-test). Parsern är pure:
+ * XML-sträng in → transaktioner ut. Ingen IO.
+ */
+
+export interface CamtStructuredRef {
+  /** Referensen (OCR eller fakturanr/dokumentnr), trimmad. */
+  ref: string;
+  /** Delbelopp i öre för just denna referens (RfrdDocAmt), eller null. */
+  amountOre: number | null;
+}
+
+export interface CamtTransaction {
+  /** Unik transaktionsreferens för idempotent import (AcctSvcrRef → EndToEndId → msgId:index). */
+  reference: string;
+  /** Transaktionsbelopp i öre (TxAmt, annars Ntry-beloppet). */
+  amountOre: number;
+  currency: string;
+  /** Valutadatum (YYYY-MM-DD) från Ntry/ValDt, eller null. */
+  valueDate: string | null;
+  /** Betalarens namn (RltdPties/Dbtr/Nm), eller null. */
+  debtorName: string | null;
+  /** CRDT = inbetalning (det vi prickar av). DBIT hoppas över i matchningen. */
+  creditDebit: "CRDT" | "DBIT";
+  structuredRefs: CamtStructuredRef[];
+  /** Ostrukturerad remittance-info (Ustrd-rader). */
+  freeTexts: string[];
+}
+
+export interface CamtFile {
+  messageId: string | null;
+  transactions: CamtTransaction[];
+}
+
+/** Direkta barn-element med givet tag-namn (getElementsByTagName är subtree-vid). */
+function children(el: Element, tag: string): Element[] {
+  return Array.from(el.children).filter((c) => c.tagName === tag);
+}
+
+/** Första matchande element längs en path av direkta barn. */
+function find(el: Element, ...path: string[]): Element | null {
+  let cur: Element | null = el;
+  for (const tag of path) {
+    cur = cur ? (children(cur, tag)[0] ?? null) : null;
+  }
+  return cur;
+}
+
+function text(el: Element | null): string | null {
+  const t = el?.textContent?.trim();
+  return t ? t : null;
+}
+
+/** "100.00" → 10000 öre. Kastar på icke-numeriskt (trasig fil ska synas, inte tystas). */
+function toOre(decimal: string): number {
+  const n = Number(decimal);
+  if (!Number.isFinite(n)) throw new Error(`Ogiltigt camt-belopp: "${decimal}"`);
+  return Math.round(n * 100);
+}
+
+/** Strukturerade referenser ur en TxDtls: alla Strd-block, OCR eller dokumentnr. */
+function structuredRefsOf(tx: Element): CamtStructuredRef[] {
+  const rmtInf = find(tx, "RmtInf");
+  if (!rmtInf) return [];
+  return children(rmtInf, "Strd").flatMap((strd) => {
+    const ref = text(find(strd, "CdtrRefInf", "Ref")) ?? text(find(strd, "RfrdDocInf", "Nb"));
+    if (!ref) return [];
+    const amt = text(find(strd, "RfrdDocAmt", "RmtdAmt"));
+    return [{ ref, amountOre: amt ? toOre(amt) : null }];
+  });
+}
+
+function freeTextsOf(tx: Element): string[] {
+  const rmtInf = find(tx, "RmtInf");
+  if (!rmtInf) return [];
+  return children(rmtInf, "Ustrd")
+    .map((u) => u.textContent?.trim() ?? "")
+    .filter((s) => s !== "");
+}
+
+interface EntryContext {
+  amountOre: number;
+  currency: string;
+  valueDate: string | null;
+  creditDebit: "CRDT" | "DBIT";
+  messageId: string | null;
+  index: () => number;
+}
+
+/** En TxDtls (eller Ntry utan detaljer) → CamtTransaction. */
+function toTransaction(tx: Element, entry: EntryContext): CamtTransaction {
+  const txAmt = text(find(tx, "AmtDtls", "TxAmt", "Amt"));
+  const txCcy = find(tx, "AmtDtls", "TxAmt", "Amt")?.getAttribute("Ccy");
+  const cdtDbt = text(find(tx, "CdtDbtInd")) as "CRDT" | "DBIT" | null;
+  const reference =
+    text(find(tx, "Refs", "AcctSvcrRef")) ??
+    text(find(tx, "Refs", "EndToEndId")) ??
+    `${entry.messageId ?? "camt"}:${entry.index()}`;
+  return {
+    reference,
+    amountOre: txAmt ? toOre(txAmt) : entry.amountOre,
+    currency: txCcy ?? entry.currency,
+    valueDate: entry.valueDate,
+    debtorName: text(find(tx, "RltdPties", "Dbtr", "Nm")),
+    creditDebit: cdtDbt ?? entry.creditDebit,
+    structuredRefs: structuredRefsOf(tx),
+    freeTexts: freeTextsOf(tx),
+  };
+}
+
+function entryContextOf(ntry: Element, messageId: string | null, index: () => number): EntryContext {
+  const amtEl = children(ntry, "Amt")[0] ?? null;
+  return {
+    amountOre: toOre(text(amtEl) ?? "0"),
+    currency: amtEl?.getAttribute("Ccy") ?? "SEK",
+    valueDate: text(find(ntry, "ValDt", "Dt")),
+    creditDebit: (text(find(ntry, "CdtDbtInd")) as "CRDT" | "DBIT" | null) ?? "CRDT",
+    messageId,
+    index,
+  };
+}
+
+/** Alla transaktioner i en Ntry: en per TxDtls, eller Ntry:n själv utan detaljer. */
+function transactionsOfEntry(ntry: Element, entry: EntryContext): CamtTransaction[] {
+  const txDtls = children(ntry, "NtryDtls").flatMap((d) => children(d, "TxDtls"));
+  if (txDtls.length === 0) return [toTransaction(ntry, entry)];
+  return txDtls.map((tx) => toTransaction(tx, entry));
+}
+
+/**
+ * Parsa en camt.053/054-fil. Kastar på XML som inte alls är camt
+ * (saknar Ntry-bärande rot); en fil utan transaktioner ger tom lista.
+ */
+export function parseCamtXml(xml: string): CamtFile {
+  const doc = new DOMParser().parseFromString(xml, "text/xml");
+  const root = doc.documentElement;
+  if (!root || root.tagName !== "Document") throw new Error("Inte en camt-fil (Document-rot saknas).");
+  const msg = children(root, "BkToCstmrDbtCdtNtfctn")[0] ?? children(root, "BkToCstmrStmt")[0];
+  if (!msg) throw new Error("Inte en camt.053/054-fil (BkToCstmrDbtCdtNtfctn/BkToCstmrStmt saknas).");
+
+  const messageId = text(find(msg, "GrpHdr", "MsgId"));
+  let counter = 0;
+  const index = (): number => ++counter;
+  const transactions: CamtTransaction[] = [];
+
+  // Ntfctn (054) eller Stmt (053) — kan vara flera (paginering).
+  for (const container of [...children(msg, "Ntfctn"), ...children(msg, "Stmt")]) {
+    for (const ntry of children(container, "Ntry")) {
+      transactions.push(...transactionsOfEntry(ntry, entryContextOf(ntry, messageId, index)));
+    }
+  }
+  return { messageId, transactions };
+}

--- a/src/lib/shared/payments/match-payments.ts
+++ b/src/lib/shared/payments/match-payments.ts
@@ -1,0 +1,189 @@
+/**
+ * Matchningsmotor för betalfils-import (#181): camt-transaktioner →
+ * bokningsbara betalningar mot AVA-fakturor.
+ *
+ * FLEXIBEL KASKAD (en faktura betalas inte alltid med OCR):
+ *   1. Strukturerade referenser (Strd): OCR (#182) ELLER fakturanummer —
+ *      kunden anger ibland fakturanumret som referens i stället för OCR.
+ *      En TxDtls kan bära FLERA Strd med egna delbelopp (RfrdDocAmt) →
+ *      varje referens blir en egen bokningsbar betalning (samlad betalning
+ *      som täcker flera fakturor, t.ex. domstol → flera kostnadsräkningar).
+ *   2. Fri text (Ustrd): fakturanummer/referens i löptext — normaliseras
+ *      och matchas tokenvis (#175 fri-text-fallet växer härifrån).
+ *   3. Belopp används ALDRIG som primär nyckel (delbetalning/prutning gör
+ *      belopp opålitligt) — bara referens-träffar bokas.
+ *   4. Tvetydigt (flera fakturor träffar) eller ingen träff → granskning,
+ *      aldrig auto-match på osäker grund.
+ *
+ * Idempotens: varje bokad betalning bär en deterministisk referens
+ * (txRef, eller `txRef#n` för delposter). Transaktioner vars referens redan
+ * finns bland fakturornas betalningar flaggas som dubbletter och bokas inte.
+ */
+
+import type { CamtTransaction } from "./camt-parse";
+
+export interface InvoiceCandidate {
+  id: string;
+  invoiceNumber: string | null;
+  ocrReference: string | null;
+  /** Fakturabelopp i öre (visning/rimlighetskoll — inte matchningsnyckel). */
+  amount: number;
+  /** Referenser på redan bokförda betalningar (Payment.reference) — dubblettskydd. */
+  paymentReferences: readonly string[];
+}
+
+/** En bokningsbar betalning (en transaktion kan ge flera vid delbelopp). */
+export interface BookablePayment {
+  invoiceId: string;
+  amountOre: number;
+  /** Deterministisk referens för idempotens (txRef eller txRef#n). */
+  reference: string;
+  matchedBy: "ocr" | "invoiceNumber" | "freetext";
+  tx: CamtTransaction;
+}
+
+export interface UnmatchedTransaction {
+  tx: CamtTransaction;
+  reason: "ingen-träff" | "tvetydig" | "dubblett" | "debet";
+  /** Vid "tvetydig": de fakturor som träffades. */
+  candidateInvoiceIds?: string[];
+}
+
+export interface MatchOutcome {
+  bookable: BookablePayment[];
+  unmatched: UnmatchedTransaction[];
+}
+
+/** Normalisera en referens-token: versaler, bara A-Z0-9. */
+export function normalizeRef(raw: string): string {
+  return raw.toUpperCase().replace(/[^A-Z0-9]/g, "");
+}
+
+type RefIndex = Map<string, { invoiceId: string; matchedBy: "ocr" | "invoiceNumber" }>;
+
+/** Index: normaliserad nyckel → faktura. OCR + fakturanr (med och utan F-prefix). */
+function buildRefIndex(invoices: readonly InvoiceCandidate[]): RefIndex {
+  const index: RefIndex = new Map();
+  for (const inv of invoices) {
+    if (inv.ocrReference) index.set(normalizeRef(inv.ocrReference), { invoiceId: inv.id, matchedBy: "ocr" });
+    if (inv.invoiceNumber) {
+      const norm = normalizeRef(inv.invoiceNumber);
+      index.set(norm, { invoiceId: inv.id, matchedBy: "invoiceNumber" });
+      const digits = inv.invoiceNumber.replace(/\D/g, "");
+      // Siffervarianten (20260001) får inte skugga en annan fakturas nyckel.
+      if (digits && !index.has(digits)) index.set(digits, { invoiceId: inv.id, matchedBy: "invoiceNumber" });
+    }
+  }
+  return index;
+}
+
+/** Slå upp en rå referens i indexet (normaliserad + siffervariant). */
+function lookup(index: RefIndex, raw: string): { invoiceId: string; matchedBy: "ocr" | "invoiceNumber" } | null {
+  const norm = normalizeRef(raw);
+  if (norm === "") return null;
+  const hit = index.get(norm) ?? index.get(norm.replace(/\D/g, ""));
+  return hit ?? null;
+}
+
+/** Kandidat-tokens ur fri text: hela raden + ord/nummer-sekvenser. */
+function freeTextTokens(texts: readonly string[]): string[] {
+  return texts.flatMap((t) => [t, ...(t.match(/[A-Za-z]?[\d][\d\- ]*\d|\d+/g) ?? [])]);
+}
+
+interface StructuredOutcome {
+  payments?: BookablePayment[];
+  ambiguousInvoiceIds?: string[];
+}
+
+/** Matcha en transaktions strukturerade referenser → bokningsbara delposter. */
+function matchStructured(tx: CamtTransaction, index: RefIndex): StructuredOutcome | null {
+  const hits: Array<{ sr: CamtTransaction["structuredRefs"][number]; hit: NonNullable<ReturnType<typeof lookup>> }> = [];
+  for (const sr of tx.structuredRefs) {
+    const hit = lookup(index, sr.ref);
+    if (hit) hits.push({ sr, hit });
+  }
+  if (hits.length === 0) return null;
+  // En ensam träff utan delbelopp tar hela transaktionsbeloppet.
+  if (hits.length === 1) {
+    const first = hits[0] as (typeof hits)[number];
+    const payment: BookablePayment = {
+      invoiceId: first.hit.invoiceId,
+      amountOre: first.sr.amountOre ?? tx.amountOre,
+      reference: tx.reference,
+      matchedBy: first.hit.matchedBy,
+      tx,
+    };
+    return { payments: [payment] };
+  }
+  // Flera träffar: kräver delbelopp per referens (RfrdDocAmt) för att kunna
+  // allokera — annars granskning, vi gissar aldrig fördelningen.
+  if (hits.some((h) => h.sr.amountOre === null)) {
+    return { ambiguousInvoiceIds: [...new Set(hits.map((h) => h.hit.invoiceId))] };
+  }
+  return {
+    payments: hits.map(({ sr, hit }, i) => ({
+      invoiceId: hit.invoiceId,
+      amountOre: sr.amountOre as number,
+      reference: `${tx.reference}#${i + 1}`,
+      matchedBy: hit.matchedBy,
+      tx,
+    })),
+  };
+}
+
+/** Matcha fri text: exakt EN unik faktura-träff krävs, annars null/tvetydig. */
+function matchFreeText(tx: CamtTransaction, index: RefIndex): { single?: BookablePayment; ambiguous?: string[] } {
+  const hits = new Map<string, "ocr" | "invoiceNumber">();
+  for (const token of freeTextTokens(tx.freeTexts)) {
+    const hit = lookup(index, token);
+    if (hit) hits.set(hit.invoiceId, hit.matchedBy);
+  }
+  if (hits.size === 0) return {};
+  if (hits.size > 1) return { ambiguous: [...hits.keys()] };
+  const [invoiceId] = [...hits.keys()] as [string];
+  return { single: { invoiceId, amountOre: tx.amountOre, reference: tx.reference, matchedBy: "freetext", tx } };
+}
+
+type OneOutcome = { payments: BookablePayment[] } | { skip: UnmatchedTransaction };
+
+/** Fri-text-benet av kaskaden (sist): exakt en träff bokar, annars granskning. */
+function freeTextOutcome(tx: CamtTransaction, index: RefIndex): OneOutcome {
+  const free = matchFreeText(tx, index);
+  if (free.single) return { payments: [free.single] };
+  if (free.ambiguous) return { skip: { tx, reason: "tvetydig", candidateInvoiceIds: free.ambiguous } };
+  return { skip: { tx, reason: "ingen-träff" } };
+}
+
+/** Kaskaden för EN transaktion: debet/dubblett → strukturerat → fri text. */
+function matchOne(tx: CamtTransaction, index: RefIndex, imported: ReadonlySet<string>): OneOutcome {
+  if (tx.creditDebit !== "CRDT") return { skip: { tx, reason: "debet" } };
+  if (imported.has(tx.reference) || imported.has(`${tx.reference}#1`)) {
+    return { skip: { tx, reason: "dubblett" } };
+  }
+  const structured = matchStructured(tx, index);
+  if (structured?.payments) return { payments: structured.payments };
+  if (structured?.ambiguousInvoiceIds) {
+    return { skip: { tx, reason: "tvetydig", candidateInvoiceIds: structured.ambiguousInvoiceIds } };
+  }
+  return freeTextOutcome(tx, index);
+}
+
+/**
+ * Matcha camt-transaktioner mot faktura-kandidater. Bara CRDT (inbetalningar)
+ * bokas; redan importerade (referens finns på en Payment) blir dubbletter.
+ */
+export function matchTransactions(
+  transactions: readonly CamtTransaction[],
+  invoices: readonly InvoiceCandidate[],
+): MatchOutcome {
+  const index = buildRefIndex(invoices);
+  const imported = new Set(invoices.flatMap((i) => i.paymentReferences));
+  const bookable: BookablePayment[] = [];
+  const unmatched: UnmatchedTransaction[] = [];
+  for (const tx of transactions) {
+    const outcome = matchOne(tx, index, imported);
+    if ("payments" in outcome) bookable.push(...outcome.payments);
+    else unmatched.push(outcome.skip);
+  }
+  return { bookable, unmatched };
+}

--- a/src/lib/shared/schemas/billing.ts
+++ b/src/lib/shared/schemas/billing.ts
@@ -132,6 +132,9 @@ export const paymentSchema = z.object({
   amount: z.number().int(),
   paidAt: dateLike,
   note: z.string().nullish(),
+  /** Extern betalningsreferens (camt AcctSvcrRef m.m., #181) — idempotent
+   *  betalfils-import: samma fil omladdad bokför inte om samma betalning. */
+  reference: z.string().nullish(),
   recordedById: userIdSchema,
   createdAt: dateLike,
 }).passthrough();

--- a/test/unit/app/payments/import-page.test.tsx
+++ b/test/unit/app/payments/import-page.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Test för betalfils-importsidan (#181): klistra in camt-XML → förhandsvisning
+ * (matchad + granskning) → "Bokför" anropar recordPayment med referens
+ * (idempotens) och rätt belopp/datum.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest-compat";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+import { buildOcrReference } from "@/lib/shared/ocr-reference";
+
+const OCR = buildOcrReference("20260001");
+
+const mutateAsync = vi.fn().mockResolvedValue({});
+const invalidate = vi.fn();
+const invoiceList = {
+  data: [
+    {
+      id: "inv-1", invoiceNumber: "F-2026-0001", ocrReference: OCR,
+      amount: 10_000, payments: [],
+      matter: { id: "m1", matterNumber: "2026-0001", title: "T" },
+    },
+  ],
+  isLoading: false,
+};
+
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: {
+    useUtils: () => ({ invoice: { list: { invalidate } } }),
+    invoice: {
+      list: { useQuery: () => invoiceList },
+      recordPayment: { useMutation: () => ({ mutateAsync, isPending: false }) },
+    },
+  },
+}));
+
+import PaymentImportPage from "@/app/payments/import/page";
+
+/** Minimal camt.054: en CRDT-Ntry med en TxDtls som bär OCR:en + en omatchbar. */
+const CAMT = `<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.054.001.02">
+  <BkToCstmrDbtCdtNtfctn>
+    <GrpHdr><MsgId>MSG1</MsgId></GrpHdr>
+    <Ntfctn>
+      <Ntry>
+        <Amt Ccy="SEK">100.00</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <ValDt><Dt>2026-06-01</Dt></ValDt>
+        <NtryDtls>
+          <TxDtls>
+            <Refs><AcctSvcrRef>REF-A</AcctSvcrRef></Refs>
+            <AmtDtls><TxAmt><Amt Ccy="SEK">100.00</Amt></TxAmt></AmtDtls>
+            <RltdPties><Dbtr><Nm>Klient AB</Nm></Dbtr></RltdPties>
+            <RmtInf><Strd><CdtrRefInf><Ref>${OCR}</Ref></CdtrRefInf></Strd></RmtInf>
+          </TxDtls>
+        </NtryDtls>
+      </Ntry>
+      <Ntry>
+        <Amt Ccy="SEK">55.00</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <ValDt><Dt>2026-06-02</Dt></ValDt>
+        <NtryDtls>
+          <TxDtls>
+            <Refs><AcctSvcrRef>REF-B</AcctSvcrRef></Refs>
+            <AmtDtls><TxAmt><Amt Ccy="SEK">55.00</Amt></TxAmt></AmtDtls>
+            <RltdPties><Dbtr><Nm>Domstolsverket</Nm></Dbtr></RltdPties>
+            <RmtInf><Ustrd>T 1234-26</Ustrd></RmtInf>
+          </TxDtls>
+        </NtryDtls>
+      </Ntry>
+    </Ntfctn>
+  </BkToCstmrDbtCdtNtfctn>
+</Document>`;
+
+beforeEach(() => {
+  mutateAsync.mockClear();
+  invalidate.mockClear();
+});
+
+describe("PaymentImportPage (#181)", () => {
+  it("tom start: rubrik + filväljare, ingen förhandsvisning", () => {
+    render(<PaymentImportPage />);
+    expect(screen.getByText("Importera betalfil")).toBeInTheDocument();
+    expect(screen.queryByText(/Matchade betalningar/)).not.toBeInTheDocument();
+  });
+
+  it("inklistrad camt → matchad rad (OCR) + granskningsrad (fri text utan träff)", () => {
+    render(<PaymentImportPage />);
+    fireEvent.change(screen.getByLabelText("camt-XML"), { target: { value: CAMT } });
+
+    expect(screen.getByText("Matchade betalningar (1)")).toBeInTheDocument();
+    expect(screen.getByText("F-2026-0001")).toBeInTheDocument();
+    expect(screen.getByText("OCR")).toBeInTheDocument();
+    expect(screen.getByText("Kräver granskning (1)")).toBeInTheDocument();
+    expect(screen.getByText("Domstolsverket")).toBeInTheDocument();
+    expect(screen.getByText("Ingen träff — koppla manuellt")).toBeInTheDocument();
+  });
+
+  it("Bokför → recordPayment med referens, belopp och valutadatum + invalidate", async () => {
+    render(<PaymentImportPage />);
+    fireEvent.change(screen.getByLabelText("camt-XML"), { target: { value: CAMT } });
+    fireEvent.click(screen.getByRole("button", { name: /Bokför 1 betalningar/ }));
+
+    await waitFor(() => expect(screen.getByText(/bokförda\./)).toBeInTheDocument());
+    expect(mutateAsync).toHaveBeenCalledTimes(1);
+    expect(mutateAsync).toHaveBeenCalledWith({
+      invoiceId: "inv-1",
+      amount: 10_000,
+      paidAt: "2026-06-01",
+      note: "Betalfils-import — Klient AB",
+      reference: "REF-A",
+    });
+    expect(invalidate).toHaveBeenCalled();
+  });
+
+  it("ogiltig XML → felmeddelande, inget bokfört", () => {
+    render(<PaymentImportPage />);
+    fireEvent.change(screen.getByLabelText("camt-XML"), { target: { value: "<foo/>" } });
+    expect(screen.getByText(/Kunde inte läsa filen/)).toBeInTheDocument();
+    expect(mutateAsync).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/lib/payments/camt-parse.test.ts
+++ b/test/unit/lib/payments/camt-parse.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Test för camt-parsern (#181) — körs mot SEB:s riktiga exempel-filer
+ * (test/fixtures/camt-seb, #176).
+ *
+ * Nyckelfall:
+ *   - camt.054 BGC: en Ntry (200 kr) → 2 TxDtls à 100 kr; den andra TxDtls
+ *     bär TVÅ Strd-referenser med egna delbelopp (50+50) — en betalning som
+ *     täcker två fakturor (domstols-scenariot i #175).
+ *   - camt.053 BGC: samlad insättning 91 838 kr → 6 TxDtls vars summa stämmer.
+ *   - camt.054 SE: fri-text-referenser (Ustrd), inga strukturerade.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { parseCamtXml } from "@/lib/shared/payments/camt-parse";
+
+const FIXTURES = resolve(__dirname, "../../../fixtures/camt-seb");
+const read = (f: string): string => readFileSync(resolve(FIXTURES, f), "utf8");
+
+describe("parseCamtXml — camt.054 BGC (strukturerade referenser)", () => {
+  const file = parseCamtXml(read("camt.054_SE_CRED_BGC.xml"));
+
+  it("itererar TxDtls, inte bara Ntry (1 Ntry → 2 transaktioner)", () => {
+    expect(file.transactions).toHaveLength(2);
+    expect(file.transactions.every((t) => t.creditDebit === "CRDT")).toBe(true);
+    expect(file.transactions.every((t) => t.amountOre === 100_00)).toBe(true);
+  });
+
+  it("transaktion 1: en strukturerad referens (dokumentnr) med delbelopp", () => {
+    const [t1] = file.transactions;
+    expect(t1?.reference).toBe("STOIIQ0I220505085240644513000001"); // AcctSvcrRef
+    expect(t1?.debtorName).toBe("Debtor");
+    expect(t1?.structuredRefs).toEqual([{ ref: "98547", amountOre: 100_00 }]);
+  });
+
+  it("transaktion 2: TVÅ Strd-referenser med egna delbelopp (50+50)", () => {
+    const t2 = file.transactions[1];
+    expect(t2?.structuredRefs).toHaveLength(2);
+    expect(t2?.structuredRefs.every((r) => r.amountOre === 50_00)).toBe(true);
+    const sum = (t2?.structuredRefs ?? []).reduce((s, r) => s + (r.amountOre ?? 0), 0);
+    expect(sum).toBe(t2?.amountOre);
+  });
+});
+
+describe("parseCamtXml — camt.053 BGC (samlad insättning)", () => {
+  it("en Ntry på 91 838 kr → 6 TxDtls vars belopp summerar exakt", () => {
+    const file = parseCamtXml(read("camt.053_SE_BGC_Credit.xml"));
+    expect(file.transactions).toHaveLength(6);
+    const sum = file.transactions.reduce((s, t) => s + t.amountOre, 0);
+    expect(sum).toBe(91_838_00);
+    // Alla bär minst en strukturerad referens.
+    expect(file.transactions.every((t) => t.structuredRefs.length > 0)).toBe(true);
+  });
+});
+
+describe("parseCamtXml — camt.054 SE (fri text)", () => {
+  const file = parseCamtXml(read("camt.054_SE.xml"));
+
+  it("plockar Ustrd som freeTexts (inga strukturerade referenser)", () => {
+    const withFree = file.transactions.filter((t) => t.freeTexts.length > 0);
+    expect(withFree.length).toBeGreaterThan(0);
+    expect(file.transactions.every((t) => t.structuredRefs.length === 0)).toBe(true);
+  });
+
+  it("känd transaktion: 157 145 SEK med Ustrd '3071358' och valutadatum", () => {
+    const tx = file.transactions.find((t) => t.freeTexts.includes("3071358"));
+    expect(tx).toBeDefined();
+    expect(tx?.amountOre).toBe(157_145_00);
+    expect(tx?.currency).toBe("SEK");
+    expect(tx?.valueDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("transaktionsreferenser är unika (idempotens-nyckeln)", () => {
+    const refs = file.transactions.map((t) => t.reference);
+    expect(new Set(refs).size).toBe(refs.length);
+  });
+});
+
+describe("parseCamtXml — felfall", () => {
+  it("kastar på icke-camt-XML", () => {
+    expect(() => parseCamtXml("<foo/>")).toThrow(/camt/);
+    expect(() => parseCamtXml("<Document><Other/></Document>")).toThrow(/camt\.053\/054/);
+  });
+});

--- a/test/unit/lib/payments/match-payments.test.ts
+++ b/test/unit/lib/payments/match-payments.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Test för matchningsmotorn (#181) — den flexibla kaskaden:
+ * OCR → fakturanummer (strukturerat ELLER fri text) → granskning.
+ * Inkl. delbelopps-allokering (flera Strd), dubblettskydd och debet-skip.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+
+import { buildOcrReference } from "@/lib/shared/ocr-reference";
+import type { CamtTransaction } from "@/lib/shared/payments/camt-parse";
+import {
+  matchTransactions,
+  normalizeRef,
+  type InvoiceCandidate,
+} from "@/lib/shared/payments/match-payments";
+
+const OCR_1 = buildOcrReference("20260001");
+const OCR_2 = buildOcrReference("20260002");
+
+const INVOICES: InvoiceCandidate[] = [
+  { id: "inv-1", invoiceNumber: "F-2026-0001", ocrReference: OCR_1, amount: 100_000, paymentReferences: [] },
+  { id: "inv-2", invoiceNumber: "F-2026-0002", ocrReference: OCR_2, amount: 50_000, paymentReferences: [] },
+  // Kostnadsräkning till domstol: varken OCR eller fakturanummer (#173).
+  { id: "inv-court", invoiceNumber: null, ocrReference: null, amount: 75_000, paymentReferences: [] },
+];
+
+function tx(over: Partial<CamtTransaction>): CamtTransaction {
+  return {
+    reference: "TX-1",
+    amountOre: 100_000,
+    currency: "SEK",
+    valueDate: "2026-06-01",
+    debtorName: "Klient AB",
+    creditDebit: "CRDT",
+    structuredRefs: [],
+    freeTexts: [],
+    ...over,
+  };
+}
+
+describe("normalizeRef", () => {
+  it("versaler + bara alfanumeriskt", () => {
+    expect(normalizeRef(" f-2026-0001 ")).toBe("F20260001");
+    expect(normalizeRef("2026 0001")).toBe("20260001");
+  });
+});
+
+describe("matchTransactions — kaskaden", () => {
+  it("1. OCR i Strd → match", () => {
+    const out = matchTransactions([tx({ structuredRefs: [{ ref: OCR_1, amountOre: null }] })], INVOICES);
+    expect(out.bookable).toEqual([
+      expect.objectContaining({ invoiceId: "inv-1", amountOre: 100_000, matchedBy: "ocr", reference: "TX-1" }),
+    ]);
+  });
+
+  it("2. fakturanummer i Strd (kunden anger fakturanr i stället för OCR)", () => {
+    const out = matchTransactions([tx({ structuredRefs: [{ ref: "F-2026-0002", amountOre: null }] })], INVOICES);
+    expect(out.bookable[0]).toMatchObject({ invoiceId: "inv-2", matchedBy: "invoiceNumber" });
+  });
+
+  it("3. fakturanummer i FRI TEXT, olika skrivsätt", () => {
+    for (const skrivet of ["F-2026-0001", "F20260001", "Betalning F-2026-0001 tack", "fakt 20260001"]) {
+      const out = matchTransactions([tx({ freeTexts: [skrivet] })], INVOICES);
+      expect(out.bookable[0]?.invoiceId, `"${skrivet}"`).toBe("inv-1");
+      expect(out.bookable[0]?.matchedBy).toBe("freetext");
+    }
+  });
+
+  it("4. samlad betalning: två Strd med delbelopp → två bokningsbara delposter", () => {
+    const out = matchTransactions(
+      [tx({
+        amountOre: 150_000,
+        structuredRefs: [
+          { ref: OCR_1, amountOre: 100_000 },
+          { ref: "F-2026-0002", amountOre: 50_000 },
+        ],
+      })],
+      INVOICES,
+    );
+    expect(out.bookable).toHaveLength(2);
+    expect(out.bookable[0]).toMatchObject({ invoiceId: "inv-1", amountOre: 100_000, reference: "TX-1#1" });
+    expect(out.bookable[1]).toMatchObject({ invoiceId: "inv-2", amountOre: 50_000, reference: "TX-1#2" });
+  });
+
+  it("5. flera Strd UTAN delbelopp → granskning (gissar aldrig fördelningen)", () => {
+    const out = matchTransactions(
+      [tx({ structuredRefs: [{ ref: OCR_1, amountOre: null }, { ref: OCR_2, amountOre: null }] })],
+      INVOICES,
+    );
+    expect(out.bookable).toHaveLength(0);
+    expect(out.unmatched[0]).toMatchObject({ reason: "tvetydig", candidateInvoiceIds: ["inv-1", "inv-2"] });
+  });
+
+  it("6. tvetydig fri text (två fakturanummer i samma Ustrd) → granskning", () => {
+    const out = matchTransactions([tx({ freeTexts: ["F-2026-0001 och F-2026-0002"] })], INVOICES);
+    expect(out.bookable).toHaveLength(0);
+    expect(out.unmatched[0]?.reason).toBe("tvetydig");
+  });
+
+  it("7. ingen träff → granskning (belopp är ALDRIG matchningsnyckel)", () => {
+    // Beloppet råkar exakt matcha inv-court — men utan referens bokas inget.
+    const out = matchTransactions([tx({ amountOre: 75_000, freeTexts: ["T 1234-26"] })], INVOICES);
+    expect(out.bookable).toHaveLength(0);
+    expect(out.unmatched[0]?.reason).toBe("ingen-träff");
+  });
+
+  it("8. dubblett: referensen redan bokförd → bokas inte om", () => {
+    const invoices: InvoiceCandidate[] = [
+      { ...(INVOICES[0] as InvoiceCandidate), paymentReferences: ["TX-1"] },
+    ];
+    const out = matchTransactions([tx({ structuredRefs: [{ ref: OCR_1, amountOre: null }] })], invoices);
+    expect(out.bookable).toHaveLength(0);
+    expect(out.unmatched[0]?.reason).toBe("dubblett");
+  });
+
+  it("9. delpost-dubblett (#1-referens) fångas också", () => {
+    const invoices: InvoiceCandidate[] = [
+      { ...(INVOICES[0] as InvoiceCandidate), paymentReferences: ["TX-1#1"] },
+      INVOICES[1] as InvoiceCandidate,
+    ];
+    const out = matchTransactions(
+      [tx({ structuredRefs: [{ ref: OCR_1, amountOre: 50_000 }, { ref: OCR_2, amountOre: 50_000 }] })],
+      invoices,
+    );
+    expect(out.unmatched[0]?.reason).toBe("dubblett");
+  });
+
+  it("10. DBIT hoppas över (ej inbetalning)", () => {
+    const out = matchTransactions([tx({ creditDebit: "DBIT", structuredRefs: [{ ref: OCR_1, amountOre: null }] })], INVOICES);
+    expect(out.bookable).toHaveLength(0);
+    expect(out.unmatched[0]?.reason).toBe("debet");
+  });
+});

--- a/test/unit/server/routers/invoice.test.ts
+++ b/test/unit/server/routers/invoice.test.ts
@@ -761,3 +761,23 @@ describe("OCR-referens på kundfakturor (#182)", () => {
     expect(data.ocrReference).toBeUndefined();
   });
 });
+
+// ─── recordPayment: extern referens (#181) ───────────────────────
+
+describe("recordPayment med extern referens (#181)", () => {
+  it("referensen lagras på betalningen (idempotent betalfils-import)", async () => {
+    mockPrisma.invoice.findFirst.mockResolvedValue({
+      id: "inv-1", amount: 1000, status: "SENT", paymentPlan: null, payments: [],
+    });
+    mockPrisma.payment.create.mockResolvedValue({ id: "pay-1" });
+    mockPrisma.invoice.update.mockResolvedValue({});
+
+    await makeCaller().recordPayment({
+      invoiceId: "inv-1", amount: 1000, paidAt: "2026-06-01", reference: "REF-A",
+    });
+
+    expect(mockPrisma.payment.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ reference: "REF-A" }) }),
+    );
+  });
+});


### PR DESCRIPTION
Closes #181.

Kärnfunktionen från spike #164: läs in en **camt.054/053-fil** (SEB/Bankgirot "Kontohändelser via fil") och pricka av inbetalningar mot AVA-fakturor — med den **flexibla matchningskaskaden** (en faktura betalas inte alltid med OCR).

## Moduler (pure, i `src/lib/shared/payments/`)
- **`camt-parse.ts`** (DOMParser): itererar `Ntry → NtryDtls → TxDtls[]` — en samlad insättning (domstol → flera kostnadsräkningar) itemiseras per post. Läser strukturerade referenser (`CdtrRefInf/Ref` = OCR och `RfrdDocInf/Nb` = dokumentnr) **med delbelopp** (`RfrdDocAmt`), fri text (`Ustrd`), betalare, valutadatum, CRDT/DBIT, unik transaktionsreferens (`AcctSvcrRef`).
- **`match-payments.ts`**: kaskaden **OCR (#182) → fakturanummer (strukturerat ELLER fri text, normaliserat: `F-2026-0001`/`F20260001`/`20260001`) → granskning**. En TxDtls med flera Strd + delbelopp bokas som flera delposter (`txRef#n`); utan delbelopp → granskning (gissar aldrig fördelningen). **Belopp är aldrig matchningsnyckel** (delbetalning/prutning). Tvetydigt → granskning.

## Idempotent re-import
`paymentSchema` får additivt `reference`-fält (ADR 0004, ingen versionsbump); `recordPayment` tar/lagrar referensen. Samma fil omladdad → dubbletter flaggas, inget dubbelbokförs.

## UI
`/payments/import` (länkad från fakturalistan): filuppladdning + klistra-in-fallback → förhandsgranskning (matchade med via-badge: OCR/Fakturanr/Fri text; granskningslista med orsak: ingen träff/tvetydig/dubblett/debet) → "Bokför N betalningar" → `recordPayment` per rad (ADR 0007-partitionen validerar varje bokning).

## Test (testat mot SEB:s riktiga exempelfiler, #176)
- Parser: BGC-054 (1 Ntry → 2 TxDtls; dubbla Strd 50+50 = tx-beloppet), BGC-053 (6 TxDtls = 91 838,00 kr exakt), SE-054 (Ustrd fri text, unika referenser), felfall.
- Matchare: kaskadens 10 fall (OCR, fakturanr i Strd, fakturanr i fri text i 4 skrivsätt, delbelopps-allokering, o-allokerbar multi-Strd, tvetydig, ingen träff trots exakt belopp, dubblett, delpost-dubblett, DBIT).
- Sida: klistra in → förhandsvisa → bokför (referens/belopp/valutadatum) + ogiltig XML.
- Router: referensen lagras på betalningen.

## Verifiering
`bun run test:all` grönt (static + unit/coverage + e2e round-trip, 306s). En orelaterad git-contention-flake i första körningen (känd familj #112/#116), grön isolerat + i omkörning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)