### PR TITLE
feat(client): online-only-handlingar — status + badge (#417)

### DIFF
--- a/src/components/shell/external-action-badge.tsx
+++ b/src/components/shell/external-action-badge.tsx
@@ -1,0 +1,41 @@
+/**
+ * `ExternalActionBadge` (#417, ADR 0021) — per-post indikator för en online-only-
+ * handlings läge (mail/Fortnox/webhook): väntar på att skickas, skickad, eller
+ * misslyckad. Komplement till `QueuedBadge` (#416, sync-status) — den här gäller
+ * den EXTERNA sido-effekten, inte sync:en av datat.
+ *
+ * Rent presentationell; status härleds av `externalActionStatus` ur dispatch-/
+ * job-state och matas in.
+ */
+
+import type { ExternalActionStatus } from "@/lib/client/sync/external-actions";
+
+interface Props {
+  status: ExternalActionStatus;
+}
+
+interface BadgeView {
+  icon: string;
+  label: string;
+  cls: string;
+}
+
+const VIEWS: Record<ExternalActionStatus, BadgeView> = {
+  pending: { icon: "⏳", label: "Skickas när du är online igen", cls: "bg-amber-50 text-amber-800 border-amber-200" },
+  done: { icon: "✓", label: "Skickad", cls: "bg-green-50 text-green-800 border-green-200" },
+  failed: { icon: "⚠", label: "Misslyckades — försök igen", cls: "bg-red-50 text-red-800 border-red-200" },
+};
+
+export function ExternalActionBadge({ status }: Props) {
+  const { icon, label, cls } = VIEWS[status];
+  return (
+    <span
+      data-testid="external-action-badge"
+      data-status={status}
+      className={`text-[11px] px-1.5 py-0.5 rounded border inline-flex items-center gap-1 ${cls}`}
+    >
+      <span aria-hidden>{icon}</span>
+      <span>{label}</span>
+    </span>
+  );
+}

--- a/src/lib/client/sync/external-actions.ts
+++ b/src/lib/client/sync/external-actions.ts
@@ -1,0 +1,35 @@
+/**
+ * Online-only-handlingar — klient-status (#417, ADR 0021).
+ *
+ * ADR 0021: externa sido-effekter (mail/SMTP, Fortnox-push, webhooks) modelleras
+ * som **köat data-state + idempotent server-worker**. Klienten köar ingen egen
+ * handling — den skapar en data-rad (t.ex. `invoiceDispatch` `queued`), synkar
+ * den, och servern utför anropet. Klientens jobb är att **visa status** ("skickas
+ * när du är online igen" / "skickad" / "misslyckades — försök igen").
+ *
+ * Den här modulen härleder en användarvänlig status ur rådstatusen + räknar
+ * väntande handlingar för den globala indikatorn.
+ */
+
+import type { DispatchStatus } from "@/lib/shared/schemas/billing";
+
+// Online-only-operationer (mail/SMTP, Fortnox-push, webhooks, OIDC-refresh) utförs
+// server-side vid sync (ADR 0021); klienten visar bara status nedan.
+
+/** Användarvänligt läge för en extern handling. */
+export type ExternalActionStatus = "pending" | "done" | "failed";
+
+/**
+ * Härled läge ur en dispatch-/job-rådstatus. `queued` (+ okänt/in-flight) →
+ * `pending`; `sent`/`delivered` → `done`; `failed` → `failed`.
+ */
+export function externalActionStatus(rawStatus: DispatchStatus | string): ExternalActionStatus {
+  if (rawStatus === "sent" || rawStatus === "delivered") return "done";
+  if (rawStatus === "failed") return "failed";
+  return "pending";
+}
+
+/** Antal handlingar som väntar på att skickas (pending) — för global indikator. */
+export function pendingExternalCount(items: ReadonlyArray<{ status: string }>): number {
+  return items.filter((i) => externalActionStatus(i.status) === "pending").length;
+}

--- a/test/unit/app/external-action-badge.test.tsx
+++ b/test/unit/app/external-action-badge.test.tsx
@@ -1,0 +1,24 @@
+/**
+ * `ExternalActionBadge` (#417) — online-only-handlings-indikator.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest-compat";
+import { ExternalActionBadge } from "@/components/shell/external-action-badge";
+
+describe("ExternalActionBadge", () => {
+  it("pending → 'Skickas när du är online igen'", () => {
+    render(<ExternalActionBadge status="pending" />);
+    const badge = screen.getByTestId("external-action-badge");
+    expect(badge).toHaveAttribute("data-status", "pending");
+    expect(badge.textContent).toContain("Skickas när du är online igen");
+  });
+  it("done → 'Skickad'", () => {
+    render(<ExternalActionBadge status="done" />);
+    expect(screen.getByTestId("external-action-badge").textContent).toContain("Skickad");
+  });
+  it("failed → 'Misslyckades — försök igen'", () => {
+    render(<ExternalActionBadge status="failed" />);
+    expect(screen.getByTestId("external-action-badge").textContent).toContain("Misslyckades");
+  });
+});

--- a/test/unit/lib/sync/external-actions.test.ts
+++ b/test/unit/lib/sync/external-actions.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Online-only-handlingar — status-härledning (#417, ADR 0021).
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { externalActionStatus, pendingExternalCount } from "@/lib/client/sync/external-actions";
+
+describe("externalActionStatus", () => {
+  it("queued → pending", () => {
+    expect(externalActionStatus("queued")).toBe("pending");
+  });
+  it("sent/delivered → done", () => {
+    expect(externalActionStatus("sent")).toBe("done");
+    expect(externalActionStatus("delivered")).toBe("done");
+  });
+  it("failed → failed", () => {
+    expect(externalActionStatus("failed")).toBe("failed");
+  });
+  it("okänt/in-flight → pending (defensivt)", () => {
+    expect(externalActionStatus("sending")).toBe("pending");
+  });
+});
+
+describe("pendingExternalCount", () => {
+  it("räknar bara handlingar som väntar på att skickas", () => {
+    const items = [{ status: "queued" }, { status: "sent" }, { status: "failed" }, { status: "queued" }];
+    expect(pendingExternalCount(items)).toBe(2);
+  });
+  it("tom lista → 0", () => {
+    expect(pendingExternalCount([])).toBe(0);
+  });
+});


### PR DESCRIPTION
## Vad

Implementerar klient-sidan av **#417** (ADR 0021) — bygger på #415/#416.

ADR 0021:s slutsats: externa sido-effekter (mail/SMTP, Fortnox-push, webhooks) modelleras som **köat data-state + idempotent server-worker** (som redan finns, t.ex. `dispatch-job`). Klienten köar därför **ingen egen handling** — den skapar en data-rad, synkar, servern utför anropet. Klientens jobb är att **visa status**.

- **`externalActionStatus`** — härleder `pending`/`done`/`failed` ur dispatch-/job-status (`queued`→pending, `sent`/`delivered`→done, `failed`→failed, okänt→pending defensivt).
- **`pendingExternalCount`** — antal väntande handlingar för global indikator.
- **`ExternalActionBadge`** — per-post "⏳ Skickas när du är online igen" / "✓ Skickad" / "⚠ Misslyckades — försök igen" (komplement till `QueuedBadge` som visar *sync*-status).

## Test

`externalActionStatus` (alla status-mappningar + defensiv default), `pendingExternalCount`, `ExternalActionBadge` (alla tre lägen). 9 tester. Lokalt grönt: typecheck (båda projekten, fresh), zero-warning lint, knip, jscpd.

## Not

Idempotent uppspelning + retry/backoff lever i de server-sidiga workers (ADR 0021 / befintliga peer-loop-jobb); den här PR:en är klient-status-lagret. Per-vy-inwiring följer när server-first-backenden aktiveras (#419).

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)