### PR TITLE
test(demo): cover demoCacheKey version-busting branches (#27)

### DIFF
--- a/test/unit/lib/demo/demo-cache-key.test.ts
+++ b/test/unit/lib/demo/demo-cache-key.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Tester för `demoCacheKey` — OPFS-cache-nyckeln för demo-slaben.
+ *
+ * Två grenar: versionerad nyckel (NEXT_PUBLIC_DEMO_VERSION satt, deploy) vs
+ * stabil nyckel (osatt, lokalt). Version-prefixet trunkeras till 12 tecken.
+ */
+
+import { afterEach, describe, it, expect } from "vitest-compat";
+import { demoCacheKey } from "@/lib/client/demo/demo-cache-key";
+
+const ORIGINAL = process.env.NEXT_PUBLIC_DEMO_VERSION;
+
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.NEXT_PUBLIC_DEMO_VERSION;
+  else process.env.NEXT_PUBLIC_DEMO_VERSION = ORIGINAL;
+});
+
+describe("demoCacheKey", () => {
+  it("utan version → stabil nyckel 'ava-demo' (lokalt, överlever reloads)", () => {
+    delete process.env.NEXT_PUBLIC_DEMO_VERSION;
+    expect(demoCacheKey()).toBe("ava-demo");
+  });
+
+  it("med version → versionerad nyckel (version-busting per deploy)", () => {
+    process.env.NEXT_PUBLIC_DEMO_VERSION = "abcdef1234567890";
+    expect(demoCacheKey()).toBe("ava-demo-abcdef123456");
+  });
+
+  it("trunkerar versionen till 12 tecken (lång commit-sha)", () => {
+    process.env.NEXT_PUBLIC_DEMO_VERSION = "0123456789abcdef0123456789";
+    expect(demoCacheKey()).toBe("ava-demo-0123456789ab");
+  });
+
+  it("kort version padd:as inte (kortare än 12 tecken används rakt av)", () => {
+    process.env.NEXT_PUBLIC_DEMO_VERSION = "v1";
+    expect(demoCacheKey()).toBe("ava-demo-v1");
+  });
+
+  it("tom version → faller tillbaka på stabila nyckeln (falsy)", () => {
+    process.env.NEXT_PUBLIC_DEMO_VERSION = "";
+    expect(demoCacheKey()).toBe("ava-demo");
+  });
+});


### PR DESCRIPTION
## Vad

Liten kodtäcknings-step mot #27. `demoCacheKey` (OPFS-cache-nyckeln för demo-slaben) saknade test (0% rader). Lägger till täckning för båda grenarna:
- **versionerad nyckel** (`NEXT_PUBLIC_DEMO_VERSION` satt → 12-tecken-trunkerad sha för version-busting per deploy)
- **stabila lokala fallbacken** (`ava-demo`)
- tom/kort-version-kanter.

## Golv oförändrat
Den lokala `--parallel`-lcov:en har inaktuella/dubblerade `SF:`-poster (listar bl.a. filer som inte finns, t.ex. `sync/pick-provider.ts`), så den är ingen säker grund för att räkna om ratchet-golvet mot CI:s Node-version-varians (Node 24 instrumenterar mer). Därför bara ny täckning (kan bara höja), inget golv-byte.

## Verifiering
- `bun test demo-cache-key` — 5 pass.
- `bun run typecheck` (båda configs) — 0 fel.
- `bun run lint` (max-warnings 0) — rent.

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)