### PR TITLE
feat(server): köbackad e-post-port i server-first (durabelt utskick)

### DIFF
--- a/src/bin/server-first.ts
+++ b/src/bin/server-first.ts
@@ -17,9 +17,11 @@
  *   AVA_HTTP_HOST         (default 127.0.0.1)
  */
 
+import { noopPorts } from "@/lib/server/adapters/noop-ports";
 import { serveFetchHandler } from "@/lib/server/http/node-http-adapter";
 import { buildServerFirstApi, loadServerFirstConfig } from "@/lib/server/http/server-first-api";
 import { startJobRuntime, type JobRuntime } from "@/lib/server/jobs/job-worker-runtime";
+import { QueueBackedEmailSender } from "@/lib/server/jobs/queue-backed-email-sender";
 import { buildServerFirstJobHandlers, loadSmtpConfigFromEnv } from "@/lib/server/jobs/server-first-handlers";
 
 function log(msg: string): void {
@@ -39,9 +41,16 @@ function main(): void {
   }
 
   const config = loadServerFirstConfig();
+
+  // E-post-porten köar durabelt på pg-boss (#504). Boss:en hämtas lazy — den
+  // startas best-effort NEDAN, efter att API:t byggts. Porten skapas här uppe.
+  let jobRuntime: JobRuntime | null = null;
+  const ports = { ...noopPorts, email: new QueueBackedEmailSender(() => jobRuntime?.boss ?? null) };
+
   const api = buildServerFirstApi({
     databaseUrl: config.databaseUrl,
     organizationId: config.organizationId,
+    ports,
     onError: (err) => log(`router-fel: ${String(err)}`),
   });
   const server = serveFetchHandler(api.handler, { port: config.httpPort, hostname: config.httpHost });
@@ -51,7 +60,6 @@ function main(): void {
   // serveringen. Handlers per konfigurerad integration (e-post via AVA_SMTP_*).
   const smtp = loadSmtpConfigFromEnv();
   const handlers = buildServerFirstJobHandlers(smtp ? { smtp } : {});
-  let jobRuntime: JobRuntime | null = null;
   void startJobRuntime({ connectionString: config.databaseUrl, handlers })
     .then((rt) => { jobRuntime = rt; log(`jobb-kö startad (pg-boss; ${Object.keys(handlers).length} handlers)`); })
     .catch((err) => log(`jobb-kö start misslyckades (fortsätter utan): ${String(err)}`));

--- a/src/lib/server/jobs/job-worker-runtime.ts
+++ b/src/lib/server/jobs/job-worker-runtime.ts
@@ -9,7 +9,7 @@
  * (redo att ta emot jobb) men ingen handler konsumerar ännu.
  */
 
-import type { Job } from "pg-boss";
+import type { Job, PgBoss } from "pg-boss";
 import { JOB_QUEUES, type JobQueueName, createJobQueue, startJobQueue } from "./job-queue";
 
 /** En handler kör ETT jobb. Kastar → pg-boss retry:ar (backoff) → dead-letter. */
@@ -19,6 +19,8 @@ export type JobHandler = (job: Job) => Promise<void>;
 export type JobHandlers = Partial<Record<JobQueueName, JobHandler>>;
 
 export interface JobRuntime {
+  /** Den startade pg-boss-instansen (för enqueue, t.ex. QueueBackedEmailSender). */
+  boss: PgBoss;
   /** Stoppa pollingen och stäng pg-boss-anslutningen (graceful). */
   stop(): Promise<void>;
 }
@@ -42,7 +44,7 @@ export async function startJobRuntime(opts: JobRuntimeOptions): Promise<JobRunti
   boss.on("error", (err) => console.error("[job-queue] fel:", err));
   await startJobQueue(boss);
   await registerWorkers(boss, opts.handlers ?? {});
-  return { stop: () => boss.stop({ graceful: true }) };
+  return { boss, stop: () => boss.stop({ graceful: true }) };
 }
 
 /** Registrera en `boss.work`-worker per kö som har en handler. */

--- a/src/lib/server/jobs/queue-backed-email-sender.ts
+++ b/src/lib/server/jobs/queue-backed-email-sender.ts
@@ -1,0 +1,30 @@
+/**
+ * `QueueBackedEmailSender` (#504 Fas 3) — `IEmailSender`-porten för server-first
+ * som KÖAR mejlet durabelt på pg-boss (`email-dispatch`) i st.f. att skicka det
+ * synkront. `email-dispatch-handler` plockar och skickar via smtp-sender, med
+ * pg-boss retry/backoff/dead-letter. Routrar anropar `ctx.ports.email.send(...)`
+ * som vanligt — durabiliteten är transparent.
+ *
+ * Boss:en hämtas lazy (`getBoss`): porten skapas i composition-rooten INNAN
+ * jobb-kön startats (best-effort, efter att API:t byggts), så vi får inte hålla
+ * en boss-referens vid konstruktion. Saknas boss vid send → tydligt fel
+ * (routern returnerar det till anroparen).
+ */
+
+import type { PgBoss } from "pg-boss";
+import type { IEmailSender, SendEmailInput } from "@/lib/server/ports";
+import { JOB_QUEUES } from "./job-queue";
+
+export class QueueBackedEmailSender implements IEmailSender {
+  constructor(private readonly getBoss: () => PgBoss | null) {}
+
+  async send(input: SendEmailInput): Promise<void> {
+    const boss = this.getBoss();
+    if (!boss) throw new Error("jobb-kön är inte redo — e-post kunde inte köas");
+    await boss.send(JOB_QUEUES.emailDispatch, {
+      to: input.to,
+      subject: input.subject,
+      text: input.text,
+    });
+  }
+}

--- a/test/unit/server/jobs/queue-backed-email-sender.test.ts
+++ b/test/unit/server/jobs/queue-backed-email-sender.test.ts
@@ -1,0 +1,41 @@
+/**
+ * `QueueBackedEmailSender` (#504 Fas 3) — IEmailSender-porten som köar mejlet på
+ * pg-boss. Rena enhetstester (ingen Postgres): send köar ett email-dispatch-jobb
+ * med rätt payload; saknad boss → tydligt fel; lazy getter läses per send.
+ */
+
+import type { PgBoss } from "pg-boss";
+import { describe, it, expect, vi } from "vitest-compat";
+import { JOB_QUEUES } from "@/lib/server/jobs/job-queue";
+import { QueueBackedEmailSender } from "@/lib/server/jobs/queue-backed-email-sender";
+
+function fakeBoss() {
+  const send = vi.fn(async () => "job-1");
+  return { boss: { send } as unknown as PgBoss, send };
+}
+
+describe("QueueBackedEmailSender", () => {
+  it("köar ett email-dispatch-jobb med {to,subject,text}", async () => {
+    const { boss, send } = fakeBoss();
+    const sender = new QueueBackedEmailSender(() => boss);
+    await sender.send({ to: "domstol@ex.se", subject: "Faktura F-1", text: "Bifogat.", html: "<p>ignoreras</p>" });
+    expect(send).toHaveBeenCalledWith(JOB_QUEUES.emailDispatch, {
+      to: "domstol@ex.se", subject: "Faktura F-1", text: "Bifogat.",
+    });
+  });
+
+  it("kastar tydligt när kön inte är redo (ingen boss)", async () => {
+    const sender = new QueueBackedEmailSender(() => null);
+    await expect(sender.send({ to: "x@y.se", subject: "s", text: "t" })).rejects.toThrow(/kön är inte redo/);
+  });
+
+  it("läser boss lazy per send (redo först efter att kön startat)", async () => {
+    const { boss, send } = fakeBoss();
+    let current: PgBoss | null = null;
+    const sender = new QueueBackedEmailSender(() => current);
+    await expect(sender.send({ to: "x@y.se", subject: "s", text: "t" })).rejects.toThrow();
+    current = boss; // kön startade
+    await sender.send({ to: "x@y.se", subject: "s", text: "t" });
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Vad

Kompletterar e-post-vertikalen i **#504**: server-first:ens `ctx.ports.email`
går från **no-op → durabelt köat** utskick. Maskineriet är därmed helt:
`router → ports.email.send → pg-boss (email-dispatch) → handler → smtp-sender`
med retry/backoff/dead-letter.

- `queue-backed-email-sender.ts` — `IEmailSender` → `boss.send(email-dispatch,
  {to,subject,text})`. Boss:en hämtas **lazy** (porten skapas innan kön startat).
- `job-worker-runtime.ts` — `JobRuntime` exponerar nu `boss` (för enqueue).
- `bin/server-first.ts` — wirar email-porten (lazy boss-ref) i `ports` innan
  `buildServerFirstApi`; jobb-kön startar best-effort.

## Återstår (steer)
Enqueue-trigger (router som anropar `ports.email.send`) + dispatch-livscykeln;
samt Fortnox-/regelmotor-handlers.

## Verifierat
`typecheck`/`knip`/`deps:check`/`lint`/`duplicates` rena; `test:cov` 90.11 %
rader / 84.66 % funktioner. Rena enhetstester för porten.

Refs #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)