### PR TITLE
feat(tooling): bash-bootstrap-installer (hämtar GH-release + kör install-server) (#325)

### DIFF
--- a/test/scripts/install-from-release.test.ts
+++ b/test/scripts/install-from-release.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Test för bootstrap-installern (#325). Kör scriptet i --dry-run (ingen curl/
+ * docker) och verifierar planen + arg-validering. Bash-I/O-stegen körs aldrig.
+ */
+
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { describe, it, expect } from "vitest-compat";
+
+const SCRIPT = join(process.cwd(), "tooling/scripts/install-from-release.sh");
+
+function run(args: string[]): { status: number; out: string } {
+  const r = spawnSync("bash", [SCRIPT, ...args], { encoding: "utf8" });
+  return { status: r.status ?? -1, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+}
+
+describe("install-from-release.sh --dry-run", () => {
+  it("planen innehåller käll-tarball-URL:en för taggen + install-kommandot", () => {
+    const { status, out } = run(["--version", "v1.2.3", "--config", "./install.json", "--dir", "/srv/ava", "--dry-run"]);
+    expect(status).toBe(0);
+    expect(out).toContain("https://github.com/ulrik-s/ava/archive/refs/tags/v1.2.3.tar.gz");
+    expect(out).toContain("bun tooling/scripts/install-server.ts --config ./install.json --start");
+    expect(out).toContain("/srv/ava");
+  });
+
+  it("default install-dir = ava-<tag> när --dir utelämnas", () => {
+    const { out } = run(["--version", "v9.9.9", "--config", "x.json", "--dry-run"]);
+    expect(out).toContain("ava-v9.9.9");
+  });
+
+  it("respekterar --repo-override i URL:en", () => {
+    const { out } = run(["--version", "v1.0.0", "--config", "x.json", "--repo", "acme/ava-fork", "--dry-run"]);
+    expect(out).toContain("https://github.com/acme/ava-fork/archive/refs/tags/v1.0.0.tar.gz");
+  });
+});
+
+describe("install-from-release.sh arg-validering", () => {
+  it("saknat --config → exit 1 + tydligt fel", () => {
+    const { status, out } = run(["--version", "v1.2.3", "--dry-run"]);
+    expect(status).toBe(1);
+    expect(out).toMatch(/--config.*krävs/);
+  });
+
+  it("okänt argument → exit 1", () => {
+    const { status, out } = run(["--frobnicate", "--config", "x.json", "--dry-run"]);
+    expect(status).toBe(1);
+    expect(out).toMatch(/okänt argument/);
+  });
+
+  it("--help → exit 0 + användning", () => {
+    const { status, out } = run(["--help"]);
+    expect(status).toBe(0);
+    expect(out).toMatch(/ett-svep-installer/);
+    expect(out).toContain("--version");
+  });
+});

--- a/tooling/scripts/install-from-release.sh
+++ b/tooling/scripts/install-from-release.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# install-from-release.sh (#325) — ett-svep-installer för AVA-server.
+#
+# Hämtar AVA vid en GitHub-release-tagg och kör HELA install-flödet:
+#   1. förutsättnings-koll (docker, bun, curl, tar)
+#   2. ladda ner käll-tarballen för taggen (innehåller compose + install-server)
+#   3. packa upp + `bun install --frozen-lockfile`
+#   4. `install-server.ts --config <fil> --start` (valv + env + preflight +
+#      docker up + tjänste-kontroller, #323)
+#
+# Käll-tarballen används eftersom compose-filerna + install-server-scriptet inte
+# är fristående release-assets (binärerna/checksums är separata). En curerad
+# server-bundle är en uppföljning (#325-avgränsning).
+#
+# Användning:
+#   curl -fsSL <raw-url>/install-from-release.sh | bash -s -- \
+#     --version v1.2.3 --config ./install.json --dir /srv/ava
+#   # eller lokalt:
+#   bash tooling/scripts/install-from-release.sh --version latest --config ./install.json
+#
+#   --version <tag|latest>   release-tagg (default: latest)
+#   --config  <fil.json>     install-server-config (krävs; se --print-config-template)
+#   --dir     <katalog>      install-katalog (default: ./ava-<tag>)
+#   --repo    <owner/repo>   GitHub-repo (default: ulrik-s/ava)
+#   --dry-run                skriv ut planen (tagg, URL:er, kommandon) utan att köra
+#   --help                   denna hjälp
+
+set -euo pipefail
+
+REPO="ulrik-s/ava"
+VERSION="latest"
+CONFIG=""
+DIR=""
+DRY_RUN=0
+
+log()  { printf '\033[1m[ava-install]\033[0m %s\n' "$*"; }
+die()  { printf '\033[31m[ava-install] FEL:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# Skriv ut hjälp-blocket (kommentarsraderna 2.. fram till `set -euo`). awk i
+# st.f. `head -n -1` → portabelt (BSD/macOS-head saknar negativ -n).
+usage() { awk 'NR>=2 { if ($0 ~ /^set -euo pipefail/) exit; sub(/^# ?/, ""); print }' "$0"; }
+
+parse_args() {
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --version) VERSION="${2:?--version kräver ett värde}"; shift 2 ;;
+      --config)  CONFIG="${2:?--config kräver ett värde}"; shift 2 ;;
+      --dir)     DIR="${2:?--dir kräver ett värde}"; shift 2 ;;
+      --repo)    REPO="${2:?--repo kräver ett värde}"; shift 2 ;;
+      --dry-run) DRY_RUN=1; shift ;;
+      --help|-h) usage; exit 0 ;;
+      *) die "okänt argument: $1 (kör --help)" ;;
+    esac
+  done
+}
+
+# Verktyg som krävs. I dry-run räcker curl (för ev. latest-uppslag); annars allt.
+check_prereqs() {
+  local missing=""
+  local needed="curl tar"
+  [ "$DRY_RUN" -eq 1 ] || needed="$needed docker bun"
+  for bin in $needed; do
+    command -v "$bin" >/dev/null 2>&1 || missing="$missing $bin"
+  done
+  [ -z "$missing" ] || die "saknar verktyg på PATH:$missing"
+}
+
+# "latest" → slå upp senaste tag_name via GitHub API (nät). Explicit tagg = no-op.
+resolve_version() {
+  [ "$VERSION" = "latest" ] || return 0
+  log "slår upp senaste release för $REPO …"
+  local api="https://api.github.com/repos/$REPO/releases/latest"
+  VERSION="$(curl -fsSL "$api" | grep '"tag_name"' | head -1 | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')"
+  [ -n "$VERSION" ] || die "kunde inte slå upp senaste tagg ($api)"
+}
+
+main() {
+  parse_args "$@"
+  [ -n "$CONFIG" ] || die "--config <fil.json> krävs (skapa en med: install-server.ts --print-config-template)"
+  check_prereqs
+
+  # latest-uppslag hoppas i dry-run med explicit tagg (håller dry-run nät-fri/testbar).
+  if [ "$DRY_RUN" -eq 0 ] || [ "$VERSION" != "latest" ]; then resolve_version; fi
+  [ -n "$DIR" ] || DIR="./ava-${VERSION}"
+
+  local tarball_url="https://github.com/$REPO/archive/refs/tags/${VERSION}.tar.gz"
+  local install_cmd="bun tooling/scripts/install-server.ts --config $CONFIG --start"
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "DRY-RUN — inget körs. Plan:"
+    echo "  repo:       $REPO"
+    echo "  version:    $VERSION"
+    echo "  tarball:    $tarball_url"
+    echo "  install-dir:$DIR"
+    echo "  config:     $CONFIG"
+    echo "  steg 1: curl -fsSL $tarball_url | tar -xz -C $DIR --strip-components=1"
+    echo "  steg 2: (cd $DIR && bun install --frozen-lockfile)"
+    echo "  steg 3: (cd $DIR && $install_cmd)"
+    return 0
+  fi
+
+  [ -f "$CONFIG" ] || die "config-filen finns inte: $CONFIG"
+  local config_abs; config_abs="$(cd "$(dirname "$CONFIG")" && pwd)/$(basename "$CONFIG")"
+
+  log "hämtar $REPO@$VERSION → $DIR"
+  mkdir -p "$DIR"
+  curl -fsSL "$tarball_url" | tar -xz -C "$DIR" --strip-components=1
+
+  log "installerar beroenden (bun install) …"
+  ( cd "$DIR" && bun install --frozen-lockfile )
+
+  log "kör install-server (valv + env + preflight + docker up + tjänste-checks) …"
+  ( cd "$DIR" && bun tooling/scripts/install-server.ts --config "$config_abs" --start )
+
+  log "klart. AVA-server installerad från $REPO@$VERSION i $DIR."
+}
+
+main "$@"


### PR DESCRIPTION
Löser #325. Ett bash-script som hämtar AVA-server från GitHub-releasen och kör **hela installationen** i ett svep.

## `tooling/scripts/install-from-release.sh`
```sh
curl -fsSL <raw>/install-from-release.sh | bash -s -- --version v1.2.3 --config ./install.json --dir /srv/ava
```
Gör: prereq-koll (docker/bun/curl/tar) → ladda ner **käll-tarballen** för taggen (`/archive/refs/tags/<tag>.tar.gz` — innehåller compose-filer + `install-server`) → packa upp → `bun install --frozen-lockfile` → `install-server.ts --config <fil> --start` (valv + env + preflight + docker up + tjänste-checks från #323).

- Args: `--version` (tag|`latest`, latest slås upp via GH API) / `--config` / `--dir` / `--repo` / `--dry-run` / `--help`. `set -euo pipefail`, portabel `usage` (awk — BSD/macOS-head saknar `-n -1`).
- **`--dry-run`** skriver ut planen (tagg, URL:er, kommandon) utan curl/docker → CI-testbart.

## Test
6 unit-tester (`test/scripts/install-from-release.test.ts`) spawnar scriptet i `--dry-run` och asserterar tarball-URL/tagg/install-kommando/`--repo`-override + arg-validering (saknat `--config` → exit 1, okänt arg → exit 1, `--help` → exit 0). typecheck/lint/full-lint rena.

## Avgränsning
Bygger på käll-tarballen eftersom compose/install-server inte är fristående release-assets. En curerad `ava-server-<tag>.tar.gz` (förbyggd binär, ingen källbyggnad på servern) är en naturlig uppföljning som kräver ändring i `release.yml`.

Closes #325.

🤖 Generated with [Claude Code](https://claude.com/claude-code)