### PR TITLE
feat(server): install-server config-fil-läge (fyll-i-mall, ej alla flaggor)

### DIFF
--- a/test/scripts/install-server-wizard.test.ts
+++ b/test/scripts/install-server-wizard.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest-compat";
+import {
+  fieldsFor,
+  answersToConfig,
+  renderConfigTemplate,
+  parseConfigFile,
+  BASE_FIELDS,
+  OIDC_FIELDS,
+} from "../../tooling/scripts/install-server/wizard";
+
+describe("fieldsFor", () => {
+  it("htpasswd: bara grundfält", () => {
+    expect(fieldsFor("htpasswd")).toEqual(BASE_FIELDS);
+  });
+  it("oidc: grund + oidc-fält", () => {
+    expect(fieldsFor("oidc")).toEqual([...BASE_FIELDS, ...OIDC_FIELDS]);
+  });
+});
+
+describe("answersToConfig", () => {
+  it("htpasswd: mappar grundsvar, ingen oidc", () => {
+    const cfg = answersToConfig({ repo: "r", "work-dir": "w", org: "o", auth: "htpasswd" }, "/v/vault.enc");
+    expect(cfg).toEqual({ repoUrl: "r", workDir: "w", organizationId: "o", secretsFile: "/v/vault.enc", authMode: "htpasswd" });
+  });
+  it("oidc: inkluderar oidc-block", () => {
+    const cfg = answersToConfig(
+      { repo: "r", "work-dir": "w", org: "o", auth: "oidc", "oidc-issuer": "https://idp", "oidc-client-id": "ava", "oidc-client-secret": "s3cr3t", "oidc-redirect": "https://app/cb" },
+      "/v/vault.enc",
+    );
+    expect(cfg.authMode).toBe("oidc");
+    expect(cfg.oidc).toEqual({ issuerUrl: "https://idp", clientId: "ava", clientSecret: "s3cr3t", redirectUrl: "https://app/cb" });
+  });
+  it("okänt/utelämnat auth → htpasswd (säker default)", () => {
+    expect(answersToConfig({ repo: "r" }, "/v").authMode).toBe("htpasswd");
+    expect(answersToConfig({ auth: "skräp" }, "/v").authMode).toBe("htpasswd");
+  });
+});
+
+describe("renderConfigTemplate", () => {
+  it("ger giltig JSON med alla fält + _help", () => {
+    const tpl = JSON.parse(renderConfigTemplate());
+    expect(tpl.repo).toBe("");
+    expect(tpl.auth).toBe("htpasswd"); // default
+    expect(tpl["oidc-issuer"]).toBe("");
+    expect(typeof tpl._help.repo).toBe("string");
+  });
+});
+
+describe("parseConfigFile", () => {
+  it("plockar strängvärden, hoppar _help + tomma", () => {
+    const json = JSON.stringify({ _help: { repo: "x" }, repo: "r", org: "", auth: "oidc" });
+    expect(parseConfigFile(json)).toEqual({ repo: "r", auth: "oidc" });
+  });
+  it("template → parse → answersToConfig (round-trip av ifylld mall)", () => {
+    const tpl = JSON.parse(renderConfigTemplate());
+    tpl.repo = "r"; tpl["work-dir"] = "w"; tpl.org = "o";
+    const answers = parseConfigFile(JSON.stringify(tpl));
+    expect(answersToConfig(answers, "/v").repoUrl).toBe("r");
+  });
+  it("icke-objekt → kastar", () => {
+    expect(() => parseConfigFile("42")).toThrow(/JSON-objekt/);
+  });
+});

--- a/tooling/scripts/install-server.ts
+++ b/tooling/scripts/install-server.ts
@@ -28,8 +28,6 @@ import {
   vaultSecretsFor,
   validateInstallConfig,
   VAULT_KEYS,
-  type AuthMode,
-  type OidcInstallConfig,
   type ServerInstallConfig,
 } from "./install-server/core";
 import {
@@ -38,6 +36,11 @@ import {
   logsCommand,
   extractAdminToken,
 } from "./install-server/orchestrate";
+import {
+  answersToConfig,
+  renderConfigTemplate,
+  parseConfigFile,
+} from "./install-server/wizard";
 
 function flag(argv: string[], name: string): string | undefined {
   const i = argv.indexOf(`--${name}`);
@@ -68,25 +71,29 @@ async function startStack(oidc: boolean): Promise<void> {
   log(token ? `admin-token (engångs): ${token} — lägg till användare med add-user.sh` : "admin-token ej funnen i loggen ännu (kolla `docker compose logs web`)");
 }
 
-function buildOidc(argv: string[]): OidcInstallConfig {
-  return {
-    issuerUrl: flag(argv, "oidc-issuer") ?? "",
-    clientId: flag(argv, "oidc-client-id") ?? "",
-    clientSecret: flag(argv, "oidc-client-secret") ?? "",
-    redirectUrl: flag(argv, "oidc-redirect") ?? "",
-  };
+const ANSWER_KEYS = [
+  "repo", "work-dir", "org", "auth",
+  "oidc-issuer", "oidc-client-id", "oidc-client-secret", "oidc-redirect",
+] as const;
+
+/** Plocka kända flaggor till en svar-map (flagg-vägen). */
+function argvToAnswers(argv: string[]): Record<string, string | undefined> {
+  const answers: Record<string, string | undefined> = {};
+  for (const key of ANSWER_KEYS) answers[key] = flag(argv, key);
+  return answers;
 }
 
-function buildConfig(argv: string[], secretsFile: string): ServerInstallConfig {
-  const authMode = (flag(argv, "auth") ?? "htpasswd") as AuthMode;
-  return {
-    repoUrl: flag(argv, "repo") ?? "",
-    workDir: flag(argv, "work-dir") ?? "",
-    organizationId: flag(argv, "org") ?? "",
-    secretsFile,
-    authMode,
-    ...(authMode === "oidc" ? { oidc: buildOidc(argv) } : {}),
-  };
+/** Slå ihop config-fil (om angiven) med flaggor — flaggor vinner. */
+async function gatherAnswers(argv: string[]): Promise<Record<string, string | undefined>> {
+  const configPath = flag(argv, "config");
+  const fromFlags = argvToAnswers(argv);
+  if (!configPath) return fromFlags;
+  const { readFile } = await import("node:fs/promises");
+  const fromFile = parseConfigFile(await readFile(configPath, "utf8"));
+  // Flaggor vinner över filen (tillåter override per körning).
+  const merged: Record<string, string | undefined> = { ...fromFile };
+  for (const [k, v] of Object.entries(fromFlags)) if (v !== undefined) merged[k] = v;
+  return merged;
 }
 
 function log(msg: string): void {
@@ -150,7 +157,8 @@ function resolvePaths(argv: string[]): InstallPaths {
 
 /** Secrets-valv + env-bootstrap (+ valfri start). Returnerar false vid config-fel. */
 async function runInstall(argv: string[], paths: InstallPaths): Promise<boolean> {
-  const cfg = buildConfig(argv, paths.secretsFile);
+  const answers = await gatherAnswers(argv);
+  const cfg = answersToConfig(answers, paths.secretsFile);
   const errors = validateInstallConfig(cfg);
   if (errors.length) {
     for (const e of errors) console.error(`[install-server] FEL: ${e}`);
@@ -187,6 +195,12 @@ async function runInstall(argv: string[], paths: InstallPaths): Promise<boolean>
 
 async function main(): Promise<void> {
   const argv = process.argv.slice(2);
+
+  // Skriv ut en config-mall att fylla i (--config-vägen). Inga sidoeffekter.
+  if (hasFlag(argv, "print-config-template")) {
+    process.stdout.write(renderConfigTemplate());
+    return;
+  }
 
   // Avinstallation/nedrivning: stoppa stacken + ta bort volymer, sen klart.
   if (hasFlag(argv, "down")) {

--- a/tooling/scripts/install-server/wizard.ts
+++ b/tooling/scripts/install-server/wizard.ts
@@ -1,0 +1,94 @@
+/**
+ * Konfigurations-modell för install-server (#232) — gör att en icke-devops-byrå
+ * kan fylla i en JSON-mall (`--print-config-template` → redigera →
+ * `--config fil.json`) i stället för att kunna alla flaggor. Ren logik
+ * (fält-definitioner + svar→config + mall-rendering) bor här.
+ *
+ * Samma `answersToConfig` används av BÅDE flagg-vägen (argv→answers) och
+ * config-fil-vägen → en sanningskälla för config-byggandet.
+ */
+
+import type { OidcInstallConfig, ServerInstallConfig } from "./core";
+
+export interface ConfigField {
+  /** Nyckel i config/answers-mappen (= flaggnamn utan `--`). */
+  key: string;
+  /** Människoläsbar beskrivning (mall-kommentar). */
+  question: string;
+  default?: string;
+}
+
+/** Grundfält (alltid). */
+export const BASE_FIELDS: readonly ConfigField[] = [
+  { key: "repo", question: "Git-repo-URL till firma.git" },
+  { key: "work-dir", question: "Katalog för server-runtime:ns working-copy" },
+  { key: "org", question: "Organisations-id (UUID)" },
+  { key: "auth", question: "Auth-läge: htpasswd eller oidc", default: "htpasswd" },
+];
+
+/** Extra fält när auth-läget är OIDC. */
+export const OIDC_FIELDS: readonly ConfigField[] = [
+  { key: "oidc-issuer", question: "OIDC issuer-URL" },
+  { key: "oidc-client-id", question: "OIDC client-id" },
+  { key: "oidc-client-secret", question: "OIDC client-secret (skrivs i valvet, ej i .env)" },
+  { key: "oidc-redirect", question: "OIDC redirect-URL" },
+];
+
+/** Alla fält givet (ev. valt) auth-läge. */
+export function fieldsFor(authMode: string | undefined): readonly ConfigField[] {
+  return authMode === "oidc" ? [...BASE_FIELDS, ...OIDC_FIELDS] : BASE_FIELDS;
+}
+
+/**
+ * Rendera en JSON-mall (alla fält tomma + en `_help`-karta key→beskrivning).
+ * Byrån fyller i den och kör `--config fil.json`.
+ */
+export function renderConfigTemplate(): string {
+  const all = fieldsFor("oidc"); // alla fält (bas + oidc) i mallen
+  const fields: Record<string, string> = {};
+  const help: Record<string, string> = {};
+  for (const f of all) {
+    fields[f.key] = f.default ?? "";
+    help[f.key] = f.question;
+  }
+  return JSON.stringify({ _help: help, ...fields }, null, 2) + "\n";
+}
+
+/** Parsa + validera en config-fil till en answers-map (strängvärden). */
+export function parseConfigFile(json: string): Record<string, string> {
+  const parsed: unknown = JSON.parse(json);
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error("config-filen måste vara ett JSON-objekt");
+  }
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+    if (k === "_help") continue;
+    if (typeof v === "string" && v !== "") out[k] = v;
+  }
+  return out;
+}
+
+function oidcFromAnswers(a: Record<string, string | undefined>): OidcInstallConfig {
+  return {
+    issuerUrl: a["oidc-issuer"] ?? "",
+    clientId: a["oidc-client-id"] ?? "",
+    clientSecret: a["oidc-client-secret"] ?? "",
+    redirectUrl: a["oidc-redirect"] ?? "",
+  };
+}
+
+/** Bygg install-config ur en svar-/flagg-map. Enda config-byggaren. */
+export function answersToConfig(
+  answers: Record<string, string | undefined>,
+  secretsFile: string,
+): ServerInstallConfig {
+  const authMode = answers.auth === "oidc" ? "oidc" : "htpasswd";
+  return {
+    repoUrl: answers.repo ?? "",
+    workDir: answers["work-dir"] ?? "",
+    organizationId: answers.org ?? "",
+    secretsFile,
+    authMode,
+    ...(authMode === "oidc" ? { oidc: oidcFromAnswers(answers) } : {}),
+  };
+}


### PR DESCRIPTION
Tredje delen av #232 — en icke-devops-byrå kan fylla i en mall i stället för att kunna alla flaggor:
```
bun run install:server --print-config-template > ava-install.json   # redigera
bun run install:server --config ava-install.json --start
```

## Vad
- **`tooling/scripts/install-server/wizard.ts`** — fält-definitioner (`BASE_FIELDS`/`OIDC_FIELDS`, `fieldsFor`), `renderConfigTemplate` (JSON-mall med `_help`-beskrivningar), `parseConfigFile` (strikt: objekt av strängar, hoppar `_help`/tomma), och **`answersToConfig`** — den ENDA config-byggaren, nu delad av både flagg-vägen (`argvToAnswers`) och config-fil-vägen. Ersätter de duplicerade `buildConfig`/`buildOidc`.
- **`install-server.ts`** — `--config <fil>` (slås ihop med ev. flaggor; flaggor vinner) + `--print-config-template`.

## Varför inte en interaktiv TUI
Jag utvärderade en readline-wizard, men **bun:s `readline` (både `readline/promises` och callback-varianten) hänger med pipe:ad stdin** → omöjlig att testa/verifiera robust i CI. Config-fil-mallen ger samma "non-devops kan komma igång"-nytta utan den risken (och är fullt enhetstestbar).

## Verifierat
- Enhetstester: fält-listor (htpasswd vs oidc), mall-rendering (giltig JSON + alla fält + `_help`), strikt parse (hoppar `_help`/tomma, kastar på icke-objekt), round-trip mall→parse→`answersToConfig`.
- Smoke-testat: `--print-config-template` → fyll i → `--config` → master.key + valv (OIDC-secrets) + `.env` (config men **ingen secret**).
- Lokalt grönt: typecheck, lint (complexity ≤8), `test:cov` (rader 83.51% / funk 80.53%), dep-cruiser, knip, jscpd. Tooling-only.

## #232-status
Core (#253) + orchestrering/ett-kommando (#254) + config-fil-läge (denna) ger nu "installera + starta utan att handredigera env/compose". Kvar (valfri polish): en webb-baserad setup-wizard (`src/app/setup/page.tsx`) + preflight-felmeddelanden (port upptagen/docker saknas). Issuens "Klar när" är i praktiken uppfylld.

Refs #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)