### PR TITLE
fix(fortnox): skicka VoucherRows som plain array (inte XML-nästlad)

### DIFF
--- a/src/lib/server/integrations/fortnox/client.ts
+++ b/src/lib/server/integrations/fortnox/client.ts
@@ -16,9 +16,10 @@ import {
 import type { FortnoxTokenStore } from "./token-store";
 
 /**
- * Wire-format för voucher-payloaden. Enligt Fortnox-dokumentationen nästlas
- * raderna som `VoucherRows: { VoucherRow: [...] }`. (Bekräfta exakt nesting
- * mot sandbox när creds finns — isolerat här så det är en enradsändring.)
+ * Wire-format för voucher-payloaden. VERIFIERAT mot Fortnox sandbox (tenant
+ * 1838388, 2026-06-11): JSON-API:t vill ha `VoucherRows` som en PLAIN ARRAY av
+ * rad-objekt — INTE den XML-style-nästlingen `{ VoucherRow: [...] }` (den ger
+ * `400 Felaktig datastruktur`, code 2002381). Account/Debit/Credit som tal är OK.
  */
 function toWireVoucher(v: FortnoxVoucher): Record<string, unknown> {
   return {
@@ -26,7 +27,7 @@ function toWireVoucher(v: FortnoxVoucher): Record<string, unknown> {
     TransactionDate: v.TransactionDate,
     Description: v.Description,
     ...(v.Comments ? { Comments: v.Comments } : {}),
-    VoucherRows: { VoucherRow: v.VoucherRows },
+    VoucherRows: v.VoucherRows,
   };
 }
 

--- a/test/unit/server/integrations/fortnox/client.test.ts
+++ b/test/unit/server/integrations/fortnox/client.test.ts
@@ -30,7 +30,7 @@ function json(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
 }
 
-interface Counts { token: number; voucher: number; lastAuth?: string }
+interface Counts { token: number; voucher: number; lastAuth?: string; lastBody?: unknown }
 
 /** fetch som routar token- vs voucher-endpoint; voucher-status styrs per anrop. */
 function makeFetch(voucherStatuses: number[], counts: Counts) {
@@ -43,6 +43,7 @@ function makeFetch(voucherStatuses: number[], counts: Counts) {
     counts.voucher++;
     const headers = (init?.headers ?? {}) as Record<string, string>;
     counts.lastAuth = headers.Authorization ?? "";
+    counts.lastBody = typeof init?.body === "string" ? JSON.parse(init.body) : undefined;
     const status = voucherStatuses[counts.voucher - 1] ?? 200;
     return status === 200 ? json(200, VOUCHER_RESP) : json(status, { error: "x" });
   }) as typeof globalThis.fetch;
@@ -66,6 +67,18 @@ describe("FortnoxClient.createVoucher", () => {
     expect(counts.token).toBe(0);
     expect(counts.voucher).toBe(1);
     expect(counts.lastAuth).toBe("Bearer at-fresh");
+  });
+
+  it("POST-body: VoucherRows är en plain array (ej XML-nästlad VoucherRow)", async () => {
+    // Regression: Fortnox JSON-API ger 400 \"Felaktig datastruktur\" om raderna
+    // nästlas som { VoucherRow: [...] }. Verifierat mot sandbox 1838388.
+    const counts: Counts = { token: 0, voucher: 0 };
+    const client = new FortnoxClient(config, new InMemoryFortnoxTokenStore(fresh()), makeFetch([200], counts));
+
+    await client.createVoucher(VOUCHER);
+    const body = counts.lastBody as { Voucher: { VoucherRows: unknown } };
+    expect(Array.isArray(body.Voucher.VoucherRows)).toBe(true);
+    expect(body.Voucher.VoucherRows).toEqual(VOUCHER.VoucherRows);
   });
 
   it("utgången token → refreshar först och sparar den roterade token:en", async () => {


### PR DESCRIPTION
## Vad
`toWireVoucher` nästlade verifikatraderna som `VoucherRows: { VoucherRow: [...] }` (XML-style). Fortnox JSON-API:t (`POST /3/vouchers`) vill ha en **plain array** — den gamla formen gav `400 Felaktig datastruktur` (code 2002381).

## Hur verifierat
End-to-end mot Fortnox **sandbox tenant 1838388** under den manuella OAuth-anslutningen:
- nested `{ VoucherRow: [...] }` → **400**
- plain array `VoucherRows: [ … ]` (Account/Debit/Credit som tal) → **201 Created** ✅ (verifikat serie A nr 1)

Koden levererades med en kommentar som erkände att nestingen var overifierad; nu verifierad och fixad. Regressionstest pinnar POST-bodyn till en array.

## Test
- `bun run quality:fast` ✓ (typecheck + lint + 2444 unit)
- `bun run test:all --no-e2e` ✓ (static analysis + 2549 tester + coverage-golv 83.09%/79.85%)

Closes #214
Refs #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)