### PR TITLE
refactor(sync,pdf): sänk komplexitet i runSync/renderKostnadsrakningPdf (#40)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -137,11 +137,6 @@
       "count": 1
     }
   },
-  "src/lib/client/kostnadsrakning/render-pdf.ts": {
-    "max-lines-per-function": {
-      "count": 1
-    }
-  },
   "src/lib/client/sync/use-auto-sync.ts": {
     "max-lines-per-function": {
       "count": 1

--- a/src/lib/client/kostnadsrakning/render-pdf.ts
+++ b/src/lib/client/kostnadsrakning/render-pdf.ts
@@ -36,7 +36,7 @@
  */
 
 import type { KostnadsrakningResult } from "@/lib/shared/kostnadsrakning";
-import type { PDFPage, PDFFont } from "pdf-lib";
+import type { PDFPage, PDFFont, RGB } from "pdf-lib";
 
 /** En formaterad utläggsrad i templateContext.expenseLines (se
  *  kostnadsrakning.ts buildTemplateContext) — alla fält är required strings. */
@@ -62,7 +62,6 @@ export interface RenderInput {
   };
 }
 
-// eslint-disable-next-line complexity
 export async function renderKostnadsrakningPdf(input: RenderInput): Promise<Uint8Array> {
   const { PDFDocument, StandardFonts, rgb } = await import("pdf-lib");
   const pdf = await PDFDocument.create();
@@ -135,37 +134,12 @@ export async function renderKostnadsrakningPdf(input: RenderInput): Promise<Uint
     y -= 22;
   }
 
-  // Utlägg. Precis lokal radtyp (alla fält required strings) i st.f.
-  // Record<string,string> — annars ger noUncheckedIndexedAccess `string |
-  // undefined` per fält och tvingar fram döda `?? ""`-fallbacks.
-  const lines = (c.expenseLines as ExpenseRow[] | undefined) ?? [];
-  if (lines.length > 0) {
-    page.drawText("Utlägg", { x: MARGIN, y, size: 11, font: bold });
-    y -= 14;
-    // Tabell-rubriker
-    drawTableHeader(page, y, font);
-    y -= 14;
-    for (const l of lines) {
-      page.drawText(l.date, { x: MARGIN, y, size: 9, font });
-      const desc = l.description.length > 30 ? l.description.slice(0, 28) + "…" : l.description;
-      page.drawText(desc, { x: MARGIN + 70, y, size: 9, font });
-      page.drawText(l.vatRateLabel, { x: MARGIN + 250, y, size: 9, font });
-      page.drawText(l.exclVatFormatted, { x: MARGIN + 290, y, size: 9, font });
-      page.drawText(l.vatFormatted, { x: MARGIN + 370, y, size: 9, font });
-      page.drawText(l.inclVatFormatted, { x: MARGIN + 440, y, size: 9, font });
-      y -= 12;
-      if (y < 100) break; // safety — single-page
-    }
-    y -= 6;
-    page.drawLine({ start: { x: MARGIN, y }, end: { x: PAGE_W - MARGIN, y }, thickness: 0.5, color: rgb(0.7, 0.7, 0.7) });
-    y -= 14;
-    const s = c.expenseSummary as { exclVatFormatted: string; vatFormatted: string; inclVatFormatted: string };
-    page.drawText("Summa utlägg", { x: MARGIN, y, size: 10, font: bold });
-    page.drawText(s.exclVatFormatted, { x: MARGIN + 290, y, size: 10, font: bold });
-    page.drawText(s.vatFormatted, { x: MARGIN + 370, y, size: 10, font: bold });
-    page.drawText(s.inclVatFormatted, { x: MARGIN + 440, y, size: 10, font: bold });
-    y -= 22;
-  }
+  // Utlägg (tabell + summa) — egen sektion för att hålla komplexiteten nere.
+  y = drawExpenseSection(
+    { page, font, bold, marginX: MARGIN, pageW: PAGE_W, lineColor: rgb(0.7, 0.7, 0.7) },
+    c,
+    y,
+  );
 
   // TOTAL
   page.drawLine({ start: { x: MARGIN, y: y + 8 }, end: { x: PAGE_W - MARGIN, y: y + 8 }, thickness: 1, color: rgb(0, 0, 0) });
@@ -184,6 +158,51 @@ export async function renderKostnadsrakningPdf(input: RenderInput): Promise<Uint
   });
 
   return pdf.save();
+}
+
+interface PdfCtx {
+  page: PDFPage;
+  font: PDFFont;
+  bold: PDFFont;
+  marginX: number;
+  pageW: number;
+  lineColor: RGB;
+}
+
+/** Rita utläggs-tabell + summa-rad. Returnerar ny y-position. No-op om inga utlägg. */
+function drawExpenseSection(ctx: PdfCtx, c: Record<string, unknown>, startY: number): number {
+  // Lokal radtyp (alla fält required strings) i st.f. Record<string,string> —
+  // annars ger noUncheckedIndexedAccess `string | undefined` per fält.
+  const lines = (c.expenseLines as ExpenseRow[] | undefined) ?? [];
+  let y = startY;
+  if (lines.length === 0) return y;
+  const { page, font, bold } = ctx;
+
+  page.drawText("Utlägg", { x: ctx.marginX, y, size: 11, font: bold });
+  y -= 14;
+  drawTableHeader(page, y, font);
+  y -= 14;
+  for (const l of lines) {
+    page.drawText(l.date, { x: ctx.marginX, y, size: 9, font });
+    const desc = l.description.length > 30 ? l.description.slice(0, 28) + "…" : l.description;
+    page.drawText(desc, { x: ctx.marginX + 70, y, size: 9, font });
+    page.drawText(l.vatRateLabel, { x: ctx.marginX + 250, y, size: 9, font });
+    page.drawText(l.exclVatFormatted, { x: ctx.marginX + 290, y, size: 9, font });
+    page.drawText(l.vatFormatted, { x: ctx.marginX + 370, y, size: 9, font });
+    page.drawText(l.inclVatFormatted, { x: ctx.marginX + 440, y, size: 9, font });
+    y -= 12;
+    if (y < 100) break; // safety — single-page
+  }
+  y -= 6;
+  page.drawLine({ start: { x: ctx.marginX, y }, end: { x: ctx.pageW - ctx.marginX, y }, thickness: 0.5, color: ctx.lineColor });
+  y -= 14;
+  const s = c.expenseSummary as { exclVatFormatted: string; vatFormatted: string; inclVatFormatted: string };
+  page.drawText("Summa utlägg", { x: ctx.marginX, y, size: 10, font: bold });
+  page.drawText(s.exclVatFormatted, { x: ctx.marginX + 290, y, size: 10, font: bold });
+  page.drawText(s.vatFormatted, { x: ctx.marginX + 370, y, size: 10, font: bold });
+  page.drawText(s.inclVatFormatted, { x: ctx.marginX + 440, y, size: 10, font: bold });
+  y -= 22;
+  return y;
 }
 
 function drawRow(page: PDFPage, y: number, font: PDFFont, label: string, value: string): void {

--- a/src/lib/client/sync/use-auto-sync.ts
+++ b/src/lib/client/sync/use-auto-sync.ts
@@ -124,83 +124,72 @@ export function useAutoSync(opts: UseAutoSyncOptions): UseAutoSyncReturn {
    * Använder ref:s istället för deps för att slippa effekt-loops →
    * React Compiler kan inte memoizera; vi disable:ar regeln här.
    */
-  // eslint-disable-next-line
+  // eslint-disable-next-line react-hooks/preserve-manual-memoization -- refs är stabila; avsiktligt tom dep-array (React Compiler kan ej bevara memoiseringen p.g.a. bumpBackoff)
   const runSync = useCallback(async (trigger: "auto" | "manual" | "online-reconnect"): Promise<void> => {
-    const provider = providerRef.current;
-    if (!provider || !enabledRef.current) return;
-    if (busyRef.current) return;
+    type Provider = NonNullable<typeof providerRef.current>;
 
-    if (!onlineRef.current) {
-      // Visa hur många ändringar som väntar lokalt
+    /** Visa offline-state med pending-count (fel → 0). */
+    const showOffline = async (p: Provider): Promise<void> => {
       try {
-        const count = await provider.countChanges();
-        setState({ kind: "offline", count });
+        setState({ kind: "offline", count: await p.countChanges() });
       } catch {
         setState({ kind: "offline", count: 0 });
       }
-      return;
-    }
+    };
+
+    /** Guards + offline-hantering. Returnerar provider om cykeln ska köras, annars null. */
+    const precheck = async (): Promise<Provider | null> => {
+      const p = providerRef.current;
+      if (!p || !enabledRef.current || busyRef.current) return null;
+      if (!onlineRef.current) { await showOffline(p); return null; }
+      return p;
+    };
+
+    // Commit/push delar form: setState(syncing) → withTimeout(op) → fel sätter
+    // error-state + backoff. `skip` → no-op (inget att göra). false = abortera.
+    const runGitStep = async (skip: boolean, op: () => Promise<unknown>, timeoutMs: number, label: string, errPrefix: string): Promise<boolean> => {
+      if (skip) return true;
+      setState({ kind: "syncing", what: "push" });
+      try {
+        await withTimeout(op(), timeoutMs, label);
+        return true;
+      } catch (err) {
+        setState({ kind: "error", message: errMsg(err, errPrefix) });
+        bumpBackoff();
+        return false;
+      }
+    };
+
+    /** Pull (working tree antas rent). false vid merge-needed eller fel. */
+    const pullStep = async (p: Provider): Promise<boolean> => {
+      setState({ kind: "syncing", what: "pull" });
+      try {
+        const pullResult = await withTimeout(p.pull(), cfgRef.current.pullTimeoutMs, "git pull");
+        if (pullResult.kind === "merge-needed") {
+          setState({ kind: "merge-needed" });
+          backoffRef.current = cfgRef.current.pullIntervalMs;
+          return false;
+        }
+        return true;
+      } catch (err) {
+        setState({ kind: "error", message: errMsg(err, "Pull") });
+        bumpBackoff();
+        return false;
+      }
+    };
+
+    const provider = await precheck();
+    if (!provider) return;
 
     busyRef.current = true;
     void trigger; // trigger used to gate manual vs auto; nu lika behandlade
     try {
-      // ── 1. Commit lokala ändringar FÖRST ──
-      // Anledning: git.pull/checkout vägrar skriva över "Your local
-      // changes would be overwritten" om working tree är dirty. AVA:s
-      // writeBack skriver kontinuerligt till filer, så vi måste rensa
-      // working tree (= committa) innan vi pullar.
-      const initialChanges = await provider.countChanges();
-      const hasLocalCommit = initialChanges > 0;
-      if (hasLocalCommit) {
-        setState({ kind: "syncing", what: "push" });
-        try {
-          await withTimeout(
-            provider.commitLocal(),
-            cfgRef.current.pushTimeoutMs,
-            "git commit",
-          );
-        } catch (err) {
-          setState({ kind: "error", message: errMsg(err, "Commit") });
-          bumpBackoff();
-          return;
-        }
-      }
-
-      // ── 2. Pull (working tree är nu rent) ──
-      setState({ kind: "syncing", what: "pull" });
-      try {
-        const pullResult = await withTimeout(
-          provider.pull(),
-          cfgRef.current.pullTimeoutMs,
-          "git pull",
-        );
-        if (pullResult.kind === "merge-needed") {
-          setState({ kind: "merge-needed" });
-          backoffRef.current = cfgRef.current.pullIntervalMs;
-          return;
-        }
-      } catch (err) {
-        setState({ kind: "error", message: errMsg(err, "Pull") });
-        bumpBackoff();
-        return;
-      }
-
-      // ── 3. Push lokala commits (om något) ──
-      if (hasLocalCommit) {
-        setState({ kind: "syncing", what: "push" });
-        try {
-          await withTimeout(
-            provider.push(),
-            cfgRef.current.pushTimeoutMs,
-            "git push",
-          );
-        } catch (err) {
-          setState({ kind: "error", message: errMsg(err, "Push") });
-          bumpBackoff();
-          return;
-        }
-      }
-
+      // Commit FÖRST: git.pull/checkout vägrar skriva över en dirty working
+      // tree, och AVA:s writeBack skriver kontinuerligt → committa innan pull.
+      const hasLocalCommit = (await provider.countChanges()) > 0;
+      if (!(await runGitStep(!hasLocalCommit, () => provider.commitLocal(), cfgRef.current.pushTimeoutMs, "git commit", "Commit"))) return;
+      if (!(await pullStep(provider))) return;
+      if (!(await runGitStep(!hasLocalCommit, () => provider.push(), cfgRef.current.pushTimeoutMs, "git push", "Push"))) return;
       setState({ kind: "synced", at: Date.now() });
       backoffRef.current = cfgRef.current.pullIntervalMs;
     } finally {


### PR DESCRIPTION
## Vad — sista src/lib-funktionerna

| Funktion | Före | Hur |
|---|---|---|
| `use-auto-sync.runSync` | 12 | nästlade `precheck`/`showOffline`/`runGitStep`/`pullStep` (sluter över refs). Bare `eslint-disable` → specifik `react-hooks/preserve-manual-memoization` |
| `render-pdf.renderKostnadsrakningPdf` | 9 | `drawExpenseSection` |

## Milstolpe

Med denna PR är **`src/lib` helt fritt från complexity-disables (0 kvar)** och **0 funktioner > 8**. (UI-lagret `src/app`/`src/components` är spårat separat i #199.)

## Beteende

Oförändrat — `runSync` har dedikerade enhetstester + e2e git-round-trip; `render-pdf` har render-pdf.test.ts. Full svit (2518 pass) + coverage-golv grönt. Prunar en frigjord suppression.

Refs #40 (enforcing-regel kommer i separat PR nu när siffran är 0).