### PR TITLE
refactor(types): branda serviceNotes/tasks/documentTemplates

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -104,11 +104,6 @@
       "count": 3
     }
   },
-  "src/lib/server/repositories/drizzle-document-template-repository.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "src/lib/server/repositories/drizzle-invoice-dispatch-repository.ts": {
     "no-restricted-syntax": {
       "count": 1
@@ -145,16 +140,6 @@
     }
   },
   "src/lib/server/repositories/drizzle-repositories.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "src/lib/server/repositories/drizzle-service-note-repository.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "src/lib/server/repositories/drizzle-task-repository.ts": {
     "no-restricted-syntax": {
       "count": 1
     }

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -13,10 +13,11 @@
 
 import { relations } from "drizzle-orm";
 import { bigint, bigserial, index, integer, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import type { TaskPriority, TaskStatus } from "@/lib/shared/schemas/calendar";
 import type { ExpenseKind, ReminderType } from "@/lib/shared/schemas/enums";
 import type {
-  BillingRunId, ExpenseId, InvoiceId, MatterId, PaymentId, PaymentPlanId, PaymentPlanReminderId,
-  TimeEntryId, UserId, WriteOffId,
+  BillingRunId, DocumentTemplateId, ExpenseId, InvoiceId, MatterId, OrganizationId, PaymentId,
+  PaymentPlanId, PaymentPlanReminderId, ServiceNoteId, TaskId, TimeEntryId, UserId, WriteOffId,
 } from "@/lib/shared/schemas/ids";
 import { baseColumns, boolDefault, orgScopedColumns } from "./columns";
 
@@ -345,22 +346,26 @@ export const calendarEvents = pgTable("calendar_events", {
 
 export const tasks = pgTable("tasks", {
   ...orgScopedColumns,
-  userId: uuid("user_id").notNull(),
+  id: uuid("id").primaryKey().$type<TaskId>(),
+  organizationId: uuid("organization_id").notNull().$type<OrganizationId>(),
+  userId: uuid("user_id").notNull().$type<UserId>(),
   title: text("title").notNull(),
   description: text("description"),
-  status: text("status").notNull().default("TODO"),
-  priority: text("priority").notNull().default("MEDIUM"),
+  status: text("status").notNull().default("TODO").$type<TaskStatus>(),
+  priority: text("priority").notNull().default("MEDIUM").$type<TaskPriority>(),
   dueAt: timestamp("due_at", { withTimezone: true }),
   completedAt: timestamp("completed_at", { withTimezone: true }),
-  matterId: uuid("matter_id"),
+  matterId: uuid("matter_id").$type<MatterId>(),
 }, (t) => [index("tasks_user_idx").on(t.userId)]);
 
 // ─── Tjänsteanteckning / Preferenser / Mallar / Jävssök ──────────────────────
 
 export const serviceNotes = pgTable("service_notes", {
   ...orgScopedColumns,
-  matterId: uuid("matter_id").notNull(),
-  authorId: uuid("author_id").notNull(),
+  id: uuid("id").primaryKey().$type<ServiceNoteId>(),
+  organizationId: uuid("organization_id").notNull().$type<OrganizationId>(),
+  matterId: uuid("matter_id").notNull().$type<MatterId>(),
+  authorId: uuid("author_id").notNull().$type<UserId>(),
   date: text("date").notNull(),
   time: text("time").notNull(),
   text: text("text").notNull(),
@@ -383,11 +388,13 @@ export const orgPreferences = pgTable("org_preferences", {
 
 export const documentTemplates = pgTable("document_templates", {
   ...orgScopedColumns,
+  id: uuid("id").primaryKey().$type<DocumentTemplateId>(),
+  organizationId: uuid("organization_id").notNull().$type<OrganizationId>(),
   name: text("name").notNull(),
   description: text("description"),
   category: text("category"),
   content: text("content").notNull(),
-  createdById: uuid("created_by_id").notNull(),
+  createdById: uuid("created_by_id").notNull().$type<UserId>(),
 });
 
 export const conflictChecks = pgTable("conflict_checks", {

--- a/src/lib/server/repositories/drizzle-document-template-repository.ts
+++ b/src/lib/server/repositories/drizzle-document-template-repository.ts
@@ -4,6 +4,7 @@
  */
 
 import { and, asc, eq, isNull } from "drizzle-orm";
+import { asId } from "@/lib/shared/schemas/ids";
 import type { DocumentTemplate } from "@/lib/shared/schemas/misc";
 import { documentTemplates, users } from "../db/schema";
 import type { AppDb } from "../db/types";
@@ -29,13 +30,13 @@ export class DrizzleDocumentTemplateRepository
       })
       .from(documentTemplates)
       .leftJoin(users, eq(documentTemplates.createdById, users.id))
-      .where(and(eq(documentTemplates.organizationId, organizationId), isNull(documentTemplates.deletedAt)))
+      .where(and(eq(documentTemplates.organizationId, asId<"OrganizationId">(organizationId)), isNull(documentTemplates.deletedAt)))
       .orderBy(asc(documentTemplates.category), asc(documentTemplates.name));
-    return rows.map((r) => ({
-      id: r.id as string, name: r.name as string,
-      description: (r.description as string | null) ?? null, category: (r.category as string | null) ?? null,
-      createdAt: r.createdAt as Date, updatedAt: (r.updatedAt as Date | null) ?? null,
-      createdBy: r.cbName ? { name: r.cbName as string } : null,
+    return rows.map((r): DocumentTemplateListRow => ({
+      id: r.id, name: r.name,
+      description: r.description ?? null, category: r.category ?? null,
+      createdAt: r.createdAt, updatedAt: r.updatedAt ?? null,
+      createdBy: r.cbName ? { name: r.cbName } : null,
     }));
   }
 
@@ -43,9 +44,10 @@ export class DrizzleDocumentTemplateRepository
     const rows = await this.db
       .select({ tpl: documentTemplates, cbName: users.name }).from(documentTemplates)
       .leftJoin(users, eq(documentTemplates.createdById, users.id))
-      .where(and(eq(documentTemplates.id, id), eq(documentTemplates.organizationId, organizationId), isNull(documentTemplates.deletedAt)))
+      .where(and(eq(documentTemplates.id, asId<"DocumentTemplateId">(id)), eq(documentTemplates.organizationId, asId<"OrganizationId">(organizationId)), isNull(documentTemplates.deletedAt)))
       .limit(1);
-    if (!rows[0]) return null;
-    return { ...(rows[0].tpl as object), createdBy: rows[0].cbName ? { name: rows[0].cbName as string } : null } as unknown as DocumentTemplateRow;
+    const row = rows[0];
+    if (!row) return null;
+    return { ...row.tpl, createdBy: row.cbName ? { name: row.cbName } : null };
   }
 }

--- a/src/lib/server/repositories/drizzle-service-note-repository.ts
+++ b/src/lib/server/repositories/drizzle-service-note-repository.ts
@@ -4,6 +4,7 @@
  */
 
 import { and, desc, eq, isNull } from "drizzle-orm";
+import { asId } from "@/lib/shared/schemas/ids";
 import type { ServiceNote } from "@/lib/shared/schemas/service-note";
 import { matters, serviceNotes, users } from "../db/schema";
 import type { AppDb } from "../db/types";
@@ -21,23 +22,23 @@ export class DrizzleServiceNoteRepository extends DrizzleRepository<ServiceNote>
       .innerJoin(matters, eq(serviceNotes.matterId, matters.id))
       .leftJoin(users, eq(serviceNotes.authorId, users.id))
       .where(and(
-        eq(serviceNotes.matterId, matterId),
+        eq(serviceNotes.matterId, asId<"MatterId">(matterId)),
         eq(matters.organizationId, organizationId),
         isNull(serviceNotes.deletedAt),
       ))
       .orderBy(desc(serviceNotes.createdAt));
-    return rows.map((r) => ({
-      ...(r.note as object),
-      author: r.aId ? { id: r.aId, name: r.aName as string } : null,
-    })) as unknown as ServiceNoteRow[];
+    return rows.map((r): ServiceNoteRow => ({
+      ...r.note,
+      author: r.aId ? { id: r.aId, name: r.aName ?? "" } : null,
+    }));
   }
 
   async getByIdInOrg(id: string, organizationId: string): Promise<ServiceNote | null> {
     const rows = await this.db
       .select({ note: serviceNotes }).from(serviceNotes)
       .innerJoin(matters, eq(serviceNotes.matterId, matters.id))
-      .where(and(eq(serviceNotes.id, id), eq(matters.organizationId, organizationId), isNull(serviceNotes.deletedAt)))
+      .where(and(eq(serviceNotes.id, asId<"ServiceNoteId">(id)), eq(matters.organizationId, organizationId), isNull(serviceNotes.deletedAt)))
       .limit(1);
-    return this.asRow(rows[0]?.note);
+    return rows[0]?.note ?? null;
   }
 }

--- a/src/lib/server/repositories/drizzle-task-repository.ts
+++ b/src/lib/server/repositories/drizzle-task-repository.ts
@@ -5,6 +5,7 @@
 
 import { and, asc, eq, isNull } from "drizzle-orm";
 import type { Task } from "@/lib/shared/schemas/calendar";
+import { asId } from "@/lib/shared/schemas/ids";
 import { matters, tasks } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
@@ -24,25 +25,26 @@ export class DrizzleTaskRepository extends DrizzleRepository<Task> implements Ta
       .from(tasks)
       .leftJoin(matters, eq(tasks.matterId, matters.id))
       .where(and(
-        eq(tasks.userId, userId),
-        eq(tasks.organizationId, organizationId),
+        eq(tasks.userId, asId<"UserId">(userId)),
+        eq(tasks.organizationId, asId<"OrganizationId">(organizationId)),
         isNull(tasks.deletedAt),
         filter.status ? eq(tasks.status, filter.status) : undefined,
-        filter.matterId ? eq(tasks.matterId, filter.matterId) : undefined,
+        filter.matterId ? eq(tasks.matterId, asId<"MatterId">(filter.matterId)) : undefined,
       ))
       .orderBy(asc(tasks.dueAt));
-    return rows.map((r) => ({
-      ...(r.t as object),
-      matter: r.mId ? { id: r.mId, matterNumber: r.mNum as string, title: r.mTitle as string } : null,
-    })) as unknown as TaskListRow[];
+    return rows.map((r): TaskListRow => ({
+      ...r.t,
+      matter: r.mId ? { id: r.mId, matterNumber: r.mNum ?? "", title: r.mTitle ?? "" } : null,
+    }));
   }
 
   async getOwned(id: string, userId: string, organizationId: string): Promise<Task | null> {
     const rows = await this.db
       .select().from(tasks)
       .where(and(
-        eq(tasks.id, id), eq(tasks.userId, userId), eq(tasks.organizationId, organizationId), isNull(tasks.deletedAt),
+        eq(tasks.id, asId<"TaskId">(id)), eq(tasks.userId, asId<"UserId">(userId)),
+        eq(tasks.organizationId, asId<"OrganizationId">(organizationId)), isNull(tasks.deletedAt),
       )).limit(1);
-    return this.asRow(rows[0]);
+    return rows[0] ?? null;
   }
 }

--- a/src/lib/server/repositories/task-repository.ts
+++ b/src/lib/server/repositories/task-repository.ts
@@ -5,7 +5,7 @@
  * ägarskaps-vakten (id + userId + organizationId).
  */
 
-import type { Task } from "@/lib/shared/schemas/calendar";
+import type { Task, TaskStatus } from "@/lib/shared/schemas/calendar";
 import type { Repository } from "./types";
 
 /** Task + ärende-subsetet listvyn visar. */
@@ -15,7 +15,7 @@ export interface TaskListRow extends Task {
 
 /** Filter för `listForUser`. */
 export interface TaskListFilter {
-  status?: string | undefined;
+  status?: TaskStatus | undefined;
   matterId?: string | undefined;
 }
 


### PR DESCRIPTION
Del 10 av #562 — tre enkla projektions-entiteter (samma mönster som time/expense).

- **serviceNotes**: id/organizationId/matterId/authorId brandade.
- **tasks**: id/organizationId/userId/matterId + enum-kolumnerna `status` (TaskStatus) & `priority` (TaskPriority). `TaskListFilter.status` typad till `TaskStatus` (routern skickar redan zod-parsad enum).
- **documentTemplates**: id/organizationId/createdById brandade.
- Projektionerna: `...(r.X as object)` → `...r.X` + explicit map-callback; `asId` på query-params; `asRow` → direkt retur.

3 `as unknown as` bort. Baseline 299 → 296. Ren tsc + `lint --max-warnings 0` + 110 repo-tester gröna.

Refs #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)