### PR TITLE
refactor(ui): drop DocUtils + dashboard double-casts (#562)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,19 +1,4 @@
 {
-  "src/app/matters/[id]/_billing-dialog.tsx": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "src/app/matters/[id]/_verdict-dialog.tsx": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "src/app/page.tsx": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "src/lib/client/backend/server-first-store.ts": {
     "no-restricted-syntax": {
       "count": 1

--- a/src/app/matters/[id]/_billing-dialog.tsx
+++ b/src/app/matters/[id]/_billing-dialog.tsx
@@ -14,7 +14,6 @@ import { useState } from "react";
 import { Modal } from "@/components/ui/modal";
 import {
   generateFakturaDoc,
-  type DocUtils,
   type FakturaDocInvoice,
   type FakturaDocMeta,
 } from "@/lib/client/kostnadsrakning/generate-faktura-doc";
@@ -66,7 +65,7 @@ function useFakturaDoc(matterId: string, meta: BillingMeta): (invoice: FakturaDo
   };
   return async (invoice: FakturaDocInvoice) => {
     try {
-      await generateFakturaDoc({ invoice, matterId, meta: docMeta, register, utils: utils as unknown as DocUtils });
+      await generateFakturaDoc({ invoice, matterId, meta: docMeta, register, utils });
     } catch (e) { console.warn("[billing] faktura-dokument misslyckades:", e); }
   };
 }

--- a/src/app/matters/[id]/_verdict-dialog.tsx
+++ b/src/app/matters/[id]/_verdict-dialog.tsx
@@ -13,7 +13,7 @@
  */
 import { useState } from "react";
 import { Modal } from "@/components/ui/modal";
-import { generateFakturaDoc, type DocUtils } from "@/lib/client/kostnadsrakning/generate-faktura-doc";
+import { generateFakturaDoc } from "@/lib/client/kostnadsrakning/generate-faktura-doc";
 import { trpc } from "@/lib/client/trpc";
 import { formatCurrency } from "@/lib/client/utils";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
@@ -50,7 +50,7 @@ export function VerdictDialog(props: Props) {
               organizationOrgNumber: props.organizationOrgNumber,
             }),
           },
-          register, utils: utils as unknown as DocUtils,
+          register, utils,
         });
       } catch (e) { console.warn("[verdict] faktura-dokument misslyckades:", e); }
       onClose();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -306,7 +306,7 @@ function TimeCard({ ymd }: { ymd: string }) {
   const entries = trpc.timeEntry.list.useQuery(
     { userId: me.data?.id, from: range.from, to: range.to, pageSize: 50 },
     { enabled: !!me.data?.id },
-  ) as unknown as TimeQueryLike;
+  ) as TimeQueryLike;
 
   return (
     <div className="bg-white rounded-lg border border-gray-200">


### PR DESCRIPTION
## Vad

Fas 2 av #562 (ADR 0026): tar bort 3 `as unknown as`-double-casts i UI:t.

- **matters verdict-/billing-dialog**: `trpc.useUtils()` är en strukturell superset av `DocUtils` → skicka `utils` direkt, **ingen cast alls** (och ta bort den nu oanvända `DocUtils`-importen).
- **dashboard TimeCard**: `useQuery`-resultatet exponerar redan `data`/`isLoading` → en **enkel** `as TimeQueryLike`-gräns-narrowing ersätter double-castet.

## Verifiering
- `bun run typecheck` (båda configs, efter `rm tsconfig.tsbuildinfo`) — 0 fel.
- `bun run lint` (max-warnings 0) — rent.
- `bun test` (verdict/billing-dialog + timeEntry/scenario/seed-smoke) — 95 pass.

Refs #562 — 2 fullt cast-fria, 1 reducerad till enkel-cast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)