### PR TITLE
test(time-section): cover register/edit/delete flows, bump FUNC floor (#27)

### DIFF
--- a/test/unit/app/time-section-invoiced.test.tsx
+++ b/test/unit/app/time-section-invoiced.test.tsx
@@ -4,9 +4,13 @@
  * kopplingen mellan tidsrad och faktura, så koppling visas inte längre.
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest-compat";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
 import { TimeSection } from "@/app/matters/[id]/_time-section";
+
+const createMut = vi.fn();
+const updateMut = vi.fn();
+const deleteMut = vi.fn();
 
 vi.mock("@/lib/client/trpc", () => {
   const noopMut = { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false };
@@ -39,13 +43,15 @@ vi.mock("@/lib/client/trpc", () => {
             },
           }),
         },
-        create: { useMutation: () => noopMut },
-        update: { useMutation: () => noopMut },
-        delete: { useMutation: () => noopMut },
+        create: { useMutation: () => ({ mutate: createMut, mutateAsync: vi.fn(), isPending: false }) },
+        update: { useMutation: () => ({ mutate: updateMut, mutateAsync: vi.fn(), isPending: false }) },
+        delete: { useMutation: () => ({ mutate: deleteMut, mutateAsync: vi.fn(), isPending: false }) },
       },
     },
   };
 });
+
+beforeEach(() => { vi.clearAllMocks(); });
 
 function renderSection() {
   const client = new QueryClient();
@@ -73,5 +79,54 @@ describe("TimeSection — utan invoice-koppling i UI", () => {
     expect(screen.queryByText(/Låst/)).not.toBeInTheDocument();
     expect(screen.getAllByText("Ändra")).toHaveLength(2);
     expect(screen.getAllByText("Ta bort")).toHaveLength(2);
+  });
+});
+
+describe("TimeSection — registrera/ändra/ta-bort-flöden", () => {
+  it("'+ Registrera tid' → fyll formulär → Spara → create.mutate med matterId", () => {
+    renderSection();
+    fireEvent.click(screen.getByText("+ Registrera tid"));
+    expect(screen.getByText("Registrera tid")).toBeInTheDocument();
+    const dateInput = document.querySelector('input[type="date"]') as HTMLInputElement;
+    fireEvent.change(dateInput, { target: { value: "2026-05-20" } });
+    fireEvent.change(document.querySelector('input[type="number"]') as HTMLInputElement, { target: { value: "45" } });
+    fireEvent.change(screen.getByPlaceholderText("Beskrivning *"), { target: { value: "Telefonsamtal" } });
+    fireEvent.click(screen.getByText("Spara"));
+    expect(createMut).toHaveBeenCalledWith(
+      expect.objectContaining({ matterId: "m-1", minutes: 45, description: "Telefonsamtal" }),
+    );
+  });
+
+  it("'Ändra' öppnar förifyllt edit-formulär → Spara → update.mutate med id", () => {
+    renderSection();
+    fireEvent.click(screen.getAllByText("Ändra")[0]!);
+    expect(screen.getByText("Ändra tidregistrering")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Möte")).toBeInTheDocument(); // förifyllt ur te-1
+    fireEvent.click(screen.getByText("Spara"));
+    expect(updateMut).toHaveBeenCalledWith(expect.objectContaining({ id: "te-1" }));
+  });
+
+  it("'Ta bort' med confirm → delete.mutate med id", () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    renderSection();
+    fireEvent.click(screen.getAllByText("Ta bort")[0]!);
+    expect(deleteMut).toHaveBeenCalledWith({ id: "te-1" });
+    confirmSpy.mockRestore();
+  });
+
+  it("'Ta bort' med avbruten confirm → ingen delete", () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    renderSection();
+    fireEvent.click(screen.getAllByText("Ta bort")[0]!);
+    expect(deleteMut).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  it("toggla Debiterbar i skapa-formuläret + Avbryt stänger modalen", () => {
+    renderSection();
+    fireEvent.click(screen.getByText("+ Registrera tid"));
+    fireEvent.click(screen.getByRole("checkbox")); // Debiterbar
+    fireEvent.click(screen.getByText("Avbryt"));
+    expect(screen.queryByText("Registrera tid")).not.toBeInTheDocument();
   });
 });

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -95,9 +95,12 @@ const FAST = process.argv.includes("--fast");
 // 86.10% funktioner. FUNC dras upp 84.6 → 84.7, ~1.40% marginal. LINE oförändrat)
 // → 89.5 rader / 84.8 funktioner (#27: ExpenseSection skapa/edit-formulär +
 // VatPreview + moms-radio/select-handlers → lokalt 86.28% funktioner. FUNC dras
-// upp 84.7 → 84.8, ~1.48% marginal. LINE oförändrat).
+// upp 84.7 → 84.8, ~1.48% marginal. LINE oförändrat) → 89.5 rader / 84.9
+// funktioner (#27: TimeSection registrera/ändra/ta-bort-flöden + TimeForm-
+// handlers → lokalt 86.48% funktioner. FUNC dras upp 84.8 → 84.9, ~1.58%
+// marginal. LINE oförändrat).
 const LINE_FLOOR = 0.895;
-const FUNC_FLOOR = 0.848;
+const FUNC_FLOOR = 0.849;
 
 /**
  * SERIAL_FILES — testfiler som SYNKRONT spawnar en barnprocess via


### PR DESCRIPTION
## Vad

`TimeSection`:s formulär-flöden var otäckta. Lägger till:
- **+ Registrera tid** → fyll + Spara → `create.mutate` med matterId.
- **Ändra** → förifyllt edit-formulär → Spara → `update.mutate` med id.
- **Ta bort** → confirm ja/nej → `delete.mutate` resp. ingen.
- Debiterbar-toggle + Avbryt.

Lyfte distinkta create/update/delete-mock-spies till modulnivå så anropen kan asserteras. → lokal funktionstäckning 86.28% → **86.48%**.

## Ratchet
`FUNC_FLOOR` **84.8 → 84.9** (~1.58% marginal). `LINE_FLOOR` oförändrat.

## Verifiering
- `bun test time-section-invoiced` — 8 pass.
- `bun run test:cov` — gate grön (funktioner 86.48% ≥ 84.90%, rader 90.85% ≥ 89.50%).
- `bun run typecheck` + `bun run lint` — rent.

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)