### PR TITLE
feat(auth): mappa OIDC-claims → principal mot användar-allowlist (#223)

### DIFF
--- a/src/lib/server/auth/oidc-auth-provider.ts
+++ b/src/lib/server/auth/oidc-auth-provider.ts
@@ -1,0 +1,81 @@
+/**
+ * `OidcAuthProvider` — `AuthProvider` som mappar OIDC-claims → `Principal`
+ * mot användar-allowlisten i firma.git (#223, ADR 0009).
+ *
+ * AVA är en OIDC *relying party*: en extern IdP (Entra ID/Google/BankID-broker)
+ * autentiserar användaren; `oauth2-proxy` (#222) injicerar claims (email/sub/iss).
+ * Denna provider *auktoriserar* genom att slå upp claims mot allowlisten —
+ * **de existerande User-raderna** (`.ava/users/<email>.json`), inte en parallell
+ * lista (DRY). En användare är allowlistad om en User-rad finns med en roll.
+ *
+ * Regler:
+ *   - Inga/ofullständiga claims → `null` (anonym).
+ *   - Email saknas i allowlisten → `null` (neka okänd; autentisering ≠ auktorisering).
+ *   - Inaktiverad användare → `null` (avprovisionerad).
+ *   - Bunden identitet (`oidcSubject` satt) måste matcha claims sub+iss → annars
+ *     `null` (skydd mot att kapa någon annans email hos en annan IdP). Obunden
+ *     rad accepteras via email (första login; bindningen skrivs separat, #224).
+ */
+
+import type { AuthProvider, Principal } from "./principal";
+
+/** Claims oauth2-proxy/IdP:n levererar (#222 fyller dessa ur headers/userinfo). */
+export interface OidcClaims {
+  /** "email"-claim. */
+  email: string;
+  /** "sub" — stabil, IdP-unik användaridentifierare. */
+  subject: string;
+  /** "iss" — utfärdande IdP. */
+  issuer: string;
+  /** "name"-claim (valfritt, fallback för display-namn). */
+  name?: string;
+}
+
+/** Minsta allowlist-rad resolvern behöver — en delmängd av `User`. */
+export interface AllowlistedUser {
+  id: string;
+  email: string;
+  name: string;
+  role: string;
+  organizationId: string;
+  /** Bunden OIDC-identitet (sätts vid första login, #224). */
+  oidcSubject?: string | null;
+  oidcIssuer?: string | null;
+  /** false = avprovisionerad. */
+  active?: boolean;
+}
+
+function emailEq(a: string, b: string): boolean {
+  return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
+/** Är en (ev. redan bunden) rad konsistent med dessa claims? Obunden = OK. */
+function bindingOk(user: AllowlistedUser, claims: OidcClaims): boolean {
+  if (!user.oidcSubject) return true; // obunden → första login binder via email
+  return user.oidcSubject === claims.subject && user.oidcIssuer === claims.issuer;
+}
+
+function toPrincipal(user: AllowlistedUser, claims: OidcClaims): Principal {
+  return {
+    id: user.id,
+    email: user.email,
+    name: user.name || claims.name || user.email,
+    role: user.role,
+    organizationId: user.organizationId,
+  };
+}
+
+export class OidcAuthProvider implements AuthProvider {
+  constructor(
+    private readonly claims: OidcClaims | null,
+    private readonly users: readonly AllowlistedUser[],
+  ) {}
+
+  getPrincipal(): Principal | null {
+    const claims = this.claims;
+    if (!claims?.email) return null;
+    const user = this.users.find((u) => emailEq(u.email, claims.email));
+    if (!user || user.active === false || !bindingOk(user, claims)) return null;
+    return toPrincipal(user, claims);
+  }
+}

--- a/src/lib/server/local-first/projections/user.ts
+++ b/src/lib/server/local-first/projections/user.ts
@@ -21,6 +21,9 @@ export const userProjectionSchema = z.object({
   /** SSH-public-keys för git-server-auth. Tom array = ingen auth ännu. */
   sshPublicKeys: z.array(z.string()).default([]),
   organizationId: z.string(),
+  /** OIDC-bindning (#223, ADR 0009) — bevaras vid hydrering om satt. */
+  oidcSubject: z.string().nullable().optional(),
+  oidcIssuer: z.string().nullable().optional(),
 });
 
 export type UserProjectionData = z.infer<typeof userProjectionSchema>;

--- a/src/lib/shared/schemas/user.ts
+++ b/src/lib/shared/schemas/user.ts
@@ -30,6 +30,13 @@ export const userSchema = z.object({
   /** bcrypt-hash. Frivilligt — fattas för demo-användare och Azure-only. */
   passwordHash: z.string().nullish(),
   azureOid: z.string().nullish(),
+  /**
+   * Generisk OIDC-bindning (#223, ADR 0009) — `sub`/`iss` från IdP:n, sätts
+   * vid första login. `azureOid` ovan är Entra-specifik och behålls för
+   * bakåtkompat; dessa två är IdP-agnostiska (BYO-IdP).
+   */
+  oidcSubject: z.string().nullish(),
+  oidcIssuer: z.string().nullish(),
   lastLoginAt: optionalDateLike,
   publicKeys: z.array(publicKeySchema).default([]),
 }).passthrough();

--- a/test/unit/server/auth/oidc-auth-provider.test.ts
+++ b/test/unit/server/auth/oidc-auth-provider.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest-compat";
+import {
+  OidcAuthProvider,
+  type AllowlistedUser,
+  type OidcClaims,
+} from "@/lib/server/auth/oidc-auth-provider";
+
+const ORG = "org-1";
+
+function user(over: Partial<AllowlistedUser> = {}): AllowlistedUser {
+  return {
+    id: "u-1",
+    email: "anna@byra.se",
+    name: "Anna Advokat",
+    role: "LAWYER",
+    organizationId: ORG,
+    ...over,
+  };
+}
+
+function claims(over: Partial<OidcClaims> = {}): OidcClaims {
+  return { email: "anna@byra.se", subject: "sub-123", issuer: "https://idp.example", ...over };
+}
+
+describe("OidcAuthProvider.getPrincipal", () => {
+  it("inga claims → null (anonym)", () => {
+    expect(new OidcAuthProvider(null, [user()]).getPrincipal()).toBeNull();
+  });
+
+  it("tom email i claims → null", () => {
+    expect(new OidcAuthProvider(claims({ email: "" }), [user()]).getPrincipal()).toBeNull();
+  });
+
+  it("email ej i allowlisten → null (neka okänd)", () => {
+    const p = new OidcAuthProvider(claims({ email: "okand@byra.se" }), [user()]).getPrincipal();
+    expect(p).toBeNull();
+  });
+
+  it("obunden allowlist-rad → principal (första login, matchar via email)", () => {
+    const p = new OidcAuthProvider(claims(), [user()]).getPrincipal();
+    expect(p).toEqual({
+      id: "u-1",
+      email: "anna@byra.se",
+      name: "Anna Advokat",
+      role: "LAWYER",
+      organizationId: ORG,
+    });
+  });
+
+  it("email-matchning är skiftlägesokänslig + trimmad", () => {
+    const p = new OidcAuthProvider(claims({ email: "  ANNA@Byra.SE " }), [user()]).getPrincipal();
+    expect(p?.id).toBe("u-1");
+  });
+
+  it("bunden rad med matchande sub+iss → principal", () => {
+    const u = user({ oidcSubject: "sub-123", oidcIssuer: "https://idp.example" });
+    expect(new OidcAuthProvider(claims(), [u]).getPrincipal()?.id).toBe("u-1");
+  });
+
+  it("bunden rad med fel sub → null (kapningsskydd)", () => {
+    const u = user({ oidcSubject: "sub-OTHER", oidcIssuer: "https://idp.example" });
+    expect(new OidcAuthProvider(claims(), [u]).getPrincipal()).toBeNull();
+  });
+
+  it("bunden rad med fel iss → null", () => {
+    const u = user({ oidcSubject: "sub-123", oidcIssuer: "https://annan-idp" });
+    expect(new OidcAuthProvider(claims(), [u]).getPrincipal()).toBeNull();
+  });
+
+  it("inaktiverad användare → null (avprovisionerad)", () => {
+    expect(new OidcAuthProvider(claims(), [user({ active: false })]).getPrincipal()).toBeNull();
+  });
+
+  it("aktiv === true respekteras", () => {
+    expect(new OidcAuthProvider(claims(), [user({ active: true })]).getPrincipal()?.id).toBe("u-1");
+  });
+
+  it("namn-fallback: tomt user.name → claims.name → email", () => {
+    const a = new OidcAuthProvider(claims({ name: "Claims Namn" }), [user({ name: "" })]).getPrincipal();
+    expect(a?.name).toBe("Claims Namn");
+    // claims() utan name → fallback hela vägen till email
+    const b = new OidcAuthProvider(claims(), [user({ name: "" })]).getPrincipal();
+    expect(b?.name).toBe("anna@byra.se");
+  });
+
+  it("roll + org förs vidare oförändrade", () => {
+    const u = user({ role: "ADMIN", organizationId: "org-X" });
+    const p = new OidcAuthProvider(claims(), [u]).getPrincipal();
+    expect(p?.role).toBe("ADMIN");
+    expect(p?.organizationId).toBe("org-X");
+  });
+
+  it("väljer rätt rad ur en allowlist med flera", () => {
+    const users = [user({ id: "u-1", email: "anna@byra.se" }), user({ id: "u-2", email: "bo@byra.se" })];
+    const p = new OidcAuthProvider(claims({ email: "bo@byra.se" }), users).getPrincipal();
+    expect(p?.id).toBe("u-2");
+  });
+});


### PR DESCRIPTION
## Vad
Del av auth-redesignen (epic #221, ADR 0009). Implementerar **claims→principal**-halvan: AVA som OIDC relying party auktoriserar mot **användar-allowlisten i firma.git** — vilket är de **befintliga User-raderna** (`.ava/users/<email>.json`), inte en parallell lista (DRY).

- **`OidcAuthProvider implements AuthProvider`** — claims `{email, sub, iss}` → `Principal` via User-uppslag på email. Nekar (`null`): okänd email, inaktiverad rad, och bunden rad vars `sub`/`iss` inte matchar (kapningsskydd). Obunden rad accepteras via email (första login).
- **`userSchema` + `userProjectionSchema`** får generiska `oidcSubject`/`oidcIssuer` (IdP-agnostisk bindning; `azureOid` behålls för bakåtkompat). Projektionen bevarar fälten vid hydrering.
- 13 enhetstester.

Ren, sidoeffektsfri resolver — testbar utan IdP (claims är en input). Komplement: `oauth2-proxy` som levererar claims = #222; skriva bindningen vid första login + bootstrap = #224.

## Test
`bun run test:all --no-e2e` ✓ — static (typecheck+lint+knip+deps+jscpd) + 2580 tester + coverage-golv (83.19%/79.95%).

Refs #221, #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)