### PR TITLE
chore(docker): gör git-ssh opt-in (--profile ssh) (#336, ADR 0014 §5)

### DIFF
--- a/tooling/docker/docker-compose.yml
+++ b/tooling/docker/docker-compose.yml
@@ -12,10 +12,13 @@
 #
 # OBS: compose-filen ligger i docker/. Kör ALLTID med -f från repo-roten:
 #   1. Bygg web-app:n statiskt:  DEMO_BASE_PATH=/ava bash tooling/scripts/build-demo.sh
-#   2. Lägg din SSH-nyckel i:    tooling/docker/git-ssh/authorized_keys
-#   3. Starta:                   docker compose -f tooling/docker/docker-compose.yml up -d --build
-#   4. Browser:                  http://localhost:8080/ava
-#   5. Klona repo:                git clone ssh://git@localhost:2222/srv/git/firma.git
+#   2. Starta:                   docker compose -f tooling/docker/docker-compose.yml up -d --build
+#   3. Browser:                  http://localhost:8080/ava
+#   4. Git via HTTP (default):   git clone http://localhost:8080/git/firma.git
+#
+# SSH-git är OPT-IN (ADR 0014 §5): lägg din nyckel i
+# tooling/docker/git-ssh/authorized_keys och starta med `--profile ssh`, sedan
+#   git clone ssh://git@localhost:2222/srv/git/firma.git
 #
 # `name: ava` håller projekt-/volymnamnen stabila (ava_git_repos) oavsett
 # att filen flyttats till docker/ — annars skulle de prefixas "docker_".
@@ -79,8 +82,12 @@ services:
     volumes:
       - auth_data:/data
 
-  # ─── SSH + bare git-repos = datalagring ────────────────────
+  # ─── (Valbar) SSH-åtkomst till bare git-repos ──────────────
+  # Opt-in (ADR 0014 §5): default-stacken når git via HTTP (web/`/git/`), och
+  # web-containerns entrypoint skapar default-repot självt → git-ssh behövs bara
+  # om du vill klona/pusha över SSH. Aktivera med `--profile ssh`.
   git-ssh:
+    profiles: ["ssh"]
     build:
       context: ./git-ssh
       dockerfile: Dockerfile


### PR DESCRIPTION
Per ADR 0014 §5 (release-distribution). `git-ssh` saknade profil → startade i default-stacken trots att den bara behövs för SSH-git.

- HTTP-git går via `web` (`/git/`), och **web-entrypointen skapar default-repot självt** (idempotent) → git-ssh behövs inte längre i default-stacken (round-trip-e2e använder HTTP-git, ej SSH).
- La `profiles: ["ssh"]` → `docker compose up` startar nu bara `web` (`auth` + `server-runtime` redan profil-gatade via `invite-server`/`server`). SSH-git aktiveras med `--profile ssh`.
- Compose-headern uppdaterad: HTTP-git som default-klon, SSH-git som opt-in.

**Verifierat:** `docker compose config --services` → default = `web`; `--profile ssh` → `web` + `git-ssh`. Round-trip-e2e (HTTP-git) opåverkad.

Closes #336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)