### PR TITLE
refactor(types): ta bort 65 redundanta as-unknown-as-AppDb-castar

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -54,11 +54,6 @@
       "count": 3
     }
   },
-  "src/lib/server/db/client.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "src/lib/server/http/server-context.ts": {
     "no-restricted-syntax": {
       "count": 1
@@ -72,11 +67,6 @@
   "src/lib/server/repositories/drizzle-org-preference-repository.ts": {
     "no-restricted-syntax": {
       "count": 2
-    }
-  },
-  "src/lib/server/repositories/drizzle-repositories.ts": {
-    "no-restricted-syntax": {
-      "count": 1
     }
   },
   "src/lib/server/repositories/drizzle-user-preference-repository.ts": {
@@ -339,11 +329,6 @@
       "count": 2
     }
   },
-  "test/unit/server/db/pg-test-db.ts": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
   "test/unit/server/jobs/classify-document-handler.test.ts": {
     "no-restricted-syntax": {
       "count": 1
@@ -364,154 +349,14 @@
       "count": 1
     }
   },
-  "test/unit/server/repositories/acconto-deduction-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "test/unit/server/repositories/billing-run-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "test/unit/server/repositories/calendar-event-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "test/unit/server/repositories/conflict-matter-contact-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 3
-    }
-  },
-  "test/unit/server/repositories/contact-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "test/unit/server/repositories/document-folder-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "test/unit/server/repositories/document-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
-  "test/unit/server/repositories/document-suggestion-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "test/unit/server/repositories/document-template-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "test/unit/server/repositories/drizzle-repositories.test.ts": {
     "no-restricted-syntax": {
-      "count": 6
-    }
-  },
-  "test/unit/server/repositories/expected-receivable-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
-  "test/unit/server/repositories/expense-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 4
+      "count": 1
     }
   },
   "test/unit/server/repositories/in-memory-repository.test.ts": {
     "no-restricted-syntax": {
       "count": 2
-    }
-  },
-  "test/unit/server/repositories/invoice-dispatch-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "test/unit/server/repositories/invoice-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 10
-    }
-  },
-  "test/unit/server/repositories/matter-event-suggestion-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "test/unit/server/repositories/matter-reads-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 3
-    }
-  },
-  "test/unit/server/repositories/matter-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
-  "test/unit/server/repositories/organization-office-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
-  "test/unit/server/repositories/payment-plan-reminder-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "test/unit/server/repositories/payment-plan-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 4
-    }
-  },
-  "test/unit/server/repositories/payment-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "test/unit/server/repositories/preference-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
-  "test/unit/server/repositories/report-reads-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 4
-    }
-  },
-  "test/unit/server/repositories/service-note-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "test/unit/server/repositories/task-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "test/unit/server/repositories/time-entry-list-report-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "test/unit/server/repositories/time-entry-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
-  "test/unit/server/repositories/user-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "test/unit/server/repositories/write-off-repository.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
     }
   },
   "test/unit/server/routers/calendar.test.ts": {

--- a/src/lib/server/db/client.ts
+++ b/src/lib/server/db/client.ts
@@ -36,6 +36,6 @@ export function createPostgresDb(url: string, opts: PostgresDbOptions = {}): Pos
     ...(opts.max !== undefined ? { max: opts.max } : {}),
     onnotice: () => {},
   });
-  const db = drizzle(client, { schema }) as unknown as AppDb;
+  const db = drizzle(client, { schema });
   return { db, close: () => client.end({ timeout: 5 }) };
 }

--- a/src/lib/server/repositories/drizzle-repositories.ts
+++ b/src/lib/server/repositories/drizzle-repositories.ts
@@ -87,6 +87,6 @@ function reposForTx(tx: AppDb): Repositories {
 export function buildDrizzleRepositories(db: AppDb): Repositories {
   return {
     ...entityRepos(db),
-    transaction: (fn) => db.transaction((tx) => fn(reposForTx(tx as unknown as AppDb))),
+    transaction: (fn) => db.transaction((tx) => fn(reposForTx(tx))),
   };
 }

--- a/test/unit/server/db/pg-test-db.ts
+++ b/test/unit/server/db/pg-test-db.ts
@@ -38,7 +38,7 @@ async function createPgliteTestDb(): Promise<TestDbHandle> {
   const client = new PGlite();
   const db = drizzlePglite(client, { schema });
   for (const sql of migrationSql()) await client.exec(sql);
-  return { db: db as unknown as AppDb, close: () => client.close() };
+  return { db: db, close: () => client.close() };
 }
 
 /** Mot riktig Postgres: isolerat schema per handle (parallell-säkert), droppas på close. */
@@ -50,7 +50,7 @@ async function createRealPgTestDb(url: string): Promise<TestDbHandle> {
   for (const sql of migrationSql()) await client.unsafe(sql);
   const db = drizzlePostgres(client, { schema });
   return {
-    db: db as unknown as AppDb,
+    db: db,
     close: async () => {
       await client.unsafe(`DROP SCHEMA "${schemaName}" CASCADE`);
       await client.end({ timeout: 5 });

--- a/test/unit/server/repositories/acconto-deduction-repository.test.ts
+++ b/test/unit/server/repositories/acconto-deduction-repository.test.ts
@@ -5,7 +5,6 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleAccontoDeductionRepository } from "@/lib/server/repositories/drizzle-acconto-deduction-repository";
 import { InMemoryAccontoDeductionRepository } from "@/lib/server/repositories/in-memory-acconto-deduction-repository";
 import { uuidv7 } from "@/lib/shared/uuid";
@@ -28,7 +27,7 @@ describe("AccontoDeductionRepository — Drizzle (pglite)", () => {
   afterAll(async () => { await handle.close(); });
 
   it("create + getById (version 1)", async () => {
-    const repo = new DrizzleAccontoDeductionRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzleAccontoDeductionRepository(handle.db);
     const id = uuidv7();
     const created = await repo.create({ id, finalInvoiceId: uuidv7(), accontoInvoiceId: uuidv7() } as never);
     expect((created as { version?: number }).version).toBe(1);

--- a/test/unit/server/repositories/billing-run-repository.test.ts
+++ b/test/unit/server/repositories/billing-run-repository.test.ts
@@ -7,7 +7,6 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { billingRuns, invoices, matters } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleBillingRunRepository } from "@/lib/server/repositories/drizzle-billing-run-repository";
 import { InMemoryBillingRunRepository } from "@/lib/server/repositories/in-memory-billing-run-repository";
 import { prebakeJoins } from "@/lib/shared/demo-source";
@@ -72,7 +71,7 @@ describe("BillingRunRepository — Drizzle (pglite)", () => {
     await db.insert(invoices).values(v({ id: invId, matterId: mId, amount: 500, status: "DRAFT", invoiceNumber: "F-1", invoiceDate: new Date() }));
     await db.insert(billingRuns).values(v(run({ id: r1, matterId: mId, invoiceId: invId, type: "ACCONTO", status: "SENT" })));
     await db.insert(billingRuns).values(v(run({ id: r2, matterId: mId, invoiceId: null, type: "FINAL", status: "SENT" })));
-    const repo = new DrizzleBillingRunRepository(db as unknown as AppDb);
+    const repo = new DrizzleBillingRunRepository(db);
 
     const list = await repo.listForOrg(org);
     expect(list).toHaveLength(2);

--- a/test/unit/server/repositories/calendar-event-repository.test.ts
+++ b/test/unit/server/repositories/calendar-event-repository.test.ts
@@ -6,7 +6,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { calendarEvents, matters } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleCalendarEventRepository } from "@/lib/server/repositories/drizzle-calendar-event-repository";
 import { InMemoryCalendarEventRepository } from "@/lib/server/repositories/in-memory-calendar-event-repository";
 import { uuidv7 } from "@/lib/shared/uuid";
@@ -54,7 +53,7 @@ describe("CalendarEventRepository — Drizzle (pglite)", () => {
     await db.insert(calendarEvents).values(v({ id: e1, userId, organizationId: org, title: "A", startAt: new Date("2026-06-02"), matterId: mId }));
     await db.insert(calendarEvents).values(v({ id: uuidv7(), userId, organizationId: org, title: "B", startAt: new Date("2026-06-01") }));
     await db.insert(calendarEvents).values(v({ id: uuidv7(), userId: other, organizationId: org, title: "C", startAt: new Date("2026-06-03"), matterId: mId }));
-    const repo = new DrizzleCalendarEventRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzleCalendarEventRepository(handle.db);
     expect(await repo.listForUser(userId, org)).toHaveLength(2);
     expect(await repo.listForUsers([userId, other], org)).toHaveLength(3);
     expect(await repo.listForUsers([], org)).toEqual([]);

--- a/test/unit/server/repositories/conflict-matter-contact-repository.test.ts
+++ b/test/unit/server/repositories/conflict-matter-contact-repository.test.ts
@@ -7,7 +7,6 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { conflictChecks, contacts, matterContacts, matters, users } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleConflictCheckRepository } from "@/lib/server/repositories/drizzle-conflict-check-repository";
 import { DrizzleMatterContactRepository } from "@/lib/server/repositories/drizzle-matter-contact-repository";
 import { InMemoryConflictCheckRepository } from "@/lib/server/repositories/in-memory-conflict-check-repository";
@@ -79,8 +78,8 @@ describe("Conflict/MatterContact repos — Drizzle (pglite)", () => {
     await db.insert(matterContacts).values(v({ id: uuidv7(), matterId: mId, contactId: cMot, role: "MOTPART" }));
     await db.insert(matterContacts).values(v({ id: uuidv7(), matterId: mId, contactId: cKli, role: "KLIENT" }));
     await db.insert(conflictChecks).values(v({ id: uuidv7(), searchTerm: "anna", searchType: "name", results: [], checkedById: uId }));
-    const mc = new DrizzleMatterContactRepository(db as unknown as AppDb);
-    const cc = new DrizzleConflictCheckRepository(db as unknown as AppDb);
+    const mc = new DrizzleMatterContactRepository(db);
+    const cc = new DrizzleConflictCheckRepository(db);
 
     const byNumber = await mc.findForConflict(org, "19850225");
     expect(byNumber).toHaveLength(1);
@@ -182,7 +181,7 @@ describe("MatterContactRepository — läs-/skriv-metoder (Drizzle/pglite)", () 
     await db.insert(contacts).values(v({ id: cMot, organizationId: org, name: "Motpart", contactType: "PERSON" }));
     await db.insert(matterContacts).values(v({ id: linkKli, matterId: mId, contactId: cKli, role: "KLIENT" }));
     await db.insert(matterContacts).values(v({ id: linkMot, matterId: mId, contactId: cMot, role: "MOTPART" }));
-    const mc = new DrizzleMatterContactRepository(db as unknown as AppDb);
+    const mc = new DrizzleMatterContactRepository(db);
 
     // getByIdInOrg
     expect((await mc.getByIdInOrg(linkKli, org))?.id).toBe(linkKli);

--- a/test/unit/server/repositories/contact-repository.test.ts
+++ b/test/unit/server/repositories/contact-repository.test.ts
@@ -8,7 +8,6 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { contacts, matterContacts, matters } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleContactRepository } from "@/lib/server/repositories/drizzle-contact-repository";
 import { InMemoryContactRepository } from "@/lib/server/repositories/in-memory-contact-repository";
 import { prebakeJoins } from "@/lib/shared/demo-source";
@@ -75,7 +74,7 @@ describe("ContactRepository — Drizzle (pglite)", () => {
     await db.insert(contacts).values(v({ id: child, organizationId: org, name: "Anställd", contactType: "PERSON", parentId: c1 }));
     await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T", status: "ACTIVE" }));
     await db.insert(matterContacts).values(v({ id: uuidv7(), matterId: mId, contactId: c1, role: "KLIENT" }));
-    const repo = new DrizzleContactRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzleContactRepository(handle.db);
 
     const res = await repo.listForOrg(org, { page: 1, pageSize: 50 });
     expect(res.total).toBe(1); // child exkluderad (parentId satt)

--- a/test/unit/server/repositories/document-folder-repository.test.ts
+++ b/test/unit/server/repositories/document-folder-repository.test.ts
@@ -8,7 +8,6 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { documentFolders, documents, matters, users } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleDocumentFolderRepository } from "@/lib/server/repositories/drizzle-document-folder-repository";
 import { InMemoryDocumentFolderRepository } from "@/lib/server/repositories/in-memory-document-folder-repository";
 import { prebakeJoins } from "@/lib/shared/demo-source";
@@ -81,7 +80,7 @@ describe("DocumentFolderRepository — Drizzle (pglite)", () => {
     await db.insert(users).values(v({ id: t.uId, organizationId: ORG, email: "j@x", name: "Jurist" }));
     for (const f of t.folders) await db.insert(documentFolders).values(v(f));
     for (const d of t.docs) await db.insert(documents).values(v(d));
-    const repo = new DrizzleDocumentFolderRepository(db as unknown as AppDb);
+    const repo = new DrizzleDocumentFolderRepository(db);
 
     // listInParent(root) — sorterad + _count (A: 2 dok, 2 undermappar; B: tomt)
     const roots = await repo.listInParent(t.mId, null);

--- a/test/unit/server/repositories/document-repository.test.ts
+++ b/test/unit/server/repositories/document-repository.test.ts
@@ -7,7 +7,6 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { documentFolders, documents, matters, users } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleDocumentFolderRepository } from "@/lib/server/repositories/drizzle-document-folder-repository";
 import { DrizzleDocumentRepository } from "@/lib/server/repositories/drizzle-document-repository";
 import { InMemoryDocumentFolderRepository } from "@/lib/server/repositories/in-memory-document-folder-repository";
@@ -87,8 +86,8 @@ describe("DocumentRepository / DocumentFolderRepository — Drizzle (pglite)", (
       v({ matterId: mId, fileName: "f", mimeType: "application/pdf", sizeBytes: 1, storagePath: "p", uploadedById: uId, ...extra });
     await db.insert(documents).values(doc({ id: d1, folderId: root, documentType: "Avtal" }));
     await db.insert(documents).values(doc({ id: uuidv7(), folderId: null, documentType: "Faktura" }));
-    const docs = new DrizzleDocumentRepository(db as unknown as AppDb);
-    const folders = new DrizzleDocumentFolderRepository(db as unknown as AppDb);
+    const docs = new DrizzleDocumentRepository(db);
+    const folders = new DrizzleDocumentFolderRepository(db);
 
     const inRoot = await docs.listInFolder(mId, root, 1, 50);
     expect(inRoot.total).toBe(1);

--- a/test/unit/server/repositories/document-suggestion-repository.test.ts
+++ b/test/unit/server/repositories/document-suggestion-repository.test.ts
@@ -8,7 +8,6 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { documentAnalysisSuggestions, documents, matters } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleDocumentSuggestionRepository } from "@/lib/server/repositories/drizzle-document-suggestion-repository";
 import { InMemoryDocumentSuggestionRepository } from "@/lib/server/repositories/in-memory-document-suggestion-repository";
 import { prebakeJoins } from "@/lib/shared/demo-source";
@@ -63,7 +62,7 @@ describe("DocumentSuggestionRepository — Drizzle (pglite)", () => {
     await db.insert(documents).values(v({ id: dId, matterId: mId, fileName: "f.pdf", mimeType: "application/pdf", sizeBytes: 1, storagePath: "p", uploadedById: uuidv7(), title: "F" }));
     await db.insert(documentAnalysisSuggestions).values(v({ id: s1, documentId: dId, name: "Anna", role: "MOTPART", contactType: "PERSON", status: "PENDING" }));
     await db.insert(documentAnalysisSuggestions).values(v({ id: s2, documentId: dId, name: "Bo", role: "OMBUD", contactType: "PERSON", status: "REJECTED" }));
-    const repo = new DrizzleDocumentSuggestionRepository(db as unknown as AppDb);
+    const repo = new DrizzleDocumentSuggestionRepository(db);
 
     expect(await repo.getByIdInOrg(s1, org)).toMatchObject({ id: s1, document: { matterId: mId } });
     expect(await repo.getByIdInOrg(s1, uuidv7())).toBeNull();

--- a/test/unit/server/repositories/document-template-repository.test.ts
+++ b/test/unit/server/repositories/document-template-repository.test.ts
@@ -6,7 +6,6 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { documentTemplates, users } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleDocumentTemplateRepository } from "@/lib/server/repositories/drizzle-document-template-repository";
 import { InMemoryDocumentTemplateRepository } from "@/lib/server/repositories/in-memory-document-template-repository";
 import { prebakeJoins } from "@/lib/shared/demo-source";
@@ -46,7 +45,7 @@ describe("DocumentTemplateRepository — Drizzle (pglite)", () => {
     const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
     await db.insert(users).values(v({ id: userId, organizationId: org, email: "a@x", name: "Anna" }));
     await db.insert(documentTemplates).values(v({ id: t1, organizationId: org, name: "Avtal", category: "A", content: "x", createdById: userId }));
-    const repo = new DrizzleDocumentTemplateRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzleDocumentTemplateRepository(handle.db);
     const list = await repo.listForOrg(org);
     expect(list).toHaveLength(1);
     expect(list[0]!.createdBy?.name).toBe("Anna");

--- a/test/unit/server/repositories/drizzle-repositories.test.ts
+++ b/test/unit/server/repositories/drizzle-repositories.test.ts
@@ -5,7 +5,6 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
-import type { AppDb } from "@/lib/server/db/types";
 import { buildDrizzleRepositories } from "@/lib/server/repositories/drizzle-repositories";
 import type { Organization } from "@/lib/shared/schemas/organization";
 import { uuidv7 } from "@/lib/shared/uuid";
@@ -27,7 +26,7 @@ describe("buildDrizzleRepositories — kontrakt (pglite)", () => {
   afterAll(async () => { await handle.close(); });
 
   it("wirar alla 28 entitets-repos + transaction", () => {
-    const repos = buildDrizzleRepositories(handle.db as unknown as AppDb);
+    const repos = buildDrizzleRepositories(handle.db);
     for (const k of ORG_KEYS) {
       expect(repos[k], `saknar repo: ${k}`).toBeDefined();
       expect(typeof (repos[k] as { getById?: unknown }).getById).toBe("function");
@@ -36,7 +35,7 @@ describe("buildDrizzleRepositories — kontrakt (pglite)", () => {
   });
 
   it("bas-CRUD round-trippar via aggregatet (create → getById)", async () => {
-    const repos = buildDrizzleRepositories(handle.db as unknown as AppDb);
+    const repos = buildDrizzleRepositories(handle.db);
     const id = uuidv7();
     const created = await repos.organizations.create(org(id, "Aggregat AB"));
     expect((created as { version?: number }).version).toBe(1);
@@ -44,14 +43,14 @@ describe("buildDrizzleRepositories — kontrakt (pglite)", () => {
   });
 
   it("transaction committar vid success", async () => {
-    const repos = buildDrizzleRepositories(handle.db as unknown as AppDb);
+    const repos = buildDrizzleRepositories(handle.db);
     const id = uuidv7();
     await repos.transaction(async (tx) => { await tx.organizations.create(org(id)); });
     expect(await repos.organizations.getById(id)).toMatchObject({ id });
   });
 
   it("transaction rullar tillbaka vid kast (inget delvis committat)", async () => {
-    const repos = buildDrizzleRepositories(handle.db as unknown as AppDb);
+    const repos = buildDrizzleRepositories(handle.db);
     const id = uuidv7();
     await expect(
       repos.transaction(async (tx) => {
@@ -63,7 +62,7 @@ describe("buildDrizzleRepositories — kontrakt (pglite)", () => {
   });
 
   it("nästlad transaction är reentrant (delar samma tx → committar tillsammans)", async () => {
-    const repos = buildDrizzleRepositories(handle.db as unknown as AppDb);
+    const repos = buildDrizzleRepositories(handle.db);
     const a = uuidv7();
     const b = uuidv7();
     await repos.transaction(async (tx) => {

--- a/test/unit/server/repositories/expected-receivable-repository.test.ts
+++ b/test/unit/server/repositories/expected-receivable-repository.test.ts
@@ -6,7 +6,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { expectedReceivables, matters } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleExpectedReceivableRepository } from "@/lib/server/repositories/drizzle-expected-receivable-repository";
 import { DrizzleMatterRepository } from "@/lib/server/repositories/drizzle-matter-repository";
 import { InMemoryExpectedReceivableRepository } from "@/lib/server/repositories/in-memory-expected-receivable-repository";
@@ -49,11 +48,11 @@ describe("ExpectedReceivableRepository — Drizzle (pglite)", () => {
     await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
     await db.insert(expectedReceivables).values(v({ id: r1, organizationId: org, matterId: mId, description: "A", expectedAmount: 100, status: "PENDING", recordedById: uuidv7() }));
     await db.insert(expectedReceivables).values(v({ id: uuidv7(), organizationId: org, matterId: mId, description: "B", expectedAmount: 50, status: "SETTLED", recordedById: uuidv7() }));
-    const repo = new DrizzleExpectedReceivableRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzleExpectedReceivableRepository(handle.db);
     expect(await repo.listForOrg(org)).toHaveLength(2);
     expect(await repo.listForOrg(org, { status: "PENDING" })).toHaveLength(1);
     expect(await repo.getByIdInOrg(r1, org)).toMatchObject({ id: r1 });
     expect(await repo.getByIdInOrg(r1, uuidv7())).toBeNull();
-    expect(await new DrizzleMatterRepository(handle.db as unknown as AppDb).listByOrg(org)).toHaveLength(1);
+    expect(await new DrizzleMatterRepository(handle.db).listByOrg(org)).toHaveLength(1);
   });
 });

--- a/test/unit/server/repositories/expense-repository.test.ts
+++ b/test/unit/server/repositories/expense-repository.test.ts
@@ -6,7 +6,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { contacts, expenses, matterContacts, matters, users } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleExpenseRepository } from "@/lib/server/repositories/drizzle-expense-repository";
 import { InMemoryExpenseRepository } from "@/lib/server/repositories/in-memory-expense-repository";
 import { uuidv7 } from "@/lib/shared/uuid";
@@ -84,7 +83,7 @@ describe("ExpenseRepository — Drizzle (pglite)", () => {
     await db.insert(users).values(v({ id: userId, organizationId: org, email: "a@x", name: "Anna" }));
     await db.insert(expenses).values(v({ id: e1, userId, matterId: mId, date: new Date(), amount: 50_000, description: "x" }));
     await db.insert(expenses).values(v({ id: e2, userId, matterId: mId, date: new Date(), amount: 30_000, description: "y" }));
-    const repo = new DrizzleExpenseRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzleExpenseRepository(handle.db);
 
     expect(await repo.listUnbilled(mId, [e1, e2])).toHaveLength(2);
     await repo.flagBilled([e1], uuidv7());
@@ -102,7 +101,7 @@ describe("ExpenseRepository — Drizzle (pglite)", () => {
     await db.insert(users).values(v({ id: userId, organizationId: org, email: "a@x", name: "Anna" }));
     await db.insert(expenses).values(v({ id: uuidv7(), userId, matterId: mId, date: new Date("2026-06-02"), amount: 50_000, description: "a" }));
     await db.insert(expenses).values(v({ id: uuidv7(), userId, matterId: mId, date: new Date("2026-06-01"), amount: 30_000, description: "b" }));
-    const repo = new DrizzleExpenseRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzleExpenseRepository(handle.db);
     const res = await repo.listForOrg(org, { page: 1, pageSize: 50 });
     expect(res.total).toBe(2);
     expect(res.totalAmount).toBe(80_000);
@@ -122,7 +121,7 @@ describe("ExpenseRepository — Drizzle (pglite)", () => {
     await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
     await db.insert(users).values(v({ id: userId, organizationId: org, email: "a@x", name: "Anna" }));
     await db.insert(expenses).values(v({ id: eId, userId, matterId: mId, date: new Date(), amount: 1, description: "x" }));
-    const repo = new DrizzleExpenseRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzleExpenseRepository(handle.db);
     expect(await repo.getByIdInOrg(eId, org)).toMatchObject({ id: eId });
     expect(await repo.getByIdInOrg(eId, uuidv7())).toBeNull();
   });
@@ -187,7 +186,7 @@ describe("ExpenseRepository — frysning + perLawyer-period (Drizzle/pglite)", (
     await db.insert(expenses).values(v({ id: eEarly, userId: uId, matterId: mId, amount: 100, date: new Date("2026-06-01"), description: "tidig" }));
     await db.insert(expenses).values(v({ id: eFrozen, userId: uId, matterId: mId, amount: 300, date: new Date("2026-06-05"), description: "fryst", frozenByBillingRunId: uuidv7() }));
     await db.insert(expenses).values(v({ id: eOutside, userId: uId, matterId: mId, amount: 400, date: new Date("2026-05-01"), description: "utanför" }));
-    const repo = new DrizzleExpenseRepository(db as unknown as AppDb);
+    const repo = new DrizzleExpenseRepository(db);
 
     // listUnfrozenForMatter: ofrysta (eLate/eEarly/eOutside), date asc
     expect((await repo.listUnfrozenForMatter(mId)).map((e) => e.id)).toEqual([eOutside, eEarly, eLate]);

--- a/test/unit/server/repositories/invoice-dispatch-repository.test.ts
+++ b/test/unit/server/repositories/invoice-dispatch-repository.test.ts
@@ -7,7 +7,6 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { invoiceDispatches, invoices, matters } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleInvoiceDispatchRepository } from "@/lib/server/repositories/drizzle-invoice-dispatch-repository";
 import { InMemoryInvoiceDispatchRepository } from "@/lib/server/repositories/in-memory-invoice-dispatch-repository";
 import { prebakeJoins } from "@/lib/shared/demo-source";
@@ -53,7 +52,7 @@ describe("InvoiceDispatchRepository — Drizzle (pglite)", () => {
     await db.insert(invoices).values(v({ id: invId, matterId: mId, amount: 1000, status: "SENT", invoiceNumber: "F-1", invoiceDate: new Date() }));
     await db.insert(invoiceDispatches).values(v({ id: d1, invoiceId: invId, channel: "email", recipient: "a@x", status: "queued", queuedAt: new Date(), recordedById: uuidv7() }));
     await db.insert(invoiceDispatches).values(v({ id: uuidv7(), invoiceId: invId, channel: "email", recipient: "b@x", status: "sent", queuedAt: new Date(), recordedById: uuidv7() }));
-    const repo = new DrizzleInvoiceDispatchRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzleInvoiceDispatchRepository(handle.db);
     expect(await repo.listByInvoice(invId)).toHaveLength(2);
     const queued = await repo.listQueuedForOrg(org);
     expect(queued).toHaveLength(1);

--- a/test/unit/server/repositories/invoice-repository.test.ts
+++ b/test/unit/server/repositories/invoice-repository.test.ts
@@ -10,7 +10,6 @@ import {
   invoices, matters, payments, writeOffs, paymentPlans, paymentPlanReminders,
   timeEntries, expenses, documents, users, accontoDeductions,
 } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleInvoiceRepository } from "@/lib/server/repositories/drizzle-invoice-repository";
 import { InMemoryInvoiceRepository } from "@/lib/server/repositories/in-memory-invoice-repository";
 import type { InvoiceRepository } from "@/lib/server/repositories/invoice-repository";
@@ -225,7 +224,7 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
   afterAll(async () => { await handle.close(); });
 
   it("uppfyller kontraktet", async () => {
-    await assertContract(new DrizzleInvoiceRepository(handle.db as unknown as AppDb));
+    await assertContract(new DrizzleInvoiceRepository(handle.db));
   });
 
   it("getByIdWithLedger hämtar betalningar", async () => {
@@ -237,7 +236,7 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
       id: uuidv7(), invoiceId: id, amount: 7_500, paidAt: new Date(), recordedById: uuidv7(), version: 1,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
-    const ledger = await new DrizzleInvoiceRepository(handle.db as unknown as AppDb).getByIdWithLedger(id);
+    const ledger = await new DrizzleInvoiceRepository(handle.db).getByIdWithLedger(id);
     expect(ledger?.payments).toHaveLength(1);
     expect(ledger?.payments[0]!.amount).toBe(7_500);
   });
@@ -251,7 +250,7 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
     await db.insert(matters).values({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T", version: 1 } as any);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await db.insert(invoices).values(inv({ id, matterId: mId }) as any);
-    const repo = new DrizzleInvoiceRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzleInvoiceRepository(handle.db);
     expect(await repo.getByIdInOrg(id, org)).toMatchObject({ id });
     expect(await repo.getByIdInOrg(id, uuidv7())).toBeNull();
   });
@@ -276,7 +275,7 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
     await db.insert(expenses).values(v({ id: uuidv7(), userId, matterId: mId, invoiceId: id, date: new Date(), amount: 50, description: "x" }));
     await db.insert(documents).values(v({ id: uuidv7(), matterId: mId, invoiceId: id, fileName: "f.pdf", mimeType: "application/pdf", sizeBytes: 1, storagePath: "p", uploadedById: userId }));
 
-    const repo = new DrizzleInvoiceRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzleInvoiceRepository(handle.db);
     const full = await repo.getByIdWithRelations(id, org);
     expect(full?.matter?.matterNumber).toBe("2026-1");
     expect(full?.payments).toHaveLength(1);
@@ -304,7 +303,7 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
     await db.insert(invoices).values(inv({ id: creditId, matterId: mId, invoiceType: "CREDIT", creditedInvoiceId: finalId }) as never);
     await db.insert(accontoDeductions).values(v({ id: uuidv7(), finalInvoiceId: finalId, accontoInvoiceId: accontoId }));
 
-    const full = await new DrizzleInvoiceRepository(handle.db as unknown as AppDb).getByIdFull(finalId, org);
+    const full = await new DrizzleInvoiceRepository(handle.db).getByIdFull(finalId, org);
     expect(full?.accontoDeductions).toHaveLength(1);
     expect(full?.accontoDeductions[0]?.accontoInvoice?.id).toBe(accontoId);
     expect(full?.creditNote?.id).toBe(creditId);
@@ -329,7 +328,7 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
     await db.insert(accontoDeductions).values(v({ id: uuidv7(), finalInvoiceId: finalId, accontoInvoiceId: accontoId }));
     await db.insert(payments).values(v({ id: uuidv7(), invoiceId: finalId, amount: 400, paidAt: new Date(), recordedById: uuidv7() }));
 
-    const repo = new DrizzleInvoiceRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzleInvoiceRepository(handle.db);
     const all = await repo.listForOrg(org);
     expect(all.map((i) => i.id).sort()).toEqual([finalId, accontoId].sort()); // annan org exkluderad
     const final = all.find((i) => i.id === finalId)!;
@@ -348,7 +347,7 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
     await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
     await db.insert(invoices).values(inv({ id: uuidv7(), matterId: mId, invoiceNumber: "F-2026-0001" }) as never);
     await db.insert(invoices).values(inv({ id: uuidv7(), matterId: mId, invoiceNumber: "F-2026-0002" }) as never);
-    const repo = new DrizzleInvoiceRepository(handle.db as unknown as AppDb, () => new Date("2026-06-01T00:00:00.000Z"));
+    const repo = new DrizzleInvoiceRepository(handle.db, () => new Date("2026-06-01T00:00:00.000Z"));
     expect(await repo.nextInvoiceNumber(org)).toBe("F-2026-0003");
     expect(await repo.nextInvoiceNumber(uuidv7())).toBe("F-2026-0001"); // tom org → 0001
   });
@@ -365,7 +364,7 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
     await db.insert(invoices).values(inv({ id: uuidv7(), matterId: mId, invoiceType: "CREDIT", amount: -40_000, creditedInvoiceId: finalId }) as never);
     await db.insert(invoices).values(inv({ id: uuidv7(), matterId: mId, invoiceType: "CREDIT", amount: -10_000, creditedInvoiceId: finalId }) as never);
 
-    const repo = new DrizzleInvoiceRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzleInvoiceRepository(handle.db);
     expect(await repo.sumCreditNotesFor(finalId, org)).toBe(50_000);
     expect(await repo.sumCreditNotesFor(finalId, uuidv7())).toBe(0); // fel org
   });
@@ -380,7 +379,7 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
     await db.insert(matters).values(v({ id: mId, organizationId: uuidv7(), matterNumber: "2026-1", title: "T" }));
     await db.insert(invoices).values(inv({ id: origId, matterId: mId, invoiceType: "STANDARD" }) as never);
     await db.insert(invoices).values(inv({ id: creditId, matterId: mId, invoiceType: "CREDIT", amount: -100, creditedInvoiceId: origId }) as never);
-    const repo = new DrizzleInvoiceRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzleInvoiceRepository(handle.db);
     expect((await repo.getCreditNoteFor(origId))?.id).toBe(creditId);
     expect(await repo.getCreditNoteFor(uuidv7())).toBeNull();
   });
@@ -398,7 +397,7 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
     await db.insert(invoices).values(inv({ id: acc2, matterId: mId, invoiceType: "ACCONTO" }) as never);
     await db.insert(invoices).values(inv({ id: finalId, matterId: mId, invoiceType: "FINAL" }) as never);
     await db.insert(accontoDeductions).values(v({ id: uuidv7(), finalInvoiceId: finalId, accontoInvoiceId: acc2 }));
-    const repo = new DrizzleInvoiceRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzleInvoiceRepository(handle.db);
     expect((await repo.listDeductibleAccontos(mId, [acc1, acc2])).map((a) => a.id)).toEqual([acc1]);
   });
 });

--- a/test/unit/server/repositories/matter-event-suggestion-repository.test.ts
+++ b/test/unit/server/repositories/matter-event-suggestion-repository.test.ts
@@ -7,7 +7,6 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { documents, matterEventSuggestions, matters } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleMatterEventSuggestionRepository } from "@/lib/server/repositories/drizzle-matter-event-suggestion-repository";
 import { InMemoryMatterEventSuggestionRepository } from "@/lib/server/repositories/in-memory-matter-event-suggestion-repository";
 import { prebakeJoins } from "@/lib/shared/demo-source";
@@ -59,7 +58,7 @@ describe("MatterEventSuggestionRepository — Drizzle (pglite)", () => {
     await db.insert(matterEventSuggestions).values(v({ id: e1, documentId: dId, title: "Sen", startAt: new Date("2026-06-01"), status: "PENDING" }));
     await db.insert(matterEventSuggestions).values(v({ id: uuidv7(), documentId: dId, title: "Tidig", startAt: new Date("2026-05-01"), status: "PENDING" }));
     await db.insert(matterEventSuggestions).values(v({ id: uuidv7(), documentId: dId, title: "Avvisad", startAt: new Date("2026-04-01"), status: "REJECTED" }));
-    const repo = new DrizzleMatterEventSuggestionRepository(db as unknown as AppDb);
+    const repo = new DrizzleMatterEventSuggestionRepository(db);
 
     const list = await repo.listForMatter(mId, org);
     expect(list.map((r) => r.title)).toEqual(["Tidig", "Sen"]);

--- a/test/unit/server/repositories/matter-reads-repository.test.ts
+++ b/test/unit/server/repositories/matter-reads-repository.test.ts
@@ -9,7 +9,6 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { contacts, documents, matterContacts, matters, timeEntries, users } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleContactRepository } from "@/lib/server/repositories/drizzle-contact-repository";
 import { DrizzleMatterContactRepository } from "@/lib/server/repositories/drizzle-matter-contact-repository";
 import { DrizzleMatterRepository } from "@/lib/server/repositories/drizzle-matter-repository";
@@ -86,9 +85,9 @@ describe("Matter-läsningar — Drizzle (pglite)", () => {
     await db.insert(matterContacts).values(v({ id: mcId, matterId: mId, contactId: cId, role: "KLIENT" }));
     await db.insert(documents).values(v({ id: uuidv7(), matterId: mId, fileName: "a.pdf", mimeType: "application/pdf", sizeBytes: 1, storagePath: "p", uploadedById: uId }));
     await db.insert(timeEntries).values(v({ id: uuidv7(), matterId: mId, userId: uId, minutes: 30, billable: true, hourlyRate: 1000, description: "x", date: new Date() }));
-    const mRepo = new DrizzleMatterRepository(db as unknown as AppDb);
-    const mcRepo = new DrizzleMatterContactRepository(db as unknown as AppDb);
-    const cRepo = new DrizzleContactRepository(db as unknown as AppDb);
+    const mRepo = new DrizzleMatterRepository(db);
+    const mcRepo = new DrizzleMatterContactRepository(db);
+    const cRepo = new DrizzleContactRepository(db);
 
     const list = await mRepo.listForOrg(org, { page: 1, pageSize: 20 });
     expect(list.total).toBe(1);

--- a/test/unit/server/repositories/matter-repository.test.ts
+++ b/test/unit/server/repositories/matter-repository.test.ts
@@ -7,7 +7,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { matters } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleMatterRepository } from "@/lib/server/repositories/drizzle-matter-repository";
 import { InMemoryMatterRepository } from "@/lib/server/repositories/in-memory-matter-repository";
 import type { MatterRepository } from "@/lib/server/repositories/matter-repository";
@@ -58,7 +57,7 @@ describe("MatterRepository — Drizzle (pglite)", () => {
 
   it("uppfyller kontraktet", async () => {
     const org = uuidv7();
-    const repo = new DrizzleMatterRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzleMatterRepository(handle.db);
     // org-kolumnen är uuid → kontraktets create() måste ha giltig UUID-org.
     const id = uuidv7();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -76,7 +75,7 @@ describe("MatterRepository — Drizzle (pglite)", () => {
     const id = uuidv7();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await db.insert(matters).values({ id, organizationId: org, matterNumber: "2026-2", title: "T", version: 1 } as any);
-    const repo = new DrizzleMatterRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzleMatterRepository(handle.db);
     expect(await repo.getByIdInOrg(id, org)).toMatchObject({ id });
     expect(await repo.getByIdInOrg(id, uuidv7())).toBeNull(); // fel org
   });

--- a/test/unit/server/repositories/organization-office-repository.test.ts
+++ b/test/unit/server/repositories/organization-office-repository.test.ts
@@ -5,7 +5,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { offices, organizations } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleOfficeRepository } from "@/lib/server/repositories/drizzle-office-repository";
 import { DrizzleOrganizationRepository } from "@/lib/server/repositories/drizzle-organization-repository";
 import { InMemoryOfficeRepository } from "@/lib/server/repositories/in-memory-office-repository";
@@ -54,8 +53,8 @@ describe("Organization/Office — Drizzle (pglite)", () => {
     await db.insert(organizations).values(v({ id: org, name: "Byrå AB" }));
     await db.insert(offices).values(v({ id: main, organizationId: org, name: "Sthlm", isMain: true }));
     await db.insert(offices).values(v({ id: branch, organizationId: org, name: "Gbg", isMain: false }));
-    const offRepo = new DrizzleOfficeRepository(handle.db as unknown as AppDb);
-    expect(await new DrizzleOrganizationRepository(handle.db as unknown as AppDb).getById(org)).toMatchObject({ id: org });
+    const offRepo = new DrizzleOfficeRepository(handle.db);
+    expect(await new DrizzleOrganizationRepository(handle.db).getById(org)).toMatchObject({ id: org });
     expect((await offRepo.listByOrg(org)).map((o) => o.id)).toEqual([main, branch]);
     expect(await offRepo.getByIdInOrg(branch, org)).toMatchObject({ id: branch });
     expect(await offRepo.getByIdInOrg(branch, uuidv7())).toBeNull();

--- a/test/unit/server/repositories/payment-plan-reminder-repository.test.ts
+++ b/test/unit/server/repositories/payment-plan-reminder-repository.test.ts
@@ -6,7 +6,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { paymentPlanReminders } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzlePaymentPlanReminderRepository } from "@/lib/server/repositories/drizzle-payment-plan-reminder-repository";
 import { InMemoryPaymentPlanReminderRepository } from "@/lib/server/repositories/in-memory-payment-plan-reminder-repository";
 import type { PaymentPlanReminderRepository } from "@/lib/server/repositories/payment-plan-reminder-repository";
@@ -37,7 +36,7 @@ describe("PaymentPlanReminderRepository — Drizzle (pglite)", () => {
   afterAll(async () => { await handle.close(); });
 
   it("uppfyller bas-kontraktet", async () => {
-    await assertContract(new DrizzlePaymentPlanReminderRepository(handle.db as unknown as AppDb));
+    await assertContract(new DrizzlePaymentPlanReminderRepository(handle.db));
     // referera tabellen så schema-importen inte är oanvänd
     expect(paymentPlanReminders).toBeDefined();
   });

--- a/test/unit/server/repositories/payment-plan-repository.test.ts
+++ b/test/unit/server/repositories/payment-plan-repository.test.ts
@@ -7,7 +7,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { contacts, invoices, matterContacts, matters, paymentPlanReminders, paymentPlans, payments } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzlePaymentPlanRepository } from "@/lib/server/repositories/drizzle-payment-plan-repository";
 import { InMemoryPaymentPlanRepository } from "@/lib/server/repositories/in-memory-payment-plan-repository";
 import type { PaymentPlanRepository } from "@/lib/server/repositories/payment-plan-repository";
@@ -108,7 +107,7 @@ describe("PaymentPlanRepository — Drizzle (pglite)", () => {
   afterAll(async () => { await handle.close(); });
 
   it("uppfyller kontraktet", async () => {
-    await assertContract(new DrizzlePaymentPlanRepository(handle.db as unknown as AppDb));
+    await assertContract(new DrizzlePaymentPlanRepository(handle.db));
   });
 
   it("getByIdInOrg org-scopar via join faktura→ärende", async () => {
@@ -123,7 +122,7 @@ describe("PaymentPlanRepository — Drizzle (pglite)", () => {
     await db.insert(invoices).values(v({ id: invId, matterId: mId, amount: 1, status: "INSTALLMENT_PLAN", invoiceDate: new Date() }));
     await db.insert(paymentPlans).values(v({ id: pId, invoiceId: invId, monthlyAmount: 100, dayOfMonth: 15, startDate: new Date(), status: "ACTIVE" }));
 
-    const repo = new DrizzlePaymentPlanRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzlePaymentPlanRepository(handle.db);
     expect(await repo.getByIdInOrg(pId, org)).toMatchObject({ id: pId });
     expect(await repo.getByIdInOrg(pId, uuidv7())).toBeNull(); // fel org
   });
@@ -135,7 +134,7 @@ describe("PaymentPlanRepository — Drizzle (pglite)", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
     await db.insert(paymentPlans).values(v({ id: pId, invoiceId: invId, monthlyAmount: 100, dayOfMonth: 15, startDate: new Date(), status: "ACTIVE" }));
-    const repo = new DrizzlePaymentPlanRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzlePaymentPlanRepository(handle.db);
     expect(await repo.getByInvoiceId(invId)).toMatchObject({ id: pId });
     expect(await repo.getByInvoiceId(uuidv7())).toBeNull(); // ingen plan
   });
@@ -156,7 +155,7 @@ describe("PaymentPlanRepository — Drizzle (pglite)", () => {
     await db.insert(payments).values(v({ id: uuidv7(), invoiceId: invId, amount: 200, paidAt: new Date("2026-06-10"), recordedById: uuidv7() }));
     await db.insert(paymentPlans).values(v({ id: pId, invoiceId: invId, monthlyAmount: 100, dayOfMonth: 15, startDate: new Date(), status: "ACTIVE" }));
     await db.insert(paymentPlanReminders).values(v({ id: uuidv7(), planId: pId, dueMonth: "2026-06", type: "DUE", sentAt: new Date() }));
-    const repo = new DrizzlePaymentPlanRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzlePaymentPlanRepository(handle.db);
 
     const list = await repo.listForOrg(org);
     expect(list).toHaveLength(1);

--- a/test/unit/server/repositories/payment-repository.test.ts
+++ b/test/unit/server/repositories/payment-repository.test.ts
@@ -7,7 +7,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { payments } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzlePaymentRepository } from "@/lib/server/repositories/drizzle-payment-repository";
 import { InMemoryPaymentRepository } from "@/lib/server/repositories/in-memory-payment-repository";
 import { uuidv7 } from "@/lib/shared/uuid";
@@ -33,7 +32,7 @@ describe("PaymentRepository — Drizzle (pglite)", () => {
 
   it("create + sumByInvoice summerar i SQL", async () => {
     const invoiceId = uuidv7();
-    const repo = new DrizzlePaymentRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzlePaymentRepository(handle.db);
     await repo.create({ id: uuidv7(), invoiceId, amount: 30_000, paidAt: new Date(), recordedById: uuidv7() } as never);
     await repo.create({ id: uuidv7(), invoiceId, amount: 20_000, paidAt: new Date(), recordedById: uuidv7() } as never);
     await repo.create({ id: uuidv7(), invoiceId: uuidv7(), amount: 99_000, paidAt: new Date(), recordedById: uuidv7() } as never);

--- a/test/unit/server/repositories/preference-repository.test.ts
+++ b/test/unit/server/repositories/preference-repository.test.ts
@@ -5,7 +5,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { orgPreferences, userPreferences } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleOrgPreferenceRepository } from "@/lib/server/repositories/drizzle-org-preference-repository";
 import { DrizzleUserPreferenceRepository } from "@/lib/server/repositories/drizzle-user-preference-repository";
 import { InMemoryOrgPreferenceRepository } from "@/lib/server/repositories/in-memory-org-preference-repository";
@@ -46,8 +45,8 @@ describe("Preference repos — Drizzle (pglite)", () => {
     const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
     await db.insert(userPreferences).values(v({ id: up, userId, organizationId: org, key: "list.contacts", prefs: { sort: "name" } }));
     await db.insert(orgPreferences).values(v({ id: op, organizationId: org, key: "list.contacts", prefs: { sort: "createdAt" } }));
-    const uRepo = new DrizzleUserPreferenceRepository(handle.db as unknown as AppDb);
-    const oRepo = new DrizzleOrgPreferenceRepository(handle.db as unknown as AppDb);
+    const uRepo = new DrizzleUserPreferenceRepository(handle.db);
+    const oRepo = new DrizzleOrgPreferenceRepository(handle.db);
     expect((await uRepo.getByUserKey(userId, org, "list.contacts"))?.id).toBe(up);
     expect(await uRepo.getByUserKey(userId, org, "list.x")).toBeNull();
     expect((await oRepo.getByOrgKey(org, "list.contacts"))?.id).toBe(op);

--- a/test/unit/server/repositories/report-reads-repository.test.ts
+++ b/test/unit/server/repositories/report-reads-repository.test.ts
@@ -8,7 +8,6 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { contacts, expenses, invoices, matterContacts, matters, payments, timeEntries, users, writeOffs } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleExpenseRepository } from "@/lib/server/repositories/drizzle-expense-repository";
 import { DrizzlePaymentRepository } from "@/lib/server/repositories/drizzle-payment-repository";
 import { DrizzleTimeEntryRepository } from "@/lib/server/repositories/drizzle-time-entry-repository";
@@ -93,10 +92,10 @@ describe("Report-läsningar — Drizzle (pglite)", () => {
     await db.insert(expenses).values(v({ id: uuidv7(), userId: uId, matterId: mId, amount: 500, billable: true, description: "e", date: new Date("2026-06-12"), vatRate: 0, vatIncluded: false }));
     await db.insert(payments).values(v({ id: uuidv7(), invoiceId: invId, amount: 200, paidAt: new Date(), recordedById: uId }));
     await db.insert(writeOffs).values(v({ id: uuidv7(), invoiceId: invId, amount: 100, writtenOffAt: new Date("2026-06-20"), recordedById: uId }));
-    const te = new DrizzleTimeEntryRepository(db as unknown as AppDb);
-    const ex = new DrizzleExpenseRepository(db as unknown as AppDb);
-    const pay = new DrizzlePaymentRepository(db as unknown as AppDb);
-    const wo = new DrizzleWriteOffRepository(db as unknown as AppDb);
+    const te = new DrizzleTimeEntryRepository(db);
+    const ex = new DrizzleExpenseRepository(db);
+    const pay = new DrizzlePaymentRepository(db);
+    const wo = new DrizzleWriteOffRepository(db);
 
     const lawyerTime = await te.listForLawyerInPeriod(org, uId, FROM, TO);
     expect(lawyerTime).toHaveLength(2);

--- a/test/unit/server/repositories/service-note-repository.test.ts
+++ b/test/unit/server/repositories/service-note-repository.test.ts
@@ -7,7 +7,6 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { matters, serviceNotes, users } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleServiceNoteRepository } from "@/lib/server/repositories/drizzle-service-note-repository";
 import { InMemoryServiceNoteRepository } from "@/lib/server/repositories/in-memory-service-note-repository";
 import { prebakeJoins } from "@/lib/shared/demo-source";
@@ -52,7 +51,7 @@ describe("ServiceNoteRepository — Drizzle (pglite)", () => {
     await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
     await db.insert(users).values(v({ id: userId, organizationId: org, email: "a@x", name: "Anna" }));
     await db.insert(serviceNotes).values(v({ id: sn1, matterId: mId, organizationId: org, authorId: userId, date: "2026-06-15", time: "09:30", text: "A" }));
-    const repo = new DrizzleServiceNoteRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzleServiceNoteRepository(handle.db);
     const list = await repo.listByMatter(mId, org);
     expect(list).toHaveLength(1);
     expect(list[0]!.author?.name).toBe("Anna");

--- a/test/unit/server/repositories/task-repository.test.ts
+++ b/test/unit/server/repositories/task-repository.test.ts
@@ -6,7 +6,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { matters, tasks } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleTaskRepository } from "@/lib/server/repositories/drizzle-task-repository";
 import { InMemoryTaskRepository } from "@/lib/server/repositories/in-memory-task-repository";
 import { uuidv7 } from "@/lib/shared/uuid";
@@ -52,7 +51,7 @@ describe("TaskRepository — Drizzle (pglite)", () => {
     await db.insert(tasks).values(v({ id: t1, userId, organizationId: org, title: "A", status: "TODO", matterId: mId }));
     await db.insert(tasks).values(v({ id: uuidv7(), userId, organizationId: org, title: "B", status: "DONE" }));
     await db.insert(tasks).values(v({ id: uuidv7(), userId: uuidv7(), organizationId: org, title: "Annan", status: "TODO" }));
-    const repo = new DrizzleTaskRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzleTaskRepository(handle.db);
     expect(await repo.listForUser(userId, org, {})).toHaveLength(2);
     expect(await repo.listForUser(userId, org, { status: "DONE" })).toHaveLength(1);
     const withMatter = (await repo.listForUser(userId, org, { status: "TODO" }))[0]!;

--- a/test/unit/server/repositories/time-entry-list-report-repository.test.ts
+++ b/test/unit/server/repositories/time-entry-list-report-repository.test.ts
@@ -7,7 +7,6 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { contacts, matterContacts, matters, timeEntries, users } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleTimeEntryRepository } from "@/lib/server/repositories/drizzle-time-entry-repository";
 import { InMemoryTimeEntryRepository } from "@/lib/server/repositories/in-memory-time-entry-repository";
 import { prebakeJoins } from "@/lib/shared/demo-source";
@@ -65,7 +64,7 @@ describe("TimeEntryRepository list/report — Drizzle (pglite)", () => {
     await db.insert(matterContacts).values(v({ id: uuidv7(), matterId: mId, contactId: cId, role: "KLIENT" }));
     await db.insert(timeEntries).values(v({ id: t1, userId, matterId: mId, minutes: 60, description: "a", hourlyRate: 1000, date: new Date("2026-06-02") }));
     await db.insert(timeEntries).values(v({ id: uuidv7(), userId, matterId: mId, minutes: 30, description: "b", hourlyRate: 1000, date: new Date("2026-06-03") }));
-    const repo = new DrizzleTimeEntryRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzleTimeEntryRepository(handle.db);
 
     const list = await repo.listForOrg(org, { page: 1, pageSize: 50 });
     expect(list.total).toBe(2);

--- a/test/unit/server/repositories/time-entry-repository.test.ts
+++ b/test/unit/server/repositories/time-entry-repository.test.ts
@@ -6,7 +6,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { contacts, matterContacts, matters, timeEntries, users } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleTimeEntryRepository } from "@/lib/server/repositories/drizzle-time-entry-repository";
 import { InMemoryTimeEntryRepository } from "@/lib/server/repositories/in-memory-time-entry-repository";
 import { uuidv7 } from "@/lib/shared/uuid";
@@ -56,7 +55,7 @@ describe("TimeEntryRepository — Drizzle (pglite)", () => {
     await db.insert(users).values(v({ id: userId, organizationId: org, email: "a@x", name: "Anna", hourlyRate: 150_000 }));
     await db.insert(timeEntries).values(v({ id: t1, userId, matterId: mId, date: new Date(), minutes: 60, description: "x", hourlyRate: 1000 }));
     await db.insert(timeEntries).values(v({ id: t2, userId, matterId: mId, date: new Date(), minutes: 30, description: "y", hourlyRate: 1000 }));
-    const repo = new DrizzleTimeEntryRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzleTimeEntryRepository(handle.db);
 
     const unbilled = await repo.listUnbilled(mId, [t1, t2]);
     expect(unbilled).toHaveLength(2);
@@ -133,7 +132,7 @@ describe("TimeEntryRepository — frysning/perLawyer/billable (Drizzle/pglite)",
     await db.insert(contacts).values(v({ id: f.cKli, organizationId: org, name: "Klient AB", contactType: "COMPANY" }));
     await db.insert(matterContacts).values(v({ id: uuidv7(), matterId: f.mId, contactId: f.cKli, role: "KLIENT" }));
     for (const r of f.rows) await db.insert(timeEntries).values(v({ ...r, organizationId: org, hourlyRate: 1000 }));
-    const repo = new DrizzleTimeEntryRepository(db as unknown as AppDb);
+    const repo = new DrizzleTimeEntryRepository(db);
 
     expect((await repo.listUnfrozenForMatter(f.mId)).map((t) => t.id))
       .toEqual([f.teOutside, f.teEarly, f.teNonBill, f.teLate]);

--- a/test/unit/server/repositories/user-repository.test.ts
+++ b/test/unit/server/repositories/user-repository.test.ts
@@ -6,7 +6,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { users } from "@/lib/server/db/schema";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleUserRepository } from "@/lib/server/repositories/drizzle-user-repository";
 import { InMemoryUserRepository } from "@/lib/server/repositories/in-memory-user-repository";
 import { uuidv7 } from "@/lib/shared/uuid";
@@ -47,7 +46,7 @@ describe("UserRepository — Drizzle (pglite)", () => {
     await db.insert(users).values(v({ id: u1, organizationId: org, email: "a@x", name: "Beta" }));
     await db.insert(users).values(v({ id: u2, organizationId: org, email: "b@x", name: "Alfa" }));
     await db.insert(users).values(v({ id: uuidv7(), organizationId: uuidv7(), email: "c@x", name: "Gamma" }));
-    const repo = new DrizzleUserRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzleUserRepository(handle.db);
     expect(await repo.getByIdInOrg(u1, org)).toMatchObject({ id: u1 });
     expect(await repo.getByIdInOrg(u1, uuidv7())).toBeNull();
     const list = await repo.listByOrg(org);

--- a/test/unit/server/repositories/write-off-repository.test.ts
+++ b/test/unit/server/repositories/write-off-repository.test.ts
@@ -6,7 +6,6 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
-import type { AppDb } from "@/lib/server/db/types";
 import { DrizzleWriteOffRepository } from "@/lib/server/repositories/drizzle-write-off-repository";
 import { InMemoryWriteOffRepository } from "@/lib/server/repositories/in-memory-write-off-repository";
 import { uuidv7 } from "@/lib/shared/uuid";
@@ -31,7 +30,7 @@ describe("WriteOffRepository — Drizzle (pglite)", () => {
 
   it("create + sumByInvoice summerar i SQL", async () => {
     const invoiceId = uuidv7();
-    const repo = new DrizzleWriteOffRepository(handle.db as unknown as AppDb);
+    const repo = new DrizzleWriteOffRepository(handle.db);
     await repo.create({ id: uuidv7(), invoiceId, amount: 70_000, writtenOffAt: new Date(), recordedById: uuidv7() } as never);
     await repo.create({ id: uuidv7(), invoiceId: uuidv7(), amount: 5_000, writtenOffAt: new Date(), recordedById: uuidv7() } as never);
     expect(await repo.sumByInvoice(invoiceId)).toBe(70_000);


### PR DESCRIPTION
Del 19 av #562 — bulk-städning av den klart största test-cast-kategorin.

`TestDbHandle.db` är redan typad `AppDb`, och `AppDb` är medvetet bred nog att både pglite- (test) och postgres-drivrutinen (prod) är assignbara (db/types.ts). Så alla **65** `handle.db as unknown as AppDb` / `drizzle(...) as unknown as AppDb` var REDUNDANTA — borttagna i ett svep (test + src `db/client` + `pg-test-db`-hjälparen). Orphanade `AppDb`-importer rensade.

Inga beteendeändringar (cast → identitet). Baseline −65.

Verifierat: full `bun run typecheck` (BÅDA tsconfig:arna, lärdom från #581) + `lint --max-warnings 0` + 153 repo/db-tester gröna.

Refs #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)