### PR TITLE
refactor(data-store): drop double-casts in in-memory seam (#562)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -9,22 +9,7 @@
       "count": 1
     }
   },
-  "src/lib/server/data-store/in-memory/local-store.ts": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
-  "src/lib/server/data-store/in-memory/writable-delegate.ts": {
-    "no-restricted-syntax": {
-      "count": 3
-    }
-  },
   "src/lib/server/http/server-context.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "src/lib/shared/demo-source.ts": {
     "no-restricted-syntax": {
       "count": 1
     }

--- a/src/lib/server/data-store/in-memory/local-store.ts
+++ b/src/lib/server/data-store/in-memory/local-store.ts
@@ -136,7 +136,7 @@ export class LocalStore implements IDataStore {
     this.orgPreferences = this.makeDelegate("orgPreferences");
 
     this.events = new ReadOnlyEventLog();
-    this.raw = makeThrowingProxy() as unknown as IDataStore["raw"];
+    this.raw = makeThrowingProxy();
   }
 
   /** Den aktuella in-memory-källan (för persistens/snapshot). Läs, mutera ej. */
@@ -156,7 +156,7 @@ export class LocalStore implements IDataStore {
           if (!this.source[key]) {
             (this.source as Record<string, unknown[]>)[key as string] = [];
           }
-          return (this.source[key] ?? []) as unknown as T[];
+          return (this.source[key] ?? []) as T[];
         },
         relations,
         // Routa via handleMutate så att event buffras under en transaction()

--- a/src/lib/server/data-store/in-memory/writable-delegate.ts
+++ b/src/lib/server/data-store/in-memory/writable-delegate.ts
@@ -67,12 +67,16 @@ export class WritableDelegate<T extends Record<string, unknown>> extends ReadOnl
   override async create(args: unknown): Promise<never> {
     const a = args as { data: Partial<T> };
     const id = (a.data as { id?: string }).id ?? (this.wopts.generateId ?? genId)();
-    const row = {
+    // Bygg raden som Record<string, unknown> (T extends den) → `as T` blir en
+    // enkel boundary-cast i st.f. en double-cast. Runtime-fullständigheten
+    // garanteras av routern (Partial<T> + id/timestamps).
+    const built: Record<string, unknown> = {
       ...a.data,
       id,
       createdAt: (a.data as { createdAt?: Date }).createdAt ?? new Date(),
       updatedAt: new Date(),
-    } as unknown as T;
+    };
+    const row = built as T;
     this.collection.push(row);
     const enriched = this.wopts.enrichRow ? this.wopts.enrichRow(row) : row;
     // Skriv tillbaka enriched-row så framtida read:s ser pre-bakade joins
@@ -110,7 +114,7 @@ export class WritableDelegate<T extends Record<string, unknown>> extends ReadOnl
     const matches = await this.findMany(a.where !== undefined ? { where: a.where } : {});
     let count = 0;
     for (const m of matches) {
-      await this.update({ where: { id: (m as unknown as { id: string }).id }, data: a.data });
+      await this.update({ where: { id: m.id as string }, data: a.data });
       count++;
     }
     return { count } as never;
@@ -121,7 +125,7 @@ export class WritableDelegate<T extends Record<string, unknown>> extends ReadOnl
     const matches = await this.findMany(a.where !== undefined ? { where: a.where } : {});
     let count = 0;
     for (const m of matches) {
-      await this.delete({ where: { id: (m as unknown as { id: string }).id } });
+      await this.delete({ where: { id: m.id as string } });
       count++;
     }
     return { count } as never;

--- a/src/lib/shared/demo-source.ts
+++ b/src/lib/shared/demo-source.ts
@@ -47,13 +47,6 @@ export interface DemoSource {
   orgPreferences?: readonly Record<string, unknown>[];
 }
 
-interface RawMatterContact {
-  id: string;
-  matterId: string;
-  contactId: string;
-  [k: string]: unknown;
-}
-
 /**
  * Pre-baka enkla relations-joins på en `DemoSource`
  * (matterContact.contact/matter, document/timeEntry/expense/invoice.matter)
@@ -68,10 +61,10 @@ export function prebakeJoins(source: DemoSource): DemoSource {
   const mattersById = new Map((out.matters ?? []).map((m) => [(m as { id: string }).id, m]));
 
   if (out.matterContacts) {
-    out.matterContacts = (out.matterContacts as unknown as RawMatterContact[]).map((mc) => ({
+    out.matterContacts = out.matterContacts.map((mc) => ({
       ...mc,
-      contact: contactsById.get(mc.contactId) ?? null,
-      matter: mattersById.get(mc.matterId) ?? null,
+      contact: contactsById.get(mc.contactId as string) ?? null,
+      matter: mattersById.get(mc.matterId as string) ?? null,
     })) as readonly Record<string, unknown>[];
   }
 


### PR DESCRIPTION
## Vad

Fas 2 av #562 (ADR 0026): tar bort 6 `as unknown as`-double-casts i in-memory data-store-sömmen.

- **writable-delegate**: bygg create-raden via ett explicit `Record<string, unknown>`-mellansteg så att `built as T` blir en **enkel** boundary-cast (`T extends Record<string,unknown>`); `updateMany`/`deleteMany` läser `m.id` via constraint-index-signaturen (`m.id as string`).
- **local-store**: `IDataStore['raw']` är redan `unknown` → proxy-castet var redundant (borttaget); `source[key]` narrowas med en enkel `as T[]`.
- **demo-source**: ta bort `RawMatterContact`-pre-castet i `prebakeJoins`, narrowa de två id-fälten inline (`as string`); ta bort det nu oanvända interfacet.

## Verifiering
- `bun run typecheck` (båda configs, efter `rm tsconfig.tsbuildinfo`) — 0 fel.
- `bun run lint` (max-warnings 0) — rent.
- `bun test` (20 filer som kör delegate-/demo-store-/router-vägarna) — 131 pass.

Refs #562. (Kvar i src: server-context partial-stub, static-params seed, server-first-store — kräver mer omtanke/omstrukturering.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)