### PR TITLE
refactor(repositories): brand preference tables + drop double-casts (#562)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -59,16 +59,6 @@
       "count": 1
     }
   },
-  "src/lib/server/repositories/drizzle-org-preference-repository.ts": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
-  "src/lib/server/repositories/drizzle-user-preference-repository.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "src/lib/server/repositories/in-memory-document-template-repository.ts": {
     "no-restricted-syntax": {
       "count": 1

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -26,8 +26,8 @@ import type {
   AccontoDeductionId, BillingRunId, CalendarEventId, ConflictCheckId, ContactId,
   DocumentAnalysisSuggestionId, DocumentFolderId, DocumentId,
   DocumentTemplateId, ExpenseId, InvoiceDispatchId, InvoiceId, MatterContactId, MatterEventSuggestionId,
-  MatterId, OrganizationId, PaymentId, PaymentPlanId, PaymentPlanReminderId, ServiceNoteId, TaskId,
-  TimeEntryId, UserId, WriteOffId,
+  MatterId, OrganizationId, OrgPreferenceId, PaymentId, PaymentPlanId, PaymentPlanReminderId,
+  ServiceNoteId, TaskId, TimeEntryId, UserId, UserPreferenceId, WriteOffId,
 } from "@/lib/shared/schemas/ids";
 import { baseColumns, boolDefault, orgScopedColumns } from "./columns";
 
@@ -399,17 +399,20 @@ export const serviceNotes = pgTable("service_notes", {
 
 export const userPreferences = pgTable("user_preferences", {
   ...baseColumns,
-  userId: uuid("user_id").notNull(),
-  organizationId: uuid("organization_id"),
+  id: uuid("id").primaryKey().$type<UserPreferenceId>(),
+  userId: uuid("user_id").notNull().$type<UserId>(),
+  organizationId: uuid("organization_id").$type<OrganizationId>(),
   key: text("key").notNull(),
-  prefs: jsonb("prefs").notNull(),
+  prefs: jsonb("prefs").notNull().$type<Record<string, unknown>>(),
 }, (t) => [index("user_preferences_user_idx").on(t.userId)]);
 
 export const orgPreferences = pgTable("org_preferences", {
   ...orgScopedColumns,
+  id: uuid("id").primaryKey().$type<OrgPreferenceId>(),
+  organizationId: uuid("organization_id").notNull().$type<OrganizationId>(),
   key: text("key").notNull(),
-  prefs: jsonb("prefs").notNull(),
-  createdById: uuid("created_by_id"),
+  prefs: jsonb("prefs").notNull().$type<Record<string, unknown>>(),
+  createdById: uuid("created_by_id").$type<UserId>(),
 });
 
 export const documentTemplates = pgTable("document_templates", {

--- a/src/lib/server/repositories/drizzle-org-preference-repository.ts
+++ b/src/lib/server/repositories/drizzle-org-preference-repository.ts
@@ -1,6 +1,7 @@
 /** Drizzle `OrgPreferenceRepository` (ADR 0020). */
 
 import { and, asc, eq, isNull } from "drizzle-orm";
+import { asId } from "@/lib/shared/schemas/ids";
 import type { OrgPreference } from "@/lib/shared/schemas/preference";
 import { orgPreferences } from "../db/schema";
 import type { AppDb } from "../db/types";
@@ -15,16 +16,16 @@ export class DrizzleOrgPreferenceRepository extends DrizzleRepository<OrgPrefere
   async getByOrgKey(organizationId: string, key: string): Promise<OrgPreference | null> {
     const rows = await this.db
       .select().from(orgPreferences)
-      .where(and(eq(orgPreferences.organizationId, organizationId), eq(orgPreferences.key, key), isNull(orgPreferences.deletedAt)))
+      .where(and(eq(orgPreferences.organizationId, asId<"OrganizationId">(organizationId)), eq(orgPreferences.key, key), isNull(orgPreferences.deletedAt)))
       .limit(1);
-    return (rows[0] as unknown as OrgPreference | undefined) ?? null;
+    return rows[0] ?? null;
   }
 
   async listByOrg(organizationId: string): Promise<OrgPreference[]> {
     const rows = await this.db
       .select().from(orgPreferences)
-      .where(and(eq(orgPreferences.organizationId, organizationId), isNull(orgPreferences.deletedAt)))
+      .where(and(eq(orgPreferences.organizationId, asId<"OrganizationId">(organizationId)), isNull(orgPreferences.deletedAt)))
       .orderBy(asc(orgPreferences.key));
-    return rows as unknown as OrgPreference[];
+    return rows;
   }
 }

--- a/src/lib/server/repositories/drizzle-user-preference-repository.ts
+++ b/src/lib/server/repositories/drizzle-user-preference-repository.ts
@@ -1,6 +1,7 @@
 /** Drizzle `UserPreferenceRepository` (ADR 0020). */
 
 import { and, eq, isNull } from "drizzle-orm";
+import { asId } from "@/lib/shared/schemas/ids";
 import type { UserPreference } from "@/lib/shared/schemas/preference";
 import { userPreferences } from "../db/schema";
 import type { AppDb } from "../db/types";
@@ -15,8 +16,8 @@ export class DrizzleUserPreferenceRepository extends DrizzleRepository<UserPrefe
   async getByUserKey(userId: string, organizationId: string, key: string): Promise<UserPreference | null> {
     const rows = await this.db
       .select().from(userPreferences)
-      .where(and(eq(userPreferences.userId, userId), eq(userPreferences.organizationId, organizationId), eq(userPreferences.key, key), isNull(userPreferences.deletedAt)))
+      .where(and(eq(userPreferences.userId, asId<"UserId">(userId)), eq(userPreferences.organizationId, asId<"OrganizationId">(organizationId)), eq(userPreferences.key, key), isNull(userPreferences.deletedAt)))
       .limit(1);
-    return (rows[0] as unknown as UserPreference | undefined) ?? null;
+    return rows[0] ?? null;
   }
 }

--- a/src/lib/shared/schemas/preference.ts
+++ b/src/lib/shared/schemas/preference.ts
@@ -15,7 +15,7 @@ const prefsPayloadSchema = z.record(z.string(), z.unknown());
 export const userPreferenceSchema = z.object({
   id: userPreferenceIdSchema,
   userId: userIdSchema,
-  organizationId: organizationIdSchema.optional(),
+  organizationId: organizationIdSchema.nullish(),
   /** Stabil nyckel: "list.contacts", "list.matters", … (1 per UI-vy). */
   key: z.string(),
   prefs: prefsPayloadSchema,
@@ -31,7 +31,7 @@ export const orgPreferenceSchema = z.object({
   key: z.string(),
   prefs: prefsPayloadSchema,
   /** Admin som satte default:en (audit-spår). */
-  createdById: userIdSchema.optional(),
+  createdById: userIdSchema.nullish(),
   createdAt: z.union([z.date(), z.string()]).optional(),
   updatedAt: z.union([z.date(), z.string()]).optional(),
 }).passthrough();


### PR DESCRIPTION
## Vad

Fas 2 av #562 (ADR 0026): tar bort fler `as unknown as`-double-casts genom att brand:a `userPreferences`/`orgPreferences`-kolumnerna och applicera `asId<...>()` vid `eq()`-värdesiterna i drizzle-preference-repos.

- Brand:ade kolumner (`.$type<XId>()`) på `userPreferences` (id/userId/organizationId/prefs) och `orgPreferences` (id/organizationId/createdById/prefs).
- 3 st `as unknown as OrgPreference/UserPreference`-casts → direkta returer (`rows[0] ?? null` / `return rows`).
- `organizationId`/`createdById` → `.nullish()` i schemat (DB-kolumnerna är nullable → måste acceptera `null` lika väl som `undefined`, annars droppar strict-parse rader).
- Rensar 3 inaktuella lint-suppressions.

## Verifiering
- `bun run typecheck` (båda configs, efter `rm tsconfig.tsbuildinfo`) — 0 fel.
- `bun run lint` (max-warnings 0) — rent.
- `bun test preference-repository.test.ts` — 2 pass.

Refs #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)