### PR TITLE
feat(repositories): migrate task router to typed repository (ADR 0020)

### DIFF
--- a/src/lib/server/repositories/drizzle-task-repository.ts
+++ b/src/lib/server/repositories/drizzle-task-repository.ts
@@ -1,0 +1,48 @@
+/**
+ * Drizzle `TaskRepository` (ADR 0020) — server-impl. Ärver bas-CRUD;
+ * `listForUser` left-joinar matter (nullable FK), `getOwned` ägar-scopar.
+ */
+
+import { and, asc, eq, isNull } from "drizzle-orm";
+import type { Task } from "@/lib/shared/schemas/calendar";
+import { matters, tasks } from "../db/schema";
+import type { AppDb } from "../db/types";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import type { TaskListFilter, TaskListRow, TaskRepository } from "./task-repository";
+
+export class DrizzleTaskRepository extends DrizzleRepository<Task> implements TaskRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, tasks as unknown as VersionedTable, now);
+  }
+
+  async listForUser(userId: string, organizationId: string, filter: TaskListFilter): Promise<TaskListRow[]> {
+    const rows = await this.db
+      .select({
+        t: tasks,
+        mId: matters.id, mNum: matters.matterNumber, mTitle: matters.title,
+      })
+      .from(tasks)
+      .leftJoin(matters, eq(tasks.matterId, matters.id))
+      .where(and(
+        eq(tasks.userId, userId),
+        eq(tasks.organizationId, organizationId),
+        isNull(tasks.deletedAt),
+        filter.status ? eq(tasks.status, filter.status) : undefined,
+        filter.matterId ? eq(tasks.matterId, filter.matterId) : undefined,
+      ))
+      .orderBy(asc(tasks.dueAt));
+    return rows.map((r) => ({
+      ...(r.t as object),
+      matter: r.mId ? { id: r.mId, matterNumber: r.mNum as string, title: r.mTitle as string } : null,
+    })) as unknown as TaskListRow[];
+  }
+
+  async getOwned(id: string, userId: string, organizationId: string): Promise<Task | null> {
+    const rows = await this.db
+      .select().from(tasks)
+      .where(and(
+        eq(tasks.id, id), eq(tasks.userId, userId), eq(tasks.organizationId, organizationId), isNull(tasks.deletedAt),
+      )).limit(1);
+    return (rows[0] as unknown as Task | undefined) ?? null;
+  }
+}

--- a/src/lib/server/repositories/in-memory-repositories.ts
+++ b/src/lib/server/repositories/in-memory-repositories.ts
@@ -16,6 +16,7 @@ import { InMemoryInvoiceRepository } from "./in-memory-invoice-repository";
 import { InMemoryMatterRepository } from "./in-memory-matter-repository";
 import { InMemoryPaymentPlanRepository } from "./in-memory-payment-plan-repository";
 import { InMemoryPaymentRepository } from "./in-memory-payment-repository";
+import { InMemoryTaskRepository } from "./in-memory-task-repository";
 import { InMemoryTimeEntryRepository } from "./in-memory-time-entry-repository";
 import { InMemoryUserRepository } from "./in-memory-user-repository";
 import { InMemoryWriteOffRepository } from "./in-memory-write-off-repository";
@@ -34,6 +35,7 @@ function reposForTx(tx: DataStoreTx): Repositories {
     accontoDeductions: new InMemoryAccontoDeductionRepository(tx),
     contacts: new InMemoryContactRepository(tx),
     users: new InMemoryUserRepository(tx),
+    tasks: new InMemoryTaskRepository(tx),
     transaction: (fn) => fn(repos),
   };
   return repos;
@@ -51,6 +53,7 @@ export function buildInMemoryRepositories(dataStore: IDataStore): Repositories {
     accontoDeductions: new InMemoryAccontoDeductionRepository(dataStore),
     contacts: new InMemoryContactRepository(dataStore),
     users: new InMemoryUserRepository(dataStore),
+    tasks: new InMemoryTaskRepository(dataStore),
     transaction: (fn) => dataStore.transaction((tx) => fn(reposForTx(tx))),
   };
 }

--- a/src/lib/server/repositories/in-memory-task-repository.ts
+++ b/src/lib/server/repositories/in-memory-task-repository.ts
@@ -1,0 +1,36 @@
+/**
+ * In-memory `TaskRepository` (ADR 0020) — browser/offline-impl. Ärver bas-CRUD;
+ * list/ägar-vakt använder samma where/include som routern.
+ */
+
+import type { Task } from "@/lib/shared/schemas/calendar";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import { InMemoryRepository } from "./in-memory-repository";
+import type { TaskListFilter, TaskListRow, TaskRepository } from "./task-repository";
+
+/** Delegaten repot behöver — uppfylls av `IDataStore`, `DataStoreTx` och `LocalStore`. */
+export type TaskRepoSource = Pick<IDataStore, "tasks">;
+
+export class InMemoryTaskRepository extends InMemoryRepository<Task> implements TaskRepository {
+  constructor(store: TaskRepoSource, now?: () => Date) {
+    super(store.tasks as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async listForUser(userId: string, organizationId: string, filter: TaskListFilter): Promise<TaskListRow[]> {
+    return (await this.delegate.findMany({
+      where: {
+        userId,
+        organizationId,
+        ...(filter.status ? { status: filter.status } : {}),
+        ...(filter.matterId ? { matterId: filter.matterId } : {}),
+      },
+      orderBy: { dueAt: "asc" },
+      include: { matter: { select: { id: true, matterNumber: true, title: true } } },
+    })) as TaskListRow[];
+  }
+
+  async getOwned(id: string, userId: string, organizationId: string): Promise<Task | null> {
+    const row = (await this.delegate.findFirst({ where: { id, userId, organizationId } })) as Task | null;
+    return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
+  }
+}

--- a/src/lib/server/repositories/repositories.ts
+++ b/src/lib/server/repositories/repositories.ts
@@ -12,6 +12,7 @@ import type { InvoiceRepository } from "./invoice-repository";
 import type { MatterRepository } from "./matter-repository";
 import type { PaymentPlanRepository } from "./payment-plan-repository";
 import type { PaymentRepository } from "./payment-repository";
+import type { TaskRepository } from "./task-repository";
 import type { TimeEntryRepository } from "./time-entry-repository";
 import type { UserRepository } from "./user-repository";
 import type { WriteOffRepository } from "./write-off-repository";
@@ -27,5 +28,6 @@ export interface Repositories {
   accontoDeductions: AccontoDeductionRepository;
   contacts: ContactRepository;
   users: UserRepository;
+  tasks: TaskRepository;
   transaction<T>(fn: (tx: Repositories) => Promise<T>): Promise<T>;
 }

--- a/src/lib/server/repositories/task-repository.ts
+++ b/src/lib/server/repositories/task-repository.ts
@@ -1,0 +1,27 @@
+/**
+ * `TaskRepository` (ADR 0020, #409 fan-out) — uppgifter (todo med valfri due-date).
+ * Tasks är PER-USER (ägare = userId) inom org:en. Bas-CRUD ärvs; `listForUser`
+ * ger den ägar-/org-scopade listan med ärende-subset och `getOwned` är
+ * ägarskaps-vakten (id + userId + organizationId).
+ */
+
+import type { Task } from "@/lib/shared/schemas/calendar";
+import type { Repository } from "./types";
+
+/** Task + ärende-subsetet listvyn visar. */
+export interface TaskListRow extends Task {
+  matter: { id: string; matterNumber: string; title: string } | null;
+}
+
+/** Filter för `listForUser`. */
+export interface TaskListFilter {
+  status?: string | undefined;
+  matterId?: string | undefined;
+}
+
+export interface TaskRepository extends Repository<Task> {
+  /** Användarens uppgifter i org:en (dueAt asc), med ärende-subset. */
+  listForUser(userId: string, organizationId: string, filter: TaskListFilter): Promise<TaskListRow[]>;
+  /** Uppgift by id, ägar-scopad (id + userId + org). Null om saknas/ej ägd/raderad. */
+  getOwned(id: string, userId: string, organizationId: string): Promise<Task | null>;
+}

--- a/src/lib/server/routers/task.ts
+++ b/src/lib/server/routers/task.ts
@@ -9,9 +9,9 @@
 
 import { z } from "zod";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
-import { taskPrioritySchema, taskStatusSchema } from "@/lib/shared/schemas";
+import { taskPrioritySchema, taskStatusSchema, type Task } from "@/lib/shared/schemas";
 import { asId, taskIdSchema, matterIdSchema, userIdSchema } from "@/lib/shared/schemas/ids";
-import { router, protectedProcedure } from "../trpc";
+import { router, protectedProcedure, TRPCError } from "../trpc";
 
 const createInput = z.object({
   title: z.string().min(1),
@@ -40,69 +40,57 @@ export const taskRouter = router({
         matterId: z.string().optional(),
       }).optional(),
     )
-    .query(async ({ ctx, input }) => {
-      const where: Record<string, unknown> = {
-        userId: ctx.user.id,
-        organizationId: ctx.user.organizationId,
-      };
-      if (input?.status) where.status = input.status;
-      if (input?.matterId) where.matterId = input.matterId;
-      return ctx.dataStore.tasks.findMany({
-        where,
-        orderBy: { dueAt: "asc" },
-        include: { matter: { select: { id: true, matterNumber: true, title: true } } },
-      });
-    }),
+    // Migrerad till repository-sömmen (ADR 0020): ägar-/org-scopad listForUser.
+    .query(({ ctx, input }) =>
+      ctx.repos.tasks.listForUser(ctx.user.id, ctx.user.organizationId, {
+        status: input?.status,
+        matterId: input?.matterId,
+      }),
+    ),
 
   create: protectedProcedure
     .input(createInput)
     .mutation(({ ctx, input }) => {
       const { id, createdAt, ...rest } = input;
-      return ctx.dataStore.tasks.create({
-        data: {
-          ...rest,
-          status: input.status ?? "TODO",
-          userId: input.userId ?? asId<"UserId">(ctx.user.id),
-          organizationId: asId<"OrganizationId">(ctx.user.organizationId),
-          ...omitUndefined({ id }),
-          ...(createdAt != null ? { createdAt } : {}),
-        },
-      });
+      return ctx.repos.tasks.create({
+        ...rest,
+        status: input.status ?? "TODO",
+        userId: input.userId ?? asId<"UserId">(ctx.user.id),
+        organizationId: asId<"OrganizationId">(ctx.user.organizationId),
+        ...omitUndefined({ id }),
+        ...(createdAt != null ? { createdAt } : {}),
+      } as Partial<Task>);
     }),
 
   update: protectedProcedure
     .input(updateInput)
     .mutation(async ({ ctx, input }) => {
       const { id, ...data } = input;
-      // Ownership-guard
-      await ctx.dataStore.tasks.findFirstOrThrow({
-        where: { id, userId: ctx.user.id, organizationId: ctx.user.organizationId },
-      });
+      // Ownership-guard (id + userId + org).
+      const owned = await ctx.repos.tasks.getOwned(id, ctx.user.id, ctx.user.organizationId);
+      if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
       // Auto-set completedAt när status flippas till DONE
       const patch: Record<string, unknown> = { ...data };
       if (data.status === "DONE") patch.completedAt = new Date();
       if (data.status && data.status !== "DONE") patch.completedAt = null;
-      return ctx.dataStore.tasks.update({ where: { id }, data: patch });
+      return ctx.repos.tasks.update(id, patch as Partial<Task>);
     }),
 
   complete: protectedProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      await ctx.dataStore.tasks.findFirstOrThrow({
-        where: { id: input.id, userId: ctx.user.id, organizationId: ctx.user.organizationId },
-      });
-      return ctx.dataStore.tasks.update({
-        where: { id: input.id },
-        data: { status: "DONE", completedAt: new Date() },
-      });
+      const owned = await ctx.repos.tasks.getOwned(input.id, ctx.user.id, ctx.user.organizationId);
+      if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
+      return ctx.repos.tasks.update(input.id, { status: "DONE", completedAt: new Date() } as Partial<Task>);
     }),
 
   delete: protectedProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      await ctx.dataStore.tasks.findFirstOrThrow({
-        where: { id: input.id, userId: ctx.user.id, organizationId: ctx.user.organizationId },
-      });
-      return ctx.dataStore.tasks.delete({ where: { id: input.id } });
+      const owned = await ctx.repos.tasks.getOwned(input.id, ctx.user.id, ctx.user.organizationId);
+      if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
+      // Hård delete bevarar dagens beteende (ADR 0017-delete-policy öppen).
+      await ctx.repos.tasks.hardDelete(input.id);
+      return { id: input.id };
     }),
 });

--- a/test/unit/server/repositories/task-repository.test.ts
+++ b/test/unit/server/repositories/task-repository.test.ts
@@ -1,0 +1,63 @@
+/**
+ * TaskRepository-paritet (ADR 0020, #409 fan-out) — in-memory + Drizzle (pglite).
+ * `listForUser` (ägar-/org-scope + matter-subset + filter) och `getOwned`.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { matters, tasks } from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzleTaskRepository } from "@/lib/server/repositories/drizzle-task-repository";
+import { InMemoryTaskRepository } from "@/lib/server/repositories/in-memory-task-repository";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+describe("TaskRepository — in-memory", () => {
+  it("listForUser (ägar-scope + filter + matter) och getOwned", async () => {
+    const userId = uuidv7();
+    const mId = uuidv7();
+    const t1 = uuidv7();
+    const store = new LocalStore({
+      matters: [{ id: mId, organizationId: "org-1", matterNumber: "2026-1", title: "T" }],
+      tasks: [
+        { id: t1, userId, organizationId: "org-1", title: "A", status: "TODO", matterId: mId },
+        { id: uuidv7(), userId, organizationId: "org-1", title: "B", status: "DONE", matterId: null },
+        { id: uuidv7(), userId: uuidv7(), organizationId: "org-1", title: "Annan", status: "TODO" },
+      ],
+    }, async () => {});
+    const repo = new InMemoryTaskRepository(store);
+    expect(await repo.listForUser(userId, "org-1", {})).toHaveLength(2); // bara egna
+    expect(await repo.listForUser(userId, "org-1", { status: "DONE" })).toHaveLength(1);
+    const withMatter = (await repo.listForUser(userId, "org-1", { status: "TODO" }))[0]!;
+    expect(withMatter.matter?.matterNumber).toBe("2026-1");
+    expect(await repo.getOwned(t1, userId, "org-1")).toMatchObject({ id: t1 });
+    expect(await repo.getOwned(t1, uuidv7(), "org-1")).toBeNull(); // annan user
+  });
+});
+
+describe("TaskRepository — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("listForUser (left-join matter) och getOwned", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const userId = uuidv7();
+    const mId = uuidv7();
+    const t1 = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
+    await db.insert(tasks).values(v({ id: t1, userId, organizationId: org, title: "A", status: "TODO", matterId: mId }));
+    await db.insert(tasks).values(v({ id: uuidv7(), userId, organizationId: org, title: "B", status: "DONE" }));
+    await db.insert(tasks).values(v({ id: uuidv7(), userId: uuidv7(), organizationId: org, title: "Annan", status: "TODO" }));
+    const repo = new DrizzleTaskRepository(handle.db as unknown as AppDb);
+    expect(await repo.listForUser(userId, org, {})).toHaveLength(2);
+    expect(await repo.listForUser(userId, org, { status: "DONE" })).toHaveLength(1);
+    const withMatter = (await repo.listForUser(userId, org, { status: "TODO" }))[0]!;
+    expect(withMatter.matter?.matterNumber).toBe("2026-1");
+    expect(await repo.getOwned(t1, userId, org)).toMatchObject({ id: t1 });
+    expect(await repo.getOwned(t1, uuidv7(), org)).toBeNull();
+  });
+});

--- a/test/unit/server/routers/task.test.ts
+++ b/test/unit/server/routers/task.test.ts
@@ -1,14 +1,17 @@
 /**
  * Tester för taskRouter — CRUD + complete + auto-completedAt-hantering.
+ * Migrerad till repository-sömmen (ADR 0020): ägar-vakt via getOwned (findFirst).
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import { taskRouter } from "@/lib/server/routers/task";
 import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
 
 const mockPrisma = {
   task: {
-    findFirstOrThrow: vi.fn(),
+    findFirst: vi.fn(),
     findMany: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
@@ -17,9 +20,11 @@ const mockPrisma = {
 };
 
 function makeCaller(userId = "u1", orgId = "org-a") {
+  const dataStore = dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>);
   const ctx = {
     user: { id: userId, email: "a@b.se", name: "T", role: "LAWYER", organizationId: orgId },
-    dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+    dataStore,
+    repos: buildInMemoryRepositories(dataStore as unknown as IDataStore),
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return taskRouter.createCaller(ctx as any);
@@ -76,14 +81,14 @@ describe("task.create", () => {
 });
 
 describe("task.update", () => {
-  it("guardar ownership", async () => {
-    mockPrisma.task.findFirstOrThrow.mockRejectedValue(new Error("Not found"));
-    await expect(makeCaller().update({ id: "t-1", title: "x" })).rejects.toThrow("Not found");
+  it("guardar ownership (NOT_FOUND när ej ägd)", async () => {
+    mockPrisma.task.findFirst.mockResolvedValue(null);
+    await expect(makeCaller().update({ id: "t-1", title: "x" })).rejects.toMatchObject({ code: "NOT_FOUND" });
     expect(mockPrisma.task.update).not.toHaveBeenCalled();
   });
 
   it("sätter completedAt när status=DONE", async () => {
-    mockPrisma.task.findFirstOrThrow.mockResolvedValue({ id: "t-1" });
+    mockPrisma.task.findFirst.mockResolvedValue({ id: "t-1" });
     mockPrisma.task.update.mockResolvedValue({});
     await makeCaller().update({ id: "t-1", status: "DONE" });
     const arg = mockPrisma.task.update.mock.calls[0]![0] as { data: { completedAt: Date } };
@@ -91,7 +96,7 @@ describe("task.update", () => {
   });
 
   it("nollställer completedAt när status flippas till TODO", async () => {
-    mockPrisma.task.findFirstOrThrow.mockResolvedValue({ id: "t-1" });
+    mockPrisma.task.findFirst.mockResolvedValue({ id: "t-1" });
     mockPrisma.task.update.mockResolvedValue({});
     await makeCaller().update({ id: "t-1", status: "TODO" });
     const arg = mockPrisma.task.update.mock.calls[0]![0] as { data: { completedAt: Date | null } };
@@ -101,7 +106,7 @@ describe("task.update", () => {
 
 describe("task.complete", () => {
   it("convenience-mutation — status=DONE + completedAt=now", async () => {
-    mockPrisma.task.findFirstOrThrow.mockResolvedValue({ id: "t-1" });
+    mockPrisma.task.findFirst.mockResolvedValue({ id: "t-1" });
     mockPrisma.task.update.mockResolvedValue({});
     await makeCaller().complete({ id: "t-1" });
     const arg = mockPrisma.task.update.mock.calls[0]![0] as { data: { status: string; completedAt: Date } };
@@ -109,17 +114,23 @@ describe("task.complete", () => {
     expect(arg.data.completedAt).toBeInstanceOf(Date);
   });
 
-  it("guardar ownership", async () => {
-    mockPrisma.task.findFirstOrThrow.mockRejectedValue(new Error("Not found"));
-    await expect(makeCaller().complete({ id: "t-1" })).rejects.toThrow("Not found");
+  it("guardar ownership (NOT_FOUND när ej ägd)", async () => {
+    mockPrisma.task.findFirst.mockResolvedValue(null);
+    await expect(makeCaller().complete({ id: "t-1" })).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 });
 
 describe("task.delete", () => {
-  it("guardar ownership + delete", async () => {
-    mockPrisma.task.findFirstOrThrow.mockResolvedValue({ id: "t-1" });
+  it("guardar ownership + hård delete", async () => {
+    mockPrisma.task.findFirst.mockResolvedValue({ id: "t-1" });
     mockPrisma.task.delete.mockResolvedValue({});
     await makeCaller().delete({ id: "t-1" });
     expect(mockPrisma.task.delete).toHaveBeenCalledWith({ where: { id: "t-1" } });
+  });
+
+  it("guardar ownership (NOT_FOUND när ej ägd)", async () => {
+    mockPrisma.task.findFirst.mockResolvedValue(null);
+    await expect(makeCaller().delete({ id: "t-1" })).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(mockPrisma.task.delete).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What

Continues the per-router fan-out (invoice #442–#451, expense #452, contact #453, user #454). Single-entity `task` router.

### `TaskRepository`
- `listForUser(userId, orgId, { status?, matterId? })` → the user's tasks (org-scoped, `dueAt` asc) with the `matter` subset (Drizzle left-joins the nullable matter FK).
- `getOwned(id, userId, orgId)` — the per-user ownership guard (`id` + `userId` + `organizationId`).

### Router
`task.{list,create,update,complete,delete}` → `ctx.repos.tasks`. The ownership guard becomes `getOwned` (throws `NOT_FOUND` on null, was `findFirstOrThrow`); the `completedAt` auto-set logic stays in the router; `delete` keeps hard-delete.

### Tests
Router test rewired to the seam (`findFirst` ownership mocks, `delete` where `{id}`). New parity tests (in-memory + pglite) for `listForUser` (incl. filters + matter join) and `getOwned`.

## Verification
- `bun run quality` green (coverage gate green, clones 11, deps + knip clean).
- `bun run build:demo` green.

Refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)