### PR TITLE
refactor(settings): bryt ut useKeypair-hook ur KeypairManager (#6)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -29,11 +29,6 @@
       "count": 1
     }
   },
-  "src/components/settings/keypair-manager.tsx": {
-    "max-lines-per-function": {
-      "count": 1
-    }
-  },
   "src/components/shell/demo-bootstrap.tsx": {
     "max-lines-per-function": {
       "count": 1

--- a/src/components/settings/keypair-manager.tsx
+++ b/src/components/settings/keypair-manager.tsx
@@ -32,7 +32,12 @@ interface Props {
   saving?: boolean;
 }
 
-export function KeypairManager({ onAddToProfile, saving }: Props) {
+/**
+ * All nyckel-state + WebCrypto/IndexedDB-effekter + åtgärder (generera,
+ * glöm, kopiera, lägg till i profil, registrera på GitHub). Bryts ut ur
+ * KeypairManager så komponenten blir en tunn render-shell.
+ */
+function useKeypair(onAddToProfile: Props["onAddToProfile"]) {
   const [supported, setSupported] = useState<boolean | null>(null);
   const [keypair, setKeypair] = useState<StoredKeypair | null>(null);
   const [sshString, setSshString] = useState<string>("");
@@ -138,10 +143,20 @@ export function KeypairManager({ onAddToProfile, saving }: Props) {
     });
   }, [comment, keypair]);
 
-  if (supported === null) {
+  return {
+    supported, keypair, sshString, fingerprint, comment, setComment,
+    busy, err, copied, registering, registeredOk,
+    onGenerate, onForget, onCopy, onAdd, onRegisterOnGithub,
+  };
+}
+
+export function KeypairManager({ onAddToProfile, saving }: Props) {
+  const k = useKeypair(onAddToProfile);
+
+  if (k.supported === null) {
     return <p className="text-xs text-gray-400">Kontrollerar webbläsarstöd…</p>;
   }
-  if (!supported) {
+  if (!k.supported) {
     return (
       <div className="bg-amber-50 border border-amber-200 rounded p-3 text-xs text-amber-900">
         Webbläsaren stöder inte WebCrypto Ed25519. Kräver Chrome 113+, Safari 17+ eller Firefox 130+.
@@ -156,7 +171,7 @@ export function KeypairManager({ onAddToProfile, saving }: Props) {
         <h3 className="text-sm font-semibold text-gray-900 flex items-center gap-2">
           <KeyRound size={14} /> Generera nyckel i browser
         </h3>
-        {!keypair && <GenerateKeyButton busy={busy} onGenerate={() => void onGenerate()} />}
+        {!k.keypair && <GenerateKeyButton busy={k.busy} onGenerate={() => void k.onGenerate()} />}
       </div>
 
       <p className="text-xs text-gray-600">
@@ -165,22 +180,22 @@ export function KeypairManager({ onAddToProfile, saving }: Props) {
         den lämnar aldrig den här enheten, inte ens via vår egen kod.
       </p>
 
-      {err && <p className="text-xs text-red-700">✗ {err}</p>}
+      {k.err && <p className="text-xs text-red-700">✗ {k.err}</p>}
 
-      {keypair && (
+      {k.keypair && (
         <KeypairPanel
-          comment={comment}
-          setComment={setComment}
-          sshString={sshString}
-          fingerprint={fingerprint}
-          copied={copied}
+          comment={k.comment}
+          setComment={k.setComment}
+          sshString={k.sshString}
+          fingerprint={k.fingerprint}
+          copied={k.copied}
           saving={saving}
-          registering={registering}
-          registeredOk={registeredOk}
-          onCopy={() => void onCopy()}
-          onAdd={onAdd}
-          onRegister={() => void onRegisterOnGithub()}
-          onForget={() => void onForget()}
+          registering={k.registering}
+          registeredOk={k.registeredOk}
+          onCopy={() => void k.onCopy()}
+          onAdd={k.onAdd}
+          onRegister={() => void k.onRegisterOnGithub()}
+          onForget={() => void k.onForget()}
         />
       )}
     </div>


### PR DESCRIPTION
## Vad

#6 ratchet-steg: `src/components/settings/keypair-manager.tsx` —
`KeypairManager` var ~150 rader (1 max-lines-per-function-suppression).

All nyckel-state, WebCrypto/IndexedDB-effekterna och åtgärderna
(generera / glöm / kopiera / lägg till i profil / registrera på GitHub)
flyttas till en **`useKeypair`**-hook. Komponenten blir en tunn render-shell
(~40 rader) — `GenerateKeyButton` + `KeypairPanel` var sedan tidigare utbrutna.

Beteendet är oförändrat. Suppressionen borttagen ur `eslint-suppressions.json`.

## Verifiering (CI-spegel lokalt)
- `bun run typecheck` — rent (efter `rm tsconfig.tsbuildinfo`)
- `bun run lint --max-warnings 0` — rent
- `bun run lint:prune` → `grep -c keypair-manager eslint-suppressions.json` = 0
- `bun run knip` — rent
- `bun test test/unit/components/keypair-manager.test.tsx` — 4 pass

Refs #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)