### PR TITLE
test(payment-plans): cover status filter + search + row-click + loading (#27)

### DIFF
--- a/test/unit/app/payment-plans/page.test.tsx
+++ b/test/unit/app/payment-plans/page.test.tsx
@@ -40,7 +40,8 @@ vi.mock("@/lib/client/trpc", () => ({
     },
   },
 }));
-vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+const pushSpy = vi.fn();
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: pushSpy }) }));
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -105,5 +106,46 @@ describe("PaymentPlansPage — Skicka påminnelser nu (#71)", () => {
     const btn = screen.getByTestId("send-reminders") as HTMLButtonElement;
     expect(btn.disabled).toBe(true);
     expect(btn.textContent).toContain("Skickar");
+  });
+});
+
+describe("PaymentPlansPage — filter, sök, rad-klick", () => {
+  const planRow = {
+    id: "pp1", status: "ACTIVE", monthlyAmount: 10_000, dayOfMonth: 15,
+    invoice: {
+      amount: 100_000, payments: [], writeOffs: [],
+      matter: { matterNumber: "2026-0001", title: "Tvist", contacts: [{ contact: { id: "c1", name: "Anna" } }] },
+    },
+  };
+
+  it("status-filter: klick på Slutförda/Avbrutna sätter aria-pressed", () => {
+    render(<PaymentPlansPage />);
+    const completed = screen.getByRole("button", { name: "Slutförda" });
+    fireEvent.click(completed);
+    expect(completed).toHaveAttribute("aria-pressed", "true");
+    const cancelled = screen.getByRole("button", { name: "Avbrutna" });
+    fireEvent.click(cancelled);
+    expect(cancelled).toHaveAttribute("aria-pressed", "true");
+    expect(completed).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("sökfältet uppdaterar värdet", () => {
+    render(<PaymentPlansPage />);
+    const search = screen.getByPlaceholderText(/Sök på klient/) as HTMLInputElement;
+    fireEvent.change(search, { target: { value: "Anna" } });
+    expect(search.value).toBe("Anna");
+  });
+
+  it("rad-klick navigerar till plan-detaljen (router.push)", () => {
+    listQuery.data = [planRow];
+    render(<PaymentPlansPage />);
+    fireEvent.click(screen.getByText("Tvist"));
+    expect(pushSpy).toHaveBeenCalled();
+  });
+
+  it("laddar-tillstånd visar 'Laddar…'", () => {
+    listQuery.isLoading = true;
+    render(<PaymentPlansPage />);
+    expect(screen.getByText("Laddar…")).toBeInTheDocument();
   });
 });

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -107,9 +107,12 @@ const FAST = process.argv.includes("--fast");
 // marginal. LINE oförändrat) → 89.5 rader / 85.3 funktioner (#27: TodoClient
 // dag-navigering + toggle/create/edit/delete-flöden + användar-väljare → lokalt
 // 86.95% funktioner / 91.13% rader. FUNC dras upp 85.1 → 85.3 (~1.65% marginal,
-// konservativt pga större hopp). LINE oförändrat — lcov-line-brus + Node-buffert).
+// konservativt pga större hopp). LINE oförändrat — lcov-line-brus + Node-buffert)
+// → 89.5 rader / 85.4 funktioner (#27: PaymentPlansPage status-filter + sök +
+// rad-klick + laddar-tillstånd → lokalt 87.02% funktioner. FUNC dras upp 85.3 →
+// 85.4, ~1.62% marginal. LINE oförändrat).
 const LINE_FLOOR = 0.895;
-const FUNC_FLOOR = 0.853;
+const FUNC_FLOOR = 0.854;
 
 /**
  * SERIAL_FILES — testfiler som SYNKRONT spawnar en barnprocess via


### PR DESCRIPTION
## Vad

`PaymentPlansPage`:s status-filter-knappar (`setStatus` över ACTIVE/COMPLETED/CANCELLED), sökfältet, DataTable-rad-klick-navigeringen (`router.push`) och laddar-tillståndet var otäckta. Lägger till interaktions-tester (med modulnivå-router-push-spy). → lokal funktionstäckning 86.95% → **87.02%**.

## Ratchet
`FUNC_FLOOR` **85.3 → 85.4** (~1.62% marginal). `LINE_FLOOR` oförändrat.

## Verifiering
- `bun test payment-plans/page` — 10 pass.
- `bun run test:cov` — gate grön (funktioner 87.02% ≥ 85.40%, rader 91.14% ≥ 89.50%).
- `bun run typecheck` + `bun run lint` — rent.

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)