### PR TITLE
feat(client): alltid-online tRPC-over-HTTP-väg via HttpBackendRuntime (#411)

### DIFF
--- a/src/lib/client/backend/http-backend-runtime.ts
+++ b/src/lib/client/backend/http-backend-runtime.ts
@@ -1,0 +1,61 @@
+/**
+ * `HttpBackendRuntime` — `BackendRuntime` för server-first-backenden (#411,
+ * ADR 0016). Den "alltid-online"-väg som `backend-runtime.ts` förutser:
+ *
+ *   GitBackendRuntime  → inProcessLink(ctx)   (routrarna körs i klienten, offline)
+ *   HttpBackendRuntime → httpBatchLink(server) (routrarna körs PÅ SERVERN, #410)
+ *
+ * UI:t och `appRouter` ändras inte — båda ser samma `TRPCLink<AppRouter>`-seam.
+ * Servern (server-runtime, #410) kör routrarna mot Postgres och verifierar
+ * principalen server-side ur oauth2-proxy-headers.
+ *
+ * Auth: web-appen rider på oauth2-proxy:s **samma-origin-cookie** (ADR 0009) —
+ * `fetch` skickar den automatiskt same-origin, ingen klient-token-kod behövs.
+ * (Office-add-ins använder i stället Bearer-PAT via `addin-client.ts`.)
+ *
+ * `CachingSyncDataStore` (#415) lindar sedan denna väg med lokal store +
+ * optimistisk kö + reconcile för offline-first.
+ */
+
+import { httpBatchLink, type TRPCLink } from "@trpc/client";
+import superjson from "superjson";
+import type { AppRouter } from "@/lib/server/routers/_app";
+import type { BackendRuntime } from "./backend-runtime";
+
+/** tRPC-endpointens suffix på serverns origin (matchar `DEFAULT_TRPC_ENDPOINT`). */
+export const SERVER_TRPC_PATH = "/api/trpc";
+
+/** Minimal fetch-form för override (test/icke-standard-runtime). En DOM-`fetch`
+ *  uppfyller den; tRPC:s interna `FetchEsque` är inte publikt exporterad. */
+export type HttpBackendFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+/** tRPC:s httpBatchLink-fetch-typ (icke-exporterad `FetchEsque`), härledd ur
+ *  länkens optionsparameter så vi kan brygga en DOM-fetch dit utan import. */
+type LinkFetch = NonNullable<NonNullable<Parameters<typeof httpBatchLink<AppRouter>>[0]>["fetch"]>;
+
+/** Bygg full tRPC-endpoint-URL ur serverns bas-URL. Tom bas = samma origin
+ *  (web-appen bakom nginx). Trimmar avslutande "/". */
+export function serverTrpcEndpoint(baseUrl = ""): string {
+  return `${baseUrl.replace(/\/+$/, "")}${SERVER_TRPC_PATH}`;
+}
+
+export interface HttpBackendRuntimeDeps {
+  /** Serverns bas-URL. Tom (default) = samma origin som web-appen. */
+  baseUrl?: string;
+  /** Valfri `fetch`-override (test/icke-standard-runtime). Default: global fetch. */
+  fetch?: HttpBackendFetch;
+}
+
+export class HttpBackendRuntime implements BackendRuntime {
+  constructor(private readonly deps: HttpBackendRuntimeDeps = {}) {}
+
+  createLink(): TRPCLink<AppRouter> {
+    return httpBatchLink({
+      url: serverTrpcEndpoint(this.deps.baseUrl),
+      transformer: superjson,
+      // En DOM-fetch är runtime-kompatibel med tRPC:s FetchEsque; typerna
+      // skiljer bara i exactOptional-detaljer (signal null vs undefined).
+      ...(this.deps.fetch ? { fetch: this.deps.fetch as unknown as LinkFetch } : {}),
+    });
+  }
+}

--- a/test/unit/client/backend/http-backend-runtime.test.ts
+++ b/test/unit/client/backend/http-backend-runtime.test.ts
@@ -1,0 +1,85 @@
+/**
+ * `HttpBackendRuntime` (#411) — den "alltid-online"-väg som server-first-
+ * backenden använder. Drivs end-to-end mot den RIKTIGA server-runtime-handlern
+ * (`createServerTrpcHandler`, #410) via en injicerad `fetch` som simulerar
+ * oauth2-proxy:s forwarded headers → bevisar att klienten är wire-kompatibel
+ * med servern (samma `/api/trpc`, superjson, server-verifierad principal).
+ *
+ * Detta är "PostgresBackendRuntime droppar in" (jfr backend-runtime-
+ * pluggability): samma `createTRPCClient(runtime.createLink())`-konsument-väg
+ * som GitBackendRuntime, fast routrarna körs på servern.
+ */
+
+import { createTRPCClient, type TRPCLink } from "@trpc/client";
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import {
+  HttpBackendRuntime,
+  serverTrpcEndpoint,
+  type HttpBackendFetch,
+} from "@/lib/client/backend/http-backend-runtime";
+import { noopPorts } from "@/lib/server/adapters/noop-ports";
+import { users } from "@/lib/server/db/schema";
+import { createServerTrpcHandler } from "@/lib/server/http/server-trpc-handler";
+import { buildDrizzleRepositories } from "@/lib/server/repositories/drizzle-repositories";
+import type { AppRouter } from "@/lib/server/routers/_app";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../../server/db/pg-test-db";
+
+const ORG = uuidv7();
+const ANNA = uuidv7();
+
+/** Klient byggd via runtime:ns länk (samma väg som web-app-providern). */
+function clientVia(fetch: HttpBackendFetch) {
+  const link = new HttpBackendRuntime({ baseUrl: "https://byra.example", fetch }).createLink();
+  return createTRPCClient<AppRouter>({ links: [link as TRPCLink<AppRouter>] });
+}
+
+describe("serverTrpcEndpoint", () => {
+  it("samma origin (tom bas) → /api/trpc", () => {
+    expect(serverTrpcEndpoint()).toBe("/api/trpc");
+  });
+  it("lägger på /api/trpc och trimmar avslutande slash", () => {
+    expect(serverTrpcEndpoint("https://byra.example")).toBe("https://byra.example/api/trpc");
+    expect(serverTrpcEndpoint("https://byra.example///")).toBe("https://byra.example/api/trpc");
+  });
+});
+
+describe("HttpBackendRuntime (#411) — end-to-end mot server-runtimen", () => {
+  let handle: TestDbHandle;
+  let handler: (req: Request) => Promise<Response>;
+
+  beforeAll(async () => {
+    handle = await createTestDb();
+    const repos = buildDrizzleRepositories(handle.db);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await handle.db.insert(users).values(
+      v({ id: ANNA, organizationId: ORG, email: "anna@byra.se", name: "Anna", role: "LAWYER", active: true }),
+    );
+    handler = createServerTrpcHandler({ repos, ports: noopPorts, organizationId: ORG });
+  });
+  afterAll(async () => { await handle.close(); });
+
+  /** Fetch som routar till server-handlern; `email` simulerar oauth2-proxy:s
+   *  forwarded `X-Auth-Request-Email` (det nginx sätter i deployen). */
+  const fetchVia = (email?: string): HttpBackendFetch => (input, init) => {
+    const headers = new Headers(init?.headers);
+    if (email) headers.set("X-Auth-Request-Email", email);
+    return handler(new Request(input as string, { ...init, headers }));
+  };
+
+  it("server-verifierad principal → user.current end-to-end", async () => {
+    const me = await clientVia(fetchVia("anna@byra.se")).user.current.query();
+    expect(me).toMatchObject({ id: ANNA, email: "anna@byra.se", role: "LAWYER" });
+    expect(me.createdAt).toBeInstanceOf(Date); // superjson round-trippade en Date
+  });
+
+  it("org-scopad orgProcedure round-trippar (contacts.list)", async () => {
+    const res = await clientVia(fetchVia("anna@byra.se")).contacts.list.query({});
+    expect(res).toMatchObject({ contacts: [], total: 0 });
+  });
+
+  it("ingen forwarded identitet → klienten kastar (UNAUTHORIZED server-side)", async () => {
+    await expect(clientVia(fetchVia()).user.current.query()).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Vad

Bygger **ADR 0016:s "alltid-online"-väg** (epic #403, bygger på #410): en `BackendRuntime` som returnerar en `httpBatchLink` mot server-runtimens tRPC-over-HTTP-API i stället för `GitBackendRuntime`s in-process-länk. Routrarna körs **på servern** mot Postgres med server-verifierad principal; UI och `appRouter` rörs inte — samma `TRPCLink<AppRouter>`-seam (`backend-runtime.ts` förutsåg exakt detta: *"Att byta till Postgres = en PostgresBackendRuntime som returnerar en httpBatchLink"*).

Stänger #411.

## Detaljer

- `HttpBackendRuntime` + `serverTrpcEndpoint` (matchar `DEFAULT_TRPC_ENDPOINT` = `/api/trpc`).
- **Auth:** web-appen rider på oauth2-proxy:s **samma-origin-cookie** (ADR 0009) — `fetch` skickar den automatiskt same-origin, ingen klient-token-kod. (Office-add-ins använder i stället Bearer-PAT via `addin-client.ts`.)
- Speglar `addin-client.ts` (httpBatchLink + superjson + `FetchEsque`-brygga), men som `BackendRuntime` och utan Bearer-header.

## Test

End-to-end mot den **riktiga** `createServerTrpcHandler` (#410) via en injicerad `fetch` som simulerar oauth2-proxy:s forwarded `X-Auth-Request-Email` (det nginx sätter i deployen):

- server-verifierad principal → `user.current` round-trippar (inkl. superjson-`Date`);
- org-scopad `orgProcedure` (`contacts.list`) round-trippar;
- ingen forwarded identitet → klienten kastar (`UNAUTHORIZED` server-side);
- `serverTrpcEndpoint`-URL-bygge (samma-origin + trim).

Detta är "PostgresBackendRuntime droppar in"-beviset (jfr `backend-runtime-pluggability`): samma `createTRPCClient(runtime.createLink())`-konsumentväg som git-backenden, fast routrarna körs på servern.

Lokalt grönt: `quality:fast` (3195 tester), zero-warning lint, knip, deps:check, jscpd — alla exit 0.

`CachingSyncDataStore` (#415) lindar sedan denna väg med lokal store + kö + reconcile för offline-first.

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)