### PR TITLE
feat(server): guidat install-flöde för backenden (secrets + env, idempotent)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "demo:serve:fast": "SKIP_BUILD=1 bash tooling/scripts/demo-serve.sh",
     "seed:local": "bun tooling/scripts/seed-firma-local.ts",
     "server-runtime": "bun src/bin/server-runtime.ts",
+    "install:server": "bun tooling/scripts/install-server.ts",
     "server-runtime:build": "bun tooling/scripts/build-server-runtime.ts",
     "server-runtime:smoke": "bash tooling/scripts/smoke-server-runtime-docker.sh",
     "start": "next start",

--- a/test/scripts/install-server.test.ts
+++ b/test/scripts/install-server.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest-compat";
+import {
+  generateMasterKeyBase64,
+  generateCookieSecret,
+  vaultSecretsFor,
+  renderServerEnv,
+  planInstall,
+  validateInstallConfig,
+  VAULT_KEYS,
+  type ServerInstallConfig,
+} from "../../tooling/scripts/install-server/core";
+
+const fixedRand = (size: number) => Buffer.alloc(size, 7);
+
+const oidcCfg: ServerInstallConfig = {
+  repoUrl: "https://git.byra.se/firma.git",
+  workDir: "/srv/ava/wc",
+  organizationId: "11111111-1111-5111-8111-111111111111",
+  secretsFile: "/home/ava/.ava-secrets/vault.enc",
+  authMode: "oidc",
+  oidc: {
+    issuerUrl: "https://idp/realms/byra",
+    clientId: "ava",
+    clientSecret: "s3cr3t",
+    redirectUrl: "https://app/oauth2/callback",
+  },
+};
+
+const htpasswdCfg: ServerInstallConfig = {
+  repoUrl: "https://git.byra.se/firma.git",
+  workDir: "/srv/ava/wc",
+  organizationId: "org-1",
+  secretsFile: "/home/ava/.ava-secrets/vault.enc",
+  authMode: "htpasswd",
+};
+
+describe("generateMasterKeyBase64", () => {
+  it("ger 32 byte base64 (44 tecken)", () => {
+    const key = generateMasterKeyBase64(fixedRand);
+    expect(Buffer.from(key, "base64").length).toBe(32);
+    expect(key.length).toBe(44);
+  });
+});
+
+describe("generateCookieSecret", () => {
+  it("ger 32 byte base64url", () => {
+    const s = generateCookieSecret(fixedRand);
+    expect(Buffer.from(s, "base64url").length).toBe(32);
+    expect(s).not.toMatch(/[+/=]/); // base64url
+  });
+});
+
+describe("vaultSecretsFor", () => {
+  it("OIDC: client_secret + cookie_secret i valvet", () => {
+    expect(vaultSecretsFor(oidcCfg, "cookie123")).toEqual({
+      [VAULT_KEYS.oidcClientSecret]: "s3cr3t",
+      [VAULT_KEYS.oidcCookieSecret]: "cookie123",
+    });
+  });
+  it("htpasswd: inga valv-secrets", () => {
+    expect(vaultSecretsFor(htpasswdCfg, "cookie123")).toEqual({});
+  });
+});
+
+describe("renderServerEnv", () => {
+  it("innehåller icke-hemlig config men ALDRIG master-nyckel eller client-secret", () => {
+    const env = renderServerEnv(oidcCfg);
+    expect(env).toContain("AVA_SECRETS_FILE=/home/ava/.ava-secrets/vault.enc");
+    expect(env).toContain("AVA_SR_REPO_URL=https://git.byra.se/firma.git");
+    expect(env).toContain("OAUTH2_PROXY_CLIENT_ID=ava");
+    expect(env).toContain("OIDC_ISSUER_PUBLIC=https://idp/realms/byra");
+    // Hemligheter får ALDRIG hamna i .env (kommentar som nämner nyckeln är ok,
+    // men ingen RIKTIG env-rad får sätta master-nyckeln).
+    expect(env).not.toContain("s3cr3t");
+    expect(env.split("\n").some((l) => /^AVA_SECRETS_KEY=/.test(l))).toBe(false);
+  });
+  it("htpasswd: utelämnar OIDC-rader", () => {
+    const env = renderServerEnv(htpasswdCfg);
+    expect(env).not.toContain("OAUTH2_PROXY_CLIENT_ID");
+    expect(env).toContain("AVA_AUTH_MODE=htpasswd");
+  });
+});
+
+describe("planInstall (idempotent)", () => {
+  it("färsk install: generera nyckel + skapa valv", () => {
+    expect(planInstall({ masterKeyExists: false, vaultExists: false }, oidcCfg)).toEqual({
+      generateMasterKey: true,
+      createVault: true,
+      storeSecrets: true,
+    });
+  });
+  it("re-run: behåller befintlig nyckel + valv (skriver ej över)", () => {
+    expect(planInstall({ masterKeyExists: true, vaultExists: true }, oidcCfg)).toMatchObject({
+      generateMasterKey: false,
+      createVault: false,
+    });
+  });
+  it("htpasswd: inga secrets att lagra", () => {
+    expect(planInstall({ masterKeyExists: false, vaultExists: false }, htpasswdCfg).storeSecrets).toBe(false);
+  });
+});
+
+describe("validateInstallConfig", () => {
+  it("komplett OIDC-config → inga fel", () => {
+    expect(validateInstallConfig(oidcCfg)).toEqual([]);
+  });
+  it("OIDC utan secret → fel", () => {
+    const bad = { ...oidcCfg, oidc: { ...oidcCfg.oidc!, clientSecret: "" } };
+    expect(validateInstallConfig(bad).join(" ")).toMatch(/OIDC/);
+  });
+  it("saknad repo/org → fel", () => {
+    expect(validateInstallConfig({ ...htpasswdCfg, repoUrl: "", organizationId: "" }).length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/tooling/scripts/install-server.ts
+++ b/tooling/scripts/install-server.ts
@@ -1,0 +1,140 @@
+#!/usr/bin/env bun
+/**
+ * `install-server` (#232) — guidat, idempotent backend-install-flöde.
+ *
+ * Sätter upp det "lätt-att-få-fel" (ADR 0008): secrets-valvets master-nyckel
+ * (0600, utanför repo), valv-filen + OIDC-secrets i valvet, och en icke-hemlig
+ * `.env` för docker-stacken. Skriver ALDRIG över en befintlig master-nyckel
+ * eller valv (re-run säkert). Logiken bor i `install-server/core.ts`; den här
+ * filen är argv + fs + nästa-steg-utskrift (tunn, jfr server-runtime.ts).
+ *
+ *   bun tooling/scripts/install-server.ts \
+ *     --repo https://git.byra.se/firma.git --work-dir /srv/ava/wc --org <uuid> \
+ *     --auth oidc --oidc-issuer https://idp/realms/byra --oidc-client-id ava \
+ *     --oidc-client-secret <secret> --oidc-redirect https://app/oauth2/callback
+ *
+ * Övriga steg (bygg out/ + docker compose up + första-admin-token) skrivs ut
+ * som nästa-steg — wizard/orchestrering är en uppföljning på #232.
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { EncryptedFileVault, nodeVaultFs } from "@/lib/server/secrets/vault";
+import {
+  generateMasterKeyBase64,
+  generateCookieSecret,
+  renderServerEnv,
+  planInstall,
+  vaultSecretsFor,
+  validateInstallConfig,
+  VAULT_KEYS,
+  type AuthMode,
+  type OidcInstallConfig,
+  type ServerInstallConfig,
+} from "./install-server/core";
+
+function flag(argv: string[], name: string): string | undefined {
+  const i = argv.indexOf(`--${name}`);
+  return i >= 0 ? argv[i + 1] : undefined;
+}
+
+function buildOidc(argv: string[]): OidcInstallConfig {
+  return {
+    issuerUrl: flag(argv, "oidc-issuer") ?? "",
+    clientId: flag(argv, "oidc-client-id") ?? "",
+    clientSecret: flag(argv, "oidc-client-secret") ?? "",
+    redirectUrl: flag(argv, "oidc-redirect") ?? "",
+  };
+}
+
+function buildConfig(argv: string[], secretsFile: string): ServerInstallConfig {
+  const authMode = (flag(argv, "auth") ?? "htpasswd") as AuthMode;
+  return {
+    repoUrl: flag(argv, "repo") ?? "",
+    workDir: flag(argv, "work-dir") ?? "",
+    organizationId: flag(argv, "org") ?? "",
+    secretsFile,
+    authMode,
+    ...(authMode === "oidc" ? { oidc: buildOidc(argv) } : {}),
+  };
+}
+
+function log(msg: string): void {
+  console.log(`[install-server] ${msg}`);
+}
+
+async function exists(path: string): Promise<boolean> {
+  const { access } = await import("node:fs/promises");
+  return access(path).then(() => true).catch(() => false);
+}
+
+/** Skriv master-nyckeln 0600 om den saknas; returnera den (befintlig eller ny). */
+async function ensureMasterKey(masterKeyFile: string, generate: boolean): Promise<string> {
+  const { readFile, writeFile } = await import("node:fs/promises");
+  if (!generate) return (await readFile(masterKeyFile, "utf8")).trim();
+  const key = generateMasterKeyBase64();
+  await writeFile(masterKeyFile, key + "\n", { mode: 0o600 });
+  log(`master-nyckel skapad: ${masterKeyFile} (0600) — TAPPA INTE DENNA, valvet blir annars oåterkalleligt`);
+  return key;
+}
+
+/** Skriv OIDC-secrets i valvet; bevara befintlig cookie-secret (idempotent). */
+async function storeVaultSecrets(vault: EncryptedFileVault, cfg: ServerInstallConfig): Promise<void> {
+  const existingCookie = await vault.get(VAULT_KEYS.oidcCookieSecret);
+  const cookie = existingCookie ?? generateCookieSecret();
+  for (const [k, v] of Object.entries(vaultSecretsFor(cfg, cookie))) {
+    await vault.set(k, v);
+  }
+  log("OIDC-secrets skrivna i valvet (client_secret + cookie_secret)");
+}
+
+function printNextSteps(cfg: ServerInstallConfig, masterKeyFile: string, envFile: string): void {
+  log("klart. Nästa steg:");
+  console.log(`
+  1. export AVA_SECRETS_KEY=$(cat ${masterKeyFile})
+  2. set -a && . ${envFile} && set +a
+  3. DEMO_BASE_PATH=/ava bash tooling/scripts/build-demo.sh
+  4. docker compose -f tooling/docker/docker-compose.yml up -d --build --wait
+  5. Hämta första-admin-token ur web-loggen och lägg till användare:
+       docker compose -f tooling/docker/docker-compose.yml logs web | grep Admin-token
+       bash tooling/scripts/add-user.sh <din-epost>${cfg.authMode === "oidc" ? "\n  6. OIDC: starta även docker-compose.oidc.yml-overlayen." : ""}
+`);
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const secretsDir = flag(argv, "secrets-dir") ?? join(homedir(), ".ava-secrets");
+  const masterKeyFile = join(secretsDir, "master.key");
+  const secretsFile = join(secretsDir, "vault.enc");
+  const envFile = flag(argv, "env-out") ?? join(process.cwd(), "ava-server.env");
+
+  const cfg = buildConfig(argv, secretsFile);
+  const errors = validateInstallConfig(cfg);
+  if (errors.length) {
+    for (const e of errors) console.error(`[install-server] FEL: ${e}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const { mkdir, writeFile } = await import("node:fs/promises");
+  await mkdir(secretsDir, { recursive: true, mode: 0o700 });
+
+  const plan = planInstall(
+    { masterKeyExists: await exists(masterKeyFile), vaultExists: await exists(secretsFile) },
+    cfg,
+  );
+  if (!plan.generateMasterKey) log("befintlig master-nyckel behålls (skrivs ej över)");
+
+  const masterKey = await ensureMasterKey(masterKeyFile, plan.generateMasterKey);
+  const vault = new EncryptedFileVault(secretsFile, Buffer.from(masterKey, "base64"), nodeVaultFs());
+  if (plan.storeSecrets) await storeVaultSecrets(vault, cfg);
+
+  await writeFile(envFile, renderServerEnv(cfg), { mode: 0o600 });
+  log(`deploy-env skriven: ${envFile}`);
+  printNextSteps(cfg, masterKeyFile, envFile);
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`[install-server] startfel: ${String(err)}\n`);
+  process.exitCode = 1;
+});

--- a/tooling/scripts/install-server/core.ts
+++ b/tooling/scripts/install-server/core.ts
@@ -1,0 +1,135 @@
+/**
+ * Install-server-kärnan (#232) — ren, deterministisk logik för det guidade
+ * backend-install-flödet. CLI:n (`tooling/scripts/install-server.ts`) gör I/O
+ * (fs/docker); HÄR bor bara det "lätt-att-få-fel": nyckel-/secret-generering,
+ * env-rendering och en idempotent install-plan (re-run skriver aldrig över en
+ * befintlig master-nyckel/valv).
+ *
+ * Secrets-disciplin (ADR 0008): master-nyckeln + klient-/cookie-secret hamnar
+ * ALDRIG i en .env-fil eller i firma.git — master-nyckeln i en 0600-fil utanför
+ * repo:t, övriga secrets i det krypterade valvet.
+ */
+
+import { randomBytes } from "node:crypto";
+
+export type AuthMode = "htpasswd" | "oidc";
+
+export interface OidcInstallConfig {
+  issuerUrl: string;
+  clientId: string;
+  clientSecret: string;
+  redirectUrl: string;
+}
+
+export interface ServerInstallConfig {
+  repoUrl: string;
+  workDir: string;
+  organizationId: string;
+  /** Sökväg till den krypterade valv-filen (UTANFÖR git-working-copy:n). */
+  secretsFile: string;
+  authMode: AuthMode;
+  /** Krävs när authMode === "oidc". */
+  oidc?: OidcInstallConfig;
+}
+
+type RandFn = (size: number) => Buffer;
+
+const MASTER_KEY_BYTES = 32;
+const COOKIE_SECRET_BYTES = 32;
+
+/** 32 slumpbyte → base64 (valvets master-nyckel, `AVA_SECRETS_KEY`). */
+export function generateMasterKeyBase64(rand: RandFn = randomBytes): string {
+  return rand(MASTER_KEY_BYTES).toString("base64");
+}
+
+/** 32 slumpbyte → base64url (oauth2-proxy `COOKIE_SECRET`). */
+export function generateCookieSecret(rand: RandFn = randomBytes): string {
+  return rand(COOKIE_SECRET_BYTES).toString("base64url");
+}
+
+/** Valv-nycklar för secrets som aldrig får hamna i env/git. */
+export const VAULT_KEYS = {
+  oidcClientSecret: "oidc.client_secret",
+  oidcCookieSecret: "oidc.cookie_secret",
+} as const;
+
+/** Vilka secrets som ska skrivas i valvet för den valda konfigurationen. */
+export function vaultSecretsFor(cfg: ServerInstallConfig, cookieSecret: string): Record<string, string> {
+  if (cfg.authMode !== "oidc" || !cfg.oidc) return {};
+  return {
+    [VAULT_KEYS.oidcClientSecret]: cfg.oidc.clientSecret,
+    [VAULT_KEYS.oidcCookieSecret]: cookieSecret,
+  };
+}
+
+/**
+ * Rendera den ICKE-hemliga deploy-env:en (.env för docker-stacken). Master-
+ * nyckeln + klient-/cookie-secret är MEDVETET INTE med här — de levereras via
+ * valvet (`AVA_SECRETS_FILE`) + master-nyckel-filen.
+ */
+export function renderServerEnv(cfg: ServerInstallConfig): string {
+  const lines = [
+    "# AVA self-hosted backend — genererad av install-server (#232).",
+    "# OBS: AVA_SECRETS_KEY (master-nyckel) + klient-/cookie-secret ligger i",
+    "#      secrets-valvet/master-nyckel-filen, ALDRIG här. Vid drift:",
+    "#      export AVA_SECRETS_KEY=$(cat <master.key>)",
+    `AVA_SECRETS_FILE=${cfg.secretsFile}`,
+    `AVA_SR_REPO_URL=${cfg.repoUrl}`,
+    `AVA_SR_WORK_DIR=${cfg.workDir}`,
+    `AVA_SR_ORG_ID=${cfg.organizationId}`,
+    "DEMO_BASE_PATH=/ava",
+    `AVA_AUTH_MODE=${cfg.authMode}`,
+  ];
+  if (cfg.authMode === "oidc" && cfg.oidc) {
+    lines.push(
+      `OAUTH2_PROXY_CLIENT_ID=${cfg.oidc.clientId}`,
+      `OIDC_ISSUER_PUBLIC=${cfg.oidc.issuerUrl}`,
+      `OIDC_REDIRECT_URL=${cfg.oidc.redirectUrl}`,
+    );
+  }
+  return lines.join("\n") + "\n";
+}
+
+export interface InstallState {
+  masterKeyExists: boolean;
+  vaultExists: boolean;
+}
+
+export interface InstallPlan {
+  generateMasterKey: boolean;
+  createVault: boolean;
+  storeSecrets: boolean;
+}
+
+/**
+ * Idempotent plan: en befintlig master-nyckel/valv BEHÅLLS (skrivs aldrig över
+ * — annars blir valvet oåterkalleligt, ADR 0008). Secrets uppdateras (set är
+ * idempotent) när OIDC-läge är valt.
+ */
+export function planInstall(state: InstallState, cfg: ServerInstallConfig): InstallPlan {
+  return {
+    generateMasterKey: !state.masterKeyExists,
+    createVault: !state.vaultExists,
+    storeSecrets: cfg.authMode === "oidc",
+  };
+}
+
+function oidcComplete(o: OidcInstallConfig | undefined): boolean {
+  return Boolean(o?.issuerUrl && o.clientId && o.clientSecret && o.redirectUrl);
+}
+
+/** Validera att OIDC-konfig är komplett när authMode === "oidc". */
+export function validateInstallConfig(cfg: ServerInstallConfig): string[] {
+  const errors: string[] = [];
+  const required: ReadonlyArray<readonly [string, string]> = [
+    [cfg.repoUrl, "repoUrl saknas"],
+    [cfg.workDir, "workDir saknas"],
+    [cfg.organizationId, "organizationId saknas"],
+    [cfg.secretsFile, "secretsFile saknas"],
+  ];
+  for (const [val, msg] of required) if (!val) errors.push(msg);
+  if (cfg.authMode === "oidc" && !oidcComplete(cfg.oidc)) {
+    errors.push("OIDC-läge kräver issuerUrl, clientId, clientSecret och redirectUrl");
+  }
+  return errors;
+}


### PR DESCRIPTION
Första delen av #232 — paketerar det "lätt-att-få-fel" i self-hosted-uppsättningen (ADR 0008) bakom ett kommando: `bun run install:server`.

## Vad
- **`tooling/scripts/install-server/core.ts`** — ren, testbar kärna: master-nyckel- + cookie-secret-generering, `vaultSecretsFor` (vilka secrets som hör hemma i valvet), `renderServerEnv` (icke-hemlig `.env`; **master-nyckel + client-secret hamnar ALDRIG där**), `planInstall` (idempotent — befintlig master-nyckel/valv skrivs **aldrig** över → valvet kan inte bli oåterkalleligt), `validateInstallConfig`.
- **`tooling/scripts/install-server.ts`** — tunn CLI: skapar secrets-katalog (0700), `master.key` (0600, utanför repo), krypterat valv (återanvänder `EncryptedFileVault` #79), skriver OIDC-secrets i valvet, renderar deploy-`.env` och skriver ut nästa-steg (bygg out/ + docker compose up --wait + första-admin-token + `add-user.sh`).
- **`package.json`** — `install:server`-script.

Stödjer både htpasswd- och OIDC-läge (BYO-IdP, ADR 0009); vid OIDC läggs `client_secret` + genererad `cookie_secret` i valvet, issuer/client-id/redirect i `.env`.

## Verifierat
- Enhetstester (kärnan): nyckel-/secret-format, valv-secret-urval (oidc vs htpasswd), env-rendering (**inga secrets i .env**), idempotent plan, config-validering.
- Smoke-testat lokalt: `master.key` 0600 + krypterat `vault.enc`, `.env` utan secret, re-run bevarar master-nyckeln.
- Lokalt grönt: typecheck, lint (complexity ≤8), `test:cov` (rader 83.49% / funk 80.53%), dep-cruiser, knip, jscpd. Tooling-only → rör ej app-bundeln.

## Uppföljning på #232
Setup-wizard/UI (det finns redan `src/app/setup/page.tsx` att bygga på), full build/compose-orchestrering med healthcheck-väntan, och avinstallation/återställning.

Refs #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)