### PR TITLE
test(coverage): höj ratchet-golvet → 87.8%/83.0% efter ADR 0020-migreringen (#27)

### DIFF
--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -38,9 +38,13 @@ const FAST = process.argv.includes("--fast");
 // arSummary-router) → 87.0 (paymentPlan list/cancel/scanDueReminders) → 87.1
 // (document/core listDocumentTypes/markExternallyEdited/analyze-catch) → 87.2
 // (calendar getById/listForMatter/setMirrorState, lokalt 87.89% rader, ~0.69%
-// marginal — FUNC_FLOOR konservativt pga Node-version-varians).
-const LINE_FLOOR = 0.872;
-const FUNC_FLOOR = 0.80;
+// marginal — FUNC_FLOOR konservativt pga Node-version-varians) → 87.8 rader /
+// 83.0 funktioner (ADR 0020 repo-migrering #409: alla routrar mot ctx.repos +
+// per-repo paritetstester lyfte lokalt till 88.33% rader / 84.53% funktioner;
+// golvet låses just under, ~0.5% rad-marginal / ~1.5% funktions-marginal för
+// Node-version-varians).
+const LINE_FLOOR = 0.878;
+const FUNC_FLOOR = 0.83;
 
 /**
  * SERIAL_FILES — testfiler som SYNKRONT spawnar en barnprocess via


### PR DESCRIPTION
## Summary

Ratchet-steg mot 95%-målet (#27): den nyligen mergeade ADR 0020-repo-migreringen (#409) lade per-entitet-repositories med paritetstester (in-memory + pglite) för **alla** migrerade routrar, vilket lyfte täckningen lokalt till **88.33% rader / 84.53% funktioner**.

Det här PR:t låser in vinsten genom att flytta golvet uppåt:
- `LINE_FLOOR` 0.872 → **0.878**
- `FUNC_FLOOR` 0.80 → **0.83**

Konservativ marginal kvar (~0.5% rad, ~1.5% funktion) för Node-version-variansen mellan lokalt (Node 22) och CI (Node 24). Inga produktionsändringar — bara golvet i `tooling/scripts/run-tests.ts`.

`bun run quality` grön: 88.33% rader (golv 87.80%) / 84.53% funktioner (golv 83.00%).

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)