### PR TITLE
test(coverage): testa otestad klientlogik + dra coverage-golvet uppåt (#27)

### DIFF
--- a/test/unit/client/fsa/read-from-fsa.test.ts
+++ b/test/unit/client/fsa/read-from-fsa.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tester för `readFromFsa` (#27 — otestad FSA-läshjälp). Bygger ett fejk-
+ * FileSystemDirectoryHandle-träd och verifierar nästlad traversering, single-
+ * level-fil, samt null vid tom path / saknad mapp / saknad fil.
+ */
+import { describe, it, expect } from "vitest-compat";
+import { readFromFsa } from "@/lib/client/fsa/read-from-fsa";
+
+function file(content: string) {
+  return { getFile: async () => new Blob([content], { type: "text/plain" }) };
+}
+
+type Child = { kind: "dir" | "file"; node: unknown };
+function dir(children: Record<string, Child>): FileSystemDirectoryHandle {
+  return {
+    getDirectoryHandle: async (name: string) => {
+      const c = children[name];
+      if (!c || c.kind !== "dir") throw new Error(`no dir ${name}`);
+      return c.node;
+    },
+    getFileHandle: async (name: string) => {
+      const c = children[name];
+      if (!c || c.kind !== "file") throw new Error(`no file ${name}`);
+      return c.node;
+    },
+  } as unknown as FileSystemDirectoryHandle;
+}
+
+const textDir = dir({ "d1.txt": { kind: "file", node: file("hello") } });
+const docsDir = dir({ text: { kind: "dir", node: textDir } });
+const root = dir({
+  documents: { kind: "dir", node: docsDir },
+  "top.txt": { kind: "file", node: file("top") },
+});
+
+describe("readFromFsa", () => {
+  it("läser en nästlad fil → Blob", async () => {
+    const blob = await readFromFsa(root, "/documents/text/d1.txt");
+    expect(blob).not.toBeNull();
+    expect(await blob!.text()).toBe("hello");
+  });
+
+  it("läser en fil på rot-nivå (ingen mapp-traversering)", async () => {
+    const blob = await readFromFsa(root, "top.txt");
+    expect(await blob!.text()).toBe("top");
+  });
+
+  it("tom path → null", async () => {
+    expect(await readFromFsa(root, "/")).toBeNull();
+    expect(await readFromFsa(root, "")).toBeNull();
+  });
+
+  it("saknad mellanliggande mapp → null", async () => {
+    expect(await readFromFsa(root, "documents/saknas/x.txt")).toBeNull();
+  });
+
+  it("saknad fil i existerande mapp → null", async () => {
+    expect(await readFromFsa(root, "documents/text/saknas.txt")).toBeNull();
+  });
+});

--- a/test/unit/client/github/register-ssh-key.test.ts
+++ b/test/unit/client/github/register-ssh-key.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tester för `registerSshKeyOnGithub` (#27 — täckning för otestad
+ * säkerhetsnära klientkod). Mockar global fetch (ingen riktig request →
+ * happy-dom:s same-origin-policy gäller inte). Täcker success + alla
+ * fel-grenar (401/422/övrig) och detail-fallback-kedjan.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest-compat";
+import { registerSshKeyOnGithub } from "@/lib/client/github/register-ssh-key";
+
+const realFetch = globalThis.fetch;
+afterEach(() => { globalThis.fetch = realFetch; vi.clearAllMocks(); });
+
+function mockFetch(status: number, body: unknown): ReturnType<typeof vi.fn> {
+  const fn = vi.fn(async () => new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  }));
+  globalThis.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+const ARGS = { token: "tok-abc", title: "AVA — anna@mac", key: "ssh-ed25519 AAAA…" };
+
+describe("registerSshKeyOnGithub", () => {
+  it("POST:ar till /user/keys med Bearer-auth + JSON-body och returnerar nyckeln", async () => {
+    const created = { id: 7, key: ARGS.key, title: ARGS.title, created_at: "2026-01-01", verified: true };
+    const fn = mockFetch(201, created);
+    const out = await registerSshKeyOnGithub(ARGS);
+    expect(out).toEqual(created);
+    const [url, init] = fn.mock.calls[0]!;
+    expect(url).toBe("https://api.github.com/user/keys");
+    expect(init.method).toBe("POST");
+    expect(init.headers.Authorization).toBe("Bearer tok-abc");
+    expect(init.headers.Accept).toBe("application/vnd.github+json");
+    expect(JSON.parse(init.body)).toEqual({ title: ARGS.title, key: ARGS.key });
+  });
+
+  it("401 → tydligt scope-fel", async () => {
+    mockFetch(401, { message: "Bad credentials" });
+    await expect(registerSshKeyOnGithub(ARGS)).rejects.toThrow(/401[\s\S]*admin:public_key/);
+  });
+
+  it("422 → detail ur errors[0].message", async () => {
+    mockFetch(422, { message: "Validation Failed", errors: [{ message: "key is already in use" }] });
+    await expect(registerSshKeyOnGithub(ARGS)).rejects.toThrow(/422.*key is already in use/);
+  });
+
+  it("annan status → 'GitHub <status>: <detail>' (message-fallback)", async () => {
+    mockFetch(500, { message: "Server Error" });
+    await expect(registerSshKeyOnGithub(ARGS)).rejects.toThrow(/GitHub 500: Server Error/);
+  });
+
+  it("faller till statusText när fel-bodyn inte är JSON", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response("<html>oops</html>", { status: 503, statusText: "Service Unavailable" }),
+    ) as unknown as typeof fetch;
+    await expect(registerSshKeyOnGithub(ARGS)).rejects.toThrow(/GitHub 503: Service Unavailable/);
+  });
+});

--- a/test/unit/client/jobs/extract-text-dispatch.test.ts
+++ b/test/unit/client/jobs/extract-text-dispatch.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Tester för extract-text-dispatchern (#27 — otestad klientlogik).
+ * Täcker: ingen dispatcher → kast, redan-abortad signal → kast, samt
+ * att registrerad dispatcher anropas med args.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest-compat";
+import { setExtractTextDispatcher, dispatchExtractText } from "@/lib/client/jobs/extract-text-dispatch";
+
+afterEach(() => setExtractTextDispatcher(null));
+
+describe("dispatchExtractText", () => {
+  it("kastar när ingen dispatcher registrerats", async () => {
+    setExtractTextDispatcher(null);
+    await expect(dispatchExtractText({ documentId: "d1", text: "x" }))
+      .rejects.toThrow(/Ingen extract-text-dispatcher/);
+  });
+
+  it("kastar 'Aborted' när signalen redan abortats", async () => {
+    setExtractTextDispatcher(vi.fn(async () => {}));
+    const ac = new AbortController();
+    ac.abort();
+    await expect(dispatchExtractText({ documentId: "d1", text: "x", signal: ac.signal }))
+      .rejects.toThrow("Aborted");
+  });
+
+  it("anropar registrerad dispatcher med args", async () => {
+    const fn = vi.fn(async () => {});
+    setExtractTextDispatcher(fn);
+    await dispatchExtractText({ documentId: "d1", text: "hej" });
+    expect(fn).toHaveBeenCalledWith({ documentId: "d1", text: "hej" });
+  });
+});

--- a/tooling/scripts/check-coverage.ts
+++ b/tooling/scripts/check-coverage.ts
@@ -13,12 +13,12 @@ import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 
 // Förankrat strax under nuvarande lcov-mätning under --parallel (rader
-// ~82.8% / funktioner ~79.5%). RATCHET — flytta bara uppåt.
+// ~84.0% / funktioner ~80.9% efter #27-tester). RATCHET — flytta bara uppåt.
 // OBS: --parallel under-rapporterar mot --isolate (bun aggregerar coverage
 // löst över workers), men deterministiskt → giltigt golv. --isolate kraschar
 // på CI-linux (epoll_ctl EEXIST), så --parallel är den körbara vägen (#92).
-const LINE_FLOOR = 0.82;
-const FUNC_FLOOR = 0.79;
+const LINE_FLOOR = 0.83;
+const FUNC_FLOOR = 0.80;
 const LCOV = "coverage/lcov.info";
 
 const TEST_GLOBS = ["test/unit", "test/integration", "test/scripts"];


### PR DESCRIPTION
## Vad

Driver kodtäckningen mot **95 %-målet (#27)** genom att testa tre tidigare **~otestade (1–8 %)** klient-logikmoduler med **riktiga** tester (ingen coverage-teater), och drar sedan **ratchet-golvet** uppåt.

## Tester

- **`github/register-ssh-key`** (6 %→~100 %) — `POST /user/keys`: Bearer-auth + JSON-body + success, samt **alla fel-grenar** (401 scope-fel, 422 med detail ur `errors[0].message`, övrig status) och detail-fallback-kedjan (`errors[0].message` → `message` → `statusText`). Säkerhetsnära kod.
- **`jobs/extract-text-dispatch`** — ingen dispatcher → kast, redan-abortad signal → kast, registrerad dispatcher anropas med args.
- **`fsa/read-from-fsa`** — nästlad mapp-traversering, rot-fil, samt `null` vid tom path / saknad mapp / saknad fil (via fejk-`FileSystemDirectoryHandle`-träd).

Mockar global `fetch` (ingen riktig request) resp. injicerar fejk-handles → inga browser-/nät-beroenden.

## Ratchet

Med den nya täckningen dras golvet i `tooling/scripts/check-coverage.ts` uppåt (RATCHET, bara uppåt):
- rader **0.82 → 0.83**, funktioner **0.79 → 0.80**.
- Aktuellt: **83.98 % / 80.85 %** → marginal ~1 % / ~0.85 % (alla körningar denna session ≥83.65 % / ≥80.47 %, så stabilt).

## Verifierat lokalt (CI-spegel)

- `bun run typecheck` ✅ · `bun run lint --max-warnings 0` ✅ · `bun run deps:check` ✅
- `bun run test:cov` ✅ — **2863 tester gröna**, mot de nya golven (rader 83.98 % ≥ 83.00 %, funktioner 80.85 % ≥ 80.00 %)

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)