### PR TITLE
refactor(types): branda documents + documentFolders

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -74,16 +74,6 @@
       "count": 2
     }
   },
-  "src/lib/server/repositories/drizzle-document-folder-repository.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "src/lib/server/repositories/drizzle-document-repository.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "src/lib/server/repositories/drizzle-document-suggestion-repository.ts": {
     "no-restricted-syntax": {
       "count": 3

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -21,9 +21,10 @@ import type {
   BillingRunRecipient, BillingRunStatus, BillingRunType, ExpenseKind, ReminderType, SuggestionStatus,
 } from "@/lib/shared/schemas/enums";
 import type {
-  BillingRunId, CalendarEventId, ConflictCheckId, DocumentId, DocumentTemplateId, ExpenseId,
-  InvoiceDispatchId, InvoiceId, MatterEventSuggestionId, MatterId, OrganizationId, PaymentId,
-  PaymentPlanId, PaymentPlanReminderId, ServiceNoteId, TaskId, TimeEntryId, UserId, WriteOffId,
+  BillingRunId, CalendarEventId, ConflictCheckId, DocumentFolderId, DocumentId, DocumentTemplateId,
+  ExpenseId, InvoiceDispatchId, InvoiceId, MatterEventSuggestionId, MatterId, OrganizationId,
+  PaymentId, PaymentPlanId, PaymentPlanReminderId, ServiceNoteId, TaskId, TimeEntryId, UserId,
+  WriteOffId,
 } from "@/lib/shared/schemas/ids";
 import { baseColumns, boolDefault, orgScopedColumns } from "./columns";
 
@@ -277,27 +278,29 @@ export const expectedReceivables = pgTable("expected_receivables", {
 
 export const documentFolders = pgTable("document_folders", {
   ...baseColumns,
+  id: uuid("id").primaryKey().$type<DocumentFolderId>(),
   name: text("name").notNull(),
-  matterId: uuid("matter_id").notNull(),
-  parentId: uuid("parent_id"),
+  matterId: uuid("matter_id").notNull().$type<MatterId>(),
+  parentId: uuid("parent_id").$type<DocumentFolderId>(),
 }, (t) => [index("document_folders_matter_idx").on(t.matterId)]);
 
 export const documents = pgTable("documents", {
   ...baseColumns,
-  matterId: uuid("matter_id").notNull(),
+  id: uuid("id").primaryKey().$type<DocumentId>(),
+  matterId: uuid("matter_id").notNull().$type<MatterId>(),
   /** Valfri faktura-koppling (#397: genererade faktura-dokument). */
-  invoiceId: uuid("invoice_id"),
-  folderId: uuid("folder_id"),
+  invoiceId: uuid("invoice_id").$type<InvoiceId>(),
+  folderId: uuid("folder_id").$type<DocumentFolderId>(),
   fileName: text("file_name").notNull(),
   mimeType: text("mime_type").notNull(),
   sizeBytes: bigint("size_bytes", { mode: "number" }).notNull(),
   storagePath: text("storage_path").notNull(),
-  uploadedById: uuid("uploaded_by_id").notNull(),
+  uploadedById: uuid("uploaded_by_id").notNull().$type<UserId>(),
   title: text("title"),
   documentType: text("document_type"),
   summary: text("summary"),
   analyzedAt: timestamp("analyzed_at", { withTimezone: true }),
-  analysisStatus: text("analysis_status"),
+  analysisStatus: text("analysis_status").$type<"PENDING" | "RUNNING" | "DONE" | "ERROR">(),
   analysisModel: text("analysis_model"),
   analysisError: text("analysis_error"),
 }, (t) => [index("documents_matter_idx").on(t.matterId)]);

--- a/src/lib/server/repositories/drizzle-document-folder-repository.ts
+++ b/src/lib/server/repositories/drizzle-document-folder-repository.ts
@@ -5,6 +5,7 @@
 
 import { and, asc, eq, inArray, isNull, sql } from "drizzle-orm";
 import type { DocumentFolder } from "@/lib/shared/schemas/document";
+import { asId } from "@/lib/shared/schemas/ids";
 import { documentFolders, documents } from "../db/schema";
 import type { AppDb } from "../db/types";
 import type {
@@ -15,7 +16,7 @@ import { matterOrg } from "./matter-org";
 
 /** documentFolders.parentId = X, eller IS NULL för rot. */
 function parentEq(parentId: string | null) {
-  return parentId === null ? isNull(documentFolders.parentId) : eq(documentFolders.parentId, parentId);
+  return parentId === null ? isNull(documentFolders.parentId) : eq(documentFolders.parentId, asId<"DocumentFolderId">(parentId));
 }
 
 export class DrizzleDocumentFolderRepository
@@ -33,15 +34,14 @@ export class DrizzleDocumentFolderRepository
   async listInParent(matterId: string, parentId: string | null): Promise<DocumentFolderWithCounts[]> {
     const rows = await this.db
       .select().from(documentFolders)
-      .where(and(eq(documentFolders.matterId, matterId), parentEq(parentId), isNull(documentFolders.deletedAt)))
+      .where(and(eq(documentFolders.matterId, asId<"MatterId">(matterId)), parentEq(parentId), isNull(documentFolders.deletedAt)))
       .orderBy(asc(documentFolders.name));
-    const ids = rows.map((r) => (r as { id: string }).id);
+    const ids = rows.map((r) => r.id);
     // Grupperade count-queries (robustare än korrelerade subqueries, jfr #).
     const counts = await this.countsFor(ids);
-    return rows.map((r) => {
-      const id = (r as { id: string }).id;
-      return { ...(r as object), _count: counts.get(id) ?? { documents: 0, children: 0 } };
-    }) as unknown as DocumentFolderWithCounts[];
+    return rows.map((r): DocumentFolderWithCounts => ({
+      ...r, _count: counts.get(r.id) ?? { documents: 0, children: 0 },
+    }));
   }
 
   private async countsFor(folderIds: string[]): Promise<Map<string, { documents: number; children: number }>> {
@@ -49,28 +49,29 @@ export class DrizzleDocumentFolderRepository
     if (folderIds.length === 0) return out;
     const docRows = await this.db
       .select({ id: documents.folderId, n: sql<number>`count(*)` }).from(documents)
-      .where(and(inArray(documents.folderId, folderIds), isNull(documents.deletedAt)))
+      .where(and(inArray(documents.folderId, folderIds.map((i) => asId<"DocumentFolderId">(i))), isNull(documents.deletedAt)))
       .groupBy(documents.folderId);
     const childRows = await this.db
       .select({ id: documentFolders.parentId, n: sql<number>`count(*)` }).from(documentFolders)
-      .where(and(inArray(documentFolders.parentId, folderIds), isNull(documentFolders.deletedAt)))
+      .where(and(inArray(documentFolders.parentId, folderIds.map((i) => asId<"DocumentFolderId">(i))), isNull(documentFolders.deletedAt)))
       .groupBy(documentFolders.parentId);
     for (const id of folderIds) out.set(id, { documents: 0, children: 0 });
-    for (const r of docRows) if (r.id) out.get(r.id as string)!.documents = Number(r.n);
-    for (const r of childRows) if (r.id) out.get(r.id as string)!.children = Number(r.n);
+    for (const r of docRows) if (r.id) out.get(r.id)!.documents = Number(r.n);
+    for (const r of childRows) if (r.id) out.get(r.id)!.children = Number(r.n);
     return out;
   }
 
   async listByMatter(matterId: string): Promise<DocumentFolder[]> {
     const rows = await this.db
       .select().from(documentFolders)
-      .where(and(eq(documentFolders.matterId, matterId), isNull(documentFolders.deletedAt)))
+      .where(and(eq(documentFolders.matterId, asId<"MatterId">(matterId)), isNull(documentFolders.deletedAt)))
       .orderBy(asc(documentFolders.name));
-    return this.asRows(rows);
+    return rows;
   }
 
   async reassignParent(fromParentId: string, toParentId: string | null): Promise<void> {
     await this.db.update(documentFolders)
-      .set({ parentId: toParentId } as never).where(eq(documentFolders.parentId, fromParentId));
+      .set({ parentId: toParentId === null ? null : asId<"DocumentFolderId">(toParentId) })
+      .where(eq(documentFolders.parentId, asId<"DocumentFolderId">(fromParentId)));
   }
 }

--- a/src/lib/server/repositories/drizzle-document-repository.ts
+++ b/src/lib/server/repositories/drizzle-document-repository.ts
@@ -5,6 +5,7 @@
 
 import { and, desc, eq, isNull, sql } from "drizzle-orm";
 import type { Document } from "@/lib/shared/schemas/document";
+import { asId } from "@/lib/shared/schemas/ids";
 import { documents, matters, users } from "../db/schema";
 import type { AppDb } from "../db/types";
 import type {
@@ -15,14 +16,14 @@ import { matterOrg } from "./matter-org";
 
 /** documents.folderId = X, eller IS NULL för rot. */
 function folderEq(folderId: string | null) {
-  return folderId === null ? isNull(documents.folderId) : eq(documents.folderId, folderId);
+  return folderId === null ? isNull(documents.folderId) : eq(documents.folderId, asId<"DocumentFolderId">(folderId));
 }
 
-function toListRow(r: { doc: unknown; ubName: unknown }): DocumentListRow {
+function toListRow(r: { doc: typeof documents.$inferSelect; ubName: string | null }): DocumentListRow {
   return {
-    ...(r.doc as object),
-    uploadedBy: r.ubName ? { name: r.ubName as string } : null,
-  } as unknown as DocumentListRow;
+    ...r.doc,
+    uploadedBy: r.ubName ? { name: r.ubName } : null,
+  };
 }
 
 export class DrizzleDocumentRepository
@@ -40,7 +41,7 @@ export class DrizzleDocumentRepository
   async listInFolder(
     matterId: string, folderId: string | null, page: number, pageSize: number,
   ): Promise<{ documents: DocumentListRow[]; total: number }> {
-    const where = and(eq(documents.matterId, matterId), folderEq(folderId), isNull(documents.deletedAt));
+    const where = and(eq(documents.matterId, asId<"MatterId">(matterId)), folderEq(folderId), isNull(documents.deletedAt));
     const rows = await this.db
       .select({ doc: documents, ubName: users.name }).from(documents)
       .leftJoin(users, eq(documents.uploadedById, users.id))
@@ -55,7 +56,7 @@ export class DrizzleDocumentRepository
     const rows = await this.db
       .select({ doc: documents, ubName: users.name }).from(documents)
       .leftJoin(users, eq(documents.uploadedById, users.id))
-      .where(and(eq(documents.matterId, matterId), isNull(documents.deletedAt)))
+      .where(and(eq(documents.matterId, asId<"MatterId">(matterId)), isNull(documents.deletedAt)))
       .orderBy(desc(documents.createdAt));
     return rows.map(toListRow);
   }
@@ -76,14 +77,15 @@ export class DrizzleDocumentRepository
     const rows = await this.db
       .select({ id: documents.id, matterId: documents.matterId }).from(documents)
       .innerJoin(matters, eq(documents.matterId, matters.id))
-      .where(and(eq(documents.id, id), eq(matters.organizationId, organizationId), isNull(documents.deletedAt)))
+      .where(and(eq(documents.id, asId<"DocumentId">(id)), eq(matters.organizationId, organizationId), isNull(documents.deletedAt)))
       .limit(1);
     const row = rows[0];
-    return row ? { id: row.id as string, matterId: row.matterId as string } : null;
+    return row ? { id: row.id, matterId: row.matterId } : null;
   }
 
   async reassignFolder(fromFolderId: string, toFolderId: string | null): Promise<void> {
     await this.db.update(documents)
-      .set({ folderId: toFolderId } as never).where(eq(documents.folderId, fromFolderId));
+      .set({ folderId: toFolderId === null ? null : asId<"DocumentFolderId">(toFolderId) })
+      .where(eq(documents.folderId, asId<"DocumentFolderId">(fromFolderId)));
   }
 }

--- a/src/lib/server/repositories/drizzle-document-suggestion-repository.ts
+++ b/src/lib/server/repositories/drizzle-document-suggestion-repository.ts
@@ -5,6 +5,7 @@
 
 import { and, asc, desc, eq, inArray, isNull } from "drizzle-orm";
 import type { DocumentAnalysisSuggestion } from "@/lib/shared/schemas/document";
+import { asId } from "@/lib/shared/schemas/ids";
 import { documentAnalysisSuggestions, documents, matters } from "../db/schema";
 import type { AppDb } from "../db/types";
 import type {
@@ -38,7 +39,7 @@ export class DrizzleDocumentSuggestionRepository
       .innerJoin(documents, eq(S.documentId, documents.id))
       .innerJoin(matters, eq(documents.matterId, matters.id))
       .where(and(
-        eq(S.status, "PENDING"), eq(documents.matterId, matterId),
+        eq(S.status, "PENDING"), eq(documents.matterId, asId<"MatterId">(matterId)),
         eq(matters.organizationId, organizationId), isNull(S.deletedAt),
       ))
       .orderBy(order === "asc" ? asc(S.createdAt) : desc(S.createdAt));

--- a/src/lib/server/repositories/drizzle-matter-event-suggestion-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-event-suggestion-repository.ts
@@ -30,7 +30,7 @@ export class DrizzleMatterEventSuggestionRepository
       .innerJoin(documents, eq(matterEventSuggestions.documentId, documents.id))
       .innerJoin(matters, eq(documents.matterId, matters.id))
       .where(and(
-        eq(documents.matterId, matterId),
+        eq(documents.matterId, asId<"MatterId">(matterId)),
         eq(matters.organizationId, organizationId),
         ne(matterEventSuggestions.status, "REJECTED"),
         isNull(matterEventSuggestions.deletedAt),

--- a/src/lib/server/repositories/drizzle-matter-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-repository.ts
@@ -84,7 +84,7 @@ export class DrizzleMatterRepository extends DrizzleRepository<Matter> implement
     };
     const [docs, tes, mcs] = await Promise.all([
       this.db.select({ id: documents.matterId, n: sql<number>`count(*)` }).from(documents)
-        .where(and(inArray(documents.matterId, ids), isNull(documents.deletedAt))).groupBy(documents.matterId),
+        .where(and(inArray(documents.matterId, ids.map((i) => asId<"MatterId">(i))), isNull(documents.deletedAt))).groupBy(documents.matterId),
       this.db.select({ id: timeEntries.matterId, n: sql<number>`count(*)` }).from(timeEntries)
         .where(and(inArray(timeEntries.matterId, ids.map((i) => asId<"MatterId">(i))), isNull(timeEntries.deletedAt))).groupBy(timeEntries.matterId),
       this.db.select({ id: matterContacts.matterId, n: sql<number>`count(*)` }).from(matterContacts)


### PR DESCRIPTION
Del 14 av #562 (Fas 2).

- **documents**: id/matterId/invoiceId/folderId/uploadedById + enum-kolumnen `analysisStatus`. `toListRow` typas mot `documents.$inferSelect`.
- **documentFolders**: id/matterId/parentId. `listInParent`-projektionen (+ `_count`) typad; `countsFor` brandar inArray-ids.
- Kaskad (3 ställen): matter-repo, matter-event-suggestion, document-suggestion brandar `documents.matterId`-params med `asId`.
- `.set({…} as never)` → typade null-säkra set.

2 `as unknown as` bort. Baseline 290 → 288. Ren tsc + `lint --max-warnings 0` + 110 repo-tester gröna.

Refs #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)