### PR TITLE
feat(repositories): migrate user router to typed repository (ADR 0020)

### DIFF
--- a/src/lib/server/repositories/drizzle-user-repository.ts
+++ b/src/lib/server/repositories/drizzle-user-repository.ts
@@ -1,0 +1,33 @@
+/**
+ * Drizzle `UserRepository` (ADR 0020) — server-impl. Ärver bas-CRUD;
+ * org-scopar direkt på `users.organizationId`.
+ */
+
+import { and, asc, eq, isNull } from "drizzle-orm";
+import type { User } from "@/lib/shared/schemas/user";
+import { users } from "../db/schema";
+import type { AppDb } from "../db/types";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import type { UserRepository } from "./user-repository";
+
+export class DrizzleUserRepository extends DrizzleRepository<User> implements UserRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, users as unknown as VersionedTable, now);
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<User | null> {
+    const rows = await this.db
+      .select().from(users)
+      .where(and(eq(users.id, id), eq(users.organizationId, organizationId), isNull(users.deletedAt)))
+      .limit(1);
+    return (rows[0] as unknown as User | undefined) ?? null;
+  }
+
+  async listByOrg(organizationId: string): Promise<User[]> {
+    const rows = await this.db
+      .select().from(users)
+      .where(and(eq(users.organizationId, organizationId), isNull(users.deletedAt)))
+      .orderBy(asc(users.name));
+    return rows as unknown as User[];
+  }
+}

--- a/src/lib/server/repositories/in-memory-repositories.ts
+++ b/src/lib/server/repositories/in-memory-repositories.ts
@@ -17,6 +17,7 @@ import { InMemoryMatterRepository } from "./in-memory-matter-repository";
 import { InMemoryPaymentPlanRepository } from "./in-memory-payment-plan-repository";
 import { InMemoryPaymentRepository } from "./in-memory-payment-repository";
 import { InMemoryTimeEntryRepository } from "./in-memory-time-entry-repository";
+import { InMemoryUserRepository } from "./in-memory-user-repository";
 import { InMemoryWriteOffRepository } from "./in-memory-write-off-repository";
 import type { Repositories } from "./repositories";
 
@@ -32,6 +33,7 @@ function reposForTx(tx: DataStoreTx): Repositories {
     expenses: new InMemoryExpenseRepository(tx),
     accontoDeductions: new InMemoryAccontoDeductionRepository(tx),
     contacts: new InMemoryContactRepository(tx),
+    users: new InMemoryUserRepository(tx),
     transaction: (fn) => fn(repos),
   };
   return repos;
@@ -48,6 +50,7 @@ export function buildInMemoryRepositories(dataStore: IDataStore): Repositories {
     expenses: new InMemoryExpenseRepository(dataStore),
     accontoDeductions: new InMemoryAccontoDeductionRepository(dataStore),
     contacts: new InMemoryContactRepository(dataStore),
+    users: new InMemoryUserRepository(dataStore),
     transaction: (fn) => dataStore.transaction((tx) => fn(reposForTx(tx))),
   };
 }

--- a/src/lib/server/repositories/in-memory-user-repository.ts
+++ b/src/lib/server/repositories/in-memory-user-repository.ts
@@ -1,0 +1,27 @@
+/**
+ * In-memory `UserRepository` (ADR 0020) — browser/offline-impl. Ärver bas-CRUD;
+ * org-scopar direkt på `organizationId`.
+ */
+
+import type { User } from "@/lib/shared/schemas/user";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import { InMemoryRepository } from "./in-memory-repository";
+import type { UserRepository } from "./user-repository";
+
+/** Delegaten repot behöver — uppfylls av `IDataStore`, `DataStoreTx` och `LocalStore`. */
+export type UserRepoSource = Pick<IDataStore, "users">;
+
+export class InMemoryUserRepository extends InMemoryRepository<User> implements UserRepository {
+  constructor(store: UserRepoSource, now?: () => Date) {
+    super(store.users as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<User | null> {
+    const row = (await this.delegate.findFirst({ where: { id, organizationId } })) as User | null;
+    return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
+  }
+
+  async listByOrg(organizationId: string): Promise<User[]> {
+    return (await this.delegate.findMany({ where: { organizationId }, orderBy: { name: "asc" } })) as User[];
+  }
+}

--- a/src/lib/server/repositories/repositories.ts
+++ b/src/lib/server/repositories/repositories.ts
@@ -13,6 +13,7 @@ import type { MatterRepository } from "./matter-repository";
 import type { PaymentPlanRepository } from "./payment-plan-repository";
 import type { PaymentRepository } from "./payment-repository";
 import type { TimeEntryRepository } from "./time-entry-repository";
+import type { UserRepository } from "./user-repository";
 import type { WriteOffRepository } from "./write-off-repository";
 
 export interface Repositories {
@@ -25,5 +26,6 @@ export interface Repositories {
   expenses: ExpenseRepository;
   accontoDeductions: AccontoDeductionRepository;
   contacts: ContactRepository;
+  users: UserRepository;
   transaction<T>(fn: (tx: Repositories) => Promise<T>): Promise<T>;
 }

--- a/src/lib/server/repositories/user-repository.ts
+++ b/src/lib/server/repositories/user-repository.ts
@@ -1,0 +1,16 @@
+/**
+ * `UserRepository` (ADR 0020, #409 fan-out) — användare. Bas-CRUD ärvs;
+ * org-scopas direkt på `organizationId`. Repot returnerar HELA raden
+ * (inkl. passwordHash/publicKeys) — projektionen (vilka fält som exponeras)
+ * bor kvar i routern, så känsliga fält inte läcker av misstag.
+ */
+
+import type { User } from "@/lib/shared/schemas/user";
+import type { Repository } from "./types";
+
+export interface UserRepository extends Repository<User> {
+  /** Användare by id, org-scopad (null om saknas/annan org/raderad). */
+  getByIdInOrg(id: string, organizationId: string): Promise<User | null>;
+  /** Alla (icke-raderade) användare i org:en, namn-sorterade. */
+  listByOrg(organizationId: string): Promise<User[]>;
+}

--- a/src/lib/server/routers/user.ts
+++ b/src/lib/server/routers/user.ts
@@ -1,8 +1,17 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { userIdSchema, asId } from "@/lib/shared/schemas/ids";
-import { publicKeySchema, matterNumberPrefixSchema, type PublicKey } from "@/lib/shared/schemas/user";
+import { publicKeySchema, matterNumberPrefixSchema, type PublicKey, type User } from "@/lib/shared/schemas/user";
 import { router, protectedProcedure } from "../trpc";
+
+/** Projektion till listvyns fält (utan publicKeys/passwordHash). */
+function pickList(u: User) {
+  return {
+    id: u.id, email: u.email, name: u.name, title: u.title ?? null, role: u.role,
+    hourlyRate: u.hourlyRate ?? null, mileageRate: u.mileageRate ?? null,
+    matterNumberPrefix: u.matterNumberPrefix ?? null, createdAt: u.createdAt as Date,
+  };
+}
 // bcryptjs är borttagen — pure-git-modellen har inte server-side
 // password-hashing. Om/när lokal HTTP Basic Auth införs på Linux-boxen
 // hanteras htpasswd av nginx (bcrypt-strängar genereras med `htpasswd -B`,
@@ -13,27 +22,6 @@ async function hashPassword(password: string): Promise<string> {
   // bcrypt-hash. Riktig hashing måste göras innan vi går prod.
   return `placeholder:${password.length}-chars`;
 }
-
-// Smal select för listor — håller utgående typ stabil för konsumenter
-// (reports, tids-rader, etc.) som inte bryr sig om nycklar.
-const USER_LIST_SELECT = {
-  id: true,
-  email: true,
-  name: true,
-  title: true,
-  role: true,
-  hourlyRate: true,
-  mileageRate: true,
-  matterNumberPrefix: true,
-  createdAt: true,
-} as const;
-// Profil-select inkluderar publicKeys. Lagras som JSON-array på User
-// (`Json`-fält i Prisma eller serialiserad sträng). I demo:n läses
-// det in från användarens .json-fil.
-const USER_PROFILE_SELECT = {
-  ...USER_LIST_SELECT,
-  publicKeys: true,
-} as const;
 
 export interface UserProfile {
   id: string;
@@ -65,13 +53,10 @@ export const userRouter = router({
    * representation som UI:n kan visa men inte mutera.
    */
   current: protectedProcedure.query(async ({ ctx }): Promise<UserProfile> => {
-    try {
-      const u = await ctx.dataStore.users.findUniqueOrThrow({
-        where: { id: ctx.user.id, organizationId: ctx.user.organizationId },
-        select: USER_PROFILE_SELECT,
-      }) as unknown as UserProfile;
-      return { ...u, publicKeys: Array.isArray(u.publicKeys) ? u.publicKeys : [] };
-    } catch (_e) {
+    // Migrerad till repository-sömmen (ADR 0020). Saknas user:n (demoanvändaren)
+    // returnerar vi en transient profil som UI:n kan visa men inte mutera.
+    const u = await ctx.repos.users.getByIdInOrg(ctx.user.id, ctx.user.organizationId);
+    if (!u) {
       return {
         id: ctx.user.id,
         email: ctx.user.email,
@@ -85,28 +70,24 @@ export const userRouter = router({
         publicKeys: [],
       };
     }
+    return { ...pickList(u), publicKeys: Array.isArray(u.publicKeys) ? u.publicKeys : [] };
   }),
 
   list: protectedProcedure
     .input(z.object({ pageSize: z.number().min(1).max(100).default(50) }).optional())
     .query(async ({ ctx }) => {
-      const users = await ctx.dataStore.users.findMany({
-        where: { organizationId: ctx.user.organizationId },
-        orderBy: { name: "asc" },
-        select: USER_LIST_SELECT,
-      });
-      return { users };
+      const rows = await ctx.repos.users.listByOrg(ctx.user.organizationId);
+      return { users: rows.map(pickList) };
     }),
 
   getById: protectedProcedure
     .input(z.object({ id: z.string() }))
     .query(async ({ ctx, input }) => {
-      // Använder list-select (utan publicKeys) eftersom nycklar är
+      // Använder list-projektionen (utan publicKeys) eftersom nycklar är
       // privata — bara `current` exponerar dem.
-      return ctx.dataStore.users.findUniqueOrThrow({
-        where: { id: input.id, organizationId: ctx.user.organizationId },
-        select: USER_LIST_SELECT,
-      });
+      const u = await ctx.repos.users.getByIdInOrg(input.id, ctx.user.organizationId);
+      if (!u) throw new TRPCError({ code: "NOT_FOUND" });
+      return pickList(u);
     }),
 
   /**
@@ -130,21 +111,19 @@ export const userRouter = router({
     .mutation(async ({ ctx, input }) => {
       assertAdmin(ctx);
       const passwordHash = input.password ? await hashPassword(input.password) : null;
-      return ctx.dataStore.users.create({
-        data: {
-          ...(input.id ? { id: input.id } : {}),
-          email: input.email,
-          name: input.name,
-          title: input.title,
-          role: input.role,
-          hourlyRate: input.hourlyRate,
-          mileageRate: input.mileageRate,
-          ...(input.matterNumberPrefix ? { matterNumberPrefix: input.matterNumberPrefix } : {}),
-          passwordHash,
-          organizationId: asId<"OrganizationId">(ctx.user.organizationId),
-          publicKeys: [],
-        },
-      });
+      return ctx.repos.users.create({
+        ...(input.id ? { id: input.id } : {}),
+        email: input.email,
+        name: input.name,
+        title: input.title,
+        role: input.role,
+        hourlyRate: input.hourlyRate,
+        mileageRate: input.mileageRate,
+        ...(input.matterNumberPrefix ? { matterNumberPrefix: input.matterNumberPrefix } : {}),
+        passwordHash,
+        organizationId: asId<"OrganizationId">(ctx.user.organizationId),
+        publicKeys: [],
+      } as Partial<User>);
     }),
 
   /**
@@ -175,12 +154,12 @@ export const userRouter = router({
         throw new TRPCError({ code: "FORBIDDEN", message: "Endast administratörer kan ändra roller." });
       }
       const { id, password, ...data } = input;
+      // Org-scope: verifiera ägarskap (motsvarar gamla where:{id,organizationId}).
+      const owned = await ctx.repos.users.getByIdInOrg(id, ctx.user.organizationId);
+      if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
       const updateData: Record<string, unknown> = { ...data };
       if (password) updateData.passwordHash = await hashPassword(password);
-      return ctx.dataStore.users.update({
-        where: { id, organizationId: ctx.user.organizationId },
-        data: updateData,
-      });
+      return ctx.repos.users.update(id, updateData as Partial<User>);
     }),
 
   /**
@@ -190,34 +169,24 @@ export const userRouter = router({
   addKey: protectedProcedure
     .input(publicKeySchema)
     .mutation(async ({ ctx, input }) => {
-      const u = await ctx.dataStore.users.findUniqueOrThrow({
-        where: { id: ctx.user.id, organizationId: ctx.user.organizationId },
-        select: { publicKeys: true },
-      }) as unknown as { publicKeys?: unknown[] };
+      const u = await ctx.repos.users.getByIdInOrg(ctx.user.id, ctx.user.organizationId);
+      if (!u) throw new TRPCError({ code: "NOT_FOUND" });
       const keys = Array.isArray(u.publicKeys) ? u.publicKeys : [];
       if (keys.some((k) => (k as { fingerprint: string }).fingerprint === input.fingerprint)) {
         throw new TRPCError({ code: "CONFLICT", message: "Nyckel med samma fingerprint finns redan." });
       }
-      return ctx.dataStore.users.update({
-        where: { id: ctx.user.id, organizationId: ctx.user.organizationId },
-        data: { publicKeys: [...keys, input] } as unknown as Record<string, unknown>,
-      });
+      return ctx.repos.users.update(ctx.user.id, { publicKeys: [...keys, input] } as unknown as Partial<User>);
     }),
 
   removeKey: protectedProcedure
     .input(z.object({ fingerprint: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      const u = await ctx.dataStore.users.findUniqueOrThrow({
-        where: { id: ctx.user.id, organizationId: ctx.user.organizationId },
-        select: { publicKeys: true },
-      }) as unknown as { publicKeys?: unknown[] };
+      const u = await ctx.repos.users.getByIdInOrg(ctx.user.id, ctx.user.organizationId);
+      if (!u) throw new TRPCError({ code: "NOT_FOUND" });
       const keys = (Array.isArray(u.publicKeys) ? u.publicKeys : []).filter(
         (k) => (k as { fingerprint: string }).fingerprint !== input.fingerprint,
       );
-      return ctx.dataStore.users.update({
-        where: { id: ctx.user.id, organizationId: ctx.user.organizationId },
-        data: { publicKeys: keys } as unknown as Record<string, unknown>,
-      });
+      return ctx.repos.users.update(ctx.user.id, { publicKeys: keys } as unknown as Partial<User>);
     }),
 
   /**
@@ -231,10 +200,9 @@ export const userRouter = router({
       if (input.id === ctx.user.id) {
         throw new TRPCError({ code: "BAD_REQUEST", message: "Du kan inte inaktivera dig själv." });
       }
-      return ctx.dataStore.users.update({
-        where: { id: input.id, organizationId: ctx.user.organizationId },
-        data: { active: false } as unknown as Record<string, unknown>,
-      });
+      const owned = await ctx.repos.users.getByIdInOrg(input.id, ctx.user.organizationId);
+      if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
+      return ctx.repos.users.update(input.id, { active: false } as unknown as Partial<User>);
     }),
 
   /** Hård-delete behållen för bakåtkompabilitet, men ADMIN-only. */
@@ -245,8 +213,10 @@ export const userRouter = router({
       if (input.id === ctx.user.id) {
         throw new TRPCError({ code: "BAD_REQUEST", message: "Du kan inte ta bort dig själv." });
       }
-      return ctx.dataStore.users.delete({
-        where: { id: input.id, organizationId: ctx.user.organizationId },
-      });
+      const owned = await ctx.repos.users.getByIdInOrg(input.id, ctx.user.organizationId);
+      if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
+      // Hård delete bevarad (bakåtkompat, ADR 0017-delete-policy öppen).
+      await ctx.repos.users.hardDelete(input.id);
+      return { id: input.id };
     }),
 });

--- a/test/unit/client/addin/addin-client.test.ts
+++ b/test/unit/client/addin/addin-client.test.ts
@@ -10,8 +10,10 @@
 import { describe, it, expect } from "vitest-compat";
 import { createAddinClient, addinTrpcEndpoint, type AddinFetch } from "@/lib/client/addin/addin-client";
 import type { Principal } from "@/lib/server/auth/principal";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
 import { StaticPatVerifier, patRecord } from "@/lib/server/http/pat";
 import { createTrpcHttpHandler } from "@/lib/server/http/trpc-http-handler";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import type { Context } from "@/lib/server/trpc-core";
 
 const PRINCIPAL: Principal = {
@@ -22,9 +24,10 @@ const PRINCIPAL: Principal = {
 /** Server-handler med fake-context (user.current faller tillbaka på ctx.user). */
 function serverHandler() {
   const verifier = new StaticPatVerifier([patRecord("good-token", PRINCIPAL)]);
+  const dataStore = { users: { findFirst: async () => null } } as unknown as IDataStore;
   const context = {
-    dataStore: { users: { findUniqueOrThrow: async () => { throw new Error("no row"); } } },
-    ports: {}, user: PRINCIPAL,
+    dataStore, ports: {}, user: PRINCIPAL,
+    repos: buildInMemoryRepositories(dataStore),
   } as unknown as Context;
   return createTrpcHttpHandler({
     verifier,

--- a/test/unit/server/http/trpc-http-handler.test.ts
+++ b/test/unit/server/http/trpc-http-handler.test.ts
@@ -12,8 +12,10 @@ import { createTRPCClient, httpBatchLink, TRPCClientError } from "@trpc/client";
 import superjson from "superjson";
 import { describe, it, expect, vi } from "vitest-compat";
 import type { Principal } from "@/lib/server/auth/principal";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
 import { StaticPatVerifier, patRecord } from "@/lib/server/http/pat";
 import { createTrpcHttpHandler, type RequestSession } from "@/lib/server/http/trpc-http-handler";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import type { AppRouter } from "@/lib/server/routers/_app";
 import type { Context } from "@/lib/server/trpc-core";
 
@@ -22,13 +24,17 @@ const PRINCIPAL: Principal = {
   role: "LAWYER", organizationId: "org-1",
 };
 
-/** Minimal Context: `users.findUniqueOrThrow` kastar → user.current faller
- *  tillbaka på ctx.user, vilket bevisar att principalen flödade in. */
+/** Minimal Context: `users.findFirst` ger null → user.current faller tillbaka
+ *  på ctx.user (via repos.users.getByIdInOrg), vilket bevisar att principalen
+ *  flödade in. */
 function fakeContext(principal: Principal): Context {
   const dataStore = {
-    users: { findUniqueOrThrow: async () => { throw new Error("no row"); } },
-  };
-  return { dataStore, ports: {}, user: principal } as unknown as Context;
+    users: { findFirst: async () => null },
+  } as unknown as IDataStore;
+  return {
+    dataStore, ports: {}, user: principal,
+    repos: buildInMemoryRepositories(dataStore),
+  } as unknown as Context;
 }
 
 interface Harness {

--- a/test/unit/server/repositories/user-repository.test.ts
+++ b/test/unit/server/repositories/user-repository.test.ts
@@ -1,0 +1,57 @@
+/**
+ * UserRepository-paritet (ADR 0020, #409 fan-out) — in-memory + Drizzle (pglite).
+ * `getByIdInOrg` + `listByOrg` (org-scope direkt på organizationId).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { users } from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzleUserRepository } from "@/lib/server/repositories/drizzle-user-repository";
+import { InMemoryUserRepository } from "@/lib/server/repositories/in-memory-user-repository";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+describe("UserRepository — in-memory", () => {
+  it("getByIdInOrg + listByOrg org-scopar", async () => {
+    const u1 = uuidv7();
+    const u2 = uuidv7();
+    const store = new LocalStore({
+      users: [
+        { id: u1, organizationId: "org-1", email: "a@x", name: "Beta" },
+        { id: u2, organizationId: "org-1", email: "b@x", name: "Alfa" },
+        { id: uuidv7(), organizationId: "org-2", email: "c@x", name: "Gamma" },
+      ],
+    }, async () => {});
+    const repo = new InMemoryUserRepository(store);
+    expect(await repo.getByIdInOrg(u1, "org-1")).toMatchObject({ id: u1 });
+    expect(await repo.getByIdInOrg(u1, "org-2")).toBeNull(); // fel org
+    const list = await repo.listByOrg("org-1");
+    expect(list).toHaveLength(2);
+    expect(list.map((u) => u.name)).toEqual(["Alfa", "Beta"]); // namn-sorterat
+  });
+});
+
+describe("UserRepository — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("getByIdInOrg + listByOrg org-scopar (namn asc)", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const u1 = uuidv7();
+    const u2 = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(users).values(v({ id: u1, organizationId: org, email: "a@x", name: "Beta" }));
+    await db.insert(users).values(v({ id: u2, organizationId: org, email: "b@x", name: "Alfa" }));
+    await db.insert(users).values(v({ id: uuidv7(), organizationId: uuidv7(), email: "c@x", name: "Gamma" }));
+    const repo = new DrizzleUserRepository(handle.db as unknown as AppDb);
+    expect(await repo.getByIdInOrg(u1, org)).toMatchObject({ id: u1 });
+    expect(await repo.getByIdInOrg(u1, uuidv7())).toBeNull();
+    const list = await repo.listByOrg(org);
+    expect(list).toHaveLength(2);
+    expect(list.map((u) => u.name)).toEqual(["Alfa", "Beta"]);
+  });
+});

--- a/test/unit/server/routers/user.test.ts
+++ b/test/unit/server/routers/user.test.ts
@@ -1,28 +1,42 @@
 /**
  * Test för userRouter — list/getById/create/update/delete med org-scoping.
+ * Migrerad till repository-sömmen (ADR 0020): projektionen (säkra fält) sker i
+ * routern, repot läser hela raden via findFirst/findMany.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import { userRouter } from "@/lib/server/routers/user";
 import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
 
 const mockPrisma = {
   user: {
     findMany: vi.fn(),
-    findUniqueOrThrow: vi.fn(),
+    findFirst: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
     delete: vi.fn(),
   },
 };
 
-function makeCaller(userId = "user-1", orgId = "org-a") {
+function callerFor(role: "ADMIN" | "LAWYER" | "ASSISTANT", userId: string, orgId: string) {
+  const dataStore = dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>);
   const ctx = {
-    user: { id: userId, email: "a@b.com", name: "Test", role: "ADMIN", organizationId: orgId },
-    prisma: mockPrisma, dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+    user: { id: userId, email: "a@b.com", name: "Test", role, organizationId: orgId },
+    prisma: mockPrisma, dataStore,
+    repos: buildInMemoryRepositories(dataStore as unknown as IDataStore),
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return userRouter.createCaller(ctx as any);
+}
+
+function makeCaller(userId = "user-1", orgId = "org-a") {
+  return callerFor("ADMIN", userId, orgId);
+}
+
+function makeCallerWithRole(role: "ADMIN" | "LAWYER" | "ASSISTANT", userId = "u1", orgId = "org-a") {
+  return callerFor(role, userId, orgId);
 }
 
 beforeEach(() => vi.clearAllMocks());
@@ -39,25 +53,34 @@ describe("user.list", () => {
     );
   });
 
-  it("returnerar bara säkra fält (inte passwordHash)", async () => {
-    mockPrisma.user.findMany.mockResolvedValue([]);
-    await makeCaller().list();
-    const args = mockPrisma.user.findMany.mock.calls[0]![0];
-    expect(args.select.passwordHash).toBeUndefined();
-    expect(args.select.email).toBe(true);
-    expect(args.select.name).toBe(true);
+  it("projicerar bara säkra fält (inte passwordHash)", async () => {
+    // Repot läser hela raden; routern (pickList) släpper passwordHash/publicKeys.
+    mockPrisma.user.findMany.mockResolvedValue([
+      { id: "u1", email: "u1@x", name: "A", role: "LAWYER", passwordHash: "secret", publicKeys: [{ fingerprint: "x" }] },
+    ]);
+    const res = await makeCaller().list();
+    const u = res.users[0] as Record<string, unknown>;
+    expect(u.passwordHash).toBeUndefined();
+    expect(u.publicKeys).toBeUndefined();
+    expect(u.email).toBe("u1@x");
+    expect(u.name).toBe("A");
   });
 });
 
 describe("user.getById", () => {
-  it("hämtar med org-scope", async () => {
-    mockPrisma.user.findUniqueOrThrow.mockResolvedValue({ id: "u1", name: "A" });
+  it("hämtar med org-scope (findFirst)", async () => {
+    mockPrisma.user.findFirst.mockResolvedValue({ id: "u1", name: "A" });
     await makeCaller().getById({ id: "u1" });
-    expect(mockPrisma.user.findUniqueOrThrow).toHaveBeenCalledWith(
+    expect(mockPrisma.user.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { id: "u1", organizationId: "org-a" },
       }),
     );
+  });
+
+  it("NOT_FOUND när användaren saknas/annan org", async () => {
+    mockPrisma.user.findFirst.mockResolvedValue(null);
+    await expect(makeCaller().getById({ id: "nope" })).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 });
 
@@ -115,6 +138,7 @@ describe("user.create", () => {
 
 describe("user.update", () => {
   it("hashar lösenord när password skickas", async () => {
+    mockPrisma.user.findFirst.mockResolvedValue({ id: "u1", organizationId: "org-a" });
     mockPrisma.user.update.mockResolvedValue({ id: "u1" });
     await makeCaller().update({ id: "u1", password: "nytt-hemligt-pwd" });
     const args = mockPrisma.user.update.mock.calls[0]![0];
@@ -123,6 +147,7 @@ describe("user.update", () => {
   });
 
   it("uppdaterar utan att röra passwordHash om password ej skickas", async () => {
+    mockPrisma.user.findFirst.mockResolvedValue({ id: "u1", organizationId: "org-a" });
     mockPrisma.user.update.mockResolvedValue({});
     await makeCaller().update({ id: "u1", name: "Nytt namn" });
     const args = mockPrisma.user.update.mock.calls[0]![0];
@@ -130,21 +155,28 @@ describe("user.update", () => {
     expect(args.data.name).toBe("Nytt namn");
   });
 
-  it("scopar where på organizationId", async () => {
+  it("org-scopar ägarkollen (findFirst) innan update", async () => {
+    mockPrisma.user.findFirst.mockResolvedValue({ id: "u1", organizationId: "org-a" });
     mockPrisma.user.update.mockResolvedValue({});
     await makeCaller().update({ id: "u1", name: "X" });
-    const args = mockPrisma.user.update.mock.calls[0]![0];
-    expect(args.where).toEqual({ id: "u1", organizationId: "org-a" });
+    expect(mockPrisma.user.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "u1", organizationId: "org-a" } }),
+    );
+  });
+
+  it("NOT_FOUND när användaren tillhör annan org", async () => {
+    mockPrisma.user.findFirst.mockResolvedValue(null);
+    await expect(makeCaller().update({ id: "u1", name: "X" })).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(mockPrisma.user.update).not.toHaveBeenCalled();
   });
 });
 
 describe("user.delete", () => {
-  it("tar bort användare", async () => {
+  it("tar bort användare (org-scopad ägarkoll + hård delete)", async () => {
+    mockPrisma.user.findFirst.mockResolvedValue({ id: "other-user", organizationId: "org-a" });
     mockPrisma.user.delete.mockResolvedValue({});
     await makeCaller("admin-1").delete({ id: "other-user" });
-    expect(mockPrisma.user.delete).toHaveBeenCalledWith({
-      where: { id: "other-user", organizationId: "org-a" },
-    });
+    expect(mockPrisma.user.delete).toHaveBeenCalledWith({ where: { id: "other-user" } });
   });
 
   it("vägrar ta bort sig själv", async () => {
@@ -155,16 +187,7 @@ describe("user.delete", () => {
   });
 });
 
-// ─── Nya tester: admin-only-kontroll + key-management ────────────────
-
-function makeCallerWithRole(role: "ADMIN" | "LAWYER" | "ASSISTANT", userId = "u1", orgId = "org-a") {
-  const ctx = {
-    user: { id: userId, email: "x@y", name: "X", role, organizationId: orgId },
-    prisma: mockPrisma, dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
-  };
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return userRouter.createCaller(ctx as any);
-}
+// ─── admin-only-kontroll + key-management ────────────────────────────
 
 describe("admin-only checks", () => {
   it("user.create kräver ADMIN", async () => {
@@ -200,7 +223,7 @@ describe("admin-only checks", () => {
 
 describe("user.addKey / removeKey", () => {
   it("addKey läser publicKeys + uppdaterar (tom array → 1 nyckel)", async () => {
-    mockPrisma.user.findUniqueOrThrow.mockResolvedValue({ publicKeys: [] });
+    mockPrisma.user.findFirst.mockResolvedValue({ id: "u1", organizationId: "org-a", publicKeys: [] });
     mockPrisma.user.update.mockResolvedValue({});
     await makeCallerWithRole("LAWYER", "u1").addKey({
       fingerprint: "SHA256:abc", type: "ssh-ed25519", publicKey: "ssh-ed25519 AAAA",
@@ -212,7 +235,8 @@ describe("user.addKey / removeKey", () => {
   });
 
   it("addKey nekar dubblett-fingerprint", async () => {
-    mockPrisma.user.findUniqueOrThrow.mockResolvedValue({
+    mockPrisma.user.findFirst.mockResolvedValue({
+      id: "u1", organizationId: "org-a",
       publicKeys: [{ fingerprint: "SHA256:abc", type: "ssh-ed25519", publicKey: "x", addedAt: "..." }],
     });
     await expect(
@@ -223,7 +247,8 @@ describe("user.addKey / removeKey", () => {
   });
 
   it("removeKey filtrerar bort efter fingerprint", async () => {
-    mockPrisma.user.findUniqueOrThrow.mockResolvedValue({
+    mockPrisma.user.findFirst.mockResolvedValue({
+      id: "u1", organizationId: "org-a",
       publicKeys: [
         { fingerprint: "SHA256:a", type: "ssh-ed25519", publicKey: "x", addedAt: "..." },
         { fingerprint: "SHA256:b", type: "ssh-ed25519", publicKey: "y", addedAt: "..." },
@@ -239,15 +264,15 @@ describe("user.addKey / removeKey", () => {
 
 describe("user.current", () => {
   it("returnerar ctx.user om saknas i tabellen (demo-läget)", async () => {
-    mockPrisma.user.findUniqueOrThrow.mockRejectedValue(new Error("not found"));
+    mockPrisma.user.findFirst.mockResolvedValue(null);
     const me = await makeCallerWithRole("ADMIN", "demo-user").current();
     expect(me.id).toBe("demo-user");
     expect(me.publicKeys).toEqual([]);
   });
 
   it("returnerar databas-rad om finns", async () => {
-    mockPrisma.user.findUniqueOrThrow.mockResolvedValue({
-      id: "u1", email: "u1@x", name: "U1", title: null, role: "LAWYER",
+    mockPrisma.user.findFirst.mockResolvedValue({
+      id: "u1", organizationId: "org-a", email: "u1@x", name: "U1", title: null, role: "LAWYER",
       hourlyRate: null, mileageRate: null, createdAt: new Date(),
       publicKeys: [{ fingerprint: "SHA256:x", type: "ssh-ed25519", publicKey: "k", addedAt: "..." }],
     });


### PR DESCRIPTION
## What

Continues the per-router fan-out (invoice #442–#451, expense #452, contact #453). Single-entity `user` router — and the new `UserRepository` unblocks other routers' user reads (notably `timeEntry.create`'s `hourlyRate`).

### `UserRepository`
`getByIdInOrg` + `listByOrg` (org-scoped on `organizationId`), base CRUD inherited. The repo returns **whole rows**; the router keeps field projection (new `pickList`) so `passwordHash` / `publicKeys` never leak — `current`/`list`/`getById` project, while mutations return the full row (unchanged from today).

### Router
`user.{current,list,getById,create,update,addKey,removeKey,deactivate,delete}` → `ctx.repos.users`. `getById` throws `NOT_FOUND` on null (was `findUniqueOrThrow`); `current` falls back to `ctx.user` when the row is missing (demo user); org-scoped mutations verify ownership via `getByIdInOrg`; `delete` keeps hard-delete. Removed the now-unused `USER_LIST_SELECT`/`USER_PROFILE_SELECT` consts.

### Tests
Router test rewired to the seam (projection asserted on the *result*, `findFirst` instead of `findUniqueOrThrow`, delete `where` = `{id}`). The HTTP-handler + addin-client fake contexts now provide `repos` (their `user.current` smoke flows through `repos.users` → `findFirst` null → fallback). New parity tests (in-memory + pglite) for `getByIdInOrg` + `listByOrg`.

## Verification
- `bun run quality` green (coverage gate green, clones 11, deps + knip clean).
- `bun run build:demo` green.

Refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)