### PR TITLE
fix(demo): degradera tyst när IndexedDB är blockerat (IndexedDbFsPersistence) (#485)

### DIFF
--- a/src/lib/server/local-first/indexeddb-fs-persistence.ts
+++ b/src/lib/server/local-first/indexeddb-fs-persistence.ts
@@ -8,6 +8,11 @@
  * Återanvänder den generiska `IdbKv` (#413). `IDBFactory` injiceras (test via
  * fake-indexeddb). dbName = demo-cache-nyckeln (versionas av
  * NEXT_PUBLIC_DEMO_VERSION) → ny deploy bustar cachen.
+ *
+ * **Best-effort (som OpfsPersistence):** om IndexedDB är blockerat (privat läge,
+ * strikt spårningsskydd) markeras instansen oanvändbar vid första felet och
+ * alla vidare anrop blir tysta no-ops — demon kör vidare i minnesläge i st.f.
+ * att krascha bootstrappen (`DemoRuntime.persist()` kastar annars vidare).
  */
 
 import { IdbKv } from "@/lib/server/data-store/in-memory/idb-kv";
@@ -18,6 +23,8 @@ const KEY = "snapshot";
 
 export class IndexedDbFsPersistence implements IPersistence {
   private readonly kv: IdbKv;
+  /** Sätts vid första IndexedDB-felet → vidare anrop no-op:ar (best-effort-cache). */
+  private unusable = false;
 
   constructor(
     key: string,
@@ -28,18 +35,45 @@ export class IndexedDbFsPersistence implements IPersistence {
   }
 
   async load(): Promise<FsSnapshot | null> {
-    const raw = await this.kv.get<unknown>(KEY);
-    if (raw == null) return null;
-    // Zod vid parsegränsen (#187): validera formen innan den lämnar lagret.
-    const parsed = fsSnapshotSchema.safeParse(raw);
-    return parsed.success ? parsed.data : null;
+    if (this.unusable) return null;
+    try {
+      const raw = await this.kv.get<unknown>(KEY);
+      if (raw == null) return null;
+      // Zod vid parsegränsen (#187): validera formen innan den lämnar lagret.
+      const parsed = fsSnapshotSchema.safeParse(raw);
+      return parsed.success ? parsed.data : null;
+    } catch (err) {
+      this.markUnusable(err);
+      return null;
+    }
   }
 
   async save(snapshot: FsSnapshot): Promise<void> {
-    await this.kv.put(KEY, snapshot);
+    if (this.unusable) return;
+    try {
+      await this.kv.put(KEY, snapshot);
+    } catch (err) {
+      this.markUnusable(err);
+    }
   }
 
   async clear(): Promise<void> {
-    await this.kv.delete(KEY);
+    if (this.unusable) return;
+    try {
+      await this.kv.delete(KEY);
+    } catch (err) {
+      this.markUnusable(err);
+    }
+  }
+
+  /** Logga EN gång och no-op:a vidare — IndexedDB blockerat är väntat degraderat
+   *  läge, inte ett appfel (demon kör vidare i minnesläge). */
+  private markUnusable(_err: unknown): void {
+    if (this.unusable) return;
+    this.unusable = true;
+    console.info(
+      "[IndexedDbFsPersistence] IndexedDB ej tillgängligt — fortsätter i minnesläge " +
+        "(ändringar sparas inte över omladdning).",
+    );
   }
 }

--- a/test/unit/server/local-first/indexeddb-fs-persistence.test.ts
+++ b/test/unit/server/local-first/indexeddb-fs-persistence.test.ts
@@ -45,4 +45,14 @@ describe("IndexedDbFsPersistence", () => {
   it("tom key → kastar", () => {
     expect(() => new IndexedDbFsPersistence("", new IDBFactory())).toThrow();
   });
+
+  it("IndexedDB blockerat → best-effort no-op (kastar ej; load → null)", async () => {
+    // IDBFactory vars open() kastar (t.ex. privat läge / blockerad storage).
+    const blocked = { open: () => { throw new Error("IndexedDB blocked"); } } as unknown as IDBFactory;
+    const p = new IndexedDbFsPersistence("ava-fs-blocked", blocked);
+    // Inga av dessa får kasta — demon ska köra vidare i minnesläge.
+    await expect(p.save({ "a.json": "x" })).resolves.toBeUndefined();
+    await expect(p.load()).resolves.toBeNull();
+    await expect(p.clear()).resolves.toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Vad

Forts. **#483** (demo → IndexedDB-cache). `OpfsPersistence` degraderade **tyst** när OPFS var blockerat (privat läge / strikt spårningsskydd) — best-effort-cache. `IndexedDbFsPersistence` saknade det: vid blockerad IndexedDB **kastade `save()`**, och `DemoRuntime.persist()` (utan egen try/catch) propagerade felet → demo-bootstrappen visade **fel-skärm** i st.f. att köra vidare i minnesläge. Det var en regression mot OPFS-beteendet.

## Fix

`IndexedDbFsPersistence` markerar sig oanvändbar vid första IndexedDB-felet → `load` → `null`, `save`/`clear` → no-op (en `console.info`), exakt som `OpfsPersistence`. Demon kör vidare utan persistens om IndexedDB är blockerat (ändringar sparas bara inte över omladdning).

## Test

Ny testfall med en kastande `IDBFactory` (simulerar blockerad IndexedDB): ingen av `load`/`save`/`clear` kastar; `load` → `null`. Övriga round-trip-tester oförändrat gröna. typecheck (båda projekten, fresh), zero-warning lint, knip, deps:check, jscpd.

Skyddar demo-guardrailen i webbläsare/lägen där IndexedDB är otillgängligt.

Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)