### PR TITLE
refactor(sync): ersätt StateLabel-switch med renderar-uppslag (#6 ratchet)

### DIFF
--- a/src/components/settings/sync-diagnostics.tsx
+++ b/src/components/settings/sync-diagnostics.tsx
@@ -11,7 +11,7 @@
  *   - "Synka nu" → triggar manuell sync
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { RefreshCw } from "lucide-react";
 import { useSyncContext } from "@/lib/client/sync/sync-context";
 import type { SyncState } from "@/lib/client/sync/use-auto-sync";
@@ -108,15 +108,31 @@ export function SyncDiagnostics() {
   );
 }
 
-// eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Function 'StateLabel' has a complexity of 11. Maximum allowed is 8.)
-function StateLabel({ state }: { state: SyncState }) {
-  switch (state.kind) {
-    case "idle":           return <>Vänlar på första synk…</>;
-    case "synced":         return <>✓ Allt sparat — senast {new Date(state.at).toLocaleTimeString("sv-SE")}</>;
-    case "syncing":        return <>↻ {state.what === "pull" ? "Hämtar uppdateringar…" : "Sparar ändringar…"}</>;
-    case "pending":        return <>⏳ {state.count} ändring{state.count === 1 ? "" : "ar"} — sparas inom kort</>;
-    case "offline":        return <>⚠ Off-line — {state.count} ändring{state.count === 1 ? "" : "ar"} sparas lokalt</>;
-    case "merge-needed":   return <>⚠ Konflikt — behöver lösas manuellt</>;
-    case "error":          return <>✗ Synk misslyckades — försöker igen automatiskt</>;
-  }
+type SyncKind = SyncState["kind"];
+type SyncVariant<K extends SyncKind> = Extract<SyncState, { kind: K }>;
+
+/** "ändring"/"ändringar" — svensk pluralisering. */
+function pluralChanges(n: number): string {
+  return `ändring${n === 1 ? "" : "ar"}`;
+}
+
+/**
+ * En renderare per sync-läge. Uppslag i st.f. en 7-grenars switch håller
+ * `StateLabel` under complexity@8 (#6-ratchet) — den mappade typen ger varje
+ * renderare den smalnade varianten (t.ex. `synced` får `.at`, `pending` `.count`).
+ */
+const LABEL_RENDERERS: { [K in SyncKind]: (s: SyncVariant<K>) => ReactNode } = {
+  idle: () => <>Väntar på första synk…</>,
+  synced: (s) => <>✓ Allt sparat — senast {new Date(s.at).toLocaleTimeString("sv-SE")}</>,
+  syncing: (s) => <>↻ {s.what === "pull" ? "Hämtar uppdateringar…" : "Sparar ändringar…"}</>,
+  pending: (s) => <>⏳ {s.count} {pluralChanges(s.count)} — sparas inom kort</>,
+  offline: (s) => <>⚠ Off-line — {s.count} {pluralChanges(s.count)} sparas lokalt</>,
+  "merge-needed": () => <>⚠ Konflikt — behöver lösas manuellt</>,
+  error: () => <>✗ Synk misslyckades — försöker igen automatiskt</>,
+};
+
+export function StateLabel({ state }: { state: SyncState }) {
+  // Uppslaget kan inte korreleras med `state`:s variant av TS → en lokal cast.
+  const render = LABEL_RENDERERS[state.kind] as (s: SyncState) => ReactNode;
+  return <>{render(state)}</>;
 }

--- a/test/unit/components/sync-diagnostics.test.tsx
+++ b/test/unit/components/sync-diagnostics.test.tsx
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, vi } from "vitest-compat";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { SyncDiagnostics } from "@/components/settings/sync-diagnostics";
+import { SyncDiagnostics, StateLabel } from "@/components/settings/sync-diagnostics";
 import type { SyncState } from "@/lib/client/sync/use-auto-sync";
 
 const ctxState = {
@@ -88,4 +88,24 @@ describe("SyncDiagnostics", () => {
     render(<SyncDiagnostics />);
     expect(screen.getByText(/Web FSA/)).toBeInTheDocument();
   });
+});
+
+describe("StateLabel (#6-ratchet: renderar-uppslag per läge)", () => {
+  const cases: Array<[SyncState, RegExp]> = [
+    [{ kind: "idle" }, /Väntar på första synk/],
+    [{ kind: "synced", at: Date.now() }, /Allt sparat/],
+    [{ kind: "syncing", what: "pull" }, /Hämtar uppdateringar/],
+    [{ kind: "syncing", what: "push" }, /Sparar ändringar/],
+    [{ kind: "pending", count: 1 }, /1 ändring —/],
+    [{ kind: "pending", count: 3 }, /3 ändringar —/],
+    [{ kind: "offline", count: 2 }, /Off-line — 2 ändringar/],
+    [{ kind: "merge-needed" }, /Konflikt/],
+    [{ kind: "error", message: "x" }, /misslyckades/],
+  ];
+  for (const [state, re] of cases) {
+    it(`renderar "${state.kind}"`, () => {
+      const { container } = render(<StateLabel state={state} />);
+      expect(container.textContent ?? "").toMatch(re);
+    });
+  }
 });


### PR DESCRIPTION
## Vad

Ett **#6-ratchet-steg** på `src/components/settings/sync-diagnostics.tsx`. `StateLabel` låg på **complexity 11** (max 8) bakom en inline `// eslint-disable-next-line complexity` (7-grenars `switch` på sync-läget + pluralis-/pull-ternarer).

## Hur

Ersätter switchen med ett **typat renderar-uppslag** `LABEL_RENDERERS` — en mappad typ `{ [K in SyncKind]: (s: SyncVariant<K>) => ReactNode }` ger varje renderare den **smalnade** `SyncState`-varianten (t.ex. `synced` får `.at`, `pending` `.count`). Plus en `pluralChanges`-helper. `StateLabel` faller till **complexity 1**. Inline-disablen bort. Fixar även stavfelet **"Vänlar"→"Väntar"** i idle-texten.

Exporterar `StateLabel` + lägger till direkta render-tester för **alla sju lägen** (idle / synced / syncing pull+push / pending sing+plural / offline / merge-needed / error) — tidigare täcktes bara synced + syncing-pull via panel-rendering.

`SyncDiagnostics`-komponentens **egen** complexity-disable lämnas orörd (separat steg).

## Verifierat lokalt (CI-spegel)

- `bun run typecheck` ✅ · `bun run lint --max-warnings 0` ✅
- `bun run deps:check` ✅ · `bun run duplicates` ✅ (12 kloner) · knip rent
- `bun run test:cov` ✅ — **2846 tester gröna**, coverage (rader 83.89 %, funktioner 80.68 %)

Refs #6 #40 #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)