### PR TITLE
refactor(fsa): sänk komplexitet i open-in-finder/git-ops/preload (#40)

### DIFF
--- a/src/lib/client/fsa/git-ops.ts
+++ b/src/lib/client/fsa/git-ops.ts
@@ -153,11 +153,17 @@ export async function cloneRepo(
   });
 }
 
-// eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Async function 'statusMatrix' has a complexity of 10. Maximum allowed is 8.)
+// statusMatrix-tupel [filepath, HEAD, WORKDIR, STAGE]: 0=missing, 1=existerar,
+// 2=ändrad, 3=ny stage. Klassificera ett (head,workdir,stage)-läge.
+function classifyStatus(head: number, workdir: number, stage: number): GitStatusEntry["status"] {
+  if (head === 0 && workdir > 0) return "untracked";
+  if (workdir === 0 && head > 0) return "deleted";
+  if (head === 0 && stage > 0) return "added";
+  return "modified";
+}
+
 export async function statusMatrix(fs: FsaIsoGitAdapter): Promise<GitStatusEntry[]> {
   const git = await loadIsoGit();
-  // statusMatrix returnerar tupler [filepath, HEAD, WORKDIR, STAGE]
-  // där 0=missing, 1=existerar, 2=ändrad, 3=ny stage.
   const matrix = await git.statusMatrix({
     fs: asFsClient(fs),
     dir: "/",
@@ -165,12 +171,7 @@ export async function statusMatrix(fs: FsaIsoGitAdapter): Promise<GitStatusEntry
   const entries: GitStatusEntry[] = [];
   for (const [filepath, head, workdir, stage] of matrix) {
     if (head === workdir && workdir === stage) continue; // oförändrad
-    let status: GitStatusEntry["status"];
-    if (head === 0 && workdir > 0) status = "untracked";
-    else if (workdir === 0 && head > 0) status = "deleted";
-    else if (head === 0 && stage > 0) status = "added";
-    else status = "modified";
-    entries.push({ path: filepath, status });
+    entries.push({ path: filepath, status: classifyStatus(head, workdir, stage) });
   }
   return entries;
 }

--- a/src/lib/client/fsa/open-in-finder.ts
+++ b/src/lib/client/fsa/open-in-finder.ts
@@ -43,7 +43,57 @@ export interface OpenInFinderOpts {
   downloadFallbackBase?: string;
 }
 
-// eslint-disable-next-line complexity
+/** Navigera ner genom katalog-delarna (alla utom sista = filnamnet). */
+async function navigateToDir(
+  root: FileSystemDirectoryHandle,
+  parts: string[],
+): Promise<FileSystemDirectoryHandle | null> {
+  let dir = root;
+  for (let i = 0; i < parts.length - 1; i++) {
+    try {
+      dir = await dir.getDirectoryHandle(parts[i]!);
+    } catch {
+      return null;
+    }
+  }
+  return dir;
+}
+
+/** Demo-mode: lazy-ladda filen från GH Pages och skriv till FSA. */
+async function downloadFallback(
+  root: FileSystemDirectoryHandle,
+  storagePath: string,
+  fallbackBase: string,
+): Promise<FileSystemFileHandle | null> {
+  try {
+    const { downloadToFsa } = await import("./download-to-fsa");
+    const base = fallbackBase.replace(/\/+$/, "");
+    const url = `${base}/${storagePath.replace(/^\/+/, "")}`;
+    const result = await downloadToFsa({ root, relativePath: storagePath, url });
+    return result.fileHandle;
+  } catch (err) {
+    console.warn("[openInFinder] download-fallback misslyckades:", err);
+    return null;
+  }
+}
+
+/** Hämta fil-handle; faller tillbaka på download när filen saknas lokalt. */
+async function resolveFileHandle(
+  dir: FileSystemDirectoryHandle,
+  root: FileSystemDirectoryHandle,
+  storagePath: string,
+  lastPart: string,
+  fallbackBase: string | undefined,
+): Promise<{ fileHandle: FileSystemFileHandle; justDownloaded: boolean } | null> {
+  try {
+    return { fileHandle: await dir.getFileHandle(lastPart), justDownloaded: false };
+  } catch {
+    if (!fallbackBase) return null;
+    const dl = await downloadFallback(root, storagePath, fallbackBase);
+    return dl ? { fileHandle: dl, justDownloaded: true } : null;
+  }
+}
+
 export async function openInFinder(storagePath: string, opts: OpenInFinderOpts = {}): Promise<OpenInFinderResult> {
   if (!isFsaSupported()) return { kind: "unsupported" };
   const root = await loadHandle("repo-root");
@@ -51,43 +101,16 @@ export async function openInFinder(storagePath: string, opts: OpenInFinderOpts =
   const granted = await ensureReadWrite(root);
   if (!granted) return { kind: "permission-denied" };
 
-  // Navigera ner till filen
   const parts = storagePath.replace(/^\/+/, "").split("/").filter(Boolean);
   if (parts.length === 0) return { kind: "file-not-found", path: storagePath };
-  let dir: FileSystemDirectoryHandle = root;
-  for (let i = 0; i < parts.length - 1; i++) {
-    try {
-      dir = await dir.getDirectoryHandle(parts[i]!);
-    } catch {
-      return { kind: "file-not-found", path: storagePath };
-    }
-  }
-  let fileHandle: FileSystemFileHandle;
-  let justDownloaded = false;
-  try {
-    fileHandle = await dir.getFileHandle(parts[parts.length - 1]!);
-  } catch {
-    // Demo-mode fallback: filen finns inte i user:s lokala mapp men på GH
-    // Pages. Lazy-download + skriv hit, sen returnera handle till nya filen.
-    if (opts.downloadFallbackBase) {
-      try {
-        const { downloadToFsa } = await import("./download-to-fsa");
-        const base = opts.downloadFallbackBase.replace(/\/+$/, "");
-        const url = `${base}/${storagePath.replace(/^\/+/, "")}`;
-        const result = await downloadToFsa({ root, relativePath: storagePath, url });
-        fileHandle = result.fileHandle;
-        justDownloaded = true;
-      } catch (err) {
-        console.warn("[openInFinder] download-fallback misslyckades:", err);
-        return { kind: "file-not-found", path: storagePath };
-      }
-    } else {
-      return { kind: "file-not-found", path: storagePath };
-    }
-  }
+  const dir = await navigateToDir(root, parts);
+  if (!dir) return { kind: "file-not-found", path: storagePath };
+
+  const resolved = await resolveFileHandle(dir, root, storagePath, parts[parts.length - 1]!, opts.downloadFallbackBase);
+  if (!resolved) return { kind: "file-not-found", path: storagePath };
 
   return {
     kind: "ok",
-    target: { relativePath: storagePath, folderName: root.name, fileHandle, justDownloaded },
+    target: { relativePath: storagePath, folderName: root.name, fileHandle: resolved.fileHandle, justDownloaded: resolved.justDownloaded },
   };
 }

--- a/src/lib/client/fsa/preload-documents.ts
+++ b/src/lib/client/fsa/preload-documents.ts
@@ -37,20 +37,18 @@ export interface PreloadResult {
 const manifestSchema = z.object({ paths: z.array(z.string()).optional() }).passthrough();
 const docMetaSchema = z.object({ storagePath: z.string().optional() }).passthrough();
 
-// eslint-disable-next-line complexity
-export async function preloadAllDocuments(opts: PreloadOpts): Promise<PreloadResult> {
-  const fetchFn = opts.fetchFn ?? globalThis.fetch.bind(globalThis);
-  const base = opts.baseUrl.replace(/\/+$/, "");
+type FetchFn = typeof globalThis.fetch;
 
-  // 1. Manifest → metadata-JSONs
+/** Steg 1: manifest → metadata-JSON-paths under documents/. */
+async function fetchDocMetaPaths(base: string, fetchFn: FetchFn): Promise<string[]> {
   const manifestRes = await fetchFn(`${base}/manifest.json`);
   if (!manifestRes.ok) throw new Error(`preload: HTTP ${manifestRes.status} på manifest`);
   const manifest = manifestSchema.parse(await manifestRes.json());
-  const docMetaPaths = (manifest.paths ?? []).filter(
-    (p) => p.startsWith("documents/") && p.endsWith(".json"),
-  );
+  return (manifest.paths ?? []).filter((p) => p.startsWith("documents/") && p.endsWith(".json"));
+}
 
-  // 2. Läs varje metadata och extrahera storagePath
+/** Steg 2: läs varje metadata-fil och extrahera storagePath (fel hoppas tyst). */
+async function collectBinaryPaths(base: string, docMetaPaths: string[], fetchFn: FetchFn): Promise<string[]> {
   const binaryPaths: string[] = [];
   for (const metaPath of docMetaPaths) {
     try {
@@ -62,6 +60,15 @@ export async function preloadAllDocuments(opts: PreloadOpts): Promise<PreloadRes
       // tyst — räknas som failed vid download-loop
     }
   }
+  return binaryPaths;
+}
+
+export async function preloadAllDocuments(opts: PreloadOpts): Promise<PreloadResult> {
+  const fetchFn = opts.fetchFn ?? globalThis.fetch.bind(globalThis);
+  const base = opts.baseUrl.replace(/\/+$/, "");
+
+  const docMetaPaths = await fetchDocMetaPaths(base, fetchFn);
+  const binaryPaths = await collectBinaryPaths(base, docMetaPaths, fetchFn);
 
   // 3. Ladda ner med concurrency
   const queue = [...binaryPaths];


### PR DESCRIPTION
Ratchet-steg mot **#40** (src/lib strikt complexity@8) — 3 client/fsa-funktioner:

| Funktion | Före | Extraktion |
|---|---|---|
| `open-in-finder.openInFinder` | 11 | `navigateToDir` + `downloadFallback` + `resolveFileHandle` |
| `git-ops.statusMatrix` | 10 | `classifyStatus` |
| `preload-documents.preloadAllDocuments` | 10 | `fetchDocMetaPaths` + `collectBinaryPaths` |

Beteendebevarande — full svit (2518 pass) + coverage-golv grönt. 12 → 9 kvar. Refs #40.