### PR TITLE
feat(auth): wira OIDC-login → principal i self-hosted-bootstrapen

### DIFF
--- a/src/components/shell/demo-bootstrap.tsx
+++ b/src/components/shell/demo-bootstrap.tsx
@@ -23,7 +23,7 @@ import { DemoModeProvider } from "@/lib/client/demo/demo-mode-context";
 import { demoSourceFromRuntime } from "@/lib/client/demo/demo-source-from-runtime";
 import { demoCacheKey } from "@/lib/client/demo/demo-cache-key";
 import { trpc } from "@/lib/client/trpc";
-import { loadFirmaConfig, gitAuthUsername, type FirmaConfig } from "@/lib/client/firma/firma-config";
+import { loadFirmaConfig, patchFirmaConfig, gitAuthUsername, type FirmaConfig } from "@/lib/client/firma/firma-config";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { AuthProvider, useAuthMode } from "@/lib/client/auth/use-auth-mode";
 import { AuthStatusBanner } from "./auth-status-banner";
@@ -492,22 +492,54 @@ async function loadSelfHosted(
     if (!isCancelled()) setFsaHandle(opfs);
 
     const origin = typeof window !== "undefined" ? window.location.origin : undefined;
+
+    // OIDC-login (#222/#223): på första self-hosted-laddningen (ingen principal
+    // bunden än) — om vi ligger bakom oauth2-proxy svarar /oauth2/userinfo med
+    // den inloggades email. Då klonar vi UTAN syntetisk currentUser (skriver
+    // ingen "current-user"-rad), löser principalen mot allowlisten och reloadar
+    // med bunden principalId. Utan OIDC-session: oförändrat current-user-flöde.
+    const { fetchOidcClaims, classifyOidcLogin } = await import("@/lib/client/backend/oidc-principal");
+    const needsOidc = firmaConfig.tier === "self-hosted" && !firmaConfig.principalId;
+    const oidcClaims = needsOidc ? await fetchOidcClaims().catch(() => null) : null;
+
+    const currentUser = needsOidc && oidcClaims
+      ? undefined
+      : {
+          // Måste matcha trpcClient-användaren (id principalId ?? "current-user")
+          // så att flöden som slår upp ctx.user (timeEntry.create m.fl.) hittar en rad.
+          id: firmaConfig.principalId ?? "current-user",
+          email: firmaConfig.authorEmail,
+          name: firmaConfig.authorName,
+          organizationId: firmaConfig.organizationId,
+        };
     const src = await loadSelfHostedSource({
       handle: opfs,
       repo: firmaConfig.repo,
       token: firmaConfig.token,
       username: gitAuthUsername(firmaConfig),
-      ...omitUndefined({ origin }),
-      // Måste matcha trpcClient-användaren nedan (id "current-user") så att
-      // flöden som slår upp ctx.user (timeEntry.create m.fl.) hittar en rad.
-      currentUser: {
-        id: "current-user",
-        email: firmaConfig.authorEmail,
-        name: firmaConfig.authorName,
-        organizationId: firmaConfig.organizationId,
-      },
+      ...omitUndefined({ origin, currentUser }),
     });
     if (isCancelled()) return;
+
+    if (needsOidc && oidcClaims) {
+      const outcome = classifyOidcLogin(oidcClaims, (src.users ?? []) as never);
+      if (outcome.kind === "denied") {
+        setStatus("error");
+        setErrorMsg(`Inte behörig: ${outcome.email} finns inte i byråns användarlista.`);
+        return;
+      }
+      if (outcome.kind === "authorized") {
+        // Bind principalen och ladda om med rätt identitet.
+        patchFirmaConfig({
+          principalId: outcome.principal.id,
+          authorEmail: outcome.principal.email,
+          authorName: outcome.principal.name,
+        });
+        if (typeof window !== "undefined") window.location.reload();
+        return;
+      }
+    }
+
     mergeSource(source, src);
     await queryClient.invalidateQueries();
     setStatus("ready");

--- a/src/lib/client/backend/oidc-principal.ts
+++ b/src/lib/client/backend/oidc-principal.ts
@@ -61,3 +61,25 @@ export function resolveSelfHostedPrincipal(
 ): Principal | null {
   return new OidcAuthProvider(claims, users).getPrincipal();
 }
+
+/**
+ * Klassificera self-hosted-login utifrån claims + allowlist (#222-wiring):
+ *   - `no-session`  — ingen OIDC-session (ej bakom oauth2-proxy / ej inloggad);
+ *     callern faller tillbaka på sitt vanliga (icke-OIDC) beteende.
+ *   - `denied`      — autentiserad IdP-identitet men INTE i byråns allowlist →
+ *     neka (autentisering ≠ auktorisering, #223).
+ *   - `authorized`  — allowlistad → principal ur firma.git.
+ */
+export type OidcLoginOutcome =
+  | { kind: "authorized"; principal: Principal }
+  | { kind: "denied"; email: string }
+  | { kind: "no-session" };
+
+export function classifyOidcLogin(
+  claims: OidcClaims | null,
+  users: readonly AllowlistedUser[],
+): OidcLoginOutcome {
+  if (!claims) return { kind: "no-session" };
+  const principal = resolveSelfHostedPrincipal(claims, users);
+  return principal ? { kind: "authorized", principal } : { kind: "denied", email: claims.email };
+}

--- a/test/unit/client/backend/oidc-principal.test.ts
+++ b/test/unit/client/backend/oidc-principal.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest-compat";
 import {
   fetchOidcClaims,
   resolveSelfHostedPrincipal,
+  classifyOidcLogin,
   OIDC_USERINFO_PATH,
 } from "@/lib/client/backend/oidc-principal";
 import type { AllowlistedUser } from "@/lib/server/auth/oidc-auth-provider";
@@ -65,5 +66,22 @@ describe("resolveSelfHostedPrincipal", () => {
       USERS,
     );
     expect(p).toBeNull();
+  });
+});
+
+describe("classifyOidcLogin", () => {
+  it("inga claims → no-session (icke-OIDC/ej inloggad)", () => {
+    expect(classifyOidcLogin(null, USERS)).toEqual({ kind: "no-session" });
+  });
+
+  it("allowlistad email → authorized med principal", () => {
+    const out = classifyOidcLogin({ email: "anna@byra.se", subject: "", issuer: "", name: "Anna" }, USERS);
+    expect(out.kind).toBe("authorized");
+    if (out.kind === "authorized") expect(out.principal.id).toBe("u-1");
+  });
+
+  it("autentiserad men ej allowlistad → denied med email", () => {
+    const out = classifyOidcLogin({ email: "intrang@annan.se", subject: "", issuer: "", name: "" }, USERS);
+    expect(out).toEqual({ kind: "denied", email: "intrang@annan.se" });
   });
 });


### PR DESCRIPTION
Slutför **klient-wiringen** av OIDC-login (#222/#223, ADR 0009). Backbone:n (`fetchOidcClaims`/`resolveSelfHostedPrincipal` + `OidcAuthProvider` + allowlist) fanns redan men var owirad — `fetchOidcClaims` anropades ingenstans.

## Vad
På första self-hosted-laddningen (ingen principal bunden) läses den inloggades email ur oauth2-proxyns `/oauth2/userinfo`, principalen löses mot användar-allowlisten i firma.git (`.ava/users/<email>.json`), och appen laddas om med bunden `principalId` (commit-författare + identitet).

- **`oidc-principal.ts`** — ny `classifyOidcLogin(claims, users)`: `authorized` (allowlistad → principal) | `denied` (autentiserad IdP-identitet men **ej** i allowlist → nekas; autentisering ≠ auktorisering, #223) | `no-session` (ej bakom oauth2-proxy → oförändrat current-user-flöde).
- **`demo-bootstrap.tsx` `loadSelfHosted`** — hämtar claims FÖRE klon; på resolutions-passet klonas **utan** syntetisk `currentUser` (ingen `"current-user"`-rad skrivs/pushas), klassificerar mot `src.users`, patchar `principalId` + författar-email/namn → `reload` (eller error-vy "Inte behörig" vid nekad). Subsekventa laddningar: `principalId` cachad → ingen extra runda.

## Risk/regression
Ändringen ligger i bootstrap-**effekten** (`loadSelfHosted`, körs i `useEffect`), inte render-fasen → ingen render-storm-risk (jfr #249-lärdomen). **Round-trip validerad lokalt** mot docker-stacken (self-hosted UTAN oauth2-proxy): `/oauth2/userinfo` → 404 → `null` → `no-session` → current-user-fallback, oförändrat beteende, kontakt + settings-test gröna.

## Verifierat
- Tester: `classifyOidcLogin` (authorized/denied/no-session); befintliga bridge-tester (`fetchOidcClaims`/`resolveSelfHostedPrincipal`) oförändrade.
- Lokalt grönt: typecheck, lint, `test:cov` (rader 83.51% / funk 80.53%), dep-cruiser, knip, jscpd, **round-trip** (kontakt + settings).

## Kvar i auth-epiken
`sub`/`iss`-bindning vid första login (#224, oauth2-proxy userinfo ger ej dem nu) + skarp allowlist-onboarding-UI. Denna PR levererar happy-path + allowlist-nekande.

Refs #222 #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)