### PR TITLE
feat(repositories): migrate calendar router to typed repository (ADR 0020)

### DIFF
--- a/src/lib/server/repositories/calendar-event-repository.ts
+++ b/src/lib/server/repositories/calendar-event-repository.ts
@@ -1,0 +1,27 @@
+/**
+ * `CalendarEventRepository` (ADR 0020, #409 fan-out) — kalenderhändelser.
+ * Events är per-user inom org:en. Bas-CRUD ärvs. Tids-/visibility-filter görs
+ * i routern (in-memory query-engine stödjer inte Date-range); repot levererar
+ * den org-/ägar-scopade listan med ärende-subset.
+ */
+
+import type { CalendarEvent } from "@/lib/shared/schemas/calendar";
+import type { Repository } from "./types";
+
+/** Händelse + ärende-subsetet vyerna visar. */
+export interface CalendarEventRow extends CalendarEvent {
+  matter: { id: string; matterNumber: string; title: string } | null;
+}
+
+export interface CalendarEventRepository extends Repository<CalendarEvent> {
+  /** Den aktiva användarens händelser (startAt asc), med ärende-subset. */
+  listForUser(userId: string, organizationId: string): Promise<CalendarEventRow[]>;
+  /** Flera användares händelser (multi-user-vy), org-scopat, med ärende-subset. */
+  listForUsers(userIds: string[], organizationId: string): Promise<CalendarEventRow[]>;
+  /** Alla händelser för ett ärende, kronologiskt (utan ärende-subset). */
+  listForMatter(matterId: string, organizationId: string): Promise<CalendarEvent[]>;
+  /** Händelse by id, ägar-scopad (id + userId + org). Null om saknas/ej ägd/raderad. */
+  getOwned(id: string, userId: string, organizationId: string): Promise<CalendarEvent | null>;
+  /** Som `getOwned` men med ärende-subset (detaljvyn). */
+  getOwnedWithMatter(id: string, userId: string, organizationId: string): Promise<CalendarEventRow | null>;
+}

--- a/src/lib/server/repositories/drizzle-calendar-event-repository.ts
+++ b/src/lib/server/repositories/drizzle-calendar-event-repository.ts
@@ -1,0 +1,77 @@
+/**
+ * Drizzle `CalendarEventRepository` (ADR 0020) — server-impl. Ärver bas-CRUD;
+ * list/detalj left-joinar matter (nullable FK).
+ */
+
+import { and, asc, eq, inArray, isNull } from "drizzle-orm";
+import type { CalendarEvent } from "@/lib/shared/schemas/calendar";
+import { calendarEvents, matters } from "../db/schema";
+import type { AppDb } from "../db/types";
+import type { CalendarEventRepository, CalendarEventRow } from "./calendar-event-repository";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+
+type MatterCols = { mId: string | null; mNum: string | null; mTitle: string | null };
+
+function withMatter<T extends MatterCols & { ev: unknown }>(r: T): CalendarEventRow {
+  return {
+    ...(r.ev as object),
+    matter: r.mId ? { id: r.mId, matterNumber: r.mNum as string, title: r.mTitle as string } : null,
+  } as unknown as CalendarEventRow;
+}
+
+export class DrizzleCalendarEventRepository extends DrizzleRepository<CalendarEvent> implements CalendarEventRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, calendarEvents as unknown as VersionedTable, now);
+  }
+
+  private matterSelect() {
+    return {
+      ev: calendarEvents,
+      mId: matters.id, mNum: matters.matterNumber, mTitle: matters.title,
+    };
+  }
+
+  async listForUser(userId: string, organizationId: string): Promise<CalendarEventRow[]> {
+    const rows = await this.db
+      .select(this.matterSelect()).from(calendarEvents)
+      .leftJoin(matters, eq(calendarEvents.matterId, matters.id))
+      .where(and(eq(calendarEvents.userId, userId), eq(calendarEvents.organizationId, organizationId), isNull(calendarEvents.deletedAt)))
+      .orderBy(asc(calendarEvents.startAt));
+    return rows.map(withMatter);
+  }
+
+  async listForUsers(userIds: string[], organizationId: string): Promise<CalendarEventRow[]> {
+    if (!userIds.length) return [];
+    const rows = await this.db
+      .select(this.matterSelect()).from(calendarEvents)
+      .leftJoin(matters, eq(calendarEvents.matterId, matters.id))
+      .where(and(eq(calendarEvents.organizationId, organizationId), inArray(calendarEvents.userId, userIds), isNull(calendarEvents.deletedAt)))
+      .orderBy(asc(calendarEvents.startAt));
+    return rows.map(withMatter);
+  }
+
+  async listForMatter(matterId: string, organizationId: string): Promise<CalendarEvent[]> {
+    const rows = await this.db
+      .select().from(calendarEvents)
+      .where(and(eq(calendarEvents.matterId, matterId), eq(calendarEvents.organizationId, organizationId), isNull(calendarEvents.deletedAt)))
+      .orderBy(asc(calendarEvents.startAt));
+    return rows as unknown as CalendarEvent[];
+  }
+
+  async getOwned(id: string, userId: string, organizationId: string): Promise<CalendarEvent | null> {
+    const rows = await this.db
+      .select().from(calendarEvents)
+      .where(and(eq(calendarEvents.id, id), eq(calendarEvents.userId, userId), eq(calendarEvents.organizationId, organizationId), isNull(calendarEvents.deletedAt)))
+      .limit(1);
+    return (rows[0] as unknown as CalendarEvent | undefined) ?? null;
+  }
+
+  async getOwnedWithMatter(id: string, userId: string, organizationId: string): Promise<CalendarEventRow | null> {
+    const rows = await this.db
+      .select(this.matterSelect()).from(calendarEvents)
+      .leftJoin(matters, eq(calendarEvents.matterId, matters.id))
+      .where(and(eq(calendarEvents.id, id), eq(calendarEvents.userId, userId), eq(calendarEvents.organizationId, organizationId), isNull(calendarEvents.deletedAt)))
+      .limit(1);
+    return rows[0] ? withMatter(rows[0]) : null;
+  }
+}

--- a/src/lib/server/repositories/in-memory-calendar-event-repository.ts
+++ b/src/lib/server/repositories/in-memory-calendar-event-repository.ts
@@ -1,0 +1,56 @@
+/**
+ * In-memory `CalendarEventRepository` (ADR 0020) — browser/offline-impl.
+ * Ärver bas-CRUD; list/ägar-vakt använder samma where/include som routern.
+ */
+
+import type { CalendarEvent } from "@/lib/shared/schemas/calendar";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { CalendarEventRepository, CalendarEventRow } from "./calendar-event-repository";
+import { InMemoryRepository } from "./in-memory-repository";
+
+/** Delegaten repot behöver — uppfylls av `IDataStore`, `DataStoreTx` och `LocalStore`. */
+export type CalendarEventRepoSource = Pick<IDataStore, "calendarEvents">;
+
+const MATTER_INCLUDE = { matter: { select: { id: true, matterNumber: true, title: true } } };
+
+export class InMemoryCalendarEventRepository extends InMemoryRepository<CalendarEvent> implements CalendarEventRepository {
+  constructor(store: CalendarEventRepoSource, now?: () => Date) {
+    super(store.calendarEvents as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async listForUser(userId: string, organizationId: string): Promise<CalendarEventRow[]> {
+    return (await this.delegate.findMany({
+      where: { userId, organizationId },
+      orderBy: { startAt: "asc" },
+      include: MATTER_INCLUDE,
+    })) as CalendarEventRow[];
+  }
+
+  async listForUsers(userIds: string[], organizationId: string): Promise<CalendarEventRow[]> {
+    return (await this.delegate.findMany({
+      where: { organizationId, userId: { in: userIds } },
+      orderBy: { startAt: "asc" },
+      include: MATTER_INCLUDE,
+    })) as CalendarEventRow[];
+  }
+
+  async listForMatter(matterId: string, organizationId: string): Promise<CalendarEvent[]> {
+    return (await this.delegate.findMany({
+      where: { matterId, organizationId },
+      orderBy: { startAt: "asc" },
+    })) as CalendarEvent[];
+  }
+
+  async getOwned(id: string, userId: string, organizationId: string): Promise<CalendarEvent | null> {
+    const row = (await this.delegate.findFirst({ where: { id, userId, organizationId } })) as CalendarEvent | null;
+    return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
+  }
+
+  async getOwnedWithMatter(id: string, userId: string, organizationId: string): Promise<CalendarEventRow | null> {
+    const row = (await this.delegate.findFirst({
+      where: { id, userId, organizationId },
+      include: MATTER_INCLUDE,
+    })) as CalendarEventRow | null;
+    return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
+  }
+}

--- a/src/lib/server/repositories/in-memory-repositories.ts
+++ b/src/lib/server/repositories/in-memory-repositories.ts
@@ -10,6 +10,7 @@
 
 import type { DataStoreTx, IDataStore } from "../data-store/IDataStore";
 import { InMemoryAccontoDeductionRepository } from "./in-memory-acconto-deduction-repository";
+import { InMemoryCalendarEventRepository } from "./in-memory-calendar-event-repository";
 import { InMemoryContactRepository } from "./in-memory-contact-repository";
 import { InMemoryExpenseRepository } from "./in-memory-expense-repository";
 import { InMemoryInvoiceRepository } from "./in-memory-invoice-repository";
@@ -36,6 +37,7 @@ function reposForTx(tx: DataStoreTx): Repositories {
     contacts: new InMemoryContactRepository(tx),
     users: new InMemoryUserRepository(tx),
     tasks: new InMemoryTaskRepository(tx),
+    calendarEvents: new InMemoryCalendarEventRepository(tx),
     transaction: (fn) => fn(repos),
   };
   return repos;
@@ -54,6 +56,7 @@ export function buildInMemoryRepositories(dataStore: IDataStore): Repositories {
     contacts: new InMemoryContactRepository(dataStore),
     users: new InMemoryUserRepository(dataStore),
     tasks: new InMemoryTaskRepository(dataStore),
+    calendarEvents: new InMemoryCalendarEventRepository(dataStore),
     transaction: (fn) => dataStore.transaction((tx) => fn(reposForTx(tx))),
   };
 }

--- a/src/lib/server/repositories/repositories.ts
+++ b/src/lib/server/repositories/repositories.ts
@@ -6,6 +6,7 @@
  */
 
 import type { AccontoDeductionRepository } from "./acconto-deduction-repository";
+import type { CalendarEventRepository } from "./calendar-event-repository";
 import type { ContactRepository } from "./contact-repository";
 import type { ExpenseRepository } from "./expense-repository";
 import type { InvoiceRepository } from "./invoice-repository";
@@ -29,5 +30,6 @@ export interface Repositories {
   contacts: ContactRepository;
   users: UserRepository;
   tasks: TaskRepository;
+  calendarEvents: CalendarEventRepository;
   transaction<T>(fn: (tx: Repositories) => Promise<T>): Promise<T>;
 }

--- a/src/lib/server/routers/calendar.ts
+++ b/src/lib/server/routers/calendar.ts
@@ -13,7 +13,7 @@
  */
 
 import { z } from "zod";
-import { calendarEventKindSchema, calendarEventVisibilitySchema } from "@/lib/shared/schemas";
+import { calendarEventKindSchema, calendarEventVisibilitySchema, type CalendarEvent } from "@/lib/shared/schemas";
 import {
   asId,
   calendarEventIdSchema,
@@ -21,7 +21,7 @@ import {
   userIdSchema,
   contactIdSchema,
 } from "@/lib/shared/schemas/ids";
-import { router, protectedProcedure } from "../trpc";
+import { router, protectedProcedure, TRPCError } from "../trpc";
 
 const createInput = z.object({
   kind: calendarEventKindSchema.default("appointment"),
@@ -97,14 +97,7 @@ export const calendarRouter = router({
       }).optional(),
     )
     .query(async ({ ctx, input }) => {
-      const events = await ctx.dataStore.calendarEvents.findMany({
-        where: {
-          userId: ctx.user.id,
-          organizationId: ctx.user.organizationId,
-        },
-        orderBy: { startAt: "asc" },
-        include: { matter: { select: { id: true, matterNumber: true, title: true } } },
-      });
+      const events = await ctx.repos.calendarEvents.listForUser(ctx.user.id, ctx.user.organizationId);
       // Tidsfilter sker i minne (in-memory query-engine stödjer inte range över Date)
       if (!input?.from && !input?.to) return events;
       return events.filter((e: { startAt: Date | string }) => {
@@ -134,14 +127,7 @@ export const calendarRouter = router({
     }))
     .query(async ({ ctx, input }) => {
       if (input.userIds.length === 0) return [];
-      const events = await ctx.dataStore.calendarEvents.findMany({
-        where: {
-          organizationId: ctx.user.organizationId,
-          userId: { in: input.userIds },
-        },
-        orderBy: { startAt: "asc" },
-        include: { matter: { select: { id: true, matterNumber: true, title: true } } },
-      });
+      const events = await ctx.repos.calendarEvents.listForUsers(input.userIds, ctx.user.organizationId);
       const visible = events.filter((e: { userId: string; visibility?: string }) =>
         e.visibility !== "private" || e.userId === ctx.user.id,
       );
@@ -156,12 +142,11 @@ export const calendarRouter = router({
 
   getById: protectedProcedure
     .input(z.object({ id: z.string() }))
-    .query(({ ctx, input }) =>
-      ctx.dataStore.calendarEvents.findFirstOrThrow({
-        where: { id: input.id, userId: ctx.user.id, organizationId: ctx.user.organizationId },
-        include: { matter: { select: { id: true, matterNumber: true, title: true } } },
-      }),
-    ),
+    .query(async ({ ctx, input }) => {
+      const ev = await ctx.repos.calendarEvents.getOwnedWithMatter(input.id, ctx.user.id, ctx.user.organizationId);
+      if (!ev) throw new TRPCError({ code: "NOT_FOUND" });
+      return ev;
+    }),
 
   create: protectedProcedure
     .input(createInput)
@@ -171,53 +156,47 @@ export const calendarRouter = router({
       const cleanInput = Object.fromEntries(
         Object.entries(input).filter(([, v]) => v !== undefined),
       );
-      return ctx.dataStore.calendarEvents.create({
-        data: {
-          ...cleanInput,
-          userId: input.userId ?? asId<"UserId">(ctx.user.id),
-          organizationId: asId<"OrganizationId">(ctx.user.organizationId),
-          mirrorStatus: input.mirrorToOutlook ? "pending" : null,
-        },
-      });
+      return ctx.repos.calendarEvents.create({
+        ...cleanInput,
+        userId: input.userId ?? asId<"UserId">(ctx.user.id),
+        organizationId: asId<"OrganizationId">(ctx.user.organizationId),
+        mirrorStatus: input.mirrorToOutlook ? "pending" : null,
+      } as Partial<CalendarEvent>);
     }),
 
   /** Alla events kopplade till ett specifikt ärende, kronologiskt. */
   listForMatter: protectedProcedure
     .input(z.object({ matterId: z.string() }))
-    .query(async ({ ctx, input }) => {
-      return ctx.dataStore.calendarEvents.findMany({
-        where: { matterId: input.matterId, organizationId: ctx.user.organizationId },
-        orderBy: { startAt: "asc" },
-      });
-    }),
+    .query(({ ctx, input }) =>
+      ctx.repos.calendarEvents.listForMatter(input.matterId, ctx.user.organizationId),
+    ),
 
   update: protectedProcedure
     .input(updateInput)
     .mutation(async ({ ctx, input }) => {
       const { id, ...data } = input;
-      const existing = await ctx.dataStore.calendarEvents.findFirstOrThrow({
-        where: { id, userId: ctx.user.id, organizationId: ctx.user.organizationId },
-      });
+      const existing = await ctx.repos.calendarEvents.getOwned(id, ctx.user.id, ctx.user.organizationId);
+      if (!existing) throw new TRPCError({ code: "NOT_FOUND" });
       // exactOptionalPropertyTypes: utelämna nycklar vars värde är undefined
       // i write-payloaden (förr droppades de ändå). `computeMirrorPatch` får
       // dock det råa `data` så dess nyckel-räkning av "ändrade fält" bevaras.
       const writeData = Object.fromEntries(
         Object.entries(data).filter(([, v]) => v !== undefined),
       );
-      return ctx.dataStore.calendarEvents.update({
-        where: { id },
-        data: { ...writeData, ...computeMirrorPatch(data, existing) },
-      });
+      return ctx.repos.calendarEvents.update(id, {
+        ...writeData, ...computeMirrorPatch(data, existing),
+      } as Partial<CalendarEvent>);
     }),
 
   delete: protectedProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
       // Säkerställ ownership innan delete
-      await ctx.dataStore.calendarEvents.findFirstOrThrow({
-        where: { id: input.id, userId: ctx.user.id, organizationId: ctx.user.organizationId },
-      });
-      return ctx.dataStore.calendarEvents.delete({ where: { id: input.id } });
+      const owned = await ctx.repos.calendarEvents.getOwned(input.id, ctx.user.id, ctx.user.organizationId);
+      if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
+      // Hård delete bevarar dagens beteende (ADR 0017-delete-policy öppen).
+      await ctx.repos.calendarEvents.hardDelete(input.id);
+      return { id: input.id };
     }),
 
   /**
@@ -237,10 +216,9 @@ export const calendarRouter = router({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      await ctx.dataStore.calendarEvents.findFirstOrThrow({
-        where: { id: input.id, userId: ctx.user.id, organizationId: ctx.user.organizationId },
-      });
+      const owned = await ctx.repos.calendarEvents.getOwned(input.id, ctx.user.id, ctx.user.organizationId);
+      if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
       const { id, ...data } = input;
-      return ctx.dataStore.calendarEvents.update({ where: { id }, data });
+      return ctx.repos.calendarEvents.update(id, data as Partial<CalendarEvent>);
     }),
 });

--- a/test/unit/server/repositories/calendar-event-repository.test.ts
+++ b/test/unit/server/repositories/calendar-event-repository.test.ts
@@ -1,0 +1,66 @@
+/**
+ * CalendarEventRepository-paritet (ADR 0020, #409 fan-out) — in-memory + Drizzle
+ * (pglite). listForUser/listForUsers/listForMatter + getOwned/getOwnedWithMatter.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { calendarEvents, matters } from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzleCalendarEventRepository } from "@/lib/server/repositories/drizzle-calendar-event-repository";
+import { InMemoryCalendarEventRepository } from "@/lib/server/repositories/in-memory-calendar-event-repository";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+describe("CalendarEventRepository — in-memory", () => {
+  it("list-varianter + ägar-vakt", async () => {
+    const userId = uuidv7();
+    const other = uuidv7();
+    const mId = uuidv7();
+    const e1 = uuidv7();
+    const store = new LocalStore({
+      matters: [{ id: mId, organizationId: "org-1", matterNumber: "2026-1", title: "T" }],
+      calendarEvents: [
+        { id: e1, userId, organizationId: "org-1", title: "A", startAt: new Date("2026-06-02"), matterId: mId },
+        { id: uuidv7(), userId, organizationId: "org-1", title: "B", startAt: new Date("2026-06-01"), matterId: null },
+        { id: uuidv7(), userId: other, organizationId: "org-1", title: "C", startAt: new Date("2026-06-03"), matterId: mId },
+      ],
+    }, async () => {});
+    const repo = new InMemoryCalendarEventRepository(store);
+    expect(await repo.listForUser(userId, "org-1")).toHaveLength(2);
+    expect(await repo.listForUsers([userId, other], "org-1")).toHaveLength(3);
+    expect(await repo.listForMatter(mId, "org-1")).toHaveLength(2); // e1 + other's C
+    expect(await repo.getOwned(e1, userId, "org-1")).toMatchObject({ id: e1 });
+    expect(await repo.getOwned(e1, other, "org-1")).toBeNull(); // annan user
+    expect((await repo.getOwnedWithMatter(e1, userId, "org-1"))?.matter?.matterNumber).toBe("2026-1");
+  });
+});
+
+describe("CalendarEventRepository — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("list-varianter (left-join matter) + ägar-vakt", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const userId = uuidv7();
+    const other = uuidv7();
+    const mId = uuidv7();
+    const e1 = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
+    await db.insert(calendarEvents).values(v({ id: e1, userId, organizationId: org, title: "A", startAt: new Date("2026-06-02"), matterId: mId }));
+    await db.insert(calendarEvents).values(v({ id: uuidv7(), userId, organizationId: org, title: "B", startAt: new Date("2026-06-01") }));
+    await db.insert(calendarEvents).values(v({ id: uuidv7(), userId: other, organizationId: org, title: "C", startAt: new Date("2026-06-03"), matterId: mId }));
+    const repo = new DrizzleCalendarEventRepository(handle.db as unknown as AppDb);
+    expect(await repo.listForUser(userId, org)).toHaveLength(2);
+    expect(await repo.listForUsers([userId, other], org)).toHaveLength(3);
+    expect(await repo.listForUsers([], org)).toEqual([]);
+    expect(await repo.listForMatter(mId, org)).toHaveLength(2);
+    expect(await repo.getOwned(e1, userId, org)).toMatchObject({ id: e1 });
+    expect(await repo.getOwned(e1, other, org)).toBeNull();
+    expect((await repo.getOwnedWithMatter(e1, userId, org))?.matter?.matterNumber).toBe("2026-1");
+  });
+});

--- a/test/unit/server/routers/calendar.test.ts
+++ b/test/unit/server/routers/calendar.test.ts
@@ -8,13 +8,14 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import { calendarRouter } from "@/lib/server/routers/calendar";
 import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
 
 const mockPrisma = {
   calendarEvent: {
     findFirst: vi.fn(),
-    findFirstOrThrow: vi.fn(),
     findMany: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
@@ -23,9 +24,11 @@ const mockPrisma = {
 };
 
 function makeCaller(userId = "u1", orgId = "org-a") {
+  const dataStore = dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>);
   const ctx = {
     user: { id: userId, email: "a@b.se", name: "T", role: "LAWYER", organizationId: orgId },
-    dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+    dataStore,
+    repos: buildInMemoryRepositories(dataStore as unknown as IDataStore),
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return calendarRouter.createCaller(ctx as any);
@@ -168,16 +171,16 @@ describe("calendar.create", () => {
 
 describe("calendar.update", () => {
   it("guardar ownership innan update", async () => {
-    mockPrisma.calendarEvent.findFirstOrThrow.mockRejectedValue(new Error("Not found"));
+    mockPrisma.calendarEvent.findFirst.mockResolvedValue(null);
     await expect(makeCaller().update({
       id: "e1",
       title: "Försöker ändra andras",
-    })).rejects.toThrow("Not found");
+    })).rejects.toMatchObject({ code: "NOT_FOUND" });
     expect(mockPrisma.calendarEvent.update).not.toHaveBeenCalled();
   });
 
   it("flippa till mirrorToOutlook=true → sätt mirrorStatus=pending", async () => {
-    mockPrisma.calendarEvent.findFirstOrThrow.mockResolvedValue({
+    mockPrisma.calendarEvent.findFirst.mockResolvedValue({
       id: "e1", mirrorToOutlook: false, mirrorStatus: null,
     });
     mockPrisma.calendarEvent.update.mockResolvedValue({});
@@ -187,7 +190,7 @@ describe("calendar.update", () => {
   });
 
   it("flippa till mirrorToOutlook=false → nollställ outlookEventId + status", async () => {
-    mockPrisma.calendarEvent.findFirstOrThrow.mockResolvedValue({
+    mockPrisma.calendarEvent.findFirst.mockResolvedValue({
       id: "e1", mirrorToOutlook: true, mirrorStatus: "synced", outlookEventId: "ou-1",
     });
     mockPrisma.calendarEvent.update.mockResolvedValue({});
@@ -198,7 +201,7 @@ describe("calendar.update", () => {
   });
 
   it("ändra title på mirrored event → mirrorStatus=pending (re-push)", async () => {
-    mockPrisma.calendarEvent.findFirstOrThrow.mockResolvedValue({
+    mockPrisma.calendarEvent.findFirst.mockResolvedValue({
       id: "e1", mirrorToOutlook: true, mirrorStatus: "synced",
     });
     mockPrisma.calendarEvent.update.mockResolvedValue({});
@@ -210,10 +213,10 @@ describe("calendar.update", () => {
 
 describe("calendar.getById", () => {
   it("scopar till id + aktiv användare + org", async () => {
-    mockPrisma.calendarEvent.findFirstOrThrow.mockResolvedValue({ id: "e1", title: "Möte" });
+    mockPrisma.calendarEvent.findFirst.mockResolvedValue({ id: "e1", title: "Möte" });
     const res = await makeCaller("u-anna", "org-x").getById({ id: "e1" });
     expect(res).toMatchObject({ id: "e1" });
-    expect(mockPrisma.calendarEvent.findFirstOrThrow).toHaveBeenCalledWith(
+    expect(mockPrisma.calendarEvent.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { id: "e1", userId: "u-anna", organizationId: "org-x" },
       }),
@@ -221,8 +224,8 @@ describe("calendar.getById", () => {
   });
 
   it("kastar när eventet inte är användarens", async () => {
-    mockPrisma.calendarEvent.findFirstOrThrow.mockRejectedValue(new Error("Not found"));
-    await expect(makeCaller().getById({ id: "e1" })).rejects.toThrow("Not found");
+    mockPrisma.calendarEvent.findFirst.mockResolvedValue(null);
+    await expect(makeCaller().getById({ id: "e1" })).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 });
 
@@ -242,15 +245,15 @@ describe("calendar.listForMatter", () => {
 
 describe("calendar.setMirrorState", () => {
   it("guardar ownership innan uppdatering", async () => {
-    mockPrisma.calendarEvent.findFirstOrThrow.mockRejectedValue(new Error("Not found"));
+    mockPrisma.calendarEvent.findFirst.mockResolvedValue(null);
     await expect(
       makeCaller().setMirrorState({ id: "e1", mirrorStatus: "synced" }),
-    ).rejects.toThrow("Not found");
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
     expect(mockPrisma.calendarEvent.update).not.toHaveBeenCalled();
   });
 
   it("skriver mirror-fält rakt av UTAN computeMirrorPatch (ingen pending-loop)", async () => {
-    mockPrisma.calendarEvent.findFirstOrThrow.mockResolvedValue({ id: "e1" });
+    mockPrisma.calendarEvent.findFirst.mockResolvedValue({ id: "e1" });
     mockPrisma.calendarEvent.update.mockResolvedValue({});
     await makeCaller().setMirrorState({
       id: "e1", outlookEventId: "ou-1", mirrorStatus: "synced",
@@ -267,13 +270,13 @@ describe("calendar.setMirrorState", () => {
 
 describe("calendar.delete", () => {
   it("guardar ownership innan delete", async () => {
-    mockPrisma.calendarEvent.findFirstOrThrow.mockRejectedValue(new Error("Not found"));
-    await expect(makeCaller().delete({ id: "e1" })).rejects.toThrow("Not found");
+    mockPrisma.calendarEvent.findFirst.mockResolvedValue(null);
+    await expect(makeCaller().delete({ id: "e1" })).rejects.toMatchObject({ code: "NOT_FOUND" });
     expect(mockPrisma.calendarEvent.delete).not.toHaveBeenCalled();
   });
 
   it("delete forwardar till dataStore", async () => {
-    mockPrisma.calendarEvent.findFirstOrThrow.mockResolvedValue({ id: "e1" });
+    mockPrisma.calendarEvent.findFirst.mockResolvedValue({ id: "e1" });
     mockPrisma.calendarEvent.delete.mockResolvedValue({});
     await makeCaller().delete({ id: "e1" });
     expect(mockPrisma.calendarEvent.delete).toHaveBeenCalledWith({ where: { id: "e1" } });


### PR DESCRIPTION
## What

Continues the per-router fan-out (invoice #442–#451, expense #452, contact #453, user #454, task #455). Single-entity `calendar` router (8 procedures).

### `CalendarEventRepository`
- `listForUser` / `listForUsers` / `listForMatter` — the various list shapes, with the matter subset where the views show it (Drizzle left-joins the nullable matter FK).
- `getOwned` + `getOwnedWithMatter` — per-user ownership guards (the latter for `getById`'s detail view).

### Router
`calendar.{list,listForUsers,getById,create,listForMatter,update,delete,setMirrorState}` → `ctx.repos.calendarEvents`. The in-memory time-window + visibility filters and the `computeMirrorPatch` mirror-state logic stay in the router; ownership guards become `getOwned` (throw `NOT_FOUND` on null, was `findFirstOrThrow`); `delete` keeps hard-delete.

### Tests
Router test rewired to the seam (`findFirst` ownership mocks, `delete` where `{id}`). New parity tests (in-memory + pglite) for all five read methods.

## Verification
- `bun run quality` green (coverage gate green, clones 11, deps + knip clean).
- `bun run build:demo` green.

Refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)