### PR TITLE
feat(invoices): manuellt fakturautskick via helper compose-mail (#179)

### DIFF
--- a/src/app/invoices/[id]/_client.tsx
+++ b/src/app/invoices/[id]/_client.tsx
@@ -21,6 +21,7 @@ import { WriteOffModal } from "./_write-off-modal";
 import { InvoiceActions } from "./_invoice-actions";
 import { PaymentsTable } from "./_payments-table";
 import { DispatchHistory } from "./_dispatch-history";
+import { SendInvoiceModal } from "./_send-invoice-modal";
 
 const STATUS_LABELS: Record<string, string> = {
   DRAFT: "Utkast",
@@ -42,6 +43,7 @@ export default function InvoiceDetailClient({ id: paramId }: { id: string }) {
   const [showPlan, setShowPlan] = useState(false);
   const [showCredit, setShowCredit] = useState(false);
   const [showWriteOff, setShowWriteOff] = useState(false);
+  const [showSend, setShowSend] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const refetchAll = () => {
@@ -109,6 +111,7 @@ export default function InvoiceDetailClient({ id: paramId }: { id: string }) {
           onShowPlan={() => setShowPlan(true)}
           onShowCredit={() => setShowCredit(true)}
           onShowWriteOff={() => setShowWriteOff(true)}
+          onShowSend={() => setShowSend(true)}
           onSetStatus={(status) => setStatus.mutate({ invoiceId: inv.id, status: status as Parameters<typeof setStatus.mutate>[0]["status"] })}
         />
         {inv.notes && <p className="mt-4 text-sm text-gray-600 border-t pt-3">{inv.notes}</p>}
@@ -174,6 +177,20 @@ export default function InvoiceDetailClient({ id: paramId }: { id: string }) {
           error={error}
           onSubmit={(data) => writeOff.mutate(data)}
           onClose={() => { setShowWriteOff(false); setError(null); }}
+        />
+      )}
+
+      {showSend && (
+        <SendInvoiceModal
+          invoiceId={inv.id}
+          invoiceNumber={(inv as { invoiceNumber?: string | null }).invoiceNumber}
+          amount={inv.amount}
+          ocrReference={(inv as { ocrReference?: string | null }).ocrReference}
+          invoiceDate={inv.invoiceDate}
+          matterNumber={inv.matter.matterNumber}
+          matterTitle={inv.matter.title}
+          onRecorded={() => { void utils.invoiceDispatch.list.invalidate({ invoiceId: inv.id }); }}
+          onClose={() => setShowSend(false)}
         />
       )}
     </div>

--- a/src/app/invoices/[id]/_invoice-actions.tsx
+++ b/src/app/invoices/[id]/_invoice-actions.tsx
@@ -11,6 +11,7 @@ interface Props {
   onShowPlan: () => void;
   onShowCredit: () => void;
   onShowWriteOff: () => void;
+  onShowSend: () => void;
   onSetStatus: (status: string) => void;
 }
 
@@ -21,9 +22,19 @@ interface Visibility {
   cancel: boolean;
   credit: boolean;
   writeOff: boolean;
+  send: boolean;
 }
 
 const TERMINAL_STATUS: ReadonlySet<string> = new Set(["PAID", "CANCELLED"]);
+
+/**
+ * E-posta-knappen (#179): en utställd faktura (SENT/avbetalningsplan) eller en
+ * icke-annullerad kreditfaktura kan skickas manuellt till klienten.
+ */
+function canEmail(isCredit: boolean, status: string): boolean {
+  if (status === "SENT" || status === "INSTALLMENT_PLAN") return true;
+  return isCredit && status !== "CANCELLED";
+}
 
 function computeVisibility(invoiceType: string, status: string, hasPlan: boolean, hasCreditNote: boolean, outstanding: number): Visibility {
   const isCredit = invoiceType === "CREDIT";
@@ -39,12 +50,13 @@ function computeVisibility(invoiceType: string, status: string, hasPlan: boolean
     // Avskrivning: utställd faktura med utestående kvar (även en plan-faktura
     // som klienten slutat betala) → räkna-en-gång (ADR 0007).
     writeOff: issuedActive && outstanding > 0,
+    send: canEmail(isCredit, status),
   };
 }
 
 export function InvoiceActions({
   invoiceType, status, hasPlan, hasCreditNote, outstanding,
-  onShowPayment, onShowPlan, onShowCredit, onShowWriteOff, onSetStatus,
+  onShowPayment, onShowPlan, onShowCredit, onShowWriteOff, onShowSend, onSetStatus,
 }: Props) {
   const v = computeVisibility(invoiceType, status, hasPlan, hasCreditNote, outstanding);
 
@@ -58,6 +70,11 @@ export function InvoiceActions({
       {v.plan && (
         <button onClick={onShowPlan} className="px-3 py-1.5 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700">
           Skapa avbetalningsplan
+        </button>
+      )}
+      {v.send && (
+        <button onClick={onShowSend} className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700">
+          E-posta faktura
         </button>
       )}
       {v.draft && (

--- a/src/app/invoices/[id]/_send-invoice-modal.tsx
+++ b/src/app/invoices/[id]/_send-invoice-modal.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+/**
+ * Manuellt fakturautskick (#179) — utan servermjukvara. Advokaten skickar
+ * fakturan som PDF via sin EGEN mailklient (helper `compose-mail`) eller laddar
+ * ner PDF:en och bifogar själv. AVA registrerar utskicket i git-db:n (#178)
+ * först när advokaten BEKRÄFTAR att hen skickat — undviker falska positiv
+ * (att öppna mailklienten ≠ skickat). Ingen backend kan verifiera leverans här.
+ */
+
+import { useState } from "react";
+import { Mail, Download, X } from "lucide-react";
+
+import { trpc } from "@/lib/client/trpc";
+import { useHelper, composeMailViaHelper } from "@/lib/client/helper/use-helper";
+import { bytesToBase64 } from "@/lib/client/bytes-base64";
+import { downloadBytes } from "@/lib/client/download-text";
+import { renderFakturaPdf } from "@/lib/client/kostnadsrakning/render-faktura-pdf";
+import { formatCurrency } from "@/lib/client/utils";
+
+export interface SendInvoiceModalProps {
+  invoiceId: string;
+  invoiceNumber?: string | null | undefined;
+  amount: number;
+  ocrReference?: string | null | undefined;
+  invoiceDate?: string | Date | null | undefined;
+  matterNumber: string;
+  matterTitle: string;
+  onClose: () => void;
+  onRecorded: () => void;
+}
+
+function mailBody(p: SendInvoiceModalProps): string {
+  const lines = [
+    `Faktura ${p.invoiceNumber ?? ""}`.trim(),
+    `Belopp: ${formatCurrency(p.amount)}`,
+  ];
+  if (p.ocrReference) lines.push(`OCR-referens: ${p.ocrReference}`);
+  lines.push("", "Fakturan bifogas som PDF.");
+  return lines.join("\n");
+}
+
+function pdfFileName(p: SendInvoiceModalProps): string {
+  return `Faktura ${p.invoiceNumber ?? p.matterNumber}.pdf`;
+}
+
+async function buildPdf(p: SendInvoiceModalProps, recipient: string): Promise<Uint8Array> {
+  return renderFakturaPdf({
+    invoice: {
+      amount: p.amount,
+      invoiceNumber: p.invoiceNumber ?? null,
+      ocrReference: p.ocrReference ?? null,
+      invoiceDate: p.invoiceDate ?? null,
+    },
+    meta: { matterNumber: p.matterNumber, matterTitle: p.matterTitle, ...(recipient ? { recipient } : {}) },
+  });
+}
+
+interface SendInvoiceState {
+  recipient: string;
+  setRecipient: (v: string) => void;
+  prepared: boolean;
+  busy: boolean;
+  note: string | null;
+  error: string | null;
+  isPending: boolean;
+  onEmail: () => void;
+  onDownload: () => void;
+  confirmSent: () => void;
+}
+
+/** Logiken bakom utskicket (PDF → helper/nedladdning → bekräfta → dispatch). */
+function useSendInvoice(props: SendInvoiceModalProps): SendInvoiceState {
+  const [recipient, setRecipient] = useState("");
+  const [prepared, setPrepared] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [note, setNote] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const helper = useHelper();
+
+  const record = trpc.invoiceDispatch.recordManual.useMutation({
+    onSuccess: () => { props.onRecorded(); props.onClose(); },
+    onError: (e) => setError(e.message),
+  });
+
+  const run = async (fn: () => Promise<string>): Promise<void> => {
+    setBusy(true);
+    setError(null);
+    try {
+      setNote(await fn());
+      setPrepared(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onEmail = () => void run(async () => {
+    const bytes = await buildPdf(props, recipient);
+    const opened = Boolean(helper.version) && await composeMailViaHelper({
+      ...(recipient ? { to: recipient } : {}),
+      fileName: pdfFileName(props),
+      contentBase64: bytesToBase64(bytes),
+      mimeType: "application/pdf",
+      subject: `Faktura ${props.invoiceNumber ?? props.matterNumber}`,
+      body: mailBody(props),
+    });
+    if (opened) return "Mailklienten öppnades med fakturan bifogad. Tryck skicka där.";
+    downloadBytes(pdfFileName(props), new Uint8Array(bytes), "application/pdf");
+    return "Ingen helper hittades — PDF:en laddades ner. Bifoga den själv i din mailklient.";
+  });
+
+  const onDownload = () => void run(async () => {
+    const bytes = await buildPdf(props, recipient);
+    downloadBytes(pdfFileName(props), new Uint8Array(bytes), "application/pdf");
+    return "PDF:en laddades ner.";
+  });
+
+  const confirmSent = () => {
+    const trimmed = recipient.trim();
+    record.mutate({
+      invoiceId: props.invoiceId,
+      channel: trimmed.includes("@") ? "email" : "manual",
+      recipient: trimmed || "Manuellt utskick",
+    });
+  };
+
+  return { recipient, setRecipient, prepared, busy, note, error, isPending: record.isPending, onEmail, onDownload, confirmSent };
+}
+
+export function SendInvoiceModal(props: SendInvoiceModalProps) {
+  const s = useSendInvoice(props);
+  return (
+    <div className="fixed inset-0 z-50 bg-black/40 flex md:items-center md:justify-center md:p-4">
+      <div className="bg-white w-full md:max-w-lg md:rounded-xl flex flex-col h-full md:h-auto overflow-hidden shadow-2xl">
+        <div className="flex items-center justify-between border-b border-gray-200 px-5 py-4">
+          <h2 className="text-base sm:text-lg font-bold text-gray-900 flex items-center gap-2">
+            <Mail size={18} className="text-blue-600" />
+            E-posta faktura {props.invoiceNumber ?? ""}
+          </h2>
+          <button onClick={props.onClose} aria-label="Stäng" className="p-2 hover:bg-gray-100 rounded">
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="p-5 space-y-4">
+          <label className="block text-sm">
+            <span className="text-gray-700">Mottagarens e-post (valfritt)</span>
+            <input
+              type="email"
+              value={s.recipient}
+              onChange={(e) => s.setRecipient(e.target.value)}
+              placeholder="klient@example.se"
+              className="mt-1 w-full rounded border border-gray-300 px-3 py-1.5 text-sm"
+            />
+            <span className="mt-1 block text-xs text-gray-400">
+              Förifylls i mailklienten. Mailet skickas från din egen e-post — ingen server inblandad.
+            </span>
+          </label>
+
+          <div className="flex flex-wrap gap-2">
+            <button
+              onClick={s.onEmail}
+              disabled={s.busy || s.isPending}
+              className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 flex items-center gap-1.5"
+            >
+              <Mail size={15} /> Öppna i mailklient
+            </button>
+            <button
+              onClick={s.onDownload}
+              disabled={s.busy || s.isPending}
+              className="px-3 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50 flex items-center gap-1.5"
+            >
+              <Download size={15} /> Ladda ner PDF
+            </button>
+          </div>
+
+          {s.note && <p className="text-sm text-gray-600 bg-gray-50 border border-gray-200 rounded p-2">{s.note}</p>}
+          {s.error && <p className="text-sm text-red-600">{s.error}</p>}
+
+          {s.prepared && (
+            <div className="border-t pt-3">
+              <p className="text-sm text-gray-700 mb-2">
+                Har du skickat fakturan? Markera den som skickad så registreras utskicket i AVA.
+              </p>
+              <button
+                onClick={s.confirmSent}
+                disabled={s.isPending}
+                className="px-3 py-1.5 text-sm bg-green-600 text-white rounded hover:bg-green-700 disabled:opacity-50"
+              >
+                {s.isPending ? "Registrerar…" : "Markera som skickad"}
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/matters/[id]/_kostnadsrakning-modal.tsx
+++ b/src/app/matters/[id]/_kostnadsrakning-modal.tsx
@@ -26,6 +26,7 @@ import { omitUndefined } from "@/lib/shared/omit-undefined";
 import type { TaxaLevel } from "@/lib/shared/brottmalstaxa";
 import { renderKostnadsrakningPdf } from "@/lib/client/kostnadsrakning/render-pdf";
 import { useHelper, composeMailViaHelper } from "@/lib/client/helper/use-helper";
+import { bytesToBase64 } from "@/lib/client/bytes-base64";
 import { formatCurrency } from "@/lib/client/utils";
 import { persistGeneratedDoc } from "@/lib/client/demo/persist-generated-doc";
 
@@ -112,12 +113,6 @@ async function recordDocument(opts: RecordDocOpts): Promise<void> {
   } catch (e) {
     console.warn("[kostnadsrakning] dokument-invalidering misslyckades (best-effort):", e);
   }
-}
-
-function bytesToBase64(bytes: Uint8Array): string {
-  let bin = "";
-  for (const byte of bytes) bin += String.fromCharCode(byte);
-  return btoa(bin);
 }
 
 interface MailOpts {

--- a/src/lib/client/bytes-base64.ts
+++ b/src/lib/client/bytes-base64.ts
@@ -1,0 +1,10 @@
+/**
+ * Konvertera råa bytes till base64 (för t.ex. helperns `compose-mail`-bilaga,
+ * som tar `contentBase64`). Delad så fakturautskick (#179) och kostnadsräkning
+ * inte duplicerar samma loop.
+ */
+export function bytesToBase64(bytes: Uint8Array): string {
+  let bin = "";
+  for (const byte of bytes) bin += String.fromCharCode(byte);
+  return btoa(bin);
+}

--- a/src/lib/server/routers/invoiceDispatch.ts
+++ b/src/lib/server/routers/invoiceDispatch.ts
@@ -74,6 +74,37 @@ export const invoiceDispatchRouter = router({
       });
     }),
 
+  /**
+   * Registrera ett MANUELLT utskick som redan skett (#179) — t.ex. när
+   * advokaten skickat fakturan via sin egen mailklient (helper compose-mail)
+   * eller laddat ner PDF:en och bifogat själv. Skapas direkt som `sent` (med
+   * `sentAt`), ALDRIG `queued` — annars skulle server-runtime-dispatch-workern
+   * (#180) plocka upp den och skicka igen. AVA kan inte verifiera leverans här:
+   * "sent" = "användaren bekräftade att hen skickade".
+   */
+  recordManual: orgProcedure
+    .input(z.object({
+      invoiceId: z.string(),
+      channel: dispatchChannelSchema,
+      recipient: z.string().min(1),
+    }))
+    .mutation(async ({ ctx, input }) => {
+      await assertInvoiceInOrg(ctx, input.invoiceId);
+      const now = new Date();
+      return ctx.dataStore.invoiceDispatches.create({
+        data: {
+          invoiceId: asId<"InvoiceId">(input.invoiceId),
+          channel: input.channel,
+          recipient: input.recipient,
+          status: "sent",
+          queuedAt: now,
+          sentAt: now,
+          recordedById: asId<"UserId">(ctx.user.id),
+          createdAt: now,
+        },
+      });
+    }),
+
   updateStatus: orgProcedure
     .input(z.object({
       dispatchId: z.string(),

--- a/test/unit/app/invoices/send-invoice-modal.test.tsx
+++ b/test/unit/app/invoices/send-invoice-modal.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * Test för SendInvoiceModal (#179) — manuellt fakturautskick via helper/nedladdning
+ * + explicit "skickad"-bekräftelse som registrerar dispatch.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const recordMutate = vi.fn();
+const composeMail = vi.fn(async () => true);
+const downloadBytes = vi.fn();
+const renderFakturaPdf = vi.fn(async () => new Uint8Array([1, 2, 3]));
+let helperVersion: string | undefined | null = "helper-v1.0.0";
+
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: {
+    invoiceDispatch: {
+      recordManual: { useMutation: (opts: { onSuccess?: () => void }) => ({ mutate: (...a: unknown[]) => { recordMutate(...a); opts.onSuccess?.(); }, isPending: false, error: null }) },
+    },
+  },
+}));
+vi.mock("@/lib/client/helper/use-helper", () => ({
+  useHelper: () => ({ version: helperVersion, checked: true }),
+  composeMailViaHelper: (...a: unknown[]) => composeMail(...a),
+}));
+vi.mock("@/lib/client/download-text", () => ({ downloadBytes: (...a: unknown[]) => downloadBytes(...a) }));
+vi.mock("@/lib/client/kostnadsrakning/render-faktura-pdf", () => ({ renderFakturaPdf: (...a: unknown[]) => renderFakturaPdf(...a) }));
+
+import { SendInvoiceModal } from "@/app/invoices/[id]/_send-invoice-modal";
+
+const baseProps = {
+  invoiceId: "inv-1",
+  invoiceNumber: "F-2026-0001",
+  amount: 12_500,
+  ocrReference: "1234567894",
+  invoiceDate: "2026-06-13",
+  matterNumber: "2026-0001",
+  matterTitle: "Tvist",
+  onClose: vi.fn(),
+  onRecorded: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  helperVersion = "helper-v1.0.0";
+});
+
+describe("SendInvoiceModal", () => {
+  it("renderar rubrik + åtgärdsknappar", () => {
+    render(<SendInvoiceModal {...baseProps} />);
+    expect(screen.getByRole("heading", { name: /E-posta faktura/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Öppna i mailklient/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Ladda ner PDF/i })).toBeInTheDocument();
+  });
+
+  it("nedladdning genererar PDF + laddar ner, sedan visas bekräftelse", async () => {
+    render(<SendInvoiceModal {...baseProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /Ladda ner PDF/i }));
+    await waitFor(() => expect(downloadBytes).toHaveBeenCalled());
+    expect(renderFakturaPdf).toHaveBeenCalled();
+    expect(await screen.findByRole("button", { name: /Markera som skickad/i })).toBeInTheDocument();
+  });
+
+  it("helper tillgänglig → öppnar mailklient (compose-mail), ingen nedladdning", async () => {
+    render(<SendInvoiceModal {...baseProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /Öppna i mailklient/i }));
+    await waitFor(() => expect(composeMail).toHaveBeenCalled());
+    expect(downloadBytes).not.toHaveBeenCalled();
+  });
+
+  it("helper saknas → faller tillbaka på nedladdning", async () => {
+    helperVersion = null;
+    render(<SendInvoiceModal {...baseProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /Öppna i mailklient/i }));
+    await waitFor(() => expect(downloadBytes).toHaveBeenCalled());
+    expect(composeMail).not.toHaveBeenCalled();
+  });
+
+  it("bekräftelse registrerar dispatch — kanal 'manual' utan e-post", async () => {
+    render(<SendInvoiceModal {...baseProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /Ladda ner PDF/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /Markera som skickad/i }));
+    await waitFor(() => expect(recordMutate).toHaveBeenCalled());
+    expect(recordMutate.mock.calls[0]![0]).toMatchObject({ invoiceId: "inv-1", channel: "manual" });
+    expect(baseProps.onRecorded).toHaveBeenCalled();
+  });
+
+  it("kanal 'email' när en e-postadress angetts", async () => {
+    render(<SendInvoiceModal {...baseProps} />);
+    fireEvent.change(screen.getByPlaceholderText(/klient@/i), { target: { value: "k@x.se" } });
+    fireEvent.click(screen.getByRole("button", { name: /Ladda ner PDF/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /Markera som skickad/i }));
+    await waitFor(() => expect(recordMutate).toHaveBeenCalled());
+    expect(recordMutate.mock.calls[0]![0]).toMatchObject({ channel: "email", recipient: "k@x.se" });
+  });
+});

--- a/test/unit/server/routers/invoiceDispatch.test.ts
+++ b/test/unit/server/routers/invoiceDispatch.test.ts
@@ -45,6 +45,37 @@ describe("invoiceDispatch.queue + list", () => {
   });
 });
 
+describe("invoiceDispatch.recordManual (#179)", () => {
+  it("skapar ett utskick direkt som sent (med sentAt), aldrig queued", async () => {
+    const { caller } = makeCaller();
+    const d = await caller.invoiceDispatch.recordManual({ invoiceId: "inv-1", channel: "manual", recipient: "Manuellt utskick" });
+    expect(d.status).toBe("sent");
+    expect(d.sentAt).toBeTruthy();
+    expect(d.channel).toBe("manual");
+
+    // Får INTE dyka upp i listQueued (annars dubbel-skickar #180-workern).
+    const queued = await caller.invoiceDispatch.listQueued();
+    expect(queued.find((q) => q.id === d.id)).toBeUndefined();
+
+    const list = await caller.invoiceDispatch.list({ invoiceId: "inv-1" });
+    expect(list[0]!.status).toBe("sent");
+  });
+
+  it("e-postkanal med mottagaradress", async () => {
+    const { caller } = makeCaller();
+    const d = await caller.invoiceDispatch.recordManual({ invoiceId: "inv-1", channel: "email", recipient: "klient@x.se" });
+    expect(d.channel).toBe("email");
+    expect(d.recipient).toBe("klient@x.se");
+  });
+
+  it("nekar mot faktura i annan org (NOT_FOUND)", async () => {
+    const { caller } = makeCaller();
+    await expect(
+      caller.invoiceDispatch.recordManual({ invoiceId: "inv-foreign", channel: "manual", recipient: "x" }),
+    ).rejects.toThrow();
+  });
+});
+
 describe("invoiceDispatch.updateStatus", () => {
   it("queued → sent sätter sentAt + messageId (idempotent)", async () => {
     const { caller } = makeCaller();


### PR DESCRIPTION
## Vad

Fakturautskick **utan servermjukvara** (demo-tier / self-hosted utan server-runtime). Från faktura-detaljen kan advokaten:
1. **E-posta via sin egen mailklient** — helperns `compose-mail` öppnar Outlook/Apple Mail med PDF:en bifogad + förifylld mottagare/ämne/text. Mailet går från byråns egen e-post; ingen server, ingen tredjeparts-infra.
2. **Ladda ner PDF** som fallback (när ingen helper körs) och bifoga själv.

AVA registrerar utskicket i git-db:n (#178) **först vid explicit bekräftelse** ("Markera som skickad") — att öppna mailklienten är inte samma sak som att ha skickat (issuens fråga 2: undvik falska positiv).

## Hur

- **`invoiceDispatch.recordManual`** (ny mutation): skapar dispatch-raden direkt som `sent` (med `sentAt`), **aldrig `queued`** — annars skulle server-runtime-dispatch-workern (#180) plocka upp den och dubbel-skicka via SMTP. Org-scopad via faktura→ärende-joinen.
- **`_send-invoice-modal.tsx`**: `renderFakturaPdf` → `composeMailViaHelper` (om helper finns) annars `downloadBytes` → bekräftelse-knapp som registrerar dispatch (kanal `email` om e-postadress angetts, annars `manual`).
- **"E-posta faktura"-knapp** i `InvoiceActions` (utställd faktura, avbetalningsplan, eller kreditfaktura).
- **DRY:** `bytesToBase64` extraherad till `lib/client/bytes-base64.ts`; kostnadsräkning-modalen återanvänder den nu (tidigare lokal kopia).

## Bygger på (redan i main)

#178 (dispatch-modell: `invoiceDispatchSchema` + router) och helperns `compose-mail` (`composeMailViaHelper`). Detta är wiring + den saknade `recordManual`-vägen.

## Avgränsning (per issuen)

Ingen schemaläggning; varje utskick är manuellt. AVA kan inte verifiera leverans utan backend → "skickad" = "användaren bekräftade". Fungerar i demo + self-hosted utan server-runtime.

## Verifierat lokalt

- typecheck, `lint --max-warnings 0`, `lint:lib-complexity`, dep-cruiser (0 violations), jscpd (0.42%, tröskel 4.5%) — grönt
- nya tester: `recordManual` (sent direkt, ej i `listQueued`, org-scoping) + `SendInvoiceModal` (helper-väg, fallback-nedladdning, bekräftelse → kanal manual/email). Berörda sviter (invoices + matters): 76 pass.

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)