### PR TITLE
feat(invoices): exportera utfärdade fakturor som SIE-fil

### DIFF
--- a/src/app/invoices/_sie-export-button.tsx
+++ b/src/app/invoices/_sie-export-button.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+/**
+ * "Exportera SIE" (#244) — laddar ner byråns utfärdade fakturor som en SIE 4-fil
+ * för import i valfritt bokföringssystem. Ren klient-funktion (samma i demo +
+ * self-hosted): hämtar fakturor + org-info via tRPC, renderar SIE lokalt
+ * ([[sie-from-invoices]]) och triggar en nedladdning. Inaktiverad tills minst
+ * en utfärdad faktura finns.
+ */
+
+import { trpc } from "@/lib/client/trpc";
+import { downloadTextFile } from "@/lib/client/download-text";
+import {
+  countExportable,
+  invoicesToSie,
+  type ExportableInvoice,
+} from "@/lib/shared/accounting/sie-from-invoices";
+
+function pad2(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+/** Dagens datum som `YYYYMMDD` (lokal tid). */
+function todayStamp(): string {
+  const d = new Date();
+  return `${d.getFullYear()}${pad2(d.getMonth() + 1)}${pad2(d.getDate())}`;
+}
+
+export function SieExportButton() {
+  const invoices = trpc.invoice.list.useQuery({});
+  const org = trpc.organization.getSettings.useQuery();
+
+  const rows = (invoices.data ?? []) as ExportableInvoice[];
+  const exportableCount = countExportable(rows);
+
+  function handleExport(): void {
+    const stamp = todayStamp();
+    const sie = invoicesToSie(rows, {
+      company: {
+        name: org.data?.name ?? "Byrå",
+        ...(org.data?.orgNumber ? { orgNr: org.data.orgNumber } : {}),
+      },
+      generatedDate: stamp,
+    });
+    downloadTextFile(`bokforing_${stamp}.sie`, sie);
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleExport}
+      disabled={exportableCount === 0}
+      title={exportableCount === 0 ? "Inga utfärdade fakturor att exportera" : `Exportera ${exportableCount} verifikat`}
+      className="text-sm text-blue-600 hover:underline disabled:text-gray-400 disabled:no-underline disabled:cursor-not-allowed"
+    >
+      Exportera SIE →
+    </button>
+  );
+}

--- a/src/app/invoices/page.tsx
+++ b/src/app/invoices/page.tsx
@@ -5,6 +5,7 @@ import { trpc } from "@/lib/client/trpc";
 import { formatCurrency } from "@/lib/client/utils";
 import { EntityLink } from "@/lib/client/demo/entity-link";
 import { DataTable, type Column } from "@/components/ui/data-table";
+import { SieExportButton } from "./_sie-export-button";
 
 const STATUS_LABELS: Record<string, string> = {
   DRAFT: "Utkast",
@@ -87,9 +88,12 @@ export default function InvoicesPage() {
     <div>
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold text-gray-900">Fakturor</h1>
-        <Link href="/payments/import" className="text-sm text-blue-600 hover:underline">
-          Importera betalfil →
-        </Link>
+        <div className="flex items-center gap-4">
+          <SieExportButton />
+          <Link href="/payments/import" className="text-sm text-blue-600 hover:underline">
+            Importera betalfil →
+          </Link>
+        </div>
       </div>
       {invoices.isLoading ? (
         <div className="bg-white rounded-lg border border-gray-200 p-6">

--- a/src/lib/client/download-text.ts
+++ b/src/lib/client/download-text.ts
@@ -1,0 +1,20 @@
+/**
+ * Trigga en browser-nedladdning av en textfil (Blob + `<a download>`).
+ *
+ * Samma mönster som rapport-exporten (xlsx) men för text vi genererat i
+ * klienten (t.ex. SIE-fil, #244). Ingen server inblandad → fungerar i alla
+ * tiers.
+ */
+export function downloadTextFile(
+  filename: string,
+  content: string,
+  mime = "text/plain;charset=utf-8",
+): void {
+  const blob = new Blob([content], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/src/lib/shared/accounting/sie-from-invoices.ts
+++ b/src/lib/shared/accounting/sie-from-invoices.ts
@@ -1,0 +1,69 @@
+/**
+ * AVA-fakturor → SIE 4-fil (#244, ADR 0011-uppföljning).
+ *
+ * Orchestrerar den rena kedjan faktura → semantiskt verifikat ([[semantic-voucher]])
+ * → SIE-rendering ([[sie]]). Ren, framework-agnostisk funktion — körs lika gärna
+ * i browsern (demo + self-hosted) som på servern; ingen extern integration.
+ *
+ * Roll→konto använder BAS-standardkonton som default (advokatbyrå); en
+ * per-byrå-mappning som org-inställning är en naturlig följd-issue.
+ */
+
+import { buildSemanticVoucher, type SemanticVoucherInput } from "./semantic-voucher";
+import { renderSie, type SieAccountMap, type SieCompany } from "./sie";
+import type { VatRate } from "../vat";
+
+/** BAS-standardkonton för en advokatbyrå (default tills byrån mappar själv). */
+export const DEFAULT_BAS_ACCOUNT_MAP: SieAccountMap = {
+  kundfordran: { number: "1510", name: "Kundfordringar" },
+  intaktArvode: { number: "3041", name: "Advokatarvoden" },
+  momsUtgaende: { number: "2611", name: "Utgående moms 25 %" },
+  intaktUtlagg: { number: "3590", name: "Övriga sidointäkter" },
+};
+
+/** Bara utfärdade fakturor bokförs (samma som Fortnox-connectorn); ej DRAFT/CANCELLED/BAD_DEBT. */
+export const SIE_EXPORTABLE_STATUSES: readonly string[] = ["SENT", "PAID", "INSTALLMENT_PLAN"];
+
+/** Minsta faktura-fält exporten behöver. */
+export interface ExportableInvoice extends SemanticVoucherInput {
+  status: string;
+}
+
+export interface SieExportOptions {
+  company: SieCompany;
+  /** Genereringsdatum `YYYYMMDD` (för `#GEN`). */
+  generatedDate: string;
+  accountMap?: SieAccountMap;
+  /** Verifikatserie (default "A"). */
+  series?: string;
+  vatRate?: VatRate;
+}
+
+/** Hur många av fakturorna som är exporterbara (för UI-gating). */
+export function countExportable(invoices: readonly { status: string }[]): number {
+  return invoices.filter((i) => SIE_EXPORTABLE_STATUSES.includes(i.status)).length;
+}
+
+/** Verifikatnummer ur fakturanumrets siffror (unikt), annars löpande index. */
+function verNumber(inv: ExportableInvoice, index: number): string {
+  const digits = inv.invoiceNumber?.replace(/\D/g, "");
+  return digits ? digits : String(index + 1);
+}
+
+/** Rendera utfärdade fakturor till en SIE 4-fil. */
+export function invoicesToSie(
+  invoices: readonly ExportableInvoice[],
+  opts: SieExportOptions,
+): string {
+  const exportable = invoices.filter((i) => SIE_EXPORTABLE_STATUSES.includes(i.status));
+  const series = opts.series ?? "A";
+  return renderSie({
+    company: opts.company,
+    generatedDate: opts.generatedDate,
+    accountMap: opts.accountMap ?? DEFAULT_BAS_ACCOUNT_MAP,
+    vouchers: exportable.map((inv, i) => ({
+      meta: { series, number: verNumber(inv, i) },
+      voucher: buildSemanticVoucher(inv, opts.vatRate),
+    })),
+  });
+}

--- a/test/unit/app/invoices/page.test.tsx
+++ b/test/unit/app/invoices/page.test.tsx
@@ -17,6 +17,9 @@ vi.mock("@/lib/client/trpc", () => ({
     invoice: {
       list: { useQuery: () => invoicesQuery },
     },
+    organization: {
+      getSettings: { useQuery: () => ({ data: { name: "Byrå", orgNumber: "5566778899" } }) },
+    },
     prefs: {
       get: { useQuery: () => ({ data: undefined, isLoading: false }) },
       save: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },

--- a/test/unit/app/sie-export-button.test.tsx
+++ b/test/unit/app/sie-export-button.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest-compat";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SieExportButton } from "@/app/invoices/_sie-export-button";
+
+const downloadMock = vi.fn();
+
+vi.mock("@/lib/client/download-text", () => ({
+  downloadTextFile: (...args: unknown[]) => downloadMock(...args),
+}));
+
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: {
+    invoice: {
+      list: {
+        useQuery: () => ({
+          data: [
+            { amount: 12_500, invoiceDate: "2026-05-25", invoiceNumber: "F-2026-0042", status: "SENT" },
+            { amount: 9_999, invoiceDate: "2026-05-01", invoiceNumber: "F-1", status: "DRAFT" },
+          ],
+        }),
+      },
+    },
+    organization: {
+      getSettings: { useQuery: () => ({ data: { name: "Byrå X", orgNumber: "5566778899" } }) },
+    },
+  },
+}));
+
+describe("SieExportButton", () => {
+  it("renderar en aktiv knapp när det finns utfärdade fakturor", () => {
+    render(<SieExportButton />);
+    const btn = screen.getByRole("button", { name: /Exportera SIE/ });
+    expect(btn).not.toBeDisabled();
+  });
+
+  it("klick laddar ner en SIE-fil med byråns namn + verifikat", () => {
+    render(<SieExportButton />);
+    fireEvent.click(screen.getByRole("button", { name: /Exportera SIE/ }));
+
+    expect(downloadMock).toHaveBeenCalledTimes(1);
+    const [filename, content] = downloadMock.mock.calls[0] as [string, string];
+    expect(filename).toMatch(/^bokforing_\d{8}\.sie$/);
+    expect(content).toContain('#FNAMN "Byrå X"');
+    expect(content).toContain("#ORGNR 5566778899");
+    // bara SENT-fakturan exporteras, inte DRAFT
+    expect(content).toContain('#VER "A" "20260042"');
+    expect(content.includes('"F-1"')).toBe(false);
+  });
+});

--- a/test/unit/lib/client/download-text.test.ts
+++ b/test/unit/lib/client/download-text.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from "vitest-compat";
+import { downloadTextFile } from "@/lib/client/download-text";
+
+describe("downloadTextFile", () => {
+  it("skapar en Blob, klickar en <a download> och städar URL:en", () => {
+    const createObjectURL = vi.fn(() => "blob:fake");
+    const revokeObjectURL = vi.fn();
+    const urlDesc = Object.getOwnPropertyDescriptor(URL, "createObjectURL");
+    const revokeDesc = Object.getOwnPropertyDescriptor(URL, "revokeObjectURL");
+    Object.defineProperty(URL, "createObjectURL", { value: createObjectURL, configurable: true, writable: true });
+    Object.defineProperty(URL, "revokeObjectURL", { value: revokeObjectURL, configurable: true, writable: true });
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    try {
+      downloadTextFile("bok.sie", "#FLAGGA 0\r\n");
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
+      expect(createObjectURL.mock.calls[0]![0]).toBeInstanceOf(Blob);
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:fake");
+    } finally {
+      clickSpy.mockRestore();
+      if (urlDesc) Object.defineProperty(URL, "createObjectURL", urlDesc);
+      if (revokeDesc) Object.defineProperty(URL, "revokeObjectURL", revokeDesc);
+    }
+  });
+});

--- a/test/unit/shared/accounting/sie-from-invoices.test.ts
+++ b/test/unit/shared/accounting/sie-from-invoices.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest-compat";
+import {
+  invoicesToSie,
+  countExportable,
+  DEFAULT_BAS_ACCOUNT_MAP,
+  type ExportableInvoice,
+} from "@/lib/shared/accounting/sie-from-invoices";
+
+const company = { name: "Advokatbyrå AB", orgNr: "5566778899" };
+
+const inv = (over: Partial<ExportableInvoice> = {}): ExportableInvoice => ({
+  amount: 12_500,
+  invoiceDate: "2026-05-25",
+  invoiceNumber: "F-2026-0042",
+  status: "SENT",
+  ...over,
+});
+
+const lines = (sie: string) => sie.split("\r\n");
+
+describe("countExportable", () => {
+  it("räknar bara utfärdade (SENT/PAID/INSTALLMENT_PLAN)", () => {
+    const rows = [inv(), inv({ status: "PAID" }), inv({ status: "DRAFT" }), inv({ status: "CANCELLED" })];
+    expect(countExportable(rows)).toBe(2);
+  });
+});
+
+describe("invoicesToSie", () => {
+  it("renderar utfärdade fakturor med BAS-default-konton + #GEN", () => {
+    const sie = invoicesToSie([inv()], { company, generatedDate: "20260612" });
+    expect(sie).toContain("#GEN 20260612");
+    expect(sie).toContain('#FNAMN "Advokatbyrå AB"');
+    expect(sie).toContain("#ORGNR 5566778899");
+    expect(sie).toContain('#KONTO 1510 "Kundfordringar"');
+    // Verifikatnr ur fakturanumrets siffror
+    expect(sie).toContain('#VER "A" "20260042" 20260525 "Faktura F-2026-0042"');
+    expect(sie).toContain("#TRANS 1510 {} 125.00");
+  });
+
+  it("hoppar över ej utfärdade fakturor (DRAFT/CANCELLED)", () => {
+    const sie = invoicesToSie([inv({ status: "DRAFT" }), inv({ status: "CANCELLED" })], {
+      company,
+      generatedDate: "20260612",
+    });
+    expect(sie.includes("#VER")).toBe(false);
+  });
+
+  it("faller tillbaka på löpande verifikatnr när fakturanummer saknas", () => {
+    const sie = invoicesToSie([inv({ invoiceNumber: null })], { company, generatedDate: "20260612" });
+    expect(sie).toContain('#VER "A" "1"');
+  });
+
+  it("kreditfaktura (negativt belopp) renderas med vänd debet/kredit", () => {
+    const sie = lines(invoicesToSie([inv({ amount: -12_500, invoiceNumber: "K-1" })], { company, generatedDate: "20260612" }));
+    // kundfordran krediteras → negativt belopp på 1510
+    expect(sie).toContain("   #TRANS 1510 {} -125.00");
+  });
+
+  it("DEFAULT_BAS_ACCOUNT_MAP täcker alla fyra roller", () => {
+    expect(Object.keys(DEFAULT_BAS_ACCOUNT_MAP).sort()).toEqual(
+      ["intaktArvode", "intaktUtlagg", "kundfordran", "momsUtgaende"].sort(),
+    );
+  });
+});


### PR DESCRIPTION
Följd på #236 (ADR 0011) — wire:ar in SIE-exporten i UI:t (#244). En **"Exportera SIE"-knapp** i fakturalistans header laddar ner byråns utfärdade fakturor som en SIE 4-fil för import i valfritt bokföringssystem.

Ren klient-funktion → fungerar i **både demo och self-hosted** (ingen extern integration, ingen server): hämtar fakturor + org-info via tRPC, renderar SIE lokalt, triggar nedladdning.

## Vad
- **`src/lib/shared/accounting/sie-from-invoices.ts`** — orchestrerar faktura → semantiskt verifikat (#235) → SIE (#236). Filtrerar till utfärdade (SENT/PAID/INSTALLMENT_PLAN), verifikatnr ur fakturanumrets siffror (fallback löpande), **BAS-standardkonton** som default (`DEFAULT_BAS_ACCOUNT_MAP` — 1510/3041/2611/3590; per-byrå-mappning som org-inställning är en naturlig följd-issue). `countExportable` för UI-gating.
- **`src/lib/client/download-text.ts`** — liten Blob + `<a download>`-helper (samma mönster som xlsx-rapportexporten).
- **`src/app/invoices/_sie-export-button.tsx`** — knappen i fakturalistans header, inaktiverad tills minst en utfärdad faktura finns.

## Verifierat
- Tester: pure-modulen (status-filter, verifikatnr-fallback, kreditfaktura med vänd debet/kredit, BAS-default), download-helpern (Blob/click/cleanup), knappen (klick → nedladdning med rätt filnamn `bokforing_YYYYMMDD.sie` + innehåll, bara utfärdade exporteras). InvoicesPage-testets trpc-mock uppdaterad.
- Lokalt grönt: typecheck, lint, `test:cov` (rader 83.44% / funk 80.34%, över golv), dep-cruiser, knip, jscpd.

## Känd begränsning / följd-issues
- Filen skrivs UTF-8 medan headern deklarerar `#FORMAT PC8` (CP437) — åäö i byrånamn/kontonamn kan behöva CP437-kodning för strikta importörer; hårdgöring av teckenkodning är en lämplig följd-issue.
- Konfigurerbar BAS-konto-mappning som org-inställning (jfr Fortnox #217).

Refs #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)