### PR TITLE
feat(server): dockerisera server-runtime + git-auth (#81)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# Build-context-filter. Gäller ENDAST builds med context = repo-roten, dvs
+# server-runtime-imagen (#81). web/git-ssh/auth-server bygger från egna
+# under-kataloger och påverkas inte.
+#
+# Whitelist: imagen behöver bara den förbyggda binären + entrypoint:en, så vi
+# ignorerar allt och släpper bara in de två sökvägarna. Håller contexten på
+# några MB (istf. hela monorepo:t) och undviker att läcka källkod/hemligheter.
+*
+!dist
+dist/*
+!dist/server-runtime
+# imagen kör bara linux — darwin-binärerna behövs ej i contexten.
+dist/server-runtime/*darwin*
+!tooling
+tooling/*
+!tooling/docker
+tooling/docker/*
+!tooling/docker/server-runtime

--- a/docs/server-runtime-deploy.md
+++ b/docs/server-runtime-deploy.md
@@ -1,0 +1,71 @@
+# Server-runtime — drift & auth (#81, ADR 0005)
+
+Server-runtime:n är en **git-peer**: den klonar `firma.git`, kör mutationer mot
+sin egen working-copy och pushar tillbaka (konflikt-säkert, ADR 0002/0005). Den
+är **valbar** — bara byråer som vill ha server-drivna integrationer (Fortnox
+#82, påminnelser) kör den. En ensam jurist utan integrationer kör helt utan
+server, precis som förut (USP: din data, ingen tredjepartsinfra).
+
+## Paketering
+
+En tunn docker-image (`debian-slim` + `git` + den förbyggda standalone-binären):
+
+```bash
+bun run server-runtime:build        # → dist/server-runtime/ava-server-runtime-linux-{x64,arm64}
+docker build -f tooling/docker/server-runtime/Dockerfile -t ava-server-runtime .
+```
+
+Binären byggs utanför imagen (samma artefakt som release-pipelinen #87
+publicerar) så vi slipper en tung monorepo-`bun install` i docker. Entrypoint:en
+väljer rätt arkitektur via `uname -m`.
+
+## Köra i stacken
+
+Tjänsten ligger i `tooling/docker/docker-compose.yml` bakom profilen `server`
+(default av):
+
+```bash
+AVA_SR_ORG_ID=<org-id> \
+AVA_SR_GIT_USER=<htpasswd-användare> AVA_SR_GIT_TOKEN=<PAT> \
+  docker compose -f tooling/docker/docker-compose.yml --profile server up -d --build
+```
+
+## Auth mot firma.git
+
+Git-creds tas vid körning (aldrig inbakade i imagen). Två vägar:
+
+| Metod | Env | Användning |
+|-------|-----|------------|
+| **HTTP-basic** | `AVA_SR_GIT_USER` + `AVA_SR_GIT_TOKEN` | htpasswd-användare/PAT mot nginx `/git/` (samma som browser-push). Default-URL `http://web/git/firma.git` i det interna nätet. |
+| **SSH-deploy-key** | `AVA_SR_SSH_KEY_FILE` (monterad privat nyckel) | `ssh://`-remotes (lägg publika nyckeln i `git-ssh/authorized_keys`). |
+
+Entrypoint:en skriver en 600-skyddad `~/.git-credentials` (HTTP) resp. sätter
+`GIT_SSH_COMMAND` (SSH). `file://`-repos (lokal drift/röktest) behöver ingen auth.
+
+## Konfiguration (env)
+
+Obligatoriskt: `AVA_SR_REPO_URL`, `AVA_SR_WORK_DIR` (satt i imagen), `AVA_SR_ORG_ID`.
+Övrigt (`AVA_SR_BRANCH`, `AVA_SR_REMOTE`, `AVA_SR_POLL_INTERVAL_MS`,
+`AVA_SR_MAX_RETRIES`, `AVA_SR_PRINCIPAL_*`) har defaults — se
+`src/lib/server/local-first/server-runtime-config.ts` (`ENV_KEYS`).
+
+### Fortnox-connector (#82)
+
+Connectorn aktiveras när secrets-valvet (#79) är tillgängligt: sätt
+`AVA_SECRETS_KEY` + `AVA_SECRETS_FILE` och montera valv-filen i containern
+(se den utkommenterade volym-raden i compose). Saknas valv/tokens kör loopen i
+sync-läge (ingen bokföring) — riskfritt.
+
+## Röktest
+
+```bash
+bun run server-runtime:smoke
+```
+
+Bygger binär + image och kör containern `--once` mot ett lokalt bare-repo;
+verifierar att den klonar, tickar och avslutar 0. Kräver docker + bun + git.
+
+## Webhooks
+
+Skyddad webhook-endpoint (HTTPS + signaturverifiering) hör till v1.1 (#219) —
+server-runtime:n är poll-baserad idag och har ingen webhook-konsument.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "seed:local": "bun tooling/scripts/seed-firma-local.ts",
     "server-runtime": "bun src/bin/server-runtime.ts",
     "server-runtime:build": "bun tooling/scripts/build-server-runtime.ts",
+    "server-runtime:smoke": "bash tooling/scripts/smoke-server-runtime-docker.sh",
     "start": "next start",
     "tier3:up": "docker compose -f tooling/docker/docker-compose.yml up -d --build",
     "tier3:down": "docker compose -f tooling/docker/docker-compose.yml down",

--- a/tooling/docker/docker-compose.yml
+++ b/tooling/docker/docker-compose.yml
@@ -112,7 +112,11 @@ services:
     environment:
       AVA_SR_REPO_URL: ${AVA_SR_REPO_URL:-http://web/git/firma.git}
       AVA_SR_WORK_DIR: /var/lib/ava/firma
-      AVA_SR_ORG_ID: ${AVA_SR_ORG_ID:?sätt AVA_SR_ORG_ID (org-id för server-principalen)}
+      # Obligatorisk när profilen "server" är aktiv — men använd INTE ${VAR:?}
+      # här: compose interpolerar hela filen vid parse (oavsett profil), så :?
+      # skulle bryta `docker compose up` även för web/git-ssh. Saknat org-id
+      # fångas istället vid container-start av runtime:ns zod-validering.
+      AVA_SR_ORG_ID: ${AVA_SR_ORG_ID:-}
       AVA_SR_GIT_USER: ${AVA_SR_GIT_USER:-}
       AVA_SR_GIT_TOKEN: ${AVA_SR_GIT_TOKEN:-}
       AVA_SR_POLL_INTERVAL_MS: ${AVA_SR_POLL_INTERVAL_MS:-15000}

--- a/tooling/docker/docker-compose.yml
+++ b/tooling/docker/docker-compose.yml
@@ -89,9 +89,49 @@ services:
       - git_repos:/srv/git
       - ./git-ssh/authorized_keys:/keys/authorized_keys:ro
 
+  # ─── (Valbar) Server-runtime: git-peer för integrationer/påminnelser ──
+  # ADR 0005 fas 2. Default OFF — bara byråer som vill ha server-drivna
+  # integrationer (Fortnox #82, påminnelser) kör den; 1-mans utan
+  # integrationer kör utan denna tjänst precis som förut (USP: din data,
+  # ingen tredjepartsinfra).
+  #
+  # Aktivera:
+  #   bun run server-runtime:build      # förbygg linux-binären (dist/server-runtime/)
+  #   AVA_SR_ORG_ID=<org> AVA_SR_GIT_USER=<htpasswd-user> AVA_SR_GIT_TOKEN=<pat> \
+  #     docker compose -f tooling/docker/docker-compose.yml --profile server up -d --build
+  #
+  # Auth mot firma.git: HTTP-basic (htpasswd-användare/PAT, samma som browser-
+  # push). Pekar default på web-containerns /git/-endpoint i det interna nätet.
+  # Fortnox-connectorn (#82) aktiveras om secrets-valvet monteras (se nedan).
+  server-runtime:
+    profiles: ["server"]
+    build:
+      context: ../..
+      dockerfile: tooling/docker/server-runtime/Dockerfile
+    restart: unless-stopped
+    environment:
+      AVA_SR_REPO_URL: ${AVA_SR_REPO_URL:-http://web/git/firma.git}
+      AVA_SR_WORK_DIR: /var/lib/ava/firma
+      AVA_SR_ORG_ID: ${AVA_SR_ORG_ID:?sätt AVA_SR_ORG_ID (org-id för server-principalen)}
+      AVA_SR_GIT_USER: ${AVA_SR_GIT_USER:-}
+      AVA_SR_GIT_TOKEN: ${AVA_SR_GIT_TOKEN:-}
+      AVA_SR_POLL_INTERVAL_MS: ${AVA_SR_POLL_INTERVAL_MS:-15000}
+      # Fortnox-connector (#82/#79): aktiveras när valv-env + mount finns.
+      AVA_SECRETS_KEY: ${AVA_SECRETS_KEY:-}
+      AVA_SECRETS_FILE: ${AVA_SECRETS_FILE:-}
+    volumes:
+      - server_work:/var/lib/ava
+      # Montera byråns secrets-valv (utanför repo:t) för Fortnox-connectorn:
+      #   - ${AVA_SECRETS_HOST_FILE:-/dev/null}:/run/ava/vault.enc:ro
+    depends_on:
+      - web
+
 volumes:
   # Persistent storage för bare git-repos. Backup = `tar` på denna volym.
   git_repos:
   # Persistent storage för auth-state (htpasswd, invites). Delad mellan
   # auth-tjänsten (read/write) och web/nginx (read).
   auth_data:
+  # Server-runtime:ns egen working-copy (firma.git-klon). Engångs-/cache-data
+  # — kan raderas, klonas om vid nästa start.
+  server_work:

--- a/tooling/docker/server-runtime/Dockerfile
+++ b/tooling/docker/server-runtime/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1
+#
+# AVA server-runtime (#81, ADR 0005) — git-peer-tjänsten i byråns EGEN stack.
+#
+# Tunn runtime-image: debian-slim + git + ca-certificates + openssh-client och
+# den förbyggda standalone-binären. Binären byggs UTANFÖR imagen med
+#   bun run server-runtime:build      # → dist/server-runtime/ava-server-runtime-linux-*
+# (samma binär som release-pipelinen #87 publicerar). Så slipper vi köra en
+# tung monorepo-`bun install` i docker; imagen bär bara det den behöver.
+#
+# Bygg (från repo-roten, så dist/ ligger i build-contexten):
+#   docker build -f tooling/docker/server-runtime/Dockerfile -t ava-server-runtime .
+FROM debian:stable-slim
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git ca-certificates openssh-client \
+  && rm -rf /var/lib/apt/lists/*
+
+# Båda linux-arkitekturerna; entrypoint väljer rätt via `uname -m`.
+COPY dist/server-runtime/ava-server-runtime-linux-x64   /opt/ava/bin/ava-server-runtime-linux-x64
+COPY dist/server-runtime/ava-server-runtime-linux-arm64 /opt/ava/bin/ava-server-runtime-linux-arm64
+COPY tooling/docker/server-runtime/entrypoint.sh        /entrypoint.sh
+RUN chmod +x /opt/ava/bin/ava-server-runtime-linux-* /entrypoint.sh \
+  && mkdir -p /var/lib/ava
+
+# Working-copy:n (firma.git-klonen) ligger på en volym (se docker-compose.yml).
+ENV AVA_SR_WORK_DIR=/var/lib/ava/firma
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/tooling/docker/server-runtime/entrypoint.sh
+++ b/tooling/docker/server-runtime/entrypoint.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Entrypoint för server-runtime-containern (#81, ADR 0005).
+#
+#   1. Välj rätt binär för arkitekturen (multi-arch image).
+#   2. Sätt git-identitet (commit-författare) + safe.directory.
+#   3. Konfigurera git-auth mot firma.git ur env:
+#        - HTTP-basic:  AVA_SR_GIT_USER + AVA_SR_GIT_TOKEN (htpasswd-användare/PAT)
+#        - SSH:         AVA_SR_SSH_KEY_FILE (monterad privat deploy-key)
+#      file://-repos (lokal drift/röktest) behöver ingen auth.
+#   4. Exec:a binären och vidarebefordra argv (t.ex. --once).
+#
+# Inga hemligheter bakas in i imagen — de injiceras vid körning (env/mount).
+set -euo pipefail
+
+export HOME=/root
+
+# ── 1. Arkitektur → binär ───────────────────────────────────────────────
+case "$(uname -m)" in
+  x86_64)  BIN=/opt/ava/bin/ava-server-runtime-linux-x64 ;;
+  aarch64) BIN=/opt/ava/bin/ava-server-runtime-linux-arm64 ;;
+  *) echo "[server-runtime] okänd arkitektur: $(uname -m)" >&2; exit 1 ;;
+esac
+
+# ── 2. Git-identitet + dubious-ownership-guard ──────────────────────────
+git config --global --add safe.directory '*'
+git config --global user.name  "${AVA_SR_PRINCIPAL_NAME:-AVA Server-runtime}"
+git config --global user.email "${AVA_SR_PRINCIPAL_EMAIL:-server-runtime@ava.local}"
+
+# ── 3. Git-auth ─────────────────────────────────────────────────────────
+# HTTP-basic mot nginx /git/ (htpasswd). Creds-filen skyddas 600 (umask 077).
+if [[ -n "${AVA_SR_GIT_USER:-}" && -n "${AVA_SR_GIT_TOKEN:-}" ]]; then
+  url="${AVA_SR_REPO_URL:?AVA_SR_REPO_URL saknas (krävs för HTTP-basic-auth)}"
+  scheme="$(printf '%s' "$url" | sed -E 's#^(https?)://.*#\1#')"
+  host="$(printf '%s' "$url" | sed -E 's#^https?://([^/]+)/.*#\1#')"
+  git config --global credential.helper store
+  ( umask 077; printf '%s://%s:%s@%s\n' "$scheme" "$AVA_SR_GIT_USER" "$AVA_SR_GIT_TOKEN" "$host" > "$HOME/.git-credentials" )
+  echo "[server-runtime] git-auth: HTTP-basic som '$AVA_SR_GIT_USER' mot $host"
+fi
+
+# SSH-deploy-key (alternativ till HTTP-basic; ssh://-remotes).
+if [[ -n "${AVA_SR_SSH_KEY_FILE:-}" ]]; then
+  mkdir -p "$HOME/.ssh"; chmod 700 "$HOME/.ssh"
+  export GIT_SSH_COMMAND="ssh -i ${AVA_SR_SSH_KEY_FILE} -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=${HOME}/.ssh/known_hosts"
+  echo "[server-runtime] git-auth: SSH-deploy-key ${AVA_SR_SSH_KEY_FILE}"
+fi
+
+# ── 4. Kör ──────────────────────────────────────────────────────────────
+echo "[server-runtime] startar: $BIN $*"
+exec "$BIN" "$@"

--- a/tooling/scripts/smoke-server-runtime-docker.sh
+++ b/tooling/scripts/smoke-server-runtime-docker.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Röktest för server-runtime-containern (#81).
+#
+# Bygger linux-binärerna + docker-imagen och kör containern `--once` mot ett
+# lokalt bare-repo (file://, ingen auth). Verifierar att containern:
+#   - startar och väljer rätt binär,
+#   - klonar firma.git till sin working-copy,
+#   - kör en sync-tick och avslutar 0.
+#
+# Detta täcker deploy-paketeringen (#81) utan att kräva hela compose-stacken.
+# Kräver: docker + bun + git.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+IMAGE="ava-server-runtime:smoke"
+
+echo "==> [1/3] Bygger linux-binärer (server-runtime:build)…"
+bun run server-runtime:build
+
+echo "==> [2/3] Bygger docker-image ${IMAGE} …"
+docker build -f tooling/docker/server-runtime/Dockerfile -t "$IMAGE" .
+
+echo "==> [3/3] Kör containern --once mot ett lokalt bare-repo…"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+BARE="$WORK/firma.git"
+SEED="$WORK/seed"
+git init --bare -b main "$BARE" >/dev/null
+git clone -q "$BARE" "$SEED"
+git -C "$SEED" -c user.email=smoke@ava.local -c user.name=smoke commit -q --allow-empty -m "seed"
+git -C "$SEED" push -q origin main
+
+OUT="$(docker run --rm \
+  -e AVA_SR_REPO_URL="file:///bare/firma.git" \
+  -e AVA_SR_ORG_ID="smoke-org" \
+  -v "$BARE":/bare/firma.git:ro \
+  "$IMAGE" --once 2>&1)"
+echo "----- container-logg -----"
+echo "$OUT"
+echo "--------------------------"
+
+echo "$OUT" | grep -q "klonar" || { echo "❌ FEL: containern klonade inte firma.git"; exit 1; }
+echo "✅ server-runtime-container röktest OK (byggd, klonade, tickade, avslutade 0)"


### PR DESCRIPTION
## Vad
Sista v1.0-biten (#81, ADR 0005 fas 2): paketerar git-peer-servern för drift i byråns **egen** stack. Re-scope:at till **deploy + git-auth**; webhook-skydd flyttat till #219 (v1.1) eftersom server-runtime:n är poll-baserad och saknar webhook-konsument (Fortnox-connectorn #82 pollar).

### Bitar
- **`tooling/docker/server-runtime/Dockerfile`** — tunn `debian-slim` + `git` + den förbyggda standalone-binären (`bun run server-runtime:build`, samma artefakt som release-pipelinen #87). Entrypoint väljer arkitektur via `uname -m` (multi-arch).
- **`entrypoint.sh`** — git-auth ur env: **HTTP-basic** (`AVA_SR_GIT_USER`/`AVA_SR_GIT_TOKEN` mot nginx `/git/`, samma som browser-push) eller **SSH-deploy-key** (`AVA_SR_SSH_KEY_FILE`). Sätter git-identitet + `safe.directory`. Inga hemligheter bakas in.
- **`docker-compose.yml`** — valbar tjänst bakom profilen **`server`** (default av; 1-mans utan integrationer kör utan server som förut). Default-remote = web-containerns `/git/`. Fortnox-connectorn (#82) aktiveras när secrets-valvet monteras.
- **`smoke-server-runtime-docker.sh`** (+ `server-runtime:smoke`) — bygger binär + image och kör containern `--once` mot ett bare-repo.
- **`docs/server-runtime-deploy.md`** — drift, auth, env, röktest.
- **`.dockerignore`** — whitelist (bara binär + entrypoint i contexten).

### Verifierat
- **Docker-röktest grönt** (`bun run server-runtime:smoke`): containern bygger, väljer arm64-binären, klonar `firma.git`, startar peer-loopen i sync-läge, avslutar 0. Fortnox-connectorn korrekt **av** utan valv (riskfri default).
- `bun run quality:fast` ✓ (ingen TS ändrad; 2462 tester gröna).

### Stänger 1.0
Detta är den sista öppna issuen i milstolpen **v1.0 — Produktionsklar kärna** (övriga 7 stängda).

Closes #81
Refs #82, #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)