### PR TITLE
test(repositories): täck TimeEntry frysning/perLawyer/billable + höj FUNC-golv → 84.3% (#27)

### DIFF
--- a/test/unit/server/repositories/time-entry-repository.test.ts
+++ b/test/unit/server/repositories/time-entry-repository.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
-import { matters, timeEntries, users } from "@/lib/server/db/schema";
+import { contacts, matterContacts, matters, timeEntries, users } from "@/lib/server/db/schema";
 import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleTimeEntryRepository } from "@/lib/server/repositories/drizzle-time-entry-repository";
 import { InMemoryTimeEntryRepository } from "@/lib/server/repositories/in-memory-time-entry-repository";
@@ -64,5 +64,88 @@ describe("TimeEntryRepository — Drizzle (pglite)", () => {
 
     await repo.flagBilled([t1], uuidv7());
     expect(await repo.listUnbilled(mId, [t1, t2])).toHaveLength(1);
+  });
+});
+
+// ─── Frysning + perLawyer-period + listBillableForOrg (#27: otäckta metoder) ───
+
+const ORG = "77777777-7777-7777-8777-777777777777";
+
+// Delad fixtur: ett ärende (org), en jurist, en KLIENT-kontakt; 5 tidsposter
+// (juni-period + en i maj utanför, en fryst, en icke-debiterbar).
+function teFixture() {
+  const mId = uuidv7(), uId = uuidv7(), cKli = uuidv7();
+  const teEarly = uuidv7(), teLate = uuidv7(), teFrozen = uuidv7(), teOutside = uuidv7(), teNonBill = uuidv7();
+  const rows = [
+    { id: teLate, userId: uId, matterId: mId, minutes: 60, date: new Date("2026-06-10"), description: "sen", billable: true, frozenByBillingRunId: null },
+    { id: teEarly, userId: uId, matterId: mId, minutes: 30, date: new Date("2026-06-01"), description: "tidig", billable: true, frozenByBillingRunId: null },
+    { id: teFrozen, userId: uId, matterId: mId, minutes: 45, date: new Date("2026-06-05"), description: "fryst", billable: true, frozenByBillingRunId: uuidv7() },
+    { id: teOutside, userId: uId, matterId: mId, minutes: 20, date: new Date("2026-05-01"), description: "maj", billable: true, frozenByBillingRunId: null },
+    { id: teNonBill, userId: uId, matterId: mId, minutes: 15, date: new Date("2026-06-02"), description: "ej deb", billable: false, frozenByBillingRunId: null },
+  ];
+  return { mId, uId, cKli, teEarly, teLate, teFrozen, teOutside, teNonBill, rows };
+}
+
+describe("TimeEntryRepository — frysning/perLawyer/billable (in-memory)", () => {
+  it("listUnfrozenForMatter + listForLawyerInPeriod + listBillableForOrg + freezeForMatter", async () => {
+    const f = teFixture();
+    const store = new LocalStore({
+      matters: [{ id: f.mId, organizationId: ORG, matterNumber: "2026-1", title: "T" }],
+      users: [{ id: f.uId, name: "Anna" }],
+      contacts: [{ id: f.cKli, organizationId: ORG, name: "Klient AB", contactType: "COMPANY" }],
+      matterContacts: [{ id: uuidv7(), matterId: f.mId, contactId: f.cKli, role: "KLIENT" }],
+      timeEntries: f.rows,
+    }, async () => {});
+    const repo = new InMemoryTimeEntryRepository(store);
+
+    // listUnfrozenForMatter: alla ofrysta (oavsett billable), date asc; ej den frusna.
+    expect((await repo.listUnfrozenForMatter(f.mId)).map((t) => t.id))
+      .toEqual([f.teOutside, f.teEarly, f.teNonBill, f.teLate]);
+
+    // listForLawyerInPeriod: juni → exkl maj, date asc, med KLIENT-namn.
+    const period = await repo.listForLawyerInPeriod(ORG, f.uId, new Date("2026-06-01"), new Date("2026-06-30"));
+    expect(period.map((t) => t.id)).toEqual([f.teEarly, f.teNonBill, f.teFrozen, f.teLate]);
+    expect(period[0]!.matter?.contacts[0]?.contact.name).toBe("Klient AB");
+
+    // listBillableForOrg: bara billable i org (ej teNonBill).
+    expect((await repo.listBillableForOrg(ORG)).map((t) => t.id).sort())
+      .toEqual([f.teEarly, f.teLate, f.teFrozen, f.teOutside].sort());
+
+    // freezeForMatter: fryser alla ofrysta → inga ofrysta kvar.
+    await repo.freezeForMatter(f.mId, uuidv7(), new Date("2026-06-30"));
+    expect(await repo.listUnfrozenForMatter(f.mId)).toHaveLength(0);
+  });
+});
+
+describe("TimeEntryRepository — frysning/perLawyer/billable (Drizzle/pglite)", () => {
+  let handle: TestDbHandle;
+  beforeAll(async () => { handle = await createTestDb(); });
+  afterAll(async () => { await handle.close(); });
+
+  it("listUnfrozenForMatter + listForLawyerInPeriod + listBillableForOrg + freezeForMatter", async () => {
+    const db = handle.db;
+    const f = teFixture();
+    const org = uuidv7();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
+    await db.insert(matters).values(v({ id: f.mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
+    await db.insert(users).values(v({ id: f.uId, organizationId: org, email: "a@x", name: "Anna" }));
+    await db.insert(contacts).values(v({ id: f.cKli, organizationId: org, name: "Klient AB", contactType: "COMPANY" }));
+    await db.insert(matterContacts).values(v({ id: uuidv7(), matterId: f.mId, contactId: f.cKli, role: "KLIENT" }));
+    for (const r of f.rows) await db.insert(timeEntries).values(v({ ...r, organizationId: org, hourlyRate: 1000 }));
+    const repo = new DrizzleTimeEntryRepository(db as unknown as AppDb);
+
+    expect((await repo.listUnfrozenForMatter(f.mId)).map((t) => t.id))
+      .toEqual([f.teOutside, f.teEarly, f.teNonBill, f.teLate]);
+
+    const period = await repo.listForLawyerInPeriod(org, f.uId, new Date("2026-06-01"), new Date("2026-06-30"));
+    expect(period.map((t) => t.id)).toEqual([f.teEarly, f.teNonBill, f.teFrozen, f.teLate]);
+    expect(period[0]!.matter?.contacts[0]?.contact.name).toBe("Klient AB");
+
+    expect((await repo.listBillableForOrg(org)).map((t) => t.id).sort())
+      .toEqual([f.teEarly, f.teLate, f.teFrozen, f.teOutside].sort());
+
+    await repo.freezeForMatter(f.mId, uuidv7(), new Date("2026-06-30"));
+    expect(await repo.listUnfrozenForMatter(f.mId)).toHaveLength(0);
   });
 });

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -76,9 +76,14 @@ const FAST = process.argv.includes("--fast");
 // nyligen täckta repo-metoderna (folder/matter-contact) är FUNC-marginalen
 // återhämtad efter #518 Fas 5 till ~1.45% → FUNC-golvet dras upp 84.1 → 84.2
 // (~1.35% marginal, inom historiska 1.3–1.5%). LINE oförändrat (rader dippar
-// till 90.64% på vissa körningar → 0.895 är nära taket).
+// till 90.64% på vissa körningar → 0.895 är nära taket) → 89.5 rader / 84.3
+// funktioner (#27: TimeEntryRepository.listUnfrozenForMatter/freezeForMatter/
+// listForLawyerInPeriod/listBillableForOrg testade → drizzle-time-entry 81%→100%.
+// Repo-täckningssvepet (matter-contact/folder/expense/time-entry) klart →
+// lokalt 90.77% rader / 85.63% funktioner. FUNC dras upp 84.2 → 84.3
+// (~1.33% marginal). LINE oförändrat).
 const LINE_FLOOR = 0.895;
-const FUNC_FLOOR = 0.842;
+const FUNC_FLOOR = 0.843;
 
 /**
  * SERIAL_FILES — testfiler som SYNKRONT spawnar en barnprocess via


### PR DESCRIPTION
Ratchet-steg för #27 — **sista repot i täckningssvepet**.

## Vad
`TimeEntryRepository` hade billing-run-/perLawyer-/billable-metoderna otestade. Lägger till **paritetstester (in-memory + Drizzle/pglite)**:

- `listUnfrozenForMatter` — ofrysta tidsposter i ärende (oavsett billable), date asc
- `listForLawyerInPeriod` — en jurists tidsposter i en period, date asc + period-filtrering + ärende-ref med KLIENT-kontaktnamn
- `listBillableForOrg` — bara debiterbara tidsposter i org:en
- `freezeForMatter` — fryser alla ofrysta mot en billing-run

## Effekt
- `drizzle-time-entry-repository.ts`: **81 % → 100 % rader**.
- **Repo-täckningssvepet klart**: matter-contact (#538), folder (#540), expense (#541), time-entry (denna).
- Merged-täckning lokalt: **90.77 % rader / 85.63 % funktioner** → `FUNC_FLOOR` 0.842 → **0.843** (~1.33 % marginal). `LINE_FLOOR` oförändrat (0.895).

## Verifierat lokalt
`typecheck`, `lint` (--max-warnings 0), `test:cov` (grön vid golv 89.5 / 84.3).

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)