### PR TITLE
ci: demo browser-smoke (serverad out/ + playwright demo-login) (#554)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,3 +226,44 @@ jobs:
           bun-version: latest
       - run: bun install --frozen-lockfile
       - run: bun run build:demo
+
+  # ───────────────── Demo E2E (browser-smoke) ─────────────────
+  # `build:demo` ovan bevisar att demon BYGGER — men inte att den LADDAR i en
+  # browser. Två produktions-buggar slank igenom just därför (#550/#552: demon
+  # fastnade på "AVA Laddar…"). Det här jobbet serverar den byggda out/ och kör
+  # en deterministisk render-smoke (färsk besökare → /login renderar, fastnar
+  # inte på platshållaren). Det tyngre faktura-flödet (demo-invoice-document)
+  # körs i `test:all` lokalt — här hålls CI-gaten snabb + hermetisk. (Kör på PR;
+  # INTE required check — ingen branch-protection-ändring.)
+  demo-e2e:
+    name: Demo E2E (browser-smoke)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - run: bun run build:demo
+      - run: bun run e2e:install
+      - name: Servera out/ + kör demo render-smoke
+        run: |
+          bun tooling/scripts/serve-demo-static.ts &
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:8799/ava/login/ >/dev/null && break
+            sleep 1
+          done
+          AVA_DEMO_BASE_URL=http://localhost:8799/ava \
+            npx playwright test test/e2e/demo-login.spec.ts \
+            --config tooling/config/playwright-demo.config.ts
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-demo-report
+          path: reports/playwright-demo/

--- a/tooling/scripts/serve-demo-static.ts
+++ b/tooling/scripts/serve-demo-static.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env bun
+/**
+ * `serve-demo-static.ts` — minimal statisk server för `out/` under `/ava`-
+ * prefixet, som speglar GitHub Pages (okänd path → 404.html SPA-fallback).
+ * Används av demo-e2e:t i CI (`bun run e2e:demo` mot en serverad out/) utan
+ * att dra in docker/nginx (demo-serve.sh kräver docker).
+ *
+ *   bun tooling/scripts/serve-demo-static.ts            # port 8799
+ *   DEMO_PORT=8080 bun tooling/scripts/serve-demo-static.ts
+ *
+ * Öppna http://localhost:8799/ava/. Avsiktligt ZERO beroenden (node:http).
+ */
+
+import { readFile, stat } from "node:fs/promises";
+import { createServer } from "node:http";
+import { extname, join } from "node:path";
+
+const ROOT = join(process.cwd(), "out");
+const PORT = Number(process.env.DEMO_PORT ?? 8799);
+const MIME: Record<string, string> = {
+  ".html": "text/html", ".js": "text/javascript", ".css": "text/css",
+  ".json": "application/json", ".svg": "image/svg+xml", ".png": "image/png",
+  ".pdf": "application/pdf", ".txt": "text/plain", ".ico": "image/x-icon",
+  ".woff2": "font/woff2", ".webmanifest": "application/manifest+json",
+};
+
+/** Returnera en serverbar fil-path (fil direkt, eller katalogens index.html). */
+async function resolveFile(p: string): Promise<string | null> {
+  try {
+    const s = await stat(p);
+    if (s.isFile()) return p;
+    if (s.isDirectory()) {
+      const idx = join(p, "index.html");
+      await stat(idx);
+      return idx;
+    }
+  } catch { /* saknas */ }
+  return null;
+}
+
+const server = createServer((req, res) => {
+  void (async () => {
+    const url = decodeURIComponent((req.url ?? "/").split("?")[0]!);
+    const rel = url.startsWith("/ava") ? url.slice(4) : url; // strip GH-Pages-prefixet
+    // Fil → annars 404.html (SPA-fallback, precis som GH Pages).
+    const file = (await resolveFile(join(ROOT, rel))) ?? (await resolveFile(join(ROOT, "404.html")));
+    if (!file) { res.writeHead(404).end("not found"); return; }
+    res.writeHead(200, { "content-type": MIME[extname(file)] ?? "application/octet-stream" });
+    res.end(await readFile(file));
+  })();
+});
+
+server.listen(PORT, () => console.log(`[serve-demo-static] http://localhost:${PORT}/ava/ (out/)`));


### PR DESCRIPTION
Stänger gapet som lät #550 + #552 nå live-demon: **ingen CI-grind laddade demon i en browser.**

## Vad
Nytt CI-jobb **"Demo E2E (browser-smoke)"** (ci.yml): bygger `out/`, installerar Playwright-chromium, serverar `out/` via en **beroende-fri statisk server** (`tooling/scripts/serve-demo-static.ts` — speglar GH-Pages `/ava`-prefix + 404-fallback) och kör den deterministiska `demo-login.spec.ts` (färsk besökare → `/login` renderar, fastnar inte på "AVA Laddar…").

- Hermetiskt + snabbt → låg flake-risk. Det tyngre `demo-invoice-document`-flödet stannar i `test:all` (lokalt).
- Kör på PR (som `demo-build`). **Ej required check** (ingen branch-protection-ändring) — men röd signal syns på PR:en. Att göra den required är ett separat admin-beslut (säg till så fixar jag det).

## Verifierat lokalt
Körde exakt CI-steget: `serve-demo-static.ts` + `demo-login`-specen mot serverad `out/` → **passerar**. `typecheck`, `lint` (--max-warnings 0), `knip`, `deps:check` gröna. (Ingen `src/`-ändring → coverage opåverkad.)

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)