### PR TITLE
test(demo): täck demoStaticParamsBySeedId + billing-grenar, höj line-golv

### DIFF
--- a/test/unit/lib/demo/static-params.test.ts
+++ b/test/unit/lib/demo/static-params.test.ts
@@ -35,6 +35,62 @@ describe("collectDemoIds", () => {
     const { collectDemoIds } = await import("@/lib/client/demo/static-params");
     expect(await collectDemoIds("does-not-exist")).toEqual([]);
   });
+
+  it("invoices → inkluderar deterministiska billing-id:n (collectBillingIds)", async () => {
+    const { collectDemoIds } = await import("@/lib/client/demo/static-params");
+    const ids = await collectDemoIds("invoices");
+    expect(Array.isArray(ids)).toBe(true);
+    expect(ids.length).toBeGreaterThan(0);
+    expect(ids.every((i) => typeof i === "string")).toBe(true);
+  });
+
+  it("payment-plans → billing-plan-id:n via collectBillingIds", async () => {
+    const { collectDemoIds } = await import("@/lib/client/demo/static-params");
+    const ids = await collectDemoIds("payment-plans");
+    expect(Array.isArray(ids)).toBe(true);
+    expect(ids.every((i) => typeof i === "string")).toBe(true);
+  });
+});
+
+describe("demoStaticParams — invoices/payment-plans kortsluts till bara sentinel", () => {
+  beforeEach(() => { process.env.DEMO_BUILD = "1"; });
+
+  it("invoices → ENDAST SHELL_PARAM (per-id-prerendering vore skadlig här)", async () => {
+    const { demoStaticParams, SHELL_PARAM } = await import("@/lib/client/demo/static-params");
+    expect(await demoStaticParams("invoices")).toEqual([{ id: SHELL_PARAM }]);
+  });
+
+  it("payment-plans → ENDAST SHELL_PARAM", async () => {
+    const { demoStaticParams, SHELL_PARAM } = await import("@/lib/client/demo/static-params");
+    expect(await demoStaticParams("payment-plans")).toEqual([{ id: SHELL_PARAM }]);
+  });
+});
+
+describe("demoStaticParamsBySeedId", () => {
+  afterEach(() => { delete process.env.DEMO_BUILD; });
+
+  it("returnerar [] när DEMO_BUILD inte är satt", async () => {
+    delete process.env.DEMO_BUILD;
+    const { demoStaticParamsBySeedId } = await import("@/lib/client/demo/static-params");
+    expect(await demoStaticParamsBySeedId("users")).toEqual([]);
+  });
+
+  it("läser seed-objektens .id (ej filnamn) + sentinel när DEMO_BUILD=1", async () => {
+    process.env.DEMO_BUILD = "1";
+    const { demoStaticParamsBySeedId, SHELL_PARAM } = await import("@/lib/client/demo/static-params");
+    const params = await demoStaticParamsBySeedId("users");
+    const ids = params.map((p) => p.id);
+    // users-seeden har UUID-id:n (≠ filnamnet som är e-post)
+    expect(ids.filter((i) => i !== SHELL_PARAM).length).toBeGreaterThan(0);
+    expect(ids.filter((i) => i !== SHELL_PARAM).every((i) => isUuid(i))).toBe(true);
+    expect(ids[ids.length - 1]).toBe(SHELL_PARAM);
+  });
+
+  it("okänd sourceKey → bara sentinel (tom lista + SHELL_PARAM)", async () => {
+    process.env.DEMO_BUILD = "1";
+    const { demoStaticParamsBySeedId, SHELL_PARAM } = await import("@/lib/client/demo/static-params");
+    expect(await demoStaticParamsBySeedId("does-not-exist")).toEqual([{ id: SHELL_PARAM }]);
+  });
 });
 
 describe("demoStaticParams", () => {

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -49,8 +49,11 @@ const FAST = process.argv.includes("--fast");
 // till 88.46% rader / 84.97% funktioner; samma ~0.5%/~1.5%-marginal) → 88.0
 // rader / 83.5 funktioner (#27: handle-store IndexedDB-persistens mot fake-
 // indexeddb lyfte lokalt till 88.53% rader / 85.07% funktioner; FUNC-golvet
-// låses just under 85%-milstolpen, LINE oförändrat ~0.5% marginal).
-const LINE_FLOOR = 0.88;
+// låses just under 85%-milstolpen, LINE oförändrat ~0.5% marginal) → 88.1 rader
+// / 83.5 funktioner (#27: demoStaticParamsBySeedId + billing-grenarna i static-
+// params lyfte lokalt till 88.58% rader / 85.12% funktioner; LINE dras upp,
+// FUNC oförändrat ~1.6% marginal).
+const LINE_FLOOR = 0.881;
 const FUNC_FLOOR = 0.835;
 
 /**


### PR DESCRIPTION
## Vad

`#27`-ratchet-steg på durabel demo-logik (demon måste fortsätta funka på GH
Pages). `demoStaticParamsBySeedId` var **helt otestad** och `invoices`/
`payment-plans`-grenarna i `demoStaticParams`/`collectDemoIds` saknade täckning.

## Test (utökar `test/unit/lib/demo/static-params.test.ts`)

- `collectDemoIds("invoices"|"payment-plans")` → kör `collectBillingIds`-grenen
- `demoStaticParams("invoices"|"payment-plans")` DEMO_BUILD=1 → kortsluts till
  **bara** `SHELL_PARAM` (per-id-prerendering vore skadlig där)
- `demoStaticParamsBySeedId`: not-set → `[]`; DEMO_BUILD=1 → seed-objektens
  `.id` (UUID, ≠ filnamnet som är e-post) + sentinel sist; okänd sourceKey →
  bara sentinel

## Ratchet

Lokalt **88.58 % rader / 85.12 % funktioner**. `LINE_FLOOR` 0.880 → 0.881
(~0.5 % marginal). `FUNC_FLOOR` oförändrat 0.835 (~1.6 % marginal).

## Verifierat lokalt

`quality:fast`, `test:cov` (grön mot nya golv), `knip`, `deps:check`,
`duplicates` — alla gröna.

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)