### PR TITLE
feat(repositories): wira ctx.repos i tRPC-contexten (ADR 0020, #409 fas 2b)

### DIFF
--- a/src/lib/server/build-context.ts
+++ b/src/lib/server/build-context.ts
@@ -9,6 +9,8 @@
 import type { Principal } from "./auth/principal";
 import type { IDataStore } from "./data-store/IDataStore";
 import type { IPorts } from "./ports";
+import { buildInMemoryRepositories } from "./repositories/in-memory-repositories";
+import type { Repositories } from "./repositories/repositories";
 import type { Context } from "./trpc-core";
 
 export interface BuildContextDeps {
@@ -16,11 +18,17 @@ export interface BuildContextDeps {
   ports: IPorts;
   /** Fastställd av en `AuthProvider`. `null` = anonym/publik. */
   principal: Principal | null;
+  /**
+   * Repository-aggregat (ADR 0020). Default: in-memory-repos ovanpå `dataStore`
+   * (git/demo/offline-vägen). Server-runtimen (#410) injicerar Drizzle-repos.
+   */
+  repos?: Repositories;
 }
 
 export function buildContext(deps: BuildContextDeps): Context {
   return {
     dataStore: deps.dataStore,
+    repos: deps.repos ?? buildInMemoryRepositories(deps.dataStore),
     ports: deps.ports,
     user: deps.principal,
   };

--- a/src/lib/server/repositories/in-memory-invoice-repository.ts
+++ b/src/lib/server/repositories/in-memory-invoice-repository.ts
@@ -5,13 +5,15 @@
  */
 
 import type { Invoice } from "@/lib/shared/schemas/billing";
-import type { Delegate } from "../data-store/IDataStore";
-import type { LocalStore } from "../data-store/in-memory/local-store";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type { InvoiceRepository, InvoiceWithLedger } from "./invoice-repository";
 
+/** Delegaterna repot behöver — uppfylls av `IDataStore`, `DataStoreTx` och `LocalStore`. */
+export type InvoiceRepoSource = Pick<IDataStore, "invoices" | "payments" | "writeOffs">;
+
 export class InMemoryInvoiceRepository extends InMemoryRepository<Invoice> implements InvoiceRepository {
-  constructor(private readonly store: LocalStore, now?: () => Date) {
+  constructor(private readonly store: InvoiceRepoSource, now?: () => Date) {
     super(store.invoices as unknown as Delegate, now ?? (() => new Date()));
   }
 

--- a/src/lib/server/repositories/in-memory-repositories.ts
+++ b/src/lib/server/repositories/in-memory-repositories.ts
@@ -1,0 +1,29 @@
+/**
+ * `buildInMemoryRepositories` (ADR 0020, #409 Fas 2b) — bygger `Repositories`-
+ * aggregatet ovanpå en `IDataStore` (browser/offline/demo-vägen). In-memory-
+ * repona delegerar internt till store:ns query-engine (#412).
+ *
+ * `transaction` återanvänder store:ns snapshot/rollback och ger callbacken en
+ * tx-scopad repos-vy; nästlad `transaction` i den vyn är reentrant (no-op
+ * snapshot — yttre nivån committar), speglar `DemoDataStore.transaction`.
+ */
+
+import type { DataStoreTx, IDataStore } from "../data-store/IDataStore";
+import { InMemoryInvoiceRepository } from "./in-memory-invoice-repository";
+import type { Repositories } from "./repositories";
+
+/** Repos-vy bunden till en transaktions-tx (reentrant transaction). */
+function reposForTx(tx: DataStoreTx): Repositories {
+  const repos: Repositories = {
+    invoices: new InMemoryInvoiceRepository(tx),
+    transaction: (fn) => fn(repos),
+  };
+  return repos;
+}
+
+export function buildInMemoryRepositories(dataStore: IDataStore): Repositories {
+  return {
+    invoices: new InMemoryInvoiceRepository(dataStore),
+    transaction: (fn) => dataStore.transaction((tx) => fn(reposForTx(tx))),
+  };
+}

--- a/src/lib/server/repositories/repositories.ts
+++ b/src/lib/server/repositories/repositories.ts
@@ -1,0 +1,13 @@
+/**
+ * `Repositories` (ADR 0020) — aggregatet som ersätter `IDataStore` i `ctx`.
+ * Växer per migrerad entitet (fan-out); samexisterar med `IDataStore` tills
+ * sista entiteten migrerats. Egen fil (inte `types.ts`) så bas-kontrakten kan
+ * importeras av entitets-repositories utan cirkel-beroende.
+ */
+
+import type { InvoiceRepository } from "./invoice-repository";
+
+export interface Repositories {
+  invoices: InvoiceRepository;
+  transaction<T>(fn: (tx: Repositories) => Promise<T>): Promise<T>;
+}

--- a/src/lib/server/repositories/types.ts
+++ b/src/lib/server/repositories/types.ts
@@ -31,11 +31,3 @@ export interface Repository<Row extends RowBase> {
   /** Mjuk delete (sätter `deletedAt`, bumpar `version`) — tombstone, ADR 0017. */
   softDelete(id: string): Promise<Row>;
 }
-
-/**
- * Aggregatet som ersätter `IDataStore` i `ctx`. Växer per migrerad entitet
- * (fan-out); samexisterar med `IDataStore` tills sista entiteten migrerats.
- */
-export interface Repositories {
-  transaction<T>(fn: (tx: Repositories) => Promise<T>): Promise<T>;
-}

--- a/src/lib/server/trpc-core.ts
+++ b/src/lib/server/trpc-core.ts
@@ -21,10 +21,16 @@ import { asId } from "@/lib/shared/schemas/ids";
 import type { Principal } from "./auth/principal";
 import type { IDataStore } from "./data-store/IDataStore";
 import type { IPorts } from "./ports";
+import type { Repositories } from "./repositories/repositories";
 
 export type Context = {
   /** Read/write-data via abstraktion. Git-backenden wirar DemoDataStore. */
   dataStore: IDataStore;
+  /**
+   * Typat repository-aggregat (ADR 0020) — den nya sömmen routrarna migreras
+   * till, entitet för entitet. Samexisterar med `dataStore` under övergången.
+   */
+  repos: Repositories;
   /** Server-side ports (email, search, etc). Git-backenden wirar no-ops. */
   ports: IPorts;
   /**

--- a/test/unit/server/build-context.test.ts
+++ b/test/unit/server/build-context.test.ts
@@ -24,6 +24,7 @@ describe("buildContext", () => {
     expect(ctx.dataStore).toBe(fakeStore);
     expect(ctx.ports).toBe(fakePorts);
     expect(ctx.user).toBe(principal);
+    expect(ctx.repos).toBeDefined(); // ADR 0020 — default in-memory-repos
   });
 
   it("principal=null → ctx.user=null (anonym/publik)", () => {
@@ -33,6 +34,6 @@ describe("buildContext", () => {
 
   it("returnerar exakt Context-formen (inga extra fält)", () => {
     const ctx = buildContext({ dataStore: fakeStore, ports: fakePorts, principal });
-    expect(Object.keys(ctx).sort()).toEqual(["dataStore", "ports", "user"]);
+    expect(Object.keys(ctx).sort()).toEqual(["dataStore", "ports", "repos", "user"]);
   });
 });

--- a/test/unit/server/repositories/repos-wiring.test.ts
+++ b/test/unit/server/repositories/repos-wiring.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Repos-wiring (ADR 0020, #409 fas 2b) — `buildContext` exponerar `ctx.repos`
+ * (in-memory default ovanpå dataStore) och `ctx.repos.transaction` ärver
+ * store:ns snapshot/rollback. Bevisar att sömmen är tillgänglig i varje
+ * tRPC-context utan att någon router migrerats än (samexistens).
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { noopPorts } from "@/lib/server/adapters/noop-ports";
+import { buildContext } from "@/lib/server/build-context";
+import { DemoDataStore } from "@/lib/server/data-store/DemoDataStore";
+import { uuidv7 } from "@/lib/shared/uuid";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const inv = (id: string, matterId: string): any => ({
+  id, matterId, amount: 1_000, status: "DRAFT", invoiceType: "STANDARD",
+  invoiceDate: new Date("2026-06-01T00:00:00.000Z"),
+});
+
+function ctxOver(seed: Record<string, unknown[]>) {
+  const ds = new DemoDataStore(seed as never, async () => {});
+  return buildContext({ dataStore: ds, ports: noopPorts, principal: null });
+}
+
+describe("buildContext — repos-wiring", () => {
+  it("exponerar ctx.repos.invoices (in-memory) ovanpå dataStore", async () => {
+    const id = uuidv7();
+    const matterId = uuidv7();
+    const ctx = ctxOver({ invoices: [], payments: [], writeOffs: [] });
+    expect(ctx.repos).toBeDefined();
+    const created = await ctx.repos.invoices.create(inv(id, matterId));
+    expect(created.amount).toBe(1_000);
+    expect(await ctx.repos.invoices.getById(id)).toMatchObject({ id });
+    expect((await ctx.repos.invoices.listByMatter(matterId)).map((i) => i.id)).toContain(id);
+  });
+
+  it("ctx.repos.transaction rullar tillbaka vid fel (ärver store-snapshot)", async () => {
+    const id = uuidv7();
+    const ctx = ctxOver({ invoices: [], payments: [], writeOffs: [] });
+    await expect(
+      ctx.repos.transaction(async (tx) => {
+        await tx.invoices.create(inv(id, uuidv7()));
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    expect(await ctx.repos.invoices.getById(id)).toBeNull(); // rullades tillbaka
+  });
+
+  it("ctx.repos.transaction commit:ar vid framgång", async () => {
+    const id = uuidv7();
+    const ctx = ctxOver({ invoices: [], payments: [], writeOffs: [] });
+    await ctx.repos.transaction(async (tx) => {
+      await tx.invoices.create(inv(id, uuidv7()));
+    });
+    expect(await ctx.repos.invoices.getById(id)).toMatchObject({ id });
+  });
+});


### PR DESCRIPTION
Gör repository-sömmen tillgänglig i **varje tRPC-context** — utan att migrera någon router (samexistens → **noll regressionsrisk**).

## Vad
- `Context.repos: Repositories` + `buildContext` bygger default **in-memory-repos ovanpå `dataStore`** (git/demo/offline-vägen). Server-runtimen (#410) injicerar Drizzle-repos.
- `ctx.repos.transaction` ärver store:ns snapshot/rollback (reentrant tx-scopad repos-vy).
- Bröt ut `Repositories`-aggregatet till egen fil för att undvika cirkel-beroende `types`↔`invoice-repository` (fångades av dep-cruiser/fitness-testet).
- Generaliserade `InMemoryInvoiceRepository` att ta en delegate-källa (IDataStore/DataStoreTx/LocalStore).

## Verifiering
typecheck ✓ · lint ✓ · complexity ✓ · dep-cruiser ✓ (cirkel fixad) · knip ✓ · jscpd ✓ · coverage 88.02% ≥ 87.2% ✓ · **build:demo ✓** (rör browser-context-vägen). Tester: buildContext exponerar ctx.repos.invoices + transaction commit/rollback.

## Härnäst
Router-migrering (anropsställen → `ctx.repos`) per-entitet när repo-metoderna växer (org-scopade + full-include-varianter som matchar routrarnas nuvarande queries).

refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)