### PR TITLE
chore(coverage): höj rader-/funktionsgolv till 82/79 (#27)

### DIFF
--- a/tooling/scripts/check-coverage.ts
+++ b/tooling/scripts/check-coverage.ts
@@ -13,12 +13,12 @@ import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 
 // Förankrat strax under nuvarande lcov-mätning under --parallel (rader
-// ~78.0% / funktioner ~78.3%). RATCHET — flytta bara uppåt.
+// ~82.8% / funktioner ~79.5%). RATCHET — flytta bara uppåt.
 // OBS: --parallel under-rapporterar mot --isolate (bun aggregerar coverage
 // löst över workers), men deterministiskt → giltigt golv. --isolate kraschar
 // på CI-linux (epoll_ctl EEXIST), så --parallel är den körbara vägen (#92).
-const LINE_FLOOR = 0.76;
-const FUNC_FLOOR = 0.77;
+const LINE_FLOOR = 0.82;
+const FUNC_FLOOR = 0.79;
 const LCOV = "coverage/lcov.info";
 
 const TEST_GLOBS = ["test/unit", "test/integration", "test/scripts"];


### PR DESCRIPTION
## Vad

Höjer coverage-golvet i `check-coverage.ts` från 76%/77% → **82%/79%** (rader/funktioner), förankrat strax under nuvarande utfall (82.79% / 79.52%).

## Varför

Golvet låg ~6pp under verkligheten → fångade inga regressioner. Ratchet-steg (#27, mål 95%). Marginal: rader +0.79pp, funktioner +0.52pp.

## Verifierat

`bun run test:cov` (--parallel, samma som CI) grönt med marginal.

Refs #27