### PR TITLE
feat(repositories): hardDelete base + migrate createPaymentPlan (ADR 0020)

### DIFF
--- a/src/lib/server/repositories/drizzle-repository.ts
+++ b/src/lib/server/repositories/drizzle-repository.ts
@@ -60,6 +60,11 @@ export class DrizzleRepository<Row extends RowBase> implements Repository<Row> {
       .where(eq(this.table.id, id)).returning();
     return row as unknown as Row;
   }
+
+  /** Hård delete — se `Repository.hardDelete` (medvetet ADR 0017-undantag). */
+  async hardDelete(id: string): Promise<void> {
+    await this.db.delete(this.table).where(eq(this.table.id, id));
+  }
 }
 
 function nextVersion(row: RowBase): number {

--- a/src/lib/server/repositories/in-memory-repository.ts
+++ b/src/lib/server/repositories/in-memory-repository.ts
@@ -45,4 +45,9 @@ export class InMemoryRepository<Row extends RowBase> implements Repository<Row> 
     const data = { deletedAt: this.now(), version: (current.version ?? 1) + 1 } as Partial<Row>;
     return (await this.delegate.update({ where: { id }, data })) as Row;
   }
+
+  /** Hård delete — se `Repository.hardDelete` (medvetet ADR 0017-undantag). */
+  async hardDelete(id: string): Promise<void> {
+    await this.delegate.delete({ where: { id } });
+  }
 }

--- a/src/lib/server/repositories/types.ts
+++ b/src/lib/server/repositories/types.ts
@@ -30,4 +30,11 @@ export interface Repository<Row extends RowBase> {
   update(id: string, patch: Partial<Row>): Promise<Row>;
   /** Mjuk delete (sätter `deletedAt`, bumpar `version`) — tombstone, ADR 0017. */
   softDelete(id: string): Promise<Row>;
+  /**
+   * Hård delete (tar bort raden helt). MEDVETEN ADR 0017-undantag: en hård
+   * delete kan inte reconcile:as/replikeras (raden bara försvinner). Använd
+   * BARA där en unik-constraint kräver det (t.ex. PaymentPlan.invoiceId @unique
+   * när en gammal CANCELLED-plan måste ge plats åt en ny). Default = softDelete.
+   */
+  hardDelete(id: string): Promise<void>;
 }

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -20,7 +20,7 @@ import { canTransition, transitionErrorMessage } from "@/lib/shared/invoice-stat
 import { ocrFromInvoiceNumber } from "@/lib/shared/ocr-reference";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { computeRadgivningsavgift } from "@/lib/shared/rattshjalp";
-import type { Invoice, Payment, WriteOff } from "@/lib/shared/schemas/billing";
+import type { Invoice, Payment, PaymentPlan, WriteOff } from "@/lib/shared/schemas/billing";
 import type { InvoiceStatus } from "@/lib/shared/schemas/enums";
 import {
   asId,
@@ -484,14 +484,15 @@ export const invoiceRouter = router({
         notes: z.string().optional(),
       }),
     )
-    .mutation(async ({ ctx, input }) => {
-      return ctx.dataStore.transaction(async (tx) => {
-        const inv = await tx.invoices.findFirst({
-          where: { id: input.invoiceId, matter: { organizationId: ctx.orgId } },
-          include: { paymentPlan: true },
-        });
+    // Migrerad till repository-sömmen (ADR 0020). Planen läses via
+    // getByInvoiceId; en gammal CANCELLED-plan hårdraderas (invoiceId @unique →
+    // medvetet ADR 0017-undantag, se Repository.hardDelete).
+    .mutation(({ ctx, input }) =>
+      ctx.repos.transaction(async (repos) => {
+        const inv = await repos.invoices.getByIdInOrg(input.invoiceId, ctx.orgId);
         if (!inv) throw new TRPCError({ code: "NOT_FOUND" });
-        if (inv.paymentPlan && inv.paymentPlan.status === "ACTIVE") {
+        const existing = await repos.paymentPlans.getByInvoiceId(inv.id);
+        if (existing && existing.status === "ACTIVE") {
           throw new TRPCError({
             code: "BAD_REQUEST",
             message: "En aktiv avbetalningsplan finns redan för denna faktura.",
@@ -506,28 +507,24 @@ export const invoiceRouter = router({
 
         // Om en gammal CANCELLED-plan finns, ta bort den först — `invoiceId`
         // är @unique på PaymentPlan så vi kan inte ha två rader.
-        if (inv.paymentPlan && inv.paymentPlan.status !== "ACTIVE") {
-          await tx.paymentPlans.delete({ where: { id: inv.paymentPlan.id } });
+        if (existing && existing.status !== "ACTIVE") {
+          await repos.paymentPlans.hardDelete(existing.id);
         }
 
-        const plan = await tx.paymentPlans.create({
-          data: {
-            ...omitUndefined({ id: input.id, notes: input.notes }), // undefined → store genererar
-            invoiceId: inv.id,
-            monthlyAmount: input.monthlyAmount,
-            dayOfMonth: input.dayOfMonth,
-            startDate: new Date(input.startDate),
-            // Explicit (Prisma schema-default appliceras inte av in-memory-store:n).
-            status: "ACTIVE",
-          },
-        });
-        await tx.invoices.update({
-          where: { id: inv.id },
-          data: { status: "INSTALLMENT_PLAN" },
-        });
+        const plan = await repos.paymentPlans.create(omitUndefined({
+          id: input.id, // undefined → store genererar
+          notes: input.notes,
+          invoiceId: inv.id,
+          monthlyAmount: input.monthlyAmount,
+          dayOfMonth: input.dayOfMonth,
+          startDate: new Date(input.startDate),
+          // Explicit (Prisma schema-default appliceras inte av in-memory-store:n).
+          status: "ACTIVE",
+        }) as Partial<PaymentPlan>);
+        await repos.invoices.update(inv.id, { status: "INSTALLMENT_PLAN" });
         return plan;
-      });
-    }),
+      }),
+    ),
 
   cancelPaymentPlan: orgProcedure
     .input(z.object({ planId: z.string() }))

--- a/test/unit/server/repositories/payment-plan-repository.test.ts
+++ b/test/unit/server/repositories/payment-plan-repository.test.ts
@@ -38,6 +38,13 @@ async function assertContract(repo: PaymentPlanRepository): Promise<void> {
 
   await repo.softDelete(planId);
   expect(await repo.getById(planId)).toBeNull();
+
+  // hardDelete (ADR 0017-undantag, används av createPaymentPlan): raden försvinner helt.
+  const hardId = uuidv7();
+  await repo.create(plan({ id: hardId }));
+  expect(await repo.getById(hardId)).toMatchObject({ id: hardId });
+  await repo.hardDelete(hardId);
+  expect(await repo.getById(hardId)).toBeNull();
 }
 
 describe("PaymentPlanRepository — in-memory", () => {

--- a/test/unit/server/routers/invoice.test.ts
+++ b/test/unit/server/routers/invoice.test.ts
@@ -56,6 +56,7 @@ const mockPrisma = {
     create: vi.fn(),
     update: vi.fn(),
     findFirst: vi.fn(),
+    delete: vi.fn(),
   },
   // $transaction(fn) kör callbacken direkt mot samma mock.
   $transaction: vi.fn(<T,>(fn: (tx: typeof mockPrisma) => Promise<T>) => fn(mockPrisma)),
@@ -86,6 +87,9 @@ beforeEach(() => {
   mockPrisma.writeOff.findMany.mockResolvedValue([]);
   // Repository-sömmens ledger läser betalt-hinken via payments.sumByInvoice.
   mockPrisma.payment.findMany.mockResolvedValue([]);
+  // paymentPlans.getByInvoiceId default: ingen plan (clearAllMocks nollar inte
+  // mockResolvedValue → annars läcker en annan tests plan hit).
+  mockPrisma.paymentPlan.findFirst.mockResolvedValue(null);
 });
 
 const MATTER_A = { id: "matter-1", organizationId: "org-a", matterNumber: "2026-0001", title: "T" };
@@ -453,18 +457,18 @@ describe("invoice.createPaymentPlan", () => {
         }),
       }),
     );
-    expect(mockPrisma.invoice.update).toHaveBeenCalledWith({
-      where: { id: "inv-1" },
-      data: { status: "INSTALLMENT_PLAN" },
-    });
+    expect(mockPrisma.invoice.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "inv-1" }, data: expect.objectContaining({ status: "INSTALLMENT_PLAN" }) }),
+    );
   });
 
   it("BAD_REQUEST om fakturan redan har en plan", async () => {
     mockPrisma.invoice.findFirst.mockResolvedValue({
       id: "inv-1",
       status: "INSTALLMENT_PLAN",
-      paymentPlan: { id: "existing" },
     });
+    // getByInvoiceId returnerar en AKTIV plan → blockerar.
+    mockPrisma.paymentPlan.findFirst.mockResolvedValue({ id: "existing", status: "ACTIVE" });
 
     await expect(
       makeCaller().createPaymentPlan({


### PR DESCRIPTION
## What

Decision **Q1 = A**: add `hardDelete` to the repo base, then migrate `createPaymentPlan`.

### `hardDelete(id)` on the base
Interface + in-memory + Drizzle. A **deliberate ADR 0017 carve-out** — a hard delete can't be reconciled/replicated, so `softDelete` (tombstone) stays the default; `hardDelete` is documented as "use only where a unique constraint forces it."

### `createPaymentPlan` migration
Off `ctx.dataStore.transaction` onto `ctx.repos.transaction`:
- invoice → `repos.invoices.getByIdInOrg`
- existing plan → `repos.paymentPlans.getByInvoiceId`
- stale CANCELLED plan removal → `repos.paymentPlans.hardDelete` (`invoiceId` is `@unique`, so a new ACTIVE plan can't coexist with the old row)
- create + invoice status flip → typed repos

### Tests
Mocked router tests declare the plan precondition via `paymentPlan.findFirst`; a `beforeEach` default of `null` stops cross-test leakage (`vi.clearAllMocks()` doesn't reset `mockResolvedValue`). `hardDelete` is covered by the payment-plan parity contract (in-memory + pglite).

## Verification
- `bun run quality` green (coverage gate green, clones unchanged at 13, deps + knip clean).
- `bun run build:demo` green.
- Integration scenario tests green.

Refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)