### PR TITLE
refactor(routers): branda id:n i create/update (eliminerar 21 as-unknown-as-Partial)

### DIFF
--- a/src/lib/server/jobs/handlers/classify-document-handler.ts
+++ b/src/lib/server/jobs/handlers/classify-document-handler.ts
@@ -58,6 +58,6 @@ export function createClassifyDocumentHandler(deps: ClassifyDocumentDeps): JobHa
       analyzedAt: now(),
       analysisStatus: "DONE",
       analysisModel: model,
-    } as unknown as Partial<Document>);
+    });
   };
 }

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -17,7 +17,6 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { proposedAccontoOre } from "@/lib/shared/billing-proposal";
-import type { BillingRun, Expense, Invoice } from "@/lib/shared/schemas/billing";
 import { billingRunRecipientSchema, type ExpenseKind } from "@/lib/shared/schemas/enums";
 import {
   matterIdSchema,
@@ -173,14 +172,14 @@ export const billingRunRouter = router({
           matterId: input.matterId, amount: input.amountOre,
           invoiceType: "ACCONTO", status: "DRAFT",
           invoiceDate: new Date(), notes: input.notes,
-        } as unknown as Partial<Invoice>);
+        });
         const run = await tx.billingRuns.create({
           matterId: input.matterId, type: "ACCONTO", recipient: input.recipient,
           status: "SENT", workValueOreAtRun: value, clientShareBips: input.clientShareBips,
           proposedAmountOre: proposedOre, amountOre: input.amountOre,
           invoiceId: invoice.id, deductedBillingRunIds: [],
           periodTo: new Date(), notes: input.notes,
-        } as unknown as Partial<BillingRun>);
+        });
         await emit.invoiceCreated(ctx, invoice);
         return { run, invoice };
       });
@@ -204,14 +203,14 @@ export const billingRunRouter = router({
           matterId: input.matterId, amount: finalAmount,
           invoiceType: "FINAL", status: "DRAFT",
           invoiceDate: new Date(), notes: input.notes,
-        } as unknown as Partial<Invoice>);
+        });
         const run = await tx.billingRuns.create({
           matterId: input.matterId, type: "FINAL", recipient: input.recipient,
           status: "SENT", workValueOreAtRun: value,
           proposedAmountOre: value, amountOre: finalAmount,
           invoiceId: invoice.id, deductedBillingRunIds: input.deductedBillingRunIds,
           periodTo: new Date(), notes: input.notes,
-        } as unknown as Partial<BillingRun>);
+        });
         await freezeWork(tx, input.matterId, run.id as BillingRunId);
         await emit.invoiceCreated(ctx, invoice);
         return { run, invoice };
@@ -231,7 +230,7 @@ export const billingRunRouter = router({
           proposedAmountOre: value, amountOre: value,
           invoiceId: null, deductedBillingRunIds: [],
           periodTo: new Date(), notes: input.notes,
-        } as unknown as Partial<BillingRun>);
+        });
         return { run };
       });
     }),
@@ -254,16 +253,16 @@ export const billingRunRouter = router({
             matterId: run.matterId, userId: asId<"UserId">(ctx.user.id), date: new Date(),
             amount: input.prutningOre, description: "Prutning enligt dom",
             billable: true, vatRate: 0, vatIncluded: false, kind: "PRUTNING",
-          } as unknown as Partial<Expense>);
+          });
         }
         const invoice = await tx.invoices.create({
           matterId: run.matterId, amount: finalAmount,
           invoiceType: "FINAL", status: "DRAFT",
           invoiceDate: new Date(),
-        } as unknown as Partial<Invoice>);
+        });
         await tx.billingRuns.update(run.id, {
           status: "SENT", invoiceId: invoice.id, amountOre: finalAmount, prutningOre: input.prutningOre,
-        } as unknown as Partial<BillingRun>);
+        });
         await freezeWork(tx, run.matterId, run.id as BillingRunId);
         await emit.invoiceCreated(ctx, invoice);
         return { run, invoice };

--- a/src/lib/server/routers/conflict.ts
+++ b/src/lib/server/routers/conflict.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import { similarity } from "@/lib/shared/fuzzy-similarity";
 import { asId } from "@/lib/shared/schemas/ids";
-import type { ConflictCheck } from "@/lib/shared/schemas/misc";
 import type { ConflictContactRow } from "../repositories/matter-contact-repository";
 import type { Repositories } from "../repositories/repositories";
 import { router, protectedProcedure } from "../trpc";
@@ -87,7 +86,7 @@ export const conflictRouter = router({
         searchType: input.searchType,
         results: results as unknown as unknown[],
         checkedById: asId<"UserId">(ctx.user.id),
-      } as unknown as Partial<ConflictCheck>);
+      });
 
       return { results, matchCount: results.length, searchTerm: input.searchTerm };
     }),

--- a/src/lib/server/routers/document/core.ts
+++ b/src/lib/server/routers/document/core.ts
@@ -9,6 +9,7 @@ import { base64ToBytes, bytesToBase64, contentStoragePath, sha256Hex } from "@/l
 import { isJunkFileName } from "@/lib/shared/junk-files";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import type { Document } from "@/lib/shared/schemas/document";
+import { asId } from "@/lib/shared/schemas/ids";
 import { orgProcedure } from "../../trpc";
 import { assertDocAccess } from "./shared";
 
@@ -121,18 +122,18 @@ export const coreProcedures = {
       // Verifiera matter:n tillhör org:n
       const matter = await ctx.repos.matters.getByIdInOrg(input.matterId, ctx.orgId);
       if (!matter) throw new TRPCError({ code: "NOT_FOUND" });
-      const data = {
-        id: input.id,
-        matterId: input.matterId,
+      const data = omitUndefined({
+        id: asId<"DocumentId">(input.id),
+        matterId: asId<"MatterId">(input.matterId),
         fileName: input.fileName,
         mimeType: input.mimeType,
         sizeBytes: input.sizeBytes,
         fileSize: input.sizeBytes, // denormaliserat (UI läser fileSize)
         storagePath: input.storagePath,
-        folderId: input.folderId ?? null,
+        folderId: input.folderId ? asId<"DocumentFolderId">(input.folderId) : null,
         organizationId: ctx.orgId,
         analysisStatus: input.analysisStatus ?? "PENDING",
-        uploadedById: input.uploadedById ?? ctx.user.id,
+        uploadedById: asId<"UserId">(input.uploadedById ?? ctx.user.id),
         version: input.version,
         title: input.title,
         documentType: input.documentType,
@@ -140,8 +141,8 @@ export const coreProcedures = {
         analyzedAt: input.analyzedAt ? new Date(input.analyzedAt) : undefined,
         createdAt: input.createdAt ? new Date(input.createdAt) : undefined,
         invoiceId: input.invoiceId ?? undefined,
-      };
-      return ctx.repos.documents.create(data as unknown as Partial<Document>);
+      });
+      return ctx.repos.documents.create(data);
     }),
 
   /** Kör (eller kör om) AI-analys på ett dokument. Returnerar omedelbart. */
@@ -175,7 +176,7 @@ export const coreProcedures = {
         sizeBytes: bytes.byteLength,
         fileSize: bytes.byteLength,
         analysisStatus: "PENDING",
-      } as unknown as Partial<Document>);
+      });
       ctx.ports.documentAnalyzer.analyze(input.documentId).catch((e: unknown) =>
         console.error("classify after upload failed:", e),
       );
@@ -246,7 +247,7 @@ export const coreProcedures = {
                 : analyzedAt,
         }),
       };
-      return ctx.repos.documents.update(documentId, data as unknown as Partial<Document>);
+      return ctx.repos.documents.update(documentId, data);
     }),
 
   /**
@@ -270,7 +271,7 @@ export const coreProcedures = {
       // repo.update bumpar version + updatedAt automatiskt (reconcile-konvention).
       return ctx.repos.documents.update(
         input.id,
-        omitUndefined({ sizeBytes: input.sizeBytes, fileSize: input.sizeBytes }) as unknown as Partial<Document>,
+        omitUndefined({ sizeBytes: input.sizeBytes, fileSize: input.sizeBytes }),
       );
     }),
 };

--- a/src/lib/server/routers/document/folders.ts
+++ b/src/lib/server/routers/document/folders.ts
@@ -8,7 +8,7 @@
 
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import type { Document, DocumentFolder } from "@/lib/shared/schemas/document";
+import type { DocumentFolder } from "@/lib/shared/schemas/document";
 import {
   matterIdSchema,
   documentFolderIdSchema,
@@ -57,7 +57,7 @@ export const folderProcedures = {
   moveDocument: orgProcedure
     .input(z.object({ documentId: documentIdSchema, folderId: documentFolderIdSchema.nullable() }))
     .mutation(({ ctx, input }) =>
-      ctx.repos.documents.update(input.documentId, { folderId: input.folderId } as unknown as Partial<Document>),
+      ctx.repos.documents.update(input.documentId, { folderId: input.folderId }),
     ),
 
   /** Flyttar en mapp; blockerar cykler (mapp-in-i-sig-själv/descendant). */

--- a/src/lib/server/routers/kostnadsrakning.ts
+++ b/src/lib/server/routers/kostnadsrakning.ts
@@ -13,7 +13,8 @@
  */
 
 import { z } from "zod";
-import { KOSTNADSRAKNING_DOCUMENT_TYPE, type Document } from "@/lib/shared/schemas/document";
+import { KOSTNADSRAKNING_DOCUMENT_TYPE } from "@/lib/shared/schemas/document";
+import { asId } from "@/lib/shared/schemas/ids";
 import { emit } from "../events/emit";
 import { router, orgProcedure } from "../trpc";
 
@@ -41,8 +42,8 @@ export const kostnadsrakningRouter = router({
     .mutation(async ({ ctx, input }) => {
       // 1. Registrera dokumentet (samma som document.register-flödet)
       const docData = {
-        id: input.id,
-        matterId: input.matterId,
+        id: asId<"DocumentId">(input.id),
+        matterId: asId<"MatterId">(input.matterId),
         fileName: input.fileName,
         mimeType: input.mimeType,
         sizeBytes: input.sizeBytes,
@@ -50,11 +51,11 @@ export const kostnadsrakningRouter = router({
         folderId: null,
         organizationId: ctx.orgId,
         documentType: KOSTNADSRAKNING_DOCUMENT_TYPE,
-        analysisStatus: "DONE",
+        analysisStatus: "DONE" as const,
         analyzedAt: new Date(),
-        uploadedById: ctx.user.id,
+        uploadedById: asId<"UserId">(ctx.user.id),
       };
-      const doc = await ctx.repos.documents.create(docData as unknown as Partial<Document>);
+      const doc = await ctx.repos.documents.create(docData);
 
       // 2. Emit event så regelmotorn kan trigga.
       //    OBS: går via `emit`-helpern (safeEmit) — INTE `ctx.dataStore.events.emit`

--- a/src/lib/server/routers/mail.ts
+++ b/src/lib/server/routers/mail.ts
@@ -13,8 +13,6 @@
  */
 
 import { z } from "zod";
-import type { TimeEntry } from "@/lib/shared/schemas/billing";
-import type { Document } from "@/lib/shared/schemas/document";
 import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { emit, type EmitCtx } from "../events/emit";
@@ -80,22 +78,22 @@ export const mailRouter = router({
       // 3. Registrera dokument-metadata (projektion).
       const fileName = emlFileName(input.subject);
       const docData = {
-        id,
-        matterId: input.matterId,
+        id: asId<"DocumentId">(id),
+        matterId: asId<"MatterId">(input.matterId),
         fileName,
         mimeType: "message/rfc822",
         sizeBytes: bytes.byteLength,
         fileSize: bytes.byteLength, // denormaliserat (UI läser fileSize)
         storagePath,
-        folderId: input.folderId ?? null,
+        folderId: input.folderId ? asId<"DocumentFolderId">(input.folderId) : null,
         organizationId: ctx.orgId,
-        analysisStatus: "PENDING",
-        uploadedById: ctx.user.id,
+        analysisStatus: "PENDING" as const,
+        uploadedById: asId<"UserId">(ctx.user.id),
         title: input.subject,
         documentType: "E-post",
         createdAt: new Date(input.receivedAt),
       };
-      const doc = await ctx.repos.documents.create(docData as unknown as Partial<Document>);
+      const doc = await ctx.repos.documents.create(docData);
       await emit.documentUploaded(ctx, { id, fileName, matterId: input.matterId });
 
       // 4. Valfri tidspost kopplad till mailet.
@@ -119,14 +117,14 @@ async function createMailTimeEntry(
   const user = await ctx.repos.users.getByIdOrThrow(userId);
   const entryData = {
     userId,
-    matterId,
+    matterId: asId<"MatterId">(matterId),
     date: new Date(receivedAt),
     minutes: time.minutes,
     description: time.description ?? subject,
     hourlyRate: user.hourlyRate ?? 0,
     billable: true,
   };
-  const entry = await ctx.repos.timeEntries.create(entryData as unknown as Partial<TimeEntry>);
+  const entry = await ctx.repos.timeEntries.create(entryData);
   await emit.timeEntryAdded(ctx, { id: entry.id, matterId: entry.matterId, minutes: entry.minutes });
   return entry;
 }

--- a/src/lib/server/routers/paymentPlan.ts
+++ b/src/lib/server/routers/paymentPlan.ts
@@ -21,7 +21,8 @@ import {
   computeDueReminders,
   type PlanForScan,
 } from "@/lib/shared/payment-reminders";
-import { paymentPlanStatusSchema, reminderTypeSchema, type Invoice, type PaymentPlan, type PaymentPlanReminder } from "@/lib/shared/schemas";
+import { paymentPlanStatusSchema, reminderTypeSchema, type Invoice, type PaymentPlan } from "@/lib/shared/schemas";
+import { asId } from "@/lib/shared/schemas/ids";
 import { emit } from "../events/emit";
 import type {
   JoinedPaymentPlan, JoinedPaymentPlanWithReminders,
@@ -142,12 +143,12 @@ export const paymentPlanRouter = router({
       const plan = await ctx.repos.paymentPlans.getByIdInOrg(input.planId, ctx.orgId);
       if (!plan) throw new TRPCError({ code: "NOT_FOUND" });
       return ctx.repos.paymentPlanReminders.create({
-        id: input.id,
-        planId: input.planId,
+        ...(input.id ? { id: asId<"PaymentPlanReminderId">(input.id) } : {}),
+        planId: asId<"PaymentPlanId">(input.planId),
         dueMonth: input.dueMonth,
         type: input.type,
         sentAt: input.sentAt ? new Date(input.sentAt) : new Date(),
-      } as unknown as Partial<PaymentPlanReminder>);
+      });
     }),
 
   /**
@@ -173,8 +174,8 @@ export const paymentPlanRouter = router({
 
       for (const r of planned) {
         await ctx.repos.paymentPlanReminders.create({
-          planId: r.planId, dueMonth: r.dueMonth, type: r.type, sentAt: now,
-        } as unknown as Partial<PaymentPlanReminder>);
+          planId: asId<"PaymentPlanId">(r.planId), dueMonth: r.dueMonth, type: r.type, sentAt: now,
+        });
         if (r.type === "DUE") await emit.paymentDue(ctx, r.payload, r.matterId);
         else await emit.paymentOverdue(ctx, r.payload, r.matterId);
       }

--- a/src/lib/server/routers/user.ts
+++ b/src/lib/server/routers/user.ts
@@ -169,7 +169,7 @@ export const userRouter = router({
       }
       const owned = await ctx.repos.users.getByIdInOrg(input.id, ctx.user.organizationId);
       if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
-      return ctx.repos.users.update(input.id, { active: false } as unknown as Partial<User>);
+      return ctx.repos.users.update(input.id, { active: false });
     }),
 
   /** Hård-delete behållen för bakåtkompabilitet, men ADMIN-only. */


### PR DESCRIPTION
**Punkt 2** av typnings-hardeningen. Tar bort **alla 21 `as unknown as Partial<Row>`-castar** i routrar/handlers.

De flesta castar var **onödiga** (objektet var redan tilldelningsbart — castet stängde bara av all typkontroll). De som inte var det **dolde äkta brister**:
- **Branded-id-mismatch** — routrar byggde objekt med plain `string`-id:n men `Document.id` m.fl. är `string & brand<"DocumentId">`. Nu `asId<"…">(…)` på de 6 create-sites (dokument-register, e-post→dokument, e-post→tidspost, plan-påminnelser ×2).
- **exactOptional** — enum-literaler (`"DONE"`/`"PENDING"`) widenade till `string` → `as const`; valfritt `id` → villkorlig spread i st.f. att skicka `undefined`.

Resultat: **full typkontroll** körs nu på varje create/update-objekt (fel fält-typ fångas vid kompilering i st.f. tyst `as unknown as`). Orphan-typimporter städade.

## Verifiering
- typecheck + eslint (`--max-warnings 0`) + knip + dep-cruiser + jscpd ✅
- 533 server-tester gröna; `bun run test:cov` 90.71% / 85.46% ✅

Refs arkitektur-/typningsgranskningen (punkt 2/3; punkt 3 = PR #534, mergad).

🤖 Generated with [Claude Code](https://claude.com/claude-code)