### PR TITLE
feat(auth): oidc first-admin-claim via auth-server (#224)

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -57,6 +57,24 @@ mock-OIDC och verifierar wiringen strukturellt (auth_request → oauth2-proxy �
 discovery → authorize-redirect). Hela token-dansen valideras mot din riktiga
 IdP (browser-inloggning).
 
+### Första-admin (bootstrap, #224)
+
+Hönan-och-ägget: en färsk firma.git har inga User-rader → ingen är allowlistad.
+Rotförtroende = den som kör `docker compose up` (host shell-access).
+
+- Vid första start (tom allowlist) printas en **engångs claim-secret**
+  (`BOOT_SECRET`) i auth-tjänstens logg.
+- Första inloggade OIDC-användaren löser in den: `POST /auth/claim-admin`
+  `{ secret, email }`. auth-servern verifierar secret + att ingen admin finns
+  än (`admins.txt`), engångs (409 därefter). auth-servern **pratar inte git** →
+  den auktoriserar bara; **klienten** skriver `.ava/users/<email>.json`
+  (role ADMIN, `oidcSubject`) och pushar.
+- Alternativ: `add-user.sh --admin <epost>` på hosten.
+
+OIDC-bootstrap kräver alltså att **auth-tjänsten** körs (profil `invite-server`)
+vid sidan av `oauth2-proxy`. Pure-besluts-logiken (`claimAdminDecision`) är
+enhetstestad i `test/unit/lib/auth-server-core.test.ts`.
+
 ## Designmål
 
 - **Tunn server**: ingen custom auth-tjänst, inga long-running processer

--- a/test/unit/lib/auth-server-core.test.ts
+++ b/test/unit/lib/auth-server-core.test.ts
@@ -13,6 +13,7 @@ const {
   hashToken, safeEqual, newToken,
   parseHtpasswd, serializeHtpasswd, upsertHtpasswd,
   createInvite, findValidInvite, redeemInvite, hasAdmin,
+  claimAdminDecision,
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } = core as any;
 
@@ -127,5 +128,39 @@ describe("hasAdmin", () => {
 
   it("true när minst en användare finns", () => {
     expect(hasAdmin(parseHtpasswd("anna:h\n"))).toBe(true);
+  });
+});
+
+describe("claimAdminDecision (#224 OIDC first-admin)", () => {
+  const SECRET = "boot-secret-xyz";
+
+  it("ok när tom allowlist + rätt secret + giltig email", () => {
+    const d = claimAdminDecision(new Set(), SECRET, "Anna@Byra.SE", SECRET);
+    expect(d).toEqual({ ok: true, email: "anna@byra.se" });
+  });
+
+  it("503 när BOOT_SECRET saknas på servern", () => {
+    const d = claimAdminDecision(new Set(), SECRET, "a@b.se", "");
+    expect(d).toMatchObject({ ok: false, status: 503 });
+  });
+
+  it("409 (engångs) när admin redan finns", () => {
+    const d = claimAdminDecision(new Set(["x@y.se"]), SECRET, "a@b.se", SECRET);
+    expect(d).toMatchObject({ ok: false, status: 409 });
+  });
+
+  it("403 vid fel secret", () => {
+    const d = claimAdminDecision(new Set(), "fel", "a@b.se", SECRET);
+    expect(d).toMatchObject({ ok: false, status: 403 });
+  });
+
+  it("400 vid ogiltig email", () => {
+    const d = claimAdminDecision(new Set(), SECRET, "inte-en-email", SECRET);
+    expect(d).toMatchObject({ ok: false, status: 400 });
+  });
+
+  it("400 när email saknas (icke-sträng)", () => {
+    const d = claimAdminDecision(new Set(), SECRET, undefined, SECRET);
+    expect(d).toMatchObject({ ok: false, status: 400 });
   });
 });

--- a/tooling/docker/auth-server/auth-core.mjs
+++ b/tooling/docker/auth-server/auth-core.mjs
@@ -111,3 +111,33 @@ export function redeemInvite(invites, token, now = new Date()) {
 export function hasAdmin(htpasswdMap) {
   return htpasswdMap.size > 0;
 }
+
+// ─── OIDC first-admin-claim (#224, ADR 0009) ───────────────────────────────
+//
+// I OIDC-läget (oauth2-proxy, #222) finns inga htpasswd-användare för
+// människor — allowlisten är User-raderna i firma.git (#223). Bootstrappen
+// kan därför inte basera "har admin" på htpasswd; vi spårar admin-emails i
+// `admins.txt` (`adminsSet`). Första inloggade OIDC-användaren löser in en
+// engångs claim-secret (= BOOT_SECRET, printad i loggen vid första start) →
+// blir admin. auth-servern "pratar inte git" → den AUKTORISERAR bara; klienten
+// skriver själva `.ava/users/<email>.json` (role ADMIN) och pushar.
+
+/**
+ * Beslut om en admin-claim får göras. Rent (ingen I/O) → unit-testbart.
+ *   - bootSecret saknas på servern        → { ok:false, status:503 }
+ *   - admin finns redan (adminsSet ej tom) → { ok:false, status:409 } (engångs)
+ *   - fel secret                           → { ok:false, status:403 }
+ *   - ogiltig email                        → { ok:false, status:400 }
+ *   - annars                               → { ok:true, email: <normaliserad> }
+ */
+export function claimAdminDecision(adminsSet, providedSecret, email, bootSecret) {
+  if (!bootSecret) return { ok: false, status: 503, reason: "BOOT_SECRET ej konfigurerat" };
+  if (adminsSet.size > 0) return { ok: false, status: 409, reason: "admin redan provisionerad" };
+  if (typeof providedSecret !== "string" || !safeEqual(providedSecret, bootSecret)) {
+    return { ok: false, status: 403, reason: "felaktig claim-secret" };
+  }
+  if (typeof email !== "string" || !email.includes("@")) {
+    return { ok: false, status: 400, reason: "giltig email krävs" };
+  }
+  return { ok: true, email: email.toLowerCase().trim() };
+}

--- a/tooling/docker/auth-server/server.mjs
+++ b/tooling/docker/auth-server/server.mjs
@@ -28,7 +28,7 @@ import { resolve } from "node:path";
 import {
   parseHtpasswd, serializeHtpasswd, upsertHtpasswd, hasAdmin,
   createInvite, findValidInvite, redeemInvite,
-  newToken, safeEqual,
+  newToken, safeEqual, claimAdminDecision,
 } from "./auth-core.mjs";
 
 const PORT = Number(process.env.PORT || 3001);
@@ -191,6 +191,23 @@ async function handleRedeem(req, res) {
   json(res, 200, { email: email.toLowerCase().trim(), token: pat, role: result.invite.role });
 }
 
+/**
+ * OIDC first-admin-claim (#224). Första inloggade OIDC-användaren löser in
+ * engångs claim-secret:n (= BOOT_SECRET) → blir admin. auth-servern pratar
+ * inte git → den auktoriserar bara (+ spårar admin i admins.txt); klienten
+ * skriver `.ava/users/<email>.json` (role ADMIN, oidcSubject) och pushar.
+ */
+async function handleClaimAdmin(req, res) {
+  const body = await readBody(req);
+  if (!body) return json(res, 400, { error: "fel JSON" });
+  const admins = await loadAdmins();
+  const decision = claimAdminDecision(admins, body.secret, body.email, BOOT_SECRET);
+  if (!decision.ok) return json(res, decision.status, { error: decision.reason });
+  admins.add(decision.email);
+  await saveAdmins(admins);
+  json(res, 200, { ok: true, email: decision.email, role: "ADMIN" });
+}
+
 // ─── Router ──────────────────────────────────────────────────────────────
 
 async function handle(req, res) {
@@ -209,6 +226,7 @@ async function handle(req, res) {
   try {
     if (req.method === "GET" && (path === "/status" || path === "/")) return await handleStatus(req, res);
     if (req.method === "POST" && path === "/bootstrap") return await handleBootstrap(req, res);
+    if (req.method === "POST" && path === "/claim-admin") return await handleClaimAdmin(req, res);
     if (req.method === "POST" && path === "/invite") return await handleInvite(req, res);
     if (req.method === "POST" && path === "/redeem-invite") return await handleRedeem(req, res);
     return json(res, 404, { error: `Okänd path: ${path}` });


### PR DESCRIPTION
## Vad
Sista biten i auth-epiken (#221, ADR 0009): bootstrap av första admin i OIDC-läget.

- **auth-core** `claimAdminDecision()` — ren beslutslogik (503 utan BOOT_SECRET, 409 om admin redan finns [engångs], 403 fel secret, 400 ogiltig email, annars ok). 6 enhetstester.
- **server.mjs** `POST /auth/claim-admin` — första inloggade OIDC-användaren löser in engångs claim-secret:n (= `BOOT_SECRET`, printad i loggen vid första start) → blir admin (`admins.txt`), engångs.
- **Browser-only-modellen:** auth-servern "pratar inte git" → den **auktoriserar bara**; **klienten** skriver `.ava/users/<email>.json` (role ADMIN, `oidcSubject`) och pushar (återanvänder typad `user.create` — ingen schema-dubblering i den dep-fria .mjs:en).
- **docs/auth.md:** bootstrap-flödet + att auth-tjänsten måste köra vid sidan av oauth2-proxy i OIDC-läget.

## Test
`bun run test:all --no-e2e` ✓ — static + 23 auth-core-tester (6 nya) + coverage-golv (83.21%/79.97%).

## Kvar
Klient-claim-UI:t (browser-formuläret som POST:ar /auth/claim-admin + skriver user-raden) + end-to-end mot riktig IdP. Säkerhetsmodell: repo-åtkomst = förtroende (ADR 0001, ingen per-rad-ACL) — claim-token:en gat:ar den legitima UI-vägen.

Refs #221, #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)