### PR TITLE
refactor(types): typa IDataStore-query-input — noll explicit any (ADR 0026, #562 Fas 1)

### DIFF
--- a/docs/adr/0026-branda-persistens-gransen.md
+++ b/docs/adr/0026-branda-persistens-gransen.md
@@ -1,0 +1,68 @@
+# ADR 0026 — Branda persistens-gränsen (typad delegate + branded kolumner)
+
+Status: Accepterad — Fas 1 implementerad (2026-06-19), Fas 2 spårad (#562)
+
+## Kontext
+
+Arkitekturgenomgången (jun 2026) visade att kodbasen är starkt typad (`strict`
++ `exactOptionalPropertyTypes` + `noUncheckedIndexedAccess`, 0 `@ts-ignore`),
+men hade två kvarvarande typsvagheter vid persistens-gränsen:
+
+1. **Den sista explicit `any`:n** — `IDataStore.Delegate` hade `args: any` på
+   query-metoderna (findUnique/findFirst/findMany/count/delete/aggregate) +
+   `JoinedRelations`-fält som `any` + `$queryRaw: any`. Det var det ENDA
+   `no-explicit-any`-undantaget i src (en dokumenterad eslint-disable).
+2. **~105 `as unknown as`** kvar efter quick-wins #557/#559/#561 (213→105),
+   varav ~85 vid drizzle-ORM-kanten: `db.select()` ger `id: string`, domänen
+   vill `MatterId` → raden assertas (centraliserat i `asRow`/`asRows`, #560).
+
+## Beslut
+
+**Branda persistens-gränsen i två faser.** Mål: noll explicit `any` + minimera
+`as unknown as` i repository/datastore-lagret.
+
+### Fas 1 — typa delegate-query-input (DENNA PR, #562)
+
+- `FindArgs<Row>` / `WhereInput<Row>` / `OrderByInput<Row>` / `AggregateArgs`
+  ersätter `args: any` på alla delegate-metoder.
+- `JoinedRelations`-fält `any` → `unknown` (caller narrowar/castar till sin
+  `WithRelations`-typ — branded id:n bevaras eftersom fälten är optional).
+- `$queryRaw` borttagen (oanvänd). `Delegate<Row = Record<string, unknown>>`.
+- **eslint-disable borttagen** → `no-explicit-any` är nu `error` ÖVERALLT i src,
+  utan undantag. **Noll explicit `any` i kodbasen.**
+
+`WhereInput<Row>` är medvetet **permissiv**: fält-nycklar hintas mot `Row`, men
+värdena är `unknown` (+ `Record<string, unknown>`-escape för relations-filter),
+eftersom (a) repos:en skickar OBRANDADE id-strängar (metod-params är `string`)
+och (b) relations-filter (`{ matter: { organizationId } }`) refererar typer
+delegaten inte känner generiskt. Query-engine:n validerar formen i runtime.
+Striktare per-entitet-where skulle kräva Prisma-stil GENERERADE typer per
+entitet (100+ rader/entitet) — ej motiverat; det är inte en `any`, bara löst.
+
+Fallout var liten + kontenerad: in-memory-delegate-klasserna pekades om till
+`FindArgs<T>`, och 4 projektion-castar blev `as unknown as` (resultatet är nu
+`Joined<Record<string, unknown>>` i st.f. `Joined<any>`). Net `as unknown as`:
+105 → 109 — en medveten avvägning (eliminera `any` > 4 gräns-castar).
+
+### Fas 2 — branda drizzle-kolumnerna (spårat, ej i denna PR)
+
+`.$type<XId>()` på id/FK-kolumnerna i `db/schema.ts` så `db.select()` bär
+branded id:n → `asRow`/`asRows`-castarna blir onödiga. **Probe** (jun 2026)
+visade att branding av en kolumn kaskaderar: `eq(matters.id, stringParam)`
+slutar matcha → query-param-typerna + repo-metod-signaturerna måste brandas
+(`getById(id: MatterId)`) över 27 entiteter, plus de delade `baseColumns`. Görs
+som en koordinerad per-entitet/lager-PR-serie. Inte ett quick-win.
+
+## Konsekvenser
+
+- **Noll explicit `any`** i src — `no-explicit-any: error` utan undantag (ratchet
+  låst i topp). Den största delen av användarens "no any anywhere"-mål uppnått.
+- Delegate-query-input är nu strukturellt typad (arg-formen tvingas, fält-nyckel-
+  autocomplete) men where-VÄRDEN är permissiva (`unknown`) — runtime-validerat.
+- Fas 2 (branded kolumner) tar bort de återstående ORM-gräns-castarna; spåras i
+  #562. Net `as unknown as` denna session: 213 → 109.
+
+## Relaterat
+
+Quick-wins: #557 (LocalStore-delegater), #559 (in-memory-delegering), #560
+(`asRow`/`asRows`). ADR 0019 (Postgres-schema), ADR 0020 (repository-söm). #562.

--- a/src/lib/server/data-store/IDataStore.ts
+++ b/src/lib/server/data-store/IDataStore.ts
@@ -52,63 +52,105 @@ export interface ClaimOpts {
 //   type MatterRow = z.infer<typeof matterSchema>
 //   export type MatterDelegate = Delegate<MatterRow>
 
-// ENDA kvarvarande `no-explicit-any`-undantaget i src efter #47. `args: any`
-// på delegate-metoderna är den flytande Prisma-stil-query-ytan (where/select/
-// include) som inte går att typa exakt utan en massiv router-omskrivning —
-// det egna query-typsystemet spåras separat. `no-explicit-any` är `error`
-// överallt annars (ratchet); detta block är det medvetna, dokumenterade
-// undantaget. Returtyperna är däremot typade (`Joined<Row>`, #39) så branded
-// id:n flödar ut även om query-INPUT förblir `any` här.
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 /**
  * Kända relations-/join-fält som `include` kan lägga på en rad.
  *
- * Uppräknade som optional `any` — INTE en `[k: string]: any`-index-signatur —
- * eftersom en string-index-signatur tvättar bort Row:s EGNA fälttyper (särskilt
- * branded id:n, [[ids]]) till `any` i intersektionen. Med en uppräkning behåller
- * `Joined<Matter>["id"]` sin `MatterId`-typ, medan joinade fält fortsatt är `any`
- * (vi typar inte de exakta include-formerna här — det vore router-omskrivningen).
+ * Uppräknade som optional `unknown` — INTE en `[k: string]: unknown`-index-
+ * signatur — eftersom en string-index-signatur tvättar bort Row:s EGNA fälttyper
+ * (särskilt branded id:n, [[ids]]) i intersektionen. Med en uppräkning behåller
+ * `Joined<Matter>["id"]` sin `MatterId`-typ. De joinade fälten är `unknown` (vi
+ * typar inte de exakta include-formerna här — det vore router-omskrivningen);
+ * caller:n narrowar/castar till sin egen `WithRelations`-typ.
  */
 export interface JoinedRelations {
-  matter?: any; contact?: any; contacts?: any; matterLinks?: any;
-  children?: any; parent?: any; documents?: any; document?: any;
-  timeEntries?: any; expenses?: any; payments?: any; invoice?: any;
-  folder?: any; paymentPlan?: any; billingRun?: any; reminders?: any;
-  accontoInvoice?: any; finalInvoice?: any; creditNote?: any;
-  uploadedBy?: any; recordedBy?: any; createdBy?: any; checkedBy?: any;
-  author?: any; serviceNotes?: any;
-  user?: any; emails?: any; _count?: any;
+  matter?: unknown; contact?: unknown; contacts?: unknown; matterLinks?: unknown;
+  children?: unknown; parent?: unknown; documents?: unknown; document?: unknown;
+  timeEntries?: unknown; expenses?: unknown; payments?: unknown; invoice?: unknown;
+  folder?: unknown; paymentPlan?: unknown; billingRun?: unknown; reminders?: unknown;
+  accontoInvoice?: unknown; finalInvoice?: unknown; creditNote?: unknown;
+  uploadedBy?: unknown; recordedBy?: unknown; createdBy?: unknown; checkedBy?: unknown;
+  author?: unknown; serviceNotes?: unknown;
+  user?: unknown; emails?: unknown; _count?: unknown;
 }
 
 /**
  * Output-typ för en delegate-fråga: basraden (`Row`, från Zod-schemat) plus
  * de optionella relations-fälten. Se `JoinedRelations` för varför det inte är
- * en index-signatur (branded id:n skulle annars tvättas bort till `any`).
+ * en index-signatur (branded id:n skulle annars tvättas bort).
  */
 export type Joined<Row> = Row & JoinedRelations;
 
-export interface Delegate<Row = any> {
-  findUnique(args: any): Promise<Joined<Row> | null>;
-  findUniqueOrThrow(args: any): Promise<Joined<Row>>;
-  findFirst(args?: any): Promise<Joined<Row> | null>;
-  findFirstOrThrow(args?: any): Promise<Joined<Row>>;
-  findMany(args?: any): Promise<Joined<Row>[]>;
-  // Skriv-args: `data`/`create`/`update` typas mot `Partial<Row>` så
-  // write-literals (inkl. enum-fält) typkollas (#24). `where`/`include`/`select`
-  // hålls lösa (flytande query-yta).
-  create(args: { data: Partial<Row>; include?: unknown; select?: unknown }): Promise<Joined<Row>>;
-  update(args: { where: unknown; data: Partial<Row>; include?: unknown; select?: unknown }): Promise<Joined<Row>>;
-  updateMany(args: { where?: unknown; data: Partial<Row> }): Promise<{ count: number }>;
-  upsert(args: { where: unknown; create: Partial<Row>; update: Partial<Row> }): Promise<Joined<Row>>;
-  delete(args: any): Promise<Joined<Row>>;
-  deleteMany(args?: any): Promise<{ count: number }>;
-  count(args?: any): Promise<number>;
-  aggregate(args: any): Promise<any>;
-  $queryRaw?: (...args: any[]) => Promise<any>;
-}
-/* eslint-enable @typescript-eslint/no-explicit-any */
+// ─── Typad query-input (#562, ADR 0026) ──────────────────────────────────
+// Ersätter den gamla `args: any`-ytan. Den enda kvarvarande lösheten är
+// `Record<string, unknown>`-escape-hatchen för relations-filter (vars relaterade
+// rad-typ delegaten inte känner generiskt) + include/select-former. INGEN
+// explicit `any` kvar — `no-explicit-any` är `error` även här.
 
+/** Operatorer query-engine:n stödjer på ett fält (Prisma-subset). */
+export interface WhereOps {
+  equals?: unknown; not?: unknown;
+  in?: readonly unknown[]; notIn?: readonly unknown[];
+  lt?: unknown; lte?: unknown; gt?: unknown; gte?: unknown;
+  contains?: string; startsWith?: string; endsWith?: string;
+  mode?: "insensitive" | "default";
+  some?: WhereInput; none?: WhereInput; every?: WhereInput;
+}
+
+/**
+ * Filter-shape. Fält-nycklarna hintas mot `Row` (autocomplete), men värdena är
+ * `unknown` — ett fält kan vara ett direkt värde, ett `WhereOps`-objekt eller
+ * ett nästlat relations-filter, och repos:en skickar ofta OBRANDADE id-strängar
+ * (metod-params är `string`, inte `MatterId`). `Record<string, unknown>`-escapen
+ * tillåter relations-nycklar (`{ matter: { organizationId } }`) utöver Row:s
+ * egna. INGEN `any` — query-engine:n validerar formen i runtime.
+ */
+export type WhereInput<Row = Record<string, unknown>> =
+  & { [K in keyof Row]?: unknown }
+  & { OR?: readonly WhereInput<Row>[]; AND?: readonly WhereInput<Row>[]; NOT?: WhereInput<Row> }
+  & Record<string, unknown>;
+
+export type OrderDir = "asc" | "desc";
+export type OrderByInput<Row = Record<string, unknown>> =
+  | ({ [K in keyof Row]?: OrderDir } & Record<string, OrderDir>)
+  | Array<{ [K in keyof Row]?: OrderDir } & Record<string, OrderDir>>;
+
+export interface FindArgs<Row = Record<string, unknown>> {
+  where?: WhereInput<Row>;
+  orderBy?: OrderByInput<Row>;
+  skip?: number;
+  take?: number;
+  select?: Record<string, unknown>;
+  include?: Record<string, unknown>;
+  distinct?: string | readonly string[];
+}
+
+/** `aggregate`-subset (Prisma-stil): `_count`/`_sum`/`_avg`/`_min`/`_max`. */
+export interface AggregateArgs {
+  where?: WhereInput;
+  _count?: true | Record<string, true>;
+  _sum?: Record<string, true>;
+  _avg?: Record<string, true>;
+  _min?: Record<string, true>;
+  _max?: Record<string, true>;
+}
+
+export interface Delegate<Row = Record<string, unknown>> {
+  findUnique(args: FindArgs<Row>): Promise<Joined<Row> | null>;
+  findUniqueOrThrow(args: FindArgs<Row>): Promise<Joined<Row>>;
+  findFirst(args?: FindArgs<Row>): Promise<Joined<Row> | null>;
+  findFirstOrThrow(args?: FindArgs<Row>): Promise<Joined<Row>>;
+  findMany(args?: FindArgs<Row>): Promise<Joined<Row>[]>;
+  // Skriv-args: `data`/`create`/`update` typas mot `Partial<Row>` så
+  // write-literals (inkl. enum-fält) typkollas (#24).
+  create(args: { data: Partial<Row>; include?: Record<string, unknown>; select?: Record<string, unknown> }): Promise<Joined<Row>>;
+  update(args: { where: WhereInput<Row>; data: Partial<Row>; include?: Record<string, unknown>; select?: Record<string, unknown> }): Promise<Joined<Row>>;
+  updateMany(args: { where?: WhereInput<Row>; data: Partial<Row> }): Promise<{ count: number }>;
+  upsert(args: { where: WhereInput<Row>; create: Partial<Row>; update: Partial<Row> }): Promise<Joined<Row>>;
+  delete(args: FindArgs<Row>): Promise<Joined<Row>>;
+  deleteMany(args?: FindArgs<Row>): Promise<{ count: number }>;
+  count(args?: FindArgs<Row>): Promise<number>;
+  aggregate(args: AggregateArgs): Promise<Record<string, unknown>>;
+}
 // Per-entitet-delegate: binder `Row` (branded id:n flödar ut via `Joined<Row>`).
 // In-memory-impl:en (`ReadOnlyDelegate<T> implements Delegate<T>`) satisfierar
 // dessa, så `LocalStore` wirar dem TYPADE utan casts (#typing). Den enda kvar-

--- a/src/lib/server/data-store/in-memory/read-only-delegate.ts
+++ b/src/lib/server/data-store/in-memory/read-only-delegate.ts
@@ -18,8 +18,8 @@
  */
 
 import { omitUndefined } from "@/lib/shared/omit-undefined";
-import type { Delegate } from "../IDataStore";
-import { InMemoryQueryEngine, type QueryOptions } from "./query-engine";
+import type { AggregateArgs, Delegate, FindArgs } from "../IDataStore";
+import { InMemoryQueryEngine } from "./query-engine";
 
 export class ReadOnlyError extends Error {
   constructor(operation: string) {
@@ -52,15 +52,6 @@ export interface ReadOnlyDelegateOpts<T extends Record<string, unknown>> {
   relations?: Record<string, RelationConfig<T>>;
 }
 
-export interface FindArgs {
-  where?: Record<string, unknown>;
-  orderBy?: QueryOptions["orderBy"];
-  skip?: number;
-  take?: number;
-  select?: Record<string, unknown>;
-  include?: Record<string, unknown>;
-}
-
 export class ReadOnlyDelegate<T extends Record<string, unknown>> implements Delegate<T> {
   private engine = new InMemoryQueryEngine<T>();
 
@@ -71,33 +62,33 @@ export class ReadOnlyDelegate<T extends Record<string, unknown>> implements Dele
 
   // ─── Läs-metoder ──────────────────────────────────────────────────
 
-  async findMany(args: FindArgs = {}): Promise<T[]> {
+  async findMany(args: FindArgs<T> = {}): Promise<T[]> {
     const rows = this.queryRows(args);
     return rows.map((r) => this.hydrate(r, args.include ?? args.select));
   }
 
-  async findFirst(args: FindArgs = {}): Promise<T | null> {
+  async findFirst(args: FindArgs<T> = {}): Promise<T | null> {
     const r = this.queryRows({ ...args, take: 1 })[0] ?? null;
     return r ? this.hydrate(r, args.include ?? args.select) : null;
   }
 
-  async findUnique(args: FindArgs = {}): Promise<T | null> {
+  async findUnique(args: FindArgs<T> = {}): Promise<T | null> {
     return this.findFirst(args);
   }
 
-  async findFirstOrThrow(args: FindArgs = {}): Promise<T> {
+  async findFirstOrThrow(args: FindArgs<T> = {}): Promise<T> {
     const r = await this.findFirst(args);
     if (!r) throw new Error("No record found");
     return r;
   }
 
-  async findUniqueOrThrow(args: FindArgs = {}): Promise<T> {
+  async findUniqueOrThrow(args: FindArgs<T> = {}): Promise<T> {
     const r = await this.findUnique(args);
     if (!r) throw new Error("No record found");
     return r;
   }
 
-  async count(args: FindArgs = {}): Promise<number> {
+  async count(args: FindArgs<T> = {}): Promise<number> {
     return this.filterRows(this.rowsFn(), args.where).length;
   }
 
@@ -106,14 +97,7 @@ export class ReadOnlyDelegate<T extends Record<string, unknown>> implements Dele
    * över numeriska fält. Räcker för router-användningarna (timeEntry-summor,
    * rapporter). Okända fält → 0/null.
    */
-  async aggregate(args: {
-    where?: Record<string, unknown>;
-    _count?: true | Record<string, true>;
-    _sum?: Record<string, true>;
-    _avg?: Record<string, true>;
-    _min?: Record<string, true>;
-    _max?: Record<string, true>;
-  } = {}): Promise<Record<string, unknown>> {
+  async aggregate(args: AggregateArgs = {}): Promise<Record<string, unknown>> {
     const rows = this.filterRows(this.rowsFn(), args.where);
     const nums = (field: string) => rows.map((r) => Number((r as Record<string, unknown>)[field]) || 0);
     const out: Record<string, unknown> = {};
@@ -134,7 +118,7 @@ export class ReadOnlyDelegate<T extends Record<string, unknown>> implements Dele
   }
 
   /** Filtrera (med relations-prehydrering) → sortera/paginera. */
-  private queryRows(args: FindArgs): T[] {
+  private queryRows(args: FindArgs<T>): T[] {
     const filtered = this.filterRows(this.rowsFn(), args.where);
     return this.engine.query(filtered, omitUndefined({
       orderBy: args.orderBy,

--- a/src/lib/server/repositories/in-memory-document-template-repository.ts
+++ b/src/lib/server/repositories/in-memory-document-template-repository.ts
@@ -26,7 +26,7 @@ export class InMemoryDocumentTemplateRepository
         createdAt: true, updatedAt: true, createdBy: { select: { name: true } },
       },
       orderBy: [{ category: "asc" }, { name: "asc" }],
-    })) as DocumentTemplateListRow[];
+    })) as unknown as DocumentTemplateListRow[];
   }
 
   async getByIdInOrg(id: string, organizationId: string): Promise<DocumentTemplateRow | null> {

--- a/src/lib/server/repositories/in-memory-matter-contact-repository.ts
+++ b/src/lib/server/repositories/in-memory-matter-contact-repository.ts
@@ -37,7 +37,7 @@ export class InMemoryMatterContactRepository
           contact: { OR: [{ personalNumber: { contains: numberTerm } }, { orgNumber: { contains: numberTerm } }] },
         }
       : { matter: { organizationId } };
-    return (await this.delegate.findMany({ where, include: MC_INCLUDE })) as ConflictContactRow[];
+    return (await this.delegate.findMany({ where, include: MC_INCLUDE })) as unknown as ConflictContactRow[];
   }
 
   async getByIdInOrg(id: string, organizationId: string): Promise<MatterContact | null> {

--- a/src/lib/server/repositories/in-memory-payment-repository.ts
+++ b/src/lib/server/repositories/in-memory-payment-repository.ts
@@ -17,7 +17,7 @@ export class InMemoryPaymentRepository extends InMemoryRepository<Payment> imple
   }
 
   async sumByInvoice(invoiceId: string): Promise<number> {
-    const rows = (await this.delegate.findMany({ where: { invoiceId } })) as ReadonlyArray<Payment>;
+    const rows = (await this.delegate.findMany({ where: { invoiceId } })) as unknown as ReadonlyArray<Payment>;
     return rows
       .filter((r) => !(r as { deletedAt?: unknown }).deletedAt)
       .reduce((s, p) => s + p.amount, 0);

--- a/src/lib/server/repositories/in-memory-write-off-repository.ts
+++ b/src/lib/server/repositories/in-memory-write-off-repository.ts
@@ -17,7 +17,7 @@ export class InMemoryWriteOffRepository extends InMemoryRepository<WriteOff> imp
   }
 
   async sumByInvoice(invoiceId: string): Promise<number> {
-    const rows = (await this.delegate.findMany({ where: { invoiceId } })) as ReadonlyArray<WriteOff>;
+    const rows = (await this.delegate.findMany({ where: { invoiceId } })) as unknown as ReadonlyArray<WriteOff>;
     return rows
       .filter((r) => !(r as { deletedAt?: unknown }).deletedAt)
       .reduce((s, w) => s + w.amount, 0);


### PR DESCRIPTION
**#562 Fas 1 — eliminerar den SISTA explicit `any`:n i kodbasen.**

`IDataStore.Delegate` hade `args: any` på query-metoderna (findUnique/findFirst/findMany/count/delete/aggregate) + `JoinedRelations`-fält som `any` + oanvänd `$queryRaw: any` — det ENDA `no-explicit-any`-undantaget i src.

## Vad
- Inför `FindArgs<Row>` / `WhereInput<Row>` / `OrderByInput<Row>` / `AggregateArgs` → ersätter alla `args: any`.
- `JoinedRelations`-fält `any` → `unknown` (branded id:n bevaras — fälten är optional). `$queryRaw` borttagen (oanvänd). `Delegate<Row = Record<string, unknown>>`.
- **eslint-disable borttagen** → `no-explicit-any` är nu `error` **överallt** i src utan undantag. **Noll explicit `any` i kodbasen.**

## Designval (ärligt)
`WhereInput` är medvetet **permissiv**: fält-nycklar hintas mot `Row`, men värdena är `unknown` (+ `Record<string, unknown>`-escape för relations-filter), eftersom repos:en skickar obrandade id-strängar och relations-typer är okända generiskt. Query-engine:n validerar formen i runtime. Det är **inte en `any`** — bara löst typad input. Striktare per-entitet-where kräver Prisma-stil genererade typer (ej motiverat).

## Fallout
Type-only (0 testfel). In-memory-delegate-klasserna pekades om till `FindArgs<T>`; 4 projektion-castar blev `as unknown as` (resultatet är nu `Joined<Record>` ej `Joined<any>`). Net `as unknown as`: 105 → 109 — medveten avvägning (eliminera `any` väger tyngre än 4 gräns-castar).

## Fas 2 (spårad i #562, ej här)
Branda drizzle-kolumnerna (`.$type<XId>()`) för att ta bort `asRow`/`asRows`-gräns-castarna. **Probe** visade att det kaskaderar till query-param-typer + repo-metod-signaturer över 27 entiteter → koordinerad per-entitet-PR-serie. ADR 0026 dokumenterar planen.

## Verifierat lokalt
`typecheck`, `lint` (--max-warnings 0, no-explicit-any=error), `knip`, `deps:check`, `test:cov` (90.71 % / 85.64 %), `build:demo` — alla gröna.

Refs #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)