### PR TITLE
refactor(repos): type-checkad versionedTable-helper (eliminerar 28 cast)

### DIFF
--- a/src/lib/server/repositories/drizzle-acconto-deduction-repository.ts
+++ b/src/lib/server/repositories/drizzle-acconto-deduction-repository.ts
@@ -6,12 +6,12 @@ import type { AccontoDeduction } from "@/lib/shared/schemas/billing";
 import { accontoDeductions } from "../db/schema";
 import type { AppDb } from "../db/types";
 import type { AccontoDeductionRepository } from "./acconto-deduction-repository";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 
 export class DrizzleAccontoDeductionRepository
   extends DrizzleRepository<AccontoDeduction>
   implements AccontoDeductionRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, accontoDeductions as unknown as VersionedTable, now);
+    super(db, versionedTable(accontoDeductions), now);
   }
 }

--- a/src/lib/server/repositories/drizzle-billing-run-repository.ts
+++ b/src/lib/server/repositories/drizzle-billing-run-repository.ts
@@ -10,13 +10,13 @@ import type { AppDb } from "../db/types";
 import type {
   BillingRunDetailRow, BillingRunListRow, BillingRunRepository,
 } from "./billing-run-repository";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 
 export class DrizzleBillingRunRepository
   extends DrizzleRepository<BillingRun>
   implements BillingRunRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, billingRuns as unknown as VersionedTable, now);
+    super(db, versionedTable(billingRuns), now);
   }
 
   async listForOrg(organizationId: string, matterId?: string): Promise<BillingRunListRow[]> {

--- a/src/lib/server/repositories/drizzle-calendar-event-repository.ts
+++ b/src/lib/server/repositories/drizzle-calendar-event-repository.ts
@@ -8,7 +8,7 @@ import type { CalendarEvent } from "@/lib/shared/schemas/calendar";
 import { calendarEvents, matters } from "../db/schema";
 import type { AppDb } from "../db/types";
 import type { CalendarEventRepository, CalendarEventRow } from "./calendar-event-repository";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 
 type MatterCols = { mId: string | null; mNum: string | null; mTitle: string | null };
 
@@ -21,7 +21,7 @@ function withMatter<T extends MatterCols & { ev: unknown }>(r: T): CalendarEvent
 
 export class DrizzleCalendarEventRepository extends DrizzleRepository<CalendarEvent> implements CalendarEventRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, calendarEvents as unknown as VersionedTable, now);
+    super(db, versionedTable(calendarEvents), now);
   }
 
   private matterSelect() {

--- a/src/lib/server/repositories/drizzle-conflict-check-repository.ts
+++ b/src/lib/server/repositories/drizzle-conflict-check-repository.ts
@@ -8,13 +8,13 @@ import type { ConflictCheck } from "@/lib/shared/schemas/misc";
 import { conflictChecks, users } from "../db/schema";
 import type { AppDb } from "../db/types";
 import type { ConflictCheckRepository, ConflictCheckRow } from "./conflict-check-repository";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 
 export class DrizzleConflictCheckRepository
   extends DrizzleRepository<ConflictCheck>
   implements ConflictCheckRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, conflictChecks as unknown as VersionedTable, now);
+    super(db, versionedTable(conflictChecks), now);
   }
 
   async listHistory(page: number, pageSize: number): Promise<{ checks: ConflictCheckRow[]; total: number }> {

--- a/src/lib/server/repositories/drizzle-contact-repository.ts
+++ b/src/lib/server/repositories/drizzle-contact-repository.ts
@@ -12,11 +12,11 @@ import type { AppDb } from "../db/types";
 import type {
   ContactFull, ContactListOptions, ContactListResult, ContactListRow, ContactRepository,
 } from "./contact-repository";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 
 export class DrizzleContactRepository extends DrizzleRepository<Contact> implements ContactRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, contacts as unknown as VersionedTable, now);
+    super(db, versionedTable(contacts), now);
   }
 
   async listForOrg(organizationId: string, opts: ContactListOptions): Promise<ContactListResult> {

--- a/src/lib/server/repositories/drizzle-document-folder-repository.ts
+++ b/src/lib/server/repositories/drizzle-document-folder-repository.ts
@@ -10,7 +10,7 @@ import type { AppDb } from "../db/types";
 import type {
   DocumentFolderRepository, DocumentFolderWithCounts,
 } from "./document-folder-repository";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import { matterOrg } from "./matter-org";
 
 /** documentFolders.parentId = X, eller IS NULL för rot. */
@@ -22,7 +22,7 @@ export class DrizzleDocumentFolderRepository
   extends DrizzleRepository<DocumentFolder>
   implements DocumentFolderRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, documentFolders as unknown as VersionedTable, now);
+    super(db, versionedTable(documentFolders), now);
   }
 
   /** Mappar saknar org-kolumn → härled via ärendet (#528) så change_log/pull funkar. */

--- a/src/lib/server/repositories/drizzle-document-repository.ts
+++ b/src/lib/server/repositories/drizzle-document-repository.ts
@@ -10,7 +10,7 @@ import type { AppDb } from "../db/types";
 import type {
   DocumentAccessRow, DocumentListRow, DocumentRepository,
 } from "./document-repository";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import { matterOrg } from "./matter-org";
 
 /** documents.folderId = X, eller IS NULL för rot. */
@@ -29,7 +29,7 @@ export class DrizzleDocumentRepository
   extends DrizzleRepository<Document>
   implements DocumentRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, documents as unknown as VersionedTable, now);
+    super(db, versionedTable(documents), now);
   }
 
   /** Dokument saknar org-kolumn → härled via ärendet (#528) så change_log/pull funkar. */

--- a/src/lib/server/repositories/drizzle-document-suggestion-repository.ts
+++ b/src/lib/server/repositories/drizzle-document-suggestion-repository.ts
@@ -10,7 +10,7 @@ import type { AppDb } from "../db/types";
 import type {
   DocumentSuggestionRepository, SuggestionListRow, SuggestionWithMatter,
 } from "./document-suggestion-repository";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 
 const S = documentAnalysisSuggestions;
 
@@ -18,7 +18,7 @@ export class DrizzleDocumentSuggestionRepository
   extends DrizzleRepository<DocumentAnalysisSuggestion>
   implements DocumentSuggestionRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, S as unknown as VersionedTable, now);
+    super(db, versionedTable(S), now);
   }
 
   async getByIdInOrg(id: string, organizationId: string): Promise<SuggestionWithMatter | null> {

--- a/src/lib/server/repositories/drizzle-document-template-repository.ts
+++ b/src/lib/server/repositories/drizzle-document-template-repository.ts
@@ -10,13 +10,13 @@ import type { AppDb } from "../db/types";
 import type {
   DocumentTemplateListRow, DocumentTemplateRepository, DocumentTemplateRow,
 } from "./document-template-repository";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 
 export class DrizzleDocumentTemplateRepository
   extends DrizzleRepository<DocumentTemplate>
   implements DocumentTemplateRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, documentTemplates as unknown as VersionedTable, now);
+    super(db, versionedTable(documentTemplates), now);
   }
 
   async listForOrg(organizationId: string): Promise<DocumentTemplateListRow[]> {

--- a/src/lib/server/repositories/drizzle-expected-receivable-repository.ts
+++ b/src/lib/server/repositories/drizzle-expected-receivable-repository.ts
@@ -6,14 +6,14 @@ import { and, desc, eq, isNull } from "drizzle-orm";
 import type { ExpectedReceivable } from "@/lib/shared/schemas/billing";
 import { expectedReceivables } from "../db/schema";
 import type { AppDb } from "../db/types";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import type { ExpectedReceivableListFilter, ExpectedReceivableRepository } from "./expected-receivable-repository";
 
 export class DrizzleExpectedReceivableRepository
   extends DrizzleRepository<ExpectedReceivable>
   implements ExpectedReceivableRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, expectedReceivables as unknown as VersionedTable, now);
+    super(db, versionedTable(expectedReceivables), now);
   }
 
   async listForOrg(organizationId: string, filter?: ExpectedReceivableListFilter): Promise<ExpectedReceivable[]> {

--- a/src/lib/server/repositories/drizzle-expense-repository.ts
+++ b/src/lib/server/repositories/drizzle-expense-repository.ts
@@ -7,14 +7,14 @@ import { and, asc, desc, eq, gte, inArray, isNull, lte, sql } from "drizzle-orm"
 import type { Expense } from "@/lib/shared/schemas/billing";
 import { expenses, invoices, matters, users } from "../db/schema";
 import type { AppDb } from "../db/types";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import type {
   ExpenseListOptions, ExpenseListResult, ExpenseListRow, ExpenseRepository, LawyerReportExpense,
 } from "./expense-repository";
 
 export class DrizzleExpenseRepository extends DrizzleRepository<Expense> implements ExpenseRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, expenses as unknown as VersionedTable, now);
+    super(db, versionedTable(expenses), now);
   }
 
   async listForOrg(organizationId: string, opts: ExpenseListOptions): Promise<ExpenseListResult> {

--- a/src/lib/server/repositories/drizzle-invoice-dispatch-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-dispatch-repository.ts
@@ -7,14 +7,14 @@ import { and, asc, desc, eq, isNull } from "drizzle-orm";
 import type { InvoiceDispatch } from "@/lib/shared/schemas/billing";
 import { invoiceDispatches, invoices, matters } from "../db/schema";
 import type { AppDb } from "../db/types";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import type { InvoiceDispatchQueuedRow, InvoiceDispatchRepository } from "./invoice-dispatch-repository";
 
 export class DrizzleInvoiceDispatchRepository
   extends DrizzleRepository<InvoiceDispatch>
   implements InvoiceDispatchRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, invoiceDispatches as unknown as VersionedTable, now);
+    super(db, versionedTable(invoiceDispatches), now);
   }
 
   async listByInvoice(invoiceId: string): Promise<InvoiceDispatch[]> {

--- a/src/lib/server/repositories/drizzle-invoice-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-repository.ts
@@ -13,7 +13,7 @@ import { and, desc, eq, inArray, isNull, like, sql } from "drizzle-orm";
 import type { Invoice, Payment, WriteOff } from "@/lib/shared/schemas/billing";
 import { accontoDeductions, invoices, matters, paymentPlans, payments, writeOffs } from "../db/schema";
 import type { AppDb } from "../db/types";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import {
   invoiceNumberPrefix, nextInvoiceNumberFrom,
   type InvoiceFull, type InvoiceListFilter, type InvoiceListRow, type InvoiceRepository,
@@ -22,7 +22,7 @@ import {
 
 export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> implements InvoiceRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, invoices as unknown as VersionedTable, now);
+    super(db, versionedTable(invoices), now);
   }
 
   async getByIdInOrg(id: string, organizationId: string): Promise<Invoice | null> {

--- a/src/lib/server/repositories/drizzle-matter-contact-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-contact-repository.ts
@@ -9,7 +9,7 @@ import type { Contact } from "@/lib/shared/schemas/contact";
 import type { MatterContact } from "@/lib/shared/schemas/matter";
 import { contacts, matterContacts, matters } from "../db/schema";
 import type { AppDb } from "../db/types";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import type {
   ConflictContactRow, MatterContactRepository, MatterContactWithContact,
 } from "./matter-contact-repository";
@@ -18,7 +18,7 @@ export class DrizzleMatterContactRepository
   extends DrizzleRepository<MatterContact>
   implements MatterContactRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, matterContacts as unknown as VersionedTable, now);
+    super(db, versionedTable(matterContacts), now);
   }
 
   async findForConflict(organizationId: string, numberTerm?: string): Promise<ConflictContactRow[]> {

--- a/src/lib/server/repositories/drizzle-matter-event-suggestion-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-event-suggestion-repository.ts
@@ -7,7 +7,7 @@ import { and, asc, eq, isNull, ne } from "drizzle-orm";
 import type { MatterEventSuggestion } from "@/lib/shared/schemas/document";
 import { documents, matterEventSuggestions, matters } from "../db/schema";
 import type { AppDb } from "../db/types";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import type {
   MatterEventSuggestionRepository, MatterEventSuggestionRow,
 } from "./matter-event-suggestion-repository";
@@ -16,7 +16,7 @@ export class DrizzleMatterEventSuggestionRepository
   extends DrizzleRepository<MatterEventSuggestion>
   implements MatterEventSuggestionRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, matterEventSuggestions as unknown as VersionedTable, now);
+    super(db, versionedTable(matterEventSuggestions), now);
   }
 
   async listForMatter(matterId: string, organizationId: string): Promise<MatterEventSuggestionRow[]> {

--- a/src/lib/server/repositories/drizzle-matter-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-repository.ts
@@ -9,14 +9,14 @@ import { and, asc, desc, eq, ilike, inArray, isNull, or, sql } from "drizzle-orm
 import type { Matter, MatterContact } from "@/lib/shared/schemas/matter";
 import { contacts, documents, matterContacts, matters, timeEntries } from "../db/schema";
 import type { AppDb } from "../db/types";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import type {
   MatterDetailRow, MatterListFilter, MatterListResult, MatterListRow, MatterRepository,
 } from "./matter-repository";
 
 export class DrizzleMatterRepository extends DrizzleRepository<Matter> implements MatterRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, matters as unknown as VersionedTable, now);
+    super(db, versionedTable(matters), now);
   }
 
   async getByIdInOrg(id: string, organizationId: string): Promise<Matter | null> {

--- a/src/lib/server/repositories/drizzle-office-repository.ts
+++ b/src/lib/server/repositories/drizzle-office-repository.ts
@@ -6,12 +6,12 @@ import { and, asc, desc, eq, isNull } from "drizzle-orm";
 import type { Office } from "@/lib/shared/schemas/organization";
 import { offices } from "../db/schema";
 import type { AppDb } from "../db/types";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import type { OfficeRepository } from "./office-repository";
 
 export class DrizzleOfficeRepository extends DrizzleRepository<Office> implements OfficeRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, offices as unknown as VersionedTable, now);
+    super(db, versionedTable(offices), now);
   }
 
   async listByOrg(organizationId: string): Promise<Office[]> {

--- a/src/lib/server/repositories/drizzle-org-preference-repository.ts
+++ b/src/lib/server/repositories/drizzle-org-preference-repository.ts
@@ -4,12 +4,12 @@ import { and, asc, eq, isNull } from "drizzle-orm";
 import type { OrgPreference } from "@/lib/shared/schemas/preference";
 import { orgPreferences } from "../db/schema";
 import type { AppDb } from "../db/types";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import type { OrgPreferenceRepository, OrgPreferenceRow } from "./org-preference-repository";
 
 export class DrizzleOrgPreferenceRepository extends DrizzleRepository<OrgPreferenceRow> implements OrgPreferenceRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, orgPreferences as unknown as VersionedTable, now);
+    super(db, versionedTable(orgPreferences), now);
   }
 
   async getByOrgKey(organizationId: string, key: string): Promise<OrgPreference | null> {

--- a/src/lib/server/repositories/drizzle-organization-repository.ts
+++ b/src/lib/server/repositories/drizzle-organization-repository.ts
@@ -5,11 +5,11 @@
 import type { Organization } from "@/lib/shared/schemas/organization";
 import { organizations } from "../db/schema";
 import type { AppDb } from "../db/types";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import type { OrganizationRepository } from "./organization-repository";
 
 export class DrizzleOrganizationRepository extends DrizzleRepository<Organization> implements OrganizationRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, organizations as unknown as VersionedTable, now);
+    super(db, versionedTable(organizations), now);
   }
 }

--- a/src/lib/server/repositories/drizzle-payment-plan-reminder-repository.ts
+++ b/src/lib/server/repositories/drizzle-payment-plan-reminder-repository.ts
@@ -5,13 +5,13 @@
 import type { PaymentPlanReminder } from "@/lib/shared/schemas/billing";
 import { paymentPlanReminders } from "../db/schema";
 import type { AppDb } from "../db/types";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import type { PaymentPlanReminderRepository } from "./payment-plan-reminder-repository";
 
 export class DrizzlePaymentPlanReminderRepository
   extends DrizzleRepository<PaymentPlanReminder>
   implements PaymentPlanReminderRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, paymentPlanReminders as unknown as VersionedTable, now);
+    super(db, versionedTable(paymentPlanReminders), now);
   }
 }

--- a/src/lib/server/repositories/drizzle-payment-plan-repository.ts
+++ b/src/lib/server/repositories/drizzle-payment-plan-repository.ts
@@ -11,14 +11,14 @@ import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 import type { PaymentPlan, PaymentPlanReminder } from "@/lib/shared/schemas/billing";
 import { invoices, matters, paymentPlanReminders, paymentPlans } from "../db/schema";
 import type { AppDb } from "../db/types";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import type {
   JoinedPaymentPlan, JoinedPaymentPlanWithReminders, PaymentPlanRepository,
 } from "./payment-plan-repository";
 
 export class DrizzlePaymentPlanRepository extends DrizzleRepository<PaymentPlan> implements PaymentPlanRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, paymentPlans as unknown as VersionedTable, now);
+    super(db, versionedTable(paymentPlans), now);
   }
 
   async getByIdInOrg(planId: string, organizationId: string): Promise<PaymentPlan | null> {

--- a/src/lib/server/repositories/drizzle-payment-repository.ts
+++ b/src/lib/server/repositories/drizzle-payment-repository.ts
@@ -7,12 +7,12 @@ import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import type { Payment } from "@/lib/shared/schemas/billing";
 import { payments } from "../db/schema";
 import type { AppDb } from "../db/types";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import type { PaymentRepository } from "./payment-repository";
 
 export class DrizzlePaymentRepository extends DrizzleRepository<Payment> implements PaymentRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, payments as unknown as VersionedTable, now);
+    super(db, versionedTable(payments), now);
   }
 
   async sumByInvoice(invoiceId: string): Promise<number> {

--- a/src/lib/server/repositories/drizzle-repository.ts
+++ b/src/lib/server/repositories/drizzle-repository.ts
@@ -26,6 +26,16 @@ import type { Repository, RowBase } from "./types";
 /** En tabell med de reconcile-kolumner bas-CRUD:n läser/skriver. */
 export type VersionedTable = PgTable & Record<"id" | "deletedAt" | "version", AnyColumn>;
 
+/**
+ * Markera en konkret tabell som `VersionedTable`. Type-checkat: tabellen MÅSTE
+ * ha reconcile-kolumnerna (id/version/deletedAt via `baseColumns`) — saknas de
+ * blir det kompileringsfel. Ersätter `as unknown as VersionedTable` med ett
+ * kontrollerat anrop i alla repo-konstruktorer (#typing).
+ */
+export function versionedTable<T extends VersionedTable>(table: T): VersionedTable {
+  return table;
+}
+
 export class DrizzleRepository<Row extends RowBase> implements Repository<Row> {
   private changeLog?: ChangeLogRecorder;
 

--- a/src/lib/server/repositories/drizzle-service-note-repository.ts
+++ b/src/lib/server/repositories/drizzle-service-note-repository.ts
@@ -7,12 +7,12 @@ import { and, desc, eq, isNull } from "drizzle-orm";
 import type { ServiceNote } from "@/lib/shared/schemas/service-note";
 import { matters, serviceNotes, users } from "../db/schema";
 import type { AppDb } from "../db/types";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import type { ServiceNoteRepository, ServiceNoteRow } from "./service-note-repository";
 
 export class DrizzleServiceNoteRepository extends DrizzleRepository<ServiceNote> implements ServiceNoteRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, serviceNotes as unknown as VersionedTable, now);
+    super(db, versionedTable(serviceNotes), now);
   }
 
   async listByMatter(matterId: string, organizationId: string): Promise<ServiceNoteRow[]> {

--- a/src/lib/server/repositories/drizzle-task-repository.ts
+++ b/src/lib/server/repositories/drizzle-task-repository.ts
@@ -7,12 +7,12 @@ import { and, asc, eq, isNull } from "drizzle-orm";
 import type { Task } from "@/lib/shared/schemas/calendar";
 import { matters, tasks } from "../db/schema";
 import type { AppDb } from "../db/types";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import type { TaskListFilter, TaskListRow, TaskRepository } from "./task-repository";
 
 export class DrizzleTaskRepository extends DrizzleRepository<Task> implements TaskRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, tasks as unknown as VersionedTable, now);
+    super(db, versionedTable(tasks), now);
   }
 
   async listForUser(userId: string, organizationId: string, filter: TaskListFilter): Promise<TaskListRow[]> {

--- a/src/lib/server/repositories/drizzle-time-entry-repository.ts
+++ b/src/lib/server/repositories/drizzle-time-entry-repository.ts
@@ -7,7 +7,7 @@ import { and, asc, desc, eq, gte, inArray, isNull, lte, sql } from "drizzle-orm"
 import type { TimeEntry } from "@/lib/shared/schemas/billing";
 import { matters, timeEntries, users } from "../db/schema";
 import type { AppDb } from "../db/types";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import type {
   LawyerReportTimeEntry, TimeEntryListFilter, TimeEntryListResult, TimeEntryListRow,
   TimeEntryReportFilter, TimeEntryReportRow, TimeEntryRepository, UnbilledTimeEntry,
@@ -27,7 +27,7 @@ function listWhere(organizationId: string, opts: TimeEntryListFilter) {
 
 export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> implements TimeEntryRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, timeEntries as unknown as VersionedTable, now);
+    super(db, versionedTable(timeEntries), now);
   }
 
   async listForOrg(organizationId: string, opts: TimeEntryListFilter): Promise<TimeEntryListResult> {

--- a/src/lib/server/repositories/drizzle-user-preference-repository.ts
+++ b/src/lib/server/repositories/drizzle-user-preference-repository.ts
@@ -4,12 +4,12 @@ import { and, eq, isNull } from "drizzle-orm";
 import type { UserPreference } from "@/lib/shared/schemas/preference";
 import { userPreferences } from "../db/schema";
 import type { AppDb } from "../db/types";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import type { UserPreferenceRepository, UserPreferenceRow } from "./user-preference-repository";
 
 export class DrizzleUserPreferenceRepository extends DrizzleRepository<UserPreferenceRow> implements UserPreferenceRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, userPreferences as unknown as VersionedTable, now);
+    super(db, versionedTable(userPreferences), now);
   }
 
   async getByUserKey(userId: string, organizationId: string, key: string): Promise<UserPreference | null> {

--- a/src/lib/server/repositories/drizzle-user-repository.ts
+++ b/src/lib/server/repositories/drizzle-user-repository.ts
@@ -7,12 +7,12 @@ import { and, asc, eq, isNull } from "drizzle-orm";
 import type { User } from "@/lib/shared/schemas/user";
 import { users } from "../db/schema";
 import type { AppDb } from "../db/types";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import type { UserRepository } from "./user-repository";
 
 export class DrizzleUserRepository extends DrizzleRepository<User> implements UserRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, users as unknown as VersionedTable, now);
+    super(db, versionedTable(users), now);
   }
 
   async getByIdInOrg(id: string, organizationId: string): Promise<User | null> {

--- a/src/lib/server/repositories/drizzle-write-off-repository.ts
+++ b/src/lib/server/repositories/drizzle-write-off-repository.ts
@@ -7,12 +7,12 @@ import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import type { WriteOff } from "@/lib/shared/schemas/billing";
 import { writeOffs } from "../db/schema";
 import type { AppDb } from "../db/types";
-import { DrizzleRepository, type VersionedTable } from "./drizzle-repository";
+import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import type { WriteOffRepository } from "./write-off-repository";
 
 export class DrizzleWriteOffRepository extends DrizzleRepository<WriteOff> implements WriteOffRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
-    super(db, writeOffs as unknown as VersionedTable, now);
+    super(db, versionedTable(writeOffs), now);
   }
 
   async sumByInvoice(invoiceId: string): Promise<number> {


### PR DESCRIPTION
**Punkt 3** av typnings-hardeningen (arkitekturrapporten). Ersätter `X as unknown as VersionedTable` i **alla 28 drizzle-repo-konstruktorer** med `versionedTable(X)`.

Helpern är generisk + **kompileringskontrollerad**:
```ts
export function versionedTable<T extends VersionedTable>(table: T): VersionedTable { return table; }
```
→ castet är **eliminerat** (inte bara centraliserat); en tabell utan reconcile-kolumner (id/version/deletedAt) ger nu kompileringsfel i st.f. tyst `as unknown as`.

## Effekt
**28 färre type-escapes.** Inga beteendeändringar.

## Verifiering
- typecheck + eslint (`--max-warnings 0`) + knip + dep-cruiser + jscpd ✅
- repo-tester: 99 pass; `bun run test:cov` 90.69% / 85.55% ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)