### PR TITLE
refactor(demo): type DemoSource fields via mapped view rows (#562)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -9,11 +9,6 @@
       "count": 4
     }
   },
-  "src/app/demo/_demo-client.tsx": {
-    "no-restricted-syntax": {
-      "count": 3
-    }
-  },
   "src/app/matters/[id]/_billing-dialog.tsx": {
     "no-restricted-syntax": {
       "count": 1

--- a/src/app/demo/_demo-client.tsx
+++ b/src/app/demo/_demo-client.tsx
@@ -54,9 +54,26 @@ export function DemoClient({
   // Ref istället för state — vi vill inte trigga rerender när flaggan sätts.
   const autoLoadAttempted = useRef(false);
 
-  const matters = (source.matters ?? []) as unknown as MatterLike[];
-  const contacts = (source.contacts ?? []) as unknown as ContactLike[];
-  const users = (source.users ?? []) as unknown as UserLike[];
+  // `DemoSource`-fälten är medvetet otypad JSON (`Record<string, unknown>`) —
+  // narrowa varje fält till vy-typen vid konsumtions-gränsen.
+  const matters: readonly MatterLike[] = (source.matters ?? []).map((m) => ({
+    id: m.id as string,
+    matterNumber: m.matterNumber as string,
+    title: m.title as string,
+    status: m.status as string,
+  }));
+  const contacts: readonly ContactLike[] = (source.contacts ?? []).map((c) => ({
+    id: c.id as string,
+    name: c.name as string,
+    contactType: c.contactType as string,
+    email: (c.email ?? null) as string | null,
+  }));
+  const users: readonly UserLike[] = (source.users ?? []).map((u) => ({
+    id: u.id as string,
+    email: u.email as string,
+    name: u.name as string,
+    role: u.role as string,
+  }));
 
   async function handleLoad(): Promise<void> {
     if (!url.trim()) return;
@@ -140,7 +157,7 @@ function DemoStatusBanners({ status, error }: StatusBannersProps) {
   );
 }
 
-interface ResultsProps { matters: MatterLike[]; contacts: ContactLike[]; users: UserLike[] }
+interface ResultsProps { matters: readonly MatterLike[]; contacts: readonly ContactLike[]; users: readonly UserLike[] }
 
 /** Resultat-vyn när demon laddats: summering + listor per entitet. */
 function DemoResults({ matters, contacts, users }: ResultsProps) {


### PR DESCRIPTION
## Vad

Fas 2 av #562 (ADR 0026): tar bort 3 `as unknown as`-double-casts i `DemoClient`.

`DemoSource`-fälten är **medvetet** otypad JSON (`readonly Record<string, unknown>[]` — ramverks-agnostiskt format, ADR 0016/0025). Komponenten castade dem till sina lokala `*Like`-vy-typer med `as unknown as`. Ersatt med en typad `.map()` som narrowar varje JSON-fält vid konsumtions-gränsen (enkla `unknown as string`-assertions, inte double-casts). Vy-arrayerna är `readonly` eftersom de bara läses.

## Verifiering
- `bun run typecheck` (båda configs, efter `rm tsconfig.tsbuildinfo`) — 0 fel.
- `bun run lint` (max-warnings 0) — rent.
- `bun test demo-client` — 12 pass.

Refs #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)