### PR TITLE
feat(server): köbackad e-post-port i server-first (durabelt utskick)

### DIFF
--- a/src/bin/server-first.ts
+++ b/src/bin/server-first.ts
@@ -20,6 +20,7 @@
 import { serveFetchHandler } from "@/lib/server/http/node-http-adapter";
 import { buildServerFirstApi, loadServerFirstConfig } from "@/lib/server/http/server-first-api";
 import { startJobRuntime, type JobRuntime } from "@/lib/server/jobs/job-worker-runtime";
+import { buildServerFirstJobHandlers, loadSmtpConfigFromEnv } from "@/lib/server/jobs/server-first-handlers";
 
 function log(msg: string): void {
   console.log(`[server-first] ${msg}`);
@@ -30,7 +31,9 @@ function main(): void {
     process.stdout.write(
       "ava server-first (#410, ADR 0016)\n\n" +
         "tRPC-over-HTTP mot Postgres med server-verifierad principal.\n\n" +
-        "Env: AVA_DATABASE_URL, AVA_ORGANIZATION_ID, AVA_HTTP_PORT, AVA_HTTP_HOST\n",
+        "Env: AVA_DATABASE_URL, AVA_ORGANIZATION_ID, AVA_HTTP_PORT, AVA_HTTP_HOST\n" +
+        "Jobb-kö (#504): pg-boss på samma DB. E-postutskick aktiveras när\n" +
+        "AVA_SMTP_HOST/PORT/USER/PASS/FROM (+ valfri AVA_SMTP_SECURE) är satta.\n",
     );
     return;
   }
@@ -45,10 +48,12 @@ function main(): void {
   log(`lyssnar på ${config.httpHost}:${config.httpPort} (org ${config.organizationId})`);
 
   // Jobb-kö (#504): best-effort start — en kö-hicka får ALDRIG ta ned HTTP-
-  // serveringen. Tom handler-karta tills Fas 3 (utskick/Fortnox/regler).
+  // serveringen. Handlers per konfigurerad integration (e-post via AVA_SMTP_*).
+  const smtp = loadSmtpConfigFromEnv();
+  const handlers = buildServerFirstJobHandlers(smtp ? { smtp } : {});
   let jobRuntime: JobRuntime | null = null;
-  void startJobRuntime({ connectionString: config.databaseUrl })
-    .then((rt) => { jobRuntime = rt; log("jobb-kö startad (pg-boss)"); })
+  void startJobRuntime({ connectionString: config.databaseUrl, handlers })
+    .then((rt) => { jobRuntime = rt; log(`jobb-kö startad (pg-boss; ${Object.keys(handlers).length} handlers)`); })
     .catch((err) => log(`jobb-kö start misslyckades (fortsätter utan): ${String(err)}`));
 
   for (const sig of ["SIGTERM", "SIGINT"] as const) {

--- a/src/bin/server-first.ts
+++ b/src/bin/server-first.ts
@@ -17,9 +17,11 @@
  *   AVA_HTTP_HOST         (default 127.0.0.1)
  */
 
+import { noopPorts } from "@/lib/server/adapters/noop-ports";
 import { serveFetchHandler } from "@/lib/server/http/node-http-adapter";
 import { buildServerFirstApi, loadServerFirstConfig } from "@/lib/server/http/server-first-api";
 import { startJobRuntime, type JobRuntime } from "@/lib/server/jobs/job-worker-runtime";
+import { QueueBackedEmailSender } from "@/lib/server/jobs/queue-backed-email-sender";
 import { buildServerFirstJobHandlers, loadSmtpConfigFromEnv } from "@/lib/server/jobs/server-first-handlers";
 
 function log(msg: string): void {
@@ -39,9 +41,16 @@ function main(): void {
   }
 
   const config = loadServerFirstConfig();
+
+  // E-post-porten köar durabelt på pg-boss (#504). Boss:en hämtas lazy — den
+  // startas best-effort NEDAN, efter att API:t byggts. Porten skapas här uppe.
+  let jobRuntime: JobRuntime | null = null;
+  const ports = { ...noopPorts, email: new QueueBackedEmailSender(() => jobRuntime?.boss ?? null) };
+
   const api = buildServerFirstApi({
     databaseUrl: config.databaseUrl,
     organizationId: config.organizationId,
+    ports,
     onError: (err) => log(`router-fel: ${String(err)}`),
   });
   const server = serveFetchHandler(api.handler, { port: config.httpPort, hostname: config.httpHost });
@@ -51,7 +60,6 @@ function main(): void {
   // serveringen. Handlers per konfigurerad integration (e-post via AVA_SMTP_*).
   const smtp = loadSmtpConfigFromEnv();
   const handlers = buildServerFirstJobHandlers(smtp ? { smtp } : {});
-  let jobRuntime: JobRuntime | null = null;
   void startJobRuntime({ connectionString: config.databaseUrl, handlers })
     .then((rt) => { jobRuntime = rt; log(`jobb-kö startad (pg-boss; ${Object.keys(handlers).length} handlers)`); })
     .catch((err) => log(`jobb-kö start misslyckades (fortsätter utan): ${String(err)}`));

--- a/src/lib/server/jobs/handlers/email-dispatch-handler.ts
+++ b/src/lib/server/jobs/handlers/email-dispatch-handler.ts
@@ -1,0 +1,31 @@
+/**
+ * E-postutskicks-handler (#504 Fas 3) — konsumerar `email-dispatch`-kön och
+ * skickar mejlet via en injicerad `EmailSender` (smtp-sender i produktion).
+ *
+ * pg-boss äger durabiliteten: kastar handlern (SMTP-fel) retry:ar pg-boss med
+ * backoff och dead-letter:ar efter `retryLimit`. Idempotens: skicka samma jobb
+ * en gång — pg-boss levererar varje jobb till EN worker via lease/SKIP LOCKED.
+ *
+ * Payloaden är ett färdigbyggt mejl (`{to,subject,text}`); att BYGGA mejlet ur
+ * en faktura hör hemma hos enqueue:aren (routern) — handlern är generisk send.
+ * Zod vid parsegränsen (#187): job.data är otypad tills den parsas här.
+ */
+
+import type { Job } from "pg-boss";
+import { z } from "zod";
+import type { EmailSender } from "@/lib/server/integrations/email/email-sender";
+import type { JobHandler } from "../job-worker-runtime";
+
+const emailJobSchema = z.object({
+  to: z.string().min(1),
+  subject: z.string(),
+  text: z.string(),
+});
+
+/** Bygg en handler som validerar payloaden och skickar via `sender`. */
+export function createEmailDispatchHandler(sender: EmailSender): JobHandler {
+  return async (job: Job): Promise<void> => {
+    const msg = emailJobSchema.parse(job.data);
+    await sender.sendMail(msg);
+  };
+}

--- a/src/lib/server/jobs/job-worker-runtime.ts
+++ b/src/lib/server/jobs/job-worker-runtime.ts
@@ -9,7 +9,7 @@
  * (redo att ta emot jobb) men ingen handler konsumerar ännu.
  */
 
-import type { Job } from "pg-boss";
+import type { Job, PgBoss } from "pg-boss";
 import { JOB_QUEUES, type JobQueueName, createJobQueue, startJobQueue } from "./job-queue";
 
 /** En handler kör ETT jobb. Kastar → pg-boss retry:ar (backoff) → dead-letter. */
@@ -19,6 +19,8 @@ export type JobHandler = (job: Job) => Promise<void>;
 export type JobHandlers = Partial<Record<JobQueueName, JobHandler>>;
 
 export interface JobRuntime {
+  /** Den startade pg-boss-instansen (för enqueue, t.ex. QueueBackedEmailSender). */
+  boss: PgBoss;
   /** Stoppa pollingen och stäng pg-boss-anslutningen (graceful). */
   stop(): Promise<void>;
 }
@@ -42,7 +44,7 @@ export async function startJobRuntime(opts: JobRuntimeOptions): Promise<JobRunti
   boss.on("error", (err) => console.error("[job-queue] fel:", err));
   await startJobQueue(boss);
   await registerWorkers(boss, opts.handlers ?? {});
-  return { stop: () => boss.stop({ graceful: true }) };
+  return { boss, stop: () => boss.stop({ graceful: true }) };
 }
 
 /** Registrera en `boss.work`-worker per kö som har en handler. */

--- a/src/lib/server/jobs/queue-backed-email-sender.ts
+++ b/src/lib/server/jobs/queue-backed-email-sender.ts
@@ -1,0 +1,30 @@
+/**
+ * `QueueBackedEmailSender` (#504 Fas 3) — `IEmailSender`-porten för server-first
+ * som KÖAR mejlet durabelt på pg-boss (`email-dispatch`) i st.f. att skicka det
+ * synkront. `email-dispatch-handler` plockar och skickar via smtp-sender, med
+ * pg-boss retry/backoff/dead-letter. Routrar anropar `ctx.ports.email.send(...)`
+ * som vanligt — durabiliteten är transparent.
+ *
+ * Boss:en hämtas lazy (`getBoss`): porten skapas i composition-rooten INNAN
+ * jobb-kön startats (best-effort, efter att API:t byggts), så vi får inte hålla
+ * en boss-referens vid konstruktion. Saknas boss vid send → tydligt fel
+ * (routern returnerar det till anroparen).
+ */
+
+import type { PgBoss } from "pg-boss";
+import type { IEmailSender, SendEmailInput } from "@/lib/server/ports";
+import { JOB_QUEUES } from "./job-queue";
+
+export class QueueBackedEmailSender implements IEmailSender {
+  constructor(private readonly getBoss: () => PgBoss | null) {}
+
+  async send(input: SendEmailInput): Promise<void> {
+    const boss = this.getBoss();
+    if (!boss) throw new Error("jobb-kön är inte redo — e-post kunde inte köas");
+    await boss.send(JOB_QUEUES.emailDispatch, {
+      to: input.to,
+      subject: input.subject,
+      text: input.text,
+    });
+  }
+}

--- a/src/lib/server/jobs/server-first-handlers.ts
+++ b/src/lib/server/jobs/server-first-handlers.ts
@@ -1,0 +1,42 @@
+/**
+ * Job-handler-registret för server-first-runtimen (#504 Fas 3). Bygger
+ * `JobHandlers`-kartan som `startJobRuntime` registrerar. En kö får en worker
+ * BARA när dess integration är konfigurerad (annars körs kön men konsumeras ej).
+ *
+ * Idag: e-postutskick (smtp-sender) när AVA_SMTP_* är satt. Fortnox-sync +
+ * regelmotor-handlers slotas in här i takt med att deras config/triggers byggs.
+ */
+
+import { createSmtpSender, type SmtpConfig } from "@/lib/server/integrations/email/smtp-sender";
+import { createEmailDispatchHandler } from "./handlers/email-dispatch-handler";
+import { JOB_QUEUES } from "./job-queue";
+import type { JobHandlers } from "./job-worker-runtime";
+
+export interface JobHandlerConfig {
+  /** SMTP-konfig för e-postutskick. Saknas → ingen email-worker registreras. */
+  smtp?: SmtpConfig;
+}
+
+/** Bygg handler-kartan ur den tillgängliga integrations-konfigen. */
+export function buildServerFirstJobHandlers(cfg: JobHandlerConfig): JobHandlers {
+  const handlers: JobHandlers = {};
+  if (cfg.smtp) {
+    handlers[JOB_QUEUES.emailDispatch] = createEmailDispatchHandler(createSmtpSender(cfg.smtp));
+  }
+  return handlers;
+}
+
+/**
+ * Läs SMTP-konfig ur env (server-first-deployen). Returnerar undefined om någon
+ * obligatorisk nyckel saknas → e-postutskick avregistreras tyst (best-effort).
+ */
+export function loadSmtpConfigFromEnv(env: Record<string, string | undefined> = process.env): SmtpConfig | undefined {
+  const host = env.AVA_SMTP_HOST;
+  const port = env.AVA_SMTP_PORT;
+  const user = env.AVA_SMTP_USER;
+  const pass = env.AVA_SMTP_PASS;
+  const from = env.AVA_SMTP_FROM;
+  if (!host || !port || !user || !pass || !from) return undefined;
+  const cfg: SmtpConfig = { host, port: Number(port), user, pass, from };
+  return env.AVA_SMTP_SECURE ? { ...cfg, secure: env.AVA_SMTP_SECURE === "true" } : cfg;
+}

--- a/test/unit/server/jobs/email-dispatch-handler.test.ts
+++ b/test/unit/server/jobs/email-dispatch-handler.test.ts
@@ -1,0 +1,71 @@
+/**
+ * E-postutskicks-handler + handler-registret (#504 Fas 3). Rena enhetstester
+ * (ingen Postgres): handlern validerar payloaden, skickar via injicerad sender,
+ * och propagerar fel (→ pg-boss retry). Registret kopplar in email-handlern bara
+ * när SMTP är konfigurerat; SMTP-env-läsaren kräver alla nycklar.
+ */
+
+import type { Job } from "pg-boss";
+import { describe, it, expect, vi } from "vitest-compat";
+import type { EmailSender } from "@/lib/server/integrations/email/email-sender";
+import { createEmailDispatchHandler } from "@/lib/server/jobs/handlers/email-dispatch-handler";
+import { JOB_QUEUES } from "@/lib/server/jobs/job-queue";
+import { buildServerFirstJobHandlers, loadSmtpConfigFromEnv } from "@/lib/server/jobs/server-first-handlers";
+
+const job = (data: unknown): Job => ({ id: "j1", name: "email-dispatch", data } as unknown as Job);
+
+describe("createEmailDispatchHandler", () => {
+  it("validerar payloaden och skickar mejlet", async () => {
+    const sendMail = vi.fn(async () => ({ messageId: "<m1>" }));
+    const sender: EmailSender = { sendMail };
+    await createEmailDispatchHandler(sender)(job({ to: "domstol@ex.se", subject: "Faktura F-1", text: "Bifogat." }));
+    expect(sendMail).toHaveBeenCalledWith({ to: "domstol@ex.se", subject: "Faktura F-1", text: "Bifogat." });
+  });
+
+  it("ogiltig payload → kastar (zod) utan att skicka", async () => {
+    const sendMail = vi.fn(async () => ({ messageId: "x" }));
+    await expect(createEmailDispatchHandler({ sendMail })(job({ subject: "x" }))).rejects.toThrow();
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it("propagerar sänd-fel (→ pg-boss retry/dead-letter)", async () => {
+    const sender: EmailSender = { sendMail: vi.fn(async () => { throw new Error("550 relay denied"); }) };
+    await expect(
+      createEmailDispatchHandler(sender)(job({ to: "x@y.se", subject: "s", text: "t" })),
+    ).rejects.toThrow(/relay denied/);
+  });
+});
+
+describe("buildServerFirstJobHandlers", () => {
+  const smtp = { host: "smtp.ex.se", port: 587, user: "u", pass: "p", from: "noreply@ex.se" };
+
+  it("registrerar email-handlern när SMTP finns", () => {
+    const handlers = buildServerFirstJobHandlers({ smtp });
+    expect(typeof handlers[JOB_QUEUES.emailDispatch]).toBe("function");
+  });
+
+  it("ingen email-handler utan SMTP", () => {
+    expect(buildServerFirstJobHandlers({})).toEqual({});
+  });
+});
+
+describe("loadSmtpConfigFromEnv", () => {
+  const full = {
+    AVA_SMTP_HOST: "smtp.ex.se", AVA_SMTP_PORT: "465", AVA_SMTP_USER: "u",
+    AVA_SMTP_PASS: "p", AVA_SMTP_FROM: "noreply@ex.se",
+  };
+
+  it("läser alla nycklar → SmtpConfig (port som number)", () => {
+    expect(loadSmtpConfigFromEnv(full)).toEqual({ host: "smtp.ex.se", port: 465, user: "u", pass: "p", from: "noreply@ex.se" });
+  });
+
+  it("AVA_SMTP_SECURE styr secure-flaggan", () => {
+    expect(loadSmtpConfigFromEnv({ ...full, AVA_SMTP_SECURE: "true" })).toMatchObject({ secure: true });
+    expect(loadSmtpConfigFromEnv({ ...full, AVA_SMTP_SECURE: "false" })).toMatchObject({ secure: false });
+  });
+
+  it("saknad nyckel → undefined (avregistrerar tyst)", () => {
+    const { AVA_SMTP_PASS: _omit, ...partial } = full;
+    expect(loadSmtpConfigFromEnv(partial)).toBeUndefined();
+  });
+});

--- a/test/unit/server/jobs/queue-backed-email-sender.test.ts
+++ b/test/unit/server/jobs/queue-backed-email-sender.test.ts
@@ -1,0 +1,41 @@
+/**
+ * `QueueBackedEmailSender` (#504 Fas 3) — IEmailSender-porten som köar mejlet på
+ * pg-boss. Rena enhetstester (ingen Postgres): send köar ett email-dispatch-jobb
+ * med rätt payload; saknad boss → tydligt fel; lazy getter läses per send.
+ */
+
+import type { PgBoss } from "pg-boss";
+import { describe, it, expect, vi } from "vitest-compat";
+import { JOB_QUEUES } from "@/lib/server/jobs/job-queue";
+import { QueueBackedEmailSender } from "@/lib/server/jobs/queue-backed-email-sender";
+
+function fakeBoss() {
+  const send = vi.fn(async () => "job-1");
+  return { boss: { send } as unknown as PgBoss, send };
+}
+
+describe("QueueBackedEmailSender", () => {
+  it("köar ett email-dispatch-jobb med {to,subject,text}", async () => {
+    const { boss, send } = fakeBoss();
+    const sender = new QueueBackedEmailSender(() => boss);
+    await sender.send({ to: "domstol@ex.se", subject: "Faktura F-1", text: "Bifogat.", html: "<p>ignoreras</p>" });
+    expect(send).toHaveBeenCalledWith(JOB_QUEUES.emailDispatch, {
+      to: "domstol@ex.se", subject: "Faktura F-1", text: "Bifogat.",
+    });
+  });
+
+  it("kastar tydligt när kön inte är redo (ingen boss)", async () => {
+    const sender = new QueueBackedEmailSender(() => null);
+    await expect(sender.send({ to: "x@y.se", subject: "s", text: "t" })).rejects.toThrow(/kön är inte redo/);
+  });
+
+  it("läser boss lazy per send (redo först efter att kön startat)", async () => {
+    const { boss, send } = fakeBoss();
+    let current: PgBoss | null = null;
+    const sender = new QueueBackedEmailSender(() => current);
+    await expect(sender.send({ to: "x@y.se", subject: "s", text: "t" })).rejects.toThrow();
+    current = boss; // kön startade
+    await sender.send({ to: "x@y.se", subject: "s", text: "t" });
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Vad

Kompletterar e-post-vertikalen i **#504**: server-first:ens `ctx.ports.email`
går från **no-op → durabelt köat** utskick. Maskineriet är därmed helt:
`router → ports.email.send → pg-boss (email-dispatch) → handler → smtp-sender`
med retry/backoff/dead-letter. Routrar anropar `ports.email.send(...)` precis som
förr — durabiliteten är transparent.

- `queue-backed-email-sender.ts` — `IEmailSender` som `boss.send(email-dispatch,
  {to,subject,text})`. Boss:en hämtas **lazy** (porten skapas i composition-rooten
  innan kön startat best-effort).
- `job-worker-runtime.ts` — `JobRuntime` exponerar nu `boss` (för enqueue).
- `bin/server-first.ts` — wirar email-porten (lazy boss-ref) i `ports` innan
  `buildServerFirstApi`; jobb-kön startar best-effort som förut.

## Återstår (steer)
Faktisk enqueue-trigger (en router som anropar `ports.email.send`, t.ex.
`invoiceDispatch`) + dispatch-post-livscykeln i den asynkrona kön; samt
Fortnox-sync- och regelmotor-handlers.

## Verifierat
`typecheck`/`knip`/`deps:check`/`lint`/`duplicates` rena; `test:cov` 90.11 %
rader / 84.66 % funktioner (0 fail). Rena enhetstester för porten (enqueue-
payload, ej-redo-fel, lazy boss).

Refs #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)