### PR TITLE
refactor(repositories): extract DrizzleRepository base from invoice repo (ADR 0020)

### DIFF
--- a/src/lib/server/repositories/drizzle-invoice-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-repository.ts
@@ -13,27 +13,14 @@ import { and, desc, eq, isNull } from "drizzle-orm";
 import type { Invoice, Payment, WriteOff } from "@/lib/shared/schemas/billing";
 import { accontoDeductions, invoices, matters, paymentPlans, payments, writeOffs } from "../db/schema";
 import type { AppDb } from "../db/types";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
 import type {
   InvoiceFull, InvoiceListFilter, InvoiceListRow, InvoiceRepository, InvoiceWithLedger, InvoiceWithRelations,
 } from "./invoice-repository";
 
-export class DrizzleInvoiceRepository implements InvoiceRepository {
-  constructor(
-    private readonly db: AppDb,
-    private readonly now: () => Date = () => new Date(),
-  ) {}
-
-  async getById(id: string): Promise<Invoice | null> {
-    const rows = await this.db
-      .select().from(invoices)
-      .where(and(eq(invoices.id, id), isNull(invoices.deletedAt))).limit(1);
-    return (rows[0] as unknown as Invoice | undefined) ?? null;
-  }
-
-  async getByIdOrThrow(id: string): Promise<Invoice> {
-    const row = await this.getById(id);
-    if (!row) throw new Error(`Ingen faktura med id ${id}`);
-    return row;
+export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> implements InvoiceRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, invoices as unknown as VersionedTable, now);
   }
 
   async getByIdInOrg(id: string, organizationId: string): Promise<Invoice | null> {
@@ -46,28 +33,6 @@ export class DrizzleInvoiceRepository implements InvoiceRepository {
         isNull(invoices.deletedAt),
       )).limit(1);
     return (rows[0]?.inv as unknown as Invoice | undefined) ?? null;
-  }
-
-  async create(data: Partial<Invoice>): Promise<Invoice> {
-    const [row] = await this.db.insert(invoices)
-      .values({ ...data, version: 1 } as never).returning();
-    return row as unknown as Invoice;
-  }
-
-  async update(id: string, patch: Partial<Invoice>): Promise<Invoice> {
-    const current = await this.getByIdOrThrow(id);
-    const [row] = await this.db.update(invoices)
-      .set({ ...patch, version: nextVersion(current), updatedAt: this.now() } as never)
-      .where(eq(invoices.id, id)).returning();
-    return row as unknown as Invoice;
-  }
-
-  async softDelete(id: string): Promise<Invoice> {
-    const current = await this.getByIdOrThrow(id);
-    const [row] = await this.db.update(invoices)
-      .set({ deletedAt: this.now(), version: nextVersion(current) } as never)
-      .where(eq(invoices.id, id)).returning();
-    return row as unknown as Invoice;
   }
 
   /** Bar faktura-rad utan org/delete-filter (för self-ref-uppslag). */
@@ -173,8 +138,4 @@ export class DrizzleInvoiceRepository implements InvoiceRepository {
       .orderBy(desc(invoices.invoiceDate));
     return rows as unknown as Invoice[];
   }
-}
-
-function nextVersion(row: Invoice): number {
-  return ((row as { version?: number }).version ?? 1) + 1;
 }

--- a/src/lib/server/repositories/drizzle-repository.ts
+++ b/src/lib/server/repositories/drizzle-repository.ts
@@ -1,0 +1,67 @@
+/**
+ * `DrizzleRepository` (ADR 0020, #409 Fas 2 — fan-out-fundament) — server-bas
+ * för entitets-repositories, motsvarigheten till `InMemoryRepository`. Ärver
+ * bas-CRUD (getById/create/update/softDelete) så varje entitets-repo bara lägger
+ * sina TYPADE relations-/list-metoder, utan att duplicera reconcile-konventionerna.
+ *
+ * Centraliserar reconcile-app-nivå (ADR 0019): create→version 1, update→
+ * version-bump + updatedAt, softDelete→deletedAt (tombstone). Casterna vid
+ * Drizzle-gränsen (`as never` på values/set, `as unknown` på resultat) är
+ * medvetna: Drizzles rad-typ och zod-typen skiljer sig; strikt zod-parse vid
+ * gränsen läggs som delad helper i ett senare steg.
+ */
+
+import { and, eq, isNull, type AnyColumn } from "drizzle-orm";
+import type { PgTable } from "drizzle-orm/pg-core";
+import type { AppDb } from "../db/types";
+import type { Repository, RowBase } from "./types";
+
+/** En tabell med de reconcile-kolumner bas-CRUD:n läser/skriver. */
+export type VersionedTable = PgTable & Record<"id" | "deletedAt" | "version", AnyColumn>;
+
+export class DrizzleRepository<Row extends RowBase> implements Repository<Row> {
+  constructor(
+    protected readonly db: AppDb,
+    protected readonly table: VersionedTable,
+    protected readonly now: () => Date = () => new Date(),
+  ) {}
+
+  async getById(id: string): Promise<Row | null> {
+    const rows = await this.db
+      .select().from(this.table)
+      .where(and(eq(this.table.id, id), isNull(this.table.deletedAt))).limit(1);
+    return (rows[0] as unknown as Row | undefined) ?? null;
+  }
+
+  async getByIdOrThrow(id: string): Promise<Row> {
+    const row = await this.getById(id);
+    if (!row) throw new Error(`Ingen rad med id ${id}`);
+    return row;
+  }
+
+  async create(data: Partial<Row>): Promise<Row> {
+    const [row] = await this.db.insert(this.table)
+      .values({ ...data, version: 1 } as never).returning();
+    return row as unknown as Row;
+  }
+
+  async update(id: string, patch: Partial<Row>): Promise<Row> {
+    const current = await this.getByIdOrThrow(id);
+    const [row] = await this.db.update(this.table)
+      .set({ ...patch, version: nextVersion(current), updatedAt: this.now() } as never)
+      .where(eq(this.table.id, id)).returning();
+    return row as unknown as Row;
+  }
+
+  async softDelete(id: string): Promise<Row> {
+    const current = await this.getByIdOrThrow(id);
+    const [row] = await this.db.update(this.table)
+      .set({ deletedAt: this.now(), version: nextVersion(current) } as never)
+      .where(eq(this.table.id, id)).returning();
+    return row as unknown as Row;
+  }
+}
+
+function nextVersion(row: RowBase): number {
+  return (row.version ?? 1) + 1;
+}


### PR DESCRIPTION
## What

Groundwork for the next step of the ADR 0020 per-entity repository fan-out (follows #442 `getById` and #443 `list`).

Adds `DrizzleRepository<Row>` — the server-side counterpart to the existing `InMemoryRepository<Row>` — holding the shared base-CRUD (`getById`, `getByIdOrThrow`, `create`, `update`, `softDelete`) and the app-level reconcile conventions (create→version 1, update→version-bump + `updatedAt`, softDelete→`deletedAt`). The table is passed as a `VersionedTable` constructor arg, so each entity repo only adds its own typed relation/list methods.

`DrizzleInvoiceRepository` now `extends DrizzleRepository<Invoice>`, dropping the duplicated CRUD + local `nextVersion`.

## Why now

The next entity repo (`paymentPlans`, to migrate the transaction-based `cancelPaymentPlan`) would otherwise clone ~45 lines of identical Drizzle CRUD and trip the jscpd ratchet. Extracting the base first keeps the fan-out clean.

## Verification
- No behaviour change — the existing pglite parity tests (`assertContract` covering create/getById/update/softDelete + all relation reads) pass unchanged.
- `bun run quality` green (coverage gate green, clones unchanged at 13, deps + knip clean).
- `bun run build:demo` green.

Refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)