### PR TITLE
test(coverage): preloadAllDocuments + computeTimkostnadsnorm (#27)

### DIFF
--- a/test/unit/lib/fsa/preload-documents.test.ts
+++ b/test/unit/lib/fsa/preload-documents.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Test för preloadAllDocuments — demo-läges förladdning av dokumentbinärer
+ * från GH Pages till FSA-mappen. Verifierar manifest→meta→binär-flödet,
+ * idempotens (skippar befintliga), fel-räkning och progress-callback.
+ *
+ * Använder fake-FSA + injicerad fetch (modulen tar `fetchFn`).
+ */
+
+import { describe, it, expect, vi } from "vitest-compat";
+import { preloadAllDocuments } from "@/lib/client/fsa/preload-documents";
+import { makeFakeFsa } from "../../../helpers/fake-fsa";
+
+const BASE = "https://example.github.io/ava";
+
+/** Response-lik stub. */
+function res(body: { json?: unknown; bytes?: Uint8Array; ok?: boolean }): Response {
+  return {
+    ok: body.ok ?? true,
+    status: body.ok === false ? 404 : 200,
+    json: async () => body.json,
+    arrayBuffer: async () => (body.bytes ?? new Uint8Array([1, 2, 3])).buffer,
+  } as unknown as Response;
+}
+
+/** Routar fetch per URL-suffix; binärfiler default-OK med 3 bytes. */
+function makeFetch(overrides: Record<string, () => Response> = {}) {
+  return vi.fn(async (url: string | URL): Promise<Response> => {
+    const u = String(url);
+    for (const [suffix, fn] of Object.entries(overrides)) {
+      if (u.endsWith(suffix)) return fn();
+    }
+    if (u.endsWith("manifest.json")) {
+      return res({ json: { paths: ["documents/d1.json", "documents/d2.json", "other/skip.json"] } });
+    }
+    if (u.endsWith("d1.json")) return res({ json: { storagePath: "documents/content/d1.pdf" } });
+    if (u.endsWith("d2.json")) return res({ json: { storagePath: "documents/content/d2.pdf" } });
+    return res({ bytes: new Uint8Array([9, 9, 9]) }); // binärer
+  });
+}
+
+describe("preloadAllDocuments", () => {
+  it("laddar ner alla binärer från manifestets documents/-metadata", async () => {
+    const fsa = makeFakeFsa();
+    const r = await preloadAllDocuments({ root: fsa.root, baseUrl: BASE, fetchFn: makeFetch() });
+    expect(r).toEqual({ downloaded: 2, skipped: 0, failed: 0 });
+    expect(fsa.readFile("documents/content/d1.pdf")).not.toBeNull();
+    expect(fsa.readFile("documents/content/d2.pdf")).not.toBeNull();
+  });
+
+  it("är idempotent — andra körningen skippar befintliga filer", async () => {
+    const fsa = makeFakeFsa();
+    await preloadAllDocuments({ root: fsa.root, baseUrl: BASE, fetchFn: makeFetch() });
+    const r2 = await preloadAllDocuments({ root: fsa.root, baseUrl: BASE, fetchFn: makeFetch() });
+    expect(r2).toEqual({ downloaded: 0, skipped: 2, failed: 0 });
+  });
+
+  it("räknar nedladdningsfel utan att avbryta (binär 404 → failed)", async () => {
+    const fsa = makeFakeFsa();
+    const fetchFn = makeFetch({ "d2.pdf": () => res({ ok: false }) });
+    const r = await preloadAllDocuments({ root: fsa.root, baseUrl: BASE, fetchFn });
+    expect(r.downloaded).toBe(1);
+    expect(r.failed).toBe(1);
+  });
+
+  it("hoppar tyst över metadata-filer som inte går att hämta", async () => {
+    const fsa = makeFakeFsa();
+    const fetchFn = makeFetch({ "d2.json": () => res({ ok: false }) });
+    const r = await preloadAllDocuments({ root: fsa.root, baseUrl: BASE, fetchFn });
+    // d2:s storagePath samlas aldrig in → bara d1 laddas ner
+    expect(r.downloaded).toBe(1);
+    expect(r.skipped + r.failed).toBe(0);
+  });
+
+  it("kastar om manifestet inte kan hämtas", async () => {
+    const fsa = makeFakeFsa();
+    const fetchFn = makeFetch({ "manifest.json": () => res({ ok: false }) });
+    await expect(preloadAllDocuments({ root: fsa.root, baseUrl: BASE, fetchFn })).rejects.toThrow(/manifest/);
+  });
+
+  it("trim:ar trailing slash i baseUrl och anropar onProgress per fil", async () => {
+    const fsa = makeFakeFsa();
+    const onProgress = vi.fn();
+    const r = await preloadAllDocuments({ root: fsa.root, baseUrl: `${BASE}/`, fetchFn: makeFetch(), onProgress });
+    expect(r.downloaded).toBe(2);
+    expect(onProgress).toHaveBeenCalledTimes(2);
+    expect(onProgress).toHaveBeenLastCalledWith(2, 2, expect.any(String));
+  });
+
+  it("tomt manifest → inga nedladdningar", async () => {
+    const fsa = makeFakeFsa();
+    const fetchFn = makeFetch({ "manifest.json": () => res({ json: { paths: [] } }) });
+    const r = await preloadAllDocuments({ root: fsa.root, baseUrl: BASE, fetchFn });
+    expect(r).toEqual({ downloaded: 0, skipped: 0, failed: 0 });
+  });
+});

--- a/test/unit/shared/brottmalstaxa.test.ts
+++ b/test/unit/shared/brottmalstaxa.test.ts
@@ -8,8 +8,11 @@
 import { describe, it, expect } from "vitest-compat";
 import {
   computeBrottmalstaxa,
+  computeTimkostnadsnorm,
   BROTTMALSTAXA_TABLE,
   TAXA_MAX_MINUTES,
+  TIMKOSTNADSNORM_FTAX_ORE_PER_H,
+  TIMKOSTNADSNORM_NO_FTAX_ORE_PER_H,
   applyNoFTaxFactor,
 } from "@/lib/shared/brottmalstaxa";
 
@@ -90,6 +93,56 @@ describe("F-skatt-justering", () => {
   it("applyNoFTaxFactor — 2809 kr × 1237/1626 = ca 2137 kr", () => {
     // 280900 * 1237 / 1626 = 213697.59... → 213698 öre
     expect(applyNoFTaxFactor(280900)).toBe(213698);
+  });
+});
+
+describe("computeTimkostnadsnorm (löpande räkning > taxetak / non-taxemål)", () => {
+  it("F-skatt (default): 60 min arbete → 1 626 kr, rate 162600 öre/h", () => {
+    const r = computeTimkostnadsnorm({ arbetsMinutes: 60 });
+    expect(r.rateOrePerH).toBe(TIMKOSTNADSNORM_FTAX_ORE_PER_H);
+    expect(r.arbete).toBe(162_600);
+    expect(r.tidsspillan).toBe(0);
+    expect(r.total).toBe(162_600);
+  });
+
+  it("utan F-skatt: lägre timkostnadsnorm (1 237 kr/h)", () => {
+    const r = computeTimkostnadsnorm({ arbetsMinutes: 60, hasFTax: false });
+    expect(r.rateOrePerH).toBe(TIMKOSTNADSNORM_NO_FTAX_ORE_PER_H);
+    expect(r.arbete).toBe(123_700);
+  });
+
+  it("tidsspillan ersätts med samma norm och adderas till total", () => {
+    const r = computeTimkostnadsnorm({ arbetsMinutes: 30, tidsspillanMinutes: 30 });
+    expect(r.arbete).toBe(Math.round((30 * TIMKOSTNADSNORM_FTAX_ORE_PER_H) / 60));
+    expect(r.tidsspillan).toBe(Math.round((30 * TIMKOSTNADSNORM_FTAX_ORE_PER_H) / 60));
+    expect(r.total).toBe(r.arbete + r.tidsspillan);
+  });
+
+  it("avrundar till hela ören (1 min)", () => {
+    const r = computeTimkostnadsnorm({ arbetsMinutes: 1 });
+    expect(r.arbete).toBe(Math.round(TIMKOSTNADSNORM_FTAX_ORE_PER_H / 60));
+  });
+
+  it("0 min → 0 kr", () => {
+    expect(computeTimkostnadsnorm({ arbetsMinutes: 0 }).total).toBe(0);
+  });
+});
+
+describe("buildNotes-grenar", () => {
+  it("nära intervallets övre gräns → varningsnot om avslutsklockslag", () => {
+    // 12 min ligger i 0-14-intervallet, > toMin-5 (=9) → noten ska finnas.
+    const r = computeBrottmalstaxa({ huvudforhandlingMinutes: 12, level: 1 });
+    expect(r.notes.join(" ")).toMatch(/övre gräns/i);
+  });
+
+  it("mitt i intervallet → ingen övre-gräns-not", () => {
+    const r = computeBrottmalstaxa({ huvudforhandlingMinutes: 2, level: 1 });
+    expect(r.notes.join(" ")).not.toMatch(/övre gräns/i);
+  });
+
+  it("gränsvärdet F-skatt-justeras också utan F-skatt", () => {
+    const withoutFTax = computeBrottmalstaxa({ huvudforhandlingMinutes: 0, level: 1, hasFTax: false });
+    expect(withoutFTax.gransvardeExclVat).toBe(applyNoFTaxFactor(421900));
   });
 });
 


### PR DESCRIPTION
## Vad

#27-ratchet-steg (täckning mot 95%). Två rena/leaf-moduler som saknade direkt
enhets-test:

- **`preloadAllDocuments`** (`src/lib/client/fsa/preload-documents.ts`, 8.5% →
  täckt): nytt **`test/unit/lib/fsa/preload-documents.test.ts`** (7 fall) —
  manifest→meta→binär-flödet, idempotens (skippar befintliga), nedladdningsfel
  räknas utan avbrott, tysta meta-hämtningsfel, manifest-fel kastar,
  baseUrl-trim + `onProgress`, tomt manifest. Använder `makeFakeFsa` +
  injicerad `fetch`.
- **`computeTimkostnadsnorm` + buildNotes-grenar** i `brottmalstaxa.test.ts`
  (8 fall): F-skatt/utan, tidsspillan, avrundning, "nära övre gräns"-noten,
  gränsvärdes-F-skatt-justering.

Rad-täckning (src/) **84.46% → 84.69%**, funktioner 80.93% → 81.09%.

`LINE_FLOOR` lämnas på 0.84 — 84.69% når inte säkert 0.85 med CI-marginal
(jfr [Node-version-täckningsfällan]); vinsten ackumuleras till nästa
golv-höjning.

## Verifiering (CI-spegel lokalt)
- `bun run test:cov` — rader 84.69% (golv 84.00%), funktioner 81.09% → grön
- `bun run lint --max-warnings 0` — rent
- `bun run knip` — rent
- `bun run typecheck` — rent
- `bun test …/preload-documents.test.ts …/brottmalstaxa.test.ts` — 7 + 30 pass

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)