### PR TITLE
test(expense-section): cover create/edit form + VatPreview, bump FUNC floor (#27)

### DIFF
--- a/test/unit/app/matters/expense-section.test.tsx
+++ b/test/unit/app/matters/expense-section.test.tsx
@@ -87,4 +87,44 @@ describe("ExpenseSection", () => {
     expect(screen.getByText("Nytt utlägg")).toBeInTheDocument();
     expect(screen.getByText("Debiterbar")).toBeInTheDocument();
   });
+
+  it("fyller i skapa-formuläret + Spara → create.mutate med matterId + payload", () => {
+    render(<ExpenseSection matterId="m1" />);
+    fireEvent.click(screen.getByText("+ Nytt utlägg"));
+    const dateInput = document.querySelector('input[type="date"]') as HTMLInputElement;
+    fireEvent.change(dateInput, { target: { value: "2026-03-15" } });
+    fireEvent.change(screen.getByPlaceholderText("0,00"), { target: { value: "150" } });
+    fireEvent.change(screen.getByPlaceholderText("Beskrivning *"), { target: { value: "Parkering" } });
+    // VatPreview-grenen (amount>0) renderar moms-uppdelningen.
+    expect(screen.getByText(/Ex:.*M:.*In:/)).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Spara"));
+    expect(createMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ matterId: "m1", description: "Parkering" }),
+    );
+  });
+
+  it("växlar moms-radio (Exkl moms) + momssats-select utan att krascha", () => {
+    render(<ExpenseSection matterId="m1" />);
+    fireEvent.click(screen.getByText("+ Nytt utlägg"));
+    fireEvent.click(screen.getByRole("radio", { name: /Exkl moms/ }));
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "1200" } });
+    fireEvent.click(screen.getByRole("checkbox")); // Debiterbar av
+    expect(screen.getByText("Spara")).toBeInTheDocument();
+  });
+
+  it("'Ändra' öppnar förifyllt edit-formulär → Spara ändring → update.mutate med id", () => {
+    render(<ExpenseSection matterId="m1" />);
+    fireEvent.click(screen.getByText("Ändra"));
+    expect(screen.getByText("Ändra utlägg")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Tågbiljett")).toBeInTheDocument(); // förifyllt ur e1
+    fireEvent.click(screen.getByText("Spara ändring"));
+    expect(updateMutate).toHaveBeenCalledWith(expect.objectContaining({ id: "e1" }));
+  });
+
+  it("Avbryt stänger skapa-modalen", () => {
+    render(<ExpenseSection matterId="m1" />);
+    fireEvent.click(screen.getByText("+ Nytt utlägg"));
+    fireEvent.click(screen.getByText("Avbryt"));
+    expect(screen.queryByText("Nytt utlägg")).not.toBeInTheDocument();
+  });
 });

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -92,9 +92,12 @@ const FAST = process.argv.includes("--fast");
 // FUNC dras upp 84.5 → 84.6, ~1.39% marginal. LINE oförändrat) → 89.5 rader /
 // 84.7 funktioner (#27: DataTable footer/summa-rader + grupp-summa + chip-
 // borttagning + unhide-via-lista → data-table.tsx 57→65 funktioner, lokalt
-// 86.10% funktioner. FUNC dras upp 84.6 → 84.7, ~1.40% marginal. LINE oförändrat).
+// 86.10% funktioner. FUNC dras upp 84.6 → 84.7, ~1.40% marginal. LINE oförändrat)
+// → 89.5 rader / 84.8 funktioner (#27: ExpenseSection skapa/edit-formulär +
+// VatPreview + moms-radio/select-handlers → lokalt 86.28% funktioner. FUNC dras
+// upp 84.7 → 84.8, ~1.48% marginal. LINE oförändrat).
 const LINE_FLOOR = 0.895;
-const FUNC_FLOOR = 0.847;
+const FUNC_FLOOR = 0.848;
 
 /**
  * SERIAL_FILES — testfiler som SYNKRONT spawnar en barnprocess via


### PR DESCRIPTION
## Vad

`ExpenseSection`:s formulär-sub-komponenter var render-otäckta. Lägger till:
- **fyll-i + Spara** (create) → `create.mutate` med matterId + payload (täcker fält-handlers + `submitForm` + `payloadOf` + `VatPreview`-grenen).
- **Ändra → förifyllt edit-formulär → Spara ändring** → `update.mutate` (täcker `startEdit`/`toForm`).
- **moms-radio (Exkl) + momssats-select + Debiterbar-toggle**.
- **Avbryt** stänger modalen.

→ lokal funktionstäckning 86.10% → **86.28%**.

## Ratchet
`FUNC_FLOOR` **84.7 → 84.8** (~1.48% marginal). `LINE_FLOOR` oförändrat.

## Verifiering
- `bun test expense-section` — 9 pass.
- `bun run test:cov` — gate grön (funktioner 86.28% ≥ 84.80%, rader 90.79% ≥ 89.50%).
- `bun run typecheck` + `bun run lint` — rent.

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)