### PR TITLE
test(coverage): testa CheckboxList + höj rad-golvet till 84% (#27)

### DIFF
--- a/test/unit/components/checkbox-list.test.tsx
+++ b/test/unit/components/checkbox-list.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Test för CheckboxList — kompakt filtrerbar multi-select (kollegor/kontakter
+ * till kalender-event). Ren, kontrollerad komponent: vi verifierar rendering,
+ * filtrering (label + sublabel), tomtillstånd, toggla på/av och markerat-räknare.
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest-compat";
+import { CheckboxList, type CheckboxOption } from "@/components/ui/checkbox-list";
+
+const OPTIONS: CheckboxOption[] = [
+  { id: "u1", label: "Anna Advokat", sublabel: "Partner" },
+  { id: "u2", label: "Björn Bauer", sublabel: "Biträdande" },
+  { id: "u3", label: "Cecilia Carlsson" },
+];
+
+describe("CheckboxList", () => {
+  it("renderar label och alla alternativ", () => {
+    render(<CheckboxList options={OPTIONS} selectedIds={[]} onChange={vi.fn()} label="Bjud in" />);
+    expect(screen.getByText("Bjud in")).toBeInTheDocument();
+    expect(screen.getByText("Anna Advokat")).toBeInTheDocument();
+    expect(screen.getByText("Cecilia Carlsson")).toBeInTheDocument();
+  });
+
+  it("default-placeholder 'Sök…' när ingen anges", () => {
+    render(<CheckboxList options={OPTIONS} selectedIds={[]} onChange={vi.fn()} />);
+    expect(screen.getByPlaceholderText("Sök…")).toBeInTheDocument();
+  });
+
+  it("filtrerar på label (case-insensitive)", () => {
+    render(<CheckboxList options={OPTIONS} selectedIds={[]} onChange={vi.fn()} />);
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "björn" } });
+    expect(screen.getByText("Björn Bauer")).toBeInTheDocument();
+    expect(screen.queryByText("Anna Advokat")).not.toBeInTheDocument();
+  });
+
+  it("filtrerar även på sublabel", () => {
+    render(<CheckboxList options={OPTIONS} selectedIds={[]} onChange={vi.fn()} />);
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "partner" } });
+    expect(screen.getByText("Anna Advokat")).toBeInTheDocument();
+    expect(screen.queryByText("Björn Bauer")).not.toBeInTheDocument();
+  });
+
+  it("visar tommeddelande (default + custom) när inget matchar", () => {
+    const { rerender } = render(<CheckboxList options={OPTIONS} selectedIds={[]} onChange={vi.fn()} />);
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "xyz" } });
+    expect(screen.getByText("Inga matchningar.")).toBeInTheDocument();
+    rerender(<CheckboxList options={[]} selectedIds={[]} onChange={vi.fn()} emptyMessage="Inga kollegor" />);
+    expect(screen.getByText("Inga kollegor")).toBeInTheDocument();
+  });
+
+  it("toggla ett omarkerat alternativ → onChange med id tillagt", () => {
+    const onChange = vi.fn();
+    render(<CheckboxList options={OPTIONS} selectedIds={["u1"]} onChange={onChange} />);
+    fireEvent.click(screen.getByText("Björn Bauer"));
+    expect(onChange).toHaveBeenCalledWith(["u1", "u2"]);
+  });
+
+  it("toggla ett markerat alternativ → onChange med id borttaget", () => {
+    const onChange = vi.fn();
+    render(<CheckboxList options={OPTIONS} selectedIds={["u1", "u2"]} onChange={onChange} />);
+    fireEvent.click(screen.getByText("Anna Advokat"));
+    expect(onChange).toHaveBeenCalledWith(["u2"]);
+  });
+
+  it("checkboxar reflekterar selectedIds", () => {
+    render(<CheckboxList options={OPTIONS} selectedIds={["u2"]} onChange={vi.fn()} />);
+    const boxes = screen.getAllByRole("checkbox") as HTMLInputElement[];
+    expect(boxes[0]!.checked).toBe(false); // u1
+    expect(boxes[1]!.checked).toBe(true); // u2
+  });
+
+  it("visar markerat-räknare när något är valt", () => {
+    render(<CheckboxList options={OPTIONS} selectedIds={["u1", "u3"]} onChange={vi.fn()} />);
+    expect(screen.getByText("2 markerade")).toBeInTheDocument();
+  });
+
+  it("ingen räknare när inget är valt", () => {
+    render(<CheckboxList options={OPTIONS} selectedIds={[]} onChange={vi.fn()} />);
+    expect(screen.queryByText(/markerade/)).not.toBeInTheDocument();
+  });
+});

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -31,7 +31,7 @@ const COVERAGE = process.argv.includes("--coverage");
 const FAST = process.argv.includes("--fast");
 
 // Ratchet-golv (flyttat hit från check-coverage.ts) — flytta BARA uppåt.
-const LINE_FLOOR = 0.83;
+const LINE_FLOOR = 0.84;
 const FUNC_FLOOR = 0.80;
 
 /**


### PR DESCRIPTION
## Vad

#27-ratchet-steg (täckning mot 95% över tid). `CheckboxList`
(`src/components/ui/checkbox-list.tsx`) saknade test — 3.8% rad-täckning.

Lägger till **`test/unit/components/checkbox-list.test.tsx`** (10 fall):
rendering av label+alternativ, default-placeholder, filtrering på label
(case-insensitive) + på sublabel, tom-meddelande (default + custom), toggla
omarkerat → `onChange` med id tillagt, toggla markerat → id borttaget,
checkbox-state speglar `selectedIds`, markerat-räknare (visas/döljs).

Rad-täckningen (src/) steg **84.31% → 84.46%**. Höjer `LINE_FLOOR` 0.83 → 0.84
i `tooling/scripts/run-tests.ts` för att ratcheta in vinsten (golvet flyttas
bara uppåt, jfr quality-ratchet i AGENTS.md). `FUNC_FLOOR` lämnas på 0.80 —
smalare marginal (80.93%) och func-% svänger när kod läggs till; jfr
Node-version-täckningsfällan (CI instrumenterar mer än lokalt).

## Verifiering (CI-spegel lokalt)
- `bun run test:cov` — rader 84.46% (golv **84.00%**), funktioner 80.93%
  (golv 80.00%) → grinden grön
- `bun run lint --max-warnings 0` — rent
- `bun run knip` — rent
- `bun run typecheck` — rent
- `bun test …/checkbox-list.test.tsx` — 10 pass

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)