### PR TITLE
feat(ledger): pullPayments-connector för bankfil (camt) bakom porten

### DIFF
--- a/src/lib/server/integrations/ledger/bank-file-connector.ts
+++ b/src/lib/server/integrations/ledger/bank-file-connector.ts
@@ -1,0 +1,87 @@
+/**
+ * `BankFileLedgerConnector` — pullPayments via bankfil (#237, ADR 0011).
+ *
+ * Vendor-neutral avprickningskälla UTAN bankuppkoppling/PSD2: byrån laddar upp
+ * sin banks återrapporteringsfil (ISO 20022 camt.053/054) och connectorn
+ * parsar inkomna kundbetalningar bakom ledger-porten. Ingen extern integration
+ * — bara filinläsning. (BGMAX kan läggas till som en andra parser senare.)
+ *
+ * Connectorn sluter över sin filkälla (`loadCamtFiles`, injiceras av runtime/
+ * UI) precis som Fortnox-connectorn sluter över sin klient. Den mappar varje
+ * INBETALNING (CRDT) till portens flata `LedgerPayment`-DTO; den rika camt-
+ * matchningen (flera referenser/delbelopp/fri text) ägs av
+ * [[match-payments]] och lever vidare som den detaljerade in-app-motorn.
+ *
+ * Capabilities: bara `pullPayments`.
+ */
+
+import { isValidOcrReference } from "@/lib/shared/ocr-reference";
+import { parseCamtXml, type CamtTransaction } from "@/lib/shared/payments/camt-parse";
+import {
+  ledgerPaymentSchema,
+  type LedgerCapabilities,
+  type LedgerConnector,
+  type LedgerPayment,
+  type PullPaymentsQuery,
+} from "./port";
+
+export interface BankFileConnectorDeps {
+  /**
+   * Hämta råa camt-XML-filer för intervallet (injiceras av runtime/UI —
+   * uppladdade filer eller server-runtime-peer). Tom lista = inga betalningar.
+   */
+  loadCamtFiles: (query: PullPaymentsQuery) => Promise<ReadonlyArray<string>>;
+}
+
+const BANK_FILE_CAPABILITIES: LedgerCapabilities = {
+  pushVoucher: false,
+  pushInvoice: false,
+  pullPayments: true,
+  exportSie: false,
+};
+
+/** Bästa OCR-kandidat: en strukturerad referens som validerar som OCR (mod-10). */
+function ocrOf(tx: CamtTransaction): string | undefined {
+  const valid = tx.structuredRefs.find((r) => isValidOcrReference(r.ref));
+  return (valid ?? tx.structuredRefs[0])?.ref;
+}
+
+/** En CRDT-transaktion → flat LedgerPayment (null om beloppet ej är positivt). */
+function toLedgerPayment(tx: CamtTransaction): LedgerPayment | null {
+  if (tx.creditDebit !== "CRDT" || tx.amountOre <= 0) return null;
+  // Strikt parse vid connector-gränsen ([[feedback-zod-strict-parsing]]).
+  return ledgerPaymentSchema.parse({
+    externalId: tx.reference,
+    amount: tx.amountOre,
+    ...(tx.valueDate ? { date: tx.valueDate } : {}),
+    ...(ocrOf(tx) ? { ocrReference: ocrOf(tx) } : {}),
+    ...(tx.debtorName ? { payerName: tx.debtorName } : {}),
+  });
+}
+
+export class BankFileLedgerConnector implements LedgerConnector {
+  readonly name = "bankfil-camt";
+
+  constructor(private readonly deps: BankFileConnectorDeps) {}
+
+  capabilities(): LedgerCapabilities {
+    return BANK_FILE_CAPABILITIES;
+  }
+
+  async pullPayments(query: PullPaymentsQuery): Promise<LedgerPayment[]> {
+    const files = await this.deps.loadCamtFiles(query);
+    const payments: LedgerPayment[] = [];
+    const seen = new Set<string>();
+    for (const xml of files) {
+      for (const tx of parseCamtXml(xml).transactions) {
+        const payment = toLedgerPayment(tx);
+        // Idempotens vid överlappande filer: dedup på externalId.
+        if (payment && !seen.has(payment.externalId)) {
+          seen.add(payment.externalId);
+          payments.push(payment);
+        }
+      }
+    }
+    return payments;
+  }
+}

--- a/src/lib/server/integrations/ledger/port.ts
+++ b/src/lib/server/integrations/ledger/port.ts
@@ -88,8 +88,9 @@ export const ledgerPaymentSchema = z.object({
   externalId: z.string().min(1),
   /** Inbetalt belopp i öre (positivt). */
   amount: z.number().int().positive(),
-  /** Bokföringsdatum `YYYY-MM-DD`. */
-  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  /** Bokförings-/valutadatum `YYYY-MM-DD`. Valfritt — alla källor anger inte
+   *  datum (t.ex. camt utan ValDt); avprickningen nyckar på referens, inte datum. */
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
   /** OCR-/betalningsreferens om angiven (mod-10) — primär matchningsnyckel. */
   ocrReference: z.string().min(1).optional(),
   /** Betalarens namn om angivet (heuristik-fallback). */

--- a/test/unit/server/integrations/ledger/bank-file-connector.test.ts
+++ b/test/unit/server/integrations/ledger/bank-file-connector.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest-compat";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { BankFileLedgerConnector } from "@/lib/server/integrations/ledger/bank-file-connector";
+import { assertConnectorMatchesCapabilities } from "@/lib/server/integrations/ledger/capabilities";
+import { ledgerPaymentSchema } from "@/lib/server/integrations/ledger/port";
+
+const FIXTURES = resolve(__dirname, "../../../../fixtures/camt-seb");
+const read = (f: string): string => readFileSync(resolve(FIXTURES, f), "utf8");
+
+const connectorFor = (...files: string[]) =>
+  new BankFileLedgerConnector({ loadCamtFiles: async () => files });
+
+/** Minimal camt.054 med två Strd-referenser: ett dokumentnr + en giltig OCR. */
+const OCR = "2026004206"; // buildOcrReference("20260042"), validerar mod-10
+const camtWithOcr = `<?xml version="1.0" encoding="UTF-8"?>
+<Document>
+  <BkToCstmrDbtCdtNtfctn>
+    <GrpHdr><MsgId>MSG-1</MsgId></GrpHdr>
+    <Ntfctn>
+      <Ntry>
+        <Amt Ccy="SEK">125.00</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <ValDt><Dt>2026-06-01</Dt></ValDt>
+        <NtryDtls><TxDtls>
+          <Refs><AcctSvcrRef>TX-OCR-1</AcctSvcrRef></Refs>
+          <RltdPties><Dbtr><Nm>Klient AB</Nm></Dbtr></RltdPties>
+          <RmtInf>
+            <Strd><RfrdDocInf><Nb>98547</Nb></RfrdDocInf></Strd>
+            <Strd><CdtrRefInf><Ref>${OCR}</Ref></CdtrRefInf></Strd>
+          </RmtInf>
+        </TxDtls></NtryDtls>
+      </Ntry>
+    </Ntfctn>
+  </BkToCstmrDbtCdtNtfctn>
+</Document>`;
+
+describe("BankFileLedgerConnector", () => {
+  it("deklarerar bara pullPayments-capability (invariant capability⇔metod håller)", () => {
+    const connector = connectorFor();
+    expect(connector.name).toBe("bankfil-camt");
+    expect(connector.capabilities()).toEqual({
+      pushVoucher: false,
+      pushInvoice: false,
+      pullPayments: true,
+      exportSie: false,
+    });
+    expect(() => assertConnectorMatchesCapabilities(connector)).not.toThrow();
+  });
+
+  it("parsar camt.054-fil → LedgerPayments (CRDT, belopp i öre, payerName)", async () => {
+    const payments = await connectorFor(read("camt.054_SE_CRED_BGC.xml")).pullPayments({ since: "2026-01-01" });
+    expect(payments).toHaveLength(2);
+    expect(payments.every((p) => ledgerPaymentSchema.safeParse(p).success)).toBe(true);
+    expect(payments[0]).toMatchObject({ externalId: "STOIIQ0I220505085240644513000001", amount: 100_00, payerName: "Debtor" });
+  });
+
+  it("väljer en giltig OCR-referens framför ett dokumentnummer", async () => {
+    const [payment] = await connectorFor(camtWithOcr).pullPayments({ since: "2026-01-01" });
+    expect(payment).toMatchObject({ externalId: "TX-OCR-1", amount: 125_00, ocrReference: OCR, date: "2026-06-01" });
+  });
+
+  it("dedupar på externalId över överlappande filer (idempotent)", async () => {
+    const once = await connectorFor(camtWithOcr).pullPayments({ since: "2026-01-01" });
+    const twice = await connectorFor(camtWithOcr, camtWithOcr).pullPayments({ since: "2026-01-01" });
+    expect(twice).toHaveLength(once.length);
+  });
+
+  it("tom källa → inga betalningar", async () => {
+    expect(await connectorFor().pullPayments({ since: "2026-01-01" })).toEqual([]);
+  });
+
+  it("fri-text-fil (inga strukturerade refs) → betalningar utan ocrReference", async () => {
+    const payments = await connectorFor(read("camt.054_SE.xml")).pullPayments({ since: "2026-01-01" });
+    expect(payments.length).toBeGreaterThan(0);
+    expect(payments.every((p) => p.ocrReference === undefined)).toBe(true);
+  });
+});

--- a/test/unit/server/integrations/ledger/capabilities.test.ts
+++ b/test/unit/server/integrations/ledger/capabilities.test.ts
@@ -86,7 +86,12 @@ describe("ledgerPaymentSchema (inbound, strikt)", () => {
     expect(p.payerName).toBeUndefined();
   });
 
-  it("avvisar negativt/icke-heltals-belopp och fel datumformat", () => {
+  it("godtar betalning utan datum (date är valfritt — camt kan sakna ValDt)", () => {
+    const p = ledgerPaymentSchema.parse({ externalId: "x", amount: 100 });
+    expect(p.date).toBeUndefined();
+  });
+
+  it("avvisar negativt/icke-heltals-belopp och fel datumformat (när satt)", () => {
     expect(ledgerPaymentSchema.safeParse({ externalId: "x", amount: -1, date: "2026-06-01" }).success).toBe(false);
     expect(ledgerPaymentSchema.safeParse({ externalId: "x", amount: 100.5, date: "2026-06-01" }).success).toBe(false);
     expect(ledgerPaymentSchema.safeParse({ externalId: "x", amount: 100, date: "1/6 2026" }).success).toBe(false);


### PR DESCRIPTION
Del av #233 (ADR 0011) — **sista steget i ledger-connector-epiken**. Formaliserar `pullPayments`-capability:n: avprickning via bankfil, ingen bankuppkoppling/PSD2 (bara filinläsning).

## Vad
- **`src/lib/server/integrations/ledger/bank-file-connector.ts`** — `BankFileLedgerConnector implements LedgerConnector`, bara `pullPayments`-capability. Sluter över sin filkälla (`loadCamtFiles(query)`, injiceras av runtime/UI — uppladdade filer eller server-runtime-peer) och bryggar den **befintliga** camt-parsern (#181, `shared/payments/camt-parse`) till portens flata `LedgerPayment`-DTO:
  - en CRDT-transaktion → en betalning (belopp i öre, `payerName` ur `Dbtr/Nm`),
  - `ocrReference` = en strukturerad referens som validerar mod-10 (`isValidOcrReference`), annars första referensen,
  - dedup på `externalId` över överlappande filer (idempotent), strikt zod-parse vid gränsen.
- **`port.ts`** — `LedgerPayment.date` blir **valfritt** (camt `ValDt` kan saknas; avprickningen nyckar på referens, inte datum). #234-testet uppdaterat.

## Avgränsning
Den rika camt-matchningen (flera referenser/delbelopp/fri text — `shared/payments/match-payments`, #181) ägs fortsatt av den detaljerade in-app-motorn. Porten ger den **vendor-neutrala** betalnings-listan för capability-gating + uniform pull (samma shape oavsett camt/BGMAX/Fortnox-invoicepayments).

## Verifierat
- Tester mot **riktiga SEB-camt-fixturer** (`camt.054_SE_CRED_BGC.xml`, `camt.054_SE.xml`) + inline-XML för OCR-valet och dedup. Capability-invariant via `assertConnectorMatchesCapabilities`.
- Lokalt grönt: typecheck, lint, `test:cov` (rader 83.39% / funk 80.28%, över golv), dep-cruiser (0 violations), knip, jscpd.

## Epiken #233 klar
#235 ✓ semantisk modell → #234 ✓ port + capabilities → #82 ✓ Fortnox bakom porten → #236 ✓ SIE-export → **#237 ✓ pullPayments/camt**. Fakturamodulen är nu bevisligen systemoberoende med fyra capabilities (pushVoucher/exportSie/pullPayments + pushInvoice-plats). Följd-issues: runtime-/UI-wiring av SIE-export + bankfil-uppladdning.

Refs #237 #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)