### PR TITLE
docs(adr): flippa adr 0017/0021/0022 till accepterad

### DIFF
--- a/docs/adr/0017-sync-reconcile-protokoll.md
+++ b/docs/adr/0017-sync-reconcile-protokoll.md
@@ -1,7 +1,7 @@
 # ADR 0017 — Sync/reconcile-protokoll + konfliktpolicy (offline-first klient)
 
-- **Status:** Föreslagen
-- **Datum:** 2026-06-16
+- **Status:** Accepterad
+- **Datum:** 2026-06-16 (accepterad 2026-06-18)
 - **Beslutsfattare:** Ulrik Sjölin
 - **Berör:** offline-sync, datalager, konflikthantering, DB-schema, statemaskin
 - **Bygger på:** [ADR 0016](0016-server-first-med-offline-first-klient.md) (server-first +

--- a/docs/adr/0021-online-only-handlingar.md
+++ b/docs/adr/0021-online-only-handlingar.md
@@ -1,7 +1,7 @@
 # ADR 0021 — Online-only-handlingar (kö-modell + UI) i offline-first-klienten
 
-- **Status:** Föreslagen
-- **Datum:** 2026-06-17
+- **Status:** Accepterad
+- **Datum:** 2026-06-17 (accepterad 2026-06-18)
 - **Beslutsfattare:** Ulrik Sjölin
 - **Berör:** offline-first-klient, server-runtime, integrationer (mail/Fortnox/webhooks), sync, UI
 - **Issue:** [#407](https://github.com/ulrik-s/ava/issues/407) (design; blockerar #417-implementationen)

--- a/docs/adr/0022-working-set-scoping.md
+++ b/docs/adr/0022-working-set-scoping.md
@@ -1,7 +1,7 @@
 # ADR 0022 — Working-set-scoping (prefetch + budget) för offline-first-klienten
 
-- **Status:** Föreslagen
-- **Datum:** 2026-06-17
+- **Status:** Accepterad
+- **Datum:** 2026-06-17 (accepterad 2026-06-18)
 - **Beslutsfattare:** Ulrik Sjölin
 - **Berör:** offline-first-klient, prefetch, sync (delta-pull), lokal store, lagringsbudget
 - **Issue:** [#406](https://github.com/ulrik-s/ava/issues/406) (design; blockerar #418-implementationen)


### PR DESCRIPTION
Flippar ADR **0017** (sync/reconcile-protokoll + konfliktpolicy), **0021**
(online-only-handlingar) och **0022** (working-set-scoping) från *Föreslagen*
→ **Accepterad** (2026-06-18).

De foundationella design-besluten för offline-first-klienten låses i takt med
att server-first-cutovern genomförs (ADR 0016 / epic #403).

🤖 Generated with [Claude Code](https://claude.com/claude-code)