### PR TITLE
refactor(templates): sänk komplexitet i buildTemplateContext (#40)

### DIFF
--- a/src/lib/client/templates/build-template-context.ts
+++ b/src/lib/client/templates/build-template-context.ts
@@ -40,36 +40,54 @@ export interface BuildTemplateContextInput {
   now?: Date;
 }
 
-// eslint-disable-next-line complexity
+/** `YYYY-MM-DD` lokalt — stabil shape som seed-mallar förväntar sig. */
+function formatToday(now: Date): string {
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+}
+
+function buildMatter(matter: TemplateMatter): Record<string, unknown> {
+  return {
+    matterNumber: matter.matterNumber,
+    title: matter.title,
+    matterType: matter.matterType ?? "",
+  };
+}
+
+/** Mottagare/klient: `null` (ej tomt objekt) när kontakten saknas. */
+function buildRecipient(recipient: TemplateContact | null | undefined): Record<string, unknown> | null {
+  if (!recipient) return null;
+  return {
+    name: recipient.name,
+    email: recipient.email ?? "",
+    phone: recipient.phone ?? "",
+    personalNumber: recipient.personalNumber ?? "",
+    orgNumber: recipient.orgNumber ?? "",
+  };
+}
+
+function buildClient(client: TemplateContact | null | undefined): Record<string, unknown> | null {
+  if (!client) return null;
+  return { name: client.name, email: client.email ?? "", phone: client.phone ?? "" };
+}
+
+function buildOrganization(organization: TemplateOrganization | null | undefined): Record<string, unknown> {
+  const org: TemplateOrganization = organization ?? {};
+  return {
+    name: org.name ?? "",
+    orgNumber: org.orgNumber ?? "",
+    address: org.address ?? "",
+    email: org.email ?? "",
+    phone: org.phone ?? "",
+  };
+}
+
 export function buildTemplateContext(input: BuildTemplateContextInput): Record<string, unknown> {
   const now = input.now ?? new Date();
-  const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
-
   return {
-    today,
-    matter: {
-      matterNumber: input.matter.matterNumber,
-      title: input.matter.title,
-      matterType: input.matter.matterType ?? "",
-    },
-    recipient: input.recipient
-      ? {
-          name: input.recipient.name,
-          email: input.recipient.email ?? "",
-          phone: input.recipient.phone ?? "",
-          personalNumber: input.recipient.personalNumber ?? "",
-          orgNumber: input.recipient.orgNumber ?? "",
-        }
-      : null,
-    client: input.client
-      ? { name: input.client.name, email: input.client.email ?? "", phone: input.client.phone ?? "" }
-      : null,
-    organization: {
-      name: input.organization?.name ?? "",
-      orgNumber: input.organization?.orgNumber ?? "",
-      address: input.organization?.address ?? "",
-      email: input.organization?.email ?? "",
-      phone: input.organization?.phone ?? "",
-    },
+    today: formatToday(now),
+    matter: buildMatter(input.matter),
+    recipient: buildRecipient(input.recipient),
+    client: buildClient(input.client),
+    organization: buildOrganization(input.organization),
   };
 }


### PR DESCRIPTION
## Vad

Bryter ut `buildTemplateContext` (cyklomatisk komplexitet **21**, hade `// eslint-disable-next-line complexity`) i rena per-sektions-byggare: `formatToday`, `buildMatter`, `buildRecipient`, `buildClient`, `buildOrganization`. Varje funktion ligger nu **≤8** och disable:n är borttagen.

## Varför

Ett ratchet-steg mot **#40** (strikt complexity i `src/lib`). Detta var den **värsta** src/lib-funktionen (21). Mätt med `eslint --no-inline-config` finns **28** genuina complexity-överträdelser i `src/lib`; den här fixar #1 → 27 kvar. Loopen tar en per varv.

## Beteende

Oförändrat — identisk output-shape och defaults (tom sträng för saknade fält; `recipient`/`client` → `null` när kontakt saknas). Verifierat av `generate-template.test.ts` (5 tester) + full svit.

## Verifierat lokalt

`bun run test:all --no-e2e` grönt: static (typecheck + lint --max-warnings 0 + knip + deps + duplicates) + unit/coverage (2518 pass, golv grönt). E2E körs av CI.

Refs #40