### PR TITLE
feat(client): byte-synk för dokument-innehåll vid reconnect (#518, ADR 0023)

### DIFF
--- a/src/lib/client/backend/content-cache.ts
+++ b/src/lib/client/backend/content-cache.ts
@@ -1,0 +1,58 @@
+"use client";
+
+/**
+ * `DocumentContentCache` (#518, ADR 0023) — klientens byte-cache för
+ * dokument-innehåll i IndexedDB (ovanpå `IdbKv`).
+ *
+ * Två roller:
+ *   1. **Immutabel blob-cache** nyckel-ad på sha256 → snabb öppning + offline,
+ *      behöver aldrig invalideras (content-adresserat).
+ *   2. **Pending-upload-manifest** (`documentId → sha`) som byte-synken läser
+ *      vid reconnect. Manifestet är keyat på `documentId` → flera offline-
+ *      sparningar av samma dokument **slås samman** till den senaste sha:n
+ *      (bara den laddas upp).
+ */
+
+import { IdbKv } from "@/lib/server/data-store/in-memory/idb-kv";
+
+const DB_NAME = "ava-doc-content";
+const STORE = "kv";
+const PENDING_KEY = "__pending__";
+const blobKey = (sha: string): string => `blob:${sha}`;
+
+type PendingMap = Record<string, string>; // documentId → sha
+
+export class DocumentContentCache {
+  private readonly kv: IdbKv;
+
+  constructor(factory: IDBFactory = globalThis.indexedDB) {
+    this.kv = new IdbKv(factory, DB_NAME, STORE);
+  }
+
+  /** Cacha bytes (by sha) + markera dokumentet som väntande på upload. */
+  async cache(documentId: string, sha: string, bytes: Uint8Array): Promise<void> {
+    await this.kv.put(blobKey(sha), bytes);
+    const pending = (await this.kv.get<PendingMap>(PENDING_KEY)) ?? {};
+    pending[documentId] = sha; // coalesce: senaste sha per dokument
+    await this.kv.put(PENDING_KEY, pending);
+  }
+
+  /** Cachade bytes för en sha, eller null. */
+  async getBytes(sha: string): Promise<Uint8Array | null> {
+    const v = await this.kv.get<Uint8Array | ArrayBuffer>(blobKey(sha));
+    return v ? new Uint8Array(v) : null;
+  }
+
+  /** Dokument som väntar på byte-upload ({documentId, sha}). */
+  async pendingUploads(): Promise<Array<{ documentId: string; sha: string }>> {
+    const pending = (await this.kv.get<PendingMap>(PENDING_KEY)) ?? {};
+    return Object.entries(pending).map(([documentId, sha]) => ({ documentId, sha }));
+  }
+
+  /** Ta bort dokumentet ur pending-manifestet (blobben behålls i läs-cachen). */
+  async markUploaded(documentId: string): Promise<void> {
+    const pending = (await this.kv.get<PendingMap>(PENDING_KEY)) ?? {};
+    delete pending[documentId];
+    await this.kv.put(PENDING_KEY, pending);
+  }
+}

--- a/src/lib/client/backend/content-sync.ts
+++ b/src/lib/client/backend/content-sync.ts
@@ -1,0 +1,70 @@
+"use client";
+
+/**
+ * Byte-synk (#518, ADR 0023) — vid reconnect: ladda upp de content-adresserade
+ * blobbar som servern saknar. Skild kanal från entitets-mutation-kön (som bara
+ * bär metadatan `storagePath`); byte:sen rider INTE med i den.
+ *
+ * `runContentSync` är ren + dep-injicerad (testbar utan IndexedDB/tRPC).
+ * `syncDocumentContent` wirar den mot tRPC-klienten + `DocumentContentCache`.
+ *
+ * Dedup: frågar `missingContent` först → laddar bara upp sha:n servern saknar.
+ * Coalesce: pending-manifestet är keyat på documentId → bara senaste versionen.
+ */
+
+import { bytesToBase64, contentStoragePath } from "@/lib/shared/content-address";
+import { DocumentContentCache } from "./content-cache";
+
+export interface ContentSyncDeps {
+  /** Väntande {documentId, sha}. */
+  pending: () => Promise<Array<{ documentId: string; sha: string }>>;
+  /** Vilka av dessa storagePaths saknar servern? */
+  missing: (storagePaths: string[]) => Promise<string[]>;
+  /** Cachade bytes för en sha (null = borta → hoppa). */
+  getBytes: (sha: string) => Promise<Uint8Array | null>;
+  /** Ladda upp bytes för ett dokument. */
+  upload: (documentId: string, bytes: Uint8Array) => Promise<void>;
+  /** Markera dokumentet som synkat (ta ur pending). */
+  markUploaded: (documentId: string) => Promise<void>;
+}
+
+/** Ladda upp saknade blobbar. Returnerar sha:n som faktiskt laddades upp. */
+export async function runContentSync(deps: ContentSyncDeps): Promise<string[]> {
+  const pend = await deps.pending();
+  if (pend.length === 0) return [];
+  const missing = new Set(await deps.missing(pend.map((p) => contentStoragePath(p.sha))));
+  const uploaded: string[] = [];
+  for (const { documentId, sha } of pend) {
+    if (!missing.has(contentStoragePath(sha))) { await deps.markUploaded(documentId); continue; }
+    const bytes = await deps.getBytes(sha);
+    if (!bytes) { await deps.markUploaded(documentId); continue; }
+    await deps.upload(documentId, bytes);
+    await deps.markUploaded(documentId);
+    uploaded.push(sha);
+  }
+  return uploaded;
+}
+
+/** tRPC-ytan byte-synken behöver (strukturell → undviker hård klient-typ-koppling). */
+export interface ContentSyncClient {
+  document: {
+    missingContent: { query: (input: { storagePaths: string[] }) => Promise<{ missing: string[] }> };
+    uploadContent: { mutate: (input: { documentId: string; contentBase64: string }) => Promise<unknown> };
+  };
+}
+
+/** Wira `runContentSync` mot tRPC-klienten + byte-cachen. */
+export function syncDocumentContent(
+  client: ContentSyncClient,
+  cache: DocumentContentCache = new DocumentContentCache(),
+): Promise<string[]> {
+  return runContentSync({
+    pending: () => cache.pendingUploads(),
+    missing: async (paths) => (await client.document.missingContent.query({ storagePaths: paths })).missing,
+    getBytes: (sha) => cache.getBytes(sha),
+    upload: async (documentId, bytes) => {
+      await client.document.uploadContent.mutate({ documentId, contentBase64: bytesToBase64(bytes) });
+    },
+    markUploaded: (documentId) => cache.markUploaded(documentId),
+  });
+}

--- a/src/lib/client/backend/server-first-store.ts
+++ b/src/lib/client/backend/server-first-store.ts
@@ -62,6 +62,12 @@ export async function createServerFirstStore(deps: ServerFirstStoreDeps = {}): P
     persistence: deps.persistence ?? new IndexedDbPersistence(),
     queuePersistence: deps.queuePersistence ?? new IndexedDbMutationQueuePersistence(),
   });
-  if (!deps.skipInitialReconcile) await cachingSync.reconcile();
+  if (!deps.skipInitialReconcile) {
+    await cachingSync.reconcile();
+    // Byte-synk (#518, ADR 0023): ladda upp dokument-blobbar servern saknar.
+    // Best-effort — får aldrig ta ned bootstrappen (tom pending → no-op).
+    const { syncDocumentContent } = await import("./content-sync");
+    void syncDocumentContent(client as unknown as Parameters<typeof syncDocumentContent>[0]).catch(() => {});
+  }
   return cachingSync;
 }

--- a/src/lib/server/adapters/git-content-store.ts
+++ b/src/lib/server/adapters/git-content-store.ts
@@ -84,6 +84,17 @@ export class GitContentStore implements IContentStore {
       return null; // saknas / oläsbar → null (anroparen hanterar)
     }
   }
+
+  async exists(storagePath: string): Promise<boolean> {
+    const abs = this.safeResolve(storagePath);
+    if (!abs) return false;
+    try {
+      await access(abs);
+      return true;
+    } catch {
+      return false;
+    }
+  }
 }
 
 /**

--- a/src/lib/server/adapters/noop-ports.ts
+++ b/src/lib/server/adapters/noop-ports.ts
@@ -41,6 +41,7 @@ export const noopPaymentScanner: IPaymentScanner = {
 export const noopContentStore: IContentStore = {
   async write() { /* no-op */ },
   async read() { return null; },
+  async exists() { return false; },
 };
 
 export const noopPorts: IPorts = {

--- a/src/lib/server/ports.ts
+++ b/src/lib/server/ports.ts
@@ -112,6 +112,13 @@ export interface IContentStore {
    * klient-sidigt, inte på servern).
    */
   read(storagePath: string): Promise<Uint8Array | null>;
+
+  /**
+   * Finns bytes för `storagePath`? Billig (ingen läsning av innehållet) —
+   * byte-synken (#518, ADR 0023) frågar vilka content-adresserade sha:n
+   * servern saknar innan klienten laddar upp. Demo/web → `false`.
+   */
+  exists(storagePath: string): Promise<boolean>;
 }
 
 // ─── Aggregat ──────────────────────────────────────────────────────

--- a/src/lib/server/routers/document/core.ts
+++ b/src/lib/server/routers/document/core.ts
@@ -199,6 +199,20 @@ export const coreProcedures = {
     }),
 
   /**
+   * `missingContent` (#518, ADR 0023) — vilka content-adresserade sökvägar
+   * saknar servern? Byte-synken frågar detta vid reconnect och laddar bara
+   * upp blobbar servern inte redan har (dedup på sha).
+   */
+  missingContent: orgProcedure
+    .input(z.object({ storagePaths: z.array(z.string()).max(500) }))
+    .query(async ({ ctx, input }) => {
+      const checks = await Promise.all(
+        input.storagePaths.map(async (p) => ({ p, has: await ctx.ports.content.exists(p) })),
+      );
+      return { missing: checks.filter((c) => !c.has).map((c) => c.p) };
+    }),
+
+  /**
    * Skriv AI-genererad metadata (eller manuell override). Accepterar
    * även `analyzedAt` + `analysisStatus` så client-side workers kan
    * markera dokumentet som färdiganalyserat.

--- a/test/unit/client/backend/content-cache.test.ts
+++ b/test/unit/client/backend/content-cache.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Tester för `DocumentContentCache` (#518, ADR 0023) — IndexedDB byte-cache
+ * (fake-indexeddb). Blob-roundtrip, pending-manifest, coalesce (senaste sha per
+ * dokument), markUploaded.
+ */
+
+import { IDBFactory } from "fake-indexeddb";
+import { beforeEach, describe, expect, it } from "vitest-compat";
+import { DocumentContentCache } from "@/lib/client/backend/content-cache";
+
+let cache: DocumentContentCache;
+beforeEach(() => { cache = new DocumentContentCache(new IDBFactory()); });
+
+describe("DocumentContentCache", () => {
+  it("cachar bytes + listar pending + roundtrip", async () => {
+    await cache.cache("d1", "sha-a", new Uint8Array([1, 2, 3]));
+    expect(await cache.pendingUploads()).toEqual([{ documentId: "d1", sha: "sha-a" }]);
+    expect(Array.from((await cache.getBytes("sha-a"))!)).toEqual([1, 2, 3]);
+  });
+
+  it("coalesce: ny sparning av samma dokument → bara senaste sha pending", async () => {
+    await cache.cache("d1", "sha-v1", new Uint8Array([1]));
+    await cache.cache("d1", "sha-v2", new Uint8Array([2]));
+    expect(await cache.pendingUploads()).toEqual([{ documentId: "d1", sha: "sha-v2" }]);
+    // Gamla blobben finns kvar i läs-cachen (immutabel), bara manifestet slogs ihop.
+    expect(await cache.getBytes("sha-v1")).not.toBeNull();
+  });
+
+  it("markUploaded tar bort ur pending men behåller blobben", async () => {
+    await cache.cache("d1", "sha-a", new Uint8Array([9]));
+    await cache.markUploaded("d1");
+    expect(await cache.pendingUploads()).toEqual([]);
+    expect(await cache.getBytes("sha-a")).not.toBeNull();
+  });
+
+  it("getBytes för okänd sha → null", async () => {
+    expect(await cache.getBytes("nope")).toBeNull();
+  });
+});

--- a/test/unit/client/backend/content-sync.test.ts
+++ b/test/unit/client/backend/content-sync.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tester för byte-synk-orkestreringen (#518, ADR 0023) — `runContentSync`.
+ * Dep-injicerad, ingen IndexedDB/tRPC: verifierar dedup (hoppa sha:n servern
+ * har), upload av saknade, markUploaded alltid, samt no-op vid tom pending.
+ */
+
+import { describe, expect, it, vi } from "vitest-compat";
+import { runContentSync } from "@/lib/client/backend/content-sync";
+import { contentStoragePath } from "@/lib/shared/content-address";
+
+describe("runContentSync", () => {
+  it("tom pending → no-op", async () => {
+    const upload = vi.fn();
+    const out = await runContentSync({
+      pending: async () => [], missing: async () => [], getBytes: async () => null, upload, markUploaded: vi.fn(),
+    });
+    expect(out).toEqual([]);
+    expect(upload).not.toHaveBeenCalled();
+  });
+
+  it("laddar bara upp sha:n servern saknar (dedup) + markUploaded för alla", async () => {
+    const pending = [
+      { documentId: "d1", sha: "aaa" },
+      { documentId: "d2", sha: "bbb" }, // servern har redan denna
+    ];
+    const upload = vi.fn(async () => {});
+    const markUploaded = vi.fn(async () => {});
+    const out = await runContentSync({
+      pending: async () => pending,
+      missing: async () => [contentStoragePath("aaa")], // bara aaa saknas
+      getBytes: async (sha) => new Uint8Array([sha === "aaa" ? 1 : 2]),
+      upload,
+      markUploaded,
+    });
+    expect(out).toEqual(["aaa"]);
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(upload).toHaveBeenCalledWith("d1", new Uint8Array([1]));
+    expect(markUploaded).toHaveBeenCalledTimes(2); // båda rensas ur pending
+  });
+
+  it("saknad blob (getBytes null) → hoppa upload men markUploaded", async () => {
+    const upload = vi.fn(async () => {});
+    const markUploaded = vi.fn(async () => {});
+    const out = await runContentSync({
+      pending: async () => [{ documentId: "d1", sha: "ccc" }],
+      missing: async () => [contentStoragePath("ccc")],
+      getBytes: async () => null,
+      upload,
+      markUploaded,
+    });
+    expect(out).toEqual([]);
+    expect(upload).not.toHaveBeenCalled();
+    expect(markUploaded).toHaveBeenCalledWith("d1");
+  });
+});

--- a/test/unit/server/routers/document/upload-content.test.ts
+++ b/test/unit/server/routers/document/upload-content.test.ts
@@ -45,6 +45,7 @@ function makeCaller(orgId = ORG) {
     content: {
       write: async (p: string, b: Uint8Array) => { blobs.set(p, b); },
       read: async (p: string) => blobs.get(p) ?? null,
+      exists: async (p: string) => blobs.has(p),
     },
   };
   const ctx = { user: { id: "u1", email: "a@b.se", name: "T", role: "LAWYER", organizationId: orgId }, dataStore: store, repos, orgId, ports };
@@ -91,5 +92,16 @@ describe("document.downloadContent", () => {
     const { caller } = makeCaller();
     // Inget uppladdat → storagePath "documents/content/old" finns ej i content-store.
     await expect(caller.downloadContent({ documentId: "d1" })).rejects.toThrow(/saknas/i);
+  });
+});
+
+describe("document.missingContent", () => {
+  it("returnerar bara sökvägar servern saknar (byte-synk-dedup)", async () => {
+    const { caller } = makeCaller();
+    const bytes = new Uint8Array([7, 7]);
+    await caller.uploadContent({ documentId: "d1", contentBase64: bytesToBase64(bytes) });
+    const have = contentStoragePath(await sha256Hex(bytes));
+    const res = await caller.missingContent({ storagePaths: [have, "documents/content/finns-ej"] });
+    expect(res.missing).toEqual(["documents/content/finns-ej"]);
   });
 });


### PR DESCRIPTION
Bygger **byte-synken** — den separata kanalen som laddar upp dokument-blobbar servern saknar vid reconnect. Får offline-scenariot att fungera: *ladda upp PDF + ändra + spara offline → online → servern får senaste versionen, klassificeras.*

## Varför en egen kanal
Entitets-mutation-kön bär bara metadatan (`storagePath = sha`) — byte:sen rider inte med (`content.write` är ett port-anrop, inte en store-mutation). Så bytes synkas separat, content-adresserat.

## Ändringar
- **`DocumentContentCache`** (IndexedDB via `IdbKv`): immutabel blob-cache (by sha) + pending-manifest keyat på `documentId` → flera offline-sparningar **slås samman** till senaste sha:n (ditt val "1 slå samman").
- **`runContentSync`** (ren, dep-injicerad) + **`syncDocumentContent`** (wirar tRPC + cache): vid reconnect → `missingContent`-fråga (**dedup** på sha) → ladda bara upp det servern saknar via `uploadContent`.
- **Server:** `IContentStore.exists` (GitContentStore/noop) + **`document.missingContent`**-query.
- Wirad **best-effort** efter initial reconcile i `createServerFirstStore` (tom pending → no-op, får aldrig ta ned bootstrappen).
- Ligger i `client/backend/` (in-process-store-sömmen, undantagen `ui→server`-regeln).

## Verifiering
- typecheck + eslint + knip + dep-cruiser + jscpd ✅
- `bun run test:cov` — 90.70% rader / 85.41% funktioner (golv 88.80/83.80); runContentSync (dedup/skip/markUploaded) + byte-cache (fake-indexeddb, coalesce) + missingContent ✅
- `bun run build:demo` ✅ (demon intakt)

## Kvar i #518
**Producenten:** spara-primitiv (hash → `cache.cache()` + köa metadata) + öppna-primitiv (download→cache) — det som POPULERAR cachen så synken har något att ladda upp. Sen explicit versions-UI + retire `markExternallyEdited`/FSA, och ta bort klient-web-llm.

Refs #518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)