### PR TITLE
feat(data-store): reconcile-motor (#414)

### DIFF
--- a/src/lib/server/data-store/in-memory/cursor-store.ts
+++ b/src/lib/server/data-store/in-memory/cursor-store.ts
@@ -1,0 +1,38 @@
+/**
+ * `CursorStore` (ADR 0017, #414) — persisterar offline-klientens delta-sync-
+ * cursor (serverns senaste sedda position). In-memory för tester/demo,
+ * IndexedDB (via `IdbKv`) i browsern.
+ */
+
+import { IdbKv } from "./idb-kv";
+
+export interface CursorStore {
+  get(): Promise<number>;
+  set(cursor: number): Promise<void>;
+}
+
+export class InMemoryCursorStore implements CursorStore {
+  constructor(private cursor = 0) {}
+  async get(): Promise<number> {
+    return this.cursor;
+  }
+  async set(cursor: number): Promise<void> {
+    this.cursor = cursor;
+  }
+}
+
+export class IndexedDbCursorStore implements CursorStore {
+  private readonly kv: IdbKv;
+  constructor(
+    factory: IDBFactory = (globalThis as unknown as { indexedDB: IDBFactory }).indexedDB,
+    dbName = "ava-sync-cursor",
+  ) {
+    this.kv = new IdbKv(factory, dbName, "cursor");
+  }
+  async get(): Promise<number> {
+    return (await this.kv.get<number>("current")) ?? 0;
+  }
+  async set(cursor: number): Promise<void> {
+    await this.kv.put("current", cursor);
+  }
+}

--- a/src/lib/server/data-store/in-memory/reconcile-engine.ts
+++ b/src/lib/server/data-store/in-memory/reconcile-engine.ts
@@ -1,0 +1,99 @@
+/**
+ * `ReconcileEngine` (ADR 0017, #414) — offline-klientens reconcile-sekvens vid
+ * reconnect: **pull** (delta-cursor) → applicera kanoniska rader (hoppa rader
+ * med ej-uppspelad lokal mutation) → **replay** köade mutationer server-
+ * auktoritativt → **advance** cursor.
+ *
+ * Motorn är transport-agnostisk: den pratar med en `SyncTransport`-port och
+ * skriver kanoniska rader via en injicerad `apply`-callback (wires till en TYST
+ * lokal-store-skrivning i #415, så server-data inte köas om). Konflikter
+ * (surface-klassen) ytläggs i resultatet — de blockerar inte resten av kön.
+ */
+
+import { conflictClassOf, type ConflictClass } from "@/lib/shared/conflict-policy";
+import { omitUndefined } from "@/lib/shared/omit-undefined";
+import type { CursorStore } from "./cursor-store";
+import type { MutationQueue, QueuedMutation } from "./mutation-queue";
+import type { PulledChange, SyncTransport } from "./sync-transport";
+
+/** Tyst skrivning av en kanonisk server-rad till lokal store (utan att köa om). */
+export type ApplyCanonical = (
+  entity: string,
+  row: Record<string, unknown>,
+  deleted: boolean,
+) => void | Promise<void>;
+
+export interface ConflictRecord {
+  mutation: QueuedMutation;
+  conflictClass: ConflictClass;
+  reason: string;
+  current?: Record<string, unknown>;
+}
+
+export interface ReconcileResult {
+  pulled: number;
+  pushed: number;
+  rebased: number;
+  conflicts: ConflictRecord[];
+  cursor: number;
+}
+
+export interface ReconcileDeps {
+  transport: SyncTransport;
+  queue: MutationQueue;
+  cursor: CursorStore;
+  apply: ApplyCanonical;
+}
+
+const rowId = (row: Record<string, unknown>): string =>
+  typeof row.id === "string" ? row.id : "";
+const keyOf = (entity: string, row: Record<string, unknown>): string => `${entity}:${rowId(row)}`;
+
+export class ReconcileEngine {
+  constructor(private readonly deps: ReconcileDeps) {}
+
+  async reconcile(): Promise<ReconcileResult> {
+    const since = await this.deps.cursor.get();
+    const pull = await this.deps.transport.pull(since);
+    const pulled = await this.applyPull(pull.changes, this.pendingKeys());
+    const replay = await this.replayQueue();
+    await this.deps.cursor.set(pull.cursor);
+    return { pulled, ...replay, cursor: pull.cursor };
+  }
+
+  private pendingKeys(): Set<string> {
+    return new Set(this.deps.queue.pending().map((m) => keyOf(m.entity, m.row)));
+  }
+
+  /** Applicera kanoniska rader; hoppa rader med en ej-uppspelad lokal mutation. */
+  private async applyPull(changes: readonly PulledChange[], pending: Set<string>): Promise<number> {
+    let n = 0;
+    for (const ch of changes) {
+      if (pending.has(keyOf(ch.entity, ch.row))) continue;
+      await this.deps.apply(ch.entity, ch.row, ch.deleted ?? false);
+      n++;
+    }
+    return n;
+  }
+
+  /** Spela upp kön (FIFO). accepted/rebased → applicera + ack; conflict → ytlägg + ack. */
+  private async replayQueue(): Promise<{ pushed: number; rebased: number; conflicts: ConflictRecord[] }> {
+    let pushed = 0;
+    let rebased = 0;
+    const conflicts: ConflictRecord[] = [];
+    for (const m of [...this.deps.queue.pending()]) {
+      const res = await this.deps.transport.push(m);
+      if (res.status === "conflict") {
+        conflicts.push(omitUndefined({
+          mutation: m, conflictClass: conflictClassOf(m.entity), reason: res.reason, current: res.current,
+        }) as ConflictRecord);
+      } else {
+        await this.deps.apply(m.entity, res.row, false);
+        if (res.status === "rebased") rebased++;
+        else pushed++;
+      }
+      await this.deps.queue.ack(m.mutationId);
+    }
+    return { pushed, rebased, conflicts };
+  }
+}

--- a/src/lib/server/data-store/in-memory/sync-transport.ts
+++ b/src/lib/server/data-store/in-memory/sync-transport.ts
@@ -1,0 +1,36 @@
+/**
+ * `SyncTransport` (ADR 0017, #414) — porten reconcile-motorn pratar med.
+ * Den server-auktoritativa sidan (HttpDataStore-baserad, #411) implementerar
+ * den; tester använder en fejk. Reconcile-motorn känner inte till HTTP/tRPC.
+ */
+
+import type { QueuedMutation } from "./mutation-queue";
+
+/** En kanonisk ändring servern returnerar i en delta-pull (tombstone via `deleted`). */
+export interface PulledChange {
+  entity: string;
+  row: Record<string, unknown>;
+  deleted?: boolean;
+}
+
+export interface PullResult {
+  changes: PulledChange[];
+  /** Serverns nya cursor-position (delta-sync). */
+  cursor: number;
+}
+
+/**
+ * Utfall av att pusha en köad mutation (ADR 0017 tre konfliktklasser):
+ *   - `accepted` — applicerad; kanonisk rad (version bumpad) returneras.
+ *   - `rebased`  — LWW: servern hade nyare; kanonisk rad returneras.
+ *   - `conflict` — surface: avvisad efter invariant/statemaskin-validering.
+ */
+export type PushResult =
+  | { status: "accepted"; row: Record<string, unknown> }
+  | { status: "rebased"; row: Record<string, unknown> }
+  | { status: "conflict"; reason: string; current?: Record<string, unknown> };
+
+export interface SyncTransport {
+  pull(sinceCursor: number): Promise<PullResult>;
+  push(mutation: QueuedMutation): Promise<PushResult>;
+}

--- a/src/lib/shared/conflict-policy.ts
+++ b/src/lib/shared/conflict-policy.ts
@@ -1,0 +1,30 @@
+/**
+ * Konfliktpolicy per entitet (ADR 0017, #414) — den delade klassificeringen
+ * som styr hur servern löser en stale skrivning vid reconcile:
+ *
+ *   - `append`  — append-only, ingen konflikt möjlig (idempotent upsert på id).
+ *   - `lww`     — sista-skrivning-vinner; servern rebasar och returnerar kanoniskt.
+ *   - `surface` — servern validerar invariant/statemaskin mot AKTUELLT tillstånd
+ *                 och AVVISAR en stale skrivning → ytläggs för användarbeslut.
+ *
+ * Ren modul (server + klient delar den). En entitet utan klassning defaultar
+ * till `surface` — säkrast: avvisar hellre än överskriver tyst (ADR 0017).
+ */
+
+export type ConflictClass = "append" | "lww" | "surface";
+
+const APPEND: ReadonlySet<string> = new Set([
+  "timeEntry", "expense", "payment", "paymentPlanReminder", "billingRun",
+  "writeOff", "accontoDeduction", "document", "calendarEvent",
+]);
+
+const LWW: ReadonlySet<string> = new Set([
+  "matter", "contact", "matterContact", "documentFolder", "task",
+  "serviceNote", "userPreference", "orgPreference",
+]);
+
+export function conflictClassOf(entity: string): ConflictClass {
+  if (APPEND.has(entity)) return "append";
+  if (LWW.has(entity)) return "lww";
+  return "surface";
+}

--- a/test/unit/server/data-store/cursor-store.test.ts
+++ b/test/unit/server/data-store/cursor-store.test.ts
@@ -1,0 +1,29 @@
+/**
+ * CursorStore (ADR 0017, #414) — delta-sync-cursorns persistens.
+ */
+
+import { IDBFactory } from "fake-indexeddb";
+import { describe, it, expect } from "vitest-compat";
+import { InMemoryCursorStore, IndexedDbCursorStore } from "@/lib/server/data-store/in-memory/cursor-store";
+
+describe("InMemoryCursorStore", () => {
+  it("default 0, set→get round-trippar", async () => {
+    const c = new InMemoryCursorStore();
+    expect(await c.get()).toBe(0);
+    await c.set(42);
+    expect(await c.get()).toBe(42);
+  });
+});
+
+describe("IndexedDbCursorStore", () => {
+  it("tom DB → 0", async () => {
+    const c = new IndexedDbCursorStore(new IDBFactory(), "cursor-empty");
+    expect(await c.get()).toBe(0);
+  });
+
+  it("set persisteras över 'omstart'", async () => {
+    const factory = new IDBFactory();
+    await new IndexedDbCursorStore(factory, "cursor-rt").set(7);
+    expect(await new IndexedDbCursorStore(factory, "cursor-rt").get()).toBe(7);
+  });
+});

--- a/test/unit/server/data-store/reconcile-engine.test.ts
+++ b/test/unit/server/data-store/reconcile-engine.test.ts
@@ -1,0 +1,118 @@
+/**
+ * ReconcileEngine (ADR 0017, #414) — pull→apply→replay→advance:
+ * applicering av kanoniska rader, hopp över pending-rader, replay
+ * (accepted/rebased/conflict), konflikt-låda och cursor-advance.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { InMemoryCursorStore } from "@/lib/server/data-store/in-memory/cursor-store";
+import { MutationQueue, InMemoryMutationQueuePersistence } from "@/lib/server/data-store/in-memory/mutation-queue";
+import { ReconcileEngine, type ApplyCanonical } from "@/lib/server/data-store/in-memory/reconcile-engine";
+import type { PullResult, PushResult, SyncTransport } from "@/lib/server/data-store/in-memory/sync-transport";
+import type { MutationEvent } from "@/lib/server/data-store/in-memory/writable-delegate";
+
+const ev = (entity: string, id: string, extra: Record<string, unknown> = {}): MutationEvent<Record<string, unknown>> => ({
+  entity, kind: "create", row: { id, ...extra },
+});
+
+class FakeTransport implements SyncTransport {
+  pulls: PullResult = { changes: [], cursor: 0 };
+  pushResults = new Map<string, PushResult>();
+  pushed: string[] = [];
+  async pull(): Promise<PullResult> {
+    return this.pulls;
+  }
+  async push(m: { mutationId: string; row: Record<string, unknown> }): Promise<PushResult> {
+    this.pushed.push(m.mutationId);
+    return this.pushResults.get(m.mutationId) ?? { status: "accepted", row: m.row };
+  }
+}
+
+function harness() {
+  const applied: Array<{ entity: string; row: Record<string, unknown>; deleted: boolean }> = [];
+  const apply: ApplyCanonical = (entity, row, deleted) => { applied.push({ entity, row, deleted }); };
+  const transport = new FakeTransport();
+  const cursor = new InMemoryCursorStore();
+  return { applied, apply, transport, cursor };
+}
+
+describe("ReconcileEngine — pull", () => {
+  it("applicerar kanoniska rader och avancerar cursor", async () => {
+    const h = harness();
+    h.transport.pulls = { changes: [{ entity: "matter", row: { id: "m1", title: "T" } }], cursor: 12 };
+    const queue = await MutationQueue.hydrate();
+    const res = await new ReconcileEngine({ transport: h.transport, queue, cursor: h.cursor, apply: h.apply }).reconcile();
+    expect(res.pulled).toBe(1);
+    expect(h.applied[0]).toMatchObject({ entity: "matter", row: { id: "m1" }, deleted: false });
+    expect(res.cursor).toBe(12);
+    expect(await h.cursor.get()).toBe(12);
+  });
+
+  it("hoppar över en pull-rad som har en ej-uppspelad lokal mutation", async () => {
+    const h = harness();
+    const queue = await MutationQueue.hydrate(new InMemoryMutationQueuePersistence());
+    await queue.enqueue(ev("invoice", "i1"), { mutationId: "m1" });
+    // En matchande server-rad för invoice:i1 ska INTE klottra över den lokala.
+    h.transport.pulls = {
+      changes: [{ entity: "invoice", row: { id: "i1", v: 9 } }, { entity: "matter", row: { id: "m9" } }],
+      cursor: 5,
+    };
+    h.transport.pushResults.set("m1", { status: "accepted", row: { id: "i1", v: 10 } });
+    const res = await new ReconcileEngine({ transport: h.transport, queue, cursor: h.cursor, apply: h.apply }).reconcile();
+    expect(res.pulled).toBe(1); // bara matter:m9
+    expect(h.applied.some((a) => a.entity === "invoice" && (a.row as { v?: number }).v === 9)).toBe(false);
+  });
+});
+
+describe("ReconcileEngine — replay", () => {
+  it("accepted → applicerar kanonisk rad, ack:ar kön, räknar pushed", async () => {
+    const h = harness();
+    const queue = await MutationQueue.hydrate(new InMemoryMutationQueuePersistence());
+    await queue.enqueue(ev("timeEntry", "t1"), { mutationId: "m1" });
+    h.transport.pushResults.set("m1", { status: "accepted", row: { id: "t1", version: 1 } });
+    const res = await new ReconcileEngine({ transport: h.transport, queue, cursor: h.cursor, apply: h.apply }).reconcile();
+    expect(res.pushed).toBe(1);
+    expect(queue.size()).toBe(0);
+    expect(h.applied.find((a) => a.entity === "timeEntry")?.row).toMatchObject({ version: 1 });
+  });
+
+  it("rebased (LWW) → applicerar serverns kanoniska rad, räknar rebased", async () => {
+    const h = harness();
+    const queue = await MutationQueue.hydrate(new InMemoryMutationQueuePersistence());
+    await queue.enqueue(ev("matter", "m1", { title: "lokal" }), { mutationId: "mm" });
+    h.transport.pushResults.set("mm", { status: "rebased", row: { id: "m1", title: "server-vinner" } });
+    const res = await new ReconcileEngine({ transport: h.transport, queue, cursor: h.cursor, apply: h.apply }).reconcile();
+    expect(res.rebased).toBe(1);
+    expect(res.pushed).toBe(0);
+    expect(h.applied.at(-1)?.row).toMatchObject({ title: "server-vinner" });
+    expect(queue.size()).toBe(0);
+  });
+
+  it("conflict (surface) → ej applicerad, ytläggs med conflictClass, ack:as ur kön", async () => {
+    const h = harness();
+    const queue = await MutationQueue.hydrate(new InMemoryMutationQueuePersistence());
+    await queue.enqueue({ entity: "invoice", kind: "update", row: { id: "i1", status: "SENT" } }, { mutationId: "mc" });
+    h.transport.pushResults.set("mc", { status: "conflict", reason: "redan annullerad", current: { id: "i1", status: "CANCELLED" } });
+    const res = await new ReconcileEngine({ transport: h.transport, queue, cursor: h.cursor, apply: h.apply }).reconcile();
+    expect(res.conflicts).toHaveLength(1);
+    expect(res.conflicts[0]).toMatchObject({ conflictClass: "surface", reason: "redan annullerad" });
+    expect(res.conflicts[0]?.current).toMatchObject({ status: "CANCELLED" });
+    expect(h.applied.some((a) => a.entity === "invoice")).toBe(false); // ej applicerad
+    expect(queue.size()).toBe(0); // ut ur huvudkön (konflikt-låda i resultatet)
+  });
+
+  it("blandat: accepted + conflict i FIFO, kön töms, cursor avanceras", async () => {
+    const h = harness();
+    const queue = await MutationQueue.hydrate(new InMemoryMutationQueuePersistence());
+    await queue.enqueue(ev("timeEntry", "t1"), { mutationId: "a" });
+    await queue.enqueue({ entity: "invoice", kind: "update", row: { id: "i1" } }, { mutationId: "b" });
+    h.transport.pushResults.set("b", { status: "conflict", reason: "stale" });
+    h.transport.pulls = { changes: [], cursor: 99 };
+    const res = await new ReconcileEngine({ transport: h.transport, queue, cursor: h.cursor, apply: h.apply }).reconcile();
+    expect(h.transport.pushed).toEqual(["a", "b"]); // FIFO
+    expect(res.pushed).toBe(1);
+    expect(res.conflicts).toHaveLength(1);
+    expect(queue.size()).toBe(0);
+    expect(res.cursor).toBe(99);
+  });
+});

--- a/test/unit/shared/conflict-policy.test.ts
+++ b/test/unit/shared/conflict-policy.test.ts
@@ -1,0 +1,30 @@
+/**
+ * conflictClassOf (ADR 0017, #414) — entitets-matrisen append/lww/surface
+ * + default-surface för oklassade entiteter.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { conflictClassOf } from "@/lib/shared/conflict-policy";
+
+describe("conflictClassOf", () => {
+  it("append-only entiteter → append", () => {
+    for (const e of ["timeEntry", "expense", "payment", "billingRun", "writeOff", "calendarEvent"]) {
+      expect(conflictClassOf(e)).toBe("append");
+    }
+  });
+
+  it("beskrivande entiteter → lww", () => {
+    for (const e of ["matter", "contact", "matterContact", "task", "serviceNote", "userPreference"]) {
+      expect(conflictClassOf(e)).toBe("lww");
+    }
+  });
+
+  it("pengar/tillstånd → surface", () => {
+    expect(conflictClassOf("invoice")).toBe("surface");
+    expect(conflictClassOf("paymentPlan")).toBe("surface");
+  });
+
+  it("oklassad entitet defaultar till surface (säkrast)", () => {
+    expect(conflictClassOf("nånting-nytt")).toBe("surface");
+  });
+});


### PR DESCRIPTION
Fas 2 i ADR 0016-migreringen (epic #403), ovanpå mutations-kön (#413) och ADR 0017 (#404).

## Vad
- **`ReconcileEngine`** — reconnect-sekvensen ur ADR 0017: **pull** (delta-cursor) → applicera kanoniska rader (hoppa rader med ej-uppspelad lokal mutation) → **replay** köade mutationer server-auktoritativt → **advance** cursor.
- Transport-agnostisk via **`SyncTransport`**-port (pull/push) — server-sidan (#411) implementerar den; tester använder en fejk. Kanoniska rader skrivs via en injicerad `apply`-callback (tyst lokal-store-skrivning wires i #415, så server-data inte köas om).
- Tre konfliktklasser: accepted/rebased → applicera + ack; **conflict (surface)** → ytläggs i konflikt-låda, blockerar inte resten av kön.
- **`conflict-policy.ts`** — delad append/lww/surface-matris (default surface). **`cursor-store.ts`** — InMemory + IndexedDB (via IdbKv).

## Verifiering
typecheck ✓ · lint ✓ · complexity ✓ · dep-cruiser ✓ · knip ✓ · jscpd ✓ · coverage 87.75% ≥ 87.0% ✓. Nya tester: matris, cursor-persistens, reconcile-sekvens (pull-apply/skip-pending/accepted/rebased/conflict/FIFO/cursor).

Nästa: #415 CachingSyncDataStore (komponerar #412–#414 + #411 till den `IDataStore` appen använder).

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)