### PR TITLE
refactor(matters): bryt ut form/filter/pager ur MattersContent + delad Pager (#6 ratchet)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -29,11 +29,6 @@
       "count": 1
     }
   },
-  "src/app/matters/page.tsx": {
-    "max-lines-per-function": {
-      "count": 1
-    }
-  },
   "src/app/payment-plans/[id]/_client.tsx": {
     "max-lines-per-function": {
       "count": 1

--- a/src/app/contacts/page.tsx
+++ b/src/app/contacts/page.tsx
@@ -7,6 +7,7 @@ import { trpc } from "@/lib/client/trpc";
 import { labelForContactType, contactTypeOptions } from "@/lib/client/labels";
 import { useIsReadOnly } from "@/lib/client/demo/demo-mode-context";
 import { DataTable, type Column } from "@/components/ui/data-table";
+import { Pager } from "@/components/ui/pager";
 
 interface ContactRow {
   id: string;
@@ -144,25 +145,6 @@ function NewContactForm({ form, setForm, onSubmit, onCancel, isPending, error }:
   );
 }
 
-/** Pagineringsfot (utbruten ur ContactsContent, #6-ratchet). Renderar inget
- *  när det bara finns en sida. */
-function ListPager(
-  { data, page, onPage }: { data: { pages: number; total: number } | undefined; page: number; onPage: (p: number) => void },
-) {
-  if (!data || data.pages <= 1) return null;
-  return (
-    <div className="px-6 py-3 mt-2 bg-white border border-gray-200 rounded-lg flex items-center justify-between">
-      <p className="text-sm text-gray-500">Sida {page} av {data.pages} ({data.total} totalt)</p>
-      <div className="flex gap-2">
-        <button disabled={page <= 1} onClick={() => onPage(page - 1)}
-          className="px-3 py-1 text-sm border rounded disabled:opacity-50">Föregående</button>
-        <button disabled={page >= data.pages} onClick={() => onPage(page + 1)}
-          className="px-3 py-1 text-sm border rounded disabled:opacity-50">Nästa</button>
-      </div>
-    </div>
-  );
-}
-
 function ContactsContent() {
   const searchParams = useSearchParams();
   const readOnly = useIsReadOnly();
@@ -243,7 +225,7 @@ function ContactsContent() {
       </div>
 
       <ContactsTable rows={(contacts.data?.contacts ?? []) as ContactRow[]} />
-      <ListPager data={contacts.data} page={page} onPage={setPage} />
+      <Pager data={contacts.data} page={page} onPage={setPage} showTotal />
     </div>
   );
 }

--- a/src/app/matters/page.tsx
+++ b/src/app/matters/page.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from "next/navigation";
 import { trpc } from "@/lib/client/trpc";
 import { useIsReadOnly } from "@/lib/client/demo/demo-mode-context";
 import { DataTable, type Column } from "@/components/ui/data-table";
+import { Pager } from "@/components/ui/pager";
 
 interface MatterRow {
   id: string;
@@ -62,29 +63,182 @@ const matterColumns: Column<MatterRow>[] = [
     render: (m) => <span className="text-sm text-gray-500">{m._count.contacts}</span> },
 ];
 
-// eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Function 'MattersContent' has a complexity of 11. Maximum allowed is 8.)
-function MattersContent() {
-  const searchParams = useSearchParams();
-  const [search, setSearch] = useState("");
-  const [statusFilter, setStatusFilter] = useState<"ACTIVE" | "CLOSED" | "ARCHIVED" | "">("");
-  const [employeeId, setEmployeeId] = useState("");
-  const [page, setPage] = useState(1);
-  const [showForm, setShowForm] = useState(searchParams.get("new") === "1");
-  const readOnly = useIsReadOnly();
+type StatusFilter = "ACTIVE" | "CLOSED" | "ARCHIVED" | "";
+type NamedOption = { id: string; name: string };
+
+interface MatterForm {
+  title: string;
+  description: string;
+  matterType: string;
+  klientId: string;
+  responsibleLawyerId: string;
+  courtCaseNumber: string;
+  isTaxeArende: boolean;
+}
+
+/** Bygg query-args för matter.list (flyttar `|| undefined`-grenarna ut ur
+ *  MattersContent → håller den under complexity@8). */
+function matterListArgs(p: { search: string; status: StatusFilter; employeeId: string; page: number }) {
+  return {
+    search: p.search,
+    status: p.status || undefined,
+    employeeId: p.employeeId || undefined,
+    page: p.page,
+    pageSize: 20,
+  };
+}
+
+interface NewMatterFormProps {
+  form: MatterForm;
+  setForm: (f: MatterForm) => void;
+  contactsData: { contacts: NamedOption[] } | undefined;
+  employeesData: { users: NamedOption[] } | undefined;
+  onSubmit: (e: React.FormEvent) => void;
+  isPending: boolean;
+  error: { message: string } | null | undefined;
+}
+
+/** Nytt-ärende-formuläret (utbrutet ur MattersContent, #6-ratchet). Äger sina
+ *  fält-id:n; presentational (form-state + submit som props). */
+function NewMatterForm({ form, setForm, contactsData, employeesData, onSubmit, isPending, error }: NewMatterFormProps) {
   const titleId = useId();
   const klientId = useId();
   const matterTypeId = useId();
   const descriptionId = useId();
   const responsibleId = useId();
   const courtCaseId = useId();
+  return (
+    <form onSubmit={onSubmit} className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
+      <h2 className="font-semibold text-gray-900 mb-4">Nytt ärende</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label htmlFor={titleId} className="block text-sm font-medium text-gray-700 mb-1">Titel *</label>
+          <input id={titleId} type="text" required value={form.title}
+            onChange={(e) => setForm({ ...form, title: e.target.value })}
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" />
+        </div>
+        <div>
+          <label htmlFor={klientId} className="block text-sm font-medium text-gray-700 mb-1">Klient</label>
+          <select id={klientId} value={form.klientId}
+            onChange={(e) => setForm({ ...form, klientId: e.target.value })}
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm">
+            <option value="">Välj klient (valfritt)...</option>
+            {contactsData?.contacts.map((c) => (
+              <option key={c.id} value={c.id}>{c.name}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label htmlFor={matterTypeId} className="block text-sm font-medium text-gray-700 mb-1">Ärendetyp</label>
+          <input id={matterTypeId} type="text" value={form.matterType}
+            onChange={(e) => setForm({ ...form, matterType: e.target.value })}
+            placeholder="T.ex. Familjerätt, Brottmål..."
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" />
+        </div>
+        <div>
+          <label htmlFor={responsibleId} className="block text-sm font-medium text-gray-700 mb-1">Ansvarig advokat/jurist</label>
+          <select id={responsibleId} value={form.responsibleLawyerId}
+            onChange={(e) => setForm({ ...form, responsibleLawyerId: e.target.value })}
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm">
+            <option value="">Jag själv (standard)</option>
+            {employeesData?.users.map((u) => (
+              <option key={u.id} value={u.id}>{u.name}</option>
+            ))}
+          </select>
+          <p className="mt-1 text-xs text-gray-500">Styr ärendenummerserien (juristens prefix).</p>
+        </div>
+        <div>
+          <label htmlFor={courtCaseId} className="block text-sm font-medium text-gray-700 mb-1">Domstolens målnummer</label>
+          <input id={courtCaseId} type="text" value={form.courtCaseNumber}
+            onChange={(e) => setForm({ ...form, courtCaseNumber: e.target.value })}
+            placeholder="t.ex. B 1234-26 (valfritt)"
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm font-mono" />
+          <p className="mt-1 text-xs text-gray-500">Matchningsnyckel för domstolsbetalningar (#173).</p>
+        </div>
+        <div className="md:col-span-2">
+          <label htmlFor={descriptionId} className="block text-sm font-medium text-gray-700 mb-1">Beskrivning</label>
+          <textarea id={descriptionId} value={form.description}
+            onChange={(e) => setForm({ ...form, description: e.target.value })}
+            rows={2} className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" />
+        </div>
+        <div className="md:col-span-2">
+          <label className="inline-flex items-start gap-2 text-sm cursor-pointer">
+            <input
+              type="checkbox"
+              checked={form.isTaxeArende}
+              onChange={(e) => setForm({ ...form, isTaxeArende: e.target.checked })}
+              className="mt-0.5"
+            />
+            <span>
+              <span className="font-medium text-gray-900">Taxeärende</span>
+              <span className="block text-xs text-gray-500 mt-0.5">
+                Ersättning enligt Domstolsverkets fastställda taxa (schablon)
+                istället för löpande timdebitering. Vanligast för brottmål med
+                offentlig försvarare, konkursförvaltning och förordnandemål.
+              </span>
+            </span>
+          </label>
+        </div>
+      </div>
+      <div className="mt-4 flex gap-2">
+        <button type="submit" disabled={isPending}
+          className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 disabled:opacity-50">
+          {isPending ? "Skapar..." : "Skapa ärende"}
+        </button>
+      </div>
+      {error && <p className="mt-2 text-sm text-red-600">{error.message}</p>}
+    </form>
+  );
+}
 
-  const matters = trpc.matter.list.useQuery({
-    search,
-    status: statusFilter || undefined,
-    employeeId: employeeId || undefined,
-    page,
-    pageSize: 20,
-  });
+interface MatterFiltersProps {
+  search: string;
+  status: StatusFilter;
+  employeeId: string;
+  employeesData: { users: NamedOption[] } | undefined;
+  onSearch: (v: string) => void;
+  onStatus: (v: StatusFilter) => void;
+  onEmployee: (v: string) => void;
+}
+
+/** Sök- + status- + medarbetar-filter (utbrutet ur MattersContent, #6-ratchet). */
+function MatterFilters({ search, status, employeeId, employeesData, onSearch, onStatus, onEmployee }: MatterFiltersProps) {
+  return (
+    <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 mb-4">
+      <input type="text" placeholder="Sök ärenden..." value={search}
+        onChange={(e) => onSearch(e.target.value)}
+        className="flex-1 sm:max-w-md rounded-lg border border-gray-300 px-3 py-2 text-sm" />
+      <select value={status}
+        onChange={(e) => onStatus(e.target.value as StatusFilter)}
+        className="rounded-lg border border-gray-300 px-3 py-2 text-sm">
+        <option value="">Alla statusar</option>
+        <option value="ACTIVE">Aktiva</option>
+        <option value="CLOSED">Stängda</option>
+        <option value="ARCHIVED">Arkiverade</option>
+      </select>
+      <select value={employeeId}
+        onChange={(e) => onEmployee(e.target.value)}
+        title="Visa ärenden som medarbetaren har arbetat på (har tidsposter på)"
+        className="rounded-lg border border-gray-300 px-3 py-2 text-sm">
+        <option value="">Alla medarbetare</option>
+        {employeesData?.users.map((u) => (
+          <option key={u.id} value={u.id}>{u.name}</option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function MattersContent() {
+  const searchParams = useSearchParams();
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("");
+  const [employeeId, setEmployeeId] = useState("");
+  const [page, setPage] = useState(1);
+  const [showForm, setShowForm] = useState(searchParams.get("new") === "1");
+  const readOnly = useIsReadOnly();
+
+  const matters = trpc.matter.list.useQuery(matterListArgs({ search, status: statusFilter, employeeId, page }));
 
   const contacts = trpc.contacts.list.useQuery({ pageSize: 100 });
   const employees = trpc.user.list.useQuery();
@@ -97,7 +251,7 @@ function MattersContent() {
     },
   });
 
-  const [form, setForm] = useState({
+  const [form, setForm] = useState<MatterForm>({
     title: "",
     description: "",
     matterType: "",
@@ -134,110 +288,26 @@ function MattersContent() {
       </div>
 
       {showForm && (
-        <form onSubmit={handleSubmit} className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
-          <h2 className="font-semibold text-gray-900 mb-4">Nytt ärende</h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>
-              <label htmlFor={titleId} className="block text-sm font-medium text-gray-700 mb-1">Titel *</label>
-              <input id={titleId} type="text" required value={form.title}
-                onChange={(e) => setForm({ ...form, title: e.target.value })}
-                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" />
-            </div>
-            <div>
-              <label htmlFor={klientId} className="block text-sm font-medium text-gray-700 mb-1">Klient</label>
-              <select id={klientId} value={form.klientId}
-                onChange={(e) => setForm({ ...form, klientId: e.target.value })}
-                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm">
-                <option value="">Välj klient (valfritt)...</option>
-                {contacts.data?.contacts.map((c) => (
-                  <option key={c.id} value={c.id}>{c.name}</option>
-                ))}
-              </select>
-            </div>
-            <div>
-              <label htmlFor={matterTypeId} className="block text-sm font-medium text-gray-700 mb-1">Ärendetyp</label>
-              <input id={matterTypeId} type="text" value={form.matterType}
-                onChange={(e) => setForm({ ...form, matterType: e.target.value })}
-                placeholder="T.ex. Familjerätt, Brottmål..."
-                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" />
-            </div>
-            <div>
-              <label htmlFor={responsibleId} className="block text-sm font-medium text-gray-700 mb-1">Ansvarig advokat/jurist</label>
-              <select id={responsibleId} value={form.responsibleLawyerId}
-                onChange={(e) => setForm({ ...form, responsibleLawyerId: e.target.value })}
-                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm">
-                <option value="">Jag själv (standard)</option>
-                {employees.data?.users.map((u) => (
-                  <option key={u.id} value={u.id}>{u.name}</option>
-                ))}
-              </select>
-              <p className="mt-1 text-xs text-gray-500">Styr ärendenummerserien (juristens prefix).</p>
-            </div>
-            <div>
-              <label htmlFor={courtCaseId} className="block text-sm font-medium text-gray-700 mb-1">Domstolens målnummer</label>
-              <input id={courtCaseId} type="text" value={form.courtCaseNumber}
-                onChange={(e) => setForm({ ...form, courtCaseNumber: e.target.value })}
-                placeholder="t.ex. B 1234-26 (valfritt)"
-                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm font-mono" />
-              <p className="mt-1 text-xs text-gray-500">Matchningsnyckel för domstolsbetalningar (#173).</p>
-            </div>
-            <div className="md:col-span-2">
-              <label htmlFor={descriptionId} className="block text-sm font-medium text-gray-700 mb-1">Beskrivning</label>
-              <textarea id={descriptionId} value={form.description}
-                onChange={(e) => setForm({ ...form, description: e.target.value })}
-                rows={2} className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" />
-            </div>
-            <div className="md:col-span-2">
-              <label className="inline-flex items-start gap-2 text-sm cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={form.isTaxeArende}
-                  onChange={(e) => setForm({ ...form, isTaxeArende: e.target.checked })}
-                  className="mt-0.5"
-                />
-                <span>
-                  <span className="font-medium text-gray-900">Taxeärende</span>
-                  <span className="block text-xs text-gray-500 mt-0.5">
-                    Ersättning enligt Domstolsverkets fastställda taxa (schablon)
-                    istället för löpande timdebitering. Vanligast för brottmål med
-                    offentlig försvarare, konkursförvaltning och förordnandemål.
-                  </span>
-                </span>
-              </label>
-            </div>
-          </div>
-          <div className="mt-4 flex gap-2">
-            <button type="submit" disabled={createMatter.isPending}
-              className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 disabled:opacity-50">
-              {createMatter.isPending ? "Skapar..." : "Skapa ärende"}
-            </button>
-          </div>
-          {createMatter.error && <p className="mt-2 text-sm text-red-600">{createMatter.error.message}</p>}
-        </form>
+        <NewMatterForm
+          form={form}
+          setForm={setForm}
+          contactsData={contacts.data}
+          employeesData={employees.data}
+          onSubmit={handleSubmit}
+          isPending={createMatter.isPending}
+          error={createMatter.error}
+        />
       )}
 
-      <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 mb-4">
-        <input type="text" placeholder="Sök ärenden..." value={search}
-          onChange={(e) => { setSearch(e.target.value); setPage(1); }}
-          className="flex-1 sm:max-w-md rounded-lg border border-gray-300 px-3 py-2 text-sm" />
-        <select value={statusFilter}
-          onChange={(e) => { setStatusFilter(e.target.value as typeof statusFilter); setPage(1); }}
-          className="rounded-lg border border-gray-300 px-3 py-2 text-sm">
-          <option value="">Alla statusar</option>
-          <option value="ACTIVE">Aktiva</option>
-          <option value="CLOSED">Stängda</option>
-          <option value="ARCHIVED">Arkiverade</option>
-        </select>
-        <select value={employeeId}
-          onChange={(e) => { setEmployeeId(e.target.value); setPage(1); }}
-          title="Visa ärenden som medarbetaren har arbetat på (har tidsposter på)"
-          className="rounded-lg border border-gray-300 px-3 py-2 text-sm">
-          <option value="">Alla medarbetare</option>
-          {employees.data?.users.map((u) => (
-            <option key={u.id} value={u.id}>{u.name}</option>
-          ))}
-        </select>
-      </div>
+      <MatterFilters
+        search={search}
+        status={statusFilter}
+        employeeId={employeeId}
+        employeesData={employees.data}
+        onSearch={(v) => { setSearch(v); setPage(1); }}
+        onStatus={(v) => { setStatusFilter(v); setPage(1); }}
+        onEmployee={(v) => { setEmployeeId(v); setPage(1); }}
+      />
 
       <DataTable
         prefKey="list.matters"
@@ -246,15 +316,7 @@ function MattersContent() {
         rowKey={(m) => m.id}
         emptyMessage="Inga ärenden."
       />
-      {matters.data && matters.data.pages > 1 && (
-        <div className="px-6 py-3 mt-2 bg-white border border-gray-200 rounded-lg flex items-center justify-between">
-          <p className="text-sm text-gray-500">Sida {page} av {matters.data.pages}</p>
-          <div className="flex gap-2">
-            <button disabled={page <= 1} onClick={() => setPage(page - 1)} className="px-3 py-1 text-sm border rounded disabled:opacity-50">Föregående</button>
-            <button disabled={page >= matters.data.pages} onClick={() => setPage(page + 1)} className="px-3 py-1 text-sm border rounded disabled:opacity-50">Nästa</button>
-          </div>
-        </div>
-      )}
+      <Pager data={matters.data} page={page} onPage={setPage} />
     </div>
   );
 }

--- a/src/components/ui/pager.tsx
+++ b/src/components/ui/pager.tsx
@@ -1,0 +1,32 @@
+/**
+ * `Pager` — delad pagineringsfot för list-vyer (#6-ratchet, DRY).
+ *
+ * Tar list-queryns `data` ({ pages, total? }) och renderar inget vid ≤1 sida.
+ * `showTotal` styr om "(N totalt)" visas (kontakt-listan vill ha det, ärende-
+ * listan inte) — så samma komponent bevarar båda vyernas exakta utseende utan
+ * att tvinga `?.`-grenar tillbaka in i sid-komponenterna.
+ */
+
+interface PagerProps {
+  data: { pages: number; total?: number } | undefined;
+  page: number;
+  onPage: (p: number) => void;
+  /** Visa "(N totalt)" efter sidräknaren (default false). */
+  showTotal?: boolean;
+}
+
+export function Pager({ data, page, onPage, showTotal = false }: PagerProps) {
+  if (!data || data.pages <= 1) return null;
+  const suffix = showTotal && data.total !== undefined ? ` (${data.total} totalt)` : "";
+  return (
+    <div className="px-6 py-3 mt-2 bg-white border border-gray-200 rounded-lg flex items-center justify-between">
+      <p className="text-sm text-gray-500">Sida {page} av {data.pages}{suffix}</p>
+      <div className="flex gap-2">
+        <button disabled={page <= 1} onClick={() => onPage(page - 1)}
+          className="px-3 py-1 text-sm border rounded disabled:opacity-50">Föregående</button>
+        <button disabled={page >= data.pages} onClick={() => onPage(page + 1)}
+          className="px-3 py-1 text-sm border rounded disabled:opacity-50">Nästa</button>
+      </div>
+    </div>
+  );
+}

--- a/test/unit/components/pager.test.tsx
+++ b/test/unit/components/pager.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * Test för den delade `Pager` (#6-ratchet, DRY). Täcker: dold vid ≤1 sida /
+ * saknad data, sidräknare, "(N totalt)" bara med showTotal, och prev/next.
+ */
+import { describe, it, expect, vi } from "vitest-compat";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Pager } from "@/components/ui/pager";
+
+describe("Pager", () => {
+  it("renderar inget vid en sida eller saknad data", () => {
+    const { container, rerender } = render(<Pager data={undefined} page={1} onPage={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+    rerender(<Pager data={{ pages: 1, total: 5 }} page={1} onPage={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("visar sidräknare utan total som default", () => {
+    render(<Pager data={{ pages: 3, total: 42 }} page={2} onPage={vi.fn()} />);
+    expect(screen.getByText("Sida 2 av 3")).toBeInTheDocument();
+    expect(screen.queryByText(/totalt/)).not.toBeInTheDocument();
+  });
+
+  it("visar '(N totalt)' när showTotal är satt", () => {
+    render(<Pager data={{ pages: 3, total: 42 }} page={1} onPage={vi.fn()} showTotal />);
+    expect(screen.getByText("Sida 1 av 3 (42 totalt)")).toBeInTheDocument();
+  });
+
+  it("Föregående/Nästa anropar onPage; kant-knappar disabled", () => {
+    const onPage = vi.fn();
+    const { rerender } = render(<Pager data={{ pages: 3 }} page={1} onPage={onPage} />);
+    const prev = screen.getByRole("button", { name: /Föregående/ });
+    const next = screen.getByRole("button", { name: /Nästa/ });
+    expect(prev).toBeDisabled();
+    fireEvent.click(next);
+    expect(onPage).toHaveBeenCalledWith(2);
+
+    rerender(<Pager data={{ pages: 3 }} page={3} onPage={onPage} />);
+    expect(screen.getByRole("button", { name: /Nästa/ })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: /Föregående/ }));
+    expect(onPage).toHaveBeenCalledWith(2);
+  });
+});


### PR DESCRIPTION
## Vad

Ett **#6-ratchet-steg** på `src/app/matters/page.tsx`. `MattersContent` låg på **complexity 11** (max 8) bakom en inline `// eslint-disable-next-line complexity`.

## Hur

- Bryter ut **`NewMatterForm`** (nytt-ärende-formuläret; äger sina fält-id:n), **`MatterFilters`** (sök/status/medarbetare) och en query-args-helper **`matterListArgs`** (flyttar `|| undefined`-grenarna ut). `MattersContent` faller under complexity@8 → inline-disablen bort + dess `max-lines-per-function`-suppression prunas.
- Pagineringsfoten lyfts till en **delad `src/components/ui/pager.tsx`** (`Pager`) som nu används av **både** ärende- och kontakt-listan → tar bort jscpd-klonen som extraktionen annars skapat (**DRY**, åter till 12 kloner). `showTotal`-flaggan bevarar exakt utseende: kontakter visar "(N totalt)", ärenden inte. Kontakt-sidans lokala `ListPager` ersätts av den delade.

## Beteende oförändrat

Rena extraktioner (identisk DOM):
- `matters/page` test **9/9** grönt, `contacts/page` test **14/14** grönt (oförändrade).
- Nytt **`Pager`-enhetstest** (dold vid ≤1 sida/saknad data, sidräknare, `showTotal`, prev/next + disabled-kanter).

## Verifierat lokalt (CI-spegel)

- `bun run typecheck` ✅ · `bun run lint --max-warnings 0` ✅ (inline-disable + suppression borta)
- `bun run deps:check` ✅ · `bun run duplicates` ✅ (**12 kloner** — klonen borta) · knip rent
- `bun run test:cov` ✅ — **2830 tester gröna**, coverage (rader 83.82 %, funktioner 80.63 %)

Refs #6 #40 #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)