### PR TITLE
test(data-store): lås shallow-snapshot rollback-invariant (#190)

### DIFF
--- a/test/unit/server/data-store/demo-data-store-transaction.test.ts
+++ b/test/unit/server/data-store/demo-data-store-transaction.test.ts
@@ -79,3 +79,69 @@ describe("DemoDataStore.transaction", () => {
     expect(events).toHaveLength(1);
   });
 });
+
+/**
+ * Rollback-invariant för den SHALLOW snapshot:en (#190).
+ *
+ * `snapshotSource()` kopierar varje source-array (shallow) — INTE rad-objekten.
+ * Snapshot-arrayen delar alltså rad-referenser med live-arrayen. Det räcker för
+ * rollback ENBART så länge delegates *ersätter* en rad-slot (`collection[idx] =
+ * {...current, ...data}`) i stället för att mutera rad-objektet in-place. Om en
+ * delegate-väg någonsin börjar mutera ett rad-objekt direkt skulle snapshot:en
+ * peka på samma (nu muterade) objekt och rollback bli verkningslös.
+ *
+ * Dessa tester låser invarianten så ett sådant regress fångas.
+ */
+describe("DemoDataStore.transaction — shallow snapshot-invariant (#190)", () => {
+  it("muterar aldrig original-rad-objektet in-place vid rollback", async () => {
+    const { ds, source } = makeStore();
+    const originalInvoice = source.invoices![0]; // fånga referensen FÖRE tx
+    const before = { ...originalInvoice };
+
+    await expect(
+      ds.transaction(async (tx) => {
+        await tx.invoices.update({
+          where: { id: "inv1" },
+          data: { status: "PAID", amount: 9999 },
+        } as never);
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    // Original-objektet får ALDRIG ha muterats — annars räcker inte den shallow
+    // snapshot:en. (Object.assign(current, data) i update() skulle falla här.)
+    expect(originalInvoice).toEqual(before);
+    // Och source pekar tillbaka på det oförändrade originalet
+    expect(source.invoices![0]).toBe(originalInvoice);
+    expect((source.invoices![0] as { status: string }).status).toBe("SENT");
+    expect((source.invoices![0] as { amount: number }).amount).toBe(1000);
+  });
+
+  it("återställer nästlade objekt-fält vid rollback", async () => {
+    const source: DemoSource = {
+      invoices: [
+        { id: "inv1", amount: 1000, status: "SENT", matterId: "m1", meta: { note: "ursprunglig" } },
+      ],
+      payments: [],
+    };
+    const events: MutationEvent<Record<string, unknown>>[] = [];
+    const ds = new DemoDataStore(source, (e) => {
+      events.push(e);
+    });
+
+    await expect(
+      ds.transaction(async (tx) => {
+        await tx.invoices.update({
+          where: { id: "inv1" },
+          data: { meta: { note: "ändrad" } },
+        } as never);
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    // Det nästlade objektet återställs eftersom hela original-raden bevaras
+    // via referens i snapshot:en (update ersätter slot:en, muterar ej meta).
+    expect((source.invoices![0] as { meta: { note: string } }).meta.note).toBe("ursprunglig");
+    expect(events).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Vad

Två tester som låser rollback-invarianten för `DemoDataStore.transaction()`.

## Varför

`snapshotSource()` är **shallow** — den kopierar source-arrayerna men delar rad-objekten via referens. Rollback via `restoreSource()` fungerar därför korrekt **endast** så länge delegates *ersätter* en rad-slot (`collection[idx] = {...current, ...data}`, se `writable-delegate.ts:93`) i stället för att mutera rad-objektet in-place. Invarianten var implicit; den här PR:en gör den explicit och regress-skyddad.

## Tester

- `muterar aldrig original-rad-objektet in-place vid rollback` — fångar ett framtida `Object.assign(current, data)`-regress i `update()` (kollar både objekt-identitet och fält).
- `återställer nästlade objekt-fält vid rollback` — täcker nästlat objekt-fält (befintlig täckning testade bara skalärt `status`).

## Risk

Ingen — endast tillägg av test, inga produktionsändringar.

## Verifierat lokalt

- `bun run test:all --no-e2e` grönt: static (typecheck + lint --max-warnings 0 + knip + deps + duplicates) + unit/coverage (2518 pass, golv grönt). E2E (git round-trip) lämnas till CI (orört av en test-only-ändring; lokal e2e skulle störa den körande demo-containern).

Closes #190