### PR TITLE
test(client): täck syncDocumentContent + ratchet coverage-golv (#518)

### DIFF
--- a/test/unit/client/backend/content-sync.test.ts
+++ b/test/unit/client/backend/content-sync.test.ts
@@ -4,9 +4,11 @@
  * har), upload av saknade, markUploaded alltid, samt no-op vid tom pending.
  */
 
+import { IDBFactory } from "fake-indexeddb";
 import { describe, expect, it, vi } from "vitest-compat";
-import { runContentSync } from "@/lib/client/backend/content-sync";
-import { contentStoragePath } from "@/lib/shared/content-address";
+import { DocumentContentCache } from "@/lib/client/backend/content-cache";
+import { runContentSync, syncDocumentContent } from "@/lib/client/backend/content-sync";
+import { base64ToBytes, contentStoragePath, sha256Hex } from "@/lib/shared/content-address";
 
 describe("runContentSync", () => {
   it("tom pending → no-op", async () => {
@@ -51,5 +53,44 @@ describe("runContentSync", () => {
     expect(out).toEqual([]);
     expect(upload).not.toHaveBeenCalled();
     expect(markUploaded).toHaveBeenCalledWith("d1");
+  });
+});
+
+describe("syncDocumentContent (wirad mot tRPC + cache)", () => {
+  it("laddar upp pending blob via uploadContent + rensar pending", async () => {
+    const cache = new DocumentContentCache(new IDBFactory());
+    const bytes = new Uint8Array([5, 6, 7]);
+    const sha = await sha256Hex(bytes);
+    await cache.cache("d1", sha, bytes);
+
+    const uploads: Array<{ documentId: string; contentBase64: string }> = [];
+    const client = {
+      document: {
+        missingContent: { query: async (i: { storagePaths: string[] }) => ({ missing: i.storagePaths }) },
+        uploadContent: { mutate: async (i: { documentId: string; contentBase64: string }) => { uploads.push(i); } },
+      },
+    };
+
+    const out = await syncDocumentContent(client, cache);
+    expect(out).toEqual([sha]);
+    expect(uploads).toHaveLength(1);
+    expect(uploads[0]!.documentId).toBe("d1");
+    expect(Array.from(base64ToBytes(uploads[0]!.contentBase64))).toEqual([5, 6, 7]);
+    expect(await cache.pendingUploads()).toEqual([]); // rensad efter upload
+  });
+
+  it("servern har redan blobben → ingen upload, pending rensas", async () => {
+    const cache = new DocumentContentCache(new IDBFactory());
+    await cache.cache("d2", await sha256Hex(new Uint8Array([1])), new Uint8Array([1]));
+    const uploads: unknown[] = [];
+    const client = {
+      document: {
+        missingContent: { query: async () => ({ missing: [] }) }, // servern har allt
+        uploadContent: { mutate: async (i: unknown) => { uploads.push(i); } },
+      },
+    };
+    expect(await syncDocumentContent(client, cache)).toEqual([]);
+    expect(uploads).toHaveLength(0);
+    expect(await cache.pendingUploads()).toEqual([]);
   });
 });

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -56,9 +56,12 @@ const FAST = process.argv.includes("--fast");
 // noop-ports + alla emit-helpers täckta efter server-first-migreringen, som
 // dessutom tog bort otestad git/OPFS/mem-fs-kod → lokalt 90.50% rader / 85.11%
 // funktioner; LINE-marginalen krymps mot den deterministiska kod-borttagningen
-// medan FUNC behåller ~1.3% Node-version-marginal).
-const LINE_FLOOR = 0.888;
-const FUNC_FLOOR = 0.838;
+// medan FUNC behåller ~1.3% Node-version-marginal) → 88.9 rader / 84.0
+// funktioner (#518: byte-synk + content-address + uploadContent/download +
+// syncDocumentContent-wiring täckta → lokalt 90.70% rader / 85.51% funktioner;
+// båda golven dras upp en knapp, ~1.5% FUNC-marginal behålls).
+const LINE_FLOOR = 0.889;
+const FUNC_FLOOR = 0.840;
 
 /**
  * SERIAL_FILES — testfiler som SYNKRONT spawnar en barnprocess via


### PR DESCRIPTION
Täcker byte-synkens tRPC-wirade glue (`syncDocumentContent`) som saknade tester efter #524 — fake tRPC-klient + fake-indexeddb-cache: upload av pending blob + dedup (servern har redan blobben → ingen upload).

Ratchet: **FUNC 0.838→0.840, LINE 0.888→0.889** just under lokalt **90.70% rader / 85.51% funktioner** (~1.5% FUNC Node-version-marginal behålls).

## Verifiering
- typecheck + eslint + knip + dep-cruiser + jscpd ✅
- `bun run test:cov` — 90.70% / 85.51% (golv 88.90/84.00) ✅
- `bun run build:demo` ✅

Refs #518, #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)