### PR TITLE
feat(client): self-hosted server-first-store (CachingSyncDataStore + TrpcSyncTransport) (#481)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Repository-tester mot riktig Postgres
         env:
           PG_TEST_URL: postgres://ava:ava@localhost:5433/ava_test
-        run: bun test test/unit/server/repositories/ test/unit/server/db/relations.test.ts test/unit/server/http/server-context.test.ts test/unit/server/http/server-trpc-handler.test.ts test/unit/server/sync/ test/unit/client/sync/trpc-sync-transport.test.ts test/unit/server/http/server-first-http-e2e.test.ts test/unit/server/db/server-first-deploy.test.ts
+        run: bun test test/unit/server/repositories/ test/unit/server/db/relations.test.ts test/unit/server/http/server-context.test.ts test/unit/server/http/server-trpc-handler.test.ts test/unit/server/sync/ test/unit/client/sync/trpc-sync-transport.test.ts test/unit/server/http/server-first-http-e2e.test.ts test/unit/server/db/server-first-deploy.test.ts test/unit/client/backend/server-first-store.test.ts
       - name: Tear down docker
         if: always()
         run: docker compose -f tooling/docker/docker-compose.test.yml down -v

--- a/src/lib/client/backend/server-first-store.ts
+++ b/src/lib/client/backend/server-first-store.ts
@@ -1,0 +1,67 @@
+/**
+ * `createServerFirstStore` (#2b, ADR 0016) — self-hosted-klientens offline-first-
+ * store i server-first-läge: en `CachingSyncDataStore` synkad mot den deployade
+ * server-first-runtimen (#479) via `TrpcSyncTransport` över HTTP, persisterad i
+ * IndexedDB. Ersätter iso-git-vägen (clone/push/pull) för self-hosted.
+ *
+ * Routrarna körs fortsatt i klienten (in-process) mot `.store`; synk sker via
+ * `reconcile()` (pull→apply→replay→advance) i st.f. git. Auth rider på
+ * oauth2-proxy:s samma-origin-cookie (ADR 0009) — `fetch` default skickar den.
+ *
+ * Additiv: detta är den server-first-väg self-hosted byter TILL. Git-default
+ * + round-trip-E2E rörs inte förrän cutovern (#420–#422) — då flippas valet.
+ */
+
+import { createTRPCClient, httpBatchLink } from "@trpc/client";
+import superjson from "superjson";
+import { TrpcSyncTransport } from "@/lib/client/sync/trpc-sync-transport";
+import { CachingSyncDataStore } from "@/lib/server/data-store/in-memory/caching-sync-data-store";
+import { IndexedDbPersistence } from "@/lib/server/data-store/in-memory/indexeddb-persistence";
+import type { LocalStorePersistence } from "@/lib/server/data-store/in-memory/local-store-persistence";
+import {
+  IndexedDbMutationQueuePersistence,
+  type MutationQueuePersistence,
+} from "@/lib/server/data-store/in-memory/mutation-queue";
+import type { AppRouter } from "@/lib/server/routers/_app";
+import { serverTrpcEndpoint } from "./http-backend-runtime";
+
+/** tRPC:s httpBatchLink-fetch-typ (icke-exporterad `FetchEsque`). */
+type LinkFetch = NonNullable<NonNullable<Parameters<typeof httpBatchLink<AppRouter>>[0]>["fetch"]>;
+export type ServerFirstFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+export interface ServerFirstStoreDeps {
+  /** Server-bas-URL. Tom (default) = samma origin (bakom nginx/oauth2-proxy). */
+  baseUrl?: string;
+  /** Source-persistens. Default IndexedDB (browser). Override i tester. */
+  persistence?: LocalStorePersistence;
+  /** Mutations-kö-persistens. Default IndexedDB. Override i tester. */
+  queuePersistence?: MutationQueuePersistence;
+  /** `fetch`-override (test/icke-standard-runtime). Default global fetch (samma-origin-cookie). */
+  fetch?: ServerFirstFetch;
+  /** Hoppa initial reconcile (pull) — för tester som kontrollerar timing. */
+  skipInitialReconcile?: boolean;
+}
+
+/**
+ * Bygg + hydrera self-hosted-klientens server-first-store och gör en initial
+ * reconcile (pull) mot servern. Returnerar `CachingSyncDataStore` — `.store` är
+ * `ctx.dataStore`, `.reconcile()` driver löpande synk.
+ */
+export async function createServerFirstStore(deps: ServerFirstStoreDeps = {}): Promise<CachingSyncDataStore> {
+  const client = createTRPCClient<AppRouter>({
+    links: [
+      httpBatchLink({
+        url: serverTrpcEndpoint(deps.baseUrl),
+        transformer: superjson,
+        ...(deps.fetch ? { fetch: deps.fetch as unknown as LinkFetch } : {}),
+      }),
+    ],
+  });
+  const cachingSync = await CachingSyncDataStore.create({
+    transport: new TrpcSyncTransport(client),
+    persistence: deps.persistence ?? new IndexedDbPersistence(),
+    queuePersistence: deps.queuePersistence ?? new IndexedDbMutationQueuePersistence(),
+  });
+  if (!deps.skipInitialReconcile) await cachingSync.reconcile();
+  return cachingSync;
+}

--- a/test/unit/client/backend/server-first-store.test.ts
+++ b/test/unit/client/backend/server-first-store.test.ts
@@ -1,0 +1,76 @@
+/**
+ * `createServerFirstStore` (#2b) — self-hosted-klientens offline-first-store i
+ * server-first-läge, end-to-end mot den RIKTIGA server-handlern (#410) + Drizzle-
+ * repos över Postgres (pglite/PG via createTestDb). Bevisar att klienten pullar
+ * server-data initialt och pushar lokala mutationer vid reconcile.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import { createServerFirstStore } from "@/lib/client/backend/server-first-store";
+import { noopPorts } from "@/lib/server/adapters/noop-ports";
+import { InMemoryPersistence } from "@/lib/server/data-store/in-memory/local-store-persistence";
+import { InMemoryMutationQueuePersistence } from "@/lib/server/data-store/in-memory/mutation-queue";
+import { users } from "@/lib/server/db/schema";
+import { createServerTrpcHandler } from "@/lib/server/http/server-trpc-handler";
+import { createDbChangeLogRecorder, enableChangeLogOnAll } from "@/lib/server/repositories/change-log-recorder";
+import { buildDrizzleRepositories } from "@/lib/server/repositories/drizzle-repositories";
+import type { Repositories } from "@/lib/server/repositories/repositories";
+import { DrizzleSyncStore } from "@/lib/server/sync/drizzle-sync-store";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../../server/db/pg-test-db";
+
+const ORG = uuidv7();
+
+describe("createServerFirstStore (#2b)", () => {
+  let handle: TestDbHandle;
+  let repos: Repositories;
+  let handler: (req: Request) => Promise<Response>;
+
+  beforeAll(async () => {
+    handle = await createTestDb();
+    repos = buildDrizzleRepositories(handle.db);
+    enableChangeLogOnAll(repos, createDbChangeLogRecorder(handle.db));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await handle.db.insert(users).values(
+      v({ id: uuidv7(), organizationId: ORG, email: "anna@byra.se", name: "Anna", role: "LAWYER", active: true }),
+    );
+    handler = createServerTrpcHandler({ repos, ports: noopPorts, organizationId: ORG, sync: new DrizzleSyncStore(handle.db, repos) });
+  });
+  afterAll(async () => { await handle.close(); });
+
+  /** Injicerad fetch → server-handlern, med oauth2-proxy-email (kringgår happy-dom-CORS). */
+  const fetchToServer = (input: string | URL, init?: RequestInit): Promise<Response> => {
+    const headers = new Headers(init?.headers);
+    headers.set("X-Auth-Request-Email", "anna@byra.se");
+    return handler(new Request(input as string, { ...init, headers } as RequestInit));
+  };
+
+  function makeStore() {
+    return createServerFirstStore({
+      baseUrl: "http://ava.test",
+      fetch: fetchToServer,
+      persistence: new InMemoryPersistence(),
+      queuePersistence: new InMemoryMutationQueuePersistence(),
+    });
+  }
+
+  it("initial reconcile pullar server-skapade rader till den lokala store:n", async () => {
+    const m1 = uuidv7();
+    await repos.matters.create({ id: m1, organizationId: ORG, title: "Server-ärende", status: "ACTIVE", matterNumber: "2026-0200" } as never);
+
+    const ds = await makeStore(); // create() gör initial reconcile (pull)
+    expect(await ds.store.matters.findUnique({ where: { id: m1 } })).toMatchObject({ id: m1, title: "Server-ärende" });
+  });
+
+  it("lokal mutation köas och pushas server-auktoritativt vid reconcile", async () => {
+    const ds = await makeStore();
+    const m2 = uuidv7();
+    await ds.store.matters.create({ data: { id: m2, organizationId: ORG, title: "Klient-ärende", status: "ACTIVE", matterNumber: "2026-0201" } as never });
+    expect(ds.pendingCount()).toBe(1); // köad lokalt, ej synkad
+
+    await ds.reconcile();
+    expect(ds.pendingCount()).toBe(0); // pushad + ack:ad
+    expect(await repos.matters.getById(m2)).toMatchObject({ id: m2, title: "Klient-ärende" }); // server fick den
+  });
+});


### PR DESCRIPTION
## Vad

**Steg 2b** mot server-first (forts. #479, epic #403) — self-hosted-klientens **offline-first-store i server-first-läge**, som ersätter iso-git-vägen (clone/push/pull).

- **`createServerFirstStore`** (`client/backend/server-first-store.ts`): bygger en tRPC-klient (`httpBatchLink`, samma-origin oauth2-proxy-cookie) + `TrpcSyncTransport` + `CachingSyncDataStore` (IndexedDB-persistens + kö-persistens) + **initial reconcile (pull)**. Routrarna körs fortsatt **in-process** mot `.store`; löpande synk via `reconcile()` i st.f. git push/pull. Persistens/kö/`fetch` är injicerbara (testbart i node).

## Säkerhet (additiv)

**Git-default + round-trip-E2E är orörda.** Det faktiska bytet (flippa self-hosted till server-first) görs i cutover-finalen tillsammans med **#420/#421/#422** (då git-E2E:n ersätts av server-sync-E2E). Inget i den körande appen ändras — demon och git-self-hosted fungerar precis som förr.

## Verifiering

End-to-end mot den **riktiga server-handlern** (#410) + Drizzle-repos över **Postgres** (pglite + riktig PG i CI:s Repository-jobb): initial reconcile pullar server-skapade rader till den lokala store:n; en lokal mutation köas och pushas server-auktoritativt vid reconcile (`pendingCount` 1→0, servern får raden). typecheck (båda projekten, fresh), zero-warning lint, knip, deps:check, jscpd.

## Sekvens

1. ✅ #477 — db:migrate + deploy-verifiering.
2. ✅ #479 — deployerbar docker-artefakt + container-E2E.
3. ✅ **#481 — self-hosted server-first-klient-store (denna PR).**
4. Demo → IndexedDB-cache (seed-populerad).
5. #420/#421 — pensionera git/slab + gamla server-runtime.
6. #422 — flippa self-hosted-default till server-first + ersätt git-round-trip-E2E.

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)