### PR TITLE
fix(fortnox): gör account_type konfigurerbart, default user-consent (#213)

### DIFF
--- a/src/lib/server/integrations/fortnox/README.md
+++ b/src/lib/server/integrations/fortnox/README.md
@@ -24,7 +24,7 @@ Allt är enhetstestat utan riktig Fortnox (injicerad `fetch`).
    - Skapa ett **sandbox** att validera mot innan skarp drift.
 2. **Konto-mappning** — `FortnoxKontoMappning` (verifikatserie + konton för kundfordran/arvode/moms) är ett **bokföringsbeslut per byrå**. Connectorn levereras utan defaults.
 3. **Server-wiring** — koppla in `FortnoxClient.createVoucher` som en `PeerAct`-connector i `server-runtime` (pull av icke-synkade fakturor → bygg verifikat → push → skriv tillbaka `invoice.fortnoxId` för idempotens). Görs när creds finns.
-4. **Bekräfta mot sandbox**: exakt voucher-wire-nesting (`VoucherRows: { VoucherRow: [...] }` per dok) och authorize-parametrarna (`access_type=offline`, `account_type=service`). Isolerat i `toWireVoucher` / `buildAuthorizeUrl` → trivialt att justera.
+4. **Bekräfta mot sandbox**: exakt voucher-wire-nesting (`VoucherRows: { VoucherRow: [...] }` per dok) och authorize-parametrarna (`access_type=offline`; `account_type` se nedan). Isolerat i `toWireVoucher` / `buildAuthorizeUrl` → trivialt att justera.
 5. **Uppföljning**: fler-VAT-/vidarefakturerade-utlägg-uppdelning (kräver fakturarader, inte bara totalen).
 
 ## OAuth-flöde (kortfattat)
@@ -38,3 +38,23 @@ FortnoxClient.createVoucher(v)    → använder/refreshar token automatiskt
 
 Refresh-token **roterar** (gammal blir ogiltig) — `client.ts` sparar alltid den
 nya via `FortnoxTokenStore.save`. Access-token: 1 h, refresh-token: 45 dygn.
+
+## Konto-modell: user-consent (default) vs service-konto (#213)
+
+Fortnox `account_type` vid authorize är **valfri** (enda giltiga värdet är
+`service`, [dok](https://www.fortnox.se/developer/authorization/get-authorization-code)):
+
+- **Default = utelämnad → user-consent.** Access-token knyts till den användare
+  som godkände (t.ex. `sub: 1@<tenant>`, sysadmin). Detta är flödet som
+  **verifierats mot sandbox** (tokens i valvet, `GET /3/voucherseries` → 200).
+- **`account_type=service` → service-konto.** Inte knutet till en enskild
+  användare (överlever att hen slutar) — rätt modell för en obevakad
+  self-hosted connector på sikt. Kräver dock att **service-konto aktiverats för
+  appen i Developer Portal** och att en **sysadmin** auktoriserar (en
+  service-konto per client_id + kund). Ej end-to-end-verifierat än.
+
+Beslut: connectorn kör **user-consent som default** (det som bevisligen
+fungerar). Service-konto är **opt-in** via `accountType: "service"` i
+`FortnoxConfig`, eller env `AVA_FORTNOX_ACCOUNT_TYPE=service` i server-runtime:n.
+Refresh-flödet bryr sig inte om `account_type` — befintliga tokens roterar
+oavsett vald modell.

--- a/src/lib/server/integrations/fortnox/oauth.ts
+++ b/src/lib/server/integrations/fortnox/oauth.ts
@@ -27,15 +27,18 @@ const TOKEN_PATH = "/oauth-v1/token";
 /** Bygg authorize-URL:n användaren skickas till. `state` ska vara slumpad (CSRF). */
 export function buildAuthorizeUrl(config: FortnoxConfig, state: string): string {
   const url = new URL(AUTH_PATH, config.authBase);
-  url.search = new URLSearchParams({
+  const params = new URLSearchParams({
     client_id: config.clientId,
     redirect_uri: config.redirectUri,
     scope: config.scopes.join(" "),
     state,
     access_type: "offline", // krävs för att få en refresh-token
     response_type: "code",
-    account_type: "service",
-  }).toString();
+  });
+  // account_type är VALFRI hos Fortnox: utelämnad = user-consent (det verifierade
+  // flödet). Sätt bara "service" när byrån medvetet kör service-konto (#213).
+  if (config.accountType) params.set("account_type", config.accountType);
+  url.search = params.toString();
   return url.toString();
 }
 

--- a/src/lib/server/integrations/fortnox/runtime.ts
+++ b/src/lib/server/integrations/fortnox/runtime.ts
@@ -56,6 +56,8 @@ function fortnoxConfigFromEnv(
     scopes: ["bookkeeping"],
     ...(env.AVA_FORTNOX_AUTH_BASE ? { authBase: env.AVA_FORTNOX_AUTH_BASE } : {}),
     ...(env.AVA_FORTNOX_API_BASE ? { apiBase: env.AVA_FORTNOX_API_BASE } : {}),
+    // Opt-in service-konto (#213); default (utelämnad) = user-consent.
+    ...(env.AVA_FORTNOX_ACCOUNT_TYPE === "service" ? { accountType: "service" as const } : {}),
   });
 }
 

--- a/src/lib/server/integrations/fortnox/schema.ts
+++ b/src/lib/server/integrations/fortnox/schema.ts
@@ -30,6 +30,14 @@ export const fortnoxConfigSchema = z.object({
   /** Override för sandbox/test; default = produktions-endpoints. */
   authBase: z.string().url().default(FORTNOX_AUTH_BASE),
   apiBase: z.string().url().default(FORTNOX_API_BASE),
+  /**
+   * Fortnox `account_type` vid authorize (VALFRI; enda giltiga värdet =
+   * "service"). Utelämnad = user-consent (token knyts till användaren) — det
+   * flöde som verifierats mot sandbox. "service" = obevakat service-konto
+   * (överlever att användaren slutar) men kräver att service-konto aktiverats
+   * för appen i Developer Portal + att en sysadmin auktoriserar. Se README. (#213)
+   */
+  accountType: z.literal("service").optional(),
 });
 export type FortnoxConfig = z.infer<typeof fortnoxConfigSchema>;
 

--- a/test/unit/server/integrations/fortnox/oauth.test.ts
+++ b/test/unit/server/integrations/fortnox/oauth.test.ts
@@ -52,7 +52,16 @@ describe("buildAuthorizeUrl", () => {
     expect(p.get("state")).toBe("xyz-state");
     expect(p.get("response_type")).toBe("code");
     expect(p.get("access_type")).toBe("offline");
-    expect(p.get("account_type")).toBe("service");
+  });
+
+  it("utelämnar account_type som default (user-consent, det verifierade flödet)", () => {
+    const u = new URL(buildAuthorizeUrl(config, "s"));
+    expect(u.searchParams.has("account_type")).toBe(false);
+  });
+
+  it("sätter account_type=service bara när det konfigurerats (opt-in)", () => {
+    const u = new URL(buildAuthorizeUrl({ ...config, accountType: "service" }, "s"));
+    expect(u.searchParams.get("account_type")).toBe("service");
   });
 });
 


### PR DESCRIPTION
## Problem

`buildAuthorizeUrl` (`oauth.ts:37`) hårdkodade `account_type=service`. Men det flöde som faktiskt gick igenom till consent + gav tokens mot sandbox (tenant 1838388) var **user-consent-varianten UTAN `account_type`** — access-token knuten till användaren (`sub: 1@1838388`, sysadmin), inte ett service-konto. Koden reproducerade alltså inte den anslutning som fungerade.

## Verifierat mot Fortnox-doc

[Get Authorization-Code](https://www.fortnox.se/developer/authorization/get-authorization-code): `account_type` är **valfri**, enda giltiga värdet är `service`, och service-konto kräver att det **aktiverats för appen i Developer Portal** + att en **sysadmin** auktoriserar.

## Fix

- `account_type` är nu ett **valfritt** fält i `FortnoxConfig` (`z.literal("service").optional()`).
- `buildAuthorizeUrl` tar bara med parametern när den är satt → **default = utelämnad = user-consent** (det verifierade flödet).
- Opt-in service-konto via env `AVA_FORTNOX_ACCOUNT_TYPE=service` i server-runtime:n.
- Beslutet dokumenterat i connectorns `README.md` (user-consent default, service opt-in).
- Refresh-flödet (`refreshTokens`) är oförändrat — det bryr sig inte om `account_type`, så lagrade tokens roterar oavsett modell.

## Inte gjort (kräver dig)

Punkt 3 i issuen — **end-to-end-verifiering av service-konto-flödet mot sandbox** — kräver en Developer Portal-ändring (aktivera service-konto för appen) + omauth. Koden stödjer det nu, men jag kan inte verifiera det utan din sandbox/portal-access. Lämnas som manuellt nästa steg.

## Verifierat lokalt

- typecheck, lint, dep-cruiser (0 violations), jscpd (0.38%) grönt
- fortnox-tester: 40 pass (+2 nya: account_type utelämnas default / sätts vid opt-in)

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)