### PR TITLE
test(users-page): cover admin/non-admin branches + deactivate flow, bump FUNC floor (#27)

### DIFF
--- a/test/unit/app/users/page.test.tsx
+++ b/test/unit/app/users/page.test.tsx
@@ -2,7 +2,7 @@
  * Test för UsersPage (lista).
  */
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
 import UsersPage from "@/app/users/page";
 
@@ -39,8 +39,16 @@ vi.mock("@/lib/client/trpc", () => ({
 }));
 
 beforeEach(() => {
+  vi.clearAllMocks();
   usersQuery.data = { users: [] };
+  usersQuery.isLoading = false;
+  currentQuery.data = { id: "admin", role: "ADMIN" };
 });
+
+const sampleUser = {
+  id: "u1", name: "Anna Karlsson", title: "Advokat", email: "anna@x.se",
+  role: "LAWYER", hourlyRate: 3000, mileageRate: 2500,
+};
 
 describe("UsersPage", () => {
   it("renderar rubrik + Ny användare-länk", () => {
@@ -78,5 +86,46 @@ describe("UsersPage", () => {
     // "Advokat" finns både som roll och titel — matcha minst en
     expect(screen.getAllByText("Advokat").length).toBeGreaterThan(0);
     expect(screen.getByText("Assistent")).toBeInTheDocument();
+  });
+});
+
+describe("UsersPage — behörighet + inaktivera + status", () => {
+  it("icke-admin: visar notis + döljer Ny användare-länk + actions", () => {
+    currentQuery.data = { id: "u9", role: "LAWYER" };
+    usersQuery.data = { users: [sampleUser] };
+    render(<UsersPage />);
+    expect(screen.getByText(/Endast administratörer/)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /\+ Ny användare/i })).not.toBeInTheDocument();
+    expect(screen.queryByText("Inaktivera")).not.toBeInTheDocument();
+  });
+
+  it("admin: Inaktivera med confirm → deactivate.mutate med id", () => {
+    usersQuery.data = { users: [sampleUser] }; // id "u1" ≠ current "admin"
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    render(<UsersPage />);
+    fireEvent.click(screen.getByText("Inaktivera"));
+    expect(deactivateMutation.mutate).toHaveBeenCalledWith({ id: "u1" });
+    confirmSpy.mockRestore();
+  });
+
+  it("admin: Inaktivera med avbruten confirm → ingen mutation", () => {
+    usersQuery.data = { users: [sampleUser] };
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    render(<UsersPage />);
+    fireEvent.click(screen.getByText("Inaktivera"));
+    expect(deactivateMutation.mutate).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  it("egen rad får ingen Inaktivera-knapp (kan inte inaktivera sig själv)", () => {
+    usersQuery.data = { users: [{ ...sampleUser, id: "admin" }] }; // = current user
+    render(<UsersPage />);
+    expect(screen.queryByText("Inaktivera")).not.toBeInTheDocument();
+  });
+
+  it("laddar-tillstånd visar 'Laddar...'", () => {
+    usersQuery.isLoading = true;
+    render(<UsersPage />);
+    expect(screen.getByText("Laddar...")).toBeInTheDocument();
   });
 });

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -110,9 +110,12 @@ const FAST = process.argv.includes("--fast");
 // konservativt pga större hopp). LINE oförändrat — lcov-line-brus + Node-buffert)
 // → 89.5 rader / 85.4 funktioner (#27: PaymentPlansPage status-filter + sök +
 // rad-klick + laddar-tillstånd → lokalt 87.02% funktioner. FUNC dras upp 85.3 →
-// 85.4, ~1.62% marginal. LINE oförändrat).
+// 85.4, ~1.62% marginal. LINE oförändrat) → 89.5 rader / 85.5 funktioner (#27:
+// UsersPage behörighets-grenar (admin/icke-admin) + inaktivera-flöde (confirm
+// ja/nej) + egen-rad-vakt + laddar-tillstånd → lokalt 87.08% funktioner. FUNC
+// dras upp 85.4 → 85.5, ~1.58% marginal. LINE oförändrat).
 const LINE_FLOOR = 0.895;
-const FUNC_FLOOR = 0.854;
+const FUNC_FLOOR = 0.855;
 
 /**
  * SERIAL_FILES — testfiler som SYNKRONT spawnar en barnprocess via


### PR DESCRIPTION
## Vad

`UsersPage`:s behörighets-grenar (icke-admin-notis + dold Ny användare-länk + inga åtgärder), inaktivera-flödet (confirm ja/nej → `deactivate.mutate`), egen-rad-vakten (kan inte inaktivera sig själv) och laddar-tillståndet var otäckta. Lägger till tester för alla. → lokal funktionstäckning 87.02% → **87.08%**.

## Ratchet
`FUNC_FLOOR` **85.4 → 85.5** (~1.58% marginal). `LINE_FLOOR` oförändrat.

## Verifiering
- `bun test users/page` — 7 pass.
- `bun run test:cov` — gate grön (funktioner 87.08% ≥ 85.50%, rader 91.17% ≥ 89.50%).
- `bun run typecheck` + `bun run lint` — rent.

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)