### PR TITLE
feat(client): spara-primitiv — ladda upp dokument-bytes till servern (#518)

### DIFF
--- a/src/components/documents/document-browser.tsx
+++ b/src/components/documents/document-browser.tsx
@@ -236,6 +236,31 @@ function UploadErrorBanner({ message, onDismiss }: { message: string; onDismiss:
   );
 }
 
+interface UploadResult { id: string; fileName: string; mimeType: string; sizeBytes: number; storagePath: string }
+
+/**
+ * Lös var bytes hamnar: FSA (lokal working copy om ansluten) eller server-first
+ * (#518) — generera id + läs bytes som laddas upp content-adresserat efter
+ * register. `serverBytes` är null i FSA-fallet.
+ */
+async function resolveUpload(file: File, matterId: string): Promise<{ result: UploadResult; serverBytes: Uint8Array | null }> {
+  const { isFsaSupported, loadHandle } = await import("@/lib/client/fsa/handle-store");
+  const handle = isFsaSupported() ? await loadHandle("repo-root") : null;
+  if (handle) {
+    const { uploadDocumentToFsa } = await import("@/lib/client/fsa/upload-document");
+    return { result: await uploadDocumentToFsa({ handle, matterId, file }), serverBytes: null };
+  }
+  const { uuidv7 } = await import("@/lib/shared/uuid");
+  const id = uuidv7();
+  return {
+    result: {
+      id, fileName: file.name, mimeType: file.type || "application/octet-stream",
+      sizeBytes: file.size, storagePath: `documents/content/pending-${id}`,
+    },
+    serverBytes: new Uint8Array(await file.arrayBuffer()),
+  };
+}
+
 /**
  * Uppladdnings-state + handler: optimistiska placeholder-rader, FSA-write,
  * tRPC-register, invalidate och bakgrundsjobb (klassificering + text-extraktion).
@@ -272,21 +297,7 @@ function useFileUpload({ matterId, mutations, fileInputRef }: {
     };
 
     try {
-      const { isFsaSupported, loadHandle } = await import("@/lib/client/fsa/handle-store");
-      if (!isFsaSupported()) {
-        throw new Error(
-          "Din webbläsare stödjer inte File System Access. Använd Chrome eller Edge."
-        );
-      }
-      const handle = await loadHandle("repo-root");
-      if (!handle) {
-        throw new Error(
-          "Ingen lokal mapp är vald. Gå till Inställningar → välj din firma-mapp och försök igen."
-        );
-      }
-
-      const { uploadDocumentToFsa } = await import("@/lib/client/fsa/upload-document");
-      const result = await uploadDocumentToFsa({ handle, matterId, file });
+      const { result, serverBytes } = await resolveUpload(file, matterId);
 
       // Byt placeholder-id mot riktigt id så raden inte hoppar.
       setUploadingIds((s) => {
@@ -303,6 +314,12 @@ function useFileUpload({ matterId, mutations, fileInputRef }: {
           sizeBytes: result.sizeBytes,
           storagePath: result.storagePath,
         });
+        // Server-first: ladda upp bytes (content-adresserat) efter att metadatan
+        // registrerats → repekar storagePath + triggar server-klassificering.
+        if (serverBytes) {
+          const { saveDocumentContent } = await import("@/lib/client/backend/save-document-content");
+          await saveDocumentContent(utils.client, result.id, serverBytes);
+        }
       } finally {
         await utils.document.tree.invalidate({ matterId });
         setUploadingIds((s) => {

--- a/src/lib/client/backend/save-document-content.ts
+++ b/src/lib/client/backend/save-document-content.ts
@@ -1,0 +1,33 @@
+"use client";
+
+/**
+ * `saveDocumentContent` (#518, ADR 0023) — spara-primitiv: cacha dokument-bytes
+ * (content-adresserat, markerat pending) + ladda upp via `document.uploadContent`
+ * (servern content-adresserar + repekar `storagePath`).
+ *
+ * Online: uploadContent når servern direkt. Offline: mutationen körs in-process
+ * (köas) och blobben ligger pending i cachen → byte-synken (`syncDocumentContent`)
+ * laddar upp den vid reconnect. Samma skriv-väg oavsett.
+ */
+
+import { bytesToBase64, sha256Hex } from "@/lib/shared/content-address";
+import { DocumentContentCache } from "./content-cache";
+
+/** tRPC-ytan primitiven behöver (strukturell). */
+export interface UploadClient {
+  document: {
+    uploadContent: { mutate: (input: { documentId: string; contentBase64: string }) => Promise<unknown> };
+  };
+}
+
+export async function saveDocumentContent(
+  client: UploadClient,
+  documentId: string,
+  bytes: Uint8Array,
+  cache: DocumentContentCache = new DocumentContentCache(),
+): Promise<string> {
+  const sha = await sha256Hex(bytes);
+  await cache.cache(documentId, sha, bytes); // blob + pending (offline-säkert)
+  await client.document.uploadContent.mutate({ documentId, contentBase64: bytesToBase64(bytes) });
+  return sha;
+}

--- a/test/unit/client/backend/save-document-content.test.ts
+++ b/test/unit/client/backend/save-document-content.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Tester för `saveDocumentContent` (#518, ADR 0023) — spara-primitiven:
+ * cacha (pending) + ladda upp via uploadContent. Fake-indexeddb + fake-klient.
+ */
+
+import { IDBFactory } from "fake-indexeddb";
+import { beforeEach, describe, expect, it, vi } from "vitest-compat";
+import { DocumentContentCache } from "@/lib/client/backend/content-cache";
+import { saveDocumentContent } from "@/lib/client/backend/save-document-content";
+import { base64ToBytes, sha256Hex } from "@/lib/shared/content-address";
+
+let cache: DocumentContentCache;
+beforeEach(() => { cache = new DocumentContentCache(new IDBFactory()); });
+
+describe("saveDocumentContent", () => {
+  it("cachar bytes (pending) + laddar upp via uploadContent (base64)", async () => {
+    const uploads: Array<{ documentId: string; contentBase64: string }> = [];
+    const client = { document: { uploadContent: { mutate: async (i: { documentId: string; contentBase64: string }) => { uploads.push(i); } } } };
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+
+    const sha = await saveDocumentContent(client, "doc-1", bytes, cache);
+
+    expect(sha).toBe(await sha256Hex(bytes));
+    // Pending → byte-synken laddar upp vid reconnect (offline-säkert).
+    expect(await cache.pendingUploads()).toEqual([{ documentId: "doc-1", sha }]);
+    expect(Array.from((await cache.getBytes(sha))!)).toEqual([1, 2, 3, 4]);
+    // uploadContent anropad med rätt bytes.
+    expect(uploads).toHaveLength(1);
+    expect(uploads[0]!.documentId).toBe("doc-1");
+    expect(Array.from(base64ToBytes(uploads[0]!.contentBase64))).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/test/unit/client/backend/save-document-content.test.ts
+++ b/test/unit/client/backend/save-document-content.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { IDBFactory } from "fake-indexeddb";
-import { beforeEach, describe, expect, it, vi } from "vitest-compat";
+import { beforeEach, describe, expect, it } from "vitest-compat";
 import { DocumentContentCache } from "@/lib/client/backend/content-cache";
 import { saveDocumentContent } from "@/lib/client/backend/save-document-content";
 import { base64ToBytes, sha256Hex } from "@/lib/shared/content-address";


### PR DESCRIPTION
Producentens **skriv-sida**: dokument-upload i server-first laddar nu upp bytes till servern i st.f. att kräva den borttagna FSA-mappen (kastade *"Ingen lokal mapp"*). Komplett byte-loop tillsammans med öppna-primitiven (#526).

## Ändringar
- **`saveDocumentContent`**: hasha → cacha (pending, offline-säkert) → `uploadContent` (content-adresserar + repekar `storagePath` server-side + triggar server-klassning). Offline → mutationen köas in-process + blobben ligger pending → byte-synken (#524) laddar upp vid reconnect.
- **`document-browser`-upload**: `resolveUpload` väljer FSA (om working copy ansluten) annars **server-first** (generera id → register → `saveDocumentContent`). Fixar trasig server-first-upload; demo/FSA oförändrat när handle finns.

## Verifiering
- typecheck + eslint (`--max-warnings 0`, komplexitet ≤8) + knip + dep-cruiser + jscpd ✅
- `bun run test:cov` — 90.71% / 85.46% (golv 88.90/84.00) ✅
- `bun run build:demo` ✅

Refs #518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)