### PR TITLE
feat(repositories): ledger-via-repos — migrate recordPayment + writeOff (ADR 0020)

### DIFF
--- a/src/lib/server/repositories/drizzle-invoice-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-repository.ts
@@ -9,7 +9,7 @@
  * helper när vi fan-out:ar entiteterna; pilotens korrekthet bevisas av pglite-testerna.
  */
 
-import { and, desc, eq, isNull, like } from "drizzle-orm";
+import { and, desc, eq, isNull, like, sql } from "drizzle-orm";
 import type { Invoice, Payment, WriteOff } from "@/lib/shared/schemas/billing";
 import { accontoDeductions, invoices, matters, paymentPlans, payments, writeOffs } from "../db/schema";
 import type { AppDb } from "../db/types";
@@ -133,6 +133,18 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
       .where(and(eq(matters.organizationId, organizationId), like(invoices.invoiceNumber, `${prefix}%`)))
       .orderBy(desc(invoices.invoiceNumber)).limit(1);
     return nextInvoiceNumberFrom(prefix, rows[0]?.invoiceNumber);
+  }
+
+  async sumCreditNotesFor(invoiceId: string, organizationId: string): Promise<number> {
+    const rows = await this.db
+      .select({ total: sql<number>`coalesce(sum(abs(${invoices.amount})), 0)` }).from(invoices)
+      .innerJoin(matters, eq(invoices.matterId, matters.id))
+      .where(and(
+        eq(invoices.creditedInvoiceId, invoiceId),
+        eq(matters.organizationId, organizationId),
+        isNull(invoices.deletedAt),
+      ));
+    return Number(rows[0]?.total ?? 0);
   }
 
   async getByIdWithLedger(id: string): Promise<InvoiceWithLedger | null> {

--- a/src/lib/server/repositories/drizzle-payment-plan-repository.ts
+++ b/src/lib/server/repositories/drizzle-payment-plan-repository.ts
@@ -28,4 +28,11 @@ export class DrizzlePaymentPlanRepository extends DrizzleRepository<PaymentPlan>
       )).limit(1);
     return (rows[0]?.plan as unknown as PaymentPlan | undefined) ?? null;
   }
+
+  async getByInvoiceId(invoiceId: string): Promise<PaymentPlan | null> {
+    const rows = await this.db
+      .select().from(paymentPlans)
+      .where(and(eq(paymentPlans.invoiceId, invoiceId), isNull(paymentPlans.deletedAt))).limit(1);
+    return (rows[0] as unknown as PaymentPlan | undefined) ?? null;
+  }
 }

--- a/src/lib/server/repositories/drizzle-payment-repository.ts
+++ b/src/lib/server/repositories/drizzle-payment-repository.ts
@@ -1,0 +1,24 @@
+/**
+ * Drizzle `PaymentRepository` (ADR 0020) — server-impl. Ärver bas-CRUD;
+ * `sumByInvoice` summerar i SQL (COALESCE(SUM(amount), 0)) bland icke-raderade.
+ */
+
+import { and, eq, isNull, sql } from "drizzle-orm";
+import type { Payment } from "@/lib/shared/schemas/billing";
+import { payments } from "../db/schema";
+import type { AppDb } from "../db/types";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import type { PaymentRepository } from "./payment-repository";
+
+export class DrizzlePaymentRepository extends DrizzleRepository<Payment> implements PaymentRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, payments as unknown as VersionedTable, now);
+  }
+
+  async sumByInvoice(invoiceId: string): Promise<number> {
+    const rows = await this.db
+      .select({ total: sql<number>`coalesce(sum(${payments.amount}), 0)` }).from(payments)
+      .where(and(eq(payments.invoiceId, invoiceId), isNull(payments.deletedAt)));
+    return Number(rows[0]?.total ?? 0);
+  }
+}

--- a/src/lib/server/repositories/drizzle-write-off-repository.ts
+++ b/src/lib/server/repositories/drizzle-write-off-repository.ts
@@ -1,0 +1,24 @@
+/**
+ * Drizzle `WriteOffRepository` (ADR 0020) — server-impl. Ärver bas-CRUD;
+ * `sumByInvoice` summerar i SQL bland icke-raderade.
+ */
+
+import { and, eq, isNull, sql } from "drizzle-orm";
+import type { WriteOff } from "@/lib/shared/schemas/billing";
+import { writeOffs } from "../db/schema";
+import type { AppDb } from "../db/types";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import type { WriteOffRepository } from "./write-off-repository";
+
+export class DrizzleWriteOffRepository extends DrizzleRepository<WriteOff> implements WriteOffRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, writeOffs as unknown as VersionedTable, now);
+  }
+
+  async sumByInvoice(invoiceId: string): Promise<number> {
+    const rows = await this.db
+      .select({ total: sql<number>`coalesce(sum(${writeOffs.amount}), 0)` }).from(writeOffs)
+      .where(and(eq(writeOffs.invoiceId, invoiceId), isNull(writeOffs.deletedAt)));
+    return Number(rows[0]?.total ?? 0);
+  }
+}

--- a/src/lib/server/repositories/in-memory-invoice-repository.ts
+++ b/src/lib/server/repositories/in-memory-invoice-repository.ts
@@ -109,6 +109,14 @@ export class InMemoryInvoiceRepository extends InMemoryRepository<Invoice> imple
     return nextInvoiceNumberFrom(prefix, last?.invoiceNumber);
   }
 
+  async sumCreditNotesFor(invoiceId: string, organizationId: string): Promise<number> {
+    const rows = (await (this.store.invoices as unknown as Delegate)
+      .findMany({ where: { creditedInvoiceId: invoiceId, matter: { organizationId } } })) as ReadonlyArray<Invoice>;
+    return rows
+      .filter((r) => !(r as { deletedAt?: unknown }).deletedAt)
+      .reduce((s, c) => s + Math.abs(c.amount), 0);
+  }
+
   async listByMatter(matterId: string): Promise<Invoice[]> {
     const rows = (await (this.store.invoices as unknown as Delegate)
       .findMany({ where: { matterId }, orderBy: { invoiceDate: "desc" } })) as Invoice[];

--- a/src/lib/server/repositories/in-memory-payment-plan-repository.ts
+++ b/src/lib/server/repositories/in-memory-payment-plan-repository.ts
@@ -22,4 +22,9 @@ export class InMemoryPaymentPlanRepository extends InMemoryRepository<PaymentPla
       .findFirst({ where: { id: planId, invoice: { matter: { organizationId } } } })) as PaymentPlan | null;
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }
+
+  async getByInvoiceId(invoiceId: string): Promise<PaymentPlan | null> {
+    const row = (await this.delegate.findFirst({ where: { invoiceId } })) as PaymentPlan | null;
+    return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
+  }
 }

--- a/src/lib/server/repositories/in-memory-payment-repository.ts
+++ b/src/lib/server/repositories/in-memory-payment-repository.ts
@@ -1,0 +1,25 @@
+/**
+ * In-memory `PaymentRepository` (ADR 0020) — browser/offline-impl. Ärver bas-CRUD;
+ * `sumByInvoice` läser via delegaten och summerar (samma reduce routern gjorde).
+ */
+
+import type { Payment } from "@/lib/shared/schemas/billing";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import { InMemoryRepository } from "./in-memory-repository";
+import type { PaymentRepository } from "./payment-repository";
+
+/** Delegaten repot behöver — uppfylls av `IDataStore`, `DataStoreTx` och `LocalStore`. */
+export type PaymentRepoSource = Pick<IDataStore, "payments">;
+
+export class InMemoryPaymentRepository extends InMemoryRepository<Payment> implements PaymentRepository {
+  constructor(store: PaymentRepoSource, now?: () => Date) {
+    super(store.payments as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async sumByInvoice(invoiceId: string): Promise<number> {
+    const rows = (await this.delegate.findMany({ where: { invoiceId } })) as ReadonlyArray<Payment>;
+    return rows
+      .filter((r) => !(r as { deletedAt?: unknown }).deletedAt)
+      .reduce((s, p) => s + p.amount, 0);
+  }
+}

--- a/src/lib/server/repositories/in-memory-repositories.ts
+++ b/src/lib/server/repositories/in-memory-repositories.ts
@@ -12,6 +12,8 @@ import type { DataStoreTx, IDataStore } from "../data-store/IDataStore";
 import { InMemoryInvoiceRepository } from "./in-memory-invoice-repository";
 import { InMemoryMatterRepository } from "./in-memory-matter-repository";
 import { InMemoryPaymentPlanRepository } from "./in-memory-payment-plan-repository";
+import { InMemoryPaymentRepository } from "./in-memory-payment-repository";
+import { InMemoryWriteOffRepository } from "./in-memory-write-off-repository";
 import type { Repositories } from "./repositories";
 
 /** Repos-vy bunden till en transaktions-tx (reentrant transaction). */
@@ -19,6 +21,8 @@ function reposForTx(tx: DataStoreTx): Repositories {
   const repos: Repositories = {
     invoices: new InMemoryInvoiceRepository(tx),
     matters: new InMemoryMatterRepository(tx),
+    payments: new InMemoryPaymentRepository(tx),
+    writeOffs: new InMemoryWriteOffRepository(tx),
     paymentPlans: new InMemoryPaymentPlanRepository(tx),
     transaction: (fn) => fn(repos),
   };
@@ -29,6 +33,8 @@ export function buildInMemoryRepositories(dataStore: IDataStore): Repositories {
   return {
     invoices: new InMemoryInvoiceRepository(dataStore),
     matters: new InMemoryMatterRepository(dataStore),
+    payments: new InMemoryPaymentRepository(dataStore),
+    writeOffs: new InMemoryWriteOffRepository(dataStore),
     paymentPlans: new InMemoryPaymentPlanRepository(dataStore),
     transaction: (fn) => dataStore.transaction((tx) => fn(reposForTx(tx))),
   };

--- a/src/lib/server/repositories/in-memory-write-off-repository.ts
+++ b/src/lib/server/repositories/in-memory-write-off-repository.ts
@@ -1,0 +1,25 @@
+/**
+ * In-memory `WriteOffRepository` (ADR 0020) — browser/offline-impl. Ärver
+ * bas-CRUD; `sumByInvoice` läser via delegaten och summerar.
+ */
+
+import type { WriteOff } from "@/lib/shared/schemas/billing";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import { InMemoryRepository } from "./in-memory-repository";
+import type { WriteOffRepository } from "./write-off-repository";
+
+/** Delegaten repot behöver — uppfylls av `IDataStore`, `DataStoreTx` och `LocalStore`. */
+export type WriteOffRepoSource = Pick<IDataStore, "writeOffs">;
+
+export class InMemoryWriteOffRepository extends InMemoryRepository<WriteOff> implements WriteOffRepository {
+  constructor(store: WriteOffRepoSource, now?: () => Date) {
+    super(store.writeOffs as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async sumByInvoice(invoiceId: string): Promise<number> {
+    const rows = (await this.delegate.findMany({ where: { invoiceId } })) as ReadonlyArray<WriteOff>;
+    return rows
+      .filter((r) => !(r as { deletedAt?: unknown }).deletedAt)
+      .reduce((s, w) => s + w.amount, 0);
+  }
+}

--- a/src/lib/server/repositories/invoice-repository.ts
+++ b/src/lib/server/repositories/invoice-repository.ts
@@ -95,6 +95,8 @@ export interface InvoiceRepository extends Repository<Invoice> {
   listForOrg(organizationId: string, filter?: InvoiceListFilter): Promise<InvoiceListRow[]>;
   /** Nästa lediga fakturanummer (`F-YYYY-NNNN`) för org:en (året från repots klocka). */
   nextInvoiceNumber(organizationId: string): Promise<string>;
+  /** Summa krediterat på en faktura: |belopp| av dess kreditnotor, org-scopat (öre). */
+  sumCreditNotesFor(invoiceId: string, organizationId: string): Promise<number>;
   /** Alla (icke-raderade) fakturor i ett ärende, nyaste först. */
   listByMatter(matterId: string): Promise<Invoice[]>;
 }

--- a/src/lib/server/repositories/payment-plan-repository.ts
+++ b/src/lib/server/repositories/payment-plan-repository.ts
@@ -11,4 +11,6 @@ import type { Repository } from "./types";
 export interface PaymentPlanRepository extends Repository<PaymentPlan> {
   /** Plan by id, org-scopad via faktura→ärende (null om saknas/annan org/raderad). */
   getByIdInOrg(planId: string, organizationId: string): Promise<PaymentPlan | null>;
+  /** Plan för en faktura (invoiceId är unik på planen) — null om ingen/raderad. */
+  getByInvoiceId(invoiceId: string): Promise<PaymentPlan | null>;
 }

--- a/src/lib/server/repositories/payment-repository.ts
+++ b/src/lib/server/repositories/payment-repository.ts
@@ -1,0 +1,13 @@
+/**
+ * `PaymentRepository` (ADR 0020, #409 fan-out) — fakturabetalningar. Bas-CRUD
+ * ärvs (`create` används av `invoice.recordPayment`); `sumByInvoice` summerar
+ * betalt-hinken för fakturans ledger (ersätter den dynamiska `findMany`-reduce).
+ */
+
+import type { Payment } from "@/lib/shared/schemas/billing";
+import type { Repository } from "./types";
+
+export interface PaymentRepository extends Repository<Payment> {
+  /** Summa av alla (icke-raderade) betalningar på en faktura (öre). */
+  sumByInvoice(invoiceId: string): Promise<number>;
+}

--- a/src/lib/server/repositories/repositories.ts
+++ b/src/lib/server/repositories/repositories.ts
@@ -8,10 +8,14 @@
 import type { InvoiceRepository } from "./invoice-repository";
 import type { MatterRepository } from "./matter-repository";
 import type { PaymentPlanRepository } from "./payment-plan-repository";
+import type { PaymentRepository } from "./payment-repository";
+import type { WriteOffRepository } from "./write-off-repository";
 
 export interface Repositories {
   invoices: InvoiceRepository;
   matters: MatterRepository;
+  payments: PaymentRepository;
+  writeOffs: WriteOffRepository;
   paymentPlans: PaymentPlanRepository;
   transaction<T>(fn: (tx: Repositories) => Promise<T>): Promise<T>;
 }

--- a/src/lib/server/repositories/write-off-repository.ts
+++ b/src/lib/server/repositories/write-off-repository.ts
@@ -1,0 +1,13 @@
+/**
+ * `WriteOffRepository` (ADR 0020, #409 fan-out) — konstaterade kundförluster
+ * (ADR 0007). Bas-CRUD ärvs (`create` används av `invoice.writeOff`);
+ * `sumByInvoice` summerar avskrivet-hinken för fakturans ledger.
+ */
+
+import type { WriteOff } from "@/lib/shared/schemas/billing";
+import type { Repository } from "./types";
+
+export interface WriteOffRepository extends Repository<WriteOff> {
+  /** Summa av alla (icke-raderade) avskrivningar på en faktura (öre). */
+  sumByInvoice(invoiceId: string): Promise<number>;
+}

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -20,7 +20,7 @@ import { canTransition, transitionErrorMessage } from "@/lib/shared/invoice-stat
 import { ocrFromInvoiceNumber } from "@/lib/shared/ocr-reference";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { computeRadgivningsavgift } from "@/lib/shared/rattshjalp";
-import type { Invoice } from "@/lib/shared/schemas/billing";
+import type { Invoice, Payment, WriteOff } from "@/lib/shared/schemas/billing";
 import type { InvoiceStatus } from "@/lib/shared/schemas/enums";
 import {
   asId,
@@ -35,6 +35,7 @@ import { computeInvoiceLedger, deriveInvoiceStatus, invoicePartitionViolation } 
 import type { DataStoreTx } from "../data-store/IDataStore";
 import { emit } from "../events/emit";
 import { invoiceNumberPrefix, nextInvoiceNumberFrom } from "../repositories/invoice-repository";
+import type { Repositories } from "../repositories/repositories";
 import { router, orgProcedure } from "../trpc";
 
 // ─── createFinal-hjälpare (validera + koppla poster) ──────────────
@@ -113,17 +114,20 @@ function ensureWritableOff<T extends { status?: string } | null>(inv: T): NonNul
   return inv as NonNullable<T>;
 }
 
-/** Summera fakturans avräkningshinkar (betalt/krediterat/avskrivet) → ledger. */
+/**
+ * Summera fakturans avräkningshinkar (betalt/krediterat/avskrivet) → ledger.
+ * Migrerad till repository-sömmen (ADR 0020): typade `sumByInvoice`/
+ * `sumCreditNotesFor` i st.f. dynamiska `findMany`-reduce. Den rena matematiken
+ * (`computeInvoiceLedger`) + tillståndslogiken bor kvar i routern.
+ */
 async function gatherInvoiceLedger(
-  tx: DataStoreTx,
+  repos: Repositories,
   orgId: string,
-  inv: { id: string; amount: number; payments?: ReadonlyArray<{ amount: number }> },
+  inv: { id: string; amount: number },
 ): Promise<{ paid: number; credited: number; writtenOff: number; ledger: ReturnType<typeof computeInvoiceLedger> }> {
-  const paid = (inv.payments ?? []).reduce((s, p) => s + p.amount, 0);
-  const credits = await tx.invoices.findMany({ where: { creditedInvoiceId: inv.id, matter: { organizationId: orgId } } });
-  const credited = ((credits ?? []) as ReadonlyArray<{ amount: number }>).reduce((s, c) => s + Math.abs(c.amount), 0);
-  const existing = await tx.writeOffs.findMany({ where: { invoiceId: inv.id } });
-  const writtenOff = ((existing ?? []) as ReadonlyArray<{ amount: number }>).reduce((s, w) => s + w.amount, 0);
+  const paid = await repos.payments.sumByInvoice(inv.id);
+  const credited = await repos.invoices.sumCreditNotesFor(inv.id, orgId);
+  const writtenOff = await repos.writeOffs.sumByInvoice(inv.id);
   return { paid, credited, writtenOff, ledger: computeInvoiceLedger(inv.amount, paid, credited, writtenOff) };
 }
 
@@ -416,12 +420,11 @@ export const invoiceRouter = router({
         reference: z.string().optional(),
       }),
     )
-    .mutation(async ({ ctx, input }) => {
-      return ctx.dataStore.transaction(async (tx) => {
-        const inv = await tx.invoices.findFirst({
-          where: { id: input.invoiceId, matter: { organizationId: ctx.orgId } },
-          include: { paymentPlan: true, payments: true },
-        });
+    // Migrerad till repository-sömmen (ADR 0020). Tillståndsmaskinen + ledger-
+    // matematiken bor kvar här; reads/writes går via typade repos i transaktionen.
+    .mutation(({ ctx, input }) =>
+      ctx.repos.transaction(async (repos) => {
+        const inv = await repos.invoices.getByIdInOrg(input.invoiceId, ctx.orgId);
         if (!inv) throw new TRPCError({ code: "NOT_FOUND" });
 
         // Tillståndsmaskin (#350, [ADR 0015]): en CANCELLED-faktura kan aldrig
@@ -434,48 +437,41 @@ export const invoiceRouter = router({
           });
         }
         if (inv.status === "DRAFT") {
-          await tx.invoices.update({ where: { id: inv.id }, data: { status: "SENT" } });
+          await repos.invoices.update(inv.id, { status: "SENT" });
         }
 
         // Konsistens-skydd (ADR 0007): en betalning får inte översumera fakturan
         // (betalt + krediterat + avskrivet > belopp → utestående < 0). Validera
         // FÖRE skapandet så vi inte lämnar en partition-brytande rad.
-        const { paid, credited, writtenOff } = await gatherInvoiceLedger(tx, ctx.orgId, inv);
+        const { paid, credited, writtenOff } = await gatherInvoiceLedger(repos, ctx.orgId, inv);
         const afterLedger = computeInvoiceLedger(inv.amount, paid + input.amount, credited, writtenOff);
         const violation = invoicePartitionViolation(inv.amount, afterLedger);
         if (violation) {
           throw new TRPCError({ code: "BAD_REQUEST", message: `Betalningen kan inte registreras: ${violation}` });
         }
 
-        const payment = await tx.payments.create({
-          data: {
-            invoiceId: inv.id,
-            amount: input.amount,
-            paidAt: new Date(input.paidAt),
-            note: input.note,
-            reference: input.reference,
-            recordedById: asId<"UserId">(ctx.user.id),
-          },
-        });
+        const payment = await repos.payments.create(omitUndefined({
+          invoiceId: inv.id,
+          amount: input.amount,
+          paidAt: new Date(input.paidAt),
+          note: input.note,
+          reference: input.reference,
+          recordedById: asId<"UserId">(ctx.user.id),
+        }) as Partial<Payment>);
 
-        const paidSum =
-          inv.payments.reduce((s: number, p: { amount: number }) => s + p.amount, 0) + input.amount;
+        // `paid` = betalt FÖRE denna betalning (sumByInvoice) → + input.amount.
+        const paidSum = paid + input.amount;
 
         if (isPaymentPlanSettled(inv.amount, paidSum)) {
-          await tx.invoices.update({
-            where: { id: inv.id },
-            data: { status: "PAID" },
-          });
-          if (inv.paymentPlan) {
-            await tx.paymentPlans.update({
-              where: { id: inv.paymentPlan.id },
-              data: { status: "COMPLETED" },
-            });
+          await repos.invoices.update(inv.id, { status: "PAID" });
+          const plan = await repos.paymentPlans.getByInvoiceId(inv.id);
+          if (plan) {
+            await repos.paymentPlans.update(plan.id, { status: "COMPLETED" });
           }
         }
         return { payment, paidSum, settled: isPaymentPlanSettled(inv.amount, paidSum) };
-      });
-    }),
+      }),
+    ),
 
   createPaymentPlan: orgProcedure
     .input(
@@ -567,39 +563,35 @@ export const invoiceRouter = router({
         writtenOffAt: z.string().optional(),
       }),
     )
-    .mutation(async ({ ctx, input }) => {
-      return ctx.dataStore.transaction(async (tx) => {
-        const inv = ensureWritableOff(
-          await tx.invoices.findFirst({
-            where: { id: input.invoiceId, matter: { organizationId: ctx.orgId } },
-            include: { payments: true },
-          }),
-        );
+    // Migrerad till repository-sömmen (ADR 0020). Ledger-läsningarna är typade
+    // repo-metoder; ADR 0007-vakterna (ensureWritableOff/resolveWriteOffAmount)
+    // + status-härledningen bor kvar i routern.
+    .mutation(({ ctx, input }) =>
+      ctx.repos.transaction(async (repos) => {
+        const inv = ensureWritableOff(await repos.invoices.getByIdInOrg(input.invoiceId, ctx.orgId));
 
-        const { paid, credited, writtenOff, ledger } = await gatherInvoiceLedger(tx, ctx.orgId, inv);
+        const { paid, credited, writtenOff, ledger } = await gatherInvoiceLedger(repos, ctx.orgId, inv);
         const amount = resolveWriteOffAmount(ledger.outstanding, input.amount);
 
-        const writeOff = await tx.writeOffs.create({
-          data: {
-            invoiceId: inv.id,
-            amount,
-            writtenOffAt: input.writtenOffAt ? new Date(input.writtenOffAt) : new Date(),
-            ...omitUndefined({ reason: input.reason }),
-            recordedById: asId<"UserId">(ctx.user.id),
-          },
-        });
+        const writeOff = await repos.writeOffs.create(omitUndefined({
+          invoiceId: inv.id,
+          amount,
+          writtenOffAt: input.writtenOffAt ? new Date(input.writtenOffAt) : new Date(),
+          reason: input.reason,
+          recordedById: asId<"UserId">(ctx.user.id),
+        }) as Partial<WriteOff>);
 
         // Härled status efter avskrivningen och persistera om återstoden stängdes.
         const after = computeInvoiceLedger(inv.amount, paid, credited, writtenOff + amount);
         const derived = deriveInvoiceStatus(inv.status as InvoiceStatus, after);
         if (derived !== inv.status) {
-          await tx.invoices.update({ where: { id: inv.id }, data: { status: derived } });
+          await repos.invoices.update(inv.id, { status: derived });
         }
 
         await emit.invoiceWrittenOff(ctx, inv.id, inv.matterId, amount);
         return { writeOff, outstanding: after.outstanding, status: derived };
-      });
-    }),
+      }),
+    ),
 
   /**
    * Manuell statusändring för DRAFT→SENT, SENT→CANCELLED, SENT→BAD_DEBT.

--- a/test/unit/server/repositories/invoice-repository.test.ts
+++ b/test/unit/server/repositories/invoice-repository.test.ts
@@ -162,6 +162,24 @@ describe("InvoiceRepository — in-memory", () => {
     expect(await repo.nextInvoiceNumber("org-1")).toBe("F-2026-0003");
     expect(await repo.nextInvoiceNumber("org-2")).toBe("F-2026-0001"); // tom org → 0001
   });
+
+  it("sumCreditNotesFor summerar |belopp| av kreditnotor, org-scopat", async () => {
+    const mId = uuidv7();
+    const finalId = uuidv7();
+    const store = new LocalStore({
+      matters: [{ id: mId, organizationId: "org-1", matterNumber: "2026-1", title: "T" }],
+      invoices: [
+        inv({ id: finalId, matterId: mId, invoiceType: "FINAL" }),
+        inv({ id: uuidv7(), matterId: mId, invoiceType: "CREDIT", amount: -40_000, creditedInvoiceId: finalId }),
+        inv({ id: uuidv7(), matterId: mId, invoiceType: "CREDIT", amount: -10_000, creditedInvoiceId: finalId }),
+      ],
+      payments: [], writeOffs: [],
+    }, async () => {});
+    const repo = new InMemoryInvoiceRepository(store);
+    expect(await repo.sumCreditNotesFor(finalId, "org-1")).toBe(50_000); // |−40000| + |−10000|
+    expect(await repo.sumCreditNotesFor(finalId, "org-2")).toBe(0); // fel org
+    expect(await repo.sumCreditNotesFor(uuidv7(), "org-1")).toBe(0); // inga kreditnotor
+  });
 });
 
 describe("InvoiceRepository — Drizzle (pglite)", () => {
@@ -296,5 +314,22 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
     const repo = new DrizzleInvoiceRepository(handle.db as unknown as AppDb, () => new Date("2026-06-01T00:00:00.000Z"));
     expect(await repo.nextInvoiceNumber(org)).toBe("F-2026-0003");
     expect(await repo.nextInvoiceNumber(uuidv7())).toBe("F-2026-0001"); // tom org → 0001
+  });
+
+  it("sumCreditNotesFor summerar |belopp| av kreditnotor (join mot matters)", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const mId = uuidv7();
+    const finalId = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
+    await db.insert(invoices).values(inv({ id: finalId, matterId: mId, invoiceType: "FINAL" }) as never);
+    await db.insert(invoices).values(inv({ id: uuidv7(), matterId: mId, invoiceType: "CREDIT", amount: -40_000, creditedInvoiceId: finalId }) as never);
+    await db.insert(invoices).values(inv({ id: uuidv7(), matterId: mId, invoiceType: "CREDIT", amount: -10_000, creditedInvoiceId: finalId }) as never);
+
+    const repo = new DrizzleInvoiceRepository(handle.db as unknown as AppDb);
+    expect(await repo.sumCreditNotesFor(finalId, org)).toBe(50_000);
+    expect(await repo.sumCreditNotesFor(finalId, uuidv7())).toBe(0); // fel org
   });
 });

--- a/test/unit/server/repositories/payment-plan-repository.test.ts
+++ b/test/unit/server/repositories/payment-plan-repository.test.ts
@@ -57,6 +57,13 @@ describe("PaymentPlanRepository — in-memory", () => {
     expect(await repo.getByIdInOrg(planId, "org-1")).toMatchObject({ id: planId });
     expect(await repo.getByIdInOrg(planId, "org-2")).toBeNull(); // fel org
   });
+
+  it("getByInvoiceId hämtar planen för en faktura", async () => {
+    const store = new LocalStore({ paymentPlans: [plan({ id: planId, invoiceId })] }, async () => {});
+    const repo = new InMemoryPaymentPlanRepository(store);
+    expect(await repo.getByInvoiceId(invoiceId)).toMatchObject({ id: planId });
+    expect(await repo.getByInvoiceId(uuidv7())).toBeNull(); // ingen plan
+  });
 });
 
 describe("PaymentPlanRepository — Drizzle (pglite)", () => {
@@ -83,5 +90,17 @@ describe("PaymentPlanRepository — Drizzle (pglite)", () => {
     const repo = new DrizzlePaymentPlanRepository(handle.db as unknown as AppDb);
     expect(await repo.getByIdInOrg(pId, org)).toMatchObject({ id: pId });
     expect(await repo.getByIdInOrg(pId, uuidv7())).toBeNull(); // fel org
+  });
+
+  it("getByInvoiceId hämtar planen för en faktura", async () => {
+    const db = handle.db;
+    const invId = uuidv7();
+    const pId = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(paymentPlans).values(v({ id: pId, invoiceId: invId, monthlyAmount: 100, dayOfMonth: 15, startDate: new Date(), status: "ACTIVE" }));
+    const repo = new DrizzlePaymentPlanRepository(handle.db as unknown as AppDb);
+    expect(await repo.getByInvoiceId(invId)).toMatchObject({ id: pId });
+    expect(await repo.getByInvoiceId(uuidv7())).toBeNull(); // ingen plan
   });
 });

--- a/test/unit/server/repositories/payment-repository.test.ts
+++ b/test/unit/server/repositories/payment-repository.test.ts
@@ -1,0 +1,45 @@
+/**
+ * PaymentRepository-paritet (ADR 0020, #409 fan-out) — SAMMA kontrakt mot båda
+ * impls: in-memory (LocalStore) och Drizzle (pglite). Bas-CRUD (ärvd) +
+ * `sumByInvoice` (betalt-hinken för fakturans ledger).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { payments } from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzlePaymentRepository } from "@/lib/server/repositories/drizzle-payment-repository";
+import { InMemoryPaymentRepository } from "@/lib/server/repositories/in-memory-payment-repository";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+describe("PaymentRepository — in-memory", () => {
+  it("create + sumByInvoice summerar per faktura", async () => {
+    const invoiceId = uuidv7();
+    const store = new LocalStore({ payments: [] }, async () => {});
+    const repo = new InMemoryPaymentRepository(store);
+    await repo.create({ id: uuidv7(), invoiceId, amount: 30_000, paidAt: new Date(), recordedById: uuidv7() } as never);
+    await repo.create({ id: uuidv7(), invoiceId, amount: 20_000, paidAt: new Date(), recordedById: uuidv7() } as never);
+    await repo.create({ id: uuidv7(), invoiceId: uuidv7(), amount: 99_000, paidAt: new Date(), recordedById: uuidv7() } as never);
+    expect(await repo.sumByInvoice(invoiceId)).toBe(50_000);
+    expect(await repo.sumByInvoice(uuidv7())).toBe(0); // ingen betalning
+  });
+});
+
+describe("PaymentRepository — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("create + sumByInvoice summerar i SQL", async () => {
+    const invoiceId = uuidv7();
+    const repo = new DrizzlePaymentRepository(handle.db as unknown as AppDb);
+    await repo.create({ id: uuidv7(), invoiceId, amount: 30_000, paidAt: new Date(), recordedById: uuidv7() } as never);
+    await repo.create({ id: uuidv7(), invoiceId, amount: 20_000, paidAt: new Date(), recordedById: uuidv7() } as never);
+    await repo.create({ id: uuidv7(), invoiceId: uuidv7(), amount: 99_000, paidAt: new Date(), recordedById: uuidv7() } as never);
+    expect(await repo.sumByInvoice(invoiceId)).toBe(50_000);
+    expect(await repo.sumByInvoice(uuidv7())).toBe(0);
+    // Kontroll att raderna skrevs (sanity för pglite-insert).
+    expect((await handle.db.select().from(payments)).length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/test/unit/server/repositories/write-off-repository.test.ts
+++ b/test/unit/server/repositories/write-off-repository.test.ts
@@ -1,0 +1,40 @@
+/**
+ * WriteOffRepository-paritet (ADR 0020, #409 fan-out) — SAMMA kontrakt mot båda
+ * impls: in-memory (LocalStore) och Drizzle (pglite). Bas-CRUD (ärvd) +
+ * `sumByInvoice` (avskrivet-hinken för fakturans ledger).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzleWriteOffRepository } from "@/lib/server/repositories/drizzle-write-off-repository";
+import { InMemoryWriteOffRepository } from "@/lib/server/repositories/in-memory-write-off-repository";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+describe("WriteOffRepository — in-memory", () => {
+  it("create + sumByInvoice summerar per faktura", async () => {
+    const invoiceId = uuidv7();
+    const store = new LocalStore({ writeOffs: [] }, async () => {});
+    const repo = new InMemoryWriteOffRepository(store);
+    await repo.create({ id: uuidv7(), invoiceId, amount: 70_000, writtenOffAt: new Date(), recordedById: uuidv7() } as never);
+    await repo.create({ id: uuidv7(), invoiceId: uuidv7(), amount: 5_000, writtenOffAt: new Date(), recordedById: uuidv7() } as never);
+    expect(await repo.sumByInvoice(invoiceId)).toBe(70_000);
+    expect(await repo.sumByInvoice(uuidv7())).toBe(0);
+  });
+});
+
+describe("WriteOffRepository — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("create + sumByInvoice summerar i SQL", async () => {
+    const invoiceId = uuidv7();
+    const repo = new DrizzleWriteOffRepository(handle.db as unknown as AppDb);
+    await repo.create({ id: uuidv7(), invoiceId, amount: 70_000, writtenOffAt: new Date(), recordedById: uuidv7() } as never);
+    await repo.create({ id: uuidv7(), invoiceId: uuidv7(), amount: 5_000, writtenOffAt: new Date(), recordedById: uuidv7() } as never);
+    expect(await repo.sumByInvoice(invoiceId)).toBe(70_000);
+    expect(await repo.sumByInvoice(uuidv7())).toBe(0);
+  });
+});

--- a/test/unit/server/routers/invoice.demo-store.test.ts
+++ b/test/unit/server/routers/invoice.demo-store.test.ts
@@ -34,6 +34,7 @@ function setup(overrides?: Partial<DemoSource>) {
   const caller = (orgId = "o1") => invoiceRouter.createCaller({
     user: { id: "u1", email: "a@b.c", name: "A", role: "LAWYER", organizationId: orgId },
     dataStore: ds,
+    repos: buildInMemoryRepositories(ds),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any);
   return { source, events, caller };

--- a/test/unit/server/routers/invoice.test.ts
+++ b/test/unit/server/routers/invoice.test.ts
@@ -45,6 +45,7 @@ const mockPrisma = {
     create: vi.fn(),
   },
   payment: {
+    findMany: vi.fn(),
     create: vi.fn(),
   },
   writeOff: {
@@ -83,6 +84,8 @@ beforeEach(() => {
   // (clearAllMocks rensar call-data men inte implementationer).
   mockPrisma.invoice.findMany.mockResolvedValue([]);
   mockPrisma.writeOff.findMany.mockResolvedValue([]);
+  // Repository-sömmens ledger läser betalt-hinken via payments.sumByInvoice.
+  mockPrisma.payment.findMany.mockResolvedValue([]);
 });
 
 const MATTER_A = { id: "matter-1", organizationId: "org-a", matterNumber: "2026-0001", title: "T" };
@@ -306,8 +309,8 @@ describe("invoice.recordPayment", () => {
       amount: 1_000_000,
       status: "SENT",
       paymentPlan: null,
-      payments: [{ amount: 200_000 }],
     });
+    mockPrisma.payment.findMany.mockResolvedValue([{ amount: 200_000 }]); // betalt före
     mockPrisma.payment.create.mockResolvedValue({ id: "pay-1", amount: 300_000 });
 
     const res = await makeCaller().recordPayment({
@@ -327,8 +330,8 @@ describe("invoice.recordPayment", () => {
       amount: 1_000_000,
       status: "SENT",
       paymentPlan: null,
-      payments: [{ amount: 900_000 }],
     });
+    mockPrisma.payment.findMany.mockResolvedValue([{ amount: 900_000 }]); // betalt före
     mockPrisma.payment.create.mockResolvedValue({ id: "pay-2", amount: 100_000 });
 
     const res = await makeCaller().recordPayment({
@@ -338,10 +341,9 @@ describe("invoice.recordPayment", () => {
     });
 
     expect(res.settled).toBe(true);
-    expect(mockPrisma.invoice.update).toHaveBeenCalledWith({
-      where: { id: "inv-1" },
-      data: { status: "PAID" },
-    });
+    expect(mockPrisma.invoice.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "inv-1" }, data: expect.objectContaining({ status: "PAID" }) }),
+    );
     expect(mockPrisma.paymentPlan.update).not.toHaveBeenCalled();
   });
 
@@ -350,9 +352,9 @@ describe("invoice.recordPayment", () => {
       id: "inv-1",
       amount: 1_000_000,
       status: "INSTALLMENT_PLAN",
-      paymentPlan: { id: "plan-1" },
-      payments: [{ amount: 999_999 }],
     });
+    mockPrisma.payment.findMany.mockResolvedValue([{ amount: 999_999 }]); // betalt före
+    mockPrisma.paymentPlan.findFirst.mockResolvedValue({ id: "plan-1", invoiceId: "inv-1" });
     mockPrisma.payment.create.mockResolvedValue({ id: "pay-last", amount: 1 });
 
     await makeCaller().recordPayment({
@@ -361,14 +363,12 @@ describe("invoice.recordPayment", () => {
       paidAt: "2026-05-15",
     });
 
-    expect(mockPrisma.invoice.update).toHaveBeenCalledWith({
-      where: { id: "inv-1" },
-      data: { status: "PAID" },
-    });
-    expect(mockPrisma.paymentPlan.update).toHaveBeenCalledWith({
-      where: { id: "plan-1" },
-      data: { status: "COMPLETED" },
-    });
+    expect(mockPrisma.invoice.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "inv-1" }, data: expect.objectContaining({ status: "PAID" }) }),
+    );
+    expect(mockPrisma.paymentPlan.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "plan-1" }, data: expect.objectContaining({ status: "COMPLETED" }) }),
+    );
   });
 
   it("NOT_FOUND när fakturan tillhör annan org", async () => {
@@ -394,7 +394,9 @@ describe("invoice.recordPayment", () => {
 
     // Betalningen registreras OCH fakturan auto-sätts SENT (inte kvar som DRAFT).
     expect(mockPrisma.payment.create).toHaveBeenCalled();
-    expect(mockPrisma.invoice.update).toHaveBeenCalledWith({ where: { id: "inv-1" }, data: { status: "SENT" } });
+    expect(mockPrisma.invoice.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "inv-1" }, data: expect.objectContaining({ status: "SENT" }) }),
+    );
     expect(res.settled).toBe(false); // delbetalning → stannar SENT
   });
 
@@ -412,8 +414,8 @@ describe("invoice.recordPayment", () => {
   it("avvisar översummerande betalning (partition-invariant, ADR 0007)", async () => {
     mockPrisma.invoice.findFirst.mockResolvedValue({
       id: "inv-1", amount: 1_000_000, status: "SENT", paymentPlan: null,
-      payments: [{ amount: 900_000 }],
     });
+    mockPrisma.payment.findMany.mockResolvedValue([{ amount: 900_000 }]); // betalt före
     mockPrisma.invoice.findMany.mockResolvedValue([]); // inga krediteringar
     mockPrisma.writeOff.findMany.mockResolvedValue([]); // inget avskrivet
 
@@ -542,8 +544,8 @@ describe("invoice.writeOff", () => {
   it("delbetald → avskriven återstod: skapar WriteOff + härleder BAD_DEBT", async () => {
     mockPrisma.invoice.findFirst.mockResolvedValue({
       id: "inv-1", matterId: "matter-1", amount: 100_000, status: "SENT",
-      payments: [{ amount: 30_000 }],
     });
+    mockPrisma.payment.findMany.mockResolvedValue([{ amount: 30_000 }]); // betalt
     mockPrisma.invoice.findMany.mockResolvedValue([]); // inga krediteringar
     mockPrisma.writeOff.findMany.mockResolvedValue([]); // inget avskrivet än
     mockPrisma.writeOff.create.mockResolvedValue({ id: "wo-1", invoiceId: "inv-1", amount: 70_000 });
@@ -557,9 +559,10 @@ describe("invoice.writeOff", () => {
     );
     expect(res.outstanding).toBe(0);
     expect(res.status).toBe("BAD_DEBT");
-    expect(mockPrisma.invoice.update).toHaveBeenCalledWith({
-      where: { id: "inv-1" }, data: { status: "BAD_DEBT" },
-    });
+    // Repo.update bumpar version + updatedAt (ADR 0019) → matcha löst på status.
+    expect(mockPrisma.invoice.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "inv-1" }, data: expect.objectContaining({ status: "BAD_DEBT" }) }),
+    );
   });
 
   it("räkna en gång: redan avskriven faktura (outstanding 0) → BAD_REQUEST", async () => {
@@ -576,8 +579,9 @@ describe("invoice.writeOff", () => {
 
   it("avskrivningsbelopp > utestående → BAD_REQUEST", async () => {
     mockPrisma.invoice.findFirst.mockResolvedValue({
-      id: "inv-1", matterId: "matter-1", amount: 100_000, status: "SENT", payments: [{ amount: 60_000 }],
+      id: "inv-1", matterId: "matter-1", amount: 100_000, status: "SENT",
     });
+    mockPrisma.payment.findMany.mockResolvedValue([{ amount: 60_000 }]); // betalt
     mockPrisma.invoice.findMany.mockResolvedValue([]);
     mockPrisma.writeOff.findMany.mockResolvedValue([]);
 


### PR DESCRIPTION
## What

The agreed-on decision #1: migrate the two ledger-mutations (`recordPayment` + `writeOff`) together, since both share `gatherInvoiceLedger`.

### New repos / methods (each gets a consumer → knip-green)
- `PaymentRepository` — `create` (consumed by `recordPayment`) + `sumByInvoice` (paid bucket).
- `WriteOffRepository` — `create` (consumed by `writeOff`) + `sumByInvoice` (written-off bucket).
- `InvoiceRepository.sumCreditNotesFor(invoiceId, orgId)` — credited bucket, org-scoped (replaces the dynamic `findMany({ where: { creditedInvoiceId, matter:{org} } })`).
- `PaymentPlanRepository.getByInvoiceId` — used by `recordPayment` to complete the plan on settle.

Both Drizzle sum-methods push the aggregation into SQL (`coalesce(sum(...), 0)`); the in-memory ones reduce over the delegate. `payments` + `writeOffs` wired into the `Repositories` aggregate + both builders.

### Ledger helper
`gatherInvoiceLedger` now takes `repos` and calls the typed sum-methods; the pure math (`computeInvoiceLedger` / `invoicePartitionViolation` / `deriveInvoiceStatus`) and the ADR 0007 / state-machine guards stay in the router.

### Mutations
Both move to `ctx.repos.transaction` — reads + writes through tx-bound repos, so the ledger sums observe in-transaction state. `recordPayment` org-scopes via `getByIdInOrg` and looks up the plan via `getByInvoiceId` only when settling (avoids over-fetch and the relations org-post-check that the mocked tests can't satisfy).

### Tests
Mocked router tests updated to the seam: paid bucket read via `payments.findMany`, status writes via `update` (version-bump + `updatedAt` → `objectContaining`). New in-memory + pglite parity tests for all four read methods.

## Out of scope (decision #2)
`createPaymentPlan`'s hard-delete (`tx.paymentPlans.delete`) vs tombstone is still open — not touched here.

## Verification
- `bun run quality` green (coverage gate green, clones unchanged at 13, deps + knip clean).
- `bun run build:demo` green.
- Integration scenario tests (real DemoDataStore, full payment/write-off flows) green.

Refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)