### PR TITLE
feat(demo): byte-cache-hydrering via StaticContentStore (ADR 0025, #545)

### DIFF
--- a/src/components/shell/demo-bootstrap.tsx
+++ b/src/components/shell/demo-bootstrap.tsx
@@ -27,13 +27,16 @@ import { AuthProvider, useAuthMode } from "@/lib/client/auth/use-auth-mode";
 import { createDemoStore } from "@/lib/client/backend/create-demo-store";
 import { GitBackendRuntime } from "@/lib/client/backend/git-backend-runtime";
 import type { OidcLoginOutcome, OidcClaims } from "@/lib/client/backend/oidc-principal";
+import { StaticContentStore } from "@/lib/client/backend/static-content-store";
 import { DemoModeProvider } from "@/lib/client/demo/demo-mode-context";
 import { loadFirmaConfig, patchFirmaConfig, type FirmaConfig } from "@/lib/client/firma/firma-config";
 import { SyncProviderRoot } from "@/lib/client/sync/sync-context";
 import { trpc } from "@/lib/client/trpc";
+import { buildGitPorts } from "@/lib/server/adapters/git-ports";
 import { GitAuthProvider } from "@/lib/server/auth/git-auth-provider";
 import type { IDataStore } from "@/lib/server/data-store/IDataStore";
 import type { CachingSyncDataStore } from "@/lib/server/data-store/in-memory/caching-sync-data-store";
+import { resolveGhPagesUrl } from "@/lib/shared/gh-pages-url";
 import { AppShell } from "./app-shell";
 import { AuthStatusBanner } from "./auth-status-banner";
 import { AutoSync } from "./auto-sync";
@@ -91,10 +94,19 @@ function makeDemoQueryClient(): QueryClient {
 }
 
 function createDemoTrpcClient(dataStore: IDataStore, firmaConfig: FirmaConfig) {
+  // Content-porten serverar de bundlade dokument-blobbarna (#545, ADR 0025) så
+  // `document.downloadContent` → byte-cachen funkar i demon, via SAMMA
+  // IContentStore-söm som GitContentStore server-side (noopContentStore gav
+  // `read → null` → seed-dokument gick aldrig att öppna).
+  const ports = {
+    ...buildGitPorts(dataStore),
+    content: new StaticContentStore(resolveGhPagesUrl(firmaConfig.repo)),
+  };
   return trpc.createClient({
     links: [
       new GitBackendRuntime({
         dataStore,
+        ports,
         authProvider: new GitAuthProvider({
           // principalId sätts av login-flowet (`/login`). Demo utan satt
           // principal → guest-id (datakällan filtrerar bort user-bundna

--- a/src/lib/client/backend/static-content-store.ts
+++ b/src/lib/client/backend/static-content-store.ts
@@ -1,0 +1,46 @@
+"use client";
+
+/**
+ * `StaticContentStore` (#545, ADR 0025) — `IContentStore` för demon utan server.
+ * `read(storagePath)` hämtar den bundlade blobben (`<baseUrl>/<storagePath>`,
+ * t.ex. `documents/content/doc-docx-12.docx`) som `build-demo` la i out/.
+ *
+ * Poängen: demon öppnar dokument via SAMMA väg som den riktiga klienten —
+ * `loadDocumentBlob` → `document.downloadContent` → `ctx.ports.content.read` →
+ * klientens IndexedDB-byte-cache (`DocumentContentCache.putBytes`). Andra
+ * öppningen är en cache-hit (ingen fetch). Så demon bevisar byte-cache-vägen
+ * (läs → cache → läs) med samma `IContentStore`-söm som `GitContentStore`
+ * server-side — i st.f. `noopContentStore` (som ger `read → null` → dokumenten
+ * gick aldrig att öppna i demon).
+ *
+ * `write` är no-op och `exists` görs billigt via en GET (GH Pages saknar HEAD-
+ * stöd för statiska filer på ett pålitligt sätt) — demon laddar aldrig upp.
+ */
+
+import type { IContentStore } from "@/lib/server/ports";
+
+export class StaticContentStore implements IContentStore {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly fetchFn: typeof fetch = globalThis.fetch.bind(globalThis),
+  ) {}
+
+  private url(storagePath: string): string {
+    return `${this.baseUrl}/${storagePath.replace(/^\/+/, "")}`;
+  }
+
+  async write(): Promise<void> {
+    /* no-op: demon laddar aldrig upp bytes (ingen server). */
+  }
+
+  async read(storagePath: string): Promise<Uint8Array | null> {
+    const res = await this.fetchFn(this.url(storagePath), { method: "GET", cache: "no-store" });
+    if (!res.ok) return null;
+    return new Uint8Array(await res.arrayBuffer());
+  }
+
+  async exists(storagePath: string): Promise<boolean> {
+    const res = await this.fetchFn(this.url(storagePath), { method: "GET", cache: "no-store" });
+    return res.ok;
+  }
+}

--- a/test/unit/lib/backend/static-content-store.test.ts
+++ b/test/unit/lib/backend/static-content-store.test.ts
@@ -1,0 +1,56 @@
+/**
+ * `StaticContentStore` (#545, ADR 0025) — IContentStore som serverar bundlade
+ * demo-blobbar via fetch. Demon öppnar dokument via samma content-port-söm som
+ * server-first (GitContentStore).
+ */
+
+import { describe, it, expect, vi } from "vitest-compat";
+import { StaticContentStore } from "@/lib/client/backend/static-content-store";
+import type { IContentStore } from "@/lib/server/ports";
+
+function res(body: Uint8Array | null): Response {
+  if (body === null) return new Response("", { status: 404 });
+  return new Response(body as BlobPart, { status: 200 });
+}
+
+describe("StaticContentStore", () => {
+  it("read() hämtar bytes från <baseUrl>/<storagePath>", async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const fetchFn = vi.fn(async () => res(bytes)) as unknown as typeof fetch;
+    const store = new StaticContentStore("https://x.io/ava", fetchFn);
+
+    const got = await store.read("documents/content/doc-12.pdf");
+    expect(got).toEqual(bytes);
+    expect(fetchFn).toHaveBeenCalledWith(
+      "https://x.io/ava/documents/content/doc-12.pdf",
+      { method: "GET", cache: "no-store" },
+    );
+  });
+
+  it("read() normaliserar ledande slash i storagePath", async () => {
+    const fetchFn = vi.fn(async () => res(new Uint8Array([9]))) as unknown as typeof fetch;
+    const store = new StaticContentStore("https://x.io/ava", fetchFn);
+    await store.read("/documents/content/x.pdf");
+    expect(fetchFn).toHaveBeenCalledWith("https://x.io/ava/documents/content/x.pdf", expect.anything());
+  });
+
+  it("read() → null vid 404 (blob saknas)", async () => {
+    const fetchFn = vi.fn(async () => res(null)) as unknown as typeof fetch;
+    const store = new StaticContentStore("https://x.io/ava", fetchFn);
+    expect(await store.read("documents/content/missing.pdf")).toBeNull();
+  });
+
+  it("exists() speglar svaret ok/404", async () => {
+    const okFetch = vi.fn(async () => res(new Uint8Array([1]))) as unknown as typeof fetch;
+    const missFetch = vi.fn(async () => res(null)) as unknown as typeof fetch;
+    expect(await new StaticContentStore("b", okFetch).exists("p")).toBe(true);
+    expect(await new StaticContentStore("b", missFetch).exists("p")).toBe(false);
+  });
+
+  it("write() är no-op (demon laddar aldrig upp)", async () => {
+    const fetchFn = vi.fn() as unknown as typeof fetch;
+    const store: IContentStore = new StaticContentStore("b", fetchFn);
+    await store.write("p", new Uint8Array([1]));
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Del 3 (sista) av epic #542 (ADR 0025). Bygger på #547.

## Vad
Demon öppnar nu dokument via **samma byte-väg** som den riktiga klienten, i st.f. `noopContentStore` (som gav `read → null` → seed-dokument gick aldrig att öppna i demon).

- `StaticContentStore implements IContentStore` — `read(storagePath)` hämtar den bundlade blobben (`<baseUrl>/documents/content/…`) som `build-demo` la i `out/`. `write` = no-op, `exists` = GET-ok (demon laddar aldrig upp).
- Wirad in i demons tRPC-klient (`createDemoTrpcClient` → `GitBackendRuntime`-ports). `demo-bootstrap` är composition-root (dep-cruiser-undantaget) → får värde-importera `buildGitPorts`.

## Effekt (byte-vägen bevisad)
Hela öppna-vägen funkar serverlöst och övar byte-cachen — exakt samma kedja som server-first:
`loadDocumentBlob` → `document.downloadContent` → `ctx.ports.content.read` (StaticContentStore) → `DocumentContentCache.putBytes` (IndexedDB) → `Blob`; **andra öppningen är en cache-hit** (ingen fetch). Samma `IContentStore`-söm som `GitContentStore` server-side.

## Verifierat lokalt
`typecheck`, `lint` (--max-warnings 0), `knip`, `deps:check`, `build:demo`, `test:cov` (90.73 % rader / 85.58 % funktioner) — alla gröna.

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)