### PR TITLE
fix(login): ersätt inaktuell self-hosted-text med OIDC-hänvisning

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 /**
- * `/login` — demo-läget:s användarväljare. Self-hosted lägger till
- * username/password-fält i nästa iteration.
+ * `/login` — demo-lägets användarväljare. ENDAST demo: i self-hosted sker
+ * inloggning via OIDC (ADR 0009) — oauth2-proxy gat:ar nginx-fronten och
+ * dirigerar till byråns IdP innan appen laddas, och principalen binds i
+ * bootstrappen (`resolveOidcLogin`). Den här sidan nås aldrig i det flödet.
  *
- * Användaren väljer ett konto, skriver "demo" som lösenord, klickar
+ * Demo: användaren väljer ett konto, skriver "demo" som lösenord, klickar
  * "Logga in" → `principalId` + `organizationId` sparas i `ava.firma`
  * localStorage och vi navigerar till `/`.
  *
@@ -19,6 +21,7 @@ import { DEMO_PASSWORD } from "../../../tooling/demo-config";
 type State =
   | { kind: "loading" }
   | { kind: "ready"; meta: DemoMeta }
+  | { kind: "info"; message: string }
   | { kind: "error"; message: string };
 
 async function initLogin(
@@ -28,10 +31,11 @@ async function initLogin(
   const cfg = loadFirmaConfig();
   if (cfg.tier !== "demo") {
     setState({
-      kind: "error",
+      kind: "info",
       message:
-        "Self-hosted-login ännu ej implementerad — använd nginx auth_basic " +
-        "via /settings tills vidare.",
+        "Self-hosted: inloggning sker via din identitetsleverantör (OIDC). " +
+        "oauth2-proxy dirigerar dig dit automatiskt — den här sidan används " +
+        "bara i demo-läget.",
     });
     return;
   }
@@ -95,6 +99,19 @@ export default function LoginPage() {
           <p className="text-sm text-red-700 bg-red-50 border border-red-200 rounded p-3">
             {state.message}
           </p>
+        )}
+        {state.kind === "info" && (
+          <div className="space-y-3">
+            <p className="text-sm text-blue-800 bg-blue-50 border border-blue-200 rounded p-3">
+              {state.message}
+            </p>
+            <a
+              href={`${process.env.NEXT_PUBLIC_DEMO_BASE_PATH ?? ""}/`}
+              className="inline-block w-full text-center rounded-md bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 text-sm font-medium"
+            >
+              Till startsidan
+            </a>
+          </div>
         )}
         {state.kind === "ready" && (
           <LoginForm

--- a/test/unit/app/login/page.test.tsx
+++ b/test/unit/app/login/page.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * Tester för `/login` (#516) — demo-lägets användarväljare + self-hosted-info.
+ *
+ * Self-hosted: inloggning sker via OIDC (oauth2-proxy) innan appen laddas →
+ * sidan visar bara en informativ hänvisning, inte den gamla "nginx
+ * auth_basic"-texten.
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest-compat";
+import LoginPage from "@/app/login/page";
+
+let tier = "demo";
+vi.mock("@/lib/client/firma/firma-config", () => ({
+  loadFirmaConfig: () => ({ tier, repo: "ulrik-s/ava-demo" }),
+  patchFirmaConfig: vi.fn(),
+}));
+
+vi.mock("@/lib/client/demo/demo-meta", () => ({
+  loadDemoMeta: vi.fn(async () => ({
+    organizationName: "Demo Byrå AB",
+    organizationId: "demo-firma",
+    users: [
+      { id: "u-anna", name: "Anna", title: "Advokat", role: "ADMIN", email: "anna@demo.se" },
+      { id: "u-bo", name: "Bo", title: null, role: "LAWYER", email: "bo@demo.se" },
+    ],
+  })),
+}));
+
+beforeEach(() => {
+  tier = "demo";
+});
+
+describe("/login", () => {
+  it("demo-läge: laddar användarväljaren med konton + lösenordsfält", async () => {
+    render(<LoginPage />);
+    await waitFor(() => expect(screen.getByText("Demo Byrå AB")).toBeInTheDocument());
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getByText(/Anna/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Logga in/ })).toBeInTheDocument();
+  });
+
+  it("self-hosted: visar OIDC-info + länk till startsidan, INTE auth_basic", async () => {
+    tier = "self-hosted";
+    render(<LoginPage />);
+    await waitFor(() => expect(screen.getByText(/identitetsleverantör \(OIDC\)/)).toBeInTheDocument());
+    expect(screen.getByRole("link", { name: /Till startsidan/ })).toBeInTheDocument();
+    // Den pensionerade legacy-texten ska vara borta.
+    expect(screen.queryByText(/auth_basic/)).toBeNull();
+    expect(screen.queryByText(/ännu ej implementerad/)).toBeNull();
+    // Ingen användarväljare i self-hosted.
+    expect(screen.queryByRole("combobox")).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #516.

`/login` visade för self-hosted-tier: *"Self-hosted-login ännu ej implementerad — använd nginx auth_basic via /settings tills vidare."* — inaktuellt på två sätt efter ADR 0009 / server-first:

1. **"ännu ej implementerad"** — OIDC-login ÄR byggd (`fetchOidcClaims` via oauth2-proxy → allowlist → principal-bindning i `demo-bootstrap.tsx`; overlay `docker-compose.oidc.yml`, #222/#223).
2. **"nginx auth_basic"** — htpasswd/auth_basic är den *legacy*-modell ADR 0009 ersätter med OIDC.

Self-hosted gat:as dessutom av oauth2-proxy i nginx-fronten → `/login` nås aldrig i det flödet (sidan är demo-only).

## Ändringar
- Ny `info`-state: neutral OIDC-hänvisning + "Till startsidan"-länk (i stället för röd error-box).
- Uppdaterad JSDoc (ingen username/password — det är OIDC).
- Nytt unit-test för login-sidan (saknades helt → även #27-täckning).

## Verifiering
- typecheck + eslint + knip + dep-cruiser + jscpd ✅
- `bun run test:cov` — 90.71% rader / 85.38% funktioner (golv 88.80/83.80) ✅
- `bun run build:demo` ✅ (demon intakt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)