### PR TITLE
feat(server): git-backad content-store för server-first (#518 fas 1)

### DIFF
--- a/src/bin/server-first.ts
+++ b/src/bin/server-first.ts
@@ -15,8 +15,11 @@
  *   AVA_ORGANIZATION_ID   (obligatorisk)  byråns org-id
  *   AVA_HTTP_PORT         (default 3001)
  *   AVA_HTTP_HOST         (default 127.0.0.1)
+ *   AVA_CONTENT_DIR       (valfri) katalog för dokument-bytes (server-side
+ *                         lagring; krävs för dokumentklassificering, #518)
  */
 
+import { loadContentDirFromEnv, makeContentStore } from "@/lib/server/adapters/git-content-store";
 import { noopPorts } from "@/lib/server/adapters/noop-ports";
 import { serveFetchHandler } from "@/lib/server/http/node-http-adapter";
 import { buildServerFirstApi, loadServerFirstConfig } from "@/lib/server/http/server-first-api";
@@ -33,7 +36,8 @@ function main(): void {
     process.stdout.write(
       "ava server-first (#410, ADR 0016)\n\n" +
         "tRPC-over-HTTP mot Postgres med server-verifierad principal.\n\n" +
-        "Env: AVA_DATABASE_URL, AVA_ORGANIZATION_ID, AVA_HTTP_PORT, AVA_HTTP_HOST\n" +
+        "Env: AVA_DATABASE_URL, AVA_ORGANIZATION_ID, AVA_HTTP_PORT, AVA_HTTP_HOST,\n" +
+        "     AVA_CONTENT_DIR (dokument-bytes på disk, #518)\n" +
         "Jobb-kö (#504): pg-boss på samma DB. E-postutskick aktiveras när\n" +
         "AVA_SMTP_HOST/PORT/USER/PASS/FROM (+ valfri AVA_SMTP_SECURE) är satta.\n",
     );
@@ -45,7 +49,15 @@ function main(): void {
   // E-post-porten köar durabelt på pg-boss (#504). Boss:en hämtas lazy — den
   // startas best-effort NEDAN, efter att API:t byggts. Porten skapas här uppe.
   let jobRuntime: JobRuntime | null = null;
-  const ports = { ...noopPorts, email: new QueueBackedEmailSender(() => jobRuntime?.boss ?? null) };
+  // Dokument-bytes lagras i ett git-repo (`AVA_CONTENT_DIR`) så server-side-jobb
+  // (klassificering, #518) kan läsa innehållet OCH en annan server kan `git pull`
+  // för backup. Saknas dir:t → no-op (ingen server-side-lagring), som tidigare.
+  const contentStore = makeContentStore(loadContentDirFromEnv());
+  const ports = {
+    ...noopPorts,
+    email: new QueueBackedEmailSender(() => jobRuntime?.boss ?? null),
+    ...(contentStore ? { content: contentStore } : {}),
+  };
 
   const api = buildServerFirstApi({
     databaseUrl: config.databaseUrl,

--- a/src/lib/server/adapters/git-content-store.ts
+++ b/src/lib/server/adapters/git-content-store.ts
@@ -1,0 +1,104 @@
+/**
+ * `GitContentStore` (#518) — git-backad `IContentStore` för server-first.
+ *
+ * `AVA_CONTENT_DIR` är ett git-repo: varje skrivning committas, så en annan
+ * server kan `git pull` dokument-byte:sen som backup, och git-historiken ger
+ * versionering. Innehållet lagras platt (content-adresserat av anroparen —
+ * `storagePath` = `documents/content/<sha256>`); **mappstrukturen bor i
+ * Postgres** (`document_folders`), inte i repo-trädet. Postgres backas upp
+ * separat (pg_dump).
+ *
+ * Demo/web rör aldrig detta — de använder `noopContentStore`.
+ *
+ * `storagePath` saneras mot path-traversal (måste lösa sig UNDER rot-dir:t).
+ */
+
+import { execFile } from "node:child_process";
+import { access, mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, relative, resolve } from "node:path";
+import { promisify } from "node:util";
+import type { IContentStore } from "../ports";
+
+const exec = promisify(execFile);
+
+/** Committar `relPath` i `repoDir` (init:ar repot vid behov). Injicerbar för test. */
+export type GitCommitter = (repoDir: string, relPath: string, message: string) => Promise<void>;
+
+async function hasGitDir(dir: string): Promise<boolean> {
+  try { await access(resolve(dir, ".git")); return true; } catch { return false; }
+}
+
+/**
+ * Standard-committer: shellar ut till `git` (samma binär som driver
+ * git-http-backend i web-containern). Init:ar repot om det saknas och
+ * hoppar commit om inget stagats (identiskt content-adresserat innehåll).
+ */
+export const gitCommit: GitCommitter = async (repoDir, relPath, message) => {
+  if (!(await hasGitDir(repoDir))) {
+    await exec("git", ["-C", repoDir, "init", "-q"]);
+  }
+  await exec("git", ["-C", repoDir, "add", "--", relPath]);
+  try {
+    // exit 0 = inget stagat → identiskt innehåll, hoppa commit.
+    await exec("git", ["-C", repoDir, "diff", "--cached", "--quiet"]);
+    return;
+  } catch {
+    // exit≠0 = stagade ändringar finns → committa nedan.
+  }
+  await exec("git", [
+    "-C", repoDir,
+    "-c", "user.name=AVA", "-c", "user.email=ava@localhost",
+    "commit", "-q", "-m", message,
+  ]);
+};
+
+export class GitContentStore implements IContentStore {
+  private readonly root: string;
+
+  constructor(rootDir: string, private readonly committer: GitCommitter = gitCommit) {
+    this.root = resolve(rootDir);
+  }
+
+  /** Lös + validera att `storagePath` hamnar under rot-dir:t (anti-traversal). */
+  private safeResolve(storagePath: string): string | null {
+    const abs = resolve(this.root, storagePath);
+    const rel = relative(this.root, abs);
+    if (rel.startsWith("..") || resolve(this.root, rel) !== abs) return null;
+    return abs;
+  }
+
+  async write(storagePath: string, bytes: Uint8Array): Promise<void> {
+    const abs = this.safeResolve(storagePath);
+    if (!abs) throw new Error(`GitContentStore: ogiltig storagePath "${storagePath}"`);
+    await mkdir(dirname(abs), { recursive: true });
+    await writeFile(abs, bytes);
+    await this.committer(this.root, relative(this.root, abs), `content: ${storagePath}`);
+  }
+
+  async read(storagePath: string): Promise<Uint8Array | null> {
+    const abs = this.safeResolve(storagePath);
+    if (!abs) return null;
+    try {
+      return new Uint8Array(await readFile(abs));
+    } catch {
+      return null; // saknas / oläsbar → null (anroparen hanterar)
+    }
+  }
+}
+
+/**
+ * Läs content-dir:t ur env. `AVA_CONTENT_DIR` pekar på git-repot där
+ * server-first lagrar dokument-bytes. Saknas den → `undefined` (anroparen
+ * faller tillbaka till no-op-store, dvs ingen server-side-lagring).
+ */
+export function loadContentDirFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): string | undefined {
+  const dir = env.AVA_CONTENT_DIR?.trim();
+  return dir ? resolve(dir) : undefined;
+}
+
+/** Bygg server-first content-store: `GitContentStore` om dir satt, annars null. */
+export function makeContentStore(contentDir: string | undefined): GitContentStore | null {
+  return contentDir ? new GitContentStore(contentDir) : null;
+}

--- a/src/lib/server/adapters/noop-ports.ts
+++ b/src/lib/server/adapters/noop-ports.ts
@@ -34,12 +34,13 @@ export const noopPaymentScanner: IPaymentScanner = {
 
 /**
  * No-op content-store: i demo/web skrivs dokument-bytes klient-sidigt via
- * FSA (`uploadDocumentToFsa`), aldrig server-sidigt — så detta är en tyst
- * no-op (konsistent med demo:ns read-only-semantik). Server-runtime:n
- * (git-peer) ersätter denna med en skrivande impl (`NodeContentStore`).
+ * FSA (`uploadDocumentToFsa`), aldrig server-sidigt — så write är en tyst
+ * no-op och read ger `null` (inget innehåll bor på servern). Server-first-
+ * runtime:n ersätter denna med `FsContentStore`.
  */
 export const noopContentStore: IContentStore = {
   async write() { /* no-op */ },
+  async read() { return null; },
 };
 
 export const noopPorts: IPorts = {

--- a/src/lib/server/ports.ts
+++ b/src/lib/server/ports.ts
@@ -99,11 +99,19 @@ export interface IPaymentScanner {
 export interface IContentStore {
   /**
    * Skriv `bytes` till `storagePath` (repo-relativ, t.ex.
-   * `documents/content/<id>.eml`). Server-runtime:n skriver in i
-   * git-working-copy:n så de commit:as + push:as; demo/web är no-op
-   * (innehåll skrivs klient-sidigt via FSA).
+   * `documents/content/<id>.eml`). Server-first-runtime:n skriver till sitt
+   * content-dir (`FsContentStore`); demo/web är no-op (innehåll skrivs
+   * klient-sidigt via FSA).
    */
   write(storagePath: string, bytes: Uint8Array): Promise<void>;
+
+  /**
+   * Läs tillbaka `bytes` för `storagePath`, eller `null` om de saknas.
+   * Server-side bruk: dokument-klassificerings-jobbet (#518) läser bytes
+   * för text-extraktion. Demo/web returnerar `null` (innehållet bor
+   * klient-sidigt, inte på servern).
+   */
+  read(storagePath: string): Promise<Uint8Array | null>;
 }
 
 // ─── Aggregat ──────────────────────────────────────────────────────

--- a/test/unit/server/adapters/git-content-store.test.ts
+++ b/test/unit/server/adapters/git-content-store.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tester för `GitContentStore` (#518) — git-backad content-store för
+ * server-first. Enhetstester injicerar en stub-committer (snabba, kräver ej
+ * git); ett integrationstest kör riktiga `gitCommit` (git finns i CI/dev).
+ */
+
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest-compat";
+import {
+  GitContentStore,
+  gitCommit,
+  loadContentDirFromEnv,
+  makeContentStore,
+} from "@/lib/server/adapters/git-content-store";
+
+const exec = promisify(execFile);
+
+describe("GitContentStore (stub committer)", () => {
+  let dir: string;
+  beforeEach(async () => { dir = await mkdtemp(join(tmpdir(), "ava-git-content-")); });
+  afterEach(async () => { await rm(dir, { recursive: true, force: true }); });
+
+  it("write skriver fil + committar; read returnerar samma bytes", async () => {
+    const committer = vi.fn(async () => {});
+    const store = new GitContentStore(dir, committer);
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    await store.write("documents/content/abc123", bytes);
+
+    expect(committer).toHaveBeenCalledTimes(1);
+    const [repoDir, relPath, message] = committer.mock.calls[0]!;
+    expect(repoDir).toBe(dir);
+    expect(relPath).toBe("documents/content/abc123");
+    expect(message).toContain("documents/content/abc123");
+
+    const read = await store.read("documents/content/abc123");
+    expect(Array.from(read!)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("read av saknad sökväg → null", async () => {
+    const store = new GitContentStore(dir, vi.fn(async () => {}));
+    expect(await store.read("documents/content/saknas")).toBeNull();
+  });
+
+  it("anti-traversal: write utanför roten kastar + committar inte", async () => {
+    const committer = vi.fn(async () => {});
+    const store = new GitContentStore(dir, committer);
+    await expect(store.write("../escape", new Uint8Array([1]))).rejects.toThrow(/ogiltig storagePath/);
+    expect(committer).not.toHaveBeenCalled();
+  });
+
+  it("anti-traversal: read utanför roten → null", async () => {
+    const store = new GitContentStore(dir, vi.fn(async () => {}));
+    expect(await store.read("../../etc/passwd")).toBeNull();
+  });
+});
+
+describe("gitCommit (riktig git)", () => {
+  let dir: string;
+  beforeEach(async () => { dir = await mkdtemp(join(tmpdir(), "ava-git-real-")); });
+  afterEach(async () => { await rm(dir, { recursive: true, force: true }); });
+
+  it("init:ar repot + committar bytes; git pull-bar historik", async () => {
+    const store = new GitContentStore(dir); // riktig gitCommit
+    await store.write("documents/content/h1", new Uint8Array([9, 9, 9]));
+
+    // En commit ska finnas, och fil-bytes ska vara läsbara.
+    const { stdout } = await exec("git", ["-C", dir, "log", "--oneline"]);
+    expect(stdout.trim().split("\n").length).toBe(1);
+    expect(Array.from(await readFile(join(dir, "documents/content/h1")))).toEqual([9, 9, 9]);
+
+    // Identiskt content-adresserat innehåll → ingen ny commit (inget stagat).
+    await store.write("documents/content/h1", new Uint8Array([9, 9, 9]));
+    const after = await exec("git", ["-C", dir, "log", "--oneline"]);
+    expect(after.stdout.trim().split("\n").length).toBe(1);
+  });
+
+  it("gitCommit exporteras som default-committer", () => {
+    expect(typeof gitCommit).toBe("function");
+  });
+});
+
+describe("loadContentDirFromEnv", () => {
+  it("returnerar absolut sökväg när AVA_CONTENT_DIR satt", () => {
+    expect(loadContentDirFromEnv({ AVA_CONTENT_DIR: "/var/ava/content" })).toBe("/var/ava/content");
+  });
+  it("undefined när env saknas/tom", () => {
+    expect(loadContentDirFromEnv({})).toBeUndefined();
+    expect(loadContentDirFromEnv({ AVA_CONTENT_DIR: "  " })).toBeUndefined();
+  });
+});
+
+describe("makeContentStore", () => {
+  it("undefined dir → null (ingen server-side-lagring)", () => {
+    expect(makeContentStore(undefined)).toBeNull();
+  });
+  it("dir → GitContentStore-instans", () => {
+    expect(makeContentStore("/tmp/ava")).toBeInstanceOf(GitContentStore);
+  });
+});

--- a/test/unit/server/adapters/noop-ports.test.ts
+++ b/test/unit/server/adapters/noop-ports.test.ts
@@ -52,6 +52,10 @@ describe("noop-ports", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("noopContentStore.read ger null (inget innehåll på servern)", async () => {
+    await expect(noopContentStore.read("documents/content/d1.pdf")).resolves.toBeNull();
+  });
+
   it("noopPorts aggregerar alla no-op-portar", () => {
     expect(noopPorts.email).toBe(noopEmail);
     expect(noopPorts.documentAnalyzer).toBe(noopDocumentAnalyzer);


### PR DESCRIPTION
Fas 1 av #518 (flytta LLM-dokumentklassificering till servern). Fundamentet: servern lagrar dokument-bytes i ett **git-repo** i stället för dagens no-op.

## Lagringsdesign (steer)
- **`AVA_CONTENT_DIR` = git-repo.** Varje skrivning committas → en annan server kan `git pull` byte:sen som **backup**; git-historik = versionering.
- Platta, **content-adresserade** bytes (`documents/content/<sha256>`). **Mappstrukturen bor i Postgres** (`document_folders`) — git-repot speglar den inte. DB backas upp separat (`pg_dump`).

## Ändringar
- `IContentStore.read(storagePath)` — servern kan läsa tillbaka bytes (för klassificerings-jobbet i senare fas). Demo/web → `null` (innehåll klient-sidigt). `noopContentStore.read` ger null.
- **`GitContentStore`**: `write` committar via injicerbar `gitCommit` (init:ar repot, hoppar commit när inget stagats = identiskt innehåll); `read` by path; anti-path-traversal.
- Wirad i `server-first.ts` via `AVA_CONTENT_DIR` (saknas → no-op, som förr) — isolerat till server-binären; demo orörd.

## Nästa faser (#518)
2. server-textextraktion (pdfjs/mammoth i Node) · 3. `ServerLlmExtractor` + ollama-profil · 4. `classify-document`-jobb + enqueue · 5. ta bort klient-web-llm.

## Verifiering
- typecheck + eslint + knip + dep-cruiser + jscpd ✅
- `bun run test:cov` — 90.73% rader / 85.43% funktioner (golv 88.80/83.80); inkl. riktig-git integrationstest (init/commit/dedup) ✅
- `bun run build:demo` ✅ (demon intakt)

Refs #518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)