### PR TITLE
feat(repositories): migrate createFinal — invoice router fully on repos (ADR 0020)

### DIFF
--- a/src/lib/server/repositories/acconto-deduction-repository.ts
+++ b/src/lib/server/repositories/acconto-deduction-repository.ts
@@ -1,0 +1,11 @@
+/**
+ * `AccontoDeductionRepository` (ADR 0020, #409 fan-out) — acconto-avdrag (kopplar
+ * en FINAL-faktura till de ACCONTO-fakturor den drar av). `createFinal` använder
+ * bara bas-`create`; "ej redan avdragna"-filtret bor på `InvoiceRepository`
+ * (`listDeductibleAccontos`) eftersom det är en faktura-fråga.
+ */
+
+import type { AccontoDeduction } from "@/lib/shared/schemas/billing";
+import type { Repository } from "./types";
+
+export type AccontoDeductionRepository = Repository<AccontoDeduction>;

--- a/src/lib/server/repositories/drizzle-acconto-deduction-repository.ts
+++ b/src/lib/server/repositories/drizzle-acconto-deduction-repository.ts
@@ -1,0 +1,17 @@
+/**
+ * Drizzle `AccontoDeductionRepository` (ADR 0020) — server-impl. Endast bas-CRUD.
+ */
+
+import type { AccontoDeduction } from "@/lib/shared/schemas/billing";
+import { accontoDeductions } from "../db/schema";
+import type { AppDb } from "../db/types";
+import type { AccontoDeductionRepository } from "./acconto-deduction-repository";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+
+export class DrizzleAccontoDeductionRepository
+  extends DrizzleRepository<AccontoDeduction>
+  implements AccontoDeductionRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, accontoDeductions as unknown as VersionedTable, now);
+  }
+}

--- a/src/lib/server/repositories/drizzle-expense-repository.ts
+++ b/src/lib/server/repositories/drizzle-expense-repository.ts
@@ -1,0 +1,30 @@
+/**
+ * Drizzle `ExpenseRepository` (ADR 0020) — server-impl. Ärver bas-CRUD;
+ * `flagBilled` bulk-sätter invoiceId.
+ */
+
+import { and, eq, inArray, isNull } from "drizzle-orm";
+import type { Expense } from "@/lib/shared/schemas/billing";
+import { expenses } from "../db/schema";
+import type { AppDb } from "../db/types";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import type { ExpenseRepository } from "./expense-repository";
+
+export class DrizzleExpenseRepository extends DrizzleRepository<Expense> implements ExpenseRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, expenses as unknown as VersionedTable, now);
+  }
+
+  async listUnbilled(matterId: string, ids: string[]): Promise<Expense[]> {
+    if (!ids.length) return [];
+    const rows = await this.db
+      .select().from(expenses)
+      .where(and(inArray(expenses.id, ids), eq(expenses.matterId, matterId), isNull(expenses.invoiceId)));
+    return rows as unknown as Expense[];
+  }
+
+  async flagBilled(ids: string[], invoiceId: string): Promise<void> {
+    if (!ids.length) return;
+    await this.db.update(expenses).set({ invoiceId } as never).where(inArray(expenses.id, ids));
+  }
+}

--- a/src/lib/server/repositories/drizzle-invoice-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-repository.ts
@@ -9,7 +9,7 @@
  * helper när vi fan-out:ar entiteterna; pilotens korrekthet bevisas av pglite-testerna.
  */
 
-import { and, desc, eq, isNull, like, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, like, sql } from "drizzle-orm";
 import type { Invoice, Payment, WriteOff } from "@/lib/shared/schemas/billing";
 import { accontoDeductions, invoices, matters, paymentPlans, payments, writeOffs } from "../db/schema";
 import type { AppDb } from "../db/types";
@@ -152,6 +152,23 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
       .select().from(invoices)
       .where(and(eq(invoices.creditedInvoiceId, invoiceId), isNull(invoices.deletedAt))).limit(1);
     return (rows[0] as unknown as Invoice | undefined) ?? null;
+  }
+
+  async listDeductibleAccontos(matterId: string, ids: string[]): Promise<Invoice[]> {
+    if (!ids.length) return [];
+    // ACCONTO i ärendet som ännu inte dragits av: left-join acconto_deductions
+    // på accontoInvoiceId + filtrera bort träffar (deductedOnFinals = none).
+    const rows = await this.db
+      .select({ inv: invoices }).from(invoices)
+      .leftJoin(accontoDeductions, eq(accontoDeductions.accontoInvoiceId, invoices.id))
+      .where(and(
+        inArray(invoices.id, ids),
+        eq(invoices.matterId, matterId),
+        eq(invoices.invoiceType, "ACCONTO"),
+        isNull(invoices.deletedAt),
+        isNull(accontoDeductions.id),
+      ));
+    return rows.map((r) => r.inv) as unknown as Invoice[];
   }
 
   async getByIdWithLedger(id: string): Promise<InvoiceWithLedger | null> {

--- a/src/lib/server/repositories/drizzle-time-entry-repository.ts
+++ b/src/lib/server/repositories/drizzle-time-entry-repository.ts
@@ -1,0 +1,33 @@
+/**
+ * Drizzle `TimeEntryRepository` (ADR 0020) — server-impl. Ärver bas-CRUD;
+ * `listUnbilled` joinar users för timtaxan, `flagBilled` bulk-sätter invoiceId.
+ */
+
+import { and, eq, inArray, isNull } from "drizzle-orm";
+import type { TimeEntry } from "@/lib/shared/schemas/billing";
+import { timeEntries, users } from "../db/schema";
+import type { AppDb } from "../db/types";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import type { TimeEntryRepository, UnbilledTimeEntry } from "./time-entry-repository";
+
+export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> implements TimeEntryRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, timeEntries as unknown as VersionedTable, now);
+  }
+
+  async listUnbilled(matterId: string, ids: string[]): Promise<UnbilledTimeEntry[]> {
+    if (!ids.length) return [];
+    const rows = await this.db
+      .select({ te: timeEntries, hourlyRate: users.hourlyRate }).from(timeEntries)
+      .innerJoin(users, eq(timeEntries.userId, users.id))
+      .where(and(inArray(timeEntries.id, ids), eq(timeEntries.matterId, matterId), isNull(timeEntries.invoiceId)));
+    return rows.map((r) => ({
+      ...(r.te as object), user: { hourlyRate: r.hourlyRate },
+    })) as unknown as UnbilledTimeEntry[];
+  }
+
+  async flagBilled(ids: string[], invoiceId: string): Promise<void> {
+    if (!ids.length) return;
+    await this.db.update(timeEntries).set({ invoiceId } as never).where(inArray(timeEntries.id, ids));
+  }
+}

--- a/src/lib/server/repositories/expense-repository.ts
+++ b/src/lib/server/repositories/expense-repository.ts
@@ -1,0 +1,15 @@
+/**
+ * `ExpenseRepository` (ADR 0020, #409 fan-out) — utlägg. Bas-CRUD ärvs;
+ * `listUnbilled` hämtar valda ofakturerade utlägg, `flagBilled` kopplar dem
+ * till fakturan (bulk).
+ */
+
+import type { Expense } from "@/lib/shared/schemas/billing";
+import type { Repository } from "./types";
+
+export interface ExpenseRepository extends Repository<Expense> {
+  /** Valda ofakturerade utlägg i ett ärende. Tom lista vid tomma ids. */
+  listUnbilled(matterId: string, ids: string[]): Promise<Expense[]>;
+  /** Koppla utlägg till en faktura (sätter invoiceId). No-op vid tomma ids. */
+  flagBilled(ids: string[], invoiceId: string): Promise<void>;
+}

--- a/src/lib/server/repositories/in-memory-acconto-deduction-repository.ts
+++ b/src/lib/server/repositories/in-memory-acconto-deduction-repository.ts
@@ -1,0 +1,20 @@
+/**
+ * In-memory `AccontoDeductionRepository` (ADR 0020) — browser/offline-impl.
+ * Endast bas-CRUD (createFinal anropar `create`).
+ */
+
+import type { AccontoDeduction } from "@/lib/shared/schemas/billing";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { AccontoDeductionRepository } from "./acconto-deduction-repository";
+import { InMemoryRepository } from "./in-memory-repository";
+
+/** Delegaten repot behöver — uppfylls av `IDataStore`, `DataStoreTx` och `LocalStore`. */
+export type AccontoDeductionRepoSource = Pick<IDataStore, "accontoDeductions">;
+
+export class InMemoryAccontoDeductionRepository
+  extends InMemoryRepository<AccontoDeduction>
+  implements AccontoDeductionRepository {
+  constructor(store: AccontoDeductionRepoSource, now?: () => Date) {
+    super(store.accontoDeductions as unknown as Delegate, now ?? (() => new Date()));
+  }
+}

--- a/src/lib/server/repositories/in-memory-expense-repository.ts
+++ b/src/lib/server/repositories/in-memory-expense-repository.ts
@@ -1,0 +1,30 @@
+/**
+ * In-memory `ExpenseRepository` (ADR 0020) — browser/offline-impl. Ärver
+ * bas-CRUD; `flagBilled` bulk-uppdaterar invoiceId via delegaten.
+ */
+
+import type { Expense } from "@/lib/shared/schemas/billing";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { ExpenseRepository } from "./expense-repository";
+import { InMemoryRepository } from "./in-memory-repository";
+
+/** Delegaten repot behöver — uppfylls av `IDataStore`, `DataStoreTx` och `LocalStore`. */
+export type ExpenseRepoSource = Pick<IDataStore, "expenses">;
+
+export class InMemoryExpenseRepository extends InMemoryRepository<Expense> implements ExpenseRepository {
+  constructor(store: ExpenseRepoSource, now?: () => Date) {
+    super(store.expenses as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async listUnbilled(matterId: string, ids: string[]): Promise<Expense[]> {
+    if (!ids.length) return [];
+    return (await this.delegate.findMany({
+      where: { id: { in: ids }, matterId, invoiceId: null },
+    })) as Expense[];
+  }
+
+  async flagBilled(ids: string[], invoiceId: string): Promise<void> {
+    if (!ids.length) return;
+    await this.delegate.updateMany({ where: { id: { in: ids } }, data: { invoiceId } as Partial<Expense> });
+  }
+}

--- a/src/lib/server/repositories/in-memory-invoice-repository.ts
+++ b/src/lib/server/repositories/in-memory-invoice-repository.ts
@@ -123,6 +123,13 @@ export class InMemoryInvoiceRepository extends InMemoryRepository<Invoice> imple
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }
 
+  async listDeductibleAccontos(matterId: string, ids: string[]): Promise<Invoice[]> {
+    if (!ids.length) return [];
+    return (await (this.store.invoices as unknown as Delegate).findMany({
+      where: { id: { in: ids }, matterId, invoiceType: "ACCONTO", deductedOnFinals: { none: {} } },
+    })) as Invoice[];
+  }
+
   async listByMatter(matterId: string): Promise<Invoice[]> {
     const rows = (await (this.store.invoices as unknown as Delegate)
       .findMany({ where: { matterId }, orderBy: { invoiceDate: "desc" } })) as Invoice[];

--- a/src/lib/server/repositories/in-memory-repositories.ts
+++ b/src/lib/server/repositories/in-memory-repositories.ts
@@ -9,10 +9,13 @@
  */
 
 import type { DataStoreTx, IDataStore } from "../data-store/IDataStore";
+import { InMemoryAccontoDeductionRepository } from "./in-memory-acconto-deduction-repository";
+import { InMemoryExpenseRepository } from "./in-memory-expense-repository";
 import { InMemoryInvoiceRepository } from "./in-memory-invoice-repository";
 import { InMemoryMatterRepository } from "./in-memory-matter-repository";
 import { InMemoryPaymentPlanRepository } from "./in-memory-payment-plan-repository";
 import { InMemoryPaymentRepository } from "./in-memory-payment-repository";
+import { InMemoryTimeEntryRepository } from "./in-memory-time-entry-repository";
 import { InMemoryWriteOffRepository } from "./in-memory-write-off-repository";
 import type { Repositories } from "./repositories";
 
@@ -24,6 +27,9 @@ function reposForTx(tx: DataStoreTx): Repositories {
     payments: new InMemoryPaymentRepository(tx),
     writeOffs: new InMemoryWriteOffRepository(tx),
     paymentPlans: new InMemoryPaymentPlanRepository(tx),
+    timeEntries: new InMemoryTimeEntryRepository(tx),
+    expenses: new InMemoryExpenseRepository(tx),
+    accontoDeductions: new InMemoryAccontoDeductionRepository(tx),
     transaction: (fn) => fn(repos),
   };
   return repos;
@@ -36,6 +42,9 @@ export function buildInMemoryRepositories(dataStore: IDataStore): Repositories {
     payments: new InMemoryPaymentRepository(dataStore),
     writeOffs: new InMemoryWriteOffRepository(dataStore),
     paymentPlans: new InMemoryPaymentPlanRepository(dataStore),
+    timeEntries: new InMemoryTimeEntryRepository(dataStore),
+    expenses: new InMemoryExpenseRepository(dataStore),
+    accontoDeductions: new InMemoryAccontoDeductionRepository(dataStore),
     transaction: (fn) => dataStore.transaction((tx) => fn(reposForTx(tx))),
   };
 }

--- a/src/lib/server/repositories/in-memory-time-entry-repository.ts
+++ b/src/lib/server/repositories/in-memory-time-entry-repository.ts
@@ -1,0 +1,32 @@
+/**
+ * In-memory `TimeEntryRepository` (ADR 0020) — browser/offline-impl. Ärver
+ * bas-CRUD; `listUnbilled` använder samma include som routern (user.hourlyRate),
+ * `flagBilled` bulk-uppdaterar invoiceId via delegaten.
+ */
+
+import type { TimeEntry } from "@/lib/shared/schemas/billing";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import { InMemoryRepository } from "./in-memory-repository";
+import type { TimeEntryRepository, UnbilledTimeEntry } from "./time-entry-repository";
+
+/** Delegaten repot behöver — uppfylls av `IDataStore`, `DataStoreTx` och `LocalStore`. */
+export type TimeEntryRepoSource = Pick<IDataStore, "timeEntries">;
+
+export class InMemoryTimeEntryRepository extends InMemoryRepository<TimeEntry> implements TimeEntryRepository {
+  constructor(store: TimeEntryRepoSource, now?: () => Date) {
+    super(store.timeEntries as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async listUnbilled(matterId: string, ids: string[]): Promise<UnbilledTimeEntry[]> {
+    if (!ids.length) return [];
+    return (await this.delegate.findMany({
+      where: { id: { in: ids }, matterId, invoiceId: null },
+      include: { user: { select: { hourlyRate: true } } },
+    })) as UnbilledTimeEntry[];
+  }
+
+  async flagBilled(ids: string[], invoiceId: string): Promise<void> {
+    if (!ids.length) return;
+    await this.delegate.updateMany({ where: { id: { in: ids } }, data: { invoiceId } as Partial<TimeEntry> });
+  }
+}

--- a/src/lib/server/repositories/invoice-repository.ts
+++ b/src/lib/server/repositories/invoice-repository.ts
@@ -99,6 +99,8 @@ export interface InvoiceRepository extends Repository<Invoice> {
   sumCreditNotesFor(invoiceId: string, organizationId: string): Promise<number>;
   /** Kreditnotan för en faktura (`creditedInvoiceId = id`) — null om ej krediterad. */
   getCreditNoteFor(invoiceId: string): Promise<Invoice | null>;
+  /** Valda ACCONTO-fakturor i ett ärende som ÄNNU INTE dragits av på en FINAL. Tom vid tomma ids. */
+  listDeductibleAccontos(matterId: string, ids: string[]): Promise<Invoice[]>;
   /** Alla (icke-raderade) fakturor i ett ärende, nyaste först. */
   listByMatter(matterId: string): Promise<Invoice[]>;
 }

--- a/src/lib/server/repositories/repositories.ts
+++ b/src/lib/server/repositories/repositories.ts
@@ -5,10 +5,13 @@
  * importeras av entitets-repositories utan cirkel-beroende.
  */
 
+import type { AccontoDeductionRepository } from "./acconto-deduction-repository";
+import type { ExpenseRepository } from "./expense-repository";
 import type { InvoiceRepository } from "./invoice-repository";
 import type { MatterRepository } from "./matter-repository";
 import type { PaymentPlanRepository } from "./payment-plan-repository";
 import type { PaymentRepository } from "./payment-repository";
+import type { TimeEntryRepository } from "./time-entry-repository";
 import type { WriteOffRepository } from "./write-off-repository";
 
 export interface Repositories {
@@ -17,5 +20,8 @@ export interface Repositories {
   payments: PaymentRepository;
   writeOffs: WriteOffRepository;
   paymentPlans: PaymentPlanRepository;
+  timeEntries: TimeEntryRepository;
+  expenses: ExpenseRepository;
+  accontoDeductions: AccontoDeductionRepository;
   transaction<T>(fn: (tx: Repositories) => Promise<T>): Promise<T>;
 }

--- a/src/lib/server/repositories/time-entry-repository.ts
+++ b/src/lib/server/repositories/time-entry-repository.ts
@@ -1,0 +1,20 @@
+/**
+ * `TimeEntryRepository` (ADR 0020, #409 fan-out) — tidsposter. Bas-CRUD ärvs;
+ * `listUnbilled` hämtar valda ofakturerade poster (med juristens timtaxa för
+ * fakturaberäkningen) och `flagBilled` kopplar dem till fakturan (bulk).
+ */
+
+import type { TimeEntry } from "@/lib/shared/schemas/billing";
+import type { Repository } from "./types";
+
+/** Tidspost + juristens timtaxa (det fakturaberäkningen behöver). */
+export interface UnbilledTimeEntry extends TimeEntry {
+  user: { hourlyRate: number | null };
+}
+
+export interface TimeEntryRepository extends Repository<TimeEntry> {
+  /** Valda ofakturerade tidsposter i ett ärende (med user.hourlyRate). Tom lista vid tomma ids. */
+  listUnbilled(matterId: string, ids: string[]): Promise<UnbilledTimeEntry[]>;
+  /** Koppla tidsposter till en faktura (sätter invoiceId). No-op vid tomma ids. */
+  flagBilled(ids: string[], invoiceId: string): Promise<void>;
+}

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -20,7 +20,7 @@ import { canTransition, transitionErrorMessage } from "@/lib/shared/invoice-stat
 import { ocrFromInvoiceNumber } from "@/lib/shared/ocr-reference";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { computeRadgivningsavgift } from "@/lib/shared/rattshjalp";
-import type { Invoice, Payment, PaymentPlan, WriteOff } from "@/lib/shared/schemas/billing";
+import type { AccontoDeduction, Invoice, Payment, PaymentPlan, WriteOff } from "@/lib/shared/schemas/billing";
 import type { InvoiceStatus } from "@/lib/shared/schemas/enums";
 import {
   asId,
@@ -33,22 +33,15 @@ import {
 } from "@/lib/shared/schemas/ids";
 import type { Matter } from "@/lib/shared/schemas/matter";
 import { computeInvoiceLedger, deriveInvoiceStatus, invoicePartitionViolation } from "@/lib/shared/write-off-calc";
-import type { DataStoreTx } from "../data-store/IDataStore";
 import { emit } from "../events/emit";
-import { invoiceNumberPrefix, nextInvoiceNumberFrom } from "../repositories/invoice-repository";
 import type { Repositories } from "../repositories/repositories";
 import { router, orgProcedure } from "../trpc";
 
 // ─── createFinal-hjälpare (validera + koppla poster) ──────────────
 
 /** Hämta valda obetalda tidsposter; kasta om någon redan fakturerats/ägs av annat ärende. */
-async function fetchUnbilledTimeEntries(tx: DataStoreTx, matterId: string, ids: string[]) {
-  const rows = ids.length
-    ? await tx.timeEntries.findMany({
-        where: { id: { in: ids }, matterId, invoiceId: null },
-        include: { user: { select: { hourlyRate: true } } },
-      })
-    : [];
+async function fetchUnbilledTimeEntries(repos: Repositories, matterId: string, ids: string[]) {
+  const rows = await repos.timeEntries.listUnbilled(matterId, ids);
   if (rows.length !== ids.length) {
     throw new TRPCError({ code: "BAD_REQUEST", message: "Några tidsposter är redan fakturerade eller tillhör annat ärende." });
   }
@@ -56,10 +49,8 @@ async function fetchUnbilledTimeEntries(tx: DataStoreTx, matterId: string, ids: 
 }
 
 /** Hämta valda obetalda utlägg; kasta om någon redan fakturerats/ägs av annat ärende. */
-async function fetchUnbilledExpenses(tx: DataStoreTx, matterId: string, ids: string[]) {
-  const rows = ids.length
-    ? await tx.expenses.findMany({ where: { id: { in: ids }, matterId, invoiceId: null } })
-    : [];
+async function fetchUnbilledExpenses(repos: Repositories, matterId: string, ids: string[]) {
+  const rows = await repos.expenses.listUnbilled(matterId, ids);
   if (rows.length !== ids.length) {
     throw new TRPCError({ code: "BAD_REQUEST", message: "Några utlägg är redan fakturerade eller tillhör annat ärende." });
   }
@@ -67,12 +58,8 @@ async function fetchUnbilledExpenses(tx: DataStoreTx, matterId: string, ids: str
 }
 
 /** Validera accontos: samma ärende, typ ACCONTO, ej redan avdragna på en FINAL. */
-async function fetchDeductibleAccontos(tx: DataStoreTx, matterId: string, ids: string[]) {
-  const rows = ids.length
-    ? await tx.invoices.findMany({
-        where: { id: { in: ids }, matterId, invoiceType: "ACCONTO", deductedOnFinals: { none: {} } },
-      })
-    : [];
+async function fetchDeductibleAccontos(repos: Repositories, matterId: string, ids: string[]) {
+  const rows = await repos.invoices.listDeductibleAccontos(matterId, ids);
   if (rows.length !== ids.length) {
     throw new TRPCError({ code: "BAD_REQUEST", message: "Några acconto-fakturor är redan avdragna eller tillhör annat ärende." });
   }
@@ -80,24 +67,20 @@ async function fetchDeductibleAccontos(tx: DataStoreTx, matterId: string, ids: s
 }
 
 /**
- * Koppla poster till fakturan + skapa acconto-avdrag via explicita anrop
+ * Koppla poster till fakturan + skapa acconto-avdrag via typade repo-anrop
  * (ej Prisma nested writes) så samma kod kör mot både Postgres och git-store:n.
  */
 async function linkBilledItems(
-  tx: DataStoreTx,
+  repos: Repositories,
   invoiceId: InvoiceId,
   timeEntries: ReadonlyArray<{ id: TimeEntryId }>,
   expenses: ReadonlyArray<{ id: ExpenseId }>,
   accontos: ReadonlyArray<{ id: InvoiceId }>,
 ): Promise<void> {
-  if (timeEntries.length) {
-    await tx.timeEntries.updateMany({ where: { id: { in: timeEntries.map((t) => t.id) } }, data: { invoiceId } });
-  }
-  if (expenses.length) {
-    await tx.expenses.updateMany({ where: { id: { in: expenses.map((e) => e.id) } }, data: { invoiceId } });
-  }
+  await repos.timeEntries.flagBilled(timeEntries.map((t) => t.id), invoiceId);
+  await repos.expenses.flagBilled(expenses.map((e) => e.id), invoiceId);
   for (const a of accontos) {
-    await tx.accontoDeductions.create({ data: { finalInvoiceId: invoiceId, accontoInvoiceId: a.id } });
+    await repos.accontoDeductions.create({ finalInvoiceId: invoiceId, accontoInvoiceId: a.id } as Partial<AccontoDeduction>);
   }
 }
 
@@ -148,23 +131,6 @@ function resolveWriteOffAmount(outstanding: number, requested?: number): number 
     });
   }
   return amount;
-}
-
-/**
- * Nästa lediga fakturanummer (F-YYYY-NNNN) för org:en. Kvarvarande tx-väg för
- * de ännu icke-migrerade mutationerna (createRadgivning/createFinal/createCredit);
- * delar format-logiken med `InvoiceRepository.nextInvoiceNumber` (ADR 0020).
- */
-async function nextInvoiceNumber(
-  invoices: { findFirst: (args: unknown) => Promise<unknown> },
-  orgId: string,
-): Promise<string> {
-  const prefix = invoiceNumberPrefix(new Date().getFullYear());
-  const last = (await invoices.findFirst({
-    where: { matter: { organizationId: orgId }, invoiceNumber: { startsWith: prefix } },
-    orderBy: { invoiceNumber: "desc" },
-  })) as { invoiceNumber?: string | null } | null;
-  return nextInvoiceNumberFrom(prefix, last?.invoiceNumber);
 }
 
 const invoiceTypeSchema = z.enum(["STANDARD", "ACCONTO", "FINAL"]);
@@ -296,16 +262,16 @@ export const invoiceRouter = router({
         notes: z.string().optional(),
       }),
     )
+    // Migrerad till repository-sömmen (ADR 0020). Typade list/flag-metoder +
+    // accontoDeductions-repo; beräkningen (computeFinalInvoiceBreakdown) i routern.
     .mutation(async ({ ctx, input }) => {
-      return ctx.dataStore.transaction(async (tx) => {
-        const matter = await tx.matters.findFirst({
-          where: { id: input.matterId, organizationId: ctx.orgId },
-        });
+      const result = await ctx.repos.transaction(async (repos) => {
+        const matter = await repos.matters.getByIdInOrg(input.matterId, ctx.orgId);
         if (!matter) throw new TRPCError({ code: "NOT_FOUND" });
 
-        const timeEntries = await fetchUnbilledTimeEntries(tx, input.matterId, input.timeEntryIds);
-        const expenses = await fetchUnbilledExpenses(tx, input.matterId, input.expenseIds);
-        const accontos = await fetchDeductibleAccontos(tx, input.matterId, input.accontoInvoiceIds);
+        const timeEntries = await fetchUnbilledTimeEntries(repos, input.matterId, input.timeEntryIds);
+        const expenses = await fetchUnbilledExpenses(repos, input.matterId, input.expenseIds);
+        const accontos = await fetchDeductibleAccontos(repos, input.matterId, input.accontoInvoiceIds);
 
         const breakdown = computeFinalInvoiceBreakdown(
           timeEntries.map((t) => ({ minutes: t.minutes, hourlyRate: t.user.hourlyRate ?? 0 })),
@@ -313,28 +279,25 @@ export const invoiceRouter = router({
           accontos.map((a) => ({ id: a.id, amount: a.amount })),
         );
 
-        const finalNumber = await nextInvoiceNumber(tx.invoices, ctx.orgId);
-        const invoice = await tx.invoices.create({
-          data: omitUndefined({
-            id: input.id, // undefined → store genererar
-            matterId: input.matterId,
-            invoiceNumber: finalNumber,
-            ocrReference: ocrFromInvoiceNumber(finalNumber), // kundfaktura → OCR (#182)
-            amount: breakdown.grossAmount,
-            invoiceType: "FINAL",
-            status: "DRAFT",
-            invoiceDate: input.invoiceDate ? new Date(input.invoiceDate) : new Date(),
-            dueDate: input.dueDate ? new Date(input.dueDate) : null,
-            notes: input.notes,
-          }),
-        });
+        const finalNumber = await repos.invoices.nextInvoiceNumber(ctx.orgId);
+        const invoice = await repos.invoices.create(omitUndefined({
+          id: input.id, // undefined → store genererar
+          matterId: input.matterId,
+          invoiceNumber: finalNumber,
+          ocrReference: ocrFromInvoiceNumber(finalNumber), // kundfaktura → OCR (#182)
+          amount: breakdown.grossAmount,
+          invoiceType: "FINAL",
+          status: "DRAFT",
+          invoiceDate: input.invoiceDate ? new Date(input.invoiceDate) : new Date(),
+          dueDate: input.dueDate ? new Date(input.dueDate) : null,
+          notes: input.notes,
+        }) as Partial<Invoice>);
 
-        await linkBilledItems(tx, invoice.id, timeEntries, expenses, accontos);
+        await linkBilledItems(repos, invoice.id as InvoiceId, timeEntries, expenses, accontos);
         return { invoice, breakdown };
-      }).then(async (result) => {
-        await emit.invoiceCreated(ctx, result.invoice);
-        return result;
       });
+      await emit.invoiceCreated(ctx, result.invoice);
+      return result;
     }),
 
   /**

--- a/test/unit/server/repositories/acconto-deduction-repository.test.ts
+++ b/test/unit/server/repositories/acconto-deduction-repository.test.ts
@@ -1,0 +1,37 @@
+/**
+ * AccontoDeductionRepository-paritet (ADR 0020, #409 fan-out) — in-memory +
+ * Drizzle (pglite). Endast bas-CRUD: createFinal anropar `create`.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzleAccontoDeductionRepository } from "@/lib/server/repositories/drizzle-acconto-deduction-repository";
+import { InMemoryAccontoDeductionRepository } from "@/lib/server/repositories/in-memory-acconto-deduction-repository";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+describe("AccontoDeductionRepository — in-memory", () => {
+  it("create + getById (version 1)", async () => {
+    const store = new LocalStore({ accontoDeductions: [] }, async () => {});
+    const repo = new InMemoryAccontoDeductionRepository(store);
+    const id = uuidv7();
+    const created = await repo.create({ id, finalInvoiceId: uuidv7(), accontoInvoiceId: uuidv7() } as never);
+    expect((created as { version?: number }).version).toBe(1);
+    expect(await repo.getById(id)).toMatchObject({ id });
+  });
+});
+
+describe("AccontoDeductionRepository — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("create + getById (version 1)", async () => {
+    const repo = new DrizzleAccontoDeductionRepository(handle.db as unknown as AppDb);
+    const id = uuidv7();
+    const created = await repo.create({ id, finalInvoiceId: uuidv7(), accontoInvoiceId: uuidv7() } as never);
+    expect((created as { version?: number }).version).toBe(1);
+    expect(await repo.getById(id)).toMatchObject({ id });
+  });
+});

--- a/test/unit/server/repositories/expense-repository.test.ts
+++ b/test/unit/server/repositories/expense-repository.test.ts
@@ -1,0 +1,61 @@
+/**
+ * ExpenseRepository-paritet (ADR 0020, #409 fan-out) — in-memory + Drizzle
+ * (pglite). `listUnbilled` + `flagBilled` (bulk-koppling).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { expenses, matters, users } from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzleExpenseRepository } from "@/lib/server/repositories/drizzle-expense-repository";
+import { InMemoryExpenseRepository } from "@/lib/server/repositories/in-memory-expense-repository";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+describe("ExpenseRepository — in-memory", () => {
+  it("listUnbilled + flagBilled kopplar till faktura", async () => {
+    const matterId = uuidv7();
+    const e1 = uuidv7();
+    const e2 = uuidv7();
+    const store = new LocalStore({
+      matters: [{ id: matterId, organizationId: "org-1" }],
+      expenses: [
+        { id: e1, matterId, amount: 50_000, billable: true, invoiceId: null },
+        { id: e2, matterId, amount: 30_000, billable: true, invoiceId: null },
+      ],
+    }, async () => {});
+    const repo = new InMemoryExpenseRepository(store);
+
+    expect(await repo.listUnbilled(matterId, [e1, e2])).toHaveLength(2);
+    expect(await repo.listUnbilled(matterId, [])).toEqual([]);
+
+    await repo.flagBilled([e1], uuidv7());
+    expect(await repo.listUnbilled(matterId, [e1, e2])).toHaveLength(1); // e1 nu fakturerad
+  });
+});
+
+describe("ExpenseRepository — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("listUnbilled + flagBilled bulk-sätter invoiceId", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const mId = uuidv7();
+    const userId = uuidv7();
+    const e1 = uuidv7();
+    const e2 = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
+    await db.insert(users).values(v({ id: userId, organizationId: org, email: "a@x", name: "Anna" }));
+    await db.insert(expenses).values(v({ id: e1, userId, matterId: mId, date: new Date(), amount: 50_000, description: "x" }));
+    await db.insert(expenses).values(v({ id: e2, userId, matterId: mId, date: new Date(), amount: 30_000, description: "y" }));
+    const repo = new DrizzleExpenseRepository(handle.db as unknown as AppDb);
+
+    expect(await repo.listUnbilled(mId, [e1, e2])).toHaveLength(2);
+    await repo.flagBilled([e1], uuidv7());
+    expect(await repo.listUnbilled(mId, [e1, e2])).toHaveLength(1);
+  });
+});

--- a/test/unit/server/repositories/invoice-repository.test.ts
+++ b/test/unit/server/repositories/invoice-repository.test.ts
@@ -197,6 +197,26 @@ describe("InvoiceRepository — in-memory", () => {
     expect((await repo.getCreditNoteFor(origId))?.id).toBe(creditId);
     expect(await repo.getCreditNoteFor(uuidv7())).toBeNull(); // ej krediterad
   });
+
+  it("listDeductibleAccontos: ACCONTO i ärendet som ej redan avdragits", async () => {
+    const mId = uuidv7();
+    const acc1 = uuidv7();
+    const acc2 = uuidv7();
+    const finalId = uuidv7();
+    const store = new LocalStore({
+      matters: [{ id: mId, organizationId: "org-1", matterNumber: "2026-1", title: "T" }],
+      invoices: [
+        inv({ id: acc1, matterId: mId, invoiceType: "ACCONTO" }),
+        inv({ id: acc2, matterId: mId, invoiceType: "ACCONTO" }), // redan avdragen
+        inv({ id: finalId, matterId: mId, invoiceType: "FINAL" }),
+      ],
+      accontoDeductions: [{ id: uuidv7(), finalInvoiceId: finalId, accontoInvoiceId: acc2 }],
+      payments: [], writeOffs: [],
+    }, async () => {});
+    const repo = new InMemoryInvoiceRepository(store);
+    expect((await repo.listDeductibleAccontos(mId, [acc1, acc2])).map((a) => a.id)).toEqual([acc1]); // acc2 utesluten
+    expect(await repo.listDeductibleAccontos(mId, [])).toEqual([]);
+  });
 });
 
 describe("InvoiceRepository — Drizzle (pglite)", () => {
@@ -363,5 +383,22 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
     const repo = new DrizzleInvoiceRepository(handle.db as unknown as AppDb);
     expect((await repo.getCreditNoteFor(origId))?.id).toBe(creditId);
     expect(await repo.getCreditNoteFor(uuidv7())).toBeNull();
+  });
+
+  it("listDeductibleAccontos: ACCONTO ej redan avdragna (left-join)", async () => {
+    const db = handle.db;
+    const mId = uuidv7();
+    const acc1 = uuidv7();
+    const acc2 = uuidv7();
+    const finalId = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: mId, organizationId: uuidv7(), matterNumber: "2026-1", title: "T" }));
+    await db.insert(invoices).values(inv({ id: acc1, matterId: mId, invoiceType: "ACCONTO" }) as never);
+    await db.insert(invoices).values(inv({ id: acc2, matterId: mId, invoiceType: "ACCONTO" }) as never);
+    await db.insert(invoices).values(inv({ id: finalId, matterId: mId, invoiceType: "FINAL" }) as never);
+    await db.insert(accontoDeductions).values(v({ id: uuidv7(), finalInvoiceId: finalId, accontoInvoiceId: acc2 }));
+    const repo = new DrizzleInvoiceRepository(handle.db as unknown as AppDb);
+    expect((await repo.listDeductibleAccontos(mId, [acc1, acc2])).map((a) => a.id)).toEqual([acc1]);
   });
 });

--- a/test/unit/server/repositories/time-entry-repository.test.ts
+++ b/test/unit/server/repositories/time-entry-repository.test.ts
@@ -1,0 +1,68 @@
+/**
+ * TimeEntryRepository-paritet (ADR 0020, #409 fan-out) — in-memory + Drizzle
+ * (pglite). `listUnbilled` (med user.hourlyRate) + `flagBilled` (bulk-koppling).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { matters, timeEntries, users } from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzleTimeEntryRepository } from "@/lib/server/repositories/drizzle-time-entry-repository";
+import { InMemoryTimeEntryRepository } from "@/lib/server/repositories/in-memory-time-entry-repository";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+describe("TimeEntryRepository — in-memory", () => {
+  it("listUnbilled (user.hourlyRate) + flagBilled kopplar till faktura", async () => {
+    const matterId = uuidv7();
+    const userId = uuidv7();
+    const t1 = uuidv7();
+    const t2 = uuidv7();
+    const store = new LocalStore({
+      matters: [{ id: matterId, organizationId: "org-1" }],
+      users: [{ id: userId, name: "Anna", hourlyRate: 150_000 }],
+      timeEntries: [
+        { id: t1, userId, matterId, minutes: 60, billable: true, invoiceId: null },
+        { id: t2, userId, matterId, minutes: 30, billable: true, invoiceId: null },
+      ],
+    }, async () => {});
+    const repo = new InMemoryTimeEntryRepository(store);
+
+    const unbilled = await repo.listUnbilled(matterId, [t1, t2]);
+    expect(unbilled).toHaveLength(2);
+    expect(unbilled[0]!.user.hourlyRate).toBe(150_000);
+    expect(await repo.listUnbilled(matterId, [])).toEqual([]);
+
+    await repo.flagBilled([t1], uuidv7());
+    expect(await repo.listUnbilled(matterId, [t1, t2])).toHaveLength(1); // t1 nu fakturerad
+  });
+});
+
+describe("TimeEntryRepository — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("listUnbilled joinar user.hourlyRate + flagBilled bulk-sätter invoiceId", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const mId = uuidv7();
+    const userId = uuidv7();
+    const t1 = uuidv7();
+    const t2 = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
+    await db.insert(users).values(v({ id: userId, organizationId: org, email: "a@x", name: "Anna", hourlyRate: 150_000 }));
+    await db.insert(timeEntries).values(v({ id: t1, userId, matterId: mId, date: new Date(), minutes: 60, description: "x", hourlyRate: 1000 }));
+    await db.insert(timeEntries).values(v({ id: t2, userId, matterId: mId, date: new Date(), minutes: 30, description: "y", hourlyRate: 1000 }));
+    const repo = new DrizzleTimeEntryRepository(handle.db as unknown as AppDb);
+
+    const unbilled = await repo.listUnbilled(mId, [t1, t2]);
+    expect(unbilled).toHaveLength(2);
+    expect(unbilled[0]!.user.hourlyRate).toBe(150_000);
+
+    await repo.flagBilled([t1], uuidv7());
+    expect(await repo.listUnbilled(mId, [t1, t2])).toHaveLength(1);
+  });
+});

--- a/test/unit/server/routers/invoice.test.ts
+++ b/test/unit/server/routers/invoice.test.ts
@@ -194,9 +194,12 @@ describe("invoice.createFinal", () => {
       where: { id: { in: ["e1", "e2"] } },
       data: { invoiceId: "final-1" },
     });
-    expect(mockPrisma.invoiceAccontoDeduction.create).toHaveBeenCalledWith({
-      data: { finalInvoiceId: "final-1", accontoInvoiceId: "acc1" },
-    });
+    // Repo.create lägger version → matcha löst.
+    expect(mockPrisma.invoiceAccontoDeduction.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ finalInvoiceId: "final-1", accontoInvoiceId: "acc1" }),
+      }),
+    );
   });
 
   it("BAD_REQUEST om någon time entry redan är fakturerad (eller tillhör annat ärende)", async () => {


### PR DESCRIPTION
## What

The final invoice mutation (Q2 + Q3, approved "A"). After this, **the entire invoice router is off `ctx.dataStore` and on the typed repository seam** — the ADR 0020 invoice-entity migration is complete.

### New entities
- `TimeEntryRepository` + `ExpenseRepository`: `listUnbilled(matterId, ids)` (the count-check guard stays in the router helper; time entries carry `user.hourlyRate` for the breakdown) and typed `flagBilled(ids, invoiceId)` — **Q2=A** (bulk, not a generic `updateMany`).
- `AccontoDeductionRepository`: base CRUD (`create`).
- `InvoiceRepository.listDeductibleAccontos(matterId, ids)` — **Q3=A**: ACCONTO invoices in the matter not yet deducted on a FINAL (Drizzle: left-join + `IS NULL`; in-memory: `deductedOnFinals: { none: {} }`).

All three wired into the `Repositories` aggregate + both builders.

### `createFinal` migration
Moved to `ctx.repos.transaction`. The `fetchUnbilled*` helpers + `linkBilledItems` now take `repos` and call the typed methods; `computeFinalInvoiceBreakdown` stays in the router. This removes the **last** `ctx.dataStore` use from the invoice router, so the dead free `nextInvoiceNumber` helper and its now-unused imports (`DataStoreTx`, the format helpers) are dropped.

### Tests
Mocked router test: acconto-deduction `create` asserted via `objectContaining` (repo adds `version`). New in-memory + pglite parity tests for all three repos + `listDeductibleAccontos`.

## Verification
- `bun run quality` green (coverage gate green, clones unchanged at 13, deps + knip clean).
- `bun run build:demo` green.
- Integration scenario tests (real DemoDataStore, full final-invoice flow) green.

Refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)