### PR TITLE
refactor(invoice): migrera markFortnoxBooked till ctx.repos (ADR 0020, #409)

### DIFF
--- a/src/lib/server/repositories/drizzle-invoice-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-repository.ts
@@ -11,7 +11,7 @@
 
 import { and, desc, eq, isNull } from "drizzle-orm";
 import type { Invoice, Payment, WriteOff } from "@/lib/shared/schemas/billing";
-import { invoices, payments, writeOffs } from "../db/schema";
+import { invoices, matters, payments, writeOffs } from "../db/schema";
 import type { AppDb } from "../db/types";
 import type { InvoiceRepository, InvoiceWithLedger } from "./invoice-repository";
 
@@ -32,6 +32,18 @@ export class DrizzleInvoiceRepository implements InvoiceRepository {
     const row = await this.getById(id);
     if (!row) throw new Error(`Ingen faktura med id ${id}`);
     return row;
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<Invoice | null> {
+    const rows = await this.db
+      .select({ inv: invoices }).from(invoices)
+      .innerJoin(matters, eq(invoices.matterId, matters.id))
+      .where(and(
+        eq(invoices.id, id),
+        eq(matters.organizationId, organizationId),
+        isNull(invoices.deletedAt),
+      )).limit(1);
+    return (rows[0]?.inv as unknown as Invoice | undefined) ?? null;
   }
 
   async create(data: Partial<Invoice>): Promise<Invoice> {

--- a/src/lib/server/repositories/in-memory-invoice-repository.ts
+++ b/src/lib/server/repositories/in-memory-invoice-repository.ts
@@ -17,6 +17,13 @@ export class InMemoryInvoiceRepository extends InMemoryRepository<Invoice> imple
     super(store.invoices as unknown as Delegate, now ?? (() => new Date()));
   }
 
+  async getByIdInOrg(id: string, organizationId: string): Promise<Invoice | null> {
+    // Samma relations-filter som routern använde mot DemoDataStore (org via ärende).
+    const row = (await (this.store.invoices as unknown as Delegate)
+      .findFirst({ where: { id, matter: { organizationId } } })) as Invoice | null;
+    return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
+  }
+
   async getByIdWithLedger(id: string): Promise<InvoiceWithLedger | null> {
     const invoice = await this.getById(id);
     if (!invoice) return null;

--- a/src/lib/server/repositories/invoice-repository.ts
+++ b/src/lib/server/repositories/invoice-repository.ts
@@ -20,6 +20,8 @@ export interface InvoiceWithLedger extends Invoice {
 }
 
 export interface InvoiceRepository extends Repository<Invoice> {
+  /** Faktura by id, org-scopad via ärendet (null om saknas/annan org/raderad). */
+  getByIdInOrg(id: string, organizationId: string): Promise<Invoice | null>;
   /** Faktura med betalningar + avskrivningar (ledger). Null om saknas/raderad. */
   getByIdWithLedger(id: string): Promise<InvoiceWithLedger | null>;
   /** Alla (icke-raderade) fakturor i ett ärende, nyaste först. */

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -683,14 +683,10 @@ export const invoiceRouter = router({
   markFortnoxBooked: orgProcedure
     .input(z.object({ invoiceId: invoiceIdSchema, fortnoxId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
-      const inv = await ctx.dataStore.invoices.findFirst({
-        where: { id: input.invoiceId, matter: { organizationId: ctx.orgId } },
-      });
+      // Migrerad till repository-sömmen (ADR 0020). Org-scope via getByIdInOrg.
+      const inv = await ctx.repos.invoices.getByIdInOrg(input.invoiceId, ctx.orgId);
       if (!inv) throw new TRPCError({ code: "NOT_FOUND" });
       if (inv.fortnoxId) return inv; // redan bokförd → no-op (idempotens)
-      return ctx.dataStore.invoices.update({
-        where: { id: inv.id },
-        data: { fortnoxId: input.fortnoxId },
-      });
+      return ctx.repos.invoices.update(input.invoiceId, { fortnoxId: input.fortnoxId });
     }),
 });

--- a/test/unit/server/repositories/invoice-repository.test.ts
+++ b/test/unit/server/repositories/invoice-repository.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
-import { invoices, payments } from "@/lib/server/db/schema";
+import { invoices, matters, payments } from "@/lib/server/db/schema";
 import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleInvoiceRepository } from "@/lib/server/repositories/drizzle-invoice-repository";
 import { InMemoryInvoiceRepository } from "@/lib/server/repositories/in-memory-invoice-repository";
@@ -60,6 +60,17 @@ describe("InvoiceRepository — in-memory", () => {
     expect(ledger?.writeOffs).toHaveLength(1);
     expect(ledger?.payments[0]!.amount).toBe(5_000);
   });
+
+  it("getByIdInOrg org-scopar via ärendet", async () => {
+    const store = new LocalStore({
+      matters: [{ id: matterId, organizationId: "org-1" }],
+      invoices: [inv({ id: invId, matterId })],
+      payments: [], writeOffs: [],
+    }, async () => {});
+    const repo = new InMemoryInvoiceRepository(store);
+    expect(await repo.getByIdInOrg(invId, "org-1")).toMatchObject({ id: invId });
+    expect(await repo.getByIdInOrg(invId, "org-2")).toBeNull(); // fel org
+  });
 });
 
 describe("InvoiceRepository — Drizzle (pglite)", () => {
@@ -83,5 +94,19 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
     const ledger = await new DrizzleInvoiceRepository(handle.db as unknown as AppDb).getByIdWithLedger(id);
     expect(ledger?.payments).toHaveLength(1);
     expect(ledger?.payments[0]!.amount).toBe(7_500);
+  });
+
+  it("getByIdInOrg org-scopar via join mot matters", async () => {
+    const db = handle.db;
+    const id = uuidv7();
+    const mId = uuidv7();
+    const org = uuidv7(); // uuid-kolumn → måste vara giltig UUID
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await db.insert(matters).values({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T", version: 1 } as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await db.insert(invoices).values(inv({ id, matterId: mId }) as any);
+    const repo = new DrizzleInvoiceRepository(handle.db as unknown as AppDb);
+    expect(await repo.getByIdInOrg(id, org)).toMatchObject({ id });
+    expect(await repo.getByIdInOrg(id, uuidv7())).toBeNull();
   });
 });

--- a/test/unit/server/routers/invoice.test.ts
+++ b/test/unit/server/routers/invoice.test.ts
@@ -14,6 +14,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import { invoiceRouter } from "@/lib/server/routers/invoice";
 import { ocrFromInvoiceNumber, isValidOcrReference } from "@/lib/shared/ocr-reference";
 import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
@@ -59,9 +61,12 @@ const mockPrisma = {
 };
 
 function makeCaller(orgId = "org-a", userId = "user-1") {
+  const dataStore = dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>);
   const ctx = {
     user: { id: userId, email: "a@b.com", name: "Test", role: "LAWYER", organizationId: orgId },
-    prisma: mockPrisma, dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+    prisma: mockPrisma, dataStore,
+    // ADR 0020: markFortnoxBooked är migrerad till ctx.repos → wira in-memory-repos.
+    repos: buildInMemoryRepositories(dataStore as unknown as IDataStore),
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return invoiceRouter.createCaller(ctx as any);
@@ -659,10 +664,13 @@ describe("invoice.markFortnoxBooked", () => {
     const res = await makeCaller().markFortnoxBooked({ invoiceId: "inv-1", fortnoxId: "A/1" });
 
     expect(res.fortnoxId).toBe("A/1");
-    expect(mockPrisma.invoice.update).toHaveBeenCalledWith({
-      where: { id: "inv-1" },
-      data: { fortnoxId: "A/1" },
-    });
+    // Repo.update bumpar version + updatedAt (ADR 0019), så matcha löst på fortnoxId.
+    expect(mockPrisma.invoice.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "inv-1" },
+        data: expect.objectContaining({ fortnoxId: "A/1" }),
+      }),
+    );
   });
 
   it("idempotent: skriver INTE över befintlig fortnoxId", async () => {


### PR DESCRIPTION
**Första riktiga router→repository-migreringen** (epic #403). Bevisar router→repos→båda-backends end-to-end på den minsta möjliga ytan.

## Vad
- `invoice.markFortnoxBooked` använder nu `ctx.repos.invoices` i st.f. `ctx.dataStore.invoices`.
- Ny **`getByIdInOrg(id, orgId)`** på InvoiceRepository (org-scope via ärendet):
  - in-memory: samma `matter:{organizationId}`-relations-filter som routern hade (oförändrad query-form).
  - Drizzle: explicit join invoices↔matters.
- update går via repo → bumpar version + updatedAt (ADR 0019-konvention).

## Noll regressionsrisk, bevisat
Hela invoice-routerns testsvit grön — `markFortnoxBooked`-testerna wirar nu `ctx.repos` via `buildInMemoryRepositories` och verifierar samma beteende (idempotens, cross-org NOT_FOUND). Paritets-test för `getByIdInOrg` mot **båda** impls (in-memory + pglite-join).

## Verifiering
typecheck ✓ · lint ✓ · complexity ✓ · dep-cruiser ✓ · knip ✓ · jscpd ✓ · coverage 88.00% ≥ 87.2% ✓ · build:demo ✓.

Mönstret är nu etablerat för fan-out: per router-anropsställe, lägg matchande typad repo-metod + migrera + kör routerns befintliga testsvit.

refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)