### PR TITLE
test(fsa): täck handle-store IndexedDB-persistens, höj func-golv

### DIFF
--- a/test/unit/lib/fsa/handle-store.test.ts
+++ b/test/unit/lib/fsa/handle-store.test.ts
@@ -1,11 +1,12 @@
 /**
  * Tester för handle-store: permission-handling + FSA/OPFS-detektering +
- * getOpfsRoot. IndexedDB-paths (saveHandle/loadHandle/deleteHandle) testas
- * inte i unit-suiten — de kräver en full IDB-implementation (fake-indexeddb
- * eller jsdom-fork). Täcks via e2e/round-trip-suiten istället.
+ * getOpfsRoot + IndexedDB-persistensen (saveHandle/loadHandle/deleteHandle)
+ * mot fake-indexeddb (happy-dom saknar IndexedDB → vi stoppar in en IDBFactory
+ * som global `indexedDB`; --isolate håller mutationen i denna fil).
  */
 
-import { afterEach, describe, expect, it, vi } from "vitest-compat";
+import { IDBFactory } from "fake-indexeddb";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest-compat";
 
 describe("ensureReadWrite", () => {
   it("OPFS-handle (saknar query/requestPermission) → alltid granted", async () => {
@@ -99,5 +100,64 @@ describe("getOpfsRoot", () => {
     });
     const { getOpfsRoot } = await import("@/lib/client/fsa/handle-store");
     expect(await getOpfsRoot("working-copy")).toBe(subdirHandle);
+  });
+});
+
+describe("IndexedDB-persistens (saveHandle / loadHandle / deleteHandle)", () => {
+  let prevIndexedDb: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    prevIndexedDb = Object.getOwnPropertyDescriptor(globalThis, "indexedDB");
+    // Färsk in-memory-IDB per test → ingen läckning mellan testfall.
+    Object.defineProperty(globalThis, "indexedDB", {
+      value: new IDBFactory(),
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    if (prevIndexedDb) Object.defineProperty(globalThis, "indexedDB", prevIndexedDb);
+    else delete (globalThis as { indexedDB?: unknown }).indexedDB;
+  });
+
+  // FSA-handles serialiseras via structured clone i IndexedDB; en vanlig
+  // plain-object-stub räcker som fixtur (fake-indexeddb klonar den).
+  const fakeHandle = (name: string) =>
+    ({ name, kind: "directory" }) as unknown as FileSystemDirectoryHandle;
+
+  it("loadHandle på okänd nyckel → null", async () => {
+    const { loadHandle } = await import("@/lib/client/fsa/handle-store");
+    expect(await loadHandle("repo-root")).toBeNull();
+  });
+
+  it("saveHandle → loadHandle round-trippar handle:n (per nyckel)", async () => {
+    const { saveHandle, loadHandle } = await import("@/lib/client/fsa/handle-store");
+    await saveHandle("repo-root", fakeHandle("wc"));
+    const loaded = await loadHandle("repo-root");
+    expect(loaded).toMatchObject({ name: "wc", kind: "directory" });
+    // Annan nyckel är orörd.
+    expect(await loadHandle("other")).toBeNull();
+  });
+
+  it("saveHandle skriver över samma nyckel", async () => {
+    const { saveHandle, loadHandle } = await import("@/lib/client/fsa/handle-store");
+    await saveHandle("k", fakeHandle("first"));
+    await saveHandle("k", fakeHandle("second"));
+    expect(await loadHandle("k")).toMatchObject({ name: "second" });
+  });
+
+  it("deleteHandle tömmer nyckeln → loadHandle null igen", async () => {
+    const { saveHandle, loadHandle, deleteHandle } = await import("@/lib/client/fsa/handle-store");
+    await saveHandle("k", fakeHandle("wc"));
+    expect(await loadHandle("k")).not.toBeNull();
+    await deleteHandle("k");
+    expect(await loadHandle("k")).toBeNull();
+  });
+
+  it("loadHandle utan IndexedDB i miljön → null (SSR/privat flik-fallback)", async () => {
+    delete (globalThis as { indexedDB?: unknown }).indexedDB;
+    const { loadHandle } = await import("@/lib/client/fsa/handle-store");
+    expect(await loadHandle("repo-root")).toBeNull();
   });
 });

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -46,9 +46,12 @@ const FAST = process.argv.includes("--fast");
 // WebCrypto-/IndexedDB-tester för ed25519-keypair lyfte lokalt till 88.38%
 // rader / 84.89% funktioner; samma marginal-konvention behålls) → 88.0 rader /
 // 83.4 funktioner (#27: smtp-sender + ExternalEditIndicator-tester lyfte lokalt
-// till 88.46% rader / 84.97% funktioner; samma ~0.5%/~1.5%-marginal).
+// till 88.46% rader / 84.97% funktioner; samma ~0.5%/~1.5%-marginal) → 88.0
+// rader / 83.5 funktioner (#27: handle-store IndexedDB-persistens mot fake-
+// indexeddb lyfte lokalt till 88.53% rader / 85.07% funktioner; FUNC-golvet
+// låses just under 85%-milstolpen, LINE oförändrat ~0.5% marginal).
 const LINE_FLOOR = 0.88;
-const FUNC_FLOOR = 0.834;
+const FUNC_FLOOR = 0.835;
 
 /**
  * SERIAL_FILES — testfiler som SYNKRONT spawnar en barnprocess via


### PR DESCRIPTION
## Vad

`#27`-ratchet-steg. `handle-store`:s IndexedDB-persistens
(`saveHandle`/`loadHandle`/`deleteHandle` + `openDb`/`tx`) var **explicit
otestad** i unit-suiten (headern sa "kräver fake-indexeddb"). Det finns redan
i repot (ed25519 + indexeddb-fs-persistence), så gapet kan stängas.

## Test (utökar `test/unit/lib/fsa/handle-store.test.ts`)

Injicerar en `IDBFactory` som global `indexedDB` per test (`--isolate`):
- `loadHandle` på okänd nyckel → `null`
- `saveHandle` → `loadHandle` round-trip per nyckel (annan nyckel orörd)
- `saveHandle` skriver över samma nyckel
- `deleteHandle` → `loadHandle` `null` igen
- `loadHandle` utan `indexedDB` i miljön → `null` (SSR/privat-flik-grenen)

## Ratchet

Lokalt **88.53 % rader / 85.07 % funktioner**. `FUNC_FLOOR` 0.834 → 0.835
(låser 85 %-milstolpen, ~1.5 % marginal). `LINE_FLOOR` oförändrat 0.880
(~0.5 % marginal — ingen plats att dra tightare utan att underskrida
konventionen).

## Verifierat lokalt

`quality:fast`, `test:cov` (grön mot nya golv), `knip`, `deps:check`,
`duplicates` — alla gröna.

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)