### PR TITLE
feat(sync): serverlös loopback-transport (StaticSyncSource) för demon (ADR 0025, #543)

### DIFF
--- a/docs/adr/0025-demo-som-cache-hydrerad-offline-klient.md
+++ b/docs/adr/0025-demo-som-cache-hydrerad-offline-klient.md
@@ -1,0 +1,80 @@
+# ADR 0025 — Demon som cache-hydrerad offline-klient
+
+Status: Accepterad (2026-06-19)
+
+## Kontext
+
+Server-first (ADR 0016) gjorde web-klienten offline-first: den läser/skriver mot
+en lokal `CachingSyncDataStore` (LocalStore-kärna + IndexedDB-snapshot +
+`MutationQueue`) och synkar mot servern via `reconcile()` (pull→apply→replay→
+advance, ADR 0017) bakom en transport-söm — `SyncTransport { pull, push }`.
+Self-hosted injicerar en tRPC-transport; demon injicerar `noSyncTransport`
+(no-op).
+
+Demon (GH Pages) kör alltså **redan** samma store/cache/kö som den riktiga
+klienten — det är inte längre en separat datalager-väg som i den gamla
+git-first-demon. MEN cachen *seedas* fortfarande på ett eget sätt:
+
+- **Riktig klient:** `reconcile → transport.pull(cursor) → applyPull →
+  writeCanonical → persist`.
+- **Demo:** en separat `seed`-option på `CachingSyncDeps` + `loadDemoSeed()` som
+  hämtar `manifest.json` + N JSON-filer från CDN:n och injiceras direkt i
+  LocalStore — **förbi** pull/apply-vägen.
+
+Det är två kodvägar för samma sak (populera cachen), och demon övar aldrig den
+riktiga reconcile-vägen.
+
+## Beslut
+
+**Hydrera demons cache genom den riktiga reconcile/pull-vägen.** Ersätt
+`seed`-optionen + `loadDemoSeed`/manifest med en **`StaticSyncSource`** som
+implementerar `SyncTransport`:
+
+- `pull(0)` returnerar den bundlade `DemoSource` plattad till `PulledChange[]`
+  (cursor = N).
+- `pull(n>0)` returnerar loopback-ändringar med seq > n.
+- `push(mutation)` ack:ar (`accepted`) **och** lägger raden i loggen så nästa
+  `pull` serverar tillbaka den.
+
+Demon blir en självständig **loopback-"server"** i klienten. Bygget emit:ar en
+`demo-seed.json`-artefakt; klienten själv-hydrerar IndexedDB vid första
+laddningen via pull-vägen (engångs, version-gated av `NEXT_PUBLIC_DEMO_VERSION`).
+
+### Två mål, ett grepp
+
+1. **Färre kodvägar** — `seed`-optionen, `demo-seed-loader.ts` och
+   manifest-genereringen/-hämtningen försvinner; cache-populering enas på
+   reconcile-vägen.
+2. **Bevisad cache** — varje demobesök övar `reconcile()` pull→apply→persist→
+   replay→ack på riktigt, i produktion. Loopback-pushen gör att mutations-kön
+   faktiskt dräneras (annars växer den obegränsat utan server) och att en pull
+   ser klientens egna tidigare ändringar.
+
+## Konsekvenser
+
+- **Cold-start-UX ändras (till det ärligare):** demon går tom → reconcile →
+  populerad i st.f. att pre-seedas synkront. Det är samma initial-load-väg som
+  riktiga klienten redan har → ev. loading-state-buggar syns i demon i st.f. att
+  döljas.
+- **Vad det bevisar:** klient-halvan (offline-store + sync-*klient*:
+  apply/replay/cursor/ack). **Inte** serverns `change_log`/seq-generering, äkta
+  samtidig konfliktreconcile, oauth2-proxy-auth eller server-side byte-lagring —
+  de täcks fortsatt av docker-e2e (#527/#531). Demon är ett *levande test av
+  klient-cachen*, komplement till — inte ersättning för — server-e2e.
+- **Versionering/reset:** oförändrat — `NEXT_PUBLIC_DEMO_VERSION` ger cache-
+  nyckeln; redeploy → ny nyckel → re-hydrering; reset-demo rensar cachen.
+- **Dokument-bytes (ADR 0023)** är en separat väg (content-sync, byte-cache) som
+  entitets-reconcile inte bär. Steg 3 (#545) hydrerar byte-cachen via en
+  parallell `StaticContentSource` så även byte-vägen bevisas.
+
+## Genomförande (en PR per steg)
+
+1. `StaticSyncSource` + denna ADR + enhetstester (#543) — ingen wiring-ändring.
+2. Wira `createDemoStore` → `StaticSyncSource`; ta bort `loadDemoSeed`/manifest;
+   bygget emit:ar `demo-seed.json` (#544).
+3. Byte-cache-hydrering via `StaticContentSource` (#545).
+
+## Relaterat
+
+ADR 0016 (server-first), ADR 0017 (reconcile/cursor), ADR 0023 (dokument-bytes),
+ADR 0004 (demo-cache-versionering). Epic #542.

--- a/src/lib/server/data-store/in-memory/static-sync-source.ts
+++ b/src/lib/server/data-store/in-memory/static-sync-source.ts
@@ -1,0 +1,67 @@
+/**
+ * `StaticSyncSource` (#543, ADR 0025) — en `SyncTransport` utan server, för
+ * demon (GH Pages). Hela poängen: demon hydrerar sin offline-cache via SAMMA
+ * `reconcile → pull → applyPull → persist`-väg som den riktiga klienten, i
+ * st.f. en separat seed-populerings-fork (`seed`-optionen + `loadDemoSeed`).
+ *
+ * Modell — en självständig loopback-"server" i klienten:
+ *   - `pull(0)`       → den bundlade `DemoSource` plattad till `PulledChange[]`
+ *                       (varje entitet i seeden = en kanonisk rad), cursor = N.
+ *   - `pull(n)`       → ändringar med seq > n (loopback: det klienten själv
+ *                       push:at sedan dess). Tomt om inget nytt.
+ *   - `push(mutation)`→ `accepted` + raden läggs i loggen med nästa seq, så
+ *                       NÄSTA pull serverar tillbaka den. Det dränerar
+ *                       mutations-kön (ack i replay) OCH övar att en pull ser
+ *                       klientens egna tidigare ändringar — hela reconcile-
+ *                       loopen bevisas, deterministiskt, vid varje demobesök.
+ *
+ * Cursorn är en monoton sekvens (seq) över loggen (seed-rader 1..N, därefter
+ * push:ade rader N+1, N+2 …) — exakt formen `change_log.seq` har på servern
+ * (ADR 0017), så reconcile-motorn ser ingen skillnad mot en riktig server.
+ */
+
+import type { DemoSource } from "@/lib/shared/demo-source";
+import { ENTITY_NAME_BY_SOURCE_KEY } from "./entity-source-keys";
+import type { QueuedMutation } from "./mutation-queue";
+import type { PullResult, PulledChange, PushResult, SyncTransport } from "./sync-transport";
+
+/** Platta en `DemoSource` (plural-nycklar → rad-arrayer) till kanoniska
+ *  `PulledChange`-rader (singular entity), i en stabil nyckel-ordning. Okända
+ *  source-nycklar hoppas (samma defensiva hållning som reconcile-apply). */
+export function flattenSeedToChanges(seed: DemoSource): PulledChange[] {
+  const out: PulledChange[] = [];
+  const src = seed as Record<string, unknown>;
+  for (const [sourceKey, entity] of Object.entries(ENTITY_NAME_BY_SOURCE_KEY)) {
+    const rows = src[sourceKey];
+    if (!Array.isArray(rows)) continue;
+    for (const row of rows) out.push({ entity, row: row as Record<string, unknown> });
+  }
+  return out;
+}
+
+export class StaticSyncSource implements SyncTransport {
+  /** Append-only logg; seq = index+1 (monoton, börjar på 1). */
+  private readonly log: Array<{ seq: number; change: PulledChange }> = [];
+  private seq = 0;
+
+  constructor(seed: DemoSource = {}) {
+    for (const change of flattenSeedToChanges(seed)) this.append(change);
+  }
+
+  private append(change: PulledChange): void {
+    this.seq += 1;
+    this.log.push({ seq: this.seq, change });
+  }
+
+  pull(sinceCursor: number): Promise<PullResult> {
+    const changes = this.log.filter((e) => e.seq > sinceCursor).map((e) => e.change);
+    return Promise.resolve({ changes, cursor: this.seq });
+  }
+
+  push(mutation: QueuedMutation): Promise<PushResult> {
+    // Loopback: spara raden så nästa pull serverar tillbaka den (kanonisk).
+    // Delete → tombstone (deleted), annars upsert av raden.
+    this.append({ entity: mutation.entity, row: mutation.row, deleted: mutation.kind === "delete" });
+    return Promise.resolve({ status: "accepted", row: mutation.row });
+  }
+}

--- a/test/unit/server/data-store/static-sync-source.test.ts
+++ b/test/unit/server/data-store/static-sync-source.test.ts
@@ -1,0 +1,103 @@
+/**
+ * `StaticSyncSource` (#543, ADR 0025) — serverlös `SyncTransport` för demon.
+ * Enhetsnivå (pull/push/cursor/loopback) + integration mot `CachingSyncDataStore`
+ * + `ReconcileEngine` som bevisar hela klient-reconcile-loopen.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { CachingSyncDataStore } from "@/lib/server/data-store/in-memory/caching-sync-data-store";
+import type { QueuedMutation } from "@/lib/server/data-store/in-memory/mutation-queue";
+import { flattenSeedToChanges, StaticSyncSource } from "@/lib/server/data-store/in-memory/static-sync-source";
+import type { DemoSource } from "@/lib/shared/demo-source";
+
+const seed: DemoSource = {
+  matters: [{ id: "m1", organizationId: "org", matterNumber: "2026-1", title: "X", version: 1 }],
+  contacts: [
+    { id: "c1", organizationId: "org", name: "Anna", contactType: "PERSON", version: 1 },
+    { id: "c2", organizationId: "org", name: "Bo", contactType: "PERSON", version: 1 },
+  ],
+} as unknown as DemoSource;
+
+function mutation(over: Partial<QueuedMutation> & Pick<QueuedMutation, "entity" | "kind" | "row">): QueuedMutation {
+  return { mutationId: "mut-1", enqueuedAt: 0, ...over };
+}
+
+describe("flattenSeedToChanges", () => {
+  it("plattar plural-source → singular-entity-rader, hoppar okända nycklar", () => {
+    const changes = flattenSeedToChanges(seed);
+    expect(changes).toHaveLength(3); // 1 matter + 2 contacts
+    expect(changes.filter((c) => c.entity === "matter")).toHaveLength(1);
+    expect(changes.filter((c) => c.entity === "contact")).toHaveLength(2);
+    // okänd source-nyckel ignoreras
+    expect(flattenSeedToChanges({ totallyUnknown: [{ id: "x" }] } as unknown as DemoSource)).toEqual([]);
+  });
+});
+
+describe("StaticSyncSource — pull/push/cursor", () => {
+  it("pull(0) returnerar hela seeden som changes, cursor = N", async () => {
+    const src = new StaticSyncSource(seed);
+    const res = await src.pull(0);
+    expect(res.changes).toHaveLength(3);
+    expect(res.cursor).toBe(3);
+  });
+
+  it("pull(N) (allt redan hämtat) → inga changes, cursor oförändrad", async () => {
+    const src = new StaticSyncSource(seed);
+    const res = await src.pull(3);
+    expect(res.changes).toEqual([]);
+    expect(res.cursor).toBe(3);
+  });
+
+  it("tom seed → pull(0) ger inget, cursor 0", async () => {
+    const res = await new StaticSyncSource().pull(0);
+    expect(res.changes).toEqual([]);
+    expect(res.cursor).toBe(0);
+  });
+
+  it("push ack:ar och loopback:ar raden till nästa pull (cursor monoton)", async () => {
+    const src = new StaticSyncSource(seed);
+    const push = await src.push(mutation({ entity: "matter", kind: "update", row: { id: "m1", title: "Y", version: 2 } }));
+    expect(push).toEqual({ status: "accepted", row: { id: "m1", title: "Y", version: 2 } });
+    // nästa pull sedan cursor 3 ser klientens egen ändring (seq 4)
+    const res = await src.pull(3);
+    expect(res.changes).toEqual([{ entity: "matter", row: { id: "m1", title: "Y", version: 2 }, deleted: false }]);
+    expect(res.cursor).toBe(4);
+  });
+
+  it("delete-mutation loopback:as som tombstone (deleted)", async () => {
+    const src = new StaticSyncSource(seed);
+    await src.push(mutation({ entity: "contact", kind: "delete", row: { id: "c1" } }));
+    const res = await src.pull(3);
+    expect(res.changes).toEqual([{ entity: "contact", row: { id: "c1" }, deleted: true }]);
+  });
+});
+
+describe("StaticSyncSource — integration med CachingSyncDataStore (hela reconcile-loopen)", () => {
+  it("hydrerar cachen via pull, dränerar kön via loopback-push, ser egna ändringar", async () => {
+    const cs = await CachingSyncDataStore.create({ transport: new StaticSyncSource(seed) });
+
+    // Före reconcile: cachen är TOM (ingen seed-option — hydrering sker via pull).
+    expect((await cs.store.matters.findMany({})).length).toBe(0);
+
+    // reconcile #1: pull(0) → seeden appliceras (pull/apply-vägen, inte seed-option).
+    const r1 = await cs.reconcile();
+    expect(r1.pulled).toBe(3);
+    expect((await cs.store.matters.findMany({})).length).toBe(1);
+    expect((await cs.store.contacts.findMany({})).length).toBe(2);
+
+    // Lokal mutation (offline) → köas optimistiskt.
+    await cs.store.contacts.create({ data: { id: "c3", organizationId: "org", name: "Cilla", contactType: "PERSON" } as never });
+    expect(cs.pendingCount()).toBe(1);
+    expect((await cs.store.contacts.findMany({})).length).toBe(3);
+
+    // reconcile #2: replay push:ar mutationen (loopback ack) → kön dräneras.
+    const r2 = await cs.reconcile();
+    expect(r2.pushed).toBe(1);
+    expect(cs.pendingCount()).toBe(0);
+
+    // reconcile #3: pull serverar tillbaka klientens egen push → "pull ser egna ändringen".
+    const r3 = await cs.reconcile();
+    expect(r3.pulled).toBe(1);
+    expect((await cs.store.contacts.findMany({})).length).toBe(3); // idempotent upsert
+  });
+});


### PR DESCRIPTION
Del 1 av epic #542 (ADR 0025).

## Vad
`StaticSyncSource implements SyncTransport` — en serverlös loopback-"server" i klienten, så demon kan hydrera sin offline-cache via **samma `reconcile → pull → applyPull → persist`-väg** som den riktiga klienten (i st.f. seed-populerings-forken `seed`-option + `loadDemoSeed`/manifest).

- `pull(0)` → bundlad `DemoSource` plattad till `PulledChange[]` (cursor = N)
- `pull(n)` → loopback-ändringar med seq > n
- `push(m)` → `accepted` + raden läggs i loggen → nästa `pull` serverar tillbaka den (kön dräneras via ack; pull ser klientens egna ändringar)

Cursorn är en monoton seq över loggen — samma form som serverns `change_log.seq` (ADR 0017), så `ReconcileEngine` ser ingen skillnad mot en riktig server.

**Ingen wiring-ändring** — `noSyncTransport`/`createDemoStore` är orörda (#544 wirar in detta). Lägger till **ADR 0025**.

## Tester
Enhetsnivå (flatten, pull/push/cursor, delete-tombstone) + **integrationstest** mot `CachingSyncDataStore` + `ReconcileEngine` som bevisar hela loopen: tom cache → reconcile hydrerar från seed → lokal mutation köas → reconcile dränerar kön via loopback-push → nästa reconcile ser klientens egen ändring tillbaka.

## Verifierat lokalt
`typecheck`, `lint` (--max-warnings 0), `knip`, `deps:check`, `test:cov` (90.81 % rader / 85.57 % funktioner) — alla gröna.

Refs #543, #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)