### PR TITLE
feat(installer): renderTrialRealm — Keycloak trial-realm ur install-params (#337)

### DIFF
--- a/test/scripts/install-server-trial-realm.test.ts
+++ b/test/scripts/install-server-trial-realm.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Test för renderTrialRealm (#337) — Keycloak trial-realm ur install-parametrar.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { renderTrialRealm } from "../../tooling/scripts/install-server/trial-realm";
+
+const opts = {
+  realm: "byra",
+  adminEmail: "ada@byra.se",
+  adminPassword: "hemligt123",
+  clientId: "ava-web",
+  clientSecret: "s3cr3t",
+  redirectUris: ["https://ava.byra.se/oauth2/callback", "http://localhost:8080/oauth2/callback"],
+};
+
+describe("renderTrialRealm", () => {
+  it("realm-grundinställningar (namn, enabled, http tillåtet, ingen registrering)", () => {
+    const r = renderTrialRealm(opts);
+    expect(r.realm).toBe("byra");
+    expect(r.enabled).toBe(true);
+    expect(r.sslRequired).toBe("none");
+    expect(r.registrationAllowed).toBe(false);
+    expect(r.loginWithEmailAllowed).toBe(true);
+  });
+
+  it("EN confidential klient med secret + redirectUris + standard flow", () => {
+    const c = renderTrialRealm(opts).clients;
+    expect(c).toHaveLength(1);
+    expect(c[0]).toMatchObject({
+      clientId: "ava-web",
+      publicClient: false,
+      secret: "s3cr3t",
+      standardFlowEnabled: true,
+      directAccessGrantsEnabled: false,
+      redirectUris: opts.redirectUris,
+    });
+  });
+
+  it("audience-mapper pekar på klient-id:t (oauth2-proxy-token funkar)", () => {
+    const mapper = renderTrialRealm(opts).clients[0]!.protocolMappers[0]!;
+    expect(mapper.protocolMapper).toBe("oidc-audience-mapper");
+    expect(mapper.config["included.client.audience"]).toBe("ava-web");
+  });
+
+  it("EN admin-användare: email = username, lösenord ej temporärt, emailVerified", () => {
+    const u = renderTrialRealm(opts).users;
+    expect(u).toHaveLength(1);
+    expect(u[0]).toMatchObject({ username: "ada@byra.se", email: "ada@byra.se", emailVerified: true });
+    expect(u[0]!.credentials[0]).toEqual({ type: "password", value: "hemligt123", temporary: false });
+  });
+
+  it("defaults: realm 'ava' + klient 'ava' när inget anges", () => {
+    const r = renderTrialRealm({ ...opts, realm: "ava", clientId: "ava" });
+    expect(r.realm).toBe("ava");
+    expect(r.clients[0]!.clientId).toBe("ava");
+  });
+});

--- a/tooling/scripts/install-server.ts
+++ b/tooling/scripts/install-server.ts
@@ -38,6 +38,7 @@ import {
 } from "./install-server/orchestrate";
 import { interpretPreflight, runPreflight } from "./install-server/preflight";
 import { checkServices, summarizeServiceChecks } from "./install-server/service-checks";
+import { renderTrialRealm } from "./install-server/trial-realm";
 import {
   answersToConfig,
   renderConfigTemplate,
@@ -254,28 +255,58 @@ async function runInstall(argv: string[], paths: InstallPaths): Promise<boolean>
   return true;
 }
 
-async function main(): Promise<void> {
-  const argv = process.argv.slice(2);
+/** Skriv ut en Keycloak trial-realm (#337, ADR 0014 §4) ur flaggor → stdout. */
+function printTrialRealm(argv: string[]): boolean {
+  const adminEmail = flag(argv, "admin-email");
+  const adminPassword = flag(argv, "admin-password");
+  const clientSecret = flag(argv, "client-secret");
+  if (!adminEmail || !adminPassword || !clientSecret) {
+    console.error("[install-server] --print-realm kräver --admin-email, --admin-password och --client-secret");
+    return false;
+  }
+  const realm = renderTrialRealm({
+    realm: flag(argv, "realm") ?? "ava",
+    adminEmail,
+    adminPassword,
+    clientId: flag(argv, "client-id") ?? "ava",
+    clientSecret,
+    redirectUris: (flag(argv, "redirect-uri") ?? "http://localhost:8080/oauth2/callback").split(",").map((s) => s.trim()),
+  });
+  process.stdout.write(JSON.stringify(realm, null, 2) + "\n");
+  return true;
+}
 
-  // Skriv ut en config-mall att fylla i (--config-vägen). Inga sidoeffekter.
+/**
+ * Icke-install-subkommandon (rena utskrifter / nedrivning / nåbarhetskoll).
+ * Returnerar true om ett hanterades → main() ska INTE installera.
+ */
+async function handleSubcommand(argv: string[]): Promise<boolean> {
   if (hasFlag(argv, "print-config-template")) {
     process.stdout.write(renderConfigTemplate());
-    return;
+    return true;
   }
-
-  // Tjänste-kommunikationskoll (#323): verifiera att en (redan körande)
-  // installation når web/git/IdP. Ingen install — bara nåbarhets-rapport.
+  // Trial-Keycloak-realm (#337) ur flaggor.
+  if (hasFlag(argv, "print-realm")) {
+    process.exitCode = printTrialRealm(argv) ? 0 : 1;
+    return true;
+  }
+  // Tjänste-kommunikationskoll (#323): når en körande installation web/git/IdP?
   if (hasFlag(argv, "check-services")) {
     process.exitCode = (await runServiceChecks(argv)) ? 0 : 1;
-    return;
+    return true;
   }
-
-  // Avinstallation/nedrivning: stoppa stacken + ta bort volymer, sen klart.
+  // Nedrivning: stoppa stacken + ta bort volymer.
   if (hasFlag(argv, "down")) {
     await runCommands(buildStopCommands({ oidc: (flag(argv, "auth") ?? "htpasswd") === "oidc" }), process.env);
     log("stacken nedriven (volymer borttagna). Secrets-valvet är oförändrat.");
-    return;
+    return true;
   }
+  return false;
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  if (await handleSubcommand(argv)) return;
 
   const ok = await runInstall(argv, resolvePaths(argv));
   if (!ok) process.exitCode = 1;

--- a/tooling/scripts/install-server/trial-realm.ts
+++ b/tooling/scripts/install-server/trial-realm.ts
@@ -1,0 +1,93 @@
+/**
+ * `renderTrialRealm` (#337, ADR 0014 §4) — genererar en Keycloak-realm för
+ * TRIAL-läget (bundlad, ephemeral IdP) ur install-parametrar, i st.f. den
+ * statiska dev-realmen (`tooling/docker/keycloak/realm-ava.json`) med dess
+ * hårdkodade testanvändare.
+ *
+ * Producerar EN confidential OIDC-klient (för oauth2-proxy) + EN admin-användare
+ * (byråns login). Auktorisering görs av AVA:s allowlist i firma.git (ADR 0009),
+ * så realmen behöver bara att användaren finns + kan autentisera. Importeras av
+ * Keycloak via `start-dev --import-realm`.
+ *
+ * Modellerad på den fungerande realm-ava.json (scopes, audience-mapper,
+ * webOrigins) så oauth2-proxy-token/-userinfo funkar likadant. PROD = BYO-IdP.
+ */
+
+export interface TrialRealmOpts {
+  /** Realm-namn (= issuer-path-segmentet, t.ex. "ava" → /realms/ava). */
+  realm: string;
+  /** Byråns admin — blir login-användaren (email används som username). */
+  adminEmail: string;
+  adminPassword: string;
+  /** oauth2-proxy-klienten. */
+  clientId: string;
+  clientSecret: string;
+  /** Tillåtna redirect-URI:er (oauth2-proxy /oauth2/callback per origin). */
+  redirectUris: string[];
+}
+
+interface KeycloakClient {
+  clientId: string; name: string; enabled: true; protocol: "openid-connect";
+  publicClient: false; secret: string; standardFlowEnabled: true;
+  directAccessGrantsEnabled: false; redirectUris: string[]; webOrigins: string[];
+  attributes: Record<string, string>; defaultClientScopes: string[];
+  protocolMappers: Array<{ name: string; protocol: string; protocolMapper: string; config: Record<string, string> }>;
+}
+interface KeycloakUser {
+  username: string; enabled: true; emailVerified: true; email: string;
+  credentials: Array<{ type: "password"; value: string; temporary: false }>;
+}
+export interface KeycloakRealm {
+  realm: string; enabled: true; sslRequired: "none"; registrationAllowed: false;
+  loginWithEmailAllowed: true; duplicateEmailsAllowed: false; accessTokenLifespan: number;
+  clients: KeycloakClient[]; users: KeycloakUser[];
+}
+
+function audienceMapper(clientId: string) {
+  return {
+    name: `audience-${clientId}`,
+    protocol: "openid-connect",
+    protocolMapper: "oidc-audience-mapper",
+    config: { "included.client.audience": clientId, "id.token.claim": "true", "access.token.claim": "true" },
+  };
+}
+
+export function renderTrialRealm(opts: TrialRealmOpts): KeycloakRealm {
+  return {
+    realm: opts.realm,
+    enabled: true,
+    // Trial: HTTP tillåtet (ephemeral, localhost). Prod-IdP terminerar TLS.
+    sslRequired: "none",
+    registrationAllowed: false,
+    loginWithEmailAllowed: true,
+    duplicateEmailsAllowed: false,
+    accessTokenLifespan: 300,
+    clients: [
+      {
+        clientId: opts.clientId,
+        name: "AVA (OIDC)",
+        enabled: true,
+        protocol: "openid-connect",
+        publicClient: false,
+        secret: opts.clientSecret,
+        standardFlowEnabled: true,
+        // Bara browser-login via oauth2-proxy (standard flow) → ingen direct-access.
+        directAccessGrantsEnabled: false,
+        redirectUris: opts.redirectUris,
+        webOrigins: ["+"],
+        attributes: { "post.logout.redirect.uris": "+" },
+        defaultClientScopes: ["openid", "email", "profile", "roles"],
+        protocolMappers: [audienceMapper(opts.clientId)],
+      },
+    ],
+    users: [
+      {
+        username: opts.adminEmail,
+        enabled: true,
+        emailVerified: true,
+        email: opts.adminEmail,
+        credentials: [{ type: "password", value: opts.adminPassword, temporary: false }],
+      },
+    ],
+  };
+}


### PR DESCRIPTION
Per ADR 0014 §4 (release-distribution, epic #332). Trial-Keycloak får en realm **genererad ur install-parametrar** i st.f. dev-realmens hårdkodade testanvändare (admin/lawyer/outsider).

- **`renderTrialRealm({ realm, adminEmail, adminPassword, clientId, clientSecret, redirectUris })`** → EN confidential oauth2-proxy-klient (audience-mapper + scopes modellerade på den fungerande `realm-ava.json`) + EN admin-användare (email = username; auktorisering via AVA:s allowlist i firma.git, ADR 0009).
- **`install-server --print-realm`** (flagg-styrt) skriver realmen till stdout. `main()` dispatchar nu icke-install-subkommandon via `handleSubcommand` (håller complexity@8).
- **5 unit-tester** + **verifierat mot live Keycloak 26**: realmen importeras (`Realm 'byra' imported`) och `/realms/byra/.well-known/openid-configuration` svarar med issuer/authorization/token-endpoints.

Prod = BYO-IdP (ADR 0009), ej i scope.

Closes #337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)