### PR TITLE
refactor(shell): formatState via renderar-uppslag + delad pluralChanges (#6 ratchet)

### DIFF
--- a/src/components/settings/sync-diagnostics.tsx
+++ b/src/components/settings/sync-diagnostics.tsx
@@ -17,6 +17,7 @@ import { useSyncContext } from "@/lib/client/sync/sync-context";
 import type { SyncState } from "@/lib/client/sync/use-auto-sync";
 import { loadFirmaConfig } from "@/lib/client/firma/firma-config";
 import { loadHandle } from "@/lib/client/fsa/handle-store";
+import { pluralChanges } from "@/lib/client/utils";
 
 // eslint-disable-next-line complexity
 export function SyncDiagnostics() {
@@ -110,11 +111,6 @@ export function SyncDiagnostics() {
 
 type SyncKind = SyncState["kind"];
 type SyncVariant<K extends SyncKind> = Extract<SyncState, { kind: K }>;
-
-/** "ändring"/"ändringar" — svensk pluralisering. */
-function pluralChanges(n: number): string {
-  return `ändring${n === 1 ? "" : "ar"}`;
-}
 
 /**
  * En renderare per sync-läge. Uppslag i st.f. en 7-grenars switch håller

--- a/src/components/shell/sync-status-pill.tsx
+++ b/src/components/shell/sync-status-pill.tsx
@@ -15,6 +15,7 @@
 
 import Link from "next/link";
 import type { SyncState } from "@/lib/client/sync/use-auto-sync";
+import { pluralChanges } from "@/lib/client/utils";
 
 interface Props {
   state: SyncState;
@@ -35,53 +36,33 @@ export function SyncStatusPill({ state }: Props) {
   );
 }
 
-// eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Function 'formatState' has a complexity of 12. Maximum allowed is 8.)
-function formatState(s: SyncState): { icon: string; label: string; cls: string; title: string } {
-  switch (s.kind) {
-    case "idle":
-      return { icon: "○", label: "Inte synkat ännu", cls: "bg-gray-50 text-gray-700 border-gray-200", title: "Synk inte påbörjad" };
-    case "synced":
-      return {
-        icon: "✓", label: "Sparat",
-        cls: "bg-green-50 text-green-800 border-green-200",
-        title: `Senast synkat ${formatRelative(s.at)}`,
-      };
-    case "syncing":
-      return {
-        icon: "↻",
-        label: s.what === "pull" ? "Hämtar…" : "Sparar…",
-        cls: "bg-blue-50 text-blue-800 border-blue-200",
-        title: "Synkar med GitHub",
-      };
-    case "pending":
-      return {
-        icon: "⏳",
-        label: `${s.count} ändring${s.count === 1 ? "" : "ar"} — sparas snart`,
-        cls: "bg-amber-50 text-amber-800 border-amber-200",
-        title: "Sparas automatiskt om några sekunder",
-      };
-    case "offline":
-      return {
-        icon: "⚠",
-        label: s.count > 0
-          ? `Off-line — ${s.count} ändring${s.count === 1 ? "" : "ar"} väntar`
-          : "Off-line",
-        cls: "bg-gray-100 text-gray-700 border-gray-300",
-        title: "Sparas till disk lokalt; pushas när du är tillbaka online",
-      };
-    case "merge-needed":
-      return {
-        icon: "⚠", label: "Merge behövs",
-        cls: "bg-orange-50 text-orange-900 border-orange-200",
-        title: "Konflikt — öppna inställningar för att lösa",
-      };
-    case "error":
-      return {
-        icon: "✗", label: "Synk-fel — försöker igen",
-        cls: "bg-red-50 text-red-800 border-red-200",
-        title: s.message,
-      };
-  }
+interface PillView { icon: string; label: string; cls: string; title: string }
+type SyncKind = SyncState["kind"];
+type SyncVariant<K extends SyncKind> = Extract<SyncState, { kind: K }>;
+
+function offlineLabel(count: number): string {
+  return count > 0 ? `Off-line — ${count} ${pluralChanges(count)} väntar` : "Off-line";
+}
+
+/**
+ * En vy per sync-läge. Uppslag i st.f. en 7-grenars switch håller `formatState`
+ * under complexity@8 (#6-ratchet); den mappade typen ger varje vy den smalnade
+ * varianten (t.ex. `synced` får `.at`, `error` `.message`).
+ */
+const PILL_VIEWS: { [K in SyncKind]: (s: SyncVariant<K>) => PillView } = {
+  idle: () => ({ icon: "○", label: "Inte synkat ännu", cls: "bg-gray-50 text-gray-700 border-gray-200", title: "Synk inte påbörjad" }),
+  synced: (s) => ({ icon: "✓", label: "Sparat", cls: "bg-green-50 text-green-800 border-green-200", title: `Senast synkat ${formatRelative(s.at)}` }),
+  syncing: (s) => ({ icon: "↻", label: s.what === "pull" ? "Hämtar…" : "Sparar…", cls: "bg-blue-50 text-blue-800 border-blue-200", title: "Synkar med GitHub" }),
+  pending: (s) => ({ icon: "⏳", label: `${s.count} ${pluralChanges(s.count)} — sparas snart`, cls: "bg-amber-50 text-amber-800 border-amber-200", title: "Sparas automatiskt om några sekunder" }),
+  offline: (s) => ({ icon: "⚠", label: offlineLabel(s.count), cls: "bg-gray-100 text-gray-700 border-gray-300", title: "Sparas till disk lokalt; pushas när du är tillbaka online" }),
+  "merge-needed": () => ({ icon: "⚠", label: "Merge behövs", cls: "bg-orange-50 text-orange-900 border-orange-200", title: "Konflikt — öppna inställningar för att lösa" }),
+  error: (s) => ({ icon: "✗", label: "Synk-fel — försöker igen", cls: "bg-red-50 text-red-800 border-red-200", title: s.message }),
+};
+
+function formatState(s: SyncState): PillView {
+  // Uppslaget kan inte korreleras med `s`:s variant av TS → en lokal cast.
+  const view = PILL_VIEWS[s.kind] as (x: SyncState) => PillView;
+  return view(s);
 }
 
 function formatRelative(at: number): string {

--- a/src/lib/client/utils.ts
+++ b/src/lib/client/utils.ts
@@ -17,3 +17,9 @@ export function formatCurrency(amountInOre: number): string {
     currency: "SEK",
   }).format(amountInOre / 100);
 }
+
+/** Svensk pluralisering av "ändring": 1 → "ändring", annars "ändringar".
+ *  Delas av sync-pillarna (sync-status-pill + sync-diagnostics). */
+export function pluralChanges(n: number): string {
+  return `ändring${n === 1 ? "" : "ar"}`;
+}

--- a/test/unit/client/utils.test.ts
+++ b/test/unit/client/utils.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Tester för klient-utils. Fokus: pluralChanges (delad sv-pluralisering, #6).
+ */
+import { describe, it, expect } from "vitest-compat";
+import { pluralChanges, formatMinutes, formatCurrency } from "@/lib/client/utils";
+
+describe("pluralChanges", () => {
+  it("singular vid exakt 1", () => {
+    expect(pluralChanges(1)).toBe("ändring");
+  });
+  it("plural vid 0 och >1", () => {
+    expect(pluralChanges(0)).toBe("ändringar");
+    expect(pluralChanges(2)).toBe("ändringar");
+    expect(pluralChanges(42)).toBe("ändringar");
+  });
+});
+
+describe("formatMinutes", () => {
+  it("formaterar h:mm med nollpaddning", () => {
+    expect(formatMinutes(90)).toBe("1:30");
+    expect(formatMinutes(5)).toBe("0:05");
+  });
+});
+
+describe("formatCurrency", () => {
+  it("öre → SEK-format", () => {
+    expect(formatCurrency(150000)).toMatch(/1\s?500/);
+  });
+});


### PR DESCRIPTION
## Vad

Ett **#6-ratchet-steg** på `src/components/shell/sync-status-pill.tsx`. `formatState` låg på **complexity 12** (max 8) bakom en inline `// eslint-disable-next-line complexity` (7-grenars `switch` på sync-läget + ternarer).

## Hur

- Ersätter switchen med ett **typat vy-uppslag** `PILL_VIEWS` — mappad typ `{ [K in SyncKind]: (s: SyncVariant<K>) => PillView }` ger varje vy den smalnade `SyncState`-varianten (`synced`→`.at`, `error`→`.message`, …) + en `offlineLabel`-helper. `formatState` faller till **complexity 1**. Inline-disablen bort.
- Bryter ut **`pluralChanges`** (sv-pluralisering av "ändring") till `src/lib/client/utils.ts` och använder den i **båda** sync-pillarna — tar bort den lokala kopia som `StateLabel`-refaktorn (#294) införde i `sync-diagnostics` (**DRY**, ingen ny jscpd-klon). Util:n får ett fokuserat test (+ `formatMinutes`/`formatCurrency`-smoke som saknade direkt test).

Samma struktur/refaktor som #294 (`StateLabel`); här är systervärden i top-baren.

## Verifierat lokalt (CI-spegel)

- `bun run typecheck` ✅ · `bun run lint --max-warnings 0` ✅
- `bun run deps:check` ✅ · `bun run duplicates` ✅ (12 kloner) · knip rent
- `bun run test:cov` ✅ — **2850 tester gröna**, coverage (rader 83.87 %, funktioner 80.72 %)

Refs #6 #40 #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)