### PR TITLE
feat(client): öppna-primitiv — hämta dokument via server + byte-cache (#518)

### DIFF
--- a/src/app/invoices/[id]/_client.tsx
+++ b/src/app/invoices/[id]/_client.tsx
@@ -7,6 +7,7 @@
 
 import type { inferRouterOutputs } from "@trpc/server";
 import { type ComponentProps, useState } from "react";
+import type { DownloadClient } from "@/lib/client/backend/load-document-blob";
 import { EntityLink } from "@/lib/client/demo/entity-link";
 import { useRouteId } from "@/lib/client/demo/use-route-id";
 import { trpc } from "@/lib/client/trpc";
@@ -441,22 +442,26 @@ function SettlementSummaryCard({ settlement }: { settlement: MatterSettlement })
  * Tidigare länkade namnet felaktigt till /matters → man dirigerades in i
  * ärendet istället för att få upp filen.
  */
-async function openInvoiceDoc(doc: InvoiceDocRow): Promise<void> {
+async function openInvoiceDoc(doc: InvoiceDocRow, client: DownloadClient): Promise<void> {
   const { openDocument } = await import("@/lib/client/firma/open-document");
   const { loadHandle } = await import("@/lib/client/fsa/handle-store");
   const { readFromFsa } = await import("@/lib/client/fsa/read-from-fsa");
+  const { loadDocumentBlob } = await import("@/lib/client/backend/load-document-blob");
   await openDocument({
     doc: { id: doc.id, ...(doc.storagePath != null ? { storagePath: doc.storagePath } : {}), fileName: doc.fileName },
     isDemo: process.env.NEXT_PUBLIC_DEMO_BUILD === "1",
     ...omitUndefined({ demoRepo: process.env.NEXT_PUBLIC_DEFAULT_DEMO_REPO }),
     loadHandle: () => loadHandle("repo-root"),
     readFromHandle: readFromFsa,
+    // Server-first (#518): hämta bytes från servern (+ klient-cache) i st.f. FSA.
+    fetchBlob: () => loadDocumentBlob(client, { id: doc.id, storagePath: doc.storagePath ?? null, fileName: doc.fileName }),
     openUrl: (u) => window.open(u, "_blank", "noopener,noreferrer"),
     notifyError: (m) => alert(m),
   });
 }
 
 function InvoiceDocumentsCard({ documents }: { documents: InvoiceDocRow[] }) {
+  const utils = trpc.useUtils();
   if (documents.length === 0) return null;
   return (
     <div className="bg-white rounded-lg border border-gray-200 p-6">
@@ -466,7 +471,7 @@ function InvoiceDocumentsCard({ documents }: { documents: InvoiceDocRow[] }) {
           <li key={d.id} className="py-2 flex items-center justify-between">
             <button
               type="button"
-              onClick={() => void openInvoiceDoc(d)}
+              onClick={() => void openInvoiceDoc(d, utils.client)}
               className="text-blue-600 hover:underline text-left"
             >
               {d.fileName}

--- a/src/lib/client/backend/content-cache.ts
+++ b/src/lib/client/backend/content-cache.ts
@@ -37,6 +37,11 @@ export class DocumentContentCache {
     await this.kv.put(PENDING_KEY, pending);
   }
 
+  /** Cacha bytes utan pending-markering (läs-cache: download→cache vid öppning). */
+  async putBytes(sha: string, bytes: Uint8Array): Promise<void> {
+    await this.kv.put(blobKey(sha), bytes);
+  }
+
   /** Cachade bytes för en sha, eller null. */
   async getBytes(sha: string): Promise<Uint8Array | null> {
     const v = await this.kv.get<Uint8Array | ArrayBuffer>(blobKey(sha));

--- a/src/lib/client/backend/load-document-blob.ts
+++ b/src/lib/client/backend/load-document-blob.ts
@@ -1,0 +1,54 @@
+"use client";
+
+/**
+ * `loadDocumentBlob` (#518, ADR 0023) — öppna-primitiv för server-first:
+ * hämta dokument-bytes som `Blob` ur byte-cachen (hit) eller via
+ * `document.downloadContent` (miss → cacha). Ersätter den borttagna
+ * FSA-working-copy-läsningen. Cachen är content-adresserad → immutabel.
+ */
+
+import { base64ToBytes } from "@/lib/shared/content-address";
+import { DocumentContentCache } from "./content-cache";
+
+/** tRPC-ytan primitiven behöver (strukturell → ingen hård klient-typ-koppling). */
+export interface DownloadClient {
+  document: {
+    downloadContent: {
+      query: (input: { documentId: string }) => Promise<{ contentBase64: string; mimeType: string }>;
+    };
+  };
+}
+
+const MIME_BY_EXT: Record<string, string> = {
+  pdf: "application/pdf",
+  docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  doc: "application/msword",
+};
+
+function mimeFromName(fileName: string): string {
+  const ext = fileName.toLowerCase().match(/\.([a-z0-9]+)$/)?.[1] ?? "";
+  return MIME_BY_EXT[ext] ?? "application/octet-stream";
+}
+
+/** Cache-nyckel ur storagePath (sista segmentet = sha, content-adresserat). */
+function cacheKey(doc: { id: string; storagePath?: string | null }): string {
+  return doc.storagePath?.split("/").pop() ?? doc.id;
+}
+
+export async function loadDocumentBlob(
+  client: DownloadClient,
+  doc: { id: string; storagePath?: string | null; fileName: string },
+  cache: DocumentContentCache = new DocumentContentCache(),
+): Promise<Blob | null> {
+  const key = cacheKey(doc);
+  const cached = await cache.getBytes(key);
+  if (cached) return new Blob([cached as BlobPart], { type: mimeFromName(doc.fileName) });
+  try {
+    const res = await client.document.downloadContent.query({ documentId: doc.id });
+    const bytes = base64ToBytes(res.contentBase64);
+    await cache.putBytes(key, bytes);
+    return new Blob([bytes as BlobPart], { type: res.mimeType || mimeFromName(doc.fileName) });
+  } catch {
+    return null; // download misslyckades (offline + ej cachad, eller saknas)
+  }
+}

--- a/src/lib/client/firma/open-document.ts
+++ b/src/lib/client/firma/open-document.ts
@@ -27,10 +27,22 @@ export interface OpenDocumentDeps {
   openUrl: (url: string) => void;
   /** Visar fel till användaren (injicerbar för test). */
   notifyError: (msg: string) => void;
+  /**
+   * Server-first (#518): hämta dokument-bytes från servern (+ klient-cache) i
+   * st.f. den borttagna FSA-working-copyn. Sätts → används före FSA-vägen.
+   */
+  fetchBlob?: () => Promise<Blob | null>;
+}
+
+/** Öppna en blob i ny flik (charset-taggad för text). Revoke efter 60 s. */
+function openBlobUrl(blob: Blob, storagePath: string, openUrl: (url: string) => void): void {
+  const url = URL.createObjectURL(withUtf8CharsetIfText(blob, storagePath));
+  openUrl(url);
+  setTimeout(() => URL.revokeObjectURL(url), 60_000);
 }
 
 export async function openDocument(deps: OpenDocumentDeps): Promise<"opened-gh-pages" | "opened-blob" | "opened-generated" | "error"> {
-  const { doc, isDemo, demoRepo, loadHandle, readFromHandle, openUrl, notifyError } = deps;
+  const { doc, isDemo, demoRepo, openUrl, notifyError, fetchBlob } = deps;
   const storagePath = doc.storagePath ?? `documents/${doc.id}`;
 
   // Demo + self-hosted: dokument som genererats client-side under denna
@@ -50,25 +62,31 @@ export async function openDocument(deps: OpenDocumentDeps): Promise<"opened-gh-p
     return "opened-gh-pages";
   }
 
+  // Server-first (#518): hämta bytes från servern (+ klient-cache). Före FSA.
+  if (fetchBlob) {
+    const blob = await fetchBlob();
+    if (!blob) { notifyError(`Dokumentet kunde inte hämtas (${storagePath}).`); return "error"; }
+    openBlobUrl(blob, storagePath, openUrl);
+    return "opened-blob";
+  }
+
+  return openFromFsa(deps, storagePath);
+}
+
+/** Öppna ur den lokala FSA-working-copyn (legacy git-first-vägen). */
+async function openFromFsa(deps: OpenDocumentDeps, storagePath: string): Promise<"opened-blob" | "error"> {
+  const { loadHandle, readFromHandle, openUrl, notifyError } = deps;
   const handle = await loadHandle();
   if (!handle) {
     notifyError("Ingen working copy är ansluten — anslut via /settings.");
     return "error";
   }
-
   const blob = await readFromHandle(handle, storagePath);
   if (!blob) {
     notifyError(`Dokumentet kunde inte hittas på disk (${storagePath}).`);
     return "error";
   }
-
-  // För text-baserade format MÅSTE vi tagga blob:en med "charset=utf-8",
-  // annars renderar browsern ofta som ISO-8859-1 → å/ä/ö blir trasiga.
-  // Binärformat (PDF, DOCX, bilder) behåller sin mime-type oförändrad.
-  const url = URL.createObjectURL(withUtf8CharsetIfText(blob, storagePath));
-  openUrl(url);
-  // Vänta lite innan revoke så browsern hinner ladda — 60 s är gott nog.
-  setTimeout(() => URL.revokeObjectURL(url), 60_000);
+  openBlobUrl(blob, storagePath, openUrl);
   return "opened-blob";
 }
 

--- a/test/unit/client/backend/load-document-blob.test.ts
+++ b/test/unit/client/backend/load-document-blob.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Tester för `loadDocumentBlob` (#518, ADR 0023) — öppna-primitiven:
+ * cache-hit, download→cache (miss), och fel→null. Fake-indexeddb-cache +
+ * fake tRPC-klient.
+ */
+
+import { IDBFactory } from "fake-indexeddb";
+import { beforeEach, describe, expect, it, vi } from "vitest-compat";
+import { DocumentContentCache } from "@/lib/client/backend/content-cache";
+import { loadDocumentBlob } from "@/lib/client/backend/load-document-blob";
+
+let cache: DocumentContentCache;
+beforeEach(() => { cache = new DocumentContentCache(new IDBFactory()); });
+
+const doc = { id: "d1", storagePath: "documents/content/sha-abc", fileName: "avtal.pdf" };
+
+function clientReturning(contentBase64: string, mimeType = "application/pdf") {
+  return { document: { downloadContent: { query: vi.fn(async () => ({ contentBase64, mimeType })) } } };
+}
+
+describe("loadDocumentBlob", () => {
+  it("cache-hit → Blob utan nätanrop", async () => {
+    await cache.putBytes("sha-abc", new Uint8Array([1, 2, 3]));
+    const client = clientReturning("");
+    const blob = await loadDocumentBlob(client, doc, cache);
+    expect(blob).not.toBeNull();
+    expect(blob!.type).toBe("application/pdf");
+    expect(Array.from(new Uint8Array(await blob!.arrayBuffer()))).toEqual([1, 2, 3]);
+    expect(client.document.downloadContent.query).not.toHaveBeenCalled();
+  });
+
+  it("miss → download + cacha (nästa gång cache-hit)", async () => {
+    // base64 av [9,9,9]
+    const b64 = Buffer.from([9, 9, 9]).toString("base64");
+    const client = clientReturning(b64);
+    const blob = await loadDocumentBlob(client, doc, cache);
+    expect(Array.from(new Uint8Array(await blob!.arrayBuffer()))).toEqual([9, 9, 9]);
+    expect(client.document.downloadContent.query).toHaveBeenCalledWith({ documentId: "d1" });
+    // Cachad nu → ingen ny query
+    const client2 = clientReturning("");
+    await loadDocumentBlob(client2, doc, cache);
+    expect(client2.document.downloadContent.query).not.toHaveBeenCalled();
+  });
+
+  it("download-fel → null", async () => {
+    const client = { document: { downloadContent: { query: vi.fn(async () => { throw new Error("404"); }) } } };
+    expect(await loadDocumentBlob(client, doc, cache)).toBeNull();
+  });
+});

--- a/test/unit/lib/firma/open-document.test.ts
+++ b/test/unit/lib/firma/open-document.test.ts
@@ -92,6 +92,42 @@ describe("openDocument", () => {
     expect(openUrl).toHaveBeenCalledWith("blob:fake-url");
   });
 
+  it("server-first: fetchBlob används före FSA → opened-blob (loadHandle ej anropad)", async () => {
+    globalThis.URL.createObjectURL = vi.fn(() => "blob:server-first");
+    globalThis.URL.revokeObjectURL = vi.fn();
+    const loadHandle = vi.fn(async () => null);
+    const openUrl = vi.fn();
+    const result = await openDocument({
+      doc: baseDoc,
+      isDemo: false,
+      loadHandle,
+      readFromHandle: async () => null,
+      fetchBlob: async () => new Blob(["pdf"], { type: "application/pdf" }),
+      openUrl,
+      notifyError: vi.fn(),
+    });
+    expect(result).toBe("opened-blob");
+    expect(openUrl).toHaveBeenCalledWith("blob:server-first");
+    expect(loadHandle).not.toHaveBeenCalled(); // FSA hoppas helt
+  });
+
+  it("server-first: fetchBlob → null → notifyError, ingen URL", async () => {
+    const openUrl = vi.fn();
+    const notifyError = vi.fn();
+    const result = await openDocument({
+      doc: baseDoc,
+      isDemo: false,
+      loadHandle: async () => null,
+      readFromHandle: async () => null,
+      fetchBlob: async () => null,
+      openUrl,
+      notifyError,
+    });
+    expect(result).toBe("error");
+    expect(notifyError.mock.calls[0]![0]).toMatch(/kunde inte hämtas/i);
+    expect(openUrl).not.toHaveBeenCalled();
+  });
+
   it("self-hosted med .md fil → blob taggas med UTF-8 charset (annars trasas å/ä/ö)", async () => {
     globalThis.URL.createObjectURL = vi.fn(() => "blob:url");
     globalThis.URL.revokeObjectURL = vi.fn();


### PR DESCRIPTION
Producent-steg för byte-cachen + **fixar en riktig server-first-bugg**: att öppna ett dokument läste tidigare ur den *borttagna* FSA-working-copyn → "Ingen working copy ansluten". Nu hämtas bytes från servern och cachas.

## Ändringar
- **`loadDocumentBlob`** (öppna-primitiv): cache-hit (by storagePath-sha) → `Blob`; miss → `document.downloadContent` → cacha → `Blob`; fel → null.
- **`DocumentContentCache.putBytes`** — icke-pending läs-cache (download→cache).
- **`openDocument`**: ny `fetchBlob`-dep används **före** FSA (server-first-vägen); FSA-vägen utbruten till `openFromFsa` (komplexitet ≤8). Bakåtkompatibel — anropare utan `fetchBlob` faller tillbaka på FSA.
- Wirad i fakturadokument-öppningen (`invoices/_client` via `utils.client`).

## Effekt
Öppning populerar byte-cachen → **byte-synken (#524) får innehåll att jobba med**, och content-addresseringen gör cachen evigt giltig.

## Verifiering
- typecheck + eslint (`--max-warnings 0`, komplexitet ≤8) + knip + dep-cruiser + jscpd ✅
- `bun run test:cov` — 90.72% / 85.52% (golv 88.90/84.00); loadDocumentBlob (hit/miss/fel) + openDocument fetchBlob-gren ✅
- `bun run build:demo` ✅ (demon orörd — demo-grenen i openDocument oförändrad)

## Kvar i #518
Resten av öppna-sajterna (`_document-row`, search) + **spara-primitiv** (hash → `cache.cache()` + uploadContent) + explicit versions-UI + retire `markExternallyEdited`/FSA, och ta bort klient-web-llm. (Kräver trpc-klient-åtkomst utanför hooks för module-level öppnare — invoices hade redan `useUtils`.)

Refs #518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)