### PR TITLE
feat(fortnox): bokför fakturor som verifikat via server-runtime peer-job (#82)

### DIFF
--- a/src/bin/server-runtime.ts
+++ b/src/bin/server-runtime.ts
@@ -17,6 +17,7 @@
 
 import { ENV_KEYS, loadRuntimeConfig } from "@/lib/server/local-first/server-runtime-config";
 import { startServerRuntime } from "@/lib/server/local-first/server-runtime";
+import { buildFortnoxJob } from "@/lib/server/integrations/fortnox/runtime";
 
 const HELP = `ava server-runtime (ADR 0005 fas 1)
 
@@ -53,7 +54,10 @@ async function main(): Promise<void> {
   }
 
   const config = loadRuntimeConfig();
-  const loop = await startServerRuntime(config);
+  // Fortnox-connector (#82): aktiveras bara när byrån anslutit Fortnox (valv +
+  // tokens). Annars null → loopen kör i sync-läge precis som förut.
+  const job = await buildFortnoxJob({ workDir: config.workDir });
+  const loop = await startServerRuntime(config, job ? { job } : {});
 
   if (argv.includes("--once")) {
     await loop.tickOnce();

--- a/src/lib/server/integrations/fortnox/invoice-job.ts
+++ b/src/lib/server/integrations/fortnox/invoice-job.ts
@@ -1,0 +1,141 @@
+/**
+ * Fortnox-connectorns peer-job (#82, ADR 0005 fas 2).
+ *
+ * Kör som en `PeerAct` i server-runtime:ns konflikt-säkra pull→act→push-cykel:
+ * varje tick listas fakturorna i git-db:n, de som ännu inte bokförts
+ * (`fortnoxId` saknas) byggs till balanserade verifikat och pushas till
+ * Fortnox Voucher API; vid lyckad push skrivs `fortnoxId` tillbaka på raden.
+ *
+ * IDEMPOTENT (ADR 0005-invarianten): bokningskandidaten är "saknar fortnoxId".
+ * Så fort ett verifikat skapats märks fakturan (`markFortnoxBooked`), och en
+ * omkörd cykel hoppar över den → ingen dubbelbokföring. Konto-mappningen läses
+ * ur firma.git (#217); saknas den vägrar connectorn boka (completeness-gate).
+ */
+
+import { DEFAULT_VAT_RATE, type VatRate } from "@/lib/shared/vat";
+import type { InvoiceStatus } from "@/lib/shared/schemas/enums";
+import type { PeerJob } from "../../local-first/peer-loop";
+import type { FortnoxClient } from "./client";
+import type { FortnoxKontoMappning } from "./schema";
+import { buildVoucherFromInvoice, type InvoiceForVoucher } from "./voucher";
+
+/** Endast verifikat på UTFÄRDADE fakturor; DRAFT/CANCELLED/BAD_DEBT bokförs ej här. */
+export const DEFAULT_BOOKABLE_STATUSES: readonly InvoiceStatus[] = ["SENT", "PAID", "INSTALLMENT_PLAN"];
+
+/** Den delmängd av en faktura-rad connectorn behöver. */
+export interface BookableInvoice extends InvoiceForVoucher {
+  id: string;
+  status: InvoiceStatus;
+  fortnoxId?: string | null;
+}
+
+/** Den delmängd av tRPC-callern connectorn använder (resten av grafen ignoreras). */
+export interface FortnoxJobCaller {
+  invoice: {
+    list: (input: Record<string, never>) => Promise<BookableInvoice[]>;
+    markFortnoxBooked: (input: { invoiceId: string; fortnoxId: string }) => Promise<unknown>;
+  };
+}
+
+export interface FortnoxInvoiceJobDeps {
+  client: Pick<FortnoxClient, "createVoucher">;
+  /** Läs konto-mappningen ur firma.git (#217). null = ej konfigurerad → boka inget. */
+  loadMapping: () => Promise<FortnoxKontoMappning | null>;
+  vatRate?: VatRate;
+  bookableStatuses?: readonly InvoiceStatus[];
+  log?: (msg: string) => void;
+}
+
+export interface BookResult {
+  booked: number;
+  failed: number;
+  skipped: number;
+}
+
+function isPending(inv: BookableInvoice, bookable: ReadonlySet<InvoiceStatus>): boolean {
+  return !inv.fortnoxId && bookable.has(inv.status);
+}
+
+/** Bygg + pusha ETT verifikat och märk fakturan bokförd. */
+async function bookOne(
+  caller: FortnoxJobCaller,
+  client: Pick<FortnoxClient, "createVoucher">,
+  inv: BookableInvoice,
+  mapping: FortnoxKontoMappning,
+  vatRate: VatRate,
+): Promise<void> {
+  const voucher = buildVoucherFromInvoice(inv, mapping, vatRate);
+  const resp = await client.createVoucher(voucher);
+  const fortnoxId = `${resp.Voucher.VoucherSeries}/${resp.Voucher.VoucherNumber}`;
+  await caller.invoice.markFortnoxBooked({ invoiceId: inv.id, fortnoxId });
+}
+
+interface BookContext {
+  caller: FortnoxJobCaller;
+  client: Pick<FortnoxClient, "createVoucher">;
+  mapping: FortnoxKontoMappning;
+  vatRate: VatRate;
+  log: (msg: string) => void;
+}
+
+/** Bokför varje kandidat; ett fel stoppar inte resten (loggas + räknas). */
+async function bookEach(
+  pending: readonly BookableInvoice[],
+  ctx: BookContext,
+): Promise<{ booked: number; failed: number }> {
+  let booked = 0;
+  let failed = 0;
+  for (const inv of pending) {
+    try {
+      await bookOne(ctx.caller, ctx.client, inv, ctx.mapping, ctx.vatRate);
+      booked += 1;
+    } catch (err) {
+      failed += 1;
+      ctx.log(`Fortnox: kunde inte boka faktura ${inv.id}: ${String(err)}`);
+    }
+  }
+  return { booked, failed };
+}
+
+/**
+ * Bokför alla ännu obokförda, utfärdade fakturor. Idempotent: kandidaten är
+ * "saknar fortnoxId", och varje lyckad push märks direkt (`markFortnoxBooked`).
+ */
+export async function bookUnsyncedInvoices(
+  caller: FortnoxJobCaller,
+  deps: FortnoxInvoiceJobDeps,
+): Promise<BookResult> {
+  const log = deps.log ?? (() => {});
+  const mapping = await deps.loadMapping();
+  if (!mapping) {
+    log("Fortnox: ingen konto-mappning (settings/fortnox-account-map.json) — hoppar över");
+    return { booked: 0, failed: 0, skipped: 0 };
+  }
+
+  const bookable = new Set<InvoiceStatus>(deps.bookableStatuses ?? DEFAULT_BOOKABLE_STATUSES);
+  const invoices = await caller.invoice.list({});
+  const pending = invoices.filter((inv) => isPending(inv, bookable));
+  const { booked, failed } = await bookEach(pending, {
+    caller,
+    client: deps.client,
+    mapping,
+    vatRate: deps.vatRate ?? DEFAULT_VAT_RATE,
+    log,
+  });
+
+  const skipped = invoices.length - pending.length;
+  if (booked || failed) log(`Fortnox: bokförde ${booked} verifikat (${failed} fel, ${skipped} hoppade)`);
+  return { booked, failed, skipped };
+}
+
+/** Paketera connectorn som ett `PeerJob` för server-runtime:ns peer-loop. */
+export function makeFortnoxInvoiceJob(deps: FortnoxInvoiceJobDeps): PeerJob {
+  return {
+    message: "chore(fortnox): bokför nya fakturor som verifikat",
+    act: async (caller) => {
+      // PeerAct ger hela tRPC-callern; connectorn använder bara en strukturell
+      // delmängd (invoice.list + markFortnoxBooked) — isolerad cast i gränsen.
+      await bookUnsyncedInvoices(caller as unknown as FortnoxJobCaller, deps);
+    },
+  };
+}

--- a/src/lib/server/integrations/fortnox/runtime.ts
+++ b/src/lib/server/integrations/fortnox/runtime.ts
@@ -1,0 +1,105 @@
+/**
+ * Fortnox-connectorns boot-wiring för server-runtime:n (#82).
+ *
+ * Bygger ett `PeerJob` ur:
+ *   - secrets-valvet (#79): client_id/secret + de roterande OAuth-tokens,
+ *   - firma.git: konto-mappningen (`settings/fortnox-account-map.json`, #217).
+ *
+ * Returnerar `null` (→ loopen stannar i sync-läge) när Fortnox inte är
+ * konfigurerat: inget valv, inga credentials, eller inte auktoriserad än.
+ * Det gör inkopplingen RISKFRI för demo/test/CI — connectorn aktiveras först
+ * när en byrå faktiskt anslutit Fortnox.
+ */
+
+import { join } from "node:path";
+
+import { createVaultFromEnv, type SecretsVault } from "../../secrets/vault";
+import type { PeerJob } from "../../local-first/peer-loop";
+import { FortnoxClient } from "./client";
+import { makeFortnoxInvoiceJob } from "./invoice-job";
+import {
+  fortnoxConfigSchema,
+  fortnoxKontoMappningSchema,
+  type FortnoxConfig,
+  type FortnoxKontoMappning,
+} from "./schema";
+import { VaultFortnoxTokenStore } from "./token-store";
+
+/** Sökväg (relativt working-copy:n) till byråns konto-mappning. */
+export const KONTO_MAPPNING_PATH = "settings/fortnox-account-map.json";
+
+export interface BuildFortnoxJobOpts {
+  /** Server-runtime:ns working-copy (firma.git-klonen). */
+  workDir: string;
+  env?: NodeJS.ProcessEnv;
+  log?: (msg: string) => void;
+}
+
+/** Läs + strikt-parsa konto-mappningen ur firma.git. null om filen saknas. */
+export async function loadKontoMappning(workDir: string): Promise<FortnoxKontoMappning | null> {
+  const { readFile } = await import("node:fs/promises");
+  let raw: string;
+  try {
+    raw = await readFile(join(workDir, KONTO_MAPPNING_PATH), "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+  return fortnoxKontoMappningSchema.parse(JSON.parse(raw));
+}
+
+/** Bygg FortnoxConfig ur env + valv-credentials (overridebar bas-URL för sandbox). */
+function fortnoxConfigFromEnv(
+  env: NodeJS.ProcessEnv,
+  clientId: string,
+  clientSecret: string,
+): FortnoxConfig {
+  return fortnoxConfigSchema.parse({
+    clientId,
+    clientSecret,
+    // redirectUri/scopes används bara vid authorize; refresh kräver dem ej,
+    // men schemat kräver giltiga värden.
+    redirectUri: env.AVA_FORTNOX_REDIRECT_URI ?? "http://localhost/fortnox/callback",
+    scopes: ["bookkeeping"],
+    ...(env.AVA_FORTNOX_AUTH_BASE ? { authBase: env.AVA_FORTNOX_AUTH_BASE } : {}),
+    ...(env.AVA_FORTNOX_API_BASE ? { apiBase: env.AVA_FORTNOX_API_BASE } : {}),
+  });
+}
+
+/** Hämta valvet om det är konfigurerat (env satt), annars null. */
+function vaultIfConfigured(env: NodeJS.ProcessEnv): SecretsVault | null {
+  if (!env.AVA_SECRETS_KEY || !env.AVA_SECRETS_FILE) return null;
+  return createVaultFromEnv(env);
+}
+
+export async function buildFortnoxJob(opts: BuildFortnoxJobOpts): Promise<PeerJob | null> {
+  const env = opts.env ?? process.env;
+  const log = opts.log ?? ((msg: string) => console.log(`[fortnox] ${msg}`));
+
+  const vault = vaultIfConfigured(env);
+  if (!vault) {
+    log("valv ej konfigurerat (AVA_SECRETS_KEY/FILE saknas) — connector av");
+    return null;
+  }
+
+  const clientId = await vault.get("fortnox.client_id");
+  const clientSecret = await vault.get("fortnox.client_secret");
+  if (!clientId || !clientSecret) {
+    log("inga Fortnox-credentials i valvet — connector av");
+    return null;
+  }
+
+  const store = new VaultFortnoxTokenStore(vault);
+  if (!(await store.load())) {
+    log("Fortnox ej auktoriserad (inga tokens i valvet) — connector av");
+    return null;
+  }
+
+  const client = new FortnoxClient(fortnoxConfigFromEnv(env, clientId, clientSecret), store);
+  log("connector aktiv — bokför nya fakturor som verifikat");
+  return makeFortnoxInvoiceJob({
+    client,
+    loadMapping: () => loadKontoMappning(opts.workDir),
+    log,
+  });
+}

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -608,4 +608,27 @@ export const invoiceRouter = router({
         data: { status: input.status },
       });
     }),
+
+  /**
+   * Märk en faktura som bokförd i Fortnox (#82). Anropas av server-runtime:ns
+   * Fortnox-connector efter en lyckad verifikat-push; `fortnoxId` =
+   * "<VoucherSeries>/<VoucherNumber>".
+   *
+   * IDEMPOTENT: skriver ALDRIG över en redan satt `fortnoxId` — det är
+   * dubbelbokförings-skyddet (en omkörd peer-cykel får inte boka om). Redan
+   * märkt → returnera oförändrad rad.
+   */
+  markFortnoxBooked: orgProcedure
+    .input(z.object({ invoiceId: invoiceIdSchema, fortnoxId: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const inv = await ctx.dataStore.invoices.findFirst({
+        where: { id: input.invoiceId, matter: { organizationId: ctx.orgId } },
+      });
+      if (!inv) throw new TRPCError({ code: "NOT_FOUND" });
+      if (inv.fortnoxId) return inv; // redan bokförd → no-op (idempotens)
+      return ctx.dataStore.invoices.update({
+        where: { id: inv.id },
+        data: { fortnoxId: input.fortnoxId },
+      });
+    }),
 });

--- a/test/unit/server/integrations/fortnox/invoice-job.test.ts
+++ b/test/unit/server/integrations/fortnox/invoice-job.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest-compat";
+import {
+  bookUnsyncedInvoices,
+  makeFortnoxInvoiceJob,
+  type BookableInvoice,
+  type FortnoxJobCaller,
+} from "@/lib/server/integrations/fortnox/invoice-job";
+import type { FortnoxClient } from "@/lib/server/integrations/fortnox/client";
+import type { FortnoxKontoMappning, FortnoxVoucher, FortnoxVoucherResponse } from "@/lib/server/integrations/fortnox/schema";
+
+const MAPPING: FortnoxKontoMappning = {
+  voucherSeries: "A",
+  kundfordran: "1510",
+  intaktArvode: "3000",
+  momsUtgaende: "2611",
+};
+
+function inv(over: Partial<BookableInvoice> = {}): BookableInvoice {
+  return {
+    id: "inv-1",
+    status: "SENT",
+    amount: 1_250_000, // 12 500 kr brutto (öre)
+    invoiceDate: "2026-06-11",
+    invoiceNumber: "F-1",
+    fortnoxId: null,
+    ...over,
+  };
+}
+
+function makeCaller(invoices: BookableInvoice[]) {
+  const booked: { invoiceId: string; fortnoxId: string }[] = [];
+  const caller: FortnoxJobCaller = {
+    invoice: {
+      list: async () => invoices,
+      markFortnoxBooked: async (input) => {
+        booked.push(input);
+        return {};
+      },
+    },
+  };
+  return { caller, booked };
+}
+
+function makeClient(failMatch?: (v: FortnoxVoucher) => boolean) {
+  const calls: FortnoxVoucher[] = [];
+  let n = 0;
+  const client: Pick<FortnoxClient, "createVoucher"> = {
+    createVoucher: async (v: FortnoxVoucher): Promise<FortnoxVoucherResponse> => {
+      calls.push(v);
+      if (failMatch?.(v)) throw new Error("boom");
+      n += 1;
+      return { Voucher: { VoucherSeries: v.VoucherSeries, VoucherNumber: n } };
+    },
+  };
+  return { client, calls };
+}
+
+const mapping = (m: FortnoxKontoMappning | null) => async () => m;
+
+describe("bookUnsyncedInvoices", () => {
+  it("bokför obokförda utfärdade fakturor + skriver tillbaka fortnoxId", async () => {
+    const { caller, booked } = makeCaller([inv({ id: "a" }), inv({ id: "b" })]);
+    const { client, calls } = makeClient();
+
+    const res = await bookUnsyncedInvoices(caller, { client, loadMapping: mapping(MAPPING) });
+
+    expect(res).toEqual({ booked: 2, failed: 0, skipped: 0 });
+    expect(calls).toHaveLength(2);
+    expect(booked).toEqual([
+      { invoiceId: "a", fortnoxId: "A/1" },
+      { invoiceId: "b", fortnoxId: "A/2" },
+    ]);
+  });
+
+  it("hoppar över redan bokförda (fortnoxId satt)", async () => {
+    const { caller, booked } = makeCaller([inv({ id: "a", fortnoxId: "A/9" }), inv({ id: "b" })]);
+    const { client } = makeClient();
+
+    const res = await bookUnsyncedInvoices(caller, { client, loadMapping: mapping(MAPPING) });
+
+    expect(res).toEqual({ booked: 1, failed: 0, skipped: 1 });
+    expect(booked).toEqual([{ invoiceId: "b", fortnoxId: "A/1" }]);
+  });
+
+  it("hoppar över ej bokningsbara statusar (DRAFT/CANCELLED)", async () => {
+    const { caller, booked } = makeCaller([
+      inv({ id: "a", status: "DRAFT" }),
+      inv({ id: "b", status: "CANCELLED" }),
+      inv({ id: "c", status: "PAID" }),
+    ]);
+    const { client } = makeClient();
+
+    const res = await bookUnsyncedInvoices(caller, { client, loadMapping: mapping(MAPPING) });
+
+    expect(res).toEqual({ booked: 1, failed: 0, skipped: 2 });
+    expect(booked).toEqual([{ invoiceId: "c", fortnoxId: "A/1" }]);
+  });
+
+  it("ingen konto-mappning → bokför inget (completeness-gate)", async () => {
+    const { caller, booked } = makeCaller([inv()]);
+    const { client, calls } = makeClient();
+
+    const res = await bookUnsyncedInvoices(caller, { client, loadMapping: mapping(null) });
+
+    expect(res).toEqual({ booked: 0, failed: 0, skipped: 0 });
+    expect(calls).toHaveLength(0);
+    expect(booked).toHaveLength(0);
+  });
+
+  it("ett fel stoppar inte resten (räknas som failed, ingen markering)", async () => {
+    const { caller, booked } = makeCaller([inv({ id: "a", invoiceNumber: "F-A" }), inv({ id: "b", invoiceNumber: "F-B" })]);
+    const { client } = makeClient((v) => v.Description.includes("F-A"));
+
+    const res = await bookUnsyncedInvoices(caller, { client, loadMapping: mapping(MAPPING) });
+
+    expect(res).toEqual({ booked: 1, failed: 1, skipped: 0 });
+    expect(booked).toEqual([{ invoiceId: "b", fortnoxId: "A/1" }]); // bara den lyckade
+  });
+
+  it("bygger ett balanserat verifikat (debet kundfordran = brutto)", async () => {
+    const { caller } = makeCaller([inv()]);
+    const { client, calls } = makeClient();
+
+    await bookUnsyncedInvoices(caller, { client, loadMapping: mapping(MAPPING) });
+
+    const rows = calls[0]!.VoucherRows;
+    const debit = rows.reduce((s, r) => s + r.Debit, 0);
+    const credit = rows.reduce((s, r) => s + r.Credit, 0);
+    expect(debit).toBeCloseTo(credit); // balans
+    const kundfordran = rows.find((r) => r.Account === 1510)!;
+    expect(kundfordran.Debit).toBeCloseTo(12_500); // brutto i SEK
+  });
+});
+
+describe("makeFortnoxInvoiceJob", () => {
+  it("returnerar ett PeerJob vars act bokför via callern", async () => {
+    const { caller, booked } = makeCaller([inv({ id: "a" })]);
+    const { client } = makeClient();
+    const job = makeFortnoxInvoiceJob({ client, loadMapping: mapping(MAPPING) });
+
+    expect(job.message).toMatch(/fortnox/i);
+    // act tar hela tRPC-callern; vi skickar vår delmängd (samma cast som i wrappern).
+    await job.act(caller as unknown as Parameters<typeof job.act>[0]);
+
+    expect(booked).toEqual([{ invoiceId: "a", fortnoxId: "A/1" }]);
+  });
+});

--- a/test/unit/server/integrations/fortnox/runtime.test.ts
+++ b/test/unit/server/integrations/fortnox/runtime.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest-compat";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+import {
+  buildFortnoxJob,
+  loadKontoMappning,
+  KONTO_MAPPNING_PATH,
+} from "@/lib/server/integrations/fortnox/runtime";
+import { createVaultFromEnv } from "@/lib/server/secrets/vault";
+import { VaultFortnoxTokenStore } from "@/lib/server/integrations/fortnox/token-store";
+import type { FortnoxKontoMappning } from "@/lib/server/integrations/fortnox/schema";
+
+const MAPPING: FortnoxKontoMappning = {
+  voucherSeries: "A",
+  kundfordran: "1510",
+  intaktArvode: "3000",
+  momsUtgaende: "2611",
+};
+
+let dir: string;
+const silent = () => {};
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "fortnox-rt-"));
+});
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+/** Env med en färsk (tom) valv-fil i temp-katalogen. */
+function vaultEnv(): NodeJS.ProcessEnv {
+  return {
+    AVA_SECRETS_KEY: randomBytes(32).toString("base64"),
+    AVA_SECRETS_FILE: join(dir, "vault.enc"),
+  } as NodeJS.ProcessEnv;
+}
+
+async function writeMapping(value: unknown): Promise<void> {
+  await mkdir(join(dir, "settings"), { recursive: true });
+  await writeFile(join(dir, KONTO_MAPPNING_PATH), JSON.stringify(value), "utf8");
+}
+
+describe("loadKontoMappning", () => {
+  it("läser + strikt-parsar mappningen ur firma.git", async () => {
+    await writeMapping(MAPPING);
+    expect(await loadKontoMappning(dir)).toEqual(MAPPING);
+  });
+
+  it("saknad fil → null", async () => {
+    expect(await loadKontoMappning(dir)).toBeNull();
+  });
+
+  it("ogiltig mappning → kastar (strikt parsning)", async () => {
+    await writeMapping({ voucherSeries: "A" }); // saknar obligatoriska konton
+    await expect(loadKontoMappning(dir)).rejects.toThrow();
+  });
+});
+
+describe("buildFortnoxJob", () => {
+  it("valv ej konfigurerat (env saknas) → null", async () => {
+    expect(await buildFortnoxJob({ workDir: dir, env: {}, log: silent })).toBeNull();
+  });
+
+  it("valv men inga credentials → null", async () => {
+    const job = await buildFortnoxJob({ workDir: dir, env: vaultEnv(), log: silent });
+    expect(job).toBeNull();
+  });
+
+  it("credentials men inga tokens (ej auktoriserad) → null", async () => {
+    const env = vaultEnv();
+    const vault = createVaultFromEnv(env);
+    await vault.set("fortnox.client_id", "cid");
+    await vault.set("fortnox.client_secret", "secret");
+
+    const job = await buildFortnoxJob({ workDir: dir, env, log: silent });
+    expect(job).toBeNull();
+  });
+
+  it("fullt konfigurerat (creds + tokens) → returnerar ett PeerJob", async () => {
+    const env = vaultEnv();
+    const vault = createVaultFromEnv(env);
+    await vault.set("fortnox.client_id", "cid");
+    await vault.set("fortnox.client_secret", "secret");
+    await new VaultFortnoxTokenStore(vault).save({
+      accessToken: "at",
+      refreshToken: "rt",
+      accessTokenExpiresAt: Date.now() + 600_000,
+    });
+
+    const job = await buildFortnoxJob({ workDir: dir, env, log: silent });
+    expect(job).not.toBeNull();
+    expect(job?.message).toMatch(/fortnox/i);
+    expect(typeof job?.act).toBe("function");
+  });
+});

--- a/test/unit/server/routers/invoice.test.ts
+++ b/test/unit/server/routers/invoice.test.ts
@@ -566,6 +566,46 @@ describe("invoice.setStatus", () => {
   });
 });
 
+// ─── markFortnoxBooked (#82) ─────────────────────────────────────
+
+describe("invoice.markFortnoxBooked", () => {
+  it("sätter fortnoxId på obokförd faktura", async () => {
+    mockPrisma.invoice.findFirst.mockResolvedValue({ id: "inv-1", fortnoxId: null });
+    mockPrisma.invoice.update.mockResolvedValue({ id: "inv-1", fortnoxId: "A/1" });
+
+    const res = await makeCaller().markFortnoxBooked({ invoiceId: "inv-1", fortnoxId: "A/1" });
+
+    expect(res.fortnoxId).toBe("A/1");
+    expect(mockPrisma.invoice.update).toHaveBeenCalledWith({
+      where: { id: "inv-1" },
+      data: { fortnoxId: "A/1" },
+    });
+  });
+
+  it("idempotent: skriver INTE över befintlig fortnoxId", async () => {
+    mockPrisma.invoice.findFirst.mockResolvedValue({ id: "inv-1", fortnoxId: "A/7" });
+
+    const res = await makeCaller().markFortnoxBooked({ invoiceId: "inv-1", fortnoxId: "A/99" });
+
+    expect(res.fortnoxId).toBe("A/7"); // oförändrad
+    expect(mockPrisma.invoice.update).not.toHaveBeenCalled();
+  });
+
+  it("NOT_FOUND cross-org", async () => {
+    mockPrisma.invoice.findFirst.mockResolvedValue(null);
+
+    await expect(
+      makeCaller("org-b").markFortnoxBooked({ invoiceId: "inv-1", fortnoxId: "A/1" }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("zod kräver icke-tom fortnoxId", async () => {
+    await expect(
+      makeCaller().markFortnoxBooked({ invoiceId: "inv-1", fortnoxId: "" }),
+    ).rejects.toThrow();
+  });
+});
+
 // ─── list / getById ──────────────────────────────────────────────
 
 describe("invoice.list", () => {


### PR DESCRIPTION
## Vad
Kopplar in Fortnox-connectorn som en `PeerAct` i server-runtime:ns konflikt-säkra pull→act→push-cykel (ADR 0005 fas 2). Detta är #82:s kärna.

### Bitar
- **`invoice.markFortnoxBooked`** — idempotent mutation som skriver tillbaka `fortnoxId`; skriver **aldrig** över ett befintligt värde (dubbelbokförings-skydd).
- **`invoice-job.ts`** — `bookUnsyncedInvoices()`: listar fakturor, filtrerar utfärdade (SENT/PAID/INSTALLMENT_PLAN) utan `fortnoxId`, bygger balanserat verifikat (`buildVoucherFromInvoice`), POST:ar via `FortnoxClient`, märker bokförd. Ett fel på en faktura stoppar inte resten.
- **`runtime.ts`** — `buildFortnoxJob()`: bygger jobbet ur secrets-valvet (#79, creds + roterande tokens) + konto-mappningen ur firma.git (`settings/fortnox-account-map.json`, #217). **Returnerar `null` när Fortnox inte är konfigurerat** → loopen kör i sync-läge precis som förut. Riskfritt för demo/test/CI — connectorn aktiveras först när en byrå anslutit.
- **`server-runtime.ts`** (entry) aktiverar connectorn vid start.

### Idempotens (ADR 0005-invarianten)
Kandidaten är "saknar `fortnoxId`" och varje lyckad push märks omedelbart. En omkörd peer-cykel (efter NonFastForward) hoppar därför över redan bokförda → ingen dubbelbokföring.

### Verifierat
- `bun run test:all --no-e2e` ✓ — static analysis (typecheck + lint/complexity + knip + deps + jscpd) + 2567 tester + coverage-golv (83.17% rader / 79.92% funktioner).
- Nya tester: connector-logiken (bokar/hoppar/fel-isolering/balanserat verifikat), boot-wiring-guards (null när ej konfigurerat), `loadKontoMappning` (läs/saknad/ogiltig), `markFortnoxBooked` (idempotens + cross-org).
- Voucher-wire-formatet är redan **sandbox-verifierat** (#215 — verifikat serie A nr 1 i tenant 1838388).

### Kvar (separata issues)
- #217 — konto-mappningen som redigerbar org-inställning (UI). Denna PR läser filen; #217 skapar den i /settings.
- Live end-to-end mot en körande server-runtime + sandbox (operationell validering).

Closes #82
Refs #79, #215, #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)