### PR TITLE
feat(demo): kör demon på CachingSyncDataStore (offline-first-kärnan) (#419)

### DIFF
--- a/src/components/shell/demo-bootstrap.tsx
+++ b/src/components/shell/demo-bootstrap.tsx
@@ -1,8 +1,12 @@
 "use client";
 
 /**
- * `DemoBootstrap` — singleton-init av DemoRuntime + DemoDataStore i
+ * `DemoBootstrap` — singleton-init av DemoRuntime + offline-first-store i
  * demo-builden. Tillåter alla sidor att köra tRPC mot demo-data.
+ *
+ * Sedan #419 kör demon på `CachingSyncDataStore` (ADR 0016 offline-first-kärna)
+ * UTAN synk-mål — `.store` (LocalStore) är datalagret, mutationer persisteras via
+ * `writeBack` (slab/FSA) som förr, och kön ackumuleras lokalt men synkas aldrig.
  *
  * /demo-routen kör sin egen runtime (DemoClient → useDemoRuntime) och
  * skippas här för att undvika double-load mot OPFS.
@@ -26,11 +30,13 @@ import { pickProvider } from "@/lib/client/sync/pick-provider";
 import { SyncProviderRoot } from "@/lib/client/sync/sync-context";
 import { trpc } from "@/lib/client/trpc";
 import { GitAuthProvider } from "@/lib/server/auth/git-auth-provider";
-import { DemoDataStore, type DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import { CachingSyncDataStore, noSyncTransport } from "@/lib/server/data-store/in-memory/caching-sync-data-store";
 import type { MutationEvent } from "@/lib/server/data-store/in-memory/writable-delegate";
 import { DemoRuntime } from "@/lib/server/local-first/demo-runtime";
 import { createGhPagesCloneFn } from "@/lib/server/local-first/gh-pages-loader";
 import { OpfsPersistence } from "@/lib/server/local-first/persistence";
+import type { DemoSource } from "@/lib/shared/demo-source";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { AppShell } from "./app-shell";
 import { AuthStatusBanner } from "./auth-status-banner";
@@ -232,7 +238,7 @@ function makeDemoQueryClient(): QueryClient {
   });
 }
 
-function createDemoTrpcClient(dataStore: DemoDataStore, firmaConfig: FirmaConfig) {
+function createDemoTrpcClient(dataStore: IDataStore, firmaConfig: FirmaConfig) {
   return trpc.createClient({
     links: [
       new GitBackendRuntime({
@@ -380,13 +386,20 @@ export function DemoBootstrap({ children }: { children: ReactNode }) {
   const { writeBack, fsaRef, runtimeRef } = useDemoWriteBack();
   useWriteBackListeners(writeBack, runtimeRef);
 
-  const [dataStore] = useState(() => new DemoDataStore(source, writeBack));
+  // Demon kör nu på offline-first-kärnan (ADR 0016/#419): CachingSyncDataStore
+  // UTAN synk-mål (noSyncTransport). `.store` är LocalStore-kärnan appen läser/
+  // skriver mot; `source` fylls async av clone/restore (delad mutabel ref).
+  // Mutationer persisteras via samma `writeBack` (slab/FSA) som förr; kön
+  // ackumuleras lokalt men synkas aldrig (demon = degenerat-fallet).
+  const [cachingSync] = useState(() =>
+    CachingSyncDataStore.createEphemeral({ transport: noSyncTransport, seed: source, writeBack }),
+  );
   // Initial status MÅSTE vara SSR-stabil för att undvika hydration-mismatch
   // (React #418). Pathname-baserad logik flyttas till useDemoBootstrap.
   const [status, setStatus] = useState<Status>("loading");
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [queryClient] = useState(makeDemoQueryClient);
-  const [trpcClient] = useState(() => createDemoTrpcClient(dataStore, firmaConfig));
+  const [trpcClient] = useState(() => createDemoTrpcClient(cachingSync.store, firmaConfig));
 
   // Flippa efter första commit → byter från platshållare till full app-tree.
   // Egen effekt (separat från boot-effekten) så hydreringen hinner committa rent.

--- a/src/lib/server/data-store/in-memory/caching-sync-data-store.ts
+++ b/src/lib/server/data-store/in-memory/caching-sync-data-store.ts
@@ -38,13 +38,25 @@ export interface CachingSyncDeps {
   transport: SyncTransport;
   /** Seed-data om persistensen är tom (eller saknas). */
   seed?: DemoSource;
-  /** Hydrera/spara hela source:n (IndexedDB i browsern; in-memory i tester). */
+  /** Hydrera/spara hela source:n (snapshot — IndexedDB i browsern). */
   persistence?: LocalStorePersistence;
+  /**
+   * Per-mutation write-back (alternativ till `persistence`): anropas med varje
+   * `MutationEvent` så caller:n kan persistera finkornigt. Demo-vägen (#419) ger
+   * sin slab/FSA-pipeline här i st.f. snapshot-persistens.
+   */
+  writeBack?: (event: MutationEvent<Record<string, unknown>>) => void | Promise<void>;
   /** Persistens för mutations-kön (IndexedDB i browsern). */
   queuePersistence?: MutationQueuePersistence;
   /** Delta-sync-cursor-lagring. Default: in-memory. */
   cursor?: CursorStore;
 }
+
+/** No-op-transport: ingen synk (demon = degenerat-fallet, ADR 0016 — inget synk-mål). */
+export const noSyncTransport: SyncTransport = {
+  pull: () => Promise.resolve({ changes: [], cursor: 0 }),
+  push: (mutation) => Promise.resolve({ status: "accepted", row: mutation.row }),
+};
 
 /**
  * Skriv en kanonisk server-rad TYST till lokal source (ingen re-enqueue):
@@ -73,14 +85,26 @@ export class CachingSyncDataStore {
     private readonly engine: ReconcileEngine,
   ) {}
 
-  /** Hydrera (kö + source) och komponera klossarna. */
+  /** Hydrera (kö + source ur persistens) och komponera klossarna (server-vägen). */
   static async create(deps: CachingSyncDeps): Promise<CachingSyncDataStore> {
     const queue = await MutationQueue.hydrate(deps.queuePersistence);
-    const cursor = deps.cursor ?? new InMemoryCursorStore();
     const hydrated = deps.persistence ? await deps.persistence.hydrate() : null;
     const source: DemoSource = hydrated ?? deps.seed ?? {};
+    return CachingSyncDataStore.wire(deps, queue, source);
+  }
 
-    const persist = (): Promise<void> =>
+  /**
+   * Synkron variant utan async-hydrering: tom kö, seed direkt. Demo-vägen (#419)
+   * — inget synk-mål, ingen kö-persistens; mutationer persisteras via `writeBack`.
+   */
+  static createEphemeral(deps: CachingSyncDeps): CachingSyncDataStore {
+    return CachingSyncDataStore.wire(deps, new MutationQueue(), deps.seed ?? {});
+  }
+
+  /** Komponera LocalStore (onMutate → enqueue + persist) + ReconcileEngine. */
+  private static wire(deps: CachingSyncDeps, queue: MutationQueue, source: DemoSource): CachingSyncDataStore {
+    const cursor = deps.cursor ?? new InMemoryCursorStore();
+    const persistSnapshot = (): Promise<void> =>
       deps.persistence ? deps.persistence.save(store.currentSource) : Promise.resolve();
 
     const onLocalMutation = async (event: MutationEvent<Record<string, unknown>>): Promise<void> => {
@@ -94,14 +118,15 @@ export class CachingSyncDataStore {
         },
         typeof version === "number" ? { baseVersion: version } : {},
       );
-      await persist();
+      await persistSnapshot();
+      if (deps.writeBack) await deps.writeBack(event);
     };
 
     const store = new LocalStore(source, onLocalMutation);
 
     const apply: ApplyCanonical = async (entity, row, deleted) => {
       writeCanonical(store, entity, row, deleted);
-      await persist();
+      await persistSnapshot();
     };
 
     const engine = new ReconcileEngine({ transport: deps.transport, queue, cursor, apply });

--- a/test/unit/server/data-store/caching-sync-data-store.test.ts
+++ b/test/unit/server/data-store/caching-sync-data-store.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from "vitest-compat";
-import { CachingSyncDataStore } from "@/lib/server/data-store/in-memory/caching-sync-data-store";
+import { CachingSyncDataStore, noSyncTransport } from "@/lib/server/data-store/in-memory/caching-sync-data-store";
 import { InMemoryPersistence } from "@/lib/server/data-store/in-memory/local-store-persistence";
 import type { QueuedMutation } from "@/lib/server/data-store/in-memory/mutation-queue";
 import type { PullResult, PushResult, SyncTransport } from "@/lib/server/data-store/in-memory/sync-transport";
@@ -118,6 +118,42 @@ describe("CachingSyncDataStore (#415)", () => {
       expect(res.conflicts).toHaveLength(1);
       expect(res.conflicts[0]).toMatchObject({ conflictClass: "surface", reason: "stale-status" });
       expect(ds.pendingCount()).toBe(0); // acked trots konflikt (blockerar inte kön)
+    });
+  });
+
+  describe("createEphemeral (demo-vägen #419 — synkron, writeBack, inget synk-mål)", () => {
+    it("skriver lokalt, anropar writeBack per mutation, köar (men synkar aldrig)", async () => {
+      const events: string[] = [];
+      const ds = CachingSyncDataStore.createEphemeral({
+        transport: noSyncTransport,
+        writeBack: (e) => { events.push(`${e.kind}:${e.entity}`); },
+      });
+      const m1 = uuidv7();
+      await ds.store.matters.create({ data: matter(m1) as never });
+
+      expect(await ds.store.matters.findUnique({ where: { id: m1 } })).toMatchObject({ id: m1 });
+      expect(events).toEqual(["create:matter"]); // writeBack-pipelinen (slab/FSA) fick eventet
+      expect(ds.pendingCount()).toBe(1); // köad lokalt
+    });
+
+    it("delar seed-referensen (clone fyller source efter create)", async () => {
+      const source: { matters?: Record<string, unknown>[] } = {};
+      const ds = CachingSyncDataStore.createEphemeral({ transport: noSyncTransport, seed: source as never });
+      // Simulera att clone fyller den delade source-refen efteråt.
+      source.matters = [matter(uuidv7())];
+      const list = await ds.store.matters.findMany({});
+      expect(list).toHaveLength(1);
+    });
+  });
+
+  describe("noSyncTransport", () => {
+    it("pull ger tom delta, push ekar raden som accepted", async () => {
+      expect(await noSyncTransport.pull(0)).toEqual({ changes: [], cursor: 0 });
+      const row = { id: "x" };
+      expect(await noSyncTransport.push({ mutationId: "m", entity: "matter", kind: "create", row, enqueuedAt: 0 })).toEqual({
+        status: "accepted",
+        row,
+      });
     });
   });
 });


### PR DESCRIPTION
## Vad

**#419** (epic #403) — flyttar GH Pages-demon till offline-first-kärnan (`CachingSyncDataStore`, ADR 0016) **utan synk-mål**, så demon blir det *degenererade* offline-first-fallet i st.f. ett divergent spår ("demon = gratis biprodukt").

## Hur (minimalt + bakåtkompatibelt)

- **`CachingSyncDataStore`**: lade till en **synkron `createEphemeral`** (tom kö, seed direkt — ingen async-hydrering) + valfri **per-mutation `writeBack`** (alternativ till snapshot-`persistence`) + **`noSyncTransport`** (no-op pull/push). `create` (server-vägen) är oförändrad; wiringen delas via en privat `wire`.
- **`demo-bootstrap`**: `new DemoDataStore(source, writeBack)` → `CachingSyncDataStore.createEphemeral({ transport: noSyncTransport, seed: source, writeBack }).store`. **Samma `writeBack`-pipeline (slab/FSA)** → persistensen är oförändrad; den delade mutabla `source` fylls av clone/restore precis som förr; kön ackumuleras lokalt men synkas aldrig (inget synk-mål).

`.store` är `LocalStore` (samma klass `DemoDataStore` ärvde) → datalagrets beteende är identiskt; enda tillägget är den (osynkade) mutations-kön.

## Verifiering

- ✅ **`build:demo`** grön — full static export (97 HTML, 502 entiteter, manifest, 60 binärer), demo-seed intakt.
- ✅ `test:fast` (3251 + 38 tester, 0 fail), inkl. `demo-bootstrap`-tester (21) + nya `createEphemeral`/`writeBack`/`noSyncTransport`-tester.
- ✅ typecheck (båda projekten, fresh), zero-warning lint, complexity-strict, knip, deps:check, jscpd.
- 🔄 **Round-trip-E2E (CI)** kör demo-runtimen end-to-end i en riktig browser mot docker — den validerar att demon faktiskt laddar + muterar. Mergas först när den är grön.

## Not

Persistens-beteendet är medvetet oförändrat (per-event `writeBack` → slab/FSA), inte CachingSyncDataStore:s snapshot-`persistence`. Att byta demon till IndexedDB-snapshot-persistens (och dra in den fulla sync-vägen) är en separd uppföljning; #419:s mål är att ena *datalager-kärnan*.

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)