### PR TITLE
test(reports): täck arSummary-routern, höj line-floor 86.8→86.9 (#27)

### DIFF
--- a/test/unit/server/routers/reports-ar-summary.test.ts
+++ b/test/unit/server/routers/reports-ar-summary.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Test för reports.arSummary (#27 coverage) — Kundfordrings-sammanställningen
+ * (ADR 0007): brygga + åldersanalys + per-faktura-rader, period-scoping, och
+ * den valfria advokat-attributionen (proportionellt mot fryst arbetsvärde).
+ *
+ * Täcker router-proceduren + helprarna arMetaById/arRowsFrom/lawyerShareRatios
+ * som de andra reports-testerna (perLawyer/billed) inte rör.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { reportsRouter } from "@/lib/server/routers/reports";
+import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
+
+const mockPrisma = {
+  user: { findFirst: vi.fn() },
+  invoice: { findMany: vi.fn() },
+  payment: { findMany: vi.fn() },
+  writeOff: { findMany: vi.fn() },
+  billingRun: { findMany: vi.fn() },
+  timeEntry: { findMany: vi.fn() },
+};
+
+function makeCaller(orgId = "org-a") {
+  const ctx = {
+    user: { id: "u-self", email: "a@b.se", name: "T", role: "LAWYER", organizationId: orgId },
+    prisma: mockPrisma, dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return reportsRouter.createCaller(ctx as any);
+}
+
+const JUNE = { from: "2026-06-01", to: "2026-06-30" };
+
+const inv = (o: Record<string, unknown> = {}) => ({
+  id: "i1", amount: 100_000, status: "SENT", invoiceType: "STANDARD", creditedInvoiceId: null,
+  invoiceNumber: "F-2026-0001", invoiceDate: new Date("2026-06-15"), dueDate: new Date("2026-07-15"), dueAt: null,
+  matter: { id: "m1", matterNumber: "2026-0001", title: "Tvist" }, ...o,
+});
+const teFrozen = (o: Record<string, unknown> = {}) => ({
+  userId: "u1", minutes: 60, hourlyRate: 100_000, invoiceId: "i1", frozenByBillingRunId: null, ...o,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.user.findFirst.mockResolvedValue({ id: "u1", name: "Anna" });
+  mockPrisma.invoice.findMany.mockResolvedValue([]);
+  mockPrisma.payment.findMany.mockResolvedValue([]);
+  mockPrisma.writeOff.findMany.mockResolvedValue([]);
+  mockPrisma.billingRun.findMany.mockResolvedValue([]);
+  mockPrisma.timeEntry.findMany.mockResolvedValue([]);
+});
+
+describe("reports.arSummary — utan advokatfilter", () => {
+  it("bygger brygga + per-faktura-rader ur faktura/betalning/avskrivning", async () => {
+    mockPrisma.invoice.findMany.mockResolvedValue([inv()]);
+    mockPrisma.payment.findMany.mockResolvedValue([{ invoiceId: "i1", amount: 30_000 }]);
+
+    const res = await makeCaller().arSummary({ ...JUNE });
+    expect(res.bridge.fakturerat).toBe(100_000);
+    expect(res.bridge.inbetalt).toBe(30_000);
+    expect(res.bridge.utestaende).toBe(70_000);
+    expect(res.rows).toHaveLength(1);
+    expect(res.rows[0]).toMatchObject({
+      id: "i1", invoiceNumber: "F-2026-0001", matterNumber: "2026-0001", title: "Tvist",
+      fakturerat: 100_000, inbetalt: 30_000, utestaende: 70_000,
+    });
+    expect(res.aging).toBeDefined();
+  });
+
+  it("avskrivning syns i bryggan som konstaterad kundförlust", async () => {
+    mockPrisma.invoice.findMany.mockResolvedValue([inv({ status: "BAD_DEBT" })]);
+    mockPrisma.writeOff.findMany.mockResolvedValue([{ invoiceId: "i1", amount: 100_000 }]);
+
+    const res = await makeCaller().arSummary({ ...JUNE });
+    expect(res.bridge.konstateradKundforlust).toBe(100_000);
+    expect(res.rows[0]).toMatchObject({ avskrivet: 100_000 });
+  });
+
+  it("scopar bort fakturor utställda utanför perioden", async () => {
+    mockPrisma.invoice.findMany.mockResolvedValue([inv({ invoiceDate: new Date("2026-03-01") })]);
+    const res = await makeCaller().arSummary({ ...JUNE });
+    expect(res.rows).toHaveLength(0);
+    expect(res.bridge.fakturerat).toBe(0);
+  });
+});
+
+describe("reports.arSummary — med advokatfilter (attribution)", () => {
+  it("hela fakturan attribueras advokaten när all frusen tid är hens (ratio 1.0)", async () => {
+    mockPrisma.invoice.findMany.mockResolvedValue([inv()]);
+    mockPrisma.payment.findMany.mockResolvedValue([{ invoiceId: "i1", amount: 30_000 }]);
+    mockPrisma.timeEntry.findMany.mockResolvedValue([teFrozen({ userId: "u1" })]);
+
+    const res = await makeCaller().arSummary({ ...JUNE, userId: "u1" });
+    expect(res.bridge.fakturerat).toBe(100_000);
+    expect(res.rows[0]).toMatchObject({ fakturerat: 100_000 });
+  });
+
+  it("attribuerar via BillingRun (frozenByBillingRunId → invoiceId)", async () => {
+    mockPrisma.invoice.findMany.mockResolvedValue([inv()]);
+    mockPrisma.billingRun.findMany.mockResolvedValue([{ id: "run1", invoiceId: "i1" }]);
+    mockPrisma.timeEntry.findMany.mockResolvedValue([
+      teFrozen({ userId: "u1", invoiceId: null, frozenByBillingRunId: "run1" }),
+    ]);
+    const res = await makeCaller().arSummary({ ...JUNE, userId: "u1" });
+    expect(res.bridge.fakturerat).toBe(100_000);
+  });
+
+  it("annan advokats arbete (ratio 0) → inget attribueras", async () => {
+    mockPrisma.invoice.findMany.mockResolvedValue([inv()]);
+    mockPrisma.timeEntry.findMany.mockResolvedValue([teFrozen({ userId: "u2" })]);
+    const res = await makeCaller().arSummary({ ...JUNE, userId: "u1" });
+    expect(res.bridge.fakturerat).toBe(0);
+  });
+
+  it("proportionell andel: 75 % av fakturan", async () => {
+    mockPrisma.invoice.findMany.mockResolvedValue([inv()]);
+    mockPrisma.timeEntry.findMany.mockResolvedValue([
+      teFrozen({ userId: "u1", minutes: 45 }), // 75 000 öre
+      teFrozen({ userId: "u2", minutes: 15 }), // 25 000 öre
+    ]);
+    const res = await makeCaller().arSummary({ ...JUNE, userId: "u1" });
+    expect(res.bridge.fakturerat).toBe(75_000);
+  });
+});

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -34,9 +34,10 @@ const FAST = process.argv.includes("--fast");
 // #27: 84.0 → 84.8 (pick-provider) → 85.2 (external-edit-modal) → 85.5
 // (verdict-dialog) → 85.7 (billing-dialog) → 85.8 (expected-receivables) → 86.0
 // (integrations-section) → 86.2 (expectedReceivable) → 86.6 (DayView-render) →
-// 86.7 (datasource-section) → 86.8 (extract-text pdf/docx, lokalt 87.29% rader,
-// ~0.49% marginal — FUNC_FLOOR konservativt pga Node-version-varians).
-const LINE_FLOOR = 0.868;
+// 86.7 (datasource-section) → 86.8 (extract-text pdf/docx) → 86.9 (reports
+// arSummary-router, lokalt 87.59% rader, ~0.69% marginal — FUNC_FLOOR
+// konservativt pga Node-version-varians).
+const LINE_FLOOR = 0.869;
 const FUNC_FLOOR = 0.80;
 
 /**


### PR DESCRIPTION
## Vad
Ratchet-steg för #27: täcker `reports.arSummary` (Kundfordrings-sammanställningen,
ADR 0007) som saknade router-test. Hela proceduren + helprarna
`arMetaById`/`arRowsFrom`/`lawyerShareRatios` var otäckta i union-coverage.

## Test (via DemoDataStore-caller, samma mönster som reports-billed)
- brygga + åldersanalys + per-faktura-rader ur faktura/betalning/avskrivning
- konstaterad kundförlust i bryggan
- period-scoping (fakturor utanför perioden filtreras bort)
- valfri advokat-attribution: direkt `invoiceId`, via `BillingRun`, ratio 0 / 0.75 / 1.0

## Ratchet
Lokalt: rader 87.35% → **87.59%**. `LINE_FLOOR` 86.8 → **86.9** (~0.69% marginal).
`FUNC_FLOOR` oförändrat (Node-version-varians). Gates flyttas bara uppåt.

## Verifiering
`typecheck` ✓ · `lint` ✓ · `test:cov` ✓ (rader 87.59% ≥ golv 86.90%).
Endast `test/` + `tooling/` — inga app-ändringar (build:demo ej relevant).

refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)
