### PR TITLE
refactor(fortnox): driv bokföringen via LedgerConnector-porten

### DIFF
--- a/src/lib/server/integrations/fortnox/connector.ts
+++ b/src/lib/server/integrations/fortnox/connector.ts
@@ -1,0 +1,53 @@
+/**
+ * `FortnoxLedgerConnector` — Fortnox bakom `LedgerConnector`-porten (#82, ADR 0011).
+ *
+ * Fortnox är EN av flera möjliga ledger-connectorer. Den tar emot domänens
+ * systemoberoende semantiska verifikat ([[semantic-voucher]]) och renderar det
+ * till Fortnox Voucher-JSON (roll→kontonummer via byråns konto-mappning) +
+ * POST:ar mot Voucher API. Capabilities: bara `pushVoucher` — Fortnox-
+ * connectorn skapar inga fakturor och hämtar inga betalningar här (jfr ADR
+ * 0011: `pullPayments` löses vendor-neutralt via bankfil, #237).
+ *
+ * Idempotensen ägs av sync-drivern (invoice-job): kandidaten är "saknar
+ * fortnoxId", och varje lyckad push märks direkt. Connectorn är därför ren
+ * push utan eget idempotens-state.
+ */
+
+import type { SemanticVoucher } from "@/lib/shared/accounting/semantic-voucher";
+import type {
+  LedgerCapabilities,
+  LedgerConnector,
+  PushVoucherResult,
+} from "../ledger/port";
+import type { FortnoxClient } from "./client";
+import type { FortnoxKontoMappning } from "./schema";
+import { renderFortnoxVoucher } from "./voucher";
+
+export interface FortnoxConnectorDeps {
+  client: Pick<FortnoxClient, "createVoucher">;
+  /** Byråns roll→konto-mappning (#217), läst ur firma.git. */
+  mapping: FortnoxKontoMappning;
+}
+
+const FORTNOX_CAPABILITIES: LedgerCapabilities = {
+  pushVoucher: true,
+  pushInvoice: false,
+  pullPayments: false,
+  exportSie: false,
+};
+
+export class FortnoxLedgerConnector implements LedgerConnector {
+  readonly name = "fortnox";
+
+  constructor(private readonly deps: FortnoxConnectorDeps) {}
+
+  capabilities(): LedgerCapabilities {
+    return FORTNOX_CAPABILITIES;
+  }
+
+  async pushVoucher(voucher: SemanticVoucher): Promise<PushVoucherResult> {
+    const fortnoxVoucher = renderFortnoxVoucher(voucher, this.deps.mapping);
+    const resp = await this.deps.client.createVoucher(fortnoxVoucher);
+    return { externalId: `${resp.Voucher.VoucherSeries}/${resp.Voucher.VoucherNumber}` };
+  }
+}

--- a/src/lib/server/integrations/fortnox/invoice-job.ts
+++ b/src/lib/server/integrations/fortnox/invoice-job.ts
@@ -12,18 +12,17 @@
  * ur firma.git (#217); saknas den vägrar connectorn boka (completeness-gate).
  */
 
+import { buildSemanticVoucher, type SemanticVoucherInput } from "@/lib/shared/accounting/semantic-voucher";
 import { DEFAULT_VAT_RATE, type VatRate } from "@/lib/shared/vat";
 import type { InvoiceStatus } from "@/lib/shared/schemas/enums";
 import type { PeerJob } from "../../local-first/peer-loop";
-import type { FortnoxClient } from "./client";
-import type { FortnoxKontoMappning } from "./schema";
-import { buildVoucherFromInvoice, type InvoiceForVoucher } from "./voucher";
+import type { LedgerConnector } from "../ledger/port";
 
 /** Endast verifikat på UTFÄRDADE fakturor; DRAFT/CANCELLED/BAD_DEBT bokförs ej här. */
 export const DEFAULT_BOOKABLE_STATUSES: readonly InvoiceStatus[] = ["SENT", "PAID", "INSTALLMENT_PLAN"];
 
-/** Den delmängd av en faktura-rad connectorn behöver. */
-export interface BookableInvoice extends InvoiceForVoucher {
+/** Den delmängd av en faktura-rad sync-drivern behöver. */
+export interface BookableInvoice extends SemanticVoucherInput {
   id: string;
   status: InvoiceStatus;
   fortnoxId?: string | null;
@@ -38,9 +37,12 @@ export interface FortnoxJobCaller {
 }
 
 export interface FortnoxInvoiceJobDeps {
-  client: Pick<FortnoxClient, "createVoucher">;
-  /** Läs konto-mappningen ur firma.git (#217). null = ej konfigurerad → boka inget. */
-  loadMapping: () => Promise<FortnoxKontoMappning | null>;
+  /**
+   * Bygg ledger-connectorn för den aktuella cykeln (läser färsk konto-mappning
+   * ur firma.git, #217). `null` = ej konfigurerad → boka inget (completeness-
+   * gate). Drivern jobbar mot PORTEN, inte mot Fortnox direkt (ADR 0011).
+   */
+  loadConnector: () => Promise<LedgerConnector | null>;
   vatRate?: VatRate;
   bookableStatuses?: readonly InvoiceStatus[];
   log?: (msg: string) => void;
@@ -56,24 +58,44 @@ function isPending(inv: BookableInvoice, bookable: ReadonlySet<InvoiceStatus>): 
   return !inv.fortnoxId && bookable.has(inv.status);
 }
 
-/** Bygg + pusha ETT verifikat och märk fakturan bokförd. */
+/** Bygg semantiskt verifikat, pusha via porten och märk fakturan bokförd. */
 async function bookOne(
   caller: FortnoxJobCaller,
-  client: Pick<FortnoxClient, "createVoucher">,
+  connector: PushCapableConnector,
   inv: BookableInvoice,
-  mapping: FortnoxKontoMappning,
   vatRate: VatRate,
 ): Promise<void> {
-  const voucher = buildVoucherFromInvoice(inv, mapping, vatRate);
-  const resp = await client.createVoucher(voucher);
-  const fortnoxId = `${resp.Voucher.VoucherSeries}/${resp.Voucher.VoucherNumber}`;
-  await caller.invoice.markFortnoxBooked({ invoiceId: inv.id, fortnoxId });
+  const voucher = buildSemanticVoucher(inv, vatRate);
+  const { externalId } = await connector.pushVoucher(voucher, { idempotencyKey: inv.id });
+  await caller.invoice.markFortnoxBooked({ invoiceId: inv.id, fortnoxId: externalId });
+}
+
+/** En connector vars `pushVoucher` är garanterat närvarande (capability-grindad). */
+type PushCapableConnector = LedgerConnector & Required<Pick<LedgerConnector, "pushVoucher">>;
+
+/**
+ * Bygg connectorn för cykeln och grinda på pushVoucher-capabilityn. null när
+ * connectorn saknas (ej konfigurerad) eller inte kan boka verifikat.
+ */
+async function resolvePushConnector(
+  deps: FortnoxInvoiceJobDeps,
+  log: (msg: string) => void,
+): Promise<PushCapableConnector | null> {
+  const connector = await deps.loadConnector();
+  if (!connector) {
+    log("Fortnox: ingen connector/konto-mappning (settings/fortnox-account-map.json) — hoppar över");
+    return null;
+  }
+  if (!connector.capabilities().pushVoucher || !connector.pushVoucher) {
+    log(`Ledger-connector "${connector.name}" saknar pushVoucher-capability — hoppar över`);
+    return null;
+  }
+  return connector as PushCapableConnector;
 }
 
 interface BookContext {
   caller: FortnoxJobCaller;
-  client: Pick<FortnoxClient, "createVoucher">;
-  mapping: FortnoxKontoMappning;
+  connector: PushCapableConnector;
   vatRate: VatRate;
   log: (msg: string) => void;
 }
@@ -87,7 +109,7 @@ async function bookEach(
   let failed = 0;
   for (const inv of pending) {
     try {
-      await bookOne(ctx.caller, ctx.client, inv, ctx.mapping, ctx.vatRate);
+      await bookOne(ctx.caller, ctx.connector, inv, ctx.vatRate);
       booked += 1;
     } catch (err) {
       failed += 1;
@@ -106,19 +128,15 @@ export async function bookUnsyncedInvoices(
   deps: FortnoxInvoiceJobDeps,
 ): Promise<BookResult> {
   const log = deps.log ?? (() => {});
-  const mapping = await deps.loadMapping();
-  if (!mapping) {
-    log("Fortnox: ingen konto-mappning (settings/fortnox-account-map.json) — hoppar över");
-    return { booked: 0, failed: 0, skipped: 0 };
-  }
+  const connector = await resolvePushConnector(deps, log);
+  if (!connector) return { booked: 0, failed: 0, skipped: 0 };
 
   const bookable = new Set<InvoiceStatus>(deps.bookableStatuses ?? DEFAULT_BOOKABLE_STATUSES);
   const invoices = await caller.invoice.list({});
   const pending = invoices.filter((inv) => isPending(inv, bookable));
   const { booked, failed } = await bookEach(pending, {
     caller,
-    client: deps.client,
-    mapping,
+    connector,
     vatRate: deps.vatRate ?? DEFAULT_VAT_RATE,
     log,
   });

--- a/src/lib/server/integrations/fortnox/runtime.ts
+++ b/src/lib/server/integrations/fortnox/runtime.ts
@@ -15,7 +15,9 @@ import { join } from "node:path";
 
 import { createVaultFromEnv, type SecretsVault } from "../../secrets/vault";
 import type { PeerJob } from "../../local-first/peer-loop";
+import type { LedgerConnector } from "../ledger/port";
 import { FortnoxClient } from "./client";
+import { FortnoxLedgerConnector } from "./connector";
 import { makeFortnoxInvoiceJob } from "./invoice-job";
 import {
   fortnoxConfigSchema,
@@ -98,8 +100,13 @@ export async function buildFortnoxJob(opts: BuildFortnoxJobOpts): Promise<PeerJo
   const client = new FortnoxClient(fortnoxConfigFromEnv(env, clientId, clientSecret), store);
   log("connector aktiv — bokför nya fakturor som verifikat");
   return makeFortnoxInvoiceJob({
-    client,
-    loadMapping: () => loadKontoMappning(opts.workDir),
+    // Per cykel: läs färsk konto-mappning ur git och bygg connectorn bakom
+    // porten. null när mappningen saknas → drivern hoppar över (completeness).
+    loadConnector: async (): Promise<LedgerConnector | null> => {
+      const mapping = await loadKontoMappning(opts.workDir);
+      if (!mapping) return null;
+      return new FortnoxLedgerConnector({ client, mapping });
+    },
     log,
   });
 }

--- a/src/lib/server/integrations/fortnox/voucher.ts
+++ b/src/lib/server/integrations/fortnox/voucher.ts
@@ -9,18 +9,12 @@
  * och andra renderare (uppföljning på #233).
  */
 
-import {
-  buildSemanticVoucher,
-  type SemanticVoucher,
-  type SemanticVoucherInput,
-  type SemanticVoucherRow,
-  type VoucherRole,
+import type {
+  SemanticVoucher,
+  SemanticVoucherRow,
+  VoucherRole,
 } from "@/lib/shared/accounting/semantic-voucher";
-import type { VatRate } from "@/lib/shared/vat";
 import type { FortnoxKontoMappning, FortnoxVoucher, FortnoxVoucherRow } from "./schema";
-
-/** Re-export: connectorn (invoice-job) jobbar mot samma input-typ som domänen. */
-export type InvoiceForVoucher = SemanticVoucherInput;
 
 function pad2(n: number): string {
   return String(n).padStart(2, "0");
@@ -71,13 +65,4 @@ export function renderFortnoxVoucher(
     Description: voucher.description,
     VoucherRows: voucher.rows.map((r) => renderRow(r, mapping)),
   };
-}
-
-/** Bekvämlighet: bygg semantiskt verifikat ur fakturan och rendera direkt. */
-export function buildVoucherFromInvoice(
-  invoice: InvoiceForVoucher,
-  mapping: FortnoxKontoMappning,
-  vatRate: VatRate = 2500,
-): FortnoxVoucher {
-  return renderFortnoxVoucher(buildSemanticVoucher(invoice, vatRate), mapping);
 }

--- a/test/unit/server/integrations/fortnox/connector.test.ts
+++ b/test/unit/server/integrations/fortnox/connector.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest-compat";
+import { FortnoxLedgerConnector } from "@/lib/server/integrations/fortnox/connector";
+import { assertConnectorMatchesCapabilities } from "@/lib/server/integrations/ledger/capabilities";
+import type { FortnoxClient } from "@/lib/server/integrations/fortnox/client";
+import type { FortnoxKontoMappning, FortnoxVoucher, FortnoxVoucherResponse } from "@/lib/server/integrations/fortnox/schema";
+import type { SemanticVoucher } from "@/lib/shared/accounting/semantic-voucher";
+
+const MAPPING: FortnoxKontoMappning = {
+  voucherSeries: "A",
+  kundfordran: "1510",
+  intaktArvode: "3041",
+  momsUtgaende: "2611",
+};
+
+function makeClient() {
+  const calls: FortnoxVoucher[] = [];
+  const client: Pick<FortnoxClient, "createVoucher"> = {
+    createVoucher: async (v: FortnoxVoucher): Promise<FortnoxVoucherResponse> => {
+      calls.push(v);
+      return { Voucher: { VoucherSeries: v.VoucherSeries, VoucherNumber: 7 } };
+    },
+  };
+  return { client, calls };
+}
+
+const semantic: SemanticVoucher = {
+  date: "2026-06-11",
+  description: "Faktura F-1",
+  rows: [
+    { role: "kundfordran", debit: 12_500, credit: 0 },
+    { role: "intaktArvode", debit: 0, credit: 10_000 },
+    { role: "momsUtgaende", debit: 0, credit: 2_500 },
+  ],
+};
+
+describe("FortnoxLedgerConnector", () => {
+  it("deklarerar bara pushVoucher-capability (invariant capability⇔metod håller)", () => {
+    const { client } = makeClient();
+    const connector = new FortnoxLedgerConnector({ client, mapping: MAPPING });
+    expect(connector.name).toBe("fortnox");
+    expect(connector.capabilities()).toEqual({
+      pushVoucher: true,
+      pushInvoice: false,
+      pullPayments: false,
+      exportSie: false,
+    });
+    expect(() => assertConnectorMatchesCapabilities(connector)).not.toThrow();
+  });
+
+  it("renderar semantiskt verifikat → Fortnox-konton (öre→SEK) och returnerar externalId", async () => {
+    const { client, calls } = makeClient();
+    const connector = new FortnoxLedgerConnector({ client, mapping: MAPPING });
+
+    const res = await connector.pushVoucher(semantic);
+
+    expect(res).toEqual({ externalId: "A/7" });
+    expect(calls).toHaveLength(1);
+    const v = calls[0]!;
+    expect(v.VoucherSeries).toBe("A");
+    expect(v.Description).toBe("Faktura F-1");
+    const byAcct = (n: number) => v.VoucherRows.find((r) => r.Account === n)!;
+    expect(byAcct(1510)).toMatchObject({ Debit: 125, Credit: 0 });
+    expect(byAcct(3041)).toMatchObject({ Debit: 0, Credit: 100 });
+    expect(byAcct(2611)).toMatchObject({ Debit: 0, Credit: 25 });
+  });
+});

--- a/test/unit/server/integrations/fortnox/invoice-job.test.ts
+++ b/test/unit/server/integrations/fortnox/invoice-job.test.ts
@@ -5,8 +5,10 @@ import {
   type BookableInvoice,
   type FortnoxJobCaller,
 } from "@/lib/server/integrations/fortnox/invoice-job";
+import { FortnoxLedgerConnector } from "@/lib/server/integrations/fortnox/connector";
 import type { FortnoxClient } from "@/lib/server/integrations/fortnox/client";
 import type { FortnoxKontoMappning, FortnoxVoucher, FortnoxVoucherResponse } from "@/lib/server/integrations/fortnox/schema";
+import type { LedgerConnector } from "@/lib/server/integrations/ledger/port";
 
 const MAPPING: FortnoxKontoMappning = {
   voucherSeries: "A",
@@ -55,14 +57,18 @@ function makeClient(failMatch?: (v: FortnoxVoucher) => boolean) {
   return { client, calls };
 }
 
-const mapping = (m: FortnoxKontoMappning | null) => async () => m;
+/** Bygg en `loadConnector` som lindar Fortnox-connectorn runt fake-klienten. */
+const withConnector =
+  (client: Pick<FortnoxClient, "createVoucher">, m: FortnoxKontoMappning | null) =>
+  async (): Promise<LedgerConnector | null> =>
+    m ? new FortnoxLedgerConnector({ client, mapping: m }) : null;
 
 describe("bookUnsyncedInvoices", () => {
   it("bokför obokförda utfärdade fakturor + skriver tillbaka fortnoxId", async () => {
     const { caller, booked } = makeCaller([inv({ id: "a" }), inv({ id: "b" })]);
     const { client, calls } = makeClient();
 
-    const res = await bookUnsyncedInvoices(caller, { client, loadMapping: mapping(MAPPING) });
+    const res = await bookUnsyncedInvoices(caller, { loadConnector: withConnector(client, MAPPING) });
 
     expect(res).toEqual({ booked: 2, failed: 0, skipped: 0 });
     expect(calls).toHaveLength(2);
@@ -76,7 +82,7 @@ describe("bookUnsyncedInvoices", () => {
     const { caller, booked } = makeCaller([inv({ id: "a", fortnoxId: "A/9" }), inv({ id: "b" })]);
     const { client } = makeClient();
 
-    const res = await bookUnsyncedInvoices(caller, { client, loadMapping: mapping(MAPPING) });
+    const res = await bookUnsyncedInvoices(caller, { loadConnector: withConnector(client, MAPPING) });
 
     expect(res).toEqual({ booked: 1, failed: 0, skipped: 1 });
     expect(booked).toEqual([{ invoiceId: "b", fortnoxId: "A/1" }]);
@@ -90,7 +96,7 @@ describe("bookUnsyncedInvoices", () => {
     ]);
     const { client } = makeClient();
 
-    const res = await bookUnsyncedInvoices(caller, { client, loadMapping: mapping(MAPPING) });
+    const res = await bookUnsyncedInvoices(caller, { loadConnector: withConnector(client, MAPPING) });
 
     expect(res).toEqual({ booked: 1, failed: 0, skipped: 2 });
     expect(booked).toEqual([{ invoiceId: "c", fortnoxId: "A/1" }]);
@@ -100,10 +106,21 @@ describe("bookUnsyncedInvoices", () => {
     const { caller, booked } = makeCaller([inv()]);
     const { client, calls } = makeClient();
 
-    const res = await bookUnsyncedInvoices(caller, { client, loadMapping: mapping(null) });
+    const res = await bookUnsyncedInvoices(caller, { loadConnector: withConnector(client, null) });
 
     expect(res).toEqual({ booked: 0, failed: 0, skipped: 0 });
     expect(calls).toHaveLength(0);
+    expect(booked).toHaveLength(0);
+  });
+
+  it("connector utan pushVoucher-capability → bokför inget", async () => {
+    const { caller, booked } = makeCaller([inv()]);
+    const noPush: LedgerConnector = {
+      name: "saknar-push",
+      capabilities: () => ({ pushVoucher: false, pushInvoice: false, pullPayments: false, exportSie: false }),
+    };
+    const res = await bookUnsyncedInvoices(caller, { loadConnector: async () => noPush });
+    expect(res).toEqual({ booked: 0, failed: 0, skipped: 0 });
     expect(booked).toHaveLength(0);
   });
 
@@ -111,7 +128,7 @@ describe("bookUnsyncedInvoices", () => {
     const { caller, booked } = makeCaller([inv({ id: "a", invoiceNumber: "F-A" }), inv({ id: "b", invoiceNumber: "F-B" })]);
     const { client } = makeClient((v) => v.Description.includes("F-A"));
 
-    const res = await bookUnsyncedInvoices(caller, { client, loadMapping: mapping(MAPPING) });
+    const res = await bookUnsyncedInvoices(caller, { loadConnector: withConnector(client, MAPPING) });
 
     expect(res).toEqual({ booked: 1, failed: 1, skipped: 0 });
     expect(booked).toEqual([{ invoiceId: "b", fortnoxId: "A/1" }]); // bara den lyckade
@@ -121,7 +138,7 @@ describe("bookUnsyncedInvoices", () => {
     const { caller } = makeCaller([inv()]);
     const { client, calls } = makeClient();
 
-    await bookUnsyncedInvoices(caller, { client, loadMapping: mapping(MAPPING) });
+    await bookUnsyncedInvoices(caller, { loadConnector: withConnector(client, MAPPING) });
 
     const rows = calls[0]!.VoucherRows;
     const debit = rows.reduce((s, r) => s + r.Debit, 0);
@@ -136,7 +153,7 @@ describe("makeFortnoxInvoiceJob", () => {
   it("returnerar ett PeerJob vars act bokför via callern", async () => {
     const { caller, booked } = makeCaller([inv({ id: "a" })]);
     const { client } = makeClient();
-    const job = makeFortnoxInvoiceJob({ client, loadMapping: mapping(MAPPING) });
+    const job = makeFortnoxInvoiceJob({ loadConnector: withConnector(client, MAPPING) });
 
     expect(job.message).toMatch(/fortnox/i);
     // act tar hela tRPC-callern; vi skickar vår delmängd (samma cast som i wrappern).

--- a/test/unit/server/integrations/fortnox/voucher.test.ts
+++ b/test/unit/server/integrations/fortnox/voucher.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from "vitest-compat";
-import { buildVoucherFromInvoice, renderFortnoxVoucher } from "@/lib/server/integrations/fortnox/voucher";
+import { renderFortnoxVoucher } from "@/lib/server/integrations/fortnox/voucher";
 import type { FortnoxKontoMappning } from "@/lib/server/integrations/fortnox/schema";
-import type { SemanticVoucher } from "@/lib/shared/accounting/semantic-voucher";
+import {
+  buildSemanticVoucher,
+  type SemanticVoucher,
+  type SemanticVoucherInput,
+} from "@/lib/shared/accounting/semantic-voucher";
+import type { VatRate } from "@/lib/shared/vat";
 
 const mapping: FortnoxKontoMappning = {
   voucherSeries: "A",
@@ -13,13 +18,14 @@ const mapping: FortnoxKontoMappning = {
 const sum = (rows: { Debit: number; Credit: number }[], k: "Debit" | "Credit") =>
   rows.reduce((s, r) => s + r[k], 0);
 
-describe("buildVoucherFromInvoice", () => {
+/** Tvåstegs-vägen som connectorn använder: faktura → semantiskt → Fortnox-JSON. */
+const render = (invoice: SemanticVoucherInput, vatRate?: VatRate) =>
+  renderFortnoxVoucher(buildSemanticVoucher(invoice, vatRate), mapping);
+
+describe("faktura → semantiskt verifikat → Fortnox-rendering", () => {
   it("standardfaktura: 3 balanserade rader (debet kundfordran = kredit intäkt+moms)", () => {
     // 12500 öre brutto inkl 25 % moms → 100 kr netto + 25 kr moms = 125 kr.
-    const v = buildVoucherFromInvoice(
-      { amount: 12_500, invoiceDate: "2026-05-25", invoiceNumber: "F-2026-0042" },
-      mapping,
-    );
+    const v = render({ amount: 12_500, invoiceDate: "2026-05-25", invoiceNumber: "F-2026-0042" });
     expect(v.VoucherSeries).toBe("A");
     expect(v.TransactionDate).toBe("2026-05-25");
     expect(v.Description).toBe("Faktura F-2026-0042");
@@ -35,10 +41,11 @@ describe("buildVoucherFromInvoice", () => {
   });
 
   it("kreditfaktura (negativt belopp) vänder debet/kredit men håller balans", () => {
-    const v = buildVoucherFromInvoice(
-      { amount: -12_500, invoiceDate: new Date("2026-05-25T10:00:00Z"), invoiceNumber: "K-2026-0001" },
-      mapping,
-    );
+    const v = render({
+      amount: -12_500,
+      invoiceDate: new Date("2026-05-25T10:00:00Z"),
+      invoiceNumber: "K-2026-0001",
+    });
     const byAcct = (n: number) => v.VoucherRows.find((r) => r.Account === n)!;
     expect(byAcct(1510)).toMatchObject({ Debit: 0, Credit: 125 }); // kundfordran krediteras
     expect(byAcct(3041)).toMatchObject({ Debit: 100, Credit: 0 });
@@ -47,11 +54,7 @@ describe("buildVoucherFromInvoice", () => {
   });
 
   it("0 % moms: moms-raden släpps (2 rader kvar, fortf. balanserat)", () => {
-    const v = buildVoucherFromInvoice(
-      { amount: 10_000, invoiceDate: "2026-01-01" },
-      mapping,
-      0,
-    );
+    const v = render({ amount: 10_000, invoiceDate: "2026-01-01" }, 0);
     expect(v.VoucherRows).toHaveLength(2);
     expect(v.VoucherRows.some((r) => r.Account === 2611)).toBe(false);
     expect(sum(v.VoucherRows, "Debit")).toBe(sum(v.VoucherRows, "Credit"));
@@ -60,7 +63,7 @@ describe("buildVoucherFromInvoice", () => {
 
   it("balans håller även för 'sneda' belopp (öre-rest hamnar i moms)", () => {
     // 10001 öre — momsen blir resten så debet/kredit alltid stämmer.
-    const v = buildVoucherFromInvoice({ amount: 10_001, invoiceDate: "2026-03-03" }, mapping);
+    const v = render({ amount: 10_001, invoiceDate: "2026-03-03" });
     expect(sum(v.VoucherRows, "Debit")).toBeCloseTo(sum(v.VoucherRows, "Credit"), 10);
     expect(sum(v.VoucherRows, "Debit")).toBeCloseTo(100.01, 10);
   });


### PR DESCRIPTION
Del av #233 (ADR 0011). Migrerar Fortnox till att ligga **bakom** ledger-porten (#234) — fakturamodulens sync-drivare blir systemoberoende, Fortnox blir en av flera möjliga connectorer.

## Vad
- **`connector.ts`** — ny `FortnoxLedgerConnector implements LedgerConnector`. Capabilities `{ pushVoucher: true, pushInvoice: false, pullPayments: false, exportSie: false }`. `pushVoucher(semantiskt verifikat)` renderar via `renderFortnoxVoucher` (roll→kontonummer) + POST:ar mot Voucher API och returnerar `{ externalId }`.
- **`invoice-job.ts`** — sync-drivern bygger nu domänens semantiska verifikat (`buildSemanticVoucher` från `shared`) och pushar via **porten** (`connector.pushVoucher`), inte mot Fortnox direkt. Capability-grind hoppar över connectorer utan `pushVoucher`. Idempotensen (kandidat = saknar `fortnoxId`; märk vid lyckad push) **oförändrad**. Deps: `loadConnector()` per cykel (färsk konto-mappning ur git → connector bakom porten; `null` = completeness-gate).
- **`runtime.ts`** — bygger `FortnoxLedgerConnector` per cykel via `loadConnector`.
- **`voucher.ts`** — tar bort den nu redundanta `buildVoucherFromInvoice` + `InvoiceForVoucher`; tvåstegs-vägen `buildSemanticVoucher → renderFortnoxVoucher` ersätter den. Renderaren kvar. Befintliga tester omskrivna till tvåstegs-vägen (alla slut-output-assertioner bevarade).

## Verifierat
- Nya tester: `FortnoxLedgerConnector` (capabilities-invariant via `assertConnectorMatchesCapabilities` + rendering→`externalId`) och capability-grind i drivern.
- Lokalt grönt: typecheck, lint (complexity ≤8 efter helper-extraktion), `test:cov` (rader 83.30% / funk 80.15%, över golv), dep-cruiser (0 violations — ingen connector-import i domänen), knip, jscpd.

## Ordning i epiken
#235 ✓ → #234 ✓ → **#82 (denna)**. Kvar: #236 (SIE-renderare på samma semantiska modell), #237 (pullPayments/camt). Sandbox-end-to-end mot körande server-runtime kvarstår som operationell verifiering (oförändrad av denna refaktorering).

Refs #82 #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)