### PR TITLE
feat(repositories): add MatterRepository + nextInvoiceNumber; migrate createAcconto (ADR 0020)

### DIFF
--- a/src/lib/server/repositories/drizzle-invoice-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-repository.ts
@@ -9,13 +9,15 @@
  * helper när vi fan-out:ar entiteterna; pilotens korrekthet bevisas av pglite-testerna.
  */
 
-import { and, desc, eq, isNull } from "drizzle-orm";
+import { and, desc, eq, isNull, like } from "drizzle-orm";
 import type { Invoice, Payment, WriteOff } from "@/lib/shared/schemas/billing";
 import { accontoDeductions, invoices, matters, paymentPlans, payments, writeOffs } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
-import type {
-  InvoiceFull, InvoiceListFilter, InvoiceListRow, InvoiceRepository, InvoiceWithLedger, InvoiceWithRelations,
+import {
+  invoiceNumberPrefix, nextInvoiceNumberFrom,
+  type InvoiceFull, type InvoiceListFilter, type InvoiceListRow, type InvoiceRepository,
+  type InvoiceWithLedger, type InvoiceWithRelations,
 } from "./invoice-repository";
 
 export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> implements InvoiceRepository {
@@ -121,6 +123,16 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
         creditNote: (creditNoteRows[0] as unknown as InvoiceListRow["creditNote"]) ?? null,
       };
     })) as unknown as InvoiceListRow[];
+  }
+
+  async nextInvoiceNumber(organizationId: string): Promise<string> {
+    const prefix = invoiceNumberPrefix(this.now().getFullYear());
+    const rows = await this.db
+      .select({ invoiceNumber: invoices.invoiceNumber }).from(invoices)
+      .innerJoin(matters, eq(invoices.matterId, matters.id))
+      .where(and(eq(matters.organizationId, organizationId), like(invoices.invoiceNumber, `${prefix}%`)))
+      .orderBy(desc(invoices.invoiceNumber)).limit(1);
+    return nextInvoiceNumberFrom(prefix, rows[0]?.invoiceNumber);
   }
 
   async getByIdWithLedger(id: string): Promise<InvoiceWithLedger | null> {

--- a/src/lib/server/repositories/drizzle-matter-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-repository.ts
@@ -1,0 +1,25 @@
+/**
+ * Drizzle `MatterRepository` (ADR 0020) — server-impl. Ärver bas-CRUD;
+ * org-scopar direkt på `matters.organizationId` (ingen join).
+ */
+
+import { and, eq, isNull } from "drizzle-orm";
+import type { Matter } from "@/lib/shared/schemas/matter";
+import { matters } from "../db/schema";
+import type { AppDb } from "../db/types";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import type { MatterRepository } from "./matter-repository";
+
+export class DrizzleMatterRepository extends DrizzleRepository<Matter> implements MatterRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, matters as unknown as VersionedTable, now);
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<Matter | null> {
+    const rows = await this.db
+      .select().from(matters)
+      .where(and(eq(matters.id, id), eq(matters.organizationId, organizationId), isNull(matters.deletedAt)))
+      .limit(1);
+    return (rows[0] as unknown as Matter | undefined) ?? null;
+  }
+}

--- a/src/lib/server/repositories/in-memory-invoice-repository.ts
+++ b/src/lib/server/repositories/in-memory-invoice-repository.ts
@@ -7,8 +7,10 @@
 import type { Invoice } from "@/lib/shared/schemas/billing";
 import type { Delegate, IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
-import type {
-  InvoiceFull, InvoiceListFilter, InvoiceListRow, InvoiceRepository, InvoiceWithLedger, InvoiceWithRelations,
+import {
+  invoiceNumberPrefix, nextInvoiceNumberFrom,
+  type InvoiceFull, type InvoiceListFilter, type InvoiceListRow, type InvoiceRepository,
+  type InvoiceWithLedger, type InvoiceWithRelations,
 } from "./invoice-repository";
 
 /** Delegaterna repot behöver — uppfylls av `IDataStore`, `DataStoreTx` och `LocalStore`. */
@@ -96,6 +98,15 @@ export class InMemoryInvoiceRepository extends InMemoryRepository<Invoice> imple
       },
     })) as InvoiceListRow[];
     return rows.filter((r) => !(r as { deletedAt?: unknown }).deletedAt);
+  }
+
+  async nextInvoiceNumber(organizationId: string): Promise<string> {
+    const prefix = invoiceNumberPrefix(this.now().getFullYear());
+    const last = (await (this.store.invoices as unknown as Delegate).findFirst({
+      where: { matter: { organizationId }, invoiceNumber: { startsWith: prefix } },
+      orderBy: { invoiceNumber: "desc" },
+    })) as { invoiceNumber?: string | null } | null;
+    return nextInvoiceNumberFrom(prefix, last?.invoiceNumber);
   }
 
   async listByMatter(matterId: string): Promise<Invoice[]> {

--- a/src/lib/server/repositories/in-memory-matter-repository.ts
+++ b/src/lib/server/repositories/in-memory-matter-repository.ts
@@ -1,0 +1,23 @@
+/**
+ * In-memory `MatterRepository` (ADR 0020) — browser/offline-impl. Ärver bas-CRUD
+ * och org-scopar direkt på `organizationId` (ärenden saknar relations-beroende).
+ */
+
+import type { Matter } from "@/lib/shared/schemas/matter";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import { InMemoryRepository } from "./in-memory-repository";
+import type { MatterRepository } from "./matter-repository";
+
+/** Delegaten repot behöver — uppfylls av `IDataStore`, `DataStoreTx` och `LocalStore`. */
+export type MatterRepoSource = Pick<IDataStore, "matters">;
+
+export class InMemoryMatterRepository extends InMemoryRepository<Matter> implements MatterRepository {
+  constructor(store: MatterRepoSource, now?: () => Date) {
+    super(store.matters as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<Matter | null> {
+    const row = (await this.delegate.findFirst({ where: { id, organizationId } })) as Matter | null;
+    return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
+  }
+}

--- a/src/lib/server/repositories/in-memory-repositories.ts
+++ b/src/lib/server/repositories/in-memory-repositories.ts
@@ -10,6 +10,7 @@
 
 import type { DataStoreTx, IDataStore } from "../data-store/IDataStore";
 import { InMemoryInvoiceRepository } from "./in-memory-invoice-repository";
+import { InMemoryMatterRepository } from "./in-memory-matter-repository";
 import { InMemoryPaymentPlanRepository } from "./in-memory-payment-plan-repository";
 import type { Repositories } from "./repositories";
 
@@ -17,6 +18,7 @@ import type { Repositories } from "./repositories";
 function reposForTx(tx: DataStoreTx): Repositories {
   const repos: Repositories = {
     invoices: new InMemoryInvoiceRepository(tx),
+    matters: new InMemoryMatterRepository(tx),
     paymentPlans: new InMemoryPaymentPlanRepository(tx),
     transaction: (fn) => fn(repos),
   };
@@ -26,6 +28,7 @@ function reposForTx(tx: DataStoreTx): Repositories {
 export function buildInMemoryRepositories(dataStore: IDataStore): Repositories {
   return {
     invoices: new InMemoryInvoiceRepository(dataStore),
+    matters: new InMemoryMatterRepository(dataStore),
     paymentPlans: new InMemoryPaymentPlanRepository(dataStore),
     transaction: (fn) => dataStore.transaction((tx) => fn(reposForTx(tx))),
   };

--- a/src/lib/server/repositories/invoice-repository.ts
+++ b/src/lib/server/repositories/invoice-repository.ts
@@ -69,6 +69,19 @@ export interface InvoiceListRow extends Invoice {
   creditNote: Pick<Invoice, "id" | "invoiceDate" | "amount"> | null;
 }
 
+/** Fakturanummer-prefix för ett år (`F-YYYY-`). Delad mellan repo-impls + router. */
+export function invoiceNumberPrefix(year: number): string {
+  return `F-${year}-`;
+}
+
+/** Nästa nummer givet prefix + senaste numret (öka sekvensen, annars 0001). */
+export function nextInvoiceNumberFrom(prefix: string, lastNumber: string | null | undefined): string {
+  const seq = lastNumber && lastNumber.startsWith(prefix)
+    ? parseInt(lastNumber.slice(prefix.length), 10) + 1
+    : 1;
+  return `${prefix}${seq.toString().padStart(4, "0")}`;
+}
+
 export interface InvoiceRepository extends Repository<Invoice> {
   /** Faktura by id, org-scopad via ärendet (null om saknas/annan org/raderad). */
   getByIdInOrg(id: string, organizationId: string): Promise<Invoice | null>;
@@ -80,6 +93,8 @@ export interface InvoiceRepository extends Repository<Invoice> {
   getByIdWithRelations(id: string, organizationId: string): Promise<InvoiceWithRelations | null>;
   /** Org-bred fakturalista (listvyns include), nyaste först, valfritt filtrerad. */
   listForOrg(organizationId: string, filter?: InvoiceListFilter): Promise<InvoiceListRow[]>;
+  /** Nästa lediga fakturanummer (`F-YYYY-NNNN`) för org:en (året från repots klocka). */
+  nextInvoiceNumber(organizationId: string): Promise<string>;
   /** Alla (icke-raderade) fakturor i ett ärende, nyaste först. */
   listByMatter(matterId: string): Promise<Invoice[]>;
 }

--- a/src/lib/server/repositories/matter-repository.ts
+++ b/src/lib/server/repositories/matter-repository.ts
@@ -1,0 +1,15 @@
+/**
+ * `MatterRepository` (ADR 0020, #409 fan-out) — ärenden. Nästan varje
+ * faktura-mutation börjar med en org-scopad ärende-uppslagning, så detta är
+ * fundamentet som de transaktions-mutationerna stegvis migrerar ovanpå.
+ * Bas-CRUD ärvs; `getByIdInOrg` är den enda entitets-specifika läsningen
+ * (ärenden bär `organizationId` direkt → enkel where, ingen join).
+ */
+
+import type { Matter } from "@/lib/shared/schemas/matter";
+import type { Repository } from "./types";
+
+export interface MatterRepository extends Repository<Matter> {
+  /** Ärende by id, org-scopat (null om saknas/annan org/raderat). */
+  getByIdInOrg(id: string, organizationId: string): Promise<Matter | null>;
+}

--- a/src/lib/server/repositories/repositories.ts
+++ b/src/lib/server/repositories/repositories.ts
@@ -6,10 +6,12 @@
  */
 
 import type { InvoiceRepository } from "./invoice-repository";
+import type { MatterRepository } from "./matter-repository";
 import type { PaymentPlanRepository } from "./payment-plan-repository";
 
 export interface Repositories {
   invoices: InvoiceRepository;
+  matters: MatterRepository;
   paymentPlans: PaymentPlanRepository;
   transaction<T>(fn: (tx: Repositories) => Promise<T>): Promise<T>;
 }

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -20,6 +20,7 @@ import { canTransition, transitionErrorMessage } from "@/lib/shared/invoice-stat
 import { ocrFromInvoiceNumber } from "@/lib/shared/ocr-reference";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { computeRadgivningsavgift } from "@/lib/shared/rattshjalp";
+import type { Invoice } from "@/lib/shared/schemas/billing";
 import type { InvoiceStatus } from "@/lib/shared/schemas/enums";
 import {
   asId,
@@ -33,6 +34,7 @@ import {
 import { computeInvoiceLedger, deriveInvoiceStatus, invoicePartitionViolation } from "@/lib/shared/write-off-calc";
 import type { DataStoreTx } from "../data-store/IDataStore";
 import { emit } from "../events/emit";
+import { invoiceNumberPrefix, nextInvoiceNumberFrom } from "../repositories/invoice-repository";
 import { router, orgProcedure } from "../trpc";
 
 // ─── createFinal-hjälpare (validera + koppla poster) ──────────────
@@ -143,18 +145,21 @@ function resolveWriteOffAmount(outstanding: number, requested?: number): number 
   return amount;
 }
 
-/** Nästa lediga fakturanummer (F-YYYY-NNNN) för org:en. Speglar nextMatterNumber. */
+/**
+ * Nästa lediga fakturanummer (F-YYYY-NNNN) för org:en. Kvarvarande tx-väg för
+ * de ännu icke-migrerade mutationerna (createRadgivning/createFinal/createCredit);
+ * delar format-logiken med `InvoiceRepository.nextInvoiceNumber` (ADR 0020).
+ */
 async function nextInvoiceNumber(
   invoices: { findFirst: (args: unknown) => Promise<unknown> },
   orgId: string,
 ): Promise<string> {
-  const prefix = `F-${new Date().getFullYear()}-`;
+  const prefix = invoiceNumberPrefix(new Date().getFullYear());
   const last = (await invoices.findFirst({
     where: { matter: { organizationId: orgId }, invoiceNumber: { startsWith: prefix } },
     orderBy: { invoiceNumber: "desc" },
   })) as { invoiceNumber?: string | null } | null;
-  const seq = last?.invoiceNumber ? parseInt(last.invoiceNumber.slice(prefix.length), 10) + 1 : 1;
-  return `${prefix}${seq.toString().padStart(4, "0")}`;
+  return nextInvoiceNumberFrom(prefix, last?.invoiceNumber);
 }
 
 const invoiceTypeSchema = z.enum(["STANDARD", "ACCONTO", "FINAL"]);
@@ -203,14 +208,14 @@ export const invoiceRouter = router({
         notes: z.string().optional(),
       }),
     )
+    // Migrerad till repository-sömmen (ADR 0020): org-scopad ärende-koll +
+    // typad nummergenerering + create (inget dynamiskt where/data-objekt).
     .mutation(async ({ ctx, input }) => {
-      const matter = await ctx.dataStore.matters.findFirst({
-        where: { id: input.matterId, organizationId: ctx.orgId },
-      });
+      const matter = await ctx.repos.matters.getByIdInOrg(input.matterId, ctx.orgId);
       if (!matter) throw new TRPCError({ code: "NOT_FOUND" });
-      const accontoNumber = await nextInvoiceNumber(ctx.dataStore.invoices, ctx.orgId);
-      const invoice = await ctx.dataStore.invoices.create({
-        data: omitUndefined({
+      const accontoNumber = await ctx.repos.invoices.nextInvoiceNumber(ctx.orgId);
+      const invoice = await ctx.repos.invoices.create(
+        omitUndefined({
           id: input.id, // undefined → store genererar
           matterId: input.matterId,
           invoiceNumber: accontoNumber,
@@ -223,8 +228,8 @@ export const invoiceRouter = router({
           invoiceDate: input.invoiceDate ? new Date(input.invoiceDate) : new Date(),
           dueDate: input.dueDate ? new Date(input.dueDate) : null,
           notes: input.notes,
-        }),
-      });
+        }) as Partial<Invoice>,
+      );
       await emit.invoiceCreated(ctx, invoice);
       return invoice;
     }),

--- a/test/unit/server/repositories/invoice-repository.test.ts
+++ b/test/unit/server/repositories/invoice-repository.test.ts
@@ -147,6 +147,21 @@ describe("InvoiceRepository — in-memory", () => {
     expect((await repo.listForOrg("org-1", { status: "PAID" })).map((i) => i.id)).toEqual([accontoId]);
     expect((await repo.listForOrg("org-1", { invoiceType: "FINAL" })).map((i) => i.id)).toEqual([invId]);
   });
+
+  it("nextInvoiceNumber ökar sekvensen per org/år", async () => {
+    const mId = uuidv7();
+    const store = new LocalStore({
+      matters: [{ id: mId, organizationId: "org-1" }],
+      invoices: [
+        inv({ id: uuidv7(), matterId: mId, invoiceNumber: "F-2026-0001" }),
+        inv({ id: uuidv7(), matterId: mId, invoiceNumber: "F-2026-0002" }),
+      ],
+      payments: [], writeOffs: [],
+    }, async () => {});
+    const repo = new InMemoryInvoiceRepository(store, () => new Date("2026-06-01T00:00:00.000Z"));
+    expect(await repo.nextInvoiceNumber("org-1")).toBe("F-2026-0003");
+    expect(await repo.nextInvoiceNumber("org-2")).toBe("F-2026-0001"); // tom org → 0001
+  });
 });
 
 describe("InvoiceRepository — Drizzle (pglite)", () => {
@@ -267,5 +282,19 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
     expect(final.payments).toHaveLength(1);
     expect(final.accontoDeductions[0]?.accontoInvoice?.id).toBe(accontoId);
     expect((await repo.listForOrg(org, { status: "PAID" })).map((i) => i.id)).toEqual([accontoId]);
+  });
+
+  it("nextInvoiceNumber ökar sekvensen per org/år (join mot matters)", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const mId = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
+    await db.insert(invoices).values(inv({ id: uuidv7(), matterId: mId, invoiceNumber: "F-2026-0001" }) as never);
+    await db.insert(invoices).values(inv({ id: uuidv7(), matterId: mId, invoiceNumber: "F-2026-0002" }) as never);
+    const repo = new DrizzleInvoiceRepository(handle.db as unknown as AppDb, () => new Date("2026-06-01T00:00:00.000Z"));
+    expect(await repo.nextInvoiceNumber(org)).toBe("F-2026-0003");
+    expect(await repo.nextInvoiceNumber(uuidv7())).toBe("F-2026-0001"); // tom org → 0001
   });
 });

--- a/test/unit/server/repositories/matter-repository.test.ts
+++ b/test/unit/server/repositories/matter-repository.test.ts
@@ -1,0 +1,83 @@
+/**
+ * MatterRepository-paritet (ADR 0020, #409 fan-out) — SAMMA kontrakt mot båda
+ * impls: in-memory (LocalStore) och Drizzle (pglite). Bas-CRUD (ärvd) + den
+ * direkta org-scopningen (`getByIdInOrg`, ärenden bär organizationId själva).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { matters } from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzleMatterRepository } from "@/lib/server/repositories/drizzle-matter-repository";
+import { InMemoryMatterRepository } from "@/lib/server/repositories/in-memory-matter-repository";
+import type { MatterRepository } from "@/lib/server/repositories/matter-repository";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+const matterId = uuidv7();
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const matter = (o: Record<string, unknown> = {}): any => ({
+  id: matterId, organizationId: "org-1", matterNumber: "2026-0001", title: "Test", status: "ACTIVE", ...o,
+});
+
+async function assertContract(repo: MatterRepository): Promise<void> {
+  const created = await repo.create(matter());
+  expect(created.matterNumber).toBe("2026-0001");
+  expect((created as { version?: number }).version).toBe(1);
+
+  expect(await repo.getById(matterId)).toMatchObject({ id: matterId });
+  expect(await repo.getById(uuidv7())).toBeNull();
+
+  const updated = await repo.update(matterId, { title: "Ny titel" });
+  expect(updated.title).toBe("Ny titel");
+  expect((updated as { version?: number }).version).toBe(2);
+
+  await repo.softDelete(matterId);
+  expect(await repo.getById(matterId)).toBeNull();
+}
+
+describe("MatterRepository — in-memory", () => {
+  it("uppfyller kontraktet", async () => {
+    const store = new LocalStore({ matters: [] }, async () => {});
+    await assertContract(new InMemoryMatterRepository(store));
+  });
+
+  it("getByIdInOrg org-scopar direkt på organizationId", async () => {
+    const store = new LocalStore({ matters: [matter({ id: matterId, organizationId: "org-1" })] }, async () => {});
+    const repo = new InMemoryMatterRepository(store);
+    expect(await repo.getByIdInOrg(matterId, "org-1")).toMatchObject({ id: matterId });
+    expect(await repo.getByIdInOrg(matterId, "org-2")).toBeNull(); // fel org
+  });
+});
+
+describe("MatterRepository — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("uppfyller kontraktet", async () => {
+    const org = uuidv7();
+    const repo = new DrizzleMatterRepository(handle.db as unknown as AppDb);
+    // org-kolumnen är uuid → kontraktets create() måste ha giltig UUID-org.
+    const id = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const created = await repo.create({ id, organizationId: org, matterNumber: "2026-9", title: "T" } as any);
+    expect((created as { version?: number }).version).toBe(1);
+    const updated = await repo.update(id, { title: "Ny" });
+    expect((updated as { version?: number }).version).toBe(2);
+    await repo.softDelete(id);
+    expect(await repo.getById(id)).toBeNull();
+  });
+
+  it("getByIdInOrg org-scopar direkt på organizationId", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const id = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await db.insert(matters).values({ id, organizationId: org, matterNumber: "2026-2", title: "T", version: 1 } as any);
+    const repo = new DrizzleMatterRepository(handle.db as unknown as AppDb);
+    expect(await repo.getByIdInOrg(id, org)).toMatchObject({ id });
+    expect(await repo.getByIdInOrg(id, uuidv7())).toBeNull(); // fel org
+  });
+});


### PR DESCRIPTION
## What

Next entity in the ADR 0020 fan-out (follows #442/#443/#444/#445). Introduces `matters` — the entity nearly every invoice mutation starts from — and migrates the first invoice **creation** path.

### `MatterRepository`
Both impls on the shared bases (#444), with the only entity-specific method `getByIdInOrg` — matters carry `organizationId` directly, so a plain where (no join). Wired into the `Repositories` aggregate + both builders.

### `InvoiceRepository.nextInvoiceNumber(orgId)`
Typed numbering method (both impls). The sequence-format logic is extracted to shared pure helpers (`invoiceNumberPrefix` / `nextInvoiceNumberFrom`) reused by the router's remaining tx-path `nextInvoiceNumber` helper — so no duplication and the two paths can't diverge. The year comes from the repo's injectable clock (deterministic tests).

### `createAcconto` migration
This mutation isn't transactional, so it migrates cleanly off `ctx.dataStore`:
`ctx.repos.matters.getByIdInOrg` (org-scope) + `ctx.repos.invoices.nextInvoiceNumber` + `ctx.repos.invoices.create`.

## Why matters now

The remaining transactional mutations (`recordPayment`, `writeOff`, `createFinal`, …) all open with an org-scoped matter lookup. Landing `MatterRepository` first de-fangs those migrations incrementally. (Those still need a shared-ledger-via-repos design + a hard-delete policy decision for `createPaymentPlan`, so they're deliberately not in this PR.)

## Verification
- `bun run quality` green (coverage gate green, clones unchanged at 13, deps + knip clean).
- `bun run build:demo` green.
- New parity tests (in-memory + pglite): MatterRepository contract + org-scope; invoice numbering sequence per org/year.

Refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)