### PR TITLE
feat(ledger): pluggbar connector-port + capability-modell + dep-cruiser-regel

### DIFF
--- a/src/lib/server/integrations/ledger/capabilities.ts
+++ b/src/lib/server/integrations/ledger/capabilities.ts
@@ -1,0 +1,61 @@
+/**
+ * Capability-helpers för `LedgerConnector` (#234, ADR 0011).
+ *
+ * Rena predikat som gat:ar UI och verifierar port-invarianten (en `true`-
+ * capability måste motsvaras av en implementerad metod). Inget I/O.
+ */
+
+import type { LedgerCapabilities, LedgerConnector } from "./port";
+
+/** Ingen connector ansluten → allt avstängt (default-läge, t.ex. demo-tier). */
+export const NO_CAPABILITIES: LedgerCapabilities = {
+  pushVoucher: false,
+  pushInvoice: false,
+  pullPayments: false,
+  exportSie: false,
+};
+
+/**
+ * Kan byrån bokföra fakturan i ledger-systemet? Gat:ar "Bokför i …"-knappen —
+ * sant om connectorn kan ta verifikat ELLER skapa faktura.
+ */
+export function canBookkeep(caps: LedgerCapabilities): boolean {
+  return caps.pushVoucher || caps.pushInvoice;
+}
+
+/** Kan byrån hämta inkomna betalningar? Gat:ar "Hämta betalningar". */
+export function canPullPayments(caps: LedgerCapabilities): boolean {
+  return caps.pullPayments;
+}
+
+/** Kan byrån exportera SIE? Gat:ar "Exportera SIE". */
+export function canExportSie(caps: LedgerCapabilities): boolean {
+  return caps.exportSie;
+}
+
+/** Map: capability-flagga → namnet på port-metoden som måste finnas. */
+const CAPABILITY_METHODS: Record<keyof LedgerCapabilities, keyof LedgerConnector> = {
+  pushVoucher: "pushVoucher",
+  pushInvoice: "pushInvoice",
+  pullPayments: "pullPayments",
+  exportSie: "exportSie",
+};
+
+/**
+ * Verifierar port-invarianten: varje `true`-capability har en implementerad
+ * metod, och ingen metod saknar motsvarande `true`-flagga. Kastar vid avvikelse
+ * — connectorer bör köra detta i sin egen konstruktion/test.
+ */
+export function assertConnectorMatchesCapabilities(connector: LedgerConnector): void {
+  const caps = connector.capabilities();
+  for (const cap of Object.keys(CAPABILITY_METHODS) as (keyof LedgerCapabilities)[]) {
+    const method = CAPABILITY_METHODS[cap];
+    const implemented = typeof connector[method] === "function";
+    if (caps[cap] && !implemented) {
+      throw new Error(`Connector "${connector.name}": capability ${cap}=true men metoden ${method} saknas`);
+    }
+    if (!caps[cap] && implemented) {
+      throw new Error(`Connector "${connector.name}": metoden ${method} finns men capability ${cap}=false`);
+    }
+  }
+}

--- a/src/lib/server/integrations/ledger/port.ts
+++ b/src/lib/server/integrations/ledger/port.ts
@@ -1,0 +1,133 @@
+/**
+ * `LedgerConnector` — pluggbar bokförings-/faktura-port (#234, ADR 0011).
+ *
+ * Faktura-domänen i AVA är SYSTEMOBEROENDE: den bygger semantiska verifikat
+ * mot roller ([[semantic-voucher]]), äger fakturanummer/PDF/domänlogik och
+ * vet inget om Fortnox, Visma, e-conomic eller SIE. Nedströms-bokföring och
+ * -export sker via DENNA port. Varje externt system blir EN connector som
+ * implementerar porten (Fortnox = den första, #82).
+ *
+ * Dep-cruiser (`invoice-domain-not-import-connector`) tvingar att
+ * faktura-domänen (`src/lib/shared` + billing-routrar) får importera porten
+ * men ALDRIG en connector (`integrations/<system>/`) — så fakturamodulen
+ * bevisligen är fristående.
+ *
+ * All inbound extern data (betalningar) parsas strikt med zod vid
+ * connector-gränsen per [[feedback-zod-strict-parsing]]; utbound DTO:er
+ * (verifikat/faktura) byggs internt och är rena TS-interfaces.
+ */
+
+import { z } from "zod";
+import type { SemanticVoucher } from "@/lib/shared/accounting/semantic-voucher";
+
+export type { SemanticVoucher } from "@/lib/shared/accounting/semantic-voucher";
+
+// ─── Capabilities ─────────────────────────────────────────────────────────
+
+/**
+ * Vad en connector KAN göra. Gat:ar både UI och vilka port-metoder som finns
+ * — en `true`-flagga MÅSTE motsvaras av en implementerad metod (invariant
+ * verifierad av `assertConnectorMatchesCapabilities`).
+ */
+export interface LedgerCapabilities {
+  /** Tar emot semantiska verifikat (bokföring nedströms via Voucher-API e.d.). */
+  pushVoucher: boolean;
+  /** Skapar faktura i ledger-systemet (egen nummerserie — samexistens-läget). */
+  pushInvoice: boolean;
+  /** Levererar inkomna kundbetalningar för avprickning (bankfil/camt/BGI). */
+  pullPayments: boolean;
+  /** Exporterar SIE-fil. */
+  exportSie: boolean;
+}
+
+// ─── Utbound DTO:er (byggs internt) ─────────────────────────────────────────
+
+/** Kontext för en verifikat-push (idempotens-nyckel + spårning). */
+export interface LedgerPushContext {
+  /** Idempotens-nyckel (t.ex. billingRunId) — connectorn får ej dubbel-bokföra. */
+  idempotencyKey: string;
+}
+
+/** Resultat av en verifikat-push — det vi behöver för idempotens/spårning. */
+export interface PushVoucherResult {
+  /** Externt verifikat-id (t.ex. Fortnox VoucherSeries+VoucherNumber). */
+  externalId: string;
+}
+
+/** Domän-faktura för `pushInvoice` (samexistens: faktura skapas i ledger-systemet). */
+export interface LedgerInvoice {
+  /** AVA:s fakturanummer (källan till sanning). */
+  invoiceNumber: string;
+  /** Bokföringsdatum. */
+  invoiceDate: Date | string;
+  /** Förfallodatum (om satt). */
+  dueDate?: Date | string;
+  /** Brutto i öre (negativt = kreditfaktura). */
+  amount: number;
+  /** Moms-sats i basis points (0/600/1200/2500). */
+  vatRate: number;
+  /** Kundens namn (för matchning/uppslag i ledger-systemet). */
+  customerName: string;
+}
+
+/** Resultat av en faktura-push. */
+export interface PushInvoiceResult {
+  /** Externt faktura-id i ledger-systemet. */
+  externalId: string;
+}
+
+// ─── Inbound DTO (parsas vid connector-gränsen) ─────────────────────────────
+
+/**
+ * En inkommen kundbetalning (för avprickning mot AVA-faktura). Vendor-neutral:
+ * samma form oavsett källa (camt.053/054, BGMAX, Fortnox invoicepayments).
+ * Connectorn parsar leverantörens format till denna DTO.
+ */
+export const ledgerPaymentSchema = z.object({
+  /** Connector-/källspecifikt id (idempotens vid upprepad pull). */
+  externalId: z.string().min(1),
+  /** Inbetalt belopp i öre (positivt). */
+  amount: z.number().int().positive(),
+  /** Bokföringsdatum `YYYY-MM-DD`. */
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  /** OCR-/betalningsreferens om angiven (mod-10) — primär matchningsnyckel. */
+  ocrReference: z.string().min(1).optional(),
+  /** Betalarens namn om angivet (heuristik-fallback). */
+  payerName: z.string().min(1).optional(),
+});
+export type LedgerPayment = z.infer<typeof ledgerPaymentSchema>;
+
+/** Fråga för `pullPayments` — hämta betalningar från och med ett datum. */
+export interface PullPaymentsQuery {
+  /** Hämta betalningar bokförda från och med detta datum (`YYYY-MM-DD`). */
+  since: string;
+}
+
+/** Datumintervall för SIE-export (`YYYY-MM-DD`). */
+export interface SieExportRange {
+  from: string;
+  to: string;
+}
+
+// ─── Porten ─────────────────────────────────────────────────────────────────
+
+/**
+ * En pluggbar bokförings-/faktura-connector. Frivilliga metoder motsvaras 1:1
+ * av `capabilities()`-flaggorna (se invarianten ovan). Server-runtime:ns
+ * PeerAct (#80/#82) driver synken mot DENNA port, aldrig mot en konkret
+ * leverantör.
+ */
+export interface LedgerConnector {
+  /** Stabil connector-identitet, t.ex. `"fortnox"`. */
+  readonly name: string;
+  /** Vad connectorn kan i den aktuella konfigurationen. */
+  capabilities(): LedgerCapabilities;
+  /** Bokför ett semantiskt verifikat. Finns omm `capabilities().pushVoucher`. */
+  pushVoucher?(voucher: SemanticVoucher, ctx: LedgerPushContext): Promise<PushVoucherResult>;
+  /** Skapar en faktura i ledger-systemet. Finns omm `capabilities().pushInvoice`. */
+  pushInvoice?(invoice: LedgerInvoice): Promise<PushInvoiceResult>;
+  /** Hämtar inkomna betalningar. Finns omm `capabilities().pullPayments`. */
+  pullPayments?(query: PullPaymentsQuery): Promise<LedgerPayment[]>;
+  /** Exporterar SIE-fil. Finns omm `capabilities().exportSie`. */
+  exportSie?(range: SieExportRange): Promise<string>;
+}

--- a/test/unit/server/integrations/ledger/capabilities.test.ts
+++ b/test/unit/server/integrations/ledger/capabilities.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest-compat";
+import {
+  NO_CAPABILITIES,
+  canBookkeep,
+  canPullPayments,
+  canExportSie,
+  assertConnectorMatchesCapabilities,
+} from "@/lib/server/integrations/ledger/capabilities";
+import {
+  ledgerPaymentSchema,
+  type LedgerCapabilities,
+  type LedgerConnector,
+} from "@/lib/server/integrations/ledger/port";
+
+const caps = (over: Partial<LedgerCapabilities> = {}): LedgerCapabilities => ({
+  ...NO_CAPABILITIES,
+  ...over,
+});
+
+describe("ledger capabilities-gating", () => {
+  it("NO_CAPABILITIES stänger allt (demo/ingen connector)", () => {
+    expect(canBookkeep(NO_CAPABILITIES)).toBe(false);
+    expect(canPullPayments(NO_CAPABILITIES)).toBe(false);
+    expect(canExportSie(NO_CAPABILITIES)).toBe(false);
+  });
+
+  it("canBookkeep sant vid pushVoucher ELLER pushInvoice", () => {
+    expect(canBookkeep(caps({ pushVoucher: true }))).toBe(true);
+    expect(canBookkeep(caps({ pushInvoice: true }))).toBe(true);
+    expect(canBookkeep(caps({ pullPayments: true }))).toBe(false);
+  });
+
+  it("canPullPayments / canExportSie speglar sin flagga", () => {
+    expect(canPullPayments(caps({ pullPayments: true }))).toBe(true);
+    expect(canExportSie(caps({ exportSie: true }))).toBe(true);
+    expect(canExportSie(caps({ pullPayments: true }))).toBe(false);
+  });
+});
+
+describe("assertConnectorMatchesCapabilities", () => {
+  it("accepterar en connector där flaggor och metoder matchar", () => {
+    const connector: LedgerConnector = {
+      name: "test-voucher-only",
+      capabilities: () => caps({ pushVoucher: true }),
+      pushVoucher: async () => ({ externalId: "A-1" }),
+    };
+    expect(() => assertConnectorMatchesCapabilities(connector)).not.toThrow();
+  });
+
+  it("accepterar en tom connector (allt false, inga metoder)", () => {
+    const connector: LedgerConnector = {
+      name: "noop",
+      capabilities: () => NO_CAPABILITIES,
+    };
+    expect(() => assertConnectorMatchesCapabilities(connector)).not.toThrow();
+  });
+
+  it("kastar när en true-capability saknar sin metod", () => {
+    const connector: LedgerConnector = {
+      name: "trasig",
+      capabilities: () => caps({ pullPayments: true }),
+      // pullPayments saknas
+    };
+    expect(() => assertConnectorMatchesCapabilities(connector)).toThrow(/pullPayments/);
+  });
+
+  it("kastar när en metod finns utan motsvarande true-capability", () => {
+    const connector: LedgerConnector = {
+      name: "odeklarerad",
+      capabilities: () => NO_CAPABILITIES,
+      exportSie: async () => "#FLAGGA",
+    };
+    expect(() => assertConnectorMatchesCapabilities(connector)).toThrow(/exportSie/);
+  });
+});
+
+describe("ledgerPaymentSchema (inbound, strikt)", () => {
+  it("godtar en giltig betalning med OCR-referens", () => {
+    const p = ledgerPaymentSchema.parse({
+      externalId: "camt-054-row-7",
+      amount: 12_500,
+      date: "2026-06-01",
+      ocrReference: "1234567890",
+    });
+    expect(p.amount).toBe(12_500);
+    expect(p.payerName).toBeUndefined();
+  });
+
+  it("avvisar negativt/icke-heltals-belopp och fel datumformat", () => {
+    expect(ledgerPaymentSchema.safeParse({ externalId: "x", amount: -1, date: "2026-06-01" }).success).toBe(false);
+    expect(ledgerPaymentSchema.safeParse({ externalId: "x", amount: 100.5, date: "2026-06-01" }).success).toBe(false);
+    expect(ledgerPaymentSchema.safeParse({ externalId: "x", amount: 100, date: "1/6 2026" }).success).toBe(false);
+  });
+});

--- a/tooling/config/dependency-cruiser.cjs
+++ b/tooling/config/dependency-cruiser.cjs
@@ -186,6 +186,34 @@ module.exports = {
       to: { path: "^src/lib/(client|server)/" },
     },
     {
+      // Pluggbar ledger/faktura (ADR 0011, #234): faktura-domänen — det
+      // framework-agnostiska shared-lagret + billing-routrarna (invoice/
+      // billingRun/reports) — är SYSTEMOBEROENDE. Den får importera PORTEN
+      // (`integrations/ledger/`) men ALDRIG en konkret connector
+      // (`integrations/<system>/`, t.ex. fortnox). Det bevisar att
+      // fakturamodulen är fristående och utbytbar. Wiring av en connector hör
+      // hemma i composition-root:en (`src/bin/server-runtime.ts`), inte i
+      // domänen. (shared kan ändå inte importera server alls — vaktas av
+      // `shared-must-not-import-up`; raden här fångar billing-routrarna.)
+      name: "invoice-domain-not-import-connector",
+      severity: "error",
+      comment:
+        "Faktura-domänen (shared + billing-routrar) får importera ledger-" +
+        "PORTEN (integrations/ledger/) men aldrig en connector " +
+        "(integrations/<system>/). Wire connectorer i server-runtime, inte i " +
+        "domänen (ADR 0011, #234).",
+      from: {
+        path: [
+          "^src/lib/shared/",
+          "^src/lib/server/routers/(invoice|billingRun|reports)\\.ts$",
+        ],
+      },
+      to: {
+        path: "^src/lib/server/integrations/",
+        pathNot: "^src/lib/server/integrations/ledger/",
+      },
+    },
+    {
       // Kompositions-disciplin: varje top-level-router (`routers/<x>.ts`)
       // exporterar EN `xRouter` och komponeras ihop i `_app.ts`. Routrar får
       // inte importera varandra — det skapar implicit koppling, cykler och gör

--- a/tooling/config/knip.json
+++ b/tooling/config/knip.json
@@ -16,6 +16,7 @@
     "src/lib/shared/helper/protocol.ts",
     "src/lib/server/data-store/IDataStore.ts",
     "src/lib/server/ports.ts",
+    "src/lib/server/integrations/ledger/port.ts",
     "src/lib/server/events/schema.ts",
     "src/lib/server/rules/schema.ts",
     "src/lib/server/trpc.ts",


### PR DESCRIPTION
Del av #233 (ADR 0011). Grunden för pluggbar bokföring/faktura-export — fakturamodulen blir bevisligen systemoberoende.

## Vad
- **`src/lib/server/integrations/ledger/port.ts`** — `LedgerConnector`-interface med frivilliga metoder (`pushVoucher`/`pushInvoice`/`pullPayments`/`exportSie`), `LedgerCapabilities` (gat:ar UI + speglar vilka metoder som finns), och systemoberoende DTO:er: semantiskt verifikat (återanvänt från `shared/accounting`), domän-faktura, domän-betalning. Inbound betalning (`ledgerPaymentSchema`) parsas **strikt med zod**.
- **`capabilities.ts`** — rena predikat `canBookkeep` / `canPullPayments` / `canExportSie` + `NO_CAPABILITIES` (demo/ingen connector) + `assertConnectorMatchesCapabilities` som verifierar invarianten *capability ⇔ implementerad metod*.
- **dep-cruiser-regel `invoice-domain-not-import-connector`** — faktura-domänen (`src/lib/shared` + billing-routrarna `invoice`/`billingRun`/`reports`) får importera **porten** (`integrations/ledger/`) men ALDRIG en connector (`integrations/<system>/`). Bevisar att fakturamodulen är fristående.
- **knip** — porten listad som contract-entry (samma mönster som `IDataStore.ts`/`ports.ts`); konsumenter landar i kommande PR:er.

## Verifierat
- Regeln **fångar** en olovlig `integrations/fortnox`-import i `invoice.ts` (error) och **tillåter** `integrations/ledger`-porten — testat lokalt genom att temporärt införa importen.
- Lokalt grönt: typecheck, lint, `test:cov` (rader 83.31% / funk 80.12%, över golv), dep-cruiser (0 violations), knip, jscpd.
- Enhetstester för gating, invariant (capability⇔metod, båda riktningarna) och strikt betalnings-parse.

## Ordning i epiken
Nästa steg: **#82** (Fortnox implementerar porten + runtime-wiring mot porten), sedan #236 (SIE-renderare på samma semantiska modell) och #237 (pullPayments/camt).

Refs #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)