### PR TITLE
test(calendar): render-täck DayView, höj line-floor 86.2→86.6

### DIFF
--- a/test/unit/app/calendar/day-view-render.test.tsx
+++ b/test/unit/app/calendar/day-view-render.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Render-tester för DayView (#27 coverage) — dag-vyns komponent: rubrik,
+ * heldags-/frist-sektion, timade event-block, navigering (föreg/idag/nästa)
+ * och klick → onSelectEvent. Pure-helpers täcks separat i day-view-helpers.
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { DayView, type DayEvent } from "@/app/calendar/_day-view";
+
+const listQuery = { data: [] as DayEvent[], isLoading: false };
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: { calendar: { listForUsers: { useQuery: () => listQuery } } },
+}));
+
+const anchor = new Date(2026, 3, 15, 12, 0); // 15 april 2026, lokal
+const baseProps = {
+  anchor,
+  onAnchorChange: vi.fn(),
+  userIds: ["u1"] as const,
+  userNames: { u1: "Anna" },
+  onSelectEvent: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listQuery.data = [];
+  listQuery.isLoading = false;
+});
+
+describe("DayView", () => {
+  it("visar datum-rubrik + event-räknare (0 event)", () => {
+    render(<DayView {...baseProps} />);
+    expect(screen.getByText(/april/i)).toBeInTheDocument();
+    expect(screen.getByText("0 event")).toBeInTheDocument();
+  });
+
+  it("visar 'Laddar…' under laddning", () => {
+    listQuery.isLoading = true;
+    render(<DayView {...baseProps} />);
+    expect(screen.getByText("Laddar…")).toBeInTheDocument();
+  });
+
+  it("renderar ett timat event som block med titel + tid, klick → onSelectEvent", () => {
+    listQuery.data = [{
+      id: "e1", userId: "u1", title: "Möte med klient",
+      startAt: new Date(2026, 3, 15, 9, 0), endAt: new Date(2026, 3, 15, 10, 0),
+      allDay: false, kind: "appointment",
+    }];
+    render(<DayView {...baseProps} />);
+    expect(screen.getByText("Möte med klient")).toBeInTheDocument();
+    expect(screen.getByText("1 event")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Möte med klient"));
+    expect(baseProps.onSelectEvent).toHaveBeenCalledWith(expect.objectContaining({ id: "e1" }));
+  });
+
+  it("frister/heldag hamnar i 'Heldag / Frister'-sektionen", () => {
+    listQuery.data = [{
+      id: "d1", userId: "u1", title: "Svarsfrist", startAt: new Date(2026, 3, 15, 0, 0),
+      endAt: null, allDay: false, kind: "deadline",
+    }];
+    render(<DayView {...baseProps} />);
+    expect(screen.getByText(/Heldag \/ Frister/i)).toBeInTheDocument();
+    expect(screen.getByText("Svarsfrist")).toBeInTheDocument();
+  });
+
+  it("navigering: föregående/nästa/idag → onAnchorChange", () => {
+    render(<DayView {...baseProps} />);
+    fireEvent.click(screen.getByLabelText("Föregående dag"));
+    fireEvent.click(screen.getByLabelText("Nästa dag"));
+    fireEvent.click(screen.getByRole("button", { name: "Idag" }));
+    expect(baseProps.onAnchorChange).toHaveBeenCalledTimes(3);
+  });
+});

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -33,9 +33,9 @@ const FAST = process.argv.includes("--fast");
 // Ratchet-golv (flyttat hit från check-coverage.ts) — flytta BARA uppåt.
 // #27: 84.0 → 84.8 (pick-provider) → 85.2 (external-edit-modal) → 85.5
 // (verdict-dialog) → 85.7 (billing-dialog) → 85.8 (expected-receivables) → 86.0
-// (integrations-section) → 86.2 (expectedReceivable candidates/update, lokalt
-// 86.67% rader, ~0.47% marginal — FUNC_FLOOR konservativt pga Node-version-varians).
-const LINE_FLOOR = 0.862;
+// (integrations-section) → 86.2 (expectedReceivable) → 86.6 (DayView-render,
+// lokalt 87.02% rader, ~0.42% marginal — FUNC_FLOOR konservativt pga Node-version-varians).
+const LINE_FLOOR = 0.866;
 const FUNC_FLOOR = 0.80;
 
 /**


### PR DESCRIPTION
Del av #27 (kodtäckning → 95 %, ratchet). Ett steg.

## Vad
- **`_day-view.tsx` (DayView-komponenten)** (31 % → täckt): render-tester för datum-rubrik + event-räknare, laddningstillstånd, timat event-block (titel + tid) med klick → `onSelectEvent`, frist/heldag-sektionen, samt navigering (föreg/idag/nästa → `onAnchorChange`). De pure-helpers (`eventsForDate`/`layoutEventsForDay`/`dayBounds`) täcktes redan separat.
- **Ratchet:** merged line-coverage 86.67 % → **87.02 %** → `LINE_FLOOR` 0.862 → **0.866**. `FUNC_FLOOR` kvar på 0.80.

## Verifierat lokalt
- `bun test day-view-render` → 5 pass
- `bun run test:cov` → rader 87.01 % (golv 86.60 %), funktioner 82.30 % ✓
- `tsc` + `lint` gröna

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)