### PR TITLE
feat(auth): bootstrap-admin-script — seeda första admin i OIDC-allowlisten

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "seed:local": "bun tooling/scripts/seed-firma-local.ts",
     "server-runtime": "bun src/bin/server-runtime.ts",
     "install:server": "bun tooling/scripts/install-server.ts",
+    "bootstrap:admin": "bun tooling/scripts/bootstrap-admin.ts",
     "server-runtime:build": "bun tooling/scripts/build-server-runtime.ts",
     "server-runtime:smoke": "bash tooling/scripts/smoke-server-runtime-docker.sh",
     "start": "next start",

--- a/test/scripts/bootstrap-admin.test.ts
+++ b/test/scripts/bootstrap-admin.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest-compat";
+import { buildAdminUserRow, adminUserGitPath } from "../../tooling/scripts/bootstrap-admin/core";
+import { userSchema } from "@/lib/shared/schemas/user";
+import { classifyOidcLogin } from "@/lib/client/backend/oidc-principal";
+import type { AllowlistedUser } from "@/lib/server/auth/oidc-auth-provider";
+
+const ORG = "11111111-1111-5111-8111-111111111111";
+
+describe("buildAdminUserRow", () => {
+  it("bygger en giltig ADMIN-rad (validerar mot userSchema)", () => {
+    const row = buildAdminUserRow({ email: "Admin@Byra.SE", organizationId: ORG, now: new Date("2026-06-12T10:00:00Z") });
+    expect(userSchema.safeParse(row).success).toBe(true);
+    expect(row.role).toBe("ADMIN");
+    expect(row.active).toBe(true);
+    expect(row.email).toBe("admin@byra.se"); // normaliserad (lowercase + trim)
+    expect(row.organizationId).toBe(ORG);
+  });
+
+  it("id är deterministiskt (idempotent re-run) men unikt per email", () => {
+    const a = buildAdminUserRow({ email: "a@x.se", organizationId: ORG });
+    const a2 = buildAdminUserRow({ email: "a@x.se", organizationId: ORG });
+    const b = buildAdminUserRow({ email: "b@x.se", organizationId: ORG });
+    expect(a.id).toBe(a2.id);
+    expect(a.id).not.toBe(b.id);
+  });
+
+  it("namn defaultar till email-delen före @", () => {
+    expect(buildAdminUserRow({ email: "anna@byra.se", organizationId: ORG }).name).toBe("anna");
+    expect(buildAdminUserRow({ email: "x@y.se", organizationId: ORG, name: "Anna A" }).name).toBe("Anna A");
+  });
+});
+
+describe("bootstrap → OIDC-login (stänger chicken-egg-loopen)", () => {
+  it("seedad admin-rad resolvar till ADMIN-principal via classifyOidcLogin (#252)", () => {
+    const row = buildAdminUserRow({ email: "admin@byra.se", organizationId: ORG });
+    // Den seedade raden är en giltig allowlist-post; OIDC-login mot samma email → ADMIN.
+    const outcome = classifyOidcLogin(
+      { email: "admin@byra.se", subject: "", issuer: "", name: "Admin" },
+      [row as unknown as AllowlistedUser],
+    );
+    expect(outcome.kind).toBe("authorized");
+    if (outcome.kind === "authorized") expect(outcome.principal.role).toBe("ADMIN");
+  });
+});
+
+describe("adminUserGitPath", () => {
+  it("pekar på .ava/users/<email>.json (normaliserad)", () => {
+    expect(adminUserGitPath(" Admin@Byra.SE ")).toBe(".ava/users/admin@byra.se.json");
+  });
+});

--- a/tooling/scripts/bootstrap-admin.ts
+++ b/tooling/scripts/bootstrap-admin.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env bun
+/**
+ * `bootstrap-admin` (#224) — seeda första admin i OIDC-allowlisten på en färsk
+ * self-hosted-stack. Körs på hosten (rotförtroende = shell-access), före första
+ * OIDC-login. Skriver en admin-rad (`.ava/users/<email>.json`, role=ADMIN) i
+ * firma.git-working-copy:n; efter commit/push kan personen logga in via OIDC och
+ * resolvas som ADMIN ([[oidc-principal]]).
+ *
+ *   bun tooling/scripts/bootstrap-admin.ts --work-dir /srv/ava/wc \
+ *     --email admin@byra.se --org <org-uuid> [--name "Anna"] [--commit]
+ *
+ * Idempotent: kör om → samma deterministiska id, skriver bara om raden saknas
+ * eller inte redan är ADMIN. Logik i `bootstrap-admin/core.ts`; denna fil är
+ * argv + fs + (valfri) git-commit.
+ */
+
+import { join } from "node:path";
+import { buildAdminUserRow, adminUserGitPath } from "./bootstrap-admin/core";
+
+function flag(argv: string[], name: string): string | undefined {
+  const i = argv.indexOf(`--${name}`);
+  return i >= 0 ? argv[i + 1] : undefined;
+}
+
+function log(msg: string): void {
+  console.log(`[bootstrap-admin] ${msg}`);
+}
+
+/** Är raden redan en admin? (idempotens — undvik onödig skrivning/commit.) */
+async function alreadyAdmin(path: string): Promise<boolean> {
+  const { readFile } = await import("node:fs/promises");
+  try {
+    const row = JSON.parse(await readFile(path, "utf8")) as { role?: string };
+    return row.role === "ADMIN";
+  } catch {
+    return false;
+  }
+}
+
+async function gitCommit(workDir: string, relPath: string, email: string): Promise<void> {
+  const { spawnSync } = await import("node:child_process");
+  const run = (args: string[]) => spawnSync("git", ["-C", workDir, ...args], { stdio: "inherit" });
+  run(["add", relPath]);
+  run(["commit", "-m", `feat(auth): bootstrap admin ${email} i allowlisten (#224)`]);
+  log("committat — pusha med `git push` (eller låt server-runtime-peern göra det).");
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const workDir = flag(argv, "work-dir");
+  const email = flag(argv, "email");
+  const org = flag(argv, "org");
+  if (!workDir || !email || !org) {
+    console.error("[bootstrap-admin] FEL: --work-dir, --email och --org krävs.");
+    process.exitCode = 1;
+    return;
+  }
+
+  const relPath = adminUserGitPath(email);
+  const fullPath = join(workDir, relPath);
+  if (await alreadyAdmin(fullPath)) {
+    log(`${email} är redan ADMIN i allowlisten — inget att göra.`);
+    return;
+  }
+
+  const nameFlag = flag(argv, "name");
+  const row = buildAdminUserRow({ email, organizationId: org, ...(nameFlag ? { name: nameFlag } : {}) });
+  const { mkdir, writeFile } = await import("node:fs/promises");
+  await mkdir(join(workDir, ".ava", "users"), { recursive: true });
+  await writeFile(fullPath, JSON.stringify(row, null, 2) + "\n");
+  log(`admin-rad skriven: ${relPath} (role=ADMIN, id=${row.id})`);
+
+  if (argv.includes("--commit")) await gitCommit(workDir, relPath, email);
+  else log("kör om med --commit för att committa, eller commita/pusha själv.");
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`[bootstrap-admin] startfel: ${String(err)}\n`);
+  process.exitCode = 1;
+});

--- a/tooling/scripts/bootstrap-admin/core.ts
+++ b/tooling/scripts/bootstrap-admin/core.ts
@@ -1,0 +1,46 @@
+/**
+ * Bootstrap av första admin i OIDC-allowlisten (#224) — ren rad-byggare.
+ *
+ * Hönan-och-ägget: på en färsk stack är allowlisten (`.ava/users/<email>.json`,
+ * #223) tom, och `user.create` kräver admin-kontext. Rotförtroendet är den som
+ * har host shell-access. Den här byggaren producerar en giltig admin-användarrad
+ * som host-scriptet skriver direkt till firma.git-working-copy:n → efter det kan
+ * personen logga in via OIDC och resolvas som ADMIN ([[oidc-principal]]).
+ *
+ * Id:t är DETERMINISTISKT (uuidv5 på email) → idempotent: kör om → samma id,
+ * ingen dubblettrad. zod-validerat mot `userSchema`.
+ */
+
+import { uuidv5, AVA_NAMESPACE } from "@/lib/shared/uuid-derive";
+import { userSchema, type User } from "@/lib/shared/schemas/user";
+
+export interface AdminBootstrapInput {
+  email: string;
+  organizationId: string;
+  /** Visningsnamn (default = email-delen före @). */
+  name?: string;
+  /** Tidsstämpel (injicerbar för deterministiska tester). */
+  now?: Date;
+}
+
+/** Bygg + validera en admin-allowlist-rad (role=ADMIN, active). Ren. */
+export function buildAdminUserRow(input: AdminBootstrapInput): User {
+  const email = input.email.trim().toLowerCase();
+  const id = uuidv5(`user:${email}`, AVA_NAMESPACE);
+  const now = (input.now ?? new Date()).toISOString();
+  return userSchema.parse({
+    id,
+    organizationId: input.organizationId,
+    email,
+    name: input.name?.trim() || email.split("@")[0],
+    role: "ADMIN",
+    active: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+/** Relativ git-path till allowlist-raden (samma som fsa-write-back/#223). */
+export function adminUserGitPath(email: string): string {
+  return `.ava/users/${email.trim().toLowerCase()}.json`;
+}


### PR DESCRIPTION
Löser hönan-och-ägget i #224: på en färsk stack är OIDC-allowlisten (`.ava/users/`, #223) tom och `user.create` kräver admin-kontext → ingen kan logga in. Rotförtroendet är host shell-access (issuens accepterade "`add-user.sh --admin`"-alternativ), här som ett dedikerat script.

## Vad
- **`bootstrap-admin/core.ts`** — `buildAdminUserRow`: giltig ADMIN-allowlist-rad (zod-validerad mot `userSchema`), **deterministiskt id** (uuidv5 på email → idempotent). `adminUserGitPath` → `.ava/users/<email>.json`.
- **`bootstrap-admin.ts`** — host-CLI: `bun run bootstrap:admin --work-dir <wc> --email <e> --org <uuid> [--name] [--commit]` → skriver admin-raden i firma.git-working-copy:n, idempotent (hoppar över om redan ADMIN), valfri git-commit.

## Stänger loopen
Med OIDC-login-wiringen (#252): ett **integrationstest** bevisar att den seedade raden resolvar till en ADMIN-principal via `classifyOidcLogin`. Så: `bootstrap:admin` på hosten → OIDC-login → ADMIN på en färsk stack.

## Kvar i #224 (behåller öppen)
Engångs-token-redeem-flödet via auth-servern (#228 byggde `/auth/claim-admin`-endpointen, men klient-redeem + att skriva allowlist-raden från claim är inte ihopkopplat) + **`oidcSubject`-bindning** vid första login — det senare kräver att oauth2-proxy forwardar `sub`/`iss` (saknas i `/oauth2/userinfo` idag; binding sker på email tills vidare). Dessa spåras vidare på #224.

## Verifierat
- Tester: row-byggaren (userSchema-validering, deterministiskt/unikt id, namn-default, email-normalisering), git-path, bootstrap→login-resolution (ADMIN-principal). Smoke-testat CLI:n (skriver giltig rad, idempotent re-run).
- Lokalt grönt: typecheck, lint, `test:cov` (rader 83.63% / funk 80.58%), dep-cruiser, knip, jscpd. Tooling-only.

Refs #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)