### PR TITLE
feat(repositories): add PaymentPlanRepository + migrate cancelPaymentPlan (ADR 0020)

### DIFF
--- a/src/lib/server/repositories/drizzle-payment-plan-repository.ts
+++ b/src/lib/server/repositories/drizzle-payment-plan-repository.ts
@@ -1,0 +1,31 @@
+/**
+ * Drizzle `PaymentPlanRepository` (ADR 0020) — server-impl. Ärver bas-CRUD från
+ * `DrizzleRepository`; org-scopningen joinar plan→faktura→ärende (planer saknar
+ * egen organizationId), spegling av in-memory-impl:ens relations-where.
+ */
+
+import { and, eq, isNull } from "drizzle-orm";
+import type { PaymentPlan } from "@/lib/shared/schemas/billing";
+import { invoices, matters, paymentPlans } from "../db/schema";
+import type { AppDb } from "../db/types";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import type { PaymentPlanRepository } from "./payment-plan-repository";
+
+export class DrizzlePaymentPlanRepository extends DrizzleRepository<PaymentPlan> implements PaymentPlanRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, paymentPlans as unknown as VersionedTable, now);
+  }
+
+  async getByIdInOrg(planId: string, organizationId: string): Promise<PaymentPlan | null> {
+    const rows = await this.db
+      .select({ plan: paymentPlans }).from(paymentPlans)
+      .innerJoin(invoices, eq(paymentPlans.invoiceId, invoices.id))
+      .innerJoin(matters, eq(invoices.matterId, matters.id))
+      .where(and(
+        eq(paymentPlans.id, planId),
+        eq(matters.organizationId, organizationId),
+        isNull(paymentPlans.deletedAt),
+      )).limit(1);
+    return (rows[0]?.plan as unknown as PaymentPlan | undefined) ?? null;
+  }
+}

--- a/src/lib/server/repositories/in-memory-payment-plan-repository.ts
+++ b/src/lib/server/repositories/in-memory-payment-plan-repository.ts
@@ -1,0 +1,25 @@
+/**
+ * In-memory `PaymentPlanRepository` (ADR 0020) — browser/offline-impl. Ärver
+ * bas-CRUD från `InMemoryRepository` (delegerar till LocalStore/query-engine);
+ * org-scopningen sker via samma relations-where routern använde (`invoice.matter`).
+ */
+
+import type { PaymentPlan } from "@/lib/shared/schemas/billing";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import { InMemoryRepository } from "./in-memory-repository";
+import type { PaymentPlanRepository } from "./payment-plan-repository";
+
+/** Delegaten repot behöver — uppfylls av `IDataStore`, `DataStoreTx` och `LocalStore`. */
+export type PaymentPlanRepoSource = Pick<IDataStore, "paymentPlans">;
+
+export class InMemoryPaymentPlanRepository extends InMemoryRepository<PaymentPlan> implements PaymentPlanRepository {
+  constructor(store: PaymentPlanRepoSource, now?: () => Date) {
+    super(store.paymentPlans as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async getByIdInOrg(planId: string, organizationId: string): Promise<PaymentPlan | null> {
+    const row = (await this.delegate
+      .findFirst({ where: { id: planId, invoice: { matter: { organizationId } } } })) as PaymentPlan | null;
+    return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
+  }
+}

--- a/src/lib/server/repositories/in-memory-repositories.ts
+++ b/src/lib/server/repositories/in-memory-repositories.ts
@@ -10,12 +10,14 @@
 
 import type { DataStoreTx, IDataStore } from "../data-store/IDataStore";
 import { InMemoryInvoiceRepository } from "./in-memory-invoice-repository";
+import { InMemoryPaymentPlanRepository } from "./in-memory-payment-plan-repository";
 import type { Repositories } from "./repositories";
 
 /** Repos-vy bunden till en transaktions-tx (reentrant transaction). */
 function reposForTx(tx: DataStoreTx): Repositories {
   const repos: Repositories = {
     invoices: new InMemoryInvoiceRepository(tx),
+    paymentPlans: new InMemoryPaymentPlanRepository(tx),
     transaction: (fn) => fn(repos),
   };
   return repos;
@@ -24,6 +26,7 @@ function reposForTx(tx: DataStoreTx): Repositories {
 export function buildInMemoryRepositories(dataStore: IDataStore): Repositories {
   return {
     invoices: new InMemoryInvoiceRepository(dataStore),
+    paymentPlans: new InMemoryPaymentPlanRepository(dataStore),
     transaction: (fn) => dataStore.transaction((tx) => fn(reposForTx(tx))),
   };
 }

--- a/src/lib/server/repositories/payment-plan-repository.ts
+++ b/src/lib/server/repositories/payment-plan-repository.ts
@@ -1,0 +1,14 @@
+/**
+ * `PaymentPlanRepository` (ADR 0020, #409 fan-out) — avbetalningsplaner.
+ * Bas-CRUD ärvs (in-memory: `InMemoryRepository`, server: `DrizzleRepository`);
+ * den enda entitets-specifika läsningen är org-scopning via faktura→ärende
+ * (planer har ingen egen organizationId).
+ */
+
+import type { PaymentPlan } from "@/lib/shared/schemas/billing";
+import type { Repository } from "./types";
+
+export interface PaymentPlanRepository extends Repository<PaymentPlan> {
+  /** Plan by id, org-scopad via faktura→ärende (null om saknas/annan org/raderad). */
+  getByIdInOrg(planId: string, organizationId: string): Promise<PaymentPlan | null>;
+}

--- a/src/lib/server/repositories/repositories.ts
+++ b/src/lib/server/repositories/repositories.ts
@@ -6,8 +6,10 @@
  */
 
 import type { InvoiceRepository } from "./invoice-repository";
+import type { PaymentPlanRepository } from "./payment-plan-repository";
 
 export interface Repositories {
   invoices: InvoiceRepository;
+  paymentPlans: PaymentPlanRepository;
   transaction<T>(fn: (tx: Repositories) => Promise<T>): Promise<T>;
 }

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -531,26 +531,17 @@ export const invoiceRouter = router({
 
   cancelPaymentPlan: orgProcedure
     .input(z.object({ planId: z.string() }))
-    .mutation(async ({ ctx, input }) => {
-      return ctx.dataStore.transaction(async (tx) => {
-        const plan = await tx.paymentPlans.findFirst({
-          where: {
-            id: input.planId,
-            invoice: { matter: { organizationId: ctx.orgId } },
-          },
-        });
+    // Migrerad till repository-sömmen (ADR 0020). Transaktionen korsar två repos
+    // (paymentPlans + invoices); getByIdInOrg org-scopar via faktura→ärende.
+    .mutation(({ ctx, input }) =>
+      ctx.repos.transaction(async (repos) => {
+        const plan = await repos.paymentPlans.getByIdInOrg(input.planId, ctx.orgId);
         if (!plan) throw new TRPCError({ code: "NOT_FOUND" });
-        await tx.paymentPlans.update({
-          where: { id: plan.id },
-          data: { status: "CANCELLED" },
-        });
-        await tx.invoices.update({
-          where: { id: plan.invoiceId },
-          data: { status: "SENT" },
-        });
+        await repos.paymentPlans.update(plan.id, { status: "CANCELLED" });
+        await repos.invoices.update(plan.invoiceId, { status: "SENT" });
         return { ok: true };
-      });
-    }),
+      }),
+    ),
 
   /**
    * Boka en konstaterad kundförlust (ADR 0007). Skapar en daterad WriteOff-post

--- a/test/unit/server/repositories/payment-plan-repository.test.ts
+++ b/test/unit/server/repositories/payment-plan-repository.test.ts
@@ -1,0 +1,87 @@
+/**
+ * PaymentPlanRepository-paritet (ADR 0020, #409 fan-out) — SAMMA kontrakt mot
+ * båda impls: in-memory (LocalStore) och Drizzle (pglite). Bevisar bas-CRUD
+ * (ärvd) + den entitets-specifika org-scopningen via faktura→ärende.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { invoices, matters, paymentPlans } from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzlePaymentPlanRepository } from "@/lib/server/repositories/drizzle-payment-plan-repository";
+import { InMemoryPaymentPlanRepository } from "@/lib/server/repositories/in-memory-payment-plan-repository";
+import type { PaymentPlanRepository } from "@/lib/server/repositories/payment-plan-repository";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+const planId = uuidv7();
+const invoiceId = uuidv7();
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const plan = (o: Record<string, unknown> = {}): any => ({
+  id: planId, invoiceId, monthlyAmount: 100_000, dayOfMonth: 15,
+  startDate: new Date("2026-06-01T00:00:00.000Z"), status: "ACTIVE", ...o,
+});
+
+/** Delat kontrakt — körs identiskt mot varje backend. */
+async function assertContract(repo: PaymentPlanRepository): Promise<void> {
+  const created = await repo.create(plan());
+  expect(created.status).toBe("ACTIVE");
+  expect((created as { version?: number }).version).toBe(1);
+
+  expect(await repo.getById(planId)).toMatchObject({ id: planId });
+  expect(await repo.getById(uuidv7())).toBeNull();
+
+  const updated = await repo.update(planId, { status: "CANCELLED" });
+  expect(updated.status).toBe("CANCELLED");
+  expect((updated as { version?: number }).version).toBe(2);
+
+  await repo.softDelete(planId);
+  expect(await repo.getById(planId)).toBeNull();
+}
+
+describe("PaymentPlanRepository — in-memory", () => {
+  it("uppfyller kontraktet", async () => {
+    const store = new LocalStore({ paymentPlans: [] }, async () => {});
+    await assertContract(new InMemoryPaymentPlanRepository(store));
+  });
+
+  it("getByIdInOrg org-scopar via faktura→ärende", async () => {
+    const matterId = uuidv7();
+    const store = new LocalStore({
+      matters: [{ id: matterId, organizationId: "org-1" }],
+      invoices: [{ id: invoiceId, matterId, amount: 1, status: "INSTALLMENT_PLAN" }],
+      paymentPlans: [plan({ id: planId, invoiceId })],
+    }, async () => {});
+    const repo = new InMemoryPaymentPlanRepository(store);
+    expect(await repo.getByIdInOrg(planId, "org-1")).toMatchObject({ id: planId });
+    expect(await repo.getByIdInOrg(planId, "org-2")).toBeNull(); // fel org
+  });
+});
+
+describe("PaymentPlanRepository — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("uppfyller kontraktet", async () => {
+    await assertContract(new DrizzlePaymentPlanRepository(handle.db as unknown as AppDb));
+  });
+
+  it("getByIdInOrg org-scopar via join faktura→ärende", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const mId = uuidv7();
+    const invId = uuidv7();
+    const pId = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
+    await db.insert(invoices).values(v({ id: invId, matterId: mId, amount: 1, status: "INSTALLMENT_PLAN", invoiceDate: new Date() }));
+    await db.insert(paymentPlans).values(v({ id: pId, invoiceId: invId, monthlyAmount: 100, dayOfMonth: 15, startDate: new Date(), status: "ACTIVE" }));
+
+    const repo = new DrizzlePaymentPlanRepository(handle.db as unknown as AppDb);
+    expect(await repo.getByIdInOrg(pId, org)).toMatchObject({ id: pId });
+    expect(await repo.getByIdInOrg(pId, uuidv7())).toBeNull(); // fel org
+  });
+});

--- a/test/unit/server/routers/invoice.test.ts
+++ b/test/unit/server/routers/invoice.test.ts
@@ -510,17 +510,20 @@ describe("invoice.createPaymentPlan", () => {
 describe("invoice.cancelPaymentPlan", () => {
   it("sätter plan CANCELLED och invoice tillbaka till SENT", async () => {
     mockPrisma.paymentPlan.findFirst.mockResolvedValue({ id: "plan-1", invoiceId: "inv-1" });
+    // Repository-sömmens update läser nuvarande rad (version-bump) före skrivning.
+    mockPrisma.invoice.findFirst.mockResolvedValue({ id: "inv-1", status: "INSTALLMENT_PLAN" });
 
     await makeCaller().cancelPaymentPlan({ planId: "plan-1" });
 
-    expect(mockPrisma.paymentPlan.update).toHaveBeenCalledWith({
+    // objectContaining: repo:t lägger till version/updatedAt i data utöver status.
+    expect(mockPrisma.paymentPlan.update).toHaveBeenCalledWith(expect.objectContaining({
       where: { id: "plan-1" },
-      data: { status: "CANCELLED" },
-    });
-    expect(mockPrisma.invoice.update).toHaveBeenCalledWith({
+      data: expect.objectContaining({ status: "CANCELLED" }),
+    }));
+    expect(mockPrisma.invoice.update).toHaveBeenCalledWith(expect.objectContaining({
       where: { id: "inv-1" },
-      data: { status: "SENT" },
-    });
+      data: expect.objectContaining({ status: "SENT" }),
+    }));
   });
 
   it("NOT_FOUND om planen tillhör annan org", async () => {


### PR DESCRIPTION
## What

Next entity in the ADR 0020 fan-out (follows #442 getById, #443 list, #444 DrizzleRepository base). First repository **transaction crossing two repos**.

### `PaymentPlanRepository`
Both impls, built on the shared bases (`InMemoryRepository` / `DrizzleRepository` from #444 — so no CRUD duplication). The only entity-specific method is `getByIdInOrg`, org-scoped via faktura→ärende since payment plans carry no `organizationId` of their own (in-memory: relations-where; Drizzle: join plan→invoice→matter).

Added `paymentPlans` to the `Repositories` aggregate and wired into `buildInMemoryRepositories` + the tx-bound `reposForTx` view.

### `cancelPaymentPlan` migration
Moved off `ctx.dataStore.transaction(tx => …)` onto `ctx.repos.transaction(repos => …)`, calling `repos.paymentPlans.getByIdInOrg` / `.update` and `repos.invoices.update`. This establishes the multi-entity-transaction pattern for the remaining invoice mutations (`recordPayment`, `writeOff`, `createFinal`, …).

### Test
The mocked router test now reflects the repository seam: base `update` reads the current row for the version-bump and adds `version`/`updatedAt` to the patch, so assertions use `objectContaining`. The NOT_FOUND-cross-org test is unchanged.

## Verification
- `bun run quality` green (coverage gate green, clones unchanged at 13, deps + knip clean).
- `bun run build:demo` green.
- New parity tests (in-memory + pglite): contract (create/getById/update/softDelete) + org-scope.

Refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)