### PR TITLE
feat(server): wira pg-boss-worker-loopen i server-first-runtimen (fas 2)

### DIFF
--- a/src/bin/server-first.ts
+++ b/src/bin/server-first.ts
@@ -19,6 +19,7 @@
 
 import { serveFetchHandler } from "@/lib/server/http/node-http-adapter";
 import { buildServerFirstApi, loadServerFirstConfig } from "@/lib/server/http/server-first-api";
+import { startJobRuntime, type JobRuntime } from "@/lib/server/jobs/job-worker-runtime";
 
 function log(msg: string): void {
   console.log(`[server-first] ${msg}`);
@@ -43,11 +44,19 @@ function main(): void {
   const server = serveFetchHandler(api.handler, { port: config.httpPort, hostname: config.httpHost });
   log(`lyssnar på ${config.httpHost}:${config.httpPort} (org ${config.organizationId})`);
 
+  // Jobb-kö (#504): best-effort start — en kö-hicka får ALDRIG ta ned HTTP-
+  // serveringen. Tom handler-karta tills Fas 3 (utskick/Fortnox/regler).
+  let jobRuntime: JobRuntime | null = null;
+  void startJobRuntime({ connectionString: config.databaseUrl })
+    .then((rt) => { jobRuntime = rt; log("jobb-kö startad (pg-boss)"); })
+    .catch((err) => log(`jobb-kö start misslyckades (fortsätter utan): ${String(err)}`));
+
   for (const sig of ["SIGTERM", "SIGINT"] as const) {
     process.on(sig, () => {
       log(`${sig} — stoppar`);
       server.close();
-      void api.close().finally(() => process.exit(0));
+      void Promise.allSettled([api.close(), jobRuntime?.stop() ?? Promise.resolve()])
+        .finally(() => process.exit(0));
     });
   }
 }

--- a/src/lib/server/jobs/job-queue.ts
+++ b/src/lib/server/jobs/job-queue.ts
@@ -26,6 +26,8 @@ export const JOB_QUEUES = {
   outlookMirror: "outlook-mirror",
 } as const;
 
+export type JobQueueName = (typeof JOB_QUEUES)[keyof typeof JOB_QUEUES];
+
 const DEFAULT_SCHEMA = "pgboss";
 const DEFAULT_RETRY_LIMIT = 5;
 

--- a/src/lib/server/jobs/job-worker-runtime.ts
+++ b/src/lib/server/jobs/job-worker-runtime.ts
@@ -1,0 +1,60 @@
+/**
+ * Job-worker-runtime (#504 Fas 2) — startar pg-boss-kön och registrerar
+ * worker-handlers i server-first-runtimen, med graceful shutdown.
+ *
+ * pg-boss ÄR worker-loopen: `boss.work(queue, handler)` pollar, claim:ar (FOR
+ * UPDATE SKIP LOCKED), kör handlern, ack:ar vid succé och retry:ar/dead-letter:ar
+ * vid fel. Här wirar vi bara livscykeln (start → registrera → stop) + en
+ * handler-karta som Fas 3 fyller (utskick/Fortnox/regler). Tom karta = kön körs
+ * (redo att ta emot jobb) men ingen handler konsumerar ännu.
+ */
+
+import type { Job } from "pg-boss";
+import { JOB_QUEUES, type JobQueueName, createJobQueue, startJobQueue } from "./job-queue";
+
+/** En handler kör ETT jobb. Kastar → pg-boss retry:ar (backoff) → dead-letter. */
+export type JobHandler = (job: Job) => Promise<void>;
+
+/** Per-kö-handlers. Saknad kö = ingen worker (jobb köas men konsumeras ej). */
+export type JobHandlers = Partial<Record<JobQueueName, JobHandler>>;
+
+export interface JobRuntime {
+  /** Stoppa pollingen och stäng pg-boss-anslutningen (graceful). */
+  stop(): Promise<void>;
+}
+
+export interface JobRuntimeOptions {
+  connectionString: string;
+  schema?: string;
+  handlers?: JobHandlers;
+}
+
+/**
+ * Starta kön + registrera workers. Returnerar en handle med `stop()` för
+ * shutdown. pg-boss kräver en `error`-lyssnare (annars kraschar processen på
+ * connection-fel) — vi loggar.
+ */
+export async function startJobRuntime(opts: JobRuntimeOptions): Promise<JobRuntime> {
+  const boss = createJobQueue({
+    connectionString: opts.connectionString,
+    ...(opts.schema ? { schema: opts.schema } : {}),
+  });
+  boss.on("error", (err) => console.error("[job-queue] fel:", err));
+  await startJobQueue(boss);
+  await registerWorkers(boss, opts.handlers ?? {});
+  return { stop: () => boss.stop({ graceful: true }) };
+}
+
+/** Registrera en `boss.work`-worker per kö som har en handler. */
+async function registerWorkers(
+  boss: Awaited<ReturnType<typeof createJobQueue>>,
+  handlers: JobHandlers,
+): Promise<void> {
+  for (const name of Object.values(JOB_QUEUES)) {
+    const handler = handlers[name];
+    if (!handler) continue;
+    await boss.work(name, async (jobs: Job[]) => {
+      for (const job of jobs) await handler(job);
+    });
+  }
+}

--- a/test/unit/server/jobs/job-worker-runtime.test.ts
+++ b/test/unit/server/jobs/job-worker-runtime.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Job-worker-runtime (#504 Fas 2). PG-gated (`PG_TEST_URL`, CI:s Postgres-jobb):
+ * `startJobRuntime` startar pg-boss + registrerar workers; ett skickat jobb
+ * körs av rätt handler; `stop()` stänger gracefully. Hoppas lokalt utan PG.
+ */
+
+import postgres from "postgres";
+import { afterEach, describe, expect, it } from "vitest-compat";
+import { createJobQueue, JOB_QUEUES, startJobQueue } from "@/lib/server/jobs/job-queue";
+import { startJobRuntime } from "@/lib/server/jobs/job-worker-runtime";
+import { uuidv7 } from "@/lib/shared/uuid";
+
+const url = process.env.PG_TEST_URL;
+const itPg = url ? it : it.skip;
+
+describe("job-worker-runtime (PG_TEST_URL)", () => {
+  let schema = "";
+  afterEach(async () => {
+    if (!url || !schema) return;
+    const c = postgres(url, { max: 1, onnotice: () => {} });
+    await c.unsafe(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+    await c.end();
+    schema = "";
+  });
+
+  itPg("registrerad handler kör ett skickat jobb; stop() stänger", async () => {
+    schema = `pgboss_test_${uuidv7().replace(/-/g, "")}`;
+    const got: unknown[] = [];
+    const rt = await startJobRuntime({
+      connectionString: url!,
+      schema,
+      handlers: { [JOB_QUEUES.emailDispatch]: async (job) => { got.push(job.data); } },
+    });
+    try {
+      // Skicka via en separat boss-instans mot samma schema (som en router skulle).
+      const sender = createJobQueue({ connectionString: url!, schema });
+      sender.on("error", () => {});
+      await startJobQueue(sender);
+      await sender.send(JOB_QUEUES.emailDispatch, { to: "domstol@ex.se" });
+      await sender.stop({ graceful: false });
+      for (let i = 0; i < 100 && got.length === 0; i++) await new Promise((r) => setTimeout(r, 100));
+      expect(got).toEqual([{ to: "domstol@ex.se" }]);
+    } finally {
+      await rt.stop();
+    }
+  }, 60_000);
+
+  itPg("kö utan handler konsumeras inte (jobbet ligger kvar)", async () => {
+    schema = `pgboss_test_${uuidv7().replace(/-/g, "")}`;
+    const rt = await startJobRuntime({ connectionString: url!, schema, handlers: {} });
+    try {
+      const sender = createJobQueue({ connectionString: url!, schema });
+      sender.on("error", () => {});
+      await startJobQueue(sender);
+      const id = await sender.send(JOB_QUEUES.fortnoxSync, { x: 1 });
+      await new Promise((r) => setTimeout(r, 1500));
+      const job = id ? await sender.getJobById(JOB_QUEUES.fortnoxSync, id) : null;
+      // Ingen worker → jobbet är inte completed (created/retry, ej done).
+      expect(job?.state).not.toBe("completed");
+      await sender.stop({ graceful: false });
+    } finally {
+      await rt.stop();
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
## Vad

**Fas 2 av #504.** Server-first-runtimen startar nu jobb-kön + dess workers.
pg-boss ÄR worker-loopen (`boss.work` pollar/claim:ar/ack:ar/retry:ar) — här
wiras livscykeln in i runtimen.

- `src/lib/server/jobs/job-worker-runtime.ts` — `startJobRuntime({ connectionString,
  schema, handlers })`: createJobQueue + startJobQueue + en `boss.work`-worker per
  kö som har en handler. `JobHandler`/`JobHandlers`-typer (Fas 3 fyller kartan).
  Returnerar `stop()` (graceful). Obligatorisk `error`-lyssnare.
- `src/bin/server-first.ts` — startar kön **best-effort** på boot (en kö-hicka får
  aldrig ta ned HTTP-serveringen) och stoppar den gracefully vid SIGTERM/SIGINT
  ihop med `api.close()`.
- Test (PG-gated): registrerad handler kör skickat jobb; kö utan handler
  konsumeras ej; `stop()` stänger.

## Verifierat

Den **kompilerade** server-first-binären (`bun build --compile`) bootar, serverar
HTTP **och** startar pg-boss mot riktig Postgres (`[server-first] jobb-kö startad
(pg-boss)`) — deploy-vägen funkar i kompilerat läge. Plus `typecheck`/`knip`/
`deps:check`/`lint`/`duplicates` rena; `test:cov` 90.09 % rader / 84.59 %
funktioner (golv 88.10/83.50, 0 fail). Worker-runtime-testet körs mot riktig
Postgres i CI:s "Repository (Postgres)"-jobb.

## Nästa
Fas 3: handlers (smtp-utskick / Fortnox / regelmotor) kopplas in i `handlers`-kartan.

Refs #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)