### PR TITLE
feat(install): verifiera tjänste-kommunikation i install-server (#323)

### DIFF
--- a/test/scripts/install-server-services.test.ts
+++ b/test/scripts/install-server-services.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Test för install-server tjänste-kommunikationskontroller (#323):
+ * checkOidcIssuer / checkWeb / checkGitHttp / checkServices / summarize.
+ * fetch injiceras → inga riktiga tjänster.
+ */
+
+import { describe, it, expect, vi } from "vitest-compat";
+import type { ServerInstallConfig } from "../../tooling/scripts/install-server/core";
+import {
+  checkOidcIssuer,
+  checkWeb,
+  checkGitHttp,
+  checkServices,
+  summarizeServiceChecks,
+} from "../../tooling/scripts/install-server/service-checks";
+
+const htpasswdCfg: ServerInstallConfig = {
+  repoUrl: "https://git.ex/firma.git", workDir: "/wc", organizationId: "org-1",
+  secretsFile: "/v.enc", authMode: "htpasswd",
+};
+const oidcCfg: ServerInstallConfig = {
+  ...htpasswdCfg, authMode: "oidc",
+  oidc: { issuerUrl: "https://idp.ex/realms/byra", clientId: "ava", clientSecret: "s", redirectUrl: "https://app/oauth2/callback" },
+};
+
+describe("checkOidcIssuer", () => {
+  it("200 + authorization_endpoint → ok, träffar discovery-URL:en", async () => {
+    const f = vi.fn(async () => new Response(JSON.stringify({ authorization_endpoint: "https://idp.ex/auth" }), { status: 200 }));
+    const r = await checkOidcIssuer("https://idp.ex/realms/byra/", f);
+    expect(r.ok).toBe(true);
+    expect(f).toHaveBeenCalledWith("https://idp.ex/realms/byra/.well-known/openid-configuration");
+  });
+
+  it("200 men utan authorization_endpoint → fail", async () => {
+    const f = vi.fn(async () => new Response(JSON.stringify({ issuer: "x" }), { status: 200 }));
+    expect((await checkOidcIssuer("https://idp.ex", f)).ok).toBe(false);
+  });
+
+  it("404 → fail med statuskod i detalj", async () => {
+    const f = vi.fn(async () => new Response("nope", { status: 404 }));
+    const r = await checkOidcIssuer("https://idp.ex", f);
+    expect(r.ok).toBe(false);
+    expect(r.detail).toContain("404");
+  });
+
+  it("nätfel (throw) → fail, inte kasta", async () => {
+    const f = vi.fn(async () => { throw new Error("ECONNREFUSED"); });
+    const r = await checkOidcIssuer("https://idp.ex", f);
+    expect(r.ok).toBe(false);
+    expect(r.detail).toContain("ECONNREFUSED");
+  });
+});
+
+describe("checkWeb", () => {
+  it("200 + 'AVA' i body → ok", async () => {
+    const f = vi.fn(async () => new Response("<html><title>AVA</title></html>", { status: 200 }));
+    expect((await checkWeb("http://localhost:8080", f)).ok).toBe(true);
+  });
+
+  it("200 men saknar AVA-markör → fail (stale out/)", async () => {
+    const f = vi.fn(async () => new Response("<h1>nginx</h1>", { status: 200 }));
+    const r = await checkWeb("http://localhost:8080", f);
+    expect(r.ok).toBe(false);
+    expect(r.detail).toMatch(/markör|stale/i);
+  });
+
+  it("anropar /ava/", async () => {
+    const f = vi.fn(async () => new Response("AVA", { status: 200 }));
+    await checkWeb("http://localhost:8080/", f);
+    expect(f).toHaveBeenCalledWith("http://localhost:8080/ava/");
+  });
+});
+
+describe("checkGitHttp", () => {
+  it("200 → ok", async () => {
+    const f = vi.fn(async () => new Response("", { status: 200 }));
+    expect((await checkGitHttp("http://localhost:8080", "firma.git", f)).ok).toBe(true);
+  });
+
+  it("401 → ok (auth krävs men nåbar)", async () => {
+    const f = vi.fn(async () => new Response("", { status: 401 }));
+    const r = await checkGitHttp("http://localhost:8080", "firma.git", f);
+    expect(r.ok).toBe(true);
+    expect(r.detail).toMatch(/auth krävs/);
+  });
+
+  it("500 → fail", async () => {
+    const f = vi.fn(async () => new Response("", { status: 500 }));
+    expect((await checkGitHttp("http://localhost:8080", "firma.git", f)).ok).toBe(false);
+  });
+
+  it("bygger info/refs-URL:en med upload-pack-service", async () => {
+    const f = vi.fn(async () => new Response("", { status: 200 }));
+    await checkGitHttp("http://localhost:8080/", "/firma.git", f);
+    expect(f).toHaveBeenCalledWith("http://localhost:8080/git/firma.git/info/refs?service=git-upload-pack");
+  });
+});
+
+describe("checkServices", () => {
+  const okFetch = vi.fn(async (url: string) => {
+    if (url.includes("openid-configuration")) return new Response(JSON.stringify({ authorization_endpoint: "x" }), { status: 200 });
+    if (url.includes("/git/")) return new Response("", { status: 401 });
+    return new Response("AVA", { status: 200 });
+  });
+
+  it("htpasswd: bara web + git (ingen OIDC-koll)", async () => {
+    const checks = await checkServices(htpasswdCfg, { baseUrl: "http://localhost:8080", fetchFn: okFetch });
+    expect(checks.map((c) => c.name).sort()).toEqual(["git smart-HTTP", "web"]);
+  });
+
+  it("oidc: web + git + OIDC issuer", async () => {
+    const checks = await checkServices(oidcCfg, { baseUrl: "http://localhost:8080", fetchFn: okFetch });
+    expect(checks.map((c) => c.name).sort()).toEqual(["OIDC issuer", "git smart-HTTP", "web"]);
+    expect(checks.every((c) => c.ok)).toBe(true);
+  });
+});
+
+describe("summarizeServiceChecks", () => {
+  it("ok=true bara när alla ok; rader prefixas med ✓/✗", () => {
+    const s = summarizeServiceChecks([
+      { name: "web", ok: true, detail: "200" },
+      { name: "git smart-HTTP", ok: false, detail: "500" },
+    ]);
+    expect(s.ok).toBe(false);
+    expect(s.lines[0]).toMatch(/^✓ web/);
+    expect(s.lines[1]).toMatch(/^✗ git/);
+  });
+});

--- a/tooling/scripts/install-server.ts
+++ b/tooling/scripts/install-server.ts
@@ -37,6 +37,7 @@ import {
   extractAdminToken,
 } from "./install-server/orchestrate";
 import { interpretPreflight, runPreflight } from "./install-server/preflight";
+import { checkServices, summarizeServiceChecks } from "./install-server/service-checks";
 import {
   answersToConfig,
   renderConfigTemplate,
@@ -130,6 +131,25 @@ function log(msg: string): void {
   console.log(`[install-server] ${msg}`);
 }
 
+/** Verifiera att den körande installationen NÅR tjänsterna (#323): web, git
+ *  smart-HTTP och — vid OIDC — IdP:ns discovery-endpoint. Ren rapport + bool. */
+async function runServiceChecks(argv: string[]): Promise<boolean> {
+  const cfg = answersToConfig(await gatherAnswers(argv), "");
+  const baseUrl = flag(argv, "base-url") ?? `http://localhost:${WEB_PORT}`;
+  const repoPath = flag(argv, "repo-path");
+  const checks = await checkServices(cfg, { baseUrl, ...(repoPath ? { repoPath } : {}) });
+  const { ok, lines } = summarizeServiceChecks(checks);
+  for (const l of lines) log(l);
+  log(ok ? "alla tjänster svarar." : "en eller flera tjänster svarar INTE — se ovan.");
+  return ok;
+}
+
+/** Kör tjänste-kontroller mot den lokala stacken + logga raderna (post-start). */
+async function reportServiceChecks(cfg: ServerInstallConfig): Promise<void> {
+  const { lines } = summarizeServiceChecks(await checkServices(cfg, { baseUrl: `http://localhost:${WEB_PORT}` }));
+  for (const l of lines) log(l);
+}
+
 async function exists(path: string): Promise<boolean> {
   const { access } = await import("node:fs/promises");
   return access(path).then(() => true).catch(() => false);
@@ -218,6 +238,9 @@ async function runInstall(argv: string[], paths: InstallPaths): Promise<boolean>
     process.env.AVA_SECRETS_FILE = paths.secretsFile;
     const oidc = cfg.authMode === "oidc";
     await startStack(oidc, await buildOidcStartEnv(cfg, vault));
+    // Verifiera att tjänsterna faktiskt svarar (#323) — rapport, ej hård-fail
+    // (vissa kan behöva några sekunder till; kör `--check-services` igen vid behov).
+    await reportServiceChecks(cfg);
     if (oidc) {
       log("backenden uppe (OIDC). Seeda första admin + org i firma.git:");
       log(`  bun run bootstrap:admin --work-dir <klon-av-firma.git> --email <din-epost> --org ${cfg.organizationId} --org-name "<Byrå>" --commit`);
@@ -237,6 +260,13 @@ async function main(): Promise<void> {
   // Skriv ut en config-mall att fylla i (--config-vägen). Inga sidoeffekter.
   if (hasFlag(argv, "print-config-template")) {
     process.stdout.write(renderConfigTemplate());
+    return;
+  }
+
+  // Tjänste-kommunikationskoll (#323): verifiera att en (redan körande)
+  // installation når web/git/IdP. Ingen install — bara nåbarhets-rapport.
+  if (hasFlag(argv, "check-services")) {
+    process.exitCode = (await runServiceChecks(argv)) ? 0 : 1;
     return;
   }
 

--- a/tooling/scripts/install-server/service-checks.ts
+++ b/tooling/scripts/install-server/service-checks.ts
@@ -1,0 +1,103 @@
+/**
+ * Tjänste-kommunikationskontroller för install-server (#323, uppföljning #232/#258).
+ *
+ * Medan `preflight.ts` kollar LOKALA förutsättningar FÖRE start (docker finns,
+ * web-porten ledig), verifierar detta att den körande installationen faktiskt
+ * NÅR och får rätt svar från de olika tjänsterna: IdP:n (OIDC-discovery),
+ * web-containern och git smart-HTTP. `fetch` injiceras → rent testbart utan
+ * riktiga tjänster.
+ */
+
+import type { ServerInstallConfig } from "./core";
+
+export interface ServiceCheck {
+  name: string;
+  ok: boolean;
+  detail: string;
+}
+
+type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
+
+function errText(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+const trimSlash = (s: string): string => s.replace(/\/+$/, "");
+
+/**
+ * IdP-koll: hämta OIDC-discovery-dokumentet och kräv ett
+ * `authorization_endpoint`. Detta är "kommunicerar vi med IdP:n?"-testet.
+ */
+export async function checkOidcIssuer(issuerUrl: string, fetchFn: FetchLike): Promise<ServiceCheck> {
+  const url = `${trimSlash(issuerUrl)}/.well-known/openid-configuration`;
+  const name = "OIDC issuer";
+  try {
+    const res = await fetchFn(url);
+    if (!res.ok) return { name, ok: false, detail: `${url} → HTTP ${res.status}` };
+    const doc = (await res.json()) as { authorization_endpoint?: string };
+    if (!doc.authorization_endpoint) {
+      return { name, ok: false, detail: `discovery saknar authorization_endpoint (${url})` };
+    }
+    return { name, ok: true, detail: `discovery OK (${url})` };
+  } catch (e) {
+    return { name, ok: false, detail: `${url} onåbar: ${errText(e)}` };
+  }
+}
+
+/** Web-koll: `/ava/` svarar 200 och innehåller appens markör. */
+export async function checkWeb(baseUrl: string, fetchFn: FetchLike): Promise<ServiceCheck> {
+  const url = `${trimSlash(baseUrl)}/ava/`;
+  const name = "web";
+  try {
+    const res = await fetchFn(url);
+    const body = await res.text();
+    if (res.ok && body.includes("AVA")) return { name, ok: true, detail: `${url} → 200 (AVA)` };
+    return { name, ok: false, detail: `${url} → HTTP ${res.status}${res.ok ? " men saknar 'AVA'-markör (stale out/?)" : ""}` };
+  } catch (e) {
+    return { name, ok: false, detail: `${url} onåbar: ${errText(e)}` };
+  }
+}
+
+/**
+ * Git smart-HTTP-koll: `info/refs?service=git-upload-pack`. 200 = öppet,
+ * 401 = auth krävs (men nåbar — förväntat bakom htpasswd/oidc). Övrigt = fel.
+ */
+export async function checkGitHttp(baseUrl: string, repoPath: string, fetchFn: FetchLike): Promise<ServiceCheck> {
+  const repo = repoPath.replace(/^\/+/, "");
+  const url = `${trimSlash(baseUrl)}/git/${repo}/info/refs?service=git-upload-pack`;
+  const name = "git smart-HTTP";
+  try {
+    const res = await fetchFn(url);
+    const reachable = res.status === 200 || res.status === 401;
+    return { name, ok: reachable, detail: `${url} → HTTP ${res.status}${res.status === 401 ? " (auth krävs — nåbar)" : ""}` };
+  } catch (e) {
+    return { name, ok: false, detail: `${url} onåbar: ${errText(e)}` };
+  }
+}
+
+export interface ServiceCheckOpts {
+  /** Origin för web + git (t.ex. http://localhost:8080). */
+  baseUrl: string;
+  /** Git-repo-path under /git/ (default firma.git). */
+  repoPath?: string;
+  fetchFn?: FetchLike;
+}
+
+/** Kör alla relevanta tjänste-kontroller för den givna installationen. */
+export async function checkServices(cfg: ServerInstallConfig, opts: ServiceCheckOpts): Promise<ServiceCheck[]> {
+  const fetchFn = opts.fetchFn ?? (globalThis.fetch as FetchLike);
+  const checks: Promise<ServiceCheck>[] = [
+    checkWeb(opts.baseUrl, fetchFn),
+    checkGitHttp(opts.baseUrl, opts.repoPath ?? "firma.git", fetchFn),
+  ];
+  if (cfg.authMode === "oidc" && cfg.oidc) {
+    checks.push(checkOidcIssuer(cfg.oidc.issuerUrl, fetchFn));
+  }
+  return Promise.all(checks);
+}
+
+/** Sammanställ till {ok, rader} för CLI-rapport. */
+export function summarizeServiceChecks(checks: readonly ServiceCheck[]): { ok: boolean; lines: string[] } {
+  const lines = checks.map((c) => `${c.ok ? "✓" : "✗"} ${c.name}: ${c.detail}`);
+  return { ok: checks.every((c) => c.ok), lines };
+}


### PR DESCRIPTION
Löser #323. Visade sig att install-server-flödet **redan fanns** (byggt under #232/#258): config-fil (`--config` + `--print-config-template`), OIDC-config, secrets-valv, env-render och docker-orkestrering. Men preflight kollade bara **lokala** förutsättningar (docker finns, web-port ledig) — #323:s kärna var att **testa att kommunikationen med tjänsterna fungerar**. Det fyllde jag.

## Nytt: `service-checks.ts` (fetch-injicerat → CI-testbart)
- **`checkOidcIssuer`** — hämtar IdP:ns `/.well-known/openid-configuration` och kräver `authorization_endpoint`. Detta är "når vi IdP:n?"-testet.
- **`checkWeb`** — `/ava/` → 200 + `AVA`-markör (fångar stale `out/`).
- **`checkGitHttp`** — `info/refs?service=git-upload-pack` → 200/401 (401 = auth krävs men nåbar).
- **`checkServices`** kör de relevanta (OIDC-kollen bara i oidc-läge) + `summarizeServiceChecks`.

## CLI
- `bun tooling/scripts/install-server.ts --check-services [--config f.json] [--base-url ...]` → verifierar en körande installation, exit-kod.
- Automatisk rapport efter `--start`.

## Test
14 nya unit-tester (200/401/404/throw, AVA-markör, oidc-vs-htpasswd-urval, summarize). typecheck/lint/knip rena; alla 4 install-server-testfiler (38 tester) gröna.

## Avgränsning
Config-fil + IdP + env-render fanns redan (#232). Att lägga **användare/admin-lösenord i configen** (utöver dagens add-user.sh / OIDC-allowlist) är en rimlig uppföljning men kräver kartläggning av allowlist-lagringen — utelämnat här för att inte halv-bygga user-provisioning.

Closes #323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)