### PR TITLE
refactor(types): branda matters + org-scope-kaskaden

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -79,11 +79,6 @@
       "count": 5
     }
   },
-  "src/lib/server/repositories/drizzle-matter-repository.ts": {
-    "no-restricted-syntax": {
-      "count": 3
-    }
-  },
   "src/lib/server/repositories/drizzle-org-preference-repository.ts": {
     "no-restricted-syntax": {
       "count": 2

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -19,7 +19,7 @@ import type {
 } from "@/lib/shared/schemas/calendar";
 import type {
   BillingRunRecipient, BillingRunStatus, BillingRunType, ContactType, ExpenseKind, MatterRole,
-  ReminderType, SuggestionStatus,
+  MatterStatus, PaymentMethod, ReminderType, SuggestionStatus,
 } from "@/lib/shared/schemas/enums";
 import type {
   BillingRunId, CalendarEventId, ConflictCheckId, ContactId, DocumentFolderId, DocumentId,
@@ -88,14 +88,16 @@ export const contacts = pgTable("contacts", {
 
 export const matters = pgTable("matters", {
   ...orgScopedColumns,
+  id: uuid("id").primaryKey().$type<MatterId>(),
+  organizationId: uuid("organization_id").notNull().$type<OrganizationId>(),
   matterNumber: text("matter_number").notNull(),
-  responsibleLawyerId: uuid("responsible_lawyer_id"),
+  responsibleLawyerId: uuid("responsible_lawyer_id").$type<UserId>(),
   courtCaseNumber: text("court_case_number"),
   title: text("title").notNull(),
   description: text("description"),
-  status: text("status").notNull().default("ACTIVE"),
+  status: text("status").notNull().default("ACTIVE").$type<MatterStatus>(),
   matterType: text("matter_type"),
-  paymentMethod: text("payment_method").notNull().default("PENDING"),
+  paymentMethod: text("payment_method").notNull().default("PENDING").$type<PaymentMethod>(),
   paymentMethodNote: text("payment_method_note"),
   paymentMethodDecidedAt: timestamp("payment_method_decided_at", { withTimezone: true }),
   isTaxeArende: boolDefault("is_taxe_arende", false),

--- a/src/lib/server/repositories/drizzle-billing-run-repository.ts
+++ b/src/lib/server/repositories/drizzle-billing-run-repository.ts
@@ -30,7 +30,7 @@ export class DrizzleBillingRunRepository
       .innerJoin(matters, eq(billingRuns.matterId, matters.id))
       .leftJoin(invoices, eq(billingRuns.invoiceId, invoices.id))
       .where(and(
-        eq(matters.organizationId, organizationId),
+        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
         matterId ? eq(billingRuns.matterId, asId<"MatterId">(matterId)) : undefined,
         isNull(billingRuns.deletedAt),
       ))
@@ -51,7 +51,7 @@ export class DrizzleBillingRunRepository
       .from(billingRuns)
       .innerJoin(matters, eq(billingRuns.matterId, matters.id))
       .leftJoin(invoices, eq(billingRuns.invoiceId, invoices.id))
-      .where(and(eq(billingRuns.id, asId<"BillingRunId">(id)), eq(matters.organizationId, organizationId), isNull(billingRuns.deletedAt)))
+      .where(and(eq(billingRuns.id, asId<"BillingRunId">(id)), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(billingRuns.deletedAt)))
       .limit(1);
     const r = rows[0];
     if (!r) return null;

--- a/src/lib/server/repositories/drizzle-document-repository.ts
+++ b/src/lib/server/repositories/drizzle-document-repository.ts
@@ -65,7 +65,7 @@ export class DrizzleDocumentRepository
     const rows = await this.db
       .select({ type: documents.documentType, count: sql<number>`count(*)` })
       .from(documents).innerJoin(matters, eq(documents.matterId, matters.id))
-      .where(and(eq(matters.organizationId, organizationId), isNull(documents.deletedAt)))
+      .where(and(eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(documents.deletedAt)))
       .groupBy(documents.documentType);
     return rows
       .filter((r): r is { type: string; count: number } => Boolean(r.type))
@@ -77,7 +77,7 @@ export class DrizzleDocumentRepository
     const rows = await this.db
       .select({ id: documents.id, matterId: documents.matterId }).from(documents)
       .innerJoin(matters, eq(documents.matterId, matters.id))
-      .where(and(eq(documents.id, asId<"DocumentId">(id)), eq(matters.organizationId, organizationId), isNull(documents.deletedAt)))
+      .where(and(eq(documents.id, asId<"DocumentId">(id)), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(documents.deletedAt)))
       .limit(1);
     const row = rows[0];
     return row ? { id: row.id, matterId: row.matterId } : null;

--- a/src/lib/server/repositories/drizzle-document-suggestion-repository.ts
+++ b/src/lib/server/repositories/drizzle-document-suggestion-repository.ts
@@ -27,7 +27,7 @@ export class DrizzleDocumentSuggestionRepository
       .select({ s: S, matterId: documents.matterId }).from(S)
       .innerJoin(documents, eq(S.documentId, documents.id))
       .innerJoin(matters, eq(documents.matterId, matters.id))
-      .where(and(eq(S.id, id), eq(matters.organizationId, organizationId), isNull(S.deletedAt)))
+      .where(and(eq(S.id, id), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(S.deletedAt)))
       .limit(1);
     const r = rows[0];
     return r ? ({ ...(r.s as object), document: { matterId: r.matterId as string } } as unknown as SuggestionWithMatter) : null;
@@ -40,7 +40,7 @@ export class DrizzleDocumentSuggestionRepository
       .innerJoin(matters, eq(documents.matterId, matters.id))
       .where(and(
         eq(S.status, "PENDING"), eq(documents.matterId, asId<"MatterId">(matterId)),
-        eq(matters.organizationId, organizationId), isNull(S.deletedAt),
+        eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(S.deletedAt),
       ))
       .orderBy(order === "asc" ? asc(S.createdAt) : desc(S.createdAt));
     return rows.map((r) => ({
@@ -55,7 +55,7 @@ export class DrizzleDocumentSuggestionRepository
       .select({ s: S, matterId: documents.matterId }).from(S)
       .innerJoin(documents, eq(S.documentId, documents.id))
       .innerJoin(matters, eq(documents.matterId, matters.id))
-      .where(and(inArray(S.id, ids), eq(S.status, "PENDING"), eq(matters.organizationId, organizationId), isNull(S.deletedAt)));
+      .where(and(inArray(S.id, ids), eq(S.status, "PENDING"), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(S.deletedAt)));
     return rows.map((r) => ({ ...(r.s as object), document: { matterId: r.matterId as string } })) as unknown as SuggestionWithMatter[];
   }
 
@@ -65,7 +65,7 @@ export class DrizzleDocumentSuggestionRepository
       .select({ id: S.id }).from(S)
       .innerJoin(documents, eq(S.documentId, documents.id))
       .innerJoin(matters, eq(documents.matterId, matters.id))
-      .where(and(inArray(S.id, ids), eq(matters.organizationId, organizationId), isNull(S.deletedAt)));
+      .where(and(inArray(S.id, ids), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(S.deletedAt)));
     return rows.map((r) => ({ id: r.id as string }));
   }
 

--- a/src/lib/server/repositories/drizzle-expense-repository.ts
+++ b/src/lib/server/repositories/drizzle-expense-repository.ts
@@ -23,7 +23,7 @@ export class DrizzleExpenseRepository extends DrizzleRepository<Expense> impleme
 
   async listForOrg(organizationId: string, opts: ExpenseListOptions): Promise<ExpenseListResult> {
     const where = and(
-      eq(matters.organizationId, organizationId),
+      eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
       opts.matterId ? eq(expenses.matterId, asId<"MatterId">(opts.matterId)) : undefined,
     );
     const rows = await this.db
@@ -59,7 +59,7 @@ export class DrizzleExpenseRepository extends DrizzleRepository<Expense> impleme
     const rows = await this.db
       .select({ exp: expenses }).from(expenses)
       .innerJoin(matters, eq(expenses.matterId, matters.id))
-      .where(and(eq(expenses.id, asId<"ExpenseId">(id)), eq(matters.organizationId, organizationId), isNull(expenses.deletedAt)))
+      .where(and(eq(expenses.id, asId<"ExpenseId">(id)), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(expenses.deletedAt)))
       .limit(1);
     return rows[0]?.exp ?? null;
   }
@@ -106,7 +106,7 @@ export class DrizzleExpenseRepository extends DrizzleRepository<Expense> impleme
       .from(expenses)
       .innerJoin(matters, eq(expenses.matterId, matters.id))
       .where(and(
-        eq(matters.organizationId, organizationId), eq(expenses.userId, asId<"UserId">(userId)),
+        eq(matters.organizationId, asId<"OrganizationId">(organizationId)), eq(expenses.userId, asId<"UserId">(userId)),
         gte(expenses.date, from), lte(expenses.date, to), isNull(expenses.deletedAt),
       ))
       .orderBy(asc(expenses.date));

--- a/src/lib/server/repositories/drizzle-invoice-dispatch-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-dispatch-repository.ts
@@ -38,7 +38,7 @@ export class DrizzleInvoiceDispatchRepository
       .innerJoin(matters, eq(invoices.matterId, matters.id))
       .where(and(
         eq(invoiceDispatches.status, "queued"),
-        eq(matters.organizationId, organizationId),
+        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
         isNull(invoiceDispatches.deletedAt),
       ))
       .orderBy(asc(invoiceDispatches.queuedAt));

--- a/src/lib/server/repositories/drizzle-invoice-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-repository.ts
@@ -32,7 +32,7 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
       .innerJoin(matters, eq(invoices.matterId, matters.id))
       .where(and(
         eq(invoices.id, id),
-        eq(matters.organizationId, organizationId),
+        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
         isNull(invoices.deletedAt),
       )).limit(1);
     return this.asRow(rows[0]?.inv);
@@ -95,7 +95,7 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
       .select({ inv: invoices, matter: matters }).from(invoices)
       .innerJoin(matters, eq(invoices.matterId, matters.id))
       .where(and(
-        eq(matters.organizationId, organizationId),
+        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
         isNull(invoices.deletedAt),
         filter?.matterId ? eq(invoices.matterId, filter.matterId) : undefined,
         filter?.invoiceType ? eq(invoices.invoiceType, filter.invoiceType) : undefined,
@@ -131,7 +131,7 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
     const rows = await this.db
       .select({ invoiceNumber: invoices.invoiceNumber }).from(invoices)
       .innerJoin(matters, eq(invoices.matterId, matters.id))
-      .where(and(eq(matters.organizationId, organizationId), like(invoices.invoiceNumber, `${prefix}%`)))
+      .where(and(eq(matters.organizationId, asId<"OrganizationId">(organizationId)), like(invoices.invoiceNumber, `${prefix}%`)))
       .orderBy(desc(invoices.invoiceNumber)).limit(1);
     return nextInvoiceNumberFrom(prefix, rows[0]?.invoiceNumber);
   }
@@ -142,7 +142,7 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
       .innerJoin(matters, eq(invoices.matterId, matters.id))
       .where(and(
         eq(invoices.creditedInvoiceId, invoiceId),
-        eq(matters.organizationId, organizationId),
+        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
         isNull(invoices.deletedAt),
       ));
     return Number(rows[0]?.total ?? 0);

--- a/src/lib/server/repositories/drizzle-matter-contact-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-contact-repository.ts
@@ -41,7 +41,7 @@ export class DrizzleMatterContactRepository
       .from(matterContacts)
       .innerJoin(contacts, eq(matterContacts.contactId, contacts.id))
       .innerJoin(matters, eq(matterContacts.matterId, matters.id))
-      .where(and(eq(matters.organizationId, organizationId), isNull(matterContacts.deletedAt), numberFilter));
+      .where(and(eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(matterContacts.deletedAt), numberFilter));
     return rows.map((r) => ({
       role: r.role as string,
       contact: {
@@ -59,7 +59,7 @@ export class DrizzleMatterContactRepository
     const rows = await this.db
       .select({ mc: matterContacts }).from(matterContacts)
       .innerJoin(matters, eq(matterContacts.matterId, matters.id))
-      .where(and(eq(matterContacts.id, asId<"MatterContactId">(id)), eq(matters.organizationId, organizationId), isNull(matterContacts.deletedAt)))
+      .where(and(eq(matterContacts.id, asId<"MatterContactId">(id)), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(matterContacts.deletedAt)))
       .limit(1);
     return rows[0]?.mc ?? null;
   }

--- a/src/lib/server/repositories/drizzle-matter-event-suggestion-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-event-suggestion-repository.ts
@@ -31,7 +31,7 @@ export class DrizzleMatterEventSuggestionRepository
       .innerJoin(matters, eq(documents.matterId, matters.id))
       .where(and(
         eq(documents.matterId, asId<"MatterId">(matterId)),
-        eq(matters.organizationId, organizationId),
+        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
         ne(matterEventSuggestions.status, "REJECTED"),
         isNull(matterEventSuggestions.deletedAt),
       ))
@@ -49,7 +49,7 @@ export class DrizzleMatterEventSuggestionRepository
       .innerJoin(matters, eq(documents.matterId, matters.id))
       .where(and(
         eq(matterEventSuggestions.id, asId<"MatterEventSuggestionId">(id)),
-        eq(matters.organizationId, organizationId),
+        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
         isNull(matterEventSuggestions.deletedAt),
       ))
       .limit(1);

--- a/src/lib/server/repositories/drizzle-matter-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-repository.ts
@@ -7,7 +7,7 @@
 
 import { and, asc, desc, eq, ilike, inArray, isNull, or, sql } from "drizzle-orm";
 import { asId } from "@/lib/shared/schemas/ids";
-import type { Matter, MatterContact } from "@/lib/shared/schemas/matter";
+import type { Matter } from "@/lib/shared/schemas/matter";
 import { contacts, documents, matterContacts, matters, timeEntries } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
@@ -23,7 +23,7 @@ export class DrizzleMatterRepository extends DrizzleRepository<Matter> implement
   async getByIdInOrg(id: string, organizationId: string): Promise<Matter | null> {
     const rows = await this.db
       .select().from(matters)
-      .where(and(eq(matters.id, id), eq(matters.organizationId, organizationId), isNull(matters.deletedAt)))
+      .where(and(eq(matters.id, asId<"MatterId">(id)), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(matters.deletedAt)))
       .limit(1);
     return this.asRow(rows[0]);
   }
@@ -31,14 +31,14 @@ export class DrizzleMatterRepository extends DrizzleRepository<Matter> implement
   async listByOrg(organizationId: string): Promise<Matter[]> {
     const rows = await this.db
       .select().from(matters)
-      .where(and(eq(matters.organizationId, organizationId), isNull(matters.deletedAt)));
+      .where(and(eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(matters.deletedAt)));
     return this.asRows(rows);
   }
 
   private listWhere(organizationId: string, f: MatterListFilter) {
     const pat = f.search ? `%${f.search}%` : "";
     return and(
-      eq(matters.organizationId, organizationId),
+      eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
       isNull(matters.deletedAt),
       f.status ? eq(matters.status, f.status) : undefined,
       f.employeeId
@@ -60,17 +60,16 @@ export class DrizzleMatterRepository extends DrizzleRepository<Matter> implement
       .orderBy(desc(matters.createdAt))
       .limit(filter.pageSize).offset((filter.page - 1) * filter.pageSize);
     const [agg] = await this.db.select({ total: sql<number>`count(*)` }).from(matters).where(where);
-    const ids = rows.map((r) => (r as { id: string }).id);
+    const ids = rows.map((r) => r.id);
     const [counts, klient] = await Promise.all([this.countsFor(ids), this.klientFor(ids)]);
-    const matterRows = rows.map((r) => {
-      const id = (r as { id: string }).id;
-      const k = klient.get(id);
+    const matterRows = rows.map((r): MatterListRow => {
+      const k = klient.get(r.id);
       return {
-        ...(r as object),
+        ...r,
         contacts: k ? [{ contact: k }] : [],
-        _count: counts.get(id) ?? { documents: 0, timeEntries: 0, contacts: 0 },
+        _count: counts.get(r.id) ?? { documents: 0, timeEntries: 0, contacts: 0 },
       };
-    }) as unknown as MatterListRow[];
+    });
     return { matters: matterRows, total: Number(agg?.total ?? 0) };
   }
 
@@ -121,20 +120,20 @@ export class DrizzleMatterRepository extends DrizzleRepository<Matter> implement
       .innerJoin(contacts, eq(matterContacts.contactId, contacts.id))
       .where(and(eq(matterContacts.matterId, asId<"MatterId">(id)), isNull(matterContacts.deletedAt)))
       .orderBy(asc(matterContacts.createdAt));
-    const linkContacts = rows.map((r) => ({ ...(r.mc as object), contact: r.contact })) as unknown as MatterContact[];
+    const linkContacts = rows.map((r) => ({ ...r.mc, contact: r.contact }));
     const counts = (await this.countsFor([id])).get(id) ?? { documents: 0, timeEntries: 0, contacts: 0 };
     return {
-      ...(base as object),
+      ...base,
       contacts: linkContacts,
       _count: { documents: counts.documents, timeEntries: counts.timeEntries, emails: 0 },
-    } as unknown as MatterDetailRow;
+    };
   }
 
   async listByResponsibleLawyer(organizationId: string, responsibleLawyerId: string): Promise<Matter[]> {
     const rows = await this.db.select().from(matters)
       .where(and(
-        eq(matters.organizationId, organizationId),
-        eq(matters.responsibleLawyerId, responsibleLawyerId),
+        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
+        eq(matters.responsibleLawyerId, asId<"UserId">(responsibleLawyerId)),
         isNull(matters.deletedAt),
       ));
     return this.asRows(rows);
@@ -143,7 +142,7 @@ export class DrizzleMatterRepository extends DrizzleRepository<Matter> implement
   async listByNumberPrefix(organizationId: string, prefix: string): Promise<Matter[]> {
     const rows = await this.db.select().from(matters)
       .where(and(
-        eq(matters.organizationId, organizationId),
+        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
         ilike(matters.matterNumber, `${prefix}%`),
         isNull(matters.deletedAt),
       ));

--- a/src/lib/server/repositories/drizzle-payment-plan-repository.ts
+++ b/src/lib/server/repositories/drizzle-payment-plan-repository.ts
@@ -29,7 +29,7 @@ export class DrizzlePaymentPlanRepository extends DrizzleRepository<PaymentPlan>
       .innerJoin(matters, eq(invoices.matterId, matters.id))
       .where(and(
         eq(paymentPlans.id, planId),
-        eq(matters.organizationId, organizationId),
+        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
         isNull(paymentPlans.deletedAt),
       )).limit(1);
     return this.asRow(rows[0]?.plan);
@@ -49,7 +49,7 @@ export class DrizzlePaymentPlanRepository extends DrizzleRepository<PaymentPlan>
       .innerJoin(invoices, eq(paymentPlans.invoiceId, invoices.id))
       .innerJoin(matters, eq(invoices.matterId, matters.id))
       .where(and(
-        eq(matters.organizationId, organizationId),
+        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
         status ? eq(paymentPlans.status, status) : undefined,
         isNull(paymentPlans.deletedAt),
       ));

--- a/src/lib/server/repositories/drizzle-service-note-repository.ts
+++ b/src/lib/server/repositories/drizzle-service-note-repository.ts
@@ -23,7 +23,7 @@ export class DrizzleServiceNoteRepository extends DrizzleRepository<ServiceNote>
       .leftJoin(users, eq(serviceNotes.authorId, users.id))
       .where(and(
         eq(serviceNotes.matterId, asId<"MatterId">(matterId)),
-        eq(matters.organizationId, organizationId),
+        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
         isNull(serviceNotes.deletedAt),
       ))
       .orderBy(desc(serviceNotes.createdAt));
@@ -37,7 +37,7 @@ export class DrizzleServiceNoteRepository extends DrizzleRepository<ServiceNote>
     const rows = await this.db
       .select({ note: serviceNotes }).from(serviceNotes)
       .innerJoin(matters, eq(serviceNotes.matterId, matters.id))
-      .where(and(eq(serviceNotes.id, asId<"ServiceNoteId">(id)), eq(matters.organizationId, organizationId), isNull(serviceNotes.deletedAt)))
+      .where(and(eq(serviceNotes.id, asId<"ServiceNoteId">(id)), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(serviceNotes.deletedAt)))
       .limit(1);
     return rows[0]?.note ?? null;
   }

--- a/src/lib/server/repositories/drizzle-time-entry-repository.ts
+++ b/src/lib/server/repositories/drizzle-time-entry-repository.ts
@@ -23,7 +23,7 @@ import type {
 /** Org-scopat where för `listForOrg` (utbruten för komplexitet ≤8). */
 function listWhere(organizationId: string, opts: TimeEntryListFilter) {
   return and(
-    eq(matters.organizationId, organizationId),
+    eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
     isNull(timeEntries.deletedAt),
     opts.matterId ? eq(timeEntries.matterId, asId<"MatterId">(opts.matterId)) : undefined,
     opts.userId ? eq(timeEntries.userId, asId<"UserId">(opts.userId)) : undefined,
@@ -66,7 +66,7 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
     const rows = await this.db
       .select({ te: timeEntries }).from(timeEntries)
       .innerJoin(matters, eq(timeEntries.matterId, matters.id))
-      .where(and(eq(timeEntries.id, asId<"TimeEntryId">(id)), eq(matters.organizationId, organizationId), isNull(timeEntries.deletedAt)))
+      .where(and(eq(timeEntries.id, asId<"TimeEntryId">(id)), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(timeEntries.deletedAt)))
       .limit(1);
     return rows[0]?.te ?? null;
   }
@@ -82,7 +82,7 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
       .innerJoin(matters, eq(timeEntries.matterId, matters.id))
       .leftJoin(users, eq(timeEntries.userId, users.id))
       .where(and(
-        eq(matters.organizationId, organizationId),
+        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
         isNull(timeEntries.deletedAt),
         gte(timeEntries.date, filter.from),
         lte(timeEntries.date, filter.to),
@@ -141,7 +141,7 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
       .from(timeEntries)
       .innerJoin(matters, eq(timeEntries.matterId, matters.id))
       .where(and(
-        eq(matters.organizationId, organizationId), eq(timeEntries.userId, asId<"UserId">(userId)),
+        eq(matters.organizationId, asId<"OrganizationId">(organizationId)), eq(timeEntries.userId, asId<"UserId">(userId)),
         gte(timeEntries.date, from), lte(timeEntries.date, to), isNull(timeEntries.deletedAt),
       ))
       .orderBy(asc(timeEntries.date));
@@ -160,7 +160,7 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
     const rows = await this.db
       .select({ te: timeEntries }).from(timeEntries)
       .innerJoin(matters, eq(timeEntries.matterId, matters.id))
-      .where(and(eq(matters.organizationId, organizationId), eq(timeEntries.billable, true), isNull(timeEntries.deletedAt)));
+      .where(and(eq(matters.organizationId, asId<"OrganizationId">(organizationId)), eq(timeEntries.billable, true), isNull(timeEntries.deletedAt)));
     return rows.map((r) => r.te);
   }
 

--- a/src/lib/server/repositories/matter-org.ts
+++ b/src/lib/server/repositories/matter-org.ts
@@ -7,6 +7,7 @@
  */
 
 import { eq } from "drizzle-orm";
+import { asId } from "@/lib/shared/schemas/ids";
 import { matters } from "../db/schema";
 import type { AppDb } from "../db/types";
 
@@ -15,7 +16,7 @@ export async function matterOrg(db: AppDb, matterId: string | null | undefined):
   const [m] = await db
     .select({ org: matters.organizationId })
     .from(matters)
-    .where(eq(matters.id, matterId))
+    .where(eq(matters.id, asId<"MatterId">(matterId)))
     .limit(1);
   return m?.org ?? undefined;
 }

--- a/src/lib/server/repositories/matter-repository.ts
+++ b/src/lib/server/repositories/matter-repository.ts
@@ -5,6 +5,7 @@
  * Bas-CRUD ärvs; läsmetoderna org-scopar direkt (ärenden bär `organizationId`).
  */
 
+import type { MatterStatus } from "@/lib/shared/schemas/enums";
 import type { Matter, MatterContact } from "@/lib/shared/schemas/matter";
 import type { Repository } from "./types";
 
@@ -34,7 +35,7 @@ export interface MatterDetailRow extends Matter {
 /** Filter/paginering för `listForOrg`. */
 export interface MatterListFilter {
   search?: string | undefined;
-  status?: string | undefined;
+  status?: MatterStatus | undefined;
   employeeId?: string | undefined;
   page: number;
   pageSize: number;


### PR DESCRIPTION
Del 16 av #562 (Fas 2) — den största entiteten.

- **matters**: id/organizationId/responsibleLawyerId + enum `status` (MatterStatus) & `paymentMethod` (PaymentMethod).
- **matter-repo**: `MatterListRow` (_count + KLIENT), `MatterDetailRow` och `linkContacts` typas utan `as object`/`as unknown as`; `MatterListFilter.status` → `MatterStatus`.
- **Stor org-scope-kaskad**: branding av `matters.organizationId` tvingar `asId` på `eq(matters.organizationId, …)` i ~22 ställen i alla repos som org-scopar via matter-join (time/expense/invoice/document/billing/payment-plan/service-note/matter-contact/suggestion + matter-org-hjälparen).

3 `as unknown as` bort. Baseline 284 → 281. Ren tsc + `lint --max-warnings 0` + 570 tester gröna.

Refs #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)