### PR TITLE
feat(settings): konfigurerbar konto-mappning (BAS) för bokföringsexport

### DIFF
--- a/src/app/invoices/_sie-export-button.tsx
+++ b/src/app/invoices/_sie-export-button.tsx
@@ -12,6 +12,11 @@ import { trpc } from "@/lib/client/trpc";
 import { downloadBytes } from "@/lib/client/download-text";
 import { encodePc8 } from "@/lib/shared/accounting/pc8";
 import {
+  DEFAULT_LEDGER_ACCOUNT_MAP,
+  toSieAccountMap,
+  type LedgerAccountMap,
+} from "@/lib/shared/accounting/account-map";
+import {
   countExportable,
   invoicesToSie,
   type ExportableInvoice,
@@ -36,12 +41,16 @@ export function SieExportButton() {
 
   function handleExport(): void {
     const stamp = todayStamp();
+    // Byråns mappning om konfigurerad (#249), annars BAS-standard.
+    const map = (org.data?.ledgerAccountMap as LedgerAccountMap | null) ?? DEFAULT_LEDGER_ACCOUNT_MAP;
     const sie = invoicesToSie(rows, {
       company: {
         name: org.data?.name ?? "Byrå",
         ...(org.data?.orgNumber ? { orgNr: org.data.orgNumber } : {}),
       },
       generatedDate: stamp,
+      accountMap: toSieAccountMap(map),
+      series: map.voucherSeries,
     });
     // SIE deklarerar #FORMAT PC8 → koda bytes i CP437 så åäö tolkas rätt (#247).
     downloadBytes(`bokforing_${stamp}.sie`, encodePc8(sie));

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -9,6 +9,7 @@ import { ExternalEditSection } from "@/components/settings/external-edit-section
 import { EditorExtensionsSection } from "@/components/settings/editor-extensions-section";
 import { LlmSettingsCard } from "@/components/llm/llm-settings-card";
 import { OrgDefaultsSection } from "@/components/settings/org-defaults-section";
+import { LedgerAccountsSection } from "@/components/settings/ledger-accounts-section";
 import { HelperSection } from "@/components/settings/helper-section";
 
 // Zod vid parsegränsen (#187): logo-API:ts svar valideras.
@@ -525,8 +526,12 @@ export default function SettingsPage() {
       <SectionHeader num={5} title="Standardvyer (admin)" subtitle="Org-globala kolumn- och sort-defaults för listor. Personliga val vinner över org-defaults." />
       <OrgDefaultsSection />
 
-      {/* 6. Avancerat / opt-in */}
-      <SectionHeader num={6} title="Avancerat" subtitle="Opt-in-funktioner som kräver extra resurser eller setup." />
+      {/* 6. Bokföringsexport */}
+      <SectionHeader num={6} title="Bokföringsexport (admin)" subtitle="Konto-mappning (BAS) som SIE-exporten bokför mot. Förifyllt med standard för advokatbyrå." />
+      <LedgerAccountsSection />
+
+      {/* 7. Avancerat / opt-in */}
+      <SectionHeader num={7} title="Avancerat" subtitle="Opt-in-funktioner som kräver extra resurser eller setup." />
       <div className="mb-5">
         <LlmSettingsCard />
       </div>

--- a/src/components/settings/ledger-accounts-section.tsx
+++ b/src/components/settings/ledger-accounts-section.tsx
@@ -8,7 +8,7 @@
  * obligatoriska rollerna.
  */
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { trpc } from "@/lib/client/trpc";
 import {
   DEFAULT_LEDGER_ACCOUNT_MAP,
@@ -157,8 +157,18 @@ function LedgerAccountForm({ initial }: { initial: LedgerAccountMap }) {
 }
 
 export function LedgerAccountsSection() {
-  const me = trpc.user.current.useQuery();
-  const settings = trpc.organization.getSettings.useQuery();
+  // Mount-grind: rendera inget förrän appen hydrerat + bootstrap:en är klar.
+  // Under self-hosted-bootstrapen ("Laddar data…") pågår en re-render-cykel i
+  // shell:en; att delta i den render-fasen med queries/formulär svälter
+  // commit-fasen (#249-regression). Vi väntar därför till post-mount.
+  const [mounted, setMounted] = useState(false);
+  // eslint-disable-next-line react-hooks/set-state-in-effect -- engångs-flip post-mount; det ÄR avsikten (jfr demo-bootstrap)
+  useEffect(() => setMounted(true), []);
+
+  const me = trpc.user.current.useQuery(undefined, { enabled: mounted });
+  const settings = trpc.organization.getSettings.useQuery(undefined, { enabled: mounted });
+
+  if (!mounted) return null;
 
   if (me.data?.role !== "ADMIN") {
     return (

--- a/src/components/settings/ledger-accounts-section.tsx
+++ b/src/components/settings/ledger-accounts-section.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+/**
+ * `LedgerAccountsSection` (#249) — admin redigerar byråns roll→konto-mappning
+ * (BAS-konton + verifikatserie) som används av bokföringsexporten (SIE m.fl.).
+ * Förifylls med byråns sparade mappning, annars BAS-standard. Strikt zod-
+ * validering vid spar; completeness-gaten i renderaren kräver de tre
+ * obligatoriska rollerna.
+ */
+
+import { useState } from "react";
+import { trpc } from "@/lib/client/trpc";
+import {
+  DEFAULT_LEDGER_ACCOUNT_MAP,
+  ledgerAccountMapSchema,
+  type LedgerAccount,
+  type LedgerAccountMap,
+} from "@/lib/shared/accounting/account-map";
+
+interface RoleDef {
+  key: "kundfordran" | "intaktArvode" | "momsUtgaende" | "intaktUtlagg";
+  label: string;
+  optional?: boolean;
+}
+
+const ROLES: readonly RoleDef[] = [
+  { key: "kundfordran", label: "Kundfordran (debet)" },
+  { key: "intaktArvode", label: "Intäkt arvode (kredit)" },
+  { key: "momsUtgaende", label: "Utgående moms (kredit)" },
+  { key: "intaktUtlagg", label: "Intäkt utlägg (valfritt)", optional: true },
+];
+
+type Draft = Record<RoleDef["key"], LedgerAccount>;
+
+function toDraft(map: LedgerAccountMap): Draft {
+  const empty: LedgerAccount = { number: "", name: "" };
+  return {
+    kundfordran: map.kundfordran,
+    intaktArvode: map.intaktArvode,
+    momsUtgaende: map.momsUtgaende,
+    intaktUtlagg: map.intaktUtlagg ?? empty,
+  };
+}
+
+/** Bygg en (ev. ogiltig) mappning ur formuläret; tomt utläggskonto utelämnas. */
+function draftToMap(series: string, draft: Draft): unknown {
+  const utlagg = draft.intaktUtlagg;
+  const hasUtlagg = utlagg.number !== "" || utlagg.name !== "";
+  return {
+    voucherSeries: series,
+    kundfordran: draft.kundfordran,
+    intaktArvode: draft.intaktArvode,
+    momsUtgaende: draft.momsUtgaende,
+    ...(hasUtlagg ? { intaktUtlagg: utlagg } : {}),
+  };
+}
+
+function AccountRow({
+  role,
+  value,
+  onChange,
+}: {
+  role: RoleDef;
+  value: LedgerAccount;
+  onChange: (next: LedgerAccount) => void;
+}) {
+  return (
+    <div className="flex items-center gap-3 py-1.5">
+      <label className="w-48 text-sm text-gray-700">{role.label}</label>
+      <input
+        aria-label={`${role.label} kontonummer`}
+        value={value.number}
+        onChange={(e) => onChange({ ...value, number: e.target.value })}
+        placeholder="1510"
+        className="w-24 rounded border border-gray-300 px-2 py-1 text-sm font-mono"
+      />
+      <input
+        aria-label={`${role.label} kontonamn`}
+        value={value.name}
+        onChange={(e) => onChange({ ...value, name: e.target.value })}
+        placeholder="Kontonamn"
+        className="flex-1 rounded border border-gray-300 px-2 py-1 text-sm"
+      />
+    </div>
+  );
+}
+
+function LedgerAccountForm({ initial }: { initial: LedgerAccountMap }) {
+  const utils = trpc.useUtils();
+  const [series, setSeries] = useState(initial.voucherSeries);
+  const [draft, setDraft] = useState<Draft>(() => toDraft(initial));
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+  const save = trpc.organization.updateSettings.useMutation({
+    onSuccess: () => {
+      setSaved(true);
+      void utils.organization.getSettings.invalidate();
+    },
+  });
+
+  function setRole(key: RoleDef["key"], next: LedgerAccount): void {
+    setSaved(false);
+    setDraft((d) => ({ ...d, [key]: next }));
+  }
+
+  function handleSave(): void {
+    const parsed = ledgerAccountMapSchema.safeParse(draftToMap(series, draft));
+    if (!parsed.success) {
+      setError(parsed.error.issues[0]?.message ?? "Ogiltig konto-mappning");
+      return;
+    }
+    setError(null);
+    save.mutate({ ledgerAccountMap: parsed.data });
+  }
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-5 mb-5">
+      <h2 className="font-semibold text-gray-900 mb-1">Konto-mappning (bokföringsexport)</h2>
+      <p className="text-xs text-gray-500 mb-4">
+        BAS-konton som SIE-exporten bokför mot. Förifyllt med standard för advokatbyrå.
+      </p>
+
+      <div className="flex items-center gap-3 py-1.5 mb-2">
+        <label className="w-48 text-sm text-gray-700">Verifikatserie</label>
+        <input
+          aria-label="Verifikatserie"
+          value={series}
+          onChange={(e) => {
+            setSaved(false);
+            setSeries(e.target.value);
+          }}
+          placeholder="A"
+          className="w-24 rounded border border-gray-300 px-2 py-1 text-sm font-mono"
+        />
+      </div>
+
+      {ROLES.map((role) => (
+        <AccountRow key={role.key} role={role} value={draft[role.key]} onChange={(next) => setRole(role.key, next)} />
+      ))}
+
+      <div className="mt-4 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={save.isPending}
+          className="rounded bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          Spara mappning
+        </button>
+        {save.isPending && <span className="text-xs text-gray-500">Sparar…</span>}
+        {saved && !error && <span className="text-xs text-green-600">Sparat ✓</span>}
+        {error && <span className="text-xs text-red-600">{error}</span>}
+        {save.error && <span className="text-xs text-red-600">{save.error.message}</span>}
+      </div>
+    </div>
+  );
+}
+
+export function LedgerAccountsSection() {
+  const me = trpc.user.current.useQuery();
+  const settings = trpc.organization.getSettings.useQuery();
+
+  if (me.data?.role !== "ADMIN") {
+    return (
+      <div className="bg-white border border-gray-200 rounded-lg p-5 mb-5">
+        <p className="text-sm text-gray-500">Endast administratörer kan redigera konto-mappningen.</p>
+      </div>
+    );
+  }
+  if (settings.isLoading) {
+    return (
+      <div className="bg-white border border-gray-200 rounded-lg p-5 mb-5">
+        <p className="text-xs text-gray-400">Laddar…</p>
+      </div>
+    );
+  }
+
+  const initial = (settings.data?.ledgerAccountMap as LedgerAccountMap | null) ?? DEFAULT_LEDGER_ACCOUNT_MAP;
+  return <LedgerAccountForm initial={initial} />;
+}

--- a/src/lib/server/routers/organization.ts
+++ b/src/lib/server/routers/organization.ts
@@ -3,6 +3,7 @@ import { TRPCError } from "@trpc/server";
 import { router, protectedProcedure } from "../trpc";
 import { organizationIdSchema, asId } from "@/lib/shared/schemas/ids";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
+import { ledgerAccountMapSchema } from "@/lib/shared/accounting/account-map";
 
 export const organizationRouter = router({
   // ── Settings ────────────────────────────────────────────────────
@@ -19,6 +20,7 @@ export const organizationRouter = router({
         email: true,
         bankgiro: true,
         logoPath: true,
+        ledgerAccountMap: true,
       },
     });
   }),
@@ -32,6 +34,8 @@ export const organizationRouter = router({
         phone: z.string().optional(),
         email: z.string().optional(),
         bankgiro: z.string().optional(),
+        /** Roll→konto-mappning för bokföringsexport (#249). */
+        ledgerAccountMap: ledgerAccountMapSchema.optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {

--- a/src/lib/shared/accounting/account-map.ts
+++ b/src/lib/shared/accounting/account-map.ts
@@ -1,0 +1,51 @@
+/**
+ * Konto-mappning per byrå (#249, ADR 0011-uppföljning).
+ *
+ * Vendor-neutral roll→konto-mappning som org-inställning: vilka BAS-konton
+ * (nummer + namn) + verifikatserie en byrå bokför sina semantiska verifikat
+ * ([[semantic-voucher]]) mot. Används av SIE-exporten ([[sie-from-invoices]]);
+ * samma modell kan senare driva Fortnox-mappningen (#217). Strikt zod.
+ */
+
+import { z } from "zod";
+import type { SieAccountMap } from "./sie";
+
+/** Ett bokföringskonto: BAS-nummer (4–6 siffror) + namn (för SIE #KONTO). */
+export const ledgerAccountSchema = z.object({
+  number: z.string().regex(/^\d{4,6}$/, "Kontonummer ska vara 4–6 siffror"),
+  name: z.string().min(1),
+});
+export type LedgerAccount = z.infer<typeof ledgerAccountSchema>;
+
+/**
+ * Roll→konto + verifikatserie. `intaktUtlagg` är valfritt (bara byråer som
+ * vidarefakturerar utlägg behöver det). Övriga roller är obligatoriska — utan
+ * dem kan ett verifikat inte balanseras (completeness-gate i renderaren).
+ */
+export const ledgerAccountMapSchema = z.object({
+  voucherSeries: z.string().min(1),
+  kundfordran: ledgerAccountSchema,
+  intaktArvode: ledgerAccountSchema,
+  momsUtgaende: ledgerAccountSchema,
+  intaktUtlagg: ledgerAccountSchema.optional(),
+});
+export type LedgerAccountMap = z.infer<typeof ledgerAccountMapSchema>;
+
+/** BAS-standard för en advokatbyrå (default tills byrån redigerar själv). */
+export const DEFAULT_LEDGER_ACCOUNT_MAP: LedgerAccountMap = {
+  voucherSeries: "A",
+  kundfordran: { number: "1510", name: "Kundfordringar" },
+  intaktArvode: { number: "3041", name: "Advokatarvoden" },
+  momsUtgaende: { number: "2611", name: "Utgående moms 25 %" },
+  intaktUtlagg: { number: "3590", name: "Övriga sidointäkter" },
+};
+
+/** Plocka ut roll→konto-delen (utan serie) som SIE-renderarens `SieAccountMap`. */
+export function toSieAccountMap(map: LedgerAccountMap): SieAccountMap {
+  return {
+    kundfordran: map.kundfordran,
+    intaktArvode: map.intaktArvode,
+    momsUtgaende: map.momsUtgaende,
+    ...(map.intaktUtlagg ? { intaktUtlagg: map.intaktUtlagg } : {}),
+  };
+}

--- a/src/lib/shared/accounting/sie-from-invoices.ts
+++ b/src/lib/shared/accounting/sie-from-invoices.ts
@@ -5,21 +5,17 @@
  * → SIE-rendering ([[sie]]). Ren, framework-agnostisk funktion — körs lika gärna
  * i browsern (demo + self-hosted) som på servern; ingen extern integration.
  *
- * Roll→konto använder BAS-standardkonton som default (advokatbyrå); en
- * per-byrå-mappning som org-inställning är en naturlig följd-issue.
+ * Roll→konto använder byråns konto-mappning ([[account-map]]); faller tillbaka
+ * på BAS-standard när ingen mappning är konfigurerad.
  */
 
+import { DEFAULT_LEDGER_ACCOUNT_MAP, toSieAccountMap } from "./account-map";
 import { buildSemanticVoucher, type SemanticVoucherInput } from "./semantic-voucher";
 import { renderSie, type SieAccountMap, type SieCompany } from "./sie";
 import type { VatRate } from "../vat";
 
 /** BAS-standardkonton för en advokatbyrå (default tills byrån mappar själv). */
-export const DEFAULT_BAS_ACCOUNT_MAP: SieAccountMap = {
-  kundfordran: { number: "1510", name: "Kundfordringar" },
-  intaktArvode: { number: "3041", name: "Advokatarvoden" },
-  momsUtgaende: { number: "2611", name: "Utgående moms 25 %" },
-  intaktUtlagg: { number: "3590", name: "Övriga sidointäkter" },
-};
+export const DEFAULT_BAS_ACCOUNT_MAP: SieAccountMap = toSieAccountMap(DEFAULT_LEDGER_ACCOUNT_MAP);
 
 /** Bara utfärdade fakturor bokförs (samma som Fortnox-connectorn); ej DRAFT/CANCELLED/BAD_DEBT. */
 export const SIE_EXPORTABLE_STATUSES: readonly string[] = ["SENT", "PAID", "INSTALLMENT_PLAN"];

--- a/src/lib/shared/schemas/organization.ts
+++ b/src/lib/shared/schemas/organization.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { baseFields, dateLike } from "./common";
 import { organizationIdSchema, officeIdSchema } from "./ids";
+import { ledgerAccountMapSchema } from "../accounting/account-map";
 
 /**
  * Organisation = byrå. En per git-repo (vanligen). Lagras i
@@ -18,6 +19,8 @@ export const organizationSchema = z.object({
   logoPath: z.string().nullish(),
   /** Entra ID tenant-id för O365 single-tenant-inloggning. Server-only fält. */
   azureTenantId: z.string().nullish(),
+  /** Per-byrå roll→konto-mappning för bokföringsexport (SIE m.fl., #249). */
+  ledgerAccountMap: ledgerAccountMapSchema.nullish(),
 }).passthrough();
 
 export type Organization = z.infer<typeof organizationSchema>;

--- a/test/unit/app/settings/page.test.tsx
+++ b/test/unit/app/settings/page.test.tsx
@@ -37,6 +37,10 @@ vi.mock("@/components/settings/datasource-section", () => ({
 vi.mock("@/components/settings/org-defaults-section", () => ({
   OrgDefaultsSection: () => null,
 }));
+// LedgerAccountsSection har separat täckning — stubba ut för isolering.
+vi.mock("@/components/settings/ledger-accounts-section", () => ({
+  LedgerAccountsSection: () => null,
+}));
 
 vi.mock("@/lib/client/trpc", () => ({
   trpc: {

--- a/test/unit/components/settings/ledger-accounts-section.test.tsx
+++ b/test/unit/components/settings/ledger-accounts-section.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest-compat";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { LedgerAccountsSection } from "@/components/settings/ledger-accounts-section";
+
+const state = { role: "ADMIN" as string };
+const mutate = vi.fn();
+
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: {
+    useUtils: () => ({ organization: { getSettings: { invalidate: vi.fn() } } }),
+    user: { current: { useQuery: () => ({ data: { role: state.role } }) } },
+    organization: {
+      getSettings: { useQuery: () => ({ data: { ledgerAccountMap: null }, isLoading: false }) },
+      updateSettings: {
+        useMutation: (opts?: { onSuccess?: () => void }) => ({
+          mutate: (...args: unknown[]) => {
+            mutate(...args);
+            opts?.onSuccess?.();
+          },
+          isPending: false,
+          error: null,
+        }),
+      },
+    },
+  },
+}));
+
+describe("LedgerAccountsSection", () => {
+  it("admin: förifyller BAS-default och sparar ändrad mappning", () => {
+    state.role = "ADMIN";
+    mutate.mockClear();
+    render(<LedgerAccountsSection />);
+
+    const kundNr = screen.getByLabelText(/Kundfordran.*kontonummer/) as HTMLInputElement;
+    expect(kundNr.value).toBe("1510"); // BAS-default förifyllt
+
+    fireEvent.change(kundNr, { target: { value: "1511" } });
+    fireEvent.click(screen.getByRole("button", { name: /Spara mappning/ }));
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    const arg = mutate.mock.calls[0]![0] as { ledgerAccountMap: { kundfordran: { number: string } } };
+    expect(arg.ledgerAccountMap.kundfordran.number).toBe("1511");
+    expect(screen.getByText(/Sparat/)).toBeTruthy();
+  });
+
+  it("admin: ogiltigt kontonummer ger valideringsfel utan att spara", () => {
+    state.role = "ADMIN";
+    mutate.mockClear();
+    render(<LedgerAccountsSection />);
+
+    const momsNr = screen.getByLabelText(/Utgående moms.*kontonummer/) as HTMLInputElement;
+    fireEvent.change(momsNr, { target: { value: "26" } }); // för kort
+    fireEvent.click(screen.getByRole("button", { name: /Spara mappning/ }));
+
+    expect(mutate).not.toHaveBeenCalled();
+    expect(screen.getByText(/siffror/)).toBeTruthy();
+  });
+
+  it("icke-admin ser bara ett meddelande", () => {
+    state.role = "LAWYER";
+    render(<LedgerAccountsSection />);
+    expect(screen.getByText(/Endast administratörer/)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Spara mappning/ })).toBeNull();
+  });
+});

--- a/test/unit/shared/accounting/account-map.test.ts
+++ b/test/unit/shared/accounting/account-map.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest-compat";
+import {
+  ledgerAccountMapSchema,
+  toSieAccountMap,
+  DEFAULT_LEDGER_ACCOUNT_MAP,
+  type LedgerAccountMap,
+} from "@/lib/shared/accounting/account-map";
+
+const valid: LedgerAccountMap = {
+  voucherSeries: "A",
+  kundfordran: { number: "1510", name: "Kundfordringar" },
+  intaktArvode: { number: "3041", name: "Advokatarvoden" },
+  momsUtgaende: { number: "2611", name: "Utgående moms" },
+};
+
+describe("ledgerAccountMapSchema", () => {
+  it("godtar en giltig mappning (utan utlägg)", () => {
+    expect(ledgerAccountMapSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it("godtar valfritt utläggskonto", () => {
+    const withUtlagg = { ...valid, intaktUtlagg: { number: "3590", name: "Utlägg" } };
+    expect(ledgerAccountMapSchema.safeParse(withUtlagg).success).toBe(true);
+  });
+
+  it("avvisar kontonummer som inte är 4–6 siffror", () => {
+    expect(ledgerAccountMapSchema.safeParse({ ...valid, kundfordran: { number: "15", name: "x" } }).success).toBe(false);
+    expect(ledgerAccountMapSchema.safeParse({ ...valid, kundfordran: { number: "ABCD", name: "x" } }).success).toBe(false);
+  });
+
+  it("avvisar saknad obligatorisk roll", () => {
+    const { momsUtgaende: _omit, ...rest } = valid;
+    expect(ledgerAccountMapSchema.safeParse(rest).success).toBe(false);
+  });
+
+  it("avvisar tomt kontonamn", () => {
+    expect(ledgerAccountMapSchema.safeParse({ ...valid, intaktArvode: { number: "3041", name: "" } }).success).toBe(false);
+  });
+});
+
+describe("toSieAccountMap", () => {
+  it("plockar ut roll→konto utan serie", () => {
+    expect(toSieAccountMap(valid)).toEqual({
+      kundfordran: { number: "1510", name: "Kundfordringar" },
+      intaktArvode: { number: "3041", name: "Advokatarvoden" },
+      momsUtgaende: { number: "2611", name: "Utgående moms" },
+    });
+  });
+
+  it("tar med utläggskontot när det finns", () => {
+    const out = toSieAccountMap({ ...valid, intaktUtlagg: { number: "3590", name: "Utlägg" } });
+    expect(out.intaktUtlagg).toEqual({ number: "3590", name: "Utlägg" });
+  });
+});
+
+describe("DEFAULT_LEDGER_ACCOUNT_MAP", () => {
+  it("är en giltig mappning med serie A och fyra roller", () => {
+    expect(ledgerAccountMapSchema.safeParse(DEFAULT_LEDGER_ACCOUNT_MAP).success).toBe(true);
+    expect(DEFAULT_LEDGER_ACCOUNT_MAP.voucherSeries).toBe("A");
+    expect(DEFAULT_LEDGER_ACCOUNT_MAP.intaktUtlagg).toBeDefined();
+  });
+});


### PR DESCRIPTION
Följd på #244/#236. Byrån kan nu **redigera roll→konto-mappningen** som SIE-exporten bokför mot, i stället för hårdkodade BAS-standardkonton.

## Vad
- **`src/lib/shared/accounting/account-map.ts`** — `ledgerAccountMapSchema` (voucherSeries + roll→`{number,name}`, strikt zod), `DEFAULT_LEDGER_ACCOUNT_MAP` (BAS-standard för advokatbyrå), `toSieAccountMap`. `sie-from-invoices` härleder nu sin default härifrån (en sanningskälla).
- **`organizationSchema` + organization-routern** — nytt fält `ledgerAccountMap` (`getSettings` select + `updateSettings` input, strikt validerat; lagras i org-JSON i git).
- **`LedgerAccountsSection`** i /settings (admin-gated) — förifylls med byråns sparade mappning, annars BAS-default; verifikatserie + 4 roll-rader (kundfordran/intäkt arvode/utgående moms/utlägg), zod-validering vid spar.
- **SIE-export-knappen** läser byråns mappning (fallback default) och skickar konto-map + serie till renderaren.

Vendor-neutral → samma mappning kan senare driva Fortnox-connectorn (#217).

## Verifierat
- Tester: schema-validering (nummerformat, saknad roll, tomt namn), `toSieAccountMap`, default; sektionen (förifyll BAS, spara ändring → mutation, valideringsfel utan spar, icke-admin-vy); SettingsPage-mock uppdaterad (stubbar sektionen, jfr DatasourceSection/OrgDefaultsSection).
- Lokalt grönt: typecheck, lint, `test:cov` (rader 83.53% / funk 80.39%), dep-cruiser, knip, jscpd.

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)