### PR TITLE
refactor(types): branda writeOffs + paymentPlanReminders-kolumner

### DIFF
--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -13,7 +13,10 @@
 
 import { relations } from "drizzle-orm";
 import { bigint, bigserial, index, integer, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
-import type { InvoiceId, PaymentId, UserId } from "@/lib/shared/schemas/ids";
+import type { ReminderType } from "@/lib/shared/schemas/enums";
+import type {
+  InvoiceId, PaymentId, PaymentPlanId, PaymentPlanReminderId, UserId, WriteOffId,
+} from "@/lib/shared/schemas/ids";
 import { baseColumns, boolDefault, orgScopedColumns } from "./columns";
 
 /** Monetärt öre-belopp (bigint → ingen int4-overflow för stora fakturor). */
@@ -180,11 +183,12 @@ export const payments = pgTable("payments", {
 
 export const writeOffs = pgTable("write_offs", {
   ...baseColumns,
-  invoiceId: uuid("invoice_id").notNull(),
+  id: uuid("id").primaryKey().$type<WriteOffId>(),
+  invoiceId: uuid("invoice_id").notNull().$type<InvoiceId>(),
   amount: ore("amount").notNull(),
   writtenOffAt: timestamp("written_off_at", { withTimezone: true }).notNull(),
   reason: text("reason"),
-  recordedById: uuid("recorded_by_id").notNull(),
+  recordedById: uuid("recorded_by_id").notNull().$type<UserId>(),
 }, (t) => [index("write_offs_invoice_idx").on(t.invoiceId)]);
 
 export const invoiceDispatches = pgTable("invoice_dispatches", {
@@ -214,9 +218,10 @@ export const paymentPlans = pgTable("payment_plans", {
 
 export const paymentPlanReminders = pgTable("payment_plan_reminders", {
   ...baseColumns,
-  planId: uuid("plan_id").notNull(),
+  id: uuid("id").primaryKey().$type<PaymentPlanReminderId>(),
+  planId: uuid("plan_id").notNull().$type<PaymentPlanId>(),
   dueMonth: text("due_month").notNull(),
-  type: text("type").notNull(),
+  type: text("type").notNull().$type<ReminderType>(),
   sentAt: timestamp("sent_at", { withTimezone: true }).notNull(),
 }, (t) => [index("payment_plan_reminders_plan_idx").on(t.planId)]);
 

--- a/src/lib/server/repositories/drizzle-invoice-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-repository.ts
@@ -10,7 +10,7 @@
  */
 
 import { and, desc, eq, inArray, isNull, like, sql } from "drizzle-orm";
-import type { Invoice, Payment, WriteOff } from "@/lib/shared/schemas/billing";
+import type { Invoice } from "@/lib/shared/schemas/billing";
 import { asId } from "@/lib/shared/schemas/ids";
 import { accontoDeductions, invoices, matters, paymentPlans, payments, writeOffs } from "../db/schema";
 import type { AppDb } from "../db/types";
@@ -117,7 +117,7 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
         ...inv,
         matter: { id: (matter as { id: string }).id, matterNumber: (matter as { matterNumber: string }).matterNumber, title: (matter as { title: string }).title },
         paymentPlan: (plan[0] as unknown) ?? null,
-        payments: pays as unknown as Payment[],
+        payments: pays,
         accontoDeductions: accontoDeductionsFull,
         deductedOnFinals: usages,
         creditedInvoice: creditedInvoice as InvoiceListRow["creditedInvoice"],
@@ -176,8 +176,8 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
     const invoice = await this.getById(id);
     if (!invoice) return null;
     const pays = await this.db.select().from(payments).where(eq(payments.invoiceId, asId<"InvoiceId">(id)));
-    const wos = await this.db.select().from(writeOffs).where(eq(writeOffs.invoiceId, id));
-    return { ...invoice, payments: pays, writeOffs: wos as unknown as WriteOff[] };
+    const wos = await this.db.select().from(writeOffs).where(eq(writeOffs.invoiceId, asId<"InvoiceId">(id)));
+    return { ...invoice, payments: pays, writeOffs: wos };
   }
 
   async listByMatter(matterId: string): Promise<Invoice[]> {

--- a/src/lib/server/repositories/drizzle-payment-plan-repository.ts
+++ b/src/lib/server/repositories/drizzle-payment-plan-repository.ts
@@ -9,6 +9,7 @@
 
 import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 import type { PaymentPlan, PaymentPlanReminder } from "@/lib/shared/schemas/billing";
+import { asId } from "@/lib/shared/schemas/ids";
 import { invoices, matters, paymentPlanReminders, paymentPlans } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
@@ -84,9 +85,9 @@ export class DrizzlePaymentPlanRepository extends DrizzleRepository<PaymentPlan>
     if (ids.length === 0) return out;
     const rows = await this.db
       .select().from(paymentPlanReminders)
-      .where(inArray(paymentPlanReminders.planId, ids))
+      .where(inArray(paymentPlanReminders.planId, ids.map((id) => asId<"PaymentPlanId">(id))))
       .orderBy(desc(paymentPlanReminders.sentAt));
-    for (const r of rows as unknown as PaymentPlanReminder[]) {
+    for (const r of rows) {
       (out.get(r.planId) ?? out.set(r.planId, []).get(r.planId)!).push(r);
     }
     return out;

--- a/src/lib/server/repositories/drizzle-write-off-repository.ts
+++ b/src/lib/server/repositories/drizzle-write-off-repository.ts
@@ -5,6 +5,7 @@
 
 import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import type { WriteOff } from "@/lib/shared/schemas/billing";
+import { asId } from "@/lib/shared/schemas/ids";
 import { writeOffs } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
@@ -18,7 +19,7 @@ export class DrizzleWriteOffRepository extends DrizzleRepository<WriteOff> imple
   async sumByInvoice(invoiceId: string): Promise<number> {
     const rows = await this.db
       .select({ total: sql<number>`coalesce(sum(${writeOffs.amount}), 0)` }).from(writeOffs)
-      .where(and(eq(writeOffs.invoiceId, invoiceId), isNull(writeOffs.deletedAt)));
+      .where(and(eq(writeOffs.invoiceId, asId<"InvoiceId">(invoiceId)), isNull(writeOffs.deletedAt)));
     return Number(rows[0]?.total ?? 0);
   }
 
@@ -26,7 +27,7 @@ export class DrizzleWriteOffRepository extends DrizzleRepository<WriteOff> imple
     if (!invoiceIds.length) return [];
     const rows = await this.db
       .select().from(writeOffs)
-      .where(and(inArray(writeOffs.invoiceId, invoiceIds), isNull(writeOffs.deletedAt)));
-    return this.asRows(rows);
+      .where(and(inArray(writeOffs.invoiceId, invoiceIds.map((id) => asId<"InvoiceId">(id))), isNull(writeOffs.deletedAt)));
+    return rows;
   }
 }


### PR DESCRIPTION
Del 4 av PR-serien som eliminerar alla `as unknown as`-dubbel-castar i `src/` (#562). Kategori **A (drizzle-ORM-gräns)**.

## Ändringar
- **writeOffs** brandad (id/invoiceId/recordedById) → `asRows` i write-off-repo + `wos as unknown as WriteOff[]` i invoice-repo bort. Query-params brandas med `asId`.
- **paymentPlanReminders** brandad (id/planId) + text-kolumnen `type` → `.$type<ReminderType>()` (enum-literal vs `string`) → reminder-casten bort.
- Bonus: invoice-repo `listForOrg` tappar `pays as unknown as Payment[]` (payments brandad i #564).

3 `as unknown as` borta.

## Inte med här
org/user-preferences: deras `createdById`/`organizationId` är zod `.optional()` (`T | undefined`) men nullable i DB (`T | null`) → under `exactOptionalPropertyTypes` krävs ett schema-byte till `.nullish()` (eget domän-beslut). Tas i separat PR.

## Verifierat
Ren `tsc --noEmit` (raderade tsbuildinfo — incremental-cachen maskerar cross-file-fel) + lint + repo-tester (write-off/payment-plan/reminder) gröna. Repository (Postgres)-jobbet validerar SQL:en.

Refs #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)