### PR TITLE
feat(billing): skicka DRAFT-faktura — automatiskt (köa) eller manuellt, DRAFT→SENT (#392)

### DIFF
--- a/src/app/invoices/[id]/_client.tsx
+++ b/src/app/invoices/[id]/_client.tsx
@@ -186,7 +186,12 @@ function InvoiceModals({ inv, ledger, s }: { inv: Inv; ledger: LedgerView; s: In
           invoiceDate={inv.invoiceDate}
           matterNumber={inv.matter.matterNumber}
           matterTitle={inv.matter.title}
-          onRecorded={() => { void s.utils.invoiceDispatch.list.invalidate({ invoiceId: inv.id }); }}
+          onRecorded={() => {
+            void s.utils.invoiceDispatch.list.invalidate({ invoiceId: inv.id });
+            // #392: utskick (auto/manuellt) flippar DRAFT→SENT → ladda om fakturan.
+            void s.utils.invoice.getById.invalidate({ id: inv.id });
+            void s.utils.invoice.list.invalidate();
+          }}
           onClose={() => s.setShowSend(false)}
         />
       )}

--- a/src/app/invoices/[id]/_invoice-actions.tsx
+++ b/src/app/invoices/[id]/_invoice-actions.tsx
@@ -28,11 +28,12 @@ interface Visibility {
 const TERMINAL_STATUS: ReadonlySet<string> = new Set(["PAID", "CANCELLED"]);
 
 /**
- * E-posta-knappen (#179): en utställd faktura (SENT/avbetalningsplan) eller en
- * icke-annullerad kreditfaktura kan skickas manuellt till klienten.
+ * Skicka-knappen (#179/#392): en faktura kan skickas i DRAFT (då blir den SENT),
+ * är utställd (SENT/avbetalningsplan → kan skickas om), eller är en icke-annullerad
+ * kreditfaktura. Modalen erbjuder automatiskt (köa → server) + manuellt utskick.
  */
-function canEmail(isCredit: boolean, status: string): boolean {
-  if (status === "SENT" || status === "INSTALLMENT_PLAN") return true;
+function canSend(isCredit: boolean, status: string): boolean {
+  if (status === "DRAFT" || status === "SENT" || status === "INSTALLMENT_PLAN") return true;
   return isCredit && status !== "CANCELLED";
 }
 
@@ -50,7 +51,7 @@ function computeVisibility(invoiceType: string, status: string, hasPlan: boolean
     // Avskrivning: utställd faktura med utestående kvar (även en plan-faktura
     // som klienten slutat betala) → räkna-en-gång (ADR 0007).
     writeOff: issuedActive && outstanding > 0,
-    send: canEmail(isCredit, status),
+    send: canSend(isCredit, status),
   };
 }
 
@@ -74,7 +75,7 @@ export function InvoiceActions({
       )}
       {v.send && (
         <button onClick={onShowSend} className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700">
-          E-posta faktura
+          Skicka faktura
         </button>
       )}
       {v.draft && (

--- a/src/app/invoices/[id]/_send-invoice-modal.tsx
+++ b/src/app/invoices/[id]/_send-invoice-modal.tsx
@@ -64,8 +64,10 @@ interface SendInvoiceState {
   note: string | null;
   error: string | null;
   isPending: boolean;
+  queuePending: boolean;
   onEmail: () => void;
   onDownload: () => void;
+  onQueue: () => void;
   confirmSent: () => void;
 }
 
@@ -82,6 +84,18 @@ function useSendInvoice(props: SendInvoiceModalProps): SendInvoiceState {
     onSuccess: () => { props.onRecorded(); props.onClose(); },
     onError: (e) => setError(e.message),
   });
+  // Automatiskt utskick (#392): köa → server-runtime-workern skickar via SMTP.
+  const queue = trpc.invoiceDispatch.queue.useMutation({
+    onSuccess: () => { props.onRecorded(); props.onClose(); },
+    onError: (e) => setError(e.message),
+  });
+
+  const onQueue = (): void => {
+    const trimmed = recipient.trim();
+    if (!trimmed.includes("@")) { setError("Ange mottagarens e-post för automatiskt utskick."); return; }
+    setError(null);
+    queue.mutate({ invoiceId: props.invoiceId, channel: "email", recipient: trimmed });
+  };
 
   const run = async (fn: () => Promise<string>): Promise<void> => {
     setBusy(true);
@@ -126,7 +140,11 @@ function useSendInvoice(props: SendInvoiceModalProps): SendInvoiceState {
     });
   };
 
-  return { recipient, setRecipient, prepared, busy, note, error, isPending: record.isPending, onEmail, onDownload, confirmSent };
+  return {
+    recipient, setRecipient, prepared, busy, note, error,
+    isPending: record.isPending, queuePending: queue.isPending,
+    onEmail, onDownload, onQueue, confirmSent,
+  };
 }
 
 export function SendInvoiceModal(props: SendInvoiceModalProps) {
@@ -137,7 +155,7 @@ export function SendInvoiceModal(props: SendInvoiceModalProps) {
         <div className="flex items-center justify-between border-b border-gray-200 px-5 py-4">
           <h2 className="text-base sm:text-lg font-bold text-gray-900 flex items-center gap-2">
             <Mail size={18} className="text-blue-600" />
-            E-posta faktura {props.invoiceNumber ?? ""}
+            Skicka faktura {props.invoiceNumber ?? ""}
           </h2>
           <button onClick={props.onClose} aria-label="Stäng" className="p-2 hover:bg-gray-100 rounded">
             <X size={18} />
@@ -155,46 +173,85 @@ export function SendInvoiceModal(props: SendInvoiceModalProps) {
               className="mt-1 w-full rounded border border-gray-300 px-3 py-1.5 text-sm"
             />
             <span className="mt-1 block text-xs text-gray-400">
-              Förifylls i mailklienten. Mailet skickas från din egen e-post — ingen server inblandad.
+              Används för både automatiskt och manuellt utskick.
             </span>
           </label>
 
-          <div className="flex flex-wrap gap-2">
-            <button
-              onClick={s.onEmail}
-              disabled={s.busy || s.isPending}
-              className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 flex items-center gap-1.5"
-            >
-              <Mail size={15} /> Öppna i mailklient
-            </button>
-            <button
-              onClick={s.onDownload}
-              disabled={s.busy || s.isPending}
-              className="px-3 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50 flex items-center gap-1.5"
-            >
-              <Download size={15} /> Ladda ner PDF
-            </button>
-          </div>
+          <AutoSendSection s={s} />
+          <ManualSendSection s={s} />
 
           {s.note && <p className="text-sm text-gray-600 bg-gray-50 border border-gray-200 rounded p-2">{s.note}</p>}
           {s.error && <p className="text-sm text-red-600">{s.error}</p>}
 
-          {s.prepared && (
-            <div className="border-t pt-3">
-              <p className="text-sm text-gray-700 mb-2">
-                Har du skickat fakturan? Markera den som skickad så registreras utskicket i AVA.
-              </p>
-              <button
-                onClick={s.confirmSent}
-                disabled={s.isPending}
-                className="px-3 py-1.5 text-sm bg-green-600 text-white rounded hover:bg-green-700 disabled:opacity-50"
-              >
-                {s.isPending ? "Registrerar…" : "Markera som skickad"}
-              </button>
-            </div>
-          )}
+          <ConfirmSentBlock s={s} />
         </div>
       </div>
+    </div>
+  );
+}
+
+/** Automatiskt utskick: köa → server-runtime skickar via SMTP (#392). */
+function AutoSendSection({ s }: { s: SendInvoiceState }) {
+  return (
+    <div className="rounded-lg border border-blue-200 bg-blue-50 p-3">
+      <p className="text-sm font-medium text-blue-900 mb-1">Automatiskt utskick</p>
+      <p className="text-xs text-blue-800 mb-2">
+        Köa fakturan — servern skickar den via e-post (kräver konfigurerad SMTP).
+      </p>
+      <button
+        onClick={s.onQueue}
+        disabled={s.busy || s.queuePending || s.isPending}
+        className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 flex items-center gap-1.5"
+      >
+        <Mail size={15} /> {s.queuePending ? "Köar…" : "Köa för automatiskt utskick"}
+      </button>
+    </div>
+  );
+}
+
+/** Manuellt utskick: advokaten skickar via egen mailklient (helper) / nedladdning. */
+function ManualSendSection({ s }: { s: SendInvoiceState }) {
+  return (
+    <div className="rounded-lg border border-gray-200 p-3">
+      <p className="text-sm font-medium text-gray-900 mb-1">Manuellt utskick</p>
+      <p className="text-xs text-gray-500 mb-2">
+        Skicka från din egen e-post via helper-appen, eller ladda ner PDF:en och bifoga själv.
+      </p>
+      <div className="flex flex-wrap gap-2">
+        <button
+          onClick={s.onEmail}
+          disabled={s.busy || s.isPending}
+          className="px-3 py-1.5 text-sm bg-gray-800 text-white rounded hover:bg-gray-900 disabled:opacity-50 flex items-center gap-1.5"
+        >
+          <Mail size={15} /> Öppna i mailklient
+        </button>
+        <button
+          onClick={s.onDownload}
+          disabled={s.busy || s.isPending}
+          className="px-3 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50 flex items-center gap-1.5"
+        >
+          <Download size={15} /> Ladda ner PDF
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** "Markera som skickad" efter att man förberett ett manuellt utskick. */
+function ConfirmSentBlock({ s }: { s: SendInvoiceState }) {
+  if (!s.prepared) return null;
+  return (
+    <div className="border-t pt-3">
+      <p className="text-sm text-gray-700 mb-2">
+        Har du skickat fakturan? Markera den som skickad så registreras utskicket i AVA.
+      </p>
+      <button
+        onClick={s.confirmSent}
+        disabled={s.isPending}
+        className="px-3 py-1.5 text-sm bg-green-600 text-white rounded hover:bg-green-700 disabled:opacity-50"
+      >
+        {s.isPending ? "Registrerar…" : "Markera som skickad"}
+      </button>
     </div>
   );
 }

--- a/src/lib/server/routers/invoiceDispatch.ts
+++ b/src/lib/server/routers/invoiceDispatch.ts
@@ -10,18 +10,31 @@
 
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import { canTransition } from "@/lib/shared/invoice-state-machine";
 import { dispatchChannelSchema, dispatchStatusSchema, type DispatchStatus } from "@/lib/shared/schemas/billing";
+import type { InvoiceStatus } from "@/lib/shared/schemas/enums";
 import { asId } from "@/lib/shared/schemas/ids";
+import type { IDataStore } from "../data-store/IDataStore";
 import { router, orgProcedure } from "../trpc";
 
-async function assertInvoiceInOrg(
-  ctx: { dataStore: { invoices: { findFirst: (a: unknown) => Promise<unknown> } }; orgId: string },
-  invoiceId: string,
-): Promise<void> {
-  const inv = await ctx.dataStore.invoices.findFirst({
+type DispatchCtx = { dataStore: IDataStore; orgId: string };
+
+/** Verifiera org-tillhörighet + returnera fakturans id/status. */
+async function assertInvoiceInOrg(ctx: DispatchCtx, invoiceId: string): Promise<{ id: string; status: string }> {
+  const inv = (await ctx.dataStore.invoices.findFirst({
     where: { id: invoiceId, matter: { organizationId: ctx.orgId } },
-  });
+  })) as { id: string; status: string } | null;
   if (!inv) throw new TRPCError({ code: "NOT_FOUND", message: "Fakturan finns inte i organisationen." });
+  return inv;
+}
+
+/**
+ * En köad/skickad faktura är inte längre ett utkast (#392). Flippa DRAFT → SENT
+ * via tillståndsmaskinen (#350); redan utställd faktura lämnas oförändrad.
+ */
+async function markSentIfDraft(ctx: DispatchCtx, inv: { id: string; status: string }): Promise<void> {
+  if (inv.status !== "DRAFT" || !canTransition("DRAFT", "SENT")) return;
+  await ctx.dataStore.invoices.update({ where: { id: inv.id }, data: { status: "SENT" satisfies InvoiceStatus } });
 }
 
 /** Tidsstämpelfältet som en statusövergång sätter (queued sätts vid skapande). */
@@ -59,9 +72,9 @@ export const invoiceDispatchRouter = router({
       recipient: z.string().min(1),
     }))
     .mutation(async ({ ctx, input }) => {
-      await assertInvoiceInOrg(ctx, input.invoiceId);
+      const inv = await assertInvoiceInOrg(ctx, input.invoiceId);
       const now = new Date();
-      return ctx.dataStore.invoiceDispatches.create({
+      const dispatch = await ctx.dataStore.invoiceDispatches.create({
         data: {
           invoiceId: asId<"InvoiceId">(input.invoiceId),
           channel: input.channel,
@@ -72,6 +85,9 @@ export const invoiceDispatchRouter = router({
           createdAt: now,
         },
       });
+      // Köad för automatiskt utskick → fakturan är inte längre ett utkast (#392).
+      await markSentIfDraft(ctx, inv);
+      return dispatch;
     }),
 
   /**
@@ -89,9 +105,9 @@ export const invoiceDispatchRouter = router({
       recipient: z.string().min(1),
     }))
     .mutation(async ({ ctx, input }) => {
-      await assertInvoiceInOrg(ctx, input.invoiceId);
+      const inv = await assertInvoiceInOrg(ctx, input.invoiceId);
       const now = new Date();
-      return ctx.dataStore.invoiceDispatches.create({
+      const dispatch = await ctx.dataStore.invoiceDispatches.create({
         data: {
           invoiceId: asId<"InvoiceId">(input.invoiceId),
           channel: input.channel,
@@ -103,6 +119,9 @@ export const invoiceDispatchRouter = router({
           createdAt: now,
         },
       });
+      // Manuellt skickad → fakturan är inte längre ett utkast (#392).
+      await markSentIfDraft(ctx, inv);
+      return dispatch;
     }),
 
   updateStatus: orgProcedure

--- a/test/unit/app/invoices/send-invoice-modal.test.tsx
+++ b/test/unit/app/invoices/send-invoice-modal.test.tsx
@@ -9,6 +9,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest-compat";
 import { SendInvoiceModal } from "@/app/invoices/[id]/_send-invoice-modal";
 
 const recordMutate = vi.fn();
+const queueMutate = vi.fn();
 const composeMail = vi.fn(async () => true);
 const downloadBytes = vi.fn();
 const renderFakturaPdf = vi.fn(async () => new Uint8Array([1, 2, 3]));
@@ -18,6 +19,7 @@ vi.mock("@/lib/client/trpc", () => ({
   trpc: {
     invoiceDispatch: {
       recordManual: { useMutation: (opts: { onSuccess?: () => void }) => ({ mutate: (...a: unknown[]) => { recordMutate(...a); opts.onSuccess?.(); }, isPending: false, error: null }) },
+      queue: { useMutation: (opts: { onSuccess?: () => void }) => ({ mutate: (...a: unknown[]) => { queueMutate(...a); opts.onSuccess?.(); }, isPending: false, error: null }) },
     },
   },
 }));
@@ -46,11 +48,28 @@ beforeEach(() => {
 });
 
 describe("SendInvoiceModal", () => {
-  it("renderar rubrik + åtgärdsknappar", () => {
+  it("renderar rubrik + automatisk/manuell sektion", () => {
     render(<SendInvoiceModal {...baseProps} />);
-    expect(screen.getByRole("heading", { name: /E-posta faktura/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Skicka faktura/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Köa för automatiskt utskick/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Öppna i mailklient/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Ladda ner PDF/i })).toBeInTheDocument();
+  });
+
+  it("automatiskt: köar utskick (server) med e-postkanal + mottagare (#392)", async () => {
+    render(<SendInvoiceModal {...baseProps} />);
+    fireEvent.change(screen.getByPlaceholderText(/klient@/i), { target: { value: "k@x.se" } });
+    fireEvent.click(screen.getByRole("button", { name: /Köa för automatiskt utskick/i }));
+    await waitFor(() => expect(queueMutate).toHaveBeenCalled());
+    expect(queueMutate.mock.calls[0]![0]).toMatchObject({ invoiceId: "inv-1", channel: "email", recipient: "k@x.se" });
+    expect(baseProps.onRecorded).toHaveBeenCalled();
+  });
+
+  it("automatiskt utan e-post → fel, ingen köning", async () => {
+    render(<SendInvoiceModal {...baseProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /Köa för automatiskt utskick/i }));
+    expect(await screen.findByText(/Ange mottagarens e-post/i)).toBeInTheDocument();
+    expect(queueMutate).not.toHaveBeenCalled();
   });
 
   it("nedladdning genererar PDF + laddar ner, sedan visas bekräftelse", async () => {

--- a/test/unit/server/routers/invoiceDispatch.test.ts
+++ b/test/unit/server/routers/invoiceDispatch.test.ts
@@ -17,6 +17,7 @@ function makeCaller() {
     users: [{ id: "u-1", organizationId: "org-1", email: "a@x", name: "Anna", role: "ADMIN" }],
     invoices: [
       { id: "inv-1", matterId: "m-1", amount: 12_500, status: "SENT", invoiceType: "STANDARD", invoiceDate: new Date(), createdAt: new Date() },
+      { id: "inv-draft", matterId: "m-1", amount: 9_000, status: "DRAFT", invoiceType: "STANDARD", invoiceDate: new Date(), createdAt: new Date() },
       { id: "inv-foreign", matterId: "m-2", amount: 5_000, status: "SENT", invoiceType: "STANDARD", invoiceDate: new Date(), createdAt: new Date() },
     ],
   }, async () => {});
@@ -73,6 +74,29 @@ describe("invoiceDispatch.recordManual (#179)", () => {
     await expect(
       caller.invoiceDispatch.recordManual({ invoiceId: "inv-foreign", channel: "manual", recipient: "x" }),
     ).rejects.toThrow();
+  });
+});
+
+describe("skickning flippar DRAFT → SENT (#392)", () => {
+  it("queue på en DRAFT-faktura → fakturan blir SENT", async () => {
+    const { caller } = makeCaller();
+    await caller.invoiceDispatch.queue({ invoiceId: "inv-draft", channel: "email", recipient: "k@x.se" });
+    const inv = await caller.invoice.getById({ id: "inv-draft" });
+    expect(inv.status).toBe("SENT");
+  });
+
+  it("recordManual på en DRAFT-faktura → fakturan blir SENT", async () => {
+    const { caller } = makeCaller();
+    await caller.invoiceDispatch.recordManual({ invoiceId: "inv-draft", channel: "manual", recipient: "Manuellt" });
+    const inv = await caller.invoice.getById({ id: "inv-draft" });
+    expect(inv.status).toBe("SENT");
+  });
+
+  it("redan SENT lämnas oförändrad (ingen otillåten övergång)", async () => {
+    const { caller } = makeCaller();
+    await caller.invoiceDispatch.queue({ invoiceId: "inv-1", channel: "email", recipient: "k@x.se" });
+    const inv = await caller.invoice.getById({ id: "inv-1" });
+    expect(inv.status).toBe("SENT");
   });
 });
 


### PR DESCRIPTION
**Closes #392.** En faktura i `DRAFT` saknade utskicks-knapp — nu finns båda vägarna du beskrev.

## Vad
- **Skicka-knapp på DRAFT** (`_invoice-actions.tsx`): `canSend` inkluderar `DRAFT` → "Skicka faktura"-knappen visas (öppnar send-modalen). "Markera som skickad" (naken flip) finns kvar som genväg.
- **Send-modalen erbjuder BÅDA sätten** (`_send-invoice-modal.tsx`):
  - **Automatiskt**: "Köa för automatiskt utskick" → `invoiceDispatch.queue` (status `queued`). Server-runtime-dispatch-workern (`dispatchQueuedEmails`, SMTP) plockar upp + skickar. Kräver mottagar-e-post.
  - **Manuellt**: "Öppna i mailklient" (helper `compose-mail`) / "Ladda ner PDF" → bekräfta → `recordManual`.
- **`DRAFT → SENT` vid utskick**: både `queue` och `recordManual` flippar fakturan via tillståndsmaskinen (#350/ADR 0015) — en köad/skickad faktura är inte längre ett utkast. Redan `SENT` lämnas oförändrad. (`_client.tsx` laddar om fakturan efter utskick.)

## Två sätt (din modell)
1. **Automatiskt** — "sätt en flagga" = köa ett `InvoiceDispatch` (`queued`); servern plockar upp och skickar.
2. **Manuellt** — skapa mail + bifoga fakturan via helper-appen (`compose-mail`), eller ladda ner PDF:en.

## Tester
- Dispatch-router (#392): `queue`/`recordManual` på en DRAFT → fakturan blir `SENT`; redan `SENT` → oförändrad.
- Send-modal: queue-vägen (kanal `email` + mottagare → `onRecorded`), samt fel utan e-post.
- Befintliga dispatch/modal-tester gröna (102 i invoice-klustret).

## Verifierat lokalt
- `tsc` + `bun run lint` + `bun run knip` + `eslint --no-inline-config --rule complexity:8` (0 offenders — bröt ut Auto/Manual/Confirm-sektionerna ur modalen) gröna.
- `bun run test:cov` → rader 86.67 % (golv 86.20 %) ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)