### PR TITLE
feat(billing): förväntad domstolsbetalning utan faktura (#173)

### DIFF
--- a/src/app/matters/[id]/_client.tsx
+++ b/src/app/matters/[id]/_client.tsx
@@ -8,6 +8,7 @@ import { DocumentBrowser } from "@/components/documents/document-browser";
 import { SuggestionsPanel } from "@/components/matter/suggestions-panel";
 import { EventsPanel } from "@/components/matter/events-panel";
 import { PaymentMethodCard } from "@/components/matter/payment-method-card";
+import { ExpectedReceivablesSection } from "./_expected-receivables-section";
 import { FileDown } from "lucide-react";
 import { ContactsSection } from "./_contacts-section";
 import { TimeSection } from "./_time-section";
@@ -17,6 +18,11 @@ import { GenerateModal } from "./_generate-modal";
 import { useRouteId } from "@/lib/client/demo/use-route-id";
 
  
+/** Ärendets målnummer som sträng (getById-typen saknar fältet i select-typen). */
+function courtCaseOf(m: unknown): string {
+  return (m as { courtCaseNumber?: string | null }).courtCaseNumber ?? "";
+}
+
 export default function MatterDetailClient({ id: paramId }: { id: string }) {
   // Static export serverar en sentinel-shell för nya id:n → läs riktiga
   // id:t ur URL:en (faller tillbaka till build-time-param i server-mode).
@@ -58,6 +64,7 @@ export default function MatterDetailClient({ id: paramId }: { id: string }) {
         <ContactsSection matterId={id} contacts={m.contacts} />
         <DocumentBrowser matterId={id} />
         <BillingPanel matterId={id} matter={m} />
+        <ExpectedReceivablesSection matterId={id} courtCaseNumber={courtCaseOf(m)} />
         <TimeSection matterId={id} isTaxeArende={m.isTaxeArende} />
         <ExpenseSection matterId={id} isTaxeArende={m.isTaxeArende} />
       </div>

--- a/src/app/matters/[id]/_expected-receivables-section.tsx
+++ b/src/app/matters/[id]/_expected-receivables-section.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+/**
+ * Förväntade domstolsbetalningar utan faktura (#173) på ärende-sidan.
+ *
+ * Registrera en kostnadsräkning som väntar på utbetalning (Domstolsverket),
+ * pricka av faktiskt utbetalt belopp (3b-ii: begärt är memo, utbetalt bokas),
+ * och redigera ärendets målnummer (matchningsnyckel för avprickningen, #175).
+ */
+
+import { useId, useState } from "react";
+import { trpc } from "@/lib/client/trpc";
+import { formatCurrency } from "@/lib/client/utils";
+
+interface Receivable {
+  id: string;
+  description: string;
+  expectedAmount: number;
+  status: string;
+  settledAmount?: number | null;
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  PENDING: "Väntar",
+  SETTLED: "Mottagen",
+  CANCELLED: "Avbruten",
+};
+
+/** Inline-redigering av ärendets målnummer (domstolens referens). */
+function CourtCaseNumberField({ matterId, value }: { matterId: string; value: string }) {
+  const id = useId();
+  const [text, setText] = useState(value);
+  const utils = trpc.useUtils();
+  const update = trpc.matter.update.useMutation({
+    onSuccess: () => void utils.matter.getById.invalidate({ id: matterId }),
+  });
+  return (
+    <div className="flex items-end gap-2 mb-4">
+      <div className="flex-1">
+        <label htmlFor={id} className="block text-xs font-medium text-gray-500 mb-1">Domstolens målnummer</label>
+        <input id={id} value={text} onChange={(e) => setText(e.target.value)} placeholder="t.ex. B 1234-26"
+          className="w-full rounded border border-gray-300 px-2 py-1.5 text-sm font-mono" />
+      </div>
+      <button onClick={() => update.mutate({ id: matterId, courtCaseNumber: text || null })}
+        disabled={update.isPending || text === value}
+        className="px-3 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50">
+        Spara målnummer
+      </button>
+    </div>
+  );
+}
+
+/** Formulär för att registrera en ny förväntad domstolsbetalning. */
+function AddReceivableForm({ matterId, onAdded }: { matterId: string; onAdded: () => void }) {
+  const descId = useId();
+  const amtId = useId();
+  const [desc, setDesc] = useState("");
+  const [kr, setKr] = useState("");
+  const create = trpc.expectedReceivable.create.useMutation({
+    onSuccess: () => { setDesc(""); setKr(""); onAdded(); },
+  });
+  const submit = () =>
+    create.mutate({ matterId, description: desc, expectedAmount: Math.round(Number(kr) * 100) });
+  return (
+    <div className="border-t pt-3 mt-3 space-y-2">
+      <input value={desc} onChange={(e) => setDesc(e.target.value)} aria-labelledby={descId}
+        placeholder="Kostnadsräkning t.ex. Svea HovR mål B 1234-26"
+        className="w-full rounded border border-gray-300 px-2 py-1.5 text-sm" />
+      <div className="flex gap-2">
+        <input value={kr} onChange={(e) => setKr(e.target.value)} type="number" aria-labelledby={amtId}
+          placeholder="Begärt belopp (kr)"
+          className="flex-1 rounded border border-gray-300 px-2 py-1.5 text-sm" />
+        <button onClick={submit} disabled={create.isPending || !desc || !kr}
+          className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50">
+          Lägg till fordran
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** En fordran-rad med avprickning (markera mottagen) / avbryt. */
+function ReceivableRow({ r, onChanged }: { r: Receivable; onChanged: () => void }) {
+  const [kr, setKr] = useState("");
+  const settle = trpc.expectedReceivable.settle.useMutation({ onSuccess: onChanged });
+  const cancel = trpc.expectedReceivable.cancel.useMutation({ onSuccess: onChanged });
+  return (
+    <li className="py-2 text-sm">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-gray-800">{r.description}</span>
+        <span className="text-xs rounded-full bg-gray-100 text-gray-600 px-2 py-0.5">{STATUS_LABEL[r.status] ?? r.status}</span>
+      </div>
+      <div className="text-xs text-gray-500 mt-0.5">
+        Begärt: <span className="font-mono">{formatCurrency(r.expectedAmount)}</span>
+        {r.status === "SETTLED" && r.settledAmount != null && (
+          <> · Mottaget: <span className="font-mono text-green-700">{formatCurrency(r.settledAmount)}</span></>
+        )}
+      </div>
+      {r.status === "PENDING" && (
+        <div className="flex gap-2 mt-1.5">
+          <input value={kr} onChange={(e) => setKr(e.target.value)} type="number" placeholder="Utbetalt (kr)"
+            className="w-32 rounded border border-gray-300 px-2 py-1 text-sm" />
+          <button onClick={() => settle.mutate({ id: r.id, settledAmount: Math.round(Number(kr) * 100) })}
+            disabled={settle.isPending || !kr}
+            className="px-2 py-1 text-xs bg-green-600 text-white rounded hover:bg-green-700 disabled:opacity-50">
+            Markera mottagen
+          </button>
+          <button onClick={() => cancel.mutate({ id: r.id })} disabled={cancel.isPending}
+            className="px-2 py-1 text-xs border border-gray-300 rounded hover:bg-gray-50">
+            Avbryt
+          </button>
+        </div>
+      )}
+    </li>
+  );
+}
+
+export function ExpectedReceivablesSection({ matterId, courtCaseNumber }: { matterId: string; courtCaseNumber: string }) {
+  const list = trpc.expectedReceivable.list.useQuery({ matterId });
+  const utils = trpc.useUtils();
+  const refetch = () => void utils.expectedReceivable.list.invalidate({ matterId });
+  const rows = (list.data ?? []) as Receivable[];
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6">
+      <h2 className="font-semibold text-gray-900 mb-1">Domstolsbetalningar (utan faktura)</h2>
+      <p className="text-xs text-gray-500 mb-3">
+        Kostnadsräkningar som domstolen betalar. Begärt belopp är ett memo — det
+        domstolen faktiskt betalar bokas vid avprickning.
+      </p>
+      <CourtCaseNumberField matterId={matterId} value={courtCaseNumber} />
+      {rows.length > 0 ? (
+        <ul className="divide-y divide-gray-100">
+          {rows.map((r) => <ReceivableRow key={r.id} r={r} onChanged={refetch} />)}
+        </ul>
+      ) : (
+        <p className="text-xs text-gray-400">Inga registrerade ännu.</p>
+      )}
+      <AddReceivableForm matterId={matterId} onAdded={refetch} />
+    </div>
+  );
+}

--- a/src/app/matters/page.tsx
+++ b/src/app/matters/page.tsx
@@ -76,6 +76,7 @@ function MattersContent() {
   const matterTypeId = useId();
   const descriptionId = useId();
   const responsibleId = useId();
+  const courtCaseId = useId();
 
   const matters = trpc.matter.list.useQuery({
     search,
@@ -102,6 +103,7 @@ function MattersContent() {
     matterType: "",
     klientId: "",
     responsibleLawyerId: "",
+    courtCaseNumber: "",
     isTaxeArende: false,
   });
 
@@ -113,6 +115,7 @@ function MattersContent() {
       matterType: form.matterType || undefined,
       klientId: form.klientId || undefined,
       responsibleLawyerId: form.responsibleLawyerId || undefined,
+      courtCaseNumber: form.courtCaseNumber || undefined,
       isTaxeArende: form.isTaxeArende || undefined,
     });
   }
@@ -169,6 +172,14 @@ function MattersContent() {
                 ))}
               </select>
               <p className="mt-1 text-xs text-gray-500">Styr ärendenummerserien (juristens prefix).</p>
+            </div>
+            <div>
+              <label htmlFor={courtCaseId} className="block text-sm font-medium text-gray-700 mb-1">Domstolens målnummer</label>
+              <input id={courtCaseId} type="text" value={form.courtCaseNumber}
+                onChange={(e) => setForm({ ...form, courtCaseNumber: e.target.value })}
+                placeholder="t.ex. B 1234-26 (valfritt)"
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm font-mono" />
+              <p className="mt-1 text-xs text-gray-500">Matchningsnyckel för domstolsbetalningar (#173).</p>
             </div>
             <div className="md:col-span-2">
               <label htmlFor={descriptionId} className="block text-sm font-medium text-gray-700 mb-1">Beskrivning</label>

--- a/src/lib/server/data-store/DemoDataStore.ts
+++ b/src/lib/server/data-store/DemoDataStore.ts
@@ -46,6 +46,7 @@ import type {
   PaymentDelegate,
   WriteOffDelegate,
   InvoiceDispatchDelegate,
+  ExpectedReceivableDelegate,
   PaymentPlanDelegate,
   AccontoDeductionDelegate,
   BillingRunDelegate,
@@ -79,6 +80,7 @@ export class DemoDataStore implements IDataStore {
   readonly payments: PaymentDelegate;
   readonly writeOffs: WriteOffDelegate;
   readonly invoiceDispatches: InvoiceDispatchDelegate;
+  readonly expectedReceivables: ExpectedReceivableDelegate;
   readonly paymentPlans: PaymentPlanDelegate;
   readonly paymentPlanReminders: Delegate;
   readonly accontoDeductions: AccontoDeductionDelegate;
@@ -132,6 +134,7 @@ export class DemoDataStore implements IDataStore {
     this.payments = this.makeDelegate("payments") as unknown as PaymentDelegate;
     this.writeOffs = this.makeDelegate("writeOffs") as unknown as WriteOffDelegate;
     this.invoiceDispatches = this.makeDelegate("invoiceDispatches", relations.invoiceDispatches) as unknown as InvoiceDispatchDelegate;
+    this.expectedReceivables = this.makeDelegate("expectedReceivables") as unknown as ExpectedReceivableDelegate;
     this.paymentPlans = this.makeDelegate("paymentPlans", relations.paymentPlans) as unknown as PaymentPlanDelegate;
     this.paymentPlanReminders = this.makeDelegate("paymentPlanReminders") as unknown as Delegate;
     this.accontoDeductions = this.makeDelegate("accontoDeductions") as unknown as AccontoDeductionDelegate;
@@ -223,6 +226,7 @@ export class DemoDataStore implements IDataStore {
       payments: "payment",
       writeOffs: "writeOff",
       invoiceDispatches: "invoiceDispatch",
+      expectedReceivables: "expectedReceivable",
       paymentPlans: "paymentPlan",
       paymentPlanReminders: "paymentPlanReminder",
       accontoDeductions: "accontoDeduction",
@@ -296,6 +300,7 @@ export class DemoDataStore implements IDataStore {
       payments: this.payments,
       writeOffs: this.writeOffs,
       invoiceDispatches: this.invoiceDispatches,
+      expectedReceivables: this.expectedReceivables,
       paymentPlans: this.paymentPlans,
       accontoDeductions: this.accontoDeductions,
       billingRuns: this.billingRuns,

--- a/src/lib/server/data-store/IDataStore.ts
+++ b/src/lib/server/data-store/IDataStore.ts
@@ -18,6 +18,7 @@ import type {
   DocumentTemplate, DocumentAnalysisSuggestion, MatterEventSuggestion,
   Invoice, TimeEntry, Expense, User, Organization, Office, ConflictCheck,
   Payment, PaymentPlan, AccontoDeduction, BillingRun, WriteOff, InvoiceDispatch,
+  ExpectedReceivable,
   CalendarEvent, Task,
 } from "@/lib/shared/schemas";
 
@@ -130,6 +131,7 @@ export type ConflictCheckDelegate = Delegate<ConflictCheck>;
 export type PaymentDelegate = Delegate<Payment>;
 export type WriteOffDelegate = Delegate<WriteOff>;
 export type InvoiceDispatchDelegate = Delegate<InvoiceDispatch>;
+export type ExpectedReceivableDelegate = Delegate<ExpectedReceivable>;
 export type PaymentPlanDelegate = Delegate<PaymentPlan>;
 export type AccontoDeductionDelegate = Delegate<AccontoDeduction>;
 export type BillingRunDelegate = Delegate<BillingRun>;
@@ -185,6 +187,7 @@ export interface DataStoreTx {
   payments: PaymentDelegate;
   writeOffs: WriteOffDelegate;
   invoiceDispatches: InvoiceDispatchDelegate;
+  expectedReceivables: ExpectedReceivableDelegate;
   paymentPlans: PaymentPlanDelegate;
   accontoDeductions: AccontoDeductionDelegate;
   billingRuns: BillingRunDelegate;
@@ -222,6 +225,7 @@ export interface IDataStore {
   readonly payments: PaymentDelegate;
   readonly writeOffs: WriteOffDelegate;
   readonly invoiceDispatches: InvoiceDispatchDelegate;
+  readonly expectedReceivables: ExpectedReceivableDelegate;
   readonly paymentPlans: PaymentPlanDelegate;
   readonly paymentPlanReminders: Delegate;
   readonly accontoDeductions: AccontoDeductionDelegate;

--- a/src/lib/server/local-first/projections/default-registry.ts
+++ b/src/lib/server/local-first/projections/default-registry.ts
@@ -40,6 +40,7 @@ export function buildDefaultRegistry(): ProjectionRegistry {
   // händelser hydrerades inte vid restore → "Inga billingruns ännu" efter reload.
   r.register({ entity: "billingRun", projection: new GenericProjection("billing-runs"), ownsPath: (p) => p.startsWith("billing-runs/") });
   r.register({ entity: "accontoDeduction", projection: new GenericProjection("acconto-deductions"), ownsPath: (p) => p.startsWith("acconto-deductions/") });
+  r.register({ entity: "expectedReceivable", projection: new GenericProjection("expected-receivables"), ownsPath: (p) => p.startsWith("expected-receivables/") });
   r.register({ entity: "task", projection: new GenericProjection("tasks"), ownsPath: (p) => p.startsWith("tasks/") });
   r.register({ entity: "conflictCheck", projection: new GenericProjection("conflict-checks"), ownsPath: (p) => p.startsWith("conflict-checks/") });
   r.register({ entity: "documentTemplate", projection: new GenericProjection(".ava/templates"), ownsPath: (p) => p.startsWith(".ava/templates/") });

--- a/src/lib/server/routers/_app.ts
+++ b/src/lib/server/routers/_app.ts
@@ -11,6 +11,7 @@ import { organizationRouter } from "./organization";
 import { reportsRouter } from "./reports";
 import { invoiceRouter } from "./invoice";
 import { invoiceDispatchRouter } from "./invoiceDispatch";
+import { expectedReceivableRouter } from "./expectedReceivable";
 import { billingRunRouter } from "./billingRun";
 import { paymentPlanRouter } from "./paymentPlan";
 import { kostnadsrakningRouter } from "./kostnadsrakning";
@@ -32,6 +33,7 @@ export const appRouter = router({
   reports: reportsRouter,
   invoice: invoiceRouter,
   invoiceDispatch: invoiceDispatchRouter,
+  expectedReceivable: expectedReceivableRouter,
   billingRun: billingRunRouter,
   paymentPlan: paymentPlanRouter,
   kostnadsrakning: kostnadsrakningRouter,

--- a/src/lib/server/routers/expectedReceivable.ts
+++ b/src/lib/server/routers/expectedReceivable.ts
@@ -1,0 +1,131 @@
+/**
+ * Förväntade domstolsbetalningar utan faktura (#173).
+ *
+ * En `ExpectedReceivable` är en kostnadsräkning till domstol som Domstolsverket
+ * betalar — det finns ingen AVA-faktura att pricka av mot. Försiktighetsprincip
+ * (3b-ii): `expectedAmount` är ett memo (begärt), `settledAmount` (det domstolen
+ * faktiskt betalar) är det som bokas. `settle` registrerar utfallet; skillnaden
+ * (prutning) bokförs varken som intäkt eller kundförlust.
+ *
+ * Org-scopad via raden (`organizationId`) + ärendekoppling (`matterId`).
+ * Den AUTOMATISKA camt-fri-text-matchningen (målnummer → settle) är #175;
+ * här finns den manuella registreringen + avprickningen.
+ */
+
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { router, orgProcedure } from "../trpc";
+import { asId } from "@/lib/shared/schemas/ids";
+import { expectedReceivableStatusSchema } from "@/lib/shared/schemas/billing";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
+
+type Ctx = { dataStore: { expectedReceivables: { findUnique: (a: unknown) => Promise<unknown> } }; orgId: string };
+
+/** Hämta en fordran och verifiera org-tillhörighet. */
+async function assertInOrg(ctx: Ctx, id: string): Promise<{ id: string; status: string }> {
+  const row = (await ctx.dataStore.expectedReceivables.findUnique({ where: { id } })) as
+    | { id: string; organizationId?: string; status: string }
+    | null;
+  if (!row || row.organizationId !== ctx.orgId) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Fordran finns inte i organisationen." });
+  }
+  return row;
+}
+
+export const expectedReceivableRouter = router({
+  /** Lista fordringar i org:en, valfritt filtrerat på ärende. */
+  list: orgProcedure
+    .input(z.object({ matterId: z.string().optional() }).optional())
+    .query(async ({ ctx, input }) => {
+      return ctx.dataStore.expectedReceivables.findMany({
+        where: {
+          organizationId: ctx.orgId,
+          ...(input?.matterId ? { matterId: input.matterId } : {}),
+        },
+        orderBy: { createdAt: "desc" },
+      });
+    }),
+
+  /** Registrera en förväntad domstolsbetalning (status PENDING). */
+  create: orgProcedure
+    .input(z.object({
+      matterId: z.string(),
+      description: z.string().min(1),
+      expectedAmount: z.number().int().nonnegative(),
+    }))
+    .mutation(async ({ ctx, input }) => {
+      // Ärendet måste tillhöra org:en (annars läcker man fordringar in i andra byråer).
+      const matter = await ctx.dataStore.matters.findFirst({
+        where: { id: input.matterId, organizationId: ctx.orgId },
+      });
+      if (!matter) throw new TRPCError({ code: "NOT_FOUND", message: "Ärendet finns inte i organisationen." });
+
+      const now = new Date();
+      return ctx.dataStore.expectedReceivables.create({
+        data: {
+          matterId: asId<"MatterId">(input.matterId),
+          description: input.description,
+          expectedAmount: input.expectedAmount,
+          status: "PENDING",
+          organizationId: asId<"OrganizationId">(ctx.orgId),
+          recordedById: asId<"UserId">(ctx.user.id),
+          createdAt: now,
+          updatedAt: now,
+        },
+      });
+    }),
+
+  /**
+   * Pricka av: registrera FAKTISKT utbetalt belopp (3b-ii). Idempotent på
+   * `paymentReference` — en redan avprickad betalning (samma externalId)
+   * skrivs inte två gånger (camt-peern, #175, kan köra om samma fil).
+   */
+  settle: orgProcedure
+    .input(z.object({
+      id: z.string(),
+      settledAmount: z.number().int().nonnegative(),
+      settledAt: z.string().optional(),
+      paymentReference: z.string().optional(),
+    }))
+    .mutation(async ({ ctx, input }) => {
+      await assertInOrg(ctx, input.id);
+      return ctx.dataStore.expectedReceivables.update({
+        where: { id: input.id },
+        data: {
+          status: "SETTLED",
+          settledAmount: input.settledAmount,
+          settledAt: input.settledAt ? new Date(input.settledAt) : new Date(),
+          ...(input.paymentReference !== undefined ? { paymentReference: input.paymentReference } : {}),
+          updatedAt: new Date(),
+        },
+      });
+    }),
+
+  /** Avbryt en fordran (t.ex. felregistrerad eller domstolen avslog helt). */
+  cancel: orgProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      await assertInOrg(ctx, input.id);
+      return ctx.dataStore.expectedReceivables.update({
+        where: { id: input.id },
+        data: { status: "CANCELLED", updatedAt: new Date() },
+      });
+    }),
+
+  /** Uppdatera memo-fälten (begärt belopp/beskrivning) medan PENDING. */
+  update: orgProcedure
+    .input(z.object({
+      id: z.string(),
+      description: z.string().min(1).optional(),
+      expectedAmount: z.number().int().nonnegative().optional(),
+      status: expectedReceivableStatusSchema.optional(),
+    }))
+    .mutation(async ({ ctx, input }) => {
+      await assertInOrg(ctx, input.id);
+      const { id, ...rest } = input;
+      return ctx.dataStore.expectedReceivables.update({
+        where: { id },
+        data: { ...omitUndefined(rest), updatedAt: new Date() },
+      });
+    }),
+});

--- a/src/lib/server/routers/matter.ts
+++ b/src/lib/server/routers/matter.ts
@@ -53,6 +53,8 @@ const matterCreateInput = z.object({
   taxaHasFTax: z.boolean().nullable().optional(),
   /** Ansvarig advokat/biträdande jurist (#174) — styr ärendenummerserien. */
   responsibleLawyerId: z.string().optional(),
+  /** Domstolens målnummer (#173) — matchningsnyckel för domstolsbetalningar. */
+  courtCaseNumber: z.string().optional(),
   /** Historiskt skapad-datum (demo-generator/fixtures, ADR 0003) — annars now(). */
   createdAt: z.string().optional(),
   klientId: z.string().optional(),
@@ -126,6 +128,7 @@ function buildMatterData(
   const optional: Record<string, unknown> = {
     id: input.id,
     responsibleLawyerId,
+    courtCaseNumber: input.courtCaseNumber,
     paymentMethod: input.paymentMethod,
     paymentMethodNote: input.paymentMethodNote,
     paymentMethodDecidedAt: toDateOrNull(input.paymentMethodDecidedAt),
@@ -251,6 +254,8 @@ export const matterRouter = router({
         matterType: z.string().optional(),
         /** Byt ansvarig jurist (#174). Befintligt ärendenummer ändras EJ. */
         responsibleLawyerId: z.string().nullable().optional(),
+        /** Domstolens målnummer (#173) — för avprickning av domstolsbetalningar. */
+        courtCaseNumber: z.string().nullable().optional(),
         paymentMethod: z
           .enum(["PENDING", "RATTSHJALP", "RATTSSKYDD", "OFFENTLIG_FORSVARARE", "PRIVAT", "MIX"])
           .optional(),

--- a/src/lib/shared/demo-source.ts
+++ b/src/lib/shared/demo-source.ts
@@ -39,6 +39,7 @@ export interface DemoSource {
   billingRuns?: readonly Record<string, unknown>[];
   writeOffs?: readonly Record<string, unknown>[];
   invoiceDispatches?: readonly Record<string, unknown>[];
+  expectedReceivables?: readonly Record<string, unknown>[];
   calendarEvents?: readonly Record<string, unknown>[];
   tasks?: readonly Record<string, unknown>[];
   userPreferences?: readonly Record<string, unknown>[];

--- a/src/lib/shared/schemas/billing.ts
+++ b/src/lib/shared/schemas/billing.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { baseFields, dateLike, optionalDateLike } from "./common";
+import { baseFields, orgScopedFields, dateLike, optionalDateLike } from "./common";
 import {
   billingRunRecipientSchema,
   billingRunStatusSchema,
@@ -21,6 +21,7 @@ import {
   billingRunIdSchema,
   writeOffIdSchema,
   invoiceDispatchIdSchema,
+  expectedReceivableIdSchema,
   matterIdSchema,
   userIdSchema,
 } from "./ids";
@@ -293,3 +294,40 @@ export const billingRunSchema = z.object({
 }).passthrough();
 
 export type BillingRun = z.infer<typeof billingRunSchema>;
+
+/**
+ * ExpectedReceivable (#173) — en FÖRVÄNTAD inbetalning utan faktura, typiskt
+ * en kostnadsräkning till domstol som Domstolsverket betalar. Det finns ingen
+ * AVA-faktura att pricka av mot, betalaren anger ärende-/målnummer (ej OCR),
+ * och utbetalt belopp kan avvika från begärt (domstolen prutar).
+ *
+ * Bokföringsmodell (beslut, #173): **försiktighetsprincipen (3b-ii)** — vi
+ * bokar BARA det domstolen faktiskt betalar. `expectedAmount` är ett memo (vad
+ * kostnadsräkningen begärde, för uppföljning), inte en bokförd fordran;
+ * `settledAmount` är det som faktiskt kom in. Skillnaden (prutning) bokförs
+ * varken som intäkt eller kundförlust — den är bara "begärt minus utfall".
+ *
+ * Separat entitet (INTE en faktura-typ): ingen PDF, inget fakturanummer,
+ * ingen OCR, ingen Fortnox-push. Org-scopad + kopplad till ett ärende.
+ */
+export const expectedReceivableStatusSchema = z.enum(["PENDING", "SETTLED", "CANCELLED"]);
+export type ExpectedReceivableStatus = z.infer<typeof expectedReceivableStatusSchema>;
+
+export const expectedReceivableSchema = z.object({
+  ...orgScopedFields,
+  id: expectedReceivableIdSchema,
+  matterId: matterIdSchema,
+  /** Kort beskrivning, t.ex. "Kostnadsräkning Svea HovR mål B 1234-26". */
+  description: z.string().min(1),
+  /** Begärt belopp (öre) — MEMO, ej bokförd fordran (försiktighetsprincip). */
+  expectedAmount: z.number().int().nonnegative(),
+  status: expectedReceivableStatusSchema.default("PENDING"),
+  /** Faktiskt utbetalt (öre) — sätts vid avprickning. Detta är det som "bokas". */
+  settledAmount: z.number().int().nonnegative().nullish(),
+  settledAt: optionalDateLike,
+  /** Bankbetalningens externalId (idempotens vid camt-avprickning, #175). */
+  paymentReference: z.string().nullish(),
+  recordedById: userIdSchema,
+}).passthrough();
+
+export type ExpectedReceivable = z.infer<typeof expectedReceivableSchema>;

--- a/src/lib/shared/schemas/ids.ts
+++ b/src/lib/shared/schemas/ids.ts
@@ -83,6 +83,9 @@ export type WriteOffId = z.infer<typeof writeOffIdSchema>;
 export const invoiceDispatchIdSchema = brandedId<"InvoiceDispatchId">();
 export type InvoiceDispatchId = z.infer<typeof invoiceDispatchIdSchema>;
 
+export const expectedReceivableIdSchema = brandedId<"ExpectedReceivableId">();
+export type ExpectedReceivableId = z.infer<typeof expectedReceivableIdSchema>;
+
 export const documentTemplateIdSchema = brandedId<"DocumentTemplateId">();
 export type DocumentTemplateId = z.infer<typeof documentTemplateIdSchema>;
 

--- a/src/lib/shared/schemas/index.ts
+++ b/src/lib/shared/schemas/index.ts
@@ -34,6 +34,7 @@ import {
   billingRunSchema,
   writeOffSchema,
   invoiceDispatchSchema,
+  expectedReceivableSchema,
 } from "./billing";
 import { documentTemplateSchema, conflictCheckSchema } from "./misc";
 import { calendarEventSchema, taskSchema } from "./calendar";
@@ -197,6 +198,12 @@ export const ENTITY_REGISTRY: Record<string, EntityEntry> = {
     gitPrefix: "invoice-dispatches",
     sourceKey: "invoiceDispatches",
   },
+  expectedReceivable: {
+    schema: expectedReceivableSchema,
+    gitPath: p((id) => `expected-receivables/${id}.json`),
+    gitPrefix: "expected-receivables",
+    sourceKey: "expectedReceivables",
+  },
   documentTemplate: {
     schema: documentTemplateSchema,
     gitPath: p((id) => `.ava/templates/${id}.json`),
@@ -243,6 +250,7 @@ export type EntityName =
   | "document" | "documentFolder" | "documentAnalysisSuggestion" | "matterEventSuggestion"
   | "timeEntry" | "expense" | "invoice" | "payment" | "paymentPlan"
   | "paymentPlanReminder" | "accontoDeduction" | "billingRun" | "writeOff"
+  | "invoiceDispatch" | "expectedReceivable"
   | "documentTemplate" | "conflictCheck"
   | "calendarEvent" | "task"
   | "userPreference" | "orgPreference";

--- a/src/lib/shared/schemas/matter.ts
+++ b/src/lib/shared/schemas/matter.ts
@@ -18,6 +18,12 @@ export const matterSchema = z.object({
    * serie utan prefix (`2026-0001`, bakåtkompatibelt).
    */
   responsibleLawyerId: userIdSchema.nullish(),
+  /**
+   * Domstolens målnummer (#173/#175) — matchningsnyckel för avprickning av
+   * domstolsbetalningar utan OCR (Domstolsverket anger målnummer i fri text).
+   * Fri sträng (format varierar per domstol, t.ex. "B 1234-26").
+   */
+  courtCaseNumber: z.string().nullish(),
   title: z.string(),
   description: z.string().nullish(),
   status: matterStatusSchema.default("ACTIVE"),

--- a/test/e2e/round-trip/round-trip.spec.ts
+++ b/test/e2e/round-trip/round-trip.spec.ts
@@ -80,10 +80,13 @@ async function createContact(page: Page, name: string): Promise<void> {
 /** Registrera en tidspost (120 min) på öppen matter-detalj. */
 async function registerTime(page: Page, desc: string): Promise<void> {
   await page.getByRole("button", { name: /Registrera tid/i }).click();
-  await page.locator('input[type="date"]').first().fill(new Date().toISOString().slice(0, 10));
-  await page.locator('input[type="number"]').first().fill("120");
-  await page.getByPlaceholder(/Beskrivning/i).fill(desc);
-  await page.getByRole("button", { name: /^Spara$/ }).click();
+  // Scopa till modalen — matter-sidan har egna number-fält (t.ex. förväntade
+  // domstolsbetalningar #173) så en sid-bred `.first()` blir tvetydig.
+  const modal = page.getByRole("dialog");
+  await modal.locator('input[type="date"]').first().fill(new Date().toISOString().slice(0, 10));
+  await modal.locator('input[type="number"]').first().fill("120");
+  await modal.getByPlaceholder(/Beskrivning/i).fill(desc);
+  await modal.getByRole("button", { name: /^Spara$/ }).click();
   await expect(page.getByText(desc)).toBeVisible({ timeout: 10_000 });
 }
 
@@ -263,10 +266,13 @@ test("fakturering: tid → acconto → betalning landar i git-db:n", async ({ pa
 
   // ── Registrera tid (120 min) ──
   await page.getByRole("button", { name: /Registrera tid/i }).click();
-  await page.locator('input[type="date"]').first().fill(new Date().toISOString().slice(0, 10));
-  await page.locator('input[type="number"]').first().fill("120");
-  await page.getByPlaceholder(/Beskrivning/i).fill(timeDesc);
-  await page.getByRole("button", { name: /^Spara$/ }).click();
+  // Scopa till modalen (matter-sidan har egna number-fält, #173) — annars
+  // träffar `.first()` fel fält och minuterna blir kvar på default (30).
+  const timeModal = page.getByRole("dialog");
+  await timeModal.locator('input[type="date"]').first().fill(new Date().toISOString().slice(0, 10));
+  await timeModal.locator('input[type="number"]').first().fill("120");
+  await timeModal.getByPlaceholder(/Beskrivning/i).fill(timeDesc);
+  await timeModal.getByRole("button", { name: /^Spara$/ }).click();
   await expect(page.getByText(timeDesc)).toBeVisible({ timeout: 10_000 });
 
   // ── Skapa acconto-faktura (1000 kr) via BillingPanel ──

--- a/test/fixtures/camt-seb/camt.053_domstolsverket.xml
+++ b/test/fixtures/camt-seb/camt.053_domstolsverket.xml
@@ -11,8 +11,22 @@
     2. Inkommande klientbetalning (CRDT) med fri-text-referens (RfrdDocInf/Nb).
     3. DOMSTOLSVERKET (Dbtr "SVERIGES DOMSTOLAR Utbetalning SCR"): EN betalning
        som splittats över MÅNGA <Strd>-rader, var och en en kostnadsräkning med
-       referens i fri text (Nb = "<fakturanr> <målnr> <namn>"). Detta är
-       nyckelfallet för #173 (fordran utan faktura) + #175 (fri-text-match).
+       referens i fri text. Detta är nyckelfallet för #173 (fordran utan
+       faktura) + #175 (fri-text-match).
+
+  REFERENSFORMATET (verifierat med byrån) — i både <InstrId> och <Strd>/<Nb>:
+       "1154602 3288-26 ENOKSSON"
+        ├ 1154602  = ÄRENDENUMMER (byråns system idag/KATS; framtida AVA-
+        │            ärendenummer #174) → matchningsnyckel mot Matter
+        ├ 3288-26  = MÅLNUMMER i tingsrätten → matchar Matter.courtCaseNumber (#173)
+        └ ENOKSSON = ANSVARIG ADVOKATS efternamn (#174 responsibleLawyer) — INTE
+                     klienten. Sekundär verifieringsnyckel.
+  → #175 bör matcha på ärendenummer ELLER målnummer (båda finns i referensen),
+    och kan validera mot ansvarig jurist. Referensen finns i TVÅ fält: <InstrId>
+    (Refs) och <RmtInf>/<Strd>/<RfrdDocInf>/<Nb> — matcha gärna på båda.
+
+  (Anonymiserade exempel nedan: efternamnen är fejkade, men numerken behåller
+   formatet ärendenr + målnr så matchningslogiken kan testas.)
 -->
 <Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02" xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02 camt.053.001.02.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <BkToCstmrStmt>

--- a/test/fixtures/camt-seb/camt.053_domstolsverket.xml
+++ b/test/fixtures/camt-seb/camt.053_domstolsverket.xml
@@ -1,0 +1,347 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ANONYMISERAD fixtur (#173/#175). Strukturen kommer från ett VERKLIGT
+  camt.053-kontoutdrag (SEB) där bl.a. Domstolsverket betalar kostnadsräkningar
+  till en advokatbyrå. Alla personuppgifter (byrå-/klientnamn, adresser,
+  konto-/bankgironummer, OCR-/referensnummer) är utbytta mot påhittade värden —
+  bara FORMATET är bevarat. Spara aldrig verklig klient-PII i repot (GDPR).
+
+  Tre intressanta fall för avprickningen:
+    1. Utgående betalning (DBIT) med strukturerad OCR-referens (SCOR/CdtrRefInf).
+    2. Inkommande klientbetalning (CRDT) med fri-text-referens (RfrdDocInf/Nb).
+    3. DOMSTOLSVERKET (Dbtr "SVERIGES DOMSTOLAR Utbetalning SCR"): EN betalning
+       som splittats över MÅNGA <Strd>-rader, var och en en kostnadsräkning med
+       referens i fri text (Nb = "<fakturanr> <målnr> <namn>"). Detta är
+       nyckelfallet för #173 (fordran utan faktura) + #175 (fri-text-match).
+-->
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02" xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02 camt.053.001.02.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <BkToCstmrStmt>
+    <GrpHdr>
+      <MsgId>100000001</MsgId>
+      <CreDtTm>2026-06-13T04:11:16+01:00</CreDtTm>
+      <MsgRcpt>
+        <Id>
+          <OrgId>
+            <Othr>
+              <Id>11111111110000</Id>
+              <SchmeNm><Cd>BANK</Cd></SchmeNm>
+            </Othr>
+          </OrgId>
+        </Id>
+      </MsgRcpt>
+    </GrpHdr>
+    <Stmt>
+      <Id>STOIID25260613040632000013</Id>
+      <ElctrncSeqNb>1</ElctrncSeqNb>
+      <LglSeqNb>1</LglSeqNb>
+      <CreDtTm>2026-06-13T04:06:32+01:00</CreDtTm>
+      <FrToDt>
+        <FrDtTm>2026-06-12T00:00:00+01:00</FrDtTm>
+        <ToDtTm>2026-06-12T23:59:59+01:00</ToDtTm>
+      </FrToDt>
+      <Acct>
+        <Id>
+          <Othr>
+            <Id>12345678901</Id>
+            <SchmeNm><Cd>BBAN</Cd></SchmeNm>
+          </Othr>
+        </Id>
+        <Ccy>SEK</Ccy>
+        <Nm>EXEMPEL &amp; PARTNER ADVOKATER AB</Nm>
+        <Ownr>
+          <Nm>EXEMPEL &amp; PARTNER ADVOKATER AB</Nm>
+          <Id>
+            <OrgId>
+              <Othr>
+                <Id>11111111110000</Id>
+                <SchmeNm><Cd>BANK</Cd></SchmeNm>
+              </Othr>
+            </OrgId>
+          </Id>
+        </Ownr>
+        <Svcr>
+          <FinInstnId><BIC>ESSESESSXXX</BIC></FinInstnId>
+        </Svcr>
+      </Acct>
+      <Bal>
+        <Tp><CdOrPrtry><Cd>OPBD</Cd></CdOrPrtry></Tp>
+        <Amt Ccy="SEK">2111930.67</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <Dt><Dt>2026-06-12</Dt></Dt>
+      </Bal>
+      <Bal>
+        <Tp><CdOrPrtry><Cd>CLBD</Cd></CdOrPrtry></Tp>
+        <CdtLine><Incl>false</Incl></CdtLine>
+        <Amt Ccy="SEK">2298832.67</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <Dt><Dt>2026-06-12</Dt></Dt>
+      </Bal>
+      <Bal>
+        <Tp><CdOrPrtry><Cd>CLAV</Cd></CdOrPrtry></Tp>
+        <CdtLine><Incl>false</Incl></CdtLine>
+        <Amt Ccy="SEK">2298832.67</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <Dt><Dt>2026-06-12</Dt></Dt>
+      </Bal>
+      <Bal>
+        <Tp><CdOrPrtry><Cd>FWAV</Cd></CdOrPrtry></Tp>
+        <Amt Ccy="SEK">2298832.67</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <Dt><Dt>2026-06-15</Dt></Dt>
+      </Bal>
+      <TxsSummry>
+        <TtlCdtNtries>
+          <NbOfNtries>2</NbOfNtries>
+          <Sum>191982.00</Sum>
+        </TtlCdtNtries>
+        <TtlDbtNtries>
+          <NbOfNtries>1</NbOfNtries>
+          <Sum>5080.00</Sum>
+        </TtlDbtNtries>
+      </TxsSummry>
+
+      <!-- 1. Utgående betalning (DBIT) med strukturerad OCR-referens (SCOR). -->
+      <Ntry>
+        <NtryRef>LBE 555-0000-0011129</NtryRef>
+        <Amt Ccy="SEK">5080.00</Amt>
+        <CdtDbtInd>DBIT</CdtDbtInd>
+        <Sts>BOOK</Sts>
+        <BookgDt><Dt>2026-06-12</Dt></BookgDt>
+        <ValDt><Dt>2026-06-12</Dt></ValDt>
+        <AcctSvcrRef>STOI123456789010011129</AcctSvcrRef>
+        <BkTxCd>
+          <Domn>
+            <Cd>PMNT</Cd>
+            <Fmly><Cd>ICDT</Cd><SubFmlyCd>ATXN</SubFmlyCd></Fmly>
+          </Domn>
+          <Prtry><Cd>TRF</Cd><Issr>SWIFT</Issr></Prtry>
+        </BkTxCd>
+        <NtryDtls>
+          <TxDtls>
+            <Refs>
+              <MsgId>0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0</MsgId>
+              <AcctSvcrRef>STOESI05260604101532903978000001</AcctSvcrRef>
+              <PmtInfId>1000000-360-0000000000000000000000</PmtInfId>
+              <InstrId>360</InstrId>
+              <EndToEndId>C1000000-360-0000000000000000000000</EndToEndId>
+            </Refs>
+            <AmtDtls><TxAmt><Amt Ccy="SEK">1270.00</Amt></TxAmt></AmtDtls>
+            <RltdPties>
+              <Dbtr><Nm>EXEMPEL &amp; PARTNER ADVOKATER AB</Nm></Dbtr>
+              <DbtrAcct><Id><Othr><Id>5550000</Id><SchmeNm><Prtry>BGNR</Prtry></SchmeNm></Othr></Id></DbtrAcct>
+              <Cdtr><Nm>EXEMPEL PASTORAT</Nm></Cdtr>
+              <CdtrAcct><Id><Othr><Id>9990001</Id><SchmeNm><Prtry>BGNR</Prtry></SchmeNm><Issr>BGC</Issr></Othr></Id></CdtrAcct>
+            </RltdPties>
+            <RltdAgts><DbtrAgt><FinInstnId><Nm>Skandinaviska Enskilda Banken</Nm></FinInstnId></DbtrAgt></RltdAgts>
+            <RmtInf>
+              <Strd>
+                <RfrdDocAmt><RmtdAmt Ccy="SEK">1270.00</RmtdAmt></RfrdDocAmt>
+                <CdtrRefInf>
+                  <Tp><CdOrPrtry><Cd>SCOR</Cd></CdOrPrtry></Tp>
+                  <Ref>20000001</Ref>
+                </CdtrRefInf>
+              </Strd>
+            </RmtInf>
+          </TxDtls>
+          <TxDtls>
+            <Refs>
+              <MsgId>0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0</MsgId>
+              <AcctSvcrRef>STOESI05260604101532903980000001</AcctSvcrRef>
+              <PmtInfId>1000000-358-0000000000000000000000</PmtInfId>
+              <InstrId>358</InstrId>
+              <EndToEndId>C1000000-358-0000000000000000000000</EndToEndId>
+            </Refs>
+            <AmtDtls><TxAmt><Amt Ccy="SEK">3810.00</Amt></TxAmt></AmtDtls>
+            <RltdPties>
+              <Dbtr><Nm>EXEMPEL &amp; PARTNER ADVOKATER AB</Nm></Dbtr>
+              <DbtrAcct><Id><Othr><Id>5550000</Id><SchmeNm><Prtry>BGNR</Prtry></SchmeNm></Othr></Id></DbtrAcct>
+              <Cdtr><Nm>EXEMPEL PASTORAT</Nm></Cdtr>
+              <CdtrAcct><Id><Othr><Id>9990001</Id><SchmeNm><Prtry>BGNR</Prtry></SchmeNm><Issr>BGC</Issr></Othr></Id></CdtrAcct>
+            </RltdPties>
+            <RltdAgts><DbtrAgt><FinInstnId><Nm>Skandinaviska Enskilda Banken</Nm></FinInstnId></DbtrAgt></RltdAgts>
+            <RmtInf>
+              <Strd>
+                <RfrdDocAmt><RmtdAmt Ccy="SEK">3810.00</RmtdAmt></RfrdDocAmt>
+                <CdtrRefInf>
+                  <Tp><CdOrPrtry><Cd>SCOR</Cd></CdOrPrtry></Tp>
+                  <Ref>20000002</Ref>
+                </CdtrRefInf>
+              </Strd>
+            </RmtInf>
+          </TxDtls>
+        </NtryDtls>
+      </Ntry>
+
+      <!-- 2. Inkommande klientbetalning (CRDT) med fri-text-referens. -->
+      <Ntry>
+        <NtryRef>BG05550000 00143-0011130</NtryRef>
+        <Amt Ccy="SEK">4598.00</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <Sts>BOOK</Sts>
+        <BookgDt><Dt>2026-06-12</Dt></BookgDt>
+        <ValDt><Dt>2026-06-12</Dt></ValDt>
+        <AcctSvcrRef>STOI123456789010011130</AcctSvcrRef>
+        <BkTxCd>
+          <Domn>
+            <Cd>PMNT</Cd>
+            <Fmly><Cd>RCDT</Cd><SubFmlyCd>ATXN</SubFmlyCd></Fmly>
+          </Domn>
+          <Prtry><Cd>TRF</Cd><Issr>SWIFT</Issr></Prtry>
+        </BkTxCd>
+        <NtryDtls>
+          <TxDtls>
+            <Refs>
+              <AcctSvcrRef>STOIIQ0I260612134125105030000001</AcctSvcrRef>
+              <InstrId>EXEMPEL KLIENT</InstrId>
+            </Refs>
+            <AmtDtls><TxAmt><Amt Ccy="SEK">4598.00</Amt></TxAmt></AmtDtls>
+            <RltdPties>
+              <Dbtr>
+                <Nm>KLIENT EXEMPEL</Nm>
+                <PstlAdr>
+                  <StrtNm>EXEMPELGATAN 1 LGH 1101</StrtNm>
+                  <PstCd>216 12</PstCd>
+                  <TwnNm>LIMHAMN</TwnNm>
+                </PstlAdr>
+              </Dbtr>
+              <Cdtr><Nm>EXEMPEL &amp; PARTNER ADVOKATER AB</Nm></Cdtr>
+              <CdtrAcct><Id><Othr><Id>5550000</Id><SchmeNm><Prtry>BGNR</Prtry></SchmeNm></Othr></Id></CdtrAcct>
+            </RltdPties>
+            <RltdAgts>
+              <DbtrAgt><FinInstnId><BIC>ESSESESS</BIC></FinInstnId></DbtrAgt>
+              <CdtrAgt><FinInstnId><BIC>ESSESESS</BIC></FinInstnId></CdtrAgt>
+            </RltdAgts>
+            <RmtInf>
+              <Strd>
+                <RfrdDocInf>
+                  <Tp><CdOrPrtry><Cd>CINV</Cd></CdOrPrtry></Tp>
+                  <Nb>EXEMPEL KLIENT</Nb>
+                </RfrdDocInf>
+                <RfrdDocAmt><RmtdAmt Ccy="SEK">4598.00</RmtdAmt></RfrdDocAmt>
+              </Strd>
+            </RmtInf>
+          </TxDtls>
+        </NtryDtls>
+      </Ntry>
+
+      <!-- 3. DOMSTOLSVERKET: en betalning splittad över många kostnadsräkningar. -->
+      <Ntry>
+        <NtryRef>BG05550000 00144-0011131</NtryRef>
+        <Amt Ccy="SEK">187384.00</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <Sts>BOOK</Sts>
+        <BookgDt><Dt>2026-06-12</Dt></BookgDt>
+        <ValDt><Dt>2026-06-12</Dt></ValDt>
+        <AcctSvcrRef>STOI123456789010011131</AcctSvcrRef>
+        <BkTxCd>
+          <Domn>
+            <Cd>PMNT</Cd>
+            <Fmly><Cd>RCDT</Cd><SubFmlyCd>ATXN</SubFmlyCd></Fmly>
+          </Domn>
+          <Prtry><Cd>TRF</Cd><Issr>SWIFT</Issr></Prtry>
+        </BkTxCd>
+        <NtryDtls>
+          <TxDtls>
+            <Refs>
+              <AcctSvcrRef>STOIIQ0I260612134125127019000001</AcctSvcrRef>
+              <InstrId>6130/1154501 AC Klient Ex</InstrId>
+            </Refs>
+            <AmtDtls><TxAmt><Amt Ccy="SEK">2033.00</Amt></TxAmt></AmtDtls>
+            <RltdPties>
+              <Dbtr>
+                <Nm>ANNAN KLIENT EXEMPEL</Nm>
+                <PstlAdr>
+                  <StrtNm>EXEMPELVÄGEN 22 LGH 1202</StrtNm>
+                  <PstCd>222 24</PstCd>
+                  <TwnNm>LUND</TwnNm>
+                </PstlAdr>
+              </Dbtr>
+              <Cdtr><Nm>EXEMPEL &amp; PARTNER ADVOKATER AB</Nm></Cdtr>
+              <CdtrAcct><Id><Othr><Id>5550000</Id><SchmeNm><Prtry>BGNR</Prtry></SchmeNm></Othr></Id></CdtrAcct>
+            </RltdPties>
+            <RltdAgts>
+              <DbtrAgt><FinInstnId><BIC>ESSESESS</BIC></FinInstnId></DbtrAgt>
+              <CdtrAgt><FinInstnId><BIC>ESSESESS</BIC></FinInstnId></CdtrAgt>
+            </RltdAgts>
+            <RmtInf>
+              <Strd>
+                <RfrdDocInf>
+                  <Tp><CdOrPrtry><Cd>CINV</Cd></CdOrPrtry></Tp>
+                  <Nb>6130/1154501 AC Klient Ex</Nb>
+                </RfrdDocInf>
+                <RfrdDocAmt><RmtdAmt Ccy="SEK">2033.00</RmtdAmt></RfrdDocAmt>
+                <AddtlRmtInf>lan</AddtlRmtInf>
+              </Strd>
+            </RmtInf>
+          </TxDtls>
+          <TxDtls>
+            <Refs>
+              <AcctSvcrRef>STOIIQ0I260612134125128930000001</AcctSvcrRef>
+              <InstrId>1154602 3288-26 EXEMPELSSON</InstrId>
+            </Refs>
+            <AmtDtls><TxAmt><Amt Ccy="SEK">185351.00</Amt></TxAmt></AmtDtls>
+            <RltdPties>
+              <Dbtr>
+                <Nm>SVERIGES DOMSTOLAR Utbetalning SCR</Nm>
+                <PstlAdr>
+                  <StrtNm>BOX</StrtNm>
+                  <PstCd>55181</PstCd>
+                  <TwnNm>JÖNKÖPING</TwnNm>
+                </PstlAdr>
+              </Dbtr>
+              <DbtrAcct>
+                <Id><Othr><Id>5990000</Id><SchmeNm><Prtry>BGNR</Prtry></SchmeNm></Othr></Id>
+                <Ccy>SEK</Ccy>
+              </DbtrAcct>
+              <Cdtr><Nm>EXEMPEL &amp; PARTNER ADVOKATER AB</Nm></Cdtr>
+              <CdtrAcct><Id><Othr><Id>5550000</Id><SchmeNm><Prtry>BGNR</Prtry></SchmeNm></Othr></Id></CdtrAcct>
+            </RltdPties>
+            <RltdAgts><CdtrAgt><FinInstnId><BIC>ESSESESS</BIC></FinInstnId></CdtrAgt></RltdAgts>
+            <RmtInf>
+              <Strd>
+                <RfrdDocInf><Tp><CdOrPrtry><Cd>CINV</Cd></CdOrPrtry></Tp><Nb>1154602 3288-26 EXEMPELSSON</Nb></RfrdDocInf>
+                <RfrdDocAmt><RmtdAmt Ccy="SEK">7246.00</RmtdAmt></RfrdDocAmt>
+              </Strd>
+              <Strd>
+                <RfrdDocInf><Tp><CdOrPrtry><Cd>CINV</Cd></CdOrPrtry></Tp><Nb>1160301 3290-26 EXEMPELSSON</Nb></RfrdDocInf>
+                <RfrdDocAmt><RmtdAmt Ccy="SEK">7246.00</RmtdAmt></RfrdDocAmt>
+              </Strd>
+              <Strd>
+                <RfrdDocInf><Tp><CdOrPrtry><Cd>CINV</Cd></CdOrPrtry></Tp><Nb>1160601 3330-26 DIAZ EXEMPEL</Nb></RfrdDocInf>
+                <RfrdDocAmt><RmtdAmt Ccy="SEK">11963.00</RmtdAmt></RfrdDocAmt>
+              </Strd>
+              <Strd>
+                <RfrdDocInf><Tp><CdOrPrtry><Cd>CINV</Cd></CdOrPrtry></Tp><Nb>5311 5040-25 TEST CECILIA</Nb></RfrdDocInf>
+                <RfrdDocAmt><RmtdAmt Ccy="SEK">22352.00</RmtdAmt></RfrdDocAmt>
+              </Strd>
+              <Strd>
+                <RfrdDocInf><Tp><CdOrPrtry><Cd>CINV</Cd></CdOrPrtry></Tp><Nb>1101601 695-26 TEST CECIL</Nb></RfrdDocInf>
+                <RfrdDocAmt><RmtdAmt Ccy="SEK">14105.00</RmtdAmt></RfrdDocAmt>
+              </Strd>
+              <Strd>
+                <RfrdDocInf><Tp><CdOrPrtry><Cd>CINV</Cd></CdOrPrtry></Tp><Nb>5291 5799-25 PARTNER MA</Nb></RfrdDocInf>
+                <RfrdDocAmt><RmtdAmt Ccy="SEK">73143.00</RmtdAmt></RfrdDocAmt>
+              </Strd>
+              <Strd>
+                <RfrdDocInf><Tp><CdOrPrtry><Cd>CINV</Cd></CdOrPrtry></Tp><Nb>1162902 3415-26 EXEMPEL P</Nb></RfrdDocInf>
+                <RfrdDocAmt><RmtdAmt Ccy="SEK">10265.00</RmtdAmt></RfrdDocAmt>
+              </Strd>
+              <Strd>
+                <RfrdDocInf><Tp><CdOrPrtry><Cd>CINV</Cd></CdOrPrtry></Tp><Nb>1005701 5603-26 EXEMPEL B</Nb></RfrdDocInf>
+                <RfrdDocAmt><RmtdAmt Ccy="SEK">23981.00</RmtdAmt></RfrdDocAmt>
+              </Strd>
+              <Strd>
+                <RfrdDocInf><Tp><CdOrPrtry><Cd>CINV</Cd></CdOrPrtry></Tp><Nb>1163501 3477-26 TEST CECI</Nb></RfrdDocInf>
+                <RfrdDocAmt><RmtdAmt Ccy="SEK">6066.00</RmtdAmt></RfrdDocAmt>
+              </Strd>
+              <Strd>
+                <RfrdDocInf><Tp><CdOrPrtry><Cd>CINV</Cd></CdOrPrtry></Tp><Nb>1065101 2938-26 EXEMPEL</Nb></RfrdDocInf>
+                <RfrdDocAmt><RmtdAmt Ccy="SEK">8984.00</RmtdAmt></RfrdDocAmt>
+              </Strd>
+            </RmtInf>
+          </TxDtls>
+        </NtryDtls>
+      </Ntry>
+    </Stmt>
+  </BkToCstmrStmt>
+</Document>

--- a/test/unit/app/matters/[id]/page.test.tsx
+++ b/test/unit/app/matters/[id]/page.test.tsx
@@ -30,6 +30,7 @@ const utilsMock = {
   contacts: { list: { invalidate: vi.fn() } },
   document: { tree: { invalidate: vi.fn() } },
   prefs: { get: { invalidate: vi.fn() } },
+  expectedReceivable: { list: { invalidate: vi.fn() } },
 };
 const stubs = {
   addContact: { mutate: vi.fn(), isPending: false },
@@ -94,6 +95,12 @@ vi.mock("@/lib/client/trpc", () => ({
       create: { useMutation: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }) },
       update: { useMutation: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }) },
       delete: { useMutation: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }) },
+    },
+    expectedReceivable: {
+      list: { useQuery: () => ({ data: [], isLoading: false }) },
+      create: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      settle: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      cancel: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
     },
     user: {
       current: { useQuery: () => ({ data: { id: "u1", name: "Anna", email: "anna@firma.local" } }) },

--- a/test/unit/lib/payments/camt-fixtures.test.ts
+++ b/test/unit/lib/payments/camt-fixtures.test.ts
@@ -23,6 +23,7 @@ const XML_FIXTURES = [
   { file: "camt.054_SE.xml", ns: "camt.054.001.02", root: "BkToCstmrDbtCdtNtfctn" },
   { file: "camt.053_SE.xml", ns: "camt.053.001.02", root: "BkToCstmrStmt" },
   { file: "camt.053_SE_BGC_Credit.xml", ns: "camt.053.001.02", root: "BkToCstmrStmt" },
+  { file: "camt.053_domstolsverket.xml", ns: "camt.053.001.02", root: "BkToCstmrStmt" },
 ] as const;
 
 describe("SEB camt-fixturer", () => {
@@ -55,6 +56,20 @@ describe("SEB camt-fixturer", () => {
     // Ingen Strd/CdtrRefInf-OCR i denna → just det fall avprickningen måste
     // klara via fri-text (målnummer / ärendereferens).
     expect(xml).not.toContain("<CdtrRefInf>");
+  });
+
+  it("Domstolsverket-filen: en betalning splittad över många kostnadsräkningar (#173/#175)", () => {
+    const xml = read("camt.053_domstolsverket.xml");
+    // Domstolsverket som betalare (Dbtr) — nyckeln för att känna igen
+    // domstolsbetalningar utan AVA-faktura.
+    expect(xml).toContain("SVERIGES DOMSTOLAR");
+    // EN <Ntry>/<TxDtls> med MÅNGA <Strd> (kostnadsräkningar) → fri-text-refer
+    // i <Nb> (fakturanr + målnr + namn), inte OCR. Minst 10 i exemplet.
+    const strdCount = xml.split("<Strd>").length - 1;
+    expect(strdCount).toBeGreaterThanOrEqual(10);
+    // Får INTE innehålla verklig klient-PII (anonymiserad fixtur).
+    expect(xml).not.toContain("GROSSKOPF");
+    expect(xml).toContain("ANONYMISERAD");
   });
 
   it("XSD:erna är scheman för rätt camt-version", () => {

--- a/test/unit/lib/payments/camt-parse.test.ts
+++ b/test/unit/lib/payments/camt-parse.test.ts
@@ -131,3 +131,22 @@ describe("zod-validering vid parsegränsen (#185)", () => {
     expect(camtFileSchema.safeParse(file).success).toBe(true);
   });
 });
+
+describe("parseCamtXml — Domstolsverket (#173/#175, anonymiserad real-fixtur)", () => {
+  const file = parseCamtXml(read("camt.053_domstolsverket.xml"));
+
+  it("parsar utan fel + passerar schemat", () => {
+    expect(camtFileSchema.safeParse(file).success).toBe(true);
+    expect(file.transactions.length).toBeGreaterThan(0);
+  });
+
+  it("hittar Domstolsverkets betalning med MÅNGA kostnadsräknings-referenser", () => {
+    const dom = file.transactions.find((t) => (t.debtorName ?? "").includes("SVERIGES DOMSTOLAR"));
+    expect(dom).toBeTruthy();
+    expect(dom!.amountOre).toBe(185_351_00);
+    // En betalning → 10 strukturerade referenser (fri-text Nb, ej OCR).
+    expect(dom!.structuredRefs.length).toBe(10);
+    // Referenserna bär fakturanr + målnr i fri text (matchningsnyckel #175).
+    expect(dom!.structuredRefs.some((r) => r.ref.includes("3288-26"))).toBe(true);
+  });
+});

--- a/test/unit/server/helpers/mock-data-store.ts
+++ b/test/unit/server/helpers/mock-data-store.ts
@@ -31,6 +31,7 @@ export interface MockDataStore {
   conflictChecks: unknown;
   payments: unknown;
   writeOffs: unknown;
+  expectedReceivables: unknown;
   paymentPlans: unknown;
   paymentPlanReminders: unknown;
   accontoDeductions: unknown;
@@ -73,6 +74,7 @@ export function dataStoreFromMockPrisma(mockPrisma: Record<string, unknown>): Mo
       conflictChecks: mockPrisma.conflictCheck,
       payments: mockPrisma.payment,
       writeOffs: mockPrisma.writeOff,
+      expectedReceivables: mockPrisma.expectedReceivable,
       paymentPlans: mockPrisma.paymentPlan,
       paymentPlanReminders: mockPrisma.paymentPlanReminder,
       accontoDeductions: mockPrisma.invoiceAccontoDeduction,
@@ -99,6 +101,7 @@ export function dataStoreFromMockPrisma(mockPrisma: Record<string, unknown>): Mo
     conflictChecks: mockPrisma.conflictCheck,
     payments: mockPrisma.payment,
     writeOffs: mockPrisma.writeOff,
+    expectedReceivables: mockPrisma.expectedReceivable,
     paymentPlans: mockPrisma.paymentPlan,
     paymentPlanReminders: mockPrisma.paymentPlanReminder,
     accontoDeductions: mockPrisma.invoiceAccontoDeduction,

--- a/test/unit/server/local-first/projections/default-registry.test.ts
+++ b/test/unit/server/local-first/projections/default-registry.test.ts
@@ -9,12 +9,12 @@ import { buildDefaultRegistry } from "@/lib/server/local-first/projections/defau
 describe("buildDefaultRegistry", () => {
   const registry = buildDefaultRegistry();
 
-  it("har alla 21 entiteter registrerade (matter, contact, billingRun, prefs m.fl.)", () => {
+  it("har alla 22 entiteter registrerade (matter, contact, billingRun, expectedReceivable, prefs m.fl.)", () => {
     // JS sort är case-sensitive → uppercase < lowercase → "orgPreference" < "organization".
     expect(registry.entities().sort()).toEqual([
       "accontoDeduction", "billingRun",
       "calendarEvent", "conflictCheck", "contact", "document", "documentTemplate",
-      "expense", "invoice", "matter", "matterContact", "office",
+      "expectedReceivable", "expense", "invoice", "matter", "matterContact", "office",
       "orgPreference", "organization",
       "payment", "paymentPlan", "paymentPlanReminder",
       "task", "timeEntry", "user", "userPreference",

--- a/test/unit/server/routers/expectedReceivable.test.ts
+++ b/test/unit/server/routers/expectedReceivable.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Integrationstest för expectedReceivableRouter (#173) — förväntade
+ * domstolsbetalningar utan faktura. Kör mot riktig DemoDataStore (verifierar
+ * entitets-wiringen) via createCaller.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { appRouter } from "@/lib/server/routers/_app";
+import { DemoDataStore } from "@/lib/server/data-store/DemoDataStore";
+import { buildContext } from "@/lib/server/build-context";
+import { noopPorts } from "@/lib/server/adapters/noop-ports";
+import type { Principal } from "@/lib/server/auth/principal";
+
+const PRINCIPAL: Principal = { id: "u-1", email: "a@x", name: "Anna", role: "ADMIN", organizationId: "org-1" };
+
+function makeCaller() {
+  const ds = new DemoDataStore({
+    organizations: [{ id: "org-1", name: "Byrå" }, { id: "org-2", name: "Annan" }],
+    matters: [
+      { id: "m-1", organizationId: "org-1", matterNumber: "2026-0001", title: "Brottmål", status: "ACTIVE", createdAt: new Date() },
+      { id: "m-foreign", organizationId: "org-2", matterNumber: "2026-0002", title: "U", status: "ACTIVE", createdAt: new Date() },
+    ],
+    users: [{ id: "u-1", organizationId: "org-1", email: "a@x", name: "Anna", role: "ADMIN" }],
+  }, async () => {});
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return appRouter.createCaller(buildContext({ dataStore: ds, ports: noopPorts, principal: PRINCIPAL }) as any);
+}
+
+describe("expectedReceivable.create + list", () => {
+  it("registrerar en fordran (PENDING) kopplad till ärende", async () => {
+    const caller = makeCaller();
+    const r = await caller.expectedReceivable.create({
+      matterId: "m-1",
+      description: "Kostnadsräkning Svea HovR mål B 1234-26",
+      expectedAmount: 50_000,
+    });
+    expect(r.status).toBe("PENDING");
+    expect(r.expectedAmount).toBe(50_000);
+    expect(r.settledAmount == null).toBe(true);
+
+    const list = await caller.expectedReceivable.list({ matterId: "m-1" });
+    expect(list).toHaveLength(1);
+    expect(list[0]!.description).toContain("B 1234-26");
+  });
+
+  it("nekar fordran mot ärende i annan org (NOT_FOUND)", async () => {
+    const caller = makeCaller();
+    await expect(
+      caller.expectedReceivable.create({ matterId: "m-foreign", description: "X", expectedAmount: 1 }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("expectedReceivable.settle", () => {
+  it("bokar faktiskt utbetalt (3b-ii): SETTLED + settledAmount, skild från expected", async () => {
+    const caller = makeCaller();
+    const r = await caller.expectedReceivable.create({ matterId: "m-1", description: "K", expectedAmount: 50_000 });
+
+    // Domstolen prutade: begärt 50 000, betalt 42 000.
+    const settled = await caller.expectedReceivable.settle({ id: String(r.id), settledAmount: 42_000, paymentReference: "camt-xyz" });
+    expect(settled.status).toBe("SETTLED");
+    expect(settled.settledAmount).toBe(42_000);
+    expect(settled.expectedAmount).toBe(50_000); // memo oförändrat — prutning bokförs ej som förlust
+    expect(settled.settledAt).toBeTruthy();
+    expect(settled.paymentReference).toBe("camt-xyz");
+  });
+});
+
+describe("expectedReceivable.cancel", () => {
+  it("avbryter en fordran", async () => {
+    const caller = makeCaller();
+    const r = await caller.expectedReceivable.create({ matterId: "m-1", description: "K", expectedAmount: 10_000 });
+    const c = await caller.expectedReceivable.cancel({ id: String(r.id) });
+    expect(c.status).toBe("CANCELLED");
+  });
+});

--- a/tooling/scripts/generate-demo-manifest.ts
+++ b/tooling/scripts/generate-demo-manifest.ts
@@ -36,7 +36,7 @@ const DEFAULT_SCAN_PATHS = [
   "calendar", "tasks",
   "payment-plans", "payment-plan-reminders", "payments",
   "acconto-deductions", "billing-runs", "write-offs", "conflict-checks", "offices",
-  "invoice-dispatches",
+  "invoice-dispatches", "expected-receivables",
 ];
 
 async function listProjectionFiles(root: string, dir: string): Promise<string[]> {


### PR DESCRIPTION
## Vad

Ny entitet **`ExpectedReceivable`** — en kostnadsräkning till domstol som Domstolsverket betalar. Det finns ingen AVA-faktura att pricka av mot, betalaren anger **målnummer** (ej OCR), och utbetalt kan avvika från begärt (domstolen prutar).

## Beslut (dina val: 1A, 2A, 3b-ii)

- **1A — separat entitet** (ej en faktura-typ): ingen PDF, inget fakturanummer, ingen OCR, ingen Fortnox-push. Org-scopad + kopplad till `matterId`. Egen vy (ej inbakad i kundfordrings-bryggan).
- **2A — `Matter.courtCaseNumber`** (domstolens målnummer) som matchningsnyckel för avprickningen.
- **3b-ii — försiktighetsprincip:** `expectedAmount` är ett **memo** (begärt belopp, för uppföljning), `settledAmount` (det domstolen **faktiskt betalar**) bokas vid avprickning. Skillnaden (prutning) bokförs varken som intäkt eller kundförlust — den är bara "begärt minus utfall".

## Omfattning

- `expectedReceivableSchema` (PENDING/SETTLED/CANCELLED) + branded id + **full entitets-wiring** (IDataStore, DemoDataStore, ENTITY_REGISTRY + EntityName-union, git-projektion, demo-source, manifest-scan, test-mock-store). Passade på att fixa att `invoiceDispatch` saknades i EntityName-unionen.
- Router `expectedReceivable`: `list` / `create` / `settle` / `cancel` / `update`, org-scopad. `settle` tar `paymentReference` (idempotens för camt-peern, #175).
- `Matter.courtCaseNumber` i schema + `matter.create`/`update` + nytt-ärende-formuläret.
- UI: `ExpectedReceivablesSection` på ärende-sidan — målnummer-editor + lista + lägg-till + "markera mottagen" (registrerar utbetalt) + avbryt.

## Avgränsning

Den **automatiska** camt-fri-text-matchningen (målnummer i `Ustrd` → `settle`) är **#175** — utanför denna PR. Här finns domänmodellen + manuell registrering/avprickning.

## Verifierat lokalt

typecheck, `lint --max-warnings 0`, `lint:lib-complexity`, dep-cruiser (0 violations), jscpd (0.41%) — grönt. 1074 server/scripts/matters-tester pass. Nya tester: router-integration mot riktig DemoDataStore (create/settle/cancel + org-scoping) + uppdaterad projektions-registry-count (21→22).

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)