### PR TITLE
ci(quality): utöka complexity-strict-grinden till src/app + src/components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,10 @@ jobs:
       # warnings OCH oavsedda warning-regler. Skulden betas av via `yarn
       # lint:prune` när en lång funktion bryts ut. Se docs/quality.md.
       - run: bun run lint --max-warnings 0
-      # Enforcing #40: src/lib hålls strikt på complexity@8 — inga complexity-
-      # undantag (inline-disable eller suppressions). Se docs/quality.md.
-      - run: bun run lint:lib-complexity
+      # Enforcing #40 + #199: src/lib, src/app + src/components hålls strikt på
+      # complexity@8 — inga complexity-undantag (inline-disable/suppressions).
+      # Se docs/quality.md.
+      - run: bun run lint:complexity-strict
       - run: bun run deps:check
       # Gating: fäller på strukturfynd (döda filer, oanvända/olistade deps).
       # Export-/typ-fynd är "warn" i knip.json (rådgivande) tills #3/#4 städat dem.

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -92,17 +92,21 @@ Alla struktur-regler är `error` (inte `warn`). CI kör `bun run lint --max-warn
 | Parametrar per funktion | 5 | error |
 | Nästade callbacks | 4 | error |
 
-#### `src/lib` strikt på complexity (#40)
+#### `src/lib` + `src/app` + `src/components` strikt på complexity (#40 + #199)
 
 `complexity@8` gäller globalt, men kunde kringgås med inline-disable eller en
-post i `eslint-suppressions.json`. **`src/lib/**` (ren logik) hålls nu helt
-fritt från complexity-undantag** — `bun run lint:lib-complexity`
-([`check-lib-complexity-strict.ts`](../tooling/scripts/check-lib-complexity-strict.ts))
-faller om någon återinför en complexity-disable eller -suppression där. Den
-körs i CI:s static-jobb. Bryt ut hjälpfunktioner i stället (alla 23 tidigare
-offenders refaktorerades i #40). UI-lagret (`src/app`/`src/components`), där
-JSX-grenar blåser upp cyklomatisk komplexitet, får en egen komponentmedveten
-tröskel separat (#199).
+post i `eslint-suppressions.json`. **`src/lib/**` (ren logik, #40) samt
+`src/app/**` + `src/components/**` (UI, #199) hålls nu helt fritt från
+complexity-undantag** — `bun run lint:complexity-strict`
+([`check-complexity-strict.ts`](../tooling/scripts/check-complexity-strict.ts))
+faller om någon återinför en complexity-disable eller -suppression i något av
+dessa träd. Den körs i CI:s static-jobb. Bryt ut hjälpfunktioner/sub-komponenter
+i stället (alla 23 lib-offenders refaktorerades i #40; UI-offenders i #199).
+
+**Ingen lösare tröskel för UI.** JSX-grenar (`{cond && <X/>}`, optional chaining)
+räknas mot komplexiteten precis som annan kod — lösningen är att bryta ut
+sub-komponenter/hjälpare, inte ett högre tak. UI-kod är up for refactoring som
+vilken annan kod som helst (#199).
 
 #### max-lines-cap & ventil (#41)
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "smoke:tier3": "bash tooling/scripts/test-tier3-smoke.sh",
     "test:all": "bash tooling/scripts/test-all.sh",
     "duplicates": "jscpd --config tooling/config/jscpd.json src",
-    "lint:lib-complexity": "bun tooling/scripts/check-lib-complexity-strict.ts",
+    "lint:complexity-strict": "bun tooling/scripts/check-complexity-strict.ts",
     "deps:check": "depcruise --config tooling/config/dependency-cruiser.cjs --output-type err src test helper-app office-addin",
     "deps:graph": "depcruise --config tooling/config/dependency-cruiser.cjs --output-type dot src | dot -Tsvg > reports/dependency-graph.svg",
     "deps:archi": "depcruise --config tooling/config/dependency-cruiser.cjs --output-type archi src | dot -Tsvg > reports/architecture.svg",

--- a/tooling/scripts/check-complexity-strict.ts
+++ b/tooling/scripts/check-complexity-strict.ts
@@ -1,24 +1,26 @@
 /**
- * Enforcing-grind för #40: `src/lib/**` ska hållas STRIKT på complexity@8 —
- * helt fritt från complexity-undantag.
+ * Enforcing-grind för complexity@8: source-trädet ska hållas STRIKT på
+ * complexity@8 — helt fritt från complexity-undantag.
  *
  * ESLint-regeln `complexity: ["error", { max: 8 }]` gäller redan globalt, men
  * den kan kringgås på två sätt. Den här grinden stänger båda specifikt för
- * `src/lib` (ren logik — JSX-komponenter i src/app hanteras separat, #199):
+ * `src/lib` (#40, ren logik), `src/app` + `src/components` (#199, UI):
  *
  *   1. Inline `// eslint-disable[-next-line] … complexity`.
  *   2. Poster i `eslint-suppressions.json` med en `complexity`-nyckel.
  *
- * Faller (exit 1) om något återinförs. RATCHET: src/lib gick till 0 i #40 och
- * ska förbli 0. Se docs/quality.md.
+ * Faller (exit 1) om något återinförs. RATCHET: alla tre trädena gick till 0
+ * (src/lib i #40, src/app + src/components i #199) och ska förbli 0. UI-kod är
+ * up for refactoring som vilken annan kod som helst — bryt ut hjälpfunktioner/
+ * sub-komponenter så funktionen hamnar ≤8 i stället. Se docs/quality.md.
  *
- * Kör: `bun run lint:lib-complexity`
+ * Kör: `bun run lint:complexity-strict`
  */
 
 import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
-const LIB_DIR = "src/lib";
+const DIRS = ["src/lib", "src/app", "src/components"];
 const SUPPRESSIONS = "eslint-suppressions.json";
 const DISABLE_RE = /eslint-disable(?:-next-line|-line)?[^\n]*\bcomplexity\b/;
 
@@ -33,18 +35,21 @@ function walk(dir: string): string[] {
 }
 
 const inlineHits: string[] = [];
-for (const file of walk(LIB_DIR)) {
-  const lines = readFileSync(file, "utf8").split("\n");
-  lines.forEach((line, i) => {
-    if (DISABLE_RE.test(line)) inlineHits.push(`${file}:${i + 1}`);
-  });
+for (const dir of DIRS) {
+  for (const file of walk(dir)) {
+    const lines = readFileSync(file, "utf8").split("\n");
+    lines.forEach((line, i) => {
+      if (DISABLE_RE.test(line)) inlineHits.push(`${file}:${i + 1}`);
+    });
+  }
 }
 
 const suppressionHits: string[] = [];
 try {
   const sup = JSON.parse(readFileSync(SUPPRESSIONS, "utf8")) as Record<string, Record<string, unknown>>;
   for (const [file, rules] of Object.entries(sup)) {
-    if (file.startsWith(`${LIB_DIR}/`) && rules && "complexity" in rules) {
+    const inScope = DIRS.some((d) => file.startsWith(`${d}/`));
+    if (inScope && rules && "complexity" in rules) {
       suppressionHits.push(file);
     }
   }
@@ -53,11 +58,11 @@ try {
 }
 
 if (inlineHits.length === 0 && suppressionHits.length === 0) {
-  console.log(`✓ ${LIB_DIR} är strikt på complexity@8 — inga complexity-undantag.`);
+  console.log(`✓ ${DIRS.join(", ")} är strikt på complexity@8 — inga complexity-undantag.`);
   process.exit(0);
 }
 
-console.error(`✗ ${LIB_DIR} måste hållas fritt från complexity-undantag (#40).`);
+console.error(`✗ ${DIRS.join(", ")} måste hållas fritt från complexity-undantag (#40 + #199).`);
 if (inlineHits.length > 0) {
   console.error(`\n  Inline-disables (${inlineHits.length}):`);
   for (const h of inlineHits) console.error(`    ${h}`);
@@ -66,5 +71,5 @@ if (suppressionHits.length > 0) {
   console.error(`\n  Suppressions-poster (${suppressionHits.length}):`);
   for (const h of suppressionHits) console.error(`    ${h}`);
 }
-console.error(`\n  Bryt ut hjälpfunktioner så funktionen hamnar ≤8 i stället. Se docs/quality.md.`);
+console.error(`\n  Bryt ut hjälpfunktioner/sub-komponenter så funktionen hamnar ≤8 i stället. Se docs/quality.md.`);
 process.exit(1);

--- a/tooling/scripts/test-all.sh
+++ b/tooling/scripts/test-all.sh
@@ -60,7 +60,7 @@ START=$SECONDS
 bold "[1/3] Static analysis (typecheck + lint + deps + knip + duplicates)"
 run "typecheck"             bun run typecheck
 run "lint (--max-warnings 0)" bun run lint --max-warnings 0
-run "lint:lib-complexity (#40 strikt)" bun run lint:lib-complexity
+run "lint:complexity-strict (#40+#199 strikt)" bun run lint:complexity-strict
 run "deps:check (cykeldetektion)" bun run deps:check
 run "knip (död kod — gate)" bun run knip
 run "duplicates (jscpd)"    bun run duplicates


### PR DESCRIPTION
**Closes #199** — slutsteget. Alla per-fil-offendrar i UI-lagret är nu refaktorerade (#363–#374, #377, #378); denna PR låser ner det med en ratchet.

## Vad
- Generaliserar `check-lib-complexity-strict.ts` → **`check-complexity-strict.ts`**: scannar nu `src/lib` (#40) **+ `src/app` + `src/components`** (#199) och faller om någon återinför en inline `complexity`-disable eller en `complexity`-suppression i något av träden.
- Byter npm-skript `lint:lib-complexity` → **`lint:complexity-strict`**; uppdaterar CI (`.github/workflows/ci.yml` static-jobbet), `test-all.sh` och `docs/quality.md`.
- **Ingen lösare UI-tröskel** — dokumenterat i quality.md: JSX-grenar räknas som annan kod, lösningen är att bryta ut sub-komponenter/hjälpare (per din instruktion på #199).

## Kontext
Hela #199-serien (en fil per PR, grön CI varje steg):
page.tsx, invoices/[id], todo, calendar, document-row, reports, sync-diagnostics, firma-settings, users, loadSelfHosted, MatterHeader → alla ≤8 utan inline-disables.

## Verifierat lokalt
- `bun run lint:complexity-strict` → ✓ (src/lib, src/app, src/components rena) — **och faller korrekt (exit 1)** om en disable temporärt läggs tillbaka (testat)
- `eslint --no-inline-config --rule complexity:8` över hela `src/app`+`src/components` → 0 offenders
- `tsc --noEmit` + `bun run lint` + `bun run knip` gröna

🤖 Generated with [Claude Code](https://claude.com/claude-code)