### PR TITLE
test(documents): täck ExternalEditIndicator, höj coverage-golv

### DIFF
--- a/test/unit/components/external-edit-indicator.test.tsx
+++ b/test/unit/components/external-edit-indicator.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * Tester för `ExternalEditIndicator` (#27 coverage) — shell-bannern som visar
+ * väntande externa edit-sessions och låter användaren trigga commit ("Spara
+ * nu"). `ExternalEditTracker` mockas; komponenten pollar var 1000 ms via
+ * setInterval → vi använder fake timers + `act` för att flusha poll-ticken.
+ */
+
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest-compat";
+import { ExternalEditIndicator } from "@/components/documents/external-edit-indicator";
+import type { EditSession } from "@/lib/client/fsa/external-edit-tracker";
+
+const flushNowMock = vi.fn(async () => {});
+let tracker: { listSessions: () => EditSession[]; flushNow: (id: string) => Promise<void> } | null;
+
+vi.mock("@/lib/client/fsa/external-edit-tracker", () => ({
+  getExternalEditTracker: () => tracker,
+}));
+
+/** Rendera + flusha en poll-tick (intervallet läser trackern var 1000 ms). */
+async function renderAndPoll(): Promise<void> {
+  render(<ExternalEditIndicator />);
+  await act(async () => {
+    vi.advanceTimersByTime(1000);
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  flushNowMock.mockClear();
+  tracker = { listSessions: () => [], flushNow: flushNowMock };
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("ExternalEditIndicator", () => {
+  it("inga väntande sessions → renderar inget", async () => {
+    await renderAndPoll();
+    expect(screen.queryByText(/Externa ändringar väntar/)).not.toBeInTheDocument();
+  });
+
+  it("trackern saknas (null) → tål det och renderar inget", async () => {
+    tracker = null;
+    await renderAndPoll();
+    expect(screen.queryByText(/Externa ändringar väntar/)).not.toBeInTheDocument();
+  });
+
+  it("visar filnamn (sista path-segmentet) + sparningar i plural", async () => {
+    tracker = {
+      listSessions: () => [{ docId: "d1", path: "matters/abc/avtal.docx", saves: 3, startedAt: 1000 }],
+      flushNow: flushNowMock,
+    };
+    await renderAndPoll();
+    expect(screen.getByText(/Externa ändringar väntar/)).toBeInTheDocument();
+    expect(screen.getByText("avtal.docx")).toBeInTheDocument();
+    expect(screen.getByText(/\(3 sparningar\)/)).toBeInTheDocument();
+  });
+
+  it("en sparning → singularformen 'sparning'", async () => {
+    tracker = {
+      listSessions: () => [{ docId: "d1", path: "x/y/fil.txt", saves: 1, startedAt: 1000 }],
+      flushNow: flushNowMock,
+    };
+    await renderAndPoll();
+    expect(screen.getByText(/\(1 sparning\)/)).toBeInTheDocument();
+    expect(screen.queryByText(/\(1 sparningar\)/)).not.toBeInTheDocument();
+  });
+
+  it("flera sessions → en rad per dokument", async () => {
+    tracker = {
+      listSessions: () => [
+        { docId: "d1", path: "a/one.docx", saves: 2, startedAt: 1000 },
+        { docId: "d2", path: "b/two.pdf", saves: 5, startedAt: 2000 },
+      ],
+      flushNow: flushNowMock,
+    };
+    await renderAndPoll();
+    expect(screen.getByText("one.docx")).toBeInTheDocument();
+    expect(screen.getByText("two.pdf")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: /Spara nu/ })).toHaveLength(2);
+  });
+
+  it("'Spara nu' kallar tracker.flushNow med rätt docId", async () => {
+    tracker = {
+      listSessions: () => [{ docId: "doc-42", path: "p/akt.docx", saves: 1, startedAt: 1000 }],
+      flushNow: flushNowMock,
+    };
+    await renderAndPoll();
+    fireEvent.click(screen.getByRole("button", { name: /Spara nu/ }));
+    expect(flushNowMock).toHaveBeenCalledWith("doc-42");
+  });
+});

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -44,9 +44,11 @@ const FAST = process.argv.includes("--fast");
 // golvet låses just under, ~0.5% rad-marginal / ~1.5% funktions-marginal för
 // Node-version-varians) → 87.9 rader / 83.2 funktioner (#27: äkta
 // WebCrypto-/IndexedDB-tester för ed25519-keypair lyfte lokalt till 88.38%
-// rader / 84.89% funktioner; samma marginal-konvention behålls).
-const LINE_FLOOR = 0.879;
-const FUNC_FLOOR = 0.832;
+// rader / 84.89% funktioner; samma marginal-konvention behålls) → 88.0 rader /
+// 83.4 funktioner (#27: smtp-sender + ExternalEditIndicator-tester lyfte lokalt
+// till 88.46% rader / 84.97% funktioner; samma ~0.5%/~1.5%-marginal).
+const LINE_FLOOR = 0.88;
+const FUNC_FLOOR = 0.834;
 
 /**
  * SERIAL_FILES — testfiler som SYNKRONT spawnar en barnprocess via


### PR DESCRIPTION
## Vad

`#27`-ratchet-steg. `ExternalEditIndicator` (shell-bannern som visar väntande
externa edit-sessions och låter användaren trigga commit manuellt) saknade
direkt test.

## Test (`test/unit/components/external-edit-indicator.test.tsx`)

`ExternalEditTracker` mockas; komponenten pollar var 1000 ms via `setInterval`,
så fake timers + `act` flushar poll-ticken. Låser fast:

- inga sessions → renderar `null`
- tracker saknas (`null`) → tål det, renderar `null`
- filnamn = sista path-segmentet; sparningar i singular/plural
  (`sparning`/`sparningar`)
- flera sessions → en rad + en "Spara nu"-knapp per dokument
- "Spara nu" → `tracker.flushNow(docId)` med rätt id

## Ratchet

Lokalt **88.46 % rader / 84.97 % funktioner** → golvet höjs `0.879 → 0.880`
(rader) och `0.832 → 0.834` (funktioner), samma ~0.5 %/~1.5 % marginal.

## Verifierat lokalt

`quality:fast`, `test:cov` (grön mot nya golv), `knip`, `deps:check`,
`duplicates` — alla gröna.

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)