### PR TITLE
refactor(data-store): remove dead Prisma-mimicry surface from IDataStore (#562)

### DIFF
--- a/src/lib/server/data-store/IDataStore.ts
+++ b/src/lib/server/data-store/IDataStore.ts
@@ -31,19 +31,6 @@ export interface IEventLog {
   onNewEvent(handler: (event: AvaEvent) => void | Promise<void>): () => void;
 }
 
-// ─── Claim-store (oanvänd i ren git-modell, kvar för framtida ev. hjälpprocess) ───
-
-export interface IClaimStore {
-  tryClaim(claimId: string, opts: ClaimOpts): Promise<boolean>;
-  isStale(claimId: string): Promise<boolean>;
-}
-
-export interface ClaimOpts {
-  ttlSec?: number;
-  preferredRunnerOrder?: string[];
-  me: string;
-}
-
 // ─── Domän-delegates ──────────────────────────────────────────────────
 //
 // Tunn generisk delegate som täcker den Prisma-stil-yta som routrarna
@@ -145,9 +132,7 @@ export interface Delegate<Row = Record<string, unknown>> {
   create(args: { data: Partial<Row>; include?: Record<string, unknown>; select?: Record<string, unknown> }): Promise<Joined<Row>>;
   update(args: { where: WhereInput<Row>; data: Partial<Row>; include?: Record<string, unknown>; select?: Record<string, unknown> }): Promise<Joined<Row>>;
   updateMany(args: { where?: WhereInput<Row>; data: Partial<Row> }): Promise<{ count: number }>;
-  upsert(args: { where: WhereInput<Row>; create: Partial<Row>; update: Partial<Row> }): Promise<Joined<Row>>;
   delete(args: FindArgs<Row>): Promise<Joined<Row>>;
-  deleteMany(args?: FindArgs<Row>): Promise<{ count: number }>;
   count(args?: FindArgs<Row>): Promise<number>;
   aggregate(args: AggregateArgs): Promise<Record<string, unknown>>;
 }
@@ -183,29 +168,6 @@ export type CalendarEventDelegate = Delegate<CalendarEvent>;
 export type TaskDelegate = Delegate<Task>;
 export type ServiceNoteDelegate = Delegate<ServiceNote>;
 
-// Opt-in: enskilda callers som vill ha striktare row-typ kan importera
-// dessa istället. T.ex. `const matters = ctx.dataStore.matters as MattersStrict`.
-// TODO: när schema-mismatches är fixade kan vi växla över delegaterna ovan.
-export type MattersStrict = Delegate<Matter>;
-export type ContactsStrict = Delegate<Contact>;
-export type MatterContactsStrict = Delegate<MatterContact>;
-export type DocumentsStrict = Delegate<Document>;
-export type DocumentFoldersStrict = Delegate<DocumentFolder>;
-export type DocumentTemplatesStrict = Delegate<DocumentTemplate>;
-export type DocumentAnalysisSuggestionsStrict = Delegate<DocumentAnalysisSuggestion>;
-export type MatterEventSuggestionsStrict = Delegate<MatterEventSuggestion>;
-export type InvoicesStrict = Delegate<Invoice>;
-export type TimeEntriesStrict = Delegate<TimeEntry>;
-export type ExpensesStrict = Delegate<Expense>;
-export type UsersStrict = Delegate<User>;
-export type OrganizationsStrict = Delegate<Organization>;
-export type OfficesStrict = Delegate<Office>;
-export type ConflictChecksStrict = Delegate<ConflictCheck>;
-export type PaymentsStrict = Delegate<Payment>;
-export type PaymentPlansStrict = Delegate<PaymentPlan>;
-export type AccontoDeductionsStrict = Delegate<AccontoDeduction>;
-export type CalendarEventsStrict = Delegate<CalendarEvent>;
-export type TasksStrict = Delegate<Task>;
 
 // ─── Transaktionsvy ───────────────────────────────────────────────────
 //
@@ -249,9 +211,6 @@ export interface DataStoreTx {
 export interface IDataStore {
   /** Event-loggen. */
   events: IEventLog;
-
-  /** Claim-store. Oanvänd just nu (var aktiv i Tauri-helper-läget). */
-  claims?: IClaimStore;
 
   // ─── Domän-repos ────────────────────────────────────────────────
   readonly matters: MatterDelegate;

--- a/src/lib/server/data-store/in-memory/read-only-delegate.ts
+++ b/src/lib/server/data-store/in-memory/read-only-delegate.ts
@@ -142,12 +142,9 @@ export class ReadOnlyDelegate<T extends Record<string, unknown>> implements Dele
   // ─── Mutationer — alla kastar ─────────────────────────────────────
 
   async create(_args: unknown): Promise<never> { throw new ReadOnlyError("create"); }
-  async createMany(_args: unknown): Promise<never> { throw new ReadOnlyError("createMany"); }
   async update(_args: unknown): Promise<never> { throw new ReadOnlyError("update"); }
   async updateMany(_args: unknown): Promise<never> { throw new ReadOnlyError("updateMany"); }
   async delete(_args: unknown): Promise<never> { throw new ReadOnlyError("delete"); }
-  async deleteMany(_args?: unknown): Promise<never> { throw new ReadOnlyError("deleteMany"); }
-  async upsert(_args: unknown): Promise<never> { throw new ReadOnlyError("upsert"); }
 
   // ─── Privat: relations-hydrering ─────────────────────────────────
 

--- a/src/lib/server/data-store/in-memory/writable-delegate.ts
+++ b/src/lib/server/data-store/in-memory/writable-delegate.ts
@@ -119,24 +119,4 @@ export class WritableDelegate<T extends Record<string, unknown>> extends ReadOnl
     }
     return { count } as never;
   }
-
-  override async deleteMany(args: unknown): Promise<never> {
-    const a = args as { where?: Record<string, unknown> };
-    const matches = await this.findMany(a.where !== undefined ? { where: a.where } : {});
-    let count = 0;
-    for (const m of matches) {
-      await this.delete({ where: { id: m.id as string } });
-      count++;
-    }
-    return { count } as never;
-  }
-
-  override async upsert(args: unknown): Promise<never> {
-    const a = args as { where: { id: string }; create: Partial<T>; update: Partial<T> };
-    const existing = await this.findUnique({ where: { id: a.where.id } });
-    const result = existing
-      ? await this.update({ where: a.where, data: a.update })
-      : await this.create({ data: { ...a.create, id: a.where.id } as Partial<T> });
-    return result as never;
-  }
 }

--- a/test/unit/server/data-store/in-memory/read-only-delegate.test.ts
+++ b/test/unit/server/data-store/in-memory/read-only-delegate.test.ts
@@ -154,20 +154,8 @@ describe("ReadOnlyDelegate — mutationsförbud", () => {
     await expect(delegate.delete({ where: { id: "m1" } })).rejects.toThrow(ReadOnlyError);
   });
 
-  it("upsert kastar", async () => {
-    await expect(delegate.upsert({ where: { id: "m1" }, create: {}, update: {} })).rejects.toThrow(ReadOnlyError);
-  });
-
-  it("deleteMany kastar", async () => {
-    await expect(delegate.deleteMany()).rejects.toThrow(ReadOnlyError);
-  });
-
   it("updateMany kastar", async () => {
     await expect(delegate.updateMany({ data: {} })).rejects.toThrow(ReadOnlyError);
-  });
-
-  it("createMany kastar", async () => {
-    await expect(delegate.createMany({ data: [] })).rejects.toThrow(ReadOnlyError);
   });
 });
 


### PR DESCRIPTION
## Bakgrund
Du bad mig verifiera att all kod används (oro för kvarvarande Prisma-kod). `knip` + dep-cruiser är rena, MEN `IDataStore.ts` är en knip-**entry point** → döda *medlemmar inuti* den syns inte för knip. En djupsökning hittade exakt det: kvarvarande Prisma-API-mimicry utan några produktions-anropare.

## Borttaget (noll produktions-anropare — verifierat)
- `Delegate.upsert` + `Delegate.deleteMany` (interface + ReadOnlyDelegate + WritableDelegate-impls) — anropades bara av sina egna enhetstester.
- `ReadOnlyDelegate.createMany`-stub (fanns inte ens i interfacet).
- `IClaimStore` + `ClaimOpts` + `IDataStore.claims` (0 refs; legacy Tauri-helper-claim-store).
- Alla `*Strict`-Delegate-alias (`MattersStrict` … `TasksStrict`) — 0 refs.
- `upsert`/`deleteMany`/`createMany`-ReadOnlyError-testerna.

## Behållet (inte dött)
`findUnique`/`findUniqueOrThrow`/`findFirstOrThrow` (inga prod-anropare men används som läs-accessorer av flera tester) och `IDataStore.raw` (sammanflätat med ett test + mock-hjälparen).

## Verifierat
typecheck 0 · lint 0 · knip 0 · 142 data-store-tester + hela unit-sviten (3118) gröna.

Refs #562. (Övrig dead-code-status: ingen Prisma-dependency, inga .prisma-filer, ingen Prisma i src; knip+dep-cruiser rena på filer/exports/deps.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)