### PR TITLE
feat(server): install-server kan bygga + starta + riva stacken (ett kommando)

### DIFF
--- a/test/scripts/install-server-orchestrate.test.ts
+++ b/test/scripts/install-server-orchestrate.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest-compat";
+import {
+  buildStartCommands,
+  buildStopCommands,
+  logsCommand,
+  extractAdminToken,
+} from "../../tooling/scripts/install-server/orchestrate";
+
+describe("buildStartCommands", () => {
+  it("htpasswd: build-demo + compose up --wait (bara bas-compose)", () => {
+    const cmds = buildStartCommands({ oidc: false });
+    expect(cmds[0]).toEqual(["bash", "tooling/scripts/build-demo.sh"]);
+    const up = cmds[1]!;
+    expect(up.slice(0, 4)).toEqual(["docker", "compose", "-f", "tooling/docker/docker-compose.yml"]);
+    expect(up).toContain("up");
+    expect(up).toContain("--wait");
+    expect(up).not.toContain("docker-compose.oidc.yml");
+  });
+
+  it("oidc: inkluderar overlay-filen", () => {
+    const up = buildStartCommands({ oidc: true })[1]!;
+    expect(up).toContain("tooling/docker/docker-compose.oidc.yml");
+    // bägge -f-filerna före up
+    expect(up.indexOf("-f")).toBeLessThan(up.indexOf("up"));
+  });
+});
+
+describe("buildStopCommands", () => {
+  it("down -v (ta bort volymer)", () => {
+    const [cmd] = buildStopCommands({ oidc: false });
+    expect(cmd).toContain("down");
+    expect(cmd).toContain("-v");
+  });
+});
+
+describe("logsCommand", () => {
+  it("hämtar web-loggen", () => {
+    expect(logsCommand(false).slice(-2)).toEqual(["logs", "web"]);
+  });
+});
+
+describe("extractAdminToken", () => {
+  it("plockar 40-teckens token ur entrypoint-loggen", () => {
+    const log = "[web] bootstrap\n[web]    Admin-token:      " + "a".repeat(40) + "\n[web] klar";
+    expect(extractAdminToken(log)).toBe("a".repeat(40));
+  });
+
+  it("null när ingen token-rad finns", () => {
+    expect(extractAdminToken("[web] inget här")).toBeNull();
+  });
+
+  it("ignorerar för korta/långa kandidater", () => {
+    expect(extractAdminToken("Admin-token:   abc")).toBeNull();
+  });
+});

--- a/tooling/scripts/install-server.ts
+++ b/tooling/scripts/install-server.ts
@@ -32,10 +32,40 @@ import {
   type OidcInstallConfig,
   type ServerInstallConfig,
 } from "./install-server/core";
+import {
+  buildStartCommands,
+  buildStopCommands,
+  logsCommand,
+  extractAdminToken,
+} from "./install-server/orchestrate";
 
 function flag(argv: string[], name: string): string | undefined {
   const i = argv.indexOf(`--${name}`);
   return i >= 0 ? argv[i + 1] : undefined;
+}
+
+function hasFlag(argv: string[], name: string): boolean {
+  return argv.includes(`--${name}`);
+}
+
+/** Kör en kommandosekvens (ärver stdio); kasta vid första misslyckande. */
+async function runCommands(cmds: string[][], env: NodeJS.ProcessEnv): Promise<void> {
+  const { spawnSync } = await import("node:child_process");
+  for (const [bin, ...args] of cmds) {
+    log(`$ ${bin} ${args.join(" ")}`);
+    const r = spawnSync(bin!, args, { stdio: "inherit", env });
+    if (r.status !== 0) throw new Error(`kommandot misslyckades (${r.status ?? r.signal}): ${bin}`);
+  }
+}
+
+/** Bygg + starta stacken och skriv ut den bootstrappade admin-token:n. */
+async function startStack(oidc: boolean): Promise<void> {
+  const { spawnSync } = await import("node:child_process");
+  await runCommands(buildStartCommands({ oidc }), { ...process.env, DEMO_BASE_PATH: "/ava" });
+  const [bin, ...args] = logsCommand(oidc);
+  const logs = spawnSync(bin!, args, { encoding: "utf8" }).stdout ?? "";
+  const token = extractAdminToken(logs);
+  log(token ? `admin-token (engångs): ${token} — lägg till användare med add-user.sh` : "admin-token ej funnen i loggen ännu (kolla `docker compose logs web`)");
 }
 
 function buildOidc(argv: string[]): OidcInstallConfig {
@@ -101,37 +131,72 @@ function printNextSteps(cfg: ServerInstallConfig, masterKeyFile: string, envFile
 `);
 }
 
-async function main(): Promise<void> {
-  const argv = process.argv.slice(2);
-  const secretsDir = flag(argv, "secrets-dir") ?? join(homedir(), ".ava-secrets");
-  const masterKeyFile = join(secretsDir, "master.key");
-  const secretsFile = join(secretsDir, "vault.enc");
-  const envFile = flag(argv, "env-out") ?? join(process.cwd(), "ava-server.env");
+interface InstallPaths {
+  secretsDir: string;
+  masterKeyFile: string;
+  secretsFile: string;
+  envFile: string;
+}
 
-  const cfg = buildConfig(argv, secretsFile);
+function resolvePaths(argv: string[]): InstallPaths {
+  const secretsDir = flag(argv, "secrets-dir") ?? join(homedir(), ".ava-secrets");
+  return {
+    secretsDir,
+    masterKeyFile: join(secretsDir, "master.key"),
+    secretsFile: join(secretsDir, "vault.enc"),
+    envFile: flag(argv, "env-out") ?? join(process.cwd(), "ava-server.env"),
+  };
+}
+
+/** Secrets-valv + env-bootstrap (+ valfri start). Returnerar false vid config-fel. */
+async function runInstall(argv: string[], paths: InstallPaths): Promise<boolean> {
+  const cfg = buildConfig(argv, paths.secretsFile);
   const errors = validateInstallConfig(cfg);
   if (errors.length) {
     for (const e of errors) console.error(`[install-server] FEL: ${e}`);
-    process.exitCode = 1;
-    return;
+    return false;
   }
 
   const { mkdir, writeFile } = await import("node:fs/promises");
-  await mkdir(secretsDir, { recursive: true, mode: 0o700 });
+  await mkdir(paths.secretsDir, { recursive: true, mode: 0o700 });
 
   const plan = planInstall(
-    { masterKeyExists: await exists(masterKeyFile), vaultExists: await exists(secretsFile) },
+    { masterKeyExists: await exists(paths.masterKeyFile), vaultExists: await exists(paths.secretsFile) },
     cfg,
   );
   if (!plan.generateMasterKey) log("befintlig master-nyckel behålls (skrivs ej över)");
 
-  const masterKey = await ensureMasterKey(masterKeyFile, plan.generateMasterKey);
-  const vault = new EncryptedFileVault(secretsFile, Buffer.from(masterKey, "base64"), nodeVaultFs());
+  const masterKey = await ensureMasterKey(paths.masterKeyFile, plan.generateMasterKey);
+  const vault = new EncryptedFileVault(paths.secretsFile, Buffer.from(masterKey, "base64"), nodeVaultFs());
   if (plan.storeSecrets) await storeVaultSecrets(vault, cfg);
 
-  await writeFile(envFile, renderServerEnv(cfg), { mode: 0o600 });
-  log(`deploy-env skriven: ${envFile}`);
-  printNextSteps(cfg, masterKeyFile, envFile);
+  await writeFile(paths.envFile, renderServerEnv(cfg), { mode: 0o600 });
+  log(`deploy-env skriven: ${paths.envFile}`);
+
+  if (hasFlag(argv, "start")) {
+    // Ett-kommando-vägen: exportera valv-nyckeln + bygg + starta + verifiera.
+    process.env.AVA_SECRETS_KEY = masterKey;
+    process.env.AVA_SECRETS_FILE = paths.secretsFile;
+    await startStack(cfg.authMode === "oidc");
+    log("backenden uppe. Lägg till användare med tooling/scripts/add-user.sh.");
+    return true;
+  }
+  printNextSteps(cfg, paths.masterKeyFile, paths.envFile);
+  return true;
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+
+  // Avinstallation/nedrivning: stoppa stacken + ta bort volymer, sen klart.
+  if (hasFlag(argv, "down")) {
+    await runCommands(buildStopCommands({ oidc: (flag(argv, "auth") ?? "htpasswd") === "oidc" }), process.env);
+    log("stacken nedriven (volymer borttagna). Secrets-valvet är oförändrat.");
+    return;
+  }
+
+  const ok = await runInstall(argv, resolvePaths(argv));
+  if (!ok) process.exitCode = 1;
 }
 
 main().catch((err: unknown) => {

--- a/tooling/scripts/install-server/orchestrate.ts
+++ b/tooling/scripts/install-server/orchestrate.ts
@@ -1,0 +1,48 @@
+/**
+ * Orchestrering för install-server (#232) — bygg + starta + verifiera stacken
+ * som ETT kommando. Ren, testbar logik: kommandosekvenserna (argv-listor) och
+ * admin-token-extraktionen ur web-loggen. CLI:n kör dem via spawn (I/O).
+ */
+
+const DEMO_COMPOSE = "tooling/docker/docker-compose.yml";
+const OIDC_OVERLAY = "tooling/docker/docker-compose.oidc.yml";
+/** Web-containern printar `Admin-token:      <40 tecken>` EN gång vid bootstrap. */
+const ADMIN_TOKEN_RE = /Admin-token:\s+([A-Za-z0-9]{40})/;
+const WAIT_TIMEOUT_S = "180";
+
+export interface StartOptions {
+  /** OIDC-läge → starta även oauth2-proxy/Keycloak-overlayen. */
+  oidc: boolean;
+}
+
+function composeArgs(oidc: boolean): string[] {
+  const files = oidc ? [DEMO_COMPOSE, OIDC_OVERLAY] : [DEMO_COMPOSE];
+  return ["docker", "compose", ...files.flatMap((f) => ["-f", f])];
+}
+
+/**
+ * Kommandosekvens för att bygga static-export:en och starta stacken (väntar in
+ * healthy via `--wait`). Returneras som argv-listor så CLI:n kan köra dem i
+ * ordning; build-demo läser `DEMO_BASE_PATH` ur env (sätts av CLI:n).
+ */
+export function buildStartCommands(opts: StartOptions): string[][] {
+  return [
+    ["bash", "tooling/scripts/build-demo.sh"],
+    [...composeArgs(opts.oidc), "up", "-d", "--build", "--wait", "--wait-timeout", WAIT_TIMEOUT_S],
+  ];
+}
+
+/** Kommando för att läsa web-loggen (admin-token-extraktion). */
+export function logsCommand(oidc: boolean): string[] {
+  return [...composeArgs(oidc), "logs", "web"];
+}
+
+/** Avinstallation/nedrivning: stoppa stacken + ta bort volymer. */
+export function buildStopCommands(opts: StartOptions): string[][] {
+  return [[...composeArgs(opts.oidc), "down", "-v"]];
+}
+
+/** Plocka ut den bootstrappade admin-token:n ur web-loggen. null om ej funnen. */
+export function extractAdminToken(logText: string): string | null {
+  return logText.match(ADMIN_TOKEN_RE)?.[1] ?? null;
+}


### PR DESCRIPTION
Andra delen av #232 — gör install-flödet till **ett kommando** (issuens "Klar när") ovanpå secrets/env-kärnan (#253).

## Vad
- **`tooling/scripts/install-server/orchestrate.ts`** (ren, testbar): `buildStartCommands` (build-demo + `docker compose up -d --build --wait`), `buildStopCommands` (`down -v`), `logsCommand`, och `extractAdminToken` (plockar den 40-teckens bootstrappade admin-token:n ur web-loggen — samma mönster som CI). OIDC-läge inkluderar `docker-compose.oidc.yml`-overlayen.
- **`install-server.ts`** — nya flaggor:
  - `--start`: exporterar valv-nyckeln → bygger `out/` → startar stacken (väntar healthy via `--wait`) → skriver ut admin-token:n. Hela kedjan i ett kommando.
  - `--down`: avinstallation/nedrivning (`compose down -v`); secrets-valvet lämnas orört.
  - `main` bantad till `resolvePaths` + `runInstall`-helpers (complexity ≤8).

## Verifierat
- Enhetstester: kommandosekvenserna (htpasswd vs oidc-overlay, `up --wait`, `down -v`, `logs web`) + `extractAdminToken` (träff/null/för kort). Spawn/docker är tunt I/O (ej enhetstestat).
- Smoke-testat: grund-install (utan `--start`) oförändrad efter refaktorn.
- Lokalt grönt: typecheck, lint (complexity ≤8), `test:cov` (rader 83.49% / funk 80.53%), dep-cruiser, knip, jscpd. Tooling-only → rör ej app-bundeln.

## Kvar på #232
Setup-wizard/UI (bygg på `src/app/setup/page.tsx`) + tydligare felmeddelanden (port upptagen / docker saknas). Då kan #232 stängas.

Refs #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)