### PR TITLE
test(coverage): testa dokument-dispatcher-registrarerna (#27)

### DIFF
--- a/test/unit/components/analyze-dispatcher-registrar.test.tsx
+++ b/test/unit/components/analyze-dispatcher-registrar.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * Test för `AnalyzeDispatcherRegistrar` (#27). Mockar trpc; verifierar att den
+ * registrerade dispatchern anropar document.updateMetadata + invaliderar
+ * document.tree, och att unmount avregistrerar.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest-compat";
+import { render } from "@testing-library/react";
+
+const mutateAsync = vi.fn(async () => {});
+const treeInvalidate = vi.fn(async () => {});
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: {
+    document: { updateMetadata: { useMutation: () => ({ mutateAsync }) } },
+    useUtils: () => ({ document: { tree: { invalidate: treeInvalidate } } }),
+  },
+}));
+
+import { AnalyzeDispatcherRegistrar } from "@/components/documents/analyze-dispatcher-registrar";
+import { dispatchAnalyze, setAnalyzeDispatcher } from "@/lib/client/jobs/analyze-dispatch";
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => setAnalyzeDispatcher(null));
+
+describe("AnalyzeDispatcherRegistrar", () => {
+  it("registrerar dispatcher → updateMetadata.mutateAsync + tree.invalidate", async () => {
+    const { unmount } = render(<AnalyzeDispatcherRegistrar />);
+    await dispatchAnalyze({ documentId: "d1", kind: "INVOICE", analyzedAt: "2026-01-01T00:00:00Z", analysisStatus: "DONE" });
+    expect(mutateAsync).toHaveBeenCalledWith({
+      documentId: "d1",
+      documentType: "INVOICE",
+      analyzedAt: "2026-01-01T00:00:00Z",
+      analysisStatus: "DONE",
+    });
+    expect(treeInvalidate).toHaveBeenCalled();
+
+    unmount();
+    await expect(dispatchAnalyze({ documentId: "d2", kind: "OTHER" }))
+      .rejects.toThrow(/Ingen analyze-dispatcher/);
+  });
+});

--- a/test/unit/components/extract-text-dispatcher-registrar.test.tsx
+++ b/test/unit/components/extract-text-dispatcher-registrar.test.tsx
@@ -1,0 +1,30 @@
+/**
+ * Test för `ExtractTextDispatcherRegistrar` (#27). Integrationstest mot den
+ * RIKTIGA extract-text-dispatchern (ingen mock): mount registrerar en dispatcher
+ * som dispatchar `ava:document-text-extracted`; unmount avregistrerar.
+ */
+import { describe, it, expect, afterEach } from "vitest-compat";
+import { render } from "@testing-library/react";
+import { ExtractTextDispatcherRegistrar } from "@/components/documents/extract-text-dispatcher-registrar";
+import { dispatchExtractText, setExtractTextDispatcher } from "@/lib/client/jobs/extract-text-dispatch";
+
+afterEach(() => setExtractTextDispatcher(null));
+
+describe("ExtractTextDispatcherRegistrar", () => {
+  it("mount registrerar dispatcher → dispatchExtractText dispatchar event; unmount avregistrerar", async () => {
+    const events: CustomEvent[] = [];
+    const listener = (e: Event) => events.push(e as CustomEvent);
+    window.addEventListener("ava:document-text-extracted", listener);
+
+    const { unmount } = render(<ExtractTextDispatcherRegistrar />);
+    await dispatchExtractText({ documentId: "d1", text: "hej världen" });
+    expect(events).toHaveLength(1);
+    expect(events[0]!.detail).toEqual({ documentId: "d1", text: "hej världen" });
+
+    unmount();
+    await expect(dispatchExtractText({ documentId: "d2", text: "x" }))
+      .rejects.toThrow(/Ingen extract-text-dispatcher/);
+
+    window.removeEventListener("ava:document-text-extracted", listener);
+  });
+});


### PR DESCRIPTION
## Vad

Fortsätter **#27** med tester för två otestade (18–20 %) registrar-komponenter som kopplar job-workern till sid-effekter:

- **`ExtractTextDispatcherRegistrar`** — integrationstest mot den **riktiga** extract-text-dispatchern (ingen mock): mount registrerar en dispatcher som dispatchar `ava:document-text-extracted`; unmount avregistrerar (→ efterföljande dispatch kastar).
- **`AnalyzeDispatcherRegistrar`** — mockar trpc; den registrerade dispatchern anropar `document.updateMetadata.mutateAsync` med rätt args + `document.tree.invalidate`; unmount avregistrerar.

## Verifierat lokalt (CI-spegel)

- `bun run typecheck` ✅ · `bun run lint --max-warnings 0` ✅
- `bun run test:cov` ✅ — **2877 tester gröna**, coverage **rader 84.22→84.33 %**, **funktioner 81.03→81.12 %** (golv 83 %/80 % hålls)

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)