### PR TITLE
feat(helper): self-install-kommando (#86)

### DIFF
--- a/helper-app/README.md
+++ b/helper-app/README.md
@@ -59,30 +59,46 @@ linux arm64/x64, windows x64) och namnger binärerna
 `ava-helper-<os>-<arch>` — samma namn som självuppdateringen
 (`src/update.ts`) letar efter i GitHub-releasen.
 
-## Installera
+## Installera (#86)
 
-| OS | Kommando |
-|---|---|
-| macOS | `bash service/install-macos.sh` |
-| Linux | `bash service/install-linux.sh` |
-| Windows | `powershell -File service\install-windows.ps1` |
+**Self-install — ett kommando, samma binär på alla OS:**
 
-Script:en kopierar binären till user-writable plats, registrerar
-service-units och startar processen. Inga sudo/admin-rättigheter
-behövs.
+```bash
+./ava-helper --install      # registrera som user-service + (macOS) CA-trust
+./ava-helper --uninstall    # avregistrera servicen
+```
 
-På **macOS** installerar scriptet även helperns lokala CA i login-keychain
-(`ava-helper --install-trust`) så Safari/WKWebView (Office-add-ins) litar på
-HTTPS-loopback-certet — det ger en engångs-auktoriseringsprompt (ADR 0006).
-Chrome/Edge/Firefox + Windows/Linux behöver inte detta (HTTP-loopback funkar).
+`--install` (beslut #86: self-install, ingen sudo, ingen .pkg/.msi/.deb):
+
+1. kopierar binären till data-dir (`~/Library/Application Support/AVA`,
+   `~/.local/share/AVA`, `%LOCALAPPDATA%\AVA`),
+2. skriver service-definitionen (launchd-plist / systemd user-unit / Task
+   Scheduler-XML) med absolut path till binären,
+3. registrerar + startar servicen (`launchctl load` / `systemctl --user enable
+   --now` / `schtasks /Create`) → startar vid login, lyssnar på loopback,
+4. på **macOS** installerar helperns lokala CA i login-keychain
+   (`--install-trust`, ADR 0006) så Safari/WKWebView (Office-add-ins) litar på
+   HTTPS-loopback-certet (engångs-auktoriseringsprompt). Chrome/Edge/Firefox +
+   Windows/Linux behöver inte detta.
+
+Self-update (#78/#110) sköts sedan av den körande servicen.
+
+> ⚠️ **Signering/notarisering (kvarstår, kräver dina certifikat):** för att köra
+> UTAN OS-varningar måste binären vara **Apple Developer ID-signerad + notariserad**
+> (macOS) resp. **Authenticode-signerad** (Windows). Det kräver byråns/utgivarens
+> kodsignerings-certifikat och kan inte göras i koden — se uppföljnings-issue.
+> Osignerad binär fungerar men ger en Gatekeeper-/SmartScreen-varning vid första
+> körning.
+
+De äldre shell-skripten under `service/` (`install-macos.sh` m.fl.) finns kvar
+som referens men `--install` är den primära vägen.
 
 ## Avinstallera
 
-| OS | Kommando |
-|---|---|
-| macOS | `~/Library/Application\ Support/AVA/ava-helper --uninstall-trust; launchctl unload -w ~/Library/LaunchAgents/se.ava.helper.plist && rm "$_"` |
-| Linux | `systemctl --user disable --now ava-helper` |
-| Windows | `schtasks /delete /tn "AVA Helper" /f` |
+`./ava-helper --uninstall` avregistrerar servicen på alla OS (launchctl unload /
+systemctl --user disable / schtasks /Delete). Binär + data-dir lämnas kvar; ta
+bort dem manuellt vid behov. På macOS: `--uninstall-trust` tar bort CA:n ur
+keychain.
 
 ## Release-process
 

--- a/helper-app/src/install.ts
+++ b/helper-app/src/install.ts
@@ -1,0 +1,205 @@
+/**
+ * Self-install (#86): `ava-helper --install` / `--uninstall`.
+ *
+ * BESLUT (#86): self-install — binären installerar SIG SJÄLV som en
+ * användar-service (ingen sudo), i stället för separata .pkg/.msi/.deb. Ett
+ * kommando på alla tre OS:
+ *   1. kopierar binären till data-dir (`resolveDataDir`),
+ *   2. skriver service-definitionen (launchd-plist / systemd-unit / Task
+ *      Scheduler-XML) med ABSOLUT path till binären,
+ *   3. registrerar + startar servicen (launchctl / systemctl --user / schtasks),
+ *   4. installerar lokal-CA-trust på macOS (`--install-trust`, ADR 0006) så
+ *      Safari/WKWebView litar på HTTPS-loopback (Office-add-ins #83).
+ * Self-update (#78/#110) sköts sedan av den körande servicen.
+ *
+ * SIGNERING/NOTARISERING (Apple Developer ID / Windows-cert) är ett SEPARAT,
+ * manuellt steg som kräver byråns/utgivarens certifikat — kan inte göras i
+ * koden. Utan det varnar OS:et vid första körning. Se README + #87.
+ *
+ * Allt OS-anrop går via injicerade deps (SOLID) → testbart utan att faktiskt
+ * röra maskinen (samma mönster som tls/trust.ts).
+ */
+
+import { join } from "node:path";
+import { resolveDataDir, type DataDirEnv } from "./paths.ts";
+import type { Platform } from "./platform/runtime.ts";
+
+const LABEL = "se.ava.helper";
+
+export interface InstallPaths {
+  /** Var binären ska bo (kopieras hit från execPath). */
+  binPath: string;
+  /** Service-definitionens målfil (plist/unit/xml). */
+  servicePath: string;
+  /** Logg-katalog (macOS launchd skriver hit). */
+  logDir: string;
+}
+
+/** Lös installations-paths per OS. `null` = ej stödd plattform / ingen home. */
+export function resolveInstallPaths(platform: Platform, home: string, env: DataDirEnv = {}): InstallPaths | null {
+  const dataDir = resolveDataDir(platform, home, env);
+  if (dataDir === null) return null;
+  const exe = platform === "windows" ? "ava-helper.exe" : "ava-helper";
+  const binPath = join(dataDir, exe);
+  switch (platform) {
+    case "darwin":
+      return { binPath, servicePath: join(home, "Library", "LaunchAgents", `${LABEL}.plist`), logDir: join(home, "Library", "Logs", "AVA") };
+    case "linux":
+      return { binPath, servicePath: join(home, ".config", "systemd", "user", "ava-helper.service"), logDir: join(dataDir, "logs") };
+    case "windows":
+      return { binPath, servicePath: join(dataDir, "ava-helper-task.xml"), logDir: join(dataDir, "logs") };
+    default:
+      return null;
+  }
+}
+
+/** launchd-user-agent (KeepAlive → startar om efter self-update-exit). */
+export function renderLaunchdPlist(binPath: string, logDir: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>${LABEL}</string>
+    <key>ProgramArguments</key><array><string>${binPath}</string></array>
+    <key>RunAtLoad</key><true/>
+    <key>KeepAlive</key><true/>
+    <key>ProcessType</key><string>Background</string>
+    <key>StandardOutPath</key><string>${join(logDir, "launchd.out.log")}</string>
+    <key>StandardErrorPath</key><string>${join(logDir, "launchd.err.log")}</string>
+    <key>ThrottleInterval</key><integer>30</integer>
+</dict>
+</plist>
+`;
+}
+
+/** systemd user-unit (Restart=always → startar om efter self-update-exit). */
+export function renderSystemdUnit(binPath: string): string {
+  return `[Unit]
+Description=AVA Helper — lokala dokument-broker
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=${binPath}
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=ava-helper
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+/** Windows Task Scheduler-XML (kör vid logon, startar om vid krasch). */
+export function renderWindowsTaskXml(binPath: string): string {
+  return `<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <Triggers><LogonTrigger><Enabled>true</Enabled></LogonTrigger></Triggers>
+  <Settings>
+    <RestartOnFailure><Interval>PT1M</Interval><Count>3</Count></RestartOnFailure>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+  </Settings>
+  <Actions><Exec><Command>${binPath}</Command></Exec></Actions>
+</Task>
+`;
+}
+
+/** Service-definitionens innehåll för plattformen. */
+export function renderServiceFile(platform: Platform, paths: InstallPaths): string {
+  switch (platform) {
+    case "darwin":
+      return renderLaunchdPlist(paths.binPath, paths.logDir);
+    case "linux":
+      return renderSystemdUnit(paths.binPath);
+    case "windows":
+      return renderWindowsTaskXml(paths.binPath);
+    default:
+      return "";
+  }
+}
+
+/** Kommandon för att (av)registrera servicen — rena arg-byggare (testbara). */
+export function registerArgs(platform: Platform, paths: InstallPaths): Array<{ cmd: string; args: string[] }> {
+  switch (platform) {
+    case "darwin":
+      return [
+        { cmd: "launchctl", args: ["unload", paths.servicePath] },
+        { cmd: "launchctl", args: ["load", "-w", paths.servicePath] },
+      ];
+    case "linux":
+      return [
+        { cmd: "systemctl", args: ["--user", "daemon-reload"] },
+        { cmd: "systemctl", args: ["--user", "enable", "--now", "ava-helper"] },
+      ];
+    case "windows":
+      return [{ cmd: "schtasks", args: ["/Create", "/F", "/TN", "AVA Helper", "/XML", paths.servicePath] }];
+    default:
+      return [];
+  }
+}
+
+export function unregisterArgs(platform: Platform, paths: InstallPaths): Array<{ cmd: string; args: string[] }> {
+  switch (platform) {
+    case "darwin":
+      return [{ cmd: "launchctl", args: ["unload", "-w", paths.servicePath] }];
+    case "linux":
+      return [{ cmd: "systemctl", args: ["--user", "disable", "--now", "ava-helper"] }];
+    case "windows":
+      return [{ cmd: "schtasks", args: ["/Delete", "/F", "/TN", "AVA Helper"] }];
+    default:
+      return [];
+  }
+}
+
+/** Injicerbara OS-/fs-beroenden (SOLID) — fakes i test, riktiga i main. */
+export interface InstallDeps {
+  mkdirp: (dir: string) => void;
+  copyFile: (from: string, to: string) => void;
+  chmodExec: (path: string) => void;
+  writeFile: (path: string, content: string) => void;
+  run: (cmd: string, args: string[]) => void;
+  /** macOS CA-trust (no-op på andra OS). */
+  installTrust: () => void;
+  log: (msg: string) => void;
+}
+
+/**
+ * Installera helpern som user-service. Ren orkestrering över injicerade deps:
+ * kopiera binär → skriv service-fil → registrera → (macOS) trust.
+ */
+export function installService(platform: Platform, home: string, execPath: string, deps: InstallDeps, env: DataDirEnv = {}): boolean {
+  const paths = resolveInstallPaths(platform, home, env);
+  if (!paths) {
+    deps.log(`self-install stöds inte på plattformen "${platform}"`);
+    return false;
+  }
+  deps.mkdirp(dirOf(paths.binPath));
+  deps.mkdirp(dirOf(paths.servicePath));
+  deps.mkdirp(paths.logDir);
+  if (execPath !== paths.binPath) {
+    deps.copyFile(execPath, paths.binPath);
+    deps.chmodExec(paths.binPath);
+  }
+  deps.writeFile(paths.servicePath, renderServiceFile(platform, paths));
+  for (const { cmd, args } of registerArgs(platform, paths)) deps.run(cmd, args);
+  if (platform === "darwin") deps.installTrust();
+  deps.log(`ava-helper installerad som user-service (${paths.binPath})`);
+  return true;
+}
+
+/** Avregistrera servicen (binären/data-dir lämnas kvar). */
+export function uninstallService(platform: Platform, home: string, deps: InstallDeps, env: DataDirEnv = {}): boolean {
+  const paths = resolveInstallPaths(platform, home, env);
+  if (!paths) return false;
+  for (const { cmd, args } of unregisterArgs(platform, paths)) deps.run(cmd, args);
+  deps.log("ava-helper avregistrerad");
+  return true;
+}
+
+function dirOf(path: string): string {
+  const i = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  return i <= 0 ? path : path.slice(0, i);
+}

--- a/helper-app/src/main.ts
+++ b/helper-app/src/main.ts
@@ -15,6 +15,9 @@
  */
 
 import { join } from "node:path";
+import { homedir } from "node:os";
+import { mkdirSync, copyFileSync, chmodSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 
 import { HELPER_HTTPS_PORT, HELPER_PORT } from "@/lib/shared/helper/protocol";
 
@@ -24,6 +27,8 @@ import { createHandler } from "./server.ts";
 import { loadOrCreateTls } from "./tls/certs.ts";
 import { installCaTrust, removeCaTrust } from "./tls/trust.ts";
 import { checkOnce, runUpdateLoop, type UpdateConfig } from "./update.ts";
+import { installService, uninstallService, type InstallDeps } from "./install.ts";
+import { currentPlatform } from "./platform/runtime.ts";
 import { VERSION } from "./version.ts";
 
 const SHUTDOWN_TIMEOUT_MS = 5_000;
@@ -60,6 +65,28 @@ function handleTrust(action: "install" | "uninstall"): void {
     res.skipped ? `${label}: hoppad (${res.reason ?? ""})\n` : `${label}: ${res.ok ? "ok" : "misslyckades"}\n`,
   );
   if (!res.ok && !res.skipped) process.exitCode = 1;
+}
+
+/** Riktiga OS-/fs-deps för self-install (#86). */
+function installDeps(): InstallDeps {
+  return {
+    mkdirp: (dir) => mkdirSync(dir, { recursive: true }),
+    copyFile: (from, to) => copyFileSync(from, to),
+    chmodExec: (path) => chmodSync(path, 0o755),
+    writeFile: (path, content) => writeFileSync(path, content, "utf8"),
+    run: (cmd, args) => { spawnSync(cmd, args, { stdio: "inherit" }); },
+    installTrust: () => handleTrust("install"),
+    log: (msg) => process.stdout.write(`${msg}\n`),
+  };
+}
+
+/** `--install` / `--uninstall`: registrera/avregistrera helpern som user-service. */
+function handleInstall(action: "install" | "uninstall"): void {
+  const ok =
+    action === "install"
+      ? installService(currentPlatform(), homedir(), process.execPath, installDeps())
+      : uninstallService(currentPlatform(), homedir(), installDeps());
+  if (!ok) process.exitCode = 1;
 }
 
 type Handler = (req: Request) => Promise<Response>;
@@ -116,6 +143,14 @@ function main(): void {
   }
   if (process.argv.includes("--uninstall-trust")) {
     handleTrust("uninstall");
+    return;
+  }
+  if (process.argv.includes("--install")) {
+    handleInstall("install");
+    return;
+  }
+  if (process.argv.includes("--uninstall")) {
+    handleInstall("uninstall");
     return;
   }
 

--- a/helper-app/test/install.test.ts
+++ b/helper-app/test/install.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  resolveInstallPaths,
+  renderLaunchdPlist,
+  renderSystemdUnit,
+  renderWindowsTaskXml,
+  registerArgs,
+  unregisterArgs,
+  installService,
+  uninstallService,
+  type InstallDeps,
+  type InstallPaths,
+} from "../src/install.ts";
+
+const HOME = "/home/anna";
+
+describe("resolveInstallPaths", () => {
+  test("macOS: launchd-plist + Application Support-bin", () => {
+    const p = resolveInstallPaths("darwin", HOME)!;
+    expect(p.binPath).toBe(`${HOME}/Library/Application Support/AVA/ava-helper`);
+    expect(p.servicePath).toBe(`${HOME}/Library/LaunchAgents/se.ava.helper.plist`);
+  });
+  test("Linux: systemd user-unit + .local/share-bin", () => {
+    const p = resolveInstallPaths("linux", HOME)!;
+    expect(p.binPath).toBe(`${HOME}/.local/share/AVA/ava-helper`);
+    expect(p.servicePath).toBe(`${HOME}/.config/systemd/user/ava-helper.service`);
+  });
+  test("Windows: .exe-binär + task-xml", () => {
+    const p = resolveInstallPaths("windows", HOME, { localAppData: "C:/Users/Anna/AppData/Local" })!;
+    expect(p.binPath.endsWith("ava-helper.exe")).toBe(true);
+    expect(p.servicePath.endsWith("ava-helper-task.xml")).toBe(true);
+  });
+  test("ostödd plattform → null", () => {
+    expect(resolveInstallPaths("other", HOME)).toBeNull();
+  });
+});
+
+describe("service-fil-renderare", () => {
+  test("launchd-plist bär absolut bin-path + KeepAlive + label", () => {
+    const xml = renderLaunchdPlist("/bin/ava-helper", "/logs");
+    expect(xml).toContain("<string>/bin/ava-helper</string>");
+    expect(xml).toContain("<key>KeepAlive</key><true/>");
+    expect(xml).toContain("se.ava.helper");
+  });
+  test("systemd-unit har ExecStart + Restart=always", () => {
+    const u = renderSystemdUnit("/bin/ava-helper");
+    expect(u).toContain("ExecStart=/bin/ava-helper");
+    expect(u).toContain("Restart=always");
+  });
+  test("windows task-xml har Command", () => {
+    expect(renderWindowsTaskXml("C:/x/ava-helper.exe")).toContain("<Command>C:/x/ava-helper.exe</Command>");
+  });
+});
+
+describe("registerArgs / unregisterArgs", () => {
+  const p: InstallPaths = { binPath: "/b", servicePath: "/s", logDir: "/l" };
+  test("macOS: launchctl load / unload", () => {
+    expect(registerArgs("darwin", p).at(-1)).toEqual({ cmd: "launchctl", args: ["load", "-w", "/s"] });
+    expect(unregisterArgs("darwin", p)[0]).toEqual({ cmd: "launchctl", args: ["unload", "-w", "/s"] });
+  });
+  test("Linux: systemctl enable / disable --user", () => {
+    expect(registerArgs("linux", p).at(-1)).toEqual({ cmd: "systemctl", args: ["--user", "enable", "--now", "ava-helper"] });
+    expect(unregisterArgs("linux", p)[0]).toEqual({ cmd: "systemctl", args: ["--user", "disable", "--now", "ava-helper"] });
+  });
+  test("Windows: schtasks /Create /Delete", () => {
+    expect(registerArgs("windows", p)[0]!.args).toContain("/Create");
+    expect(unregisterArgs("windows", p)[0]!.args).toContain("/Delete");
+  });
+});
+
+interface Recorder {
+  copied: Array<[string, string]>;
+  written: string[];
+  ran: Array<{ cmd: string; args: string[] }>;
+  trust: number;
+  deps: InstallDeps;
+}
+
+function recorder(): Recorder {
+  const r: Recorder = { copied: [], written: [], ran: [], trust: 0, deps: {} as InstallDeps };
+  r.deps = {
+    mkdirp: () => {},
+    copyFile: (from, to) => { r.copied.push([from, to]); },
+    chmodExec: () => {},
+    writeFile: (path) => { r.written.push(path); },
+    run: (cmd, args) => { r.ran.push({ cmd, args }); },
+    installTrust: () => { r.trust += 1; },
+    log: () => {},
+  };
+  return r;
+}
+
+describe("installService (orkestrering)", () => {
+  test("macOS: kopierar binär, skriver plist, laddar launchd, installerar trust", () => {
+    const r = recorder();
+    const ok = installService("darwin", HOME, "/tmp/ava-helper", r.deps);
+    expect(ok).toBe(true);
+    expect(r.copied[0]![1]).toBe(`${HOME}/Library/Application Support/AVA/ava-helper`);
+    expect(r.written.some((p) => p.endsWith("se.ava.helper.plist"))).toBe(true);
+    expect(r.ran.some((c) => c.cmd === "launchctl" && c.args.includes("load"))).toBe(true);
+    expect(r.trust).toBe(1);
+  });
+
+  test("Linux: ingen trust, systemctl enable", () => {
+    const r = recorder();
+    installService("linux", HOME, "/tmp/ava-helper", r.deps);
+    expect(r.trust).toBe(0);
+    expect(r.ran.some((c) => c.cmd === "systemctl" && c.args.includes("enable"))).toBe(true);
+  });
+
+  test("hoppar kopiering när binären redan ligger på målet", () => {
+    const r = recorder();
+    const target = `${HOME}/.local/share/AVA/ava-helper`;
+    installService("linux", HOME, target, r.deps);
+    expect(r.copied).toHaveLength(0);
+  });
+
+  test("ostödd plattform → false, inga sidoeffekter", () => {
+    const r = recorder();
+    expect(installService("other", HOME, "/tmp/x", r.deps)).toBe(false);
+    expect(r.written).toHaveLength(0);
+  });
+});
+
+describe("uninstallService", () => {
+  test("macOS: launchctl unload", () => {
+    const r = recorder();
+    expect(uninstallService("darwin", HOME, r.deps)).toBe(true);
+    expect(r.ran[0]).toEqual({ cmd: "launchctl", args: ["unload", "-w", `${HOME}/Library/LaunchAgents/se.ava.helper.plist`] });
+  });
+});


### PR DESCRIPTION
## Beslut (#86) — self-install

Binären registrerar **sig själv** som user-service (ingen sudo, ingen .pkg/.msi/.deb). Ett kommando, samma binär på macOS/Linux/Windows:

```bash
./ava-helper --install      # registrera service + (macOS) CA-trust
./ava-helper --uninstall    # avregistrera
```

`--install`:
1. kopierar binären till data-dir (`resolveDataDir` — Application Support / .local/share / %LOCALAPPDATA%),
2. skriver service-definitionen (**launchd-plist** / **systemd user-unit** / **Task Scheduler-XML**) med absolut bin-path,
3. registrerar + startar (`launchctl load` / `systemctl --user enable --now` / `schtasks /Create`) → startar vid login, lyssnar på loopback,
4. macOS: installerar lokal-CA-trust (`--install-trust`, ADR 0006) för Safari/WKWebView HTTPS-loopback (Office-add-ins #83).

Self-update (#78/#110) sköts sedan av den körande servicen.

## Arkitektur

`install.ts`: rena renderare (plist/unit/xml) + path-resolvers + arg-byggare, och en orkestrering över **injicerade OS-/fs-deps** (samma SOLID-mönster som `tls/trust.ts`). → testbart med fakes **utan att röra maskinen** (jag kör aldrig `--install` lokalt). `install.ts` 98 % linjetäckt; 15 tester (paths, renderare, register-args, orkestrering per OS, ostödd-plattform, idempotent skip).

## Kvarstår (separat, kräver dina certifikat) → #275

**Signering/notarisering** (Apple Developer ID + notarytool / Windows Authenticode) kan inte göras i koden — kräver utgivarens kodsignerings-cert/konton. Osignerad binär **fungerar** men ger en Gatekeeper-/SmartScreen-varning vid första körning. Spåras i **#275**. Self-update-signaturen (#110, Ed25519) är ortogonal mot OS-kodsignering.

## Verifierat lokalt

helper typecheck rent (utöver pre-existing `node-forge`-worktree-artefakt), lint rent, repo `deps:check` 0 violations. 15 install-tester pass.

Closes #86
Refs #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)