### PR TITLE
feat(client): working-set prefetch + LRU-budget (#418)

### DIFF
--- a/src/lib/client/working-set/lru-budget.ts
+++ b/src/lib/client/working-set/lru-budget.ts
@@ -1,0 +1,52 @@
+/**
+ * `LruBudget` (#418, ADR 0022) — håller koll på touch-ordning för ärenden i den
+ * lokala store:n och avgör vilka som ska vräkas när budgeten överskrids.
+ *
+ * Vräknings-regler (ADR 0022): **pinnade** ärenden (mina aktiva + kalenderfönstret)
+ * OCH ärenden med icke-uppspelad lokal mutation vräks ALDRIG — de skickas in som
+ * `pinned`. Bland resten vräks minst-nyligen-rörda först (LRU).
+ */
+export class LruBudget {
+  /** Touch-ordning: index 0 = minst nyligen rörd, sist = nyast. */
+  private order: string[] = [];
+
+  constructor(private readonly capacity: number) {}
+
+  /** Markera ett ärende som nyss rört (flyttar det sist i LRU-ordningen). */
+  touch(id: string): void {
+    const i = this.order.indexOf(id);
+    if (i >= 0) this.order.splice(i, 1);
+    this.order.push(id);
+  }
+
+  /** Glöm ett ärende (efter vräkning). */
+  forget(id: string): void {
+    const i = this.order.indexOf(id);
+    if (i >= 0) this.order.splice(i, 1);
+  }
+
+  has(id: string): boolean {
+    return this.order.includes(id);
+  }
+
+  size(): number {
+    return this.order.length;
+  }
+
+  /**
+   * Vilka ärenden ska vräkas för att rymmas inom `capacity`? Vräker minst-
+   * nyligen-rörda icke-pinnade först. Pinnade räknas mot kapaciteten men vräks
+   * aldrig — om de ensamma överstiger budgeten vräks inget (de är okränkbara).
+   */
+  overflow(pinned: ReadonlySet<string>): string[] {
+    const evict: string[] = [];
+    let total = this.order.length;
+    for (const id of this.order) {
+      if (total <= this.capacity) break;
+      if (pinned.has(id)) continue;
+      evict.push(id);
+      total--;
+    }
+    return evict;
+  }
+}

--- a/src/lib/client/working-set/working-set-cache.ts
+++ b/src/lib/client/working-set/working-set-cache.ts
@@ -1,0 +1,66 @@
+/**
+ * `WorkingSetCache` (#418, ADR 0022) — koordinerar prefetch + on-demand-hämtning
+ * + LRU-budget för offline-klientens ärende-cache. Komponerar `computeWorkingSet`
+ * (vad som ska hållas) + `LruBudget` (vad som ska vräkas).
+ *
+ * Transport-agnostisk: lagrings-I/O injiceras (`loadMatter`/`evictMatter`) så
+ * koordinatorn kan testas med fakes och wire:as mot `CachingSyncDataStore` (#415)
+ * när server-first-backenden aktiveras (#419).
+ */
+
+import { LruBudget } from "./lru-budget";
+import { computeWorkingSet, type WorkingSet, type WorkingSetInput } from "./working-set";
+
+export interface WorkingSetCacheDeps {
+  /** Max antal ärenden i den lokala cachen. */
+  budget: number;
+  /** Hämta ett ärendes subträd till lokal store (prefetch/on-demand). */
+  loadMatter: (matterId: string) => Promise<void>;
+  /** Vräk ett ärendes subträd ur lokal store. */
+  evictMatter: (matterId: string) => Promise<void>;
+  /** Ärenden med icke-uppspelad lokal mutation (vräks ALDRIG, ADR 0017). */
+  pendingMatterIds?: () => ReadonlySet<string>;
+}
+
+export class WorkingSetCache {
+  private readonly lru: LruBudget;
+  private pinned: ReadonlySet<string> = new Set();
+
+  constructor(private readonly deps: WorkingSetCacheDeps) {
+    this.lru = new LruBudget(deps.budget);
+  }
+
+  /** Förhämta working-set:en vid login/online. Returnerar de hämtade ärende-id:na. */
+  async prefetch(input: Omit<WorkingSetInput, "budget">): Promise<string[]> {
+    const ws: WorkingSet = computeWorkingSet({ ...input, budget: this.deps.budget });
+    this.pinned = ws.pinned;
+    for (const id of ws.matterIds) {
+      await this.deps.loadMatter(id);
+      this.lru.touch(id);
+    }
+    await this.enforceBudget();
+    return ws.matterIds;
+  }
+
+  /** Öppna ett ärende — hämtar on-demand om det är utanför cachen, touch:ar LRU. */
+  async openMatter(matterId: string): Promise<void> {
+    if (!this.lru.has(matterId)) await this.deps.loadMatter(matterId);
+    this.lru.touch(matterId);
+    await this.enforceBudget();
+  }
+
+  /** Antal ärenden i cachen. */
+  size(): number {
+    return this.lru.size();
+  }
+
+  /** Vräk LRU-ärenden över budgeten (pinnade + pending undantagna). */
+  private async enforceBudget(): Promise<void> {
+    const pins = new Set(this.pinned);
+    for (const id of this.deps.pendingMatterIds?.() ?? []) pins.add(id);
+    for (const id of this.lru.overflow(pins)) {
+      await this.deps.evictMatter(id);
+      this.lru.forget(id);
+    }
+  }
+}

--- a/src/lib/client/working-set/working-set.ts
+++ b/src/lib/client/working-set/working-set.ts
@@ -1,0 +1,62 @@
+/**
+ * `computeWorkingSet` (#418, ADR 0022) — beräknar vilka ärenden offline-klienten
+ * håller lokalt: *mina aktiva ärenden* (`responsibleLawyerId == jag`) +
+ * *kalender-ärenden* (pinnade — vräks aldrig) + *senast öppnade* (fyller upp till
+ * budgeten). Övrigt hämtas on-demand online.
+ *
+ * Ren funktion (ingen I/O) — prefetch-koordinatorn (`WorkingSetCache`) matar in
+ * id-mängderna den hämtat och får tillbaka working-set:ens form + pin-mängd.
+ */
+
+const ACTIVE = "ACTIVE";
+
+export interface WorkingSetMatter {
+  id: string;
+  responsibleLawyerId?: string | null;
+  status?: string;
+}
+
+export interface WorkingSetInput {
+  /** Inloggad användare (ägar-matchning). */
+  userId: string;
+  /** Kandidat-ärenden att välja ur (id + ägare + status). */
+  matters: readonly WorkingSetMatter[];
+  /** Senast öppnade ärende-id, NYAST FÖRST. */
+  recentMatterIds?: readonly string[];
+  /** Ärende-id kopplade till kalenderhändelser i fönstret. */
+  calendarMatterIds?: readonly string[];
+  /** Max antal ärenden i working-set (budget). Pinnade kan överstiga den. */
+  budget: number;
+}
+
+export interface WorkingSet {
+  /** Ärende-id i working-set: pinnade först, sedan senaste (kapat till budget). */
+  matterIds: string[];
+  /** Pinnade ärenden — vräks aldrig (mina aktiva + kalender). */
+  pinned: Set<string>;
+}
+
+/** Pin-mängden: mina aktiva ärenden + kalender-ärenden (vräks aldrig). */
+function computePinned(input: WorkingSetInput, byId: Map<string, WorkingSetMatter>): Set<string> {
+  const pinned = new Set<string>();
+  for (const m of input.matters) {
+    if (m.responsibleLawyerId === input.userId && (m.status ?? ACTIVE) === ACTIVE) pinned.add(m.id);
+  }
+  for (const id of input.calendarMatterIds ?? []) {
+    if (byId.has(id)) pinned.add(id);
+  }
+  return pinned;
+}
+
+/** Beräkna working-set:ens ärende-mängd + pin-mängd (ADR 0022). */
+export function computeWorkingSet(input: WorkingSetInput): WorkingSet {
+  const byId = new Map(input.matters.map((m) => [m.id, m]));
+  const pinned = computePinned(input, byId);
+  const matterIds = [...pinned];
+  // Fyll upp med senast öppnade (ej redan pinnade) tills budgeten nås.
+  for (const id of input.recentMatterIds ?? []) {
+    if (matterIds.length >= input.budget) break;
+    if (!pinned.has(id) && byId.has(id)) matterIds.push(id);
+  }
+  return { matterIds, pinned };
+}

--- a/test/unit/client/working-set/working-set-cache.test.ts
+++ b/test/unit/client/working-set/working-set-cache.test.ts
@@ -1,0 +1,70 @@
+/**
+ * `WorkingSetCache` (#418, ADR 0022) — prefetch + on-demand + LRU-vräkning mot
+ * injicerade lagrings-loaders (fakes).
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import type { WorkingSetMatter } from "@/lib/client/working-set/working-set";
+import { WorkingSetCache } from "@/lib/client/working-set/working-set-cache";
+
+const ME = "u-1";
+
+function fakes() {
+  const loaded: string[] = [];
+  const evicted: string[] = [];
+  return {
+    loaded, evicted,
+    loadMatter: async (id: string) => { loaded.push(id); },
+    evictMatter: async (id: string) => { evicted.push(id); },
+  };
+}
+
+const matters: WorkingSetMatter[] = [
+  { id: "mine", responsibleLawyerId: ME, status: "ACTIVE" },
+  { id: "r1", responsibleLawyerId: "u-2", status: "ACTIVE" },
+  { id: "r2", responsibleLawyerId: "u-2", status: "ACTIVE" },
+  { id: "extra", responsibleLawyerId: "u-2", status: "ACTIVE" },
+];
+
+describe("WorkingSetCache (#418)", () => {
+  it("prefetch hämtar working-set:en och touch:ar LRU", async () => {
+    const f = fakes();
+    const cache = new WorkingSetCache({ budget: 3, loadMatter: f.loadMatter, evictMatter: f.evictMatter });
+    const ids = await cache.prefetch({ userId: ME, matters, recentMatterIds: ["r1", "r2"] });
+    expect(ids).toEqual(["mine", "r1", "r2"]);
+    expect(f.loaded).toEqual(["mine", "r1", "r2"]);
+    expect(f.evicted).toEqual([]);
+    expect(cache.size()).toBe(3);
+  });
+
+  it("openMatter hämtar on-demand utanför cachen och vräker LRU över budget", async () => {
+    const f = fakes();
+    const cache = new WorkingSetCache({ budget: 3, loadMatter: f.loadMatter, evictMatter: f.evictMatter });
+    await cache.prefetch({ userId: ME, matters, recentMatterIds: ["r1", "r2"] });
+    // Öppna "extra" (utanför set) → hämtas, och äldsta icke-pinnade (r1) vräks.
+    await cache.openMatter("extra");
+    expect(f.loaded).toContain("extra");
+    expect(f.evicted).toEqual(["r1"]); // mine pinnad, r1 äldst icke-pinnad
+    expect(cache.size()).toBe(3);
+  });
+
+  it("vräker aldrig ett ärende med icke-uppspelad mutation (pending)", async () => {
+    const f = fakes();
+    const pending = new Set(["r1"]);
+    const cache = new WorkingSetCache({
+      budget: 3, loadMatter: f.loadMatter, evictMatter: f.evictMatter, pendingMatterIds: () => pending,
+    });
+    await cache.prefetch({ userId: ME, matters, recentMatterIds: ["r1", "r2"] });
+    await cache.openMatter("extra");
+    expect(f.evicted).toEqual(["r2"]); // r1 pending → skyddad, r2 vräks istället
+  });
+
+  it("öppning av redan cachat ärende hämtar inte igen", async () => {
+    const f = fakes();
+    const cache = new WorkingSetCache({ budget: 5, loadMatter: f.loadMatter, evictMatter: f.evictMatter });
+    await cache.prefetch({ userId: ME, matters, recentMatterIds: ["r1"] });
+    const before = f.loaded.length;
+    await cache.openMatter("mine");
+    expect(f.loaded.length).toBe(before); // redan i cachen
+  });
+});

--- a/test/unit/client/working-set/working-set.test.ts
+++ b/test/unit/client/working-set/working-set.test.ts
@@ -1,0 +1,80 @@
+/**
+ * `computeWorkingSet` + `LruBudget` (#418, ADR 0022) — working-set-algoritmen.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { LruBudget } from "@/lib/client/working-set/lru-budget";
+import { computeWorkingSet, type WorkingSetMatter } from "@/lib/client/working-set/working-set";
+
+const ME = "u-1";
+const matters = (extra: WorkingSetMatter[] = []): WorkingSetMatter[] => [
+  { id: "m-mine", responsibleLawyerId: ME, status: "ACTIVE" },
+  { id: "m-mine-closed", responsibleLawyerId: ME, status: "CLOSED" },
+  { id: "m-other", responsibleLawyerId: "u-2", status: "ACTIVE" },
+  { id: "m-cal", responsibleLawyerId: "u-2", status: "ACTIVE" },
+  { id: "m-recent1", responsibleLawyerId: "u-2", status: "ACTIVE" },
+  { id: "m-recent2", responsibleLawyerId: "u-2", status: "ACTIVE" },
+  ...extra,
+];
+
+describe("computeWorkingSet (#418)", () => {
+  it("pinnar mina AKTIVA ärenden (ej stängda, ej andras)", () => {
+    const ws = computeWorkingSet({ userId: ME, matters: matters(), budget: 10 });
+    expect(ws.pinned.has("m-mine")).toBe(true);
+    expect(ws.pinned.has("m-mine-closed")).toBe(false);
+    expect(ws.pinned.has("m-other")).toBe(false);
+  });
+
+  it("pinnar kalender-ärenden", () => {
+    const ws = computeWorkingSet({ userId: ME, matters: matters(), calendarMatterIds: ["m-cal"], budget: 10 });
+    expect(ws.pinned.has("m-cal")).toBe(true);
+  });
+
+  it("fyller upp med senast öppnade till budgeten", () => {
+    const ws = computeWorkingSet({
+      userId: ME, matters: matters(), recentMatterIds: ["m-recent1", "m-recent2"], budget: 2,
+    });
+    // pinned m-mine (1) + 1 recent = budget 2
+    expect(ws.matterIds).toHaveLength(2);
+    expect(ws.matterIds).toContain("m-mine");
+    expect(ws.matterIds).toContain("m-recent1");
+    expect(ws.matterIds).not.toContain("m-recent2");
+  });
+
+  it("pinnade får överstiga budgeten (vräks aldrig)", () => {
+    const many = Array.from({ length: 5 }, (_, i) => ({ id: `mine-${i}`, responsibleLawyerId: ME, status: "ACTIVE" }));
+    const ws = computeWorkingSet({ userId: ME, matters: many, budget: 2 });
+    expect(ws.matterIds).toHaveLength(5); // alla pinnade trots budget 2
+  });
+
+  it("hoppar recent-id som inte finns bland matters", () => {
+    const ws = computeWorkingSet({ userId: ME, matters: matters(), recentMatterIds: ["ghost"], budget: 10 });
+    expect(ws.matterIds).not.toContain("ghost");
+  });
+});
+
+describe("LruBudget (#418)", () => {
+  it("vräker minst-nyligen-rörda först, undantar pinnade", () => {
+    const lru = new LruBudget(2);
+    lru.touch("a"); lru.touch("b"); lru.touch("c"); // a äldst
+    expect(lru.overflow(new Set())).toEqual(["a"]); // 3 > 2 → vräk a
+    expect(lru.overflow(new Set(["a"]))).toEqual(["b"]); // a pinnad → vräk b istället
+  });
+
+  it("vräker inget när pinnade ensamma överstiger kapaciteten", () => {
+    const lru = new LruBudget(1);
+    lru.touch("a"); lru.touch("b");
+    expect(lru.overflow(new Set(["a", "b"]))).toEqual([]);
+  });
+
+  it("touch flyttar sist; forget tar bort", () => {
+    const lru = new LruBudget(2);
+    lru.touch("a"); lru.touch("b"); lru.touch("a"); // a nu nyast → b äldst
+    expect(lru.overflow(new Set())).toEqual([]); // 2 <= 2
+    lru.touch("c"); // 3 > 2, b äldst
+    expect(lru.overflow(new Set())).toEqual(["b"]);
+    lru.forget("b");
+    expect(lru.has("b")).toBe(false);
+    expect(lru.size()).toBe(2);
+  });
+});


### PR DESCRIPTION
## Vad

Implementerar **#418** (ADR 0022 working-set-scoping) för offline-klienten — bygger på #415.

- **`computeWorkingSet`** (ren): ärende-mängden — *mina AKTIVA ärenden* (`responsibleLawyerId`) + *kalender-ärenden* pinnade; *senast öppnade* fyller upp till budgeten; pinnade får överstiga budgeten.
- **`LruBudget`**: touch-ordning + `overflow`-vräkning (minst-nyligen-rörda först), undantar pinnade.
- **`WorkingSetCache`**: koordinerar **prefetch** (login/online), **on-demand**-hämtning (öppna ärende utanför cachen → hämta + touch), och **LRU-vräkning**. Vräker **ALDRIG** pinnade eller ärenden med icke-uppspelad mutation (ADR 0017).

Lagrings-I/O injiceras (`loadMatter`/`evictMatter`) → transport-agnostisk, testbar med fakes; wire:as mot `CachingSyncDataStore` när server-first-backenden aktiveras (#419).

## Test

`computeWorkingSet` (pin-regler, budget-fyllnad, pinnade > budget, okända id), `LruBudget` (LRU-ordning, pin-undantag, forget), `WorkingSetCache` (prefetch, on-demand + vräkning, pending-skydd, ingen dubbel-hämtning). 12 tester. Lokalt grönt: typecheck (båda projekten, fresh), zero-warning lint, complexity-strict, knip, deps:check, jscpd.

## Not

Default-budgetvärden (antal ärenden, kalenderfönster) är inte hårdkodade här — de injiceras (`budget`) och ska mätas mot verklig data (ADR 0022 öppen fråga). Slutlig app-wiring följer #419.

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)