### PR TITLE
test(sync): härda ava:data-changed-testet mot attach-race (#27)

### DIFF
--- a/test/unit/client/sync/sync-context.test.tsx
+++ b/test/unit/client/sync/sync-context.test.tsx
@@ -60,8 +60,14 @@ describe("SyncProviderRoot", () => {
   it("ava:data-changed → notifyChange (när write + provider)", async () => {
     render(<SyncProviderRoot token="t" pickProvider={pickFsa()}><Probe /></SyncProviderRoot>);
     await waitFor(() => expect(read().enabled).toBe(true));
-    act(() => { window.dispatchEvent(new Event("ava:data-changed")); });
-    expect(autoSync.notifyChange).toHaveBeenCalled();
+    // Re-dispatcha inuti waitFor: lyssnaren kopplas i en effekt EFTER att
+    // `enabled` blivit true → ett enstaka dispatch kan racea attach:en under
+    // --parallel-last. Engångs-event:et "förbrukas" om lyssnaren inte hunnit,
+    // så vi måste dispatcha om tills notifyChange faktiskt anropats.
+    await waitFor(() => {
+      act(() => { window.dispatchEvent(new Event("ava:data-changed")); });
+      expect(autoSync.notifyChange).toHaveBeenCalled();
+    });
   });
 
   it("persisterar lastError från error-state", async () => {


### PR DESCRIPTION
`SyncProviderRoot`-testet **"ava:data-changed → notifyChange"** (infört i #301) flakade på CI under `--parallel`: event-lyssnaren kopplas i en effekt **efter** att `enabled` blivit true, så ett enstaka `dispatchEvent` kan racea attach:en — och engångs-event:et "förbrukas" om lyssnaren inte hunnit. Dispatchar nu **om inuti `waitFor`** tills `notifyChange` faktiskt anropats → deterministiskt.

Ren test-fix, ingen produktionskod. `bun run typecheck`/`lint`/det isolerade testet ✅.

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)