### PR TITLE
refactor(settings): dekomponera FsaFolderSelector (#6)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -64,11 +64,6 @@
       "count": 1
     }
   },
-  "src/components/settings/fsa-folder-selector.tsx": {
-    "max-lines-per-function": {
-      "count": 1
-    }
-  },
   "src/components/settings/keypair-manager.tsx": {
     "max-lines-per-function": {
       "count": 1

--- a/src/components/settings/fsa-folder-selector.tsx
+++ b/src/components/settings/fsa-folder-selector.tsx
@@ -17,7 +17,70 @@ import type { FsClient } from "isomorphic-git";
 
 const HANDLE_KEY = "repo-root";
 
-// eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Function 'FsaFolderSelector' has a complexity of 11. Maximum allowed is 8.)
+/** Browser-specifikt "stöder inte FSA"-meddelande (ren — testbar). */
+function unsupportedMessage(): string {
+  const ua = typeof navigator !== "undefined" ? navigator.userAgent : "";
+  const reason = ua.includes("Firefox")
+    ? "Firefox stöder inte File System Access API."
+    : ua.includes("Safari") && !ua.includes("Chrome")
+    ? "Safari stöder inte File System Access API."
+    : "Den här webbläsaren stöder inte File System Access API.";
+  return `${reason} Använd Chrome, Edge, Brave eller Opera för skrivstöd.`;
+}
+
+/**
+ * Är handle:n ett *fungerande* git-repo? Vi nöjer oss inte med att
+ * .git/-mappen finns — den kan vara halv-skapad från en avbruten clone.
+ * Kräver att HEAD kan resolvas.
+ */
+async function probeHasGit(handle: FileSystemDirectoryHandle): Promise<boolean> {
+  try {
+    await handle.getDirectoryHandle(".git");
+    const { FsaIsoGitAdapter } = await import("@/lib/client/fsa/fs-adapter");
+    const git = await import("isomorphic-git");
+    await git.resolveRef({ fs: new FsaIsoGitAdapter(handle) as unknown as FsClient, dir: "/", ref: "HEAD" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Läs ev. sparad handle + verifiera rw-access + git-status. */
+async function loadExistingHandle(): Promise<{ handle: FileSystemDirectoryHandle; hasGit: boolean } | null> {
+  const { loadHandle, ensureReadWrite } = await import("@/lib/client/fsa/handle-store");
+  const h = await loadHandle(HANDLE_KEY);
+  if (!h) return null;
+  const ok = await ensureReadWrite(h).catch(() => false);
+  if (!ok) return null;
+  return { handle: h, hasGit: await probeHasGit(h) };
+}
+
+/** Öppna mapp-väljaren i readwrite-läge. Returnerar null vid avbrutet
+ *  (ingen err) eller nekat skrivtillstånd (sätter err). */
+async function pickWritableDir(setErr: (e: string | null) => void): Promise<FileSystemDirectoryHandle | null> {
+  const { ensureReadWrite } = await import("@/lib/client/fsa/handle-store");
+  const win = window as Window & {
+    showDirectoryPicker?: (o: { mode: string }) => Promise<FileSystemDirectoryHandle>;
+  };
+  const picked = await win.showDirectoryPicker?.({ mode: "readwrite" });
+  if (!picked) return null;
+  if (!(await ensureReadWrite(picked))) {
+    setErr("Skrivtillstånd nekat");
+    return null;
+  }
+  return picked;
+}
+
+/** Mål-handle för en clone: nuvarande (om useCurrent) annars en ny vald mapp. */
+async function resolveCloneTarget(
+  useCurrent: boolean,
+  current: FileSystemDirectoryHandle | null,
+  setErr: (e: string | null) => void,
+): Promise<FileSystemDirectoryHandle | null> {
+  if (useCurrent && current) return current;
+  return pickWritableDir(setErr);
+}
+
 export function FsaFolderSelector({ repoUrl, token }: { repoUrl: string; token: string }) {
   const [supported, setSupported] = useState<boolean | null>(null);
   const [unsupportedReason, setUnsupportedReason] = useState<string | null>(null);
@@ -28,48 +91,18 @@ export function FsaFolderSelector({ repoUrl, token }: { repoUrl: string; token: 
 
   useEffect(() => {
     let cancelled = false;
-    // eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Async arrow function has a complexity of 14. Maximum allowed is 8.)
     void (async () => {
-      const { isFsaSupported, loadHandle, ensureReadWrite } = await import("@/lib/client/fsa/handle-store");
+      const { isFsaSupported } = await import("@/lib/client/fsa/handle-store");
       if (!isFsaSupported()) {
-        const ua = typeof navigator !== "undefined" ? navigator.userAgent : "";
-        const reason = ua.includes("Firefox")
-          ? "Firefox stöder inte File System Access API."
-          : ua.includes("Safari") && !ua.includes("Chrome")
-          ? "Safari stöder inte File System Access API."
-          : "Den här webbläsaren stöder inte File System Access API.";
-        if (!cancelled) {
-          setSupported(false);
-          setUnsupportedReason(`${reason} Använd Chrome, Edge, Brave eller Opera för skrivstöd.`);
-        }
+        if (!cancelled) { setSupported(false); setUnsupportedReason(unsupportedMessage()); }
         return;
       }
       if (cancelled) return;
       setSupported(true);
-      const h = await loadHandle(HANDLE_KEY);
-      if (!h) return;
-      const ok = await ensureReadWrite(h).catch(() => false);
-      if (ok && !cancelled) {
-        setHandle(h);
-        // Kolla om det är ett *fungerande* git-repo. Vi nöjer oss inte
-        // med att .git/-mappen finns — den kan vara halv-skapad från
-        // en tidigare clone som avbröts. Kräver att HEAD kan resolvas.
-        try {
-          await h.getDirectoryHandle(".git");
-          const { FsaIsoGitAdapter } = await import("@/lib/client/fsa/fs-adapter");
-          const git = await import("isomorphic-git");
-          const fsAdapter = new FsaIsoGitAdapter(h);
-          await git.resolveRef({
-            fs: fsAdapter as unknown as FsClient,
-            dir: "/",
-            ref: "HEAD",
-          });
-          if (!cancelled) setHasGit(true);
-        } catch {
-          // .git saknas, är trasig, eller HEAD är inte resolvbar
-          if (!cancelled) setHasGit(false);
-        }
-      }
+      const existing = await loadExistingHandle();
+      if (cancelled || !existing) return;
+      setHandle(existing.handle);
+      setHasGit(existing.hasGit);
     })();
     return () => { cancelled = true; };
   }, []);
@@ -78,16 +111,9 @@ export function FsaFolderSelector({ repoUrl, token }: { repoUrl: string; token: 
     setBusy(true);
     setErr(null);
     try {
-      const { saveHandle, ensureReadWrite } = await import("@/lib/client/fsa/handle-store");
-      const win = window as Window & {
-        showDirectoryPicker?: (o: { mode: string }) => Promise<FileSystemDirectoryHandle>;
-      };
-      const h = await win.showDirectoryPicker?.({ mode: "readwrite" });
+      const { saveHandle } = await import("@/lib/client/fsa/handle-store");
+      const h = await pickWritableDir(setErr);
       if (!h) return;
-      if (!(await ensureReadWrite(h))) {
-        setErr("Skrivtillstånd nekat");
-        return;
-      }
       await saveHandle(HANDLE_KEY, h);
       setHandle(h);
     } catch (e) {
@@ -98,34 +124,19 @@ export function FsaFolderSelector({ repoUrl, token }: { repoUrl: string; token: 
   };
 
   /**
-   * Klona repo. Om `useCurrent` → klona till nuvarande handle (för
-   * "Klona hit nu" när användaren redan valt en tom mapp). Annars
-   * be om en ny mapp.
+   * Klona repo. `useCurrent` → klona till nuvarande handle (för "Klona
+   * hit nu" när användaren redan valt en tom mapp). Annars be om en ny mapp.
    */
-  // eslint-disable-next-line complexity -- TODO: refactor (currently fails complexity@8: Async arrow function has a complexity of 11. Maximum allowed is 8.)
   const cloneNew = async (useCurrent = false) => {
     if (!repoUrl) { setErr("Repo-URL saknas — fyll i datakälla först"); return; }
     setBusy(true);
     setErr(null);
     try {
-      const { saveHandle, ensureReadWrite } = await import("@/lib/client/fsa/handle-store");
+      const { saveHandle } = await import("@/lib/client/fsa/handle-store");
       const { FsaIsoGitAdapter } = await import("@/lib/client/fsa/fs-adapter");
       const { cloneRepo } = await import("@/lib/client/fsa/git-ops");
-      let h: FileSystemDirectoryHandle;
-      if (useCurrent && handle) {
-        h = handle;
-      } else {
-        const win = window as Window & {
-          showDirectoryPicker?: (o: { mode: string }) => Promise<FileSystemDirectoryHandle>;
-        };
-        const picked = await win.showDirectoryPicker?.({ mode: "readwrite" });
-        if (!picked) return;
-        if (!(await ensureReadWrite(picked))) {
-          setErr("Skrivtillstånd nekat");
-          return;
-        }
-        h = picked;
-      }
+      const h = await resolveCloneTarget(useCurrent, handle, setErr);
+      if (!h) return;
       const fs = new FsaIsoGitAdapter(h);
       await cloneRepo(fs, { url: githubize(repoUrl), ...(token ? { token } : {}) });
       await saveHandle(HANDLE_KEY, h);
@@ -161,63 +172,94 @@ export function FsaFolderSelector({ repoUrl, token }: { repoUrl: string; token: 
         <strong className="text-gray-800">Lokal mapp</strong>
       </div>
       {handle ? (
-        <>
-          <div className="flex items-center justify-between gap-3">
-            <span className="text-gray-700">
-              Vald: <span className="font-mono text-gray-900">{handle.name}</span>
-            </span>
-            <button
-              type="button"
-              onClick={() => void forgetFolder()}
-              className="text-gray-500 hover:underline"
-            >
-              Byt mapp
-            </button>
-          </div>
-          {hasGit === false && (
-            <div className="mt-2 bg-amber-50 border border-amber-200 rounded p-2">
-              <p className="text-amber-900 mb-2">
-                <strong>⚠ Mappen är inte ett git-repo.</strong> Klona ett
-                repo hit för att kunna synka. Annars fungerar inte
-                pull/push.
-              </p>
-              <button
-                type="button"
-                onClick={() => void cloneNew(true)}
-                disabled={busy || !repoUrl}
-                className="px-2 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-300"
-              >
-                {busy ? "Klonar…" : "Klona hit nu"}
-              </button>
-              {!repoUrl && (
-                <p className="text-amber-800 mt-2">
-                  Fyll i Repo-URL ovan först.
-                </p>
-              )}
-            </div>
-          )}
-        </>
+        <SelectedFolder
+          folderName={handle.name}
+          hasGit={hasGit}
+          busy={busy}
+          repoUrl={repoUrl}
+          onForget={() => void forgetFolder()}
+          onCloneHere={() => void cloneNew(true)}
+        />
       ) : (
-        <div className="flex gap-2 items-center">
+        <FolderPicker
+          busy={busy}
+          repoUrl={repoUrl}
+          onPick={() => void pickExisting()}
+          onClone={() => void cloneNew()}
+        />
+      )}
+      {err && <p className="mt-2 text-red-700">✗ {err}</p>}
+    </div>
+  );
+}
+
+interface SelectedFolderProps {
+  folderName: string;
+  hasGit: boolean | null;
+  busy: boolean;
+  repoUrl: string;
+  onForget: () => void;
+  onCloneHere: () => void;
+}
+
+/** Vald-mapp-vyn: namn + "Byt mapp", samt varning/clone om mappen saknar git. */
+function SelectedFolder({ folderName, hasGit, busy, repoUrl, onForget, onCloneHere }: SelectedFolderProps) {
+  return (
+    <>
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-gray-700">
+          Vald: <span className="font-mono text-gray-900">{folderName}</span>
+        </span>
+        <button type="button" onClick={onForget} className="text-gray-500 hover:underline">
+          Byt mapp
+        </button>
+      </div>
+      {hasGit === false && (
+        <div className="mt-2 bg-amber-50 border border-amber-200 rounded p-2">
+          <p className="text-amber-900 mb-2">
+            <strong>⚠ Mappen är inte ett git-repo.</strong> Klona ett
+            repo hit för att kunna synka. Annars fungerar inte
+            pull/push.
+          </p>
           <button
             type="button"
-            onClick={() => void pickExisting()}
-            disabled={busy}
-            className="px-2 py-1 bg-white border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50"
-          >
-            Välj befintlig mapp
-          </button>
-          <button
-            type="button"
-            onClick={() => void cloneNew()}
+            onClick={onCloneHere}
             disabled={busy || !repoUrl}
             className="px-2 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-300"
           >
-            {busy ? "Arbetar…" : "Klona repo hit"}
+            {busy ? "Klonar…" : "Klona hit nu"}
           </button>
+          {!repoUrl && (
+            <p className="text-amber-800 mt-2">
+              Fyll i Repo-URL ovan först.
+            </p>
+          )}
         </div>
       )}
-      {err && <p className="mt-2 text-red-700">✗ {err}</p>}
+    </>
+  );
+}
+
+/** Ej-vald-vyn: välj befintlig mapp eller klona repo hit. */
+function FolderPicker({ busy, repoUrl, onPick, onClone }: { busy: boolean; repoUrl: string; onPick: () => void; onClone: () => void }) {
+  return (
+    <div className="flex gap-2 items-center">
+      <button
+        type="button"
+        onClick={onPick}
+        disabled={busy}
+        className="px-2 py-1 bg-white border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50"
+      >
+        Välj befintlig mapp
+      </button>
+      <button
+        type="button"
+        onClick={onClone}
+        disabled={busy || !repoUrl}
+        className="px-2 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-300"
+      >
+        {busy ? "Arbetar…" : "Klona repo hit"}
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Vad

Dekomponerar `src/components/settings/fsa-folder-selector.tsx` — hade **tre** inline `complexity`-disablar (komponent 11, mount-effekt 14, `cloneNew` 11) + en `max-lines-per-function`-suppression. Rena helpers + två vy-komponenter, alla under complexity@8:

- **`unsupportedMessage()`** — browser-specifikt FSA-meddelande (ren).
- **`probeHasGit(handle)`** — `.git` + HEAD-resolve-koll.
- **`loadExistingHandle()`** — läs sparad handle + rw-access + git-status.
- **`pickWritableDir(setErr)`** — mapp-väljare i rw-läge (null vid avbrutet/nekat).
- **`resolveCloneTarget(...)`** — clone-mål-handle.
- **`SelectedFolder`** / **`FolderPicker`** — vald-mapp- resp. ej-vald-vyn.

Mount-effekten **14 → ~6**, `cloneNew` **11 → ~5**, komponenten **11 → ~5**. Alla 3 inline-disablar + suppressionen borta. `githubize` orörd.

## Beteende oförändrat

Ren extraktion (identisk DOM) → befintliga testet **grönt 7/7** (`githubize`-cases + Firefox/Safari/övrig-meddelanden + Välj-/Klona-knappar; handle-store mockas dynamiskt som förr).

## Verifierat lokalt (CI-spegel)

- `bun run typecheck` ✅ · `bun run lint --max-warnings 0` ✅ (3 disablar + suppression borta)
- `bun run deps:check` ✅ · `bun run duplicates` ✅ (12 kloner) · knip rent
- `bun run test:cov` ✅ — **0 fail**, coverage rader 84.70 % / funktioner 81.28 %

Refs #6 #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)