### PR TITLE
refactor(demo): ta bort död OpfsPersistence (slice av #420) (#488)

### DIFF
--- a/src/lib/server/local-first/demo-runtime.ts
+++ b/src/lib/server/local-first/demo-runtime.ts
@@ -25,8 +25,8 @@
  * Designval (DI):
  *   - `cloneFn` injiceras — produktion använder en wrapper kring
  *     `isomorphic-git.clone`; tester använder en fake.
- *   - `persistence` injiceras — OpfsPersistence i browser, InMemory
- *     i tester, eller utelämnas helt.
+ *   - `persistence` injiceras — IndexedDbFsPersistence i browser (#483),
+ *     InMemory i tester, eller utelämnas helt.
  */
 
 import { DemoLoader, type DemoCloneFn, type LoadResult } from "./demo-loader";

--- a/src/lib/server/local-first/persistence.ts
+++ b/src/lib/server/local-first/persistence.ts
@@ -9,14 +9,16 @@
  *
  * Implementationer:
  *   - `InMemoryPersistence`: bara minne. För tester och fallback.
- *   - `OpfsPersistence`: Origin Private File System i browser. Survivar
- *     page-reload, är persistent per origin, kvotgräns ~quotaSize.
- *   - (Framtid) `IndexedDBPersistence` om vi behöver bredare browser-stöd.
+ *   - `IndexedDbFsPersistence` (`indexeddb-fs-persistence.ts`): browser-cachen
+ *     (demon, #3). Survivar page-reload, best-effort (no-op om IndexedDB blockerat).
+ *
+ * (`OpfsPersistence` togs bort i #420 — demon kör på IndexedDB sedan #483 och
+ *  ingen kod använde OPFS-backenden längre.)
  */
 
 import { z } from "zod";
 
-// Zod vid parsegränsen (#187): snapshotten läses från OPFS — validera formen.
+// Zod vid parsegränsen (#187): snapshotten läses från cache — validera formen.
 export const fsSnapshotSchema = z.record(z.string(), z.string());
 export type FsSnapshot = z.infer<typeof fsSnapshotSchema>;
 
@@ -44,156 +46,5 @@ export class InMemoryPersistence implements IPersistence {
 
   async clear(): Promise<void> {
     this.snapshot = null;
-  }
-}
-
-// ─── OpfsPersistence ──────────────────────────────────────────────
-
-interface OpfsDirHandle {
-  getFileHandle(name: string, options?: { create?: boolean }): Promise<OpfsFileHandle>;
-  removeEntry(name: string): Promise<void>;
-}
-
-interface OpfsFileHandle {
-  getFile(): Promise<{ text(): Promise<string> }>;
-  createWritable(): Promise<{ write(content: string): Promise<void>; close(): Promise<void> }>;
-}
-
-interface NavigatorWithStorage {
-  storage?: { getDirectory(): Promise<OpfsDirHandle> };
-}
-
-const FILE_NAME = "snapshot.json";
-
-/**
- * `OpfsPersistence` — sparar snapshot till en JSON-fil i Origin Private
- * File System. Varje key (typiskt en GitHub-URL eller demo-id) får sin
- * egen sub-katalog så att flera demos inte krockar.
- */
-export class OpfsPersistence implements IPersistence {
-  /**
-   * Sätts till true första gången OPFS visar sig oanvändbart. Vissa
-   * webbläsare (t.ex. Firefox med blockerad/raderad site-data eller strikt
-   * spårningsskydd) exponerar `navigator.storage.getDirectory` men kastar
-   * `SecurityError` när den anropas. Efter det första felet blir alla
-   * vidare anrop tysta no-ops — en best-effort-cache ska aldrig spamma
-   * konsolloggen (och därmed felrapporten) med upprepade varningar.
-   */
-  private unusable = false;
-
-  constructor(private readonly key: string) {
-    if (!key || /[/\\]/.test(key)) {
-      throw new Error(`OpfsPersistence: ogiltig key "${key}"`);
-    }
-  }
-
-  /**
-   * Kolla om aktuell runtime *faktiskt* stödjer OPFS. Det räcker inte att
-   * `getDirectory` finns — den måste gå att anropa utan att kasta (Firefox
-   * kastar SecurityError när site-data är blockerad). Vi probar därför på
-   * riktigt istället för att bara typkolla funktionen.
-   */
-  static async isSupported(): Promise<boolean> {
-    const nav = (globalThis as { navigator?: NavigatorWithStorage }).navigator;
-    if (typeof nav?.storage?.getDirectory !== "function") return false;
-    try {
-      await nav.storage.getDirectory();
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  async load(): Promise<FsSnapshot | null> {
-    if (this.unusable) return null;
-    try {
-      const dir = await this.getKeyDir();
-      const file = await dir.getFileHandle(FILE_NAME);
-      const content = await (await file.getFile()).text();
-      const parsed = fsSnapshotSchema.safeParse(JSON.parse(content));
-      return parsed.success ? parsed.data : null;
-    } catch (err) {
-      // Filen finns inte, OPFS stödjs inte, eller JSON kunde inte parsas.
-      // För en cache är "ingen data" rätt fallback. Om felet beror på att
-      // OPFS är otillgängligt markeras instansen så vidare anrop no-op:ar.
-      this.markUnusableIfOpfsBlocked(err);
-      return null;
-    }
-  }
-
-  async save(snapshot: FsSnapshot): Promise<void> {
-    if (this.unusable) return;
-    try {
-      const dir = await this.getKeyDir();
-      const file = await dir.getFileHandle(FILE_NAME, { create: true });
-      const writable = await file.createWritable();
-      await writable.write(JSON.stringify(snapshot));
-      await writable.close();
-    } catch (err) {
-      // Persistens är best-effort. Om OPFS inte fungerar ska appen
-      // ändå funka — bara utan offline-cache.
-      this.markUnusableIfOpfsBlocked(err);
-    }
-  }
-
-  async clear(): Promise<void> {
-    if (this.unusable) return;
-    try {
-      const dir = await this.getKeyDir();
-      await dir.removeEntry(FILE_NAME);
-    } catch {
-      // Ingen att rensa — OK.
-    }
-  }
-
-  // ── private ───────────────────────────────────────────────────
-
-  /**
-   * Avgör om felet betyder att OPFS är otillgängligt (snarare än "filen
-   * fanns inte"). I så fall: logga EN gång och markera instansen som
-   * oanvändbar så att efterföljande save/load/clear blir tysta no-ops.
-   *
-   * Heuristik: SecurityError eller "OPFS stöds inte"-felet från getKeyDir
-   * betyder blockerad/saknad OPFS. Andra fel (t.ex. en saknad fil) lämnar
-   * cachen aktiv — det är ett normalt "ingen data ännu"-utfall.
-   */
-  private markUnusableIfOpfsBlocked(err: unknown): void {
-    if (this.unusable) return;
-    const name = (err as { name?: string })?.name;
-    const isBlocked =
-      name === "SecurityError" ||
-      (err instanceof Error && err.message.includes("OPFS stöds inte"));
-    if (!isBlocked) return;
-    this.unusable = true;
-    // Informativ, en gång: detta är ett väntat degraderat läge, inte ett
-    // appfel. Demon kör vidare i minnesläge (ändringar sparas ej över reload).
-    console.info(
-      "[OpfsPersistence] OPFS ej tillgängligt i denna webbläsare/läge — " +
-        "fortsätter i minnesläge (ändringar sparas inte över omladdning).",
-    );
-  }
-
-  private async getKeyDir(): Promise<OpfsDirHandle> {
-    const nav = (globalThis as { navigator?: NavigatorWithStorage }).navigator;
-    if (!nav?.storage?.getDirectory) {
-      throw new Error("OPFS stöds inte i denna runtime");
-    }
-    const root = await nav.storage.getDirectory();
-    // Vissa OPFS-impl stödjer create:true på getDirectoryHandle. Vi
-    // skapar bara en fil per key med key-prefix istället för en under-mapp
-    // — det funkar i alla OPFS-impl och är tillräckligt för cache.
-    return {
-      async getFileHandle(name: string, options?: { create?: boolean }) {
-        return root.getFileHandle(`${this.keyPrefix}__${name}`, options);
-      },
-      async removeEntry(name: string) {
-        return root.removeEntry(`${this.keyPrefix}__${name}`);
-      },
-      keyPrefix: this.sanitizeKey(this.key),
-    } as OpfsDirHandle & { keyPrefix: string };
-  }
-
-  private sanitizeKey(key: string): string {
-    return key.replace(/[^a-zA-Z0-9._-]/g, "_");
   }
 }

--- a/test/unit/server/local-first/persistence.test.ts
+++ b/test/unit/server/local-first/persistence.test.ts
@@ -1,22 +1,12 @@
 /**
  * Tester för `IPersistence`-implementationer.
  *
- * Vi testar:
- *   - `InMemoryPersistence` (för enhet-tester av högre lager)
- *   - `OpfsPersistence` (browser-runtime — testas mot en mockad OPFS-API
- *     i jsdom)
- *
- * Designval: en gemensam test-svit körs mot bägge backends så de
- * uppfyller Liskov-substitutionsprincipen. Skiljnaden mellan dem är
- * bara var datat hamnar.
+ * `InMemoryPersistence` (tester/fallback). `OpfsPersistence` togs bort i #420
+ * (demon kör på IndexedDB sedan #483 — se `indexeddb-fs-persistence.test.ts`).
  */
 
-import { describe, it, expect, beforeEach, vi } from "vitest-compat";
-import {
-  InMemoryPersistence,
-  OpfsPersistence,
-  type IPersistence,
-} from "@/lib/server/local-first/persistence";
+import { describe, it, expect, beforeEach } from "vitest-compat";
+import { InMemoryPersistence, type IPersistence } from "@/lib/server/local-first/persistence";
 
 function contractTests(name: string, factory: () => Promise<IPersistence>) {
   describe(name, () => {
@@ -47,121 +37,3 @@ function contractTests(name: string, factory: () => Promise<IPersistence>) {
 }
 
 contractTests("InMemoryPersistence", async () => new InMemoryPersistence());
-
-describe("OpfsPersistence (browser-mock)", () => {
-  // Mocka navigator.storage.getDirectory + FileSystemDirectoryHandle/FileHandle
-  beforeEach(() => {
-    const fileMap = new Map<string, string>();
-
-    const fileHandle = (name: string) => ({
-      async getFile() {
-        const content = fileMap.get(name);
-        if (content === undefined) throw new Error("not found");
-        return {
-          async text() { return content; },
-        };
-      },
-      async createWritable() {
-        return {
-          async write(text: string) { fileMap.set(name, text); },
-          async close() {},
-        };
-      },
-    });
-
-    const dirHandle = {
-      async getFileHandle(name: string, opts?: { create?: boolean }) {
-        if (!fileMap.has(name) && !opts?.create) throw new Error("ENOENT");
-        return fileHandle(name);
-      },
-      async removeEntry(name: string) {
-        if (!fileMap.has(name)) throw new Error("ENOENT");
-        fileMap.delete(name);
-      },
-    };
-
-    vi.stubGlobal("navigator", {
-      storage: { getDirectory: async () => dirHandle },
-    });
-    (globalThis as { __opfsMockStore?: Map<string, string> }).__opfsMockStore = fileMap;
-  });
-
-  it("är inte stödd när navigator.storage saknas", async () => {
-    vi.stubGlobal("navigator", undefined);
-    expect(await OpfsPersistence.isSupported()).toBe(false);
-  });
-
-  it("är stödd när navigator.storage.getDirectory finns", async () => {
-    expect(await OpfsPersistence.isSupported()).toBe(true);
-  });
-
-  it("är INTE stödd när getDirectory finns men kastar (Firefox SecurityError)", async () => {
-    (globalThis as { navigator?: { storage: { getDirectory: () => unknown } } }).navigator!.storage.getDirectory =
-      () => { throw new DOMException("Security error when calling GetDirectory", "SecurityError"); };
-    expect(await OpfsPersistence.isSupported()).toBe(false);
-  });
-
-  it("SecurityError → save blir tyst no-op och loggar EN gång (ingen spam)", async () => {
-    const p = new OpfsPersistence("ava-demo");
-    (globalThis as { navigator?: { storage: { getDirectory: () => unknown } } }).navigator!.storage.getDirectory =
-      () => { throw new DOMException("Security error when calling GetDirectory", "SecurityError"); };
-    const info = vi.spyOn(console, "info").mockImplementation(() => {});
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    await p.save({ "x": "y" });
-    await p.save({ "x": "z" });
-    await p.save({ "x": "w" });
-    // Exakt en informativ rad totalt, aldrig console.warn.
-    expect(info).toHaveBeenCalledTimes(1);
-    expect(warn).not.toHaveBeenCalled();
-    info.mockRestore();
-    warn.mockRestore();
-  });
-
-  it("efter SecurityError blir load tyst no-op (returnerar null utan att kasta)", async () => {
-    const p = new OpfsPersistence("ava-demo");
-    (globalThis as { navigator?: { storage: { getDirectory: () => unknown } } }).navigator!.storage.getDirectory =
-      () => { throw new DOMException("blocked", "SecurityError"); };
-    const info = vi.spyOn(console, "info").mockImplementation(() => {});
-    expect(await p.load()).toBeNull();
-    expect(await p.load()).toBeNull();
-    expect(info).toHaveBeenCalledTimes(1); // markerad oanvändbar vid första anropet
-    info.mockRestore();
-  });
-
-  it("save → load round-trip via OPFS", async () => {
-    const p = new OpfsPersistence("ava-demo");
-    await p.save({ "matters/active/m1.json": "ewogICJpZCI6ICJtMSIKfQ==" });
-    expect(await p.load()).toEqual({ "matters/active/m1.json": "ewogICJpZCI6ICJtMSIKfQ==" });
-  });
-
-  it("clear gör att load returnerar null", async () => {
-    const p = new OpfsPersistence("ava-demo");
-    await p.save({ "x": "y" });
-    await p.clear();
-    expect(await p.load()).toBeNull();
-  });
-
-  it("isolerat per key (olika instanser delar inte data)", async () => {
-    const a = new OpfsPersistence("demo-a");
-    const b = new OpfsPersistence("demo-b");
-    await a.save({ "f": "AAAA" });
-    await b.save({ "f": "BBBB" });
-    expect((await a.load())!.f).toBe("AAAA");
-    expect((await b.load())!.f).toBe("BBBB");
-  });
-
-  it("load returnerar null vid OPFS-fel istället för att kasta", async () => {
-    const p = new OpfsPersistence("ava-demo");
-    // Sabotera getDirectory så det kastar
-    (globalThis as { navigator?: { storage: { getDirectory: () => unknown } } }).navigator!.storage.getDirectory = () => { throw new Error("OPFS nere"); };
-    expect(await p.load()).toBeNull();
-  });
-
-  it("save sväljer fel tyst (för icke-kritisk cache)", async () => {
-    const p = new OpfsPersistence("ava-demo");
-    (globalThis as { navigator?: { storage: { getDirectory: () => unknown } } }).navigator!.storage.getDirectory = () => { throw new Error("OPFS nere"); };
-    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    await expect(p.save({ "x": "y" })).resolves.toBeUndefined();
-    spy.mockRestore();
-  });
-});


### PR DESCRIPTION
## Vad

Slice av **#420** (pensionera OPFS). Sedan **#483** (demo → IndexedDB-cache) använder **ingen kod** `OpfsPersistence`: demon + `/demo`-routen kör `IndexedDbFsPersistence`, och self-hosted använder OPFS via FSA/`handle-store` (inte denna `IPersistence`-backend). `OpfsPersistence` var bara test-täckt → död kod.

- Ta bort `OpfsPersistence`-klassen + dess OPFS-interfaces/`FILE_NAME` ur `persistence.ts` (`IPersistence`/`FsSnapshot`/`InMemoryPersistence` kvar).
- Trimma `persistence.test.ts` (OpfsPersistence-sviten bort; `InMemoryPersistence`-kontraktstestet kvar).
- Uppdatera stale doc-kommentar i `demo-runtime.ts`.

## Not

Detta är bara den **döda** OPFS-backenden. #420 i övrigt — iso-git, MemFs-slab, och self-hosteds OPFS-working-copy — kräver self-hosted-cutovern (finalen) och kvarstår. `Refs #420`.

## Verifiering

Inga konsumenter (grep: bara doc-kommentarer). typecheck (båda projekten, fresh), zero-warning lint, knip (inga oanvända), deps:check, jscpd, `test:fast` (3250) — alla gröna.

Closes #488