### PR TITLE
refactor(jobs): bryt ut JobActions ur JobRow (#6 ratchet)

### DIFF
--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -75,7 +75,6 @@ function Section({ title, jobs, emptyText }: { title: string; jobs: Job[]; empty
   );
 }
 
-// eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Function 'JobRow' has a complexity of 9. Maximum allowed is 8.)
 function JobRow({ job }: { job: Job }) {
   // För körande jobb visar vi inget exakt millisek-värde (annars triggar
   // varje setInterval en re-render). Bara start-tid och status räcker.
@@ -95,30 +94,38 @@ function JobRow({ job }: { job: Job }) {
       </td>
       <td className="px-3 py-2 text-xs text-gray-500 font-mono">{job.kind}</td>
       <td className="px-3 py-2 text-xs text-gray-500">{elapsed !== null ? formatMs(elapsed) : "—"}</td>
-      <td className="px-3 py-2 text-right">
-        {(job.status === "queued" || job.status === "running") && (
-          <button
-            type="button"
-            onClick={() => jobQueue.cancel(job.id)}
-            className="text-xs text-gray-500 hover:text-red-600 inline-flex items-center gap-1"
-            title="Avbryt"
-          >
-            <X size={12} /> Avbryt
-          </button>
-        )}
-        {(job.status === "failed" || job.status === "canceled") && (
-          <button
-            type="button"
-            onClick={() => jobQueue.retry(job.id)}
-            className="text-xs text-gray-500 hover:text-blue-600 inline-flex items-center gap-1"
-            title="Försök igen"
-          >
-            <RotateCcw size={12} /> Försök igen
-          </button>
-        )}
-      </td>
+      <td className="px-3 py-2 text-right"><JobActions job={job} /></td>
     </tr>
   );
+}
+
+/** Rad-actions: Avbryt (köad/körande) eller Försök igen (misslyckad/avbruten). */
+function JobActions({ job }: { job: Job }) {
+  if (job.status === "queued" || job.status === "running") {
+    return (
+      <button
+        type="button"
+        onClick={() => jobQueue.cancel(job.id)}
+        className="text-xs text-gray-500 hover:text-red-600 inline-flex items-center gap-1"
+        title="Avbryt"
+      >
+        <X size={12} /> Avbryt
+      </button>
+    );
+  }
+  if (job.status === "failed" || job.status === "canceled") {
+    return (
+      <button
+        type="button"
+        onClick={() => jobQueue.retry(job.id)}
+        className="text-xs text-gray-500 hover:text-blue-600 inline-flex items-center gap-1"
+        title="Försök igen"
+      >
+        <RotateCcw size={12} /> Försök igen
+      </button>
+    );
+  }
+  return null;
 }
 
 function StatusBadge({ status, progress }: { status: Job["status"]; progress?: number | undefined }) {

--- a/test/unit/app/jobs/page.test.tsx
+++ b/test/unit/app/jobs/page.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Test för `/jobs`-sidan — rad-rendering, status-badge, tidsformat och
+ * rad-actions (Avbryt / Försök igen). Täcker den utbrutna `JobActions`
+ * (#6-ratchet: JobRow låg på complexity 9) i alla tre grenar.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import type { Job } from "@/lib/client/jobs/job-queue";
+
+let JOBS: Job[] = [];
+const cancel = vi.fn();
+const retry = vi.fn();
+const clearFinished = vi.fn();
+
+vi.mock("@/lib/client/jobs/use-jobs", () => ({ useJobs: () => JOBS }));
+vi.mock("@/lib/client/jobs/job-queue", () => ({
+  jobQueue: { cancel, retry, clearFinished },
+}));
+
+// Importeras efter mockarna (bun/vitest hoistar vi.mock).
+import JobsPage from "@/app/jobs/page";
+
+function job(over: Partial<Job> & Pick<Job, "id" | "status">): Job {
+  return { kind: "classify-document", label: `Jobb ${over.id}`, enqueuedAt: 1000, ...over } as Job;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  JOBS = [];
+});
+
+describe("JobsPage / JobActions", () => {
+  it("körande jobb → Avbryt-knapp som anropar jobQueue.cancel", () => {
+    JOBS = [job({ id: "r1", status: "running", progress: 0.5 })];
+    render(<JobsPage />);
+    const row = screen.getByRole("row", { name: /Jobb r1/ });
+    fireEvent.click(within(row).getByRole("button", { name: /Avbryt/ }));
+    expect(cancel).toHaveBeenCalledWith("r1");
+    expect(screen.getByText("↻ 50%")).toBeInTheDocument();
+  });
+
+  it("köat jobb utan progress → '↻ Körs'/'⏳ Köad' + Avbryt", () => {
+    JOBS = [job({ id: "q1", status: "queued" }), job({ id: "r2", status: "running" })];
+    render(<JobsPage />);
+    expect(screen.getByText("⏳ Köad")).toBeInTheDocument();
+    expect(screen.getByText("↻ Körs")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: /Avbryt/ })).toHaveLength(2);
+  });
+
+  it("misslyckat jobb → Försök igen (anropar retry) + felmeddelande", () => {
+    JOBS = [job({ id: "f1", status: "failed", error: "boom", startedAt: 1000, finishedAt: 1500 })];
+    render(<JobsPage />);
+    const row = screen.getByRole("row", { name: /Jobb f1/ });
+    expect(within(row).getByTitle("boom")).toBeInTheDocument();
+    fireEvent.click(within(row).getByRole("button", { name: /Försök igen/ }));
+    expect(retry).toHaveBeenCalledWith("f1");
+  });
+
+  it("avbrutet jobb → Försök igen", () => {
+    JOBS = [job({ id: "c1", status: "canceled", startedAt: 1000, finishedAt: 1500 })];
+    render(<JobsPage />);
+    expect(screen.getByRole("button", { name: /Försök igen/ })).toBeInTheDocument();
+  });
+
+  it("klart jobb → varken Avbryt eller Försök igen", () => {
+    JOBS = [job({ id: "d1", status: "done", startedAt: 1000, finishedAt: 1500 })];
+    render(<JobsPage />);
+    expect(screen.getByText("✓ Klart")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Avbryt/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Försök igen/ })).not.toBeInTheDocument();
+  });
+
+  it("formatMs: ms / s / min beroende på förfluten tid", () => {
+    JOBS = [
+      job({ id: "ms", status: "done", startedAt: 0, finishedAt: 500 }),
+      job({ id: "s", status: "done", startedAt: 0, finishedAt: 5_000 }),
+      job({ id: "min", status: "done", startedAt: 0, finishedAt: 120_000 }),
+    ];
+    render(<JobsPage />);
+    expect(screen.getByText("500 ms")).toBeInTheDocument();
+    expect(screen.getByText("5.0 s")).toBeInTheDocument();
+    expect(screen.getByText("2.0 min")).toBeInTheDocument();
+  });
+
+  it("'Rensa historik' syns när historik finns och anropar clearFinished", () => {
+    JOBS = [job({ id: "d1", status: "done", startedAt: 0, finishedAt: 10 })];
+    render(<JobsPage />);
+    fireEvent.click(screen.getByRole("button", { name: /Rensa historik/ }));
+    expect(clearFinished).toHaveBeenCalled();
+  });
+
+  it("tomt läge → tom-texter, ingen Rensa-knapp", () => {
+    JOBS = [];
+    render(<JobsPage />);
+    expect(screen.getByText("Inga aktiva jobb.")).toBeInTheDocument();
+    expect(screen.getByText("Ingen historik ännu.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Rensa historik/ })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Vad

Ett **#6-ratchet-steg** på `src/app/jobs/page.tsx`. `JobRow` låg på **complexity 9** (max 8) bakom en inline `// eslint-disable-next-line complexity`.

## Hur

- Bryter ut de två status-villkorade rad-knapparna — **Avbryt** (köad/körande) och **Försök igen** (misslyckad/avbruten) — till en egen `JobActions`-komponent. Det tar bort båda `||`-kedjorna ur `JobRow`, som faller under complexity@8 → inline-disablen bort.
- Lägger till ett **komponenttest** för `/jobs` (sidan saknade test helt) som täcker `JobActions` alla tre grenar (avbryt / retry / `null`), `StatusBadge`-etiketterna inkl. progress-grenen, och `formatMs` (ms/s/min).

## Verifierat lokalt (CI-spegel)

- `bun run typecheck` ✅
- `bun run lint --max-warnings 0` ✅ (inline-disable borta, inga kvarvarande suppressions)
- `bun run deps:check` ✅ · `bun run duplicates` ✅
- `bun run test:cov` ✅ — **2803 tester gröna**, coverage **upp** (rader 83.65→83.73 %, funktioner 80.47→80.53 %)

Refs #6 #40 #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)