### PR TITLE
refactor(types): ta bort 39 as-unknown-as-Delegate i in-memory-repos (#558)

### DIFF
--- a/src/lib/server/repositories/in-memory-acconto-deduction-repository.ts
+++ b/src/lib/server/repositories/in-memory-acconto-deduction-repository.ts
@@ -4,7 +4,7 @@
  */
 
 import type { AccontoDeduction } from "@/lib/shared/schemas/billing";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import type { AccontoDeductionRepository } from "./acconto-deduction-repository";
 import { InMemoryRepository } from "./in-memory-repository";
 
@@ -15,6 +15,6 @@ export class InMemoryAccontoDeductionRepository
   extends InMemoryRepository<AccontoDeduction>
   implements AccontoDeductionRepository {
   constructor(store: AccontoDeductionRepoSource, now?: () => Date) {
-    super(store.accontoDeductions as unknown as Delegate, now ?? (() => new Date()));
+    super(store.accontoDeductions, now ?? (() => new Date()));
   }
 }

--- a/src/lib/server/repositories/in-memory-billing-run-repository.ts
+++ b/src/lib/server/repositories/in-memory-billing-run-repository.ts
@@ -4,7 +4,7 @@
  */
 
 import type { BillingRun } from "@/lib/shared/schemas/billing";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import type {
   BillingRunDetailRow, BillingRunListRow, BillingRunRepository,
 } from "./billing-run-repository";
@@ -16,7 +16,7 @@ export class InMemoryBillingRunRepository
   extends InMemoryRepository<BillingRun>
   implements BillingRunRepository {
   constructor(store: BillingRunRepoSource, now?: () => Date) {
-    super(store.billingRuns as unknown as Delegate, now ?? (() => new Date()));
+    super(store.billingRuns, now ?? (() => new Date()));
   }
 
   async listForOrg(organizationId: string, matterId?: string): Promise<BillingRunListRow[]> {

--- a/src/lib/server/repositories/in-memory-calendar-event-repository.ts
+++ b/src/lib/server/repositories/in-memory-calendar-event-repository.ts
@@ -4,7 +4,7 @@
  */
 
 import type { CalendarEvent } from "@/lib/shared/schemas/calendar";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import type { CalendarEventRepository, CalendarEventRow } from "./calendar-event-repository";
 import { InMemoryRepository } from "./in-memory-repository";
 
@@ -15,7 +15,7 @@ const MATTER_INCLUDE = { matter: { select: { id: true, matterNumber: true, title
 
 export class InMemoryCalendarEventRepository extends InMemoryRepository<CalendarEvent> implements CalendarEventRepository {
   constructor(store: CalendarEventRepoSource, now?: () => Date) {
-    super(store.calendarEvents as unknown as Delegate, now ?? (() => new Date()));
+    super(store.calendarEvents, now ?? (() => new Date()));
   }
 
   async listForUser(userId: string, organizationId: string): Promise<CalendarEventRow[]> {

--- a/src/lib/server/repositories/in-memory-conflict-check-repository.ts
+++ b/src/lib/server/repositories/in-memory-conflict-check-repository.ts
@@ -3,7 +3,7 @@
  */
 
 import type { ConflictCheck } from "@/lib/shared/schemas/misc";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import type { ConflictCheckRepository, ConflictCheckRow } from "./conflict-check-repository";
 import { InMemoryRepository } from "./in-memory-repository";
 
@@ -13,7 +13,7 @@ export class InMemoryConflictCheckRepository
   extends InMemoryRepository<ConflictCheck>
   implements ConflictCheckRepository {
   constructor(store: ConflictCheckRepoSource, now?: () => Date) {
-    super(store.conflictChecks as unknown as Delegate, now ?? (() => new Date()));
+    super(store.conflictChecks, now ?? (() => new Date()));
   }
 
   async listHistory(page: number, pageSize: number): Promise<{ checks: ConflictCheckRow[]; total: number }> {

--- a/src/lib/server/repositories/in-memory-contact-repository.ts
+++ b/src/lib/server/repositories/in-memory-contact-repository.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Contact } from "@/lib/shared/schemas/contact";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import type {
   ContactFull, ContactListOptions, ContactListResult, ContactListRow, ContactRepository,
 } from "./contact-repository";
@@ -16,7 +16,7 @@ export type ContactRepoSource = Pick<IDataStore, "contacts">;
 
 export class InMemoryContactRepository extends InMemoryRepository<Contact> implements ContactRepository {
   constructor(store: ContactRepoSource, now?: () => Date) {
-    super(store.contacts as unknown as Delegate, now ?? (() => new Date()));
+    super(store.contacts, now ?? (() => new Date()));
   }
 
   async listForOrg(organizationId: string, opts: ContactListOptions): Promise<ContactListResult> {

--- a/src/lib/server/repositories/in-memory-document-folder-repository.ts
+++ b/src/lib/server/repositories/in-memory-document-folder-repository.ts
@@ -4,7 +4,7 @@
  */
 
 import type { DocumentFolder } from "@/lib/shared/schemas/document";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import type {
   DocumentFolderRepository, DocumentFolderWithCounts,
 } from "./document-folder-repository";
@@ -16,7 +16,7 @@ export class InMemoryDocumentFolderRepository
   extends InMemoryRepository<DocumentFolder>
   implements DocumentFolderRepository {
   constructor(store: DocumentFolderRepoSource, now?: () => Date) {
-    super(store.documentFolders as unknown as Delegate, now ?? (() => new Date()));
+    super(store.documentFolders, now ?? (() => new Date()));
   }
 
   async listInParent(matterId: string, parentId: string | null): Promise<DocumentFolderWithCounts[]> {

--- a/src/lib/server/repositories/in-memory-document-repository.ts
+++ b/src/lib/server/repositories/in-memory-document-repository.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Document } from "@/lib/shared/schemas/document";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import type {
   DocumentAccessRow, DocumentListRow, DocumentRepository,
 } from "./document-repository";
@@ -16,7 +16,7 @@ export class InMemoryDocumentRepository
   extends InMemoryRepository<Document>
   implements DocumentRepository {
   constructor(store: DocumentRepoSource, now?: () => Date) {
-    super(store.documents as unknown as Delegate, now ?? (() => new Date()));
+    super(store.documents, now ?? (() => new Date()));
   }
 
   async listInFolder(

--- a/src/lib/server/repositories/in-memory-document-suggestion-repository.ts
+++ b/src/lib/server/repositories/in-memory-document-suggestion-repository.ts
@@ -4,7 +4,7 @@
  */
 
 import type { DocumentAnalysisSuggestion } from "@/lib/shared/schemas/document";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import type {
   DocumentSuggestionRepository, SuggestionListRow, SuggestionWithMatter,
 } from "./document-suggestion-repository";
@@ -16,7 +16,7 @@ export class InMemoryDocumentSuggestionRepository
   extends InMemoryRepository<DocumentAnalysisSuggestion>
   implements DocumentSuggestionRepository {
   constructor(store: DocumentSuggestionRepoSource, now?: () => Date) {
-    super(store.documentAnalysisSuggestions as unknown as Delegate, now ?? (() => new Date()));
+    super(store.documentAnalysisSuggestions, now ?? (() => new Date()));
   }
 
   async getByIdInOrg(id: string, organizationId: string): Promise<SuggestionWithMatter | null> {

--- a/src/lib/server/repositories/in-memory-document-template-repository.ts
+++ b/src/lib/server/repositories/in-memory-document-template-repository.ts
@@ -3,7 +3,7 @@
  */
 
 import type { DocumentTemplate } from "@/lib/shared/schemas/misc";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import type {
   DocumentTemplateListRow, DocumentTemplateRepository, DocumentTemplateRow,
 } from "./document-template-repository";
@@ -15,7 +15,7 @@ export class InMemoryDocumentTemplateRepository
   extends InMemoryRepository<DocumentTemplate>
   implements DocumentTemplateRepository {
   constructor(store: DocumentTemplateRepoSource, now?: () => Date) {
-    super(store.documentTemplates as unknown as Delegate, now ?? (() => new Date()));
+    super(store.documentTemplates, now ?? (() => new Date()));
   }
 
   async listForOrg(organizationId: string): Promise<DocumentTemplateListRow[]> {

--- a/src/lib/server/repositories/in-memory-expected-receivable-repository.ts
+++ b/src/lib/server/repositories/in-memory-expected-receivable-repository.ts
@@ -3,7 +3,7 @@
  */
 
 import type { ExpectedReceivable } from "@/lib/shared/schemas/billing";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import type { ExpectedReceivableListFilter, ExpectedReceivableRepository } from "./expected-receivable-repository";
 import { InMemoryRepository } from "./in-memory-repository";
 
@@ -13,7 +13,7 @@ export class InMemoryExpectedReceivableRepository
   extends InMemoryRepository<ExpectedReceivable>
   implements ExpectedReceivableRepository {
   constructor(store: ExpectedReceivableRepoSource, now?: () => Date) {
-    super(store.expectedReceivables as unknown as Delegate, now ?? (() => new Date()));
+    super(store.expectedReceivables, now ?? (() => new Date()));
   }
 
   async listForOrg(organizationId: string, filter?: ExpectedReceivableListFilter): Promise<ExpectedReceivable[]> {

--- a/src/lib/server/repositories/in-memory-expense-repository.ts
+++ b/src/lib/server/repositories/in-memory-expense-repository.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Expense } from "@/lib/shared/schemas/billing";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import type {
   ExpenseListOptions, ExpenseListResult, ExpenseListRow, ExpenseRepository, LawyerReportExpense,
 } from "./expense-repository";
@@ -15,7 +15,7 @@ export type ExpenseRepoSource = Pick<IDataStore, "expenses">;
 
 export class InMemoryExpenseRepository extends InMemoryRepository<Expense> implements ExpenseRepository {
   constructor(store: ExpenseRepoSource, now?: () => Date) {
-    super(store.expenses as unknown as Delegate, now ?? (() => new Date()));
+    super(store.expenses, now ?? (() => new Date()));
   }
 
   async listForOrg(organizationId: string, opts: ExpenseListOptions): Promise<ExpenseListResult> {

--- a/src/lib/server/repositories/in-memory-invoice-dispatch-repository.ts
+++ b/src/lib/server/repositories/in-memory-invoice-dispatch-repository.ts
@@ -3,7 +3,7 @@
  */
 
 import type { InvoiceDispatch } from "@/lib/shared/schemas/billing";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type { InvoiceDispatchQueuedRow, InvoiceDispatchRepository } from "./invoice-dispatch-repository";
 
@@ -13,7 +13,7 @@ export class InMemoryInvoiceDispatchRepository
   extends InMemoryRepository<InvoiceDispatch>
   implements InvoiceDispatchRepository {
   constructor(store: InvoiceDispatchRepoSource, now?: () => Date) {
-    super(store.invoiceDispatches as unknown as Delegate, now ?? (() => new Date()));
+    super(store.invoiceDispatches, now ?? (() => new Date()));
   }
 
   async listByInvoice(invoiceId: string): Promise<InvoiceDispatch[]> {

--- a/src/lib/server/repositories/in-memory-invoice-repository.ts
+++ b/src/lib/server/repositories/in-memory-invoice-repository.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Invoice } from "@/lib/shared/schemas/billing";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import {
   invoiceNumberPrefix, nextInvoiceNumberFrom,
@@ -18,12 +18,12 @@ export type InvoiceRepoSource = Pick<IDataStore, "invoices" | "payments" | "writ
 
 export class InMemoryInvoiceRepository extends InMemoryRepository<Invoice> implements InvoiceRepository {
   constructor(private readonly store: InvoiceRepoSource, now?: () => Date) {
-    super(store.invoices as unknown as Delegate, now ?? (() => new Date()));
+    super(store.invoices, now ?? (() => new Date()));
   }
 
   async getByIdInOrg(id: string, organizationId: string): Promise<Invoice | null> {
     // Samma relations-filter som routern använde mot DemoDataStore (org via ärende).
-    const row = (await (this.store.invoices as unknown as Delegate)
+    const row = (await this.store.invoices
       .findFirst({ where: { id, matter: { organizationId } } })) as Invoice | null;
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }
@@ -31,7 +31,7 @@ export class InMemoryInvoiceRepository extends InMemoryRepository<Invoice> imple
   async getByIdFull(id: string, organizationId: string): Promise<InvoiceFull | null> {
     // In-memory query-engine resolvar alla relationer (samma include som routern
     // använt) i ETT anrop — inga sekundär-queries behövs (jfr Drizzle-impl:en).
-    const row = (await (this.store.invoices as unknown as Delegate).findFirst({
+    const row = (await this.store.invoices.findFirst({
       where: { id, matter: { organizationId } },
       include: {
         matter: true,
@@ -51,7 +51,7 @@ export class InMemoryInvoiceRepository extends InMemoryRepository<Invoice> imple
   }
 
   async getByIdWithRelations(id: string, organizationId: string): Promise<InvoiceWithRelations | null> {
-    const row = (await (this.store.invoices as unknown as Delegate).findFirst({
+    const row = (await this.store.invoices.findFirst({
       where: { id, matter: { organizationId } },
       include: {
         matter: true,
@@ -69,9 +69,9 @@ export class InMemoryInvoiceRepository extends InMemoryRepository<Invoice> imple
   async getByIdWithLedger(id: string): Promise<InvoiceWithLedger | null> {
     const invoice = await this.getById(id);
     if (!invoice) return null;
-    const payments = (await (this.store.payments as unknown as Delegate)
+    const payments = (await this.store.payments
       .findMany({ where: { invoiceId: id } })) as InvoiceWithLedger["payments"];
-    const writeOffs = (await (this.store.writeOffs as unknown as Delegate)
+    const writeOffs = (await this.store.writeOffs
       .findMany({ where: { invoiceId: id } })) as InvoiceWithLedger["writeOffs"];
     return { ...invoice, payments, writeOffs };
   }
@@ -79,7 +79,7 @@ export class InMemoryInvoiceRepository extends InMemoryRepository<Invoice> imple
   async listForOrg(organizationId: string, filter?: InvoiceListFilter): Promise<InvoiceListRow[]> {
     // Samma where/include som routern använde mot DemoDataStore — query-engine:n
     // resolvar relationerna i ett anrop (jfr Drizzle-impl:ens sekundär-queries).
-    const rows = (await (this.store.invoices as unknown as Delegate).findMany({
+    const rows = (await this.store.invoices.findMany({
       where: {
         matter: { organizationId },
         ...(filter?.matterId ? { matterId: filter.matterId } : {}),
@@ -102,7 +102,7 @@ export class InMemoryInvoiceRepository extends InMemoryRepository<Invoice> imple
 
   async nextInvoiceNumber(organizationId: string): Promise<string> {
     const prefix = invoiceNumberPrefix(this.now().getFullYear());
-    const last = (await (this.store.invoices as unknown as Delegate).findFirst({
+    const last = (await this.store.invoices.findFirst({
       where: { matter: { organizationId }, invoiceNumber: { startsWith: prefix } },
       orderBy: { invoiceNumber: "desc" },
     })) as { invoiceNumber?: string | null } | null;
@@ -110,7 +110,7 @@ export class InMemoryInvoiceRepository extends InMemoryRepository<Invoice> imple
   }
 
   async sumCreditNotesFor(invoiceId: string, organizationId: string): Promise<number> {
-    const rows = (await (this.store.invoices as unknown as Delegate)
+    const rows = (await this.store.invoices
       .findMany({ where: { creditedInvoiceId: invoiceId, matter: { organizationId } } })) as ReadonlyArray<Invoice>;
     return rows
       .filter((r) => !(r as { deletedAt?: unknown }).deletedAt)
@@ -118,20 +118,20 @@ export class InMemoryInvoiceRepository extends InMemoryRepository<Invoice> imple
   }
 
   async getCreditNoteFor(invoiceId: string): Promise<Invoice | null> {
-    const row = (await (this.store.invoices as unknown as Delegate)
+    const row = (await this.store.invoices
       .findFirst({ where: { creditedInvoiceId: invoiceId } })) as Invoice | null;
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }
 
   async listDeductibleAccontos(matterId: string, ids: string[]): Promise<Invoice[]> {
     if (!ids.length) return [];
-    return (await (this.store.invoices as unknown as Delegate).findMany({
+    return (await this.store.invoices.findMany({
       where: { id: { in: ids }, matterId, invoiceType: "ACCONTO", deductedOnFinals: { none: {} } },
     })) as Invoice[];
   }
 
   async listByMatter(matterId: string): Promise<Invoice[]> {
-    const rows = (await (this.store.invoices as unknown as Delegate)
+    const rows = (await this.store.invoices
       .findMany({ where: { matterId }, orderBy: { invoiceDate: "desc" } })) as Invoice[];
     return rows.filter((r) => !(r as { deletedAt?: unknown }).deletedAt);
   }

--- a/src/lib/server/repositories/in-memory-matter-contact-repository.ts
+++ b/src/lib/server/repositories/in-memory-matter-contact-repository.ts
@@ -6,7 +6,7 @@
 
 import type { Contact } from "@/lib/shared/schemas/contact";
 import type { MatterContact } from "@/lib/shared/schemas/matter";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type {
   ConflictContactRow, MatterContactRepository, MatterContactWithContact,
@@ -27,7 +27,7 @@ export class InMemoryMatterContactRepository
   extends InMemoryRepository<MatterContact>
   implements MatterContactRepository {
   constructor(store: MatterContactRepoSource, now?: () => Date) {
-    super(store.matterContacts as unknown as Delegate, now ?? (() => new Date()));
+    super(store.matterContacts, now ?? (() => new Date()));
   }
 
   async findForConflict(organizationId: string, numberTerm?: string): Promise<ConflictContactRow[]> {

--- a/src/lib/server/repositories/in-memory-matter-event-suggestion-repository.ts
+++ b/src/lib/server/repositories/in-memory-matter-event-suggestion-repository.ts
@@ -4,7 +4,7 @@
  */
 
 import type { MatterEventSuggestion } from "@/lib/shared/schemas/document";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type {
   MatterEventSuggestionRepository, MatterEventSuggestionRow,
@@ -16,7 +16,7 @@ export class InMemoryMatterEventSuggestionRepository
   extends InMemoryRepository<MatterEventSuggestion>
   implements MatterEventSuggestionRepository {
   constructor(store: MatterEventSuggestionRepoSource, now?: () => Date) {
-    super(store.matterEventSuggestions as unknown as Delegate, now ?? (() => new Date()));
+    super(store.matterEventSuggestions, now ?? (() => new Date()));
   }
 
   async listForMatter(matterId: string, organizationId: string): Promise<MatterEventSuggestionRow[]> {

--- a/src/lib/server/repositories/in-memory-matter-repository.ts
+++ b/src/lib/server/repositories/in-memory-matter-repository.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Matter } from "@/lib/shared/schemas/matter";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type {
   MatterDetailRow, MatterListFilter, MatterListResult, MatterListRow, MatterRepository,
@@ -34,7 +34,7 @@ function listWhere(organizationId: string, f: MatterListFilter): Record<string, 
 
 export class InMemoryMatterRepository extends InMemoryRepository<Matter> implements MatterRepository {
   constructor(store: MatterRepoSource, now?: () => Date) {
-    super(store.matters as unknown as Delegate, now ?? (() => new Date()));
+    super(store.matters, now ?? (() => new Date()));
   }
 
   async getByIdInOrg(id: string, organizationId: string): Promise<Matter | null> {

--- a/src/lib/server/repositories/in-memory-office-repository.ts
+++ b/src/lib/server/repositories/in-memory-office-repository.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Office } from "@/lib/shared/schemas/organization";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type { OfficeRepository } from "./office-repository";
 
@@ -11,7 +11,7 @@ export type OfficeRepoSource = Pick<IDataStore, "offices">;
 
 export class InMemoryOfficeRepository extends InMemoryRepository<Office> implements OfficeRepository {
   constructor(store: OfficeRepoSource, now?: () => Date) {
-    super(store.offices as unknown as Delegate, now ?? (() => new Date()));
+    super(store.offices, now ?? (() => new Date()));
   }
 
   async listByOrg(organizationId: string): Promise<Office[]> {

--- a/src/lib/server/repositories/in-memory-org-preference-repository.ts
+++ b/src/lib/server/repositories/in-memory-org-preference-repository.ts
@@ -1,7 +1,7 @@
 /** In-memory `OrgPreferenceRepository` (ADR 0020). */
 
 import type { OrgPreference } from "@/lib/shared/schemas/preference";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type { OrgPreferenceRepository, OrgPreferenceRow } from "./org-preference-repository";
 
@@ -9,7 +9,7 @@ export type OrgPreferenceRepoSource = Pick<IDataStore, "orgPreferences">;
 
 export class InMemoryOrgPreferenceRepository extends InMemoryRepository<OrgPreferenceRow> implements OrgPreferenceRepository {
   constructor(store: OrgPreferenceRepoSource, now?: () => Date) {
-    super(store.orgPreferences as unknown as Delegate, now ?? (() => new Date()));
+    super(store.orgPreferences, now ?? (() => new Date()));
   }
 
   async getByOrgKey(organizationId: string, key: string): Promise<OrgPreference | null> {

--- a/src/lib/server/repositories/in-memory-organization-repository.ts
+++ b/src/lib/server/repositories/in-memory-organization-repository.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Organization } from "@/lib/shared/schemas/organization";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type { OrganizationRepository } from "./organization-repository";
 
@@ -11,6 +11,6 @@ export type OrganizationRepoSource = Pick<IDataStore, "organizations">;
 
 export class InMemoryOrganizationRepository extends InMemoryRepository<Organization> implements OrganizationRepository {
   constructor(store: OrganizationRepoSource, now?: () => Date) {
-    super(store.organizations as unknown as Delegate, now ?? (() => new Date()));
+    super(store.organizations, now ?? (() => new Date()));
   }
 }

--- a/src/lib/server/repositories/in-memory-payment-plan-reminder-repository.ts
+++ b/src/lib/server/repositories/in-memory-payment-plan-reminder-repository.ts
@@ -3,7 +3,7 @@
  */
 
 import type { PaymentPlanReminder } from "@/lib/shared/schemas/billing";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type { PaymentPlanReminderRepository } from "./payment-plan-reminder-repository";
 
@@ -13,6 +13,6 @@ export class InMemoryPaymentPlanReminderRepository
   extends InMemoryRepository<PaymentPlanReminder>
   implements PaymentPlanReminderRepository {
   constructor(store: PaymentPlanReminderRepoSource, now?: () => Date) {
-    super(store.paymentPlanReminders as unknown as Delegate, now ?? (() => new Date()));
+    super(store.paymentPlanReminders, now ?? (() => new Date()));
   }
 }

--- a/src/lib/server/repositories/in-memory-payment-plan-repository.ts
+++ b/src/lib/server/repositories/in-memory-payment-plan-repository.ts
@@ -6,7 +6,7 @@
  */
 
 import type { PaymentPlan } from "@/lib/shared/schemas/billing";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type {
   JoinedPaymentPlan, JoinedPaymentPlanWithReminders, PaymentPlanRepository,
@@ -38,7 +38,7 @@ const SCAN_INVOICE_INCLUDE = {
 
 export class InMemoryPaymentPlanRepository extends InMemoryRepository<PaymentPlan> implements PaymentPlanRepository {
   constructor(store: PaymentPlanRepoSource, now?: () => Date) {
-    super(store.paymentPlans as unknown as Delegate, now ?? (() => new Date()));
+    super(store.paymentPlans, now ?? (() => new Date()));
   }
 
   async getByIdInOrg(planId: string, organizationId: string): Promise<PaymentPlan | null> {

--- a/src/lib/server/repositories/in-memory-payment-repository.ts
+++ b/src/lib/server/repositories/in-memory-payment-repository.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Payment } from "@/lib/shared/schemas/billing";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type { PaymentRepository } from "./payment-repository";
 
@@ -13,7 +13,7 @@ export type PaymentRepoSource = Pick<IDataStore, "payments">;
 
 export class InMemoryPaymentRepository extends InMemoryRepository<Payment> implements PaymentRepository {
   constructor(store: PaymentRepoSource, now?: () => Date) {
-    super(store.payments as unknown as Delegate, now ?? (() => new Date()));
+    super(store.payments, now ?? (() => new Date()));
   }
 
   async sumByInvoice(invoiceId: string): Promise<number> {

--- a/src/lib/server/repositories/in-memory-service-note-repository.ts
+++ b/src/lib/server/repositories/in-memory-service-note-repository.ts
@@ -4,7 +4,7 @@
  */
 
 import type { ServiceNote } from "@/lib/shared/schemas/service-note";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type { ServiceNoteRepository, ServiceNoteRow } from "./service-note-repository";
 
@@ -13,7 +13,7 @@ export type ServiceNoteRepoSource = Pick<IDataStore, "serviceNotes">;
 
 export class InMemoryServiceNoteRepository extends InMemoryRepository<ServiceNote> implements ServiceNoteRepository {
   constructor(store: ServiceNoteRepoSource, now?: () => Date) {
-    super(store.serviceNotes as unknown as Delegate, now ?? (() => new Date()));
+    super(store.serviceNotes, now ?? (() => new Date()));
   }
 
   async listByMatter(matterId: string, organizationId: string): Promise<ServiceNoteRow[]> {

--- a/src/lib/server/repositories/in-memory-task-repository.ts
+++ b/src/lib/server/repositories/in-memory-task-repository.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Task } from "@/lib/shared/schemas/calendar";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type { TaskListFilter, TaskListRow, TaskRepository } from "./task-repository";
 
@@ -13,7 +13,7 @@ export type TaskRepoSource = Pick<IDataStore, "tasks">;
 
 export class InMemoryTaskRepository extends InMemoryRepository<Task> implements TaskRepository {
   constructor(store: TaskRepoSource, now?: () => Date) {
-    super(store.tasks as unknown as Delegate, now ?? (() => new Date()));
+    super(store.tasks, now ?? (() => new Date()));
   }
 
   async listForUser(userId: string, organizationId: string, filter: TaskListFilter): Promise<TaskListRow[]> {

--- a/src/lib/server/repositories/in-memory-time-entry-repository.ts
+++ b/src/lib/server/repositories/in-memory-time-entry-repository.ts
@@ -5,7 +5,7 @@
  */
 
 import type { TimeEntry } from "@/lib/shared/schemas/billing";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type {
   LawyerReportTimeEntry, TimeEntryListFilter, TimeEntryListResult, TimeEntryListRow,
@@ -22,7 +22,7 @@ function dateRange(from?: Date, to?: Date): Record<string, unknown> {
 
 export class InMemoryTimeEntryRepository extends InMemoryRepository<TimeEntry> implements TimeEntryRepository {
   constructor(store: TimeEntryRepoSource, now?: () => Date) {
-    super(store.timeEntries as unknown as Delegate, now ?? (() => new Date()));
+    super(store.timeEntries, now ?? (() => new Date()));
   }
 
   async listForOrg(organizationId: string, opts: TimeEntryListFilter): Promise<TimeEntryListResult> {

--- a/src/lib/server/repositories/in-memory-user-preference-repository.ts
+++ b/src/lib/server/repositories/in-memory-user-preference-repository.ts
@@ -1,7 +1,7 @@
 /** In-memory `UserPreferenceRepository` (ADR 0020). */
 
 import type { UserPreference } from "@/lib/shared/schemas/preference";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type { UserPreferenceRepository, UserPreferenceRow } from "./user-preference-repository";
 
@@ -9,7 +9,7 @@ export type UserPreferenceRepoSource = Pick<IDataStore, "userPreferences">;
 
 export class InMemoryUserPreferenceRepository extends InMemoryRepository<UserPreferenceRow> implements UserPreferenceRepository {
   constructor(store: UserPreferenceRepoSource, now?: () => Date) {
-    super(store.userPreferences as unknown as Delegate, now ?? (() => new Date()));
+    super(store.userPreferences, now ?? (() => new Date()));
   }
 
   async getByUserKey(userId: string, organizationId: string, key: string): Promise<UserPreference | null> {

--- a/src/lib/server/repositories/in-memory-user-repository.ts
+++ b/src/lib/server/repositories/in-memory-user-repository.ts
@@ -4,7 +4,7 @@
  */
 
 import type { User } from "@/lib/shared/schemas/user";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type { UserRepository } from "./user-repository";
 
@@ -13,7 +13,7 @@ export type UserRepoSource = Pick<IDataStore, "users">;
 
 export class InMemoryUserRepository extends InMemoryRepository<User> implements UserRepository {
   constructor(store: UserRepoSource, now?: () => Date) {
-    super(store.users as unknown as Delegate, now ?? (() => new Date()));
+    super(store.users, now ?? (() => new Date()));
   }
 
   async getByIdInOrg(id: string, organizationId: string): Promise<User | null> {

--- a/src/lib/server/repositories/in-memory-write-off-repository.ts
+++ b/src/lib/server/repositories/in-memory-write-off-repository.ts
@@ -4,7 +4,7 @@
  */
 
 import type { WriteOff } from "@/lib/shared/schemas/billing";
-import type { Delegate, IDataStore } from "../data-store/IDataStore";
+import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type { WriteOffRepository } from "./write-off-repository";
 
@@ -13,7 +13,7 @@ export type WriteOffRepoSource = Pick<IDataStore, "writeOffs">;
 
 export class InMemoryWriteOffRepository extends InMemoryRepository<WriteOff> implements WriteOffRepository {
   constructor(store: WriteOffRepoSource, now?: () => Date) {
-    super(store.writeOffs as unknown as Delegate, now ?? (() => new Date()));
+    super(store.writeOffs, now ?? (() => new Date()));
   }
 
   async sumByInvoice(invoiceId: string): Promise<number> {


### PR DESCRIPTION
Typnings-quickwin **3/3** från arkitekturgenomgången. Efter #557 (ReadOnlyDelegate implements Delegate<T>) är store-delegaterna (Delegate<Row>) tilldelningsbara till bas-repots `Delegate`-param + direkt anropbara utan cast.

Tar bort **39 `as unknown as Delegate`** i 28 `in-memory-*-repository.ts` + nu oanvända `Delegate`-importer. **Type-only → noll runtime-påverkan** (alla tester gröna).

`as unknown as` i src: **185 → 146**.

Verifierat lokalt: typecheck, lint (--max-warnings 0), knip, deps:check, test:cov (90.71 % / 85.63 %) — alla gröna.

Refs #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)