### PR TITLE
refactor(jobs,sync): sänk komplexitet i detectKind/worker/errMsg (#40)

### DIFF
--- a/src/lib/client/jobs/extract-text.ts
+++ b/src/lib/client/jobs/extract-text.ts
@@ -39,20 +39,31 @@ export async function extractText(input: ExtractInput): Promise<string> {
   }
 }
 
+type ExtractKind = "text" | "pdf" | "docx" | "unknown";
+
+const DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+
+/** Datadriven kind-detektering: första regel som matchar mime-prefix/-likhet/ext. */
+const KIND_RULES: ReadonlyArray<{ kind: ExtractKind; mimePrefix?: string; mimes: string[]; exts: string[] }> = [
+  { kind: "text", mimePrefix: "text/", mimes: ["application/json"], exts: ["txt", "md", "csv", "log", "html", "xml", "yaml", "yml", "json"] },
+  { kind: "pdf", mimes: ["application/pdf"], exts: ["pdf"] },
+  { kind: "docx", mimes: [DOCX_MIME], exts: ["docx"] },
+];
+
+/** Filändelse (utan punkt, gemener) ur filnamnet; tom om ingen. */
+function fileExt(fileName: string | undefined): string {
+  return (fileName ?? "").toLowerCase().match(/\.([a-z0-9]+)$/)?.[1] ?? "";
+}
+
 /** Vilket extraktorn ska användas för denna fil. */
-// eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Function 'detectKind' has a complexity of 13. Maximum allowed is 8.)
-export function detectKind(input: ExtractInput): "text" | "pdf" | "docx" | "unknown" {
+export function detectKind(input: ExtractInput): ExtractKind {
   const mime = (input.mimeType ?? "").toLowerCase();
-  const ext = (input.fileName ?? "").toLowerCase().match(/\.([a-z0-9]+)$/)?.[1] ?? "";
-
-  if (mime.startsWith("text/") || ["txt", "md", "csv", "log", "html", "xml", "yaml", "yml"].includes(ext)) return "text";
-  if (mime === "application/json" || ext === "json") return "text";
-  if (mime === "application/pdf" || ext === "pdf") return "pdf";
-  if (
-    mime === "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-    || ext === "docx"
-  ) return "docx";
-
+  const ext = fileExt(input.fileName);
+  for (const r of KIND_RULES) {
+    if ((r.mimePrefix && mime.startsWith(r.mimePrefix)) || r.mimes.includes(mime) || r.exts.includes(ext)) {
+      return r.kind;
+    }
+  }
   return "unknown";
 }
 

--- a/src/lib/client/jobs/register-workers.ts
+++ b/src/lib/client/jobs/register-workers.ts
@@ -49,7 +49,11 @@ interface MirrorPayload extends Record<string, unknown> {
   outlookCalendarId?: string | null;
 }
 
-// eslint-disable-next-line complexity
+/** Graph-anrops-opts: token + (valfritt) calendarId när payload har det. */
+function graphOpts(token: string, payload: MirrorPayload): { token: string; calendarId?: string } {
+  return { token, ...(payload.outlookCalendarId != null ? { calendarId: payload.outlookCalendarId } : {}) };
+}
+
 jobQueue.registerWorker<MirrorPayload>("mirror-to-outlook", async (payload, ctx) => {
   ctx.setProgress(0.1);
   const { getOutlookToken, dispatchMirrorState } = await import("./mirror-outlook-dispatch");
@@ -68,7 +72,7 @@ jobQueue.registerWorker<MirrorPayload>("mirror-to-outlook", async (payload, ctx)
   try {
     if (payload.op === "delete") {
       if (payload.outlookEventId) {
-        await graph.deleteGraphEvent(payload.outlookEventId, { token, ...(payload.outlookCalendarId != null ? { calendarId: payload.outlookCalendarId } : {}) });
+        await graph.deleteGraphEvent(payload.outlookEventId, graphOpts(token, payload));
       }
       // Vid delete på AVA-eventet finns ingen rad att uppdatera — workern
       // slutar bara här. (Calendar-routerns delete tar bort raden helt.)
@@ -80,10 +84,10 @@ jobQueue.registerWorker<MirrorPayload>("mirror-to-outlook", async (payload, ctx)
     const body = graph.toGraphEvent({ ...payload.event });
     let outlookEventId: string;
     if (payload.outlookEventId) {
-      const res = await graph.updateGraphEvent(payload.outlookEventId, body, { token, ...(payload.outlookCalendarId != null ? { calendarId: payload.outlookCalendarId } : {}) });
+      const res = await graph.updateGraphEvent(payload.outlookEventId, body, graphOpts(token, payload));
       outlookEventId = res.id;
     } else {
-      const res = await graph.createGraphEvent(body, { token, ...(payload.outlookCalendarId != null ? { calendarId: payload.outlookCalendarId } : {}) });
+      const res = await graph.createGraphEvent(body, graphOpts(token, payload));
       outlookEventId = res.id;
     }
     ctx.setProgress(0.9);

--- a/src/lib/client/sync/use-auto-sync.ts
+++ b/src/lib/client/sync/use-auto-sync.ts
@@ -295,29 +295,26 @@ export function useAutoSync(opts: UseAutoSyncOptions): UseAutoSyncReturn {
   return { state, syncNow, notifyChange };
 }
 
-// eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Function 'errMsg' has a complexity of 9. Maximum allowed is 8.)
+// Översätt vanliga isomorphic-git-fel till begripliga råd. Första matchande
+// regel vinner; `match` är RegExp eller predikat mot felmeddelandet.
+const ERR_RULES: ReadonlyArray<{ match: RegExp | ((m: string) => boolean); message: (prefix: string) => string }> = [
+  {
+    match: (m) => m.includes("A requested file or directory could not be found") || m.includes("ENOENT"),
+    message: (p) => `${p}: Mappen är inte ett git-repo (saknar .git/). Klona repo:t först i datakällan ovan.`,
+  },
+  { match: /401|unauthorized|bad credentials/i, message: (p) => `${p}: GitHub-token avvisades (401). Kontrollera att token finns och har 'repo'-scope.` },
+  { match: /404|not found/i, message: (p) => `${p}: Repo eller branch hittades inte (404). Kontrollera repo-URL och att branchen 'main' finns.` },
+  { match: /Failed to fetch|fetch failed/i, message: (p) => `${p}: Nät-fel (Failed to fetch). Vanligast: CORS-proxyn (cors.isomorphic-git.org) är nere eller blockerad. Konfigurera en egen CORS-proxy i Inställningar → Datakälla.` },
+  { match: /CORS/i, message: (p) => `${p}: CORS-fel. Proxyn svarar inte med rätt headers. Byt CORS-proxy i Inställningar.` },
+];
+
 function errMsg(err: unknown, prefix: string): string {
   if (err instanceof SyncTimeoutError) return `${prefix}: timeout — försöker igen senare`;
-  if (err instanceof Error) {
-    const m = err.message;
-    // Översätt vanliga isomorphic-git-fel till begripliga råd
-    if (m.includes("A requested file or directory could not be found")
-        || m.includes("ENOENT")) {
-      return `${prefix}: Mappen är inte ett git-repo (saknar .git/). Klona repo:t först i datakällan ovan.`;
-    }
-    if (/401|unauthorized|bad credentials/i.test(m)) {
-      return `${prefix}: GitHub-token avvisades (401). Kontrollera att token finns och har 'repo'-scope.`;
-    }
-    if (/404|not found/i.test(m)) {
-      return `${prefix}: Repo eller branch hittades inte (404). Kontrollera repo-URL och att branchen 'main' finns.`;
-    }
-    if (/Failed to fetch|fetch failed/i.test(m)) {
-      return `${prefix}: Nät-fel (Failed to fetch). Vanligast: CORS-proxyn (cors.isomorphic-git.org) är nere eller blockerad. Konfigurera en egen CORS-proxy i Inställningar → Datakälla.`;
-    }
-    if (/CORS/i.test(m)) {
-      return `${prefix}: CORS-fel. Proxyn svarar inte med rätt headers. Byt CORS-proxy i Inställningar.`;
-    }
-    return `${prefix}: ${m}`;
+  if (!(err instanceof Error)) return `${prefix}: ${String(err)}`;
+  const m = err.message;
+  for (const rule of ERR_RULES) {
+    const hit = typeof rule.match === "function" ? rule.match(m) : rule.match.test(m);
+    if (hit) return rule.message(prefix);
   }
-  return `${prefix}: ${String(err)}`;
+  return `${prefix}: ${m}`;
 }


### PR DESCRIPTION
Ratchet-steg mot **#40** (src/lib strikt complexity@8):

| Funktion | Före | Hur |
|---|---|---|
| `extract-text.detectKind` | 13 | datadriven `KIND_RULES`-tabell + `fileExt` |
| `register-workers` mirror-worker | 11 | `graphOpts` (samlar upprepade calendarId-ternärer) |
| `use-auto-sync.errMsg` | 9 | datadriven `ERR_RULES`-tabell |

`use-auto-sync.runSync` (stor useCallback med React-Compiler-disable) tas i egen batch.

Beteendebevarande — full svit (2518 pass) + coverage-golv grönt. 9 → 6 kvar. Refs #40.