### PR TITLE
refactor(payments): camt-parsern validerar med zod vid parsegränsen (#185)

### DIFF
--- a/src/lib/shared/payments/camt-parse.ts
+++ b/src/lib/shared/payments/camt-parse.ts
@@ -20,36 +20,49 @@
  *
  * Använder DOMParser (browser-nativ; happy-dom i bun-test). Parsern är pure:
  * XML-sträng in → transaktioner ut. Ingen IO.
+ *
+ * STRIKTA DATATYPER: utdatat valideras med zod vid parsegränsen
+ * (`camtFileSchema.parse`) — trasig/oväntad fildata failar högt här i stället
+ * för att propagera in i matchning/bokföring. Typerna är z.infer-härledda.
  */
 
-export interface CamtStructuredRef {
+import { z } from "zod";
+
+export const camtStructuredRefSchema = z.object({
   /** Referensen (OCR eller fakturanr/dokumentnr), trimmad. */
-  ref: string;
+  ref: z.string().min(1),
   /** Delbelopp i öre för just denna referens (RfrdDocAmt), eller null. */
-  amountOre: number | null;
-}
+  amountOre: z.number().int().nullable(),
+});
 
-export interface CamtTransaction {
+export type CamtStructuredRef = z.infer<typeof camtStructuredRefSchema>;
+
+export const camtTransactionSchema = z.object({
   /** Unik transaktionsreferens för idempotent import (AcctSvcrRef → EndToEndId → msgId:index). */
-  reference: string;
+  reference: z.string().min(1),
   /** Transaktionsbelopp i öre (TxAmt, annars Ntry-beloppet). */
-  amountOre: number;
-  currency: string;
-  /** Valutadatum (YYYY-MM-DD) från Ntry/ValDt, eller null. */
-  valueDate: string | null;
+  amountOre: z.number().int(),
+  /** ISO 4217-valutakod (SEK, EUR, …). */
+  currency: z.string().regex(/^[A-Z]{3}$/),
+  /** Valutadatum från Ntry/ValDt, eller null. */
+  valueDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).nullable(),
   /** Betalarens namn (RltdPties/Dbtr/Nm), eller null. */
-  debtorName: string | null;
+  debtorName: z.string().min(1).nullable(),
   /** CRDT = inbetalning (det vi prickar av). DBIT hoppas över i matchningen. */
-  creditDebit: "CRDT" | "DBIT";
-  structuredRefs: CamtStructuredRef[];
+  creditDebit: z.enum(["CRDT", "DBIT"]),
+  structuredRefs: z.array(camtStructuredRefSchema),
   /** Ostrukturerad remittance-info (Ustrd-rader). */
-  freeTexts: string[];
-}
+  freeTexts: z.array(z.string().min(1)),
+});
 
-export interface CamtFile {
-  messageId: string | null;
-  transactions: CamtTransaction[];
-}
+export type CamtTransaction = z.infer<typeof camtTransactionSchema>;
+
+export const camtFileSchema = z.object({
+  messageId: z.string().min(1).nullable(),
+  transactions: z.array(camtTransactionSchema),
+});
+
+export type CamtFile = z.infer<typeof camtFileSchema>;
 
 /** Direkta barn-element med givet tag-namn (getElementsByTagName är subtree-vid). */
 function children(el: Element, tag: string): Element[] {
@@ -168,5 +181,7 @@ export function parseCamtXml(xml: string): CamtFile {
       transactions.push(...transactionsOfEntry(ntry, entryContextOf(ntry, messageId, index)));
     }
   }
-  return { messageId, transactions };
+  // Strikta datatyper (#185): hela utdatat valideras vid parsegränsen — en
+  // fil med t.ex. okänd CdtDbtInd eller trasigt datum failar HÄR, högt.
+  return camtFileSchema.parse({ messageId, transactions });
 }

--- a/test/unit/lib/payments/camt-parse.test.ts
+++ b/test/unit/lib/payments/camt-parse.test.ts
@@ -14,7 +14,12 @@ import { describe, it, expect } from "vitest-compat";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-import { parseCamtXml } from "@/lib/shared/payments/camt-parse";
+import {
+  parseCamtXml,
+  camtFileSchema,
+  camtTransactionSchema,
+  camtStructuredRefSchema,
+} from "@/lib/shared/payments/camt-parse";
 
 const FIXTURES = resolve(__dirname, "../../../fixtures/camt-seb");
 const read = (f: string): string => readFileSync(resolve(FIXTURES, f), "utf8");
@@ -82,5 +87,47 @@ describe("parseCamtXml — felfall", () => {
   it("kastar på icke-camt-XML", () => {
     expect(() => parseCamtXml("<foo/>")).toThrow(/camt/);
     expect(() => parseCamtXml("<Document><Other/></Document>")).toThrow(/camt\.053\/054/);
+  });
+});
+
+describe("zod-validering vid parsegränsen (#185)", () => {
+  const VALID_TX = {
+    reference: "REF-1", amountOre: 100_00, currency: "SEK", valueDate: "2026-06-01",
+    debtorName: "Klient AB", creditDebit: "CRDT", structuredRefs: [], freeTexts: [],
+  };
+
+  it("camtTransactionSchema avvisar trasiga fält (strikta datatyper)", () => {
+    expect(camtTransactionSchema.safeParse(VALID_TX).success).toBe(true);
+    expect(camtTransactionSchema.safeParse({ ...VALID_TX, creditDebit: "KRED" }).success).toBe(false);
+    expect(camtTransactionSchema.safeParse({ ...VALID_TX, valueDate: "01/06/2026" }).success).toBe(false);
+    expect(camtTransactionSchema.safeParse({ ...VALID_TX, amountOre: 100.5 }).success).toBe(false);
+    expect(camtTransactionSchema.safeParse({ ...VALID_TX, currency: "sek" }).success).toBe(false);
+    expect(camtTransactionSchema.safeParse({ ...VALID_TX, reference: "" }).success).toBe(false);
+  });
+
+  it("camtStructuredRefSchema kräver icke-tom referens + heltals-delbelopp", () => {
+    expect(camtStructuredRefSchema.safeParse({ ref: "98547", amountOre: 50_00 }).success).toBe(true);
+    expect(camtStructuredRefSchema.safeParse({ ref: "", amountOre: null }).success).toBe(false);
+    expect(camtStructuredRefSchema.safeParse({ ref: "98547", amountOre: 12.3 }).success).toBe(false);
+  });
+
+  it("parseCamtXml failar HÖGT på fil med okänd CdtDbtInd (validering, inte propagering)", () => {
+    const bad = `<?xml version="1.0"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.054.001.02">
+  <BkToCstmrDbtCdtNtfctn>
+    <GrpHdr><MsgId>M</MsgId></GrpHdr>
+    <Ntfctn><Ntry>
+      <Amt Ccy="SEK">10.00</Amt>
+      <CdtDbtInd>KREDIT</CdtDbtInd>
+      <ValDt><Dt>2026-06-01</Dt></ValDt>
+    </Ntry></Ntfctn>
+  </BkToCstmrDbtCdtNtfctn>
+</Document>`;
+    expect(() => parseCamtXml(bad)).toThrow();
+  });
+
+  it("fixturernas utdata passerar camtFileSchema oförändrat (round-trip)", () => {
+    const file = parseCamtXml(read("camt.054_SE_CRED_BGC.xml"));
+    expect(camtFileSchema.safeParse(file).success).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #185.

Stilregel (nu även sparad som arbetsprincip): **zod ska användas i så stor utsträckning som möjligt i parsandet — strikta datatyper är projektets motto.** camt-parsern (#181) byggde handskrivna TS-interfaces utan runtime-validering; extern fildata (camt-XML från bank) ska faila högt vid gränsen i stället för att propagera in i matchning/bokföring.

## Ändringar
- **zod-schemas för parserns hela utdata:** `camtStructuredRefSchema`, `camtTransactionSchema`, `camtFileSchema` — strikta typer:
  - `amountOre: z.number().int()` (öre, aldrig decimaler)
  - `creditDebit: z.enum(["CRDT","DBIT"])`
  - `valueDate: regex ^\d{4}-\d{2}-\d{2}$`
  - `currency: regex ^[A-Z]{3}$` (ISO 4217)
  - referenser/fritext `.min(1)`
- **Typerna `z.infer`-härledda** — samma namn som de gamla interfacen, så `match-payments.ts` och import-sidan är orörda.
- **`parseCamtXml` returnerar `camtFileSchema.parse(...)`** — varje parsad fil valideras; en fil med okänd `CdtDbtInd` eller trasigt datum kastar vid parsegränsen.

## Test
- Schema-avvisning per fält (okänd CdtDbtInd, fel datumformat, icke-heltals-belopp, gemen valutakod, tom referens).
- Fil-nivå: camt-XML med ogiltig `CdtDbtInd` kastar i `parseCamtXml`.
- Round-trip: SEB-fixturernas (#176) utdata passerar schemat oförändrat; alla befintliga fixtur-tester gröna.

## Verifiering
`bun run test:all` grönt (static + unit/coverage + e2e 18 passed/1 skipped, 322s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)