### PR TITLE
docs(auth): stäng #224 — host-shell-CLI-bootstrap + email-only (beslut)

### DIFF
--- a/docs/adr/0009-oidc-login-via-servern.md
+++ b/docs/adr/0009-oidc-login-via-servern.md
@@ -68,12 +68,22 @@ nginx-fronten.
   första login binds `oidcSubject`. Okänd identitet utan allowlist-rad nekas
   (autentisering ≠ auktorisering). Avprovisionering = ta bort rad + invalidera
   session.
-- **Första användaren (bootstrap):** rotförtroende = den som kör
-  `docker compose up` (host shell-access). Vid tom allowlist mint:as en
-  **engångs admin-claim-token** som printas i serverloggen (samma mönster som
-  dagens admin-PAT-bootstrap); första personen löser in den vid OIDC-login och
-  binds som admin, varefter token invalideras. Alternativ: `add-user.sh --admin
-  <epost>` på hosten. (Detalj: [#224](https://github.com/ulrik-s/ava/issues/224).)
+- **Första användaren (bootstrap) — BESLUTAT ([#224](https://github.com/ulrik-s/ava/issues/224), stängd):**
+  rotförtroende = den som kör `docker compose up` (host shell-access). Första
+  admin seedas med **`bun run bootstrap:admin --email <epost> --org <namn>`**
+  som skriver `.ava/users/<epost>.json` (role ADMIN, deterministiskt uuidv5-id,
+  idempotent) i firma.git. Därefter loggar personen in via OIDC och resolvas som
+  ADMIN (allowlisten = User-raderna, ingen parallell lista).
+  - **Engångs-token-via-HTTP-flödet förkastades** (YAGNI): alla self-hosted-
+    deploys har shell-access vid uppsättning, så CLI:n räcker och undviker en
+    admin-mintande endpoint + token-livscykel. (Ett token-flöde kan återupptas
+    om en *managed* deploy utan shell blir aktuell; auth-tjänstens `claim-admin`
+    finns kvar som valfri, ej default-väg.)
+  - **Auktorisering är email-only** (`oidcSubject`-bindning uppskjuten): byrån
+    kör EN IdP via oauth2-proxy → email är auktoritativ. `OidcAuthProvider`
+    stödjer redan sub/iss-bindning (kräver bunden rad matcha claims), men
+    bindning skrivs inte än — det blir relevant först vid multi-IdP-allowlist
+    och kräver att oauth2-proxy exponerar `sub`/`iss` (gör det ej i userinfo idag).
 
 ### Demo-tier
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -64,23 +64,33 @@ skydd-utan-session. Körs i CI (jobbet **E2E (OIDC login)**). OBS: lokalt på
 Mac kan Docker Desktop ge flakiga browser→port-anslutningar; CI (linux) är
 den deterministiska grinden (samma mönster som round-trip-e2e:n).
 
-### Första-admin (bootstrap, #224)
+### Första-admin (bootstrap, #224 — BESLUTAT)
 
 Hönan-och-ägget: en färsk firma.git har inga User-rader → ingen är allowlistad.
 Rotförtroende = den som kör `docker compose up` (host shell-access).
 
-- Vid första start (tom allowlist) printas en **engångs claim-secret**
-  (`BOOT_SECRET`) i auth-tjänstens logg.
-- Första inloggade OIDC-användaren löser in den: `POST /auth/claim-admin`
-  `{ secret, email }`. auth-servern verifierar secret + att ingen admin finns
-  än (`admins.txt`), engångs (409 därefter). auth-servern **pratar inte git** →
-  den auktoriserar bara; **klienten** skriver `.ava/users/<email>.json`
-  (role ADMIN, `oidcSubject`) och pushar.
-- Alternativ: `add-user.sh --admin <epost>` på hosten.
+**Kanonisk väg — host-shell-CLI:**
 
-OIDC-bootstrap kräver alltså att **auth-tjänsten** körs (profil `invite-server`)
-vid sidan av `oauth2-proxy`. Pure-besluts-logiken (`claimAdminDecision`) är
-enhetstestad i `test/unit/lib/auth-server-core.test.ts`.
+```bash
+bun run bootstrap:admin --work-dir <firma.git-klon> --email du@byrå.se --org "Byrå AB" --commit
+```
+
+Skriver `.ava/users/<email>.json` (role ADMIN, deterministiskt uuidv5-id,
+idempotent) + org + `.ava/meta.json`, committar i firma.git. Därefter loggar du
+in via OIDC och resolvas som ADMIN (allowlisten = User-raderna). Se runbooken
+[`self-hosted-entra.md`](./self-hosted-entra.md) steg 3.
+
+> **Beslut #224:** vi bygger INTE ett engångs-token-via-HTTP-bootstrap för
+> standard-self-hosted (alla sådana deploys har shell → CLI:n räcker; undviker
+> en admin-mintande endpoint). Auktorisering är **email-only** — `oidcSubject`-
+> bindning är uppskjuten (relevant först vid multi-IdP; kräver att oauth2-proxy
+> exponerar sub/iss). Se [ADR 0009](./adr/0009-oidc-login-via-servern.md).
+
+**Valfritt (ej default-väg):** auth-tjänsten (profil `invite-server`) har ett
+`POST /auth/claim-admin` (engångs `BOOT_SECRET` i loggen) som låter en inloggad
+OIDC-användare claima admin utan shell. Kvar för en eventuell *managed* deploy
+utan shell-access men ingår inte i standard-flödet. Pure-logiken
+(`claimAdminDecision`) är enhetstestad i `test/unit/lib/auth-server-core.test.ts`.
 
 ## Designmål
 

--- a/src/lib/client/backend/oidc-principal.ts
+++ b/src/lib/client/backend/oidc-principal.ts
@@ -7,8 +7,9 @@
  * användar-allowlisten i firma.git via `OidcAuthProvider` (#223).
  *
  * `sub`/`iss`-bindning utelämnas här (oauth2-proxy:s userinfo ger inte dem) →
- * matchning sker på email (obunden = första-login-vägen i resolvern). Att
- * skriva bindningen vid första login hanteras separat (#224).
+ * matchning sker på email. Det är den BESLUTADE modellen (#224, ADR 0009):
+ * single-IdP → email-only; sub/iss-bindning uppskjuten tills multi-IdP blir
+ * aktuellt (kräver då att oauth2-proxy exponerar sub/iss).
  */
 
 import { z } from "zod";

--- a/src/lib/server/auth/oidc-auth-provider.ts
+++ b/src/lib/server/auth/oidc-auth-provider.ts
@@ -14,7 +14,10 @@
  *   - Inaktiverad användare → `null` (avprovisionerad).
  *   - Bunden identitet (`oidcSubject` satt) måste matcha claims sub+iss → annars
  *     `null` (skydd mot att kapa någon annans email hos en annan IdP). Obunden
- *     rad accepteras via email (första login; bindningen skrivs separat, #224).
+ *     rad accepteras via email — det är den BESLUTADE modellen (#224, ADR 0009):
+ *     single-IdP → email är auktoritativ, sub/iss-bindning uppskjuten tills
+ *     multi-IdP blir aktuellt. Matchningen nedan stödjer redan bindning den dag
+ *     allowlist-rader får `oidcSubject` satt.
  */
 
 import type { AuthProvider, Principal } from "./principal";
@@ -38,7 +41,8 @@ export interface AllowlistedUser {
   name: string;
   role: string;
   organizationId: string;
-  /** Bunden OIDC-identitet (sätts vid första login, #224). */
+  /** Bunden OIDC-identitet. Email-only idag (#224/ADR 0009); sätts först när
+   *  sub/iss-bindning införs (multi-IdP). Satt → måste matcha claims sub+iss. */
   oidcSubject?: string | null;
   oidcIssuer?: string | null;
   /** false = avprovisionerad. */


### PR DESCRIPTION
## Beslut (#224, ADR 0009)

Stänger #224 på det beslut du tog: **1A + 2A**.

- **1A — host-shell-CLI är kanonisk första-admin-bootstrap.** `bun run bootstrap:admin --email <epost> --org <namn> --commit` seedar `.ava/users/<email>.json` (role ADMIN, deterministiskt uuidv5-id, idempotent). Sedan loggar admin in via OIDC och resolvas som ADMIN. **Engångs-token-via-HTTP-flödet byggs inte** för standard-self-hosted (YAGNI — alla sådana deploys har shell; undviker en admin-mintande endpoint + token-livscykel).
- **2A — email-only auktorisering.** Single-IdP → email är auktoritativ. `oidcSubject`-bindning uppskjuten (relevant först vid multi-IdP; kräver att oauth2-proxy exponerar sub/iss, vilket userinfo inte gör idag). `OidcAuthProvider` stödjer redan bindningen den dag den behövs.

## Ändringar (docs + kommentarer, ingen logik)

- **ADR 0009**: bootstrap-stycket omskrivet — CLI-vägen + det medvetna email-only-beslutet + varför token-flödet förkastades.
- **docs/auth.md**: "Första-admin"-sektionen gjord CLI-kanonisk; auth-tjänstens `claim-admin` demoterad till **valfri** (eventuell managed-deploy utan shell), ej default-väg.
- **Kod-kommentarer** (`oidc-auth-provider.ts`, `oidc-principal.ts`): dinglande "binds separat #224" → BESLUTAT email-only; matchningen stödjer redan framtida sub/iss-bindning.

Ingen kod-logik ändrad — CLI:n (`bootstrap-admin`, #260) + email-only-resolvern (#223) finns och är testade. Detta är en besluts-/dokumentationsstängning.

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)