### PR TITLE
feat(server): durabel jobb-kö via pg-boss (fas 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Repository-tester mot riktig Postgres
         env:
           PG_TEST_URL: postgres://ava:ava@localhost:5433/ava_test
-        run: bun test test/unit/server/repositories/ test/unit/server/db/relations.test.ts test/unit/server/http/server-context.test.ts test/unit/server/http/server-trpc-handler.test.ts test/unit/server/sync/ test/unit/client/sync/trpc-sync-transport.test.ts test/unit/server/http/server-first-http-e2e.test.ts test/unit/server/db/server-first-deploy.test.ts test/unit/client/backend/server-first-store.test.ts
+        run: bun test test/unit/server/repositories/ test/unit/server/db/relations.test.ts test/unit/server/http/server-context.test.ts test/unit/server/http/server-trpc-handler.test.ts test/unit/server/sync/ test/unit/server/jobs/ test/unit/client/sync/trpc-sync-transport.test.ts test/unit/server/http/server-first-http-e2e.test.ts test/unit/server/db/server-first-deploy.test.ts test/unit/client/backend/server-first-store.test.ts
       - name: Tear down docker
         if: always()
         run: docker compose -f tooling/docker/docker-compose.test.yml down -v

--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
         "next": "16.2.7",
         "nodemailer": "^8.0.11",
         "pdfjs-dist": "^6.0.227",
+        "pg-boss": "^12.19.1",
         "postgres": "^3.4.9",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -1244,6 +1245,8 @@
 
     "nodemailer": ["nodemailer@8.0.11", "", {}, "sha512-nrO/pDAUKl+wXX+lx16tDLbnm0fW6sK/x8mgohaCpg+CdCEl482bD4tCuAZk2DyliruiNTIZxRCoWkDqJEnAiA=="],
 
+    "non-error": ["non-error@0.1.0", "", {}, "sha512-TMB1uHiGsHRGv1uYclfhivcnf0/PdFp2pNqRxXjncaAsjYMoisaQJI+SSZCqRq+VliwRTC8tsMQfmrWjDMhkPQ=="],
+
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
@@ -1296,6 +1299,24 @@
 
     "pdfjs-dist": ["pdfjs-dist@6.0.227", "", { "optionalDependencies": { "@napi-rs/canvas": "^1.0.0" } }, "sha512-/P6M4SXw+70waMVLUM7rdRtvo+dEzqE1t6W/zQNvBETo2MaRa5rrvCcAYdfWGiUzadTgM0lJmRApUrW0d9zgKg=="],
 
+    "pg": ["pg@8.21.0", "", { "dependencies": { "pg-connection-string": "^2.13.0", "pg-pool": "^3.14.0", "pg-protocol": "^1.14.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.4.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA=="],
+
+    "pg-boss": ["pg-boss@12.19.1", "", { "dependencies": { "cron-parser": "^5.5.0", "pg": "^8.21.0", "serialize-error": "^13.0.1" }, "bin": { "pg-boss": "dist/cli.js" } }, "sha512-IwFXopV2lzKYMZLw9ThI70BfgxqG7JEX/n99StMA2PudgF38pCjibM6h8IlxtBEJOXncQpjpdxBUxW1CTy57Zg=="],
+
+    "pg-cloudflare": ["pg-cloudflare@1.4.0", "", {}, "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A=="],
+
+    "pg-connection-string": ["pg-connection-string@2.13.0", "", {}, "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig=="],
+
+    "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
+
+    "pg-pool": ["pg-pool@3.14.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw=="],
+
+    "pg-protocol": ["pg-protocol@1.14.0", "", {}, "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA=="],
+
+    "pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
+
+    "pgpass": ["pgpass@1.0.5", "", { "dependencies": { "split2": "^4.1.0" } }, "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
@@ -1311,6 +1332,14 @@
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
     "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
+
+    "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
+
+    "postgres-bytea": ["postgres-bytea@1.0.1", "", {}, "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="],
+
+    "postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
+
+    "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
@@ -1380,6 +1409,8 @@
 
     "semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
 
+    "serialize-error": ["serialize-error@13.0.1", "", { "dependencies": { "non-error": "^0.1.0", "type-fest": "^5.4.1" } }, "sha512-bBZaRwLH9PN5HbLCjPId4dP5bNGEtumcErgOX952IsvOhVPrm3/AeK1y0UHA/QaPG701eg0yEnOKsCOC6X/kaA=="],
+
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
     "set-function-name": ["set-function-name@2.0.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "functions-have-names": "^1.2.3", "has-property-descriptors": "^1.0.2" } }, "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ=="],
@@ -1423,6 +1454,8 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
@@ -1468,6 +1501,8 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
+    "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
+
     "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 
     "tailwindcss": ["tailwindcss@4.3.0", "", {}, "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="],
@@ -1497,6 +1532,8 @@
     "tsx": ["tsx@4.22.4", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "type-fest": ["type-fest@5.7.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg=="],
 
     "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
 

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "next": "16.2.7",
     "nodemailer": "^8.0.11",
     "pdfjs-dist": "^6.0.227",
+    "pg-boss": "^12.19.1",
     "postgres": "^3.4.9",
     "react": "19.2.7",
     "react-dom": "19.2.7",

--- a/src/lib/server/jobs/job-queue.ts
+++ b/src/lib/server/jobs/job-queue.ts
@@ -1,0 +1,53 @@
+/**
+ * Server-sidig durabel jobb-kö via **pg-boss** (#504).
+ *
+ * pg-boss äger sitt EGET `pgboss`-schema i samma Postgres-DB (skilt från
+ * drizzle-app-schemat i `public`) och ger claim/lease (`FOR UPDATE SKIP
+ * LOCKED`), retry med exponentiell backoff, dead-letter och cron out-of-the-box
+ * — alltså exakt durabiliteten som försvann med git-peer-runtimen (#421). En
+ * kraschad/omstartad server tappar inga köade jobb (de ligger i Postgres) och
+ * dubbelkör dem inte (lease + SKIP LOCKED).
+ *
+ * "Använd biblioteket rakt av": vi wrappar bara namngivningen av köerna + start-
+ * sekvensen. Handlers registreras direkt via `boss.work(name, …)` (Fas 2).
+ *
+ * Anslutning: connectionString (pg-boss egen pool). `fromDrizzle`-adaptern delar
+ * pool men antar `pg`-resultatformen (`.rows`) → krockar med vårt postgres-js +
+ * pglite — därför egen connection (samma DB, eget schema).
+ */
+
+import { PgBoss } from "pg-boss";
+
+/** De server-sidiga jobb-köerna (Fas 3 kopplar in handlers). */
+export const JOB_QUEUES = {
+  emailDispatch: "email-dispatch",
+  fortnoxSync: "fortnox-sync",
+  rulesTick: "rules-tick",
+  outlookMirror: "outlook-mirror",
+} as const;
+
+const DEFAULT_SCHEMA = "pgboss";
+const DEFAULT_RETRY_LIMIT = 5;
+
+export interface JobQueueOptions {
+  /** Postgres-URL (samma DB som server-first; pg-boss skapar `pgboss`-schemat). */
+  connectionString: string;
+  /** pg-boss-schema (default `pgboss`). Sätt unikt i tester för isolering. */
+  schema?: string;
+}
+
+/** Konstruera (men starta inte) pg-boss-instansen. */
+export function createJobQueue(opts: JobQueueOptions): PgBoss {
+  return new PgBoss({ connectionString: opts.connectionString, schema: opts.schema ?? DEFAULT_SCHEMA });
+}
+
+/**
+ * Starta pg-boss (skapar/migrerar `pgboss`-schemat — idempotent) och registrera
+ * alla köer med retry + exponentiell backoff. Anropa en gång vid server-start.
+ */
+export async function startJobQueue(boss: PgBoss, retryLimit = DEFAULT_RETRY_LIMIT): Promise<void> {
+  await boss.start();
+  for (const name of Object.values(JOB_QUEUES)) {
+    await boss.createQueue(name, { retryLimit, retryBackoff: true });
+  }
+}

--- a/test/unit/server/jobs/job-queue.test.ts
+++ b/test/unit/server/jobs/job-queue.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Server-sidig jobb-kö (pg-boss, #504). Två nivåer:
+ *   - alltid: kö-namnen är distinkta (ren konfig).
+ *   - PG-gated (`PG_TEST_URL`, CI:s Postgres-jobb): RIKTIG round-trip mot pg-boss
+ *     — start (skapar pgboss-schemat) → send → work → handlern får payloaden.
+ *     Hoppas lokalt utan Postgres (pglite kan inte köra pg-boss advisory-locks).
+ */
+
+import postgres from "postgres";
+import { afterEach, describe, expect, it } from "vitest-compat";
+import { JOB_QUEUES, createJobQueue, startJobQueue } from "@/lib/server/jobs/job-queue";
+import { uuidv7 } from "@/lib/shared/uuid";
+
+const url = process.env.PG_TEST_URL;
+const itPg = url ? it : it.skip;
+
+describe("job-queue — konfig", () => {
+  it("har distinkta kö-namn", () => {
+    const names = Object.values(JOB_QUEUES);
+    expect(new Set(names).size).toBe(names.length);
+    expect(names).toContain("email-dispatch");
+  });
+});
+
+describe("job-queue — pg-boss round-trip (PG_TEST_URL)", () => {
+  let schema = "";
+  afterEach(async () => {
+    if (!url || !schema) return;
+    const c = postgres(url, { max: 1, onnotice: () => {} });
+    await c.unsafe(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+    await c.end();
+    schema = "";
+  });
+
+  itPg("start → send → work levererar jobbet durabelt", async () => {
+    schema = `pgboss_test_${uuidSchemaSuffix()}`;
+    const boss = createJobQueue({ connectionString: url!, schema });
+    boss.on("error", () => {});
+    try {
+      await startJobQueue(boss);
+      const got: unknown[] = [];
+      await boss.work(JOB_QUEUES.emailDispatch, async (jobs) => { for (const job of jobs) got.push(job.data); });
+      const id = await boss.send(JOB_QUEUES.emailDispatch, { to: "anna@firma.se" });
+      expect(id).toBeTruthy();
+      for (let i = 0; i < 100 && got.length === 0; i++) await new Promise((r) => setTimeout(r, 100));
+      expect(got).toEqual([{ to: "anna@firma.se" }]);
+    } finally {
+      await boss.stop({ graceful: false });
+    }
+  }, 60_000);
+});
+
+/** Schema-säkert unikt suffix (hex) för isolerat pgboss-testschema. */
+function uuidSchemaSuffix(): string {
+  return uuidv7().replace(/-/g, "");
+}


### PR DESCRIPTION
## Vad

**Fas 1 av #504.** Server-first har saknat server-sidig jobb-bearbetning sedan
git-peer-runtimen + `filesystem-claim-store`-durabiliteten togs bort i #421. Den
här PR:en lägger grunden med **pg-boss** — ett moget, Postgres-backat kö-bibliotek.

Per din input använder vi **biblioteket rakt av** (pg-boss + drizzle, två libs):
pg-boss äger sitt eget `pgboss`-schema i samma Postgres-DB (skilt från drizzle-
app-schemat) och ger ur lådan:
- **claim/lease** (`FOR UPDATE SKIP LOCKED`) → flera workers, ingen dubbelkörning
- **retry** med exponentiell backoff, **dead-letter**, **cron**
- durabelt: köade jobb ligger i Postgres → **tål server-restart**, tappas/dubbel-
  körs inte

## Ändring

- `src/lib/server/jobs/job-queue.ts` — `JOB_QUEUES`-namn + `createJobQueue`
  (connection-string-läge) + `startJobQueue` (start + `createQueue` med retry/backoff).
- pg-boss via egen connection, **inte** `fromDrizzle`: den adaptern antar `pg`:s
  `.rows`-resultatform → krockar med vårt postgres-js (array-likt) + pglite
  (advisory-lock-SQL:en kraschar). Verifierat: connection-string-läget fungerar
  under Bun.
- Test: kö-namn (alltid); pg-boss round-trip (start→send→work) **PG-gated** mot
  riktig Postgres (CI:s "Repository (Postgres)"-jobb), hoppas lokalt utan PG.

## Nästa faser
Fas 2: worker-loop i server-first-runtimen (start/stop + `boss.work`-handlers).
Fas 3: koppla in handlers (smtp-utskick/Fortnox/regelmotor).

## Verifierat lokalt
`typecheck`/`knip`/`deps:check`/`lint`/`duplicates` rena; `test:cov` 89.25 %
rader / 84.66 % funktioner (golv 88.10/83.50, 0 fail); pg-boss round-trip grön
mot Postgres 16 (docker). `bun install --frozen-lockfile` konsistent.

Refs #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)