### PR TITLE
refactor(profile): bryt ut KeyList/AddKeyForm + useManualKeyAdd + test (#6)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -14,11 +14,6 @@
       "count": 1
     }
   },
-  "src/app/profile/page.tsx": {
-    "max-lines-per-function": {
-      "count": 1
-    }
-  },
   "src/components/documents/_document-row.tsx": {
     "max-depth": {
       "count": 1

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -173,10 +173,13 @@ interface KeysSectionProps {
   addingGenerated: boolean;
 }
 
-function KeysSection({ keys, onAdd, onRemove, addErr, onAddGenerated, addingGenerated }: KeysSectionProps) {
+/** Manuell paste-nyckel-state: parsning + add via tRPC, reset vid avbryt/klar. */
+function useManualKeyAdd(onAdd: (key: PublicKey) => void) {
   const [adding, setAdding] = useState(false);
   const [input, setInput] = useState("");
   const [comment, setComment] = useState("");
+
+  const cancel = () => { setAdding(false); setInput(""); setComment(""); };
 
   const tryAdd = async () => {
     const trimmed = input.trim();
@@ -193,10 +196,14 @@ function KeysSection({ keys, onAdd, onRemove, addErr, onAddGenerated, addingGene
       comment: comment || parsed.comment,
       addedAt: new Date().toISOString(),
     });
-    setInput("");
-    setComment("");
-    setAdding(false);
+    cancel();
   };
+
+  return { adding, setAdding, input, setInput, comment, setComment, cancel, tryAdd };
+}
+
+function KeysSection({ keys, onAdd, onRemove, addErr, onAddGenerated, addingGenerated }: KeysSectionProps) {
+  const add = useManualKeyAdd(onAdd);
 
   return (
     <section className="bg-white border border-gray-200 rounded-lg p-5 mb-5">
@@ -204,10 +211,10 @@ function KeysSection({ keys, onAdd, onRemove, addErr, onAddGenerated, addingGene
         <h2 className="font-semibold text-gray-900 flex items-center gap-2">
           <KeyRound size={16} /> Publika nycklar
         </h2>
-        {!adding && (
+        {!add.adding && (
           <button
             type="button"
-            onClick={() => setAdding(true)}
+            onClick={() => add.setAdding(true)}
             className="text-xs px-2 py-1 bg-white border border-gray-300 text-gray-700 rounded hover:bg-gray-50 inline-flex items-center gap-1"
           >
             <Plus size={12} /> Lägg till nyckel
@@ -219,7 +226,7 @@ function KeysSection({ keys, onAdd, onRemove, addErr, onAddGenerated, addingGene
         commits. Nycklarna är privata — bara du ser dem.
       </p>
 
-      {keys.length === 0 && !adding && (
+      {keys.length === 0 && !add.adding && (
         <p className="text-sm text-gray-400 italic mb-4">Inga nycklar registrerade ännu.</p>
       )}
 
@@ -230,70 +237,100 @@ function KeysSection({ keys, onAdd, onRemove, addErr, onAddGenerated, addingGene
         <code>ssh-keygen -t ed25519</code>):
       </div>
 
-      <ul className="space-y-2">
-        {keys.map((k) => (
-          <li key={k.fingerprint} className="flex items-start justify-between gap-3 py-2 border-b border-gray-100 last:border-0">
-            <div className="min-w-0">
-              <div className="text-sm font-mono text-gray-900">{k.fingerprint}</div>
-              <div className="text-xs text-gray-500 mt-0.5">
-                {k.type} {k.comment && `· ${k.comment}`}
-                <span className="ml-2 text-gray-400">tillagd {new Date(k.addedAt).toLocaleDateString("sv-SE")}</span>
-              </div>
-            </div>
-            <button
-              type="button"
-              onClick={() => { if (confirm(`Ta bort nyckeln ${k.fingerprint}?`)) onRemove(k.fingerprint); }}
-              className="text-xs text-gray-400 hover:text-red-600 inline-flex items-center gap-1"
-              title="Ta bort"
-            >
-              <Trash2 size={12} /> Ta bort
-            </button>
-          </li>
-        ))}
-      </ul>
+      <KeyList keys={keys} onRemove={onRemove} />
 
-      {adding && (
-        <div className="mt-4 bg-blue-50 border border-blue-200 rounded p-3 space-y-2">
-          <label className="block">
-            <span className="text-xs text-blue-900 mb-1 block">Publik nyckel (innehåll från ~/.ssh/id_ed25519.pub)</span>
-            <textarea
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              placeholder="ssh-ed25519 AAAA... du@dator"
-              rows={3}
-              className="w-full rounded border border-gray-300 px-2 py-1.5 text-xs font-mono"
-            />
-          </label>
-          <label className="block">
-            <span className="text-xs text-blue-900 mb-1 block">Kommentar (valfri, t.ex. enhetens namn)</span>
-            <input
-              type="text"
-              value={comment}
-              onChange={(e) => setComment(e.target.value)}
-              placeholder="MacBook Pro 2024"
-              className="w-full rounded border border-gray-300 px-2 py-1 text-xs"
-            />
-          </label>
-          {addErr && <p className="text-xs text-red-700">{addErr}</p>}
-          <div className="flex gap-2 justify-end">
-            <button
-              type="button"
-              onClick={() => { setAdding(false); setInput(""); setComment(""); }}
-              className="text-xs text-gray-500 hover:underline"
-            >
-              Avbryt
-            </button>
-            <button
-              type="button"
-              onClick={() => void tryAdd()}
-              className="px-3 py-1 text-xs bg-blue-600 text-white rounded hover:bg-blue-700"
-            >
-              Lägg till
-            </button>
-          </div>
-        </div>
+      {add.adding && (
+        <AddKeyForm
+          input={add.input}
+          setInput={add.setInput}
+          comment={add.comment}
+          setComment={add.setComment}
+          addErr={addErr}
+          onCancel={add.cancel}
+          onSubmit={() => void add.tryAdd()}
+        />
       )}
     </section>
+  );
+}
+
+/** Listan över registrerade publika nycklar (med ta-bort-bekräftelse). */
+function KeyList({ keys, onRemove }: { keys: PublicKey[]; onRemove: (fingerprint: string) => void }) {
+  return (
+    <ul className="space-y-2">
+      {keys.map((k) => (
+        <li key={k.fingerprint} className="flex items-start justify-between gap-3 py-2 border-b border-gray-100 last:border-0">
+          <div className="min-w-0">
+            <div className="text-sm font-mono text-gray-900">{k.fingerprint}</div>
+            <div className="text-xs text-gray-500 mt-0.5">
+              {k.type} {k.comment && `· ${k.comment}`}
+              <span className="ml-2 text-gray-400">tillagd {new Date(k.addedAt).toLocaleDateString("sv-SE")}</span>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => { if (confirm(`Ta bort nyckeln ${k.fingerprint}?`)) onRemove(k.fingerprint); }}
+            className="text-xs text-gray-400 hover:text-red-600 inline-flex items-center gap-1"
+            title="Ta bort"
+          >
+            <Trash2 size={12} /> Ta bort
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/** Formuläret för att klistra in en extern SSH-pubkey. */
+function AddKeyForm({ input, setInput, comment, setComment, addErr, onCancel, onSubmit }: {
+  input: string;
+  setInput: (v: string) => void;
+  comment: string;
+  setComment: (v: string) => void;
+  addErr: string | null;
+  onCancel: () => void;
+  onSubmit: () => void;
+}) {
+  return (
+    <div className="mt-4 bg-blue-50 border border-blue-200 rounded p-3 space-y-2">
+      <label className="block">
+        <span className="text-xs text-blue-900 mb-1 block">Publik nyckel (innehåll från ~/.ssh/id_ed25519.pub)</span>
+        <textarea
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="ssh-ed25519 AAAA... du@dator"
+          rows={3}
+          className="w-full rounded border border-gray-300 px-2 py-1.5 text-xs font-mono"
+        />
+      </label>
+      <label className="block">
+        <span className="text-xs text-blue-900 mb-1 block">Kommentar (valfri, t.ex. enhetens namn)</span>
+        <input
+          type="text"
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+          placeholder="MacBook Pro 2024"
+          className="w-full rounded border border-gray-300 px-2 py-1 text-xs"
+        />
+      </label>
+      {addErr && <p className="text-xs text-red-700">{addErr}</p>}
+      <div className="flex gap-2 justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="text-xs text-gray-500 hover:underline"
+        >
+          Avbryt
+        </button>
+        <button
+          type="button"
+          onClick={onSubmit}
+          className="px-3 py-1 text-xs bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          Lägg till
+        </button>
+      </div>
+    </div>
   );
 }
 

--- a/test/unit/app/profile/page.test.tsx
+++ b/test/unit/app/profile/page.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * Test för ProfilePage — egen profil: uppgifts-formulär (hydreras från
+ * user.current) + publika nycklar (lista, ta bort, manuell paste-add).
+ *
+ * KeypairManager (WebCrypto/IndexedDB) och IntegrationsSection (tRPC) stubbas
+ * — de testas separat; här verifierar vi profil-sidans egen logik.
+ */
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest-compat";
+import ProfilePage from "@/app/profile/page";
+
+vi.mock("@/components/settings/keypair-manager", () => ({
+  KeypairManager: () => <div data-testid="keypair-manager-stub" />,
+}));
+vi.mock("@/components/settings/integrations-section", () => ({
+  IntegrationsSection: () => <div data-testid="integrations-stub" />,
+}));
+
+const meData = {
+  id: "u1",
+  name: "Anna Advokat",
+  title: "Advokat",
+  email: "anna@firma.se",
+  role: "LAWYER",
+  publicKeys: [
+    { fingerprint: "SHA256:abc123", type: "ssh-ed25519", comment: "mac", addedAt: "2026-01-01T00:00:00Z" },
+  ],
+};
+const meQuery = { data: meData as unknown, isLoading: false };
+const updateMutate = vi.fn();
+const addMutate = vi.fn();
+const removeMutate = vi.fn();
+
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: {
+    useUtils: () => ({ user: { current: { invalidate: vi.fn() } } }),
+    user: {
+      current: { useQuery: () => meQuery },
+      update: { useMutation: () => ({ mutate: updateMutate, isPending: false, error: null }) },
+      addKey: { useMutation: () => ({ mutate: addMutate, isPending: false, error: null }) },
+      removeKey: { useMutation: () => ({ mutate: removeMutate, isPending: false, error: null }) },
+    },
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ProfilePage", () => {
+  it("renderar rubrik + hydrerar formuläret från user.current", async () => {
+    render(<ProfilePage />);
+    expect(screen.getByText("Min profil")).toBeInTheDocument();
+    expect(await screen.findByDisplayValue("Anna Advokat")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("anna@firma.se")).toBeInTheDocument();
+  });
+
+  it("visar registrerade nycklar", () => {
+    render(<ProfilePage />);
+    expect(screen.getByText("SHA256:abc123")).toBeInTheDocument();
+  });
+
+  it("Spara → update.mutate med formulärvärdena", async () => {
+    render(<ProfilePage />);
+    await screen.findByDisplayValue("Anna Advokat");
+    fireEvent.click(screen.getByRole("button", { name: /^Spara$/ }));
+    expect(updateMutate).toHaveBeenCalledWith({
+      id: "u1",
+      name: "Anna Advokat",
+      title: "Advokat",
+      email: "anna@firma.se",
+    });
+  });
+
+  it("Lägg till nyckel öppnar paste-formuläret; Avbryt stänger det", async () => {
+    render(<ProfilePage />);
+    await screen.findByDisplayValue("Anna Advokat");
+    fireEvent.click(screen.getByRole("button", { name: /Lägg till nyckel/ }));
+    expect(screen.getByPlaceholderText(/ssh-ed25519 AAAA/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Avbryt/ }));
+    await waitFor(() => expect(screen.queryByPlaceholderText(/ssh-ed25519 AAAA/)).not.toBeInTheDocument());
+  });
+
+  it("Ta bort nyckel med confirm → removeKey.mutate", async () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    render(<ProfilePage />);
+    await screen.findByDisplayValue("Anna Advokat");
+    fireEvent.click(screen.getByRole("button", { name: /Ta bort/ }));
+    expect(removeMutate).toHaveBeenCalledWith({ fingerprint: "SHA256:abc123" });
+    confirmSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Vad

#6 ratchet-steg: `src/app/profile/page.tsx` — `KeysSection` var ~120 rader
(1 max-lines-per-function-suppression).

Bryts ned i:
- **`useManualKeyAdd`** — paste-nyckel-state + SSH-parsning + add via tRPC.
- **`KeyList`** — listan över registrerade nycklar (med ta-bort-bekräftelse).
- **`AddKeyForm`** — formuläret för att klistra in en extern SSH-pubkey.

`KeysSection` blir en tunn shell.

Filen saknade test → la till **`test/unit/app/profile/page.test.tsx`** (5 fall):
rubrik + formulär-hydrering från `user.current`, nyckellista, Spara →
`update.mutate` med formulärvärdena, "Lägg till nyckel" öppnar/avbryter
paste-formuläret, ta bort → `removeKey.mutate`. `KeypairManager` +
`IntegrationsSection` stubbade (testas separat).

Suppressionen borttagen ur `eslint-suppressions.json`.

## Verifiering (CI-spegel lokalt)
- `bun run typecheck` — rent (efter `rm tsconfig.tsbuildinfo`)
- `bun run lint --max-warnings 0` — rent
- `bun run lint:prune` → `grep -c profile/page eslint-suppressions.json` = 0
- `bun run knip` — rent
- `bun test test/unit/app/profile/page.test.tsx` — 5 pass (ny coverage)

Refs #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)