### PR TITLE
feat(addin): delad tRPC-klient + host-manifest för Office-add-ins (#83)

### DIFF
--- a/office-addin/README.md
+++ b/office-addin/README.md
@@ -1,0 +1,55 @@
+# AVA Office-add-ins (#83)
+
+Grunden för Word- (#84) och Outlook- (#72) add-ins, enligt
+[ADR 0013](../docs/adr/0013-office-add-in-arkitektur.md).
+
+## Arkitektur (kort)
+
+Add-ins är **tunna tRPC-HTTP-klienter**. De äger ingen git-db, kör ingen
+iso-git och rör inget filsystem. De pratar med **server-runtime:ns
+tRPC-over-HTTP-API** (`/api/trpc`, Bearer-PAT, superjson) som äger `firma.git`:
+
+```
+Office-add-in (Office.js, valfri webview/OS)
+   │  tRPC httpBatchLink + Authorization: Bearer <PAT>
+   ▼
+nginx-front  →  AVA-server (server-runtime, tRPC-over-HTTP)  →  firma.git
+```
+
+Servern är byggd och mergad (steg 1/1b/1c): se
+`src/lib/server/http/` (handler, PAT, working-copy-session, node-http-adapter)
+och `src/bin/server-runtime.ts` (montering + delad Mutex).
+
+## Vad som finns nu
+
+- **Delad tRPC-klient** — `src/lib/client/addin/addin-client.ts`:
+  `createAddinClient({ baseUrl, token })` ger en fullt typad `AppRouter`-klient
+  (`client.matter.list.query(...)`, `client.user.current.query()`, …),
+  end-to-end-typad mot servern, med superjson + Bearer-PAT. Wire-kompatibilitet
+  med servern är enhetstestad (`test/unit/client/addin/addin-client.test.ts`).
+- **Manifest per host** — `manifests/word-manifest.xml`, `manifests/outlook-manifest.xml`
+  (sideload-redo; `SourceLocation` pekar på en HTTPS-serverad task-pane-bundle).
+
+## Vad som återstår (per-host feature-lager, #84/#72)
+
+Detta kräver Office-runtime-infra som inte kan CI-verifieras utan en riktig
+Office-värd, och bör därför byggas tillsammans med respektive host-add-in:
+
+1. **Task-pane-bundle** — en HTML+JS-artefakt (t.ex. via `bun build`) som
+   monterar en React-shell ovanpå `createAddinClient`. Behöver
+   `@types/office-js` + `Office.onReady`/host-detektering.
+2. **HTTPS-servering** av bundlen (Office kräver HTTPS vid sideload; dev-cert
+   à la `helper-app/src/tls/`).
+3. **PAT-inmatning/-lagring** i task-panen (användaren klistrar in sin PAT;
+   lagras i add-in-roaming-settings).
+4. **Host-specifik UI** — Word: infoga ärende-/malldata, spara DOCX (#84).
+   Outlook: koppla mail → ärende, spara mail/bilagor (#72).
+
+## Sideload (när en bundle finns)
+
+- **Word:** Infoga → Mina tillägg → Ladda upp mitt tillägg → `word-manifest.xml`.
+- **Outlook:** Hämta tillägg → Mina tillägg → Egna tillägg → Lägg till från fil →
+  `outlook-manifest.xml`.
+
+Båda kräver att task-pane-bundlen serveras över HTTPS på den URL som
+`SourceLocation` pekar på.

--- a/office-addin/manifests/outlook-manifest.xml
+++ b/office-addin/manifests/outlook-manifest.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  AVA Outlook-add-in (#72) — task-pane-manifest (read/compose surface).
+
+  Pekar på en HTTPS-serverad task-pane-bundle (SourceLocation via bt:Url).
+  Add-in:en är en tunn tRPC-HTTP-klient (src/lib/client/addin/addin-client.ts)
+  mot AVA-serverns /api/trpc (ADR 0013). Byt ut https://localhost:3443 mot den
+  faktiska bundle-värden vid sideload/AppSource.
+
+  Sideload (dev): Outlook → Hämta tillägg → Mina tillägg → Egna tillägg →
+  Lägg till från fil → välj denna fil (kräver HTTPS-serverad bundle).
+-->
+<OfficeApp
+  xmlns="http://schemas.microsoft.com/office/appforoffice/1.1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:bt="http://schemas.microsoft.com/office/officeappbasictypes/1.0"
+  xmlns:mailappor="http://schemas.microsoft.com/office/mailappversionoverrides/1.0"
+  xsi:type="MailApp">
+  <Id>3a0c9b4d-2e5f-4b7c-8d3a-1b2c3d4e5f60</Id>
+  <Version>0.1.0</Version>
+  <ProviderName>AVA</ProviderName>
+  <DefaultLocale>sv-SE</DefaultLocale>
+  <DisplayName DefaultValue="AVA" />
+  <Description DefaultValue="Koppla mail till ärenden och spara mail/bilagor till ärendets git-db från Outlook." />
+  <IconUrl DefaultValue="https://localhost:3443/assets/icon-64.png" />
+  <HighResolutionIconUrl DefaultValue="https://localhost:3443/assets/icon-128.png" />
+  <SupportUrl DefaultValue="https://github.com/ulrik-s/ava" />
+  <Hosts>
+    <Host Name="Mailbox" />
+  </Hosts>
+  <Requirements>
+    <Sets>
+      <Set Name="Mailbox" MinVersion="1.5" />
+    </Sets>
+  </Requirements>
+  <FormSettings>
+    <Form xsi:type="ItemRead">
+      <DesktopSettings>
+        <SourceLocation DefaultValue="https://localhost:3443/taskpane.html" />
+        <RequestedHeight>450</RequestedHeight>
+      </DesktopSettings>
+    </Form>
+  </FormSettings>
+  <Permissions>ReadWriteItem</Permissions>
+  <Rule xsi:type="RuleCollection" Mode="Or">
+    <Rule xsi:type="ItemIs" ItemType="Message" FormType="Read" />
+  </Rule>
+</OfficeApp>

--- a/office-addin/manifests/word-manifest.xml
+++ b/office-addin/manifests/word-manifest.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  AVA Word-add-in (#84) — task-pane-manifest.
+
+  Pekar på en HTTPS-serverad task-pane-bundle (SourceLocation). Add-in:en är en
+  tunn tRPC-HTTP-klient (se src/lib/client/addin/addin-client.ts) mot
+  AVA-serverns /api/trpc (ADR 0013). Byt ut https://localhost:3443 mot den
+  faktiska bundle-värden vid sideload/AppSource.
+
+  Sideload (dev): Word → Infoga → Mina tillägg → Ladda upp mitt tillägg →
+  välj denna fil. Kräver att task-pane-bundlen serveras över HTTPS.
+-->
+<OfficeApp
+  xmlns="http://schemas.microsoft.com/office/appforoffice/1.1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:bt="http://schemas.microsoft.com/office/officeappbasictypes/1.0"
+  xsi:type="TaskPaneApp">
+  <Id>2f9b8a3c-1d4e-4a6b-9c2f-0a1b2c3d4e5f</Id>
+  <Version>0.1.0</Version>
+  <ProviderName>AVA</ProviderName>
+  <DefaultLocale>sv-SE</DefaultLocale>
+  <DisplayName DefaultValue="AVA" />
+  <Description DefaultValue="Infoga ärende-, klient- och malldata från AVA och spara dokument till ärendets git-db." />
+  <IconUrl DefaultValue="https://localhost:3443/assets/icon-32.png" />
+  <HighResolutionIconUrl DefaultValue="https://localhost:3443/assets/icon-80.png" />
+  <SupportUrl DefaultValue="https://github.com/ulrik-s/ava" />
+  <Hosts>
+    <Host Name="Document" />
+  </Hosts>
+  <DefaultSettings>
+    <SourceLocation DefaultValue="https://localhost:3443/taskpane.html" />
+  </DefaultSettings>
+  <Permissions>ReadWriteDocument</Permissions>
+</OfficeApp>

--- a/src/lib/client/addin/addin-client.ts
+++ b/src/lib/client/addin/addin-client.ts
@@ -1,0 +1,65 @@
+/**
+ * `addin-client` — den delade tRPC-klienten för Office-add-ins (#83, ADR 0013).
+ *
+ * Add-ins är **tunna HTTP-klienter**: de äger ingen git-db, ingen iso-git, inget
+ * OPFS. De pratar med server-runtime:ns tRPC-over-HTTP-API (`/api/trpc`, byggt i
+ * steg 1/1b/1c) via `httpBatchLink` + `superjson` (matchar serverns transformer)
+ * och auktoriserar med `Authorization: Bearer <PAT>` (ADR 0013 §3 C1).
+ *
+ * Återanvänder `AppRouter`-typen (type-only import → ingen server-kod i bundlen,
+ * respekterar lager-regeln `ui-imports-server-by-type-only`). Word (#84) och
+ * Outlook (#72) bygger sina task-panes ovanpå exakt denna klient — samma
+ * end-to-end-typer som web-appen, ingen reimplementation.
+ *
+ * Office.js-fritt med flit: detta är transport-/datalagret och kan därför
+ * enhetstestas mot den riktiga server-handlern utan en Office-runtime.
+ */
+
+import { createTRPCClient, httpBatchLink, type TRPCClient } from "@trpc/client";
+import superjson from "superjson";
+import type { AppRouter } from "@/lib/server/routers/_app";
+
+/** Minimal fetch-form för override (test/icke-standard-runtime). En DOM-`fetch`
+ *  uppfyller den; tRPC:s interna `FetchEsque` är inte publikt exporterad. */
+export type AddinFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+/** tRPC:s httpBatchLink-fetch-typ (icke-exporterad `FetchEsque`), härledd ur
+ *  länkens optionsparameter så vi kan brygga en DOM-fetch dit utan import. */
+type LinkFetch = NonNullable<NonNullable<Parameters<typeof httpBatchLink<AppRouter>>[0]>["fetch"]>;
+
+/** tRPC-endpointens default-suffix på serverns origin (matchar DEFAULT_TRPC_ENDPOINT). */
+export const ADDIN_TRPC_PATH = "/api/trpc";
+
+/** Bygg full endpoint-URL ur serverns bas-URL (trimmar avslutande "/"). */
+export function addinTrpcEndpoint(baseUrl: string): string {
+  return `${baseUrl.replace(/\/+$/, "")}${ADDIN_TRPC_PATH}`;
+}
+
+export interface AddinClientOptions {
+  /** Serverns bas-URL (t.ex. https://byra.example). `/api/trpc` läggs på. */
+  baseUrl: string;
+  /** Bearer-PAT som auktoriserar mot API:t. */
+  token: string;
+  /** Valfri `fetch`-override (test/icke-standard-runtime). Default: global fetch. */
+  fetch?: AddinFetch;
+}
+
+/**
+ * Skapa en typad tRPC-klient mot AVA-serverns HTTP-API. Returvärdet har hela
+ * `AppRouter`-ytan (t.ex. `client.matter.list.query(...)`, `client.user.current
+ * .query()`), end-to-end-typad mot servern.
+ */
+export function createAddinClient(opts: AddinClientOptions): TRPCClient<AppRouter> {
+  return createTRPCClient<AppRouter>({
+    links: [
+      httpBatchLink({
+        url: addinTrpcEndpoint(opts.baseUrl),
+        transformer: superjson,
+        headers: () => ({ authorization: `Bearer ${opts.token}` }),
+        // En DOM-fetch är runtime-kompatibel med tRPC:s FetchEsque; typerna
+        // skiljer bara i exactOptional-detaljer (signal null vs undefined).
+        ...(opts.fetch ? { fetch: opts.fetch as unknown as LinkFetch } : {}),
+      }),
+    ],
+  });
+}

--- a/test/unit/client/addin/addin-client.test.ts
+++ b/test/unit/client/addin/addin-client.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Enhetstest för den delade add-in-tRPC-klienten (#83, ADR 0013).
+ *
+ * Driver `createAddinClient` mot den RIKTIGA server-handlern
+ * (`createTrpcHttpHandler`) via en injicerad `fetch` → bevisar att add-in-
+ * klienten är wire-kompatibel med servern: samma `/api/trpc`-endpoint,
+ * superjson-transformer och Bearer-PAT-auth. Detta är hela poängen med
+ * "add-ins är tunna tRPC-klienter".
+ */
+import { describe, it, expect } from "vitest-compat";
+import { createAddinClient, addinTrpcEndpoint, type AddinFetch } from "@/lib/client/addin/addin-client";
+import { createTrpcHttpHandler } from "@/lib/server/http/trpc-http-handler";
+import { StaticPatVerifier, patRecord } from "@/lib/server/http/pat";
+import type { Context } from "@/lib/server/trpc-core";
+import type { Principal } from "@/lib/server/auth/principal";
+
+const PRINCIPAL: Principal = {
+  id: "p-1", email: "advokat@byra.se", name: "Ada Advokat",
+  role: "LAWYER", organizationId: "org-1",
+};
+
+/** Server-handler med fake-context (user.current faller tillbaka på ctx.user). */
+function serverHandler() {
+  const verifier = new StaticPatVerifier([patRecord("good-token", PRINCIPAL)]);
+  const context = {
+    dataStore: { users: { findUniqueOrThrow: async () => { throw new Error("no row"); } } },
+    ports: {}, user: PRINCIPAL,
+  } as unknown as Context;
+  return createTrpcHttpHandler({
+    verifier,
+    openSession: () => ({ context, finalize: async () => {} }),
+  });
+}
+
+/** Add-in-klient som routar via en given server-handler (i st.f. nätet). */
+function clientVia(handler: (req: Request) => Promise<Response>, token: string) {
+  const fetchImpl: AddinFetch = (input, init) => handler(new Request(input, init));
+  return createAddinClient({ baseUrl: "https://byra.example/", token, fetch: fetchImpl });
+}
+
+describe("addinTrpcEndpoint", () => {
+  it("lägger på /api/trpc och trimmar avslutande slash", () => {
+    expect(addinTrpcEndpoint("https://byra.example")).toBe("https://byra.example/api/trpc");
+    expect(addinTrpcEndpoint("https://byra.example/")).toBe("https://byra.example/api/trpc");
+    expect(addinTrpcEndpoint("https://byra.example///")).toBe("https://byra.example/api/trpc");
+  });
+});
+
+describe("createAddinClient", () => {
+  it("giltig PAT → user.current returnerar principalen (end-to-end mot servern)", async () => {
+    const client = clientVia(serverHandler(), "good-token");
+    const me = await client.user.current.query();
+    expect(me.email).toBe(PRINCIPAL.email);
+    expect(me.name).toBe(PRINCIPAL.name);
+    expect(me.createdAt).toBeInstanceOf(Date); // superjson round-trippade en Date
+  });
+
+  it("fel PAT → 401 → klienten kastar", async () => {
+    const client = clientVia(serverHandler(), "wrong-token");
+    await expect(client.user.current.query()).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Vad

**Add-in-sidans grund för #83** ([ADR 0013](../blob/main/docs/adr/0013-office-add-in-arkitektur.md)). Add-ins är **tunna tRPC-HTTP-klienter** mot server-runtime:ns `/api/trpc` (byggt i steg 1/1b/1c). Word (#84) och Outlook (#72) blir tunna feature-lager ovanpå detta.

## Hur

- **`src/lib/client/addin/addin-client.ts`** — `createAddinClient({ baseUrl, token })` ger en **fullt typad `AppRouter`-klient** via `httpBatchLink` + `superjson` (matchar serverns transformer) + `Authorization: Bearer <PAT>`. `addinTrpcEndpoint(baseUrl)` bygger `/api/trpc`-URL:en. `AppRouter` importeras **type-only** → ingen server-kod i bundlen (respekterar `ui-imports-server-by-type-only`).
- **`office-addin/manifests/{word,outlook}-manifest.xml`** — sideload-redo task-pane-manifest (`SourceLocation` pekar på en HTTPS-serverad bundle).
- **`office-addin/README.md`** — arkitektur, sideload-steg, och vad som återstår.

## Test

Wire-kompatibilitet **enhetstestad mot den riktiga server-handlern** (`createTrpcHttpHandler`) via injicerad fetch — exakt add-in:ens väg över nätet:
- giltig PAT → `client.user.current.query()` returnerar principalen, **superjson round-trippar en `Date`**;
- fel PAT → 401 → klienten kastar;
- `addinTrpcEndpoint` trimmar slash + lägger på `/api/trpc`.

## Verifierat lokalt (CI-spegel)

- `bun run typecheck` ✅ · `bun run lint --max-warnings 0` ✅
- `bun run deps:check` ✅ (type-only AppRouter-import passerar lager-regeln) · `bun run duplicates` ✅ · knip rent
- `bun run test:cov` ✅ — **2826 tester gröna**, coverage upp (rader 83.83 %, funktioner 80.59 %)

## Återstår på #83 (per-host, #84/#72)

Office-runtime-infra som **inte är CI-verifierbar** utan en Office-värd och därför byggs med respektive host-add-in: Office.js task-pane-**bundle** (`@types/office-js` + `bun build`) + **HTTPS-servering** av bundlen + **PAT-inmatning** i panelen + host-specifik UI. Se `office-addin/README.md`. Datalagret (denna klient) + manifesten är klara och delade.

Refs #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)