### PR TITLE
feat(server): montera tRPC-over-HTTP-API:t i server-runtime-processen (#83 steg 1c)

### DIFF
--- a/docs/adr/0013-office-add-in-arkitektur.md
+++ b/docs/adr/0013-office-add-in-arkitektur.md
@@ -127,6 +127,26 @@ Då blir **#84 (Word)** och **#72 (Outlook)** tunna feature-lager.
   + reimplementation. tRPC-over-HTTP (A1) räcker eftersom add-ins är AVA-klienter,
   inte tredje part.
 
+## Concurrency (beslut A, 2026-06-13)
+
+Server-runtime:ns HTTP-API och dess peer-loop (15 s pull→act→push) arbetar mot
+**samma** `firma.git`-working-copy. För att aldrig skriva git samtidigt
+serialiseras de via **ett delat async-lås (Mutex)** — beslut **A** av tre:
+
+- **A (valt):** en working-copy + ett delat lås. Enklast, en skrivare i taget,
+  återanvänder commit/push-vägen. Add-in-trafik är låg-QPS → kostnaden trivial.
+  Per HTTP-mutation (inuti låset): fetch+reset → hydrera → kör → commit+push
+  (bara POST, bara vid faktisk ändring).
+- **B (förkastat):** klon per request — ingen kontention men dyrt + fler peers
+  mot remote (mer last-write-wins-churn). Överdrivet vid add-in-QPS.
+- **C (förkastat):** köa mutationer in i peer-loopens act-fas — eventual/async,
+  ger upp till intervallets latens på en interaktiv "spara". Fel trade-off.
+
+Levererat i tre steg: **1** (PR #283) transport + Bearer-PAT-grind; **1b**
+(PR #286) Mutex + `openSession`/`finalize`-seam + working-copy-session +
+peer-loop-låsinjektion; **1c** HTTP-listener i server-runtime-processen
+(node:http) + nginx `/api/`-proxy + docker + PAT-provisioning via env.
+
 ## Ändringshistorik
 
 - **2026-06-13 (rev 1):** Datatväg 1B (helpern som git-peer + loopback-brygga) →

--- a/src/bin/server-runtime.ts
+++ b/src/bin/server-runtime.ts
@@ -15,13 +15,18 @@
  * git-config/credential-helper — inga hemligheter via env.
  */
 
-import { ENV_KEYS, loadRuntimeConfig } from "@/lib/server/local-first/server-runtime-config";
+import type { Server } from "node:http";
+
+import { ENV_KEYS, loadRuntimeConfig, type RuntimeConfig } from "@/lib/server/local-first/server-runtime-config";
 import { startServerRuntime } from "@/lib/server/local-first/server-runtime";
 import { buildFortnoxJob } from "@/lib/server/integrations/fortnox/runtime";
 import { buildBankFilePaymentsJob } from "@/lib/server/integrations/ledger/bank-file-runtime";
 import { buildDispatchJob } from "@/lib/server/integrations/email/dispatch-runtime";
 import { makeRulesJob } from "@/lib/server/local-first/rules-job";
 import { composeJobs } from "@/lib/server/local-first/compose-jobs";
+import { Mutex } from "@/lib/server/concurrency/mutex";
+import { buildServerApiHandler } from "@/lib/server/http/server-api";
+import { serveFetchHandler } from "@/lib/server/http/node-http-adapter";
 
 const HELP = `ava server-runtime (ADR 0005 fas 1)
 
@@ -44,10 +49,39 @@ Miljövariabler:
   ${ENV_KEYS.pollIntervalMs}  (default 15000)
   ${ENV_KEYS.maxRetries}       (default 3)
   ${ENV_KEYS.principalId} / ${ENV_KEYS.principalEmail} / ${ENV_KEYS.principalName} / ${ENV_KEYS.principalRole}
+  ${ENV_KEYS.httpPort}        (valfri)  port för tRPC-over-HTTP-API:t (#83)
+  ${ENV_KEYS.apiTokens}      (valfri)  komma-separerade Bearer-PAT:er mot API:t
 `;
 
 function log(msg: string): void {
   console.log(`[server-runtime] ${msg}`);
+}
+
+/**
+ * Montera det additiva tRPC-over-HTTP-API:t (#83) om port + token finns.
+ * Delar `lock` med peer-loopen (ADR 0013 beslut A). Returnerar servern (att
+ * stänga vid nedstängning) eller `undefined` när API:t inte är konfigurerat.
+ */
+function startApi(config: RuntimeConfig, lock: <T>(fn: () => Promise<T>) => Promise<T>): Server | undefined {
+  const handler = buildServerApiHandler(
+    {
+      workDir: config.workDir,
+      remote: config.remote,
+      branch: config.branch,
+      apiTokens: config.apiTokens,
+      principal: config.principal,
+    },
+    { lock, log },
+  );
+  if (!handler || config.httpPort === undefined) {
+    if (config.apiTokens.length > 0 || config.httpPort !== undefined) {
+      log("HTTP-API ej monterat: kräver både " + `${ENV_KEYS.httpPort} och ${ENV_KEYS.apiTokens}`);
+    }
+    return undefined;
+  }
+  const server = serveFetchHandler(handler, { port: config.httpPort, hostname: config.httpHost });
+  log(`tRPC-API lyssnar på ${config.httpHost}:${config.httpPort} (${config.apiTokens.length} token)`);
+  return server;
 }
 
 async function main(): Promise<void> {
@@ -58,6 +92,11 @@ async function main(): Promise<void> {
   }
 
   const config = loadRuntimeConfig();
+  // EN delad Mutex (ADR 0013 beslut A): peer-loopen och HTTP-API:t serialiseras
+  // mot samma working-copy så de aldrig skriver git samtidigt.
+  const mutex = new Mutex();
+  const lock = <T>(fn: () => Promise<T>): Promise<T> => mutex.runExclusive(fn);
+
   // Regelmotor (#80): alltid på — schemalagda idempotenta regler (påminnelser).
   // Fortnox-connector (#82): bara när byrån anslutit Fortnox (valv + tokens).
   // composeJobs kör båda i samma cykel; no-empty-commit-grinden (#80) ser till
@@ -69,11 +108,13 @@ async function main(): Promise<void> {
   // Fakturautskick (#180): bara när SMTP-uppgifter finns i valvet; annars null.
   const dispatch = await buildDispatchJob({ log });
   const job = composeJobs([makeRulesJob({ log }), fortnox, payments, dispatch]);
-  const loop = await startServerRuntime(config, job ? { job } : {});
+  const loop = await startServerRuntime(config, { ...(job ? { job } : {}), lock });
+  const apiServer = startApi(config, lock);
 
   if (argv.includes("--once")) {
     await loop.tickOnce();
     loop.stop();
+    apiServer?.close();
     return;
   }
 
@@ -81,6 +122,7 @@ async function main(): Promise<void> {
     process.on(sig, () => {
       log(`${sig} — stoppar`);
       loop.stop();
+      apiServer?.close();
       process.exit(0);
     });
   }

--- a/src/lib/server/http/node-http-adapter.ts
+++ b/src/lib/server/http/node-http-adapter.ts
@@ -1,0 +1,80 @@
+/**
+ * `node-http-adapter` — monterar en fetch-standard `(Request) => Response`-
+ * handler på en `node:http`-server (#83 steg 1c). Vald framför `Bun.serve` så
+ * koden typkollar under rot-tsconfig:en (`types: []`, inga Bun-globaler) och
+ * fungerar oavsett runtime.
+ *
+ * Servern lyssnar default på 127.0.0.1 — den är INTE tänkt att exponeras
+ * direkt mot internet utan att sitta bakom nginx-fronten (ADR 0009), som
+ * TLS-terminerar och proxar `/api/`.
+ */
+
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from "node:http";
+
+type FetchHandler = (req: Request) => Promise<Response>;
+
+/** Läs hela request-bodyn till en Buffer. */
+function readBody(req: IncomingMessage): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks)));
+    req.on("error", reject);
+  });
+}
+
+/** node:http-headers (string | string[] | undefined) → fetch Headers. */
+function toHeaders(raw: IncomingMessage["headers"]): Headers {
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(raw)) {
+    if (Array.isArray(value)) value.forEach((v) => headers.append(key, v));
+    else if (value !== undefined) headers.set(key, value);
+  }
+  return headers;
+}
+
+/** node:http IncomingMessage → fetch Request. */
+function toFetchRequest(req: IncomingMessage, body: Buffer): Request {
+  const url = `http://${req.headers.host ?? "localhost"}${req.url ?? "/"}`;
+  const method = req.method ?? "GET";
+  const hasBody = method !== "GET" && method !== "HEAD" && body.length > 0;
+  return new Request(url, {
+    method,
+    headers: toHeaders(req.headers),
+    ...(hasBody ? { body: new Uint8Array(body) } : {}),
+  });
+}
+
+/** Skriv en fetch Response till en node:http ServerResponse. */
+async function writeFetchResponse(res: ServerResponse, response: Response): Promise<void> {
+  res.statusCode = response.status;
+  response.headers.forEach((value, key) => res.setHeader(key, value));
+  res.end(Buffer.from(await response.arrayBuffer()));
+}
+
+async function handle(handler: FetchHandler, req: IncomingMessage, res: ServerResponse): Promise<void> {
+  try {
+    const request = toFetchRequest(req, await readBody(req));
+    await writeFetchResponse(res, await handler(request));
+  } catch {
+    res.statusCode = 500;
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({ error: "internal" }));
+  }
+}
+
+export interface ServeOpts {
+  port: number;
+  /** Lyssna-adress. Default 127.0.0.1 (loopback; nginx proxar utifrån). */
+  hostname?: string;
+}
+
+/**
+ * Starta en `node:http`-server som serverar `handler`. Returnerar servern
+ * (anropa `.close()` vid nedstängning).
+ */
+export function serveFetchHandler(handler: FetchHandler, opts: ServeOpts): Server {
+  const server = createServer((req, res) => { void handle(handler, req, res); });
+  server.listen(opts.port, opts.hostname ?? "127.0.0.1");
+  return server;
+}

--- a/src/lib/server/http/server-api.ts
+++ b/src/lib/server/http/server-api.ts
@@ -1,0 +1,64 @@
+/**
+ * `server-api` — composition-root för server-runtime:ns tRPC-over-HTTP-API
+ * (#83 steg 1c, ADR 0013). Knyter ihop bitarna från steg 1/1b till EN
+ * fetch-handler:
+ *
+ *   PAT-verifierare (config-tokens → principal)         [steg 1]
+ *   + per-request working-copy-session (sync/commit/push) [steg 1b]
+ *   + delat lås mot peer-loopen                           [beslut A]
+ *   → `createTrpcHttpHandler`                             [steg 1]
+ *
+ * Alla tokens mappar till runtime:ns `principal` (maskin-principal-vägen, ADR
+ * 0009); per-användar-PAT:er (token → specifik user-principal) är en framtida
+ * uppgradering. Detta håller #83-MVP:n enkel: en byrå-server, en principal.
+ */
+
+import { createTrpcHttpHandler } from "./trpc-http-handler";
+import { makeWorkingCopySessionOpener } from "./working-copy-session";
+import { StaticPatVerifier, patRecord } from "./pat";
+import type { Principal } from "@/lib/server/auth/principal";
+
+export interface ServerApiConfig {
+  /** Working-copy-katalogen (delas med peer-loopen). */
+  workDir: string;
+  /** Remote/branch för sync + push. */
+  remote: string;
+  branch: string;
+  /** Bearer-PAT:er som auktoriserar mot API:t. */
+  apiTokens: readonly string[];
+  /** Principalen alla tokens auktoriserar som (maskin-principal). */
+  principal: Principal;
+}
+
+export interface ServerApiDeps {
+  /** Delat lås mot peer-loopen (ADR 0013 beslut A). */
+  lock: <T>(fn: () => Promise<T>) => Promise<T>;
+  log?: (msg: string) => void;
+}
+
+/**
+ * Bygg fetch-handlern för server-runtime:ns HTTP-API. Returnerar `null` om
+ * inga tokens är konfigurerade (då monteras inget API — ren git-peer).
+ */
+export function buildServerApiHandler(
+  config: ServerApiConfig,
+  deps: ServerApiDeps,
+): ((req: Request) => Promise<Response>) | null {
+  if (config.apiTokens.length === 0) return null;
+
+  const verifier = new StaticPatVerifier(
+    config.apiTokens.map((token) => patRecord(token, config.principal)),
+  );
+  const openSession = makeWorkingCopySessionOpener({
+    dir: config.workDir,
+    remote: config.remote,
+    branch: config.branch,
+  });
+  const log = deps.log ?? (() => {});
+  return createTrpcHttpHandler({
+    verifier,
+    openSession,
+    lock: deps.lock,
+    onError: (err) => log(`[api] router-fel: ${String(err)}`),
+  });
+}

--- a/src/lib/server/local-first/server-runtime-config.ts
+++ b/src/lib/server/local-first/server-runtime-config.ts
@@ -29,6 +29,22 @@ export const runtimeConfigSchema = z.object({
   /** Max push-försök vid NonFastForward-konflikt per cykel. */
   maxRetries: z.coerce.number().int().positive().default(DEFAULT_MAX_RETRIES),
   /**
+   * Port för det additiva tRPC-over-HTTP-API:t (#83, ADR 0013). Utelämnas →
+   * inget API monteras (ren git-peer, oförändrat beteende). Aktiveras bara
+   * tillsammans med minst en `apiToken`.
+   */
+  httpPort: z.coerce.number().int().positive().optional(),
+  /**
+   * Lyssna-adress för API:t. Default 127.0.0.1 (loopback, säkrast). I docker
+   * sätts 0.0.0.0 så nginx-fronten i en annan container kan proxa hit.
+   */
+  httpHost: z.string().min(1).default("127.0.0.1"),
+  /**
+   * Bearer-PAT:er som auktoriserar mot API:t (ADR 0013 §3 C1). Alla mappar
+   * till `principal` (maskin-principal-vägen). Tomt → API:t monteras inte.
+   */
+  apiTokens: z.array(z.string().min(1)).default([]),
+  /**
    * Self-deklarerad principal (git-backenden har ingen ACL, ADR 0001). Blir
    * också git-författare för commits. Bara `organizationId` är obligatorisk;
    * övriga fält har körbara defaults.
@@ -52,6 +68,9 @@ export const ENV_KEYS = {
   remote: "AVA_SR_REMOTE",
   pollIntervalMs: "AVA_SR_POLL_INTERVAL_MS",
   maxRetries: "AVA_SR_MAX_RETRIES",
+  httpPort: "AVA_SR_API_PORT",
+  httpHost: "AVA_SR_API_HOST",
+  apiTokens: "AVA_SR_API_TOKENS",
   principalId: "AVA_SR_PRINCIPAL_ID",
   principalEmail: "AVA_SR_PRINCIPAL_EMAIL",
   principalName: "AVA_SR_PRINCIPAL_NAME",
@@ -63,6 +82,14 @@ export const ENV_KEYS = {
 function read(env: NodeJS.ProcessEnv, key: string): string | undefined {
   const value = env[key];
   return value === undefined || value === "" ? undefined : value;
+}
+
+/** Komma-separerad token-lista → trimmad array (tomma element bort). `undefined`
+ *  när env saknas, så schemats default `[]` slår in. */
+function parseTokens(raw: string | undefined): string[] | undefined {
+  if (raw === undefined) return undefined;
+  const tokens = raw.split(",").map((t) => t.trim()).filter((t) => t.length > 0);
+  return tokens.length > 0 ? tokens : undefined;
 }
 
 function formatIssues(error: z.ZodError): string {
@@ -83,6 +110,9 @@ export function loadRuntimeConfig(env: NodeJS.ProcessEnv = process.env): Runtime
     remote: read(env, ENV_KEYS.remote),
     pollIntervalMs: read(env, ENV_KEYS.pollIntervalMs),
     maxRetries: read(env, ENV_KEYS.maxRetries),
+    httpPort: read(env, ENV_KEYS.httpPort),
+    httpHost: read(env, ENV_KEYS.httpHost),
+    apiTokens: parseTokens(read(env, ENV_KEYS.apiTokens)),
     principal: {
       id: read(env, ENV_KEYS.principalId),
       email: read(env, ENV_KEYS.principalEmail),

--- a/src/lib/server/local-first/server-runtime.ts
+++ b/src/lib/server/local-first/server-runtime.ts
@@ -22,6 +22,12 @@ export interface StartServerRuntimeDeps {
   /** Connector-mutationen per tick. Utelämnas → loopen kör i sync-läge. */
   job?: PeerJob;
   log?: (msg: string) => void;
+  /**
+   * Delat lås runt varje tick (#83, ADR 0013 beslut A). Entryn skapar EN
+   * Mutex och delar den mellan peer-loopen och HTTP-API:t så de aldrig skriver
+   * working-copy:n samtidigt. Utelämnas → ingen serialisering (default).
+   */
+  lock?: <T>(fn: () => Promise<T>) => Promise<T>;
 }
 
 async function defaultIsGitRepo(dir: string): Promise<boolean> {
@@ -46,6 +52,7 @@ function buildLoopDeps(config: RuntimeConfig, deps: StartServerRuntimeDeps): Pee
     intervalMs: config.pollIntervalMs,
     ...(deps.job ? { job: deps.job } : {}),
     ...(deps.log ? { log: deps.log } : {}),
+    ...(deps.lock ? { lock: deps.lock } : {}),
   };
 }
 

--- a/test/unit/server/http/node-http-adapter.test.ts
+++ b/test/unit/server/http/node-http-adapter.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Integrationstest för `serveFetchHandler` (#83 steg 1c) — node:http-adaptern.
+ * Startar en riktig server på en OS-tilldelad port och anropar den med en
+ * node:http-klient (test-miljöns happy-dom-`fetch` blockerar cross-origin mot
+ * 127.0.0.1). Verifierar Request-/Response-översättningen + 500 vid kast.
+ */
+import { describe, it, expect, afterEach } from "vitest-compat";
+import { once } from "node:events";
+import { request, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { serveFetchHandler } from "@/lib/server/http/node-http-adapter";
+
+let server: Server | undefined;
+afterEach(() => { server?.close(); server = undefined; });
+
+async function start(handler: (req: Request) => Promise<Response>): Promise<number> {
+  server = serveFetchHandler(handler, { port: 0 });
+  await once(server, "listening");
+  return (server.address() as AddressInfo).port;
+}
+
+interface Reply { status: number; headers: Record<string, string | string[] | undefined>; body: string }
+
+/** Liten node:http-klient (oberoende av happy-dom:s fetch). */
+function call(
+  port: number, path: string,
+  opts: { method?: string; headers?: Record<string, string>; body?: string } = {},
+): Promise<Reply> {
+  return new Promise((resolve, reject) => {
+    const req = request(
+      { host: "127.0.0.1", port, path, method: opts.method ?? "GET", headers: opts.headers },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () => resolve({
+          status: res.statusCode ?? 0, headers: res.headers, body: Buffer.concat(chunks).toString(),
+        }));
+      },
+    );
+    req.on("error", reject);
+    if (opts.body !== undefined) req.write(opts.body);
+    req.end();
+  });
+}
+
+describe("serveFetchHandler", () => {
+  it("GET: metod/headers/url → Request; Response → status/headers/body", async () => {
+    const port = await start(async (req) =>
+      new Response(JSON.stringify({
+        method: req.method,
+        path: new URL(req.url).pathname,
+        auth: req.headers.get("authorization"),
+      }), { status: 200, headers: { "content-type": "application/json", "x-test": "1" } }),
+    );
+    const res = await call(port, "/hello", { headers: { authorization: "Bearer t" } });
+    expect(res.status).toBe(200);
+    expect(res.headers["x-test"]).toBe("1");
+    const body = JSON.parse(res.body) as { method: string; path: string; auth: string };
+    expect(body.method).toBe("GET");
+    expect(body.path).toBe("/hello");
+    expect(body.auth).toBe("Bearer t");
+  });
+
+  it("POST: bodyn vidarebefordras till handlern", async () => {
+    const port = await start(async (req) => new Response(`echo:${await req.text()}`, { status: 201 }));
+    const res = await call(port, "/x", { method: "POST", body: "payload" });
+    expect(res.status).toBe(201);
+    expect(res.body).toBe("echo:payload");
+  });
+
+  it("handler-kast → 500", async () => {
+    const port = await start(async () => { throw new Error("boom"); });
+    const res = await call(port, "/x");
+    expect(res.status).toBe(500);
+    expect(JSON.parse(res.body)).toEqual({ error: "internal" });
+  });
+});

--- a/test/unit/server/http/server-api.test.ts
+++ b/test/unit/server/http/server-api.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Enhetstester för `buildServerApiHandler` (#83 steg 1c) — composition-root:en.
+ * Verifierar token-grinden (utan git): inget API utan tokens, och att en
+ * konfigurerad token krävs (401 utan/fel token, session/git aldrig nådd).
+ */
+import { describe, it, expect } from "vitest-compat";
+import { buildServerApiHandler, type ServerApiConfig } from "@/lib/server/http/server-api";
+import type { Principal } from "@/lib/server/auth/principal";
+
+const PRINCIPAL: Principal = {
+  id: "sr", email: "sr@ava.local", name: "SR", role: "ADMIN", organizationId: "org-1",
+};
+
+const baseConfig = (tokens: string[]): ServerApiConfig => ({
+  workDir: "/nonexistent/wc", remote: "origin", branch: "main",
+  apiTokens: tokens, principal: PRINCIPAL,
+});
+
+const noLock = <T>(fn: () => Promise<T>) => fn();
+
+describe("buildServerApiHandler", () => {
+  it("inga tokens → null (inget API monteras)", () => {
+    expect(buildServerApiHandler(baseConfig([]), { lock: noLock })).toBeNull();
+  });
+
+  it("med tokens → handler; saknad token → 401 (working-copy aldrig öppnad)", async () => {
+    const handler = buildServerApiHandler(baseConfig(["good"]), { lock: noLock });
+    expect(handler).not.toBeNull();
+    const res = await handler!(new Request("http://x/api/trpc/user.current"));
+    expect(res.status).toBe(401);
+    // Att vi får 401 (inte ett git-/ENOENT-fel mot /nonexistent/wc) bevisar att
+    // auth-grinden går FÖRE openSession → ingen working-copy-hydrering skedde.
+  });
+
+  it("fel token → 401", async () => {
+    const handler = buildServerApiHandler(baseConfig(["good"]), { lock: noLock });
+    const res = await handler!(new Request("http://x/api/trpc/user.current", {
+      headers: { authorization: "Bearer wrong" },
+    }));
+    expect(res.status).toBe(401);
+  });
+});

--- a/test/unit/server/local-first/server-runtime-config.test.ts
+++ b/test/unit/server/local-first/server-runtime-config.test.ts
@@ -76,4 +76,32 @@ describe("loadRuntimeConfig (#118)", () => {
   it("samlar flera fel i ett kast", () => {
     expect(() => loadRuntimeConfig({})).toThrow(/repoUrl[\s\S]*workDir|workDir[\s\S]*repoUrl/);
   });
+
+  it("HTTP-API (#83): default → ingen port, inga tokens, loopback-host", () => {
+    const cfg = loadRuntimeConfig(MINIMAL);
+    expect(cfg.httpPort).toBeUndefined();
+    expect(cfg.apiTokens).toEqual([]);
+    expect(cfg.httpHost).toBe("127.0.0.1");
+  });
+
+  it("HTTP-API: parsar port, host och komma-separerade tokens (trim + tomma bort)", () => {
+    const cfg = loadRuntimeConfig({
+      ...MINIMAL,
+      AVA_SR_API_PORT: "9443",
+      AVA_SR_API_HOST: "0.0.0.0",
+      AVA_SR_API_TOKENS: " tok-a , tok-b ,, ",
+    });
+    expect(cfg.httpPort).toBe(9443);
+    expect(cfg.httpHost).toBe("0.0.0.0");
+    expect(cfg.apiTokens).toEqual(["tok-a", "tok-b"]);
+  });
+
+  it("HTTP-API: tom token-sträng → [] (default)", () => {
+    const cfg = loadRuntimeConfig({ ...MINIMAL, AVA_SR_API_TOKENS: "  ,  " });
+    expect(cfg.apiTokens).toEqual([]);
+  });
+
+  it("HTTP-API: ogiltig port kastar", () => {
+    expect(() => loadRuntimeConfig({ ...MINIMAL, AVA_SR_API_PORT: "-5" })).toThrow(/httpPort/);
+  });
 });

--- a/test/unit/server/local-first/server-runtime.test.ts
+++ b/test/unit/server/local-first/server-runtime.test.ts
@@ -40,6 +40,8 @@ function cfg(over: Partial<RuntimeConfig>): RuntimeConfig {
     remote: "origin",
     pollIntervalMs: 600_000, // högt → interval-timern firar inte under testet
     maxRetries: 3,
+    httpHost: "127.0.0.1",
+    apiTokens: [],
     principal: PRINCIPAL,
     ...over,
   };

--- a/tooling/docker/docker-compose.yml
+++ b/tooling/docker/docker-compose.yml
@@ -122,9 +122,18 @@ services:
       AVA_SR_GIT_USER: ${AVA_SR_GIT_USER:-}
       AVA_SR_GIT_TOKEN: ${AVA_SR_GIT_TOKEN:-}
       AVA_SR_POLL_INTERVAL_MS: ${AVA_SR_POLL_INTERVAL_MS:-15000}
+      # tRPC-over-HTTP-API (#83): nginx /api/ proxar hit. Lyssnar på 0.0.0.0
+      # (annan container når den över docker-nätet); porten publiceras INTE
+      # mot host:en — bara nåbar via nginx-fronten. API:t monteras bara när
+      # minst en token finns i AVA_SR_API_TOKENS (komma-separerade Bearer-PAT).
+      AVA_SR_API_PORT: ${AVA_SR_API_PORT:-9443}
+      AVA_SR_API_HOST: 0.0.0.0
+      AVA_SR_API_TOKENS: ${AVA_SR_API_TOKENS:-}
       # Fortnox-connector (#82/#79): aktiveras när valv-env + mount finns.
       AVA_SECRETS_KEY: ${AVA_SECRETS_KEY:-}
       AVA_SECRETS_FILE: ${AVA_SECRETS_FILE:-}
+    expose:
+      - "9443"
     volumes:
       - server_work:/var/lib/ava
       # Montera byråns secrets-valv (utanför repo:t) för Fortnox-connectorn:

--- a/tooling/docker/nginx.conf
+++ b/tooling/docker/nginx.conf
@@ -81,6 +81,23 @@ server {
     fastcgi_buffering off;
   }
 
+  # ─── tRPC-over-HTTP-API (server-runtime, #83 / ADR 0013) ──────────
+  # Office-add-ins och andra native-klienter når domän-routrarna här via
+  # httpBatchLink + `Authorization: Bearer <PAT>`. Bara meningsfullt när
+  # server-profilen körs (server-runtime-containern äger git-db:n). Samma
+  # variabel-proxy + runtime-DNS-mönster som /auth/ nedan, så nginx bootar
+  # även utan server-runtime (502 vid request om den saknas).
+  location /api/ {
+    set $ava_api "http://server-runtime:9443";
+    proxy_pass $ava_api;
+    proxy_set_header Host $host;
+    proxy_set_header Authorization $http_authorization;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    client_max_body_size 25m;
+    proxy_read_timeout 60;
+  }
+
   # ─── Auth-server: provisioning / invites (öppen, men token-gated) ───
   # Sätter ingen auth_basic här eftersom auth-server SJÄLV verifierar
   # bootstrap-secret / invite-token / admin-PAT i body:n. Endpoints:


### PR DESCRIPTION
## Vad

**#83 steg 1c** — sista steget av plattformsgrunden ([ADR 0013](../blob/main/docs/adr/0013-office-add-in-arkitektur.md)). API:t från steg 1 (PR #283) + 1b (PR #286) blir **nåbart end-to-end**: monterat i server-runtime-processen, bakom nginx, med delat lås mot peer-loopen (beslut A).

## Hur

- **`server-runtime-config.ts`** — nya env: `AVA_SR_API_PORT`, `AVA_SR_API_HOST` (default `127.0.0.1`), `AVA_SR_API_TOKENS` (komma-separerade Bearer-PAT, trimmas; tomt → `[]`). API:t monteras **bara** när både port och ≥1 token finns.
- **`http/server-api.ts`** — `buildServerApiHandler`: composition-root som knyter PAT-verifierare (tokens → maskin-principal) + working-copy-session + delat lås → en fetch-handler. `null` utan tokens (ren git-peer, oförändrat).
- **`http/node-http-adapter.ts`** — `serveFetchHandler` monterar `(Request)=>Response` på **`node:http`** (vald framför `Bun.serve` så koden typkollar under rot-tsconfig:en, `types: []`).
- **`server-runtime.ts`** — injicerbar `lock` vidare till `PeerLoop`.
- **`bin/server-runtime.ts`** — skapar **EN delad `Mutex`**, ger `lock` till både loopen och API:t (ADR 0013 beslut A), monterar listenern + stänger den vid SIGTERM/`--once`.
- **`nginx.conf`** — `/api/`-proxy med **variabel-upstream + docker-resolver** så nginx **bootar även när server-profilen är nere** (annars skulle web-only-stacken — och e2e — brytas; 502 vid request i stället).
- **`docker-compose.yml`** — API-env + `expose: 9443` (publiceras **ej** mot host; nås bara via nginx). `0.0.0.0` i container så nginx i annan container når hit.
- **ADR 0013** — dokumenterar concurrency-beslut A + de tre stegen.

## Test

- `server-runtime-config`: port/host/token-parsning (trim, tomma bort, default, ogiltig port kastar).
- `server-api`: `null` utan tokens; med token → 401 utan/fel token (auth-grind **före** working-copy → ingen git mot en fejk-dir).
- `node-http-adapter`: **riktig server** på OS-tilldelad port, driven av en `node:http`-klient (test-miljöns happy-dom-`fetch` blockerar loopback). GET (metod/headers/url/Response-mappning), POST (body), handler-kast → 500.

## Verifierat lokalt (CI-spegel)

- `bun run typecheck` ✅ · `bun run lint --max-warnings 0` ✅
- `bun run deps:check` ✅ · `bun run duplicates` ✅ · knip rent
- `bun run test:cov` ✅ — **2823 tester gröna**, coverage upp (rader 83.81 %, funktioner 80.56 %)
- `bun src/bin/server-runtime.ts --help` ✅ (visar de nya env-flaggorna)

**nginx-ändringen valideras av E2E-checkarna** (git round-trip bootar web-containern med denna nginx.conf).

## Status: #83 grund klar

Servern kan nu, via tRPC-over-HTTP (Bearer-PAT), läsa/skriva git-db:n med återanvända routrar + delade typer — #83:s "klar när". Kvar för **#84 (Word)** / **#72 (Outlook)**: den delade Office.js-task-pane-shellen med `httpBatchLink`-klient + manifest per host (tunna feature-lager ovanpå detta).

Refs #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)