### PR TITLE
refactor(types): rensa redundanta/onödiga castar (conflict + sök-index)

### DIFF
--- a/src/lib/server/adapters/demo-search-index.ts
+++ b/src/lib/server/adapters/demo-search-index.ts
@@ -17,8 +17,8 @@ import type { ISearchIndex, SearchResponse } from "../ports";
 interface DocLike {
   id: string;
   fileName?: string;
-  documentType?: string | null;
-  summary?: string | null;
+  documentType?: string | null | undefined;
+  summary?: string | null | undefined;
   matterId: string;
   /** Path till filinnehållet — propageras till hit:en så UI kan öppna. */
   storagePath?: string | null;
@@ -237,10 +237,10 @@ export function makeDemoSearchIndex(dataStore: IDataStore): ISearchIndex {
       // (DocumentWhereInput har ingen organizationId-direkt, det går
       // via matter-relation som vår in-memory-implementation inte
       // expanderar transparent).
-      const docs = await dataStore.documents.findMany({}) as unknown as DocLike[];
-      const matterRows = await dataStore.matters.findMany({
+      const docs: DocLike[] = await dataStore.documents.findMany({});
+      const matterRows: MatterLike[] = await dataStore.matters.findMany({
         where: { organizationId },
-      }) as unknown as MatterLike[];
+      });
       const matters = new Map(matterRows.map((m) => [m.id, m]));
       return searchDocuments(docs, matters, query, organizationId, { ...opts, limit });
     },

--- a/src/lib/server/routers/conflict.ts
+++ b/src/lib/server/routers/conflict.ts
@@ -84,7 +84,7 @@ export const conflictRouter = router({
       await ctx.repos.conflictChecks.create({
         searchTerm: input.searchTerm,
         searchType: input.searchType,
-        results: results as unknown as unknown[],
+        results,
         checkedById: asId<"UserId">(ctx.user.id),
       });
 


### PR DESCRIPTION
Del 6 av PR-serien (#562). Små rena vinster (kategori C/E).

- **conflict.ts**: `results as unknown as unknown[]` var en redundant dubbel-cast — `ConflictResult[]` är redan tilldelningsbart till fältets `unknown[]`.
- **demo-search-index**: IDataStore-delegaterna är typade, så `findMany` returnerar `Joined<Document>`/`Joined<Matter>`. De lokala läs-vyerna `DocLike`/`MatterLike` tar emot dem; `DocLike.documentType`/`summary` vidgas till `| undefined` (Document använder `.nullish()`) → båda `as unknown as`-castarna bort.

3 `as unknown as` borta. Ren typecheck + 44 tester gröna.

Refs #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)