### PR TITLE
feat(demo): hydrera cachen via StaticSyncSource + bundlad demo-seed.json (ADR 0025, #544)

### DIFF
--- a/src/app/demo/_demo-client.tsx
+++ b/src/app/demo/_demo-client.tsx
@@ -15,7 +15,7 @@
  */
 
 import { useEffect, useRef, useState } from "react";
-import { loadDemoSeed } from "@/lib/client/demo/demo-seed-loader";
+import { loadBundledSeed } from "@/lib/client/demo/bundled-seed-loader";
 import { useDemoSeed } from "@/lib/client/demo/use-demo-seed";
 import type { DemoSource } from "@/lib/shared/demo-source";
 
@@ -29,9 +29,9 @@ const DEFAULT_DEMO_REPO =
 
 export interface DemoClientProps {
   /**
-   * Valfri seed-loader. Default = GH Pages-fetch (`loadDemoSeed`). Tester
-   * injicerar en fake. Server Components MÅSTE INTE passa funktioner till
-   * Client Components (Next 16/RSC) — därför är prop:en optional.
+   * Valfri seed-loader. Default = bundlad `demo-seed.json` (`loadBundledSeed`,
+   * ADR 0025). Tester injicerar en fake. Server Components MÅSTE INTE passa
+   * funktioner till Client Components (Next 16/RSC) — därför är prop:en optional.
    */
   loader?: (repo: string) => Promise<DemoSource>;
   /**
@@ -46,7 +46,7 @@ interface ContactLike { id: string; name: string; contactType: string; email?: s
 interface UserLike { id: string; email: string; name: string; role: string }
 
 export function DemoClient({
-  loader = loadDemoSeed,
+  loader = loadBundledSeed,
   defaultRepo = DEFAULT_DEMO_REPO,
 }: DemoClientProps) {
   const { status, error, source, loadDemo } = useDemoSeed(loader);

--- a/src/components/shell/demo-bootstrap.tsx
+++ b/src/components/shell/demo-bootstrap.tsx
@@ -4,14 +4,14 @@
  * `DemoBootstrap` — singleton-init av offline-first-store + tRPC-klient i
  * demo-builden. Tillåter alla sidor att köra tRPC mot demo-data.
  *
- * Sedan #420 (ADR 0016) kör demon på en **persisterad** `CachingSyncDataStore`
- * UTAN synk-mål (`noSyncTransport`):
- *   - `seed` byggs DIREKT av `loadDemoSeed` (fetch av manifest.json + .ava/*.json
- *     från GH Pages → `DemoSource`) — ingen MemFs/slab, ingen projection-hydrering.
+ * Sedan #420 (ADR 0016) kör demon på en **persisterad** `CachingSyncDataStore`;
+ * sedan #544 (ADR 0025) hydreras cachen via den riktiga reconcile/pull-vägen mot
+ * en serverlös `StaticSyncSource`:
+ *   - första besök/cache-miss: `createDemoStore` laddar EN bundlad `demo-seed.json`
+ *     och `reconcile()` pull:ar in den (samma apply-väg som riktiga klienten).
  *   - `persistence` (IndexedDB) + `queuePersistence` (IndexedDB) cachar source:n
- *     och mutations-kön → "populera IndexedDB-cachen med demo-data"-modellen.
- *     `create()` hydrerar cachen först, annars seed:en. Mutationer persisteras
- *     automatiskt (snapshot) → överlever reload utan slab/FSA-write-back.
+ *     och mutations-kön → efterföljande besök hydreras direkt ur snapshotet.
+ *     Mutationer persisteras automatiskt (snapshot) → överlever reload.
  *
  * /demo-routen kör sin egen runtime (DemoClient → useDemoSeed).
  */
@@ -159,8 +159,8 @@ function useDemoBootstrap(args: BootstrapArgs) {
     }
 
     // ── demo/github-tier: persisterad offline-first-kärna utan synk-mål ──
-    // `createDemoStore` hydrerar IndexedDB-cachen om den finns, annars fetchas
-    // seed:en från GH Pages (manifest.json + .ava/*.json) och persisteras.
+    // `createDemoStore` hydrerar IndexedDB-cachen om den finns, annars laddas
+    // den bundlade `demo-seed.json` in via reconcile/pull (ADR 0025).
     void (async () => {
       try {
         const store = await createDemoStore(firmaConfig);

--- a/src/lib/client/backend/create-demo-store.ts
+++ b/src/lib/client/backend/create-demo-store.ts
@@ -2,31 +2,45 @@
 
 /**
  * `createDemoStore` — bygger den persisterade offline-first-storen som demon
- * (och github-tier) kör mot (ADR 0016, #420).
+ * (och github-tier) kör mot (ADR 0016/0025, #420/#544).
  *
- * `CachingSyncDataStore.create()` hydrerar IndexedDB-cachen först; finns inget
- * cachat (första besök, eller ny `NEXT_PUBLIC_DEMO_VERSION` → ny cache-nyckel →
- * version-busting) fetchas seed:en från GH Pages via `loadDemoSeed`. Vi
- * persisterar då seed:en direkt så efterföljande mutationer kan läggas till
- * ovanpå och överleva reload — "populera IndexedDB-cachen med demo-data".
+ * Demon hydrerar sin IndexedDB-cache via SAMMA väg som den riktiga klienten:
+ * `reconcile → pull → applyPull → persist`. Transporten är en `StaticSyncSource`
+ * (serverlös loopback) som serverar den bundlade `demo-seed.json`. Det enar
+ * cache-populeringen på reconcile-vägen (i st.f. den gamla `seed`-optionen +
+ * `loadDemoSeed`/manifest) OCH gör att varje cold-start övar reconcile-loopen
+ * på riktigt (ADR 0025).
  *
- * Inget synk-mål (`noSyncTransport`): demon synkar aldrig. Mutationer köas
- * lokalt + persisteras (snapshot + kö) men pushas aldrig.
+ *   - Cache-hit  (snapshot finns): `create()` hydrerar source + kö ur IndexedDB.
+ *     Ingen reconcile/seed-fetch behövs — datan (inkl. användarens mutationer)
+ *     ligger redan i snapshotet.
+ *   - Cache-miss (första besök / ny `NEXT_PUBLIC_DEMO_VERSION` → version-busting):
+ *     tom store → seed laddas → `reconcile()` pull:ar in den via apply-vägen +
+ *     persisterar.
+ *
+ * Inget riktigt synk-mål: `StaticSyncSource.push` ack:ar lokalt (loopback), så
+ * mutationer köas + persisteras men når aldrig en server.
  */
 
+import { loadBundledSeed } from "@/lib/client/demo/bundled-seed-loader";
 import { demoCacheKey } from "@/lib/client/demo/demo-cache-key";
-import { loadDemoSeed } from "@/lib/client/demo/demo-seed-loader";
 import type { FirmaConfig } from "@/lib/client/firma/firma-config";
-import { CachingSyncDataStore, noSyncTransport } from "@/lib/server/data-store/in-memory/caching-sync-data-store";
+import { CachingSyncDataStore } from "@/lib/server/data-store/in-memory/caching-sync-data-store";
 import { IndexedDbPersistence } from "@/lib/server/data-store/in-memory/indexeddb-persistence";
 import { IndexedDbMutationQueuePersistence } from "@/lib/server/data-store/in-memory/mutation-queue";
+import { StaticSyncSource } from "@/lib/server/data-store/in-memory/static-sync-source";
 import type { DemoSource } from "@/lib/shared/demo-source";
 
 export interface CreateDemoStoreDeps {
   /** Injicerbar IndexedDB-factory (tester → fake-indexeddb). Default = global. */
   factory?: IDBFactory;
-  /** Injicerbar seed-loader (tester → fake). Default = GH-Pages-fetch. */
+  /** Injicerbar seed-loader (tester → fake). Default = bundlad demo-seed.json. */
   loadSeed?: (repo: string) => Promise<DemoSource>;
+}
+
+/** True om source:n saknar rader (alla entitets-arrayer tomma/saknas). */
+function isEmptySource(source: Record<string, unknown[] | undefined>): boolean {
+  return Object.values(source).every((arr) => !arr || arr.length === 0);
 }
 
 export async function createDemoStore(
@@ -34,7 +48,7 @@ export async function createDemoStore(
   deps: CreateDemoStoreDeps = {},
 ): Promise<CachingSyncDataStore> {
   const factory = deps.factory; // undefined → IndexedDbPersistence faller till globalThis.indexedDB
-  const loadSeed = deps.loadSeed ?? loadDemoSeed;
+  const loadSeed = deps.loadSeed ?? loadBundledSeed;
   // Source-snapshot och mutations-kö MÅSTE ligga i SKILDA IndexedDB-databaser:
   // `IdbKv` skapar bara sitt object-store i `onupgradeneeded`, och två KV mot
   // samma db-namn (men olika stores) gör att den andras store aldrig skapas →
@@ -44,14 +58,16 @@ export async function createDemoStore(
   const persistence = new IndexedDbPersistence(factory, `${cacheKey}-source`);
   const queuePersistence = new IndexedDbMutationQueuePersistence(factory, `${cacheKey}-queue`);
 
-  // Cache-hit? Hydrera utan nät-roundtrip (bevarar användarens mutationer).
-  const cached = await persistence.hydrate();
-  if (cached) {
-    return CachingSyncDataStore.create({ transport: noSyncTransport, persistence, queuePersistence, seed: cached });
-  }
+  // En serverlös loopback-transport. `create()` hydrerar source + kö ur
+  // IndexedDB (cache-hit) eller ger en tom store (cache-miss).
+  const transport = new StaticSyncSource();
+  const store = await CachingSyncDataStore.create({ transport, persistence, queuePersistence });
 
-  // Cache-miss: fetcha färsk seed från GH Pages och persistera den direkt.
-  const seed = await loadSeed(firmaConfig.repo);
-  await persistence.save(seed);
-  return CachingSyncDataStore.create({ transport: noSyncTransport, persistence, queuePersistence, seed });
+  // Cache-miss (tom cache) → ladda seeden (en bundlad demo-seed.json) och
+  // hydrera via den riktiga reconcile/pull-vägen (apply persisterar snapshotet).
+  if (isEmptySource(store.store.currentSource as Record<string, unknown[] | undefined>)) {
+    transport.reset(await loadSeed(firmaConfig.repo));
+    await store.reconcile();
+  }
+  return store;
 }

--- a/src/lib/client/demo/bundled-seed-loader.ts
+++ b/src/lib/client/demo/bundled-seed-loader.ts
@@ -1,0 +1,43 @@
+/**
+ * `loadBundledSeed` (#544, ADR 0025) — hämtar demons seed som EN bundlad
+ * `demo-seed.json` (emit:ad av `build-demo`) i st.f. `manifest.json` + N
+ * parallella fil-fetchar (`loadDemoSeed`).
+ *
+ * Seeden matas sedan in i cachen via den riktiga `reconcile → pull`-vägen
+ * (`StaticSyncSource`), inte via `seed`-optionen — så demon övar samma
+ * hydrerings-väg som den riktiga klienten. En enda same-origin-fil → ingen
+ * manifest-rundtripp, ingen burst av CDN-requests.
+ *
+ * Filen är redan en färdig `DemoSource` (prebake:ad vid bygget), så loadern är
+ * en ren fetch+parse. `cache: "no-store"` så "Återställ demo" får färsk data.
+ */
+
+import { type DemoSource, prebakeJoins } from "@/lib/shared/demo-source";
+import { resolveGhPagesUrl } from "@/lib/shared/gh-pages-url";
+
+export const DEMO_SEED_FILE = "demo-seed.json";
+
+export interface BundledSeedLoaderOpts {
+  /** Bas-URL till den publicerade demo-datan (auto-härleds från repo annars). */
+  baseUrl?: string;
+  /** Inject:bar fetch — default global `fetch`. */
+  fetchFn?: typeof fetch;
+}
+
+/** Ladda den bundlade `demo-seed.json` → `DemoSource`. */
+export async function loadBundledSeed(repo: string, opts: BundledSeedLoaderOpts = {}): Promise<DemoSource> {
+  const fetchFn = opts.fetchFn ?? globalThis.fetch.bind(globalThis);
+  const baseUrl = opts.baseUrl ?? resolveGhPagesUrl(repo);
+  const url = `${baseUrl}/${DEMO_SEED_FILE}`;
+  const res = await fetchFn(url, { method: "GET", cache: "no-store" });
+  if (!res.ok) {
+    throw new Error(
+      `Kunde inte hämta demo-seed från ${url}: HTTP ${res.status}. ` +
+      `Är GH Pages aktiverat och har build-demo emit:at demo-seed.json?`,
+    );
+  }
+  const source = (await res.json()) as DemoSource;
+  // prebakeJoins är idempotent — säkerställer joins även om filen skulle vara
+  // en rå (icke-prebake:ad) DemoSource.
+  return prebakeJoins(source);
+}

--- a/src/lib/server/data-store/in-memory/static-sync-source.ts
+++ b/src/lib/server/data-store/in-memory/static-sync-source.ts
@@ -64,4 +64,12 @@ export class StaticSyncSource implements SyncTransport {
     this.append({ entity: mutation.entity, row: mutation.row, deleted: mutation.kind === "delete" });
     return Promise.resolve({ status: "accepted", row: mutation.row });
   }
+
+  /** Ersätt seeden (töm loggen, börja om från seq 0). Demo-vägen laddar seeden
+   *  lazy först vid cache-miss → konstruerar tom och `reset`:ar sedan (#544). */
+  reset(seed: DemoSource): void {
+    this.log.length = 0;
+    this.seq = 0;
+    for (const change of flattenSeedToChanges(seed)) this.append(change);
+  }
 }

--- a/test/unit/server/data-store/static-sync-source.test.ts
+++ b/test/unit/server/data-store/static-sync-source.test.ts
@@ -70,6 +70,15 @@ describe("StaticSyncSource — pull/push/cursor", () => {
     const res = await src.pull(3);
     expect(res.changes).toEqual([{ entity: "contact", row: { id: "c1" }, deleted: true }]);
   });
+
+  it("reset() tömmer loggen och seedar om från seq 0", async () => {
+    const src = new StaticSyncSource();
+    expect((await src.pull(0)).cursor).toBe(0);
+    src.reset(seed);
+    const res = await src.pull(0);
+    expect(res.changes).toHaveLength(3);
+    expect(res.cursor).toBe(3);
+  });
 });
 
 describe("StaticSyncSource — integration med CachingSyncDataStore (hela reconcile-loopen)", () => {

--- a/tooling/scripts/build-demo.sh
+++ b/tooling/scripts/build-demo.sh
@@ -125,6 +125,11 @@ bun tooling/scripts/build-demo-repo.ts --dir "$ROOT/out"
 echo "[build-demo] Genererar manifest.json över out/..."
 bun tooling/scripts/generate-demo-manifest.ts "$ROOT/out"
 
+# demo-seed.json (#544, ADR 0025): EN bundlad seed som klienten hämtar i st.f.
+# manifest + N filer → hydrerar cachen via den riktiga reconcile/pull-vägen.
+echo "[build-demo] Genererar demo-seed.json över out/..."
+bun tooling/scripts/generate-demo-seed.ts "$ROOT/out"
+
 # .nojekyll: utan denna fil ignorerar GitHub Pages alla dotfile-mappar
 # (t.ex. /.ava/users/) → users + org-data skulle 404:a.
 touch "$ROOT/out/.nojekyll"

--- a/tooling/scripts/generate-demo-seed.ts
+++ b/tooling/scripts/generate-demo-seed.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env tsx
+/**
+ * `generate-demo-seed.ts` (#544, ADR 0025) — emit:ar EN bundlad `demo-seed.json`
+ * i demo-out:en. Klienten hämtar den (i st.f. manifest.json + N filer) och
+ * hydrerar cachen via den riktiga reconcile/pull-vägen (`StaticSyncSource`).
+ *
+ * DRY: vi återanvänder `loadDemoSeed` (klientens egen seed-assembler) med en
+ * filsystems-`fetch` mot out-mappen → `demo-seed.json` blir EXAKT den
+ * `DemoSource` klienten annars hade byggt av manifest + filer (samma gruppering,
+ * versionsgrind och `prebakeJoins`). Körs i `build-demo.sh` efter att
+ * `generate-demo-manifest` skrivit manifestet.
+ *
+ * Användning:  bun tooling/scripts/generate-demo-seed.ts <out-dir>
+ */
+
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { loadDemoSeed } from "../../src/lib/client/demo/demo-seed-loader";
+
+/** Filsystems-`fetch`: mappar `<baseUrl=""><path>` → fil i out-mappen. */
+function fileFetch(outDir: string): typeof fetch {
+  return (async (url: string | URL | Request): Promise<Response> => {
+    const rel = String(url).replace(/^\/+/, "");
+    try {
+      const body = await readFile(join(outDir, rel), "utf8");
+      return new Response(body, { status: 200 });
+    } catch {
+      return new Response("", { status: 404 });
+    }
+  }) as typeof fetch;
+}
+
+async function main(): Promise<void> {
+  const outDir = process.argv[2];
+  if (!outDir) {
+    console.error("[demo-seed] saknar out-dir-argument");
+    process.exit(1);
+  }
+  const seed = await loadDemoSeed("local", { baseUrl: "", fetchFn: fileFetch(outDir), concurrency: 64 });
+  const dest = join(outDir, "demo-seed.json");
+  await writeFile(dest, JSON.stringify(seed));
+  const counts = Object.entries(seed)
+    .map(([k, v]) => `${k}=${Array.isArray(v) ? v.length : 0}`)
+    .filter((s) => !s.endsWith("=0"));
+  console.log(`[demo-seed] skrev ${dest} (${counts.join(", ")})`);
+}
+
+main().catch((err) => {
+  console.error("[demo-seed] FEL:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
Del 2 av epic #542 (ADR 0025). Bygger på #546.

## Vad
Demon hydrerar nu sin offline-cache via **samma `reconcile → pull → applyPull → persist`-väg** som den riktiga klienten, i st.f. seed-populerings-forken (`seed`-option + `loadDemoSeed`/manifest).

**Klient**
- `createDemoStore` injicerar `StaticSyncSource` och kör `reconcile()` vid **cache-miss** → seeden pull:as in via apply-vägen + persisteras. **Cache-hit** hydreras direkt ur IndexedDB-snapshotet (ingen seed-fetch). Seeden laddas lazy först vid miss (`StaticSyncSource.reset`).
- Ny `loadBundledSeed` — hämtar **en** same-origin `demo-seed.json` i st.f. `loadDemoSeed`s manifest + N parallella fetchar.
- `/demo`-routen (`DemoClient`) använder också `loadBundledSeed`.
- **Inget runtime-klientflöde fetchar längre `manifest.json` / kör `loadDemoSeed`.**

**Bygge**
- `build-demo.sh` emit:ar `demo-seed.json` via nya `generate-demo-seed.ts`, som **DRY** återanvänder `loadDemoSeed` med en filsystems-`fetch` → filen blir *exakt* den `DemoSource` klienten annars byggt (samma gruppering, versionsgrind, `prebakeJoins`).

## Avgränsning
`loadDemoSeed`/manifest behålls som **build-intern assembler** (och `/demo`-routens loader är bytt). Fullständig borttagning av manifest väntar tills byte-vägen (#545) frikopplats — manifest matar fortfarande build-assemblern och cachas av PWA-strategin.

## Cold-start
Demon går nu tom → reconcile → populerad (samma initial-load-väg som riktiga klienten) — exakt poängen med ADR 0025: varje cache-miss övar reconcile-loopen i produktion.

## Verifierat lokalt
`typecheck`, `lint` (--max-warnings 0), `knip`, `deps:check`, `build:demo` (demo-seed.json: 19 entitetstyper, 396 KB), `test:cov` (90.76 % rader / 85.56 % funktioner) — alla gröna. Den faktiska browser-hydreringen valideras av CI:s deploy-/demo-E2E.

Refs #544, #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)