### PR TITLE
test(e2e): stabilisera round-trip via sync-settle ist. för debounce-race (#209)

### DIFF
--- a/src/components/shell/sync-status-pill.tsx
+++ b/src/components/shell/sync-status-pill.tsx
@@ -26,6 +26,7 @@ export function SyncStatusPill({ state }: Props) {
     <Link
       href="/settings"
       title={title}
+      data-testid="sync-pill"
       className={`text-xs px-2 py-1 rounded border inline-flex items-center gap-1.5 hover:opacity-80 ${cls}`}
     >
       <span aria-hidden>{icon}</span>

--- a/test/e2e/round-trip/round-trip.spec.ts
+++ b/test/e2e/round-trip/round-trip.spec.ts
@@ -50,6 +50,19 @@ function contactNamesInRepo(): string[] {
   return rowsInRepo("contacts").map((c) => String(c.name ?? ""));
 }
 
+/**
+ * Vänta tills en UI-mutation faktiskt committats + pushats till git-db:n,
+ * i st.f. att racea browserns 10 s push-debounce mot ett pollfönster (#209).
+ *
+ * Sync-pillen visar `✓ Sparat` (synced) ENBART när inga ändringar väntar — en
+ * mutation gör pillen pending/syncing tills push:en landat. Anropa EFTER att
+ * UI:t bekräftat att ändringen sparats (då är pillen redan pending), så att vi
+ * inte matchar ett gammalt "Sparat" från en tidigare cykel.
+ */
+async function waitForGitDbPush(page: Page): Promise<void> {
+  await expect(page.getByTestId("sync-pill")).toContainText("Sparat", { timeout: 90_000 });
+}
+
 /** Skapa en org-scopad kontakt via UI:t (förutsättning för flera flöden). */
 async function createContact(page: Page, name: string): Promise<void> {
   await page.goto("/ava/contacts/");
@@ -426,6 +439,7 @@ test("jävskontroll: sök på personnummer → conflict-checks i git-db:n", asyn
   await expect(page.getByRole("heading", { name: /Resultat för/i })).toBeVisible({ timeout: 15_000 });
 
   // En conflict-checks-rad ska landa i git-db:n (loggas oavsett antal träffar)
+  await waitForGitDbPush(page);
   await expect.poll(() => rowsInRepo("conflict-checks").map((c) => String(c.searchTerm)), POLL).toContain(pnr);
 });
 
@@ -500,6 +514,7 @@ test("användare: skapa via /users/new + inaktivera → .ava/users i git-db:n", 
   await expect(page.getByText(name)).toBeVisible({ timeout: 15_000 });
 
   // Användarrow:n persisterad till .ava/users/<email>.json
+  await waitForGitDbPush(page);
   await expect.poll(() => rowsInRepo(".ava/users").map((u) => String(u.email)), POLL).toContain(email);
 
   // Inaktivera användaren — confirm()-dialog accepteras automatiskt
@@ -507,6 +522,7 @@ test("användare: skapa via /users/new + inaktivera → .ava/users i git-db:n", 
   await page.getByRole("row", { name: new RegExp(name) }).getByRole("button", { name: /Inaktivera/ }).click();
 
   // active: false ska persisteras till samma fil
+  await waitForGitDbPush(page);
   await expect.poll(() => {
     const row = rowsInRepo(".ava/users").find((u) => String(u.email) === email);
     return row ? row.active : "(saknas)";


### PR DESCRIPTION
## Problem

Flaky round-trip-e2e (`jävskontroll` rad 398, `users` rad 480) — tvingade omkörning på #197, #204, #208. Racet: UI-mutation → browserns **10 s push-debounce** auto-sync → testet `expect.poll`:ar genom att **klona git-db:n per försök**; under CI-last > 60 s pollfönster → timeout.

## Fix (deterministisk, ingen race)

Vänta på en explicit "push klar"-signal innan repo:t läses:
- `sync-status-pill`: `data-testid="sync-pill"`.
- `waitForGitDbPush(page)`: väntar tills pillen visar **`Sparat`** (synced = 0 pending = push landad). Anropas EFTER att UI:t bekräftat sparningen, så vi inte matchar ett gammalt "Sparat".
- Används i `jävskontroll` + `users` före `rowsInRepo`-assertions; befintliga pollfönster blir snabb safety-net.

Pillen renderas i shell-headern (`<AutoSync/>`) för alla self-hosted-routes — verifierat för /users och /conflicts (renderas oberoende av loader-status).

## Verifierat

typecheck + lint + full unit/coverage grönt (2530 pass). Själva e2e:t körs av CI (i den miljö som flaka:de) — fixen tar bort timing-beroendet snarare än att bara höja timeout.

Closes #209