### PR TITLE
refactor(lint): töm eslint-suppressions.json — sista max-depth + max-params (#6)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,17 +1,2 @@
 {
-  "src/components/documents/_document-row.tsx": {
-    "max-depth": {
-      "count": 1
-    }
-  },
-  "src/lib/server/adapters/demo-search-index.ts": {
-    "max-params": {
-      "count": 1
-    }
-  },
-  "src/lib/server/local-first/demo-loader.ts": {
-    "max-depth": {
-      "count": 2
-    }
-  }
 }

--- a/src/components/documents/_document-row.tsx
+++ b/src/components/documents/_document-row.tsx
@@ -9,6 +9,26 @@ import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { formatFileSize } from "./_drag-helpers";
 import { ExternalEditModal, type ModalState } from "./external-edit-modal";
 
+/**
+ * Försök öppna dokumentet från den lokala FSA-working-copyn som blob:-URL
+ * (nyligen uppladdade filer hinner inte till remote än). Returnerar `true`
+ * om filen öppnades, annars `false` (→ caller faller tillbaka på GH Pages-URL).
+ * Platta tidiga returer håller nästlingsdjupet under gränsen.
+ */
+async function tryOpenViaFsa(path: string): Promise<boolean> {
+  const { isFsaSupported, loadHandle } = await import("@/lib/client/fsa/handle-store");
+  if (!isFsaSupported()) return false;
+  const handle = await loadHandle("repo-root");
+  if (!handle) return false;
+  const blob = await readFromFsa(handle, path);
+  if (!blob) return false;
+  const url = URL.createObjectURL(blob);
+  window.open(url, "_blank", "noopener,noreferrer");
+  // Återvinn URL:n efter en stund (browsern behåller den medan tab:n öppen)
+  setTimeout(() => URL.revokeObjectURL(url), 60_000);
+  return true;
+}
+
 export interface DocumentRecord {
   id: string;
   fileName: string;
@@ -178,20 +198,7 @@ function DocumentActions({
 
     if (path) {
       try {
-        const { isFsaSupported, loadHandle } = await import("@/lib/client/fsa/handle-store");
-        if (isFsaSupported()) {
-          const handle = await loadHandle("repo-root");
-          if (handle) {
-            const blob = await readFromFsa(handle, path);
-            if (blob) {
-              const url = URL.createObjectURL(blob);
-              window.open(url, "_blank", "noopener,noreferrer");
-              // Återvinn URL:n efter en stund (browsern behåller den medan tab:n öppen)
-              setTimeout(() => URL.revokeObjectURL(url), 60_000);
-              return;
-            }
-          }
-        }
+        if (await tryOpenViaFsa(path)) return;
       } catch (err) {
         console.warn("[open] FSA-läsning misslyckades, faller tillbaka till GH Pages:", err);
       }

--- a/src/lib/server/adapters/demo-search-index.ts
+++ b/src/lib/server/adapters/demo-search-index.ts
@@ -88,6 +88,8 @@ export interface SearchOpts {
   /** Begränsa till dokument vars documentType matchar någon i listan.
    *  Tomt array eller undefined = alla typer. */
   documentTypes?: string[];
+  /** Max antal träffar (default 20). */
+  limit?: number;
 }
 
 type SearchHit = SearchResponse["hits"][number];
@@ -160,14 +162,26 @@ function toSearchHit(doc: DocLike, snippet: string, matters: Map<string, MatterL
   };
 }
 
+/** Facet-räknare per documentType (för typ-filter-badges), sorterad fallande. */
+function computeFacetEntries(queryMatches: DocLike[]): Array<{ type: string; count: number }> {
+  const facetCounts = new Map<string, number>();
+  for (const d of queryMatches) {
+    if (!d.documentType) continue;
+    facetCounts.set(d.documentType, (facetCounts.get(d.documentType) ?? 0) + 1);
+  }
+  return [...facetCounts.entries()]
+    .map(([type, count]) => ({ type, count }))
+    .sort((a, b) => b.count - a.count || a.type.localeCompare(b.type, "sv"));
+}
+
 export function searchDocuments(
   docs: DocLike[],
   matters: Map<string, MatterLike>,
   query: string,
   organizationId: string,
-  limit: number,
   opts: SearchOpts = {},
 ): SearchResponse {
+  const limit = opts.limit ?? 20;
   const matcher = compileNeedle(query);
   if (!matcher.raw) return { hits: [], estimatedTotalHits: 0 };
 
@@ -188,15 +202,7 @@ export function searchDocuments(
     if (matcher.test(haystack)) return true;
     return matcher.test(getDocumentContent(d.id).toLowerCase());
   });
-  // Facet-räknare per typ
-  const facetCounts = new Map<string, number>();
-  for (const d of queryMatches) {
-    if (!d.documentType) continue;
-    facetCounts.set(d.documentType, (facetCounts.get(d.documentType) ?? 0) + 1);
-  }
-  const facetEntries = [...facetCounts.entries()]
-    .map(([type, count]) => ({ type, count }))
-    .sort((a, b) => b.count - a.count || a.type.localeCompare(b.type, "sv"));
+  const facetEntries = computeFacetEntries(queryMatches);
 
   const matched = orgDocs
     .filter((d) => typeFilter === null || (d.documentType !== null && d.documentType !== undefined && typeFilter.has(d.documentType)))
@@ -236,7 +242,7 @@ export function makeDemoSearchIndex(dataStore: IDataStore): ISearchIndex {
         where: { organizationId },
       }) as unknown as MatterLike[];
       const matters = new Map(matterRows.map((m) => [m.id, m]));
-      return searchDocuments(docs, matters, query, organizationId, limit, opts);
+      return searchDocuments(docs, matters, query, organizationId, { ...opts, limit });
     },
     async upsert() { /* no-op — vi använder live data-store, inget index att uppdatera */ },
     async remove() { /* no-op */ },

--- a/src/lib/server/local-first/demo-loader.ts
+++ b/src/lib/server/local-first/demo-loader.ts
@@ -136,19 +136,26 @@ export class DemoLoader {
     for (const entity of this.deps.registry.entities()) {
       for (const prefix of this.knownPrefixes(entity)) {
         const items = await this.deps.fs.listDir(prefix);
-        for (const item of items) {
-          if (!item.endsWith(".json")) continue;
-          const path = `${prefix}/${item}`;
-          try {
-            const r = await hydrator.hydratePath(path);
-            if (!r) continue;
-            if (!this.hydrated.has(r.entity)) this.hydrated.set(r.entity, []);
-            this.hydrated.get(r.entity)!.push(r.data);
-          } catch {
-            // Korrupta filer i cache — hoppa över
-          }
-        }
+        for (const item of items) await this.hydrateItemInto(hydrator, prefix, item);
       }
+    }
+  }
+
+  /** Hydratisera en enskild fil in i `this.hydrated` (korrupta filer hoppas över). */
+  private async hydrateItemInto(
+    hydrator: { hydratePath: (path: string) => Promise<{ entity: string; data: unknown } | null> },
+    prefix: string,
+    item: string,
+  ): Promise<void> {
+    if (!item.endsWith(".json")) return;
+    const path = `${prefix}/${item}`;
+    try {
+      const r = await hydrator.hydratePath(path);
+      if (!r) return;
+      if (!this.hydrated.has(r.entity)) this.hydrated.set(r.entity, []);
+      this.hydrated.get(r.entity)!.push(r.data);
+    } catch {
+      // Korrupta filer i cache — hoppa över
     }
   }
 

--- a/test/unit/server/adapters/demo-search-index.test.ts
+++ b/test/unit/server/adapters/demo-search-index.test.ts
@@ -23,26 +23,26 @@ const matters = new Map([
 
 describe("searchDocuments", () => {
   it("matchar mot fileName (case-insensitive)", () => {
-    const r = searchDocuments(docs, matters, "vårdnad", "org-1", 20);
+    const r = searchDocuments(docs, matters, "vårdnad", "org-1", { limit: 20 });
     expect(r.hits.length).toBe(2); // d-1 (fileName+summary), d-2 (summary)
     expect(r.hits.map((h) => h.id)).toContain("d-1");
     expect(r.hits.map((h) => h.id)).toContain("d-2");
   });
 
   it("matchar mot documentType", () => {
-    const r = searchDocuments(docs, matters, "stämning", "org-1", 20);
+    const r = searchDocuments(docs, matters, "stämning", "org-1", { limit: 20 });
     expect(r.hits.length).toBeGreaterThan(0);
     expect(r.hits[0]!.id).toBe("d-1");
   });
 
   it("matchar mot summary", () => {
-    const r = searchDocuments(docs, matters, "Eriksson", "org-1", 20);
+    const r = searchDocuments(docs, matters, "Eriksson", "org-1", { limit: 20 });
     expect(r.hits.length).toBe(1);
     expect(r.hits[0]!.id).toBe("d-3");
   });
 
   it("filtrerar bort dokument från annan org", () => {
-    const r = searchDocuments(docs, matters, "Hemlig", "org-1", 20);
+    const r = searchDocuments(docs, matters, "Hemlig", "org-1", { limit: 20 });
     expect(r.hits.length).toBe(0);
   });
 
@@ -57,23 +57,23 @@ describe("searchDocuments", () => {
       ["m-firma", { id: "m-firma", matterNumber: "F-1", title: "Internt", organizationId: "firma-ab" }],
       ["m-extern", { id: "m-extern", matterNumber: "E-1", title: "Extern", organizationId: "other-org" }],
     ]) as unknown as Parameters<typeof searchDocuments>[1];
-    const r = searchDocuments(docsWithoutOrg, mattersByOrg, "Note", "firma-ab", 20);
+    const r = searchDocuments(docsWithoutOrg, mattersByOrg, "Note", "firma-ab", { limit: 20 });
     expect(r.hits.map((h) => h.id)).toEqual(["d-a"]);
   });
 
   it("tomt query → inga träffar", () => {
-    expect(searchDocuments(docs, matters, "", "org-1", 20).hits).toEqual([]);
-    expect(searchDocuments(docs, matters, "   ", "org-1", 20).hits).toEqual([]);
+    expect(searchDocuments(docs, matters, "", "org-1", { limit: 20 }).hits).toEqual([]);
+    expect(searchDocuments(docs, matters, "   ", "org-1", { limit: 20 }).hits).toEqual([]);
   });
 
   it("inkluderar matter-info i resultat", () => {
-    const r = searchDocuments(docs, matters, "Stämningsansökan", "org-1", 20);
+    const r = searchDocuments(docs, matters, "Stämningsansökan", "org-1", { limit: 20 });
     expect(r.hits[0]!.matterNumber).toBe("2026-001");
     expect(r.hits[0]!.matterTitle).toBe("Vårdnad");
   });
 
   it("respekterar limit", () => {
-    const r = searchDocuments(docs, matters, "pdf", "org-1", 1);
+    const r = searchDocuments(docs, matters, "pdf", "org-1", { limit: 1 });
     // Inte alla matchar "pdf" eftersom det är ej i fileName/type/summary normalt
     expect(r.hits.length).toBeLessThanOrEqual(1);
   });
@@ -81,14 +81,14 @@ describe("searchDocuments", () => {
   it("ranking: fileName-träff prioriteras över summary-träff", () => {
     // "vårdnad" finns i d-1.fileName + d-1.summary + d-2.summary
     // d-1 ska ranka högst eftersom det har träff i både fileName + summary
-    const r = searchDocuments(docs, matters, "vårdnad", "org-1", 20);
+    const r = searchDocuments(docs, matters, "vårdnad", "org-1", { limit: 20 });
     expect(r.hits[0]!.id).toBe("d-1");
   });
 
   it("hittar ord som ENDAST finns i dokumentinnehåll (content-cache)", () => {
     // Inget av docs har "skadan" i metadata, men vi cachar det i content
     setDocumentContent("d-3", "BRF beslutar avslag pga att skadan inte är dokumenterad.");
-    const r = searchDocuments(docs, matters, "skadan", "org-1", 20);
+    const r = searchDocuments(docs, matters, "skadan", "org-1", { limit: 20 });
     expect(r.hits.length).toBe(1);
     expect(r.hits[0]!.id).toBe("d-3");
     // Snippet ska innehålla kontext runt query
@@ -101,7 +101,7 @@ describe("searchDocuments", () => {
       "och någonstans i mitten finns ordet TARGET som vi söker efter, " +
       "och sedan fortsätter det med ännu mer information som inte är relevant."
     );
-    const r = searchDocuments(docs, matters, "target", "org-1", 20);
+    const r = searchDocuments(docs, matters, "target", "org-1", { limit: 20 });
     expect(r.hits.length).toBe(1);
     const snippet = r.hits[0]!._formatted?.content ?? "";
     expect(snippet).toContain("TARGET");
@@ -111,7 +111,7 @@ describe("searchDocuments", () => {
 
   it("kombinerar metadata- + content-träff (boost-summa)", () => {
     setDocumentContent("d-1", "innehåller också vårdnad-text");
-    const r = searchDocuments(docs, matters, "vårdnad", "org-1", 20);
+    const r = searchDocuments(docs, matters, "vårdnad", "org-1", { limit: 20 });
     expect(r.hits[0]!.id).toBe("d-1");
     // d-1 har: fileName(2) + summary(1) + content(1) + meta(1) = 5
     // d-2 har: summary(1) + meta(1) = 2
@@ -120,28 +120,28 @@ describe("searchDocuments", () => {
   // ─── Wildcard (*) ────────────────────────────────────────────────────
   describe("wildcard *", () => {
     it("'stäm*' matchar 'Stämningsansökan'", () => {
-      const r = searchDocuments(docs, matters, "stäm*", "org-1", 20);
+      const r = searchDocuments(docs, matters, "stäm*", "org-1", { limit: 20 });
       expect(r.hits.map((h) => h.id)).toContain("d-1");
     });
 
     it("'*ansökan*' matchar i mitten av ord", () => {
-      const r = searchDocuments(docs, matters, "*ansökan*", "org-1", 20);
+      const r = searchDocuments(docs, matters, "*ansökan*", "org-1", { limit: 20 });
       expect(r.hits.map((h) => h.id)).toContain("d-1");
     });
 
     it("'dom*tings*' matchar flera ord i ordning", () => {
-      const r = searchDocuments(docs, matters, "dom*tings*", "org-1", 20);
+      const r = searchDocuments(docs, matters, "dom*tings*", "org-1", { limit: 20 });
       expect(r.hits.map((h) => h.id)).toContain("d-2");
     });
 
     it("ren prefix utan * fungerar fortsatt (substring)", () => {
-      const r = searchDocuments(docs, matters, "vårdnad", "org-1", 20);
+      const r = searchDocuments(docs, matters, "vårdnad", "org-1", { limit: 20 });
       expect(r.hits.map((h) => h.id)).toContain("d-1");
     });
 
     it("* i content-cache matchas och ger snippet", () => {
       setDocumentContent("d-3", "Vid arvskiftet upptäcktes att testamentet var ogiltigt.");
-      const r = searchDocuments(docs, matters, "testa*", "org-1", 20);
+      const r = searchDocuments(docs, matters, "testa*", "org-1", { limit: 20 });
       expect(r.hits.map((h) => h.id)).toContain("d-3");
       const snippet = r.hits.find((h) => h.id === "d-3")?._formatted?.content ?? "";
       expect(snippet).toContain("testamentet");
@@ -149,12 +149,12 @@ describe("searchDocuments", () => {
 
     it("regex-metachars i query escapas (.+ ska INTE matcha annat)", () => {
       // ".+" som literal sträng finns inte i någon doc → inga träffar.
-      const r = searchDocuments(docs, matters, ".+", "org-1", 20);
+      const r = searchDocuments(docs, matters, ".+", "org-1", { limit: 20 });
       expect(r.hits).toEqual([]);
     });
 
     it("'*' ensamt matchar allt (om q inte är tomt)", () => {
-      const r = searchDocuments(docs, matters, "*", "org-1", 20);
+      const r = searchDocuments(docs, matters, "*", "org-1", { limit: 20 });
       // Alla 3 doks i org-1 ska träffas
       expect(r.hits.length).toBe(3);
     });

--- a/test/unit/server/search-document-type-filter.test.ts
+++ b/test/unit/server/search-document-type-filter.test.ts
@@ -23,30 +23,30 @@ const docs = [
 
 describe("searchDocuments — documentTypes-filter", () => {
   it("utan filter returnerar träffar i alla typer", () => {
-    const r = searchDocuments(docs, matters, "tvist", ORG, 50);
+    const r = searchDocuments(docs, matters, "tvist", ORG, { limit: 50 });
     const types = r.hits.map((h) => docs.find((d) => d.id === h.id)?.documentType);
     expect(types.sort()).toEqual(["Dom", "Stämningsansökan", "Yttrande"]);
   });
 
   it("filter ['Dom'] returnerar bara dom-träffar", () => {
-    const r = searchDocuments(docs, matters, "tvist", ORG, 50, { documentTypes: ["Dom"] });
+    const r = searchDocuments(docs, matters, "tvist", ORG, { limit: 50, documentTypes: ["Dom"] });
     expect(r.hits).toHaveLength(1);
     expect(r.hits[0]!.id).toBe("d2");
   });
 
   it("filter ['Dom', 'Yttrande'] inkluderar båda", () => {
-    const r = searchDocuments(docs, matters, "tvist", ORG, 50, { documentTypes: ["Dom", "Yttrande"] });
+    const r = searchDocuments(docs, matters, "tvist", ORG, { limit: 50, documentTypes: ["Dom", "Yttrande"] });
     const ids = r.hits.map((h) => h.id).sort();
     expect(ids).toEqual(["d2", "d3"]);
   });
 
   it("filter på okänd typ → inga träffar", () => {
-    const r = searchDocuments(docs, matters, "tvist", ORG, 50, { documentTypes: ["FinnsEj"] });
+    const r = searchDocuments(docs, matters, "tvist", ORG, { limit: 50, documentTypes: ["FinnsEj"] });
     expect(r.hits).toHaveLength(0);
   });
 
   it("tom array → samma som inget filter (alla typer)", () => {
-    const r = searchDocuments(docs, matters, "tvist", ORG, 50, { documentTypes: [] });
+    const r = searchDocuments(docs, matters, "tvist", ORG, { limit: 50, documentTypes: [] });
     expect(r.hits).toHaveLength(3);
   });
 
@@ -54,7 +54,7 @@ describe("searchDocuments — documentTypes-filter", () => {
   // Räknas alltid på fullständigt query-result så badges visar hur många
   // träffar varje filter SKULLE ge.
   it("facets innehåller alla typer som matchar query (utan type-filter)", () => {
-    const r = searchDocuments(docs, matters, "tvist", ORG, 50);
+    const r = searchDocuments(docs, matters, "tvist", ORG, { limit: 50 });
     expect(r.facets?.documentTypes?.sort((a, b) => a.type.localeCompare(b.type)))
       .toEqual([
         { type: "Dom", count: 1 },
@@ -64,7 +64,7 @@ describe("searchDocuments — documentTypes-filter", () => {
   });
 
   it("facets är samma även när type-filter är satt (badges = vad MAN SKULLE få)", () => {
-    const r = searchDocuments(docs, matters, "tvist", ORG, 50, { documentTypes: ["Dom"] });
+    const r = searchDocuments(docs, matters, "tvist", ORG, { limit: 50, documentTypes: ["Dom"] });
     // Hits begränsas till Dom (1 träff), men facets-counts visar att Yttrande
     // + Stämningsansökan SKULLE ge 1 träff vardera om man togglade dem.
     expect(r.hits).toHaveLength(1);
@@ -72,7 +72,7 @@ describe("searchDocuments — documentTypes-filter", () => {
   });
 
   it("facets exkluderar dokument som inte matchar query alls", () => {
-    const r = searchDocuments(docs, matters, "klientens", ORG, 50);
+    const r = searchDocuments(docs, matters, "klientens", ORG, { limit: 50 });
     // Bara d3 (Yttrande) har "klientens" i summary
     expect(r.facets?.documentTypes).toEqual([{ type: "Yttrande", count: 1 }]);
   });


### PR DESCRIPTION
## Vad

Sista #6-steget: rensar de **tre sista** lint-suppressionerna så
`eslint-suppressions.json` blir **tom (`{}`)**.

- **`demo-search-index.ts`** (`max-params`): `searchDocuments` tog 6 parametrar.
  Fold:ade `limit` in i `SearchOpts` → 5 parametrar. Bröt även ut
  `computeFacetEntries` så `complexity` hålls ≤8. Anropare uppdaterade
  (index-wrappern + 2 testfiler: `{ limit: N }` i st.f. positionellt).
- **`demo-loader.ts`** (`max-depth`): `replaceEntitiesFromFs` nästlade 5 djupt
  → bröt ut `hydrateItemInto` (per-fil-hydrering).
- **`_document-row.tsx`** (`max-depth`): `openInEditor` nästlade 6 djupt → bröt
  ut `tryOpenViaFsa` med platta tidiga returer.

## Innebörd

Tillsammans med PR #341-#354 är **hela #6 nu i hamn**: noll
`max-lines-per-function`-suppressions OCH noll övriga suppressions kvar —
ratchet-filen är tom. `--max-warnings 0` är rent utan undertryckningar.

## Verifiering (CI-spegel lokalt)
- `bun run typecheck` — rent (efter `rm tsconfig.tsbuildinfo`)
- `bun run lint --max-warnings 0` — rent
- `bun run lint:prune` → `eslint-suppressions.json` = `{}`
- `bun run knip` — rent
- 55 sök-/dokument-tester + 291 local-first/hydration-tester gröna
  (beteende oförändrat)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)