### PR TITLE
feat(repositories): migrate invoice.list to typed repository (ADR 0020)

### DIFF
--- a/src/lib/server/repositories/drizzle-invoice-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-repository.ts
@@ -11,9 +11,11 @@
 
 import { and, desc, eq, isNull } from "drizzle-orm";
 import type { Invoice, Payment, WriteOff } from "@/lib/shared/schemas/billing";
-import { accontoDeductions, invoices, matters, payments, writeOffs } from "../db/schema";
+import { accontoDeductions, invoices, matters, paymentPlans, payments, writeOffs } from "../db/schema";
 import type { AppDb } from "../db/types";
-import type { InvoiceFull, InvoiceRepository, InvoiceWithLedger, InvoiceWithRelations } from "./invoice-repository";
+import type {
+  InvoiceFull, InvoiceListFilter, InvoiceListRow, InvoiceRepository, InvoiceWithLedger, InvoiceWithRelations,
+} from "./invoice-repository";
 
 export class DrizzleInvoiceRepository implements InvoiceRepository {
   constructor(
@@ -116,6 +118,44 @@ export class DrizzleInvoiceRepository implements InvoiceRepository {
       return null;
     }
     return row as unknown as InvoiceWithRelations;
+  }
+
+  async listForOrg(organizationId: string, filter?: InvoiceListFilter): Promise<InvoiceListRow[]> {
+    // Bas-rader: org-scope via inner-join på ärendet + valfria filter (undefined
+    // ignoreras av `and`). Relationerna berikas per rad (self-ref → sekundär-queries).
+    const baseRows = await this.db
+      .select({ inv: invoices, matter: matters }).from(invoices)
+      .innerJoin(matters, eq(invoices.matterId, matters.id))
+      .where(and(
+        eq(matters.organizationId, organizationId),
+        isNull(invoices.deletedAt),
+        filter?.matterId ? eq(invoices.matterId, filter.matterId) : undefined,
+        filter?.invoiceType ? eq(invoices.invoiceType, filter.invoiceType) : undefined,
+        filter?.status ? eq(invoices.status, filter.status) : undefined,
+      ))
+      .orderBy(desc(invoices.invoiceDate));
+    return Promise.all(baseRows.map(async ({ inv, matter }) => {
+      const id = (inv as { id: string }).id;
+      const plan = await this.db.select().from(paymentPlans).where(eq(paymentPlans.invoiceId, id)).limit(1);
+      const pays = await this.db.select().from(payments).where(eq(payments.invoiceId, id)).orderBy(desc(payments.paidAt));
+      const deductions = await this.db.select().from(accontoDeductions).where(eq(accontoDeductions.finalInvoiceId, id));
+      const accontoDeductionsFull = await Promise.all(
+        deductions.map(async (d) => ({ ...d, accontoInvoice: await this.rawInvoice((d as { accontoInvoiceId: string }).accontoInvoiceId) })),
+      );
+      const usages = await this.db.select({ id: accontoDeductions.id }).from(accontoDeductions).where(eq(accontoDeductions.accontoInvoiceId, id));
+      const creditedInvoice = await this.rawInvoice((inv as { creditedInvoiceId?: string | null }).creditedInvoiceId);
+      const creditNoteRows = await this.db.select().from(invoices).where(eq(invoices.creditedInvoiceId, id)).limit(1);
+      return {
+        ...inv,
+        matter: { id: (matter as { id: string }).id, matterNumber: (matter as { matterNumber: string }).matterNumber, title: (matter as { title: string }).title },
+        paymentPlan: (plan[0] as unknown) ?? null,
+        payments: pays as unknown as Payment[],
+        accontoDeductions: accontoDeductionsFull,
+        deductedOnFinals: usages,
+        creditedInvoice: creditedInvoice as InvoiceListRow["creditedInvoice"],
+        creditNote: (creditNoteRows[0] as unknown as InvoiceListRow["creditNote"]) ?? null,
+      };
+    })) as unknown as InvoiceListRow[];
   }
 
   async getByIdWithLedger(id: string): Promise<InvoiceWithLedger | null> {

--- a/src/lib/server/repositories/in-memory-invoice-repository.ts
+++ b/src/lib/server/repositories/in-memory-invoice-repository.ts
@@ -7,7 +7,9 @@
 import type { Invoice } from "@/lib/shared/schemas/billing";
 import type { Delegate, IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
-import type { InvoiceFull, InvoiceRepository, InvoiceWithLedger, InvoiceWithRelations } from "./invoice-repository";
+import type {
+  InvoiceFull, InvoiceListFilter, InvoiceListRow, InvoiceRepository, InvoiceWithLedger, InvoiceWithRelations,
+} from "./invoice-repository";
 
 /** Delegaterna repot behöver — uppfylls av `IDataStore`, `DataStoreTx` och `LocalStore`. */
 export type InvoiceRepoSource = Pick<IDataStore, "invoices" | "payments" | "writeOffs">;
@@ -70,6 +72,30 @@ export class InMemoryInvoiceRepository extends InMemoryRepository<Invoice> imple
     const writeOffs = (await (this.store.writeOffs as unknown as Delegate)
       .findMany({ where: { invoiceId: id } })) as InvoiceWithLedger["writeOffs"];
     return { ...invoice, payments, writeOffs };
+  }
+
+  async listForOrg(organizationId: string, filter?: InvoiceListFilter): Promise<InvoiceListRow[]> {
+    // Samma where/include som routern använde mot DemoDataStore — query-engine:n
+    // resolvar relationerna i ett anrop (jfr Drizzle-impl:ens sekundär-queries).
+    const rows = (await (this.store.invoices as unknown as Delegate).findMany({
+      where: {
+        matter: { organizationId },
+        ...(filter?.matterId ? { matterId: filter.matterId } : {}),
+        ...(filter?.invoiceType ? { invoiceType: filter.invoiceType } : {}),
+        ...(filter?.status ? { status: filter.status } : {}),
+      },
+      orderBy: { invoiceDate: "desc" },
+      include: {
+        matter: { select: { id: true, matterNumber: true, title: true } },
+        paymentPlan: true,
+        payments: { orderBy: { paidAt: "desc" } },
+        accontoDeductions: { include: { accontoInvoice: true } },
+        deductedOnFinals: { select: { id: true } },
+        creditedInvoice: { select: { id: true, invoiceDate: true, amount: true } },
+        creditNote: { select: { id: true, invoiceDate: true, amount: true } },
+      },
+    })) as InvoiceListRow[];
+    return rows.filter((r) => !(r as { deletedAt?: unknown }).deletedAt);
   }
 
   async listByMatter(matterId: string): Promise<Invoice[]> {

--- a/src/lib/server/repositories/invoice-repository.ts
+++ b/src/lib/server/repositories/invoice-repository.ts
@@ -47,6 +47,28 @@ export interface InvoiceFull extends InvoiceWithRelations {
   creditNote: Pick<Invoice, "id" | "invoiceDate" | "amount"> | null;
 }
 
+/** Filter för `listForOrg` (alla optional → org-bred lista). */
+export interface InvoiceListFilter {
+  matterId?: string | undefined;
+  invoiceType?: Invoice["invoiceType"] | undefined;
+  status?: Invoice["status"] | undefined;
+}
+
+/**
+ * Faktura-rad för listvyn (motsvarar `invoice.list`-routerns include exakt).
+ * Lättare shape än `InvoiceFull`: ärendet är en select-delmängd, inga
+ * write-offs/tid/utlägg/dok, och `deductedOnFinals` bara `id` (för räkning).
+ */
+export interface InvoiceListRow extends Invoice {
+  matter: Pick<Matter, "id" | "matterNumber" | "title">;
+  paymentPlan: PaymentPlan | null;
+  payments: Payment[];
+  accontoDeductions: Array<AccontoDeduction & { accontoInvoice: Invoice | null }>;
+  deductedOnFinals: Array<Pick<AccontoDeduction, "id">>;
+  creditedInvoice: Pick<Invoice, "id" | "invoiceDate" | "amount"> | null;
+  creditNote: Pick<Invoice, "id" | "invoiceDate" | "amount"> | null;
+}
+
 export interface InvoiceRepository extends Repository<Invoice> {
   /** Faktura by id, org-scopad via ärendet (null om saknas/annan org/raderad). */
   getByIdInOrg(id: string, organizationId: string): Promise<Invoice | null>;
@@ -56,6 +78,8 @@ export interface InvoiceRepository extends Repository<Invoice> {
   getByIdWithLedger(id: string): Promise<InvoiceWithLedger | null>;
   /** Faktura + huvudrelationer (matter/payments/writeOffs/plan/tid/utlägg/dok), org-scopad. */
   getByIdWithRelations(id: string, organizationId: string): Promise<InvoiceWithRelations | null>;
+  /** Org-bred fakturalista (listvyns include), nyaste först, valfritt filtrerad. */
+  listForOrg(organizationId: string, filter?: InvoiceListFilter): Promise<InvoiceListRow[]>;
   /** Alla (icke-raderade) fakturor i ett ärende, nyaste först. */
   listByMatter(matterId: string): Promise<Invoice[]>;
 }

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -176,26 +176,9 @@ export const invoiceRouter = router({
         status: invoiceStatusSchema.optional(),
       }),
     )
-    .query(({ ctx, input }) =>
-      ctx.dataStore.invoices.findMany({
-        where: {
-          matter: { organizationId: ctx.orgId },
-          ...(input.matterId ? { matterId: input.matterId } : {}),
-          ...(input.invoiceType ? { invoiceType: input.invoiceType } : {}),
-          ...(input.status ? { status: input.status } : {}),
-        },
-        orderBy: { invoiceDate: "desc" },
-        include: {
-          matter: { select: { id: true, matterNumber: true, title: true } },
-          paymentPlan: true,
-          payments: { orderBy: { paidAt: "desc" } },
-          accontoDeductions: { include: { accontoInvoice: true } },
-          deductedOnFinals: { select: { id: true } },
-          creditedInvoice: { select: { id: true, invoiceDate: true, amount: true } },
-          creditNote: { select: { id: true, invoiceDate: true, amount: true } },
-        },
-      }),
-    ),
+    // Migrerad till repository-sömmen (ADR 0020). listForOrg org-scopar +
+    // hämtar listvyns include (matter-subset, plan, betalningar, aconto-avdrag).
+    .query(({ ctx, input }) => ctx.repos.invoices.listForOrg(ctx.orgId, input)),
 
   getById: orgProcedure
     .input(z.object({ id: z.string() }))

--- a/test/unit/server/repositories/invoice-repository.test.ts
+++ b/test/unit/server/repositories/invoice-repository.test.ts
@@ -118,6 +118,35 @@ describe("InvoiceRepository — in-memory", () => {
     expect(full?.accontoDeductions).toHaveLength(1);
     expect((full?.accontoDeductions[0]?.accontoInvoice as { id?: string } | null)?.id).toBe(accontoId);
   });
+
+  it("listForOrg org-scopar, filtrerar och tar med listrelationer", async () => {
+    const accontoId = uuidv7();
+    const otherId = uuidv7();
+    const otherMatter = uuidv7();
+    const store = new LocalStore({
+      matters: [
+        { id: matterId, organizationId: "org-1", matterNumber: "2026-1", title: "T" },
+        { id: otherMatter, organizationId: "org-2", matterNumber: "2026-2", title: "U" },
+      ],
+      invoices: [
+        inv({ id: invId, matterId, invoiceType: "FINAL", status: "SENT" }),
+        inv({ id: accontoId, matterId, invoiceType: "ACCONTO", status: "PAID" }),
+        inv({ id: otherId, matterId: otherMatter, status: "SENT" }),
+      ],
+      accontoDeductions: [{ id: uuidv7(), finalInvoiceId: invId, accontoInvoiceId: accontoId }],
+      payments: [{ id: uuidv7(), invoiceId: invId, amount: 400 }],
+      paymentPlans: [], writeOffs: [],
+    }, async () => {});
+    const repo = new InMemoryInvoiceRepository(store);
+    const all = await repo.listForOrg("org-1");
+    expect(all.map((i) => i.id).sort()).toEqual([invId, accontoId].sort()); // org-2-fakturan exkluderad
+    const final = all.find((i) => i.id === invId)!;
+    expect(final.matter.matterNumber).toBe("2026-1");
+    expect(final.payments).toHaveLength(1);
+    expect((final.accontoDeductions[0]?.accontoInvoice as { id?: string } | null)?.id).toBe(accontoId);
+    expect((await repo.listForOrg("org-1", { status: "PAID" })).map((i) => i.id)).toEqual([accontoId]);
+    expect((await repo.listForOrg("org-1", { invoiceType: "FINAL" })).map((i) => i.id)).toEqual([invId]);
+  });
 });
 
 describe("InvoiceRepository — Drizzle (pglite)", () => {
@@ -209,5 +238,34 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
     expect(full?.accontoDeductions).toHaveLength(1);
     expect(full?.accontoDeductions[0]?.accontoInvoice?.id).toBe(accontoId);
     expect(full?.creditNote?.id).toBe(creditId);
+  });
+
+  it("listForOrg: org-scope via join + self-ref-berikning per rad", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const otherOrg = uuidv7();
+    const mId = uuidv7();
+    const otherMatter = uuidv7();
+    const finalId = uuidv7();
+    const accontoId = uuidv7();
+    const otherId = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
+    await db.insert(matters).values(v({ id: otherMatter, organizationId: otherOrg, matterNumber: "2026-2", title: "U" }));
+    await db.insert(invoices).values(inv({ id: finalId, matterId: mId, invoiceType: "FINAL", status: "SENT" }) as never);
+    await db.insert(invoices).values(inv({ id: accontoId, matterId: mId, invoiceType: "ACCONTO", status: "PAID" }) as never);
+    await db.insert(invoices).values(inv({ id: otherId, matterId: otherMatter, status: "SENT" }) as never);
+    await db.insert(accontoDeductions).values(v({ id: uuidv7(), finalInvoiceId: finalId, accontoInvoiceId: accontoId }));
+    await db.insert(payments).values(v({ id: uuidv7(), invoiceId: finalId, amount: 400, paidAt: new Date(), recordedById: uuidv7() }));
+
+    const repo = new DrizzleInvoiceRepository(handle.db as unknown as AppDb);
+    const all = await repo.listForOrg(org);
+    expect(all.map((i) => i.id).sort()).toEqual([finalId, accontoId].sort()); // annan org exkluderad
+    const final = all.find((i) => i.id === finalId)!;
+    expect(final.matter.matterNumber).toBe("2026-1");
+    expect(final.payments).toHaveLength(1);
+    expect(final.accontoDeductions[0]?.accontoInvoice?.id).toBe(accontoId);
+    expect((await repo.listForOrg(org, { status: "PAID" })).map((i) => i.id)).toEqual([accontoId]);
   });
 });


### PR DESCRIPTION
## What

Continues the ADR 0020 per-entity repository migration (follows #442 which migrated `invoice.getById`). Migrates `invoice.list` off the dynamic Prisma-shaped `ctx.dataStore.invoices.findMany` onto a typed `ctx.repos.invoices.listForOrg`.

### `listForOrg(orgId, filter?)`
New `InvoiceRepository` method (both impls) returning `InvoiceListRow[]`, matching the router's previous list include exactly:
- matter-subset (`id`/`matterNumber`/`title`), `paymentPlan`, `payments` (paidAt desc)
- `accontoDeductions`→`accontoInvoice`, `deductedOnFinals` (id only), `creditedInvoice` + `creditNote` (id/invoiceDate/amount)

Org-scoped via the matter, soft-delete filtered, ordered `invoiceDate` desc, with optional `matterId` / `invoiceType` / `status` filters.

- **In-memory** resolves all relations in one query-engine include (mirrors the old router call shape — so the existing mocked `findMany` assertions still hold).
- **Drizzle** inner-joins `matters` for org-scope + filters, and enriches each row's self-ref relations (`accontoDeductions` / `creditedInvoice` / `creditNote`) via secondary queries, exactly as `getByIdFull` does.

## Verification
- `bun run quality` — green, coverage gate green.
- `bun run build:demo` — green (97 HTML / 502 entities).
- New parity tests (in-memory + pglite): org-scope, filters, relations.

Refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)