### PR TITLE
refactor(github): sänk komplexitet i pushViaRest/pullViaRest (#40)

### DIFF
--- a/src/lib/client/github/pull.ts
+++ b/src/lib/client/github/pull.ts
@@ -36,7 +36,30 @@ export interface PullResult {
   filesUpdated: number;
 }
 
-// eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Async function 'pullViaRest' has a complexity of 13. Maximum allowed is 8.)
+/** Remote blob-SHAs per path (ignorerar tree/non-blob-entries). */
+function buildRemoteFiles(treeEntries: ReadonlyArray<{ type: string; path: string; sha: string }>): Map<string, string> {
+  const remoteFiles = new Map<string, string>();
+  for (const e of treeEntries) {
+    if (e.type === "blob") remoteFiles.set(e.path, e.sha);
+  }
+  return remoteFiles;
+}
+
+/** Filer att hämta: i remote, men saknas lokalt eller har annan SHA. */
+function computeFetchList(remoteFiles: Map<string, string>, localMap: Map<string, string>): Array<{ path: string; sha: string }> {
+  const toFetch: Array<{ path: string; sha: string }> = [];
+  for (const [path, sha] of remoteFiles) {
+    if (localMap.get(path) !== sha) toFetch.push({ path, sha });
+  }
+  return toFetch;
+}
+
+/** Filer att radera: fanns i förra sync-state men inte i remote nu. */
+function computeDeleteList(state: SyncState | null, remoteFiles: Map<string, string>): string[] {
+  if (!state) return [];
+  return Object.keys(state.files).filter((path) => !remoteFiles.has(path));
+}
+
 export async function pullViaRest(args: PullArgs): Promise<PullResult> {
   const opts = { token: args.token, ...(args.signal !== undefined ? { signal: args.signal } : {}) };
   const state = await readSyncState(args.handle);
@@ -52,29 +75,11 @@ export async function pullViaRest(args: PullArgs): Promise<PullResult> {
     throw new Error(`Tree är för stort (>100k entries) — REST-pull kan inte hantera det. Använd CLI-clone som engångsoperation.`);
   }
 
-  // Bygg karta över remote-fil-SHAs
-  const remoteFiles = new Map<string, string>();
-  for (const e of tree.tree) {
-    if (e.type === "blob") remoteFiles.set(e.path, e.sha);
-  }
-
-  // Lokala filer för diff
+  const remoteFiles = buildRemoteFiles(tree.tree);
   const localFiles = await walkFsa(args.handle);
   const localMap = new Map(localFiles.map((f) => [f.path, f.sha]));
-
-  // Filer att hämta: i remote, saknas lokalt ELLER har annan SHA
-  const toFetch: Array<{ path: string; sha: string }> = [];
-  for (const [path, sha] of remoteFiles) {
-    if (localMap.get(path) !== sha) toFetch.push({ path, sha });
-  }
-
-  // Filer att radera: fanns lokalt + i förra sync, men inte i remote nu
-  const toDelete: string[] = [];
-  if (state) {
-    for (const path of Object.keys(state.files)) {
-      if (!remoteFiles.has(path)) toDelete.push(path);
-    }
-  }
+  const toFetch = computeFetchList(remoteFiles, localMap);
+  const toDelete = computeDeleteList(state, remoteFiles);
 
   // Parallell-fetch (men begränsad till 8 samtidigt för att undvika
   // GitHub rate-limit-burst). 5000 req/h auth räcker mer än väl.
@@ -88,16 +93,13 @@ export async function pullViaRest(args: PullArgs): Promise<PullResult> {
     await deleteFile(args.handle, path);
   }
 
-  // Skriv ny sync-state
-  const filesMap: Record<string, string> = {};
-  for (const [path, sha] of remoteFiles) filesMap[path] = sha;
   const newState: SyncState = {
     version: 1,
     branch: args.branch,
     lastHead: newHead,
     lastTree: commit.tree.sha,
     lastSyncedAt: new Date().toISOString(),
-    files: filesMap,
+    files: Object.fromEntries(remoteFiles),
   };
   await writeSyncState(args.handle, newState);
 

--- a/src/lib/client/github/push.ts
+++ b/src/lib/client/github/push.ts
@@ -39,7 +39,68 @@ export interface PushResult {
   filesPushed: number;
 }
 
-// eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Async function 'pushViaRest' has a complexity of 12. Maximum allowed is 8.)
+interface ChangedFile {
+  path: string;
+  bytes: Uint8Array;
+}
+interface PushDiff {
+  changed: ChangedFile[];
+  deleted: string[];
+}
+type TreeEntry = { path: string; mode: string; type: "blob"; sha: string | null };
+
+/** Diffa lokal working-copy mot sync-state: ändrade (sha skiljer) + raderade. */
+function diffAgainstState(
+  local: Array<{ path: string; bytes: Uint8Array; sha: string }>,
+  state: SyncState,
+): PushDiff {
+  const localMap = new Map(local.map((f) => [f.path, f]));
+  const changed: ChangedFile[] = [];
+  const deleted: string[] = [];
+  for (const f of local) {
+    if (state.files[f.path] !== f.sha) changed.push({ path: f.path, bytes: f.bytes });
+  }
+  for (const path of Object.keys(state.files)) {
+    if (!localMap.has(path)) deleted.push(path);
+  }
+  return { changed, deleted };
+}
+
+/** Tree-entries för GitHub create-tree (sha=null = radering). */
+function buildTreeEntries(diff: PushDiff, newBlobShas: Map<string, string>): TreeEntry[] {
+  const entries: TreeEntry[] = [];
+  for (const item of diff.changed) {
+    entries.push({ path: item.path, mode: "100644", type: "blob", sha: newBlobShas.get(item.path)! });
+  }
+  for (const path of diff.deleted) {
+    entries.push({ path, mode: "100644", type: "blob", sha: null });
+  }
+  return entries;
+}
+
+/** Commit-payload med valfria signature/author (utelämnas när undefined). */
+function buildCommitPayload(args: PushArgs, tree: string, parent: string) {
+  return {
+    message: args.message,
+    tree,
+    parents: [parent],
+    ...(args.signature !== undefined ? { signature: args.signature } : {}),
+    ...(args.author !== undefined ? { author: args.author } : {}),
+  };
+}
+
+/** Ny files-map: applicera ändrade SHAs + ta bort raderade. */
+function applyFileChanges(
+  stateFiles: Record<string, string>,
+  diff: PushDiff,
+  newBlobShas: Map<string, string>,
+): Record<string, string> {
+  const filesMap: Record<string, string> = { ...stateFiles };
+  for (const item of diff.changed) filesMap[item.path] = newBlobShas.get(item.path)!;
+  for (const path of diff.deleted) delete filesMap[path];
+  return filesMap;
+}
+
 export async function pushViaRest(args: PushArgs): Promise<PushResult> {
   const opts = { token: args.token, ...(args.signal !== undefined ? { signal: args.signal } : {}) };
   const state = await readSyncState(args.handle);
@@ -48,62 +109,23 @@ export async function pushViaRest(args: PushArgs): Promise<PushResult> {
   }
 
   const local = await walkFsa(args.handle);
-  const localMap = new Map(local.map((f) => [f.path, f]));
+  const diff = diffAgainstState(local, state);
 
-  // Diff
-  const changed: Array<{ path: string; bytes: Uint8Array }> = [];
-  const deleted: string[] = [];
-
-  for (const f of local) {
-    const lastSha = state.files[f.path];
-    if (lastSha !== f.sha) changed.push({ path: f.path, bytes: f.bytes });
-  }
-  for (const path of Object.keys(state.files)) {
-    if (!localMap.has(path)) deleted.push(path);
-  }
-
-  if (changed.length === 0 && deleted.length === 0) {
+  if (diff.changed.length === 0 && diff.deleted.length === 0) {
     return { kind: "up-to-date", head: state.lastHead, filesPushed: 0 };
   }
 
   // Skapa blobs parallellt
   const newBlobShas = new Map<string, string>();
-  await parallelLimit(changed, 8, async (item) => {
+  await parallelLimit(diff.changed, 8, async (item) => {
     const sha = await createBlob(args.repo, item.bytes, opts);
     newBlobShas.set(item.path, sha);
   });
 
-  // Bygg tree-entries (sha=null = delete)
-  const entries: Array<{ path: string; mode: string; type: "blob"; sha: string | null }> = [];
-  for (const item of changed) {
-    entries.push({
-      path: item.path,
-      mode: "100644",
-      type: "blob",
-      sha: newBlobShas.get(item.path)!,
-    });
-  }
-  for (const path of deleted) {
-    entries.push({ path, mode: "100644", type: "blob", sha: null });
-  }
-
-  const newTreeSha = await createTree(args.repo, state.lastTree, entries, opts);
-  const newCommitSha = await createCommit(args.repo, {
-    message: args.message,
-    tree: newTreeSha,
-    parents: [state.lastHead],
-    ...(args.signature !== undefined ? { signature: args.signature } : {}),
-    ...(args.author !== undefined ? { author: args.author } : {}),
-  }, opts);
+  const newTreeSha = await createTree(args.repo, state.lastTree, buildTreeEntries(diff, newBlobShas), opts);
+  const newCommitSha = await createCommit(args.repo, buildCommitPayload(args, newTreeSha, state.lastHead), opts);
 
   await updateRef(args.repo, args.branch, newCommitSha, opts);
-
-  // Uppdatera sync-state med nya SHAs
-  const filesMap: Record<string, string> = { ...state.files };
-  for (const item of changed) {
-    filesMap[item.path] = newBlobShas.get(item.path)!;
-  }
-  for (const path of deleted) delete filesMap[path];
 
   const newState: SyncState = {
     version: 1,
@@ -111,14 +133,14 @@ export async function pushViaRest(args: PushArgs): Promise<PushResult> {
     lastHead: newCommitSha,
     lastTree: newTreeSha,
     lastSyncedAt: new Date().toISOString(),
-    files: filesMap,
+    files: applyFileChanges(state.files, diff, newBlobShas),
   };
   await writeSyncState(args.handle, newState);
 
   return {
     kind: "pushed",
     head: newCommitSha,
-    filesPushed: changed.length + deleted.length,
+    filesPushed: diff.changed.length + diff.deleted.length,
   };
 }
 


### PR DESCRIPTION
## Vad

Tar bort två `complexity`-disables i git-sync-klienten via rena helper-extraktioner:
- **push**: `diffAgainstState`, `buildTreeEntries`, `buildCommitPayload`, `applyFileChanges` (12→≤8)
- **pull**: `buildRemoteFiles`, `computeFetchList`, `computeDeleteList` + `Object.fromEntries` (13→≤8)

## Beteende

Oförändrat — identisk diff-/tree-/sync-state-logik. Verifierat av github-tester (14) + full svit (2518 pass) + coverage-golv grönt (82.80%/79.57%).

## Scope

Ratchet-steg mot **#40** (src/lib strikt complexity@8): 23 → 21 kvar. Refs #40.