### PR TITLE
feat(server): server-first HTTP-tRPC-runtime med server-verifierad principal (#410)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Repository-tester mot riktig Postgres
         env:
           PG_TEST_URL: postgres://ava:ava@localhost:5433/ava_test
-        run: bun test test/unit/server/repositories/ test/unit/server/db/relations.test.ts
+        run: bun test test/unit/server/repositories/ test/unit/server/db/relations.test.ts test/unit/server/http/server-context.test.ts test/unit/server/http/server-trpc-handler.test.ts
       - name: Tear down docker
         if: always()
         run: docker compose -f tooling/docker/docker-compose.test.yml down -v

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "demo:serve:fast": "SKIP_BUILD=1 bash tooling/scripts/demo-serve.sh",
     "seed:local": "bun tooling/scripts/seed-firma-local.ts",
     "server-runtime": "bun src/bin/server-runtime.ts",
+    "server-first": "bun src/bin/server-first.ts",
     "install:server": "bun tooling/scripts/install-server.ts",
     "bootstrap:admin": "bun tooling/scripts/bootstrap-admin.ts",
     "server-runtime:build": "bun tooling/scripts/build-server-runtime.ts",

--- a/src/bin/server-first.ts
+++ b/src/bin/server-first.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env bun
+/**
+ * Server-first-runtime (#410, ADR 0016) — körbar entry.
+ *
+ * Serverar `appRouter` över tRPC-over-HTTP mot den auktoritativa Postgres-db:n,
+ * med en server-verifierad principal ur oauth2-proxy:s forwarded headers
+ * (ADR 0009). Tänkt att sitta bakom nginx-fronten (loopback) — se
+ * `node-http-adapter` + `forwarded-claims` (förtroendegräns).
+ *
+ * All logik bor i testbara moduler (`server-first-api`, `server-trpc-handler`,
+ * `server-context`); den här filen är bara env + signaler + livscykel (samma
+ * tunna mönster som `bin/server-runtime.ts`).
+ *
+ *   AVA_DATABASE_URL      (obligatorisk)  postgres://…
+ *   AVA_ORGANIZATION_ID   (obligatorisk)  byråns org-id
+ *   AVA_HTTP_PORT         (default 3001)
+ *   AVA_HTTP_HOST         (default 127.0.0.1)
+ */
+
+import { serveFetchHandler } from "@/lib/server/http/node-http-adapter";
+import { buildServerFirstApi, loadServerFirstConfig } from "@/lib/server/http/server-first-api";
+
+function log(msg: string): void {
+  console.log(`[server-first] ${msg}`);
+}
+
+function main(): void {
+  if (process.argv.slice(2).includes("--help")) {
+    process.stdout.write(
+      "ava server-first (#410, ADR 0016)\n\n" +
+        "tRPC-over-HTTP mot Postgres med server-verifierad principal.\n\n" +
+        "Env: AVA_DATABASE_URL, AVA_ORGANIZATION_ID, AVA_HTTP_PORT, AVA_HTTP_HOST\n",
+    );
+    return;
+  }
+
+  const config = loadServerFirstConfig();
+  const api = buildServerFirstApi({
+    databaseUrl: config.databaseUrl,
+    organizationId: config.organizationId,
+    onError: (err) => log(`router-fel: ${String(err)}`),
+  });
+  const server = serveFetchHandler(api.handler, { port: config.httpPort, hostname: config.httpHost });
+  log(`lyssnar på ${config.httpHost}:${config.httpPort} (org ${config.organizationId})`);
+
+  for (const sig of ["SIGTERM", "SIGINT"] as const) {
+    process.on(sig, () => {
+      log(`${sig} — stoppar`);
+      server.close();
+      void api.close().finally(() => process.exit(0));
+    });
+  }
+}
+
+try {
+  main();
+} catch (err) {
+  process.stderr.write(`[server-first] startfel: ${String(err)}\n`);
+  process.exitCode = 1;
+}

--- a/src/lib/server/db/client.ts
+++ b/src/lib/server/db/client.ts
@@ -1,0 +1,41 @@
+/**
+ * `createPostgresDb` — produktions-Postgres-handle för server-first-runtimen
+ * (#410, ADR 0016/0019). node-postgres (`postgres`-drivern) + Drizzle, typad som
+ * den driver-agnostiska {@link AppDb} så repositoryn (ADR 0020) inte kopplas till
+ * en specifik driver.
+ *
+ * Server-only: drar in `postgres` + `drizzle-orm/postgres-js` och får ALDRIG
+ * hamna i klient-bundeln (dep-cruiser-grind). Anslutningen är lat — `postgres()`
+ * kopplar upp först vid första queryn.
+ *
+ * Testerna kör mot pglite/riktig Postgres via `test/.../pg-test-db.ts`
+ * (`createTestDb`); den här fabriken är produktionsvägen (composition-root
+ * `buildServerFirstApi` + `bin/server-first.ts`).
+ */
+
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import * as schema from "./schema";
+import type { AppDb } from "./types";
+
+export interface PostgresDb {
+  /** Drizzle-handle som repositoryn byggs ovanpå. */
+  db: AppDb;
+  /** Stäng connection-poolen (vid nedstängning). */
+  close: () => Promise<void>;
+}
+
+export interface PostgresDbOptions {
+  /** Max antal connections i poolen (default: postgres-js standard). */
+  max?: number;
+}
+
+/** Bygg ett Postgres-`AppDb`-handle mot `url` (t.ex. `postgres://…`). */
+export function createPostgresDb(url: string, opts: PostgresDbOptions = {}): PostgresDb {
+  const client = postgres(url, {
+    ...(opts.max !== undefined ? { max: opts.max } : {}),
+    onnotice: () => {},
+  });
+  const db = drizzle(client, { schema }) as unknown as AppDb;
+  return { db, close: () => client.end({ timeout: 5 }) };
+}

--- a/src/lib/server/http/forwarded-claims.ts
+++ b/src/lib/server/http/forwarded-claims.ts
@@ -1,0 +1,51 @@
+/**
+ * `forwarded-claims` — server-side OIDC-claims ur oauth2-proxy:s forwarded
+ * headers (#410, ADR 0016 server-first + ADR 0009 OIDC relying party).
+ *
+ * I server-first-runtimen verifieras principalen **server-side**: oauth2-proxy
+ * (#222) sitter framför nginx-fronten, gör hela OIDC-dansen, och injicerar den
+ * inloggade användarens claims som `X-Auth-Request-*`-headers
+ * (`OAUTH2_PROXY_SET_XAUTHREQUEST=true`). Detta är server-motsvarigheten till
+ * klientens `/oauth2/userinfo`-hämtning (`src/lib/client/backend/oidc-principal.ts`)
+ * och ger SAMMA claim-form (email + display-namn; `sub`/`iss` forwardas inte →
+ * email-only-modellen, #224/ADR 0009).
+ *
+ * **Förtroendegräns (KRITISK):** dessa headers får BARA litas på när requesten
+ * bevisligen passerat oauth2-proxy. I deployen sätter nginx dem via
+ * `auth_request_set` EFTER `auth_request /oauth2/auth` och MÅSTE strippa
+ * klient-skickade `X-Auth-Request-*` så en klient inte kan spoofa en identitet.
+ * Backenden lyssnar bara på loopback bakom fronten (se `node-http-adapter`).
+ */
+
+import type { OidcClaims } from "@/lib/server/auth/oidc-auth-provider";
+
+/** Header-namnen oauth2-proxy/nginx exponerar (gemener — `Headers.get` är case-insensitivt). */
+export interface ForwardedHeaderNames {
+  email: string;
+  user: string;
+  preferredUsername: string;
+}
+
+/** Default: oauth2-proxy:s `X-Auth-Request-*` (SET_XAUTHREQUEST). */
+export const DEFAULT_FORWARDED_HEADER_NAMES: ForwardedHeaderNames = {
+  email: "x-auth-request-email",
+  user: "x-auth-request-user",
+  preferredUsername: "x-auth-request-preferred-username",
+};
+
+/**
+ * Läs forwarded OIDC-claims ur request-headers. `null` när email saknas
+ * (ej inloggad / ej bakom oauth2-proxy) → principal-resolvern ger då `null`
+ * och skyddade procedurer kastar `UNAUTHORIZED`.
+ */
+export function forwardedClaims(
+  headers: Headers,
+  names: ForwardedHeaderNames = DEFAULT_FORWARDED_HEADER_NAMES,
+): OidcClaims | null {
+  const email = headers.get(names.email)?.trim();
+  if (!email) return null;
+  const preferred = headers.get(names.preferredUsername)?.trim();
+  const user = headers.get(names.user)?.trim();
+  // sub/iss forwardas inte av oauth2-proxy (email-only, #224/ADR 0009).
+  return { email, subject: "", issuer: "", name: preferred || user || "" };
+}

--- a/src/lib/server/http/server-context.ts
+++ b/src/lib/server/http/server-context.ts
@@ -1,0 +1,91 @@
+/**
+ * `createServerContext` — server-first-runtimens tRPC-`Context` (#410, ADR 0016).
+ *
+ * Bygger en `Context` per HTTP-request mot Postgres-backenden:
+ *   1. Verifierar principalen SERVER-SIDE ur oauth2-proxy:s forwarded headers
+ *      ({@link forwardedClaims}) mot byråns allowlist (`OidcAuthProvider`,
+ *      ADR 0009). Ingen självdeklarerad principal — till skillnad från
+ *      git/demo-vägen (ADR 0001/0016 §gränskontrakt punkt 4).
+ *   2. Exponerar de typade Drizzle-repositoryn (ADR 0020) via `ctx.repos`.
+ *
+ * `orgProcedure`/`protectedProcedure` (trpc-core) enforce:as därmed server-side:
+ * saknad/okänd identitet → `principal=null` → `UNAUTHORIZED`.
+ *
+ * `ctx.dataStore`: efter ADR 0020 läser routrarna ALL data via `ctx.repos`.
+ * Det enda som rör `ctx.dataStore` är emit-helpern (`events/emit.ts`). Postgres-
+ * backad event-logg hör till change-log-arbetet (ADR 0017/#408, ej byggt) →
+ * en sink vars `emit` kastar ett `ReadOnlyError`-namngivet fel som `safeEmit`
+ * sväljer tyst (precis som demo/git-vägen). Byts mot en Drizzle-logg vid #408.
+ */
+
+import type { AllowlistedUser } from "@/lib/server/auth/oidc-auth-provider";
+import { OidcAuthProvider } from "@/lib/server/auth/oidc-auth-provider";
+import { buildContext } from "@/lib/server/build-context";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import type { AvaEvent, EmitInput } from "@/lib/server/events/schema";
+import type { IPorts } from "@/lib/server/ports";
+import type { Repositories } from "@/lib/server/repositories/repositories";
+import type { Context } from "@/lib/server/trpc-core";
+import type { User } from "@/lib/shared/schemas/user";
+import { forwardedClaims, type ForwardedHeaderNames } from "./forwarded-claims";
+
+/**
+ * Event-sink för server-first innan change-loggen byggts (ADR 0017/#408).
+ * `name = "ReadOnlyError"` är kontraktet `safeEmit` (events/emit.ts) matchar på
+ * för att svälja felet tyst — håll det i synk om felnamnet ändras där.
+ */
+class EventLogNotBuiltError extends Error {
+  constructor() {
+    super("Server-first event-logg är inte byggd än (ADR 0017/#408).");
+    this.name = "ReadOnlyError";
+  }
+}
+
+/** Read-only event-logg: `emit` no-op:ar via ReadOnlyError, `query` ger []. */
+export const serverFirstEventLog = {
+  emit(_input: EmitInput): Promise<AvaEvent> {
+    return Promise.reject(new EventLogNotBuiltError());
+  },
+  query(): Promise<AvaEvent[]> {
+    return Promise.resolve([]);
+  },
+};
+
+// Routrarna rör bara `.events` på dataStore (allt annat via ctx.repos, ADR 0020).
+const serverDataStore = { events: serverFirstEventLog } as unknown as IDataStore;
+
+export interface ServerContextDeps {
+  /** Typade Drizzle-repositoryn (ADR 0020) för den auktoritativa Postgres-db:n. */
+  repos: Repositories;
+  /** Server-side ports (mail/sök/etc). */
+  ports: IPorts;
+  /**
+   * Byråns org (single-org server-MVP, ADR 0016). Avgränsar allowlisten
+   * principal-resolvern matchar claims mot.
+   */
+  organizationId: string;
+  /** Override av forwarded-header-namn (default oauth2-proxy `X-Auth-Request-*`). */
+  headerNames?: ForwardedHeaderNames;
+}
+
+/** Mappa en allowlist-rad ur full `User` → den delmängd `OidcAuthProvider` behöver. */
+function toAllowlist(users: readonly User[]): AllowlistedUser[] {
+  return users.map((u) => ({
+    id: u.id,
+    email: u.email,
+    name: u.name,
+    role: u.role,
+    organizationId: u.organizationId,
+    oidcSubject: u.oidcSubject ?? null,
+    oidcIssuer: u.oidcIssuer ?? null,
+    active: u.active ?? true,
+  }));
+}
+
+/** Bygg en server-first-`Context` för en inkommande HTTP-request. */
+export async function createServerContext(req: Request, deps: ServerContextDeps): Promise<Context> {
+  const claims = forwardedClaims(req.headers, deps.headerNames);
+  const users = await deps.repos.users.listByOrg(deps.organizationId);
+  const principal = new OidcAuthProvider(claims, toAllowlist(users)).getPrincipal();
+  return buildContext({ dataStore: serverDataStore, ports: deps.ports, principal, repos: deps.repos });
+}

--- a/src/lib/server/http/server-first-api.ts
+++ b/src/lib/server/http/server-first-api.ts
@@ -1,0 +1,92 @@
+/**
+ * `server-first-api` — composition-root för server-first-runtimens
+ * tRPC-over-HTTP-API (#410, ADR 0016). Knyter ihop:
+ *
+ *   createPostgresDb (db/client)        ← den auktoritativa Postgres-db:n
+ *   + buildDrizzleRepositories (ADR 0020) ← typade repos ovanpå db:n
+ *   + server-verifierad principal (server-context) ← oauth2-proxy-headers
+ *   → createServerTrpcHandler            ← fetch-handler (Request → Response)
+ *
+ * `bin/server-first.ts` är den tunna körbara entryn ovanpå detta (argv/env +
+ * `serveFetchHandler` + signaler) — all wiring-logik bor här (testbar).
+ */
+
+import { noopPorts } from "@/lib/server/adapters/noop-ports";
+import { createPostgresDb } from "@/lib/server/db/client";
+import type { IPorts } from "@/lib/server/ports";
+import { buildDrizzleRepositories } from "@/lib/server/repositories/drizzle-repositories";
+import { createServerTrpcHandler } from "./server-trpc-handler";
+
+export interface ServerFirstApiConfig {
+  /** Postgres-connection-URL (`postgres://…`). */
+  databaseUrl: string;
+  /** Byråns org (single-org server-MVP, ADR 0016). */
+  organizationId: string;
+  /** Server-side ports (default: no-op). */
+  ports?: IPorts;
+  /** tRPC-URL-prefix (default `/api/trpc`). */
+  endpoint?: string;
+  /** Max db-connections. */
+  maxConnections?: number;
+  /** Server-side fel-logg. */
+  onError?: (err: unknown) => void;
+}
+
+export interface ServerFirstApi {
+  /** Fetch-handler att montera (t.ex. via `serveFetchHandler`). */
+  handler: (req: Request) => Promise<Response>;
+  /** Stäng db-poolen vid nedstängning. */
+  close: () => Promise<void>;
+}
+
+/** Bygg server-first-API:t (handler + db-livscykel) ur en config. */
+export function buildServerFirstApi(config: ServerFirstApiConfig): ServerFirstApi {
+  const { db, close } = createPostgresDb(
+    config.databaseUrl,
+    config.maxConnections !== undefined ? { max: config.maxConnections } : {},
+  );
+  const repos = buildDrizzleRepositories(db);
+  const handler = createServerTrpcHandler({
+    repos,
+    ports: config.ports ?? noopPorts,
+    organizationId: config.organizationId,
+    ...(config.endpoint ? { endpoint: config.endpoint } : {}),
+    ...(config.onError ? { onError: config.onError } : {}),
+  });
+  return { handler, close };
+}
+
+/** Env-nycklar för den körbara entryn. */
+export const SERVER_FIRST_ENV = {
+  databaseUrl: "AVA_DATABASE_URL",
+  organizationId: "AVA_ORGANIZATION_ID",
+  httpPort: "AVA_HTTP_PORT",
+  httpHost: "AVA_HTTP_HOST",
+} as const;
+
+export interface ServerFirstRuntimeConfig {
+  databaseUrl: string;
+  organizationId: string;
+  httpPort: number;
+  httpHost: string;
+}
+
+const DEFAULT_HTTP_PORT = 3001;
+const DEFAULT_HTTP_HOST = "127.0.0.1";
+
+/** Läs runtime-config ur miljövariabler (kastar på saknade obligatoriska). */
+export function loadServerFirstConfig(
+  env: Record<string, string | undefined> = process.env,
+): ServerFirstRuntimeConfig {
+  const databaseUrl = env[SERVER_FIRST_ENV.databaseUrl];
+  const organizationId = env[SERVER_FIRST_ENV.organizationId];
+  if (!databaseUrl) throw new Error(`${SERVER_FIRST_ENV.databaseUrl} krävs`);
+  if (!organizationId) throw new Error(`${SERVER_FIRST_ENV.organizationId} krävs`);
+  const port = env[SERVER_FIRST_ENV.httpPort];
+  return {
+    databaseUrl,
+    organizationId,
+    httpPort: port ? Number(port) : DEFAULT_HTTP_PORT,
+    httpHost: env[SERVER_FIRST_ENV.httpHost] ?? DEFAULT_HTTP_HOST,
+  };
+}

--- a/src/lib/server/http/server-trpc-handler.ts
+++ b/src/lib/server/http/server-trpc-handler.ts
@@ -1,0 +1,49 @@
+/**
+ * `createServerTrpcHandler` — server-first tRPC-over-HTTP-endpoint (#410,
+ * ADR 0016). Exponerar SAMMA `appRouter` som git/demo-vägen kör in-process,
+ * men över HTTP mot Postgres-backenden, med en server-verifierad principal.
+ *
+ * Skild från `trpc-http-handler.ts` (ADR 0013 git-peer: Bearer-PAT +
+ * working-copy-session + commit/push-lås): här är auth oauth2-proxy-header-trust
+ * och persistensen Postgres-transaktioner (inget git-lås behövs). Båda delar
+ * fetch-standard-formen `(Request) => Promise<Response>` så de kan monteras via
+ * samma `node-http-adapter`.
+ *
+ * Auth: ingen global 401 — oauth2-proxy gat:ar redan åtkomsten (ADR 0009).
+ * Saknas en giltig forwarded-identitet blir principalen `null` och
+ * `protectedProcedure`/`orgProcedure` kastar `UNAUTHORIZED` (publika procedurer
+ * fungerar fortsatt).
+ */
+
+import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
+import { appRouter } from "@/lib/server/routers/_app";
+import { createServerContext, type ServerContextDeps } from "./server-context";
+import { DEFAULT_TRPC_ENDPOINT } from "./trpc-http-handler";
+
+export interface ServerTrpcHandlerDeps extends ServerContextDeps {
+  /** URL-prefix (default {@link DEFAULT_TRPC_ENDPOINT}). */
+  endpoint?: string;
+  /** Server-side fel-logg (valfri). */
+  onError?: (err: unknown) => void;
+}
+
+/** Skapa fetch-handlern som serverar `appRouter` mot Postgres-backenden. */
+export function createServerTrpcHandler(
+  deps: ServerTrpcHandlerDeps,
+): (req: Request) => Promise<Response> {
+  const endpoint = deps.endpoint ?? DEFAULT_TRPC_ENDPOINT;
+  const ctxDeps: ServerContextDeps = {
+    repos: deps.repos,
+    ports: deps.ports,
+    organizationId: deps.organizationId,
+    ...(deps.headerNames ? { headerNames: deps.headerNames } : {}),
+  };
+  return (req: Request): Promise<Response> =>
+    fetchRequestHandler({
+      endpoint,
+      req,
+      router: appRouter,
+      createContext: () => createServerContext(req, ctxDeps),
+      ...(deps.onError ? { onError: ({ error }) => deps.onError?.(error) } : {}),
+    });
+}

--- a/test/unit/server/db/client.test.ts
+++ b/test/unit/server/db/client.test.ts
@@ -1,0 +1,23 @@
+/**
+ * `createPostgresDb` (#410) — produktions-Postgres-handle. Anslutningen är lat
+ * (postgres-js kopplar först vid query) → handle-formen + livscykeln testas
+ * utan live-server; den riktiga driver-vägen täcks av repository-sviten mot
+ * Postgres (CI:s "Repository (Postgres)"-jobb via `createTestDb`).
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { createPostgresDb } from "@/lib/server/db/client";
+
+describe("createPostgresDb", () => {
+  it("ger ett { db, close }-handle utan att ansluta (lat connection)", async () => {
+    const handle = createPostgresDb("postgres://ava:ava@127.0.0.1:1/ava_test", { max: 1 });
+    expect(typeof handle.db.select).toBe("function");
+    await expect(handle.close()).resolves.toBeUndefined();
+  });
+
+  it("accepterar default-options (ingen max)", async () => {
+    const handle = createPostgresDb("postgres://ava:ava@127.0.0.1:1/ava_test");
+    expect(handle.db).toBeDefined();
+    await handle.close();
+  });
+});

--- a/test/unit/server/http/forwarded-claims.test.ts
+++ b/test/unit/server/http/forwarded-claims.test.ts
@@ -1,0 +1,48 @@
+/**
+ * `forwardedClaims` (#410) — server-side OIDC-claims ur oauth2-proxy-headers.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import {
+  forwardedClaims,
+  DEFAULT_FORWARDED_HEADER_NAMES,
+} from "@/lib/server/http/forwarded-claims";
+
+function h(init: Record<string, string>): Headers {
+  return new Headers(init);
+}
+
+describe("forwardedClaims", () => {
+  it("läser email + display-namn ur preferred-username", () => {
+    const claims = forwardedClaims(
+      h({
+        "X-Auth-Request-Email": "anna@byra.se",
+        "X-Auth-Request-Preferred-Username": "Anna Jurist",
+        "X-Auth-Request-User": "anna",
+      }),
+    );
+    expect(claims).toEqual({ email: "anna@byra.se", subject: "", issuer: "", name: "Anna Jurist" });
+  });
+
+  it("faller tillbaka på user-headern när preferred-username saknas", () => {
+    const claims = forwardedClaims(h({ "x-auth-request-email": "b@x.se", "x-auth-request-user": "b" }));
+    expect(claims?.name).toBe("b");
+  });
+
+  it("ger tomt namn när varken preferred-username eller user finns", () => {
+    expect(forwardedClaims(h({ "x-auth-request-email": "c@x.se" }))?.name).toBe("");
+  });
+
+  it("ger null utan email-header (ej inloggad / ej bakom proxy)", () => {
+    expect(forwardedClaims(h({}))).toBeNull();
+    expect(forwardedClaims(h({ "x-auth-request-email": "   " }))).toBeNull();
+  });
+
+  it("respekterar custom header-namn", () => {
+    const claims = forwardedClaims(h({ "x-forwarded-email": "d@x.se" }), {
+      ...DEFAULT_FORWARDED_HEADER_NAMES,
+      email: "x-forwarded-email",
+    });
+    expect(claims?.email).toBe("d@x.se");
+  });
+});

--- a/test/unit/server/http/server-context.test.ts
+++ b/test/unit/server/http/server-context.test.ts
@@ -6,7 +6,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import { noopPorts } from "@/lib/server/adapters/noop-ports";
 import { users } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import {
   createServerContext,
   serverFirstEventLog,

--- a/test/unit/server/http/server-context.test.ts
+++ b/test/unit/server/http/server-context.test.ts
@@ -1,0 +1,80 @@
+/**
+ * `createServerContext` (#410) — server-verifierad principal ur oauth2-proxy-
+ * headers + Drizzle-repos (pglite/Postgres via createTestDb).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import { noopPorts } from "@/lib/server/adapters/noop-ports";
+import { users } from "@/lib/server/db/schema";
+import type { AppDb } from "@/lib/server/db/types";
+import {
+  createServerContext,
+  serverFirstEventLog,
+} from "@/lib/server/http/server-context";
+import { buildDrizzleRepositories } from "@/lib/server/repositories/drizzle-repositories";
+import type { Repositories } from "@/lib/server/repositories/repositories";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+const ORG = uuidv7();
+const ANNA = uuidv7();
+
+function req(headers: Record<string, string> = {}): Request {
+  return new Request("http://ava.test/api/trpc/user.current", { headers });
+}
+
+describe("createServerContext (#410)", () => {
+  let handle: TestDbHandle;
+  let repos: Repositories;
+
+  beforeAll(async () => {
+    handle = await createTestDb();
+    repos = buildDrizzleRepositories(handle.db);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await handle.db.insert(users).values(
+      v({ id: ANNA, organizationId: ORG, email: "anna@byra.se", name: "Anna", role: "LAWYER", active: true }),
+    );
+    await handle.db.insert(users).values(
+      v({ id: uuidv7(), organizationId: ORG, email: "gamla@byra.se", name: "Gamla", role: "LAWYER", active: false }),
+    );
+  });
+  afterAll(async () => { await handle.close(); });
+
+  const deps = () => ({ repos, ports: noopPorts, organizationId: ORG });
+
+  it("verifierar principalen server-side ur forwarded email-header", async () => {
+    const ctx = await createServerContext(req({ "X-Auth-Request-Email": "anna@byra.se" }), deps());
+    expect(ctx.user).toMatchObject({ id: ANNA, email: "anna@byra.se", role: "LAWYER", organizationId: ORG });
+    expect(ctx.repos).toBe(repos);
+  });
+
+  it("ger null-principal utan forwarded identitet (→ UNAUTHORIZED i procedurer)", async () => {
+    const ctx = await createServerContext(req({}), deps());
+    expect(ctx.user).toBeNull();
+  });
+
+  it("nekar okänd email (autentisering ≠ auktorisering)", async () => {
+    const ctx = await createServerContext(req({ "X-Auth-Request-Email": "okand@annan.se" }), deps());
+    expect(ctx.user).toBeNull();
+  });
+
+  it("nekar avprovisionerad (inaktiv) användare", async () => {
+    const ctx = await createServerContext(req({ "X-Auth-Request-Email": "gamla@byra.se" }), deps());
+    expect(ctx.user).toBeNull();
+  });
+
+  it("matchar email case-insensitivt", async () => {
+    const ctx = await createServerContext(req({ "X-Auth-Request-Email": "ANNA@Byra.SE" }), deps());
+    expect(ctx.user?.id).toBe(ANNA);
+  });
+});
+
+describe("serverFirstEventLog (#410, ADR 0017/#408 ej byggt)", () => {
+  it("emit kastar ReadOnlyError-namngivet fel (sväljs av safeEmit)", async () => {
+    await expect(serverFirstEventLog.emit({} as never)).rejects.toMatchObject({ name: "ReadOnlyError" });
+  });
+  it("query ger tom logg", async () => {
+    expect(await serverFirstEventLog.query()).toEqual([]);
+  });
+});

--- a/test/unit/server/http/server-first-api.test.ts
+++ b/test/unit/server/http/server-first-api.test.ts
@@ -1,0 +1,61 @@
+/**
+ * `buildServerFirstApi` + `loadServerFirstConfig` (#410) — composition-root.
+ * Wiring testas utan live-server (lat Postgres-connection); env-parsningen
+ * testas mot ett explicit env-objekt.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import {
+  buildServerFirstApi,
+  loadServerFirstConfig,
+  SERVER_FIRST_ENV,
+} from "@/lib/server/http/server-first-api";
+
+describe("buildServerFirstApi", () => {
+  it("bygger { handler, close } ur en config (lat connection)", async () => {
+    const api = buildServerFirstApi({
+      databaseUrl: "postgres://ava:ava@127.0.0.1:1/ava_test",
+      organizationId: "org-1",
+      maxConnections: 1,
+    });
+    expect(typeof api.handler).toBe("function");
+    await expect(api.close()).resolves.toBeUndefined();
+  });
+});
+
+describe("loadServerFirstConfig", () => {
+  const base = {
+    [SERVER_FIRST_ENV.databaseUrl]: "postgres://db/x",
+    [SERVER_FIRST_ENV.organizationId]: "org-1",
+  };
+
+  it("läser obligatoriska + default-värden", () => {
+    expect(loadServerFirstConfig(base)).toEqual({
+      databaseUrl: "postgres://db/x",
+      organizationId: "org-1",
+      httpPort: 3001,
+      httpHost: "127.0.0.1",
+    });
+  });
+
+  it("läser custom port/host", () => {
+    const cfg = loadServerFirstConfig({
+      ...base,
+      [SERVER_FIRST_ENV.httpPort]: "8088",
+      [SERVER_FIRST_ENV.httpHost]: "0.0.0.0",
+    });
+    expect(cfg).toMatchObject({ httpPort: 8088, httpHost: "0.0.0.0" });
+  });
+
+  it("kastar utan databas-URL", () => {
+    expect(() => loadServerFirstConfig({ [SERVER_FIRST_ENV.organizationId]: "org-1" })).toThrow(
+      SERVER_FIRST_ENV.databaseUrl,
+    );
+  });
+
+  it("kastar utan organizationId", () => {
+    expect(() => loadServerFirstConfig({ [SERVER_FIRST_ENV.databaseUrl]: "postgres://db/x" })).toThrow(
+      SERVER_FIRST_ENV.organizationId,
+    );
+  });
+});

--- a/test/unit/server/http/server-trpc-handler.test.ts
+++ b/test/unit/server/http/server-trpc-handler.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Integrationstest för server-first tRPC-over-HTTP-handlern (#410, ADR 0016).
+ *
+ * Driver handlern via en RIKTIG tRPC-`httpBatchLink`-klient med injicerad
+ * `fetch` (samma transport som web-appens HttpDataStore, #411). Verifierar
+ * AC för #410:
+ *   - HTTP-tRPC-endpoint live (routern körs över HTTP mot Drizzle-repos).
+ *   - Principal verifieras SERVER-SIDE ur forwarded email-header.
+ *   - `protectedProcedure`/`orgProcedure` enforce:as server-side (ingen
+ *     identitet → UNAUTHORIZED; med identitet → org-scopad data).
+ */
+
+import { createTRPCClient, httpBatchLink, TRPCClientError } from "@trpc/client";
+import superjson from "superjson";
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import { noopPorts } from "@/lib/server/adapters/noop-ports";
+import { users } from "@/lib/server/db/schema";
+import { createServerTrpcHandler } from "@/lib/server/http/server-trpc-handler";
+import { buildDrizzleRepositories } from "@/lib/server/repositories/drizzle-repositories";
+import type { AppRouter } from "@/lib/server/routers/_app";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
+
+const ORG = uuidv7();
+const ANNA = uuidv7();
+
+function makeClient(handler: (req: Request) => Promise<Response>, email?: string) {
+  return createTRPCClient<AppRouter>({
+    links: [
+      httpBatchLink({
+        url: "http://ava.test/api/trpc",
+        transformer: superjson,
+        headers: () => (email ? { "X-Auth-Request-Email": email } : {}),
+        fetch: (input, init) => handler(new Request(input as string, init as RequestInit)),
+      }),
+    ],
+  });
+}
+
+describe("createServerTrpcHandler (#410)", () => {
+  let handle: TestDbHandle;
+  let handler: (req: Request) => Promise<Response>;
+
+  beforeAll(async () => {
+    handle = await createTestDb();
+    const repos = buildDrizzleRepositories(handle.db);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await handle.db.insert(users).values(
+      v({ id: ANNA, organizationId: ORG, email: "anna@byra.se", name: "Anna", role: "LAWYER", active: true }),
+    );
+    handler = createServerTrpcHandler({ repos, ports: noopPorts, organizationId: ORG });
+  });
+  afterAll(async () => { await handle.close(); });
+
+  it("kör en protectedProcedure med server-verifierad principal", async () => {
+    const me = await makeClient(handler, "anna@byra.se").user.current.query();
+    expect(me).toMatchObject({ id: ANNA, email: "anna@byra.se", role: "LAWYER" });
+  });
+
+  it("enforce:ar protectedProcedure server-side — ingen identitet → UNAUTHORIZED", async () => {
+    await expect(makeClient(handler).user.current.query()).rejects.toBeInstanceOf(TRPCClientError);
+  });
+
+  it("enforce:ar orgProcedure server-side — org-scopad query lyckas med principal", async () => {
+    const res = await makeClient(handler, "anna@byra.se").contacts.list.query({});
+    expect(res).toMatchObject({ contacts: [], total: 0 });
+  });
+
+  it("orgProcedure utan identitet → UNAUTHORIZED", async () => {
+    await expect(makeClient(handler).contacts.list.query({})).rejects.toBeInstanceOf(TRPCClientError);
+  });
+});


### PR DESCRIPTION
## Vad

Bygger **ADR 0016:s server-first-runtime** (epic #403): `appRouter` serveras över **tRPC-over-HTTP** mot den auktoritativa Postgres-db:n, med en **server-verifierad** principal. Routrarna är oförändrade ovanför sömmen (ADR 0020 typade repos).

Stänger #410. Skild från ADR 0013:s git-peer-PAT-runtime (`trpc-http-handler.ts`) — annan auth (oauth2-proxy-header-trust vs Bearer-PAT) och annan persistens (Postgres-transaktioner vs git-working-copy + commit/push-lås).

## AC ✓

| AC | Hur |
|---|---|
| HTTP-tRPC-endpoint live | `createServerTrpcHandler` → fetch-handler (`Request → Response`); monteras via befintlig `node-http-adapter` i `bin/server-first.ts` |
| Principal verifieras server-side | `forwardedClaims` läser oauth2-proxy:s `X-Auth-Request-*`-headers → `OidcAuthProvider` mot byråns allowlist (ADR 0009). Ingen självdeklaration |
| orgProcedure enforce:as på servern | `protectedProcedure`/`orgProcedure` (trpc-core) körs med den verifierade principalen; ingen identitet → `UNAUTHORIZED` |

## Filer

- `http/forwarded-claims.ts` — server-side OIDC-claims ur forwarded headers (email-only, #224). Dokumenterar **förtroendegränsen** (nginx `auth_request_set` + strippning av klient-skickade headers; backend på loopback bakom fronten).
- `http/server-context.ts` — `createServerContext`: verifierad principal + Drizzle-repos. Read-only event-sink tills change-loggen byggs (ADR 0017/#408).
- `http/server-trpc-handler.ts` — fetch-handlern.
- `db/client.ts` — `createPostgresDb` (node-postgres + Drizzle, server-only, lat connection; dep-cruiser-grindat).
- `http/server-first-api.ts` + `bin/server-first.ts` — composition-root + tunn körbar entry (`bun run server-first`).

## Test

- Enhetstest: `forwarded-claims` (header-parsning), `server-first-api` (config/wiring), `db/client` (lat handle).
- Integrationstest mot **pglite + riktig Postgres**: `server-context` (principal-verifiering: okänd/inaktiv/case-insensitiv email → rätt utfall) och `server-trpc-handler` (tRPC-klient → `user.current` med verifierad principal; `contacts.list` org-scopad; ingen identitet → `UNAUTHORIZED`).
- CI:s "Repository (Postgres)"-jobb kör nu även dessa två integrationstester mot riktig Postgres.

Lokalt grönt: `quality:fast` (3190 tester), `knip`, `deps:check`, `duplicates` — alla exit 0; integrationstesterna gröna mot Postgres 16.

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)