### PR TITLE
test(calendar): cover list view + event/task forms + row actions, bump floors (#27)

### DIFF
--- a/test/unit/app/calendar/calendar-forms.test.tsx
+++ b/test/unit/app/calendar/calendar-forms.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * CalendarPage (#27) — lista-vyn (EventList/TaskList + badges), samt
+ * skapa-flödena (Nytt event → calendar.create, Ny task → task.create) och
+ * rad-åtgärder (ta bort event, klar/ta bort task).
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import CalendarPage from "@/app/calendar/page";
+
+const calCreate = vi.fn();
+const calDelete = vi.fn();
+const taskCreate = vi.fn();
+const taskComplete = vi.fn();
+const taskDelete = vi.fn();
+
+const eventRows = [
+  {
+    id: "e1", userId: "u1", title: "Förhandling Tingsrätt", kind: "appointment",
+    startAt: new Date("2026-05-20T09:00:00Z"), endAt: new Date("2026-05-20T10:00:00Z"),
+    allDay: false, location: "Sal 5", matter: { id: "m1", matterNumber: "2026-0001", title: "Tvist" },
+    mirrorToOutlook: true, mirrorStatus: "synced", outlookEventId: "o1", outlookCalendarId: "c1",
+  },
+];
+const taskRows = [
+  { id: "t1", title: "Ring klient", status: "TODO", priority: "HIGH", dueAt: new Date("2026-05-21T00:00:00Z"),
+    matter: { id: "m1", matterNumber: "2026-0001", title: "Tvist" } },
+];
+const calListQuery = { data: eventRows as unknown[], isLoading: false };
+const taskListQuery = { data: taskRows as unknown[], isLoading: false };
+
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: {
+    useUtils: () => ({ calendar: { invalidate: vi.fn(), list: { invalidate: vi.fn() } }, task: { list: { invalidate: vi.fn() } } }),
+    user: {
+      current: { useQuery: () => ({ data: { id: "u1", name: "Anna", role: "LAWYER" } }) },
+      list: { useQuery: () => ({ data: { users: [{ id: "u1", name: "Anna" }] }, isLoading: false }) },
+    },
+    contacts: { list: { useQuery: () => ({ data: { contacts: [] } }) } },
+    matter: { list: { useQuery: () => ({ data: { matters: [] } }) } },
+    calendar: {
+      list: { useQuery: () => calListQuery },
+      listForUsers: { useQuery: () => ({ data: [], isLoading: false }) },
+      create: { useMutation: () => ({ mutate: calCreate, isPending: false }) },
+      update: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      delete: { useMutation: () => ({ mutate: calDelete, isPending: false }) },
+    },
+    task: {
+      list: { useQuery: () => taskListQuery },
+      create: { useMutation: () => ({ mutate: taskCreate, isPending: false }) },
+      complete: { useMutation: () => ({ mutate: taskComplete, isPending: false }) },
+      delete: { useMutation: () => ({ mutate: taskDelete, isPending: false }) },
+    },
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  calListQuery.data = eventRows;
+  taskListQuery.data = taskRows;
+});
+
+describe("CalendarPage — lista + skapa-flöden", () => {
+  it("TaskList renderar tasks med prioritets-badge", () => {
+    render(<CalendarPage />);
+    expect(screen.getByText("Ring klient")).toBeInTheDocument();
+    expect(screen.getByText("Hög")).toBeInTheDocument(); // PriorityBadge HIGH
+  });
+
+  it("lista-vyn renderar EventList med kind/Outlook-badge", () => {
+    render(<CalendarPage />);
+    fireEvent.click(screen.getByRole("button", { name: "Lista" }));
+    expect(screen.getByText("Förhandling Tingsrätt")).toBeInTheDocument();
+    expect(screen.getByText(/Outlook/)).toBeInTheDocument(); // MirrorBadge
+  });
+
+  it("'Nytt event' → fyll titel + start → Skapa → calendar.create", () => {
+    render(<CalendarPage />);
+    fireEvent.click(screen.getByRole("button", { name: /Nytt event/ }));
+    fireEvent.change(screen.getByRole("textbox", { name: /Titel/i }) ?? document.querySelector('input[type="text"]')!, { target: { value: "Möte" } });
+    const startInput = document.querySelector('input[type="datetime-local"]') as HTMLInputElement;
+    fireEvent.change(startInput, { target: { value: "2026-06-01T10:00" } });
+    fireEvent.click(screen.getByRole("button", { name: /^Skapa$/ }));
+    expect(calCreate).toHaveBeenCalledWith(expect.objectContaining({ title: "Möte" }));
+  });
+
+  it("'Ny task' → fyll titel → Skapa → task.create", () => {
+    render(<CalendarPage />);
+    fireEvent.click(screen.getByRole("button", { name: /Ny task/ }));
+    const titleInput = screen.getAllByRole("textbox")[0] as HTMLInputElement;
+    fireEvent.change(titleInput, { target: { value: "Skriv inlaga" } });
+    fireEvent.click(screen.getByRole("button", { name: /^Skapa$/ }));
+    expect(taskCreate).toHaveBeenCalledWith(expect.objectContaining({ title: "Skriv inlaga" }));
+  });
+
+  it("task klar-markeras → task.complete; ta bort → confirm → task.delete", () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    render(<CalendarPage />);
+    fireEvent.click(screen.getByTitle("Markera klar"));
+    expect(taskComplete).toHaveBeenCalledWith({ id: "t1" });
+    fireEvent.click(screen.getAllByTitle("Ta bort")[0]!);
+    expect(taskDelete).toHaveBeenCalledWith({ id: "t1" });
+    confirmSpy.mockRestore();
+  });
+});

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -113,9 +113,13 @@ const FAST = process.argv.includes("--fast");
 // 85.4, ~1.62% marginal. LINE oförändrat) → 89.5 rader / 85.5 funktioner (#27:
 // UsersPage behörighets-grenar (admin/icke-admin) + inaktivera-flöde (confirm
 // ja/nej) + egen-rad-vakt + laddar-tillstånd → lokalt 87.08% funktioner. FUNC
-// dras upp 85.4 → 85.5, ~1.58% marginal. LINE oförändrat).
-const LINE_FLOOR = 0.895;
-const FUNC_FLOOR = 0.855;
+// dras upp 85.4 → 85.5, ~1.58% marginal. LINE oförändrat) → 90.0 rader / 85.6
+// funktioner (#27: CalendarPage lista-vy + Nytt event/Ny task-formulär + rad-
+// åtgärder → lokalt 92.34% rader / 87.21% funktioner. Rad-täckningen har stigit
+// stadigt över ~14 steg (90.86 → 92.34) → LINE-golvet dras ÄNTLIGEN upp 89.5 →
+// 90.0 (~2.34% marginal, fortsatt generös Node-buffert). FUNC 85.5 → 85.6).
+const LINE_FLOOR = 0.900;
+const FUNC_FLOOR = 0.856;
 
 /**
  * SERIAL_FILES — testfiler som SYNKRONT spawnar en barnprocess via


### PR DESCRIPTION
## Vad

`CalendarPage` lista-vyn + skapa-flöden var otäckta. Ny `calendar-forms`-test:
- **lista-vyn** (EventList/TaskList + kind-/prioritets-/Outlook-badges)
- **Nytt event** + **Ny task** (fyll + Skapa → `calendar.create` / `task.create`)
- task klar/ta bort.

→ lokalt **92.34% rader / 87.21% funktioner**.

## Ratchet — LINE-golvet rör sig äntligen
Rad-täckningen har stigit stadigt över ~14 #27-steg (90.86 → 92.34), så `LINE_FLOOR` dras upp **89.5 → 90.0** (~2.34% marginal, fortsatt generös Node-buffert). `FUNC_FLOOR` **85.5 → 85.6**.

## Verifiering
- `bun test calendar-forms` — 5 pass.
- `bun run test:cov` — gate grön (rader 92.34% ≥ 90.00%, funktioner 87.21% ≥ 85.60%).
- `bun run typecheck` + `bun run lint` — rent.

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)