### PR TITLE
test(server): cover noop-ports + all emit-helpers; ratchet coverage floors

### DIFF
--- a/test/unit/server/adapters/noop-ports.test.ts
+++ b/test/unit/server/adapters/noop-ports.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tester för demo-lägets no-op-ports. Read-only-semantik: alla side-effect-
+ * portar är tysta no-ops, och sök returnerar ett tomt men välformat svar.
+ * Täcker hela `noopPorts`-aggregatet så att composition-root:en (DemoBootstrap)
+ * kan wira in det utan överraskningar.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import {
+  noopEmail,
+  noopDocumentAnalyzer,
+  noopSearchIndex,
+  noopPaymentScanner,
+  noopContentStore,
+  noopPorts,
+} from "@/lib/server/adapters/noop-ports";
+
+describe("noop-ports", () => {
+  it("noopEmail.send är en tyst no-op", async () => {
+    await expect(
+      noopEmail.send({ to: "a@b.se", subject: "x", text: "y" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("noopDocumentAnalyzer.analyze är en tyst no-op", async () => {
+    await expect(noopDocumentAnalyzer.analyze("doc-1")).resolves.toBeUndefined();
+  });
+
+  it("noopSearchIndex.search returnerar tomt men välformat svar", async () => {
+    const res = await noopSearchIndex.search("fråga", "org-1");
+    expect(res.hits).toEqual([]);
+    expect(res.estimatedTotalHits).toBe(0);
+  });
+
+  it("noopSearchIndex.upsert + remove är tysta no-ops", async () => {
+    await expect(
+      noopSearchIndex.upsert({
+        id: "d1", fileName: "f.pdf", content: "c", matterId: "m1",
+        matterNumber: "2026-0001", matterTitle: "T", organizationId: "org-1",
+      }),
+    ).resolves.toBeUndefined();
+    await expect(noopSearchIndex.remove("d1")).resolves.toBeUndefined();
+  });
+
+  it("noopPaymentScanner.scan är en tyst no-op", async () => {
+    await expect(noopPaymentScanner.scan("org-1")).resolves.toBeUndefined();
+  });
+
+  it("noopContentStore.write är en tyst no-op", async () => {
+    await expect(
+      noopContentStore.write("documents/content/d1.pdf", new Uint8Array([1, 2, 3])),
+    ).resolves.toBeUndefined();
+  });
+
+  it("noopPorts aggregerar alla no-op-portar", () => {
+    expect(noopPorts.email).toBe(noopEmail);
+    expect(noopPorts.documentAnalyzer).toBe(noopDocumentAnalyzer);
+    expect(noopPorts.searchIndex).toBe(noopSearchIndex);
+    expect(noopPorts.paymentScanner).toBe(noopPaymentScanner);
+    expect(noopPorts.content).toBe(noopContentStore);
+  });
+});

--- a/test/unit/server/events/emit.test.ts
+++ b/test/unit/server/events/emit.test.ts
@@ -51,6 +51,46 @@ describe("emit-helpers", () => {
     expect(arg.payload).toEqual({ entryId: "t1", minutes: 90 });
   });
 
+  it("täcker alla emit-helpers (varje typ → ett event)", async () => {
+    const { ctx, emitFn } = makeCtx();
+    await emit.matterUpdated(ctx, "m1", { title: "ny" });
+    await emit.matterArchived(ctx, "m1");
+    await emit.contactCreated(ctx, { id: "c1", name: "Anna" });
+    await emit.contactUpdated(ctx, "c1", { name: "Anna B" });
+    await emit.contactDeleted(ctx, "c1");
+    await emit.documentUploaded(ctx, { id: "d1", fileName: "f.pdf", matterId: "m1" });
+    await emit.documentDeleted(ctx, { id: "d1", matterId: "m1" });
+    await emit.documentAnalyzed(ctx, { id: "d1", matterId: "m1" }, { kind: "kontrakt" });
+    await emit.invoiceCreated(ctx, { id: "inv1", matterId: "m1", amount: 1000 });
+    await emit.invoiceSent(ctx, "inv1", "m1");
+    await emit.invoiceWrittenOff(ctx, "inv1", "m1", 250);
+    await emit.timeEntryUpdated(ctx, { id: "t1", matterId: "m1" });
+    await emit.timeEntryDeleted(ctx, "t1", "m1");
+    await emit.kostnadsrakningGenerated(ctx, "m1", {
+      documentId: "d1", fileName: "kr.pdf", totalInclVat: 5000,
+      huvudforhandlingMinutes: 120, organizationId: "org-1",
+    });
+    await emit.paymentDue(ctx, { invoiceId: "inv1" }, "m1");
+    await emit.paymentOverdue(ctx, { invoiceId: "inv1" });
+    await emit.userAction(ctx, { action: "login" });
+
+    const types = emitFn.mock.calls.map((c: unknown[]) => (c[0] as { type: string }).type);
+    expect(types).toEqual([
+      "matter.updated", "matter.archived",
+      "contact.created", "contact.updated", "contact.deleted",
+      "document.uploaded", "document.deleted", "document.analyzed",
+      "invoice.created", "invoice.sent", "invoice.written_off",
+      "time-entry.updated", "time-entry.deleted",
+      "kostnadsrakning.generated",
+      "payment.due", "payment.overdue",
+      "user.action",
+    ]);
+    // System-källan sätts för payment-scan-events; user-källan för övriga.
+    const paymentDue = emitFn.mock.calls.find((c: unknown[]) => (c[0] as { type: string }).type === "payment.due")![0] as Record<string, unknown>;
+    expect(paymentDue.source).toBe("system");
+    expect(paymentDue.actor).toEqual({ kind: "system", id: "payment-scan" });
+  });
+
   it("emit-fel kraschar INTE caller (safeEmit sväljer)", async () => {
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const ctx = {

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -52,9 +52,13 @@ const FAST = process.argv.includes("--fast");
 // låses just under 85%-milstolpen, LINE oförändrat ~0.5% marginal) → 88.1 rader
 // / 83.5 funktioner (#27: demoStaticParamsBySeedId + billing-grenarna i static-
 // params lyfte lokalt till 88.58% rader / 85.12% funktioner; LINE dras upp,
-// FUNC oförändrat ~1.6% marginal).
-const LINE_FLOOR = 0.881;
-const FUNC_FLOOR = 0.835;
+// FUNC oförändrat ~1.6% marginal) → 88.8 rader / 83.8 funktioner (#27:
+// noop-ports + alla emit-helpers täckta efter server-first-migreringen, som
+// dessutom tog bort otestad git/OPFS/mem-fs-kod → lokalt 90.50% rader / 85.11%
+// funktioner; LINE-marginalen krymps mot den deterministiska kod-borttagningen
+// medan FUNC behåller ~1.3% Node-version-marginal).
+const LINE_FLOOR = 0.888;
+const FUNC_FLOOR = 0.838;
 
 /**
  * SERIAL_FILES — testfiler som SYNKRONT spawnar en barnprocess via


### PR DESCRIPTION
A #27 ratchet-step closing two server-side function-coverage gaps surfaced after the server-first migration.

## What's added
- **`noop-ports.ts`** (demo read-only adapters) had **zero tests** — new suite exercises all seven no-ops (`email.send`, `documentAnalyzer.analyze`, `searchIndex.search/upsert/remove`, `paymentScanner.scan`, `content.write`) plus the `noopPorts` aggregate.
- **`emit.ts`** only tested 4 of its event-helpers — added a sweep firing every helper once, asserting the `user` vs `system` source split. The `ReadOnlyError`-swallow branch (read-only-eventlog trap) stays covered.

## Ratchet
The server-first migration (#420/#421) also deleted a large body of untested git/OPFS/mem-fs code, lifting local line coverage to **90.50%**. Floors tighten:
- lines `0.881 → 0.888`
- functions `0.835 → 0.838`

keeping the ~1.3% Node-version margin on functions (the conservative convention for CI Node 24 vs local).

## Verification
- typecheck + eslint + knip + dep-cruiser + jscpd ✅
- `bun run test:cov` — 3074 + 19 pass; **90.50% lines (floor 88.80%) / 85.11% functions (floor 83.80%)** ✅

Test-only + tooling change; no app/runtime code touched.

Refs #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)