### PR TITLE
ci(quality): enforca strikt complexity i src/lib (#40)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
       # warnings OCH oavsedda warning-regler. Skulden betas av via `yarn
       # lint:prune` när en lång funktion bryts ut. Se docs/quality.md.
       - run: bun run lint --max-warnings 0
+      # Enforcing #40: src/lib hålls strikt på complexity@8 — inga complexity-
+      # undantag (inline-disable eller suppressions). Se docs/quality.md.
+      - run: bun run lint:lib-complexity
       - run: bun run deps:check
       # Gating: fäller på strukturfynd (döda filer, oanvända/olistade deps).
       # Export-/typ-fynd är "warn" i knip.json (rådgivande) tills #3/#4 städat dem.

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -88,6 +88,18 @@ Alla struktur-regler är `error` (inte `warn`). CI kör `bun run lint --max-warn
 | Parametrar per funktion | 5 | error |
 | Nästade callbacks | 4 | error |
 
+#### `src/lib` strikt på complexity (#40)
+
+`complexity@8` gäller globalt, men kunde kringgås med inline-disable eller en
+post i `eslint-suppressions.json`. **`src/lib/**` (ren logik) hålls nu helt
+fritt från complexity-undantag** — `bun run lint:lib-complexity`
+([`check-lib-complexity-strict.ts`](../tooling/scripts/check-lib-complexity-strict.ts))
+faller om någon återinför en complexity-disable eller -suppression där. Den
+körs i CI:s static-jobb. Bryt ut hjälpfunktioner i stället (alla 23 tidigare
+offenders refaktorerades i #40). UI-lagret (`src/app`/`src/components`), där
+JSX-grenar blåser upp cyklomatisk komplexitet, får en egen komponentmedveten
+tröskel separat (#199).
+
 #### max-lines-cap & ventil (#41)
 
 Tidigare låg lint på `--max-warnings 45` med struktur-reglerna som `warn` —

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "smoke:tier3": "bash tooling/scripts/test-tier3-smoke.sh",
     "test:all": "bash tooling/scripts/test-all.sh",
     "duplicates": "jscpd --config tooling/config/jscpd.json src",
+    "lint:lib-complexity": "bun tooling/scripts/check-lib-complexity-strict.ts",
     "deps:check": "depcruise --config tooling/config/dependency-cruiser.cjs --output-type err src test helper-app",
     "deps:graph": "depcruise --config tooling/config/dependency-cruiser.cjs --output-type dot src | dot -Tsvg > reports/dependency-graph.svg",
     "deps:archi": "depcruise --config tooling/config/dependency-cruiser.cjs --output-type archi src | dot -Tsvg > reports/architecture.svg",

--- a/tooling/scripts/check-lib-complexity-strict.ts
+++ b/tooling/scripts/check-lib-complexity-strict.ts
@@ -1,0 +1,70 @@
+/**
+ * Enforcing-grind för #40: `src/lib/**` ska hållas STRIKT på complexity@8 —
+ * helt fritt från complexity-undantag.
+ *
+ * ESLint-regeln `complexity: ["error", { max: 8 }]` gäller redan globalt, men
+ * den kan kringgås på två sätt. Den här grinden stänger båda specifikt för
+ * `src/lib` (ren logik — JSX-komponenter i src/app hanteras separat, #199):
+ *
+ *   1. Inline `// eslint-disable[-next-line] … complexity`.
+ *   2. Poster i `eslint-suppressions.json` med en `complexity`-nyckel.
+ *
+ * Faller (exit 1) om något återinförs. RATCHET: src/lib gick till 0 i #40 och
+ * ska förbli 0. Se docs/quality.md.
+ *
+ * Kör: `bun run lint:lib-complexity`
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const LIB_DIR = "src/lib";
+const SUPPRESSIONS = "eslint-suppressions.json";
+const DISABLE_RE = /eslint-disable(?:-next-line|-line)?[^\n]*\bcomplexity\b/;
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(p));
+    else if (/\.(ts|tsx)$/.test(entry.name)) out.push(p);
+  }
+  return out;
+}
+
+const inlineHits: string[] = [];
+for (const file of walk(LIB_DIR)) {
+  const lines = readFileSync(file, "utf8").split("\n");
+  lines.forEach((line, i) => {
+    if (DISABLE_RE.test(line)) inlineHits.push(`${file}:${i + 1}`);
+  });
+}
+
+const suppressionHits: string[] = [];
+try {
+  const sup = JSON.parse(readFileSync(SUPPRESSIONS, "utf8")) as Record<string, Record<string, unknown>>;
+  for (const [file, rules] of Object.entries(sup)) {
+    if (file.startsWith(`${LIB_DIR}/`) && rules && "complexity" in rules) {
+      suppressionHits.push(file);
+    }
+  }
+} catch {
+  /* ingen suppressions-fil → inget att kontrollera */
+}
+
+if (inlineHits.length === 0 && suppressionHits.length === 0) {
+  console.log(`✓ ${LIB_DIR} är strikt på complexity@8 — inga complexity-undantag.`);
+  process.exit(0);
+}
+
+console.error(`✗ ${LIB_DIR} måste hållas fritt från complexity-undantag (#40).`);
+if (inlineHits.length > 0) {
+  console.error(`\n  Inline-disables (${inlineHits.length}):`);
+  for (const h of inlineHits) console.error(`    ${h}`);
+}
+if (suppressionHits.length > 0) {
+  console.error(`\n  Suppressions-poster (${suppressionHits.length}):`);
+  for (const h of suppressionHits) console.error(`    ${h}`);
+}
+console.error(`\n  Bryt ut hjälpfunktioner så funktionen hamnar ≤8 i stället. Se docs/quality.md.`);
+process.exit(1);

--- a/tooling/scripts/test-all.sh
+++ b/tooling/scripts/test-all.sh
@@ -60,6 +60,7 @@ START=$SECONDS
 bold "[1/3] Static analysis (typecheck + lint + deps + knip + duplicates)"
 run "typecheck"             bun run typecheck
 run "lint (--max-warnings 0)" bun run lint --max-warnings 0
+run "lint:lib-complexity (#40 strikt)" bun run lint:lib-complexity
 run "deps:check (cykeldetektion)" bun run deps:check
 run "knip (död kod — gate)" bun run knip
 run "duplicates (jscpd)"    bun run duplicates


### PR DESCRIPTION
## Vad — sista pusselbiten i #40

Nu när **src/lib är på 0 complexity-överträdelser och 0 disables** (refaktorerat i #198/#200–206): lås det med en grind.

- Ny grind **`check-lib-complexity-strict.ts`** (`bun run lint:lib-complexity`): faller om en `eslint-disable … complexity` ELLER en `src/lib`-post i `eslint-suppressions.json` återinförs. Verifierad positivt (grön nu) + negativt (injicerad disable → exit 1).
- Körs i **CI:s static-jobb** (efter `lint`) + i `test-all.sh`.
- Dokumenterad i `docs/quality.md`.

## Helhet (#40)

`complexity@8` (error) gällde redan globalt men kunde kringgås. Den här grinden stänger kringgångs-vägarna specifikt för `src/lib` (ren logik). De **23** tidigare src/lib-offenders refaktorerades till ≤8 i de föregående PR:erna. JSX-tunga `src/app`/`src/components` (42 funktioner) får en egen komponentmedveten tröskel separat i **#199**.

Closes #40