### PR TITLE
ci: kör Drizzle-repository-sviten mot riktig Postgres i docker (server-test-harness)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,34 @@ jobs:
           name: coverage
           path: coverage/
 
+  # ───────────────── Repository (Postgres) ─────────────────
+  # Kör Drizzle-repository-sviten (+ buildDrizzleRepositories-aggregatet) mot en
+  # RIKTIG Postgres i docker (compose), inte bara pglite (WASM). Fångar driver-/
+  # SQL-skillnader inför server-runtimen (#410). Grunden för server-sync-E2E (#422):
+  # docker-compose.test.yml får en `server`-tjänst när #410 landar.
+  repository-postgres:
+    name: Repository (Postgres)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - name: Start Postgres (docker compose)
+        run: docker compose -f tooling/docker/docker-compose.test.yml up -d --wait --wait-timeout 90
+      - name: Repository-tester mot riktig Postgres
+        env:
+          PG_TEST_URL: postgres://ava:ava@localhost:5433/ava_test
+        run: bun test test/unit/server/repositories/ test/unit/server/db/relations.test.ts
+      - name: Tear down docker
+        if: always()
+        run: docker compose -f tooling/docker/docker-compose.test.yml down -v
+
   # ───────────────── E2E (git round-trip) ─────────────────
   # Den riktiga browser-klienten klonar/pushar mot docker-git-servern
   # (self-hosted). Auth: PAT bootstrappas av web-containern; vi exporterar

--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
         "next": "16.2.7",
         "nodemailer": "^8.0.11",
         "pdfjs-dist": "^6.0.227",
+        "postgres": "^3.4.9",
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "superjson": "^2.2.6",
@@ -1313,6 +1314,8 @@
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "next": "16.2.7",
     "nodemailer": "^8.0.11",
     "pdfjs-dist": "^6.0.227",
+    "postgres": "^3.4.9",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "superjson": "^2.2.6",

--- a/test/unit/server/db/pg-test-db.ts
+++ b/test/unit/server/db/pg-test-db.ts
@@ -1,30 +1,64 @@
 /**
- * pglite-testhjälp (ADR 0019/0020) — kör en riktig Postgres-motor in-process
- * (WASM, ingen docker) och applicerar de genererade drizzle-migrationerna, så
- * Drizzle-repositories kan testas mot äkta SQL. `--> statement-breakpoint`-
- * raderna i migrations-SQL:en är `--`-kommentarer → hela filen kan exec:as.
+ * Postgres-testhjälp (ADR 0019/0020). Två lägen, samma `createTestDb()`-API:
+ *
+ *  - **Default (pglite):** kör en Postgres-motor in-process (WASM, ingen docker)
+ *    — snabbt, körs i den vanliga unit-test-jobben.
+ *  - **`PG_TEST_URL` satt:** kör mot en RIKTIG Postgres (docker-compose.test.yml
+ *    i CI:s "Repository (Postgres)"-jobb) → fångar driver-/SQL-skillnader som
+ *    WASM-emuleringen missar. Varje handle får ett isolerat schema (migrationerna
+ *    är icke-idempotenta `CREATE TABLE`), som droppas på `close`.
+ *
+ * `--> statement-breakpoint`-raderna i migrations-SQL:en är `--`-kommentarer →
+ * hela filen kan exec:as i ett svep.
  */
 
 import { readFileSync, readdirSync } from "node:fs";
 import { PGlite } from "@electric-sql/pglite";
-import { drizzle } from "drizzle-orm/pglite";
+import { drizzle as drizzlePglite } from "drizzle-orm/pglite";
+import { drizzle as drizzlePostgres } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
 import * as schema from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import { uuidv7 } from "@/lib/shared/uuid";
 
 const MIGRATIONS_DIR = "tooling/db/migrations";
 
-export type TestDb = ReturnType<typeof drizzle<typeof schema>>;
-
 export interface TestDbHandle {
-  db: TestDb;
+  db: AppDb;
   close: () => Promise<void>;
 }
 
-export async function createTestDb(): Promise<TestDbHandle> {
+function migrationSql(): string[] {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith(".sql")).sort()
+    .map((f) => readFileSync(`${MIGRATIONS_DIR}/${f}`, "utf8"));
+}
+
+async function createPgliteTestDb(): Promise<TestDbHandle> {
   const client = new PGlite();
-  const db = drizzle(client, { schema });
-  const files = readdirSync(MIGRATIONS_DIR).filter((f) => f.endsWith(".sql")).sort();
-  for (const f of files) {
-    await client.exec(readFileSync(`${MIGRATIONS_DIR}/${f}`, "utf8"));
-  }
-  return { db, close: () => client.close() };
+  const db = drizzlePglite(client, { schema });
+  for (const sql of migrationSql()) await client.exec(sql);
+  return { db: db as unknown as AppDb, close: () => client.close() };
+}
+
+/** Mot riktig Postgres: isolerat schema per handle (parallell-säkert), droppas på close. */
+async function createRealPgTestDb(url: string): Promise<TestDbHandle> {
+  const schemaName = `t_${uuidv7().replace(/-/g, "")}`;
+  // max:1 → en enda connection så search_path persisterar genom hela handle:n.
+  const client = postgres(url, { max: 1, onnotice: () => {} });
+  await client.unsafe(`CREATE SCHEMA "${schemaName}"; SET search_path TO "${schemaName}"`);
+  for (const sql of migrationSql()) await client.unsafe(sql);
+  const db = drizzlePostgres(client, { schema });
+  return {
+    db: db as unknown as AppDb,
+    close: async () => {
+      await client.unsafe(`DROP SCHEMA "${schemaName}" CASCADE`);
+      await client.end({ timeout: 5 });
+    },
+  };
+}
+
+export async function createTestDb(): Promise<TestDbHandle> {
+  const url = process.env.PG_TEST_URL;
+  return url ? createRealPgTestDb(url) : createPgliteTestDb();
 }

--- a/tooling/docker/docker-compose.test.yml
+++ b/tooling/docker/docker-compose.test.yml
@@ -1,0 +1,32 @@
+# AVA test-harness (ADR 0016) — Postgres för repository-/server-kedje-tester.
+#
+# Bär det "riktiga" beroendet test-sviten behöver för att köra mot äkta
+# Postgres i st.f. pglite (WASM). CI:s "Repository (Postgres)"-jobb gör:
+#
+#   docker compose -f tooling/docker/docker-compose.test.yml up -d --wait
+#   PG_TEST_URL=postgres://ava:ava@localhost:5433/ava_test bun test test/unit/server/repositories/
+#   docker compose -f tooling/docker/docker-compose.test.yml down -v
+#
+# Lokalt: samma kommandon. Port 5433 (ej 5432) → krockar inte med en lokal PG.
+#
+# Framåt (#410/#422): lägg till en `server`-tjänst (HTTP-tRPC-runtime ovanpå
+# samma postgres) här → server-sync-E2E kör hela kedjan i samma compose.
+
+name: ava-test
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: ava
+      POSTGRES_PASSWORD: ava
+      POSTGRES_DB: ava_test
+    ports:
+      - "5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ava -d ava_test"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+    tmpfs:
+      - /var/lib/postgresql/data # ephemeral — testdata behöver inte överleva


### PR DESCRIPTION
## Bakgrund

> "Can we have the CI pipeline build and run a docker container? … a docker-compose.yml can hold all we need to run proper tests."

**CI bygger + kör redan docker** — `E2E (git round-trip)`-jobbet gör `docker compose ... up -d --build --wait` mot web-containern. Det här PR:t lägger grunden för att testa **hela server-kedjan mot äkta Postgres** (inte bara pglite/WASM), vilket också är harnessen som server-sync-E2E (#422) byggs på.

## Ändringar
- **`tooling/docker/docker-compose.test.yml`** — `postgres:16`-tjänst (tmpfs, healthcheck, port 5433). Utbyggbar med en `server`-tjänst när HTTP-runtimen (#410) landar → hela kedjan i samma compose.
- **`createTestDb()` tar `PG_TEST_URL`**: satt → riktig Postgres via postgres-js, **isolerat schema per handle** (migrationerna är icke-idempotenta `CREATE TABLE`) som droppas på `close`; osatt → pglite som förut (snabbt; det vanliga unit-jobbet är **oförändrat**).
- **Nytt CI-jobb `Repository (Postgres)`**: `compose up postgres` → kör `test/unit/server/repositories/` + `db/relations` mot riktig PG → `compose down`.

## Verifierat lokalt (docker 29)
101 repository-tester gröna mot **Postgres 16** — inkl. `buildDrizzleRepositories`-aggregatets transaktioner, matter `_count`-grupperingar och KLIENT-joins. pglite-default oförändrad. `bun run quality` + `bun run build:demo` gröna.

Produktions-anslutningsfaktorn (`createPostgresDb`) för runtimen kommer med #410 (där den faktiskt konsumeras).

Refs #422 #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)