### PR TITLE
refactor(calendar): eventFormDefaults ≤8, ta bort complexity-disable

### DIFF
--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -371,23 +371,40 @@ function toLocalInput(d: Date | string | null | undefined): string {
   return `${dt.getFullYear()}-${pad(dt.getMonth() + 1)}-${pad(dt.getDate())}T${pad(dt.getHours())}:${pad(dt.getMinutes())}`;
 }
 
-/**
- * Initialvärden för event-formuläret ur en ev. redigerad rad. Platt
- * fält-mappning utan logik — komplexiteten är enbart nullish-defaults.
- */
-// eslint-disable-next-line complexity
-function eventFormDefaults(initial?: EventRow) {
+/** Tomma initialvärden för ett nytt event (ingen redigerad rad). */
+function emptyEventForm() {
   return {
-    title: initial?.title ?? "",
-    kind: initial?.kind ?? "appointment",
-    startAt: initial ? toLocalInput(initial.startAt) : new Date().toISOString().slice(0, 16),
-    endAt: initial?.endAt ? toLocalInput(initial.endAt) : "",
-    location: initial?.location ?? "",
-    matterId: initial?.matterId ?? "",
-    mirrorToOutlook: initial?.mirrorToOutlook ?? false,
-    inviteeUserIds: initial?.inviteeUserIds ?? [],
-    inviteeContactIds: initial?.inviteeContactIds ?? [],
+    title: "",
+    kind: "appointment" as "appointment" | "deadline",
+    startAt: new Date().toISOString().slice(0, 16),
+    endAt: "",
+    location: "",
+    matterId: "",
+    mirrorToOutlook: false,
+    inviteeUserIds: [] as string[],
+    inviteeContactIds: [] as string[],
   };
+}
+
+/** Initialvärden ur en redigerad rad. `i` är garanterat satt → vanlig
+ *  fält-access (inte optional-chain), så komplexiteten stannar lågt. */
+function eventFormFromRow(i: EventRow) {
+  return {
+    title: i.title,
+    kind: i.kind,
+    startAt: toLocalInput(i.startAt),
+    endAt: i.endAt ? toLocalInput(i.endAt) : "",
+    location: i.location ?? "",
+    matterId: i.matterId ?? "",
+    mirrorToOutlook: i.mirrorToOutlook ?? false,
+    inviteeUserIds: i.inviteeUserIds ?? [],
+    inviteeContactIds: i.inviteeContactIds ?? [],
+  };
+}
+
+/** Initialvärden för event-formuläret ur en ev. redigerad rad. */
+function eventFormDefaults(initial?: EventRow) {
+  return initial ? eventFormFromRow(initial) : emptyEventForm();
 }
 
 /** Bygger mirror-to-outlook-argumenten (upsert) för en sparad event-rad. */


### PR DESCRIPTION
Del av #199 — UI-kod under komplexitetstaket 8, inga inline-disables.

## Vad
`src/app/calendar/page.tsx`:
- `eventFormDefaults` (cyklomatisk komplexitet **18**) bröt mot 8-taket via inline `// eslint-disable-next-line complexity`.
- Delas i tre: `emptyEventForm` (tomt nytt event), `eventFormFromRow(i: EventRow)` (känd rad → **vanlig fält-access istället för `initial?.`-optional-chain**, vilket är där komplexiteten kom ifrån), och en tunn `eventFormDefaults` som väljer mellan dem.
- **Inline-disable borttagen.**

## Verifierat lokalt
- `eslint --no-inline-config --rule complexity:8` → 0 complexity-offenders (kvar: 2 `react-hooks/set-state-in-effect` — separata, legitima inline-disables, utanför #199:s scope)
- `tsc --noEmit` (efter `rm tsbuildinfo`) grön
- `bun run lint` på filen grön
- `bun test test/unit/app/calendar/` → 49 pass

Refs #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)