### PR TITLE
test(settings): täck integrations-section, höj line-floor 85.8→86.0

### DIFF
--- a/test/unit/components/integrations-section.test.tsx
+++ b/test/unit/components/integrations-section.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Tester för IntegrationsSection (#27 coverage) — generisk connector-lista:
+ * tomtillstånd, status-rader (alla StatusLine-grenar), samt connect/disconnect
+ * med busy- och fel-hantering.
+ */
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { IntegrationsSection } from "@/components/settings/integrations-section";
+import type { ConnectionStatus } from "@/lib/client/integrations/types";
+
+let connectors: unknown[] = [];
+let currentStatus: ConnectionStatus = { kind: "disconnected" };
+const connectFn = vi.fn(async () => {});
+const disconnectFn = vi.fn(async () => {});
+
+function fakeConnector() {
+  return {
+    id: "ms365",
+    displayName: "Microsoft 365",
+    capabilities: ["mail", "calendar"],
+    subscribe: (cb: (s: ConnectionStatus) => void) => { cb(currentStatus); return () => {}; },
+    connect: connectFn,
+    disconnect: disconnectFn,
+  };
+}
+
+vi.mock("@/lib/client/integrations/office365-connector", () => ({}));
+vi.mock("@/lib/client/integrations/registry", () => ({ listConnectors: () => connectors }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  connectors = [fakeConnector()];
+  currentStatus = { kind: "disconnected" };
+});
+
+describe("IntegrationsSection", () => {
+  it("renderar null när inga connectors finns", () => {
+    connectors = [];
+    const { container } = render(<IntegrationsSection />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("visar connector med namn + capabilities + 'Ej ansluten'", () => {
+    render(<IntegrationsSection />);
+    expect(screen.getByText("Microsoft 365")).toBeInTheDocument();
+    expect(screen.getByText("mail · calendar")).toBeInTheDocument();
+    expect(screen.getByText("Ej ansluten")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Anslut" })).toBeInTheDocument();
+  });
+
+  it("connected-status → visar e-post + 'Koppla bort'", () => {
+    currentStatus = { kind: "connected", account: { email: "anna@firma.se" } } as ConnectionStatus;
+    render(<IntegrationsSection />);
+    expect(screen.getByText(/anna@firma\.se/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Koppla bort" })).toBeInTheDocument();
+  });
+
+  it("expired + error-status renderar respektive StatusLine-gren", () => {
+    currentStatus = { kind: "expired" } as ConnectionStatus;
+    const { unmount } = render(<IntegrationsSection />);
+    expect(screen.getByText(/Token förfallit/)).toBeInTheDocument();
+    unmount();
+    currentStatus = { kind: "error", message: "boom" } as ConnectionStatus;
+    render(<IntegrationsSection />);
+    expect(screen.getByText(/✗ boom/)).toBeInTheDocument();
+  });
+
+  it("Anslut anropar connector.connect", async () => {
+    render(<IntegrationsSection />);
+    fireEvent.click(screen.getByRole("button", { name: "Anslut" }));
+    await waitFor(() => expect(connectFn).toHaveBeenCalled());
+  });
+
+  it("Koppla bort anropar connector.disconnect", async () => {
+    currentStatus = { kind: "connected", account: { email: "a@b.se" } } as ConnectionStatus;
+    render(<IntegrationsSection />);
+    fireEvent.click(screen.getByRole("button", { name: "Koppla bort" }));
+    await waitFor(() => expect(disconnectFn).toHaveBeenCalled());
+  });
+
+  it("fel vid connect visas i raden", async () => {
+    connectFn.mockRejectedValueOnce(new Error("nätverksfel"));
+    render(<IntegrationsSection />);
+    fireEvent.click(screen.getByRole("button", { name: "Anslut" }));
+    await waitFor(() => expect(screen.getByText("nätverksfel")).toBeInTheDocument());
+  });
+});

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -32,9 +32,10 @@ const FAST = process.argv.includes("--fast");
 
 // Ratchet-golv (flyttat hit från check-coverage.ts) — flytta BARA uppåt.
 // #27: 84.0 → 84.8 (pick-provider) → 85.2 (external-edit-modal) → 85.5
-// (verdict-dialog) → 85.7 (billing-dialog) → 85.8 (expected-receivables, lokalt
-// 86.30% rader, ~0.50% marginal — FUNC_FLOOR konservativt pga Node-version-varians).
-const LINE_FLOOR = 0.858;
+// (verdict-dialog) → 85.7 (billing-dialog) → 85.8 (expected-receivables) → 86.0
+// (integrations-section, lokalt 86.57% rader, ~0.57% marginal — FUNC_FLOOR
+// konservativt pga Node-version-varians).
+const LINE_FLOOR = 0.860;
 const FUNC_FLOOR = 0.80;
 
 /**


### PR DESCRIPTION
Del av #27 (kodtäckning → 95 %, ratchet). Ett steg.

## Vad
- **`integrations-section.tsx`** (6 % → täckt): tomtillstånd (inga connectors → null), connector-rad med namn + capabilities, alla `StatusLine`-grenar (disconnected/connected/expired/error), samt connect/disconnect-flödena med busy + fel-hantering (mockad connector-registry + office365-side-effekt).
- **Ratchet:** merged line-coverage 86.30 % → **86.57 %** → `LINE_FLOOR` 0.858 → **0.860**. `FUNC_FLOOR` kvar på 0.80.

## Verifierat lokalt
- `bun test integrations-section` → 7 pass
- `bun run test:cov` → rader 86.57 % (golv 86.00 %), funktioner 82.13 % ✓
- `tsc` + `lint` gröna

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)