### PR TITLE
test(matters-page): cover full new-matter form + prev pagination, bump FUNC floor (#27)

### DIFF
--- a/test/unit/app/matters/page.test.tsx
+++ b/test/unit/app/matters/page.test.tsx
@@ -168,4 +168,30 @@ describe("MattersPage", () => {
     expect(screen.getByText("Stängt")).toBeInTheDocument();
     expect(screen.getByText("Arkiverat")).toBeInTheDocument();
   });
+
+  it("fyller alla fält i Nytt ärende-formuläret → create med komplett payload", () => {
+    render(<MattersPage />);
+    fireEvent.click(screen.getByRole("button", { name: /\+ Nytt ärende/i }));
+    fireEvent.change(screen.getByLabelText(/Titel/), { target: { value: "Tvist AB" } });
+    fireEvent.change(screen.getByLabelText("Ärendetyp"), { target: { value: "Brottmål" } });
+    fireEvent.change(screen.getByLabelText(/målnummer/), { target: { value: "B 1234-26" } });
+    fireEvent.change(screen.getByLabelText("Beskrivning"), { target: { value: "Misshandel" } });
+    fireEvent.click(screen.getByRole("checkbox")); // Taxeärende
+    fireEvent.click(screen.getByRole("button", { name: /Skapa ärende/i }));
+    expect(createMatterMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Tvist AB", matterType: "Brottmål",
+        courtCaseNumber: "B 1234-26", description: "Misshandel", isTaxeArende: true,
+      }),
+    );
+  });
+
+  it("paginering: Nästa följt av Föregående går tillbaka till sida 1", () => {
+    mattersQuery.data = { matters: [], total: 50, pages: 3 };
+    render(<MattersPage />);
+    fireEvent.click(screen.getByRole("button", { name: /Nästa/i }));
+    expect(screen.getByText(/Sida 2 av 3/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Föregående/i }));
+    expect(screen.getByText(/Sida 1 av 3/)).toBeInTheDocument();
+  });
 });

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -101,9 +101,12 @@ const FAST = process.argv.includes("--fast");
 // marginal. LINE oförändrat) → 89.5 rader / 85.0 funktioner (#27:
 // ContactsSection ny/befintlig-kontakt-formulär (PERSON/ORG-grenar, roll-
 // select) → lokalt 86.57% funktioner. FUNC passerar 85%-milstolpen 84.9 → 85.0,
-// ~1.57% marginal. LINE oförändrat).
+// ~1.57% marginal. LINE oförändrat) → 89.5 rader / 85.1 funktioner (#27:
+// MattersPage NewMatterForm-fält (typ/målnr/beskrivning/taxeärende) + Föregående-
+// paginering → lokalt 86.66% funktioner. FUNC dras upp 85.0 → 85.1, ~1.56%
+// marginal. LINE oförändrat).
 const LINE_FLOOR = 0.895;
-const FUNC_FLOOR = 0.850;
+const FUNC_FLOOR = 0.851;
 
 /**
  * SERIAL_FILES — testfiler som SYNKRONT spawnar en barnprocess via


### PR DESCRIPTION
## Vad

`NewMatterForm`-testet fyllde bara titeln; `matterType`/`courtCaseNumber`/`description`-fält-handlers + Taxeärende-checkboxen + Föregående-pagineringsknappen var otäckta. Lägger till:
- **full-fill + submit** (asserterar komplett create-payload: titel, ärendetyp, målnr, beskrivning, isTaxeärende).
- **paginering** Nästa → Föregående → tillbaka till sida 1.

→ lokal funktionstäckning 86.57% → **86.66%**.

## Ratchet
`FUNC_FLOOR` **85.0 → 85.1** (~1.56% marginal). `LINE_FLOOR` oförändrat.

## Verifiering
- `bun test matters/page` — 11 pass.
- `bun run test:cov` — gate grön (funktioner 86.66% ≥ 85.10%, rader 90.85% ≥ 89.50%).
- `bun run typecheck` + `bun run lint` — rent.

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)