### PR TITLE
feat(data-store): optimistisk mutations-kö (#413)

### DIFF
--- a/src/lib/server/data-store/in-memory/idb-kv.ts
+++ b/src/lib/server/data-store/in-memory/idb-kv.ts
@@ -1,0 +1,57 @@
+/**
+ * `IdbKv` — minimal generisk IndexedDB key-value-lagring (#413). Delas av
+ * `IndexedDbPersistence` (hela DemoSource) och mutations-köns persistens, så
+ * den råa open/get/put-koden inte dupliceras.
+ *
+ * `IDBFactory` injiceras (default `globalThis.indexedDB`) → testbar via
+ * fake-indexeddb och oberoende av globalt tillstånd mellan tester.
+ */
+
+const DB_VERSION = 1;
+
+export class IdbKv {
+  constructor(
+    private readonly factory: IDBFactory,
+    private readonly dbName: string,
+    private readonly storeName: string,
+  ) {}
+
+  private open(): Promise<IDBDatabase> {
+    return new Promise((resolve, reject) => {
+      const req = this.factory.open(this.dbName, DB_VERSION);
+      req.onupgradeneeded = () => {
+        if (!req.result.objectStoreNames.contains(this.storeName)) req.result.createObjectStore(this.storeName);
+      };
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error ?? new Error("indexedDB open misslyckades"));
+    });
+  }
+
+  async get<V>(key: string): Promise<V | null> {
+    const db = await this.open();
+    try {
+      return await new Promise<V | null>((resolve, reject) => {
+        const req = db.transaction(this.storeName, "readonly").objectStore(this.storeName).get(key);
+        req.onsuccess = () => resolve((req.result as V | undefined) ?? null);
+        req.onerror = () => reject(req.error ?? new Error("indexedDB get misslyckades"));
+      });
+    } finally {
+      db.close();
+    }
+  }
+
+  async put<V>(key: string, value: V): Promise<void> {
+    const db = await this.open();
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const tx = db.transaction(this.storeName, "readwrite");
+        tx.objectStore(this.storeName).put(value, key);
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error ?? new Error("indexedDB put misslyckades"));
+        tx.onabort = () => reject(tx.error ?? new Error("indexedDB-transaktion avbröts"));
+      });
+    } finally {
+      db.close();
+    }
+  }
+}

--- a/src/lib/server/data-store/in-memory/indexeddb-persistence.ts
+++ b/src/lib/server/data-store/in-memory/indexeddb-persistence.ts
@@ -3,61 +3,34 @@
  * persisterade offline-cachens lagring i browsern. Hela `DemoSource` lagras
  * strukturklonad under en nyckel (Date-fält bevaras av structured clone).
  *
- * `IDBFactory` injiceras (default `globalThis.indexedDB`) så adaptern är
- * testbar utan en riktig browser (fake-indexeddb) och oberoende av globalt
- * tillstånd mellan tester.
+ * Bygger på den generiska `IdbKv` (#413) så open/get/put inte dupliceras.
+ * `IDBFactory` injiceras (default `globalThis.indexedDB`) → testbar via
+ * fake-indexeddb.
  */
 
 import type { DemoSource } from "@/lib/shared/demo-source";
+import { IdbKv } from "./idb-kv";
 import type { LocalStorePersistence } from "./local-store-persistence";
 
 const DB_NAME = "ava-local-store";
 const STORE = "source";
 const KEY = "current";
-const DB_VERSION = 1;
 
 export class IndexedDbPersistence implements LocalStorePersistence {
-  constructor(
-    private readonly factory: IDBFactory = (globalThis as unknown as { indexedDB: IDBFactory }).indexedDB,
-    private readonly dbName: string = DB_NAME,
-  ) {}
+  private readonly kv: IdbKv;
 
-  private open(): Promise<IDBDatabase> {
-    return new Promise((resolve, reject) => {
-      const req = this.factory.open(this.dbName, DB_VERSION);
-      req.onupgradeneeded = () => {
-        if (!req.result.objectStoreNames.contains(STORE)) req.result.createObjectStore(STORE);
-      };
-      req.onsuccess = () => resolve(req.result);
-      req.onerror = () => reject(req.error ?? new Error("indexedDB open misslyckades"));
-    });
+  constructor(
+    factory: IDBFactory = (globalThis as unknown as { indexedDB: IDBFactory }).indexedDB,
+    dbName: string = DB_NAME,
+  ) {
+    this.kv = new IdbKv(factory, dbName, STORE);
   }
 
   async hydrate(): Promise<DemoSource | null> {
-    const db = await this.open();
-    try {
-      return await new Promise<DemoSource | null>((resolve, reject) => {
-        const req = db.transaction(STORE, "readonly").objectStore(STORE).get(KEY);
-        req.onsuccess = () => resolve((req.result as DemoSource | undefined) ?? null);
-        req.onerror = () => reject(req.error ?? new Error("indexedDB get misslyckades"));
-      });
-    } finally {
-      db.close();
-    }
+    return this.kv.get<DemoSource>(KEY);
   }
 
   async save(source: DemoSource): Promise<void> {
-    const db = await this.open();
-    try {
-      await new Promise<void>((resolve, reject) => {
-        const tx = db.transaction(STORE, "readwrite");
-        tx.objectStore(STORE).put(source, KEY);
-        tx.oncomplete = () => resolve();
-        tx.onerror = () => reject(tx.error ?? new Error("indexedDB put misslyckades"));
-        tx.onabort = () => reject(tx.error ?? new Error("indexedDB-transaktion avbröts"));
-      });
-    } finally {
-      db.close();
-    }
+    await this.kv.put(KEY, source);
   }
 }

--- a/src/lib/server/data-store/in-memory/mutation-queue.ts
+++ b/src/lib/server/data-store/in-memory/mutation-queue.ts
@@ -1,0 +1,134 @@
+/**
+ * `MutationQueue` (#413, ADR 0017) — den optimistiska mutations-kön i offline-
+ * klienten. Mutationer appliceras lokalt direkt (av `LocalStore`) och köas här
+ * för uppspelning mot servern vid reconnect (reconcile-motorn #414).
+ *
+ * Varje köpost bär ett klient-genererat **UUIDv7** (`mutationId`) — tidsordnat
+ * (ADR 0003) och idempotent: re-enqueue av samma id är en no-op, och
+ * uppspelning kan dedupa säkert. Köordningen bevaras (FIFO).
+ *
+ * Kön är persistens-agnostisk (`MutationQueuePersistence`-port) → IndexedDB i
+ * browsern, in-memory i tester/demo.
+ */
+
+import { omitUndefined } from "@/lib/shared/omit-undefined";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { IdbKv } from "./idb-kv";
+import type { MutationEvent, MutationKind } from "./writable-delegate";
+
+export interface QueuedMutation {
+  /** Klient-genererat UUIDv7 — dedupe-nyckel + idempotent uppspelning. */
+  mutationId: string;
+  entity: string;
+  kind: MutationKind;
+  /** Raden efter mutationen (bär sitt eget UUIDv7 `id` → server-upsert). */
+  row: Record<string, unknown>;
+  /** Föregående rad (update/delete) — för rollback/konflikt. */
+  previous?: Record<string, unknown>;
+  /** Observerad `version` vid mutationen (ADR 0017 optimistisk concurrency). */
+  baseVersion?: number;
+  enqueuedAt: number;
+}
+
+export interface MutationQueuePersistence {
+  load(): Promise<QueuedMutation[]>;
+  save(items: readonly QueuedMutation[]): Promise<void>;
+}
+
+/** In-memory-persistens (tester/demo) — djupkopierar för att undvika delad referens. */
+export class InMemoryMutationQueuePersistence implements MutationQueuePersistence {
+  constructor(private items: QueuedMutation[] = []) {}
+  async load(): Promise<QueuedMutation[]> {
+    return structuredClone(this.items);
+  }
+  async save(items: readonly QueuedMutation[]): Promise<void> {
+    this.items = structuredClone([...items]);
+  }
+}
+
+/** IndexedDB-persistens — hela kön under en nyckel via `IdbKv`. */
+export class IndexedDbMutationQueuePersistence implements MutationQueuePersistence {
+  private readonly kv: IdbKv;
+  constructor(
+    factory: IDBFactory = (globalThis as unknown as { indexedDB: IDBFactory }).indexedDB,
+    dbName = "ava-mutation-queue",
+  ) {
+    this.kv = new IdbKv(factory, dbName, "queue");
+  }
+  async load(): Promise<QueuedMutation[]> {
+    return (await this.kv.get<QueuedMutation[]>("pending")) ?? [];
+  }
+  async save(items: readonly QueuedMutation[]): Promise<void> {
+    await this.kv.put("pending", [...items]);
+  }
+}
+
+export interface EnqueueOpts {
+  /** Explicit mutationId för idempotent enqueue (annars genereras UUIDv7). */
+  mutationId?: string;
+  baseVersion?: number;
+  /** Injicerad tidsstämpel (deterministiska tester). */
+  now?: number;
+}
+
+export class MutationQueue {
+  private items: QueuedMutation[] = [];
+
+  constructor(private readonly persistence?: MutationQueuePersistence) {}
+
+  /** Skapa en kö och hydrera den ur persistensen (om någon). */
+  static async hydrate(persistence?: MutationQueuePersistence): Promise<MutationQueue> {
+    const q = new MutationQueue(persistence);
+    if (persistence) q.items = await persistence.load();
+    return q;
+  }
+
+  /** Köa en mutation sist. Idempotent på `mutationId` (re-enqueue → no-op). */
+  async enqueue(event: MutationEvent<Record<string, unknown>>, opts: EnqueueOpts = {}): Promise<QueuedMutation> {
+    const mutationId = opts.mutationId ?? uuidv7(opts.now);
+    const existing = this.items.find((m) => m.mutationId === mutationId);
+    if (existing) return existing;
+    const item = omitUndefined({
+      mutationId,
+      entity: event.entity,
+      kind: event.kind,
+      row: event.row,
+      previous: event.previous,
+      baseVersion: opts.baseVersion,
+      enqueuedAt: opts.now ?? Date.now(),
+    }) as QueuedMutation;
+    this.items.push(item);
+    await this.persist();
+    return item;
+  }
+
+  /** Köposterna i FIFO-ordning (för uppspelning). */
+  pending(): readonly QueuedMutation[] {
+    return this.items;
+  }
+
+  size(): number {
+    return this.items.length;
+  }
+
+  has(mutationId: string): boolean {
+    return this.items.some((m) => m.mutationId === mutationId);
+  }
+
+  /** Ta bort en post efter server-bekräftelse. */
+  async ack(mutationId: string): Promise<void> {
+    const before = this.items.length;
+    this.items = this.items.filter((m) => m.mutationId !== mutationId);
+    if (this.items.length !== before) await this.persist();
+  }
+
+  async clear(): Promise<void> {
+    if (this.items.length === 0) return;
+    this.items = [];
+    await this.persist();
+  }
+
+  private async persist(): Promise<void> {
+    await this.persistence?.save(this.items);
+  }
+}

--- a/test/unit/server/data-store/idb-kv.test.ts
+++ b/test/unit/server/data-store/idb-kv.test.ts
@@ -1,0 +1,40 @@
+/**
+ * IdbKv (#413) — generisk IndexedDB key-value, testad mot fake-indexeddb.
+ * Round-trip, miss → null, överskrivning, och isolering mellan stores.
+ */
+
+import { IDBFactory } from "fake-indexeddb";
+import { describe, it, expect } from "vitest-compat";
+import { IdbKv } from "@/lib/server/data-store/in-memory/idb-kv";
+
+describe("IdbKv", () => {
+  it("get på saknad nyckel → null", async () => {
+    const kv = new IdbKv(new IDBFactory(), "kv-empty", "s");
+    expect(await kv.get("nope")).toBeNull();
+  });
+
+  it("put → get round-trippar och bevarar Date", async () => {
+    const kv = new IdbKv(new IDBFactory(), "kv-roundtrip", "s");
+    const d = new Date("2026-06-16T08:00:00.000Z");
+    await kv.put("k", { n: 1, when: d });
+    const out = await kv.get<{ n: number; when: Date }>("k");
+    expect(out?.n).toBe(1);
+    expect(out?.when).toBeInstanceOf(Date);
+    expect(out?.when.getTime()).toBe(d.getTime());
+  });
+
+  it("put skriver över föregående värde", async () => {
+    const kv = new IdbKv(new IDBFactory(), "kv-overwrite", "s");
+    await kv.put("k", "a");
+    await kv.put("k", "b");
+    expect(await kv.get("k")).toBe("b");
+  });
+
+  it("olika nycklar är isolerade", async () => {
+    const kv = new IdbKv(new IDBFactory(), "kv-keys", "s");
+    await kv.put("a", 1);
+    await kv.put("b", 2);
+    expect(await kv.get("a")).toBe(1);
+    expect(await kv.get("b")).toBe(2);
+  });
+});

--- a/test/unit/server/data-store/mutation-queue.test.ts
+++ b/test/unit/server/data-store/mutation-queue.test.ts
@@ -1,0 +1,95 @@
+/**
+ * MutationQueue (#413, ADR 0017) — optimistisk mutations-kö: FIFO-ordning,
+ * UUIDv7-mutationId, idempotent enqueue, ack, clear, persistens (in-memory +
+ * IndexedDB-rehydrering via fake-indexeddb).
+ */
+
+import { IDBFactory } from "fake-indexeddb";
+import { describe, it, expect } from "vitest-compat";
+import {
+  MutationQueue,
+  InMemoryMutationQueuePersistence,
+  IndexedDbMutationQueuePersistence,
+} from "@/lib/server/data-store/in-memory/mutation-queue";
+import type { MutationEvent } from "@/lib/server/data-store/in-memory/writable-delegate";
+
+const ev = (o: Partial<MutationEvent<Record<string, unknown>>> = {}): MutationEvent<Record<string, unknown>> => ({
+  entity: "invoice", kind: "create", row: { id: "inv-1", amount: 100 }, ...o,
+});
+
+describe("MutationQueue — kärna", () => {
+  it("enqueue genererar UUIDv7-mutationId och bevarar FIFO-ordning", async () => {
+    const q = new MutationQueue();
+    const a = await q.enqueue(ev({ row: { id: "a" } }), { now: 1 });
+    const b = await q.enqueue(ev({ row: { id: "b" } }), { now: 2 });
+    expect(a.mutationId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7/); // v7
+    expect(q.size()).toBe(2);
+    expect(q.pending().map((m) => (m.row as { id: string }).id)).toEqual(["a", "b"]);
+    expect(b.enqueuedAt).toBe(2);
+  });
+
+  it("enqueue är idempotent på explicit mutationId (re-enqueue = no-op)", async () => {
+    const q = new MutationQueue();
+    const first = await q.enqueue(ev(), { mutationId: "m1" });
+    const again = await q.enqueue(ev({ row: { id: "annan" } }), { mutationId: "m1" });
+    expect(again).toBe(first);
+    expect(q.size()).toBe(1);
+  });
+
+  it("bär kind/previous/baseVersion (update)", async () => {
+    const q = new MutationQueue();
+    const m = await q.enqueue(
+      ev({ kind: "update", row: { id: "x", v: 2 }, previous: { id: "x", v: 1 } }),
+      { baseVersion: 1, mutationId: "m1" },
+    );
+    expect(m.kind).toBe("update");
+    expect(m.previous).toEqual({ id: "x", v: 1 });
+    expect(m.baseVersion).toBe(1);
+  });
+
+  it("ack tar bort en post; clear tömmer", async () => {
+    const q = new MutationQueue();
+    await q.enqueue(ev(), { mutationId: "m1" });
+    await q.enqueue(ev(), { mutationId: "m2" });
+    await q.ack("m1");
+    expect(q.has("m1")).toBe(false);
+    expect(q.has("m2")).toBe(true);
+    await q.clear();
+    expect(q.size()).toBe(0);
+  });
+});
+
+describe("MutationQueue — persistens", () => {
+  it("in-memory: enqueue persisteras och rehydreras", async () => {
+    const p = new InMemoryMutationQueuePersistence();
+    const q1 = await MutationQueue.hydrate(p);
+    await q1.enqueue(ev({ row: { id: "a" } }), { mutationId: "m1" });
+
+    const q2 = await MutationQueue.hydrate(p);
+    expect(q2.size()).toBe(1);
+    expect(q2.has("m1")).toBe(true);
+  });
+
+  it("ack persisteras (rehydrerad kö ser borttagningen)", async () => {
+    const p = new InMemoryMutationQueuePersistence();
+    const q1 = await MutationQueue.hydrate(p);
+    await q1.enqueue(ev(), { mutationId: "m1" });
+    await q1.enqueue(ev(), { mutationId: "m2" });
+    await q1.ack("m1");
+
+    const q2 = await MutationQueue.hydrate(p);
+    expect(q2.size()).toBe(1);
+    expect(q2.has("m2")).toBe(true);
+  });
+
+  it("IndexedDB-persistens rehydrerar kön över 'omstart'", async () => {
+    const factory = new IDBFactory();
+    const q1 = await MutationQueue.hydrate(new IndexedDbMutationQueuePersistence(factory, "q-test"));
+    await q1.enqueue(ev({ row: { id: "a" } }), { mutationId: "m1" });
+    await q1.enqueue(ev({ row: { id: "b" } }), { mutationId: "m2" });
+
+    const q2 = await MutationQueue.hydrate(new IndexedDbMutationQueuePersistence(factory, "q-test"));
+    expect(q2.size()).toBe(2);
+    expect(q2.pending().map((m) => m.mutationId)).toEqual(["m1", "m2"]);
+  });
+});


### PR DESCRIPTION
Fas 2 i ADR 0016-migreringen (epic #403), ovanpå `LocalStore` (#412) och ADR 0017 (#404).

## Vad
- **`MutationQueue`** — persisterad, FIFO-ordnad kö för offline-klientens optimistiska mutationer. Varje post bär ett klient-genererat **UUIDv7** (`mutationId`): tidsordnat (ADR 0003) + **idempotent** (re-enqueue av samma id = no-op; uppspelning kan dedupa). API: enqueue/pending/ack/clear/has/size + `hydrate`.
- **`MutationQueuePersistence`**-port + `InMemory`- och `IndexedDb`-adaptrar. Posterna bär kind/previous/baseVersion för reconcile-motorn (#414).
- Bröt ut den råa IndexedDB-koden ur `indexeddb-persistence.ts` (#412) till en generisk **`IdbKv`** (open/get/put) som båda persistenserna delar → ingen jscpd-duplicering. `IndexedDbPersistence`:s beteende oförändrat (samma db/store/nyckel).

## Verifiering
typecheck ✓ · lint ✓ · complexity ✓ · dep-cruiser ✓ · knip ✓ · jscpd ✓ (inga kloner i nya filer) · coverage 87.72% ≥ 87.0% ✓. Nya tester: IdbKv + MutationQueue (inkl. IndexedDB-rehydrering via fake-indexeddb).

Nästa: #414 reconcile-motor (konsumerar kön).

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)