### PR TITLE
chore(deps-cruiser): begränsa helper-app till shared-lagret (#85)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "smoke:tier3": "bash tooling/scripts/test-tier3-smoke.sh",
     "test:all": "bash tooling/scripts/test-all.sh",
     "duplicates": "jscpd --config tooling/config/jscpd.json src",
-    "deps:check": "depcruise --config tooling/config/dependency-cruiser.cjs --output-type err src test",
+    "deps:check": "depcruise --config tooling/config/dependency-cruiser.cjs --output-type err src test helper-app",
     "deps:graph": "depcruise --config tooling/config/dependency-cruiser.cjs --output-type dot src | dot -Tsvg > reports/dependency-graph.svg",
     "deps:archi": "depcruise --config tooling/config/dependency-cruiser.cjs --output-type archi src | dot -Tsvg > reports/architecture.svg",
     "knip": "knip --config tooling/config/knip.json",

--- a/tooling/config/dependency-cruiser.cjs
+++ b/tooling/config/dependency-cruiser.cjs
@@ -168,6 +168,24 @@ module.exports = {
       to: { path: "node_modules/(react|react-dom|next|@trpc)(/|$)" },
     },
     {
+      // Lager-gräns (#85): helper-appen (@ava/helper) är ett separat build-
+      // target (egen bundler) som delar kod med web-appen ENBART via det
+      // framework-agnostiska shared-lagret (protocol-kontrakt, scheman). Den
+      // får aldrig dra in UI- (client/) eller backend- (server/) kod — det
+      // skulle koppla en fristående process till Next-appens interna lager och
+      // vore första steget mot att tvingas bryta ut ett @ava/core-paket (#85
+      // är deferred just för att den här gränsen räcker som REGEL, utan paket).
+      // Samma gräns gäller framtida add-ins (lägg till from-path per target).
+      name: "helper-app-only-imports-shared",
+      severity: "error",
+      comment:
+        "helper-app får bara importera från src/lib/shared/ (delad, framework-" +
+        "agnostisk kärna) — aldrig client/ eller server/. Delad kod som helpern " +
+        "behöver hör hemma i shared/. (Se #85.)",
+      from: { path: "^helper-app/" },
+      to: { path: "^src/lib/(client|server)/" },
+    },
+    {
       // Kompositions-disciplin: varje top-level-router (`routers/<x>.ts`)
       // exporterar EN `xRouter` och komponeras ihop i `_app.ts`. Routrar får
       // inte importera varandra — det skapar implicit koppling, cykler och gör


### PR DESCRIPTION
## Vad

Formaliserar gränsen "helper-app delar kod med web-appen ENBART via shared-lagret" som en dependency-cruiser-regel.

- Ny regel **`helper-app-only-imports-shared`**: `^helper-app/` får importera `^src/lib/shared/` men aldrig `client/`/`server/` (severity error).
- `deps:check`-scope utökad: `src test` → `src test helper-app` (helper-app cruisades inte alls tidigare).

## Varför

Interim-alternativ till **#85** (bryta ut `@ava/core`-workspace-paket). Diskussionen på #85: paket köper (a) enforced gränser och (b) cross-target-delning — båda har vi redan (dep-cruiser + `@/`-alias). Den här regeln ger gräns-garantin som paket skulle gett, till **noll build-kostnad**. #85 förblir deferred tills en andra tung konsument med egen bundler (#83/#80) behöver dela mer än protocol-kontraktet.

## Verifierat

- `deps:check` grönt med nya scope+regeln (700 moduler, 0 violations).
- **Negativt test:** injicerade en `helper-app → @/lib/server/...`-import → regeln fångade den som error och `deps:check` exit 1; grönt igen efter revert.
- `bun run test:all --no-e2e` grönt: static + unit/coverage (2518 pass, golv 82.81%/79.52%). E2E körs av CI.

Refs #85