### PR TITLE
refactor(invoices): ersätt statusBadge if/switch med uppslagstabeller (#6 ratchet)

### DIFF
--- a/src/components/matter/invoices-section.tsx
+++ b/src/components/matter/invoices-section.tsx
@@ -24,20 +24,26 @@ interface InvoiceRow {
   amount: number;
 }
 
-// eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Function 'statusBadge' has a complexity of 9. Maximum allowed is 8.)
-function statusBadge(status: string, invoiceType: string): string {
-  const base = "text-[10px] rounded-full px-2 py-0.5 font-medium";
-  if (invoiceType === "ACCONTO") return `${base} bg-purple-100 text-purple-700`;
-  if (invoiceType === "FINAL") return `${base} bg-blue-100 text-blue-700`;
-  if (invoiceType === "CREDIT") return `${base} bg-orange-100 text-orange-700`;
-  switch (status) {
-    case "PAID": return `${base} bg-green-100 text-green-700`;
-    case "SENT": return `${base} bg-amber-100 text-amber-700`;
-    case "INSTALLMENT_PLAN": return `${base} bg-indigo-100 text-indigo-700`;
-    case "CANCELLED": return `${base} bg-gray-200 text-gray-600`;
-    case "BAD_DEBT": return `${base} bg-red-100 text-red-700`;
-    default: return `${base} bg-gray-100 text-gray-600`;
-  }
+const BADGE_BASE = "text-[10px] rounded-full px-2 py-0.5 font-medium";
+/** Faktura-typ vinner över status (acconto/slut/kredit får egen färg). */
+const TYPE_BADGE: Record<string, string> = {
+  ACCONTO: "bg-purple-100 text-purple-700",
+  FINAL: "bg-blue-100 text-blue-700",
+  CREDIT: "bg-orange-100 text-orange-700",
+};
+const STATUS_BADGE: Record<string, string> = {
+  PAID: "bg-green-100 text-green-700",
+  SENT: "bg-amber-100 text-amber-700",
+  INSTALLMENT_PLAN: "bg-indigo-100 text-indigo-700",
+  CANCELLED: "bg-gray-200 text-gray-600",
+  BAD_DEBT: "bg-red-100 text-red-700",
+};
+
+/** Badge-klass för en faktura: typ-färg först, annars status-färg, annars grå.
+ *  Uppslag i st.f. if/switch-kedja (håller under complexity@8). Exporterad för test. */
+export function statusBadge(status: string, invoiceType: string): string {
+  const color = TYPE_BADGE[invoiceType] ?? STATUS_BADGE[status] ?? "bg-gray-100 text-gray-600";
+  return `${BADGE_BASE} ${color}`;
 }
 
 function statusLabel(status: string): string {

--- a/test/unit/components/invoices-section.test.tsx
+++ b/test/unit/components/invoices-section.test.tsx
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { InvoicesSection } from "@/components/matter/invoices-section";
+import { InvoicesSection, statusBadge } from "@/components/matter/invoices-section";
 
 const invoicesQuery = { isLoading: false, data: [] as Array<Record<string, unknown>> };
 const timeQuery: { data: { entries: Array<Record<string, unknown>> } } = { data: { entries: [] } };
@@ -341,5 +341,26 @@ describe("InvoicesSection", () => {
     fireEvent.click(screen.getByRole("button", { name: /Skapa slutfaktura/ }));
     const arg = createFinalMutate.mock.calls[0]![0];
     expect(arg.accontoInvoiceIds).toEqual(["ac1"]);
+  });
+});
+
+describe("statusBadge (#6-ratchet: uppslag i st.f. if/switch)", () => {
+  it("faktura-typ vinner över status", () => {
+    expect(statusBadge("PAID", "ACCONTO")).toContain("bg-purple-100");
+    expect(statusBadge("SENT", "FINAL")).toContain("bg-blue-100");
+    expect(statusBadge("PAID", "CREDIT")).toContain("bg-orange-100");
+  });
+  it("faller till status-färg när typen saknar egen färg", () => {
+    expect(statusBadge("PAID", "STANDARD")).toContain("bg-green-100");
+    expect(statusBadge("SENT", "STANDARD")).toContain("bg-amber-100");
+    expect(statusBadge("INSTALLMENT_PLAN", "STANDARD")).toContain("bg-indigo-100");
+    expect(statusBadge("CANCELLED", "STANDARD")).toContain("bg-gray-200");
+    expect(statusBadge("BAD_DEBT", "STANDARD")).toContain("bg-red-100");
+  });
+  it("okänd typ + okänd status → grå default", () => {
+    expect(statusBadge("DRAFT", "STANDARD")).toContain("bg-gray-100");
+  });
+  it("behåller bas-klasserna", () => {
+    expect(statusBadge("PAID", "ACCONTO")).toContain("rounded-full");
   });
 });


### PR DESCRIPTION
## Vad

Ett **#6-ratchet-steg** på `src/components/matter/invoices-section.tsx`. `statusBadge` låg på **complexity 9** (max 8) bakom en inline `// eslint-disable-next-line complexity` (3 typ-`if`:ar + en 5-grenars status-`switch`).

## Hur

Ersätter if/switch-kedjan med två `Record`-uppslagstabeller (`TYPE_BADGE` / `STATUS_BADGE`): **typ-färg vinner, annars status-färg, annars grå default** — exakt samma semantik, complexity ~3. Inline-disablen bort.

Exporterar `statusBadge` och lägger till ett **uttömmande gren-test**: typ vinner över status (ACCONTO/FINAL/CREDIT), status-fallback för alla färger (PAID/SENT/INSTALLMENT_PLAN/CANCELLED/BAD_DEBT), okänd→grå default, bas-klasser bevaras. Tidigare täcktes bara ACCONTO/FINAL/CREDIT + PAID/SENT via render.

`InvoicesSection`-komponentens **egen** complexity-disable lämnas orörd (separat, större refaktorering — eget ratchet-steg).

## Verifierat lokalt (CI-spegel)

- `bun run typecheck` ✅ · `bun run lint --max-warnings 0` ✅
- `bun run deps:check` ✅ · `bun run duplicates` ✅ (12 kloner) · knip rent
- `bun run test:cov` ✅ — **2834 tester gröna**, coverage (rader 83.86 %, funktioner 80.63 %)

Refs #6 #40 #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)