### PR TITLE
refactor(parsing): zod vid alla parsegränser — nätverk, fil, localStorage (#187)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,11 @@
 @AGENTS.md
+
+## graphify
+
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+
+Rules:
+- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
+- If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
+- Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,1 @@
 @AGENTS.md
-
-## graphify
-
-This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
-
-Rules:
-- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
-- If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
-- Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
-- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/src/app/calendar/_user-picker.tsx
+++ b/src/app/calendar/_user-picker.tsx
@@ -8,6 +8,8 @@
  * minns vilka man tittar på mellan sessioner.
  */
 
+import { z } from "zod";
+import { loadFromStorage } from "@/lib/client/load-from-storage";
 import { useEffect } from "react";
 import { Users } from "lucide-react";
 import { trpc } from "@/lib/client/trpc";
@@ -85,13 +87,10 @@ export function UserPicker({ selectedUserIds, onChange, enforceAtLeastOne, userC
 
 /** Läs sparat val från localStorage. Returnerar tom array om inget eller fel. */
 export function loadSelectedUserIds(): string[] {
-  if (typeof window === "undefined") return [];
-  try {
-    const raw = localStorage.getItem(LS_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed.filter((x) => typeof x === "string") : [];
-  } catch {
-    return [];
-  }
+  // Zod vid parsegränsen (#187); trasigt innehåll → tomt val (ofarligt).
+  const schema = z
+    .array(z.unknown())
+    .catch([])
+    .transform((arr) => arr.filter((x): x is string => typeof x === "string"));
+  return loadFromStorage(LS_KEY, schema, []);
 }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { z } from "zod";
 import { useEffect, useId, useRef, useState } from "react";
 import { trpc } from "@/lib/client/trpc";
 import { Upload, Trash2, Building2, Plus, Pencil, X, Check } from "lucide-react";
@@ -9,6 +10,10 @@ import { EditorExtensionsSection } from "@/components/settings/editor-extensions
 import { LlmSettingsCard } from "@/components/llm/llm-settings-card";
 import { OrgDefaultsSection } from "@/components/settings/org-defaults-section";
 import { HelperSection } from "@/components/settings/helper-section";
+
+// Zod vid parsegränsen (#187): logo-API:ts svar valideras.
+const logoResponseSchema = z.object({ logoUrl: z.string().nullable() });
+const uploadErrorSchema = z.object({ error: z.string().optional() }).passthrough();
 
 // ─── Offices sub-component ───────────────────────────────────────
 
@@ -264,7 +269,7 @@ export default function SettingsPage() {
     // Fetch current logo
     fetch("/api/organization/logo")
       .then((r) => r.json())
-      .then((d: { logoUrl: string | null }) => setLogoUrl(d.logoUrl))
+      .then((d: unknown) => setLogoUrl(logoResponseSchema.parse(d).logoUrl))
       .catch(() => {});
   }
 
@@ -295,10 +300,10 @@ export default function SettingsPage() {
       fd.append("file", file);
       const res = await fetch("/api/organization/logo", { method: "POST", body: fd });
       if (!res.ok) {
-        const err = await res.json() as { error?: string };
+        const err = uploadErrorSchema.parse(await res.json());
         throw new Error(err.error ?? "Uppladdning misslyckades");
       }
-      const data = await res.json() as { logoUrl: string };
+      const data = logoResponseSchema.parse(await res.json());
       setLogoUrl(data.logoUrl);
     } catch (e) {
       setLogoError(e instanceof Error ? e.message : "Okänt fel");

--- a/src/components/settings/web-oauth-device-flow.tsx
+++ b/src/components/settings/web-oauth-device-flow.tsx
@@ -13,6 +13,7 @@
  * Tauri-builden använder `OAuthDeviceFlow` (libcurl direkt) istället.
  */
 
+import { z } from "zod";
 import { useEffect, useState } from "react";
 import { ExternalLink } from "lucide-react";
 import { loadOAuthConfig } from "@/lib/client/auth/oauth-config";
@@ -22,19 +23,22 @@ interface Props {
   onCancel: () => void;
 }
 
-interface DeviceCodeResponse {
-  device_code: string;
-  user_code: string;
-  verification_uri: string;
-  expires_in: number;
-  interval: number;
-}
+// Zod vid parsegränsen (#187): OAuth-proxysvar valideras innan bruk.
+const deviceCodeResponseSchema = z.object({
+  device_code: z.string().min(1),
+  user_code: z.string(),
+  verification_uri: z.string(),
+  expires_in: z.number(),
+  interval: z.number(),
+});
 
-interface TokenResponse {
-  access_token?: string;
-  error?: string;
-  error_description?: string;
-}
+const tokenResponseSchema = z.object({
+  access_token: z.string().optional(),
+  error: z.string().optional(),
+  error_description: z.string().optional(),
+}).passthrough();
+
+type DeviceCodeResponse = z.infer<typeof deviceCodeResponseSchema>;
 
 export function WebOAuthDeviceFlow({ onComplete, onCancel }: Props) {
   // SSR-stabil initial — riktig config läses post-mount
@@ -53,9 +57,10 @@ export function WebOAuthDeviceFlow({ onComplete, onCancel }: Props) {
           headers: { "Content-Type": "application/json" },
         });
         if (!res.ok) throw new Error(`Proxy ${res.status}`);
-        const data = await res.json() as DeviceCodeResponse;
+        const parsed = deviceCodeResponseSchema.safeParse(await res.json());
         if (cancelled) return;
-        if (!data.device_code) throw new Error("Proxy returnerade ingen device_code");
+        if (!parsed.success) throw new Error("Proxy returnerade ingen giltig device_code");
+        const data = parsed.data;
         setCode(data);
         setStep("waiting");
       } catch (e) {
@@ -88,7 +93,7 @@ export function WebOAuthDeviceFlow({ onComplete, onCancel }: Props) {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ device_code: code.device_code }),
         });
-        const data = await res.json() as TokenResponse;
+        const data = tokenResponseSchema.parse(await res.json());
         if (cancelled) return;
         if (data.access_token) {
           onComplete(data.access_token);

--- a/src/components/shell/sidebar.tsx
+++ b/src/components/shell/sidebar.tsx
@@ -4,6 +4,8 @@ import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/client/utils";
+import { z } from "zod";
+import { loadFromStorage } from "@/lib/client/load-from-storage";
 
 /**
  * Pure git-modell — ingen NextAuth-session. "Logga ut" rensar
@@ -13,7 +15,8 @@ import { cn } from "@/lib/client/utils";
  */
 export function signOutLocally(): void {
   try {
-    const cfg = JSON.parse(localStorage.getItem("ava.firma") ?? "{}") as Record<string, unknown>;
+    // Zod vid parsegränsen (#187): validera som objekt; trasigt → {} (utloggning rensar ändå).
+    const cfg = loadFromStorage("ava.firma", z.record(z.string(), z.unknown()).catch({}), {});
     delete cfg.token;
     delete cfg.principalId;
     localStorage.setItem("ava.firma", JSON.stringify(cfg));

--- a/src/lib/client/auth/github-auth.ts
+++ b/src/lib/client/auth/github-auth.ts
@@ -14,16 +14,25 @@
  * token-närvaro: token → identified-write, annars anonymous.
  */
 
+import { z } from "zod";
 import { isLocalOrSameOrigin } from "@/lib/client/sync/cors-proxy";
 
 export type AuthMode = "anonymous" | "identified-read" | "identified-write";
 
-export interface GitHubUser {
-  login: string;
-  id: number;
-  name?: string | null;
-  avatar_url?: string;
-}
+// Zod vid parsegränsen (#187): GitHub-API-svar (identitet + access-beslut)
+// valideras — aldrig rena casts på nätverksdata.
+const gitHubUserSchema = z.object({
+  login: z.string().min(1),
+  id: z.number().int(),
+  name: z.string().nullish(),
+  avatar_url: z.string().optional(),
+});
+
+const repoResponseSchema = z.object({
+  permissions: z.object({ push: z.boolean().optional(), pull: z.boolean().optional() }).optional(),
+}).passthrough();
+
+export type GitHubUser = z.infer<typeof gitHubUserSchema>;
 
 export interface RepoPermissions {
   canRead: boolean;
@@ -78,7 +87,8 @@ export async function getCurrentUser(token: string): Promise<GitHubUser | null> 
   try {
     const res = await fetch("https://api.github.com/user", { headers: authHeaders(token) });
     if (!res.ok) return null;
-    return await res.json() as GitHubUser;
+    const parsed = gitHubUserSchema.safeParse(await res.json());
+    return parsed.success ? parsed.data : null;
   } catch {
     return null;
   }
@@ -99,8 +109,8 @@ export async function getRepoPermissions(
       { headers: authHeaders(token) },
     );
     if (!res.ok) return null;
-    const body = await res.json() as { permissions?: { push?: boolean; pull?: boolean } };
-    const perms = body.permissions;
+    const body = repoResponseSchema.safeParse(await res.json());
+    const perms = body.success ? body.data.permissions : undefined;
     if (!perms) {
       // Publika repo: kan läsa men inte pusha
       return { canRead: true, canPush: false };

--- a/src/lib/client/auth/oauth-config.ts
+++ b/src/lib/client/auth/oauth-config.ts
@@ -8,30 +8,27 @@
  * pratar direkt mot GitHub via libcurl (ingen CORS).
  */
 
+import { z } from "zod";
+
+import { loadFromStorage } from "@/lib/client/load-from-storage";
+
 const STORAGE_KEY = "ava.oauthConfig";
 
-export interface OAuthConfig {
+// Zod vid parsegränsen (#187). `.catch("")` = fältvis tolerans (fel typ på
+// ett fält nollar bara det fältet, som förr) — men aldrig ovaliderad data ut.
+const oauthConfigSchema = z.object({
   /** URL till deployerad Cloudflare Worker (eller liknande proxy). */
-  proxyUrl: string;
+  proxyUrl: z.string().catch(""),
   /** GitHub OAuth App Client ID (publik). */
-  clientId: string;
-}
+  clientId: z.string().catch(""),
+});
+
+export type OAuthConfig = z.infer<typeof oauthConfigSchema>;
 
 const DEFAULT: OAuthConfig = { proxyUrl: "", clientId: "" };
 
 export function loadOAuthConfig(): OAuthConfig {
-  if (typeof window === "undefined") return DEFAULT;
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return DEFAULT;
-    const parsed = JSON.parse(raw) as Partial<OAuthConfig>;
-    return {
-      proxyUrl: typeof parsed.proxyUrl === "string" ? parsed.proxyUrl : "",
-      clientId: typeof parsed.clientId === "string" ? parsed.clientId : "",
-    };
-  } catch {
-    return DEFAULT;
-  }
+  return loadFromStorage(STORAGE_KEY, oauthConfigSchema, DEFAULT);
 }
 
 export function saveOAuthConfig(cfg: OAuthConfig): void {

--- a/src/lib/client/auth/use-auth-mode.tsx
+++ b/src/lib/client/auth/use-auth-mode.tsx
@@ -15,6 +15,8 @@
  * sidopanelen, mutation-knappar etc. kan reagera direkt.
  */
 
+import { z } from "zod";
+import { loadFromStorage } from "@/lib/client/load-from-storage";
 import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
 import { detectAuthMode, getCurrentUser, type AuthMode, type GitHubUser } from "./github-auth";
 
@@ -28,15 +30,11 @@ export interface AuthSettings {
   allowAnonymousRead: boolean;
 }
 
+// Zod vid parsegränsen (#187): inga ovaliderade spreads in i access-konfig.
+const authSettingsSchema = z.object({ allowAnonymousRead: z.boolean().catch(true) });
+
 export function loadAuthSettings(): AuthSettings {
-  if (typeof window === "undefined") return { allowAnonymousRead: true };
-  try {
-    const raw = localStorage.getItem(SETTINGS_KEY);
-    if (!raw) return { allowAnonymousRead: true };
-    return { allowAnonymousRead: true, ...JSON.parse(raw) };
-  } catch {
-    return { allowAnonymousRead: true };
-  }
+  return loadFromStorage(SETTINGS_KEY, authSettingsSchema, { allowAnonymousRead: true });
 }
 
 export function saveAuthSettings(s: AuthSettings): void {

--- a/src/lib/client/demo/demo-meta.ts
+++ b/src/lib/client/demo/demo-meta.ts
@@ -7,31 +7,37 @@
  *
  * Cachas i minne efter första hämtningen (samma data hela sessionen).
  */
+import { z } from "zod";
+
 import { DEMO_META_PATH } from "../../../../tooling/demo-config";
 import { resolveGhPagesUrl } from "@/lib/shared/gh-pages-url";
-import {
-  assertRepoSchemaCompatible,
-  parseSchemaVersion,
-} from "@/lib/shared/schema-version";
+import { assertRepoSchemaCompatible } from "@/lib/shared/schema-version";
 
-export interface DemoMetaUser {
+// Zod vid parsegränsen (#187): meta.json är extern nätverksdata — valideras
+// strikt här i stället för handrullade typeof-helpers. Felmeddelandena är
+// del av kontraktet ("saknar X" pekar byggaren rätt).
+export const demoMetaUserSchema = z.object({
   /** UUID — principalId som /login sparar i firma-config. */
-  id: string;
-  name: string;
-  email: string;
-  role: "ADMIN" | "LAWYER" | "ASSISTANT";
-  title?: string;
-}
+  id: z.string({ message: "saknar id" }).min(1, "saknar id"),
+  name: z.string({ message: "saknar name" }).min(1, "saknar name"),
+  email: z.string().default(""),
+  role: z.enum(["ADMIN", "LAWYER", "ASSISTANT"]),
+  title: z.string().optional(),
+});
 
-export interface DemoMeta {
-  /** Datamodellens version (ADR 0004). Saknas i repon byggda före grinden. */
-  schemaVersion?: number;
+export const demoMetaSchema = z.object({
+  /** Datamodellens version (ADR 0004). Saknas/ogiltig i repon byggda före
+   *  grinden → undefined = v1-baslinje (samma tolerans som parseSchemaVersion). */
+  schemaVersion: z.number().int().positive().optional().catch(undefined),
   /** UUID på orgen. */
-  organizationId: string;
-  organizationName: string;
-  users: DemoMetaUser[];
-  buildAt: string;
-}
+  organizationId: z.string({ message: "saknar organizationId" }).min(1, "saknar organizationId"),
+  organizationName: z.string({ message: "saknar organizationName" }).min(1, "saknar organizationName"),
+  users: z.array(demoMetaUserSchema).min(1, "saknar users"),
+  buildAt: z.string().default(""),
+});
+
+export type DemoMetaUser = z.infer<typeof demoMetaUserSchema>;
+export type DemoMeta = z.infer<typeof demoMetaSchema>;
 
 let cache: { url: string; data: DemoMeta } | null = null;
 
@@ -58,8 +64,15 @@ export async function loadDemoMeta(
       `Är meta.json genererad av build-demo-repo?`,
     );
   }
-  const json = await res.json() as unknown;
-  const meta = validate(json, url);
+  const json: unknown = await res.json();
+  const parsed = demoMetaSchema.safeParse(json);
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .map((i) => (i.path.length ? `${i.path.join(".")}: ${i.message}` : i.message))
+      .join("; ");
+    throw new Error(`meta.json från ${url} ogiltig: ${issues}`);
+  }
+  const meta = parsed.data;
   // Versionsgrind (ADR 0004): vägra ett repo som är nyare än koden förstår,
   // INNAN user-/org-data används. Saknad version → baslinje (v1) → OK.
   assertRepoSchemaCompatible(meta.schemaVersion);
@@ -69,44 +82,3 @@ export async function loadDemoMeta(
 
 /** Bara för tester. */
 export function _resetDemoMetaCache(): void { cache = null; }
-
-function requireString(value: unknown, errorMsg: string): string {
-  if (typeof value !== "string" || !value) throw new Error(errorMsg);
-  return value;
-}
-
-function asObject(value: unknown, errorMsg: string): Record<string, unknown> {
-  if (!value || typeof value !== "object") throw new Error(errorMsg);
-  return value as Record<string, unknown>;
-}
-
-function validate(json: unknown, url: string): DemoMeta {
-  const o = asObject(json, `meta.json från ${url} är inte ett objekt`);
-  if (!Array.isArray(o.users) || o.users.length === 0) {
-    throw new Error(`meta.json från ${url} saknar users`);
-  }
-  const schemaVersion = parseSchemaVersion(o.schemaVersion);
-  return {
-    // exactOptionalPropertyTypes: utelämna nyckeln helt när den saknas
-    // istället för att sätta `undefined`.
-    ...(schemaVersion !== undefined ? { schemaVersion } : {}),
-    organizationId: requireString(o.organizationId, `meta.json från ${url} saknar organizationId`),
-    organizationName: requireString(o.organizationName, `meta.json från ${url} saknar organizationName`),
-    users: o.users.map((u, i) => validateUser(u, url, i)),
-    buildAt: typeof o.buildAt === "string" ? o.buildAt : "",
-  };
-}
-
-function validateUser(raw: unknown, url: string, idx: number): DemoMetaUser {
-  const u = asObject(raw, `meta.json från ${url}: users[${idx}] är inte objekt`);
-  if (typeof u.name !== "string" || typeof u.role !== "string") {
-    throw new Error(`meta.json från ${url}: users[${idx}] saknar name/role`);
-  }
-  return {
-    id: requireString(u.id, `meta.json från ${url}: users[${idx}] saknar id`),
-    name: u.name,
-    email: typeof u.email === "string" ? u.email : "",
-    role: u.role as "ADMIN" | "LAWYER" | "ASSISTANT",
-    ...(typeof u.title === "string" ? { title: u.title } : {}),
-  };
-}

--- a/src/lib/client/firma/firma-config.ts
+++ b/src/lib/client/firma/firma-config.ts
@@ -9,6 +9,11 @@
  * Persisteras i localStorage. Browser-only (SSR-safe via guard).
  */
 
+import { z } from "zod";
+
+import { loadFromStorage } from "@/lib/client/load-from-storage";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
+
 export type FirmaTier = "demo" | "github" | "self-hosted";
 
 export interface FirmaConfig {
@@ -112,16 +117,30 @@ export function defaultConfigForHost(hostname: string | undefined): FirmaConfig 
   return DEMO_DEFAULT;
 }
 
+
+// Zod vid parsegränsen (#187): lagrad config valideras innan spread in i
+// domänobjektet. Alla fält optionella (partiella skrivningar förekommer);
+// .passthrough() bevarar okända fält från nyare versioner i andra flikar.
+const storedFirmaConfigSchema = z.object({
+  tier: z.enum(["demo", "github", "self-hosted"]).optional(),
+  repo: z.string().optional(),
+  token: z.string().optional(),
+  organizationId: z.string().optional(),
+  principalId: z.string().optional(),
+  authorName: z.string().optional(),
+  authorEmail: z.string().optional(),
+  gitUsername: z.string().optional(),
+  corsProxy: z.string().optional(),
+}).passthrough();
+
 export function loadFirmaConfig(): FirmaConfig {
   if (typeof window === "undefined") return DEMO_DEFAULT;
   const fallback = defaultConfigForHost(window.location.hostname);
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return fallback;
-    const parsed = JSON.parse(raw) as Partial<FirmaConfig>;
+    const parsed = loadFromStorage(STORAGE_KEY, storedFirmaConfigSchema, {});
     return {
       ...fallback,
-      ...parsed,
+      ...omitUndefined(parsed),
       // Tomt repo → fall tillbaka till hostens default
       repo: parsed.repo || fallback.repo,
     };

--- a/src/lib/client/firma/load-self-hosted-source.ts
+++ b/src/lib/client/firma/load-self-hosted-source.ts
@@ -19,10 +19,8 @@ import { resolveCorsProxy } from "@/lib/client/sync/cors-proxy";
 import { hydrateWorkingCopy } from "./hydrate-working-copy";
 import { setDocumentContent } from "@/lib/client/demo/document-content-cache";
 import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
-import {
-  assertRepoSchemaCompatible,
-  parseSchemaVersion,
-} from "@/lib/shared/schema-version";
+import { assertRepoSchemaCompatible } from "@/lib/shared/schema-version";
+import { schemaVersionFromMetaJson } from "@/lib/shared/meta-json";
 import { DEMO_META_PATH } from "../../../../tooling/demo-config";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 
@@ -109,10 +107,8 @@ async function readWorkingCopySchemaVersion(
   fs: FsaIsoGitAdapter,
 ): Promise<number | undefined> {
   try {
-    const raw = JSON.parse(
-      (await fs.readFile(`/${DEMO_META_PATH}`, "utf8")) as string,
-    ) as { schemaVersion?: unknown };
-    return parseSchemaVersion(raw.schemaVersion);
+    // Zod vid parsegränsen (#187) — delad helper för alla meta.json-läsare.
+    return schemaVersionFromMetaJson((await fs.readFile(`/${DEMO_META_PATH}`, "utf8")) as string);
   } catch {
     return undefined;
   }

--- a/src/lib/client/fsa/preload-documents.ts
+++ b/src/lib/client/fsa/preload-documents.ts
@@ -15,6 +15,7 @@
  * "Förladdar 7 av 40…".
  */
 
+import { z } from "zod";
 import { downloadToFsa } from "./download-to-fsa";
 
 export interface PreloadOpts {
@@ -32,7 +33,9 @@ export interface PreloadResult {
   failed: number;
 }
 
-interface DocMeta { storagePath?: string }
+// Zod vid parsegränsen (#187).
+const manifestSchema = z.object({ paths: z.array(z.string()).optional() }).passthrough();
+const docMetaSchema = z.object({ storagePath: z.string().optional() }).passthrough();
 
 // eslint-disable-next-line complexity
 export async function preloadAllDocuments(opts: PreloadOpts): Promise<PreloadResult> {
@@ -42,7 +45,7 @@ export async function preloadAllDocuments(opts: PreloadOpts): Promise<PreloadRes
   // 1. Manifest → metadata-JSONs
   const manifestRes = await fetchFn(`${base}/manifest.json`);
   if (!manifestRes.ok) throw new Error(`preload: HTTP ${manifestRes.status} på manifest`);
-  const manifest = await manifestRes.json() as { paths?: string[] };
+  const manifest = manifestSchema.parse(await manifestRes.json());
   const docMetaPaths = (manifest.paths ?? []).filter(
     (p) => p.startsWith("documents/") && p.endsWith(".json"),
   );
@@ -53,7 +56,7 @@ export async function preloadAllDocuments(opts: PreloadOpts): Promise<PreloadRes
     try {
       const r = await fetchFn(`${base}/${metaPath}`);
       if (!r.ok) continue;
-      const meta = await r.json() as DocMeta;
+      const meta = docMetaSchema.parse(await r.json());
       if (meta.storagePath) binaryPaths.push(meta.storagePath);
     } catch {
       // tyst — räknas som failed vid download-loop

--- a/src/lib/client/github/api.ts
+++ b/src/lib/client/github/api.ts
@@ -9,6 +9,7 @@
  * parallella blob-fetches, bara skapade objekt postas.
  */
 
+import { z } from "zod";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 
 const API = "https://api.github.com";
@@ -23,36 +24,51 @@ interface ApiOpts {
   signal?: AbortSignal;
 }
 
-export interface TreeEntry {
-  path: string;
-  mode: string;       // "100644" (file), "100755" (exec), "040000" (tree)
-  type: "blob" | "tree" | "commit";
-  sha: string;
-  size?: number;
-  url?: string;
-}
+// Zod vid parsegränsen (#187): GitHub-API-svar valideras per endpoint-schema
+// i expectOk — typerna är z.infer-härledda (samma exporterade namn som förr).
+// Kräver det koden KONSUMERAR (path/type/sha resp. tree.sha, encoding,
+// content); övriga API-fält är optionella — strikt där det räknas, utan att
+// vara skört mot API-tillägg.
+const treeEntrySchema = z.object({
+  path: z.string(),
+  mode: z.string().optional(), // "100644" (file), "100755" (exec), "040000" (tree)
+  type: z.enum(["blob", "tree", "commit"]),
+  sha: z.string(),
+  size: z.number().optional(),
+  url: z.string().optional(),
+});
 
-export interface TreeData {
-  sha: string;
-  truncated: boolean;
-  tree: TreeEntry[];
-}
+const treeDataSchema = z.object({
+  sha: z.string(),
+  truncated: z.boolean(),
+  tree: z.array(treeEntrySchema),
+});
 
-export interface CommitData {
-  sha: string;
-  message: string;
-  tree: { sha: string };
-  parents: Array<{ sha: string }>;
-  author: { name: string; email: string; date: string };
-  committer: { name: string; email: string; date: string };
-}
+const gitActorSchema = z.object({ name: z.string(), email: z.string(), date: z.string() });
 
-export interface BlobData {
-  sha: string;
-  content: string;
-  encoding: "base64" | "utf-8";
-  size: number;
-}
+const commitDataSchema = z.object({
+  sha: z.string(),
+  message: z.string().optional(),
+  tree: z.object({ sha: z.string() }),
+  parents: z.array(z.object({ sha: z.string() })).optional(),
+  author: gitActorSchema.optional(),
+  committer: gitActorSchema.optional(),
+});
+
+const blobDataSchema = z.object({
+  sha: z.string().optional(),
+  content: z.string(),
+  encoding: z.enum(["base64", "utf-8"]),
+  size: z.number().optional(),
+});
+
+const shaResponseSchema = z.object({ sha: z.string() });
+const branchHeadSchema = z.object({ object: z.object({ sha: z.string() }) });
+const errorBodySchema = z.object({ message: z.string().optional() }).passthrough();
+
+export type TreeData = z.infer<typeof treeDataSchema>;
+export type CommitData = z.infer<typeof commitDataSchema>;
+export type BlobData = z.infer<typeof blobDataSchema>;
 
 async function apiFetch(path: string, init: RequestInit, opts: ApiOpts): Promise<Response> {
   const res = await fetch(`${API}${path}`, {
@@ -68,39 +84,42 @@ async function apiFetch(path: string, init: RequestInit, opts: ApiOpts): Promise
   return res;
 }
 
-async function expectOk<T>(res: Response, label: string): Promise<T> {
+async function expectOk<S extends z.ZodType>(res: Response, label: string, schema: S): Promise<z.infer<S>> {
   if (!res.ok) {
     const body = await res.text().catch(() => "");
     let msg = body;
-    try { msg = (JSON.parse(body) as { message?: string }).message ?? body; } catch { /* ignorera */ }
+    try {
+      const parsed = errorBodySchema.safeParse(JSON.parse(body));
+      if (parsed.success && parsed.data.message) msg = parsed.data.message;
+    } catch { /* ignorera — rå body */ }
     throw new Error(`${label}: ${res.status} ${res.statusText} ${msg ? "— " + msg : ""}`);
   }
-  return res.json() as Promise<T>;
+  return schema.parse(await res.json()) as z.infer<S>;
 }
 
 /** GET /repos/{o}/{r}/git/refs/heads/{branch} */
 export async function getBranchHead(repo: RepoLocator, branch: string, opts: ApiOpts): Promise<string> {
   const res = await apiFetch(`/repos/${repo.owner}/${repo.repo}/git/ref/heads/${encodeURIComponent(branch)}`, {}, opts);
-  const data = await expectOk<{ object: { sha: string } }>(res, "getBranchHead");
+  const data = await expectOk(res, "getBranchHead", branchHeadSchema);
   return data.object.sha;
 }
 
 /** GET /repos/{o}/{r}/git/commits/{sha} */
 export async function getCommit(repo: RepoLocator, sha: string, opts: ApiOpts): Promise<CommitData> {
   const res = await apiFetch(`/repos/${repo.owner}/${repo.repo}/git/commits/${sha}`, {}, opts);
-  return expectOk<CommitData>(res, "getCommit");
+  return expectOk(res, "getCommit", commitDataSchema);
 }
 
 /** GET /repos/{o}/{r}/git/trees/{sha}?recursive=1 */
 export async function getTreeRecursive(repo: RepoLocator, treeSha: string, opts: ApiOpts): Promise<TreeData> {
   const res = await apiFetch(`/repos/${repo.owner}/${repo.repo}/git/trees/${treeSha}?recursive=1`, {}, opts);
-  return expectOk<TreeData>(res, "getTreeRecursive");
+  return expectOk(res, "getTreeRecursive", treeDataSchema);
 }
 
 /** GET /repos/{o}/{r}/git/blobs/{sha} */
 export async function getBlob(repo: RepoLocator, sha: string, opts: ApiOpts): Promise<BlobData> {
   const res = await apiFetch(`/repos/${repo.owner}/${repo.repo}/git/blobs/${sha}`, {}, opts);
-  return expectOk<BlobData>(res, "getBlob");
+  return expectOk(res, "getBlob", blobDataSchema);
 }
 
 /** POST /repos/{o}/{r}/git/blobs */
@@ -117,7 +136,7 @@ export async function createBlob(repo: RepoLocator, content: Uint8Array, opts: A
     },
     opts,
   );
-  const data = await expectOk<{ sha: string }>(res, "createBlob");
+  const data = await expectOk(res, "createBlob", shaResponseSchema);
   return data.sha;
 }
 
@@ -139,7 +158,7 @@ export async function createTree(
     },
     opts,
   );
-  const data = await expectOk<{ sha: string }>(res, "createTree");
+  const data = await expectOk(res, "createTree", shaResponseSchema);
   return data.sha;
 }
 
@@ -165,7 +184,7 @@ export async function createCommit(
     },
     opts,
   );
-  const data = await expectOk<{ sha: string }>(res, "createCommit");
+  const data = await expectOk(res, "createCommit", shaResponseSchema);
   return data.sha;
 }
 
@@ -185,7 +204,7 @@ export async function updateRef(
     },
     opts,
   );
-  await expectOk(res, "updateRef");
+  await expectOk(res, "updateRef", z.record(z.string(), z.unknown()));
 }
 
 // ─── Hjälpfunktioner ─────────────────────────────────────────────────

--- a/src/lib/client/github/sync-state.ts
+++ b/src/lib/client/github/sync-state.ts
@@ -22,23 +22,28 @@
 
 const PATH = ".ava/sync-state.json";
 
-export interface SyncState {
-  version: 1;
-  branch: string;
-  lastHead: string;
-  lastTree: string;
-  lastSyncedAt: string;
-  files: Record<string, string>;
-}
+import { z } from "zod";
+
+// Zod vid parsegränsen (#187): versionen bärs av z.literal — fel version
+// eller form → null (samma utfall som förr, men validerat fält för fält).
+const syncStateSchema = z.object({
+  version: z.literal(1),
+  branch: z.string(),
+  lastHead: z.string(),
+  lastTree: z.string(),
+  lastSyncedAt: z.string(),
+  files: z.record(z.string(), z.string()),
+});
+
+export type SyncState = z.infer<typeof syncStateSchema>;
 
 export async function readSyncState(handle: FileSystemDirectoryHandle): Promise<SyncState | null> {
   try {
     const ava = await handle.getDirectoryHandle(".ava");
     const file = await ava.getFileHandle("sync-state.json");
     const text = await (await file.getFile()).text();
-    const parsed = JSON.parse(text) as SyncState;
-    if (parsed.version !== 1) return null;
-    return parsed;
+    const parsed = syncStateSchema.safeParse(JSON.parse(text));
+    return parsed.success ? parsed.data : null;
   } catch {
     return null;
   }

--- a/src/lib/client/integrations/microsoft-graph.ts
+++ b/src/lib/client/integrations/microsoft-graph.ts
@@ -13,6 +13,8 @@
 
 const GRAPH_BASE = "https://graph.microsoft.com/v1.0";
 
+import { z } from "zod";
+
 export interface GraphEventBody {
   subject: string;
   body?: { contentType: "HTML" | "text"; content: string };
@@ -23,12 +25,17 @@ export interface GraphEventBody {
   sensitivity?: "normal" | "personal" | "private" | "confidential";
 }
 
-export interface GraphEventResponse {
-  id: string;
-  subject: string;
-  start: { dateTime: string; timeZone: string };
-  end: { dateTime: string; timeZone: string };
-}
+// Zod vid parsegränsen (#187): Graph-svar valideras i expectOk.
+const graphDateTimeSchema = z.object({ dateTime: z.string(), timeZone: z.string() });
+const graphEventResponseSchema = z.object({
+  id: z.string(),
+  subject: z.string(),
+  start: graphDateTimeSchema,
+  end: graphDateTimeSchema,
+});
+const graphErrorBodySchema = z.object({ error: z.object({ message: z.string().optional() }).optional() }).passthrough();
+
+export type GraphEventResponse = z.infer<typeof graphEventResponseSchema>;
 
 export interface GraphOpts {
   token: string;
@@ -55,13 +62,13 @@ async function graphFetch(
   });
 }
 
-async function expectOk<T>(res: Response, label: string): Promise<T> {
-  if (res.ok) return res.json() as Promise<T>;
+async function expectOk<S extends z.ZodType>(res: Response, label: string, schema: S): Promise<z.infer<S>> {
+  if (res.ok) return schema.parse(await res.json()) as z.infer<S>;
   const body = await res.text().catch(() => "");
   let msg = body;
   try {
-    const j = JSON.parse(body) as { error?: { message?: string } };
-    msg = j.error?.message ?? body;
+    const parsed = graphErrorBodySchema.safeParse(JSON.parse(body));
+    if (parsed.success && parsed.data.error?.message) msg = parsed.data.error.message;
   } catch { /* använd rå body */ }
   throw new Error(`${label}: ${res.status} ${res.statusText}${msg ? ` — ${msg}` : ""}`);
 }
@@ -76,7 +83,7 @@ export async function createGraphEvent(body: GraphEventBody, opts: GraphOpts): P
     method: "POST",
     body: JSON.stringify(body),
   }, opts);
-  return expectOk<GraphEventResponse>(res, "createGraphEvent");
+  return expectOk(res, "createGraphEvent", graphEventResponseSchema);
 }
 
 /** PATCH → uppdatera ett befintligt event. */
@@ -92,7 +99,7 @@ export async function updateGraphEvent(
     method: "PATCH",
     body: JSON.stringify(body),
   }, opts);
-  return expectOk<GraphEventResponse>(res, "updateGraphEvent");
+  return expectOk(res, "updateGraphEvent", graphEventResponseSchema);
 }
 
 /** DELETE → ta bort ett event. 404 räknas som ok (redan borta). */

--- a/src/lib/client/llm/llm-config.ts
+++ b/src/lib/client/llm/llm-config.ts
@@ -15,6 +15,10 @@
  * `@mlc-ai/web-llm` prebuiltAppConfig.model_list-strängar — checka in nya
  * här innan UI-toggle kan välja dem.
  */
+import { z } from "zod";
+
+import { loadFromStorage } from "@/lib/client/load-from-storage";
+
 export const LLM_MODELS = [
   "Llama-3.2-1B-Instruct-q4f16_1-MLC",
   "Llama-3.2-3B-Instruct-q4f16_1-MLC",
@@ -26,24 +30,16 @@ export const DEFAULT_LLM_MODEL: LlmModelId = "Llama-3.2-1B-Instruct-q4f16_1-MLC"
 
 const KEY = "ava.llm";
 
-interface LlmConfig {
-  enabled: boolean;
-  modelId: LlmModelId;
-}
+// Zod vid parsegränsen (#187): enum-validerad modell + boolean, fältvis tolerans.
+const llmConfigSchema = z.object({
+  enabled: z.boolean().catch(false),
+  modelId: z.enum(LLM_MODELS).catch(DEFAULT_LLM_MODEL),
+});
+
+type LlmConfig = z.infer<typeof llmConfigSchema>;
 
 function loadConfig(): LlmConfig {
-  if (typeof window === "undefined") return { enabled: false, modelId: DEFAULT_LLM_MODEL };
-  try {
-    const raw = localStorage.getItem(KEY);
-    if (!raw) return { enabled: false, modelId: DEFAULT_LLM_MODEL };
-    const parsed = JSON.parse(raw) as Partial<LlmConfig>;
-    const modelId = (LLM_MODELS as readonly string[]).includes(parsed.modelId as string)
-      ? (parsed.modelId as LlmModelId)
-      : DEFAULT_LLM_MODEL;
-    return { enabled: Boolean(parsed.enabled), modelId };
-  } catch {
-    return { enabled: false, modelId: DEFAULT_LLM_MODEL };
-  }
+  return loadFromStorage(KEY, llmConfigSchema, { enabled: false, modelId: DEFAULT_LLM_MODEL });
 }
 
 function saveConfig(cfg: LlmConfig): void {

--- a/src/lib/client/llm/web-llm-extractor.ts
+++ b/src/lib/client/llm/web-llm-extractor.ts
@@ -21,6 +21,7 @@
  *     separat för testbarhet utan att behöva instansiera WebGPU.
  */
 
+import { z } from "zod";
 import type { MLCEngine } from "@mlc-ai/web-llm";
 import type { ExtractionResult, ExtractionSchema, FieldType, ILlmExtractor } from "@/lib/server/llm/llm-extractor";
 import type { LlmModelId } from "./llm-config";
@@ -121,14 +122,14 @@ export function buildPrompt(text: string, schema: ExtractionSchema): string {
  */
 export function parseJsonResponse(raw: string, schema: ExtractionSchema): ExtractionResult {
   const json = extractJsonObject(raw);
+  // Zod vid parsegränsen (#187): LLM-svar är ostrukturerad text — validera
+  // som objekt; första kandidaten rå, andra med trailing commas rensade.
   let parsed: Record<string, unknown> = {};
-  try {
-    parsed = JSON.parse(json) as Record<string, unknown>;
-  } catch {
-    // Sista försök: ta bort trailing commas före fältnamn
+  for (const candidate of [json, json.replace(/,\s*([}\]])/g, "$1")]) {
     try {
-      parsed = JSON.parse(json.replace(/,\s*([}\]])/g, "$1")) as Record<string, unknown>;
-    } catch { /* fall back to defaults */ }
+      const obj = z.record(z.string(), z.unknown()).safeParse(JSON.parse(candidate));
+      if (obj.success) { parsed = obj.data; break; }
+    } catch { /* prova nästa kandidat, annars defaults */ }
   }
   const out: ExtractionResult = {};
   for (const [name, spec] of Object.entries(schema)) {

--- a/src/lib/client/load-from-storage.ts
+++ b/src/lib/client/load-from-storage.ts
@@ -1,0 +1,30 @@
+/**
+ * `loadFromStorage` — zod-validerad localStorage-läsning (#187).
+ *
+ * Ersätter mönstret `JSON.parse(raw) as Partial<X>` + manuella typeof-koll
+ * som fanns i firma-config, oauth-config, authSettings, llm-config m.fl.
+ * Stilregeln: zod vid varje parsegräns — även egen lagring (en annan flik/
+ * äldre version/handredigering kan ha skrivit vad som helst).
+ *
+ * Tolerant per design: trasig JSON eller schema-miss → fallback (lagrings-
+ * preferenser ska aldrig krascha appen), men det som RETURNERAS är alltid
+ * schema-validerat — ovaliderad data sprids aldrig in i domänobjekt.
+ */
+
+import type { z } from "zod";
+
+export function loadFromStorage<S extends z.ZodType>(
+  key: string,
+  schema: S,
+  fallback: z.infer<S>,
+): z.infer<S> {
+  if (typeof window === "undefined") return fallback;
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw === null) return fallback;
+    const parsed = schema.safeParse(JSON.parse(raw));
+    return parsed.success ? (parsed.data as z.infer<S>) : fallback;
+  } catch {
+    return fallback;
+  }
+}

--- a/src/lib/server/local-first/demo-loader.ts
+++ b/src/lib/server/local-first/demo-loader.ts
@@ -27,10 +27,8 @@ import type { MemFs } from "./mem-fs";
 import { ProjectionHydrator } from "./projection-writer";
 import type { ProjectionRegistry } from "./projections/registry";
 import { ENTITY_REGISTRY } from "@/lib/shared/schemas";
-import {
-  assertRepoSchemaCompatible,
-  parseSchemaVersion,
-} from "@/lib/shared/schema-version";
+import { assertRepoSchemaCompatible } from "@/lib/shared/schema-version";
+import { schemaVersionFromMetaJson } from "@/lib/shared/meta-json";
 import { DEMO_META_PATH } from "../../../../tooling/demo-config";
 
 export type DemoCloneFn = (fs: MemFs, url: string) => Promise<void>;
@@ -151,10 +149,8 @@ export class DemoLoader {
   private async readRepoSchemaVersion(): Promise<number | undefined> {
     try {
       if (!(await this.deps.fs.exists(DEMO_META_PATH))) return undefined;
-      const raw = JSON.parse(await this.deps.fs.readFile(DEMO_META_PATH)) as {
-        schemaVersion?: unknown;
-      };
-      return parseSchemaVersion(raw.schemaVersion);
+      // Zod vid parsegränsen (#187) — delad helper för alla meta.json-läsare.
+      return schemaVersionFromMetaJson(await this.deps.fs.readFile(DEMO_META_PATH));
     } catch {
       return undefined;
     }

--- a/src/lib/server/local-first/persistence.ts
+++ b/src/lib/server/local-first/persistence.ts
@@ -14,7 +14,11 @@
  *   - (Framtid) `IndexedDBPersistence` om vi behöver bredare browser-stöd.
  */
 
-export type FsSnapshot = Record<string, string>;
+import { z } from "zod";
+
+// Zod vid parsegränsen (#187): snapshotten läses från OPFS — validera formen.
+export const fsSnapshotSchema = z.record(z.string(), z.string());
+export type FsSnapshot = z.infer<typeof fsSnapshotSchema>;
 
 export interface IPersistence {
   /** Returnera tidigare sparad snapshot, eller null om inget finns. */
@@ -106,7 +110,8 @@ export class OpfsPersistence implements IPersistence {
       const dir = await this.getKeyDir();
       const file = await dir.getFileHandle(FILE_NAME);
       const content = await (await file.getFile()).text();
-      return JSON.parse(content) as FsSnapshot;
+      const parsed = fsSnapshotSchema.safeParse(JSON.parse(content));
+      return parsed.success ? parsed.data : null;
     } catch (err) {
       // Filen finns inte, OPFS stödjs inte, eller JSON kunde inte parsas.
       // För en cache är "ingen data" rätt fallback. Om felet beror på att

--- a/src/lib/server/local-first/server-working-copy.ts
+++ b/src/lib/server/local-first/server-working-copy.ts
@@ -12,7 +12,8 @@
  * Servern är en git-peer, inte dataägare.
  */
 
-import { CURRENT_SCHEMA_VERSION, parseSchemaVersion } from "@/lib/shared/schema-version";
+import { CURRENT_SCHEMA_VERSION } from "@/lib/shared/schema-version";
+import { schemaVersionFromMetaJson } from "@/lib/shared/meta-json";
 import { ENTITY_REGISTRY } from "@/lib/shared/schemas";
 import { type DemoSource, prebakeJoins } from "@/lib/shared/demo-source";
 import { DemoDataStore } from "@/lib/server/data-store/DemoDataStore";
@@ -37,8 +38,8 @@ import { buildDefaultRegistry } from "./projections/default-registry";
 async function repoSchemaVersion(fs: IFileSystem): Promise<number> {
   try {
     if (!(await fs.exists(DEMO_META_PATH))) return CURRENT_SCHEMA_VERSION;
-    const raw = JSON.parse(await fs.readFile(DEMO_META_PATH)) as { schemaVersion?: unknown };
-    return parseSchemaVersion(raw.schemaVersion) ?? CURRENT_SCHEMA_VERSION;
+    // Zod vid parsegränsen (#187) — delad helper för alla meta.json-läsare.
+    return schemaVersionFromMetaJson(await fs.readFile(DEMO_META_PATH)) ?? CURRENT_SCHEMA_VERSION;
   } catch {
     return CURRENT_SCHEMA_VERSION;
   }

--- a/src/lib/shared/meta-json.ts
+++ b/src/lib/shared/meta-json.ts
@@ -1,0 +1,31 @@
+/**
+ * `.ava/meta.json` — zod-validerad läsning av repots schemaVersion (#187).
+ *
+ * Tre kodvägar läste tidigare meta-filen med `JSON.parse(...) as
+ * { schemaVersion?: unknown }` (demo-loader, server-working-copy,
+ * load-self-hosted-source). Stilregeln säger zod vid parsegränsen — det här
+ * är den delade gränsen.
+ *
+ * Tolerant per design (ADR 0004): saknad/icke-numerisk version → `undefined`
+ * (= v1-baslinje för grinden). Trasig JSON kastar — anroparna behåller sina
+ * try/catch eftersom "trasig fil" ska tolkas som baslinje, inte krasch.
+ */
+
+import { z } from "zod";
+
+import { parseSchemaVersion } from "./schema-version";
+
+export const metaJsonSchema = z
+  .object({ schemaVersion: z.number().int().positive().optional() })
+  .passthrough();
+
+/**
+ * Läs schemaVersion ur meta.json-TEXT. Zod-validering vid gränsen: fel typ på
+ * `schemaVersion` (sträng, negativt, decimal) → `undefined` (v1-baslinje),
+ * precis som en saknad nyckel. Ogiltig JSON kastar.
+ */
+export function schemaVersionFromMetaJson(text: string): number | undefined {
+  const parsed = metaJsonSchema.safeParse(JSON.parse(text));
+  if (!parsed.success) return undefined;
+  return parseSchemaVersion(parsed.data.schemaVersion);
+}

--- a/src/lib/shared/schema-migrations.ts
+++ b/src/lib/shared/schema-migrations.ts
@@ -14,6 +14,7 @@
  *
  * [ADR 0004]: ../../../docs/adr/0004-schemaversion-och-versionsgrind.md
  */
+import { z } from "zod";
 import { CURRENT_SCHEMA_VERSION } from "./schema-version";
 
 /** Lyfter en rå rad exakt ETT versionssteg (from → from+1). Ren funktion. */
@@ -70,8 +71,11 @@ export function migrateRawJson(
   } catch {
     return raw;
   }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return raw;
-  const migrated = migrateRow(entity, parsed as Record<string, unknown>, fromVersion, toVersion);
+  // Zod vid parsegränsen (#187); array-guard kvar (record accepterar inte arrays semantiskt här).
+  if (Array.isArray(parsed)) return raw;
+  const obj = z.record(z.string(), z.unknown()).safeParse(parsed);
+  if (!obj.success) return raw;
+  const migrated = migrateRow(entity, obj.data, fromVersion, toVersion);
   return JSON.stringify(migrated);
 }
 

--- a/test/unit/lib/auth/github-auth.test.tsx
+++ b/test/unit/lib/auth/github-auth.test.tsx
@@ -106,13 +106,13 @@ describe("detectAuthMode", () => {
     expect(m).toBe("anonymous");
   });
   it("token + push → identified-write", async () => {
-    fetchMock.mockResolvedValueOnce(ok({ login: "anna" })); // GET user
+    fetchMock.mockResolvedValueOnce(ok({ login: "anna", id: 1 })); // GET user
     fetchMock.mockResolvedValueOnce(ok({ permissions: { push: true } })); // GET repo
     const m = await detectAuthMode({ token: "ghp_x", repoUrl: "ulrik-s/ava-demo" });
     expect(m).toBe("identified-write");
   });
   it("token + ingen push → identified-read", async () => {
-    fetchMock.mockResolvedValueOnce(ok({ login: "guest" }));
+    fetchMock.mockResolvedValueOnce(ok({ login: "guest", id: 2 }));
     fetchMock.mockResolvedValueOnce(ok({ permissions: { push: false } }));
     const m = await detectAuthMode({ token: "ghp_x", repoUrl: "ulrik-s/ava-demo" });
     expect(m).toBe("identified-read");

--- a/test/unit/lib/client/load-from-storage.test.ts
+++ b/test/unit/lib/client/load-from-storage.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Test för zod-validerad localStorage-läsning (#187).
+ */
+
+import { describe, it, expect, beforeEach } from "vitest-compat";
+import { z } from "zod";
+
+import { loadFromStorage } from "@/lib/client/load-from-storage";
+
+const KEY = "test.loadFromStorage";
+const schema = z.object({ a: z.string(), n: z.number().int().catch(0) });
+const FALLBACK = { a: "fallback", n: -1 };
+
+beforeEach(() => localStorage.removeItem(KEY));
+
+describe("loadFromStorage (#187)", () => {
+  it("saknad nyckel → fallback", () => {
+    expect(loadFromStorage(KEY, schema, FALLBACK)).toEqual(FALLBACK);
+  });
+
+  it("giltig lagrad data → schema-validerad retur", () => {
+    localStorage.setItem(KEY, JSON.stringify({ a: "x", n: 7 }));
+    expect(loadFromStorage(KEY, schema, FALLBACK)).toEqual({ a: "x", n: 7 });
+  });
+
+  it("fältvis tolerans via .catch i schemat", () => {
+    localStorage.setItem(KEY, JSON.stringify({ a: "x", n: "inte-tal" }));
+    expect(loadFromStorage(KEY, schema, FALLBACK)).toEqual({ a: "x", n: 0 });
+  });
+
+  it("schema-miss (fel form) → fallback, aldrig ovaliderad data", () => {
+    localStorage.setItem(KEY, JSON.stringify({ helt: "fel" }));
+    expect(loadFromStorage(KEY, schema, FALLBACK)).toEqual(FALLBACK);
+  });
+
+  it("trasig JSON → fallback, kastar inte", () => {
+    localStorage.setItem(KEY, "{inte json");
+    expect(loadFromStorage(KEY, schema, FALLBACK)).toEqual(FALLBACK);
+  });
+});

--- a/test/unit/lib/shared/meta-json.test.ts
+++ b/test/unit/lib/shared/meta-json.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Test för zod-validerad meta.json-läsning (#187, ADR 0004-tolerans).
+ */
+
+import { describe, it, expect } from "vitest-compat";
+
+import { metaJsonSchema, schemaVersionFromMetaJson } from "@/lib/shared/meta-json";
+
+describe("schemaVersionFromMetaJson (#187)", () => {
+  it("läser giltig version", () => {
+    expect(schemaVersionFromMetaJson('{"schemaVersion": 2}')).toBe(2);
+  });
+
+  it("saknad nyckel → undefined (v1-baslinje)", () => {
+    expect(schemaVersionFromMetaJson("{}")).toBeUndefined();
+    expect(schemaVersionFromMetaJson('{"other": true}')).toBeUndefined();
+  });
+
+  it("fel typ (sträng/decimal/negativ) → undefined, inte krasch", () => {
+    expect(schemaVersionFromMetaJson('{"schemaVersion": "2"}')).toBeUndefined();
+    expect(schemaVersionFromMetaJson('{"schemaVersion": 1.5}')).toBeUndefined();
+    expect(schemaVersionFromMetaJson('{"schemaVersion": -1}')).toBeUndefined();
+  });
+
+  it("trasig JSON kastar (anroparen tolkar som baslinje i sin try/catch)", () => {
+    expect(() => schemaVersionFromMetaJson("not json")).toThrow();
+  });
+
+  it("passthrough: okända fält bevaras i schemat", () => {
+    const parsed = metaJsonSchema.parse({ schemaVersion: 2, demoVersion: "x" });
+    expect((parsed as Record<string, unknown>).demoVersion).toBe("x");
+  });
+});


### PR DESCRIPTION
Closes #187.

Svep efter stilregeln (#185): **21 ställen** parsade extern/ostrukturerad data utan zod (rena `as`-casts, handrullade typeof-helpers). Nu valideras allt vid gränsen; typer är `z.infer`-härledda där interfaces ersatts.

## Nya delade helpers
- **`src/lib/shared/meta-json.ts`** — `schemaVersionFromMetaJson`: EN zod-validerad läsväg för `.ava/meta.json` (ersätter tre `JSON.parse(...) as`-ställen: demo-loader, server-working-copy, load-self-hosted-source). ADR 0004-toleransen bevarad (ogiltig version → v1-baslinje).
- **`src/lib/client/load-from-storage.ts`** — `loadFromStorage(key, schema, fallback)`: zod-validerad localStorage-läsning; ersätter parse+cast i firma-config, oauth-config, authSettings, llm-config, sidebar, kalender-user-picker. Nya gränser får zod gratis.

## HIGH — nätverk/fil → domänlogik
- **demo-meta.ts**: handrullade validatorer → `demoMetaSchema` (roll som `z.enum`; felmeddelanden "saknar X" bevarade som zod-messages — befintliga tester passerar oförändrade).
- **github-auth.ts**: `GitHubUser` (identitet) + repo-permissions (access-beslut) safeParse:as — var rena casts.
- **web-oauth-device-flow.tsx**: device-code- + token-svar valideras.
- **github/api.ts + microsoft-graph.ts**: `expectOk` är nu **schema-drivet** (`expectOk(res, label, schema)`) i stället för typ-parameter; felkroppar zod-parsas. Schemana kräver det koden **konsumerar** (`tree.sha`, `path/type/sha`, `encoding/content`) — övriga API-fält optionella, så klienten inte blir skör mot API-tillägg.
- **settings/page.tsx** (logo-API), **preload-documents.ts** (manifest + doc-meta).

## MEDIUM — egen lagring
- **sync-state.ts**: `z.literal(1)`-version ersätter cast + manuell versionskoll. **persistence.ts**: `fsSnapshotSchema` för OPFS-snapshot. **schema-migrations.ts** + **web-llm-extractor.ts**: objekt-validering via `z.record`.

## Beteenden bevarade
Fältvis tolerans via `.catch` (oauth/llm — fel typ på ett fält nollar bara det fältet), element-vis filtrering i user-picker (`transform`), meta.json-baslinje (ADR 0004). Auth-test-mockar kompletterade med obligatoriskt `id` (riktiga API:t skickar alltid det).

OBS: en mellancommit ångrar en lokal CLAUDE.md-ändring (graphify-verktygets install-skript) som inte hör till PR:en — netto-diffen för CLAUDE.md är tom.

## Verifiering
`bun run test:all` grönt (2411 enhetstester + coverage + e2e round-trip, 308s). Nya tester: meta-json (5), load-from-storage (5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)