### PR TITLE
refactor(types): branda timeEntries + typa projektionerna → 5 castar

### DIFF
--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -15,7 +15,8 @@ import { relations } from "drizzle-orm";
 import { bigint, bigserial, index, integer, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import type { ReminderType } from "@/lib/shared/schemas/enums";
 import type {
-  InvoiceId, PaymentId, PaymentPlanId, PaymentPlanReminderId, UserId, WriteOffId,
+  BillingRunId, InvoiceId, MatterId, PaymentId, PaymentPlanId, PaymentPlanReminderId,
+  TimeEntryId, UserId, WriteOffId,
 } from "@/lib/shared/schemas/ids";
 import { baseColumns, boolDefault, orgScopedColumns } from "./columns";
 
@@ -127,16 +128,17 @@ export const changeLog = pgTable("change_log", {
 
 export const timeEntries = pgTable("time_entries", {
   ...baseColumns,
-  userId: uuid("user_id").notNull(),
-  matterId: uuid("matter_id").notNull(),
+  id: uuid("id").primaryKey().$type<TimeEntryId>(),
+  userId: uuid("user_id").notNull().$type<UserId>(),
+  matterId: uuid("matter_id").notNull().$type<MatterId>(),
   date: timestamp("date", { withTimezone: true }).notNull(),
   minutes: integer("minutes").notNull(),
   description: text("description").notNull(),
   hourlyRate: integer("hourly_rate").notNull(),
   billable: boolDefault("billable", true),
-  invoiceId: uuid("invoice_id"),
+  invoiceId: uuid("invoice_id").$type<InvoiceId>(),
   frozenAt: timestamp("frozen_at", { withTimezone: true }),
-  frozenByBillingRunId: uuid("frozen_by_billing_run_id"),
+  frozenByBillingRunId: uuid("frozen_by_billing_run_id").$type<BillingRunId>(),
 }, (t) => [index("time_entries_matter_idx").on(t.matterId)]);
 
 export const expenses = pgTable("expenses", {

--- a/src/lib/server/repositories/drizzle-matter-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-repository.ts
@@ -6,6 +6,7 @@
  */
 
 import { and, asc, desc, eq, ilike, inArray, isNull, or, sql } from "drizzle-orm";
+import { asId } from "@/lib/shared/schemas/ids";
 import type { Matter, MatterContact } from "@/lib/shared/schemas/matter";
 import { contacts, documents, matterContacts, matters, timeEntries } from "../db/schema";
 import type { AppDb } from "../db/types";
@@ -85,7 +86,7 @@ export class DrizzleMatterRepository extends DrizzleRepository<Matter> implement
       this.db.select({ id: documents.matterId, n: sql<number>`count(*)` }).from(documents)
         .where(and(inArray(documents.matterId, ids), isNull(documents.deletedAt))).groupBy(documents.matterId),
       this.db.select({ id: timeEntries.matterId, n: sql<number>`count(*)` }).from(timeEntries)
-        .where(and(inArray(timeEntries.matterId, ids), isNull(timeEntries.deletedAt))).groupBy(timeEntries.matterId),
+        .where(and(inArray(timeEntries.matterId, ids.map((i) => asId<"MatterId">(i))), isNull(timeEntries.deletedAt))).groupBy(timeEntries.matterId),
       this.db.select({ id: matterContacts.matterId, n: sql<number>`count(*)` }).from(matterContacts)
         .where(and(inArray(matterContacts.matterId, ids), isNull(matterContacts.deletedAt))).groupBy(matterContacts.matterId),
     ]);

--- a/src/lib/server/repositories/drizzle-time-entry-repository.ts
+++ b/src/lib/server/repositories/drizzle-time-entry-repository.ts
@@ -1,10 +1,17 @@
 /**
  * Drizzle `TimeEntryRepository` (ADR 0020) — server-impl. Ärver bas-CRUD;
  * `listUnbilled` joinar users för timtaxan, `flagBilled` bulk-sätter invoiceId.
+ *
+ * `timeEntries`-kolumnerna är brandade (#562) → `select({ te: timeEntries })` bär
+ * branded id:n och projektionernas \`...r.te\`-spread är typad (ingen \`as object\`).
+ * Query-params brandas vid gränsen med \`asId\` (en typad tag, inte en dubbel-cast).
+ * Kvarvarande \`as string\`/\`as Date\` på join-fälten är enkla narrowing-castar av
+ * leftJoin-nullbara select-värden, inte \`as unknown as\`.
  */
 
 import { and, asc, desc, eq, gte, inArray, isNull, lte, sql } from "drizzle-orm";
 import type { TimeEntry } from "@/lib/shared/schemas/billing";
+import { asId } from "@/lib/shared/schemas/ids";
 import { matters, timeEntries, users } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
@@ -18,8 +25,8 @@ function listWhere(organizationId: string, opts: TimeEntryListFilter) {
   return and(
     eq(matters.organizationId, organizationId),
     isNull(timeEntries.deletedAt),
-    opts.matterId ? eq(timeEntries.matterId, opts.matterId) : undefined,
-    opts.userId ? eq(timeEntries.userId, opts.userId) : undefined,
+    opts.matterId ? eq(timeEntries.matterId, asId<"MatterId">(opts.matterId)) : undefined,
+    opts.userId ? eq(timeEntries.userId, asId<"UserId">(opts.userId)) : undefined,
     opts.from ? gte(timeEntries.date, opts.from) : undefined,
     opts.to ? lte(timeEntries.date, opts.to) : undefined,
   );
@@ -44,12 +51,12 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
       .select({ total: sql<number>`count(*)`, sum: sql<number>`coalesce(sum(${timeEntries.minutes}), 0)` })
       .from(timeEntries).innerJoin(matters, eq(timeEntries.matterId, matters.id)).where(where);
     return {
-      entries: rows.map((r) => ({
-        ...(r.te as object),
-        user: r.uId ? { id: r.uId, name: r.uName as string } : null,
-        matter: { id: r.mId, matterNumber: r.mNum as string, title: r.mTitle as string },
+      entries: rows.map((r): TimeEntryListRow => ({
+        ...r.te,
+        user: r.uId ? { id: r.uId, name: r.uName ?? "" } : null,
+        matter: { id: r.mId, matterNumber: r.mNum, title: r.mTitle },
         invoice: null,
-      })) as unknown as TimeEntryListRow[],
+      })),
       total: Number(agg?.total ?? 0),
       totalMinutes: Number(agg?.sum ?? 0),
     };
@@ -59,9 +66,9 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
     const rows = await this.db
       .select({ te: timeEntries }).from(timeEntries)
       .innerJoin(matters, eq(timeEntries.matterId, matters.id))
-      .where(and(eq(timeEntries.id, id), eq(matters.organizationId, organizationId), isNull(timeEntries.deletedAt)))
+      .where(and(eq(timeEntries.id, asId<"TimeEntryId">(id)), eq(matters.organizationId, organizationId), isNull(timeEntries.deletedAt)))
       .limit(1);
-    return this.asRow(rows[0]?.te);
+    return rows[0]?.te ?? null;
   }
 
   async listForReport(organizationId: string, filter: TimeEntryReportFilter): Promise<TimeEntryReportRow[]> {
@@ -79,20 +86,20 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
         isNull(timeEntries.deletedAt),
         gte(timeEntries.date, filter.from),
         lte(timeEntries.date, filter.to),
-        filter.matterId ? eq(timeEntries.matterId, filter.matterId) : undefined,
+        filter.matterId ? eq(timeEntries.matterId, asId<"MatterId">(filter.matterId)) : undefined,
         filter.userIds && filter.userIds.length > 0
-          ? inArray(timeEntries.userId, filter.userIds)
-          : filter.userId ? eq(timeEntries.userId, filter.userId) : undefined,
+          ? inArray(timeEntries.userId, filter.userIds.map((u) => asId<"UserId">(u)))
+          : filter.userId ? eq(timeEntries.userId, asId<"UserId">(filter.userId)) : undefined,
       ))
       .orderBy(asc(timeEntries.userId), asc(timeEntries.date));
-    return rows.map((r) => ({
-      ...(r.te as object),
-      user: { id: r.uId as string, name: r.uName as string },
+    return rows.map((r): TimeEntryReportRow => ({
+      ...r.te,
+      user: { id: r.uId ?? "", name: r.uName ?? "" },
       matter: {
-        id: r.mId, matterNumber: r.mNum as string, title: r.mTitle as string,
-        contacts: r.klient ? [{ contact: { name: r.klient as string } }] : [],
+        id: r.mId, matterNumber: r.mNum, title: r.mTitle,
+        contacts: r.klient ? [{ contact: { name: r.klient } }] : [],
       },
-    })) as unknown as TimeEntryReportRow[];
+    }));
   }
 
   async listUnbilled(matterId: string, ids: string[]): Promise<UnbilledTimeEntry[]> {
@@ -100,23 +107,24 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
     const rows = await this.db
       .select({ te: timeEntries, hourlyRate: users.hourlyRate }).from(timeEntries)
       .innerJoin(users, eq(timeEntries.userId, users.id))
-      .where(and(inArray(timeEntries.id, ids), eq(timeEntries.matterId, matterId), isNull(timeEntries.invoiceId)));
-    return rows.map((r) => ({
-      ...(r.te as object), user: { hourlyRate: r.hourlyRate },
-    })) as unknown as UnbilledTimeEntry[];
+      .where(and(inArray(timeEntries.id, ids.map((i) => asId<"TimeEntryId">(i))), eq(timeEntries.matterId, asId<"MatterId">(matterId)), isNull(timeEntries.invoiceId)));
+    return rows.map((r): UnbilledTimeEntry => ({
+      ...r.te, user: { hourlyRate: r.hourlyRate },
+    }));
   }
 
   async flagBilled(ids: string[], invoiceId: string): Promise<void> {
     if (!ids.length) return;
-    await this.db.update(timeEntries).set({ invoiceId } as never).where(inArray(timeEntries.id, ids));
+    await this.db.update(timeEntries).set({ invoiceId: asId<"InvoiceId">(invoiceId) })
+      .where(inArray(timeEntries.id, ids.map((i) => asId<"TimeEntryId">(i))));
   }
 
   async listUnfrozenForMatter(matterId: string): Promise<TimeEntry[]> {
     const rows = await this.db
       .select().from(timeEntries)
-      .where(and(eq(timeEntries.matterId, matterId), isNull(timeEntries.frozenByBillingRunId), isNull(timeEntries.deletedAt)))
+      .where(and(eq(timeEntries.matterId, asId<"MatterId">(matterId)), isNull(timeEntries.frozenByBillingRunId), isNull(timeEntries.deletedAt)))
       .orderBy(asc(timeEntries.date));
-    return this.asRows(rows);
+    return rows;
   }
 
   async listForLawyerInPeriod(
@@ -133,19 +141,19 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
       .from(timeEntries)
       .innerJoin(matters, eq(timeEntries.matterId, matters.id))
       .where(and(
-        eq(matters.organizationId, organizationId), eq(timeEntries.userId, userId),
+        eq(matters.organizationId, organizationId), eq(timeEntries.userId, asId<"UserId">(userId)),
         gte(timeEntries.date, from), lte(timeEntries.date, to), isNull(timeEntries.deletedAt),
       ))
       .orderBy(asc(timeEntries.date));
-    return rows.map((r) => ({
-      ...(r.te as object),
+    return rows.map((r): LawyerReportTimeEntry => ({
+      ...r.te,
       matter: {
-        id: r.mId as string, matterNumber: r.mNum as string, title: r.mTitle as string,
-        paymentMethod: r.mPay as string, paymentMethodNote: (r.mNote as string | null) ?? null,
-        paymentMethodDecidedAt: (r.mDecided as Date | null) ?? null,
-        contacts: r.klient ? [{ contact: { name: r.klient as string } }] : [],
+        id: r.mId, matterNumber: r.mNum, title: r.mTitle,
+        paymentMethod: r.mPay, paymentMethodNote: r.mNote ?? null,
+        paymentMethodDecidedAt: r.mDecided ?? null,
+        contacts: r.klient ? [{ contact: { name: r.klient } }] : [],
       },
-    })) as unknown as LawyerReportTimeEntry[];
+    }));
   }
 
   async listBillableForOrg(organizationId: string): Promise<TimeEntry[]> {
@@ -153,12 +161,12 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
       .select({ te: timeEntries }).from(timeEntries)
       .innerJoin(matters, eq(timeEntries.matterId, matters.id))
       .where(and(eq(matters.organizationId, organizationId), eq(timeEntries.billable, true), isNull(timeEntries.deletedAt)));
-    return rows.map((r) => r.te) as unknown as TimeEntry[];
+    return rows.map((r) => r.te);
   }
 
   async freezeForMatter(matterId: string, billingRunId: string, now: Date): Promise<void> {
     await this.db.update(timeEntries)
-      .set({ frozenAt: now, frozenByBillingRunId: billingRunId } as never)
-      .where(and(eq(timeEntries.matterId, matterId), isNull(timeEntries.frozenByBillingRunId)));
+      .set({ frozenAt: now, frozenByBillingRunId: asId<"BillingRunId">(billingRunId) })
+      .where(and(eq(timeEntries.matterId, asId<"MatterId">(matterId)), isNull(timeEntries.frozenByBillingRunId)));
   }
 }


### PR DESCRIPTION
Del 7 av PR-serien (#562). Första **projektions-vertikalen** (kategori A+B) — mallen för resten av kärn-entiteterna.

## Ändringar
- Brandar `timeEntries`-kolumnerna (id/userId/matterId/invoiceId/frozenByBillingRunId).
- Alla **5** `as unknown as` i `drizzle-time-entry-repository` försvinner:
  - Projektionerna byter `...(r.te as object)` (typ-radering!) mot `...r.te` (typad efter branding) + explicit map-callback-typ (`(r): TimeEntryListRow => …`).
  - `listBillableForOrg` returnerar `rows.map(r => r.te)` direkt.
- Query-params brandas vid gränsen med `asId` (en typad tag, **inte** en `as unknown as`-dubbel-cast). Join-villkor är kolumn-kolumn → orörda.
- Bonus: `.set({…} as never)` → typade `.set({ invoiceId: asId(…) })`; join-fält-castar ersatta med `?? ""` / borttagna (text-notNull-kolumner är redan `string`).
- Kaskad (1 ställe): `matter-repository` `inArray(timeEntries.matterId, ids)` brandar ids.

## Verifierat
Ren `tsc --noEmit` (tsbuildinfo rensad) + lint + 110 repo-tester (pglite). Repository (Postgres)-jobbet kör SQL:en.

Refs #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)