### PR TITLE
test(matters): täck expected-receivables-section, höj line-floor 85.7→85.8

### DIFF
--- a/test/unit/app/matters/expected-receivables-section.test.tsx
+++ b/test/unit/app/matters/expected-receivables-section.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Tester för ExpectedReceivablesSection (#27 coverage / #173) — förväntade
+ * domstolsbetalningar: målnummer-redigering, registrera fordran, avprickning
+ * (markera mottagen) + avbryt, samt list-/tomtillstånd.
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { ExpectedReceivablesSection } from "@/app/matters/[id]/_expected-receivables-section";
+
+const listQuery = { data: [] as unknown[], isLoading: false };
+const createMutate = vi.fn();
+const settleMutate = vi.fn();
+const cancelMutate = vi.fn();
+const updateMutate = vi.fn();
+const invalidate = vi.fn();
+
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: {
+    useUtils: () => ({
+      expectedReceivable: { list: { invalidate } },
+      matter: { getById: { invalidate: vi.fn() } },
+    }),
+    expectedReceivable: {
+      list: { useQuery: () => listQuery },
+      create: { useMutation: (o?: { onSuccess?: () => void }) => ({ mutate: (a: unknown) => { createMutate(a); o?.onSuccess?.(); }, isPending: false }) },
+      settle: { useMutation: (o?: { onSuccess?: () => void }) => ({ mutate: (a: unknown) => { settleMutate(a); o?.onSuccess?.(); }, isPending: false }) },
+      cancel: { useMutation: (o?: { onSuccess?: () => void }) => ({ mutate: (a: unknown) => { cancelMutate(a); o?.onSuccess?.(); }, isPending: false }) },
+    },
+    matter: { update: { useMutation: () => ({ mutate: (a: unknown) => updateMutate(a), isPending: false }) } },
+  },
+}));
+
+beforeEach(() => { vi.clearAllMocks(); listQuery.data = []; });
+
+describe("ExpectedReceivablesSection", () => {
+  it("tomtillstånd när inga fordringar finns", () => {
+    render(<ExpectedReceivablesSection matterId="m1" courtCaseNumber="" />);
+    expect(screen.getByText(/Inga registrerade ännu/)).toBeInTheDocument();
+  });
+
+  it("målnummer: Spara disabled när oförändrat, enabled + sparar efter ändring", () => {
+    render(<ExpectedReceivablesSection matterId="m1" courtCaseNumber="B 1-26" />);
+    const save = screen.getByRole("button", { name: "Spara målnummer" }) as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+    fireEvent.change(screen.getByLabelText("Domstolens målnummer"), { target: { value: "B 9-26" } });
+    expect(save.disabled).toBe(false);
+    fireEvent.click(save);
+    expect(updateMutate).toHaveBeenCalledWith({ id: "m1", courtCaseNumber: "B 9-26" });
+  });
+
+  it("registrera fordran skickar description + belopp i öre", () => {
+    render(<ExpectedReceivablesSection matterId="m1" courtCaseNumber="" />);
+    fireEvent.change(screen.getByPlaceholderText(/Kostnadsräkning/), { target: { value: "Svea HovR" } });
+    fireEvent.change(screen.getByPlaceholderText(/Begärt belopp/), { target: { value: "1500" } });
+    fireEvent.click(screen.getByRole("button", { name: "Lägg till fordran" }));
+    expect(createMutate).toHaveBeenCalledWith({ matterId: "m1", description: "Svea HovR", expectedAmount: 150_000 });
+  });
+
+  it("PENDING-rad: markera mottagen bokar utbetalt belopp, avbryt avbryter", () => {
+    listQuery.data = [{ id: "er-1", description: "Mål B 1-26", expectedAmount: 200_000, status: "PENDING" }];
+    render(<ExpectedReceivablesSection matterId="m1" courtCaseNumber="" />);
+    fireEvent.change(screen.getByPlaceholderText("Utbetalt (kr)"), { target: { value: "1800" } });
+    fireEvent.click(screen.getByRole("button", { name: "Markera mottagen" }));
+    expect(settleMutate).toHaveBeenCalledWith({ id: "er-1", settledAmount: 180_000 });
+    fireEvent.click(screen.getByRole("button", { name: "Avbryt" }));
+    expect(cancelMutate).toHaveBeenCalledWith({ id: "er-1" });
+  });
+
+  it("SETTLED-rad visar mottaget belopp och ingen avprickning", () => {
+    listQuery.data = [{ id: "er-2", description: "Mål B 2-26", expectedAmount: 200_000, status: "SETTLED", settledAmount: 190_000 }];
+    render(<ExpectedReceivablesSection matterId="m1" courtCaseNumber="" />);
+    expect(screen.getByText(/Mottaget:/)).toBeInTheDocument();
+    expect(screen.getByText("Mottagen")).toBeInTheDocument(); // status-label
+    expect(screen.queryByRole("button", { name: "Markera mottagen" })).not.toBeInTheDocument();
+  });
+});

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -32,9 +32,9 @@ const FAST = process.argv.includes("--fast");
 
 // Ratchet-golv (flyttat hit från check-coverage.ts) — flytta BARA uppåt.
 // #27: 84.0 → 84.8 (pick-provider) → 85.2 (external-edit-modal) → 85.5
-// (verdict-dialog) → 85.7 (billing-dialog, lokalt 86.19% rader, ~0.49% marginal
-// — FUNC_FLOOR lämnas konservativt pga Node-version-varians).
-const LINE_FLOOR = 0.857;
+// (verdict-dialog) → 85.7 (billing-dialog) → 85.8 (expected-receivables, lokalt
+// 86.30% rader, ~0.50% marginal — FUNC_FLOOR konservativt pga Node-version-varians).
+const LINE_FLOOR = 0.858;
 const FUNC_FLOOR = 0.80;
 
 /**


### PR DESCRIPTION
Del av #27 (kodtäckning → 95 %, ratchet). Ett steg.

## Vad
- **`_expected-receivables-section.tsx`** (#173-vyn, 67 % → täckt): målnummer-redigering (spara-gating på ändring), registrera förväntad domstolsbetalning (belopp→öre), avprickning (markera mottagen → `settle`, avbryt → `cancel`), samt list-/tomtillstånd + `SETTLED`-radens "Mottaget".
- **Ratchet:** merged line-coverage 86.19 % → **86.30 %** → `LINE_FLOOR` 0.857 → **0.858**. `FUNC_FLOOR` kvar på 0.80 (steg 81.79 → 82.02 %).

## Verifierat lokalt
- `bun test expected-receivables-section` → 5 pass
- `bun run test:cov` → rader 86.30 % (golv 85.80 %), funktioner 82.02 % ✓
- `tsc` + `lint` gröna

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)