### PR TITLE
ci(tooling): bundle-size-budget som CI-grind (#14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,9 @@ jobs:
           bun-version: latest
       - run: bun install --frozen-lockfile
       - run: bun run build:demo
+      # Bundle-size-budget (#14): fäll om klient-JS:en svällt över budgeten.
+      # Återanvänder demo-bygget ovan (out/) — ingen extra build.
+      - run: bun run size
       - run: bun run e2e:install
       - name: Start docker + hämta bootstrappad admin-PAT
         run: |

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -45,6 +45,7 @@ lever som JSON i ett git-repo (se [`architecture.md`](./architecture.md)).
 | E2E-tester | Playwright (Chromium) | `tooling/config/playwright.config.ts`, `test/e2e/` |
 | Kodtäckning | `bun test --coverage` (lcov) + ratchet-skript | `tooling/scripts/check-coverage.ts` |
 | Duplikatdetektering (DRY) | jscpd | `tooling/config/jscpd.json` |
+| Bundle-size-budget | gzip-summa av klient-chunks + ratchet-skript | `tooling/scripts/check-bundle-size.ts` |
 | Arkitektur (SOLID/lager) | dependency-cruiser | `tooling/config/dependency-cruiser.cjs` |
 | Död kod / oanvända exports | knip | `tooling/config/knip.json` |
 | Pre-commit | husky + lint-staged | `.husky/pre-commit`, `package.json` |
@@ -137,6 +138,22 @@ ratchet-loosening — undvik den; bryt hellre ut funktionen. Antalet poster i
 |---|---|
 | Duplicerade kodblock | ≥ 8 rader / ≥ 80 tokens |
 | Procent duplikat | < 1.5 % av kodbasen |
+
+### Bundle-size (`bun run size`, #14)
+
+Browser-bundeln är tung (LLM opt-in, pdfjs/exceljs/mammoth, Temporal-polyfill).
+[`check-bundle-size.ts`](../tooling/scripts/check-bundle-size.ts) summerar alla
+statiska JS-chunks i demo-exporten (`out/`, kräver `bun run build:demo` först)
+**gzip-komprimerat** och faller om summan överstiger budgeten.
+
+| Mått | Gräns |
+|---|---|
+| Total klient-JS (gzip) | `BUDGET_KB` i skriptet (nu 3400 KB; baslinje ~3223 KB) |
+
+Budgeten är en **ratchet** (samma anda som coverage/complexity): den ligger
+strax över dagens siffra. Höj `BUDGET_KB` BARA när en ökning är medveten —
+lazy-loada annars tunga libs. CI kör `bun run size` direkt efter `build:demo`
+(återanvänder samma `out/`, ingen extra build).
 
 ### Arkitektur (`bun run deps:check`)
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "next build",
     "build:demo": "DEMO_BASE_PATH=/ava bash tooling/scripts/build-demo.sh",
     "build:demo-repo": "bun tooling/scripts/build-demo-repo.ts",
+    "size": "bun tooling/scripts/check-bundle-size.ts",
     "demo:generate": "bun tooling/demo-generator/generate.ts",
     "demo:serve": "bash tooling/scripts/demo-serve.sh",
     "demo:serve:fast": "SKIP_BUILD=1 bash tooling/scripts/demo-serve.sh",

--- a/tooling/scripts/check-bundle-size.ts
+++ b/tooling/scripts/check-bundle-size.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env bun
+/**
+ * Bundle-size-budget (#14) — fäller om klient-JS:en sväller tyst.
+ *
+ * Mäter summan av alla statiska JS-chunks i demo-exporten (`out/`, byggd med
+ * `bun run build:demo`) gzip-komprimerat och jämför mot en budget. CI kör detta
+ * efter build:demo. Budgeten är en RATCHET i samma anda som coverage/lint
+ * (`docs/quality.md`): den ligger strax över dagens siffra och justeras BARA
+ * när en ökning är medveten — aldrig som genväg för att landa kod.
+ *
+ * Inget extra npm-beroende (size-limit drar in en stor transitiv graf) — Bun
+ * har gzip inbyggt, och vi äger tröskeln själva (jfr check-coverage.ts).
+ */
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import { gzipSync } from "node:zlib";
+import { join } from "node:path";
+
+/** Total gzip-budget för all statisk klient-JS (KB). Dagens nivå ~3164 KB. */
+const BUDGET_KB = 3400;
+
+/** Leta upp Next:s chunk-katalog under out/ (basePath-oberoende). */
+async function findChunksDir(root: string): Promise<string | null> {
+  const candidates = [join(root, "out", "_next", "static", "chunks")];
+  // basePath-build (DEMO_BASE_PATH) lägger ibland assets under out/<base>/_next.
+  try {
+    for (const entry of await readdir(join(root, "out"))) {
+      candidates.push(join(root, "out", entry, "_next", "static", "chunks"));
+    }
+  } catch {
+    // out/ saknas → hanteras av anroparen.
+  }
+  for (const dir of candidates) {
+    try {
+      if ((await stat(dir)).isDirectory()) return dir;
+    } catch {
+      /* nästa kandidat */
+    }
+  }
+  return null;
+}
+
+/** Alla .js-filer i en katalog (icke-rekursivt; Next lägger chunks platt). */
+async function jsFiles(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  for (const name of await readdir(dir)) {
+    if (name.endsWith(".js")) out.push(join(dir, name));
+  }
+  return out;
+}
+
+interface Measured {
+  count: number;
+  gzipKb: number;
+  biggest: { name: string; gzipKb: number } | null;
+}
+
+async function measure(dir: string): Promise<Measured> {
+  const files = await jsFiles(dir);
+  let total = 0;
+  let biggest: Measured["biggest"] = null;
+  for (const file of files) {
+    const gz = gzipSync(await readFile(file)).byteLength;
+    total += gz;
+    if (!biggest || gz > biggest.gzipKb * 1024) {
+      biggest = { name: file.split("/").pop() ?? file, gzipKb: gz / 1024 };
+    }
+  }
+  return { count: files.length, gzipKb: total / 1024, biggest };
+}
+
+async function main(): Promise<void> {
+  const root = process.cwd();
+  const dir = await findChunksDir(root);
+  if (!dir) {
+    console.error("✗ hittade ingen out/_next/static/chunks — kör `bun run build:demo` först.");
+    process.exit(1);
+  }
+
+  const m = await measure(dir);
+  const pct = ((m.gzipKb / BUDGET_KB) * 100).toFixed(1);
+  console.log(`Bundle-size (#14): ${m.count} JS-chunks, ${m.gzipKb.toFixed(1)} KB gzip`);
+  if (m.biggest) console.log(`  största chunk: ${m.biggest.name} (${m.biggest.gzipKb.toFixed(1)} KB gzip)`);
+  console.log(`  budget: ${BUDGET_KB} KB  (${pct} % använt)`);
+
+  if (m.gzipKb > BUDGET_KB) {
+    console.error(
+      `✗ klient-JS ${m.gzipKb.toFixed(1)} KB > budget ${BUDGET_KB} KB.\n` +
+        "  Bundeln har svällt. Lazy-loada tunga libs (pdfjs/exceljs/mammoth/LLM)\n" +
+        "  eller, om ökningen är medveten, höj BUDGET_KB i tooling/scripts/check-bundle-size.ts.",
+    );
+    process.exit(1);
+  }
+  console.log("✓ inom budget.");
+}
+
+await main();


### PR DESCRIPTION
## Vad

Browser-bundeln är tung (LLM opt-in, pdfjs/exceljs/mammoth, `@js-temporal/polyfill`) och kunde svälla tyst. Den här PR:en lägger en **bundle-size-budget gat:ad i CI**.

`tooling/scripts/check-bundle-size.ts` summerar alla statiska JS-chunks i demo-exporten (`out/`) **gzip-komprimerat** och faller om summan överstiger budgeten.

- **Budget:** `BUDGET_KB = 3400` (baslinje uppmätt ~**3223 KB** gzip → ~5,5 % headroom).
- **Inget nytt npm-beroende:** `size-limit` drar in en stor transitiv graf. Vi äger tröskeln själva via ett litet ratchet-skript — exakt samma mönster som `check-coverage.ts` / `check-lib-complexity-strict.ts` — med `node:zlib` gzip.
- **CI:** `bun run size` körs direkt efter `bun run build:demo` (i E2E-jobbet) → återanvänder samma `out/`, ingen extra build.
- **Ratchet:** höj `BUDGET_KB` bara när en ökning är medveten; lazy-loada annars tunga libs. Dokumenterat i `docs/quality.md`.

## Verifierat lokalt

```
$ bun run build:demo && bun run size
Bundle-size (#14): 80 JS-chunks, 3223.2 KB gzip
  största chunk: 16g7xyn3av-aq.js (2112.9 KB gzip)   ← lazy pdf/xlsx/LLM
  budget: 3400 KB  (94.8 % använt)
✓ inom budget.
```

- typecheck, `lint --max-warnings 0`, dep-cruiser (0 violations), knip (skriptet ej flaggat — `tooling/scripts/*.ts` är entry) — grönt.

> Den största chunken (~2,1 MB gzip) är de lazy-laddade tunga libsen (pdfjs/exceljs/mammoth/LLM) — de räknas in i totalen så att budgeten fångar även om de råkar bli eager-laddade.

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)