### PR TITLE
test(data-table): cover footer/summary + chip-remove + unhide, bump FUNC floor (#27)

### DIFF
--- a/test/unit/components/data-table-component.test.tsx
+++ b/test/unit/components/data-table-component.test.tsx
@@ -171,3 +171,56 @@ describe("DataTable", () => {
     expect(screen.queryByText(/\+ Visa kolumn/)).not.toBeInTheDocument();
   });
 });
+
+// ── Footer / summa-rader + chip-borttagning + unhide-interaktioner ──────
+
+const colsSummary: Column<Row>[] = [
+  { key: "name", label: "Namn", render: (r) => r.name, sortable: true, sortValue: (r) => r.name, groupable: true },
+  { key: "age", label: "Ålder", render: (r) => r.age, align: "right", summary: (rs) => `Σ ${rs.reduce((s, r) => s + r.age, 0)}` },
+];
+
+describe("DataTable — footer/summa + interaktioner", () => {
+  it("kolumn med summary auto-renderar en footer-summa-rad", () => {
+    render(<DataTable prefKey="x" columns={colsSummary} data={rows} rowKey={(r) => r.id} />);
+    expect(screen.getByText("Σ 65")).toBeInTheDocument(); // 25 + 40
+  });
+
+  it("explicit footer-prop renderar footer-cell-innehåll", () => {
+    render(
+      <DataTable
+        prefKey="x" columns={cols} data={rows} rowKey={(r) => r.id}
+        footer={(rs) => ({ age: `Antal ${rs.length}` })}
+      />,
+    );
+    expect(screen.getByText("Antal 2")).toBeInTheDocument();
+  });
+
+  it("gruppering + summary → en summa-rad per grupp", () => {
+    persisted.data = { user: { groupBy: "name" }, org: null };
+    render(<DataTable prefKey="x" columns={colsSummary} data={rows} rowKey={(r) => r.id} />);
+    // En grupp per namn (Anna=25, Bo=40) → två grupp-summa-rader + en total-footer.
+    expect(screen.getByText("Σ 25")).toBeInTheDocument();
+    expect(screen.getByText("Σ 40")).toBeInTheDocument();
+  });
+
+  it("klick på chip-kryss (Ta bort) rensar sorteringen → persist", () => {
+    persisted.data = { user: { sortBy: "name", sortDir: "asc" }, org: null };
+    render(<DataTable prefKey="x" columns={cols} data={rows} rowKey={(r) => r.id} />);
+    fireEvent.click(screen.getByRole("button", { name: "Ta bort" }));
+    return new Promise<void>((resolve) => {
+      setTimeout(() => { expect(saveMutate).toHaveBeenCalled(); resolve(); }, 500);
+    });
+  });
+
+  it("unhide via '+ Visa kolumn'-listan triggar persist", () => {
+    persisted.data = { user: { columns: [{ key: "age", hidden: true }] }, org: null };
+    render(<DataTable prefKey="x" columns={cols} data={rows} rowKey={(r) => r.id} />);
+    fireEvent.click(screen.getByText(/\+ Visa kolumn/));
+    // Klicka kolumnen i "Dolda kolumner"-listan (sista "Ålder"-träffen = lista).
+    const ages = screen.getAllByText("Ålder");
+    fireEvent.click(ages[ages.length - 1]!);
+    return new Promise<void>((resolve) => {
+      setTimeout(() => { expect(saveMutate).toHaveBeenCalled(); resolve(); }, 500);
+    });
+  });
+});

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -89,9 +89,12 @@ const FAST = process.argv.includes("--fast");
 // — dess marginal är en avsiktlig Node-version-buffert + lcov-line-bruset) →
 // 89.5 rader / 84.6 funktioner (#27: query-engine endsWith/notIn (#598) +
 // ReadOnlyDelegate _min/_max/findUniqueOrThrow → lokalt 85.99% funktioner.
-// FUNC dras upp 84.5 → 84.6, ~1.39% marginal. LINE oförändrat).
+// FUNC dras upp 84.5 → 84.6, ~1.39% marginal. LINE oförändrat) → 89.5 rader /
+// 84.7 funktioner (#27: DataTable footer/summa-rader + grupp-summa + chip-
+// borttagning + unhide-via-lista → data-table.tsx 57→65 funktioner, lokalt
+// 86.10% funktioner. FUNC dras upp 84.6 → 84.7, ~1.40% marginal. LINE oförändrat).
 const LINE_FLOOR = 0.895;
-const FUNC_FLOOR = 0.846;
+const FUNC_FLOOR = 0.847;
 
 /**
  * SERIAL_FILES — testfiler som SYNKRONT spawnar en barnprocess via


### PR DESCRIPTION
## Vad

DataTable:s render-bara sub-komponenter var otäckta. Lägger till render-/interaktions-tester för:
- **auto-footer** (summary-kolumner + explicit `footer`-prop)
- **per-grupp summa-rader** (gruppering + summary)
- **chip-kryss** (rensa sortering/filter/gruppering via `Ta bort`)
- **unhide** via `+ Visa kolumn`-listan

→ `data-table.tsx` 57→65 funktioner, lokal funktionstäckning 85.99% → **86.10%**.

## Ratchet
`FUNC_FLOOR` **84.6 → 84.7** (~1.40% marginal). `LINE_FLOOR` oförändrat.

## Verifiering
- `bun test data-table-component` — 24 pass.
- `bun run test:cov` — gate grön (funktioner 86.10% ≥ 84.70%, rader 90.75% ≥ 89.50%).
- `bun run typecheck` + `bun run lint` — rent.

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)