### PR TITLE
feat(server): regelmotor som idempotenta PeerActs + no-empty-commit (#80)

### DIFF
--- a/docs/adr/0010-regelmotor-som-idempotenta-peeracts.md
+++ b/docs/adr/0010-regelmotor-som-idempotenta-peeracts.md
@@ -1,0 +1,69 @@
+# ADR 0010 — Regelmotor som idempotenta schemalagda PeerActs
+
+- **Status:** Accepterad
+- **Datum:** 2026-06-11
+- **Beslutsfattare:** Ulrik Sjölin
+- **Berör:** server-runtime (ADR 0005), påminnelser (#71), framtida automatiseringar
+- **Issue:** [#80](https://github.com/ulrik-s/ava/issues/80)
+- **Relaterat:** [ADR 0005](./0005-server-som-git-peer.md) (git-peer-server), [ADR 0002](./0002-git-konflikthantering-backend-a.md) (konflikthantering), [#71](https://github.com/ulrik-s/ava/issues/71), [#82](https://github.com/ulrik-s/ava/issues/82)
+
+## Kontext
+
+`paymentPlan.scanDueReminders` (förfallo-/förseningspåminnelser) finns och är
+testad men kördes bara manuellt (#71 gav en knapp). Vi vill att schemalagda
+regler körs **automatiskt** på servern. Problemet i local-first: det finns
+ingen server-cron och ingen dataägande server — bara git-peers (ADR 0005).
+
+Frågan har väntat på "den vilande regelmotorn" (scheduler-tick + event-dispatch).
+Nu när server-runtime:n (#77/#81) + dess konflikt-säkra peer-loop + PeerAct-
+mönstret (Fortnox #82) finns, kan vi besvara den utan ny infrastruktur.
+
+## Beslut
+
+**Regelmotorn = idempotenta regler som körs som en `PeerAct` på server-runtime:ns
+peer-tick.** Ingen separat scheduler, ingen separat event-buss.
+
+- **Schemaläggning = peer-tick:en.** Loopen tickar redan periodiskt (#81). Varje
+  tick kör regel-acten mot working-copy:ns tRPC-caller.
+- **Idempotens i stället för schemaläggnings-state.** Reglerna skapar varje
+  effekt högst en gång (t.ex. `scanDueReminders` nycklar påminnelser på
+  plan+månad+typ). Att köra varje tick är därför säkert; cadensen blir naturligt
+  "en gång per förfallomånad" utan att persistera "senast körd". Detta speglar
+  konflikt-säkerheten i ADR 0002 (additivt + nyckel-baserat).
+- **No-empty-commit-grind.** `runPeerCycle` committar/pushar nu bara om
+  `git status` visar ändringar (`NodeGitOps.hasChanges()`). En alltid-på regel
+  utan nya effekter ger alltså inga tomma commits varje tick (returnerar
+  `{ noop: true }`). Gäller även Fortnox-connectorn.
+- **Flera regler/connectors i samma cykel.** `composeJobs([...])` kör flera
+  `PeerJob`-`act`:er i sekvens mot samma caller → en commit per tick som
+  innehåller summan (regelmotor + Fortnox + framtida). Ej-konfigurerade jobb
+  (null) filtreras bort.
+- **Event-dispatch = befintliga emits.** Reglerna anropar routrar som redan
+  emit:ar domänhändelser (`scanDueReminders` → `paymentDue`/`paymentOverdue`
+  via den skrivbara event-loggen). Ingen separat dispatch behövs.
+
+Regelmotorn är **alltid på** när server-runtime:n körs (kärnfunktion, ej
+integrations-gated som Fortnox).
+
+## Konsekvenser
+
+- **+** Noll ny infrastruktur — återanvänder peer-loop + PeerAct + emits.
+- **+** Robust mot omkörning/konflikt (idempotent + ADR 0002).
+- **+** No-empty-commit-grinden gör en hög-frekvent tick ofarlig (ingen
+  commit-spam) och förbättrar även Fortnox-connectorn.
+- **+** Utbyggbart: nya regler = utöka `runRules`; nya connectors = `composeJobs`.
+- **−** Cadensen är knuten till tick-intervallet (default 15 s) snarare än en
+  cron-spec. För regler som MÅSTE köra på en exakt tid (ej fallet för
+  påminnelser) behövs framtida tid-grindning i regeln själv.
+- **−** Regler delar en commit per tick → blandade ändringar i en commit. OK
+  givet additiv modell; kan delas upp per regel senare om spårbarhet kräver.
+
+## Alternativ (förkastade)
+
+- **Separat scheduler-tjänst/cron** — ny alltid-på-komponent, bryter "tunn
+  server" + saknar plats i local-first (ingen dataägare). Nej.
+- **Browser-open-job** (#71-alternativet) — kräver att job-queue-worker:n wiras
+  och att en flik är öppen; opålitligt för tidskänsliga påminnelser. Behålls som
+  komplement (manuell knapp finns), ej primär väg.
+- **Persistera "senast körd"-state** — onödigt när reglerna är idempotenta;
+  undviker en state-fil som ändå skulle nollställas av `resetHardToRemote`.

--- a/src/bin/server-runtime.ts
+++ b/src/bin/server-runtime.ts
@@ -18,6 +18,8 @@
 import { ENV_KEYS, loadRuntimeConfig } from "@/lib/server/local-first/server-runtime-config";
 import { startServerRuntime } from "@/lib/server/local-first/server-runtime";
 import { buildFortnoxJob } from "@/lib/server/integrations/fortnox/runtime";
+import { makeRulesJob } from "@/lib/server/local-first/rules-job";
+import { composeJobs } from "@/lib/server/local-first/compose-jobs";
 
 const HELP = `ava server-runtime (ADR 0005 fas 1)
 
@@ -54,9 +56,12 @@ async function main(): Promise<void> {
   }
 
   const config = loadRuntimeConfig();
-  // Fortnox-connector (#82): aktiveras bara när byrån anslutit Fortnox (valv +
-  // tokens). Annars null → loopen kör i sync-läge precis som förut.
-  const job = await buildFortnoxJob({ workDir: config.workDir });
+  // Regelmotor (#80): alltid på — schemalagda idempotenta regler (påminnelser).
+  // Fortnox-connector (#82): bara när byrån anslutit Fortnox (valv + tokens).
+  // composeJobs kör båda i samma cykel; no-empty-commit-grinden (#80) ser till
+  // att tomma tick:ar inte pushar.
+  const fortnox = await buildFortnoxJob({ workDir: config.workDir });
+  const job = composeJobs([makeRulesJob({ log }), fortnox]);
   const loop = await startServerRuntime(config, job ? { job } : {});
 
   if (argv.includes("--once")) {

--- a/src/lib/server/local-first/compose-jobs.ts
+++ b/src/lib/server/local-first/compose-jobs.ts
@@ -1,0 +1,25 @@
+/**
+ * Kombinera flera `PeerJob` till ETT (#80).
+ *
+ * PeerLoop kör ett enda `job` per tick. Server-runtime:n vill köra flera
+ * connectors/regler (regelmotor #80 + Fortnox #82 + framtida): vi kör deras
+ * `act`:er i sekvens mot samma caller, så alla mutationer hamnar i SAMMA
+ * commit/cykel (och no-empty-commit-grinden i runPeerCycle gäller summan).
+ * Ordningen bevaras; `null`/`undefined` (ej konfigurerade jobb) filtreras bort.
+ */
+
+import type { PeerJob } from "./peer-loop";
+import type { PeerAct } from "./server-peer";
+
+export function composeJobs(jobs: ReadonlyArray<PeerJob | null | undefined>): PeerJob | null {
+  const active = jobs.filter((j): j is PeerJob => Boolean(j));
+  if (active.length === 0) return null;
+  if (active.length === 1) return active[0]!;
+
+  const act: PeerAct = async (caller) => {
+    for (const job of active) {
+      await job.act(caller);
+    }
+  };
+  return { act, message: active.map((j) => j.message).join("; ") };
+}

--- a/src/lib/server/local-first/node-git-ops.ts
+++ b/src/lib/server/local-first/node-git-ops.ts
@@ -106,6 +106,17 @@ export class NodeGitOps implements IGitOps {
     return stdout.split("\n").map((s) => s.trim()).filter(Boolean);
   }
 
+  /**
+   * True om working-tree:t har ändringar att committa (`git status --porcelain`
+   * icke-tomt). Peer-cykeln använder detta för att hoppa över tomma commits när
+   * en connector/regel inte producerade något (#80) — annars skulle en
+   * alltid-på regelmotor pusha en tom commit varje tick.
+   */
+  async hasChanges(): Promise<boolean> {
+    const { stdout } = await this.run(["status", "--porcelain"]);
+    return stdout.trim().length > 0;
+  }
+
   // ── private ───────────────────────────────────────────────────
 
   private async run(args: string[]): Promise<{ stdout: string; stderr: string }> {

--- a/src/lib/server/local-first/peer-loop.ts
+++ b/src/lib/server/local-first/peer-loop.ts
@@ -111,7 +111,13 @@ export class PeerLoop {
     try {
       if (job) {
         const result = await this.runCycle(dir, job.act, job.message, cycleOpts);
-        this.log(result.pushed ? `pushade (${result.attempts} försök)` : `push misslyckades: ${result.reason ?? "okänt"}`);
+        this.log(
+          result.pushed
+            ? `pushade (${result.attempts} försök)`
+            : result.noop
+              ? "inga ändringar (noop)"
+              : `push misslyckades: ${result.reason ?? "okänt"}`,
+        );
         return { mode: "cycle", result };
       }
       await this.syncOnce(dir, cycleOpts);

--- a/src/lib/server/local-first/rules-job.ts
+++ b/src/lib/server/local-first/rules-job.ts
@@ -1,0 +1,43 @@
+/**
+ * Regelmotor-job (#80, ADR 0010) — schemalagda regler som en `PeerAct`.
+ *
+ * Designen återanvänder server-runtime:ns peer-loop (#81): varje tick kör
+ * regel-acten mot working-copy:ns tRPC-caller, och peer-cykeln committar +
+ * pushar ENDAST om något faktiskt skapades (no-empty-commit-grinden, #80).
+ * Reglerna måste vara **idempotenta** — `paymentPlan.scanDueReminders` skapar
+ * varje påminnelse (nyckel: plan+månad+typ) högst en gång, så att köra den
+ * varje tick är säkert; cadensen blir naturligt "en gång per förfallomånad"
+ * utan separat schemaläggnings-state.
+ *
+ * Fler regler läggs till genom att utöka `runRules` (alla idempotenta).
+ */
+
+import type { PeerJob } from "./peer-loop";
+
+/** Delmängd av tRPC-callern regelmotorn använder. */
+export interface RulesJobCaller {
+  paymentPlan: {
+    scanDueReminders: (input: Record<string, never>) => Promise<{ planned?: number } | unknown>;
+  };
+}
+
+export interface RulesJobDeps {
+  log?: (msg: string) => void;
+}
+
+/** Kör alla schemalagda (idempotenta) regler en gång. */
+export async function runRules(caller: RulesJobCaller, deps: RulesJobDeps = {}): Promise<void> {
+  const res = (await caller.paymentPlan.scanDueReminders({})) as { planned?: number };
+  const planned = res?.planned ?? 0;
+  if (planned && deps.log) deps.log(`Regelmotor: ${planned} påminnelser skapade`);
+}
+
+/** Paketera regelmotorn som ett `PeerJob` för server-runtime:ns peer-loop. */
+export function makeRulesJob(deps: RulesJobDeps = {}): PeerJob {
+  return {
+    message: "chore(rules): schemalagda regler (påminnelser)",
+    act: async (caller) => {
+      await runRules(caller as unknown as RulesJobCaller, deps);
+    },
+  };
+}

--- a/src/lib/server/local-first/server-peer.ts
+++ b/src/lib/server/local-first/server-peer.ts
@@ -67,6 +67,8 @@ export interface PeerCycleResult {
   commit?: GitCommit;
   /** Anledning vid misslyckande (sista pushens reason). */
   reason?: PushResult["reason"];
+  /** `act` producerade inga ändringar → ingen commit/push gjordes (#80). */
+  noop?: boolean;
 }
 
 /**
@@ -83,6 +85,12 @@ export interface PeerCycleResult {
  * `act` MÅSTE vara idempotent/additiv (nyckla mot entitets-id) så en omkörning
  * efter konflikt inte dubblerar — det är konflikt-säkerheten (ADR 0002).
  */
+/** Bygg NodeGitOps ur opts (författare/remote/branch-defaults). */
+function gitOpsFor(dir: string, opts: RunPeerCycleOpts): NodeGitOps {
+  const author = opts.author ?? { name: opts.principal.name, email: opts.principal.email };
+  return new NodeGitOps(dir, author.name, author.email, opts.remote ?? "origin", opts.branch ?? "main");
+}
+
 export async function runPeerCycle(
   dir: string,
   act: PeerAct,
@@ -90,8 +98,7 @@ export async function runPeerCycle(
   opts: RunPeerCycleOpts,
 ): Promise<PeerCycleResult> {
   const maxRetries = opts.maxRetries ?? 3;
-  const author = opts.author ?? { name: opts.principal.name, email: opts.principal.email };
-  const gitOps = new NodeGitOps(dir, author.name, author.email, opts.remote ?? "origin", opts.branch ?? "main");
+  const gitOps = gitOpsFor(dir, opts);
 
   let reason: PushResult["reason"];
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
@@ -102,6 +109,12 @@ export async function runPeerCycle(
     // Färsk hydrering ovanpå senaste remote → act → commit.
     const wc = await openServerWorkingCopy(dir, opts);
     await act(wc.caller);
+
+    // Inga ändringar (t.ex. en alltid-på regelmotor utan nya påminnelser) →
+    // hoppa över commit + push så vi inte spammar tomma commits varje tick (#80).
+    if (!(await gitOps.hasChanges())) {
+      return { pushed: false, attempts: attempt, noop: true };
+    }
     const commit = await wc.commit(message);
 
     const result = await gitOps.push();

--- a/test/unit/server/local-first/compose-jobs.test.ts
+++ b/test/unit/server/local-first/compose-jobs.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest-compat";
+import { composeJobs } from "@/lib/server/local-first/compose-jobs";
+import type { PeerJob } from "@/lib/server/local-first/peer-loop";
+
+function fakeJob(message: string, order: string[]): PeerJob {
+  return { message, act: async () => { order.push(message); } };
+}
+
+describe("composeJobs", () => {
+  it("tom lista → null", () => {
+    expect(composeJobs([])).toBeNull();
+    expect(composeJobs([null, undefined])).toBeNull();
+  });
+
+  it("ett jobb → returneras oförändrat", () => {
+    const order: string[] = [];
+    const j = fakeJob("a", order);
+    expect(composeJobs([j])).toBe(j);
+    expect(composeJobs([null, j, undefined])).toBe(j);
+  });
+
+  it("flera jobb → kör act:er i ordning + slår ihop message", async () => {
+    const order: string[] = [];
+    const composed = composeJobs([fakeJob("rules", order), fakeJob("fortnox", order)]);
+    expect(composed).not.toBeNull();
+    expect(composed!.message).toBe("rules; fortnox");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await composed!.act({} as any);
+    expect(order).toEqual(["rules", "fortnox"]);
+  });
+
+  it("filtrerar bort null/undefined men behåller ordning", async () => {
+    const order: string[] = [];
+    const composed = composeJobs([null, fakeJob("rules", order), undefined, fakeJob("fortnox", order)]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await composed!.act({} as any);
+    expect(order).toEqual(["rules", "fortnox"]);
+  });
+});

--- a/test/unit/server/local-first/rules-job.test.ts
+++ b/test/unit/server/local-first/rules-job.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from "vitest-compat";
+import { runRules, makeRulesJob, type RulesJobCaller } from "@/lib/server/local-first/rules-job";
+
+function makeCaller(result: { planned?: number } = {}) {
+  const scan = vi.fn(async () => result);
+  const caller: RulesJobCaller = { paymentPlan: { scanDueReminders: scan } };
+  return { caller, scan };
+}
+
+describe("runRules", () => {
+  it("kör scanDueReminders med {}", async () => {
+    const { caller, scan } = makeCaller({ planned: 0 });
+    await runRules(caller);
+    expect(scan).toHaveBeenCalledWith({});
+  });
+
+  it("loggar när påminnelser skapades", async () => {
+    const { caller } = makeCaller({ planned: 3 });
+    const log = vi.fn();
+    await runRules(caller, { log });
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("3"));
+  });
+
+  it("loggar inte vid noll planerade", async () => {
+    const { caller } = makeCaller({ planned: 0 });
+    const log = vi.fn();
+    await runRules(caller, { log });
+    expect(log).not.toHaveBeenCalled();
+  });
+});
+
+describe("makeRulesJob", () => {
+  it("returnerar ett PeerJob vars act kör reglerna", async () => {
+    const { caller, scan } = makeCaller({ planned: 1 });
+    const job = makeRulesJob();
+    expect(job.message).toMatch(/regler/i);
+    await job.act(caller as unknown as Parameters<typeof job.act>[0]);
+    expect(scan).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/server/local-first/server-peer.test.ts
+++ b/test/unit/server/local-first/server-peer.test.ts
@@ -102,6 +102,20 @@ suite("server-peer — klona + pull→act→push (#117)", () => {
     expect(await remoteFiles("contacts")).toContain("c-happy.json");
   });
 
+  it("no-op: act utan ändringar → ingen commit/push (noop) (#80)", async () => {
+    const headBefore = execSync(`git -C "${bare}" rev-parse main`).toString().trim();
+    const res = await runPeerCycle(
+      peerDir,
+      async () => { /* en regel-tick utan nya effekter */ },
+      "chore: tom regel-tick",
+      { principal: ADMIN },
+    );
+    expect(res.noop).toBe(true);
+    expect(res.pushed).toBe(false);
+    // Remote-HEAD oförändrad → ingen tom commit pushad.
+    expect(execSync(`git -C "${bare}" rev-parse main`).toString().trim()).toBe(headBefore);
+  });
+
   it("konflikt-säkert: konkurrent-push mellan reset och push → retry + additivt resultat", async () => {
     let raced = false;
     const res = await runPeerCycle(


### PR DESCRIPTION
## Vad
#80 (**ADR 0010**): schemalagda regler körs **automatiskt** på server-runtime:ns peer-tick — ingen separat scheduler/cron (finns ingen plats i local-first). Kompletterar #71:s manuella knapp med den automatiska vägen.

- **`rules-job.ts`** — `makeRulesJob()` PeerAct som kör `paymentPlan.scanDueReminders` varje tick. **Idempotent** (påminnelser nyckel-baserade plan+månad+typ) → säkert att köra ofta; cadens blir naturligt en gång/förfallomånad utan schemaläggnings-state. Alltid på (kärnfunktion).
- **`compose-jobs.ts`** — `composeJobs([...])` kör flera PeerActs (regelmotor + Fortnox #82 + framtida) i sekvens i **samma** cykel/commit.
- **no-empty-commit-grind** — `NodeGitOps.hasChanges()` + `runPeerCycle` hoppar commit/push när inget ändrats (`{ noop: true }`). Annars skulle en alltid-på regel spamma tomma commits varje tick. Gäller även Fortnox-connectorn.
- **bin** — regelmotor (alltid) + Fortnox (om konfigurerad), `composeJobs`:ade.
- **ADR 0010** dokumenterar designen + förkastade alternativ (cron-tjänst, browser-job, persisterad state).

## Test
`bun run test:all --no-e2e` ✓ — static (typecheck + complexity@8 + knip + deps + jscpd) + tester + coverage-golv. Nya: `runRules`/`makeRulesJob`, `composeJobs` (ordning/filtrering/message), realgit **no-op-cykel** (remote-HEAD oförändrad).

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)