### PR TITLE
feat(repositories): getByIdWithRelations (ADR 0020, #409)

### DIFF
--- a/src/lib/server/db/types.ts
+++ b/src/lib/server/db/types.ts
@@ -4,7 +4,9 @@
  * så de inte kopplas till en specifik driver.
  */
 
+import type { ExtractTablesWithRelations } from "drizzle-orm";
 import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
 import type * as schema from "./schema";
 
-export type AppDb = PgDatabase<PgQueryResultHKT, typeof schema>;
+/** Tredje generic-parametern ger den typade `db.query`-ytan (RQB, relations). */
+export type AppDb = PgDatabase<PgQueryResultHKT, typeof schema, ExtractTablesWithRelations<typeof schema>>;

--- a/src/lib/server/repositories/drizzle-invoice-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-repository.ts
@@ -13,7 +13,7 @@ import { and, desc, eq, isNull } from "drizzle-orm";
 import type { Invoice, Payment, WriteOff } from "@/lib/shared/schemas/billing";
 import { invoices, matters, payments, writeOffs } from "../db/schema";
 import type { AppDb } from "../db/types";
-import type { InvoiceRepository, InvoiceWithLedger } from "./invoice-repository";
+import type { InvoiceRepository, InvoiceWithLedger, InvoiceWithRelations } from "./invoice-repository";
 
 export class DrizzleInvoiceRepository implements InvoiceRepository {
   constructor(
@@ -66,6 +66,26 @@ export class DrizzleInvoiceRepository implements InvoiceRepository {
       .set({ deletedAt: this.now(), version: nextVersion(current) } as never)
       .where(eq(invoices.id, id)).returning();
     return row as unknown as Invoice;
+  }
+
+  async getByIdWithRelations(id: string, organizationId: string): Promise<InvoiceWithRelations | null> {
+    const row = await this.db.query.invoices.findFirst({
+      where: eq(invoices.id, id),
+      with: {
+        matter: true,
+        payments: { with: { recordedBy: true }, orderBy: (p, { desc }) => [desc(p.paidAt)] },
+        writeOffs: { orderBy: (w, { desc }) => [desc(w.writtenOffAt)] },
+        paymentPlan: { with: { reminders: { orderBy: (r, { desc }) => [desc(r.sentAt)] } } },
+        timeEntries: true,
+        expenses: true,
+        documents: { orderBy: (d, { desc }) => [desc(d.createdAt)] },
+      },
+    });
+    // Org-scope via ärendet + mjuk-delete-filter (db.query saknar relations-where).
+    if (!row || row.deletedAt || (row.matter as { organizationId?: string } | null)?.organizationId !== organizationId) {
+      return null;
+    }
+    return row as unknown as InvoiceWithRelations;
   }
 
   async getByIdWithLedger(id: string): Promise<InvoiceWithLedger | null> {

--- a/src/lib/server/repositories/in-memory-invoice-repository.ts
+++ b/src/lib/server/repositories/in-memory-invoice-repository.ts
@@ -7,7 +7,7 @@
 import type { Invoice } from "@/lib/shared/schemas/billing";
 import type { Delegate, IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
-import type { InvoiceRepository, InvoiceWithLedger } from "./invoice-repository";
+import type { InvoiceRepository, InvoiceWithLedger, InvoiceWithRelations } from "./invoice-repository";
 
 /** Delegaterna repot behöver — uppfylls av `IDataStore`, `DataStoreTx` och `LocalStore`. */
 export type InvoiceRepoSource = Pick<IDataStore, "invoices" | "payments" | "writeOffs">;
@@ -21,6 +21,22 @@ export class InMemoryInvoiceRepository extends InMemoryRepository<Invoice> imple
     // Samma relations-filter som routern använde mot DemoDataStore (org via ärende).
     const row = (await (this.store.invoices as unknown as Delegate)
       .findFirst({ where: { id, matter: { organizationId } } })) as Invoice | null;
+    return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
+  }
+
+  async getByIdWithRelations(id: string, organizationId: string): Promise<InvoiceWithRelations | null> {
+    const row = (await (this.store.invoices as unknown as Delegate).findFirst({
+      where: { id, matter: { organizationId } },
+      include: {
+        matter: true,
+        payments: { orderBy: { paidAt: "desc" }, include: { recordedBy: { select: { name: true } } } },
+        writeOffs: { orderBy: { writtenOffAt: "desc" } },
+        paymentPlan: { include: { reminders: { orderBy: { sentAt: "desc" } } } },
+        timeEntries: true,
+        expenses: true,
+        documents: { orderBy: { createdAt: "desc" } },
+      },
+    })) as InvoiceWithRelations | null;
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }
 

--- a/src/lib/server/repositories/invoice-repository.ts
+++ b/src/lib/server/repositories/invoice-repository.ts
@@ -10,7 +10,11 @@
  * dataåtkomst. Två impls: in-memory (browser/offline) + Drizzle (server).
  */
 
-import type { Invoice, Payment, WriteOff } from "@/lib/shared/schemas/billing";
+import type {
+  Expense, Invoice, Payment, PaymentPlan, PaymentPlanReminder, TimeEntry, WriteOff,
+} from "@/lib/shared/schemas/billing";
+import type { Document } from "@/lib/shared/schemas/document";
+import type { Matter } from "@/lib/shared/schemas/matter";
 import type { Repository } from "./types";
 
 /** Faktura + dess avräknings-poster (motsvarar dagens `include` payments/writeOffs). */
@@ -19,11 +23,28 @@ export interface InvoiceWithLedger extends Invoice {
   writeOffs: WriteOff[];
 }
 
+/**
+ * Faktura + relationerna som fakturadetalj-sidan läser, via relations()-infran
+ * (ADR 0020 #439). Self-ref-relationerna (accontoDeductions/deductedOnFinals/
+ * creditedInvoice/creditNote) läggs till i steget som migrerar `getById`.
+ */
+export interface InvoiceWithRelations extends Invoice {
+  matter: Matter | null;
+  payments: Array<Payment & { recordedBy: { name: string } | null }>;
+  writeOffs: WriteOff[];
+  paymentPlan: (PaymentPlan & { reminders: PaymentPlanReminder[] }) | null;
+  timeEntries: TimeEntry[];
+  expenses: Expense[];
+  documents: Document[];
+}
+
 export interface InvoiceRepository extends Repository<Invoice> {
   /** Faktura by id, org-scopad via ärendet (null om saknas/annan org/raderad). */
   getByIdInOrg(id: string, organizationId: string): Promise<Invoice | null>;
   /** Faktura med betalningar + avskrivningar (ledger). Null om saknas/raderad. */
   getByIdWithLedger(id: string): Promise<InvoiceWithLedger | null>;
+  /** Faktura + huvudrelationer (matter/payments/writeOffs/plan/tid/utlägg/dok), org-scopad. */
+  getByIdWithRelations(id: string, organizationId: string): Promise<InvoiceWithRelations | null>;
   /** Alla (icke-raderade) fakturor i ett ärende, nyaste först. */
   listByMatter(matterId: string): Promise<Invoice[]>;
 }

--- a/test/unit/server/repositories/invoice-repository.test.ts
+++ b/test/unit/server/repositories/invoice-repository.test.ts
@@ -6,7 +6,10 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
-import { invoices, matters, payments } from "@/lib/server/db/schema";
+import {
+  invoices, matters, payments, writeOffs, paymentPlans, paymentPlanReminders,
+  timeEntries, expenses, documents, users,
+} from "@/lib/server/db/schema";
 import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleInvoiceRepository } from "@/lib/server/repositories/drizzle-invoice-repository";
 import { InMemoryInvoiceRepository } from "@/lib/server/repositories/in-memory-invoice-repository";
@@ -71,6 +74,34 @@ describe("InvoiceRepository — in-memory", () => {
     expect(await repo.getByIdInOrg(invId, "org-1")).toMatchObject({ id: invId });
     expect(await repo.getByIdInOrg(invId, "org-2")).toBeNull(); // fel org
   });
+
+  it("getByIdWithRelations hämtar huvudrelationerna", async () => {
+    const userId = uuidv7();
+    const planId = uuidv7();
+    const store = new LocalStore({
+      matters: [{ id: matterId, organizationId: "org-1", matterNumber: "2026-1", title: "T" }],
+      users: [{ id: userId, name: "Anna" }],
+      invoices: [inv({ id: invId, matterId })],
+      payments: [{ id: uuidv7(), invoiceId: invId, amount: 400, recordedById: userId }],
+      writeOffs: [{ id: uuidv7(), invoiceId: invId, amount: 100 }],
+      paymentPlans: [{ id: planId, invoiceId: invId, status: "ACTIVE" }],
+      paymentPlanReminders: [{ id: uuidv7(), planId, dueMonth: "2026-06", type: "DUE" }],
+      timeEntries: [{ id: uuidv7(), invoiceId: invId, matterId, minutes: 60, billable: true, hourlyRate: 1000 }],
+      expenses: [{ id: uuidv7(), invoiceId: invId, matterId, amount: 50, billable: true }],
+      documents: [{ id: uuidv7(), invoiceId: invId, matterId, fileName: "f.pdf" }],
+    }, async () => {});
+    const repo = new InMemoryInvoiceRepository(store);
+    const full = await repo.getByIdWithRelations(invId, "org-1");
+    expect(full?.matter?.matterNumber).toBe("2026-1");
+    expect(full?.payments).toHaveLength(1);
+    expect(full?.payments[0]?.recordedBy?.name).toBe("Anna");
+    expect(full?.paymentPlan?.reminders).toHaveLength(1);
+    expect(full?.writeOffs).toHaveLength(1);
+    expect(full?.timeEntries).toHaveLength(1);
+    expect(full?.expenses).toHaveLength(1);
+    expect(full?.documents).toHaveLength(1);
+    expect(await repo.getByIdWithRelations(invId, "org-2")).toBeNull(); // fel org
+  });
 });
 
 describe("InvoiceRepository — Drizzle (pglite)", () => {
@@ -108,5 +139,38 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
     const repo = new DrizzleInvoiceRepository(handle.db as unknown as AppDb);
     expect(await repo.getByIdInOrg(id, org)).toMatchObject({ id });
     expect(await repo.getByIdInOrg(id, uuidv7())).toBeNull();
+  });
+
+  it("getByIdWithRelations hämtar huvudrelationerna (with-query)", async () => {
+    const db = handle.db;
+    const id = uuidv7();
+    const mId = uuidv7();
+    const org = uuidv7();
+    const userId = uuidv7();
+    const planId = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
+    await db.insert(users).values(v({ id: userId, organizationId: org, email: "a@x", name: "Anna" }));
+    await db.insert(invoices).values(inv({ id, matterId: mId }) as never);
+    await db.insert(payments).values(v({ id: uuidv7(), invoiceId: id, amount: 400, paidAt: new Date(), recordedById: userId }));
+    await db.insert(writeOffs).values(v({ id: uuidv7(), invoiceId: id, amount: 100, writtenOffAt: new Date(), recordedById: userId }));
+    await db.insert(paymentPlans).values(v({ id: planId, invoiceId: id, monthlyAmount: 100, dayOfMonth: 15, startDate: new Date(), status: "ACTIVE" }));
+    await db.insert(paymentPlanReminders).values(v({ id: uuidv7(), planId, dueMonth: "2026-06", type: "DUE", sentAt: new Date() }));
+    await db.insert(timeEntries).values(v({ id: uuidv7(), userId, matterId: mId, invoiceId: id, date: new Date(), minutes: 60, description: "x", hourlyRate: 1000 }));
+    await db.insert(expenses).values(v({ id: uuidv7(), userId, matterId: mId, invoiceId: id, date: new Date(), amount: 50, description: "x" }));
+    await db.insert(documents).values(v({ id: uuidv7(), matterId: mId, invoiceId: id, fileName: "f.pdf", mimeType: "application/pdf", sizeBytes: 1, storagePath: "p", uploadedById: userId }));
+
+    const repo = new DrizzleInvoiceRepository(handle.db as unknown as AppDb);
+    const full = await repo.getByIdWithRelations(id, org);
+    expect(full?.matter?.matterNumber).toBe("2026-1");
+    expect(full?.payments).toHaveLength(1);
+    expect(full?.payments[0]?.recordedBy?.name).toBe("Anna");
+    expect(full?.paymentPlan?.reminders).toHaveLength(1);
+    expect(full?.writeOffs).toHaveLength(1);
+    expect(full?.timeEntries).toHaveLength(1);
+    expect(full?.expenses).toHaveLength(1);
+    expect(full?.documents).toHaveLength(1);
+    expect(await repo.getByIdWithRelations(id, uuidv7())).toBeNull(); // fel org
   });
 });


### PR DESCRIPTION
Rik faktura-läsning på relations-infran (#439) — bygg-steget innan `invoice.getById` migreras. **Inga router-ändringar** (samexistens).

## Vad
- `getByIdWithRelations(id, orgId)` → faktura + huvudrelationer (matter, payments→recordedBy, writeOffs, paymentPlan→reminders, timeEntries, expenses, documents), org-scopad + mjuk-delete.
- **in-memory**: återanvänder exakt samma `include`-form som routern → garanterad samma shape.
- **Drizzle**: `db.query.invoices.findFirst({ with })` (RQB). `AppDb` fick tredje generic-parametern (`ExtractTablesWithRelations`) → `db.query` typad.
- Self-ref-relationerna (accontoDeductions/deductedOnFinals/credited/creditNote) läggs till via sekundär-queries i nästa steg (migrera getById).

## Verifiering
Paritetstest **in-memory ⟷ Drizzle (pglite)** över alla 7 relationer + nästlad recordedBy + org-scoping + null-fall. typecheck ✓ lint ✓ complexity ✓ dep-cruiser ✓ knip ✓ jscpd ✓ coverage 88.04% ✓.

## Härnäst
Lägg self-ref-relationerna + migrera `invoice.getById` → `ctx.repos.invoices.getByIdFull`.

refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)