### PR TITLE
feat(demo): kör demon på IndexedDB-cache (IndexedDbFsPersistence) i st.f. OPFS (#483)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Repository-tester mot riktig Postgres
         env:
           PG_TEST_URL: postgres://ava:ava@localhost:5433/ava_test
-        run: bun test test/unit/server/repositories/ test/unit/server/db/relations.test.ts test/unit/server/http/server-context.test.ts test/unit/server/http/server-trpc-handler.test.ts test/unit/server/sync/ test/unit/client/sync/trpc-sync-transport.test.ts test/unit/server/http/server-first-http-e2e.test.ts test/unit/server/db/server-first-deploy.test.ts
+        run: bun test test/unit/server/repositories/ test/unit/server/db/relations.test.ts test/unit/server/http/server-context.test.ts test/unit/server/http/server-trpc-handler.test.ts test/unit/server/sync/ test/unit/client/sync/trpc-sync-transport.test.ts test/unit/server/http/server-first-http-e2e.test.ts test/unit/server/db/server-first-deploy.test.ts test/unit/client/backend/server-first-store.test.ts
       - name: Tear down docker
         if: always()
         run: docker compose -f tooling/docker/docker-compose.test.yml down -v

--- a/src/app/demo/_demo-client.tsx
+++ b/src/app/demo/_demo-client.tsx
@@ -20,7 +20,7 @@ import { useEffect, useRef, useState } from "react";
 import { useDemoRuntime } from "@/lib/client/use-demo-runtime";
 import { DemoRuntime } from "@/lib/server/local-first/demo-runtime";
 import { createGhPagesCloneFn } from "@/lib/server/local-first/gh-pages-loader";
-import { OpfsPersistence } from "@/lib/server/local-first/persistence";
+import { IndexedDbFsPersistence } from "@/lib/server/local-first/indexeddb-fs-persistence";
 
 /**
  * Default demo-data-repo. Användare kan klistra in eget om de vill,
@@ -51,11 +51,11 @@ function defaultRuntimeFactory(): DemoRuntime {
   // isomorphic-git, ingen git-historik — bara filer-via-CDN. Se
   // `gh-pages-loader.ts` för detaljer. För full git-historik
   // (Tauri/Node-läget) använd `cloneFromGithub()` istället.
-  // OpfsPersistence skapas alltid — implementationen sväljer fel
-  // tyst i runtimes som inte stödjer OPFS (vissa Safari-versioner).
+  // IndexedDB-persistens (#3): slab-snapshotten cachas i IndexedDB (samma nyckel
+  // som förr) i st.f. OPFS — populerar demo-cachen utan OPFS-beroende.
   return DemoRuntime.create({
     cloneFn: createGhPagesCloneFn(),
-    persistence: new OpfsPersistence("ava-demo"),
+    persistence: new IndexedDbFsPersistence("ava-demo"),
   });
 }
 

--- a/src/components/shell/demo-bootstrap.tsx
+++ b/src/components/shell/demo-bootstrap.tsx
@@ -35,7 +35,7 @@ import { CachingSyncDataStore, noSyncTransport } from "@/lib/server/data-store/i
 import type { MutationEvent } from "@/lib/server/data-store/in-memory/writable-delegate";
 import { DemoRuntime } from "@/lib/server/local-first/demo-runtime";
 import { createGhPagesCloneFn } from "@/lib/server/local-first/gh-pages-loader";
-import { OpfsPersistence } from "@/lib/server/local-first/persistence";
+import { IndexedDbFsPersistence } from "@/lib/server/local-first/indexeddb-fs-persistence";
 import type { DemoSource } from "@/lib/shared/demo-source";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { AppShell } from "./app-shell";
@@ -311,7 +311,9 @@ function useDemoBootstrap(args: BootstrapArgs) {
 
     const runtime = DemoRuntime.create({
       cloneFn: createGhPagesCloneFn(),
-      persistence: new OpfsPersistence(demoCacheKey()),
+      // Demon persisterar slab-snapshotten i IndexedDB (#3) — "populera cachen
+      // med demo-data" — i st.f. OPFS. Survivar reload utan OPFS-beroende.
+      persistence: new IndexedDbFsPersistence(demoCacheKey()),
     });
     runtimeRef.current = runtime; // exponera slaben för writeBack (persisterad demo-skrivning)
 

--- a/src/lib/client/backend/server-first-store.ts
+++ b/src/lib/client/backend/server-first-store.ts
@@ -1,0 +1,67 @@
+/**
+ * `createServerFirstStore` (#2b, ADR 0016) — self-hosted-klientens offline-first-
+ * store i server-first-läge: en `CachingSyncDataStore` synkad mot den deployade
+ * server-first-runtimen (#479) via `TrpcSyncTransport` över HTTP, persisterad i
+ * IndexedDB. Ersätter iso-git-vägen (clone/push/pull) för self-hosted.
+ *
+ * Routrarna körs fortsatt i klienten (in-process) mot `.store`; synk sker via
+ * `reconcile()` (pull→apply→replay→advance) i st.f. git. Auth rider på
+ * oauth2-proxy:s samma-origin-cookie (ADR 0009) — `fetch` default skickar den.
+ *
+ * Additiv: detta är den server-first-väg self-hosted byter TILL. Git-default
+ * + round-trip-E2E rörs inte förrän cutovern (#420–#422) — då flippas valet.
+ */
+
+import { createTRPCClient, httpBatchLink } from "@trpc/client";
+import superjson from "superjson";
+import { TrpcSyncTransport } from "@/lib/client/sync/trpc-sync-transport";
+import { CachingSyncDataStore } from "@/lib/server/data-store/in-memory/caching-sync-data-store";
+import { IndexedDbPersistence } from "@/lib/server/data-store/in-memory/indexeddb-persistence";
+import type { LocalStorePersistence } from "@/lib/server/data-store/in-memory/local-store-persistence";
+import {
+  IndexedDbMutationQueuePersistence,
+  type MutationQueuePersistence,
+} from "@/lib/server/data-store/in-memory/mutation-queue";
+import type { AppRouter } from "@/lib/server/routers/_app";
+import { serverTrpcEndpoint } from "./http-backend-runtime";
+
+/** tRPC:s httpBatchLink-fetch-typ (icke-exporterad `FetchEsque`). */
+type LinkFetch = NonNullable<NonNullable<Parameters<typeof httpBatchLink<AppRouter>>[0]>["fetch"]>;
+export type ServerFirstFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+export interface ServerFirstStoreDeps {
+  /** Server-bas-URL. Tom (default) = samma origin (bakom nginx/oauth2-proxy). */
+  baseUrl?: string;
+  /** Source-persistens. Default IndexedDB (browser). Override i tester. */
+  persistence?: LocalStorePersistence;
+  /** Mutations-kö-persistens. Default IndexedDB. Override i tester. */
+  queuePersistence?: MutationQueuePersistence;
+  /** `fetch`-override (test/icke-standard-runtime). Default global fetch (samma-origin-cookie). */
+  fetch?: ServerFirstFetch;
+  /** Hoppa initial reconcile (pull) — för tester som kontrollerar timing. */
+  skipInitialReconcile?: boolean;
+}
+
+/**
+ * Bygg + hydrera self-hosted-klientens server-first-store och gör en initial
+ * reconcile (pull) mot servern. Returnerar `CachingSyncDataStore` — `.store` är
+ * `ctx.dataStore`, `.reconcile()` driver löpande synk.
+ */
+export async function createServerFirstStore(deps: ServerFirstStoreDeps = {}): Promise<CachingSyncDataStore> {
+  const client = createTRPCClient<AppRouter>({
+    links: [
+      httpBatchLink({
+        url: serverTrpcEndpoint(deps.baseUrl),
+        transformer: superjson,
+        ...(deps.fetch ? { fetch: deps.fetch as unknown as LinkFetch } : {}),
+      }),
+    ],
+  });
+  const cachingSync = await CachingSyncDataStore.create({
+    transport: new TrpcSyncTransport(client),
+    persistence: deps.persistence ?? new IndexedDbPersistence(),
+    queuePersistence: deps.queuePersistence ?? new IndexedDbMutationQueuePersistence(),
+  });
+  if (!deps.skipInitialReconcile) await cachingSync.reconcile();
+  return cachingSync;
+}

--- a/src/lib/server/data-store/in-memory/idb-kv.ts
+++ b/src/lib/server/data-store/in-memory/idb-kv.ts
@@ -54,4 +54,19 @@ export class IdbKv {
       db.close();
     }
   }
+
+  async delete(key: string): Promise<void> {
+    const db = await this.open();
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const tx = db.transaction(this.storeName, "readwrite");
+        tx.objectStore(this.storeName).delete(key);
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error ?? new Error("indexedDB delete misslyckades"));
+        tx.onabort = () => reject(tx.error ?? new Error("indexedDB-transaktion avbröts"));
+      });
+    } finally {
+      db.close();
+    }
+  }
 }

--- a/src/lib/server/local-first/indexeddb-fs-persistence.ts
+++ b/src/lib/server/local-first/indexeddb-fs-persistence.ts
@@ -1,0 +1,45 @@
+/**
+ * `IndexedDbFsPersistence` (#3, ADR 0016) — `IPersistence`-backend som lagrar
+ * `DemoRuntime`s MemFs-snapshot i **IndexedDB** i st.f. OPFS. Det är så
+ * GH-Pages-demon "populerar cachen med demo-data": hela slab-snapshotten (data
+ * + genererade dokument + extraherad text) persisteras till IndexedDB, så demon
+ * överlever reload utan OPFS.
+ *
+ * Återanvänder den generiska `IdbKv` (#413). `IDBFactory` injiceras (test via
+ * fake-indexeddb). dbName = demo-cache-nyckeln (versionas av
+ * NEXT_PUBLIC_DEMO_VERSION) → ny deploy bustar cachen.
+ */
+
+import { IdbKv } from "@/lib/server/data-store/in-memory/idb-kv";
+import { fsSnapshotSchema, type FsSnapshot, type IPersistence } from "./persistence";
+
+const STORE = "fs";
+const KEY = "snapshot";
+
+export class IndexedDbFsPersistence implements IPersistence {
+  private readonly kv: IdbKv;
+
+  constructor(
+    key: string,
+    factory: IDBFactory = (globalThis as unknown as { indexedDB: IDBFactory }).indexedDB,
+  ) {
+    if (!key) throw new Error(`IndexedDbFsPersistence: ogiltig key "${key}"`);
+    this.kv = new IdbKv(factory, key, STORE);
+  }
+
+  async load(): Promise<FsSnapshot | null> {
+    const raw = await this.kv.get<unknown>(KEY);
+    if (raw == null) return null;
+    // Zod vid parsegränsen (#187): validera formen innan den lämnar lagret.
+    const parsed = fsSnapshotSchema.safeParse(raw);
+    return parsed.success ? parsed.data : null;
+  }
+
+  async save(snapshot: FsSnapshot): Promise<void> {
+    await this.kv.put(KEY, snapshot);
+  }
+
+  async clear(): Promise<void> {
+    await this.kv.delete(KEY);
+  }
+}

--- a/test/unit/client/backend/server-first-store.test.ts
+++ b/test/unit/client/backend/server-first-store.test.ts
@@ -1,0 +1,76 @@
+/**
+ * `createServerFirstStore` (#2b) — self-hosted-klientens offline-first-store i
+ * server-first-läge, end-to-end mot den RIKTIGA server-handlern (#410) + Drizzle-
+ * repos över Postgres (pglite/PG via createTestDb). Bevisar att klienten pullar
+ * server-data initialt och pushar lokala mutationer vid reconcile.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
+import { createServerFirstStore } from "@/lib/client/backend/server-first-store";
+import { noopPorts } from "@/lib/server/adapters/noop-ports";
+import { InMemoryPersistence } from "@/lib/server/data-store/in-memory/local-store-persistence";
+import { InMemoryMutationQueuePersistence } from "@/lib/server/data-store/in-memory/mutation-queue";
+import { users } from "@/lib/server/db/schema";
+import { createServerTrpcHandler } from "@/lib/server/http/server-trpc-handler";
+import { createDbChangeLogRecorder, enableChangeLogOnAll } from "@/lib/server/repositories/change-log-recorder";
+import { buildDrizzleRepositories } from "@/lib/server/repositories/drizzle-repositories";
+import type { Repositories } from "@/lib/server/repositories/repositories";
+import { DrizzleSyncStore } from "@/lib/server/sync/drizzle-sync-store";
+import { uuidv7 } from "@/lib/shared/uuid";
+import { createTestDb, type TestDbHandle } from "../../server/db/pg-test-db";
+
+const ORG = uuidv7();
+
+describe("createServerFirstStore (#2b)", () => {
+  let handle: TestDbHandle;
+  let repos: Repositories;
+  let handler: (req: Request) => Promise<Response>;
+
+  beforeAll(async () => {
+    handle = await createTestDb();
+    repos = buildDrizzleRepositories(handle.db);
+    enableChangeLogOnAll(repos, createDbChangeLogRecorder(handle.db));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await handle.db.insert(users).values(
+      v({ id: uuidv7(), organizationId: ORG, email: "anna@byra.se", name: "Anna", role: "LAWYER", active: true }),
+    );
+    handler = createServerTrpcHandler({ repos, ports: noopPorts, organizationId: ORG, sync: new DrizzleSyncStore(handle.db, repos) });
+  });
+  afterAll(async () => { await handle.close(); });
+
+  /** Injicerad fetch → server-handlern, med oauth2-proxy-email (kringgår happy-dom-CORS). */
+  const fetchToServer = (input: string | URL, init?: RequestInit): Promise<Response> => {
+    const headers = new Headers(init?.headers);
+    headers.set("X-Auth-Request-Email", "anna@byra.se");
+    return handler(new Request(input as string, { ...init, headers } as RequestInit));
+  };
+
+  function makeStore() {
+    return createServerFirstStore({
+      baseUrl: "http://ava.test",
+      fetch: fetchToServer,
+      persistence: new InMemoryPersistence(),
+      queuePersistence: new InMemoryMutationQueuePersistence(),
+    });
+  }
+
+  it("initial reconcile pullar server-skapade rader till den lokala store:n", async () => {
+    const m1 = uuidv7();
+    await repos.matters.create({ id: m1, organizationId: ORG, title: "Server-ärende", status: "ACTIVE", matterNumber: "2026-0200" } as never);
+
+    const ds = await makeStore(); // create() gör initial reconcile (pull)
+    expect(await ds.store.matters.findUnique({ where: { id: m1 } })).toMatchObject({ id: m1, title: "Server-ärende" });
+  });
+
+  it("lokal mutation köas och pushas server-auktoritativt vid reconcile", async () => {
+    const ds = await makeStore();
+    const m2 = uuidv7();
+    await ds.store.matters.create({ data: { id: m2, organizationId: ORG, title: "Klient-ärende", status: "ACTIVE", matterNumber: "2026-0201" } as never });
+    expect(ds.pendingCount()).toBe(1); // köad lokalt, ej synkad
+
+    await ds.reconcile();
+    expect(ds.pendingCount()).toBe(0); // pushad + ack:ad
+    expect(await repos.matters.getById(m2)).toMatchObject({ id: m2, title: "Klient-ärende" }); // server fick den
+  });
+});

--- a/test/unit/server/local-first/indexeddb-fs-persistence.test.ts
+++ b/test/unit/server/local-first/indexeddb-fs-persistence.test.ts
@@ -1,0 +1,48 @@
+/**
+ * `IndexedDbFsPersistence` (#3) — DemoRuntime-slab-snapshot i IndexedDB (demo-
+ * cachen). Testas mot fake-indexeddb (happy-dom saknar IndexedDB). load/save/
+ * clear-round-trip + zod-validering vid parsegränsen.
+ */
+
+import { IDBFactory } from "fake-indexeddb";
+import { describe, it, expect } from "vitest-compat";
+import { IndexedDbFsPersistence } from "@/lib/server/local-first/indexeddb-fs-persistence";
+
+describe("IndexedDbFsPersistence", () => {
+  it("load på tom DB → null", async () => {
+    const p = new IndexedDbFsPersistence("ava-fs-empty", new IDBFactory());
+    expect(await p.load()).toBeNull();
+  });
+
+  it("save → load round-trippar slab-snapshotten (path → base64)", async () => {
+    const p = new IndexedDbFsPersistence("ava-fs-roundtrip", new IDBFactory());
+    const snap = { "matters/m1.json": "eyJpZCI6Im0xIn0=", "documents/content/d1.pdf": "JVBERi0=" };
+    await p.save(snap);
+    expect(await p.load()).toEqual(snap);
+  });
+
+  it("save skriver över; clear nollställer → load null", async () => {
+    const p = new IndexedDbFsPersistence("ava-fs-clear", new IDBFactory());
+    await p.save({ "a.json": "x" });
+    await p.save({ "b.json": "y" });
+    expect(await p.load()).toEqual({ "b.json": "y" });
+    await p.clear();
+    expect(await p.load()).toBeNull();
+  });
+
+  it("ogiltig snapshot-form (zod) → null (tolerant cache-fallback)", async () => {
+    const factory = new IDBFactory();
+    const p = new IndexedDbFsPersistence("ava-fs-bad", factory);
+    // Skriv en icke-Record<string,string> direkt via en andra instans/raw put.
+    await p.save({ ok: "1" });
+    // Sabotera: en ny instans som lagrar fel form under samma nyckel.
+    const bad = new IndexedDbFsPersistence("ava-fs-bad", factory);
+    // @ts-expect-error — medvetet fel form för parse-gränstest
+    await bad.save({ n: 123 });
+    expect(await p.load()).toBeNull();
+  });
+
+  it("tom key → kastar", () => {
+    expect(() => new IndexedDbFsPersistence("", new IDBFactory())).toThrow();
+  });
+});


### PR DESCRIPTION
## Vad

**Steg 3** mot server-first (forts. #481, epic #403) — din "**populera cachen med demo-data**": GH-Pages-demons slab-snapshot persisteras nu i **IndexedDB** i st.f. OPFS, så demon kör på en IndexedDB-cache utan OPFS-beroende (steg mot att pensionera OPFS, #420).

- **`IndexedDbFsPersistence`** (`local-first/indexeddb-fs-persistence.ts`): `IPersistence`-backend för `DemoRuntime`-slab-snapshotten, byggd på den generiska `IdbKv` (+ ny `IdbKv.delete`). Zod-validering vid parsegränsen; `dbName` = demo-cache-nyckeln (versionas av `NEXT_PUBLIC_DEMO_VERSION`).
- **demo-bootstrap + /demo-route** (`_demo-client`): `OpfsPersistence` → `IndexedDbFsPersistence` med **samma cache-nycklar** → oförändrad cache-semantik, bara IDB-backend. Live-läsningar är orörda (slaben är ren persistens; reads går via `source`/store).

Surgiskt: bara persistens-backenden byts (samma `IPersistence`-kontrakt). DemoRuntime/MemFs/loading/dokument/text oförändrade.

## Verifiering (demo = guardrail, lokal validering)

- ✅ `build:demo` grön (97 HTML, 502 entiteter).
- ✅ **`demo-invoice-document` E2E grön** mot lokalt serverad demo (`demo:serve` nginx) — full flow: login → ärende → kostnadsräkning → faktura → **dokument öppnas** (genererad-dok-persistens via den nu IDB-backade slaben).
- ✅ **A/B-bevis**: `demo-smoke` har **samma 9 fel / 14 pass på BÅDE OPFS och IndexedDB** → de 9 är pre-existerande (lokal-serve-begränsning; demo-smoke är gjord för LIVE-demon), **ej** en regression från swappen. Swappen är beteende-neutral.
- ✅ Enhetstest för `IndexedDbFsPersistence` (fake-indexeddb: load/save/clear + zod). typecheck (båda projekten, fresh), zero-warning lint, knip, deps:check, jscpd, test:fast (3258).

## Sekvens

1. ✅ #477 db:migrate + deploy-verifiering · 2. ✅ #479 docker-artefakt · 3. ✅ #481 self-hosted-klient-store · 4. ✅ **#483 demo → IndexedDB-cache (denna PR)**
5. #420/#421 — pensionera OPFS/iso-git/slab-rester + gamla server-runtime
6. #422 — flippa self-hosted-default + ersätt git-round-trip-E2E

## Not

OPFS är nu borttaget ur demo-vägen. `OpfsPersistence` finns kvar (test-täckt) tills #420 städar; MemFs/DemoRuntime kvarstår (transient fetch + dokument/text) och pensioneras i #420.

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)