### PR TITLE
test(e2e): 10 ändringar/5 dokument offline (mät sync-tid) + revert-version (#531)

### DIFF
--- a/tooling/scripts/server-first-offline-e2e.ts
+++ b/tooling/scripts/server-first-offline-e2e.ts
@@ -91,12 +91,99 @@ const docRow = (id: string): Promise<{ file_name: string; folder_id: string | nu
   withDb(async (sql) => ((await sql`SELECT file_name, folder_id FROM documents WHERE id = ${id}` as unknown as Array<{ file_name: string; folder_id: string | null }>)[0]));
 const folderExists = (id: string): Promise<boolean> =>
   withDb(async (sql) => ((await sql`SELECT 1 FROM document_folders WHERE id = ${id}` as unknown as unknown[]).length > 0));
+interface DocFull { file_name: string; folder_id: string | null; storage_path: string; version: number }
+const docFull = (id: string): Promise<DocFull | undefined> =>
+  withDb(async (sql) => ((await sql`SELECT file_name, folder_id, storage_path, version FROM documents WHERE id = ${id}` as unknown as DocFull[])[0]));
 
 async function pushAll(t: TrpcSyncTransport, muts: Mutation[]): Promise<void> {
   for (const m of muts) {
     const res = await t.push(m);
     if (res.status !== "accepted") throw new Error(`push ej accepterad (${m.entity}/${m.kind}): ${res.status}`);
   }
+}
+
+/** Pollar `pred` tills sann eller timeout. */
+async function waitUntil(pred: () => Promise<boolean>, label: string, timeoutMs: number): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await pred()) return;
+    await sleep(100);
+  }
+  throw new Error(`timeout: ${label} (${timeoutMs}ms)`);
+}
+
+function docMut(kind: "create" | "update", base: Record<string, unknown>, fileName: string, storagePath: string, sizeBytes: number): Mutation {
+  return mut("document", kind, { ...base, fileName, storagePath, sizeBytes });
+}
+
+/**
+ * FAS 4 (#531): 10 ändringar i 5 dokument offline → mät sync-tid + verifiera data.
+ * Varje dokument ändras två gånger offline (10 ändringar); coalesce behåller
+ * senaste per dokument → 5 pushar vid online. Mät tid tills servern speglar alla.
+ */
+async function tenChangesFiveDocs(t: TrpcSyncTransport, matterId: string, folderId: string, userId: string): Promise<void> {
+  const ids = Array.from({ length: 5 }, () => uuidv7());
+  const base = (id: string) => ({ id, matterId, mimeType: "application/pdf", uploadedById: userId, folderId });
+  await pushAll(t, ids.map((id, i) => docMut("create", base(id), `dok${i}.pdf`, `documents/content/d${i}-v0`, 100 + i)));
+
+  // OFFLINE: 10 ändringar (2/dok) — köas, INTE pushade.
+  const finalName = (i: number) => `dok${i}-final.pdf`;
+  const finalPath = (i: number) => `documents/content/d${i}-v2`;
+  const queued: Mutation[] = [];
+  ids.forEach((id, i) => {
+    queued.push(docMut("update", base(id), `dok${i}-tmp.pdf`, `documents/content/d${i}-v1`, 200 + i));
+    queued.push(docMut("update", base(id), finalName(i), finalPath(i), 300 + i));
+  });
+  assert(queued.length === 10, "10 offline-ändringar köade");
+  // Servern oförändrad (inget pushat).
+  assert((await docFull(ids[0]!))?.file_name === "dok0.pdf", "offline: servern visar ursprungsnamn");
+
+  // Coalesce per dokument (senaste vinner) → 5 effektiva pushar.
+  const coalesced = [...new Map(queued.map((m) => [(m.row as { id: string }).id, m])).values()];
+  assert(coalesced.length === 5, "coalesce: 10 ändringar → 5 dokument");
+
+  // ONLINE: mät tid tills servern speglar alla 5 slutvärden.
+  const t0 = Date.now();
+  await pushAll(t, coalesced);
+  await waitUntil(
+    async () => (await Promise.all(ids.map(docFull))).every((r, i) => r?.file_name === finalName(i)),
+    "alla 5 dokument synkade", 30_000,
+  );
+  const elapsed = Date.now() - t0;
+  for (let i = 0; i < 5; i++) {
+    const r = await docFull(ids[i]!);
+    assert(r?.file_name === finalName(i), `dok${i}: rätt slutnamn på servern`);
+    assert(r?.storage_path === finalPath(i), `dok${i}: rätt content-pekare på servern`);
+  }
+  console.log(`✓ FAS 4: 10 ändringar i 5 dokument (coalesce→5) synkade på ${elapsed} ms; data verifierad`);
+}
+
+/**
+ * FAS 5 (#531): backa till en äldre version + gör ändringar + spara → verifiera
+ * servern. Content-adresserat (ADR 0023): revert = ny version som pekar på den
+ * gamla hashen; varje skrivning bumpar `version`.
+ */
+async function revertVersions(t: TrpcSyncTransport, matterId: string, folderId: string, userId: string): Promise<void> {
+  const id = uuidv7();
+  const base = { id, matterId, mimeType: "application/pdf", uploadedById: userId, folderId };
+  await pushAll(t, [docMut("create", base, "avtal-v1.pdf", "documents/content/sha-v1", 10)]);
+  await pushAll(t, [docMut("update", base, "avtal-v2.pdf", "documents/content/sha-v2", 20)]);
+  const v2 = await docFull(id);
+  assert(v2?.file_name === "avtal-v2.pdf" && v2?.storage_path === "documents/content/sha-v2", "v2 på servern");
+
+  // Backa till v1 (ny version som pekar på v1:s content-hash).
+  await pushAll(t, [docMut("update", base, "avtal-v1.pdf", "documents/content/sha-v1", 10)]);
+  const reverted = await docFull(id);
+  assert(reverted?.storage_path === "documents/content/sha-v1", "revert: servern pekar på v1-content");
+  assert(reverted!.version > v2!.version, "revert skapar en NY version (version bumpad)");
+
+  // Gör ändringar och spara (offline → online).
+  await pushAll(t, [docMut("update", base, "avtal-v1-redigerad.pdf", "documents/content/sha-v3", 33)]);
+  const final = await docFull(id);
+  assert(final?.file_name === "avtal-v1-redigerad.pdf", "final: rätt namn på servern");
+  assert(final?.storage_path === "documents/content/sha-v3", "final: rätt content-pekare på servern");
+  assert(final!.version > reverted!.version, "ändring efter revert = ytterligare version");
+  console.log(`✓ FAS 5: backa till v1 → ändra → spara; servern har rätt data (version ${final!.version})`);
 }
 
 async function main(): Promise<void> {
@@ -147,6 +234,12 @@ async function main(): Promise<void> {
   assert(docNew?.file_name === "stamning-reviderad.pdf", "online: dokumentnamn synkat");
   assert(docNew?.folder_id === folderB, "online: dokumentet flyttat till mapp B");
   console.log("✓ FAS 3 (online): köade ändringar (ärende/namn/mapp) synkade till servern");
+
+  // ── FAS 4: 10 ändringar i 5 dokument offline → mät sync-tid + data (#531) ──
+  await tenChangesFiveDocs(t, m1, folderA, userId);
+
+  // ── FAS 5: backa till äldre version + ändra + spara → verifiera data (#531) ──
+  await revertVersions(t, m1, folderA, userId);
 
   console.log("✓ server-first offline/online-E2E: alla faser gröna");
 }


### PR DESCRIPTION
Utökar offline/online-E2E:n (mot docker-compose-server-first-stacken) med två scenarier:

## FAS 4 — 10 ändringar i 5 dokument offline → mät sync-tid + verifiera data
Skapar 5 dokument, gör **10 ändringar offline** (2 per dokument). Coalesce (ditt val) → senaste per dokument = 5 pushar vid online. **Mäter tiden** från push-start tills servern speglar alla 5 slutvärden, och verifierar **namn + content-pekare per dokument**. Lokalt mot docker: **~58 ms**.

## FAS 5 — backa till äldre version → ändra → spara → verifiera servern
Content-adresserat (ADR 0023): create v1 → update v2 → **revert till v1** (ny version som pekar på v1:s hash) → **ändra + spara** (ny content-hash). Verifierar att servern har rätt namn/content-pekare och att `version` bumpas för varje skrivning (revert + edit = distinkta versioner; slutversion 4).

## Verifiering
- typecheck + eslint (`--max-warnings 0`) ✅
- **Lokalt mot docker: alla 5 faser gröna** (byggd binär + compose up + migrate + körd).
- Kör i CI:s `server-first-e2e`-jobb mot samma stack.

Closes #531. Refs #518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)