### PR TITLE
test(calendar): täck getById/listForMatter/setMirrorState, höj golv 87.1→87.2 (#27)

### DIFF
--- a/test/unit/server/routers/calendar.test.ts
+++ b/test/unit/server/routers/calendar.test.ts
@@ -208,6 +208,63 @@ describe("calendar.update", () => {
   });
 });
 
+describe("calendar.getById", () => {
+  it("scopar till id + aktiv användare + org", async () => {
+    mockPrisma.calendarEvent.findFirstOrThrow.mockResolvedValue({ id: "e1", title: "Möte" });
+    const res = await makeCaller("u-anna", "org-x").getById({ id: "e1" });
+    expect(res).toMatchObject({ id: "e1" });
+    expect(mockPrisma.calendarEvent.findFirstOrThrow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "e1", userId: "u-anna", organizationId: "org-x" },
+      }),
+    );
+  });
+
+  it("kastar när eventet inte är användarens", async () => {
+    mockPrisma.calendarEvent.findFirstOrThrow.mockRejectedValue(new Error("Not found"));
+    await expect(makeCaller().getById({ id: "e1" })).rejects.toThrow("Not found");
+  });
+});
+
+describe("calendar.listForMatter", () => {
+  it("scopar på matterId + org, kronologiskt", async () => {
+    mockPrisma.calendarEvent.findMany.mockResolvedValue([{ id: "e1" }, { id: "e2" }]);
+    const res = await makeCaller("u1", "org-x").listForMatter({ matterId: "m1" });
+    expect(res).toHaveLength(2);
+    expect(mockPrisma.calendarEvent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { matterId: "m1", organizationId: "org-x" },
+        orderBy: { startAt: "asc" },
+      }),
+    );
+  });
+});
+
+describe("calendar.setMirrorState", () => {
+  it("guardar ownership innan uppdatering", async () => {
+    mockPrisma.calendarEvent.findFirstOrThrow.mockRejectedValue(new Error("Not found"));
+    await expect(
+      makeCaller().setMirrorState({ id: "e1", mirrorStatus: "synced" }),
+    ).rejects.toThrow("Not found");
+    expect(mockPrisma.calendarEvent.update).not.toHaveBeenCalled();
+  });
+
+  it("skriver mirror-fält rakt av UTAN computeMirrorPatch (ingen pending-loop)", async () => {
+    mockPrisma.calendarEvent.findFirstOrThrow.mockResolvedValue({ id: "e1" });
+    mockPrisma.calendarEvent.update.mockResolvedValue({});
+    await makeCaller().setMirrorState({
+      id: "e1", outlookEventId: "ou-1", mirrorStatus: "synced",
+    });
+    const arg = mockPrisma.calendarEvent.update.mock.calls[0]![0] as {
+      where: unknown; data: Record<string, unknown>;
+    };
+    expect(arg.where).toEqual({ id: "e1" });
+    expect(arg.data.mirrorStatus).toBe("synced"); // INTE flippad till pending
+    expect(arg.data.outlookEventId).toBe("ou-1");
+    expect(arg.data).not.toHaveProperty("id"); // id lyfts ut ur data
+  });
+});
+
 describe("calendar.delete", () => {
   it("guardar ownership innan delete", async () => {
     mockPrisma.calendarEvent.findFirstOrThrow.mockRejectedValue(new Error("Not found"));

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -36,9 +36,10 @@ const FAST = process.argv.includes("--fast");
 // (integrations-section) → 86.2 (expectedReceivable) → 86.6 (DayView-render) →
 // 86.7 (datasource-section) → 86.8 (extract-text pdf/docx) → 86.9 (reports
 // arSummary-router) → 87.0 (paymentPlan list/cancel/scanDueReminders) → 87.1
-// (document/core listDocumentTypes/markExternallyEdited/analyze-catch, lokalt
-// 87.83% rader, ~0.73% marginal — FUNC_FLOOR konservativt pga Node-version-varians).
-const LINE_FLOOR = 0.871;
+// (document/core listDocumentTypes/markExternallyEdited/analyze-catch) → 87.2
+// (calendar getById/listForMatter/setMirrorState, lokalt 87.89% rader, ~0.69%
+// marginal — FUNC_FLOOR konservativt pga Node-version-varians).
+const LINE_FLOOR = 0.872;
 const FUNC_FLOOR = 0.80;
 
 /**


### PR DESCRIPTION
Ratchet-steg för #27 (oberoende av den pausade #408). calendarRouter:s tre otäckta procedurer:
- `getById` — ownership-scoping + NOT_FOUND
- `listForMatter` — matter + org-scope, kronologiskt
- `setMirrorState` — skriver mirror-fält rakt av (ingen computeMirrorPatch → ingen pending-loop)

Lokalt: rader 87.83% → **87.89%**. `LINE_FLOOR` 87.1 → **87.2**. typecheck ✓ lint ✓ test:cov ✓. Endast test/ + tooling/.

refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)