### PR TITLE
feat(server): server-side classify-document-jobb via pg-boss (#518 fas 2)

### DIFF
--- a/src/bin/server-first.ts
+++ b/src/bin/server-first.ts
@@ -24,6 +24,7 @@ import { noopPorts } from "@/lib/server/adapters/noop-ports";
 import { serveFetchHandler } from "@/lib/server/http/node-http-adapter";
 import { buildServerFirstApi, loadServerFirstConfig } from "@/lib/server/http/server-first-api";
 import { startJobRuntime, type JobRuntime } from "@/lib/server/jobs/job-worker-runtime";
+import { QueueBackedDocumentAnalyzer } from "@/lib/server/jobs/queue-backed-document-analyzer";
 import { QueueBackedEmailSender } from "@/lib/server/jobs/queue-backed-email-sender";
 import { buildServerFirstJobHandlers, loadSmtpConfigFromEnv } from "@/lib/server/jobs/server-first-handlers";
 
@@ -56,6 +57,9 @@ function main(): void {
   const ports = {
     ...noopPorts,
     email: new QueueBackedEmailSender(() => jobRuntime?.boss ?? null),
+    // Dokumentklassificering (#518): `document.analyze` enqueue:ar ett
+    // classify-document-jobb durabelt på pg-boss i st.f. noop.
+    documentAnalyzer: new QueueBackedDocumentAnalyzer(() => jobRuntime?.boss ?? null, config.organizationId),
     ...(contentStore ? { content: contentStore } : {}),
   };
 
@@ -69,9 +73,13 @@ function main(): void {
   log(`lyssnar på ${config.httpHost}:${config.httpPort} (org ${config.organizationId})`);
 
   // Jobb-kö (#504): best-effort start — en kö-hicka får ALDRIG ta ned HTTP-
-  // serveringen. Handlers per konfigurerad integration (e-post via AVA_SMTP_*).
+  // serveringen. Handlers per konfigurerad integration (e-post via AVA_SMTP_*,
+  // dokumentklassificering via repos #518).
   const smtp = loadSmtpConfigFromEnv();
-  const handlers = buildServerFirstJobHandlers(smtp ? { smtp } : {});
+  const handlers = buildServerFirstJobHandlers({
+    ...(smtp ? { smtp } : {}),
+    documents: api.repos.documents,
+  });
   void startJobRuntime({ connectionString: config.databaseUrl, handlers })
     .then((rt) => { jobRuntime = rt; log(`jobb-kö startad (pg-boss; ${Object.keys(handlers).length} handlers)`); })
     .catch((err) => log(`jobb-kö start misslyckades (fortsätter utan): ${String(err)}`));

--- a/src/lib/client/llm/classify-document.ts
+++ b/src/lib/client/llm/classify-document.ts
@@ -15,18 +15,13 @@
  */
 
 import type { ILlmExtractor } from "@/lib/server/llm/llm-extractor";
+import { KNOWN_KINDS, type DocumentKind, guessFromFilename } from "@/lib/shared/document-kind";
 
-export const KNOWN_KINDS = [
-  "STAMNING",
-  "DOM",
-  "BEVIS",
-  "FULLMAKT",
-  "AVTAL",
-  "FAKTURA",
-  "RAPPORT",
-  "OKLASSIFICERAT",
-] as const;
-export type DocumentKind = (typeof KNOWN_KINDS)[number];
+// Kategorierna + filnamns-heuristiken bor numera i `lib/shared/document-kind`
+// (delas med server-jobbet, #518). Re-exporteras så befintliga importörer
+// (register-workers m.fl.) fortsätter peka hit.
+export { KNOWN_KINDS, guessFromFilename };
+export type { DocumentKind };
 
 export interface ClassifyInput {
   fileName: string;
@@ -53,16 +48,4 @@ export async function classifyDocument(input: ClassifyInput): Promise<DocumentKi
     }
   }
   return heuristic;
-}
-
-export function guessFromFilename(name: string): DocumentKind {
-  const lower = name.toLowerCase();
-  if (/(stamning|kallelse|stämning)/.test(lower)) return "STAMNING";
-  if (/(dom|beslut|tingsr|domstol)/.test(lower)) return "DOM";
-  if (/(bevis|fotografi|bilaga|exhibit)/.test(lower)) return "BEVIS";
-  if (/(fullmakt|poa|power)/.test(lower)) return "FULLMAKT";
-  if (/(avtal|kontrakt|hyres|köpe|köpeavtal)/.test(lower)) return "AVTAL";
-  if (/(faktura|invoice|kvitto|receipt)/.test(lower)) return "FAKTURA";
-  if (/(rapport|utlatande|utlåtande|expert)/.test(lower)) return "RAPPORT";
-  return "OKLASSIFICERAT";
 }

--- a/src/lib/server/http/server-first-api.ts
+++ b/src/lib/server/http/server-first-api.ts
@@ -37,6 +37,8 @@ export interface ServerFirstApiConfig {
 export interface ServerFirstApi {
   /** Fetch-handler att montera (t.ex. via `serveFetchHandler`). */
   handler: (req: Request) => Promise<Response>;
+  /** Typade repos ovanpå db:n — exponeras så jobb-handlers (#518) kan läsa/skriva. */
+  repos: ReturnType<typeof buildDrizzleRepositories>;
   /** Stäng db-poolen vid nedstängning. */
   close: () => Promise<void>;
 }
@@ -59,7 +61,7 @@ export function buildServerFirstApi(config: ServerFirstApiConfig): ServerFirstAp
     ...(config.endpoint ? { endpoint: config.endpoint } : {}),
     ...(config.onError ? { onError: config.onError } : {}),
   });
-  return { handler, close };
+  return { handler, repos, close };
 }
 
 /** Env-nycklar för den körbara entryn. */

--- a/src/lib/server/jobs/handlers/classify-document-handler.ts
+++ b/src/lib/server/jobs/handlers/classify-document-handler.ts
@@ -1,0 +1,52 @@
+/**
+ * `classify-document`-handler (#518) — klassificerar ett uppladdat dokument
+ * server-side och skriver tillbaka kategorin på dokumentet.
+ *
+ * Fas 2: klassificeringen är filnamns-heuristik (`guessFromFilename`) —
+ * deterministisk, ingen LLM, ingen modell-nedladdning. Fas 3 injicerar en
+ * LLM-backad `classify` (server-LLM via ollama) med samma signatur.
+ *
+ * Idempotent: kör om → samma kategori skrivs igen (ofarligt). Saknat dokument
+ * (raderat innan jobbet kördes) → tyst no-op.
+ */
+
+import { z } from "zod";
+import { type DocumentKind, guessFromFilename } from "@/lib/shared/document-kind";
+import type { Document } from "@/lib/shared/schemas/document";
+import type { DocumentRepository } from "../../repositories/document-repository";
+import type { JobHandler } from "../job-worker-runtime";
+
+const classifyJobSchema = z.object({
+  documentId: z.string(),
+  organizationId: z.string().optional(),
+});
+
+export interface ClassifyDocumentDeps {
+  /** Dokument-repo (läs hela raden + skriv tillbaka metadatan). */
+  documents: Pick<DocumentRepository, "getById" | "update">;
+  /** Klassificerare; default = filnamns-heuristik. Fas 3 injicerar LLM-varianten. */
+  classify?: (doc: { fileName: string }) => Promise<DocumentKind>;
+  /** Modell-etikett som sparas i `analysisModel`. */
+  model?: string;
+  /** Injicerbar nu-tid för deterministiska tester. */
+  now?: () => Date;
+}
+
+export function createClassifyDocumentHandler(deps: ClassifyDocumentDeps): JobHandler {
+  const classify = deps.classify ?? (async (doc) => guessFromFilename(doc.fileName));
+  const model = deps.model ?? "filename-heuristic";
+  const now = deps.now ?? (() => new Date());
+
+  return async (job): Promise<void> => {
+    const { documentId } = classifyJobSchema.parse(job.data);
+    const doc = await deps.documents.getById(documentId);
+    if (!doc) return; // raderat innan jobbet kördes → no-op
+    const kind = await classify({ fileName: (doc as Document).fileName });
+    await deps.documents.update(documentId, {
+      documentType: kind,
+      analyzedAt: now(),
+      analysisStatus: "DONE",
+      analysisModel: model,
+    } as unknown as Partial<Document>);
+  };
+}

--- a/src/lib/server/jobs/job-queue.ts
+++ b/src/lib/server/jobs/job-queue.ts
@@ -21,6 +21,7 @@ import { PgBoss } from "pg-boss";
 /** De server-sidiga jobb-köerna (Fas 3 kopplar in handlers). */
 export const JOB_QUEUES = {
   emailDispatch: "email-dispatch",
+  classifyDocument: "classify-document",
   fortnoxSync: "fortnox-sync",
   rulesTick: "rules-tick",
   outlookMirror: "outlook-mirror",

--- a/src/lib/server/jobs/queue-backed-document-analyzer.ts
+++ b/src/lib/server/jobs/queue-backed-document-analyzer.ts
@@ -1,0 +1,28 @@
+/**
+ * `QueueBackedDocumentAnalyzer` (#518) — `IDocumentAnalyzer`-porten för
+ * server-first som KÖAR ett `classify-document`-jobb durabelt på pg-boss i
+ * st.f. att klassificera synkront. `classify-document-handler` plockar och
+ * kör (filnamns-heuristik nu, server-LLM i Fas 3). Routrar anropar
+ * `ctx.ports.documentAnalyzer.analyze(documentId)` som vanligt
+ * (`document.analyze`, fire-and-forget) — durabiliteten är transparent.
+ *
+ * Boss:en hämtas lazy (`getBoss`): porten skapas i composition-rooten INNAN
+ * jobb-kön startats. Saknas boss vid enqueue → tydligt fel.
+ */
+
+import type { PgBoss } from "pg-boss";
+import type { IDocumentAnalyzer } from "@/lib/server/ports";
+import { JOB_QUEUES } from "./job-queue";
+
+export class QueueBackedDocumentAnalyzer implements IDocumentAnalyzer {
+  constructor(
+    private readonly getBoss: () => PgBoss | null,
+    private readonly organizationId: string,
+  ) {}
+
+  async analyze(documentId: string): Promise<void> {
+    const boss = this.getBoss();
+    if (!boss) throw new Error("jobb-kön är inte redo — dokumentet kunde inte köas för klassificering");
+    await boss.send(JOB_QUEUES.classifyDocument, { documentId, organizationId: this.organizationId });
+  }
+}

--- a/src/lib/server/jobs/server-first-handlers.ts
+++ b/src/lib/server/jobs/server-first-handlers.ts
@@ -8,6 +8,7 @@
  */
 
 import { createSmtpSender, type SmtpConfig } from "@/lib/server/integrations/email/smtp-sender";
+import { createClassifyDocumentHandler, type ClassifyDocumentDeps } from "./handlers/classify-document-handler";
 import { createEmailDispatchHandler } from "./handlers/email-dispatch-handler";
 import { JOB_QUEUES } from "./job-queue";
 import type { JobHandlers } from "./job-worker-runtime";
@@ -15,6 +16,8 @@ import type { JobHandlers } from "./job-worker-runtime";
 export interface JobHandlerConfig {
   /** SMTP-konfig för e-postutskick. Saknas → ingen email-worker registreras. */
   smtp?: SmtpConfig;
+  /** Dokument-repo för `classify-document`-jobbet (#518). Saknas → ingen classify-worker. */
+  documents?: ClassifyDocumentDeps["documents"];
 }
 
 /** Bygg handler-kartan ur den tillgängliga integrations-konfigen. */
@@ -22,6 +25,9 @@ export function buildServerFirstJobHandlers(cfg: JobHandlerConfig): JobHandlers 
   const handlers: JobHandlers = {};
   if (cfg.smtp) {
     handlers[JOB_QUEUES.emailDispatch] = createEmailDispatchHandler(createSmtpSender(cfg.smtp));
+  }
+  if (cfg.documents) {
+    handlers[JOB_QUEUES.classifyDocument] = createClassifyDocumentHandler({ documents: cfg.documents });
   }
   return handlers;
 }

--- a/src/lib/shared/document-kind.ts
+++ b/src/lib/shared/document-kind.ts
@@ -1,0 +1,34 @@
+/**
+ * Dokumentkategorier + filnamns-heuristik — delad mellan klient (web-llm-
+ * klassificerare) och server (`classify-document`-jobbet, #518). Ren, inga
+ * beroenden, så både `lib/client` och `lib/server` kan importera den.
+ */
+
+export const KNOWN_KINDS = [
+  "STAMNING",
+  "DOM",
+  "BEVIS",
+  "FULLMAKT",
+  "AVTAL",
+  "FAKTURA",
+  "RAPPORT",
+  "OKLASSIFICERAT",
+] as const;
+export type DocumentKind = (typeof KNOWN_KINDS)[number];
+
+/**
+ * Deterministisk fallback-klassificering ur filnamnet. Snabb och alltid
+ * tillgänglig — används direkt (server-first Fas 2) och som fallback när
+ * LLM:en är av/inte redo/svarar med skräp.
+ */
+export function guessFromFilename(name: string): DocumentKind {
+  const lower = name.toLowerCase();
+  if (/(stamning|kallelse|stämning)/.test(lower)) return "STAMNING";
+  if (/(dom|beslut|tingsr|domstol)/.test(lower)) return "DOM";
+  if (/(bevis|fotografi|bilaga|exhibit)/.test(lower)) return "BEVIS";
+  if (/(fullmakt|poa|power)/.test(lower)) return "FULLMAKT";
+  if (/(avtal|kontrakt|hyres|köpe|köpeavtal)/.test(lower)) return "AVTAL";
+  if (/(faktura|invoice|kvitto|receipt)/.test(lower)) return "FAKTURA";
+  if (/(rapport|utlatande|utlåtande|expert)/.test(lower)) return "RAPPORT";
+  return "OKLASSIFICERAT";
+}

--- a/test/unit/server/jobs/classify-document-handler.test.ts
+++ b/test/unit/server/jobs/classify-document-handler.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Tester för `classify-document`-handlern (#518). Stubbar repo:t; verifierar
+ * filnamns-heuristik → metadata-skrivning, no-op vid saknat dokument, samt
+ * injicerbar klassificerare (Fas 3:s LLM-väg).
+ */
+
+import type { Job } from "pg-boss";
+import { describe, expect, it, vi } from "vitest-compat";
+import { createClassifyDocumentHandler } from "@/lib/server/jobs/handlers/classify-document-handler";
+
+function jobFor(documentId: string): Job {
+  return { data: { documentId } } as unknown as Job;
+}
+
+describe("createClassifyDocumentHandler", () => {
+  it("klassificerar via filnamn + skriver tillbaka metadata", async () => {
+    const documents = {
+      getById: vi.fn(async () => ({ id: "d1", fileName: "Stämning.pdf" })),
+      update: vi.fn(async () => ({})),
+    };
+    const handler = createClassifyDocumentHandler({ documents: documents as never });
+    await handler(jobFor("d1"));
+
+    expect(documents.getById).toHaveBeenCalledWith("d1");
+    const [id, patch] = documents.update.mock.calls[0]!;
+    expect(id).toBe("d1");
+    expect(patch).toMatchObject({
+      documentType: "STAMNING",
+      analysisStatus: "DONE",
+      analysisModel: "filename-heuristic",
+    });
+    expect((patch as { analyzedAt: Date }).analyzedAt).toBeInstanceOf(Date);
+  });
+
+  it("saknat dokument (raderat) → ingen skrivning", async () => {
+    const documents = {
+      getById: vi.fn(async () => null),
+      update: vi.fn(async () => ({})),
+    };
+    const handler = createClassifyDocumentHandler({ documents: documents as never });
+    await handler(jobFor("borta"));
+    expect(documents.update).not.toHaveBeenCalled();
+  });
+
+  it("använder injicerad classify (Fas 3 LLM-väg) + model-etikett", async () => {
+    const documents = {
+      getById: vi.fn(async () => ({ id: "d1", fileName: "x.bin" })),
+      update: vi.fn(async () => ({})),
+    };
+    const classify = vi.fn(async () => "AVTAL" as const);
+    const handler = createClassifyDocumentHandler({ documents: documents as never, classify, model: "ollama:llama" });
+    await handler(jobFor("d1"));
+    expect(classify).toHaveBeenCalledWith({ fileName: "x.bin" });
+    expect(documents.update.mock.calls[0]![1]).toMatchObject({ documentType: "AVTAL", analysisModel: "ollama:llama" });
+  });
+});

--- a/test/unit/server/jobs/queue-backed-document-analyzer.test.ts
+++ b/test/unit/server/jobs/queue-backed-document-analyzer.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Tester för `QueueBackedDocumentAnalyzer` (#518) — enqueue:ar classify-jobb
+ * på pg-boss; tydligt fel om kön inte är redo.
+ */
+
+import type { PgBoss } from "pg-boss";
+import { describe, expect, it, vi } from "vitest-compat";
+import { QueueBackedDocumentAnalyzer } from "@/lib/server/jobs/queue-backed-document-analyzer";
+
+describe("QueueBackedDocumentAnalyzer", () => {
+  it("enqueue:ar classify-document med documentId + organizationId", async () => {
+    const send = vi.fn(async () => "job-1");
+    const analyzer = new QueueBackedDocumentAnalyzer(() => ({ send } as unknown as PgBoss), "org-1");
+    await analyzer.analyze("doc-9");
+    expect(send).toHaveBeenCalledWith("classify-document", { documentId: "doc-9", organizationId: "org-1" });
+  });
+
+  it("kastar tydligt när boss saknas (kön ej redo)", async () => {
+    const analyzer = new QueueBackedDocumentAnalyzer(() => null, "org-1");
+    await expect(analyzer.analyze("doc-9")).rejects.toThrow(/jobb-kön är inte redo/);
+  });
+});

--- a/test/unit/shared/document-kind.test.ts
+++ b/test/unit/shared/document-kind.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Tester för `document-kind` — delad filnamns-heuristik (#518).
+ */
+
+import { describe, expect, it } from "vitest-compat";
+import { KNOWN_KINDS, guessFromFilename } from "@/lib/shared/document-kind";
+
+describe("guessFromFilename", () => {
+  const cases: Array<[string, string]> = [
+    ["Stämning Tingsrätten.pdf", "STAMNING"],
+    ["kallelse-2026.pdf", "STAMNING"],
+    ["Dom 2026-01.pdf", "DOM"],
+    ["beslut.pdf", "DOM"],
+    ["bevis-foto.jpg", "BEVIS"],
+    ["fullmakt.pdf", "FULLMAKT"],
+    ["hyresavtal.docx", "AVTAL"],
+    ["faktura-123.pdf", "FAKTURA"],
+    ["expertrapport.pdf", "RAPPORT"],
+    ["anteckningar.txt", "OKLASSIFICERAT"],
+  ];
+  for (const [name, expected] of cases) {
+    it(`"${name}" → ${expected}`, () => {
+      expect(guessFromFilename(name)).toBe(expected);
+    });
+  }
+
+  it("alla utfall finns i KNOWN_KINDS", () => {
+    for (const [name] of cases) {
+      expect(KNOWN_KINDS).toContain(guessFromFilename(name));
+    }
+  });
+});


### PR DESCRIPTION
Fas 2 av #518. Hela dokumentklassificerings-pipelinen körs nu **server-side via jobb-kön** — ingen klient-LLM inblandad.

När klienten anropar `document.analyze` (efter upload) enqueue:ar server-first ett durabelt `classify-document`-jobb på pg-boss; en worker klassificerar och skriver tillbaka kategorin. Fas 2 använder **filnamns-heuristik** (deterministisk, ingen modell-nedladdning); **Fas 3 injicerar server-LLM:en (ollama)** via samma `classify`-söm.

## Ändringar
- **`lib/shared/document-kind`** — `KNOWN_KINDS`/`DocumentKind`/`guessFromFilename` flyttade hit (delas klient↔server; `client/llm/classify-document` re-exporterar → inga importör-ändringar).
- **`JOB_QUEUES.classifyDocument`** + **`createClassifyDocumentHandler`** (läser dokument via repo → klassificerar → skriver `documentType`/`analyzedAt`/`analysisStatus`/`analysisModel`; no-op om dokumentet raderats).
- **`QueueBackedDocumentAnalyzer`** — `IDocumentAnalyzer` som enqueue:ar (speglar `QueueBackedEmailSender`).
- **`buildServerFirstApi`** exponerar `repos`; `server-first.ts` wirar `documentAnalyzer`-porten + registrerar classify-handlern.

## Trigger
`document.analyze` anropar redan `ctx.ports.documentAnalyzer.analyze` fire-and-forget — server-first byter bara porten noop → queue-backed.

## Verifiering
- typecheck + eslint + knip + dep-cruiser + jscpd ✅
- `bun run test:cov` — 90.74% rader / 85.45% funktioner (golv 88.80/83.80) ✅
- `bun run build:demo` ✅ (demon intakt; demo använder fortsatt klient-pipelinen via `demoDocumentAnalyzer`)

## Kvar i #518
Fas 3: server-textextraktion (pdfjs/mammoth i Node) + `ServerLlmExtractor` (ollama bakom docker-profil) → injicera `classify`. Fas 4: ta bort klient-web-llm.

Refs #518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)