### PR TITLE
refactor(routers): brand id inputs in contact/serviceNote/task (#27)

### DIFF
--- a/src/lib/server/routers/contact.ts
+++ b/src/lib/server/routers/contact.ts
@@ -31,7 +31,7 @@ export const contactRouter = router({
     }),
 
   getById: orgProcedure
-    .input(z.object({ id: z.string() }))
+    .input(z.object({ id: contactIdSchema }))
     // Migrerad: getByIdFull (barn/förälder/ärende-kopplingar), org-scopad.
     .query(async ({ ctx, input }) => {
       const contact = await ctx.repos.contacts.getByIdFull(input.id, ctx.orgId);
@@ -68,7 +68,7 @@ export const contactRouter = router({
   update: orgProcedure
     .input(
       z.object({
-        id: z.string(),
+        id: contactIdSchema,
         name: z.string().min(1).optional(),
         contactType: contactTypeSchema.optional(),
         personalNumber: z.string().optional(),
@@ -96,7 +96,7 @@ export const contactRouter = router({
     }),
 
   delete: orgProcedure
-    .input(z.object({ id: z.string() }))
+    .input(z.object({ id: contactIdSchema }))
     .mutation(async ({ ctx, input }) => {
       await requireOrgOwned(
         () => ctx.repos.contacts.getById(input.id),

--- a/src/lib/server/routers/serviceNote.ts
+++ b/src/lib/server/routers/serviceNote.ts
@@ -17,7 +17,7 @@ import { router, protectedProcedure, orgProcedure, TRPCError } from "../trpc";
  */
 export const serviceNoteRouter = router({
   list: protectedProcedure
-    .input(z.object({ matterId: z.string() }))
+    .input(z.object({ matterId: matterIdSchema }))
     // Migrerad till repository-sömmen (ADR 0020): listByMatter org-scopar via ärendet.
     .query(({ ctx, input }) =>
       ctx.repos.serviceNotes.listByMatter(input.matterId, ctx.user.organizationId),
@@ -52,7 +52,7 @@ export const serviceNoteRouter = router({
   update: orgProcedure
     .input(
       z.object({
-        id: z.string(),
+        id: serviceNoteIdSchema,
         date: z.string().min(1).optional(),
         time: z.string().min(1).optional(),
         text: z.string().min(1).optional(),
@@ -68,7 +68,7 @@ export const serviceNoteRouter = router({
     }),
 
   delete: orgProcedure
-    .input(z.object({ id: z.string() }))
+    .input(z.object({ id: serviceNoteIdSchema }))
     .mutation(async ({ ctx, input }) => {
       const owned = await ctx.repos.serviceNotes.getByIdInOrg(input.id, ctx.orgId);
       if (!owned) throw new TRPCError({ code: "NOT_FOUND" });

--- a/src/lib/server/routers/task.ts
+++ b/src/lib/server/routers/task.ts
@@ -37,7 +37,7 @@ export const taskRouter = router({
     .input(
       z.object({
         status: taskStatusSchema.optional(),
-        matterId: z.string().optional(),
+        matterId: matterIdSchema.optional(),
       }).optional(),
     )
     // Migrerad till repository-sömmen (ADR 0020): ägar-/org-scopad listForUser.
@@ -77,7 +77,7 @@ export const taskRouter = router({
     }),
 
   complete: protectedProcedure
-    .input(z.object({ id: z.string() }))
+    .input(z.object({ id: taskIdSchema }))
     .mutation(async ({ ctx, input }) => {
       const owned = await ctx.repos.tasks.getOwned(input.id, ctx.user.id, ctx.user.organizationId);
       if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
@@ -85,7 +85,7 @@ export const taskRouter = router({
     }),
 
   delete: protectedProcedure
-    .input(z.object({ id: z.string() }))
+    .input(z.object({ id: taskIdSchema }))
     .mutation(async ({ ctx, input }) => {
       const owned = await ctx.repos.tasks.getOwned(input.id, ctx.user.id, ctx.user.organizationId);
       if (!owned) throw new TRPCError({ code: "NOT_FOUND" });


### PR DESCRIPTION
## Vad
Ersätter `z.string()` med matchande `*IdSchema` för entitets-id-inputs i contact-, serviceNote- och task-routrarna (getById/update/delete + matterId-filter). Del av strong-typing-direktivet från arkitektur-genomgången.

**Runtime-identiskt:** `brandedId = z.string().min(1).brand<…>()` är rent typ-nivå (doc i `ids.ts`), så demons läsbara ids (`m-001-vardnad`, `current-user`) passerar fortfarande — men tRPC-gränsen bär nu branded ids hela vägen.

Första batchen som etablerar mönstret; övriga routrar följer (matter, invoice, calendar, billingRun, expectedReceivable, invoiceDispatch, paymentPlan, documentTemplate, expense, timeEntry, organization, user).

## Verifierat
typecheck 0 (branded ids flödar rent → repos tar `string`, `asId` re-brandar), lint 0, router-tester gröna (31).

Refs #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)