### PR TITLE
fix(demo): persistera reconcile-snapshot en gång per batch (inte per rad) (#550)

### DIFF
--- a/src/lib/server/data-store/in-memory/caching-sync-data-store.ts
+++ b/src/lib/server/data-store/in-memory/caching-sync-data-store.ts
@@ -83,6 +83,8 @@ export class CachingSyncDataStore {
     readonly store: LocalStore,
     private readonly queue: MutationQueue,
     private readonly engine: ReconcileEngine,
+    /** Persistera hela source-snapshotet (en gång per reconcile-batch). */
+    private readonly persistSnapshot: () => Promise<void>,
   ) {}
 
   /** Hydrera (kö + source ur persistens) och komponera klossarna (server-vägen). */
@@ -124,18 +126,29 @@ export class CachingSyncDataStore {
 
     const store = new LocalStore(source, onLocalMutation);
 
-    const apply: ApplyCanonical = async (entity, row, deleted) => {
+    // apply skriver bara till lokal store — INGEN persist per rad. En reconcile
+    // som hydrerar hela seeden (#544: ~500 rader) skulle annars trigga ~500
+    // snapshot-skrivningar av en växande source (O(n²) bytes → hängde demon på
+    // mobil-IndexedDB, "AVA laddar…"). `reconcile()` persisterar EN gång efter
+    // hela batchen i st.f. Mid-reconcile-krasch → cursorn ej advancerad → rader
+    // re-pullas nästa gång (idempotent), så inget tappas.
+    const apply: ApplyCanonical = (entity, row, deleted) => {
       writeCanonical(store, entity, row, deleted);
-      await persistSnapshot();
     };
 
     const engine = new ReconcileEngine({ transport: deps.transport, queue, cursor, apply });
-    return new CachingSyncDataStore(store, queue, engine);
+    return new CachingSyncDataStore(store, queue, engine, persistSnapshot);
   }
 
-  /** Reconcile mot servern (pull→apply→replay→advance) — online-vägen. */
-  reconcile(): Promise<ReconcileResult> {
-    return this.engine.reconcile();
+  /** Reconcile mot servern (pull→apply→replay→advance) — online-vägen.
+   *  Persisterar snapshotet EN gång efter hela batchen (se `apply` ovan), och
+   *  bara om något faktiskt ändrades (tom poll-reconcile → ingen skrivning). */
+  async reconcile(): Promise<ReconcileResult> {
+    const result = await this.engine.reconcile();
+    if (result.pulled > 0 || result.pushed > 0 || result.rebased > 0) {
+      await this.persistSnapshot();
+    }
+    return result;
   }
 
   /** Antal ej-synkade (köade) mutationer. */

--- a/test/unit/server/data-store/caching-sync-data-store.test.ts
+++ b/test/unit/server/data-store/caching-sync-data-store.test.ts
@@ -156,4 +156,29 @@ describe("CachingSyncDataStore (#415)", () => {
       });
     });
   });
+
+  // #544/ADR 0025 regression: en reconcile som pullar in N rader (demons seed-
+  // hydrering) får INTE persistera per rad — det blev O(n²) bytes och hängde
+  // demon på mobil-IndexedDB ("AVA laddar…"). EN skrivning per batch, och tom
+  // poll-reconcile skriver inte alls.
+  describe("persist-per-batch (inte per rad)", () => {
+    it("persisterar snapshotet en gång för en N-raders pull; tom reconcile = 0 skrivningar", async () => {
+      const transport = new FakeTransport();
+      transport.pullResult = {
+        changes: Array.from({ length: 5 }, (_, i) => ({ entity: "matter", row: matter(uuidv7(), `M${i}`) })),
+        cursor: 5,
+      };
+      let saves = 0;
+      const persistence = { hydrate: async () => null, save: async () => { saves++; } };
+      const ds = await CachingSyncDataStore.create({ transport, persistence });
+
+      const r = await ds.reconcile();
+      expect(r.pulled).toBe(5);
+      expect(saves).toBe(1); // EN skrivning för hela batchen, inte 5
+
+      transport.pullResult = { changes: [], cursor: 5 };
+      await ds.reconcile();
+      expect(saves).toBe(1); // tom poll-reconcile → ingen extra skrivning
+    });
+  });
 });


### PR DESCRIPTION
## Symptom
Demon fastnar på **"AVA laddar…"** utan felmeddelande (särskilt mobil/iPad, och vid cache-miss = ny deploy).

## Rotorsak
ADR 0025/#544 lät demon hydrera cachen via `reconcile()`. `CachingSyncDataStore`s `apply`-callback anropade `persistSnapshot()` (hel IndexedDB-skrivning av HELA source:n) **per rad**. Demons seed = ~500 rader → ~500 sekventiella skrivningar av en växande snapshot (**O(n²) bytes, ~113 MB totalt**) → hängde på mobil-IndexedDB.

## Fix
- `apply` skriver bara till lokal store (ingen persist per rad).
- `reconcile()` persisterar snapshotet **en gång** efter hela batchen, och bara om något ändrades (tom poll-reconcile → ingen skrivning).
- Gäller även server-first stora pulls + sparar onödiga skrivningar vid auto-sync-polling.
- Mid-reconcile-krasch → cursorn ej advancerad → rader re-pullas (idempotent), inget tappas.

**Mätt** (498-raders demo-seed-hydrering): persist-skrivningar **498 → 1**, serialiserat **113 MB → 0.39 MB**.

## Test
Regressionstest: en N-raders pull ger 1 persist; tom reconcile ger 0.

## Varför CI inte fångade det
Ingen check laddar demon i en webbläsare och väntar på data — deploy-E2E testar server-first, "Demo build" bygger bara out/. (Separat uppföljning värd att överväga: en browser-smoke för demon.)

## Verifierat lokalt
`typecheck`, `lint` (--max-warnings 0), `test:cov` (90.77 % rader / 85.63 % funktioner) — gröna.

Closes #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)