### PR TITLE
test(job-queue): cover no-worker failure + listener-throw resilience (#27)

### DIFF
--- a/test/unit/lib/jobs/job-queue.test.ts
+++ b/test/unit/lib/jobs/job-queue.test.ts
@@ -133,4 +133,31 @@ describe("JobQueue", () => {
     jobQueue.clearFinished();
     expect(jobQueue.list().filter((j) => j.status === "done").length).toBe(0);
   });
+
+  it("kind utan registrerad worker → status=failed med tydligt felmeddelande", async () => {
+    // "sync" registreras aldrig i denna fil → pump-grenen "ingen worker".
+    const id = jobQueue.enqueue("sync", "Saknar worker");
+    const job = await waitForStatus(id, "failed");
+    expect(job.error).toContain("Ingen worker registrerad");
+    expect(job.error).toContain("sync");
+  });
+
+  it("en kastande listener bryter inte kön (notify fångar och fortsätter)", async () => {
+    const good = vi.fn();
+    // Kasta först vid notify (inte den initiala subscribe-snapshoten, som inte
+    // är try/catch-skyddad) → träffar notify:s try/catch.
+    let first = true;
+    const unsubBad = jobQueue.subscribe(() => {
+      if (first) { first = false; return; }
+      throw new Error("trasig listener");
+    });
+    const unsubGood = jobQueue.subscribe(good);
+    jobQueue.registerWorker("custom", async () => {});
+    const id = jobQueue.enqueue("custom", "Trots trasig listener");
+    const job = await waitForStatus(id, "done");
+    expect(job.status).toBe("done"); // kön körde klart trots att en listener kastade
+    expect(good).toHaveBeenCalled();
+    unsubBad();
+    unsubGood();
+  });
 });


### PR DESCRIPTION
## Vad

Två verkliga felvägar i `JobQueue` var otestade:
- **enqueue av en `kind` utan registrerad worker** → ska bli `failed` med tydligt meddelande (inte hänga).
- **en subscriber som kastar** → `notify` måste fånga och hålla kön igång.

Lägger till tester för båda (robusthet — kunde annars regrera tyst).

## Golv
Oförändrat. Gren-/rad-täckning på felvägarna; `FUNC_FLOOR` rörs ej (kvarvarande job-queue-luckor är `makeId`/`isAbortError`-hjälpare). 

## Verifiering
- `bun test job-queue` — 11 pass.
- `bun run test:cov` — gate grön (funktioner 85.99% ≥ 84.60%, rader 90.68% ≥ 89.50%).
- `bun run typecheck` + `bun run lint` — rent.

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)