### PR TITLE
docs(adr): revidera 0013 — tunn server med git-db + HTTP-API (#83)

### DIFF
--- a/docs/adr/0013-office-add-in-arkitektur.md
+++ b/docs/adr/0013-office-add-in-arkitektur.md
@@ -1,134 +1,138 @@
-# ADR 0013 — Office-add-in-arkitektur: add-in:en är en git-medveten AVA-klient
+# ADR 0013 — Office-add-in-arkitektur: tunn server med git-db + HTTP-API, add-ins som tunna klienter
 
-- **Status:** Accepterad (reviderad 2026-06-13 — se "Ändringshistorik")
+- **Status:** Accepterad (reviderad 2× 2026-06-13 — se "Ändringshistorik")
 - **Datum:** 2026-06-13
 - **Beslutsfattare:** Ulrik Sjölin
-- **Berör:** helper-appen (#78/#86/#110), Office-add-ins (#83 plattform, #84 Word, #72 Outlook), git-db-åtkomst
+- **Berör:** server-runtime (ADR 0005, #80/#82), Office-add-ins (#83 plattform, #84 Word, #72 Outlook), git-db-åtkomst för native-klienter
 - **Issue:** [#83](https://github.com/ulrik-s/ava/issues/83)
-- **Relaterat:** [ADR 0001](./0001-pluggbar-backend-bakom-idatastore.md) (pluggbar backend-seam), [ADR 0002](./0002-git-konflikthantering-backend-a.md) (git-konflikt: last-write-wins), [ADR 0005](./0005-server-som-git-peer.md) (server som git-peer / `GitBackendRuntime`), [ADR 0006](./0006-helper-https-lokal-ca.md) (helper-HTTPS via lokal CA), [ADR 0009](./0009-oidc-login-via-servern.md) (auth)
+- **Relaterat:** [ADR 0001](./0001-pluggbar-backend-bakom-idatastore.md) (pluggbar backend-seam), [ADR 0002](./0002-git-konflikthantering-backend-a.md) (git-konflikt: last-write-wins), [ADR 0005](./0005-server-som-git-peer.md) (server som git-peer / `GitBackendRuntime`), [ADR 0009](./0009-oidc-login-via-servern.md) (auth)
 
 ## Kontext
 
-Advokater vill arbeta i Word (#84) och Outlook (#72) men koppla mot AVA:
-infoga ärende-/klient-/malldata och spara dokument/mail tillbaka till ärendets
-git-db. Office-add-ins är Office.js-appar med samma grundbehov → bygg grunden
-en gång (#83), så blir host-add-insen tunna feature-lager.
+Advokater vill arbeta i Word (#84) och Outlook (#72) men koppla mot AVA: infoga
+ärende-/klient-/malldata och spara dokument/mail tillbaka till ärendets git-db.
+Office-add-ins är Office.js-appar med samma grundbehov → bygg grunden en gång
+(#83), så blir host-add-insen tunna feature-lager.
 
-**Förutsättningar:**
-- Office-add-ins kör i en **browser-webview** (WebView2 på Windows, WKWebView på
-  macOS) utan OS-filsystem — MEN med browser-storage-API:er (IndexedDB, ev.
-  OPFS) och `fetch`. Det är samma miljö som AVA-web-appen använder för sin
-  self-hosted-klon (isomorphic-git mot browser-storage). Add-in:en kan alltså
-  **själv köra git-db:n** precis som web-appen — den behöver ingen helper-brygga
-  för data.
-- Git-db-klienten + domän-routrarna + zod-scheman lever redan i web-appens
-  `src/lib` (ADR 0001:s seam; tRPC in-process via `GitBackendRuntime`/`inProcessLink`).
-  Add-in:en **importerar den delade koden** i stället för att reimplementera.
-- Push mot `firma.git`-remoten sker över HTTPS (samma som web-appens
-  self-hosted-läge). Add-in:en är en egen origin → OIDC-cookien (ADR 0009) följer
-  INTE med automatiskt; auth-credential för push måste lösas explicit (se beslut 2).
+**Problem:** att köra AVA:s git-db-klient (isomorphic-git mot browser-storage)
+*inuti* add-in-webviewen är opålitligt cross-platform — IndexedDB/OPFS-stöd och
+cross-origin-push (CORS) varierar mellan WebView2 (Windows) och WKWebView
+(macOS) och mellan Office-värdar. Att i stället bryggas via den lokala helpern
+binder add-ins till att helpern är installerad + loopback-HTTPS per OS.
+
+**Drivande krav:** add-ins ska funka **på alla plattformar** med minsta möjliga
+klient-antaganden. Den enklaste gemensamma nämnaren är att add-in:en bara gör
+**HTTP-anrop** — något varje webview klarar.
 
 ## Beslut
 
-### 1. Datatväg: add-in:en är en git-medveten AVA-klient (INGEN helper)
+### 1. Den tunna servern äger git-db:n och exponerar den över HTTP (A1)
 
-Add-in:en kör **AVA:s git-db-klient själv** — samma kod som web-appen i
-self-hosted-läge. Den **importerar den delade lib:en** (IDataStore/`DemoDataStore`
-+ iso-git-klienten + tRPC-routrarna + zod-scheman ur web-appens `src/lib`),
-klonar `firma.git` till add-in-webviewens browser-storage, kör routrarna
-in-process (`GitBackendRuntime`/`inProcessLink`, ADR 0005) och pushar till
-remoten över HTTPS. **Helpern är inte i datatvägen.**
+Den tunna servern (self-hosted) kör redan **server-runtime:n** (ADR 0005) med
+domän-routrarna in-process mot en `firma.git`-working-copy (`GitBackendRuntime`,
+för Fortnox-/avpricknings-/påminnelse-jobben). **Vi exponerar samma routrar över
+HTTP** — tRPC-over-HTTP (`httpBatchLink`-server) — på serverns origin (bakom
+nginx-fronten, ADR 0009). Det är "REST-likt" (HTTP + JSON) men återanvänder
+routrar + zod-scheman + end-to-end-typer utan reimplementation (A1, INTE ett
+handskrivet REST-lager).
+
+**Add-ins är tunna tRPC/HTTP-klienter** (`httpBatchLink`) — de äger ingen git-db,
+kör ingen iso-git, behöver inget filsystem/OPFS. De anropar serverns API; servern
+gör mutationen mot sin working-copy och pushar. Fungerar i vilken webview som
+helst på vilken plattform som helst.
 
 ```
-Office-add-in (Office.js, task-pane)  ──  importerar AVA:s src/lib
-   ├─ git-db-klient (iso-git mot browser-storage)  ← samma som web-appen
-   ├─ tRPC in-process (GitBackendRuntime, ADR 0005) → domän-routrar + zod
-   └─ Office.js för dokument-/mail-sidan (insert/läs)
-        │  clone / pull → act → push (HTTPS)
-        ▼
-   firma.git (remote)
+Office-add-in (Office.js, vilken webview/OS som helst)
+   │  tRPC-over-HTTP (httpBatchLink) + Authorization: Bearer <PAT>
+   ▼
+nginx-front (ADR 0009)  →  AVA-server (server-runtime, ADR 0005)
+   │  tRPC-routrar in-process (GitBackendRuntime) → firma.git-working-copy
+   ▼
+firma.git
 ```
 
-- **Ingen helper-brygga, ingen helper-git-peer.** Add-in:en är "ännu en
-  AVA-klient" precis som en web-flik — fristående.
-- **Kod-import = #85:s trigger.** En andra bundler (add-in) som delar MER än
-  kontrakt (hela git-db-klienten + routrarna) är exakt den situation [#85](https://github.com/ulrik-s/ava/issues/85)
-  pekade ut. Per #85: gör det lazily — börja med `@/`-path-alias; om aliaset
-  läcker (add-in-bundlern drar av misstag in Next/server-only-kod) bryt ut ett
-  **source-only `@ava/core`** (inga dist/builds). dep-cruiser-regler bevakar
-  gränsen oavsett.
-- **Flera git-peers** (web-OPFS-klon, server-runtime, add-in-klon) mot samma
-  remote → oförändrad konflikt-hantering, last-write-wins + git-merge
-  ([ADR 0002](./0002-git-konflikthantering-backend-a.md)).
+- **Helpern är inte inblandad** i add-in-datavägen (förblir den tunna
+  doc/mail-brokern för web-appen: `/open`, `/compose-mail`).
+- Add-ins bär **ingen git-db-kod** → liten bundle; ingen `@ava/core`-utbrytning
+  tvingas fram (delar bara tRPC-klient-typer, ej hela klienten — under #85:s
+  trigger).
 
-### 2. Auth: add-in:en autentiserar sin egen push (egen origin)
+### 2. Web-appen + demo förblir lokal-först — HTTP-API:t är additivt (B1)
 
-OIDC-cookien (ADR 0009) följer inte med till add-in-originen. Add-in:en behöver
-ett eget push-credential mot `firma.git`:
-- **v1: PAT/deploy-key i add-in:ens storage** (samma maskin-/klient-principal-
-  väg som ADR 0009 lämnar för icke-browser-git — anges en gång, lagras i
-  add-in-webviewens storage). Commit-författare härleds ur den principalen.
-- **Senare: OIDC i add-in-webviewen** (egen oauth2-proxy-login i en dialog/popup)
-  för fullständig människo-auth — uppskjutet (mer Office.js-dialog-arbete).
-- **MS Graph-token** (Office-sidans data: mail/kalender via Office.js) är
-  **ortogonal** mot git-db-pushen.
+Web-appen och GH Pages-demon är **oförändrade**: browsern äger sin OPFS-klon och
+kör tRPC **in-process** (`inProcessLink`) — ingen HTTP-väg, ingen obligatorisk
+server. HTTP-API:t finns BARA för native-klienter (add-ins) som inte kan köra
+browser-git-db:n. USP:n (browsern är runtime, server "så tunn det går",
+demo/lokal-först) bevaras (se [[project-usp-constraints]]).
 
-*(Detta är den kvarvarande sub-frågan att spika vid implementation: PAT-i-storage
-för v1 vs OIDC-i-webview. Lutar åt PAT för v1.)*
+Det betyder att **server-runtime:ns working-copy är ännu en git-peer** vid sidan
+av webbens OPFS-klon — flera peers mot samma `firma.git` hanteras oförändrat av
+last-write-wins + git-merge ([ADR 0002](./0002-git-konflikthantering-backend-a.md)).
 
-### 3. Omfattning av #83: full delad shell + båda manifesten (3B)
+### 3. Auth: Bearer-token mot API:t (C1)
 
-#83 bygger **hela den delade grunden**:
-- En delad Office.js **task-pane-shell** (UI-skal + den importerade git-db-
-  klienten + tRPC-in-process-uppsättningen), återanvändbar av båda hosts.
-- **Add-in-manifest per host** (Word + Outlook), HTTPS-serverad bundle.
-- Mekanismen att **importera/dela web-appens `src/lib`** in i add-in-bundlern
-  (alias eller `@ava/core` om aliaset läcker, jfr #85).
+Add-in är en egen origin → OIDC-cookien (ADR 0009) följer inte med. API:t
+auktoriseras med ett **Bearer-token (PAT)**: add-in:en skickar
+`Authorization: Bearer <PAT>`; servern validerar mot en principal (samma
+maskin-/CLI-principal-väg som ADR 0009 lämnar för icke-browser-klienter). Commit-
+författare härleds ur principalen. OIDC-i-webview (egen login-popup) är en
+framtida uppgradering. **MS Graph-token** (Office-sidans data) är ortogonal.
 
-Då blir **#84 (Word)** och **#72 (Outlook)** tunna feature-lager ovanpå shell:en.
+### 4. Omfattning av #83: full delad shell + båda manifesten (3B)
+
+#83 bygger **hela grunden**:
+- **Server-sidan:** exponera tRPC-routrarna över HTTP i server-runtime:n +
+  Bearer-auth-grind.
+- **Add-in-sidan:** delad Office.js **task-pane-shell** med en tRPC-HTTP-klient
+  (`httpBatchLink` mot serverns API) + **add-in-manifest per host** (Word +
+  Outlook), HTTPS-serverad bundle.
+
+Då blir **#84 (Word)** och **#72 (Outlook)** tunna feature-lager.
 
 ## Konsekvenser
 
-- **+** Add-ins fungerar **fristående** (ingen öppen webbflik, ingen helper i
-  datatvägen) — robust UX, en arkitektur (add-in = AVA-klient).
-- **+** Maximal kod-återanvändning: add-in:en importerar web-appens git-db-
-  klient + routrar + scheman rakt av (ADR 0001-seam) — ingen brygg-/proxy-kod,
-  ingen reimplementation.
-- **+** Helpern slipper en git-peer-roll — förblir den tunna doc/mail-brokern
-  (`/open`, `/compose-mail`). Mindre klient-state.
-- **+** #84/#72 blir tunna givet 3B.
-- **−** **Teknisk risk att validera tidigt:** add-in-webviewen måste faktiskt
-  stödja browser-storage (IndexedDB/OPFS) för iso-git-klonen + tillåta
-  cross-origin HTTPS-push (CORS) mot `firma.git`-remoten. Detta är miljön
-  ADR:ns ursprungliga version undvek via helpern — det är nu ett antagande som
-  ett tidigt spike-steg i #83 ska bekräfta per host (WebView2/WKWebView).
-- **−** **Push-auth utan same-origin-cookie:** add-in:en måste bära ett eget
-  credential (PAT i storage för v1) — ett credential i webview-storage (mindre
-  bra än helperns process-förtroende, men lokalt på användarens maskin).
-- **−** Add-in:en drar in **hela git-db-klienten** i sin bundle → större bundle
-  + #85:s alias-/`@ava/core`-fråga aktiveras (hanteras lazily, se beslut 1).
-- **−** Flera git-peers (web + add-in + server-runtime) → ADR 0002 last-write-
-  wins; användaren kan behöva refresh i en öppen webbflik för att se add-in-
-  ändringar.
+- **+** **Cross-platform med minsta klient-antaganden:** add-ins gör bara
+  HTTP-anrop → funkar i WebView2/WKWebView/alla Office-värdar utan
+  storage/OPFS/CORS-/iso-git-beroenden.
+- **+** **Återanvänder routrar + scheman** (A1) — end-to-end-typer, ingen
+  reimplementation, inget brygg-/proxy-lager, ingen `@ava/core`-tvång.
+- **+** **USP bevarad** (B1): web-app + demo förblir lokal-först/in-process;
+  API:t är additivt och bara för native-klienter.
+- **+** En enda git-db-skrivare för add-ins (serverns working-copy) → enkel
+  författare-/konflikt-modell.
+- **−** **Server-runtime:n får en HTTP-API-yta** (kör redan routrarna in-process;
+  deltat är att exponera dem + auth-grind) — ett steg från "ren nginx +
+  git-http-backend", men additivt och bara aktivt när add-ins/native-klienter
+  används.
+- **−** Add-ins kräver en **nåbar server** (de är inte offline-fristående som en
+  browser-OPFS-klient) + ett **PAT**.
+- **−** Server-working-copy + webb-OPFS-klon är två peers mot samma remote → ADR
+  0002 last-write-wins; en öppen webbflik kan behöva refresh för att se
+  add-in-ändringar.
 
 ## Alternativ (förkastade)
 
-- **1B (tidigare valt, nu ersatt) — helpern blir git-peer, add-in → helper-
-  loopback → git-db:** undviker att köra git-db i add-in-webviewen, men ger
-  helpern en tung git-peer-roll + en brygg-/proxy-väg + helper-credential.
-  Ersatt: add-in-som-klient ger en enklare, enhetlig arkitektur (add-in = samma
-  AVA-klient som webben) och slipper helper-git-peer-komplexiteten. Risken
-  flyttas till "funkar git-db i webviewen?" (valideras i #83-spiken).
-- **1A — `Add-in → helper → öppen web-app → git-db`:** kräver att en AVA-flik är
-  öppen samtidigt → skör UX. Nej.
-- **3A — Word + minimal vertikal slice först:** vi tar full shell direkt (3B) så
-  host-add-insen blir tunna.
+- **Add-in som git-medveten klient (importerar web-appens lib, kör iso-git i
+  webviewen)** — *tidigare valt, nu ersatt*. Förutsatte att add-in-webviewen
+  pålitligt kör browser-git-db (IndexedDB/OPFS) + cross-origin-push (CORS), vilket
+  varierar per host/OS → opålitligt cross-platform. Servern-äger-git-db tar bort
+  det antagandet helt: add-in:en är en dum HTTP-klient.
+- **Helpern som git-peer + loopback-brygga (1B)** — *ursprungligt beslut*. Binder
+  add-ins till lokalt installerad helper + loopback-HTTPS per OS; server-API:t är
+  mer generellt och plattformsoberoende.
+- **Allt via server-API:t (även web-appen, B2)** — bryter USP:n (server blir
+  obligatorisk app-server, demo/lokal-först faller). Web-appen förblir
+  lokal-först (B1).
+- **Handskrivet REST-lager (A2)** — rent språk-agnostiskt kontrakt men dubbel yta
+  + reimplementation. tRPC-over-HTTP (A1) räcker eftersom add-ins är AVA-klienter,
+  inte tredje part.
 
 ## Ändringshistorik
 
-- **2026-06-13 (revidering):** Datatvägen ändrad från **1B (helpern som git-peer
-  + loopback-brygga)** till **add-in:en som git-medveten AVA-klient som importerar
-  web-appens lib** (ingen helper i datatvägen). Auth-beslutet (2) ändrat från
-  loopback-förtroende till add-in:ens egna push-credential (PAT v1). Inget hade
-  byggts på 1B-beslutet. Skäl: enklare, enhetlig arkitektur (add-in = AVA-klient);
-  helpern hålls tunn. Ny risk att validera: git-db i add-in-webviewen.
+- **2026-06-13 (rev 1):** Datatväg 1B (helpern som git-peer + loopback-brygga) →
+  add-in:en som git-medveten klient som importerar web-appens lib.
+- **2026-06-13 (rev 2, gällande):** → **tunn server äger git-db + exponerar tRPC-
+  over-HTTP; add-ins är tunna HTTP-klienter med Bearer-PAT (A1+B1+C1)**. Skäl:
+  enklaste cross-platform-modellen (add-in = dum HTTP-klient, inga
+  webview-storage/CORS-antaganden); web-app/demo förblir lokal-först (USP intakt).
+  Inget hade byggts på de tidigare varianterna.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,9 +37,9 @@
 >   externt system (Fortnox) har var sin obrutna serie, aldrig en delad räknare
 >   (lagligt enl. 17 kap. 24 § 2 ML / art. 226.2 momsdirektivet).
 > - [ADR 0013](./adr/0013-office-add-in-arkitektur.md) — Office-add-ins (Word/
->   Outlook): add-in:en är en git-medveten AVA-klient som importerar web-appens
->   lib (git-db-klient + routrar) och kör/pushar själv — INGEN helper i
->   datatvägen; egen push-credential (PAT v1); delad task-pane-shell.
+>   Outlook): tunna servern äger git-db + exponerar tRPC-over-HTTP; add-ins är
+>   tunna HTTP-klienter (Bearer-PAT). Web-app/demo förblir lokal-först (USP).
+>   Delad task-pane-shell; #84/#72 tunna lager.
 
 ## Tre lager
 


### PR DESCRIPTION
## Vad

Reviderar ADR 0013 till din nya riktning (**A1 + B1 + C1**): **den tunna servern äger git-db:n och exponerar den via ett HTTP-API; add-ins är tunna klienter.**

## Beslut

- **A1 — tRPC-over-HTTP.** Server-runtime:n (ADR 0005) kör redan routrarna in-process mot en `firma.git`-working-copy; deltat är att **exponera dem över HTTP** (`httpBatchLink`-server, "REST-likt", bakom nginx-fronten). Återanvänder routrar + zod-scheman + end-to-end-typer, inget handskrivet REST.
- **Add-ins = tunna tRPC/HTTP-klienter** — ingen git-db, ingen iso-git, inget filsystem/OPFS i webviewen → funkar på **alla** plattformar (WebView2/WKWebView/alla Office-värdar) med minsta klient-antaganden.
- **B1 — USP bevarad.** Web-app + demo är **oförändrade** (lokal-först, browser äger OPFS-klon + in-process-tRPC). HTTP-API:t är additivt, bara för native-klienter. Server-working-copy = ännu en git-peer (ADR 0002 last-write-wins).
- **C1 — Bearer-token (PAT)** mot API:t (egen origin → ingen OIDC-cookie); maskin-principal-väg (ADR 0009).

## Varför ersätter detta rev1 (add-in-som-git-medveten-klient)

Rev1 förutsatte att add-in-webviewen pålitligt kör browser-git-db (IndexedDB/OPFS) + cross-origin-push (CORS) — varierar per host/OS. Server-äger-git-db **tar bort det antagandet helt**: add-in:en är en dum HTTP-klient. (Ingen webview-git-db-spike behövs längre.)

## Konsekvens att notera

Server-runtime:n får en **HTTP-API-yta** (kör redan routrarna; deltat = exponera + auth-grind) — ett steg från "ren nginx + git-http-backend", men additivt och bara aktivt när native-klienter används. USP:n hålls intakt via B1.

Docs-only. Ändringshistorik + flippade alternativ i ADR:n.

Refs #83 #84 #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)