### PR TITLE
test(coverage): testa ContactsSection — ärendets kontakt-panel (#27)

### DIFF
--- a/test/unit/app/matters/contacts-section.test.tsx
+++ b/test/unit/app/matters/contacts-section.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Test för ContactsSection (#27) — kontakt-panelen i ärendet: lista (namn/roll/
+ * nummer), lägg-till-formulär (ny vs befintlig), skapa/koppla/ta-bort-mutationer.
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest-compat";
+import { ContactsSection } from "@/app/matters/[id]/_contacts-section";
+
+vi.mock("@/lib/client/demo/entity-link", () => ({
+  EntityLink: ({ children }: { children: React.ReactNode }) => <a href="#">{children}</a>,
+}));
+
+const contactsListQuery = { data: { contacts: [{ id: "c2", name: "Berit Befintlig" }] }, isLoading: false };
+const addContact = vi.fn();
+const addNewContact = vi.fn();
+const removeContact = vi.fn();
+const noopMut = () => ({ mutate: vi.fn(), isPending: false });
+
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: {
+    useUtils: () => ({
+      matter: { getById: { invalidate: vi.fn() } },
+      contacts: { list: { invalidate: vi.fn() } },
+    }),
+    contacts: { list: { useQuery: () => contactsListQuery } },
+    matter: {
+      addContact: { useMutation: () => ({ mutate: addContact, isPending: false }) },
+      addNewContact: { useMutation: () => ({ mutate: addNewContact, isPending: false }) },
+      removeContact: { useMutation: () => ({ mutate: removeContact, isPending: false }) },
+    },
+    prefs: {
+      get: { useQuery: () => ({ data: undefined, isLoading: false }) },
+      save: { useMutation: noopMut },
+      clear: { useMutation: noopMut },
+      setOrgDefault: { useMutation: noopMut },
+      clearOrgDefault: { useMutation: noopMut },
+    },
+    user: { current: { useQuery: () => ({ data: { id: "u1", role: "LAWYER" } }) } },
+  },
+}));
+
+const contacts = [
+  { id: "mc1", role: "KLIENT", contact: { id: "c1", name: "Klient Karlsson", personalNumber: "19800101-1234" } },
+];
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("ContactsSection", () => {
+  it("visar rubrik med antal + kontaktraderna (namn, roll, nummer)", () => {
+    render(<ContactsSection matterId="m1" contacts={contacts} />);
+    expect(screen.getByText("Kontakter (1)")).toBeInTheDocument();
+    expect(screen.getByText("Klient Karlsson")).toBeInTheDocument();
+    expect(screen.getByText("19800101-1234")).toBeInTheDocument();
+  });
+
+  it("tomt → tomtillstånd", () => {
+    render(<ContactsSection matterId="m1" contacts={[]} />);
+    expect(screen.getByText("Kontakter (0)")).toBeInTheDocument();
+    expect(screen.getByText("Inga kontakter kopplade")).toBeInTheDocument();
+  });
+
+  it("'+ Lägg till' öppnar ny-kontakt-formuläret (default-läge)", () => {
+    render(<ContactsSection matterId="m1" contacts={[]} />);
+    fireEvent.click(screen.getByText("+ Lägg till"));
+    expect(screen.getByPlaceholderText("Namn *")).toBeInTheDocument();
+  });
+
+  it("skapar ny kontakt → addNewContact.mutate med matterId + fält", () => {
+    render(<ContactsSection matterId="m1" contacts={[]} />);
+    fireEvent.click(screen.getByText("+ Lägg till"));
+    fireEvent.change(screen.getByPlaceholderText("Namn *"), { target: { value: "Ny Person" } });
+    fireEvent.click(screen.getByRole("button", { name: /Skapa & lägg till/ }));
+    expect(addNewContact).toHaveBeenCalledWith(expect.objectContaining({ matterId: "m1", name: "Ny Person" }));
+  });
+
+  it("växlar till befintlig kontakt och kopplar → addContact.mutate", () => {
+    render(<ContactsSection matterId="m1" contacts={[]} />);
+    fireEvent.click(screen.getByText("+ Lägg till"));
+    fireEvent.click(screen.getByText("Befintlig kontakt"));
+    // Första comboboxen i befintlig-formuläret = kontakt-väljaren.
+    fireEvent.change(screen.getAllByRole("combobox")[0]!, { target: { value: "c2" } });
+    fireEvent.click(screen.getByRole("button", { name: /^Lägg till$/ }));
+    expect(addContact).toHaveBeenCalledWith(expect.objectContaining({ matterId: "m1", contactId: "c2" }));
+  });
+
+  it("Ta bort → removeContact.mutate med matterContactId", () => {
+    render(<ContactsSection matterId="m1" contacts={contacts} />);
+    fireEvent.click(screen.getByText("Ta bort"));
+    expect(removeContact).toHaveBeenCalledWith({ matterContactId: "mc1" });
+  });
+});


### PR DESCRIPTION
## Vad

#27-ratchet-steg. `src/app/matters/[id]/_contacts-section.tsx` saknade direkt
test (bara råd-renderad via matter-detalj-sidans test).

Lägger till **`test/unit/app/matters/contacts-section.test.tsx`** (6 fall):
rubrik + rader (namn/roll/nummer), tomtillstånd, öppna lägg-till-formuläret,
skapa ny kontakt → `addNewContact.mutate`, koppla befintlig → `addContact.mutate`,
ta bort → `removeContact.mutate`. Låser kontakt-formulärens beteende (ny vs
befintlig) som annars bara fanns oprövat.

Rad-täckning (src/) **84.85% → 84.87%**, funktioner 81.28% (oförändrat — netto-
vinsten är gren-täckning av formulären; panelen råd-renderas redan av sid-testet).
Golvet lämnas (0.84/0.80).

## Verifiering (CI-spegel lokalt)
- `bun run test:cov` — rader 84.87% (golv 84.00%) → grön
- `bun run lint --max-warnings 0` / `knip` / `typecheck` — rent
- `bun test …/contacts-section.test.tsx` — 6 pass

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)