### PR TITLE
feat(server): serialiserad working-copy-session för HTTP-API:t (#83 steg 1b, beslut A)

### DIFF
--- a/src/lib/server/concurrency/mutex.ts
+++ b/src/lib/server/concurrency/mutex.ts
@@ -1,0 +1,41 @@
+/**
+ * `Mutex` — ett minimalt async-lås (FIFO) för att serialisera åtkomst till en
+ * delad resurs (#83, ADR 0013, concurrency-beslut A).
+ *
+ * Server-runtime:ns HTTP-API och dess PeerLoop (15s pull→act→push) arbetar mot
+ * SAMMA `firma.git`-working-copy på disk. Två samtidiga skrivare = trasigt
+ * git-index. Lösningen (Option A) är att båda tar samma lås: en HTTP-mutation
+ * och en peer-tick kan aldrig köra överlappande. Add-in-trafik är låg-QPS, så
+ * serialiseringen är i praktiken gratis.
+ *
+ * Avsiktligt beroendefritt (ingen `async-mutex`-dep): `runExclusive` köar
+ * callbacks och kör dem en i taget i anropsordning. Ett kast i en callback
+ * släpper låset (nästa väntare körs) och propagerar till just den anroparen.
+ */
+
+export class Mutex {
+  /** Svansen i kön: löftet den senast schemalagda väntaren väntar på. */
+  private tail: Promise<void> = Promise.resolve();
+
+  /**
+   * Kör `fn` exklusivt: väntar tills alla tidigare köade jobb är klara, kör
+   * `fn`, och släpper låset (även vid kast) så nästa väntare kan köra.
+   * Returnerar `fn`:s resultat (eller kastar dess fel) till just denna anropare.
+   */
+  runExclusive<T>(fn: () => Promise<T> | T): Promise<T> {
+    // Skapa "released"-löftet som nästa väntare kedjar på FÖRE vi kör fn, så
+    // ordningen blir strikt FIFO även om fn är synkron.
+    let release: () => void = () => {};
+    const released = new Promise<void>((resolve) => { release = resolve; });
+    const prior = this.tail;
+    this.tail = prior.then(() => released);
+
+    return prior.then(async () => {
+      try {
+        return await fn();
+      } finally {
+        release();
+      }
+    });
+  }
+}

--- a/src/lib/server/http/trpc-http-handler.ts
+++ b/src/lib/server/http/trpc-http-handler.ts
@@ -6,13 +6,16 @@
  *
  * Designval: en ren `(Request) => Promise<Response>`-handler (fetch-standard)
  * så den kan monteras i vilken Node-/Bun-/edge-server som helst. Den är
- * transport + auth-grind; HUR en per-principal-`Context` byggs (working-copy,
- * commit/push) injiceras via `createContext` — composition-root:ens ansvar
+ * transport + auth-grind; HUR en `Context` byggs och persisteras (working-copy,
+ * commit/push) injiceras via `openSession` — composition-root:ens ansvar
  * (server-runtime-processen), inte transportens.
  *
- * Auth: `Authorization: Bearer <PAT>` verifieras FÖRE routern körs (ADR 0013
- * §3, C1). Saknad/ogiltig token → 401 utan att routern (eller en dyr
- * working-copy-bygge) ens nås.
+ * Concurrency (beslut A): en valfri `lock` serialiserar HELA requesten
+ * (hydrera → kör → commit/push) mot peer-loopen som delar samma working-copy.
+ *
+ * Auth: `Authorization: Bearer <PAT>` verifieras FÖRE något annat (ADR 0013
+ * §3, C1). Saknad/ogiltig token → 401 utan att en session (eller ett dyrt
+ * working-copy-bygge) ens öppnas.
  */
 
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
@@ -24,16 +27,33 @@ import { parseBearerToken, type PatVerifier } from "./pat";
 /** Default-URL-prefix mot vilket klienten gör tRPC-anrop. */
 export const DEFAULT_TRPC_ENDPOINT = "/api/trpc";
 
+/**
+ * En öppnad request-session: en `Context` att köra routern mot, och en
+ * `finalize` som anropas EFTER att requesten körts (i en `finally`) för att
+ * persistera ev. mutationer. `finalize` får requesten så den kan avgöra
+ * query vs mutation (tRPC: GET=query, POST=mutation).
+ */
+export interface RequestSession {
+  context: Context;
+  finalize: (req: Request) => Promise<void>;
+}
+
 export interface TrpcHttpHandlerOpts {
   /** Verifierar Bearer-token → principal. */
   verifier: PatVerifier;
   /**
-   * Bygg en per-principal tRPC-`Context` (working-copy/dataStore/ports).
-   * Anropas bara för autentiserade requests.
+   * Öppna en per-principal-session (working-copy/dataStore/ports + finalize).
+   * Anropas bara för autentiserade requests, inuti `lock` om sådan finns.
    */
-  createContext: (principal: Principal) => Promise<Context> | Context;
+  openSession: (principal: Principal) => Promise<RequestSession> | RequestSession;
   /** URL-prefix (default {@link DEFAULT_TRPC_ENDPOINT}). */
   endpoint?: string;
+  /**
+   * Serialiserar hela requesten mot andra skrivare (peer-loopen). Default:
+   * ingen serialisering (kör direkt). Composition-root:en injicerar ett delat
+   * lås (ADR 0013, beslut A).
+   */
+  lock?: <T>(fn: () => Promise<T>) => Promise<T>;
   /** Server-side fel-logg (valfri). */
   onError?: (err: unknown) => void;
 }
@@ -54,18 +74,27 @@ export function createTrpcHttpHandler(
   opts: TrpcHttpHandlerOpts,
 ): (req: Request) => Promise<Response> {
   const endpoint = opts.endpoint ?? DEFAULT_TRPC_ENDPOINT;
+  const lock = opts.lock ?? (<T>(fn: () => Promise<T>) => fn());
+
+  const serve = async (req: Request, principal: Principal): Promise<Response> => {
+    const session = await opts.openSession(principal);
+    try {
+      return await fetchRequestHandler({
+        endpoint,
+        req,
+        router: appRouter,
+        createContext: () => session.context,
+        ...(opts.onError ? { onError: ({ error }) => opts.onError?.(error) } : {}),
+      });
+    } finally {
+      await session.finalize(req);
+    }
+  };
+
   return async (req: Request): Promise<Response> => {
     const token = parseBearerToken(req.headers.get("authorization"));
     const principal = token ? opts.verifier.verify(token) : null;
     if (!principal) return unauthorized();
-
-    const ctx = await opts.createContext(principal);
-    return fetchRequestHandler({
-      endpoint,
-      req,
-      router: appRouter,
-      createContext: () => ctx,
-      ...(opts.onError ? { onError: ({ error }) => opts.onError?.(error) } : {}),
-    });
+    return lock(() => serve(req, principal));
   };
 }

--- a/src/lib/server/http/working-copy-session.ts
+++ b/src/lib/server/http/working-copy-session.ts
@@ -1,0 +1,77 @@
+/**
+ * `working-copy-session` — composition mellan HTTP-handlern (#83) och
+ * server-runtime:ns git-working-copy (ADR 0005). Implementerar `openSession`
+ * för {@link createTrpcHttpHandler} enligt concurrency-beslut A (ADR 0013):
+ *
+ *   per request (inuti det delade låset):
+ *     1. `sync`   — fetch + hård reset till remote (var à jour med peers)
+ *     2. `open`   — hydrera entiteter → DemoDataStore → Context
+ *     3. servera  — handlern kör routern mot contexten
+ *     4. finalize — BARA för mutationer (POST): commit + push om det blev en
+ *                   faktisk ändring (`hasChanges`), annars no-op (inga tomma
+ *                   commits, ingen onödig push på queries).
+ *
+ * Allt I/O (sync/open) injiceras så enheten är testbar utan riktig git.
+ */
+
+import { openServerWorkingCopy, type ServerWorkingCopy } from "@/lib/server/local-first/server-working-copy";
+import { NodeGitOps } from "@/lib/server/local-first/node-git-ops";
+import type { Principal } from "@/lib/server/auth/principal";
+import type { RequestSession } from "./trpc-http-handler";
+
+/** tRPC över HTTP: GET = query, POST = mutation (httpBatchLink-konventionen). */
+function isMutation(req: Request): boolean {
+  return req.method === "POST";
+}
+
+export interface WorkingCopySessionDeps {
+  /** Working-copy-katalogen (server-runtime:ns `firma.git`-klon). */
+  dir: string;
+  /** Remote/branch för sync + push. Default origin/main. */
+  remote?: string;
+  branch?: string;
+  /** Hydrera working-copy:n (default {@link openServerWorkingCopy}). */
+  open?: (dir: string, principal: Principal) => Promise<ServerWorkingCopy>;
+  /** Var à jour med remote före hydrering (default: fetch + reset --hard). */
+  sync?: (dir: string, principal: Principal) => Promise<void>;
+  /** Commit-meddelande för en add-in-mutation. */
+  commitMessage?: (principal: Principal) => string;
+}
+
+/** Default-sync: fetch + hård reset till remote (speglar peer-loopens sync-tick). */
+async function defaultSync(
+  dir: string, principal: Principal, remote: string, branch: string,
+): Promise<void> {
+  const git = new NodeGitOps(dir, principal.name, principal.email, remote, branch);
+  await git.fetch();
+  await git.resetHardToRemote();
+}
+
+/**
+ * Bygg en `openSession(principal)` för {@link createTrpcHttpHandler}. Anropas
+ * inuti handlerns delade lås, så sync/hydrera/commit/push aldrig krockar med
+ * peer-loopen (ADR 0013, beslut A).
+ */
+export function makeWorkingCopySessionOpener(
+  deps: WorkingCopySessionDeps,
+): (principal: Principal) => Promise<RequestSession> {
+  const remote = deps.remote ?? "origin";
+  const branch = deps.branch ?? "main";
+  const open = deps.open ?? ((dir, principal) => openServerWorkingCopy(dir, { principal, remote, branch }));
+  const sync = deps.sync ?? ((dir, principal) => defaultSync(dir, principal, remote, branch));
+  const commitMessage = deps.commitMessage ?? ((p) => `ava: add-in-mutation (${p.email})`);
+
+  return async (principal: Principal): Promise<RequestSession> => {
+    await sync(deps.dir, principal);
+    const wc = await open(deps.dir, principal);
+    return {
+      context: wc.context,
+      finalize: async (req: Request) => {
+        if (!isMutation(req)) return;
+        if (!(await wc.gitOps.hasChanges())) return;
+        await wc.commit(commitMessage(principal));
+        await wc.gitOps.push();
+      },
+    };
+  };
+}

--- a/src/lib/server/local-first/peer-loop.ts
+++ b/src/lib/server/local-first/peer-loop.ts
@@ -53,6 +53,12 @@ export interface PeerLoopDeps {
   /** Sätts → cykel-läge; utelämnas → sync-läge. */
   job?: PeerJob;
   log?: (msg: string) => void;
+  /**
+   * Serialiserar varje tick mot andra skrivare av samma working-copy (#83,
+   * ADR 0013 beslut A: HTTP-API:t delar detta lås). Default: ingen
+   * serialisering (kör direkt) — bevarar beteendet när inget API är monterat.
+   */
+  lock?: <T>(fn: () => Promise<T>) => Promise<T>;
   /** Injicerbara seams för test. */
   runCycle?: RunCycle;
   syncOnce?: SyncOnce;
@@ -77,12 +83,14 @@ export class PeerLoop {
   private readonly log: (msg: string) => void;
   private readonly runCycle: RunCycle;
   private readonly syncOnce: SyncOnce;
+  private readonly lock: <T>(fn: () => Promise<T>) => Promise<T>;
 
   constructor(private readonly deps: PeerLoopDeps) {
     this.intervalMs = deps.intervalMs ?? DEFAULT_INTERVAL_MS;
     this.log = deps.log ?? ((msg) => console.log(`[server-runtime] ${msg}`));
     this.runCycle = deps.runCycle ?? runPeerCycle;
     this.syncOnce = deps.syncOnce ?? defaultSyncOnce;
+    this.lock = deps.lock ?? (<T>(fn: () => Promise<T>) => fn());
   }
 
   /** Starta polling. Idempotent — andra anrop är no-op om redan startad. */
@@ -109,19 +117,22 @@ export class PeerLoop {
   async tickOnce(): Promise<PeerLoopTick> {
     const { job, dir, cycleOpts } = this.deps;
     try {
-      if (job) {
-        const result = await this.runCycle(dir, job.act, job.message, cycleOpts);
-        this.log(
-          result.pushed
-            ? `pushade (${result.attempts} försök)`
-            : result.noop
-              ? "inga ändringar (noop)"
-              : `push misslyckades: ${result.reason ?? "okänt"}`,
-        );
-        return { mode: "cycle", result };
-      }
-      await this.syncOnce(dir, cycleOpts);
-      return { mode: "sync" };
+      // Serialisera mot HTTP-API:t som delar samma working-copy (ADR 0013 A).
+      return await this.lock<PeerLoopTick>(async () => {
+        if (job) {
+          const result = await this.runCycle(dir, job.act, job.message, cycleOpts);
+          this.log(
+            result.pushed
+              ? `pushade (${result.attempts} försök)`
+              : result.noop
+                ? "inga ändringar (noop)"
+                : `push misslyckades: ${result.reason ?? "okänt"}`,
+          );
+          return { mode: "cycle", result };
+        }
+        await this.syncOnce(dir, cycleOpts);
+        return { mode: "sync" };
+      });
     } catch (error) {
       this.log(`tick-fel: ${String(error)}`);
       return { mode: "error", error };

--- a/src/lib/server/local-first/server-working-copy.ts
+++ b/src/lib/server/local-first/server-working-copy.ts
@@ -20,6 +20,7 @@ import { DemoDataStore } from "@/lib/server/data-store/DemoDataStore";
 import { buildGitPorts } from "@/lib/server/adapters/git-ports";
 import { buildContext } from "@/lib/server/build-context";
 import { appRouter } from "@/lib/server/routers/_app";
+import type { Context } from "@/lib/server/trpc-core";
 import type { Principal } from "@/lib/server/auth/principal";
 // Skriv-vägens kärna delas med klientens FSA-/OPFS-write-back (DRY). Lager-
 // regeln `server-contracts-must-not-import-client` undantar uttryckligen
@@ -102,6 +103,12 @@ class NodeWriteBackFs implements WriteBackFs {
 export interface ServerWorkingCopy {
   /** tRPC-caller — samma routrar som klienten, bara node-fs som datakälla. */
   readonly caller: ReturnType<typeof appRouter.createCaller>;
+  /**
+   * Den byggda tRPC-`Context`:en (dataStore/ports/principal). Exponeras för
+   * HTTP-vägen (#83), som kör routern via `fetchRequestHandler` (egen caller)
+   * och därför behöver själva contexten, inte den färdiga callern.
+   */
+  readonly context: Context;
   /** Underliggande git-operationer (fetch/commit/push/...) mot working-copy:n. */
   readonly gitOps: NodeGitOps;
   /**
@@ -148,6 +155,7 @@ export async function openServerWorkingCopy(
   const gitOps = new NodeGitOps(dir, author.name, author.email, opts.remote ?? "origin", opts.branch ?? "main");
   return {
     caller: appRouter.createCaller(ctx),
+    context: ctx,
     gitOps,
     commit: (message) => gitOps.commit(message),
   };

--- a/test/unit/server/concurrency/mutex.test.ts
+++ b/test/unit/server/concurrency/mutex.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Enhetstester för `Mutex` (#83, ADR 0013 beslut A) — FIFO-serialisering,
+ * resultat-/fel-propagering och att låset släpps även vid kast.
+ */
+import { describe, it, expect } from "vitest-compat";
+import { Mutex } from "@/lib/server/concurrency/mutex";
+
+const tick = () => new Promise((r) => setTimeout(r, 5));
+
+describe("Mutex", () => {
+  it("returnerar fn:s resultat", async () => {
+    const m = new Mutex();
+    expect(await m.runExclusive(() => 42)).toBe(42);
+    expect(await m.runExclusive(async () => "x")).toBe("x");
+  });
+
+  it("serialiserar överlappande anrop (ingen interleaving)", async () => {
+    const m = new Mutex();
+    const events: string[] = [];
+    const job = (id: string) => m.runExclusive(async () => {
+      events.push(`${id}:start`);
+      await tick();
+      events.push(`${id}:end`);
+    });
+    // Starta tre samtidigt — de ska köras strikt en i taget, i anropsordning.
+    await Promise.all([job("a"), job("b"), job("c")]);
+    expect(events).toEqual([
+      "a:start", "a:end", "b:start", "b:end", "c:start", "c:end",
+    ]);
+  });
+
+  it("ett kast släpper låset så nästa väntare kör, och propagerar till anroparen", async () => {
+    const m = new Mutex();
+    const order: string[] = [];
+    const failing = m.runExclusive(async () => { order.push("boom"); throw new Error("nej"); });
+    const next = m.runExclusive(async () => { order.push("efter"); return "ok"; });
+    await expect(failing).rejects.toThrow("nej");
+    expect(await next).toBe("ok");
+    expect(order).toEqual(["boom", "efter"]);
+  });
+});

--- a/test/unit/server/http/trpc-http-handler.test.ts
+++ b/test/unit/server/http/trpc-http-handler.test.ts
@@ -4,9 +4,9 @@
  * Driver handlern via en RIKTIG tRPC-`httpBatchLink`-klient med en injicerad
  * `fetch` → det är exakt Office-add-in:ens anropsväg (samma transport +
  * superjson-transformer). Verifierar:
- *   - Bearer-grinden: ingen/ogiltig token → 401, `createContext` aldrig anropad.
- *   - Giltig token → routern körs, principalen ur token flödar in i `ctx.user`
- *     (verifieras via `user.current`s fallback) och superjson round-trippar.
+ *   - Bearer-grinden: ingen/ogiltig token → 401, `openSession` aldrig anropad.
+ *   - Giltig token → routern körs, principalen ur token flödar in i `ctx.user`.
+ *   - `finalize` anropas efter requesten; `lock` serialiserar hela requesten.
  */
 import { describe, it, expect, vi } from "vitest-compat";
 import { createTRPCClient, httpBatchLink, TRPCClientError } from "@trpc/client";
@@ -14,7 +14,7 @@ import superjson from "superjson";
 import type { AppRouter } from "@/lib/server/routers/_app";
 import type { Context } from "@/lib/server/trpc-core";
 import type { Principal } from "@/lib/server/auth/principal";
-import { createTrpcHttpHandler } from "@/lib/server/http/trpc-http-handler";
+import { createTrpcHttpHandler, type RequestSession } from "@/lib/server/http/trpc-http-handler";
 import { StaticPatVerifier, patRecord } from "@/lib/server/http/pat";
 
 const PRINCIPAL: Principal = {
@@ -33,14 +33,16 @@ function fakeContext(principal: Principal): Context {
 
 interface Harness {
   handler: (req: Request) => Promise<Response>;
-  createContext: ReturnType<typeof vi.fn>;
+  openSession: ReturnType<typeof vi.fn>;
+  finalize: ReturnType<typeof vi.fn>;
 }
 
-function makeHarness(): Harness {
+function makeHarness(extra?: Partial<Parameters<typeof createTrpcHttpHandler>[0]>): Harness {
   const verifier = new StaticPatVerifier([patRecord("good-token", PRINCIPAL)]);
-  const createContext = vi.fn((p: Principal) => fakeContext(p));
-  const handler = createTrpcHttpHandler({ verifier, createContext });
-  return { handler, createContext };
+  const finalize = vi.fn(async () => {});
+  const openSession = vi.fn((p: Principal): RequestSession => ({ context: fakeContext(p), finalize }));
+  const handler = createTrpcHttpHandler({ verifier, openSession, ...extra });
+  return { handler, openSession, finalize };
 }
 
 /** tRPC-klient som routar all fetch genom handlern, med valfri Bearer-token. */
@@ -64,21 +66,23 @@ describe("createTrpcHttpHandler", () => {
     expect(me.name).toBe(PRINCIPAL.name);
     expect(me.role).toBe(PRINCIPAL.role);
     expect(me.createdAt).toBeInstanceOf(Date); // superjson round-trippade en Date
-    expect(h.createContext).toHaveBeenCalledWith(PRINCIPAL);
+    expect(h.openSession).toHaveBeenCalledWith(PRINCIPAL);
+    expect(h.finalize).toHaveBeenCalledTimes(1); // finalize körs efter requesten
   });
 
-  it("ingen token → 401, routern/createContext aldrig nådd", async () => {
+  it("ingen token → 401, openSession aldrig nådd", async () => {
     const h = makeHarness();
     const client = clientFor(h.handler);
     await expect(client.user.current.query()).rejects.toBeInstanceOf(TRPCClientError);
-    expect(h.createContext).not.toHaveBeenCalled();
+    expect(h.openSession).not.toHaveBeenCalled();
+    expect(h.finalize).not.toHaveBeenCalled();
   });
 
   it("ogiltig token → 401", async () => {
     const h = makeHarness();
     const client = clientFor(h.handler, "wrong-token");
     await expect(client.user.current.query()).rejects.toBeInstanceOf(TRPCClientError);
-    expect(h.createContext).not.toHaveBeenCalled();
+    expect(h.openSession).not.toHaveBeenCalled();
   });
 
   it("svarar 401 på rå request utan Authorization", async () => {
@@ -88,20 +92,41 @@ describe("createTrpcHttpHandler", () => {
     expect(res.headers.get("www-authenticate")).toBe("Bearer");
   });
 
+  it("lock omsluter hela requesten (öppnas + släpps runt serveringen)", async () => {
+    const events: string[] = [];
+    const lock = async <T>(fn: () => Promise<T>): Promise<T> => {
+      events.push("lock:acquire");
+      try { return await fn(); } finally { events.push("lock:release"); }
+    };
+    const h = makeHarness({ lock });
+    h.finalize.mockImplementation(async () => { events.push("finalize"); });
+    const client = clientFor(h.handler, "good-token");
+    await client.user.current.query();
+    // finalize sker inuti låset (före release).
+    expect(events).toEqual(["lock:acquire", "finalize", "lock:release"]);
+  });
+
+  it("finalize körs även när requesten är ett 401 (gör den inte) — dvs bara vid auth", async () => {
+    const h = makeHarness();
+    await h.handler(new Request("http://ava.test/api/trpc/user.current")); // ingen auth
+    expect(h.finalize).not.toHaveBeenCalled();
+  });
+
   it("rapporterar router-fel via onError-hooken (okänd procedure)", async () => {
     const verifier = new StaticPatVerifier([patRecord("good-token", PRINCIPAL)]);
     const onError = vi.fn();
+    const finalize = vi.fn(async () => {});
     const handler = createTrpcHttpHandler({
       verifier,
-      createContext: (p) => fakeContext(p),
+      openSession: (p) => ({ context: fakeContext(p), finalize }),
       onError,
     });
-    // Autentiserad men okänd procedure-path → tRPC kastar → onError-grinden.
     const res = await handler(new Request(
       "http://ava.test/api/trpc/does.not.exist?input=%7B%7D",
       { headers: { authorization: "Bearer good-token" } },
     ));
     expect(res.status).toBeGreaterThanOrEqual(400);
     expect(onError).toHaveBeenCalled();
+    expect(finalize).toHaveBeenCalled(); // finalize körs i finally även vid fel
   });
 });

--- a/test/unit/server/http/working-copy-session.test.ts
+++ b/test/unit/server/http/working-copy-session.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Enhetstester för `makeWorkingCopySessionOpener` (#83, ADR 0013 beslut A).
+ * Verifierar per-request-flödet med injicerade fakes (ingen riktig git):
+ *   - sync körs FÖRE hydrering (open)
+ *   - query (GET) → ingen commit/push
+ *   - mutation (POST) med ändringar → commit + push
+ *   - mutation (POST) utan ändringar → ingen commit (inga tomma commits)
+ */
+import { describe, it, expect, vi } from "vitest-compat";
+import { makeWorkingCopySessionOpener } from "@/lib/server/http/working-copy-session";
+import type { ServerWorkingCopy } from "@/lib/server/local-first/server-working-copy";
+import type { Context } from "@/lib/server/trpc-core";
+import type { Principal } from "@/lib/server/auth/principal";
+
+const PRINCIPAL: Principal = {
+  id: "p-1", email: "advokat@byra.se", name: "Ada", role: "LAWYER", organizationId: "org-1",
+};
+
+interface Fakes {
+  events: string[];
+  commit: ReturnType<typeof vi.fn>;
+  push: ReturnType<typeof vi.fn>;
+  context: Context;
+}
+
+function makeOpener(hasChanges: boolean) {
+  const events: string[] = [];
+  const commit = vi.fn(async () => { events.push("commit"); return { hash: "h", message: "m" }; });
+  const push = vi.fn(async () => { events.push("push"); return { ok: true }; });
+  const context = { user: PRINCIPAL } as unknown as Context;
+  const wc = {
+    context,
+    commit,
+    gitOps: { hasChanges: async () => hasChanges, push },
+  } as unknown as ServerWorkingCopy;
+
+  const open = vi.fn(async (_dir: string, _p: Principal) => { events.push("open"); return wc; });
+  const sync = vi.fn(async (_dir: string, _p: Principal) => { events.push("sync"); });
+
+  const openSession = makeWorkingCopySessionOpener({ dir: "/wc", open, sync });
+  const fakes: Fakes = { events, commit, push, context };
+  return { openSession, fakes };
+}
+
+const get = () => new Request("http://x/api/trpc/user.current");
+const post = () => new Request("http://x/api/trpc/timeEntry.create", { method: "POST" });
+
+describe("makeWorkingCopySessionOpener", () => {
+  it("synkar FÖRE hydrering och returnerar working-copy:ns context", async () => {
+    const { openSession, fakes } = makeOpener(true);
+    const session = await openSession(PRINCIPAL);
+    expect(fakes.events).toEqual(["sync", "open"]);
+    expect(session.context).toBe(fakes.context);
+  });
+
+  it("query (GET) → varken commit eller push", async () => {
+    const { openSession, fakes } = makeOpener(true);
+    const session = await openSession(PRINCIPAL);
+    await session.finalize(get());
+    expect(fakes.commit).not.toHaveBeenCalled();
+    expect(fakes.push).not.toHaveBeenCalled();
+  });
+
+  it("mutation (POST) med ändringar → commit + push (i ordning)", async () => {
+    const { openSession, fakes } = makeOpener(true);
+    const session = await openSession(PRINCIPAL);
+    await session.finalize(post());
+    expect(fakes.commit).toHaveBeenCalledTimes(1);
+    expect(fakes.push).toHaveBeenCalledTimes(1);
+    expect(fakes.events).toEqual(["sync", "open", "commit", "push"]);
+  });
+
+  it("mutation (POST) utan ändringar → ingen commit (inga tomma commits)", async () => {
+    const { openSession, fakes } = makeOpener(false);
+    const session = await openSession(PRINCIPAL);
+    await session.finalize(post());
+    expect(fakes.commit).not.toHaveBeenCalled();
+    expect(fakes.push).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/server/local-first/peer-loop.test.ts
+++ b/test/unit/server/local-first/peer-loop.test.ts
@@ -64,6 +64,20 @@ describe("PeerLoop (#118)", () => {
     expect(tick).toEqual({ mode: "error", error: boom });
   });
 
+  it("lock: omsluter hela ticket (acquire → arbete → release)", async () => {
+    const events: string[] = [];
+    const lock = async <T>(fn: () => Promise<T>): Promise<T> => {
+      events.push("acquire");
+      try { return await fn(); } finally { events.push("release"); }
+    };
+    const loop = new PeerLoop(baseDeps({
+      syncOnce: async () => { events.push("sync"); },
+      lock,
+    }));
+    await loop.tickOnce();
+    expect(events).toEqual(["acquire", "sync", "release"]);
+  });
+
   it("start() är idempotent och stop() rensar timern", async () => {
     let ticks = 0;
     const loop = new PeerLoop(baseDeps({


### PR DESCRIPTION
## Vad

**#83 steg 1b** — composition-lagret mellan tRPC-over-HTTP-handlern (steg 1, PR #283) och server-runtime:ns git-working-copy. Implementerar **concurrency-beslut A** ([ADR 0013](../blob/main/docs/adr/0013-office-add-in-arkitektur.md)): **en** working-copy, **ett** delat lås mellan HTTP-vägen och peer-loopen (15 s pull→act→push) så de aldrig skriver git samtidigt. Add-in-trafik är låg-QPS → serialiseringen är i praktiken gratis.

## Hur

- **`concurrency/mutex.ts`** — minimalt FIFO-async-lås (`runExclusive`), beroendefritt. Släpper låset även vid kast; propagerar resultat/fel till anroparen.
- **`http/trpc-http-handler.ts`** — byter seamen `createContext` → **`openSession`** (`{ context, finalize }`) + valfri **`lock`**. `lock` omsluter HELA requesten (hydrera → kör → finalize); `finalize` körs i `finally`. Auth-grinden oförändrad (401 *före* en session öppnas).
- **`http/working-copy-session.ts`** — `makeWorkingCopySessionOpener`: per request **sync (fetch+reset) → hydrera → context**; `finalize` gör **commit + push BARA för mutationer (POST)** och bara om `hasChanges` (inga tomma commits, ingen push på queries). Allt I/O injicerat → testbart utan git.
- **`local-first/server-working-copy.ts`** — exponerar den byggda `Context`.
- **`local-first/peer-loop.ts`** — injicerbar `lock` runt `tickOnce` (default identity → **oförändrat beteende** när inget API är monterat). Processen delar samma `Mutex`-instans mellan loopen och handlern.

## Test

- `mutex`: FIFO-serialisering (ingen interleaving), fel släpper låset + propagerar.
- `trpc-http-handler`: 401 utan/fel token (session aldrig öppnad), principal flödar in, **lock-ordning** (`acquire → finalize → release`), finalize i `finally` även vid router-fel.
- `working-copy-session`: sync **före** hydrering, query → ingen commit, mutation+ändring → commit+push, mutation utan ändring → ingen commit.
- `peer-loop`: lock omsluter ticket.

## Verifierat lokalt (CI-spegel)

- `bun run typecheck` ✅ · `bun run lint --max-warnings 0` ✅
- `bun run deps:check` ✅ (inga lagerbrott; `http → local-first` tillåtet) · `bun run duplicates` ✅ · knip rent
- `bun run test:cov` ✅ — **2813 tester gröna**, coverage-golvet hålls (rader 83.74 %, funktioner 80.53 %)

## Nästa (#83 steg 1c)

Montera HTTP-listenern i server-runtime-processen (delad `Mutex` mellan PeerLoop + handler) + nginx-route (`/api/`) + docker-port + PAT-provisioning. Då är endpointen nåbar end-to-end ("klar när").

Refs #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)