### PR TITLE
test(e2e): härda /users-flödets git-db-poll mot push-fördröjning efter navigering (#216)

### DIFF
--- a/test/e2e/round-trip/round-trip.spec.ts
+++ b/test/e2e/round-trip/round-trip.spec.ts
@@ -349,6 +349,17 @@ test("fakturering: tid → acconto → betalning landar i git-db:n", async ({ pa
 
 const POLL = { timeout: 60_000, intervals: [3_000, 3_000, 5_000, 5_000, 5_000, 10_000] };
 
+/**
+ * Längre poll-fönster (#216) för git-db-skrivningar som följer en HÅRD
+ * sid-navigering (t.ex. /users/new → router.push("/users")). Navigeringen
+ * remountar sync-providern och kan skjuta upp den debouncade push:en (10 s)
+ * bakom en pågående initial-clone-sync → push:en kan landa först efter > 60 s
+ * på en långsam CI-körning. Den fristående clone-poll:en är auktoritativ;
+ * vi ger den helt enkelt tillräckligt med tid (sync-pillen är opålitlig över
+ * navigeringen, jfr hypotes 1 i #216).
+ */
+const POLL_LONG = { timeout: 150_000, intervals: [3_000, 3_000, 5_000, 5_000, 10_000, 10_000, 15_000, 15_000, 20_000] };
+
 test("utlägg: + Nytt utlägg i UI:t → expenses i git-db:n", async ({ page }) => {
   const stamp = Date.now();
   const desc = `Utlägg ${stamp}`;
@@ -517,6 +528,11 @@ test("kontor: lägg till kontor i settings → offices i git-db:n", async ({ pag
 });
 
 test("användare: skapa via /users/new + inaktivera → .ava/users i git-db:n", async ({ page }) => {
+  // #216: detta flöde navigerar hårt (/users/new → /users) vilket kan skjuta
+  // upp den debouncade push:en förbi standard-poll:ens 60 s på långsam CI.
+  // Ge testet + bare-repo-poll:erna (POLL_LONG) gott om tid; happy path är
+  // fortfarande sekundsnabbt.
+  test.setTimeout(360_000);
   const stamp = Date.now();
   const email = `new-${stamp}@firma.local`;
   const name = `Ny Användare ${stamp}`;
@@ -538,9 +554,10 @@ test("användare: skapa via /users/new + inaktivera → .ava/users i git-db:n", 
   await page.waitForURL(/\/users\/?$/, { timeout: 15_000 });
   await expect(page.getByText(name)).toBeVisible({ timeout: 15_000 });
 
-  // Användarrow:n persisterad till .ava/users/<email>.json
+  // Användarrow:n persisterad till .ava/users/<email>.json. POLL_LONG: push:en
+  // kan dröja efter den hårda navigeringen (#216) — clone-poll:en är auktoritativ.
   await waitForGitDbPush(page);
-  await expect.poll(() => rowsInRepo(".ava/users").map((u) => String(u.email)), POLL).toContain(email);
+  await expect.poll(() => rowsInRepo(".ava/users").map((u) => String(u.email)), POLL_LONG).toContain(email);
 
   // Inaktivera användaren — confirm()-dialog accepteras automatiskt
   page.once("dialog", (d) => d.accept());
@@ -551,7 +568,7 @@ test("användare: skapa via /users/new + inaktivera → .ava/users i git-db:n", 
   await expect.poll(() => {
     const row = rowsInRepo(".ava/users").find((u) => String(u.email) === email);
     return row ? row.active : "(saknas)";
-  }, POLL).toBe(false);
+  }, POLL_LONG).toBe(false);
 });
 
 test("dokument: ladda upp fil på matter → documents/<id>.json + content-fil i git-db:n", async ({ page }) => {


### PR DESCRIPTION
Refs #216 — den flakiga `användare: skapa via /users/new`-round-trip-testen ("rowsInRepo tom efter 60s").

## Diagnos
Testet är unikt bland git-db-testerna: det **navigerar hårt** (`/users/new` → `router.push("/users")` i onSuccess). De stabila testerna (org/kontor/dokument) stannar på samma sida och pollar bare-repot i 60 s — det räcker. Navigeringen remountar sync-providern och kan skjuta upp den debouncade push:en (10 s) bakom en pågående initial-clone-sync, så raden landar i bare-repot **först efter > 60 s** på en långsam CI-körning. Sync-pillen (`waitForGitDbPush`) är opålitlig över navigeringen (hypotes 1 i issuen) — den fristående clone-poll:en är den auktoritativa sanningen (hypotes 3).

## Fix
- Ny **`POLL_LONG`** (150 s) för de två `.ava/users`-assertionerna i users-testet — ger den auktoritativa poll:en tillräckligt med tid för en navigerings-fördröjd push.
- **`test.setTimeout(360_000)`** bara för detta flöde (två sekventiella long-polls + steg). Övriga round-trip-tester behåller 90 s.
- Happy path är fortfarande sekundsnabbt (poll:en returnerar så fort raden finns); bara den långsamma flaky-vägen utnyttjar extra-tiden.

## Verifiering
- `tsc` + `bun run lint` gröna.
- CI:s **E2E (git round-trip)** kör testet mot en färsk docker-stack. ⚠ Jag kunde inte köra `bun run round-trip` 20× lokalt här (ingen docker i sessionen), så statistisk flake-eliminering (#216:s 20/20-kriterium) bör bekräftas över några körningar. CI-grönt på denna PR validerar att flödet passerar med fixen.

Relaterat: #209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)