### PR TITLE
test(document): täck core listDocumentTypes/markExternallyEdited/analyze-catch, höj golv 87.0→87.1 (#27)

### DIFF
--- a/test/unit/server/routers/document/core.test.ts
+++ b/test/unit/server/routers/document/core.test.ts
@@ -19,6 +19,7 @@ const mockPrisma = {
   document: {
     findMany: vi.fn(),
     findFirst: vi.fn(),
+    findUniqueOrThrow: vi.fn(),
     count: vi.fn(),
     delete: vi.fn(),
     update: vi.fn(),
@@ -177,6 +178,79 @@ describe("document.analyze", () => {
     const res = await makeCaller().analyze({ documentId: "d1" });
     expect(res).toEqual({ ok: true });
     expect(mockPorts.documentAnalyzer.analyze).toHaveBeenCalledWith("d1");
+  });
+
+  it("sväljer ett analys-fel (fire-and-forget .catch) utan att kasta", async () => {
+    mockPrisma.document.findFirst.mockResolvedValue({ id: "d1", matterId: "m1" });
+    mockPorts.documentAnalyzer.analyze.mockRejectedValue(new Error("analys-krasch"));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await makeCaller().analyze({ documentId: "d1" });
+    expect(res).toEqual({ ok: true });
+    await new Promise((r) => setTimeout(r, 0)); // låt .catch:en köra
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});
+
+describe("document.listDocumentTypes", () => {
+  it("räknar unika documentType:er, hoppar null, sorterar på sv", async () => {
+    mockPrisma.document.findMany.mockResolvedValue([
+      { documentType: "Faktura" },
+      { documentType: "Avtal" },
+      { documentType: "Avtal" },
+      { documentType: null },
+      { documentType: "Ärende" },
+    ]);
+    const res = await makeCaller().listDocumentTypes();
+    expect(res).toEqual([
+      { type: "Avtal", count: 2 },
+      { type: "Faktura", count: 1 },
+      { type: "Ärende", count: 1 },
+    ]);
+  });
+
+  it("tom lista när inga dokument", async () => {
+    mockPrisma.document.findMany.mockResolvedValue([]);
+    expect(await makeCaller().listDocumentTypes()).toEqual([]);
+  });
+});
+
+describe("document.markExternallyEdited", () => {
+  it("bumpar version + updatedAt + sizeBytes efter access-check", async () => {
+    mockPrisma.document.findFirst.mockResolvedValue({ id: "d1", matterId: "m1" });
+    mockPrisma.document.findUniqueOrThrow.mockResolvedValue({ id: "d1", version: 2 });
+    mockPrisma.document.update.mockResolvedValue({ id: "d1", version: 3 });
+
+    await makeCaller().markExternallyEdited({
+      id: "d1", saves: 2, sessionStartedAt: "2026-06-16T08:00:00Z", sizeBytes: 4096,
+    });
+
+    const arg = mockPrisma.document.update.mock.calls[0]![0] as { where: unknown; data: Record<string, unknown> };
+    expect(arg.where).toEqual({ id: "d1" });
+    expect(arg.data.version).toBe(3);
+    expect(arg.data.updatedAt).toBeInstanceOf(Date);
+    expect(arg.data.sizeBytes).toBe(4096);
+    expect(arg.data.fileSize).toBe(4096);
+  });
+
+  it("defaultar version till 1→2 när raden saknar version", async () => {
+    mockPrisma.document.findFirst.mockResolvedValue({ id: "d1", matterId: "m1" });
+    mockPrisma.document.findUniqueOrThrow.mockResolvedValue({ id: "d1" });
+    mockPrisma.document.update.mockResolvedValue({ id: "d1" });
+
+    await makeCaller().markExternallyEdited({ id: "d1", saves: 1, sessionStartedAt: new Date() });
+    const arg = mockPrisma.document.update.mock.calls[0]![0] as { data: Record<string, unknown> };
+    expect(arg.data.version).toBe(2);
+    expect(arg.data.sizeBytes).toBeUndefined(); // utelämnad → ej satt
+  });
+
+  it("vägrar mot dokument i annan org", async () => {
+    mockPrisma.document.findFirst.mockResolvedValue(null);
+    await expect(
+      makeCaller("org-b").markExternallyEdited({ id: "d1", saves: 1, sessionStartedAt: new Date() }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(mockPrisma.document.update).not.toHaveBeenCalled();
   });
 });
 

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -35,9 +35,10 @@ const FAST = process.argv.includes("--fast");
 // (verdict-dialog) → 85.7 (billing-dialog) → 85.8 (expected-receivables) → 86.0
 // (integrations-section) → 86.2 (expectedReceivable) → 86.6 (DayView-render) →
 // 86.7 (datasource-section) → 86.8 (extract-text pdf/docx) → 86.9 (reports
-// arSummary-router) → 87.0 (paymentPlan list/cancel/scanDueReminders, lokalt
-// 87.67% rader, ~0.67% marginal — FUNC_FLOOR konservativt pga Node-version-varians).
-const LINE_FLOOR = 0.870;
+// arSummary-router) → 87.0 (paymentPlan list/cancel/scanDueReminders) → 87.1
+// (document/core listDocumentTypes/markExternallyEdited/analyze-catch, lokalt
+// 87.83% rader, ~0.73% marginal — FUNC_FLOOR konservativt pga Node-version-varians).
+const LINE_FLOOR = 0.871;
 const FUNC_FLOOR = 0.80;
 
 /**


### PR DESCRIPTION
Ratchet-steg för #27 (oberoende av den pausade #408-migreringen). Täcker document/core:s tre otäckta procedurer/grenar:
- `listDocumentTypes` — unika documentType + antal, null-skip, sv-sortering
- `markExternallyEdited` — version-bump + updatedAt + sizeBytes, default 1→2, cross-org NOT_FOUND
- `analyze` fire-and-forget `.catch` — sväljer analys-fel utan att kasta

Lokalt: rader 87.75% → **87.83%**. `LINE_FLOOR` 87.0 → **87.1**. typecheck ✓ lint ✓ test:cov ✓. Endast test/ + tooling/.

refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)