### PR TITLE
feat(matters): redigera/ta bort tjänsteanteckning + radåtgärder + textwrap

### DIFF
--- a/src/app/matters/[id]/_service-notes-section.tsx
+++ b/src/app/matters/[id]/_service-notes-section.tsx
@@ -2,10 +2,10 @@
 
 /**
  * Tjänsteanteckningar (#348) — panel i ärendet. Korta, daterade noteringar
- * (datum + tid + text + författare). Append-only i v1.
+ * (datum + tid + text + författare). Redigerbara/raderbara (#375).
  */
 
-import { NotebookPen } from "lucide-react";
+import { NotebookPen, Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { DataTable, type Column } from "@/components/ui/data-table";
 import { trpc } from "@/lib/client/trpc";
@@ -37,8 +37,9 @@ function authorName(n: ServiceNote): string {
 }
 
 /** Kolumnerna för tjänsteanteckningstabellen — en rad per anteckning, alla
- *  sorterbara/filterbara precis som övriga AVA-tabeller (#367). */
-function noteColumns(): Column<ServiceNote>[] {
+ *  sorterbara/filterbara precis som övriga AVA-tabeller (#367). Anteckning-
+ *  kolumnen wrappar lång text + en actions-kolumn med redigera/ta-bort (#375). */
+function noteColumns(opts: { onEdit: (n: ServiceNote) => void; onDelete: (id: string) => void }): Column<ServiceNote>[] {
   return [
     { key: "date", label: "Datum", sortable: true, filterable: true,
       sortValue: (n) => n.date, filterValue: (n) => n.date,
@@ -49,18 +50,46 @@ function noteColumns(): Column<ServiceNote>[] {
     { key: "author", label: "Författare", sortable: true, filterable: true, groupable: true,
       sortValue: authorName, filterValue: authorName, groupValue: authorName,
       render: (n) => <span className="text-sm text-gray-900 whitespace-nowrap">{authorName(n)}</span> },
-    { key: "text", label: "Anteckning", sortable: true, filterable: true,
+    { key: "text", label: "Anteckning", sortable: true, filterable: true, wrap: true, defaultWidth: 380,
       sortValue: (n) => n.text, filterValue: (n) => n.text,
-      render: (n) => <span className="text-sm text-gray-800 whitespace-pre-wrap">{n.text}</span> },
+      render: (n) => <span className="text-sm text-gray-800 whitespace-pre-wrap break-words">{n.text}</span> },
+    { key: "actions", label: "", sortable: false, align: "right", hideable: false,
+      render: (n) => (
+        <span className="inline-flex items-center gap-2 whitespace-nowrap">
+          <button type="button" onClick={() => opts.onEdit(n)} title="Redigera"
+            className="text-gray-400 hover:text-blue-600"><Pencil size={14} /></button>
+          <button type="button" onClick={() => opts.onDelete(n.id)} title="Ta bort"
+            className="text-gray-400 hover:text-red-600"><Trash2 size={14} /></button>
+        </span>
+      ) },
   ];
+}
+
+/** Initialvärden för formuläret: redigerad nots fält, annars nu + tom text. */
+function initialValues(initial?: ServiceNote | null): { date: string; time: string; text: string } {
+  if (initial) return { date: initial.date, time: initial.time, text: initial.text };
+  const n = nowParts();
+  return { date: n.date, time: n.time, text: "" };
 }
 
 export function ServiceNotesSection({ matterId }: { matterId: string }) {
   const utils = trpc.useUtils();
   const notes = trpc.serviceNote.list.useQuery({ matterId });
   const [adding, setAdding] = useState(false);
+  const [editing, setEditing] = useState<ServiceNote | null>(null);
+  const del = trpc.serviceNote.delete.useMutation({
+    onSuccess: () => void utils.serviceNote.list.invalidate({ matterId }),
+  });
+
+  const close = (): void => { setAdding(false); setEditing(null); };
+  const refresh = (): void => { close(); void utils.serviceNote.list.invalidate({ matterId }); };
+  const showForm = adding || editing !== null;
 
   const items = ((notes.data ?? []) as ServiceNote[]).slice().sort(byDateTimeDesc);
+  const columns = noteColumns({
+    onEdit: (n) => { setAdding(false); setEditing(n); },
+    onDelete: (id) => { if (confirm("Ta bort tjänsteanteckningen?")) del.mutate({ id }); },
+  });
 
   return (
     <div className="bg-white rounded-lg border border-gray-200 lg:col-span-2">
@@ -68,20 +97,16 @@ export function ServiceNotesSection({ matterId }: { matterId: string }) {
         <h2 className="font-semibold text-gray-900 flex items-center gap-2">
           <NotebookPen size={16} /> Tjänsteanteckningar
         </h2>
-        {!adding && (
-          <button onClick={() => setAdding(true)} className="text-sm text-blue-600 hover:underline">
+        {!showForm && (
+          <button onClick={() => { setEditing(null); setAdding(true); }} className="text-sm text-blue-600 hover:underline">
             + Ny anteckning
           </button>
         )}
       </div>
 
       <div className="p-4 space-y-3">
-        {adding && (
-          <NoteForm
-            matterId={matterId}
-            onDone={() => { setAdding(false); void utils.serviceNote.list.invalidate({ matterId }); }}
-            onCancel={() => setAdding(false)}
-          />
+        {showForm && (
+          <NoteForm matterId={matterId} initial={editing} onDone={refresh} onCancel={close} />
         )}
 
         {notes.isLoading ? (
@@ -89,7 +114,7 @@ export function ServiceNotesSection({ matterId }: { matterId: string }) {
         ) : (
           <DataTable
             prefKey={`list.matter-service-notes.${matterId}`}
-            columns={noteColumns()}
+            columns={columns}
             data={items}
             rowKey={(n) => n.id}
             emptyMessage="Inga tjänsteanteckningar ännu."
@@ -100,17 +125,22 @@ export function ServiceNotesSection({ matterId }: { matterId: string }) {
   );
 }
 
-function NoteForm({ matterId, onDone, onCancel }: { matterId: string; onDone: () => void; onCancel: () => void }) {
-  const init = nowParts();
-  const [date, setDate] = useState(init.date);
-  const [time, setTime] = useState(init.time);
-  const [text, setText] = useState("");
+function NoteForm({ matterId, initial, onDone, onCancel }: {
+  matterId: string; initial?: ServiceNote | null; onDone: () => void; onCancel: () => void;
+}) {
+  const start = initialValues(initial);
+  const [date, setDate] = useState(start.date);
+  const [time, setTime] = useState(start.time);
+  const [text, setText] = useState(start.text);
   const create = trpc.serviceNote.create.useMutation({ onSuccess: onDone });
+  const update = trpc.serviceNote.update.useMutation({ onSuccess: onDone });
+  const pending = create.isPending || update.isPending;
 
   function submit(e: React.FormEvent): void {
     e.preventDefault();
     if (!text.trim()) return;
-    create.mutate({ matterId, date, time, text: text.trim() });
+    if (initial) update.mutate({ id: initial.id, date, time, text: text.trim() });
+    else create.mutate({ matterId, date, time, text: text.trim() });
   }
 
   return (
@@ -136,9 +166,9 @@ function NoteForm({ matterId, onDone, onCancel }: { matterId: string; onDone: ()
       <div className="flex justify-end gap-2">
         <button type="button" onClick={onCancel}
           className="px-3 py-1.5 text-sm border border-gray-300 rounded hover:bg-white">Avbryt</button>
-        <button type="submit" disabled={!text.trim() || create.isPending}
+        <button type="submit" disabled={!text.trim() || pending}
           className="px-3 py-1.5 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 disabled:opacity-50">
-          {create.isPending ? "Sparar…" : "Spara"}
+          {pending ? "Sparar…" : "Spara"}
         </button>
       </div>
     </form>

--- a/src/components/ui/data-table-logic.ts
+++ b/src/components/ui/data-table-logic.ts
@@ -28,6 +28,9 @@ export interface Column<T> {
   groupable?: boolean;
   defaultWidth?: number;
   align?: "left" | "right" | "center";
+  /** Låt cellens innehåll wrappa över flera rader (annars `nowrap`). Använd
+   *  för fri-text-kolumner (t.ex. tjänsteanteckningar) som annars trunkeras. */
+  wrap?: boolean;
   hideable?: boolean;
   /** Kolumnen finns i katalogen men är inte visad förrän användaren explicit
    *  väljer "+ Visa kolumn → <denna>". Använd för fält som är intressanta

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -51,6 +51,12 @@ function widthOf<T>(col: Column<T>, prefs: DataTablePrefs): number | undefined {
   return prefs.columns?.find((c) => c.key === col.key)?.width ?? col.defaultWidth;
 }
 
+/** Cell-klass för data-rader: wrappande kolumner bryter text över flera rader,
+ *  övriga håller `nowrap` (default). */
+function cellClass<T>(col: Column<T>): string {
+  return `px-3 py-2 ${col.wrap ? "whitespace-normal break-words" : "whitespace-nowrap"}`;
+}
+
 export function DataTable<T>({ prefKey, columns, data, rowKey, onRowClick, emptyMessage, footer }: Props<T>) {
   const persisted = trpc.prefs.get.useQuery({ key: prefKey });
   const save = trpc.prefs.save.useMutation();
@@ -383,7 +389,7 @@ function GroupBlock<T>({ group, vCols, prefs, rowKey, onRowClick, showSummary, c
       {group.rows.map((r) => (
         <tr key={rowKey(r)} className={onRowClick ? "hover:bg-gray-50 cursor-pointer" : ""} onClick={onRowClick ? () => onRowClick(r) : undefined}>
           {vCols.map((c) => (
-            <td key={c.key} style={{ width: widthOf(c, prefs), textAlign: c.align ?? "left" }} className="px-3 py-2 whitespace-nowrap">
+            <td key={c.key} style={{ width: widthOf(c, prefs), textAlign: c.align ?? "left" }} className={cellClass(c)}>
               {c.render(r)}
             </td>
           ))}

--- a/src/lib/server/routers/serviceNote.ts
+++ b/src/lib/server/routers/serviceNote.ts
@@ -6,12 +6,13 @@ import {
   userIdSchema,
   serviceNoteIdSchema,
 } from "@/lib/shared/schemas/ids";
-import { router, protectedProcedure } from "../trpc";
+import { router, protectedProcedure, orgProcedure, TRPCError } from "../trpc";
 
 /**
  * Tjänsteanteckningar (#348) — korta, daterade noteringar i ett ärende.
- * Append-only i v1 (juridisk spårbarhet): bara `list` + `create`, ingen
- * update/delete. `authorId` sätts från principalen (ej editerbart i UI:t).
+ * `list` + `create` + `update` + `delete` (#375). `authorId` sätts från
+ * principalen vid create (ej editerbart i UI:t). Redigera/ta-bort är
+ * org-scopade: ägarkoll via matter INNAN mutation, NOT_FOUND vid mismatch.
  */
 export const serviceNoteRouter = router({
   list: protectedProcedure
@@ -53,5 +54,38 @@ export const serviceNoteRouter = router({
           ...(input.createdAt ? { createdAt: new Date(input.createdAt) } : {}),
         }),
       });
+    }),
+
+  update: orgProcedure
+    .input(
+      z.object({
+        id: z.string(),
+        date: z.string().min(1).optional(),
+        time: z.string().min(1).optional(),
+        text: z.string().min(1).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      // Ägarkoll (samma org-scopning som `list`) INNAN update — NOT_FOUND vid
+      // mismatch läcker inte existens.
+      const owned = await ctx.dataStore.serviceNotes.findFirst({
+        where: { id: input.id, matter: { organizationId: ctx.orgId } },
+      });
+      if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
+      const { id, date, time, text } = input;
+      return ctx.dataStore.serviceNotes.update({
+        where: { id },
+        data: omitUndefined({ date, time, text }),
+      });
+    }),
+
+  delete: orgProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const owned = await ctx.dataStore.serviceNotes.findFirst({
+        where: { id: input.id, matter: { organizationId: ctx.orgId } },
+      });
+      if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
+      return ctx.dataStore.serviceNotes.delete({ where: { id: input.id } });
     }),
 });

--- a/test/unit/app/matters/[id]/page.test.tsx
+++ b/test/unit/app/matters/[id]/page.test.tsx
@@ -106,6 +106,8 @@ vi.mock("@/lib/client/trpc", () => ({
     serviceNote: {
       list: { useQuery: () => ({ data: [], isLoading: false }) },
       create: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      update: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      delete: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
     },
     user: {
       current: { useQuery: () => ({ data: { id: "u1", name: "Anna", email: "anna@firma.local" } }) },

--- a/test/unit/app/matters/service-notes-section.test.tsx
+++ b/test/unit/app/matters/service-notes-section.test.tsx
@@ -10,6 +10,8 @@ import { ServiceNotesSection } from "@/app/matters/[id]/_service-notes-section";
 
 const listQuery = { data: [] as unknown[], isLoading: false };
 const createMutate = vi.fn();
+const updateMutate = vi.fn();
+const deleteMutate = vi.fn();
 let createOnSuccess: (() => void) | undefined;
 const invalidate = vi.fn();
 
@@ -27,6 +29,8 @@ vi.mock("@/lib/client/trpc", () => ({
           return { mutate: (a: unknown) => createMutate(a), isPending: false };
         },
       },
+      update: { useMutation: () => ({ mutate: (a: unknown) => updateMutate(a), isPending: false }) },
+      delete: { useMutation: () => ({ mutate: (a: unknown) => deleteMutate(a), isPending: false }) },
     },
     // DataTable-beroenden (#367): tjänsteanteckningarna renderas nu i en
     // DataTable som läser prefs + current user.
@@ -89,5 +93,41 @@ describe("ServiceNotesSection", () => {
     const form = screen.getByPlaceholderText(/Vad hände/).closest("form")!;
     fireEvent.submit(form);
     expect(createMutate).not.toHaveBeenCalled();
+  });
+
+  it("Redigera öppnar formuläret förifyllt och submit skickar update med id (#375)", () => {
+    listQuery.data = [
+      { id: "a", date: "2026-06-10", time: "08:00", text: "Gammal text", author: { name: "Anna" } },
+    ];
+    render(<ServiceNotesSection matterId="m1" />);
+    fireEvent.click(screen.getByTitle("Redigera"));
+    const textarea = screen.getByPlaceholderText(/Vad hände/) as HTMLTextAreaElement;
+    expect(textarea.value).toBe("Gammal text"); // förifyllt
+    fireEvent.change(textarea, { target: { value: "Ny text" } });
+    fireEvent.click(screen.getByRole("button", { name: "Spara" }));
+    expect(updateMutate).toHaveBeenCalledWith(expect.objectContaining({ id: "a", text: "Ny text" }));
+    expect(createMutate).not.toHaveBeenCalled();
+  });
+
+  it("Ta bort kallar delete med id efter confirm (#375)", () => {
+    listQuery.data = [
+      { id: "a", date: "2026-06-10", time: "08:00", text: "Text", author: { name: "Anna" } },
+    ];
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    render(<ServiceNotesSection matterId="m1" />);
+    fireEvent.click(screen.getByTitle("Ta bort"));
+    expect(deleteMutate).toHaveBeenCalledWith({ id: "a" });
+    confirmSpy.mockRestore();
+  });
+
+  it("Ta bort gör inget om confirm avbryts (#375)", () => {
+    listQuery.data = [
+      { id: "a", date: "2026-06-10", time: "08:00", text: "Text", author: { name: "Anna" } },
+    ];
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    render(<ServiceNotesSection matterId="m1" />);
+    fireEvent.click(screen.getByTitle("Ta bort"));
+    expect(deleteMutate).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
   });
 });

--- a/test/unit/server/routers/serviceNote.test.ts
+++ b/test/unit/server/routers/serviceNote.test.ts
@@ -1,7 +1,7 @@
 /**
- * Test för serviceNoteRouter (#348) — append-only list + create.
+ * Test för serviceNoteRouter (#348/#375) — list + create + update + delete.
  * list org-scopas via matter.organizationId; create sätter authorId + org
- * från context.
+ * från context; update/delete ägarkollar via matter (findFirst) → NOT_FOUND.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
@@ -12,6 +12,9 @@ const mockPrisma = {
   serviceNote: {
     findMany: vi.fn(),
     create: vi.fn(),
+    findFirst: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
   },
 };
 
@@ -28,6 +31,9 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockPrisma.serviceNote.findMany.mockResolvedValue([]);
   mockPrisma.serviceNote.create.mockResolvedValue({ id: "sn1" });
+  mockPrisma.serviceNote.findFirst.mockResolvedValue({ id: "sn1" });
+  mockPrisma.serviceNote.update.mockResolvedValue({ id: "sn1" });
+  mockPrisma.serviceNote.delete.mockResolvedValue({ id: "sn1" });
 });
 
 describe("serviceNote.list", () => {
@@ -67,5 +73,43 @@ describe("serviceNote.create", () => {
       matterId: "m1", date: "2026-06-15", time: "09:30", text: "X", authorId: "u-fix",
     });
     expect(mockPrisma.serviceNote.create.mock.calls[0]![0].data.authorId).toBe("u-fix");
+  });
+});
+
+describe("serviceNote.update (#375)", () => {
+  it("ägarkollar via matter.organizationId innan update", async () => {
+    await makeCaller("org-a").update({ id: "sn1", text: "Rättad" });
+    expect(mockPrisma.serviceNote.findFirst).toHaveBeenCalledWith({
+      where: { id: "sn1", matter: { organizationId: "org-a" } },
+    });
+    expect(mockPrisma.serviceNote.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "sn1" }, data: expect.objectContaining({ text: "Rättad" }) }),
+    );
+  });
+
+  it("kastar NOT_FOUND vid org-mismatch (läcker inte existens)", async () => {
+    mockPrisma.serviceNote.findFirst.mockResolvedValue(null);
+    await expect(makeCaller("org-x").update({ id: "sn1", text: "X" })).rejects.toThrow();
+    expect(mockPrisma.serviceNote.update).not.toHaveBeenCalled();
+  });
+
+  it("kräver icke-tom text när text anges", async () => {
+    await expect(makeCaller().update({ id: "sn1", text: "" })).rejects.toThrow();
+  });
+});
+
+describe("serviceNote.delete (#375)", () => {
+  it("ägarkollar via matter.organizationId innan delete", async () => {
+    await makeCaller("org-a").delete({ id: "sn1" });
+    expect(mockPrisma.serviceNote.findFirst).toHaveBeenCalledWith({
+      where: { id: "sn1", matter: { organizationId: "org-a" } },
+    });
+    expect(mockPrisma.serviceNote.delete).toHaveBeenCalledWith({ where: { id: "sn1" } });
+  });
+
+  it("kastar NOT_FOUND vid org-mismatch", async () => {
+    mockPrisma.serviceNote.findFirst.mockResolvedValue(null);
+    await expect(makeCaller("org-x").delete({ id: "sn1" })).rejects.toThrow();
+    expect(mockPrisma.serviceNote.delete).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #375 — tjänsteanteckningar var append-only; användaren behöver kunna rätta/ta bort dem, med radåtgärds-ikoner och läsbar (wrappad) text.

## Vad
**Router** (`serviceNote.ts`): nya `update` + `delete` mutationer. Org-scopad ägarkoll via `matter.organizationId` (`findFirst`) INNAN mutation → `NOT_FOUND` vid mismatch (läcker inte existens), samma mönster som `expense`-routern.

**UI** (`_service-notes-section.tsx`):
- Actions-kolumn längst till höger (`hideable:false`, ej sorterbar) med **penna**- (redigera) och **papperskorg**-ikoner (ta bort).
- Redigera öppnar formuläret **förifyllt** och sparar via `update`; Ta bort **bekräftas** (confirm) och kallar `delete`.
- "+ Ny anteckning" och redigera delar samma `NoteForm` (create vs update beroende på `initial`).

**DataTable** (`data-table.tsx` + `-logic.ts`): ny per-kolumn-flagga **`wrap`** → cellen får `whitespace-normal break-words` istället för `nowrap`. Anteckning-kolumnen sätter `wrap` + `defaultWidth` så **lång text wrappar över flera rader** istället för att trunkeras.

## Verifierat lokalt
- `eslint --no-inline-config --rule complexity:8` → 0 offenders (alla nya funktioner ≤8)
- `tsc --noEmit` (efter `rm tsbuildinfo`) grön
- `bun run lint` + `bun run knip` grön
- Tester: serviceNote-routern (update/delete + NOT_FOUND), ServiceNotesSection (redigera förifyllt → update, ta bort → delete + confirm-avbryt), DataTable, matter-sidan → alla gröna

Refs #348 #367