### PR TITLE
refactor(calendar): bryt ut useCalendarState + event-form-hook (#6)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,9 +1,4 @@
 {
-  "src/app/calendar/page.tsx": {
-    "max-lines-per-function": {
-      "count": 2
-    }
-  },
   "src/app/matters/[id]/_expense-section.tsx": {
     "max-lines-per-function": {
       "count": 1

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -54,19 +54,20 @@ function enqueueMirror(args: MirrorArgs): void {
   jobQueue.enqueue("mirror-to-outlook", label, args as unknown as Record<string, unknown>);
 }
 
-// eslint-disable-next-line complexity
-export default function CalendarPage() {
-  const [showNewEvent, setShowNewEvent] = useState(false);
-  const [showNewTask, setShowNewTask] = useState(false);
-  const [view, setView] = useState<ViewMode>("week");
-  const [selectedEvent, setSelectedEvent] = useState<EventDetail | null>(null);
-  const [editingEvent, setEditingEvent] = useState<EventRow | null>(null);
-  // Hydration-safe init: `new Date()` och `localStorage` ger olika värden
-  // SSR (statisk export, byggtid) vs klient. Vi initialiserar deterministiskt
-  // till null/[] och fyller via useEffect efter mount — då matchar SSR-HTML
-  // klientens första render.
+/**
+ * Kalender-sidans state: anchor (date-param-deep-link), vy, multi-user-val
+ * samt namn-/färgmappar. Effekterna är hydration-säkra — de initialiserar
+ * deterministiskt till null/[] och fyller efter mount, så SSR-HTML matchar
+ * klientens första render.
+ */
+function useCalendarState() {
   const [anchor, setAnchor] = useState<Date | null>(null);
-   
+  const [view, setView] = useState<ViewMode>("week");
+  const currentUser = trpc.user.current.useQuery();
+  const orgUsers = trpc.user.list.useQuery();
+  const [selectedUserIds, setSelectedUserIds] = useState<string[]>([]);
+  const [userSelInit, setUserSelInit] = useState(false);
+
   useEffect(() => {
     // Acceptera ?date=YYYY-MM-DD så andra sidor kan länka hit och hoppa
     // direkt till en specifik dag (matter-detalj: "Gå till kalendern").
@@ -76,18 +77,12 @@ export default function CalendarPage() {
     const valid = parsed && !isNaN(parsed.getTime()) ? parsed : new Date();
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setAnchor(startOfDay(valid));
-     
     if (dateParam) setView("day");
   }, []);
 
-  // Persistera vilka användare som visas (multi-user). Default: bara mig,
-  // men ?date=-deep-link (från matter) väljer alla så event av andra
-  // ägare syns. Beslutet lever i pure resolveSelectedUsers (testad).
-  const currentUser = trpc.user.current.useQuery();
-  const orgUsers = trpc.user.list.useQuery();
-  const [selectedUserIds, setSelectedUserIds] = useState<string[]>([]);
-  const [userSelInit, setUserSelInit] = useState(false);
   useEffect(() => {
+    // Default: bara mig, men ?date=-deep-link (från matter) väljer alla så
+    // event av andra ägare syns. Beslutet lever i pure resolveSelectedUsers.
     // Vänta tills minst current-user laddats så vi inte sätter [] permanent.
     if (userSelInit) return;
     const hasDateParam = typeof window !== "undefined" && new URL(window.location.href).searchParams.has("date");
@@ -101,24 +96,33 @@ export default function CalendarPage() {
     if (resolved.length > 0) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setSelectedUserIds(resolved);
-       
       setUserSelInit(true);
     }
   }, [currentUser.data?.id, orgUsers.data?.users, userSelInit]);
 
+  // Namn-/färgmappar byggs över ALLA org-användare så de är stabila även när
+  // man togglar individer i pickern. buildUserColorMap sorterar id:na
+  // deterministiskt och garanterar unika färger för ≤12 användare.
   const userNames = useMemo<Record<string, string>>(() => {
     const m: Record<string, string> = {};
     for (const u of orgUsers.data?.users ?? []) m[u.id] = u.name;
     return m;
   }, [orgUsers.data?.users]);
 
-  // Färgmappen byggs över ALLA org-användare så färgerna är stabila även
-  // när man togglar in/ut individer i pickern. `buildUserColorMap` sorterar
-  // id:na deterministiskt och garanterar unika färger för ≤12 användare.
   const userColors = useMemo<Map<string, UserColor>>(() => {
     const ids = (orgUsers.data?.users ?? []).map((u: { id: string }) => u.id);
     return buildUserColorMap(ids);
   }, [orgUsers.data?.users]);
+
+  return { anchor, setAnchor, view, setView, selectedUserIds, setSelectedUserIds, userNames, userColors };
+}
+
+export default function CalendarPage() {
+  const [showNewEvent, setShowNewEvent] = useState(false);
+  const [selectedEvent, setSelectedEvent] = useState<EventDetail | null>(null);
+  const [editingEvent, setEditingEvent] = useState<EventRow | null>(null);
+  const { anchor, setAnchor, view, setView, selectedUserIds, setSelectedUserIds, userNames, userColors } =
+    useCalendarState();
 
   return (
     <div className="max-w-6xl">
@@ -153,56 +157,76 @@ export default function CalendarPage() {
             </button>
           </div>
           {showNewEvent && <NewEventForm onClose={() => setShowNewEvent(false)} />}
-          {editingEvent && (
-            <NewEventForm
-              initial={editingEvent}
-              onClose={() => setEditingEvent(null)}
-            />
-          )}
+          {editingEvent && <NewEventForm initial={editingEvent} onClose={() => setEditingEvent(null)} />}
           {view === "list" && <EventList />}
-          {/* anchor är null fram till första mount — då renderar vi en
-              osynlig placeholder så SSR-HTML matchar klientens första render. */}
-          {!anchor && <div data-calendar-placeholder className="h-64" aria-hidden />}
-          {anchor && view === "day" && (
-            <DayView anchor={anchor} onAnchorChange={setAnchor} userIds={selectedUserIds} userNames={userNames} userColors={userColors} onSelectEvent={setSelectedEvent} />
-          )}
-          {anchor && (view === "week" || view === "month") && (
-            <CalendarGrid
-              mode={view}
-              userIds={selectedUserIds}
-              userNames={userNames}
-              userColors={userColors}
-              anchor={anchor}
-              onAnchorChange={setAnchor}
-              onSelectEvent={setSelectedEvent}
-            />
-          )}
-          <EventDetailModal
-            event={selectedEvent}
-            userName={selectedEvent ? (userNames[selectedEvent.userId] ?? "?") : ""}
-            {...(selectedEvent && userColors.get(selectedEvent.userId)
-              ? { color: userColors.get(selectedEvent.userId)! }
-              : {})}
+          <CalendarBody
+            view={view}
+            anchor={anchor}
+            setAnchor={setAnchor}
+            selectedUserIds={selectedUserIds}
+            userNames={userNames}
+            userColors={userColors}
+            onSelectEvent={setSelectedEvent}
+          />
+          <EventDetailPanel
+            selectedEvent={selectedEvent}
+            userNames={userNames}
+            userColors={userColors}
             onClose={() => setSelectedEvent(null)}
             onEdit={(ev) => { setSelectedEvent(null); setEditingEvent(ev as unknown as EventRow); }}
           />
         </div>
       </section>
 
-      <section>
-        <div className="flex items-center justify-between mb-3">
-          <h2 className="text-lg font-semibold text-gray-800">Tasks</h2>
-          <button
-            onClick={() => setShowNewTask((v) => !v)}
-            className="flex items-center gap-1.5 px-3 py-1.5 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700"
-          >
-            <Plus size={14} /> Ny task
-          </button>
-        </div>
-        {showNewTask && <NewTaskForm onClose={() => setShowNewTask(false)} />}
-        <TaskList />
-      </section>
+      <TasksSection />
     </div>
+  );
+}
+
+/**
+ * Renderar den valda vyn. anchor är null fram till första mount — då en
+ * osynlig placeholder så SSR-HTML matchar klientens första render.
+ */
+function CalendarBody({ view, anchor, setAnchor, selectedUserIds, userNames, userColors, onSelectEvent }: {
+  view: ViewMode;
+  anchor: Date | null;
+  setAnchor: (d: Date) => void;
+  selectedUserIds: string[];
+  userNames: Record<string, string>;
+  userColors: Map<string, UserColor>;
+  onSelectEvent: (ev: EventDetail) => void;
+}) {
+  if (!anchor) return <div data-calendar-placeholder className="h-64" aria-hidden />;
+  if (view === "day") {
+    return (
+      <DayView anchor={anchor} onAnchorChange={setAnchor} userIds={selectedUserIds} userNames={userNames} userColors={userColors} onSelectEvent={onSelectEvent} />
+    );
+  }
+  if (view === "week" || view === "month") {
+    return (
+      <CalendarGrid mode={view} userIds={selectedUserIds} userNames={userNames} userColors={userColors} anchor={anchor} onAnchorChange={setAnchor} onSelectEvent={onSelectEvent} />
+    );
+  }
+  return null;
+}
+
+/** Detalj-modalen för ett valt event (med ägarens färg). */
+function EventDetailPanel({ selectedEvent, userNames, userColors, onClose, onEdit }: {
+  selectedEvent: EventDetail | null;
+  userNames: Record<string, string>;
+  userColors: Map<string, UserColor>;
+  onClose: () => void;
+  onEdit: (ev: EventDetail) => void;
+}) {
+  const color = selectedEvent ? userColors.get(selectedEvent.userId) : undefined;
+  return (
+    <EventDetailModal
+      event={selectedEvent}
+      userName={selectedEvent ? (userNames[selectedEvent.userId] ?? "?") : ""}
+      {...(color ? { color } : {})}
+      onClose={onClose}
+      onEdit={onEdit}
+    />
   );
 }
 
@@ -263,6 +287,26 @@ function EventList() {
 
 // ─── Task-list ────────────────────────────────────────────────────────────
 
+/** Tasks-sektionen: rubrik + "ny task"-toggle + listan. */
+function TasksSection() {
+  const [showNewTask, setShowNewTask] = useState(false);
+  return (
+    <section>
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-lg font-semibold text-gray-800">Tasks</h2>
+        <button
+          onClick={() => setShowNewTask((v) => !v)}
+          className="flex items-center gap-1.5 px-3 py-1.5 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700"
+        >
+          <Plus size={14} /> Ny task
+        </button>
+      </div>
+      {showNewTask && <NewTaskForm onClose={() => setShowNewTask(false)} />}
+      <TaskList />
+    </section>
+  );
+}
+
 function TaskList() {
   const { data: tasks, isLoading } = trpc.task.list.useQuery();
   const utils = trpc.useUtils();
@@ -319,8 +363,55 @@ function TaskList() {
 
 // ─── Create forms ─────────────────────────────────────────────────────────
 
+/** ISO/Date → datetime-local-värde "YYYY-MM-DDTHH:mm". */
+function toLocalInput(d: Date | string | null | undefined): string {
+  if (!d) return "";
+  const dt = typeof d === "string" ? new Date(d) : d;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${dt.getFullYear()}-${pad(dt.getMonth() + 1)}-${pad(dt.getDate())}T${pad(dt.getHours())}:${pad(dt.getMinutes())}`;
+}
+
+/**
+ * Initialvärden för event-formuläret ur en ev. redigerad rad. Platt
+ * fält-mappning utan logik — komplexiteten är enbart nullish-defaults.
+ */
 // eslint-disable-next-line complexity
-function NewEventForm({ onClose, initial }: { onClose: () => void; initial?: EventRow }) {
+function eventFormDefaults(initial?: EventRow) {
+  return {
+    title: initial?.title ?? "",
+    kind: initial?.kind ?? "appointment",
+    startAt: initial ? toLocalInput(initial.startAt) : new Date().toISOString().slice(0, 16),
+    endAt: initial?.endAt ? toLocalInput(initial.endAt) : "",
+    location: initial?.location ?? "",
+    matterId: initial?.matterId ?? "",
+    mirrorToOutlook: initial?.mirrorToOutlook ?? false,
+    inviteeUserIds: initial?.inviteeUserIds ?? [],
+    inviteeContactIds: initial?.inviteeContactIds ?? [],
+  };
+}
+
+/** Bygger mirror-to-outlook-argumenten (upsert) för en sparad event-rad. */
+function buildMirrorArgs(saved: EventRow): MirrorArgs {
+  const iso = (d: Date | string) => (typeof d === "string" ? d : d.toISOString());
+  return {
+    eventId: saved.id,
+    op: "upsert",
+    event: {
+      title: saved.title,
+      description: null,
+      location: saved.location ?? null,
+      startAt: iso(saved.startAt),
+      endAt: saved.endAt ? iso(saved.endAt) : null,
+      allDay: saved.allDay,
+      visibility: "normal",
+      kind: saved.kind,
+    },
+    outlookCalendarId: saved.outlookCalendarId ?? null,
+  };
+}
+
+/** All state + mutationer för event-formuläret (create + edit). */
+function useEventForm({ initial, onClose }: { initial?: EventRow | undefined; onClose: () => void }) {
   const utils = trpc.useUtils();
   const isEdit = !!initial;
   const matters = trpc.matter.list.useQuery({ pageSize: 500, status: "ACTIVE" });
@@ -328,50 +419,26 @@ function NewEventForm({ onClose, initial }: { onClose: () => void; initial?: Eve
   const contacts = trpc.contacts.list.useQuery({ pageSize: 500 });
 
   // Boundary-cast: mutationen returnerar en branded/optional tRPC-rad som är
-  // bredare än den lokala vy-typen EventRow; vi läser bara de fält som finns.
-  const onCreateOrUpdateSuccess = (savedRow: unknown): void => {
+  // bredare än vy-typen EventRow; vi läser bara de fält som finns.
+  const onSuccess = (savedRow: unknown): void => {
     const saved = savedRow as EventRow;
     void utils.calendar.invalidate();
-    if (saved.mirrorToOutlook) {
-      enqueueMirror({
-        eventId: saved.id,
-        op: "upsert",
-        event: {
-          title: saved.title,
-          description: null,
-          location: saved.location ?? null,
-          startAt: typeof saved.startAt === "string" ? saved.startAt : saved.startAt.toISOString(),
-          endAt: saved.endAt ? (typeof saved.endAt === "string" ? saved.endAt : saved.endAt.toISOString()) : null,
-          allDay: saved.allDay,
-          visibility: "normal",
-          kind: saved.kind,
-        },
-        outlookCalendarId: saved.outlookCalendarId ?? null,
-      });
-    }
+    if (saved.mirrorToOutlook) enqueueMirror(buildMirrorArgs(saved));
     onClose();
   };
+  const create = trpc.calendar.create.useMutation({ onSuccess });
+  const update = trpc.calendar.update.useMutation({ onSuccess });
 
-  const create = trpc.calendar.create.useMutation({ onSuccess: onCreateOrUpdateSuccess });
-  const update = trpc.calendar.update.useMutation({ onSuccess: onCreateOrUpdateSuccess });
-
-  // Hjälpare: ISO → datetime-local-värde "YYYY-MM-DDTHH:mm"
-  const toLocalInput = (d: Date | string | null | undefined): string => {
-    if (!d) return "";
-    const dt = typeof d === "string" ? new Date(d) : d;
-    const pad = (n: number) => String(n).padStart(2, "0");
-    return `${dt.getFullYear()}-${pad(dt.getMonth() + 1)}-${pad(dt.getDate())}T${pad(dt.getHours())}:${pad(dt.getMinutes())}`;
-  };
-
-  const [title, setTitle] = useState(initial?.title ?? "");
-  const [kind, setKind] = useState<"appointment" | "deadline">(initial?.kind ?? "appointment");
-  const [startAt, setStartAt] = useState(initial ? toLocalInput(initial.startAt) : new Date().toISOString().slice(0, 16));
-  const [endAt, setEndAt] = useState(initial?.endAt ? toLocalInput(initial.endAt) : "");
-  const [location, setLocation] = useState(initial?.location ?? "");
-  const [matterId, setMatterId] = useState(initial?.matterId ?? "");
-  const [mirrorToOutlook, setMirrorToOutlook] = useState(initial?.mirrorToOutlook ?? false);
-  const [inviteeUserIds, setInviteeUserIds] = useState<string[]>(initial?.inviteeUserIds ?? []);
-  const [inviteeContactIds, setInviteeContactIds] = useState<string[]>(initial?.inviteeContactIds ?? []);
+  const d = eventFormDefaults(initial);
+  const [title, setTitle] = useState(d.title);
+  const [kind, setKind] = useState<"appointment" | "deadline">(d.kind);
+  const [startAt, setStartAt] = useState(d.startAt);
+  const [endAt, setEndAt] = useState(d.endAt);
+  const [location, setLocation] = useState(d.location);
+  const [matterId, setMatterId] = useState(d.matterId);
+  const [mirrorToOutlook, setMirrorToOutlook] = useState(d.mirrorToOutlook);
+  const [inviteeUserIds, setInviteeUserIds] = useState<string[]>(d.inviteeUserIds);
+  const [inviteeContactIds, setInviteeContactIds] = useState<string[]>(d.inviteeContactIds);
 
   const submit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -390,22 +457,67 @@ function NewEventForm({ onClose, initial }: { onClose: () => void; initial?: Eve
     else create.mutate(payload);
   };
 
-  const pending = create.isPending || update.isPending;
+  const matterOptions = matters.data?.matters ?? [];
+  const userOptions = orgUsers.data?.users ?? [];
+  const contactOptions = contacts.data?.contacts ?? [];
 
+  return {
+    isEdit, matterOptions, userOptions, contactOptions,
+    title, setTitle, kind, setKind, startAt, setStartAt, endAt, setEndAt,
+    location, setLocation, matterId, setMatterId,
+    mirrorToOutlook, setMirrorToOutlook, inviteeUserIds, setInviteeUserIds,
+    inviteeContactIds, setInviteeContactIds, submit,
+    pending: create.isPending || update.isPending,
+  };
+}
+
+interface InviteeOption { id: string; name: string; role?: string; contactType?: string }
+
+/** De två "bjud in"-listorna (kollegor + kontakter). */
+function InviteePickers({ users, contacts, userIds, setUserIds, contactIds, setContactIds }: {
+  users: InviteeOption[];
+  contacts: InviteeOption[];
+  userIds: string[];
+  setUserIds: (ids: string[]) => void;
+  contactIds: string[];
+  setContactIds: (ids: string[]) => void;
+}) {
   return (
-    <form onSubmit={submit} className="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-3 space-y-3">
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+      <CheckboxList
+        label="Bjud in kollegor"
+        options={users.map((u) => ({ id: u.id, label: u.name, ...omitUndefined({ sublabel: u.role }) }))}
+        selectedIds={userIds}
+        onChange={setUserIds}
+        placeholder="Sök kollega…"
+      />
+      <CheckboxList
+        label="Bjud in från kontakter"
+        options={contacts.map((c) => ({ id: c.id, label: c.name, ...omitUndefined({ sublabel: c.contactType }) }))}
+        selectedIds={contactIds}
+        onChange={setContactIds}
+        placeholder="Sök kontakt…"
+      />
+    </div>
+  );
+}
+
+function NewEventForm({ onClose, initial }: { onClose: () => void; initial?: EventRow }) {
+  const f = useEventForm({ initial, onClose });
+  return (
+    <form onSubmit={f.submit} className="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-3 space-y-3">
       <div className="grid grid-cols-2 gap-3">
         <label className="block col-span-2">
           <span className="text-xs text-gray-600 mb-1 block">Titel *</span>
           <input
-            type="text" required value={title}
-            onChange={(e) => setTitle(e.target.value)}
+            type="text" required value={f.title}
+            onChange={(e) => f.setTitle(e.target.value)}
             className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm"
           />
         </label>
         <label className="block">
           <span className="text-xs text-gray-600 mb-1 block">Typ</span>
-          <select value={kind} onChange={(e) => setKind(e.target.value as "appointment" | "deadline")}
+          <select value={f.kind} onChange={(e) => f.setKind(e.target.value as "appointment" | "deadline")}
             className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm">
             <option value="appointment">Möte / Förhandling</option>
             <option value="deadline">Frist</option>
@@ -414,8 +526,8 @@ function NewEventForm({ onClose, initial }: { onClose: () => void; initial?: Eve
         <label className="block">
           <span className="text-xs text-gray-600 mb-1 block">Plats</span>
           <input
-            type="text" value={location}
-            onChange={(e) => setLocation(e.target.value)}
+            type="text" value={f.location}
+            onChange={(e) => f.setLocation(e.target.value)}
             placeholder="Stockholms tingsrätt, sal 5"
             className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm"
           />
@@ -423,17 +535,17 @@ function NewEventForm({ onClose, initial }: { onClose: () => void; initial?: Eve
         <label className="block">
           <span className="text-xs text-gray-600 mb-1 block">Start *</span>
           <input
-            type="datetime-local" required value={startAt}
-            onChange={(e) => setStartAt(e.target.value)}
+            type="datetime-local" required value={f.startAt}
+            onChange={(e) => f.setStartAt(e.target.value)}
             className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm"
           />
         </label>
-        {kind === "appointment" && (
+        {f.kind === "appointment" && (
           <label className="block">
             <span className="text-xs text-gray-600 mb-1 block">Slut</span>
             <input
-              type="datetime-local" value={endAt}
-              onChange={(e) => setEndAt(e.target.value)}
+              type="datetime-local" value={f.endAt}
+              onChange={(e) => f.setEndAt(e.target.value)}
               className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm"
             />
           </label>
@@ -442,44 +554,32 @@ function NewEventForm({ onClose, initial }: { onClose: () => void; initial?: Eve
       <div>
         <MatterCombobox
           label="Ärende (vad mötet handlar om)"
-          matters={matters.data?.matters ?? []}
-          value={matterId}
-          onChange={setMatterId}
+          matters={f.matterOptions}
+          value={f.matterId}
+          onChange={f.setMatterId}
           placeholder="Valfritt — sök på ärendenr eller titel…"
         />
       </div>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-        <CheckboxList
-          label="Bjud in kollegor"
-          options={(orgUsers.data?.users ?? []).map((u: { id: string; name: string; role?: string }) => ({
-            id: u.id, label: u.name, ...omitUndefined({ sublabel: u.role }),
-          }))}
-          selectedIds={inviteeUserIds}
-          onChange={setInviteeUserIds}
-          placeholder="Sök kollega…"
-        />
-        <CheckboxList
-          label="Bjud in från kontakter"
-          options={(contacts.data?.contacts ?? []).map((c: { id: string; name: string; contactType?: string }) => ({
-            id: c.id, label: c.name, ...omitUndefined({ sublabel: c.contactType }),
-          }))}
-          selectedIds={inviteeContactIds}
-          onChange={setInviteeContactIds}
-          placeholder="Sök kontakt…"
-        />
-      </div>
+      <InviteePickers
+        users={f.userOptions}
+        contacts={f.contactOptions}
+        userIds={f.inviteeUserIds}
+        setUserIds={f.setInviteeUserIds}
+        contactIds={f.inviteeContactIds}
+        setContactIds={f.setInviteeContactIds}
+      />
       <label className="flex items-center gap-2 text-xs text-gray-700">
         <input
-          type="checkbox" checked={mirrorToOutlook}
-          onChange={(e) => setMirrorToOutlook(e.target.checked)}
+          type="checkbox" checked={f.mirrorToOutlook}
+          onChange={(e) => f.setMirrorToOutlook(e.target.checked)}
         />
         <ExternalLink size={12} /> Spegla till Outlook (kräver O365-anslutning)
       </label>
       <div className="flex justify-end gap-2">
         <button type="button" onClick={onClose} className="px-3 py-1.5 text-sm text-gray-700 hover:bg-white rounded">Avbryt</button>
-        <button type="submit" disabled={!title || pending}
+        <button type="submit" disabled={!f.title || f.pending}
           className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50">
-          {pending ? "Sparar…" : isEdit ? "Spara ändringar" : "Skapa"}
+          {f.pending ? "Sparar…" : f.isEdit ? "Spara ändringar" : "Skapa"}
         </button>
       </div>
     </form>


### PR DESCRIPTION
## Vad

#6 ratchet-steg: `src/app/calendar/page.tsx` hade **2** max-lines-per-function-
suppressions (`CalendarPage` + `NewEventForm`) plus inline `// eslint-disable
complexity` på båda.

**CalendarPage** bryts ned i:
- **`useCalendarState()`** — anchor (date-param-deep-link), vy, multi-user-val,
  namn-/färgmappar (effekterna + memos).
- **`CalendarBody`** — placeholder/dag/vecka/månad-renderingen.
- **`EventDetailPanel`** — detalj-modalen med ägarfärg.
- **`TasksSection`** — tasks-rubrik + toggle + lista (äger sin egen state).

Page:n är nu en tunn shell; inline complexity-disablen borta.

**NewEventForm** bryts ned i:
- **`useEventForm()`** — all state + create/update-mutationer + submit.
- **`toLocalInput` / `eventFormDefaults` / `buildMirrorArgs`** — rena modul-helpers.
- **`InviteePickers`** — de två "bjud in"-listorna.

Komponenten är nu ren JSX utan complexity-disable. `eventFormDefaults` behåller
en disable (platt nullish-default-mappning, ingen logik — isolerad där i st.f.
på en 165-radersfunktion).

Båda posterna borttagna ur `eslint-suppressions.json`.

## Verifiering (CI-spegel lokalt)
- `bun run typecheck` — rent (efter `rm tsconfig.tsbuildinfo`)
- `bun run lint --max-warnings 0` — rent (inga oanvända disable-direktiv)
- `bun run lint:prune` → `grep -c calendar/page eslint-suppressions.json` = 0
- `bun run knip` — rent
- `bun test test/unit/app/calendar/` — 49 pass

Refs #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)