### PR TITLE
feat(matter): tjänsteanteckningar — ny panel i ärendet (#348)

### DIFF
--- a/src/app/matters/[id]/_client.tsx
+++ b/src/app/matters/[id]/_client.tsx
@@ -15,6 +15,7 @@ import { ContactsSection } from "./_contacts-section";
 import { ExpectedReceivablesSection } from "./_expected-receivables-section";
 import { ExpenseSection } from "./_expense-section";
 import { GenerateModal } from "./_generate-modal";
+import { ServiceNotesSection } from "./_service-notes-section";
 import { TimeSection } from "./_time-section";
 
  
@@ -67,6 +68,7 @@ export default function MatterDetailClient({ id: paramId }: { id: string }) {
         <ExpectedReceivablesSection matterId={id} courtCaseNumber={courtCaseOf(m)} />
         <TimeSection matterId={id} isTaxeArende={m.isTaxeArende} />
         <ExpenseSection matterId={id} isTaxeArende={m.isTaxeArende} />
+        <ServiceNotesSection matterId={id} />
       </div>
 
       {showGenerateModal && (

--- a/src/app/matters/[id]/_service-notes-section.tsx
+++ b/src/app/matters/[id]/_service-notes-section.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+/**
+ * Tjänsteanteckningar (#348) — panel i ärendet. Korta, daterade noteringar
+ * (datum + tid + text + författare). Append-only i v1.
+ */
+
+import { NotebookPen } from "lucide-react";
+import { useState } from "react";
+import { trpc } from "@/lib/client/trpc";
+
+interface ServiceNote {
+  id: string;
+  date: string;
+  time: string;
+  text: string;
+  author?: { name?: string | null } | null;
+}
+
+function nowParts(): { date: string; time: string } {
+  const d = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return {
+    date: `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`,
+    time: `${pad(d.getHours())}:${pad(d.getMinutes())}`,
+  };
+}
+
+/** Fallande sortering på notens egna datum+tid (senaste först). */
+function byDateTimeDesc(a: ServiceNote, b: ServiceNote): number {
+  return `${b.date}T${b.time}`.localeCompare(`${a.date}T${a.time}`);
+}
+
+export function ServiceNotesSection({ matterId }: { matterId: string }) {
+  const utils = trpc.useUtils();
+  const notes = trpc.serviceNote.list.useQuery({ matterId });
+  const [adding, setAdding] = useState(false);
+
+  const items = ((notes.data ?? []) as ServiceNote[]).slice().sort(byDateTimeDesc);
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 lg:col-span-2">
+      <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+        <h2 className="font-semibold text-gray-900 flex items-center gap-2">
+          <NotebookPen size={16} /> Tjänsteanteckningar
+        </h2>
+        {!adding && (
+          <button onClick={() => setAdding(true)} className="text-sm text-blue-600 hover:underline">
+            + Ny anteckning
+          </button>
+        )}
+      </div>
+
+      <div className="p-4 space-y-3">
+        {adding && (
+          <NoteForm
+            matterId={matterId}
+            onDone={() => { setAdding(false); void utils.serviceNote.list.invalidate({ matterId }); }}
+            onCancel={() => setAdding(false)}
+          />
+        )}
+
+        {notes.isLoading ? (
+          <p className="text-sm text-gray-500">Laddar…</p>
+        ) : items.length === 0 ? (
+          <p className="text-sm text-gray-400 italic">Inga tjänsteanteckningar ännu.</p>
+        ) : (
+          <NoteList items={items} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function NoteList({ items }: { items: ServiceNote[] }) {
+  return (
+    <ul className="divide-y divide-gray-100">
+      {items.map((n) => (
+        <li key={n.id} className="py-3">
+          <div className="flex items-center justify-between text-xs text-gray-500 mb-1">
+            <span>
+              {n.date} {n.time}
+              <span className="ml-2 text-gray-400">· {n.author?.name ?? "—"}</span>
+            </span>
+          </div>
+          <p className="text-sm text-gray-800 whitespace-pre-wrap">{n.text}</p>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function NoteForm({ matterId, onDone, onCancel }: { matterId: string; onDone: () => void; onCancel: () => void }) {
+  const init = nowParts();
+  const [date, setDate] = useState(init.date);
+  const [time, setTime] = useState(init.time);
+  const [text, setText] = useState("");
+  const create = trpc.serviceNote.create.useMutation({ onSuccess: onDone });
+
+  function submit(e: React.FormEvent): void {
+    e.preventDefault();
+    if (!text.trim()) return;
+    create.mutate({ matterId, date, time, text: text.trim() });
+  }
+
+  return (
+    <form onSubmit={submit} className="bg-blue-50 border border-blue-200 rounded-lg p-4 space-y-3">
+      <div className="grid grid-cols-2 gap-3">
+        <label className="block">
+          <span className="text-xs text-gray-600 mb-1 block">Datum *</span>
+          <input type="date" required value={date} onChange={(e) => setDate(e.target.value)}
+            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm" />
+        </label>
+        <label className="block">
+          <span className="text-xs text-gray-600 mb-1 block">Tid *</span>
+          <input type="time" required value={time} onChange={(e) => setTime(e.target.value)}
+            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm" />
+        </label>
+      </div>
+      <label className="block">
+        <span className="text-xs text-gray-600 mb-1 block">Anteckning *</span>
+        <textarea required value={text} onChange={(e) => setText(e.target.value)} rows={3}
+          placeholder="Vad hände? (samtal, åtgärd, övervägande…)"
+          className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm" />
+      </label>
+      <div className="flex justify-end gap-2">
+        <button type="button" onClick={onCancel}
+          className="px-3 py-1.5 text-sm border border-gray-300 rounded hover:bg-white">Avbryt</button>
+        <button type="submit" disabled={!text.trim() || create.isPending}
+          className="px-3 py-1.5 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 disabled:opacity-50">
+          {create.isPending ? "Sparar…" : "Spara"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/lib/server/data-store/DemoDataStore.ts
+++ b/src/lib/server/data-store/DemoDataStore.ts
@@ -51,6 +51,7 @@ import type {
   BillingRunDelegate,
   CalendarEventDelegate,
   TaskDelegate,
+  ServiceNoteDelegate,
 } from "./IDataStore";
 import { ReadOnlyDelegate, ReadOnlyError, type RelationConfig } from "./in-memory/read-only-delegate";
 import { WritableDelegate, type MutationEvent, type WritableDelegateOpts } from "./in-memory/writable-delegate";
@@ -87,6 +88,7 @@ export class DemoDataStore implements IDataStore {
   readonly billingRuns: BillingRunDelegate;
   readonly calendarEvents: CalendarEventDelegate;
   readonly tasks: TaskDelegate;
+  readonly serviceNotes: ServiceNoteDelegate;
   readonly userPreferences: Delegate;
   readonly orgPreferences: Delegate;
   readonly events: IEventLog;
@@ -141,6 +143,7 @@ export class DemoDataStore implements IDataStore {
     this.billingRuns = this.makeDelegate("billingRuns", relations.billingRuns) as unknown as BillingRunDelegate;
     this.calendarEvents = this.makeDelegate("calendarEvents", relations.calendarEvents) as unknown as CalendarEventDelegate;
     this.tasks = this.makeDelegate("tasks", relations.tasks) as unknown as TaskDelegate;
+    this.serviceNotes = this.makeDelegate("serviceNotes", relations.serviceNotes) as unknown as ServiceNoteDelegate;
     this.userPreferences = this.makeDelegate("userPreferences") as unknown as Delegate;
     this.orgPreferences = this.makeDelegate("orgPreferences") as unknown as Delegate;
 
@@ -233,6 +236,7 @@ export class DemoDataStore implements IDataStore {
       billingRuns: "billingRun",
       calendarEvents: "calendarEvent",
       tasks: "task",
+      serviceNotes: "serviceNote",
       userPreferences: "userPreference",
       orgPreferences: "orgPreference",
     };
@@ -306,6 +310,7 @@ export class DemoDataStore implements IDataStore {
       billingRuns: this.billingRuns,
       calendarEvents: this.calendarEvents,
       tasks: this.tasks,
+      serviceNotes: this.serviceNotes,
       userPreferences: this.userPreferences,
       orgPreferences: this.orgPreferences,
     };

--- a/src/lib/server/data-store/IDataStore.ts
+++ b/src/lib/server/data-store/IDataStore.ts
@@ -18,7 +18,7 @@ import type {
   Invoice, TimeEntry, Expense, User, Organization, Office, ConflictCheck,
   Payment, PaymentPlan, AccontoDeduction, BillingRun, WriteOff, InvoiceDispatch,
   ExpectedReceivable,
-  CalendarEvent, Task,
+  CalendarEvent, Task, ServiceNote,
 } from "@/lib/shared/schemas";
 import type { AvaEvent, EmitInput, EventFilter } from "../events/schema";
 
@@ -77,6 +77,7 @@ export interface JoinedRelations {
   folder?: any; paymentPlan?: any; billingRun?: any; reminders?: any;
   accontoInvoice?: any; finalInvoice?: any; creditNote?: any;
   uploadedBy?: any; recordedBy?: any; createdBy?: any; checkedBy?: any;
+  author?: any; serviceNotes?: any;
   user?: any; emails?: any; _count?: any;
 }
 
@@ -137,6 +138,7 @@ export type AccontoDeductionDelegate = Delegate<AccontoDeduction>;
 export type BillingRunDelegate = Delegate<BillingRun>;
 export type CalendarEventDelegate = Delegate<CalendarEvent>;
 export type TaskDelegate = Delegate<Task>;
+export type ServiceNoteDelegate = Delegate<ServiceNote>;
 
 // Opt-in: enskilda callers som vill ha striktare row-typ kan importera
 // dessa istället. T.ex. `const matters = ctx.dataStore.matters as MattersStrict`.
@@ -193,6 +195,7 @@ export interface DataStoreTx {
   billingRuns: BillingRunDelegate;
   calendarEvents: CalendarEventDelegate;
   tasks: TaskDelegate;
+  serviceNotes: ServiceNoteDelegate;
   userPreferences: Delegate;
   orgPreferences: Delegate;
 }
@@ -232,6 +235,7 @@ export interface IDataStore {
   readonly billingRuns: BillingRunDelegate;
   readonly calendarEvents: CalendarEventDelegate;
   readonly tasks: TaskDelegate;
+  readonly serviceNotes: ServiceNoteDelegate;
   readonly userPreferences: Delegate;
   readonly orgPreferences: Delegate;
 

--- a/src/lib/server/data-store/relations.ts
+++ b/src/lib/server/data-store/relations.ts
@@ -61,6 +61,7 @@ export interface DemoRelations {
   billingRuns: Relations;
   calendarEvents: Relations;
   tasks: Relations;
+  serviceNotes: Relations;
 }
 
 /**
@@ -76,6 +77,7 @@ export function buildRelations(getSource: GetSource): DemoRelations {
       timeEntries: r("timeEntries", "matterId", "id"),
       expenses: r("expenses", "matterId", "id"),
       invoices: r("invoices", "matterId", "id"),
+      serviceNotes: r("serviceNotes", "matterId", "id"),
     },
     matterContacts: {
       contact: r("contacts", "id", "contactId", "one"),
@@ -154,5 +156,9 @@ export function buildRelations(getSource: GetSource): DemoRelations {
     },
     calendarEvents: { matter: r("matters", "id", "matterId", "one") },
     tasks: { matter: r("matters", "id", "matterId", "one") },
+    serviceNotes: {
+      matter: r("matters", "id", "matterId", "one"),
+      author: r("users", "id", "authorId", "one"),
+    },
   };
 }

--- a/src/lib/server/routers/_app.ts
+++ b/src/lib/server/routers/_app.ts
@@ -16,6 +16,7 @@ import { organizationRouter } from "./organization";
 import { paymentPlanRouter } from "./paymentPlan";
 import { preferenceRouter } from "./preference";
 import { reportsRouter } from "./reports";
+import { serviceNoteRouter } from "./serviceNote";
 import { taskRouter } from "./task";
 import { timeEntryRouter } from "./timeEntry";
 import { todoRouter } from "./todo";
@@ -40,6 +41,7 @@ export const appRouter = router({
   kostnadsrakning: kostnadsrakningRouter,
   calendar: calendarRouter,
   task: taskRouter,
+  serviceNote: serviceNoteRouter,
   todo: todoRouter,
   prefs: preferenceRouter,
   mail: mailRouter,

--- a/src/lib/server/routers/serviceNote.ts
+++ b/src/lib/server/routers/serviceNote.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
+import {
+  asId,
+  matterIdSchema,
+  userIdSchema,
+  serviceNoteIdSchema,
+} from "@/lib/shared/schemas/ids";
+import { router, protectedProcedure } from "../trpc";
+
+/**
+ * Tjänsteanteckningar (#348) — korta, daterade noteringar i ett ärende.
+ * Append-only i v1 (juridisk spårbarhet): bara `list` + `create`, ingen
+ * update/delete. `authorId` sätts från principalen (ej editerbart i UI:t).
+ */
+export const serviceNoteRouter = router({
+  list: protectedProcedure
+    .input(z.object({ matterId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      return ctx.dataStore.serviceNotes.findMany({
+        where: {
+          matterId: input.matterId,
+          matter: { organizationId: ctx.user.organizationId },
+        },
+        orderBy: { createdAt: "desc" },
+        include: { author: { select: { id: true, name: true } } },
+      });
+    }),
+
+  create: protectedProcedure
+    .input(
+      z.object({
+        matterId: matterIdSchema,
+        date: z.string().min(1),
+        time: z.string().min(1),
+        text: z.string().min(1),
+        // Valfria setup-fält (demo-generator/fixtures, ADR 0003).
+        id: serviceNoteIdSchema.optional(),
+        authorId: userIdSchema.optional(),
+        createdAt: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      return ctx.dataStore.serviceNotes.create({
+        data: omitUndefined({
+          id: input.id, // undefined → store genererar
+          organizationId: asId<"OrganizationId">(ctx.user.organizationId),
+          matterId: input.matterId,
+          authorId: input.authorId ?? asId<"UserId">(ctx.user.id),
+          date: input.date,
+          time: input.time,
+          text: input.text,
+          ...(input.createdAt ? { createdAt: new Date(input.createdAt) } : {}),
+        }),
+      });
+    }),
+});

--- a/src/lib/shared/demo-source.ts
+++ b/src/lib/shared/demo-source.ts
@@ -42,6 +42,7 @@ export interface DemoSource {
   expectedReceivables?: readonly Record<string, unknown>[];
   calendarEvents?: readonly Record<string, unknown>[];
   tasks?: readonly Record<string, unknown>[];
+  serviceNotes?: readonly Record<string, unknown>[];
   userPreferences?: readonly Record<string, unknown>[];
   orgPreferences?: readonly Record<string, unknown>[];
 }

--- a/src/lib/shared/schemas/ids.ts
+++ b/src/lib/shared/schemas/ids.ts
@@ -98,6 +98,9 @@ export type CalendarEventId = z.infer<typeof calendarEventIdSchema>;
 export const taskIdSchema = brandedId<"TaskId">();
 export type TaskId = z.infer<typeof taskIdSchema>;
 
+export const serviceNoteIdSchema = brandedId<"ServiceNoteId">();
+export type ServiceNoteId = z.infer<typeof serviceNoteIdSchema>;
+
 export const userPreferenceIdSchema = brandedId<"UserPreferenceId">();
 export type UserPreferenceId = z.infer<typeof userPreferenceIdSchema>;
 

--- a/src/lib/shared/schemas/index.ts
+++ b/src/lib/shared/schemas/index.ts
@@ -38,6 +38,7 @@ import { matterSchema, matterContactSchema } from "./matter";
 import { documentTemplateSchema, conflictCheckSchema } from "./misc";
 import { organizationSchema, officeSchema } from "./organization";
 import { userPreferenceSchema, orgPreferenceSchema } from "./preference";
+import { serviceNoteSchema } from "./service-note";
 import { userSchema } from "./user";
 
 export * from "./enums";
@@ -51,6 +52,7 @@ export * from "./document";
 export * from "./billing";
 export * from "./misc";
 export * from "./calendar";
+export * from "./service-note";
 
 /**
  * Pathfunktion för en entitet. Andra argumentet är raden själv — vissa
@@ -230,6 +232,12 @@ export const ENTITY_REGISTRY: Record<string, EntityEntry> = {
     gitPrefix: "tasks",
     sourceKey: "tasks",
   },
+  serviceNote: {
+    schema: serviceNoteSchema,
+    gitPath: p((id) => `service-notes/${id}.json`),
+    gitPrefix: "service-notes",
+    sourceKey: "serviceNotes",
+  },
   userPreference: {
     schema: userPreferenceSchema,
     gitPath: p((id) => `.ava/user-preferences/${id}.json`),
@@ -252,7 +260,7 @@ export type EntityName =
   | "paymentPlanReminder" | "accontoDeduction" | "billingRun" | "writeOff"
   | "invoiceDispatch" | "expectedReceivable"
   | "documentTemplate" | "conflictCheck"
-  | "calendarEvent" | "task"
+  | "calendarEvent" | "task" | "serviceNote"
   | "userPreference" | "orgPreference";
 
 /** Lista alla entity-namn (för iteration). */

--- a/src/lib/shared/schemas/service-note.ts
+++ b/src/lib/shared/schemas/service-note.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+import { baseFields, dateLike } from "./common";
+import { serviceNoteIdSchema, matterIdSchema, userIdSchema, organizationIdSchema } from "./ids";
+
+/**
+ * `ServiceNote` — tjänsteanteckning i ett ärende (#348). En kort, daterad
+ * notering om vad som hänt (samtal, åtgärd, övervägande), skild från tidsposter
+ * (arvode) och dokument.
+ *
+ * Append-only i v1 (juridisk spårbarhet) — ingen update/delete via routern.
+ * Lagras flat under `service-notes/<id>.json`. `authorId` = principalen som
+ * skapade noteringen (sätts av routern, ej editerbart i UI:t).
+ *
+ * `date` + `time`: separata fält enligt issue:t — `date` är dagen noteringen
+ * avser (YYYY-MM-DD), `time` klockslaget (HH:mm). Båda strängar så de inte
+ * tidszons-skiftas vid serialisering.
+ */
+export const serviceNoteSchema = z.object({
+  ...baseFields,
+  id: serviceNoteIdSchema,
+  organizationId: organizationIdSchema,
+  matterId: matterIdSchema,
+  /** Författare (principal som skapade noteringen). */
+  authorId: userIdSchema,
+  /** Datum noteringen avser, "YYYY-MM-DD". */
+  date: z.string().min(1),
+  /** Klockslag, "HH:mm". */
+  time: z.string().min(1),
+  /** Fritext. */
+  text: z.string().min(1),
+  createdAt: dateLike,
+  updatedAt: dateLike,
+}).passthrough();
+
+export type ServiceNote = z.infer<typeof serviceNoteSchema>;

--- a/test/unit/app/matters/[id]/page.test.tsx
+++ b/test/unit/app/matters/[id]/page.test.tsx
@@ -31,6 +31,7 @@ const utilsMock = {
   document: { tree: { invalidate: vi.fn() } },
   prefs: { get: { invalidate: vi.fn() } },
   expectedReceivable: { list: { invalidate: vi.fn() } },
+  serviceNote: { list: { invalidate: vi.fn() } },
 };
 const stubs = {
   addContact: { mutate: vi.fn(), isPending: false },
@@ -101,6 +102,10 @@ vi.mock("@/lib/client/trpc", () => ({
       create: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
       settle: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
       cancel: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+    },
+    serviceNote: {
+      list: { useQuery: () => ({ data: [], isLoading: false }) },
+      create: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
     },
     user: {
       current: { useQuery: () => ({ data: { id: "u1", name: "Anna", email: "anna@firma.local" } }) },

--- a/test/unit/app/matters/service-notes-section.test.tsx
+++ b/test/unit/app/matters/service-notes-section.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * Test för ServiceNotesSection (#348) — tjänsteanteckningar-panelen:
+ * tomtillstånd, lista (sorterad fallande på datum+tid med författare),
+ * öppna/avbryt formulär och skapa-flödet.
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest-compat";
+import { ServiceNotesSection } from "@/app/matters/[id]/_service-notes-section";
+
+const listQuery = { data: [] as unknown[], isLoading: false };
+const createMutate = vi.fn();
+let createOnSuccess: (() => void) | undefined;
+const invalidate = vi.fn();
+
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: {
+    useUtils: () => ({ serviceNote: { list: { invalidate } } }),
+    serviceNote: {
+      list: { useQuery: () => listQuery },
+      create: {
+        useMutation: (opts?: { onSuccess?: () => void }) => {
+          createOnSuccess = opts?.onSuccess;
+          return { mutate: (a: unknown) => createMutate(a), isPending: false };
+        },
+      },
+    },
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listQuery.data = [];
+  listQuery.isLoading = false;
+});
+
+describe("ServiceNotesSection", () => {
+  it("visar tomtillstånd när inga anteckningar finns", () => {
+    render(<ServiceNotesSection matterId="m1" />);
+    expect(screen.getByText("Tjänsteanteckningar")).toBeInTheDocument();
+    expect(screen.getByText(/Inga tjänsteanteckningar ännu/)).toBeInTheDocument();
+  });
+
+  it("renderar anteckningar med författare, sorterade senaste först", () => {
+    listQuery.data = [
+      { id: "a", date: "2026-06-10", time: "08:00", text: "Äldre", author: { name: "Anna" } },
+      { id: "b", date: "2026-06-15", time: "14:00", text: "Nyare", author: { name: "Björn" } },
+    ];
+    render(<ServiceNotesSection matterId="m1" />);
+    const texts = screen.getAllByText(/Äldre|Nyare/).map((e) => e.textContent);
+    expect(texts).toEqual(["Nyare", "Äldre"]); // fallande på datum+tid
+    expect(screen.getByText(/Björn/)).toBeInTheDocument();
+  });
+
+  it("'+ Ny anteckning' öppnar formuläret, Avbryt stänger det", () => {
+    render(<ServiceNotesSection matterId="m1" />);
+    fireEvent.click(screen.getByText("+ Ny anteckning"));
+    expect(screen.getByPlaceholderText(/Vad hände/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Avbryt" }));
+    expect(screen.queryByPlaceholderText(/Vad hände/)).not.toBeInTheDocument();
+  });
+
+  it("submit skickar create med matterId + text och invaliderar listan vid success", () => {
+    render(<ServiceNotesSection matterId="m1" />);
+    fireEvent.click(screen.getByText("+ Ny anteckning"));
+    fireEvent.change(screen.getByPlaceholderText(/Vad hände/), { target: { value: "Ringde klienten" } });
+    fireEvent.click(screen.getByRole("button", { name: "Spara" }));
+    expect(createMutate).toHaveBeenCalledWith(expect.objectContaining({ matterId: "m1", text: "Ringde klienten" }));
+    createOnSuccess?.(); // simulera lyckad mutation
+    expect(invalidate).toHaveBeenCalledWith({ matterId: "m1" });
+  });
+
+  it("submit utan text gör ingen mutation (required + trim-vakt)", () => {
+    render(<ServiceNotesSection matterId="m1" />);
+    fireEvent.click(screen.getByText("+ Ny anteckning"));
+    const form = screen.getByPlaceholderText(/Vad hände/).closest("form")!;
+    fireEvent.submit(form);
+    expect(createMutate).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/server/helpers/mock-data-store.ts
+++ b/test/unit/server/helpers/mock-data-store.ts
@@ -38,6 +38,7 @@ export interface MockDataStore {
   billingRuns: unknown;
   calendarEvents: unknown;
   tasks: unknown;
+  serviceNotes: unknown;
   userPreferences: unknown;
   orgPreferences: unknown;
 }
@@ -81,6 +82,7 @@ export function dataStoreFromMockPrisma(mockPrisma: Record<string, unknown>): Mo
       billingRuns: mockPrisma.billingRun,
       calendarEvents: mockPrisma.calendarEvent,
       tasks: mockPrisma.task,
+      serviceNotes: mockPrisma.serviceNote,
       userPreferences: mockPrisma.userPreference,
       orgPreferences: mockPrisma.orgPreference,
     }),
@@ -108,6 +110,7 @@ export function dataStoreFromMockPrisma(mockPrisma: Record<string, unknown>): Mo
     billingRuns: mockPrisma.billingRun,
     calendarEvents: mockPrisma.calendarEvent,
     tasks: mockPrisma.task,
+    serviceNotes: mockPrisma.serviceNote,
     userPreferences: mockPrisma.userPreference,
     orgPreferences: mockPrisma.orgPreference,
   };

--- a/test/unit/server/routers/serviceNote.test.ts
+++ b/test/unit/server/routers/serviceNote.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Test för serviceNoteRouter (#348) — append-only list + create.
+ * list org-scopas via matter.organizationId; create sätter authorId + org
+ * från context.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { serviceNoteRouter } from "@/lib/server/routers/serviceNote";
+import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
+
+const mockPrisma = {
+  serviceNote: {
+    findMany: vi.fn(),
+    create: vi.fn(),
+  },
+};
+
+function makeCaller(orgId = "org-a", userId = "u1") {
+  const ctx = {
+    user: { id: userId, email: "a@b.se", name: "T", role: "LAWYER", organizationId: orgId },
+    prisma: mockPrisma, dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return serviceNoteRouter.createCaller(ctx as any);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.serviceNote.findMany.mockResolvedValue([]);
+  mockPrisma.serviceNote.create.mockResolvedValue({ id: "sn1" });
+});
+
+describe("serviceNote.list", () => {
+  it("scopar via matter.organizationId + matterId och inkluderar author", async () => {
+    await makeCaller("org-a").list({ matterId: "m1" });
+    expect(mockPrisma.serviceNote.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { matterId: "m1", matter: { organizationId: "org-a" } },
+        include: { author: { select: { id: true, name: true } } },
+      }),
+    );
+  });
+});
+
+describe("serviceNote.create", () => {
+  it("sätter authorId + organizationId från context och skickar date/time/text", async () => {
+    await makeCaller("org-a", "u-9").create({
+      matterId: "m1", date: "2026-06-15", time: "09:30", text: "Samtal",
+    });
+    const data = mockPrisma.serviceNote.create.mock.calls[0]![0].data;
+    expect(data.authorId).toBe("u-9");
+    expect(data.organizationId).toBe("org-a");
+    expect(data.matterId).toBe("m1");
+    expect(data.date).toBe("2026-06-15");
+    expect(data.time).toBe("09:30");
+    expect(data.text).toBe("Samtal");
+  });
+
+  it("kräver icke-tom text", async () => {
+    await expect(
+      makeCaller().create({ matterId: "m1", date: "2026-06-15", time: "09:30", text: "" }),
+    ).rejects.toThrow();
+  });
+
+  it("respekterar explicit authorId (setup/fixtures)", async () => {
+    await makeCaller("org-a", "u-9").create({
+      matterId: "m1", date: "2026-06-15", time: "09:30", text: "X", authorId: "u-fix",
+    });
+    expect(mockPrisma.serviceNote.create.mock.calls[0]![0].data.authorId).toBe("u-fix");
+  });
+});

--- a/test/unit/shared/service-note.test.ts
+++ b/test/unit/shared/service-note.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Test för serviceNoteSchema (#348) — strikt parsning av tjänsteanteckningar.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { serviceNoteSchema } from "@/lib/shared/schemas/service-note";
+
+const valid = {
+  id: "sn-1",
+  organizationId: "org-1",
+  matterId: "m-1",
+  authorId: "u-1",
+  date: "2026-06-15",
+  time: "09:30",
+  text: "Klientsamtal — gick igenom tidplan.",
+  createdAt: "2026-06-15T09:30:00.000Z",
+  updatedAt: "2026-06-15T09:30:00.000Z",
+};
+
+describe("serviceNoteSchema", () => {
+  it("parsar en giltig anteckning + revivar datum till Date", () => {
+    const r = serviceNoteSchema.parse(valid);
+    expect(r.text).toBe(valid.text);
+    expect(r.date).toBe("2026-06-15");
+    expect(r.time).toBe("09:30");
+    expect(r.createdAt).toBeInstanceOf(Date);
+  });
+
+  it("kräver icke-tom text", () => {
+    expect(() => serviceNoteSchema.parse({ ...valid, text: "" })).toThrow();
+  });
+
+  it("kräver date + time", () => {
+    expect(() => serviceNoteSchema.parse({ ...valid, date: "" })).toThrow();
+    expect(() => serviceNoteSchema.parse({ ...valid, time: "" })).toThrow();
+  });
+
+  it("kräver matterId + authorId", () => {
+    const { matterId: _m, ...noMatter } = valid;
+    const { authorId: _a, ...noAuthor } = valid;
+    expect(() => serviceNoteSchema.parse(noMatter)).toThrow();
+    expect(() => serviceNoteSchema.parse(noAuthor)).toThrow();
+  });
+});

--- a/tooling/scripts/generate-demo-manifest.ts
+++ b/tooling/scripts/generate-demo-manifest.ts
@@ -33,7 +33,7 @@ const DEFAULT_SCAN_PATHS = [
   "time-entries", "expenses", "invoices",
   // Senare tillagda entiteter — utan dessa skulle demo:n inte se kalender,
   // tasks, avbetalningsplaner eller jäv-historik.
-  "calendar", "tasks",
+  "calendar", "tasks", "service-notes",
   "payment-plans", "payment-plan-reminders", "payments",
   "acconto-deductions", "billing-runs", "write-offs", "conflict-checks", "offices",
   "invoice-dispatches", "expected-receivables",

--- a/tooling/scripts/seed-data.ts
+++ b/tooling/scripts/seed-data.ts
@@ -154,6 +154,7 @@ export interface SeedDataset {
   conflictChecks: Record<string, unknown>[];
   paymentPlans: Record<string, unknown>[];
   paymentPlanReminders: Record<string, unknown>[];
+  serviceNotes: Record<string, unknown>[];
 }
 
 export function buildSeed(opts: BuildSeedOpts = {}): SeedDataset {
@@ -213,6 +214,7 @@ export function buildSeed(opts: BuildSeedOpts = {}): SeedDataset {
     conflictChecks: [],
     paymentPlans: [],
     paymentPlanReminders: [],
+    serviceNotes: [],
   };
 
   out.matterContacts = buildMatterContacts(orgId);
@@ -234,7 +236,44 @@ export function buildSeed(opts: BuildSeedOpts = {}): SeedDataset {
   out.tasks = buildTasks(orgId, ASSIGN_USERS);
   out.documentTemplates = buildTemplates(orgId, currentUserId);
   out.conflictChecks = buildConflictChecks(currentUserId);
+  out.serviceNotes = buildServiceNotes(orgId, ASSIGN_USERS);
 
+  return out;
+}
+
+/** Tjänsteanteckningar (#348) — 2-3 per aktivt ärende, spridda författare/datum. */
+function buildServiceNotes(orgId: string, assignUsers: string[]): SeedDataset["serviceNotes"] {
+  const out: SeedDataset["serviceNotes"] = [];
+  const texts = [
+    "Telefonsamtal med klienten — gick igenom nästa steg och tidplan.",
+    "Genomgång av motpartens svaromål; noterade två svaga punkter.",
+    "Kort avstämning med domstolen om förhandlingsdatum.",
+    "Klienten inkom med kompletterande underlag, diarieförde.",
+    "Övervägande kring förlikningsbud — bevakar klientens instruktion.",
+  ];
+  const activeMatters = MATTERS.filter((m) => m.status === "ACTIVE");
+  let seq = 0;
+  activeMatters.forEach((matter, mi) => {
+    const count = 2 + (mi % 2); // 2-3 per aktivt ärende
+    for (let j = 0; j < count; j++) {
+      seq++;
+      const authorId = assignUsers[(mi + j) % assignUsers.length];
+      const daysAgo = (seq * 2) + 1;
+      const d = isoDate(-daysAgo, 9 + (j % 6));
+      const pad = (n: number) => String(n).padStart(2, "0");
+      out.push({
+        id: `sn-${String(seq).padStart(3, "0")}`,
+        organizationId: orgId,
+        matterId: matter.id,
+        authorId,
+        date: `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`,
+        time: `${pad(d.getHours())}:${pad(d.getMinutes())}`,
+        text: texts[seq % texts.length],
+        createdAt: d,
+        updatedAt: d,
+      });
+    }
+  });
   return out;
 }
 


### PR DESCRIPTION
## Vad

Ny git-db-entitet **`ServiceNote`** (tjänsteanteckning) + panel i ärendet —
**datum + tid + text + författare**, append-only i v1 (juridisk spårbarhet).

Full vertikal slice:

- **Schema**: `serviceNoteSchema` (zod-strikt) + `serviceNoteIdSchema`;
  registrerad i `ENTITY_REGISTRY` (`service-notes/<id>.json`) + `EntityName`-
  union + `DemoSource`.
- **Datastore**: `ServiceNoteDelegate` i `IDataStore` + `DataStoreTx`, wirad i
  `DemoDataStore` (delegate, `entityNameFor`, `txView`) + relations
  (`matter` + `author`).
- **tRPC**: `serviceNoteRouter` — `list` (per ärende, org-scopad via
  `matter.organizationId`, joinar `author`) + `create` (sätter `authorId` +
  `organizationId` från principalen). Registrerad i `_app`.
- **UI**: `ServiceNotesSection`-panel i ärende-detaljen — lista (fallande på
  notens datum+tid, författarnamn) + skapa-formulär (datum/tid förifyllt till nu).
- **Seed**: 2-3 exempel-anteckningar per aktivt ärende.
- **generate-demo-manifest**: la till `service-notes` i scan-paths (annars
  404:ar demon på `/service-notes/.json`) — test-vakten "ALLA entity-mappar"
  fångade detta.

## Tester (ny coverage)
- `service-note.test.ts` — schema-parse (strikt, kräver text/date/time/matter/author)
- `serviceNote.test.ts` — router list-scoping + author-join + create-fält
- `service-notes-section.test.tsx` — panel: tomtillstånd, lista+sortering,
  öppna/avbryt/skapa-flöde
- matter-detalj-sidans + mock-data-store:s trpc-mock utökad med `serviceNote`

## Verifiering (CI-spegel lokalt)
- `bun run test:run` — pass A 2983 + pass B 48, **0 fail**
- `bun run typecheck` / `lint --max-warnings 0` / `knip` — rent
- `bash tooling/scripts/build-demo.sh` — OK (static export)

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)