### PR TITLE
feat(billing): rättshjälp rådgivningstimme — registrera + klientfaktura + kostnadsräknings-textrad

### DIFF
--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -20,6 +20,7 @@ import { trpc } from "@/lib/client/trpc";
 import { formatCurrency } from "@/lib/client/utils";
 import type { AppRouter } from "@/lib/server/routers/_app";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
+import { computeRadgivningsavgift } from "@/lib/shared/rattshjalp";
 import { BILLING_RUN_TYPE_LABELS, BILLING_RUN_STATUS_LABELS } from "@/lib/shared/schemas/enums";
 import { BillingDialog } from "./_billing-dialog";
 import { KostnadsrakningModal } from "./_kostnadsrakning-modal";
@@ -33,6 +34,7 @@ interface MatterContext {
   taxaHufStart?: string | Date | null | undefined;
   isTaxeArende?: boolean | null | undefined;
   paymentMethod?: string | null | undefined;
+  radgivningBetaldAt?: string | Date | null | undefined;
   contacts?: ReadonlyArray<{ role: string; contact?: { name?: string | null | undefined; email?: string | null | undefined } | null | undefined }> | undefined;
 }
 
@@ -223,6 +225,7 @@ function KostnadsrakningTrigger({ matterId, matter, open, onClose, onRecorded }:
       initialHasFTax={matter.taxaHasFTax ?? undefined}
       initialHufStart={matter.taxaHufStart ?? undefined}
       initialIsTaxe={matter.isTaxeArende ?? undefined}
+      radgivningPaid={!!matter.radgivningBetaldAt}
       onClose={onModalClose}
     />
   );
@@ -249,6 +252,7 @@ export function BillingPanel({ matterId, matter }: Props) {
         <BillingActions paymentMethod={matter.paymentMethod ?? ""} onPick={onPick} />
       </div>
       <SummaryCards totals={computeTotals(rows)} />
+      <RadgivningBanner matterId={matterId} matter={matter} onRecorded={refetch} />
       {pending && <PendingVerdictBanner matterId={matterId} run={pending} onClick={() => setVerdictRunId(pending.id)} />}
       <RunsList rows={rows} loading={runs.isLoading} />
       <BillingDialogs matterId={matterId} matter={matter} rows={rows}
@@ -261,6 +265,31 @@ export function BillingPanel({ matterId, matter }: Props) {
         onClose={() => setShowKr(false)}
         onRecorded={refetch}
       />
+    </div>
+  );
+}
+
+/** Rättshjälp (#383): registrera klientens betalda rådgivningstimme som en
+ *  separat klientfaktura. Self-gating — null för icke-rättshjälpsärenden. */
+function RadgivningBanner({ matterId, matter, onRecorded }: { matterId: string; matter: MatterContext; onRecorded: () => void }) {
+  const create = trpc.invoice.createRadgivning.useMutation({ onSuccess: onRecorded });
+  if (matter.paymentMethod !== "RATTSHJALP") return null;
+  const hasFTaxArg = omitUndefined({ hasFTax: matter.taxaHasFTax ?? undefined });
+  const avgift = computeRadgivningsavgift(hasFTaxArg);
+  return (
+    <div className="mx-6 mb-4 rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 flex items-center justify-between gap-3">
+      <div className="text-xs text-blue-900">
+        <strong>Rådgivningstimme (rättshjälp)</strong> — klientens 1 tim enligt rättshjälpstaxan,{" "}
+        <span className="font-mono">{formatCurrency(avgift.beloppExclVatOre)}</span> exkl moms, faktureras separat till klienten.
+      </div>
+      {matter.radgivningBetaldAt ? (
+        <span className="text-xs text-green-700 whitespace-nowrap">✓ Registrerad</span>
+      ) : (
+        <button type="button" onClick={() => create.mutate({ matterId, ...hasFTaxArg })} disabled={create.isPending}
+          className="text-xs px-2 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 whitespace-nowrap">
+          {create.isPending ? "Registrerar…" : "Registrera betald"}
+        </button>
+      )}
     </div>
   );
 }

--- a/src/app/matters/[id]/_kostnadsrakning-modal.tsx
+++ b/src/app/matters/[id]/_kostnadsrakning-modal.tsx
@@ -50,6 +50,9 @@ interface Props {
   initialHasFTax?: boolean | undefined;
   initialHufStart?: string | Date | null | undefined;
   initialIsTaxe?: boolean | undefined;
+  /** Rättshjälp (#383): klienten har betalat rådgivningstimmen separat →
+   *  text-rad på kostnadsräkningen. */
+  radgivningPaid?: boolean | undefined;
   onClose: () => void;
 }
 
@@ -179,7 +182,7 @@ function useKostnadsrakningModal(props: Props) {
   }, [hufStart]);
 
   const ctx = useMemo(() => buildKostnadsrakningContext({
-    matter: { matterNumber: props.matterNumber, title: props.matterTitle, clientName: props.clientName },
+    matter: { matterNumber: props.matterNumber, title: props.matterTitle, clientName: props.clientName, ...omitUndefined({ radgivningPaid: props.radgivningPaid }) },
     defender: {
       name: props.defenderName,
       ...omitUndefined({ email: props.defenderEmail }),

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -19,6 +19,7 @@ import { computeFinalInvoiceBreakdown, isPaymentPlanSettled } from "@/lib/shared
 import { canTransition, transitionErrorMessage } from "@/lib/shared/invoice-state-machine";
 import { ocrFromInvoiceNumber } from "@/lib/shared/ocr-reference";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
+import { computeRadgivningsavgift } from "@/lib/shared/rattshjalp";
 import type { InvoiceStatus } from "@/lib/shared/schemas/enums";
 import {
   asId,
@@ -261,6 +262,46 @@ export const invoiceRouter = router({
       });
       await emit.invoiceCreated(ctx, invoice);
       return invoice;
+    }),
+
+  /**
+   * RÅDGIVNING (#383, rättshjälp del A): registrera klientens betalda
+   * rådgivningstimme (1 tim enligt rättshjälpstaxan) som en SEPARAT klient-
+   * faktura (STANDARD mot KLIENT) + märk ärendet (`radgivningBetaldAt`) så
+   * domstolens kostnadsräkning visar text-raden. Timmen ingår ALDRIG i
+   * domstolens kostnadsräkning som debiterbar post. Idempotent: avvisar om
+   * redan registrerad.
+   */
+  createRadgivning: orgProcedure
+    .input(z.object({ matterId: matterIdSchema, hasFTax: z.boolean().optional() }))
+    .mutation(async ({ ctx, input }) => {
+      return ctx.dataStore.transaction(async (tx) => {
+        const matter = await tx.matters.findFirst({
+          where: { id: input.matterId, organizationId: ctx.orgId },
+        });
+        if (!matter) throw new TRPCError({ code: "NOT_FOUND" });
+        if ((matter as { radgivningBetaldAt?: unknown }).radgivningBetaldAt) {
+          throw new TRPCError({ code: "BAD_REQUEST", message: "Rådgivningstimmen är redan registrerad för detta ärende." });
+        }
+        const avgift = computeRadgivningsavgift({ ...omitUndefined({ hasFTax: input.hasFTax }) });
+        const invoiceNumber = await nextInvoiceNumber(tx.invoices, ctx.orgId);
+        const invoice = await tx.invoices.create({
+          data: {
+            matterId: input.matterId,
+            invoiceNumber,
+            ocrReference: ocrFromInvoiceNumber(invoiceNumber),
+            amount: avgift.beloppExclVatOre,
+            invoiceType: "STANDARD",
+            status: "DRAFT",
+            invoiceDate: new Date(),
+            dueDate: null,
+            notes: "Rådgivningstimme enligt rättshjälpstaxan (1 tim).",
+          },
+        });
+        await tx.matters.update({ where: { id: input.matterId }, data: { radgivningBetaldAt: new Date() } });
+        await emit.invoiceCreated(ctx, invoice);
+        return { invoice, beloppExclVatOre: avgift.beloppExclVatOre };
+      });
     }),
 
   /**

--- a/src/lib/shared/kostnadsrakning-template.ts
+++ b/src/lib/shared/kostnadsrakning-template.ts
@@ -52,6 +52,7 @@ export const KOSTNADSRAKNING_DEFAULT_HTML = `<!DOCTYPE html>
   tfoot td { font-weight: 700; border-top: 1px solid #aaa; padding-top: 6pt; }
   .footer { margin-top: 32pt; color: #666; font-size: 9pt; }
   .warn { background: #fff7e6; border: 1px solid #f0c574; padding: 6pt 10pt; border-radius: 4pt; margin: 8pt 0; font-size: 10pt; color: #8a5a00; }
+  .note { background: #f3f6fb; border: 1px solid #c9d6ea; padding: 6pt 10pt; border-radius: 4pt; margin: 8pt 0; font-size: 10pt; color: #33415c; }
   @media print { .noprint { display: none !important; } }
   .noprint { background: #eef; padding: 8pt; text-align: center; font-size: 9pt; color: #335; border-bottom: 1px solid #aac; }
 </style>
@@ -95,6 +96,10 @@ export const KOSTNADSRAKNING_DEFAULT_HTML = `<!DOCTYPE html>
     Förhandlingstiden överstiger taxans maxgräns (3 tim 45 min).
     Ersättning beräknas enligt timkostnadsnorm × faktisk tid (DVFS 2025:6 § 8).
   </div>
+{{/if}}
+
+{{#if radgivningNotice}}
+<div class="note">{{radgivningNotice}}</div>
 {{/if}}
 
 {{#if expenseLines.length}}

--- a/src/lib/shared/kostnadsrakning.ts
+++ b/src/lib/shared/kostnadsrakning.ts
@@ -18,6 +18,7 @@
  */
 
 import { computeBrottmalstaxa, computeTimkostnadsnorm, type TaxaLevel, type TaxaResult } from "./brottmalstaxa";
+import { radgivningTextRad } from "./rattshjalp";
 import { splitVat } from "./vat";
 
 export interface ExpenseInput {
@@ -38,6 +39,9 @@ export interface BuildInput {
     matterNumber: string;
     title: string;
     clientName?: string;
+    /** Rättshjälp (#383): klienten har betalat en rådgivningstimme separat →
+     *  visa transparens-textraden på kostnadsräkningen (inget belopp). */
+    radgivningPaid?: boolean;
   };
   defender: {
     name: string;
@@ -178,6 +182,9 @@ function buildKrTemplateContext(a: KrTemplateArgs): Record<string, unknown> {
     matterNumber: a.input.matter.matterNumber,
     matterTitle: a.input.matter.title,
     clientName: a.input.matter.clientName ?? "",
+    // #383: rådgivningstimmen redovisas som textrad (utan belopp) — ingår ej
+    // i domstolens kostnadsräkning, klienten har betalat den separat.
+    radgivningNotice: a.input.matter.radgivningPaid ? radgivningTextRad() : null,
     defenderName: a.input.defender.name,
     defenderEmail: a.input.defender.email ?? "",
     ...orgContext(a.input.organization),

--- a/src/lib/shared/rattshjalp.ts
+++ b/src/lib/shared/rattshjalp.ts
@@ -37,6 +37,15 @@ export function computeRadgivningsavgift(opts: { hasFTax?: boolean } = {}): Radg
   return { minutes: RADGIVNING_MINUTES, rateOrePerH: norm.rateOrePerH, beloppExclVatOre: norm.arbete };
 }
 
+/**
+ * Textraden om den klient-betalda rådgivningstimmen som ska synas på domstolens
+ * kostnadsräkning (#383): transparens, inget belopp domstolen ska betala.
+ */
+export function radgivningTextRad(): string {
+  return "Klienten har betalat en rådgivningstimme (1 tim) enligt rättshjälpstaxan separat. " +
+    "Ingår ej i denna kostnadsräkning.";
+}
+
 export interface MatterSettlementInput {
   /** Upparbetat arvode (debiterbar tid), öre. */
   arvodeOre: number;

--- a/src/lib/shared/schemas/matter.ts
+++ b/src/lib/shared/schemas/matter.ts
@@ -70,6 +70,12 @@ export const matterSchema = z.object({
    * rättssalen — slut-tidpunkten triggas av "STOPPA NU".
    */
   taxaHufStart: optionalDateLike,
+  /**
+   * Rättshjälp (#349/#383): tidpunkt då klientens rådgivningstimme (1 tim
+   * enligt rättshjälpstaxan) registrerades som betald + fakturerad separat.
+   * Null = ej registrerad. Styr text-raden på domstolens kostnadsräkning.
+   */
+  radgivningBetaldAt: optionalDateLike,
 }).passthrough();
 
 export type Matter = z.infer<typeof matterSchema>;

--- a/test/unit/app/matters/[id]/page.test.tsx
+++ b/test/unit/app/matters/[id]/page.test.tsx
@@ -89,6 +89,10 @@ vi.mock("@/lib/client/trpc", () => ({
       createKostnadsrakning: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
       setVerdict: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
     },
+    invoice: {
+      // #383: BillingPanel → RadgivningBanner använder createRadgivning.
+      createRadgivning: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+    },
     calendar: {
       listForMatter: { useQuery: () => ({ data: [] }) },
       listForUsers: { useQuery: () => ({ data: [] }) },

--- a/test/unit/server/routers/invoice.test.ts
+++ b/test/unit/server/routers/invoice.test.ts
@@ -29,6 +29,7 @@ const mockPrisma = {
   },
   matter: {
     findFirst: vi.fn(),
+    update: vi.fn(),
   },
   timeEntry: {
     findMany: vi.fn(),
@@ -249,6 +250,45 @@ describe("invoice.createFinal", () => {
         expenseIds: [],
       }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+});
+
+// ─── createRadgivning (#383, rättshjälp) ─────────────────────────
+
+describe("invoice.createRadgivning", () => {
+  beforeEach(() => {
+    mockPrisma.invoice.findFirst.mockResolvedValue(null); // nextInvoiceNumber → seq 1
+    mockPrisma.invoice.create.mockImplementation(async (a: { data: Record<string, unknown> }) => ({ id: "rad-1", ...a.data }));
+    mockPrisma.matter.update.mockResolvedValue({});
+  });
+
+  it("skapar en separat STANDARD-klientfaktura för rådgivningstimmen + märker ärendet", async () => {
+    mockPrisma.matter.findFirst.mockResolvedValue({ id: "m1", organizationId: "org-a", radgivningBetaldAt: null });
+
+    const res = await makeCaller().createRadgivning({ matterId: "m1" });
+
+    // 1 tim × timkostnadsnorm (F-skatt default) = 162 600 öre.
+    expect(res.beloppExclVatOre).toBe(162_600);
+    const data = mockPrisma.invoice.create.mock.calls[0]![0].data;
+    expect(data.invoiceType).toBe("STANDARD");
+    expect(data.amount).toBe(162_600);
+    expect(data.status).toBe("DRAFT");
+    // Ärendet märks som registrerat.
+    expect(mockPrisma.matter.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "m1" }, data: expect.objectContaining({ radgivningBetaldAt: expect.any(Date) }) }),
+    );
+  });
+
+  it("är idempotent — avvisar om redan registrerad", async () => {
+    mockPrisma.matter.findFirst.mockResolvedValue({ id: "m1", organizationId: "org-a", radgivningBetaldAt: new Date() });
+
+    await expect(makeCaller().createRadgivning({ matterId: "m1" })).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(mockPrisma.invoice.create).not.toHaveBeenCalled();
+  });
+
+  it("NOT_FOUND cross-org", async () => {
+    mockPrisma.matter.findFirst.mockResolvedValue(null);
+    await expect(makeCaller("org-b").createRadgivning({ matterId: "m1" })).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 });
 

--- a/test/unit/shared/kostnadsrakning.test.ts
+++ b/test/unit/shared/kostnadsrakning.test.ts
@@ -146,3 +146,28 @@ describe("templateContext — formaterad data för Handlebars", () => {
     expect(lines[0]!.inclVatFormatted).toMatch(/450,00\s+kr/);
   });
 });
+
+describe("buildKostnadsrakningContext — rådgivningstimme (#383)", () => {
+  it("radgivningPaid=true → textrad i templateContext (utan belopp)", () => {
+    const r = buildKostnadsrakningContext({
+      ...baseInput,
+      matter: { ...baseInput.matter, radgivningPaid: true },
+    });
+    const notice = r.templateContext.radgivningNotice as string | null;
+    expect(notice).toMatch(/rådgivningstimme/i);
+    expect(notice).toMatch(/ingår ej/i);
+    expect(notice).not.toMatch(/kr|öre|\bSEK\b/i); // inget belopp domstolen ska betala
+  });
+
+  it("default (ej satt) → ingen textrad", () => {
+    const r = buildKostnadsrakningContext(baseInput);
+    expect(r.templateContext.radgivningNotice).toBeNull();
+  });
+
+  it("rådgivningstimmen påverkar inte arvode/totaler (dubbelräknas ej mot domstolen)", () => {
+    const withR = buildKostnadsrakningContext({ ...baseInput, matter: { ...baseInput.matter, radgivningPaid: true } });
+    const without = buildKostnadsrakningContext(baseInput);
+    expect(withR.templateContext.arvodeInclVat).toBe(without.templateContext.arvodeInclVat);
+    expect(withR.templateContext.totalInclVat).toBe(without.templateContext.totalInclVat);
+  });
+});


### PR DESCRIPTION
**Closes #383** (#349 del A). Den klient-betalda rådgivningstimmen i rättshjälpsärenden: registrera den, fakturera den separat till klienten, och visa en transparens-textrad på domstolens kostnadsräkning. Beräkningen (`computeRadgivningsavgift`) landade i #382.

## Vad
1. **Registrera** — nytt matter-fält `radgivningBetaldAt` (tidpunkt).
2. **Separat klientfaktura** — `invoice.createRadgivning({ matterId, hasFTax? })`: skapar en **STANDARD**-faktura mot klienten för rådgivningsavgiften (1 tim × timkostnadsnormen) + sätter `radgivningBetaldAt` i samma transaktion. **Idempotent** (avvisar om redan registrerad). Timmen ingår ALDRIG i domstolens kostnadsräkning.
3. **Textrad på kostnadsräkningen** — `radgivningTextRad()` (åter)införd; `buildKostnadsrakningContext` emitterar `radgivningNotice` (utan belopp) när `matter.radgivningPaid`; Handlebars-mallen renderar en `.note`-ruta. Modal:en trådar `radgivningPaid` från `matter.radgivningBetaldAt`.
4. **UI** — `RadgivningBanner` i `BillingPanel` (self-gating till rättshjälp): visar avgiften + "Registrera betald", eller "✓ Registrerad".

## Tester
- `invoice.createRadgivning` (3): skapar STANDARD-faktura med rätt belopp + märker ärendet; idempotent → BAD_REQUEST; NOT_FOUND cross-org.
- `buildKostnadsrakningContext` (3): textrad finns vid `radgivningPaid`, saknas annars, och **påverkar inte arvode/totaler** (dubbelräknas ej mot domstolen).
- Matter-sidan + kostnadsräknings-modal + rättshjälp-/brottmål-scenarier gröna (mock uppdaterad med `invoice.createRadgivning`).

## Verifierat lokalt
- `tsc` + `bun run lint` + `bun run knip` + `eslint --no-inline-config --rule complexity:8` (0 offenders) gröna.
- `bun run test:cov` → rader 86.58 % (golv 86.00 %) ✓.

Refs #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)