### PR TITLE
feat(client): offline-first CachingSyncDataStore (komponerar C1–C3) (#415)

### DIFF
--- a/src/lib/server/auth/cached-session-auth-provider.ts
+++ b/src/lib/server/auth/cached-session-auth-provider.ts
@@ -1,0 +1,42 @@
+/**
+ * `CachedSessionAuthProvider` (#415 / D2, ADR 0018 Option A — fallback) —
+ * den principal offline-klienten arbetar under när den inte når IdP:n.
+ *
+ * ADR 0018: efter login cachas den verifierade OIDC-identiteten; klienten får
+ * arbeta offline under en konfigurerbar **grace** (default ~7 dagar). När
+ * grace:n löpt ut returneras `null` (→ skyddade procedurer kastar UNAUTHORIZED;
+ * klienten måste återansluta och re-validera). Servern omvaliderar ändå
+ * principalen vid sync (reconcile) — detta är bara den lokala offline-grinden.
+ *
+ * Den primära mekanismen (Option B, `offline_access`-refresh-token) lever i
+ * auth-/token-lagret; denna provider täcker fallback-vägen + är den enkla
+ * abstraktion `buildContext({ principal })` matas med offline.
+ */
+
+import type { AuthProvider, Principal } from "./principal";
+
+/** ~7 dagar — ADR 0018 default-grace. */
+export const DEFAULT_OFFLINE_GRACE_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface CachedSession {
+  /** Den vid login verifierade principalen. */
+  principal: Principal;
+  /** Epoch-ms när sessionen cachades (vid senaste lyckade online-login). */
+  cachedAt: number;
+  /** Grace-fönstrets längd i ms. Default {@link DEFAULT_OFFLINE_GRACE_MS}. */
+  graceMs?: number;
+}
+
+export class CachedSessionAuthProvider implements AuthProvider {
+  constructor(
+    private readonly session: CachedSession | null,
+    private readonly now: () => number = () => Date.now(),
+  ) {}
+
+  getPrincipal(): Principal | null {
+    if (!this.session) return null;
+    const graceMs = this.session.graceMs ?? DEFAULT_OFFLINE_GRACE_MS;
+    if (this.now() - this.session.cachedAt > graceMs) return null; // grace utgången
+    return this.session.principal;
+  }
+}

--- a/src/lib/server/data-store/in-memory/caching-sync-data-store.ts
+++ b/src/lib/server/data-store/in-memory/caching-sync-data-store.ts
@@ -1,0 +1,120 @@
+/**
+ * `CachingSyncDataStore` (#415, ADR 0016/0017) — den offline-first-väg appen
+ * faktiskt kör mot i server-first-arkitekturen. Komponerar de tre klossarna:
+ *
+ *   C1  LocalStore (#412)        — lokal store-kärna; läser/skriver direkt (snabbt, offline).
+ *   C2  MutationQueue (#413)     — varje lokal mutation köas optimistiskt (UUIDv7, idempotent).
+ *   C3  ReconcileEngine (#414)   — vid reconnect: pull→apply→replay→advance mot servern.
+ *
+ * Komposition framför arv: `LocalStore`s `onMutate` injiceras i konstruktorn och
+ * måste referera kö/persistens, vilket `super(...)`-argument inte kan (this-före-
+ * super). Wrappern exponerar därför `.store` (den `IDataStore` appen använder som
+ * `ctx.dataStore`) + sync-kontrollerna (`reconcile`, `pendingCount`).
+ *
+ * Skrivflöde (offline): mutation → LocalStore uppdaterar source → `onMutate`
+ * → enqueue + persist. Inga nätanrop.
+ * Reconcile (online): `ReconcileEngine` skriver kanoniska server-rader via
+ * `apply` → TYST source-skrivning (ingen re-enqueue) + persist; köade mutationer
+ * spelas upp; surface-konflikter ytläggs i resultatet.
+ *
+ * Transport-agnostisk: tar en `SyncTransport`-port (en HTTP/tRPC-impl mot
+ * server-runtimen, #410/#411, eller en fejk i tester). Principalen offline
+ * kommer från en cachad session (D2/ADR 0018, `CachedSessionAuthProvider`).
+ */
+
+import type { DemoSource } from "@/lib/shared/demo-source";
+import type { CursorStore } from "./cursor-store";
+import { InMemoryCursorStore } from "./cursor-store";
+import { SOURCE_KEY_BY_ENTITY } from "./entity-source-keys";
+import { LocalStore } from "./local-store";
+import type { LocalStorePersistence } from "./local-store-persistence";
+import { MutationQueue, type MutationQueuePersistence } from "./mutation-queue";
+import { ReconcileEngine, type ApplyCanonical, type ReconcileResult } from "./reconcile-engine";
+import type { SyncTransport } from "./sync-transport";
+import type { MutationEvent } from "./writable-delegate";
+
+export interface CachingSyncDeps {
+  /** Port mot den server-auktoritativa sidan (pull/push). Fejk i tester. */
+  transport: SyncTransport;
+  /** Seed-data om persistensen är tom (eller saknas). */
+  seed?: DemoSource;
+  /** Hydrera/spara hela source:n (IndexedDB i browsern; in-memory i tester). */
+  persistence?: LocalStorePersistence;
+  /** Persistens för mutations-kön (IndexedDB i browsern). */
+  queuePersistence?: MutationQueuePersistence;
+  /** Delta-sync-cursor-lagring. Default: in-memory. */
+  cursor?: CursorStore;
+}
+
+/**
+ * Skriv en kanonisk server-rad TYST till lokal source (ingen re-enqueue):
+ * upsert på `id`, eller ta bort vid tombstone. `entity` är singular (ADR 0017);
+ * source-arrayen är plural → slå upp via {@link SOURCE_KEY_BY_ENTITY}.
+ */
+function writeCanonical(store: LocalStore, entity: string, row: Record<string, unknown>, deleted: boolean): void {
+  const key = SOURCE_KEY_BY_ENTITY[entity];
+  if (!key) return; // okänd entitet → hoppa defensivt
+  const src = store.currentSource as Record<string, Record<string, unknown>[] | undefined>;
+  const arr = (src[key] ??= []);
+  const idx = arr.findIndex((r) => r.id === row.id);
+  if (deleted) {
+    if (idx >= 0) arr.splice(idx, 1);
+    return;
+  }
+  if (idx >= 0) arr[idx] = row;
+  else arr.push(row);
+}
+
+export class CachingSyncDataStore {
+  private constructor(
+    /** Den `IDataStore` appen läser/skriver mot (lokal-först) — `ctx.dataStore`. */
+    readonly store: LocalStore,
+    private readonly queue: MutationQueue,
+    private readonly engine: ReconcileEngine,
+  ) {}
+
+  /** Hydrera (kö + source) och komponera klossarna. */
+  static async create(deps: CachingSyncDeps): Promise<CachingSyncDataStore> {
+    const queue = await MutationQueue.hydrate(deps.queuePersistence);
+    const cursor = deps.cursor ?? new InMemoryCursorStore();
+    const hydrated = deps.persistence ? await deps.persistence.hydrate() : null;
+    const source: DemoSource = hydrated ?? deps.seed ?? {};
+
+    const persist = (): Promise<void> =>
+      deps.persistence ? deps.persistence.save(store.currentSource) : Promise.resolve();
+
+    const onLocalMutation = async (event: MutationEvent<Record<string, unknown>>): Promise<void> => {
+      const version = event.row.version;
+      await queue.enqueue(
+        {
+          entity: event.entity,
+          kind: event.kind,
+          row: event.row,
+          ...(event.previous !== undefined ? { previous: event.previous } : {}),
+        },
+        typeof version === "number" ? { baseVersion: version } : {},
+      );
+      await persist();
+    };
+
+    const store = new LocalStore(source, onLocalMutation);
+
+    const apply: ApplyCanonical = async (entity, row, deleted) => {
+      writeCanonical(store, entity, row, deleted);
+      await persist();
+    };
+
+    const engine = new ReconcileEngine({ transport: deps.transport, queue, cursor, apply });
+    return new CachingSyncDataStore(store, queue, engine);
+  }
+
+  /** Reconcile mot servern (pull→apply→replay→advance) — online-vägen. */
+  reconcile(): Promise<ReconcileResult> {
+    return this.engine.reconcile();
+  }
+
+  /** Antal ej-synkade (köade) mutationer. */
+  pendingCount(): number {
+    return this.queue.size();
+  }
+}

--- a/src/lib/server/data-store/in-memory/entity-source-keys.ts
+++ b/src/lib/server/data-store/in-memory/entity-source-keys.ts
@@ -1,0 +1,48 @@
+/**
+ * Kanonisk mappning **DemoSource-nyckel (plural) ↔ projektions-entitetsnamn
+ * (singular)** — en sanningskälla (DRY) som både `LocalStore.entityNameFor`
+ * (write-back-tagging) och reconcile-apply i `CachingSyncDataStore` (#415)
+ * använder.
+ *
+ * `MutationEvent.entity` och `PulledChange.entity` (ADR 0017) är SINGULAR
+ * (`"matter"`, `"invoice"`); `DemoSource`-arrayerna är PLURAL (`matters`,
+ * `invoices`). Reconcile-motorn skriver kanoniska rader per *entity* (singular)
+ * → vi måste slå upp rätt source-array (plural) för att applicera dem.
+ */
+
+/** plural source-nyckel → singular entitetsnamn. */
+export const ENTITY_NAME_BY_SOURCE_KEY: Record<string, string> = {
+  matters: "matter",
+  contacts: "contact",
+  matterContacts: "matterContact",
+  documents: "document",
+  documentFolders: "documentFolder",
+  documentTemplates: "documentTemplate",
+  documentAnalysisSuggestions: "documentAnalysisSuggestion",
+  matterEventSuggestions: "matterEventSuggestion",
+  timeEntries: "timeEntry",
+  expenses: "expense",
+  invoices: "invoice",
+  users: "user",
+  organizations: "organization",
+  offices: "office",
+  conflictChecks: "conflictCheck",
+  payments: "payment",
+  writeOffs: "writeOff",
+  invoiceDispatches: "invoiceDispatch",
+  expectedReceivables: "expectedReceivable",
+  paymentPlans: "paymentPlan",
+  paymentPlanReminders: "paymentPlanReminder",
+  accontoDeductions: "accontoDeduction",
+  billingRuns: "billingRun",
+  calendarEvents: "calendarEvent",
+  tasks: "task",
+  serviceNotes: "serviceNote",
+  userPreferences: "userPreference",
+  orgPreferences: "orgPreference",
+};
+
+/** singular entitetsnamn → plural source-nyckel (invers av ovan). */
+export const SOURCE_KEY_BY_ENTITY: Record<string, string> = Object.fromEntries(
+  Object.entries(ENTITY_NAME_BY_SOURCE_KEY).map(([sourceKey, entity]) => [entity, sourceKey]),
+);

--- a/src/lib/server/data-store/in-memory/local-store.ts
+++ b/src/lib/server/data-store/in-memory/local-store.ts
@@ -47,6 +47,7 @@ import type {
   ServiceNoteDelegate,
 } from "../IDataStore";
 import { buildRelations } from "../relations";
+import { ENTITY_NAME_BY_SOURCE_KEY } from "./entity-source-keys";
 import { ReadOnlyDelegate, ReadOnlyError, type RelationConfig } from "./read-only-delegate";
 import { WritableDelegate, type MutationEvent, type WritableDelegateOpts } from "./writable-delegate";
 
@@ -196,39 +197,10 @@ export class LocalStore implements IDataStore {
     return row;
   }
 
-  /** Map DemoSource-nyckel → projection-entitetsnamn för write-back. */
+  /** Map DemoSource-nyckel → projection-entitetsnamn för write-back.
+   *  Mappningen bor i `entity-source-keys.ts` (DRY — delas med reconcile-apply). */
   private entityNameFor(key: keyof DemoSource): string {
-    const map: Record<string, string> = {
-      matters: "matter",
-      contacts: "contact",
-      matterContacts: "matterContact",
-      documents: "document",
-      documentFolders: "documentFolder",
-      documentTemplates: "documentTemplate",
-      documentAnalysisSuggestions: "documentAnalysisSuggestion",
-      matterEventSuggestions: "matterEventSuggestion",
-      timeEntries: "timeEntry",
-      expenses: "expense",
-      invoices: "invoice",
-      users: "user",
-      organizations: "organization",
-      offices: "office",
-      conflictChecks: "conflictCheck",
-      payments: "payment",
-      writeOffs: "writeOff",
-      invoiceDispatches: "invoiceDispatch",
-      expectedReceivables: "expectedReceivable",
-      paymentPlans: "paymentPlan",
-      paymentPlanReminders: "paymentPlanReminder",
-      accontoDeductions: "accontoDeduction",
-      billingRuns: "billingRun",
-      calendarEvents: "calendarEvent",
-      tasks: "task",
-      serviceNotes: "serviceNote",
-      userPreferences: "userPreference",
-      orgPreferences: "orgPreference",
-    };
-    return map[key as string] ?? String(key);
+    return ENTITY_NAME_BY_SOURCE_KEY[key as string] ?? String(key);
   }
 
   // ─── Transaktioner (in-memory snapshot/rollback) ──────────────────

--- a/test/unit/server/auth/cached-session-auth-provider.test.ts
+++ b/test/unit/server/auth/cached-session-auth-provider.test.ts
@@ -1,0 +1,48 @@
+/**
+ * `CachedSessionAuthProvider` (#415 / D2, ADR 0018 Option A) — offline-principal
+ * ur en cachad session med grace-utgång.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import {
+  CachedSessionAuthProvider,
+  DEFAULT_OFFLINE_GRACE_MS,
+} from "@/lib/server/auth/cached-session-auth-provider";
+import type { Principal } from "@/lib/server/auth/principal";
+
+const PRINCIPAL: Principal = {
+  id: "u-1", email: "anna@byra.se", name: "Anna", role: "LAWYER", organizationId: "org-1",
+};
+
+describe("CachedSessionAuthProvider", () => {
+  it("ger null utan cachad session", () => {
+    expect(new CachedSessionAuthProvider(null).getPrincipal()).toBeNull();
+  });
+
+  it("ger principalen inom grace-fönstret", () => {
+    const now = 1_000_000;
+    const provider = new CachedSessionAuthProvider(
+      { principal: PRINCIPAL, cachedAt: now - DEFAULT_OFFLINE_GRACE_MS + 1 },
+      () => now,
+    );
+    expect(provider.getPrincipal()).toEqual(PRINCIPAL);
+  });
+
+  it("ger null när grace löpt ut", () => {
+    const now = 10 * DEFAULT_OFFLINE_GRACE_MS;
+    const provider = new CachedSessionAuthProvider(
+      { principal: PRINCIPAL, cachedAt: now - DEFAULT_OFFLINE_GRACE_MS - 1 },
+      () => now,
+    );
+    expect(provider.getPrincipal()).toBeNull();
+  });
+
+  it("respekterar en custom grace-längd", () => {
+    const now = 1_000_000;
+    const provider = new CachedSessionAuthProvider(
+      { principal: PRINCIPAL, cachedAt: now - 5000, graceMs: 1000 },
+      () => now,
+    );
+    expect(provider.getPrincipal()).toBeNull(); // 5s sedan > 1s grace
+  });
+});

--- a/test/unit/server/data-store/caching-sync-data-store.test.ts
+++ b/test/unit/server/data-store/caching-sync-data-store.test.ts
@@ -38,7 +38,7 @@ describe("CachingSyncDataStore (#415)", () => {
       const ds = await CachingSyncDataStore.create({ transport, persistence });
 
       const m1 = uuidv7();
-      await ds.store.matters.create({ data: matter(m1) });
+      await ds.store.matters.create({ data: matter(m1) as never });
 
       // Läsbart direkt lokalt (offline).
       expect(await ds.store.matters.findUnique({ where: { id: m1 } })).toMatchObject({ id: m1, title: "Ärende" });
@@ -57,7 +57,7 @@ describe("CachingSyncDataStore (#415)", () => {
       const ds = await CachingSyncDataStore.create({ transport, persistence: new InMemoryPersistence() });
 
       const m1 = uuidv7();
-      await ds.store.matters.create({ data: matter(m1) });
+      await ds.store.matters.create({ data: matter(m1) as never });
       // Servern accepterar och bumpar version.
       transport.pushImpl = (m) => ({ status: "accepted", row: { ...m.row, version: 5 } });
 
@@ -109,7 +109,7 @@ describe("CachingSyncDataStore (#415)", () => {
       const ds = await CachingSyncDataStore.create({ transport, persistence: new InMemoryPersistence() });
 
       const inv = uuidv7();
-      await ds.store.invoices.create({ data: { id: inv, organizationId: ORG, matterId: uuidv7(), status: "DRAFT" } });
+      await ds.store.invoices.create({ data: { id: inv, organizationId: ORG, matterId: uuidv7(), status: "DRAFT" } as never });
       transport.pushImpl = () => ({ status: "conflict", reason: "stale-status" });
 
       const res = await ds.reconcile();

--- a/test/unit/server/data-store/caching-sync-data-store.test.ts
+++ b/test/unit/server/data-store/caching-sync-data-store.test.ts
@@ -1,0 +1,123 @@
+/**
+ * `CachingSyncDataStore` (#415) — komponerar LocalStore (C1) + MutationQueue (C2)
+ * + ReconcileEngine (C3) till offline-first-vägen. Testar online + offline mot
+ * en fejk-`SyncTransport` (ingen körande server behövs — server-impl är #410/#411).
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { CachingSyncDataStore } from "@/lib/server/data-store/in-memory/caching-sync-data-store";
+import { InMemoryPersistence } from "@/lib/server/data-store/in-memory/local-store-persistence";
+import type { QueuedMutation } from "@/lib/server/data-store/in-memory/mutation-queue";
+import type { PullResult, PushResult, SyncTransport } from "@/lib/server/data-store/in-memory/sync-transport";
+import { uuidv7 } from "@/lib/shared/uuid";
+
+class FakeTransport implements SyncTransport {
+  pullResult: PullResult = { changes: [], cursor: 0 };
+  pushImpl: (m: QueuedMutation) => PushResult = (m) => ({ status: "accepted", row: { ...m.row, version: 2 } });
+  pushed: QueuedMutation[] = [];
+  async pull(): Promise<PullResult> {
+    return this.pullResult;
+  }
+  async push(m: QueuedMutation): Promise<PushResult> {
+    this.pushed.push(m);
+    return this.pushImpl(m);
+  }
+}
+
+const ORG = uuidv7();
+
+function matter(id: string, title = "Ärende") {
+  return { id, organizationId: ORG, title, status: "ACTIVE", matterNumber: "2026-0001" };
+}
+
+describe("CachingSyncDataStore (#415)", () => {
+  describe("offline — lokal-först + optimistisk kö", () => {
+    it("skriver lokalt, köar mutationen och rör inte transporten", async () => {
+      const transport = new FakeTransport();
+      const persistence = new InMemoryPersistence();
+      const ds = await CachingSyncDataStore.create({ transport, persistence });
+
+      const m1 = uuidv7();
+      await ds.store.matters.create({ data: matter(m1) });
+
+      // Läsbart direkt lokalt (offline).
+      expect(await ds.store.matters.findUnique({ where: { id: m1 } })).toMatchObject({ id: m1, title: "Ärende" });
+      // Köad, inte synkad.
+      expect(ds.pendingCount()).toBe(1);
+      expect(transport.pushed).toHaveLength(0);
+      // Persisterad till (in-memory) store.
+      const saved = await persistence.hydrate();
+      expect(saved?.matters).toHaveLength(1);
+    });
+  });
+
+  describe("online — reconcile (pull + replay)", () => {
+    it("spelar upp köade mutationer och applicerar serverns kanoniska rad", async () => {
+      const transport = new FakeTransport();
+      const ds = await CachingSyncDataStore.create({ transport, persistence: new InMemoryPersistence() });
+
+      const m1 = uuidv7();
+      await ds.store.matters.create({ data: matter(m1) });
+      // Servern accepterar och bumpar version.
+      transport.pushImpl = (m) => ({ status: "accepted", row: { ...m.row, version: 5 } });
+
+      const res = await ds.reconcile();
+
+      expect(res.pushed).toBe(1);
+      expect(res.conflicts).toHaveLength(0);
+      expect(ds.pendingCount()).toBe(0); // kön tömd
+      // Lokala raden rebasad till serverns kanoniska (version 5).
+      const row = await ds.store.matters.findUnique({ where: { id: m1 } });
+      expect(row).toMatchObject({ id: m1, version: 5 });
+    });
+
+    it("applicerar pullade kanoniska rader (server-skapade) lokalt + avancerar cursor", async () => {
+      const c1 = uuidv7();
+      const transport = new FakeTransport();
+      transport.pullResult = {
+        changes: [{ entity: "contact", row: { id: c1, organizationId: ORG, name: "Server-kontakt" } }],
+        cursor: 42,
+      };
+      const ds = await CachingSyncDataStore.create({ transport, persistence: new InMemoryPersistence() });
+
+      const res = await ds.reconcile();
+
+      expect(res.pulled).toBe(1);
+      expect(res.cursor).toBe(42);
+      expect(await ds.store.contacts.findUnique({ where: { id: c1 } })).toMatchObject({ id: c1, name: "Server-kontakt" });
+    });
+
+    it("applicerar en tombstone (deleted) genom att ta bort raden lokalt", async () => {
+      const m1 = uuidv7();
+      const transport = new FakeTransport();
+      const ds = await CachingSyncDataStore.create({
+        transport,
+        seed: { matters: [matter(m1)] },
+        persistence: new InMemoryPersistence(),
+      });
+      transport.pullResult = { changes: [{ entity: "matter", row: { id: m1 }, deleted: true }], cursor: 7 };
+
+      await ds.reconcile();
+
+      expect(await ds.store.matters.findUnique({ where: { id: m1 } })).toBeNull();
+    });
+  });
+
+  describe("konflikt — surface-klassen ytläggs", () => {
+    it("avvisad push ytläggs som konflikt och tas ur kön", async () => {
+      const transport = new FakeTransport();
+      const ds = await CachingSyncDataStore.create({ transport, persistence: new InMemoryPersistence() });
+
+      const inv = uuidv7();
+      await ds.store.invoices.create({ data: { id: inv, organizationId: ORG, matterId: uuidv7(), status: "DRAFT" } });
+      transport.pushImpl = () => ({ status: "conflict", reason: "stale-status" });
+
+      const res = await ds.reconcile();
+
+      expect(res.pushed).toBe(0);
+      expect(res.conflicts).toHaveLength(1);
+      expect(res.conflicts[0]).toMatchObject({ conflictClass: "surface", reason: "stale-status" });
+      expect(ds.pendingCount()).toBe(0); // acked trots konflikt (blockerar inte kön)
+    });
+  });
+});

--- a/test/unit/server/data-store/entity-source-keys.test.ts
+++ b/test/unit/server/data-store/entity-source-keys.test.ts
@@ -1,0 +1,26 @@
+/**
+ * `entity-source-keys` (#415) — en sanningskälla för plural↔singular-mappningen
+ * som LocalStore.entityNameFor + reconcile-apply delar.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import {
+  ENTITY_NAME_BY_SOURCE_KEY,
+  SOURCE_KEY_BY_ENTITY,
+} from "@/lib/server/data-store/in-memory/entity-source-keys";
+
+describe("entity-source-keys", () => {
+  it("SOURCE_KEY_BY_ENTITY är en exakt invers", () => {
+    for (const [sourceKey, entity] of Object.entries(ENTITY_NAME_BY_SOURCE_KEY)) {
+      expect(SOURCE_KEY_BY_ENTITY[entity]).toBe(sourceKey);
+    }
+    expect(Object.keys(SOURCE_KEY_BY_ENTITY)).toHaveLength(Object.keys(ENTITY_NAME_BY_SOURCE_KEY).length);
+  });
+
+  it("mappar kända entiteter (singular → plural)", () => {
+    expect(SOURCE_KEY_BY_ENTITY.matter).toBe("matters");
+    expect(SOURCE_KEY_BY_ENTITY.invoice).toBe("invoices");
+    expect(SOURCE_KEY_BY_ENTITY.timeEntry).toBe("timeEntries");
+    expect(SOURCE_KEY_BY_ENTITY.paymentPlanReminder).toBe("paymentPlanReminders");
+  });
+});


### PR DESCRIPTION
## Vad

ADR 0016/0017:s **offline-first-keystone** (epic #403): `CachingSyncDataStore` komponerar de tre redan byggda klossarna till den `IDataStore` appen kör mot:

- **C1** `LocalStore` (#412) — lokal store-kärna (snabba läsningar/skrivningar, offline).
- **C2** `MutationQueue` (#413) — varje lokal mutation köas optimistiskt (UUIDv7, idempotent).
- **C3** `ReconcileEngine` (#414) — vid reconnect: pull→apply→replay→advance mot servern.

Stänger #415.

## Beteende

- **Offline:** skrivning → LocalStore uppdaterar source → `onMutate` → enqueue + persist. Läsning ur lokal store. Inga nätanrop.
- **Online (`reconcile()`):** `ReconcileEngine` pullar kanoniska rader (skrivs **tyst** lokalt — ingen re-enqueue — + persist) och spelar upp kön; **surface-konflikter** ytläggs i resultatet utan att blockera resten av kön (ADR 0017).

## Designval

- **Komposition framför arv:** `LocalStore.onMutate` injiceras i konstruktorn och måste referera kö/persistens, vilket `super(...)`-argument inte kan (this-före-super). Wrappern exponerar `.store` (den `IDataStore` som blir `ctx.dataStore`) + `reconcile()`/`pendingCount()`.
- **`entity-source-keys.ts`:** plural↔singular-entitetsmappningen (som låg inline i `LocalStore.entityNameFor`) extraherad till EN sanningskälla (DRY) — `LocalStore` och reconcile-apply delar den nu. (`MutationEvent`/`PulledChange` är singular; `DemoSource`-nycklar plural.)
- **`CachedSessionAuthProvider`** (D2 / ADR 0018 Option A): offline-principal ur en cachad session med grace-utgång (default ~7 d). Den enkla abstraktion `buildContext({ principal })` matas med offline.

## Test

Online + offline mot en **fejk-`SyncTransport`** (ingen körande server behövs — den riktiga SyncTransport-over-HTTP-impl:en mot server-runtimen #410/#411 är nästa steg):

- offline: lokal skrivning läsbar direkt, köad, transporten orörd, persisterad;
- reconcile: köad mutation uppspelad + lokal rad rebasad till serverns kanoniska (version-bump); pullade server-rader applicerade; cursor avancerad; tombstone tar bort lokalt;
- konflikt: avvisad push ytläggs (`conflictClass: "surface"`) och tas ur kön;
- `CachedSessionAuthProvider`: grace-fönster + utgång; `entity-source-keys`: exakt invers.

Lokalt grönt: zero-warning lint, knip, deps:check, jscpd, `test:fast` (3206 tester) — alla exit 0. `LocalStore`-refaktorn regressionsfri (befintliga tester gröna).

Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)