### PR TITLE
test(delegate): cover aggregate _min/_max + findUniqueOrThrow, bump FUNC floor (#27)

### DIFF
--- a/test/unit/server/data-store/in-memory/read-only-delegate.test.ts
+++ b/test/unit/server/data-store/in-memory/read-only-delegate.test.ts
@@ -80,6 +80,30 @@ describe("ReadOnlyDelegate — aggregate", () => {
     expect(r._count).toBe(3);
     expect(r._avg.minutes).toBe(45);
   });
+
+  it("_min + _max över alla rader", async () => {
+    const r = await del.aggregate({ _min: { minutes: true }, _max: { minutes: true } }) as {
+      _min: { minutes: number }; _max: { minutes: number };
+    };
+    expect(r._min.minutes).toBe(15);
+    expect(r._max.minutes).toBe(90);
+  });
+
+  it("_min/_max med where som snävar till en matter", async () => {
+    const r = await del.aggregate({ where: { matterId: "m1" }, _min: { minutes: true }, _max: { minutes: true } }) as {
+      _min: { minutes: number }; _max: { minutes: number };
+    };
+    expect(r._min.minutes).toBe(30);
+    expect(r._max.minutes).toBe(90);
+  });
+
+  it("_min/_max utan träff → null (tom rad-mängd)", async () => {
+    const r = await del.aggregate({ where: { matterId: "x" }, _min: { minutes: true }, _max: { minutes: true } }) as {
+      _min: { minutes: number | null }; _max: { minutes: number | null };
+    };
+    expect(r._min.minutes).toBeNull();
+    expect(r._max.minutes).toBeNull();
+  });
 });
 
 describe("ReadOnlyDelegate — läsning", () => {
@@ -104,6 +128,11 @@ describe("ReadOnlyDelegate — läsning", () => {
 
   it("findFirstOrThrow kastar när inget hittas", async () => {
     await expect(delegate.findFirstOrThrow({ where: { id: "missing" } })).rejects.toThrow();
+  });
+
+  it("findUniqueOrThrow returnerar raden vid träff, kastar annars", async () => {
+    expect((await delegate.findUniqueOrThrow({ where: { id: "m1" } })).id).toBe("m1");
+    await expect(delegate.findUniqueOrThrow({ where: { id: "missing" } })).rejects.toThrow();
   });
 
   it("count", async () => {

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -86,9 +86,12 @@ const FAST = process.argv.includes("--fast");
 // (registry-testet kallade tidigare aldrig callbackarna) → lokalt 90.67% rader /
 // 85.87% funktioner. FUNC dras upp 84.3 → 84.5 (~1.37% marginal; funktions-
 // täckning är Node-version-stabil till skillnad från branches). LINE oförändrat
-// — dess marginal är en avsiktlig Node-version-buffert + lcov-line-bruset).
+// — dess marginal är en avsiktlig Node-version-buffert + lcov-line-bruset) →
+// 89.5 rader / 84.6 funktioner (#27: query-engine endsWith/notIn (#598) +
+// ReadOnlyDelegate _min/_max/findUniqueOrThrow → lokalt 85.99% funktioner.
+// FUNC dras upp 84.5 → 84.6, ~1.39% marginal. LINE oförändrat).
 const LINE_FLOOR = 0.895;
-const FUNC_FLOOR = 0.845;
+const FUNC_FLOOR = 0.846;
 
 /**
  * SERIAL_FILES — testfiler som SYNKRONT spawnar en barnprocess via


### PR DESCRIPTION
## Vad

#27-ratchet-step. `ReadOnlyDelegate.aggregate` täckte `_count`/`_sum`/`_avg` men **inte `_min`/`_max`** (båda fold-callbacks + tom-rad-null-grenen), och `findUniqueOrThrow` var otestad. Lägger till dessa → read-only-delegate 39/43 → **43/44** funktioner.

## Ratchet
Konsoliderar den ackumulerade vinsten (detta + query-engine #598): `FUNC_FLOOR` **84.5 → 84.6** (lokalt 85.99%, ~1.39% marginal). Funktionstäckning är Node-version-stabil. `LINE_FLOOR` oförändrat.

## Verifiering
- `bun test read-only-delegate` — 24 pass.
- `bun run test:cov` — gate grön (funktioner 85.99% ≥ golv 84.60%, rader 90.68% ≥ 89.50%).
- `bun run typecheck` + `bun run lint` — rent.

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)