### PR TITLE
feat(server): content-adresserad dokument-byte-upload/download (#518, ADR 0023)

### DIFF
--- a/docs/adr/0023-dokument-bytes-content-adresserat.md
+++ b/docs/adr/0023-dokument-bytes-content-adresserat.md
@@ -1,0 +1,58 @@
+# ADR 0023 — Dokument-bytes: innehålls-adresserade, klient-cachade, versionerade
+
+Status: Accepterad (2026-06-18)
+
+## Kontext
+
+Server-first (ADR 0016) flyttade entiteterna till Postgres men lämnade
+dokument-*bytes* (PDF/DOCX) i ett limbo: den gamla git-first-modellen lagrade
+dem i en klonad FSA-working-copy och versionerade via git-commits — allt det
+pensionerades (#420/#501/#502). `IContentStore` var en no-op och öppna/editera/
+spara-flödet i koden pekade fortfarande mot den borttagna FSA-mappen.
+
+Två sorters data kräver två cache-strategier:
+- **Entiteter** (metadata) — server-Postgres, klient-cache i IndexedDB
+  (`CachingSyncDataStore`), delta-synk via `change_log` (ADR 0017).
+- **Bytes** (filinnehåll) — stora binärer som inte ska delta-synkas.
+
+## Beslut
+
+1. **Lagring:** dokument-bytes lagras i ett **git-repo** på servern
+   (`AVA_CONTENT_DIR`, `GitContentStore`, #518 fas 1). En annan server kan
+   `git pull` för backup; git-historik = versionering på disk. Postgres backas
+   upp separat (`pg_dump`).
+
+2. **Innehålls-adressering:** byte:s lagras under `documents/content/<sha256>`
+   — **immutabelt**. En redigering skapar en NY hash → ny blob; dokumentets
+   `storagePath` repekas. Gamla blobben behålls. Ger dedup + perfekt
+   cache-barhet (cachen invalideras aldrig) + naturlig versionshistorik.
+
+3. **Klient-cache:** en byte-cache i IndexedDB nyckel-ad på sha256. Läsa
+   (öppna) = cache-hit eller `downloadContent` → cacha. Skriva (spara) = hasha
+   lokalt → cacha → köa `uploadContent` (mutation-kön, offline-säker).
+
+4. **Versionering:** explicit — varje `uploadContent` ger en ny version
+   (`documents.version` bumpas av reconcile-konventionen; en explicit
+   version→hash-lista exponeras i UI:t i ett senare steg). Konflikt mellan två
+   offline-redigeringar → last-write-wins på `storagePath` men BÅDA blobbarna
+   bevaras → ingen data förloras (juridiskt krav).
+
+5. **Mekanik (server-API, denna ADR:s första steg):**
+   - `document.uploadContent(documentId, contentBase64)` → content-adressera →
+     `content.write` → repeka `storagePath` + bump version + `analysisStatus:
+     PENDING` + trigga server-klassificering (jobb-kö).
+   - `document.downloadContent(documentId)` → `content.read(storagePath)` →
+     base64.
+   - Binärt skickas som base64 över tRPC/JSON (`lib/shared/content-address`,
+     universell sha256 + base64).
+
+## Konsekvenser
+
+- **Bra:** ett byte-lager med backup (git pull), versionering, dedup och en
+  trivial klient-cache. Alla edit-mekanismer (helper-rundtur, ner/upp, in-app)
+  landar på samma två primitiver (läs-by-hash / skriv-by-hash).
+- **Pris:** klient→server byte-upload + öppna-flöde + edit-mekanik + versions-UI
+  byggs i steg; `markExternallyEdited`/FSA-vägen retire:as när server-first-
+  öppna-flödet är på plats.
+- **Ej:** ingen klient-Postgres, ingen två-Postgres-replikering (se cache-
+  resonemanget — `change_log`-sömmen är enklare och redan byggd).

--- a/src/lib/server/routers/document/core.ts
+++ b/src/lib/server/routers/document/core.ts
@@ -5,6 +5,7 @@
 
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import { base64ToBytes, bytesToBase64, contentStoragePath, sha256Hex } from "@/lib/shared/content-address";
 import { isJunkFileName } from "@/lib/shared/junk-files";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import type { Document } from "@/lib/shared/schemas/document";
@@ -153,6 +154,48 @@ export const coreProcedures = {
         console.error("analyze failed:", e),
       );
       return { ok: true };
+    }),
+
+  /**
+   * `uploadContent` (#518, ADR 0023) — ta emot dokument-bytes (base64) och
+   * lagra dem INNEHÅLLS-ADRESSERAT (sha256). Repekar dokumentets `storagePath`
+   * till den nya hashen → ny immutabel version (repo.update bumpar `version`
+   * automatiskt, reconcile-konvention). Nytt innehåll → klassificera om
+   * (analysen körs server-side via jobb-kön). Gamla bytes behålls (git-historik).
+   */
+  uploadContent: orgProcedure
+    .input(z.object({ documentId: z.string(), contentBase64: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      await assertDocAccess(ctx, input.documentId);
+      const bytes = base64ToBytes(input.contentBase64);
+      const storagePath = contentStoragePath(await sha256Hex(bytes));
+      await ctx.ports.content.write(storagePath, bytes);
+      const updated = await ctx.repos.documents.update(input.documentId, {
+        storagePath,
+        sizeBytes: bytes.byteLength,
+        fileSize: bytes.byteLength,
+        analysisStatus: "PENDING",
+      } as unknown as Partial<Document>);
+      ctx.ports.documentAnalyzer.analyze(input.documentId).catch((e: unknown) =>
+        console.error("classify after upload failed:", e),
+      );
+      return updated;
+    }),
+
+  /**
+   * `downloadContent` (#518, ADR 0023) — läs tillbaka dokument-bytes (base64)
+   * från content-store:n via dokumentets `storagePath`. Klienten cachar
+   * resultatet innehålls-adresserat (immutabelt → cacha för evigt).
+   */
+  downloadContent: orgProcedure
+    .input(z.object({ documentId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      await assertDocAccess(ctx, input.documentId);
+      const doc = (await ctx.repos.documents.getById(input.documentId)) as Document | null;
+      if (!doc) throw new TRPCError({ code: "NOT_FOUND" });
+      const bytes = await ctx.ports.content.read(doc.storagePath);
+      if (!bytes) throw new TRPCError({ code: "NOT_FOUND", message: "Innehåll saknas på servern." });
+      return { contentBase64: bytesToBase64(bytes), mimeType: doc.mimeType, fileName: doc.fileName };
     }),
 
   /**

--- a/src/lib/shared/content-address.ts
+++ b/src/lib/shared/content-address.ts
@@ -1,0 +1,44 @@
+/**
+ * Innehålls-adressering av dokument-bytes (#518, ADR 0023). Universell
+ * (browser + Node/bun) — delas av klient (hasha/koda före upload, avkoda efter
+ * download) och server (avkoda vid upload, koda vid download).
+ *
+ * sha256 → immutabel, dedup, perfekt cache-bar (cachen behöver aldrig
+ * invalideras). Binärt skickas som base64 över tRPC/JSON.
+ */
+
+/** sha256-hex av bytes via Web Crypto (`crypto` är global i browser/Node/bun). */
+export async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  // `as BufferSource`: TS 5.7+ typar Uint8Array som `<ArrayBufferLike>` (kan vara
+  // SharedArrayBuffer) men WebCrypto vill ha `BufferSource` — runtime är identiskt.
+  const digest = await crypto.subtle.digest("SHA-256", bytes as BufferSource);
+  let hex = "";
+  for (const b of new Uint8Array(digest)) hex += b.toString(16).padStart(2, "0");
+  return hex;
+}
+
+/** Repo-relativ, innehålls-adresserad sökväg för dokument-bytes. */
+export function contentStoragePath(hash: string): string {
+  return `documents/content/${hash}`;
+}
+
+// Chunk-storlek för base64 (undviker stack-overflow vid stora filer i
+// `String.fromCharCode(...)`).
+const CHUNK = 0x8000;
+
+/** base64 → bytes (`atob` är global i browser/Node/bun). */
+export function base64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+/** bytes → base64 (chunkad). */
+export function bytesToBase64(bytes: Uint8Array): string {
+  let bin = "";
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    bin += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(bin);
+}

--- a/test/unit/server/routers/document/upload-content.test.ts
+++ b/test/unit/server/routers/document/upload-content.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Test för document.uploadContent / downloadContent (#518, ADR 0023).
+ * Innehålls-adresserad lagring (sha256), repekning av storagePath, re-klassning,
+ * download-roundtrip + org-scope. Kör mot riktig in-memory-store; content-port
+ * är en Map-backad fake.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import type { IDataStore } from "@/lib/server/data-store/IDataStore";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
+import { documentRouter } from "@/lib/server/routers/document";
+import { bytesToBase64, contentStoragePath, sha256Hex } from "@/lib/shared/content-address";
+import { prebakeJoins } from "@/lib/shared/demo-source";
+
+vi.mock("@/lib/server/services/meilisearch", () => ({
+  searchDocuments: vi.fn(),
+  removeDocument: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/server/services/document-analysis", () => ({
+  analyzeDocument: vi.fn().mockResolvedValue(undefined),
+}));
+
+const ORG = "org-a";
+
+function makeCaller(orgId = ORG) {
+  const source = prebakeJoins({
+    matters: [{ id: "m1", organizationId: ORG, matterNumber: "2026-1", title: "T" }],
+    documentFolders: [],
+    documents: [{
+      id: "d1", organizationId: ORG, matterId: "m1", fileName: "avtal.pdf",
+      mimeType: "application/pdf", sizeBytes: 3, storagePath: "documents/content/old", version: 1,
+    }],
+  } as DemoSource);
+  const store = new LocalStore(source, async () => {});
+  const repos = buildInMemoryRepositories(store as unknown as IDataStore);
+  const blobs = new Map<string, Uint8Array>();
+  const analyze = vi.fn().mockResolvedValue(undefined);
+  const ports = {
+    email: { send: vi.fn() },
+    paymentScanner: { scan: vi.fn() },
+    documentAnalyzer: { analyze },
+    searchIndex: { search: vi.fn(), upsert: vi.fn(), remove: vi.fn().mockResolvedValue(undefined) },
+    content: {
+      write: async (p: string, b: Uint8Array) => { blobs.set(p, b); },
+      read: async (p: string) => blobs.get(p) ?? null,
+    },
+  };
+  const ctx = { user: { id: "u1", email: "a@b.se", name: "T", role: "LAWYER", organizationId: orgId }, dataStore: store, repos, orgId, ports };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return { caller: documentRouter.createCaller(ctx as any), blobs, analyze };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("document.uploadContent", () => {
+  it("lagrar innehålls-adresserat, repekar storagePath + triggar klassning", async () => {
+    const { caller, blobs, analyze } = makeCaller();
+    const bytes = new Uint8Array([1, 2, 3]);
+    await caller.uploadContent({ documentId: "d1", contentBase64: bytesToBase64(bytes) });
+
+    const expectedPath = contentStoragePath(await sha256Hex(bytes));
+    expect(Array.from(blobs.get(expectedPath)!)).toEqual([1, 2, 3]);
+    expect(analyze).toHaveBeenCalledWith("d1");
+
+    // storagePath repekad → downloadContent ger tillbaka samma bytes.
+    const dl = await caller.downloadContent({ documentId: "d1" });
+    expect(Array.from(Buffer.from(dl.contentBase64, "base64"))).toEqual([1, 2, 3]);
+    expect(dl.mimeType).toBe("application/pdf");
+  });
+
+  it("identiskt innehåll → samma hash (dedup)", async () => {
+    const { caller, blobs } = makeCaller();
+    const b64 = bytesToBase64(new Uint8Array([9, 9]));
+    await caller.uploadContent({ documentId: "d1", contentBase64: b64 });
+    await caller.uploadContent({ documentId: "d1", contentBase64: b64 });
+    expect(blobs.size).toBe(1); // samma sha → en blob
+  });
+
+  it("org-scope: dokument i annan org → NOT_FOUND", async () => {
+    const { caller } = makeCaller("org-b");
+    await expect(
+      caller.uploadContent({ documentId: "d1", contentBase64: bytesToBase64(new Uint8Array([1])) }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("document.downloadContent", () => {
+  it("saknat innehåll på servern → NOT_FOUND", async () => {
+    const { caller } = makeCaller();
+    // Inget uppladdat → storagePath "documents/content/old" finns ej i content-store.
+    await expect(caller.downloadContent({ documentId: "d1" })).rejects.toThrow(/saknas/i);
+  });
+});

--- a/test/unit/shared/content-address.test.ts
+++ b/test/unit/shared/content-address.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Tester för innehålls-adressering (#518, ADR 0023) — sha256, base64-roundtrip,
+ * storagePath.
+ */
+
+import { describe, expect, it } from "vitest-compat";
+import { base64ToBytes, bytesToBase64, contentStoragePath, sha256Hex } from "@/lib/shared/content-address";
+
+describe("content-address", () => {
+  it("sha256Hex matchar känt testvektor (tomma bytes)", async () => {
+    // sha256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    expect(await sha256Hex(new Uint8Array([]))).toBe(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    );
+  });
+
+  it("sha256Hex är deterministisk + skiljer på innehåll", async () => {
+    const a = await sha256Hex(new Uint8Array([1, 2, 3]));
+    const b = await sha256Hex(new Uint8Array([1, 2, 3]));
+    const c = await sha256Hex(new Uint8Array([1, 2, 4]));
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("base64 roundtrip bevarar bytes (inkl. > chunk-gränsen)", () => {
+    const big = new Uint8Array(40000).map((_, i) => i % 256);
+    expect(Array.from(base64ToBytes(bytesToBase64(big)))).toEqual(Array.from(big));
+  });
+
+  it("contentStoragePath bygger repo-relativ hash-sökväg", () => {
+    expect(contentStoragePath("abc123")).toBe("documents/content/abc123");
+  });
+});


### PR DESCRIPTION
Server-byte-API:t som knyter ihop dokument-livscykeln (öppna/editera/spara) i server-first — fundamentet alla edit-mekanismer delar. Realiserar den content-adresserade byte-modellen vi designade (cache + versionering).

## Ändringar
- **`lib/shared/content-address`** — universell sha256 + base64 (browser+Node/bun), `contentStoragePath(hash)`.
- **`document.uploadContent(documentId, contentBase64)`** — content-adressera (sha256) → `content.write` → repeka `storagePath` till nya hashen (**ny immutabel version**; repo bumpar `version`) → `analysisStatus: PENDING` + **trigga server-klassificering** (jobb-kö). Gamla bytes behålls (git-historik).
- **`document.downloadContent(documentId)`** — `content.read(storagePath)` → base64 (klienten cachar innehålls-adresserat → immutabelt).
- **ADR 0023** — dokument-bytes content-adresserade, klient-cachade, versionerade (förankrar hela design-diskussionen).

## Stänger server-side-kedjan
`uploadContent` skriver bytes → `analyze` → `classify-document`-jobbet (fas 2/3) läser dem via `content.read` → klassificerar. Hela vägen fungerar nu server-side när bytes laddas upp.

## Verifiering
- typecheck + eslint + knip + dep-cruiser + jscpd ✅
- `bun run test:cov` — 90.73% rader / 85.40% funktioner (golv 88.80/83.80); content-address (sha256-vektor + base64-roundtrip > chunk) + upload/download-roundtrip + dedup + org-scope ✅
- `bun run build:demo` ✅ (universell sha256/base64 — ingen node:crypto/Buffer i klient-bundlen; demon intakt)

## Kvar i #518
Klient: byte-cache (IndexedDB, hash-keyad) + öppna-flöde (download→cache) + edit-mekanik (B: ner/upp först, A: helper-rundtur) + explicit versions-UI + retire `markExternallyEdited`/FSA-vägen. Sen: ta bort klient-web-llm.

Refs #518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)