### PR TITLE
refactor(payment-plans): bryt ut detalj-sektioner + test (#6)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -9,11 +9,6 @@
       "count": 1
     }
   },
-  "src/app/payment-plans/[id]/_client.tsx": {
-    "max-lines-per-function": {
-      "count": 1
-    }
-  },
   "src/components/documents/_document-row.tsx": {
     "max-depth": {
       "count": 1

--- a/src/app/payment-plans/[id]/_client.tsx
+++ b/src/app/payment-plans/[id]/_client.tsx
@@ -19,7 +19,6 @@ const STATUS_PILL: Record<string, string> = {
   CANCELLED: "bg-red-100 text-red-800",
 };
 
-// eslint-disable-next-line complexity
 export default function PaymentPlanDetailClient({ id: paramId }: { id: string }) {
   const id = useRouteId() ?? paramId;
   const plan = trpc.paymentPlan.getById.useQuery({ id });
@@ -36,8 +35,6 @@ export default function PaymentPlanDetailClient({ id: paramId }: { id: string })
   if (!plan.data) return null;
   const p = plan.data as PlanDetail;
 
-  const klient = p.invoice?.matter?.contacts?.[0]?.contact?.name ?? "—";
-
   return (
     <div className="max-w-3xl">
       <div className="mb-4">
@@ -46,139 +43,188 @@ export default function PaymentPlanDetailClient({ id: paramId }: { id: string })
         </Link>
       </div>
 
-      <div className="flex items-start justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
-            <Wallet size={22} /> Avbetalningsplan
-          </h1>
-          <p className="text-sm text-gray-500 mt-1">
-            {p.invoice?.matter?.id ? (
-              <EntityLink route="matters" id={p.invoice.matter.id} className="text-blue-600 hover:underline">
-                {p.invoice.matter.matterNumber ?? "—"}
-              </EntityLink>
-            ) : (
-              <span>{p.invoice?.matter?.matterNumber ?? "—"}</span>
-            )}
-            {" · "}{p.invoice?.matter?.title ?? "—"}{" · "}{klient}
-          </p>
-        </div>
-        <span className={`text-xs uppercase font-medium rounded px-2 py-1 ${STATUS_PILL[p.status] ?? "bg-gray-100 text-gray-700"}`}>
-          {STATUS_LABEL[p.status] ?? p.status}
-        </span>
-      </div>
+      <PlanHeader p={p} />
+      <PlanSummaryCard p={p} onCancel={() => cancel.mutate({ planId: p.id })} cancelling={cancel.isPending} />
+      <PaymentsSection invoice={p.invoice} />
+      <RemindersSection reminders={p.reminders} />
+    </div>
+  );
+}
 
-      <div className="bg-white border border-gray-200 rounded-lg p-5 mb-6">
-        <dl className="grid grid-cols-2 gap-y-3 text-sm">
-          <dt className="text-gray-500">Månadsbelopp</dt>
-          <dd className="font-mono text-gray-900">{formatCurrency(p.monthlyAmount)}</dd>
-          <dt className="text-gray-500">Förfaller</dt>
-          <dd className="text-gray-900">Den {p.dayOfMonth}:e varje månad</dd>
-          <dt className="text-gray-500">Startdatum</dt>
-          <dd className="text-gray-900">{new Date(p.startDate).toLocaleDateString("sv-SE")}</dd>
-          <dt className="text-gray-500">Faktura</dt>
-          <dd>
-            {p.invoice?.id ? (
-              <EntityLink route="invoices" id={p.invoice.id} className="text-blue-600 hover:underline">
-                {p.invoice.id}
-              </EntityLink>
-            ) : (
-              <span>—</span>
-            )}
-            {" · "}
-            <span className="font-mono">{p.invoice ? formatCurrency(p.invoice.amount) : ""}</span>
-          </dd>
-          {p.notes && (
-            <>
-              <dt className="text-gray-500">Anteckningar</dt>
-              <dd className="text-gray-900">{p.notes}</dd>
-            </>
+type PlanMatter = NonNullable<NonNullable<PlanDetail["invoice"]>["matter"]>;
+
+function klientName(m: PlanMatter | undefined): string {
+  return m?.contacts?.[0]?.contact?.name ?? "—";
+}
+
+function statusPillView(status: string): { label: string; cls: string } {
+  return {
+    label: STATUS_LABEL[status] ?? status,
+    cls: STATUS_PILL[status] ?? "bg-gray-100 text-gray-700",
+  };
+}
+
+/** Ärende-referensen: länk om ärende-id finns, annars enbart numret. */
+function MatterRef({ m }: { m: PlanMatter | undefined }) {
+  const number = m?.matterNumber ?? "—";
+  if (m?.id) {
+    return (
+      <EntityLink route="matters" id={m.id} className="text-blue-600 hover:underline">
+        {number}
+      </EntityLink>
+    );
+  }
+  return <span>{number}</span>;
+}
+
+/** Rubrik: titel, länk till ärende/klient och status-pill. */
+function PlanHeader({ p }: { p: PlanDetail }) {
+  const m = p.invoice?.matter;
+  const pill = statusPillView(p.status);
+  return (
+    <div className="flex items-start justify-between mb-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+          <Wallet size={22} /> Avbetalningsplan
+        </h1>
+        <p className="text-sm text-gray-500 mt-1">
+          <MatterRef m={m} />
+          {" · "}{m?.title ?? "—"}{" · "}{klientName(m)}
+        </p>
+      </div>
+      <span className={`text-xs uppercase font-medium rounded px-2 py-1 ${pill.cls}`}>
+        {pill.label}
+      </span>
+    </div>
+  );
+}
+
+/** Plan-detaljer (belopp, förfallodag, faktura) + avbryt-knapp för aktiv plan. */
+function PlanSummaryCard({ p, onCancel, cancelling }: { p: PlanDetail; onCancel: () => void; cancelling: boolean }) {
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-5 mb-6">
+      <dl className="grid grid-cols-2 gap-y-3 text-sm">
+        <dt className="text-gray-500">Månadsbelopp</dt>
+        <dd className="font-mono text-gray-900">{formatCurrency(p.monthlyAmount)}</dd>
+        <dt className="text-gray-500">Förfaller</dt>
+        <dd className="text-gray-900">Den {p.dayOfMonth}:e varje månad</dd>
+        <dt className="text-gray-500">Startdatum</dt>
+        <dd className="text-gray-900">{new Date(p.startDate).toLocaleDateString("sv-SE")}</dd>
+        <dt className="text-gray-500">Faktura</dt>
+        <dd>
+          {p.invoice?.id ? (
+            <EntityLink route="invoices" id={p.invoice.id} className="text-blue-600 hover:underline">
+              {p.invoice.id}
+            </EntityLink>
+          ) : (
+            <span>—</span>
           )}
-        </dl>
-
-        {p.status === "ACTIVE" && (
-          <div className="mt-5 pt-4 border-t border-gray-100">
-            <button
-              type="button"
-              onClick={() => {
-                if (confirm("Avbryta avbetalningsplanen? Fakturan återgår till status SENT.")) {
-                  cancel.mutate({ planId: p.id });
-                }
-              }}
-              disabled={cancel.isPending}
-              className="inline-flex items-center gap-2 px-3 py-1.5 text-sm bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50"
-            >
-              <Ban size={14} /> {cancel.isPending ? "Avbryter…" : "Avbryt planen"}
-            </button>
-          </div>
-        )}
-      </div>
-
-      <section className="mb-6">
-        <h2 className="text-sm font-semibold text-gray-700 mb-2">Inbetalningar</h2>
-        {(p.invoice?.payments ?? []).length === 0 ? (
-          <p className="text-sm text-gray-500 italic">Inga inbetalningar registrerade än.</p>
-        ) : (
+          {" · "}
+          <span className="font-mono">{p.invoice ? formatCurrency(p.invoice.amount) : ""}</span>
+        </dd>
+        {p.notes && (
           <>
-            <ul className="divide-y divide-gray-100 bg-white border border-gray-200 rounded-lg">
-              {(p.invoice?.payments ?? []).map((pay) => (
-                <li key={pay.id} className="px-4 py-2 text-sm flex items-center justify-between">
-                  <span className="text-gray-700">
-                    {new Date(pay.paidAt).toLocaleDateString("sv-SE")}
-                    {pay.note && <span className="ml-2 text-xs text-gray-500">{pay.note}</span>}
-                  </span>
-                  <span className="font-mono text-gray-900">{formatCurrency(pay.amount)}</span>
-                </li>
-              ))}
-            </ul>
-            <div className="mt-2 text-xs text-gray-500 flex justify-between">
-              <span>{(p.invoice?.payments ?? []).length} st inbetalningar</span>
-              <span>
-                Totalt betalt:{" "}
-                <span className="font-mono text-gray-900">
-                  {formatCurrency((p.invoice?.payments ?? []).reduce((s, x) => s + x.amount, 0))}
-                </span>
-                {" av "}
-                <span className="font-mono">{p.invoice ? formatCurrency(p.invoice.amount) : ""}</span>
-              </span>
-            </div>
-            {p.invoice && (
-              <div className="mt-1 text-xs flex justify-end gap-1">
-                <span className="text-gray-500">Utestående:</span>
-                <span className="font-mono font-semibold text-gray-900">
-                  {formatCurrency(computeInvoiceLedger(
-                    p.invoice.amount,
-                    (p.invoice.payments ?? []).reduce((s, x) => s + x.amount, 0),
-                    0,
-                    ((p.invoice as { writeOffs?: Array<{ amount: number }> }).writeOffs ?? []).reduce((s, w) => s + w.amount, 0),
-                  ).outstanding)}
-                </span>
-              </div>
-            )}
+            <dt className="text-gray-500">Anteckningar</dt>
+            <dd className="text-gray-900">{p.notes}</dd>
           </>
         )}
-      </section>
+      </dl>
 
-      <section>
-        <h2 className="text-sm font-semibold text-gray-700 mb-2">Påminnelser</h2>
-        {p.reminders.length === 0 ? (
-          <p className="text-sm text-gray-500 italic">Inga påminnelser skickade än.</p>
-        ) : (
+      {p.status === "ACTIVE" && (
+        <div className="mt-5 pt-4 border-t border-gray-100">
+          <button
+            type="button"
+            onClick={() => {
+              if (confirm("Avbryta avbetalningsplanen? Fakturan återgår till status SENT.")) onCancel();
+            }}
+            disabled={cancelling}
+            className="inline-flex items-center gap-2 px-3 py-1.5 text-sm bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50"
+          >
+            <Ban size={14} /> {cancelling ? "Avbryter…" : "Avbryt planen"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+type PlanInvoice = NonNullable<PlanDetail["invoice"]>;
+
+/** Inbetalningar mot fakturan: lista, summa och utestående saldo. */
+function PaymentsSection({ invoice }: { invoice: PlanDetail["invoice"] }) {
+  const payments = invoice?.payments ?? [];
+  return (
+    <section className="mb-6">
+      <h2 className="text-sm font-semibold text-gray-700 mb-2">Inbetalningar</h2>
+      {payments.length === 0 ? (
+        <p className="text-sm text-gray-500 italic">Inga inbetalningar registrerade än.</p>
+      ) : (
+        <>
           <ul className="divide-y divide-gray-100 bg-white border border-gray-200 rounded-lg">
-            {p.reminders.map((r) => (
-              <li key={r.id} className="px-4 py-2 text-sm flex items-center justify-between">
-                <span>
-                  <span className="font-mono text-gray-700">{r.dueMonth}</span>
-                  <span className="ml-2 text-[10px] uppercase rounded bg-gray-100 text-gray-600 px-1.5 py-0.5">{r.type}</span>
+            {payments.map((pay) => (
+              <li key={pay.id} className="px-4 py-2 text-sm flex items-center justify-between">
+                <span className="text-gray-700">
+                  {new Date(pay.paidAt).toLocaleDateString("sv-SE")}
+                  {pay.note && <span className="ml-2 text-xs text-gray-500">{pay.note}</span>}
                 </span>
-                <span className="text-xs text-gray-500">
-                  Skickad {new Date(r.sentAt).toLocaleString("sv-SE")}
-                </span>
+                <span className="font-mono text-gray-900">{formatCurrency(pay.amount)}</span>
               </li>
             ))}
           </ul>
-        )}
-      </section>
+          <div className="mt-2 text-xs text-gray-500 flex justify-between">
+            <span>{payments.length} st inbetalningar</span>
+            <span>
+              Totalt betalt:{" "}
+              <span className="font-mono text-gray-900">
+                {formatCurrency(payments.reduce((s, x) => s + x.amount, 0))}
+              </span>
+              {" av "}
+              <span className="font-mono">{invoice ? formatCurrency(invoice.amount) : ""}</span>
+            </span>
+          </div>
+          {invoice && <OutstandingRow invoice={invoice} payments={payments} />}
+        </>
+      )}
+    </section>
+  );
+}
+
+/** Utestående-raden: faktura-belopp minus betalningar och ev. avskrivningar. */
+function OutstandingRow({ invoice, payments }: { invoice: PlanInvoice; payments: NonNullable<PlanInvoice["payments"]> }) {
+  const paid = payments.reduce((s, x) => s + x.amount, 0);
+  const writtenOff = ((invoice as { writeOffs?: Array<{ amount: number }> }).writeOffs ?? []).reduce((s, w) => s + w.amount, 0);
+  const { outstanding } = computeInvoiceLedger(invoice.amount, paid, 0, writtenOff);
+  return (
+    <div className="mt-1 text-xs flex justify-end gap-1">
+      <span className="text-gray-500">Utestående:</span>
+      <span className="font-mono font-semibold text-gray-900">{formatCurrency(outstanding)}</span>
     </div>
+  );
+}
+
+/** Skickade påminnelser för planen. */
+function RemindersSection({ reminders }: { reminders: PlanDetail["reminders"] }) {
+  return (
+    <section>
+      <h2 className="text-sm font-semibold text-gray-700 mb-2">Påminnelser</h2>
+      {reminders.length === 0 ? (
+        <p className="text-sm text-gray-500 italic">Inga påminnelser skickade än.</p>
+      ) : (
+        <ul className="divide-y divide-gray-100 bg-white border border-gray-200 rounded-lg">
+          {reminders.map((r) => (
+            <li key={r.id} className="px-4 py-2 text-sm flex items-center justify-between">
+              <span>
+                <span className="font-mono text-gray-700">{r.dueMonth}</span>
+                <span className="ml-2 text-[10px] uppercase rounded bg-gray-100 text-gray-600 px-1.5 py-0.5">{r.type}</span>
+              </span>
+              <span className="text-xs text-gray-500">
+                Skickad {new Date(r.sentAt).toLocaleString("sv-SE")}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
   );
 }
 

--- a/test/unit/app/payment-plans/detail-client.test.tsx
+++ b/test/unit/app/payment-plans/detail-client.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Test för PaymentPlanDetailClient — detaljvyn för en avbetalningsplan:
+ * rubrik/status, plan-detaljer, inbetalningar (summa + utestående),
+ * påminnelser och avbryt-flödet.
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest-compat";
+import PaymentPlanDetailClient from "@/app/payment-plans/[id]/_client";
+
+vi.mock("@/lib/client/demo/use-route-id", () => ({ useRouteId: () => null }));
+vi.mock("@/lib/client/demo/entity-link", () => ({
+  EntityLink: ({ children }: { children: React.ReactNode }) => <a href="#">{children}</a>,
+}));
+
+const planData = {
+  id: "pp1",
+  status: "ACTIVE",
+  monthlyAmount: 100000, // 1 000 kr (öre)
+  dayOfMonth: 28,
+  startDate: "2026-01-01",
+  notes: "Delas upp på 6 mån",
+  invoice: {
+    id: "inv1",
+    amount: 600000, // 6 000 kr
+    matter: { id: "m1", matterNumber: "2026-0001", title: "Tvist AB", contacts: [{ contact: { id: "c1", name: "Anna Klient" } }] },
+    payments: [
+      { id: "pay1", amount: 100000, paidAt: "2026-02-28", note: "feb" },
+      { id: "pay2", amount: 100000, paidAt: "2026-03-28", note: null },
+    ],
+  },
+  reminders: [{ id: "r1", dueMonth: "2026-04", type: "EMAIL", sentAt: "2026-04-01T08:00:00Z" }],
+};
+
+const planQuery = { data: planData as unknown, isLoading: false, error: null as null | { message: string } };
+const cancelMutate = vi.fn();
+
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: {
+    useUtils: () => ({ paymentPlan: { getById: { invalidate: vi.fn() }, list: { invalidate: vi.fn() } } }),
+    paymentPlan: {
+      getById: { useQuery: () => planQuery },
+      cancel: { useMutation: () => ({ mutate: cancelMutate, isPending: false }) },
+    },
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  planQuery.data = planData;
+  planQuery.isLoading = false;
+  planQuery.error = null;
+});
+
+describe("PaymentPlanDetailClient", () => {
+  it("visar laddar-tillstånd", () => {
+    planQuery.isLoading = true;
+    render(<PaymentPlanDetailClient id="pp1" />);
+    expect(screen.getByText("Laddar…")).toBeInTheDocument();
+  });
+
+  it("renderar rubrik, klient och status-pill", () => {
+    render(<PaymentPlanDetailClient id="pp1" />);
+    expect(screen.getByText("Avbetalningsplan")).toBeInTheDocument();
+    expect(screen.getByText(/Anna Klient/)).toBeInTheDocument();
+    expect(screen.getByText("Aktiv")).toBeInTheDocument();
+  });
+
+  it("visar inbetalningar med antal, summa och utestående saldo", () => {
+    render(<PaymentPlanDetailClient id="pp1" />);
+    expect(screen.getByText(/2 st inbetalningar/)).toBeInTheDocument();
+    // betalt 2 000 kr av 6 000 → utestående 4 000 kr
+    expect(screen.getByText(/Utestående:/)).toBeInTheDocument();
+  });
+
+  it("visar påminnelser", () => {
+    render(<PaymentPlanDetailClient id="pp1" />);
+    expect(screen.getByText("2026-04")).toBeInTheDocument();
+  });
+
+  it("Avbryt-knappen (aktiv plan) → confirm → cancel.mutate med planId", () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    render(<PaymentPlanDetailClient id="pp1" />);
+    fireEvent.click(screen.getByRole("button", { name: /Avbryt planen/ }));
+    expect(cancelMutate).toHaveBeenCalledWith({ planId: "pp1" });
+    confirmSpy.mockRestore();
+  });
+
+  it("ingen avbryt-knapp när planen inte är aktiv", () => {
+    planQuery.data = { ...planData, status: "COMPLETED" };
+    render(<PaymentPlanDetailClient id="pp1" />);
+    expect(screen.queryByRole("button", { name: /Avbryt planen/ })).not.toBeInTheDocument();
+    expect(screen.getByText("Slutförd")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Vad

#6 ratchet-steg: `src/app/payment-plans/[id]/_client.tsx` —
`PaymentPlanDetailClient` var ~160 rader (1 max-lines-per-function-suppression)
med en inline `// eslint-disable complexity`.

Bryts ned i:
- **`PlanHeader`** + helpers **`MatterRef`** / **`klientName`** /
  **`statusPillView`** — så optional-chain-/nullish-komplexiteten (som
  ESLint:s `complexity` räknar) inte koncentreras i en funktion.
- **`PlanSummaryCard`** — belopp/förfallodag/faktura + avbryt-knapp.
- **`PaymentsSection`** + **`OutstandingRow`** — inbetalningar, summa, saldo.
- **`RemindersSection`** — skickade påminnelser.

Huvudkomponenten blir en tunn shell — inline-disablen behövs inte längre.

Filen saknade direkt test (page-testet täcker list-sidan) → la till
**`test/unit/app/payment-plans/detail-client.test.tsx`** (6 fall): laddar,
rubrik/klient/status, inbetalningar + utestående saldo, påminnelser, avbryt →
`cancel.mutate({ planId })`, ingen avbryt-knapp när planen ej är aktiv.
`trpc`/`useRouteId`/`EntityLink` stubbade.

Suppressionen borttagen ur `eslint-suppressions.json`.

## Verifiering (CI-spegel lokalt)
- `bun run typecheck` — rent (efter `rm tsconfig.tsbuildinfo`)
- `bun run lint --max-warnings 0` — rent (complexity 16 → uppdelad < 8)
- `bun run lint:prune` → `grep -c payment-plans eslint-suppressions.json` = 0
- `bun run knip` — rent
- `bun test …/detail-client.test.tsx` — 6 pass (ny coverage)

Refs #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)