### PR TITLE
refactor(types): branda contacts + matterContacts (kontakt-vertikalen)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -69,11 +69,6 @@
       "count": 1
     }
   },
-  "src/lib/server/repositories/drizzle-contact-repository.ts": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
   "src/lib/server/repositories/drizzle-document-suggestion-repository.ts": {
     "no-restricted-syntax": {
       "count": 3
@@ -82,11 +77,6 @@
   "src/lib/server/repositories/drizzle-invoice-repository.ts": {
     "no-restricted-syntax": {
       "count": 5
-    }
-  },
-  "src/lib/server/repositories/drizzle-matter-contact-repository.ts": {
-    "no-restricted-syntax": {
-      "count": 2
     }
   },
   "src/lib/server/repositories/drizzle-matter-repository.ts": {

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -18,13 +18,14 @@ import type {
   CalendarEventKind, CalendarEventVisibility, TaskPriority, TaskStatus,
 } from "@/lib/shared/schemas/calendar";
 import type {
-  BillingRunRecipient, BillingRunStatus, BillingRunType, ExpenseKind, ReminderType, SuggestionStatus,
+  BillingRunRecipient, BillingRunStatus, BillingRunType, ContactType, ExpenseKind, MatterRole,
+  ReminderType, SuggestionStatus,
 } from "@/lib/shared/schemas/enums";
 import type {
-  BillingRunId, CalendarEventId, ConflictCheckId, DocumentFolderId, DocumentId, DocumentTemplateId,
-  ExpenseId, InvoiceDispatchId, InvoiceId, MatterEventSuggestionId, MatterId, OrganizationId,
-  PaymentId, PaymentPlanId, PaymentPlanReminderId, ServiceNoteId, TaskId, TimeEntryId, UserId,
-  WriteOffId,
+  BillingRunId, CalendarEventId, ConflictCheckId, ContactId, DocumentFolderId, DocumentId,
+  DocumentTemplateId, ExpenseId, InvoiceDispatchId, InvoiceId, MatterContactId, MatterEventSuggestionId,
+  MatterId, OrganizationId, PaymentId, PaymentPlanId, PaymentPlanReminderId, ServiceNoteId, TaskId,
+  TimeEntryId, UserId, WriteOffId,
 } from "@/lib/shared/schemas/ids";
 import { baseColumns, boolDefault, orgScopedColumns } from "./columns";
 
@@ -72,15 +73,17 @@ export const users = pgTable("users", {
 
 export const contacts = pgTable("contacts", {
   ...orgScopedColumns,
+  id: uuid("id").primaryKey().$type<ContactId>(),
+  organizationId: uuid("organization_id").notNull().$type<OrganizationId>(),
   name: text("name").notNull(),
-  contactType: text("contact_type").notNull().default("PERSON"),
+  contactType: text("contact_type").notNull().default("PERSON").$type<ContactType>(),
   personalNumber: text("personal_number"),
   orgNumber: text("org_number"),
   email: text("email"),
   phone: text("phone"),
   address: text("address"),
   notes: text("notes"),
-  parentId: uuid("parent_id"),
+  parentId: uuid("parent_id").$type<ContactId>(),
 }, (t) => [index("contacts_org_idx").on(t.organizationId)]);
 
 export const matters = pgTable("matters", {
@@ -111,9 +114,10 @@ export const matters = pgTable("matters", {
  */
 export const matterContacts = pgTable("matter_contacts", {
   ...baseColumns,
-  matterId: uuid("matter_id").notNull(),
-  contactId: uuid("contact_id").notNull(),
-  role: text("role").notNull(),
+  id: uuid("id").primaryKey().$type<MatterContactId>(),
+  matterId: uuid("matter_id").notNull().$type<MatterId>(),
+  contactId: uuid("contact_id").notNull().$type<ContactId>(),
+  role: text("role").notNull().$type<MatterRole>(),
   notes: text("notes"),
 }, (t) => [index("matter_contacts_matter_idx").on(t.matterId)]);
 

--- a/src/lib/server/repositories/contact-repository.ts
+++ b/src/lib/server/repositories/contact-repository.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Contact } from "@/lib/shared/schemas/contact";
+import type { ContactType } from "@/lib/shared/schemas/enums";
 import type { Repository } from "./types";
 
 /** Kontakt + antal relationer (listvyns _count). */
@@ -34,7 +35,7 @@ export interface ContactFull extends Contact {
 /** Filter/paginering för `listForOrg`. */
 export interface ContactListOptions {
   search?: string | undefined;
-  contactType?: string | undefined;
+  contactType?: ContactType | undefined;
   page: number;
   pageSize: number;
 }

--- a/src/lib/server/repositories/drizzle-contact-repository.ts
+++ b/src/lib/server/repositories/drizzle-contact-repository.ts
@@ -7,6 +7,7 @@
 import { and, asc, desc, eq, ilike, inArray, isNull, like, or, sql } from "drizzle-orm";
 import type { PgColumn, PgTable } from "drizzle-orm/pg-core";
 import type { Contact } from "@/lib/shared/schemas/contact";
+import { asId } from "@/lib/shared/schemas/ids";
 import { contacts, matterContacts, matters } from "../db/schema";
 import type { AppDb } from "../db/types";
 import type {
@@ -21,7 +22,7 @@ export class DrizzleContactRepository extends DrizzleRepository<Contact> impleme
 
   async listForOrg(organizationId: string, opts: ContactListOptions): Promise<ContactListResult> {
     const where = and(
-      eq(contacts.organizationId, organizationId),
+      eq(contacts.organizationId, asId<"OrganizationId">(organizationId)),
       isNull(contacts.parentId), // bara topp-nivå
       isNull(contacts.deletedAt),
       opts.contactType ? eq(contacts.contactType, opts.contactType) : undefined,
@@ -42,17 +43,14 @@ export class DrizzleContactRepository extends DrizzleRepository<Contact> impleme
     const [{ total } = { total: 0 }] = await this.db
       .select({ total: sql<number>`count(*)` }).from(contacts).where(where);
     // _count via grupperade frågor över sidans ids (robustare än korrelerade subqueries).
-    const ids = rows.map((r) => (r as { id: string }).id);
+    const ids = rows.map((r) => r.id);
     const linkCounts = await this.countBy(matterContacts, matterContacts.contactId, ids);
     const childCounts = await this.countBy(contacts, contacts.parentId, ids);
     return {
-      contacts: rows.map((r) => {
-        const id = (r as { id: string }).id;
-        return {
-          ...(r as object),
-          _count: { matterLinks: linkCounts.get(id) ?? 0, children: childCounts.get(id) ?? 0 },
-        };
-      }) as unknown as ContactListRow[],
+      contacts: rows.map((r): ContactListRow => ({
+        ...r,
+        _count: { matterLinks: linkCounts.get(r.id) ?? 0, children: childCounts.get(r.id) ?? 0 },
+      })),
       total: Number(total),
     };
   }
@@ -71,13 +69,13 @@ export class DrizzleContactRepository extends DrizzleRepository<Contact> impleme
   async getByIdFull(id: string, organizationId: string): Promise<ContactFull | null> {
     const [c] = await this.db
       .select().from(contacts)
-      .where(and(eq(contacts.id, id), eq(contacts.organizationId, organizationId), isNull(contacts.deletedAt)))
+      .where(and(eq(contacts.id, asId<"ContactId">(id)), eq(contacts.organizationId, asId<"OrganizationId">(organizationId)), isNull(contacts.deletedAt)))
       .limit(1);
     if (!c) return null;
     const children = await this.db
       .select().from(contacts)
-      .where(and(eq(contacts.parentId, id), isNull(contacts.deletedAt))).orderBy(asc(contacts.name));
-    const parentId = (c as { parentId?: string | null }).parentId;
+      .where(and(eq(contacts.parentId, asId<"ContactId">(id)), isNull(contacts.deletedAt))).orderBy(asc(contacts.name));
+    const parentId = c.parentId;
     const parentRows = parentId
       ? await this.db.select({ id: contacts.id, name: contacts.name }).from(contacts).where(eq(contacts.id, parentId)).limit(1)
       : [];
@@ -88,29 +86,29 @@ export class DrizzleContactRepository extends DrizzleRepository<Contact> impleme
       })
       .from(matterContacts)
       .innerJoin(matters, eq(matterContacts.matterId, matters.id)) // matterId NOT NULL FK → matter finns alltid
-      .where(eq(matterContacts.contactId, id))
+      .where(eq(matterContacts.contactId, asId<"ContactId">(id)))
       .orderBy(desc(matterContacts.createdAt));
     return {
-      ...(c as object),
-      children: this.asRows(children),
-      parent: parentRows[0] ? { id: parentRows[0].id, name: parentRows[0].name as string } : null,
+      ...c,
+      children,
+      parent: parentRows[0] ? { id: parentRows[0].id, name: parentRows[0].name } : null,
       matterLinks: linkRows.map((l) => ({
-        ...(l.mc as object),
-        matter: { id: l.mId, matterNumber: l.mNum as string, title: l.mTitle as string, status: l.mStatus as string },
+        ...l.mc,
+        matter: { id: l.mId, matterNumber: l.mNum, title: l.mTitle, status: l.mStatus },
       })),
-    } as unknown as ContactFull;
+    };
   }
 
   async findByPersonalNumber(organizationId: string, personalNumber: string): Promise<Contact | null> {
     const rows = await this.db.select().from(contacts)
-      .where(and(eq(contacts.organizationId, organizationId), eq(contacts.personalNumber, personalNumber), isNull(contacts.deletedAt)))
+      .where(and(eq(contacts.organizationId, asId<"OrganizationId">(organizationId)), eq(contacts.personalNumber, personalNumber), isNull(contacts.deletedAt)))
       .limit(1);
     return this.asRow(rows[0]);
   }
 
   async findByOrgNumber(organizationId: string, orgNumber: string): Promise<Contact | null> {
     const rows = await this.db.select().from(contacts)
-      .where(and(eq(contacts.organizationId, organizationId), eq(contacts.orgNumber, orgNumber), isNull(contacts.deletedAt)))
+      .where(and(eq(contacts.organizationId, asId<"OrganizationId">(organizationId)), eq(contacts.orgNumber, orgNumber), isNull(contacts.deletedAt)))
       .limit(1);
     return this.asRow(rows[0]);
   }

--- a/src/lib/server/repositories/drizzle-matter-contact-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-contact-repository.ts
@@ -6,6 +6,8 @@
 
 import { and, eq, isNull, or, sql } from "drizzle-orm";
 import type { Contact } from "@/lib/shared/schemas/contact";
+import type { MatterRole } from "@/lib/shared/schemas/enums";
+import { asId } from "@/lib/shared/schemas/ids";
 import type { MatterContact } from "@/lib/shared/schemas/matter";
 import { contacts, matterContacts, matters } from "../db/schema";
 import type { AppDb } from "../db/types";
@@ -57,32 +59,32 @@ export class DrizzleMatterContactRepository
     const rows = await this.db
       .select({ mc: matterContacts }).from(matterContacts)
       .innerJoin(matters, eq(matterContacts.matterId, matters.id))
-      .where(and(eq(matterContacts.id, id), eq(matters.organizationId, organizationId), isNull(matterContacts.deletedAt)))
+      .where(and(eq(matterContacts.id, asId<"MatterContactId">(id)), eq(matters.organizationId, organizationId), isNull(matterContacts.deletedAt)))
       .limit(1);
-    return this.asRow(rows[0]?.mc);
+    return rows[0]?.mc ?? null;
   }
 
   async linkContact(data: Partial<MatterContact>): Promise<MatterContactWithContact> {
     const link = await this.create(data);
     const [contact] = await this.db
-      .select().from(contacts).where(eq(contacts.id, (link as { contactId: string }).contactId)).limit(1);
-    return { ...(link as object), contact: contact as unknown as Contact } as MatterContactWithContact;
+      .select().from(contacts).where(eq(contacts.id, link.contactId)).limit(1);
+    return { ...link, contact: contact as Contact };
   }
 
   async findLink(matterId: string, contactId: string, role: string): Promise<MatterContact | null> {
     const rows = await this.db.select().from(matterContacts)
       .where(and(
-        eq(matterContacts.matterId, matterId), eq(matterContacts.contactId, contactId),
-        eq(matterContacts.role, role), isNull(matterContacts.deletedAt),
+        eq(matterContacts.matterId, asId<"MatterId">(matterId)), eq(matterContacts.contactId, asId<"ContactId">(contactId)),
+        eq(matterContacts.role, role as MatterRole), isNull(matterContacts.deletedAt),
       )).limit(1);
-    return this.asRow(rows[0]);
+    return rows[0] ?? null;
   }
 
   async listContactsForMatter(matterId: string): Promise<Contact[]> {
     const rows = await this.db
       .select({ contact: contacts }).from(matterContacts)
       .innerJoin(contacts, eq(matterContacts.contactId, contacts.id))
-      .where(and(eq(matterContacts.matterId, matterId), isNull(matterContacts.deletedAt)));
-    return rows.map((r) => r.contact as unknown as Contact);
+      .where(and(eq(matterContacts.matterId, asId<"MatterId">(matterId)), isNull(matterContacts.deletedAt)));
+    return rows.map((r) => r.contact);
   }
 }

--- a/src/lib/server/repositories/drizzle-matter-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-repository.ts
@@ -88,7 +88,7 @@ export class DrizzleMatterRepository extends DrizzleRepository<Matter> implement
       this.db.select({ id: timeEntries.matterId, n: sql<number>`count(*)` }).from(timeEntries)
         .where(and(inArray(timeEntries.matterId, ids.map((i) => asId<"MatterId">(i))), isNull(timeEntries.deletedAt))).groupBy(timeEntries.matterId),
       this.db.select({ id: matterContacts.matterId, n: sql<number>`count(*)` }).from(matterContacts)
-        .where(and(inArray(matterContacts.matterId, ids), isNull(matterContacts.deletedAt))).groupBy(matterContacts.matterId),
+        .where(and(inArray(matterContacts.matterId, ids.map((i) => asId<"MatterId">(i))), isNull(matterContacts.deletedAt))).groupBy(matterContacts.matterId),
     ]);
     apply(docs, "documents");
     apply(tes, "timeEntries");
@@ -104,7 +104,7 @@ export class DrizzleMatterRepository extends DrizzleRepository<Matter> implement
       .select({ matterId: matterContacts.matterId, cId: contacts.id, cName: contacts.name })
       .from(matterContacts)
       .innerJoin(contacts, eq(matterContacts.contactId, contacts.id))
-      .where(and(inArray(matterContacts.matterId, ids), eq(matterContacts.role, "KLIENT")));
+      .where(and(inArray(matterContacts.matterId, ids.map((i) => asId<"MatterId">(i))), eq(matterContacts.role, "KLIENT")));
     for (const r of rows) {
       const mid = r.matterId as string;
       if (!out.has(mid)) out.set(mid, { id: r.cId as string, name: r.cName as string });
@@ -119,7 +119,7 @@ export class DrizzleMatterRepository extends DrizzleRepository<Matter> implement
       .select({ mc: matterContacts, contact: contacts })
       .from(matterContacts)
       .innerJoin(contacts, eq(matterContacts.contactId, contacts.id))
-      .where(and(eq(matterContacts.matterId, id), isNull(matterContacts.deletedAt)))
+      .where(and(eq(matterContacts.matterId, asId<"MatterId">(id)), isNull(matterContacts.deletedAt)))
       .orderBy(asc(matterContacts.createdAt));
     const linkContacts = rows.map((r) => ({ ...(r.mc as object), contact: r.contact })) as unknown as MatterContact[];
     const counts = (await this.countsFor([id])).get(id) ?? { documents: 0, timeEntries: 0, contacts: 0 };


### PR DESCRIPTION
Del 15 av #562 (Fas 2) — den tätt kopplade kontakt-vertikalen.

- **contacts**: id/organizationId/parentId + enum `contactType`.
- **matterContacts**: id/matterId/contactId + enum `role` (MatterRole).
- **contact-repo**: `_count`-projektionen + `ContactFull` (children/parent/matterLinks) typas utan `as object`/`as unknown as`; `ContactListOptions.contactType` → `ContactType`.
- **matter-contact-repo**: `linkContact` + `listContactsForMatter` utan cast; `findLink` role narrowas med enkel `as MatterRole`.
- Kaskad: matter-repo brandar `matterContacts.matterId`-params (countsFor/klientFor/getByIdWithContacts).

4 `as unknown as` bort. Baseline 288 → 284. Ren tsc + `lint --max-warnings 0` + 524 repo/router-tester gröna.

Refs #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)