### PR TITLE
test(query-engine): cover endsWith + notIn operators (#27)

### DIFF
--- a/test/unit/server/data-store/in-memory/query-engine.test.ts
+++ b/test/unit/server/data-store/in-memory/query-engine.test.ts
@@ -202,3 +202,36 @@ describe("InMemoryQueryEngine — first/unique", () => {
     expect(engine.findUnique(rows, { where: { id: "1" } })?.name).toBe("Alpha");
   });
 });
+
+// ─── Operatorer som saknade täckning (endsWith, notIn) ───────────────
+
+describe("InMemoryQueryEngine endsWith / notIn", () => {
+  it("endsWith matchar suffix (case-sensitive)", () => {
+    const out = engine.query(rows, { where: { name: { endsWith: "ta" } } });
+    expect(out.map((r) => r.id).sort()).toEqual(["2", "4"]); // Beta, Delta
+  });
+
+  it("endsWith med mode: insensitive ignorerar skiftläge", () => {
+    const out = engine.query(rows, { where: { name: { endsWith: "TA", mode: "insensitive" } } });
+    expect(out.map((r) => r.id).sort()).toEqual(["2", "4"]);
+  });
+
+  it("endsWith på icke-strängfält → ingen match (strOp-guard)", () => {
+    expect(engine.query(rows, { where: { count: { endsWith: "0" } } })).toHaveLength(0);
+  });
+
+  it("notIn exkluderar de uppräknade värdena", () => {
+    const out = engine.query(rows, { where: { status: { notIn: ["CLOSED"] } } });
+    expect(out.map((r) => r.id).sort()).toEqual(["1", "3", "4"]); // alla ACTIVE
+  });
+
+  it("notIn med icke-array → false (ingen match)", () => {
+    // opVal måste vara en array; annars matchar notIn inget.
+    expect(engine.query(rows, { where: { id: { notIn: "1" } } })).toHaveLength(0);
+  });
+
+  it("cmp coercar Date↔ISO-sträng (gte med sträng mot Date-fält)", () => {
+    const out = engine.query(rows, { where: { createdAt: { gte: "2025-03-01" } } });
+    expect(out.map((r) => r.id).sort()).toEqual(["3", "4"]);
+  });
+});


### PR DESCRIPTION
## Vad

`InMemoryQueryEngine`-testet hade ett-test-per-operator men missade **`endsWith`** och **`notIn`** (aldrig körda → dispatch-tabellens arrow-fns var otäckta). Lägger till fall för:
- `endsWith` (case-sensitive, `mode: insensitive`, samt icke-strängfält-guard)
- `notIn` (array + icke-array-guard)
- `cmp` Date↔ISO-sträng-coercion (gte med sträng mot Date-fält).

Värdet är test-kvalitet: dessa operatorer kunde annars regrera tyst.

## Golv
Oförändrat (`FUNC_FLOOR` höjdes i förra PR:n #597). Detta lägger marginal mot nästa höjning.

## Verifiering
- `bun test query-engine` — 34 pass.
- `bun run test:cov` — gate grön (funktioner 85.92% ≥ golv 84.50%, rader 90.67% ≥ 89.50%).
- `bun run typecheck` + `bun run lint` — rent.

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)