### PR TITLE
feat(repositories): migrate expense router to typed repository (ADR 0020)

### DIFF
--- a/src/lib/server/repositories/drizzle-expense-repository.ts
+++ b/src/lib/server/repositories/drizzle-expense-repository.ts
@@ -3,16 +3,61 @@
  * `flagBilled` bulk-sätter invoiceId.
  */
 
-import { and, eq, inArray, isNull } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, sql } from "drizzle-orm";
 import type { Expense } from "@/lib/shared/schemas/billing";
-import { expenses } from "../db/schema";
+import { expenses, invoices, matters, users } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
-import type { ExpenseRepository } from "./expense-repository";
+import type {
+  ExpenseListOptions, ExpenseListResult, ExpenseListRow, ExpenseRepository,
+} from "./expense-repository";
 
 export class DrizzleExpenseRepository extends DrizzleRepository<Expense> implements ExpenseRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
     super(db, expenses as unknown as VersionedTable, now);
+  }
+
+  async listForOrg(organizationId: string, opts: ExpenseListOptions): Promise<ExpenseListResult> {
+    const where = and(
+      eq(matters.organizationId, organizationId),
+      opts.matterId ? eq(expenses.matterId, opts.matterId) : undefined,
+    );
+    const rows = await this.db
+      .select({
+        exp: expenses,
+        uId: users.id, uName: users.name,
+        mId: matters.id, mNum: matters.matterNumber, mTitle: matters.title,
+        invId: invoices.id, invNum: invoices.invoiceNumber,
+      })
+      .from(expenses)
+      .innerJoin(matters, eq(expenses.matterId, matters.id))
+      .leftJoin(users, eq(expenses.userId, users.id))
+      .leftJoin(invoices, eq(expenses.invoiceId, invoices.id))
+      .where(where)
+      .orderBy(desc(expenses.date))
+      .limit(opts.pageSize).offset((opts.page - 1) * opts.pageSize);
+    const [agg] = await this.db
+      .select({ total: sql<number>`count(*)`, sum: sql<number>`coalesce(sum(${expenses.amount}), 0)` })
+      .from(expenses).innerJoin(matters, eq(expenses.matterId, matters.id)).where(where);
+    return {
+      expenses: rows.map((r) => ({
+        ...(r.exp as object),
+        user: r.uId ? { id: r.uId, name: r.uName as string } : null,
+        matter: r.mId ? { id: r.mId, matterNumber: r.mNum as string, title: r.mTitle as string } : null,
+        invoice: r.invId ? { id: r.invId, invoiceNumber: r.invNum } : null,
+      })) as unknown as ExpenseListRow[],
+      total: Number(agg?.total ?? 0),
+      totalAmount: Number(agg?.sum ?? 0),
+    };
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<Expense | null> {
+    const rows = await this.db
+      .select({ exp: expenses }).from(expenses)
+      .innerJoin(matters, eq(expenses.matterId, matters.id))
+      .where(and(eq(expenses.id, id), eq(matters.organizationId, organizationId), isNull(expenses.deletedAt)))
+      .limit(1);
+    return (rows[0]?.exp as unknown as Expense | undefined) ?? null;
   }
 
   async listUnbilled(matterId: string, ids: string[]): Promise<Expense[]> {

--- a/src/lib/server/repositories/expense-repository.ts
+++ b/src/lib/server/repositories/expense-repository.ts
@@ -7,7 +7,32 @@
 import type { Expense } from "@/lib/shared/schemas/billing";
 import type { Repository } from "./types";
 
+/** Utlägg + listvyns relationer (motsvarar `expense.list`-routerns include). */
+export interface ExpenseListRow extends Expense {
+  user: { id: string; name: string } | null;
+  matter: { id: string; matterNumber: string; title: string } | null;
+  invoice: { id: string; invoiceNumber: string | null } | null;
+}
+
+/** Filter/paginering för `listForOrg`. */
+export interface ExpenseListOptions {
+  matterId?: string | undefined;
+  page: number;
+  pageSize: number;
+}
+
+/** Sidresultat: raderna + totalt antal + summa belopp (för listvyns rubrik). */
+export interface ExpenseListResult {
+  expenses: ExpenseListRow[];
+  total: number;
+  totalAmount: number;
+}
+
 export interface ExpenseRepository extends Repository<Expense> {
+  /** Org-scopad, paginerad utläggslista (nyaste först) + total + summa belopp. */
+  listForOrg(organizationId: string, opts: ExpenseListOptions): Promise<ExpenseListResult>;
+  /** Utlägg by id, org-scopat via ärendet (null om saknas/annan org/raderat). */
+  getByIdInOrg(id: string, organizationId: string): Promise<Expense | null>;
   /** Valda ofakturerade utlägg i ett ärende. Tom lista vid tomma ids. */
   listUnbilled(matterId: string, ids: string[]): Promise<Expense[]>;
   /** Koppla utlägg till en faktura (sätter invoiceId). No-op vid tomma ids. */

--- a/src/lib/server/repositories/in-memory-expense-repository.ts
+++ b/src/lib/server/repositories/in-memory-expense-repository.ts
@@ -5,7 +5,7 @@
 
 import type { Expense } from "@/lib/shared/schemas/billing";
 import type { Delegate, IDataStore } from "../data-store/IDataStore";
-import type { ExpenseRepository } from "./expense-repository";
+import type { ExpenseListOptions, ExpenseListResult, ExpenseListRow, ExpenseRepository } from "./expense-repository";
 import { InMemoryRepository } from "./in-memory-repository";
 
 /** Delegaten repot behöver — uppfylls av `IDataStore`, `DataStoreTx` och `LocalStore`. */
@@ -14,6 +14,35 @@ export type ExpenseRepoSource = Pick<IDataStore, "expenses">;
 export class InMemoryExpenseRepository extends InMemoryRepository<Expense> implements ExpenseRepository {
   constructor(store: ExpenseRepoSource, now?: () => Date) {
     super(store.expenses as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async listForOrg(organizationId: string, opts: ExpenseListOptions): Promise<ExpenseListResult> {
+    const where = {
+      matter: { organizationId },
+      ...(opts.matterId ? { matterId: opts.matterId } : {}),
+    };
+    const [expenses, total] = await Promise.all([
+      this.delegate.findMany({
+        where,
+        orderBy: { date: "desc" },
+        skip: (opts.page - 1) * opts.pageSize,
+        take: opts.pageSize,
+        include: {
+          user: { select: { id: true, name: true } },
+          matter: { select: { id: true, matterNumber: true, title: true } },
+          invoice: { select: { id: true, invoiceNumber: true } },
+        },
+      }) as Promise<ExpenseListRow[]>,
+      this.delegate.count({ where }),
+    ]);
+    const agg = await this.delegate.aggregate({ where, _sum: { amount: true } });
+    return { expenses, total, totalAmount: (agg as { _sum?: { amount?: number } })._sum?.amount ?? 0 };
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<Expense | null> {
+    const row = (await this.delegate
+      .findFirst({ where: { id, matter: { organizationId } } })) as Expense | null;
+    return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }
 
   async listUnbilled(matterId: string, ids: string[]): Promise<Expense[]> {

--- a/src/lib/server/routers/expense.ts
+++ b/src/lib/server/routers/expense.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
+import type { Expense } from "@/lib/shared/schemas/billing";
 import {
   asId,
   matterIdSchema,
@@ -18,36 +19,17 @@ export const expenseRouter = router({
         pageSize: z.number().min(1).max(100).default(50),
       })
     )
+    // Migrerad till repository-sömmen (ADR 0020): paginerad list + summa via
+    // typad listForOrg (org-scope, include + count + sum inkapslat).
     .query(async ({ ctx, input }) => {
-      const where = {
-        matter: { organizationId: ctx.user.organizationId },
-        ...(input.matterId ? { matterId: input.matterId } : {}),
-      };
-
-      const [expenses, total] = await Promise.all([
-        ctx.dataStore.expenses.findMany({
-          where,
-          orderBy: { date: "desc" },
-          skip: (input.page - 1) * input.pageSize,
-          take: input.pageSize,
-          include: {
-            user: { select: { id: true, name: true } },
-            matter: { select: { id: true, matterNumber: true, title: true } },
-            invoice: { select: { id: true, invoiceNumber: true } },
-          },
-        }),
-        ctx.dataStore.expenses.count({ where }),
-      ]);
-
-      const totalAmount = await ctx.dataStore.expenses.aggregate({
-        where,
-        _sum: { amount: true },
-      });
-
+      const { expenses, total, totalAmount } = await ctx.repos.expenses.listForOrg(
+        ctx.user.organizationId,
+        { matterId: input.matterId, page: input.page, pageSize: input.pageSize },
+      );
       return {
         expenses,
         total,
-        totalAmount: totalAmount._sum.amount ?? 0,
+        totalAmount,
         pages: Math.ceil(total / input.pageSize),
       };
     }),
@@ -72,21 +54,19 @@ export const expenseRouter = router({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      return ctx.dataStore.expenses.create({
-        data: omitUndefined({
-          id: input.id, // undefined → store genererar
-          userId: input.userId ?? asId<"UserId">(ctx.user.id),
-          matterId: input.matterId,
-          date: new Date(input.date),
-          amount: input.amount,
-          description: input.description,
-          billable: input.billable,
-          vatRate: input.vatRate,
-          vatIncluded: input.vatIncluded,
-          invoiceId: input.invoiceId ?? null,
-          ...(input.createdAt ? { createdAt: new Date(input.createdAt) } : {}),
-        }),
-      });
+      return ctx.repos.expenses.create(omitUndefined({
+        id: input.id, // undefined → store genererar
+        userId: input.userId ?? asId<"UserId">(ctx.user.id),
+        matterId: input.matterId,
+        date: new Date(input.date),
+        amount: input.amount,
+        description: input.description,
+        billable: input.billable,
+        vatRate: input.vatRate,
+        vatIncluded: input.vatIncluded,
+        invoiceId: input.invoiceId ?? null,
+        ...(input.createdAt ? { createdAt: new Date(input.createdAt) } : {}),
+      }) as Partial<Expense>);
     }),
 
   update: orgProcedure
@@ -104,31 +84,27 @@ export const expenseRouter = router({
     .mutation(async ({ ctx, input }) => {
       // Säkerhet (#60): verifiera org-ägarskap (via matter, samma scopning som
       // `list`) INNAN update. NOT_FOUND vid mismatch — läcker inte existens.
-      const owned = await ctx.dataStore.expenses.findFirst({
-        where: { id: input.id, matter: { organizationId: ctx.orgId } },
-      });
+      const owned = await ctx.repos.expenses.getByIdInOrg(input.id, ctx.orgId);
       if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
       const { id, date, amount, description, billable, vatRate, vatIncluded } = input;
-      return ctx.dataStore.expenses.update({
-        where: { id },
-        data: omitUndefined({
-          amount,
-          description,
-          billable,
-          vatRate,
-          vatIncluded,
-          ...(date ? { date: new Date(date) } : {}),
-        }),
-      });
+      return ctx.repos.expenses.update(id, omitUndefined({
+        amount,
+        description,
+        billable,
+        vatRate,
+        vatIncluded,
+        ...(date ? { date: new Date(date) } : {}),
+      }) as Partial<Expense>);
     }),
 
   delete: orgProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      const owned = await ctx.dataStore.expenses.findFirst({
-        where: { id: input.id, matter: { organizationId: ctx.orgId } },
-      });
+      const owned = await ctx.repos.expenses.getByIdInOrg(input.id, ctx.orgId);
       if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
-      return ctx.dataStore.expenses.delete({ where: { id: input.id } });
+      // Hård delete bevarar dagens beteende (utlägg tombstone-as ej). Se ADR 0017-
+      // not om delete-policy (cross-cutting, ej avgjort per router).
+      await ctx.repos.expenses.hardDelete(input.id);
+      return { id: input.id };
     }),
 });

--- a/test/unit/server/repositories/expense-repository.test.ts
+++ b/test/unit/server/repositories/expense-repository.test.ts
@@ -32,6 +32,38 @@ describe("ExpenseRepository — in-memory", () => {
     await repo.flagBilled([e1], uuidv7());
     expect(await repo.listUnbilled(matterId, [e1, e2])).toHaveLength(1); // e1 nu fakturerad
   });
+
+  it("listForOrg paginerar, summerar och inkluderar relationer", async () => {
+    const mId = uuidv7();
+    const userId = uuidv7();
+    const store = new LocalStore({
+      matters: [{ id: mId, organizationId: "org-1", matterNumber: "2026-1", title: "T" }],
+      users: [{ id: userId, name: "Anna" }],
+      expenses: [
+        { id: uuidv7(), userId, matterId: mId, amount: 50_000, date: new Date("2026-06-02"), description: "a", billable: true, invoiceId: null },
+        { id: uuidv7(), userId, matterId: mId, amount: 30_000, date: new Date("2026-06-01"), description: "b", billable: true, invoiceId: null },
+      ],
+    }, async () => {});
+    const repo = new InMemoryExpenseRepository(store);
+    const res = await repo.listForOrg("org-1", { page: 1, pageSize: 50 });
+    expect(res.total).toBe(2);
+    expect(res.totalAmount).toBe(80_000);
+    expect(res.expenses[0]!.matter?.matterNumber).toBe("2026-1");
+    expect(res.expenses[0]!.user?.name).toBe("Anna");
+    expect((await repo.listForOrg("org-2", { page: 1, pageSize: 50 })).total).toBe(0); // fel org
+  });
+
+  it("getByIdInOrg org-scopar via ärendet", async () => {
+    const mId = uuidv7();
+    const eId = uuidv7();
+    const store = new LocalStore({
+      matters: [{ id: mId, organizationId: "org-1" }],
+      expenses: [{ id: eId, matterId: mId, amount: 1, date: new Date(), description: "x" }],
+    }, async () => {});
+    const repo = new InMemoryExpenseRepository(store);
+    expect(await repo.getByIdInOrg(eId, "org-1")).toMatchObject({ id: eId });
+    expect(await repo.getByIdInOrg(eId, "org-2")).toBeNull(); // fel org
+  });
 });
 
 describe("ExpenseRepository — Drizzle (pglite)", () => {
@@ -57,5 +89,41 @@ describe("ExpenseRepository — Drizzle (pglite)", () => {
     expect(await repo.listUnbilled(mId, [e1, e2])).toHaveLength(2);
     await repo.flagBilled([e1], uuidv7());
     expect(await repo.listUnbilled(mId, [e1, e2])).toHaveLength(1);
+  });
+
+  it("listForOrg joinar relationer + summerar i SQL", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const mId = uuidv7();
+    const userId = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
+    await db.insert(users).values(v({ id: userId, organizationId: org, email: "a@x", name: "Anna" }));
+    await db.insert(expenses).values(v({ id: uuidv7(), userId, matterId: mId, date: new Date("2026-06-02"), amount: 50_000, description: "a" }));
+    await db.insert(expenses).values(v({ id: uuidv7(), userId, matterId: mId, date: new Date("2026-06-01"), amount: 30_000, description: "b" }));
+    const repo = new DrizzleExpenseRepository(handle.db as unknown as AppDb);
+    const res = await repo.listForOrg(org, { page: 1, pageSize: 50 });
+    expect(res.total).toBe(2);
+    expect(res.totalAmount).toBe(80_000);
+    expect(res.expenses[0]!.matter?.matterNumber).toBe("2026-1");
+    expect(res.expenses[0]!.user?.name).toBe("Anna");
+    expect(res.expenses[0]!.amount).toBe(50_000); // nyaste först (date desc)
+  });
+
+  it("getByIdInOrg org-scopar via join mot matters", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const mId = uuidv7();
+    const userId = uuidv7();
+    const eId = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
+    await db.insert(users).values(v({ id: userId, organizationId: org, email: "a@x", name: "Anna" }));
+    await db.insert(expenses).values(v({ id: eId, userId, matterId: mId, date: new Date(), amount: 1, description: "x" }));
+    const repo = new DrizzleExpenseRepository(handle.db as unknown as AppDb);
+    expect(await repo.getByIdInOrg(eId, org)).toMatchObject({ id: eId });
+    expect(await repo.getByIdInOrg(eId, uuidv7())).toBeNull();
   });
 });

--- a/test/unit/server/routers/expense.test.ts
+++ b/test/unit/server/routers/expense.test.ts
@@ -6,6 +6,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import { expenseRouter } from "@/lib/server/routers/expense";
 import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
 
@@ -22,9 +24,11 @@ const mockPrisma = {
 };
 
 function makeCaller(orgId = "org-a", userId = "u1") {
+  const dataStore = dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>);
   const ctx = {
     user: { id: userId, email: "a@b.se", name: "T", role: "LAWYER", organizationId: orgId },
-    prisma: mockPrisma, dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+    prisma: mockPrisma, dataStore,
+    repos: buildInMemoryRepositories(dataStore as unknown as IDataStore),
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return expenseRouter.createCaller(ctx as any);


### PR DESCRIPTION
## What

First **non-invoice** router on the repository seam — the invoice entity is fully migrated (#442–#451), so the fan-out now moves to the other routers.

### `ExpenseRepository` additions
- `listForOrg(orgId, { matterId?, page, pageSize })` → `{ expenses, total, totalAmount }`, where each row carries the `user` / `matter` / `invoice` subsets the list view shows. In-memory uses the delegate's `findMany` + `count` + `aggregate`; Drizzle joins `matters`/`users`/`invoices` and does `count(*)` + `coalesce(sum(amount),0)` in SQL.
- `getByIdInOrg(id, orgId)` — the org-ownership check (#60), scoped via the matter.

### Router
`expense.{list,create,update,delete}` moved off `ctx.dataStore` onto `ctx.repos.expenses`.

**Delete:** keeps today's **hard-delete** behaviour via the base `hardDelete`. Whether user-facing deletes should become tombstones (ADR 0017) is a cross-cutting policy question across all routers — flagged here, not decided per-router.

### Tests
The mocked router test ctx is wired with `repos`; assertions are unchanged because the in-memory repo preserves the underlying `findMany`/`delete` call shapes (field-level reads tolerate the `version` bump). New in-memory + pglite parity tests for `listForOrg` + `getByIdInOrg`.

## Verification
- `bun run quality` green (coverage gate green, clones 13→11, deps + knip clean).
- `bun run build:demo` green.

Refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)