### PR TITLE
refactor(types): riktiga DOM-typer + fetch-adapter → bort med 9 miljö-castar

### DIFF
--- a/src/lib/client/addin/addin-client.ts
+++ b/src/lib/client/addin/addin-client.ts
@@ -17,15 +17,12 @@
 
 import { createTRPCClient, httpBatchLink, type TRPCClient } from "@trpc/client";
 import superjson from "superjson";
+import { toLinkFetch, type InjectableFetch } from "@/lib/client/link-fetch";
 import type { AppRouter } from "@/lib/server/routers/_app";
 
 /** Minimal fetch-form för override (test/icke-standard-runtime). En DOM-`fetch`
  *  uppfyller den; tRPC:s interna `FetchEsque` är inte publikt exporterad. */
-export type AddinFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
-
-/** tRPC:s httpBatchLink-fetch-typ (icke-exporterad `FetchEsque`), härledd ur
- *  länkens optionsparameter så vi kan brygga en DOM-fetch dit utan import. */
-type LinkFetch = NonNullable<NonNullable<Parameters<typeof httpBatchLink<AppRouter>>[0]>["fetch"]>;
+export type AddinFetch = InjectableFetch;
 
 /** tRPC-endpointens default-suffix på serverns origin (matchar DEFAULT_TRPC_ENDPOINT). */
 export const ADDIN_TRPC_PATH = "/api/trpc";
@@ -56,9 +53,7 @@ export function createAddinClient(opts: AddinClientOptions): TRPCClient<AppRoute
         url: addinTrpcEndpoint(opts.baseUrl),
         transformer: superjson,
         headers: () => ({ authorization: `Bearer ${opts.token}` }),
-        // En DOM-fetch är runtime-kompatibel med tRPC:s FetchEsque; typerna
-        // skiljer bara i exactOptional-detaljer (signal null vs undefined).
-        ...(opts.fetch ? { fetch: opts.fetch as unknown as LinkFetch } : {}),
+        ...(opts.fetch ? { fetch: toLinkFetch(opts.fetch) } : {}),
       }),
     ],
   });

--- a/src/lib/client/backend/http-backend-runtime.ts
+++ b/src/lib/client/backend/http-backend-runtime.ts
@@ -19,6 +19,7 @@
 
 import { httpBatchLink, type TRPCLink } from "@trpc/client";
 import superjson from "superjson";
+import { toLinkFetch, type InjectableFetch } from "@/lib/client/link-fetch";
 import type { AppRouter } from "@/lib/server/routers/_app";
 import type { BackendRuntime } from "./backend-runtime";
 
@@ -27,11 +28,7 @@ export const SERVER_TRPC_PATH = "/api/trpc";
 
 /** Minimal fetch-form för override (test/icke-standard-runtime). En DOM-`fetch`
  *  uppfyller den; tRPC:s interna `FetchEsque` är inte publikt exporterad. */
-export type HttpBackendFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
-
-/** tRPC:s httpBatchLink-fetch-typ (icke-exporterad `FetchEsque`), härledd ur
- *  länkens optionsparameter så vi kan brygga en DOM-fetch dit utan import. */
-type LinkFetch = NonNullable<NonNullable<Parameters<typeof httpBatchLink<AppRouter>>[0]>["fetch"]>;
+export type HttpBackendFetch = InjectableFetch;
 
 /** Bygg full tRPC-endpoint-URL ur serverns bas-URL. Tom bas = samma origin
  *  (web-appen bakom nginx). Trimmar avslutande "/". */
@@ -53,9 +50,7 @@ export class HttpBackendRuntime implements BackendRuntime {
     return httpBatchLink({
       url: serverTrpcEndpoint(this.deps.baseUrl),
       transformer: superjson,
-      // En DOM-fetch är runtime-kompatibel med tRPC:s FetchEsque; typerna
-      // skiljer bara i exactOptional-detaljer (signal null vs undefined).
-      ...(this.deps.fetch ? { fetch: this.deps.fetch as unknown as LinkFetch } : {}),
+      ...(this.deps.fetch ? { fetch: toLinkFetch(this.deps.fetch) } : {}),
     });
   }
 }

--- a/src/lib/client/backend/server-first-store.ts
+++ b/src/lib/client/backend/server-first-store.ts
@@ -14,6 +14,7 @@
 
 import { createTRPCClient, httpBatchLink } from "@trpc/client";
 import superjson from "superjson";
+import { toLinkFetch, type InjectableFetch } from "@/lib/client/link-fetch";
 import { TrpcSyncTransport } from "@/lib/client/sync/trpc-sync-transport";
 import { CachingSyncDataStore } from "@/lib/server/data-store/in-memory/caching-sync-data-store";
 import { IndexedDbPersistence } from "@/lib/server/data-store/in-memory/indexeddb-persistence";
@@ -25,9 +26,7 @@ import {
 import type { AppRouter } from "@/lib/server/routers/_app";
 import { serverTrpcEndpoint } from "./http-backend-runtime";
 
-/** tRPC:s httpBatchLink-fetch-typ (icke-exporterad `FetchEsque`). */
-type LinkFetch = NonNullable<NonNullable<Parameters<typeof httpBatchLink<AppRouter>>[0]>["fetch"]>;
-export type ServerFirstFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
+export type ServerFirstFetch = InjectableFetch;
 
 export interface ServerFirstStoreDeps {
   /** Server-bas-URL. Tom (default) = samma origin (bakom nginx/oauth2-proxy). */
@@ -53,7 +52,7 @@ export async function createServerFirstStore(deps: ServerFirstStoreDeps = {}): P
       httpBatchLink({
         url: serverTrpcEndpoint(deps.baseUrl),
         transformer: superjson,
-        ...(deps.fetch ? { fetch: deps.fetch as unknown as LinkFetch } : {}),
+        ...(deps.fetch ? { fetch: toLinkFetch(deps.fetch) } : {}),
       }),
     ],
   });

--- a/src/lib/client/demo/reset-demo.ts
+++ b/src/lib/client/demo/reset-demo.ts
@@ -30,29 +30,19 @@ const DEMO_SNAPSHOT_PREFIX = "ava-demo";
 const WORKING_COPY_DIR = "working-copy";
 const LS_PREFIX = "ava.";
 
-/** Minimal vy av OPFS-roten — bara det reset:en behöver (jfr persistence.ts). */
-interface OpfsRootHandle {
-  keys(): AsyncIterableIterator<string>;
-  removeEntry(name: string, options?: { recursive?: boolean }): Promise<void>;
-}
-
-interface NavigatorWithStorage {
-  storage?: { getDirectory?: () => Promise<OpfsRootHandle> };
-}
-
 /** OPFS-roten, eller null om OPFS saknas/inte går att öppna. */
-async function opfsRoot(): Promise<OpfsRootHandle | null> {
-  const nav = (globalThis as unknown as { navigator?: NavigatorWithStorage }).navigator;
-  if (!nav?.storage?.getDirectory) return null;
+async function opfsRoot(): Promise<FileSystemDirectoryHandle | null> {
+  const storage = typeof navigator === "undefined" ? undefined : navigator.storage;
+  if (!storage?.getDirectory) return null;
   try {
-    return await nav.storage.getDirectory();
+    return await storage.getDirectory();
   } catch {
     return null;
   }
 }
 
 /** Toppnivå-namn i OPFS-roten, eller [] om de inte kan listas. */
-async function opfsNames(root: OpfsRootHandle): Promise<string[]> {
+async function opfsNames(root: FileSystemDirectoryHandle): Promise<string[]> {
   const names: string[] = [];
   try {
     for await (const name of root.keys()) names.push(name);
@@ -108,7 +98,7 @@ function deleteIdb(factory: IDBFactory, name: string): Promise<void> {
  * (även gamla version-namespaces) så "Återställ demo" verkligen ger färsk seed.
  */
 async function clearDemoIdb(): Promise<void> {
-  const factory = (globalThis as unknown as { indexedDB?: IDBFactory }).indexedDB;
+  const factory = globalThis.indexedDB;
   if (!factory) return;
   try {
     const dbs = typeof factory.databases === "function" ? await factory.databases() : [];

--- a/src/lib/client/diagnostics/log-buffer.ts
+++ b/src/lib/client/diagnostics/log-buffer.ts
@@ -167,6 +167,5 @@ export function installConsoleCapture(opts: InstallOptions): () => void {
 }
 
 function defaultTarget(): EventTargetLike | null {
-  const g = globalThis as { addEventListener?: unknown; removeEventListener?: unknown };
-  return typeof g.addEventListener === "function" ? (g as unknown as EventTargetLike) : null;
+  return typeof globalThis.addEventListener === "function" ? globalThis : null;
 }

--- a/src/lib/client/fsa/fs-adapter.ts
+++ b/src/lib/client/fsa/fs-adapter.ts
@@ -19,14 +19,6 @@
  *   - Recursive mkdir hanteras manuellt eftersom FSA inte har det.
  */
 
-/**
- * `FileSystemDirectoryHandle.entries()` är en del av File System Access API
- * men saknas i den lib.dom-version vi kompilerar mot. Vi beskriver bara den
- * delen vi använder (async-iteration över [namn, handle]-par).
- */
-interface DirectoryHandleWithEntries {
-  entries(): AsyncIterableIterator<[string, FileSystemHandle]>;
-}
 
 interface IsoFsStat {
   type: "file" | "dir";
@@ -146,10 +138,7 @@ export class FsaIsoGitAdapter {
     let dir: FileSystemDirectoryHandle;
     try { dir = await resolveDir(this.root, parts); } catch { throw enoent(path); }
     const names: string[] = [];
-    // `entries()` finns på FileSystemDirectoryHandle men saknas i vår
-    // lib.dom-version. Narrow till en lokal vy istället för `any`.
-    const iterable = dir as unknown as DirectoryHandleWithEntries;
-    for await (const [name] of iterable.entries()) names.push(name);
+    for await (const [name] of dir.entries()) names.push(name);
     return names;
   }
 

--- a/src/lib/client/link-fetch.ts
+++ b/src/lib/client/link-fetch.ts
@@ -1,0 +1,28 @@
+/**
+ * Adapter mellan en injicerad DOM-fetch och tRPC:s `httpBatchLink`-fetch.
+ *
+ * Add-ins och self-hosted-backenden injicerar en DOM-kompatibel fetch
+ * (`InjectableFetch`). Den är runtime-kompatibel med tRPC:s `FetchEsque`, men
+ * typerna skiljer i exactOptional-detaljer (`RequestInit.signal` null vs
+ * undefined m.m.). I st.f. en `as unknown as`-cast på varje länk-konfiguration
+ * bryggar vi i EN adapter med en lokal `as RequestInit`-tag — den verkliga
+ * DOM-rad-formen, inte en blind dubbel-cast.
+ */
+
+import type { httpBatchLink } from "@trpc/client";
+import type { AppRouter } from "@/lib/server/routers/_app";
+
+/** En DOM-kompatibel fetch (det add-ins/backends injicerar). */
+export type InjectableFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+/** tRPC:s fetch-typ för `httpBatchLink` (`FetchEsque`). */
+export type LinkFetch = NonNullable<NonNullable<Parameters<typeof httpBatchLink<AppRouter>>[0]>["fetch"]>;
+
+/** Adaptera en injicerad DOM-fetch till tRPC:s länk-fetch. */
+export function toLinkFetch(fetchImpl: InjectableFetch): LinkFetch {
+  // `httpBatchLink` anropar med en URL-sträng/URL, men `FetchEsque`-typen
+  // tillåter även `Request` → normalisera den till sin `.url` (runtime-korrekt,
+  // ingen url-cast). `init` bryggas med en lokal `as` för signal-varianten.
+  return (url, init) =>
+    fetchImpl(url instanceof Request ? url.url : url, init as RequestInit | undefined);
+}

--- a/src/lib/server/data-store/in-memory/cursor-store.ts
+++ b/src/lib/server/data-store/in-memory/cursor-store.ts
@@ -24,7 +24,7 @@ export class InMemoryCursorStore implements CursorStore {
 export class IndexedDbCursorStore implements CursorStore {
   private readonly kv: IdbKv;
   constructor(
-    factory: IDBFactory = (globalThis as unknown as { indexedDB: IDBFactory }).indexedDB,
+    factory: IDBFactory = globalThis.indexedDB,
     dbName = "ava-sync-cursor",
   ) {
     this.kv = new IdbKv(factory, dbName, "cursor");

--- a/src/lib/server/data-store/in-memory/indexeddb-persistence.ts
+++ b/src/lib/server/data-store/in-memory/indexeddb-persistence.ts
@@ -20,7 +20,7 @@ export class IndexedDbPersistence implements LocalStorePersistence {
   private readonly kv: IdbKv;
 
   constructor(
-    factory: IDBFactory = (globalThis as unknown as { indexedDB: IDBFactory }).indexedDB,
+    factory: IDBFactory = globalThis.indexedDB,
     dbName: string = DB_NAME,
   ) {
     this.kv = new IdbKv(factory, dbName, STORE);

--- a/src/lib/server/data-store/in-memory/mutation-queue.ts
+++ b/src/lib/server/data-store/in-memory/mutation-queue.ts
@@ -50,7 +50,7 @@ export class InMemoryMutationQueuePersistence implements MutationQueuePersistenc
 export class IndexedDbMutationQueuePersistence implements MutationQueuePersistence {
   private readonly kv: IdbKv;
   constructor(
-    factory: IDBFactory = (globalThis as unknown as { indexedDB: IDBFactory }).indexedDB,
+    factory: IDBFactory = globalThis.indexedDB,
     dbName = "ava-mutation-queue",
   ) {
     this.kv = new IdbKv(factory, dbName, "queue");


### PR DESCRIPTION
Del 3 av PR-serien som eliminerar alla `as unknown as`-dubbel-castar i `src/` (#562). Kategori **D (external/dynamic)** — runtime-gränser.

## Ändringar

**lib.dom (TS 6) typar redan det de gamla castarna kringgick:**
- IndexedDB-prober (cursor-store, indexeddb-persistence, mutation-queue, reset-demo): `(globalThis as unknown as { indexedDB }).indexedDB` → `globalThis.indexedDB`.
- OPFS (reset-demo): `OpfsRootHandle`/`NavigatorWithStorage`-shimsen skrevs för en äldre lib.dom — `navigator.storage.getDirectory()` + handle-metoderna finns nu på riktigt.
- FSA (fs-adapter): `FileSystemDirectoryHandle.entries()` finns i lib.dom → `dir.entries()` direkt.
- diagnostics (log-buffer): `globalThis` ÄR en `EventTarget`.

**fetch→tRPC (3 ställen):** ny delad `toLinkFetch`-adapter (`src/lib/client/link-fetch.ts`). DOM-fetchen är runtime-kompatibel; den enda äkta variansen (`RequestInit.signal` null vs undefined) bryggas med EN lokal `as RequestInit` i adaptern, `Request`-input normaliseras till `.url` — i st.f. `as unknown as LinkFetch` på tre call-sites.

9 `as unknown as` borta. Runtime-feature-gardena behålls.

## Verifierat
Ren typecheck + lint + knip + 64 tester (cursor/mutation-queue/idb/fsa/reset-demo/log-buffer/addin/backend/content-sync) gröna.

Refs #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)