### PR TITLE
feat(jobs): pg-boss som durabel jobb-kö + enqueue-idempotens (ADR 0024, #504)

### DIFF
--- a/docs/adr/0024-pg-boss-som-durabel-jobbko.md
+++ b/docs/adr/0024-pg-boss-som-durabel-jobbko.md
@@ -1,0 +1,86 @@
+# ADR 0024 — pg-boss som durabel jobb-kö (server-first)
+
+Status: Accepterad (2026-06-19)
+
+## Kontext
+
+#421 tog bort den gamla git-peer-runtimens jobb-system (peer-loop +
+`compose-jobs`/`rules-job` + `filesystem-claim-store`/`filesystem-event-log`)
+och därmed dess durabilitet. Server-first (`bin/server-first.ts`, ADR 0016)
+behöver server-sidiga jobb — e-postutskick (`email-dispatch`),
+dokumentklassificering (`classify-document`, #518), Fortnox-sync, regelmotor,
+Outlook-spegling — som **tål en server-restart** och varken tappas eller
+dubbelkörs.
+
+#504 formulerade kravet som en **egen** Postgres-backad kö: en `jobs`-tabell +
+`JobQueueRepository` med claim/lease (`SELECT … FOR UPDATE SKIP LOCKED`),
+retry/backoff, idempotens och status-fält.
+
+Sedan #504 skrevs har dock **pg-boss** redan wirats in i server-first-runtimen
+(`src/lib/server/jobs/job-queue.ts`, `startJobRuntime`). pg-boss är ett moget
+bibliotek som gör *exakt* det #504 beskriver, byggt på samma Postgres-
+primitiver.
+
+## Beslut
+
+**pg-boss ÄR den durabla jobb-kön. Vi bygger ingen egen `jobs`-tabell/-kö.**
+Att underhålla en andra kö-implementation parallellt med pg-boss vore ett brott
+mot DRY och en onödig underhållsbörda, utan funktionell vinst.
+
+Varje krav i #504 mappas mot pg-boss:
+
+| #504-krav | pg-boss |
+|-----------|---------|
+| Claim/lease, ingen dubbelkörning | `fetch` använder `FOR UPDATE SKIP LOCKED`; en kraschad workers lease löper ut → jobbet återtas |
+| Retry/backoff, `maxAttempts` | `createQueue(name, { retryLimit, retryBackoff: true })` (`startJobQueue`, retryLimit 5) |
+| `runAfter` (fördröjd/schemalagd) | `send(name, data, { startAfter })`; cron via `schedule()` |
+| Dead-letter | inbyggt `failed`-state efter uttömda retries |
+| Status `queued/running/done/failed` | pg-boss jobb-state-maskin |
+| Durabelt, inget körande tillstånd i processen | allt committat i Postgres (eget `pgboss`-schema, skilt från drizzle-`public`) |
+| Idempotens (UUIDv7, ADR 0017) | se nedan |
+
+### Idempotens
+
+Två lager, i linje med ADR 0017 ("server upsertar på id → ingen dubbel-skapande
+vid omspelning"):
+
+1. **Enqueue-dedupe (`singletonKey`):** anrop till `send` förses med en stabil
+   nyckel så att som mest ETT väntande/aktivt jobb finns per nyckel — upprepade
+   triggers (reconcile-replay, dubbelklick, at-least-once-anrop uppströms)
+   skapar inte dubbletter.
+   - `classify-document`: `singletonKey = documentId` — det väntande jobbet
+     läser ändå dokumentets aktuella state, så att droppa dubbletten är säkert.
+   - `email-dispatch`: `singletonKey = SendEmailInput.idempotencyKey` när
+     anroparen anger den (t.ex. fakturans/påminnelsens UUIDv7) → en replay
+     skickar inte samma mejl två gånger. Utan nyckel: oförändrat beteende.
+
+2. **Idempotenta handlers:** varje handler ska kunna köras om utan biverkningar
+   (classify skriver samma `documentType`; metadata-uppdateringar är upsertande).
+   Detta är handler-design, inte kö-infrastruktur.
+
+### Avgränsning
+
+pg-boss kör sin egen schema-migration (`boss.start()`) i sitt `pgboss`-schema —
+det ligger utanför drizzle-toolchainen (ADR 0019) med flit; de delar bara
+Postgres-instans, inte schema. `fromDrizzle`-adaptern används INTE (antar
+`pg`-resultatformen, krockar med postgres-js/pglite) → pg-boss får egen
+connection mot samma DB.
+
+## Konsekvenser
+
+- **#504 stängs** — durabilitetskravet är uppfyllt av pg-boss; den egna kön
+  byggs inte.
+- Nya server-jobb läggs till genom att (a) lägga ett namn i `JOB_QUEUES`, (b)
+  registrera en handler i `buildServerFirstJobHandlers`, (c) enqueue:a via en
+  port (`QueueBackedEmailSender`/`QueueBackedDocumentAnalyzer`-mönstret) med en
+  `singletonKey` när idempotens behövs.
+- Enhetstester mockar `boss.send` och verifierar payload + `singletonKey`; ett
+  riktigt pg-boss-mot-Postgres-test behövs inte för portarna.
+- Om vi någon gång vill bort från pg-boss-beroendet får en egen kö övervägas på
+  nytt — men först när ett konkret skäl finns (denna ADR supersedas då).
+
+## Relaterat
+
+ADR 0016 (server-first), ADR 0017 (idempotens/UUIDv7), ADR 0019 (Postgres-
+schema/toolchain), ADR 0020 (repository-söm). Ersätter durabiliteten som
+försvann i #421. Stänger #504.

--- a/src/lib/server/jobs/queue-backed-document-analyzer.ts
+++ b/src/lib/server/jobs/queue-backed-document-analyzer.ts
@@ -23,6 +23,14 @@ export class QueueBackedDocumentAnalyzer implements IDocumentAnalyzer {
   async analyze(documentId: string): Promise<void> {
     const boss = this.getBoss();
     if (!boss) throw new Error("jobb-kön är inte redo — dokumentet kunde inte köas för klassificering");
-    await boss.send(JOB_QUEUES.classifyDocument, { documentId, organizationId: this.organizationId });
+    // Idempotens (#504, ADR 0024): `singletonKey = documentId` → som mest ETT
+    // väntande/aktivt classify-jobb per dokument. Upprepade analyze-anrop
+    // (uppladdning + manuell "Analysera" + reconcile-replay) skapar inte
+    // dubbletter; det väntande jobbet läser ändå dokumentets aktuella state.
+    await boss.send(
+      JOB_QUEUES.classifyDocument,
+      { documentId, organizationId: this.organizationId },
+      { singletonKey: documentId },
+    );
   }
 }

--- a/src/lib/server/jobs/queue-backed-email-sender.ts
+++ b/src/lib/server/jobs/queue-backed-email-sender.ts
@@ -21,10 +21,13 @@ export class QueueBackedEmailSender implements IEmailSender {
   async send(input: SendEmailInput): Promise<void> {
     const boss = this.getBoss();
     if (!boss) throw new Error("jobb-kön är inte redo — e-post kunde inte köas");
-    await boss.send(JOB_QUEUES.emailDispatch, {
-      to: input.to,
-      subject: input.subject,
-      text: input.text,
-    });
+    // Idempotens (#504, ADR 0024): om anroparen anger en idempotensnyckel köas
+    // den som pg-boss `singletonKey` → en replay/dubbel-trigger med samma nyckel
+    // skickar inte mejlet två gånger. Utan nyckel: oförändrat beteende.
+    await boss.send(
+      JOB_QUEUES.emailDispatch,
+      { to: input.to, subject: input.subject, text: input.text },
+      input.idempotencyKey ? { singletonKey: input.idempotencyKey } : {},
+    );
   }
 }

--- a/src/lib/server/ports.ts
+++ b/src/lib/server/ports.ts
@@ -13,6 +13,13 @@ export interface SendEmailInput {
   subject: string;
   text: string;
   html?: string;
+  /**
+   * Idempotensnyckel (#504, ADR 0024). Sätts av anroparen till ett stabilt id
+   * för den utlösande händelsen (t.ex. fakturans/påminnelsens UUIDv7) → köas
+   * som pg-boss `singletonKey` så att en reconcile-replay eller dubbel-trigger
+   * inte skickar samma mejl två gånger (som mest ett väntande jobb per nyckel).
+   */
+  idempotencyKey?: string;
 }
 
 export interface IEmailSender {

--- a/test/unit/server/jobs/queue-backed-document-analyzer.test.ts
+++ b/test/unit/server/jobs/queue-backed-document-analyzer.test.ts
@@ -8,11 +8,16 @@ import { describe, expect, it, vi } from "vitest-compat";
 import { QueueBackedDocumentAnalyzer } from "@/lib/server/jobs/queue-backed-document-analyzer";
 
 describe("QueueBackedDocumentAnalyzer", () => {
-  it("enqueue:ar classify-document med documentId + organizationId", async () => {
+  it("enqueue:ar classify-document med documentId + organizationId + singletonKey (idempotens)", async () => {
     const send = vi.fn(async () => "job-1");
     const analyzer = new QueueBackedDocumentAnalyzer(() => ({ send } as unknown as PgBoss), "org-1");
     await analyzer.analyze("doc-9");
-    expect(send).toHaveBeenCalledWith("classify-document", { documentId: "doc-9", organizationId: "org-1" });
+    // singletonKey = documentId → som mest ett väntande classify-jobb per dokument (#504).
+    expect(send).toHaveBeenCalledWith(
+      "classify-document",
+      { documentId: "doc-9", organizationId: "org-1" },
+      { singletonKey: "doc-9" },
+    );
   });
 
   it("kastar tydligt när boss saknas (kön ej redo)", async () => {

--- a/test/unit/server/jobs/queue-backed-email-sender.test.ts
+++ b/test/unit/server/jobs/queue-backed-email-sender.test.ts
@@ -15,13 +15,26 @@ function fakeBoss() {
 }
 
 describe("QueueBackedEmailSender", () => {
-  it("köar ett email-dispatch-jobb med {to,subject,text}", async () => {
+  it("köar ett email-dispatch-jobb med {to,subject,text} (utan nyckel → inga options)", async () => {
     const { boss, send } = fakeBoss();
     const sender = new QueueBackedEmailSender(() => boss);
     await sender.send({ to: "domstol@ex.se", subject: "Faktura F-1", text: "Bifogat.", html: "<p>ignoreras</p>" });
-    expect(send).toHaveBeenCalledWith(JOB_QUEUES.emailDispatch, {
-      to: "domstol@ex.se", subject: "Faktura F-1", text: "Bifogat.",
-    });
+    expect(send).toHaveBeenCalledWith(
+      JOB_QUEUES.emailDispatch,
+      { to: "domstol@ex.se", subject: "Faktura F-1", text: "Bifogat." },
+      {},
+    );
+  });
+
+  it("idempotensnyckel → pg-boss singletonKey (dedupe vid replay/dubbel-trigger)", async () => {
+    const { boss, send } = fakeBoss();
+    const sender = new QueueBackedEmailSender(() => boss);
+    await sender.send({ to: "x@y.se", subject: "s", text: "t", idempotencyKey: "invoice-42" });
+    expect(send).toHaveBeenCalledWith(
+      JOB_QUEUES.emailDispatch,
+      { to: "x@y.se", subject: "s", text: "t" },
+      { singletonKey: "invoice-42" },
+    );
   });
 
   it("kastar tydligt när kön inte är redo (ingen boss)", async () => {


### PR DESCRIPTION
## Vad
#504 efterfrågade en **egen** durabel Postgres-jobb-kö. Men **pg-boss är redan inwirad** i server-first (`job-queue.ts` / `startJobRuntime`) och uppfyller alla kraven. Att bygga + underhålla en andra kö parallellt vore ett DRY-brott utan funktionell vinst. Denna PR **adopterar pg-boss formellt** (ADR 0024) och härdar idempotensen — det enda som faktiskt saknades.

## Beslut (ADR 0024)
Mappar varje #504-krav mot pg-boss:

| #504-krav | pg-boss |
|-----------|---------|
| Claim/lease, ingen dubbelkörning | `fetch` → `FOR UPDATE SKIP LOCKED`, lease-utgång återtar jobb |
| Retry/backoff | `createQueue(name, { retryLimit, retryBackoff })` |
| `runAfter` / cron | `send(..., { startAfter })` / `schedule()` |
| Dead-letter, status | inbyggt `failed`-state + state-maskin |
| Durabelt | committat i Postgres (`pgboss`-schema, skilt från `public`) |
| Idempotens (ADR 0017) | `singletonKey` vid enqueue + idempotenta handlers |

## Idempotens-härdning (kod)
- **classify-document**: enqueue:as med `singletonKey = documentId` → som mest ETT väntande/aktivt classify-jobb per dokument. Upprepad `analyze` (upload + manuell "Analysera" + reconcile-replay) ger inga dubbletter; det väntande jobbet läser ändå dokumentets aktuella state.
- **email-dispatch**: `SendEmailInput` får valfri `idempotencyKey` → köas som `singletonKey` när anroparen anger den (t.ex. fakturans/påminnelsens UUIDv7) → en replay skickar inte samma mejl två gånger. Utan nyckel: oförändrat beteende.
- Tester verifierar att `singletonKey` skickas (classify + e-post, med/utan nyckel).

## Verifierat lokalt
`typecheck` ✓ (validerar `singletonKey` mot pg-boss-typerna), `lint` (--max-warnings 0) ✓, `knip` ✓, `deps:check` ✓, `test:cov` ✓ (90.68 % rader / 85.47 % funktioner, över golv).

Closes #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)