### PR TITLE
refactor(demo): drop double-casts in static-params + server-first sync (#562)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,14 +1,4 @@
 {
-  "src/lib/client/backend/server-first-store.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "src/lib/client/demo/static-params.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "src/lib/server/http/server-context.ts": {
     "no-restricted-syntax": {
       "count": 1

--- a/src/lib/client/backend/server-first-store.ts
+++ b/src/lib/client/backend/server-first-store.ts
@@ -66,7 +66,7 @@ export async function createServerFirstStore(deps: ServerFirstStoreDeps = {}): P
     // Byte-synk (#518, ADR 0023): ladda upp dokument-blobbar servern saknar.
     // Best-effort — får aldrig ta ned bootstrappen (tom pending → no-op).
     const { syncDocumentContent } = await import("./content-sync");
-    void syncDocumentContent(client as unknown as Parameters<typeof syncDocumentContent>[0]).catch(() => {});
+    void syncDocumentContent(client).catch(() => {});
   }
   return cachingSync;
 }

--- a/src/lib/client/demo/static-params.ts
+++ b/src/lib/client/demo/static-params.ts
@@ -93,8 +93,8 @@ export async function demoStaticParamsBySeedId(sourceKey: string): Promise<{ id:
       currentUserId: DEMO_CURRENT_USER_ID,
       emailDomain: DEMO_EMAIL_DOMAIN,
       organizationName: DEMO_ORG_NAME,
-    }), createIdTranslator()) as unknown as Record<string, Array<{ id?: string }>>;
-    const list = seed[sourceKey] ?? [];
+    }), createIdTranslator());
+    const list = (seed[sourceKey as keyof typeof seed] ?? []) as Array<{ id?: string }>;
     const ids = list.map((x) => x.id).filter((x): x is string => typeof x === "string");
     return [...ids, SHELL_PARAM].map((id) => ({ id }));
   } catch {


### PR DESCRIPTION
## Vad

Fas 2 av #562 (ADR 0026): tar bort 2 `as unknown as`-double-casts.

- **server-first-store**: `syncDocumentContent` tar den strukturella `ContentSyncClient`, som den riktiga tRPC-klienten är en superset av → skicka `client` direkt, ingen cast.
- **static-params**: indexera seed via `keyof typeof seed` + en **enkel** cast på den indexerade arrayen (`as Array<{id?:string}>`) i st.f. att casta hela `SeedDataset` genom `unknown`.

## Status efter denna PR
Detta lämnar **`server-context.ts:56`** som den sista kvarvarande riktiga `as unknown as` i src/ (övriga grep-träffar är doc-kommentarer). Den är en partial-`IDataStore`-stub (server-first; routrar rör bara `.events`) och kräver att ctx-typen smalnas till `Pick<IDataStore,'events'>` — hanteras separat.

## Verifiering
- `bun run typecheck` (båda configs, efter `rm tsconfig.tsbuildinfo`) — 0 fel.
- `bun run lint` (max-warnings 0) — rent.
- `bun test` (static-params + server-first-store + content-sync m.fl.) — 31 pass.

Refs #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)