### PR TITLE
refactor(invoice): migrera setStatus till ctx.repos (ADR 0020, #409)

### DIFF
--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -656,19 +656,15 @@ export const invoiceRouter = router({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      const inv = await ctx.dataStore.invoices.findFirst({
-        where: { id: input.invoiceId, matter: { organizationId: ctx.orgId } },
-      });
+      // Migrerad till repository-sömmen (ADR 0020). Statemaskinen stannar i routern.
+      const inv = await ctx.repos.invoices.getByIdInOrg(input.invoiceId, ctx.orgId);
       if (!inv) throw new TRPCError({ code: "NOT_FOUND" });
       // Tillståndsmaskin (#350): blockera omöjliga övergångar (t.ex. DRAFT→BAD_DEBT
       // utan att ha skickats). Se [ADR 0015].
       if (!canTransition(inv.status as InvoiceStatus, input.status)) {
         throw new TRPCError({ code: "BAD_REQUEST", message: transitionErrorMessage(inv.status as InvoiceStatus, input.status) });
       }
-      return ctx.dataStore.invoices.update({
-        where: { id: inv.id },
-        data: { status: input.status },
-      });
+      return ctx.repos.invoices.update(input.invoiceId, { status: input.status });
     }),
 
   /**

--- a/test/unit/server/routers/invoice.test.ts
+++ b/test/unit/server/routers/invoice.test.ts
@@ -614,10 +614,13 @@ describe("invoice.setStatus", () => {
 
     await makeCaller().setStatus({ invoiceId: "inv-1", status: "BAD_DEBT" });
 
-    expect(mockPrisma.invoice.update).toHaveBeenCalledWith({
-      where: { id: "inv-1" },
-      data: { status: "BAD_DEBT" },
-    });
+    // Repo.update bumpar version + updatedAt (ADR 0019) → matcha löst på status.
+    expect(mockPrisma.invoice.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "inv-1" },
+        data: expect.objectContaining({ status: "BAD_DEBT" }),
+      }),
+    );
   });
 
   it("zod tillåter inte godtyckliga statusar (t.ex. PAID)", async () => {


### PR DESCRIPTION
Andra router-anropsstället migrerat till repository-sömmen (epic #403).

`invoice.setStatus` → `ctx.repos.invoices.getByIdInOrg` + `repo.update`. Statemaskinen (`canTransition`/`transitionErrorMessage`) stannar i routern (affärslogik ≠ dataåtkomst). **Återanvänder `getByIdInOrg`** från fortnox-migreringen — ingen ny repo-metod, minimal yta.

Invoice-routerns testsvit grön (52 tester; en setStatus-assertion löst:ad pga repo:ns version-bump). typecheck ✓ lint ✓ complexity ✓ deps ✓ knip ✓ jscpd ✓ coverage 88.00% ✓ build:demo ✓.

Fan-out fortsätter: nästa anropsställen som mappar mot getByIdInOrg+update är billiga; rikare metoder (list/getById-full/recordPayment) tar egna repo-metoder.

refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)