### PR TITLE
docs(adr): revidera 0013 — add-in:en är git-medveten klient (ej helper-brygga) (#83)

### DIFF
--- a/docs/adr/0013-office-add-in-arkitektur.md
+++ b/docs/adr/0013-office-add-in-arkitektur.md
@@ -1,6 +1,6 @@
-# ADR 0013 — Office-add-in-arkitektur: helpern som git-peer + loopback-brygga
+# ADR 0013 — Office-add-in-arkitektur: add-in:en är en git-medveten AVA-klient
 
-- **Status:** Accepterad
+- **Status:** Accepterad (reviderad 2026-06-13 — se "Ändringshistorik")
 - **Datum:** 2026-06-13
 - **Beslutsfattare:** Ulrik Sjölin
 - **Berör:** helper-appen (#78/#86/#110), Office-add-ins (#83 plattform, #84 Word, #72 Outlook), git-db-åtkomst
@@ -14,98 +14,121 @@ infoga ärende-/klient-/malldata och spara dokument/mail tillbaka till ärendets
 git-db. Office-add-ins är Office.js-appar med samma grundbehov → bygg grunden
 en gång (#83), så blir host-add-insen tunna feature-lager.
 
-**Verifierade begränsningar:**
-- Office-add-ins kör i en **sandboxad webview UTAN filsystem/OS-åtkomst** (alla
-  plattformar) → kan inte köra OPFS/isomorphic-git → kan **inte** röra git-db
-  direkt. Måste bryggas via helpern.
-- På macOS (WebKit) krävs **HTTPS på loopback** (inte http) → helperns lokala
-  CA måste vara betrodd (ADR 0006; installeras av `ava-helper --install`, #86).
-- Git-db:n ägs idag av **web-appen** (OPFS-klon + iso-git). Helpern är hittills
-  tier-agnostisk och äger inte git-db (bara `/open`, `/compose-mail`).
+**Förutsättningar:**
+- Office-add-ins kör i en **browser-webview** (WebView2 på Windows, WKWebView på
+  macOS) utan OS-filsystem — MEN med browser-storage-API:er (IndexedDB, ev.
+  OPFS) och `fetch`. Det är samma miljö som AVA-web-appen använder för sin
+  self-hosted-klon (isomorphic-git mot browser-storage). Add-in:en kan alltså
+  **själv köra git-db:n** precis som web-appen — den behöver ingen helper-brygga
+  för data.
+- Git-db-klienten + domän-routrarna + zod-scheman lever redan i web-appens
+  `src/lib` (ADR 0001:s seam; tRPC in-process via `GitBackendRuntime`/`inProcessLink`).
+  Add-in:en **importerar den delade koden** i stället för att reimplementera.
+- Push mot `firma.git`-remoten sker över HTTPS (samma som web-appens
+  self-hosted-läge). Add-in:en är en egen origin → OIDC-cookien (ADR 0009) följer
+  INTE med automatiskt; auth-credential för push måste lösas explicit (se beslut 2).
 
 ## Beslut
 
-### 1. Datatväg: helpern blir en git-peer (1B)
+### 1. Datatväg: add-in:en är en git-medveten AVA-klient (INGEN helper)
 
-**Helpern görs git-medveten** — den klonar en egen `firma.git`-working-copy och
-kör **samma tRPC-routrar in-process** som webben och server-runtime:n, via
-`GitBackendRuntime` (ADR 0005). Add-in:en pratar med helpern över
-HTTPS-loopback; helpern kör mutationen mot sin working-copy och pushar.
+Add-in:en kör **AVA:s git-db-klient själv** — samma kod som web-appen i
+self-hosted-läge. Den **importerar den delade lib:en** (IDataStore/`DemoDataStore`
++ iso-git-klienten + tRPC-routrarna + zod-scheman ur web-appens `src/lib`),
+klonar `firma.git` till add-in-webviewens browser-storage, kör routrarna
+in-process (`GitBackendRuntime`/`inProcessLink`, ADR 0005) och pushar till
+remoten över HTTPS. **Helpern är inte i datatvägen.**
 
 ```
-Office-add-in (Office.js, task-pane)
-   │  tRPC över HTTPS-loopback (127.0.0.1, helperns lokala CA)
-   ▼
-helper-app (Bun)  ──  GitBackendRuntime (samma routrar + zod-scheman, ADR 0001/0005)
-   │  clone / pull → act → push  (git-peer, ADR 0005)
-   ▼
-firma.git (remote)
+Office-add-in (Office.js, task-pane)  ──  importerar AVA:s src/lib
+   ├─ git-db-klient (iso-git mot browser-storage)  ← samma som web-appen
+   ├─ tRPC in-process (GitBackendRuntime, ADR 0005) → domän-routrar + zod
+   └─ Office.js för dokument-/mail-sidan (insert/läs)
+        │  clone / pull → act → push (HTTPS)
+        ▼
+   firma.git (remote)
 ```
 
-- Add-in:en innehåller en **`IDataStore`-bryggimplementation** som routar
-  tRPC-anrop via HTTPS-loopback till helpern (ADR 0001:s seam) → domän-routrar +
-  zod-scheman återanvänds, ingen reimplementation.
-- Add-in:en fungerar **fristående** — ingen öppen AVA-webbflik krävs.
+- **Ingen helper-brygga, ingen helper-git-peer.** Add-in:en är "ännu en
+  AVA-klient" precis som en web-flik — fristående.
+- **Kod-import = #85:s trigger.** En andra bundler (add-in) som delar MER än
+  kontrakt (hela git-db-klienten + routrarna) är exakt den situation [#85](https://github.com/ulrik-s/ava/issues/85)
+  pekade ut. Per #85: gör det lazily — börja med `@/`-path-alias; om aliaset
+  läcker (add-in-bundlern drar av misstag in Next/server-only-kod) bryt ut ett
+  **source-only `@ava/core`** (inga dist/builds). dep-cruiser-regler bevakar
+  gränsen oavsett.
+- **Flera git-peers** (web-OPFS-klon, server-runtime, add-in-klon) mot samma
+  remote → oförändrad konflikt-hantering, last-write-wins + git-merge
+  ([ADR 0002](./0002-git-konflikthantering-backend-a.md)).
 
-**Flera git-peers samexisterar** redan i modellen: webbens OPFS-klon,
-server-runtime:n (#80/#82) och nu helpern är alla peers mot samma `firma.git`.
-Konflikt-/sammanslagningshantering är **oförändrad** — last-write-wins +
-git-merge per [ADR 0002](./0002-git-konflikthantering-backend-a.md). Helpern
-inför alltså ingen ny konfliktmodell; den är "ännu en peer".
+### 2. Auth: add-in:en autentiserar sin egen push (egen origin)
 
-### 2. Auth: loopback-förtroende, författare = helperns identitet (2A)
+OIDC-cookien (ADR 0009) följer inte med till add-in-originen. Add-in:en behöver
+ett eget push-credential mot `firma.git`:
+- **v1: PAT/deploy-key i add-in:ens storage** (samma maskin-/klient-principal-
+  väg som ADR 0009 lämnar för icke-browser-git — anges en gång, lagras i
+  add-in-webviewens storage). Commit-författare härleds ur den principalen.
+- **Senare: OIDC i add-in-webviewen** (egen oauth2-proxy-login i en dialog/popup)
+  för fullständig människo-auth — uppskjutet (mer Office.js-dialog-arbete).
+- **MS Graph-token** (Office-sidans data: mail/kalender via Office.js) är
+  **ortogonal** mot git-db-pushen.
 
-OIDC-cookien (ADR 0009) följer inte in i Office-sandboxen. För v1:
-- **Helpern litar på den lokala anroparen** (samma förtroende som dagens
-  `/open` — helpern är användarens egen process på loopback).
-- **Commit-författaren** tas från helperns konfigurerade/inloggade identitet
-  (samma princip som server-runtime-principalen, ADR 0005) — INTE från
-  add-in:en. Add-in:en bär ingen egen AVA-token i v1.
-- **MS Graph-token** (för Office-sidans data: mail/kalender via Office.js) är
-  **ortogonal** — den hämtas av add-in:en för Office-API:t och rör inte
-  git-db-åtkomsten.
-
-Per-användar-författarskap via add-in-token (alt 2B) är en framtida uppgradering
-om/när flera jurister delar samma helper-värd.
+*(Detta är den kvarvarande sub-frågan att spika vid implementation: PAT-i-storage
+för v1 vs OIDC-i-webview. Lutar åt PAT för v1.)*
 
 ### 3. Omfattning av #83: full delad shell + båda manifesten (3B)
 
 #83 bygger **hela den delade grunden**:
-- En delad Office.js **task-pane-shell** (UI-skal + helper-brygga + IDataStore-
-  bryggan), återanvändbar av båda hosts.
-- **Add-in-manifest per host** (Word + Outlook).
-- Helpern **serverar add-in-bundlen över HTTPS-loopback** (CA-trust via #86).
+- En delad Office.js **task-pane-shell** (UI-skal + den importerade git-db-
+  klienten + tRPC-in-process-uppsättningen), återanvändbar av båda hosts.
+- **Add-in-manifest per host** (Word + Outlook), HTTPS-serverad bundle.
+- Mekanismen att **importera/dela web-appens `src/lib`** in i add-in-bundlern
+  (alias eller `@ava/core` om aliaset läcker, jfr #85).
 
 Då blir **#84 (Word)** och **#72 (Outlook)** tunna feature-lager ovanpå shell:en.
 
 ## Konsekvenser
 
-- **+** Add-ins fungerar fristående (ingen öppen webbflik) — robust UX.
-- **+** Återanvänder backend-seam (ADR 0001) + git-peer-lagret (ADR 0005) →
-  routrar/scheman delas, ingen reimplementation.
-- **+** Allt lokalt/offline: helper-loopback servar både bundle och data; CA-
-  trusten finns redan (#86).
+- **+** Add-ins fungerar **fristående** (ingen öppen webbflik, ingen helper i
+  datatvägen) — robust UX, en arkitektur (add-in = AVA-klient).
+- **+** Maximal kod-återanvändning: add-in:en importerar web-appens git-db-
+  klient + routrar + scheman rakt av (ADR 0001-seam) — ingen brygg-/proxy-kod,
+  ingen reimplementation.
+- **+** Helpern slipper en git-peer-roll — förblir den tunna doc/mail-brokern
+  (`/open`, `/compose-mail`). Mindre klient-state.
 - **+** #84/#72 blir tunna givet 3B.
-- **−** Helpern får en **tyngre roll** (äger en working-copy, push/pull,
-  remote-credential) — mer state + ansvar på klienten än dagens broker.
-- **−** Två lokala git-peers (webbens OPFS-klon + helpern) kan skriva mot samma
-  remote → hanteras av ADR 0002 (last-write-wins), men användaren kan behöva
-  pull/refresh i webben för att se add-in-skapade ändringar.
-- **−** Helpern behöver remote-credential för push (PAT/deploy-key, separat
-  från människo-OIDC, jfr ADR 0009 maskin-principaler).
-- **−** OS-kodsignering av helpern (#275) kvarstår oberoende.
+- **−** **Teknisk risk att validera tidigt:** add-in-webviewen måste faktiskt
+  stödja browser-storage (IndexedDB/OPFS) för iso-git-klonen + tillåta
+  cross-origin HTTPS-push (CORS) mot `firma.git`-remoten. Detta är miljön
+  ADR:ns ursprungliga version undvek via helpern — det är nu ett antagande som
+  ett tidigt spike-steg i #83 ska bekräfta per host (WebView2/WKWebView).
+- **−** **Push-auth utan same-origin-cookie:** add-in:en måste bära ett eget
+  credential (PAT i storage för v1) — ett credential i webview-storage (mindre
+  bra än helperns process-förtroende, men lokalt på användarens maskin).
+- **−** Add-in:en drar in **hela git-db-klienten** i sin bundle → större bundle
+  + #85:s alias-/`@ava/core`-fråga aktiveras (hanteras lazily, se beslut 1).
+- **−** Flera git-peers (web + add-in + server-runtime) → ADR 0002 last-write-
+  wins; användaren kan behöva refresh i en öppen webbflik för att se add-in-
+  ändringar.
 
 ## Alternativ (förkastade)
 
-- **1A — `Add-in → helper → öppen web-app → git-db`:** kräver att en AVA-flik
-  är öppen samtidigt → skör UX + "vilken flik"-tvetydighet. Helpern blir bara en
-  proxy, men beroendet av en öppen webb gör den opålitlig. Nej.
-- **1C — Add-in bäddar in web-appen (iframe) + använder OPFS direkt:** OPFS/iso-
-  git i Office-WebView (WebKit) är oprövat/osäkert; CORS + cookie-isolering;
-  samma dubbel-klon-konflikt som 1B men i en skörare miljö. Nej.
-- **2B — Add-in bär egen AVA-token:** korrekt per-användar-författarskap men
-  token-livscykel i Office-sandboxen är overkill för v1 (en helper-värd =
-  en jurist). Uppskjutet.
-- **3A — Word + minimal vertikal slice först:** mindre, men #84/#72 skulle få
-  bygga shell-grunden ändå. Vi tar full shell direkt (3B) så host-add-insen blir
-  tunna.
+- **1B (tidigare valt, nu ersatt) — helpern blir git-peer, add-in → helper-
+  loopback → git-db:** undviker att köra git-db i add-in-webviewen, men ger
+  helpern en tung git-peer-roll + en brygg-/proxy-väg + helper-credential.
+  Ersatt: add-in-som-klient ger en enklare, enhetlig arkitektur (add-in = samma
+  AVA-klient som webben) och slipper helper-git-peer-komplexiteten. Risken
+  flyttas till "funkar git-db i webviewen?" (valideras i #83-spiken).
+- **1A — `Add-in → helper → öppen web-app → git-db`:** kräver att en AVA-flik är
+  öppen samtidigt → skör UX. Nej.
+- **3A — Word + minimal vertikal slice först:** vi tar full shell direkt (3B) så
+  host-add-insen blir tunna.
+
+## Ändringshistorik
+
+- **2026-06-13 (revidering):** Datatvägen ändrad från **1B (helpern som git-peer
+  + loopback-brygga)** till **add-in:en som git-medveten AVA-klient som importerar
+  web-appens lib** (ingen helper i datatvägen). Auth-beslutet (2) ändrat från
+  loopback-förtroende till add-in:ens egna push-credential (PAT v1). Inget hade
+  byggts på 1B-beslutet. Skäl: enklare, enhetlig arkitektur (add-in = AVA-klient);
+  helpern hålls tunn. Ny risk att validera: git-db i add-in-webviewen.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,8 +37,9 @@
 >   externt system (Fortnox) har var sin obrutna serie, aldrig en delad räknare
 >   (lagligt enl. 17 kap. 24 § 2 ML / art. 226.2 momsdirektivet).
 > - [ADR 0013](./adr/0013-office-add-in-arkitektur.md) — Office-add-ins (Word/
->   Outlook): helpern blir git-peer (`GitBackendRuntime`) + loopback-brygga;
->   add-in → helper → git-db, loopback-förtroende-auth, delad task-pane-shell.
+>   Outlook): add-in:en är en git-medveten AVA-klient som importerar web-appens
+>   lib (git-db-klient + routrar) och kör/pushar själv — INGEN helper i
+>   datatvägen; egen push-credential (PAT v1); delad task-pane-shell.
 
 ## Tre lager
 


### PR DESCRIPTION
## Vad

Du ändrade dig om #83-arkitekturen. Reviderar ADR 0013: **add-in:en är en git-medveten AVA-klient som importerar web-appens lib — ingen helper i datatvägen.**

## Nytt beslut (ersätter tidigare 1B)

- **Datatväg:** add-in:en kör AVA:s git-db-klient själv — importerar `src/lib` (iso-git-klient + tRPC-routrar + zod-scheman), klonar `firma.git` till add-in-webviewens browser-storage, kör routrarna in-process (`GitBackendRuntime`, ADR 0005) och pushar själv över HTTPS. Helpern är **inte** inblandad. Add-in = "ännu en AVA-klient" (som en web-flik).
- **Auth:** egen origin → OIDC-cookien följer ej med; add-in:en bär eget push-credential — **v1 = PAT i storage** (maskin-principal-väg, ADR 0009). OIDC-i-webview uppskjutet. MS Graph-token ortogonal.
- **Kod-delning = #85:s trigger:** en andra bundler som delar mer än kontrakt → lazily per #85 (alias först, source-only `@ava/core` om aliaset läcker).
- **#83-scope (3B):** delad task-pane-shell + båda manifesten + import-mekanismen för `src/lib`.

## Ärligt om risken

ADR:ns ursprungliga premiss var "add-in-webviewen kan inte köra git-db → helper-brygga". Det nya beslutet förutsätter motsatsen → **ett tidigt spike-steg i #83 måste bekräfta** att add-in-webviewen (WebView2/WKWebView) stödjer browser-storage (IndexedDB/OPFS) för iso-git-klonen + cross-origin HTTPS-push (CORS). Det är dokumenterat som risk + ordnings-steg 1 i ADR:n.

Förkastat 1B (helper-git-peer) — inget hade byggts på det. Ändringshistorik i ADR:n. Docs-only.

Refs #83 #84 #72 #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)