### PR TITLE
feat(repositories): buildDrizzleRepositories — server-authoritativt Repositories-aggregat (#409)

### DIFF
--- a/src/lib/server/repositories/drizzle-repositories.ts
+++ b/src/lib/server/repositories/drizzle-repositories.ts
@@ -1,0 +1,92 @@
+/**
+ * `buildDrizzleRepositories` (ADR 0020 / #409) — bygger `Repositories`-aggregatet
+ * ovanpå en Drizzle/Postgres-`AppDb` (server-authoritativa vägen). Speglar
+ * `buildInMemoryRepositories`: samma 28 entiteter, samma `transaction`-semantik.
+ *
+ * `transaction` använder Drizzles `db.transaction` (riktig SQL-transaktion med
+ * rollback vid kast); callbacken får en tx-scopad repos-vy. Nästlad
+ * `transaction` i den vyn är reentrant (delar samma tx — ingen ny savepoint),
+ * exakt som in-memory-aggregatets reentranta no-op.
+ *
+ * Server-runtimen (#410) injicerar detta via `buildContext({ repos })`. En
+ * konkret Postgres-anslutning (node-postgres/`postgres`) wiras i runtimen — det
+ * här laget är driver-agnostiskt (tar emot `AppDb`).
+ */
+
+import type { AppDb } from "../db/types";
+import { DrizzleAccontoDeductionRepository } from "./drizzle-acconto-deduction-repository";
+import { DrizzleBillingRunRepository } from "./drizzle-billing-run-repository";
+import { DrizzleCalendarEventRepository } from "./drizzle-calendar-event-repository";
+import { DrizzleConflictCheckRepository } from "./drizzle-conflict-check-repository";
+import { DrizzleContactRepository } from "./drizzle-contact-repository";
+import { DrizzleDocumentFolderRepository } from "./drizzle-document-folder-repository";
+import { DrizzleDocumentRepository } from "./drizzle-document-repository";
+import { DrizzleDocumentSuggestionRepository } from "./drizzle-document-suggestion-repository";
+import { DrizzleDocumentTemplateRepository } from "./drizzle-document-template-repository";
+import { DrizzleExpectedReceivableRepository } from "./drizzle-expected-receivable-repository";
+import { DrizzleExpenseRepository } from "./drizzle-expense-repository";
+import { DrizzleInvoiceDispatchRepository } from "./drizzle-invoice-dispatch-repository";
+import { DrizzleInvoiceRepository } from "./drizzle-invoice-repository";
+import { DrizzleMatterContactRepository } from "./drizzle-matter-contact-repository";
+import { DrizzleMatterEventSuggestionRepository } from "./drizzle-matter-event-suggestion-repository";
+import { DrizzleMatterRepository } from "./drizzle-matter-repository";
+import { DrizzleOfficeRepository } from "./drizzle-office-repository";
+import { DrizzleOrgPreferenceRepository } from "./drizzle-org-preference-repository";
+import { DrizzleOrganizationRepository } from "./drizzle-organization-repository";
+import { DrizzlePaymentPlanReminderRepository } from "./drizzle-payment-plan-reminder-repository";
+import { DrizzlePaymentPlanRepository } from "./drizzle-payment-plan-repository";
+import { DrizzlePaymentRepository } from "./drizzle-payment-repository";
+import { DrizzleServiceNoteRepository } from "./drizzle-service-note-repository";
+import { DrizzleTaskRepository } from "./drizzle-task-repository";
+import { DrizzleTimeEntryRepository } from "./drizzle-time-entry-repository";
+import { DrizzleUserPreferenceRepository } from "./drizzle-user-preference-repository";
+import { DrizzleUserRepository } from "./drizzle-user-repository";
+import { DrizzleWriteOffRepository } from "./drizzle-write-off-repository";
+import type { Repositories } from "./repositories";
+
+/** De entitets-bundna repona (utan `transaction`) för en given db/tx-handle. */
+function entityRepos(db: AppDb): Omit<Repositories, "transaction"> {
+  return {
+    invoices: new DrizzleInvoiceRepository(db),
+    matters: new DrizzleMatterRepository(db),
+    payments: new DrizzlePaymentRepository(db),
+    writeOffs: new DrizzleWriteOffRepository(db),
+    paymentPlans: new DrizzlePaymentPlanRepository(db),
+    paymentPlanReminders: new DrizzlePaymentPlanReminderRepository(db),
+    timeEntries: new DrizzleTimeEntryRepository(db),
+    expenses: new DrizzleExpenseRepository(db),
+    accontoDeductions: new DrizzleAccontoDeductionRepository(db),
+    billingRuns: new DrizzleBillingRunRepository(db),
+    contacts: new DrizzleContactRepository(db),
+    matterContacts: new DrizzleMatterContactRepository(db),
+    conflictChecks: new DrizzleConflictCheckRepository(db),
+    users: new DrizzleUserRepository(db),
+    tasks: new DrizzleTaskRepository(db),
+    calendarEvents: new DrizzleCalendarEventRepository(db),
+    serviceNotes: new DrizzleServiceNoteRepository(db),
+    documents: new DrizzleDocumentRepository(db),
+    documentFolders: new DrizzleDocumentFolderRepository(db),
+    matterEventSuggestions: new DrizzleMatterEventSuggestionRepository(db),
+    documentAnalysisSuggestions: new DrizzleDocumentSuggestionRepository(db),
+    documentTemplates: new DrizzleDocumentTemplateRepository(db),
+    expectedReceivables: new DrizzleExpectedReceivableRepository(db),
+    invoiceDispatches: new DrizzleInvoiceDispatchRepository(db),
+    organizations: new DrizzleOrganizationRepository(db),
+    offices: new DrizzleOfficeRepository(db),
+    userPreferences: new DrizzleUserPreferenceRepository(db),
+    orgPreferences: new DrizzleOrgPreferenceRepository(db),
+  };
+}
+
+/** Repos-vy bunden till en pågående tx — nästlad `transaction` är reentrant. */
+function reposForTx(tx: AppDb): Repositories {
+  const repos: Repositories = { ...entityRepos(tx), transaction: (fn) => fn(repos) };
+  return repos;
+}
+
+export function buildDrizzleRepositories(db: AppDb): Repositories {
+  return {
+    ...entityRepos(db),
+    transaction: (fn) => db.transaction((tx) => fn(reposForTx(tx as unknown as AppDb))),
+  };
+}

--- a/test/unit/server/repositories/drizzle-repositories.test.ts
+++ b/test/unit/server/repositories/drizzle-repositories.test.ts
@@ -1,0 +1,76 @@
+/**
+ * `buildDrizzleRepositories` (ADR 0020 / #409) — kontraktstest mot pglite.
+ * Verifierar att aggregatet wirar alla entiteter + att `transaction` ger en
+ * riktig SQL-transaktion (commit vid success, rollback vid kast, reentrant nästling).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import type { AppDb } from "@/lib/server/db/types";
+import { buildDrizzleRepositories } from "@/lib/server/repositories/drizzle-repositories";
+import type { Organization } from "@/lib/shared/schemas/organization";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+const ORG_KEYS = [
+  "invoices", "matters", "payments", "writeOffs", "paymentPlans", "paymentPlanReminders",
+  "timeEntries", "expenses", "accontoDeductions", "billingRuns", "contacts", "matterContacts",
+  "conflictChecks", "users", "tasks", "calendarEvents", "serviceNotes", "documents",
+  "documentFolders", "matterEventSuggestions", "documentAnalysisSuggestions", "documentTemplates",
+  "expectedReceivables", "invoiceDispatches", "organizations", "offices", "userPreferences", "orgPreferences",
+] as const;
+
+const org = (id: string, name = "X") => ({ id, name }) as unknown as Partial<Organization>;
+
+describe("buildDrizzleRepositories — kontrakt (pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("wirar alla 28 entitets-repos + transaction", () => {
+    const repos = buildDrizzleRepositories(handle.db as unknown as AppDb);
+    for (const k of ORG_KEYS) {
+      expect(repos[k], `saknar repo: ${k}`).toBeDefined();
+      expect(typeof (repos[k] as { getById?: unknown }).getById).toBe("function");
+    }
+    expect(typeof repos.transaction).toBe("function");
+  });
+
+  it("bas-CRUD round-trippar via aggregatet (create → getById)", async () => {
+    const repos = buildDrizzleRepositories(handle.db as unknown as AppDb);
+    const id = uuidv7();
+    const created = await repos.organizations.create(org(id, "Aggregat AB"));
+    expect((created as { version?: number }).version).toBe(1);
+    expect(await repos.organizations.getById(id)).toMatchObject({ id, name: "Aggregat AB" });
+  });
+
+  it("transaction committar vid success", async () => {
+    const repos = buildDrizzleRepositories(handle.db as unknown as AppDb);
+    const id = uuidv7();
+    await repos.transaction(async (tx) => { await tx.organizations.create(org(id)); });
+    expect(await repos.organizations.getById(id)).toMatchObject({ id });
+  });
+
+  it("transaction rullar tillbaka vid kast (inget delvis committat)", async () => {
+    const repos = buildDrizzleRepositories(handle.db as unknown as AppDb);
+    const id = uuidv7();
+    await expect(
+      repos.transaction(async (tx) => {
+        await tx.organizations.create(org(id));
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    expect(await repos.organizations.getById(id)).toBeNull();
+  });
+
+  it("nästlad transaction är reentrant (delar samma tx → committar tillsammans)", async () => {
+    const repos = buildDrizzleRepositories(handle.db as unknown as AppDb);
+    const a = uuidv7();
+    const b = uuidv7();
+    await repos.transaction(async (tx) => {
+      await tx.organizations.create(org(a, "Yttre"));
+      await tx.transaction(async (inner) => { await inner.organizations.create(org(b, "Inre")); });
+    });
+    expect(await repos.organizations.getById(a)).toMatchObject({ id: a });
+    expect(await repos.organizations.getById(b)).toMatchObject({ id: b });
+  });
+});


### PR DESCRIPTION
## Summary

Bygger **`buildDrizzleRepositories(db)`** — `Repositories`-aggregatet ovanpå en Drizzle/Postgres-`AppDb`, dvs den server-authoritativa data-vägen i ADR 0016.

ADR 0020 (#458) lade de 28 typade `DrizzleXRepository`-klasserna (alla pglite-paritetstestade) + reserverade injektionssömmen i `buildContext` (`repos?: Repositories` — *"Server-runtimen (#410) injicerar Drizzle-repos"*). Det här PR:t assemblerar dem till aggregatet och lägger `transaction`-semantiken — så seamen har nu en server-backad implementation, redo att injiceras av HTTP-runtimen (#410).

## Detaljer
- `transaction` använder Drizzles `db.transaction` → riktig SQL-transaktion: **commit vid success, rollback vid kast**, och **reentrant nästling** (nästlad `transaction` delar samma tx — speglar `buildInMemoryRepositories` exakt).
- **Driver-agnostiskt** (tar emot `AppDb`). Konkret Postgres-anslutning (node-postgres/`postgres`) wiras i server-runtimen #410, inte här — det här laget är ren assembly.
- Påverkar INTE den live in-memory-vägen (demo/git): default i `buildContext` är fortfarande `buildInMemoryRepositories`.

## Verifiering
Kontraktstest mot pglite: alla 28 entitets-repos wirade + `transaction` commit/rollback/nästling. `bun run quality` grön (88.35% rader / 84.55% funktioner) + `bun run build:demo` grön.

Refs #409 (kritiska vägens första länk i server-spinen #409 → #410 → #411).

🤖 Generated with [Claude Code](https://claude.com/claude-code)