### PR TITLE
refactor(types): branda billingRuns + typa projektionerna

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -69,11 +69,6 @@
       "count": 1
     }
   },
-  "src/lib/server/repositories/drizzle-billing-run-repository.ts": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
   "src/lib/server/repositories/drizzle-contact-repository.ts": {
     "no-restricted-syntax": {
       "count": 2

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -17,7 +17,9 @@ import type { DispatchChannel, DispatchStatus } from "@/lib/shared/schemas/billi
 import type {
   CalendarEventKind, CalendarEventVisibility, TaskPriority, TaskStatus,
 } from "@/lib/shared/schemas/calendar";
-import type { ExpenseKind, ReminderType, SuggestionStatus } from "@/lib/shared/schemas/enums";
+import type {
+  BillingRunRecipient, BillingRunStatus, BillingRunType, ExpenseKind, ReminderType, SuggestionStatus,
+} from "@/lib/shared/schemas/enums";
 import type {
   BillingRunId, CalendarEventId, ConflictCheckId, DocumentId, DocumentTemplateId, ExpenseId,
   InvoiceDispatchId, InvoiceId, MatterEventSuggestionId, MatterId, OrganizationId, PaymentId,
@@ -242,17 +244,18 @@ export const accontoDeductions = pgTable("acconto_deductions", {
 
 export const billingRuns = pgTable("billing_runs", {
   ...baseColumns,
-  matterId: uuid("matter_id").notNull(),
-  type: text("type").notNull(),
-  recipient: text("recipient").notNull(),
-  status: text("status").notNull().default("DRAFT"),
+  id: uuid("id").primaryKey().$type<BillingRunId>(),
+  matterId: uuid("matter_id").notNull().$type<MatterId>(),
+  type: text("type").notNull().$type<BillingRunType>(),
+  recipient: text("recipient").notNull().$type<BillingRunRecipient>(),
+  status: text("status").notNull().default("DRAFT").$type<BillingRunStatus>(),
   workValueOreAtRun: ore("work_value_ore_at_run").notNull(),
   clientShareBips: integer("client_share_bips"),
   proposedAmountOre: ore("proposed_amount_ore").notNull(),
   amountOre: ore("amount_ore").notNull(),
   prutningOre: ore("prutning_ore"),
-  invoiceId: uuid("invoice_id"),
-  deductedBillingRunIds: jsonb("deducted_billing_run_ids").notNull().default([]),
+  invoiceId: uuid("invoice_id").$type<InvoiceId>(),
+  deductedBillingRunIds: jsonb("deducted_billing_run_ids").notNull().default([]).$type<BillingRunId[]>(),
   periodFrom: timestamp("period_from", { withTimezone: true }),
   periodTo: timestamp("period_to", { withTimezone: true }),
   notes: text("notes"),

--- a/src/lib/server/repositories/drizzle-billing-run-repository.ts
+++ b/src/lib/server/repositories/drizzle-billing-run-repository.ts
@@ -5,6 +5,7 @@
 
 import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 import type { BillingRun } from "@/lib/shared/schemas/billing";
+import { asId } from "@/lib/shared/schemas/ids";
 import { billingRuns, invoices, matters } from "../db/schema";
 import type { AppDb } from "../db/types";
 import type {
@@ -30,14 +31,14 @@ export class DrizzleBillingRunRepository
       .leftJoin(invoices, eq(billingRuns.invoiceId, invoices.id))
       .where(and(
         eq(matters.organizationId, organizationId),
-        matterId ? eq(billingRuns.matterId, matterId) : undefined,
+        matterId ? eq(billingRuns.matterId, asId<"MatterId">(matterId)) : undefined,
         isNull(billingRuns.deletedAt),
       ))
       .orderBy(desc(billingRuns.createdAt));
-    return rows.map((r) => ({
-      ...(r.run as object),
+    return rows.map((r): BillingRunListRow => ({
+      ...r.run,
       invoice: r.invId ? { id: r.invId, invoiceNumber: r.invNum, status: r.invStatus as string } : null,
-    })) as unknown as BillingRunListRow[];
+    }));
   }
 
   async getByIdInOrg(id: string, organizationId: string): Promise<BillingRunDetailRow | null> {
@@ -50,29 +51,29 @@ export class DrizzleBillingRunRepository
       .from(billingRuns)
       .innerJoin(matters, eq(billingRuns.matterId, matters.id))
       .leftJoin(invoices, eq(billingRuns.invoiceId, invoices.id))
-      .where(and(eq(billingRuns.id, id), eq(matters.organizationId, organizationId), isNull(billingRuns.deletedAt)))
+      .where(and(eq(billingRuns.id, asId<"BillingRunId">(id)), eq(matters.organizationId, organizationId), isNull(billingRuns.deletedAt)))
       .limit(1);
     const r = rows[0];
     if (!r) return null;
     return {
-      ...(r.run as object),
+      ...r.run,
       invoice: r.invId
         ? { id: r.invId, invoiceNumber: r.invNum, status: r.invStatus as string, amount: Number(r.invAmount ?? 0) }
         : null,
       matter: r.mId
-        ? { id: r.mId, matterNumber: r.mNum as string, title: r.mTitle as string, paymentMethod: (r.mPay as string | null) ?? null }
+        ? { id: r.mId, matterNumber: r.mNum, title: r.mTitle, paymentMethod: r.mPay ?? null }
         : null,
-    } as unknown as BillingRunDetailRow;
+    };
   }
 
   async listAccontoSent(matterId: string): Promise<BillingRun[]> {
     const rows = await this.db
       .select().from(billingRuns)
       .where(and(
-        eq(billingRuns.matterId, matterId), eq(billingRuns.type, "ACCONTO"),
+        eq(billingRuns.matterId, asId<"MatterId">(matterId)), eq(billingRuns.type, "ACCONTO"),
         eq(billingRuns.status, "SENT"), isNull(billingRuns.deletedAt),
       ));
-    return this.asRows(rows);
+    return rows;
   }
 
   async listAccontoByIds(matterId: string, ids: string[]): Promise<BillingRun[]> {
@@ -80,9 +81,9 @@ export class DrizzleBillingRunRepository
     const rows = await this.db
       .select().from(billingRuns)
       .where(and(
-        inArray(billingRuns.id, ids), eq(billingRuns.matterId, matterId),
+        inArray(billingRuns.id, ids.map((i) => asId<"BillingRunId">(i))), eq(billingRuns.matterId, asId<"MatterId">(matterId)),
         eq(billingRuns.type, "ACCONTO"), isNull(billingRuns.deletedAt),
       ));
-    return this.asRows(rows);
+    return rows;
   }
 }


### PR DESCRIPTION
Del 13 av #562 (Fas 2).

- **billingRuns**: id/matterId/invoiceId + enum-kolumnerna `type` (BillingRunType), `recipient` (BillingRunRecipient), `status` (BillingRunStatus) + jsonb `deductedBillingRunIds` (`.$type<BillingRunId[]>()`).
- Båda projektionerna byter `...(r.run as object)` → `...r.run` + explicit retur-typ; `asId` på query-params; `asRows` → direkt retur. Faktura-fältets leftJoin-nullbara `status` narrowas med enkel `as string` (ej dubbel-cast).

2 `as unknown as` bort. Baseline 292 → 290. Ren tsc + `lint --max-warnings 0` + 142 tester gröna.

Refs #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)