### PR TITLE
feat(billing): rättshjälp-beräkningar + slutfaktura-sammanställning (#349)

### DIFF
--- a/src/app/invoices/[id]/_client.tsx
+++ b/src/app/invoices/[id]/_client.tsx
@@ -13,6 +13,7 @@ import { trpc } from "@/lib/client/trpc";
 import { formatCurrency } from "@/lib/client/utils";
 import type { AppRouter } from "@/lib/server/routers/_app";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
+import { computeMatterSettlement, computeRadgivningsavgift, type MatterSettlement } from "@/lib/shared/rattshjalp";
 import { computeInvoiceLedger } from "@/lib/shared/write-off-calc";
 import { CreditModal } from "./_credit-modal";
 import { DispatchHistory } from "./_dispatch-history";
@@ -147,9 +148,7 @@ function InvoiceSections({ inv, ledger, onCancelPlan }: { inv: Inv; ledger: Ledg
       <InvoiceDocumentsCard documents={(inv.documents ?? []) as unknown as InvoiceDocRow[]} />
       <CreditBanners inv={inv} />
       {inv.paymentPlan && <PaymentPlanCard plan={inv.paymentPlan} onCancel={onCancelPlan} />}
-      {inv.invoiceType === "FINAL" && ledger.accontoDeductions.length > 0 && (
-        <AccontoDeductions deductions={ledger.accontoDeductions} />
-      )}
+      <FinalInvoiceExtras inv={inv} ledger={ledger} />
       <PaymentsTable payments={inv.payments} paidSum={ledger.paidSum} />
       <DispatchHistory invoiceId={inv.id} />
       {ledger.writeOffs.length > 0 && <WriteOffsCard writeOffs={ledger.writeOffs} />}
@@ -364,6 +363,71 @@ function PaymentPlanCard({
 type SpecTimeRow = { id: string; date: string | Date; description: string; minutes: number; hourlyRate?: number | null };
 type SpecExpenseRow = { id: string; date: string | Date; description: string; amount: number };
 type InvoiceDocRow = { id: string; fileName: string; documentType?: string | null; createdAt?: string | Date | null; storagePath?: string | null; mimeType?: string | null };
+
+/** Bygg slutfaktura-sammanställningen (#349 C) ur fakturans spec + ledger.
+ *  Rådgivningstimmen (rättshjälpstaxa) tas med för rättshjälpsärenden. */
+function buildSettlement(inv: Inv, ledger: LedgerView): MatterSettlement {
+  const times = (inv.timeEntries ?? []) as unknown as SpecTimeRow[];
+  const exps = (inv.expenses ?? []) as unknown as SpecExpenseRow[];
+  const arvodeOre = times.reduce((s, t) => s + Math.round((t.minutes / 60) * (t.hourlyRate ?? 0)), 0);
+  const utlaggOre = exps.reduce((s, e) => s + e.amount, 0);
+  const m = inv.matter as { paymentMethod?: string | null; taxaHasFTax?: boolean | null } | null;
+  const radgivningOre = m?.paymentMethod === "RATTSHJALP"
+    ? computeRadgivningsavgift({ hasFTax: m.taxaHasFTax ?? true }).beloppExclVatOre
+    : 0;
+  return computeMatterSettlement({
+    arvodeOre, utlaggOre, radgivningOre,
+    accontoPaidOre: ledger.accontoDeductionTotal,
+    paymentsOre: ledger.paidSum,
+  });
+}
+
+/** Rader för sammanställningskortet (negativa = avdrag). */
+function settlementRows(s: MatterSettlement): Array<{ label: string; ore: number; strong?: boolean }> {
+  const rows: Array<{ label: string; ore: number; strong?: boolean }> = [
+    { label: "Upparbetat arvode", ore: s.arvodeOre },
+    { label: "Utlägg", ore: s.utlaggOre },
+  ];
+  if (s.prutningOre !== 0) rows.push({ label: "Prutning (domstol)", ore: s.prutningOre });
+  rows.push({ label: "Brutto", ore: s.bruttoOre, strong: true });
+  if (s.accontoPaidOre !== 0) rows.push({ label: "Avgår betalda acconton", ore: -s.accontoPaidOre });
+  rows.push({ label: "Slutfaktura", ore: s.slutfakturaOre, strong: true });
+  if (s.paymentsOre !== 0) rows.push({ label: "Avgår inbetalt", ore: -s.paymentsOre });
+  if (s.radgivningOre !== 0) {
+    rows.push({ label: "Rådgivningstimme (rättshjälpstaxa, separat klientfaktura)", ore: s.radgivningOre });
+  }
+  rows.push({ label: "Utestående", ore: s.outstandingOre, strong: true });
+  return rows;
+}
+
+/** FINAL-fakturans extra sektioner: accontoavdrag + ärende-sammanställning (#349). */
+function FinalInvoiceExtras({ inv, ledger }: { inv: Inv; ledger: LedgerView }) {
+  if (inv.invoiceType !== "FINAL") return null;
+  return (
+    <>
+      {ledger.accontoDeductions.length > 0 && <AccontoDeductions deductions={ledger.accontoDeductions} />}
+      <SettlementSummaryCard settlement={buildSettlement(inv, ledger)} />
+    </>
+  );
+}
+
+/** Slutfaktura-sammanställning (#349 C): hela ärendets belopp + betalningar. */
+function SettlementSummaryCard({ settlement }: { settlement: MatterSettlement }) {
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6">
+      <h2 className="font-semibold text-gray-900 mb-1">Sammanställning</h2>
+      <p className="text-sm text-gray-500 mb-4">Hela ärendets belopp och betalningar.</p>
+      <dl className="divide-y divide-gray-100">
+        {settlementRows(settlement).map((r) => (
+          <div key={r.label} className="flex items-center justify-between py-1.5">
+            <dt className={r.strong ? "text-sm font-semibold text-gray-900" : "text-sm text-gray-600"}>{r.label}</dt>
+            <dd className={`text-sm font-mono ${r.strong ? "font-semibold text-gray-900" : "text-gray-700"}`}>{formatCurrency(r.ore)}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
 
 /**
  * Öppna ett fakturadokument (PDF m.fl.) i en ny flik — SAMMA flöde som

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -202,7 +202,9 @@ export const invoiceRouter = router({
       const inv = await ctx.dataStore.invoices.findFirst({
         where: { id: input.id, matter: { organizationId: ctx.orgId } },
         include: {
-          matter: { select: { id: true, matterNumber: true, title: true } },
+          // paymentMethod + taxaHasFTax: slutfaktura-sammanställningen (#349)
+          // visar rådgivningstimmen enligt rättshjälpstaxan för rättshjälpsärenden.
+          matter: { select: { id: true, matterNumber: true, title: true, paymentMethod: true, taxaHasFTax: true } },
           paymentPlan: { include: { reminders: { orderBy: { sentAt: "desc" } } } },
           payments: {
             orderBy: { paidAt: "desc" },

--- a/src/lib/shared/rattshjalp.ts
+++ b/src/lib/shared/rattshjalp.ts
@@ -1,0 +1,96 @@
+/**
+ * Rättshjälps-billing (#349). Ren beräkningslogik, inga DB-anrop — allt i öre.
+ *
+ * Ett rättshjälpsärende går via domstol och faktureras med en kostnadsräkning
+ * till domstolen. Klienten betalar själv två saker:
+ *   1. En **rådgivningstimme** (1 h) enligt rättshjälpstaxan — en separat
+ *      klientfaktura. Den syns som en TEXTRAD på domstolens kostnadsräkning
+ *      (transparens, inget belopp domstolen ska betala).
+ *   2. **Rättshjälpsavgiften** — en procent-andel av upparbetad tid, faktureras
+ *      som acconto till klienten (täcks av `clientShareBips` på BillingRun).
+ *
+ * Rådgivningsersättningen enligt rättshjälpslagen följer **timkostnadsnormen**
+ * (samma norm som brottmål/offentligt biträde), därför återanvänds
+ * {@link computeTimkostnadsnorm} här i stället för en egen hårdkodad sats.
+ */
+
+import { computeTimkostnadsnorm } from "@/lib/shared/brottmalstaxa";
+
+/** Rådgivning enligt rättshjälpslagen = 1 timme. */
+export const RADGIVNING_MINUTES = 60;
+
+export interface Radgivningsavgift {
+  /** Antal minuter (alltid 60 — en rådgivningstimme). */
+  minutes: number;
+  /** Tillämpad timkostnadsnorm (öre/h). */
+  rateOrePerH: number;
+  /** Avgiften exkl moms (öre) — en timme × timkostnadsnormen. */
+  beloppExclVatOre: number;
+}
+
+/**
+ * Rådgivningsavgiften för den klient-betalda rådgivningstimmen: 1 h enligt
+ * timkostnadsnormen (F-skatt-justerad om advokaten saknar F-skatt).
+ */
+export function computeRadgivningsavgift(opts: { hasFTax?: boolean } = {}): Radgivningsavgift {
+  const norm = computeTimkostnadsnorm({ arbetsMinutes: RADGIVNING_MINUTES, ...opts });
+  return { minutes: RADGIVNING_MINUTES, rateOrePerH: norm.rateOrePerH, beloppExclVatOre: norm.arbete };
+}
+
+export interface MatterSettlementInput {
+  /** Upparbetat arvode (debiterbar tid), öre. */
+  arvodeOre: number;
+  /** Debiterbara utlägg, öre. */
+  utlaggOre: number;
+  /** Domstolens prutning (≤ 0 — minskar bruttot). Default 0. */
+  prutningOre?: number;
+  /** Klient-betald rådgivningstimme (separat klientfaktura), öre. Default 0. */
+  radgivningOre?: number;
+  /** Summa acconto-fakturor klienten redan betalat, öre. Default 0. */
+  accontoPaidOre?: number;
+  /** Summa registrerade betalningar mot slutfakturan, öre. Default 0. */
+  paymentsOre?: number;
+}
+
+export interface MatterSettlement {
+  arvodeOre: number;
+  utlaggOre: number;
+  prutningOre: number;
+  /** Brutto efter prutning: arvode + utlägg + prutning (prutning negativ). */
+  bruttoOre: number;
+  radgivningOre: number;
+  accontoPaidOre: number;
+  /** Vad slutfakturan till klienten kräver: brutto − redan betalda acconton. */
+  slutfakturaOre: number;
+  paymentsOre: number;
+  /** Kvar att betala på slutfakturan: slutfaktura − betalningar. */
+  outstandingOre: number;
+}
+
+/**
+ * Bygger den fullständiga ärende-sammanställningen för slutfakturan (#349 C):
+ * upparbetat arvode, utlägg, ev. prutning, betalda acconton, rådgivningstimmen
+ * och utestående saldo. Generellt användbar även utanför rättshjälp.
+ */
+export function computeMatterSettlement(input: MatterSettlementInput): MatterSettlement {
+  const prutningOre = input.prutningOre ?? 0;
+  const radgivningOre = input.radgivningOre ?? 0;
+  const accontoPaidOre = input.accontoPaidOre ?? 0;
+  const paymentsOre = input.paymentsOre ?? 0;
+
+  const bruttoOre = input.arvodeOre + input.utlaggOre + prutningOre;
+  const slutfakturaOre = bruttoOre - accontoPaidOre;
+  const outstandingOre = slutfakturaOre - paymentsOre;
+
+  return {
+    arvodeOre: input.arvodeOre,
+    utlaggOre: input.utlaggOre,
+    prutningOre,
+    bruttoOre,
+    radgivningOre,
+    accontoPaidOre,
+    slutfakturaOre,
+    paymentsOre,
+    outstandingOre,
+  };
+}

--- a/test/unit/shared/rattshjalp.test.ts
+++ b/test/unit/shared/rattshjalp.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tester för rättshjälps-billing (#349): rådgivningsavgiften (1 h enligt
+ * timkostnadsnormen) och ärende-sammanställningen för slutfakturan.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import {
+  TIMKOSTNADSNORM_FTAX_ORE_PER_H,
+  TIMKOSTNADSNORM_NO_FTAX_ORE_PER_H,
+} from "@/lib/shared/brottmalstaxa";
+import {
+  computeRadgivningsavgift,
+  computeMatterSettlement,
+  RADGIVNING_MINUTES,
+} from "@/lib/shared/rattshjalp";
+
+describe("computeRadgivningsavgift", () => {
+  it("är en timme enligt timkostnadsnormen (F-skatt)", () => {
+    const r = computeRadgivningsavgift();
+    expect(r.minutes).toBe(RADGIVNING_MINUTES);
+    expect(r.minutes).toBe(60);
+    expect(r.rateOrePerH).toBe(TIMKOSTNADSNORM_FTAX_ORE_PER_H);
+    expect(r.beloppExclVatOre).toBe(TIMKOSTNADSNORM_FTAX_ORE_PER_H); // 1 h
+  });
+
+  it("F-skatt-justeras nedåt utan F-skatt", () => {
+    const r = computeRadgivningsavgift({ hasFTax: false });
+    expect(r.rateOrePerH).toBe(TIMKOSTNADSNORM_NO_FTAX_ORE_PER_H);
+    expect(r.beloppExclVatOre).toBe(TIMKOSTNADSNORM_NO_FTAX_ORE_PER_H);
+  });
+});
+
+describe("computeMatterSettlement", () => {
+  it("summerar brutto, slutfaktura och utestående", () => {
+    const s = computeMatterSettlement({
+      arvodeOre: 500_000,
+      utlaggOre: 50_000,
+      accontoPaidOre: 100_000,
+      paymentsOre: 0,
+    });
+    expect(s.bruttoOre).toBe(550_000);          // arvode + utlägg
+    expect(s.slutfakturaOre).toBe(450_000);     // brutto − acconto
+    expect(s.outstandingOre).toBe(450_000);     // inget betalt än
+  });
+
+  it("prutning (negativ) minskar bruttot", () => {
+    const s = computeMatterSettlement({ arvodeOre: 600_000, utlaggOre: 0, prutningOre: -100_000 });
+    expect(s.bruttoOre).toBe(500_000);
+    expect(s.slutfakturaOre).toBe(500_000);
+  });
+
+  it("betalningar minskar utestående till noll", () => {
+    const s = computeMatterSettlement({
+      arvodeOre: 400_000, utlaggOre: 0, accontoPaidOre: 100_000, paymentsOre: 300_000,
+    });
+    expect(s.slutfakturaOre).toBe(300_000);
+    expect(s.outstandingOre).toBe(0);
+  });
+
+  it("rådgivningstimmen redovisas separat (påverkar inte brutto/slutfaktura)", () => {
+    const withR = computeMatterSettlement({ arvodeOre: 200_000, utlaggOre: 0, radgivningOre: 162_600 });
+    const without = computeMatterSettlement({ arvodeOre: 200_000, utlaggOre: 0 });
+    expect(withR.radgivningOre).toBe(162_600);
+    expect(withR.bruttoOre).toBe(without.bruttoOre);       // ej inräknad i domstols-brutto
+    expect(withR.slutfakturaOre).toBe(without.slutfakturaOre);
+  });
+
+  it("defaultar valfria poster till 0", () => {
+    const s = computeMatterSettlement({ arvodeOre: 100_000, utlaggOre: 0 });
+    expect(s.prutningOre).toBe(0);
+    expect(s.accontoPaidOre).toBe(0);
+    expect(s.paymentsOre).toBe(0);
+    expect(s.radgivningOre).toBe(0);
+    expect(s.outstandingOre).toBe(100_000);
+  });
+});


### PR DESCRIPTION
Refs #349 — levererar de testbara beräknings-kärnorna + slutfaktura-sammanställningen (del C). Återstående UI-flöde för del A följs upp separat (se nedan).

## Vad
**Ny ren modul** `src/lib/shared/rattshjalp.ts`:
- `computeRadgivningsavgift({hasFTax})` — den klient-betalda **rådgivningstimmen** = 1 h enligt **timkostnadsnormen** (rättshjälpslagens rådgivningsersättning följer normen; återanvänder `computeTimkostnadsnorm` istället för en hårdkodad sats).
- `computeMatterSettlement(...)` — ärende-sammanställning: arvode, utlägg, prutning, brutto, betalda acconton, slutfaktura, inbetalt, rådgivningstimme, **utestående**.

**Del C (slutfaktura-mallen):** slutfakturan (`invoices/[id]`) visar nu en **`SettlementSummaryCard`** med hela ärendets belopp + betalningar. Rådgivningstimmen tas med för rättshjälpsärenden (`paymentMethod === RATTSHJALP`). `invoice.getById` inkluderar nu `matter.paymentMethod` + `taxaHasFTax`.

**Del B (acconto-procent):** täcks redan av `clientShareBips` (basis points) på `billingRun.createAcconto` — ingen ny kod behövs.

## Vad som följs upp (del A, separat issue)
Det fulla A-flödet — **registrera** den betalda rådgivningstimmen + skapa en **separat klientfaktura** för den + **textraden på domstolens kostnadsräkning** — kräver ett nytt matter-fält + UI och filas som uppföljning (beräkningen `computeRadgivningsavgift` ligger redo).

## Verifierat lokalt
- `bun test rattshjalp` (8) + invoice-page + invoice-router (82 totalt) gröna.
- `tsc` + `lint` + `knip` + `eslint --no-inline-config --rule complexity:8` (0 offenders) gröna.
- `test:cov` → rader 85.27 % (golv 84.80 %) ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)