### PR TITLE
docs(adr): synka genomförande-status mot koden (0001/0016/0019/0020)

### DIFF
--- a/docs/adr/0001-pluggbar-backend-bakom-idatastore.md
+++ b/docs/adr/0001-pluggbar-backend-bakom-idatastore.md
@@ -1,6 +1,6 @@
 # ADR 0001 — Pluggbar backend bakom `IDataStore`/tRPC: Git (local-first) ⟷ Postgres (server)
 
-- **Status:** Reviderad av [ADR 0016](0016-server-first-med-offline-first-klient.md) (2026-06-16) — dual-backend-modellen ersatt av server-first (Postgres + tRPC) med offline-first klient; git-vägen (Backend A) pensioneras.
+- **Status:** Reviderad av [ADR 0016](0016-server-first-med-offline-first-klient.md) (2026-06-16) — dual-backend-modellen ersatt av server-first (Postgres + tRPC) med offline-first klient. Git-vägen (Backend A) pensioneras **stegvis** (issues #420/#421) och är fortfarande den aktiva backenden (server-runtime per [ADR 0005](0005-server-som-git-peer.md) + demo) tills server-spinen (#410/#411/#415) landat.
 - **Datum:** 2026-05-27
 - **Beslutsfattare:** Ulrik Sjölin
 - **Berör:** datalager, tRPC-routrar, deploy-modeller, framtida ACL

--- a/docs/adr/0016-server-first-med-offline-first-klient.md
+++ b/docs/adr/0016-server-first-med-offline-first-klient.md
@@ -1,6 +1,10 @@
 # ADR 0016 — Server-first med offline-first klient (Postgres + tRPC, lokal store + sync)
 
-- **Status:** Accepterad
+- **Status:** Accepterad (mål-arkitektur — genomförande pågår)
+- **Genomförande (per 2026-06-17):** Repository-sömmen (ADR 0020) klar med Drizzle-
+  + in-memory-impl. ÄNNU EJ byggt: Postgres-backad HTTP-tRPC-runtime + server-verifierad
+  Principal (#410), klientens `HttpDataStore` (#411) och `CachingSyncDataStore` (#415).
+  Server-runtimen är fortfarande git-peer (ADR 0005). Diagrammet/flödena nedan beskriver MÅLET.
 - **Datum:** 2026-06-16
 - **Beslutsfattare:** Ulrik Sjölin
 - **Berör:** datalager, tRPC-transport, deploy-modeller, offline-UX, demo, auth

--- a/docs/adr/0019-postgres-schema-och-db-toolchain.md
+++ b/docs/adr/0019-postgres-schema-och-db-toolchain.md
@@ -1,6 +1,7 @@
 # ADR 0019 — Postgres-schema & DB-toolchain (Drizzle, version/change-log, IDataStore-subset)
 
 - **Status:** Accepterad (beslut 5 — frusen arg-subset + tolk — **amenderat av [ADR 0020](0020-typat-repository-i-stallet-for-prisma-formad-seam.md)**: tolken ersätts av ett typat repository. Schema/toolchain/version/change-log (beslut 1–4) gäller fortsatt.)
+- **Genomförande:** Beslut 1–4 implementerade — `src/lib/server/db/schema.ts` + migrations (`tooling/db/migrations/`) + Drizzle-toolchain. Testas mot pglite (unit) och, sedan 2026-06-17, mot riktig Postgres i CI (`tooling/docker/docker-compose.test.yml`).
 - **Datum:** 2026-06-16
 - **Beslutsfattare:** Ulrik Sjölin
 - **Berör:** server-backend, DB-schema, migrations, reconcile, IDataStore-kontrakt

--- a/docs/adr/0020-typat-repository-i-stallet-for-prisma-formad-seam.md
+++ b/docs/adr/0020-typat-repository-i-stallet-for-prisma-formad-seam.md
@@ -1,6 +1,12 @@
 # ADR 0020 — Typat repository i stället för Prisma-formad `IDataStore`-söm
 
 - **Status:** Accepterad
+- **Genomförande:** Implementerad (2026-06-17). Alla router-filer läser/skriver via
+  `ctx.repos` (`Repositories`-aggregatet); in-memory- + Drizzle-impl finns för alla
+  28 entiteter; `buildInMemoryRepositories` (live demo/git-väg) + `buildDrizzleRepositories`
+  (server, transaktioner) byggda; per-repo paritetstester (pglite). `IDataStore`
+  samexisterar men används inte längre för dataåtkomst i routrarna. CI kör hela
+  Drizzle-repository-sviten mot riktig Postgres (`tooling/docker/docker-compose.test.yml`).
 - **Datum:** 2026-06-16
 - **Beslutsfattare:** Ulrik Sjölin
 - **Berör:** datalager-söm, routrar, PostgresStore, offline-klient, alla backends


### PR DESCRIPTION
## Summary

> "Make sure that the ADRs are in sync with the code."

Auditerade alla ADR:er (`docs/adr/*.md`) mot den faktiska koden. De är beslutsdokument och i allt väsentligt **i synk** — det som saknades var **genomförande-status** efter att repository-migreringen (ADR 0020) och Postgres-test-harnessen landat. Kirurgiska `Genomförande`-tillägg, **inga omskrivna motiveringar**:

- **0020** — status-not *Implementerad*: alla routrar läser/skriver via `ctx.repos`, in-memory + Drizzle för 28 entiteter, `buildInMemoryRepositories` + `buildDrizzleRepositories`, CI kör Drizzle-sviten mot riktig Postgres. (ADR:n lästes tidigare som en plan.)
- **0016** — markerar diagrammet som **MÅL-arkitektur**; genomförande pågår (repo-sömmen klar; #410/#411/#415 ej byggda; server-runtime fortfarande git-peer per ADR 0005). Hindrar att en läsare tror Postgres-runtimen redan kör.
- **0001** — förtydligar att git-vägen (Backend A) pensioneras **stegvis** (#420/#421) och är **fortfarande aktiv** (server-runtime + demo) tills server-spinen landat — inte redan borttagen.
- **0019** — genomförande-not: schema/migrations/toolchain implementerade; testas mot pglite (unit) + riktig Postgres i CI.

Övriga ADR:er (0002–0015) korrelerades och verifierades som i synk (0009 OIDC: web-app via oauth2-proxy, server-runtime via Bearer-PAT per ADR 0013 — stämmer med koden).

Dok-only ändring (4 filer, +13/−2); inga kod-/test-/CI-checkar berörs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)