### PR TITLE
feat(auth): oauth2-proxy OIDC forward-auth + klient-brygga (#222)

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -13,6 +13,50 @@ Denna fil beskriver hur autentisering fungerar för AVA:s **self-hosted**-läge
 > **nuvarande** htpasswd/PAT-modellen tills epiken landar; maskin-/CLI-klienter
 > (server-runtime, `git clone`) behåller PAT/deploy-key även efteråt.
 
+## OIDC-läge (#222, opt-in) — oauth2-proxy
+
+OIDC-inloggning aktiveras med en compose-overlay (default-stacken är oförändrad):
+
+```bash
+docker compose -f tooling/docker/docker-compose.yml \
+               -f tooling/docker/docker-compose.oidc.yml up -d --build
+```
+
+**Komponenter:**
+
+- `nginx-oidc.conf` — nginx gat:ar appen + `/git/` med `auth_request` →
+  `oauth2-proxy`. 401 → `/oauth2/start` (OIDC-inloggning). Eftersom appen och
+  `/git/` är samma origin följer oauth2-proxy-cookien automatiskt med iso-gits
+  `fetch` → git-push/pull funkar utan klient-token-kod.
+- `oauth2-proxy` — OIDC relying party. Pekas mot byråns IdP via
+  `OAUTH2_PROXY_OIDC_ISSUER_URL` + `CLIENT_ID`/`CLIENT_SECRET`; cookie-secret
+  ur secrets-valvet (#79). `mock-oidc`-tjänsten i overlayen är **endast dev**
+  (navikt/mock-oauth2-server) — ta bort den i drift och peka issuer mot Entra
+  ID/Google/BankID-broker.
+- **Klient-bryggan:** appen hämtar inloggad email från `/oauth2/userinfo`
+  (`src/lib/client/auth/oidc-principal.ts`) och auktoriserar mot
+  användar-allowlisten i firma.git via `OidcAuthProvider` (#223). Okänd email
+  nekas (autentisering ≠ auktorisering).
+
+**Skarp drift (env, ur valvet):**
+
+```
+OAUTH2_PROXY_OIDC_ISSUER_URL=https://login.microsoftonline.com/<tenant>/v2.0
+OAUTH2_PROXY_CLIENT_ID=<app-reg-client-id>
+OAUTH2_PROXY_CLIENT_SECRET=<ur valvet #79>
+OAUTH2_PROXY_COOKIE_SECRET=<32 byte, ur valvet>
+OAUTH2_PROXY_REDIRECT_URL=https://<din-host>/oauth2/callback
+```
+
+**CLI/maskin (icke-browser):** behåller Basic-auth/PAT — sätt
+`OAUTH2_PROXY_HTPASSWD_FILE=/auth-data/htpasswd` så oauth2-proxy accepterar
+både OIDC-cookie och PAT på `/git/`. server-runtime (#81) använder PAT/deploy-key.
+
+**Verifiering:** `bun run oidc:smoke` startar stacken (på port 8088) mot
+mock-OIDC och verifierar wiringen strukturellt (auth_request → oauth2-proxy →
+discovery → authorize-redirect). Hela token-dansen valideras mot din riktiga
+IdP (browser-inloggning).
+
 ## Designmål
 
 - **Tunn server**: ingen custom auth-tjänst, inga long-running processer

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "server-runtime": "bun src/bin/server-runtime.ts",
     "server-runtime:build": "bun tooling/scripts/build-server-runtime.ts",
     "server-runtime:smoke": "bash tooling/scripts/smoke-server-runtime-docker.sh",
+    "oidc:smoke": "bash tooling/scripts/smoke-oidc-stack.sh",
     "start": "next start",
     "tier3:up": "docker compose -f tooling/docker/docker-compose.yml up -d --build",
     "tier3:down": "docker compose -f tooling/docker/docker-compose.yml down",

--- a/src/lib/client/backend/oidc-principal.ts
+++ b/src/lib/client/backend/oidc-principal.ts
@@ -1,0 +1,63 @@
+/**
+ * Self-hosted OIDC-login: brygga från oauth2-proxy → AVA-principal (#222, ADR 0009).
+ *
+ * oauth2-proxy (#222-infra) sköter hela OIDC-dansen och exponerar den
+ * inloggade användarens claims på `/oauth2/userinfo` (samma origin → cookien
+ * följer med automatiskt). Vi hämtar email därifrån och auktoriserar mot
+ * användar-allowlisten i firma.git via `OidcAuthProvider` (#223).
+ *
+ * `sub`/`iss`-bindning utelämnas här (oauth2-proxy:s userinfo ger inte dem) →
+ * matchning sker på email (obunden = första-login-vägen i resolvern). Att
+ * skriva bindningen vid första login hanteras separat (#224).
+ */
+
+import { z } from "zod";
+import {
+  OidcAuthProvider,
+  type AllowlistedUser,
+  type OidcClaims,
+} from "@/lib/server/auth/oidc-auth-provider";
+import type { Principal } from "@/lib/server/auth/principal";
+
+/** Delmängd av oauth2-proxy:s `/oauth2/userinfo`-svar vi använder. */
+const oidcUserinfoSchema = z
+  .object({
+    email: z.string().default(""),
+    user: z.string().default(""),
+    preferredUsername: z.string().optional(),
+  })
+  .passthrough();
+
+/** Default-endpoint oauth2-proxy exponerar (samma origin som appen). */
+export const OIDC_USERINFO_PATH = "/oauth2/userinfo";
+
+/**
+ * Hämta + strikt-parsa claims från oauth2-proxy. `null` = ej inloggad
+ * (401/302/redirect) eller saknad email → callern skickar till `/oauth2/start`.
+ */
+export async function fetchOidcClaims(
+  fetchFn: typeof globalThis.fetch = globalThis.fetch,
+  path: string = OIDC_USERINFO_PATH,
+): Promise<OidcClaims | null> {
+  const res = await fetchFn(path, {
+    headers: { Accept: "application/json" },
+    credentials: "same-origin",
+  });
+  if (!res.ok) return null;
+  const info = oidcUserinfoSchema.parse(await res.json());
+  if (!info.email) return null;
+  return {
+    email: info.email,
+    subject: "",
+    issuer: "",
+    name: info.preferredUsername ?? info.user ?? "",
+  };
+}
+
+/** Lös self-hosted-principalen ur OIDC-claims + firma.git-allowlisten (#223). */
+export function resolveSelfHostedPrincipal(
+  claims: OidcClaims | null,
+  users: readonly AllowlistedUser[],
+): Principal | null {
+  return new OidcAuthProvider(claims, users).getPrincipal();
+}

--- a/test/unit/client/backend/oidc-principal.test.ts
+++ b/test/unit/client/backend/oidc-principal.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest-compat";
+import {
+  fetchOidcClaims,
+  resolveSelfHostedPrincipal,
+  OIDC_USERINFO_PATH,
+} from "@/lib/client/backend/oidc-principal";
+import type { AllowlistedUser } from "@/lib/server/auth/oidc-auth-provider";
+
+function jsonRes(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const USERS: AllowlistedUser[] = [
+  { id: "u-1", email: "anna@byra.se", name: "Anna", role: "ADMIN", organizationId: "org-1" },
+];
+
+describe("fetchOidcClaims", () => {
+  it("hämtar email + namn ur userinfo", async () => {
+    const fetchFn = (async (path: string | URL | Request) => {
+      expect(String(path)).toBe(OIDC_USERINFO_PATH);
+      return jsonRes(200, { email: "anna@byra.se", user: "anna", preferredUsername: "Anna A" });
+    }) as unknown as typeof globalThis.fetch;
+
+    const claims = await fetchOidcClaims(fetchFn);
+    expect(claims).toEqual({ email: "anna@byra.se", subject: "", issuer: "", name: "Anna A" });
+  });
+
+  it("namn faller tillbaka på user när preferredUsername saknas", async () => {
+    const fetchFn = (async () => jsonRes(200, { email: "x@y.se", user: "x" })) as unknown as typeof globalThis.fetch;
+    const claims = await fetchOidcClaims(fetchFn);
+    expect(claims?.name).toBe("x");
+  });
+
+  it("icke-ok svar (401/redirect) → null (ej inloggad)", async () => {
+    const fetchFn = (async () => jsonRes(401, {})) as unknown as typeof globalThis.fetch;
+    expect(await fetchOidcClaims(fetchFn)).toBeNull();
+  });
+
+  it("svar utan email → null", async () => {
+    const fetchFn = (async () => jsonRes(200, { user: "x" })) as unknown as typeof globalThis.fetch;
+    expect(await fetchOidcClaims(fetchFn)).toBeNull();
+  });
+});
+
+describe("resolveSelfHostedPrincipal", () => {
+  it("matchar email mot allowlisten → principal", () => {
+    const p = resolveSelfHostedPrincipal(
+      { email: "anna@byra.se", subject: "", issuer: "", name: "Anna" },
+      USERS,
+    );
+    expect(p?.id).toBe("u-1");
+    expect(p?.role).toBe("ADMIN");
+  });
+
+  it("null claims → null", () => {
+    expect(resolveSelfHostedPrincipal(null, USERS)).toBeNull();
+  });
+
+  it("okänd email → null (ej allowlistad)", () => {
+    const p = resolveSelfHostedPrincipal(
+      { email: "okand@byra.se", subject: "", issuer: "", name: "" },
+      USERS,
+    );
+    expect(p).toBeNull();
+  });
+});

--- a/tooling/docker/docker-compose.oidc.yml
+++ b/tooling/docker/docker-compose.oidc.yml
@@ -1,0 +1,60 @@
+# OIDC-overlay (#222, ADR 0009) — opt-in människo-auth via oauth2-proxy.
+#
+# Bas-stacken (docker-compose.yml) använder htpasswd. Denna overlay byter
+# web-containerns nginx-config till OIDC-varianten och lägger till oauth2-proxy
+# + en mock-OIDC-IdP för lokal verifiering. Aktivera genom att lägga på den:
+#
+#   docker compose -f tooling/docker/docker-compose.yml \
+#                  -f tooling/docker/docker-compose.oidc.yml up -d --build
+#
+# I skarp drift: peka OAUTH2_PROXY_OIDC_ISSUER_URL mot byråns riktiga IdP
+# (Entra ID/Google/BankID-broker), sätt CLIENT_ID/SECRET + COOKIE_SECRET ur
+# secrets-valvet (#79), och ta bort mock-oidc-tjänsten. Se docs/auth.md.
+
+name: ava
+
+services:
+  # Byt nginx-config till OIDC-varianten (samma target → ersätter bas-mounten).
+  web:
+    volumes:
+      - ../../out:/usr/share/nginx/html:ro
+      - ./nginx-oidc.conf:/etc/nginx/conf.d/default.conf:ro
+      - git_repos:/srv/git
+      - auth_data:/auth-data
+    depends_on:
+      - oauth2-proxy
+
+  # ─── oauth2-proxy: OIDC relying party (auth_request-backend för nginx) ──
+  oauth2-proxy:
+    image: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
+    restart: unless-stopped
+    environment:
+      OAUTH2_PROXY_HTTP_ADDRESS: "0.0.0.0:4180"
+      OAUTH2_PROXY_PROVIDER: "oidc"
+      # Mock i dev; byt mot byråns IdP i drift.
+      OAUTH2_PROXY_OIDC_ISSUER_URL: "${OAUTH2_PROXY_OIDC_ISSUER_URL:-http://mock-oidc:8080/default}"
+      OAUTH2_PROXY_CLIENT_ID: "${OAUTH2_PROXY_CLIENT_ID:-ava}"
+      OAUTH2_PROXY_CLIENT_SECRET: "${OAUTH2_PROXY_CLIENT_SECRET:-ava-mock-secret}"
+      # 32-byte cookie-secret. Dev-default; sätt ur valvet (#79) i drift.
+      OAUTH2_PROXY_COOKIE_SECRET: "${OAUTH2_PROXY_COOKIE_SECRET:-ava-dev-cookie-secret-0123456789}"
+      OAUTH2_PROXY_REDIRECT_URL: "${OAUTH2_PROXY_REDIRECT_URL:-http://localhost:8080/oauth2/callback}"
+      # Auktorisering görs av AVA (allowlist i firma.git), inte av proxy:n →
+      # släpp alla email-domäner; okänd email nekas ändå av OidcAuthProvider.
+      OAUTH2_PROXY_EMAIL_DOMAINS: "*"
+      OAUTH2_PROXY_UPSTREAMS: "static://202"
+      OAUTH2_PROXY_REVERSE_PROXY: "true"
+      OAUTH2_PROXY_SET_XAUTHREQUEST: "true"
+      OAUTH2_PROXY_SKIP_PROVIDER_BUTTON: "true"
+      # Localhost-dev kör http → otillåt secure-cookie/overifierad mock-email.
+      OAUTH2_PROXY_COOKIE_SECURE: "false"
+      OAUTH2_PROXY_INSECURE_OIDC_ALLOW_UNVERIFIED_EMAIL: "true"
+    depends_on:
+      - mock-oidc
+
+  # ─── mock-OIDC-IdP (ENBART dev/test — ta bort i drift) ─────────────────
+  mock-oidc:
+    image: ghcr.io/navikt/mock-oauth2-server:2.1.10
+    restart: unless-stopped
+    environment:
+      # Lyssna på 8080; issuer "default" → /default/.well-known/openid-configuration
+      SERVER_PORT: "8080"

--- a/tooling/docker/docker-compose.yml
+++ b/tooling/docker/docker-compose.yml
@@ -40,7 +40,9 @@ services:
       dockerfile: Dockerfile
     restart: unless-stopped
     ports:
-      - "8080:80"
+      # Host-port konfigurerbar (default 8080) så parallella stackar (t.ex.
+      # OIDC-röktestet #222) kan köra på en annan port utan att krocka.
+      - "${AVA_WEB_PORT:-8080}:80"
     volumes:
       - ../../out:/usr/share/nginx/html:ro
       - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro

--- a/tooling/docker/nginx-oidc.conf
+++ b/tooling/docker/nginx-oidc.conf
@@ -1,0 +1,102 @@
+# nginx-config för AVA — OIDC-variant (#222, ADR 0009).
+#
+# Som nginx.conf MEN människo-auth sker via oauth2-proxy (OIDC relying party)
+# i stället för auth_basic/htpasswd. Opt-in: monteras bara när profilen `oidc`
+# körs (se docker-compose.yml). Default-stacken är oförändrad (nginx.conf).
+#
+# Mönster: nginx `auth_request` → oauth2-proxy. Eftersom appen + /git/ är samma
+# origin följer oauth2-proxy-sessions-cookien automatiskt med iso-gits fetch →
+# git-push/pull funkar utan klient-token-kod. /git/ accepterar dessutom
+# Basic-auth/PAT (oauth2-proxy --htpasswd-file) för CLI-/maskin-klienter.
+
+server {
+  listen 80;
+  server_name _;
+  index index.html;
+
+  # ─── oauth2-proxy endpoints (OIDC-dansen) ──────────────────────────
+  # /oauth2/start, /oauth2/callback, /oauth2/userinfo, /oauth2/auth.
+  resolver 127.0.0.11 ipv6=off valid=30s;
+  location /oauth2/ {
+    set $oauth2_upstream "http://oauth2-proxy:4180";
+    proxy_pass $oauth2_upstream;
+    proxy_set_header Host                    $host;
+    proxy_set_header X-Real-IP               $remote_addr;
+    proxy_set_header X-Forwarded-Uri         $request_uri;
+    proxy_set_header X-Forwarded-Proto       $scheme;
+  }
+
+  # Intern auth-subrequest (anropas av auth_request nedan).
+  location = /oauth2/auth {
+    internal;
+    set $oauth2_upstream "http://oauth2-proxy:4180";
+    proxy_pass $oauth2_upstream;
+    proxy_pass_request_body off;
+    proxy_set_header Content-Length "";
+    proxy_set_header X-Original-URI $request_uri;
+  }
+
+  # ─── /ava/_next/static/ — oskyddade hashade assets (cache aggressivt) ──
+  location ~ ^/ava/_next/static/(.+\.mjs)$ {
+    alias /usr/share/nginx/html/_next/static/$1;
+    default_type application/javascript;
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+  }
+  location /ava/_next/static/ {
+    alias /usr/share/nginx/html/_next/static/;
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+    try_files $uri =404;
+  }
+
+  # ─── Appen (skyddad: kräver inloggad OIDC-session) ─────────────────
+  location /ava/ {
+    auth_request /oauth2/auth;
+    error_page 401 = @oidc_signin;
+    alias /usr/share/nginx/html/;
+    try_files $uri $uri.html $uri/index.html /index.html =404;
+  }
+
+  location = / { return 302 /ava/; }
+
+  # 401 → starta OIDC-inloggning, återvänd hit efteråt.
+  location @oidc_signin {
+    return 302 /oauth2/start?rd=$scheme://$http_host$request_uri;
+  }
+
+  # ─── Smart-HTTP git ─────────────────────────────────────────────────
+  # Skyddad av oauth2-proxy: browser via cookie (auth_request), CLI/maskin via
+  # Basic-auth/PAT (oauth2-proxy --htpasswd-file). Vi gat:ar med auth_request
+  # som accepterar BÅDA (oauth2-proxy returnerar 202 för giltig cookie ELLER
+  # giltig Basic-auth).
+  location ~ ^/git(/.*)?$ {
+    add_header Access-Control-Allow-Origin "$http_origin" always;
+    add_header Access-Control-Allow-Credentials "true" always;
+    add_header Access-Control-Allow-Methods "GET, POST, OPTIONS" always;
+    add_header Access-Control-Allow-Headers "Authorization, Content-Type, X-Requested-With" always;
+    add_header Access-Control-Expose-Headers "Content-Type, Content-Length, WWW-Authenticate" always;
+    if ($request_method = OPTIONS) { return 204; }
+
+    auth_request /oauth2/auth;
+
+    fastcgi_pass unix:/var/run/fcgiwrap.socket;
+    include fastcgi_params;
+    fastcgi_param SCRIPT_FILENAME /usr/libexec/git-core/git-http-backend;
+    fastcgi_param GIT_PROJECT_ROOT /srv/git;
+    fastcgi_param GIT_HTTP_EXPORT_ALL "";
+    fastcgi_param PATH_INFO $1;
+    client_max_body_size 0;
+    fastcgi_read_timeout 300;
+    fastcgi_buffering off;
+  }
+
+  location ~ "^/ava/(matters|contacts|invoices|payment-plans|users|templates)/([^/]+)(/edit)?/?$" {
+    auth_request /oauth2/auth;
+    error_page 401 = @oidc_signin;
+    alias /usr/share/nginx/html/;
+    try_files /$1/$2$3/index.html /$1/__shell__$3/index.html /index.html =404;
+  }
+
+  location ~ /\. { deny all; }
+}

--- a/tooling/scripts/smoke-oidc-stack.sh
+++ b/tooling/scripts/smoke-oidc-stack.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Strukturellt röktest för OIDC-stacken (#222).
+#
+# Verifierar att wiringen nginx auth_request → oauth2-proxy → mock-OIDC är
+# korrekt UTAN att skripta hela browser-token-dansen (den dual-URL-biten kräver
+# en riktig IdP / browser och valideras manuellt). Det vi bevisar:
+#   1. compose-overlayen är giltig,
+#   2. oauth2-proxy startar = den hämtade mock-OIDC:s discovery-dokument
+#      (provider=oidc vägrar starta annars),
+#   3. oskyddad request mot appen → 302 till /oauth2/start (auth_request gat:ar),
+#   4. /oauth2/start → 302 till IdP:ns authorize-endpoint (provider-wiring).
+# Kräver docker. Isolerat projektnamn så det inte krockar med en körande stack.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+PROJECT="ava-oidc-smoke"
+# Egen host-port (default-stacken kör på 8080) så röktestet inte krockar.
+PORT="${AVA_WEB_PORT:-8088}"
+export AVA_WEB_PORT="$PORT"
+COMPOSE=(docker compose -p "$PROJECT" -f tooling/docker/docker-compose.yml -f tooling/docker/docker-compose.oidc.yml)
+
+cleanup() { "${COMPOSE[@]}" down -v --remove-orphans >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "==> [1/4] Validerar compose-overlay…"
+"${COMPOSE[@]}" config >/dev/null
+echo "    ok"
+
+echo "==> [2/4] Startar web + oauth2-proxy + mock-oidc…"
+"${COMPOSE[@]}" up -d --build web oauth2-proxy mock-oidc >/dev/null 2>&1
+
+echo "==> [3/4] Väntar in oauth2-proxy (hämtar mock-OIDC discovery)…"
+ok=""
+for i in $(seq 1 30); do
+  code=$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:${PORT}/ava/" || true)
+  loc=$(curl -s -o /dev/null -w '%{redirect_url}' "http://localhost:${PORT}/ava/" || true)
+  if [ "$code" = "302" ] && printf '%s' "$loc" | grep -q "/oauth2/start"; then ok="1"; break; fi
+  sleep 2
+done
+if [ -z "$ok" ]; then
+  echo "❌ FEL: /ava/ gav inte 302→/oauth2/start (code=$code loc=$loc)"
+  "${COMPOSE[@]}" logs oauth2-proxy mock-oidc | tail -40
+  exit 1
+fi
+echo "    /ava/ → 302 $loc  ✓ (auth_request gat:ar + oauth2-proxy uppe)"
+
+echo "==> [4/4] /oauth2/start → IdP authorize…"
+start_loc=$(curl -s -o /dev/null -w '%{redirect_url}' "http://localhost:${PORT}/oauth2/start?rd=%2Fava%2F" || true)
+if ! printf '%s' "$start_loc" | grep -qiE "authorize|/default/"; then
+  echo "❌ FEL: /oauth2/start pekade inte mot IdP authorize (loc=$start_loc)"
+  exit 1
+fi
+echo "    /oauth2/start → $start_loc  ✓ (provider-wiring)"
+
+echo "✅ OIDC-stack röktest OK — auth_request + oauth2-proxy + mock-OIDC korrekt wirat."
+echo "   (Full token-dans valideras mot en riktig IdP — se docs/auth.md.)"


### PR DESCRIPTION
## Vad
Del av auth-redesignen (epic #221, ADR 0009). Människo-login via **OIDC**, **opt-in** (default-stacken oförändrad → e2e/demo opåverkade).

### Infra (compose-overlay)
- **`nginx-oidc.conf`** — gat:ar app + `/git/` med `auth_request` → oauth2-proxy; 401 → `/oauth2/start`. Samma origin → oauth2-proxy-cookien följer automatiskt med iso-gits `fetch` (git-push/pull utan klient-token-kod).
- **`docker-compose.oidc.yml`** — `oauth2-proxy` (OIDC RP) + `mock-oidc` (endast dev — byt mot byråns IdP i drift). BYO-IdP via env/valv (#79). Web-host-porten konfigurerbar (`${AVA_WEB_PORT:-8080}`) så röktestet kör parallellt utan portkrock.

### Klient-brygga
- **`src/lib/client/backend/oidc-principal.ts`** — hämtar email ur `/oauth2/userinfo` och auktoriserar mot allowlisten via `OidcAuthProvider` (#223). Ligger i composition-root-lagret (där värde-import av `server` är tillåten enligt dep-cruiser-regeln `ui-imports-server-by-type-only`).

### Verifierat
- **`bun run oidc:smoke`** — strukturellt röktest mot mock-OIDC, **kört grönt**: `/ava/` → 302 `/oauth2/start`; `/oauth2/start` → mock-OIDC `/default/authorize`. (Bevisar auth_request-wiring + oauth2-proxy↔discovery + provider-redirect.)
- **`bun run test:all --no-e2e`** ✓ — static (typecheck+lint+complexity+deps+knip+jscpd) + 2586 tester + coverage-golv.

### Kvar (mock → verklig IdP)
Hela browser-token-dansen valideras mot **din riktiga IdP** (Entra/Google) — kan inte skriptas headless p.g.a. OIDC:s dual-URL. Att skriva sub/iss-bindningen vid första login + bootstrap = #224. `docs/auth.md` har drift-stegen.

Refs #221, #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)