### PR TITLE
fix(demo): rendera /login och /demo utan trpcClient-gaten — fixar "AVA Laddar…"-hängning (#552)

### DIFF
--- a/src/components/shell/demo-bootstrap.tsx
+++ b/src/components/shell/demo-bootstrap.tsx
@@ -227,8 +227,28 @@ export function DemoBootstrap({ children }: { children: ReactNode }) {
   });
 
   // Hydrerings-grind: identisk markup på server + klientens första render.
-  // Vi gate:ar även på att storen byggts (trpcClient).
-  if (!mounted || !trpcClient) {
+  if (!mounted) {
+    return (
+      <div className="fixed inset-0 flex items-center justify-center bg-white">
+        <div className="text-center">
+          <div className="text-lg font-medium text-gray-900 mb-2">AVA</div>
+          <div className="text-sm text-gray-500">Laddar…</div>
+        </div>
+      </div>
+    );
+  }
+
+  // Skip-auth-sidor (/login, /demo) bygger ALDRIG en demo-store/trpc-klient
+  // (skip-ready-gaten i useDemoBootstrap returnerar tidigt). De renderar sitt
+  // eget innehåll utan datakällan → gate:a INTE på trpcClient, annars fastnar
+  // de för evigt på "AVA Laddar…" (regression från #498:s !trpcClient-gate; en
+  // ny besökare utan principalId dirigeras till /login och kunde inte logga in).
+  if (pathSkipsAuth(window.location.pathname)) {
+    return <>{children}</>;
+  }
+
+  // Data-sidor väntar på att storen byggts.
+  if (!trpcClient) {
     return (
       <div className="fixed inset-0 flex items-center justify-center bg-white">
         <div className="text-center">

--- a/test/e2e/demo-login.spec.ts
+++ b/test/e2e/demo-login.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * E2E (demo): en FÄRSK besökare (ingen principal) ska kunna logga in.
+ *
+ * Regressionsskydd för buggen där hela demon fastnade på "AVA Laddar…":
+ * `DemoBootstrap` gate:ade HELA renderingen på `!trpcClient`, men skip-auth-
+ * sidorna (/login, /demo) bygger aldrig en trpc-klient (skip-ready-gaten
+ * returnerar tidigt). En ny besökare utan `principalId` dirigeras till /login
+ * → som aldrig renderade → ingen kunde logga in (#498-regression).
+ *
+ * Testet kör mot den deployade demon (default) eller en lokalt serverad out/:
+ *   AVA_DEMO_BASE_URL=http://localhost:8080/ava bun run e2e:demo
+ */
+import { test, expect } from "@playwright/test";
+
+test("färsk besökare (ingen principal) → /login renderar inloggningen, fastnar inte på 'Laddar…'", async ({ page, context, baseURL }) => {
+  const base = baseURL ?? "https://ulrik-s.github.io/ava";
+
+  // Färsk demo-besökare: tier=demo, INGEN principalId (deterministiskt oavsett
+  // build-defaults). Detta är exakt vad en ny besökare på live-demon har.
+  await context.addInitScript(() => {
+    try {
+      localStorage.setItem("ava.firma", JSON.stringify({
+        tier: "demo", repo: "ulrik-s/ava", token: "",
+        principalId: "", organizationId: "", authorName: "", authorEmail: "",
+      }));
+    } catch { /* ignore */ }
+  });
+
+  await page.goto(`${base}/`, { waitUntil: "domcontentloaded" });
+
+  // Utan principal → bootstrap dirigerar till /login.
+  await expect(page).toHaveURL(/\/login\/?$/, { timeout: 20_000 });
+
+  // /login renderar sitt eget innehåll (rubrik + Logga in-knapp) — INTE bara
+  // DemoBootstrap-platshållaren. (Rubriken renderas oberoende av meta-laddning.)
+  await expect(page.getByRole("heading", { name: /Logga in/i })).toBeVisible({ timeout: 20_000 });
+  await expect(page.getByRole("button", { name: /^Logga in$/ })).toBeVisible({ timeout: 20_000 });
+
+  // Explicit regressionsvakt: vi får INTE ha fastnat på "AVA Laddar…"-skärmen.
+  const body = (await page.locator("body").innerText()).replace(/\s+/g, " ").trim();
+  expect(body, "demon fastnade på bootstrap-platshållaren").not.toBe("AVA Laddar…");
+});

--- a/tooling/config/playwright-demo.config.ts
+++ b/tooling/config/playwright-demo.config.ts
@@ -14,7 +14,7 @@ const projectRoot = path.resolve(__dirname, "..", "..");
  */
 export default defineConfig({
   testDir: path.join(projectRoot, "test/e2e"),
-  testMatch: /demo-invoice-document\.spec\.ts$/,
+  testMatch: /demo-(invoice-document|login)\.spec\.ts$/,
   timeout: 90_000,
   expect: { timeout: 15_000 },
   fullyParallel: false,


### PR DESCRIPTION
## Symptom
Demon fastnar på **"AVA Laddar…"** i Chrome OCH Firefox, utan felmeddelande — en färsk besökare kan inte logga in. (Min tidigare #551-fix var fel diagnos; detta är den faktiska orsaken.)

## Rotorsak (verifierad i riktig webbläsare)
`DemoBootstrap` gate:ade HELA renderingen på `if (!mounted || !trpcClient)` (infört i **#498**). Skip-auth-sidorna `/login` och `/demo` returnerar tidigt ur `useDemoBootstrap` (skip-ready-gaten) och bygger **aldrig** en `trpcClient` → gaten är alltid sann → de fastnar för evigt på platshållaren. En färsk besökare utan `principalId` dirigeras till `/login` → som aldrig renderar → **ingen kan logga in** → hela demon är oanvändbar.

`/matters` m.fl. funkar **med** en satt principal (då byggs en trpcClient), vilket fick det att se ut som ett data-/cache-fel — men det är renderings-gaten.

## Fix
Efter `mounted`: rendera skip-auth-sidornas `children` direkt, utan trpc-gaten. De behöver ingen demo-datastore (`/login` = egen meta-fetch + localStorage; `/demo` = `useDemoSeed`). Data-sidor väntar fortfarande på `trpcClient`.

## Test (det du bad om)
`test/e2e/demo-login.spec.ts`: färsk besökare (tier=demo, ingen principal) → `/` → redirect `/login` → inloggningen renderar (ej "Laddar…"). **Verifierad i riktig browser (playwright/chromium):**
- ✅ PASSERAR mot fixad build (lokalt serverad `out/`).
- ❌ FAILAR mot den live-deployade (buggiga) demon — bevisar att testet faktiskt fångar regressionen.

Wirad in i `playwright-demo.config` → körs av `bun run test:all`.

## Verifierat lokalt
`typecheck`, `lint` (--max-warnings 0), `knip`, `deps:check`, `build:demo`, `test:cov` (90.71 % / 85.63 %), + e2e demo-login mot serverad out/.

## Uppföljning
Ingen GitHub-Actions-check kör demo-e2e idag (deploy-E2E = server-first, "Demo build" bygger bara) — därför slank både detta och #498:s regression igenom. Värt en separat CI-job som kör `e2e:demo` mot en serverad `out/`.

Closes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)