### PR TITLE
feat(server): install-server preflight (docker + port) före start

### DIFF
--- a/test/scripts/install-server-preflight.test.ts
+++ b/test/scripts/install-server-preflight.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest-compat";
+import { createServer } from "node:net";
+import {
+  interpretPreflight,
+  dockerAvailable,
+  portFree,
+} from "../../tooling/scripts/install-server/preflight";
+
+describe("interpretPreflight", () => {
+  it("alla ok → inga fel", () => {
+    expect(interpretPreflight([{ name: "docker", ok: true }, { name: "port 8080", ok: true }])).toEqual({
+      ok: true,
+      errors: [],
+    });
+  });
+
+  it("samlar fel med hint", () => {
+    const out = interpretPreflight([
+      { name: "docker", ok: false, hint: "docker saknas" },
+      { name: "port 8080", ok: true },
+    ]);
+    expect(out.ok).toBe(false);
+    expect(out.errors).toEqual(["docker: docker saknas"]);
+  });
+});
+
+describe("dockerAvailable", () => {
+  it("status 0 → tillgängligt", async () => {
+    expect(await dockerAvailable(() => ({ status: 0 }))).toBe(true);
+  });
+  it("status !=0 / saknas → ej tillgängligt", async () => {
+    expect(await dockerAvailable(() => ({ status: 127 }))).toBe(false);
+    expect(await dockerAvailable(() => ({ status: null }))).toBe(false);
+  });
+});
+
+describe("portFree", () => {
+  it("upptagen port → false, ledig → true", async () => {
+    const server = createServer();
+    await new Promise<void>((res) => server.listen(0, "127.0.0.1", res));
+    const port = (server.address() as { port: number }).port;
+    try {
+      expect(await portFree(port)).toBe(false); // vi håller porten
+    } finally {
+      await new Promise<void>((res) => server.close(() => res()));
+    }
+    // Samma port är ledig igen efter close
+    expect(await portFree(port)).toBe(true);
+  });
+});

--- a/tooling/scripts/install-server.ts
+++ b/tooling/scripts/install-server.ts
@@ -36,6 +36,7 @@ import {
   logsCommand,
   extractAdminToken,
 } from "./install-server/orchestrate";
+import { interpretPreflight, runPreflight } from "./install-server/preflight";
 import {
   answersToConfig,
   renderConfigTemplate,
@@ -59,6 +60,17 @@ async function runCommands(cmds: string[][], env: NodeJS.ProcessEnv): Promise<vo
     const r = spawnSync(bin!, args, { stdio: "inherit", env });
     if (r.status !== 0) throw new Error(`kommandot misslyckades (${r.status ?? r.signal}): ${bin}`);
   }
+}
+
+const WEB_PORT = 8080;
+
+/** Preflight: docker + web-port. Returnerar false (+ loggar) vid problem. */
+async function preflightOk(): Promise<boolean> {
+  const { ok, errors } = interpretPreflight(await runPreflight(WEB_PORT));
+  if (!ok) {
+    for (const e of errors) console.error(`[install-server] preflight: ${e}`);
+  }
+  return ok;
 }
 
 /** Bygg + starta stacken och skriv ut den bootstrappade admin-token:n. */
@@ -182,7 +194,8 @@ async function runInstall(argv: string[], paths: InstallPaths): Promise<boolean>
   log(`deploy-env skriven: ${paths.envFile}`);
 
   if (hasFlag(argv, "start")) {
-    // Ett-kommando-vägen: exportera valv-nyckeln + bygg + starta + verifiera.
+    // Ett-kommando-vägen: preflight → exportera valv-nyckeln → bygg → starta.
+    if (!(await preflightOk())) return false;
     process.env.AVA_SECRETS_KEY = masterKey;
     process.env.AVA_SECRETS_FILE = paths.secretsFile;
     await startStack(cfg.authMode === "oidc");

--- a/tooling/scripts/install-server/preflight.ts
+++ b/tooling/scripts/install-server/preflight.ts
@@ -1,0 +1,52 @@
+/**
+ * Preflight-kontroller för install-server (#258, uppföljning #232) — fångar
+ * vanliga fällor FÖRE `--start` och ger tydliga fel i stället för kryptiska
+ * docker-fel: (1) docker tillgängligt, (2) web-porten ledig.
+ *
+ * `interpretPreflight` är ren + testbar; I/O-runnerna injicerar sina beroenden
+ * (spawn/net) så även de kan testas utan en riktig docker/ledig port.
+ */
+
+export interface PreflightCheck {
+  name: string;
+  ok: boolean;
+  /** Åtgärdsförslag när !ok. */
+  hint?: string;
+}
+
+/** Sammanställ checkar → {ok, errors}. Ren. */
+export function interpretPreflight(checks: readonly PreflightCheck[]): { ok: boolean; errors: string[] } {
+  const errors = checks
+    .filter((c) => !c.ok)
+    .map((c) => (c.hint ? `${c.name}: ${c.hint}` : c.name));
+  return { ok: errors.length === 0, errors };
+}
+
+type SpawnLike = (cmd: string, args: string[]) => { status: number | null };
+
+/** Är `docker` körbart? (kör `docker --version`.) */
+export async function dockerAvailable(spawn?: SpawnLike): Promise<boolean> {
+  if (spawn) return spawn("docker", ["--version"]).status === 0;
+  const { spawnSync } = await import("node:child_process");
+  return spawnSync("docker", ["--version"], { stdio: "ignore" }).status === 0;
+}
+
+/** Är `port` ledig? Försöker lyssna på den; EADDRINUSE → upptagen. */
+export async function portFree(port: number): Promise<boolean> {
+  const net = await import("node:net");
+  return new Promise<boolean>((resolve) => {
+    const server = net.createServer();
+    server.once("error", () => resolve(false));
+    server.once("listening", () => server.close(() => resolve(true)));
+    server.listen(port, "127.0.0.1");
+  });
+}
+
+/** Kör alla preflight-checkar inför start (docker + web-port). */
+export async function runPreflight(webPort: number): Promise<PreflightCheck[]> {
+  const [docker, free] = await Promise.all([dockerAvailable(), portFree(webPort)]);
+  return [
+    { name: "docker", ok: docker, hint: "docker hittades inte på PATH — installera Docker Desktop/Engine" },
+    { name: `port ${webPort}`, ok: free, hint: `porten ${webPort} är upptagen — stoppa tjänsten som använder den eller välj en annan` },
+  ];
+}


### PR DESCRIPTION
Uppföljning på #232 (server-installern) — `install:server --start` preflight-kontrollerar nu vanliga fällor och ger **tydliga fel** i stället för kryptiska docker-fel (issuens "tydliga felmeddelanden: port upptagen / docker saknas").

## Vad
- **`install-server/preflight.ts`**: `interpretPreflight` (ren, samlar fel+hint), `dockerAvailable` (kör `docker --version`; injicerbar spawn för test), `portFree` (försöker lyssna → `EADDRINUSE` = upptagen), `runPreflight` (docker + web-port 8080).
- **CLI**: kör preflight innan bygg/start i `--start`-vägen; vid problem skrivs åtgärdsförslag ut (t.ex. "docker hittades inte på PATH", "porten 8080 är upptagen") och starten avbryts → ingen halvstartad stack.

## Verifierat
- Tester: `interpretPreflight` (ok / fel-med-hint), `dockerAvailable` (injicerad status 0/127/null), `portFree` (binder en riktig port → upptagen; ledig efter close).
- Lokalt grönt: typecheck, lint, `test:cov` (rader 83.61% / funk 80.58%), dep-cruiser, knip, jscpd. Tooling-only.

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)