### PR TITLE
feat(repositories): migrate contact router to typed repository (ADR 0020)

### DIFF
--- a/src/app/contacts/[id]/_client.tsx
+++ b/src/app/contacts/[id]/_client.tsx
@@ -298,7 +298,7 @@ function ChildContactsSection(p: ChildSectionProps) {
         />
       )}
       <div className="divide-y divide-gray-100">
-        {children.map((child: { id: string; name: string; contactType: string; email: string | null; phone: string | null; notes: string | null }) => (
+        {children.map((child) => (
           <EntityLink key={child.id} route="contacts" id={child.id} className="block px-6 py-3 hover:bg-gray-50">
             <p className="text-sm font-medium text-gray-900">{child.name}</p>
             <p className="text-xs text-gray-500">

--- a/src/lib/server/repositories/contact-repository.ts
+++ b/src/lib/server/repositories/contact-repository.ts
@@ -1,0 +1,52 @@
+/**
+ * `ContactRepository` (ADR 0020, #409 fan-out) — kontakter (klienter/motparter/
+ * domstolar m.m.). Bas-CRUD ärvs; `listForOrg` ger topp-nivå-listan med
+ * relations-antal (_count) och `getByIdFull` hela detaljvyn (barn/förälder/
+ * ärende-kopplingar). Org-scopas direkt på `organizationId`.
+ */
+
+import type { Contact } from "@/lib/shared/schemas/contact";
+import type { Repository } from "./types";
+
+/** Kontakt + antal relationer (listvyns _count). */
+export interface ContactListRow extends Contact {
+  _count: { matterLinks: number; children: number };
+}
+
+/** En ärende-koppling med ärendets sammanfattning (detaljvyns matterLinks). */
+export interface ContactMatterLink {
+  id: string;
+  matterId: string;
+  contactId: string;
+  role: string;
+  notes: string | null;
+  /** Alltid satt — `matterId` är NOT NULL FK, så ärendet finns alltid. */
+  matter: { id: string; matterNumber: string; title: string; status: string };
+}
+
+/** Full kontakt-detalj (motsvarar `contact.getById`-routerns include). */
+export interface ContactFull extends Contact {
+  children: Contact[];
+  parent: { id: string; name: string } | null;
+  matterLinks: ContactMatterLink[];
+}
+
+/** Filter/paginering för `listForOrg`. */
+export interface ContactListOptions {
+  search?: string | undefined;
+  contactType?: string | undefined;
+  page: number;
+  pageSize: number;
+}
+
+export interface ContactListResult {
+  contacts: ContactListRow[];
+  total: number;
+}
+
+export interface ContactRepository extends Repository<Contact> {
+  /** Topp-nivå-kontakter (parentId null) i org:en, paginerat + sökbart, med _count. */
+  listForOrg(organizationId: string, opts: ContactListOptions): Promise<ContactListResult>;
+  /** Full kontakt-detalj (barn/förälder/ärende-kopplingar), org-scopad. Null om saknas/raderad. */
+  getByIdFull(id: string, organizationId: string): Promise<ContactFull | null>;
+}

--- a/src/lib/server/repositories/drizzle-contact-repository.ts
+++ b/src/lib/server/repositories/drizzle-contact-repository.ts
@@ -1,0 +1,103 @@
+/**
+ * Drizzle `ContactRepository` (ADR 0020) — server-impl. Ärver bas-CRUD;
+ * `listForOrg` använder korrelerade subqueries för _count (matter-kopplingar +
+ * barn) och `getByIdFull` sätter ihop detaljvyn via sekundär-queries.
+ */
+
+import { and, asc, desc, eq, ilike, inArray, isNull, like, or, sql } from "drizzle-orm";
+import type { PgColumn, PgTable } from "drizzle-orm/pg-core";
+import type { Contact } from "@/lib/shared/schemas/contact";
+import { contacts, matterContacts, matters } from "../db/schema";
+import type { AppDb } from "../db/types";
+import type {
+  ContactFull, ContactListOptions, ContactListResult, ContactListRow, ContactRepository,
+} from "./contact-repository";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+
+export class DrizzleContactRepository extends DrizzleRepository<Contact> implements ContactRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, contacts as unknown as VersionedTable, now);
+  }
+
+  async listForOrg(organizationId: string, opts: ContactListOptions): Promise<ContactListResult> {
+    const where = and(
+      eq(contacts.organizationId, organizationId),
+      isNull(contacts.parentId), // bara topp-nivå
+      isNull(contacts.deletedAt),
+      opts.contactType ? eq(contacts.contactType, opts.contactType) : undefined,
+      opts.search
+        ? or(
+            ilike(contacts.name, `%${opts.search}%`),
+            like(contacts.personalNumber, `%${opts.search}%`),
+            like(contacts.orgNumber, `%${opts.search}%`),
+            ilike(contacts.email, `%${opts.search}%`),
+          )
+        : undefined,
+    );
+    const rows = await this.db
+      .select().from(contacts)
+      .where(where)
+      .orderBy(asc(contacts.name))
+      .limit(opts.pageSize).offset((opts.page - 1) * opts.pageSize);
+    const [{ total } = { total: 0 }] = await this.db
+      .select({ total: sql<number>`count(*)` }).from(contacts).where(where);
+    // _count via grupperade frågor över sidans ids (robustare än korrelerade subqueries).
+    const ids = rows.map((r) => (r as { id: string }).id);
+    const linkCounts = await this.countBy(matterContacts, matterContacts.contactId, ids);
+    const childCounts = await this.countBy(contacts, contacts.parentId, ids);
+    return {
+      contacts: rows.map((r) => {
+        const id = (r as { id: string }).id;
+        return {
+          ...(r as object),
+          _count: { matterLinks: linkCounts.get(id) ?? 0, children: childCounts.get(id) ?? 0 },
+        };
+      }) as unknown as ContactListRow[],
+      total: Number(total),
+    };
+  }
+
+  /** Antal rader i `table` grupperat på `column`, begränsat till `ids` → Map(id→antal). */
+  private async countBy(table: PgTable, column: PgColumn, ids: string[]): Promise<Map<string, number>> {
+    if (!ids.length) return new Map();
+    const rows = await this.db
+      .select({ key: column, n: sql<number>`count(*)` })
+      .from(table)
+      .where(inArray(column, ids))
+      .groupBy(column);
+    return new Map(rows.map((r) => [String(r.key), Number(r.n)]));
+  }
+
+  async getByIdFull(id: string, organizationId: string): Promise<ContactFull | null> {
+    const [c] = await this.db
+      .select().from(contacts)
+      .where(and(eq(contacts.id, id), eq(contacts.organizationId, organizationId), isNull(contacts.deletedAt)))
+      .limit(1);
+    if (!c) return null;
+    const children = await this.db
+      .select().from(contacts)
+      .where(and(eq(contacts.parentId, id), isNull(contacts.deletedAt))).orderBy(asc(contacts.name));
+    const parentId = (c as { parentId?: string | null }).parentId;
+    const parentRows = parentId
+      ? await this.db.select({ id: contacts.id, name: contacts.name }).from(contacts).where(eq(contacts.id, parentId)).limit(1)
+      : [];
+    const linkRows = await this.db
+      .select({
+        mc: matterContacts,
+        mId: matters.id, mNum: matters.matterNumber, mTitle: matters.title, mStatus: matters.status,
+      })
+      .from(matterContacts)
+      .innerJoin(matters, eq(matterContacts.matterId, matters.id)) // matterId NOT NULL FK → matter finns alltid
+      .where(eq(matterContacts.contactId, id))
+      .orderBy(desc(matterContacts.createdAt));
+    return {
+      ...(c as object),
+      children: children as unknown as Contact[],
+      parent: parentRows[0] ? { id: parentRows[0].id, name: parentRows[0].name as string } : null,
+      matterLinks: linkRows.map((l) => ({
+        ...(l.mc as object),
+        matter: { id: l.mId, matterNumber: l.mNum as string, title: l.mTitle as string, status: l.mStatus as string },
+      })),
+    } as unknown as ContactFull;
+  }
+}

--- a/src/lib/server/repositories/in-memory-contact-repository.ts
+++ b/src/lib/server/repositories/in-memory-contact-repository.ts
@@ -1,0 +1,65 @@
+/**
+ * In-memory `ContactRepository` (ADR 0020) — browser/offline-impl. Ärver bas-CRUD;
+ * list/detalj använder samma include som routern (query-engine resolvar _count +
+ * nästlade relationer).
+ */
+
+import type { Contact } from "@/lib/shared/schemas/contact";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type {
+  ContactFull, ContactListOptions, ContactListResult, ContactListRow, ContactRepository,
+} from "./contact-repository";
+import { InMemoryRepository } from "./in-memory-repository";
+
+/** Delegaten repot behöver — uppfylls av `IDataStore`, `DataStoreTx` och `LocalStore`. */
+export type ContactRepoSource = Pick<IDataStore, "contacts">;
+
+export class InMemoryContactRepository extends InMemoryRepository<Contact> implements ContactRepository {
+  constructor(store: ContactRepoSource, now?: () => Date) {
+    super(store.contacts as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async listForOrg(organizationId: string, opts: ContactListOptions): Promise<ContactListResult> {
+    const where = {
+      organizationId,
+      parentId: null,
+      ...(opts.contactType ? { contactType: opts.contactType } : {}),
+      ...(opts.search
+        ? {
+            OR: [
+              { name: { contains: opts.search, mode: "insensitive" as const } },
+              { personalNumber: { contains: opts.search } },
+              { orgNumber: { contains: opts.search } },
+              { email: { contains: opts.search, mode: "insensitive" as const } },
+            ],
+          }
+        : {}),
+    };
+    const [contacts, total] = await Promise.all([
+      this.delegate.findMany({
+        where,
+        orderBy: { name: "asc" },
+        skip: (opts.page - 1) * opts.pageSize,
+        take: opts.pageSize,
+        include: { _count: { select: { matterLinks: true, children: true } } },
+      }) as Promise<ContactListRow[]>,
+      this.delegate.count({ where }),
+    ]);
+    return { contacts, total };
+  }
+
+  async getByIdFull(id: string, organizationId: string): Promise<ContactFull | null> {
+    const row = (await this.delegate.findFirst({
+      where: { id, organizationId },
+      include: {
+        children: { orderBy: { name: "asc" } },
+        parent: { select: { id: true, name: true } },
+        matterLinks: {
+          orderBy: { createdAt: "desc" },
+          include: { matter: { select: { id: true, matterNumber: true, title: true, status: true } } },
+        },
+      },
+    })) as ContactFull | null;
+    return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
+  }
+}

--- a/src/lib/server/repositories/in-memory-repositories.ts
+++ b/src/lib/server/repositories/in-memory-repositories.ts
@@ -10,6 +10,7 @@
 
 import type { DataStoreTx, IDataStore } from "../data-store/IDataStore";
 import { InMemoryAccontoDeductionRepository } from "./in-memory-acconto-deduction-repository";
+import { InMemoryContactRepository } from "./in-memory-contact-repository";
 import { InMemoryExpenseRepository } from "./in-memory-expense-repository";
 import { InMemoryInvoiceRepository } from "./in-memory-invoice-repository";
 import { InMemoryMatterRepository } from "./in-memory-matter-repository";
@@ -30,6 +31,7 @@ function reposForTx(tx: DataStoreTx): Repositories {
     timeEntries: new InMemoryTimeEntryRepository(tx),
     expenses: new InMemoryExpenseRepository(tx),
     accontoDeductions: new InMemoryAccontoDeductionRepository(tx),
+    contacts: new InMemoryContactRepository(tx),
     transaction: (fn) => fn(repos),
   };
   return repos;
@@ -45,6 +47,7 @@ export function buildInMemoryRepositories(dataStore: IDataStore): Repositories {
     timeEntries: new InMemoryTimeEntryRepository(dataStore),
     expenses: new InMemoryExpenseRepository(dataStore),
     accontoDeductions: new InMemoryAccontoDeductionRepository(dataStore),
+    contacts: new InMemoryContactRepository(dataStore),
     transaction: (fn) => dataStore.transaction((tx) => fn(reposForTx(tx))),
   };
 }

--- a/src/lib/server/repositories/repositories.ts
+++ b/src/lib/server/repositories/repositories.ts
@@ -6,6 +6,7 @@
  */
 
 import type { AccontoDeductionRepository } from "./acconto-deduction-repository";
+import type { ContactRepository } from "./contact-repository";
 import type { ExpenseRepository } from "./expense-repository";
 import type { InvoiceRepository } from "./invoice-repository";
 import type { MatterRepository } from "./matter-repository";
@@ -23,5 +24,6 @@ export interface Repositories {
   timeEntries: TimeEntryRepository;
   expenses: ExpenseRepository;
   accontoDeductions: AccontoDeductionRepository;
+  contacts: ContactRepository;
   transaction<T>(fn: (tx: Repositories) => Promise<T>): Promise<T>;
 }

--- a/src/lib/server/routers/contact.ts
+++ b/src/lib/server/routers/contact.ts
@@ -1,9 +1,10 @@
 import { z } from "zod";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
+import type { Contact } from "@/lib/shared/schemas/contact";
 import { contactTypeSchema } from "@/lib/shared/schemas/enums";
 import { contactIdSchema, asId } from "@/lib/shared/schemas/ids";
 import { emit } from "../events/emit";
-import { router, orgProcedure, requireOrgOwned } from "../trpc";
+import { router, orgProcedure, requireOrgOwned, TRPCError } from "../trpc";
 
 export const contactRouter = router({
   list: orgProcedure
@@ -17,57 +18,25 @@ export const contactRouter = router({
         pageSize: z.number().min(1).max(1000).default(20),
       })
     )
+    // Migrerad till repository-sömmen (ADR 0020): listForOrg kapslar in
+    // topp-nivå-filter, sök och _count.
     .query(async ({ ctx, input }) => {
-      const where = {
-        organizationId: ctx.orgId,
-        parentId: null, // Only top-level contacts, not sub-contacts
-        ...(input.contactType ? { contactType: input.contactType } : {}),
-        ...(input.search
-          ? {
-              OR: [
-                { name: { contains: input.search, mode: "insensitive" as const } },
-                { personalNumber: { contains: input.search } },
-                { orgNumber: { contains: input.search } },
-                { email: { contains: input.search, mode: "insensitive" as const } },
-              ],
-            }
-          : {}),
-      };
-
-      const [contacts, total] = await Promise.all([
-        ctx.dataStore.contacts.findMany({
-          where,
-          orderBy: { name: "asc" },
-          skip: (input.page - 1) * input.pageSize,
-          take: input.pageSize,
-          include: {
-            _count: { select: { matterLinks: true, children: true } },
-          },
-        }),
-        ctx.dataStore.contacts.count({ where }),
-      ]);
-
+      const { contacts, total } = await ctx.repos.contacts.listForOrg(ctx.orgId, {
+        search: input.search,
+        contactType: input.contactType,
+        page: input.page,
+        pageSize: input.pageSize,
+      });
       return { contacts, total, pages: Math.ceil(total / input.pageSize) };
     }),
 
   getById: orgProcedure
     .input(z.object({ id: z.string() }))
+    // Migrerad: getByIdFull (barn/förälder/ärende-kopplingar), org-scopad.
     .query(async ({ ctx, input }) => {
-      return ctx.dataStore.contacts.findFirstOrThrow({
-        where: { id: input.id, organizationId: ctx.orgId },
-        include: {
-          children: { orderBy: { name: "asc" } },
-          parent: { select: { id: true, name: true } },
-          matterLinks: {
-            orderBy: { createdAt: "desc" },
-            include: {
-              matter: {
-                select: { id: true, matterNumber: true, title: true, status: true },
-              },
-            },
-          },
-        },
-      });
+      const contact = await ctx.repos.contacts.getByIdFull(input.id, ctx.orgId);
+      if (!contact) throw new TRPCError({ code: "NOT_FOUND" });
+      return contact;
     }),
 
   create: orgProcedure
@@ -87,13 +56,11 @@ export const contactRouter = router({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const contact = await ctx.dataStore.contacts.create({
-        data: {
-          ...omitUndefined(input),
-          email: input.email || null,
-          organizationId: asId<"OrganizationId">(ctx.orgId),
-        },
-      });
+      const contact = await ctx.repos.contacts.create({
+        ...omitUndefined(input),
+        email: input.email || null,
+        organizationId: asId<"OrganizationId">(ctx.orgId),
+      } as Partial<Contact>);
       await emit.contactCreated(ctx, contact);
       return contact;
     }),
@@ -115,18 +82,15 @@ export const contactRouter = router({
     .mutation(async ({ ctx, input }) => {
       // Säkerhet: verifiera att kontakten tillhör anropande org innan update.
       await requireOrgOwned(
-        () => ctx.dataStore.contacts.findUnique({ where: { id: input.id } }),
+        () => ctx.repos.contacts.getById(input.id),
         ctx.orgId,
         (c) => c.organizationId,
       );
       const { id, ...data } = input;
-      const updated = await ctx.dataStore.contacts.update({
-        where: { id },
-        data: {
-          ...omitUndefined(data),
-          email: input.email || null,
-        },
-      });
+      const updated = await ctx.repos.contacts.update(id, {
+        ...omitUndefined(data),
+        email: input.email || null,
+      } as Partial<Contact>);
       await emit.contactUpdated(ctx, id, data);
       return updated;
     }),
@@ -135,13 +99,14 @@ export const contactRouter = router({
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
       await requireOrgOwned(
-        () => ctx.dataStore.contacts.findUnique({ where: { id: input.id } }),
+        () => ctx.repos.contacts.getById(input.id),
         ctx.orgId,
         (c) => c.organizationId,
       );
-      const result = await ctx.dataStore.contacts.delete({ where: { id: input.id } });
+      // Hård delete bevarar dagens beteende (se ADR 0017-not om delete-policy).
+      await ctx.repos.contacts.hardDelete(input.id);
       await emit.contactDeleted(ctx, input.id);
-      return result;
+      return { id: input.id };
     }),
 
   // Add a contact person to an organization
@@ -157,20 +122,18 @@ export const contactRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       await requireOrgOwned(
-        () => ctx.dataStore.contacts.findUnique({ where: { id: input.parentId } }),
+        () => ctx.repos.contacts.getById(input.parentId),
         ctx.orgId,
         (c) => c.organizationId,
       );
-      return ctx.dataStore.contacts.create({
-        data: {
-          name: input.name,
-          contactType: "PERSON",
-          email: input.email || null,
-          phone: input.phone,
-          notes: input.notes,
-          parentId: input.parentId,
-          organizationId: asId<"OrganizationId">(ctx.orgId),
-        },
-      });
+      return ctx.repos.contacts.create({
+        name: input.name,
+        contactType: "PERSON",
+        email: input.email || null,
+        phone: input.phone,
+        notes: input.notes,
+        parentId: input.parentId,
+        organizationId: asId<"OrganizationId">(ctx.orgId),
+      } as Partial<Contact>);
     }),
 });

--- a/test/unit/server/repositories/contact-repository.test.ts
+++ b/test/unit/server/repositories/contact-repository.test.ts
@@ -1,0 +1,94 @@
+/**
+ * ContactRepository-paritet (ADR 0020, #409 fan-out) — in-memory + Drizzle
+ * (pglite). `listForOrg` (topp-nivå + _count + sök) och `getByIdFull`
+ * (barn/förälder/ärende-kopplingar).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { contacts, matterContacts, matters } from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzleContactRepository } from "@/lib/server/repositories/drizzle-contact-repository";
+import { InMemoryContactRepository } from "@/lib/server/repositories/in-memory-contact-repository";
+import { prebakeJoins } from "@/lib/shared/demo-source";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+describe("ContactRepository — in-memory", () => {
+  function seed() {
+    const c1 = uuidv7();
+    const child = uuidv7();
+    const mId = uuidv7();
+    // prebakeJoins speglar demo-runtime → nästlade relationer (matterLinks.matter)
+    // resolvas, precis som i produktion.
+    const source = prebakeJoins({
+      contacts: [
+        { id: c1, organizationId: "org-1", name: "Anna AB", contactType: "COMPANY", parentId: null },
+        { id: child, organizationId: "org-1", name: "Anställd", contactType: "PERSON", parentId: c1 },
+      ],
+      matters: [{ id: mId, organizationId: "org-1", matterNumber: "2026-1", title: "T", status: "ACTIVE" }],
+      matterContacts: [{ id: uuidv7(), matterId: mId, contactId: c1, role: "KLIENT" }],
+    } as DemoSource);
+    const store = new LocalStore(source, async () => {});
+    return { store, c1, child };
+  }
+
+  it("listForOrg: topp-nivå + _count + sök", async () => {
+    const { store, c1 } = seed();
+    const repo = new InMemoryContactRepository(store);
+    const res = await repo.listForOrg("org-1", { page: 1, pageSize: 50 });
+    expect(res.total).toBe(1); // child (parentId satt) exkluderad
+    expect(res.contacts[0]!.id).toBe(c1);
+    expect(res.contacts[0]!._count.children).toBe(1);
+    expect(res.contacts[0]!._count.matterLinks).toBe(1);
+    expect((await repo.listForOrg("org-1", { search: "Anna", page: 1, pageSize: 50 })).total).toBe(1);
+    expect((await repo.listForOrg("org-1", { search: "Zzz", page: 1, pageSize: 50 })).total).toBe(0);
+    expect((await repo.listForOrg("org-2", { page: 1, pageSize: 50 })).total).toBe(0); // fel org
+  });
+
+  it("getByIdFull: barn + ärende-kopplingar, org-scopad", async () => {
+    const { store, c1 } = seed();
+    const repo = new InMemoryContactRepository(store);
+    const full = await repo.getByIdFull(c1, "org-1");
+    expect(full?.children).toHaveLength(1);
+    expect(full?.matterLinks).toHaveLength(1);
+    expect(full?.matterLinks[0]!.matter?.matterNumber).toBe("2026-1");
+    expect(await repo.getByIdFull(c1, "org-2")).toBeNull(); // fel org
+  });
+});
+
+describe("ContactRepository — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("listForOrg + getByIdFull (subquery-_count, join-detalj)", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const c1 = uuidv7();
+    const child = uuidv7();
+    const mId = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(contacts).values(v({ id: c1, organizationId: org, name: "Anna AB", contactType: "COMPANY" }));
+    await db.insert(contacts).values(v({ id: child, organizationId: org, name: "Anställd", contactType: "PERSON", parentId: c1 }));
+    await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T", status: "ACTIVE" }));
+    await db.insert(matterContacts).values(v({ id: uuidv7(), matterId: mId, contactId: c1, role: "KLIENT" }));
+    const repo = new DrizzleContactRepository(handle.db as unknown as AppDb);
+
+    const res = await repo.listForOrg(org, { page: 1, pageSize: 50 });
+    expect(res.total).toBe(1); // child exkluderad (parentId satt)
+    expect(res.contacts[0]!.id).toBe(c1);
+    expect(res.contacts[0]!._count.children).toBe(1);
+    expect(res.contacts[0]!._count.matterLinks).toBe(1);
+    expect((await repo.listForOrg(org, { search: "anna", page: 1, pageSize: 50 })).total).toBe(1); // ilike
+    expect((await repo.listForOrg(org, { search: "Zzz", page: 1, pageSize: 50 })).total).toBe(0);
+
+    const full = await repo.getByIdFull(c1, org);
+    expect(full?.children).toHaveLength(1);
+    expect(full?.matterLinks).toHaveLength(1);
+    expect(full?.matterLinks[0]!.matter.matterNumber).toBe("2026-1");
+    expect(await repo.getByIdFull(c1, uuidv7())).toBeNull();
+  });
+});

--- a/test/unit/server/routers/contact.test.ts
+++ b/test/unit/server/routers/contact.test.ts
@@ -4,6 +4,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import { contactRouter } from "@/lib/server/routers/contact";
 import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
 
@@ -21,9 +23,11 @@ const mockPrisma = {
 };
 
 function makeCaller(orgId = "org-a") {
+  const dataStore = dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>);
   const ctx = {
     user: { id: "u", email: "a@b.se", name: "T", role: "LAWYER", organizationId: orgId },
-    prisma: mockPrisma, dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+    prisma: mockPrisma, dataStore,
+    repos: buildInMemoryRepositories(dataStore as unknown as IDataStore),
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return contactRouter.createCaller(ctx as any);
@@ -75,9 +79,10 @@ describe("contact.list", () => {
 
 describe("contact.getById", () => {
   it("hämtar med org-scope och inkluderar relationer", async () => {
-    mockPrisma.contact.findFirstOrThrow.mockResolvedValue(C);
+    // getByIdFull använder findFirst (ej findFirstOrThrow) — repo:t kastar NOT_FOUND vid null.
+    mockPrisma.contact.findFirst.mockResolvedValue(C);
     await makeCaller().getById({ id: "c1" });
-    expect(mockPrisma.contact.findFirstOrThrow).toHaveBeenCalledWith(
+    expect(mockPrisma.contact.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { id: "c1", organizationId: "org-a" },
         include: expect.objectContaining({
@@ -86,6 +91,11 @@ describe("contact.getById", () => {
         }),
       }),
     );
+  });
+
+  it("NOT_FOUND när kontakten saknas/annan org", async () => {
+    mockPrisma.contact.findFirst.mockResolvedValue(null);
+    await expect(makeCaller().getById({ id: "nope" })).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 });
 
@@ -116,7 +126,7 @@ describe("contact.create", () => {
 
 describe("contact.update", () => {
   it("uppdaterar med org-scope", async () => {
-    mockPrisma.contact.findUnique.mockResolvedValue(C);
+    mockPrisma.contact.findFirst.mockResolvedValue(C);
     mockPrisma.contact.update.mockResolvedValue(C);
 
     await makeCaller().update({ id: "c1", name: "Nytt" });
@@ -129,7 +139,7 @@ describe("contact.update", () => {
   });
 
   it("vägrar uppdatera kontakt från annan org", async () => {
-    mockPrisma.contact.findUnique.mockResolvedValue({ id: "c1", organizationId: "org-b" });
+    mockPrisma.contact.findFirst.mockResolvedValue({ id: "c1", organizationId: "org-b" });
     await expect(
       makeCaller("org-a").update({ id: "c1", name: "X" }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
@@ -139,14 +149,14 @@ describe("contact.update", () => {
 
 describe("contact.delete", () => {
   it("tar bort med org-scope", async () => {
-    mockPrisma.contact.findUnique.mockResolvedValue(C);
+    mockPrisma.contact.findFirst.mockResolvedValue(C);
     mockPrisma.contact.delete.mockResolvedValue(C);
     await makeCaller().delete({ id: "c1" });
     expect(mockPrisma.contact.delete).toHaveBeenCalledWith({ where: { id: "c1" } });
   });
 
   it("vägrar ta bort kontakt från annan org", async () => {
-    mockPrisma.contact.findUnique.mockResolvedValue({ id: "c1", organizationId: "org-b" });
+    mockPrisma.contact.findFirst.mockResolvedValue({ id: "c1", organizationId: "org-b" });
     await expect(
       makeCaller("org-a").delete({ id: "c1" }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
@@ -155,7 +165,7 @@ describe("contact.delete", () => {
 
 describe("contact.addChild", () => {
   it("lägger till child-kontakt under parent", async () => {
-    mockPrisma.contact.findUnique.mockResolvedValue(C);
+    mockPrisma.contact.findFirst.mockResolvedValue(C);
     mockPrisma.contact.create.mockResolvedValue({ id: "child" });
     await makeCaller().addChild({ parentId: "c1", name: "Anställd" });
     const args = mockPrisma.contact.create.mock.calls[0]![0];
@@ -165,7 +175,7 @@ describe("contact.addChild", () => {
   });
 
   it("vägrar lägga child under förälder från annan org", async () => {
-    mockPrisma.contact.findUnique.mockResolvedValue({ id: "c1", organizationId: "org-b" });
+    mockPrisma.contact.findFirst.mockResolvedValue({ id: "c1", organizationId: "org-b" });
     await expect(
       makeCaller("org-a").addChild({ parentId: "c1", name: "X" }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });


### PR DESCRIPTION
## What

Continues the per-router fan-out (follows the invoice entity #442–#451 and expense #452). Single-entity `contact` router.

### `ContactRepository`
- `listForOrg(orgId, { search?, contactType?, page, pageSize })` → top-level contacts (`parentId null`) with `_count { matterLinks, children }` + total. In-memory uses the query-engine include; **Drizzle** pages the rows then computes the counts with grouped queries over the page ids (more robust than correlated subqueries).
- `getByIdFull(id, orgId)` → contact + `children` + `parent` + `matterLinks→matter`.

### Router
`contact.{list,getById,create,update,delete,addChild}` → `ctx.repos.contacts`. Ownership checks reuse the existing `requireOrgOwned` helper fed by base `getById`; `getById` now throws `NOT_FOUND` on null (was `findFirstOrThrow`). `delete` keeps hard-delete (the ADR 0017 delete-policy is still the open cross-cutting question). Relaxed an over-strict inline child type in the contacts detail client.

### Tests
Router test ctx wired with `repos`; ownership mocks switched `findUnique`→`findFirst` (base `getById`). New parity tests (in-memory with `prebakeJoins` so the nested `matterLinks→matter` resolves as in production + pglite) for `listForOrg` + `getByIdFull`.

## Verification
- `bun run quality` green (coverage gate green, clones 11, deps + knip clean).
- `bun run build:demo` green.

Refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)