### PR TITLE
feat(ledger): server-runtime-peer som auto-prickar av betalningar (bankfil)

### DIFF
--- a/src/bin/server-runtime.ts
+++ b/src/bin/server-runtime.ts
@@ -18,6 +18,7 @@
 import { ENV_KEYS, loadRuntimeConfig } from "@/lib/server/local-first/server-runtime-config";
 import { startServerRuntime } from "@/lib/server/local-first/server-runtime";
 import { buildFortnoxJob } from "@/lib/server/integrations/fortnox/runtime";
+import { buildBankFilePaymentsJob } from "@/lib/server/integrations/ledger/bank-file-runtime";
 import { makeRulesJob } from "@/lib/server/local-first/rules-job";
 import { composeJobs } from "@/lib/server/local-first/compose-jobs";
 
@@ -61,7 +62,10 @@ async function main(): Promise<void> {
   // composeJobs kör båda i samma cykel; no-empty-commit-grinden (#80) ser till
   // att tomma tick:ar inte pushar.
   const fortnox = await buildFortnoxJob({ workDir: config.workDir });
-  const job = composeJobs([makeRulesJob({ log }), fortnox]);
+  // Bankfil-avprickning (#245): bara när AVA_CAMT_INBOX pekar på en mapp med
+  // camt-filer; annars null → ingen avprickning (riskfritt).
+  const payments = buildBankFilePaymentsJob({ log });
+  const job = composeJobs([makeRulesJob({ log }), fortnox, payments]);
   const loop = await startServerRuntime(config, job ? { job } : {});
 
   if (argv.includes("--once")) {

--- a/src/lib/server/integrations/ledger/bank-file-runtime.ts
+++ b/src/lib/server/integrations/ledger/bank-file-runtime.ts
@@ -1,0 +1,54 @@
+/**
+ * Boot-wiring av bankfil-avprickningen för server-runtime:n (#245).
+ *
+ * Bygger ett `PeerJob` som läser camt.053/054-filer ur en inkorg-katalog
+ * (env `AVA_CAMT_INBOX`) och prickar av dem via porten ([[payments-job]] →
+ * [[bank-file-connector]]). Returnerar `null` när inkorgen inte är konfigurerad
+ * → riskfritt för demo/test/CI (peern aktiveras först när byrån pekat ut en
+ * mapp dit banken/Bankgirot droppar återrapporteringsfiler).
+ *
+ * Idempotensen ([[payments-job]]) gör det ofarligt att läsa om samma filer
+ * varje tick, så vi flyttar dem inte (v1); fil-arkivering är en uppföljning.
+ */
+
+import { join } from "node:path";
+import { BankFileLedgerConnector } from "./bank-file-connector";
+import { makeLedgerPaymentsJob } from "./payments-job";
+import type { PeerJob } from "../../local-first/peer-loop";
+
+/** Env-nyckel för inkorg-katalogen med camt-filer. */
+export const CAMT_INBOX_ENV = "AVA_CAMT_INBOX";
+
+export interface BuildBankFilePaymentsJobOpts {
+  env?: NodeJS.ProcessEnv;
+  log?: (msg: string) => void;
+}
+
+/** Läs alla `.xml`-filer i inkorgen (tom lista om katalogen saknas). */
+async function loadCamtFilesFrom(dir: string): Promise<string[]> {
+  const { readdir, readFile } = await import("node:fs/promises");
+  let names: string[];
+  try {
+    names = await readdir(dir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+  const xmls = names.filter((n) => n.toLowerCase().endsWith(".xml"));
+  return Promise.all(xmls.map((n) => readFile(join(dir, n), "utf8")));
+}
+
+export function buildBankFilePaymentsJob(opts: BuildBankFilePaymentsJobOpts = {}): PeerJob | null {
+  const env = opts.env ?? process.env;
+  const log = opts.log ?? ((msg: string) => console.log(`[bankfil] ${msg}`));
+
+  const inbox = env[CAMT_INBOX_ENV];
+  if (!inbox) {
+    log(`inkorg ej konfigurerad (${CAMT_INBOX_ENV} saknas) — avprickning av`);
+    return null;
+  }
+
+  log(`avprickning aktiv — läser camt-filer ur ${inbox}`);
+  const connector = new BankFileLedgerConnector({ loadCamtFiles: () => loadCamtFilesFrom(inbox) });
+  return makeLedgerPaymentsJob({ loadConnector: async () => connector, log });
+}

--- a/src/lib/server/integrations/ledger/payments-job.ts
+++ b/src/lib/server/integrations/ledger/payments-job.ts
@@ -1,0 +1,141 @@
+/**
+ * Avpricknings-peer för inkomna betalningar (#245, ADR 0005 fas 2 + ADR 0011).
+ *
+ * Kör som en `PeerAct` i server-runtime:ns pull→act→push-cykel: varje tick
+ * hämtas inkomna kundbetalningar via PORTEN (`pullPayments` på en pullPayments-
+ * capable connector, t.ex. [[bank-file-connector]]) och prickas av mot öppna
+ * fakturor via OCR ([[reconcile-payments]]). Träffar bokförs via
+ * `invoice.recordPayment`.
+ *
+ * IDEMPOTENT (ADR 0005-invarianten): betalningens `externalId` blir
+ * Payment.reference; redan bokförda referenser hoppas över → ofarligt att läsa
+ * om samma camt-fil varje tick (filerna behöver inte flyttas). Inget att pricka
+ * av → ingen mutation → no-empty-commit-grinden (#80) pushar inget.
+ */
+
+import type { PeerJob } from "../../local-first/peer-loop";
+import type { LedgerConnector, PullPaymentsQuery } from "./port";
+import { reconcileLedgerPayments, type ReconcileInvoice, type ReconciledPayment } from "./reconcile-payments";
+
+/** Den delmängd av en faktura-rad avprickningen behöver. */
+export interface PayableInvoice {
+  id: string;
+  ocrReference?: string | null;
+  payments?: ReadonlyArray<{ reference?: string | null }>;
+}
+
+/** Den delmängd av tRPC-callern jobbet använder. */
+export interface PaymentsJobCaller {
+  invoice: {
+    list: (input: Record<string, never>) => Promise<PayableInvoice[]>;
+    recordPayment: (input: {
+      invoiceId: string;
+      amount: number;
+      paidAt: string;
+      note?: string;
+      reference?: string;
+    }) => Promise<unknown>;
+  };
+}
+
+export interface PaymentsJobDeps {
+  /** Bygg en pullPayments-capable connector för cykeln. `null` = ej konfigurerad. */
+  loadConnector: () => Promise<LedgerConnector | null>;
+  /** Hämta betalningar från och med detta datum (`YYYY-MM-DD`); default epoch. */
+  since?: () => string;
+  /** Klocka för paidAt-fallback när betalningen saknar datum. */
+  clock?: () => Date;
+  log?: (msg: string) => void;
+}
+
+export interface ReconcileResult {
+  recorded: number;
+  unmatched: number;
+}
+
+/** En connector vars `pullPayments` är garanterat närvarande (capability-grindad). */
+type PullCapableConnector = LedgerConnector & Required<Pick<LedgerConnector, "pullPayments">>;
+
+function toCandidates(invoices: readonly PayableInvoice[]): ReconcileInvoice[] {
+  return invoices.map((inv) => ({
+    id: inv.id,
+    ocrReference: inv.ocrReference ?? null,
+    paymentReferences: (inv.payments ?? [])
+      .map((p) => p.reference)
+      .filter((r): r is string => Boolean(r)),
+  }));
+}
+
+/** Hämta + grinda connectorn på pullPayments-capabilityn. */
+async function resolvePullConnector(
+  deps: PaymentsJobDeps,
+  log: (msg: string) => void,
+): Promise<PullCapableConnector | null> {
+  const connector = await deps.loadConnector();
+  if (!connector) {
+    log("Avprickning: ingen betalnings-connector konfigurerad — hoppar över");
+    return null;
+  }
+  if (!connector.capabilities().pullPayments || !connector.pullPayments) {
+    log(`Ledger-connector "${connector.name}" saknar pullPayments-capability — hoppar över`);
+    return null;
+  }
+  return connector as PullCapableConnector;
+}
+
+function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/** Bokför varje avprickad betalning via callern (idempotent på reference). */
+async function recordAll(
+  caller: PaymentsJobCaller,
+  bookable: readonly ReconciledPayment[],
+  fallbackDate: string,
+): Promise<void> {
+  for (const p of bookable) {
+    await caller.invoice.recordPayment({
+      invoiceId: p.invoiceId,
+      amount: p.amountOre,
+      paidAt: p.date ?? fallbackDate,
+      note: p.payerName ? `Bankfil-avprickning — ${p.payerName}` : "Bankfil-avprickning",
+      reference: p.reference,
+    });
+  }
+}
+
+/**
+ * Hämta inkomna betalningar via porten och pricka av mot öppna fakturor.
+ * Idempotent: redan bokförda referenser hoppas över.
+ */
+export async function reconcilePulledPayments(
+  caller: PaymentsJobCaller,
+  deps: PaymentsJobDeps,
+): Promise<ReconcileResult> {
+  const log = deps.log ?? (() => {});
+  const connector = await resolvePullConnector(deps, log);
+  if (!connector) return { recorded: 0, unmatched: 0 };
+
+  const query: PullPaymentsQuery = { since: deps.since?.() ?? "1970-01-01" };
+  const payments = await connector.pullPayments(query);
+  const invoices = await caller.invoice.list({});
+  const outcome = reconcileLedgerPayments(payments, toCandidates(invoices));
+
+  const fallbackDate = isoDate((deps.clock ?? (() => new Date()))());
+  await recordAll(caller, outcome.bookable, fallbackDate);
+
+  if (outcome.bookable.length || outcome.unmatched.length) {
+    log(`Avprickning: ${outcome.bookable.length} bokförda, ${outcome.unmatched.length} till granskning`);
+  }
+  return { recorded: outcome.bookable.length, unmatched: outcome.unmatched.length };
+}
+
+/** Paketera avprickningen som ett `PeerJob` för server-runtime:ns peer-loop. */
+export function makeLedgerPaymentsJob(deps: PaymentsJobDeps): PeerJob {
+  return {
+    message: "chore(payments): pricka av inkomna betalningar (bankfil)",
+    act: async (caller) => {
+      await reconcilePulledPayments(caller as unknown as PaymentsJobCaller, deps);
+    },
+  };
+}

--- a/src/lib/server/integrations/ledger/reconcile-payments.ts
+++ b/src/lib/server/integrations/ledger/reconcile-payments.ts
@@ -1,0 +1,94 @@
+/**
+ * Avprickning av flata `LedgerPayment` mot AVA-fakturor (#245, ADR 0011).
+ *
+ * Server-runtime-peern hämtar inkomna betalningar via PORTEN
+ * (`pullPayments` → vendor-neutral flat `LedgerPayment`) och prickar av dem mot
+ * öppna fakturor. Vendor-neutral nyckel = OCR-referensen (mod-10), så denna
+ * matchare är medvetet enklare än den rika camt-motorn ([[match-payments]]) som
+ * driver den manuella importsidan (flera referenser/delbelopp/fri text). Den
+ * flata vägen passar automatiska källor (bankfil-inkorg, Fortnox invoicepayments)
+ * där varje betalning bär en OCR-referens.
+ *
+ * Idempotent: en betalnings `externalId` blir Payment.reference; betalningar vars
+ * externalId redan finns bland fakturornas betalningar hoppas över (dubblett).
+ * Ren funktion, inget I/O.
+ */
+
+import { normalizeRef } from "@/lib/shared/payments/match-payments";
+import type { LedgerPayment } from "./port";
+
+/** Faktura-delmängd avprickningen behöver. */
+export interface ReconcileInvoice {
+  id: string;
+  ocrReference: string | null;
+  /** Referenser på redan bokförda betalningar (Payment.reference) — dubblettskydd. */
+  paymentReferences: readonly string[];
+}
+
+/** En avprickningsbar betalning (matchad mot en faktura). */
+export interface ReconciledPayment {
+  invoiceId: string;
+  amountOre: number;
+  /** Idempotens-referens (= LedgerPayment.externalId). */
+  reference: string;
+  /** Betalningsdatum `YYYY-MM-DD` om källan angav det. */
+  date?: string;
+  payerName?: string;
+}
+
+export interface UnreconciledPayment {
+  payment: LedgerPayment;
+  reason: "saknar-ocr" | "ingen-träff" | "dubblett";
+}
+
+export interface ReconcileOutcome {
+  bookable: ReconciledPayment[];
+  unmatched: UnreconciledPayment[];
+}
+
+/** OCR-referens (normaliserad) → faktura-id. */
+function buildOcrIndex(invoices: readonly ReconcileInvoice[]): Map<string, string> {
+  const index = new Map<string, string>();
+  for (const inv of invoices) {
+    if (inv.ocrReference) index.set(normalizeRef(inv.ocrReference), inv.id);
+  }
+  return index;
+}
+
+function toReconciled(payment: LedgerPayment, invoiceId: string): ReconciledPayment {
+  return {
+    invoiceId,
+    amountOre: payment.amount,
+    reference: payment.externalId,
+    ...(payment.date ? { date: payment.date } : {}),
+    ...(payment.payerName ? { payerName: payment.payerName } : {}),
+  };
+}
+
+/**
+ * Pricka av flata betalningar mot fakturor via OCR-referens. Dubbletter
+ * (externalId redan bokfört) och betalningar utan OCR/utan träff hamnar i
+ * `unmatched` (granskningskö), aldrig auto-bokade på osäker grund.
+ */
+export function reconcileLedgerPayments(
+  payments: readonly LedgerPayment[],
+  invoices: readonly ReconcileInvoice[],
+): ReconcileOutcome {
+  const ocrIndex = buildOcrIndex(invoices);
+  const imported = new Set(invoices.flatMap((i) => i.paymentReferences));
+  const bookable: ReconciledPayment[] = [];
+  const unmatched: UnreconciledPayment[] = [];
+
+  for (const payment of payments) {
+    if (imported.has(payment.externalId)) {
+      unmatched.push({ payment, reason: "dubblett" });
+    } else if (!payment.ocrReference) {
+      unmatched.push({ payment, reason: "saknar-ocr" });
+    } else {
+      const invoiceId = ocrIndex.get(normalizeRef(payment.ocrReference));
+      if (invoiceId) bookable.push(toReconciled(payment, invoiceId));
+      else unmatched.push({ payment, reason: "ingen-träff" });
+    }
+  }
+  return { bookable, unmatched };
+}

--- a/test/unit/server/integrations/ledger/bank-file-runtime.test.ts
+++ b/test/unit/server/integrations/ledger/bank-file-runtime.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest-compat";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { buildBankFilePaymentsJob, CAMT_INBOX_ENV } from "@/lib/server/integrations/ledger/bank-file-runtime";
+import type { PaymentsJobCaller, PayableInvoice } from "@/lib/server/integrations/ledger/payments-job";
+
+const OCR = "2026004206";
+const camt = `<?xml version="1.0" encoding="UTF-8"?>
+<Document><BkToCstmrDbtCdtNtfctn>
+  <GrpHdr><MsgId>M1</MsgId></GrpHdr>
+  <Ntfctn><Ntry>
+    <Amt Ccy="SEK">125.00</Amt><CdtDbtInd>CRDT</CdtDbtInd><ValDt><Dt>2026-06-01</Dt></ValDt>
+    <NtryDtls><TxDtls>
+      <Refs><AcctSvcrRef>TX-A</AcctSvcrRef></Refs>
+      <RmtInf><Strd><CdtrRefInf><Ref>${OCR}</Ref></CdtrRefInf></Strd></RmtInf>
+    </TxDtls></NtryDtls>
+  </Ntry></Ntfctn>
+</BkToCstmrDbtCdtNtfctn></Document>`;
+
+const INV: PayableInvoice = { id: "inv-1", ocrReference: OCR, payments: [] };
+
+function makeCaller() {
+  const recorded: Array<{ invoiceId: string; reference?: string }> = [];
+  const caller: PaymentsJobCaller = {
+    invoice: {
+      list: async () => [INV],
+      recordPayment: async (input) => { recorded.push(input); return {}; },
+    },
+  };
+  return { caller, recorded };
+}
+
+describe("buildBankFilePaymentsJob", () => {
+  it("returnerar null när inkorgen inte är konfigurerad", () => {
+    expect(buildBankFilePaymentsJob({ env: {}, log: () => {} })).toBeNull();
+  });
+
+  it("läser camt-filer ur inkorgen och prickar av via porten", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "camt-inbox-"));
+    try {
+      writeFileSync(join(dir, "betalning.xml"), camt, "utf8");
+      writeFileSync(join(dir, "ignore.txt"), "skräp", "utf8");
+      const job = buildBankFilePaymentsJob({ env: { [CAMT_INBOX_ENV]: dir }, log: () => {} });
+      expect(job).not.toBeNull();
+      const j = job!;
+
+      const { caller, recorded } = makeCaller();
+      await j.act(caller as unknown as Parameters<typeof j.act>[0]);
+      expect(recorded).toEqual([{ invoiceId: "inv-1", amount: 12_500, paidAt: "2026-06-01", note: "Bankfil-avprickning", reference: "TX-A" }]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("saknad inkorg-katalog → inga betalningar (ingen krasch)", async () => {
+    const job = buildBankFilePaymentsJob({ env: { [CAMT_INBOX_ENV]: join(tmpdir(), "finns-inte-xyz") }, log: () => {} });
+    const j = job!;
+    const { caller, recorded } = makeCaller();
+    await j.act(caller as unknown as Parameters<typeof j.act>[0]);
+    expect(recorded).toHaveLength(0);
+  });
+});

--- a/test/unit/server/integrations/ledger/payments-job.test.ts
+++ b/test/unit/server/integrations/ledger/payments-job.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest-compat";
+import {
+  reconcilePulledPayments,
+  makeLedgerPaymentsJob,
+  type PaymentsJobCaller,
+  type PayableInvoice,
+} from "@/lib/server/integrations/ledger/payments-job";
+import type { LedgerConnector, LedgerPayment } from "@/lib/server/integrations/ledger/port";
+
+function makeCaller(invoices: PayableInvoice[]) {
+  const recorded: Array<{ invoiceId: string; amount: number; paidAt: string; reference?: string }> = [];
+  const caller: PaymentsJobCaller = {
+    invoice: {
+      list: async () => invoices,
+      recordPayment: async (input) => {
+        recorded.push(input);
+        return {};
+      },
+    },
+  };
+  return { caller, recorded };
+}
+
+const pullConnector = (payments: LedgerPayment[]): LedgerConnector => ({
+  name: "bankfil-camt",
+  capabilities: () => ({ pushVoucher: false, pushInvoice: false, pullPayments: true, exportSie: false }),
+  pullPayments: async () => payments,
+});
+
+const INV: PayableInvoice = { id: "inv-1", ocrReference: "2026004206", payments: [] };
+
+describe("reconcilePulledPayments", () => {
+  it("bokför matchade betalningar via recordPayment", async () => {
+    const { caller, recorded } = makeCaller([INV]);
+    const connector = pullConnector([
+      { externalId: "tx-1", amount: 12_500, ocrReference: "2026004206", date: "2026-06-01", payerName: "Klient" },
+    ]);
+    const res = await reconcilePulledPayments(caller, { loadConnector: async () => connector });
+
+    expect(res).toEqual({ recorded: 1, unmatched: 0 });
+    expect(recorded).toEqual([
+      { invoiceId: "inv-1", amount: 12_500, paidAt: "2026-06-01", note: "Bankfil-avprickning — Klient", reference: "tx-1" },
+    ]);
+  });
+
+  it("hoppar över redan bokförda referenser (idempotent)", async () => {
+    const { caller, recorded } = makeCaller([{ ...INV, payments: [{ reference: "tx-1" }] }]);
+    const connector = pullConnector([{ externalId: "tx-1", amount: 12_500, ocrReference: "2026004206" }]);
+    const res = await reconcilePulledPayments(caller, { loadConnector: async () => connector });
+    expect(res).toEqual({ recorded: 0, unmatched: 1 });
+    expect(recorded).toHaveLength(0);
+  });
+
+  it("paidAt faller tillbaka på klockan när betalningen saknar datum", async () => {
+    const { caller, recorded } = makeCaller([INV]);
+    const connector = pullConnector([{ externalId: "tx-9", amount: 5_000, ocrReference: "2026004206" }]);
+    await reconcilePulledPayments(caller, {
+      loadConnector: async () => connector,
+      clock: () => new Date("2026-06-12T10:00:00Z"),
+    });
+    expect(recorded[0]?.paidAt).toBe("2026-06-12");
+  });
+
+  it("ingen connector → ingen avprickning", async () => {
+    const { caller, recorded } = makeCaller([INV]);
+    const res = await reconcilePulledPayments(caller, { loadConnector: async () => null });
+    expect(res).toEqual({ recorded: 0, unmatched: 0 });
+    expect(recorded).toHaveLength(0);
+  });
+
+  it("connector utan pullPayments-capability → hoppar över", async () => {
+    const { caller } = makeCaller([INV]);
+    const noPull: LedgerConnector = {
+      name: "x",
+      capabilities: () => ({ pushVoucher: true, pushInvoice: false, pullPayments: false, exportSie: false }),
+    };
+    const res = await reconcilePulledPayments(caller, { loadConnector: async () => noPull });
+    expect(res).toEqual({ recorded: 0, unmatched: 0 });
+  });
+});
+
+describe("makeLedgerPaymentsJob", () => {
+  it("returnerar ett PeerJob vars act prickar av via callern", async () => {
+    const { caller, recorded } = makeCaller([INV]);
+    const connector = pullConnector([{ externalId: "tx-1", amount: 12_500, ocrReference: "2026004206" }]);
+    const job = makeLedgerPaymentsJob({ loadConnector: async () => connector });
+    expect(job.message).toMatch(/payments/i);
+    await job.act(caller as unknown as Parameters<typeof job.act>[0]);
+    expect(recorded).toHaveLength(1);
+  });
+});

--- a/test/unit/server/integrations/ledger/reconcile-payments.test.ts
+++ b/test/unit/server/integrations/ledger/reconcile-payments.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest-compat";
+import { reconcileLedgerPayments, type ReconcileInvoice } from "@/lib/server/integrations/ledger/reconcile-payments";
+import type { LedgerPayment } from "@/lib/server/integrations/ledger/port";
+
+const pay = (over: Partial<LedgerPayment> = {}): LedgerPayment => ({
+  externalId: "tx-1",
+  amount: 12_500,
+  ocrReference: "2026004206",
+  ...over,
+});
+
+const inv = (over: Partial<ReconcileInvoice> = {}): ReconcileInvoice => ({
+  id: "inv-1",
+  ocrReference: "2026004206",
+  paymentReferences: [],
+  ...over,
+});
+
+describe("reconcileLedgerPayments", () => {
+  it("matchar betalning mot faktura via OCR-referens", () => {
+    const out = reconcileLedgerPayments([pay({ date: "2026-06-01", payerName: "Klient AB" })], [inv()]);
+    expect(out.unmatched).toHaveLength(0);
+    expect(out.bookable).toEqual([
+      { invoiceId: "inv-1", amountOre: 12_500, reference: "tx-1", date: "2026-06-01", payerName: "Klient AB" },
+    ]);
+  });
+
+  it("betalning utan OCR → granskning (saknar-ocr)", () => {
+    const out = reconcileLedgerPayments([pay({ ocrReference: undefined })], [inv()]);
+    expect(out.bookable).toHaveLength(0);
+    expect(out.unmatched[0]?.reason).toBe("saknar-ocr");
+  });
+
+  it("OCR utan matchande faktura → granskning (ingen-träff)", () => {
+    const out = reconcileLedgerPayments([pay({ ocrReference: "9999999999" })], [inv()]);
+    expect(out.bookable).toHaveLength(0);
+    expect(out.unmatched[0]?.reason).toBe("ingen-träff");
+  });
+
+  it("redan bokförd referens → dubblett (idempotens)", () => {
+    const out = reconcileLedgerPayments([pay()], [inv({ paymentReferences: ["tx-1"] })]);
+    expect(out.bookable).toHaveLength(0);
+    expect(out.unmatched[0]?.reason).toBe("dubblett");
+  });
+
+  it("matchar oavsett OCR-formatering (mellanslag normaliseras bort)", () => {
+    const out = reconcileLedgerPayments([pay({ ocrReference: "2026 0042 06" })], [inv({ ocrReference: "2026004206" })]);
+    expect(out.bookable).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Den **genuina** användningen av `pullPayments`-porten (#245, ADR 0011 + ADR 0005 fas 2): en server-runtime-peer hämtar inkomna kundbetalningar via porten och prickar av dem mot öppna fakturor automatiskt.

## Varför inte route:a importsidan genom porten
Den manuella `/payments/import` (#181) använder den **rika** camt-matchningen (flera referenser/delbelopp/fri text, #175). Portens `pullPayments` är medvetet **flat** (vendor-neutral). Att tvinga den manuella sidan på den flata porten skulle regrediera funktionen. Den flata vägen passar i stället **automatiska** källor (bankfil-inkorg nu, Fortnox invoicepayments senare) — det är vad denna peer bygger.

## Vad
- **`reconcile-payments.ts`** — ren OCR-matchare: flat `LedgerPayment` → faktura via OCR-referens. Idempotent på `externalId`; `saknar-ocr`/`ingen-träff`/`dubblett` → granskning (aldrig auto-bokat på osäker grund). Återanvänder `normalizeRef` från den rika motorn.
- **`payments-job.ts`** — `PeerAct` som hämtar via `connector.pullPayments`, prickar av och bokför via `invoice.recordPayment`. Capability-grindad (`pullPayments`); idempotent → ofarligt att läsa om samma camt-fil varje tick (no-empty-commit-grinden #80 pushar inget utan träff).
- **`bank-file-runtime.ts`** — bygger jobbet ur en camt-inkorg-katalog (`AVA_CAMT_INBOX`); `null` när ej konfigurerad (riskfritt för demo/CI). Wirat i `src/bin/server-runtime.ts` via `composeJobs` bredvid regelmotorn + Fortnox.

## Verifierat
- Tester (33 i ledger-sviten): ren matchare (OCR-match/saknar-ocr/ingen-träff/dubblett/normalisering), PeerAct (bokföring, idempotens, capability-grind, klock-fallback för paidAt, no-connector-skip), runtime-byggaren (temp-inkorg → recordPayment; null utan env; saknad katalog → ingen krasch).
- Lokalt grönt: typecheck, lint (complexity ≤8 efter helper-extraktion), `test:cov` (rader 83.59% / funk 80.53%), dep-cruiser, knip, jscpd.

## Uppföljning
Fil-arkivering (flytta processade filer) + granskningskö-UI för `unmatched` är naturliga nästa steg; idempotensen gör v1 korrekt utan dem.

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)