### PR TITLE
refactor(repositories): drop double-casts in in-memory repos (#562)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -59,26 +59,6 @@
       "count": 1
     }
   },
-  "src/lib/server/repositories/in-memory-document-template-repository.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "src/lib/server/repositories/in-memory-matter-contact-repository.ts": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
-  "src/lib/server/repositories/in-memory-payment-repository.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "src/lib/server/repositories/in-memory-write-off-repository.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "src/lib/shared/demo-source.ts": {
     "no-restricted-syntax": {
       "count": 1

--- a/src/lib/server/repositories/in-memory-document-template-repository.ts
+++ b/src/lib/server/repositories/in-memory-document-template-repository.ts
@@ -14,19 +14,28 @@ export type DocumentTemplateRepoSource = Pick<IDataStore, "documentTemplates">;
 export class InMemoryDocumentTemplateRepository
   extends InMemoryRepository<DocumentTemplate>
   implements DocumentTemplateRepository {
-  constructor(store: DocumentTemplateRepoSource, now?: () => Date) {
-    super(store.documentTemplates, now ?? (() => new Date()));
+  constructor(private readonly source: DocumentTemplateRepoSource, now?: () => Date) {
+    super(source.documentTemplates, now ?? (() => new Date()));
   }
 
   async listForOrg(organizationId: string): Promise<DocumentTemplateListRow[]> {
-    return (await this.delegate.findMany({
+    const rows = await this.source.documentTemplates.findMany({
       where: { organizationId },
       select: {
         id: true, name: true, description: true, category: true,
         createdAt: true, updatedAt: true, createdBy: { select: { name: true } },
       },
       orderBy: [{ category: "asc" }, { name: "asc" }],
-    })) as unknown as DocumentTemplateListRow[];
+    });
+    return rows.map((r): DocumentTemplateListRow => ({
+      id: r.id,
+      name: r.name,
+      description: r.description ?? null,
+      category: r.category ?? null,
+      createdAt: r.createdAt,
+      updatedAt: r.updatedAt ?? null,
+      createdBy: (r.createdBy ?? null) as { name: string } | null,
+    }));
   }
 
   async getByIdInOrg(id: string, organizationId: string): Promise<DocumentTemplateRow | null> {

--- a/src/lib/server/repositories/in-memory-matter-contact-repository.ts
+++ b/src/lib/server/repositories/in-memory-matter-contact-repository.ts
@@ -26,8 +26,8 @@ const MC_INCLUDE = {
 export class InMemoryMatterContactRepository
   extends InMemoryRepository<MatterContact>
   implements MatterContactRepository {
-  constructor(store: MatterContactRepoSource, now?: () => Date) {
-    super(store.matterContacts, now ?? (() => new Date()));
+  constructor(private readonly source: MatterContactRepoSource, now?: () => Date) {
+    super(source.matterContacts, now ?? (() => new Date()));
   }
 
   async findForConflict(organizationId: string, numberTerm?: string): Promise<ConflictContactRow[]> {
@@ -37,7 +37,14 @@ export class InMemoryMatterContactRepository
           contact: { OR: [{ personalNumber: { contains: numberTerm } }, { orgNumber: { contains: numberTerm } }] },
         }
       : { matter: { organizationId } };
-    return (await this.delegate.findMany({ where, include: MC_INCLUDE })) as unknown as ConflictContactRow[];
+    const rows = await this.source.matterContacts.findMany({ where, include: MC_INCLUDE });
+    // contact/matter joinas i runtime (MC_INCLUDE) men typas `unknown` av
+    // JoinedRelations — narrowa varje join till jävskontroll-projektionen.
+    return rows.map((r): ConflictContactRow => ({
+      role: r.role,
+      contact: r.contact as ConflictContactRow["contact"],
+      matter: r.matter as ConflictContactRow["matter"],
+    }));
   }
 
   async getByIdInOrg(id: string, organizationId: string): Promise<MatterContact | null> {
@@ -48,8 +55,10 @@ export class InMemoryMatterContactRepository
   }
 
   async linkContact(data: Partial<MatterContact>): Promise<MatterContactWithContact> {
-    // create enrichar raden med contact (LocalStore.enrichRowForEntity).
-    return (await this.create(data)) as unknown as MatterContactWithContact;
+    // create enrichar raden med contact (LocalStore.enrichRowForEntity) — den
+    // körda raden är en MatterContactWithContact (smal subtyp-assertion).
+    const row = await this.create(data);
+    return row as MatterContactWithContact;
   }
 
   async findLink(matterId: string, contactId: string, role: string): Promise<MatterContact | null> {

--- a/src/lib/server/repositories/in-memory-payment-repository.ts
+++ b/src/lib/server/repositories/in-memory-payment-repository.ts
@@ -12,12 +12,12 @@ import type { PaymentRepository } from "./payment-repository";
 export type PaymentRepoSource = Pick<IDataStore, "payments">;
 
 export class InMemoryPaymentRepository extends InMemoryRepository<Payment> implements PaymentRepository {
-  constructor(store: PaymentRepoSource, now?: () => Date) {
-    super(store.payments, now ?? (() => new Date()));
+  constructor(private readonly source: PaymentRepoSource, now?: () => Date) {
+    super(source.payments, now ?? (() => new Date()));
   }
 
   async sumByInvoice(invoiceId: string): Promise<number> {
-    const rows = (await this.delegate.findMany({ where: { invoiceId } })) as unknown as ReadonlyArray<Payment>;
+    const rows = await this.source.payments.findMany({ where: { invoiceId } });
     return rows
       .filter((r) => !(r as { deletedAt?: unknown }).deletedAt)
       .reduce((s, p) => s + p.amount, 0);
@@ -25,6 +25,6 @@ export class InMemoryPaymentRepository extends InMemoryRepository<Payment> imple
 
   async listByInvoiceIds(invoiceIds: string[]): Promise<Payment[]> {
     if (!invoiceIds.length) return [];
-    return (await this.delegate.findMany({ where: { invoiceId: { in: invoiceIds } } })) as Payment[];
+    return this.source.payments.findMany({ where: { invoiceId: { in: invoiceIds } } });
   }
 }

--- a/src/lib/server/repositories/in-memory-write-off-repository.ts
+++ b/src/lib/server/repositories/in-memory-write-off-repository.ts
@@ -12,12 +12,12 @@ import type { WriteOffRepository } from "./write-off-repository";
 export type WriteOffRepoSource = Pick<IDataStore, "writeOffs">;
 
 export class InMemoryWriteOffRepository extends InMemoryRepository<WriteOff> implements WriteOffRepository {
-  constructor(store: WriteOffRepoSource, now?: () => Date) {
-    super(store.writeOffs, now ?? (() => new Date()));
+  constructor(private readonly source: WriteOffRepoSource, now?: () => Date) {
+    super(source.writeOffs, now ?? (() => new Date()));
   }
 
   async sumByInvoice(invoiceId: string): Promise<number> {
-    const rows = (await this.delegate.findMany({ where: { invoiceId } })) as unknown as ReadonlyArray<WriteOff>;
+    const rows = await this.source.writeOffs.findMany({ where: { invoiceId } });
     return rows
       .filter((r) => !(r as { deletedAt?: unknown }).deletedAt)
       .reduce((s, w) => s + w.amount, 0);
@@ -25,6 +25,6 @@ export class InMemoryWriteOffRepository extends InMemoryRepository<WriteOff> imp
 
   async listByInvoiceIds(invoiceIds: string[]): Promise<WriteOff[]> {
     if (!invoiceIds.length) return [];
-    return (await this.delegate.findMany({ where: { invoiceId: { in: invoiceIds } } })) as WriteOff[];
+    return this.source.writeOffs.findMany({ where: { invoiceId: { in: invoiceIds } } });
   }
 }


### PR DESCRIPTION
## Vad

Fas 2 av #562 (ADR 0026): tar bort 5 `as unknown as`-double-casts i in-memory-repositories.

Varje in-memory-repo får en **typad** source-delegate (`IDataStore["writeOffs"]` = `Delegate<WriteOff>` osv.) men bas-klassen `InMemoryRepository` raderar den till den otypade `Delegate`. Genom att behålla en typad referens till source:n:

- **write-off / payment** `sumByInvoice` + `listByInvoiceIds` läser `findMany()`-resultatet som `Joined<Row>[]` direkt — **ingen cast alls**.
- **document-template** `listForOrg` + **matter-contact** `findForConflict` bygger sina projektion-typer via en typad `.map()`-callback och narrowar bara de `unknown`-typade join-fälten med **enkla** casts (inte `as unknown as`).
- **matter-contact** `linkContact` returnerar en enkel subtyp-assertion.

## Verifiering
- `bun run typecheck` (båda configs, efter `rm tsconfig.tsbuildinfo`) — 0 fel.
- `bun run lint` (max-warnings 0) — rent.
- `bun test` repo-tester (write-off/payment/document-template/conflict-matter-contact) — 23 pass.

Refs #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)