### PR TITLE
refactor(types): branda invoices + paymentPlans + accontoDeductions

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -74,19 +74,9 @@
       "count": 3
     }
   },
-  "src/lib/server/repositories/drizzle-invoice-repository.ts": {
-    "no-restricted-syntax": {
-      "count": 5
-    }
-  },
   "src/lib/server/repositories/drizzle-org-preference-repository.ts": {
     "no-restricted-syntax": {
       "count": 2
-    }
-  },
-  "src/lib/server/repositories/drizzle-payment-plan-repository.ts": {
-    "no-restricted-syntax": {
-      "count": 1
     }
   },
   "src/lib/server/repositories/drizzle-repositories.ts": {

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -18,11 +18,12 @@ import type {
   CalendarEventKind, CalendarEventVisibility, TaskPriority, TaskStatus,
 } from "@/lib/shared/schemas/calendar";
 import type {
-  BillingRunRecipient, BillingRunStatus, BillingRunType, ContactType, ExpenseKind, MatterRole,
-  MatterStatus, PaymentMethod, ReminderType, SuggestionStatus,
+  BillingRunRecipient, BillingRunStatus, BillingRunType, ContactType, ExpenseKind, InvoiceStatus,
+  InvoiceType, MatterRole, MatterStatus, PaymentMethod, PaymentPlanStatus, ReminderType,
+  SuggestionStatus,
 } from "@/lib/shared/schemas/enums";
 import type {
-  BillingRunId, CalendarEventId, ConflictCheckId, ContactId, DocumentFolderId, DocumentId,
+  AccontoDeductionId, BillingRunId, CalendarEventId, ConflictCheckId, ContactId, DocumentFolderId, DocumentId,
   DocumentTemplateId, ExpenseId, InvoiceDispatchId, InvoiceId, MatterContactId, MatterEventSuggestionId,
   MatterId, OrganizationId, PaymentId, PaymentPlanId, PaymentPlanReminderId, ServiceNoteId, TaskId,
   TimeEntryId, UserId, WriteOffId,
@@ -174,17 +175,18 @@ export const expenses = pgTable("expenses", {
 
 export const invoices = pgTable("invoices", {
   ...baseColumns,
-  matterId: uuid("matter_id").notNull(),
+  id: uuid("id").primaryKey().$type<InvoiceId>(),
+  matterId: uuid("matter_id").notNull().$type<MatterId>(),
   amount: ore("amount").notNull(),
-  status: text("status").notNull().default("DRAFT"),
-  invoiceType: text("invoice_type").notNull().default("STANDARD"),
+  status: text("status").notNull().default("DRAFT").$type<InvoiceStatus>(),
+  invoiceType: text("invoice_type").notNull().default("STANDARD").$type<InvoiceType>(),
   invoiceNumber: text("invoice_number"),
   ocrReference: text("ocr_reference"),
   fortnoxId: text("fortnox_id"),
   invoiceDate: timestamp("invoice_date", { withTimezone: true }).notNull(),
   dueDate: timestamp("due_date", { withTimezone: true }),
   notes: text("notes"),
-  creditedInvoiceId: uuid("credited_invoice_id"),
+  creditedInvoiceId: uuid("credited_invoice_id").$type<InvoiceId>(),
 }, (t) => [index("invoices_matter_idx").on(t.matterId)]);
 
 export const payments = pgTable("payments", {
@@ -226,11 +228,12 @@ export const invoiceDispatches = pgTable("invoice_dispatches", {
 
 export const paymentPlans = pgTable("payment_plans", {
   ...baseColumns,
-  invoiceId: uuid("invoice_id").notNull(),
+  id: uuid("id").primaryKey().$type<PaymentPlanId>(),
+  invoiceId: uuid("invoice_id").notNull().$type<InvoiceId>(),
   monthlyAmount: ore("monthly_amount").notNull(),
   dayOfMonth: integer("day_of_month").notNull(),
   startDate: timestamp("start_date", { withTimezone: true }).notNull(),
-  status: text("status").notNull().default("ACTIVE"),
+  status: text("status").notNull().default("ACTIVE").$type<PaymentPlanStatus>(),
   notes: text("notes"),
 }, (t) => [index("payment_plans_invoice_idx").on(t.invoiceId)]);
 
@@ -245,8 +248,9 @@ export const paymentPlanReminders = pgTable("payment_plan_reminders", {
 
 export const accontoDeductions = pgTable("acconto_deductions", {
   ...baseColumns,
-  finalInvoiceId: uuid("final_invoice_id").notNull(),
-  accontoInvoiceId: uuid("acconto_invoice_id").notNull(),
+  id: uuid("id").primaryKey().$type<AccontoDeductionId>(),
+  finalInvoiceId: uuid("final_invoice_id").notNull().$type<InvoiceId>(),
+  accontoInvoiceId: uuid("acconto_invoice_id").notNull().$type<InvoiceId>(),
 });
 
 export const billingRuns = pgTable("billing_runs", {

--- a/src/lib/server/repositories/drizzle-invoice-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-repository.ts
@@ -31,7 +31,7 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
       .select({ inv: invoices }).from(invoices)
       .innerJoin(matters, eq(invoices.matterId, matters.id))
       .where(and(
-        eq(invoices.id, id),
+        eq(invoices.id, asId<"InvoiceId">(id)),
         eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
         isNull(invoices.deletedAt),
       )).limit(1);
@@ -41,7 +41,7 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
   /** Bar faktura-rad utan org/delete-filter (för self-ref-uppslag). */
   private async rawInvoice(id: string | null | undefined): Promise<Invoice | null> {
     if (!id) return null;
-    const rows = await this.db.select().from(invoices).where(eq(invoices.id, id)).limit(1);
+    const rows = await this.db.select().from(invoices).where(eq(invoices.id, asId<"InvoiceId">(id))).limit(1);
     return this.asRow(rows[0]);
   }
 
@@ -49,28 +49,28 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
     const base = await this.getByIdWithRelations(id, organizationId);
     if (!base) return null;
     // Self-ref/dubbel-FK via sekundär-queries (relations() täcker dem inte).
-    const deductions = await this.db.select().from(accontoDeductions).where(eq(accontoDeductions.finalInvoiceId, id));
-    const usages = await this.db.select().from(accontoDeductions).where(eq(accontoDeductions.accontoInvoiceId, id));
+    const deductions = await this.db.select().from(accontoDeductions).where(eq(accontoDeductions.finalInvoiceId, asId<"InvoiceId">(id)));
+    const usages = await this.db.select().from(accontoDeductions).where(eq(accontoDeductions.accontoInvoiceId, asId<"InvoiceId">(id)));
     const accontoDeductionsFull = await Promise.all(
-      deductions.map(async (d) => ({ ...d, accontoInvoice: await this.rawInvoice((d as { accontoInvoiceId: string }).accontoInvoiceId) })),
+      deductions.map(async (d) => ({ ...d, accontoInvoice: await this.rawInvoice(d.accontoInvoiceId) })),
     );
     const deductedOnFinals = await Promise.all(
-      usages.map(async (d) => ({ ...d, finalInvoice: await this.rawInvoice((d as { finalInvoiceId: string }).finalInvoiceId) })),
+      usages.map(async (d) => ({ ...d, finalInvoice: await this.rawInvoice(d.finalInvoiceId) })),
     );
-    const creditedInvoice = await this.rawInvoice((base as { creditedInvoiceId?: string | null }).creditedInvoiceId);
-    const creditNoteRows = await this.db.select().from(invoices).where(eq(invoices.creditedInvoiceId, id)).limit(1);
+    const creditedInvoice = await this.rawInvoice(base.creditedInvoiceId);
+    const creditNoteRows = await this.db.select().from(invoices).where(eq(invoices.creditedInvoiceId, asId<"InvoiceId">(id))).limit(1);
     return {
       ...base,
       accontoDeductions: accontoDeductionsFull,
       deductedOnFinals,
       creditedInvoice,
-      creditNote: this.asRow(creditNoteRows[0]),
-    } as unknown as InvoiceFull;
+      creditNote: creditNoteRows[0] ?? null,
+    };
   }
 
   async getByIdWithRelations(id: string, organizationId: string): Promise<InvoiceWithRelations | null> {
     const row = await this.db.query.invoices.findFirst({
-      where: eq(invoices.id, id),
+      where: eq(invoices.id, asId<"InvoiceId">(id)),
       with: {
         matter: true,
         payments: { with: { recordedBy: true }, orderBy: (p, { desc }) => [desc(p.paidAt)] },
@@ -82,10 +82,10 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
       },
     });
     // Org-scope via ärendet + mjuk-delete-filter (db.query saknar relations-where).
-    if (!row || row.deletedAt || (row.matter as { organizationId?: string } | null)?.organizationId !== organizationId) {
+    if (!row || row.deletedAt || row.matter?.organizationId !== organizationId) {
       return null;
     }
-    return row as unknown as InvoiceWithRelations;
+    return row;
   }
 
   async listForOrg(organizationId: string, filter?: InvoiceListFilter): Promise<InvoiceListRow[]> {
@@ -97,33 +97,33 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
       .where(and(
         eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
         isNull(invoices.deletedAt),
-        filter?.matterId ? eq(invoices.matterId, filter.matterId) : undefined,
+        filter?.matterId ? eq(invoices.matterId, asId<"MatterId">(filter.matterId)) : undefined,
         filter?.invoiceType ? eq(invoices.invoiceType, filter.invoiceType) : undefined,
         filter?.status ? eq(invoices.status, filter.status) : undefined,
       ))
       .orderBy(desc(invoices.invoiceDate));
-    return Promise.all(baseRows.map(async ({ inv, matter }) => {
-      const id = (inv as { id: string }).id;
-      const plan = await this.db.select().from(paymentPlans).where(eq(paymentPlans.invoiceId, id)).limit(1);
+    return Promise.all(baseRows.map(async ({ inv, matter }): Promise<InvoiceListRow> => {
+      const id = inv.id;
+      const plan = await this.db.select().from(paymentPlans).where(eq(paymentPlans.invoiceId, asId<"InvoiceId">(id))).limit(1);
       const pays = await this.db.select().from(payments).where(eq(payments.invoiceId, asId<"InvoiceId">(id))).orderBy(desc(payments.paidAt));
-      const deductions = await this.db.select().from(accontoDeductions).where(eq(accontoDeductions.finalInvoiceId, id));
+      const deductions = await this.db.select().from(accontoDeductions).where(eq(accontoDeductions.finalInvoiceId, asId<"InvoiceId">(id)));
       const accontoDeductionsFull = await Promise.all(
-        deductions.map(async (d) => ({ ...d, accontoInvoice: await this.rawInvoice((d as { accontoInvoiceId: string }).accontoInvoiceId) })),
+        deductions.map(async (d) => ({ ...d, accontoInvoice: await this.rawInvoice(d.accontoInvoiceId) })),
       );
-      const usages = await this.db.select({ id: accontoDeductions.id }).from(accontoDeductions).where(eq(accontoDeductions.accontoInvoiceId, id));
-      const creditedInvoice = await this.rawInvoice((inv as { creditedInvoiceId?: string | null }).creditedInvoiceId);
-      const creditNoteRows = await this.db.select().from(invoices).where(eq(invoices.creditedInvoiceId, id)).limit(1);
+      const usages = await this.db.select({ id: accontoDeductions.id }).from(accontoDeductions).where(eq(accontoDeductions.accontoInvoiceId, asId<"InvoiceId">(id)));
+      const creditedInvoice = await this.rawInvoice(inv.creditedInvoiceId);
+      const creditNoteRows = await this.db.select().from(invoices).where(eq(invoices.creditedInvoiceId, asId<"InvoiceId">(id))).limit(1);
       return {
         ...inv,
-        matter: { id: (matter as { id: string }).id, matterNumber: (matter as { matterNumber: string }).matterNumber, title: (matter as { title: string }).title },
-        paymentPlan: (plan[0] as unknown) ?? null,
+        matter: { id: matter.id, matterNumber: matter.matterNumber, title: matter.title },
+        paymentPlan: plan[0] ?? null,
         payments: pays,
         accontoDeductions: accontoDeductionsFull,
         deductedOnFinals: usages,
-        creditedInvoice: creditedInvoice as InvoiceListRow["creditedInvoice"],
-        creditNote: (creditNoteRows[0] as unknown as InvoiceListRow["creditNote"]) ?? null,
+        creditedInvoice: creditedInvoice ?? null,
+        creditNote: creditNoteRows[0] ?? null,
       };
-    })) as unknown as InvoiceListRow[];
+    }));
   }
 
   async nextInvoiceNumber(organizationId: string): Promise<string> {
@@ -141,7 +141,7 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
       .select({ total: sql<number>`coalesce(sum(abs(${invoices.amount})), 0)` }).from(invoices)
       .innerJoin(matters, eq(invoices.matterId, matters.id))
       .where(and(
-        eq(invoices.creditedInvoiceId, invoiceId),
+        eq(invoices.creditedInvoiceId, asId<"InvoiceId">(invoiceId)),
         eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
         isNull(invoices.deletedAt),
       ));
@@ -151,7 +151,7 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
   async getCreditNoteFor(invoiceId: string): Promise<Invoice | null> {
     const rows = await this.db
       .select().from(invoices)
-      .where(and(eq(invoices.creditedInvoiceId, invoiceId), isNull(invoices.deletedAt))).limit(1);
+      .where(and(eq(invoices.creditedInvoiceId, asId<"InvoiceId">(invoiceId)), isNull(invoices.deletedAt))).limit(1);
     return this.asRow(rows[0]);
   }
 
@@ -163,13 +163,13 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
       .select({ inv: invoices }).from(invoices)
       .leftJoin(accontoDeductions, eq(accontoDeductions.accontoInvoiceId, invoices.id))
       .where(and(
-        inArray(invoices.id, ids),
-        eq(invoices.matterId, matterId),
+        inArray(invoices.id, ids.map((i) => asId<"InvoiceId">(i))),
+        eq(invoices.matterId, asId<"MatterId">(matterId)),
         eq(invoices.invoiceType, "ACCONTO"),
         isNull(invoices.deletedAt),
         isNull(accontoDeductions.id),
       ));
-    return rows.map((r) => r.inv) as unknown as Invoice[];
+    return rows.map((r) => r.inv);
   }
 
   async getByIdWithLedger(id: string): Promise<InvoiceWithLedger | null> {
@@ -183,7 +183,7 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
   async listByMatter(matterId: string): Promise<Invoice[]> {
     const rows = await this.db
       .select().from(invoices)
-      .where(and(eq(invoices.matterId, matterId), isNull(invoices.deletedAt)))
+      .where(and(eq(invoices.matterId, asId<"MatterId">(matterId)), isNull(invoices.deletedAt)))
       .orderBy(desc(invoices.invoiceDate));
     return this.asRows(rows);
   }

--- a/src/lib/server/repositories/drizzle-payment-plan-repository.ts
+++ b/src/lib/server/repositories/drizzle-payment-plan-repository.ts
@@ -9,6 +9,7 @@
 
 import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 import type { PaymentPlan, PaymentPlanReminder } from "@/lib/shared/schemas/billing";
+import type { PaymentPlanStatus } from "@/lib/shared/schemas/enums";
 import { asId } from "@/lib/shared/schemas/ids";
 import { invoices, matters, paymentPlanReminders, paymentPlans } from "../db/schema";
 import type { AppDb } from "../db/types";
@@ -28,7 +29,7 @@ export class DrizzlePaymentPlanRepository extends DrizzleRepository<PaymentPlan>
       .innerJoin(invoices, eq(paymentPlans.invoiceId, invoices.id))
       .innerJoin(matters, eq(invoices.matterId, matters.id))
       .where(and(
-        eq(paymentPlans.id, planId),
+        eq(paymentPlans.id, asId<"PaymentPlanId">(planId)),
         eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
         isNull(paymentPlans.deletedAt),
       )).limit(1);
@@ -38,7 +39,7 @@ export class DrizzlePaymentPlanRepository extends DrizzleRepository<PaymentPlan>
   async getByInvoiceId(invoiceId: string): Promise<PaymentPlan | null> {
     const rows = await this.db
       .select().from(paymentPlans)
-      .where(and(eq(paymentPlans.invoiceId, invoiceId), isNull(paymentPlans.deletedAt))).limit(1);
+      .where(and(eq(paymentPlans.invoiceId, asId<"InvoiceId">(invoiceId)), isNull(paymentPlans.deletedAt))).limit(1);
     return this.asRow(rows[0]);
   }
 
@@ -50,7 +51,7 @@ export class DrizzlePaymentPlanRepository extends DrizzleRepository<PaymentPlan>
       .innerJoin(matters, eq(invoices.matterId, matters.id))
       .where(and(
         eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
-        status ? eq(paymentPlans.status, status) : undefined,
+        status ? eq(paymentPlans.status, status as PaymentPlanStatus) : undefined,
         isNull(paymentPlans.deletedAt),
       ));
     return rows.map((r) => r.id as string);
@@ -60,7 +61,7 @@ export class DrizzlePaymentPlanRepository extends DrizzleRepository<PaymentPlan>
   private async fetchJoined(ids: string[]): Promise<JoinedPaymentPlan[]> {
     if (ids.length === 0) return [];
     const rows = await this.db.query.paymentPlans.findMany({
-      where: inArray(paymentPlans.id, ids),
+      where: inArray(paymentPlans.id, ids.map((i) => asId<"PaymentPlanId">(i))),
       orderBy: (pp, { desc: d }) => [d(pp.createdAt)],
       with: {
         invoice: {
@@ -76,7 +77,7 @@ export class DrizzlePaymentPlanRepository extends DrizzleRepository<PaymentPlan>
         },
       },
     });
-    return rows as unknown as JoinedPaymentPlan[];
+    return rows;
   }
 
   /** Påminnelser per plan (sentAt desc), grupperade. */

--- a/test/unit/server/db/relations.test.ts
+++ b/test/unit/server/db/relations.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import {
   documents, invoices, matters, payments, writeOffs, paymentPlans, paymentPlanReminders, users,
 } from "@/lib/server/db/schema";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "./pg-test-db";
 
@@ -35,7 +36,7 @@ describe("Drizzle relations (pglite)", () => {
     await db.insert(paymentPlanReminders).values({ id: uuidv7(), planId, dueMonth: "2026-06", type: "DUE", sentAt: new Date(), version: 1 } as never);
 
     const row = await db.query.invoices.findFirst({
-      where: eq(invoices.id, invId),
+      where: eq(invoices.id, asId<"InvoiceId">(invId)),
       with: {
         matter: true,
         payments: { with: { recordedBy: true } },
@@ -62,7 +63,7 @@ describe("Drizzle relations (pglite)", () => {
     await db.insert(invoices).values({ id: invId, matterId: mId, amount: 1, status: "DRAFT", invoiceType: "FINAL", invoiceDate: new Date(), version: 1 } as never);
     await db.insert(documents).values({ id: docId, matterId: mId, invoiceId: invId, fileName: "Faktura.pdf", mimeType: "application/pdf", sizeBytes: 10, storagePath: "p", uploadedById: uuidv7(), version: 1 } as never);
 
-    const inv = await db.query.invoices.findFirst({ where: eq(invoices.id, invId), with: { documents: true } });
+    const inv = await db.query.invoices.findFirst({ where: eq(invoices.id, asId<"InvoiceId">(invId)), with: { documents: true } });
     expect(inv?.documents.map((d) => d.id)).toContain(docId);
   });
 });


### PR DESCRIPTION
Del 17 av #562 (Fas 2) — faktura-vertikalen, det största relations-nystanet.

- **invoices**: id/matterId/creditedInvoiceId + enum `status`/`invoiceType`.
- **paymentPlans**: id/invoiceId + enum `status`.
- **accontoDeductions**: id/finalInvoiceId/accontoInvoiceId.
- **invoice-repo**: alla 5 `as unknown as` bort — inkl. de RELATIONELLA: `getByIdWithRelations` (drizzles `db.query…with{…}` över 7 relationer) returnerar nu `InvoiceWithRelations` direkt — alla relaterade tabeller är brandade så inferensen matchar den handskrivna typen. Även `getByIdFull`/`listForOrg`/whole-row.
- **payment-plan-repo**: relationella `fetchJoined` → `JoinedPaymentPlan` utan cast; value-params brandas, status narrowas.

6 `as unknown as` bort. Baseline 281 → 275. Ren tsc + `lint --max-warnings 0` + 524 tester gröna.

Detta gör att `invoice.getById`/`list` nu bär riktiga typer hela vägen → låser upp UI-castarna i `app/invoices/[id]` (nästa PR).

Refs #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)