### PR TITLE
docs(adr): avgränsa ADR 0013 till Outlook-add-in (Word borttagen) (#72 #84)

### DIFF
--- a/docs/adr/0013-office-add-in-arkitektur.md
+++ b/docs/adr/0013-office-add-in-arkitektur.md
@@ -156,3 +156,8 @@ peer-loop-låsinjektion; **1c** HTTP-listener i server-runtime-processen
   enklaste cross-platform-modellen (add-in = dum HTTP-klient, inga
   webview-storage/CORS-antaganden); web-app/demo förblir lokal-först (USP intakt).
   Inget hade byggts på de tidigare varianterna.
+- **2026-06-14 (scope-avgränsning):** **Word-add-in (#84) borttagen** — AVA
+  behöver bara **Outlook** (#72). Plattformen (server-tRPC-over-HTTP + delad
+  klient) är oförändrad men konsumeras nu av en enda host. Outlook-add-in:en har
+  två funktioner: (1) spara inkommande mail → ärende + tidspost (kräver add-in);
+  (2) maila ut ett ärende-dokument (web-app-funktion, ej add-in — triggas i AVA).


### PR DESCRIPTION
Dokumenterar byrå-beslutet (2026-06-14): AVA behöver bara **Outlook**-add-in:en.

- **#84 (Word) borttagen** ur scope — stängd som won't-do.
- Plattformen (#83, server-tRPC-over-HTTP + delad Bearer-PAT-klient) oförändrad, konsumeras nu av en enda host.
- **#72 (Outlook)** omformulerad till två funktioner:
  1. spara inkommande mail → ärende + tidspost (**kräver add-in**),
  2. maila ut ett ärende-dokument (**web-app-funktion**, triggas i AVA — ej add-in).

Docs-only. Refs #72 #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)