### PR TITLE
test(tooling): hård wall-clock-timeout per testpass i run-tests.ts (#327)

### DIFF
--- a/test/scripts/run-tests-pass-error.test.ts
+++ b/test/scripts/run-tests-pass-error.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Test för `passError` (#327) — klassar ett spawnSync-resultat från ett testpass:
+ * timeout (SIGKILL-hang) vs signal vs exit≠0 vs ok. Ren funktion → inga subprocesser.
+ *
+ * (run-tests.ts kör main() bara när det körs direkt, ej vid import — så detta
+ * importerar passError utan att starta en testkörning.)
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { passError } from "../../tooling/scripts/run-tests";
+
+describe("passError", () => {
+  it("ok (status 0) → null", () => {
+    expect(passError("pass B", 240_000, { status: 0, signal: null })).toBeNull();
+  });
+
+  it("ETIMEDOUT → tydligt hang-meddelande med sekunder + #327", () => {
+    const err = new Error("spawnSync bun ETIMEDOUT") as NodeJS.ErrnoException;
+    err.code = "ETIMEDOUT";
+    const msg = passError("pass B (realgit, sekventiellt)", 240_000, { status: null, signal: "SIGKILL", error: err });
+    expect(msg).toContain("översteg 240s");
+    expect(msg).toContain("SIGKILL");
+    expect(msg).toContain("#327");
+  });
+
+  it("exit≠0 → exit-meddelande", () => {
+    expect(passError("pass A", 360_000, { status: 1, signal: null })).toBe("pass A: exit 1");
+  });
+
+  it("dödad av signal (utan error) → signal-meddelande", () => {
+    expect(passError("pass A", 360_000, { status: null, signal: "SIGTERM" })).toBe("pass A: dödad av signal SIGTERM");
+  });
+
+  it("annat spawn-fel (ENOENT) → kunde-inte-köras", () => {
+    const err = new Error("spawn bun ENOENT") as NodeJS.ErrnoException;
+    err.code = "ENOENT";
+    const msg = passError("pass A", 360_000, { status: null, signal: null, error: err });
+    expect(msg).toMatch(/kunde inte köras.*ENOENT/);
+  });
+});

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -62,8 +62,31 @@ function allTestFiles(): string[] {
   return [...out];
 }
 
+// Wall-clock-timeout per pass (#327). Realgit-passet (B) kan hänga indefinit
+// om en git-barnprocess (clone/push mot temp-repo) blockerar — bun:s per-test-
+// `--timeout` dödar inte alltid barnet, så hela processen lever vidare och
+// HÄNGER jobbet tills GitHubs jobb-timeout (sågs som 15-min hang, PR #326).
+// En SIGKILL-timeout gör en hang till ett bounded fel → snabb röd + rerun.
+// Generöst tilltaget över normal körtid (pass A ~60s, pass B ~30s).
+const PASS_A_TIMEOUT_MS = 360_000;
+const PASS_B_TIMEOUT_MS = 240_000;
+
+interface PassResult { status: number | null; signal: NodeJS.Signals | null; error?: Error | undefined }
+
+/** Klassa ett spawnSync-resultat → felmeddelande (eller null = ok). Ren/testbar. */
+export function passError(label: string, timeoutMs: number, r: PassResult): string | null {
+  const code = (r.error as NodeJS.ErrnoException | undefined)?.code;
+  if (code === "ETIMEDOUT") {
+    return `${label}: översteg ${Math.round(timeoutMs / 1000)}s och dödades (SIGKILL) — trolig hängande git-barnprocess (#327). Kör om; undersök realgit-testet vid upprepning.`;
+  }
+  if (r.error) return `${label}: kunde inte köras: ${r.error.message}`;
+  if (r.signal) return `${label}: dödad av signal ${r.signal}`;
+  if (r.status !== 0) return `${label}: exit ${r.status ?? "okänd"}`;
+  return null;
+}
+
 /**
- * Kör ett test-pass; avbryt processen om det fallerar.
+ * Kör ett test-pass; avbryt processen om det fallerar (eller hänger > `timeoutMs`).
  *
  * `workers`:
  *   - `N` → `--parallel=N` (worker-pool; implicerar --isolate).
@@ -74,15 +97,17 @@ function allTestFiles(): string[] {
  *     realgit-tunga filerna saknar `mock.module`/globala stubbar → trygga att
  *     dela process.
  */
-function runPass(label: string, files: string[], workers: number | null, covDir: string | null): void {
+function runPass(label: string, files: string[], workers: number | null, covDir: string | null, timeoutMs: number): void {
   if (files.length === 0) return;
   const args = ["test", "--timeout", "30000"];
   if (workers !== null) args.push(`--parallel=${workers}`);
   if (covDir) args.push("--coverage", "--coverage-reporter=lcov", `--coverage-dir=${covDir}`);
   args.push(...files);
-  const proc = spawnSync("bun", args, { stdio: "inherit" });
-  if (proc.status !== 0) {
-    console.error(`\n✗ Tester misslyckades (${label}, exit ${proc.status ?? "signal"}).`);
+  // timeout + SIGKILL: en hängande pass dödas i st.f. att hänga hela jobbet (#327).
+  const proc = spawnSync("bun", args, { stdio: "inherit", timeout: timeoutMs, killSignal: "SIGKILL" });
+  const err = passError(label, timeoutMs, proc);
+  if (err) {
+    console.error(`\n✗ Tester misslyckades (${err}).`);
     process.exit(proc.status ?? 1);
   }
 }
@@ -177,10 +202,12 @@ function main(): void {
   // Pass A: parallell-säkra tester (--parallel=2, snabbt). Pass B: realgit
   // sekventiellt (inget --parallel → enprocess, ingen kontention, ingen
   // --isolate/epoll-krasch på CI-linux).
-  runPass("pass A (parallell)", rest, 2, COVERAGE ? "coverage/a" : null);
-  runPass("pass B (realgit, sekventiellt)", realgit, null, COVERAGE ? "coverage/b" : null);
+  runPass("pass A (parallell)", rest, 2, COVERAGE ? "coverage/a" : null, PASS_A_TIMEOUT_MS);
+  runPass("pass B (realgit, sekventiellt)", realgit, null, COVERAGE ? "coverage/b" : null, PASS_B_TIMEOUT_MS);
 
   if (COVERAGE) checkCoverage(["coverage/a", "coverage/b"]);
 }
 
-main();
+// Kör bara när scriptet körs direkt (`bun …/run-tests.ts`), inte när en test
+// importerar `passError` härifrån (då skulle main() spawna en bun-test-körning).
+if (process.argv[1]?.endsWith("run-tests.ts")) main();


### PR DESCRIPTION
Löser #327 (uppföljning på #318/#319). Pass B (realgit, seriellt) kunde **hänga indefinit** om en `git`-barnprocess blockerar — bun:s per-test `--timeout` dödar inte alltid barnet → hela processen lever vidare → **jobbet hänger tills GitHubs jobb-timeout** (sågs som 15-min hang på PR #326, grön på rerun).

## Fix
- `runPass` ger `spawnSync` en **wall-clock-timeout + `killSignal: SIGKILL`** (pass A 360s, pass B 240s — generöst över normal körtid ~60s/30s). En hang blir ett **bounded fel** (snabb röd + rerun) i st.f. 15-min-hang.
- **`passError(label, timeoutMs, result)`** — ren, exporterad klassning: ETIMEDOUT→hang-meddelande (med #327-referens) / signal→dödad / exit≠0 / ok. **5 unit-tester**.
- `main()` körs nu bara vid direkt-anrop (`process.argv[1]` endsWith `run-tests.ts`) → testet kan importera `passError` utan att starta en testkörning.

## Verifierat
`bun run test:cov` kör **fullt**: 0 fail i bägge passen, coverage 83.87%/81.44% grön → guarden fyrar (ingen no-op) och timeouten påverkar inte normala körningar. typecheck/lint/knip rena.

Closes #327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)