### PR TITLE
feat(server): exponera tRPC-routrarna över HTTP bakom Bearer-PAT-grind (#83)

### DIFF
--- a/src/lib/server/http/pat.ts
+++ b/src/lib/server/http/pat.ts
@@ -1,0 +1,82 @@
+/**
+ * Bearer-PAT-autentisering för server-runtime:ns HTTP-API (#83, ADR 0013 §3 C1).
+ *
+ * Native-klienter (Office-add-ins) har en egen origin → OIDC-cookien (ADR 0009)
+ * följer inte med. De auktoriseras i stället med ett **personligt access-token
+ * (PAT)** i `Authorization: Bearer <token>`. Servern slår upp token → `Principal`
+ * (maskin-/CLI-principal-vägen som ADR 0009 lämnar för icke-browser-klienter);
+ * commit-författare härleds sedan ur principalen.
+ *
+ * Tokens lagras ALDRIG i klartext: en `PatRecord` håller bara SHA-256-hashen.
+ * Verifiering hashar inkommande token och jämför **konstant-tid** (timing-safe)
+ * mot kända hashar — ingen läckande tidsskillnad mellan "fel token" och
+ * "rätt prefix".
+ */
+
+import { createHash, timingSafeEqual } from "node:crypto";
+import type { Principal } from "@/lib/server/auth/principal";
+
+/** SHA-256-hash (hex) av en token. Single source of truth för hash-formatet. */
+export function sha256Hex(input: string): string {
+  return createHash("sha256").update(input, "utf8").digest("hex");
+}
+
+/**
+ * Plocka ut Bearer-token ur ett `Authorization`-headervärde.
+ * Returnerar `null` om headern saknas eller inte är ett Bearer-schema.
+ * Schemat matchas skiftlägesokänsligt ("Bearer"/"bearer"); token trimmas.
+ */
+export function parseBearerToken(header: string | null | undefined): string | null {
+  if (!header) return null;
+  const match = /^Bearer[ \t]+(.+)$/i.exec(header.trim());
+  const token = match?.[1]?.trim();
+  return token ? token : null;
+}
+
+/** Ett känt token (hashat) bundet till den principal det auktoriserar som. */
+export interface PatRecord {
+  /** SHA-256-hex av token (se {@link sha256Hex}). Aldrig klartext. */
+  tokenHash: string;
+  /** Principalen token auktoriserar som. */
+  principal: Principal;
+}
+
+/** Slår upp en Bearer-token → `Principal`, eller `null` om okänd/ogiltig. */
+export interface PatVerifier {
+  verify(token: string): Principal | null;
+}
+
+/** Konstant-tid-jämförelse av två hex-hashar av samma längd. */
+function hexEquals(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(Buffer.from(a, "hex"), Buffer.from(b, "hex"));
+}
+
+/**
+ * `PatVerifier` mot en fast uppsättning {@link PatRecord} (från config/valv).
+ * Verifierar genom att hasha inkommande token och konstant-tid-jämföra mot
+ * varje känd hash. Jämför ALLA poster (ingen tidig retur) så svarstiden inte
+ * läcker hur många prefix-tecken som stämde.
+ */
+export class StaticPatVerifier implements PatVerifier {
+  private readonly records: readonly PatRecord[];
+  constructor(records: readonly PatRecord[]) {
+    this.records = records;
+  }
+
+  verify(token: string): Principal | null {
+    if (!token) return null;
+    const hash = sha256Hex(token);
+    let found: Principal | null = null;
+    for (const rec of this.records) {
+      if (hexEquals(hash, rec.tokenHash)) found = rec.principal;
+    }
+    return found;
+  }
+}
+
+/** Bygg en {@link PatRecord} ur en klartext-token (hashar den). Bekvämlighet
+ *  för bootstrap/config; lagra helst hashen direkt och anropa inte denna. */
+export function patRecord(token: string, principal: Principal): PatRecord {
+  return { tokenHash: sha256Hex(token), principal };
+}

--- a/src/lib/server/http/trpc-http-handler.ts
+++ b/src/lib/server/http/trpc-http-handler.ts
@@ -1,0 +1,71 @@
+/**
+ * tRPC-over-HTTP-handler för server-runtime:ns native-klient-API (#83,
+ * ADR 0013 §1 A1). Exponerar **samma** `appRouter` som web-appen kör
+ * in-process (`inProcessLink`) — men över HTTP, så Office-add-ins kan vara
+ * tunna `httpBatchLink`-klienter utan egen git-db.
+ *
+ * Designval: en ren `(Request) => Promise<Response>`-handler (fetch-standard)
+ * så den kan monteras i vilken Node-/Bun-/edge-server som helst. Den är
+ * transport + auth-grind; HUR en per-principal-`Context` byggs (working-copy,
+ * commit/push) injiceras via `createContext` — composition-root:ens ansvar
+ * (server-runtime-processen), inte transportens.
+ *
+ * Auth: `Authorization: Bearer <PAT>` verifieras FÖRE routern körs (ADR 0013
+ * §3, C1). Saknad/ogiltig token → 401 utan att routern (eller en dyr
+ * working-copy-bygge) ens nås.
+ */
+
+import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
+import { appRouter } from "@/lib/server/routers/_app";
+import type { Context } from "@/lib/server/trpc-core";
+import type { Principal } from "@/lib/server/auth/principal";
+import { parseBearerToken, type PatVerifier } from "./pat";
+
+/** Default-URL-prefix mot vilket klienten gör tRPC-anrop. */
+export const DEFAULT_TRPC_ENDPOINT = "/api/trpc";
+
+export interface TrpcHttpHandlerOpts {
+  /** Verifierar Bearer-token → principal. */
+  verifier: PatVerifier;
+  /**
+   * Bygg en per-principal tRPC-`Context` (working-copy/dataStore/ports).
+   * Anropas bara för autentiserade requests.
+   */
+  createContext: (principal: Principal) => Promise<Context> | Context;
+  /** URL-prefix (default {@link DEFAULT_TRPC_ENDPOINT}). */
+  endpoint?: string;
+  /** Server-side fel-logg (valfri). */
+  onError?: (err: unknown) => void;
+}
+
+/** 401-svar med `WWW-Authenticate: Bearer` (RFC 6750). */
+function unauthorized(): Response {
+  return new Response(JSON.stringify({ error: "unauthorized" }), {
+    status: 401,
+    headers: { "content-type": "application/json", "www-authenticate": "Bearer" },
+  });
+}
+
+/**
+ * Skapa en fetch-handler som serverar `appRouter` över HTTP bakom en
+ * Bearer-PAT-grind. Returnerar `(req) => Promise<Response>`.
+ */
+export function createTrpcHttpHandler(
+  opts: TrpcHttpHandlerOpts,
+): (req: Request) => Promise<Response> {
+  const endpoint = opts.endpoint ?? DEFAULT_TRPC_ENDPOINT;
+  return async (req: Request): Promise<Response> => {
+    const token = parseBearerToken(req.headers.get("authorization"));
+    const principal = token ? opts.verifier.verify(token) : null;
+    if (!principal) return unauthorized();
+
+    const ctx = await opts.createContext(principal);
+    return fetchRequestHandler({
+      endpoint,
+      req,
+      router: appRouter,
+      createContext: () => ctx,
+      ...(opts.onError ? { onError: ({ error }) => opts.onError?.(error) } : {}),
+    });
+  };
+}

--- a/test/unit/server/http/pat.test.ts
+++ b/test/unit/server/http/pat.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Enhetstester för Bearer-PAT-autentiseringen (#83, ADR 0013 §3).
+ * Täcker token-parsning, hashning, konstant-tid-verifiering och
+ * defensiv hantering av okända/trasiga tokens.
+ */
+import { describe, it, expect } from "vitest-compat";
+import {
+  sha256Hex, parseBearerToken, StaticPatVerifier, patRecord, type PatRecord,
+} from "@/lib/server/http/pat";
+import type { Principal } from "@/lib/server/auth/principal";
+
+const PRINCIPAL: Principal = {
+  id: "p-1", email: "advokat@byra.se", name: "Ada Advokat",
+  role: "LAWYER", organizationId: "org-1",
+};
+
+describe("sha256Hex", () => {
+  it("ger deterministisk 64-tecken hex-hash", () => {
+    const h = sha256Hex("hemlig-token");
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+    expect(sha256Hex("hemlig-token")).toBe(h);
+  });
+  it("olika input → olika hash", () => {
+    expect(sha256Hex("a")).not.toBe(sha256Hex("b"));
+  });
+});
+
+describe("parseBearerToken", () => {
+  it("plockar ut token ur 'Bearer <token>'", () => {
+    expect(parseBearerToken("Bearer abc123")).toBe("abc123");
+  });
+  it("är skiftlägesokänsligt för schemat och trimmar token", () => {
+    expect(parseBearerToken("bearer   abc123  ")).toBe("abc123");
+    expect(parseBearerToken("  Bearer\tabc123")).toBe("abc123");
+  });
+  it("returnerar null för saknad/tom/annan auth", () => {
+    expect(parseBearerToken(null)).toBeNull();
+    expect(parseBearerToken(undefined)).toBeNull();
+    expect(parseBearerToken("")).toBeNull();
+    expect(parseBearerToken("Basic dXNlcjpwYXNz")).toBeNull();
+  });
+  it("returnerar null när Bearer saknar token", () => {
+    expect(parseBearerToken("Bearer")).toBeNull();
+    expect(parseBearerToken("Bearer    ")).toBeNull();
+  });
+});
+
+describe("StaticPatVerifier", () => {
+  const verifier = new StaticPatVerifier([patRecord("good-token", PRINCIPAL)]);
+
+  it("verifierar känd token → principal", () => {
+    expect(verifier.verify("good-token")).toEqual(PRINCIPAL);
+  });
+  it("okänd token → null", () => {
+    expect(verifier.verify("wrong-token")).toBeNull();
+  });
+  it("tom token → null", () => {
+    expect(verifier.verify("")).toBeNull();
+  });
+  it("väljer rätt principal bland flera poster", () => {
+    const other: Principal = { ...PRINCIPAL, id: "p-2", email: "b@b.se" };
+    const multi = new StaticPatVerifier([
+      patRecord("token-a", PRINCIPAL),
+      patRecord("token-b", other),
+    ]);
+    expect(multi.verify("token-b")).toEqual(other);
+    expect(multi.verify("token-a")).toEqual(PRINCIPAL);
+  });
+  it("trasig tokenHash (fel längd) → null utan att kasta", () => {
+    const bad: PatRecord = { tokenHash: "deadbeef", principal: PRINCIPAL };
+    const v = new StaticPatVerifier([bad]);
+    expect(v.verify("good-token")).toBeNull();
+  });
+});
+
+describe("patRecord", () => {
+  it("hashar token till tokenHash (aldrig klartext)", () => {
+    const rec = patRecord("min-token", PRINCIPAL);
+    expect(rec.tokenHash).toBe(sha256Hex("min-token"));
+    expect(rec.tokenHash).not.toContain("min-token");
+    expect(rec.principal).toEqual(PRINCIPAL);
+  });
+});

--- a/test/unit/server/http/trpc-http-handler.test.ts
+++ b/test/unit/server/http/trpc-http-handler.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Integrationstest för tRPC-over-HTTP-handlern (#83, ADR 0013 §1).
+ *
+ * Driver handlern via en RIKTIG tRPC-`httpBatchLink`-klient med en injicerad
+ * `fetch` → det är exakt Office-add-in:ens anropsväg (samma transport +
+ * superjson-transformer). Verifierar:
+ *   - Bearer-grinden: ingen/ogiltig token → 401, `createContext` aldrig anropad.
+ *   - Giltig token → routern körs, principalen ur token flödar in i `ctx.user`
+ *     (verifieras via `user.current`s fallback) och superjson round-trippar.
+ */
+import { describe, it, expect, vi } from "vitest-compat";
+import { createTRPCClient, httpBatchLink, TRPCClientError } from "@trpc/client";
+import superjson from "superjson";
+import type { AppRouter } from "@/lib/server/routers/_app";
+import type { Context } from "@/lib/server/trpc-core";
+import type { Principal } from "@/lib/server/auth/principal";
+import { createTrpcHttpHandler } from "@/lib/server/http/trpc-http-handler";
+import { StaticPatVerifier, patRecord } from "@/lib/server/http/pat";
+
+const PRINCIPAL: Principal = {
+  id: "p-1", email: "advokat@byra.se", name: "Ada Advokat",
+  role: "LAWYER", organizationId: "org-1",
+};
+
+/** Minimal Context: `users.findUniqueOrThrow` kastar → user.current faller
+ *  tillbaka på ctx.user, vilket bevisar att principalen flödade in. */
+function fakeContext(principal: Principal): Context {
+  const dataStore = {
+    users: { findUniqueOrThrow: async () => { throw new Error("no row"); } },
+  };
+  return { dataStore, ports: {}, user: principal } as unknown as Context;
+}
+
+interface Harness {
+  handler: (req: Request) => Promise<Response>;
+  createContext: ReturnType<typeof vi.fn>;
+}
+
+function makeHarness(): Harness {
+  const verifier = new StaticPatVerifier([patRecord("good-token", PRINCIPAL)]);
+  const createContext = vi.fn((p: Principal) => fakeContext(p));
+  const handler = createTrpcHttpHandler({ verifier, createContext });
+  return { handler, createContext };
+}
+
+/** tRPC-klient som routar all fetch genom handlern, med valfri Bearer-token. */
+function clientFor(handler: Harness["handler"], token?: string) {
+  return createTRPCClient<AppRouter>({
+    links: [httpBatchLink({
+      url: "http://ava.test/api/trpc",
+      transformer: superjson,
+      headers: () => (token ? { authorization: `Bearer ${token}` } : {}),
+      fetch: (input, init) => handler(new Request(input as string, init as RequestInit)),
+    })],
+  });
+}
+
+describe("createTrpcHttpHandler", () => {
+  it("giltig Bearer → user.current returnerar principalen ur token", async () => {
+    const h = makeHarness();
+    const client = clientFor(h.handler, "good-token");
+    const me = await client.user.current.query();
+    expect(me.email).toBe(PRINCIPAL.email);
+    expect(me.name).toBe(PRINCIPAL.name);
+    expect(me.role).toBe(PRINCIPAL.role);
+    expect(me.createdAt).toBeInstanceOf(Date); // superjson round-trippade en Date
+    expect(h.createContext).toHaveBeenCalledWith(PRINCIPAL);
+  });
+
+  it("ingen token → 401, routern/createContext aldrig nådd", async () => {
+    const h = makeHarness();
+    const client = clientFor(h.handler);
+    await expect(client.user.current.query()).rejects.toBeInstanceOf(TRPCClientError);
+    expect(h.createContext).not.toHaveBeenCalled();
+  });
+
+  it("ogiltig token → 401", async () => {
+    const h = makeHarness();
+    const client = clientFor(h.handler, "wrong-token");
+    await expect(client.user.current.query()).rejects.toBeInstanceOf(TRPCClientError);
+    expect(h.createContext).not.toHaveBeenCalled();
+  });
+
+  it("svarar 401 på rå request utan Authorization", async () => {
+    const { handler } = makeHarness();
+    const res = await handler(new Request("http://ava.test/api/trpc/user.current"));
+    expect(res.status).toBe(401);
+    expect(res.headers.get("www-authenticate")).toBe("Bearer");
+  });
+
+  it("rapporterar router-fel via onError-hooken (okänd procedure)", async () => {
+    const verifier = new StaticPatVerifier([patRecord("good-token", PRINCIPAL)]);
+    const onError = vi.fn();
+    const handler = createTrpcHttpHandler({
+      verifier,
+      createContext: (p) => fakeContext(p),
+      onError,
+    });
+    // Autentiserad men okänd procedure-path → tRPC kastar → onError-grinden.
+    const res = await handler(new Request(
+      "http://ava.test/api/trpc/does.not.exist?input=%7B%7D",
+      { headers: { authorization: "Bearer good-token" } },
+    ));
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(onError).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Vad

**Första steget av Office-add-in-plattformen** (#83, [ADR 0013 rev2](../blob/main/docs/adr/0013-office-add-in-arkitektur.md) — A1+C1): native-klienter ska kunna nå domän-routrarna över **HTTP** utan egen git-db. Detta är **transport- + auth-lagret**.

Web-appen + demo är **oförändrade** (B1): de kör fortsatt tRPC in-process (`inProcessLink`). HTTP-API:t är additivt, bara för native-klienter → USP intakt.

## Hur

- **`src/lib/server/http/pat.ts`** — Bearer-PAT-auth (ADR 0013 §3, C1):
  - `parseBearerToken` (skiftlägesokänsligt schema, trimmar token)
  - `sha256Hex` + `StaticPatVerifier`: hashar inkommande token och **konstant-tid**-jämför (`timingSafeEqual`) mot kända hashar. Tokens lagras **aldrig** i klartext; svarstiden läcker inte hur många tecken som stämde (jämför alla poster, ingen tidig retur).
- **`src/lib/server/http/trpc-http-handler.ts`** — `createTrpcHttpHandler`:
  - En fetch-standard `(Request) => Promise<Response>` som serverar **samma `appRouter`** som web-appen kör in-process, via `@trpc/server/adapters/fetch`.
  - **Bearer-grinden körs FÖRE routern**: saknad/ogiltig token → `401` (+`WWW-Authenticate: Bearer`) utan att en dyr per-principal-`Context` ens byggs.
  - HUR contexten byggs (working-copy → dataStore → commit/push) **injiceras** via `createContext` — composition-root:ens ansvar (nästa PR), inte transportens. Detta håller transporten ren och testbar och undviker att föregripa working-copy-/peer-loop-concurrency.

## Test

Tester driver handlern via en **riktig tRPC-`httpBatchLink`-klient** med injicerad `fetch` → exakt Office-add-in:ens anropsväg (samma transport + superjson round-trippas). Täcker:
- 401 utan token + 401 fel token (och att `createContext` då **aldrig** anropas)
- giltig token → principalen ur token flödar in i `ctx.user` (via `user.current`s fallback), superjson round-trippar en `Date`
- `onError`-hooken vid router-fel
- PAT-enheter: parsning, hashning, konstant-tid-verifiering, defensiv hantering av trasig/okänd token

## Verifierat lokalt (CI-spegel)

- `bun run typecheck` ✅ (efter `rm tsconfig.tsbuildinfo`)
- `bun run lint --max-warnings 0` ✅
- `bun run deps:check` (dependency-cruiser) ✅ — inga lagerbrott
- `bun run duplicates` (jscpd) ✅
- `bun run test:cov` ✅ — **2795 tester gröna**, coverage-golvet hålls (rader 83.65% ≥ 82%, funktioner 80.47% ≥ 79%)

## Nästa steg (#83, separata PR:er)

1. **Composition root:** wira `createContext` mot server-runtime:ns working-copy (serialiserad åtkomst + commit/push på mutationer) + montera handlern i server-runtime-processen + nginx-route + docker-exponering.
2. **Add-in-sidan:** delad Office.js task-pane-shell med `httpBatchLink`-klient.
3. **Manifest per host** (Word/Outlook) + HTTPS-serverad bundle.

Refs #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)