### PR TITLE
refactor(server): sänk komplexitet i query-engine/delegate/paymentPlan (#40)

### DIFF
--- a/src/lib/server/data-store/in-memory/query-engine.ts
+++ b/src/lib/server/data-store/in-memory/query-engine.ts
@@ -97,7 +97,6 @@ export class InMemoryQueryEngine<T extends Record<string, unknown>> {
     return true;
   }
 
-  // eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Method 'fieldMatches' has a complexity of 12. Maximum allowed is 8.)
   private fieldMatches(fieldVal: unknown, expected: unknown): boolean {
     // Primitiv likhet
     if (expected === null || typeof expected !== "object" || expected instanceof Date) {
@@ -109,13 +108,20 @@ export class InMemoryQueryEngine<T extends Record<string, unknown>> {
     // Annars: nested relations-filter ({ matter: { organizationId } }).
     const isOperatorObj =
       keys.length > 0 && keys.every((k) => k === "mode" || k in this.ops);
-    if (!isOperatorObj) {
-      // To-one relation: rekursera ned i det nästlade objektet.
-      if (fieldVal && typeof fieldVal === "object" && !Array.isArray(fieldVal)) {
-        return this.matches(fieldVal as Record<string, unknown>, op);
-      }
-      return false;
+    if (!isOperatorObj) return this.matchesNestedRelation(fieldVal, op);
+    return this.applyOperators(fieldVal, op);
+  }
+
+  /** To-one relation: rekursera ned i det nästlade objektet ({ matter: {…} }). */
+  private matchesNestedRelation(fieldVal: unknown, op: Record<string, unknown>): boolean {
+    if (fieldVal && typeof fieldVal === "object" && !Array.isArray(fieldVal)) {
+      return this.matches(fieldVal as Record<string, unknown>, op);
     }
+    return false;
+  }
+
+  /** Applicera ett operator-objekt ({ in }, { gte, lte }…) på fältvärdet. */
+  private applyOperators(fieldVal: unknown, op: Record<string, unknown>): boolean {
     const ci = op.mode === "insensitive";
     for (const [opName, opVal] of Object.entries(op)) {
       if (opName === "mode") continue;

--- a/src/lib/server/data-store/in-memory/read-only-delegate.ts
+++ b/src/lib/server/data-store/in-memory/read-only-delegate.ts
@@ -201,24 +201,20 @@ export class ReadOnlyDelegate<T extends Record<string, unknown>> {
     return out;
   }
 
-  // eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Method 'resolveRelation' has a complexity of 11. Maximum allowed is 8.)
   private resolveRelation(
     parent: Record<string, unknown>,
     rc: RelationConfig<Record<string, unknown>>,
     spec: unknown,
     mode: "where" | "include",
   ): unknown {
-    const userWhere = mode === "include" && isObj(spec) ? (spec.where as Record<string, unknown>) ?? {} : {};
-    const finalWhere = { ...rc.where(parent), ...userWhere };
+    const finalWhere = { ...rc.where(parent), ...userWhereFor(spec, mode) };
     let children = rc.collection().filter((c) => this.engine.matches(c, finalWhere));
 
     const subTree = subTreeFor(spec, mode);
     if (subTree && rc.relations) {
       children = children.map((c) => this.hydrateWith(c, rc.relations!, subTree, mode));
     }
-    if (mode === "include" && isObj(spec) && typeof spec.take === "number") {
-      children = children.slice(0, spec.take);
-    }
+    children = applyTake(children, spec, mode);
     return rc.kind === "one" ? (children[0] ?? null) : children;
   }
 
@@ -257,6 +253,24 @@ export class ReadOnlyDelegate<T extends Record<string, unknown>> {
 
 function isObj(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** Användar-angivet where från en include-spec ({ where: {…} }); annars tomt. */
+function userWhereFor(spec: unknown, mode: "where" | "include"): Record<string, unknown> {
+  if (mode !== "include" || !isObj(spec)) return {};
+  return (spec.where as Record<string, unknown>) ?? {};
+}
+
+/** Begränsa barn-listan med `take` (bara i include-läge med numeriskt take). */
+function applyTake(
+  children: Record<string, unknown>[],
+  spec: unknown,
+  mode: "where" | "include",
+): Record<string, unknown>[] {
+  if (mode === "include" && isObj(spec) && typeof spec.take === "number") {
+    return children.slice(0, spec.take);
+  }
+  return children;
 }
 
 /** Vilket sub-träd att rekursera ned i för nested include / nested where. */

--- a/src/lib/server/routers/paymentPlan.ts
+++ b/src/lib/server/routers/paymentPlan.ts
@@ -80,6 +80,18 @@ function toPlanForScan(p: JoinedPlan): PlanForScan {
   };
 }
 
+/** Sökbar text för en plan-rad: ärendenr + titel + klientnamn + anteckningar. */
+function planHaystack(p: Record<string, unknown>): string {
+  const plan = p as unknown as JoinedPlan;
+  const matter: Matter = plan.invoice?.matter ?? {};
+  return [
+    matter.matterNumber ?? "",
+    matter.title ?? "",
+    resolveRecipient(matter).name,
+    (p.notes as string | null) ?? "",
+  ].join(" ").toLowerCase();
+}
+
 export const paymentPlanRouter = router({
   list: orgProcedure
     .input(
@@ -117,17 +129,7 @@ export const paymentPlanRouter = router({
       });
       if (!input?.search) return plans;
       const needle = input.search.toLowerCase();
-      // eslint-disable-next-line complexity
-      return plans.filter((p: Record<string, unknown>) => {
-        const inv = p.invoice as { matter?: { matterNumber?: string; title?: string; contacts?: Array<{ contact?: { name?: string } }> } } | undefined;
-        const haystack = [
-          inv?.matter?.matterNumber ?? "",
-          inv?.matter?.title ?? "",
-          inv?.matter?.contacts?.[0]?.contact?.name ?? "",
-          (p.notes as string | null) ?? "",
-        ].join(" ").toLowerCase();
-        return haystack.includes(needle);
-      });
+      return plans.filter((p: Record<string, unknown>) => planHaystack(p).includes(needle));
     }),
 
   getById: orgProcedure


### PR DESCRIPTION
## Vad

Ratchet-steg mot **#40** (src/lib strikt complexity@8) — 3 server-funktioner:

| Funktion | Före | Extraktion |
|---|---|---|
| `query-engine.fieldMatches` | 12 | `matchesNestedRelation` + `applyOperators` |
| `read-only-delegate.resolveRelation` | 11 | `userWhereFor` + `applyTake` (modul-nivå) |
| `paymentPlan` list-filter | 14 | `planHaystack` (återanvänder befintliga `resolveRecipient`, DRY) |

## Beteende

Oförändrat — identisk query-matchning, relations-hydrering och sök-filtrering. Full svit (2518 pass) + coverage-golv grönt.

15 → 12 kvar. Refs #40.