### PR TITLE
feat(repositories): migrate serviceNote router to typed repository (ADR 0020)

### DIFF
--- a/src/lib/server/repositories/drizzle-service-note-repository.ts
+++ b/src/lib/server/repositories/drizzle-service-note-repository.ts
@@ -1,0 +1,43 @@
+/**
+ * Drizzle `ServiceNoteRepository` (ADR 0020) — server-impl. Ärver bas-CRUD;
+ * org-scopar via join mot ärendet, list left-joinar författaren.
+ */
+
+import { and, desc, eq, isNull } from "drizzle-orm";
+import type { ServiceNote } from "@/lib/shared/schemas/service-note";
+import { matters, serviceNotes, users } from "../db/schema";
+import type { AppDb } from "../db/types";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import type { ServiceNoteRepository, ServiceNoteRow } from "./service-note-repository";
+
+export class DrizzleServiceNoteRepository extends DrizzleRepository<ServiceNote> implements ServiceNoteRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, serviceNotes as unknown as VersionedTable, now);
+  }
+
+  async listByMatter(matterId: string, organizationId: string): Promise<ServiceNoteRow[]> {
+    const rows = await this.db
+      .select({ note: serviceNotes, aId: users.id, aName: users.name }).from(serviceNotes)
+      .innerJoin(matters, eq(serviceNotes.matterId, matters.id))
+      .leftJoin(users, eq(serviceNotes.authorId, users.id))
+      .where(and(
+        eq(serviceNotes.matterId, matterId),
+        eq(matters.organizationId, organizationId),
+        isNull(serviceNotes.deletedAt),
+      ))
+      .orderBy(desc(serviceNotes.createdAt));
+    return rows.map((r) => ({
+      ...(r.note as object),
+      author: r.aId ? { id: r.aId, name: r.aName as string } : null,
+    })) as unknown as ServiceNoteRow[];
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<ServiceNote | null> {
+    const rows = await this.db
+      .select({ note: serviceNotes }).from(serviceNotes)
+      .innerJoin(matters, eq(serviceNotes.matterId, matters.id))
+      .where(and(eq(serviceNotes.id, id), eq(matters.organizationId, organizationId), isNull(serviceNotes.deletedAt)))
+      .limit(1);
+    return (rows[0]?.note as unknown as ServiceNote | undefined) ?? null;
+  }
+}

--- a/src/lib/server/repositories/in-memory-repositories.ts
+++ b/src/lib/server/repositories/in-memory-repositories.ts
@@ -17,6 +17,7 @@ import { InMemoryInvoiceRepository } from "./in-memory-invoice-repository";
 import { InMemoryMatterRepository } from "./in-memory-matter-repository";
 import { InMemoryPaymentPlanRepository } from "./in-memory-payment-plan-repository";
 import { InMemoryPaymentRepository } from "./in-memory-payment-repository";
+import { InMemoryServiceNoteRepository } from "./in-memory-service-note-repository";
 import { InMemoryTaskRepository } from "./in-memory-task-repository";
 import { InMemoryTimeEntryRepository } from "./in-memory-time-entry-repository";
 import { InMemoryUserRepository } from "./in-memory-user-repository";
@@ -38,6 +39,7 @@ function reposForTx(tx: DataStoreTx): Repositories {
     users: new InMemoryUserRepository(tx),
     tasks: new InMemoryTaskRepository(tx),
     calendarEvents: new InMemoryCalendarEventRepository(tx),
+    serviceNotes: new InMemoryServiceNoteRepository(tx),
     transaction: (fn) => fn(repos),
   };
   return repos;
@@ -57,6 +59,7 @@ export function buildInMemoryRepositories(dataStore: IDataStore): Repositories {
     users: new InMemoryUserRepository(dataStore),
     tasks: new InMemoryTaskRepository(dataStore),
     calendarEvents: new InMemoryCalendarEventRepository(dataStore),
+    serviceNotes: new InMemoryServiceNoteRepository(dataStore),
     transaction: (fn) => dataStore.transaction((tx) => fn(reposForTx(tx))),
   };
 }

--- a/src/lib/server/repositories/in-memory-service-note-repository.ts
+++ b/src/lib/server/repositories/in-memory-service-note-repository.ts
@@ -1,0 +1,32 @@
+/**
+ * In-memory `ServiceNoteRepository` (ADR 0020) — browser/offline-impl. Ärver
+ * bas-CRUD; list/ägar-vakt org-scopar via ärendet (samma relations-where som routern).
+ */
+
+import type { ServiceNote } from "@/lib/shared/schemas/service-note";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import { InMemoryRepository } from "./in-memory-repository";
+import type { ServiceNoteRepository, ServiceNoteRow } from "./service-note-repository";
+
+/** Delegaten repot behöver — uppfylls av `IDataStore`, `DataStoreTx` och `LocalStore`. */
+export type ServiceNoteRepoSource = Pick<IDataStore, "serviceNotes">;
+
+export class InMemoryServiceNoteRepository extends InMemoryRepository<ServiceNote> implements ServiceNoteRepository {
+  constructor(store: ServiceNoteRepoSource, now?: () => Date) {
+    super(store.serviceNotes as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async listByMatter(matterId: string, organizationId: string): Promise<ServiceNoteRow[]> {
+    return (await this.delegate.findMany({
+      where: { matterId, matter: { organizationId } },
+      orderBy: { createdAt: "desc" },
+      include: { author: { select: { id: true, name: true } } },
+    })) as ServiceNoteRow[];
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<ServiceNote | null> {
+    const row = (await this.delegate
+      .findFirst({ where: { id, matter: { organizationId } } })) as ServiceNote | null;
+    return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
+  }
+}

--- a/src/lib/server/repositories/repositories.ts
+++ b/src/lib/server/repositories/repositories.ts
@@ -13,6 +13,7 @@ import type { InvoiceRepository } from "./invoice-repository";
 import type { MatterRepository } from "./matter-repository";
 import type { PaymentPlanRepository } from "./payment-plan-repository";
 import type { PaymentRepository } from "./payment-repository";
+import type { ServiceNoteRepository } from "./service-note-repository";
 import type { TaskRepository } from "./task-repository";
 import type { TimeEntryRepository } from "./time-entry-repository";
 import type { UserRepository } from "./user-repository";
@@ -31,5 +32,6 @@ export interface Repositories {
   users: UserRepository;
   tasks: TaskRepository;
   calendarEvents: CalendarEventRepository;
+  serviceNotes: ServiceNoteRepository;
   transaction<T>(fn: (tx: Repositories) => Promise<T>): Promise<T>;
 }

--- a/src/lib/server/repositories/service-note-repository.ts
+++ b/src/lib/server/repositories/service-note-repository.ts
@@ -1,0 +1,20 @@
+/**
+ * `ServiceNoteRepository` (ADR 0020, #409 fan-out) — tjänsteanteckningar (#348).
+ * Org-scopas via ärendet (som routern). Bas-CRUD ärvs; `listByMatter` ger
+ * ärendets noteringar med författar-subset, `getByIdInOrg` är ägarskaps-vakten.
+ */
+
+import type { ServiceNote } from "@/lib/shared/schemas/service-note";
+import type { Repository } from "./types";
+
+/** Notering + författar-subsetet listvyn visar. */
+export interface ServiceNoteRow extends ServiceNote {
+  author: { id: string; name: string } | null;
+}
+
+export interface ServiceNoteRepository extends Repository<ServiceNote> {
+  /** Ärendets noteringar (nyaste först), org-scopat via ärendet, med författare. */
+  listByMatter(matterId: string, organizationId: string): Promise<ServiceNoteRow[]>;
+  /** Notering by id, org-scopad via ärendet (null om saknas/annan org/raderad). */
+  getByIdInOrg(id: string, organizationId: string): Promise<ServiceNote | null>;
+}

--- a/src/lib/server/routers/serviceNote.ts
+++ b/src/lib/server/routers/serviceNote.ts
@@ -6,6 +6,7 @@ import {
   userIdSchema,
   serviceNoteIdSchema,
 } from "@/lib/shared/schemas/ids";
+import type { ServiceNote } from "@/lib/shared/schemas/service-note";
 import { router, protectedProcedure, orgProcedure, TRPCError } from "../trpc";
 
 /**
@@ -17,16 +18,10 @@ import { router, protectedProcedure, orgProcedure, TRPCError } from "../trpc";
 export const serviceNoteRouter = router({
   list: protectedProcedure
     .input(z.object({ matterId: z.string() }))
-    .query(async ({ ctx, input }) => {
-      return ctx.dataStore.serviceNotes.findMany({
-        where: {
-          matterId: input.matterId,
-          matter: { organizationId: ctx.user.organizationId },
-        },
-        orderBy: { createdAt: "desc" },
-        include: { author: { select: { id: true, name: true } } },
-      });
-    }),
+    // Migrerad till repository-sömmen (ADR 0020): listByMatter org-scopar via ärendet.
+    .query(({ ctx, input }) =>
+      ctx.repos.serviceNotes.listByMatter(input.matterId, ctx.user.organizationId),
+    ),
 
   create: protectedProcedure
     .input(
@@ -42,18 +37,16 @@ export const serviceNoteRouter = router({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      return ctx.dataStore.serviceNotes.create({
-        data: omitUndefined({
-          id: input.id, // undefined → store genererar
-          organizationId: asId<"OrganizationId">(ctx.user.organizationId),
-          matterId: input.matterId,
-          authorId: input.authorId ?? asId<"UserId">(ctx.user.id),
-          date: input.date,
-          time: input.time,
-          text: input.text,
-          ...(input.createdAt ? { createdAt: new Date(input.createdAt) } : {}),
-        }),
-      });
+      return ctx.repos.serviceNotes.create(omitUndefined({
+        id: input.id, // undefined → store genererar
+        organizationId: asId<"OrganizationId">(ctx.user.organizationId),
+        matterId: input.matterId,
+        authorId: input.authorId ?? asId<"UserId">(ctx.user.id),
+        date: input.date,
+        time: input.time,
+        text: input.text,
+        ...(input.createdAt ? { createdAt: new Date(input.createdAt) } : {}),
+      }) as Partial<ServiceNote>);
     }),
 
   update: orgProcedure
@@ -68,24 +61,19 @@ export const serviceNoteRouter = router({
     .mutation(async ({ ctx, input }) => {
       // Ägarkoll (samma org-scopning som `list`) INNAN update — NOT_FOUND vid
       // mismatch läcker inte existens.
-      const owned = await ctx.dataStore.serviceNotes.findFirst({
-        where: { id: input.id, matter: { organizationId: ctx.orgId } },
-      });
+      const owned = await ctx.repos.serviceNotes.getByIdInOrg(input.id, ctx.orgId);
       if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
       const { id, date, time, text } = input;
-      return ctx.dataStore.serviceNotes.update({
-        where: { id },
-        data: omitUndefined({ date, time, text }),
-      });
+      return ctx.repos.serviceNotes.update(id, omitUndefined({ date, time, text }) as Partial<ServiceNote>);
     }),
 
   delete: orgProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      const owned = await ctx.dataStore.serviceNotes.findFirst({
-        where: { id: input.id, matter: { organizationId: ctx.orgId } },
-      });
+      const owned = await ctx.repos.serviceNotes.getByIdInOrg(input.id, ctx.orgId);
       if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
-      return ctx.dataStore.serviceNotes.delete({ where: { id: input.id } });
+      // Hård delete bevarar dagens beteende (ADR 0017-delete-policy öppen).
+      await ctx.repos.serviceNotes.hardDelete(input.id);
+      return { id: input.id };
     }),
 });

--- a/test/unit/server/repositories/service-note-repository.test.ts
+++ b/test/unit/server/repositories/service-note-repository.test.ts
@@ -1,0 +1,62 @@
+/**
+ * ServiceNoteRepository-paritet (ADR 0020, #409 fan-out) — in-memory + Drizzle
+ * (pglite). `listByMatter` (org-scope via ärendet + författare) + `getByIdInOrg`.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { matters, serviceNotes, users } from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzleServiceNoteRepository } from "@/lib/server/repositories/drizzle-service-note-repository";
+import { InMemoryServiceNoteRepository } from "@/lib/server/repositories/in-memory-service-note-repository";
+import { prebakeJoins } from "@/lib/shared/demo-source";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+describe("ServiceNoteRepository — in-memory", () => {
+  it("listByMatter (org-scope via ärende + author) + getByIdInOrg", async () => {
+    const mId = uuidv7();
+    const userId = uuidv7();
+    const sn1 = uuidv7();
+    // prebakeJoins → nästlade relationer (author, matter) resolvas som i prod.
+    const source = prebakeJoins({
+      matters: [{ id: mId, organizationId: "org-1", matterNumber: "2026-1", title: "T" }],
+      users: [{ id: userId, name: "Anna" }],
+      serviceNotes: [
+        { id: sn1, matterId: mId, organizationId: "org-1", authorId: userId, date: "2026-06-15", time: "09:30", text: "A" },
+      ],
+    } as DemoSource);
+    const repo = new InMemoryServiceNoteRepository(new LocalStore(source, async () => {}));
+    const list = await repo.listByMatter(mId, "org-1");
+    expect(list).toHaveLength(1);
+    expect(list[0]!.author?.name).toBe("Anna");
+    expect(await repo.getByIdInOrg(sn1, "org-1")).toMatchObject({ id: sn1 });
+    expect(await repo.getByIdInOrg(sn1, "org-2")).toBeNull(); // fel org
+  });
+});
+
+describe("ServiceNoteRepository — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("listByMatter (join ärende/author) + getByIdInOrg", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const mId = uuidv7();
+    const userId = uuidv7();
+    const sn1 = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
+    await db.insert(users).values(v({ id: userId, organizationId: org, email: "a@x", name: "Anna" }));
+    await db.insert(serviceNotes).values(v({ id: sn1, matterId: mId, organizationId: org, authorId: userId, date: "2026-06-15", time: "09:30", text: "A" }));
+    const repo = new DrizzleServiceNoteRepository(handle.db as unknown as AppDb);
+    const list = await repo.listByMatter(mId, org);
+    expect(list).toHaveLength(1);
+    expect(list[0]!.author?.name).toBe("Anna");
+    expect(await repo.getByIdInOrg(sn1, org)).toMatchObject({ id: sn1 });
+    expect(await repo.getByIdInOrg(sn1, uuidv7())).toBeNull(); // fel org
+  });
+});

--- a/test/unit/server/routers/serviceNote.test.ts
+++ b/test/unit/server/routers/serviceNote.test.ts
@@ -5,6 +5,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import { serviceNoteRouter } from "@/lib/server/routers/serviceNote";
 import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
 
@@ -19,9 +21,11 @@ const mockPrisma = {
 };
 
 function makeCaller(orgId = "org-a", userId = "u1") {
+  const dataStore = dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>);
   const ctx = {
     user: { id: userId, email: "a@b.se", name: "T", role: "LAWYER", organizationId: orgId },
-    prisma: mockPrisma, dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+    prisma: mockPrisma, dataStore,
+    repos: buildInMemoryRepositories(dataStore as unknown as IDataStore),
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return serviceNoteRouter.createCaller(ctx as any);


### PR DESCRIPTION
## What

Continues the per-router fan-out (invoice #442–#451, expense #452, contact #453, user #454, task #455, calendar #456). Single-entity `serviceNote` router.

### `ServiceNoteRepository`
- `listByMatter(matterId, orgId)` → the matter's notes (newest first) with the `author` subset, org-scoped **via the matter** (matching the router).
- `getByIdInOrg(id, orgId)` — ownership guard, also via the matter.

### Router
`serviceNote.{list,create,update,delete}` → `ctx.repos.serviceNotes`. Ownership guard becomes `getByIdInOrg` (throws `NOT_FOUND` on null); `delete` keeps hard-delete.

### Tests
Router test wired with `repos` (the `findFirst`/`delete` call-shapes were already preserved by the seam). New parity tests (in-memory with `prebakeJoins` for the author nest + pglite).

## Verification
- `bun run quality` green (coverage gate green, clones 11, deps + knip clean).
- `bun run build:demo` green.

Refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)