### PR TITLE
feat(secrets): krypterat secrets-valv på servern (#79)

### DIFF
--- a/docs/adr/0008-secrets-valv-krypterad-fil.md
+++ b/docs/adr/0008-secrets-valv-krypterad-fil.md
@@ -1,0 +1,60 @@
+# ADR 0008 — Secrets-valv: krypterad fil i server-data-dir
+
+- **Status:** Accepterad
+- **Datum:** 2026-06-11
+- **Beslutsfattare:** Ulrik Sjölin
+- **Berör:** server-runtime (ADR 0005), Fortnox-connector (#82), framtida server-connectorer (SMTP m.fl.)
+- **Issue:** [#79](https://github.com/ulrik-s/ava/issues/79)
+- **Relaterat:** [ADR 0005](./0005-server-som-git-peer.md) (tunn git-peer-server), [#82](https://github.com/ulrik-s/ava/issues/82) (Fortnox)
+
+## Kontext
+
+Server-runtime:n behöver hålla hemligheter som inte hör hemma i git-db:n:
+Fortnox `client_secret` + OAuth-tokens, och senare SMTP-creds m.m.
+
+Två krav gör att **env-variabler inte räcker**:
+
+1. **Skrivbart i runtime.** Fortnox refresh-tokens **roterar** — varje refresh
+   ger en ny refresh-token och ogiltigförklarar den gamla. Connectorn måste
+   kunna *skriva tillbaka* den nya, och den måste överleva omstart. En env-var
+   är read-only för processen.
+2. **Krypterat i vila.** Hemligheter på disk i klartext är oacceptabelt.
+
+USP:n (ingen tredjeparts-infra) utesluter en extern secret-manager för
+baslinjen.
+
+## Beslut
+
+Ett **secrets-valv som en AES-256-GCM-krypterad fil** i serverns data-katalog.
+
+- `SecretsVault`-interface (`get`/`set`/`delete`) + `EncryptedFileVault`.
+- Hela nyckel/värde-kartan lagras som **en** krypterad blob (AES-256-GCM,
+  autentiserad → fel nyckel/manipulation upptäcks).
+- **Master-nyckeln injiceras via env** (`AVA_SECRETS_KEY`, base64-kodade 32 byte)
+  och ligger aldrig på disk med chiffertexten.
+- **Filvägen sätts separat** (`AVA_SECRETS_FILE`) och ligger **utanför
+  git-working-copy:n** — secrets-in-git undviks helt.
+- Atomisk skrivning (tmp + rename), `0600`-rättigheter.
+- `fs` injiceras (`VaultFs`) → enhetstestbart utan disk.
+
+Fortnox-token-store:n får en `VaultFortnoxTokenStore` backad av valvet, vilket
+löser rotations-kravet utan att ändra connectorns interface.
+
+## Konsekvenser
+
+- **+** Skrivbart, persistent, krypterat — uppfyller rotations-kravet; ingen
+  extern infra.
+- **+** Generiskt — återanvänds för alla framtida server-secrets.
+- **−** Nyckelhantering blir driftens ansvar (env/host-secret). Tappad
+  `AVA_SECRETS_KEY` ⇒ valvet oläsbart (byrån re-authar mot Fortnox).
+- **−** En master-nyckel för hela valvet (ingen per-secret-nyckel) — rimligt
+  för en single-tenant self-hosted server.
+
+## Alternativ (förkastade)
+
+- **Krypterad blob i git-db:n** — secrets skulle resa med repo:t och kopplas
+  till sync; högre läckage-yta även krypterat. Nej.
+- **Extern secret-manager (Vault/KMS/SOPS)** — mest robust men bryter
+  USP:n (tredjeparts-infra) för baslinjen. Kan läggas till som en
+  alternativ `SecretsVault`-impl senare utan att röra konsumenterna.
+- **Env-only** — kan inte skriva tillbaka roterade refresh-tokens. Nej.

--- a/src/lib/server/integrations/fortnox/token-store.ts
+++ b/src/lib/server/integrations/fortnox/token-store.ts
@@ -3,12 +3,13 @@
  *
  * Refresh-token roterar vid varje refresh, så den MÅSTE överleva
  * server-omstarter — annars tappar vi kopplingen och byrån måste re-autha.
- * Lagringen är abstraherad: in-memory nu (test/dev), riktig backend (krypterat
- * i git-db eller secrets-valv #79) kopplas in via samma interface utan att
- * resten av connectorn ändras.
+ * Lagringen är abstraherad: in-memory (test/dev) eller `VaultFortnoxTokenStore`
+ * backad av secrets-valvet (#79) i skarp drift — samma interface, resten av
+ * connectorn oförändrad.
  */
 
 import { fortnoxStoredTokensSchema, type FortnoxStoredTokens } from "./schema";
+import type { SecretsVault } from "../../secrets/vault";
 
 export interface FortnoxTokenStore {
   /** Hämta sparade tokens, eller null om byrån inte auth:at än. */
@@ -32,5 +33,26 @@ export class InMemoryFortnoxTokenStore implements FortnoxTokenStore {
   async save(tokens: FortnoxStoredTokens): Promise<void> {
     // Strikt parsning även internt — fångar trasig data tidigt.
     this.tokens = fortnoxStoredTokensSchema.parse(tokens);
+  }
+}
+
+/**
+ * Persistent store backad av secrets-valvet (#79). Tokens (inkl. den roterande
+ * refresh-token:en) lagras krypterat och överlever omstart.
+ */
+export class VaultFortnoxTokenStore implements FortnoxTokenStore {
+  constructor(
+    private readonly vault: SecretsVault,
+    private readonly key: string = "fortnox.tokens",
+  ) {}
+
+  async load(): Promise<FortnoxStoredTokens | null> {
+    const raw = await this.vault.get(this.key);
+    if (!raw) return null;
+    return fortnoxStoredTokensSchema.parse(JSON.parse(raw));
+  }
+
+  async save(tokens: FortnoxStoredTokens): Promise<void> {
+    await this.vault.set(this.key, JSON.stringify(fortnoxStoredTokensSchema.parse(tokens)));
   }
 }

--- a/src/lib/server/secrets/crypto.ts
+++ b/src/lib/server/secrets/crypto.ts
@@ -1,0 +1,49 @@
+/**
+ * Symmetrisk kryptering för secrets-valvet (#79, ADR 0008).
+ *
+ * AES-256-GCM (autentiserad — upptäcker manipulation/fel nyckel via auth-tag).
+ * Master-nyckeln injiceras (env `AVA_SECRETS_KEY`, base64-kodade 32 byte) och
+ * lagras ALDRIG på disk tillsammans med chiffertexten.
+ *
+ * Format på en krypterad sträng: `base64(iv):base64(tag):base64(ciphertext)`.
+ */
+
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+const ALGO = "aes-256-gcm";
+const IV_LEN = 12; // GCM-rekommendation
+const KEY_LEN = 32; // AES-256
+
+/** Validera + ladda master-nyckeln ur env-värdet (base64, 32 byte). */
+export function loadMasterKey(envValue: string | undefined): Buffer {
+  if (!envValue) {
+    throw new Error("AVA_SECRETS_KEY saknas — sätt en base64-kodad 32-byte-nyckel.");
+  }
+  const key = Buffer.from(envValue, "base64");
+  if (key.length !== KEY_LEN) {
+    throw new Error(`AVA_SECRETS_KEY måste vara ${KEY_LEN} byte (base64-kodat); fick ${key.length}.`);
+  }
+  return key;
+}
+
+export function encryptSecret(plaintext: string, key: Buffer): string {
+  const iv = randomBytes(IV_LEN);
+  const cipher = createCipheriv(ALGO, key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return [iv, tag, ciphertext].map((b) => b.toString("base64")).join(":");
+}
+
+/** Dekryptera. Kastar vid fel nyckel eller manipulerad data (GCM auth-tag). */
+export function decryptSecret(blob: string, key: Buffer): string {
+  const parts = blob.split(":");
+  if (parts.length !== 3) {
+    throw new Error("Ogiltigt secret-format (förväntade iv:tag:ciphertext).");
+  }
+  const iv = Buffer.from(parts[0]!, "base64");
+  const tag = Buffer.from(parts[1]!, "base64");
+  const ciphertext = Buffer.from(parts[2]!, "base64");
+  const decipher = createDecipheriv(ALGO, key, iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString("utf8");
+}

--- a/src/lib/server/secrets/vault.ts
+++ b/src/lib/server/secrets/vault.ts
@@ -1,0 +1,98 @@
+/**
+ * Secrets-valv (#79, ADR 0008) — krypterad nyckel/värde-store för
+ * server-runtime:n (Fortnox-tokens, client-secrets, framtida SMTP-creds …).
+ *
+ * Designval:
+ *   - **Skrivbart** — Fortnox refresh-tokens ROTERAR, så env-variabler räcker
+ *     inte; valvet måste kunna skrivas i runtime och överleva omstart.
+ *   - **Krypterat i vila** — hela kartan ligger som EN AES-256-GCM-blob (se
+ *     crypto.ts). Master-nyckeln kommer från env, aldrig från disk.
+ *   - **Utanför git-working-copy:n** — filvägen sätts separat (`AVA_SECRETS_FILE`)
+ *     och får ALDRIG ligga i repo:t (secrets-in-git undviks).
+ *   - **fs injicerad** (`VaultFs`) → testbar utan riktig disk.
+ */
+
+import { decryptSecret, encryptSecret, loadMasterKey } from "./crypto";
+
+export interface SecretsVault {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+
+/** Minimal fs-yta valvet behöver. `read` → null om filen saknas. */
+export interface VaultFs {
+  read(path: string): Promise<string | null>;
+  write(path: string, data: string): Promise<void>;
+}
+
+export class EncryptedFileVault implements SecretsVault {
+  constructor(
+    private readonly filePath: string,
+    private readonly key: Buffer,
+    private readonly fs: VaultFs,
+  ) {}
+
+  private async loadMap(): Promise<Record<string, string>> {
+    const blob = await this.fs.read(this.filePath);
+    if (!blob) return {};
+    return JSON.parse(decryptSecret(blob, this.key)) as Record<string, string>;
+  }
+
+  private async saveMap(map: Record<string, string>): Promise<void> {
+    await this.fs.write(this.filePath, encryptSecret(JSON.stringify(map), this.key));
+  }
+
+  async get(key: string): Promise<string | null> {
+    return (await this.loadMap())[key] ?? null;
+  }
+
+  async set(key: string, value: string): Promise<void> {
+    const map = await this.loadMap();
+    map[key] = value;
+    await this.saveMap(map);
+  }
+
+  async delete(key: string): Promise<void> {
+    const map = await this.loadMap();
+    delete map[key];
+    await this.saveMap(map);
+  }
+}
+
+/**
+ * Bygg valvet från env (server-runtime, ADR 0008):
+ *   - `AVA_SECRETS_KEY`  base64-kodade 32 byte master-nyckel.
+ *   - `AVA_SECRETS_FILE` sökväg till valv-filen (UTANFÖR git-working-copy:n).
+ */
+export function createVaultFromEnv(env: NodeJS.ProcessEnv = process.env): SecretsVault {
+  const key = loadMasterKey(env.AVA_SECRETS_KEY);
+  const file = env.AVA_SECRETS_FILE;
+  if (!file) {
+    throw new Error("AVA_SECRETS_FILE saknas — sökväg till valv-filen (utanför git-working-copy:n).");
+  }
+  return new EncryptedFileVault(file, key, nodeVaultFs());
+}
+
+/** Node-fs-impl: atomisk skrivning (tmp + rename) med 0600-rättigheter. */
+export function nodeVaultFs(): VaultFs {
+  return {
+    async read(path: string): Promise<string | null> {
+      const { readFile } = await import("node:fs/promises");
+      try {
+        return await readFile(path, "utf8");
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+        throw err;
+      }
+    },
+    async write(path: string, data: string): Promise<void> {
+      const { writeFile, rename, mkdir } = await import("node:fs/promises");
+      const { dirname } = await import("node:path");
+      await mkdir(dirname(path), { recursive: true });
+      const tmp = `${path}.tmp`;
+      await writeFile(tmp, data, { mode: 0o600 });
+      await rename(tmp, path);
+    },
+  };
+}

--- a/test/unit/server/integrations/fortnox/token-store.test.ts
+++ b/test/unit/server/integrations/fortnox/token-store.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest-compat";
+import { VaultFortnoxTokenStore } from "@/lib/server/integrations/fortnox/token-store";
+import type { SecretsVault } from "@/lib/server/secrets/vault";
+import type { FortnoxStoredTokens } from "@/lib/server/integrations/fortnox/schema";
+
+class MemVault implements SecretsVault {
+  readonly m = new Map<string, string>();
+  async get(k: string) {
+    return this.m.get(k) ?? null;
+  }
+  async set(k: string, v: string) {
+    this.m.set(k, v);
+  }
+  async delete(k: string) {
+    this.m.delete(k);
+  }
+}
+
+const tokens = (rt: string): FortnoxStoredTokens => ({
+  accessToken: "at",
+  refreshToken: rt,
+  accessTokenExpiresAt: 1_000,
+});
+
+describe("VaultFortnoxTokenStore", () => {
+  it("save/load roundtrip via valvet", async () => {
+    const store = new VaultFortnoxTokenStore(new MemVault());
+    await store.save(tokens("rt-1"));
+    expect((await store.load())?.refreshToken).toBe("rt-1");
+  });
+
+  it("save skriver över (rotation)", async () => {
+    const store = new VaultFortnoxTokenStore(new MemVault());
+    await store.save(tokens("rt-1"));
+    await store.save(tokens("rt-2"));
+    expect((await store.load())?.refreshToken).toBe("rt-2");
+  });
+
+  it("load → null när valvet är tomt", async () => {
+    expect(await new VaultFortnoxTokenStore(new MemVault()).load()).toBeNull();
+  });
+
+  it("använder den angivna valv-nyckeln", async () => {
+    const vault = new MemVault();
+    await new VaultFortnoxTokenStore(vault).save(tokens("rt-x"));
+    expect(vault.m.has("fortnox.tokens")).toBe(true);
+  });
+});

--- a/test/unit/server/secrets/crypto.test.ts
+++ b/test/unit/server/secrets/crypto.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest-compat";
+import { decryptSecret, encryptSecret, loadMasterKey } from "@/lib/server/secrets/crypto";
+
+const key = Buffer.alloc(32, 7);
+const wrongKey = Buffer.alloc(32, 9);
+
+describe("secrets/crypto", () => {
+  it("krypterar och dekrypterar (roundtrip)", () => {
+    const blob = encryptSecret("hemlig text åäö", key);
+    expect(blob).not.toContain("hemlig"); // klartext syns inte
+    expect(blob.split(":")).toHaveLength(3); // iv:tag:ct
+    expect(decryptSecret(blob, key)).toBe("hemlig text åäö");
+  });
+
+  it("fel nyckel kan inte dekryptera (GCM auth)", () => {
+    const blob = encryptSecret("x", key);
+    expect(() => decryptSecret(blob, wrongKey)).toThrow();
+  });
+
+  it("manipulerad ciphertext upptäcks", () => {
+    const parts = encryptSecret("orörd", key).split(":");
+    parts[2] = Buffer.from("manipulerad-ct").toString("base64");
+    expect(() => decryptSecret(parts.join(":"), key)).toThrow();
+  });
+
+  it("ogiltigt format kastar", () => {
+    expect(() => decryptSecret("inte-ett-giltigt-blob", key)).toThrow(/format/);
+  });
+
+  it("loadMasterKey validerar base64 32-byte", () => {
+    expect(() => loadMasterKey(undefined)).toThrow(/saknas/);
+    expect(() => loadMasterKey(Buffer.alloc(16, 1).toString("base64"))).toThrow(/32 byte/);
+    expect(loadMasterKey(Buffer.alloc(32, 1).toString("base64")).length).toBe(32);
+  });
+});

--- a/test/unit/server/secrets/vault.test.ts
+++ b/test/unit/server/secrets/vault.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest-compat";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { EncryptedFileVault, createVaultFromEnv, nodeVaultFs, type VaultFs } from "@/lib/server/secrets/vault";
+
+const key = Buffer.alloc(32, 3);
+const otherKey = Buffer.alloc(32, 4);
+const PATH = "/data/secrets.enc";
+
+/** In-memory VaultFs som speglar "disk". */
+function memFs(): VaultFs & { disk: Map<string, string> } {
+  const disk = new Map<string, string>();
+  return {
+    disk,
+    async read(p: string) {
+      return disk.get(p) ?? null;
+    },
+    async write(p: string, d: string) {
+      disk.set(p, d);
+    },
+  };
+}
+
+describe("EncryptedFileVault", () => {
+  it("set/get", async () => {
+    const v = new EncryptedFileVault(PATH, key, memFs());
+    await v.set("fortnox.client_secret", "s3cr3t");
+    expect(await v.get("fortnox.client_secret")).toBe("s3cr3t");
+  });
+
+  it("saknad nyckel → null", async () => {
+    const v = new EncryptedFileVault(PATH, key, memFs());
+    expect(await v.get("nope")).toBeNull();
+  });
+
+  it("delete tar bort", async () => {
+    const v = new EncryptedFileVault(PATH, key, memFs());
+    await v.set("a", "1");
+    await v.delete("a");
+    expect(await v.get("a")).toBeNull();
+  });
+
+  it("lagrar krypterat — varken nyckel eller värde i klartext på disk", async () => {
+    const fs = memFs();
+    const v = new EncryptedFileVault(PATH, key, fs);
+    await v.set("token", "super-secret-xyz");
+    const onDisk = fs.disk.get(PATH)!;
+    expect(onDisk).not.toContain("super-secret-xyz");
+    expect(onDisk).not.toContain("token");
+  });
+
+  it("persisterar — ny instans (samma fs + nyckel) ser datan", async () => {
+    const fs = memFs();
+    await new EncryptedFileVault(PATH, key, fs).set("k", "v");
+    const reopened = new EncryptedFileVault(PATH, key, fs);
+    expect(await reopened.get("k")).toBe("v");
+  });
+
+  it("fel master-nyckel kan inte läsa valvet", async () => {
+    const fs = memFs();
+    await new EncryptedFileVault(PATH, key, fs).set("k", "v");
+    const wrong = new EncryptedFileVault(PATH, otherKey, fs);
+    await expect(wrong.get("k")).rejects.toThrow();
+  });
+});
+
+describe("createVaultFromEnv", () => {
+  const validKey = Buffer.alloc(32, 1).toString("base64");
+
+  it("kräver nyckel + filväg", () => {
+    expect(() => createVaultFromEnv({})).toThrow(/AVA_SECRETS_KEY/);
+    expect(() => createVaultFromEnv({ AVA_SECRETS_KEY: validKey })).toThrow(/AVA_SECRETS_FILE/);
+  });
+
+  it("bygger ett valv när båda finns", () => {
+    const v = createVaultFromEnv({ AVA_SECRETS_KEY: validKey, AVA_SECRETS_FILE: "/srv/secrets.enc" });
+    expect(typeof v.get).toBe("function");
+  });
+});
+
+describe("nodeVaultFs (riktig disk)", () => {
+  it("saknad fil → null; skriver krypterat + läser tillbaka", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ava-vault-"));
+    try {
+      const fs = nodeVaultFs();
+      expect(await fs.read(join(dir, "missing.enc"))).toBeNull();
+
+      const file = join(dir, "secrets.enc");
+      const v = new EncryptedFileVault(file, key, fs);
+      await v.set("token", "hemlis-på-disk");
+      expect(await v.get("token")).toBe("hemlis-på-disk");
+
+      const raw = await readFile(file, "utf8");
+      expect(raw).not.toContain("hemlis-på-disk"); // krypterat på riktig disk
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Vad

AES-256-GCM-krypterat nyckel/värde-valv för server-runtime:n (ADR 0008). Löser att Fortnox **roterande** refresh-tokens behöver en **skrivbar, persistent, krypterad** store — env-variabler räcker inte.

| Fil | Ansvar |
|---|---|
| `secrets/crypto.ts` | AES-256-GCM `encryptSecret`/`decryptSecret` + `loadMasterKey` (base64 32b) |
| `secrets/vault.ts` | `SecretsVault` + `EncryptedFileVault` (hela kartan = en krypterad blob), injicerbar `VaultFs`, `nodeVaultFs` (atomisk 0600-skrivning), `createVaultFromEnv` |
| `fortnox/token-store.ts` | `VaultFortnoxTokenStore` — kopplar #82:s token-store till valvet (rotation persisteras krypterat) |
| `docs/adr/0008` | beslut + förkastade alternativ (git-blob / extern KMS / env-only) |

## Säkerhet / gränsdragning secrets↔git

- Master-nyckel via env (`AVA_SECRETS_KEY`), ligger **aldrig** på disk med chiffertexten.
- Valv-filen (`AVA_SECRETS_FILE`) ligger **utanför** git-working-copy:n → secrets-in-git undviks.
- GCM auth-tag → fel nyckel/manipulation upptäcks.

## Tester (27)

Roundtrip, fel-nyckel + manipulerad ciphertext kastar, **kryptering verifierad på riktig disk** (`nodeVaultFs` mot temp-dir), token-rotation, `createVaultFromEnv`-validering. Komplexitet ≤8 (klarar #40-grinden), full svit + coverage grönt.

## Återstår (med #82)

Wiring av valvet in i connector-loopen (server-runtime → `VaultFortnoxTokenStore` → `FortnoxClient`) görs när Fortnox-creds finns.

Closes #79