### PR TITLE
feat(ledger): rendera semantisk modell till SIE 4-fil-export

### DIFF
--- a/src/lib/server/integrations/ledger/sie-connector.ts
+++ b/src/lib/server/integrations/ledger/sie-connector.ts
@@ -1,0 +1,72 @@
+/**
+ * `SieLedgerConnector` — SIE 4-fil-export bakom ledger-porten (#236, ADR 0011).
+ *
+ * En `LedgerConnector` som BARA har `exportSie`-capability:n: den kräver inget
+ * externt bokföringssystem utan renderar domänens semantiska verifikat
+ * ([[semantic-voucher]]) till en SIE 4-fil ([[sie]]) som byrån importerar i
+ * valfritt system. För byråer utan Fortnox/extern ledger.
+ *
+ * Connectorn sluter över sin datakälla (`loadVouchers`) på samma sätt som
+ * `FortnoxLedgerConnector` sluter över sin Fortnox-klient — runtime:n
+ * injicerar källan (verifikat ur firma.git för intervallet). Tidsstämpeln för
+ * `#GEN` kommer från en injicerad klocka (deterministisk i test).
+ */
+
+import { renderSie, type SieAccountMap, type SieCompany, type SieVoucherMeta } from "@/lib/shared/accounting/sie";
+import type { SemanticVoucher } from "@/lib/shared/accounting/semantic-voucher";
+import type {
+  LedgerCapabilities,
+  LedgerConnector,
+  SieExportRange,
+} from "./port";
+
+/** Ett verifikat med sin SIE-identitet, hämtat för export. */
+export interface ExportableVoucher {
+  meta: SieVoucherMeta;
+  voucher: SemanticVoucher;
+}
+
+export interface SieConnectorDeps {
+  company: SieCompany;
+  accountMap: SieAccountMap;
+  /** Hämta verifikaten för intervallet (injiceras av runtime; läser firma.git). */
+  loadVouchers: (range: SieExportRange) => Promise<ReadonlyArray<ExportableVoucher>>;
+  /** Klocka för `#GEN`-datumet (default = systemtid). */
+  clock?: () => Date;
+}
+
+const SIE_CAPABILITIES: LedgerCapabilities = {
+  pushVoucher: false,
+  pushInvoice: false,
+  pullPayments: false,
+  exportSie: true,
+};
+
+function pad2(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+function sieDate(d: Date): string {
+  return `${d.getFullYear()}${pad2(d.getMonth() + 1)}${pad2(d.getDate())}`;
+}
+
+export class SieLedgerConnector implements LedgerConnector {
+  readonly name = "sie";
+
+  constructor(private readonly deps: SieConnectorDeps) {}
+
+  capabilities(): LedgerCapabilities {
+    return SIE_CAPABILITIES;
+  }
+
+  async exportSie(range: SieExportRange): Promise<string> {
+    const vouchers = await this.deps.loadVouchers(range);
+    const clock = this.deps.clock ?? (() => new Date());
+    return renderSie({
+      company: this.deps.company,
+      generatedDate: sieDate(clock()),
+      accountMap: this.deps.accountMap,
+      vouchers,
+    });
+  }
+}

--- a/src/lib/shared/accounting/sie.ts
+++ b/src/lib/shared/accounting/sie.ts
@@ -1,0 +1,133 @@
+/**
+ * SIE 4-rendering av semantiska verifikat (#236, ADR 0011).
+ *
+ * SIE (Standard Import/Export) är det svenska standardformatet för att flytta
+ * bokföringsdata mellan system. En byrå UTAN Fortnox/extern ledger kan exportera
+ * en SIE 4-fil och importera den i valfritt bokföringssystem — därför är detta
+ * en ren, systemoberoende renderare av domänens semantiska verifikat
+ * ([[semantic-voucher]]), helt utan externt API.
+ *
+ * Format (verifierat mot SIE-gruppens spec ver 4B + importörsdoc):
+ *   - Poster radvis, taggen först (`#FLAGGA`, `#KONTO`, `#VER`, `#TRANS` …).
+ *   - `#SIETYP 4`, teckenuppsättning historiskt PC8 (vi skriver ren text;
+ *     ev. PC8-kodning är ett nedströms-bekymmer).
+ *   - **Tecken-konvention för `#TRANS`-belopp: debet POSITIVT, kredit NEGATIVT.**
+ *   - Datum `YYYYMMDD` (utan bindestreck). Belopp med punkt-decimal, 2 decimaler.
+ *   - Verifikat: `#VER "serie" "nr" datum "text"` följt av `{` … `}` med en
+ *     `#TRANS konto {objektlista} belopp` per rad (tom objektlista = `{}`).
+ *
+ * Invariant: domänmodellen är redan balanserad (Σdebet==Σkredit) → SIE-
+ * verifikatets `#TRANS`-summa blir 0, vilket SIE kräver.
+ */
+
+import type { SemanticVoucher, VoucherRole } from "./semantic-voucher";
+
+/** Byrå-metadata för SIE-headern. */
+export interface SieCompany {
+  name: string;
+  /** Organisationsnummer (valfritt — emit:as som `#ORGNR` om satt). */
+  orgNr?: string;
+}
+
+/** Ett BAS-konto (nummer + namn) som en roll mappas till. */
+export interface SieAccount {
+  number: string;
+  name: string;
+}
+
+/** Roll → BAS-konto. Vendor-neutral motsvarighet till Fortnox konto-mappning. */
+export type SieAccountMap = Partial<Record<VoucherRole, SieAccount>>;
+
+/** Verifikat-identitet i SIE (serie + löpnummer). */
+export interface SieVoucherMeta {
+  series: string;
+  number: string;
+}
+
+export interface SieRenderInput {
+  company: SieCompany;
+  /** Genereringsdatum `YYYYMMDD` (för `#GEN`). */
+  generatedDate: string;
+  accountMap: SieAccountMap;
+  vouchers: ReadonlyArray<{ meta: SieVoucherMeta; voucher: SemanticVoucher }>;
+  /** Program-signatur för `#PROGRAM` (default AVA). */
+  program?: { name: string; version: string };
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+/** `Date | string` → `YYYYMMDD`. */
+function toSieDate(d: Date | string): string {
+  const dt = typeof d === "string" ? new Date(d) : d;
+  return `${dt.getFullYear()}${pad2(dt.getMonth() + 1)}${pad2(dt.getDate())}`;
+}
+
+/** Citera ett fält enligt SIE (dubbla citationstecken, escape:a inre `"`). */
+function quote(s: string): string {
+  return `"${s.replace(/"/g, '\\"')}"`;
+}
+
+/** Öre (debet, kredit) → signerat SEK-belopp: debet positivt, kredit negativt. */
+function transAmount(debit: number, credit: number): string {
+  return ((debit - credit) / 100).toFixed(2);
+}
+
+/** Slå upp rollens konto; kasta om mappning saknas (completeness-gate). */
+function accountFor(role: VoucherRole, map: SieAccountMap): SieAccount {
+  const account = map[role];
+  if (!account) throw new Error(`SIE: rollen '${role}' saknar konto-mappning`);
+  return account;
+}
+
+function headerLines(input: SieRenderInput): string[] {
+  const program = input.program ?? { name: "AVA", version: "1.0" };
+  const lines = [
+    "#FLAGGA 0",
+    `#PROGRAM ${quote(program.name)} ${quote(program.version)}`,
+    "#FORMAT PC8",
+    `#GEN ${input.generatedDate}`,
+    "#SIETYP 4",
+    `#FNAMN ${quote(input.company.name)}`,
+  ];
+  if (input.company.orgNr) lines.push(`#ORGNR ${input.company.orgNr}`);
+  return lines;
+}
+
+/** Unika `#KONTO`-poster för alla konton som verifikaten refererar, sorterade. */
+function kontoLines(input: SieRenderInput): string[] {
+  const accounts = new Map<string, string>();
+  for (const { voucher } of input.vouchers) {
+    for (const row of voucher.rows) {
+      const account = accountFor(row.role, input.accountMap);
+      accounts.set(account.number, account.name);
+    }
+  }
+  return [...accounts.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([number, name]) => `#KONTO ${number} ${quote(name)}`);
+}
+
+function voucherLines(
+  entry: { meta: SieVoucherMeta; voucher: SemanticVoucher },
+  map: SieAccountMap,
+): string[] {
+  const { meta, voucher } = entry;
+  const head = `#VER ${quote(meta.series)} ${quote(meta.number)} ${toSieDate(voucher.date)} ${quote(voucher.description)}`;
+  const trans = voucher.rows.map((row) => {
+    const account = accountFor(row.role, map);
+    return `   #TRANS ${account.number} {} ${transAmount(row.debit, row.credit)}`;
+  });
+  return [head, "{", ...trans, "}"];
+}
+
+/** Rendera en komplett SIE 4-fil (CRLF-terminerad enligt spec). */
+export function renderSie(input: SieRenderInput): string {
+  const lines = [
+    ...headerLines(input),
+    ...kontoLines(input),
+    ...input.vouchers.flatMap((entry) => voucherLines(entry, input.accountMap)),
+  ];
+  return lines.join("\r\n") + "\r\n";
+}

--- a/test/unit/server/integrations/ledger/sie-connector.test.ts
+++ b/test/unit/server/integrations/ledger/sie-connector.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest-compat";
+import { SieLedgerConnector, type ExportableVoucher } from "@/lib/server/integrations/ledger/sie-connector";
+import { assertConnectorMatchesCapabilities } from "@/lib/server/integrations/ledger/capabilities";
+import type { SieAccountMap } from "@/lib/shared/accounting/sie";
+
+const accountMap: SieAccountMap = {
+  kundfordran: { number: "1510", name: "Kundfordringar" },
+  intaktArvode: { number: "3041", name: "Advokatarvoden" },
+  momsUtgaende: { number: "2611", name: "Utgående moms" },
+};
+
+const exportable: ExportableVoucher = {
+  meta: { series: "A", number: "1" },
+  voucher: {
+    date: "2026-05-25",
+    description: "Faktura F-1",
+    rows: [
+      { role: "kundfordran", debit: 12_500, credit: 0 },
+      { role: "intaktArvode", debit: 0, credit: 10_000 },
+      { role: "momsUtgaende", debit: 0, credit: 2_500 },
+    ],
+  },
+};
+
+function makeConnector(vouchers: ExportableVoucher[]) {
+  const ranges: { from: string; to: string }[] = [];
+  const connector = new SieLedgerConnector({
+    company: { name: "Byrå AB" },
+    accountMap,
+    loadVouchers: async (range) => {
+      ranges.push(range);
+      return vouchers;
+    },
+    clock: () => new Date("2026-06-12T08:00:00Z"),
+  });
+  return { connector, ranges };
+}
+
+describe("SieLedgerConnector", () => {
+  it("deklarerar bara exportSie-capability (invariant capability⇔metod håller)", () => {
+    const { connector } = makeConnector([]);
+    expect(connector.name).toBe("sie");
+    expect(connector.capabilities()).toEqual({
+      pushVoucher: false,
+      pushInvoice: false,
+      pullPayments: false,
+      exportSie: true,
+    });
+    expect(() => assertConnectorMatchesCapabilities(connector)).not.toThrow();
+  });
+
+  it("hämtar verifikat för intervallet och renderar en SIE-fil med injicerat #GEN", async () => {
+    const { connector, ranges } = makeConnector([exportable]);
+    const sie = await connector.exportSie({ from: "2026-05-01", to: "2026-05-31" });
+
+    expect(ranges).toEqual([{ from: "2026-05-01", to: "2026-05-31" }]);
+    expect(sie).toContain("#GEN 20260612"); // från klockan
+    expect(sie).toContain('#FNAMN "Byrå AB"');
+    expect(sie).toContain('#VER "A" "1" 20260525 "Faktura F-1"');
+    expect(sie).toContain("#TRANS 1510 {} 125.00");
+  });
+
+  it("tom export ger giltig header utan verifikat", async () => {
+    const { connector } = makeConnector([]);
+    const sie = await connector.exportSie({ from: "2026-01-01", to: "2026-01-31" });
+    expect(sie).toContain("#SIETYP 4");
+    expect(sie.includes("#VER")).toBe(false);
+  });
+});

--- a/test/unit/shared/accounting/sie.test.ts
+++ b/test/unit/shared/accounting/sie.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest-compat";
+import { renderSie, type SieAccountMap, type SieRenderInput } from "@/lib/shared/accounting/sie";
+import type { SemanticVoucher } from "@/lib/shared/accounting/semantic-voucher";
+
+const accountMap: SieAccountMap = {
+  kundfordran: { number: "1510", name: "Kundfordringar" },
+  intaktArvode: { number: "3041", name: "Advokatarvoden" },
+  momsUtgaende: { number: "2611", name: "Utgående moms" },
+};
+
+const voucher: SemanticVoucher = {
+  date: "2026-05-25",
+  description: "Faktura F-2026-0042",
+  rows: [
+    { role: "kundfordran", debit: 12_500, credit: 0 },
+    { role: "intaktArvode", debit: 0, credit: 10_000 },
+    { role: "momsUtgaende", debit: 0, credit: 2_500 },
+  ],
+};
+
+const baseInput: SieRenderInput = {
+  company: { name: "Advokatbyrå AB", orgNr: "5566778899" },
+  generatedDate: "20260612",
+  accountMap,
+  vouchers: [{ meta: { series: "A", number: "1" }, voucher }],
+};
+
+const lines = (sie: string) => sie.split("\r\n");
+
+describe("renderSie", () => {
+  it("skriver obligatorisk header i rätt ordning", () => {
+    const out = lines(renderSie(baseInput));
+    expect(out.slice(0, 6)).toEqual([
+      "#FLAGGA 0",
+      '#PROGRAM "AVA" "1.0"',
+      "#FORMAT PC8",
+      "#GEN 20260612",
+      "#SIETYP 4",
+      '#FNAMN "Advokatbyrå AB"',
+    ]);
+    expect(out).toContain("#ORGNR 5566778899");
+  });
+
+  it("emittar unika #KONTO-poster, sorterade på kontonummer", () => {
+    const out = lines(renderSie(baseInput));
+    const konto = out.filter((l) => l.startsWith("#KONTO"));
+    expect(konto).toEqual([
+      '#KONTO 1510 "Kundfordringar"',
+      '#KONTO 2611 "Utgående moms"',
+      '#KONTO 3041 "Advokatarvoden"',
+    ]);
+  });
+
+  it("renderar #VER + #TRANS-block med debet positivt / kredit negativt", () => {
+    const out = renderSie(baseInput);
+    expect(out).toContain('#VER "A" "1" 20260525 "Faktura F-2026-0042"');
+    expect(out).toContain("   #TRANS 1510 {} 125.00"); // debet → positivt
+    expect(out).toContain("   #TRANS 3041 {} -100.00"); // kredit → negativt
+    expect(out).toContain("   #TRANS 2611 {} -25.00");
+  });
+
+  it("verifikatets #TRANS-belopp summerar till 0 (balans-invarianten)", () => {
+    const out = lines(renderSie(baseInput));
+    const sum = out
+      .filter((l) => l.includes("#TRANS"))
+      .reduce((s, l) => s + Number(l.trim().split(" ").at(-1)), 0);
+    expect(sum).toBeCloseTo(0, 10);
+  });
+
+  it("utelämnar #ORGNR när det saknas", () => {
+    const out = lines(renderSie({ ...baseInput, company: { name: "Byrå" } }));
+    expect(out.some((l) => l.startsWith("#ORGNR"))).toBe(false);
+  });
+
+  it("kastar när en roll saknar konto-mappning (completeness-gate)", () => {
+    const partial: SieAccountMap = { kundfordran: { number: "1510", name: "Kundfordringar" } };
+    expect(() => renderSie({ ...baseInput, accountMap: partial })).toThrow(/saknar konto-mappning/);
+  });
+
+  it("hanterar Date-objekt och flera verifikat", () => {
+    const out = renderSie({
+      ...baseInput,
+      vouchers: [
+        { meta: { series: "A", number: "1" }, voucher: { ...voucher, date: new Date("2026-05-25T12:00:00Z") } },
+        { meta: { series: "A", number: "2" }, voucher },
+      ],
+    });
+    expect(out).toContain('#VER "A" "1" 20260525');
+    expect(out).toContain('#VER "A" "2" 20260525');
+  });
+});


### PR DESCRIPTION
Del av #233 (ADR 0011). Implementerar `exportSie`-capability:n — en byrå **utan** Fortnox/extern ledger kan exportera bokföringen som SIE 4-fil och importera i valfritt system. Ingen extern integration krävs.

## Vad
- **`src/lib/shared/accounting/sie.ts`** — ren, system- och framework-agnostisk renderare av domänens semantiska verifikat (#235) → SIE 4. Återanvändbar även klient-sida.
  - Verifierat mot [SIE-gruppens spec (4B)](https://sie.se/wp-content/uploads/2020/05/SIE_filformat_ver_4B_ENGLISH.pdf) + importörsdoc: header (`#FLAGGA`/`#PROGRAM`/`#FORMAT PC8`/`#GEN`/`#SIETYP 4`/`#FNAMN`/`#ORGNR`), unika sorterade `#KONTO`, `#VER` + `{}`-block med `#TRANS konto {} belopp`.
  - **Tecken-konvention: debet positivt, kredit negativt.** Datum `YYYYMMDD`, punkt-decimal 2 dec. Balans-invarianten (Σdebet==Σkredit) ger `#TRANS`-summa 0 (SIE-krav).
  - Roll→BAS-konto via injicerad mappning (vendor-neutral, inte Fortnox-specifik); completeness-gate kastar vid omappad roll.
- **`src/lib/server/integrations/ledger/sie-connector.ts`** — `SieLedgerConnector implements LedgerConnector`, bara `exportSie`-capability. Sluter över sin datakälla (`loadVouchers(range)`, injiceras av runtime ur firma.git) + en klocka för `#GEN` (deterministisk i test).

## Verifierat
- Tester: renderaren (header-ordning, sorterade `#KONTO`, tecken-konvention, balans=0, `Date`-hantering, completeness-gate) + connectorn (capability-invariant via `assertConnectorMatchesCapabilities`, intervall→SIE, tom export).
- Lokalt grönt: typecheck, lint, `test:cov` (rader 83.35% / funk 80.24%, över golv), dep-cruiser (0 violations — ingen connector-import i domänen), knip, jscpd.

## Ordning i epiken
#235 ✓ → #234 ✓ → #82 ✓ → **#236 (denna)**. Kvar: #237 (pullPayments/camt). Runtime-wiring av SIE-export (UI-knapp + voucher-källa ur git) är en naturlig följd-issue.

Refs #236 #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)