### PR TITLE
feat(billing): avdragsmedvetet fakturaskapande — föreslå ofakturerade poster + aconto-formel + dokument (#397)

### DIFF
--- a/src/app/matters/[id]/_billing-dialog.tsx
+++ b/src/app/matters/[id]/_billing-dialog.tsx
@@ -1,30 +1,50 @@
 "use client";
 
 /**
- * `BillingDialog` — skapa en BillingRun. Tre kombinerade flöden:
- *   ACCONTO          — clientShareBips + beräknat belopp, advokat kan justera
- *   FINAL            — recipient-val + lista av aconton att dra av
- *   KOSTNADSRAKNING  — bara notes + bekräftelse (väntar på dom efteråt)
+ * `BillingDialog` — skapa en BillingRun. Två kombinerade flöden:
+ *   ACCONTO — avdragsmedvetet förslag (#397): belopp = klientens %-sats ×
+ *             upparbetat värde − tidigare aconton. Advokat kan justera.
+ *   FINAL   — recipient-val + lista av aconton att dra av, och en förhands-
+ *             lista över de ofakturerade poster som kommer med i fakturan.
+ *
+ * Båda flödena skapar ett DRAFT-utkast OCH ett faktura-PDF-dokument i ärendets
+ * dokumentlista (via `generateFakturaDoc`), redo för utskick.
  */
 import { useState } from "react";
 import { Modal } from "@/components/ui/modal";
+import {
+  generateFakturaDoc,
+  type DocUtils,
+  type FakturaDocInvoice,
+  type FakturaDocMeta,
+} from "@/lib/client/kostnadsrakning/generate-faktura-doc";
 import { trpc } from "@/lib/client/trpc";
 import { formatCurrency } from "@/lib/client/utils";
+import { proposedAccontoOre } from "@/lib/shared/billing-proposal";
 
 interface AccontoRow { id: string; amountOre: number; recipient: string }
+
+export interface BillingMeta {
+  matterNumber: string;
+  matterTitle: string;
+  clientName?: string;
+  organizationName?: string;
+  organizationOrgNumber?: string;
+}
 
 interface Props {
   matterId: string;
   type: "ACCONTO" | "FINAL";
   existingAccontos: AccontoRow[];
+  meta: BillingMeta;
   onClose: () => void;
 }
 
-export function BillingDialog({ matterId, type, existingAccontos, onClose }: Props) {
+export function BillingDialog({ matterId, type, existingAccontos, meta, onClose }: Props) {
   return (
     <Modal open title={titleFor(type)} onClose={onClose} widthClass="max-w-xl">
-      {type === "ACCONTO" && <AccontoForm matterId={matterId} onDone={onClose} />}
-      {type === "FINAL" && <FinalForm matterId={matterId} accontos={existingAccontos} onDone={onClose} />}
+      {type === "ACCONTO" && <AccontoForm matterId={matterId} meta={meta} onDone={onClose} />}
+      {type === "FINAL" && <FinalForm matterId={matterId} meta={meta} accontos={existingAccontos} onDone={onClose} />}
     </Modal>
   );
 }
@@ -34,25 +54,51 @@ function titleFor(type: string): string {
   return "Faktura";
 }
 
-function AccontoForm({ matterId, onDone }: { matterId: string; onDone: () => void }) {
+/** Återanvändbar doc-generator: lägg ett faktura-PDF-dokument i fil-listan. */
+function useFakturaDoc(matterId: string, meta: BillingMeta): (invoice: FakturaDocInvoice) => Promise<void> {
+  const register = trpc.document.register.useMutation();
+  const utils = trpc.useUtils();
+  const docMeta: FakturaDocMeta = {
+    matterNumber: meta.matterNumber, matterTitle: meta.matterTitle,
+    ...(meta.clientName ? { clientName: meta.clientName } : {}),
+    ...(meta.organizationName ? { organizationName: meta.organizationName } : {}),
+    ...(meta.organizationOrgNumber ? { organizationOrgNumber: meta.organizationOrgNumber } : {}),
+  };
+  return async (invoice: FakturaDocInvoice) => {
+    try {
+      await generateFakturaDoc({ invoice, matterId, meta: docMeta, register, utils: utils as unknown as DocUtils });
+    } catch (e) { console.warn("[billing] faktura-dokument misslyckades:", e); }
+  };
+}
+
+function AccontoForm({ matterId, meta, onDone }: { matterId: string; meta: BillingMeta; onDone: () => void }) {
+  const proposal = trpc.billingRun.proposal.useQuery({ matterId });
+  const workValueOre = proposal.data?.workValueOre ?? 0;
+  const priorOre = proposal.data?.priorAccontoSumOre ?? 0;
   const [clientShareBips, setBips] = useState(2000); // 20% default
-  const [amountKr, setAmountKr] = useState(2000);
-  const mut = trpc.billingRun.createAcconto.useMutation({ onSuccess: onDone });
+  const [amountKr, setAmountKr] = useState<number | null>(null); // null → följ förslaget
+  const makeDoc = useFakturaDoc(matterId, meta);
+  const suggestedOre = proposedAccontoOre(workValueOre, clientShareBips, priorOre);
+  const effectiveKr = amountKr ?? suggestedOre / 100;
+  const mut = trpc.billingRun.createAcconto.useMutation({
+    onSuccess: async (res) => { await makeDoc(res.invoice); onDone(); },
+  });
   return (
     <form onSubmit={(e) => { e.preventDefault(); mut.mutate({
-      matterId, clientShareBips, amountOre: Math.round(amountKr * 100), recipient: "KLIENT",
+      matterId, clientShareBips, amountOre: Math.round(effectiveKr * 100), recipient: "KLIENT",
     }); }} className="space-y-3">
       <p className="text-sm text-gray-600">
-        Acconto baseras på klientens självrisk-/avgifts-procentsats × upparbetat värde.
-        Justera beloppet vid behov (t.ex. för att runda av).
+        Acconto baseras på klientens självrisk-/avgifts-procentsats × upparbetat värde,
+        minus tidigare aconton. Justera beloppet vid behov (t.ex. för att runda av).
       </p>
+      <ProposalSummary workValueOre={workValueOre} priorOre={priorOre} suggestedOre={suggestedOre} />
       <Field label="Klientens andel (procent)">
         <input type="number" min={0} max={100} step={1} value={clientShareBips / 100}
           onChange={(e) => setBips(Math.round((parseFloat(e.target.value) || 0) * 100))}
           className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm" />
       </Field>
       <Field label="Belopp (kr)">
-        <input type="number" min={0} step={1} value={amountKr}
+        <input type="number" min={0} step={1} value={effectiveKr}
           onChange={(e) => setAmountKr(parseFloat(e.target.value) || 0)}
           className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm" />
       </Field>
@@ -62,18 +108,42 @@ function AccontoForm({ matterId, onDone }: { matterId: string; onDone: () => voi
   );
 }
 
-function FinalForm({ matterId, accontos, onDone }: { matterId: string; accontos: AccontoRow[]; onDone: () => void }) {
+function ProposalSummary({ workValueOre, priorOre, suggestedOre }: { workValueOre: number; priorOre: number; suggestedOre: number }) {
+  return (
+    <div className="grid grid-cols-3 gap-2 rounded border border-gray-200 bg-gray-50 px-3 py-2 text-center">
+      <Stat label="Upparbetat" value={workValueOre} />
+      <Stat label="Tidigare aconton" value={priorOre} />
+      <Stat label="Förslag" value={suggestedOre} strong />
+    </div>
+  );
+}
+
+function Stat({ label, value, strong }: { label: string; value: number; strong?: boolean }) {
+  return (
+    <div>
+      <div className="text-[10px] uppercase text-gray-500">{label}</div>
+      <div className={`font-mono text-sm ${strong ? "font-semibold text-gray-900" : "text-gray-700"}`}>{formatCurrency(value)}</div>
+    </div>
+  );
+}
+
+function FinalForm({ matterId, meta, accontos, onDone }: { matterId: string; meta: BillingMeta; accontos: AccontoRow[]; onDone: () => void }) {
+  const proposal = trpc.billingRun.proposal.useQuery({ matterId });
   const [recipient, setRecipient] = useState<"KLIENT" | "FORSAKRING" | "RATTSHJALPSMYNDIGHET">("KLIENT");
   const [selected, setSelected] = useState<string[]>(accontos.map((a) => a.id));
-  const mut = trpc.billingRun.createFinal.useMutation({ onSuccess: onDone });
+  const makeDoc = useFakturaDoc(matterId, meta);
+  const mut = trpc.billingRun.createFinal.useMutation({
+    onSuccess: async (res) => { await makeDoc(res.invoice); onDone(); },
+  });
   return (
     <form onSubmit={(e) => { e.preventDefault(); mut.mutate({
       matterId, recipient, deductedBillingRunIds: selected,
     }); }} className="space-y-3">
       <p className="text-sm text-gray-600">
         Faktura med full specifikation av tid och utlägg. Alla obetalda
-        tids- och utläggsrader fryses.
+        tids- och utläggsrader fryses och tas med nedan.
       </p>
+      <UnbilledPosts proposal={proposal.data} loading={proposal.isLoading} />
       <Field label="Mottagare">
         <select value={recipient} onChange={(e) => setRecipient(e.target.value as typeof recipient)}
           className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm">
@@ -100,6 +170,47 @@ function FinalForm({ matterId, accontos, onDone }: { matterId: string; accontos:
       <SubmitRow onDone={onDone} pending={mut.isPending} label="Skapa faktura" />
     </form>
   );
+}
+
+interface ProposalData {
+  workValueOre: number;
+  timeEntries: Array<{ id: string; description: string; valueOre: number; billable: boolean }>;
+  expenses: Array<{ id: string; description: string; amount: number; billable: boolean }>;
+}
+
+function UnbilledPosts({ proposal, loading }: { proposal: ProposalData | undefined; loading: boolean }) {
+  if (loading) return <p className="text-xs text-gray-500">Laddar ofakturerade poster…</p>;
+  const posts = unbilledRows(proposal);
+  if (posts.length === 0) return <p className="text-xs text-gray-500">Inga ofakturerade poster i ärendet.</p>;
+  return (
+    <Field label={`Ofakturerade poster (${posts.length}) — föreslås i fakturan`}>
+      <div className="space-y-1 max-h-40 overflow-y-auto rounded border border-gray-200 bg-gray-50 px-2 py-1.5">
+        {posts.map((p) => (
+          <div key={p.id} className="flex items-center justify-between text-xs">
+            <span className="truncate text-gray-700">{p.label}</span>
+            <span className="font-mono text-gray-900">{formatCurrency(p.valueOre)}</span>
+          </div>
+        ))}
+        <div className="flex items-center justify-between border-t border-gray-300 pt-1 text-xs font-semibold">
+          <span>Upparbetat värde</span>
+          <span className="font-mono">{formatCurrency(proposal?.workValueOre ?? 0)}</span>
+        </div>
+      </div>
+    </Field>
+  );
+}
+
+interface PostRow { id: string; label: string; valueOre: number }
+
+function unbilledRows(proposal: ProposalData | undefined): PostRow[] {
+  if (!proposal) return [];
+  const time = proposal.timeEntries
+    .filter((t) => t.billable)
+    .map((t) => ({ id: `te-${t.id}`, label: t.description || "Tidspost", valueOre: t.valueOre }));
+  const exp = proposal.expenses
+    .filter((e) => e.billable)
+    .map((e) => ({ id: `ex-${e.id}`, label: e.description || "Utlägg", valueOre: e.amount }));
+  return [...time, ...exp];
 }
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {

--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -22,7 +22,7 @@ import type { AppRouter } from "@/lib/server/routers/_app";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { computeRadgivningsavgift } from "@/lib/shared/rattshjalp";
 import { BILLING_RUN_TYPE_LABELS, BILLING_RUN_STATUS_LABELS } from "@/lib/shared/schemas/enums";
-import { BillingDialog } from "./_billing-dialog";
+import { BillingDialog, type BillingMeta } from "./_billing-dialog";
 import { KostnadsrakningModal } from "./_kostnadsrakning-modal";
 import { VerdictDialog } from "./_verdict-dialog";
 
@@ -141,12 +141,21 @@ interface DialogsProps {
   onRefetch: () => void;
 }
 
+function useBillingMeta(matter: MatterContext): BillingMeta {
+  const org = orgProps(trpc.organization.getSettings.useQuery().data ?? undefined);
+  return {
+    matterNumber: matter.matterNumber, matterTitle: matter.title,
+    ...omitUndefined({ clientName: clientOf(matter) || undefined, organizationName: org.name, organizationOrgNumber: org.orgNumber }),
+  };
+}
+
 function BillingDialogs({ matterId, matter, rows, dialog, setDialog, verdictRunId, setVerdictRunId, onRefetch }: DialogsProps) {
   const pending = findPendingVerdict(rows);
+  const meta = useBillingMeta(matter);
   return (
     <>
       {dialog !== "NONE" && (
-        <BillingDialog matterId={matterId} type={dialog}
+        <BillingDialog matterId={matterId} type={dialog} meta={meta}
           existingAccontos={rows.filter((r) => r.type === "ACCONTO" && r.status === "SENT")}
           onClose={() => { setDialog("NONE"); onRefetch(); }} />
       )}

--- a/src/app/matters/[id]/_verdict-dialog.tsx
+++ b/src/app/matters/[id]/_verdict-dialog.tsx
@@ -11,15 +11,12 @@
  * Domen anger det FAKTISKA beloppet, inte hur mycket som prutats — så
  * det är vad advokaten skriver in.
  */
-import type { inferRouterInputs } from "@trpc/server";
 import { useState } from "react";
 import { Modal } from "@/components/ui/modal";
+import { generateFakturaDoc, type DocUtils } from "@/lib/client/kostnadsrakning/generate-faktura-doc";
 import { trpc } from "@/lib/client/trpc";
 import { formatCurrency } from "@/lib/client/utils";
-import type { AppRouter } from "@/lib/server/routers/_app";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
-
-type RouterInputs = inferRouterInputs<AppRouter>;
 
 interface Props {
   billingRunId: string;
@@ -33,54 +30,6 @@ interface Props {
   onClose: () => void;
 }
 
-type RegisterMut = { mutateAsync: (i: RouterInputs["document"]["register"]) => Promise<unknown> };
-type TreeFilter = RouterInputs["document"]["tree"];
-type ListFilter = RouterInputs["document"]["list"];
-type DocUtils = {
-  document: {
-    tree: { invalidate: (f?: TreeFilter) => Promise<unknown>; refetch: (f?: TreeFilter) => Promise<unknown> };
-    list: { invalidate: (f?: ListFilter) => Promise<unknown> };
-  };
-};
-
-/**
- * Generera ett faktura-DOKUMENT (PDF) ur den nyss skapade invoice-entiteten och
- * lägg det i ärendets fil-lista (parallellt med Invoice-objektet). document.register
- * emittar inga events (ingen read-only-trap), så detta funkar i demo/git-backend.
- */
-async function generateFakturaDoc(
-  invoice: { id: string; amount: number; invoiceNumber?: string | null; invoiceDate?: string | Date | null },
-  props: Props, register: RegisterMut, utils: DocUtils,
-): Promise<void> {
-  const { renderFakturaPdf } = await import("@/lib/client/kostnadsrakning/render-faktura-pdf");
-  const { persistGeneratedDoc } = await import("@/lib/client/demo/persist-generated-doc");
-  const bytes = await renderFakturaPdf({
-    invoice,
-    meta: {
-      matterNumber: props.matterNumber, matterTitle: props.matterTitle,
-      ...omitUndefined({
-        clientName: props.clientName,
-        organizationName: props.organizationName,
-        organizationOrgNumber: props.organizationOrgNumber,
-      }),
-    },
-  });
-  const docId = `faktura-${invoice.id}`;
-  const fileName = `Faktura ${props.matterNumber} ${new Date().toISOString().slice(0, 10)}.pdf`;
-  const storagePath = `documents/content/${docId}.pdf`;
-  await register.mutateAsync({
-    id: docId, matterId: props.matterId, fileName, mimeType: "application/pdf",
-    sizeBytes: bytes.byteLength, storagePath, documentType: "Faktura",
-    invoiceId: invoice.id, analysisStatus: "DONE",
-  });
-  await persistGeneratedDoc({ id: docId, storagePath, fileName, mimeType: "application/pdf", bytes });
-  try {
-    await utils.document.tree.invalidate({ matterId: props.matterId });
-    await utils.document.tree.refetch({ matterId: props.matterId });
-    await utils.document.list.invalidate();
-  } catch { /* best-effort */ }
-}
-
 export function VerdictDialog(props: Props) {
   const { billingRunId, workValueOre, onClose } = props;
   const [awardedKr, setAwardedKr] = useState(workValueOre / 100);
@@ -89,8 +38,21 @@ export function VerdictDialog(props: Props) {
   const mut = trpc.billingRun.setVerdict.useMutation({
     onSuccess: async (res) => {
       // Lägg ett faktura-dokument i fil-listan ur den skapade fakturan.
-      try { await generateFakturaDoc((res as { invoice: Parameters<typeof generateFakturaDoc>[0] }).invoice, props, register, utils as unknown as DocUtils); }
-      catch (e) { console.warn("[verdict] faktura-dokument misslyckades:", e); }
+      try {
+        await generateFakturaDoc({
+          invoice: (res as { invoice: Parameters<typeof generateFakturaDoc>[0]["invoice"] }).invoice,
+          matterId: props.matterId,
+          meta: {
+            matterNumber: props.matterNumber, matterTitle: props.matterTitle,
+            ...omitUndefined({
+              clientName: props.clientName,
+              organizationName: props.organizationName,
+              organizationOrgNumber: props.organizationOrgNumber,
+            }),
+          },
+          register, utils: utils as unknown as DocUtils,
+        });
+      } catch (e) { console.warn("[verdict] faktura-dokument misslyckades:", e); }
       onClose();
     },
   });

--- a/src/lib/client/kostnadsrakning/generate-faktura-doc.ts
+++ b/src/lib/client/kostnadsrakning/generate-faktura-doc.ts
@@ -1,0 +1,85 @@
+"use client";
+
+/**
+ * `generateFakturaDoc` (#397) — generera ett faktura-DOKUMENT (PDF) ur en nyss
+ * skapad Invoice-entitet och lägg det i ärendets fil-lista, parallellt med
+ * Invoice-objektet. `document.register` emittar inga events (ingen read-only-
+ * trap), så detta funkar i både demo- och git-backend.
+ *
+ * Bröts ut ur `_verdict-dialog.tsx` så aconto-/slutfaktura-flödet i
+ * `_billing-dialog.tsx` kan dela exakt samma kod (DRY).
+ */
+
+import type { inferRouterInputs } from "@trpc/server";
+import type { AppRouter } from "@/lib/server/routers/_app";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
+
+type RouterInputs = inferRouterInputs<AppRouter>;
+type RegisterInput = RouterInputs["document"]["register"];
+type TreeFilter = RouterInputs["document"]["tree"];
+type ListFilter = RouterInputs["document"]["list"];
+
+export type RegisterMut = { mutateAsync: (i: RegisterInput) => Promise<unknown> };
+export type DocUtils = {
+  document: {
+    tree: { invalidate: (f?: TreeFilter) => Promise<unknown>; refetch: (f?: TreeFilter) => Promise<unknown> };
+    list: { invalidate: (f?: ListFilter) => Promise<unknown> };
+  };
+};
+
+export interface FakturaDocMeta {
+  matterNumber: string;
+  matterTitle: string;
+  clientName?: string;
+  recipient?: string;
+  organizationName?: string;
+  organizationOrgNumber?: string;
+}
+
+export interface FakturaDocInvoice {
+  id: string;
+  amount: number;
+  invoiceNumber?: string | null | undefined;
+  ocrReference?: string | null | undefined;
+  invoiceDate?: string | Date | null | undefined;
+}
+
+export interface GenerateFakturaDocArgs {
+  invoice: FakturaDocInvoice;
+  matterId: string;
+  meta: FakturaDocMeta;
+  register: RegisterMut;
+  utils: DocUtils;
+}
+
+export async function generateFakturaDoc(args: GenerateFakturaDocArgs): Promise<void> {
+  const { invoice, matterId, meta, register, utils } = args;
+  const { renderFakturaPdf } = await import("@/lib/client/kostnadsrakning/render-faktura-pdf");
+  const { persistGeneratedDoc } = await import("@/lib/client/demo/persist-generated-doc");
+  const bytes = await renderFakturaPdf({
+    invoice,
+    meta: {
+      matterNumber: meta.matterNumber, matterTitle: meta.matterTitle,
+      ...omitUndefined({
+        clientName: meta.clientName,
+        recipient: meta.recipient,
+        organizationName: meta.organizationName,
+        organizationOrgNumber: meta.organizationOrgNumber,
+      }),
+    },
+  });
+  const docId = `faktura-${invoice.id}`;
+  const fileName = `Faktura ${meta.matterNumber} ${new Date().toISOString().slice(0, 10)}.pdf`;
+  const storagePath = `documents/content/${docId}.pdf`;
+  await register.mutateAsync({
+    id: docId, matterId, fileName, mimeType: "application/pdf",
+    sizeBytes: bytes.byteLength, storagePath, documentType: "Faktura",
+    invoiceId: invoice.id, analysisStatus: "DONE",
+  });
+  await persistGeneratedDoc({ id: docId, storagePath, fileName, mimeType: "application/pdf", bytes });
+  try {
+    await utils.document.tree.invalidate({ matterId });
+    await utils.document.tree.refetch({ matterId });
+    await utils.document.list.invalidate();
+  } catch { /* best-effort */ }
+}

--- a/src/lib/client/kostnadsrakning/render-faktura-pdf.ts
+++ b/src/lib/client/kostnadsrakning/render-faktura-pdf.ts
@@ -13,10 +13,10 @@ import { formatCurrency } from "@/lib/client/utils";
 export interface FakturaInput {
   invoice: {
     amount: number; // öre
-    invoiceNumber?: string | null;
+    invoiceNumber?: string | null | undefined;
     /** Bankgiro-OCR (#182). Null på kostnadsräkningar/CREDIT → raden utelämnas. */
-    ocrReference?: string | null;
-    invoiceDate?: string | Date | null;
+    ocrReference?: string | null | undefined;
+    invoiceDate?: string | Date | null | undefined;
   };
   meta: {
     matterNumber: string;

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -16,6 +16,7 @@
  */
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import { proposedAccontoOre } from "@/lib/shared/billing-proposal";
 import { billingRunRecipientSchema, type ExpenseKind } from "@/lib/shared/schemas/enums";
 import {
   matterIdSchema,
@@ -32,6 +33,36 @@ interface UnfrozenWork {
   expenses: Array<{ id: string; amount: number; billable: boolean }>;
 }
 
+/** En itemiserad rad i fakturaförslaget (#397) — tidspost med beräknat värde. */
+interface ProposalTimeEntry {
+  id: string;
+  description: string;
+  minutes: number;
+  hourlyRate: number;
+  billable: boolean;
+  valueOre: number;
+}
+
+interface ProposalExpense {
+  id: string;
+  description: string;
+  amount: number;
+  billable: boolean;
+}
+
+/** Avdragsmedvetet fakturaförslag (#397): ofakturerade poster + nyckeltal. */
+interface BillingProposal {
+  workValueOre: number;
+  priorAccontoSumOre: number;
+  timeEntries: ProposalTimeEntry[];
+  expenses: ProposalExpense[];
+}
+
+/** Värdet på en (debiterbar) tidspost i öre — speglar workValueOre:s ton. */
+function timeEntryValueOre(minutes: number, hourlyRate: number): number {
+  return Math.round((minutes / 60) * hourlyRate);
+}
+
 async function fetchUnfrozenWork(tx: DataStoreTx, matterId: string): Promise<UnfrozenWork> {
   const te = await tx.timeEntries.findMany({
     where: { matterId, frozenByBillingRunId: null },
@@ -45,11 +76,40 @@ async function fetchUnfrozenWork(tx: DataStoreTx, matterId: string): Promise<Unf
 function workValueOre(work: UnfrozenWork): number {
   const time = work.timeEntries
     .filter((t) => t.billable)
-    .reduce((sum, t) => sum + Math.round((t.minutes / 60) * t.hourlyRate), 0);
+    .reduce((sum, t) => sum + timeEntryValueOre(t.minutes, t.hourlyRate), 0);
   const exp = work.expenses
     .filter((e) => e.billable)
     .reduce((sum, e) => sum + e.amount, 0);
   return time + exp;
+}
+
+/** Bygg ett itemiserat fakturaförslag ur ofrysta tids-/utläggsrader (#397). */
+function buildProposal(
+  te: ReadonlyArray<{ id: string; description?: string | null; minutes: number; hourlyRate: number; billable: boolean }>,
+  ex: ReadonlyArray<{ id: string; description?: string | null; amount: number; billable: boolean; kind?: ExpenseKind }>,
+  priorAccontoSumOre: number,
+): BillingProposal {
+  const timeEntries: ProposalTimeEntry[] = te.map((t) => ({
+    id: t.id, description: t.description ?? "", minutes: t.minutes, hourlyRate: t.hourlyRate,
+    billable: t.billable, valueOre: timeEntryValueOre(t.minutes, t.hourlyRate),
+  }));
+  const expenses: ProposalExpense[] = ex
+    .filter((e) => e.kind !== "PRUTNING")
+    .map((e) => ({ id: e.id, description: e.description ?? "", amount: e.amount, billable: e.billable }));
+  const workValueOre = timeEntries.filter((t) => t.billable).reduce((s, t) => s + t.valueOre, 0)
+    + expenses.filter((e) => e.billable).reduce((s, e) => s + e.amount, 0);
+  return { workValueOre, priorAccontoSumOre, timeEntries, expenses };
+}
+
+/** Summan av tidigare utställda ACCONTO-fakturors belopp för ett ärende (#397). */
+async function sumPriorAccontos(
+  billingRuns: { findMany: (args: unknown) => Promise<unknown> },
+  matterId: string,
+): Promise<number> {
+  const runs = (await billingRuns.findMany({
+    where: { matterId, type: "ACCONTO", status: "SENT" },
+  })) as ReadonlyArray<{ amountOre?: number }>;
+  return runs.reduce((sum, r) => sum + (r.amountOre ?? 0), 0);
 }
 
 async function freezeWork(tx: DataStoreTx, matterId: string, billingRunId: BillingRunId): Promise<void> {
@@ -95,6 +155,31 @@ export const billingRunRouter = router({
       });
     }),
 
+  /**
+   * Avdragsmedvetet fakturaförslag (#397): vilka tids-/utläggsposter är
+   * ofakturerade (ej frysta) i ärendet, deras sammanlagda upparbetade värde,
+   * och summan av tidigare aconto-fakturor. Klienten beräknar aconto-beloppet
+   * = %-sats × workValueOre − priorAccontoSumOre och visar förslaget. Org-scopat.
+   */
+  proposal: orgProcedure
+    .input(z.object({ matterId: matterIdSchema }))
+    .query(async ({ ctx, input }) => {
+      const matter = await ctx.dataStore.matters.findFirst({
+        where: { id: input.matterId, organizationId: ctx.orgId },
+      });
+      if (!matter) throw new TRPCError({ code: "NOT_FOUND", message: "Ärendet finns inte." });
+      const te = (await ctx.dataStore.timeEntries.findMany({
+        where: { matterId: input.matterId, frozenByBillingRunId: null },
+        orderBy: { date: "asc" },
+      })) as Array<{ id: string; description?: string | null; minutes: number; hourlyRate: number; billable: boolean }>;
+      const ex = (await ctx.dataStore.expenses.findMany({
+        where: { matterId: input.matterId, frozenByBillingRunId: null },
+        orderBy: { date: "asc" },
+      })) as Array<{ id: string; description?: string | null; amount: number; billable: boolean; kind?: ExpenseKind }>;
+      const priorAccontoSumOre = await sumPriorAccontos(ctx.dataStore.billingRuns, input.matterId);
+      return buildProposal(te, ex, priorAccontoSumOre);
+    }),
+
   createAcconto: orgProcedure
     .input(z.object({
       matterId: matterIdSchema,
@@ -108,7 +193,10 @@ export const billingRunRouter = router({
         await assertMatterInOrg(tx, input.matterId, ctx.orgId);
         const work = await fetchUnfrozenWork(tx, input.matterId);
         const value = workValueOre(work);
-        const proposedOre = Math.round((value * input.clientShareBips) / 10000);
+        // #397: dra av tidigare aconton i det FÖRESLAGNA beloppet —
+        // belopp = %-sats × upparbetat − Σ tidigare aconto-fakturor.
+        const priorAccontoSumOre = await sumPriorAccontos(tx.billingRuns, input.matterId);
+        const proposedOre = proposedAccontoOre(value, input.clientShareBips, priorAccontoSumOre);
         const invoice = await tx.invoices.create({
           data: {
             matterId: input.matterId, amount: input.amountOre,

--- a/src/lib/shared/billing-proposal.ts
+++ b/src/lib/shared/billing-proposal.ts
@@ -1,0 +1,18 @@
+/**
+ * Avdragsmedvetet fakturaförslag (#397) — ren formel-modul delad mellan
+ * server-routern (`billingRun.proposal`/`createAcconto`) och klient-dialogen
+ * (`_billing-dialog`) så samma uträkning aldrig divergerar.
+ */
+
+/**
+ * Föreslaget aconto-belopp i öre:
+ *   belopp = %-sats (bips) × upparbetat värde − Σ tidigare aconton.
+ * Klampas till ≥ 0 (ett aconto kan aldrig bli negativt).
+ */
+export function proposedAccontoOre(
+  workValueOre: number,
+  clientShareBips: number,
+  priorAccontoSumOre: number,
+): number {
+  return Math.max(0, Math.round((workValueOre * clientShareBips) / 10000) - priorAccontoSumOre);
+}

--- a/test/unit/app/matters/[id]/page.test.tsx
+++ b/test/unit/app/matters/[id]/page.test.tsx
@@ -84,6 +84,7 @@ vi.mock("@/lib/client/trpc", () => ({
     },
     billingRun: {
       list: { useQuery: () => ({ data: { runs: [] }, isLoading: false, refetch: vi.fn() }) },
+      proposal: { useQuery: () => ({ data: undefined, isLoading: false }) },
       createAcconto: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
       createFinal: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
       createKostnadsrakning: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },

--- a/test/unit/app/matters/billing-dialog.test.tsx
+++ b/test/unit/app/matters/billing-dialog.test.tsx
@@ -1,43 +1,113 @@
 /**
- * Tester för BillingDialog (#27 coverage) — ACCONTO- + FINAL-flödena:
- * procent↔bips-konvertering, belopp→öre, mottagar-val, acconto-avdrag och
- * submit-payloads till billingRun-mutationerna.
+ * Tester för BillingDialog (#27/#397) — ACCONTO- + FINAL-flödena:
+ * avdragsmedvetet aconto-förslag (%-sats × upparbetat − tidigare aconton),
+ * ofakturerade-poster-listan i FINAL, procent↔bips, mottagar-val, acconto-
+ * avdrag och faktura-dokument-generering på onSuccess.
  */
 
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
 import { BillingDialog } from "@/app/matters/[id]/_billing-dialog";
 
 const accontoMutate = vi.fn();
 const finalMutate = vi.fn();
+let accontoOnSuccess: ((res: unknown) => Promise<void>) | undefined;
+let finalOnSuccess: ((res: unknown) => Promise<void>) | undefined;
+const registerMutateAsync = vi.fn(async () => {});
+const renderFakturaPdf = vi.fn(async () => new Uint8Array([1, 2, 3]));
+const persistGeneratedDoc = vi.fn(async () => {});
+
+let proposalData: unknown = {
+  workValueOre: 500_000, // 5000 kr upparbetat
+  priorAccontoSumOre: 0,
+  timeEntries: [{ id: "te-1", description: "Möte med klient", minutes: 120, hourlyRate: 250_000, billable: true, valueOre: 500_000 }],
+  expenses: [{ id: "ex-1", description: "Ansökningsavgift", amount: 90_000, billable: true }],
+};
+let proposalLoading = false;
 
 vi.mock("@/lib/client/trpc", () => ({
   trpc: {
+    useUtils: () => ({ document: { tree: { invalidate: vi.fn(), refetch: vi.fn() }, list: { invalidate: vi.fn() } } }),
+    document: { register: { useMutation: () => ({ mutateAsync: registerMutateAsync }) } },
     billingRun: {
-      createAcconto: { useMutation: () => ({ mutate: accontoMutate, isPending: false, error: null }) },
-      createFinal: { useMutation: () => ({ mutate: finalMutate, isPending: false, error: null }) },
+      proposal: { useQuery: () => ({ data: proposalData, isLoading: proposalLoading }) },
+      createAcconto: {
+        useMutation: (opts: { onSuccess: (res: unknown) => Promise<void> }) => {
+          accontoOnSuccess = opts.onSuccess;
+          return { mutate: accontoMutate, isPending: false, error: null };
+        },
+      },
+      createFinal: {
+        useMutation: (opts: { onSuccess: (res: unknown) => Promise<void> }) => {
+          finalOnSuccess = opts.onSuccess;
+          return { mutate: finalMutate, isPending: false, error: null };
+        },
+      },
     },
   },
 }));
+vi.mock("@/lib/client/kostnadsrakning/render-faktura-pdf", () => ({ renderFakturaPdf }));
+vi.mock("@/lib/client/demo/persist-generated-doc", () => ({ persistGeneratedDoc }));
 
-beforeEach(() => { vi.clearAllMocks(); });
+const meta = { matterNumber: "2026-0001", matterTitle: "Tvist", clientName: "Anna Andersson" };
 
-describe("BillingDialog — ACCONTO", () => {
-  it("submit skickar bips + öre + KLIENT (default 20 % / 2000 kr)", () => {
-    render(<BillingDialog matterId="m1" type="ACCONTO" existingAccontos={[]} onClose={() => {}} />);
+beforeEach(() => {
+  vi.clearAllMocks();
+  accontoOnSuccess = undefined; finalOnSuccess = undefined;
+  proposalLoading = false;
+  proposalData = {
+    workValueOre: 500_000, priorAccontoSumOre: 0,
+    timeEntries: [{ id: "te-1", description: "Möte med klient", minutes: 120, hourlyRate: 250_000, billable: true, valueOre: 500_000 }],
+    expenses: [{ id: "ex-1", description: "Ansökningsavgift", amount: 90_000, billable: true }],
+  };
+});
+
+describe("BillingDialog — ACCONTO (#397 avdragsmedvetet förslag)", () => {
+  it("förfyller beloppet enligt formeln: 20 % × 5000 kr − 0 = 1000 kr", () => {
+    render(<BillingDialog matterId="m1" type="ACCONTO" existingAccontos={[]} meta={meta} onClose={() => {}} />);
     expect(screen.getByText("Aconto till klient")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Skapa aconto-faktura" }));
     expect(accontoMutate).toHaveBeenCalledWith({
-      matterId: "m1", clientShareBips: 2000, amountOre: 200_000, recipient: "KLIENT",
+      matterId: "m1", clientShareBips: 2000, amountOre: 100_000, recipient: "KLIENT",
     });
   });
 
-  it("procent → bips: 30 % → 3000 bips", () => {
-    render(<BillingDialog matterId="m1" type="ACCONTO" existingAccontos={[]} onClose={() => {}} />);
+  it("drar av tidigare aconton i förslaget: 20 % × 5000 − 600 = 400 kr", () => {
+    proposalData = {
+      workValueOre: 500_000, priorAccontoSumOre: 60_000, // 600 kr tidigare
+      timeEntries: [], expenses: [],
+    };
+    render(<BillingDialog matterId="m1" type="ACCONTO" existingAccontos={[]} meta={meta} onClose={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: "Skapa aconto-faktura" }));
+    expect(accontoMutate).toHaveBeenCalledWith(expect.objectContaining({ amountOre: 40_000 }));
+  });
+
+  it("procent → bips + omräknat förslag: 30 % → 3000 bips, 1500 kr", () => {
+    render(<BillingDialog matterId="m1" type="ACCONTO" existingAccontos={[]} meta={meta} onClose={() => {}} />);
     const [percent] = screen.getAllByRole("spinbutton");
     fireEvent.change(percent!, { target: { value: "30" } });
     fireEvent.click(screen.getByRole("button", { name: "Skapa aconto-faktura" }));
-    expect(accontoMutate).toHaveBeenCalledWith(expect.objectContaining({ clientShareBips: 3000 }));
+    expect(accontoMutate).toHaveBeenCalledWith(expect.objectContaining({ clientShareBips: 3000, amountOre: 150_000 }));
+  });
+
+  it("manuell justering av beloppet vinner över förslaget", () => {
+    render(<BillingDialog matterId="m1" type="ACCONTO" existingAccontos={[]} meta={meta} onClose={() => {}} />);
+    const spin = screen.getAllByRole("spinbutton");
+    fireEvent.change(spin[1]!, { target: { value: "750" } }); // belopp-fältet
+    fireEvent.click(screen.getByRole("button", { name: "Skapa aconto-faktura" }));
+    expect(accontoMutate).toHaveBeenCalledWith(expect.objectContaining({ amountOre: 75_000 }));
+  });
+
+  it("onSuccess genererar ett faktura-dokument", async () => {
+    const onClose = vi.fn();
+    render(<BillingDialog matterId="m1" type="ACCONTO" existingAccontos={[]} meta={meta} onClose={onClose} />);
+    await accontoOnSuccess!({ invoice: { id: "inv-1", amount: 100_000 } });
+    expect(renderFakturaPdf).toHaveBeenCalled();
+    expect(registerMutateAsync).toHaveBeenCalledWith(expect.objectContaining({
+      id: "faktura-inv-1", matterId: "m1", invoiceId: "inv-1", documentType: "Faktura",
+    }));
+    expect(persistGeneratedDoc).toHaveBeenCalled();
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 });
 
@@ -47,8 +117,22 @@ describe("BillingDialog — FINAL", () => {
     { id: "br-2", amountOre: 50_000, recipient: "KLIENT" },
   ];
 
+  it("visar de ofakturerade posterna + upparbetat värde", () => {
+    render(<BillingDialog matterId="m1" type="FINAL" existingAccontos={[]} meta={meta} onClose={() => {}} />);
+    expect(screen.getByText(/Ofakturerade poster \(2\)/)).toBeInTheDocument();
+    expect(screen.getByText("Möte med klient")).toBeInTheDocument();
+    expect(screen.getByText("Ansökningsavgift")).toBeInTheDocument();
+    expect(screen.getByText("Upparbetat värde")).toBeInTheDocument();
+  });
+
+  it("visar tomtext när inga ofakturerade poster finns", () => {
+    proposalData = { workValueOre: 0, priorAccontoSumOre: 0, timeEntries: [], expenses: [] };
+    render(<BillingDialog matterId="m1" type="FINAL" existingAccontos={[]} meta={meta} onClose={() => {}} />);
+    expect(screen.getByText(/Inga ofakturerade poster/)).toBeInTheDocument();
+  });
+
   it("default: alla aconton förvalda, submit drar av dem alla", () => {
-    render(<BillingDialog matterId="m1" type="FINAL" existingAccontos={accontos} onClose={() => {}} />);
+    render(<BillingDialog matterId="m1" type="FINAL" existingAccontos={accontos} meta={meta} onClose={() => {}} />);
     expect(screen.getByText("Faktura")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Skapa faktura" }));
     expect(finalMutate).toHaveBeenCalledWith({
@@ -57,7 +141,7 @@ describe("BillingDialog — FINAL", () => {
   });
 
   it("avmarkera ett aconto → utesluts ur avdragen", () => {
-    render(<BillingDialog matterId="m1" type="FINAL" existingAccontos={accontos} onClose={() => {}} />);
+    render(<BillingDialog matterId="m1" type="FINAL" existingAccontos={accontos} meta={meta} onClose={() => {}} />);
     const boxes = screen.getAllByRole("checkbox");
     fireEvent.click(boxes[0]!); // avmarkera br-1
     fireEvent.click(screen.getByRole("button", { name: "Skapa faktura" }));
@@ -65,9 +149,17 @@ describe("BillingDialog — FINAL", () => {
   });
 
   it("byt mottagare → skickas i payloaden", () => {
-    render(<BillingDialog matterId="m1" type="FINAL" existingAccontos={[]} onClose={() => {}} />);
+    render(<BillingDialog matterId="m1" type="FINAL" existingAccontos={[]} meta={meta} onClose={() => {}} />);
     fireEvent.change(screen.getByRole("combobox"), { target: { value: "FORSAKRING" } });
     fireEvent.click(screen.getByRole("button", { name: "Skapa faktura" }));
     expect(finalMutate).toHaveBeenCalledWith(expect.objectContaining({ recipient: "FORSAKRING" }));
+  });
+
+  it("onSuccess genererar ett faktura-dokument", async () => {
+    const onClose = vi.fn();
+    render(<BillingDialog matterId="m1" type="FINAL" existingAccontos={[]} meta={meta} onClose={onClose} />);
+    await finalOnSuccess!({ invoice: { id: "inv-7", amount: 590_000 } });
+    expect(registerMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ id: "faktura-inv-7", invoiceId: "inv-7" }));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 });

--- a/test/unit/lib/shared/billing-proposal.test.ts
+++ b/test/unit/lib/shared/billing-proposal.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Tester för proposedAccontoOre (#397) — den delade aconto-formeln:
+ *   belopp = %-sats (bips) × upparbetat värde − Σ tidigare aconton, klampat ≥ 0.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { proposedAccontoOre } from "@/lib/shared/billing-proposal";
+
+describe("proposedAccontoOre", () => {
+  it("20 % av 5000 kr utan tidigare aconton → 1000 kr", () => {
+    expect(proposedAccontoOre(500_000, 2000, 0)).toBe(100_000);
+  });
+
+  it("drar av tidigare aconton: 20 % × 5000 − 600 = 400 kr", () => {
+    expect(proposedAccontoOre(500_000, 2000, 60_000)).toBe(40_000);
+  });
+
+  it("klampar till 0 när tidigare aconton överstiger andelen", () => {
+    expect(proposedAccontoOre(500_000, 2000, 200_000)).toBe(0);
+  });
+
+  it("0 % → 0 oavsett upparbetat", () => {
+    expect(proposedAccontoOre(500_000, 0, 0)).toBe(0);
+  });
+
+  it("avrundar bråkdels-ören (3333 bips × 100 öre)", () => {
+    // 100 × 3333 / 10000 = 33.33 → 33
+    expect(proposedAccontoOre(100, 3333, 0)).toBe(33);
+  });
+});

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -44,6 +44,50 @@ describe("billingRun.createAcconto", () => {
     const te = await ds.timeEntries.findFirst({ where: { id: "te-1" } }) as { frozenAt?: Date | null };
     expect(te.frozenAt).toBeFalsy();
   });
+
+  it("proposedAmountOre = %-sats × upparbetat (inga tidigare aconton) — #397", async () => {
+    const { caller } = makeCaller({ workMinutes: 120 }); // 5000 kr
+    const res = await caller.billingRun.createAcconto({
+      matterId: "m-1", clientShareBips: 2000, amountOre: 100000,
+    });
+    // 20% × 500000 − 0 = 100000
+    expect((res.run as { proposedAmountOre: number }).proposedAmountOre).toBe(100000);
+  });
+
+  it("proposedAmountOre drar av tidigare ACCONTO-runs (#397)", async () => {
+    const { caller } = makeCaller({ workMinutes: 120 }); // 5000 kr
+    await caller.billingRun.createAcconto({ matterId: "m-1", clientShareBips: 2000, amountOre: 100000 });
+    const second = await caller.billingRun.createAcconto({ matterId: "m-1", clientShareBips: 5000, amountOre: 1 });
+    // 50% × 500000 − 100000 (tidigare) = 150000
+    expect((second.run as { proposedAmountOre: number }).proposedAmountOre).toBe(150000);
+  });
+});
+
+describe("billingRun.proposal (#397)", () => {
+  it("returnerar ofakturerade poster, upparbetat värde och tidigare aconto-summa", async () => {
+    const { caller } = makeCaller({ workMinutes: 120, expenseOre: 90000 }); // 5000 + 900 kr
+    await caller.billingRun.createAcconto({ matterId: "m-1", clientShareBips: 2000, amountOre: 60000 });
+    const p = await caller.billingRun.proposal({ matterId: "m-1" });
+    expect(p.workValueOre).toBe(500000 + 90000);
+    expect(p.priorAccontoSumOre).toBe(60000);
+    expect(p.timeEntries).toHaveLength(1);
+    expect(p.timeEntries[0]!.valueOre).toBe(500000);
+    expect(p.expenses).toHaveLength(1);
+    expect(p.expenses[0]!.amount).toBe(90000);
+  });
+
+  it("utelämnar frysta poster efter en FINAL", async () => {
+    const { caller } = makeCaller({ workMinutes: 60 });
+    await caller.billingRun.createFinal({ matterId: "m-1", recipient: "KLIENT" });
+    const p = await caller.billingRun.proposal({ matterId: "m-1" });
+    expect(p.timeEntries).toHaveLength(0);
+    expect(p.workValueOre).toBe(0);
+  });
+
+  it("nekar ärende i annan org (NOT_FOUND)", async () => {
+    const { caller } = makeCaller({ workMinutes: 60 });
+    await expect(caller.billingRun.proposal({ matterId: "m-saknas" })).rejects.toThrow();
+  });
 });
 
 describe("billingRun.createFinal", () => {


### PR DESCRIPTION
## Vad
Avdragsmedvetet fakturaskapande (#397) — när en faktura skapas från ett ärende
drar dialogen nu av tidigare fakturerade poster/belopp, och varje faktura blir
både ett **DRAFT-utkast** och ett **faktura-PDF-dokument i ärendets dokumentlista**
(redo för utskick).

## Två fall (enligt önskemålet)
1. **Vanlig faktura (FINAL):** listar ärendets *ofakturerade* tids-/utläggsposter
   och föreslår dem i fakturan, med upparbetat värde.
2. **Acconto:** beräknar och förfyller beloppet enligt
   `belopp = klientens %-sats × upparbetat värde − Σ tidigare aconton` (≥ 0).
   Advokaten kan justera.

## Ändringar
- **`billingRun.proposal`** (ny query): ofakturerade poster (itemiserat) +
  `workValueOre` + `priorAccontoSumOre`, org-scopat.
- **`createAcconto.proposedAmountOre`** drar av tidigare aconton (delad ren modul
  `src/lib/shared/billing-proposal.ts` — server + klient delar exakt samma formel).
- **`AccontoForm`** visar Upparbetat/Tidigare aconton/Förslag och förfyller beloppet.
- **`FinalForm`** listar de ofakturerade posterna som föreslås.
- **`generateFakturaDoc`** bruten ut ur `_verdict-dialog` till delad klient-helper
  (`src/lib/client/kostnadsrakning/generate-faktura-doc.ts`); aconto/slutfaktura
  genererar nu faktura-PDF i fil-listan, samma mönster som dom-flödet.

## Verifiering (lokal CI-spegel)
- `typecheck` ✓ · `lint` ✓ · `lint:complexity-strict` ✓ (allt ≤ 8)
- full unit-svit + coverage-grind ✓ (rader 87.35% ≥ golv 86.80%, funktioner 82.55% ≥ 80%)
- `build:demo` ✓ (97 HTML-filer, manifest 502 entiteter)

Nya tester: formel-modul, proposal-query (org-scoping + frysta poster +
prior-aconto-summa), dialog-render + doc-generering.

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)
