### PR TITLE
test(matters): täck billing-dialog, höj line-floor 85.5→85.7

### DIFF
--- a/test/unit/app/matters/billing-dialog.test.tsx
+++ b/test/unit/app/matters/billing-dialog.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * Tester för BillingDialog (#27 coverage) — ACCONTO- + FINAL-flödena:
+ * procent↔bips-konvertering, belopp→öre, mottagar-val, acconto-avdrag och
+ * submit-payloads till billingRun-mutationerna.
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { BillingDialog } from "@/app/matters/[id]/_billing-dialog";
+
+const accontoMutate = vi.fn();
+const finalMutate = vi.fn();
+
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: {
+    billingRun: {
+      createAcconto: { useMutation: () => ({ mutate: accontoMutate, isPending: false, error: null }) },
+      createFinal: { useMutation: () => ({ mutate: finalMutate, isPending: false, error: null }) },
+    },
+  },
+}));
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe("BillingDialog — ACCONTO", () => {
+  it("submit skickar bips + öre + KLIENT (default 20 % / 2000 kr)", () => {
+    render(<BillingDialog matterId="m1" type="ACCONTO" existingAccontos={[]} onClose={() => {}} />);
+    expect(screen.getByText("Aconto till klient")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Skapa aconto-faktura" }));
+    expect(accontoMutate).toHaveBeenCalledWith({
+      matterId: "m1", clientShareBips: 2000, amountOre: 200_000, recipient: "KLIENT",
+    });
+  });
+
+  it("procent → bips: 30 % → 3000 bips", () => {
+    render(<BillingDialog matterId="m1" type="ACCONTO" existingAccontos={[]} onClose={() => {}} />);
+    const [percent] = screen.getAllByRole("spinbutton");
+    fireEvent.change(percent!, { target: { value: "30" } });
+    fireEvent.click(screen.getByRole("button", { name: "Skapa aconto-faktura" }));
+    expect(accontoMutate).toHaveBeenCalledWith(expect.objectContaining({ clientShareBips: 3000 }));
+  });
+});
+
+describe("BillingDialog — FINAL", () => {
+  const accontos = [
+    { id: "br-1", amountOre: 100_000, recipient: "KLIENT" },
+    { id: "br-2", amountOre: 50_000, recipient: "KLIENT" },
+  ];
+
+  it("default: alla aconton förvalda, submit drar av dem alla", () => {
+    render(<BillingDialog matterId="m1" type="FINAL" existingAccontos={accontos} onClose={() => {}} />);
+    expect(screen.getByText("Faktura")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Skapa faktura" }));
+    expect(finalMutate).toHaveBeenCalledWith({
+      matterId: "m1", recipient: "KLIENT", deductedBillingRunIds: ["br-1", "br-2"],
+    });
+  });
+
+  it("avmarkera ett aconto → utesluts ur avdragen", () => {
+    render(<BillingDialog matterId="m1" type="FINAL" existingAccontos={accontos} onClose={() => {}} />);
+    const boxes = screen.getAllByRole("checkbox");
+    fireEvent.click(boxes[0]!); // avmarkera br-1
+    fireEvent.click(screen.getByRole("button", { name: "Skapa faktura" }));
+    expect(finalMutate).toHaveBeenCalledWith(expect.objectContaining({ deductedBillingRunIds: ["br-2"] }));
+  });
+
+  it("byt mottagare → skickas i payloaden", () => {
+    render(<BillingDialog matterId="m1" type="FINAL" existingAccontos={[]} onClose={() => {}} />);
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "FORSAKRING" } });
+    fireEvent.click(screen.getByRole("button", { name: "Skapa faktura" }));
+    expect(finalMutate).toHaveBeenCalledWith(expect.objectContaining({ recipient: "FORSAKRING" }));
+  });
+});

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -32,9 +32,9 @@ const FAST = process.argv.includes("--fast");
 
 // Ratchet-golv (flyttat hit från check-coverage.ts) — flytta BARA uppåt.
 // #27: 84.0 → 84.8 (pick-provider) → 85.2 (external-edit-modal) → 85.5
-// (verdict-dialog, lokalt 85.92% rader, ~0.42% marginal — FUNC_FLOOR lämnas
-// konservativt pga Node-version-varians).
-const LINE_FLOOR = 0.855;
+// (verdict-dialog) → 85.7 (billing-dialog, lokalt 86.19% rader, ~0.49% marginal
+// — FUNC_FLOOR lämnas konservativt pga Node-version-varians).
+const LINE_FLOOR = 0.857;
 const FUNC_FLOOR = 0.80;
 
 /**


### PR DESCRIPTION
Del av #27 (kodtäckning → 95 %, ratchet). Ett steg.

## Vad
- **`_billing-dialog.tsx`** (6 % → täckt): ACCONTO-flödet (procent↔bips-konvertering, belopp→öre, payload till `createAcconto`) + FINAL-flödet (mottagar-val, acconto-avdrags-checkboxar med toggle, payload till `createFinal`).
- **Ratchet:** merged line-coverage 85.92 % → **86.19 %** → `LINE_FLOOR` 0.855 → **0.857** (~0.49 % marginal). `FUNC_FLOOR` kvar på 0.80.

## Verifierat lokalt
- `bun test billing-dialog` → 5 pass
- `bun run test:cov` → rader 86.19 % (golv 85.70 %), funktioner 81.79 % ✓
- `tsc` + `lint` gröna

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)