### PR TITLE
test(jobs): täck extract-text PDF/DOCX-extraktorer, höj line-floor 86.7→86.8

### DIFF
--- a/test/unit/lib/jobs/extract-text-formats.test.ts
+++ b/test/unit/lib/jobs/extract-text-formats.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tester för extractText:s format-extraktorer (#27 coverage) — PDF (pdfjs) +
+ * DOCX (mammoth) via mockade dynamiska imports, plus Blob/ArrayBuffer-input
+ * (toBytes-grenarna). Plain-text/detectKind täcks i extract-text.test.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { extractText } from "@/lib/client/jobs/extract-text";
+
+let pdfThrows = false;
+const pdfDoc = {
+  numPages: 2,
+  getPage: async (i: number) => ({
+    getTextContent: async () => ({ items: [{ str: `sida${i}` }, { str: "text" }, { foo: "ingen str" }] }),
+  }),
+};
+vi.mock("pdfjs-dist/legacy/build/pdf.mjs", () => ({
+  GlobalWorkerOptions: { workerSrc: "" }, // tom → utövar worker-url-grenen
+  getDocument: () => ({ promise: pdfThrows ? Promise.reject(new Error("trasig PDF")) : Promise.resolve(pdfDoc) }),
+}));
+vi.mock("mammoth", () => ({ extractRawText: async () => ({ value: "Word-dokumentets text" }) }));
+
+beforeEach(() => { pdfThrows = false; });
+
+describe("extractText — PDF (pdfjs)", () => {
+  it("extraherar text från alla sidor (str-items, hoppar över icke-str)", async () => {
+    const out = await extractText({ bytes: new Uint8Array([1, 2]), mimeType: "application/pdf" });
+    expect(out).toContain("sida1");
+    expect(out).toContain("sida2");
+    expect(out).toContain("text");
+  });
+
+  it("fail-soft: trasig PDF → tom sträng", async () => {
+    pdfThrows = true;
+    const out = await extractText({ bytes: new Uint8Array([1]), fileName: "x.pdf" });
+    expect(out).toBe("");
+  });
+});
+
+describe("extractText — DOCX (mammoth)", () => {
+  it("extraherar rå text via mammoth", async () => {
+    const out = await extractText({ bytes: new Uint8Array([1]), fileName: "x.docx" });
+    expect(out).toBe("Word-dokumentets text");
+  });
+});
+
+describe("extractText — toBytes-grenar", () => {
+  it("accepterar Blob-input", async () => {
+    const blob = new Blob(["hej blob"], { type: "text/plain" });
+    const out = await extractText({ bytes: blob, mimeType: "text/plain" });
+    expect(out).toBe("hej blob");
+  });
+
+  it("accepterar ArrayBuffer-input", async () => {
+    const buf = new TextEncoder().encode("hej buffer").buffer;
+    const out = await extractText({ bytes: buf, fileName: "a.txt" });
+    expect(out).toBe("hej buffer");
+  });
+});

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -34,9 +34,9 @@ const FAST = process.argv.includes("--fast");
 // #27: 84.0 → 84.8 (pick-provider) → 85.2 (external-edit-modal) → 85.5
 // (verdict-dialog) → 85.7 (billing-dialog) → 85.8 (expected-receivables) → 86.0
 // (integrations-section) → 86.2 (expectedReceivable) → 86.6 (DayView-render) →
-// 86.7 (datasource-section, lokalt 87.14% rader, ~0.44% marginal — FUNC_FLOOR
-// konservativt pga Node-version-varians).
-const LINE_FLOOR = 0.867;
+// 86.7 (datasource-section) → 86.8 (extract-text pdf/docx, lokalt 87.29% rader,
+// ~0.49% marginal — FUNC_FLOOR konservativt pga Node-version-varians).
+const LINE_FLOOR = 0.868;
 const FUNC_FLOOR = 0.80;
 
 /**


### PR DESCRIPTION
Del av #27 (kodtäckning → 95 %, ratchet). Ett steg.

## Vad
- **`extract-text.ts`** (38 % → täckt): `extractText`:s tunga vägar via mockade dynamiska imports — PDF (pdfjs: alla sidor, hoppar icke-`str`-items, fail-soft vid trasig PDF) + DOCX (mammoth), samt Blob/ArrayBuffer-input (`toBytes`-grenarna). `detectKind` + plain-text täcktes redan i `extract-text.test.ts`.
- **Ratchet:** merged line-coverage 87.14 % → **87.29 %** → `LINE_FLOOR` 0.867 → **0.868**. `FUNC_FLOOR` kvar på 0.80.

## Verifierat lokalt
- `bun test extract-text-formats` → 5 pass
- `bun run test:cov` → rader 87.29 % (golv 86.80 %), funktioner 82.36 % ✓
- `tsc` + `lint` gröna

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)