### PR TITLE
refactor(context): narrow ctx.dataStore to events, drop last src double-cast (#562)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,9 +1,4 @@
 {
-  "src/lib/server/http/server-context.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "test/bun-compat.ts": {
     "no-restricted-syntax": {
       "count": 1

--- a/src/lib/server/build-context.ts
+++ b/src/lib/server/build-context.ts
@@ -7,7 +7,7 @@
  */
 
 import type { Principal } from "./auth/principal";
-import type { IDataStore } from "./data-store/IDataStore";
+import type { IDataStore, IEventLog } from "./data-store/IDataStore";
 import type { IPorts } from "./ports";
 import { buildInMemoryRepositories } from "./repositories/in-memory-repositories";
 import type { Repositories } from "./repositories/repositories";
@@ -15,7 +15,17 @@ import type { SyncStore } from "./sync/sync-store";
 import type { Context } from "./trpc-core";
 
 export interface BuildContextDeps {
-  dataStore: IDataStore;
+  /**
+   * Full in-memory-store (git/demo/offline) — bygger in-memory-repos (om `repos`
+   * utelämnas) OCH levererar event-loggen till `ctx.dataStore`. Server-first
+   * utelämnar den och anger `repos` + `eventLog` i stället.
+   */
+  dataStore?: IDataStore;
+  /**
+   * Event-logg för `ctx.dataStore` när ingen full `dataStore` finns (server-first).
+   * Faller annars tillbaka på `dataStore.events`.
+   */
+  eventLog?: IEventLog;
   ports: IPorts;
   /** Fastställd av en `AuthProvider`. `null` = anonym/publik. */
   principal: Principal | null;
@@ -29,9 +39,20 @@ export interface BuildContextDeps {
 }
 
 export function buildContext(deps: BuildContextDeps): Context {
+  const events = deps.eventLog ?? deps.dataStore?.events;
+  if (!events) {
+    throw new Error("buildContext: ange `dataStore` eller `eventLog`.");
+  }
+  let repos = deps.repos;
+  if (!repos) {
+    if (!deps.dataStore) {
+      throw new Error("buildContext: ange `repos` eller `dataStore` (för in-memory-repos).");
+    }
+    repos = buildInMemoryRepositories(deps.dataStore);
+  }
   return {
-    dataStore: deps.dataStore,
-    repos: deps.repos ?? buildInMemoryRepositories(deps.dataStore),
+    dataStore: { events },
+    repos,
     ports: deps.ports,
     user: deps.principal,
     ...(deps.sync ? { sync: deps.sync } : {}),

--- a/src/lib/server/events/emit.ts
+++ b/src/lib/server/events/emit.ts
@@ -15,7 +15,7 @@ import type { EventType, EmitInput } from "./schema";
 
 /** Den minimal subset av tRPC-context som emit-helpers behöver. */
 export interface EmitCtx {
-  dataStore: IDataStore;
+  dataStore: Pick<IDataStore, "events">;
   user: { id: string };
 }
 

--- a/src/lib/server/http/server-context.ts
+++ b/src/lib/server/http/server-context.ts
@@ -21,8 +21,8 @@
 import type { AllowlistedUser } from "@/lib/server/auth/oidc-auth-provider";
 import { OidcAuthProvider } from "@/lib/server/auth/oidc-auth-provider";
 import { buildContext } from "@/lib/server/build-context";
-import type { IDataStore } from "@/lib/server/data-store/IDataStore";
-import type { AvaEvent, EmitInput } from "@/lib/server/events/schema";
+import type { IEventLog } from "@/lib/server/data-store/IDataStore";
+import type { AvaEvent, EmitInput, EventFilter } from "@/lib/server/events/schema";
 import type { IPorts } from "@/lib/server/ports";
 import type { Repositories } from "@/lib/server/repositories/repositories";
 import type { SyncStore } from "@/lib/server/sync/sync-store";
@@ -42,18 +42,26 @@ class EventLogNotBuiltError extends Error {
   }
 }
 
-/** Read-only event-logg: `emit` no-op:ar via ReadOnlyError, `query` ger []. */
-export const serverFirstEventLog = {
+/**
+ * Read-only event-logg (full `IEventLog`): `emit` no-op:ar via ReadOnlyError,
+ * `query` ger [], `iterate` ger en tom ström, `onNewEvent` en no-op-avregistrering.
+ * Routrarna rör bara `.events` på `ctx.dataStore` (allt annat via ctx.repos, ADR 0020),
+ * så `ctx.dataStore` är typad `Pick<IDataStore, "events">` och behöver ingen full store.
+ */
+export const serverFirstEventLog: IEventLog = {
   emit(_input: EmitInput): Promise<AvaEvent> {
     return Promise.reject(new EventLogNotBuiltError());
   },
-  query(): Promise<AvaEvent[]> {
+  query(_filter?: EventFilter): Promise<AvaEvent[]> {
     return Promise.resolve([]);
   },
+  async *iterate(_filter?: EventFilter): AsyncIterable<AvaEvent> {
+    // Tom ström — inga events innan change-loggen byggts (#408).
+  },
+  onNewEvent(): () => void {
+    return () => {};
+  },
 };
-
-// Routrarna rör bara `.events` på dataStore (allt annat via ctx.repos, ADR 0020).
-const serverDataStore = { events: serverFirstEventLog } as unknown as IDataStore;
 
 export interface ServerContextDeps {
   /** Typade Drizzle-repositoryn (ADR 0020) för den auktoritativa Postgres-db:n. */
@@ -91,7 +99,7 @@ export async function createServerContext(req: Request, deps: ServerContextDeps)
   const users = await deps.repos.users.listByOrg(deps.organizationId);
   const principal = new OidcAuthProvider(claims, toAllowlist(users)).getPrincipal();
   return buildContext({
-    dataStore: serverDataStore,
+    eventLog: serverFirstEventLog,
     ports: deps.ports,
     principal,
     repos: deps.repos,

--- a/src/lib/server/trpc-core.ts
+++ b/src/lib/server/trpc-core.ts
@@ -25,8 +25,13 @@ import type { Repositories } from "./repositories/repositories";
 import type { SyncStore } from "./sync/sync-store";
 
 export type Context = {
-  /** Read/write-data via abstraktion. Git-backenden wirar DemoDataStore. */
-  dataStore: IDataStore;
+  /**
+   * Event-loggen routrarna emit:ar mot. Efter ADR 0020 läser routrarna ALL
+   * data via `ctx.repos` — det enda som rör `ctx.dataStore` är emit-helpern
+   * (`events/emit.ts`), så fältet är medvetet smalt (bara `events`). Demo/git
+   * wirar in fulla `IDataStore`:s `.events`; server-first en sink-logg.
+   */
+  dataStore: Pick<IDataStore, "events">;
   /**
    * Typat repository-aggregat (ADR 0020) — den nya sömmen routrarna migreras
    * till, entitet för entitet. Samexisterar med `dataStore` under övergången.

--- a/test/unit/server/build-context.test.ts
+++ b/test/unit/server/build-context.test.ts
@@ -12,16 +12,18 @@ import { buildContext } from "@/lib/server/build-context";
 import type { IDataStore } from "@/lib/server/data-store/IDataStore";
 import type { IPorts } from "@/lib/server/ports";
 
-const fakeStore = { marker: "store" } as unknown as IDataStore;
+const fakeEvents = { marker: "events" };
+const fakeStore = { marker: "store", events: fakeEvents } as unknown as IDataStore;
 const fakePorts = { marker: "ports" } as unknown as IPorts;
 const principal: Principal = {
   id: "u-anna", email: "a@b.se", name: "Anna", role: "ADMIN", organizationId: "org-1",
 };
 
 describe("buildContext", () => {
-  it("mappar principal → ctx.user och släpper igenom dataStore + ports", () => {
+  it("mappar principal → ctx.user och wirar dataStore.events + ports", () => {
     const ctx = buildContext({ dataStore: fakeStore, ports: fakePorts, principal });
-    expect(ctx.dataStore).toBe(fakeStore);
+    // ctx.dataStore är medvetet smal (bara `events`) — ADR 0020.
+    expect(ctx.dataStore.events).toBe(fakeEvents);
     expect(ctx.ports).toBe(fakePorts);
     expect(ctx.user).toBe(principal);
     expect(ctx.repos).toBeDefined(); // ADR 0020 — default in-memory-repos

--- a/test/unit/server/http/server-context.test.ts
+++ b/test/unit/server/http/server-context.test.ts
@@ -74,6 +74,6 @@ describe("serverFirstEventLog (#410, ADR 0017/#408 ej byggt)", () => {
     await expect(serverFirstEventLog.emit({} as never)).rejects.toMatchObject({ name: "ReadOnlyError" });
   });
   it("query ger tom logg", async () => {
-    expect(await serverFirstEventLog.query()).toEqual([]);
+    expect(await serverFirstEventLog.query({})).toEqual([]);
   });
 });


### PR DESCRIPTION
## Vad

Fas 2 av #562 (ADR 0026): tar bort den **sista** riktiga `as unknown as` i src/ (`server-context.ts`).

Efter ADR 0020 läser routrarna ALL data via `ctx.repos` — det enda som rör `ctx.dataStore` är emit-helpern (`.events`). Verifierat: ingen src- ELLER test-kod läser någon annan `dataStore`-medlem via ctx (övriga träffar är doc-kommentarer).

- `Context.dataStore` + `EmitCtx.dataStore` smalnas till `Pick<IDataStore, "events">`.
- `serverFirstEventLog` implementerar nu hela `IEventLog` (`iterate` + `onNewEvent`-stubbar) och är typad som sådan.
- `buildContext` tar event-loggen antingen från en full `dataStore` (git/demo — bygger fortfarande in-memory-repos) eller en fristående `eventLog` (server-first), och wirar `ctx.dataStore = { events }`. Server-first skickar `eventLog: serverFirstEventLog` — **ingen cast**.

## Resultat
**src/ är nu fritt från riktiga double-casts.** Kvarvarande grep-träffar i src/ är doc-kommentarer. Test-doubles (vi.fn) förblir lint-baselinade (separat kategori).

## Verifiering
- `bun run typecheck` (båda configs, efter `rm tsconfig.tsbuildinfo`) — 0 fel.
- `bun run lint` (max-warnings 0) — rent.
- `bun run test` (hela unit-sviten) — 3064 pass, 0 fail (uppdaterade build-context-testfixturen + server-context query-anropet).

Refs #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)