### PR TITLE
feat(fortnox): läs konto-mappningen ur byråns org-inställning (#217)

### DIFF
--- a/src/bin/server-runtime.ts
+++ b/src/bin/server-runtime.ts
@@ -62,7 +62,7 @@ async function main(): Promise<void> {
   // Fortnox-connector (#82): bara när byrån anslutit Fortnox (valv + tokens).
   // composeJobs kör båda i samma cykel; no-empty-commit-grinden (#80) ser till
   // att tomma tick:ar inte pushar.
-  const fortnox = await buildFortnoxJob({ workDir: config.workDir });
+  const fortnox = await buildFortnoxJob();
   // Bankfil-avprickning (#245): bara när AVA_CAMT_INBOX pekar på en mapp med
   // camt-filer; annars null → ingen avprickning (riskfritt).
   const payments = buildBankFilePaymentsJob({ log });

--- a/src/components/settings/ledger-accounts-section.tsx
+++ b/src/components/settings/ledger-accounts-section.tsx
@@ -117,7 +117,9 @@ function LedgerAccountForm({ initial }: { initial: LedgerAccountMap }) {
     <div className="bg-white border border-gray-200 rounded-lg p-5 mb-5">
       <h2 className="font-semibold text-gray-900 mb-1">Konto-mappning (bokföringsexport)</h2>
       <p className="text-xs text-gray-500 mb-4">
-        BAS-konton som SIE-exporten bokför mot. Förifyllt med standard för advokatbyrå.
+        BAS-konton som bokföringen bokför mot — driver både SIE-exporten och
+        Fortnox-connectorn. Förifyllt med standard för advokatbyrå. Saknas
+        mappningen vägrar Fortnox-connectorn att boka (completeness-grind).
       </p>
 
       <div className="flex items-center gap-3 py-1.5 mb-2">

--- a/src/lib/server/integrations/fortnox/invoice-job.ts
+++ b/src/lib/server/integrations/fortnox/invoice-job.ts
@@ -15,6 +15,7 @@
 import { buildSemanticVoucher, type SemanticVoucherInput } from "@/lib/shared/accounting/semantic-voucher";
 import { DEFAULT_VAT_RATE, type VatRate } from "@/lib/shared/vat";
 import type { InvoiceStatus } from "@/lib/shared/schemas/enums";
+import type { LedgerAccountMap } from "@/lib/shared/accounting/account-map";
 import type { PeerJob } from "../../local-first/peer-loop";
 import type { LedgerConnector } from "../ledger/port";
 
@@ -34,15 +35,20 @@ export interface FortnoxJobCaller {
     list: (input: Record<string, never>) => Promise<BookableInvoice[]>;
     markFortnoxBooked: (input: { invoiceId: string; fortnoxId: string }) => Promise<unknown>;
   };
+  /** Byråns org-inställningar — konto-mappningen läses härifrån (#217/#249). */
+  organization: {
+    getSettings: () => Promise<{ ledgerAccountMap?: LedgerAccountMap | null }>;
+  };
 }
 
 export interface FortnoxInvoiceJobDeps {
   /**
-   * Bygg ledger-connectorn för den aktuella cykeln (läser färsk konto-mappning
-   * ur firma.git, #217). `null` = ej konfigurerad → boka inget (completeness-
-   * gate). Drivern jobbar mot PORTEN, inte mot Fortnox direkt (ADR 0011).
+   * Bygg ledger-connectorn för den aktuella cykeln. Får callern → läser färsk
+   * konto-mappning ur byråns org-inställning (`ledgerAccountMap`, #217/#249).
+   * `null` = ej konfigurerad → boka inget (completeness-gate). Drivern jobbar
+   * mot PORTEN, inte mot Fortnox direkt (ADR 0011).
    */
-  loadConnector: () => Promise<LedgerConnector | null>;
+  loadConnector: (caller: FortnoxJobCaller) => Promise<LedgerConnector | null>;
   vatRate?: VatRate;
   bookableStatuses?: readonly InvoiceStatus[];
   log?: (msg: string) => void;
@@ -78,12 +84,13 @@ type PushCapableConnector = LedgerConnector & Required<Pick<LedgerConnector, "pu
  * connectorn saknas (ej konfigurerad) eller inte kan boka verifikat.
  */
 async function resolvePushConnector(
+  caller: FortnoxJobCaller,
   deps: FortnoxInvoiceJobDeps,
   log: (msg: string) => void,
 ): Promise<PushCapableConnector | null> {
-  const connector = await deps.loadConnector();
+  const connector = await deps.loadConnector(caller);
   if (!connector) {
-    log("Fortnox: ingen connector/konto-mappning (settings/fortnox-account-map.json) — hoppar över");
+    log("Fortnox: ingen konto-mappning konfigurerad (ledgerAccountMap i /settings) — hoppar över");
     return null;
   }
   if (!connector.capabilities().pushVoucher || !connector.pushVoucher) {
@@ -128,7 +135,7 @@ export async function bookUnsyncedInvoices(
   deps: FortnoxInvoiceJobDeps,
 ): Promise<BookResult> {
   const log = deps.log ?? (() => {});
-  const connector = await resolvePushConnector(deps, log);
+  const connector = await resolvePushConnector(caller, deps, log);
   if (!connector) return { booked: 0, failed: 0, skipped: 0 };
 
   const bookable = new Set<InvoiceStatus>(deps.bookableStatuses ?? DEFAULT_BOOKABLE_STATUSES);

--- a/src/lib/server/integrations/fortnox/runtime.ts
+++ b/src/lib/server/integrations/fortnox/runtime.ts
@@ -3,7 +3,8 @@
  *
  * Bygger ett `PeerJob` ur:
  *   - secrets-valvet (#79): client_id/secret + de roterande OAuth-tokens,
- *   - firma.git: konto-mappningen (`settings/fortnox-account-map.json`, #217).
+ *   - firma.git: konto-mappningen, deriverad ur byråns org-inställning
+ *     `ledgerAccountMap` (#217/#249) som admin redigerar i /settings.
  *
  * Returnerar `null` (→ loopen stannar i sync-läge) när Fortnox inte är
  * konfigurerat: inget valv, inga credentials, eller inte auktoriserad än.
@@ -11,43 +12,33 @@
  * när en byrå faktiskt anslutit Fortnox.
  */
 
-import { join } from "node:path";
-
 import { createVaultFromEnv, type SecretsVault } from "../../secrets/vault";
 import type { PeerJob } from "../../local-first/peer-loop";
 import type { LedgerConnector } from "../ledger/port";
 import { FortnoxClient } from "./client";
 import { FortnoxLedgerConnector } from "./connector";
-import { makeFortnoxInvoiceJob } from "./invoice-job";
-import {
-  fortnoxConfigSchema,
-  fortnoxKontoMappningSchema,
-  type FortnoxConfig,
-  type FortnoxKontoMappning,
-} from "./schema";
+import { makeFortnoxInvoiceJob, type FortnoxJobCaller } from "./invoice-job";
+import { fortnoxConfigSchema, fortnoxMappingFromLedgerMap, type FortnoxConfig } from "./schema";
 import { VaultFortnoxTokenStore } from "./token-store";
 
-/** Sökväg (relativt working-copy:n) till byråns konto-mappning. */
-export const KONTO_MAPPNING_PATH = "settings/fortnox-account-map.json";
-
 export interface BuildFortnoxJobOpts {
-  /** Server-runtime:ns working-copy (firma.git-klonen). */
-  workDir: string;
   env?: NodeJS.ProcessEnv;
   log?: (msg: string) => void;
 }
 
-/** Läs + strikt-parsa konto-mappningen ur firma.git. null om filen saknas. */
-export async function loadKontoMappning(workDir: string): Promise<FortnoxKontoMappning | null> {
-  const { readFile } = await import("node:fs/promises");
-  let raw: string;
-  try {
-    raw = await readFile(join(workDir, KONTO_MAPPNING_PATH), "utf8");
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
-    throw err;
-  }
-  return fortnoxKontoMappningSchema.parse(JSON.parse(raw));
+/**
+ * Bygg cykelns `loadConnector`: läs byråns `ledgerAccountMap` via callern
+ * (samma org-projektion som /settings skriver), derivera Fortnox-mappningen
+ * och linda connectorn runt klienten. `null` när mappningen saknas →
+ * completeness-gate (drivern bokför inget).
+ */
+export function makeLoadConnector(client: FortnoxClient) {
+  return async (caller: FortnoxJobCaller): Promise<LedgerConnector | null> => {
+    const settings = await caller.organization.getSettings();
+    const mapping = fortnoxMappingFromLedgerMap(settings.ledgerAccountMap);
+    if (!mapping) return null;
+    return new FortnoxLedgerConnector({ client, mapping });
+  };
 }
 
 /** Bygg FortnoxConfig ur env + valv-credentials (overridebar bas-URL för sandbox). */
@@ -74,7 +65,7 @@ function vaultIfConfigured(env: NodeJS.ProcessEnv): SecretsVault | null {
   return createVaultFromEnv(env);
 }
 
-export async function buildFortnoxJob(opts: BuildFortnoxJobOpts): Promise<PeerJob | null> {
+export async function buildFortnoxJob(opts: BuildFortnoxJobOpts = {}): Promise<PeerJob | null> {
   const env = opts.env ?? process.env;
   const log = opts.log ?? ((msg: string) => console.log(`[fortnox] ${msg}`));
 
@@ -99,14 +90,7 @@ export async function buildFortnoxJob(opts: BuildFortnoxJobOpts): Promise<PeerJo
 
   const client = new FortnoxClient(fortnoxConfigFromEnv(env, clientId, clientSecret), store);
   log("connector aktiv — bokför nya fakturor som verifikat");
-  return makeFortnoxInvoiceJob({
-    // Per cykel: läs färsk konto-mappning ur git och bygg connectorn bakom
-    // porten. null när mappningen saknas → drivern hoppar över (completeness).
-    loadConnector: async (): Promise<LedgerConnector | null> => {
-      const mapping = await loadKontoMappning(opts.workDir);
-      if (!mapping) return null;
-      return new FortnoxLedgerConnector({ client, mapping });
-    },
-    log,
-  });
+  // Per cykel: derivera färsk konto-mappning ur byråns ledgerAccountMap (via
+  // callern) och bygg connectorn bakom porten. null → completeness-gate.
+  return makeFortnoxInvoiceJob({ loadConnector: makeLoadConnector(client), log });
 }

--- a/src/lib/server/integrations/fortnox/schema.ts
+++ b/src/lib/server/integrations/fortnox/schema.ts
@@ -12,6 +12,8 @@
 
 import { z } from "zod";
 
+import type { LedgerAccountMap } from "@/lib/shared/accounting/account-map";
+
 // ─── OAuth ──────────────────────────────────────────────────────────────
 
 /** Fortnox-endpoints. Bas-URL:er är overridebara för test/sandbox. */
@@ -60,6 +62,12 @@ export type FortnoxStoredTokens = z.infer<typeof fortnoxStoredTokensSchema>;
  * Per-byrå kontoplan-mappning. VÄRDENA är ett bokföringsbeslut byrån gör —
  * connectorn levereras utan defaults (tomt = connectorn vägrar köra och ber
  * om konfiguration). BAS-kontona nedan är bara typ-dokumentation.
+ *
+ * Detta är connector-LOKAL form (bara kontonummer). Sanningskällan är byråns
+ * org-inställning `ledgerAccountMap` (#249, redigeras i /settings); connectorn
+ * deriverar denna delmängd via `fortnoxMappingFromLedgerMap` (#217). Roll→konto-
+ * översättning är connector-specifik (ADR 0011) — därför lever den här, inte i
+ * shared (som aldrig får bero på `integrations/*`).
  */
 export const fortnoxKontoMappningSchema = z.object({
   /** Verifikatserie i Fortnox (t.ex. "A" eller en kundfaktura-serie). */
@@ -74,6 +82,27 @@ export const fortnoxKontoMappningSchema = z.object({
   intaktUtlagg: z.string().min(1).optional(),
 });
 export type FortnoxKontoMappning = z.infer<typeof fortnoxKontoMappningSchema>;
+
+/**
+ * Derivera Fortnox-konto-mappningen ur byråns `ledgerAccountMap` (#217/#249).
+ * Plockar kontoNUMREN (Fortnox vill inte ha namnen) + verifikatserien.
+ *
+ * `null` när byrån inte konfigurerat någon mappning → connectorn vägrar köra
+ * (completeness-gate). Är `ledgerAccountMap` satt är den per schema komplett
+ * (alla obligatoriska roller finns), så ingen ytterligare lucka-koll behövs.
+ */
+export function fortnoxMappingFromLedgerMap(
+  map: LedgerAccountMap | null | undefined,
+): FortnoxKontoMappning | null {
+  if (!map) return null;
+  return fortnoxKontoMappningSchema.parse({
+    voucherSeries: map.voucherSeries,
+    kundfordran: map.kundfordran.number,
+    intaktArvode: map.intaktArvode.number,
+    momsUtgaende: map.momsUtgaende.number,
+    ...(map.intaktUtlagg ? { intaktUtlagg: map.intaktUtlagg.number } : {}),
+  });
+}
 
 // ─── Voucher (verifikat) ────────────────────────────────────────────────
 

--- a/test/unit/server/integrations/fortnox/invoice-job.test.ts
+++ b/test/unit/server/integrations/fortnox/invoice-job.test.ts
@@ -39,6 +39,9 @@ function makeCaller(invoices: BookableInvoice[]) {
         return {};
       },
     },
+    // Konto-mappningen deriveras härifrån i prod; dessa tester injicerar dock
+    // connectorn direkt via loadConnector, så getSettings träffas inte.
+    organization: { getSettings: async () => ({ ledgerAccountMap: null }) },
   };
   return { caller, booked };
 }

--- a/test/unit/server/integrations/fortnox/runtime.test.ts
+++ b/test/unit/server/integrations/fortnox/runtime.test.ts
@@ -1,23 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest-compat";
-import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { randomBytes } from "node:crypto";
-import {
-  buildFortnoxJob,
-  loadKontoMappning,
-  KONTO_MAPPNING_PATH,
-} from "@/lib/server/integrations/fortnox/runtime";
+import { buildFortnoxJob, makeLoadConnector } from "@/lib/server/integrations/fortnox/runtime";
 import { createVaultFromEnv } from "@/lib/server/secrets/vault";
 import { VaultFortnoxTokenStore } from "@/lib/server/integrations/fortnox/token-store";
-import type { FortnoxKontoMappning } from "@/lib/server/integrations/fortnox/schema";
-
-const MAPPING: FortnoxKontoMappning = {
-  voucherSeries: "A",
-  kundfordran: "1510",
-  intaktArvode: "3000",
-  momsUtgaende: "2611",
-};
+import type { FortnoxClient } from "@/lib/server/integrations/fortnox/client";
+import type { FortnoxJobCaller } from "@/lib/server/integrations/fortnox/invoice-job";
+import { DEFAULT_LEDGER_ACCOUNT_MAP, type LedgerAccountMap } from "@/lib/shared/accounting/account-map";
 
 let dir: string;
 const silent = () => {};
@@ -37,34 +28,43 @@ function vaultEnv(): NodeJS.ProcessEnv {
   } as NodeJS.ProcessEnv;
 }
 
-async function writeMapping(value: unknown): Promise<void> {
-  await mkdir(join(dir, "settings"), { recursive: true });
-  await writeFile(join(dir, KONTO_MAPPNING_PATH), JSON.stringify(value), "utf8");
+/** Fake-caller vars org.getSettings ger angiven (eller ingen) ledger-map. */
+function callerWithMap(map: LedgerAccountMap | null): FortnoxJobCaller {
+  return {
+    invoice: {
+      list: async () => [],
+      markFortnoxBooked: async () => ({}),
+    },
+    organization: {
+      getSettings: async () => ({ ledgerAccountMap: map }),
+    },
+  };
 }
 
-describe("loadKontoMappning", () => {
-  it("läser + strikt-parsar mappningen ur firma.git", async () => {
-    await writeMapping(MAPPING);
-    expect(await loadKontoMappning(dir)).toEqual(MAPPING);
+// FortnoxLedgerConnector lagrar bara klienten; loadConnector anropar den inte.
+const fakeClient = {} as unknown as FortnoxClient;
+
+describe("makeLoadConnector", () => {
+  it("deriverar connectorn ur byråns ledgerAccountMap (via callern)", async () => {
+    const loadConnector = makeLoadConnector(fakeClient);
+    const connector = await loadConnector(callerWithMap(DEFAULT_LEDGER_ACCOUNT_MAP));
+    expect(connector).not.toBeNull();
+    expect(connector?.capabilities().pushVoucher).toBe(true);
   });
 
-  it("saknad fil → null", async () => {
-    expect(await loadKontoMappning(dir)).toBeNull();
-  });
-
-  it("ogiltig mappning → kastar (strikt parsning)", async () => {
-    await writeMapping({ voucherSeries: "A" }); // saknar obligatoriska konton
-    await expect(loadKontoMappning(dir)).rejects.toThrow();
+  it("ingen ledgerAccountMap → null (completeness-gate)", async () => {
+    const loadConnector = makeLoadConnector(fakeClient);
+    expect(await loadConnector(callerWithMap(null))).toBeNull();
   });
 });
 
 describe("buildFortnoxJob", () => {
   it("valv ej konfigurerat (env saknas) → null", async () => {
-    expect(await buildFortnoxJob({ workDir: dir, env: {}, log: silent })).toBeNull();
+    expect(await buildFortnoxJob({ env: {}, log: silent })).toBeNull();
   });
 
   it("valv men inga credentials → null", async () => {
-    const job = await buildFortnoxJob({ workDir: dir, env: vaultEnv(), log: silent });
+    const job = await buildFortnoxJob({ env: vaultEnv(), log: silent });
     expect(job).toBeNull();
   });
 
@@ -74,7 +74,7 @@ describe("buildFortnoxJob", () => {
     await vault.set("fortnox.client_id", "cid");
     await vault.set("fortnox.client_secret", "secret");
 
-    const job = await buildFortnoxJob({ workDir: dir, env, log: silent });
+    const job = await buildFortnoxJob({ env, log: silent });
     expect(job).toBeNull();
   });
 
@@ -89,7 +89,7 @@ describe("buildFortnoxJob", () => {
       accessTokenExpiresAt: Date.now() + 600_000,
     });
 
-    const job = await buildFortnoxJob({ workDir: dir, env, log: silent });
+    const job = await buildFortnoxJob({ env, log: silent });
     expect(job).not.toBeNull();
     expect(job?.message).toMatch(/fortnox/i);
     expect(typeof job?.act).toBe("function");

--- a/test/unit/server/integrations/fortnox/schema.test.ts
+++ b/test/unit/server/integrations/fortnox/schema.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest-compat";
+import { fortnoxMappingFromLedgerMap } from "@/lib/server/integrations/fortnox/schema";
+import { DEFAULT_LEDGER_ACCOUNT_MAP, type LedgerAccountMap } from "@/lib/shared/accounting/account-map";
+
+describe("fortnoxMappingFromLedgerMap", () => {
+  it("deriverar kontoNUMREN + verifikatserien ur byråns ledger-map", () => {
+    expect(fortnoxMappingFromLedgerMap(DEFAULT_LEDGER_ACCOUNT_MAP)).toEqual({
+      voucherSeries: "A",
+      kundfordran: "1510",
+      intaktArvode: "3041",
+      momsUtgaende: "2611",
+      intaktUtlagg: "3590",
+    });
+  });
+
+  it("utelämnar intaktUtlagg när byrån inte mappat det (valfritt)", () => {
+    const map: LedgerAccountMap = {
+      voucherSeries: "B",
+      kundfordran: { number: "1510", name: "Kundfordringar" },
+      intaktArvode: { number: "3000", name: "Arvode" },
+      momsUtgaende: { number: "2611", name: "Utgående moms" },
+    };
+    const result = fortnoxMappingFromLedgerMap(map);
+    expect(result).toEqual({
+      voucherSeries: "B",
+      kundfordran: "1510",
+      intaktArvode: "3000",
+      momsUtgaende: "2611",
+    });
+    expect(result).not.toHaveProperty("intaktUtlagg");
+  });
+
+  it("null/undefined ledger-map → null (completeness-gate)", () => {
+    expect(fortnoxMappingFromLedgerMap(null)).toBeNull();
+    expect(fortnoxMappingFromLedgerMap(undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Vad

Fortnox-connectorn läste tidigare en **egen** `settings/fortnox-account-map.json` ur firma.git, parallellt med #249:s admin-redigerbara `ledgerAccountMap` (org-inställning i `/settings`, **samma roller**). Det var duplicering — och #217:s krav ("mappningen ska vara en organisations-inställning, redigerbar av admin") var redan delvis uppfyllt av #249.

Den här PR:en **unifierar** dem: connectorn deriverar nu sin konto-mappning ur byråns `ledgerAccountMap` via tRPC-callern (`organization.getSettings`) — samma källa som `/settings` skriver.

## Hur

- Ny ren funktion `fortnoxMappingFromLedgerMap(ledgerMap)` i `fortnox/schema.ts` — plockar kontonumren + verifikatserien ur den rikare ledger-mappen (Fortnox vill inte ha kontonamnen). `null` när byrån inte konfigurerat → completeness-gate.
- `loadConnector` tar nu callern och läser `ledgerAccountMap` per cykel (`makeLoadConnector`).
- Pensionerar `loadKontoMappning` / `KONTO_MAPPNING_PATH` / den separata JSON-filen. `buildFortnoxJob` behöver inte längre `workDir`.
- `LedgerAccountsSection` (#249) blir UI:t — texten förtydligad: mappningen driver **både** SIE-export och Fortnox; saknas den vägrar Fortnox boka.

## Arkitektur (ADR 0011)

Roll→konto-översättning förblir **connector-lokal**: derive-funktionen bor i `integrations/fortnox`, importerar `LedgerAccountMap` från shared. `shared` beror aldrig på `integrations/*` — verifierat av dep-cruiser (grön, 0 violations).

## Acceptanskriterier (#217)

- [x] Mappningen läses från byrå-settings (firma.git via org-projektionen), inte från kod.
- [x] Saknad/ofullständig mappning → connectorn vägrar pusha (completeness-gate, `loadConnector` → null).
- [x] Admin kan redigera mappningen i `/settings` (befintlig LedgerAccountsSection, admin-grindad).

## Verifierat lokalt

- `typecheck` grön (efter `rm tsconfig.tsbuildinfo`)
- `lint` (type-aware) grön
- `deps:check` (dep-cruiser) — 0 violations
- `duplicates` (jscpd) — 0.38%, under tröskel
- fortnox-tester: 38 pass; settings/accounting: 33 pass
- Nya tester: `fortnoxMappingFromLedgerMap` (derive + completeness), `makeLoadConnector` (deriverar via caller / null-gate)

> Notera: knip flaggar lokalt p.g.a. att git-worktree:n saknar egen `node_modules` (bun resolvar uppåt; knip lokalt) — alla fynd är standard-deps som main redan passerar, inget rör de ändrade filerna. CI kör med full install.

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)