### PR TITLE
test(schemas): cover all ENTITY_REGISTRY gitPath callbacks, bump FUNC floor (#27)

### DIFF
--- a/test/unit/shared/schemas/registry.test.ts
+++ b/test/unit/shared/schemas/registry.test.ts
@@ -50,6 +50,17 @@ describe("ENTITY_REGISTRY", () => {
     }
   });
 
+  it("varje entitets gitPath() ger en .json-path under sin gitPrefix (kör alla callbacks)", () => {
+    for (const name of ENTITY_NAMES) {
+      const entry = ENTITY_REGISTRY[name]!;
+      // Anropa gitPath för VARJE entitet (annars täcks per-entitet-callbacken
+      // aldrig). `email` sätts så user-pathens row-gren också körs.
+      const path = entry.gitPath(`${name}-1`, { email: "x@y.se", userId: "u-1" });
+      expect(path).toMatch(/\.json$/);
+      expect(path.startsWith(entry.gitPrefix)).toBe(true);
+    }
+  });
+
   it("gitPath:s första argument används i resultatet (för rader utan email-style key)", () => {
     expect(ENTITY_REGISTRY.matter!.gitPath("m-1", {})).toBe("matters/active/m-1.json");
     expect(ENTITY_REGISTRY.contact!.gitPath("c-1", {})).toBe("contacts/c-1.json");

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -81,9 +81,14 @@ const FAST = process.argv.includes("--fast");
 // listForLawyerInPeriod/listBillableForOrg testade → drizzle-time-entry 81%→100%.
 // Repo-täckningssvepet (matter-contact/folder/expense/time-entry) klart →
 // lokalt 90.77% rader / 85.63% funktioner. FUNC dras upp 84.2 → 84.3
-// (~1.33% marginal). LINE oförändrat).
+// (~1.33% marginal). LINE oförändrat) → 89.5 rader / 84.5 funktioner (#27:
+// demoCacheKey + ENTITY_REGISTRY.gitPath-callbacks för ALLA entiteter testade
+// (registry-testet kallade tidigare aldrig callbackarna) → lokalt 90.67% rader /
+// 85.87% funktioner. FUNC dras upp 84.3 → 84.5 (~1.37% marginal; funktions-
+// täckning är Node-version-stabil till skillnad från branches). LINE oförändrat
+// — dess marginal är en avsiktlig Node-version-buffert + lcov-line-bruset).
 const LINE_FLOOR = 0.895;
-const FUNC_FLOOR = 0.843;
+const FUNC_FLOOR = 0.845;
 
 /**
  * SERIAL_FILES — testfiler som SYNKRONT spawnar en barnprocess via


### PR DESCRIPTION
## Vad

Kodtäcknings-ratchet-step mot #27 (mål 95%).

`registry.test.ts` itererade `ENTITY_NAMES` men asserterade bara att `gitPath` *var* en funktion — den **kallade aldrig** per-entitet-callbackarna, så ~11 var otäckta. Lägger till ett test som anropar varje entitets `gitPath(id, row)` och verifierar en `.json`-path under dess `gitPrefix`.

## Ratchet
- Lokal funktionstäckning 85.63% → **85.87%**.
- `FUNC_FLOOR` höjs 84.3 → **84.5** (~1.37% marginal). Funktionstäckning är Node-version-**stabil** (till skillnad från branches som CI Node 24 instrumenterar hårdare), så höjningen är säker mot CI.
- `LINE_FLOOR` oförändrat (avsiktlig Node-version-buffert + lcov-line-brus).

## Verifiering
- `bun run test:cov` — gate grön: rader 90.67% (golv 89.50%), funktioner 85.87% (golv 84.50%), 0 fail.
- `bun run typecheck` (båda configs) + `bun run lint` — rent.

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)