### PR TITLE
docs(adr): typat repository i stället för prisma-formad seam (ADR 0020)

### DIFF
--- a/docs/adr/0019-postgres-schema-och-db-toolchain.md
+++ b/docs/adr/0019-postgres-schema-och-db-toolchain.md
@@ -1,6 +1,6 @@
 # ADR 0019 — Postgres-schema & DB-toolchain (Drizzle, version/change-log, IDataStore-subset)
 
-- **Status:** Accepterad
+- **Status:** Accepterad (beslut 5 — frusen arg-subset + tolk — **amenderat av [ADR 0020](0020-typat-repository-i-stallet-for-prisma-formad-seam.md)**: tolken ersätts av ett typat repository. Schema/toolchain/version/change-log (beslut 1–4) gäller fortsatt.)
 - **Datum:** 2026-06-16
 - **Beslutsfattare:** Ulrik Sjölin
 - **Berör:** server-backend, DB-schema, migrations, reconcile, IDataStore-kontrakt

--- a/docs/adr/0020-typat-repository-i-stallet-for-prisma-formad-seam.md
+++ b/docs/adr/0020-typat-repository-i-stallet-for-prisma-formad-seam.md
@@ -1,0 +1,94 @@
+# ADR 0020 — Typat repository i stället för Prisma-formad `IDataStore`-söm
+
+- **Status:** Föreslagen
+- **Datum:** 2026-06-16
+- **Beslutsfattare:** Ulrik Sjölin
+- **Berör:** datalager-söm, routrar, PostgresStore, offline-klient, alla backends
+- **Amenderar:** [ADR 0019](0019-postgres-schema-och-db-toolchain.md) (beslut 5:
+  "frusen IDataStore-arg-subset + tolk" ERSÄTTS av repository-mönstret nedan).
+  Bygger på [ADR 0016](0016-server-first-med-offline-first-klient.md)/[0001](0001-pluggbar-backend-bakom-idatastore.md).
+
+## Kontext
+
+`IDataStore` är Prisma-format: routrarna skickar **dynamiska** `where`/`include`/
+`select`-objekt (787 anropsställen, 28 router-filer, ~150 distinkta frågeformer,
+60 `include`). En Postgres-backend kräver då en **tolk** som översätter dessa
+dynamiska objekt → SQL (ADR 0019 beslut 5). Tolken är permanent komplex och
+dubbel-underhålls mot `in-memory/query-engine.ts`.
+
+Beslut (efter utvärdering av anropsytan): **ersätt den Prisma-formade sömmen med
+ett typat repository.** Varje frågeform blir en **explicit, typad metod** i stället
+för ett dynamiskt arg-objekt. Det ger full typsäkerhet, tar bort tolken, och gör
+varje backend-impl till vanliga typade funktioner. Priset är en bred men
+parallelliserbar refaktor (~787 anropsställen).
+
+## Beslut
+
+1. **Söm = per-entitet repository-interfaces med explicita typade metoder.**
+   I st.f. `ctx.dataStore.invoices.findFirst({ where, include })` →
+   `ctx.repos.invoices.getByIdWithLedger(id)` med en typad retur (`InvoiceWithLedger`).
+2. **`Repositories`-aggregat ersätter `IDataStore`** (håller alla entitets-repos +
+   `transaction(fn)` som ger en transaktionell repos-vy — speglar dagens `DataStoreTx`).
+3. **Två implementationer per repo:** Drizzle (server) + in-memory (browser/offline).
+4. **Returtyper är explicita** (`z.infer`-baserade `XWithRelations`), inte dynamiska
+   include-former → IDE-autocomplete + kompilatorn fångar fel.
+5. **Den frusna arg-subseten + tolken (ADR 0019 #5) utgår** — ingen dynamisk
+   tolkning behövs längre.
+
+```
+  Router:  ctx.repos.invoices.listByMatter(matterId)   ← typad metod, typad retur
+                          │
+            ┌─────────────┴──────────────┐
+            ▼                             ▼
+  DrizzleInvoiceRepo (server)   InMemoryInvoiceRepo (browser/offline)
+   → Drizzle/SQL pushdown        → delegerar internt till query-engine.ts
+```
+
+### Återanvänder redan byggt arbete (ingen spilld kod)
+
+- **`query-engine.ts` (#412) överlever** som *intern* motor: in-memory-repots
+  metoder implementeras tunt ovanpå den (de slutar bara vara den exponerade sömmen).
+  → in-memory-sidan blir ~150 TUNNA metoder, inte 150 nyskrivna motorer.
+- **`LocalStore` (#412)** blir den interna in-memory-lagringen bakom in-memory-repot.
+- **`MutationQueue`/`ReconcileEngine` (#413/#414)** jobbar på entitet/rad-nivå →
+  i stort sett oförändrade.
+- **`CachingSyncDataStore` (#415, ej byggt)** målar nu mot repository-interfacet
+  i st.f. `IDataStore` — ingen omarbetning, bara annan målform.
+
+### Inkrementell migrering (ingen big-bang — gröna PR:er hela vägen)
+
+1. **Fas 1 — fundament:** `Repository`-bastyper + `Repositories`-aggregat +
+   transaktions-bindning. Båda backends får en bas. Samexisterar med `IDataStore`.
+2. **Fas 2 — pilot: `invoices`** (hårdast: `getById` med 11-fälts include) — bevisar
+   mönstret end-to-end (router + Drizzle-impl + in-memory-impl + tester).
+3. **Fas 3+ — fan-out per entitet** (parallelliserbart): migrera en entitets routrar +
+   båda impls åt gången; gammal `IDataStore` lever kvar för ännu ej migrerade entiteter.
+4. **Slutfas:** när alla entiteter migrerats — ta bort `IDataStore`/delegat-lagret.
+
+### Reshaping av epic #403
+
+- **#409** blir "repository-fundament + pilot (invoices)" i st.f. "PostgresStore-tolk".
+- **#410/#411** (HTTP-tRPC-runtime / HttpDataStore) oförändrade i syfte men talar
+  repository-interfacet.
+- Per-entitet-migrering blir nya barn-issues under #403.
+
+## Konsekvenser
+
+**Positivt**
+- Full typsäkerhet (autocomplete, kompilatorfel) — slut på `any`-formade delegater.
+- Ingen tolk att bygga/underhålla; ingen "frusen subset"-fiktion.
+- Drizzle-anrop är typade och explicita; SQL-pushdown per metod.
+- Parallelliserbart per entitet; gröna inkrementella PR:er.
+
+**Negativt / risker**
+- **Stor refaktor:** ~787 anropsställen i 28 filer migreras; ~150 typade metoder ×
+  2 impls (in-memory dock tunn via query-engine). Grovt 1–2 veckors arbete.
+- **App-bred regressionsrisk** (rör varje router) — mitigeras av att den befintliga
+  router-testsviten körs oförändrad efter varje entitets-migrering + entitet-i-taget.
+- Dubbel söm under övergången (repos + IDataStore samexisterar) tills sista entiteten.
+
+## Öppna frågor (till Fas 1)
+
+- Namnkonvention för metoder (`getByIdWithLedger` vs `findByIdFull`) — låses i piloten.
+- Hur transaktioner komponerar repos (en `tx`-bunden `Repositories`-instans).
+- Var de få `aggregate`/`_count`-frågorna landar (egna metoder med typad retur).

--- a/docs/adr/0020-typat-repository-i-stallet-for-prisma-formad-seam.md
+++ b/docs/adr/0020-typat-repository-i-stallet-for-prisma-formad-seam.md
@@ -1,6 +1,6 @@
 # ADR 0020 — Typat repository i stället för Prisma-formad `IDataStore`-söm
 
-- **Status:** Föreslagen
+- **Status:** Accepterad
 - **Datum:** 2026-06-16
 - **Beslutsfattare:** Ulrik Sjölin
 - **Berör:** datalager-söm, routrar, PostgresStore, offline-klient, alla backends

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,6 +53,11 @@
 >   DB-toolchain: **Drizzle** + drizzle-kit, `uuid`-kolumner, app-nivå version-bump,
 >   global `BIGSERIAL` per-org change-log, och en **frusen IDataStore-arg-subset**
 >   (= query-engine.ts). zod förblir sanningskälla. Konkretiserar #408.
+> - [ADR 0020](./adr/0020-typat-repository-i-stallet-for-prisma-formad-seam.md) —
+>   ersätter den Prisma-formade `IDataStore`-sömmen med ett **typat repository**
+>   (explicita metoder + typade returer, två impls), tar bort tolken. Amenderar
+>   ADR 0019 #5. Inkrementell per-entitet-migrering; query-engine/LocalStore (#412)
+>   återanvänds internt.
 
 ## Tre lager
 


### PR DESCRIPTION
Du valde **C** (typat repository) informerad om kostnaden. Den här ADR:n låser designen + faserna innan kod, och amenderar ADR 0019 #5 (tolken utgår).

## Beslut
- Söm = per-entitet **repository med explicita typade metoder** (`ctx.repos.invoices.getByIdWithLedger(id)`) + typade returer, i st.f. dynamiska Prisma-args.
- Två impls: Drizzle (server) + in-memory (browser/offline).
- **Ingen tolk**, ingen frusen subset.

## Viktigt — ingen spilld kod
- `query-engine.ts`/`LocalStore` (#412) **överlever** som *intern* in-memory-motor bakom in-memory-repot → in-memory-sidan blir ~150 *tunna* metoder, inte 150 nyskrivna.
- `MutationQueue`/`ReconcileEngine` (#413/#414) i stort oförändrade.
- `CachingSyncDataStore` (#415, ej byggt) målar mot repository-interfacet — ingen omarbetning.

## Migrering (inkrementell, gröna PR:er)
Fas 1 fundament → Fas 2 pilot (invoices, hårdast) → Fas 3+ fan-out per entitet (gammal IDataStore lever kvar tills sista entiteten) → ta bort IDataStore.

**Status: Föreslagen — vill ha din review** (särskilt fas-planen + att #412–414 återanvänds) innan jag drar igång Fas 1-kod. Reshapar #409/#410/#411 + ger nya per-entitet-barn under #403.

refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)