### PR TITLE
feat(mail): server-mutation sparar inkommande .eml → ärende + tidspost (#72 slice 1)

### DIFF
--- a/src/lib/server/adapters/noop-ports.ts
+++ b/src/lib/server/adapters/noop-ports.ts
@@ -8,6 +8,7 @@ import type {
   IDocumentAnalyzer,
   ISearchIndex,
   IPaymentScanner,
+  IContentStore,
   IPorts,
 } from "../ports";
 
@@ -31,9 +32,20 @@ export const noopPaymentScanner: IPaymentScanner = {
   async scan() { /* no-op */ },
 };
 
+/**
+ * No-op content-store: i demo/web skrivs dokument-bytes klient-sidigt via
+ * FSA (`uploadDocumentToFsa`), aldrig server-sidigt — så detta är en tyst
+ * no-op (konsistent med demo:ns read-only-semantik). Server-runtime:n
+ * (git-peer) ersätter denna med en skrivande impl (`NodeContentStore`).
+ */
+export const noopContentStore: IContentStore = {
+  async write() { /* no-op */ },
+};
+
 export const noopPorts: IPorts = {
   email: noopEmail,
   documentAnalyzer: noopDocumentAnalyzer,
   searchIndex: noopSearchIndex,
   paymentScanner: noopPaymentScanner,
+  content: noopContentStore,
 };

--- a/src/lib/server/local-first/node-content-store.ts
+++ b/src/lib/server/local-first/node-content-store.ts
@@ -1,0 +1,31 @@
+/**
+ * `NodeContentStore` — `IContentStore`-impl för server-runtime:n (git-peer).
+ *
+ * Skriver dokument-binärinnehåll in i git-working-copy:n på disk (samma
+ * katalog som entitets-projektionerna), så `commit()` efter mutationen tar
+ * med bytes:en och push:ar dem. Detta är server-spegeln av klientens
+ * FSA-write (`uploadDocumentToFsa`): native-klienter (Office-add-in, #72)
+ * kan inte nå filsystemet, så de POST:ar bytes:en över tRPC och servern
+ * persisterar dem här.
+ *
+ * Path-traversal: vi delegerar till {@link NodeFileSystem}, vars `resolveSafe`
+ * avvisar paths utanför roten. `storagePath` kommer (delvis) från klient-data
+ * → skyddet är icke-förhandlingsbart.
+ */
+
+import type { IContentStore } from "../ports";
+import { NodeFileSystem } from "./node-fs";
+
+export class NodeContentStore implements IContentStore {
+  private readonly fs: NodeFileSystem;
+
+  constructor(dir: string) {
+    this.fs = new NodeFileSystem(dir);
+  }
+
+  write(storagePath: string, bytes: Uint8Array): Promise<void> {
+    // Strippa ev. ledande "/" (isomorphic-git-konventionen använder
+    // "/"-prefixade repo-relativa paths; NodeFileSystem är root-sandboxad).
+    return this.fs.writeFileBytes(storagePath.replace(/^\/+/, ""), bytes);
+  }
+}

--- a/src/lib/server/local-first/node-fs.ts
+++ b/src/lib/server/local-first/node-fs.ts
@@ -36,6 +36,18 @@ export class NodeFileSystem implements IFileSystem {
     await writeFile(abs, content, "utf8");
   }
 
+  /**
+   * Skriv rå-bytes (icke-text-innehåll: PDF/DOCX/.eml …). Samband med
+   * {@link writeFile} men utan utf8-antagandet. `resolveSafe` ger samma
+   * path-traversal-skydd, vilket är avgörande när `path` härleds ur
+   * användar-/klient-data (t.ex. ett dokument-id från en add-in).
+   */
+  async writeFileBytes(path: string, content: Uint8Array): Promise<void> {
+    const abs = this.resolveSafe(path);
+    await mkdir(dirname(abs), { recursive: true });
+    await writeFile(abs, content);
+  }
+
   async appendFile(path: string, content: string): Promise<void> {
     const abs = this.resolveSafe(path);
     await mkdir(dirname(abs), { recursive: true });

--- a/src/lib/server/local-first/server-working-copy.ts
+++ b/src/lib/server/local-first/server-working-copy.ts
@@ -30,6 +30,7 @@ import { makeWriteBack, type WriteBackFs } from "@/lib/client/firma/fsa-write-ba
 import { DEMO_META_PATH } from "../../../../tooling/demo-config";
 import type { IFileSystem } from "./file-system";
 import { NodeFileSystem } from "./node-fs";
+import { NodeContentStore } from "./node-content-store";
 import { NodeGitOps } from "./node-git-ops";
 import type { GitCommit } from "./git-ops";
 import { ProjectionHydrator } from "./projection-writer";
@@ -150,7 +151,11 @@ export async function openServerWorkingCopy(
   const source = entitiesToDemoSource(entities);
   const writeBack = makeWriteBack(new NodeWriteBackFs(dir));
   const dataStore = new DemoDataStore(source, writeBack);
-  const ctx = buildContext({ dataStore, ports: buildGitPorts(dataStore), principal: opts.principal });
+  // Git-peer:n äger filsystemet → dokument-bytes (t.ex. .eml från Outlook-
+  // add-in:en, #72) persisteras in i working-copy:n via NodeContentStore.
+  // Övriga ports = git-defaults (no-op content ersätts).
+  const ports = { ...buildGitPorts(dataStore), content: new NodeContentStore(dir) };
+  const ctx = buildContext({ dataStore, ports, principal: opts.principal });
   const author = opts.author ?? { name: opts.principal.name, email: opts.principal.email };
   const gitOps = new NodeGitOps(dir, author.name, author.email, opts.remote ?? "origin", opts.branch ?? "main");
   return {

--- a/src/lib/server/ports.ts
+++ b/src/lib/server/ports.ts
@@ -86,6 +86,26 @@ export interface IPaymentScanner {
   scan(organizationId: string): Promise<void>;
 }
 
+// ─── ContentStore ──────────────────────────────────────────────────
+
+/**
+ * Skriv dokument-binärinnehåll (PDF/DOCX/.eml …) till lagringen. Skild
+ * från entitets-projektionerna (JSON): `document.register` skriver bara
+ * metadata, bytes:en skrivs separat. I web-/FSA-flödet sker det
+ * klient-sidigt (`uploadDocumentToFsa`) INNAN register; för native-klienter
+ * (Office-add-in, #72/ADR 0013) som inte når serverns filsystem skickas
+ * bytes:en över tRPC och servern persisterar dem hit i sin git-working-copy.
+ */
+export interface IContentStore {
+  /**
+   * Skriv `bytes` till `storagePath` (repo-relativ, t.ex.
+   * `documents/content/<id>.eml`). Server-runtime:n skriver in i
+   * git-working-copy:n så de commit:as + push:as; demo/web är no-op
+   * (innehåll skrivs klient-sidigt via FSA).
+   */
+  write(storagePath: string, bytes: Uint8Array): Promise<void>;
+}
+
 // ─── Aggregat ──────────────────────────────────────────────────────
 
 /**
@@ -98,6 +118,7 @@ export interface IPorts {
   documentAnalyzer: IDocumentAnalyzer;
   searchIndex: ISearchIndex;
   paymentScanner: IPaymentScanner;
+  content: IContentStore;
 }
 
 // Buffer-typen exporteras så impl:erna kan importera utan Node:

--- a/src/lib/server/routers/_app.ts
+++ b/src/lib/server/routers/_app.ts
@@ -19,6 +19,7 @@ import { calendarRouter } from "./calendar";
 import { taskRouter } from "./task";
 import { todoRouter } from "./todo";
 import { preferenceRouter } from "./preference";
+import { mailRouter } from "./mail";
 
 export const appRouter = router({
   contacts: contactRouter,
@@ -41,6 +42,7 @@ export const appRouter = router({
   task: taskRouter,
   todo: todoRouter,
   prefs: preferenceRouter,
+  mail: mailRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/src/lib/server/routers/mail.ts
+++ b/src/lib/server/routers/mail.ts
@@ -1,0 +1,136 @@
+/**
+ * `mailRouter` — spara inkommande mail till ett ärende (#72, ADR 0013).
+ *
+ * Anropas av Outlook-add-in:en (tunn tRPC-HTTP-klient): användaren har ett
+ * mail öppet, väljer rätt ärende i panelen, och add-in:en hämtar mailets
+ * rå `.eml` (RFC822-MIME) via MS Graph (`/messages/{id}/$value`) och POST:ar
+ * det hit. Servern äger git-db:n → den skriver bytes:en i sin working-copy
+ * (`ctx.ports.content`), registrerar dokumentet och — valfritt — bokför en
+ * tidspost i samma operation. Allt commit:as + push:as av session-finalize:n.
+ *
+ * `.eml` valdes som lagringsformat (full mejl-fidelitet, ett dokument); se
+ * ADR 0013 "Ändringshistorik" (2026-06-14).
+ */
+
+import { z } from "zod";
+import { router, orgProcedure } from "../trpc";
+import { emit } from "../events/emit";
+import type { IDataStore } from "../data-store/IDataStore";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { asId } from "@/lib/shared/schemas/ids";
+
+/** Den delmängd av tRPC-context tidspost-helpern + emit behöver. */
+interface MailCtx {
+  dataStore: IDataStore;
+  user: { id: string };
+}
+
+/** Avkoda base64 → bytes (browser+Node-säkert; routern bundlas för bägge). */
+function base64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
+
+/** Härled ett säkert `.eml`-filnamn ur mejlets ämne. */
+function emlFileName(subject: string): string {
+  const base = subject.trim().replace(/[\\/:*?"<>|]+/g, "_").slice(0, 120) || "mail";
+  return `${base}.eml`;
+}
+
+const timeInput = z.object({
+  minutes: z.number().int().min(1),
+  description: z.string().min(1).optional(),
+});
+
+export const mailRouter = router({
+  /**
+   * Spara ett inkommande mail (rått `.eml`) i `matterId`:s dokumentlista,
+   * plus en valfri tidspost. Returnerar det skapade dokumentet + ev. tidspost.
+   */
+  saveIncoming: orgProcedure
+    .input(
+      z.object({
+        matterId: z.string(),
+        /** Rå RFC822-MIME, base64-kodad för transport. */
+        emlBase64: z.string().min(1),
+        subject: z.string(),
+        receivedAt: z.string(), // ISO
+        folderId: z.string().nullable().optional(),
+        time: timeInput.optional(),
+        /** Klient-genererat id (annars uuidv7). Begränsat till filnamns-säkra
+         *  tecken — path:en byggs av det (defense-in-depth mot traversal). */
+        documentId: z.string().regex(/^[A-Za-z0-9_-]+$/).optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      // 1. Verifiera att ärendet tillhör anroparens org.
+      await ctx.dataStore.matters.findFirstOrThrow({
+        where: { id: input.matterId, organizationId: ctx.orgId },
+      });
+
+      // 2. Skriv .eml-bytes till git-working-copy:n (server-runtime).
+      const id = input.documentId ?? uuidv7();
+      const storagePath = `documents/content/${id}.eml`;
+      const bytes = base64ToBytes(input.emlBase64);
+      await ctx.ports.content.write(storagePath, bytes);
+
+      // 3. Registrera dokument-metadata (projektion).
+      const fileName = emlFileName(input.subject);
+      const doc = await ctx.dataStore.documents.create({
+        data: {
+          id,
+          matterId: input.matterId,
+          fileName,
+          mimeType: "message/rfc822",
+          sizeBytes: bytes.byteLength,
+          fileSize: bytes.byteLength, // denormaliserat (UI läser fileSize)
+          storagePath,
+          folderId: input.folderId ?? null,
+          organizationId: ctx.orgId,
+          analysisStatus: "PENDING",
+          uploadedById: ctx.user.id,
+          title: input.subject,
+          documentType: "E-post",
+          createdAt: new Date(input.receivedAt),
+        } as never,
+      });
+      await emit.documentUploaded(ctx, { id, fileName, matterId: input.matterId });
+
+      // 4. Valfri tidspost kopplad till mailet.
+      const timeEntry = input.time
+        ? await createMailTimeEntry(ctx, input.matterId, input.receivedAt, input.subject, input.time)
+        : null;
+
+      return { document: doc, timeEntry };
+    }),
+});
+
+/** Bokför tidsposten som hör ihop med ett sparat mail (#72 funktion 1). */
+async function createMailTimeEntry(
+  ctx: MailCtx,
+  matterId: string,
+  receivedAt: string,
+  subject: string,
+  time: z.infer<typeof timeInput>,
+) {
+  const userId = asId<"UserId">(ctx.user.id);
+  const user = await ctx.dataStore.users.findUniqueOrThrow({
+    where: { id: userId },
+    select: { hourlyRate: true },
+  });
+  const entry = await ctx.dataStore.timeEntries.create({
+    data: {
+      userId,
+      matterId,
+      date: new Date(receivedAt),
+      minutes: time.minutes,
+      description: time.description ?? subject,
+      hourlyRate: user.hourlyRate ?? 0,
+      billable: true,
+    } as never,
+  });
+  await emit.timeEntryAdded(ctx, { id: entry.id, matterId: entry.matterId, minutes: entry.minutes });
+  return entry;
+}

--- a/test/unit/server/local-first/node-content-store.test.ts
+++ b/test/unit/server/local-first/node-content-store.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tester för `NodeContentStore` (#72 slice 1) — skriver dokument-bytes in i
+ * git-working-copy:n så de kan commit:as/push:as. Använder os.tmpdir() för
+ * isolering per suite.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest-compat";
+import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { NodeContentStore } from "@/lib/server/local-first/node-content-store";
+import { noopContentStore } from "@/lib/server/adapters/noop-ports";
+
+describe("noopContentStore", () => {
+  it("är en tyst no-op (demo/web skriver bytes klient-sidigt via FSA)", async () => {
+    await expect(noopContentStore.write("documents/content/x.eml", new Uint8Array([1])))
+      .resolves.toBeUndefined();
+  });
+});
+
+describe("NodeContentStore", () => {
+  let root: string;
+  let store: NodeContentStore;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "ava-content-"));
+    store = new NodeContentStore(root);
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("skriver bytes till storagePath under working-copy:n", async () => {
+    const bytes = new Uint8Array([0x46, 0x72, 0xc3, 0xa5, 0x6e]); // "Från" i utf8 m. icke-ascii
+    await store.write("documents/content/abc.eml", bytes);
+    const real = await readFile(join(root, "documents/content/abc.eml"));
+    expect(new Uint8Array(real)).toEqual(bytes);
+  });
+
+  it("strippar ledande '/' (isomorphic-git-konvention) → skriver i roten", async () => {
+    await store.write("/documents/content/slash.eml", new Uint8Array([1, 2]));
+    const real = await readFile(join(root, "documents/content/slash.eml"));
+    expect(new Uint8Array(real)).toEqual(new Uint8Array([1, 2]));
+  });
+
+  it("avvisar path-traversal (säkerhet — path kan komma från klient)", async () => {
+    await expect(store.write("../../escape.eml", new Uint8Array([1])))
+      .rejects.toThrow(/path.*outside|escape/i);
+  });
+});

--- a/test/unit/server/local-first/node-fs.test.ts
+++ b/test/unit/server/local-first/node-fs.test.ts
@@ -97,4 +97,22 @@ describe("NodeFileSystem", () => {
     const real = await readFile(join(root, "on-disk.txt"), "utf8");
     expect(real).toBe("syns");
   });
+
+  it("writeFileBytes skriver rå-bytes (binärt, ingen utf8-tolkning)", async () => {
+    // Bytes som INTE är giltig utf8 (0xff 0xfe ...) → måste bevaras exakt.
+    const bytes = new Uint8Array([0x00, 0xff, 0xfe, 0x42, 0x0a]);
+    await fs.writeFileBytes("documents/content/x.eml", bytes);
+    const real = await readFile(join(root, "documents/content/x.eml"));
+    expect(new Uint8Array(real)).toEqual(bytes);
+  });
+
+  it("writeFileBytes skapar nested mappar automatiskt", async () => {
+    await fs.writeFileBytes("a/b/c.bin", new Uint8Array([1, 2, 3]));
+    expect(await fs.exists("a/b/c.bin")).toBe(true);
+  });
+
+  it("writeFileBytes avvisar path-traversal", async () => {
+    await expect(fs.writeFileBytes("../escape.eml", new Uint8Array([1])))
+      .rejects.toThrow(/path.*outside|escape/i);
+  });
 });

--- a/test/unit/server/routers/mail.test.ts
+++ b/test/unit/server/routers/mail.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Test för `mail.saveIncoming` (#72 slice 1, ADR 0013) — spara inkommande
+ * mail (.eml) till ett ärende + valfri tidspost. Mockar dataStore + ports.content.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { dataStoreFromMockPrisma, type MockDataStore } from "../helpers/mock-data-store";
+import { mailRouter } from "@/lib/server/routers/mail";
+
+const mockPrisma = {
+  matter: { findFirstOrThrow: vi.fn() },
+  document: { create: vi.fn() },
+  user: { findUniqueOrThrow: vi.fn() },
+  timeEntry: { create: vi.fn() },
+};
+
+let dataStore: MockDataStore;
+const contentWrite = vi.fn();
+
+const mockPorts = {
+  email: { send: vi.fn() },
+  paymentScanner: { scan: vi.fn() },
+  documentAnalyzer: { analyze: vi.fn() },
+  searchIndex: { search: vi.fn(), upsert: vi.fn(), remove: vi.fn() },
+  content: { write: contentWrite },
+};
+
+function makeCaller(orgId = "org-a", userId = "u1") {
+  dataStore = dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>);
+  const ctx = {
+    user: { id: userId, email: "a@b.se", name: "T", role: "LAWYER", organizationId: orgId },
+    prisma: mockPrisma,
+    dataStore,
+    ports: mockPorts,
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return mailRouter.createCaller(ctx as any);
+}
+
+// Råa MIME-bytes → base64 (det add-in:en skickar). "Subject: Hej\r\n\r\nKropp"
+const RAW_EML = "Subject: Hej\r\n\r\nKropp";
+const EML_B64 = Buffer.from(RAW_EML, "utf8").toString("base64");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.matter.findFirstOrThrow.mockResolvedValue({ id: "m1", organizationId: "org-a" });
+  mockPrisma.document.create.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => data);
+  mockPrisma.user.findUniqueOrThrow.mockResolvedValue({ hourlyRate: 1800 });
+  mockPrisma.timeEntry.create.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({ id: "te-1", ...data }));
+});
+
+describe("mail.saveIncoming", () => {
+  const base = { matterId: "m1", emlBase64: EML_B64, subject: "Hej", receivedAt: "2026-06-14T08:00:00Z" };
+
+  it("verifierar att ärendet tillhör org:n", async () => {
+    await makeCaller("org-a").saveIncoming({ ...base, documentId: "doc-1" });
+    expect(mockPrisma.matter.findFirstOrThrow).toHaveBeenCalledWith({
+      where: { id: "m1", organizationId: "org-a" },
+    });
+  });
+
+  it("skriver .eml-bytes till documents/content/<id>.eml via content-port", async () => {
+    await makeCaller().saveIncoming({ ...base, documentId: "doc-1" });
+    expect(contentWrite).toHaveBeenCalledTimes(1);
+    const [path, bytes] = contentWrite.mock.calls[0]!;
+    expect(path).toBe("documents/content/doc-1.eml");
+    // Bytes:en måste avkoda tillbaka till exakt rå-MIME:n.
+    expect(Buffer.from(bytes as Uint8Array).toString("utf8")).toBe(RAW_EML);
+  });
+
+  it("registrerar dokumentet med .eml-metadata", async () => {
+    await makeCaller("org-a").saveIncoming({ ...base, documentId: "doc-1" });
+    expect(mockPrisma.document.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        id: "doc-1",
+        matterId: "m1",
+        mimeType: "message/rfc822",
+        documentType: "E-post",
+        title: "Hej",
+        fileName: "Hej.eml",
+        storagePath: "documents/content/doc-1.eml",
+        organizationId: "org-a",
+        sizeBytes: Buffer.byteLength(RAW_EML, "utf8"),
+        uploadedById: "u1",
+      }),
+    });
+  });
+
+  it("emit:ar document.uploaded", async () => {
+    await makeCaller().saveIncoming({ ...base, documentId: "doc-1" });
+    expect(dataStore.events.emit).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "document.uploaded", matterId: "m1" }),
+    );
+  });
+
+  it("utan time → ingen tidspost skapas, timeEntry=null", async () => {
+    const res = await makeCaller().saveIncoming({ ...base, documentId: "doc-1" });
+    expect(mockPrisma.timeEntry.create).not.toHaveBeenCalled();
+    expect(res.timeEntry).toBeNull();
+  });
+
+  it("med time → skapar tidspost (datum=mottaget, beskrivning faller tillbaka på ämne)", async () => {
+    await makeCaller("org-a", "u9").saveIncoming({
+      ...base, documentId: "doc-1", time: { minutes: 15 },
+    });
+    expect(mockPrisma.timeEntry.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        userId: "u9",
+        matterId: "m1",
+        minutes: 15,
+        description: "Hej", // fallback till ämnet
+        hourlyRate: 1800,
+        billable: true,
+      }),
+    });
+    const args = mockPrisma.timeEntry.create.mock.calls[0]![0] as { data: { date: Date } };
+    expect(args.data.date).toBeInstanceOf(Date);
+  });
+
+  it("med time + egen beskrivning → använder den + emit:ar time-entry.added", async () => {
+    await makeCaller().saveIncoming({
+      ...base, documentId: "doc-1", time: { minutes: 30, description: "Genomläsning" },
+    });
+    expect(mockPrisma.timeEntry.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ description: "Genomläsning", minutes: 30 }),
+    });
+    expect(dataStore.events.emit).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "time-entry.added", matterId: "m1" }),
+    );
+  });
+
+  it("genererar uuidv7-id när documentId saknas", async () => {
+    await makeCaller().saveIncoming(base);
+    const [path] = contentWrite.mock.calls[0]!;
+    expect(path).toMatch(/^documents\/content\/[0-9a-f-]{36}\.eml$/);
+  });
+
+  it("saniterar osäkra tecken i ämnet → filnamn", async () => {
+    await makeCaller().saveIncoming({ ...base, subject: "Re: a/b\\c:d?", documentId: "doc-1" });
+    const data = mockPrisma.document.create.mock.calls[0]![0]!.data as { fileName: string };
+    expect(data.fileName).toBe("Re_ a_b_c_d_.eml");
+  });
+
+  it("propagerar fel om ärendet inte tillhör org:n", async () => {
+    mockPrisma.matter.findFirstOrThrow.mockRejectedValue(new Error("not found"));
+    await expect(makeCaller().saveIncoming({ ...base, documentId: "doc-1" })).rejects.toThrow();
+    expect(contentWrite).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Första (CI-verifierbara) slicen av Outlook-add-in:ens **funktion 1** (#72, ADR 0013): server-sidan som tar emot ett inkommande mail och lägger det i ett ärende.

## Vad
Add-in:en (tunn tRPC-HTTP-klient) hämtar mailets råa `.eml` via MS Graph och POST:ar det hit. Servern äger git-db:n (ADR 0013) → den skriver bytes:en i sin working-copy, registrerar dokumentet och bokför en valfri tidspost — allt commit:as/push:as av session-finalize:n.

## Ändringar
- **Ny `IContentStore`-port** (`write(storagePath, bytes)`) — fyllde en lucka: `document.register` skriver bara metadata, och `WriteBackFs` var utf8-text-only. Server-runtime:n wirar **`NodeContentStore`** (skriver in i git-working-copy:n via sandboxad `NodeFileSystem.writeFileBytes`); demo/web är **no-op** (innehåll skrivs klient-sidigt via FSA — oförändrat).
- **`mail.saveIncoming`-mutation**: verifiera org-ägarskap → skriv `.eml` → registrera dokument (`message/rfc822`, `documentType: E-post`, titel = ämne) → emit `document.uploaded` → valfri länkad tidspost (datum = mottaget, beskrivning faller tillbaka på ämnet) + `time-entry.added`.
- **Path-traversal-skydd** på write (storagePath härleds delvis ur klient-data).

## Test
- `mail.test.ts` (10 fall): org-verifiering, byte-write till rätt path + exakt round-trip, .eml-metadata, emits, med/utan tidspost, uuidv7-fallback, ämnes-sanitering, fel-propagering.
- `node-content-store.test.ts` + `node-fs.test.ts`: binär write, '/'-strip, traversal-avvisning, no-op-store.
- Lokalt grönt: typecheck, knip, lint, dep-cruiser, **2911 tester**, coverage-golv (rader 84.76%/funk 81.39%).

## Kvar i #72 (ej i denna PR)
- Slice 2: rena Graph-helpers (`$value`-URL, `sendMail`-payload, `convertToRestId`) — CI-verifierbar.
- Slice 3: Office.js task-pane-bundle + Graph-SSO + manifest + web-app maila-knapp — sideload-testas.

Refs #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)