### PR TITLE
refactor(billing): renodla semantisk verifikat-modell från Fortnox-rendering

### DIFF
--- a/src/lib/server/integrations/fortnox/voucher.ts
+++ b/src/lib/server/integrations/fortnox/voucher.ts
@@ -1,29 +1,26 @@
 /**
- * Bygg ett Fortnox-verifikat (voucher) från en AVA-kundfaktura (#82).
+ * Fortnox-renderare för det semantiska verifikatet (#82, #235, ADR 0011).
  *
- * Standard kundfaktura (brutto, inkl moms) → balanserat verifikat:
- *   Debet  kundfordran      = brutto
- *   Kredit intäkt (arvode)  = netto (exkl moms)
- *   Kredit utgående moms     = moms
- *
- * Kreditfaktura (negativt belopp) vänder debet/kredit. Balans GARANTERAS
- * genom att moms räknas som brutto − netto (ingen avrundnings-glipa).
- *
- * Belopp i AVA är öre (heltal); Fortnox vill ha kronor (SEK med 2 decimaler).
- * Endast en VAT-sats i taget (default 25 %); flersats-/utläggs-uppdelning
- * läggs till när vi kopplar in fakturarader (uppföljning).
+ * Domänen bygger ett systemoberoende verifikat mot ROLLER
+ * ([[semantic-voucher]]). Den här filen är Fortnox-connectorns renderare:
+ * den översätter roll→kontonummer (via byråns konto-mappning) och öre→SEK,
+ * och paketerar Fortnox Voucher-JSON. Inget moms-/balans-resonemang sker här
+ * — det äger domänmodellen. Samma semantiska modell ger gratis SIE-export
+ * och andra renderare (uppföljning på #233).
  */
 
-import { splitVat, type VatRate } from "@/lib/shared/vat";
+import {
+  buildSemanticVoucher,
+  type SemanticVoucher,
+  type SemanticVoucherInput,
+  type SemanticVoucherRow,
+  type VoucherRole,
+} from "@/lib/shared/accounting/semantic-voucher";
+import type { VatRate } from "@/lib/shared/vat";
 import type { FortnoxKontoMappning, FortnoxVoucher, FortnoxVoucherRow } from "./schema";
 
-/** Minsta fält connectorn behöver — frikopplat från hela Invoice-schemat. */
-export interface InvoiceForVoucher {
-  /** Brutto i öre (negativt = kreditfaktura). */
-  amount: number;
-  invoiceDate: Date | string;
-  invoiceNumber?: string | null;
-}
+/** Re-export: connectorn (invoice-job) jobbar mot samma input-typ som domänen. */
+export type InvoiceForVoucher = SemanticVoucherInput;
 
 function pad2(n: number): string {
   return String(n).padStart(2, "0");
@@ -40,34 +37,47 @@ function oreToSek(ore: number): number {
   return ore / 100;
 }
 
-function row(account: string, sekAmount: number, debit: boolean): FortnoxVoucherRow {
+/** Roll → Fortnox-kontonummer via byråns mappning. Kastar om rollen är omappad. */
+function accountForRole(role: VoucherRole, mapping: FortnoxKontoMappning): string {
+  switch (role) {
+    case "kundfordran":
+      return mapping.kundfordran;
+    case "intaktArvode":
+      return mapping.intaktArvode;
+    case "momsUtgaende":
+      return mapping.momsUtgaende;
+    case "intaktUtlagg":
+      if (!mapping.intaktUtlagg) throw new Error("Rollen 'intaktUtlagg' saknar kontomappning");
+      return mapping.intaktUtlagg;
+  }
+}
+
+function renderRow(row: SemanticVoucherRow, mapping: FortnoxKontoMappning): FortnoxVoucherRow {
   return {
-    Account: Number(account),
-    Debit: debit ? sekAmount : 0,
-    Credit: debit ? 0 : sekAmount,
+    Account: Number(accountForRole(row.role, mapping)),
+    Debit: oreToSek(row.debit),
+    Credit: oreToSek(row.credit),
   };
 }
 
+/** Rendera ett färdigt semantiskt verifikat till Fortnox Voucher-JSON. */
+export function renderFortnoxVoucher(
+  voucher: SemanticVoucher,
+  mapping: FortnoxKontoMappning,
+): FortnoxVoucher {
+  return {
+    VoucherSeries: mapping.voucherSeries,
+    TransactionDate: isoDate(voucher.date),
+    Description: voucher.description,
+    VoucherRows: voucher.rows.map((r) => renderRow(r, mapping)),
+  };
+}
+
+/** Bekvämlighet: bygg semantiskt verifikat ur fakturan och rendera direkt. */
 export function buildVoucherFromInvoice(
   invoice: InvoiceForVoucher,
   mapping: FortnoxKontoMappning,
   vatRate: VatRate = 2500,
 ): FortnoxVoucher {
-  const bruttoOre = Math.abs(invoice.amount);
-  const { exclVat } = splitVat({ amount: bruttoOre, vatRate, vatIncluded: true });
-  const momsOre = bruttoOre - exclVat; // balans-säker rest
-  const kundfordranIsDebit = invoice.amount >= 0; // kreditfaktura vänder
-
-  const rows = [
-    row(mapping.kundfordran, oreToSek(bruttoOre), kundfordranIsDebit),
-    row(mapping.intaktArvode, oreToSek(exclVat), !kundfordranIsDebit),
-    row(mapping.momsUtgaende, oreToSek(momsOre), !kundfordranIsDebit),
-  ].filter((r) => r.Debit > 0 || r.Credit > 0); // släng 0-rader (t.ex. moms vid 0 %)
-
-  return {
-    VoucherSeries: mapping.voucherSeries,
-    TransactionDate: isoDate(invoice.invoiceDate),
-    Description: invoice.invoiceNumber ? `Faktura ${invoice.invoiceNumber}` : "Kundfaktura (AVA)",
-    VoucherRows: rows,
-  };
+  return renderFortnoxVoucher(buildSemanticVoucher(invoice, vatRate), mapping);
 }

--- a/src/lib/shared/accounting/semantic-voucher.ts
+++ b/src/lib/shared/accounting/semantic-voucher.ts
@@ -1,0 +1,83 @@
+/**
+ * Semantiskt verifikat (domänmodell) — systemoberoende (#235, ADR 0011).
+ *
+ * En kundfaktura blir ett balanserat verifikat mot SEMANTISKA ROLLER, inte
+ * mot kontonummer. Roll→konto är ett renderar-beslut (Fortnox-connectorn,
+ * SIE-export, …) och hör INTE hemma här. Den här modellen vet alltså inget
+ * om Fortnox, kontoplaner eller verifikatserier.
+ *
+ * Standard kundfaktura (brutto, inkl moms) → balanserat verifikat:
+ *   Debet  kundfordran      = brutto
+ *   Kredit intäkt (arvode)  = netto (exkl moms)
+ *   Kredit utgående moms     = moms
+ *
+ * Kreditfaktura (negativt belopp) vänder debet/kredit. Balans GARANTERAS
+ * genom att moms räknas som brutto − netto (ingen avrundnings-glipa), så
+ * invarianten Σdebet == Σkredit == |fakturabelopp| alltid håller.
+ *
+ * Alla belopp är i ÖRE (heltal) — precis som i resten av domänen. Öre→SEK
+ * (eller annan presentation) sker först i renderaren.
+ */
+
+import { splitVat, type VatRate } from "@/lib/shared/vat";
+
+/** Bokföringsroller som faktura-domänen känner till (systemoberoende). */
+export type VoucherRole = "kundfordran" | "intaktArvode" | "momsUtgaende" | "intaktUtlagg";
+
+/** En verifikatrad mot en roll. Exakt EN av debit/credit > 0 (öre, heltal). */
+export interface SemanticVoucherRow {
+  role: VoucherRole;
+  /** Debet i öre. */
+  debit: number;
+  /** Kredit i öre. */
+  credit: number;
+}
+
+/** Ett balanserat verifikat uttryckt i roller + öre. Inget systemberoende. */
+export interface SemanticVoucher {
+  /** Bokföringsdatum (domändatum — renderaren formaterar). */
+  date: Date | string;
+  /** Verifikat-beskrivning (människoläsbar). */
+  description: string;
+  /** Balanserade rader (Σdebit == Σcredit i öre). */
+  rows: SemanticVoucherRow[];
+}
+
+/** Minsta fält som behövs för att bygga ett verifikat — frikopplat från Invoice. */
+export interface SemanticVoucherInput {
+  /** Brutto i öre (negativt = kreditfaktura). */
+  amount: number;
+  invoiceDate: Date | string;
+  invoiceNumber?: string | null;
+}
+
+function semanticRow(role: VoucherRole, ore: number, debit: boolean): SemanticVoucherRow {
+  return { role, debit: debit ? ore : 0, credit: debit ? 0 : ore };
+}
+
+/**
+ * Bygg ett semantiskt verifikat ur en kundfaktura. Ren funktion, noll I/O.
+ * Endast en VAT-sats i taget (default 25 %); flersats-/utläggs-uppdelning
+ * läggs till när fakturarader kopplas in (uppföljning på #233).
+ */
+export function buildSemanticVoucher(
+  invoice: SemanticVoucherInput,
+  vatRate: VatRate = 2500,
+): SemanticVoucher {
+  const bruttoOre = Math.abs(invoice.amount);
+  const { exclVat } = splitVat({ amount: bruttoOre, vatRate, vatIncluded: true });
+  const momsOre = bruttoOre - exclVat; // balans-säker rest
+  const kundfordranIsDebit = invoice.amount >= 0; // kreditfaktura vänder
+
+  const rows = [
+    semanticRow("kundfordran", bruttoOre, kundfordranIsDebit),
+    semanticRow("intaktArvode", exclVat, !kundfordranIsDebit),
+    semanticRow("momsUtgaende", momsOre, !kundfordranIsDebit),
+  ].filter((r) => r.debit > 0 || r.credit > 0); // släng 0-rader (t.ex. moms vid 0 %)
+
+  return {
+    date: invoice.invoiceDate,
+    description: invoice.invoiceNumber ? `Faktura ${invoice.invoiceNumber}` : "Kundfaktura (AVA)",
+    rows,
+  };
+}

--- a/test/unit/server/integrations/fortnox/voucher.test.ts
+++ b/test/unit/server/integrations/fortnox/voucher.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest-compat";
-import { buildVoucherFromInvoice } from "@/lib/server/integrations/fortnox/voucher";
+import { buildVoucherFromInvoice, renderFortnoxVoucher } from "@/lib/server/integrations/fortnox/voucher";
 import type { FortnoxKontoMappning } from "@/lib/server/integrations/fortnox/schema";
+import type { SemanticVoucher } from "@/lib/shared/accounting/semantic-voucher";
 
 const mapping: FortnoxKontoMappning = {
   voucherSeries: "A",
@@ -62,5 +63,32 @@ describe("buildVoucherFromInvoice", () => {
     const v = buildVoucherFromInvoice({ amount: 10_001, invoiceDate: "2026-03-03" }, mapping);
     expect(sum(v.VoucherRows, "Debit")).toBeCloseTo(sum(v.VoucherRows, "Credit"), 10);
     expect(sum(v.VoucherRows, "Debit")).toBeCloseTo(100.01, 10);
+  });
+});
+
+describe("renderFortnoxVoucher", () => {
+  it("renderar utläggs-rollen mot mappning.intaktUtlagg (öre→SEK)", () => {
+    const semantic: SemanticVoucher = {
+      date: "2026-04-01",
+      description: "Faktura med utlägg",
+      rows: [
+        { role: "kundfordran", debit: 5_000, credit: 0 },
+        { role: "intaktUtlagg", debit: 0, credit: 5_000 },
+      ],
+    };
+    const v = renderFortnoxVoucher(semantic, { ...mapping, intaktUtlagg: "3590" });
+    expect(v.Description).toBe("Faktura med utlägg");
+    const byAcct = (n: number) => v.VoucherRows.find((r) => r.Account === n)!;
+    expect(byAcct(1510)).toMatchObject({ Debit: 50, Credit: 0 });
+    expect(byAcct(3590)).toMatchObject({ Debit: 0, Credit: 50 });
+  });
+
+  it("kastar om utläggs-rollen används utan kontomappning", () => {
+    const semantic: SemanticVoucher = {
+      date: "2026-04-01",
+      description: "Saknar utläggskonto",
+      rows: [{ role: "intaktUtlagg", debit: 0, credit: 5_000 }],
+    };
+    expect(() => renderFortnoxVoucher(semantic, mapping)).toThrow(/intaktUtlagg/);
   });
 });

--- a/test/unit/shared/accounting/semantic-voucher.test.ts
+++ b/test/unit/shared/accounting/semantic-voucher.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest-compat";
+import {
+  buildSemanticVoucher,
+  type SemanticVoucherRow,
+  type VoucherRole,
+} from "@/lib/shared/accounting/semantic-voucher";
+
+const sum = (rows: SemanticVoucherRow[], k: "debit" | "credit") =>
+  rows.reduce((s, r) => s + r[k], 0);
+
+const byRole = (rows: SemanticVoucherRow[], role: VoucherRole) =>
+  rows.find((r) => r.role === role)!;
+
+describe("buildSemanticVoucher", () => {
+  it("standardfaktura: 3 roll-rader, balanserat i öre (debet kundfordran = kredit intäkt+moms)", () => {
+    // 12500 öre brutto inkl 25 % moms → 10000 öre netto + 2500 öre moms.
+    const v = buildSemanticVoucher({
+      amount: 12_500,
+      invoiceDate: "2026-05-25",
+      invoiceNumber: "F-2026-0042",
+    });
+    expect(v.date).toBe("2026-05-25");
+    expect(v.description).toBe("Faktura F-2026-0042");
+    expect(v.rows).toHaveLength(3);
+
+    expect(byRole(v.rows, "kundfordran")).toEqual({ role: "kundfordran", debit: 12_500, credit: 0 });
+    expect(byRole(v.rows, "intaktArvode")).toEqual({ role: "intaktArvode", debit: 0, credit: 10_000 });
+    expect(byRole(v.rows, "momsUtgaende")).toEqual({ role: "momsUtgaende", debit: 0, credit: 2_500 });
+
+    // Invariant: Σdebet == Σkredit == |belopp|
+    expect(sum(v.rows, "debit")).toBe(sum(v.rows, "credit"));
+    expect(sum(v.rows, "debit")).toBe(12_500);
+  });
+
+  it("kreditfaktura (negativt belopp) vänder debet/kredit men håller balans", () => {
+    const v = buildSemanticVoucher({
+      amount: -12_500,
+      invoiceDate: new Date("2026-05-25T10:00:00Z"),
+      invoiceNumber: "K-2026-0001",
+    });
+    expect(byRole(v.rows, "kundfordran")).toEqual({ role: "kundfordran", debit: 0, credit: 12_500 });
+    expect(byRole(v.rows, "intaktArvode")).toEqual({ role: "intaktArvode", debit: 10_000, credit: 0 });
+    expect(byRole(v.rows, "momsUtgaende")).toEqual({ role: "momsUtgaende", debit: 2_500, credit: 0 });
+    expect(sum(v.rows, "debit")).toBe(sum(v.rows, "credit"));
+  });
+
+  it("0 % moms: moms-raden släpps (2 rader kvar, fortf. balanserat)", () => {
+    const v = buildSemanticVoucher({ amount: 10_000, invoiceDate: "2026-01-01" }, 0);
+    expect(v.rows).toHaveLength(2);
+    expect(v.rows.some((r) => r.role === "momsUtgaende")).toBe(false);
+    expect(sum(v.rows, "debit")).toBe(sum(v.rows, "credit"));
+    expect(v.description).toBe("Kundfaktura (AVA)"); // saknar invoiceNumber
+  });
+
+  it("balans håller i öre även för 'sneda' belopp (öre-rest hamnar i moms)", () => {
+    const v = buildSemanticVoucher({ amount: 10_001, invoiceDate: "2026-03-03" });
+    expect(sum(v.rows, "debit")).toBe(sum(v.rows, "credit"));
+    expect(sum(v.rows, "debit")).toBe(10_001);
+    // momsen är resten brutto − netto → ingen avrundnings-glipa
+    expect(byRole(v.rows, "momsUtgaende").credit).toBe(10_001 - byRole(v.rows, "intaktArvode").credit);
+  });
+
+  it("varje rad har exakt en sida > 0 (ren debet ELLER kredit)", () => {
+    const v = buildSemanticVoucher({ amount: 12_500, invoiceDate: "2026-05-25" });
+    for (const r of v.rows) {
+      expect((r.debit > 0 ? 1 : 0) + (r.credit > 0 ? 1 : 0)).toBe(1);
+    }
+  });
+});


### PR DESCRIPTION
Del av #233 (ADR 0011). Splittrar verifikat-byggandet i två lager så fakturamodulen blir systemoberoende.

## Vad
1. **Semantisk verifikat-modell** (`src/lib/shared/accounting/semantic-voucher.ts`) — domän, systemoberoende. `buildSemanticVoucher` bygger ett balanserat verifikat mot ROLLER (`kundfordran`/`intaktArvode`/`momsUtgaende`/`intaktUtlagg`) i öre, noll connector-beroende. Invarianten **Σdebet == Σkredit == |belopp|** bevaras (moms = brutto − netto), kreditfaktura vänder sidan, 0 %-moms släpper moms-raden.
2. **Fortnox-renderare** (`integrations/fortnox/voucher.ts`) — tunn connector-renderare: roll→kontonummer (konto-mappning) + öre→SEK + Fortnox Voucher-JSON. Ny export `renderFortnoxVoucher`; `buildVoucherFromInvoice` behåller **oförändrad signatur + output** (invoice-job orört).

## Varför
Samma semantiska modell ger gratis SIE-export (#236) och andra renderare bakom `LedgerConnector`-porten (#234). Ren refaktorering — noll beteendeförändring i Fortnox-outputen.

## Test
- Nya enhetstester för domänmodellen (balans, kreditfaktura, 0 %-moms, sneda öre-belopp, ren debet/kredit-sida).
- Nya renderar-tester inkl. utläggs-rollen + dess kasta-gren.
- Befintliga `voucher.test.ts` oförändrade i beteende.
- Lokalt grönt: `quality:fast` (2509), `test:cov` (rader 83.29% / funk 80.09%, över golv), jscpd, dep-cruiser (0 violations), knip.

Refs #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)