### PR TITLE
feat(payment-plans): manuell knapp för scanDueReminders (#71)

### DIFF
--- a/src/app/payment-plans/page.tsx
+++ b/src/app/payment-plans/page.tsx
@@ -7,7 +7,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Wallet, Search } from "lucide-react";
+import { Wallet, Search, BellRing } from "lucide-react";
 import { trpc } from "@/lib/client/trpc";
 import { shellPath } from "@/lib/client/demo/entity-href";
 import { formatCurrency } from "@/lib/client/utils";
@@ -58,6 +58,20 @@ function outstandingOf(p: PlanRow): number {
   return computeInvoiceLedger(totalOf(p), paidOf(p), 0, writtenOff).outstanding;
 }
 
+/** Resultatet av en `scanDueReminders`-körning (#71). */
+export interface ScanResult {
+  scanned: number;
+  planned: number;
+  due: number;
+  overdue: number;
+}
+
+/** Mänsklig sammanfattning av en påminnelse-skanning. Ren → unit-testbar. */
+export function formatScanResult(r: ScanResult): string {
+  if (r.planned === 0) return `Inga nya påminnelser (skannade ${r.scanned} aktiva planer).`;
+  return `${r.planned} påminnelser skickade — ${r.due} förfaller, ${r.overdue} försenade (av ${r.scanned} planer).`;
+}
+
 const planColumns: Column<PlanRow>[] = [
   { key: "matterNumber", label: "Ärendenr", sortable: true,
     sortValue: (p) => p.invoice?.matter?.matterNumber ?? "",
@@ -99,9 +113,21 @@ const planColumns: Column<PlanRow>[] = [
 
 export default function PaymentPlansPage() {
   const router = useRouter();
+  const utils = trpc.useUtils();
   const [status, setStatus] = useState<Status>("ACTIVE");
   const [search, setSearch] = useState("");
+  const [scanMsg, setScanMsg] = useState<string | null>(null);
   const list = trpc.paymentPlan.list.useQuery({ status, search: search || undefined });
+
+  // #71: manuell väg att köra scanDueReminders (förfallo-/försenings-
+  // påminnelser) utan ett separat tRPC-anrop. Den automatiska job-vägen
+  // väntar på regelmotorn (#80).
+  const scan = trpc.paymentPlan.scanDueReminders.useMutation({
+    onSuccess: (r) => {
+      setScanMsg(formatScanResult(r));
+      void utils.paymentPlan.list.invalidate();
+    },
+  });
 
   return (
     <div>
@@ -112,6 +138,27 @@ export default function PaymentPlansPage() {
         <p className="text-sm text-gray-500 mt-1">
           Alla planer i organisationen. Klicka för detaljer + påminnelse-historik.
         </p>
+      </div>
+
+      <div className="flex items-center gap-3 mb-3">
+        <button
+          type="button"
+          data-testid="send-reminders"
+          onClick={() => scan.mutate({})}
+          disabled={scan.isPending}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          <BellRing size={14} />
+          {scan.isPending ? "Skickar…" : "Skicka påminnelser nu"}
+        </button>
+        {scanMsg && (
+          <span data-testid="scan-result" className="text-sm text-gray-600">
+            {scanMsg}
+          </span>
+        )}
+        {scan.error && (
+          <span className="text-sm text-red-600">Kunde inte skicka: {scan.error.message}</span>
+        )}
       </div>
 
       <div className="flex items-center justify-between mb-3 gap-3">

--- a/test/unit/app/payment-plans/page.test.tsx
+++ b/test/unit/app/payment-plans/page.test.tsx
@@ -4,18 +4,31 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest-compat";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 
 const listQuery = { data: undefined as unknown[] | undefined, isLoading: false };
+type ScanResult = { scanned: number; planned: number; due: number; overdue: number };
+const scanMutate = vi.fn();
+const scanState = { isPending: false, error: null as null | { message: string } };
+let scanOnSuccess: ((r: ScanResult) => void) | undefined;
+const utilsMock = { prefs: { get: { invalidate: vi.fn() } }, paymentPlan: { list: { invalidate: vi.fn() } } };
 
 vi.mock("@/lib/client/trpc", () => ({
   trpc: {
-    useUtils: () => ({ prefs: { get: { invalidate: vi.fn() } } }),
+    useUtils: () => utilsMock,
     user: {
       current: { useQuery: () => ({ data: { id: "u1", role: "LAWYER" } }) },
       list: { useQuery: () => ({ data: { users: [] } }) },
     },
-    paymentPlan: { list: { useQuery: () => listQuery } },
+    paymentPlan: {
+      list: { useQuery: () => listQuery },
+      scanDueReminders: {
+        useMutation: (opts?: { onSuccess?: (r: ScanResult) => void }) => {
+          scanOnSuccess = opts?.onSuccess;
+          return { mutate: (a: unknown) => scanMutate(a), isPending: scanState.isPending, error: scanState.error };
+        },
+      },
+    },
     prefs: {
       get: { useQuery: () => ({ data: undefined, isLoading: false }) },
       save: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
@@ -27,11 +40,15 @@ vi.mock("@/lib/client/trpc", () => ({
 }));
 vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
 
-import PaymentPlansPage from "@/app/payment-plans/page";
+import PaymentPlansPage, { formatScanResult } from "@/app/payment-plans/page";
 
 beforeEach(() => {
+  vi.clearAllMocks();
   listQuery.data = undefined;
   listQuery.isLoading = false;
+  scanState.isPending = false;
+  scanState.error = null;
+  scanOnSuccess = undefined;
 });
 
 describe("PaymentPlansPage — utestående", () => {
@@ -52,5 +69,41 @@ describe("PaymentPlansPage — utestående", () => {
     expect(screen.getByText("Utestående")).toBeInTheDocument();
     // formatCurrency(50000) → "500,00 kr" (sv-SE). Matcha siffran robust.
     expect(screen.getByText(/500,00/)).toBeInTheDocument();
+  });
+});
+
+describe("formatScanResult (#71)", () => {
+  it("noll planerade → 'inga nya'", () => {
+    expect(formatScanResult({ scanned: 5, planned: 0, due: 0, overdue: 0 })).toMatch(/Inga nya/);
+  });
+  it("planerade → antal + förfaller/försenade", () => {
+    const msg = formatScanResult({ scanned: 4, planned: 3, due: 2, overdue: 1 });
+    expect(msg).toContain("3 påminnelser");
+    expect(msg).toContain("2 förfaller");
+    expect(msg).toContain("1 försenade");
+  });
+});
+
+describe("PaymentPlansPage — Skicka påminnelser nu (#71)", () => {
+  it("knappen kör scanDueReminders med {}", () => {
+    render(<PaymentPlansPage />);
+    fireEvent.click(screen.getByTestId("send-reminders"));
+    expect(scanMutate).toHaveBeenCalledWith({});
+  });
+
+  it("visar resultat + invaliderar listan vid onSuccess", () => {
+    render(<PaymentPlansPage />);
+    fireEvent.click(screen.getByTestId("send-reminders"));
+    act(() => scanOnSuccess?.({ scanned: 3, planned: 2, due: 1, overdue: 1 }));
+    expect(screen.getByTestId("scan-result").textContent).toContain("2 påminnelser");
+    expect(utilsMock.paymentPlan.list.invalidate).toHaveBeenCalled();
+  });
+
+  it("disablad + 'Skickar…' medan mutationen körs", () => {
+    scanState.isPending = true;
+    render(<PaymentPlansPage />);
+    const btn = screen.getByTestId("send-reminders") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(btn.textContent).toContain("Skickar");
   });
 });


### PR DESCRIPTION
## Vad
#71: en **"Skicka påminnelser nu"-knapp** på /payment-plans som kör den befintliga, testade `paymentPlan.scanDueReminders` utan ett manuellt tRPC-anrop — "minst en väg" enligt issuens *Klar när*. Den automatiska browser-open-job-vägen väntar på regelmotorn (#80) + den ej-wirade job-worker:n.

- Knapp (`data-testid=send-reminders`) + inline-resultat ("N påminnelser skickade — D förfaller, O försenade" / "Inga nya") + fel-visning; invaliderar list-queryn vid lyckad körning.
- `formatScanResult()` extraherad som ren, unit-testad funktion.
- Page-test (utökar befintligt): knappen kör mutationen med `{}`, `onSuccess` visar resultat + invaliderar, disablad + "Skickar…" medan pending.

## Test
`bun run test:all --no-e2e` ✓ — static + tester + coverage-golv (83.25%/79.99%).

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)