### PR TITLE
test(settings): täck DatasourceSection, höj line-floor 86.6→86.7

### DIFF
--- a/test/unit/components/datasource-section.test.tsx
+++ b/test/unit/components/datasource-section.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * Tester för DatasourceSection (#27 coverage) — wrappern på /settings:
+ * laddningstillstånd (config ej läst än) vs laddat (rubrik + barn-paneler).
+ * Barn-komponenterna (FirmaSettingsPanel/FsaFolderSelector/SyncDiagnostics)
+ * stubbas — de testas separat.
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { DatasourceSection } from "@/components/settings/datasource-section";
+
+let loaded: unknown = { tier: "self-hosted", repo: "http://x/git/firma.git", token: "t" };
+vi.mock("@/lib/client/firma/firma-config", () => ({ loadFirmaConfig: () => loaded }));
+vi.mock("@/components/settings/firma-settings-panel", () => ({
+  FirmaSettingsPanel: ({ children }: { children?: React.ReactNode }) => <div data-testid="firma-panel">{children}</div>,
+}));
+vi.mock("@/components/settings/fsa-folder-selector", () => ({
+  FsaFolderSelector: () => <div data-testid="fsa-selector" />,
+}));
+vi.mock("@/components/settings/sync-diagnostics", () => ({
+  SyncDiagnostics: () => <div data-testid="sync-diagnostics" />,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  loaded = { tier: "self-hosted", repo: "http://x/git/firma.git", token: "t" };
+});
+
+describe("DatasourceSection", () => {
+  it("laddat: visar rubrik + firma-panel med FSA-väljare + sync-status", async () => {
+    render(<DatasourceSection />);
+    await waitFor(() => expect(screen.getByText("Datakälla & inloggning")).toBeInTheDocument());
+    expect(screen.getByTestId("firma-panel")).toBeInTheDocument();
+    expect(screen.getByTestId("fsa-selector")).toBeInTheDocument();
+    expect(screen.getByTestId("sync-diagnostics")).toBeInTheDocument();
+  });
+
+  it("laddningstillstånd när config ännu inte lästs (null)", () => {
+    loaded = null;
+    render(<DatasourceSection />);
+    expect(screen.getByText(/Laddar datakälla/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("firma-panel")).not.toBeInTheDocument();
+  });
+});

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -33,9 +33,10 @@ const FAST = process.argv.includes("--fast");
 // Ratchet-golv (flyttat hit från check-coverage.ts) — flytta BARA uppåt.
 // #27: 84.0 → 84.8 (pick-provider) → 85.2 (external-edit-modal) → 85.5
 // (verdict-dialog) → 85.7 (billing-dialog) → 85.8 (expected-receivables) → 86.0
-// (integrations-section) → 86.2 (expectedReceivable) → 86.6 (DayView-render,
-// lokalt 87.02% rader, ~0.42% marginal — FUNC_FLOOR konservativt pga Node-version-varians).
-const LINE_FLOOR = 0.866;
+// (integrations-section) → 86.2 (expectedReceivable) → 86.6 (DayView-render) →
+// 86.7 (datasource-section, lokalt 87.14% rader, ~0.44% marginal — FUNC_FLOOR
+// konservativt pga Node-version-varians).
+const LINE_FLOOR = 0.867;
 const FUNC_FLOOR = 0.80;
 
 /**


### PR DESCRIPTION
Del av #27 (kodtäckning → 95 %, ratchet). Ett steg.

## Vad
- **`datasource-section.tsx`** (15 % → täckt): wrappern på /settings — laddningstillstånd (config ej läst) vs laddat (rubrik + firma-panel med FSA-väljare + sync-status). Barn-komponenterna stubbas (testas separat).
- **Ratchet:** merged line-coverage 87.01 % → **87.14 %** → `LINE_FLOOR` 0.866 → **0.867**. `FUNC_FLOOR` kvar på 0.80.

## Verifierat lokalt
- `bun test datasource-section` → 2 pass
- `bun run test:cov` → rader 87.14 % (golv 86.70 %) ✓
- `tsc` + `lint` gröna

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)