### PR TITLE
refactor(settings): bryt ut PreloadResult ur ExternalEditSection (#6)

### DIFF
--- a/src/components/settings/external-edit-section.tsx
+++ b/src/components/settings/external-edit-section.tsx
@@ -20,7 +20,19 @@ interface PreloadState {
   error?: string;
 }
 
-// eslint-disable-next-line complexity
+/** Resultat-/fel-rad efter en preload-körning (visas när phase === "done"). */
+export function PreloadResult({ preload }: { preload: PreloadState }) {
+  if (preload.phase !== "done") return null;
+  if (preload.error) return <p className="mt-2 text-xs text-red-600">✗ {preload.error}</p>;
+  if (!preload.result) return null;
+  return (
+    <p className="mt-2 text-xs text-gray-600">
+      ✓ Klart — {preload.result.downloaded} nedladdade, {preload.result.skipped} fanns redan
+      {preload.result.failed > 0 && `, ${preload.result.failed} misslyckades`}.
+    </p>
+  );
+}
+
 export function ExternalEditSection() {
   const supported = isFsaSupported();
   const [folderName, setFolderName] = useState<string | null>(null);
@@ -95,15 +107,7 @@ export function ExternalEditSection() {
         {preload.phase === "running" ? `Förladdar ${preload.done}/${preload.total}…` : "Förladda alla dokument lokalt"}
       </button>
 
-      {preload.phase === "done" && preload.result && (
-        <p className="mt-2 text-xs text-gray-600">
-          ✓ Klart — {preload.result.downloaded} nedladdade, {preload.result.skipped} fanns redan
-          {preload.result.failed > 0 && `, ${preload.result.failed} misslyckades`}.
-        </p>
-      )}
-      {preload.phase === "done" && preload.error && (
-        <p className="mt-2 text-xs text-red-600">✗ {preload.error}</p>
-      )}
+      <PreloadResult preload={preload} />
     </div>
   );
 }

--- a/test/unit/components/external-edit-section.test.tsx
+++ b/test/unit/components/external-edit-section.test.tsx
@@ -1,0 +1,32 @@
+/**
+ * Test för `PreloadResult` (#6 — utbruten ur ExternalEditSection). Täcker
+ * idle→inget, done+resultat (med/utan failed), och done+fel.
+ */
+import { describe, it, expect } from "vitest-compat";
+import { render, screen } from "@testing-library/react";
+import { PreloadResult } from "@/components/settings/external-edit-section";
+
+describe("PreloadResult", () => {
+  it("renderar inget innan körning är klar", () => {
+    const { container } = render(<PreloadResult preload={{ phase: "idle", done: 0, total: 0 }} />);
+    expect(container).toBeEmptyDOMElement();
+    const r = render(<PreloadResult preload={{ phase: "running", done: 1, total: 3 }} />);
+    expect(r.container).toBeEmptyDOMElement();
+  });
+
+  it("done + resultat → summering utan failed-del när failed=0", () => {
+    render(<PreloadResult preload={{ phase: "done", done: 3, total: 3, result: { downloaded: 2, skipped: 1, failed: 0 } }} />);
+    expect(screen.getByText(/2 nedladdade, 1 fanns redan/)).toBeInTheDocument();
+    expect(screen.queryByText(/misslyckades/)).not.toBeInTheDocument();
+  });
+
+  it("done + resultat med fail>0 → inkluderar misslyckades-del", () => {
+    render(<PreloadResult preload={{ phase: "done", done: 5, total: 5, result: { downloaded: 3, skipped: 1, failed: 1 } }} />);
+    expect(screen.getByText(/1 misslyckades/)).toBeInTheDocument();
+  });
+
+  it("done + fel → felmeddelande", () => {
+    render(<PreloadResult preload={{ phase: "done", done: 0, total: 0, error: "nätverk nere" }} />);
+    expect(screen.getByText(/✗ nätverk nere/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Vad

`ExternalEditSection` låg på **complexity 9** (>8) bakom en inline `complexity`-disable. Bryter ut resultat-/fel-raden till en ren, exporterad **`PreloadResult`** (done→summering med/utan `failed`, done→fel, annars `null`). Komponenten faller till **complexity ~4** → disablen bort.

Lägger till ett fokuserat **`PreloadResult`-test** (sidan saknade test helt): idle/running→inget, done+resultat (med/utan failed), done+fel.

## Verifierat lokalt (CI-spegel)

- `bun run typecheck` ✅ · `bun run lint --max-warnings 0` ✅
- `bun run deps:check` ✅ · `bun run duplicates` ✅ (12 kloner) · knip rent
- `bun run test:cov` ✅ — **0 fail**, coverage rader 84.73 % / funktioner 81.30 %

Refs #6 #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)