### PR TITLE
feat(server): deployerbar server-first-artefakt — docker-image + deploy-E2E (#479)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,10 +9,13 @@
 !dist
 dist/*
 !dist/server-runtime
+!dist/server-first
 # imagen kör bara linux — darwin-binärerna behövs ej i contexten.
 dist/server-runtime/*darwin*
+dist/server-first/*darwin*
 !tooling
 tooling/*
 !tooling/docker
 tooling/docker/*
 !tooling/docker/server-runtime
+!tooling/docker/server-first

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,42 @@ jobs:
         if: always()
         run: docker compose -f tooling/docker/docker-compose.test.yml down -v
 
+  # ───────────────── Server-first (docker deploy-E2E) ─────────────────
+  # Bygger server-first-binären, kör den som en RIKTIG docker-container mot
+  # Postgres, applicerar schemat (db:migrate) och synkar push/pull via
+  # TrpcSyncTransport över HTTP. Bevisar att den deployade artefakten fungerar
+  # (grund för self-hosted server-first + #421/#422). Demon/git orörda.
+  server-first-e2e:
+    name: Server-first (deploy E2E)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - name: Bygg server-first-binär
+        run: bun run server-first:build
+      - name: Starta Postgres + server-first (docker)
+        run: docker compose -f tooling/docker/docker-compose.server-first.yml up -d --build --wait --wait-timeout 120
+      - name: Applicera schema (db:migrate)
+        env:
+          AVA_DATABASE_URL: postgres://ava:ava@localhost:5433/ava_test
+        run: bun run db:migrate
+      - name: Server-sync deploy-E2E
+        env:
+          SERVER_URL: http://localhost:3001
+          AVA_DATABASE_URL: postgres://ava:ava@localhost:5433/ava_test
+          AVA_ORGANIZATION_ID: "00000000-0000-0000-0000-000000000001"
+        run: bun tooling/scripts/server-first-sync-e2e.ts
+      - name: Tear down docker
+        if: always()
+        run: docker compose -f tooling/docker/docker-compose.server-first.yml down -v
+
   # ───────────────── E2E (git round-trip) ─────────────────
   # Den riktiga browser-klienten klonar/pushar mot docker-git-servern
   # (self-hosted). Auth: PAT bootstrappas av web-containern; vi exporterar

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "seed:local": "bun tooling/scripts/seed-firma-local.ts",
     "server-runtime": "bun src/bin/server-runtime.ts",
     "server-first": "bun src/bin/server-first.ts",
+    "server-first:build": "bun tooling/scripts/build-server-first.ts",
     "install:server": "bun tooling/scripts/install-server.ts",
     "bootstrap:admin": "bun tooling/scripts/bootstrap-admin.ts",
     "server-runtime:build": "bun tooling/scripts/build-server-runtime.ts",

--- a/tooling/docker/docker-compose.server-first.yml
+++ b/tooling/docker/docker-compose.server-first.yml
@@ -1,0 +1,42 @@
+# Server-first-stack (#410, ADR 0016) — Postgres + server-first-runtimen, för
+# lokal körning + CI:s server-sync-E2E. Migrera först (`bun run db:migrate` mot
+# den exponerade porten) — binären bär ingen migrations-SQL.
+#
+#   bun run server-first:build
+#   docker compose -f tooling/docker/docker-compose.server-first.yml up -d --build --wait
+#   AVA_DATABASE_URL=postgres://ava:ava@localhost:5433/ava_test bun run db:migrate
+#   # → server-first lyssnar på localhost:3001 (X-Auth-Request-Email-grindat)
+
+name: ava-server-first
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: ava
+      POSTGRES_PASSWORD: ava
+      POSTGRES_DB: ava_test
+    ports:
+      - "5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ava -d ava_test"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+    tmpfs:
+      - /var/lib/postgresql/data
+
+  server-first:
+    build:
+      context: ../..
+      dockerfile: tooling/docker/server-first/Dockerfile
+    environment:
+      AVA_DATABASE_URL: postgres://ava:ava@postgres:5432/ava_test
+      AVA_ORGANIZATION_ID: "${AVA_ORGANIZATION_ID:-00000000-0000-0000-0000-000000000001}"
+      AVA_HTTP_HOST: 0.0.0.0
+      AVA_HTTP_PORT: "3001"
+    ports:
+      - "3001:3001"
+    depends_on:
+      postgres:
+        condition: service_healthy

--- a/tooling/docker/server-first/Dockerfile
+++ b/tooling/docker/server-first/Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+#
+# AVA server-first-runtime (#410, ADR 0016) — den Postgres-backade tRPC-over-HTTP-
+# servern (server-verifierad principal ur oauth2-proxy-headers). Ersätter på sikt
+# git-peer-server-runtimen (#421) i byråns stack.
+#
+# Tunn runtime-image: debian-slim + ca-certificates + den förbyggda standalone-
+# binären (byggd utanför imagen, samma mönster som server-runtime):
+#   bun run server-first:build      # → dist/server-first/ava-server-first-linux-*
+#
+# Migrationer bakas INTE in — kör `bun run db:migrate` mot Postgres före start
+# (binären kan inte läsa migrations-SQL:en i runtime).
+#
+# Bygg (från repo-roten, så dist/ ligger i build-contexten):
+#   docker build -f tooling/docker/server-first/Dockerfile -t ava-server-first .
+FROM debian:stable-slim
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY dist/server-first/ava-server-first-linux-x64   /opt/ava/bin/ava-server-first-linux-x64
+COPY dist/server-first/ava-server-first-linux-arm64 /opt/ava/bin/ava-server-first-linux-arm64
+COPY tooling/docker/server-first/entrypoint.sh      /entrypoint.sh
+RUN chmod +x /opt/ava/bin/ava-server-first-linux-* /entrypoint.sh
+
+# Loopback default (sitter bakom nginx/oauth2-proxy som TLS-terminerar + injicerar
+# X-Auth-Request-*). Override:a AVA_HTTP_HOST=0.0.0.0 i docker-nätet.
+ENV AVA_HTTP_HOST=0.0.0.0 \
+    AVA_HTTP_PORT=3001
+
+EXPOSE 3001
+ENTRYPOINT ["/entrypoint.sh"]

--- a/tooling/docker/server-first/entrypoint.sh
+++ b/tooling/docker/server-first/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Entrypoint för server-first-containern (#410, ADR 0016).
+#
+#   1. Välj rätt binär för arkitekturen (multi-arch image).
+#   2. Exec:a den — config läses ur env (AVA_DATABASE_URL, AVA_ORGANIZATION_ID,
+#      AVA_HTTP_PORT, AVA_HTTP_HOST). Inga hemligheter bakas in.
+#
+# Migrationer körs INTE här — applicera schemat med `bun run db:migrate` mot
+# AVA_DATABASE_URL innan containern startar (binären bär ingen migrations-SQL).
+set -euo pipefail
+
+case "$(uname -m)" in
+  x86_64)  BIN=/opt/ava/bin/ava-server-first-linux-x64 ;;
+  aarch64) BIN=/opt/ava/bin/ava-server-first-linux-arm64 ;;
+  *) echo "[server-first] okänd arkitektur: $(uname -m)" >&2; exit 1 ;;
+esac
+
+echo "[server-first] startar: $BIN $*"
+exec "$BIN" "$@"

--- a/tooling/scripts/build-server-first.ts
+++ b/tooling/scripts/build-server-first.ts
@@ -1,0 +1,44 @@
+/**
+ * Server-first-runtime (#410, ADR 0016) — paketering till fristående binärer.
+ *
+ * Cross-compile:ar `src/bin/server-first.ts` (Postgres + tRPC-over-HTTP) till
+ * linux-binärer för docker-imagen (`tooling/docker/server-first/`). Samma
+ * `bun build --compile`-mönster som `build-server-runtime.ts`.
+ *
+ *   bun run server-first:build
+ *
+ * Migrationer bakas INTE in (binären kan inte läsa `tooling/db/migrations/` i
+ * runtime) — kör `bun run db:migrate` mot Postgres separat före start.
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdir, rm } from "node:fs/promises";
+
+const OUT_DIR = "dist/server-first";
+const ENTRY = "src/bin/server-first.ts";
+
+// Deploy = linux (docker). Darwin utelämnas — kör `bun src/bin/server-first.ts` lokalt.
+const TARGETS = [
+  { target: "bun-linux-x64", out: "ava-server-first-linux-x64" },
+  { target: "bun-linux-arm64", out: "ava-server-first-linux-arm64" },
+] as const;
+
+function buildOne(target: string, out: string): void {
+  const res = spawnSync(
+    "bun",
+    ["build", ENTRY, "--compile", `--target=${target}`, "--outfile", `${OUT_DIR}/${out}`],
+    { stdio: "inherit" },
+  );
+  if (res.status !== 0) throw new Error(`build misslyckades för ${target} (exit ${res.status ?? "signal"})`);
+  console.log(`✓ ${out}`);
+}
+
+async function main(): Promise<void> {
+  console.log(`Bygger ava-server-first →  ${OUT_DIR}/`);
+  await rm(OUT_DIR, { recursive: true, force: true });
+  await mkdir(OUT_DIR, { recursive: true });
+  for (const { target, out } of TARGETS) buildOne(target, out);
+  console.log(`Klart: ${TARGETS.length} binärer i ${OUT_DIR}/`);
+}
+
+await main();

--- a/tooling/scripts/server-first-sync-e2e.ts
+++ b/tooling/scripts/server-first-sync-e2e.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env bun
+/**
+ * Server-first DEPLOY-E2E (#410, ADR 0016) — kör mot en KÖRANDE server-first-
+ * container (docker-compose.server-first.yml). Seedar en användare i Postgres,
+ * och synkar push/pull via `TrpcSyncTransport` över HTTP mot containern — bevisar
+ * att den deployade artefakten (binär i docker) fungerar end-to-end.
+ *
+ *   bun run server-first:build
+ *   docker compose -f tooling/docker/docker-compose.server-first.yml up -d --build --wait
+ *   AVA_DATABASE_URL=postgres://ava:ava@localhost:5433/ava_test bun run db:migrate
+ *   SERVER_URL=http://localhost:3001 \
+ *   AVA_DATABASE_URL=postgres://ava:ava@localhost:5433/ava_test \
+ *   AVA_ORGANIZATION_ID=00000000-0000-0000-0000-000000000001 \
+ *     bun tooling/scripts/server-first-sync-e2e.ts
+ */
+
+import { createTRPCClient, httpBatchLink } from "@trpc/client";
+import postgres from "postgres";
+import superjson from "superjson";
+import { TrpcSyncTransport } from "@/lib/client/sync/trpc-sync-transport";
+import type { AppRouter } from "@/lib/server/routers/_app";
+import { uuidv7 } from "@/lib/shared/uuid";
+
+const SERVER_URL = process.env.SERVER_URL ?? "http://localhost:3001";
+const DB_URL = process.env.AVA_DATABASE_URL ?? "postgres://ava:ava@localhost:5433/ava_test";
+const ORG = process.env.AVA_ORGANIZATION_ID ?? "00000000-0000-0000-0000-000000000001";
+const EMAIL = "anna@byra.se";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** Seeda en allowlistad användare så orgProcedure släpper igenom. */
+async function seedUser(): Promise<void> {
+  const sql = postgres(DB_URL, { max: 1, onnotice: () => {} });
+  try {
+    await sql`INSERT INTO users (id, organization_id, email, name, role, active)
+              VALUES (${uuidv7()}, ${ORG}, ${EMAIL}, 'Anna', 'LAWYER', true)
+              ON CONFLICT DO NOTHING`;
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+function makeTransport(): TrpcSyncTransport {
+  const client = createTRPCClient<AppRouter>({
+    links: [
+      httpBatchLink({
+        url: `${SERVER_URL}/api/trpc`,
+        transformer: superjson,
+        headers: () => ({ "X-Auth-Request-Email": EMAIL }),
+      }),
+    ],
+  });
+  return new TrpcSyncTransport(client);
+}
+
+/** Vänta tills servern svarar (containern kan ta en stund att lyssna). */
+async function waitForServer(transport: TrpcSyncTransport): Promise<void> {
+  for (let i = 0; i < 30; i++) {
+    try {
+      await transport.pull(0);
+      return;
+    } catch {
+      await sleep(1000);
+    }
+  }
+  throw new Error(`server-first svarade inte på ${SERVER_URL} inom 30s`);
+}
+
+async function main(): Promise<void> {
+  await seedUser();
+  const transport = makeTransport();
+  await waitForServer(transport);
+
+  const m1 = uuidv7();
+  const push = await transport.push({
+    mutationId: uuidv7(),
+    entity: "matter",
+    kind: "create",
+    row: { id: m1, organizationId: ORG, title: "Deploy-E2E-ärende", status: "ACTIVE", matterNumber: "2026-0123" },
+    enqueuedAt: 0,
+  });
+  if (push.status !== "accepted") throw new Error(`push ej accepterad: ${push.status}`);
+
+  const pull = await transport.pull(0);
+  if (!pull.changes.some((c) => c.row.id === m1)) throw new Error("pull saknar den pushade raden");
+
+  console.log(`✓ server-first deploy-E2E: push accepted, pull cursor ${pull.cursor}, rad synlig`);
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`✗ server-first deploy-E2E: ${String(err)}\n`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Vad

Steg mot **självhostad server-first** (forts. #477, epic #403). En **deployerbar** server-first-runtime att synka mot — och artefakten som **#421** ersätter git-peer-server-runtimen med.

- **`server-first:build`** (`build-server-first.ts`): `bun build --compile` → fristående linux-binärer (x64+arm64), samma mönster som `server-runtime`.
- **`tooling/docker/server-first/`** (Dockerfile + entrypoint): tunn debian-image med binären, Postgres-backad (ingen git). Migrationer körs **externt** (`db:migrate`; binären bär ingen migrations-SQL).
- **`docker-compose.server-first.yml`**: Postgres + server-first.
- **`server-first-sync-e2e.ts`** + nytt CI-jobb **"Server-first (deploy E2E)"**: kör containern, applicerar schema, seedar en användare, synkar push/pull via `TrpcSyncTransport` över HTTP.
- **`.dockerignore`**: whitelistar server-first-artefakterna i bygg-contexten.

## Verifiering

**Lokalt mot Postgres 16 (docker)**: `server-first:build` → `compose up --build` → `db:migrate` → deploy-E2E grön (**push accepted, pull cursor 1, raden synlig**). CI-jobbet kör samma kedja. typecheck (båda projekten, fresh), zero-warning lint, knip, deps:check, jscpd. **Demon och git-vägen är orörda** — inget i den körande appen ändras.

## Var i sekvensen

1. ✅ #477 — db:migrate + deploy-verifiering (in-process).
2. ✅ **Denna PR (#479)** — deployerbar docker-artefakt + container-E2E.
3. Self-hosted-klient → `TrpcSyncTransport` mot den deployade servern (cutover).
4. Demo → IndexedDB-cache (seed-populerad).
5. #420/#421 — pensionera git/slab + gamla server-runtime (server-first ersätter den).
6. #422 — ersätt git-round-trip-E2E.

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)