### PR TITLE
feat(demo): persistera genererade dok-blobbar i IndexedDB (av-slabba)

### DIFF
--- a/src/components/shell/demo-bootstrap.tsx
+++ b/src/components/shell/demo-bootstrap.tsx
@@ -124,43 +124,17 @@ async function writeViaSlab(
 
 /**
  * Återfyll in-memory blob-cachen för klient-genererade dokument (kostnadsräkning
- * m.fl.) från slaben efter en reload, så `openDocument`/`openGeneratedDoc`
- * (blob:-URL) fungerar igen. Slabens `documents/content/` innehåller ENBART
- * runtime-genererat innehåll — seed-dokumentens content ligger inte i manifestet
- * (hämtas on-demand från GH Pages), så ingen krock.
+ * m.fl.) från IndexedDB efter en reload, så `openDocument`/`openGeneratedDoc`
+ * (blob:-URL) fungerar igen. Endast runtime-genererat innehåll lagras här —
+ * seed-dokumentens content hämtas on-demand från GH Pages (CDN-URL), så ingen
+ * krock. (Ersätter den gamla MemFs-slab-rehydreringen, ADR 0016 / #420.)
  */
-interface DocMeta { id: string; fileName?: string; storagePath?: string; mimeType?: string }
-type StashFn = (id: string, bytes: Uint8Array, mimeType: string, fileName: string) => void;
-
-/** base64 → bytes (för event-transport av binärt dokument-innehåll). */
-export function base64ToBytes(b64: string): Uint8Array {
-  const bin = atob(b64);
-  const out = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
-  return out;
-}
-
-export function inferDocMime(file: string, meta: DocMeta | undefined): string {
-  if (meta?.mimeType) return meta.mimeType;
-  if (file.endsWith(".pdf")) return "application/pdf";
-  return file.endsWith(".html") ? "text/html; charset=utf-8" : "application/octet-stream";
-}
-
-async function stashSlabDoc(runtime: DemoRuntime, file: string, docs: readonly DocMeta[], stash: StashFn): Promise<void> {
-  const meta = docs.find((d) => d.storagePath === `documents/content/${file}`);
-  const bytes = await runtime.readFileBytes(`documents/content/${file}`).catch(() => null);
-  if (bytes == null) return; // trasig/oläsbar fil → hoppa över
-  const id = meta?.id ?? file.replace(/\.[^.]+$/, "");
-  stash(id, bytes, inferDocMime(file, meta), meta?.fileName ?? file);
-}
-
-async function rehydrateGeneratedDocs(runtime: DemoRuntime, source: DemoSource): Promise<void> {
-  let files: string[];
-  try { files = await runtime.listFiles("documents/content"); } catch { return; }
-  if (!files.length) return;
+async function rehydrateGeneratedDocs(): Promise<void> {
+  const { loadAllGeneratedDocBlobs } = await import("@/lib/client/demo/generated-doc-idb");
+  const blobs = await loadAllGeneratedDocBlobs();
+  if (!blobs.length) return;
   const { stashGeneratedDoc } = await import("@/lib/client/demo/generated-doc-cache");
-  const docs = (source.documents ?? []) as unknown as readonly DocMeta[];
-  for (const f of files) await stashSlabDoc(runtime, f, docs, stashGeneratedDoc);
+  for (const b of blobs) stashGeneratedDoc(b.id, b.bytes, b.mimeType, b.fileName);
 }
 
 /**
@@ -186,13 +160,12 @@ function useDemoWriteBack() {
 }
 
 /**
- * Lyssnar på text-extraktions- och generated-doc-event från job-workers och
- * skriver via writeBack-pipelinen / demo-slaben (överlever reload, kan öppnas
- * via blob:-URL). Self-hosted utan demo-runtime → generated-doc är no-op.
+ * Lyssnar på text-extraktions-event från job-workers och skriver via writeBack-
+ * pipelinen. (Genererade dokument-blobbar persisteras numera direkt till
+ * IndexedDB i `persistGeneratedDoc`, ADR 0016 / #420 — inget event behövs.)
  */
 function useWriteBackListeners(
   writeBack: (event: WriteBackEvent) => Promise<void>,
-  runtimeRef: { current: DemoRuntime | null },
 ) {
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -208,25 +181,6 @@ function useWriteBackListeners(
     window.addEventListener("ava:document-text-extracted", handler);
     return () => window.removeEventListener("ava:document-text-extracted", handler);
   }, [writeBack]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const handler = (e: Event) => {
-      const detail = (e as CustomEvent<{ id: string; storagePath: string; contentBase64: string }>).detail;
-      const rt = runtimeRef.current;
-      if (!detail || !rt) return;
-      void (async () => {
-        try {
-          await rt.writeFileBytes(detail.storagePath, base64ToBytes(detail.contentBase64));
-          await rt.persist();
-        } catch (err) {
-          console.warn("[demo] generated-doc persist failed:", err);
-        }
-      })();
-    };
-    window.addEventListener("ava:generated-doc", handler);
-    return () => window.removeEventListener("ava:generated-doc", handler);
-  }, [runtimeRef]);
 }
 
 function makeDemoQueryClient(): QueryClient {
@@ -343,7 +297,7 @@ function useDemoBootstrap(args: BootstrapArgs) {
           await queryClient.invalidateQueries();
           setStatus("ready");
           void preloadDocs();
-          void rehydrateGeneratedDocs(runtime, source);
+          void rehydrateGeneratedDocs();
           return;
         }
       } catch { /* fall through to fresh clone */ }
@@ -361,6 +315,7 @@ function useDemoBootstrap(args: BootstrapArgs) {
         await queryClient.invalidateQueries();
         setStatus("ready");
         void preloadDocs();
+        void rehydrateGeneratedDocs();
       } catch (err) {
         if (cancelled) return;
         setStatus("error");
@@ -386,7 +341,7 @@ export function DemoBootstrap({ children }: { children: ReactNode }) {
   const [fsaHandle, setFsaHandle] = useState<FileSystemDirectoryHandle | null>(null);
 
   const { writeBack, fsaRef, runtimeRef } = useDemoWriteBack();
-  useWriteBackListeners(writeBack, runtimeRef);
+  useWriteBackListeners(writeBack);
 
   // Demon kör nu på offline-first-kärnan (ADR 0016/#419): CachingSyncDataStore
   // UTAN synk-mål (noSyncTransport). `.store` är LocalStore-kärnan appen läser/

--- a/src/lib/client/demo/generated-doc-idb.ts
+++ b/src/lib/client/demo/generated-doc-idb.ts
@@ -1,0 +1,76 @@
+"use client";
+
+/**
+ * `generated-doc-idb` — persistens av klient-genererade dokument-blobbar
+ * (kostnadsräkning, faktura, …) i IndexedDB.
+ *
+ * Bakgrund (ADR 0016 / #420): demon kör på offline-first-kärnan och ska INTE
+ * längre använda MemFs-slaben. Genererade dokument har inget CDN-URL att falla
+ * tillbaka på (de skapas i browsern), så för att de ska överleva en reload
+ * persisterar vi bytes:erna här och rehydrerar in-memory blob-cachen
+ * (`generated-doc-cache`) vid boot.
+ *
+ * Seed-dokument (shippade i demo-repot) berörs inte — de öppnas direkt mot
+ * CDN-URL:en (se `_documents-list-view.openDocumentSmart`).
+ *
+ * Best-effort: saknas IndexedDB (SSR/privat flik) → no-op / tom lista, precis
+ * som `IndexedDbFsPersistence`. IndexedDB strukturklonar `Uint8Array` direkt,
+ * så ingen base64-omkodning behövs. Egen, klient-lokal IDB-access (samma mönster
+ * som `fsa/handle-store`) så inget server-lager importeras (dep-cruiser-gräns).
+ */
+
+const DB_NAME = "ava-generated-docs";
+const STORE = "blobs";
+
+export interface StoredDocBlob {
+  id: string;
+  storagePath: string;
+  fileName: string;
+  mimeType: string;
+  bytes: Uint8Array;
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      if (!req.result.objectStoreNames.contains(STORE)) req.result.createObjectStore(STORE, { keyPath: "id" });
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/** Persistera (eller skriv över) en genererad dok-blob. No-op utan IndexedDB. */
+export async function saveGeneratedDocBlob(blob: StoredDocBlob): Promise<void> {
+  if (typeof indexedDB === "undefined") return;
+  try {
+    const db = await openDb();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE, "readwrite");
+      tx.objectStore(STORE).put(blob);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+    db.close();
+  } catch (e) {
+    console.warn("[generated-doc] IndexedDB-spar misslyckades:", e);
+  }
+}
+
+/** Alla persisterade dok-blobbar (för rehydrering vid boot). [] utan IndexedDB. */
+export async function loadAllGeneratedDocBlobs(): Promise<StoredDocBlob[]> {
+  if (typeof indexedDB === "undefined") return [];
+  try {
+    const db = await openDb();
+    const blobs = await new Promise<StoredDocBlob[]>((resolve, reject) => {
+      const req = db.transaction(STORE, "readonly").objectStore(STORE).getAll();
+      req.onsuccess = () => resolve((req.result as StoredDocBlob[] | undefined) ?? []);
+      req.onerror = () => reject(req.error);
+    });
+    db.close();
+    return blobs;
+  } catch {
+    return [];
+  }
+}

--- a/src/lib/client/demo/persist-generated-doc.ts
+++ b/src/lib/client/demo/persist-generated-doc.ts
@@ -7,21 +7,15 @@
  *
  *   1. in-memory blob-cache (`generated-doc-cache`) → öppnas direkt i sessionen.
  *   2. FSA-working-copy (self-hosted/demo-med-mapp) → riktiga bytes på disk.
- *   3. demo-slaben (MemFs) via `ava:generated-doc`-eventet → DemoBootstrap
- *      skriver bytes + persist:ar till OPFS → överlever reload (rehydreras till
- *      blob-cachen vid boot).
+ *   3. IndexedDB (`generated-doc-idb`) → överlever reload (rehydreras till
+ *      blob-cachen vid boot). Ersätter den gamla MemFs-slaben (ADR 0016 / #420).
  *
  * Metadata-raden (Document-entiteten) skapas av anroparen via tRPC
  * (kostnadsrakning.record / document.register) — detta hanterar bara INNEHÅLLET.
  */
 
 import { stashGeneratedDoc } from "./generated-doc-cache";
-
-function bytesToBase64(bytes: Uint8Array): string {
-  let bin = "";
-  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]!);
-  return btoa(bin);
-}
+import { saveGeneratedDocBlob } from "./generated-doc-idb";
 
 /** Skriv bytes till FSA-working-copyn om en handle finns (annars no-op). */
 async function writeFsa(storagePath: string, bytes: Uint8Array): Promise<void> {
@@ -47,9 +41,11 @@ export interface GeneratedDoc {
 export async function persistGeneratedDoc(doc: GeneratedDoc): Promise<void> {
   stashGeneratedDoc(doc.id, doc.bytes, doc.mimeType, doc.fileName);
   await writeFsa(doc.storagePath, doc.bytes);
-  if (typeof window !== "undefined") {
-    window.dispatchEvent(new CustomEvent("ava:generated-doc", {
-      detail: { id: doc.id, storagePath: doc.storagePath, contentBase64: bytesToBase64(doc.bytes) },
-    }));
-  }
+  await saveGeneratedDocBlob({
+    id: doc.id,
+    storagePath: doc.storagePath,
+    fileName: doc.fileName,
+    mimeType: doc.mimeType,
+    bytes: doc.bytes,
+  });
 }

--- a/test/unit/client/demo/persist-generated-doc.test.ts
+++ b/test/unit/client/demo/persist-generated-doc.test.ts
@@ -1,19 +1,24 @@
 /**
- * Tester för `persistGeneratedDoc` (#27 — otestad). Mockar cache + de
+ * Tester för `persistGeneratedDoc`. Mockar cache, IndexedDB-blob-storen och de
  * dynamiskt importerade FSA-modulerna. Verifierar: stash anropas, FSA-skrivning
- * sker bara när en handle finns (annars no-op), CustomEvent med korrekt base64,
+ * sker bara när en handle finns (annars no-op), bytes persisteras till IndexedDB
+ * (`saveGeneratedDocBlob`, ADR 0016 / #420 — ersätter det gamla slab-eventet),
  * och att FSA-fel sväljs (kastar inte).
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest-compat";
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
 
 import { persistGeneratedDoc } from "@/lib/client/demo/persist-generated-doc";
 
 const stashMock = vi.fn();
 const loadHandleMock = vi.fn();
 const writeFileMock = vi.fn(async () => {});
+const saveBlobMock = vi.fn(async () => {});
 
 vi.mock("@/lib/client/demo/generated-doc-cache", () => ({
   stashGeneratedDoc: (...a: unknown[]) => stashMock(...a),
+}));
+vi.mock("@/lib/client/demo/generated-doc-idb", () => ({
+  saveGeneratedDocBlob: (...a: unknown[]) => saveBlobMock(...a),
 }));
 vi.mock("@/lib/client/fsa/handle-store", () => ({
   loadHandle: (...a: unknown[]) => loadHandleMock(...a),
@@ -22,27 +27,26 @@ vi.mock("@/lib/client/fsa/fs-adapter", () => ({
   FsaIsoGitAdapter: class { constructor(_h: unknown) {} writeFile = writeFileMock; },
 }));
 
-const BYTES = new Uint8Array([72, 105]); // "Hi" → base64 "SGk="
+const BYTES = new Uint8Array([72, 105]); // "Hi"
 const DOC = { id: "d1", storagePath: "documents/d1.pdf", fileName: "d1.pdf", mimeType: "application/pdf", bytes: BYTES };
-
-let events: CustomEvent[] = [];
-const listener = (e: Event) => events.push(e as CustomEvent);
 
 beforeEach(() => {
   vi.clearAllMocks();
-  events = [];
-  window.addEventListener("ava:generated-doc", listener);
 });
-afterEach(() => window.removeEventListener("ava:generated-doc", listener));
 
 describe("persistGeneratedDoc", () => {
-  it("stashar, hoppar FSA utan handle, och dispatchar event med base64", async () => {
+  it("stashar, hoppar FSA utan handle, och persisterar blobben till IndexedDB", async () => {
     loadHandleMock.mockResolvedValue(null);
     await persistGeneratedDoc(DOC);
     expect(stashMock).toHaveBeenCalledWith("d1", BYTES, "application/pdf", "d1.pdf");
     expect(writeFileMock).not.toHaveBeenCalled();
-    expect(events).toHaveLength(1);
-    expect(events[0]!.detail).toEqual({ id: "d1", storagePath: "documents/d1.pdf", contentBase64: "SGk=" });
+    expect(saveBlobMock).toHaveBeenCalledWith({
+      id: "d1",
+      storagePath: "documents/d1.pdf",
+      fileName: "d1.pdf",
+      mimeType: "application/pdf",
+      bytes: BYTES,
+    });
   });
 
   it("skriver till FSA-working-copyn när en handle finns", async () => {
@@ -51,10 +55,10 @@ describe("persistGeneratedDoc", () => {
     expect(writeFileMock).toHaveBeenCalledWith("/documents/d1.pdf", BYTES);
   });
 
-  it("sväljer FSA-skrivfel (kastar inte, event dispatchas ändå)", async () => {
+  it("sväljer FSA-skrivfel (kastar inte, blobben persisteras ändå)", async () => {
     loadHandleMock.mockResolvedValue({});
     writeFileMock.mockRejectedValueOnce(new Error("disk full"));
     await expect(persistGeneratedDoc(DOC)).resolves.toBeUndefined();
-    expect(events).toHaveLength(1);
+    expect(saveBlobMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/unit/components/demo-bootstrap-helpers.test.tsx
+++ b/test/unit/components/demo-bootstrap-helpers.test.tsx
@@ -8,8 +8,6 @@ import { describe, it, expect, vi, afterEach } from "vitest-compat";
 import {
   pathSkipsAuth,
   checkBootstrapGate,
-  inferDocMime,
-  base64ToBytes,
 } from "@/components/shell/demo-bootstrap";
 import type { FirmaConfig } from "@/lib/client/firma/firma-config";
 
@@ -71,26 +69,5 @@ describe("checkBootstrapGate", () => {
     expect(checkBootstrapGate({ ...noPrincipal, tier: "self-hosted" }))
       .toBe("continue");
     restore();
-  });
-});
-
-describe("inferDocMime", () => {
-  it("föredrar metans mimeType", () => {
-    expect(inferDocMime("x.bin", { id: "1", mimeType: "image/png" })).toBe("image/png");
-  });
-  it("härleder pdf/html, annars octet-stream", () => {
-    expect(inferDocMime("a.pdf", undefined)).toBe("application/pdf");
-    expect(inferDocMime("a.html", undefined)).toBe("text/html; charset=utf-8");
-    expect(inferDocMime("a.docx", undefined)).toBe("application/octet-stream");
-  });
-});
-
-describe("base64ToBytes", () => {
-  it("avkodar base64 → bytes (round-trip mot btoa)", () => {
-    const bytes = base64ToBytes(btoa("hej"));
-    expect(Array.from(bytes)).toEqual([104, 101, 106]); // h,e,j
-  });
-  it("tom sträng → tom array", () => {
-    expect(base64ToBytes("").length).toBe(0);
   });
 });

--- a/test/unit/lib/demo/generated-doc-idb.test.ts
+++ b/test/unit/lib/demo/generated-doc-idb.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tester för `generated-doc-idb` (ADR 0016 / #420) — IndexedDB-persistens av
+ * klient-genererade dok-blobbar som ersätter MemFs-slaben. Testas mot
+ * fake-indexeddb (happy-dom saknar IndexedDB) via en injicerad global
+ * `indexedDB`; --isolate håller mutationen i denna fil.
+ */
+
+import { IDBFactory } from "fake-indexeddb";
+import { describe, it, expect, beforeEach, afterEach } from "vitest-compat";
+import {
+  saveGeneratedDocBlob,
+  loadAllGeneratedDocBlobs,
+  type StoredDocBlob,
+} from "@/lib/client/demo/generated-doc-idb";
+
+let prev: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+  prev = Object.getOwnPropertyDescriptor(globalThis, "indexedDB");
+  Object.defineProperty(globalThis, "indexedDB", { value: new IDBFactory(), configurable: true, writable: true });
+});
+
+afterEach(() => {
+  if (prev) Object.defineProperty(globalThis, "indexedDB", prev);
+  else delete (globalThis as { indexedDB?: unknown }).indexedDB;
+});
+
+const doc = (id: string): StoredDocBlob => ({
+  id,
+  storagePath: `documents/content/${id}.pdf`,
+  fileName: `${id}.pdf`,
+  mimeType: "application/pdf",
+  bytes: new Uint8Array([37, 80, 68, 70]), // %PDF
+});
+
+describe("generated-doc-idb", () => {
+  it("tom DB → loadAll returnerar []", async () => {
+    expect(await loadAllGeneratedDocBlobs()).toEqual([]);
+  });
+
+  it("save → loadAll round-trippar blobben (bytes bevarade via structured clone)", async () => {
+    await saveGeneratedDocBlob(doc("d1"));
+    const all = await loadAllGeneratedDocBlobs();
+    expect(all).toHaveLength(1);
+    expect(all[0]!.id).toBe("d1");
+    expect(all[0]!.mimeType).toBe("application/pdf");
+    expect(Array.from(all[0]!.bytes)).toEqual([37, 80, 68, 70]);
+  });
+
+  it("flera blobbar + överskrivning per id", async () => {
+    await saveGeneratedDocBlob(doc("a"));
+    await saveGeneratedDocBlob(doc("b"));
+    await saveGeneratedDocBlob({ ...doc("a"), fileName: "ny.pdf" });
+    const all = await loadAllGeneratedDocBlobs();
+    expect(all).toHaveLength(2);
+    expect(all.find((d) => d.id === "a")!.fileName).toBe("ny.pdf");
+  });
+
+  it("utan IndexedDB i miljön → save är no-op, loadAll []", async () => {
+    delete (globalThis as { indexedDB?: unknown }).indexedDB;
+    await expect(saveGeneratedDocBlob(doc("x"))).resolves.toBeUndefined();
+    expect(await loadAllGeneratedDocBlobs()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Vad

**PR 1/4 av server-first-finalen (ADR 0016 / epic #403).** Förberedelse för
#420: flyttar klient-genererade dokument-blobbar (kostnadsräkning/faktura-PDF:er)
från MemFs-slaben till en egen klient-lokal IndexedDB-store, så slaben kan
pensioneras utan att tappa reload-persistens för genererade dokument.

## Ändring

- Ny `src/lib/client/demo/generated-doc-idb.ts` — `saveGeneratedDocBlob` /
  `loadAllGeneratedDocBlobs` (egen IDB-access, klient-lokal → ingen
  server-import; best-effort no-op utan IndexedDB).
- `persistGeneratedDoc` skriver bytes direkt till IndexedDB i st.f. att
  dispatcha `ava:generated-doc` till slaben.
- `demo-bootstrap` rehydrerar in-memory blob-cachen från IndexedDB vid boot
  (båda restore- och fresh-clone-vägarna); tar bort slab-eventlyssnaren + de
  nu döda helpers (`base64ToBytes`/`inferDocMime`/`stashSlabDoc`).

## Varför demon inte går sönder

Seed-dokument (shippade i demo-repot, 60 PDF/DOCX) öppnas mot **CDN-URL:en** via
`openDocumentSmart`-fallbacken — aldrig via slaben/blob-cachen. Endast
runtime-*genererade* dokument låg i slaben; de täcks nu av IndexedDB.

## Verifierat lokalt

`quality:fast`, `test:cov` (88.65 % rader / 85.11 % funktioner, grön),
`knip`, `deps:check`, `duplicates`, **`build:demo`** (97 HTML, 502 entiteter,
60 binärer) — alla gröna.

Refs #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)