### PR TITLE
refactor(types): typa LocalStore-delegaterna, ta bort 28 as-unknown-as-casts (#556)

### DIFF
--- a/src/lib/server/data-store/IDataStore.ts
+++ b/src/lib/server/data-store/IDataStore.ts
@@ -109,11 +109,12 @@ export interface Delegate<Row = any> {
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
-// Delegate-typerna är fortfarande Delegate<any>. Tightening per delegate via
-// `Delegate<Matter>` etc. avslöjar legacy-mismatches mellan schemas (nullish)
-// och kallar (förväntar `null`-only), samt relation-joins (matter.contacts)
-// som inte finns i bas-schemat. Tighten har gjorts opt-in via TypedDelegate
-// nedan så enskilda callers kan välja striktare typer när de vill.
+// Per-entitet-delegate: binder `Row` (branded id:n flödar ut via `Joined<Row>`).
+// In-memory-impl:en (`ReadOnlyDelegate<T> implements Delegate<T>`) satisfierar
+// dessa, så `LocalStore` wirar dem TYPADE utan casts (#typing). Den enda kvar-
+// varande lösheten är query-INPUT (`args`/`where`) inne i `Delegate` ovan — den
+// otypade Prisma-formade ytan (dokumenterad any). Tighta den kräver en
+// `WhereInput<Row>`-modell + 300+ router-anrops-rewrites (eget projekt).
 export type MatterDelegate = Delegate<Matter>;
 export type ContactDelegate = Delegate<Contact>;
 export type MatterContactDelegate = Delegate<MatterContact>;

--- a/src/lib/server/data-store/in-memory/local-store.ts
+++ b/src/lib/server/data-store/in-memory/local-store.ts
@@ -14,6 +14,9 @@
 
 import type { DemoSource } from "@/lib/shared/demo-source";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
+import type {
+  AccontoDeduction, BillingRun, CalendarEvent, ConflictCheck, Contact, Document, DocumentAnalysisSuggestion, DocumentFolder, DocumentTemplate, ExpectedReceivable, Expense, Invoice, InvoiceDispatch, Matter, MatterContact, MatterEventSuggestion, Office, Organization, Payment, PaymentPlan, ServiceNote, Task, TimeEntry, User, WriteOff,
+} from "@/lib/shared/schemas";
 import type { AvaEvent, EmitInput, EventFilter } from "../../events/schema";
 import type {
   IDataStore,
@@ -103,34 +106,34 @@ export class LocalStore implements IDataStore {
     // läser den AKTUELLA source-referensen så collections ser senaste arrayen.
     const relations = buildRelations(() => this.source);
 
-    this.matters = this.makeDelegate("matters", relations.matters) as unknown as MatterDelegate;
-    this.matterContacts = this.makeDelegate("matterContacts", relations.matterContacts) as unknown as MatterContactDelegate;
-    this.contacts = this.makeDelegate("contacts", relations.contacts) as unknown as ContactDelegate;
-    this.documents = this.makeDelegate("documents", relations.documents) as unknown as DocumentDelegate;
-    this.documentFolders = this.makeDelegate("documentFolders", relations.documentFolders) as unknown as DocumentFolderDelegate;
-    this.documentTemplates = this.makeDelegate("documentTemplates", relations.documentTemplates) as unknown as DocumentTemplateDelegate;
-    this.documentAnalysisSuggestions = this.makeDelegate("documentAnalysisSuggestions", relations.documentAnalysisSuggestions) as unknown as DocumentAnalysisSuggestionDelegate;
-    this.matterEventSuggestions = this.makeDelegate("matterEventSuggestions", relations.matterEventSuggestions) as unknown as MatterEventSuggestionDelegate;
-    this.invoices = this.makeDelegate("invoices", relations.invoices) as unknown as InvoiceDelegate;
-    this.timeEntries = this.makeDelegate("timeEntries", relations.timeEntries) as unknown as TimeEntryDelegate;
-    this.expenses = this.makeDelegate("expenses", relations.expenses) as unknown as ExpenseDelegate;
-    this.users = this.makeDelegate("users") as unknown as UserDelegate;
-    this.organizations = this.makeDelegate("organizations") as unknown as OrganizationDelegate;
-    this.offices = this.makeDelegate("offices") as unknown as OfficeDelegate;
-    this.conflictChecks = this.makeDelegate("conflictChecks", relations.conflictChecks) as unknown as ConflictCheckDelegate;
-    this.payments = this.makeDelegate("payments") as unknown as PaymentDelegate;
-    this.writeOffs = this.makeDelegate("writeOffs") as unknown as WriteOffDelegate;
-    this.invoiceDispatches = this.makeDelegate("invoiceDispatches", relations.invoiceDispatches) as unknown as InvoiceDispatchDelegate;
-    this.expectedReceivables = this.makeDelegate("expectedReceivables") as unknown as ExpectedReceivableDelegate;
-    this.paymentPlans = this.makeDelegate("paymentPlans", relations.paymentPlans) as unknown as PaymentPlanDelegate;
-    this.paymentPlanReminders = this.makeDelegate("paymentPlanReminders") as unknown as Delegate;
-    this.accontoDeductions = this.makeDelegate("accontoDeductions") as unknown as AccontoDeductionDelegate;
-    this.billingRuns = this.makeDelegate("billingRuns", relations.billingRuns) as unknown as BillingRunDelegate;
-    this.calendarEvents = this.makeDelegate("calendarEvents", relations.calendarEvents) as unknown as CalendarEventDelegate;
-    this.tasks = this.makeDelegate("tasks", relations.tasks) as unknown as TaskDelegate;
-    this.serviceNotes = this.makeDelegate("serviceNotes", relations.serviceNotes) as unknown as ServiceNoteDelegate;
-    this.userPreferences = this.makeDelegate("userPreferences") as unknown as Delegate;
-    this.orgPreferences = this.makeDelegate("orgPreferences") as unknown as Delegate;
+    this.matters = this.makeDelegate<Matter>("matters", relations.matters);
+    this.matterContacts = this.makeDelegate<MatterContact>("matterContacts", relations.matterContacts);
+    this.contacts = this.makeDelegate<Contact>("contacts", relations.contacts);
+    this.documents = this.makeDelegate<Document>("documents", relations.documents);
+    this.documentFolders = this.makeDelegate<DocumentFolder>("documentFolders", relations.documentFolders);
+    this.documentTemplates = this.makeDelegate<DocumentTemplate>("documentTemplates", relations.documentTemplates);
+    this.documentAnalysisSuggestions = this.makeDelegate<DocumentAnalysisSuggestion>("documentAnalysisSuggestions", relations.documentAnalysisSuggestions);
+    this.matterEventSuggestions = this.makeDelegate<MatterEventSuggestion>("matterEventSuggestions", relations.matterEventSuggestions);
+    this.invoices = this.makeDelegate<Invoice>("invoices", relations.invoices);
+    this.timeEntries = this.makeDelegate<TimeEntry>("timeEntries", relations.timeEntries);
+    this.expenses = this.makeDelegate<Expense>("expenses", relations.expenses);
+    this.users = this.makeDelegate<User>("users");
+    this.organizations = this.makeDelegate<Organization>("organizations");
+    this.offices = this.makeDelegate<Office>("offices");
+    this.conflictChecks = this.makeDelegate<ConflictCheck>("conflictChecks", relations.conflictChecks);
+    this.payments = this.makeDelegate<Payment>("payments");
+    this.writeOffs = this.makeDelegate<WriteOff>("writeOffs");
+    this.invoiceDispatches = this.makeDelegate<InvoiceDispatch>("invoiceDispatches", relations.invoiceDispatches);
+    this.expectedReceivables = this.makeDelegate<ExpectedReceivable>("expectedReceivables");
+    this.paymentPlans = this.makeDelegate<PaymentPlan>("paymentPlans", relations.paymentPlans);
+    this.paymentPlanReminders = this.makeDelegate("paymentPlanReminders");
+    this.accontoDeductions = this.makeDelegate<AccontoDeduction>("accontoDeductions");
+    this.billingRuns = this.makeDelegate<BillingRun>("billingRuns", relations.billingRuns);
+    this.calendarEvents = this.makeDelegate<CalendarEvent>("calendarEvents", relations.calendarEvents);
+    this.tasks = this.makeDelegate<Task>("tasks", relations.tasks);
+    this.serviceNotes = this.makeDelegate<ServiceNote>("serviceNotes", relations.serviceNotes);
+    this.userPreferences = this.makeDelegate("userPreferences");
+    this.orgPreferences = this.makeDelegate("orgPreferences");
 
     this.events = new ReadOnlyEventLog();
     this.raw = makeThrowingProxy() as unknown as IDataStore["raw"];

--- a/src/lib/server/data-store/in-memory/read-only-delegate.ts
+++ b/src/lib/server/data-store/in-memory/read-only-delegate.ts
@@ -18,6 +18,7 @@
  */
 
 import { omitUndefined } from "@/lib/shared/omit-undefined";
+import type { Delegate } from "../IDataStore";
 import { InMemoryQueryEngine, type QueryOptions } from "./query-engine";
 
 export class ReadOnlyError extends Error {
@@ -60,7 +61,7 @@ export interface FindArgs {
   include?: Record<string, unknown>;
 }
 
-export class ReadOnlyDelegate<T extends Record<string, unknown>> {
+export class ReadOnlyDelegate<T extends Record<string, unknown>> implements Delegate<T> {
   private engine = new InMemoryQueryEngine<T>();
 
   constructor(


### PR DESCRIPTION
Typnings-quickwin **1/3** från arkitekturgenomgången (mål: "no any anywhere").

## Bakgrund
Explicit `any` är utrotat utom i `IDataStore.ts` (en dokumenterad exception). Den verkliga typsvagheten är **213 `as unknown as`** (mjuk any), 162 i repository/datastore-lagret. `LocalStore`-konstruktorn ensam hade 28: alla delegate-fält castades `as unknown as XDelegate` för att `ReadOnlyDelegate<T>`/`WritableDelegate<T>` inte formellt deklarerade `implements Delegate<T>`.

## Fix
- `ReadOnlyDelegate<T> implements Delegate<T>` (WritableDelegate ärver → satisfierar också).
- Explicit row-typ vid varje `makeDelegate<Row>("x", relations.x)` → tilldelning till `Delegate<Row>`-fältet utan cast.
- Uppdaterade den inaktuella kommentaren i `IDataStore.ts` (den påstod att tightening avslöjar "nullish-mismatches" — gör det inte; 0 typfel).

**`implements` + type-args är type-only → noll runtime-ändring** (alla tester gröna).

## Effekt
- `as unknown as` i src: **213 → 185** (−28).
- Steg kvar (separata PR): `parseRow`-helper för drizzle-repos (2/3), in-memory-repo-delegering (3/3). Att helt eliminera `IDataStore`-any:n kräver en typad `WhereInput<Row>` + 300+ router-rewrites (eget projekt med egen ADR).

## Verifierat lokalt
`typecheck`, `lint` (--max-warnings 0), `knip`, `deps:check`, `test:cov` (90.71 % / 85.63 %) — alla gröna.

Refs #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)