### PR TITLE
feat(repositories): repository-fundament (ADR 0020, #409 fas 1)

### DIFF
--- a/src/lib/server/repositories/in-memory-repository.ts
+++ b/src/lib/server/repositories/in-memory-repository.ts
@@ -1,0 +1,48 @@
+/**
+ * `InMemoryRepository` (ADR 0020, #409 Fas 1) — bas för in-memory-entitets-
+ * repositories (browser/demo/offline). Delegerar till en befintlig `IDataStore`-
+ * `Delegate` (dvs `LocalStore`/query-engine, #412) så vi INTE återimplementerar
+ * query-motorn — den blir bara intern i st.f. den exponerade sömmen.
+ *
+ * Centraliserar reconcile-konventionerna: `create` sätter `version=1`, `update`
+ * bumpar `version` + `updatedAt`, `softDelete` sätter `deletedAt` (tombstone).
+ */
+
+import type { Delegate } from "../data-store/IDataStore";
+import type { Repository, RowBase } from "./types";
+
+export class InMemoryRepository<Row extends RowBase> implements Repository<Row> {
+  constructor(
+    protected readonly delegate: Delegate,
+    /** Injicerbar klocka för deterministiska tester. */
+    protected readonly now: () => Date = () => new Date(),
+  ) {}
+
+  /** Hämta icke-mjukraderad rad (frånvarande `deletedAt` = ej raderad). */
+  async getById(id: string): Promise<Row | null> {
+    const row = (await this.delegate.findFirst({ where: { id } })) as Row | null;
+    return row && !row.deletedAt ? row : null;
+  }
+
+  async getByIdOrThrow(id: string): Promise<Row> {
+    const row = await this.getById(id);
+    if (!row) throw new Error(`Ingen rad med id ${id}`);
+    return row;
+  }
+
+  async create(data: Partial<Row>): Promise<Row> {
+    return (await this.delegate.create({ data: { version: 1, ...data } as Partial<Row> })) as Row;
+  }
+
+  async update(id: string, patch: Partial<Row>): Promise<Row> {
+    const current = await this.getByIdOrThrow(id);
+    const data = { ...patch, version: (current.version ?? 1) + 1, updatedAt: this.now() } as Partial<Row>;
+    return (await this.delegate.update({ where: { id }, data })) as Row;
+  }
+
+  async softDelete(id: string): Promise<Row> {
+    const current = await this.getByIdOrThrow(id);
+    const data = { deletedAt: this.now(), version: (current.version ?? 1) + 1 } as Partial<Row>;
+    return (await this.delegate.update({ where: { id }, data })) as Row;
+  }
+}

--- a/src/lib/server/repositories/types.ts
+++ b/src/lib/server/repositories/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Repository-sömmens kontrakt (ADR 0020) — ersätter stegvis den Prisma-formade
+ * `IDataStore`. Per-entitet-repositories exponerar EXPLICITA, TYPADE metoder i
+ * stället för dynamiska `where`/`include`-objekt; varje backend (Drizzle på
+ * servern, in-memory i browsern/offline) implementerar samma typade metoder.
+ *
+ * Fas 1 (#409) lägger fundamentet: bas-kontrakten + en in-memory-bas som
+ * delegerar till den befintliga query-engine/LocalStore (ingen spilld kod).
+ * Entitets-repositories + Drizzle-impl följer per-entitet (fan-out).
+ */
+
+/** Minsta form en repository-rad har (reconcile-konventioner, ADR 0017/0019). */
+export interface RowBase {
+  id: string;
+  version?: number;
+  createdAt?: Date | string;
+  updatedAt?: Date | string;
+  deletedAt?: Date | string | null;
+}
+
+/**
+ * Bas-CRUD som varje entitets-repository ärver. Entiteter LÄGGER TILL egna
+ * typade metoder (t.ex. `invoices.getByIdWithLedger`, `matters.listByOrg`) —
+ * inga dynamiska arg-objekt.
+ */
+export interface Repository<Row extends RowBase> {
+  getById(id: string): Promise<Row | null>;
+  getByIdOrThrow(id: string): Promise<Row>;
+  create(data: Partial<Row>): Promise<Row>;
+  update(id: string, patch: Partial<Row>): Promise<Row>;
+  /** Mjuk delete (sätter `deletedAt`, bumpar `version`) — tombstone, ADR 0017. */
+  softDelete(id: string): Promise<Row>;
+}
+
+/**
+ * Aggregatet som ersätter `IDataStore` i `ctx`. Växer per migrerad entitet
+ * (fan-out); samexisterar med `IDataStore` tills sista entiteten migrerats.
+ */
+export interface Repositories {
+  transaction<T>(fn: (tx: Repositories) => Promise<T>): Promise<T>;
+}

--- a/test/unit/server/repositories/in-memory-repository.test.ts
+++ b/test/unit/server/repositories/in-memory-repository.test.ts
@@ -1,0 +1,61 @@
+/**
+ * InMemoryRepository (ADR 0020, #409 Fas 1) — bas-CRUD ovanpå en LocalStore-
+ * delegate: getById (mjuk-delete-filter), create (version=1), update (version-
+ * bump + updatedAt), softDelete (deletedAt + tombstone-bump).
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import type { Delegate } from "@/lib/server/data-store/IDataStore";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { InMemoryRepository } from "@/lib/server/repositories/in-memory-repository";
+import type { RowBase } from "@/lib/server/repositories/types";
+
+const NOW = new Date("2026-06-16T12:00:00.000Z");
+
+interface UserRow extends RowBase { name: string }
+
+function makeRepo(seed: UserRow[] = []) {
+  const store = new LocalStore({ users: seed as unknown as Record<string, unknown>[] }, async () => {});
+  return new InMemoryRepository<UserRow>(store.users as unknown as Delegate, () => NOW);
+}
+
+describe("InMemoryRepository", () => {
+  it("getById returnerar raden; okänt id → null", async () => {
+    const repo = makeRepo([{ id: "u1", name: "Anna", version: 1 }]);
+    expect(await repo.getById("u1")).toMatchObject({ name: "Anna" });
+    expect(await repo.getById("saknas")).toBeNull();
+  });
+
+  it("getById filtrerar bort mjukraderade rader", async () => {
+    const repo = makeRepo([{ id: "u1", name: "Borta", version: 1, deletedAt: NOW }]);
+    expect(await repo.getById("u1")).toBeNull();
+  });
+
+  it("getByIdOrThrow kastar för okänt id", async () => {
+    await expect(makeRepo().getByIdOrThrow("x")).rejects.toThrow(/Ingen rad/);
+  });
+
+  it("create sätter version=1", async () => {
+    const repo = makeRepo();
+    const row = await repo.create({ id: "u2", name: "Bo" });
+    expect(row).toMatchObject({ id: "u2", name: "Bo", version: 1 });
+    expect(await repo.getById("u2")).toMatchObject({ name: "Bo" });
+  });
+
+  it("update bumpar version + sätter updatedAt", async () => {
+    const repo = makeRepo([{ id: "u1", name: "Anna", version: 2 }]);
+    const row = await repo.update("u1", { name: "Anna II" });
+    expect(row.name).toBe("Anna II");
+    expect(row.version).toBe(3);
+    // In-memory-delegaten sätter sin egen updatedAt (Drizzle-impl:en använder repo:ns now()).
+    expect(row.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it("softDelete sätter deletedAt + bumpar version, raden försvinner ur getById", async () => {
+    const repo = makeRepo([{ id: "u1", name: "Anna", version: 1 }]);
+    const row = await repo.softDelete("u1");
+    expect(row.deletedAt).toBe(NOW);
+    expect(row.version).toBe(2);
+    expect(await repo.getById("u1")).toBeNull();
+  });
+});


### PR DESCRIPTION
Fas 1 av repository-migreringen (ADR 0020, epic #403) — fundamentet innan per-entitet-fan-out.

## Vad
- **Kontrakt** (`types.ts`): `RowBase`, `Repository<Row>` (getById/getByIdOrThrow/create/update/softDelete), `Repositories`-aggregat (ersätter `IDataStore` stegvis).
- **`InMemoryRepository`-bas** som **delegerar till en befintlig IDataStore-delegate** (LocalStore/query-engine, #412) → query-motorn återimplementeras INTE, blir bara intern. Bekräftar ADR 0020:s "ingen spilld kod".
- Centraliserar reconcile-konventioner: create→version 1, update→version-bump+updatedAt, softDelete→deletedAt (tombstone, ADR 0017).

## Samexistens
Lägger sig BREDVID `IDataStore` — inget rörs i routrarna ännu. Nästa: pilot `invoices` (Drizzle-impl + in-memory-impl + migrera invoice-routerns anrop).

## Verifiering
typecheck ✓ · lint ✓ · complexity ✓ · dep-cruiser ✓ · knip ✓ · jscpd ✓ · coverage 88.03% ≥ 87.2% ✓. Tester: getById (mjuk-delete-filter) + create/update/softDelete-konventionerna.

refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)