### PR TITLE
feat(repositories): finish ADR 0020 router migration — drop IDataStore from all routers (#409)

### DIFF
--- a/src/lib/server/data-store/IDataStore.ts
+++ b/src/lib/server/data-store/IDataStore.ts
@@ -191,6 +191,7 @@ export interface DataStoreTx {
   invoiceDispatches: InvoiceDispatchDelegate;
   expectedReceivables: ExpectedReceivableDelegate;
   paymentPlans: PaymentPlanDelegate;
+  paymentPlanReminders: Delegate;
   accontoDeductions: AccontoDeductionDelegate;
   billingRuns: BillingRunDelegate;
   calendarEvents: CalendarEventDelegate;

--- a/src/lib/server/data-store/in-memory/local-store.ts
+++ b/src/lib/server/data-store/in-memory/local-store.ts
@@ -294,6 +294,7 @@ export class LocalStore implements IDataStore {
       invoiceDispatches: this.invoiceDispatches,
       expectedReceivables: this.expectedReceivables,
       paymentPlans: this.paymentPlans,
+      paymentPlanReminders: this.paymentPlanReminders,
       accontoDeductions: this.accontoDeductions,
       billingRuns: this.billingRuns,
       calendarEvents: this.calendarEvents,

--- a/src/lib/server/data-store/in-memory/local-store.ts
+++ b/src/lib/server/data-store/in-memory/local-store.ts
@@ -109,7 +109,7 @@ export class LocalStore implements IDataStore {
     this.documentFolders = this.makeDelegate("documentFolders", relations.documentFolders) as unknown as DocumentFolderDelegate;
     this.documentTemplates = this.makeDelegate("documentTemplates", relations.documentTemplates) as unknown as DocumentTemplateDelegate;
     this.documentAnalysisSuggestions = this.makeDelegate("documentAnalysisSuggestions") as unknown as DocumentAnalysisSuggestionDelegate;
-    this.matterEventSuggestions = this.makeDelegate("matterEventSuggestions") as unknown as MatterEventSuggestionDelegate;
+    this.matterEventSuggestions = this.makeDelegate("matterEventSuggestions", relations.matterEventSuggestions) as unknown as MatterEventSuggestionDelegate;
     this.invoices = this.makeDelegate("invoices", relations.invoices) as unknown as InvoiceDelegate;
     this.timeEntries = this.makeDelegate("timeEntries", relations.timeEntries) as unknown as TimeEntryDelegate;
     this.expenses = this.makeDelegate("expenses", relations.expenses) as unknown as ExpenseDelegate;

--- a/src/lib/server/data-store/in-memory/local-store.ts
+++ b/src/lib/server/data-store/in-memory/local-store.ts
@@ -106,7 +106,7 @@ export class LocalStore implements IDataStore {
     this.matterContacts = this.makeDelegate("matterContacts", relations.matterContacts) as unknown as MatterContactDelegate;
     this.contacts = this.makeDelegate("contacts", relations.contacts) as unknown as ContactDelegate;
     this.documents = this.makeDelegate("documents", relations.documents) as unknown as DocumentDelegate;
-    this.documentFolders = this.makeDelegate("documentFolders") as unknown as DocumentFolderDelegate;
+    this.documentFolders = this.makeDelegate("documentFolders", relations.documentFolders) as unknown as DocumentFolderDelegate;
     this.documentTemplates = this.makeDelegate("documentTemplates", relations.documentTemplates) as unknown as DocumentTemplateDelegate;
     this.documentAnalysisSuggestions = this.makeDelegate("documentAnalysisSuggestions") as unknown as DocumentAnalysisSuggestionDelegate;
     this.matterEventSuggestions = this.makeDelegate("matterEventSuggestions") as unknown as MatterEventSuggestionDelegate;

--- a/src/lib/server/data-store/in-memory/local-store.ts
+++ b/src/lib/server/data-store/in-memory/local-store.ts
@@ -108,7 +108,7 @@ export class LocalStore implements IDataStore {
     this.documents = this.makeDelegate("documents", relations.documents) as unknown as DocumentDelegate;
     this.documentFolders = this.makeDelegate("documentFolders", relations.documentFolders) as unknown as DocumentFolderDelegate;
     this.documentTemplates = this.makeDelegate("documentTemplates", relations.documentTemplates) as unknown as DocumentTemplateDelegate;
-    this.documentAnalysisSuggestions = this.makeDelegate("documentAnalysisSuggestions") as unknown as DocumentAnalysisSuggestionDelegate;
+    this.documentAnalysisSuggestions = this.makeDelegate("documentAnalysisSuggestions", relations.documentAnalysisSuggestions) as unknown as DocumentAnalysisSuggestionDelegate;
     this.matterEventSuggestions = this.makeDelegate("matterEventSuggestions", relations.matterEventSuggestions) as unknown as MatterEventSuggestionDelegate;
     this.invoices = this.makeDelegate("invoices", relations.invoices) as unknown as InvoiceDelegate;
     this.timeEntries = this.makeDelegate("timeEntries", relations.timeEntries) as unknown as TimeEntryDelegate;

--- a/src/lib/server/data-store/relations.ts
+++ b/src/lib/server/data-store/relations.ts
@@ -53,6 +53,7 @@ export interface DemoRelations {
   documents: Relations;
   documentFolders: Relations;
   matterEventSuggestions: Relations;
+  documentAnalysisSuggestions: Relations;
   documentTemplates: Relations;
   invoices: Relations;
   invoiceDispatches: Relations;
@@ -79,7 +80,7 @@ export interface DemoRelations {
  * - folder documents/children krävs för `_count` i dokumentlistan (core.list).
  * - matterEventSuggestions.document→matter krävs för org-scoping + include.
  */
-function documentRelations(r: Rel): Pick<DemoRelations, "documents" | "documentFolders" | "matterEventSuggestions"> {
+function documentRelations(r: Rel): Pick<DemoRelations, "documents" | "documentFolders" | "matterEventSuggestions" | "documentAnalysisSuggestions"> {
   return {
     documents: {
       matter: r("matters", "id", "matterId", "one"),
@@ -92,6 +93,11 @@ function documentRelations(r: Rel): Pick<DemoRelations, "documents" | "documentF
       children: r("documentFolders", "parentId", "id"),
     },
     matterEventSuggestions: {
+      document: r("documents", "id", "documentId", "one", {
+        matter: r("matters", "id", "matterId", "one"),
+      }),
+    },
+    documentAnalysisSuggestions: {
       document: r("documents", "id", "documentId", "one", {
         matter: r("matters", "id", "matterId", "one"),
       }),

--- a/src/lib/server/data-store/relations.ts
+++ b/src/lib/server/data-store/relations.ts
@@ -130,7 +130,13 @@ export function buildRelations(getSource: GetSource): DemoRelations {
     },
     timeEntries: {
       user: r("users", "id", "userId", "one"),
-      matter: r("matters", "id", "matterId", "one"),
+      // Nested matter.contacts.contact krävs för tidsrapportens KLIENT-kontakt
+      // (listForReport), annars blir matter.contacts undefined in-memory.
+      matter: r("matters", "id", "matterId", "one", {
+        contacts: r("matterContacts", "matterId", "id", "many", {
+          contact: r("contacts", "id", "contactId", "one"),
+        }),
+      }),
       invoice: r("invoices", "id", "invoiceId", "one"),
     },
     expenses: {

--- a/src/lib/server/data-store/relations.ts
+++ b/src/lib/server/data-store/relations.ts
@@ -52,6 +52,7 @@ export interface DemoRelations {
   contacts: Relations;
   documents: Relations;
   documentFolders: Relations;
+  matterEventSuggestions: Relations;
   documentTemplates: Relations;
   invoices: Relations;
   invoiceDispatches: Relations;
@@ -69,6 +70,35 @@ export interface DemoRelations {
  * Bygg relations-mappen per entitet. Endast entiteter MED relationer listas;
  * övriga (users, offices, payments, writeOffs, …) skapas utan relations.
  */
+/**
+ * Dokument-relaterade relations (documents/folders/event-suggestions). Utbruten
+ * ur `buildRelations` för att hålla den under max-lines-per-function.
+ *
+ * - documents.matter `one` är AVGÖRANDE — annars matchas nested where
+ *   `matter: { organizationId }` mot en array → assertDocAccess NOT_FOUND.
+ * - folder documents/children krävs för `_count` i dokumentlistan (core.list).
+ * - matterEventSuggestions.document→matter krävs för org-scoping + include.
+ */
+function documentRelations(r: Rel): Pick<DemoRelations, "documents" | "documentFolders" | "matterEventSuggestions"> {
+  return {
+    documents: {
+      matter: r("matters", "id", "matterId", "one"),
+      uploadedBy: r("users", "id", "uploadedById", "one"),
+    },
+    documentFolders: {
+      matter: r("matters", "id", "matterId", "one"),
+      parent: r("documentFolders", "id", "parentId", "one"),
+      documents: r("documents", "folderId", "id"),
+      children: r("documentFolders", "parentId", "id"),
+    },
+    matterEventSuggestions: {
+      document: r("documents", "id", "documentId", "one", {
+        matter: r("matters", "id", "matterId", "one"),
+      }),
+    },
+  };
+}
+
 export function buildRelations(getSource: GetSource): DemoRelations {
   const r = makeRel(getSource);
   return {
@@ -96,19 +126,7 @@ export function buildRelations(getSource: GetSource): DemoRelations {
       children: r("contacts", "parentId", "id"),
       parent: r("contacts", "id", "parentId", "one"),
     },
-    // kind:"one" är AVGÖRANDE — annars matchas nested where `matter:
-    // { organizationId }` mot en array → assertDocAccess NOT_FOUND (tidigare bugg).
-    documents: {
-      matter: r("matters", "id", "matterId", "one"),
-      uploadedBy: r("users", "id", "uploadedById", "one"),
-    },
-    // documents/children krävs för `_count` i dokumentlistan (core.list).
-    documentFolders: {
-      matter: r("matters", "id", "matterId", "one"),
-      parent: r("documentFolders", "id", "parentId", "one"),
-      documents: r("documents", "folderId", "id"),
-      children: r("documentFolders", "parentId", "id"),
-    },
+    ...documentRelations(r),
     documentTemplates: { createdBy: r("users", "id", "createdById", "one") },
     invoices: {
       matter: r("matters", "id", "matterId", "one"),

--- a/src/lib/server/data-store/relations.ts
+++ b/src/lib/server/data-store/relations.ts
@@ -179,9 +179,12 @@ export function buildRelations(getSource: GetSource): DemoRelations {
     paymentPlans: {
       invoice: r("invoices", "id", "invoiceId", "one", {
         matter: r("matters", "id", "matterId", "one", {
-          contacts: r("matterContacts", "matterId", "id"),
+          contacts: r("matterContacts", "matterId", "id", "many", {
+            contact: r("contacts", "id", "contactId", "one"),
+          }),
         }),
         payments: r("payments", "invoiceId", "id"),
+        writeOffs: r("writeOffs", "invoiceId", "id"),
       }),
       reminders: r("paymentPlanReminders", "planId", "id"),
     },

--- a/src/lib/server/data-store/relations.ts
+++ b/src/lib/server/data-store/relations.ts
@@ -51,6 +51,7 @@ export interface DemoRelations {
   matterContacts: Relations;
   contacts: Relations;
   documents: Relations;
+  documentFolders: Relations;
   documentTemplates: Relations;
   invoices: Relations;
   invoiceDispatches: Relations;
@@ -97,7 +98,17 @@ export function buildRelations(getSource: GetSource): DemoRelations {
     },
     // kind:"one" är AVGÖRANDE — annars matchas nested where `matter:
     // { organizationId }` mot en array → assertDocAccess NOT_FOUND (tidigare bugg).
-    documents: { matter: r("matters", "id", "matterId", "one") },
+    documents: {
+      matter: r("matters", "id", "matterId", "one"),
+      uploadedBy: r("users", "id", "uploadedById", "one"),
+    },
+    // documents/children krävs för `_count` i dokumentlistan (core.list).
+    documentFolders: {
+      matter: r("matters", "id", "matterId", "one"),
+      parent: r("documentFolders", "id", "parentId", "one"),
+      documents: r("documents", "folderId", "id"),
+      children: r("documentFolders", "parentId", "id"),
+    },
     documentTemplates: { createdBy: r("users", "id", "createdById", "one") },
     invoices: {
       matter: r("matters", "id", "matterId", "one"),

--- a/src/lib/server/data-store/relations.ts
+++ b/src/lib/server/data-store/relations.ts
@@ -169,7 +169,13 @@ export function buildRelations(getSource: GetSource): DemoRelations {
       invoice: r("invoices", "id", "invoiceId", "one"),
     },
     expenses: {
-      matter: r("matters", "id", "matterId", "one"),
+      // Nested matter.contacts.contact krävs för advokatrapportens KLIENT-kontakt
+      // (listForLawyerInPeriod), speglar timeEntries.matter.
+      matter: r("matters", "id", "matterId", "one", {
+        contacts: r("matterContacts", "matterId", "id", "many", {
+          contact: r("contacts", "id", "contactId", "one"),
+        }),
+      }),
       user: r("users", "id", "userId", "one"),
       invoice: r("invoices", "id", "invoiceId", "one"),
     },

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -436,3 +436,14 @@ export const documentsRelations = relations(documents, ({ one }) => ({
   invoice: one(invoices, { fields: [documents.invoiceId], references: [invoices.id] }),
   matter: one(matters, { fields: [documents.matterId], references: [matters.id] }),
 }));
+
+// matter↔kontakt via junction (matterContacts). Driver `with`-nesting för
+// repository-läsningar som behöver KLIENT-kontakten (paymentPlan/matter m.fl.).
+export const mattersRelations = relations(matters, ({ many }) => ({
+  contacts: many(matterContacts),
+}));
+
+export const matterContactsRelations = relations(matterContacts, ({ one }) => ({
+  matter: one(matters, { fields: [matterContacts.matterId], references: [matters.id] }),
+  contact: one(contacts, { fields: [matterContacts.contactId], references: [contacts.id] }),
+}));

--- a/src/lib/server/repositories/billing-run-repository.ts
+++ b/src/lib/server/repositories/billing-run-repository.ts
@@ -1,0 +1,31 @@
+/**
+ * `BillingRunRepository` (ADR 0020, #409 fan-out) — faktureringshändelser.
+ * Bas-CRUD ärvs; läsningarna org-scopas via ärendet (billing-runs saknar egen
+ * organizationId). list/byId tar med faktura (+ ärende för detaljvyn); avdrags-
+ * /aconto-läsningarna driver fakturaförslaget och FINAL-avdragen.
+ */
+
+import type { BillingRun } from "@/lib/shared/schemas/billing";
+import type { Repository } from "./types";
+
+/** Billing-run + faktura (listvyn). */
+export interface BillingRunListRow extends BillingRun {
+  invoice: { id: string; invoiceNumber: string | null; status: string } | null;
+}
+
+/** Billing-run + faktura + ärende (detaljvyn). */
+export interface BillingRunDetailRow extends BillingRun {
+  invoice: { id: string; invoiceNumber: string | null; status: string; amount: number } | null;
+  matter: { id: string; matterNumber: string; title: string; paymentMethod: string | null } | null;
+}
+
+export interface BillingRunRepository extends Repository<BillingRun> {
+  /** Org:ens billing-runs (createdAt desc), valfritt ärende-filtrerade, med faktura. */
+  listForOrg(organizationId: string, matterId?: string): Promise<BillingRunListRow[]>;
+  /** En billing-run by id, org-scopad, med faktura + ärende. Null om saknas. */
+  getByIdInOrg(id: string, organizationId: string): Promise<BillingRunDetailRow | null>;
+  /** Utställda ACCONTO-runs i ett ärende (för Σ tidigare aconto, #397). */
+  listAccontoSent(matterId: string): Promise<BillingRun[]>;
+  /** ACCONTO-runs i ett ärende med givna id:n (FINAL-avdrag, #60-validering). */
+  listAccontoByIds(matterId: string, ids: string[]): Promise<BillingRun[]>;
+}

--- a/src/lib/server/repositories/conflict-check-repository.ts
+++ b/src/lib/server/repositories/conflict-check-repository.ts
@@ -1,0 +1,18 @@
+/**
+ * `ConflictCheckRepository` (ADR 0020, #409 fan-out) — jävskontroll-loggen.
+ * Bas-CRUD ärvs (`create` loggar en sökning). `listHistory` är medvetet INTE
+ * org-scopad — tabellen saknar organizationId (speglar dagens beteende).
+ */
+
+import type { ConflictCheck } from "@/lib/shared/schemas/misc";
+import type { Repository } from "./types";
+
+/** Logg-rad + vem som körde kontrollen. */
+export interface ConflictCheckRow extends ConflictCheck {
+  checkedBy: { name: string } | null;
+}
+
+export interface ConflictCheckRepository extends Repository<ConflictCheck> {
+  /** Paginerad historik (createdAt desc) med utförarens namn + totalantal. */
+  listHistory(page: number, pageSize: number): Promise<{ checks: ConflictCheckRow[]; total: number }>;
+}

--- a/src/lib/server/repositories/contact-repository.ts
+++ b/src/lib/server/repositories/contact-repository.ts
@@ -49,4 +49,8 @@ export interface ContactRepository extends Repository<Contact> {
   listForOrg(organizationId: string, opts: ContactListOptions): Promise<ContactListResult>;
   /** Full kontakt-detalj (barn/förälder/ärende-kopplingar), org-scopad. Null om saknas/raderad. */
   getByIdFull(id: string, organizationId: string): Promise<ContactFull | null>;
+  /** Kontakt med givet personnummer i org:en (dedup). Null om ingen. */
+  findByPersonalNumber(organizationId: string, personalNumber: string): Promise<Contact | null>;
+  /** Kontakt med givet org-nummer i org:en (dedup). Null om ingen. */
+  findByOrgNumber(organizationId: string, orgNumber: string): Promise<Contact | null>;
 }

--- a/src/lib/server/repositories/document-folder-repository.ts
+++ b/src/lib/server/repositories/document-folder-repository.ts
@@ -1,0 +1,21 @@
+/**
+ * `DocumentFolderRepository` (ADR 0020, #409 fan-out) — dokumentmappar (träd).
+ * Bas-CRUD ärvs; listvyn tar med antal dokument + undermappar (`_count`).
+ */
+
+import type { DocumentFolder } from "@/lib/shared/schemas/document";
+import type { Repository } from "./types";
+
+/** Mapp + antal direkta dokument/undermappar (dokumentlistan). */
+export interface DocumentFolderWithCounts extends DocumentFolder {
+  _count: { documents: number; children: number };
+}
+
+export interface DocumentFolderRepository extends Repository<DocumentFolder> {
+  /** Direkta undermappar i ett ärende/parent (namn asc) med `_count`. */
+  listInParent(matterId: string, parentId: string | null): Promise<DocumentFolderWithCounts[]>;
+  /** Alla mappar i ett ärende (namn asc) — för trädvyn. */
+  listByMatter(matterId: string): Promise<DocumentFolder[]>;
+  /** Flytta alla direkta undermappar till en annan parent (vid radering). */
+  reassignParent(fromParentId: string, toParentId: string | null): Promise<void>;
+}

--- a/src/lib/server/repositories/document-repository.ts
+++ b/src/lib/server/repositories/document-repository.ts
@@ -1,0 +1,34 @@
+/**
+ * `DocumentRepository` (ADR 0020, #409 fan-out) — dokument. Org-scopas via
+ * ärendet (documents saknar egen organizationId-kolumn). Bas-CRUD ärvs;
+ * list-metoderna tar med uppladdarens namn (`uploadedBy`).
+ */
+
+import type { Document } from "@/lib/shared/schemas/document";
+import type { Repository } from "./types";
+
+/** Dokument + uppladdare (listvyn). */
+export interface DocumentListRow extends Document {
+  uploadedBy: { name: string } | null;
+}
+
+/** Smal access-projektion (assertDocAccess). */
+export interface DocumentAccessRow {
+  id: string;
+  matterId: string;
+}
+
+export interface DocumentRepository extends Repository<Document> {
+  /** Paginerad lista i ett ärende/folder (createdAt desc) + total. */
+  listInFolder(
+    matterId: string, folderId: string | null, page: number, pageSize: number,
+  ): Promise<{ documents: DocumentListRow[]; total: number }>;
+  /** Alla dokument i ett ärende (createdAt desc) — för trädvyn. */
+  listByMatter(matterId: string): Promise<DocumentListRow[]>;
+  /** Distinkta documentType-värden i org:en + antal per typ (namn-sorterat, sv). */
+  listDocumentTypesForOrg(organizationId: string): Promise<Array<{ type: string; count: number }>>;
+  /** Dokument by id, org-scopat via ärendet. Null om saknas/annan org/raderat. */
+  getByIdInOrg(id: string, organizationId: string): Promise<DocumentAccessRow | null>;
+  /** Flytta alla dokument i en folder till en annan (vid folder-radering). */
+  reassignFolder(fromFolderId: string, toFolderId: string | null): Promise<void>;
+}

--- a/src/lib/server/repositories/document-suggestion-repository.ts
+++ b/src/lib/server/repositories/document-suggestion-repository.ts
@@ -1,0 +1,32 @@
+/**
+ * `DocumentSuggestionRepository` (ADR 0020, #409 fan-out) — AI-genererade
+ * kontaktförslag (DocumentAnalysisSuggestion). Org-scopas via dokument→ärende.
+ * Bas-CRUD ärvs (`update` sätter status/acceptedContactId); list/by-ids driver
+ * accept/reject (enskilt + grupp).
+ */
+
+import type { DocumentAnalysisSuggestion } from "@/lib/shared/schemas/document";
+import type { Repository } from "./types";
+
+/** Förslag + ursprungsärendet (accept-flödet behöver matterId). */
+export interface SuggestionWithMatter extends DocumentAnalysisSuggestion {
+  document: { matterId: string };
+}
+
+/** Förslag + dokument-metadata (listvyn/gruppning). */
+export interface SuggestionListRow extends DocumentAnalysisSuggestion {
+  document: { id: string; fileName: string; title: string | null };
+}
+
+export interface DocumentSuggestionRepository extends Repository<DocumentAnalysisSuggestion> {
+  /** Förslag by id, org-scopat via dokument→ärende (med matterId). Null om saknas/annan org. */
+  getByIdInOrg(id: string, organizationId: string): Promise<SuggestionWithMatter | null>;
+  /** Pending-förslag för ett ärende (dokument-include), sorterade createdAt. */
+  listPendingForMatter(matterId: string, organizationId: string, order: "asc" | "desc"): Promise<SuggestionListRow[]>;
+  /** Pending-förslag med givna id:n, org-scopat (grupp-accept). */
+  listPendingByIds(ids: string[], organizationId: string): Promise<SuggestionWithMatter[]>;
+  /** Förslag (oavsett status) med givna id:n, org-scopat — id:n (grupp-reject-validering). */
+  listByIdsInOrg(ids: string[], organizationId: string): Promise<Array<{ id: string }>>;
+  /** Sätt status (+ ev. acceptedContactId) på flera förslag (grupp). No-op vid tomma ids. */
+  updateManyByIds(ids: string[], patch: Partial<DocumentAnalysisSuggestion>): Promise<void>;
+}

--- a/src/lib/server/repositories/document-template-repository.ts
+++ b/src/lib/server/repositories/document-template-repository.ts
@@ -1,0 +1,30 @@
+/**
+ * `DocumentTemplateRepository` (ADR 0020, #409 fan-out) — dokumentmallar.
+ * Org-scopas direkt. Bas-CRUD ärvs; list/detalj tar med skaparens namn.
+ */
+
+import type { DocumentTemplate } from "@/lib/shared/schemas/misc";
+import type { Repository } from "./types";
+
+/** Mall + skapare (detaljvyn). */
+export interface DocumentTemplateRow extends DocumentTemplate {
+  createdBy: { name: string } | null;
+}
+
+/** Listrad (smal projektion, utan content). */
+export interface DocumentTemplateListRow {
+  id: string;
+  name: string;
+  description: string | null;
+  category: string | null;
+  createdAt: Date | string;
+  updatedAt: Date | string | null;
+  createdBy: { name: string } | null;
+}
+
+export interface DocumentTemplateRepository extends Repository<DocumentTemplate> {
+  /** Org:ens mallar (kategori asc, namn asc), smal projektion med skapar-namn. */
+  listForOrg(organizationId: string): Promise<DocumentTemplateListRow[]>;
+  /** Mall by id, org-scopad, med skapare. Null om saknas/annan org/raderad. */
+  getByIdInOrg(id: string, organizationId: string): Promise<DocumentTemplateRow | null>;
+}

--- a/src/lib/server/repositories/drizzle-billing-run-repository.ts
+++ b/src/lib/server/repositories/drizzle-billing-run-repository.ts
@@ -1,0 +1,88 @@
+/**
+ * Drizzle `BillingRunRepository` (ADR 0020) — server-impl. Org-scopar via join
+ * mot ärendet; left-joinar fakturan (+ ärende-detaljer i byId).
+ */
+
+import { and, desc, eq, inArray, isNull } from "drizzle-orm";
+import type { BillingRun } from "@/lib/shared/schemas/billing";
+import { billingRuns, invoices, matters } from "../db/schema";
+import type { AppDb } from "../db/types";
+import type {
+  BillingRunDetailRow, BillingRunListRow, BillingRunRepository,
+} from "./billing-run-repository";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+
+export class DrizzleBillingRunRepository
+  extends DrizzleRepository<BillingRun>
+  implements BillingRunRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, billingRuns as unknown as VersionedTable, now);
+  }
+
+  async listForOrg(organizationId: string, matterId?: string): Promise<BillingRunListRow[]> {
+    const rows = await this.db
+      .select({
+        run: billingRuns,
+        invId: invoices.id, invNum: invoices.invoiceNumber, invStatus: invoices.status,
+      })
+      .from(billingRuns)
+      .innerJoin(matters, eq(billingRuns.matterId, matters.id))
+      .leftJoin(invoices, eq(billingRuns.invoiceId, invoices.id))
+      .where(and(
+        eq(matters.organizationId, organizationId),
+        matterId ? eq(billingRuns.matterId, matterId) : undefined,
+        isNull(billingRuns.deletedAt),
+      ))
+      .orderBy(desc(billingRuns.createdAt));
+    return rows.map((r) => ({
+      ...(r.run as object),
+      invoice: r.invId ? { id: r.invId, invoiceNumber: r.invNum, status: r.invStatus as string } : null,
+    })) as unknown as BillingRunListRow[];
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<BillingRunDetailRow | null> {
+    const rows = await this.db
+      .select({
+        run: billingRuns,
+        invId: invoices.id, invNum: invoices.invoiceNumber, invStatus: invoices.status, invAmount: invoices.amount,
+        mId: matters.id, mNum: matters.matterNumber, mTitle: matters.title, mPay: matters.paymentMethod,
+      })
+      .from(billingRuns)
+      .innerJoin(matters, eq(billingRuns.matterId, matters.id))
+      .leftJoin(invoices, eq(billingRuns.invoiceId, invoices.id))
+      .where(and(eq(billingRuns.id, id), eq(matters.organizationId, organizationId), isNull(billingRuns.deletedAt)))
+      .limit(1);
+    const r = rows[0];
+    if (!r) return null;
+    return {
+      ...(r.run as object),
+      invoice: r.invId
+        ? { id: r.invId, invoiceNumber: r.invNum, status: r.invStatus as string, amount: Number(r.invAmount ?? 0) }
+        : null,
+      matter: r.mId
+        ? { id: r.mId, matterNumber: r.mNum as string, title: r.mTitle as string, paymentMethod: (r.mPay as string | null) ?? null }
+        : null,
+    } as unknown as BillingRunDetailRow;
+  }
+
+  async listAccontoSent(matterId: string): Promise<BillingRun[]> {
+    const rows = await this.db
+      .select().from(billingRuns)
+      .where(and(
+        eq(billingRuns.matterId, matterId), eq(billingRuns.type, "ACCONTO"),
+        eq(billingRuns.status, "SENT"), isNull(billingRuns.deletedAt),
+      ));
+    return rows as unknown as BillingRun[];
+  }
+
+  async listAccontoByIds(matterId: string, ids: string[]): Promise<BillingRun[]> {
+    if (!ids.length) return [];
+    const rows = await this.db
+      .select().from(billingRuns)
+      .where(and(
+        inArray(billingRuns.id, ids), eq(billingRuns.matterId, matterId),
+        eq(billingRuns.type, "ACCONTO"), isNull(billingRuns.deletedAt),
+      ));
+    return rows as unknown as BillingRun[];
+  }
+}

--- a/src/lib/server/repositories/drizzle-conflict-check-repository.ts
+++ b/src/lib/server/repositories/drizzle-conflict-check-repository.ts
@@ -1,0 +1,35 @@
+/**
+ * Drizzle `ConflictCheckRepository` (ADR 0020) — server-impl. Left-joinar
+ * utföraren (users) för namn. Historiken är global (ingen org-kolumn).
+ */
+
+import { desc, eq, sql } from "drizzle-orm";
+import type { ConflictCheck } from "@/lib/shared/schemas/misc";
+import { conflictChecks, users } from "../db/schema";
+import type { AppDb } from "../db/types";
+import type { ConflictCheckRepository, ConflictCheckRow } from "./conflict-check-repository";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+
+export class DrizzleConflictCheckRepository
+  extends DrizzleRepository<ConflictCheck>
+  implements ConflictCheckRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, conflictChecks as unknown as VersionedTable, now);
+  }
+
+  async listHistory(page: number, pageSize: number): Promise<{ checks: ConflictCheckRow[]; total: number }> {
+    const rows = await this.db
+      .select({ chk: conflictChecks, cbName: users.name }).from(conflictChecks)
+      .leftJoin(users, eq(conflictChecks.checkedById, users.id))
+      .orderBy(desc(conflictChecks.createdAt))
+      .limit(pageSize).offset((page - 1) * pageSize);
+    const [agg] = await this.db.select({ total: sql<number>`count(*)` }).from(conflictChecks);
+    return {
+      checks: rows.map((r) => ({
+        ...(r.chk as object),
+        checkedBy: r.cbName ? { name: r.cbName as string } : null,
+      })) as unknown as ConflictCheckRow[],
+      total: Number(agg?.total ?? 0),
+    };
+  }
+}

--- a/src/lib/server/repositories/drizzle-contact-repository.ts
+++ b/src/lib/server/repositories/drizzle-contact-repository.ts
@@ -100,4 +100,18 @@ export class DrizzleContactRepository extends DrizzleRepository<Contact> impleme
       })),
     } as unknown as ContactFull;
   }
+
+  async findByPersonalNumber(organizationId: string, personalNumber: string): Promise<Contact | null> {
+    const rows = await this.db.select().from(contacts)
+      .where(and(eq(contacts.organizationId, organizationId), eq(contacts.personalNumber, personalNumber), isNull(contacts.deletedAt)))
+      .limit(1);
+    return (rows[0] as unknown as Contact | undefined) ?? null;
+  }
+
+  async findByOrgNumber(organizationId: string, orgNumber: string): Promise<Contact | null> {
+    const rows = await this.db.select().from(contacts)
+      .where(and(eq(contacts.organizationId, organizationId), eq(contacts.orgNumber, orgNumber), isNull(contacts.deletedAt)))
+      .limit(1);
+    return (rows[0] as unknown as Contact | undefined) ?? null;
+  }
 }

--- a/src/lib/server/repositories/drizzle-document-folder-repository.ts
+++ b/src/lib/server/repositories/drizzle-document-folder-repository.ts
@@ -1,0 +1,70 @@
+/**
+ * Drizzle `DocumentFolderRepository` (ADR 0020) — server-impl. `_count` via
+ * korrelerade subqueries (documents i mappen + direkta undermappar).
+ */
+
+import { and, asc, eq, inArray, isNull, sql } from "drizzle-orm";
+import type { DocumentFolder } from "@/lib/shared/schemas/document";
+import { documentFolders, documents } from "../db/schema";
+import type { AppDb } from "../db/types";
+import type {
+  DocumentFolderRepository, DocumentFolderWithCounts,
+} from "./document-folder-repository";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+
+/** documentFolders.parentId = X, eller IS NULL för rot. */
+function parentEq(parentId: string | null) {
+  return parentId === null ? isNull(documentFolders.parentId) : eq(documentFolders.parentId, parentId);
+}
+
+export class DrizzleDocumentFolderRepository
+  extends DrizzleRepository<DocumentFolder>
+  implements DocumentFolderRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, documentFolders as unknown as VersionedTable, now);
+  }
+
+  async listInParent(matterId: string, parentId: string | null): Promise<DocumentFolderWithCounts[]> {
+    const rows = await this.db
+      .select().from(documentFolders)
+      .where(and(eq(documentFolders.matterId, matterId), parentEq(parentId), isNull(documentFolders.deletedAt)))
+      .orderBy(asc(documentFolders.name));
+    const ids = rows.map((r) => (r as { id: string }).id);
+    // Grupperade count-queries (robustare än korrelerade subqueries, jfr #).
+    const counts = await this.countsFor(ids);
+    return rows.map((r) => {
+      const id = (r as { id: string }).id;
+      return { ...(r as object), _count: counts.get(id) ?? { documents: 0, children: 0 } };
+    }) as unknown as DocumentFolderWithCounts[];
+  }
+
+  private async countsFor(folderIds: string[]): Promise<Map<string, { documents: number; children: number }>> {
+    const out = new Map<string, { documents: number; children: number }>();
+    if (folderIds.length === 0) return out;
+    const docRows = await this.db
+      .select({ id: documents.folderId, n: sql<number>`count(*)` }).from(documents)
+      .where(and(inArray(documents.folderId, folderIds), isNull(documents.deletedAt)))
+      .groupBy(documents.folderId);
+    const childRows = await this.db
+      .select({ id: documentFolders.parentId, n: sql<number>`count(*)` }).from(documentFolders)
+      .where(and(inArray(documentFolders.parentId, folderIds), isNull(documentFolders.deletedAt)))
+      .groupBy(documentFolders.parentId);
+    for (const id of folderIds) out.set(id, { documents: 0, children: 0 });
+    for (const r of docRows) if (r.id) out.get(r.id as string)!.documents = Number(r.n);
+    for (const r of childRows) if (r.id) out.get(r.id as string)!.children = Number(r.n);
+    return out;
+  }
+
+  async listByMatter(matterId: string): Promise<DocumentFolder[]> {
+    const rows = await this.db
+      .select().from(documentFolders)
+      .where(and(eq(documentFolders.matterId, matterId), isNull(documentFolders.deletedAt)))
+      .orderBy(asc(documentFolders.name));
+    return rows as unknown as DocumentFolder[];
+  }
+
+  async reassignParent(fromParentId: string, toParentId: string | null): Promise<void> {
+    await this.db.update(documentFolders)
+      .set({ parentId: toParentId } as never).where(eq(documentFolders.parentId, fromParentId));
+  }
+}

--- a/src/lib/server/repositories/drizzle-document-repository.ts
+++ b/src/lib/server/repositories/drizzle-document-repository.ts
@@ -1,0 +1,83 @@
+/**
+ * Drizzle `DocumentRepository` (ADR 0020) — server-impl. Org-scopar via join
+ * mot matters; left-joinar uppladdaren (users) för namn.
+ */
+
+import { and, desc, eq, isNull, sql } from "drizzle-orm";
+import type { Document } from "@/lib/shared/schemas/document";
+import { documents, matters, users } from "../db/schema";
+import type { AppDb } from "../db/types";
+import type {
+  DocumentAccessRow, DocumentListRow, DocumentRepository,
+} from "./document-repository";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+
+/** documents.folderId = X, eller IS NULL för rot. */
+function folderEq(folderId: string | null) {
+  return folderId === null ? isNull(documents.folderId) : eq(documents.folderId, folderId);
+}
+
+function toListRow(r: { doc: unknown; ubName: unknown }): DocumentListRow {
+  return {
+    ...(r.doc as object),
+    uploadedBy: r.ubName ? { name: r.ubName as string } : null,
+  } as unknown as DocumentListRow;
+}
+
+export class DrizzleDocumentRepository
+  extends DrizzleRepository<Document>
+  implements DocumentRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, documents as unknown as VersionedTable, now);
+  }
+
+  async listInFolder(
+    matterId: string, folderId: string | null, page: number, pageSize: number,
+  ): Promise<{ documents: DocumentListRow[]; total: number }> {
+    const where = and(eq(documents.matterId, matterId), folderEq(folderId), isNull(documents.deletedAt));
+    const rows = await this.db
+      .select({ doc: documents, ubName: users.name }).from(documents)
+      .leftJoin(users, eq(documents.uploadedById, users.id))
+      .where(where).orderBy(desc(documents.createdAt))
+      .limit(pageSize).offset((page - 1) * pageSize);
+    const [agg] = await this.db
+      .select({ total: sql<number>`count(*)` }).from(documents).where(where);
+    return { documents: rows.map(toListRow), total: Number(agg?.total ?? 0) };
+  }
+
+  async listByMatter(matterId: string): Promise<DocumentListRow[]> {
+    const rows = await this.db
+      .select({ doc: documents, ubName: users.name }).from(documents)
+      .leftJoin(users, eq(documents.uploadedById, users.id))
+      .where(and(eq(documents.matterId, matterId), isNull(documents.deletedAt)))
+      .orderBy(desc(documents.createdAt));
+    return rows.map(toListRow);
+  }
+
+  async listDocumentTypesForOrg(organizationId: string): Promise<Array<{ type: string; count: number }>> {
+    const rows = await this.db
+      .select({ type: documents.documentType, count: sql<number>`count(*)` })
+      .from(documents).innerJoin(matters, eq(documents.matterId, matters.id))
+      .where(and(eq(matters.organizationId, organizationId), isNull(documents.deletedAt)))
+      .groupBy(documents.documentType);
+    return rows
+      .filter((r): r is { type: string; count: number } => Boolean(r.type))
+      .map((r) => ({ type: r.type, count: Number(r.count) }))
+      .sort((a, b) => a.type.localeCompare(b.type, "sv"));
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<DocumentAccessRow | null> {
+    const rows = await this.db
+      .select({ id: documents.id, matterId: documents.matterId }).from(documents)
+      .innerJoin(matters, eq(documents.matterId, matters.id))
+      .where(and(eq(documents.id, id), eq(matters.organizationId, organizationId), isNull(documents.deletedAt)))
+      .limit(1);
+    const row = rows[0];
+    return row ? { id: row.id as string, matterId: row.matterId as string } : null;
+  }
+
+  async reassignFolder(fromFolderId: string, toFolderId: string | null): Promise<void> {
+    await this.db.update(documents)
+      .set({ folderId: toFolderId } as never).where(eq(documents.folderId, fromFolderId));
+  }
+}

--- a/src/lib/server/repositories/drizzle-document-suggestion-repository.ts
+++ b/src/lib/server/repositories/drizzle-document-suggestion-repository.ts
@@ -1,0 +1,75 @@
+/**
+ * Drizzle `DocumentSuggestionRepository` (ADR 0020) — server-impl. Org-scopar
+ * via join förslag→dokument→ärende.
+ */
+
+import { and, asc, desc, eq, inArray, isNull } from "drizzle-orm";
+import type { DocumentAnalysisSuggestion } from "@/lib/shared/schemas/document";
+import { documentAnalysisSuggestions, documents, matters } from "../db/schema";
+import type { AppDb } from "../db/types";
+import type {
+  DocumentSuggestionRepository, SuggestionListRow, SuggestionWithMatter,
+} from "./document-suggestion-repository";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+
+const S = documentAnalysisSuggestions;
+
+export class DrizzleDocumentSuggestionRepository
+  extends DrizzleRepository<DocumentAnalysisSuggestion>
+  implements DocumentSuggestionRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, S as unknown as VersionedTable, now);
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<SuggestionWithMatter | null> {
+    const rows = await this.db
+      .select({ s: S, matterId: documents.matterId }).from(S)
+      .innerJoin(documents, eq(S.documentId, documents.id))
+      .innerJoin(matters, eq(documents.matterId, matters.id))
+      .where(and(eq(S.id, id), eq(matters.organizationId, organizationId), isNull(S.deletedAt)))
+      .limit(1);
+    const r = rows[0];
+    return r ? ({ ...(r.s as object), document: { matterId: r.matterId as string } } as unknown as SuggestionWithMatter) : null;
+  }
+
+  async listPendingForMatter(matterId: string, organizationId: string, order: "asc" | "desc"): Promise<SuggestionListRow[]> {
+    const rows = await this.db
+      .select({ s: S, dId: documents.id, dFile: documents.fileName, dTitle: documents.title }).from(S)
+      .innerJoin(documents, eq(S.documentId, documents.id))
+      .innerJoin(matters, eq(documents.matterId, matters.id))
+      .where(and(
+        eq(S.status, "PENDING"), eq(documents.matterId, matterId),
+        eq(matters.organizationId, organizationId), isNull(S.deletedAt),
+      ))
+      .orderBy(order === "asc" ? asc(S.createdAt) : desc(S.createdAt));
+    return rows.map((r) => ({
+      ...(r.s as object),
+      document: { id: r.dId as string, fileName: r.dFile as string, title: (r.dTitle as string | null) ?? null },
+    })) as unknown as SuggestionListRow[];
+  }
+
+  async listPendingByIds(ids: string[], organizationId: string): Promise<SuggestionWithMatter[]> {
+    if (!ids.length) return [];
+    const rows = await this.db
+      .select({ s: S, matterId: documents.matterId }).from(S)
+      .innerJoin(documents, eq(S.documentId, documents.id))
+      .innerJoin(matters, eq(documents.matterId, matters.id))
+      .where(and(inArray(S.id, ids), eq(S.status, "PENDING"), eq(matters.organizationId, organizationId), isNull(S.deletedAt)));
+    return rows.map((r) => ({ ...(r.s as object), document: { matterId: r.matterId as string } })) as unknown as SuggestionWithMatter[];
+  }
+
+  async listByIdsInOrg(ids: string[], organizationId: string): Promise<Array<{ id: string }>> {
+    if (!ids.length) return [];
+    const rows = await this.db
+      .select({ id: S.id }).from(S)
+      .innerJoin(documents, eq(S.documentId, documents.id))
+      .innerJoin(matters, eq(documents.matterId, matters.id))
+      .where(and(inArray(S.id, ids), eq(matters.organizationId, organizationId), isNull(S.deletedAt)));
+    return rows.map((r) => ({ id: r.id as string }));
+  }
+
+  async updateManyByIds(ids: string[], patch: Partial<DocumentAnalysisSuggestion>): Promise<void> {
+    if (!ids.length) return;
+    await this.db.update(S).set(patch as never).where(inArray(S.id, ids));
+  }
+}

--- a/src/lib/server/repositories/drizzle-document-template-repository.ts
+++ b/src/lib/server/repositories/drizzle-document-template-repository.ts
@@ -1,0 +1,51 @@
+/**
+ * Drizzle `DocumentTemplateRepository` (ADR 0020) — server-impl. Left-joinar
+ * skaparen (users) för namn.
+ */
+
+import { and, asc, eq, isNull } from "drizzle-orm";
+import type { DocumentTemplate } from "@/lib/shared/schemas/misc";
+import { documentTemplates, users } from "../db/schema";
+import type { AppDb } from "../db/types";
+import type {
+  DocumentTemplateListRow, DocumentTemplateRepository, DocumentTemplateRow,
+} from "./document-template-repository";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+
+export class DrizzleDocumentTemplateRepository
+  extends DrizzleRepository<DocumentTemplate>
+  implements DocumentTemplateRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, documentTemplates as unknown as VersionedTable, now);
+  }
+
+  async listForOrg(organizationId: string): Promise<DocumentTemplateListRow[]> {
+    const rows = await this.db
+      .select({
+        id: documentTemplates.id, name: documentTemplates.name,
+        description: documentTemplates.description, category: documentTemplates.category,
+        createdAt: documentTemplates.createdAt, updatedAt: documentTemplates.updatedAt,
+        cbName: users.name,
+      })
+      .from(documentTemplates)
+      .leftJoin(users, eq(documentTemplates.createdById, users.id))
+      .where(and(eq(documentTemplates.organizationId, organizationId), isNull(documentTemplates.deletedAt)))
+      .orderBy(asc(documentTemplates.category), asc(documentTemplates.name));
+    return rows.map((r) => ({
+      id: r.id as string, name: r.name as string,
+      description: (r.description as string | null) ?? null, category: (r.category as string | null) ?? null,
+      createdAt: r.createdAt as Date, updatedAt: (r.updatedAt as Date | null) ?? null,
+      createdBy: r.cbName ? { name: r.cbName as string } : null,
+    }));
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<DocumentTemplateRow | null> {
+    const rows = await this.db
+      .select({ tpl: documentTemplates, cbName: users.name }).from(documentTemplates)
+      .leftJoin(users, eq(documentTemplates.createdById, users.id))
+      .where(and(eq(documentTemplates.id, id), eq(documentTemplates.organizationId, organizationId), isNull(documentTemplates.deletedAt)))
+      .limit(1);
+    if (!rows[0]) return null;
+    return { ...(rows[0].tpl as object), createdBy: rows[0].cbName ? { name: rows[0].cbName as string } : null } as unknown as DocumentTemplateRow;
+  }
+}

--- a/src/lib/server/repositories/drizzle-expected-receivable-repository.ts
+++ b/src/lib/server/repositories/drizzle-expected-receivable-repository.ts
@@ -1,0 +1,39 @@
+/**
+ * Drizzle `ExpectedReceivableRepository` (ADR 0020) — server-impl.
+ */
+
+import { and, desc, eq, isNull } from "drizzle-orm";
+import type { ExpectedReceivable } from "@/lib/shared/schemas/billing";
+import { expectedReceivables } from "../db/schema";
+import type { AppDb } from "../db/types";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import type { ExpectedReceivableListFilter, ExpectedReceivableRepository } from "./expected-receivable-repository";
+
+export class DrizzleExpectedReceivableRepository
+  extends DrizzleRepository<ExpectedReceivable>
+  implements ExpectedReceivableRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, expectedReceivables as unknown as VersionedTable, now);
+  }
+
+  async listForOrg(organizationId: string, filter?: ExpectedReceivableListFilter): Promise<ExpectedReceivable[]> {
+    const rows = await this.db
+      .select().from(expectedReceivables)
+      .where(and(
+        eq(expectedReceivables.organizationId, organizationId),
+        isNull(expectedReceivables.deletedAt),
+        filter?.matterId ? eq(expectedReceivables.matterId, filter.matterId) : undefined,
+        filter?.status ? eq(expectedReceivables.status, filter.status) : undefined,
+      ))
+      .orderBy(desc(expectedReceivables.createdAt));
+    return rows as unknown as ExpectedReceivable[];
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<ExpectedReceivable | null> {
+    const rows = await this.db
+      .select().from(expectedReceivables)
+      .where(and(eq(expectedReceivables.id, id), eq(expectedReceivables.organizationId, organizationId), isNull(expectedReceivables.deletedAt)))
+      .limit(1);
+    return (rows[0] as unknown as ExpectedReceivable | undefined) ?? null;
+  }
+}

--- a/src/lib/server/repositories/drizzle-expense-repository.ts
+++ b/src/lib/server/repositories/drizzle-expense-repository.ts
@@ -3,7 +3,7 @@
  * `flagBilled` bulk-sätter invoiceId.
  */
 
-import { and, desc, eq, inArray, isNull, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull, sql } from "drizzle-orm";
 import type { Expense } from "@/lib/shared/schemas/billing";
 import { expenses, invoices, matters, users } from "../db/schema";
 import type { AppDb } from "../db/types";
@@ -71,5 +71,19 @@ export class DrizzleExpenseRepository extends DrizzleRepository<Expense> impleme
   async flagBilled(ids: string[], invoiceId: string): Promise<void> {
     if (!ids.length) return;
     await this.db.update(expenses).set({ invoiceId } as never).where(inArray(expenses.id, ids));
+  }
+
+  async listUnfrozenForMatter(matterId: string): Promise<Expense[]> {
+    const rows = await this.db
+      .select().from(expenses)
+      .where(and(eq(expenses.matterId, matterId), isNull(expenses.frozenByBillingRunId), isNull(expenses.deletedAt)))
+      .orderBy(asc(expenses.date));
+    return rows as unknown as Expense[];
+  }
+
+  async freezeForMatter(matterId: string, billingRunId: string, now: Date): Promise<void> {
+    await this.db.update(expenses)
+      .set({ frozenAt: now, frozenByBillingRunId: billingRunId } as never)
+      .where(and(eq(expenses.matterId, matterId), isNull(expenses.frozenByBillingRunId)));
   }
 }

--- a/src/lib/server/repositories/drizzle-expense-repository.ts
+++ b/src/lib/server/repositories/drizzle-expense-repository.ts
@@ -3,13 +3,13 @@
  * `flagBilled` bulk-sätter invoiceId.
  */
 
-import { and, asc, desc, eq, inArray, isNull, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gte, inArray, isNull, lte, sql } from "drizzle-orm";
 import type { Expense } from "@/lib/shared/schemas/billing";
 import { expenses, invoices, matters, users } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
 import type {
-  ExpenseListOptions, ExpenseListResult, ExpenseListRow, ExpenseRepository,
+  ExpenseListOptions, ExpenseListResult, ExpenseListRow, ExpenseRepository, LawyerReportExpense,
 } from "./expense-repository";
 
 export class DrizzleExpenseRepository extends DrizzleRepository<Expense> implements ExpenseRepository {
@@ -85,5 +85,34 @@ export class DrizzleExpenseRepository extends DrizzleRepository<Expense> impleme
     await this.db.update(expenses)
       .set({ frozenAt: now, frozenByBillingRunId: billingRunId } as never)
       .where(and(eq(expenses.matterId, matterId), isNull(expenses.frozenByBillingRunId)));
+  }
+
+  async listForLawyerInPeriod(
+    organizationId: string, userId: string, from: Date, to: Date,
+  ): Promise<LawyerReportExpense[]> {
+    const klient = sql<string | null>`(select c.name from matter_contacts mc join contacts c on mc.contact_id = c.id where mc.matter_id = ${matters.id} and mc.role = 'KLIENT' limit 1)`;
+    const rows = await this.db
+      .select({
+        exp: expenses,
+        mId: matters.id, mNum: matters.matterNumber, mTitle: matters.title,
+        mPay: matters.paymentMethod, mNote: matters.paymentMethodNote, mDecided: matters.paymentMethodDecidedAt,
+        klient,
+      })
+      .from(expenses)
+      .innerJoin(matters, eq(expenses.matterId, matters.id))
+      .where(and(
+        eq(matters.organizationId, organizationId), eq(expenses.userId, userId),
+        gte(expenses.date, from), lte(expenses.date, to), isNull(expenses.deletedAt),
+      ))
+      .orderBy(asc(expenses.date));
+    return rows.map((r) => ({
+      ...(r.exp as object),
+      matter: {
+        id: r.mId as string, matterNumber: r.mNum as string, title: r.mTitle as string,
+        paymentMethod: r.mPay as string, paymentMethodNote: (r.mNote as string | null) ?? null,
+        paymentMethodDecidedAt: (r.mDecided as Date | null) ?? null,
+        contacts: r.klient ? [{ contact: { name: r.klient as string } }] : [],
+      },
+    })) as unknown as LawyerReportExpense[];
   }
 }

--- a/src/lib/server/repositories/drizzle-invoice-dispatch-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-dispatch-repository.ts
@@ -1,0 +1,49 @@
+/**
+ * Drizzle `InvoiceDispatchRepository` (ADR 0020) — server-impl. Org-scopar
+ * `listQueuedForOrg` via join faktura→ärende.
+ */
+
+import { and, asc, desc, eq, isNull } from "drizzle-orm";
+import type { InvoiceDispatch } from "@/lib/shared/schemas/billing";
+import { invoiceDispatches, invoices, matters } from "../db/schema";
+import type { AppDb } from "../db/types";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import type { InvoiceDispatchQueuedRow, InvoiceDispatchRepository } from "./invoice-dispatch-repository";
+
+export class DrizzleInvoiceDispatchRepository
+  extends DrizzleRepository<InvoiceDispatch>
+  implements InvoiceDispatchRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, invoiceDispatches as unknown as VersionedTable, now);
+  }
+
+  async listByInvoice(invoiceId: string): Promise<InvoiceDispatch[]> {
+    const rows = await this.db
+      .select().from(invoiceDispatches)
+      .where(and(eq(invoiceDispatches.invoiceId, invoiceId), isNull(invoiceDispatches.deletedAt)))
+      .orderBy(desc(invoiceDispatches.queuedAt));
+    return rows as unknown as InvoiceDispatch[];
+  }
+
+  async listQueuedForOrg(organizationId: string): Promise<InvoiceDispatchQueuedRow[]> {
+    const rows = await this.db
+      .select({
+        d: invoiceDispatches,
+        iId: invoices.id, iNum: invoices.invoiceNumber, iAmount: invoices.amount,
+        iOcr: invoices.ocrReference, iDue: invoices.dueDate,
+      })
+      .from(invoiceDispatches)
+      .innerJoin(invoices, eq(invoiceDispatches.invoiceId, invoices.id))
+      .innerJoin(matters, eq(invoices.matterId, matters.id))
+      .where(and(
+        eq(invoiceDispatches.status, "queued"),
+        eq(matters.organizationId, organizationId),
+        isNull(invoiceDispatches.deletedAt),
+      ))
+      .orderBy(asc(invoiceDispatches.queuedAt));
+    return rows.map((r) => ({
+      ...(r.d as object),
+      invoice: { id: r.iId, invoiceNumber: r.iNum, amount: r.iAmount as number, ocrReference: r.iOcr, dueDate: r.iDue },
+    })) as unknown as InvoiceDispatchQueuedRow[];
+  }
+}

--- a/src/lib/server/repositories/drizzle-matter-contact-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-contact-repository.ts
@@ -5,11 +5,14 @@
  */
 
 import { and, eq, isNull, or, sql } from "drizzle-orm";
+import type { Contact } from "@/lib/shared/schemas/contact";
 import type { MatterContact } from "@/lib/shared/schemas/matter";
 import { contacts, matterContacts, matters } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
-import type { ConflictContactRow, MatterContactRepository } from "./matter-contact-repository";
+import type {
+  ConflictContactRow, MatterContactRepository, MatterContactWithContact,
+} from "./matter-contact-repository";
 
 export class DrizzleMatterContactRepository
   extends DrizzleRepository<MatterContact>
@@ -48,5 +51,21 @@ export class DrizzleMatterContactRepository
         contacts: r.klient ? [{ contact: { name: r.klient as string } }] : [],
       },
     }));
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<MatterContact | null> {
+    const rows = await this.db
+      .select({ mc: matterContacts }).from(matterContacts)
+      .innerJoin(matters, eq(matterContacts.matterId, matters.id))
+      .where(and(eq(matterContacts.id, id), eq(matters.organizationId, organizationId), isNull(matterContacts.deletedAt)))
+      .limit(1);
+    return (rows[0]?.mc as unknown as MatterContact | undefined) ?? null;
+  }
+
+  async linkContact(data: Partial<MatterContact>): Promise<MatterContactWithContact> {
+    const link = await this.create(data);
+    const [contact] = await this.db
+      .select().from(contacts).where(eq(contacts.id, (link as { contactId: string }).contactId)).limit(1);
+    return { ...(link as object), contact: contact as unknown as Contact } as MatterContactWithContact;
   }
 }

--- a/src/lib/server/repositories/drizzle-matter-contact-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-contact-repository.ts
@@ -1,0 +1,52 @@
+/**
+ * Drizzle `MatterContactRepository` (ADR 0020) — server-impl. Joinar kontakt +
+ * ärende; KLIENT-namnet hämtas via korrelerad subquery (samma mönster som
+ * tidsrapportens listForReport).
+ */
+
+import { and, eq, isNull, or, sql } from "drizzle-orm";
+import type { MatterContact } from "@/lib/shared/schemas/matter";
+import { contacts, matterContacts, matters } from "../db/schema";
+import type { AppDb } from "../db/types";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import type { ConflictContactRow, MatterContactRepository } from "./matter-contact-repository";
+
+export class DrizzleMatterContactRepository
+  extends DrizzleRepository<MatterContact>
+  implements MatterContactRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, matterContacts as unknown as VersionedTable, now);
+  }
+
+  async findForConflict(organizationId: string, numberTerm?: string): Promise<ConflictContactRow[]> {
+    const klient = sql<string | null>`(select c.name from matter_contacts mc join contacts c on mc.contact_id = c.id where mc.matter_id = ${matters.id} and mc.role = 'KLIENT' limit 1)`;
+    const numberFilter = numberTerm
+      ? or(
+          sql`${contacts.personalNumber} like ${"%" + numberTerm + "%"}`,
+          sql`${contacts.orgNumber} like ${"%" + numberTerm + "%"}`,
+        )
+      : undefined;
+    const rows = await this.db
+      .select({
+        role: matterContacts.role,
+        cId: contacts.id, cName: contacts.name, cType: contacts.contactType,
+        cPnr: contacts.personalNumber, cOrg: contacts.orgNumber,
+        mId: matters.id, mNum: matters.matterNumber, mTitle: matters.title, klient,
+      })
+      .from(matterContacts)
+      .innerJoin(contacts, eq(matterContacts.contactId, contacts.id))
+      .innerJoin(matters, eq(matterContacts.matterId, matters.id))
+      .where(and(eq(matters.organizationId, organizationId), isNull(matterContacts.deletedAt), numberFilter));
+    return rows.map((r) => ({
+      role: r.role as string,
+      contact: {
+        id: r.cId as string, name: r.cName as string, contactType: r.cType as string,
+        personalNumber: (r.cPnr as string | null) ?? null, orgNumber: (r.cOrg as string | null) ?? null,
+      },
+      matter: {
+        id: r.mId as string, matterNumber: r.mNum as string, title: r.mTitle as string,
+        contacts: r.klient ? [{ contact: { name: r.klient as string } }] : [],
+      },
+    }));
+  }
+}

--- a/src/lib/server/repositories/drizzle-matter-contact-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-contact-repository.ts
@@ -68,4 +68,21 @@ export class DrizzleMatterContactRepository
       .select().from(contacts).where(eq(contacts.id, (link as { contactId: string }).contactId)).limit(1);
     return { ...(link as object), contact: contact as unknown as Contact } as MatterContactWithContact;
   }
+
+  async findLink(matterId: string, contactId: string, role: string): Promise<MatterContact | null> {
+    const rows = await this.db.select().from(matterContacts)
+      .where(and(
+        eq(matterContacts.matterId, matterId), eq(matterContacts.contactId, contactId),
+        eq(matterContacts.role, role), isNull(matterContacts.deletedAt),
+      )).limit(1);
+    return (rows[0] as unknown as MatterContact | undefined) ?? null;
+  }
+
+  async listContactsForMatter(matterId: string): Promise<Contact[]> {
+    const rows = await this.db
+      .select({ contact: contacts }).from(matterContacts)
+      .innerJoin(contacts, eq(matterContacts.contactId, contacts.id))
+      .where(and(eq(matterContacts.matterId, matterId), isNull(matterContacts.deletedAt)));
+    return rows.map((r) => r.contact as unknown as Contact);
+  }
 }

--- a/src/lib/server/repositories/drizzle-matter-event-suggestion-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-event-suggestion-repository.ts
@@ -1,0 +1,57 @@
+/**
+ * Drizzle `MatterEventSuggestionRepository` (ADR 0020) — server-impl. Org-scopar
+ * via join dokument→ärende.
+ */
+
+import { and, asc, eq, isNull, ne } from "drizzle-orm";
+import type { MatterEventSuggestion } from "@/lib/shared/schemas/document";
+import { documents, matterEventSuggestions, matters } from "../db/schema";
+import type { AppDb } from "../db/types";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import type {
+  MatterEventSuggestionRepository, MatterEventSuggestionRow,
+} from "./matter-event-suggestion-repository";
+
+export class DrizzleMatterEventSuggestionRepository
+  extends DrizzleRepository<MatterEventSuggestion>
+  implements MatterEventSuggestionRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, matterEventSuggestions as unknown as VersionedTable, now);
+  }
+
+  async listForMatter(matterId: string, organizationId: string): Promise<MatterEventSuggestionRow[]> {
+    const rows = await this.db
+      .select({
+        ev: matterEventSuggestions,
+        dId: documents.id, dFile: documents.fileName, dTitle: documents.title,
+      })
+      .from(matterEventSuggestions)
+      .innerJoin(documents, eq(matterEventSuggestions.documentId, documents.id))
+      .innerJoin(matters, eq(documents.matterId, matters.id))
+      .where(and(
+        eq(documents.matterId, matterId),
+        eq(matters.organizationId, organizationId),
+        ne(matterEventSuggestions.status, "REJECTED"),
+        isNull(matterEventSuggestions.deletedAt),
+      ))
+      .orderBy(asc(matterEventSuggestions.startAt));
+    return rows.map((r) => ({
+      ...(r.ev as object),
+      document: { id: r.dId as string, fileName: r.dFile as string, title: (r.dTitle as string | null) ?? null },
+    })) as unknown as MatterEventSuggestionRow[];
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<MatterEventSuggestion | null> {
+    const rows = await this.db
+      .select({ ev: matterEventSuggestions }).from(matterEventSuggestions)
+      .innerJoin(documents, eq(matterEventSuggestions.documentId, documents.id))
+      .innerJoin(matters, eq(documents.matterId, matters.id))
+      .where(and(
+        eq(matterEventSuggestions.id, id),
+        eq(matters.organizationId, organizationId),
+        isNull(matterEventSuggestions.deletedAt),
+      ))
+      .limit(1);
+    return (rows[0]?.ev as unknown as MatterEventSuggestion | undefined) ?? null;
+  }
+}

--- a/src/lib/server/repositories/drizzle-matter-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-repository.ts
@@ -1,14 +1,18 @@
 /**
  * Drizzle `MatterRepository` (ADR 0020) — server-impl. Ärver bas-CRUD;
- * org-scopar direkt på `matters.organizationId` (ingen join).
+ * org-scopar direkt på `matters.organizationId`. Listan/detaljen berikar
+ * KLIENT-kontakt + relations-antal (`_count`) via grupperade sido-queries
+ * (robustare än korrelerade subqueries; jfr document-folder-repo:t).
  */
 
-import { and, eq, isNull } from "drizzle-orm";
-import type { Matter } from "@/lib/shared/schemas/matter";
-import { matters } from "../db/schema";
+import { and, asc, desc, eq, ilike, inArray, isNull, or, sql } from "drizzle-orm";
+import type { Matter, MatterContact } from "@/lib/shared/schemas/matter";
+import { contacts, documents, matterContacts, matters, timeEntries } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
-import type { MatterRepository } from "./matter-repository";
+import type {
+  MatterDetailRow, MatterListFilter, MatterListResult, MatterListRow, MatterRepository,
+} from "./matter-repository";
 
 export class DrizzleMatterRepository extends DrizzleRepository<Matter> implements MatterRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
@@ -27,6 +31,121 @@ export class DrizzleMatterRepository extends DrizzleRepository<Matter> implement
     const rows = await this.db
       .select().from(matters)
       .where(and(eq(matters.organizationId, organizationId), isNull(matters.deletedAt)));
+    return rows as unknown as Matter[];
+  }
+
+  private listWhere(organizationId: string, f: MatterListFilter) {
+    const pat = f.search ? `%${f.search}%` : "";
+    return and(
+      eq(matters.organizationId, organizationId),
+      isNull(matters.deletedAt),
+      f.status ? eq(matters.status, f.status) : undefined,
+      f.employeeId
+        ? sql`exists (select 1 from time_entries te where te.matter_id = ${matters.id} and te.user_id = ${f.employeeId})`
+        : undefined,
+      f.search
+        ? or(
+            ilike(matters.title, pat),
+            ilike(matters.matterNumber, pat),
+            sql`exists (select 1 from matter_contacts mc join contacts c on mc.contact_id = c.id where mc.matter_id = ${matters.id} and c.name ilike ${pat})`,
+          )
+        : undefined,
+    );
+  }
+
+  async listForOrg(organizationId: string, filter: MatterListFilter): Promise<MatterListResult> {
+    const where = this.listWhere(organizationId, filter);
+    const rows = await this.db.select().from(matters).where(where)
+      .orderBy(desc(matters.createdAt))
+      .limit(filter.pageSize).offset((filter.page - 1) * filter.pageSize);
+    const [agg] = await this.db.select({ total: sql<number>`count(*)` }).from(matters).where(where);
+    const ids = rows.map((r) => (r as { id: string }).id);
+    const [counts, klient] = await Promise.all([this.countsFor(ids), this.klientFor(ids)]);
+    const matterRows = rows.map((r) => {
+      const id = (r as { id: string }).id;
+      const k = klient.get(id);
+      return {
+        ...(r as object),
+        contacts: k ? [{ contact: k }] : [],
+        _count: counts.get(id) ?? { documents: 0, timeEntries: 0, contacts: 0 },
+      };
+    }) as unknown as MatterListRow[];
+    return { matters: matterRows, total: Number(agg?.total ?? 0) };
+  }
+
+  /** Grupperade relations-antal per ärende-id (documents/timeEntries/contacts). */
+  private async countsFor(ids: string[]): Promise<Map<string, { documents: number; timeEntries: number; contacts: number }>> {
+    const out = new Map<string, { documents: number; timeEntries: number; contacts: number }>();
+    if (ids.length === 0) return out;
+    for (const id of ids) out.set(id, { documents: 0, timeEntries: 0, contacts: 0 });
+    const apply = (rows: Array<{ id: unknown; n: number }>, key: "documents" | "timeEntries" | "contacts") => {
+      for (const r of rows) { const cur = r.id ? out.get(r.id as string) : undefined; if (cur) cur[key] = Number(r.n); }
+    };
+    const [docs, tes, mcs] = await Promise.all([
+      this.db.select({ id: documents.matterId, n: sql<number>`count(*)` }).from(documents)
+        .where(and(inArray(documents.matterId, ids), isNull(documents.deletedAt))).groupBy(documents.matterId),
+      this.db.select({ id: timeEntries.matterId, n: sql<number>`count(*)` }).from(timeEntries)
+        .where(and(inArray(timeEntries.matterId, ids), isNull(timeEntries.deletedAt))).groupBy(timeEntries.matterId),
+      this.db.select({ id: matterContacts.matterId, n: sql<number>`count(*)` }).from(matterContacts)
+        .where(and(inArray(matterContacts.matterId, ids), isNull(matterContacts.deletedAt))).groupBy(matterContacts.matterId),
+    ]);
+    apply(docs, "documents");
+    apply(tes, "timeEntries");
+    apply(mcs, "contacts");
+    return out;
+  }
+
+  /** KLIENT-kontakt (id+namn) per ärende-id (första). */
+  private async klientFor(ids: string[]): Promise<Map<string, { id: string; name: string }>> {
+    const out = new Map<string, { id: string; name: string }>();
+    if (ids.length === 0) return out;
+    const rows = await this.db
+      .select({ matterId: matterContacts.matterId, cId: contacts.id, cName: contacts.name })
+      .from(matterContacts)
+      .innerJoin(contacts, eq(matterContacts.contactId, contacts.id))
+      .where(and(inArray(matterContacts.matterId, ids), eq(matterContacts.role, "KLIENT")));
+    for (const r of rows) {
+      const mid = r.matterId as string;
+      if (!out.has(mid)) out.set(mid, { id: r.cId as string, name: r.cName as string });
+    }
+    return out;
+  }
+
+  async getByIdWithContacts(id: string, organizationId: string): Promise<MatterDetailRow | null> {
+    const base = await this.getByIdInOrg(id, organizationId);
+    if (!base) return null;
+    const rows = await this.db
+      .select({ mc: matterContacts, contact: contacts })
+      .from(matterContacts)
+      .innerJoin(contacts, eq(matterContacts.contactId, contacts.id))
+      .where(and(eq(matterContacts.matterId, id), isNull(matterContacts.deletedAt)))
+      .orderBy(asc(matterContacts.createdAt));
+    const linkContacts = rows.map((r) => ({ ...(r.mc as object), contact: r.contact })) as unknown as MatterContact[];
+    const counts = (await this.countsFor([id])).get(id) ?? { documents: 0, timeEntries: 0, contacts: 0 };
+    return {
+      ...(base as object),
+      contacts: linkContacts,
+      _count: { documents: counts.documents, timeEntries: counts.timeEntries, emails: 0 },
+    } as unknown as MatterDetailRow;
+  }
+
+  async listByResponsibleLawyer(organizationId: string, responsibleLawyerId: string): Promise<Matter[]> {
+    const rows = await this.db.select().from(matters)
+      .where(and(
+        eq(matters.organizationId, organizationId),
+        eq(matters.responsibleLawyerId, responsibleLawyerId),
+        isNull(matters.deletedAt),
+      ));
+    return rows as unknown as Matter[];
+  }
+
+  async listByNumberPrefix(organizationId: string, prefix: string): Promise<Matter[]> {
+    const rows = await this.db.select().from(matters)
+      .where(and(
+        eq(matters.organizationId, organizationId),
+        ilike(matters.matterNumber, `${prefix}%`),
+        isNull(matters.deletedAt),
+      ));
     return rows as unknown as Matter[];
   }
 }

--- a/src/lib/server/repositories/drizzle-matter-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-repository.ts
@@ -22,4 +22,11 @@ export class DrizzleMatterRepository extends DrizzleRepository<Matter> implement
       .limit(1);
     return (rows[0] as unknown as Matter | undefined) ?? null;
   }
+
+  async listByOrg(organizationId: string): Promise<Matter[]> {
+    const rows = await this.db
+      .select().from(matters)
+      .where(and(eq(matters.organizationId, organizationId), isNull(matters.deletedAt)));
+    return rows as unknown as Matter[];
+  }
 }

--- a/src/lib/server/repositories/drizzle-office-repository.ts
+++ b/src/lib/server/repositories/drizzle-office-repository.ts
@@ -1,0 +1,37 @@
+/**
+ * Drizzle `OfficeRepository` (ADR 0020) — server-impl.
+ */
+
+import { and, asc, desc, eq, isNull } from "drizzle-orm";
+import type { Office } from "@/lib/shared/schemas/organization";
+import { offices } from "../db/schema";
+import type { AppDb } from "../db/types";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import type { OfficeRepository } from "./office-repository";
+
+export class DrizzleOfficeRepository extends DrizzleRepository<Office> implements OfficeRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, offices as unknown as VersionedTable, now);
+  }
+
+  async listByOrg(organizationId: string): Promise<Office[]> {
+    const rows = await this.db
+      .select().from(offices)
+      .where(and(eq(offices.organizationId, organizationId), isNull(offices.deletedAt)))
+      .orderBy(desc(offices.isMain), asc(offices.name));
+    return rows as unknown as Office[];
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<Office | null> {
+    const rows = await this.db
+      .select().from(offices)
+      .where(and(eq(offices.id, id), eq(offices.organizationId, organizationId), isNull(offices.deletedAt)))
+      .limit(1);
+    return (rows[0] as unknown as Office | undefined) ?? null;
+  }
+
+  async demoteMains(organizationId: string): Promise<void> {
+    await this.db.update(offices).set({ isMain: false } as never)
+      .where(and(eq(offices.organizationId, organizationId), eq(offices.isMain, true)));
+  }
+}

--- a/src/lib/server/repositories/drizzle-org-preference-repository.ts
+++ b/src/lib/server/repositories/drizzle-org-preference-repository.ts
@@ -1,0 +1,30 @@
+/** Drizzle `OrgPreferenceRepository` (ADR 0020). */
+
+import { and, asc, eq, isNull } from "drizzle-orm";
+import type { OrgPreference } from "@/lib/shared/schemas/preference";
+import { orgPreferences } from "../db/schema";
+import type { AppDb } from "../db/types";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import type { OrgPreferenceRepository, OrgPreferenceRow } from "./org-preference-repository";
+
+export class DrizzleOrgPreferenceRepository extends DrizzleRepository<OrgPreferenceRow> implements OrgPreferenceRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, orgPreferences as unknown as VersionedTable, now);
+  }
+
+  async getByOrgKey(organizationId: string, key: string): Promise<OrgPreference | null> {
+    const rows = await this.db
+      .select().from(orgPreferences)
+      .where(and(eq(orgPreferences.organizationId, organizationId), eq(orgPreferences.key, key), isNull(orgPreferences.deletedAt)))
+      .limit(1);
+    return (rows[0] as unknown as OrgPreference | undefined) ?? null;
+  }
+
+  async listByOrg(organizationId: string): Promise<OrgPreference[]> {
+    const rows = await this.db
+      .select().from(orgPreferences)
+      .where(and(eq(orgPreferences.organizationId, organizationId), isNull(orgPreferences.deletedAt)))
+      .orderBy(asc(orgPreferences.key));
+    return rows as unknown as OrgPreference[];
+  }
+}

--- a/src/lib/server/repositories/drizzle-organization-repository.ts
+++ b/src/lib/server/repositories/drizzle-organization-repository.ts
@@ -1,0 +1,15 @@
+/**
+ * Drizzle `OrganizationRepository` (ADR 0020) — endast bas-CRUD.
+ */
+
+import type { Organization } from "@/lib/shared/schemas/organization";
+import { organizations } from "../db/schema";
+import type { AppDb } from "../db/types";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import type { OrganizationRepository } from "./organization-repository";
+
+export class DrizzleOrganizationRepository extends DrizzleRepository<Organization> implements OrganizationRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, organizations as unknown as VersionedTable, now);
+  }
+}

--- a/src/lib/server/repositories/drizzle-payment-plan-reminder-repository.ts
+++ b/src/lib/server/repositories/drizzle-payment-plan-reminder-repository.ts
@@ -1,0 +1,17 @@
+/**
+ * Drizzle `PaymentPlanReminderRepository` (ADR 0020) — server-impl (bas-CRUD).
+ */
+
+import type { PaymentPlanReminder } from "@/lib/shared/schemas/billing";
+import { paymentPlanReminders } from "../db/schema";
+import type { AppDb } from "../db/types";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import type { PaymentPlanReminderRepository } from "./payment-plan-reminder-repository";
+
+export class DrizzlePaymentPlanReminderRepository
+  extends DrizzleRepository<PaymentPlanReminder>
+  implements PaymentPlanReminderRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, paymentPlanReminders as unknown as VersionedTable, now);
+  }
+}

--- a/src/lib/server/repositories/drizzle-payment-plan-repository.ts
+++ b/src/lib/server/repositories/drizzle-payment-plan-repository.ts
@@ -1,15 +1,20 @@
 /**
  * Drizzle `PaymentPlanRepository` (ADR 0020) — server-impl. Ärver bas-CRUD från
  * `DrizzleRepository`; org-scopningen joinar plan→faktura→ärende (planer saknar
- * egen organizationId), spegling av in-memory-impl:ens relations-where.
+ * egen organizationId). Joinade läsningar använder Drizzles relationella
+ * `with`-queries (org-filtret görs via id-prefiltrering, då `db.query` saknar
+ * relations-where — samma mönster som invoice-repo:t). Påminnelserna grafas på
+ * via en sekundär-query (undviker att duplicera den nästlade faktura-joinen).
  */
 
-import { and, eq, isNull } from "drizzle-orm";
-import type { PaymentPlan } from "@/lib/shared/schemas/billing";
-import { invoices, matters, paymentPlans } from "../db/schema";
+import { and, desc, eq, inArray, isNull } from "drizzle-orm";
+import type { PaymentPlan, PaymentPlanReminder } from "@/lib/shared/schemas/billing";
+import { invoices, matters, paymentPlanReminders, paymentPlans } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
-import type { PaymentPlanRepository } from "./payment-plan-repository";
+import type {
+  JoinedPaymentPlan, JoinedPaymentPlanWithReminders, PaymentPlanRepository,
+} from "./payment-plan-repository";
 
 export class DrizzlePaymentPlanRepository extends DrizzleRepository<PaymentPlan> implements PaymentPlanRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
@@ -34,5 +39,75 @@ export class DrizzlePaymentPlanRepository extends DrizzleRepository<PaymentPlan>
       .select().from(paymentPlans)
       .where(and(eq(paymentPlans.invoiceId, invoiceId), isNull(paymentPlans.deletedAt))).limit(1);
     return (rows[0] as unknown as PaymentPlan | undefined) ?? null;
+  }
+
+  /** Plan-id:n i org:en (via faktura→ärende), valfritt status-filtrerade. */
+  private async planIdsInOrg(organizationId: string, status?: string): Promise<string[]> {
+    const rows = await this.db
+      .select({ id: paymentPlans.id }).from(paymentPlans)
+      .innerJoin(invoices, eq(paymentPlans.invoiceId, invoices.id))
+      .innerJoin(matters, eq(invoices.matterId, matters.id))
+      .where(and(
+        eq(matters.organizationId, organizationId),
+        status ? eq(paymentPlans.status, status) : undefined,
+        isNull(paymentPlans.deletedAt),
+      ));
+    return rows.map((r) => r.id as string);
+  }
+
+  /** Hämta joinade planer (faktura + ärende inkl. KLIENT + betalningar + avskrivningar). */
+  private async fetchJoined(ids: string[]): Promise<JoinedPaymentPlan[]> {
+    if (ids.length === 0) return [];
+    const rows = await this.db.query.paymentPlans.findMany({
+      where: inArray(paymentPlans.id, ids),
+      orderBy: (pp, { desc: d }) => [d(pp.createdAt)],
+      with: {
+        invoice: {
+          with: {
+            matter: {
+              with: {
+                contacts: { where: (mc, { eq: e }) => e(mc.role, "KLIENT"), limit: 1, with: { contact: true } },
+              },
+            },
+            payments: { orderBy: (p, { desc: d }) => [d(p.paidAt)] },
+            writeOffs: true,
+          },
+        },
+      },
+    });
+    return rows as unknown as JoinedPaymentPlan[];
+  }
+
+  /** Påminnelser per plan (sentAt desc), grupperade. */
+  private async remindersByPlan(ids: string[]): Promise<Map<string, PaymentPlanReminder[]>> {
+    const out = new Map<string, PaymentPlanReminder[]>();
+    if (ids.length === 0) return out;
+    const rows = await this.db
+      .select().from(paymentPlanReminders)
+      .where(inArray(paymentPlanReminders.planId, ids))
+      .orderBy(desc(paymentPlanReminders.sentAt));
+    for (const r of rows as unknown as PaymentPlanReminder[]) {
+      (out.get(r.planId) ?? out.set(r.planId, []).get(r.planId)!).push(r);
+    }
+    return out;
+  }
+
+  async listForOrg(organizationId: string, status?: string): Promise<JoinedPaymentPlan[]> {
+    return this.fetchJoined(await this.planIdsInOrg(organizationId, status));
+  }
+
+  async getByIdWithDetails(id: string, organizationId: string): Promise<JoinedPaymentPlanWithReminders | null> {
+    if (!(await this.getByIdInOrg(id, organizationId))) return null;
+    const [plan] = await this.fetchJoined([id]);
+    if (!plan) return null;
+    const reminders = (await this.remindersByPlan([id])).get(id) ?? [];
+    return { ...plan, reminders };
+  }
+
+  async listActiveForScan(organizationId: string): Promise<JoinedPaymentPlanWithReminders[]> {
+    const ids = await this.planIdsInOrg(organizationId, "ACTIVE");
+    const plans = await this.fetchJoined(ids);
+    const byPlan = await this.remindersByPlan(ids);
+    return plans.map((p) => ({ ...p, reminders: byPlan.get(p.id) ?? [] }));
   }
 }

--- a/src/lib/server/repositories/drizzle-payment-repository.ts
+++ b/src/lib/server/repositories/drizzle-payment-repository.ts
@@ -3,7 +3,7 @@
  * `sumByInvoice` summerar i SQL (COALESCE(SUM(amount), 0)) bland icke-raderade.
  */
 
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import type { Payment } from "@/lib/shared/schemas/billing";
 import { payments } from "../db/schema";
 import type { AppDb } from "../db/types";
@@ -20,5 +20,13 @@ export class DrizzlePaymentRepository extends DrizzleRepository<Payment> impleme
       .select({ total: sql<number>`coalesce(sum(${payments.amount}), 0)` }).from(payments)
       .where(and(eq(payments.invoiceId, invoiceId), isNull(payments.deletedAt)));
     return Number(rows[0]?.total ?? 0);
+  }
+
+  async listByInvoiceIds(invoiceIds: string[]): Promise<Payment[]> {
+    if (!invoiceIds.length) return [];
+    const rows = await this.db
+      .select().from(payments)
+      .where(and(inArray(payments.invoiceId, invoiceIds), isNull(payments.deletedAt)));
+    return rows as unknown as Payment[];
   }
 }

--- a/src/lib/server/repositories/drizzle-time-entry-repository.ts
+++ b/src/lib/server/repositories/drizzle-time-entry-repository.ts
@@ -3,16 +3,96 @@
  * `listUnbilled` joinar users för timtaxan, `flagBilled` bulk-sätter invoiceId.
  */
 
-import { and, eq, inArray, isNull } from "drizzle-orm";
+import { and, asc, desc, eq, gte, inArray, isNull, lte, sql } from "drizzle-orm";
 import type { TimeEntry } from "@/lib/shared/schemas/billing";
-import { timeEntries, users } from "../db/schema";
+import { matters, timeEntries, users } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
-import type { TimeEntryRepository, UnbilledTimeEntry } from "./time-entry-repository";
+import type {
+  TimeEntryListFilter, TimeEntryListResult, TimeEntryListRow, TimeEntryReportFilter,
+  TimeEntryReportRow, TimeEntryRepository, UnbilledTimeEntry,
+} from "./time-entry-repository";
+
+/** Org-scopat where för `listForOrg` (utbruten för komplexitet ≤8). */
+function listWhere(organizationId: string, opts: TimeEntryListFilter) {
+  return and(
+    eq(matters.organizationId, organizationId),
+    isNull(timeEntries.deletedAt),
+    opts.matterId ? eq(timeEntries.matterId, opts.matterId) : undefined,
+    opts.userId ? eq(timeEntries.userId, opts.userId) : undefined,
+    opts.from ? gte(timeEntries.date, opts.from) : undefined,
+    opts.to ? lte(timeEntries.date, opts.to) : undefined,
+  );
+}
 
 export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> implements TimeEntryRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
     super(db, timeEntries as unknown as VersionedTable, now);
+  }
+
+  async listForOrg(organizationId: string, opts: TimeEntryListFilter): Promise<TimeEntryListResult> {
+    const where = listWhere(organizationId, opts);
+    const base = this.db.select({
+      te: timeEntries,
+      uId: users.id, uName: users.name,
+      mId: matters.id, mNum: matters.matterNumber, mTitle: matters.title,
+    }).from(timeEntries).innerJoin(matters, eq(timeEntries.matterId, matters.id))
+      .leftJoin(users, eq(timeEntries.userId, users.id));
+    const rows = await base.where(where).orderBy(desc(timeEntries.date))
+      .limit(opts.pageSize).offset((opts.page - 1) * opts.pageSize);
+    const [agg] = await this.db
+      .select({ total: sql<number>`count(*)`, sum: sql<number>`coalesce(sum(${timeEntries.minutes}), 0)` })
+      .from(timeEntries).innerJoin(matters, eq(timeEntries.matterId, matters.id)).where(where);
+    return {
+      entries: rows.map((r) => ({
+        ...(r.te as object),
+        user: r.uId ? { id: r.uId, name: r.uName as string } : null,
+        matter: { id: r.mId, matterNumber: r.mNum as string, title: r.mTitle as string },
+        invoice: null,
+      })) as unknown as TimeEntryListRow[],
+      total: Number(agg?.total ?? 0),
+      totalMinutes: Number(agg?.sum ?? 0),
+    };
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<TimeEntry | null> {
+    const rows = await this.db
+      .select({ te: timeEntries }).from(timeEntries)
+      .innerJoin(matters, eq(timeEntries.matterId, matters.id))
+      .where(and(eq(timeEntries.id, id), eq(matters.organizationId, organizationId), isNull(timeEntries.deletedAt)))
+      .limit(1);
+    return (rows[0]?.te as unknown as TimeEntry | undefined) ?? null;
+  }
+
+  async listForReport(organizationId: string, filter: TimeEntryReportFilter): Promise<TimeEntryReportRow[]> {
+    const klient = sql<string | null>`(select c.name from matter_contacts mc join contacts c on mc.contact_id = c.id where mc.matter_id = ${matters.id} and mc.role = 'KLIENT' limit 1)`;
+    const rows = await this.db
+      .select({
+        te: timeEntries, uId: users.id, uName: users.name,
+        mId: matters.id, mNum: matters.matterNumber, mTitle: matters.title, klient,
+      })
+      .from(timeEntries)
+      .innerJoin(matters, eq(timeEntries.matterId, matters.id))
+      .leftJoin(users, eq(timeEntries.userId, users.id))
+      .where(and(
+        eq(matters.organizationId, organizationId),
+        isNull(timeEntries.deletedAt),
+        gte(timeEntries.date, filter.from),
+        lte(timeEntries.date, filter.to),
+        filter.matterId ? eq(timeEntries.matterId, filter.matterId) : undefined,
+        filter.userIds && filter.userIds.length > 0
+          ? inArray(timeEntries.userId, filter.userIds)
+          : filter.userId ? eq(timeEntries.userId, filter.userId) : undefined,
+      ))
+      .orderBy(asc(timeEntries.userId), asc(timeEntries.date));
+    return rows.map((r) => ({
+      ...(r.te as object),
+      user: { id: r.uId as string, name: r.uName as string },
+      matter: {
+        id: r.mId, matterNumber: r.mNum as string, title: r.mTitle as string,
+        contacts: r.klient ? [{ contact: { name: r.klient as string } }] : [],
+      },
+    })) as unknown as TimeEntryReportRow[];
   }
 
   async listUnbilled(matterId: string, ids: string[]): Promise<UnbilledTimeEntry[]> {

--- a/src/lib/server/repositories/drizzle-time-entry-repository.ts
+++ b/src/lib/server/repositories/drizzle-time-entry-repository.ts
@@ -110,4 +110,18 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
     if (!ids.length) return;
     await this.db.update(timeEntries).set({ invoiceId } as never).where(inArray(timeEntries.id, ids));
   }
+
+  async listUnfrozenForMatter(matterId: string): Promise<TimeEntry[]> {
+    const rows = await this.db
+      .select().from(timeEntries)
+      .where(and(eq(timeEntries.matterId, matterId), isNull(timeEntries.frozenByBillingRunId), isNull(timeEntries.deletedAt)))
+      .orderBy(asc(timeEntries.date));
+    return rows as unknown as TimeEntry[];
+  }
+
+  async freezeForMatter(matterId: string, billingRunId: string, now: Date): Promise<void> {
+    await this.db.update(timeEntries)
+      .set({ frozenAt: now, frozenByBillingRunId: billingRunId } as never)
+      .where(and(eq(timeEntries.matterId, matterId), isNull(timeEntries.frozenByBillingRunId)));
+  }
 }

--- a/src/lib/server/repositories/drizzle-time-entry-repository.ts
+++ b/src/lib/server/repositories/drizzle-time-entry-repository.ts
@@ -9,8 +9,8 @@ import { matters, timeEntries, users } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
 import type {
-  TimeEntryListFilter, TimeEntryListResult, TimeEntryListRow, TimeEntryReportFilter,
-  TimeEntryReportRow, TimeEntryRepository, UnbilledTimeEntry,
+  LawyerReportTimeEntry, TimeEntryListFilter, TimeEntryListResult, TimeEntryListRow,
+  TimeEntryReportFilter, TimeEntryReportRow, TimeEntryRepository, UnbilledTimeEntry,
 } from "./time-entry-repository";
 
 /** Org-scopat where för `listForOrg` (utbruten för komplexitet ≤8). */
@@ -117,6 +117,43 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
       .where(and(eq(timeEntries.matterId, matterId), isNull(timeEntries.frozenByBillingRunId), isNull(timeEntries.deletedAt)))
       .orderBy(asc(timeEntries.date));
     return rows as unknown as TimeEntry[];
+  }
+
+  async listForLawyerInPeriod(
+    organizationId: string, userId: string, from: Date, to: Date,
+  ): Promise<LawyerReportTimeEntry[]> {
+    const klient = sql<string | null>`(select c.name from matter_contacts mc join contacts c on mc.contact_id = c.id where mc.matter_id = ${matters.id} and mc.role = 'KLIENT' limit 1)`;
+    const rows = await this.db
+      .select({
+        te: timeEntries,
+        mId: matters.id, mNum: matters.matterNumber, mTitle: matters.title,
+        mPay: matters.paymentMethod, mNote: matters.paymentMethodNote, mDecided: matters.paymentMethodDecidedAt,
+        klient,
+      })
+      .from(timeEntries)
+      .innerJoin(matters, eq(timeEntries.matterId, matters.id))
+      .where(and(
+        eq(matters.organizationId, organizationId), eq(timeEntries.userId, userId),
+        gte(timeEntries.date, from), lte(timeEntries.date, to), isNull(timeEntries.deletedAt),
+      ))
+      .orderBy(asc(timeEntries.date));
+    return rows.map((r) => ({
+      ...(r.te as object),
+      matter: {
+        id: r.mId as string, matterNumber: r.mNum as string, title: r.mTitle as string,
+        paymentMethod: r.mPay as string, paymentMethodNote: (r.mNote as string | null) ?? null,
+        paymentMethodDecidedAt: (r.mDecided as Date | null) ?? null,
+        contacts: r.klient ? [{ contact: { name: r.klient as string } }] : [],
+      },
+    })) as unknown as LawyerReportTimeEntry[];
+  }
+
+  async listBillableForOrg(organizationId: string): Promise<TimeEntry[]> {
+    const rows = await this.db
+      .select({ te: timeEntries }).from(timeEntries)
+      .innerJoin(matters, eq(timeEntries.matterId, matters.id))
+      .where(and(eq(matters.organizationId, organizationId), eq(timeEntries.billable, true), isNull(timeEntries.deletedAt)));
+    return rows.map((r) => r.te) as unknown as TimeEntry[];
   }
 
   async freezeForMatter(matterId: string, billingRunId: string, now: Date): Promise<void> {

--- a/src/lib/server/repositories/drizzle-user-preference-repository.ts
+++ b/src/lib/server/repositories/drizzle-user-preference-repository.ts
@@ -1,0 +1,22 @@
+/** Drizzle `UserPreferenceRepository` (ADR 0020). */
+
+import { and, eq, isNull } from "drizzle-orm";
+import type { UserPreference } from "@/lib/shared/schemas/preference";
+import { userPreferences } from "../db/schema";
+import type { AppDb } from "../db/types";
+import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import type { UserPreferenceRepository, UserPreferenceRow } from "./user-preference-repository";
+
+export class DrizzleUserPreferenceRepository extends DrizzleRepository<UserPreferenceRow> implements UserPreferenceRepository {
+  constructor(db: AppDb, now: () => Date = () => new Date()) {
+    super(db, userPreferences as unknown as VersionedTable, now);
+  }
+
+  async getByUserKey(userId: string, organizationId: string, key: string): Promise<UserPreference | null> {
+    const rows = await this.db
+      .select().from(userPreferences)
+      .where(and(eq(userPreferences.userId, userId), eq(userPreferences.organizationId, organizationId), eq(userPreferences.key, key), isNull(userPreferences.deletedAt)))
+      .limit(1);
+    return (rows[0] as unknown as UserPreference | undefined) ?? null;
+  }
+}

--- a/src/lib/server/repositories/drizzle-write-off-repository.ts
+++ b/src/lib/server/repositories/drizzle-write-off-repository.ts
@@ -3,7 +3,7 @@
  * `sumByInvoice` summerar i SQL bland icke-raderade.
  */
 
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import type { WriteOff } from "@/lib/shared/schemas/billing";
 import { writeOffs } from "../db/schema";
 import type { AppDb } from "../db/types";
@@ -20,5 +20,13 @@ export class DrizzleWriteOffRepository extends DrizzleRepository<WriteOff> imple
       .select({ total: sql<number>`coalesce(sum(${writeOffs.amount}), 0)` }).from(writeOffs)
       .where(and(eq(writeOffs.invoiceId, invoiceId), isNull(writeOffs.deletedAt)));
     return Number(rows[0]?.total ?? 0);
+  }
+
+  async listByInvoiceIds(invoiceIds: string[]): Promise<WriteOff[]> {
+    if (!invoiceIds.length) return [];
+    const rows = await this.db
+      .select().from(writeOffs)
+      .where(and(inArray(writeOffs.invoiceId, invoiceIds), isNull(writeOffs.deletedAt)));
+    return rows as unknown as WriteOff[];
   }
 }

--- a/src/lib/server/repositories/expected-receivable-repository.ts
+++ b/src/lib/server/repositories/expected-receivable-repository.ts
@@ -1,0 +1,19 @@
+/**
+ * `ExpectedReceivableRepository` (ADR 0020, #409 fan-out) — förväntade
+ * domstolsbetalningar (#173). Org-scopas direkt. Bas-CRUD ärvs.
+ */
+
+import type { ExpectedReceivable } from "@/lib/shared/schemas/billing";
+import type { Repository } from "./types";
+
+export interface ExpectedReceivableListFilter {
+  matterId?: string | undefined;
+  status?: string | undefined;
+}
+
+export interface ExpectedReceivableRepository extends Repository<ExpectedReceivable> {
+  /** Org:ens fordringar (nyaste först), valfritt filtrerade på ärende/status. */
+  listForOrg(organizationId: string, filter?: ExpectedReceivableListFilter): Promise<ExpectedReceivable[]>;
+  /** Fordran by id, org-scopad (null om saknas/annan org/raderad). */
+  getByIdInOrg(id: string, organizationId: string): Promise<ExpectedReceivable | null>;
+}

--- a/src/lib/server/repositories/expense-repository.ts
+++ b/src/lib/server/repositories/expense-repository.ts
@@ -5,7 +5,13 @@
  */
 
 import type { Expense } from "@/lib/shared/schemas/billing";
+import type { ReportMatterRef } from "./time-entry-repository";
 import type { Repository } from "./types";
+
+/** Utlägg för advokatrapporten — med ärende-ref (KLIENT + betalsätt). */
+export interface LawyerReportExpense extends Expense {
+  matter: ReportMatterRef | null;
+}
 
 /** Utlägg + listvyns relationer (motsvarar `expense.list`-routerns include). */
 export interface ExpenseListRow extends Expense {
@@ -41,4 +47,6 @@ export interface ExpenseRepository extends Repository<Expense> {
   listUnfrozenForMatter(matterId: string): Promise<Expense[]>;
   /** Frys alla ofrysta utlägg i ett ärende mot en billing-run (bulk). */
   freezeForMatter(matterId: string, billingRunId: string, now: Date): Promise<void>;
+  /** En advokats utlägg i en period (date asc), med ärende-ref (perLawyer-rapporten). */
+  listForLawyerInPeriod(organizationId: string, userId: string, from: Date, to: Date): Promise<LawyerReportExpense[]>;
 }

--- a/src/lib/server/repositories/expense-repository.ts
+++ b/src/lib/server/repositories/expense-repository.ts
@@ -37,4 +37,8 @@ export interface ExpenseRepository extends Repository<Expense> {
   listUnbilled(matterId: string, ids: string[]): Promise<Expense[]>;
   /** Koppla utlägg till en faktura (sätter invoiceId). No-op vid tomma ids. */
   flagBilled(ids: string[], invoiceId: string): Promise<void>;
+  /** Ofrysta utlägg i ett ärende (date asc) — underlag för billing-run. */
+  listUnfrozenForMatter(matterId: string): Promise<Expense[]>;
+  /** Frys alla ofrysta utlägg i ett ärende mot en billing-run (bulk). */
+  freezeForMatter(matterId: string, billingRunId: string, now: Date): Promise<void>;
 }

--- a/src/lib/server/repositories/in-memory-billing-run-repository.ts
+++ b/src/lib/server/repositories/in-memory-billing-run-repository.ts
@@ -1,0 +1,53 @@
+/**
+ * In-memory `BillingRunRepository` (ADR 0020) — browser/offline-impl.
+ * Org-scopning via samma relations-where routern använde (`matter`).
+ */
+
+import type { BillingRun } from "@/lib/shared/schemas/billing";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type {
+  BillingRunDetailRow, BillingRunListRow, BillingRunRepository,
+} from "./billing-run-repository";
+import { InMemoryRepository } from "./in-memory-repository";
+
+export type BillingRunRepoSource = Pick<IDataStore, "billingRuns">;
+
+export class InMemoryBillingRunRepository
+  extends InMemoryRepository<BillingRun>
+  implements BillingRunRepository {
+  constructor(store: BillingRunRepoSource, now?: () => Date) {
+    super(store.billingRuns as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async listForOrg(organizationId: string, matterId?: string): Promise<BillingRunListRow[]> {
+    return (await this.delegate.findMany({
+      where: { ...(matterId ? { matterId } : {}), matter: { organizationId } },
+      orderBy: { createdAt: "desc" },
+      include: { invoice: { select: { id: true, invoiceNumber: true, status: true } } },
+    })) as BillingRunListRow[];
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<BillingRunDetailRow | null> {
+    const row = (await this.delegate.findFirst({
+      where: { id, matter: { organizationId } },
+      include: {
+        invoice: { select: { id: true, invoiceNumber: true, status: true, amount: true } },
+        matter: { select: { id: true, matterNumber: true, title: true, paymentMethod: true } },
+      },
+    })) as (BillingRunDetailRow & { deletedAt?: unknown }) | null;
+    return row && !row.deletedAt ? row : null;
+  }
+
+  async listAccontoSent(matterId: string): Promise<BillingRun[]> {
+    return (await this.delegate.findMany({
+      where: { matterId, type: "ACCONTO", status: "SENT" },
+    })) as BillingRun[];
+  }
+
+  async listAccontoByIds(matterId: string, ids: string[]): Promise<BillingRun[]> {
+    if (!ids.length) return [];
+    return (await this.delegate.findMany({
+      where: { id: { in: ids }, matterId, type: "ACCONTO" },
+    })) as BillingRun[];
+  }
+}

--- a/src/lib/server/repositories/in-memory-conflict-check-repository.ts
+++ b/src/lib/server/repositories/in-memory-conflict-check-repository.ts
@@ -1,0 +1,31 @@
+/**
+ * In-memory `ConflictCheckRepository` (ADR 0020) — browser/offline-impl.
+ */
+
+import type { ConflictCheck } from "@/lib/shared/schemas/misc";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { ConflictCheckRepository, ConflictCheckRow } from "./conflict-check-repository";
+import { InMemoryRepository } from "./in-memory-repository";
+
+export type ConflictCheckRepoSource = Pick<IDataStore, "conflictChecks">;
+
+export class InMemoryConflictCheckRepository
+  extends InMemoryRepository<ConflictCheck>
+  implements ConflictCheckRepository {
+  constructor(store: ConflictCheckRepoSource, now?: () => Date) {
+    super(store.conflictChecks as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async listHistory(page: number, pageSize: number): Promise<{ checks: ConflictCheckRow[]; total: number }> {
+    const [checks, total] = await Promise.all([
+      this.delegate.findMany({
+        orderBy: { createdAt: "desc" },
+        skip: (page - 1) * pageSize,
+        take: pageSize,
+        include: { checkedBy: { select: { name: true } } },
+      }) as Promise<ConflictCheckRow[]>,
+      this.delegate.count({}),
+    ]);
+    return { checks, total };
+  }
+}

--- a/src/lib/server/repositories/in-memory-contact-repository.ts
+++ b/src/lib/server/repositories/in-memory-contact-repository.ts
@@ -62,4 +62,12 @@ export class InMemoryContactRepository extends InMemoryRepository<Contact> imple
     })) as ContactFull | null;
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }
+
+  async findByPersonalNumber(organizationId: string, personalNumber: string): Promise<Contact | null> {
+    return (await this.delegate.findFirst({ where: { personalNumber, organizationId } })) as Contact | null;
+  }
+
+  async findByOrgNumber(organizationId: string, orgNumber: string): Promise<Contact | null> {
+    return (await this.delegate.findFirst({ where: { orgNumber, organizationId } })) as Contact | null;
+  }
 }

--- a/src/lib/server/repositories/in-memory-document-folder-repository.ts
+++ b/src/lib/server/repositories/in-memory-document-folder-repository.ts
@@ -1,0 +1,43 @@
+/**
+ * In-memory `DocumentFolderRepository` (ADR 0020) — browser/offline-impl.
+ * `_count` (documents/children) resolveras via relations.ts.
+ */
+
+import type { DocumentFolder } from "@/lib/shared/schemas/document";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type {
+  DocumentFolderRepository, DocumentFolderWithCounts,
+} from "./document-folder-repository";
+import { InMemoryRepository } from "./in-memory-repository";
+
+export type DocumentFolderRepoSource = Pick<IDataStore, "documentFolders">;
+
+export class InMemoryDocumentFolderRepository
+  extends InMemoryRepository<DocumentFolder>
+  implements DocumentFolderRepository {
+  constructor(store: DocumentFolderRepoSource, now?: () => Date) {
+    super(store.documentFolders as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async listInParent(matterId: string, parentId: string | null): Promise<DocumentFolderWithCounts[]> {
+    return (await this.delegate.findMany({
+      where: { matterId, parentId },
+      orderBy: { name: "asc" },
+      include: { _count: { select: { documents: true, children: true } } },
+    })) as DocumentFolderWithCounts[];
+  }
+
+  async listByMatter(matterId: string): Promise<DocumentFolder[]> {
+    return (await this.delegate.findMany({
+      where: { matterId },
+      orderBy: { name: "asc" },
+    })) as DocumentFolder[];
+  }
+
+  async reassignParent(fromParentId: string, toParentId: string | null): Promise<void> {
+    await this.delegate.updateMany({
+      where: { parentId: fromParentId },
+      data: { parentId: toParentId } as Partial<DocumentFolder>,
+    });
+  }
+}

--- a/src/lib/server/repositories/in-memory-document-repository.ts
+++ b/src/lib/server/repositories/in-memory-document-repository.ts
@@ -1,0 +1,75 @@
+/**
+ * In-memory `DocumentRepository` (ADR 0020) — browser/offline-impl. Delegerar
+ * till query-engine:n (uploadedBy/matter-relations registrerade i relations.ts).
+ */
+
+import type { Document } from "@/lib/shared/schemas/document";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type {
+  DocumentAccessRow, DocumentListRow, DocumentRepository,
+} from "./document-repository";
+import { InMemoryRepository } from "./in-memory-repository";
+
+export type DocumentRepoSource = Pick<IDataStore, "documents">;
+
+export class InMemoryDocumentRepository
+  extends InMemoryRepository<Document>
+  implements DocumentRepository {
+  constructor(store: DocumentRepoSource, now?: () => Date) {
+    super(store.documents as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async listInFolder(
+    matterId: string, folderId: string | null, page: number, pageSize: number,
+  ): Promise<{ documents: DocumentListRow[]; total: number }> {
+    const where = { matterId, folderId };
+    const [documents, total] = await Promise.all([
+      this.delegate.findMany({
+        where,
+        orderBy: { createdAt: "desc" },
+        skip: (page - 1) * pageSize,
+        take: pageSize,
+        include: { uploadedBy: { select: { name: true } } },
+      }) as Promise<DocumentListRow[]>,
+      this.delegate.count({ where }),
+    ]);
+    return { documents, total };
+  }
+
+  async listByMatter(matterId: string): Promise<DocumentListRow[]> {
+    return (await this.delegate.findMany({
+      where: { matterId },
+      orderBy: { createdAt: "desc" },
+      include: { uploadedBy: { select: { name: true } } },
+    })) as DocumentListRow[];
+  }
+
+  async listDocumentTypesForOrg(organizationId: string): Promise<Array<{ type: string; count: number }>> {
+    const docs = (await this.delegate.findMany({
+      where: { matter: { organizationId } },
+    })) as Array<{ documentType?: string | null }>;
+    const counts = new Map<string, number>();
+    for (const d of docs) {
+      if (!d.documentType) continue;
+      counts.set(d.documentType, (counts.get(d.documentType) ?? 0) + 1);
+    }
+    return [...counts.entries()]
+      .map(([type, count]) => ({ type, count }))
+      .sort((a, b) => a.type.localeCompare(b.type, "sv"));
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<DocumentAccessRow | null> {
+    const row = (await this.delegate.findFirst({
+      where: { id, matter: { organizationId } },
+      select: { id: true, matterId: true, deletedAt: true },
+    })) as (DocumentAccessRow & { deletedAt?: unknown }) | null;
+    return row && !row.deletedAt ? { id: row.id, matterId: row.matterId } : null;
+  }
+
+  async reassignFolder(fromFolderId: string, toFolderId: string | null): Promise<void> {
+    await this.delegate.updateMany({
+      where: { folderId: fromFolderId },
+      data: { folderId: toFolderId } as Partial<Document>,
+    });
+  }
+}

--- a/src/lib/server/repositories/in-memory-document-suggestion-repository.ts
+++ b/src/lib/server/repositories/in-memory-document-suggestion-repository.ts
@@ -1,0 +1,57 @@
+/**
+ * In-memory `DocumentSuggestionRepository` (ADR 0020) — browser/offline-impl.
+ * document→matter-relations registrerade i relations.ts.
+ */
+
+import type { DocumentAnalysisSuggestion } from "@/lib/shared/schemas/document";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type {
+  DocumentSuggestionRepository, SuggestionListRow, SuggestionWithMatter,
+} from "./document-suggestion-repository";
+import { InMemoryRepository } from "./in-memory-repository";
+
+export type DocumentSuggestionRepoSource = Pick<IDataStore, "documentAnalysisSuggestions">;
+
+export class InMemoryDocumentSuggestionRepository
+  extends InMemoryRepository<DocumentAnalysisSuggestion>
+  implements DocumentSuggestionRepository {
+  constructor(store: DocumentSuggestionRepoSource, now?: () => Date) {
+    super(store.documentAnalysisSuggestions as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<SuggestionWithMatter | null> {
+    return (await this.delegate.findFirst({
+      where: { id, document: { matter: { organizationId } } },
+      include: { document: { select: { matterId: true } } },
+    })) as SuggestionWithMatter | null;
+  }
+
+  async listPendingForMatter(matterId: string, organizationId: string, order: "asc" | "desc"): Promise<SuggestionListRow[]> {
+    return (await this.delegate.findMany({
+      where: { status: "PENDING", document: { matterId, matter: { organizationId } } },
+      include: { document: { select: { id: true, fileName: true, title: true } } },
+      orderBy: { createdAt: order },
+    })) as SuggestionListRow[];
+  }
+
+  async listPendingByIds(ids: string[], organizationId: string): Promise<SuggestionWithMatter[]> {
+    if (!ids.length) return [];
+    return (await this.delegate.findMany({
+      where: { id: { in: ids }, status: "PENDING", document: { matter: { organizationId } } },
+      include: { document: { select: { matterId: true } } },
+    })) as SuggestionWithMatter[];
+  }
+
+  async listByIdsInOrg(ids: string[], organizationId: string): Promise<Array<{ id: string }>> {
+    if (!ids.length) return [];
+    return (await this.delegate.findMany({
+      where: { id: { in: ids }, document: { matter: { organizationId } } },
+      select: { id: true },
+    })) as Array<{ id: string }>;
+  }
+
+  async updateManyByIds(ids: string[], patch: Partial<DocumentAnalysisSuggestion>): Promise<void> {
+    if (!ids.length) return;
+    await this.delegate.updateMany({ where: { id: { in: ids } }, data: patch });
+  }
+}

--- a/src/lib/server/repositories/in-memory-document-template-repository.ts
+++ b/src/lib/server/repositories/in-memory-document-template-repository.ts
@@ -1,0 +1,39 @@
+/**
+ * In-memory `DocumentTemplateRepository` (ADR 0020) — browser/offline-impl.
+ */
+
+import type { DocumentTemplate } from "@/lib/shared/schemas/misc";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type {
+  DocumentTemplateListRow, DocumentTemplateRepository, DocumentTemplateRow,
+} from "./document-template-repository";
+import { InMemoryRepository } from "./in-memory-repository";
+
+export type DocumentTemplateRepoSource = Pick<IDataStore, "documentTemplates">;
+
+export class InMemoryDocumentTemplateRepository
+  extends InMemoryRepository<DocumentTemplate>
+  implements DocumentTemplateRepository {
+  constructor(store: DocumentTemplateRepoSource, now?: () => Date) {
+    super(store.documentTemplates as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async listForOrg(organizationId: string): Promise<DocumentTemplateListRow[]> {
+    return (await this.delegate.findMany({
+      where: { organizationId },
+      select: {
+        id: true, name: true, description: true, category: true,
+        createdAt: true, updatedAt: true, createdBy: { select: { name: true } },
+      },
+      orderBy: [{ category: "asc" }, { name: "asc" }],
+    })) as DocumentTemplateListRow[];
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<DocumentTemplateRow | null> {
+    const row = (await this.delegate.findFirst({
+      where: { id, organizationId },
+      include: { createdBy: { select: { name: true } } },
+    })) as DocumentTemplateRow | null;
+    return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
+  }
+}

--- a/src/lib/server/repositories/in-memory-expected-receivable-repository.ts
+++ b/src/lib/server/repositories/in-memory-expected-receivable-repository.ts
@@ -1,0 +1,34 @@
+/**
+ * In-memory `ExpectedReceivableRepository` (ADR 0020) — browser/offline-impl.
+ */
+
+import type { ExpectedReceivable } from "@/lib/shared/schemas/billing";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { ExpectedReceivableListFilter, ExpectedReceivableRepository } from "./expected-receivable-repository";
+import { InMemoryRepository } from "./in-memory-repository";
+
+export type ExpectedReceivableRepoSource = Pick<IDataStore, "expectedReceivables">;
+
+export class InMemoryExpectedReceivableRepository
+  extends InMemoryRepository<ExpectedReceivable>
+  implements ExpectedReceivableRepository {
+  constructor(store: ExpectedReceivableRepoSource, now?: () => Date) {
+    super(store.expectedReceivables as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async listForOrg(organizationId: string, filter?: ExpectedReceivableListFilter): Promise<ExpectedReceivable[]> {
+    return (await this.delegate.findMany({
+      where: {
+        organizationId,
+        ...(filter?.matterId ? { matterId: filter.matterId } : {}),
+        ...(filter?.status ? { status: filter.status } : {}),
+      },
+      orderBy: { createdAt: "desc" },
+    })) as ExpectedReceivable[];
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<ExpectedReceivable | null> {
+    const row = (await this.delegate.findFirst({ where: { id, organizationId } })) as ExpectedReceivable | null;
+    return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
+  }
+}

--- a/src/lib/server/repositories/in-memory-expense-repository.ts
+++ b/src/lib/server/repositories/in-memory-expense-repository.ts
@@ -56,4 +56,17 @@ export class InMemoryExpenseRepository extends InMemoryRepository<Expense> imple
     if (!ids.length) return;
     await this.delegate.updateMany({ where: { id: { in: ids } }, data: { invoiceId } as Partial<Expense> });
   }
+
+  async listUnfrozenForMatter(matterId: string): Promise<Expense[]> {
+    return (await this.delegate.findMany({
+      where: { matterId, frozenByBillingRunId: null }, orderBy: { date: "asc" },
+    })) as Expense[];
+  }
+
+  async freezeForMatter(matterId: string, billingRunId: string, now: Date): Promise<void> {
+    await this.delegate.updateMany({
+      where: { matterId, frozenByBillingRunId: null },
+      data: { frozenAt: now, frozenByBillingRunId: billingRunId } as Partial<Expense>,
+    });
+  }
 }

--- a/src/lib/server/repositories/in-memory-expense-repository.ts
+++ b/src/lib/server/repositories/in-memory-expense-repository.ts
@@ -5,7 +5,9 @@
 
 import type { Expense } from "@/lib/shared/schemas/billing";
 import type { Delegate, IDataStore } from "../data-store/IDataStore";
-import type { ExpenseListOptions, ExpenseListResult, ExpenseListRow, ExpenseRepository } from "./expense-repository";
+import type {
+  ExpenseListOptions, ExpenseListResult, ExpenseListRow, ExpenseRepository, LawyerReportExpense,
+} from "./expense-repository";
 import { InMemoryRepository } from "./in-memory-repository";
 
 /** Delegaten repot behöver — uppfylls av `IDataStore`, `DataStoreTx` och `LocalStore`. */
@@ -68,5 +70,15 @@ export class InMemoryExpenseRepository extends InMemoryRepository<Expense> imple
       where: { matterId, frozenByBillingRunId: null },
       data: { frozenAt: now, frozenByBillingRunId: billingRunId } as Partial<Expense>,
     });
+  }
+
+  async listForLawyerInPeriod(
+    organizationId: string, userId: string, from: Date, to: Date,
+  ): Promise<LawyerReportExpense[]> {
+    return (await this.delegate.findMany({
+      where: { matter: { organizationId }, userId, date: { gte: from, lte: to } },
+      include: { matter: { include: { contacts: { where: { role: "KLIENT" }, include: { contact: { select: { name: true } } }, take: 1 } } } },
+      orderBy: { date: "asc" },
+    })) as LawyerReportExpense[];
   }
 }

--- a/src/lib/server/repositories/in-memory-invoice-dispatch-repository.ts
+++ b/src/lib/server/repositories/in-memory-invoice-dispatch-repository.ts
@@ -1,0 +1,33 @@
+/**
+ * In-memory `InvoiceDispatchRepository` (ADR 0020) — browser/offline-impl.
+ */
+
+import type { InvoiceDispatch } from "@/lib/shared/schemas/billing";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import { InMemoryRepository } from "./in-memory-repository";
+import type { InvoiceDispatchQueuedRow, InvoiceDispatchRepository } from "./invoice-dispatch-repository";
+
+export type InvoiceDispatchRepoSource = Pick<IDataStore, "invoiceDispatches">;
+
+export class InMemoryInvoiceDispatchRepository
+  extends InMemoryRepository<InvoiceDispatch>
+  implements InvoiceDispatchRepository {
+  constructor(store: InvoiceDispatchRepoSource, now?: () => Date) {
+    super(store.invoiceDispatches as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async listByInvoice(invoiceId: string): Promise<InvoiceDispatch[]> {
+    return (await this.delegate.findMany({
+      where: { invoiceId },
+      orderBy: { queuedAt: "desc" },
+    })) as InvoiceDispatch[];
+  }
+
+  async listQueuedForOrg(organizationId: string): Promise<InvoiceDispatchQueuedRow[]> {
+    return (await this.delegate.findMany({
+      where: { status: "queued", invoice: { matter: { organizationId } } },
+      include: { invoice: { select: { id: true, invoiceNumber: true, amount: true, ocrReference: true, dueDate: true } } },
+      orderBy: { queuedAt: "asc" },
+    })) as InvoiceDispatchQueuedRow[];
+  }
+}

--- a/src/lib/server/repositories/in-memory-matter-contact-repository.ts
+++ b/src/lib/server/repositories/in-memory-matter-contact-repository.ts
@@ -4,6 +4,7 @@
  * KLIENT-kontakt); matterContacts-relations registrerade i relations.ts.
  */
 
+import type { Contact } from "@/lib/shared/schemas/contact";
 import type { MatterContact } from "@/lib/shared/schemas/matter";
 import type { Delegate, IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
@@ -49,5 +50,16 @@ export class InMemoryMatterContactRepository
   async linkContact(data: Partial<MatterContact>): Promise<MatterContactWithContact> {
     // create enrichar raden med contact (LocalStore.enrichRowForEntity).
     return (await this.create(data)) as unknown as MatterContactWithContact;
+  }
+
+  async findLink(matterId: string, contactId: string, role: string): Promise<MatterContact | null> {
+    return (await this.delegate.findFirst({ where: { matterId, contactId, role } })) as MatterContact | null;
+  }
+
+  async listContactsForMatter(matterId: string): Promise<Contact[]> {
+    const rows = (await this.delegate.findMany({
+      where: { matterId }, include: { contact: true },
+    })) as Array<{ contact: Contact }>;
+    return rows.map((r) => r.contact).filter(Boolean);
   }
 }

--- a/src/lib/server/repositories/in-memory-matter-contact-repository.ts
+++ b/src/lib/server/repositories/in-memory-matter-contact-repository.ts
@@ -1,0 +1,39 @@
+/**
+ * In-memory `MatterContactRepository` (ADR 0020) — browser/offline-impl.
+ * Använder samma include som tidigare conflict-routern (contact + matter inkl.
+ * KLIENT-kontakt); matterContacts-relations registrerade i relations.ts.
+ */
+
+import type { MatterContact } from "@/lib/shared/schemas/matter";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import { InMemoryRepository } from "./in-memory-repository";
+import type { ConflictContactRow, MatterContactRepository } from "./matter-contact-repository";
+
+export type MatterContactRepoSource = Pick<IDataStore, "matterContacts">;
+
+const MC_INCLUDE = {
+  contact: true,
+  matter: {
+    include: {
+      contacts: { where: { role: "KLIENT" }, include: { contact: { select: { name: true } } }, take: 1 },
+    },
+  },
+} as const;
+
+export class InMemoryMatterContactRepository
+  extends InMemoryRepository<MatterContact>
+  implements MatterContactRepository {
+  constructor(store: MatterContactRepoSource, now?: () => Date) {
+    super(store.matterContacts as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async findForConflict(organizationId: string, numberTerm?: string): Promise<ConflictContactRow[]> {
+    const where = numberTerm
+      ? {
+          matter: { organizationId },
+          contact: { OR: [{ personalNumber: { contains: numberTerm } }, { orgNumber: { contains: numberTerm } }] },
+        }
+      : { matter: { organizationId } };
+    return (await this.delegate.findMany({ where, include: MC_INCLUDE })) as ConflictContactRow[];
+  }
+}

--- a/src/lib/server/repositories/in-memory-matter-contact-repository.ts
+++ b/src/lib/server/repositories/in-memory-matter-contact-repository.ts
@@ -7,7 +7,9 @@
 import type { MatterContact } from "@/lib/shared/schemas/matter";
 import type { Delegate, IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
-import type { ConflictContactRow, MatterContactRepository } from "./matter-contact-repository";
+import type {
+  ConflictContactRow, MatterContactRepository, MatterContactWithContact,
+} from "./matter-contact-repository";
 
 export type MatterContactRepoSource = Pick<IDataStore, "matterContacts">;
 
@@ -35,5 +37,17 @@ export class InMemoryMatterContactRepository
         }
       : { matter: { organizationId } };
     return (await this.delegate.findMany({ where, include: MC_INCLUDE })) as ConflictContactRow[];
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<MatterContact | null> {
+    const row = (await this.delegate.findFirst({
+      where: { id, matter: { organizationId } },
+    })) as (MatterContact & { deletedAt?: unknown }) | null;
+    return row && !row.deletedAt ? row : null;
+  }
+
+  async linkContact(data: Partial<MatterContact>): Promise<MatterContactWithContact> {
+    // create enrichar raden med contact (LocalStore.enrichRowForEntity).
+    return (await this.create(data)) as unknown as MatterContactWithContact;
   }
 }

--- a/src/lib/server/repositories/in-memory-matter-event-suggestion-repository.ts
+++ b/src/lib/server/repositories/in-memory-matter-event-suggestion-repository.ts
@@ -1,0 +1,39 @@
+/**
+ * In-memory `MatterEventSuggestionRepository` (ADR 0020) — browser/offline-impl.
+ * document/matter-relations registrerade i relations.ts.
+ */
+
+import type { MatterEventSuggestion } from "@/lib/shared/schemas/document";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import { InMemoryRepository } from "./in-memory-repository";
+import type {
+  MatterEventSuggestionRepository, MatterEventSuggestionRow,
+} from "./matter-event-suggestion-repository";
+
+export type MatterEventSuggestionRepoSource = Pick<IDataStore, "matterEventSuggestions">;
+
+export class InMemoryMatterEventSuggestionRepository
+  extends InMemoryRepository<MatterEventSuggestion>
+  implements MatterEventSuggestionRepository {
+  constructor(store: MatterEventSuggestionRepoSource, now?: () => Date) {
+    super(store.matterEventSuggestions as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async listForMatter(matterId: string, organizationId: string): Promise<MatterEventSuggestionRow[]> {
+    return (await this.delegate.findMany({
+      where: {
+        status: { not: "REJECTED" },
+        document: { matterId, matter: { organizationId } },
+      },
+      include: { document: { select: { id: true, fileName: true, title: true } } },
+      orderBy: { startAt: "asc" },
+    })) as MatterEventSuggestionRow[];
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<MatterEventSuggestion | null> {
+    const row = (await this.delegate.findFirst({
+      where: { id, document: { matter: { organizationId } } },
+    })) as (MatterEventSuggestion & { deletedAt?: unknown }) | null;
+    return row && !row.deletedAt ? row : null;
+  }
+}

--- a/src/lib/server/repositories/in-memory-matter-repository.ts
+++ b/src/lib/server/repositories/in-memory-matter-repository.ts
@@ -6,10 +6,31 @@
 import type { Matter } from "@/lib/shared/schemas/matter";
 import type { Delegate, IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
-import type { MatterRepository } from "./matter-repository";
+import type {
+  MatterDetailRow, MatterListFilter, MatterListResult, MatterListRow, MatterRepository,
+} from "./matter-repository";
 
 /** Delegaten repot behöver — uppfylls av `IDataStore`, `DataStoreTx` och `LocalStore`. */
 export type MatterRepoSource = Pick<IDataStore, "matters">;
+
+/** Org-scopat where för listan (replikerar routerns Prisma-where). */
+function listWhere(organizationId: string, f: MatterListFilter): Record<string, unknown> {
+  const ins = (s: string) => ({ contains: s, mode: "insensitive" as const });
+  return {
+    organizationId,
+    ...(f.status ? { status: f.status } : {}),
+    ...(f.employeeId ? { timeEntries: { some: { userId: f.employeeId } } } : {}),
+    ...(f.search
+      ? {
+          OR: [
+            { title: ins(f.search) },
+            { matterNumber: ins(f.search) },
+            { contacts: { some: { contact: { name: ins(f.search) } } } },
+          ],
+        }
+      : {}),
+  };
+}
 
 export class InMemoryMatterRepository extends InMemoryRepository<Matter> implements MatterRepository {
   constructor(store: MatterRepoSource, now?: () => Date) {
@@ -24,5 +45,44 @@ export class InMemoryMatterRepository extends InMemoryRepository<Matter> impleme
   async listByOrg(organizationId: string): Promise<Matter[]> {
     const rows = (await this.delegate.findMany({ where: { organizationId } })) as Matter[];
     return rows.filter((r) => !(r as { deletedAt?: unknown }).deletedAt);
+  }
+
+  async listForOrg(organizationId: string, filter: MatterListFilter): Promise<MatterListResult> {
+    const where = listWhere(organizationId, filter);
+    const [matters, total] = await Promise.all([
+      this.delegate.findMany({
+        where,
+        orderBy: { createdAt: "desc" },
+        skip: (filter.page - 1) * filter.pageSize,
+        take: filter.pageSize,
+        include: {
+          contacts: { where: { role: "KLIENT" }, include: { contact: { select: { id: true, name: true } } }, take: 1 },
+          _count: { select: { documents: true, timeEntries: true, contacts: true } },
+        },
+      }) as Promise<MatterListRow[]>,
+      this.delegate.count({ where }),
+    ]);
+    return { matters, total };
+  }
+
+  async getByIdWithContacts(id: string, organizationId: string): Promise<MatterDetailRow | null> {
+    const row = (await this.delegate.findFirst({
+      where: { id, organizationId },
+      include: {
+        contacts: { include: { contact: true }, orderBy: { createdAt: "asc" } },
+        _count: { select: { documents: true, timeEntries: true, emails: true } },
+      },
+    })) as (MatterDetailRow & { deletedAt?: unknown }) | null;
+    return row && !row.deletedAt ? row : null;
+  }
+
+  async listByResponsibleLawyer(organizationId: string, responsibleLawyerId: string): Promise<Matter[]> {
+    return (await this.delegate.findMany({ where: { organizationId, responsibleLawyerId } })) as Matter[];
+  }
+
+  async listByNumberPrefix(organizationId: string, prefix: string): Promise<Matter[]> {
+    return (await this.delegate.findMany({
+      where: { organizationId, matterNumber: { startsWith: prefix } },
+    })) as Matter[];
   }
 }

--- a/src/lib/server/repositories/in-memory-matter-repository.ts
+++ b/src/lib/server/repositories/in-memory-matter-repository.ts
@@ -20,4 +20,9 @@ export class InMemoryMatterRepository extends InMemoryRepository<Matter> impleme
     const row = (await this.delegate.findFirst({ where: { id, organizationId } })) as Matter | null;
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }
+
+  async listByOrg(organizationId: string): Promise<Matter[]> {
+    const rows = (await this.delegate.findMany({ where: { organizationId } })) as Matter[];
+    return rows.filter((r) => !(r as { deletedAt?: unknown }).deletedAt);
+  }
 }

--- a/src/lib/server/repositories/in-memory-office-repository.ts
+++ b/src/lib/server/repositories/in-memory-office-repository.ts
@@ -1,0 +1,35 @@
+/**
+ * In-memory `OfficeRepository` (ADR 0020) — browser/offline-impl.
+ */
+
+import type { Office } from "@/lib/shared/schemas/organization";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import { InMemoryRepository } from "./in-memory-repository";
+import type { OfficeRepository } from "./office-repository";
+
+export type OfficeRepoSource = Pick<IDataStore, "offices">;
+
+export class InMemoryOfficeRepository extends InMemoryRepository<Office> implements OfficeRepository {
+  constructor(store: OfficeRepoSource, now?: () => Date) {
+    super(store.offices as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async listByOrg(organizationId: string): Promise<Office[]> {
+    return (await this.delegate.findMany({
+      where: { organizationId },
+      orderBy: [{ isMain: "desc" }, { name: "asc" }],
+    })) as Office[];
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<Office | null> {
+    const row = (await this.delegate.findFirst({ where: { id, organizationId } })) as Office | null;
+    return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
+  }
+
+  async demoteMains(organizationId: string): Promise<void> {
+    await this.delegate.updateMany({
+      where: { organizationId, isMain: true },
+      data: { isMain: false } as Partial<Office>,
+    });
+  }
+}

--- a/src/lib/server/repositories/in-memory-org-preference-repository.ts
+++ b/src/lib/server/repositories/in-memory-org-preference-repository.ts
@@ -1,0 +1,23 @@
+/** In-memory `OrgPreferenceRepository` (ADR 0020). */
+
+import type { OrgPreference } from "@/lib/shared/schemas/preference";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import { InMemoryRepository } from "./in-memory-repository";
+import type { OrgPreferenceRepository, OrgPreferenceRow } from "./org-preference-repository";
+
+export type OrgPreferenceRepoSource = Pick<IDataStore, "orgPreferences">;
+
+export class InMemoryOrgPreferenceRepository extends InMemoryRepository<OrgPreferenceRow> implements OrgPreferenceRepository {
+  constructor(store: OrgPreferenceRepoSource, now?: () => Date) {
+    super(store.orgPreferences as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async getByOrgKey(organizationId: string, key: string): Promise<OrgPreference | null> {
+    const row = (await this.delegate.findFirst({ where: { organizationId, key } })) as OrgPreference | null;
+    return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
+  }
+
+  async listByOrg(organizationId: string): Promise<OrgPreference[]> {
+    return (await this.delegate.findMany({ where: { organizationId }, orderBy: { key: "asc" } })) as OrgPreference[];
+  }
+}

--- a/src/lib/server/repositories/in-memory-organization-repository.ts
+++ b/src/lib/server/repositories/in-memory-organization-repository.ts
@@ -1,0 +1,16 @@
+/**
+ * In-memory `OrganizationRepository` (ADR 0020) — endast bas-CRUD.
+ */
+
+import type { Organization } from "@/lib/shared/schemas/organization";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import { InMemoryRepository } from "./in-memory-repository";
+import type { OrganizationRepository } from "./organization-repository";
+
+export type OrganizationRepoSource = Pick<IDataStore, "organizations">;
+
+export class InMemoryOrganizationRepository extends InMemoryRepository<Organization> implements OrganizationRepository {
+  constructor(store: OrganizationRepoSource, now?: () => Date) {
+    super(store.organizations as unknown as Delegate, now ?? (() => new Date()));
+  }
+}

--- a/src/lib/server/repositories/in-memory-payment-plan-reminder-repository.ts
+++ b/src/lib/server/repositories/in-memory-payment-plan-reminder-repository.ts
@@ -1,0 +1,18 @@
+/**
+ * In-memory `PaymentPlanReminderRepository` (ADR 0020) — browser/offline-impl.
+ */
+
+import type { PaymentPlanReminder } from "@/lib/shared/schemas/billing";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import { InMemoryRepository } from "./in-memory-repository";
+import type { PaymentPlanReminderRepository } from "./payment-plan-reminder-repository";
+
+export type PaymentPlanReminderRepoSource = Pick<IDataStore, "paymentPlanReminders">;
+
+export class InMemoryPaymentPlanReminderRepository
+  extends InMemoryRepository<PaymentPlanReminder>
+  implements PaymentPlanReminderRepository {
+  constructor(store: PaymentPlanReminderRepoSource, now?: () => Date) {
+    super(store.paymentPlanReminders as unknown as Delegate, now ?? (() => new Date()));
+  }
+}

--- a/src/lib/server/repositories/in-memory-payment-plan-repository.ts
+++ b/src/lib/server/repositories/in-memory-payment-plan-repository.ts
@@ -2,15 +2,39 @@
  * In-memory `PaymentPlanRepository` (ADR 0020) — browser/offline-impl. Ärver
  * bas-CRUD från `InMemoryRepository` (delegerar till LocalStore/query-engine);
  * org-scopningen sker via samma relations-where routern använde (`invoice.matter`).
+ * Joinade läsningar speglar router-includen (faktura/ärende/KLIENT/betalningar).
  */
 
 import type { PaymentPlan } from "@/lib/shared/schemas/billing";
 import type { Delegate, IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
-import type { PaymentPlanRepository } from "./payment-plan-repository";
+import type {
+  JoinedPaymentPlan, JoinedPaymentPlanWithReminders, PaymentPlanRepository,
+} from "./payment-plan-repository";
 
 /** Delegaten repot behöver — uppfylls av `IDataStore`, `DataStoreTx` och `LocalStore`. */
 export type PaymentPlanRepoSource = Pick<IDataStore, "paymentPlans">;
+
+/** KLIENT-kontakt (namn) + betalningar + avskrivningar — list/detalj. */
+const INVOICE_INCLUDE = {
+  matter: {
+    include: {
+      contacts: { where: { role: "KLIENT" }, include: { contact: { select: { id: true, name: true } } }, take: 1 },
+    },
+  },
+  payments: { orderBy: { paidAt: "desc" } },
+  writeOffs: true,
+} as const;
+
+/** Scan behöver KLIENT-email (mottagare) + betalningar (utan order). */
+const SCAN_INVOICE_INCLUDE = {
+  payments: true,
+  matter: {
+    include: {
+      contacts: { where: { role: "KLIENT" }, include: { contact: { select: { id: true, name: true, email: true } } }, take: 1 },
+    },
+  },
+} as const;
 
 export class InMemoryPaymentPlanRepository extends InMemoryRepository<PaymentPlan> implements PaymentPlanRepository {
   constructor(store: PaymentPlanRepoSource, now?: () => Date) {
@@ -26,5 +50,34 @@ export class InMemoryPaymentPlanRepository extends InMemoryRepository<PaymentPla
   async getByInvoiceId(invoiceId: string): Promise<PaymentPlan | null> {
     const row = (await this.delegate.findFirst({ where: { invoiceId } })) as PaymentPlan | null;
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
+  }
+
+  async listForOrg(organizationId: string, status?: string): Promise<JoinedPaymentPlan[]> {
+    return (await this.delegate.findMany({
+      where: { ...(status ? { status } : {}), invoice: { matter: { organizationId } } },
+      orderBy: { createdAt: "desc" },
+      include: { invoice: { include: INVOICE_INCLUDE } },
+    })) as JoinedPaymentPlan[];
+  }
+
+  async getByIdWithDetails(id: string, organizationId: string): Promise<JoinedPaymentPlanWithReminders | null> {
+    const row = (await this.delegate.findFirst({
+      where: { id, invoice: { matter: { organizationId } } },
+      include: {
+        invoice: { include: INVOICE_INCLUDE },
+        reminders: { orderBy: { sentAt: "desc" } },
+      },
+    })) as (JoinedPaymentPlanWithReminders & { deletedAt?: unknown }) | null;
+    return row && !row.deletedAt ? row : null;
+  }
+
+  async listActiveForScan(organizationId: string): Promise<JoinedPaymentPlanWithReminders[]> {
+    return (await this.delegate.findMany({
+      where: { status: "ACTIVE", invoice: { matter: { organizationId } } },
+      include: {
+        invoice: { include: SCAN_INVOICE_INCLUDE },
+        reminders: true,
+      },
+    })) as JoinedPaymentPlanWithReminders[];
   }
 }

--- a/src/lib/server/repositories/in-memory-payment-repository.ts
+++ b/src/lib/server/repositories/in-memory-payment-repository.ts
@@ -22,4 +22,9 @@ export class InMemoryPaymentRepository extends InMemoryRepository<Payment> imple
       .filter((r) => !(r as { deletedAt?: unknown }).deletedAt)
       .reduce((s, p) => s + p.amount, 0);
   }
+
+  async listByInvoiceIds(invoiceIds: string[]): Promise<Payment[]> {
+    if (!invoiceIds.length) return [];
+    return (await this.delegate.findMany({ where: { invoiceId: { in: invoiceIds } } })) as Payment[];
+  }
 }

--- a/src/lib/server/repositories/in-memory-repositories.ts
+++ b/src/lib/server/repositories/in-memory-repositories.ts
@@ -15,6 +15,7 @@ import { InMemoryContactRepository } from "./in-memory-contact-repository";
 import { InMemoryDocumentTemplateRepository } from "./in-memory-document-template-repository";
 import { InMemoryExpectedReceivableRepository } from "./in-memory-expected-receivable-repository";
 import { InMemoryExpenseRepository } from "./in-memory-expense-repository";
+import { InMemoryInvoiceDispatchRepository } from "./in-memory-invoice-dispatch-repository";
 import { InMemoryInvoiceRepository } from "./in-memory-invoice-repository";
 import { InMemoryMatterRepository } from "./in-memory-matter-repository";
 import { InMemoryPaymentPlanRepository } from "./in-memory-payment-plan-repository";
@@ -44,6 +45,7 @@ function reposForTx(tx: DataStoreTx): Repositories {
     serviceNotes: new InMemoryServiceNoteRepository(tx),
     documentTemplates: new InMemoryDocumentTemplateRepository(tx),
     expectedReceivables: new InMemoryExpectedReceivableRepository(tx),
+    invoiceDispatches: new InMemoryInvoiceDispatchRepository(tx),
     transaction: (fn) => fn(repos),
   };
   return repos;
@@ -66,6 +68,7 @@ export function buildInMemoryRepositories(dataStore: IDataStore): Repositories {
     serviceNotes: new InMemoryServiceNoteRepository(dataStore),
     documentTemplates: new InMemoryDocumentTemplateRepository(dataStore),
     expectedReceivables: new InMemoryExpectedReceivableRepository(dataStore),
+    invoiceDispatches: new InMemoryInvoiceDispatchRepository(dataStore),
     transaction: (fn) => dataStore.transaction((tx) => fn(reposForTx(tx))),
   };
 }

--- a/src/lib/server/repositories/in-memory-repositories.ts
+++ b/src/lib/server/repositories/in-memory-repositories.ts
@@ -11,6 +11,7 @@
 import type { DataStoreTx, IDataStore } from "../data-store/IDataStore";
 import { InMemoryAccontoDeductionRepository } from "./in-memory-acconto-deduction-repository";
 import { InMemoryCalendarEventRepository } from "./in-memory-calendar-event-repository";
+import { InMemoryConflictCheckRepository } from "./in-memory-conflict-check-repository";
 import { InMemoryContactRepository } from "./in-memory-contact-repository";
 import { InMemoryDocumentFolderRepository } from "./in-memory-document-folder-repository";
 import { InMemoryDocumentRepository } from "./in-memory-document-repository";
@@ -19,6 +20,7 @@ import { InMemoryExpectedReceivableRepository } from "./in-memory-expected-recei
 import { InMemoryExpenseRepository } from "./in-memory-expense-repository";
 import { InMemoryInvoiceDispatchRepository } from "./in-memory-invoice-dispatch-repository";
 import { InMemoryInvoiceRepository } from "./in-memory-invoice-repository";
+import { InMemoryMatterContactRepository } from "./in-memory-matter-contact-repository";
 import { InMemoryMatterEventSuggestionRepository } from "./in-memory-matter-event-suggestion-repository";
 import { InMemoryMatterRepository } from "./in-memory-matter-repository";
 import { InMemoryOfficeRepository } from "./in-memory-office-repository";
@@ -46,6 +48,8 @@ function reposForTx(tx: DataStoreTx): Repositories {
     expenses: new InMemoryExpenseRepository(tx),
     accontoDeductions: new InMemoryAccontoDeductionRepository(tx),
     contacts: new InMemoryContactRepository(tx),
+    matterContacts: new InMemoryMatterContactRepository(tx),
+    conflictChecks: new InMemoryConflictCheckRepository(tx),
     users: new InMemoryUserRepository(tx),
     tasks: new InMemoryTaskRepository(tx),
     calendarEvents: new InMemoryCalendarEventRepository(tx),
@@ -76,6 +80,8 @@ export function buildInMemoryRepositories(dataStore: IDataStore): Repositories {
     expenses: new InMemoryExpenseRepository(dataStore),
     accontoDeductions: new InMemoryAccontoDeductionRepository(dataStore),
     contacts: new InMemoryContactRepository(dataStore),
+    matterContacts: new InMemoryMatterContactRepository(dataStore),
+    conflictChecks: new InMemoryConflictCheckRepository(dataStore),
     users: new InMemoryUserRepository(dataStore),
     tasks: new InMemoryTaskRepository(dataStore),
     calendarEvents: new InMemoryCalendarEventRepository(dataStore),

--- a/src/lib/server/repositories/in-memory-repositories.ts
+++ b/src/lib/server/repositories/in-memory-repositories.ts
@@ -12,6 +12,8 @@ import type { DataStoreTx, IDataStore } from "../data-store/IDataStore";
 import { InMemoryAccontoDeductionRepository } from "./in-memory-acconto-deduction-repository";
 import { InMemoryCalendarEventRepository } from "./in-memory-calendar-event-repository";
 import { InMemoryContactRepository } from "./in-memory-contact-repository";
+import { InMemoryDocumentFolderRepository } from "./in-memory-document-folder-repository";
+import { InMemoryDocumentRepository } from "./in-memory-document-repository";
 import { InMemoryDocumentTemplateRepository } from "./in-memory-document-template-repository";
 import { InMemoryExpectedReceivableRepository } from "./in-memory-expected-receivable-repository";
 import { InMemoryExpenseRepository } from "./in-memory-expense-repository";
@@ -47,6 +49,8 @@ function reposForTx(tx: DataStoreTx): Repositories {
     tasks: new InMemoryTaskRepository(tx),
     calendarEvents: new InMemoryCalendarEventRepository(tx),
     serviceNotes: new InMemoryServiceNoteRepository(tx),
+    documents: new InMemoryDocumentRepository(tx),
+    documentFolders: new InMemoryDocumentFolderRepository(tx),
     documentTemplates: new InMemoryDocumentTemplateRepository(tx),
     expectedReceivables: new InMemoryExpectedReceivableRepository(tx),
     invoiceDispatches: new InMemoryInvoiceDispatchRepository(tx),
@@ -74,6 +78,8 @@ export function buildInMemoryRepositories(dataStore: IDataStore): Repositories {
     tasks: new InMemoryTaskRepository(dataStore),
     calendarEvents: new InMemoryCalendarEventRepository(dataStore),
     serviceNotes: new InMemoryServiceNoteRepository(dataStore),
+    documents: new InMemoryDocumentRepository(dataStore),
+    documentFolders: new InMemoryDocumentFolderRepository(dataStore),
     documentTemplates: new InMemoryDocumentTemplateRepository(dataStore),
     expectedReceivables: new InMemoryExpectedReceivableRepository(dataStore),
     invoiceDispatches: new InMemoryInvoiceDispatchRepository(dataStore),

--- a/src/lib/server/repositories/in-memory-repositories.ts
+++ b/src/lib/server/repositories/in-memory-repositories.ts
@@ -19,6 +19,7 @@ import { InMemoryExpectedReceivableRepository } from "./in-memory-expected-recei
 import { InMemoryExpenseRepository } from "./in-memory-expense-repository";
 import { InMemoryInvoiceDispatchRepository } from "./in-memory-invoice-dispatch-repository";
 import { InMemoryInvoiceRepository } from "./in-memory-invoice-repository";
+import { InMemoryMatterEventSuggestionRepository } from "./in-memory-matter-event-suggestion-repository";
 import { InMemoryMatterRepository } from "./in-memory-matter-repository";
 import { InMemoryOfficeRepository } from "./in-memory-office-repository";
 import { InMemoryOrgPreferenceRepository } from "./in-memory-org-preference-repository";
@@ -51,6 +52,7 @@ function reposForTx(tx: DataStoreTx): Repositories {
     serviceNotes: new InMemoryServiceNoteRepository(tx),
     documents: new InMemoryDocumentRepository(tx),
     documentFolders: new InMemoryDocumentFolderRepository(tx),
+    matterEventSuggestions: new InMemoryMatterEventSuggestionRepository(tx),
     documentTemplates: new InMemoryDocumentTemplateRepository(tx),
     expectedReceivables: new InMemoryExpectedReceivableRepository(tx),
     invoiceDispatches: new InMemoryInvoiceDispatchRepository(tx),
@@ -80,6 +82,7 @@ export function buildInMemoryRepositories(dataStore: IDataStore): Repositories {
     serviceNotes: new InMemoryServiceNoteRepository(dataStore),
     documents: new InMemoryDocumentRepository(dataStore),
     documentFolders: new InMemoryDocumentFolderRepository(dataStore),
+    matterEventSuggestions: new InMemoryMatterEventSuggestionRepository(dataStore),
     documentTemplates: new InMemoryDocumentTemplateRepository(dataStore),
     expectedReceivables: new InMemoryExpectedReceivableRepository(dataStore),
     invoiceDispatches: new InMemoryInvoiceDispatchRepository(dataStore),

--- a/src/lib/server/repositories/in-memory-repositories.ts
+++ b/src/lib/server/repositories/in-memory-repositories.ts
@@ -12,6 +12,7 @@ import type { DataStoreTx, IDataStore } from "../data-store/IDataStore";
 import { InMemoryAccontoDeductionRepository } from "./in-memory-acconto-deduction-repository";
 import { InMemoryCalendarEventRepository } from "./in-memory-calendar-event-repository";
 import { InMemoryContactRepository } from "./in-memory-contact-repository";
+import { InMemoryDocumentTemplateRepository } from "./in-memory-document-template-repository";
 import { InMemoryExpenseRepository } from "./in-memory-expense-repository";
 import { InMemoryInvoiceRepository } from "./in-memory-invoice-repository";
 import { InMemoryMatterRepository } from "./in-memory-matter-repository";
@@ -40,6 +41,7 @@ function reposForTx(tx: DataStoreTx): Repositories {
     tasks: new InMemoryTaskRepository(tx),
     calendarEvents: new InMemoryCalendarEventRepository(tx),
     serviceNotes: new InMemoryServiceNoteRepository(tx),
+    documentTemplates: new InMemoryDocumentTemplateRepository(tx),
     transaction: (fn) => fn(repos),
   };
   return repos;
@@ -60,6 +62,7 @@ export function buildInMemoryRepositories(dataStore: IDataStore): Repositories {
     tasks: new InMemoryTaskRepository(dataStore),
     calendarEvents: new InMemoryCalendarEventRepository(dataStore),
     serviceNotes: new InMemoryServiceNoteRepository(dataStore),
+    documentTemplates: new InMemoryDocumentTemplateRepository(dataStore),
     transaction: (fn) => dataStore.transaction((tx) => fn(reposForTx(tx))),
   };
 }

--- a/src/lib/server/repositories/in-memory-repositories.ts
+++ b/src/lib/server/repositories/in-memory-repositories.ts
@@ -26,6 +26,7 @@ import { InMemoryMatterRepository } from "./in-memory-matter-repository";
 import { InMemoryOfficeRepository } from "./in-memory-office-repository";
 import { InMemoryOrgPreferenceRepository } from "./in-memory-org-preference-repository";
 import { InMemoryOrganizationRepository } from "./in-memory-organization-repository";
+import { InMemoryPaymentPlanReminderRepository } from "./in-memory-payment-plan-reminder-repository";
 import { InMemoryPaymentPlanRepository } from "./in-memory-payment-plan-repository";
 import { InMemoryPaymentRepository } from "./in-memory-payment-repository";
 import { InMemoryServiceNoteRepository } from "./in-memory-service-note-repository";
@@ -44,6 +45,7 @@ function reposForTx(tx: DataStoreTx): Repositories {
     payments: new InMemoryPaymentRepository(tx),
     writeOffs: new InMemoryWriteOffRepository(tx),
     paymentPlans: new InMemoryPaymentPlanRepository(tx),
+    paymentPlanReminders: new InMemoryPaymentPlanReminderRepository(tx),
     timeEntries: new InMemoryTimeEntryRepository(tx),
     expenses: new InMemoryExpenseRepository(tx),
     accontoDeductions: new InMemoryAccontoDeductionRepository(tx),
@@ -76,6 +78,7 @@ export function buildInMemoryRepositories(dataStore: IDataStore): Repositories {
     payments: new InMemoryPaymentRepository(dataStore),
     writeOffs: new InMemoryWriteOffRepository(dataStore),
     paymentPlans: new InMemoryPaymentPlanRepository(dataStore),
+    paymentPlanReminders: new InMemoryPaymentPlanReminderRepository(dataStore),
     timeEntries: new InMemoryTimeEntryRepository(dataStore),
     expenses: new InMemoryExpenseRepository(dataStore),
     accontoDeductions: new InMemoryAccontoDeductionRepository(dataStore),

--- a/src/lib/server/repositories/in-memory-repositories.ts
+++ b/src/lib/server/repositories/in-memory-repositories.ts
@@ -13,6 +13,7 @@ import { InMemoryAccontoDeductionRepository } from "./in-memory-acconto-deductio
 import { InMemoryCalendarEventRepository } from "./in-memory-calendar-event-repository";
 import { InMemoryContactRepository } from "./in-memory-contact-repository";
 import { InMemoryDocumentTemplateRepository } from "./in-memory-document-template-repository";
+import { InMemoryExpectedReceivableRepository } from "./in-memory-expected-receivable-repository";
 import { InMemoryExpenseRepository } from "./in-memory-expense-repository";
 import { InMemoryInvoiceRepository } from "./in-memory-invoice-repository";
 import { InMemoryMatterRepository } from "./in-memory-matter-repository";
@@ -42,6 +43,7 @@ function reposForTx(tx: DataStoreTx): Repositories {
     calendarEvents: new InMemoryCalendarEventRepository(tx),
     serviceNotes: new InMemoryServiceNoteRepository(tx),
     documentTemplates: new InMemoryDocumentTemplateRepository(tx),
+    expectedReceivables: new InMemoryExpectedReceivableRepository(tx),
     transaction: (fn) => fn(repos),
   };
   return repos;
@@ -63,6 +65,7 @@ export function buildInMemoryRepositories(dataStore: IDataStore): Repositories {
     calendarEvents: new InMemoryCalendarEventRepository(dataStore),
     serviceNotes: new InMemoryServiceNoteRepository(dataStore),
     documentTemplates: new InMemoryDocumentTemplateRepository(dataStore),
+    expectedReceivables: new InMemoryExpectedReceivableRepository(dataStore),
     transaction: (fn) => dataStore.transaction((tx) => fn(reposForTx(tx))),
   };
 }

--- a/src/lib/server/repositories/in-memory-repositories.ts
+++ b/src/lib/server/repositories/in-memory-repositories.ts
@@ -16,6 +16,7 @@ import { InMemoryConflictCheckRepository } from "./in-memory-conflict-check-repo
 import { InMemoryContactRepository } from "./in-memory-contact-repository";
 import { InMemoryDocumentFolderRepository } from "./in-memory-document-folder-repository";
 import { InMemoryDocumentRepository } from "./in-memory-document-repository";
+import { InMemoryDocumentSuggestionRepository } from "./in-memory-document-suggestion-repository";
 import { InMemoryDocumentTemplateRepository } from "./in-memory-document-template-repository";
 import { InMemoryExpectedReceivableRepository } from "./in-memory-expected-receivable-repository";
 import { InMemoryExpenseRepository } from "./in-memory-expense-repository";
@@ -61,6 +62,7 @@ function reposForTx(tx: DataStoreTx): Repositories {
     documents: new InMemoryDocumentRepository(tx),
     documentFolders: new InMemoryDocumentFolderRepository(tx),
     matterEventSuggestions: new InMemoryMatterEventSuggestionRepository(tx),
+    documentAnalysisSuggestions: new InMemoryDocumentSuggestionRepository(tx),
     documentTemplates: new InMemoryDocumentTemplateRepository(tx),
     expectedReceivables: new InMemoryExpectedReceivableRepository(tx),
     invoiceDispatches: new InMemoryInvoiceDispatchRepository(tx),
@@ -95,6 +97,7 @@ export function buildInMemoryRepositories(dataStore: IDataStore): Repositories {
     documents: new InMemoryDocumentRepository(dataStore),
     documentFolders: new InMemoryDocumentFolderRepository(dataStore),
     matterEventSuggestions: new InMemoryMatterEventSuggestionRepository(dataStore),
+    documentAnalysisSuggestions: new InMemoryDocumentSuggestionRepository(dataStore),
     documentTemplates: new InMemoryDocumentTemplateRepository(dataStore),
     expectedReceivables: new InMemoryExpectedReceivableRepository(dataStore),
     invoiceDispatches: new InMemoryInvoiceDispatchRepository(dataStore),

--- a/src/lib/server/repositories/in-memory-repositories.ts
+++ b/src/lib/server/repositories/in-memory-repositories.ts
@@ -19,12 +19,14 @@ import { InMemoryInvoiceDispatchRepository } from "./in-memory-invoice-dispatch-
 import { InMemoryInvoiceRepository } from "./in-memory-invoice-repository";
 import { InMemoryMatterRepository } from "./in-memory-matter-repository";
 import { InMemoryOfficeRepository } from "./in-memory-office-repository";
+import { InMemoryOrgPreferenceRepository } from "./in-memory-org-preference-repository";
 import { InMemoryOrganizationRepository } from "./in-memory-organization-repository";
 import { InMemoryPaymentPlanRepository } from "./in-memory-payment-plan-repository";
 import { InMemoryPaymentRepository } from "./in-memory-payment-repository";
 import { InMemoryServiceNoteRepository } from "./in-memory-service-note-repository";
 import { InMemoryTaskRepository } from "./in-memory-task-repository";
 import { InMemoryTimeEntryRepository } from "./in-memory-time-entry-repository";
+import { InMemoryUserPreferenceRepository } from "./in-memory-user-preference-repository";
 import { InMemoryUserRepository } from "./in-memory-user-repository";
 import { InMemoryWriteOffRepository } from "./in-memory-write-off-repository";
 import type { Repositories } from "./repositories";
@@ -50,6 +52,8 @@ function reposForTx(tx: DataStoreTx): Repositories {
     invoiceDispatches: new InMemoryInvoiceDispatchRepository(tx),
     organizations: new InMemoryOrganizationRepository(tx),
     offices: new InMemoryOfficeRepository(tx),
+    userPreferences: new InMemoryUserPreferenceRepository(tx),
+    orgPreferences: new InMemoryOrgPreferenceRepository(tx),
     transaction: (fn) => fn(repos),
   };
   return repos;
@@ -75,6 +79,8 @@ export function buildInMemoryRepositories(dataStore: IDataStore): Repositories {
     invoiceDispatches: new InMemoryInvoiceDispatchRepository(dataStore),
     organizations: new InMemoryOrganizationRepository(dataStore),
     offices: new InMemoryOfficeRepository(dataStore),
+    userPreferences: new InMemoryUserPreferenceRepository(dataStore),
+    orgPreferences: new InMemoryOrgPreferenceRepository(dataStore),
     transaction: (fn) => dataStore.transaction((tx) => fn(reposForTx(tx))),
   };
 }

--- a/src/lib/server/repositories/in-memory-repositories.ts
+++ b/src/lib/server/repositories/in-memory-repositories.ts
@@ -18,6 +18,8 @@ import { InMemoryExpenseRepository } from "./in-memory-expense-repository";
 import { InMemoryInvoiceDispatchRepository } from "./in-memory-invoice-dispatch-repository";
 import { InMemoryInvoiceRepository } from "./in-memory-invoice-repository";
 import { InMemoryMatterRepository } from "./in-memory-matter-repository";
+import { InMemoryOfficeRepository } from "./in-memory-office-repository";
+import { InMemoryOrganizationRepository } from "./in-memory-organization-repository";
 import { InMemoryPaymentPlanRepository } from "./in-memory-payment-plan-repository";
 import { InMemoryPaymentRepository } from "./in-memory-payment-repository";
 import { InMemoryServiceNoteRepository } from "./in-memory-service-note-repository";
@@ -46,6 +48,8 @@ function reposForTx(tx: DataStoreTx): Repositories {
     documentTemplates: new InMemoryDocumentTemplateRepository(tx),
     expectedReceivables: new InMemoryExpectedReceivableRepository(tx),
     invoiceDispatches: new InMemoryInvoiceDispatchRepository(tx),
+    organizations: new InMemoryOrganizationRepository(tx),
+    offices: new InMemoryOfficeRepository(tx),
     transaction: (fn) => fn(repos),
   };
   return repos;
@@ -69,6 +73,8 @@ export function buildInMemoryRepositories(dataStore: IDataStore): Repositories {
     documentTemplates: new InMemoryDocumentTemplateRepository(dataStore),
     expectedReceivables: new InMemoryExpectedReceivableRepository(dataStore),
     invoiceDispatches: new InMemoryInvoiceDispatchRepository(dataStore),
+    organizations: new InMemoryOrganizationRepository(dataStore),
+    offices: new InMemoryOfficeRepository(dataStore),
     transaction: (fn) => dataStore.transaction((tx) => fn(reposForTx(tx))),
   };
 }

--- a/src/lib/server/repositories/in-memory-repositories.ts
+++ b/src/lib/server/repositories/in-memory-repositories.ts
@@ -10,6 +10,7 @@
 
 import type { DataStoreTx, IDataStore } from "../data-store/IDataStore";
 import { InMemoryAccontoDeductionRepository } from "./in-memory-acconto-deduction-repository";
+import { InMemoryBillingRunRepository } from "./in-memory-billing-run-repository";
 import { InMemoryCalendarEventRepository } from "./in-memory-calendar-event-repository";
 import { InMemoryConflictCheckRepository } from "./in-memory-conflict-check-repository";
 import { InMemoryContactRepository } from "./in-memory-contact-repository";
@@ -49,6 +50,7 @@ function reposForTx(tx: DataStoreTx): Repositories {
     timeEntries: new InMemoryTimeEntryRepository(tx),
     expenses: new InMemoryExpenseRepository(tx),
     accontoDeductions: new InMemoryAccontoDeductionRepository(tx),
+    billingRuns: new InMemoryBillingRunRepository(tx),
     contacts: new InMemoryContactRepository(tx),
     matterContacts: new InMemoryMatterContactRepository(tx),
     conflictChecks: new InMemoryConflictCheckRepository(tx),
@@ -82,6 +84,7 @@ export function buildInMemoryRepositories(dataStore: IDataStore): Repositories {
     timeEntries: new InMemoryTimeEntryRepository(dataStore),
     expenses: new InMemoryExpenseRepository(dataStore),
     accontoDeductions: new InMemoryAccontoDeductionRepository(dataStore),
+    billingRuns: new InMemoryBillingRunRepository(dataStore),
     contacts: new InMemoryContactRepository(dataStore),
     matterContacts: new InMemoryMatterContactRepository(dataStore),
     conflictChecks: new InMemoryConflictCheckRepository(dataStore),

--- a/src/lib/server/repositories/in-memory-time-entry-repository.ts
+++ b/src/lib/server/repositories/in-memory-time-entry-repository.ts
@@ -97,4 +97,17 @@ export class InMemoryTimeEntryRepository extends InMemoryRepository<TimeEntry> i
     if (!ids.length) return;
     await this.delegate.updateMany({ where: { id: { in: ids } }, data: { invoiceId } as Partial<TimeEntry> });
   }
+
+  async listUnfrozenForMatter(matterId: string): Promise<TimeEntry[]> {
+    return (await this.delegate.findMany({
+      where: { matterId, frozenByBillingRunId: null }, orderBy: { date: "asc" },
+    })) as TimeEntry[];
+  }
+
+  async freezeForMatter(matterId: string, billingRunId: string, now: Date): Promise<void> {
+    await this.delegate.updateMany({
+      where: { matterId, frozenByBillingRunId: null },
+      data: { frozenAt: now, frozenByBillingRunId: billingRunId } as Partial<TimeEntry>,
+    });
+  }
 }

--- a/src/lib/server/repositories/in-memory-time-entry-repository.ts
+++ b/src/lib/server/repositories/in-memory-time-entry-repository.ts
@@ -8,8 +8,8 @@ import type { TimeEntry } from "@/lib/shared/schemas/billing";
 import type { Delegate, IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type {
-  TimeEntryListFilter, TimeEntryListResult, TimeEntryListRow, TimeEntryReportFilter,
-  TimeEntryReportRow, TimeEntryRepository, UnbilledTimeEntry,
+  LawyerReportTimeEntry, TimeEntryListFilter, TimeEntryListResult, TimeEntryListRow,
+  TimeEntryReportFilter, TimeEntryReportRow, TimeEntryRepository, UnbilledTimeEntry,
 } from "./time-entry-repository";
 
 /** Delegaten repot behöver — uppfylls av `IDataStore`, `DataStoreTx` och `LocalStore`. */
@@ -109,5 +109,21 @@ export class InMemoryTimeEntryRepository extends InMemoryRepository<TimeEntry> i
       where: { matterId, frozenByBillingRunId: null },
       data: { frozenAt: now, frozenByBillingRunId: billingRunId } as Partial<TimeEntry>,
     });
+  }
+
+  async listForLawyerInPeriod(
+    organizationId: string, userId: string, from: Date, to: Date,
+  ): Promise<LawyerReportTimeEntry[]> {
+    return (await this.delegate.findMany({
+      where: { matter: { organizationId }, userId, date: { gte: from, lte: to } },
+      include: { matter: { include: { contacts: { where: { role: "KLIENT" }, include: { contact: { select: { name: true } } }, take: 1 } } } },
+      orderBy: { date: "asc" },
+    })) as LawyerReportTimeEntry[];
+  }
+
+  async listBillableForOrg(organizationId: string): Promise<TimeEntry[]> {
+    return (await this.delegate.findMany({
+      where: { matter: { organizationId }, billable: true },
+    })) as TimeEntry[];
   }
 }

--- a/src/lib/server/repositories/in-memory-time-entry-repository.ts
+++ b/src/lib/server/repositories/in-memory-time-entry-repository.ts
@@ -7,14 +7,82 @@
 import type { TimeEntry } from "@/lib/shared/schemas/billing";
 import type { Delegate, IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
-import type { TimeEntryRepository, UnbilledTimeEntry } from "./time-entry-repository";
+import type {
+  TimeEntryListFilter, TimeEntryListResult, TimeEntryListRow, TimeEntryReportFilter,
+  TimeEntryReportRow, TimeEntryRepository, UnbilledTimeEntry,
+} from "./time-entry-repository";
 
 /** Delegaten repot behöver — uppfylls av `IDataStore`, `DataStoreTx` och `LocalStore`. */
 export type TimeEntryRepoSource = Pick<IDataStore, "timeEntries">;
 
+function dateRange(from?: Date, to?: Date): Record<string, unknown> {
+  if (!from && !to) return {};
+  return { date: { ...(from ? { gte: from } : {}), ...(to ? { lte: to } : {}) } };
+}
+
 export class InMemoryTimeEntryRepository extends InMemoryRepository<TimeEntry> implements TimeEntryRepository {
   constructor(store: TimeEntryRepoSource, now?: () => Date) {
     super(store.timeEntries as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async listForOrg(organizationId: string, opts: TimeEntryListFilter): Promise<TimeEntryListResult> {
+    const where = {
+      matter: { organizationId },
+      ...(opts.matterId ? { matterId: opts.matterId } : {}),
+      ...(opts.userId ? { userId: opts.userId } : {}),
+      ...dateRange(opts.from, opts.to),
+    };
+    const [entries, total] = await Promise.all([
+      this.delegate.findMany({
+        where,
+        orderBy: { date: "desc" },
+        skip: (opts.page - 1) * opts.pageSize,
+        take: opts.pageSize,
+        include: {
+          user: { select: { id: true, name: true } },
+          matter: { select: { id: true, matterNumber: true, title: true } },
+          invoice: { select: { id: true, invoiceNumber: true } },
+        },
+      }) as Promise<TimeEntryListRow[]>,
+      this.delegate.count({ where }),
+    ]);
+    const agg = await this.delegate.aggregate({ where, _sum: { minutes: true } });
+    return { entries, total, totalMinutes: (agg as { _sum?: { minutes?: number } })._sum?.minutes ?? 0 };
+  }
+
+  async getByIdInOrg(id: string, organizationId: string): Promise<TimeEntry | null> {
+    const row = (await this.delegate.findFirst({ where: { id, matter: { organizationId } } })) as TimeEntry | null;
+    return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
+  }
+
+  async listForReport(organizationId: string, filter: TimeEntryReportFilter): Promise<TimeEntryReportRow[]> {
+    const userFilter = filter.userIds && filter.userIds.length > 0
+      ? { userId: { in: filter.userIds } }
+      : filter.userId
+        ? { userId: filter.userId }
+        : {};
+    return (await this.delegate.findMany({
+      where: {
+        matter: { organizationId },
+        date: { gte: filter.from, lte: filter.to },
+        ...userFilter,
+        ...(filter.matterId ? { matterId: filter.matterId } : {}),
+      },
+      include: {
+        user: { select: { id: true, name: true } },
+        // Nested relations måste gå via `include` (in-memory-motorn rekurserar
+        // bara i include-subträd, inte select). Skalärfält följer med ändå.
+        matter: {
+          include: {
+            contacts: {
+              where: { role: "KLIENT" }, take: 1,
+              include: { contact: { select: { name: true } } },
+            },
+          },
+        },
+      },
+      orderBy: [{ userId: "asc" }, { date: "asc" }],
+    })) as TimeEntryReportRow[];
   }
 
   async listUnbilled(matterId: string, ids: string[]): Promise<UnbilledTimeEntry[]> {

--- a/src/lib/server/repositories/in-memory-user-preference-repository.ts
+++ b/src/lib/server/repositories/in-memory-user-preference-repository.ts
@@ -1,0 +1,19 @@
+/** In-memory `UserPreferenceRepository` (ADR 0020). */
+
+import type { UserPreference } from "@/lib/shared/schemas/preference";
+import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import { InMemoryRepository } from "./in-memory-repository";
+import type { UserPreferenceRepository, UserPreferenceRow } from "./user-preference-repository";
+
+export type UserPreferenceRepoSource = Pick<IDataStore, "userPreferences">;
+
+export class InMemoryUserPreferenceRepository extends InMemoryRepository<UserPreferenceRow> implements UserPreferenceRepository {
+  constructor(store: UserPreferenceRepoSource, now?: () => Date) {
+    super(store.userPreferences as unknown as Delegate, now ?? (() => new Date()));
+  }
+
+  async getByUserKey(userId: string, organizationId: string, key: string): Promise<UserPreference | null> {
+    const row = (await this.delegate.findFirst({ where: { userId, organizationId, key } })) as UserPreference | null;
+    return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
+  }
+}

--- a/src/lib/server/repositories/in-memory-write-off-repository.ts
+++ b/src/lib/server/repositories/in-memory-write-off-repository.ts
@@ -22,4 +22,9 @@ export class InMemoryWriteOffRepository extends InMemoryRepository<WriteOff> imp
       .filter((r) => !(r as { deletedAt?: unknown }).deletedAt)
       .reduce((s, w) => s + w.amount, 0);
   }
+
+  async listByInvoiceIds(invoiceIds: string[]): Promise<WriteOff[]> {
+    if (!invoiceIds.length) return [];
+    return (await this.delegate.findMany({ where: { invoiceId: { in: invoiceIds } } })) as WriteOff[];
+  }
 }

--- a/src/lib/server/repositories/invoice-dispatch-repository.ts
+++ b/src/lib/server/repositories/invoice-dispatch-repository.ts
@@ -1,0 +1,22 @@
+/**
+ * `InvoiceDispatchRepository` (ADR 0020, #409 fan-out) — fakturautskick (#178).
+ * Org-scopas via faktura→ärende (posten saknar egen organizationId). Bas-CRUD ärvs.
+ */
+
+import type { InvoiceDispatch } from "@/lib/shared/schemas/billing";
+import type { Repository } from "./types";
+
+/** Köad utskickspost + fakturans fält som dispatch-workern (#180) behöver. */
+export interface InvoiceDispatchQueuedRow extends InvoiceDispatch {
+  invoice: {
+    id: string; invoiceNumber: string | null; amount: number;
+    ocrReference: string | null; dueDate: Date | string | null;
+  } | null;
+}
+
+export interface InvoiceDispatchRepository extends Repository<InvoiceDispatch> {
+  /** Alla utskick för en faktura (nyaste först). Org-koll görs av anroparen. */
+  listByInvoice(invoiceId: string): Promise<InvoiceDispatch[]>;
+  /** Alla köade utskick i org:en (äldsta först), med faktura-subset för workern. */
+  listQueuedForOrg(organizationId: string): Promise<InvoiceDispatchQueuedRow[]>;
+}

--- a/src/lib/server/repositories/matter-contact-repository.ts
+++ b/src/lib/server/repositories/matter-contact-repository.ts
@@ -37,4 +37,8 @@ export interface MatterContactRepository extends Repository<MatterContact> {
   getByIdInOrg(id: string, organizationId: string): Promise<MatterContact | null>;
   /** Skapa en länk och returnera den med kontakten (matter.addContact/addNewContact). */
   linkContact(data: Partial<MatterContact>): Promise<MatterContactWithContact>;
+  /** Befintlig länk (ärende, kontakt, roll) — för idempotent koppling. Null om ingen. */
+  findLink(matterId: string, contactId: string, role: string): Promise<MatterContact | null>;
+  /** Kontakterna kopplade till ett ärende (dedup-underlag i förslags-flödet). */
+  listContactsForMatter(matterId: string): Promise<Contact[]>;
 }

--- a/src/lib/server/repositories/matter-contact-repository.ts
+++ b/src/lib/server/repositories/matter-contact-repository.ts
@@ -4,8 +4,14 @@
  * (inkl. KLIENT-kontaktens namn) org-scopat, valfritt nummer-filtrerat.
  */
 
+import type { Contact } from "@/lib/shared/schemas/contact";
 import type { MatterContact } from "@/lib/shared/schemas/matter";
 import type { Repository } from "./types";
+
+/** Länk + kontakten (det `matter.addContact`/`addNewContact` returnerar). */
+export interface MatterContactWithContact extends MatterContact {
+  contact: Contact;
+}
 
 /** Jävskontroll-rad: länk + kontakt + ärende (med KLIENT-namn). */
 export interface ConflictContactRow {
@@ -27,4 +33,8 @@ export interface MatterContactRepository extends Repository<MatterContact> {
    * (namn-fuzzy görs i routern).
    */
   findForConflict(organizationId: string, numberTerm?: string): Promise<ConflictContactRow[]>;
+  /** Länk by id, org-scopad via ärendet. Null om saknas/annan org/raderad. */
+  getByIdInOrg(id: string, organizationId: string): Promise<MatterContact | null>;
+  /** Skapa en länk och returnera den med kontakten (matter.addContact/addNewContact). */
+  linkContact(data: Partial<MatterContact>): Promise<MatterContactWithContact>;
 }

--- a/src/lib/server/repositories/matter-contact-repository.ts
+++ b/src/lib/server/repositories/matter-contact-repository.ts
@@ -1,0 +1,30 @@
+/**
+ * `MatterContactRepository` (ADR 0020, #409 fan-out) — kontakt↔ärende-länkar.
+ * Bas-CRUD ärvs. `findForConflict` driver jävskontrollen: kontakt + ärende
+ * (inkl. KLIENT-kontaktens namn) org-scopat, valfritt nummer-filtrerat.
+ */
+
+import type { MatterContact } from "@/lib/shared/schemas/matter";
+import type { Repository } from "./types";
+
+/** Jävskontroll-rad: länk + kontakt + ärende (med KLIENT-namn). */
+export interface ConflictContactRow {
+  role: string;
+  contact: {
+    id: string; name: string; contactType: string;
+    personalNumber: string | null; orgNumber: string | null;
+  };
+  matter: {
+    id: string; matterNumber: string; title: string;
+    contacts: Array<{ contact: { name: string } }>;
+  };
+}
+
+export interface MatterContactRepository extends Repository<MatterContact> {
+  /**
+   * Länkar i org:en med kontakt + ärende (KLIENT-namn). `numberTerm` (om satt)
+   * filtrerar på contact.personalNumber/orgNumber (delsträng); annars alla
+   * (namn-fuzzy görs i routern).
+   */
+  findForConflict(organizationId: string, numberTerm?: string): Promise<ConflictContactRow[]>;
+}

--- a/src/lib/server/repositories/matter-event-suggestion-repository.ts
+++ b/src/lib/server/repositories/matter-event-suggestion-repository.ts
@@ -1,0 +1,19 @@
+/**
+ * `MatterEventSuggestionRepository` (ADR 0020, #409 fan-out) — AI-extraherade
+ * kalenderhändelser ur dokument. Org-scopas via dokument→ärende. Bas-CRUD ärvs.
+ */
+
+import type { MatterEventSuggestion } from "@/lib/shared/schemas/document";
+import type { Repository } from "./types";
+
+/** Händelse + ursprungsdokumentet (listvyn). */
+export interface MatterEventSuggestionRow extends MatterEventSuggestion {
+  document: { id: string; fileName: string; title: string | null };
+}
+
+export interface MatterEventSuggestionRepository extends Repository<MatterEventSuggestion> {
+  /** Icke-avvisade händelser för ett ärende (startAt asc), org-scopat via dokumentet. */
+  listForMatter(matterId: string, organizationId: string): Promise<MatterEventSuggestionRow[]>;
+  /** Händelse by id, org-scopad via dokument→ärende. Null om saknas/annan org/raderad. */
+  getByIdInOrg(id: string, organizationId: string): Promise<MatterEventSuggestion | null>;
+}

--- a/src/lib/server/repositories/matter-repository.ts
+++ b/src/lib/server/repositories/matter-repository.ts
@@ -2,16 +2,60 @@
  * `MatterRepository` (ADR 0020, #409 fan-out) — ärenden. Nästan varje
  * faktura-mutation börjar med en org-scopad ärende-uppslagning, så detta är
  * fundamentet som de transaktions-mutationerna stegvis migrerar ovanpå.
- * Bas-CRUD ärvs; `getByIdInOrg` är den enda entitets-specifika läsningen
- * (ärenden bär `organizationId` direkt → enkel where, ingen join).
+ * Bas-CRUD ärvs; läsmetoderna org-scopar direkt (ärenden bär `organizationId`).
  */
 
-import type { Matter } from "@/lib/shared/schemas/matter";
+import type { Matter, MatterContact } from "@/lib/shared/schemas/matter";
 import type { Repository } from "./types";
+
+/** Kontaktvyn detaljens kontaktlista bär (matchar UI-komponenternas props). */
+export interface MatterContactContactView {
+  id: string;
+  name: string;
+  contactType?: string;
+  personalNumber?: string | null;
+  orgNumber?: string | null;
+  email?: string | null;
+  phone?: string | null;
+}
+
+/** Listrad: ärende + KLIENT-kontakt + relations-antal (matter.list). */
+export interface MatterListRow extends Matter {
+  contacts: Array<{ contact: { id: string; name: string } }>;
+  _count: { documents: number; timeEntries: number; contacts: number };
+}
+
+/** Detaljrad: ärende + alla kontakter (createdAt asc) + relations-antal (matter.getById). */
+export interface MatterDetailRow extends Matter {
+  contacts: Array<MatterContact & { contact: MatterContactContactView }>;
+  _count: { documents: number; timeEntries: number; emails: number };
+}
+
+/** Filter/paginering för `listForOrg`. */
+export interface MatterListFilter {
+  search?: string | undefined;
+  status?: string | undefined;
+  employeeId?: string | undefined;
+  page: number;
+  pageSize: number;
+}
+
+export interface MatterListResult {
+  matters: MatterListRow[];
+  total: number;
+}
 
 export interface MatterRepository extends Repository<Matter> {
   /** Ärende by id, org-scopat (null om saknas/annan org/raderat). */
   getByIdInOrg(id: string, organizationId: string): Promise<Matter | null>;
   /** Alla (icke-raderade) ärenden i org:en. */
   listByOrg(organizationId: string): Promise<Matter[]>;
+  /** Org-scopad, paginerad/sökbar lista (createdAt desc) med KLIENT + _count + total. */
+  listForOrg(organizationId: string, filter: MatterListFilter): Promise<MatterListResult>;
+  /** Ärende by id med alla kontakter + _count, org-scopat. Null om saknas. */
+  getByIdWithContacts(id: string, organizationId: string): Promise<MatterDetailRow | null>;
+  /** Ärenden för en ansvarig jurist i org:en (#174 ärendenummer-serie). */
+  listByResponsibleLawyer(organizationId: string, responsibleLawyerId: string): Promise<Matter[]>;
+  /** Ärenden i org:en vars nummer börjar med ett prefix (#174 kollisionsfritt). */
+  listByNumberPrefix(organizationId: string, prefix: string): Promise<Matter[]>;
 }

--- a/src/lib/server/repositories/matter-repository.ts
+++ b/src/lib/server/repositories/matter-repository.ts
@@ -12,4 +12,6 @@ import type { Repository } from "./types";
 export interface MatterRepository extends Repository<Matter> {
   /** Ärende by id, org-scopat (null om saknas/annan org/raderat). */
   getByIdInOrg(id: string, organizationId: string): Promise<Matter | null>;
+  /** Alla (icke-raderade) ärenden i org:en. */
+  listByOrg(organizationId: string): Promise<Matter[]>;
 }

--- a/src/lib/server/repositories/office-repository.ts
+++ b/src/lib/server/repositories/office-repository.ts
@@ -1,0 +1,16 @@
+/**
+ * `OfficeRepository` (ADR 0020, #409 fan-out) — kontor. Org-scopas direkt.
+ * Bas-CRUD ärvs; `demoteMains` nollar huvudkontors-flaggan (en main åt gången).
+ */
+
+import type { Office } from "@/lib/shared/schemas/organization";
+import type { Repository } from "./types";
+
+export interface OfficeRepository extends Repository<Office> {
+  /** Org:ens kontor (huvudkontor först, sedan namn). */
+  listByOrg(organizationId: string): Promise<Office[]>;
+  /** Kontor by id, org-scopat (null om saknas/annan org/raderat). */
+  getByIdInOrg(id: string, organizationId: string): Promise<Office | null>;
+  /** Nolla `isMain` på alla nuvarande huvudkontor i org:en (innan ett nytt sätts). */
+  demoteMains(organizationId: string): Promise<void>;
+}

--- a/src/lib/server/repositories/org-preference-repository.ts
+++ b/src/lib/server/repositories/org-preference-repository.ts
@@ -1,0 +1,17 @@
+/**
+ * `OrgPreferenceRepository` (ADR 0020, #409 fan-out) — org-defaults per UI-key
+ * (ADMIN). Bas-CRUD ärvs; `getByOrgKey` upsert-uppslag, `listByOrg` admin-UI:t.
+ */
+
+import type { OrgPreference } from "@/lib/shared/schemas/preference";
+import type { Repository, RowBase } from "./types";
+
+/** Preference-schemat saknar baseFields (version/deletedAt) → intersekta RowBase. */
+export type OrgPreferenceRow = OrgPreference & RowBase;
+
+export interface OrgPreferenceRepository extends Repository<OrgPreferenceRow> {
+  /** Org-default för (org, key) — null om ingen/raderad. */
+  getByOrgKey(organizationId: string, key: string): Promise<OrgPreference | null>;
+  /** Alla org-defaults (key asc). */
+  listByOrg(organizationId: string): Promise<OrgPreference[]>;
+}

--- a/src/lib/server/repositories/organization-repository.ts
+++ b/src/lib/server/repositories/organization-repository.ts
@@ -1,0 +1,10 @@
+/**
+ * `OrganizationRepository` (ADR 0020, #409 fan-out) — organisationen är
+ * rot-entiteten (själva scope:n), så ingen org-scoping. Endast bas-CRUD
+ * (getById/create/update används av settings-vägen).
+ */
+
+import type { Organization } from "@/lib/shared/schemas/organization";
+import type { Repository } from "./types";
+
+export type OrganizationRepository = Repository<Organization>;

--- a/src/lib/server/repositories/payment-plan-reminder-repository.ts
+++ b/src/lib/server/repositories/payment-plan-reminder-repository.ts
@@ -1,0 +1,10 @@
+/**
+ * `PaymentPlanReminderRepository` (ADR 0020, #409 fan-out) — loggade
+ * avbetalnings-påminnelser. Endast bas-CRUD behövs (`create` loggar en
+ * utskickad DUE/OVERDUE-påminnelse); läsningar sker via planens join.
+ */
+
+import type { PaymentPlanReminder } from "@/lib/shared/schemas/billing";
+import type { Repository } from "./types";
+
+export type PaymentPlanReminderRepository = Repository<PaymentPlanReminder>;

--- a/src/lib/server/repositories/payment-plan-repository.ts
+++ b/src/lib/server/repositories/payment-plan-repository.ts
@@ -1,16 +1,48 @@
 /**
  * `PaymentPlanRepository` (ADR 0020, #409 fan-out) — avbetalningsplaner.
  * Bas-CRUD ärvs (in-memory: `InMemoryRepository`, server: `DrizzleRepository`);
- * den enda entitets-specifika läsningen är org-scopning via faktura→ärende
- * (planer har ingen egen organizationId).
+ * org-scopning sker via faktura→ärende (planer har ingen egen organizationId).
+ *
+ * Läsmetoderna returnerar den joinade plan-formen som list-/detalj-vyn och
+ * påminnelse-skannern (`computeDueReminders`) konsumerar: faktura + ärende
+ * (inkl. KLIENT-kontakt) + betalningar + avskrivningar (+ påminnelser).
  */
 
-import type { PaymentPlan } from "@/lib/shared/schemas/billing";
+import type { Invoice, Payment, PaymentPlan, PaymentPlanReminder, WriteOff } from "@/lib/shared/schemas/billing";
+import type { Matter } from "@/lib/shared/schemas/matter";
 import type { Repository } from "./types";
+
+/** Ärende + KLIENT-kontakten (namn/email för påminnelse-mottagaren). */
+export interface PlanMatter extends Matter {
+  contacts: Array<{ contact: { id: string; name: string; email?: string | null } }>;
+}
+
+/** Faktura med ledger-rader + ärende (det list-/scan-vyn räknar på). */
+export interface PlanInvoice extends Invoice {
+  matter: PlanMatter | null;
+  payments: Payment[];
+  writeOffs: WriteOff[];
+}
+
+/** Joinad plan (list). */
+export interface JoinedPaymentPlan extends PaymentPlan {
+  invoice: PlanInvoice | null;
+}
+
+/** Joinad plan + påminnelse-historik (detalj + scan). */
+export interface JoinedPaymentPlanWithReminders extends JoinedPaymentPlan {
+  reminders: PaymentPlanReminder[];
+}
 
 export interface PaymentPlanRepository extends Repository<PaymentPlan> {
   /** Plan by id, org-scopad via faktura→ärende (null om saknas/annan org/raderad). */
   getByIdInOrg(planId: string, organizationId: string): Promise<PaymentPlan | null>;
   /** Plan för en faktura (invoiceId är unik på planen) — null om ingen/raderad. */
   getByInvoiceId(invoiceId: string): Promise<PaymentPlan | null>;
+  /** Org:ens planer (createdAt desc), valfritt status-filtrerade, joinade. */
+  listForOrg(organizationId: string, status?: string): Promise<JoinedPaymentPlan[]>;
+  /** En plan med full join + påminnelse-historik, org-scopad. Null om saknas. */
+  getByIdWithDetails(id: string, organizationId: string): Promise<JoinedPaymentPlanWithReminders | null>;
+  /** Aktiva planer i org:en (join + påminnelser) för påminnelse-skannern. */
+  listActiveForScan(organizationId: string): Promise<JoinedPaymentPlanWithReminders[]>;
 }

--- a/src/lib/server/repositories/payment-repository.ts
+++ b/src/lib/server/repositories/payment-repository.ts
@@ -10,4 +10,6 @@ import type { Repository } from "./types";
 export interface PaymentRepository extends Repository<Payment> {
   /** Summa av alla (icke-raderade) betalningar på en faktura (öre). */
   sumByInvoice(invoiceId: string): Promise<number>;
+  /** Betalningar för en uppsättning fakturor (rapporter). Tom lista vid tomma ids. */
+  listByInvoiceIds(invoiceIds: string[]): Promise<Payment[]>;
 }

--- a/src/lib/server/repositories/repositories.ts
+++ b/src/lib/server/repositories/repositories.ts
@@ -8,6 +8,7 @@
 import type { AccontoDeductionRepository } from "./acconto-deduction-repository";
 import type { CalendarEventRepository } from "./calendar-event-repository";
 import type { ContactRepository } from "./contact-repository";
+import type { DocumentTemplateRepository } from "./document-template-repository";
 import type { ExpenseRepository } from "./expense-repository";
 import type { InvoiceRepository } from "./invoice-repository";
 import type { MatterRepository } from "./matter-repository";
@@ -33,5 +34,6 @@ export interface Repositories {
   tasks: TaskRepository;
   calendarEvents: CalendarEventRepository;
   serviceNotes: ServiceNoteRepository;
+  documentTemplates: DocumentTemplateRepository;
   transaction<T>(fn: (tx: Repositories) => Promise<T>): Promise<T>;
 }

--- a/src/lib/server/repositories/repositories.ts
+++ b/src/lib/server/repositories/repositories.ts
@@ -14,6 +14,8 @@ import type { ExpenseRepository } from "./expense-repository";
 import type { InvoiceDispatchRepository } from "./invoice-dispatch-repository";
 import type { InvoiceRepository } from "./invoice-repository";
 import type { MatterRepository } from "./matter-repository";
+import type { OfficeRepository } from "./office-repository";
+import type { OrganizationRepository } from "./organization-repository";
 import type { PaymentPlanRepository } from "./payment-plan-repository";
 import type { PaymentRepository } from "./payment-repository";
 import type { ServiceNoteRepository } from "./service-note-repository";
@@ -39,5 +41,7 @@ export interface Repositories {
   documentTemplates: DocumentTemplateRepository;
   expectedReceivables: ExpectedReceivableRepository;
   invoiceDispatches: InvoiceDispatchRepository;
+  organizations: OrganizationRepository;
+  offices: OfficeRepository;
   transaction<T>(fn: (tx: Repositories) => Promise<T>): Promise<T>;
 }

--- a/src/lib/server/repositories/repositories.ts
+++ b/src/lib/server/repositories/repositories.ts
@@ -8,6 +8,8 @@
 import type { AccontoDeductionRepository } from "./acconto-deduction-repository";
 import type { CalendarEventRepository } from "./calendar-event-repository";
 import type { ContactRepository } from "./contact-repository";
+import type { DocumentFolderRepository } from "./document-folder-repository";
+import type { DocumentRepository } from "./document-repository";
 import type { DocumentTemplateRepository } from "./document-template-repository";
 import type { ExpectedReceivableRepository } from "./expected-receivable-repository";
 import type { ExpenseRepository } from "./expense-repository";
@@ -40,6 +42,8 @@ export interface Repositories {
   tasks: TaskRepository;
   calendarEvents: CalendarEventRepository;
   serviceNotes: ServiceNoteRepository;
+  documents: DocumentRepository;
+  documentFolders: DocumentFolderRepository;
   documentTemplates: DocumentTemplateRepository;
   expectedReceivables: ExpectedReceivableRepository;
   invoiceDispatches: InvoiceDispatchRepository;

--- a/src/lib/server/repositories/repositories.ts
+++ b/src/lib/server/repositories/repositories.ts
@@ -15,6 +15,7 @@ import type { ExpectedReceivableRepository } from "./expected-receivable-reposit
 import type { ExpenseRepository } from "./expense-repository";
 import type { InvoiceDispatchRepository } from "./invoice-dispatch-repository";
 import type { InvoiceRepository } from "./invoice-repository";
+import type { MatterEventSuggestionRepository } from "./matter-event-suggestion-repository";
 import type { MatterRepository } from "./matter-repository";
 import type { OfficeRepository } from "./office-repository";
 import type { OrgPreferenceRepository } from "./org-preference-repository";
@@ -44,6 +45,7 @@ export interface Repositories {
   serviceNotes: ServiceNoteRepository;
   documents: DocumentRepository;
   documentFolders: DocumentFolderRepository;
+  matterEventSuggestions: MatterEventSuggestionRepository;
   documentTemplates: DocumentTemplateRepository;
   expectedReceivables: ExpectedReceivableRepository;
   invoiceDispatches: InvoiceDispatchRepository;

--- a/src/lib/server/repositories/repositories.ts
+++ b/src/lib/server/repositories/repositories.ts
@@ -7,6 +7,7 @@
 
 import type { AccontoDeductionRepository } from "./acconto-deduction-repository";
 import type { CalendarEventRepository } from "./calendar-event-repository";
+import type { ConflictCheckRepository } from "./conflict-check-repository";
 import type { ContactRepository } from "./contact-repository";
 import type { DocumentFolderRepository } from "./document-folder-repository";
 import type { DocumentRepository } from "./document-repository";
@@ -15,6 +16,7 @@ import type { ExpectedReceivableRepository } from "./expected-receivable-reposit
 import type { ExpenseRepository } from "./expense-repository";
 import type { InvoiceDispatchRepository } from "./invoice-dispatch-repository";
 import type { InvoiceRepository } from "./invoice-repository";
+import type { MatterContactRepository } from "./matter-contact-repository";
 import type { MatterEventSuggestionRepository } from "./matter-event-suggestion-repository";
 import type { MatterRepository } from "./matter-repository";
 import type { OfficeRepository } from "./office-repository";
@@ -39,6 +41,8 @@ export interface Repositories {
   expenses: ExpenseRepository;
   accontoDeductions: AccontoDeductionRepository;
   contacts: ContactRepository;
+  matterContacts: MatterContactRepository;
+  conflictChecks: ConflictCheckRepository;
   users: UserRepository;
   tasks: TaskRepository;
   calendarEvents: CalendarEventRepository;

--- a/src/lib/server/repositories/repositories.ts
+++ b/src/lib/server/repositories/repositories.ts
@@ -6,6 +6,7 @@
  */
 
 import type { AccontoDeductionRepository } from "./acconto-deduction-repository";
+import type { BillingRunRepository } from "./billing-run-repository";
 import type { CalendarEventRepository } from "./calendar-event-repository";
 import type { ConflictCheckRepository } from "./conflict-check-repository";
 import type { ContactRepository } from "./contact-repository";
@@ -42,6 +43,7 @@ export interface Repositories {
   timeEntries: TimeEntryRepository;
   expenses: ExpenseRepository;
   accontoDeductions: AccontoDeductionRepository;
+  billingRuns: BillingRunRepository;
   contacts: ContactRepository;
   matterContacts: MatterContactRepository;
   conflictChecks: ConflictCheckRepository;

--- a/src/lib/server/repositories/repositories.ts
+++ b/src/lib/server/repositories/repositories.ts
@@ -22,6 +22,7 @@ import type { MatterRepository } from "./matter-repository";
 import type { OfficeRepository } from "./office-repository";
 import type { OrgPreferenceRepository } from "./org-preference-repository";
 import type { OrganizationRepository } from "./organization-repository";
+import type { PaymentPlanReminderRepository } from "./payment-plan-reminder-repository";
 import type { PaymentPlanRepository } from "./payment-plan-repository";
 import type { PaymentRepository } from "./payment-repository";
 import type { ServiceNoteRepository } from "./service-note-repository";
@@ -37,6 +38,7 @@ export interface Repositories {
   payments: PaymentRepository;
   writeOffs: WriteOffRepository;
   paymentPlans: PaymentPlanRepository;
+  paymentPlanReminders: PaymentPlanReminderRepository;
   timeEntries: TimeEntryRepository;
   expenses: ExpenseRepository;
   accontoDeductions: AccontoDeductionRepository;

--- a/src/lib/server/repositories/repositories.ts
+++ b/src/lib/server/repositories/repositories.ts
@@ -12,6 +12,7 @@ import type { ConflictCheckRepository } from "./conflict-check-repository";
 import type { ContactRepository } from "./contact-repository";
 import type { DocumentFolderRepository } from "./document-folder-repository";
 import type { DocumentRepository } from "./document-repository";
+import type { DocumentSuggestionRepository } from "./document-suggestion-repository";
 import type { DocumentTemplateRepository } from "./document-template-repository";
 import type { ExpectedReceivableRepository } from "./expected-receivable-repository";
 import type { ExpenseRepository } from "./expense-repository";
@@ -54,6 +55,7 @@ export interface Repositories {
   documents: DocumentRepository;
   documentFolders: DocumentFolderRepository;
   matterEventSuggestions: MatterEventSuggestionRepository;
+  documentAnalysisSuggestions: DocumentSuggestionRepository;
   documentTemplates: DocumentTemplateRepository;
   expectedReceivables: ExpectedReceivableRepository;
   invoiceDispatches: InvoiceDispatchRepository;

--- a/src/lib/server/repositories/repositories.ts
+++ b/src/lib/server/repositories/repositories.ts
@@ -15,12 +15,14 @@ import type { InvoiceDispatchRepository } from "./invoice-dispatch-repository";
 import type { InvoiceRepository } from "./invoice-repository";
 import type { MatterRepository } from "./matter-repository";
 import type { OfficeRepository } from "./office-repository";
+import type { OrgPreferenceRepository } from "./org-preference-repository";
 import type { OrganizationRepository } from "./organization-repository";
 import type { PaymentPlanRepository } from "./payment-plan-repository";
 import type { PaymentRepository } from "./payment-repository";
 import type { ServiceNoteRepository } from "./service-note-repository";
 import type { TaskRepository } from "./task-repository";
 import type { TimeEntryRepository } from "./time-entry-repository";
+import type { UserPreferenceRepository } from "./user-preference-repository";
 import type { UserRepository } from "./user-repository";
 import type { WriteOffRepository } from "./write-off-repository";
 
@@ -43,5 +45,7 @@ export interface Repositories {
   invoiceDispatches: InvoiceDispatchRepository;
   organizations: OrganizationRepository;
   offices: OfficeRepository;
+  userPreferences: UserPreferenceRepository;
+  orgPreferences: OrgPreferenceRepository;
   transaction<T>(fn: (tx: Repositories) => Promise<T>): Promise<T>;
 }

--- a/src/lib/server/repositories/repositories.ts
+++ b/src/lib/server/repositories/repositories.ts
@@ -9,6 +9,7 @@ import type { AccontoDeductionRepository } from "./acconto-deduction-repository"
 import type { CalendarEventRepository } from "./calendar-event-repository";
 import type { ContactRepository } from "./contact-repository";
 import type { DocumentTemplateRepository } from "./document-template-repository";
+import type { ExpectedReceivableRepository } from "./expected-receivable-repository";
 import type { ExpenseRepository } from "./expense-repository";
 import type { InvoiceRepository } from "./invoice-repository";
 import type { MatterRepository } from "./matter-repository";
@@ -35,5 +36,6 @@ export interface Repositories {
   calendarEvents: CalendarEventRepository;
   serviceNotes: ServiceNoteRepository;
   documentTemplates: DocumentTemplateRepository;
+  expectedReceivables: ExpectedReceivableRepository;
   transaction<T>(fn: (tx: Repositories) => Promise<T>): Promise<T>;
 }

--- a/src/lib/server/repositories/repositories.ts
+++ b/src/lib/server/repositories/repositories.ts
@@ -11,6 +11,7 @@ import type { ContactRepository } from "./contact-repository";
 import type { DocumentTemplateRepository } from "./document-template-repository";
 import type { ExpectedReceivableRepository } from "./expected-receivable-repository";
 import type { ExpenseRepository } from "./expense-repository";
+import type { InvoiceDispatchRepository } from "./invoice-dispatch-repository";
 import type { InvoiceRepository } from "./invoice-repository";
 import type { MatterRepository } from "./matter-repository";
 import type { PaymentPlanRepository } from "./payment-plan-repository";
@@ -37,5 +38,6 @@ export interface Repositories {
   serviceNotes: ServiceNoteRepository;
   documentTemplates: DocumentTemplateRepository;
   expectedReceivables: ExpectedReceivableRepository;
+  invoiceDispatches: InvoiceDispatchRepository;
   transaction<T>(fn: (tx: Repositories) => Promise<T>): Promise<T>;
 }

--- a/src/lib/server/repositories/time-entry-repository.ts
+++ b/src/lib/server/repositories/time-entry-repository.ts
@@ -12,7 +12,49 @@ export interface UnbilledTimeEntry extends TimeEntry {
   user: { hourlyRate: number | null };
 }
 
+/** Tidspost + relationer för listvyn. matter alltid satt (matterId NOT NULL FK). */
+export interface TimeEntryListRow extends TimeEntry {
+  user: { id: string; name: string } | null;
+  matter: { id: string; matterNumber: string; title: string };
+  invoice: { id: string; invoiceNumber: string | null } | null;
+}
+
+export interface TimeEntryListFilter {
+  matterId?: string | undefined;
+  userId?: string | undefined;
+  from?: Date | undefined;
+  to?: Date | undefined;
+  page: number;
+  pageSize: number;
+}
+
+export interface TimeEntryListResult {
+  entries: TimeEntryListRow[];
+  total: number;
+  totalMinutes: number;
+}
+
+/** Tidspost för tidsrapporten — med jurist + ärende inkl. klient-kontakten (KLIENT). */
+export interface TimeEntryReportRow extends TimeEntry {
+  user: { id: string; name: string };
+  matter: { id: string; matterNumber: string; title: string; contacts: Array<{ contact: { name: string } }> } | null;
+}
+
+export interface TimeEntryReportFilter {
+  from: Date;
+  to: Date;
+  userId?: string | undefined;
+  userIds?: string[] | undefined;
+  matterId?: string | undefined;
+}
+
 export interface TimeEntryRepository extends Repository<TimeEntry> {
+  /** Org-scopad paginerad lista (datum desc) + total + summa minuter. */
+  listForOrg(organizationId: string, filter: TimeEntryListFilter): Promise<TimeEntryListResult>;
+  /** Tidspost by id, org-scopad via ärendet (null om saknas/annan org/raderad). */
+  getByIdInOrg(id: string, organizationId: string): Promise<TimeEntry | null>;
+  /** Tidsrapport-rader (jurist + ärende + KLIENT-kontakt), org-scopat, userId asc / date asc. */
+  listForReport(organizationId: string, filter: TimeEntryReportFilter): Promise<TimeEntryReportRow[]>;
   /** Valda ofakturerade tidsposter i ett ärende (med user.hourlyRate). Tom lista vid tomma ids. */
   listUnbilled(matterId: string, ids: string[]): Promise<UnbilledTimeEntry[]>;
   /** Koppla tidsposter till en faktura (sätter invoiceId). No-op vid tomma ids. */

--- a/src/lib/server/repositories/time-entry-repository.ts
+++ b/src/lib/server/repositories/time-entry-repository.ts
@@ -59,4 +59,8 @@ export interface TimeEntryRepository extends Repository<TimeEntry> {
   listUnbilled(matterId: string, ids: string[]): Promise<UnbilledTimeEntry[]>;
   /** Koppla tidsposter till en faktura (sätter invoiceId). No-op vid tomma ids. */
   flagBilled(ids: string[], invoiceId: string): Promise<void>;
+  /** Ofrysta tidsposter i ett ärende (date asc) — underlag för billing-run. */
+  listUnfrozenForMatter(matterId: string): Promise<TimeEntry[]>;
+  /** Frys alla ofrysta tidsposter i ett ärende mot en billing-run (bulk). */
+  freezeForMatter(matterId: string, billingRunId: string, now: Date): Promise<void>;
 }

--- a/src/lib/server/repositories/time-entry-repository.ts
+++ b/src/lib/server/repositories/time-entry-repository.ts
@@ -48,6 +48,22 @@ export interface TimeEntryReportFilter {
   matterId?: string | undefined;
 }
 
+/** Ärende-projektionen advokatrapporten (reports.perLawyer) läser. */
+export interface ReportMatterRef {
+  id: string;
+  matterNumber: string;
+  title: string;
+  paymentMethod: string;
+  paymentMethodNote: string | null;
+  paymentMethodDecidedAt: Date | null;
+  contacts: Array<{ contact: { name: string } }>;
+}
+
+/** Tidspost för advokatrapporten — med ärende-ref (KLIENT + betalsätt). */
+export interface LawyerReportTimeEntry extends TimeEntry {
+  matter: ReportMatterRef | null;
+}
+
 export interface TimeEntryRepository extends Repository<TimeEntry> {
   /** Org-scopad paginerad lista (datum desc) + total + summa minuter. */
   listForOrg(organizationId: string, filter: TimeEntryListFilter): Promise<TimeEntryListResult>;
@@ -63,4 +79,8 @@ export interface TimeEntryRepository extends Repository<TimeEntry> {
   listUnfrozenForMatter(matterId: string): Promise<TimeEntry[]>;
   /** Frys alla ofrysta tidsposter i ett ärende mot en billing-run (bulk). */
   freezeForMatter(matterId: string, billingRunId: string, now: Date): Promise<void>;
+  /** En advokats tidsposter i en period (date asc), med ärende-ref (perLawyer-rapporten). */
+  listForLawyerInPeriod(organizationId: string, userId: string, from: Date, to: Date): Promise<LawyerReportTimeEntry[]>;
+  /** Alla debiterbara tidsposter i org:en (för fakturerat/AR-attribuering). */
+  listBillableForOrg(organizationId: string): Promise<TimeEntry[]>;
 }

--- a/src/lib/server/repositories/user-preference-repository.ts
+++ b/src/lib/server/repositories/user-preference-repository.ts
@@ -1,0 +1,15 @@
+/**
+ * `UserPreferenceRepository` (ADR 0020, #409 fan-out) — per-användar-preferenser
+ * (kolumn/sort/vy per UI-key). Bas-CRUD ärvs; `getByUserKey` är upsert-uppslaget.
+ */
+
+import type { UserPreference } from "@/lib/shared/schemas/preference";
+import type { Repository, RowBase } from "./types";
+
+/** Preference-schemat saknar baseFields (version/deletedAt) → intersekta RowBase. */
+export type UserPreferenceRow = UserPreference & RowBase;
+
+export interface UserPreferenceRepository extends Repository<UserPreferenceRow> {
+  /** User-pref för (userId, org, key) — null om ingen/raderad. */
+  getByUserKey(userId: string, organizationId: string, key: string): Promise<UserPreference | null>;
+}

--- a/src/lib/server/repositories/write-off-repository.ts
+++ b/src/lib/server/repositories/write-off-repository.ts
@@ -10,4 +10,6 @@ import type { Repository } from "./types";
 export interface WriteOffRepository extends Repository<WriteOff> {
   /** Summa av alla (icke-raderade) avskrivningar på en faktura (öre). */
   sumByInvoice(invoiceId: string): Promise<number>;
+  /** Avskrivningar för en uppsättning fakturor (rapporter). Tom lista vid tomma ids. */
+  listByInvoiceIds(invoiceIds: string[]): Promise<WriteOff[]>;
 }

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -17,6 +17,7 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { proposedAccontoOre } from "@/lib/shared/billing-proposal";
+import type { BillingRun, Expense, Invoice } from "@/lib/shared/schemas/billing";
 import { billingRunRecipientSchema, type ExpenseKind } from "@/lib/shared/schemas/enums";
 import {
   matterIdSchema,
@@ -24,8 +25,8 @@ import {
   asId,
   type BillingRunId,
 } from "@/lib/shared/schemas/ids";
-import type { DataStoreTx } from "../data-store/IDataStore";
 import { emit } from "../events/emit";
+import type { Repositories } from "../repositories/repositories";
 import { router, orgProcedure } from "../trpc";
 
 interface UnfrozenWork {
@@ -63,13 +64,11 @@ function timeEntryValueOre(minutes: number, hourlyRate: number): number {
   return Math.round((minutes / 60) * hourlyRate);
 }
 
-async function fetchUnfrozenWork(tx: DataStoreTx, matterId: string): Promise<UnfrozenWork> {
-  const te = await tx.timeEntries.findMany({
-    where: { matterId, frozenByBillingRunId: null },
-  }) as Array<{ id: string; minutes: number; hourlyRate: number; billable: boolean }>;
-  const ex = await tx.expenses.findMany({
-    where: { matterId, frozenByBillingRunId: null },
-  }) as Array<{ id: string; amount: number; billable: boolean; kind?: ExpenseKind }>;
+async function fetchUnfrozenWork(repos: Repositories, matterId: string): Promise<UnfrozenWork> {
+  const te = await repos.timeEntries.listUnfrozenForMatter(matterId) as unknown as
+    Array<{ id: string; minutes: number; hourlyRate: number; billable: boolean }>;
+  const ex = await repos.expenses.listUnfrozenForMatter(matterId) as unknown as
+    Array<{ id: string; amount: number; billable: boolean; kind?: ExpenseKind }>;
   return { timeEntries: te, expenses: ex.filter((e) => e.kind !== "PRUTNING") };
 }
 
@@ -102,30 +101,19 @@ function buildProposal(
 }
 
 /** Summan av tidigare utställda ACCONTO-fakturors belopp för ett ärende (#397). */
-async function sumPriorAccontos(
-  billingRuns: { findMany: (args: unknown) => Promise<unknown> },
-  matterId: string,
-): Promise<number> {
-  const runs = (await billingRuns.findMany({
-    where: { matterId, type: "ACCONTO", status: "SENT" },
-  })) as ReadonlyArray<{ amountOre?: number }>;
+async function sumPriorAccontos(repos: Repositories, matterId: string): Promise<number> {
+  const runs = (await repos.billingRuns.listAccontoSent(matterId)) as ReadonlyArray<{ amountOre?: number }>;
   return runs.reduce((sum, r) => sum + (r.amountOre ?? 0), 0);
 }
 
-async function freezeWork(tx: DataStoreTx, matterId: string, billingRunId: BillingRunId): Promise<void> {
+async function freezeWork(repos: Repositories, matterId: string, billingRunId: BillingRunId): Promise<void> {
   const now = new Date();
-  await tx.timeEntries.updateMany({
-    where: { matterId, frozenByBillingRunId: null },
-    data: { frozenAt: now, frozenByBillingRunId: billingRunId },
-  });
-  await tx.expenses.updateMany({
-    where: { matterId, frozenByBillingRunId: null },
-    data: { frozenAt: now, frozenByBillingRunId: billingRunId },
-  });
+  await repos.timeEntries.freezeForMatter(matterId, billingRunId, now);
+  await repos.expenses.freezeForMatter(matterId, billingRunId, now);
 }
 
-async function assertMatterInOrg(tx: DataStoreTx, matterId: string, orgId: string): Promise<void> {
-  const m = await tx.matters.findFirst({ where: { id: matterId, organizationId: orgId } });
+async function assertMatterInOrg(repos: Repositories, matterId: string, orgId: string): Promise<void> {
+  const m = await repos.matters.getByIdInOrg(matterId, orgId);
   if (!m) throw new TRPCError({ code: "NOT_FOUND", message: "Ärendet finns inte." });
 }
 
@@ -133,26 +121,16 @@ export const billingRunRouter = router({
   list: orgProcedure
     .input(z.object({ matterId: z.string().optional() }))
     .query(async ({ ctx, input }) => {
-      const where = input.matterId
-        ? { matterId: input.matterId, matter: { organizationId: ctx.orgId } }
-        : { matter: { organizationId: ctx.orgId } };
-      const runs = await ctx.dataStore.billingRuns.findMany({
-        where, orderBy: { createdAt: "desc" },
-        include: { invoice: { select: { id: true, invoiceNumber: true, status: true } } },
-      });
+      const runs = await ctx.repos.billingRuns.listForOrg(ctx.orgId, input.matterId);
       return { runs };
     }),
 
   byId: orgProcedure
     .input(z.object({ id: z.string() }))
     .query(async ({ ctx, input }) => {
-      return ctx.dataStore.billingRuns.findFirstOrThrow({
-        where: { id: input.id, matter: { organizationId: ctx.orgId } },
-        include: {
-          invoice: { select: { id: true, invoiceNumber: true, status: true, amount: true } },
-          matter: { select: { id: true, matterNumber: true, title: true, paymentMethod: true } },
-        },
-      });
+      const run = await ctx.repos.billingRuns.getByIdInOrg(input.id, ctx.orgId);
+      if (!run) throw new TRPCError({ code: "NOT_FOUND", message: "Faktureringshändelsen finns inte." });
+      return run;
     }),
 
   /**
@@ -164,19 +142,13 @@ export const billingRunRouter = router({
   proposal: orgProcedure
     .input(z.object({ matterId: matterIdSchema }))
     .query(async ({ ctx, input }) => {
-      const matter = await ctx.dataStore.matters.findFirst({
-        where: { id: input.matterId, organizationId: ctx.orgId },
-      });
+      const matter = await ctx.repos.matters.getByIdInOrg(input.matterId, ctx.orgId);
       if (!matter) throw new TRPCError({ code: "NOT_FOUND", message: "Ärendet finns inte." });
-      const te = (await ctx.dataStore.timeEntries.findMany({
-        where: { matterId: input.matterId, frozenByBillingRunId: null },
-        orderBy: { date: "asc" },
-      })) as Array<{ id: string; description?: string | null; minutes: number; hourlyRate: number; billable: boolean }>;
-      const ex = (await ctx.dataStore.expenses.findMany({
-        where: { matterId: input.matterId, frozenByBillingRunId: null },
-        orderBy: { date: "asc" },
-      })) as Array<{ id: string; description?: string | null; amount: number; billable: boolean; kind?: ExpenseKind }>;
-      const priorAccontoSumOre = await sumPriorAccontos(ctx.dataStore.billingRuns, input.matterId);
+      const te = (await ctx.repos.timeEntries.listUnfrozenForMatter(input.matterId)) as unknown as
+        Array<{ id: string; description?: string | null; minutes: number; hourlyRate: number; billable: boolean }>;
+      const ex = (await ctx.repos.expenses.listUnfrozenForMatter(input.matterId)) as unknown as
+        Array<{ id: string; description?: string | null; amount: number; billable: boolean; kind?: ExpenseKind }>;
+      const priorAccontoSumOre = await sumPriorAccontos(ctx.repos, input.matterId);
       return buildProposal(te, ex, priorAccontoSumOre);
     }),
 
@@ -189,30 +161,26 @@ export const billingRunRouter = router({
       notes: z.string().nullish(),
     }))
     .mutation(async ({ ctx, input }) => {
-      return ctx.dataStore.transaction(async (tx) => {
+      return ctx.repos.transaction(async (tx) => {
         await assertMatterInOrg(tx, input.matterId, ctx.orgId);
         const work = await fetchUnfrozenWork(tx, input.matterId);
         const value = workValueOre(work);
         // #397: dra av tidigare aconton i det FÖRESLAGNA beloppet —
         // belopp = %-sats × upparbetat − Σ tidigare aconto-fakturor.
-        const priorAccontoSumOre = await sumPriorAccontos(tx.billingRuns, input.matterId);
+        const priorAccontoSumOre = await sumPriorAccontos(tx, input.matterId);
         const proposedOre = proposedAccontoOre(value, input.clientShareBips, priorAccontoSumOre);
         const invoice = await tx.invoices.create({
-          data: {
-            matterId: input.matterId, amount: input.amountOre,
-            invoiceType: "ACCONTO", status: "DRAFT",
-            invoiceDate: new Date(), notes: input.notes,
-          },
-        });
+          matterId: input.matterId, amount: input.amountOre,
+          invoiceType: "ACCONTO", status: "DRAFT",
+          invoiceDate: new Date(), notes: input.notes,
+        } as unknown as Partial<Invoice>);
         const run = await tx.billingRuns.create({
-          data: {
-            matterId: input.matterId, type: "ACCONTO", recipient: input.recipient,
-            status: "SENT", workValueOreAtRun: value, clientShareBips: input.clientShareBips,
-            proposedAmountOre: proposedOre, amountOre: input.amountOre,
-            invoiceId: invoice.id, deductedBillingRunIds: [],
-            periodTo: new Date(), notes: input.notes,
-          },
-        });
+          matterId: input.matterId, type: "ACCONTO", recipient: input.recipient,
+          status: "SENT", workValueOreAtRun: value, clientShareBips: input.clientShareBips,
+          proposedAmountOre: proposedOre, amountOre: input.amountOre,
+          invoiceId: invoice.id, deductedBillingRunIds: [],
+          periodTo: new Date(), notes: input.notes,
+        } as unknown as Partial<BillingRun>);
         await emit.invoiceCreated(ctx, invoice);
         return { run, invoice };
       });
@@ -226,29 +194,25 @@ export const billingRunRouter = router({
       notes: z.string().nullish(),
     }))
     .mutation(async ({ ctx, input }) => {
-      return ctx.dataStore.transaction(async (tx) => {
+      return ctx.repos.transaction(async (tx) => {
         await assertMatterInOrg(tx, input.matterId, ctx.orgId);
         const work = await fetchUnfrozenWork(tx, input.matterId);
         const value = workValueOre(work);
         const deductionOre = await sumDeductions(tx, input.matterId, input.deductedBillingRunIds);
         const finalAmount = Math.max(0, value - deductionOre);
         const invoice = await tx.invoices.create({
-          data: {
-            matterId: input.matterId, amount: finalAmount,
-            invoiceType: "FINAL", status: "DRAFT",
-            invoiceDate: new Date(), notes: input.notes,
-          },
-        });
+          matterId: input.matterId, amount: finalAmount,
+          invoiceType: "FINAL", status: "DRAFT",
+          invoiceDate: new Date(), notes: input.notes,
+        } as unknown as Partial<Invoice>);
         const run = await tx.billingRuns.create({
-          data: {
-            matterId: input.matterId, type: "FINAL", recipient: input.recipient,
-            status: "SENT", workValueOreAtRun: value,
-            proposedAmountOre: value, amountOre: finalAmount,
-            invoiceId: invoice.id, deductedBillingRunIds: input.deductedBillingRunIds,
-            periodTo: new Date(), notes: input.notes,
-          },
-        });
-        await freezeWork(tx, input.matterId, run.id);
+          matterId: input.matterId, type: "FINAL", recipient: input.recipient,
+          status: "SENT", workValueOreAtRun: value,
+          proposedAmountOre: value, amountOre: finalAmount,
+          invoiceId: invoice.id, deductedBillingRunIds: input.deductedBillingRunIds,
+          periodTo: new Date(), notes: input.notes,
+        } as unknown as Partial<BillingRun>);
+        await freezeWork(tx, input.matterId, run.id as BillingRunId);
         await emit.invoiceCreated(ctx, invoice);
         return { run, invoice };
       });
@@ -257,19 +221,17 @@ export const billingRunRouter = router({
   createKostnadsrakning: orgProcedure
     .input(z.object({ matterId: matterIdSchema, notes: z.string().nullish() }))
     .mutation(async ({ ctx, input }) => {
-      return ctx.dataStore.transaction(async (tx) => {
+      return ctx.repos.transaction(async (tx) => {
         await assertMatterInOrg(tx, input.matterId, ctx.orgId);
         const work = await fetchUnfrozenWork(tx, input.matterId);
         const value = workValueOre(work);
         const run = await tx.billingRuns.create({
-          data: {
-            matterId: input.matterId, type: "KOSTNADSRAKNING", recipient: "DOMSTOL",
-            status: "PENDING_VERDICT", workValueOreAtRun: value,
-            proposedAmountOre: value, amountOre: value,
-            invoiceId: null, deductedBillingRunIds: [],
-            periodTo: new Date(), notes: input.notes,
-          },
-        });
+          matterId: input.matterId, type: "KOSTNADSRAKNING", recipient: "DOMSTOL",
+          status: "PENDING_VERDICT", workValueOreAtRun: value,
+          proposedAmountOre: value, amountOre: value,
+          invoiceId: null, deductedBillingRunIds: [],
+          periodTo: new Date(), notes: input.notes,
+        } as unknown as Partial<BillingRun>);
         return { run };
       });
     }),
@@ -280,35 +242,29 @@ export const billingRunRouter = router({
       prutningOre: z.number().int().nonpositive(),
     }))
     .mutation(async ({ ctx, input }) => {
-      return ctx.dataStore.transaction(async (tx) => {
-        const run = await tx.billingRuns.findFirstOrThrow({
-          where: { id: input.billingRunId, matter: { organizationId: ctx.orgId } },
-        });
+      return ctx.repos.transaction(async (tx) => {
+        const run = await tx.billingRuns.getByIdInOrg(input.billingRunId, ctx.orgId);
+        if (!run) throw new TRPCError({ code: "NOT_FOUND", message: "Faktureringshändelsen finns inte." });
         if (run.type !== "KOSTNADSRAKNING" || run.status !== "PENDING_VERDICT") {
           throw new TRPCError({ code: "BAD_REQUEST", message: "Bara KOSTNADSRAKNING i PENDING_VERDICT kan domsläggas." });
         }
         const finalAmount = Math.max(0, run.workValueOreAtRun + input.prutningOre);
         if (input.prutningOre < 0) {
           await tx.expenses.create({
-            data: {
-              matterId: run.matterId, userId: asId<"UserId">(ctx.user.id), date: new Date(),
-              amount: input.prutningOre, description: "Prutning enligt dom",
-              billable: true, vatRate: 0, vatIncluded: false, kind: "PRUTNING",
-            },
-          });
+            matterId: run.matterId, userId: asId<"UserId">(ctx.user.id), date: new Date(),
+            amount: input.prutningOre, description: "Prutning enligt dom",
+            billable: true, vatRate: 0, vatIncluded: false, kind: "PRUTNING",
+          } as unknown as Partial<Expense>);
         }
         const invoice = await tx.invoices.create({
-          data: {
-            matterId: run.matterId, amount: finalAmount,
-            invoiceType: "FINAL", status: "DRAFT",
-            invoiceDate: new Date(),
-          },
-        });
-        await tx.billingRuns.update({
-          where: { id: run.id },
-          data: { status: "SENT", invoiceId: invoice.id, amountOre: finalAmount, prutningOre: input.prutningOre },
-        });
-        await freezeWork(tx, run.matterId, run.id);
+          matterId: run.matterId, amount: finalAmount,
+          invoiceType: "FINAL", status: "DRAFT",
+          invoiceDate: new Date(),
+        } as unknown as Partial<Invoice>);
+        await tx.billingRuns.update(run.id, {
+          status: "SENT", invoiceId: invoice.id, amountOre: finalAmount, prutningOre: input.prutningOre,
+        } as unknown as Partial<BillingRun>);
+        await freezeWork(tx, run.matterId, run.id as BillingRunId);
         await emit.invoiceCreated(ctx, invoice);
         return { run, invoice };
       });
@@ -316,7 +272,7 @@ export const billingRunRouter = router({
 });
 
 async function sumDeductions(
-  tx: DataStoreTx,
+  repos: Repositories,
   matterId: string,
   ids: ReadonlyArray<string>,
 ): Promise<number> {
@@ -324,9 +280,7 @@ async function sumDeductions(
   // Säkerhet (#60): avdragsposterna måste tillhöra SAMMA ärende och vara
   // ACCONTO-körningar — annars kunde en FINAL dra av främmande/fel-typade
   // billing-runs och förvanska beloppet. Kasta om någon id inte matchar.
-  const runs = await tx.billingRuns.findMany({
-    where: { id: { in: ids }, matterId, type: "ACCONTO" },
-  });
+  const runs = await repos.billingRuns.listAccontoByIds(matterId, [...ids]);
   if (runs.length !== ids.length) {
     throw new TRPCError({
       code: "BAD_REQUEST",

--- a/src/lib/server/routers/conflict.ts
+++ b/src/lib/server/routers/conflict.ts
@@ -1,10 +1,12 @@
 import { z } from "zod";
 import { similarity } from "@/lib/shared/fuzzy-similarity";
 import { asId } from "@/lib/shared/schemas/ids";
-import type { IDataStore } from "../data-store/IDataStore";
+import type { ConflictCheck } from "@/lib/shared/schemas/misc";
+import type { ConflictContactRow } from "../repositories/matter-contact-repository";
+import type { Repositories } from "../repositories/repositories";
 import { router, protectedProcedure } from "../trpc";
 
-type ConflictCtx = { dataStore: IDataStore; user: { id: string; organizationId: string } };
+type ConflictCtx = { repos: Repositories; user: { id: string; organizationId: string } };
 
 interface ConflictResult {
   contactId: string;
@@ -19,22 +21,8 @@ interface ConflictResult {
   klient: string | null;
 }
 
-/** Rad-form från matterContacts.findMany med MC_INCLUDE. */
-interface ConflictRow {
-  contact: { id: string; name: string; contactType: string; personalNumber: string | null; orgNumber: string | null };
-  matter: { id: string; matterNumber: string; title: string; contacts: Array<{ contact: { name: string } }> };
-  role: string;
-}
-
-// Tar med klient-namnet (kontext) ihop med kontakt + ärende.
-const MC_INCLUDE = {
-  contact: true,
-  matter: {
-    include: {
-      contacts: { where: { role: "KLIENT" }, include: { contact: { select: { name: true } } }, take: 1 },
-    },
-  },
-} as const;
+/** Rad-form från `repos.matterContacts.findForConflict`. */
+type ConflictRow = ConflictContactRow;
 
 function toResult(mc: ConflictRow): ConflictResult {
   return {
@@ -53,14 +41,8 @@ function toResult(mc: ConflictRow): ConflictResult {
 
 /** Exakt delsträngsmatch på person-/org-nummer. */
 async function searchByNumber(ctx: ConflictCtx, term: string): Promise<ConflictResult[]> {
-  const rows = await ctx.dataStore.matterContacts.findMany({
-    where: {
-      matter: { organizationId: ctx.user.organizationId },
-      contact: { OR: [{ personalNumber: { contains: term } }, { orgNumber: { contains: term } }] },
-    },
-    include: MC_INCLUDE,
-  });
-  return (rows as ConflictRow[]).map(toResult);
+  const rows = await ctx.repos.matterContacts.findForConflict(ctx.user.organizationId, term);
+  return rows.map(toResult);
 }
 
 /**
@@ -70,11 +52,8 @@ async function searchByNumber(ctx: ConflictCtx, term: string): Promise<ConflictR
  */
 async function searchByName(ctx: ConflictCtx, term: string): Promise<ConflictResult[]> {
   const SIM_THRESHOLD = 0.4;
-  const rows = await ctx.dataStore.matterContacts.findMany({
-    where: { matter: { organizationId: ctx.user.organizationId } },
-    include: MC_INCLUDE,
-  });
-  return (rows as ConflictRow[])
+  const rows = await ctx.repos.matterContacts.findForConflict(ctx.user.organizationId);
+  return rows
     .map((row) => ({ row, score: similarity(row.contact.name, term) }))
     .filter((s) => s.score > SIM_THRESHOLD)
     .sort((a, b) => b.score - a.score)
@@ -103,14 +82,12 @@ export const conflictRouter = router({
       if (input.searchType !== "personalNumber") pushUnique(results, await searchByName(ctx, input.searchTerm));
 
       // Logga sökningen
-      await ctx.dataStore.conflictChecks.create({
-        data: {
-          searchTerm: input.searchTerm,
-          searchType: input.searchType,
-          results: results as unknown as unknown[],
-          checkedById: asId<"UserId">(ctx.user.id),
-        },
-      });
+      await ctx.repos.conflictChecks.create({
+        searchTerm: input.searchTerm,
+        searchType: input.searchType,
+        results: results as unknown as unknown[],
+        checkedById: asId<"UserId">(ctx.user.id),
+      } as unknown as Partial<ConflictCheck>);
 
       return { results, matchCount: results.length, searchTerm: input.searchTerm };
     }),
@@ -123,16 +100,7 @@ export const conflictRouter = router({
       })
     )
     .query(async ({ ctx, input }) => {
-      const [checks, total] = await Promise.all([
-        ctx.dataStore.conflictChecks.findMany({
-          orderBy: { createdAt: "desc" },
-          skip: (input.page - 1) * input.pageSize,
-          take: input.pageSize,
-          include: { checkedBy: { select: { name: true } } },
-        }),
-        ctx.dataStore.conflictChecks.count(),
-      ]);
-
+      const { checks, total } = await ctx.repos.conflictChecks.listHistory(input.page, input.pageSize);
       return { checks, total, pages: Math.ceil(total / input.pageSize) };
     }),
 });

--- a/src/lib/server/routers/document/core.ts
+++ b/src/lib/server/routers/document/core.ts
@@ -3,9 +3,11 @@
  * Inga subgrupper eller förslag — bara själva dokumenten.
  */
 
+import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { isJunkFileName } from "@/lib/shared/junk-files";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
+import type { Document } from "@/lib/shared/schemas/document";
 import { orgProcedure } from "../../trpc";
 import { assertDocAccess } from "./shared";
 
@@ -21,23 +23,11 @@ export const coreProcedures = {
       }),
     )
     .query(async ({ ctx, input }) => {
-      const [documents, folders, total] = await Promise.all([
-        ctx.dataStore.documents.findMany({
-          where: { matterId: input.matterId, folderId: input.folderId },
-          orderBy: { createdAt: "desc" },
-          skip: (input.page - 1) * input.pageSize,
-          take: input.pageSize,
-          include: { uploadedBy: { select: { name: true } } },
-        }),
-        ctx.dataStore.documentFolders.findMany({
-          where: { matterId: input.matterId, parentId: input.folderId },
-          orderBy: { name: "asc" },
-          include: { _count: { select: { documents: true, children: true } } },
-        }),
-        ctx.dataStore.documents.count({
-          where: { matterId: input.matterId, folderId: input.folderId },
-        }),
+      const [docs, folders] = await Promise.all([
+        ctx.repos.documents.listInFolder(input.matterId, input.folderId, input.page, input.pageSize),
+        ctx.repos.documentFolders.listInParent(input.matterId, input.folderId),
       ]);
+      const { documents, total } = docs;
       return { documents, folders, total, pages: Math.ceil(total / input.pageSize) };
     }),
 
@@ -46,15 +36,8 @@ export const coreProcedures = {
     .input(z.object({ matterId: z.string() }))
     .query(async ({ ctx, input }) => {
       const [folders, documents] = await Promise.all([
-        ctx.dataStore.documentFolders.findMany({
-          where: { matterId: input.matterId },
-          orderBy: { name: "asc" },
-        }),
-        ctx.dataStore.documents.findMany({
-          where: { matterId: input.matterId },
-          orderBy: { createdAt: "desc" },
-          include: { uploadedBy: { select: { name: true } } },
-        }),
+        ctx.repos.documentFolders.listByMatter(input.matterId),
+        ctx.repos.documents.listByMatter(input.matterId),
       ]);
       // Defense-in-depth: gömmer OS-metadata-sidecars (AppleDouble ._*,
       // .DS_Store etc.) som kan ligga kvar från tidigare uploads.
@@ -93,26 +76,13 @@ export const coreProcedures = {
   /** Lista alla unika documentType-värden inom org + antal per typ.
    *  Används av sök-sidan för att rendera filter-checkboxar. */
   listDocumentTypes: orgProcedure
-    .query(async ({ ctx }) => {
-      const docs = await ctx.dataStore.documents.findMany({
-        where: { matter: { organizationId: ctx.orgId } },
-        include: { matter: { select: { organizationId: true } } },
-      }) as Array<{ documentType?: string | null }>;
-      const counts = new Map<string, number>();
-      for (const d of docs) {
-        if (!d.documentType) continue;
-        counts.set(d.documentType, (counts.get(d.documentType) ?? 0) + 1);
-      }
-      return [...counts.entries()]
-        .map(([type, count]) => ({ type, count }))
-        .sort((a, b) => a.type.localeCompare(b.type, "sv"));
-    }),
+    .query(({ ctx }) => ctx.repos.documents.listDocumentTypesForOrg(ctx.orgId)),
 
   delete: orgProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      await assertDocAccess(ctx, input.id);
-      const doc = await ctx.dataStore.documents.delete({ where: { id: input.id } });
+      const doc = await assertDocAccess(ctx, input.id);
+      await ctx.repos.documents.hardDelete(input.id);
       ctx.ports.searchIndex.remove(input.id).catch(() => {});
       return doc;
     }),
@@ -148,32 +118,29 @@ export const coreProcedures = {
     }))
     .mutation(async ({ ctx, input }) => {
       // Verifiera matter:n tillhör org:n
-      await ctx.dataStore.matters.findFirstOrThrow({
-        where: { id: input.matterId, organizationId: ctx.orgId },
-      });
-      const doc = await ctx.dataStore.documents.create({
-        data: {
-          id: input.id,
-          matterId: input.matterId,
-          fileName: input.fileName,
-          mimeType: input.mimeType,
-          sizeBytes: input.sizeBytes,
-          fileSize: input.sizeBytes, // denormaliserat (UI läser fileSize)
-          storagePath: input.storagePath,
-          folderId: input.folderId ?? null,
-          organizationId: ctx.orgId,
-          analysisStatus: input.analysisStatus ?? "PENDING",
-          uploadedById: input.uploadedById ?? ctx.user.id,
-          version: input.version,
-          title: input.title,
-          documentType: input.documentType,
-          summary: input.summary,
-          analyzedAt: input.analyzedAt ? new Date(input.analyzedAt) : undefined,
-          createdAt: input.createdAt ? new Date(input.createdAt) : undefined,
-          invoiceId: input.invoiceId ?? undefined,
-        } as never,
-      });
-      return doc;
+      const matter = await ctx.repos.matters.getByIdInOrg(input.matterId, ctx.orgId);
+      if (!matter) throw new TRPCError({ code: "NOT_FOUND" });
+      const data = {
+        id: input.id,
+        matterId: input.matterId,
+        fileName: input.fileName,
+        mimeType: input.mimeType,
+        sizeBytes: input.sizeBytes,
+        fileSize: input.sizeBytes, // denormaliserat (UI läser fileSize)
+        storagePath: input.storagePath,
+        folderId: input.folderId ?? null,
+        organizationId: ctx.orgId,
+        analysisStatus: input.analysisStatus ?? "PENDING",
+        uploadedById: input.uploadedById ?? ctx.user.id,
+        version: input.version,
+        title: input.title,
+        documentType: input.documentType,
+        summary: input.summary,
+        analyzedAt: input.analyzedAt ? new Date(input.analyzedAt) : undefined,
+        createdAt: input.createdAt ? new Date(input.createdAt) : undefined,
+        invoiceId: input.invoiceId ?? undefined,
+      };
+      return ctx.repos.documents.create(data as unknown as Partial<Document>);
     }),
 
   /** Kör (eller kör om) AI-analys på ett dokument. Returnerar omedelbart. */
@@ -222,7 +189,7 @@ export const coreProcedures = {
                 : analyzedAt,
         }),
       };
-      return ctx.dataStore.documents.update({ where: { id: documentId }, data });
+      return ctx.repos.documents.update(documentId, data as unknown as Partial<Document>);
     }),
 
   /**
@@ -243,14 +210,10 @@ export const coreProcedures = {
     )
     .mutation(async ({ ctx, input }) => {
       await assertDocAccess(ctx, input.id);
-      const doc = await ctx.dataStore.documents.findUniqueOrThrow({ where: { id: input.id } }) as { version?: number };
-      return ctx.dataStore.documents.update({
-        where: { id: input.id },
-        data: {
-          version: (doc.version ?? 1) + 1,
-          updatedAt: new Date(),
-          ...omitUndefined({ sizeBytes: input.sizeBytes, fileSize: input.sizeBytes }),
-        },
-      });
+      // repo.update bumpar version + updatedAt automatiskt (reconcile-konvention).
+      return ctx.repos.documents.update(
+        input.id,
+        omitUndefined({ sizeBytes: input.sizeBytes, fileSize: input.sizeBytes }) as unknown as Partial<Document>,
+      );
     }),
 };

--- a/src/lib/server/routers/document/events.ts
+++ b/src/lib/server/routers/document/events.ts
@@ -1,10 +1,14 @@
 /**
  * Kalenderhändelser extraherade ur dokument via AI
  * (MatterEventSuggestion): list, reject, markAdded.
+ *
+ * Migrerade till repository-sömmen (ADR 0020): org-scopning + include bor i
+ * `repos.matterEventSuggestions`.
  */
 
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import type { MatterEventSuggestion } from "@/lib/shared/schemas/document";
 import { orgProcedure } from "../../trpc";
 
 export const eventProcedures = {
@@ -12,49 +16,23 @@ export const eventProcedures = {
   events: orgProcedure
     .input(z.object({ matterId: z.string() }))
     .query(({ ctx, input }) =>
-      ctx.dataStore.matterEventSuggestions.findMany({
-        where: {
-          status: { not: "REJECTED" },
-          document: {
-            matterId: input.matterId,
-            matter: { organizationId: ctx.orgId },
-          },
-        },
-        include: { document: { select: { id: true, fileName: true, title: true } } },
-        orderBy: { startAt: "asc" },
-      }),
+      ctx.repos.matterEventSuggestions.listForMatter(input.matterId, ctx.orgId),
     ),
 
   rejectEvent: orgProcedure
     .input(z.object({ eventId: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      const ev = await ctx.dataStore.matterEventSuggestions.findFirst({
-        where: {
-          id: input.eventId,
-          document: { matter: { organizationId: ctx.orgId } },
-        },
-      });
+      const ev = await ctx.repos.matterEventSuggestions.getByIdInOrg(input.eventId, ctx.orgId);
       if (!ev) throw new TRPCError({ code: "NOT_FOUND" });
-      return ctx.dataStore.matterEventSuggestions.update({
-        where: { id: ev.id },
-        data: { status: "REJECTED" },
-      });
+      return ctx.repos.matterEventSuggestions.update(ev.id, { status: "REJECTED" } as Partial<MatterEventSuggestion>);
     }),
 
   /** Markera händelsen som tillagd i kalender (UI-indikator). */
   markEventAdded: orgProcedure
     .input(z.object({ eventId: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      const ev = await ctx.dataStore.matterEventSuggestions.findFirst({
-        where: {
-          id: input.eventId,
-          document: { matter: { organizationId: ctx.orgId } },
-        },
-      });
+      const ev = await ctx.repos.matterEventSuggestions.getByIdInOrg(input.eventId, ctx.orgId);
       if (!ev) throw new TRPCError({ code: "NOT_FOUND" });
-      return ctx.dataStore.matterEventSuggestions.update({
-        where: { id: ev.id },
-        data: { status: "ACCEPTED" },
-      });
+      return ctx.repos.matterEventSuggestions.update(ev.id, { status: "ACCEPTED" } as Partial<MatterEventSuggestion>);
     }),
 };

--- a/src/lib/server/routers/document/folders.ts
+++ b/src/lib/server/routers/document/folders.ts
@@ -8,6 +8,7 @@
 
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import type { Document, DocumentFolder } from "@/lib/shared/schemas/document";
 import {
   matterIdSchema,
   documentFolderIdSchema,
@@ -28,50 +29,36 @@ export const folderProcedures = {
     )
     .mutation(async ({ ctx, input }) => {
       await assertMatterAccess(ctx, input.matterId);
-      return ctx.dataStore.documentFolders.create({
-        data: {
-          name: input.name,
-          matterId: input.matterId,
-          parentId: input.parentId,
-        },
-      });
+      return ctx.repos.documentFolders.create({
+        name: input.name,
+        matterId: input.matterId,
+        parentId: input.parentId,
+      } as Partial<DocumentFolder>);
     }),
 
   renameFolder: orgProcedure
     .input(z.object({ id: documentFolderIdSchema, name: z.string().min(1) }))
-    .mutation(async ({ ctx, input }) => {
-      return ctx.dataStore.documentFolders.update({
-        where: { id: input.id },
-        data: { name: input.name },
-      });
-    }),
+    .mutation(({ ctx, input }) =>
+      ctx.repos.documentFolders.update(input.id, { name: input.name } as Partial<DocumentFolder>),
+    ),
 
   /** Flyttar innehåll till parent och raderar mappen. */
   deleteFolder: orgProcedure
     .input(z.object({ id: documentFolderIdSchema }))
     .mutation(async ({ ctx, input }) => {
-      const folder = await ctx.dataStore.documentFolders.findUniqueOrThrow({
-        where: { id: input.id },
-      });
-      await ctx.dataStore.documents.updateMany({
-        where: { folderId: input.id },
-        data: { folderId: folder.parentId },
-      });
-      await ctx.dataStore.documentFolders.updateMany({
-        where: { parentId: input.id },
-        data: { parentId: folder.parentId },
-      });
-      return ctx.dataStore.documentFolders.delete({ where: { id: input.id } });
+      const folder = await ctx.repos.documentFolders.getByIdOrThrow(input.id);
+      const parentId = (folder.parentId as DocumentFolderId | null | undefined) ?? null;
+      await ctx.repos.documents.reassignFolder(input.id, parentId);
+      await ctx.repos.documentFolders.reassignParent(input.id, parentId);
+      await ctx.repos.documentFolders.hardDelete(input.id);
+      return folder;
     }),
 
   moveDocument: orgProcedure
     .input(z.object({ documentId: documentIdSchema, folderId: documentFolderIdSchema.nullable() }))
-    .mutation(async ({ ctx, input }) => {
-      return ctx.dataStore.documents.update({
-        where: { id: input.documentId },
-        data: { folderId: input.folderId },
-      });
-    }),
+    .mutation(({ ctx, input }) =>
+      ctx.repos.documents.update(input.documentId, { folderId: input.folderId } as unknown as Partial<Document>),
+    ),
 
   /** Flyttar en mapp; blockerar cykler (mapp-in-i-sig-själv/descendant). */
   moveFolder: orgProcedure
@@ -86,17 +73,13 @@ export const folderProcedures = {
               message: "Cannot move a folder into itself or a descendant",
             });
           }
-          const parent = await ctx.dataStore.documentFolders.findUnique({
-            where: { id: checkId },
-            select: { parentId: true },
-          });
+          const parent = await ctx.repos.documentFolders.getById(checkId);
           checkId = (parent?.parentId as DocumentFolderId | null | undefined) ?? null;
         }
       }
-      return ctx.dataStore.documentFolders.update({
-        where: { id: input.folderId },
-        data: { parentId: input.targetParentId },
-      });
+      return ctx.repos.documentFolders.update(
+        input.folderId, { parentId: input.targetParentId } as Partial<DocumentFolder>,
+      );
     }),
 
   /** Breadcrumb-stig från rot till vald mapp. */
@@ -106,10 +89,7 @@ export const folderProcedures = {
       const path: { id: string; name: string }[] = [];
       let currentId: DocumentFolderId | null = input.folderId;
       while (currentId) {
-        const folder = await ctx.dataStore.documentFolders.findUnique({
-          where: { id: currentId },
-          select: { id: true, name: true, parentId: true },
-        });
+        const folder = await ctx.repos.documentFolders.getById(currentId);
         if (!folder) break;
         path.unshift({ id: folder.id, name: folder.name });
         currentId = (folder.parentId as DocumentFolderId | null | undefined) ?? null;

--- a/src/lib/server/routers/document/shared.ts
+++ b/src/lib/server/routers/document/shared.ts
@@ -3,29 +3,26 @@
  *
  * `assertDocAccess` och `assertMatterAccess` är internals i document-subrouters
  * och exporteras härifrån för att slippa duplicera dem i varje fil.
+ *
+ * Migrerade till repository-sömmen (ADR 0020): org-scopningen bor i
+ * `repos.documents.getByIdInOrg` / `repos.matters.getByIdInOrg`.
  */
 
 import { TRPCError } from "@trpc/server";
-import type { IDataStore } from "../../data-store/IDataStore";
+import type { Repositories } from "../../repositories/repositories";
 
-export type DocCtx = { dataStore: IDataStore; orgId: string };
+export type DocCtx = { repos: Repositories; orgId: string };
 
 /** Verifiera att dokumentet finns och tillhör anropande org. */
 export async function assertDocAccess(ctx: DocCtx, documentId: string) {
-  const doc = await ctx.dataStore.documents.findFirst({
-    where: { id: documentId, matter: { organizationId: ctx.orgId } },
-    select: { id: true, matterId: true },
-  });
+  const doc = await ctx.repos.documents.getByIdInOrg(documentId, ctx.orgId);
   if (!doc) throw new TRPCError({ code: "NOT_FOUND" });
   return doc;
 }
 
 /** Verifiera att ärendet finns och tillhör anropande org. */
 export async function assertMatterAccess(ctx: DocCtx, matterId: string) {
-  const m = await ctx.dataStore.matters.findFirst({
-    where: { id: matterId, organizationId: ctx.orgId },
-    select: { id: true },
-  });
+  const m = await ctx.repos.matters.getByIdInOrg(matterId, ctx.orgId);
   if (!m) throw new TRPCError({ code: "NOT_FOUND" });
   return m;
 }

--- a/src/lib/server/routers/document/suggestions.ts
+++ b/src/lib/server/routers/document/suggestions.ts
@@ -13,33 +13,18 @@ import {
   findExistingContactForSuggestion,
   type ContactCandidate,
 } from "@/lib/shared/contact-dedup";
+import type { DocumentAnalysisSuggestion } from "@/lib/shared/schemas/document";
 import { matterRoleSchema, contactTypeSchema, type SuggestionStatus } from "@/lib/shared/schemas/enums";
 import { asId, type ContactId } from "@/lib/shared/schemas/ids";
+import type { MatterContact } from "@/lib/shared/schemas/matter";
 import { groupSuggestions, type RawSuggestion } from "@/lib/shared/suggestion-grouping";
+import type { Repositories } from "../../repositories/repositories";
 import { orgProcedure } from "../../trpc";
 
 // ─── Helpers för acceptSuggestion ─────────────────────────────────────────
 
-type Ctx = {
-  dataStore: {
-    documentAnalysisSuggestions: {
-      findFirst: (...a: never[]) => Promise<unknown>;
-      findMany: (...a: never[]) => Promise<unknown>;
-      update: (...a: never[]) => Promise<unknown>;
-      updateMany: (...a: never[]) => Promise<unknown>;
-    };
-    contacts: {
-      findFirst: (...a: never[]) => Promise<unknown>;
-      create: (...a: never[]) => Promise<unknown>;
-    };
-    matterContacts: {
-      findFirst: (...a: never[]) => Promise<unknown>;
-      findMany: (...a: never[]) => Promise<unknown>;
-      create: (...a: never[]) => Promise<unknown>;
-    };
-  };
-  orgId: string;
-};
+// Migrerad till repository-sömmen (ADR 0020): all IO går via ctx.repos.
+type Ctx = { repos: Repositories; orgId: string };
 type SuggOverride = {
   name?: string | undefined;
   role?: string | undefined;
@@ -64,13 +49,7 @@ type Suggestion = {
 };
 
 async function loadPendingSuggestion(ctx: Ctx, suggestionId: string): Promise<Suggestion> {
-  const sugg = (await ctx.dataStore.documentAnalysisSuggestions.findFirst({
-    where: {
-      id: suggestionId,
-      document: { matter: { organizationId: ctx.orgId } },
-    },
-    include: { document: { select: { matterId: true } } },
-  } as never)) as Suggestion | null;
+  const sugg = (await ctx.repos.documentAnalysisSuggestions.getByIdInOrg(suggestionId, ctx.orgId)) as Suggestion | null;
   if (!sugg) throw new TRPCError({ code: "NOT_FOUND" });
   if (sugg.status !== "PENDING") {
     throw new TRPCError({ code: "BAD_REQUEST", message: "Suggestion already handled" });
@@ -79,9 +58,7 @@ async function loadPendingSuggestion(ctx: Ctx, suggestionId: string): Promise<Su
 }
 
 async function resolveExistingContact(ctx: Ctx, contactId: string): Promise<ContactId> {
-  const existing = (await ctx.dataStore.contacts.findFirst({
-    where: { id: contactId, organizationId: ctx.orgId },
-  } as never)) as { id: ContactId } | null;
+  const existing = (await ctx.repos.contacts.getByIdFull(contactId, ctx.orgId)) as { id: ContactId } | null;
   if (!existing) throw new TRPCError({ code: "NOT_FOUND" });
   return existing.id;
 }
@@ -96,19 +73,12 @@ async function findContactByNumberOrName(
   const pn = o.personalNumber ?? sugg.personalNumber;
   const on = o.orgNumber ?? sugg.orgNumber;
   if (pn) {
-    return (await ctx.dataStore.contacts.findFirst({
-      where: { personalNumber: pn, organizationId: ctx.orgId },
-    } as never)) as ContactCandidate | null;
+    return (await ctx.repos.contacts.findByPersonalNumber(ctx.orgId, pn)) as ContactCandidate | null;
   }
   if (on) {
-    return (await ctx.dataStore.contacts.findFirst({
-      where: { orgNumber: on, organizationId: ctx.orgId },
-    } as never)) as ContactCandidate | null;
+    return (await ctx.repos.contacts.findByOrgNumber(ctx.orgId, on)) as ContactCandidate | null;
   }
-  const matterLinks = (await ctx.dataStore.matterContacts.findMany({
-    where: { matterId },
-    include: { contact: true },
-  } as never)) as Array<{ contact: ContactCandidate }>;
+  const matterContacts = (await ctx.repos.matterContacts.listContactsForMatter(matterId)) as ContactCandidate[];
   const dedup = findExistingContactForSuggestion(
     {
       name: o.name ?? sugg.name,
@@ -117,7 +87,7 @@ async function findContactByNumberOrName(
       orgNumber: null,
     },
     [],
-    matterLinks.map((l) => l.contact),
+    matterContacts,
   );
   return dedup.kind === "match" ? dedup.contact : null;
 }
@@ -150,9 +120,9 @@ async function resolveOrCreateContact(
 ): Promise<ContactId> {
   const existing = await findContactByNumberOrName(ctx, sugg, o, matterId);
   if (existing) return asId<"ContactId">(existing.id);
-  const created = (await ctx.dataStore.contacts.create({
-    data: { ...applyOverride(sugg, o), organizationId: ctx.orgId },
-  } as never)) as { id: ContactId };
+  const created = (await ctx.repos.contacts.create(
+    { ...applyOverride(sugg, o), organizationId: ctx.orgId } as never,
+  )) as { id: ContactId };
   return created.id;
 }
 
@@ -163,13 +133,9 @@ async function ensureMatterContactLink(
   role: string,
   notes: string | null,
 ): Promise<void> {
-  const existing = await ctx.dataStore.matterContacts.findFirst({
-    where: { matterId, contactId, role },
-  } as never);
+  const existing = await ctx.repos.matterContacts.findLink(matterId, contactId, role);
   if (!existing) {
-    await ctx.dataStore.matterContacts.create({
-      data: { matterId, contactId, role, notes },
-    } as never);
+    await ctx.repos.matterContacts.create({ matterId, contactId, role, notes } as Partial<MatterContact>);
   }
 }
 
@@ -177,14 +143,7 @@ async function ensureMatterContactLink(
 
 /** Hämta + validera en grupp av förslag (existerar, pending, samma ärende). */
 async function loadPendingGroup(ctx: Ctx, suggestionIds: string[]): Promise<Suggestion[]> {
-  const suggs = (await ctx.dataStore.documentAnalysisSuggestions.findMany({
-    where: {
-      id: { in: suggestionIds },
-      status: "PENDING",
-      document: { matter: { organizationId: ctx.orgId } },
-    },
-    include: { document: { select: { matterId: true } } },
-  } as never)) as Suggestion[];
+  const suggs = (await ctx.repos.documentAnalysisSuggestions.listPendingByIds(suggestionIds, ctx.orgId)) as Suggestion[];
 
   if (suggs.length === 0) throw new TRPCError({ code: "NOT_FOUND" });
   if (suggs.length !== suggestionIds.length) {
@@ -222,16 +181,14 @@ async function resolveOrCreateGroupContact(
   const orgNumber = pickFirstFromGroup(suggs, "orgNumber");
   const existing = await findGroupContact(ctx, suggs, matterId, personalNumber, orgNumber);
   if (existing) return asId<"ContactId">(existing.id);
-  const created = (await ctx.dataStore.contacts.create({
-    data: {
-      name: first.name,
-      contactType: first.contactType,
-      email: pickFirstFromGroup(suggs, "email"),
-      phone: pickFirstFromGroup(suggs, "phone"),
-      personalNumber,
-      orgNumber,
-      organizationId: ctx.orgId,
-    },
+  const created = (await ctx.repos.contacts.create({
+    name: first.name,
+    contactType: first.contactType,
+    email: pickFirstFromGroup(suggs, "email"),
+    phone: pickFirstFromGroup(suggs, "phone"),
+    personalNumber,
+    orgNumber,
+    organizationId: ctx.orgId,
   } as never)) as { id: ContactId };
   return created.id;
 }
@@ -244,20 +201,13 @@ async function findGroupContact(
   orgNumber: string | null,
 ): Promise<ContactCandidate | null> {
   if (personalNumber) {
-    return (await ctx.dataStore.contacts.findFirst({
-      where: { personalNumber, organizationId: ctx.orgId },
-    } as never)) as ContactCandidate | null;
+    return (await ctx.repos.contacts.findByPersonalNumber(ctx.orgId, personalNumber)) as ContactCandidate | null;
   }
   if (orgNumber) {
-    return (await ctx.dataStore.contacts.findFirst({
-      where: { orgNumber, organizationId: ctx.orgId },
-    } as never)) as ContactCandidate | null;
+    return (await ctx.repos.contacts.findByOrgNumber(ctx.orgId, orgNumber)) as ContactCandidate | null;
   }
   // Namn-fallback scopad till ärendet (se contact-dedup.ts).
-  const matterLinks = (await ctx.dataStore.matterContacts.findMany({
-    where: { matterId },
-    include: { contact: true },
-  } as never)) as Array<{ contact: ContactCandidate }>;
+  const matterContacts = (await ctx.repos.matterContacts.listContactsForMatter(matterId)) as ContactCandidate[];
   const first = suggs[0];
   if (!first) return null;
   const dedup = findExistingContactForSuggestion(
@@ -268,7 +218,7 @@ async function findGroupContact(
       orgNumber: null,
     },
     [],
-    matterLinks.map((l) => l.contact),
+    matterContacts,
   );
   return dedup.kind === "match" ? dedup.contact : null;
 }
@@ -295,17 +245,7 @@ export const suggestionProcedures = {
   pendingSuggestions: orgProcedure
     .input(z.object({ matterId: z.string() }))
     .query(({ ctx, input }) =>
-      ctx.dataStore.documentAnalysisSuggestions.findMany({
-        where: {
-          status: "PENDING",
-          document: {
-            matterId: input.matterId,
-            matter: { organizationId: ctx.orgId },
-          },
-        },
-        include: { document: { select: { id: true, fileName: true, title: true } } },
-        orderBy: { createdAt: "desc" },
-      }),
+      ctx.repos.documentAnalysisSuggestions.listPendingForMatter(input.matterId, ctx.orgId, "desc"),
     ),
 
   /**
@@ -315,17 +255,7 @@ export const suggestionProcedures = {
   pendingSuggestionsGrouped: orgProcedure
     .input(z.object({ matterId: z.string() }))
     .query(async ({ ctx, input }) => {
-      const rows = await ctx.dataStore.documentAnalysisSuggestions.findMany({
-        where: {
-          status: "PENDING",
-          document: {
-            matterId: input.matterId,
-            matter: { organizationId: ctx.orgId },
-          },
-        },
-        include: { document: { select: { id: true, fileName: true, title: true } } },
-        orderBy: { createdAt: "asc" }, // asc → första förekomst vinner i first-non-empty
-      });
+      const rows = await ctx.repos.documentAnalysisSuggestions.listPendingForMatter(input.matterId, ctx.orgId, "asc");
       return groupSuggestions(rows as unknown as RawSuggestion[]);
     }),
 
@@ -365,27 +295,20 @@ export const suggestionProcedures = {
         : await resolveOrCreateContact(ctx, sugg, o, matterId);
 
       await ensureMatterContactLink(ctx, matterId, contactId, finalRole, sugg.notes);
-      await ctx.dataStore.documentAnalysisSuggestions.update({
-        where: { id: sugg.id },
-        data: { status: "ACCEPTED", acceptedContactId: contactId },
-      });
+      await ctx.repos.documentAnalysisSuggestions.update(
+        sugg.id, { status: "ACCEPTED", acceptedContactId: contactId } as Partial<DocumentAnalysisSuggestion>,
+      );
       return { contactId };
     }),
 
   rejectSuggestion: orgProcedure
     .input(z.object({ suggestionId: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      const sugg = await ctx.dataStore.documentAnalysisSuggestions.findFirst({
-        where: {
-          id: input.suggestionId,
-          document: { matter: { organizationId: ctx.orgId } },
-        },
-      });
+      const sugg = await ctx.repos.documentAnalysisSuggestions.getByIdInOrg(input.suggestionId, ctx.orgId);
       if (!sugg) throw new TRPCError({ code: "NOT_FOUND" });
-      return ctx.dataStore.documentAnalysisSuggestions.update({
-        where: { id: sugg.id },
-        data: { status: "REJECTED" },
-      });
+      return ctx.repos.documentAnalysisSuggestions.update(
+        sugg.id, { status: "REJECTED" } as Partial<DocumentAnalysisSuggestion>,
+      );
     }),
 
   /**
@@ -412,10 +335,10 @@ export const suggestionProcedures = {
         : await resolveOrCreateGroupContact(ctx, suggs, matterId);
 
       const distinctRoles = await linkGroupRoles(ctx, suggs, matterId, contactId);
-      await ctx.dataStore.documentAnalysisSuggestions.updateMany({
-        where: { id: { in: suggs.map((s) => s.id) } },
-        data: { status: "ACCEPTED", acceptedContactId: contactId },
-      } as never);
+      await ctx.repos.documentAnalysisSuggestions.updateManyByIds(
+        suggs.map((s) => s.id),
+        { status: "ACCEPTED", acceptedContactId: contactId } as Partial<DocumentAnalysisSuggestion>,
+      );
       return { contactId, acceptedRoles: distinctRoles };
     }),
 
@@ -423,13 +346,7 @@ export const suggestionProcedures = {
   rejectSuggestionGroup: orgProcedure
     .input(z.object({ suggestionIds: z.array(z.string()).min(1) }))
     .mutation(async ({ ctx, input }) => {
-      const suggs = await ctx.dataStore.documentAnalysisSuggestions.findMany({
-        where: {
-          id: { in: input.suggestionIds },
-          document: { matter: { organizationId: ctx.orgId } },
-        },
-        select: { id: true },
-      });
+      const suggs = await ctx.repos.documentAnalysisSuggestions.listByIdsInOrg(input.suggestionIds, ctx.orgId);
       if (suggs.length === 0) throw new TRPCError({ code: "NOT_FOUND" });
       if (suggs.length !== input.suggestionIds.length) {
         throw new TRPCError({
@@ -437,10 +354,9 @@ export const suggestionProcedures = {
           message: "Några förslag saknas eller tillhör annan org.",
         });
       }
-      await ctx.dataStore.documentAnalysisSuggestions.updateMany({
-        where: { id: { in: suggs.map((s) => s.id) } },
-        data: { status: "REJECTED" },
-      });
+      await ctx.repos.documentAnalysisSuggestions.updateManyByIds(
+        suggs.map((s) => s.id), { status: "REJECTED" } as Partial<DocumentAnalysisSuggestion>,
+      );
       return { rejected: suggs.length };
     }),
 };

--- a/src/lib/server/routers/documentTemplate.ts
+++ b/src/lib/server/routers/documentTemplate.ts
@@ -6,35 +6,20 @@ import {
   documentTemplateIdSchema,
   userIdSchema,
 } from "@/lib/shared/schemas/ids";
+import type { DocumentTemplate } from "@/lib/shared/schemas/misc";
 import { router, protectedProcedure } from "../trpc";
 
 export const documentTemplateRouter = router({
-  list: protectedProcedure.query(async ({ ctx }) => {
-    return ctx.dataStore.documentTemplates.findMany({
-      where: { organizationId: ctx.user.organizationId },
-      select: {
-        id: true,
-        name: true,
-        description: true,
-        category: true,
-        createdAt: true,
-        updatedAt: true,
-        createdBy: { select: { name: true } },
-      },
-      orderBy: [{ category: "asc" }, { name: "asc" }],
-    });
-  }),
+  // Migrerad till repository-sömmen (ADR 0020).
+  list: protectedProcedure.query(({ ctx }) =>
+    ctx.repos.documentTemplates.listForOrg(ctx.user.organizationId),
+  ),
 
   getById: protectedProcedure
     .input(z.object({ id: z.string() }))
     .query(async ({ ctx, input }) => {
-      const template = await ctx.dataStore.documentTemplates.findUnique({
-        where: { id: input.id },
-        include: { createdBy: { select: { name: true } } },
-      });
-      if (!template || template.organizationId !== ctx.user.organizationId) {
-        throw new TRPCError({ code: "NOT_FOUND" });
-      }
+      const template = await ctx.repos.documentTemplates.getByIdInOrg(input.id, ctx.user.organizationId);
+      if (!template) throw new TRPCError({ code: "NOT_FOUND" });
       return template;
     }),
 
@@ -52,20 +37,18 @@ export const documentTemplateRouter = router({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      return ctx.dataStore.documentTemplates.create({
-        data: {
-          ...omitUndefined({
-            id: input.id, // undefined → store genererar
-            name: input.name,
-            description: input.description,
-            category: input.category,
-            content: input.content,
-            organizationId: asId<"OrganizationId">(ctx.user.organizationId),
-            createdById: input.createdById ?? asId<"UserId">(ctx.user.id),
-          }),
-          ...(input.createdAt ? { createdAt: new Date(input.createdAt) } : {}),
-        },
-      });
+      return ctx.repos.documentTemplates.create({
+        ...omitUndefined({
+          id: input.id, // undefined → store genererar
+          name: input.name,
+          description: input.description,
+          category: input.category,
+          content: input.content,
+          organizationId: asId<"OrganizationId">(ctx.user.organizationId),
+          createdById: input.createdById ?? asId<"UserId">(ctx.user.id),
+        }),
+        ...(input.createdAt ? { createdAt: new Date(input.createdAt) } : {}),
+      } as Partial<DocumentTemplate>);
     }),
 
   update: protectedProcedure
@@ -79,30 +62,17 @@ export const documentTemplateRouter = router({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const existing = await ctx.dataStore.documentTemplates.findUnique({
-        where: { id: input.id },
-        select: { organizationId: true },
-      });
-      if (!existing || existing.organizationId !== ctx.user.organizationId) {
-        throw new TRPCError({ code: "NOT_FOUND" });
-      }
+      const existing = await ctx.repos.documentTemplates.getByIdInOrg(input.id, ctx.user.organizationId);
+      if (!existing) throw new TRPCError({ code: "NOT_FOUND" });
       const { id, name, description, category, content } = input;
-      return ctx.dataStore.documentTemplates.update({
-        where: { id },
-        data: omitUndefined({ name, description, category, content }),
-      });
+      return ctx.repos.documentTemplates.update(id, omitUndefined({ name, description, category, content }) as Partial<DocumentTemplate>);
     }),
 
   delete: protectedProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      const existing = await ctx.dataStore.documentTemplates.findUnique({
-        where: { id: input.id },
-        select: { organizationId: true },
-      });
-      if (!existing || existing.organizationId !== ctx.user.organizationId) {
-        throw new TRPCError({ code: "NOT_FOUND" });
-      }
-      await ctx.dataStore.documentTemplates.delete({ where: { id: input.id } });
+      const existing = await ctx.repos.documentTemplates.getByIdInOrg(input.id, ctx.user.organizationId);
+      if (!existing) throw new TRPCError({ code: "NOT_FOUND" });
+      await ctx.repos.documentTemplates.hardDelete(input.id);
     }),
 });

--- a/src/lib/server/routers/expectedReceivable.ts
+++ b/src/lib/server/routers/expectedReceivable.ts
@@ -15,20 +15,16 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
+import type { ExpectedReceivable } from "@/lib/shared/schemas/billing";
 import { expectedReceivableStatusSchema } from "@/lib/shared/schemas/billing";
 import { asId } from "@/lib/shared/schemas/ids";
+import type { Repositories } from "../repositories/repositories";
 import { router, orgProcedure } from "../trpc";
 
-type Ctx = { dataStore: { expectedReceivables: { findUnique: (a: unknown) => Promise<unknown> } }; orgId: string };
-
-/** Hämta en fordran och verifiera org-tillhörighet. */
-async function assertInOrg(ctx: Ctx, id: string): Promise<{ id: string; status: string }> {
-  const row = (await ctx.dataStore.expectedReceivables.findUnique({ where: { id } })) as
-    | { id: string; organizationId?: string; status: string }
-    | null;
-  if (!row || row.organizationId !== ctx.orgId) {
-    throw new TRPCError({ code: "NOT_FOUND", message: "Fordran finns inte i organisationen." });
-  }
+/** Hämta en fordran och verifiera org-tillhörighet (repository-sömmen, ADR 0020). */
+async function assertInOrg(repos: Repositories, orgId: string, id: string): Promise<ExpectedReceivable> {
+  const row = await repos.expectedReceivables.getByIdInOrg(id, orgId);
+  if (!row) throw new TRPCError({ code: "NOT_FOUND", message: "Fordran finns inte i organisationen." });
   return row;
 }
 
@@ -36,15 +32,9 @@ export const expectedReceivableRouter = router({
   /** Lista fordringar i org:en, valfritt filtrerat på ärende. */
   list: orgProcedure
     .input(z.object({ matterId: z.string().optional() }).optional())
-    .query(async ({ ctx, input }) => {
-      return ctx.dataStore.expectedReceivables.findMany({
-        where: {
-          organizationId: ctx.orgId,
-          ...(input?.matterId ? { matterId: input.matterId } : {}),
-        },
-        orderBy: { createdAt: "desc" },
-      });
-    }),
+    .query(({ ctx, input }) =>
+      ctx.repos.expectedReceivables.listForOrg(ctx.orgId, { matterId: input?.matterId }),
+    ),
 
   /**
    * Matchnings-kandidater för camt-avprickning (#175): öppna (PENDING)
@@ -52,13 +42,10 @@ export const expectedReceivableRouter = router({
    * och referens matchas client-side av `matchReceivables`.
    */
   candidates: orgProcedure.query(async ({ ctx }) => {
-    const rows = (await ctx.dataStore.expectedReceivables.findMany({
-      where: { organizationId: ctx.orgId, status: "PENDING" },
-      orderBy: { createdAt: "desc" },
-    })) as Array<{ id: string; matterId: string; description: string; expectedAmount: number }>;
-    const matters = (await ctx.dataStore.matters.findMany({
-      where: { organizationId: ctx.orgId },
-    })) as Array<{ id: string; matterNumber?: string | null; courtCaseNumber?: string | null }>;
+    const rows = (await ctx.repos.expectedReceivables.listForOrg(ctx.orgId, { status: "PENDING" })) as
+      Array<{ id: string; matterId: string; description: string; expectedAmount: number }>;
+    const matters = (await ctx.repos.matters.listByOrg(ctx.orgId)) as
+      Array<{ id: string; matterNumber?: string | null; courtCaseNumber?: string | null }>;
     const byId = new Map(matters.map((m) => [String(m.id), m]));
     return rows.map((r) => {
       const m = byId.get(String(r.matterId));
@@ -82,24 +69,20 @@ export const expectedReceivableRouter = router({
     }))
     .mutation(async ({ ctx, input }) => {
       // Ärendet måste tillhöra org:en (annars läcker man fordringar in i andra byråer).
-      const matter = await ctx.dataStore.matters.findFirst({
-        where: { id: input.matterId, organizationId: ctx.orgId },
-      });
+      const matter = await ctx.repos.matters.getByIdInOrg(input.matterId, ctx.orgId);
       if (!matter) throw new TRPCError({ code: "NOT_FOUND", message: "Ärendet finns inte i organisationen." });
 
       const now = new Date();
-      return ctx.dataStore.expectedReceivables.create({
-        data: {
-          matterId: asId<"MatterId">(input.matterId),
-          description: input.description,
-          expectedAmount: input.expectedAmount,
-          status: "PENDING",
-          organizationId: asId<"OrganizationId">(ctx.orgId),
-          recordedById: asId<"UserId">(ctx.user.id),
-          createdAt: now,
-          updatedAt: now,
-        },
-      });
+      return ctx.repos.expectedReceivables.create({
+        matterId: asId<"MatterId">(input.matterId),
+        description: input.description,
+        expectedAmount: input.expectedAmount,
+        status: "PENDING",
+        organizationId: asId<"OrganizationId">(ctx.orgId),
+        recordedById: asId<"UserId">(ctx.user.id),
+        createdAt: now,
+        updatedAt: now,
+      } as Partial<ExpectedReceivable>);
     }),
 
   /**
@@ -115,28 +98,22 @@ export const expectedReceivableRouter = router({
       paymentReference: z.string().optional(),
     }))
     .mutation(async ({ ctx, input }) => {
-      await assertInOrg(ctx, input.id);
-      return ctx.dataStore.expectedReceivables.update({
-        where: { id: input.id },
-        data: {
-          status: "SETTLED",
-          settledAmount: input.settledAmount,
-          settledAt: input.settledAt ? new Date(input.settledAt) : new Date(),
-          ...(input.paymentReference !== undefined ? { paymentReference: input.paymentReference } : {}),
-          updatedAt: new Date(),
-        },
-      });
+      await assertInOrg(ctx.repos, ctx.orgId, input.id);
+      return ctx.repos.expectedReceivables.update(input.id, {
+        status: "SETTLED",
+        settledAmount: input.settledAmount,
+        settledAt: input.settledAt ? new Date(input.settledAt) : new Date(),
+        ...(input.paymentReference !== undefined ? { paymentReference: input.paymentReference } : {}),
+        updatedAt: new Date(),
+      } as Partial<ExpectedReceivable>);
     }),
 
   /** Avbryt en fordran (t.ex. felregistrerad eller domstolen avslog helt). */
   cancel: orgProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      await assertInOrg(ctx, input.id);
-      return ctx.dataStore.expectedReceivables.update({
-        where: { id: input.id },
-        data: { status: "CANCELLED", updatedAt: new Date() },
-      });
+      await assertInOrg(ctx.repos, ctx.orgId, input.id);
+      return ctx.repos.expectedReceivables.update(input.id, { status: "CANCELLED", updatedAt: new Date() } as Partial<ExpectedReceivable>);
     }),
 
   /** Uppdatera memo-fälten (begärt belopp/beskrivning) medan PENDING. */
@@ -148,11 +125,8 @@ export const expectedReceivableRouter = router({
       status: expectedReceivableStatusSchema.optional(),
     }))
     .mutation(async ({ ctx, input }) => {
-      await assertInOrg(ctx, input.id);
+      await assertInOrg(ctx.repos, ctx.orgId, input.id);
       const { id, ...rest } = input;
-      return ctx.dataStore.expectedReceivables.update({
-        where: { id },
-        data: { ...omitUndefined(rest), updatedAt: new Date() },
-      });
+      return ctx.repos.expectedReceivables.update(id, { ...omitUndefined(rest), updatedAt: new Date() } as Partial<ExpectedReceivable>);
     }),
 });

--- a/src/lib/server/routers/invoiceDispatch.ts
+++ b/src/lib/server/routers/invoiceDispatch.ts
@@ -11,19 +11,17 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { canTransition } from "@/lib/shared/invoice-state-machine";
-import { dispatchChannelSchema, dispatchStatusSchema, type DispatchStatus } from "@/lib/shared/schemas/billing";
+import { dispatchChannelSchema, dispatchStatusSchema, type DispatchStatus, type InvoiceDispatch } from "@/lib/shared/schemas/billing";
 import type { InvoiceStatus } from "@/lib/shared/schemas/enums";
 import { asId } from "@/lib/shared/schemas/ids";
-import type { IDataStore } from "../data-store/IDataStore";
+import type { Repositories } from "../repositories/repositories";
 import { router, orgProcedure } from "../trpc";
 
-type DispatchCtx = { dataStore: IDataStore; orgId: string };
+type DispatchCtx = { repos: Repositories; orgId: string };
 
-/** Verifiera org-tillhörighet + returnera fakturans id/status. */
+/** Verifiera org-tillhörighet + returnera fakturans id/status (repository-sömmen, ADR 0020). */
 async function assertInvoiceInOrg(ctx: DispatchCtx, invoiceId: string): Promise<{ id: string; status: string }> {
-  const inv = (await ctx.dataStore.invoices.findFirst({
-    where: { id: invoiceId, matter: { organizationId: ctx.orgId } },
-  })) as { id: string; status: string } | null;
+  const inv = await ctx.repos.invoices.getByIdInOrg(invoiceId, ctx.orgId);
   if (!inv) throw new TRPCError({ code: "NOT_FOUND", message: "Fakturan finns inte i organisationen." });
   return inv;
 }
@@ -34,7 +32,7 @@ async function assertInvoiceInOrg(ctx: DispatchCtx, invoiceId: string): Promise<
  */
 async function markSentIfDraft(ctx: DispatchCtx, inv: { id: string; status: string }): Promise<void> {
   if (inv.status !== "DRAFT" || !canTransition("DRAFT", "SENT")) return;
-  await ctx.dataStore.invoices.update({ where: { id: inv.id }, data: { status: "SENT" satisfies InvoiceStatus } });
+  await ctx.repos.invoices.update(inv.id, { status: "SENT" satisfies InvoiceStatus });
 }
 
 /** Tidsstämpelfältet som en statusövergång sätter (queued sätts vid skapande). */
@@ -50,20 +48,13 @@ export const invoiceDispatchRouter = router({
     .input(z.object({ invoiceId: z.string() }))
     .query(async ({ ctx, input }) => {
       await assertInvoiceInOrg(ctx, input.invoiceId);
-      return ctx.dataStore.invoiceDispatches.findMany({
-        where: { invoiceId: input.invoiceId },
-        orderBy: { queuedAt: "desc" },
-      });
+      return ctx.repos.invoiceDispatches.listByInvoice(input.invoiceId);
     }),
 
   /** Alla köade utskick i org:en — server-runtime-dispatch-workern (#180) plockar dessa. */
-  listQueued: orgProcedure.query(async ({ ctx }) => {
-    return ctx.dataStore.invoiceDispatches.findMany({
-      where: { status: "queued", invoice: { matter: { organizationId: ctx.orgId } } },
-      include: { invoice: { select: { id: true, invoiceNumber: true, amount: true, ocrReference: true, dueDate: true } } },
-      orderBy: { queuedAt: "asc" },
-    });
-  }),
+  listQueued: orgProcedure.query(({ ctx }) =>
+    ctx.repos.invoiceDispatches.listQueuedForOrg(ctx.orgId),
+  ),
 
   queue: orgProcedure
     .input(z.object({
@@ -74,17 +65,15 @@ export const invoiceDispatchRouter = router({
     .mutation(async ({ ctx, input }) => {
       const inv = await assertInvoiceInOrg(ctx, input.invoiceId);
       const now = new Date();
-      const dispatch = await ctx.dataStore.invoiceDispatches.create({
-        data: {
-          invoiceId: asId<"InvoiceId">(input.invoiceId),
-          channel: input.channel,
-          recipient: input.recipient,
-          status: "queued",
-          queuedAt: now,
-          recordedById: asId<"UserId">(ctx.user.id),
-          createdAt: now,
-        },
-      });
+      const dispatch = await ctx.repos.invoiceDispatches.create({
+        invoiceId: asId<"InvoiceId">(input.invoiceId),
+        channel: input.channel,
+        recipient: input.recipient,
+        status: "queued",
+        queuedAt: now,
+        recordedById: asId<"UserId">(ctx.user.id),
+        createdAt: now,
+      } as Partial<InvoiceDispatch>);
       // Köad för automatiskt utskick → fakturan är inte längre ett utkast (#392).
       await markSentIfDraft(ctx, inv);
       return dispatch;
@@ -107,18 +96,16 @@ export const invoiceDispatchRouter = router({
     .mutation(async ({ ctx, input }) => {
       const inv = await assertInvoiceInOrg(ctx, input.invoiceId);
       const now = new Date();
-      const dispatch = await ctx.dataStore.invoiceDispatches.create({
-        data: {
-          invoiceId: asId<"InvoiceId">(input.invoiceId),
-          channel: input.channel,
-          recipient: input.recipient,
-          status: "sent",
-          queuedAt: now,
-          sentAt: now,
-          recordedById: asId<"UserId">(ctx.user.id),
-          createdAt: now,
-        },
-      });
+      const dispatch = await ctx.repos.invoiceDispatches.create({
+        invoiceId: asId<"InvoiceId">(input.invoiceId),
+        channel: input.channel,
+        recipient: input.recipient,
+        status: "sent",
+        queuedAt: now,
+        sentAt: now,
+        recordedById: asId<"UserId">(ctx.user.id),
+        createdAt: now,
+      } as Partial<InvoiceDispatch>);
       // Manuellt skickad → fakturan är inte längre ett utkast (#392).
       await markSentIfDraft(ctx, inv);
       return dispatch;
@@ -132,19 +119,16 @@ export const invoiceDispatchRouter = router({
       error: z.string().optional(),
     }))
     .mutation(async ({ ctx, input }) => {
-      const dispatch = await ctx.dataStore.invoiceDispatches.findUnique({ where: { id: input.dispatchId } });
+      const dispatch = await ctx.repos.invoiceDispatches.getById(input.dispatchId);
       if (!dispatch) throw new TRPCError({ code: "NOT_FOUND" });
       await assertInvoiceInOrg(ctx, String(dispatch.invoiceId));
 
       const tsField = STATUS_TIMESTAMP[input.status];
-      return ctx.dataStore.invoiceDispatches.update({
-        where: { id: input.dispatchId },
-        data: {
-          status: input.status,
-          ...(tsField ? { [tsField]: new Date() } : {}),
-          ...(input.messageId !== undefined ? { messageId: input.messageId } : {}),
-          ...(input.error !== undefined ? { error: input.error } : {}),
-        },
-      });
+      return ctx.repos.invoiceDispatches.update(input.dispatchId, {
+        status: input.status,
+        ...(tsField ? { [tsField]: new Date() } : {}),
+        ...(input.messageId !== undefined ? { messageId: input.messageId } : {}),
+        ...(input.error !== undefined ? { error: input.error } : {}),
+      } as Partial<InvoiceDispatch>);
     }),
 });

--- a/src/lib/server/routers/kostnadsrakning.ts
+++ b/src/lib/server/routers/kostnadsrakning.ts
@@ -13,7 +13,7 @@
  */
 
 import { z } from "zod";
-import { KOSTNADSRAKNING_DOCUMENT_TYPE } from "@/lib/shared/schemas/document";
+import { KOSTNADSRAKNING_DOCUMENT_TYPE, type Document } from "@/lib/shared/schemas/document";
 import { emit } from "../events/emit";
 import { router, orgProcedure } from "../trpc";
 
@@ -40,22 +40,21 @@ export const kostnadsrakningRouter = router({
     }))
     .mutation(async ({ ctx, input }) => {
       // 1. Registrera dokumentet (samma som document.register-flödet)
-      const doc = await ctx.dataStore.documents.create({
-        data: {
-          id: input.id,
-          matterId: input.matterId,
-          fileName: input.fileName,
-          mimeType: input.mimeType,
-          sizeBytes: input.sizeBytes,
-          storagePath: input.storagePath,
-          folderId: null,
-          organizationId: ctx.orgId,
-          documentType: KOSTNADSRAKNING_DOCUMENT_TYPE,
-          analysisStatus: "DONE",
-          analyzedAt: new Date(),
-          uploadedById: ctx.user.id,
-        } as never,
-      });
+      const docData = {
+        id: input.id,
+        matterId: input.matterId,
+        fileName: input.fileName,
+        mimeType: input.mimeType,
+        sizeBytes: input.sizeBytes,
+        storagePath: input.storagePath,
+        folderId: null,
+        organizationId: ctx.orgId,
+        documentType: KOSTNADSRAKNING_DOCUMENT_TYPE,
+        analysisStatus: "DONE",
+        analyzedAt: new Date(),
+        uploadedById: ctx.user.id,
+      };
+      const doc = await ctx.repos.documents.create(docData as unknown as Partial<Document>);
 
       // 2. Emit event så regelmotorn kan trigga.
       //    OBS: går via `emit`-helpern (safeEmit) — INTE `ctx.dataStore.events.emit`

--- a/src/lib/server/routers/mail.ts
+++ b/src/lib/server/routers/mail.ts
@@ -13,17 +13,19 @@
  */
 
 import { z } from "zod";
+import type { TimeEntry } from "@/lib/shared/schemas/billing";
+import type { Document } from "@/lib/shared/schemas/document";
 import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
-import type { IDataStore } from "../data-store/IDataStore";
-import { emit } from "../events/emit";
-import { router, orgProcedure } from "../trpc";
+import { emit, type EmitCtx } from "../events/emit";
+import type { Repositories } from "../repositories/repositories";
+import { router, orgProcedure, TRPCError } from "../trpc";
 
-/** Den delmängd av tRPC-context tidspost-helpern + emit behöver. */
-interface MailCtx {
-  dataStore: IDataStore;
-  user: { id: string };
-}
+/**
+ * Den delmängd av tRPC-context tidspost-helpern + emit behöver. Data-skrivningar
+ * går via `repos` (ADR 0020); `emit` använder fortfarande events-sömmen (dataStore).
+ */
+type MailCtx = EmitCtx & { repos: Repositories };
 
 /** Avkoda base64 → bytes (browser+Node-säkert; routern bundlas för bägge). */
 function base64ToBytes(b64: string): Uint8Array {
@@ -66,9 +68,8 @@ export const mailRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       // 1. Verifiera att ärendet tillhör anroparens org.
-      await ctx.dataStore.matters.findFirstOrThrow({
-        where: { id: input.matterId, organizationId: ctx.orgId },
-      });
+      const matter = await ctx.repos.matters.getByIdInOrg(input.matterId, ctx.orgId);
+      if (!matter) throw new TRPCError({ code: "NOT_FOUND" });
 
       // 2. Skriv .eml-bytes till git-working-copy:n (server-runtime).
       const id = input.documentId ?? uuidv7();
@@ -78,24 +79,23 @@ export const mailRouter = router({
 
       // 3. Registrera dokument-metadata (projektion).
       const fileName = emlFileName(input.subject);
-      const doc = await ctx.dataStore.documents.create({
-        data: {
-          id,
-          matterId: input.matterId,
-          fileName,
-          mimeType: "message/rfc822",
-          sizeBytes: bytes.byteLength,
-          fileSize: bytes.byteLength, // denormaliserat (UI läser fileSize)
-          storagePath,
-          folderId: input.folderId ?? null,
-          organizationId: ctx.orgId,
-          analysisStatus: "PENDING",
-          uploadedById: ctx.user.id,
-          title: input.subject,
-          documentType: "E-post",
-          createdAt: new Date(input.receivedAt),
-        } as never,
-      });
+      const docData = {
+        id,
+        matterId: input.matterId,
+        fileName,
+        mimeType: "message/rfc822",
+        sizeBytes: bytes.byteLength,
+        fileSize: bytes.byteLength, // denormaliserat (UI läser fileSize)
+        storagePath,
+        folderId: input.folderId ?? null,
+        organizationId: ctx.orgId,
+        analysisStatus: "PENDING",
+        uploadedById: ctx.user.id,
+        title: input.subject,
+        documentType: "E-post",
+        createdAt: new Date(input.receivedAt),
+      };
+      const doc = await ctx.repos.documents.create(docData as unknown as Partial<Document>);
       await emit.documentUploaded(ctx, { id, fileName, matterId: input.matterId });
 
       // 4. Valfri tidspost kopplad till mailet.
@@ -116,21 +116,17 @@ async function createMailTimeEntry(
   time: z.infer<typeof timeInput>,
 ) {
   const userId = asId<"UserId">(ctx.user.id);
-  const user = await ctx.dataStore.users.findUniqueOrThrow({
-    where: { id: userId },
-    select: { hourlyRate: true },
-  });
-  const entry = await ctx.dataStore.timeEntries.create({
-    data: {
-      userId,
-      matterId,
-      date: new Date(receivedAt),
-      minutes: time.minutes,
-      description: time.description ?? subject,
-      hourlyRate: user.hourlyRate ?? 0,
-      billable: true,
-    } as never,
-  });
+  const user = await ctx.repos.users.getByIdOrThrow(userId);
+  const entryData = {
+    userId,
+    matterId,
+    date: new Date(receivedAt),
+    minutes: time.minutes,
+    description: time.description ?? subject,
+    hourlyRate: user.hourlyRate ?? 0,
+    billable: true,
+  };
+  const entry = await ctx.repos.timeEntries.create(entryData as unknown as Partial<TimeEntry>);
   await emit.timeEntryAdded(ctx, { id: entry.id, matterId: entry.matterId, minutes: entry.minutes });
   return entry;
 }

--- a/src/lib/server/routers/matter.ts
+++ b/src/lib/server/routers/matter.ts
@@ -14,23 +14,23 @@ import {
   type MatterId,
   type ContactId,
 } from "@/lib/shared/schemas/ids";
-import type { IDataStore } from "../data-store/IDataStore";
+import type { Matter, MatterContact } from "@/lib/shared/schemas/matter";
 import { emit } from "../events/emit";
-import { router, orgProcedure, requireOrgOwned } from "../trpc";
+import type { Repositories } from "../repositories/repositories";
+import { router, orgProcedure, TRPCError } from "../trpc";
 
-type MatterCtx = { dataStore: IDataStore; orgId: string };
+type MatterCtx = { repos: Repositories; orgId: string };
 
 /**
  * Hjälpare: hämta matter och verifiera att den tillhör anropande org.
  * `matterId` är branded ([[ids]]) — TS hindrar att man råkar skicka en
- * `ContactId` hit.
+ * `ContactId` hit. Kastar NOT_FOUND vid mismatch (speglar `requireOrgOwned`).
  */
-const assertMatterInOrg = (ctx: MatterCtx, matterId: MatterId) =>
-  requireOrgOwned(
-    () => ctx.dataStore.matters.findUnique({ where: { id: matterId } }),
-    ctx.orgId,
-    (m) => m.organizationId,
-  );
+async function assertMatterInOrg(ctx: MatterCtx, matterId: MatterId): Promise<Matter> {
+  const m = await ctx.repos.matters.getByIdInOrg(matterId, ctx.orgId);
+  if (!m) throw new TRPCError({ code: "NOT_FOUND" });
+  return m;
+}
 
 /**
  * create-input. Optionella setup-fält (id, matterNumber, status,
@@ -78,11 +78,10 @@ function maxSeq(matters: ReadonlyArray<{ matterNumber: string }>, year: number):
 
 /** Den ansvariga juristens prefix (tom om okänd/ej i org:en/ingen prefix satt). */
 async function lawyerPrefix(ctx: MatterCtx, userId: string): Promise<string> {
-  const u = (await ctx.dataStore.users.findUnique({ where: { id: userId } })) as
-    | { organizationId?: string; matterNumberPrefix?: string | null }
+  const u = (await ctx.repos.users.getByIdInOrg(userId, ctx.orgId)) as
+    | { matterNumberPrefix?: string | null }
     | null;
-  if (!u || u.organizationId !== ctx.orgId) return "";
-  return u.matterNumberPrefix ?? "";
+  return u?.matterNumberPrefix ?? "";
 }
 
 /**
@@ -104,11 +103,9 @@ async function nextMatterNumber(ctx: MatterCtx, responsibleLawyerId?: string): P
   const prefix = responsibleLawyerId ? await lawyerPrefix(ctx, responsibleLawyerId) : "";
 
   const ownMatters = responsibleLawyerId
-    ? await ctx.dataStore.matters.findMany({ where: { organizationId: ctx.orgId, responsibleLawyerId } })
+    ? await ctx.repos.matters.listByResponsibleLawyer(ctx.orgId, responsibleLawyerId)
     : [];
-  const prefixMatters = await ctx.dataStore.matters.findMany({
-    where: { organizationId: ctx.orgId, matterNumber: { startsWith: `${prefix}${year}-` } },
-  });
+  const prefixMatters = await ctx.repos.matters.listByNumberPrefix(ctx.orgId, `${prefix}${year}-`);
 
   const seq = Math.max(maxSeq(ownMatters, year), maxSeq(prefixMatters, year)) + 1;
   return `${prefix}${year}-${seq.toString().padStart(4, "0")}`;
@@ -153,12 +150,9 @@ function buildMatterData(
 
 // Branded params: en swap av argumenten (matterId ↔ klientId) blir ett TS-fel.
 async function linkKlient(ctx: MatterCtx, matterId: MatterId, klientId: ContactId): Promise<void> {
-  await requireOrgOwned(
-    () => ctx.dataStore.contacts.findUnique({ where: { id: klientId } }),
-    ctx.orgId,
-    (c) => c.organizationId,
-  );
-  await ctx.dataStore.matterContacts.create({ data: { matterId, contactId: klientId, role: "KLIENT" } });
+  const contact = await ctx.repos.contacts.getByIdFull(klientId, ctx.orgId);
+  if (!contact) throw new TRPCError({ code: "NOT_FOUND" });
+  await ctx.repos.matterContacts.create({ matterId, contactId: klientId, role: "KLIENT" } as Partial<MatterContact>);
 }
 
 export const matterRouter = router({
@@ -173,57 +167,25 @@ export const matterRouter = router({
         pageSize: z.number().min(1).max(500).default(20),
       })
     )
+    // Migrerad till repository-sömmen (ADR 0020): listForOrg kapslar in
+    // filter/sök-where + KLIENT-include + _count + total.
     .query(async ({ ctx, input }) => {
-      const where = {
-        organizationId: ctx.orgId,
-        ...(input.status ? { status: input.status } : {}),
-        ...(input.employeeId ? { timeEntries: { some: { userId: input.employeeId } } } : {}),
-        ...(input.search
-          ? {
-              OR: [
-                { title: { contains: input.search, mode: "insensitive" as const } },
-                { matterNumber: { contains: input.search, mode: "insensitive" as const } },
-                { contacts: { some: { contact: { name: { contains: input.search, mode: "insensitive" as const } } } } },
-              ],
-            }
-          : {}),
-      };
-
-      const [matters, total] = await Promise.all([
-        ctx.dataStore.matters.findMany({
-          where,
-          orderBy: { createdAt: "desc" },
-          skip: (input.page - 1) * input.pageSize,
-          take: input.pageSize,
-          include: {
-            contacts: {
-              where: { role: "KLIENT" },
-              include: { contact: { select: { id: true, name: true } } },
-              take: 1,
-            },
-            _count: { select: { documents: true, timeEntries: true, contacts: true } },
-          },
-          // paymentMethod, paymentMethodNote, paymentMethodDecidedAt ingår som del av Matter
-        }),
-        ctx.dataStore.matters.count({ where }),
-      ]);
-
+      const { matters, total } = await ctx.repos.matters.listForOrg(ctx.orgId, {
+        search: input.search,
+        status: input.status,
+        employeeId: input.employeeId,
+        page: input.page,
+        pageSize: input.pageSize,
+      });
       return { matters, total, pages: Math.ceil(total / input.pageSize) };
     }),
 
   getById: orgProcedure
     .input(z.object({ id: z.string() }))
     .query(async ({ ctx, input }) => {
-      return ctx.dataStore.matters.findFirstOrThrow({
-        where: { id: input.id, organizationId: ctx.orgId },
-        include: {
-          contacts: {
-            include: { contact: true },
-            orderBy: { createdAt: "asc" },
-          },
-          _count: { select: { documents: true, timeEntries: true, emails: true } },
-        },
-      });
+      const matter = await ctx.repos.matters.getByIdWithContacts(input.id, ctx.orgId);
+      if (!matter) throw new TRPCError({ code: "NOT_FOUND", message: "Ärendet finns inte." });
+      return matter;
     }),
 
   create: orgProcedure
@@ -232,9 +194,9 @@ export const matterRouter = router({
       // Ansvarig jurist = explicit val, annars skaparen (#174). Styr serien.
       const responsibleLawyerId = input.responsibleLawyerId ?? ctx.user.id;
       const matterNumber = input.matterNumber ?? (await nextMatterNumber(ctx, responsibleLawyerId));
-      const matter = await ctx.dataStore.matters.create({
-        data: buildMatterData(ctx.orgId, matterNumber, responsibleLawyerId, input),
-      });
+      const matter = await ctx.repos.matters.create(
+        buildMatterData(ctx.orgId, matterNumber, responsibleLawyerId, input) as Partial<Matter>,
+      );
       await emit.matterCreated(ctx, matter);
       // matter.id washar till `any` via Joined<>; brand explicit. klientId
       // kommer från (redan validerad) input-sträng → trusted boundary-cast.
@@ -280,7 +242,7 @@ export const matterRouter = router({
       if (taxaHufStart !== undefined) {
         data.taxaHufStart = taxaHufStart ? new Date(taxaHufStart) : null;
       }
-      const updated = await ctx.dataStore.matters.update({ where: { id }, data });
+      const updated = await ctx.repos.matters.update(id, data as Partial<Matter>);
       await emit.matterUpdated(ctx, id, data);
       if (input.status && input.status !== before.status) {
         await emit.matterStatusChanged(ctx, id, before.status, input.status);
@@ -304,21 +266,15 @@ export const matterRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       await assertMatterInOrg(ctx, input.matterId);
-      await requireOrgOwned(
-        () => ctx.dataStore.contacts.findUnique({ where: { id: input.contactId } }),
-        ctx.orgId,
-        (c) => c.organizationId,
-      );
+      const contact = await ctx.repos.contacts.getByIdFull(input.contactId, ctx.orgId);
+      if (!contact) throw new TRPCError({ code: "NOT_FOUND" });
       const { createdAt, id, notes, ...rest } = input;
-      return ctx.dataStore.matterContacts.create({
-        data: omitUndefined({
-          ...rest,
-          id,
-          notes,
-          ...(createdAt ? { createdAt: new Date(createdAt) } : {}),
-        }),
-        include: { contact: true },
-      });
+      return ctx.repos.matterContacts.linkContact(omitUndefined({
+        ...rest,
+        id,
+        notes,
+        ...(createdAt ? { createdAt: new Date(createdAt) } : {}),
+      }) as Partial<MatterContact>);
     }),
 
   // Create a new contact and link it to the matter in one step
@@ -340,43 +296,30 @@ export const matterRouter = router({
       await assertMatterInOrg(ctx, input.matterId);
       const { matterId, role, notes, ...contactData } = input;
 
-      // Check if contact already exists by personal/org number
-      let contact = null;
+      // Återanvänd befintlig kontakt på pnr/orgnr, annars skapa ny.
+      let contact: { id: string } | null = null;
       if (contactData.personalNumber) {
-        contact = await ctx.dataStore.contacts.findFirst({
-          where: { personalNumber: contactData.personalNumber, organizationId: ctx.orgId },
-        });
+        contact = await ctx.repos.contacts.findByPersonalNumber(ctx.orgId, contactData.personalNumber);
       } else if (contactData.orgNumber) {
-        contact = await ctx.dataStore.contacts.findFirst({
-          where: { orgNumber: contactData.orgNumber, organizationId: ctx.orgId },
-        });
+        contact = await ctx.repos.contacts.findByOrgNumber(ctx.orgId, contactData.orgNumber);
       }
 
       if (!contact) {
-        contact = await ctx.dataStore.contacts.create({
-          data: { ...contactData, organizationId: ctx.orgId },
-        });
+        contact = await ctx.repos.contacts.create({ ...contactData, organizationId: ctx.orgId } as never);
       }
 
-      return ctx.dataStore.matterContacts.create({
-        data: { matterId, contactId: contact.id, role, notes },
-        include: { contact: true },
-      });
+      return ctx.repos.matterContacts.linkContact(
+        { matterId, contactId: contact.id, role, notes } as Partial<MatterContact>,
+      );
     }),
 
   removeContact: orgProcedure
     .input(z.object({ matterContactId: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      // Verifiera via matterContact→matter→org
-      await requireOrgOwned(
-        () =>
-          ctx.dataStore.matterContacts.findUnique({
-            where: { id: input.matterContactId },
-            include: { matter: { select: { organizationId: true } } },
-          }),
-        ctx.orgId,
-        (mc) => mc.matter.organizationId,
-      );
-      return ctx.dataStore.matterContacts.delete({ where: { id: input.matterContactId } });
+      // Verifiera via matterContact→matter→org INNAN delete.
+      const owned = await ctx.repos.matterContacts.getByIdInOrg(input.matterContactId, ctx.orgId);
+      if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
+      await ctx.repos.matterContacts.hardDelete(input.matterContactId);
+      return owned;
     }),
 });

--- a/src/lib/server/routers/organization.ts
+++ b/src/lib/server/routers/organization.ts
@@ -3,26 +3,32 @@ import { z } from "zod";
 import { ledgerAccountMapSchema } from "@/lib/shared/accounting/account-map";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { organizationIdSchema, asId } from "@/lib/shared/schemas/ids";
+import type { Office, Organization } from "@/lib/shared/schemas/organization";
 import { router, protectedProcedure } from "../trpc";
+
+/** Projektion för settings-vyn (nullish → null). Egen helper för låg komplexitet. */
+function toOrgSettings(org: Organization) {
+  return {
+    id: org.id,
+    name: org.name,
+    orgNumber: org.orgNumber ?? null,
+    address: org.address ?? null,
+    phone: org.phone ?? null,
+    email: org.email ?? null,
+    bankgiro: org.bankgiro ?? null,
+    logoPath: org.logoPath ?? null,
+    ledgerAccountMap: org.ledgerAccountMap ?? null,
+  };
+}
 
 export const organizationRouter = router({
   // ── Settings ────────────────────────────────────────────────────
 
+  // Migrerad till repository-sömmen (ADR 0020). Org är rot-entiteten (scope:n).
   getSettings: protectedProcedure.query(async ({ ctx }) => {
-    return ctx.dataStore.organizations.findUniqueOrThrow({
-      where: { id: ctx.user.organizationId },
-      select: {
-        id: true,
-        name: true,
-        orgNumber: true,
-        address: true,
-        phone: true,
-        email: true,
-        bankgiro: true,
-        logoPath: true,
-        ledgerAccountMap: true,
-      },
-    });
+    const org = await ctx.repos.organizations.getById(ctx.user.organizationId);
+    if (!org) throw new TRPCError({ code: "NOT_FOUND" });
+    return toOrgSettings(org);
   }),
 
   updateSettings: protectedProcedure
@@ -38,12 +44,9 @@ export const organizationRouter = router({
         ledgerAccountMap: ledgerAccountMapSchema.optional(),
       })
     )
-    .mutation(async ({ ctx, input }) => {
-      return ctx.dataStore.organizations.update({
-        where: { id: ctx.user.organizationId },
-        data: omitUndefined(input),
-      });
-    }),
+    .mutation(({ ctx, input }) =>
+      ctx.repos.organizations.update(ctx.user.organizationId, omitUndefined(input) as Partial<Organization>),
+    ),
 
   /**
    * Skapa en organisation med explicit id (rot-entiteten — den ÄR scope:n,
@@ -63,18 +66,15 @@ export const organizationRouter = router({
         bankgiro: z.string().optional(),
       })
     )
-    .mutation(async ({ ctx, input }) => {
-      return ctx.dataStore.organizations.create({ data: input });
-    }),
+    .mutation(({ ctx, input }) =>
+      ctx.repos.organizations.create(input as Partial<Organization>),
+    ),
 
   // ── Offices ─────────────────────────────────────────────────────
 
-  listOffices: protectedProcedure.query(async ({ ctx }) => {
-    return ctx.dataStore.offices.findMany({
-      where: { organizationId: ctx.user.organizationId },
-      orderBy: [{ isMain: "desc" }, { name: "asc" }],
-    });
-  }),
+  listOffices: protectedProcedure.query(({ ctx }) =>
+    ctx.repos.offices.listByOrg(ctx.user.organizationId),
+  ),
 
   addOffice: protectedProcedure
     .input(
@@ -88,18 +88,11 @@ export const organizationRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       // If new office is main, demote existing main first
-      if (input.isMain) {
-        await ctx.dataStore.offices.updateMany({
-          where: { organizationId: ctx.user.organizationId, isMain: true },
-          data: { isMain: false },
-        });
-      }
-      return ctx.dataStore.offices.create({
-        data: {
-          ...input,
-          organizationId: asId<"OrganizationId">(ctx.user.organizationId),
-        },
-      });
+      if (input.isMain) await ctx.repos.offices.demoteMains(ctx.user.organizationId);
+      return ctx.repos.offices.create({
+        ...input,
+        organizationId: asId<"OrganizationId">(ctx.user.organizationId),
+      } as Partial<Office>);
     }),
 
   updateOffice: protectedProcedure
@@ -115,27 +108,19 @@ export const organizationRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       const { id, ...data } = input;
-      const office = await ctx.dataStore.offices.findUnique({ where: { id } });
-      if (!office || office.organizationId !== ctx.user.organizationId) {
-        throw new TRPCError({ code: "NOT_FOUND" });
-      }
+      const office = await ctx.repos.offices.getByIdInOrg(id, ctx.user.organizationId);
+      if (!office) throw new TRPCError({ code: "NOT_FOUND" });
       // If setting as main, demote others first
-      if (data.isMain) {
-        await ctx.dataStore.offices.updateMany({
-          where: { organizationId: ctx.user.organizationId, isMain: true },
-          data: { isMain: false },
-        });
-      }
-      return ctx.dataStore.offices.update({ where: { id }, data: omitUndefined(data) });
+      if (data.isMain) await ctx.repos.offices.demoteMains(ctx.user.organizationId);
+      return ctx.repos.offices.update(id, omitUndefined(data) as Partial<Office>);
     }),
 
   deleteOffice: protectedProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      const office = await ctx.dataStore.offices.findUnique({ where: { id: input.id } });
-      if (!office || office.organizationId !== ctx.user.organizationId) {
-        throw new TRPCError({ code: "NOT_FOUND" });
-      }
-      return ctx.dataStore.offices.delete({ where: { id: input.id } });
+      const office = await ctx.repos.offices.getByIdInOrg(input.id, ctx.user.organizationId);
+      if (!office) throw new TRPCError({ code: "NOT_FOUND" });
+      await ctx.repos.offices.hardDelete(input.id);
+      return { id: input.id };
     }),
 });

--- a/src/lib/server/routers/paymentPlan.ts
+++ b/src/lib/server/routers/paymentPlan.ts
@@ -20,49 +20,37 @@ import { z } from "zod";
 import {
   computeDueReminders,
   type PlanForScan,
-  type ReminderKind,
 } from "@/lib/shared/payment-reminders";
-import { paymentPlanStatusSchema, reminderTypeSchema, type PaymentPlanStatus } from "@/lib/shared/schemas";
+import { paymentPlanStatusSchema, reminderTypeSchema, type Invoice, type PaymentPlan, type PaymentPlanReminder } from "@/lib/shared/schemas";
 import { emit } from "../events/emit";
+import type {
+  JoinedPaymentPlan, JoinedPaymentPlanWithReminders,
+} from "../repositories/payment-plan-repository";
 import { router, protectedProcedure, orgProcedure, TRPCError } from "../trpc";
 
-type Plan = { id: string; status: PaymentPlanStatus; invoiceId: string };
-
-/** Joinad plan-rad (IDataStore:s query-yta är otypad — vi formar lokalt). */
-interface JoinedPlan {
-  id: string;
-  status: string;
-  monthlyAmount: number;
-  dayOfMonth: number;
-  startDate: Date | string;
-  invoice?: {
-    amount?: number;
-    payments?: Array<{ amount?: number }>;
-    matter?: {
-      id?: string;
-      matterNumber?: string;
-      title?: string;
-      contacts?: Array<{ contact?: { name?: string; email?: string | null } }>;
-    };
-  };
-  reminders?: Array<{ dueMonth: string; type: ReminderKind }>;
-}
+/** Lokalt alias för den joinade plan-formen repot returnerar. */
+type JoinedPlan = JoinedPaymentPlanWithReminders;
 
 function sumPaidOre(payments?: Array<{ amount?: number }>): number {
   return (payments ?? []).reduce((sum, p) => sum + (p.amount ?? 0), 0);
 }
 
-type Matter = NonNullable<NonNullable<JoinedPlan["invoice"]>["matter"]>;
+type PlanMatter = NonNullable<NonNullable<JoinedPlan["invoice"]>["matter"]>;
 
 /** KLIENT-kontaktens namn/email för påminnelse-payloaden (tom om saknas). */
-function resolveRecipient(matter: Matter): { email: string; name: string } {
-  const client = matter.contacts?.[0]?.contact ?? {};
-  return { email: client.email ?? "", name: client.name ?? "" };
+function resolveRecipient(matter: PlanMatter | null): { email: string; name: string } {
+  const client = matter?.contacts?.[0]?.contact;
+  return { email: client?.email ?? "", name: client?.name ?? "" };
+}
+
+/** Ärende-fälten scannern behöver (tomma om ärendet saknas). */
+function scanMatterFields(m: PlanMatter | null): { matterId: string; matterNumber: string; matterTitle: string } {
+  return { matterId: m?.id ?? "", matterNumber: m?.matterNumber ?? "", matterTitle: m?.title ?? "" };
 }
 
 function toPlanForScan(p: JoinedPlan): PlanForScan {
-  const inv = p.invoice ?? {};
-  const matter: Matter = inv.matter ?? {};
+  const inv = p.invoice;
+  const matter = inv?.matter ?? null;
   const recipient = resolveRecipient(matter);
   return {
     planId: p.id,
@@ -70,25 +58,22 @@ function toPlanForScan(p: JoinedPlan): PlanForScan {
     monthlyAmount: p.monthlyAmount,
     dayOfMonth: p.dayOfMonth,
     startDate: new Date(p.startDate),
-    invoiceTotalOre: inv.amount ?? 0,
-    paidOre: sumPaidOre(inv.payments),
-    matterId: matter.id ?? "",
-    matterNumber: matter.matterNumber ?? "",
-    matterTitle: matter.title ?? "",
+    invoiceTotalOre: inv?.amount ?? 0,
+    paidOre: sumPaidOre(inv?.payments),
+    ...scanMatterFields(matter),
     recipientEmail: recipient.email,
     recipientName: recipient.name,
   };
 }
 
 /** Sökbar text för en plan-rad: ärendenr + titel + klientnamn + anteckningar. */
-function planHaystack(p: Record<string, unknown>): string {
-  const plan = p as unknown as JoinedPlan;
-  const matter: Matter = plan.invoice?.matter ?? {};
+function planHaystack(p: JoinedPaymentPlan): string {
+  const matter = p.invoice?.matter ?? null;
   return [
-    matter.matterNumber ?? "",
-    matter.title ?? "",
+    matter?.matterNumber ?? "",
+    matter?.title ?? "",
     resolveRecipient(matter).name,
-    (p.notes as string | null) ?? "",
+    (p as { notes?: string | null }).notes ?? "",
   ].join(" ").toLowerCase();
 }
 
@@ -100,62 +85,19 @@ export const paymentPlanRouter = router({
         search: z.string().optional(),
       }).optional(),
     )
+    // Migrerad till repository-sömmen (ADR 0020): listForOrg kapslar in
+    // org-scoping + den joinade faktura/ärende/KLIENT/betalnings-formen.
     .query(async ({ ctx, input }) => {
-      const plans = await ctx.dataStore.paymentPlans.findMany({
-        where: {
-          ...(input?.status ? { status: input.status } : {}),
-          invoice: { matter: { organizationId: ctx.orgId } },
-        },
-        orderBy: { createdAt: "desc" },
-        include: {
-          invoice: {
-            include: {
-              matter: {
-                include: {
-                  contacts: {
-                    where: { role: "KLIENT" },
-                    include: { contact: { select: { id: true, name: true } } },
-                    take: 1,
-                  },
-                },
-              },
-              // Inkludera payments så list-vyn kan visa progress (X av Y betalt)
-              payments: { orderBy: { paidAt: "desc" } },
-              // + writeOffs så utestående kan beräknas via ledgern (ADR 0007).
-              writeOffs: true,
-            },
-          },
-        },
-      });
+      const plans = await ctx.repos.paymentPlans.listForOrg(ctx.orgId, input?.status);
       if (!input?.search) return plans;
       const needle = input.search.toLowerCase();
-      return plans.filter((p: Record<string, unknown>) => planHaystack(p).includes(needle));
+      return plans.filter((p) => planHaystack(p).includes(needle));
     }),
 
   getById: orgProcedure
     .input(z.object({ id: z.string() }))
     .query(async ({ ctx, input }) => {
-      const plan = await ctx.dataStore.paymentPlans.findFirst({
-        where: { id: input.id, invoice: { matter: { organizationId: ctx.orgId } } },
-        include: {
-          invoice: {
-            include: {
-              matter: {
-                include: {
-                  contacts: {
-                    where: { role: "KLIENT" },
-                    include: { contact: { select: { id: true, name: true } } },
-                    take: 1,
-                  },
-                },
-              },
-              payments: { orderBy: { paidAt: "desc" } },
-              writeOffs: true,
-            },
-          },
-          reminders: { orderBy: { sentAt: "desc" } },
-        },
-      });
+      const plan = await ctx.repos.paymentPlans.getByIdWithDetails(input.id, ctx.orgId);
       if (!plan) throw new TRPCError({ code: "NOT_FOUND", message: "Avbetalningsplan hittades inte" });
       return plan;
     }),
@@ -169,19 +111,14 @@ export const paymentPlanRouter = router({
   cancel: protectedProcedure
     .input(z.object({ planId: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      return ctx.dataStore.transaction(async (tx) => {
-        const plan = await tx.paymentPlans.findFirst({
-          where: {
-            id: input.planId,
-            invoice: { matter: { organizationId: ctx.user.organizationId } },
-          },
-        }) as Plan | null;
+      return ctx.repos.transaction(async (tx) => {
+        const plan = await tx.paymentPlans.getByIdInOrg(input.planId, ctx.user.organizationId);
         if (!plan) throw new TRPCError({ code: "NOT_FOUND" });
         if (plan.status !== "ACTIVE") {
           throw new TRPCError({ code: "BAD_REQUEST", message: "Endast aktiva planer kan avbrytas" });
         }
-        await tx.paymentPlans.update({ where: { id: plan.id }, data: { status: "CANCELLED" } });
-        await tx.invoices.update({ where: { id: plan.invoiceId }, data: { status: "SENT" } });
+        await tx.paymentPlans.update(plan.id, { status: "CANCELLED" } as Partial<PaymentPlan>);
+        await tx.invoices.update(plan.invoiceId, { status: "SENT" } as Partial<Invoice>);
         return { ok: true };
       });
     }),
@@ -202,19 +139,15 @@ export const paymentPlanRouter = router({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      const plan = await ctx.dataStore.paymentPlans.findFirst({
-        where: { id: input.planId, invoice: { matter: { organizationId: ctx.orgId } } },
-      });
+      const plan = await ctx.repos.paymentPlans.getByIdInOrg(input.planId, ctx.orgId);
       if (!plan) throw new TRPCError({ code: "NOT_FOUND" });
-      return ctx.dataStore.paymentPlanReminders.create({
-        data: {
-          id: input.id,
-          planId: input.planId,
-          dueMonth: input.dueMonth,
-          type: input.type,
-          sentAt: input.sentAt ? new Date(input.sentAt) : new Date(),
-        },
-      });
+      return ctx.repos.paymentPlanReminders.create({
+        id: input.id,
+        planId: input.planId,
+        dueMonth: input.dueMonth,
+        type: input.type,
+        sentAt: input.sentAt ? new Date(input.sentAt) : new Date(),
+      } as unknown as Partial<PaymentPlanReminder>);
     }),
 
   /**
@@ -231,26 +164,7 @@ export const paymentPlanRouter = router({
     .input(z.object({ asOf: z.string().datetime().optional() }).optional())
     .mutation(async ({ ctx, input }) => {
       const now = input?.asOf ? new Date(input.asOf) : new Date();
-      const plans = await ctx.dataStore.paymentPlans.findMany({
-        where: { status: "ACTIVE", invoice: { matter: { organizationId: ctx.orgId } } },
-        include: {
-          invoice: {
-            include: {
-              payments: true,
-              matter: {
-                include: {
-                  contacts: {
-                    where: { role: "KLIENT" },
-                    include: { contact: { select: { id: true, name: true, email: true } } },
-                    take: 1,
-                  },
-                },
-              },
-            },
-          },
-          reminders: true,
-        },
-      }) as unknown as JoinedPlan[];
+      const plans = await ctx.repos.paymentPlans.listActiveForScan(ctx.orgId);
 
       const logged = plans.flatMap((p) =>
         (p.reminders ?? []).map((r) => ({ planId: p.id, dueMonth: r.dueMonth, type: r.type })),
@@ -258,9 +172,9 @@ export const paymentPlanRouter = router({
       const planned = computeDueReminders(plans.map(toPlanForScan), now, logged);
 
       for (const r of planned) {
-        await ctx.dataStore.paymentPlanReminders.create({
-          data: { planId: r.planId, dueMonth: r.dueMonth, type: r.type, sentAt: now },
-        });
+        await ctx.repos.paymentPlanReminders.create({
+          planId: r.planId, dueMonth: r.dueMonth, type: r.type, sentAt: now,
+        } as unknown as Partial<PaymentPlanReminder>);
         if (r.type === "DUE") await emit.paymentDue(ctx, r.payload, r.matterId);
         else await emit.paymentOverdue(ctx, r.payload, r.matterId);
       }

--- a/src/lib/server/routers/preference.ts
+++ b/src/lib/server/routers/preference.ts
@@ -10,6 +10,8 @@
 
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import type { OrgPreferenceRow } from "../repositories/org-preference-repository";
+import type { UserPreferenceRow } from "../repositories/user-preference-repository";
 import { router, orgProcedure, protectedProcedure } from "../trpc";
 
 const prefsPayloadSchema = z.record(z.string(), z.unknown());
@@ -20,12 +22,8 @@ export const preferenceRouter = router({
     .input(z.object({ key: z.string().min(1) }))
     .query(async ({ ctx, input }) => {
       const [user, org] = await Promise.all([
-        ctx.dataStore.userPreferences.findFirst({
-          where: { userId: ctx.user.id, organizationId: ctx.user.organizationId, key: input.key },
-        }),
-        ctx.dataStore.orgPreferences.findFirst({
-          where: { organizationId: ctx.user.organizationId, key: input.key },
-        }),
+        ctx.repos.userPreferences.getByUserKey(ctx.user.id, ctx.user.organizationId, input.key),
+        ctx.repos.orgPreferences.getByOrgKey(ctx.user.organizationId, input.key),
       ]);
       return {
         user: (user as { prefs?: Record<string, unknown> } | null)?.prefs ?? null,
@@ -37,28 +35,22 @@ export const preferenceRouter = router({
   save: protectedProcedure
     .input(z.object({ key: z.string().min(1), prefs: prefsPayloadSchema }))
     .mutation(async ({ ctx, input }) => {
-      const existing = await ctx.dataStore.userPreferences.findFirst({
-        where: { userId: ctx.user.id, organizationId: ctx.user.organizationId, key: input.key },
-      });
+      const existing = await ctx.repos.userPreferences.getByUserKey(ctx.user.id, ctx.user.organizationId, input.key);
       if (existing) {
-        const ex = existing as { id: string };
-        return ctx.dataStore.userPreferences.update({ where: { id: ex.id }, data: { prefs: input.prefs } });
+        return ctx.repos.userPreferences.update(existing.id, { prefs: input.prefs } as Partial<UserPreferenceRow>);
       }
-      return ctx.dataStore.userPreferences.create({
-        data: { userId: ctx.user.id, organizationId: ctx.user.organizationId, key: input.key, prefs: input.prefs },
-      });
+      return ctx.repos.userPreferences.create({
+        userId: ctx.user.id, organizationId: ctx.user.organizationId, key: input.key, prefs: input.prefs,
+      } as Partial<UserPreferenceRow>);
     }),
 
   /** Återställ user-pref (faller tillbaka till org/komponent-default). */
   clear: protectedProcedure
     .input(z.object({ key: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
-      const existing = await ctx.dataStore.userPreferences.findFirst({
-        where: { userId: ctx.user.id, organizationId: ctx.user.organizationId, key: input.key },
-      });
+      const existing = await ctx.repos.userPreferences.getByUserKey(ctx.user.id, ctx.user.organizationId, input.key);
       if (!existing) return { ok: true };
-      const ex = existing as { id: string };
-      await ctx.dataStore.userPreferences.delete({ where: { id: ex.id } });
+      await ctx.repos.userPreferences.hardDelete(existing.id);
       return { ok: true };
     }),
 
@@ -67,16 +59,13 @@ export const preferenceRouter = router({
     .input(z.object({ key: z.string().min(1), prefs: prefsPayloadSchema }))
     .mutation(async ({ ctx, input }) => {
       requireAdmin(ctx.user.role);
-      const existing = await ctx.dataStore.orgPreferences.findFirst({
-        where: { organizationId: ctx.user.organizationId, key: input.key },
-      });
+      const existing = await ctx.repos.orgPreferences.getByOrgKey(ctx.user.organizationId, input.key);
       if (existing) {
-        const ex = existing as { id: string };
-        return ctx.dataStore.orgPreferences.update({ where: { id: ex.id }, data: { prefs: input.prefs, createdById: ctx.user.id } });
+        return ctx.repos.orgPreferences.update(existing.id, { prefs: input.prefs, createdById: ctx.user.id } as Partial<OrgPreferenceRow>);
       }
-      return ctx.dataStore.orgPreferences.create({
-        data: { organizationId: ctx.user.organizationId, key: input.key, prefs: input.prefs, createdById: ctx.user.id },
-      });
+      return ctx.repos.orgPreferences.create({
+        organizationId: ctx.user.organizationId, key: input.key, prefs: input.prefs, createdById: ctx.user.id,
+      } as Partial<OrgPreferenceRow>);
     }),
 
   /** Rensa org-default (endast ADMIN). */
@@ -84,22 +73,16 @@ export const preferenceRouter = router({
     .input(z.object({ key: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       requireAdmin(ctx.user.role);
-      const existing = await ctx.dataStore.orgPreferences.findFirst({
-        where: { organizationId: ctx.user.organizationId, key: input.key },
-      });
+      const existing = await ctx.repos.orgPreferences.getByOrgKey(ctx.user.organizationId, input.key);
       if (!existing) return { ok: true };
-      const ex = existing as { id: string };
-      await ctx.dataStore.orgPreferences.delete({ where: { id: ex.id } });
+      await ctx.repos.orgPreferences.hardDelete(existing.id);
       return { ok: true };
     }),
 
   /** Lista alla nycklar som har en org-default (för admin-UI:t). */
-  listOrgDefaults: orgProcedure.query(async ({ ctx }) => {
+  listOrgDefaults: orgProcedure.query(({ ctx }) => {
     requireAdmin(ctx.user.role);
-    return ctx.dataStore.orgPreferences.findMany({
-      where: { organizationId: ctx.user.organizationId },
-      orderBy: { key: "asc" },
-    });
+    return ctx.repos.orgPreferences.listByOrg(ctx.user.organizationId);
   }),
 });
 

--- a/src/lib/server/routers/reports.ts
+++ b/src/lib/server/routers/reports.ts
@@ -180,11 +180,11 @@ interface ReportMatterRef {
 }
 interface ReportTimeEntry {
   date: Date; minutes: number; billable: boolean; hourlyRate: number;
-  invoiceId?: string | null | undefined; matter?: ReportMatterRef | undefined;
+  invoiceId?: string | null | undefined; matter?: ReportMatterRef | null | undefined;
 }
 interface ReportExpense {
   date: Date; amount: number; billable: boolean;
-  invoiceId?: string | null | undefined; matter?: ReportMatterRef | undefined;
+  invoiceId?: string | null | undefined; matter?: ReportMatterRef | null | undefined;
 }
 
 interface MatterAgg {
@@ -331,75 +331,14 @@ export const reportsRouter = router({
       const toDate = new Date(input.to);
       toDate.setUTCHours(23, 59, 59, 999);
 
-      const orgScope = { matter: { organizationId: ctx.user.organizationId } };
+      const org = ctx.user.organizationId;
 
+      // Migrerad till repository-sömmen (ADR 0020): listForLawyerInPeriod kapslar
+      // in org-scoping + matter-projektionen (betalsätt + KLIENT-kontakt).
       const [user, timeEntries, expenses] = await Promise.all([
-        ctx.dataStore.users.findFirst({
-          where: { id: input.userId, organizationId: ctx.user.organizationId },
-          select: { id: true, name: true, hourlyRate: true },
-        }),
-        ctx.dataStore.timeEntries.findMany({
-          where: {
-            ...orgScope,
-            userId: input.userId,
-            date: { gte: fromDate, lte: toDate },
-          },
-          select: {
-            id: true,
-            date: true,
-            minutes: true,
-            billable: true,
-            hourlyRate: true,
-            description: true,
-            invoiceId: true,
-            matter: {
-              select: {
-                id: true,
-                matterNumber: true,
-                title: true,
-                paymentMethod: true,
-                paymentMethodNote: true,
-                paymentMethodDecidedAt: true,
-                contacts: {
-                  where: { role: "KLIENT" },
-                  select: { contact: { select: { name: true } } },
-                  take: 1,
-                },
-              },
-            },
-          },
-          orderBy: { date: "asc" },
-        }),
-        ctx.dataStore.expenses.findMany({
-          where: {
-            ...orgScope,
-            userId: input.userId,
-            date: { gte: fromDate, lte: toDate },
-          },
-          select: {
-            id: true,
-            date: true,
-            amount: true,
-            billable: true,
-            invoiceId: true,
-            matter: {
-              select: {
-                id: true,
-                matterNumber: true,
-                title: true,
-                paymentMethod: true,
-                paymentMethodNote: true,
-                paymentMethodDecidedAt: true,
-                contacts: {
-                  where: { role: "KLIENT" },
-                  select: { contact: { select: { name: true } } },
-                  take: 1,
-                },
-              },
-            },
-          },
-          orderBy: { date: "asc" },
-        }),
+        ctx.repos.users.getByIdInOrg(input.userId, org),
+        ctx.repos.timeEntries.listForLawyerInPeriod(org, input.userId, fromDate, toDate),
+        ctx.repos.expenses.listForLawyerInPeriod(org, input.userId, fromDate, toDate),
       ]);
 
       if (!user) {
@@ -436,27 +375,18 @@ export const reportsRouter = router({
       const toDate = new Date(input.to);
       toDate.setUTCHours(23, 59, 59, 999);
       const prevPeriod = previousCalendarMonth(fromDate);
-      const orgScope = { matter: { organizationId: ctx.user.organizationId } };
+      const org = ctx.user.organizationId;
 
-      const [user, invoices, billingRuns, timeEntries, writeOffs] = await Promise.all([
-        ctx.dataStore.users.findFirst({
-          where: { id: input.userId, organizationId: ctx.user.organizationId },
-          select: { id: true, name: true },
-        }),
-        ctx.dataStore.invoices.findMany({
-          where: orgScope,
-          select: {
-            id: true, amount: true, status: true, invoiceDate: true, updatedAt: true,
-            matter: { select: { matterNumber: true, title: true } },
-          },
-        }),
-        ctx.dataStore.billingRuns.findMany({ where: orgScope, select: { id: true, invoiceId: true } }),
-        ctx.dataStore.timeEntries.findMany({
-          where: { ...orgScope, billable: true },
-          select: { userId: true, minutes: true, hourlyRate: true, invoiceId: true, frozenByBillingRunId: true },
-        }),
-        ctx.dataStore.writeOffs.findMany({ select: { invoiceId: true, writtenOffAt: true } }),
+      const [user, invoices, billingRuns, timeEntries] = await Promise.all([
+        ctx.repos.users.getByIdInOrg(input.userId, org),
+        ctx.repos.invoices.listForOrg(org),
+        ctx.repos.billingRuns.listForOrg(org),
+        ctx.repos.timeEntries.listBillableForOrg(org),
       ]);
+      // Avskrivningar org-scopas via fakturornas id:n (tidigare global findMany).
+      const writeOffs = await ctx.repos.writeOffs.listByInvoiceIds(
+        (invoices as Array<{ id: string }>).map((i) => i.id),
+      );
 
       if (!user) return null;
 
@@ -509,19 +439,12 @@ export const reportsRouter = router({
       const fromDate = new Date(input.from);
       const toDate = new Date(input.to);
       toDate.setUTCHours(23, 59, 59, 999);
-      const orgScope = { matter: { organizationId: ctx.user.organizationId } };
-      const invoices = await ctx.dataStore.invoices.findMany({
-        where: orgScope,
-        select: {
-          id: true, amount: true, status: true, invoiceType: true, creditedInvoiceId: true,
-          invoiceNumber: true, invoiceDate: true, dueDate: true, dueAt: true,
-          matter: { select: { id: true, matterNumber: true, title: true } },
-        },
-      });
+      const org = ctx.user.organizationId;
+      const invoices = await ctx.repos.invoices.listForOrg(org);
       const ids = (invoices as Array<{ id: string }>).map((i) => i.id);
       const [payments, writeOffs] = await Promise.all([
-        ctx.dataStore.payments.findMany({ where: { invoiceId: { in: ids } }, select: { invoiceId: true, amount: true } }),
-        ctx.dataStore.writeOffs.findMany({ where: { invoiceId: { in: ids } }, select: { invoiceId: true, amount: true } }),
+        ctx.repos.payments.listByInvoiceIds(ids),
+        ctx.repos.writeOffs.listByInvoiceIds(ids),
       ]);
 
       // Scopa till fakturor utställda i perioden (ADR 0007 #4, uppdaterat) så
@@ -537,14 +460,11 @@ export const reportsRouter = router({
       // frysta arbetsvärde per faktura (samma modell som "Fakturerat per advokat").
       if (input.userId) {
         const [billingRuns, timeEntries] = await Promise.all([
-          ctx.dataStore.billingRuns.findMany({ where: orgScope, select: { id: true, invoiceId: true } }),
-          ctx.dataStore.timeEntries.findMany({
-            where: { ...orgScope, billable: true },
-            select: { userId: true, minutes: true, hourlyRate: true, invoiceId: true, frozenByBillingRunId: true },
-          }),
+          ctx.repos.billingRuns.listForOrg(org),
+          ctx.repos.timeEntries.listBillableForOrg(org),
         ]);
         const runToInvoice = new Map<string, string>();
-        for (const r of billingRuns as Array<{ id: string; invoiceId?: string }>) {
+        for (const r of billingRuns as Array<{ id: string; invoiceId?: string | null }>) {
           if (r.invoiceId) runToInvoice.set(r.id, r.invoiceId);
         }
         const ratios = lawyerShareRatios(buildFrozenWork(timeEntries as RawTimeEntry[], runToInvoice), input.userId);

--- a/src/lib/server/routers/timeEntry.ts
+++ b/src/lib/server/routers/timeEntry.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
+import type { TimeEntry } from "@/lib/shared/schemas/billing";
 import {
   asId,
   matterIdSchema,
@@ -22,47 +23,18 @@ export const timeEntryRouter = router({
         pageSize: z.number().min(1).max(100).default(50),
       })
     )
+    // Migrerad till repository-sömmen (ADR 0020): listForOrg kapslar in
+    // filter/include/count/summa.
     .query(async ({ ctx, input }) => {
-      const where = {
-        matter: { organizationId: ctx.user.organizationId },
-        ...(input.matterId ? { matterId: input.matterId } : {}),
-        ...(input.userId ? { userId: input.userId } : {}),
-        ...(input.from || input.to
-          ? {
-              date: {
-                ...(input.from ? { gte: input.from } : {}),
-                ...(input.to ? { lte: input.to } : {}),
-              },
-            }
-          : {}),
-      };
-
-      const [entries, total] = await Promise.all([
-        ctx.dataStore.timeEntries.findMany({
-          where,
-          orderBy: { date: "desc" },
-          skip: (input.page - 1) * input.pageSize,
-          take: input.pageSize,
-          include: {
-            user: { select: { id: true, name: true } },
-            matter: { select: { id: true, matterNumber: true, title: true } },
-            invoice: { select: { id: true, invoiceNumber: true } },
-          },
-        }),
-        ctx.dataStore.timeEntries.count({ where }),
-      ]);
-
-      const totalMinutes = await ctx.dataStore.timeEntries.aggregate({
-        where,
-        _sum: { minutes: true },
+      const { entries, total, totalMinutes } = await ctx.repos.timeEntries.listForOrg(ctx.user.organizationId, {
+        matterId: input.matterId,
+        userId: input.userId,
+        from: input.from,
+        to: input.to,
+        page: input.page,
+        pageSize: input.pageSize,
       });
-
-      return {
-        entries,
-        total,
-        totalMinutes: totalMinutes._sum.minutes ?? 0,
-        pages: Math.ceil(total / input.pageSize),
-      };
+      return { entries, total, totalMinutes, pages: Math.ceil(total / input.pageSize) };
     }),
 
   create: protectedProcedure
@@ -83,25 +55,21 @@ export const timeEntryRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       const userId = input.userId ?? asId<"UserId">(ctx.user.id);
-      const user = await ctx.dataStore.users.findUniqueOrThrow({
-        where: { id: userId },
-        select: { hourlyRate: true },
-      });
+      const user = await ctx.repos.users.getById(userId);
+      if (!user) throw new TRPCError({ code: "NOT_FOUND", message: "Användare finns inte." });
 
-      const entry = await ctx.dataStore.timeEntries.create({
-        data: omitUndefined({
-          id: input.id, // undefined → store genererar
-          userId,
-          matterId: input.matterId,
-          date: new Date(input.date),
-          minutes: input.minutes,
-          description: input.description,
-          hourlyRate: input.hourlyRate ?? user.hourlyRate ?? 0,
-          billable: input.billable,
-          invoiceId: input.invoiceId ?? null,
-          ...(input.createdAt ? { createdAt: new Date(input.createdAt) } : {}),
-        }),
-      });
+      const entry = await ctx.repos.timeEntries.create(omitUndefined({
+        id: input.id, // undefined → store genererar
+        userId,
+        matterId: input.matterId,
+        date: new Date(input.date),
+        minutes: input.minutes,
+        description: input.description,
+        hourlyRate: input.hourlyRate ?? user.hourlyRate ?? 0,
+        billable: input.billable,
+        invoiceId: input.invoiceId ?? null,
+        ...(input.createdAt ? { createdAt: new Date(input.createdAt) } : {}),
+      }) as Partial<TimeEntry>);
       await emit.timeEntryAdded(ctx, { id: entry.id, matterId: entry.matterId, minutes: entry.minutes });
       return entry;
     }),
@@ -119,20 +87,15 @@ export const timeEntryRouter = router({
     .mutation(async ({ ctx, input }) => {
       // Säkerhet (#60): org-ägarskap via matter (samma scopning som `list`)
       // INNAN update. NOT_FOUND vid mismatch.
-      const owned = await ctx.dataStore.timeEntries.findFirst({
-        where: { id: input.id, matter: { organizationId: ctx.orgId } },
-      });
+      const owned = await ctx.repos.timeEntries.getByIdInOrg(input.id, ctx.orgId);
       if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
       const { id, date, minutes, description, billable } = input;
-      const updated = await ctx.dataStore.timeEntries.update({
-        where: { id },
-        data: omitUndefined({
-          minutes,
-          description,
-          billable,
-          ...(date ? { date: new Date(date) } : {}),
-        }),
-      });
+      const updated = await ctx.repos.timeEntries.update(id, omitUndefined({
+        minutes,
+        description,
+        billable,
+        ...(date ? { date: new Date(date) } : {}),
+      }) as Partial<TimeEntry>);
       await emit.timeEntryUpdated(ctx, { id: updated.id, matterId: updated.matterId });
       return updated;
     }),
@@ -140,13 +103,12 @@ export const timeEntryRouter = router({
   delete: orgProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      const owned = await ctx.dataStore.timeEntries.findFirst({
-        where: { id: input.id, matter: { organizationId: ctx.orgId } },
-      });
+      const owned = await ctx.repos.timeEntries.getByIdInOrg(input.id, ctx.orgId);
       if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
-      const entry = await ctx.dataStore.timeEntries.delete({ where: { id: input.id } });
-      await emit.timeEntryDeleted(ctx, entry.id, entry.matterId);
-      return entry;
+      // Hård delete bevarar dagens beteende (ADR 0017-delete-policy öppen).
+      await ctx.repos.timeEntries.hardDelete(input.id);
+      await emit.timeEntryDeleted(ctx, input.id, owned.matterId);
+      return { id: input.id };
     }),
 
   report: protectedProcedure
@@ -159,35 +121,15 @@ export const timeEntryRouter = router({
         matterId: z.string().optional(),
       })
     )
+    // Migrerad till repository-sömmen (ADR 0020): listForReport (jurist + ärende
+    // inkl. KLIENT-kontakt). Grupperingen per jurist bor kvar i routern.
     .query(async ({ ctx, input }) => {
-      const userFilter = input.userIds && input.userIds.length > 0
-        ? { userId: { in: input.userIds } }
-        : input.userId
-          ? { userId: input.userId }
-          : {};
-      const where = {
-        matter: { organizationId: ctx.user.organizationId },
-        date: { gte: new Date(input.from), lte: new Date(input.to) },
-        ...userFilter,
-        ...(input.matterId ? { matterId: input.matterId } : {}),
-      };
-
-      const entries = await ctx.dataStore.timeEntries.findMany({
-        where,
-        include: {
-          user: { select: { id: true, name: true } },
-          matter: {
-            select: {
-              id: true, matterNumber: true, title: true,
-              contacts: {
-                where: { role: "KLIENT" },
-                select: { contact: { select: { name: true } } },
-                take: 1,
-              },
-            },
-          },
-        },
-        orderBy: [{ userId: "asc" }, { date: "asc" }],
+      const entries = await ctx.repos.timeEntries.listForReport(ctx.user.organizationId, {
+        from: new Date(input.from),
+        to: new Date(input.to),
+        userId: input.userId,
+        userIds: input.userIds,
+        matterId: input.matterId,
       });
 
       // Group by user

--- a/src/lib/server/routers/todo.ts
+++ b/src/lib/server/routers/todo.ts
@@ -12,8 +12,6 @@
 
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import type { Task, CalendarEvent } from "@/lib/shared/schemas";
-import type { Joined } from "../data-store/IDataStore";
 import { router, orgProcedure } from "../trpc";
 
 export interface TodoItem {
@@ -32,8 +30,6 @@ export interface TodoItem {
   userId: string;
 }
 
-const includeMatter = { matter: { select: { id: true, matterNumber: true, title: true } } };
-
 export const todoRouter = router({
   list: orgProcedure
     .input(z.object({
@@ -50,22 +46,16 @@ export const todoRouter = router({
       // autentiserad. Det undviker race när demo-runtime hydrerar users
       // asynkront → todo.list slog tidigare in innan u-anna fanns i datalagret.
       if (userId !== ctx.user.id) {
-        const user = await ctx.dataStore.users.findFirst({
-          where: { id: userId, organizationId: ctx.user.organizationId },
-        });
+        const user = await ctx.repos.users.getByIdInOrg(userId, ctx.user.organizationId);
         if (!user) throw new TRPCError({ code: "NOT_FOUND", message: "Användare finns inte i organisationen." });
       }
 
-      const where = { userId, organizationId: ctx.user.organizationId };
+      // Migrerad till repository-sömmen (ADR 0020): hämta alla user-poster och
+      // filtrera tidsfönstret i minne (samma mönster som calendar; in-memory
+      // query-engine stödjer inte Date-range i where).
       const [tasks, events] = await Promise.all([
-        ctx.dataStore.tasks.findMany({
-          where: { ...where, dueAt: { gte: input.from, lte: input.to } },
-          include: includeMatter,
-        }),
-        ctx.dataStore.calendarEvents.findMany({
-          where: { ...where, startAt: { gte: input.from, lte: input.to } },
-          include: includeMatter,
-        }),
+        ctx.repos.tasks.listForUser(userId, ctx.user.organizationId, {}),
+        ctx.repos.calendarEvents.listForUser(userId, ctx.user.organizationId),
       ]);
 
       // Demo-projektionen (passthrough) sparar datum som ISO-strängar →
@@ -74,19 +64,25 @@ export const todoRouter = router({
       // och behöll förra resultatet → tom dashboard).
       const toDate = (v: unknown): Date => v instanceof Date ? v : new Date(v as string);
 
-      const taskItems: TodoItem[] = tasks.map((t: Joined<Task>) => ({
+      const taskItems: TodoItem[] = tasks.map((t) => ({
         id: t.id, source: "task", title: t.title, description: t.description ?? null,
         at: toDate(t.dueAt), endAt: null, allDay: false,
         status: t.status, priority: t.priority, kind: null, location: null,
         matter: t.matter ?? null, userId: t.userId,
       }));
-      const eventItems: TodoItem[] = events.map((e: Joined<CalendarEvent>) => ({
+      const eventItems: TodoItem[] = events.map((e) => ({
         id: e.id, source: "event", title: e.title, description: e.description ?? null,
         at: toDate(e.startAt), endAt: e.endAt ? toDate(e.endAt) : null, allDay: e.allDay ?? false,
         status: null, priority: null, kind: e.kind, location: e.location ?? null,
         matter: e.matter ?? null, userId: e.userId,
       }));
 
-      return [...taskItems, ...eventItems].sort((a, b) => a.at.getTime() - b.at.getTime());
+      // Tidsfönster-filter i minne: behåll poster vars `at` ligger i [from, to]
+      // (tasks utan dueAt → ogiltigt/utanför → faller bort, som förr via gte/lte).
+      const fromT = input.from.getTime();
+      const toT = input.to.getTime();
+      return [...taskItems, ...eventItems]
+        .filter((i) => { const t = i.at.getTime(); return !Number.isNaN(t) && t >= fromT && t <= toT; })
+        .sort((a, b) => a.at.getTime() - b.at.getTime());
     }),
 });

--- a/test/unit/server/repositories/billing-run-repository.test.ts
+++ b/test/unit/server/repositories/billing-run-repository.test.ts
@@ -1,0 +1,92 @@
+/**
+ * BillingRunRepository-paritet (ADR 0020) — in-memory + Drizzle (pglite).
+ * listForOrg/getByIdInOrg (join faktura+ärende) + listAccontoSent/listAccontoByIds.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { billingRuns, invoices, matters } from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzleBillingRunRepository } from "@/lib/server/repositories/drizzle-billing-run-repository";
+import { InMemoryBillingRunRepository } from "@/lib/server/repositories/in-memory-billing-run-repository";
+import { prebakeJoins } from "@/lib/shared/demo-source";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+const ORG = "44444444-4444-7444-8444-444444444444";
+
+const run = (o: Record<string, unknown>) => ({
+  type: "ACCONTO", recipient: "KLIENT", status: "SENT", workValueOreAtRun: 1000,
+  proposedAmountOre: 500, amountOre: 500, deductedBillingRunIds: [], periodTo: new Date("2026-06-01"), ...o,
+});
+
+describe("BillingRunRepository — in-memory", () => {
+  it("listForOrg/getByIdInOrg/listAcconto*", async () => {
+    const mId = uuidv7();
+    const invId = uuidv7();
+    const r1 = uuidv7();
+    const r2 = uuidv7();
+    const source = prebakeJoins({
+      matters: [{ id: mId, organizationId: ORG, matterNumber: "2026-1", title: "T", paymentMethod: "RATTSSKYDD" }],
+      invoices: [{ id: invId, matterId: mId, amount: 500, status: "DRAFT", invoiceNumber: "F-1" }],
+      billingRuns: [
+        run({ id: r1, matterId: mId, invoiceId: invId, type: "ACCONTO", status: "SENT" }),
+        run({ id: r2, matterId: mId, invoiceId: null, type: "FINAL", status: "SENT" }),
+      ],
+    } as DemoSource);
+    const repo = new InMemoryBillingRunRepository(new LocalStore(source, async () => {}));
+
+    const list = await repo.listForOrg(ORG);
+    expect(list).toHaveLength(2);
+    expect(list.find((r) => r.id === r1)!.invoice?.invoiceNumber).toBe("F-1");
+    expect(await repo.listForOrg(ORG, mId)).toHaveLength(2);
+    expect(await repo.listForOrg(uuidv7())).toHaveLength(0);
+
+    const detail = await repo.getByIdInOrg(r1, ORG);
+    expect(detail?.matter?.paymentMethod).toBe("RATTSSKYDD");
+    expect(detail?.invoice?.amount).toBe(500);
+    expect(await repo.getByIdInOrg(r1, uuidv7())).toBeNull();
+
+    expect((await repo.listAccontoSent(mId)).map((r) => r.id)).toEqual([r1]);
+    expect((await repo.listAccontoByIds(mId, [r1, r2])).map((r) => r.id)).toEqual([r1]); // r2 = FINAL filtreras
+    expect(await repo.listAccontoByIds(mId, [])).toHaveLength(0);
+  });
+});
+
+describe("BillingRunRepository — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("listForOrg/getByIdInOrg/listAcconto*", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const mId = uuidv7();
+    const invId = uuidv7();
+    const r1 = uuidv7();
+    const r2 = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T", paymentMethod: "RATTSSKYDD" }));
+    await db.insert(invoices).values(v({ id: invId, matterId: mId, amount: 500, status: "DRAFT", invoiceNumber: "F-1", invoiceDate: new Date() }));
+    await db.insert(billingRuns).values(v(run({ id: r1, matterId: mId, invoiceId: invId, type: "ACCONTO", status: "SENT" })));
+    await db.insert(billingRuns).values(v(run({ id: r2, matterId: mId, invoiceId: null, type: "FINAL", status: "SENT" })));
+    const repo = new DrizzleBillingRunRepository(db as unknown as AppDb);
+
+    const list = await repo.listForOrg(org);
+    expect(list).toHaveLength(2);
+    expect(list.find((r) => r.id === r1)!.invoice?.invoiceNumber).toBe("F-1");
+    expect(await repo.listForOrg(org, mId)).toHaveLength(2);
+    expect(await repo.listForOrg(uuidv7())).toHaveLength(0);
+
+    const detail = await repo.getByIdInOrg(r1, org);
+    expect(detail?.matter?.paymentMethod).toBe("RATTSSKYDD");
+    expect(detail?.invoice?.amount).toBe(500);
+    expect(await repo.getByIdInOrg(r1, uuidv7())).toBeNull();
+
+    expect((await repo.listAccontoSent(mId)).map((r) => r.id)).toEqual([r1]);
+    expect((await repo.listAccontoByIds(mId, [r1, r2])).map((r) => r.id)).toEqual([r1]);
+    expect(await repo.listAccontoByIds(mId, [])).toHaveLength(0);
+  });
+});

--- a/test/unit/server/repositories/conflict-matter-contact-repository.test.ts
+++ b/test/unit/server/repositories/conflict-matter-contact-repository.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Paritet (ADR 0020) för ConflictCheckRepository (listHistory) +
+ * MatterContactRepository (findForConflict) — in-memory + Drizzle (pglite).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { conflictChecks, contacts, matterContacts, matters, users } from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzleConflictCheckRepository } from "@/lib/server/repositories/drizzle-conflict-check-repository";
+import { DrizzleMatterContactRepository } from "@/lib/server/repositories/drizzle-matter-contact-repository";
+import { InMemoryConflictCheckRepository } from "@/lib/server/repositories/in-memory-conflict-check-repository";
+import { InMemoryMatterContactRepository } from "@/lib/server/repositories/in-memory-matter-contact-repository";
+import { prebakeJoins } from "@/lib/shared/demo-source";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+const ORG = "33333333-3333-7333-8333-333333333333";
+
+describe("Conflict/MatterContact repos — in-memory", () => {
+  it("findForConflict (nummer + alla) + listHistory", async () => {
+    const mId = uuidv7();
+    const cMot = uuidv7();
+    const cKli = uuidv7();
+    const uId = uuidv7();
+    const source = prebakeJoins({
+      matters: [{ id: mId, organizationId: ORG, matterNumber: "2026-1", title: "X" }],
+      users: [{ id: uId, name: "Jurist" }],
+      contacts: [
+        { id: cMot, organizationId: ORG, name: "Anna", contactType: "PERSON", personalNumber: "19850225-6655" },
+        { id: cKli, organizationId: ORG, name: "Klient AB", contactType: "COMPANY" },
+      ],
+      matterContacts: [
+        { id: uuidv7(), matterId: mId, contactId: cMot, role: "MOTPART" },
+        { id: uuidv7(), matterId: mId, contactId: cKli, role: "KLIENT" },
+      ],
+      conflictChecks: [
+        { id: uuidv7(), searchTerm: "anna", searchType: "name", results: [], checkedById: uId, createdAt: new Date() },
+      ],
+    } as DemoSource);
+    const store = new LocalStore(source, async () => {});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mc = new InMemoryMatterContactRepository(store as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cc = new InMemoryConflictCheckRepository(store as any);
+
+    const byNumber = await mc.findForConflict(ORG, "19850225");
+    expect(byNumber).toHaveLength(1);
+    expect(byNumber[0]!.contact.name).toBe("Anna");
+    expect(byNumber[0]!.matter.contacts[0]?.contact.name).toBe("Klient AB");
+    expect((await mc.findForConflict(ORG)).length).toBe(2); // MOTPART + KLIENT
+    expect(await mc.findForConflict(ORG, "0000")).toHaveLength(0);
+
+    const hist = await cc.listHistory(1, 20);
+    expect(hist.total).toBe(1);
+    expect(hist.checks[0]!.checkedBy?.name).toBe("Jurist");
+  });
+});
+
+describe("Conflict/MatterContact repos — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("findForConflict (nummer + alla) + listHistory", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const mId = uuidv7();
+    const cMot = uuidv7();
+    const cKli = uuidv7();
+    const uId = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "X" }));
+    await db.insert(users).values(v({ id: uId, organizationId: org, email: "j@x", name: "Jurist" }));
+    await db.insert(contacts).values(v({ id: cMot, organizationId: org, name: "Anna", contactType: "PERSON", personalNumber: "19850225-6655" }));
+    await db.insert(contacts).values(v({ id: cKli, organizationId: org, name: "Klient AB", contactType: "COMPANY" }));
+    await db.insert(matterContacts).values(v({ id: uuidv7(), matterId: mId, contactId: cMot, role: "MOTPART" }));
+    await db.insert(matterContacts).values(v({ id: uuidv7(), matterId: mId, contactId: cKli, role: "KLIENT" }));
+    await db.insert(conflictChecks).values(v({ id: uuidv7(), searchTerm: "anna", searchType: "name", results: [], checkedById: uId }));
+    const mc = new DrizzleMatterContactRepository(db as unknown as AppDb);
+    const cc = new DrizzleConflictCheckRepository(db as unknown as AppDb);
+
+    const byNumber = await mc.findForConflict(org, "19850225");
+    expect(byNumber).toHaveLength(1);
+    expect(byNumber[0]!.contact.name).toBe("Anna");
+    expect(byNumber[0]!.matter.contacts[0]?.contact.name).toBe("Klient AB");
+    expect((await mc.findForConflict(org)).length).toBe(2);
+    expect(await mc.findForConflict(org, "0000")).toHaveLength(0);
+
+    const hist = await cc.listHistory(1, 20);
+    expect(hist.total).toBe(1);
+    expect(hist.checks[0]!.checkedBy?.name).toBe("Jurist");
+  });
+});

--- a/test/unit/server/repositories/document-repository.test.ts
+++ b/test/unit/server/repositories/document-repository.test.ts
@@ -1,0 +1,112 @@
+/**
+ * DocumentRepository + DocumentFolderRepository-paritet (ADR 0020) —
+ * in-memory + Drizzle (pglite). list/getByIdInOrg/reassign + folder-_count.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { documentFolders, documents, matters, users } from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzleDocumentFolderRepository } from "@/lib/server/repositories/drizzle-document-folder-repository";
+import { DrizzleDocumentRepository } from "@/lib/server/repositories/drizzle-document-repository";
+import { InMemoryDocumentFolderRepository } from "@/lib/server/repositories/in-memory-document-folder-repository";
+import { InMemoryDocumentRepository } from "@/lib/server/repositories/in-memory-document-repository";
+import { prebakeJoins } from "@/lib/shared/demo-source";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+const ORG = "11111111-1111-7111-8111-111111111111";
+
+describe("DocumentRepository / DocumentFolderRepository — in-memory", () => {
+  it("list/getByIdInOrg/reassign + folder _count", async () => {
+    const mId = uuidv7();
+    const uId = uuidv7();
+    const root = uuidv7();
+    const sub = uuidv7();
+    const d1 = uuidv7();
+    const source = prebakeJoins({
+      matters: [{ id: mId, organizationId: ORG, matterNumber: "2026-1", title: "T" }],
+      users: [{ id: uId, name: "Anna" }],
+      documentFolders: [
+        { id: root, name: "Rot", matterId: mId, parentId: null },
+        { id: sub, name: "Under", matterId: mId, parentId: root },
+      ],
+      documents: [
+        { id: d1, matterId: mId, folderId: root, fileName: "a.pdf", uploadedById: uId, documentType: "Avtal" },
+        { id: uuidv7(), matterId: mId, folderId: null, fileName: "b.pdf", documentType: "Faktura" },
+      ],
+    } as DemoSource);
+    const store = new LocalStore(source, async () => {});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const docs = new InMemoryDocumentRepository(store as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const folders = new InMemoryDocumentFolderRepository(store as any);
+
+    const inRoot = await docs.listInFolder(mId, root, 1, 50);
+    expect(inRoot.total).toBe(1);
+    expect(inRoot.documents[0]!.uploadedBy?.name).toBe("Anna");
+    expect(await docs.getByIdInOrg(d1, ORG)).toMatchObject({ id: d1, matterId: mId });
+    expect(await docs.getByIdInOrg(d1, uuidv7())).toBeNull();
+    expect((await docs.listByMatter(mId)).length).toBe(2);
+    expect(await docs.listDocumentTypesForOrg(ORG)).toEqual([
+      { type: "Avtal", count: 1 }, { type: "Faktura", count: 1 },
+    ]);
+
+    const rootFolders = await folders.listInParent(mId, null);
+    expect(rootFolders).toHaveLength(1);
+    expect(rootFolders[0]!._count).toEqual({ documents: 1, children: 1 });
+
+    await docs.reassignFolder(root, null);
+    expect((await docs.listInFolder(mId, root, 1, 50)).total).toBe(0);
+    await folders.reassignParent(root, null);
+    expect((await folders.getById(sub))!.parentId).toBeNull();
+  });
+});
+
+describe("DocumentRepository / DocumentFolderRepository — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("list/getByIdInOrg/reassign + folder _count", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const mId = uuidv7();
+    const uId = uuidv7();
+    const root = uuidv7();
+    const sub = uuidv7();
+    const d1 = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
+    await db.insert(users).values(v({ id: uId, organizationId: org, email: "a@x", name: "Anna" }));
+    await db.insert(documentFolders).values(v({ id: root, name: "Rot", matterId: mId, parentId: null }));
+    await db.insert(documentFolders).values(v({ id: sub, name: "Under", matterId: mId, parentId: root }));
+    const doc = (extra: Record<string, unknown>) =>
+      v({ matterId: mId, fileName: "f", mimeType: "application/pdf", sizeBytes: 1, storagePath: "p", uploadedById: uId, ...extra });
+    await db.insert(documents).values(doc({ id: d1, folderId: root, documentType: "Avtal" }));
+    await db.insert(documents).values(doc({ id: uuidv7(), folderId: null, documentType: "Faktura" }));
+    const docs = new DrizzleDocumentRepository(db as unknown as AppDb);
+    const folders = new DrizzleDocumentFolderRepository(db as unknown as AppDb);
+
+    const inRoot = await docs.listInFolder(mId, root, 1, 50);
+    expect(inRoot.total).toBe(1);
+    expect(inRoot.documents[0]!.uploadedBy?.name).toBe("Anna");
+    expect(await docs.getByIdInOrg(d1, org)).toMatchObject({ id: d1, matterId: mId });
+    expect(await docs.getByIdInOrg(d1, uuidv7())).toBeNull();
+    expect((await docs.listByMatter(mId)).length).toBe(2);
+    expect(await docs.listDocumentTypesForOrg(org)).toEqual([
+      { type: "Avtal", count: 1 }, { type: "Faktura", count: 1 },
+    ]);
+
+    const rootFolders = await folders.listInParent(mId, null);
+    expect(rootFolders).toHaveLength(1);
+    expect(rootFolders[0]!._count).toEqual({ documents: 1, children: 1 });
+
+    await docs.reassignFolder(root, null);
+    expect((await docs.listInFolder(mId, root, 1, 50)).total).toBe(0);
+    await folders.reassignParent(root, null);
+    expect((await folders.getById(sub))!.parentId).toBeNull();
+  });
+});

--- a/test/unit/server/repositories/document-suggestion-repository.test.ts
+++ b/test/unit/server/repositories/document-suggestion-repository.test.ts
@@ -1,0 +1,77 @@
+/**
+ * DocumentSuggestionRepository-paritet (ADR 0020) — in-memory + Drizzle (pglite).
+ * getByIdInOrg / listPendingForMatter / listPendingByIds / listByIdsInOrg /
+ * updateManyByIds, org-scopat via dokument→ärende.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { documentAnalysisSuggestions, documents, matters } from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzleDocumentSuggestionRepository } from "@/lib/server/repositories/drizzle-document-suggestion-repository";
+import { InMemoryDocumentSuggestionRepository } from "@/lib/server/repositories/in-memory-document-suggestion-repository";
+import { prebakeJoins } from "@/lib/shared/demo-source";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+const ORG = "77777777-7777-7777-8777-777777777777";
+
+describe("DocumentSuggestionRepository — in-memory", () => {
+  it("getByIdInOrg/listPending*/listByIds/updateMany", async () => {
+    const mId = uuidv7();
+    const dId = uuidv7();
+    const s1 = uuidv7();
+    const s2 = uuidv7();
+    const source = prebakeJoins({
+      matters: [{ id: mId, organizationId: ORG, matterNumber: "2026-1", title: "T" }],
+      documents: [{ id: dId, matterId: mId, fileName: "f.pdf", title: "F" }],
+      documentAnalysisSuggestions: [
+        { id: s1, documentId: dId, name: "Anna", role: "MOTPART", contactType: "PERSON", status: "PENDING", createdAt: new Date("2026-06-01") },
+        { id: s2, documentId: dId, name: "Bo", role: "OMBUD", contactType: "PERSON", status: "REJECTED", createdAt: new Date("2026-06-02") },
+      ],
+    } as DemoSource);
+    const store = new LocalStore(source, async () => {});
+    const repo = new InMemoryDocumentSuggestionRepository(store);
+
+    expect(await repo.getByIdInOrg(s1, ORG)).toMatchObject({ id: s1, document: { matterId: mId } });
+    expect(await repo.getByIdInOrg(s1, uuidv7())).toBeNull();
+    expect((await repo.listPendingForMatter(mId, ORG, "asc")).map((s) => s.id)).toEqual([s1]);
+    expect((await repo.listPendingByIds([s1, s2], ORG)).map((s) => s.id)).toEqual([s1]);
+    expect((await repo.listByIdsInOrg([s1, s2], ORG)).length).toBe(2);
+
+    await repo.updateManyByIds([s1], { status: "ACCEPTED" } as never);
+    expect((await repo.listPendingForMatter(mId, ORG, "asc")).length).toBe(0);
+  });
+});
+
+describe("DocumentSuggestionRepository — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("getByIdInOrg/listPending*/listByIds/updateMany", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const mId = uuidv7();
+    const dId = uuidv7();
+    const s1 = uuidv7();
+    const s2 = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
+    await db.insert(documents).values(v({ id: dId, matterId: mId, fileName: "f.pdf", mimeType: "application/pdf", sizeBytes: 1, storagePath: "p", uploadedById: uuidv7(), title: "F" }));
+    await db.insert(documentAnalysisSuggestions).values(v({ id: s1, documentId: dId, name: "Anna", role: "MOTPART", contactType: "PERSON", status: "PENDING" }));
+    await db.insert(documentAnalysisSuggestions).values(v({ id: s2, documentId: dId, name: "Bo", role: "OMBUD", contactType: "PERSON", status: "REJECTED" }));
+    const repo = new DrizzleDocumentSuggestionRepository(db as unknown as AppDb);
+
+    expect(await repo.getByIdInOrg(s1, org)).toMatchObject({ id: s1, document: { matterId: mId } });
+    expect(await repo.getByIdInOrg(s1, uuidv7())).toBeNull();
+    expect((await repo.listPendingForMatter(mId, org, "asc")).map((s) => s.id)).toEqual([s1]);
+    expect((await repo.listPendingByIds([s1, s2], org)).map((s) => s.id)).toEqual([s1]);
+    expect((await repo.listByIdsInOrg([s1, s2], org)).length).toBe(2);
+
+    await repo.updateManyByIds([s1], { status: "ACCEPTED" } as never);
+    expect((await repo.listPendingForMatter(mId, org, "asc")).length).toBe(0);
+  });
+});

--- a/test/unit/server/repositories/document-template-repository.test.ts
+++ b/test/unit/server/repositories/document-template-repository.test.ts
@@ -1,0 +1,56 @@
+/**
+ * DocumentTemplateRepository-paritet (ADR 0020) — in-memory + Drizzle (pglite).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { documentTemplates, users } from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzleDocumentTemplateRepository } from "@/lib/server/repositories/drizzle-document-template-repository";
+import { InMemoryDocumentTemplateRepository } from "@/lib/server/repositories/in-memory-document-template-repository";
+import { prebakeJoins } from "@/lib/shared/demo-source";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+describe("DocumentTemplateRepository — in-memory", () => {
+  it("listForOrg + getByIdInOrg (med skapar-namn)", async () => {
+    const t1 = uuidv7();
+    const userId = uuidv7();
+    const source = prebakeJoins({
+      users: [{ id: userId, name: "Anna" }],
+      documentTemplates: [
+        { id: t1, organizationId: "org-1", name: "Avtal", category: "A", content: "x", createdById: userId },
+      ],
+    } as DemoSource);
+    const repo = new InMemoryDocumentTemplateRepository(new LocalStore(source, async () => {}));
+    const list = await repo.listForOrg("org-1");
+    expect(list).toHaveLength(1);
+    expect(list[0]!.createdBy?.name).toBe("Anna");
+    expect(await repo.getByIdInOrg(t1, "org-1")).toMatchObject({ id: t1 });
+    expect(await repo.getByIdInOrg(t1, "org-2")).toBeNull();
+  });
+});
+
+describe("DocumentTemplateRepository — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("listForOrg (join skapare) + getByIdInOrg", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const userId = uuidv7();
+    const t1 = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(users).values(v({ id: userId, organizationId: org, email: "a@x", name: "Anna" }));
+    await db.insert(documentTemplates).values(v({ id: t1, organizationId: org, name: "Avtal", category: "A", content: "x", createdById: userId }));
+    const repo = new DrizzleDocumentTemplateRepository(handle.db as unknown as AppDb);
+    const list = await repo.listForOrg(org);
+    expect(list).toHaveLength(1);
+    expect(list[0]!.createdBy?.name).toBe("Anna");
+    expect(await repo.getByIdInOrg(t1, org)).toMatchObject({ id: t1 });
+    expect(await repo.getByIdInOrg(t1, uuidv7())).toBeNull();
+  });
+});

--- a/test/unit/server/repositories/expected-receivable-repository.test.ts
+++ b/test/unit/server/repositories/expected-receivable-repository.test.ts
@@ -1,0 +1,59 @@
+/**
+ * ExpectedReceivableRepository-paritet (ADR 0020) — in-memory + Drizzle (pglite).
+ * Täcker även MatterRepository.listByOrg (ny metod, används av candidates).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { expectedReceivables, matters } from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzleExpectedReceivableRepository } from "@/lib/server/repositories/drizzle-expected-receivable-repository";
+import { DrizzleMatterRepository } from "@/lib/server/repositories/drizzle-matter-repository";
+import { InMemoryExpectedReceivableRepository } from "@/lib/server/repositories/in-memory-expected-receivable-repository";
+import { InMemoryMatterRepository } from "@/lib/server/repositories/in-memory-matter-repository";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+describe("ExpectedReceivableRepository — in-memory", () => {
+  it("listForOrg (filter status/matter) + getByIdInOrg; matters.listByOrg", async () => {
+    const mId = uuidv7();
+    const r1 = uuidv7();
+    const store = new LocalStore({
+      matters: [{ id: mId, organizationId: "org-1", matterNumber: "2026-1", title: "T" }],
+      expectedReceivables: [
+        { id: r1, organizationId: "org-1", matterId: mId, description: "A", expectedAmount: 100, status: "PENDING", recordedById: uuidv7() },
+        { id: uuidv7(), organizationId: "org-1", matterId: mId, description: "B", expectedAmount: 50, status: "SETTLED", recordedById: uuidv7() },
+      ],
+    }, async () => {});
+    const repo = new InMemoryExpectedReceivableRepository(store);
+    expect(await repo.listForOrg("org-1")).toHaveLength(2);
+    expect(await repo.listForOrg("org-1", { status: "PENDING" })).toHaveLength(1);
+    expect(await repo.getByIdInOrg(r1, "org-1")).toMatchObject({ id: r1 });
+    expect(await repo.getByIdInOrg(r1, "org-2")).toBeNull();
+    expect(await new InMemoryMatterRepository(store).listByOrg("org-1")).toHaveLength(1);
+  });
+});
+
+describe("ExpectedReceivableRepository — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("listForOrg + getByIdInOrg; matters.listByOrg", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const mId = uuidv7();
+    const r1 = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
+    await db.insert(expectedReceivables).values(v({ id: r1, organizationId: org, matterId: mId, description: "A", expectedAmount: 100, status: "PENDING", recordedById: uuidv7() }));
+    await db.insert(expectedReceivables).values(v({ id: uuidv7(), organizationId: org, matterId: mId, description: "B", expectedAmount: 50, status: "SETTLED", recordedById: uuidv7() }));
+    const repo = new DrizzleExpectedReceivableRepository(handle.db as unknown as AppDb);
+    expect(await repo.listForOrg(org)).toHaveLength(2);
+    expect(await repo.listForOrg(org, { status: "PENDING" })).toHaveLength(1);
+    expect(await repo.getByIdInOrg(r1, org)).toMatchObject({ id: r1 });
+    expect(await repo.getByIdInOrg(r1, uuidv7())).toBeNull();
+    expect(await new DrizzleMatterRepository(handle.db as unknown as AppDb).listByOrg(org)).toHaveLength(1);
+  });
+});

--- a/test/unit/server/repositories/invoice-dispatch-repository.test.ts
+++ b/test/unit/server/repositories/invoice-dispatch-repository.test.ts
@@ -1,0 +1,63 @@
+/**
+ * InvoiceDispatchRepository-paritet (ADR 0020) — in-memory + Drizzle (pglite).
+ * listByInvoice + listQueuedForOrg (org-scope via faktura→ärende, faktura-subset).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { invoiceDispatches, invoices, matters } from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzleInvoiceDispatchRepository } from "@/lib/server/repositories/drizzle-invoice-dispatch-repository";
+import { InMemoryInvoiceDispatchRepository } from "@/lib/server/repositories/in-memory-invoice-dispatch-repository";
+import { prebakeJoins } from "@/lib/shared/demo-source";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+describe("InvoiceDispatchRepository — in-memory", () => {
+  it("listByInvoice + listQueuedForOrg (faktura-subset)", async () => {
+    const mId = uuidv7();
+    const invId = uuidv7();
+    const d1 = uuidv7();
+    const source = prebakeJoins({
+      matters: [{ id: mId, organizationId: "org-1", matterNumber: "2026-1", title: "T" }],
+      invoices: [{ id: invId, matterId: mId, amount: 1000, status: "SENT", invoiceNumber: "F-1", invoiceDate: new Date() }],
+      invoiceDispatches: [
+        { id: d1, invoiceId: invId, channel: "email", recipient: "a@x", status: "queued", queuedAt: new Date(), recordedById: uuidv7() },
+        { id: uuidv7(), invoiceId: invId, channel: "email", recipient: "b@x", status: "sent", queuedAt: new Date(), recordedById: uuidv7() },
+      ],
+    } as DemoSource);
+    const repo = new InMemoryInvoiceDispatchRepository(new LocalStore(source, async () => {}));
+    expect(await repo.listByInvoice(invId)).toHaveLength(2);
+    const queued = await repo.listQueuedForOrg("org-1");
+    expect(queued).toHaveLength(1);
+    expect(queued[0]!.invoice?.invoiceNumber).toBe("F-1");
+    expect(await repo.listQueuedForOrg("org-2")).toHaveLength(0);
+  });
+});
+
+describe("InvoiceDispatchRepository — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("listByInvoice + listQueuedForOrg (join faktura/ärende)", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const mId = uuidv7();
+    const invId = uuidv7();
+    const d1 = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
+    await db.insert(invoices).values(v({ id: invId, matterId: mId, amount: 1000, status: "SENT", invoiceNumber: "F-1", invoiceDate: new Date() }));
+    await db.insert(invoiceDispatches).values(v({ id: d1, invoiceId: invId, channel: "email", recipient: "a@x", status: "queued", queuedAt: new Date(), recordedById: uuidv7() }));
+    await db.insert(invoiceDispatches).values(v({ id: uuidv7(), invoiceId: invId, channel: "email", recipient: "b@x", status: "sent", queuedAt: new Date(), recordedById: uuidv7() }));
+    const repo = new DrizzleInvoiceDispatchRepository(handle.db as unknown as AppDb);
+    expect(await repo.listByInvoice(invId)).toHaveLength(2);
+    const queued = await repo.listQueuedForOrg(org);
+    expect(queued).toHaveLength(1);
+    expect(queued[0]!.invoice?.invoiceNumber).toBe("F-1");
+    expect(await repo.listQueuedForOrg(uuidv7())).toHaveLength(0);
+  });
+});

--- a/test/unit/server/repositories/matter-event-suggestion-repository.test.ts
+++ b/test/unit/server/repositories/matter-event-suggestion-repository.test.ts
@@ -1,0 +1,70 @@
+/**
+ * MatterEventSuggestionRepository-paritet (ADR 0020) — in-memory + Drizzle.
+ * listForMatter (ej REJECTED, startAt asc, document-include) + getByIdInOrg.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { documents, matterEventSuggestions, matters } from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzleMatterEventSuggestionRepository } from "@/lib/server/repositories/drizzle-matter-event-suggestion-repository";
+import { InMemoryMatterEventSuggestionRepository } from "@/lib/server/repositories/in-memory-matter-event-suggestion-repository";
+import { prebakeJoins } from "@/lib/shared/demo-source";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+const ORG = "22222222-2222-7222-8222-222222222222";
+
+describe("MatterEventSuggestionRepository — in-memory", () => {
+  it("listForMatter (ej REJECTED, sorterad) + getByIdInOrg", async () => {
+    const mId = uuidv7();
+    const dId = uuidv7();
+    const e1 = uuidv7();
+    const source = prebakeJoins({
+      matters: [{ id: mId, organizationId: ORG, matterNumber: "2026-1", title: "T" }],
+      documents: [{ id: dId, matterId: mId, fileName: "s.pdf", title: "Stämning" }],
+      matterEventSuggestions: [
+        { id: e1, documentId: dId, title: "Sen", startAt: new Date("2026-06-01"), status: "PENDING" },
+        { id: uuidv7(), documentId: dId, title: "Tidig", startAt: new Date("2026-05-01"), status: "PENDING" },
+        { id: uuidv7(), documentId: dId, title: "Avvisad", startAt: new Date("2026-04-01"), status: "REJECTED" },
+      ],
+    } as DemoSource);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const repo = new InMemoryMatterEventSuggestionRepository(new LocalStore(source, async () => {}) as any);
+
+    const list = await repo.listForMatter(mId, ORG);
+    expect(list.map((r) => r.title)).toEqual(["Tidig", "Sen"]);
+    expect(list[0]!.document.fileName).toBe("s.pdf");
+    expect(await repo.getByIdInOrg(e1, ORG)).toMatchObject({ id: e1 });
+    expect(await repo.getByIdInOrg(e1, uuidv7())).toBeNull();
+  });
+});
+
+describe("MatterEventSuggestionRepository — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("listForMatter + getByIdInOrg", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const mId = uuidv7();
+    const dId = uuidv7();
+    const e1 = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
+    await db.insert(documents).values(v({ id: dId, matterId: mId, fileName: "s.pdf", mimeType: "application/pdf", sizeBytes: 1, storagePath: "p", uploadedById: uuidv7(), title: "Stämning" }));
+    await db.insert(matterEventSuggestions).values(v({ id: e1, documentId: dId, title: "Sen", startAt: new Date("2026-06-01"), status: "PENDING" }));
+    await db.insert(matterEventSuggestions).values(v({ id: uuidv7(), documentId: dId, title: "Tidig", startAt: new Date("2026-05-01"), status: "PENDING" }));
+    await db.insert(matterEventSuggestions).values(v({ id: uuidv7(), documentId: dId, title: "Avvisad", startAt: new Date("2026-04-01"), status: "REJECTED" }));
+    const repo = new DrizzleMatterEventSuggestionRepository(db as unknown as AppDb);
+
+    const list = await repo.listForMatter(mId, org);
+    expect(list.map((r) => r.title)).toEqual(["Tidig", "Sen"]);
+    expect(list[0]!.document.fileName).toBe("s.pdf");
+    expect(await repo.getByIdInOrg(e1, org)).toMatchObject({ id: e1 });
+    expect(await repo.getByIdInOrg(e1, uuidv7())).toBeNull();
+  });
+});

--- a/test/unit/server/repositories/matter-reads-repository.test.ts
+++ b/test/unit/server/repositories/matter-reads-repository.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Paritet (ADR 0020) för matter-läsningarna: MatterRepository.listForOrg/
+ * getByIdWithContacts/listByResponsibleLawyer/listByNumberPrefix,
+ * MatterContactRepository.getByIdInOrg/linkContact, ContactRepository.
+ * findByPersonalNumber/findByOrgNumber. in-memory + Drizzle (pglite).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { contacts, documents, matterContacts, matters, timeEntries, users } from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzleContactRepository } from "@/lib/server/repositories/drizzle-contact-repository";
+import { DrizzleMatterContactRepository } from "@/lib/server/repositories/drizzle-matter-contact-repository";
+import { DrizzleMatterRepository } from "@/lib/server/repositories/drizzle-matter-repository";
+import { InMemoryContactRepository } from "@/lib/server/repositories/in-memory-contact-repository";
+import { InMemoryMatterContactRepository } from "@/lib/server/repositories/in-memory-matter-contact-repository";
+import { InMemoryMatterRepository } from "@/lib/server/repositories/in-memory-matter-repository";
+import { prebakeJoins } from "@/lib/shared/demo-source";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+const ORG = "66666666-6666-7666-8666-666666666666";
+
+describe("Matter-läsningar — in-memory", () => {
+  it("listForOrg/_count + getByIdWithContacts + serie-läsningar + contact-dedup", async () => {
+    const mId = uuidv7();
+    const cId = uuidv7();
+    const uId = uuidv7();
+    const mcId = uuidv7();
+    const source = prebakeJoins({
+      matters: [
+        { id: mId, organizationId: ORG, matterNumber: "AA2026-0001", title: "Tvist", status: "ACTIVE", responsibleLawyerId: uId, createdAt: new Date("2026-01-01") },
+      ],
+      users: [{ id: uId, organizationId: ORG, name: "Anna" }],
+      contacts: [{ id: cId, organizationId: ORG, name: "Klient AB", contactType: "COMPANY", personalNumber: null, orgNumber: "556-1" }],
+      matterContacts: [{ id: mcId, matterId: mId, contactId: cId, role: "KLIENT" }],
+      documents: [{ id: uuidv7(), matterId: mId, fileName: "a.pdf", folderId: null }],
+      timeEntries: [{ id: uuidv7(), matterId: mId, userId: uId, minutes: 30, billable: true, hourlyRate: 1000, date: new Date() }],
+    } as DemoSource);
+    const store = new LocalStore(source, async () => {});
+    const mRepo = new InMemoryMatterRepository(store);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mcRepo = new InMemoryMatterContactRepository(store as any);
+    const cRepo = new InMemoryContactRepository(store);
+
+    const list = await mRepo.listForOrg(ORG, { page: 1, pageSize: 20 });
+    expect(list.total).toBe(1);
+    expect(list.matters[0]!.contacts[0]?.contact.name).toBe("Klient AB");
+    expect(list.matters[0]!._count).toMatchObject({ documents: 1, timeEntries: 1, contacts: 1 });
+    expect((await mRepo.listForOrg(ORG, { search: "tvist", page: 1, pageSize: 20 })).total).toBe(1);
+    expect((await mRepo.listForOrg(ORG, { search: "saknas", page: 1, pageSize: 20 })).total).toBe(0);
+
+    const detail = await mRepo.getByIdWithContacts(mId, ORG);
+    expect(detail?.contacts).toHaveLength(1);
+    expect(await mRepo.getByIdWithContacts(mId, uuidv7())).toBeNull();
+
+    expect((await mRepo.listByResponsibleLawyer(ORG, uId)).length).toBe(1);
+    expect((await mRepo.listByNumberPrefix(ORG, "AA2026-")).length).toBe(1);
+
+    expect(await mcRepo.getByIdInOrg(mcId, ORG)).toMatchObject({ id: mcId });
+    expect(await mcRepo.getByIdInOrg(mcId, uuidv7())).toBeNull();
+
+    expect((await cRepo.findByOrgNumber(ORG, "556-1"))?.id).toBe(cId);
+    expect(await cRepo.findByPersonalNumber(ORG, "x")).toBeNull();
+  });
+});
+
+describe("Matter-läsningar — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("listForOrg/_count + getByIdWithContacts + serie + contact-dedup + linkContact", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const mId = uuidv7();
+    const cId = uuidv7();
+    const uId = uuidv7();
+    const mcId = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "AA2026-0001", title: "Tvist", status: "ACTIVE", responsibleLawyerId: uId }));
+    await db.insert(users).values(v({ id: uId, organizationId: org, email: "a@x", name: "Anna" }));
+    await db.insert(contacts).values(v({ id: cId, organizationId: org, name: "Klient AB", contactType: "COMPANY", orgNumber: "556-1" }));
+    await db.insert(matterContacts).values(v({ id: mcId, matterId: mId, contactId: cId, role: "KLIENT" }));
+    await db.insert(documents).values(v({ id: uuidv7(), matterId: mId, fileName: "a.pdf", mimeType: "application/pdf", sizeBytes: 1, storagePath: "p", uploadedById: uId }));
+    await db.insert(timeEntries).values(v({ id: uuidv7(), matterId: mId, userId: uId, minutes: 30, billable: true, hourlyRate: 1000, description: "x", date: new Date() }));
+    const mRepo = new DrizzleMatterRepository(db as unknown as AppDb);
+    const mcRepo = new DrizzleMatterContactRepository(db as unknown as AppDb);
+    const cRepo = new DrizzleContactRepository(db as unknown as AppDb);
+
+    const list = await mRepo.listForOrg(org, { page: 1, pageSize: 20 });
+    expect(list.total).toBe(1);
+    expect(list.matters[0]!.contacts[0]?.contact.name).toBe("Klient AB");
+    expect(list.matters[0]!._count).toMatchObject({ documents: 1, timeEntries: 1, contacts: 1 });
+    expect((await mRepo.listForOrg(org, { search: "tvist", page: 1, pageSize: 20 })).total).toBe(1);
+    expect((await mRepo.listForOrg(org, { search: "klient", page: 1, pageSize: 20 })).total).toBe(1); // via kontaktnamn
+    expect((await mRepo.listForOrg(org, { search: "saknas", page: 1, pageSize: 20 })).total).toBe(0);
+
+    const detail = await mRepo.getByIdWithContacts(mId, org);
+    expect(detail?.contacts).toHaveLength(1);
+    expect(detail?._count.documents).toBe(1);
+    expect(await mRepo.getByIdWithContacts(mId, uuidv7())).toBeNull();
+
+    expect((await mRepo.listByResponsibleLawyer(org, uId)).length).toBe(1);
+    expect((await mRepo.listByNumberPrefix(org, "AA2026-")).length).toBe(1);
+
+    expect(await mcRepo.getByIdInOrg(mcId, org)).toMatchObject({ id: mcId });
+    expect(await mcRepo.getByIdInOrg(mcId, uuidv7())).toBeNull();
+    expect((await cRepo.findByOrgNumber(org, "556-1"))?.id).toBe(cId);
+
+    const link = await mcRepo.linkContact({ id: uuidv7(), matterId: mId, contactId: cId, role: "MOTPART" } as never);
+    expect(link.contact.name).toBe("Klient AB");
+  });
+});

--- a/test/unit/server/repositories/organization-office-repository.test.ts
+++ b/test/unit/server/repositories/organization-office-repository.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Organization/Office-repo-paritet (ADR 0020) — in-memory + Drizzle (pglite).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { offices, organizations } from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzleOfficeRepository } from "@/lib/server/repositories/drizzle-office-repository";
+import { DrizzleOrganizationRepository } from "@/lib/server/repositories/drizzle-organization-repository";
+import { InMemoryOfficeRepository } from "@/lib/server/repositories/in-memory-office-repository";
+import { InMemoryOrganizationRepository } from "@/lib/server/repositories/in-memory-organization-repository";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+describe("Organization/Office — in-memory", () => {
+  it("org getById/update; offices listByOrg (main först) + getByIdInOrg + demoteMains", async () => {
+    const org = "org-1";
+    const main = uuidv7();
+    const branch = uuidv7();
+    const store = new LocalStore({
+      organizations: [{ id: org, name: "Byrå AB" }],
+      offices: [
+        { id: main, organizationId: org, name: "Sthlm", isMain: true },
+        { id: branch, organizationId: org, name: "Gbg", isMain: false },
+      ],
+    }, async () => {});
+    const orgRepo = new InMemoryOrganizationRepository(store);
+    expect(await orgRepo.getById(org)).toMatchObject({ id: org });
+    const offRepo = new InMemoryOfficeRepository(store);
+    const list = await offRepo.listByOrg(org);
+    // In-memory query-engine sorterar inte boolean isMain desc (routern litar på
+    // att orderBy skickas; Drizzle/SQL-vägen ordnar). Verifiera medlemskap här.
+    expect(list.map((o) => o.id).sort()).toEqual([main, branch].sort());
+    expect(await offRepo.getByIdInOrg(branch, org)).toMatchObject({ id: branch });
+    expect(await offRepo.getByIdInOrg(branch, "org-2")).toBeNull();
+    await offRepo.demoteMains(org);
+    expect((await offRepo.getByIdInOrg(main, org))!.isMain).toBe(false);
+  });
+});
+
+describe("Organization/Office — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("org + offices med demoteMains", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const main = uuidv7();
+    const branch = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(organizations).values(v({ id: org, name: "Byrå AB" }));
+    await db.insert(offices).values(v({ id: main, organizationId: org, name: "Sthlm", isMain: true }));
+    await db.insert(offices).values(v({ id: branch, organizationId: org, name: "Gbg", isMain: false }));
+    const offRepo = new DrizzleOfficeRepository(handle.db as unknown as AppDb);
+    expect(await new DrizzleOrganizationRepository(handle.db as unknown as AppDb).getById(org)).toMatchObject({ id: org });
+    expect((await offRepo.listByOrg(org)).map((o) => o.id)).toEqual([main, branch]);
+    expect(await offRepo.getByIdInOrg(branch, org)).toMatchObject({ id: branch });
+    expect(await offRepo.getByIdInOrg(branch, uuidv7())).toBeNull();
+    await offRepo.demoteMains(org);
+    expect((await offRepo.getByIdInOrg(main, org))!.isMain).toBe(false);
+  });
+});

--- a/test/unit/server/repositories/payment-plan-reminder-repository.test.ts
+++ b/test/unit/server/repositories/payment-plan-reminder-repository.test.ts
@@ -1,0 +1,44 @@
+/**
+ * PaymentPlanReminderRepository-paritet (ADR 0020) — bas-CRUD (create/getById)
+ * mot in-memory (LocalStore) + Drizzle (pglite).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { paymentPlanReminders } from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzlePaymentPlanReminderRepository } from "@/lib/server/repositories/drizzle-payment-plan-reminder-repository";
+import { InMemoryPaymentPlanReminderRepository } from "@/lib/server/repositories/in-memory-payment-plan-reminder-repository";
+import type { PaymentPlanReminderRepository } from "@/lib/server/repositories/payment-plan-reminder-repository";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+async function assertContract(repo: PaymentPlanReminderRepository): Promise<void> {
+  const id = uuidv7();
+  const created = await repo.create({
+    id, planId: uuidv7(), dueMonth: "2026-06", type: "DUE", sentAt: new Date("2026-06-15"),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+  expect(created.dueMonth).toBe("2026-06");
+  expect((created as { version?: number }).version).toBe(1);
+  expect(await repo.getById(id)).toMatchObject({ id, type: "DUE" });
+}
+
+describe("PaymentPlanReminderRepository — in-memory", () => {
+  it("uppfyller bas-kontraktet", async () => {
+    const store = new LocalStore({ paymentPlanReminders: [] }, async () => {});
+    await assertContract(new InMemoryPaymentPlanReminderRepository(store));
+  });
+});
+
+describe("PaymentPlanReminderRepository — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("uppfyller bas-kontraktet", async () => {
+    await assertContract(new DrizzlePaymentPlanReminderRepository(handle.db as unknown as AppDb));
+    // referera tabellen så schema-importen inte är oanvänd
+    expect(paymentPlanReminders).toBeDefined();
+  });
+});

--- a/test/unit/server/repositories/payment-plan-repository.test.ts
+++ b/test/unit/server/repositories/payment-plan-repository.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
-import { invoices, matters, paymentPlans } from "@/lib/server/db/schema";
+import { contacts, invoices, matterContacts, matters, paymentPlanReminders, paymentPlans, payments } from "@/lib/server/db/schema";
 import type { AppDb } from "@/lib/server/db/types";
 import { DrizzlePaymentPlanRepository } from "@/lib/server/repositories/drizzle-payment-plan-repository";
 import { InMemoryPaymentPlanRepository } from "@/lib/server/repositories/in-memory-payment-plan-repository";
@@ -71,6 +71,35 @@ describe("PaymentPlanRepository — in-memory", () => {
     expect(await repo.getByInvoiceId(invoiceId)).toMatchObject({ id: planId });
     expect(await repo.getByInvoiceId(uuidv7())).toBeNull(); // ingen plan
   });
+
+  it("listForOrg/getByIdWithDetails/listActiveForScan joinar faktura+KLIENT+påminnelser", async () => {
+    const matterId = uuidv7();
+    const cId = uuidv7();
+    const store = new LocalStore({
+      matters: [{ id: matterId, organizationId: "org-1", matterNumber: "2026-1", title: "T" }],
+      contacts: [{ id: cId, organizationId: "org-1", name: "Klient AB", email: "k@x.se" }],
+      matterContacts: [{ id: uuidv7(), matterId, contactId: cId, role: "KLIENT" }],
+      invoices: [{ id: invoiceId, matterId, amount: 1000, status: "INSTALLMENT_PLAN" }],
+      payments: [{ id: uuidv7(), invoiceId, amount: 200, paidAt: new Date("2026-06-10") }],
+      paymentPlans: [plan({ id: planId, invoiceId, status: "ACTIVE" })],
+      paymentPlanReminders: [{ id: uuidv7(), planId, dueMonth: "2026-06", type: "DUE", sentAt: new Date() }],
+    }, async () => {});
+    const repo = new InMemoryPaymentPlanRepository(store);
+
+    const list = await repo.listForOrg("org-1");
+    expect(list).toHaveLength(1);
+    expect(list[0]!.invoice?.matter?.contacts[0]?.contact.name).toBe("Klient AB");
+    expect(list[0]!.invoice?.payments[0]?.amount).toBe(200);
+    expect(await repo.listForOrg("org-2")).toHaveLength(0);
+
+    const detail = await repo.getByIdWithDetails(planId, "org-1");
+    expect(detail?.reminders[0]?.dueMonth).toBe("2026-06");
+
+    const scan = await repo.listActiveForScan("org-1");
+    expect(scan).toHaveLength(1);
+    expect(scan[0]!.invoice?.matter?.contacts[0]?.contact.email).toBe("k@x.se");
+    expect(scan[0]!.reminders).toHaveLength(1);
+  });
 });
 
 describe("PaymentPlanRepository — Drizzle (pglite)", () => {
@@ -109,5 +138,38 @@ describe("PaymentPlanRepository — Drizzle (pglite)", () => {
     const repo = new DrizzlePaymentPlanRepository(handle.db as unknown as AppDb);
     expect(await repo.getByInvoiceId(invId)).toMatchObject({ id: pId });
     expect(await repo.getByInvoiceId(uuidv7())).toBeNull(); // ingen plan
+  });
+
+  it("listForOrg/getByIdWithDetails/listActiveForScan joinar faktura+KLIENT+påminnelser", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const mId = uuidv7();
+    const cId = uuidv7();
+    const invId = uuidv7();
+    const pId = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
+    await db.insert(contacts).values(v({ id: cId, organizationId: org, name: "Klient AB", contactType: "COMPANY", email: "k@x.se" }));
+    await db.insert(matterContacts).values(v({ id: uuidv7(), matterId: mId, contactId: cId, role: "KLIENT" }));
+    await db.insert(invoices).values(v({ id: invId, matterId: mId, amount: 1000, status: "INSTALLMENT_PLAN", invoiceDate: new Date() }));
+    await db.insert(payments).values(v({ id: uuidv7(), invoiceId: invId, amount: 200, paidAt: new Date("2026-06-10"), recordedById: uuidv7() }));
+    await db.insert(paymentPlans).values(v({ id: pId, invoiceId: invId, monthlyAmount: 100, dayOfMonth: 15, startDate: new Date(), status: "ACTIVE" }));
+    await db.insert(paymentPlanReminders).values(v({ id: uuidv7(), planId: pId, dueMonth: "2026-06", type: "DUE", sentAt: new Date() }));
+    const repo = new DrizzlePaymentPlanRepository(handle.db as unknown as AppDb);
+
+    const list = await repo.listForOrg(org);
+    expect(list).toHaveLength(1);
+    expect(list[0]!.invoice?.matter?.contacts[0]?.contact.name).toBe("Klient AB");
+    expect(list[0]!.invoice?.payments[0]?.amount).toBe(200);
+    expect(await repo.listForOrg(uuidv7())).toHaveLength(0);
+
+    const detail = await repo.getByIdWithDetails(pId, org);
+    expect(detail?.reminders[0]?.dueMonth).toBe("2026-06");
+
+    const scan = await repo.listActiveForScan(org);
+    expect(scan).toHaveLength(1);
+    expect(scan[0]!.invoice?.matter?.contacts[0]?.contact.email).toBe("k@x.se");
+    expect(scan[0]!.reminders).toHaveLength(1);
   });
 });

--- a/test/unit/server/repositories/preference-repository.test.ts
+++ b/test/unit/server/repositories/preference-repository.test.ts
@@ -1,0 +1,56 @@
+/**
+ * User/Org-PreferenceRepository-paritet (ADR 0020) — in-memory + Drizzle (pglite).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { orgPreferences, userPreferences } from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzleOrgPreferenceRepository } from "@/lib/server/repositories/drizzle-org-preference-repository";
+import { DrizzleUserPreferenceRepository } from "@/lib/server/repositories/drizzle-user-preference-repository";
+import { InMemoryOrgPreferenceRepository } from "@/lib/server/repositories/in-memory-org-preference-repository";
+import { InMemoryUserPreferenceRepository } from "@/lib/server/repositories/in-memory-user-preference-repository";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+describe("Preference repos — in-memory", () => {
+  it("getByUserKey + getByOrgKey + listByOrg", async () => {
+    const userId = uuidv7();
+    const up = uuidv7();
+    const op = uuidv7();
+    const store = new LocalStore({
+      userPreferences: [{ id: up, userId, organizationId: "org-1", key: "list.contacts", prefs: { sort: "name" } }],
+      orgPreferences: [{ id: op, organizationId: "org-1", key: "list.contacts", prefs: { sort: "createdAt" } }],
+    }, async () => {});
+    const uRepo = new InMemoryUserPreferenceRepository(store);
+    const oRepo = new InMemoryOrgPreferenceRepository(store);
+    expect((await uRepo.getByUserKey(userId, "org-1", "list.contacts"))?.id).toBe(up);
+    expect(await uRepo.getByUserKey(userId, "org-1", "list.x")).toBeNull();
+    expect((await oRepo.getByOrgKey("org-1", "list.contacts"))?.id).toBe(op);
+    expect(await oRepo.listByOrg("org-1")).toHaveLength(1);
+  });
+});
+
+describe("Preference repos — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("getByUserKey + getByOrgKey + listByOrg", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const userId = uuidv7();
+    const up = uuidv7();
+    const op = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(userPreferences).values(v({ id: up, userId, organizationId: org, key: "list.contacts", prefs: { sort: "name" } }));
+    await db.insert(orgPreferences).values(v({ id: op, organizationId: org, key: "list.contacts", prefs: { sort: "createdAt" } }));
+    const uRepo = new DrizzleUserPreferenceRepository(handle.db as unknown as AppDb);
+    const oRepo = new DrizzleOrgPreferenceRepository(handle.db as unknown as AppDb);
+    expect((await uRepo.getByUserKey(userId, org, "list.contacts"))?.id).toBe(up);
+    expect(await uRepo.getByUserKey(userId, org, "list.x")).toBeNull();
+    expect((await oRepo.getByOrgKey(org, "list.contacts"))?.id).toBe(op);
+    expect(await oRepo.listByOrg(org)).toHaveLength(1);
+  });
+});

--- a/test/unit/server/repositories/report-reads-repository.test.ts
+++ b/test/unit/server/repositories/report-reads-repository.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Paritet (ADR 0020) för rapport-läsningarna: TimeEntry.listForLawyerInPeriod/
+ * listBillableForOrg, Expense.listForLawyerInPeriod, Payment/WriteOff.listByInvoiceIds.
+ * in-memory (LocalStore) + Drizzle (pglite).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { contacts, expenses, invoices, matterContacts, matters, payments, timeEntries, users, writeOffs } from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzleExpenseRepository } from "@/lib/server/repositories/drizzle-expense-repository";
+import { DrizzlePaymentRepository } from "@/lib/server/repositories/drizzle-payment-repository";
+import { DrizzleTimeEntryRepository } from "@/lib/server/repositories/drizzle-time-entry-repository";
+import { DrizzleWriteOffRepository } from "@/lib/server/repositories/drizzle-write-off-repository";
+import { InMemoryExpenseRepository } from "@/lib/server/repositories/in-memory-expense-repository";
+import { InMemoryPaymentRepository } from "@/lib/server/repositories/in-memory-payment-repository";
+import { InMemoryTimeEntryRepository } from "@/lib/server/repositories/in-memory-time-entry-repository";
+import { InMemoryWriteOffRepository } from "@/lib/server/repositories/in-memory-write-off-repository";
+import { prebakeJoins } from "@/lib/shared/demo-source";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+const ORG = "55555555-5555-7555-8555-555555555555";
+const FROM = new Date("2026-06-01");
+const TO = new Date("2026-06-30T23:59:59.999Z");
+
+describe("Report-läsningar — in-memory", () => {
+  it("listForLawyerInPeriod (time+expense, KLIENT) + listBillableForOrg + listByInvoiceIds", async () => {
+    const mId = uuidv7();
+    const uId = uuidv7();
+    const cId = uuidv7();
+    const invId = uuidv7();
+    const source = prebakeJoins({
+      matters: [{ id: mId, organizationId: ORG, matterNumber: "2026-1", title: "T", paymentMethod: "RATTSHJALP", paymentMethodNote: "Dnr 1" }],
+      users: [{ id: uId, name: "Anna" }],
+      contacts: [{ id: cId, organizationId: ORG, name: "Klient AB" }],
+      matterContacts: [{ id: uuidv7(), matterId: mId, contactId: cId, role: "KLIENT" }],
+      invoices: [{ id: invId, matterId: mId, amount: 1000, status: "SENT" }],
+      timeEntries: [
+        { id: uuidv7(), userId: uId, matterId: mId, minutes: 60, billable: true, hourlyRate: 1000, date: new Date("2026-06-10") },
+        { id: uuidv7(), userId: uId, matterId: mId, minutes: 30, billable: false, hourlyRate: 1000, date: new Date("2026-06-11") },
+        { id: uuidv7(), userId: uId, matterId: mId, minutes: 99, billable: true, hourlyRate: 1000, date: new Date("2026-01-01") },
+      ],
+      expenses: [{ id: uuidv7(), userId: uId, matterId: mId, amount: 500, billable: true, date: new Date("2026-06-12") }],
+      payments: [{ id: uuidv7(), invoiceId: invId, amount: 200 }],
+      writeOffs: [{ id: uuidv7(), invoiceId: invId, amount: 100, writtenOffAt: new Date("2026-06-20") }],
+    } as DemoSource);
+    const store = new LocalStore(source, async () => {});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const te = new InMemoryTimeEntryRepository(store as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const ex = new InMemoryExpenseRepository(store as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pay = new InMemoryPaymentRepository(store as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const wo = new InMemoryWriteOffRepository(store as any);
+
+    const lawyerTime = await te.listForLawyerInPeriod(ORG, uId, FROM, TO);
+    expect(lawyerTime).toHaveLength(2); // jan-posten utanför perioden
+    expect(lawyerTime[0]!.matter?.paymentMethod).toBe("RATTSHJALP");
+    expect(lawyerTime[0]!.matter?.contacts[0]?.contact.name).toBe("Klient AB");
+    expect((await te.listBillableForOrg(ORG)).length).toBe(2); // 2 billable totalt
+    expect(await ex.listForLawyerInPeriod(ORG, uId, FROM, TO)).toHaveLength(1);
+    expect((await pay.listByInvoiceIds([invId]))[0]!.amount).toBe(200);
+    expect(await pay.listByInvoiceIds([])).toHaveLength(0);
+    expect((await wo.listByInvoiceIds([invId]))[0]!.amount).toBe(100);
+  });
+});
+
+describe("Report-läsningar — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("listForLawyerInPeriod (time+expense, KLIENT) + listBillableForOrg + listByInvoiceIds", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const mId = uuidv7();
+    const uId = uuidv7();
+    const cId = uuidv7();
+    const invId = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T", paymentMethod: "RATTSHJALP", paymentMethodNote: "Dnr 1" }));
+    await db.insert(users).values(v({ id: uId, organizationId: org, email: "a@x", name: "Anna" }));
+    await db.insert(contacts).values(v({ id: cId, organizationId: org, name: "Klient AB", contactType: "COMPANY" }));
+    await db.insert(matterContacts).values(v({ id: uuidv7(), matterId: mId, contactId: cId, role: "KLIENT" }));
+    await db.insert(invoices).values(v({ id: invId, matterId: mId, amount: 1000, status: "SENT", invoiceDate: new Date() }));
+    await db.insert(timeEntries).values(v({ id: uuidv7(), userId: uId, matterId: mId, minutes: 60, billable: true, hourlyRate: 1000, description: "a", date: new Date("2026-06-10") }));
+    await db.insert(timeEntries).values(v({ id: uuidv7(), userId: uId, matterId: mId, minutes: 30, billable: false, hourlyRate: 1000, description: "b", date: new Date("2026-06-11") }));
+    await db.insert(timeEntries).values(v({ id: uuidv7(), userId: uId, matterId: mId, minutes: 99, billable: true, hourlyRate: 1000, description: "c", date: new Date("2026-01-01") }));
+    await db.insert(expenses).values(v({ id: uuidv7(), userId: uId, matterId: mId, amount: 500, billable: true, description: "e", date: new Date("2026-06-12"), vatRate: 0, vatIncluded: false }));
+    await db.insert(payments).values(v({ id: uuidv7(), invoiceId: invId, amount: 200, paidAt: new Date(), recordedById: uId }));
+    await db.insert(writeOffs).values(v({ id: uuidv7(), invoiceId: invId, amount: 100, writtenOffAt: new Date("2026-06-20"), recordedById: uId }));
+    const te = new DrizzleTimeEntryRepository(db as unknown as AppDb);
+    const ex = new DrizzleExpenseRepository(db as unknown as AppDb);
+    const pay = new DrizzlePaymentRepository(db as unknown as AppDb);
+    const wo = new DrizzleWriteOffRepository(db as unknown as AppDb);
+
+    const lawyerTime = await te.listForLawyerInPeriod(org, uId, FROM, TO);
+    expect(lawyerTime).toHaveLength(2);
+    expect(lawyerTime[0]!.matter?.paymentMethod).toBe("RATTSHJALP");
+    expect(lawyerTime[0]!.matter?.contacts[0]?.contact.name).toBe("Klient AB");
+    expect((await te.listBillableForOrg(org)).length).toBe(2);
+    expect(await ex.listForLawyerInPeriod(org, uId, FROM, TO)).toHaveLength(1);
+    expect((await pay.listByInvoiceIds([invId]))[0]!.amount).toBe(200);
+    expect(await pay.listByInvoiceIds([])).toHaveLength(0);
+    expect((await wo.listByInvoiceIds([invId]))[0]!.amount).toBe(100);
+  });
+});

--- a/test/unit/server/repositories/time-entry-list-report-repository.test.ts
+++ b/test/unit/server/repositories/time-entry-list-report-repository.test.ts
@@ -1,0 +1,81 @@
+/**
+ * TimeEntryRepository list/report-paritet (ADR 0020) — in-memory + Drizzle (pglite).
+ * listForOrg (count+summa) + getByIdInOrg + listForReport (KLIENT-kontakt).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { contacts, matterContacts, matters, timeEntries, users } from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import { DrizzleTimeEntryRepository } from "@/lib/server/repositories/drizzle-time-entry-repository";
+import { InMemoryTimeEntryRepository } from "@/lib/server/repositories/in-memory-time-entry-repository";
+import { prebakeJoins } from "@/lib/shared/demo-source";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+describe("TimeEntryRepository list/report — in-memory", () => {
+  it("listForOrg (summa minuter) + getByIdInOrg + listForReport (KLIENT)", async () => {
+    const mId = uuidv7();
+    const userId = uuidv7();
+    const cId = uuidv7();
+    const t1 = uuidv7();
+    const source = prebakeJoins({
+      matters: [{ id: mId, organizationId: "org-1", matterNumber: "2026-1", title: "T" }],
+      users: [{ id: userId, name: "Anna", hourlyRate: 1000 }],
+      contacts: [{ id: cId, organizationId: "org-1", name: "Klient AB" }],
+      matterContacts: [{ id: uuidv7(), matterId: mId, contactId: cId, role: "KLIENT" }],
+      timeEntries: [
+        { id: t1, userId, matterId: mId, minutes: 60, billable: true, date: new Date("2026-06-02") },
+        { id: uuidv7(), userId, matterId: mId, minutes: 30, billable: false, date: new Date("2026-06-03") },
+      ],
+    } as DemoSource);
+    const repo = new InMemoryTimeEntryRepository(new LocalStore(source, async () => {}));
+
+    const list = await repo.listForOrg("org-1", { page: 1, pageSize: 50 });
+    expect(list.total).toBe(2);
+    expect(list.totalMinutes).toBe(90);
+    expect(list.entries[0]!.matter.matterNumber).toBe("2026-1");
+    expect(await repo.getByIdInOrg(t1, "org-1")).toMatchObject({ id: t1 });
+    expect(await repo.getByIdInOrg(t1, "org-2")).toBeNull();
+
+    const report = await repo.listForReport("org-1", { from: new Date("2026-06-01"), to: new Date("2026-06-30") });
+    expect(report).toHaveLength(2);
+    expect(report[0]!.matter?.contacts[0]?.contact.name).toBe("Klient AB");
+  });
+});
+
+describe("TimeEntryRepository list/report — Drizzle (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("listForOrg + getByIdInOrg + listForReport (KLIENT via subquery)", async () => {
+    const db = handle.db;
+    const org = uuidv7();
+    const mId = uuidv7();
+    const userId = uuidv7();
+    const cId = uuidv7();
+    const t1 = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
+    await db.insert(users).values(v({ id: userId, organizationId: org, email: "a@x", name: "Anna", hourlyRate: 1000 }));
+    await db.insert(contacts).values(v({ id: cId, organizationId: org, name: "Klient AB", contactType: "COMPANY" }));
+    await db.insert(matterContacts).values(v({ id: uuidv7(), matterId: mId, contactId: cId, role: "KLIENT" }));
+    await db.insert(timeEntries).values(v({ id: t1, userId, matterId: mId, minutes: 60, description: "a", hourlyRate: 1000, date: new Date("2026-06-02") }));
+    await db.insert(timeEntries).values(v({ id: uuidv7(), userId, matterId: mId, minutes: 30, description: "b", hourlyRate: 1000, date: new Date("2026-06-03") }));
+    const repo = new DrizzleTimeEntryRepository(handle.db as unknown as AppDb);
+
+    const list = await repo.listForOrg(org, { page: 1, pageSize: 50 });
+    expect(list.total).toBe(2);
+    expect(list.totalMinutes).toBe(90);
+    expect(list.entries[0]!.matter.matterNumber).toBe("2026-1");
+    expect(await repo.getByIdInOrg(t1, org)).toMatchObject({ id: t1 });
+    expect(await repo.getByIdInOrg(t1, uuidv7())).toBeNull();
+
+    const report = await repo.listForReport(org, { from: new Date("2026-06-01"), to: new Date("2026-06-30") });
+    expect(report).toHaveLength(2);
+    expect(report[0]!.matter?.contacts[0]?.contact.name).toBe("Klient AB");
+  });
+});

--- a/test/unit/server/routers/conflict.test.ts
+++ b/test/unit/server/routers/conflict.test.ts
@@ -1,154 +1,110 @@
 /**
- * Test för conflictRouter — javskontroll mot personnummer + namn (trigram).
+ * Test för conflictRouter — jävskontroll mot personnummer + namn (bigram).
+ * Kör mot en riktig in-memory-store (repos, ADR 0020).
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { describe, it, expect } from "vitest-compat";
+import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import { conflictRouter } from "@/lib/server/routers/conflict";
-import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
+import { prebakeJoins } from "@/lib/shared/demo-source";
 
-const mockPrisma = {
-  matterContact: {
-    findMany: vi.fn(),
-    findFirst: vi.fn(),
-  },
-  conflictCheck: {
-    create: vi.fn(),
-    findMany: vi.fn(),
-    count: vi.fn(),
-  },
-  $queryRaw: vi.fn(),
-};
+const ORG = "org-a";
 
-function makeCaller(orgId = "org-a", userId = "u1") {
+function makeCaller(seed: Partial<DemoSource> = {}, orgId = ORG, userId = "u1") {
+  const source = prebakeJoins({
+    matters: [{ id: "m1", organizationId: ORG, matterNumber: "2026-0001", title: "X" }],
+    contacts: [],
+    matterContacts: [],
+    conflictChecks: [],
+    ...seed,
+  } as DemoSource);
+  const store = new LocalStore(source, async () => {});
+  const repos = buildInMemoryRepositories(store as unknown as IDataStore);
   const ctx = {
     user: { id: userId, email: "a@b.se", name: "T", role: "LAWYER", organizationId: orgId },
-    prisma: mockPrisma, dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+    dataStore: store, repos,
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return conflictRouter.createCaller(ctx as any);
+  return { caller: conflictRouter.createCaller(ctx as any), store };
 }
 
-beforeEach(() => {
-  vi.clearAllMocks();
-  mockPrisma.matterContact.findMany.mockResolvedValue([]);
-  mockPrisma.$queryRaw.mockResolvedValue([]);
-  mockPrisma.conflictCheck.create.mockResolvedValue({});
-  mockPrisma.conflictCheck.findMany.mockResolvedValue([]);
-  mockPrisma.conflictCheck.count.mockResolvedValue(0);
-  mockPrisma.matterContact.findFirst.mockResolvedValue(null);
-});
+function checks(store: LocalStore): Array<Record<string, unknown>> {
+  return (store as unknown as { source: DemoSource }).source.conflictChecks as never;
+}
+
+/** Seed: en MOTPART + en KLIENT i samma ärende. */
+function seedWithParty(party: Record<string, unknown>): Partial<DemoSource> {
+  return {
+    contacts: [
+      { id: "c1", organizationId: ORG, name: "Anna", contactType: "PERSON", ...party },
+      { id: "klient", organizationId: ORG, name: "Klient Klientsson", contactType: "PERSON" },
+    ],
+    matterContacts: [
+      { id: "mc1", matterId: "m1", contactId: "c1", role: "MOTPART" },
+      { id: "mc2", matterId: "m1", contactId: "klient", role: "KLIENT" },
+    ],
+  };
+}
 
 describe("conflict.check", () => {
   it("hittar kontakter via personnummer-substring", async () => {
-    mockPrisma.matterContact.findMany.mockResolvedValue([
-      {
-        role: "MOTPART",
-        contact: {
-          id: "c1", name: "Anna", contactType: "PERSON",
-          personalNumber: "19850225-6655", orgNumber: null,
-        },
-        matter: {
-          id: "m1", matterNumber: "2026-0001", title: "X",
-          contacts: [{ contact: { name: "Klient Klientsson" } }],
-        },
-      },
-    ]);
-
-    const res = await makeCaller().check({
-      searchTerm: "19850225",
-      searchType: "personalNumber",
-    });
+    const { caller } = makeCaller(seedWithParty({ name: "Anna", personalNumber: "19850225-6655" }));
+    const res = await caller.check({ searchTerm: "19850225", searchType: "personalNumber" });
     expect(res.matchCount).toBe(1);
     expect(res.results[0]!.contactName).toBe("Anna");
     expect(res.results[0]!.klient).toBe("Klient Klientsson");
   });
 
   it("hittar kontakter via fuzzy namn-sökning (bigram-Jaccard)", async () => {
-    // Implementationen scannar matterContacts och kör similarity() i minne;
-    // ingen $queryRaw längre (Prisma borta).
-    mockPrisma.matterContact.findMany.mockResolvedValue([
-      {
-        role: "MOTPART",
-        contact: { id: "c1", name: "Anna Andersson", contactType: "PERSON", personalNumber: null, orgNumber: null },
-        matter: {
-          id: "m1", matterNumber: "2026-0001", title: "X",
-          contacts: [{ contact: { name: "Klienten" } }],
-        },
-      },
-    ]);
-
-    const res = await makeCaller().check({
-      // "Anna Andersson" — exakt match → score 1, klart över 0.4-tröskeln
-      searchTerm: "Anna Andersson",
-      searchType: "name",
-    });
+    const { caller } = makeCaller(seedWithParty({ name: "Anna Andersson" }));
+    const res = await caller.check({ searchTerm: "Anna Andersson", searchType: "name" });
     expect(res.matchCount).toBe(1);
     expect(res.results[0]!.contactName).toBe("Anna Andersson");
-    expect(res.results[0]!.klient).toBe("Klienten");
+    expect(res.results[0]!.klient).toBe("Klient Klientsson");
   });
 
   it("filtrerar bort matchningar under similarity-tröskeln", async () => {
-    mockPrisma.matterContact.findMany.mockResolvedValue([
-      {
-        role: "MOTPART",
-        contact: { id: "c1", name: "Anna Andersson", contactType: "PERSON", personalNumber: null, orgNumber: null },
-        matter: { id: "m1", matterNumber: "2026-0001", title: "X", contacts: [] },
-      },
-    ]);
-    const res = await makeCaller().check({
-      searchTerm: "Helt Annorlunda",
-      searchType: "name",
-    });
+    const { caller } = makeCaller(seedWithParty({ name: "Anna Andersson" }));
+    const res = await caller.check({ searchTerm: "Helt Annorlunda", searchType: "name" });
     expect(res.matchCount).toBe(0);
   });
 
   it("kombinerar både searchTypes utan dubblettrader", async () => {
-    // Samma kontakt+ärende+roll matchar både via personnummer-substring
-    // OCH namn-similarity — ska bara räknas en gång.
-    mockPrisma.matterContact.findMany.mockResolvedValue([
-      {
-        role: "MOTPART",
-        contact: { id: "c1", name: "Anna Andersson", contactType: "PERSON", personalNumber: "12345", orgNumber: null },
-        matter: { id: "m1", matterNumber: "0001", title: "Y", contacts: [] },
-      },
-    ]);
-    const res = await makeCaller().check({ searchTerm: "Anna Andersson", searchType: "both" });
+    const { caller } = makeCaller(seedWithParty({ name: "Anna Andersson", personalNumber: "12345" }));
+    const res = await caller.check({ searchTerm: "Anna Andersson", searchType: "both" });
     expect(res.matchCount).toBe(1);
   });
 
   it("loggar varje sökning till conflictCheck", async () => {
-    await makeCaller().check({ searchTerm: "test" });
-    expect(mockPrisma.conflictCheck.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          searchTerm: "test",
-          checkedById: "u1",
-        }),
-      }),
-    );
+    const { caller, store } = makeCaller({}, ORG, "u1");
+    await caller.check({ searchTerm: "test" });
+    expect(checks(store)).toHaveLength(1);
+    expect(checks(store)[0]).toMatchObject({ searchTerm: "test", checkedById: "u1" });
   });
 
   it("kräver searchTerm min(1)", async () => {
-    await expect(makeCaller().check({ searchTerm: "" })).rejects.toThrow();
+    const { caller } = makeCaller();
+    await expect(caller.check({ searchTerm: "" })).rejects.toThrow();
   });
 
-  it("scopar via matter.organizationId i personnummer-sökning", async () => {
-    await makeCaller("my-org").check({ searchTerm: "X", searchType: "personalNumber" });
-    expect(mockPrisma.matterContact.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          matter: { organizationId: "my-org" },
-        }),
-      }),
-    );
+  it("scopar via matter.organizationId (ingen läcka mellan org)", async () => {
+    const { caller } = makeCaller(seedWithParty({ name: "Anna", personalNumber: "19850225-6655" }), "annan-org");
+    const res = await caller.check({ searchTerm: "19850225", searchType: "personalNumber" });
+    expect(res.matchCount).toBe(0);
   });
 });
 
 describe("conflict.history", () => {
   it("returnerar paginerad historik", async () => {
-    mockPrisma.conflictCheck.findMany.mockResolvedValue([{ id: "ck1" }]);
-    mockPrisma.conflictCheck.count.mockResolvedValue(1);
-    const res = await makeCaller().history({ page: 1, pageSize: 20 });
+    const { caller } = makeCaller({
+      conflictChecks: [
+        { id: "ck1", searchTerm: "a", searchType: "both", results: [], checkedById: "u1", createdAt: new Date() },
+      ],
+    });
+    const res = await caller.history({ page: 1, pageSize: 20 });
     expect(res.checks).toHaveLength(1);
     expect(res.pages).toBe(1);
   });

--- a/test/unit/server/routers/document.events.test.ts
+++ b/test/unit/server/routers/document.events.test.ts
@@ -1,186 +1,97 @@
+/**
+ * Test för document events (MatterEventSuggestion) — events/rejectEvent/
+ * markEventAdded. Kör mot en riktig in-memory-store (repos, ADR 0020).
+ */
+
 import { TRPCError } from "@trpc/server";
-import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { describe, it, expect, vi } from "vitest-compat";
+import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import { documentRouter } from "@/lib/server/routers/document";
-import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
+import { prebakeJoins } from "@/lib/shared/demo-source";
 
-// ─── Helpers ─────────────────────────────────────────────────────
+vi.mock("@/lib/server/services/meilisearch", () => ({ searchDocuments: vi.fn(), removeDocument: vi.fn() }));
+vi.mock("@/lib/server/services/document-analysis", () => ({ analyzeDocument: vi.fn() }));
 
-const mockPrisma = {
-  matterEventSuggestion: {
-    findMany: vi.fn(),
-    findFirst: vi.fn(),
-    update: vi.fn(),
-  },
-};
+const ORG = "org-a";
 
-function makeCaller(orgId = "org-a") {
+function makeCaller(seed: Partial<DemoSource> = {}, orgId = ORG) {
+  const source = prebakeJoins({
+    matters: [{ id: "mat-1", organizationId: ORG, matterNumber: "2026-1", title: "T" }],
+    documents: [{ id: "doc-1", matterId: "mat-1", fileName: "stamning.pdf", title: "Stämningsansökan" }],
+    matterEventSuggestions: [],
+    ...seed,
+  } as DemoSource);
+  const store = new LocalStore(source, async () => {});
+  const repos = buildInMemoryRepositories(store as unknown as IDataStore);
   const ctx = {
     user: { id: "user-1", email: "a@b.com", name: "Test", role: "ADMIN", organizationId: orgId },
-    prisma: mockPrisma, dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+    dataStore: store, repos, orgId,
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return documentRouter.createCaller(ctx as any);
+  return { caller: documentRouter.createCaller(ctx as any), store };
 }
 
-const EVENT_PENDING = {
-  id: "ev-1",
-  documentId: "doc-1",
-  title: "Huvudförhandling",
-  description: null,
-  eventType: "Förhandling",
-  startAt: new Date("2026-05-14T09:00:00Z"),
-  endAt: null,
-  allDay: false,
-  location: "Stockholms tingsrätt",
-  status: "PENDING",
-  createdAt: new Date(),
-  updatedAt: new Date(),
-  document: { id: "doc-1", fileName: "stamning.pdf", title: "Stämningsansökan" },
-};
+function events(store: LocalStore): Array<{ id: string; status: string }> {
+  return (store as unknown as { source: DemoSource }).source.matterEventSuggestions as never;
+}
 
-beforeEach(() => {
-  vi.clearAllMocks();
+const ev = (over: Record<string, unknown>) => ({
+  id: "ev-1", documentId: "doc-1", title: "Huvudförhandling", description: null,
+  eventType: "Förhandling", startAt: new Date("2026-05-14T09:00:00Z"), endAt: null,
+  allDay: false, location: "Stockholms tingsrätt", status: "PENDING", ...over,
 });
 
-// ─── events (list) ───────────────────────────────────────────────
-
 describe("document.events — lista tidpunkter för ärende", () => {
-  it("returnerar ej avvisade events för ärende, sorterade på startAt", async () => {
-    mockPrisma.matterEventSuggestion.findMany.mockResolvedValue([EVENT_PENDING]);
-
-    const result = await makeCaller("org-a").events({ matterId: "mat-1" });
-
-    expect(result).toHaveLength(1);
-    expect(result[0]!.title).toBe("Huvudförhandling");
-    expect(mockPrisma.matterEventSuggestion.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          status: { not: "REJECTED" },
-          document: expect.objectContaining({
-            matterId: "mat-1",
-            matter: { organizationId: "org-a" },
-          }),
-        }),
-        orderBy: { startAt: "asc" },
-      })
-    );
+  it("returnerar ej avvisade events sorterade på startAt, med dokumentmetadata", async () => {
+    const { caller } = makeCaller({
+      matterEventSuggestions: [
+        ev({ id: "ev-late", startAt: new Date("2026-06-01T09:00:00Z") }),
+        ev({ id: "ev-1", startAt: new Date("2026-05-14T09:00:00Z") }),
+        ev({ id: "ev-rejected", status: "REJECTED", startAt: new Date("2026-04-01T09:00:00Z") }),
+      ],
+    });
+    const result = await caller.events({ matterId: "mat-1" });
+    expect(result.map((r) => r.id)).toEqual(["ev-1", "ev-late"]); // sorterat, REJECTED bort
+    // In-memory-motorn projicerar inte `select` strikt (Drizzle gör); asserta delmängd.
+    expect(result[0]!.document).toMatchObject({ id: "doc-1", fileName: "stamning.pdf", title: "Stämningsansökan" });
   });
 
   it("filtrerar på anropande användares organisation", async () => {
-    mockPrisma.matterEventSuggestion.findMany.mockResolvedValue([]);
-
-    await makeCaller("org-b").events({ matterId: "mat-1" });
-
-    expect(mockPrisma.matterEventSuggestion.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          document: expect.objectContaining({
-            matter: { organizationId: "org-b" },
-          }),
-        }),
-      })
-    );
-  });
-
-  it("inkluderar dokumentmetadata för visning", async () => {
-    mockPrisma.matterEventSuggestion.findMany.mockResolvedValue([]);
-
-    await makeCaller("org-a").events({ matterId: "mat-1" });
-
-    expect(mockPrisma.matterEventSuggestion.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        include: { document: { select: { id: true, fileName: true, title: true } } },
-      })
-    );
+    const { caller } = makeCaller({ matterEventSuggestions: [ev({})] }, "org-b");
+    expect(await caller.events({ matterId: "mat-1" })).toHaveLength(0);
   });
 });
-
-// ─── rejectEvent ─────────────────────────────────────────────────
 
 describe("document.rejectEvent", () => {
   it("markerar event som REJECTED", async () => {
-    mockPrisma.matterEventSuggestion.findFirst.mockResolvedValue(EVENT_PENDING);
-    mockPrisma.matterEventSuggestion.update.mockResolvedValue({
-      ...EVENT_PENDING,
-      status: "REJECTED",
-    });
-
-    const result = await makeCaller("org-a").rejectEvent({ eventId: "ev-1" });
-
+    const { caller, store } = makeCaller({ matterEventSuggestions: [ev({})] });
+    const result = await caller.rejectEvent({ eventId: "ev-1" });
     expect(result.status).toBe("REJECTED");
-    expect(mockPrisma.matterEventSuggestion.update).toHaveBeenCalledWith({
-      where: { id: "ev-1" },
-      data: { status: "REJECTED" },
-    });
-  });
-
-  it("verifierar att eventet tillhör anropande org innan update", async () => {
-    mockPrisma.matterEventSuggestion.findFirst.mockResolvedValue(EVENT_PENDING);
-    mockPrisma.matterEventSuggestion.update.mockResolvedValue(EVENT_PENDING);
-
-    await makeCaller("org-a").rejectEvent({ eventId: "ev-1" });
-
-    expect(mockPrisma.matterEventSuggestion.findFirst).toHaveBeenCalledWith({
-      where: {
-        id: "ev-1",
-        document: { matter: { organizationId: "org-a" } },
-      },
-    });
+    expect(events(store).find((e) => e.id === "ev-1")!.status).toBe("REJECTED");
   });
 
   it("kastar NOT_FOUND om event inte finns eller tillhör annan org", async () => {
-    mockPrisma.matterEventSuggestion.findFirst.mockResolvedValue(null);
-
-    await expect(
-      makeCaller("org-a").rejectEvent({ eventId: "ev-ghost" })
-    ).rejects.toBeInstanceOf(TRPCError);
-    await expect(
-      makeCaller("org-a").rejectEvent({ eventId: "ev-ghost" })
-    ).rejects.toMatchObject({ code: "NOT_FOUND" });
-    expect(mockPrisma.matterEventSuggestion.update).not.toHaveBeenCalled();
+    const { caller, store } = makeCaller({ matterEventSuggestions: [ev({})] }, "org-b");
+    await expect(caller.rejectEvent({ eventId: "ev-1" })).rejects.toBeInstanceOf(TRPCError);
+    await expect(caller.rejectEvent({ eventId: "ev-1" })).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(events(store).find((e) => e.id === "ev-1")!.status).toBe("PENDING");
   });
 });
 
-// ─── markEventAdded ──────────────────────────────────────────────
-
 describe("document.markEventAdded", () => {
   it("markerar event som ACCEPTED (tillagd i kalender)", async () => {
-    mockPrisma.matterEventSuggestion.findFirst.mockResolvedValue(EVENT_PENDING);
-    mockPrisma.matterEventSuggestion.update.mockResolvedValue({
-      ...EVENT_PENDING,
-      status: "ACCEPTED",
-    });
-
-    const result = await makeCaller("org-a").markEventAdded({ eventId: "ev-1" });
-
+    const { caller, store } = makeCaller({ matterEventSuggestions: [ev({})] });
+    const result = await caller.markEventAdded({ eventId: "ev-1" });
     expect(result.status).toBe("ACCEPTED");
-    expect(mockPrisma.matterEventSuggestion.update).toHaveBeenCalledWith({
-      where: { id: "ev-1" },
-      data: { status: "ACCEPTED" },
-    });
-  });
-
-  it("kastar NOT_FOUND för okänt event", async () => {
-    mockPrisma.matterEventSuggestion.findFirst.mockResolvedValue(null);
-
-    await expect(
-      makeCaller("org-a").markEventAdded({ eventId: "ev-ghost" })
-    ).rejects.toMatchObject({ code: "NOT_FOUND" });
-    expect(mockPrisma.matterEventSuggestion.update).not.toHaveBeenCalled();
+    expect(events(store).find((e) => e.id === "ev-1")!.status).toBe("ACCEPTED");
   });
 
   it("org-isolation: event i annan org kan inte markeras", async () => {
-    // findFirst returnerar null eftersom where-villkoret inte matchar annan org
-    mockPrisma.matterEventSuggestion.findFirst.mockResolvedValue(null);
-
-    await expect(
-      makeCaller("org-b").markEventAdded({ eventId: "ev-1" })
-    ).rejects.toMatchObject({ code: "NOT_FOUND" });
-    expect(mockPrisma.matterEventSuggestion.findFirst).toHaveBeenCalledWith({
-      where: {
-        id: "ev-1",
-        document: { matter: { organizationId: "org-b" } },
-      },
-    });
+    const { caller, store } = makeCaller({ matterEventSuggestions: [ev({})] }, "org-b");
+    await expect(caller.markEventAdded({ eventId: "ev-1" })).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(events(store).find((e) => e.id === "ev-1")!.status).toBe("PENDING");
   });
 });

--- a/test/unit/server/routers/document.groups.test.ts
+++ b/test/unit/server/routers/document.groups.test.ts
@@ -1,413 +1,226 @@
+/**
+ * Grupp-accept/reject för kontaktförslag + dedup-grenar (pnr/orgnr/namn-i-ärende).
+ * Kör mot en riktig in-memory-store (repos, ADR 0020); asserterar på observerbart
+ * resultat (skapad kontakt, länkar, notes-merge, status).
+ */
+
 import { TRPCError } from "@trpc/server";
-import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { describe, it, expect, vi } from "vitest-compat";
+import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import { documentRouter } from "@/lib/server/routers/document";
-import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
+import { prebakeJoins } from "@/lib/shared/demo-source";
 
-// ─── Helpers ─────────────────────────────────────────────────────
+vi.mock("@/lib/server/services/meilisearch", () => ({ searchDocuments: vi.fn(), removeDocument: vi.fn() }));
+vi.mock("@/lib/server/services/document-analysis", () => ({ analyzeDocument: vi.fn() }));
 
-const mockPrisma = {
-  documentAnalysisSuggestion: {
-    findMany: vi.fn(),
-    updateMany: vi.fn(),
-  },
-  contact: {
-    findFirst: vi.fn(),
-    create: vi.fn(),
-  },
-  matterContact: {
-    findFirst: vi.fn(),
-    findMany: vi.fn(),
-    create: vi.fn(),
-  },
-};
+const ORG = "org-a";
 
-function makeCaller(orgId = "org-a") {
+function makeCaller(seed: Partial<DemoSource> = {}, orgId = ORG) {
+  const source = prebakeJoins({
+    matters: [{ id: "mat-1", organizationId: ORG, matterNumber: "2026-1", title: "T" }],
+    documents: [{ id: "doc-1", matterId: "mat-1", fileName: "f.pdf" }],
+    contacts: [],
+    matterContacts: [],
+    documentAnalysisSuggestions: [],
+    ...seed,
+  } as DemoSource);
+  const store = new LocalStore(source, async () => {});
+  const repos = buildInMemoryRepositories(store as unknown as IDataStore);
   const ctx = {
     user: { id: "user-1", email: "a@b.com", name: "Test", role: "ADMIN", organizationId: orgId },
-    prisma: mockPrisma, dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+    dataStore: store, repos, orgId,
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return documentRouter.createCaller(ctx as any);
+  return { caller: documentRouter.createCaller(ctx as any), store };
 }
 
+const src = (s: LocalStore) => (s as unknown as { source: DemoSource }).source;
+const contactsOf = (s: LocalStore) => (src(s).contacts ?? []) as Array<Record<string, unknown>>;
+const linksOf = (s: LocalStore) => (src(s).matterContacts ?? []) as Array<Record<string, unknown>>;
+const suggsOf = (s: LocalStore) => (src(s).documentAnalysisSuggestions ?? []) as Array<Record<string, unknown>>;
+
 const SUGG_ANNA_KLIENT = {
-  id: "s1",
-  name: "Anna Svensson",
-  role: "KLIENT",
-  contactType: "PERSON",
-  email: null,
-  phone: null,
-  orgNumber: null,
-  personalNumber: "19850315-1234",
-  notes: "Klient i ärendet",
-  status: "PENDING",
-  document: { matterId: "mat-1" },
+  id: "s1", documentId: "doc-1", name: "Anna Svensson", role: "KLIENT", contactType: "PERSON",
+  email: null, phone: null, orgNumber: null, personalNumber: "19850315-1234", notes: "Klient i ärendet",
+  status: "PENDING", acceptedContactId: null, createdAt: new Date("2026-06-01"),
 };
 const SUGG_ANNA_VITTNE = {
-  ...SUGG_ANNA_KLIENT,
-  id: "s2",
-  role: "VITTNE",
-  email: "anna@example.se",
-  notes: "Vittne i förhandling",
+  ...SUGG_ANNA_KLIENT, id: "s2", role: "VITTNE", email: "anna@example.se", notes: "Vittne i förhandling",
+  createdAt: new Date("2026-06-02"),
 };
 
-beforeEach(() => {
-  vi.clearAllMocks();
-  // Default: inga befintliga matter-kontakter (namn-fallback hittar inget)
-  mockPrisma.matterContact.findMany.mockResolvedValue([]);
-});
-
-// ─── acceptSuggestionGroup — happy path ──────────────────────────
-
 describe("document.acceptSuggestionGroup — skapa kontakt + flera roller", () => {
-  it("skapar kontakt och länkar alla distinkta roller till ärendet", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([
-      SUGG_ANNA_KLIENT,
-      SUGG_ANNA_VITTNE,
-    ]);
-    mockPrisma.contact.findFirst.mockResolvedValue(null); // ingen befintlig kontakt
-    mockPrisma.contact.create.mockResolvedValue({ id: "contact-new" });
-    mockPrisma.matterContact.findFirst.mockResolvedValue(null);
-    mockPrisma.matterContact.create.mockResolvedValue({ id: "mc-1" });
-    mockPrisma.documentAnalysisSuggestion.updateMany.mockResolvedValue({ count: 2 });
-
-    const result = await makeCaller("org-a").acceptSuggestionGroup({
-      suggestionIds: ["s1", "s2"],
-    });
-
-    expect(result).toEqual({ contactId: "contact-new", acceptedRoles: ["KLIENT", "VITTNE"] });
-
-    // Kontakt skapad med förnyad info (email från s2 eftersom s1 saknade)
-    expect(mockPrisma.contact.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          name: "Anna Svensson",
-          personalNumber: "19850315-1234",
-          email: "anna@example.se",
-          organizationId: "org-a",
-        }),
-      })
-    );
-
-    // Två matterContact-länkar skapade (KLIENT + VITTNE)
-    expect(mockPrisma.matterContact.create).toHaveBeenCalledTimes(2);
-    expect(mockPrisma.matterContact.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({ matterId: "mat-1", contactId: "contact-new", role: "KLIENT" }),
-      })
-    );
-    expect(mockPrisma.matterContact.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({ matterId: "mat-1", contactId: "contact-new", role: "VITTNE" }),
-      })
-    );
-
-    // Alla förslag markerade som ACCEPTED
-    expect(mockPrisma.documentAnalysisSuggestion.updateMany).toHaveBeenCalledWith({
-      where: { id: { in: ["s1", "s2"] } },
-      data: { status: "ACCEPTED", acceptedContactId: "contact-new" },
-    });
+  it("skapar kontakt och länkar alla distinkta roller", async () => {
+    const { caller, store } = makeCaller({ documentAnalysisSuggestions: [SUGG_ANNA_KLIENT, SUGG_ANNA_VITTNE] });
+    const result = await caller.acceptSuggestionGroup({ suggestionIds: ["s1", "s2"] });
+    expect(result.acceptedRoles.sort()).toEqual(["KLIENT", "VITTNE"]);
+    expect(contactsOf(store)).toHaveLength(1);
+    const created = contactsOf(store)[0]!;
+    expect(created.name).toBe("Anna Svensson");
+    expect(created.personalNumber).toBe("19850315-1234");
+    expect(created.email).toBe("anna@example.se"); // från s2 (s1 saknade)
+    expect(linksOf(store)).toHaveLength(2);
+    expect(suggsOf(store).every((s) => s.status === "ACCEPTED")).toBe(true);
   });
 
   it("återanvänder befintlig kontakt som matchar på personalNumber", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([SUGG_ANNA_KLIENT]);
-    mockPrisma.contact.findFirst.mockResolvedValue({ id: "contact-existing" });
-    mockPrisma.matterContact.findFirst.mockResolvedValue(null);
-    mockPrisma.matterContact.create.mockResolvedValue({ id: "mc-1" });
-    mockPrisma.documentAnalysisSuggestion.updateMany.mockResolvedValue({ count: 1 });
-
-    const result = await makeCaller("org-a").acceptSuggestionGroup({ suggestionIds: ["s1"] });
-
-    expect(result.contactId).toBe("contact-existing");
-    expect(mockPrisma.contact.create).not.toHaveBeenCalled();
-    expect(mockPrisma.contact.findFirst).toHaveBeenCalledWith({
-      where: { personalNumber: "19850315-1234", organizationId: "org-a" },
+    const { caller, store } = makeCaller({
+      contacts: [{ id: "contact-existing", organizationId: ORG, name: "Anna", contactType: "PERSON", personalNumber: "19850315-1234" }],
+      documentAnalysisSuggestions: [SUGG_ANNA_KLIENT],
     });
+    const result = await caller.acceptSuggestionGroup({ suggestionIds: ["s1"] });
+    expect(result.contactId).toBe("contact-existing");
+    expect(contactsOf(store)).toHaveLength(1); // ingen ny
   });
 
   it("hoppar över rolllänk som redan finns", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([SUGG_ANNA_KLIENT]);
-    mockPrisma.contact.findFirst.mockResolvedValue({ id: "contact-x" });
-    mockPrisma.matterContact.findFirst.mockResolvedValue({ id: "existing-link" }); // redan länkad
-    mockPrisma.documentAnalysisSuggestion.updateMany.mockResolvedValue({ count: 1 });
-
-    await makeCaller("org-a").acceptSuggestionGroup({ suggestionIds: ["s1"] });
-
-    expect(mockPrisma.matterContact.create).not.toHaveBeenCalled();
+    const { caller, store } = makeCaller({
+      contacts: [{ id: "contact-x", organizationId: ORG, name: "Anna", contactType: "PERSON", personalNumber: "19850315-1234" }],
+      matterContacts: [{ id: "existing-link", matterId: "mat-1", contactId: "contact-x", role: "KLIENT" }],
+      documentAnalysisSuggestions: [SUGG_ANNA_KLIENT],
+    });
+    await caller.acceptSuggestionGroup({ suggestionIds: ["s1"] });
+    expect(linksOf(store)).toHaveLength(1); // ingen ny länk
   });
 
   it("använder existingContactId om det anges", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([SUGG_ANNA_KLIENT]);
-    mockPrisma.contact.findFirst.mockResolvedValue({ id: "contact-chosen" });
-    mockPrisma.matterContact.findFirst.mockResolvedValue(null);
-    mockPrisma.matterContact.create.mockResolvedValue({ id: "mc-1" });
-    mockPrisma.documentAnalysisSuggestion.updateMany.mockResolvedValue({ count: 1 });
-
-    const result = await makeCaller("org-a").acceptSuggestionGroup({
-      suggestionIds: ["s1"],
-      existingContactId: "contact-chosen",
+    const { caller } = makeCaller({
+      contacts: [{ id: "contact-chosen", organizationId: ORG, name: "Vald", contactType: "PERSON" }],
+      documentAnalysisSuggestions: [SUGG_ANNA_KLIENT],
     });
-
+    const result = await caller.acceptSuggestionGroup({ suggestionIds: ["s1"], existingContactId: "contact-chosen" });
     expect(result.contactId).toBe("contact-chosen");
-    expect(mockPrisma.contact.findFirst).toHaveBeenCalledWith({
-      where: { id: "contact-chosen", organizationId: "org-a" },
-    });
-    expect(mockPrisma.contact.create).not.toHaveBeenCalled();
   });
 
   it("slår samman notes per roll", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([
-      { ...SUGG_ANNA_KLIENT, notes: "Klient enligt doc1" },
-      { ...SUGG_ANNA_KLIENT, id: "s3", notes: "Bekräftad klient doc2" },
-    ]);
-    mockPrisma.contact.findFirst.mockResolvedValue(null);
-    mockPrisma.contact.create.mockResolvedValue({ id: "contact-1" });
-    mockPrisma.matterContact.findFirst.mockResolvedValue(null);
-    mockPrisma.matterContact.create.mockResolvedValue({ id: "mc-1" });
-    mockPrisma.documentAnalysisSuggestion.updateMany.mockResolvedValue({ count: 2 });
-
-    await makeCaller("org-a").acceptSuggestionGroup({ suggestionIds: ["s1", "s3"] });
-
-    expect(mockPrisma.matterContact.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          role: "KLIENT",
-          notes: "Klient enligt doc1\nBekräftad klient doc2",
-        }),
-      })
-    );
+    const { caller, store } = makeCaller({
+      documentAnalysisSuggestions: [
+        { ...SUGG_ANNA_KLIENT, notes: "Klient enligt doc1" },
+        { ...SUGG_ANNA_KLIENT, id: "s3", notes: "Bekräftad klient doc2" },
+      ],
+    });
+    await caller.acceptSuggestionGroup({ suggestionIds: ["s1", "s3"] });
+    const link = linksOf(store).find((l) => l.role === "KLIENT")!;
+    expect(link.notes).toBe("Klient enligt doc1\nBekräftad klient doc2");
   });
 
   it("dedupar rolllänkar när samma roll förekommer flera gånger", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([
-      SUGG_ANNA_KLIENT,
-      { ...SUGG_ANNA_KLIENT, id: "s3" }, // samma roll igen
-    ]);
-    mockPrisma.contact.findFirst.mockResolvedValue(null);
-    mockPrisma.contact.create.mockResolvedValue({ id: "contact-1" });
-    mockPrisma.matterContact.findFirst.mockResolvedValue(null);
-    mockPrisma.matterContact.create.mockResolvedValue({ id: "mc-1" });
-    mockPrisma.documentAnalysisSuggestion.updateMany.mockResolvedValue({ count: 2 });
-
-    const result = await makeCaller("org-a").acceptSuggestionGroup({
-      suggestionIds: ["s1", "s3"],
+    const { caller, store } = makeCaller({
+      documentAnalysisSuggestions: [SUGG_ANNA_KLIENT, { ...SUGG_ANNA_KLIENT, id: "s3" }],
     });
-
-    // Bara EN distinkt roll
+    const result = await caller.acceptSuggestionGroup({ suggestionIds: ["s1", "s3"] });
     expect(result.acceptedRoles).toEqual(["KLIENT"]);
-    expect(mockPrisma.matterContact.create).toHaveBeenCalledTimes(1);
+    expect(linksOf(store)).toHaveLength(1);
   });
 });
 
-// ─── acceptSuggestionGroup — namn-baserad dedup ──────────────────
-
 describe("document.acceptSuggestionGroup — dedup på namn inom ärende", () => {
-  const SUGG_NO_IDS = {
-    ...SUGG_ANNA_KLIENT,
-    personalNumber: null,
-    orgNumber: null,
-  };
+  const SUGG_NO_IDS = { ...SUGG_ANNA_KLIENT, personalNumber: null, orgNumber: null };
+  /** Seed: en befintlig matter-kontakt (namn-match-underlag). */
+  function withMatterContact(name: string, contactType = "PERSON", role = "KLIENT") {
+    return {
+      contacts: [{ id: "contact-existing", organizationId: ORG, name, contactType }],
+      matterContacts: [{ id: "ml1", matterId: "mat-1", contactId: "contact-existing", role }],
+    };
+  }
 
   it("återanvänder befintlig matter-kontakt med samma namn när personalNumber saknas", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([SUGG_NO_IDS]);
-    mockPrisma.contact.findFirst.mockResolvedValue(null);
-    mockPrisma.matterContact.findMany.mockResolvedValue([
-      {
-        matterId: "mat-1",
-        contactId: "contact-existing",
-        role: "KLIENT",
-        contact: {
-          id: "contact-existing",
-          name: "Anna Svensson",
-          contactType: "PERSON",
-          organizationId: "org-a",
-        },
-      },
-    ]);
-    mockPrisma.matterContact.findFirst.mockResolvedValue({ id: "existing-link" });
-    mockPrisma.documentAnalysisSuggestion.updateMany.mockResolvedValue({ count: 1 });
-
-    const result = await makeCaller("org-a").acceptSuggestionGroup({ suggestionIds: ["s1"] });
-
+    const { caller, store } = makeCaller({ ...withMatterContact("Anna Svensson"), documentAnalysisSuggestions: [SUGG_NO_IDS] });
+    const result = await caller.acceptSuggestionGroup({ suggestionIds: ["s1"] });
     expect(result.contactId).toBe("contact-existing");
-    expect(mockPrisma.contact.create).not.toHaveBeenCalled();
+    expect(contactsOf(store)).toHaveLength(1);
   });
 
   it("är case-insensitiv och ignorerar blanksteg vid namn-match", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([
-      { ...SUGG_NO_IDS, name: "  ANNA svensson  " },
-    ]);
-    mockPrisma.contact.findFirst.mockResolvedValue(null);
-    mockPrisma.matterContact.findMany.mockResolvedValue([
-      {
-        matterId: "mat-1",
-        contactId: "contact-existing",
-        role: "KLIENT",
-        contact: {
-          id: "contact-existing",
-          name: "Anna Svensson",
-          contactType: "PERSON",
-          organizationId: "org-a",
-        },
-      },
-    ]);
-    mockPrisma.matterContact.findFirst.mockResolvedValue({ id: "existing-link" });
-    mockPrisma.documentAnalysisSuggestion.updateMany.mockResolvedValue({ count: 1 });
-
-    const result = await makeCaller("org-a").acceptSuggestionGroup({ suggestionIds: ["s1"] });
+    const { caller, store } = makeCaller({
+      ...withMatterContact("Anna Svensson"),
+      documentAnalysisSuggestions: [{ ...SUGG_NO_IDS, name: "  ANNA svensson  " }],
+    });
+    const result = await caller.acceptSuggestionGroup({ suggestionIds: ["s1"] });
     expect(result.contactId).toBe("contact-existing");
-    expect(mockPrisma.contact.create).not.toHaveBeenCalled();
+    expect(contactsOf(store)).toHaveLength(1);
   });
 
   it("matchar INTE om contactType skiljer (PERSON vs COMPANY)", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([SUGG_NO_IDS]);
-    mockPrisma.contact.findFirst.mockResolvedValue(null);
-    mockPrisma.matterContact.findMany.mockResolvedValue([
-      {
-        matterId: "mat-1",
-        contactId: "contact-company",
-        role: "MOTPART",
-        contact: {
-          id: "contact-company",
-          name: "Anna Svensson",
-          contactType: "COMPANY",
-          organizationId: "org-a",
-        },
-      },
-    ]);
-    mockPrisma.contact.create.mockResolvedValue({ id: "contact-new" });
-    mockPrisma.matterContact.findFirst.mockResolvedValue(null);
-    mockPrisma.matterContact.create.mockResolvedValue({ id: "mc-1" });
-    mockPrisma.documentAnalysisSuggestion.updateMany.mockResolvedValue({ count: 1 });
-
-    const result = await makeCaller("org-a").acceptSuggestionGroup({ suggestionIds: ["s1"] });
-    expect(result.contactId).toBe("contact-new");
-    expect(mockPrisma.contact.create).toHaveBeenCalled();
+    const { caller, store } = makeCaller({
+      ...withMatterContact("Anna Svensson", "COMPANY", "MOTPART"),
+      documentAnalysisSuggestions: [SUGG_NO_IDS],
+    });
+    const result = await caller.acceptSuggestionGroup({ suggestionIds: ["s1"] });
+    expect(result.contactId).not.toBe("contact-existing");
+    expect(contactsOf(store)).toHaveLength(2); // ny skapad
   });
 
   it("skapar ny kontakt när namnet inte matchar någon befintlig matter-kontakt", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([SUGG_NO_IDS]);
-    mockPrisma.contact.findFirst.mockResolvedValue(null);
-    mockPrisma.matterContact.findMany.mockResolvedValue([
-      {
-        matterId: "mat-1",
-        contactId: "contact-other",
-        role: "MOTPART",
-        contact: {
-          id: "contact-other",
-          name: "Bo Karlsson",
-          contactType: "PERSON",
-          organizationId: "org-a",
-        },
-      },
-    ]);
-    mockPrisma.contact.create.mockResolvedValue({ id: "contact-new" });
-    mockPrisma.matterContact.findFirst.mockResolvedValue(null);
-    mockPrisma.matterContact.create.mockResolvedValue({ id: "mc-1" });
-    mockPrisma.documentAnalysisSuggestion.updateMany.mockResolvedValue({ count: 1 });
-
-    const result = await makeCaller("org-a").acceptSuggestionGroup({ suggestionIds: ["s1"] });
-    expect(result.contactId).toBe("contact-new");
-    expect(mockPrisma.contact.create).toHaveBeenCalled();
+    const { caller, store } = makeCaller({
+      ...withMatterContact("Bo Karlsson", "PERSON", "MOTPART"),
+      documentAnalysisSuggestions: [SUGG_NO_IDS],
+    });
+    const result = await caller.acceptSuggestionGroup({ suggestionIds: ["s1"] });
+    expect(result.contactId).not.toBe("contact-existing");
+    expect(contactsOf(store)).toHaveLength(2);
   });
 
   it("personalNumber-match går före namn-fallback", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([SUGG_ANNA_KLIENT]);
-    mockPrisma.contact.findFirst.mockResolvedValue({ id: "contact-by-pnr" });
-    mockPrisma.matterContact.findFirst.mockResolvedValue(null);
-    mockPrisma.matterContact.create.mockResolvedValue({ id: "mc-1" });
-    mockPrisma.documentAnalysisSuggestion.updateMany.mockResolvedValue({ count: 1 });
-
-    const result = await makeCaller("org-a").acceptSuggestionGroup({ suggestionIds: ["s1"] });
+    const { caller } = makeCaller({
+      contacts: [{ id: "contact-by-pnr", organizationId: ORG, name: "Annat namn", contactType: "PERSON", personalNumber: "19850315-1234" }],
+      documentAnalysisSuggestions: [SUGG_ANNA_KLIENT],
+    });
+    const result = await caller.acceptSuggestionGroup({ suggestionIds: ["s1"] });
     expect(result.contactId).toBe("contact-by-pnr");
-    // findMany ska inte ha använts eftersom personalNumber-matchen tog över
-    expect(mockPrisma.matterContact.findMany).not.toHaveBeenCalled();
   });
 });
-
-// ─── acceptSuggestionGroup — säkerhet ────────────────────────────
 
 describe("document.acceptSuggestionGroup — valideringar", () => {
   it("kastar NOT_FOUND när inga förslag hittas", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([]);
-
-    await expect(
-      makeCaller("org-a").acceptSuggestionGroup({ suggestionIds: ["missing"] })
-    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    const { caller } = makeCaller();
+    await expect(caller.acceptSuggestionGroup({ suggestionIds: ["missing"] })).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 
-  it("kastar BAD_REQUEST om bara några förslag hittas (delvis annan org)", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([SUGG_ANNA_KLIENT]);
-
-    await expect(
-      makeCaller("org-a").acceptSuggestionGroup({ suggestionIds: ["s1", "s99"] })
-    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  it("kastar BAD_REQUEST om bara några förslag hittas", async () => {
+    const { caller } = makeCaller({ documentAnalysisSuggestions: [SUGG_ANNA_KLIENT] });
+    await expect(caller.acceptSuggestionGroup({ suggestionIds: ["s1", "s99"] })).rejects.toMatchObject({ code: "BAD_REQUEST" });
   });
 
   it("kastar BAD_REQUEST om förslagen tillhör olika ärenden", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([
-      SUGG_ANNA_KLIENT,
-      { ...SUGG_ANNA_VITTNE, document: { matterId: "mat-2" } },
-    ]);
-
-    await expect(
-      makeCaller("org-a").acceptSuggestionGroup({ suggestionIds: ["s1", "s2"] })
-    ).rejects.toMatchObject({ code: "BAD_REQUEST", message: expect.stringContaining("olika ärenden") });
+    const { caller } = makeCaller({
+      matters: [
+        { id: "mat-1", organizationId: ORG, matterNumber: "2026-1", title: "T" },
+        { id: "mat-2", organizationId: ORG, matterNumber: "2026-2", title: "U" },
+      ],
+      documents: [{ id: "doc-1", matterId: "mat-1", fileName: "f" }, { id: "doc-2", matterId: "mat-2", fileName: "g" }],
+      documentAnalysisSuggestions: [SUGG_ANNA_KLIENT, { ...SUGG_ANNA_VITTNE, documentId: "doc-2" }],
+    });
+    await expect(caller.acceptSuggestionGroup({ suggestionIds: ["s1", "s2"] }))
+      .rejects.toMatchObject({ code: "BAD_REQUEST", message: expect.stringContaining("olika ärenden") });
   });
 
-  it("filtrerar på anropande organisation i findMany-query", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([SUGG_ANNA_KLIENT]);
-    mockPrisma.contact.findFirst.mockResolvedValue({ id: "c1" });
-    mockPrisma.matterContact.findFirst.mockResolvedValue(null);
-    mockPrisma.matterContact.create.mockResolvedValue({ id: "mc-1" });
-    mockPrisma.documentAnalysisSuggestion.updateMany.mockResolvedValue({ count: 1 });
-
-    await makeCaller("org-b").acceptSuggestionGroup({ suggestionIds: ["s1"] });
-
-    expect(mockPrisma.documentAnalysisSuggestion.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          document: { matter: { organizationId: "org-b" } },
-        }),
-      })
-    );
+  it("filtrerar på anropande organisation (annan org → NOT_FOUND)", async () => {
+    const { caller } = makeCaller({ documentAnalysisSuggestions: [SUGG_ANNA_KLIENT] }, "org-b");
+    await expect(caller.acceptSuggestionGroup({ suggestionIds: ["s1"] })).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 });
 
-// ─── rejectSuggestionGroup ───────────────────────────────────────
-
 describe("document.rejectSuggestionGroup", () => {
   it("avvisar alla förslag i gruppen", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([
-      { id: "s1" },
-      { id: "s2" },
-    ]);
-    mockPrisma.documentAnalysisSuggestion.updateMany.mockResolvedValue({ count: 2 });
-
-    const result = await makeCaller("org-a").rejectSuggestionGroup({
-      suggestionIds: ["s1", "s2"],
+    const { caller, store } = makeCaller({
+      documentAnalysisSuggestions: [SUGG_ANNA_KLIENT, SUGG_ANNA_VITTNE],
     });
-
+    const result = await caller.rejectSuggestionGroup({ suggestionIds: ["s1", "s2"] });
     expect(result).toEqual({ rejected: 2 });
-    expect(mockPrisma.documentAnalysisSuggestion.updateMany).toHaveBeenCalledWith({
-      where: { id: { in: ["s1", "s2"] } },
-      data: { status: "REJECTED" },
-    });
+    expect(suggsOf(store).every((s) => s.status === "REJECTED")).toBe(true);
   });
 
   it("kastar NOT_FOUND när inga förslag hittas", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([]);
-
-    await expect(
-      makeCaller("org-a").rejectSuggestionGroup({ suggestionIds: ["s1"] })
-    ).rejects.toBeInstanceOf(TRPCError);
+    const { caller } = makeCaller();
+    await expect(caller.rejectSuggestionGroup({ suggestionIds: ["s1"] })).rejects.toBeInstanceOf(TRPCError);
   });
 
   it("kastar BAD_REQUEST om bara vissa id:n tillhör anropande org", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([{ id: "s1" }]);
-
-    await expect(
-      makeCaller("org-a").rejectSuggestionGroup({ suggestionIds: ["s1", "s2"] })
-    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    const { caller } = makeCaller({ documentAnalysisSuggestions: [SUGG_ANNA_KLIENT] });
+    await expect(caller.rejectSuggestionGroup({ suggestionIds: ["s1", "s2"] })).rejects.toMatchObject({ code: "BAD_REQUEST" });
   });
 });

--- a/test/unit/server/routers/document/core.test.ts
+++ b/test/unit/server/routers/document/core.test.ts
@@ -1,11 +1,17 @@
 /**
  * Test för document.core — list/tree/search/delete/analyze/updateMetadata.
+ *
+ * Kör mot en RIKTIG in-memory-store (LocalStore + repos, ADR 0020); portar
+ * (meili/analys) är mockade. Asserterar på observerbart resultat.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import { documentRouter } from "@/lib/server/routers/document";
-import { dataStoreFromMockPrisma } from "../../helpers/mock-data-store";
-
+import { prebakeJoins } from "@/lib/shared/demo-source";
 
 vi.mock("@/lib/server/services/meilisearch", () => ({
   searchDocuments: vi.fn(),
@@ -15,22 +21,7 @@ vi.mock("@/lib/server/services/document-analysis", () => ({
   analyzeDocument: vi.fn().mockResolvedValue(undefined),
 }));
 
-const mockPrisma = {
-  document: {
-    findMany: vi.fn(),
-    findFirst: vi.fn(),
-    findUniqueOrThrow: vi.fn(),
-    count: vi.fn(),
-    delete: vi.fn(),
-    update: vi.fn(),
-  },
-  documentFolder: {
-    findMany: vi.fn(),
-  },
-  matter: {
-    findFirst: vi.fn(),
-  },
-};
+const ORG = "org-a";
 
 const mockPorts = {
   email: { send: vi.fn() },
@@ -43,54 +34,65 @@ const mockPorts = {
   },
 };
 
-function makeCaller(orgId = "org-a") {
+function makeCaller(seed: Partial<DemoSource> = {}, orgId = ORG) {
+  const source = prebakeJoins({
+    matters: [{ id: "m1", organizationId: ORG, matterNumber: "2026-1", title: "T" }],
+    documentFolders: [],
+    documents: [],
+    ...seed,
+  } as DemoSource);
+  const store = new LocalStore(source, async () => {});
+  const repos = buildInMemoryRepositories(store as unknown as IDataStore);
   const ctx = {
     user: { id: "u1", email: "a@b.se", name: "T", role: "LAWYER", organizationId: orgId },
-    prisma: mockPrisma,
-    dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
-    ports: mockPorts,
+    dataStore: store, repos, orgId, ports: mockPorts,
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return documentRouter.createCaller(ctx as any);
+  return { caller: documentRouter.createCaller(ctx as any), store };
 }
 
-beforeEach(() => {
-  vi.clearAllMocks();
-  mockPrisma.document.findMany.mockResolvedValue([]);
-  mockPrisma.documentFolder.findMany.mockResolvedValue([]);
-  mockPrisma.document.count.mockResolvedValue(0);
-});
+function docs(store: LocalStore): Array<Record<string, unknown>> {
+  return (store as unknown as { source: DemoSource }).source.documents as never;
+}
+
+beforeEach(() => vi.clearAllMocks());
 
 describe("document.list", () => {
   it("filtrerar på matterId och folderId", async () => {
-    await makeCaller().list({ matterId: "m1", folderId: "f1" });
-    expect(mockPrisma.document.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { matterId: "m1", folderId: "f1" },
-      }),
-    );
+    const { caller } = makeCaller({
+      documents: [
+        { id: "d1", matterId: "m1", folderId: "f1", fileName: "a.pdf" },
+        { id: "d2", matterId: "m1", folderId: null, fileName: "b.pdf" },
+      ],
+    });
+    const res = await caller.list({ matterId: "m1", folderId: "f1" });
+    expect(res.documents.map((d) => d.id)).toEqual(["d1"]);
+    expect(res.total).toBe(1);
   });
 
   it("default folderId = null (rot-nivå)", async () => {
-    await makeCaller().list({ matterId: "m1" });
-    expect(mockPrisma.document.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { matterId: "m1", folderId: null },
-      }),
-    );
+    const { caller } = makeCaller({
+      documents: [
+        { id: "d1", matterId: "m1", folderId: "f1", fileName: "a.pdf" },
+        { id: "d2", matterId: "m1", folderId: null, fileName: "b.pdf" },
+      ],
+    });
+    const res = await caller.list({ matterId: "m1" });
+    expect(res.documents.map((d) => d.id)).toEqual(["d2"]);
   });
 });
 
 describe("document.tree", () => {
   it("returnerar alla mappar + dokument exkl junk-filer", async () => {
-    mockPrisma.document.findMany.mockResolvedValue([
-      { id: "d1", fileName: "real.pdf" },
-      { id: "d2", fileName: "._junk.pdf" }, // AppleDouble
-      { id: "d3", fileName: ".DS_Store" },
-    ]);
-    mockPrisma.documentFolder.findMany.mockResolvedValue([{ id: "f1" }]);
-
-    const res = await makeCaller().tree({ matterId: "m1" });
+    const { caller } = makeCaller({
+      documentFolders: [{ id: "f1", name: "Mapp", matterId: "m1", parentId: null }],
+      documents: [
+        { id: "d1", matterId: "m1", folderId: null, fileName: "real.pdf" },
+        { id: "d2", matterId: "m1", folderId: null, fileName: "._junk.pdf" }, // AppleDouble
+        { id: "d3", matterId: "m1", folderId: null, fileName: ".DS_Store" },
+      ],
+    });
+    const res = await caller.tree({ matterId: "m1" });
     expect(res.folders).toHaveLength(1);
     expect(res.documents).toHaveLength(1);
     expect(res.documents[0]!.fileName).toBe("real.pdf");
@@ -113,7 +115,8 @@ describe("document.search", () => {
       estimatedTotalHits: 1,
     } as never);
 
-    const res = await makeCaller("org-a").search({ query: "test" });
+    const { caller } = makeCaller({}, "org-a");
+    const res = await caller.search({ query: "test" });
     expect(mockPorts.searchIndex.search).toHaveBeenCalledWith("test", "org-a", 20, { documentTypes: undefined });
     expect(res.totalHits).toBe(1);
     expect(res.hits[0]!.documentId).toBe("d1");
@@ -134,58 +137,63 @@ describe("document.search", () => {
       estimatedTotalHits: 1,
     } as never);
 
-    const res = await makeCaller().search({ query: "x" });
+    const { caller } = makeCaller();
+    const res = await caller.search({ query: "x" });
     expect(res.hits[0]!.highlight).toBe("");
   });
 
   it("kräver query min(1)", async () => {
-    await expect(makeCaller().search({ query: "" })).rejects.toThrow();
+    const { caller } = makeCaller();
+    await expect(caller.search({ query: "" })).rejects.toThrow();
   });
 });
 
 describe("document.delete", () => {
   it("vägrar radera när dokument ej tillhör org", async () => {
-    mockPrisma.document.findFirst.mockResolvedValue(null);
-    await expect(makeCaller().delete({ id: "d1" })).rejects.toMatchObject({
-      code: "NOT_FOUND",
-    });
-    expect(mockPrisma.document.delete).not.toHaveBeenCalled();
+    const { caller, store } = makeCaller({
+      documents: [{ id: "d1", matterId: "m1", folderId: null, fileName: "a.pdf" }],
+    }, "org-other");
+    await expect(caller.delete({ id: "d1" })).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(docs(store).some((d) => d.id === "d1")).toBe(true);
+    expect(mockPorts.searchIndex.remove).not.toHaveBeenCalled();
   });
 
   it("raderar och triggar Meili-cleanup när tillgång OK", async () => {
-    mockPrisma.document.findFirst.mockResolvedValue({ id: "d1", matterId: "m1" });
-    mockPrisma.document.delete.mockResolvedValue({ id: "d1" });
-
-    await makeCaller().delete({ id: "d1" });
-    expect(mockPrisma.document.delete).toHaveBeenCalledWith({ where: { id: "d1" } });
+    const { caller, store } = makeCaller({
+      documents: [{ id: "d1", matterId: "m1", folderId: null, fileName: "a.pdf" }],
+    });
+    await caller.delete({ id: "d1" });
+    expect(docs(store).some((d) => d.id === "d1")).toBe(false);
     expect(mockPorts.searchIndex.remove).toHaveBeenCalledWith("d1");
   });
 });
 
 describe("document.analyze", () => {
   it("vägrar när dokument tillhör annan org", async () => {
-    mockPrisma.document.findFirst.mockResolvedValue(null);
-    await expect(
-      makeCaller().analyze({ documentId: "d1" }),
-    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    const { caller } = makeCaller({
+      documents: [{ id: "d1", matterId: "m1", folderId: null, fileName: "a.pdf" }],
+    }, "org-other");
+    await expect(caller.analyze({ documentId: "d1" })).rejects.toMatchObject({ code: "NOT_FOUND" });
     expect(mockPorts.documentAnalyzer.analyze).not.toHaveBeenCalled();
   });
 
   it("triggar fire-and-forget analys när tillgång OK", async () => {
-    mockPrisma.document.findFirst.mockResolvedValue({ id: "d1", matterId: "m1" });
+    const { caller } = makeCaller({
+      documents: [{ id: "d1", matterId: "m1", folderId: null, fileName: "a.pdf" }],
+    });
     mockPorts.documentAnalyzer.analyze.mockResolvedValue(undefined);
-
-    const res = await makeCaller().analyze({ documentId: "d1" });
+    const res = await caller.analyze({ documentId: "d1" });
     expect(res).toEqual({ ok: true });
     expect(mockPorts.documentAnalyzer.analyze).toHaveBeenCalledWith("d1");
   });
 
   it("sväljer ett analys-fel (fire-and-forget .catch) utan att kasta", async () => {
-    mockPrisma.document.findFirst.mockResolvedValue({ id: "d1", matterId: "m1" });
+    const { caller } = makeCaller({
+      documents: [{ id: "d1", matterId: "m1", folderId: null, fileName: "a.pdf" }],
+    });
     mockPorts.documentAnalyzer.analyze.mockRejectedValue(new Error("analys-krasch"));
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-
-    const res = await makeCaller().analyze({ documentId: "d1" });
+    const res = await caller.analyze({ documentId: "d1" });
     expect(res).toEqual({ ok: true });
     await new Promise((r) => setTimeout(r, 0)); // låt .catch:en köra
     expect(errSpy).toHaveBeenCalled();
@@ -195,14 +203,16 @@ describe("document.analyze", () => {
 
 describe("document.listDocumentTypes", () => {
   it("räknar unika documentType:er, hoppar null, sorterar på sv", async () => {
-    mockPrisma.document.findMany.mockResolvedValue([
-      { documentType: "Faktura" },
-      { documentType: "Avtal" },
-      { documentType: "Avtal" },
-      { documentType: null },
-      { documentType: "Ärende" },
-    ]);
-    const res = await makeCaller().listDocumentTypes();
+    const { caller } = makeCaller({
+      documents: [
+        { id: "d1", matterId: "m1", documentType: "Faktura", fileName: "1" },
+        { id: "d2", matterId: "m1", documentType: "Avtal", fileName: "2" },
+        { id: "d3", matterId: "m1", documentType: "Avtal", fileName: "3" },
+        { id: "d4", matterId: "m1", documentType: null, fileName: "4" },
+        { id: "d5", matterId: "m1", documentType: "Ärende", fileName: "5" },
+      ],
+    });
+    const res = await caller.listDocumentTypes();
     expect(res).toEqual([
       { type: "Avtal", count: 2 },
       { type: "Faktura", count: 1 },
@@ -211,68 +221,64 @@ describe("document.listDocumentTypes", () => {
   });
 
   it("tom lista när inga dokument", async () => {
-    mockPrisma.document.findMany.mockResolvedValue([]);
-    expect(await makeCaller().listDocumentTypes()).toEqual([]);
+    const { caller } = makeCaller();
+    expect(await caller.listDocumentTypes()).toEqual([]);
   });
 });
 
 describe("document.markExternallyEdited", () => {
   it("bumpar version + updatedAt + sizeBytes efter access-check", async () => {
-    mockPrisma.document.findFirst.mockResolvedValue({ id: "d1", matterId: "m1" });
-    mockPrisma.document.findUniqueOrThrow.mockResolvedValue({ id: "d1", version: 2 });
-    mockPrisma.document.update.mockResolvedValue({ id: "d1", version: 3 });
-
-    await makeCaller().markExternallyEdited({
+    const { caller, store } = makeCaller({
+      documents: [{ id: "d1", matterId: "m1", version: 2, sizeBytes: 10, fileName: "a.pdf" }],
+    });
+    await caller.markExternallyEdited({
       id: "d1", saves: 2, sessionStartedAt: "2026-06-16T08:00:00Z", sizeBytes: 4096,
     });
-
-    const arg = mockPrisma.document.update.mock.calls[0]![0] as { where: unknown; data: Record<string, unknown> };
-    expect(arg.where).toEqual({ id: "d1" });
-    expect(arg.data.version).toBe(3);
-    expect(arg.data.updatedAt).toBeInstanceOf(Date);
-    expect(arg.data.sizeBytes).toBe(4096);
-    expect(arg.data.fileSize).toBe(4096);
+    const doc = docs(store).find((d) => d.id === "d1")!;
+    expect(doc.version).toBe(3);
+    expect(doc.updatedAt).toBeInstanceOf(Date);
+    expect(doc.sizeBytes).toBe(4096);
+    expect(doc.fileSize).toBe(4096);
   });
 
   it("defaultar version till 1→2 när raden saknar version", async () => {
-    mockPrisma.document.findFirst.mockResolvedValue({ id: "d1", matterId: "m1" });
-    mockPrisma.document.findUniqueOrThrow.mockResolvedValue({ id: "d1" });
-    mockPrisma.document.update.mockResolvedValue({ id: "d1" });
-
-    await makeCaller().markExternallyEdited({ id: "d1", saves: 1, sessionStartedAt: new Date() });
-    const arg = mockPrisma.document.update.mock.calls[0]![0] as { data: Record<string, unknown> };
-    expect(arg.data.version).toBe(2);
-    expect(arg.data.sizeBytes).toBeUndefined(); // utelämnad → ej satt
+    const { caller, store } = makeCaller({
+      documents: [{ id: "d1", matterId: "m1", sizeBytes: 10, fileName: "a.pdf" }],
+    });
+    await caller.markExternallyEdited({ id: "d1", saves: 1, sessionStartedAt: new Date() });
+    const doc = docs(store).find((d) => d.id === "d1")!;
+    expect(doc.version).toBe(2);
+    expect(doc.sizeBytes).toBe(10); // utelämnad → oförändrad
   });
 
   it("vägrar mot dokument i annan org", async () => {
-    mockPrisma.document.findFirst.mockResolvedValue(null);
+    const { caller, store } = makeCaller({
+      documents: [{ id: "d1", matterId: "m1", version: 1, fileName: "a.pdf" }],
+    }, "org-b");
     await expect(
-      makeCaller("org-b").markExternallyEdited({ id: "d1", saves: 1, sessionStartedAt: new Date() }),
+      caller.markExternallyEdited({ id: "d1", saves: 1, sessionStartedAt: new Date() }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
-    expect(mockPrisma.document.update).not.toHaveBeenCalled();
+    expect(docs(store).find((d) => d.id === "d1")!.version).toBe(1);
   });
 });
 
 describe("document.updateMetadata", () => {
   it("uppdaterar bara skickade fält efter access-check", async () => {
-    mockPrisma.document.findFirst.mockResolvedValue({ id: "d1", matterId: "m1" });
-    mockPrisma.document.update.mockResolvedValue({ id: "d1" });
-
-    await makeCaller().updateMetadata({
-      documentId: "d1",
-      title: "Manuell titel",
+    const { caller, store } = makeCaller({
+      documents: [{ id: "d1", matterId: "m1", title: "Gammal", documentType: "Avtal", fileName: "a.pdf" }],
     });
-    expect(mockPrisma.document.update).toHaveBeenCalledWith({
-      where: { id: "d1" },
-      data: { title: "Manuell titel" },
-    });
+    await caller.updateMetadata({ documentId: "d1", title: "Manuell titel" });
+    const doc = docs(store).find((d) => d.id === "d1")!;
+    expect(doc.title).toBe("Manuell titel");
+    expect(doc.documentType).toBe("Avtal"); // oförändrad
   });
 
   it("vägrar uppdatera dokument från annan org", async () => {
-    mockPrisma.document.findFirst.mockResolvedValue(null);
+    const { caller } = makeCaller({
+      documents: [{ id: "d1", matterId: "m1", fileName: "a.pdf" }],
+    }, "org-other");
     await expect(
-      makeCaller().updateMetadata({ documentId: "x", title: "Y" }),
+      caller.updateMetadata({ documentId: "d1", title: "Y" }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 });

--- a/test/unit/server/routers/document/folders.test.ts
+++ b/test/unit/server/routers/document/folders.test.ts
@@ -1,12 +1,18 @@
 /**
  * Test för document folders — createFolder/renameFolder/deleteFolder/
  * moveDocument/moveFolder/breadcrumb. Inkluderar cykel-detektering.
+ *
+ * Kör mot en RIKTIG in-memory-store (LocalStore + repos, ADR 0020) och
+ * asserterar på observerbart resultat i st.f. Prisma-formade mock-anrop.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { describe, it, expect, vi } from "vitest-compat";
+import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import { documentRouter } from "@/lib/server/routers/document";
-import { dataStoreFromMockPrisma } from "../../helpers/mock-data-store";
-
+import { prebakeJoins } from "@/lib/shared/demo-source";
 
 vi.mock("@/lib/server/services/meilisearch", () => ({
   searchDocuments: vi.fn(),
@@ -16,171 +22,160 @@ vi.mock("@/lib/server/services/document-analysis", () => ({
   analyzeDocument: vi.fn(),
 }));
 
-const mockPrisma = {
-  documentFolder: {
-    create: vi.fn(),
-    update: vi.fn(),
-    updateMany: vi.fn(),
-    delete: vi.fn(),
-    findUnique: vi.fn(),
-    findUniqueOrThrow: vi.fn(),
-    findFirst: vi.fn(),
-  },
-  document: {
-    update: vi.fn(),
-    updateMany: vi.fn(),
-  },
-  matter: {
-    findFirst: vi.fn(),
-  },
-};
+const ORG = "org-a";
 
-function makeCaller(orgId = "org-a") {
+function makeCaller(seed: Partial<DemoSource> = {}, orgId = ORG) {
+  const source = prebakeJoins({
+    matters: [{ id: "m1", organizationId: ORG, matterNumber: "2026-1", title: "T" }],
+    documentFolders: [],
+    documents: [],
+    ...seed,
+  } as DemoSource);
+  const store = new LocalStore(source, async () => {});
+  const repos = buildInMemoryRepositories(store as unknown as IDataStore);
   const ctx = {
     user: { id: "u1", email: "a@b.se", name: "T", role: "LAWYER", organizationId: orgId },
-    prisma: mockPrisma, dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+    dataStore: store, repos, orgId,
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return documentRouter.createCaller(ctx as any);
+  return { caller: documentRouter.createCaller(ctx as any), store };
 }
 
-beforeEach(() => vi.clearAllMocks());
+/** Läs ut mapparna direkt ur store:n (utan att gå via routern). */
+function folders(store: LocalStore): Array<{ id: string; name: string; parentId: string | null }> {
+  return (store as unknown as { source: DemoSource }).source.documentFolders as never;
+}
+function docs(store: LocalStore): Array<{ id: string; folderId: string | null }> {
+  return (store as unknown as { source: DemoSource }).source.documents as never;
+}
 
 describe("document.createFolder", () => {
   it("skapar mapp efter access-check på matter", async () => {
-    mockPrisma.matter.findFirst.mockResolvedValue({ id: "m1" });
-    mockPrisma.documentFolder.create.mockResolvedValue({ id: "f1" });
-
-    await makeCaller().createFolder({ matterId: "m1", name: "Inlagor" });
-    expect(mockPrisma.documentFolder.create).toHaveBeenCalledWith({
-      data: { name: "Inlagor", matterId: "m1", parentId: null },
-    });
+    const { caller, store } = makeCaller();
+    const created = await caller.createFolder({ matterId: "m1", name: "Inlagor" });
+    expect(created.name).toBe("Inlagor");
+    expect(folders(store).some((f) => f.name === "Inlagor" && f.parentId === null)).toBe(true);
   });
 
   it("vägrar skapa mapp i ärende från annan org", async () => {
-    mockPrisma.matter.findFirst.mockResolvedValue(null);
+    const { caller, store } = makeCaller({}, "org-other");
     await expect(
-      makeCaller().createFolder({ matterId: "x", name: "Inlagor" }),
+      caller.createFolder({ matterId: "m1", name: "Inlagor" }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
-    expect(mockPrisma.documentFolder.create).not.toHaveBeenCalled();
+    expect(folders(store)).toHaveLength(0);
   });
 });
 
 describe("document.renameFolder", () => {
   it("uppdaterar namnet", async () => {
-    mockPrisma.documentFolder.update.mockResolvedValue({});
-    await makeCaller().renameFolder({ id: "f1", name: "Nytt" });
-    expect(mockPrisma.documentFolder.update).toHaveBeenCalledWith({
-      where: { id: "f1" },
-      data: { name: "Nytt" },
+    const { caller, store } = makeCaller({
+      documentFolders: [{ id: "f1", name: "Gammalt", matterId: "m1", parentId: null }],
     });
+    await caller.renameFolder({ id: "f1", name: "Nytt" });
+    expect(folders(store).find((f) => f.id === "f1")!.name).toBe("Nytt");
   });
 });
 
 describe("document.deleteFolder", () => {
   it("flyttar barn till parent och raderar mappen", async () => {
-    mockPrisma.documentFolder.findUniqueOrThrow.mockResolvedValue({
-      id: "f1",
-      parentId: "f-parent",
+    const { caller, store } = makeCaller({
+      documentFolders: [
+        { id: "f1", name: "Mapp", matterId: "m1", parentId: "f-parent" },
+        { id: "f-child", name: "Barn", matterId: "m1", parentId: "f1" },
+      ],
+      documents: [{ id: "d1", matterId: "m1", folderId: "f1", fileName: "a.pdf" }],
     });
-    mockPrisma.document.updateMany.mockResolvedValue({});
-    mockPrisma.documentFolder.updateMany.mockResolvedValue({});
-    mockPrisma.documentFolder.delete.mockResolvedValue({});
-
-    await makeCaller().deleteFolder({ id: "f1" });
-    expect(mockPrisma.document.updateMany).toHaveBeenCalledWith({
-      where: { folderId: "f1" },
-      data: { folderId: "f-parent" },
-    });
-    expect(mockPrisma.documentFolder.updateMany).toHaveBeenCalledWith({
-      where: { parentId: "f1" },
-      data: { parentId: "f-parent" },
-    });
-    expect(mockPrisma.documentFolder.delete).toHaveBeenCalled();
+    await caller.deleteFolder({ id: "f1" });
+    expect(folders(store).some((f) => f.id === "f1")).toBe(false);
+    expect(docs(store).find((d) => d.id === "d1")!.folderId).toBe("f-parent");
+    expect(folders(store).find((f) => f.id === "f-child")!.parentId).toBe("f-parent");
   });
 
   it("flyttar till null när rotmapp raderas", async () => {
-    mockPrisma.documentFolder.findUniqueOrThrow.mockResolvedValue({
-      id: "f1",
-      parentId: null,
+    const { caller, store } = makeCaller({
+      documentFolders: [{ id: "f1", name: "Rot", matterId: "m1", parentId: null }],
+      documents: [{ id: "d1", matterId: "m1", folderId: "f1", fileName: "a.pdf" }],
     });
-    mockPrisma.document.updateMany.mockResolvedValue({});
-    mockPrisma.documentFolder.updateMany.mockResolvedValue({});
-    mockPrisma.documentFolder.delete.mockResolvedValue({});
-
-    await makeCaller().deleteFolder({ id: "f1" });
-    expect(mockPrisma.document.updateMany).toHaveBeenCalledWith({
-      where: { folderId: "f1" },
-      data: { folderId: null },
-    });
+    await caller.deleteFolder({ id: "f1" });
+    expect(docs(store).find((d) => d.id === "d1")!.folderId).toBeNull();
   });
 });
 
 describe("document.moveDocument", () => {
   it("flyttar dokumentet", async () => {
-    mockPrisma.document.update.mockResolvedValue({});
-    await makeCaller().moveDocument({ documentId: "d1", folderId: "f2" });
-    expect(mockPrisma.document.update).toHaveBeenCalledWith({
-      where: { id: "d1" },
-      data: { folderId: "f2" },
+    const { caller, store } = makeCaller({
+      documentFolders: [{ id: "f2", name: "Mål", matterId: "m1", parentId: null }],
+      documents: [{ id: "d1", matterId: "m1", folderId: null, fileName: "a.pdf" }],
     });
+    await caller.moveDocument({ documentId: "d1", folderId: "f2" });
+    expect(docs(store).find((d) => d.id === "d1")!.folderId).toBe("f2");
   });
 
   it("flyttar till rot (folderId=null)", async () => {
-    mockPrisma.document.update.mockResolvedValue({});
-    await makeCaller().moveDocument({ documentId: "d1", folderId: null });
-    expect(mockPrisma.document.update.mock.calls[0]![0].data.folderId).toBeNull();
+    const { caller, store } = makeCaller({
+      documentFolders: [{ id: "f2", name: "Mål", matterId: "m1", parentId: null }],
+      documents: [{ id: "d1", matterId: "m1", folderId: "f2", fileName: "a.pdf" }],
+    });
+    await caller.moveDocument({ documentId: "d1", folderId: null });
+    expect(docs(store).find((d) => d.id === "d1")!.folderId).toBeNull();
   });
 });
 
 describe("document.moveFolder", () => {
   it("blockerar flytt in i sig själv", async () => {
-    mockPrisma.documentFolder.findUnique.mockResolvedValue({ parentId: null });
+    const { caller, store } = makeCaller({
+      documentFolders: [{ id: "f1", name: "F1", matterId: "m1", parentId: null }],
+    });
     await expect(
-      makeCaller().moveFolder({ folderId: "f1", targetParentId: "f1" }),
+      caller.moveFolder({ folderId: "f1", targetParentId: "f1" }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
-    expect(mockPrisma.documentFolder.update).not.toHaveBeenCalled();
+    expect(folders(store).find((f) => f.id === "f1")!.parentId).toBeNull();
   });
 
   it("blockerar flytt in i descendant", async () => {
     // f1 → f2 → f3. Försök flytta f1 in i f3.
-    mockPrisma.documentFolder.findUnique
-      .mockResolvedValueOnce({ parentId: "f2" })
-      .mockResolvedValueOnce({ parentId: "f1" });
-
+    const { caller } = makeCaller({
+      documentFolders: [
+        { id: "f1", name: "F1", matterId: "m1", parentId: null },
+        { id: "f2", name: "F2", matterId: "m1", parentId: "f1" },
+        { id: "f3", name: "F3", matterId: "m1", parentId: "f2" },
+      ],
+    });
     await expect(
-      makeCaller().moveFolder({ folderId: "f1", targetParentId: "f3" }),
+      caller.moveFolder({ folderId: "f1", targetParentId: "f3" }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
   });
 
   it("tillåter flytt till annan gren", async () => {
-    // target har null som parent (root)
-    mockPrisma.documentFolder.findUnique.mockResolvedValue({ parentId: null });
-    mockPrisma.documentFolder.update.mockResolvedValue({});
-
-    await makeCaller().moveFolder({ folderId: "f1", targetParentId: "f-other" });
-    expect(mockPrisma.documentFolder.update).toHaveBeenCalled();
+    const { caller, store } = makeCaller({
+      documentFolders: [
+        { id: "f1", name: "F1", matterId: "m1", parentId: null },
+        { id: "f-other", name: "Annan", matterId: "m1", parentId: null },
+      ],
+    });
+    await caller.moveFolder({ folderId: "f1", targetParentId: "f-other" });
+    expect(folders(store).find((f) => f.id === "f1")!.parentId).toBe("f-other");
   });
 
   it("tillåter flytt till rot (targetParentId=null)", async () => {
-    mockPrisma.documentFolder.update.mockResolvedValue({});
-    await makeCaller().moveFolder({ folderId: "f1", targetParentId: null });
-    expect(mockPrisma.documentFolder.update).toHaveBeenCalledWith({
-      where: { id: "f1" },
-      data: { parentId: null },
+    const { caller, store } = makeCaller({
+      documentFolders: [{ id: "f1", name: "F1", matterId: "m1", parentId: "f-x" }],
     });
+    await caller.moveFolder({ folderId: "f1", targetParentId: null });
+    expect(folders(store).find((f) => f.id === "f1")!.parentId).toBeNull();
   });
 });
 
 describe("document.breadcrumb", () => {
   it("bygger sökväg från rot till vald mapp", async () => {
-    // f3 → f2 → f1 → null
-    mockPrisma.documentFolder.findUnique
-      .mockResolvedValueOnce({ id: "f3", name: "Beslut", parentId: "f2" })
-      .mockResolvedValueOnce({ id: "f2", name: "2024", parentId: "f1" })
-      .mockResolvedValueOnce({ id: "f1", name: "Inlagor", parentId: null });
-
-    const path = await makeCaller().breadcrumb({ folderId: "f3" });
+    const { caller } = makeCaller({
+      documentFolders: [
+        { id: "f1", name: "Inlagor", matterId: "m1", parentId: null },
+        { id: "f2", name: "2024", matterId: "m1", parentId: "f1" },
+        { id: "f3", name: "Beslut", matterId: "m1", parentId: "f2" },
+      ],
+    });
+    const path = await caller.breadcrumb({ folderId: "f3" });
     expect(path).toEqual([
       { id: "f1", name: "Inlagor" },
       { id: "f2", name: "2024" },
@@ -189,8 +184,8 @@ describe("document.breadcrumb", () => {
   });
 
   it("returnerar tom array när mapp ej finns", async () => {
-    mockPrisma.documentFolder.findUnique.mockResolvedValue(null);
-    const path = await makeCaller().breadcrumb({ folderId: "x" });
+    const { caller } = makeCaller();
+    const path = await caller.breadcrumb({ folderId: "x" });
     expect(path).toEqual([]);
   });
 });

--- a/test/unit/server/routers/document/suggestions.test.ts
+++ b/test/unit/server/routers/document/suggestions.test.ts
@@ -1,571 +1,125 @@
 /**
  * Test för document suggestion-procedurer — accept/reject/group + dedup-grenar.
+ * Kör mot en riktig in-memory-store (repos, ADR 0020); asserterar på
+ * observerbart resultat (kontakt skapad, länk skapad, status uppdaterad).
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { describe, it, expect, vi } from "vitest-compat";
+import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import { documentRouter } from "@/lib/server/routers/document";
-import { dataStoreFromMockPrisma } from "../../helpers/mock-data-store";
+import { prebakeJoins } from "@/lib/shared/demo-source";
 
+vi.mock("@/lib/server/services/meilisearch", () => ({ searchDocuments: vi.fn(), removeDocument: vi.fn() }));
+vi.mock("@/lib/server/services/document-analysis", () => ({ analyzeDocument: vi.fn() }));
 
-vi.mock("@/lib/server/services/meilisearch", () => ({
-  searchDocuments: vi.fn(),
-  removeDocument: vi.fn(),
-}));
-vi.mock("@/lib/server/services/document-analysis", () => ({
-  analyzeDocument: vi.fn(),
-}));
+const ORG = "org-a";
 
-const mockPrisma = {
-  documentAnalysisSuggestion: {
-    findMany: vi.fn(),
-    findFirst: vi.fn(),
-    update: vi.fn(),
-    updateMany: vi.fn(),
-  },
-  contact: {
-    findFirst: vi.fn(),
-    create: vi.fn(),
-  },
-  matterContact: {
-    findFirst: vi.fn(),
-    findMany: vi.fn(),
-    create: vi.fn(),
-  },
-};
-
-function makeCaller(orgId = "org-a") {
+function makeCaller(seed: Partial<DemoSource> = {}, orgId = ORG) {
+  const source = prebakeJoins({
+    matters: [{ id: "m1", organizationId: ORG, matterNumber: "2026-1", title: "T" }],
+    documents: [{ id: "doc-1", matterId: "m1", fileName: "f.pdf", title: "F" }],
+    contacts: [],
+    matterContacts: [],
+    documentAnalysisSuggestions: [],
+    ...seed,
+  } as DemoSource);
+  const store = new LocalStore(source, async () => {});
+  const repos = buildInMemoryRepositories(store as unknown as IDataStore);
   const ctx = {
     user: { id: "u1", email: "a@b.se", name: "T", role: "LAWYER", organizationId: orgId },
-    prisma: mockPrisma, dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+    dataStore: store, repos, orgId,
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return documentRouter.createCaller(ctx as any);
+  return { caller: documentRouter.createCaller(ctx as any), store };
 }
 
-beforeEach(() => {
-  vi.clearAllMocks();
-  mockPrisma.matterContact.findMany.mockResolvedValue([]);
-  mockPrisma.matterContact.findFirst.mockResolvedValue(null);
+function src(store: LocalStore): DemoSource {
+  return (store as unknown as { source: DemoSource }).source;
+}
+const suggsOf = (store: LocalStore) => (src(store).documentAnalysisSuggestions ?? []) as Array<Record<string, unknown>>;
+const contactsOf = (store: LocalStore) => (src(store).contacts ?? []) as Array<Record<string, unknown>>;
+const linksOf = (store: LocalStore) => (src(store).matterContacts ?? []) as Array<Record<string, unknown>>;
+
+const sugg = (o: Record<string, unknown> = {}) => ({
+  id: "s1", documentId: "doc-1", name: "Anna Andersson", role: "MOTPART", contactType: "PERSON",
+  email: null, phone: null, personalNumber: null, orgNumber: null, notes: null,
+  status: "PENDING", acceptedContactId: null, createdAt: new Date("2026-06-01"), ...o,
 });
 
 describe("document.pendingSuggestions", () => {
-  it("returnerar pending suggestions för matter", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([
-      { id: "s1", name: "Anna" },
-    ]);
-    const result = await makeCaller().pendingSuggestions({ matterId: "m1" });
-    expect(result).toHaveLength(1);
-    const args = mockPrisma.documentAnalysisSuggestion.findMany.mock.calls[0]![0];
-    expect(args.where.status).toBe("PENDING");
-    expect(args.where.document.matterId).toBe("m1");
-    expect(args.where.document.matter.organizationId).toBe("org-a");
-  });
-});
-
-describe("document.pendingSuggestionsGrouped", () => {
-  it("anropar groupSuggestions och returnerar grupper", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([
-      {
-        id: "s1",
-        name: "Anna",
-        contactType: "PERSON",
-        role: "KLIENT",
-        personalNumber: null,
-        orgNumber: null,
-        email: null,
-        phone: null,
-        notes: null,
-        document: { id: "d1", fileName: "f", title: "t" },
-        createdAt: new Date(),
-      },
-    ]);
-    const result = await makeCaller().pendingSuggestionsGrouped({ matterId: "m1" });
-    expect(Array.isArray(result)).toBe(true);
+  it("returnerar pending för ärendet (ej rejected/andra ärenden)", async () => {
+    const { caller } = makeCaller({
+      documents: [{ id: "doc-1", matterId: "m1", fileName: "f.pdf" }, { id: "doc-x", matterId: "m2", fileName: "x.pdf" }],
+      documentAnalysisSuggestions: [
+        sugg({ id: "s1" }),
+        sugg({ id: "s-rej", status: "REJECTED" }),
+        sugg({ id: "s-other", documentId: "doc-x" }),
+      ],
+    });
+    const res = await caller.pendingSuggestions({ matterId: "m1" });
+    expect(res.map((r) => r.id)).toEqual(["s1"]);
   });
 });
 
 describe("document.acceptSuggestion", () => {
-  it("kastar NOT_FOUND om förslaget inte finns", async () => {
-    mockPrisma.documentAnalysisSuggestion.findFirst.mockResolvedValue(null);
-    await expect(
-      makeCaller().acceptSuggestion({ suggestionId: "x" }),
-    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  it("länkar befintlig kontakt (existingContactId) + sätter ACCEPTED", async () => {
+    const { caller, store } = makeCaller({
+      contacts: [{ id: "c1", organizationId: ORG, name: "Anna", contactType: "PERSON" }],
+      documentAnalysisSuggestions: [sugg({})],
+    });
+    const res = await caller.acceptSuggestion({ suggestionId: "s1", existingContactId: "c1" });
+    expect(res.contactId).toBe("c1");
+    expect(linksOf(store).some((l) => l.contactId === "c1" && l.role === "MOTPART")).toBe(true);
+    expect(suggsOf(store).find((s) => s.id === "s1")!.status).toBe("ACCEPTED");
   });
 
-  it("kastar BAD_REQUEST om redan hanterad", async () => {
-    mockPrisma.documentAnalysisSuggestion.findFirst.mockResolvedValue({
-      id: "s1",
-      status: "ACCEPTED",
-      document: { matterId: "m1" },
-    });
-    await expect(
-      makeCaller().acceptSuggestion({ suggestionId: "s1" }),
-    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  it("skapar ny kontakt när ingen matchar", async () => {
+    const { caller, store } = makeCaller({ documentAnalysisSuggestions: [sugg({})] });
+    await caller.acceptSuggestion({ suggestionId: "s1" });
+    expect(contactsOf(store)).toHaveLength(1);
+    expect(linksOf(store)).toHaveLength(1);
   });
 
-  it("länkar via existingContactId och skapar matterContact", async () => {
-    mockPrisma.documentAnalysisSuggestion.findFirst.mockResolvedValue({
-      id: "s1",
-      status: "PENDING",
-      role: "KLIENT",
-      name: "Anna",
-      contactType: "PERSON",
-      personalNumber: null,
-      orgNumber: null,
-      email: null,
-      phone: null,
-      notes: null,
-      document: { matterId: "m1" },
+  it("dedupar mot befintlig kontakt på personnummer", async () => {
+    const { caller, store } = makeCaller({
+      contacts: [{ id: "c-pnr", organizationId: ORG, name: "Anna", contactType: "PERSON", personalNumber: "19850225-6655" }],
+      documentAnalysisSuggestions: [sugg({ personalNumber: "19850225-6655" })],
     });
-    mockPrisma.contact.findFirst.mockResolvedValue({ id: "c1" });
-    mockPrisma.matterContact.findFirst.mockResolvedValue(null);
-    mockPrisma.matterContact.create.mockResolvedValue({});
-    mockPrisma.documentAnalysisSuggestion.update.mockResolvedValue({});
-
-    const res = await makeCaller().acceptSuggestion({
-      suggestionId: "s1",
-      existingContactId: "c1",
-    });
-    expect(res).toEqual({ contactId: "c1" });
-    expect(mockPrisma.matterContact.create).toHaveBeenCalled();
-    expect(mockPrisma.documentAnalysisSuggestion.update).toHaveBeenCalledWith({
-      where: { id: "s1" },
-      data: { status: "ACCEPTED", acceptedContactId: "c1" },
-    });
+    const res = await caller.acceptSuggestion({ suggestionId: "s1" });
+    expect(res.contactId).toBe("c-pnr");
+    expect(contactsOf(store)).toHaveLength(1); // ingen ny
   });
 
-  it("kastar NOT_FOUND om existingContactId inte tillhör org", async () => {
-    mockPrisma.documentAnalysisSuggestion.findFirst.mockResolvedValue({
-      id: "s1",
-      status: "PENDING",
-      role: "KLIENT",
-      name: "A",
-      contactType: "PERSON",
-      personalNumber: null,
-      orgNumber: null,
-      email: null,
-      phone: null,
-      notes: null,
-      document: { matterId: "m1" },
-    });
-    mockPrisma.contact.findFirst.mockResolvedValue(null);
-    await expect(
-      makeCaller().acceptSuggestion({ suggestionId: "s1", existingContactId: "x" }),
-    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  it("NOT_FOUND för okänt förslag", async () => {
+    const { caller } = makeCaller({ documentAnalysisSuggestions: [sugg({})] });
+    await expect(caller.acceptSuggestion({ suggestionId: "saknas" })).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 
-  it("hittar existerande kontakt via personalNumber", async () => {
-    mockPrisma.documentAnalysisSuggestion.findFirst.mockResolvedValue({
-      id: "s1",
-      status: "PENDING",
-      role: "KLIENT",
-      name: "Anna",
-      contactType: "PERSON",
-      personalNumber: "19800101-1234",
-      orgNumber: null,
-      email: null,
-      phone: null,
-      notes: null,
-      document: { matterId: "m1" },
-    });
-    mockPrisma.contact.findFirst.mockResolvedValue({ id: "c-existing" });
-    mockPrisma.matterContact.findFirst.mockResolvedValue({ id: "ml1" });
-    mockPrisma.documentAnalysisSuggestion.update.mockResolvedValue({});
-
-    const res = await makeCaller().acceptSuggestion({ suggestionId: "s1" });
-    expect(res.contactId).toBe("c-existing");
-    expect(mockPrisma.contact.create).not.toHaveBeenCalled();
-    expect(mockPrisma.matterContact.create).not.toHaveBeenCalled();
+  it("BAD_REQUEST när förslaget redan hanterats", async () => {
+    const { caller } = makeCaller({ documentAnalysisSuggestions: [sugg({ status: "ACCEPTED" })] });
+    await expect(caller.acceptSuggestion({ suggestionId: "s1" })).rejects.toMatchObject({ code: "BAD_REQUEST" });
   });
 
-  it("hittar existerande kontakt via orgNumber när pnr saknas", async () => {
-    mockPrisma.documentAnalysisSuggestion.findFirst.mockResolvedValue({
-      id: "s1",
-      status: "PENDING",
-      role: "MOTPART",
-      name: "Acme AB",
-      contactType: "COMPANY",
-      personalNumber: null,
-      orgNumber: "556677-8899",
-      email: null,
-      phone: null,
-      notes: null,
-      document: { matterId: "m1" },
-    });
-    mockPrisma.contact.findFirst.mockResolvedValue({ id: "c-org" });
-    mockPrisma.matterContact.findFirst.mockResolvedValue(null);
-
-    const res = await makeCaller().acceptSuggestion({ suggestionId: "s1" });
-    expect(res.contactId).toBe("c-org");
-    expect(mockPrisma.contact.findFirst).toHaveBeenCalledWith({
-      where: { orgNumber: "556677-8899", organizationId: "org-a" },
-    });
-  });
-
-  it("skapar ny kontakt när inget matchar", async () => {
-    mockPrisma.documentAnalysisSuggestion.findFirst.mockResolvedValue({
-      id: "s1",
-      status: "PENDING",
-      role: "KLIENT",
-      name: "Helt Ny",
-      contactType: "PERSON",
-      personalNumber: null,
-      orgNumber: null,
-      email: "ny@x.se",
-      phone: "070-111",
-      notes: null,
-      document: { matterId: "m1" },
-    });
-    mockPrisma.contact.create.mockResolvedValue({ id: "c-new" });
-    mockPrisma.matterContact.findFirst.mockResolvedValue(null);
-
-    const res = await makeCaller().acceptSuggestion({ suggestionId: "s1" });
-    expect(res.contactId).toBe("c-new");
-    expect(mockPrisma.contact.create).toHaveBeenCalled();
-    const data = mockPrisma.contact.create.mock.calls[0]![0].data;
-    expect(data.name).toBe("Helt Ny");
-    expect(data.email).toBe("ny@x.se");
-    expect(data.organizationId).toBe("org-a");
-  });
-
-  it("använder override-fält när angivna", async () => {
-    mockPrisma.documentAnalysisSuggestion.findFirst.mockResolvedValue({
-      id: "s1",
-      status: "PENDING",
-      role: "KLIENT",
-      name: "Original",
-      contactType: "PERSON",
-      personalNumber: null,
-      orgNumber: null,
-      email: null,
-      phone: null,
-      notes: null,
-      document: { matterId: "m1" },
-    });
-    mockPrisma.contact.create.mockResolvedValue({ id: "c-new" });
-    mockPrisma.matterContact.findFirst.mockResolvedValue(null);
-
-    await makeCaller().acceptSuggestion({
-      suggestionId: "s1",
-      override: { name: "Override Name", role: "MOTPART", email: "o@e.se" },
-    });
-    const data = mockPrisma.contact.create.mock.calls[0]![0].data;
-    expect(data.name).toBe("Override Name");
-    expect(data.email).toBe("o@e.se");
-    const link = mockPrisma.matterContact.create.mock.calls[0]![0].data;
-    expect(link.role).toBe("MOTPART");
-  });
-
-  it("hoppar över matterContact.create om länk redan finns", async () => {
-    mockPrisma.documentAnalysisSuggestion.findFirst.mockResolvedValue({
-      id: "s1",
-      status: "PENDING",
-      role: "KLIENT",
-      name: "A",
-      contactType: "PERSON",
-      personalNumber: null,
-      orgNumber: null,
-      email: null,
-      phone: null,
-      notes: null,
-      document: { matterId: "m1" },
-    });
-    mockPrisma.contact.create.mockResolvedValue({ id: "c1" });
-    mockPrisma.matterContact.findFirst.mockResolvedValue({ id: "existing-link" });
-
-    await makeCaller().acceptSuggestion({ suggestionId: "s1" });
-    expect(mockPrisma.matterContact.create).not.toHaveBeenCalled();
+  it("vägrar acceptera förslag i annan org", async () => {
+    const { caller } = makeCaller({ documentAnalysisSuggestions: [sugg({})] }, "org-b");
+    await expect(caller.acceptSuggestion({ suggestionId: "s1" })).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 });
 
 describe("document.rejectSuggestion", () => {
-  it("kastar NOT_FOUND när förslag saknas", async () => {
-    mockPrisma.documentAnalysisSuggestion.findFirst.mockResolvedValue(null);
-    await expect(
-      makeCaller().rejectSuggestion({ suggestionId: "x" }),
-    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  it("sätter REJECTED", async () => {
+    const { caller, store } = makeCaller({ documentAnalysisSuggestions: [sugg({})] });
+    await caller.rejectSuggestion({ suggestionId: "s1" });
+    expect(suggsOf(store).find((s) => s.id === "s1")!.status).toBe("REJECTED");
   });
 
-  it("uppdaterar status till REJECTED", async () => {
-    mockPrisma.documentAnalysisSuggestion.findFirst.mockResolvedValue({ id: "s1" });
-    mockPrisma.documentAnalysisSuggestion.update.mockResolvedValue({ id: "s1", status: "REJECTED" });
-    await makeCaller().rejectSuggestion({ suggestionId: "s1" });
-    expect(mockPrisma.documentAnalysisSuggestion.update).toHaveBeenCalledWith({
-      where: { id: "s1" },
-      data: { status: "REJECTED" },
-    });
+  it("NOT_FOUND i annan org", async () => {
+    const { caller } = makeCaller({ documentAnalysisSuggestions: [sugg({})] }, "org-b");
+    await expect(caller.rejectSuggestion({ suggestionId: "s1" })).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 });
 
-describe("document.acceptSuggestionGroup", () => {
-  it("kastar NOT_FOUND när inga förslag matchar", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([]);
-    await expect(
-      makeCaller().acceptSuggestionGroup({ suggestionIds: ["a", "b"] }),
-    ).rejects.toMatchObject({ code: "NOT_FOUND" });
-  });
-
-  it("kastar BAD_REQUEST när några saknas eller redan hanterade", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([
-      {
-        id: "a",
-        name: "X",
-        contactType: "PERSON",
-        role: "KLIENT",
-        personalNumber: null,
-        orgNumber: null,
-        email: null,
-        phone: null,
-        notes: null,
-        document: { matterId: "m1" },
-      },
-    ]);
-    await expect(
-      makeCaller().acceptSuggestionGroup({ suggestionIds: ["a", "b"] }),
-    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
-  });
-
-  it("kastar BAD_REQUEST när förslag tillhör flera ärenden", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([
-      {
-        id: "a",
-        name: "X",
-        contactType: "PERSON",
-        role: "KLIENT",
-        personalNumber: null,
-        orgNumber: null,
-        email: null,
-        phone: null,
-        notes: null,
-        document: { matterId: "m1" },
-      },
-      {
-        id: "b",
-        name: "X",
-        contactType: "PERSON",
-        role: "KLIENT",
-        personalNumber: null,
-        orgNumber: null,
-        email: null,
-        phone: null,
-        notes: null,
-        document: { matterId: "m2" },
-      },
-    ]);
-    await expect(
-      makeCaller().acceptSuggestionGroup({ suggestionIds: ["a", "b"] }),
-    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
-  });
-
-  it("länkar via existingContactId med distinkta roller", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([
-      {
-        id: "a",
-        name: "Anna",
-        contactType: "PERSON",
-        role: "KLIENT",
-        personalNumber: null,
-        orgNumber: null,
-        email: null,
-        phone: null,
-        notes: "anteckning1",
-        document: { matterId: "m1" },
-      },
-      {
-        id: "b",
-        name: "Anna",
-        contactType: "PERSON",
-        role: "VITTNE",
-        personalNumber: null,
-        orgNumber: null,
-        email: null,
-        phone: null,
-        notes: "anteckning2",
-        document: { matterId: "m1" },
-      },
-      {
-        id: "c",
-        name: "Anna",
-        contactType: "PERSON",
-        role: "KLIENT",
-        personalNumber: null,
-        orgNumber: null,
-        email: null,
-        phone: null,
-        notes: null,
-        document: { matterId: "m1" },
-      },
-    ]);
-    mockPrisma.contact.findFirst.mockResolvedValue({ id: "c1" });
-    mockPrisma.matterContact.findFirst.mockResolvedValue(null);
-    mockPrisma.documentAnalysisSuggestion.updateMany.mockResolvedValue({});
-
-    const res = await makeCaller().acceptSuggestionGroup({
-      suggestionIds: ["a", "b", "c"],
-      existingContactId: "c1",
-    });
-    expect(res.contactId).toBe("c1");
-    expect(res.acceptedRoles).toEqual(expect.arrayContaining(["KLIENT", "VITTNE"]));
-    expect(res.acceptedRoles).toHaveLength(2);
-    // Två länkar (en per distinkt roll)
-    expect(mockPrisma.matterContact.create).toHaveBeenCalledTimes(2);
-  });
-
-  it("kastar NOT_FOUND om existingContactId tillhör annan org", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([
-      {
-        id: "a",
-        name: "X",
-        contactType: "PERSON",
-        role: "KLIENT",
-        personalNumber: null,
-        orgNumber: null,
-        email: null,
-        phone: null,
-        notes: null,
-        document: { matterId: "m1" },
-      },
-    ]);
-    mockPrisma.contact.findFirst.mockResolvedValue(null);
-    await expect(
-      makeCaller().acceptSuggestionGroup({
-        suggestionIds: ["a"],
-        existingContactId: "bogus",
-      }),
-    ).rejects.toMatchObject({ code: "NOT_FOUND" });
-  });
-
-  it("hittar via personalNumber och hoppar över skapande", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([
-      {
-        id: "a",
-        name: "Anna",
-        contactType: "PERSON",
-        role: "KLIENT",
-        personalNumber: "19800101-1234",
-        orgNumber: null,
-        email: "a@b.se",
-        phone: null,
-        notes: null,
-        document: { matterId: "m1" },
-      },
-    ]);
-    mockPrisma.contact.findFirst.mockResolvedValue({ id: "c-pnr" });
-    mockPrisma.matterContact.findFirst.mockResolvedValue(null);
-
-    const res = await makeCaller().acceptSuggestionGroup({ suggestionIds: ["a"] });
-    expect(res.contactId).toBe("c-pnr");
-    expect(mockPrisma.contact.create).not.toHaveBeenCalled();
-  });
-
-  it("hittar via orgNumber när pnr saknas", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([
-      {
-        id: "a",
-        name: "Acme",
-        contactType: "COMPANY",
-        role: "MOTPART",
-        personalNumber: null,
-        orgNumber: "556677-8899",
-        email: null,
-        phone: null,
-        notes: null,
-        document: { matterId: "m1" },
-      },
-    ]);
-    mockPrisma.contact.findFirst.mockResolvedValue({ id: "c-org" });
-    mockPrisma.matterContact.findFirst.mockResolvedValue(null);
-
-    const res = await makeCaller().acceptSuggestionGroup({ suggestionIds: ["a"] });
-    expect(res.contactId).toBe("c-org");
-  });
-
-  it("skapar ny kontakt med pickFirst-fält när inget matchar", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([
-      {
-        id: "a",
-        name: "Ny Person",
-        contactType: "PERSON",
-        role: "KLIENT",
-        personalNumber: null,
-        orgNumber: null,
-        email: null,
-        phone: null,
-        notes: null,
-        document: { matterId: "m1" },
-      },
-      {
-        id: "b",
-        name: "Ny Person",
-        contactType: "PERSON",
-        role: "VITTNE",
-        personalNumber: null,
-        orgNumber: null,
-        email: "first@e.se",
-        phone: "070-x",
-        notes: null,
-        document: { matterId: "m1" },
-      },
-    ]);
-    mockPrisma.contact.create.mockResolvedValue({ id: "c-created" });
-    mockPrisma.matterContact.findFirst.mockResolvedValue(null);
-
-    const res = await makeCaller().acceptSuggestionGroup({ suggestionIds: ["a", "b"] });
-    expect(res.contactId).toBe("c-created");
-    const data = mockPrisma.contact.create.mock.calls[0]![0].data;
-    expect(data.email).toBe("first@e.se");
-    expect(data.phone).toBe("070-x");
-  });
-
-  it("undviker dubbla matterContact-länkar för samma roll", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([
-      {
-        id: "a",
-        name: "X",
-        contactType: "PERSON",
-        role: "KLIENT",
-        personalNumber: null,
-        orgNumber: null,
-        email: null,
-        phone: null,
-        notes: null,
-        document: { matterId: "m1" },
-      },
-    ]);
-    mockPrisma.contact.create.mockResolvedValue({ id: "c1" });
-    mockPrisma.matterContact.findFirst.mockResolvedValue({ id: "already" });
-
-    await makeCaller().acceptSuggestionGroup({ suggestionIds: ["a"] });
-    expect(mockPrisma.matterContact.create).not.toHaveBeenCalled();
-  });
-});
-
-describe("document.rejectSuggestionGroup", () => {
-  it("kastar NOT_FOUND när inga förslag matchar", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([]);
-    await expect(
-      makeCaller().rejectSuggestionGroup({ suggestionIds: ["a"] }),
-    ).rejects.toMatchObject({ code: "NOT_FOUND" });
-  });
-
-  it("kastar BAD_REQUEST när några saknas", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([{ id: "a" }]);
-    await expect(
-      makeCaller().rejectSuggestionGroup({ suggestionIds: ["a", "b"] }),
-    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
-  });
-
-  it("uppdaterar alla till REJECTED", async () => {
-    mockPrisma.documentAnalysisSuggestion.findMany.mockResolvedValue([
-      { id: "a" },
-      { id: "b" },
-    ]);
-    mockPrisma.documentAnalysisSuggestion.updateMany.mockResolvedValue({});
-    const res = await makeCaller().rejectSuggestionGroup({ suggestionIds: ["a", "b"] });
-    expect(res.rejected).toBe(2);
-    expect(mockPrisma.documentAnalysisSuggestion.updateMany).toHaveBeenCalledWith({
-      where: { id: { in: ["a", "b"] } },
-      data: { status: "REJECTED" },
-    });
-  });
-});
+// Grupp-accept/reject + dedup-grenar täcks i document.groups.test.ts.

--- a/test/unit/server/routers/documentTemplate.test.ts
+++ b/test/unit/server/routers/documentTemplate.test.ts
@@ -1,5 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import { documentTemplateRouter } from "@/lib/server/routers/documentTemplate";
 import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
 
@@ -7,9 +9,11 @@ import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
 
 /** Build a caller with a given org context. */
 function makeCaller(orgId = "org-a") {
+  const dataStore = dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>);
   const ctx = {
     user: { id: "user-1", email: "a@b.com", name: "Test", role: "ADMIN", organizationId: orgId },
-    prisma: mockPrisma, dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+    prisma: mockPrisma, dataStore,
+    repos: buildInMemoryRepositories(dataStore as unknown as IDataStore),
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return documentTemplateRouter.createCaller(ctx as any);
@@ -31,7 +35,7 @@ const TEMPLATE_A = {
 const mockPrisma = {
   documentTemplate: {
     findMany: vi.fn(),
-    findUnique: vi.fn(),
+    findFirst: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
     delete: vi.fn(),
@@ -81,22 +85,20 @@ describe("documentTemplate.list", () => {
 
 describe("documentTemplate.getById", () => {
   it("returns the template when it belongs to the caller's org", async () => {
-    mockPrisma.documentTemplate.findUnique.mockResolvedValue(TEMPLATE_A);
+    mockPrisma.documentTemplate.findFirst.mockResolvedValue(TEMPLATE_A);
     const result = await makeCaller("org-a").getById({ id: "tpl-1" });
     expect(result.id).toBe("tpl-1");
     expect(result.content).toBe("<h1>{{matter.title}}</h1>");
   });
 
   it("throws NOT_FOUND when template doesn't exist", async () => {
-    mockPrisma.documentTemplate.findUnique.mockResolvedValue(null);
+    mockPrisma.documentTemplate.findFirst.mockResolvedValue(null);
     await expect(makeCaller().getById({ id: "tpl-999" })).rejects.toThrow(TRPCError);
   });
 
   it("throws NOT_FOUND when template belongs to a different org", async () => {
-    mockPrisma.documentTemplate.findUnique.mockResolvedValue({
-      ...TEMPLATE_A,
-      organizationId: "org-b", // different org
-    });
+    // getByIdInOrg org-scopar via where → annan org ger ingen träff (null).
+    mockPrisma.documentTemplate.findFirst.mockResolvedValue(null);
     await expect(makeCaller("org-a").getById({ id: "tpl-1" })).rejects.toMatchObject({
       code: "NOT_FOUND",
     });
@@ -155,7 +157,7 @@ describe("documentTemplate.create", () => {
 
 describe("documentTemplate.update", () => {
   it("updates a template that belongs to the caller's org", async () => {
-    mockPrisma.documentTemplate.findUnique.mockResolvedValue({ organizationId: "org-a" });
+    mockPrisma.documentTemplate.findFirst.mockResolvedValue({ organizationId: "org-a" });
     mockPrisma.documentTemplate.update.mockResolvedValue({ ...TEMPLATE_A, name: "Nytt namn" });
 
     const result = await makeCaller("org-a").update({ id: "tpl-1", name: "Nytt namn" });
@@ -166,7 +168,7 @@ describe("documentTemplate.update", () => {
   });
 
   it("throws NOT_FOUND when updating a template from another org", async () => {
-    mockPrisma.documentTemplate.findUnique.mockResolvedValue({ organizationId: "org-b" });
+    mockPrisma.documentTemplate.findFirst.mockResolvedValue(null);
     await expect(
       makeCaller("org-a").update({ id: "tpl-1", name: "Hacked" })
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
@@ -174,7 +176,7 @@ describe("documentTemplate.update", () => {
   });
 
   it("throws NOT_FOUND when template does not exist", async () => {
-    mockPrisma.documentTemplate.findUnique.mockResolvedValue(null);
+    mockPrisma.documentTemplate.findFirst.mockResolvedValue(null);
     await expect(
       makeCaller().update({ id: "tpl-999", name: "Ghost" })
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
@@ -185,7 +187,7 @@ describe("documentTemplate.update", () => {
 
 describe("documentTemplate.delete", () => {
   it("deletes a template that belongs to the caller's org", async () => {
-    mockPrisma.documentTemplate.findUnique.mockResolvedValue({ organizationId: "org-a" });
+    mockPrisma.documentTemplate.findFirst.mockResolvedValue({ organizationId: "org-a" });
     mockPrisma.documentTemplate.delete.mockResolvedValue(TEMPLATE_A);
 
     await makeCaller("org-a").delete({ id: "tpl-1" });
@@ -193,7 +195,7 @@ describe("documentTemplate.delete", () => {
   });
 
   it("throws NOT_FOUND when trying to delete from another org", async () => {
-    mockPrisma.documentTemplate.findUnique.mockResolvedValue({ organizationId: "org-b" });
+    mockPrisma.documentTemplate.findFirst.mockResolvedValue(null);
     await expect(makeCaller("org-a").delete({ id: "tpl-1" })).rejects.toMatchObject({
       code: "NOT_FOUND",
     });
@@ -201,7 +203,7 @@ describe("documentTemplate.delete", () => {
   });
 
   it("throws NOT_FOUND when template does not exist", async () => {
-    mockPrisma.documentTemplate.findUnique.mockResolvedValue(null);
+    mockPrisma.documentTemplate.findFirst.mockResolvedValue(null);
     await expect(makeCaller().delete({ id: "tpl-999" })).rejects.toMatchObject({
       code: "NOT_FOUND",
     });

--- a/test/unit/server/routers/mail.test.ts
+++ b/test/unit/server/routers/mail.test.ts
@@ -4,13 +4,17 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import { mailRouter } from "@/lib/server/routers/mail";
 import { dataStoreFromMockPrisma, type MockDataStore } from "../helpers/mock-data-store";
 
+// Data-skrivningar går via repos (ADR 0020) som delegerar till samma mock-
+// delegates; emit använder dataStore.events.emit (kvarvarande events-söm).
 const mockPrisma = {
-  matter: { findFirstOrThrow: vi.fn() },
+  matter: { findFirst: vi.fn() },
   document: { create: vi.fn() },
-  user: { findUniqueOrThrow: vi.fn() },
+  user: { findFirst: vi.fn() },
   timeEntry: { create: vi.fn() },
 };
 
@@ -31,6 +35,7 @@ function makeCaller(orgId = "org-a", userId = "u1") {
     user: { id: userId, email: "a@b.se", name: "T", role: "LAWYER", organizationId: orgId },
     prisma: mockPrisma,
     dataStore,
+    repos: buildInMemoryRepositories(dataStore as unknown as IDataStore),
     ports: mockPorts,
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -43,9 +48,9 @@ const EML_B64 = Buffer.from(RAW_EML, "utf8").toString("base64");
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockPrisma.matter.findFirstOrThrow.mockResolvedValue({ id: "m1", organizationId: "org-a" });
+  mockPrisma.matter.findFirst.mockResolvedValue({ id: "m1", organizationId: "org-a" });
   mockPrisma.document.create.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => data);
-  mockPrisma.user.findUniqueOrThrow.mockResolvedValue({ hourlyRate: 1800 });
+  mockPrisma.user.findFirst.mockResolvedValue({ id: "u1", hourlyRate: 1800 });
   mockPrisma.timeEntry.create.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({ id: "te-1", ...data }));
 });
 
@@ -54,7 +59,7 @@ describe("mail.saveIncoming", () => {
 
   it("verifierar att ärendet tillhör org:n", async () => {
     await makeCaller("org-a").saveIncoming({ ...base, documentId: "doc-1" });
-    expect(mockPrisma.matter.findFirstOrThrow).toHaveBeenCalledWith({
+    expect(mockPrisma.matter.findFirst).toHaveBeenCalledWith({
       where: { id: "m1", organizationId: "org-a" },
     });
   });
@@ -142,7 +147,7 @@ describe("mail.saveIncoming", () => {
   });
 
   it("propagerar fel om ärendet inte tillhör org:n", async () => {
-    mockPrisma.matter.findFirstOrThrow.mockRejectedValue(new Error("not found"));
+    mockPrisma.matter.findFirst.mockResolvedValue(null);
     await expect(makeCaller().saveIncoming({ ...base, documentId: "doc-1" })).rejects.toThrow();
     expect(contentWrite).not.toHaveBeenCalled();
   });

--- a/test/unit/server/routers/matter.test.ts
+++ b/test/unit/server/routers/matter.test.ts
@@ -1,432 +1,276 @@
 /**
- * Integrationstest för matterRouter.
- *
- * Mockar prisma-klienten och kör routern via createCaller. Täcker:
- *   - list:           pagination, status-filter, sökning, org-scoping
- *   - getById:        normalt fall + cross-org NOT_FOUND
- *   - create:         autogenerering av matterNumber, klient-koppling
- *   - update:         status, paymentMethod, paymentMethodDecidedAt-konvertering
- *   - addContact:     normal + cross-org spärr
- *   - addNewContact:  återanvändning av befintlig kontakt + skapande
- *   - removeContact:  normal + cross-org spärr
+ * Integrationstest för matterRouter — kör mot en riktig DemoDataStore via
+ * buildContext (repos, ADR 0020). Täcker list/getById/create/update/
+ * addContact/addNewContact/removeContact inkl. org-scoping + #174-serien.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest-compat";
-import { matterRouter } from "@/lib/server/routers/matter";
-import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
+import { describe, it, expect } from "vitest-compat";
+import { noopPorts } from "@/lib/server/adapters/noop-ports";
+import type { Principal } from "@/lib/server/auth/principal";
+import { buildContext } from "@/lib/server/build-context";
+import { DemoDataStore } from "@/lib/server/data-store/DemoDataStore";
+import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import { appRouter } from "@/lib/server/routers/_app";
 
-const mockPrisma = {
-  matter: {
-    findFirst: vi.fn(),
-    findUnique: vi.fn(),
-    findFirstOrThrow: vi.fn(),
-    findMany: vi.fn(),
-    count: vi.fn(),
-    create: vi.fn(),
-    update: vi.fn(),
-  },
-  contact: {
-    findFirst: vi.fn(),
-    findUnique: vi.fn(),
-    create: vi.fn(),
-  },
-  matterContact: {
-    findUnique: vi.fn(),
-    create: vi.fn(),
-    delete: vi.fn(),
-  },
-  user: {
-    findUnique: vi.fn(),
-  },
-};
+const ORG = "org-a";
+const YEAR = new Date().getFullYear();
 
-function makeCaller(orgId = "org-a", userId = "user-1") {
-  const ctx = {
-    user: { id: userId, email: "a@b.com", name: "Test", role: "LAWYER", organizationId: orgId },
-    prisma: mockPrisma, dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
-  };
+function makeCaller(seed: Partial<DemoSource> = {}, orgId = ORG, userId = "user-1") {
+  const ds = new DemoDataStore({
+    organizations: [{ id: ORG, name: "X" }, { id: "org-b", name: "Y" }],
+    users: [{ id: "user-1", organizationId: ORG, email: "a@b.com", name: "Test", role: "LAWYER" }],
+    matters: [],
+    contacts: [],
+    matterContacts: [],
+    ...seed,
+  } as DemoSource, async () => { /* writable */ });
+  const principal: Principal = { id: userId, email: "a@b.com", name: "Test", role: "LAWYER", organizationId: orgId };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return matterRouter.createCaller(ctx as any);
+  const caller = appRouter.createCaller(buildContext({ dataStore: ds, ports: noopPorts, principal }) as any);
+  return { ds, caller: caller.matter };
 }
 
-beforeEach(() => {
-  vi.clearAllMocks();
-  // Default: ansvarig jurist (ctx.user) finns i org:en utan prefix (#174) →
-  // nextMatterNumber faller tillbaka på org-gemensam serie utan prefix.
-  mockPrisma.user.findUnique.mockResolvedValue({ organizationId: "org-a", matterNumberPrefix: null });
+function src(ds: DemoDataStore): DemoSource {
+  return (ds as unknown as { source: DemoSource }).source;
+}
+function mcs(ds: DemoDataStore): Array<Record<string, unknown>> {
+  return (src(ds).matterContacts ?? []) as Array<Record<string, unknown>>;
+}
+
+const matter = (o: Record<string, unknown> = {}) => ({
+  id: "matter-1", organizationId: ORG, matterNumber: `${YEAR}-0001`, title: "Bodelning",
+  status: "ACTIVE", createdAt: new Date(), ...o,
 });
 
-const MATTER_A = {
-  id: "matter-1",
-  organizationId: "org-a",
-  matterNumber: "2026-0001",
-  title: "Bodelning",
-};
-
-// ─── list ────────────────────────────────────────────────────────
-
 describe("matter.list", () => {
-  it("returnerar paginerat resultat", async () => {
-    mockPrisma.matter.findMany.mockResolvedValue([MATTER_A]);
-    mockPrisma.matter.count.mockResolvedValue(1);
-
-    const res = await makeCaller().list({ page: 1, pageSize: 20 });
-    expect(res.matters).toHaveLength(1);
-    expect(res.total).toBe(1);
+  it("returnerar paginerat resultat, org-scopat", async () => {
+    const { caller } = makeCaller({ matters: [matter(), matter({ id: "m2", matterNumber: `${YEAR}-0002` })] });
+    const res = await caller.list({ page: 1, pageSize: 20 });
+    expect(res.matters).toHaveLength(2);
+    expect(res.total).toBe(2);
     expect(res.pages).toBe(1);
   });
 
-  it("scopar alltid på organizationId", async () => {
-    mockPrisma.matter.findMany.mockResolvedValue([]);
-    mockPrisma.matter.count.mockResolvedValue(0);
-
-    await makeCaller("org-a").list({});
-    expect(mockPrisma.matter.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({ organizationId: "org-a" }),
-      }),
-    );
+  it("scopar alltid på organizationId (ingen läcka)", async () => {
+    const { caller } = makeCaller({ matters: [matter()] }, "org-b");
+    expect((await caller.list({})).matters).toHaveLength(0);
   });
 
-  it("filtrerar på status när angivet", async () => {
-    mockPrisma.matter.findMany.mockResolvedValue([]);
-    mockPrisma.matter.count.mockResolvedValue(0);
-
-    await makeCaller().list({ status: "ACTIVE" });
-    expect(mockPrisma.matter.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({ status: "ACTIVE" }),
-      }),
-    );
+  it("filtrerar på status", async () => {
+    const { caller } = makeCaller({
+      matters: [matter(), matter({ id: "m2", matterNumber: `${YEAR}-0002`, status: "CLOSED" })],
+    });
+    const res = await caller.list({ status: "CLOSED" });
+    expect(res.matters.map((m) => m.id)).toEqual(["m2"]);
   });
 
-  it("filtrerar på medarbetare (tidsposter) när employeeId angivet", async () => {
-    mockPrisma.matter.findMany.mockResolvedValue([]);
-    mockPrisma.matter.count.mockResolvedValue(0);
-
-    await makeCaller().list({ employeeId: "u-bjorn" });
-    expect(mockPrisma.matter.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          timeEntries: { some: { userId: "u-bjorn" } },
-        }),
-      }),
-    );
+  it("filtrerar på medarbetare (tidsposter)", async () => {
+    const { caller } = makeCaller({
+      matters: [matter(), matter({ id: "m2", matterNumber: `${YEAR}-0002` })],
+      timeEntries: [{ id: "te1", organizationId: ORG, userId: "u-bjorn", matterId: "m2", minutes: 60, date: new Date(), hourlyRate: 1000, billable: true, description: "x" }],
+    });
+    const res = await caller.list({ employeeId: "u-bjorn" });
+    expect(res.matters.map((m) => m.id)).toEqual(["m2"]);
   });
 
-  it("utelämnar timeEntries-filter när employeeId saknas", async () => {
-    mockPrisma.matter.findMany.mockResolvedValue([]);
-    mockPrisma.matter.count.mockResolvedValue(0);
-
-    await makeCaller().list({});
-    const where = mockPrisma.matter.findMany.mock.calls[0]![0].where;
-    expect(where).not.toHaveProperty("timeEntries");
+  it("söker på titel/ärendenummer/klientnamn", async () => {
+    const { caller } = makeCaller({
+      matters: [matter({ title: "Tvist Bergström" }), matter({ id: "m2", matterNumber: `${YEAR}-0002`, title: "Annat" })],
+    });
+    expect((await caller.list({ search: "bergström" })).matters).toHaveLength(1);
   });
 
-  it("bygger OR-sökning på title/matterNumber/contacts", async () => {
-    mockPrisma.matter.findMany.mockResolvedValue([]);
-    mockPrisma.matter.count.mockResolvedValue(0);
-
-    await makeCaller().list({ search: "Berg" });
-    const callArgs = mockPrisma.matter.findMany.mock.calls[0]![0];
-    expect(callArgs.where.OR).toBeDefined();
-    expect(callArgs.where.OR).toHaveLength(3);
-  });
-
-  it("räknar pages korrekt vid total > pageSize", async () => {
-    mockPrisma.matter.findMany.mockResolvedValue([]);
-    mockPrisma.matter.count.mockResolvedValue(45);
-
-    const res = await makeCaller().list({ pageSize: 20 });
-    expect(res.pages).toBe(3); // ceil(45/20)
+  it("räknar pages korrekt", async () => {
+    const { caller } = makeCaller({
+      matters: [matter(), matter({ id: "m2", matterNumber: `${YEAR}-0002` }), matter({ id: "m3", matterNumber: `${YEAR}-0003` })],
+    });
+    expect((await caller.list({ pageSize: 2 })).pages).toBe(2); // ceil(3/2)
   });
 
   it("validerar pageSize-gränser via zod", async () => {
-    await expect(makeCaller().list({ pageSize: 600 })).rejects.toThrow(); // max 500
-    await expect(makeCaller().list({ page: 0 })).rejects.toThrow();
+    const { caller } = makeCaller();
+    await expect(caller.list({ pageSize: 600 })).rejects.toThrow();
+    await expect(caller.list({ page: 0 })).rejects.toThrow();
   });
 });
-
-// ─── getById ─────────────────────────────────────────────────────
 
 describe("matter.getById", () => {
-  it("hämtar matter med kontakter + counts", async () => {
-    mockPrisma.matter.findFirstOrThrow.mockResolvedValue(MATTER_A);
-    const res = await makeCaller().getById({ id: "matter-1" });
-    expect(res).toEqual(MATTER_A);
-    expect(mockPrisma.matter.findFirstOrThrow).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { id: "matter-1", organizationId: "org-a" },
-      }),
-    );
+  it("hämtar matter med kontakter", async () => {
+    const { caller } = makeCaller({
+      matters: [matter()],
+      contacts: [{ id: "c1", organizationId: ORG, name: "Klient", contactType: "PERSON" }],
+      matterContacts: [{ id: "mc1", matterId: "matter-1", contactId: "c1", role: "KLIENT" }],
+    });
+    const res = await caller.getById({ id: "matter-1" });
+    expect(res.id).toBe("matter-1");
+    expect(res.contacts).toHaveLength(1);
   });
 
-  it("kastar när matter saknas / fel org", async () => {
-    mockPrisma.matter.findFirstOrThrow.mockRejectedValue(new Error("not found"));
-    await expect(makeCaller().getById({ id: "x" })).rejects.toThrow();
+  it("NOT_FOUND när matter saknas / fel org", async () => {
+    const { caller } = makeCaller({ matters: [matter()] }, "org-b");
+    await expect(caller.getById({ id: "matter-1" })).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 });
 
-// ─── create ──────────────────────────────────────────────────────
-
 describe("matter.create", () => {
-  it("skapar nytt matter med matterNumber när inga finns", async () => {
-    mockPrisma.matter.findMany.mockResolvedValue([]);
-    mockPrisma.matter.create.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
-      ...data,
-      id: "new",
-    }));
-
-    const year = new Date().getFullYear();
-    const res = await makeCaller().create({ title: "Nytt" });
-    expect(res.matterNumber).toBe(`${year}-0001`);
+  it("genererar matterNumber YYYY-0001 i tom serie", async () => {
+    const { caller } = makeCaller();
+    expect((await caller.create({ title: "Nytt" })).matterNumber).toBe(`${YEAR}-0001`);
   });
 
-  it("ökar serienumret från senaste matter", async () => {
-    const year = new Date().getFullYear();
-    mockPrisma.matter.findMany.mockResolvedValue([{ matterNumber: `${year}-0042` }]);
-    mockPrisma.matter.create.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
-      ...data,
-      id: "new",
-    }));
-
-    const res = await makeCaller().create({ title: "T" });
-    expect(res.matterNumber).toBe(`${year}-0043`);
-  });
-
-  it("prefixar serien med ansvarig jurists prefix (#174)", async () => {
-    const year = new Date().getFullYear();
-    mockPrisma.user.findUnique.mockResolvedValue({ organizationId: "org-a", matterNumberPrefix: "AA" });
-    mockPrisma.matter.findMany.mockResolvedValue([]);
-    mockPrisma.matter.create.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({ ...data, id: "new" }));
-
-    const res = await makeCaller().create({ title: "T" });
-    expect(res.matterNumber).toBe(`AA${year}-0001`);
-  });
-
-  it("fortsätter serien vid prefix-byte: räknar på juristens egna ärenden (#174)", async () => {
-    const year = new Date().getFullYear();
-    mockPrisma.user.findUnique.mockResolvedValue({ organizationId: "org-a", matterNumberPrefix: "AB" });
-    // Juristens egna ärenden i år bär gamla prefixet AA (seq upp till 2) men
-    // inga AB-nummer finns ännu → nästa ska bli AB...0003, inte AB...0001.
-    mockPrisma.matter.findMany.mockImplementation(async ({ where }: { where: Record<string, unknown> }) => {
-      if ((where as { responsibleLawyerId?: string }).responsibleLawyerId) {
-        return [{ matterNumber: `AA${year}-0001` }, { matterNumber: `AA${year}-0002` }];
-      }
-      return []; // inga befintliga AB-nummer
+  it("ökar serienumret från juristens senaste ärende", async () => {
+    const { caller } = makeCaller({
+      matters: [matter({ id: "m0", matterNumber: `${YEAR}-0042`, responsibleLawyerId: "user-1" })],
     });
-    mockPrisma.matter.create.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({ ...data, id: "new" }));
+    expect((await caller.create({ title: "T" })).matterNumber).toBe(`${YEAR}-0043`);
+  });
 
-    const res = await makeCaller().create({ title: "T" });
-    expect(res.matterNumber).toBe(`AB${year}-0003`);
+  it("prefixar med ansvarig jurists prefix (#174)", async () => {
+    const { caller } = makeCaller({
+      users: [{ id: "user-1", organizationId: ORG, email: "a@b.com", name: "T", role: "LAWYER", matterNumberPrefix: "AA" }],
+    });
+    expect((await caller.create({ title: "T" })).matterNumber).toBe(`AA${YEAR}-0001`);
+  });
+
+  it("fortsätter serien vid prefix-byte (räknar juristens egna ärenden, #174)", async () => {
+    const { caller } = makeCaller({
+      users: [{ id: "user-1", organizationId: ORG, email: "a@b.com", name: "T", role: "LAWYER", matterNumberPrefix: "AB" }],
+      matters: [
+        matter({ id: "m1", matterNumber: `AA${YEAR}-0001`, responsibleLawyerId: "user-1" }),
+        matter({ id: "m2", matterNumber: `AA${YEAR}-0002`, responsibleLawyerId: "user-1" }),
+      ],
+    });
+    expect((await caller.create({ title: "T" })).matterNumber).toBe(`AB${YEAR}-0003`);
   });
 
   it("kopplar klient när klientId angivits", async () => {
-    mockPrisma.matter.findMany.mockResolvedValue([]);
-    mockPrisma.matter.create.mockResolvedValue({ id: "matter-1", organizationId: "org-a" });
-    mockPrisma.contact.findUnique.mockResolvedValue({ id: "c1", organizationId: "org-a" });
-    mockPrisma.matterContact.create.mockResolvedValue({});
-
-    await makeCaller().create({ title: "T", klientId: "c1" });
-    expect(mockPrisma.matterContact.create).toHaveBeenCalledWith({
-      data: { matterId: "matter-1", contactId: "c1", role: "KLIENT" },
+    const { caller, ds } = makeCaller({
+      contacts: [{ id: "c1", organizationId: ORG, name: "K", contactType: "PERSON" }],
     });
+    await caller.create({ title: "T", klientId: "c1" });
+    expect(mcs(ds).some((mc) => mc.contactId === "c1" && mc.role === "KLIENT")).toBe(true);
   });
 
-  it("vägrar att koppla klient från annan org", async () => {
-    mockPrisma.matter.findMany.mockResolvedValue([]);
-    mockPrisma.matter.create.mockResolvedValue({ id: "matter-1", organizationId: "org-a" });
-    mockPrisma.contact.findUnique.mockResolvedValue({ id: "c1", organizationId: "org-b" });
-
-    await expect(
-      makeCaller("org-a").create({ title: "T", klientId: "c1" }),
-    ).rejects.toMatchObject({ code: "NOT_FOUND" });
-    expect(mockPrisma.matterContact.create).not.toHaveBeenCalled();
+  it("vägrar koppla klient från annan org", async () => {
+    const { caller, ds } = makeCaller({
+      contacts: [{ id: "c1", organizationId: "org-b", name: "K", contactType: "PERSON" }],
+    });
+    await expect(caller.create({ title: "T", klientId: "c1" })).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(mcs(ds)).toHaveLength(0);
   });
 
   it("kräver title (zod min(1))", async () => {
-    await expect(makeCaller().create({ title: "" })).rejects.toThrow();
+    const { caller } = makeCaller();
+    await expect(caller.create({ title: "" })).rejects.toThrow();
   });
 });
-
-// ─── update ──────────────────────────────────────────────────────
 
 describe("matter.update", () => {
   it("uppdaterar status", async () => {
-    mockPrisma.matter.findUnique.mockResolvedValue(MATTER_A);
-    mockPrisma.matter.update.mockResolvedValue({ ...MATTER_A, status: "CLOSED" });
-
-    await makeCaller().update({ id: "matter-1", status: "CLOSED" });
-    expect(mockPrisma.matter.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { id: "matter-1" },
-        data: expect.objectContaining({ status: "CLOSED" }),
-      }),
-    );
+    const { caller, ds } = makeCaller({ matters: [matter()] });
+    await caller.update({ id: "matter-1", status: "CLOSED" });
+    expect((src(ds).matters as Array<{ id: string; status: string }>).find((m) => m.id === "matter-1")!.status).toBe("CLOSED");
   });
 
   it("konverterar paymentMethodDecidedAt-sträng till Date", async () => {
-    mockPrisma.matter.findUnique.mockResolvedValue(MATTER_A);
-    mockPrisma.matter.update.mockResolvedValue(MATTER_A);
-
-    await makeCaller().update({
-      id: "matter-1",
-      paymentMethod: "RATTSHJALP",
-      paymentMethodDecidedAt: "2026-03-02",
-    });
-    const args = mockPrisma.matter.update.mock.calls[0]![0];
-    expect(args.data.paymentMethodDecidedAt).toBeInstanceOf(Date);
-    expect((args.data.paymentMethodDecidedAt as Date).toISOString()).toContain("2026-03-02");
+    const { caller, ds } = makeCaller({ matters: [matter()] });
+    await caller.update({ id: "matter-1", paymentMethod: "RATTSHJALP", paymentMethodDecidedAt: "2026-03-02" });
+    const m = (src(ds).matters as Array<{ id: string; paymentMethodDecidedAt?: Date }>).find((x) => x.id === "matter-1")!;
+    expect(m.paymentMethodDecidedAt).toBeInstanceOf(Date);
   });
 
-  it("nullar paymentMethodDecidedAt när tom sträng/null", async () => {
-    mockPrisma.matter.findUnique.mockResolvedValue(MATTER_A);
-    mockPrisma.matter.update.mockResolvedValue(MATTER_A);
-
-    await makeCaller().update({ id: "matter-1", paymentMethodDecidedAt: null });
-    const args = mockPrisma.matter.update.mock.calls[0]![0];
-    expect(args.data.paymentMethodDecidedAt).toBeNull();
+  it("nullar paymentMethodDecidedAt när null", async () => {
+    const { caller, ds } = makeCaller({ matters: [matter({ paymentMethodDecidedAt: new Date() })] });
+    await caller.update({ id: "matter-1", paymentMethodDecidedAt: null });
+    const m = (src(ds).matters as Array<{ id: string; paymentMethodDecidedAt?: Date | null }>).find((x) => x.id === "matter-1")!;
+    expect(m.paymentMethodDecidedAt).toBeNull();
   });
 
   it("vägrar uppdatera matter från annan org", async () => {
-    mockPrisma.matter.findUnique.mockResolvedValue({ id: "x", organizationId: "org-b" });
-
-    await expect(
-      makeCaller("org-a").update({ id: "x", status: "CLOSED" }),
-    ).rejects.toMatchObject({ code: "NOT_FOUND" });
-    expect(mockPrisma.matter.update).not.toHaveBeenCalled();
+    const { caller } = makeCaller({ matters: [matter()] }, "org-b");
+    await expect(caller.update({ id: "matter-1", status: "CLOSED" })).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 });
 
-// ─── addContact ──────────────────────────────────────────────────
-
 describe("matter.addContact", () => {
   it("kopplar befintlig kontakt", async () => {
-    mockPrisma.matter.findUnique.mockResolvedValue(MATTER_A);
-    mockPrisma.contact.findUnique.mockResolvedValue({ id: "c1", organizationId: "org-a" });
-    mockPrisma.matterContact.create.mockResolvedValue({ id: "mc1" });
-
-    await makeCaller().addContact({
-      matterId: "matter-1",
-      contactId: "c1",
-      role: "MOTPART",
+    const { caller, ds } = makeCaller({
+      matters: [matter()],
+      contacts: [{ id: "c1", organizationId: ORG, name: "K", contactType: "PERSON" }],
     });
-    expect(mockPrisma.matterContact.create).toHaveBeenCalled();
+    await caller.addContact({ matterId: "matter-1", contactId: "c1", role: "MOTPART" });
+    expect(mcs(ds).some((mc) => mc.contactId === "c1" && mc.role === "MOTPART")).toBe(true);
   });
 
   it("vägrar koppla matter från annan org", async () => {
-    mockPrisma.matter.findUnique.mockResolvedValue({ id: "x", organizationId: "org-b" });
-
+    const { caller } = makeCaller({ matters: [matter()] }, "org-b");
     await expect(
-      makeCaller("org-a").addContact({
-        matterId: "x",
-        contactId: "c1",
-        role: "MOTPART",
-      }),
+      caller.addContact({ matterId: "matter-1", contactId: "c1", role: "MOTPART" }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 
   it("vägrar koppla kontakt från annan org", async () => {
-    mockPrisma.matter.findUnique.mockResolvedValue(MATTER_A);
-    mockPrisma.contact.findUnique.mockResolvedValue({
-      id: "c1",
-      organizationId: "org-b",
+    const { caller } = makeCaller({
+      matters: [matter()],
+      contacts: [{ id: "c1", organizationId: "org-b", name: "K", contactType: "PERSON" }],
     });
-
     await expect(
-      makeCaller("org-a").addContact({
-        matterId: "matter-1",
-        contactId: "c1",
-        role: "MOTPART",
-      }),
+      caller.addContact({ matterId: "matter-1", contactId: "c1", role: "MOTPART" }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 });
-
-// ─── addNewContact ───────────────────────────────────────────────
 
 describe("matter.addNewContact", () => {
   it("återanvänder befintlig kontakt med samma personnummer", async () => {
-    mockPrisma.matter.findUnique.mockResolvedValue(MATTER_A);
-    mockPrisma.contact.findFirst.mockResolvedValue({ id: "existing", organizationId: "org-a" });
-    mockPrisma.matterContact.create.mockResolvedValue({ id: "mc1" });
-
-    await makeCaller().addNewContact({
-      matterId: "matter-1",
-      name: "Test Person",
-      contactType: "PERSON",
-      personalNumber: "19850225-6655",
-      role: "MOTPART",
+    const { caller, ds } = makeCaller({
+      matters: [matter()],
+      contacts: [{ id: "existing", organizationId: ORG, name: "P", contactType: "PERSON", personalNumber: "19850225-6655" }],
     });
-    expect(mockPrisma.contact.create).not.toHaveBeenCalled();
-    expect(mockPrisma.matterContact.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({ contactId: "existing" }),
-      }),
-    );
+    await caller.addNewContact({
+      matterId: "matter-1", name: "Test Person", contactType: "PERSON", personalNumber: "19850225-6655", role: "MOTPART",
+    });
+    expect((src(ds).contacts as unknown[]).length).toBe(1); // ingen ny kontakt
+    expect(mcs(ds).some((mc) => mc.contactId === "existing")).toBe(true);
   });
 
   it("skapar ny kontakt när ingen matchar", async () => {
-    mockPrisma.matter.findUnique.mockResolvedValue(MATTER_A);
-    mockPrisma.contact.findFirst.mockResolvedValue(null);
-    mockPrisma.contact.create.mockResolvedValue({ id: "new", name: "Ny" });
-    mockPrisma.matterContact.create.mockResolvedValue({ id: "mc1" });
-
-    await makeCaller().addNewContact({
-      matterId: "matter-1",
-      name: "Ny",
-      contactType: "PERSON",
-      role: "MOTPART",
-    });
-    expect(mockPrisma.contact.create).toHaveBeenCalled();
-    expect(mockPrisma.matterContact.create).toHaveBeenCalled();
+    const { caller, ds } = makeCaller({ matters: [matter()] });
+    await caller.addNewContact({ matterId: "matter-1", name: "Ny", contactType: "PERSON", role: "MOTPART" });
+    expect((src(ds).contacts as unknown[]).length).toBe(1);
+    expect(mcs(ds)).toHaveLength(1);
   });
 
   it("matchar på orgnummer för företag", async () => {
-    mockPrisma.matter.findUnique.mockResolvedValue(MATTER_A);
-    mockPrisma.contact.findFirst.mockResolvedValue({ id: "co", organizationId: "org-a" });
-    mockPrisma.matterContact.create.mockResolvedValue({});
-
-    await makeCaller().addNewContact({
-      matterId: "matter-1",
-      name: "AB",
-      contactType: "COMPANY",
-      orgNumber: "556677-8899",
-      role: "MOTPART",
+    const { caller, ds } = makeCaller({
+      matters: [matter()],
+      contacts: [{ id: "co", organizationId: ORG, name: "AB", contactType: "COMPANY", orgNumber: "556677-8899" }],
     });
-    expect(mockPrisma.contact.findFirst).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({ orgNumber: "556677-8899" }),
-      }),
-    );
-    expect(mockPrisma.contact.create).not.toHaveBeenCalled();
+    await caller.addNewContact({
+      matterId: "matter-1", name: "AB", contactType: "COMPANY", orgNumber: "556677-8899", role: "MOTPART",
+    });
+    expect((src(ds).contacts as unknown[]).length).toBe(1);
+    expect(mcs(ds).some((mc) => mc.contactId === "co")).toBe(true);
   });
 });
 
-// ─── removeContact ───────────────────────────────────────────────
-
 describe("matter.removeContact", () => {
   it("tar bort koppling med korrekt org-scoping", async () => {
-    mockPrisma.matterContact.findUnique.mockResolvedValue({
-      id: "mc1",
-      matter: { organizationId: "org-a" },
+    const { caller, ds } = makeCaller({
+      matters: [matter()],
+      contacts: [{ id: "c1", organizationId: ORG, name: "K", contactType: "PERSON" }],
+      matterContacts: [{ id: "mc1", matterId: "matter-1", contactId: "c1", role: "MOTPART" }],
     });
-    mockPrisma.matterContact.delete.mockResolvedValue({});
-
-    await makeCaller().removeContact({ matterContactId: "mc1" });
-    expect(mockPrisma.matterContact.delete).toHaveBeenCalledWith({
-      where: { id: "mc1" },
-    });
+    await caller.removeContact({ matterContactId: "mc1" });
+    expect(mcs(ds).some((mc) => mc.id === "mc1")).toBe(false);
   });
 
   it("vägrar ta bort koppling från annan org", async () => {
-    mockPrisma.matterContact.findUnique.mockResolvedValue({
-      id: "mc1",
-      matter: { organizationId: "org-b" },
-    });
-    await expect(
-      makeCaller("org-a").removeContact({ matterContactId: "mc1" }),
-    ).rejects.toMatchObject({ code: "NOT_FOUND" });
-    expect(mockPrisma.matterContact.delete).not.toHaveBeenCalled();
+    const { caller, ds } = makeCaller({
+      matters: [matter()],
+      contacts: [{ id: "c1", organizationId: ORG, name: "K", contactType: "PERSON" }],
+      matterContacts: [{ id: "mc1", matterId: "matter-1", contactId: "c1", role: "MOTPART" }],
+    }, "org-b");
+    await expect(caller.removeContact({ matterContactId: "mc1" })).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(mcs(ds).some((mc) => mc.id === "mc1")).toBe(true);
   });
 });

--- a/test/unit/server/routers/organization.test.ts
+++ b/test/unit/server/routers/organization.test.ts
@@ -1,5 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import { organizationRouter } from "@/lib/server/routers/organization";
 import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
 
@@ -7,12 +9,13 @@ import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
 
 const mockPrisma = {
   organization: {
-    findUniqueOrThrow: vi.fn(),
+    findFirst: vi.fn(),
     update: vi.fn(),
+    create: vi.fn(),
   },
   office: {
     findMany: vi.fn(),
-    findUnique: vi.fn(),
+    findFirst: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
     updateMany: vi.fn(),
@@ -21,9 +24,11 @@ const mockPrisma = {
 };
 
 function makeCaller(orgId = "org-a") {
+  const dataStore = dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>);
   const ctx = {
     user: { id: "user-1", email: "a@b.com", name: "Test", role: "ADMIN", organizationId: orgId },
-    prisma: mockPrisma, dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+    prisma: mockPrisma, dataStore,
+    repos: buildInMemoryRepositories(dataStore as unknown as IDataStore),
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return organizationRouter.createCaller(ctx as any);
@@ -211,7 +216,7 @@ describe("organization — komplett flöde: registrera huvudkontor och filial", 
 
 describe("organization.updateOffice", () => {
   it("uppdaterar ett kontor i anropande organisation", async () => {
-    mockPrisma.office.findUnique.mockResolvedValue(BRANCH_OFFICE);
+    mockPrisma.office.findFirst.mockResolvedValue(BRANCH_OFFICE);
     mockPrisma.office.update.mockResolvedValue({ ...BRANCH_OFFICE, phone: "031-000 00 00" });
 
     const result = await makeCaller("org-a").updateOffice({
@@ -226,7 +231,7 @@ describe("organization.updateOffice", () => {
   });
 
   it("degraderar tidigare huvudkontor när en filial befordras", async () => {
-    mockPrisma.office.findUnique.mockResolvedValue(BRANCH_OFFICE);
+    mockPrisma.office.findFirst.mockResolvedValue(BRANCH_OFFICE);
     mockPrisma.office.updateMany.mockResolvedValue({ count: 1 });
     mockPrisma.office.update.mockResolvedValue({ ...BRANCH_OFFICE, isMain: true });
 
@@ -239,7 +244,7 @@ describe("organization.updateOffice", () => {
   });
 
   it("kastar NOT_FOUND när kontor tillhör annan organisation", async () => {
-    mockPrisma.office.findUnique.mockResolvedValue({ ...BRANCH_OFFICE, organizationId: "org-b" });
+    mockPrisma.office.findFirst.mockResolvedValue(null);
 
     await expect(
       makeCaller("org-a").updateOffice({ id: "off-branch", name: "Hijacked" })
@@ -248,7 +253,7 @@ describe("organization.updateOffice", () => {
   });
 
   it("kastar NOT_FOUND när kontor inte existerar", async () => {
-    mockPrisma.office.findUnique.mockResolvedValue(null);
+    mockPrisma.office.findFirst.mockResolvedValue(null);
 
     await expect(
       makeCaller("org-a").updateOffice({ id: "off-ghost", name: "X" })
@@ -260,7 +265,7 @@ describe("organization.updateOffice", () => {
 
 describe("organization.deleteOffice", () => {
   it("tar bort ett kontor i anropande organisation", async () => {
-    mockPrisma.office.findUnique.mockResolvedValue(BRANCH_OFFICE);
+    mockPrisma.office.findFirst.mockResolvedValue(BRANCH_OFFICE);
     mockPrisma.office.delete.mockResolvedValue(BRANCH_OFFICE);
 
     await makeCaller("org-a").deleteOffice({ id: "off-branch" });
@@ -269,7 +274,7 @@ describe("organization.deleteOffice", () => {
   });
 
   it("kastar NOT_FOUND vid borttagning från annan organisation", async () => {
-    mockPrisma.office.findUnique.mockResolvedValue({ ...BRANCH_OFFICE, organizationId: "org-b" });
+    mockPrisma.office.findFirst.mockResolvedValue(null);
 
     await expect(makeCaller("org-a").deleteOffice({ id: "off-branch" })).rejects.toMatchObject({
       code: "NOT_FOUND",
@@ -282,7 +287,7 @@ describe("organization.deleteOffice", () => {
 
 describe("organization.getSettings", () => {
   it("returnerar org-inställningar för anropande användares org", async () => {
-    mockPrisma.organization.findUniqueOrThrow.mockResolvedValue({
+    mockPrisma.organization.findFirst.mockResolvedValue({
       id: "org-a",
       name: "Advokat AB",
       orgNumber: "556123-4567",
@@ -297,7 +302,7 @@ describe("organization.getSettings", () => {
 
     expect(result.name).toBe("Advokat AB");
     expect(result.bankgiro).toBe("123-4567");
-    expect(mockPrisma.organization.findUniqueOrThrow).toHaveBeenCalledWith(
+    expect(mockPrisma.organization.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({ where: { id: "org-a" } })
     );
   });
@@ -305,6 +310,8 @@ describe("organization.getSettings", () => {
 
 describe("organization.updateSettings", () => {
   it("uppdaterar bankgiro och övriga fält", async () => {
+    // Repo.update läser nuvarande raden (version-bump) före skrivning.
+    mockPrisma.organization.findFirst.mockResolvedValue({ id: "org-a" });
     mockPrisma.organization.update.mockResolvedValue({
       id: "org-a",
       name: "Advokat AB",
@@ -313,9 +320,9 @@ describe("organization.updateSettings", () => {
 
     await makeCaller("org-a").updateSettings({ bankgiro: "999-8888" });
 
-    expect(mockPrisma.organization.update).toHaveBeenCalledWith({
-      where: { id: "org-a" },
-      data: { bankgiro: "999-8888" },
-    });
+    // objectContaining: repo lägger version/updatedAt utöver bankgiro.
+    expect(mockPrisma.organization.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "org-a" }, data: expect.objectContaining({ bankgiro: "999-8888" }) }),
+    );
   });
 });

--- a/test/unit/server/routers/paymentPlan.test.ts
+++ b/test/unit/server/routers/paymentPlan.test.ts
@@ -1,195 +1,179 @@
 /**
  * paymentPlanRouter — list (+ sökfilter/planHaystack), getById, cancel,
- * recordReminder och scanDueReminders (#23). Org-scope via planens invoice;
- * NOT_FOUND när planen inte finns/ej i org.
+ * recordReminder och scanDueReminders (#23). Kör mot en riktig in-memory-store
+ * (repos, ADR 0020); org-scope via planens faktura→ärende.
  */
 
-import { TRPCError } from "@trpc/server";
-import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { describe, it, expect } from "vitest-compat";
+import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import { paymentPlanRouter } from "@/lib/server/routers/paymentPlan";
-import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
+import { prebakeJoins } from "@/lib/shared/demo-source";
 
-const mockPrisma = {
-  paymentPlan: { findFirst: vi.fn(), findMany: vi.fn(), update: vi.fn() },
-  paymentPlanReminder: { create: vi.fn() },
-  invoice: { update: vi.fn() },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  $transaction: vi.fn(<T,>(fn: (tx: any) => Promise<T>) => fn(mockPrisma)),
-};
+const ORG = "org-a";
 
-function makeCaller(orgId = "org-a") {
+function makeCaller(seed: Partial<DemoSource> = {}, orgId = ORG) {
+  const source = prebakeJoins({
+    matters: [{ id: "m1", organizationId: ORG, matterNumber: "2026-0001", title: "Tvist Lindström" }],
+    contacts: [{ id: "klient", organizationId: ORG, name: "Anna Andersson", email: "anna@x.se" }],
+    matterContacts: [{ id: "mc1", matterId: "m1", contactId: "klient", role: "KLIENT" }],
+    invoices: [{ id: "inv-1", matterId: "m1", amount: 1_000_000, status: "SENT" }],
+    payments: [],
+    paymentPlans: [],
+    paymentPlanReminders: [],
+    ...seed,
+  } as DemoSource);
+  const store = new LocalStore(source, async () => {});
+  const repos = buildInMemoryRepositories(store as unknown as IDataStore);
   const ctx = {
     user: { id: "u1", email: "a@b.com", name: "T", role: "LAWYER", organizationId: orgId },
-    prisma: mockPrisma,
-    dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+    dataStore: store, repos, orgId,
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return paymentPlanRouter.createCaller(ctx as any);
+  return { caller: paymentPlanRouter.createCaller(ctx as any), store };
 }
 
-beforeEach(() => vi.clearAllMocks());
+function src(store: LocalStore): DemoSource {
+  return (store as unknown as { source: DemoSource }).source;
+}
+
+const plan = (o: Record<string, unknown> = {}) => ({
+  id: "pp-1", invoiceId: "inv-1", status: "ACTIVE",
+  monthlyAmount: 100_000, dayOfMonth: 15, startDate: "2026-06-01", ...o,
+});
 
 describe("paymentPlan.recordReminder", () => {
   it("loggar en påminnelse för en plan i org:en (sentAt → Date)", async () => {
-    mockPrisma.paymentPlan.findFirst.mockResolvedValue({ id: "pp-1", invoiceId: "inv-1", status: "ACTIVE" });
-    mockPrisma.paymentPlanReminder.create.mockImplementation(
-      ({ data }: { data: Record<string, unknown> }) => Promise.resolve({ ...data }),
-    );
-
-    const res = await makeCaller().recordReminder({
+    const { caller, store } = makeCaller({ paymentPlans: [plan()] });
+    const res = await caller.recordReminder({
       id: "ppr-1", planId: "pp-1", dueMonth: "2026-03", type: "DUE", sentAt: "2026-03-10T00:00:00Z",
     });
-
     expect(res.planId).toBe("pp-1");
     expect(res.dueMonth).toBe("2026-03");
-    const arg = mockPrisma.paymentPlanReminder.create.mock.calls[0]![0] as { data: Record<string, unknown> };
-    expect(arg.data.id).toBe("ppr-1");
-    expect(arg.data.type).toBe("DUE");
-    expect(arg.data.sentAt).toBeInstanceOf(Date);
+    const rem = (src(store).paymentPlanReminders as Array<Record<string, unknown>>)[0]!;
+    expect(rem.id).toBe("ppr-1");
+    expect(rem.type).toBe("DUE");
+    expect(rem.sentAt).toBeInstanceOf(Date);
   });
 
   it("defaultar sentAt till now() när det utelämnas", async () => {
-    mockPrisma.paymentPlan.findFirst.mockResolvedValue({ id: "pp-1", invoiceId: "inv-1", status: "ACTIVE" });
-    mockPrisma.paymentPlanReminder.create.mockImplementation(
-      ({ data }: { data: Record<string, unknown> }) => Promise.resolve({ ...data }),
-    );
-    await makeCaller().recordReminder({ planId: "pp-1", dueMonth: "2026-04", type: "OVERDUE" });
-    const arg = mockPrisma.paymentPlanReminder.create.mock.calls[0]![0] as { data: Record<string, unknown> };
-    expect(arg.data.sentAt).toBeInstanceOf(Date);
+    const { caller, store } = makeCaller({ paymentPlans: [plan()] });
+    await caller.recordReminder({ planId: "pp-1", dueMonth: "2026-04", type: "OVERDUE" });
+    expect((src(store).paymentPlanReminders as Array<Record<string, unknown>>)[0]!.sentAt).toBeInstanceOf(Date);
   });
 
   it("kastar NOT_FOUND när planen inte tillhör org:en", async () => {
-    mockPrisma.paymentPlan.findFirst.mockResolvedValue(null);
+    const { caller, store } = makeCaller({ paymentPlans: [plan()] }, "org-b");
     await expect(
-      makeCaller().recordReminder({ planId: "saknas", dueMonth: "2026-03", type: "DUE" }),
-    ).rejects.toThrow(TRPCError);
-    expect(mockPrisma.paymentPlanReminder.create).not.toHaveBeenCalled();
+      caller.recordReminder({ planId: "pp-1", dueMonth: "2026-03", type: "DUE" }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(src(store).paymentPlanReminders).toHaveLength(0);
   });
-});
-
-// En joinad plan-rad som list/scan returnerar.
-const joinedPlan = (o: Record<string, unknown> = {}) => ({
-  id: "pp-1", status: "ACTIVE", monthlyAmount: 100_000, dayOfMonth: 15, startDate: "2026-06-01",
-  notes: null,
-  invoice: {
-    amount: 1_000_000, payments: [{ amount: 0 }],
-    matter: { id: "m1", matterNumber: "2026-0001", title: "Tvist Lindström",
-      contacts: [{ contact: { name: "Anna Andersson", email: "anna@x.se" } }] },
-  },
-  reminders: [],
-  ...o,
 });
 
 describe("paymentPlan.list", () => {
   it("returnerar alla planer i org:en utan sökterm", async () => {
-    mockPrisma.paymentPlan.findMany.mockResolvedValue([joinedPlan(), joinedPlan({ id: "pp-2" })]);
-    const res = await makeCaller().list({});
-    expect(res).toHaveLength(2);
-    expect(mockPrisma.paymentPlan.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({ where: expect.objectContaining({ invoice: { matter: { organizationId: "org-a" } } }) }),
-    );
+    const { caller } = makeCaller({
+      invoices: [
+        { id: "inv-1", matterId: "m1", amount: 1_000_000, status: "SENT" },
+        { id: "inv-2", matterId: "m1", amount: 500_000, status: "SENT" },
+      ],
+      paymentPlans: [plan(), plan({ id: "pp-2", invoiceId: "inv-2" })],
+    });
+    expect(await caller.list({})).toHaveLength(2);
   });
 
   it("filtrerar på status när angivet", async () => {
-    mockPrisma.paymentPlan.findMany.mockResolvedValue([]);
-    await makeCaller().list({ status: "COMPLETED" });
-    expect(mockPrisma.paymentPlan.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({ where: expect.objectContaining({ status: "COMPLETED" }) }),
-    );
+    const { caller } = makeCaller({
+      invoices: [
+        { id: "inv-1", matterId: "m1", amount: 1, status: "SENT" },
+        { id: "inv-2", matterId: "m1", amount: 1, status: "SENT" },
+      ],
+      paymentPlans: [plan(), plan({ id: "pp-2", invoiceId: "inv-2", status: "COMPLETED" })],
+    });
+    const res = await caller.list({ status: "COMPLETED" });
+    expect(res.map((p) => p.id)).toEqual(["pp-2"]);
   });
 
   it("söker i ärendenr/titel/klient/anteckningar (planHaystack)", async () => {
-    mockPrisma.paymentPlan.findMany.mockResolvedValue([
-      joinedPlan({ id: "match" }),
-      joinedPlan({ id: "miss", invoice: { matter: { matterNumber: "2026-9999", title: "Annat", contacts: [] } } }),
-    ]);
-    const res = await makeCaller().list({ search: "lindström" });
-    expect(res.map((p: { id: string }) => p.id)).toEqual(["match"]);
+    const { caller } = makeCaller({ paymentPlans: [plan()] });
+    expect(await caller.list({ search: "lindström" })).toHaveLength(1); // matchar matter-titel
+    expect(await caller.list({ search: "saknas-helt" })).toHaveLength(0);
   });
 
   it("matchar på klientnamn", async () => {
-    mockPrisma.paymentPlan.findMany.mockResolvedValue([joinedPlan()]);
-    const res = await makeCaller().list({ search: "andersson" });
-    expect(res).toHaveLength(1);
+    const { caller } = makeCaller({ paymentPlans: [plan()] });
+    expect(await caller.list({ search: "andersson" })).toHaveLength(1);
   });
 });
 
 describe("paymentPlan.getById", () => {
-  it("returnerar planen när den finns i org:en", async () => {
-    const plan = joinedPlan();
-    mockPrisma.paymentPlan.findFirst.mockResolvedValue(plan);
-    expect(await makeCaller().getById({ id: "pp-1" })).toBe(plan);
+  it("returnerar planen (med reminders) när den finns i org:en", async () => {
+    const { caller } = makeCaller({ paymentPlans: [plan()] });
+    const res = await caller.getById({ id: "pp-1" });
+    expect(res.id).toBe("pp-1");
+    expect(Array.isArray(res.reminders)).toBe(true);
   });
 
   it("NOT_FOUND när planen saknas/ej i org", async () => {
-    mockPrisma.paymentPlan.findFirst.mockResolvedValue(null);
-    await expect(makeCaller().getById({ id: "x" })).rejects.toMatchObject({ code: "NOT_FOUND" });
+    const { caller } = makeCaller({ paymentPlans: [plan()] });
+    await expect(caller.getById({ id: "x" })).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 });
 
 describe("paymentPlan.cancel", () => {
   it("avbryter en aktiv plan → CANCELLED + invoice tillbaka SENT", async () => {
-    mockPrisma.paymentPlan.findFirst.mockResolvedValue({ id: "pp-1", status: "ACTIVE", invoiceId: "inv-1" });
-    const res = await makeCaller().cancel({ planId: "pp-1" });
-    expect(res).toEqual({ ok: true });
-    expect(mockPrisma.paymentPlan.update).toHaveBeenCalledWith({ where: { id: "pp-1" }, data: { status: "CANCELLED" } });
-    expect(mockPrisma.invoice.update).toHaveBeenCalledWith({ where: { id: "inv-1" }, data: { status: "SENT" } });
+    const { caller, store } = makeCaller({ paymentPlans: [plan({ status: "ACTIVE" })] });
+    expect(await caller.cancel({ planId: "pp-1" })).toEqual({ ok: true });
+    const pp = (src(store).paymentPlans as Array<{ id: string; status: string }>).find((p) => p.id === "pp-1")!;
+    expect(pp.status).toBe("CANCELLED");
+    const inv = (src(store).invoices as Array<{ id: string; status: string }>).find((i) => i.id === "inv-1")!;
+    expect(inv.status).toBe("SENT");
   });
 
   it("NOT_FOUND när planen inte tillhör org:en", async () => {
-    mockPrisma.paymentPlan.findFirst.mockResolvedValue(null);
-    await expect(makeCaller("org-b").cancel({ planId: "pp-1" })).rejects.toMatchObject({ code: "NOT_FOUND" });
-    expect(mockPrisma.paymentPlan.update).not.toHaveBeenCalled();
+    const { caller, store } = makeCaller({ paymentPlans: [plan()] }, "org-b");
+    await expect(caller.cancel({ planId: "pp-1" })).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect((src(store).paymentPlans as Array<{ status: string }>)[0]!.status).toBe("ACTIVE");
   });
 
   it("BAD_REQUEST när planen inte är ACTIVE", async () => {
-    mockPrisma.paymentPlan.findFirst.mockResolvedValue({ id: "pp-1", status: "CANCELLED", invoiceId: "inv-1" });
-    await expect(makeCaller().cancel({ planId: "pp-1" })).rejects.toMatchObject({ code: "BAD_REQUEST" });
-    expect(mockPrisma.paymentPlan.update).not.toHaveBeenCalled();
+    const { caller } = makeCaller({ paymentPlans: [plan({ status: "CANCELLED" })] });
+    await expect(caller.cancel({ planId: "pp-1" })).rejects.toMatchObject({ code: "BAD_REQUEST" });
   });
 });
 
 describe("paymentPlan.scanDueReminders (#23)", () => {
-  beforeEach(() => {
-    mockPrisma.paymentPlanReminder.create.mockImplementation(
-      ({ data }: { data: Record<string, unknown> }) => Promise.resolve({ ...data }),
-    );
-  });
-
   it("genererar en DUE-påminnelse när förfallodagen passerat innevarande månad", async () => {
-    // startDate samma månad som asOf → ingen OVERDUE; asOf-datum 20 ≥ dayOfMonth 15 → DUE.
-    mockPrisma.paymentPlan.findMany.mockResolvedValue([joinedPlan({ startDate: "2026-06-01" })]);
-    const res = await makeCaller().scanDueReminders({ asOf: "2026-06-20T00:00:00.000Z" });
+    const { caller, store } = makeCaller({ paymentPlans: [plan({ startDate: "2026-06-01" })] });
+    const res = await caller.scanDueReminders({ asOf: "2026-06-20T00:00:00.000Z" });
     expect(res.scanned).toBe(1);
     expect(res.due).toBe(1);
     expect(res.overdue).toBe(0);
-    expect(mockPrisma.paymentPlanReminder.create).toHaveBeenCalledWith(
-      expect.objectContaining({ data: expect.objectContaining({ planId: "pp-1", dueMonth: "2026-06", type: "DUE" }) }),
-    );
+    const rem = (src(store).paymentPlanReminders as Array<Record<string, unknown>>)[0]!;
+    expect(rem).toMatchObject({ planId: "pp-1", dueMonth: "2026-06", type: "DUE" });
   });
 
   it("genererar en OVERDUE-påminnelse för föregående månad", async () => {
-    // startDate i maj, asOf i juni → föregående månad (maj) obetald → OVERDUE.
-    mockPrisma.paymentPlan.findMany.mockResolvedValue([joinedPlan({ startDate: "2026-05-01" })]);
-    const res = await makeCaller().scanDueReminders({ asOf: "2026-06-20T00:00:00.000Z" });
+    const { caller } = makeCaller({ paymentPlans: [plan({ startDate: "2026-05-01" })] });
+    const res = await caller.scanDueReminders({ asOf: "2026-06-20T00:00:00.000Z" });
     expect(res.overdue).toBe(1);
-    expect(mockPrisma.paymentPlanReminder.create).toHaveBeenCalledWith(
-      expect.objectContaining({ data: expect.objectContaining({ type: "OVERDUE", dueMonth: "2026-05" }) }),
-    );
   });
 
   it("hoppar över redan loggade påminnelser (idempotent)", async () => {
-    mockPrisma.paymentPlan.findMany.mockResolvedValue([
-      joinedPlan({ startDate: "2026-06-01", reminders: [{ dueMonth: "2026-06", type: "DUE" }] }),
-    ]);
-    const res = await makeCaller().scanDueReminders({ asOf: "2026-06-20T00:00:00.000Z" });
+    const { caller, store } = makeCaller({
+      paymentPlans: [plan({ startDate: "2026-06-01" })],
+      paymentPlanReminders: [{ id: "r0", planId: "pp-1", dueMonth: "2026-06", type: "DUE", sentAt: new Date("2026-06-15") }],
+    });
+    const res = await caller.scanDueReminders({ asOf: "2026-06-20T00:00:00.000Z" });
     expect(res.due).toBe(0);
-    expect(mockPrisma.paymentPlanReminder.create).not.toHaveBeenCalled();
+    expect(src(store).paymentPlanReminders).toHaveLength(1); // ingen ny
   });
 
   it("tom org → scanned 0, inga påminnelser", async () => {
-    mockPrisma.paymentPlan.findMany.mockResolvedValue([]);
-    const res = await makeCaller().scanDueReminders();
-    expect(res).toMatchObject({ scanned: 0, planned: 0, due: 0, overdue: 0 });
+    const { caller } = makeCaller();
+    expect(await caller.scanDueReminders()).toMatchObject({ scanned: 0, planned: 0, due: 0, overdue: 0 });
   });
 });

--- a/test/unit/server/routers/preference.test.ts
+++ b/test/unit/server/routers/preference.test.ts
@@ -5,6 +5,8 @@
 
 import { TRPCError } from "@trpc/server";
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import { preferenceRouter } from "@/lib/server/routers/preference";
 import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
 
@@ -16,10 +18,11 @@ const mockPrisma = {
 };
 
 function makeCaller(role: "ADMIN" | "LAWYER" = "LAWYER", orgId = "org-a", userId = "u1") {
+  const dataStore = dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>);
   const ctx = {
     user: { id: userId, email: "a@b.se", name: "T", role, organizationId: orgId },
-    prisma: mockPrisma,
-    dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+    prisma: mockPrisma, dataStore,
+    repos: buildInMemoryRepositories(dataStore as unknown as IDataStore),
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return preferenceRouter.createCaller(ctx as any);
@@ -57,7 +60,7 @@ describe("prefs.save (upsert)", () => {
     mockPrisma.userPreference.update.mockResolvedValue({ id: "p1" });
     await makeCaller().save({ key: "list.contacts", prefs: { sort: "email" } });
     expect(mockPrisma.userPreference.update).toHaveBeenCalledWith(expect.objectContaining({
-      where: { id: "p1" }, data: { prefs: { sort: "email" } },
+      where: { id: "p1" }, data: expect.objectContaining({ prefs: { sort: "email" } }),
     }));
   });
 });

--- a/test/unit/server/routers/reports-ar-summary.test.ts
+++ b/test/unit/server/routers/reports-ar-summary.test.ts
@@ -8,6 +8,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import { reportsRouter } from "@/lib/server/routers/reports";
 import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
 
@@ -23,7 +25,9 @@ const mockPrisma = {
 function makeCaller(orgId = "org-a") {
   const ctx = {
     user: { id: "u-self", email: "a@b.se", name: "T", role: "LAWYER", organizationId: orgId },
-    prisma: mockPrisma, dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+    prisma: mockPrisma,
+    dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+    get repos() { return buildInMemoryRepositories(this.dataStore as unknown as IDataStore); },
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return reportsRouter.createCaller(ctx as any);

--- a/test/unit/server/routers/reports-billed.test.ts
+++ b/test/unit/server/routers/reports-billed.test.ts
@@ -5,6 +5,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import { reportsRouter } from "@/lib/server/routers/reports";
 import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
 
@@ -19,7 +21,9 @@ const mockPrisma = {
 function makeCaller(orgId = "org-a") {
   const ctx = {
     user: { id: "u-self", email: "a@b.se", name: "T", role: "LAWYER", organizationId: orgId },
-    prisma: mockPrisma, dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+    prisma: mockPrisma,
+    dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+    get repos() { return buildInMemoryRepositories(this.dataStore as unknown as IDataStore); },
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return reportsRouter.createCaller(ctx as any);

--- a/test/unit/server/routers/reports.test.ts
+++ b/test/unit/server/routers/reports.test.ts
@@ -3,6 +3,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import { reportsRouter } from "@/lib/server/routers/reports";
 import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
 
@@ -15,7 +17,9 @@ const mockPrisma = {
 function makeCaller(orgId = "org-a") {
   const ctx = {
     user: { id: "u-self", email: "a@b.se", name: "T", role: "LAWYER", organizationId: orgId },
-    prisma: mockPrisma, dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+    prisma: mockPrisma,
+    dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+    get repos() { return buildInMemoryRepositories(this.dataStore as unknown as IDataStore); },
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return reportsRouter.createCaller(ctx as any);

--- a/test/unit/server/routers/timeEntry.test.ts
+++ b/test/unit/server/routers/timeEntry.test.ts
@@ -3,6 +3,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import { timeEntryRouter } from "@/lib/server/routers/timeEntry";
 import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
 
@@ -17,14 +19,16 @@ const mockPrisma = {
     delete: vi.fn(),
   },
   user: {
-    findUniqueOrThrow: vi.fn(),
+    findFirst: vi.fn(),
   },
 };
 
 function makeCaller(orgId = "org-a", userId = "u1") {
+  const dataStore = dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>);
   const ctx = {
     user: { id: userId, email: "a@b.se", name: "T", role: "LAWYER", organizationId: orgId },
-    prisma: mockPrisma, dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+    prisma: mockPrisma, dataStore,
+    repos: buildInMemoryRepositories(dataStore as unknown as IDataStore),
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return timeEntryRouter.createCaller(ctx as any);
@@ -74,7 +78,7 @@ describe("timeEntry.list", () => {
 
 describe("timeEntry.create", () => {
   it("kopplar userId och hourlyRate från user-record", async () => {
-    mockPrisma.user.findUniqueOrThrow.mockResolvedValue({ hourlyRate: 3000 });
+    mockPrisma.user.findFirst.mockResolvedValue({ hourlyRate: 3000 });
     mockPrisma.timeEntry.create.mockResolvedValue({});
     await makeCaller("org-a", "u-9").create({
       matterId: "m1",
@@ -90,7 +94,7 @@ describe("timeEntry.create", () => {
   });
 
   it("nollställer hourlyRate om user saknar timtaxa", async () => {
-    mockPrisma.user.findUniqueOrThrow.mockResolvedValue({ hourlyRate: null });
+    mockPrisma.user.findFirst.mockResolvedValue({ hourlyRate: null });
     mockPrisma.timeEntry.create.mockResolvedValue({});
     await makeCaller().create({
       matterId: "m1",

--- a/test/unit/server/routers/todo.test.ts
+++ b/test/unit/server/routers/todo.test.ts
@@ -5,6 +5,8 @@
 
 import { TRPCError } from "@trpc/server";
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import { todoRouter } from "@/lib/server/routers/todo";
 import { dataStoreFromMockPrisma } from "../helpers/mock-data-store";
 
@@ -17,10 +19,11 @@ const mockPrisma = {
 };
 
 function makeCaller(orgId = "org-a", userId = "u1") {
+  const dataStore = dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>);
   const ctx = {
     user: { id: userId, email: "a@b.se", name: "T", role: "LAWYER", organizationId: orgId },
-    prisma: mockPrisma,
-    dataStore: dataStoreFromMockPrisma(mockPrisma as unknown as Record<string, unknown>),
+    prisma: mockPrisma, dataStore,
+    repos: buildInMemoryRepositories(dataStore as unknown as IDataStore),
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return todoRouter.createCaller(ctx as any);


### PR DESCRIPTION
## Summary

Completes the **ADR 0020** migration: every tRPC router now reads/writes through the typed per-entity repository seam (`ctx.repos`) instead of the Prisma-shaped `ctx.dataStore` (`IDataStore`). After this batch **no router references `ctx.dataStore`** for data access (only the events seam remains, by design).

Each entity has an `InMemoryRepository` (browser/offline/demo — the live runtime) and a `DrizzleRepository` (server, parity-tested with pglite), exposing explicit typed methods instead of dynamic `where`/`include` objects.

## Routers migrated in this batch
`documentTemplate`, `expectedReceivable`, `invoiceDispatch`, `organization`, `preference`, `todo`, `timeEntry`, document `core`/`folders`/`events`/`suggestions`, `mail`, `kostnadsräkning`, `conflict`, `paymentPlan`, `billingRun`, `reports`, `matter`.

## New repositories
`Document`, `DocumentFolder`, `MatterEventSuggestion`, `DocumentSuggestion`, `ConflictCheck`, `MatterContact`, `PaymentPlanReminder`, `BillingRun` — plus method extensions across `TimeEntry`/`Expense`/`Invoice`/`Payment`/`WriteOff`/`Matter`/`Contact`/`PaymentPlan`.

## Notable
- Deep nested reads (paymentPlan list/detail/scan) use Drizzle's relational `db.query` with new `matters`/`matterContacts` relations; `_count` + KLIENT-contact via grouped queries / raw subqueries on the in-memory + Drizzle paths.
- Mutating routers run via `repos.transaction`; `DataStoreTx` gained `paymentPlanReminders`.
- Brittle Prisma-mock router tests rewritten against a **real in-memory store** (observable-outcome assertions); per-repo parity tests (in-memory + pglite) added throughout.

## Verification
`bun run quality` (typecheck + lint + full test:cov + jscpd + dep-cruiser + knip) and `bun run build:demo` green on every commit. Coverage ~88.3% lines / ~84.5% funcs (above floor).

Refs #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)