### PR TITLE
refactor(types): branda calendarEvents + conflictChecks

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -74,16 +74,6 @@
       "count": 2
     }
   },
-  "src/lib/server/repositories/drizzle-calendar-event-repository.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "src/lib/server/repositories/drizzle-conflict-check-repository.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "src/lib/server/repositories/drizzle-contact-repository.ts": {
     "no-restricted-syntax": {
       "count": 2

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -13,11 +13,14 @@
 
 import { relations } from "drizzle-orm";
 import { bigint, bigserial, index, integer, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
-import type { TaskPriority, TaskStatus } from "@/lib/shared/schemas/calendar";
+import type {
+  CalendarEventKind, CalendarEventVisibility, TaskPriority, TaskStatus,
+} from "@/lib/shared/schemas/calendar";
 import type { ExpenseKind, ReminderType } from "@/lib/shared/schemas/enums";
 import type {
-  BillingRunId, DocumentTemplateId, ExpenseId, InvoiceId, MatterId, OrganizationId, PaymentId,
-  PaymentPlanId, PaymentPlanReminderId, ServiceNoteId, TaskId, TimeEntryId, UserId, WriteOffId,
+  BillingRunId, CalendarEventId, ConflictCheckId, DocumentTemplateId, ExpenseId, InvoiceId,
+  MatterId, OrganizationId, PaymentId, PaymentPlanId, PaymentPlanReminderId, ServiceNoteId,
+  TaskId, TimeEntryId, UserId, WriteOffId,
 } from "@/lib/shared/schemas/ids";
 import { baseColumns, boolDefault, orgScopedColumns } from "./columns";
 
@@ -326,20 +329,22 @@ export const matterEventSuggestions = pgTable("matter_event_suggestions", {
 
 export const calendarEvents = pgTable("calendar_events", {
   ...orgScopedColumns,
-  userId: uuid("user_id").notNull(),
-  kind: text("kind").notNull().default("appointment"),
+  id: uuid("id").primaryKey().$type<CalendarEventId>(),
+  organizationId: uuid("organization_id").notNull().$type<OrganizationId>(),
+  userId: uuid("user_id").notNull().$type<UserId>(),
+  kind: text("kind").notNull().default("appointment").$type<CalendarEventKind>(),
   title: text("title").notNull(),
   description: text("description"),
   location: text("location"),
   startAt: timestamp("start_at", { withTimezone: true }).notNull(),
   endAt: timestamp("end_at", { withTimezone: true }),
   allDay: boolDefault("all_day", false),
-  matterId: uuid("matter_id"),
-  visibility: text("visibility").notNull().default("normal"),
+  matterId: uuid("matter_id").$type<MatterId>(),
+  visibility: text("visibility").notNull().default("normal").$type<CalendarEventVisibility>(),
   mirrorToOutlook: boolDefault("mirror_to_outlook", false),
   outlookEventId: text("outlook_event_id"),
   outlookCalendarId: text("outlook_calendar_id"),
-  mirrorStatus: text("mirror_status"),
+  mirrorStatus: text("mirror_status").$type<"pending" | "synced" | "failed">(),
   mirrorError: text("mirror_error"),
   mirrorLastSyncedAt: timestamp("mirror_last_synced_at", { withTimezone: true }),
 }, (t) => [index("calendar_events_user_idx").on(t.userId)]);
@@ -399,10 +404,11 @@ export const documentTemplates = pgTable("document_templates", {
 
 export const conflictChecks = pgTable("conflict_checks", {
   ...baseColumns,
+  id: uuid("id").primaryKey().$type<ConflictCheckId>(),
   searchTerm: text("search_term").notNull(),
-  searchType: text("search_type").notNull(),
-  results: jsonb("results").notNull().default([]),
-  checkedById: uuid("checked_by_id").notNull(),
+  searchType: text("search_type").notNull().$type<"name" | "personalNumber" | "both">(),
+  results: jsonb("results").notNull().default([]).$type<unknown[]>(),
+  checkedById: uuid("checked_by_id").notNull().$type<UserId>(),
 });
 
 // ─── Relations (ADR 0020) — driver Drizzles relationella `with`-queries för

--- a/src/lib/server/repositories/drizzle-calendar-event-repository.ts
+++ b/src/lib/server/repositories/drizzle-calendar-event-repository.ts
@@ -5,6 +5,7 @@
 
 import { and, asc, eq, inArray, isNull } from "drizzle-orm";
 import type { CalendarEvent } from "@/lib/shared/schemas/calendar";
+import { asId } from "@/lib/shared/schemas/ids";
 import { calendarEvents, matters } from "../db/schema";
 import type { AppDb } from "../db/types";
 import type { CalendarEventRepository, CalendarEventRow } from "./calendar-event-repository";
@@ -12,11 +13,11 @@ import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 
 type MatterCols = { mId: string | null; mNum: string | null; mTitle: string | null };
 
-function withMatter<T extends MatterCols & { ev: unknown }>(r: T): CalendarEventRow {
+function withMatter(r: MatterCols & { ev: typeof calendarEvents.$inferSelect }): CalendarEventRow {
   return {
-    ...(r.ev as object),
-    matter: r.mId ? { id: r.mId, matterNumber: r.mNum as string, title: r.mTitle as string } : null,
-  } as unknown as CalendarEventRow;
+    ...r.ev,
+    matter: r.mId ? { id: r.mId, matterNumber: r.mNum ?? "", title: r.mTitle ?? "" } : null,
+  };
 }
 
 export class DrizzleCalendarEventRepository extends DrizzleRepository<CalendarEvent> implements CalendarEventRepository {
@@ -35,7 +36,7 @@ export class DrizzleCalendarEventRepository extends DrizzleRepository<CalendarEv
     const rows = await this.db
       .select(this.matterSelect()).from(calendarEvents)
       .leftJoin(matters, eq(calendarEvents.matterId, matters.id))
-      .where(and(eq(calendarEvents.userId, userId), eq(calendarEvents.organizationId, organizationId), isNull(calendarEvents.deletedAt)))
+      .where(and(eq(calendarEvents.userId, asId<"UserId">(userId)), eq(calendarEvents.organizationId, asId<"OrganizationId">(organizationId)), isNull(calendarEvents.deletedAt)))
       .orderBy(asc(calendarEvents.startAt));
     return rows.map(withMatter);
   }
@@ -45,7 +46,7 @@ export class DrizzleCalendarEventRepository extends DrizzleRepository<CalendarEv
     const rows = await this.db
       .select(this.matterSelect()).from(calendarEvents)
       .leftJoin(matters, eq(calendarEvents.matterId, matters.id))
-      .where(and(eq(calendarEvents.organizationId, organizationId), inArray(calendarEvents.userId, userIds), isNull(calendarEvents.deletedAt)))
+      .where(and(eq(calendarEvents.organizationId, asId<"OrganizationId">(organizationId)), inArray(calendarEvents.userId, userIds.map((u) => asId<"UserId">(u))), isNull(calendarEvents.deletedAt)))
       .orderBy(asc(calendarEvents.startAt));
     return rows.map(withMatter);
   }
@@ -53,24 +54,24 @@ export class DrizzleCalendarEventRepository extends DrizzleRepository<CalendarEv
   async listForMatter(matterId: string, organizationId: string): Promise<CalendarEvent[]> {
     const rows = await this.db
       .select().from(calendarEvents)
-      .where(and(eq(calendarEvents.matterId, matterId), eq(calendarEvents.organizationId, organizationId), isNull(calendarEvents.deletedAt)))
+      .where(and(eq(calendarEvents.matterId, asId<"MatterId">(matterId)), eq(calendarEvents.organizationId, asId<"OrganizationId">(organizationId)), isNull(calendarEvents.deletedAt)))
       .orderBy(asc(calendarEvents.startAt));
-    return this.asRows(rows);
+    return rows;
   }
 
   async getOwned(id: string, userId: string, organizationId: string): Promise<CalendarEvent | null> {
     const rows = await this.db
       .select().from(calendarEvents)
-      .where(and(eq(calendarEvents.id, id), eq(calendarEvents.userId, userId), eq(calendarEvents.organizationId, organizationId), isNull(calendarEvents.deletedAt)))
+      .where(and(eq(calendarEvents.id, asId<"CalendarEventId">(id)), eq(calendarEvents.userId, asId<"UserId">(userId)), eq(calendarEvents.organizationId, asId<"OrganizationId">(organizationId)), isNull(calendarEvents.deletedAt)))
       .limit(1);
-    return this.asRow(rows[0]);
+    return rows[0] ?? null;
   }
 
   async getOwnedWithMatter(id: string, userId: string, organizationId: string): Promise<CalendarEventRow | null> {
     const rows = await this.db
       .select(this.matterSelect()).from(calendarEvents)
       .leftJoin(matters, eq(calendarEvents.matterId, matters.id))
-      .where(and(eq(calendarEvents.id, id), eq(calendarEvents.userId, userId), eq(calendarEvents.organizationId, organizationId), isNull(calendarEvents.deletedAt)))
+      .where(and(eq(calendarEvents.id, asId<"CalendarEventId">(id)), eq(calendarEvents.userId, asId<"UserId">(userId)), eq(calendarEvents.organizationId, asId<"OrganizationId">(organizationId)), isNull(calendarEvents.deletedAt)))
       .limit(1);
     return rows[0] ? withMatter(rows[0]) : null;
   }

--- a/src/lib/server/repositories/drizzle-conflict-check-repository.ts
+++ b/src/lib/server/repositories/drizzle-conflict-check-repository.ts
@@ -25,10 +25,10 @@ export class DrizzleConflictCheckRepository
       .limit(pageSize).offset((page - 1) * pageSize);
     const [agg] = await this.db.select({ total: sql<number>`count(*)` }).from(conflictChecks);
     return {
-      checks: rows.map((r) => ({
-        ...(r.chk as object),
-        checkedBy: r.cbName ? { name: r.cbName as string } : null,
-      })) as unknown as ConflictCheckRow[],
+      checks: rows.map((r): ConflictCheckRow => ({
+        ...r.chk,
+        checkedBy: r.cbName ? { name: r.cbName } : null,
+      })),
       total: Number(agg?.total ?? 0),
     };
   }


### PR DESCRIPTION
Del 11 av #562.

- **calendarEvents**: id/organizationId/userId/matterId + enum-kolumnerna `kind` (CalendarEventKind), `visibility` (CalendarEventVisibility), `mirrorStatus`. `withMatter` typas mot `calendarEvents.$inferSelect` → `...r.ev` utan `as object`/`as unknown as`.
- **conflictChecks**: id/checkedById + `searchType`-enum + `results` jsonb (`.$type<unknown[]>()`).
- `asId` på query-params; `asRow`/`asRows` → direkt retur. Baseline 296 → 294.

2 `as unknown as` bort. Ren tsc + `lint --max-warnings 0` + 165 tester gröna.

Refs #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)