### PR TITLE
feat(client): sync-status för offline-first-vägen + per-post köad-badge (#416)

### DIFF
--- a/src/components/shell/queued-badge.tsx
+++ b/src/components/shell/queued-badge.tsx
@@ -1,0 +1,45 @@
+/**
+ * `QueuedBadge` (#416, ADR 0016) — per-post indikator för en rads sync-läge i
+ * offline-first-vägen: "köad" (väntar på reconcile), "synkad" (server-bekräftad)
+ * eller "konflikt" (surface-konflikt, ADR 0017). Komplement till den globala
+ * `SyncStatusPill` — den här sätts på enskilda rader i relevanta vyer.
+ *
+ * Rent presentationell (status in → badge ut) så den kan placeras var som helst
+ * och testas isolerat; datakällan (vilka rader som är köade) kommer från
+ * `CachingSyncDataStore`-kön när vägen wire:as in.
+ */
+
+export type RowSyncStatus = "queued" | "synced" | "conflict";
+
+interface Props {
+  status: RowSyncStatus;
+  /** Dölj "synkad"-fallet (default) så vyer slipper badge-brus på allt. */
+  showSynced?: boolean;
+}
+
+interface BadgeView {
+  icon: string;
+  label: string;
+  cls: string;
+}
+
+const VIEWS: Record<RowSyncStatus, BadgeView> = {
+  queued: { icon: "⏳", label: "Köad", cls: "bg-amber-50 text-amber-800 border-amber-200" },
+  synced: { icon: "✓", label: "Synkad", cls: "bg-green-50 text-green-800 border-green-200" },
+  conflict: { icon: "⚠", label: "Konflikt", cls: "bg-orange-50 text-orange-900 border-orange-200" },
+};
+
+export function QueuedBadge({ status, showSynced = false }: Props) {
+  if (status === "synced" && !showSynced) return null;
+  const { icon, label, cls } = VIEWS[status];
+  return (
+    <span
+      data-testid="queued-badge"
+      data-status={status}
+      className={`text-[11px] px-1.5 py-0.5 rounded border inline-flex items-center gap-1 ${cls}`}
+    >
+      <span aria-hidden>{icon}</span>
+      <span>{label}</span>
+    </span>
+  );
+}

--- a/src/lib/client/sync/caching-sync-status.ts
+++ b/src/lib/client/sync/caching-sync-status.ts
@@ -1,0 +1,40 @@
+/**
+ * `syncStateFromCachingSync` (#416, ADR 0016) — adaptern som låter den BEFINTLIGA
+ * sync-status-UI:n (`SyncStatusPill` + `SyncState`) visa offline-first-
+ * `CachingSyncDataStore`-vägens läge (#415), utan att duplicera UI.
+ *
+ * Git-backendens sync drivs av `useAutoSync` (commit→pull→push); server-first-
+ * vägen drivs i stället av `CachingSyncDataStore` (kö + reconcile). Båda mynnar
+ * ut i samma `SyncState` → samma pill, samma mentala modell för användaren.
+ *
+ * Mappningen är en prioritetsordning (mest brådskande först): fel > synkar >
+ * konflikt(er) > offline > köad > synkad > idle.
+ */
+
+import type { SyncState } from "./use-auto-sync";
+
+export interface CachingSyncStatus {
+  /** `navigator.onLine` (via `useOnlineStatus`). */
+  online: boolean;
+  /** Antal ej-synkade mutationer (`CachingSyncDataStore.pendingCount()`). */
+  pendingCount: number;
+  /** En reconcile pågår just nu. */
+  syncing?: boolean;
+  /** Epoch-ms för senaste lyckade reconcile (null = aldrig). */
+  lastSyncedAt?: number | null;
+  /** Antal ytlagda surface-konflikter från senaste reconcile. */
+  conflicts?: number;
+  /** Felmeddelande från senaste reconcile (null = inget fel). */
+  error?: string | null;
+}
+
+/** Härled den UI-vänliga `SyncState` ur offline-first-storens läge. */
+export function syncStateFromCachingSync(status: CachingSyncStatus): SyncState {
+  if (status.error) return { kind: "error", message: status.error };
+  if (status.syncing) return { kind: "syncing", what: "push" };
+  if ((status.conflicts ?? 0) > 0) return { kind: "merge-needed" };
+  if (!status.online) return { kind: "offline", count: status.pendingCount };
+  if (status.pendingCount > 0) return { kind: "pending", count: status.pendingCount };
+  if (status.lastSyncedAt != null) return { kind: "synced", at: status.lastSyncedAt };
+  return { kind: "idle" };
+}

--- a/test/unit/app/queued-badge.test.tsx
+++ b/test/unit/app/queued-badge.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * `QueuedBadge` (#416) — per-post sync-läge-indikator.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest-compat";
+import { QueuedBadge } from "@/components/shell/queued-badge";
+
+describe("QueuedBadge", () => {
+  it("visar 'Köad' för queued", () => {
+    render(<QueuedBadge status="queued" />);
+    const badge = screen.getByTestId("queued-badge");
+    expect(badge).toHaveAttribute("data-status", "queued");
+    expect(badge.textContent).toContain("Köad");
+  });
+
+  it("visar 'Konflikt' för conflict", () => {
+    render(<QueuedBadge status="conflict" />);
+    expect(screen.getByTestId("queued-badge").textContent).toContain("Konflikt");
+  });
+
+  it("döljer 'synced' som default (mindre brus)", () => {
+    render(<QueuedBadge status="synced" />);
+    expect(screen.queryByTestId("queued-badge")).toBeNull();
+  });
+
+  it("visar 'Synkad' när showSynced=true", () => {
+    render(<QueuedBadge status="synced" showSynced />);
+    expect(screen.getByTestId("queued-badge").textContent).toContain("Synkad");
+  });
+});

--- a/test/unit/lib/sync/caching-sync-status.test.ts
+++ b/test/unit/lib/sync/caching-sync-status.test.ts
@@ -1,0 +1,43 @@
+/**
+ * `syncStateFromCachingSync` (#416) — offline-first-store → SyncState-adapter.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { syncStateFromCachingSync } from "@/lib/client/sync/caching-sync-status";
+
+const base = { online: true, pendingCount: 0 };
+
+describe("syncStateFromCachingSync", () => {
+  it("idle utan kö, online, aldrig synkat", () => {
+    expect(syncStateFromCachingSync(base)).toEqual({ kind: "idle" });
+  });
+
+  it("synced när senast-synkat finns och kön är tom", () => {
+    expect(syncStateFromCachingSync({ ...base, lastSyncedAt: 1234 })).toEqual({ kind: "synced", at: 1234 });
+  });
+
+  it("pending när köade mutationer finns (online)", () => {
+    expect(syncStateFromCachingSync({ ...base, pendingCount: 3 })).toEqual({ kind: "pending", count: 3 });
+  });
+
+  it("offline (med pending-count) väger tyngre än pending", () => {
+    expect(syncStateFromCachingSync({ online: false, pendingCount: 2 })).toEqual({ kind: "offline", count: 2 });
+  });
+
+  it("merge-needed vid surface-konflikter", () => {
+    expect(syncStateFromCachingSync({ ...base, pendingCount: 1, conflicts: 1 })).toEqual({ kind: "merge-needed" });
+  });
+
+  it("syncing väger tyngre än konflikt/offline/pending", () => {
+    expect(syncStateFromCachingSync({ online: false, pendingCount: 5, conflicts: 2, syncing: true })).toEqual({
+      kind: "syncing",
+      what: "push",
+    });
+  });
+
+  it("error har högsta prioritet", () => {
+    expect(
+      syncStateFromCachingSync({ ...base, pendingCount: 9, syncing: true, error: "trasig sync" }),
+    ).toEqual({ kind: "error", message: "trasig sync" });
+  });
+});


### PR DESCRIPTION
## Vad

#416 (epic #403, bygger på #415). Online/offline-detektion + sync-status-UI finns redan för **git**-backenden (`useOnlineStatus`, `SyncStatusPill`, `useAutoSync`). Den här PR:en tillför glue:n så **samma** UI visar **offline-first-vägens** (`CachingSyncDataStore`) läge — utan att duplicera UI.

- **`syncStateFromCachingSync`** — ren adapter: `CachingSyncDataStore`-läge (`online`, `pendingCount`, `syncing`, `lastSyncedAt`, `conflicts`, `error`) → den befintliga `SyncState`. Prioritet: fel > synkar > konflikt > offline > köad > synkad > idle. Samma `SyncStatusPill` driver nu båda vägarna → samma mentala modell.
- **`QueuedBadge`** — per-post indikator (köad / synkad / konflikt) för "köad-indikatorer i relevanta vyer". Rent presentationell; datakällan (vilka rader som är köade) wire:as när `CachingSyncDataStore` blir aktiv backend.
- Återanvänder befintlig `useOnlineStatus` (DRY).

## Not

Detektionen (`useOnlineStatus`) och status-komponenten (`SyncStatusPill`) fanns redan — den här PR:en kopplar offline-first-modellen till dem i stället för att bygga om. Per-vy-inwiring av `QueuedBadge` följer när kö-vägen aktiveras (backend-wiring).

## Test

`syncStateFromCachingSync`: alla prioritetsgrenar (idle/synced/pending/offline/merge-needed/syncing/error). `QueuedBadge`: köad/konflikt visas, synkad döljs default, `showSynced` visar den. Lokalt grönt: typecheck (båda projekten, fresh), zero-warning lint, knip, deps:check, jscpd, `test:fast` (3217 tester) — alla exit 0.

Closes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)