### PR TITLE
test(contacts-section): cover new/existing contact forms, FUNC floor crosses 85% (#27)

### DIFF
--- a/test/unit/app/matters/contacts-section.test.tsx
+++ b/test/unit/app/matters/contacts-section.test.tsx
@@ -89,4 +89,44 @@ describe("ContactsSection", () => {
     fireEvent.click(screen.getByText("Ta bort"));
     expect(removeContact).toHaveBeenCalledWith({ matterContactId: "mc1" });
   });
+
+  it("ny ORGANISATION-kontakt: typ-byte → orgnummer-fältet + roll-select", () => {
+    render(<ContactsSection matterId="m1" contacts={[]} />);
+    fireEvent.click(screen.getByText("+ Lägg till"));
+    fireEvent.change(screen.getByPlaceholderText("Namn *"), { target: { value: "Org AB" } });
+    const [roleSel, typeSel] = screen.getAllByRole("combobox") as HTMLSelectElement[];
+    const roleOpts = roleSel!.querySelectorAll("option");
+    fireEvent.change(roleSel!, { target: { value: (roleOpts[1] as HTMLOptionElement).value } });
+    const typeOpts = Array.from(typeSel!.querySelectorAll("option")) as HTMLOptionElement[];
+    const nonPerson = typeOpts.find((o) => o.value !== "PERSON")!;
+    fireEvent.change(typeSel!, { target: { value: nonPerson.value } });
+    fireEvent.change(screen.getByPlaceholderText("Orgnummer"), { target: { value: "556677-8899" } });
+    fireEvent.click(screen.getByRole("button", { name: /Skapa & lägg till/ }));
+    expect(addNewContact).toHaveBeenCalledWith(
+      expect.objectContaining({ matterId: "m1", name: "Org AB", orgNumber: "556677-8899" }),
+    );
+  });
+
+  it("ny PERSON-kontakt: personnummer-fältet skrivs (PERSON-grenen)", () => {
+    render(<ContactsSection matterId="m1" contacts={[]} />);
+    fireEvent.click(screen.getByText("+ Lägg till"));
+    fireEvent.change(screen.getByPlaceholderText("Namn *"), { target: { value: "Per Person" } });
+    fireEvent.change(screen.getByPlaceholderText("Personnummer"), { target: { value: "19900101-1234" } });
+    fireEvent.click(screen.getByRole("button", { name: /Skapa & lägg till/ }));
+    expect(addNewContact).toHaveBeenCalledWith(
+      expect.objectContaining({ personalNumber: "19900101-1234" }),
+    );
+  });
+
+  it("befintlig-formuläret: roll-select exerceras + koppling", () => {
+    render(<ContactsSection matterId="m1" contacts={[]} />);
+    fireEvent.click(screen.getByText("+ Lägg till"));
+    fireEvent.click(screen.getByText("Befintlig kontakt"));
+    const [contactSel, roleSel] = screen.getAllByRole("combobox") as HTMLSelectElement[];
+    const roleOpts = roleSel!.querySelectorAll("option");
+    fireEvent.change(roleSel!, { target: { value: (roleOpts[1] as HTMLOptionElement).value } });
+    fireEvent.change(contactSel!, { target: { value: "c2" } });
+    fireEvent.click(screen.getByRole("button", { name: /^Lägg till$/ }));
+    expect(addContact).toHaveBeenCalledWith(expect.objectContaining({ matterId: "m1", contactId: "c2" }));
+  });
 });

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -98,9 +98,12 @@ const FAST = process.argv.includes("--fast");
 // upp 84.7 → 84.8, ~1.48% marginal. LINE oförändrat) → 89.5 rader / 84.9
 // funktioner (#27: TimeSection registrera/ändra/ta-bort-flöden + TimeForm-
 // handlers → lokalt 86.48% funktioner. FUNC dras upp 84.8 → 84.9, ~1.58%
-// marginal. LINE oförändrat).
+// marginal. LINE oförändrat) → 89.5 rader / 85.0 funktioner (#27:
+// ContactsSection ny/befintlig-kontakt-formulär (PERSON/ORG-grenar, roll-
+// select) → lokalt 86.57% funktioner. FUNC passerar 85%-milstolpen 84.9 → 85.0,
+// ~1.57% marginal. LINE oförändrat).
 const LINE_FLOOR = 0.895;
-const FUNC_FLOOR = 0.849;
+const FUNC_FLOOR = 0.850;
 
 /**
  * SERIAL_FILES — testfiler som SYNKRONT spawnar en barnprocess via


### PR DESCRIPTION
## Vad

`ContactsSection`:s formulär-fält-handlers var delvis otäckta:
- **kontakttyp-byte** (PERSON `personalNumber` vs ORGANISATION `orgNumber`-gren)
- **roll-select** i både ny- och befintlig-kontakt-formulären.

Lägger till tester som driver select:arna via deras faktiska option-värden + båda nummer-fält-grenarna. → lokal funktionstäckning 86.48% → **86.57%**.

## Ratchet — 85%-milstolpen
`FUNC_FLOOR` passerar **85%**: 84.9 → **85.0** (~1.57% marginal). `LINE_FLOOR` oförändrat. Funktionsgolvet har gått 84.3 → 85.0 över 9 steg den här sessionen.

## Verifiering
- `bun test contacts-section` — 9 pass.
- `bun run test:cov` — gate grön (funktioner 86.57% ≥ 85.00%, rader 90.86% ≥ 89.50%).
- `bun run typecheck` + `bun run lint` — rent.

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)