### PR TITLE
feat(fortnox): oauth2-flöde + voucher-klient + verifikat-byggare (#82)

### DIFF
--- a/src/lib/server/integrations/fortnox/README.md
+++ b/src/lib/server/integrations/fortnox/README.md
@@ -1,0 +1,40 @@
+# Fortnox-connector (#82)
+
+Tunn, **self-hosted** connector som pushar AVA:s kundfakturor till Fortnox som
+verifikat (vouchers) via Voucher API. Körs i server-runtime:n (ADR 0005), aldrig
+i browsern — `client_secret` och tokens får aldrig nå klienten.
+
+## Vad som är byggt (denna PR)
+
+| Fil | Ansvar |
+|---|---|
+| `schema.ts` | Zod-scheman: config, OAuth-token-svar, persisterade tokens, konto-mappning, voucher-payload/-svar |
+| `oauth.ts` | OAuth2 Authorization Code-flöde: `buildAuthorizeUrl`, `exchangeCodeForTokens`, `refreshTokens` |
+| `token-store.ts` | `FortnoxTokenStore`-interface + in-memory-impl (riktig backend = #79) |
+| `client.ts` | `FortnoxClient`: håller access-token färsk (refresh + rotation), 401-retry, `createVoucher` |
+| `voucher.ts` | `buildVoucherFromInvoice`: faktura → balanserat verifikat (debet kundfordran, kredit intäkt + moms) |
+
+Allt är enhetstestat utan riktig Fortnox (injicerad `fetch`).
+
+## Vad som återstår (kräver dig / uppföljning)
+
+1. **Fortnox-credentials** — registrera en integration i [Developer Portal](https://www.fortnox.se/developer/developer-portal):
+   - scope **`bookkeeping`** (Voucher API), en **redirect-URI** som pekar på server-connectorn.
+   - Du får `client_id` + `client_secret`. **Lägg dem i secrets-valvet (#79), inte i git.**
+   - Skapa ett **sandbox** att validera mot innan skarp drift.
+2. **Konto-mappning** — `FortnoxKontoMappning` (verifikatserie + konton för kundfordran/arvode/moms) är ett **bokföringsbeslut per byrå**. Connectorn levereras utan defaults.
+3. **Server-wiring** — koppla in `FortnoxClient.createVoucher` som en `PeerAct`-connector i `server-runtime` (pull av icke-synkade fakturor → bygg verifikat → push → skriv tillbaka `invoice.fortnoxId` för idempotens). Görs när creds finns.
+4. **Bekräfta mot sandbox**: exakt voucher-wire-nesting (`VoucherRows: { VoucherRow: [...] }` per dok) och authorize-parametrarna (`access_type=offline`, `account_type=service`). Isolerat i `toWireVoucher` / `buildAuthorizeUrl` → trivialt att justera.
+5. **Uppföljning**: fler-VAT-/vidarefakturerade-utlägg-uppdelning (kräver fakturarader, inte bara totalen).
+
+## OAuth-flöde (kortfattat)
+
+```
+buildAuthorizeUrl(config, state)  → användaren godkänner i Fortnox
+   → redirect ?code=…&state=…
+exchangeCodeForTokens(config, code) → { accessToken, refreshToken, expiresAt }  → spara i store
+FortnoxClient.createVoucher(v)    → använder/refreshar token automatiskt
+```
+
+Refresh-token **roterar** (gammal blir ogiltig) — `client.ts` sparar alltid den
+nya via `FortnoxTokenStore.save`. Access-token: 1 h, refresh-token: 45 dygn.

--- a/src/lib/server/integrations/fortnox/client.ts
+++ b/src/lib/server/integrations/fortnox/client.ts
@@ -1,0 +1,86 @@
+/**
+ * Fortnox API-klient (#82) — token-livscykel + Voucher API.
+ *
+ * Håller access-token färsk via refresh (och sparar den ROTERADE
+ * refresh-token:en). Vid 401 trots "färsk" token görs en forcerad refresh +
+ * ett omförsök. Allt nät via injicerad `fetch` (testbar utan Fortnox).
+ */
+
+import { refreshTokens, type FetchFn } from "./oauth";
+import {
+  fortnoxVoucherResponseSchema,
+  type FortnoxConfig,
+  type FortnoxVoucher,
+  type FortnoxVoucherResponse,
+} from "./schema";
+import type { FortnoxTokenStore } from "./token-store";
+
+/**
+ * Wire-format för voucher-payloaden. Enligt Fortnox-dokumentationen nästlas
+ * raderna som `VoucherRows: { VoucherRow: [...] }`. (Bekräfta exakt nesting
+ * mot sandbox när creds finns — isolerat här så det är en enradsändring.)
+ */
+function toWireVoucher(v: FortnoxVoucher): Record<string, unknown> {
+  return {
+    VoucherSeries: v.VoucherSeries,
+    TransactionDate: v.TransactionDate,
+    Description: v.Description,
+    ...(v.Comments ? { Comments: v.Comments } : {}),
+    VoucherRows: { VoucherRow: v.VoucherRows },
+  };
+}
+
+export class FortnoxClient {
+  constructor(
+    private readonly config: FortnoxConfig,
+    private readonly store: FortnoxTokenStore,
+    private readonly fetchFn: FetchFn = globalThis.fetch,
+  ) {}
+
+  /** Giltig access-token: cachad om färsk, annars refresh + spara (rotation). */
+  private async accessToken(nowMs: number = Date.now()): Promise<string> {
+    const tokens = await this.store.load();
+    if (!tokens) throw new Error("Fortnox: inga tokens — kör OAuth-flödet (buildAuthorizeUrl) först.");
+    if (nowMs < tokens.accessTokenExpiresAt) return tokens.accessToken;
+    return this.refreshAndStore(tokens.refreshToken, nowMs);
+  }
+
+  /** Forcerad refresh (t.ex. efter 401). */
+  private async forceRefresh(nowMs: number = Date.now()): Promise<string> {
+    const tokens = await this.store.load();
+    if (!tokens) throw new Error("Fortnox: inga tokens att förnya.");
+    return this.refreshAndStore(tokens.refreshToken, nowMs);
+  }
+
+  private async refreshAndStore(refreshToken: string, nowMs: number): Promise<string> {
+    const next = await refreshTokens(this.config, refreshToken, this.fetchFn, nowMs);
+    await this.store.save(next);
+    return next.accessToken;
+  }
+
+  private apiPost(path: string, token: string, body: unknown): Promise<Response> {
+    return this.fetchFn(new URL(path, this.config.apiBase).toString(), {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  /** Skapa ett verifikat. Returnerar serie + nummer (för idempotens/spårning). */
+  async createVoucher(voucher: FortnoxVoucher): Promise<FortnoxVoucherResponse> {
+    const body = { Voucher: toWireVoucher(voucher) };
+    let res = await this.apiPost("/3/vouchers", await this.accessToken(), body);
+    if (res.status === 401) {
+      res = await this.apiPost("/3/vouchers", await this.forceRefresh(), body);
+    }
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(`Fortnox voucher-fel ${res.status}: ${detail.slice(0, 300)}`);
+    }
+    return fortnoxVoucherResponseSchema.parse(await res.json());
+  }
+}

--- a/src/lib/server/integrations/fortnox/oauth.ts
+++ b/src/lib/server/integrations/fortnox/oauth.ts
@@ -1,0 +1,104 @@
+/**
+ * Fortnox OAuth2 — Authorization Code-flöde (#82).
+ *
+ *   1. `buildAuthorizeUrl` → användaren skickas till Fortnox, godkänner,
+ *      redirectas tillbaka med `?code=…&state=…`.
+ *   2. `exchangeCodeForTokens` → byt code mot access+refresh-token.
+ *   3. `refreshTokens` → förnya access-token. OBS: refresh-token ROTERAR
+ *      (gammal blir ogiltig) → spara alltid den nya.
+ *
+ * Token-endpoint kräver HTTP Basic auth (base64(client_id:client_secret))
+ * och `application/x-www-form-urlencoded`. Allt nät via injicerad `fetch`
+ * (testbar utan riktig Fortnox).
+ */
+
+import {
+  fortnoxTokenResponseSchema,
+  type FortnoxConfig,
+  type FortnoxStoredTokens,
+  type FortnoxTokenResponse,
+} from "./schema";
+
+export type FetchFn = typeof globalThis.fetch;
+
+const AUTH_PATH = "/oauth-v1/auth";
+const TOKEN_PATH = "/oauth-v1/token";
+
+/** Bygg authorize-URL:n användaren skickas till. `state` ska vara slumpad (CSRF). */
+export function buildAuthorizeUrl(config: FortnoxConfig, state: string): string {
+  const url = new URL(AUTH_PATH, config.authBase);
+  url.search = new URLSearchParams({
+    client_id: config.clientId,
+    redirect_uri: config.redirectUri,
+    scope: config.scopes.join(" "),
+    state,
+    access_type: "offline", // krävs för att få en refresh-token
+    response_type: "code",
+    account_type: "service",
+  }).toString();
+  return url.toString();
+}
+
+function basicAuthHeader(config: FortnoxConfig): string {
+  const raw = `${config.clientId}:${config.clientSecret}`;
+  return `Basic ${Buffer.from(raw, "utf8").toString("base64")}`;
+}
+
+/** Gemensam token-POST + strikt parsning. Kastar vid icke-2xx. */
+async function postToken(
+  config: FortnoxConfig,
+  body: Record<string, string>,
+  fetchFn: FetchFn,
+): Promise<FortnoxTokenResponse> {
+  const res = await fetchFn(new URL(TOKEN_PATH, config.authBase).toString(), {
+    method: "POST",
+    headers: {
+      Authorization: basicAuthHeader(config),
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams(body).toString(),
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(`Fortnox token-fel ${res.status}: ${detail.slice(0, 300)}`);
+  }
+  return fortnoxTokenResponseSchema.parse(await res.json());
+}
+
+/** Räkna ut persisterad token-shape (med ~30 s säkerhetsmarginal på utgång). */
+function toStoredTokens(resp: FortnoxTokenResponse, nowMs: number): FortnoxStoredTokens {
+  return {
+    accessToken: resp.access_token,
+    refreshToken: resp.refresh_token,
+    accessTokenExpiresAt: nowMs + (resp.expires_in - 30) * 1000,
+  };
+}
+
+/** Steg 2: byt authorization-code mot tokens. */
+export async function exchangeCodeForTokens(
+  config: FortnoxConfig,
+  code: string,
+  fetchFn: FetchFn = globalThis.fetch,
+  nowMs: number = Date.now(),
+): Promise<FortnoxStoredTokens> {
+  const resp = await postToken(config, {
+    grant_type: "authorization_code",
+    code,
+    redirect_uri: config.redirectUri,
+  }, fetchFn);
+  return toStoredTokens(resp, nowMs);
+}
+
+/** Steg 3: förnya access-token. Returnerar NYA tokens (refresh roterar!). */
+export async function refreshTokens(
+  config: FortnoxConfig,
+  refreshToken: string,
+  fetchFn: FetchFn = globalThis.fetch,
+  nowMs: number = Date.now(),
+): Promise<FortnoxStoredTokens> {
+  const resp = await postToken(config, {
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+  }, fetchFn);
+  return toStoredTokens(resp, nowMs);
+}

--- a/src/lib/server/integrations/fortnox/schema.ts
+++ b/src/lib/server/integrations/fortnox/schema.ts
@@ -1,0 +1,108 @@
+/**
+ * Fortnox-connector — zod-scheman (#82).
+ *
+ * Tunn, self-hosted connector som pushar verifikat (vouchers) till Fortnox
+ * Voucher API. OAuth2 Authorization Code-flöde (det enda som stöds sedan
+ * fasta access-tokens deprekerades 2025-04-30). Strikt parsning av all
+ * extern data per [[feedback-zod-strict-parsing]].
+ *
+ * Allt här är ren config/data — inga hemligheter hårdkodas; client_id/secret
+ * och tokens injiceras (env nu, secrets-valv #79 senare).
+ */
+
+import { z } from "zod";
+
+// ─── OAuth ──────────────────────────────────────────────────────────────
+
+/** Fortnox-endpoints. Bas-URL:er är overridebara för test/sandbox. */
+export const FORTNOX_AUTH_BASE = "https://apps.fortnox.se";
+export const FORTNOX_API_BASE = "https://api.fortnox.se";
+
+export const fortnoxConfigSchema = z.object({
+  clientId: z.string().min(1),
+  clientSecret: z.string().min(1),
+  /** Måste exakt matcha redirect-URI:n registrerad i Developer Portal. */
+  redirectUri: z.string().url(),
+  /** Scopes (t.ex. "bookkeeping"). Voucher API ligger under "bookkeeping". */
+  scopes: z.array(z.string().min(1)).min(1),
+  /** Override för sandbox/test; default = produktions-endpoints. */
+  authBase: z.string().url().default(FORTNOX_AUTH_BASE),
+  apiBase: z.string().url().default(FORTNOX_API_BASE),
+});
+export type FortnoxConfig = z.infer<typeof fortnoxConfigSchema>;
+
+/** Råsvar från `POST /oauth-v1/token` (snake_case från Fortnox). */
+export const fortnoxTokenResponseSchema = z.object({
+  access_token: z.string().min(1),
+  refresh_token: z.string().min(1),
+  token_type: z.string(),
+  /** Sekunder till access-token går ut (Fortnox: 3600 = 1h). */
+  expires_in: z.number().int().positive(),
+  scope: z.string().optional(),
+});
+export type FortnoxTokenResponse = z.infer<typeof fortnoxTokenResponseSchema>;
+
+/**
+ * Persisterade tokens. Refresh-token ROTERAR vid varje refresh (gamla blir
+ * ogiltig) → `refreshToken` MÅSTE skrivas tillbaka efter varje refresh.
+ * `accessTokenExpiresAt` = epoch ms.
+ */
+export const fortnoxStoredTokensSchema = z.object({
+  accessToken: z.string().min(1),
+  refreshToken: z.string().min(1),
+  accessTokenExpiresAt: z.number().int(),
+});
+export type FortnoxStoredTokens = z.infer<typeof fortnoxStoredTokensSchema>;
+
+// ─── Konto-mappning (per byrå) ──────────────────────────────────────────
+
+/**
+ * Per-byrå kontoplan-mappning. VÄRDENA är ett bokföringsbeslut byrån gör —
+ * connectorn levereras utan defaults (tomt = connectorn vägrar köra och ber
+ * om konfiguration). BAS-kontona nedan är bara typ-dokumentation.
+ */
+export const fortnoxKontoMappningSchema = z.object({
+  /** Verifikatserie i Fortnox (t.ex. "A" eller en kundfaktura-serie). */
+  voucherSeries: z.string().min(1),
+  /** Kundfordran-konto (debet vid kundfaktura), t.ex. 1510. */
+  kundfordran: z.string().min(1),
+  /** Intäktskonto för advokatarvode (kredit), t.ex. 3041. */
+  intaktArvode: z.string().min(1),
+  /** Utgående moms 25 % (kredit), t.ex. 2611. */
+  momsUtgaende: z.string().min(1),
+  /** Intäktskonto för vidarefakturerade utlägg (kredit), valfritt. */
+  intaktUtlagg: z.string().min(1).optional(),
+});
+export type FortnoxKontoMappning = z.infer<typeof fortnoxKontoMappningSchema>;
+
+// ─── Voucher (verifikat) ────────────────────────────────────────────────
+
+/** En verifikatrad. Exakt EN av Debit/Credit > 0 per rad (resten 0). */
+export const fortnoxVoucherRowSchema = z.object({
+  Account: z.number().int(),
+  Debit: z.number().nonnegative().default(0),
+  Credit: z.number().nonnegative().default(0),
+  TransactionInformation: z.string().optional(),
+});
+export type FortnoxVoucherRow = z.infer<typeof fortnoxVoucherRowSchema>;
+
+/** Voucher-payload (det vi POST:ar). Belopp i KRONOR (Fortnox vill ha SEK). */
+export const fortnoxVoucherSchema = z.object({
+  VoucherSeries: z.string().min(1),
+  TransactionDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  Description: z.string().min(1).max(200),
+  Comments: z.string().optional(),
+  VoucherRows: z.array(fortnoxVoucherRowSchema).min(2),
+});
+export type FortnoxVoucher = z.infer<typeof fortnoxVoucherSchema>;
+
+/** Delsvar från `POST /3/vouchers` — det vi behöver för idempotens/spårning. */
+export const fortnoxVoucherResponseSchema = z.object({
+  Voucher: z.object({
+    VoucherSeries: z.string(),
+    VoucherNumber: z.number().int(),
+    Year: z.number().int().optional(),
+    TransactionDate: z.string().optional(),
+  }),
+});
+export type FortnoxVoucherResponse = z.infer<typeof fortnoxVoucherResponseSchema>;

--- a/src/lib/server/integrations/fortnox/token-store.ts
+++ b/src/lib/server/integrations/fortnox/token-store.ts
@@ -1,0 +1,36 @@
+/**
+ * Persistens för Fortnox-tokens (#82).
+ *
+ * Refresh-token roterar vid varje refresh, så den MÅSTE överleva
+ * server-omstarter — annars tappar vi kopplingen och byrån måste re-autha.
+ * Lagringen är abstraherad: in-memory nu (test/dev), riktig backend (krypterat
+ * i git-db eller secrets-valv #79) kopplas in via samma interface utan att
+ * resten av connectorn ändras.
+ */
+
+import { fortnoxStoredTokensSchema, type FortnoxStoredTokens } from "./schema";
+
+export interface FortnoxTokenStore {
+  /** Hämta sparade tokens, eller null om byrån inte auth:at än. */
+  load(): Promise<FortnoxStoredTokens | null>;
+  /** Spara (skriv över) tokens — anropas efter varje refresh (rotation!). */
+  save(tokens: FortnoxStoredTokens): Promise<void>;
+}
+
+/** In-memory-store för tester och engångskörningar. Persisterar inget. */
+export class InMemoryFortnoxTokenStore implements FortnoxTokenStore {
+  private tokens: FortnoxStoredTokens | null;
+
+  constructor(initial?: FortnoxStoredTokens) {
+    this.tokens = initial ?? null;
+  }
+
+  async load(): Promise<FortnoxStoredTokens | null> {
+    return this.tokens;
+  }
+
+  async save(tokens: FortnoxStoredTokens): Promise<void> {
+    // Strikt parsning även internt — fångar trasig data tidigt.
+    this.tokens = fortnoxStoredTokensSchema.parse(tokens);
+  }
+}

--- a/src/lib/server/integrations/fortnox/voucher.ts
+++ b/src/lib/server/integrations/fortnox/voucher.ts
@@ -1,0 +1,73 @@
+/**
+ * Bygg ett Fortnox-verifikat (voucher) från en AVA-kundfaktura (#82).
+ *
+ * Standard kundfaktura (brutto, inkl moms) → balanserat verifikat:
+ *   Debet  kundfordran      = brutto
+ *   Kredit intäkt (arvode)  = netto (exkl moms)
+ *   Kredit utgående moms     = moms
+ *
+ * Kreditfaktura (negativt belopp) vänder debet/kredit. Balans GARANTERAS
+ * genom att moms räknas som brutto − netto (ingen avrundnings-glipa).
+ *
+ * Belopp i AVA är öre (heltal); Fortnox vill ha kronor (SEK med 2 decimaler).
+ * Endast en VAT-sats i taget (default 25 %); flersats-/utläggs-uppdelning
+ * läggs till när vi kopplar in fakturarader (uppföljning).
+ */
+
+import { splitVat, type VatRate } from "@/lib/shared/vat";
+import type { FortnoxKontoMappning, FortnoxVoucher, FortnoxVoucherRow } from "./schema";
+
+/** Minsta fält connectorn behöver — frikopplat från hela Invoice-schemat. */
+export interface InvoiceForVoucher {
+  /** Brutto i öre (negativt = kreditfaktura). */
+  amount: number;
+  invoiceDate: Date | string;
+  invoiceNumber?: string | null;
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+/** `YYYY-MM-DD` (lokal tid) — Fortnox TransactionDate-format. */
+function isoDate(d: Date | string): string {
+  const dt = typeof d === "string" ? new Date(d) : d;
+  return `${dt.getFullYear()}-${pad2(dt.getMonth() + 1)}-${pad2(dt.getDate())}`;
+}
+
+/** Öre (heltal) → SEK med 2 decimaler. Exakt eftersom öre alltid är heltal. */
+function oreToSek(ore: number): number {
+  return ore / 100;
+}
+
+function row(account: string, sekAmount: number, debit: boolean): FortnoxVoucherRow {
+  return {
+    Account: Number(account),
+    Debit: debit ? sekAmount : 0,
+    Credit: debit ? 0 : sekAmount,
+  };
+}
+
+export function buildVoucherFromInvoice(
+  invoice: InvoiceForVoucher,
+  mapping: FortnoxKontoMappning,
+  vatRate: VatRate = 2500,
+): FortnoxVoucher {
+  const bruttoOre = Math.abs(invoice.amount);
+  const { exclVat } = splitVat({ amount: bruttoOre, vatRate, vatIncluded: true });
+  const momsOre = bruttoOre - exclVat; // balans-säker rest
+  const kundfordranIsDebit = invoice.amount >= 0; // kreditfaktura vänder
+
+  const rows = [
+    row(mapping.kundfordran, oreToSek(bruttoOre), kundfordranIsDebit),
+    row(mapping.intaktArvode, oreToSek(exclVat), !kundfordranIsDebit),
+    row(mapping.momsUtgaende, oreToSek(momsOre), !kundfordranIsDebit),
+  ].filter((r) => r.Debit > 0 || r.Credit > 0); // släng 0-rader (t.ex. moms vid 0 %)
+
+  return {
+    VoucherSeries: mapping.voucherSeries,
+    TransactionDate: isoDate(invoice.invoiceDate),
+    Description: invoice.invoiceNumber ? `Faktura ${invoice.invoiceNumber}` : "Kundfaktura (AVA)",
+    VoucherRows: rows,
+  };
+}

--- a/test/unit/server/integrations/fortnox/client.test.ts
+++ b/test/unit/server/integrations/fortnox/client.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest-compat";
+import { FortnoxClient } from "@/lib/server/integrations/fortnox/client";
+import { InMemoryFortnoxTokenStore } from "@/lib/server/integrations/fortnox/token-store";
+import type { FortnoxConfig, FortnoxStoredTokens, FortnoxVoucher } from "@/lib/server/integrations/fortnox/schema";
+
+const config: FortnoxConfig = {
+  clientId: "cid",
+  clientSecret: "secret",
+  redirectUri: "https://app.example/cb",
+  scopes: ["bookkeeping"],
+  authBase: "https://auth.test",
+  apiBase: "https://api.test",
+};
+
+const VOUCHER: FortnoxVoucher = {
+  VoucherSeries: "A",
+  TransactionDate: "2026-05-25",
+  Description: "Faktura F-1",
+  VoucherRows: [
+    { Account: 1510, Debit: 125, Credit: 0 },
+    { Account: 3041, Debit: 0, Credit: 100 },
+    { Account: 2611, Debit: 0, Credit: 25 },
+  ],
+};
+
+const VOUCHER_RESP = { Voucher: { VoucherSeries: "A", VoucherNumber: 17, Year: 1 } };
+const ROTATED = { access_token: "at-new", refresh_token: "rt-new", token_type: "Bearer", expires_in: 3600 };
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}
+
+interface Counts { token: number; voucher: number; lastAuth?: string }
+
+/** fetch som routar token- vs voucher-endpoint; voucher-status styrs per anrop. */
+function makeFetch(voucherStatuses: number[], counts: Counts) {
+  return (async (url: string | URL | Request, init?: RequestInit) => {
+    const u = String(url);
+    if (u.endsWith("/oauth-v1/token")) {
+      counts.token++;
+      return json(200, ROTATED);
+    }
+    counts.voucher++;
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    counts.lastAuth = headers.Authorization ?? "";
+    const status = voucherStatuses[counts.voucher - 1] ?? 200;
+    return status === 200 ? json(200, VOUCHER_RESP) : json(status, { error: "x" });
+  }) as typeof globalThis.fetch;
+}
+
+function fresh(): FortnoxStoredTokens {
+  return { accessToken: "at-fresh", refreshToken: "rt-1", accessTokenExpiresAt: Date.now() + 600_000 };
+}
+function expired(): FortnoxStoredTokens {
+  return { accessToken: "at-old", refreshToken: "rt-1", accessTokenExpiresAt: Date.now() - 1 };
+}
+
+describe("FortnoxClient.createVoucher", () => {
+  it("färsk token → POST verifikat med Bearer, ingen refresh", async () => {
+    const counts: Counts = { token: 0, voucher: 0 };
+    const store = new InMemoryFortnoxTokenStore(fresh());
+    const client = new FortnoxClient(config, store, makeFetch([200], counts));
+
+    const res = await client.createVoucher(VOUCHER);
+    expect(res.Voucher.VoucherNumber).toBe(17);
+    expect(counts.token).toBe(0);
+    expect(counts.voucher).toBe(1);
+    expect(counts.lastAuth).toBe("Bearer at-fresh");
+  });
+
+  it("utgången token → refreshar först och sparar den roterade token:en", async () => {
+    const counts: Counts = { token: 0, voucher: 0 };
+    const store = new InMemoryFortnoxTokenStore(expired());
+    const client = new FortnoxClient(config, store, makeFetch([200], counts));
+
+    await client.createVoucher(VOUCHER);
+    expect(counts.token).toBe(1);
+    expect(counts.lastAuth).toBe("Bearer at-new");
+    const saved = await store.load();
+    expect(saved?.accessToken).toBe("at-new");
+    expect(saved?.refreshToken).toBe("rt-new"); // rotation persisterad
+  });
+
+  it("401 trots färsk token → forcerad refresh + omförsök", async () => {
+    const counts: Counts = { token: 0, voucher: 0 };
+    const store = new InMemoryFortnoxTokenStore(fresh());
+    const client = new FortnoxClient(config, store, makeFetch([401, 200], counts));
+
+    const res = await client.createVoucher(VOUCHER);
+    expect(res.Voucher.VoucherNumber).toBe(17);
+    expect(counts.token).toBe(1); // en refresh
+    expect(counts.voucher).toBe(2); // ett omförsök
+    expect(counts.lastAuth).toBe("Bearer at-new");
+  });
+
+  it("kastar om byrån inte auth:at (inga tokens)", async () => {
+    const client = new FortnoxClient(config, new InMemoryFortnoxTokenStore(), makeFetch([200], { token: 0, voucher: 0 }));
+    await expect(client.createVoucher(VOUCHER)).rejects.toThrow(/inga tokens/);
+  });
+});

--- a/test/unit/server/integrations/fortnox/oauth.test.ts
+++ b/test/unit/server/integrations/fortnox/oauth.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest-compat";
+import {
+  buildAuthorizeUrl,
+  exchangeCodeForTokens,
+  refreshTokens,
+} from "@/lib/server/integrations/fortnox/oauth";
+import type { FortnoxConfig } from "@/lib/server/integrations/fortnox/schema";
+
+const config: FortnoxConfig = {
+  clientId: "cid",
+  clientSecret: "secret",
+  redirectUri: "https://app.example/cb",
+  scopes: ["bookkeeping", "profile"],
+  authBase: "https://auth.test",
+  apiBase: "https://api.test",
+};
+
+interface Captured {
+  url: string;
+  init: RequestInit;
+}
+
+function fakeFetch(status: number, json: unknown, cap?: Captured) {
+  return (async (url: string | URL | Request, init?: RequestInit) => {
+    if (cap) {
+      cap.url = String(url);
+      cap.init = init ?? {};
+    }
+    return new Response(JSON.stringify(json), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof globalThis.fetch;
+}
+
+const TOKEN_JSON = {
+  access_token: "at-1",
+  refresh_token: "rt-2",
+  token_type: "Bearer",
+  expires_in: 3600,
+  scope: "bookkeeping",
+};
+
+describe("buildAuthorizeUrl", () => {
+  it("bygger authorize-URL med rätt parametrar", () => {
+    const u = new URL(buildAuthorizeUrl(config, "xyz-state"));
+    expect(u.origin + u.pathname).toBe("https://auth.test/oauth-v1/auth");
+    const p = u.searchParams;
+    expect(p.get("client_id")).toBe("cid");
+    expect(p.get("redirect_uri")).toBe("https://app.example/cb");
+    expect(p.get("scope")).toBe("bookkeeping profile");
+    expect(p.get("state")).toBe("xyz-state");
+    expect(p.get("response_type")).toBe("code");
+    expect(p.get("access_type")).toBe("offline");
+    expect(p.get("account_type")).toBe("service");
+  });
+});
+
+describe("exchangeCodeForTokens", () => {
+  it("POST:ar med Basic-auth + code-grant och räknar ut utgång", async () => {
+    const cap = {} as Captured;
+    const tokens = await exchangeCodeForTokens(config, "the-code", fakeFetch(200, TOKEN_JSON, cap), 1_000_000);
+
+    expect(cap.url).toBe("https://auth.test/oauth-v1/token");
+    const headers = cap.init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe(`Basic ${Buffer.from("cid:secret").toString("base64")}`);
+    expect(headers["Content-Type"]).toBe("application/x-www-form-urlencoded");
+    const body = new URLSearchParams(cap.init.body as string);
+    expect(body.get("grant_type")).toBe("authorization_code");
+    expect(body.get("code")).toBe("the-code");
+    expect(body.get("redirect_uri")).toBe("https://app.example/cb");
+
+    expect(tokens.accessToken).toBe("at-1");
+    expect(tokens.refreshToken).toBe("rt-2");
+    // 1_000_000 + (3600 - 30) * 1000
+    expect(tokens.accessTokenExpiresAt).toBe(1_000_000 + 3_570_000);
+  });
+
+  it("kastar vid icke-2xx", async () => {
+    await expect(
+      exchangeCodeForTokens(config, "bad", fakeFetch(400, { error: "invalid_grant" })),
+    ).rejects.toThrow(/Fortnox token-fel 400/);
+  });
+});
+
+describe("refreshTokens", () => {
+  it("använder refresh-grant och returnerar den ROTERADE refresh-token:en", async () => {
+    const cap = {} as Captured;
+    const rotated = { ...TOKEN_JSON, access_token: "at-new", refresh_token: "rt-rotated" };
+    const tokens = await refreshTokens(config, "rt-old", fakeFetch(200, rotated, cap), 5_000);
+
+    const body = new URLSearchParams(cap.init.body as string);
+    expect(body.get("grant_type")).toBe("refresh_token");
+    expect(body.get("refresh_token")).toBe("rt-old");
+    expect(tokens.accessToken).toBe("at-new");
+    expect(tokens.refreshToken).toBe("rt-rotated"); // gamla rt-old är nu ogiltig
+    expect(tokens.accessTokenExpiresAt).toBe(5_000 + 3_570_000);
+  });
+});

--- a/test/unit/server/integrations/fortnox/voucher.test.ts
+++ b/test/unit/server/integrations/fortnox/voucher.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest-compat";
+import { buildVoucherFromInvoice } from "@/lib/server/integrations/fortnox/voucher";
+import type { FortnoxKontoMappning } from "@/lib/server/integrations/fortnox/schema";
+
+const mapping: FortnoxKontoMappning = {
+  voucherSeries: "A",
+  kundfordran: "1510",
+  intaktArvode: "3041",
+  momsUtgaende: "2611",
+};
+
+const sum = (rows: { Debit: number; Credit: number }[], k: "Debit" | "Credit") =>
+  rows.reduce((s, r) => s + r[k], 0);
+
+describe("buildVoucherFromInvoice", () => {
+  it("standardfaktura: 3 balanserade rader (debet kundfordran = kredit intäkt+moms)", () => {
+    // 12500 öre brutto inkl 25 % moms → 100 kr netto + 25 kr moms = 125 kr.
+    const v = buildVoucherFromInvoice(
+      { amount: 12_500, invoiceDate: "2026-05-25", invoiceNumber: "F-2026-0042" },
+      mapping,
+    );
+    expect(v.VoucherSeries).toBe("A");
+    expect(v.TransactionDate).toBe("2026-05-25");
+    expect(v.Description).toBe("Faktura F-2026-0042");
+    expect(v.VoucherRows).toHaveLength(3);
+
+    const byAcct = (n: number) => v.VoucherRows.find((r) => r.Account === n)!;
+    expect(byAcct(1510)).toMatchObject({ Debit: 125, Credit: 0 });
+    expect(byAcct(3041)).toMatchObject({ Debit: 0, Credit: 100 });
+    expect(byAcct(2611)).toMatchObject({ Debit: 0, Credit: 25 });
+
+    // Balans
+    expect(sum(v.VoucherRows, "Debit")).toBe(sum(v.VoucherRows, "Credit"));
+  });
+
+  it("kreditfaktura (negativt belopp) vänder debet/kredit men håller balans", () => {
+    const v = buildVoucherFromInvoice(
+      { amount: -12_500, invoiceDate: new Date("2026-05-25T10:00:00Z"), invoiceNumber: "K-2026-0001" },
+      mapping,
+    );
+    const byAcct = (n: number) => v.VoucherRows.find((r) => r.Account === n)!;
+    expect(byAcct(1510)).toMatchObject({ Debit: 0, Credit: 125 }); // kundfordran krediteras
+    expect(byAcct(3041)).toMatchObject({ Debit: 100, Credit: 0 });
+    expect(byAcct(2611)).toMatchObject({ Debit: 25, Credit: 0 });
+    expect(sum(v.VoucherRows, "Debit")).toBe(sum(v.VoucherRows, "Credit"));
+  });
+
+  it("0 % moms: moms-raden släpps (2 rader kvar, fortf. balanserat)", () => {
+    const v = buildVoucherFromInvoice(
+      { amount: 10_000, invoiceDate: "2026-01-01" },
+      mapping,
+      0,
+    );
+    expect(v.VoucherRows).toHaveLength(2);
+    expect(v.VoucherRows.some((r) => r.Account === 2611)).toBe(false);
+    expect(sum(v.VoucherRows, "Debit")).toBe(sum(v.VoucherRows, "Credit"));
+    expect(v.Description).toBe("Kundfaktura (AVA)"); // saknar invoiceNumber
+  });
+
+  it("balans håller även för 'sneda' belopp (öre-rest hamnar i moms)", () => {
+    // 10001 öre — momsen blir resten så debet/kredit alltid stämmer.
+    const v = buildVoucherFromInvoice({ amount: 10_001, invoiceDate: "2026-03-03" }, mapping);
+    expect(sum(v.VoucherRows, "Debit")).toBeCloseTo(sum(v.VoucherRows, "Credit"), 10);
+    expect(sum(v.VoucherRows, "Debit")).toBeCloseTo(100.01, 10);
+  });
+});


### PR DESCRIPTION
## Vad — Fortnox-connectorns kärna (API + OAuth)

Tunn, **self-hosted** connector som pushar AVA-kundfakturor till Fortnox som verifikat. Hela kärnan enhetstestad utan riktig Fortnox (injicerad `fetch`).

| Fil | Ansvar |
|---|---|
| `schema.ts` | zod: config, token-svar, persisterade tokens, konto-mappning, voucher payload/svar |
| `oauth.ts` | Authorization Code-flöde: `buildAuthorizeUrl` / `exchangeCodeForTokens` / `refreshTokens` (Basic-auth, `access_type=offline`, refresh-**rotation**) |
| `token-store.ts` | `FortnoxTokenStore` + in-memory-impl (riktigt valv = #79) |
| `client.ts` | `FortnoxClient`: håller access-token färsk, 401→forcerad refresh + omförsök, `createVoucher` |
| `voucher.ts` | `buildVoucherFromInvoice`: balanserat verifikat (debet kundfordran, kredit intäkt + moms), öre→SEK, kreditfaktura vänder |

**12 tester** (OAuth-params/grants/rotation, voucher-balans/moms/kreditfaktura/0%, klient-refresh/401-retry/rotation-persist). Komplexitet ≤8 (klarar #40-grinden), coverage upp till 83.05%.

## Vad som INTE är med (medvetet — kräver dig/sandbox)

- **Server-wiring**: koppla in som `PeerAct` i server-runtime (pull osynkade fakturor → bygg → push → skriv `invoice.fortnoxId`). Görs när sandbox-creds finns.
- **Skarpa creds** (`client_id`/secret → #79-valv) + **konto-mappning** (byråns bokföringsbeslut).
- **Bekräfta mot sandbox**: exakt voucher-wire-nesting + authorize-params (isolerade i `toWireVoucher`/`buildAuthorizeUrl`).
- Fler-VAT/utläggs-uppdelning (kräver fakturarader).

Se `src/lib/server/integrations/fortnox/README.md` för setup-stegen.

Refs #82