### PR TITLE
test(coverage): testa MirrorOutlookRegistrar (#27)

### DIFF
--- a/test/unit/components/mirror-outlook-registrar.test.tsx
+++ b/test/unit/components/mirror-outlook-registrar.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Test för `MirrorOutlookRegistrar` (#27). Mockar trpc + integrations-registry.
+ * Verifierar token-providerns tre källor (manuell localStorage → o365-connector
+ * → null) inkl. icke-ansluten + kast, samt mirror-state-dispatchern och cleanup.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest-compat";
+import { render } from "@testing-library/react";
+
+const mutateAsync = vi.fn(async () => {});
+const getConnectorMock = vi.fn();
+
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: { calendar: { setMirrorState: { useMutation: () => ({ mutateAsync }) } } },
+}));
+vi.mock("@/lib/client/integrations/registry", () => ({
+  getConnector: (...a: unknown[]) => getConnectorMock(...a),
+}));
+
+import { MirrorOutlookRegistrar } from "@/components/matter/mirror-outlook-registrar";
+import {
+  getOutlookToken, dispatchMirrorState,
+  setOutlookTokenProvider, setMirrorStateDispatcher,
+} from "@/lib/client/jobs/mirror-outlook-dispatch";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getConnectorMock.mockReturnValue(null);
+  localStorage.removeItem("ava.outlookToken");
+});
+afterEach(() => { setOutlookTokenProvider(null); setMirrorStateDispatcher(null); });
+
+describe("MirrorOutlookRegistrar — token-provider", () => {
+  it("manuell token i localStorage vinner", async () => {
+    localStorage.setItem("ava.outlookToken", "manual-tok");
+    render(<MirrorOutlookRegistrar />);
+    expect(await getOutlookToken()).toBe("manual-tok");
+  });
+
+  it("ingen connector → null", async () => {
+    getConnectorMock.mockReturnValue(null);
+    render(<MirrorOutlookRegistrar />);
+    expect(await getOutlookToken()).toBeNull();
+  });
+
+  it("ansluten connector → access-token", async () => {
+    getConnectorMock.mockReturnValue({
+      getStatus: async () => ({ kind: "connected" }),
+      getAccessToken: async () => "graph-tok",
+    });
+    render(<MirrorOutlookRegistrar />);
+    expect(await getOutlookToken()).toBe("graph-tok");
+  });
+
+  it("icke-ansluten connector → null", async () => {
+    getConnectorMock.mockReturnValue({
+      getStatus: async () => ({ kind: "disconnected" }),
+      getAccessToken: async () => "x",
+    });
+    render(<MirrorOutlookRegistrar />);
+    expect(await getOutlookToken()).toBeNull();
+  });
+
+  it("connector-kast → null (catch)", async () => {
+    getConnectorMock.mockImplementation(() => { throw new Error("registry boom"); });
+    render(<MirrorOutlookRegistrar />);
+    expect(await getOutlookToken()).toBeNull();
+  });
+});
+
+describe("MirrorOutlookRegistrar — mirror-state-dispatcher", () => {
+  it("mappar patch → setMirrorState.mutateAsync (med ?? null-fallbacks)", async () => {
+    render(<MirrorOutlookRegistrar />);
+    await dispatchMirrorState({ eventId: "e1", patch: { mirrorStatus: "synced", outlookEventId: "ox-1" } });
+    expect(mutateAsync).toHaveBeenCalledWith({
+      id: "e1",
+      outlookEventId: "ox-1",
+      mirrorStatus: "synced",
+      mirrorError: null,
+      mirrorLastSyncedAt: null,
+    });
+  });
+
+  it("unmount avregistrerar både provider och dispatcher", async () => {
+    const { unmount } = render(<MirrorOutlookRegistrar />);
+    unmount();
+    expect(await getOutlookToken()).toBeNull();
+    await expect(dispatchMirrorState({ eventId: "e2", patch: { mirrorStatus: "pending" } }))
+      .rejects.toThrow(/Ingen mirror-state-dispatcher/);
+  });
+});


### PR DESCRIPTION
## Vad

Fortsätter **#27** — testar den otestade (10 %) `MirrorOutlookRegistrar`.

Mockar trpc + integrations-registry och täcker:
- **Token-providerns alla källor**: manuell `localStorage`-token vinner → o365-connector om `connected` → `null` vid ej-ansluten / ingen connector / kast (catch).
- **Mirror-state-dispatchern**: mappar `patch` → `calendar.setMirrorState.mutateAsync` med `?? null`-fallbacks.
- **Cleanup**: unmount avregistrerar både provider och dispatcher.

Drivs via de riktiga `getOutlookToken` / `dispatchMirrorState` från mirror-outlook-dispatch.

## Verifierat lokalt (CI-spegel)

- `bun run typecheck` ✅ · `bun run lint --max-warnings 0` ✅
- `bun run test:cov` ✅ — **2884 tester gröna**, coverage **rader 84.33→84.46 %**, **funktioner 81.12→81.18 %** (golv 83 %/80 % hålls)

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)