### PR TITLE
test(coverage): testa persistGeneratedDoc + useJobs/useJobsSummary (#27)

### DIFF
--- a/test/unit/client/demo/persist-generated-doc.test.ts
+++ b/test/unit/client/demo/persist-generated-doc.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tester för `persistGeneratedDoc` (#27 — otestad). Mockar cache + de
+ * dynamiskt importerade FSA-modulerna. Verifierar: stash anropas, FSA-skrivning
+ * sker bara när en handle finns (annars no-op), CustomEvent med korrekt base64,
+ * och att FSA-fel sväljs (kastar inte).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest-compat";
+
+const stashMock = vi.fn();
+const loadHandleMock = vi.fn();
+const writeFileMock = vi.fn(async () => {});
+
+vi.mock("@/lib/client/demo/generated-doc-cache", () => ({
+  stashGeneratedDoc: (...a: unknown[]) => stashMock(...a),
+}));
+vi.mock("@/lib/client/fsa/handle-store", () => ({
+  loadHandle: (...a: unknown[]) => loadHandleMock(...a),
+}));
+vi.mock("@/lib/client/fsa/fs-adapter", () => ({
+  FsaIsoGitAdapter: class { constructor(_h: unknown) {} writeFile = writeFileMock; },
+}));
+
+import { persistGeneratedDoc } from "@/lib/client/demo/persist-generated-doc";
+
+const BYTES = new Uint8Array([72, 105]); // "Hi" → base64 "SGk="
+const DOC = { id: "d1", storagePath: "documents/d1.pdf", fileName: "d1.pdf", mimeType: "application/pdf", bytes: BYTES };
+
+let events: CustomEvent[] = [];
+const listener = (e: Event) => events.push(e as CustomEvent);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  events = [];
+  window.addEventListener("ava:generated-doc", listener);
+});
+afterEach(() => window.removeEventListener("ava:generated-doc", listener));
+
+describe("persistGeneratedDoc", () => {
+  it("stashar, hoppar FSA utan handle, och dispatchar event med base64", async () => {
+    loadHandleMock.mockResolvedValue(null);
+    await persistGeneratedDoc(DOC);
+    expect(stashMock).toHaveBeenCalledWith("d1", BYTES, "application/pdf", "d1.pdf");
+    expect(writeFileMock).not.toHaveBeenCalled();
+    expect(events).toHaveLength(1);
+    expect(events[0]!.detail).toEqual({ id: "d1", storagePath: "documents/d1.pdf", contentBase64: "SGk=" });
+  });
+
+  it("skriver till FSA-working-copyn när en handle finns", async () => {
+    loadHandleMock.mockResolvedValue({});
+    await persistGeneratedDoc(DOC);
+    expect(writeFileMock).toHaveBeenCalledWith("/documents/d1.pdf", BYTES);
+  });
+
+  it("sväljer FSA-skrivfel (kastar inte, event dispatchas ändå)", async () => {
+    loadHandleMock.mockResolvedValue({});
+    writeFileMock.mockRejectedValueOnce(new Error("disk full"));
+    await expect(persistGeneratedDoc(DOC)).resolves.toBeUndefined();
+    expect(events).toHaveLength(1);
+  });
+});

--- a/test/unit/client/jobs/use-jobs.test.tsx
+++ b/test/unit/client/jobs/use-jobs.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * Tester för `useJobs` / `useJobsSummary` (#27 — otestad). Mockar jobQueue och
+ * verifierar snapshot + summerings-logiken (counts + senaste fel).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { render, screen } from "@testing-library/react";
+import type { Job } from "@/lib/client/jobs/job-queue";
+
+let jobsData: Job[] = [];
+vi.mock("@/lib/client/jobs/job-queue", () => ({
+  jobQueue: {
+    list: () => jobsData,
+    subscribe: (_fn: (j: Job[]) => void) => () => {},
+  },
+}));
+
+import { useJobs, useJobsSummary } from "@/lib/client/jobs/use-jobs";
+
+function job(over: Partial<Job> & Pick<Job, "id" | "status">): Job {
+  return { kind: "classify-document", label: `J ${over.id}`, enqueuedAt: 0, ...over } as Job;
+}
+
+function SummaryProbe() {
+  return <div data-testid="s">{JSON.stringify(useJobsSummary())}</div>;
+}
+function ListProbe() {
+  return <div data-testid="n">{useJobs().length}</div>;
+}
+
+beforeEach(() => { vi.clearAllMocks(); jobsData = []; });
+
+describe("useJobs / useJobsSummary", () => {
+  it("useJobs returnerar jobQueue.list()-snapshoten", () => {
+    jobsData = [job({ id: "a", status: "queued" }), job({ id: "b", status: "running" })];
+    render(<ListProbe />);
+    expect(screen.getByTestId("n").textContent).toBe("2");
+  });
+
+  it("summerar queued/running/failed + senaste fel", () => {
+    jobsData = [
+      job({ id: "q", status: "queued" }),
+      job({ id: "r", status: "running" }),
+      job({ id: "f1", status: "failed", error: "först" }),
+      job({ id: "f2", status: "failed", error: "sist" }),
+      job({ id: "d", status: "done" }),
+    ];
+    render(<SummaryProbe />);
+    const s = JSON.parse(screen.getByTestId("s").textContent ?? "{}");
+    expect(s).toEqual({ total: 5, queued: 1, running: 1, failed: 2, lastError: "först" });
+  });
+
+  it("tom kö → nollor + lastError null", () => {
+    jobsData = [];
+    render(<SummaryProbe />);
+    expect(JSON.parse(screen.getByTestId("s").textContent ?? "{}")).toEqual({
+      total: 0, queued: 0, running: 0, failed: 0, lastError: null,
+    });
+  });
+});


### PR DESCRIPTION
## Vad

Fortsätter **#27** med riktiga tester för två otestade klient-logikmoduler (14 % resp. 24 %):

- **`demo/persist-generated-doc`** — stash anropas, FSA-skrivning sker **bara när en handle finns** (annars no-op), `ava:generated-doc`-CustomEvent med **korrekt base64**, och att **FSA-skrivfel sväljs** (kastar inte). Mockar cache + de dynamiskt importerade FSA-modulerna.
- **`jobs/use-jobs`** — `useJobs` returnerar jobQueue-snapshoten; `useJobsSummary` summerar queued/running/failed + senaste fel (+ tom-kö-fall). Mockar `jobQueue`.

## Verifierat lokalt (CI-spegel)

- `bun run typecheck` ✅ · `bun run lint --max-warnings 0` ✅
- `bun run test:cov` ✅ — **2875 tester gröna**, coverage **rader 84.10→84.22 %**, **funktioner 80.86→81.03 %** (golv 83 %/80 % hålls)

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)