### PR TITLE
refactor(lib): sänk komplexitet i taxa/auth/content/llm (#40)

### DIFF
--- a/src/lib/client/auth/github-auth.ts
+++ b/src/lib/client/auth/github-auth.ts
@@ -131,18 +131,28 @@ export interface DetectArgs {
  * repo-permissions. För self-hosted (icke-GitHub) URL:er hanteras
  * det optimistiskt: token → write, ingen token → anonymous.
  */
-// eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Async function 'detectAuthMode' has a complexity of 11. Maximum allowed is 8.)
+/**
+ * Self-hosted (icke-GitHub): lokal/samma-origin git-server tillåter anonym
+ * push → write även utan token. Annars: token → write, annars anon.
+ */
+function detectSelfHostedMode(repoUrl: string, token: string): AuthMode {
+  const origin = typeof window !== "undefined" ? window.location.origin : undefined;
+  if (isLocalOrSameOrigin(repoUrl, origin)) return "identified-write";
+  return token ? "identified-write" : "anonymous";
+}
+
+/** GitHub-repo med token: verifiera identitet + push-status. */
+async function detectGithubAuthedMode(token: string, owner: string, repo: string): Promise<AuthMode> {
+  const user = await getCurrentUser(token);
+  if (!user) return "anonymous"; // token funkar inte
+  const perms = await getRepoPermissions(token, owner, repo);
+  if (perms?.canPush) return "identified-write";
+  return "identified-read";
+}
+
 export async function detectAuthMode(args: DetectArgs): Promise<AuthMode> {
   const parsed = parseRepoUrl(args.repoUrl);
-
-  // Self-hosted (icke-GitHub) — vi vet inte permissions via API:n.
-  if (!parsed) {
-    // Lokal/samma-origin git-server (docker:8080/git) tillåter anonym
-    // push → write även utan token. Annars: token → write, annars anon.
-    const origin = typeof window !== "undefined" ? window.location.origin : undefined;
-    if (isLocalOrSameOrigin(args.repoUrl, origin)) return "identified-write";
-    return args.token ? "identified-write" : "anonymous";
-  }
+  if (!parsed) return detectSelfHostedMode(args.repoUrl, args.token);
 
   if (!args.token) {
     // Anonymt + GitHub-repo: bekräfta att det är publikt (kan läsas).
@@ -150,10 +160,5 @@ export async function detectAuthMode(args: DetectArgs): Promise<AuthMode> {
     return perms?.canRead ? "anonymous" : "anonymous";
   }
 
-  // Med token: verifiera identitet + push-status.
-  const user = await getCurrentUser(args.token);
-  if (!user) return "anonymous"; // token funkar inte
-  const perms = await getRepoPermissions(args.token, parsed.owner, parsed.repo);
-  if (perms?.canPush) return "identified-write";
-  return "identified-read";
+  return detectGithubAuthedMode(args.token, parsed.owner, parsed.repo);
 }

--- a/src/lib/client/demo/document-content-cache.ts
+++ b/src/lib/client/demo/document-content-cache.ts
@@ -29,12 +29,15 @@ const TEXT_MIMES = new Set([
   "application/json", "application/xml",
 ]);
 
-// eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Function 'isPlainTextDoc' has a complexity of 9. Maximum allowed is 8.)
+/** Filändelse (gemener, utan punkt) ur storagePath/fileName; tom om ingen. */
+function docExt(doc: ContentDoc): string {
+  return (doc.storagePath ?? doc.fileName ?? "").toLowerCase().match(/\.([a-z0-9]+)$/)?.[1] ?? "";
+}
+
 export function isPlainTextDoc(doc: ContentDoc): boolean {
   const mime = doc.mimeType?.toLowerCase() ?? "";
   if (TEXT_MIMES.has(mime) || mime.startsWith("text/")) return true;
-  const ext = (doc.storagePath ?? doc.fileName ?? "").toLowerCase().match(/\.([a-z0-9]+)$/)?.[1] ?? "";
-  return TEXT_EXTS.has(ext);
+  return TEXT_EXTS.has(docExt(doc));
 }
 
 /**

--- a/src/lib/client/llm/web-llm-extractor.ts
+++ b/src/lib/client/llm/web-llm-extractor.ts
@@ -138,25 +138,26 @@ export function parseJsonResponse(raw: string, schema: ExtractionSchema): Extrac
   return out;
 }
 
-// eslint-disable-next-line complexity
+/** Hoppa förbi en JSON-sträng; returnerar index på avslutande citattecknet
+ *  (eller strängens slut om den är oavslutad). `\`-escape hoppar nästa tecken. */
+function skipString(raw: string, openQuoteIdx: number): number {
+  for (let i = openQuoteIdx + 1; i < raw.length; i++) {
+    if (raw[i] === "\\") { i++; continue; }
+    if (raw[i] === '"') return i;
+  }
+  return raw.length;
+}
+
 function extractJsonObject(raw: string): string {
-  // Hitta första `{` och balansera räknaren tills matching `}`
+  // Hitta första `{` och balansera räknaren tills matching `}` (hoppar strängar).
   const start = raw.indexOf("{");
   if (start < 0) return "{}";
   let depth = 0;
-  let inString = false;
-  let escape = false;
   for (let i = start; i < raw.length; i++) {
     const ch = raw[i];
-    if (escape) { escape = false; continue; }
-    if (ch === "\\") { escape = true; continue; }
-    if (ch === '"') { inString = !inString; continue; }
-    if (inString) continue;
+    if (ch === '"') { i = skipString(raw, i); continue; }
     if (ch === "{") depth++;
-    else if (ch === "}") {
-      depth--;
-      if (depth === 0) return raw.slice(start, i + 1);
-    }
+    else if (ch === "}" && --depth === 0) return raw.slice(start, i + 1);
   }
   return raw.slice(start); // unbalanced — låt JSON.parse misslyckas vid behov
 }

--- a/src/lib/shared/brottmalstaxa.ts
+++ b/src/lib/shared/brottmalstaxa.ts
@@ -153,11 +153,12 @@ export interface TaxaResult {
  * `kind` säger om taxan tillämpas eller om man måste falla tillbaka på
  * löpande räkning (HUF > 225 min) eller om input var ogiltigt.
  */
-// eslint-disable-next-line complexity
-export function computeBrottmalstaxa(opts: ComputeOpts): TaxaResult {
-  const { huvudforhandlingMinutes: huf, level } = opts;
-  const hasFTax = opts.hasFTax ?? true;
+type CellResult =
+  | { ok: true; row: TaxaRow; e: number; g: number }
+  | { ok: false; note: string };
 
+/** Tidiga input-guards (ogiltigt input / över maxgräns) → TaxaResult, annars null. */
+function validateTaxaInput(huf: number, level: number): TaxaResult | null {
   if (!Number.isFinite(huf) || huf < 0 || !isLevel(level)) {
     return {
       kind: "invalid-input", intervalLabel: "", level: 1,
@@ -165,10 +166,9 @@ export function computeBrottmalstaxa(opts: ComputeOpts): TaxaResult {
       notes: ["Ogiltigt input. HUF-minuter måste vara ≥ 0 och nivå 1-4."],
     };
   }
-
   if (huf > TAXA_MAX_MINUTES) {
     return {
-      kind: "exceeds-max", intervalLabel: "", level,
+      kind: "exceeds-max", intervalLabel: "", level: level as TaxaLevel,
       ersattningExclVat: 0, gransvardeExclVat: 0,
       notes: [
         `Förhandlingstiden överstiger taxans maxgräns (${TAXA_MAX_MINUTES} min = 3 tim 45 min).`,
@@ -176,46 +176,58 @@ export function computeBrottmalstaxa(opts: ComputeOpts): TaxaResult {
       ],
     };
   }
+  return null;
+}
 
+/** Slå upp taxa-rad + ersättning/gränsvärde för nivån (defensiva not-found-fall). */
+function findTaxaCell(huf: number, level: TaxaLevel): CellResult {
   const row = BROTTMALSTAXA_TABLE.find((r) => huf >= r.fromMin && huf <= r.toMin);
-  if (!row) {
-    // Inte väntat men defensiv
-    return {
-      kind: "invalid-input", intervalLabel: "", level,
-      ersattningExclVat: 0, gransvardeExclVat: 0,
-      notes: ["Hittade inget matchande intervall i tabellen."],
-    };
-  }
-
+  if (!row) return { ok: false, note: "Hittade inget matchande intervall i tabellen." };
   const idx = level - 1;
   const e = row.ersattning[idx];
   const g = row.gransvarde[idx];
-  if (e === undefined || g === undefined) {
-    // Inte väntat — idx härleds ur validerad nivå (1-4), men defensiv
-    return {
-      kind: "invalid-input", intervalLabel: "", level,
-      ersattningExclVat: 0, gransvardeExclVat: 0,
-      notes: ["Hittade ingen taxa-rad för angiven nivå."],
-    };
-  }
+  if (e === undefined || g === undefined) return { ok: false, note: "Hittade ingen taxa-rad för angiven nivå." };
+  return { ok: true, row, e, g };
+}
 
-  const ersattning = hasFTax ? e : applyNoFTaxFactor(e);
-  const gransvarde = hasFTax ? g : applyNoFTaxFactor(g);
+/** F-skatt-justering: oförändrat belopp med F-skatt, annars nedjusterat. */
+function adjustForFTax(value: number, hasFTax: boolean): number {
+  return hasFTax ? value : applyNoFTaxFactor(value);
+}
 
+function buildNotes(hasFTax: boolean, huf: number, row: TaxaRow): string[] {
   const notes: string[] = [];
   if (!hasFTax) notes.push("Justerat för advokat utan F-skatt (× 1237/1626).");
   notes.push("Belopp exkl moms. För advokat med F-skatt lägger Domstolsverket 25 % moms ovanpå.");
   if (huf > row.toMin - 5) {
     notes.push("Nära intervallets övre gräns — verifiera faktiskt avslutsklockslag.");
   }
+  return notes;
+}
+
+export function computeBrottmalstaxa(opts: ComputeOpts): TaxaResult {
+  const { huvudforhandlingMinutes: huf, level } = opts;
+  const hasFTax = opts.hasFTax ?? true;
+
+  const invalid = validateTaxaInput(huf, level);
+  if (invalid) return invalid;
+
+  const cell = findTaxaCell(huf, level);
+  if (!cell.ok) {
+    return {
+      kind: "invalid-input", intervalLabel: "", level,
+      ersattningExclVat: 0, gransvardeExclVat: 0,
+      notes: [cell.note],
+    };
+  }
 
   return {
     kind: "taxa-applies",
-    intervalLabel: row.label,
+    intervalLabel: cell.row.label,
     level,
-    ersattningExclVat: ersattning,
-    gransvardeExclVat: gransvarde,
-    notes,
+    ersattningExclVat: adjustForFTax(cell.e, hasFTax),
+    gransvardeExclVat: adjustForFTax(cell.g, hasFTax),
+    notes: buildNotes(hasFTax, huf, cell.row),
   };
 }
 


### PR DESCRIPTION
Ratchet-steg mot **#40** (src/lib strikt complexity@8):

| Funktion | Före | Hur |
|---|---|---|
| `brottmalstaxa.computeBrottmalstaxa` | 13 | validateTaxaInput + findTaxaCell + adjustForFTax + buildNotes |
| `github-auth.detectAuthMode` | 11 | detectSelfHostedMode + detectGithubAuthedMode |
| `document-content-cache.isPlainTextDoc` | 9 | docExt |
| `web-llm-extractor.extractJsonObject` | 10 | skipString |

Beteendebevarande — full svit (2518 pass) + coverage-golv grönt (82.82%/79.69%). 6 → 2 kvar (render-pdf + use-auto-sync.runSync i slutbatchen). Refs #40.