### PR TITLE
fix(sync): delta-synka document/documentFolder (härled org via ärendet) (#528)

### DIFF
--- a/src/lib/server/repositories/drizzle-document-folder-repository.ts
+++ b/src/lib/server/repositories/drizzle-document-folder-repository.ts
@@ -11,6 +11,7 @@ import type {
   DocumentFolderRepository, DocumentFolderWithCounts,
 } from "./document-folder-repository";
 import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { matterOrg } from "./matter-org";
 
 /** documentFolders.parentId = X, eller IS NULL för rot. */
 function parentEq(parentId: string | null) {
@@ -22,6 +23,11 @@ export class DrizzleDocumentFolderRepository
   implements DocumentFolderRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
     super(db, documentFolders as unknown as VersionedTable, now);
+  }
+
+  /** Mappar saknar org-kolumn → härled via ärendet (#528) så change_log/pull funkar. */
+  protected override resolveOrg(row: unknown): Promise<string | undefined> {
+    return matterOrg(this.db, (row as { matterId?: string }).matterId);
   }
 
   async listInParent(matterId: string, parentId: string | null): Promise<DocumentFolderWithCounts[]> {

--- a/src/lib/server/repositories/drizzle-document-repository.ts
+++ b/src/lib/server/repositories/drizzle-document-repository.ts
@@ -11,6 +11,7 @@ import type {
   DocumentAccessRow, DocumentListRow, DocumentRepository,
 } from "./document-repository";
 import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { matterOrg } from "./matter-org";
 
 /** documents.folderId = X, eller IS NULL för rot. */
 function folderEq(folderId: string | null) {
@@ -29,6 +30,11 @@ export class DrizzleDocumentRepository
   implements DocumentRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
     super(db, documents as unknown as VersionedTable, now);
+  }
+
+  /** Dokument saknar org-kolumn → härled via ärendet (#528) så change_log/pull funkar. */
+  protected override resolveOrg(row: unknown): Promise<string | undefined> {
+    return matterOrg(this.db, (row as { matterId?: string }).matterId);
   }
 
   async listInFolder(

--- a/src/lib/server/repositories/drizzle-repository.ts
+++ b/src/lib/server/repositories/drizzle-repository.ts
@@ -83,15 +83,29 @@ export class DrizzleRepository<Row extends RowBase> implements Repository<Row> {
     await this.db.delete(this.table).where(eq(this.table.id, id));
   }
 
-  /** Append en change_log-rad om loggning är på och raden är org-scopad. */
+  /**
+   * Org-id för en rad (för change_log). Default: rad-kolumnen. Override:as av
+   * matter-scopade org-lösa entiteter (document/documentFolder, #528) som
+   * härleder org via ärendet — annars loggas de aldrig → delta-synkas ej.
+   */
+  protected resolveOrg(row: unknown): Promise<string | undefined> | string | undefined {
+    return (row as { organizationId?: string }).organizationId;
+  }
+
+  /** Append en change_log-rad om loggning är på och org kunde härledas. */
   private async logChange(row: unknown, op: ChangeOp): Promise<void> {
     if (!this.changeLog) return;
-    const r = row as { id?: string; organizationId?: string; version?: number };
-    if (!r.id || !r.organizationId) return; // org-lösa entiteter syncas ej via delta
+    const r = row as { id?: string; version?: number };
+    const organizationId = await this.resolveOrg(row);
+    if (!r.id || !organizationId) return; // utan org kan raden inte delta-synkas
+    // getTableName ger snake_case (`document_folders`); ENTITY_NAME_BY_SOURCE_KEY
+    // är keyat på camelCase source-key (`documentFolders`). Konvertera, annars
+    // får fler-ords-tabeller fel entitetsnamn → klientens apply känner ej igen dem.
     const tableName = getTableName(this.table);
+    const sourceKey = tableName.replace(/_([a-z])/g, (_m, c: string) => c.toUpperCase());
     await this.changeLog.record({
-      organizationId: r.organizationId,
-      entity: ENTITY_NAME_BY_SOURCE_KEY[tableName] ?? tableName,
+      organizationId,
+      entity: ENTITY_NAME_BY_SOURCE_KEY[sourceKey] ?? ENTITY_NAME_BY_SOURCE_KEY[tableName] ?? tableName,
       rowId: r.id,
       version: r.version ?? 1,
       op,

--- a/src/lib/server/repositories/matter-org.ts
+++ b/src/lib/server/repositories/matter-org.ts
@@ -1,0 +1,21 @@
+/**
+ * `matterOrg` (#528) — härled `organizationId` för en matter-scopad entitet som
+ * saknar egen org-kolumn (document, documentFolder, …) via dess ärende. Används
+ * av repo:ernas `resolveOrg`-override så change_log får rätt org → de delta-
+ * synkas via pull (annars hoppades de över; bara org-kolumn-bärande rader
+ * loggades).
+ */
+
+import { eq } from "drizzle-orm";
+import { matters } from "../db/schema";
+import type { AppDb } from "../db/types";
+
+export async function matterOrg(db: AppDb, matterId: string | null | undefined): Promise<string | undefined> {
+  if (!matterId) return undefined;
+  const [m] = await db
+    .select({ org: matters.organizationId })
+    .from(matters)
+    .where(eq(matters.id, matterId))
+    .limit(1);
+  return m?.org ?? undefined;
+}

--- a/test/unit/server/sync/drizzle-sync-store.test.ts
+++ b/test/unit/server/sync/drizzle-sync-store.test.ts
@@ -84,4 +84,22 @@ describe("DrizzleSyncStore (#sync-bridge)", () => {
     expect(change).toMatchObject({ entity: "matter", deleted: true });
     expect(await repos.matters.getById(m2)).toBeNull();
   });
+
+  // #528: document/documentFolder saknar org-kolumn → org härleds via ärendet
+  // (resolveOrg-override) så de loggas i change_log och delta-synkas via pull.
+  it("document + documentFolder delta-synkas via pull (org härledd ur ärendet, #528)", async () => {
+    const m3 = uuidv7(), folder = uuidv7(), doc = uuidv7(), user = uuidv7();
+    await repos.matters.create({ id: m3, organizationId: ORG, title: "Dok-synk", status: "ACTIVE", matterNumber: "2026-0011" } as never);
+    const cursor = (await sync.pull(ORG, 0)).cursor;
+
+    await repos.documentFolders.create({ id: folder, matterId: m3, name: "Inlagor", parentId: null } as never);
+    await repos.documents.create({
+      id: doc, matterId: m3, fileName: "stamning.pdf", mimeType: "application/pdf",
+      sizeBytes: 10, storagePath: "documents/content/x", uploadedById: user, folderId: folder,
+    } as never);
+
+    const changes = (await sync.pull(ORG, cursor)).changes;
+    expect(changes.find((c) => c.row.id === folder)).toMatchObject({ entity: "documentFolder" });
+    expect(changes.find((c) => c.row.id === doc)).toMatchObject({ entity: "document" });
+  });
 });

--- a/tooling/scripts/server-first-offline-e2e.ts
+++ b/tooling/scripts/server-first-offline-e2e.ts
@@ -77,11 +77,9 @@ function assert(cond: boolean, msg: string): void {
 }
 
 /**
- * Verifiera mot den AUKTORITATIVA server-staten (Postgres-tabellerna) i st.f.
- * change_log/pull — pull täcker bara org-scopade entiteter (matter), medan
- * document/documentFolder (utan org-kolumn) skrivs till sina tabeller men
- * loggas inte i change_log (känd lucka, separat issue). DB-frågan svarar på det
- * scenariot faktiskt frågar: "nådde offline-ändringen servern?".
+ * Verifiera mot den AUKTORITATIVA server-staten (Postgres-tabellerna). Svarar
+ * direkt på det scenariot frågar: "nådde offline-ändringen servern?". (Sedan
+ * #528 delta-synkas document/documentFolder även via pull — se assert nedan.)
  */
 async function withDb<T>(fn: (sql: ReturnType<typeof postgres>) => Promise<T>): Promise<T> {
   const sql = postgres(DB_URL, { max: 1, onnotice: () => {} });
@@ -124,7 +122,11 @@ async function main(): Promise<void> {
   assert(doc0?.file_name === "stamning.pdf", "dokumentet skapat med rätt namn");
   assert(doc0?.folder_id === folderA, "dokumentet ligger i mapp A");
   assert(await folderExists(folderB), "mapp B skapad");
-  console.log("✓ FAS 1 (online): ärende + mappar + dokument synkade");
+  // #528: document/documentFolder delta-synkas nu via pull (org härledd ur ärendet).
+  const pulledIds = new Set((await t.pull(0)).changes.map((c) => c.row.id));
+  assert(pulledIds.has(doc1), "dokumentet delta-synkas via pull (#528)");
+  assert(pulledIds.has(folderA) && pulledIds.has(folderB), "mapparna delta-synkas via pull (#528)");
+  console.log("✓ FAS 1 (online): ärende + mappar + dokument synkade (+ pull-bara, #528)");
 
   // ── FAS 2: OFFLINE — köa ändringar UTAN att pusha ────────────────
   const offlineMuts = [


### PR DESCRIPTION
Fixar luckan som offline/online-E2E:n (#529) blottlade: `document`/`documentFolder`-ändringar skrevs till tabellerna men **delta-synkades inte via pull**. Två buggar:

1. **Org-härledning** — bas-repot hoppade change_log för rader utan `organizationId`-kolumn (document/folder saknar den). Ny overridebar `resolveOrg`; document/folder-repona härleder org via ärendet (delad `matterOrg`-helper) → de loggas nu.
2. **Entitetsnamn** — `getTableName` ger snake_case (`document_folders`), men `ENTITY_NAME_BY_SOURCE_KEY` är keyad på camelCase (`documentFolders`). Enords-tabeller (matters/documents) matchade av en slump; fler-ords föll igenom → fel `entity` → klientens apply kände inte igen dem. Konverterar nu snake→camel → **reparerar delta-synk för ALLA fler-ords-entiteter** (timeEntries, calendarEvents, matterContacts, …), inte bara dokument.

## Tester
- `drizzle-sync-store`: nytt test — document **och** documentFolder syns nu i `pull` med rätt entitet (org härledd ur ärendet).
- Offline/online-E2E (#529): la till pull-assertion att dokument/mappar är **pull-bara** (delta-synkas), körs mot docker i CI:s `server-first-e2e`.

## Verifiering
- typecheck + eslint (`--max-warnings 0`) + knip + dep-cruiser + jscpd ✅
- `bun run test:cov` — 90.70% / 85.56% (golv 88.90/84.00) ✅
- Logiken bevisad i unit-test (pglite); artefakten valideras av CI:s docker-E2E.

Closes #528. Refs #518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)