### PR TITLE
refactor(tooling): drop the last `any` in seed-data html-to-docx interop (#27)

### DIFF
--- a/tooling/scripts/seed-data.ts
+++ b/tooling/scripts/seed-data.ts
@@ -804,11 +804,18 @@ export async function generateDocumentBytes(doc: {
     return pdf.save();
   }
 
-  // DOCX via html-to-docx (saknar typings → dynamisk import + cast)
-  // @ts-expect-error — html-to-docx har inga .d.ts. Default export är callable.
-  const htmlToDocxModule = await import("html-to-docx");
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const htmlToDocx = (htmlToDocxModule as any).default as (html: string, headers?: unknown, opts?: unknown) => Promise<Buffer>;
+  // DOCX via html-to-docx. Paketet skeppar inga typings (otypat 3rd-party,
+  // endast build-time). Vi typar destruktureringen explicit (ingen `any`, ingen
+  // cast) och låter ETT smalt @ts-expect-error svälja TS7016 på importen — en
+  // ambient `declare module` skuggas under moduleResolution:bundler och en
+  // tsconfig-`paths` skulle bryta runtime-resolven (bun följer paths).
+  type HtmlToDocx = (
+    html: string,
+    headerHtml?: string | null,
+    options?: { table?: { row?: { cantSplit?: boolean } } } & Record<string, unknown>,
+  ) => Promise<Buffer>;
+  // @ts-expect-error — html-to-docx saknar .d.ts; default-exporten är callable.
+  const { default: htmlToDocx }: { default: HtmlToDocx } = await import("html-to-docx");
   const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>${escapeXml(title)}</title></head>` +
     `<body><h1>${escapeXml(title)}</h1><h2>${escapeXml(heading)}</h2><p>${escapeXml(body)}</p></body></html>`;
   const buf = await htmlToDocx(html, undefined, { table: { row: { cantSplit: true } } });


### PR DESCRIPTION
## Vad
`html-to-docx` skeppar inga typings → seed-data castade default-exporten via `as any` + `@ts-expect-error` (enda riktiga `any`:n i src/+tooling/). Ersätter `as any` med en explicit typad destrukturering (lokal `HtmlToDocx`-fn-typ) + EN smal `@ts-expect-error` på importen. **Ingen `any`, ingen cast, runtime-säker.**

Avvisade alternativ: tsconfig `paths` bryter runtime (bun resolvar importen till `.d.ts` → `ReferenceError`, sågs i första CI-körningen); ambient `declare module` skuggas under `moduleResolution: bundler`. Det otypade 3rd-party-build-only-paketet behöver det lokaliserade `@ts-expect-error` (samma kategori som json-logic-casterna i arkitektur-genomgången).

## Verifierat
- `bun run typecheck` 0 · `bun run lint` 0 · runtime-import resolvar (function) · **`build:demo` grön** (genererar DOCX via html-to-docx, 40 dok).

Resultat: noll `any`/`as any` i src/ + tooling/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)