### PR TITLE
refactor(local-first): sänk komplexitet i 6 funktioner (#40)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -154,12 +154,7 @@
   },
   "src/lib/server/local-first/demo-loader.ts": {
     "max-depth": {
-      "count": 4
-    }
-  },
-  "src/lib/server/local-first/filesystem-event-log.ts": {
-    "max-depth": {
-      "count": 3
+      "count": 2
     }
   },
   "src/lib/server/routers/reports.ts": {

--- a/src/lib/server/local-first/clone-from-github.ts
+++ b/src/lib/server/local-first/clone-from-github.ts
@@ -77,13 +77,16 @@ export function cloneFromGithub(options: CloneFromGithubOptions = {}): DemoClone
  * I browser krävs en CORS-proxy mot github.com. I Node ignoreras
  * proxy:n. `null` = användaren har stängt av explicit.
  */
-// eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Function 'resolveCorsProxy' has a complexity of 10. Maximum allowed is 8.)
 function resolveCorsProxy(opt: string | null | undefined): string | null {
   if (opt === null) return null;
   if (opt) return opt;
   const isBrowser = typeof globalThis !== "undefined"
     && (globalThis as { window?: unknown }).window !== undefined;
-  if (!isBrowser) return null;
+  return isBrowser ? resolveBrowserProxy() : null;
+}
+
+/** Auto-vald CORS-proxy i browser: build-time env → lokal dev → publik fallback. */
+function resolveBrowserProxy(): string {
   // 1. Build-time injicerad proxy (Cloudflare Worker i prod-deploy)
   const envProxy = process.env.NEXT_PUBLIC_CORS_PROXY_URL;
   if (envProxy) return envProxy;

--- a/src/lib/server/local-first/demo-loader.ts
+++ b/src/lib/server/local-first/demo-loader.ts
@@ -59,7 +59,6 @@ export class DemoLoader {
    * Klona repo och hydratisera alla entiteter.
    * Idempotent — fler anrop ersätter tidigare snapshot.
    */
-  // eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Async method 'loadDemo' has a complexity of 10. Maximum allowed is 8.)
   async loadDemo(url: string): Promise<LoadResult> {
     // Reset state — flera ladd-anrop ger fresh data
     await this.clearFs();
@@ -81,26 +80,40 @@ export class DemoLoader {
     // konvention som production-hydrator.
     for (const entity of this.deps.registry.entities()) {
       for (const prefix of this.knownPrefixes(entity)) {
-        const items = await this.deps.fs.listDir(prefix);
-        for (const item of items) {
-          if (!item.endsWith(".json")) continue;
-          const path = `${prefix}/${item}`;
-          try {
-            const r = await hydrator.hydratePath(path);
-            if (!r) continue;
-            if (!this.hydrated.has(r.entity)) this.hydrated.set(r.entity, []);
-            this.hydrated.get(r.entity)!.push(r.data);
-            result.entities[r.entity] = (result.entities[r.entity] ?? 0) + 1;
-            result.totalCount += 1;
-          } catch (err) {
-            result.errors.push({ path, error: err instanceof Error ? err.message : String(err) });
-            console.error(`[demo-loader] kunde inte hydratisera ${path}:`, err);
-          }
-        }
+        await this.hydratePrefix(hydrator, prefix, result);
       }
     }
 
     return result;
+  }
+
+  /** Hydratisera alla .json-filer under ett prefix; fel per fil loggas + samlas. */
+  private async hydratePrefix(
+    hydrator: ProjectionHydrator,
+    prefix: string,
+    result: LoadResult,
+  ): Promise<void> {
+    const items = await this.deps.fs.listDir(prefix);
+    for (const item of items) {
+      if (!item.endsWith(".json")) continue;
+      const path = `${prefix}/${item}`;
+      try {
+        const r = await hydrator.hydratePath(path);
+        if (!r) continue;
+        this.recordHydrated(r, result);
+      } catch (err) {
+        result.errors.push({ path, error: err instanceof Error ? err.message : String(err) });
+        console.error(`[demo-loader] kunde inte hydratisera ${path}:`, err);
+      }
+    }
+  }
+
+  /** Bokför en hydratiserad rad i snapshot + räknare. */
+  private recordHydrated(r: { entity: string; data: unknown }, result: LoadResult): void {
+    if (!this.hydrated.has(r.entity)) this.hydrated.set(r.entity, []);
+    this.hydrated.get(r.entity)!.push(r.data);
+    result.entities[r.entity] = (result.entities[r.entity] ?? 0) + 1;
+    result.totalCount += 1;
   }
 
   /** Returnera hydratiserade entiteter per typ. */

--- a/src/lib/server/local-first/filesystem-claim-store.ts
+++ b/src/lib/server/local-first/filesystem-claim-store.ts
@@ -36,7 +36,19 @@ export class FilesystemClaimStore implements IClaimStore {
     private maxRetries: number = DEFAULT_MAX_RETRIES,
   ) {}
 
-  // eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Async method 'tryClaim' has a complexity of 9. Maximum allowed is 8.)
+  /**
+   * Disposition för en befintlig claim:
+   *   "blocked" — någon annan har en levande claim
+   *   "ours"    — vi äger den redan (re-entrant)
+   *   "free"    — saknas eller utgången → fri att ta
+   */
+  private claimState(existing: ClaimRow | null): "blocked" | "ours" | "free" {
+    if (!existing) return "free";
+    if (existing.claimedBy === this.me) return "ours";
+    if (!this.isExpired(existing)) return "blocked";
+    return "free";
+  }
+
   async tryClaim(claimId: string, opts: ClaimOpts): Promise<boolean> {
     const ttlSec = opts.ttlSec ?? DEFAULT_TTL_SEC;
 
@@ -44,13 +56,9 @@ export class FilesystemClaimStore implements IClaimStore {
       await this.git.fetch();
       await this.git.resetHardToRemote();
 
-      const existing = await this.findClaim(claimId);
-      if (existing && existing.claimedBy !== this.me && !this.isExpired(existing)) {
-        return false; // någon annan har en levande claim
-      }
-      if (existing && existing.claimedBy === this.me) {
-        return true; // re-entrant
-      }
+      const state = this.claimState(await this.findClaim(claimId));
+      if (state === "blocked") return false;
+      if (state === "ours") return true; // re-entrant
 
       const row: ClaimRow = {
         claimId,

--- a/src/lib/server/local-first/filesystem-event-log.ts
+++ b/src/lib/server/local-first/filesystem-event-log.ts
@@ -77,7 +77,6 @@ export class FilesystemEventLog implements IEventLog {
     return results;
   }
 
-  // eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Async generator method 'iterate' has a complexity of 10. Maximum allowed is 8.)
   async *iterate(filter: EventFilter): AsyncIterable<AvaEvent> {
     // För nu: linjär scan över alla års-mappar (sorterade lex). Optimering
     // (slice efter `since/until`) kommer när vi har realistisk last.
@@ -88,17 +87,21 @@ export class FilesystemEventLog implements IEventLog {
         const days = (await this.fs.listDir(`events/${year}/${month}`)).sort();
         for (const day of days) {
           if (!day.endsWith(".jsonl")) continue;
-          const path = `events/${year}/${month}/${day}`;
-          let content: string;
-          try { content = await this.fs.readFile(path); } catch { continue; }
-          for (const line of content.split("\n")) {
-            if (!line) continue;
-            let event: AvaEvent;
-            try { event = this.projection.deserializeLine(line); } catch { continue; }
-            if (this.matches(event, filter)) yield event;
-          }
+          yield* this.iterateFile(`events/${year}/${month}/${day}`, filter);
         }
       }
+    }
+  }
+
+  /** Läs en .jsonl-dag-fil och yield:a matchande events (rad för rad). */
+  private async *iterateFile(path: string, filter: EventFilter): AsyncIterable<AvaEvent> {
+    let content: string;
+    try { content = await this.fs.readFile(path); } catch { return; }
+    for (const line of content.split("\n")) {
+      if (!line) continue;
+      let event: AvaEvent;
+      try { event = this.projection.deserializeLine(line); } catch { continue; }
+      if (this.matches(event, filter)) yield event;
     }
   }
 
@@ -109,15 +112,28 @@ export class FilesystemEventLog implements IEventLog {
 
   // ── intern matching (delar logik med PostgresEventLog) ─────────
 
-  // eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Method 'matches' has a complexity of 14. Maximum allowed is 8.)
   private matches(event: AvaEvent, filter: EventFilter): boolean {
-    if (filter.type) {
-      const types = Array.isArray(filter.type) ? filter.type : [filter.type];
-      if (!types.includes(event.type)) return false;
-    }
+    return (
+      this.matchesType(event, filter) &&
+      this.matchesScalars(event, filter) &&
+      this.matchesTimeRange(event, filter)
+    );
+  }
+
+  private matchesType(event: AvaEvent, filter: EventFilter): boolean {
+    if (!filter.type) return true;
+    const types = Array.isArray(filter.type) ? filter.type : [filter.type];
+    return types.includes(event.type);
+  }
+
+  private matchesScalars(event: AvaEvent, filter: EventFilter): boolean {
     if (filter.matterId && event.matterId !== filter.matterId) return false;
     if (filter.actorId && event.actor.id !== filter.actorId) return false;
     if (filter.source && event.source !== filter.source) return false;
+    return true;
+  }
+
+  private matchesTimeRange(event: AvaEvent, filter: EventFilter): boolean {
     if (filter.since && event.ts < filter.since) return false;
     if (filter.until && event.ts > filter.until) return false;
     return true;

--- a/src/lib/server/local-first/isomorphic-git-ops.ts
+++ b/src/lib/server/local-first/isomorphic-git-ops.ts
@@ -25,6 +25,16 @@ import * as git from "isomorphic-git";
 import type { GitCommit, IGitOps, PushResult } from "./git-ops";
 import type { MemFs } from "./mem-fs";
 
+type PushFailReason = NonNullable<PushResult["reason"]>;
+
+/** Klassificera ett push-fel till en stabil reason-kod via meddelande-mönster. */
+function classifyPushError(err: unknown): PushFailReason {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (/non-fast-forward|rejected|push not fast-forward/i.test(msg)) return "NonFastForward";
+  if (/network|fetch|timeout|connection/i.test(msg)) return "NetworkError";
+  return "Unknown";
+}
+
 export interface IsomorphicGitOpsDeps {
   /** MemFs (eller annan IFileSystem som även exponerar `nodeFs()`). */
   fs: MemFs;
@@ -122,7 +132,6 @@ export class IsomorphicGitOps implements IGitOps {
     return this.toCommit(head);
   }
 
-  // eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Async method 'push' has a complexity of 9. Maximum allowed is 8.)
   async push(): Promise<PushResult> {
     if (!this.deps.remoteUrl || !this.deps.http) {
       return { ok: false, reason: "Unknown" };
@@ -137,17 +146,9 @@ export class IsomorphicGitOps implements IGitOps {
         url: this.deps.remoteUrl,
         ...(this.deps.token ? { onAuth: () => ({ username: "token", password: this.deps.token! }) } : {}),
       });
-      if (result.ok) return { ok: true };
-      return { ok: false, reason: "NonFastForward" };
+      return result.ok ? { ok: true } : { ok: false, reason: "NonFastForward" };
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (/non-fast-forward|rejected|push not fast-forward/i.test(msg)) {
-        return { ok: false, reason: "NonFastForward" };
-      }
-      if (/network|fetch|timeout|connection/i.test(msg)) {
-        return { ok: false, reason: "NetworkError" };
-      }
-      return { ok: false, reason: "Unknown" };
+      return { ok: false, reason: classifyPushError(err) };
     }
   }
 


### PR DESCRIPTION
## Vad

Tar bort complexity-disables i 5 `server/local-first`-filer (6 funktioner) via rena extraktioner:

| Funktion | Före | Extraktion |
|---|---|---|
| `filesystem-event-log.iterate` | 10 | `iterateFile` (per-fil-generator) |
| `filesystem-event-log.matches` | 14 | `matchesType` / `matchesScalars` / `matchesTimeRange` |
| `clone-from-github.resolveCorsProxy` | 10 | `resolveBrowserProxy` |
| `demo-loader.loadDemo` | 10 | `hydratePrefix` / `recordHydrated` |
| `filesystem-claim-store.tryClaim` | 9 | `claimState` |
| `isomorphic-git-ops.push` | 9 | `classifyPushError` |

Alla ≤8 nu; disables borttagna.

## Beteende

Oförändrat — verifierat av local-first-tester (268) + full svit (2518 pass) + coverage-golv grönt (82.80%/79.58%). Prunar även stale `max-depth`-suppressioner för demo-loader/filesystem-event-log (lägre nesting → #6).

## Scope

Ratchet-steg mot **#40** (src/lib strikt): 21 → 15 kvar. Refs #40.