### PR TITLE
refactor(shell): bryt ut jobsBadgeView ur JobsBadge (#6 ratchet)

### DIFF
--- a/src/components/shell/jobs-badge.tsx
+++ b/src/components/shell/jobs-badge.tsx
@@ -8,33 +8,41 @@
 import Link from "next/link";
 import { useJobsSummary } from "@/lib/client/jobs/use-jobs";
 
-// eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Function 'JobsBadge' has a complexity of 11. Maximum allowed is 8.)
-export function JobsBadge() {
-  const { queued, running, failed } = useJobsSummary();
-  if (queued === 0 && running === 0 && failed === 0) return null;
+interface BadgeView { icon: string; cls: string; label: string }
 
-  let label: string;
-  let cls: string;
-  let icon: string;
-  if (failed > 0 && running === 0 && queued === 0) {
-    icon = "✗"; cls = "bg-red-50 text-red-800 border-red-200";
-    label = `${failed} misslyckat${failed === 1 ? "" : "a"}`;
-  } else if (running > 0 || queued > 0) {
-    icon = "↻"; cls = "bg-blue-50 text-blue-800 border-blue-200";
-    const pending = running + queued;
-    label = `${pending} jobb ${running > 0 ? "körs" : "väntar"}`;
-  } else {
-    return null;
+/**
+ * Härled badge-innehåll ur jobb-summeringen, eller `null` (dölj). Aktiva jobb
+ * (körande/köade) vinner över misslyckade — så "1 körs" visas även med fel i
+ * historiken. Ren + exporterad (testbar; håller komponenten under complexity@8).
+ */
+export function jobsBadgeView(s: { queued: number; running: number; failed: number }): BadgeView | null {
+  const active = s.running + s.queued;
+  if (active > 0) {
+    return {
+      icon: "↻", cls: "bg-blue-50 text-blue-800 border-blue-200",
+      label: `${active} jobb ${s.running > 0 ? "körs" : "väntar"}`,
+    };
   }
+  if (s.failed > 0) {
+    return {
+      icon: "✗", cls: "bg-red-50 text-red-800 border-red-200",
+      label: `${s.failed} misslyckat${s.failed === 1 ? "" : "a"}`,
+    };
+  }
+  return null;
+}
 
+export function JobsBadge() {
+  const view = jobsBadgeView(useJobsSummary());
+  if (!view) return null;
   return (
     <Link
       href="/jobs"
       title="Visa jobbkö"
-      className={`text-xs px-2 py-1 rounded border inline-flex items-center gap-1.5 hover:opacity-80 ${cls}`}
+      className={`text-xs px-2 py-1 rounded border inline-flex items-center gap-1.5 hover:opacity-80 ${view.cls}`}
     >
-      <span aria-hidden>{icon}</span>
-      <span>{label}</span>
+      <span aria-hidden>{view.icon}</span>
+      <span>{view.label}</span>
     </Link>
   );
 }

--- a/test/unit/components/jobs-badge.test.tsx
+++ b/test/unit/components/jobs-badge.test.tsx
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, vi } from "vitest-compat";
 import { render, screen } from "@testing-library/react";
-import { JobsBadge } from "@/components/shell/jobs-badge";
+import { JobsBadge, jobsBadgeView } from "@/components/shell/jobs-badge";
 
 const summary = { total: 0, queued: 0, running: 0, failed: 0, lastError: null as string | null };
 vi.mock("@/lib/client/jobs/use-jobs", () => ({
@@ -60,5 +60,22 @@ describe("JobsBadge", () => {
     setSummary({ running: 1 });
     render(<JobsBadge />);
     expect(screen.getByRole("link")).toHaveAttribute("href", "/jobs");
+  });
+});
+
+describe("jobsBadgeView (#6-ratchet)", () => {
+  it("tom kö → null", () => {
+    expect(jobsBadgeView({ queued: 0, running: 0, failed: 0 })).toBeNull();
+  });
+  it("aktiva jobb → blå ↻ (vinner över failed)", () => {
+    expect(jobsBadgeView({ queued: 0, running: 1, failed: 2 })).toEqual({
+      icon: "↻", cls: "bg-blue-50 text-blue-800 border-blue-200", label: "1 jobb körs",
+    });
+    expect(jobsBadgeView({ queued: 3, running: 0, failed: 0 })!.label).toBe("3 jobb väntar");
+  });
+  it("bara failed → röd ✗ (singular/plural)", () => {
+    const one = jobsBadgeView({ queued: 0, running: 0, failed: 1 });
+    expect(one).toEqual({ icon: "✗", cls: "bg-red-50 text-red-800 border-red-200", label: "1 misslyckat" });
+    expect(jobsBadgeView({ queued: 0, running: 0, failed: 4 })!.label).toBe("4 misslyckata");
   });
 });


### PR DESCRIPTION
## Vad

Ett **#6-ratchet-steg** på `src/components/shell/jobs-badge.tsx`. `JobsBadge` låg på **complexity 11** (max 8) bakom en inline `// eslint-disable-next-line complexity` (nästlade `&&`-villkor + tilldelnings-grenar för icon/cls/label).

## Hur

Bryter ut en ren **`jobsBadgeView(summary) → { icon, cls, label } | null`**: aktiva jobb (körande/köade) vinner över misslyckade (**samma precedens som förr** — "1 körs" visas även med fel i historiken), annars failed, annars dölj. Komponenten faller till **complexity 2**, helpern ~5. Inline-disablen bort.

Exporterar `jobsBadgeView` + lägger till direkta gren-tester (tom→null, aktiv vinner över failed inkl. **icon/cls**, failed singular/plural) — render-testerna täckte bara label-texten, inte icon/cls.

## Beteende oförändrat

Befintliga `JobsBadge`-render-testerna (tom, körs, väntar, failed sing/plural, running+failed-precedens, klick→/jobs) gröna oförändrade.

## Verifierat lokalt (CI-spegel)

- `bun run typecheck` ✅ · `bun run lint --max-warnings 0` ✅
- `bun run deps:check` ✅ · `bun run duplicates` ✅ (12 kloner) · knip rent
- `bun run test:cov` ✅ — **2837 tester gröna**, coverage (rader 83.85 %, funktioner 80.64 %)

Refs #6 #40 #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)