### PR TITLE
refactor(types): branda invoiceDispatches + matterEventSuggestions

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -94,11 +94,6 @@
       "count": 3
     }
   },
-  "src/lib/server/repositories/drizzle-invoice-dispatch-repository.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "src/lib/server/repositories/drizzle-invoice-repository.ts": {
     "no-restricted-syntax": {
       "count": 5
@@ -107,11 +102,6 @@
   "src/lib/server/repositories/drizzle-matter-contact-repository.ts": {
     "no-restricted-syntax": {
       "count": 2
-    }
-  },
-  "src/lib/server/repositories/drizzle-matter-event-suggestion-repository.ts": {
-    "no-restricted-syntax": {
-      "count": 1
     }
   },
   "src/lib/server/repositories/drizzle-matter-repository.ts": {

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -13,14 +13,15 @@
 
 import { relations } from "drizzle-orm";
 import { bigint, bigserial, index, integer, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import type { DispatchChannel, DispatchStatus } from "@/lib/shared/schemas/billing";
 import type {
   CalendarEventKind, CalendarEventVisibility, TaskPriority, TaskStatus,
 } from "@/lib/shared/schemas/calendar";
-import type { ExpenseKind, ReminderType } from "@/lib/shared/schemas/enums";
+import type { ExpenseKind, ReminderType, SuggestionStatus } from "@/lib/shared/schemas/enums";
 import type {
-  BillingRunId, CalendarEventId, ConflictCheckId, DocumentTemplateId, ExpenseId, InvoiceId,
-  MatterId, OrganizationId, PaymentId, PaymentPlanId, PaymentPlanReminderId, ServiceNoteId,
-  TaskId, TimeEntryId, UserId, WriteOffId,
+  BillingRunId, CalendarEventId, ConflictCheckId, DocumentId, DocumentTemplateId, ExpenseId,
+  InvoiceDispatchId, InvoiceId, MatterEventSuggestionId, MatterId, OrganizationId, PaymentId,
+  PaymentPlanId, PaymentPlanReminderId, ServiceNoteId, TaskId, TimeEntryId, UserId, WriteOffId,
 } from "@/lib/shared/schemas/ids";
 import { baseColumns, boolDefault, orgScopedColumns } from "./columns";
 
@@ -200,17 +201,18 @@ export const writeOffs = pgTable("write_offs", {
 
 export const invoiceDispatches = pgTable("invoice_dispatches", {
   ...baseColumns,
-  invoiceId: uuid("invoice_id").notNull(),
-  channel: text("channel").notNull(),
+  id: uuid("id").primaryKey().$type<InvoiceDispatchId>(),
+  invoiceId: uuid("invoice_id").notNull().$type<InvoiceId>(),
+  channel: text("channel").notNull().$type<DispatchChannel>(),
   recipient: text("recipient").notNull(),
-  status: text("status").notNull().default("queued"),
+  status: text("status").notNull().default("queued").$type<DispatchStatus>(),
   queuedAt: timestamp("queued_at", { withTimezone: true }).notNull(),
   sentAt: timestamp("sent_at", { withTimezone: true }),
   deliveredAt: timestamp("delivered_at", { withTimezone: true }),
   failedAt: timestamp("failed_at", { withTimezone: true }),
   messageId: text("message_id"),
   error: text("error"),
-  recordedById: uuid("recorded_by_id").notNull(),
+  recordedById: uuid("recorded_by_id").notNull().$type<UserId>(),
 }, (t) => [index("invoice_dispatches_invoice_idx").on(t.invoiceId)]);
 
 export const paymentPlans = pgTable("payment_plans", {
@@ -314,7 +316,8 @@ export const documentAnalysisSuggestions = pgTable("document_analysis_suggestion
 
 export const matterEventSuggestions = pgTable("matter_event_suggestions", {
   ...baseColumns,
-  documentId: uuid("document_id").notNull(),
+  id: uuid("id").primaryKey().$type<MatterEventSuggestionId>(),
+  documentId: uuid("document_id").notNull().$type<DocumentId>(),
   title: text("title").notNull(),
   description: text("description"),
   eventType: text("event_type"),
@@ -322,7 +325,7 @@ export const matterEventSuggestions = pgTable("matter_event_suggestions", {
   endAt: timestamp("end_at", { withTimezone: true }),
   allDay: boolDefault("all_day", false),
   location: text("location"),
-  status: text("status").notNull().default("PENDING"),
+  status: text("status").notNull().default("PENDING").$type<SuggestionStatus>(),
 }, (t) => [index("matter_event_suggestions_doc_idx").on(t.documentId)]);
 
 // ─── Kalender / Task ─────────────────────────────────────────────────────────

--- a/src/lib/server/repositories/drizzle-invoice-dispatch-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-dispatch-repository.ts
@@ -5,6 +5,7 @@
 
 import { and, asc, desc, eq, isNull } from "drizzle-orm";
 import type { InvoiceDispatch } from "@/lib/shared/schemas/billing";
+import { asId } from "@/lib/shared/schemas/ids";
 import { invoiceDispatches, invoices, matters } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
@@ -20,9 +21,9 @@ export class DrizzleInvoiceDispatchRepository
   async listByInvoice(invoiceId: string): Promise<InvoiceDispatch[]> {
     const rows = await this.db
       .select().from(invoiceDispatches)
-      .where(and(eq(invoiceDispatches.invoiceId, invoiceId), isNull(invoiceDispatches.deletedAt)))
+      .where(and(eq(invoiceDispatches.invoiceId, asId<"InvoiceId">(invoiceId)), isNull(invoiceDispatches.deletedAt)))
       .orderBy(desc(invoiceDispatches.queuedAt));
-    return this.asRows(rows);
+    return rows;
   }
 
   async listQueuedForOrg(organizationId: string): Promise<InvoiceDispatchQueuedRow[]> {
@@ -41,9 +42,9 @@ export class DrizzleInvoiceDispatchRepository
         isNull(invoiceDispatches.deletedAt),
       ))
       .orderBy(asc(invoiceDispatches.queuedAt));
-    return rows.map((r) => ({
-      ...(r.d as object),
-      invoice: { id: r.iId, invoiceNumber: r.iNum, amount: r.iAmount as number, ocrReference: r.iOcr, dueDate: r.iDue },
-    })) as unknown as InvoiceDispatchQueuedRow[];
+    return rows.map((r): InvoiceDispatchQueuedRow => ({
+      ...r.d,
+      invoice: { id: r.iId, invoiceNumber: r.iNum, amount: r.iAmount, ocrReference: r.iOcr, dueDate: r.iDue },
+    }));
   }
 }

--- a/src/lib/server/repositories/drizzle-matter-event-suggestion-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-event-suggestion-repository.ts
@@ -5,6 +5,7 @@
 
 import { and, asc, eq, isNull, ne } from "drizzle-orm";
 import type { MatterEventSuggestion } from "@/lib/shared/schemas/document";
+import { asId } from "@/lib/shared/schemas/ids";
 import { documents, matterEventSuggestions, matters } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
@@ -35,10 +36,10 @@ export class DrizzleMatterEventSuggestionRepository
         isNull(matterEventSuggestions.deletedAt),
       ))
       .orderBy(asc(matterEventSuggestions.startAt));
-    return rows.map((r) => ({
-      ...(r.ev as object),
-      document: { id: r.dId as string, fileName: r.dFile as string, title: (r.dTitle as string | null) ?? null },
-    })) as unknown as MatterEventSuggestionRow[];
+    return rows.map((r): MatterEventSuggestionRow => ({
+      ...r.ev,
+      document: { id: r.dId, fileName: r.dFile, title: r.dTitle ?? null },
+    }));
   }
 
   async getByIdInOrg(id: string, organizationId: string): Promise<MatterEventSuggestion | null> {
@@ -47,11 +48,11 @@ export class DrizzleMatterEventSuggestionRepository
       .innerJoin(documents, eq(matterEventSuggestions.documentId, documents.id))
       .innerJoin(matters, eq(documents.matterId, matters.id))
       .where(and(
-        eq(matterEventSuggestions.id, id),
+        eq(matterEventSuggestions.id, asId<"MatterEventSuggestionId">(id)),
         eq(matters.organizationId, organizationId),
         isNull(matterEventSuggestions.deletedAt),
       ))
       .limit(1);
-    return this.asRow(rows[0]?.ev);
+    return rows[0]?.ev ?? null;
   }
 }


### PR DESCRIPTION
Del 12 av #562.

- **invoiceDispatches**: id/invoiceId/recordedById + enum-kolumnerna `channel` (DispatchChannel) & `status` (DispatchStatus).
- **matterEventSuggestions**: id/documentId + `status` (SuggestionStatus).
- Projektionerna: `...(r.X as object)` → `...r.X` + explicit map-callback; `asId` på query-params; `asRow`/`asRows` → direkt retur.

2 `as unknown as` bort. Baseline 294 → 292. Ren tsc + `lint --max-warnings 0` + 110 repo-tester gröna.

Refs #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)