### PR TITLE
refactor(types): branda documentAnalysisSuggestions

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -59,11 +59,6 @@
       "count": 1
     }
   },
-  "src/lib/server/repositories/drizzle-document-suggestion-repository.ts": {
-    "no-restricted-syntax": {
-      "count": 3
-    }
-  },
   "src/lib/server/repositories/drizzle-org-preference-repository.ts": {
     "no-restricted-syntax": {
       "count": 2
@@ -90,11 +85,6 @@
     }
   },
   "src/lib/server/repositories/in-memory-write-off-repository.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "src/lib/server/routers/document/suggestions.ts": {
     "no-restricted-syntax": {
       "count": 1
     }

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -23,7 +23,8 @@ import type {
   SuggestionStatus,
 } from "@/lib/shared/schemas/enums";
 import type {
-  AccontoDeductionId, BillingRunId, CalendarEventId, ConflictCheckId, ContactId, DocumentFolderId, DocumentId,
+  AccontoDeductionId, BillingRunId, CalendarEventId, ConflictCheckId, ContactId,
+  DocumentAnalysisSuggestionId, DocumentFolderId, DocumentId,
   DocumentTemplateId, ExpenseId, InvoiceDispatchId, InvoiceId, MatterContactId, MatterEventSuggestionId,
   MatterId, OrganizationId, PaymentId, PaymentPlanId, PaymentPlanReminderId, ServiceNoteId, TaskId,
   TimeEntryId, UserId, WriteOffId,
@@ -317,17 +318,18 @@ export const documents = pgTable("documents", {
 
 export const documentAnalysisSuggestions = pgTable("document_analysis_suggestions", {
   ...baseColumns,
-  documentId: uuid("document_id").notNull(),
+  id: uuid("id").primaryKey().$type<DocumentAnalysisSuggestionId>(),
+  documentId: uuid("document_id").notNull().$type<DocumentId>(),
   name: text("name").notNull(),
-  role: text("role").notNull(),
-  contactType: text("contact_type").notNull(),
+  role: text("role").notNull().$type<MatterRole>(),
+  contactType: text("contact_type").notNull().$type<ContactType>(),
   email: text("email"),
   phone: text("phone"),
   orgNumber: text("org_number"),
   personalNumber: text("personal_number"),
   notes: text("notes"),
-  status: text("status").notNull().default("PENDING"),
-  acceptedContactId: uuid("accepted_contact_id"),
+  status: text("status").notNull().default("PENDING").$type<SuggestionStatus>(),
+  acceptedContactId: uuid("accepted_contact_id").$type<ContactId>(),
 }, (t) => [index("doc_analysis_suggestions_doc_idx").on(t.documentId)]);
 
 export const matterEventSuggestions = pgTable("matter_event_suggestions", {

--- a/src/lib/server/repositories/drizzle-document-suggestion-repository.ts
+++ b/src/lib/server/repositories/drizzle-document-suggestion-repository.ts
@@ -27,10 +27,10 @@ export class DrizzleDocumentSuggestionRepository
       .select({ s: S, matterId: documents.matterId }).from(S)
       .innerJoin(documents, eq(S.documentId, documents.id))
       .innerJoin(matters, eq(documents.matterId, matters.id))
-      .where(and(eq(S.id, id), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(S.deletedAt)))
+      .where(and(eq(S.id, asId<"DocumentAnalysisSuggestionId">(id)), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(S.deletedAt)))
       .limit(1);
     const r = rows[0];
-    return r ? ({ ...(r.s as object), document: { matterId: r.matterId as string } } as unknown as SuggestionWithMatter) : null;
+    return r ? ({ ...r.s, document: { matterId: r.matterId } }) : null;
   }
 
   async listPendingForMatter(matterId: string, organizationId: string, order: "asc" | "desc"): Promise<SuggestionListRow[]> {
@@ -44,9 +44,9 @@ export class DrizzleDocumentSuggestionRepository
       ))
       .orderBy(order === "asc" ? asc(S.createdAt) : desc(S.createdAt));
     return rows.map((r) => ({
-      ...(r.s as object),
-      document: { id: r.dId as string, fileName: r.dFile as string, title: (r.dTitle as string | null) ?? null },
-    })) as unknown as SuggestionListRow[];
+      ...r.s,
+      document: { id: r.dId, fileName: r.dFile, title: r.dTitle ?? null },
+    }));
   }
 
   async listPendingByIds(ids: string[], organizationId: string): Promise<SuggestionWithMatter[]> {
@@ -55,8 +55,8 @@ export class DrizzleDocumentSuggestionRepository
       .select({ s: S, matterId: documents.matterId }).from(S)
       .innerJoin(documents, eq(S.documentId, documents.id))
       .innerJoin(matters, eq(documents.matterId, matters.id))
-      .where(and(inArray(S.id, ids), eq(S.status, "PENDING"), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(S.deletedAt)));
-    return rows.map((r) => ({ ...(r.s as object), document: { matterId: r.matterId as string } })) as unknown as SuggestionWithMatter[];
+      .where(and(inArray(S.id, ids.map((i) => asId<"DocumentAnalysisSuggestionId">(i))), eq(S.status, "PENDING"), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(S.deletedAt)));
+    return rows.map((r) => ({ ...r.s, document: { matterId: r.matterId } }));
   }
 
   async listByIdsInOrg(ids: string[], organizationId: string): Promise<Array<{ id: string }>> {
@@ -65,12 +65,12 @@ export class DrizzleDocumentSuggestionRepository
       .select({ id: S.id }).from(S)
       .innerJoin(documents, eq(S.documentId, documents.id))
       .innerJoin(matters, eq(documents.matterId, matters.id))
-      .where(and(inArray(S.id, ids), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(S.deletedAt)));
+      .where(and(inArray(S.id, ids.map((i) => asId<"DocumentAnalysisSuggestionId">(i))), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(S.deletedAt)));
     return rows.map((r) => ({ id: r.id as string }));
   }
 
   async updateManyByIds(ids: string[], patch: Partial<DocumentAnalysisSuggestion>): Promise<void> {
     if (!ids.length) return;
-    await this.db.update(S).set(patch as never).where(inArray(S.id, ids));
+    await this.db.update(S).set(patch as never).where(inArray(S.id, ids.map((i) => asId<"DocumentAnalysisSuggestionId">(i))));
   }
 }

--- a/src/lib/server/routers/document/suggestions.ts
+++ b/src/lib/server/routers/document/suggestions.ts
@@ -17,7 +17,7 @@ import type { DocumentAnalysisSuggestion } from "@/lib/shared/schemas/document";
 import { matterRoleSchema, contactTypeSchema, type SuggestionStatus } from "@/lib/shared/schemas/enums";
 import { asId, type ContactId } from "@/lib/shared/schemas/ids";
 import type { MatterContact } from "@/lib/shared/schemas/matter";
-import { groupSuggestions, type RawSuggestion } from "@/lib/shared/suggestion-grouping";
+import { groupSuggestions } from "@/lib/shared/suggestion-grouping";
 import type { Repositories } from "../../repositories/repositories";
 import { orgProcedure } from "../../trpc";
 
@@ -256,7 +256,7 @@ export const suggestionProcedures = {
     .input(z.object({ matterId: z.string() }))
     .query(async ({ ctx, input }) => {
       const rows = await ctx.repos.documentAnalysisSuggestions.listPendingForMatter(input.matterId, ctx.orgId, "asc");
-      return groupSuggestions(rows as unknown as RawSuggestion[]);
+      return groupSuggestions(rows);
     }),
 
   /**

--- a/src/lib/shared/suggestion-grouping.ts
+++ b/src/lib/shared/suggestion-grouping.ts
@@ -19,11 +19,11 @@ export interface RawSuggestion {
   name: string;
   role: string;
   contactType: string;
-  email: string | null;
-  phone: string | null;
-  orgNumber: string | null;
-  personalNumber: string | null;
-  notes: string | null;
+  email?: string | null | undefined;
+  phone?: string | null | undefined;
+  orgNumber?: string | null | undefined;
+  personalNumber?: string | null | undefined;
+  notes?: string | null | undefined;
   document: { id: string; fileName: string; title: string | null };
 }
 


### PR DESCRIPTION
Del 20 av #562 (Fas 2) — sista billing/dokument-entiteten.

- **documentAnalysisSuggestions**: id/documentId/acceptedContactId + enum `role` (MatterRole), `contactType` (ContactType), `status` (SuggestionStatus).
- suggestion-repo: alla 3 projektioner (getByIdInOrg/listPendingForMatter/listPendingByIds) typas utan `as object`/`as unknown as`.
- Router `pendingSuggestionsGrouped`: `RawSuggestion`-fälten vidgas till `?: string | null | undefined` (matchar schemats `.nullish()`) → `groupSuggestions(rows)` utan cast.

4 `as unknown as` bort. Baseline 200 → 196. Full `bun run typecheck` (båda configs) + lint + 31 tester gröna.

Refs #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)