### PR TITLE
feat(server): self-hosted Microsoft (Entra ID) login via install-servern

### DIFF
--- a/docs/self-hosted-entra.md
+++ b/docs/self-hosted-entra.md
@@ -1,0 +1,119 @@
+# Self-hosted AVA med Microsoft-inloggning (Entra ID), lokalt
+
+Den här guiden tar dig från noll till en körande AVA-backend i Docker på din
+egen dator, där du loggar in med ditt **Microsoft-konto** (Entra ID / Microsoft
+365) via OIDC. Bygger på install-servern (#232) + OIDC-relying-party-modellen
+(ADR 0009).
+
+> AVA är en **OIDC relying party** — den äger aldrig dina lösenord. Microsoft
+> autentiserar; AVA auktoriserar mot en allowlist i din `firma.git`. Din data
+> lämnar aldrig git-repot.
+
+## Förkrav
+
+- Docker Desktop/Engine igång.
+- `bun` installerat (`curl -fsSL https://bun.sh/install | bash`).
+- Ett Microsoft Entra-konto där du kan registrera en app (Azure Portal →
+  *App registrations*).
+
+## Steg 1 — Registrera en app i Entra ID
+
+I [Azure Portal](https://portal.azure.com) → **Microsoft Entra ID** →
+**App registrations** → **New registration**:
+
+1. **Name:** `AVA (self-hosted)`.
+2. **Supported account types:** *Accounts in this organizational directory only*
+   (single-tenant) räcker för en byrå.
+3. **Redirect URI:** plattform **Web**, värde
+   `http://localhost:8080/oauth2/callback`.
+   (`localhost` tillåts av Entra för lokal körning.)
+4. Registrera → notera **Application (client) ID** + **Directory (tenant) ID**.
+5. **Certificates & secrets** → **New client secret** → kopiera *värdet* (visas
+   en gång).
+6. **Token configuration** → lägg till en **optional claim** av typ *ID* →
+   `email` (så att email-claimen finns; annars matchas på UPN).
+
+Din **issuer-URL** blir:
+`https://login.microsoftonline.com/<TENANT_ID>/v2.0`
+
+## Steg 2 — Installera + starta stacken (ett kommando)
+
+```bash
+bun run install:server \
+  --auth oidc \
+  --repo http://localhost:8080/git/firma.git \
+  --work-dir "$HOME/.ava/wc" \
+  --org "$(uuidgen | tr A-Z a-z)" \
+  --oidc-issuer "https://login.microsoftonline.com/<TENANT_ID>/v2.0" \
+  --oidc-client-id "<CLIENT_ID>" \
+  --oidc-client-secret "<CLIENT_SECRET>" \
+  --oidc-redirect "http://localhost:8080/oauth2/callback" \
+  --start
+```
+
+Det här:
+- genererar secrets-valvets master-nyckel (0600, i `~/.ava-secrets/`) + lägger
+  klient-/cookie-secret i det krypterade valvet (aldrig i klartext/git),
+- skriver en icke-hemlig `ava-server.env`,
+- **preflight**-kollar docker + att port 8080 är ledig,
+- bygger static-export:en och startar Docker-stacken med **oauth2-proxy mot
+  Entra** (BYO-IdP-overlayen — ingen Keycloak), och surfar valv-secreten till
+  oauth2-proxy:n.
+
+> Spara `--org`-värdet (UUID:t) — du behöver det i nästa steg och i appens
+> inställningar. (Tappar du valvets master-nyckel blir valvet oåterkalleligt.)
+
+## Steg 3 — Seeda din byrå + dig själv som admin
+
+En färsk `firma.git` är tom. Skapa organisationen + din admin-rad (matchar din
+Microsoft-email) och pusha:
+
+```bash
+git clone http://localhost:8080/git/firma.git "$HOME/.ava/wc"
+bun run bootstrap:admin \
+  --work-dir "$HOME/.ava/wc" \
+  --email "din.epost@byra.se" \
+  --org "<samma-org-uuid-som-ovan>" \
+  --org-name "Din Advokatbyrå" \
+  --commit
+git -C "$HOME/.ava/wc" push
+```
+
+Detta skriver `.ava/organizations/<org>.json`, `.ava/meta.json` och
+`.ava/users/din.epost@byra.se.json` (role=ADMIN) och pushar till stacken.
+Idempotent — kör om utan risk.
+
+## Steg 4 — Logga in
+
+Öppna **http://localhost:8080/ava/**. oauth2-proxy skickar dig till Microsoft;
+logga in med ditt konto. Tillbaka i AVA matchas din email mot allowlisten →
+du resolvas som **ADMIN**. Klart.
+
+> Är din email INTE i allowlisten visar AVA "Inte behörig" — det är meningen
+> (autentisering ≠ auktorisering). Lägg till fler användare genom att skapa dem
+> i appen (Användare) eller köra `bootstrap:admin` igen per epost.
+
+## Felsökning
+
+- **`port 8080 är upptagen`** — stoppa tjänsten som använder porten (preflight
+  avbryter starten innan något halvstartas).
+- **`docker hittades inte`** — starta Docker Desktop.
+- **Microsoft visar "redirect URI mismatch"** — redirect-URI:n i app-
+  registreringen måste vara EXAKT `http://localhost:8080/oauth2/callback`.
+- **oauth2-proxy startar inte: `issuer did not match … got https://login.microsoftonline.com/{tenantid}/v2.0`**
+  — du använder multi-tenant-endpointen (`/common/` eller `/organizations/`),
+  vars discovery-issuer är templad. Använd din **konkreta tenant-issuer**
+  (`https://login.microsoftonline.com/<TENANT_ID>/v2.0`, rekommenderat), eller
+  sätt `OIDC_SKIP_ISSUER_VERIFICATION=true` i miljön före `--start` om du
+  medvetet kör multi-tenant.
+- **"Inte behörig" trots inloggning** — din Microsoft-email matchar ingen
+  allowlist-rad. Kontrollera att `--email` i steg 3 är samma email Entra
+  returnerar (kolla `email`/UPN i token-claims).
+- **Riva stacken:** `bun run install:server --auth oidc --down` (valvet lämnas
+  orört).
+
+## Skarp drift (utöver lokalt)
+
+Bakom riktig HTTPS: sätt `OIDC_COOKIE_SECURE=true` och en publik
+`--oidc-redirect`/redirect-URI. Maskin-/CLI-klienter (git clone, server-runtime)
+använder PAT separat från människo-OIDC. Se [`docs/auth.md`](auth.md) + ADR 0009.

--- a/test/scripts/bootstrap-admin.test.ts
+++ b/test/scripts/bootstrap-admin.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect } from "vitest-compat";
-import { buildAdminUserRow, adminUserGitPath } from "../../tooling/scripts/bootstrap-admin/core";
+import {
+  buildAdminUserRow,
+  adminUserGitPath,
+  buildOrgRow,
+  orgGitPath,
+  metaJsonContent,
+} from "../../tooling/scripts/bootstrap-admin/core";
 import { userSchema } from "@/lib/shared/schemas/user";
+import { organizationSchema } from "@/lib/shared/schemas/organization";
+import { metaJsonSchema } from "@/lib/shared/meta-json";
 import { classifyOidcLogin } from "@/lib/client/backend/oidc-principal";
 import type { AllowlistedUser } from "@/lib/server/auth/oidc-auth-provider";
 
@@ -40,6 +48,25 @@ describe("bootstrap → OIDC-login (stänger chicken-egg-loopen)", () => {
     );
     expect(outcome.kind).toBe("authorized");
     if (outcome.kind === "authorized") expect(outcome.principal.role).toBe("ADMIN");
+  });
+});
+
+describe("buildOrgRow + meta (färsk firma.git-seed)", () => {
+  it("bygger en giltig org-rad (validerar mot organizationSchema)", () => {
+    const org = buildOrgRow({ id: ORG, name: "Advokatbyrå AB", now: new Date("2026-06-13T10:00:00Z") });
+    expect(organizationSchema.safeParse(org).success).toBe(true);
+    expect(org.id).toBe(ORG);
+    expect(org.name).toBe("Advokatbyrå AB");
+  });
+
+  it("orgGitPath pekar på .ava/organizations/<id>.json", () => {
+    expect(orgGitPath(ORG)).toBe(`.ava/organizations/${ORG}.json`);
+  });
+
+  it("metaJsonContent är giltig meta.json med schemaVersion", () => {
+    const parsed = metaJsonSchema.safeParse(JSON.parse(metaJsonContent()));
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data.schemaVersion).toBeGreaterThan(0);
   });
 });
 

--- a/test/scripts/install-server-orchestrate.test.ts
+++ b/test/scripts/install-server-orchestrate.test.ts
@@ -19,7 +19,7 @@ describe("buildStartCommands", () => {
 
   it("oidc: inkluderar overlay-filen", () => {
     const up = buildStartCommands({ oidc: true })[1]!;
-    expect(up).toContain("tooling/docker/docker-compose.oidc.yml");
+    expect(up).toContain("tooling/docker/docker-compose.oidc-byoidp.yml");
     // bägge -f-filerna före up
     expect(up.indexOf("-f")).toBeLessThan(up.indexOf("up"));
   });

--- a/test/scripts/install-server.test.ts
+++ b/test/scripts/install-server.test.ts
@@ -68,7 +68,7 @@ describe("renderServerEnv", () => {
     expect(env).toContain("AVA_SECRETS_FILE=/home/ava/.ava-secrets/vault.enc");
     expect(env).toContain("AVA_SR_REPO_URL=https://git.byra.se/firma.git");
     expect(env).toContain("OAUTH2_PROXY_CLIENT_ID=ava");
-    expect(env).toContain("OIDC_ISSUER_PUBLIC=https://idp/realms/byra");
+    expect(env).toContain("OIDC_ISSUER_URL=https://idp/realms/byra");
     // Hemligheter får ALDRIG hamna i .env (kommentar som nämner nyckeln är ok,
     // men ingen RIKTIG env-rad får sätta master-nyckeln).
     expect(env).not.toContain("s3cr3t");

--- a/tooling/docker/docker-compose.oidc-byoidp.yml
+++ b/tooling/docker/docker-compose.oidc-byoidp.yml
@@ -1,0 +1,64 @@
+# BYO-IdP OIDC-overlay (#224/#222, ADR 0009) — människo-auth via oauth2-proxy
+# mot byråns EGEN OIDC-IdP (Microsoft Entra ID, Google, BankID-broker, …).
+#
+# Till skillnad från docker-compose.oidc.yml (som bundlar Keycloak för e2e) har
+# denna overlay INGEN inbyggd IdP — oauth2-proxy gör vanlig OIDC-discovery mot
+# den publika issuern (nås från proxy:n över internet). Aktivera ovanpå bas:
+#
+#   set -a && . ava-server.env && set +a       # OIDC_ISSUER_URL m.m. (icke-secret)
+#   export OAUTH2_PROXY_CLIENT_SECRET=…         # ur secrets-valvet (#79)
+#   export OAUTH2_PROXY_COOKIE_SECRET=…         # ur secrets-valvet
+#   docker compose -f tooling/docker/docker-compose.yml \
+#                  -f tooling/docker/docker-compose.oidc-byoidp.yml up -d --build
+#
+# `install:server --auth oidc --start` gör allt detta åt dig (surfar valv-
+# secrets → env, väljer denna overlay). Se docs/self-hosted-entra.md.
+
+name: ava
+
+services:
+  # Byt nginx-config till OIDC-varianten (samma absolute_redirect off m.m. som
+  # Keycloak-overlayen — nginx-oidc.conf är IdP-agnostisk).
+  web:
+    volumes:
+      - ../../out:/usr/share/nginx/html:ro
+      - ./nginx-oidc.conf:/etc/nginx/conf.d/default.conf:ro
+      - git_repos:/srv/git
+      - auth_data:/auth-data
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 40s
+    depends_on:
+      - oauth2-proxy
+
+  # ─── oauth2-proxy: OIDC relying party mot byråns IdP (generisk OIDC) ──────
+  oauth2-proxy:
+    image: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
+    restart: unless-stopped
+    environment:
+      OAUTH2_PROXY_HTTP_ADDRESS: "0.0.0.0:4180"
+      # Generisk OIDC-provider → vanlig discovery mot issuern (Entra: v2.0).
+      OAUTH2_PROXY_PROVIDER: "${OIDC_PROVIDER:-oidc}"
+      OAUTH2_PROXY_OIDC_ISSUER_URL: "${OIDC_ISSUER_URL:?OIDC_ISSUER_URL krävs (t.ex. https://login.microsoftonline.com/<tenant>/v2.0)}"
+      # Single-tenant Entra (rekommenderat): konkret tenant-issuer matchar
+      # discovery → lämna false. Multi-tenant (.../common/ el. /organizations/)
+      # ger en TEMPLAD issuer (`{tenantid}`) som ej matchar → sätt true.
+      OAUTH2_PROXY_INSECURE_OIDC_SKIP_ISSUER_VERIFICATION: "${OIDC_SKIP_ISSUER_VERIFICATION:-false}"
+      OAUTH2_PROXY_CLIENT_ID: "${OAUTH2_PROXY_CLIENT_ID:?OAUTH2_PROXY_CLIENT_ID krävs (Entra app-id)}"
+      OAUTH2_PROXY_CLIENT_SECRET: "${OAUTH2_PROXY_CLIENT_SECRET:?OAUTH2_PROXY_CLIENT_SECRET krävs (ur valvet)}"
+      OAUTH2_PROXY_COOKIE_SECRET: "${OAUTH2_PROXY_COOKIE_SECRET:?OAUTH2_PROXY_COOKIE_SECRET krävs (ur valvet)}"
+      OAUTH2_PROXY_REDIRECT_URL: "${OIDC_REDIRECT_URL:-http://localhost:8080/oauth2/callback}"
+      # Entra lägger email i `email`-claim (kräver optional claim) eller upn.
+      OAUTH2_PROXY_OIDC_EMAIL_CLAIM: "${OIDC_EMAIL_CLAIM:-email}"
+      OAUTH2_PROXY_SCOPE: "${OIDC_SCOPE:-openid email profile}"
+      # AVA auktoriserar via allowlist i firma.git → proxy:n släpper alla domäner.
+      OAUTH2_PROXY_EMAIL_DOMAINS: "*"
+      OAUTH2_PROXY_UPSTREAMS: "static://202"
+      OAUTH2_PROXY_REVERSE_PROXY: "true"
+      OAUTH2_PROXY_SET_XAUTHREQUEST: "true"
+      OAUTH2_PROXY_SKIP_PROVIDER_BUTTON: "true"
+      # localhost-dev → http-cookie OK. I skarp drift bakom HTTPS: sätt true.
+      OAUTH2_PROXY_COOKIE_SECURE: "${OIDC_COOKIE_SECURE:-false}"

--- a/tooling/scripts/bootstrap-admin.ts
+++ b/tooling/scripts/bootstrap-admin.ts
@@ -15,7 +15,13 @@
  */
 
 import { join } from "node:path";
-import { buildAdminUserRow, adminUserGitPath } from "./bootstrap-admin/core";
+import {
+  buildAdminUserRow,
+  adminUserGitPath,
+  buildOrgRow,
+  orgGitPath,
+  metaJsonContent,
+} from "./bootstrap-admin/core";
 
 function flag(argv: string[], name: string): string | undefined {
   const i = argv.indexOf(`--${name}`);
@@ -37,12 +43,53 @@ async function alreadyAdmin(path: string): Promise<boolean> {
   }
 }
 
-async function gitCommit(workDir: string, relPath: string, email: string): Promise<void> {
+async function gitCommit(workDir: string, email: string): Promise<void> {
   const { spawnSync } = await import("node:child_process");
   const run = (args: string[]) => spawnSync("git", ["-C", workDir, ...args], { stdio: "inherit" });
-  run(["add", relPath]);
-  run(["commit", "-m", `feat(auth): bootstrap admin ${email} i allowlisten (#224)`]);
+  run(["add", "-A"]);
+  run(["commit", "-m", `feat(auth): bootstrap admin ${email} i firma.git (#224)`]);
   log("committat — pusha med `git push` (eller låt server-runtime-peern göra det).");
+}
+
+async function exists(path: string): Promise<boolean> {
+  const { access } = await import("node:fs/promises");
+  return access(path).then(() => true).catch(() => false);
+}
+
+/** Seeda org-roten + meta.json om de saknas (färsk firma.git). Returnerar true om något skrevs. */
+async function seedOrgAndMeta(workDir: string, orgId: string, orgName: string): Promise<boolean> {
+  const { mkdir, writeFile } = await import("node:fs/promises");
+  await mkdir(join(workDir, ".ava", "organizations"), { recursive: true });
+  let wrote = false;
+
+  const orgPath = join(workDir, orgGitPath(orgId));
+  if (!(await exists(orgPath))) {
+    await writeFile(orgPath, JSON.stringify(buildOrgRow({ id: orgId, name: orgName }), null, 2) + "\n");
+    log(`org-rad skriven: ${orgGitPath(orgId)} (${orgName})`);
+    wrote = true;
+  }
+  const metaPath = join(workDir, ".ava", "meta.json");
+  if (!(await exists(metaPath))) {
+    await writeFile(metaPath, metaJsonContent());
+    log("meta.json skriven (.ava/meta.json)");
+    wrote = true;
+  }
+  return wrote;
+}
+
+/** Seeda admin-allowlist-raden om den saknas. Returnerar true om den skrevs. */
+async function seedAdmin(workDir: string, email: string, org: string, name: string | undefined): Promise<boolean> {
+  const fullPath = join(workDir, adminUserGitPath(email));
+  if (await alreadyAdmin(fullPath)) {
+    log(`${email} är redan ADMIN — admin-raden lämnas orörd.`);
+    return false;
+  }
+  const { mkdir, writeFile } = await import("node:fs/promises");
+  const row = buildAdminUserRow({ email, organizationId: org, ...(name ? { name } : {}) });
+  await mkdir(join(workDir, ".ava", "users"), { recursive: true });
+  await writeFile(fullPath, JSON.stringify(row, null, 2) + "\n");
+  log(`admin-rad skriven: ${adminUserGitPath(email)} (role=ADMIN, id=${row.id})`);
+  return true;
 }
 
 async function main(): Promise<void> {
@@ -56,21 +103,16 @@ async function main(): Promise<void> {
     return;
   }
 
-  const relPath = adminUserGitPath(email);
-  const fullPath = join(workDir, relPath);
-  if (await alreadyAdmin(fullPath)) {
-    log(`${email} är redan ADMIN i allowlisten — inget att göra.`);
+  // Färsk firma.git: seeda org + meta så appen inte kraschar (--org-name).
+  const orgName = flag(argv, "org-name");
+  const seededOrg = orgName ? await seedOrgAndMeta(workDir, org, orgName) : false;
+  const seededAdmin = await seedAdmin(workDir, email, org, flag(argv, "name"));
+
+  if (!seededOrg && !seededAdmin) {
+    log("inget att göra — firma.git redan bootstrappad.");
     return;
   }
-
-  const nameFlag = flag(argv, "name");
-  const row = buildAdminUserRow({ email, organizationId: org, ...(nameFlag ? { name: nameFlag } : {}) });
-  const { mkdir, writeFile } = await import("node:fs/promises");
-  await mkdir(join(workDir, ".ava", "users"), { recursive: true });
-  await writeFile(fullPath, JSON.stringify(row, null, 2) + "\n");
-  log(`admin-rad skriven: ${relPath} (role=ADMIN, id=${row.id})`);
-
-  if (argv.includes("--commit")) await gitCommit(workDir, relPath, email);
+  if (argv.includes("--commit")) await gitCommit(workDir, email);
   else log("kör om med --commit för att committa, eller commita/pusha själv.");
 }
 

--- a/tooling/scripts/bootstrap-admin/core.ts
+++ b/tooling/scripts/bootstrap-admin/core.ts
@@ -13,6 +13,8 @@
 
 import { uuidv5, AVA_NAMESPACE } from "@/lib/shared/uuid-derive";
 import { userSchema, type User } from "@/lib/shared/schemas/user";
+import { organizationSchema, type Organization } from "@/lib/shared/schemas/organization";
+import { CURRENT_SCHEMA_VERSION } from "@/lib/shared/schema-version";
 
 export interface AdminBootstrapInput {
   email: string;
@@ -43,4 +45,28 @@ export function buildAdminUserRow(input: AdminBootstrapInput): User {
 /** Relativ git-path till allowlist-raden (samma som fsa-write-back/#223). */
 export function adminUserGitPath(email: string): string {
   return `.ava/users/${email.trim().toLowerCase()}.json`;
+}
+
+/**
+ * Bygg + validera org-roten för en färsk firma.git. Utan en organisation
+ * kraschar appen (organization.getSettings → findUniqueOrThrow). Lagras i
+ * `.ava/organizations/<id>.json`.
+ */
+export function buildOrgRow(input: { id: string; name: string; now?: Date }): Organization {
+  const now = (input.now ?? new Date()).toISOString();
+  return organizationSchema.parse({
+    id: input.id,
+    name: input.name,
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+export function orgGitPath(orgId: string): string {
+  return `.ava/organizations/${orgId}.json`;
+}
+
+/** `.ava/meta.json`-innehåll (schemaVersion) för en färsk firma.git. */
+export function metaJsonContent(): string {
+  return JSON.stringify({ schemaVersion: CURRENT_SCHEMA_VERSION }, null, 2) + "\n";
 }

--- a/tooling/scripts/install-server.ts
+++ b/tooling/scripts/install-server.ts
@@ -62,6 +62,21 @@ async function runCommands(cmds: string[][], env: NodeJS.ProcessEnv): Promise<vo
   }
 }
 
+/** Bygg env för OIDC-overlayen: issuer/client-id/redirect (config) + secrets (valv). */
+async function buildOidcStartEnv(
+  cfg: ServerInstallConfig,
+  vault: EncryptedFileVault,
+): Promise<Record<string, string>> {
+  if (cfg.authMode !== "oidc" || !cfg.oidc) return {};
+  return {
+    OIDC_ISSUER_URL: cfg.oidc.issuerUrl,
+    OAUTH2_PROXY_CLIENT_ID: cfg.oidc.clientId,
+    OIDC_REDIRECT_URL: cfg.oidc.redirectUrl,
+    OAUTH2_PROXY_CLIENT_SECRET: (await vault.get(VAULT_KEYS.oidcClientSecret)) ?? "",
+    OAUTH2_PROXY_COOKIE_SECRET: (await vault.get(VAULT_KEYS.oidcCookieSecret)) ?? "",
+  };
+}
+
 const WEB_PORT = 8080;
 
 /** Preflight: docker + web-port. Returnerar false (+ loggar) vid problem. */
@@ -74,13 +89,16 @@ async function preflightOk(): Promise<boolean> {
 }
 
 /** Bygg + starta stacken och skriv ut den bootstrappade admin-token:n. */
-async function startStack(oidc: boolean): Promise<void> {
+async function startStack(oidc: boolean, extraEnv: Record<string, string> = {}): Promise<void> {
   const { spawnSync } = await import("node:child_process");
-  await runCommands(buildStartCommands({ oidc }), { ...process.env, DEMO_BASE_PATH: "/ava" });
+  const env = { ...process.env, DEMO_BASE_PATH: "/ava", ...extraEnv };
+  await runCommands(buildStartCommands({ oidc }), env);
   const [bin, ...args] = logsCommand(oidc);
-  const logs = spawnSync(bin!, args, { encoding: "utf8" }).stdout ?? "";
+  const logs = spawnSync(bin!, args, { encoding: "utf8", env }).stdout ?? "";
   const token = extractAdminToken(logs);
-  log(token ? `admin-token (engångs): ${token} — lägg till användare med add-user.sh` : "admin-token ej funnen i loggen ännu (kolla `docker compose logs web`)");
+  if (!oidc) {
+    log(token ? `admin-token (engångs): ${token} — lägg till användare med add-user.sh` : "admin-token ej funnen i loggen ännu (kolla `docker compose logs web`)");
+  }
 }
 
 const ANSWER_KEYS = [
@@ -198,8 +216,15 @@ async function runInstall(argv: string[], paths: InstallPaths): Promise<boolean>
     if (!(await preflightOk())) return false;
     process.env.AVA_SECRETS_KEY = masterKey;
     process.env.AVA_SECRETS_FILE = paths.secretsFile;
-    await startStack(cfg.authMode === "oidc");
-    log("backenden uppe. Lägg till användare med tooling/scripts/add-user.sh.");
+    const oidc = cfg.authMode === "oidc";
+    await startStack(oidc, await buildOidcStartEnv(cfg, vault));
+    if (oidc) {
+      log("backenden uppe (OIDC). Seeda första admin + org i firma.git:");
+      log(`  bun run bootstrap:admin --work-dir <klon-av-firma.git> --email <din-epost> --org ${cfg.organizationId} --org-name "<Byrå>" --commit`);
+      log("Öppna sedan http://localhost:8080/ava/ och logga in via din IdP.");
+    } else {
+      log("backenden uppe. Lägg till användare med tooling/scripts/add-user.sh.");
+    }
     return true;
   }
   printNextSteps(cfg, paths.masterKeyFile, paths.envFile);

--- a/tooling/scripts/install-server/core.ts
+++ b/tooling/scripts/install-server/core.ts
@@ -83,7 +83,7 @@ export function renderServerEnv(cfg: ServerInstallConfig): string {
   if (cfg.authMode === "oidc" && cfg.oidc) {
     lines.push(
       `OAUTH2_PROXY_CLIENT_ID=${cfg.oidc.clientId}`,
-      `OIDC_ISSUER_PUBLIC=${cfg.oidc.issuerUrl}`,
+      `OIDC_ISSUER_URL=${cfg.oidc.issuerUrl}`,
       `OIDC_REDIRECT_URL=${cfg.oidc.redirectUrl}`,
     );
   }

--- a/tooling/scripts/install-server/orchestrate.ts
+++ b/tooling/scripts/install-server/orchestrate.ts
@@ -5,7 +5,7 @@
  */
 
 const DEMO_COMPOSE = "tooling/docker/docker-compose.yml";
-const OIDC_OVERLAY = "tooling/docker/docker-compose.oidc.yml";
+const OIDC_OVERLAY = "tooling/docker/docker-compose.oidc-byoidp.yml";
 /** Web-containern printar `Admin-token:      <40 tecken>` EN gång vid bootstrap. */
 const ADMIN_TOKEN_RE = /Admin-token:\s+([A-Za-z0-9]{40})/;
 const WAIT_TIMEOUT_S = "180";


### PR DESCRIPTION
Fyller luckorna så att du kan **installera AVA-backenden lokalt i Docker via installationsprogrammet och logga in med ditt Microsoft-konto** (uppföljning #224/#232, ADR 0009).

## Vad
- **`docker-compose.oidc-byoidp.yml`** — BYO-IdP-overlay: oauth2-proxy (generisk OIDC) mot byråns **egen** IdP (Entra ID/Google/…) via vanlig discovery, **ingen bundlad Keycloak** (den e2e-overlayen är kvar separat). Env-driven: issuer, client-id/secret, redirect, email-claim, scope. `OIDC_SKIP_ISSUER_VERIFICATION` för multi-tenant (`/common/`) — single-tenant matchar utan.
- **`install-server`** — `--auth oidc --start` använder nu byoidp-overlayen och **surfar klient-/cookie-secret ur secrets-valvet → oauth2-proxy-env** (`buildOidcStartEnv`). Env-nyckeln `OIDC_ISSUER_URL` (matchar overlayen).
- **`bootstrap-admin`** — seedar nu även **org-roten + `.ava/meta.json`** (`--org-name`) så en färsk `firma.git` inte kraschar appen (organization.getSettings) — plus admin-allowlist-raden från #260.
- **`docs/self-hosted-entra.md`** — komplett runbook: Azure app-registrering → `install:server` → `bootstrap:admin` → logga in, med felsökning (inkl. issuer-mismatch-gotchan).

## Verifierat lokalt mot Docker
- Stacken kommer **healthy**; oauth2-proxy gör OIDC-discovery mot Microsoft.
- `/ava/` (utan session) → **302 → /oauth2/start → 302 → `https://login.microsoftonline.com/.../oauth2/v2.0/authorize`** med rätt `redirect_uri` (`http://localhost:8080/oauth2/callback`) + `scope=openid email profile`.
- Upptäckte + dokumenterade Entra-gotchan: `/common/`-endpointens discovery-issuer är templad (`{tenantid}`) → använd konkret tenant-issuer (single-tenant, rekommenderat) eller `OIDC_SKIP_ISSUER_VERIFICATION=true`.
- Token-redemption + post-login allowlist→ADMIN-resolution (#252) sker på din **riktiga tenant** (kräver din app-registrering + ditt konto).

## Verifierat grönt
typecheck, lint, `test:cov` (rader 83.63% / funk 80.58%), dep-cruiser, knip, jscpd. Tooling/docker/docs — rör ej app-bundeln.

## Din väg till inloggning (sammanfattning, se docs/self-hosted-entra.md)
1. Registrera en app i Entra (redirect `http://localhost:8080/oauth2/callback`, optional `email`-claim).
2. `bun run install:server --auth oidc --oidc-issuer https://login.microsoftonline.com/<TENANT>/v2.0 --oidc-client-id <id> --oidc-client-secret <secret> --oidc-redirect http://localhost:8080/oauth2/callback --repo http://localhost:8080/git/firma.git --work-dir ~/.ava/wc --org <uuid> --start`
3. `bun run bootstrap:admin --work-dir <klon> --email <din-microsoft-epost> --org <uuid> --org-name "Byrå" --commit && git push`
4. Öppna http://localhost:8080/ava/ → logga in med Microsoft.

Refs #224 #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)