### PR TITLE
feat(helper): signaturverifiera self-update mot pinnad ed25519-nyckel (#110)

### DIFF
--- a/.github/workflows/helper-release.yml
+++ b/.github/workflows/helper-release.yml
@@ -42,6 +42,29 @@ jobs:
           sha256sum ava-helper-* > "ava-helper_${GITHUB_REF#refs/tags/}_checksums.txt"
           ls -lh
 
+      # Signera varje binär med release-nyckeln (#110). Helpers verifierar den
+      # detached Ed25519-signaturen mot en inbyggd pinnad pubkey före byte.
+      # Privata nyckeln (PEM) ligger som secret HELPER_SIGNING_KEY och används
+      # BARA här. Saknas secret:en → hoppa (osignerad release; nya helpers
+      # vägrar då uppdatera, fail-closed — sätt nyckeln innan skarp release).
+      - name: Sign binaries (Ed25519)
+        env:
+          HELPER_SIGNING_KEY: ${{ secrets.HELPER_SIGNING_KEY }}
+        run: |
+          if [ -z "$HELPER_SIGNING_KEY" ]; then
+            echo "::warning::HELPER_SIGNING_KEY saknas — hoppar signering (#110). Nya helpers vägrar uppdatera."
+            exit 0
+          fi
+          cd dist
+          printf '%s' "$HELPER_SIGNING_KEY" > "$RUNNER_TEMP/helper-release.key"
+          for f in ava-helper-*; do
+            case "$f" in *.sig|*.txt) continue;; esac
+            openssl pkeyutl -sign -inkey "$RUNNER_TEMP/helper-release.key" -rawin -in "$f" -out "$f.sig"
+            echo "signed $f → $f.sig"
+          done
+          rm -f "$RUNNER_TEMP/helper-release.key"
+          ls -lh
+
       - name: Publish release
         uses: softprops/action-gh-release@v2
         with:

--- a/helper-app/README.md
+++ b/helper-app/README.md
@@ -33,6 +33,10 @@ isär.
 * Filer skrivs till per-session-tempkatalog under `os.TempDir()` med
   läs/skriv-skydd 0700
 * Filnamn valideras (ingen path-traversal)
+* **Signerade self-updates (#110):** en nedladdad binär verifieras mot en
+  inbyggd, pinnad Ed25519-pubkey innan byte. Ingen giltig signatur (eller ingen
+  pinnad nyckel) → uppdateringen vägras och gamla binären behålls (fail-closed).
+  Skyddar mot en komprometterad GitHub-release. Se nedan + `src/update-verify.ts`.
 
 ## Bygg & kör lokalt
 
@@ -84,14 +88,36 @@ Chrome/Edge/Firefox + Windows/Linux behöver inte detta (HTTP-loopback funkar).
 
 Helper-releaser är taggade `helper-vX.Y.Z` (separerat från web-app-
 releaser). Skicka in en tag → GitHub Actions (`helper-release.yml`) kör
-`bun build.ts <tag>` → 5 binärer + `checksums.txt` laddas upp till
-releasen → installerade helpers plockar upp den vid nästa daglig
-kontroll (`src/update.ts`).
+`bun build.ts <tag>` → 5 binärer + `checksums.txt` + en detached
+`.sig` per binär laddas upp till releasen → installerade helpers
+verifierar signaturen och plockar upp den vid nästa dagliga kontroll
+(`src/update.ts`).
 
 ```bash
 git tag helper-v1.0.0
 git push origin helper-v1.0.0
 ```
+
+### Release-signeringsnyckel (#110, engångs-setup)
+
+Self-update kräver att binären är signerad med byråns release-nyckel.
+
+```bash
+# 1. Generera ett Ed25519-nyckelpar
+openssl genpkey -algorithm ed25519 -out helper-release.key
+
+# 2. Lägg PRIVATA nyckeln som GitHub Actions-secret HELPER_SIGNING_KEY
+#    (Settings → Secrets → Actions). Hela PEM:en. Används bara i release-jobbet.
+
+# 3. Härled PUBLIKA nyckeln (base64 DER SPKI) och baka in den i koden:
+openssl pkey -in helper-release.key -pubout -outform DER | base64 -w0
+#    → klistra i RELEASE_PUBLIC_KEY_SPKI_B64 i src/update-verify.ts
+```
+
+Tills nyckeln är inbakad **vägrar** nya helpers att uppdatera (fail-closed).
+**Nyckelrotation:** släpp först en version som litar på både gammal + ny nyckel
+(`acceptedPublicKeys` i `update-verify.ts`), låt flottan uppdatera, byt sedan
+secret:en. Detaljer i filhuvudet på `src/update-verify.ts`.
 
 > **Paketering:** install-scripten under `service/` letar efter en binär
 > som heter `ava-helper` (resp. `ava-helper.exe`). Release-arkiveringen

--- a/helper-app/src/update-verify.ts
+++ b/helper-app/src/update-verify.ts
@@ -1,0 +1,75 @@
+/**
+ * Self-update — äkthetskontroll av nedladdad binär (#110).
+ *
+ * Self-update över HTTPS + GitHub räcker inte: en komprometterad release
+ * skulle auto-installeras på alla helpers (de pollar dagligen). Därför
+ * verifierar vi en **detached Ed25519-signatur** över de nedladdade bytsen mot
+ * en **pinnad publik nyckel** innan binären byts ut. Ingen match → vägra
+ * (fail-closed), behåll gamla binären.
+ *
+ * Krypto: node:crypto Ed25519 (native i Bun) — ingen extern dep, jfr
+ * git-commit-signeringens ed25519-bruk.
+ *
+ * ── Provisionering (engång, av dig) ──────────────────────────────────────
+ *   1. Generera ett release-nyckelpar (Ed25519):
+ *        openssl genpkey -algorithm ed25519 -out helper-release.key
+ *   2. Lägg PRIVATA nyckeln som GitHub Actions-secret `HELPER_SIGNING_KEY`
+ *      (hela PEM:en). Används BARA i release-jobbet (helper-release.yml).
+ *   3. Härled PUBLIKA nyckeln som base64(DER SPKI) och baka in den nedan:
+ *        openssl pkey -in helper-release.key -pubout -outform DER | base64 -w0
+ *      Klistra resultatet i RELEASE_PUBLIC_KEY_SPKI_B64.
+ *
+ * ── Nyckelrotation ───────────────────────────────────────────────────────
+ *   En helper kan bara verifiera mot den pubkey den bakats med. Byte kräver
+ *   därför ett ÖVERGÅNGS-steg: släpp först en helper-version som accepterar
+ *   BÅDE gamla och nya nyckeln (lägg båda i `acceptedPublicKeys`), låt flottan
+ *   uppdatera till den, byt sedan signeringsnyckel i secret:en, och ta bort
+ *   den gamla nyckeln i nästa version.
+ */
+
+import { createPublicKey, verify as cryptoVerify } from "node:crypto";
+
+/**
+ * Pinnad publik release-nyckel, base64(DER SPKI). TOM tills du provisionerar
+ * den (se filhuvudet). Tom nyckel = self-update vägrar (fail-closed) — det är
+ * avsiktligt: en osignerad/okonfigurerad uppdatering ska aldrig installeras.
+ */
+export const RELEASE_PUBLIC_KEY_SPKI_B64 = "";
+
+/** Suffix på signatur-asseten i releasen, t.ex. `ava-helper-linux-x64.sig`. */
+export function signatureAssetName(binaryAsset: string): string {
+  return `${binaryAsset}.sig`;
+}
+
+/** De publika nycklar denna binär litar på (flera bara under rotation). */
+export function acceptedPublicKeys(): readonly string[] {
+  return [RELEASE_PUBLIC_KEY_SPKI_B64].filter((k) => k.length > 0);
+}
+
+/** Verifiera en detached Ed25519-signatur mot EN pinnad pubkey (base64 SPKI). */
+export function verifyEd25519(data: Uint8Array, signature: Uint8Array, spkiB64: string): boolean {
+  try {
+    const key = createPublicKey({ key: Buffer.from(spkiB64, "base64"), format: "der", type: "spki" });
+    return cryptoVerify(null, data, key, signature);
+  } catch {
+    // Ogiltig nyckel/signatur-encoding → behandla som icke-verifierad, kasta ej.
+    return false;
+  }
+}
+
+/**
+ * Säkerställ att `data` är signerad av NÅGON av de accepterade nycklarna.
+ * Kastar (fail-closed) när ingen nyckel är pinnad eller ingen matchar.
+ */
+export function assertSignature(
+  data: Uint8Array,
+  signature: Uint8Array,
+  keys: readonly string[] = acceptedPublicKeys(),
+): void {
+  if (keys.length === 0) {
+    throw new Error("self-update avbruten: ingen pinnad release-nyckel (RELEASE_PUBLIC_KEY_SPKI_B64 tom)");
+  }
+  if (!keys.some((k) => verifyEd25519(data, signature, k))) {
+    throw new Error("self-update avbruten: signaturen matchar ingen pinnad release-nyckel");
+  }
+}

--- a/helper-app/src/update.ts
+++ b/helper-app/src/update.ts
@@ -16,6 +16,7 @@ import { chmod, rename } from "node:fs/promises";
 import { log } from "./log.ts";
 import { currentPlatform, type Platform } from "./platform/runtime.ts";
 import { isNewer } from "./semver.ts";
+import { acceptedPublicKeys, assertSignature, signatureAssetName } from "./update-verify.ts";
 
 export interface UpdateConfig {
   currentVersion: string;
@@ -73,7 +74,8 @@ export async function runUpdateLoop(
 /** Injicerbara beroenden för en kontroll → testbar utan nät/fs. */
 export interface CheckDeps {
   fetchReleases: (repo: string) => Promise<GithubRelease[]>;
-  replace: (url: string, targetPath: string) => Promise<void>;
+  /** Verifiera signaturen (`sigUrl`) över binären (`url`) → byt bara vid match. */
+  replace: (url: string, targetPath: string, sigUrl: string) => Promise<void>;
   targetPath: string;
   asset: string;
 }
@@ -95,8 +97,15 @@ export async function checkOnce(cfg: UpdateConfig, deps: CheckDeps = defaultChec
     log(`no asset ${deps.asset} in ${latest.tag_name}`);
     return;
   }
+  // Äkthetskrav (#110): en detached signatur MÅSTE finnas + verifieras innan
+  // byte. Saknas .sig-asseten → vägra (fail-closed), behåll gamla binären.
+  const sig = latest.assets.find((a) => a.name === signatureAssetName(deps.asset));
+  if (sig === undefined) {
+    log(`no signature ${signatureAssetName(deps.asset)} in ${latest.tag_name} — refusing update`);
+    return;
+  }
   log(`updating ${cfg.currentVersion} → ${latest.tag_name}`);
-  await deps.replace(asset.browser_download_url, deps.targetPath);
+  await deps.replace(asset.browser_download_url, deps.targetPath, sig.browser_download_url);
   cfg.onUpdated(latest.tag_name);
 }
 
@@ -124,17 +133,33 @@ export function pickLatest(
   return best;
 }
 
-/**
- * Ladda ner binären till en temp-fil bredvid målet, gör den körbar och
- * byt ut den löpande binären. På unix funkar rename-over direkt; på
- * Windows flyttas den gamla undan först (kan inte skrivas över medan den
- * körs).
- */
-export async function downloadAndReplace(url: string, targetPath: string): Promise<void> {
-  const tmpPath = `${targetPath}.new`;
+/** Hämta bytes från en URL (delad av binär- + signatur-nedladdning). */
+async function fetchBytes(url: string, what: string): Promise<Uint8Array> {
   const resp = await fetch(url);
-  if (resp.status >= 400) throw new Error(`download HTTP ${resp.status}`);
-  await Bun.write(tmpPath, resp);
+  if (resp.status >= 400) throw new Error(`${what} HTTP ${resp.status}`);
+  return new Uint8Array(await resp.arrayBuffer());
+}
+
+/**
+ * Ladda ner binären + dess detached signatur, **verifiera signaturen mot den
+ * pinnade release-nyckeln** (#110) och byt först därefter ut den löpande
+ * binären. Ingen match → kasta, behåll gamla binären (fail-closed).
+ *
+ * På unix funkar rename-over direkt; på Windows flyttas den gamla undan först
+ * (kan inte skrivas över medan den körs).
+ */
+export async function downloadAndReplace(
+  url: string,
+  targetPath: string,
+  sigUrl: string,
+  keys: readonly string[] = acceptedPublicKeys(),
+): Promise<void> {
+  const bytes = await fetchBytes(url, "download");
+  const signature = await fetchBytes(sigUrl, "signature download");
+  assertSignature(bytes, signature, keys); // kastar om osignerad/ej matchande
+
+  const tmpPath = `${targetPath}.new`;
+  await Bun.write(tmpPath, bytes);
   await chmod(tmpPath, 0o755);
   if (currentPlatform() === "windows") {
     await rename(targetPath, `${targetPath}.old`).catch(() => undefined);

--- a/helper-app/test/update-verify.test.ts
+++ b/helper-app/test/update-verify.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { generateKeyPairSync, sign } from "node:crypto";
+
+import {
+  acceptedPublicKeys,
+  assertSignature,
+  RELEASE_PUBLIC_KEY_SPKI_B64,
+  signatureAssetName,
+  verifyEd25519,
+} from "../src/update-verify.ts";
+
+function keypair() {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  return { privateKey, pubB64: publicKey.export({ format: "der", type: "spki" }).toString("base64") };
+}
+
+describe("signatureAssetName", () => {
+  test("lägger .sig efter binär-assetens namn", () => {
+    expect(signatureAssetName("ava-helper-linux-x64")).toBe("ava-helper-linux-x64.sig");
+  });
+});
+
+describe("verifyEd25519", () => {
+  const data = Buffer.from("AVA helper binär-bytes");
+
+  test("true för en signatur som matchar pubkey + data", () => {
+    const { privateKey, pubB64 } = keypair();
+    expect(verifyEd25519(data, sign(null, data, privateKey), pubB64)).toBe(true);
+  });
+
+  test("false när datat manipulerats", () => {
+    const { privateKey, pubB64 } = keypair();
+    const sig = sign(null, data, privateKey);
+    expect(verifyEd25519(Buffer.from("manipulerat"), sig, pubB64)).toBe(false);
+  });
+
+  test("false för fel nyckel", () => {
+    const { privateKey } = keypair();
+    const { pubB64: otherPub } = keypair();
+    expect(verifyEd25519(data, sign(null, data, privateKey), otherPub)).toBe(false);
+  });
+
+  test("false (kastar ej) för skräp-nyckel", () => {
+    const { privateKey } = keypair();
+    expect(verifyEd25519(data, sign(null, data, privateKey), "inte-base64-spki")).toBe(false);
+  });
+});
+
+describe("assertSignature", () => {
+  const data = Buffer.from("payload");
+
+  test("ingen pinnad nyckel → kastar (fail-closed)", () => {
+    const { privateKey } = keypair();
+    expect(() => assertSignature(data, sign(null, data, privateKey), [])).toThrow(/ingen pinnad release-nyckel/);
+  });
+
+  test("matchande nyckel → kastar inte", () => {
+    const { privateKey, pubB64 } = keypair();
+    expect(() => assertSignature(data, sign(null, data, privateKey), [pubB64])).not.toThrow();
+  });
+
+  test("accepterar om NÅGON av flera nycklar matchar (rotation)", () => {
+    const { privateKey, pubB64 } = keypair();
+    const { pubB64: oldPub } = keypair();
+    expect(() => assertSignature(data, sign(null, data, privateKey), [oldPub, pubB64])).not.toThrow();
+  });
+
+  test("ingen nyckel matchar → kastar", () => {
+    const { privateKey } = keypair();
+    const { pubB64: wrong } = keypair();
+    expect(() => assertSignature(data, sign(null, data, privateKey), [wrong])).toThrow(/matchar ingen pinnad/);
+  });
+});
+
+describe("RELEASE_PUBLIC_KEY_SPKI_B64 / acceptedPublicKeys", () => {
+  test("oprovisionerad pinnad nyckel är tom → inga accepterade nycklar (fail-closed default)", () => {
+    // Tom tills release-nyckeln bakats in; säkerställer att osignerade
+    // uppdateringar vägras out-of-the-box (#110).
+    expect(RELEASE_PUBLIC_KEY_SPKI_B64).toBe("");
+    expect(acceptedPublicKeys()).toEqual([]);
+  });
+});

--- a/helper-app/test/update.test.ts
+++ b/helper-app/test/update.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { chmod, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { generateKeyPairSync, sign } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -25,8 +26,11 @@ function rel(tag: string, draft = false): Rel {
   return { tag_name: tag, draft, assets: [] };
 }
 
-function relWithAsset(tag: string, assetNameStr: string, url: string): GithubRelease {
-  return { tag_name: tag, draft: false, assets: [{ name: assetNameStr, browser_download_url: url }] };
+/** Release med binär-asset + (default) dess `.sig`-asset. */
+function relWithAsset(tag: string, assetNameStr: string, url: string, withSig = true): GithubRelease {
+  const assets = [{ name: assetNameStr, browser_download_url: url }];
+  if (withSig) assets.push({ name: `${assetNameStr}.sig`, browser_download_url: `${url}.sig` });
+  return { tag_name: tag, draft: false, assets };
 }
 
 describe("assetName", () => {
@@ -67,7 +71,7 @@ describe("pickLatest", () => {
 interface CheckHarness {
   cfg: UpdateConfig;
   deps: CheckDeps;
-  replaced: Array<{ url: string; target: string }>;
+  replaced: Array<{ url: string; target: string; sigUrl: string }>;
   updated: string[];
 }
 
@@ -79,7 +83,7 @@ function checkHarness(releases: GithubRelease[], asset = "ava-helper-test"): Che
     updated,
     deps: {
       fetchReleases: async () => releases,
-      replace: async (url, target) => { replaced.push({ url, target }); },
+      replace: async (url, target, sigUrl) => { replaced.push({ url, target, sigUrl }); },
       targetPath: "/bin/ava-helper",
       asset,
     },
@@ -102,15 +106,22 @@ describe("checkOnce", () => {
     expect(h.updated).toHaveLength(0);
   });
 
-  test("nyare + matchande asset → replace(url,target) + onUpdated(tag)", async () => {
+  test("nyare + matchande asset + signatur → replace(url,target,sigUrl) + onUpdated(tag)", async () => {
     const h = checkHarness([relWithAsset("helper-v1.5.0", "ava-helper-test", "http://dl/bin")]);
     await checkOnce(h.cfg, h.deps);
-    expect(h.replaced).toEqual([{ url: "http://dl/bin", target: "/bin/ava-helper" }]);
+    expect(h.replaced).toEqual([{ url: "http://dl/bin", target: "/bin/ava-helper", sigUrl: "http://dl/bin.sig" }]);
     expect(h.updated).toEqual(["helper-v1.5.0"]);
   });
 
   test("nyare men inget matchande asset → ingen replace/onUpdated", async () => {
     const h = checkHarness([relWithAsset("helper-v1.5.0", "ava-helper-annat-os", "http://x")]);
+    await checkOnce(h.cfg, h.deps);
+    expect(h.replaced).toHaveLength(0);
+    expect(h.updated).toHaveLength(0);
+  });
+
+  test("binär finns men signatur-asset saknas → vägrar (fail-closed)", async () => {
+    const h = checkHarness([relWithAsset("helper-v1.5.0", "ava-helper-test", "http://dl/bin", false)]);
     await checkOnce(h.cfg, h.deps);
     expect(h.replaced).toHaveLength(0);
     expect(h.updated).toHaveLength(0);
@@ -151,19 +162,62 @@ describe("downloadAndReplace (integration)", () => {
     await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true })));
   });
 
-  test("laddar ner ny binär och byter ut målet + sätter exec-bit", async () => {
+  const BINARY = "NY BINÄR v2";
+  // Färskt test-nyckelpar; den publika nyckeln injiceras i downloadAndReplace.
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  const pubB64 = publicKey.export({ format: "der", type: "spki" }).toString("base64");
+  const goodSig = sign(null, Buffer.from(BINARY), privateKey);
+
+  /** Kopiera bytes till en färsk ArrayBuffer (entydig BodyInit för Response). */
+  function toArrayBuffer(u: Uint8Array): ArrayBuffer {
+    const ab = new ArrayBuffer(u.byteLength);
+    new Uint8Array(ab).set(u);
+    return ab;
+  }
+
+  /** Bun-server som serverar binären på /bin och signaturen på /bin.sig. */
+  function serveBinaryAndSig(sig: Uint8Array) {
+    return Bun.serve({
+      port: 0,
+      fetch: (req) =>
+        new URL(req.url).pathname.endsWith(".sig")
+          ? new Response(toArrayBuffer(sig))
+          : new Response(BINARY),
+    });
+  }
+
+  test("verifierar signaturen, laddar ner + byter ut målet + sätter exec-bit", async () => {
     const dir = await mkdtemp(join(tmpdir(), "ava-upd-"));
     dirs.push(dir);
     const target = join(dir, "ava-helper");
     await writeFile(target, "GAMMAL BINÄR");
     await chmod(target, 0o644);
 
-    const server = Bun.serve({ port: 0, fetch: () => new Response("NY BINÄR v2") });
+    const server = serveBinaryAndSig(goodSig);
     try {
-      await downloadAndReplace(`http://127.0.0.1:${server.port}/bin`, target);
-      expect(await readFile(target, "utf8")).toBe("NY BINÄR v2");
+      const base = `http://127.0.0.1:${server.port}`;
+      await downloadAndReplace(`${base}/bin`, target, `${base}/bin.sig`, [pubB64]);
+      expect(await readFile(target, "utf8")).toBe(BINARY);
       const mode = (await stat(target)).mode & 0o777;
       expect(mode & 0o100).toBe(0o100); // owner-exec satt
+    } finally {
+      void server.stop(true);
+    }
+  });
+
+  test("ogiltig signatur → kastar och behåller gamla binären (fail-closed)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ava-upd-"));
+    dirs.push(dir);
+    const target = join(dir, "ava-helper");
+    await writeFile(target, "GAMMAL BINÄR");
+
+    const badSig = sign(null, Buffer.from(" fel innehåll "), privateKey);
+    const server = serveBinaryAndSig(badSig);
+    try {
+      const base = `http://127.0.0.1:${server.port}`;
+      const err = await expectRejection(downloadAndReplace(`${base}/bin`, target, `${base}/bin.sig`, [pubB64]));
+      expect(String(err)).toContain("matchar ingen pinnad release-nyckel");
+      expect(await readFile(target, "utf8")).toBe("GAMMAL BINÄR"); // oförändrad
     } finally {
       void server.stop(true);
     }
@@ -172,7 +226,8 @@ describe("downloadAndReplace (integration)", () => {
   test("HTTP-fel → kastar", async () => {
     const server = Bun.serve({ port: 0, fetch: () => new Response("nope", { status: 500 }) });
     try {
-      const err = await expectRejection(downloadAndReplace(`http://127.0.0.1:${server.port}/x`, "/tmp/whatever"));
+      const base = `http://127.0.0.1:${server.port}`;
+      const err = await expectRejection(downloadAndReplace(`${base}/x`, "/tmp/whatever", `${base}/x.sig`, [pubB64]));
       expect(String(err)).toContain("download HTTP 500");
     } finally {
       void server.stop(true);


### PR DESCRIPTION
## Problem

Self-update (`helper-app/src/update.ts` → `downloadAndReplace`) bytte ut den körande binären efter **enbart TLS + GitHub** — ingen integritets-/äkthetskontroll. En komprometterad GitHub-release skulle auto-installeras på alla helpers (de pollar dagligen och exitar för omstart). `checksums.txt` från samma release skyddar inte (angriparen genererar om den).

## Fix — fail-closed Ed25519-signaturverifiering

- **`update-verify.ts`** (ny): `verifyEd25519` (node:crypto, ingen extern dep), `assertSignature` (kastar utan pinnad/matchande nyckel), `acceptedPublicKeys` (stödjer flera nycklar under rotation), och den pinnade `RELEASE_PUBLIC_KEY_SPKI_B64`. **Tom tills provisionerad** → en osignerad/okonfigurerad uppdatering vägras out-of-the-box.
- **`update.ts`**: `checkOnce` kräver en `<asset>.sig`-asset i releasen (saknas → vägra + logga). `downloadAndReplace` hämtar binär + signatur, **verifierar mot pinnad pubkey**, och byter först därefter. Ingen match → kastar, gamla binären behålls.
- **`helper-release.yml`**: signerar varje binär med en Ed25519-nyckel ur secret `HELPER_SIGNING_KEY` (openssl `pkeyutl -rawin`) och laddar upp en detached `.sig` per binär. Saknas secret:en → hoppar med en `::warning::` (osignerad release; nya helpers vägrar uppdatera).
- **README**: provisionering (generera nyckel → sätt secret → baka in pubkey) + nyckelrotation dokumenterad.

## Kompatibilitet verifierad

openssl-signaturen (release-sidan) verifieras av helperns node:crypto (`verify(null, …)`) — raw 64-byte Ed25519, round-trip-testat lokalt → `true`.

## Kräver dig (engångs, kan ej göras härifrån)

Generera release-nyckelparet, lägg privata nyckeln som secret `HELPER_SIGNING_KEY`, och baka in pubkey:n i `RELEASE_PUBLIC_KEY_SPKI_B64` (instruktioner i README + filhuvudet på `update-verify.ts`). Tills dess är self-update **fail-closed** (vägrar uppdatera).

## Verifierat lokalt

- helper `bun run typecheck` rent (utöver pre-existing `node-forge`-fel som beror på att git-worktree:n saknar egen `node_modules` — finns i CI/full install)
- 25 update-tester pass; **`update-verify.ts` 100 % täckning**
- repo `deps:check` (dep-cruiser) — 0 violations (781 moduler); `lint` rent på de nya filerna

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)