### PR TITLE
test(matters): täck verdict-dialog, höj line-floor 85.2→85.5

### DIFF
--- a/test/unit/app/matters/verdict-dialog.test.tsx
+++ b/test/unit/app/matters/verdict-dialog.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * Tester för VerdictDialog (#27 coverage) — OFFENTLIG_FÖRSVARARE-flowets
+ * steg 2: ange dömt belopp → prutning räknas baklänges, vakt mot för högt
+ * belopp, och onSuccess genererar ett faktura-dokument.
+ */
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { VerdictDialog } from "@/app/matters/[id]/_verdict-dialog";
+
+let verdictOnSuccess: ((res: unknown) => Promise<void>) | undefined;
+const verdictMutate = vi.fn();
+const registerMutateAsync = vi.fn(async () => {});
+const renderFakturaPdf = vi.fn(async () => new Uint8Array([1, 2, 3]));
+const persistGeneratedDoc = vi.fn(async () => {});
+const treeInvalidate = vi.fn(async () => {});
+const treeRefetch = vi.fn(async () => {});
+const listInvalidate = vi.fn(async () => {});
+
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: {
+    useUtils: () => ({ document: { tree: { invalidate: treeInvalidate, refetch: treeRefetch }, list: { invalidate: listInvalidate } } }),
+    document: { register: { useMutation: () => ({ mutateAsync: registerMutateAsync }) } },
+    billingRun: {
+      setVerdict: {
+        useMutation: (opts: { onSuccess: (res: unknown) => Promise<void> }) => {
+          verdictOnSuccess = opts.onSuccess;
+          return { mutate: verdictMutate, isPending: false, error: null };
+        },
+      },
+    },
+  },
+}));
+vi.mock("@/lib/client/kostnadsrakning/render-faktura-pdf", () => ({ renderFakturaPdf }));
+vi.mock("@/lib/client/demo/persist-generated-doc", () => ({ persistGeneratedDoc }));
+
+const baseProps = {
+  billingRunId: "br-1",
+  workValueOre: 500_000,
+  matterId: "m1",
+  matterNumber: "B-2026-1",
+  matterTitle: "Brottmål",
+  onClose: vi.fn(),
+};
+
+beforeEach(() => { vi.clearAllMocks(); verdictOnSuccess = undefined; });
+
+describe("VerdictDialog", () => {
+  it("visar föreslaget belopp och initierar dömt = föreslaget (ingen prutning)", () => {
+    render(<VerdictDialog {...baseProps} />);
+    expect(screen.getByText("Föreslaget belopp")).toBeInTheDocument();
+    const input = screen.getByRole("spinbutton") as HTMLInputElement;
+    expect(input.value).toBe("5000"); // 500 000 öre / 100
+    expect(screen.queryByText("Prutning")).not.toBeInTheDocument();
+  });
+
+  it("dömt < föreslaget → visar prutning och submit skickar negativ prutningOre", () => {
+    render(<VerdictDialog {...baseProps} />);
+    fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "4000" } }); // 400 000 öre
+    expect(screen.getByText("Prutning")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Skapa faktura" }));
+    expect(verdictMutate).toHaveBeenCalledWith({ billingRunId: "br-1", prutningOre: -100_000 });
+  });
+
+  it("dömt > föreslaget → fel-text, submit disabled, ingen mutation", () => {
+    render(<VerdictDialog {...baseProps} />);
+    fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "6000" } });
+    expect(screen.getByText(/kan inte överstiga föreslaget/)).toBeInTheDocument();
+    const submit = screen.getByRole("button", { name: "Skapa faktura" }) as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+    fireEvent.submit(submit.closest("form")!);
+    expect(verdictMutate).not.toHaveBeenCalled();
+  });
+
+  it("onSuccess genererar faktura-dokument + registrerar det + stänger", async () => {
+    const onClose = vi.fn();
+    render(<VerdictDialog {...baseProps} onClose={onClose} />);
+    expect(verdictOnSuccess).toBeDefined();
+    await verdictOnSuccess!({ invoice: { id: "inv-9", amount: 400_000, invoiceNumber: "2026-9" } });
+    expect(renderFakturaPdf).toHaveBeenCalled();
+    expect(registerMutateAsync).toHaveBeenCalledWith(expect.objectContaining({
+      id: "faktura-inv-9", matterId: "m1", invoiceId: "inv-9", documentType: "Faktura",
+    }));
+    expect(persistGeneratedDoc).toHaveBeenCalled();
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+});

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -31,9 +31,10 @@ const COVERAGE = process.argv.includes("--coverage");
 const FAST = process.argv.includes("--fast");
 
 // Ratchet-golv (flyttat hit från check-coverage.ts) — flytta BARA uppåt.
-// #27: 84.0 → 84.8 (pick-provider) → 85.2 (external-edit-modal, lokalt 85.63%
-// rader, ~0.43% marginal — FUNC_FLOOR lämnas konservativt pga Node-version-varians).
-const LINE_FLOOR = 0.852;
+// #27: 84.0 → 84.8 (pick-provider) → 85.2 (external-edit-modal) → 85.5
+// (verdict-dialog, lokalt 85.92% rader, ~0.42% marginal — FUNC_FLOOR lämnas
+// konservativt pga Node-version-varians).
+const LINE_FLOOR = 0.855;
 const FUNC_FLOOR = 0.80;
 
 /**


### PR DESCRIPTION
Del av #27 (kodtäckning → 95 %, ratchet). Ett steg.

## Vad
- **`_verdict-dialog.tsx`** (8 % → täckt): OFFENTLIG_FÖRSVARARE-flowets steg 2 — prutning räknas baklänges (dömt − föreslaget), vakt mot dömt > föreslaget (fel-text + disabled submit + ingen mutation), och `onSuccess`-vägen som genererar faktura-dokumentet (`renderFakturaPdf` + `register` + `persistGeneratedDoc`, mockade dynamiska imports).
- **Ratchet:** merged line-coverage 85.63 % → **85.92 %** → `LINE_FLOOR` 0.852 → **0.855** (~0.42 % marginal). `FUNC_FLOOR` kvar på 0.80.

## Verifierat lokalt
- `bun test verdict-dialog` → 4 pass
- `bun run test:cov` → rader 85.92 % (golv 85.50 %), funktioner 81.62 % ✓
- `tsc` + `lint` gröna

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)