### PR TITLE
refactor(matters): lyft ut expenseColumns/footer ur ExpenseSection + test (#6)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,9 +1,4 @@
 {
-  "src/app/matters/[id]/_expense-section.tsx": {
-    "max-lines-per-function": {
-      "count": 1
-    }
-  },
   "src/app/matters/[id]/_kostnadsrakning-modal.tsx": {
     "max-lines-per-function": {
       "count": 1

--- a/src/app/matters/[id]/_expense-section.tsx
+++ b/src/app/matters/[id]/_expense-section.tsx
@@ -86,45 +86,20 @@ function computeTotals(expenses: Expense[]): { exclVat: number; vat: number; inc
 }
 
  
-export function ExpenseSection({ matterId, isTaxeArende }: Props) {
-  const utils = trpc.useUtils();
-  const expenses = trpc.expense.list.useQuery({ matterId });
-  const [showCreate, setShowCreate] = useState(false);
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [form, setForm] = useState<ExpenseForm>(initialForm);
+function vatOf(e: Expense) {
+  return splitVat({ amount: e.amount, vatRate: e.vatRate ?? 2500, vatIncluded: e.vatIncluded ?? true });
+}
+function invoiceLabel(e: Expense): string {
+  return e.invoice?.invoiceNumber ?? (e.invoiceId ? "(faktura)" : "Ej fakturerad");
+}
+function isInvoiced(e: Expense): boolean {
+  return e.invoiceId != null && e.invoiceId !== "";
+}
 
-  function resetClose(): void {
-    setShowCreate(false);
-    setEditingId(null);
-    setForm(initialForm());
-  }
-
-  const createExpense = trpc.expense.create.useMutation({ onSuccess: () => { void utils.expense.list.invalidate({ matterId }); resetClose(); } });
-  const updateExpense = trpc.expense.update.useMutation({ onSuccess: () => { void utils.expense.list.invalidate({ matterId }); resetClose(); } });
-  const deleteExpense = trpc.expense.delete.useMutation({ onSuccess: () => void utils.expense.list.invalidate({ matterId }) });
-
-  function startEdit(e: Expense): void {
-    setEditingId(e.id);
-    setForm(toForm(e));
-  }
-
-  function submitForm(): void {
-    const payload = payloadOf(form);
-    if (editingId) updateExpense.mutate({ id: editingId, ...payload });
-    else createExpense.mutate({ matterId, ...payload });
-  }
-
-  const items = (expenses.data?.expenses ?? []) as Expense[];
-  const isPending = createExpense.isPending || updateExpense.isPending;
-
-  function vatOf(e: Expense) {
-    return splitVat({ amount: e.amount, vatRate: e.vatRate ?? 2500, vatIncluded: e.vatIncluded ?? true });
-  }
-  function invoiceLabel(e: Expense): string {
-    return e.invoice?.invoiceNumber ?? (e.invoiceId ? "(faktura)" : "Ej fakturerad");
-  }
-  const isInvoiced = (e: Expense): boolean => e.invoiceId != null && e.invoiceId !== "";
-  const columns: Column<Expense>[] = [
+/** Tabell-kolumnerna för utläggslistan. Redigera/ta-bort låsta för
+ *  fakturerade utlägg (de sitter på en utställd faktura). */
+function expenseColumns({ onEdit, onDelete }: { onEdit: (e: Expense) => void; onDelete: (id: string) => void }): Column<Expense>[] {
+  return [
     { key: "date", label: "Datum", sortable: true, filterable: true, sortValue: (e) => new Date(e.date),
       filterValue: (e) => new Date(e.date).toLocaleDateString("sv-SE"),
       render: (e) => <span className="text-sm text-gray-500 whitespace-nowrap">{new Date(e.date).toLocaleDateString("sv-SE")}</span> },
@@ -159,22 +134,57 @@ export function ExpenseSection({ matterId, isTaxeArende }: Props) {
         isInvoiced(e)
           ? <span className="text-xs text-gray-400 italic">Låst (på faktura)</span>
           : <span className="whitespace-nowrap">
-              <button onClick={() => startEdit(e)} className="text-xs text-gray-500 hover:text-blue-600 hover:underline mr-3">Ändra</button>
-              <button onClick={() => { if (confirm("Ta bort utlägget?")) deleteExpense.mutate({ id: e.id }); }} className="text-xs text-red-500 hover:underline">Ta bort</button>
+              <button onClick={() => onEdit(e)} className="text-xs text-gray-500 hover:text-blue-600 hover:underline mr-3">Ändra</button>
+              <button onClick={() => { if (confirm("Ta bort utlägget?")) onDelete(e.id); }} className="text-xs text-red-500 hover:underline">Ta bort</button>
             </span>
       ),
     },
   ];
+}
 
-  function footerContent(rows: Expense[]): Partial<Record<string, React.ReactNode>> {
-    const t = computeTotals(rows);
-    return {
-      description: <span className="text-gray-700">Summa</span>,
-      exclVat: <span className="font-mono text-gray-900">{formatCurrency(t.exclVat)}</span>,
-      vat: <span className="font-mono text-gray-700">{formatCurrency(t.vat)}</span>,
-      inclVat: <span className="font-mono text-gray-900">{formatCurrency(t.inclVat)}</span>,
-    };
+/** Summa-rad (footer) för utläggstabellen. */
+function expenseFooter(rows: Expense[]): Partial<Record<string, React.ReactNode>> {
+  const t = computeTotals(rows);
+  return {
+    description: <span className="text-gray-700">Summa</span>,
+    exclVat: <span className="font-mono text-gray-900">{formatCurrency(t.exclVat)}</span>,
+    vat: <span className="font-mono text-gray-700">{formatCurrency(t.vat)}</span>,
+    inclVat: <span className="font-mono text-gray-900">{formatCurrency(t.inclVat)}</span>,
+  };
+}
+
+export function ExpenseSection({ matterId, isTaxeArende }: Props) {
+  const utils = trpc.useUtils();
+  const expenses = trpc.expense.list.useQuery({ matterId });
+  const [showCreate, setShowCreate] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [form, setForm] = useState<ExpenseForm>(initialForm);
+
+  function resetClose(): void {
+    setShowCreate(false);
+    setEditingId(null);
+    setForm(initialForm());
   }
+
+  const createExpense = trpc.expense.create.useMutation({ onSuccess: () => { void utils.expense.list.invalidate({ matterId }); resetClose(); } });
+  const updateExpense = trpc.expense.update.useMutation({ onSuccess: () => { void utils.expense.list.invalidate({ matterId }); resetClose(); } });
+  const deleteExpense = trpc.expense.delete.useMutation({ onSuccess: () => void utils.expense.list.invalidate({ matterId }) });
+
+  function startEdit(e: Expense): void {
+    setEditingId(e.id);
+    setForm(toForm(e));
+  }
+
+  function submitForm(): void {
+    const payload = payloadOf(form);
+    if (editingId) updateExpense.mutate({ id: editingId, ...payload });
+    else createExpense.mutate({ matterId, ...payload });
+  }
+
+  const items = (expenses.data?.expenses ?? []) as Expense[];
+  const isPending = createExpense.isPending || updateExpense.isPending;
+
+  const columns = expenseColumns({ onEdit: startEdit, onDelete: (id) => deleteExpense.mutate({ id }) });
 
   return (
     <div className="bg-white rounded-lg border border-gray-200 lg:col-span-2">
@@ -195,7 +205,7 @@ export function ExpenseSection({ matterId, isTaxeArende }: Props) {
           data={items}
           rowKey={(e) => e.id}
           emptyMessage="Inga utlägg registrerade"
-          footer={footerContent}
+          footer={expenseFooter}
         />
       </div>
 

--- a/test/unit/app/matters/expense-section.test.tsx
+++ b/test/unit/app/matters/expense-section.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Test för ExpenseSection — utläggslistan i ett ärende: rendering av rader +
+ * moms-uppdelning, summa-footer, lås av fakturerade utlägg, ta-bort-flödet
+ * och "Nytt utlägg"-modalen.
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest-compat";
+import { ExpenseSection } from "@/app/matters/[id]/_expense-section";
+
+vi.mock("@/lib/client/demo/entity-link", () => ({
+  EntityLink: ({ children }: { children: React.ReactNode }) => <a href="#">{children}</a>,
+}));
+
+const expenseQuery = {
+  data: {
+    expenses: [
+      { id: "e1", date: "2026-03-01", amount: 12500, description: "Tågbiljett", billable: true, user: { name: "Anna" }, vatRate: 2500, vatIncluded: true, invoiceId: null },
+      { id: "e2", date: "2026-03-02", amount: 50000, description: "Domstolsavgift", billable: true, user: { name: "Anna" }, vatRate: 2500, vatIncluded: true, invoiceId: "inv9", invoice: { id: "inv9", invoiceNumber: "F-2026-0001" } },
+    ],
+    totalAmount: 62500,
+  } as unknown,
+  isLoading: false,
+};
+const createMutate = vi.fn();
+const updateMutate = vi.fn();
+const deleteMutate = vi.fn();
+const noopMut = () => ({ mutate: vi.fn(), isPending: false });
+
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: {
+    useUtils: () => ({ expense: { list: { invalidate: vi.fn() } } }),
+    expense: {
+      list: { useQuery: () => expenseQuery },
+      create: { useMutation: () => ({ mutate: createMutate, isPending: false }) },
+      update: { useMutation: () => ({ mutate: updateMutate, isPending: false }) },
+      delete: { useMutation: () => ({ mutate: deleteMutate, isPending: false }) },
+    },
+    prefs: {
+      get: { useQuery: () => ({ data: undefined, isLoading: false }) },
+      save: { useMutation: noopMut },
+      clear: { useMutation: noopMut },
+      setOrgDefault: { useMutation: noopMut },
+      clearOrgDefault: { useMutation: noopMut },
+    },
+    user: { current: { useQuery: () => ({ data: { id: "u1", role: "LAWYER" } }) } },
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ExpenseSection", () => {
+  it("renderar rubrik med total och utläggsraderna", () => {
+    render(<ExpenseSection matterId="m1" />);
+    expect(screen.getByText("Utlägg")).toBeInTheDocument();
+    expect(screen.getByText(/totalt/)).toBeInTheDocument();
+    expect(screen.getByText("Tågbiljett")).toBeInTheDocument();
+    expect(screen.getByText("Domstolsavgift")).toBeInTheDocument();
+  });
+
+  it("visar summa-footer", () => {
+    render(<ExpenseSection matterId="m1" />);
+    expect(screen.getByText("Summa")).toBeInTheDocument();
+  });
+
+  it("låser fakturerade utlägg (ingen ändra/ta-bort) men tillåter åtgärder på ej fakturerade", () => {
+    render(<ExpenseSection matterId="m1" />);
+    expect(screen.getByText("Låst (på faktura)")).toBeInTheDocument();
+    // Endast det ofakturerade utlägget (e1) har Ändra/Ta bort.
+    expect(screen.getByText("Ändra")).toBeInTheDocument();
+    expect(screen.getByText("Ta bort")).toBeInTheDocument();
+  });
+
+  it("Ta bort med confirm → delete.mutate med utläggets id", () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    render(<ExpenseSection matterId="m1" />);
+    fireEvent.click(screen.getByText("Ta bort"));
+    expect(deleteMutate).toHaveBeenCalledWith({ id: "e1" });
+    confirmSpy.mockRestore();
+  });
+
+  it("'+ Nytt utlägg' öppnar skapa-modalen", () => {
+    render(<ExpenseSection matterId="m1" />);
+    fireEvent.click(screen.getByText("+ Nytt utlägg"));
+    expect(screen.getByText("Nytt utlägg")).toBeInTheDocument();
+    expect(screen.getByText("Debiterbar")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Vad

#6 ratchet-steg: `src/app/matters/[id]/_expense-section.tsx` —
`ExpenseSection` var ~125 rader (1 max-lines-per-function-suppression),
dominerad av den inline kolumn-definitionen.

Lyfter till modul-nivå:
- **`expenseColumns({ onEdit, onDelete })`** — hela `DataTable`-kolumn­
  definitionen (datum, av, beskrivning, moms-uppdelning, deb., faktura, åtgärder).
- **`expenseFooter`** — summa-raden.
- **`vatOf` / `invoiceLabel` / `isInvoiced`** — rena helpers.

`ExpenseSection` blir en tunn shell (state + mutationer + JSX).

Filen saknade test → la till **`test/unit/app/matters/expense-section.test.tsx`**
(5 fall): rubrik + total + rader, summa-footer, lås av fakturerade utlägg +
åtgärder på ofakturerade, ta bort → `delete.mutate({ id })`, "+ Nytt utlägg"
öppnar skapa-modalen. `trpc` (expense/prefs/user) + `EntityLink` stubbade.

Suppressionen borttagen ur `eslint-suppressions.json`.

## Verifiering (CI-spegel lokalt)
- `bun run typecheck` — rent (efter `rm tsconfig.tsbuildinfo`)
- `bun run lint --max-warnings 0` — rent
- `bun run lint:prune` → `grep -c _expense-section eslint-suppressions.json` = 0
- `bun run knip` — rent
- `bun test …/expense-section.test.tsx` — 5 pass (ny coverage)

Refs #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)