### PR TITLE
feat(repositories): migrate createCredit to typed repository (ADR 0020)

### DIFF
--- a/src/lib/server/repositories/drizzle-invoice-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-repository.ts
@@ -147,6 +147,13 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
     return Number(rows[0]?.total ?? 0);
   }
 
+  async getCreditNoteFor(invoiceId: string): Promise<Invoice | null> {
+    const rows = await this.db
+      .select().from(invoices)
+      .where(and(eq(invoices.creditedInvoiceId, invoiceId), isNull(invoices.deletedAt))).limit(1);
+    return (rows[0] as unknown as Invoice | undefined) ?? null;
+  }
+
   async getByIdWithLedger(id: string): Promise<InvoiceWithLedger | null> {
     const invoice = await this.getById(id);
     if (!invoice) return null;

--- a/src/lib/server/repositories/in-memory-invoice-repository.ts
+++ b/src/lib/server/repositories/in-memory-invoice-repository.ts
@@ -117,6 +117,12 @@ export class InMemoryInvoiceRepository extends InMemoryRepository<Invoice> imple
       .reduce((s, c) => s + Math.abs(c.amount), 0);
   }
 
+  async getCreditNoteFor(invoiceId: string): Promise<Invoice | null> {
+    const row = (await (this.store.invoices as unknown as Delegate)
+      .findFirst({ where: { creditedInvoiceId: invoiceId } })) as Invoice | null;
+    return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
+  }
+
   async listByMatter(matterId: string): Promise<Invoice[]> {
     const rows = (await (this.store.invoices as unknown as Delegate)
       .findMany({ where: { matterId }, orderBy: { invoiceDate: "desc" } })) as Invoice[];

--- a/src/lib/server/repositories/invoice-repository.ts
+++ b/src/lib/server/repositories/invoice-repository.ts
@@ -97,6 +97,8 @@ export interface InvoiceRepository extends Repository<Invoice> {
   nextInvoiceNumber(organizationId: string): Promise<string>;
   /** Summa krediterat på en faktura: |belopp| av dess kreditnotor, org-scopat (öre). */
   sumCreditNotesFor(invoiceId: string, organizationId: string): Promise<number>;
+  /** Kreditnotan för en faktura (`creditedInvoiceId = id`) — null om ej krediterad. */
+  getCreditNoteFor(invoiceId: string): Promise<Invoice | null>;
   /** Alla (icke-raderade) fakturor i ett ärende, nyaste först. */
   listByMatter(matterId: string): Promise<Invoice[]>;
 }

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -352,12 +352,11 @@ export const invoiceRouter = router({
         notes: z.string().optional(),
       }),
     )
-    .mutation(async ({ ctx, input }) => {
-      return ctx.dataStore.transaction(async (tx) => {
-        const original = await tx.invoices.findFirst({
-          where: { id: input.invoiceId, matter: { organizationId: ctx.orgId } },
-          include: { creditNote: true, paymentPlan: true },
-        });
+    // Migrerad till repository-sömmen (ADR 0020). "Redan krediterad"-kollen via
+    // getCreditNoteFor; aktiv plan avbryts via paymentPlans; allt i transaktionen.
+    .mutation(({ ctx, input }) =>
+      ctx.repos.transaction(async (repos) => {
+        const original = await repos.invoices.getByIdInOrg(input.invoiceId, ctx.orgId);
         if (!original) throw new TRPCError({ code: "NOT_FOUND" });
         if (original.invoiceType === "CREDIT") {
           throw new TRPCError({
@@ -365,7 +364,7 @@ export const invoiceRouter = router({
             message: "Kan inte kreditera en kreditfaktura.",
           });
         }
-        if (original.creditNote) {
+        if (await repos.invoices.getCreditNoteFor(original.id)) {
           throw new TRPCError({
             code: "BAD_REQUEST",
             message: "Fakturan är redan krediterad.",
@@ -379,34 +378,27 @@ export const invoiceRouter = router({
         }
 
         // Om originalet har en aktiv avbetalningsplan: avbryt den
-        if (original.paymentPlan && original.paymentPlan.status === "ACTIVE") {
-          await tx.paymentPlans.update({
-            where: { id: original.paymentPlan.id },
-            data: { status: "CANCELLED" },
-          });
+        const plan = await repos.paymentPlans.getByInvoiceId(original.id);
+        if (plan && plan.status === "ACTIVE") {
+          await repos.paymentPlans.update(plan.id, { status: "CANCELLED" });
         }
 
-        const credit = await tx.invoices.create({
-          data: {
-            ...omitUndefined({ id: input.id, notes: input.notes }), // undefined → store genererar
-            matterId: original.matterId,
-            invoiceNumber: await nextInvoiceNumber(tx.invoices, ctx.orgId),
-            amount: -original.amount,
-            invoiceType: "CREDIT",
-            status: "SENT", // kreditfaktura är "färdig" direkt
-            invoiceDate: new Date(),
-            creditedInvoiceId: original.id,
-          },
-        });
+        const credit = await repos.invoices.create(omitUndefined({
+          id: input.id, // undefined → store genererar
+          notes: input.notes,
+          matterId: original.matterId,
+          invoiceNumber: await repos.invoices.nextInvoiceNumber(ctx.orgId),
+          amount: -original.amount,
+          invoiceType: "CREDIT",
+          status: "SENT", // kreditfaktura är "färdig" direkt
+          invoiceDate: new Date(),
+          creditedInvoiceId: original.id,
+        }) as Partial<Invoice>);
 
-        await tx.invoices.update({
-          where: { id: original.id },
-          data: { status: "CANCELLED" },
-        });
-
+        await repos.invoices.update(original.id, { status: "CANCELLED" });
         return credit;
-      });
-    }),
+      }),
+    ),
 
   recordPayment: orgProcedure
     .input(

--- a/test/unit/server/repositories/invoice-repository.test.ts
+++ b/test/unit/server/repositories/invoice-repository.test.ts
@@ -180,6 +180,23 @@ describe("InvoiceRepository — in-memory", () => {
     expect(await repo.sumCreditNotesFor(finalId, "org-2")).toBe(0); // fel org
     expect(await repo.sumCreditNotesFor(uuidv7(), "org-1")).toBe(0); // inga kreditnotor
   });
+
+  it("getCreditNoteFor hittar kreditnotan för en faktura", async () => {
+    const mId = uuidv7();
+    const origId = uuidv7();
+    const creditId = uuidv7();
+    const store = new LocalStore({
+      matters: [{ id: mId, organizationId: "org-1", matterNumber: "2026-1", title: "T" }],
+      invoices: [
+        inv({ id: origId, matterId: mId, invoiceType: "STANDARD" }),
+        inv({ id: creditId, matterId: mId, invoiceType: "CREDIT", amount: -100, creditedInvoiceId: origId }),
+      ],
+      payments: [], writeOffs: [],
+    }, async () => {});
+    const repo = new InMemoryInvoiceRepository(store);
+    expect((await repo.getCreditNoteFor(origId))?.id).toBe(creditId);
+    expect(await repo.getCreditNoteFor(uuidv7())).toBeNull(); // ej krediterad
+  });
 });
 
 describe("InvoiceRepository — Drizzle (pglite)", () => {
@@ -331,5 +348,20 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
     const repo = new DrizzleInvoiceRepository(handle.db as unknown as AppDb);
     expect(await repo.sumCreditNotesFor(finalId, org)).toBe(50_000);
     expect(await repo.sumCreditNotesFor(finalId, uuidv7())).toBe(0); // fel org
+  });
+
+  it("getCreditNoteFor hittar kreditnotan (creditedInvoiceId)", async () => {
+    const db = handle.db;
+    const mId = uuidv7();
+    const origId = uuidv7();
+    const creditId = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: mId, organizationId: uuidv7(), matterNumber: "2026-1", title: "T" }));
+    await db.insert(invoices).values(inv({ id: origId, matterId: mId, invoiceType: "STANDARD" }) as never);
+    await db.insert(invoices).values(inv({ id: creditId, matterId: mId, invoiceType: "CREDIT", amount: -100, creditedInvoiceId: origId }) as never);
+    const repo = new DrizzleInvoiceRepository(handle.db as unknown as AppDb);
+    expect((await repo.getCreditNoteFor(origId))?.id).toBe(creditId);
+    expect(await repo.getCreditNoteFor(uuidv7())).toBeNull();
   });
 });

--- a/test/unit/server/routers/invoice.test.ts
+++ b/test/unit/server/routers/invoice.test.ts
@@ -784,43 +784,32 @@ describe("invoice.createCredit", () => {
   });
 
   it("kastar BAD_REQUEST när fakturan redan är krediterad", async () => {
-    mockPrisma.invoice.findFirst.mockResolvedValue({
-      id: "inv-1",
-      invoiceType: "STANDARD",
-      status: "SENT",
-      amount: 1000,
-      creditNote: { id: "cn1" },
-      paymentPlan: null,
-    });
+    // getByIdInOrg → originalet; getCreditNoteFor ({creditedInvoiceId}) → kreditnota finns.
+    mockPrisma.invoice.findFirst.mockImplementation((args?: { where?: Record<string, unknown> }) =>
+      args?.where?.creditedInvoiceId
+        ? { id: "cn1" }
+        : { id: "inv-1", invoiceType: "STANDARD", status: "SENT", amount: 1000 });
     await expect(
       makeCaller().createCredit({ invoiceId: "inv-1" }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
   });
 
   it("kastar BAD_REQUEST när fakturan är CANCELLED", async () => {
-    mockPrisma.invoice.findFirst.mockResolvedValue({
-      id: "inv-1",
-      invoiceType: "STANDARD",
-      status: "CANCELLED",
-      amount: 1000,
-      creditNote: null,
-      paymentPlan: null,
-    });
+    // Ingen kreditnota → getCreditNoteFor passerar → CANCELLED-kollen nås.
+    mockPrisma.invoice.findFirst.mockImplementation((args?: { where?: Record<string, unknown> }) =>
+      args?.where?.creditedInvoiceId
+        ? null
+        : { id: "inv-1", invoiceType: "STANDARD", status: "CANCELLED", amount: 1000 });
     await expect(
       makeCaller().createCredit({ invoiceId: "inv-1" }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
   });
 
   it("skapar kreditfaktura med negativt belopp och annullerar originalet", async () => {
-    mockPrisma.invoice.findFirst.mockResolvedValue({
-      id: "inv-1",
-      matterId: "m1",
-      invoiceType: "STANDARD",
-      status: "SENT",
-      amount: 1000,
-      creditNote: null,
-      paymentPlan: null,
-    });
+    mockPrisma.invoice.findFirst.mockImplementation((args?: { where?: Record<string, unknown> }) =>
+      args?.where?.creditedInvoiceId || args?.where?.invoiceNumber
+        ? null
+        : { id: "inv-1", matterId: "m1", invoiceType: "STANDARD", status: "SENT", amount: 1000 });
     mockPrisma.invoice.create.mockResolvedValue({
       id: "credit-1",
       invoiceType: "CREDIT",
@@ -845,32 +834,27 @@ describe("invoice.createCredit", () => {
         }),
       }),
     );
-    expect(mockPrisma.invoice.update).toHaveBeenCalledWith({
-      where: { id: "inv-1" },
-      data: { status: "CANCELLED" },
-    });
+    // Repo.update bumpar version + updatedAt → matcha löst på status.
+    expect(mockPrisma.invoice.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "inv-1" }, data: expect.objectContaining({ status: "CANCELLED" }) }),
+    );
   });
 
   it("avbryter aktiv avbetalningsplan när originalet krediteras", async () => {
-    mockPrisma.invoice.findFirst.mockResolvedValue({
-      id: "inv-1",
-      matterId: "m1",
-      invoiceType: "STANDARD",
-      status: "INSTALLMENT_PLAN",
-      amount: 1000,
-      creditNote: null,
-      paymentPlan: { id: "pp1", status: "ACTIVE" },
-    });
+    mockPrisma.invoice.findFirst.mockImplementation((args?: { where?: Record<string, unknown> }) =>
+      args?.where?.creditedInvoiceId || args?.where?.invoiceNumber
+        ? null
+        : { id: "inv-1", matterId: "m1", invoiceType: "STANDARD", status: "INSTALLMENT_PLAN", amount: 1000 });
+    mockPrisma.paymentPlan.findFirst.mockResolvedValue({ id: "pp1", status: "ACTIVE" }); // getByInvoiceId
     mockPrisma.invoice.create.mockResolvedValue({ id: "credit-1" });
     mockPrisma.invoice.update.mockResolvedValue({});
     mockPrisma.paymentPlan.update.mockResolvedValue({});
 
     await makeCaller().createCredit({ invoiceId: "inv-1" });
 
-    expect(mockPrisma.paymentPlan.update).toHaveBeenCalledWith({
-      where: { id: "pp1" },
-      data: { status: "CANCELLED" },
-    });
+    expect(mockPrisma.paymentPlan.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "pp1" }, data: expect.objectContaining({ status: "CANCELLED" }) }),
+    );
   });
 });
 
@@ -893,10 +877,10 @@ describe("OCR-referens på kundfakturor (#182)", () => {
   });
 
   it("createCredit sätter INGEN ocrReference (krediter betalas inte med OCR)", async () => {
-    mockPrisma.invoice.findFirst.mockResolvedValue({
-      id: "inv-1", matterId: "m1", invoiceType: "STANDARD", status: "SENT",
-      amount: 1000, creditNote: null, paymentPlan: null,
-    });
+    mockPrisma.invoice.findFirst.mockImplementation((args?: { where?: Record<string, unknown> }) =>
+      args?.where?.creditedInvoiceId || args?.where?.invoiceNumber
+        ? null
+        : { id: "inv-1", matterId: "m1", invoiceType: "STANDARD", status: "SENT", amount: 1000 });
     mockPrisma.invoice.create.mockResolvedValue({ id: "credit-1", invoiceType: "CREDIT", amount: -1000 });
     mockPrisma.invoice.update.mockResolvedValue({});
 


### PR DESCRIPTION
## What

Decision **Q4 = A**: add `InvoiceRepository.getCreditNoteFor(invoiceId)`, then migrate `createCredit`.

### `getCreditNoteFor(invoiceId)`
In-memory + Drizzle. The "already credited?" read — the credit note is the invoice with `creditedInvoiceId = id` (non-deleted). One small typed read instead of `getByIdFull`'s heavy include + the relations org-post-check that mocks can't satisfy.

### `createCredit` migration
Off `ctx.dataStore.transaction` onto `ctx.repos.transaction`:
- original → `repos.invoices.getByIdInOrg`
- already-credited guard → `repos.invoices.getCreditNoteFor`
- active-plan cancel → `repos.paymentPlans.getByInvoiceId` + `update`
- credit create + numbering + original status flip → typed repos

### Tests
The mocked `invoice.findFirst` is now where-aware, since `getByIdInOrg`, `getCreditNoteFor`, and `nextInvoiceNumber` all hit the same delegate (the mock returns by `where` shape). Status writes assert via `objectContaining`. New parity test for `getCreditNoteFor` (in-memory + pglite).

## Verification
- `bun run quality` green (coverage gate green, clones unchanged at 13, deps + knip clean).
- `bun run build:demo` green.
- Integration scenario tests green.

Refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)