### PR TITLE
refactor(types): centralisera drizzle DB-gräns-cast i asRow/asRows (#560)

### DIFF
--- a/src/lib/server/repositories/drizzle-billing-run-repository.ts
+++ b/src/lib/server/repositories/drizzle-billing-run-repository.ts
@@ -72,7 +72,7 @@ export class DrizzleBillingRunRepository
         eq(billingRuns.matterId, matterId), eq(billingRuns.type, "ACCONTO"),
         eq(billingRuns.status, "SENT"), isNull(billingRuns.deletedAt),
       ));
-    return rows as unknown as BillingRun[];
+    return this.asRows(rows);
   }
 
   async listAccontoByIds(matterId: string, ids: string[]): Promise<BillingRun[]> {
@@ -83,6 +83,6 @@ export class DrizzleBillingRunRepository
         inArray(billingRuns.id, ids), eq(billingRuns.matterId, matterId),
         eq(billingRuns.type, "ACCONTO"), isNull(billingRuns.deletedAt),
       ));
-    return rows as unknown as BillingRun[];
+    return this.asRows(rows);
   }
 }

--- a/src/lib/server/repositories/drizzle-calendar-event-repository.ts
+++ b/src/lib/server/repositories/drizzle-calendar-event-repository.ts
@@ -55,7 +55,7 @@ export class DrizzleCalendarEventRepository extends DrizzleRepository<CalendarEv
       .select().from(calendarEvents)
       .where(and(eq(calendarEvents.matterId, matterId), eq(calendarEvents.organizationId, organizationId), isNull(calendarEvents.deletedAt)))
       .orderBy(asc(calendarEvents.startAt));
-    return rows as unknown as CalendarEvent[];
+    return this.asRows(rows);
   }
 
   async getOwned(id: string, userId: string, organizationId: string): Promise<CalendarEvent | null> {
@@ -63,7 +63,7 @@ export class DrizzleCalendarEventRepository extends DrizzleRepository<CalendarEv
       .select().from(calendarEvents)
       .where(and(eq(calendarEvents.id, id), eq(calendarEvents.userId, userId), eq(calendarEvents.organizationId, organizationId), isNull(calendarEvents.deletedAt)))
       .limit(1);
-    return (rows[0] as unknown as CalendarEvent | undefined) ?? null;
+    return this.asRow(rows[0]);
   }
 
   async getOwnedWithMatter(id: string, userId: string, organizationId: string): Promise<CalendarEventRow | null> {

--- a/src/lib/server/repositories/drizzle-contact-repository.ts
+++ b/src/lib/server/repositories/drizzle-contact-repository.ts
@@ -92,7 +92,7 @@ export class DrizzleContactRepository extends DrizzleRepository<Contact> impleme
       .orderBy(desc(matterContacts.createdAt));
     return {
       ...(c as object),
-      children: children as unknown as Contact[],
+      children: this.asRows(children),
       parent: parentRows[0] ? { id: parentRows[0].id, name: parentRows[0].name as string } : null,
       matterLinks: linkRows.map((l) => ({
         ...(l.mc as object),
@@ -105,13 +105,13 @@ export class DrizzleContactRepository extends DrizzleRepository<Contact> impleme
     const rows = await this.db.select().from(contacts)
       .where(and(eq(contacts.organizationId, organizationId), eq(contacts.personalNumber, personalNumber), isNull(contacts.deletedAt)))
       .limit(1);
-    return (rows[0] as unknown as Contact | undefined) ?? null;
+    return this.asRow(rows[0]);
   }
 
   async findByOrgNumber(organizationId: string, orgNumber: string): Promise<Contact | null> {
     const rows = await this.db.select().from(contacts)
       .where(and(eq(contacts.organizationId, organizationId), eq(contacts.orgNumber, orgNumber), isNull(contacts.deletedAt)))
       .limit(1);
-    return (rows[0] as unknown as Contact | undefined) ?? null;
+    return this.asRow(rows[0]);
   }
 }

--- a/src/lib/server/repositories/drizzle-document-folder-repository.ts
+++ b/src/lib/server/repositories/drizzle-document-folder-repository.ts
@@ -66,7 +66,7 @@ export class DrizzleDocumentFolderRepository
       .select().from(documentFolders)
       .where(and(eq(documentFolders.matterId, matterId), isNull(documentFolders.deletedAt)))
       .orderBy(asc(documentFolders.name));
-    return rows as unknown as DocumentFolder[];
+    return this.asRows(rows);
   }
 
   async reassignParent(fromParentId: string, toParentId: string | null): Promise<void> {

--- a/src/lib/server/repositories/drizzle-expected-receivable-repository.ts
+++ b/src/lib/server/repositories/drizzle-expected-receivable-repository.ts
@@ -26,7 +26,7 @@ export class DrizzleExpectedReceivableRepository
         filter?.status ? eq(expectedReceivables.status, filter.status) : undefined,
       ))
       .orderBy(desc(expectedReceivables.createdAt));
-    return rows as unknown as ExpectedReceivable[];
+    return this.asRows(rows);
   }
 
   async getByIdInOrg(id: string, organizationId: string): Promise<ExpectedReceivable | null> {
@@ -34,6 +34,6 @@ export class DrizzleExpectedReceivableRepository
       .select().from(expectedReceivables)
       .where(and(eq(expectedReceivables.id, id), eq(expectedReceivables.organizationId, organizationId), isNull(expectedReceivables.deletedAt)))
       .limit(1);
-    return (rows[0] as unknown as ExpectedReceivable | undefined) ?? null;
+    return this.asRow(rows[0]);
   }
 }

--- a/src/lib/server/repositories/drizzle-expense-repository.ts
+++ b/src/lib/server/repositories/drizzle-expense-repository.ts
@@ -57,7 +57,7 @@ export class DrizzleExpenseRepository extends DrizzleRepository<Expense> impleme
       .innerJoin(matters, eq(expenses.matterId, matters.id))
       .where(and(eq(expenses.id, id), eq(matters.organizationId, organizationId), isNull(expenses.deletedAt)))
       .limit(1);
-    return (rows[0]?.exp as unknown as Expense | undefined) ?? null;
+    return this.asRow(rows[0]?.exp);
   }
 
   async listUnbilled(matterId: string, ids: string[]): Promise<Expense[]> {
@@ -65,7 +65,7 @@ export class DrizzleExpenseRepository extends DrizzleRepository<Expense> impleme
     const rows = await this.db
       .select().from(expenses)
       .where(and(inArray(expenses.id, ids), eq(expenses.matterId, matterId), isNull(expenses.invoiceId)));
-    return rows as unknown as Expense[];
+    return this.asRows(rows);
   }
 
   async flagBilled(ids: string[], invoiceId: string): Promise<void> {
@@ -78,7 +78,7 @@ export class DrizzleExpenseRepository extends DrizzleRepository<Expense> impleme
       .select().from(expenses)
       .where(and(eq(expenses.matterId, matterId), isNull(expenses.frozenByBillingRunId), isNull(expenses.deletedAt)))
       .orderBy(asc(expenses.date));
-    return rows as unknown as Expense[];
+    return this.asRows(rows);
   }
 
   async freezeForMatter(matterId: string, billingRunId: string, now: Date): Promise<void> {

--- a/src/lib/server/repositories/drizzle-invoice-dispatch-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-dispatch-repository.ts
@@ -22,7 +22,7 @@ export class DrizzleInvoiceDispatchRepository
       .select().from(invoiceDispatches)
       .where(and(eq(invoiceDispatches.invoiceId, invoiceId), isNull(invoiceDispatches.deletedAt)))
       .orderBy(desc(invoiceDispatches.queuedAt));
-    return rows as unknown as InvoiceDispatch[];
+    return this.asRows(rows);
   }
 
   async listQueuedForOrg(organizationId: string): Promise<InvoiceDispatchQueuedRow[]> {

--- a/src/lib/server/repositories/drizzle-invoice-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-repository.ts
@@ -34,14 +34,14 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
         eq(matters.organizationId, organizationId),
         isNull(invoices.deletedAt),
       )).limit(1);
-    return (rows[0]?.inv as unknown as Invoice | undefined) ?? null;
+    return this.asRow(rows[0]?.inv);
   }
 
   /** Bar faktura-rad utan org/delete-filter (för self-ref-uppslag). */
   private async rawInvoice(id: string | null | undefined): Promise<Invoice | null> {
     if (!id) return null;
     const rows = await this.db.select().from(invoices).where(eq(invoices.id, id)).limit(1);
-    return (rows[0] as unknown as Invoice | undefined) ?? null;
+    return this.asRow(rows[0]);
   }
 
   async getByIdFull(id: string, organizationId: string): Promise<InvoiceFull | null> {
@@ -63,7 +63,7 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
       accontoDeductions: accontoDeductionsFull,
       deductedOnFinals,
       creditedInvoice,
-      creditNote: (creditNoteRows[0] as unknown as Invoice | undefined) ?? null,
+      creditNote: this.asRow(creditNoteRows[0]),
     } as unknown as InvoiceFull;
   }
 
@@ -151,7 +151,7 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
     const rows = await this.db
       .select().from(invoices)
       .where(and(eq(invoices.creditedInvoiceId, invoiceId), isNull(invoices.deletedAt))).limit(1);
-    return (rows[0] as unknown as Invoice | undefined) ?? null;
+    return this.asRow(rows[0]);
   }
 
   async listDeductibleAccontos(matterId: string, ids: string[]): Promise<Invoice[]> {
@@ -184,6 +184,6 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
       .select().from(invoices)
       .where(and(eq(invoices.matterId, matterId), isNull(invoices.deletedAt)))
       .orderBy(desc(invoices.invoiceDate));
-    return rows as unknown as Invoice[];
+    return this.asRows(rows);
   }
 }

--- a/src/lib/server/repositories/drizzle-matter-contact-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-contact-repository.ts
@@ -59,7 +59,7 @@ export class DrizzleMatterContactRepository
       .innerJoin(matters, eq(matterContacts.matterId, matters.id))
       .where(and(eq(matterContacts.id, id), eq(matters.organizationId, organizationId), isNull(matterContacts.deletedAt)))
       .limit(1);
-    return (rows[0]?.mc as unknown as MatterContact | undefined) ?? null;
+    return this.asRow(rows[0]?.mc);
   }
 
   async linkContact(data: Partial<MatterContact>): Promise<MatterContactWithContact> {
@@ -75,7 +75,7 @@ export class DrizzleMatterContactRepository
         eq(matterContacts.matterId, matterId), eq(matterContacts.contactId, contactId),
         eq(matterContacts.role, role), isNull(matterContacts.deletedAt),
       )).limit(1);
-    return (rows[0] as unknown as MatterContact | undefined) ?? null;
+    return this.asRow(rows[0]);
   }
 
   async listContactsForMatter(matterId: string): Promise<Contact[]> {

--- a/src/lib/server/repositories/drizzle-matter-event-suggestion-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-event-suggestion-repository.ts
@@ -52,6 +52,6 @@ export class DrizzleMatterEventSuggestionRepository
         isNull(matterEventSuggestions.deletedAt),
       ))
       .limit(1);
-    return (rows[0]?.ev as unknown as MatterEventSuggestion | undefined) ?? null;
+    return this.asRow(rows[0]?.ev);
   }
 }

--- a/src/lib/server/repositories/drizzle-matter-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-repository.ts
@@ -24,14 +24,14 @@ export class DrizzleMatterRepository extends DrizzleRepository<Matter> implement
       .select().from(matters)
       .where(and(eq(matters.id, id), eq(matters.organizationId, organizationId), isNull(matters.deletedAt)))
       .limit(1);
-    return (rows[0] as unknown as Matter | undefined) ?? null;
+    return this.asRow(rows[0]);
   }
 
   async listByOrg(organizationId: string): Promise<Matter[]> {
     const rows = await this.db
       .select().from(matters)
       .where(and(eq(matters.organizationId, organizationId), isNull(matters.deletedAt)));
-    return rows as unknown as Matter[];
+    return this.asRows(rows);
   }
 
   private listWhere(organizationId: string, f: MatterListFilter) {
@@ -136,7 +136,7 @@ export class DrizzleMatterRepository extends DrizzleRepository<Matter> implement
         eq(matters.responsibleLawyerId, responsibleLawyerId),
         isNull(matters.deletedAt),
       ));
-    return rows as unknown as Matter[];
+    return this.asRows(rows);
   }
 
   async listByNumberPrefix(organizationId: string, prefix: string): Promise<Matter[]> {
@@ -146,6 +146,6 @@ export class DrizzleMatterRepository extends DrizzleRepository<Matter> implement
         ilike(matters.matterNumber, `${prefix}%`),
         isNull(matters.deletedAt),
       ));
-    return rows as unknown as Matter[];
+    return this.asRows(rows);
   }
 }

--- a/src/lib/server/repositories/drizzle-office-repository.ts
+++ b/src/lib/server/repositories/drizzle-office-repository.ts
@@ -19,7 +19,7 @@ export class DrizzleOfficeRepository extends DrizzleRepository<Office> implement
       .select().from(offices)
       .where(and(eq(offices.organizationId, organizationId), isNull(offices.deletedAt)))
       .orderBy(desc(offices.isMain), asc(offices.name));
-    return rows as unknown as Office[];
+    return this.asRows(rows);
   }
 
   async getByIdInOrg(id: string, organizationId: string): Promise<Office | null> {
@@ -27,7 +27,7 @@ export class DrizzleOfficeRepository extends DrizzleRepository<Office> implement
       .select().from(offices)
       .where(and(eq(offices.id, id), eq(offices.organizationId, organizationId), isNull(offices.deletedAt)))
       .limit(1);
-    return (rows[0] as unknown as Office | undefined) ?? null;
+    return this.asRow(rows[0]);
   }
 
   async demoteMains(organizationId: string): Promise<void> {

--- a/src/lib/server/repositories/drizzle-payment-plan-repository.ts
+++ b/src/lib/server/repositories/drizzle-payment-plan-repository.ts
@@ -31,14 +31,14 @@ export class DrizzlePaymentPlanRepository extends DrizzleRepository<PaymentPlan>
         eq(matters.organizationId, organizationId),
         isNull(paymentPlans.deletedAt),
       )).limit(1);
-    return (rows[0]?.plan as unknown as PaymentPlan | undefined) ?? null;
+    return this.asRow(rows[0]?.plan);
   }
 
   async getByInvoiceId(invoiceId: string): Promise<PaymentPlan | null> {
     const rows = await this.db
       .select().from(paymentPlans)
       .where(and(eq(paymentPlans.invoiceId, invoiceId), isNull(paymentPlans.deletedAt))).limit(1);
-    return (rows[0] as unknown as PaymentPlan | undefined) ?? null;
+    return this.asRow(rows[0]);
   }
 
   /** Plan-id:n i org:en (via faktura→ärende), valfritt status-filtrerade. */

--- a/src/lib/server/repositories/drizzle-payment-repository.ts
+++ b/src/lib/server/repositories/drizzle-payment-repository.ts
@@ -27,6 +27,6 @@ export class DrizzlePaymentRepository extends DrizzleRepository<Payment> impleme
     const rows = await this.db
       .select().from(payments)
       .where(and(inArray(payments.invoiceId, invoiceIds), isNull(payments.deletedAt)));
-    return rows as unknown as Payment[];
+    return this.asRows(rows);
   }
 }

--- a/src/lib/server/repositories/drizzle-repository.ts
+++ b/src/lib/server/repositories/drizzle-repository.ts
@@ -50,11 +50,28 @@ export class DrizzleRepository<Row extends RowBase> implements Repository<Row> {
     this.changeLog = recorder;
   }
 
+  /**
+   * DB→domän-gräns (#typing): drizzle-resultatet bär inte branded id:n
+   * (kolumnen är `string`, domäntypen `MatterId` etc.), så raden måste
+   * assertas till `Row` vid ORM-kanten. Centralisera den ENDA assertionen i
+   * `asRow`/`asRows` i st.f. spridda `as unknown as Row` — en audit-punkt + krok
+   * för framtida zod-parse. (Noll-cast skulle kräva `.$type`-branding av
+   * drizzle-kolumnerna, vilket kaskaderar till alla query-param-typer → eget
+   * "branda persistens-gränsen"-projekt.)
+   */
+  protected asRow(raw: unknown): Row | null {
+    return (raw ?? null) as Row | null;
+  }
+
+  protected asRows(raw: readonly unknown[]): Row[] {
+    return raw as Row[];
+  }
+
   async getById(id: string): Promise<Row | null> {
     const rows = await this.db
       .select().from(this.table)
       .where(and(eq(this.table.id, id), isNull(this.table.deletedAt))).limit(1);
-    return (rows[0] as unknown as Row | undefined) ?? null;
+    return this.asRow(rows[0]);
   }
 
   async getByIdOrThrow(id: string): Promise<Row> {
@@ -67,7 +84,7 @@ export class DrizzleRepository<Row extends RowBase> implements Repository<Row> {
     const [row] = await this.db.insert(this.table)
       .values({ ...data, version: 1 } as never).returning();
     await this.logChange(row, "create");
-    return row as unknown as Row;
+    return this.asRow(row) as Row;
   }
 
   async update(id: string, patch: Partial<Row>): Promise<Row> {
@@ -76,7 +93,7 @@ export class DrizzleRepository<Row extends RowBase> implements Repository<Row> {
       .set({ ...patch, version: nextVersion(current), updatedAt: this.now() } as never)
       .where(eq(this.table.id, id)).returning();
     await this.logChange(row, "update");
-    return row as unknown as Row;
+    return this.asRow(row) as Row;
   }
 
   async softDelete(id: string): Promise<Row> {
@@ -85,7 +102,7 @@ export class DrizzleRepository<Row extends RowBase> implements Repository<Row> {
       .set({ deletedAt: this.now(), version: nextVersion(current) } as never)
       .where(eq(this.table.id, id)).returning();
     await this.logChange(row, "delete");
-    return row as unknown as Row;
+    return this.asRow(row) as Row;
   }
 
   /** Hård delete — se `Repository.hardDelete` (medvetet ADR 0017-undantag). */

--- a/src/lib/server/repositories/drizzle-service-note-repository.ts
+++ b/src/lib/server/repositories/drizzle-service-note-repository.ts
@@ -38,6 +38,6 @@ export class DrizzleServiceNoteRepository extends DrizzleRepository<ServiceNote>
       .innerJoin(matters, eq(serviceNotes.matterId, matters.id))
       .where(and(eq(serviceNotes.id, id), eq(matters.organizationId, organizationId), isNull(serviceNotes.deletedAt)))
       .limit(1);
-    return (rows[0]?.note as unknown as ServiceNote | undefined) ?? null;
+    return this.asRow(rows[0]?.note);
   }
 }

--- a/src/lib/server/repositories/drizzle-task-repository.ts
+++ b/src/lib/server/repositories/drizzle-task-repository.ts
@@ -43,6 +43,6 @@ export class DrizzleTaskRepository extends DrizzleRepository<Task> implements Ta
       .where(and(
         eq(tasks.id, id), eq(tasks.userId, userId), eq(tasks.organizationId, organizationId), isNull(tasks.deletedAt),
       )).limit(1);
-    return (rows[0] as unknown as Task | undefined) ?? null;
+    return this.asRow(rows[0]);
   }
 }

--- a/src/lib/server/repositories/drizzle-time-entry-repository.ts
+++ b/src/lib/server/repositories/drizzle-time-entry-repository.ts
@@ -61,7 +61,7 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
       .innerJoin(matters, eq(timeEntries.matterId, matters.id))
       .where(and(eq(timeEntries.id, id), eq(matters.organizationId, organizationId), isNull(timeEntries.deletedAt)))
       .limit(1);
-    return (rows[0]?.te as unknown as TimeEntry | undefined) ?? null;
+    return this.asRow(rows[0]?.te);
   }
 
   async listForReport(organizationId: string, filter: TimeEntryReportFilter): Promise<TimeEntryReportRow[]> {
@@ -116,7 +116,7 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
       .select().from(timeEntries)
       .where(and(eq(timeEntries.matterId, matterId), isNull(timeEntries.frozenByBillingRunId), isNull(timeEntries.deletedAt)))
       .orderBy(asc(timeEntries.date));
-    return rows as unknown as TimeEntry[];
+    return this.asRows(rows);
   }
 
   async listForLawyerInPeriod(

--- a/src/lib/server/repositories/drizzle-user-repository.ts
+++ b/src/lib/server/repositories/drizzle-user-repository.ts
@@ -20,7 +20,7 @@ export class DrizzleUserRepository extends DrizzleRepository<User> implements Us
       .select().from(users)
       .where(and(eq(users.id, id), eq(users.organizationId, organizationId), isNull(users.deletedAt)))
       .limit(1);
-    return (rows[0] as unknown as User | undefined) ?? null;
+    return this.asRow(rows[0]);
   }
 
   async listByOrg(organizationId: string): Promise<User[]> {
@@ -28,6 +28,6 @@ export class DrizzleUserRepository extends DrizzleRepository<User> implements Us
       .select().from(users)
       .where(and(eq(users.organizationId, organizationId), isNull(users.deletedAt)))
       .orderBy(asc(users.name));
-    return rows as unknown as User[];
+    return this.asRows(rows);
   }
 }

--- a/src/lib/server/repositories/drizzle-write-off-repository.ts
+++ b/src/lib/server/repositories/drizzle-write-off-repository.ts
@@ -27,6 +27,6 @@ export class DrizzleWriteOffRepository extends DrizzleRepository<WriteOff> imple
     const rows = await this.db
       .select().from(writeOffs)
       .where(and(inArray(writeOffs.invoiceId, invoiceIds), isNull(writeOffs.deletedAt)));
-    return rows as unknown as WriteOff[];
+    return this.asRows(rows);
   }
 }


### PR DESCRIPTION
Typnings-quickwin **2/3** (sista i kedjan). Drizzle-resultat bär inte branded id:n (kolumn `string` vs domän `MatterId`), så raden assertas till `Row` vid ORM-kanten.

Ersätter **~41** spridda `as unknown as Row`/`Row[]` (bas-repot + 19 subklasser) med två centrala helpers **`asRow`/`asRows`** — en audit-punkt + krok för framtida zod-parse vid gränsen. **Type-only → 0 testfel.**

`as unknown as` i src: **146 → 105**.

### Ärlig avgränsning
Detta **centraliserar** den legitima ORM→domän-gräns-assertionen — det **eliminerar** den inte (casten är fundamental givet drizzle-inferens vs branded id:n). En äkta noll-cast kräver `.$type<XId>()`-branding av drizzle-kolumnerna, vilket (verifierat via probe) **kaskaderar** till alla query-param-typer + metod-signaturer över 27 entiteter → hör ihop med IDataStore-WhereInput-omtypningen som ETT dedikerat *"branda persistens-gränsen"*-projekt (egen ADR), inte ett quick-win.

### Kedjan komplett (213 → 105 casts)
- #557 (1/3): LocalStore-delegater — 28 borttagna (genuint, casts var onödiga)
- #559 (3/3): in-memory-repo-delegering — 39 borttagna (genuint)
- denna (2/3): drizzle-gräns centraliserad — ~41

Verifierat lokalt: typecheck, lint (--max-warnings 0), knip, deps:check, test:cov (90.71 % / 85.64 %) — alla gröna.

Refs #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)