### PR TITLE
refactor(routers): brand remaining id inputs with *IdSchema (#27)

### DIFF
--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -116,14 +116,14 @@ async function assertMatterInOrg(repos: Repositories, matterId: string, orgId: s
 
 export const billingRunRouter = router({
   list: orgProcedure
-    .input(z.object({ matterId: z.string().optional() }))
+    .input(z.object({ matterId: matterIdSchema.optional() }))
     .query(async ({ ctx, input }) => {
       const runs = await ctx.repos.billingRuns.listForOrg(ctx.orgId, input.matterId);
       return { runs };
     }),
 
   byId: orgProcedure
-    .input(z.object({ id: z.string() }))
+    .input(z.object({ id: billingRunIdSchema }))
     .query(async ({ ctx, input }) => {
       const run = await ctx.repos.billingRuns.getByIdInOrg(input.id, ctx.orgId);
       if (!run) throw new TRPCError({ code: "NOT_FOUND", message: "Faktureringshändelsen finns inte." });
@@ -233,7 +233,7 @@ export const billingRunRouter = router({
 
   setVerdict: orgProcedure
     .input(z.object({
-      billingRunId: z.string(),
+      billingRunId: billingRunIdSchema,
       prutningOre: z.number().int().nonpositive(),
     }))
     .mutation(async ({ ctx, input }) => {

--- a/src/lib/server/routers/calendar.ts
+++ b/src/lib/server/routers/calendar.ts
@@ -141,7 +141,7 @@ export const calendarRouter = router({
     }),
 
   getById: protectedProcedure
-    .input(z.object({ id: z.string() }))
+    .input(z.object({ id: calendarEventIdSchema }))
     .query(async ({ ctx, input }) => {
       const ev = await ctx.repos.calendarEvents.getOwnedWithMatter(input.id, ctx.user.id, ctx.user.organizationId);
       if (!ev) throw new TRPCError({ code: "NOT_FOUND" });
@@ -166,7 +166,7 @@ export const calendarRouter = router({
 
   /** Alla events kopplade till ett specifikt ärende, kronologiskt. */
   listForMatter: protectedProcedure
-    .input(z.object({ matterId: z.string() }))
+    .input(z.object({ matterId: matterIdSchema }))
     .query(({ ctx, input }) =>
       ctx.repos.calendarEvents.listForMatter(input.matterId, ctx.user.organizationId),
     ),
@@ -189,7 +189,7 @@ export const calendarRouter = router({
     }),
 
   delete: protectedProcedure
-    .input(z.object({ id: z.string() }))
+    .input(z.object({ id: calendarEventIdSchema }))
     .mutation(async ({ ctx, input }) => {
       // Säkerställ ownership innan delete
       const owned = await ctx.repos.calendarEvents.getOwned(input.id, ctx.user.id, ctx.user.organizationId);
@@ -208,7 +208,7 @@ export const calendarRouter = router({
   setMirrorState: protectedProcedure
     .input(
       z.object({
-        id: z.string(),
+        id: calendarEventIdSchema,
         outlookEventId: z.string().nullish(),
         mirrorStatus: z.enum(["synced", "failed", "pending"]).nullable(),
         mirrorError: z.string().nullish(),

--- a/src/lib/server/routers/documentTemplate.ts
+++ b/src/lib/server/routers/documentTemplate.ts
@@ -16,7 +16,7 @@ export const documentTemplateRouter = router({
   ),
 
   getById: protectedProcedure
-    .input(z.object({ id: z.string() }))
+    .input(z.object({ id: documentTemplateIdSchema }))
     .query(async ({ ctx, input }) => {
       const template = await ctx.repos.documentTemplates.getByIdInOrg(input.id, ctx.user.organizationId);
       if (!template) throw new TRPCError({ code: "NOT_FOUND" });
@@ -54,7 +54,7 @@ export const documentTemplateRouter = router({
   update: protectedProcedure
     .input(
       z.object({
-        id: z.string(),
+        id: documentTemplateIdSchema,
         name: z.string().min(1).optional(),
         description: z.string().optional(),
         category: z.string().optional(),
@@ -69,7 +69,7 @@ export const documentTemplateRouter = router({
     }),
 
   delete: protectedProcedure
-    .input(z.object({ id: z.string() }))
+    .input(z.object({ id: documentTemplateIdSchema }))
     .mutation(async ({ ctx, input }) => {
       const existing = await ctx.repos.documentTemplates.getByIdInOrg(input.id, ctx.user.organizationId);
       if (!existing) throw new TRPCError({ code: "NOT_FOUND" });

--- a/src/lib/server/routers/expectedReceivable.ts
+++ b/src/lib/server/routers/expectedReceivable.ts
@@ -17,7 +17,7 @@ import { z } from "zod";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import type { ExpectedReceivable } from "@/lib/shared/schemas/billing";
 import { expectedReceivableStatusSchema } from "@/lib/shared/schemas/billing";
-import { asId } from "@/lib/shared/schemas/ids";
+import { asId, expectedReceivableIdSchema, matterIdSchema } from "@/lib/shared/schemas/ids";
 import type { Repositories } from "../repositories/repositories";
 import { router, orgProcedure } from "../trpc";
 
@@ -31,7 +31,7 @@ async function assertInOrg(repos: Repositories, orgId: string, id: string): Prom
 export const expectedReceivableRouter = router({
   /** Lista fordringar i org:en, valfritt filtrerat på ärende. */
   list: orgProcedure
-    .input(z.object({ matterId: z.string().optional() }).optional())
+    .input(z.object({ matterId: matterIdSchema.optional() }).optional())
     .query(({ ctx, input }) =>
       ctx.repos.expectedReceivables.listForOrg(ctx.orgId, { matterId: input?.matterId }),
     ),
@@ -63,7 +63,7 @@ export const expectedReceivableRouter = router({
   /** Registrera en förväntad domstolsbetalning (status PENDING). */
   create: orgProcedure
     .input(z.object({
-      matterId: z.string(),
+      matterId: matterIdSchema,
       description: z.string().min(1),
       expectedAmount: z.number().int().nonnegative(),
     }))
@@ -92,7 +92,7 @@ export const expectedReceivableRouter = router({
    */
   settle: orgProcedure
     .input(z.object({
-      id: z.string(),
+      id: expectedReceivableIdSchema,
       settledAmount: z.number().int().nonnegative(),
       settledAt: z.string().optional(),
       paymentReference: z.string().optional(),
@@ -110,7 +110,7 @@ export const expectedReceivableRouter = router({
 
   /** Avbryt en fordran (t.ex. felregistrerad eller domstolen avslog helt). */
   cancel: orgProcedure
-    .input(z.object({ id: z.string() }))
+    .input(z.object({ id: expectedReceivableIdSchema }))
     .mutation(async ({ ctx, input }) => {
       await assertInOrg(ctx.repos, ctx.orgId, input.id);
       return ctx.repos.expectedReceivables.update(input.id, { status: "CANCELLED", updatedAt: new Date() } as Partial<ExpectedReceivable>);
@@ -119,7 +119,7 @@ export const expectedReceivableRouter = router({
   /** Uppdatera memo-fälten (begärt belopp/beskrivning) medan PENDING. */
   update: orgProcedure
     .input(z.object({
-      id: z.string(),
+      id: expectedReceivableIdSchema,
       description: z.string().min(1).optional(),
       expectedAmount: z.number().int().nonnegative().optional(),
       status: expectedReceivableStatusSchema.optional(),

--- a/src/lib/server/routers/expense.ts
+++ b/src/lib/server/routers/expense.ts
@@ -14,7 +14,7 @@ export const expenseRouter = router({
   list: protectedProcedure
     .input(
       z.object({
-        matterId: z.string().optional(),
+        matterId: matterIdSchema.optional(),
         page: z.number().min(1).default(1),
         pageSize: z.number().min(1).max(100).default(50),
       })
@@ -72,7 +72,7 @@ export const expenseRouter = router({
   update: orgProcedure
     .input(
       z.object({
-        id: z.string(),
+        id: expenseIdSchema,
         date: z.string().optional(),
         amount: z.number().min(1).optional(),
         description: z.string().min(1).optional(),
@@ -98,7 +98,7 @@ export const expenseRouter = router({
     }),
 
   delete: orgProcedure
-    .input(z.object({ id: z.string() }))
+    .input(z.object({ id: expenseIdSchema }))
     .mutation(async ({ ctx, input }) => {
       const owned = await ctx.repos.expenses.getByIdInOrg(input.id, ctx.orgId);
       if (!owned) throw new TRPCError({ code: "NOT_FOUND" });

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -147,7 +147,7 @@ export const invoiceRouter = router({
   list: orgProcedure
     .input(
       z.object({
-        matterId: z.string().optional(),
+        matterId: matterIdSchema.optional(),
         invoiceType: invoiceTypeSchema.optional(),
         status: invoiceStatusSchema.optional(),
       }),
@@ -157,7 +157,7 @@ export const invoiceRouter = router({
     .query(({ ctx, input }) => ctx.repos.invoices.listForOrg(ctx.orgId, input)),
 
   getById: orgProcedure
-    .input(z.object({ id: z.string() }))
+    .input(z.object({ id: invoiceIdSchema }))
     .query(async ({ ctx, input }) => {
       // Migrerad till repository-sömmen (ADR 0020). getByIdFull org-scopar +
       // hämtar hela detalj-shapen (relations + aconto-avdrag/kredit).
@@ -366,7 +366,7 @@ export const invoiceRouter = router({
   recordPayment: orgProcedure
     .input(
       z.object({
-        invoiceId: z.string(),
+        invoiceId: invoiceIdSchema,
         amount: z.number().int().min(1),
         paidAt: z.string(),
         note: z.string().optional(),
@@ -482,7 +482,7 @@ export const invoiceRouter = router({
     ),
 
   cancelPaymentPlan: orgProcedure
-    .input(z.object({ planId: z.string() }))
+    .input(z.object({ planId: paymentPlanIdSchema }))
     // Migrerad till repository-sömmen (ADR 0020). Transaktionen korsar två repos
     // (paymentPlans + invoices); getByIdInOrg org-scopar via faktura→ärende.
     .mutation(({ ctx, input }) =>
@@ -508,7 +508,7 @@ export const invoiceRouter = router({
   writeOff: orgProcedure
     .input(
       z.object({
-        invoiceId: z.string(),
+        invoiceId: invoiceIdSchema,
         amount: z.number().int().min(1).optional(),
         reason: z.string().optional(),
         writtenOffAt: z.string().optional(),
@@ -555,7 +555,7 @@ export const invoiceRouter = router({
   setStatus: orgProcedure
     .input(
       z.object({
-        invoiceId: z.string(),
+        invoiceId: invoiceIdSchema,
         status: z.enum(["SENT", "CANCELLED", "BAD_DEBT"]),
       }),
     )

--- a/src/lib/server/routers/invoiceDispatch.ts
+++ b/src/lib/server/routers/invoiceDispatch.ts
@@ -13,7 +13,7 @@ import { z } from "zod";
 import { canTransition } from "@/lib/shared/invoice-state-machine";
 import { dispatchChannelSchema, dispatchStatusSchema, type DispatchStatus, type InvoiceDispatch } from "@/lib/shared/schemas/billing";
 import type { InvoiceStatus } from "@/lib/shared/schemas/enums";
-import { asId } from "@/lib/shared/schemas/ids";
+import { asId, invoiceDispatchIdSchema, invoiceIdSchema } from "@/lib/shared/schemas/ids";
 import type { Repositories } from "../repositories/repositories";
 import { router, orgProcedure } from "../trpc";
 
@@ -45,7 +45,7 @@ const STATUS_TIMESTAMP: Record<DispatchStatus, "sentAt" | "deliveredAt" | "faile
 
 export const invoiceDispatchRouter = router({
   list: orgProcedure
-    .input(z.object({ invoiceId: z.string() }))
+    .input(z.object({ invoiceId: invoiceIdSchema }))
     .query(async ({ ctx, input }) => {
       await assertInvoiceInOrg(ctx, input.invoiceId);
       return ctx.repos.invoiceDispatches.listByInvoice(input.invoiceId);
@@ -58,7 +58,7 @@ export const invoiceDispatchRouter = router({
 
   queue: orgProcedure
     .input(z.object({
-      invoiceId: z.string(),
+      invoiceId: invoiceIdSchema,
       channel: dispatchChannelSchema,
       recipient: z.string().min(1),
     }))
@@ -89,7 +89,7 @@ export const invoiceDispatchRouter = router({
    */
   recordManual: orgProcedure
     .input(z.object({
-      invoiceId: z.string(),
+      invoiceId: invoiceIdSchema,
       channel: dispatchChannelSchema,
       recipient: z.string().min(1),
     }))
@@ -113,7 +113,7 @@ export const invoiceDispatchRouter = router({
 
   updateStatus: orgProcedure
     .input(z.object({
-      dispatchId: z.string(),
+      dispatchId: invoiceDispatchIdSchema,
       status: dispatchStatusSchema,
       messageId: z.string().optional(),
       error: z.string().optional(),

--- a/src/lib/server/routers/kostnadsrakning.ts
+++ b/src/lib/server/routers/kostnadsrakning.ts
@@ -14,7 +14,7 @@
 
 import { z } from "zod";
 import { KOSTNADSRAKNING_DOCUMENT_TYPE } from "@/lib/shared/schemas/document";
-import { asId } from "@/lib/shared/schemas/ids";
+import { asId, documentIdSchema, matterIdSchema } from "@/lib/shared/schemas/ids";
 import { emit } from "../events/emit";
 import { router, orgProcedure } from "../trpc";
 
@@ -28,8 +28,8 @@ export const kostnadsrakningRouter = router({
    */
   record: orgProcedure
     .input(z.object({
-      id: z.string(),
-      matterId: z.string(),
+      id: documentIdSchema,
+      matterId: matterIdSchema,
       fileName: z.string(),
       mimeType: z.string(),
       sizeBytes: z.number(),

--- a/src/lib/server/routers/mail.ts
+++ b/src/lib/server/routers/mail.ts
@@ -13,7 +13,7 @@
  */
 
 import { z } from "zod";
-import { asId } from "@/lib/shared/schemas/ids";
+import { asId, matterIdSchema } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { emit, type EmitCtx } from "../events/emit";
 import type { Repositories } from "../repositories/repositories";
@@ -52,7 +52,7 @@ export const mailRouter = router({
   saveIncoming: orgProcedure
     .input(
       z.object({
-        matterId: z.string(),
+        matterId: matterIdSchema,
         /** Rå RFC822-MIME, base64-kodad för transport. */
         emlBase64: z.string().min(1),
         subject: z.string(),

--- a/src/lib/server/routers/matter.ts
+++ b/src/lib/server/routers/matter.ts
@@ -10,6 +10,7 @@ import {
   matterIdSchema,
   contactIdSchema,
   matterContactIdSchema,
+  userIdSchema,
   asId,
   type MatterId,
   type ContactId,
@@ -38,7 +39,7 @@ async function assertMatterInOrg(ctx: MatterCtx, matterId: MatterId): Promise<Ma
  * (ADR 0003) — i normalt UI-flöde utelämnas de och defaultas.
  */
 const matterCreateInput = z.object({
-  id: z.string().optional(),
+  id: matterIdSchema.optional(),
   matterNumber: z.string().optional(),
   title: z.string().min(1),
   description: z.string().optional(),
@@ -52,12 +53,12 @@ const matterCreateInput = z.object({
   taxaHuvudforhandlingMin: z.number().int().nonnegative().nullable().optional(),
   taxaHasFTax: z.boolean().nullable().optional(),
   /** Ansvarig advokat/biträdande jurist (#174) — styr ärendenummerserien. */
-  responsibleLawyerId: z.string().optional(),
+  responsibleLawyerId: userIdSchema.optional(),
   /** Domstolens målnummer (#173) — matchningsnyckel för domstolsbetalningar. */
   courtCaseNumber: z.string().optional(),
   /** Historiskt skapad-datum (demo-generator/fixtures, ADR 0003) — annars now(). */
   createdAt: z.string().optional(),
-  klientId: z.string().optional(),
+  klientId: contactIdSchema.optional(),
 });
 type MatterCreateInput = z.infer<typeof matterCreateInput>;
 
@@ -162,7 +163,7 @@ export const matterRouter = router({
         search: z.string().optional(),
         status: z.enum(["ACTIVE", "CLOSED", "ARCHIVED"]).optional(),
         /** Filtrera till ärenden som medarbetaren har arbetat på (har tidsposter på). */
-        employeeId: z.string().optional(),
+        employeeId: userIdSchema.optional(),
         page: z.number().min(1).default(1),
         pageSize: z.number().min(1).max(500).default(20),
       })
@@ -181,7 +182,7 @@ export const matterRouter = router({
     }),
 
   getById: orgProcedure
-    .input(z.object({ id: z.string() }))
+    .input(z.object({ id: matterIdSchema }))
     .query(async ({ ctx, input }) => {
       const matter = await ctx.repos.matters.getByIdWithContacts(input.id, ctx.orgId);
       if (!matter) throw new TRPCError({ code: "NOT_FOUND", message: "Ärendet finns inte." });
@@ -209,13 +210,13 @@ export const matterRouter = router({
   update: orgProcedure
     .input(
       z.object({
-        id: z.string(),
+        id: matterIdSchema,
         title: z.string().min(1).optional(),
         description: z.string().optional(),
         status: z.enum(["ACTIVE", "CLOSED", "ARCHIVED"]).optional(),
         matterType: z.string().optional(),
         /** Byt ansvarig jurist (#174). Befintligt ärendenummer ändras EJ. */
-        responsibleLawyerId: z.string().nullable().optional(),
+        responsibleLawyerId: userIdSchema.nullable().optional(),
         /** Domstolens målnummer (#173) — för avprickning av domstolsbetalningar. */
         courtCaseNumber: z.string().nullable().optional(),
         paymentMethod: z
@@ -314,7 +315,7 @@ export const matterRouter = router({
     }),
 
   removeContact: orgProcedure
-    .input(z.object({ matterContactId: z.string() }))
+    .input(z.object({ matterContactId: matterContactIdSchema }))
     .mutation(async ({ ctx, input }) => {
       // Verifiera via matterContact→matter→org INNAN delete.
       const owned = await ctx.repos.matterContacts.getByIdInOrg(input.matterContactId, ctx.orgId);

--- a/src/lib/server/routers/organization.ts
+++ b/src/lib/server/routers/organization.ts
@@ -98,7 +98,7 @@ export const organizationRouter = router({
   updateOffice: protectedProcedure
     .input(
       z.object({
-        id: z.string(),
+        id: organizationIdSchema,
         name: z.string().min(1).optional(),
         address: z.string().optional(),
         phone: z.string().optional(),
@@ -116,7 +116,7 @@ export const organizationRouter = router({
     }),
 
   deleteOffice: protectedProcedure
-    .input(z.object({ id: z.string() }))
+    .input(z.object({ id: organizationIdSchema }))
     .mutation(async ({ ctx, input }) => {
       const office = await ctx.repos.offices.getByIdInOrg(input.id, ctx.user.organizationId);
       if (!office) throw new TRPCError({ code: "NOT_FOUND" });

--- a/src/lib/server/routers/paymentPlan.ts
+++ b/src/lib/server/routers/paymentPlan.ts
@@ -22,7 +22,7 @@ import {
   type PlanForScan,
 } from "@/lib/shared/payment-reminders";
 import { paymentPlanStatusSchema, reminderTypeSchema, type Invoice, type PaymentPlan } from "@/lib/shared/schemas";
-import { asId } from "@/lib/shared/schemas/ids";
+import { asId, paymentPlanIdSchema, paymentPlanReminderIdSchema } from "@/lib/shared/schemas/ids";
 import { emit } from "../events/emit";
 import type {
   JoinedPaymentPlan, JoinedPaymentPlanWithReminders,
@@ -96,7 +96,7 @@ export const paymentPlanRouter = router({
     }),
 
   getById: orgProcedure
-    .input(z.object({ id: z.string() }))
+    .input(z.object({ id: paymentPlanIdSchema }))
     .query(async ({ ctx, input }) => {
       const plan = await ctx.repos.paymentPlans.getByIdWithDetails(input.id, ctx.orgId);
       if (!plan) throw new TRPCError({ code: "NOT_FOUND", message: "Avbetalningsplan hittades inte" });
@@ -110,7 +110,7 @@ export const paymentPlanRouter = router({
    * vid sida tills UI:n migrerat helt hit; ändringar måste göras på båda.
    */
   cancel: protectedProcedure
-    .input(z.object({ planId: z.string() }))
+    .input(z.object({ planId: paymentPlanIdSchema }))
     .mutation(async ({ ctx, input }) => {
       return ctx.repos.transaction(async (tx) => {
         const plan = await tx.paymentPlans.getByIdInOrg(input.planId, ctx.user.organizationId);
@@ -132,8 +132,8 @@ export const paymentPlanRouter = router({
   recordReminder: orgProcedure
     .input(
       z.object({
-        id: z.string().optional(),
-        planId: z.string(),
+        id: paymentPlanReminderIdSchema.optional(),
+        planId: paymentPlanIdSchema,
         dueMonth: z.string().regex(/^\d{4}-\d{2}$/),
         type: reminderTypeSchema,
         sentAt: z.string().optional(),

--- a/src/lib/server/routers/reports.ts
+++ b/src/lib/server/routers/reports.ts
@@ -5,6 +5,7 @@ import {
   type BilledInvoiceInput,
   type FrozenWorkInput,
 } from "@/lib/shared/billed-per-lawyer";
+import { userIdSchema } from "@/lib/shared/schemas/ids";
 import { router, protectedProcedure } from "../trpc";
 
 /**
@@ -324,7 +325,7 @@ export const reportsRouter = router({
     .input(z.object({
       from: z.string(),
       to: z.string(),
-      userId: z.string(),
+      userId: userIdSchema,
     }))
     .query(async ({ ctx, input }) => {
       const fromDate = new Date(input.from);
@@ -368,7 +369,7 @@ export const reportsRouter = router({
     .input(z.object({
       from: z.string(),
       to: z.string(),
-      userId: z.string(),
+      userId: userIdSchema,
     }))
     .query(async ({ ctx, input }) => {
       const fromDate = new Date(input.from);
@@ -434,7 +435,7 @@ export const reportsRouter = router({
    * daterad sanning, inte en härledd updatedAt-gissning.
    */
   arSummary: protectedProcedure
-    .input(z.object({ from: z.string(), to: z.string(), userId: z.string().optional() }))
+    .input(z.object({ from: z.string(), to: z.string(), userId: userIdSchema.optional() }))
     .query(async ({ ctx, input }) => {
       const fromDate = new Date(input.from);
       const toDate = new Date(input.to);

--- a/src/lib/server/routers/timeEntry.ts
+++ b/src/lib/server/routers/timeEntry.ts
@@ -15,8 +15,8 @@ export const timeEntryRouter = router({
   list: protectedProcedure
     .input(
       z.object({
-        matterId: z.string().optional(),
-        userId: z.string().optional(),
+        matterId: matterIdSchema.optional(),
+        userId: userIdSchema.optional(),
         from: z.date().optional(),
         to: z.date().optional(),
         page: z.number().min(1).default(1),
@@ -77,7 +77,7 @@ export const timeEntryRouter = router({
   update: orgProcedure
     .input(
       z.object({
-        id: z.string(),
+        id: timeEntryIdSchema,
         date: z.string().optional(),
         minutes: z.number().min(1).optional(),
         description: z.string().min(1).optional(),
@@ -101,7 +101,7 @@ export const timeEntryRouter = router({
     }),
 
   delete: orgProcedure
-    .input(z.object({ id: z.string() }))
+    .input(z.object({ id: timeEntryIdSchema }))
     .mutation(async ({ ctx, input }) => {
       const owned = await ctx.repos.timeEntries.getByIdInOrg(input.id, ctx.orgId);
       if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
@@ -116,9 +116,9 @@ export const timeEntryRouter = router({
       z.object({
         from: z.string(),
         to: z.string(),
-        userId: z.string().optional(),
+        userId: userIdSchema.optional(),
         userIds: z.array(z.string()).optional(),
-        matterId: z.string().optional(),
+        matterId: matterIdSchema.optional(),
       })
     )
     // Migrerad till repository-sömmen (ADR 0020): listForReport (jurist + ärende

--- a/src/lib/server/routers/user.ts
+++ b/src/lib/server/routers/user.ts
@@ -79,7 +79,7 @@ export const userRouter = router({
     }),
 
   getById: protectedProcedure
-    .input(z.object({ id: z.string() }))
+    .input(z.object({ id: userIdSchema }))
     .query(async ({ ctx, input }) => {
       const u = await ctx.repos.users.getByIdInOrg(input.id, ctx.user.organizationId);
       if (!u) throw new TRPCError({ code: "NOT_FOUND" });
@@ -127,7 +127,7 @@ export const userRouter = router({
    */
   update: protectedProcedure
     .input(z.object({
-      id: z.string(),
+      id: userIdSchema,
       email: z.string().email().optional(),
       name: z.string().min(1).optional(),
       title: z.string().nullable().optional(),
@@ -161,7 +161,7 @@ export const userRouter = router({
    * så historik bevaras.
    */
   deactivate: protectedProcedure
-    .input(z.object({ id: z.string() }))
+    .input(z.object({ id: userIdSchema }))
     .mutation(async ({ ctx, input }) => {
       assertAdmin(ctx);
       if (input.id === ctx.user.id) {
@@ -174,7 +174,7 @@ export const userRouter = router({
 
   /** Hård-delete behållen för bakåtkompabilitet, men ADMIN-only. */
   delete: protectedProcedure
-    .input(z.object({ id: z.string() }))
+    .input(z.object({ id: userIdSchema }))
     .mutation(async ({ ctx, input }) => {
       assertAdmin(ctx);
       if (input.id === ctx.user.id) {


### PR DESCRIPTION
## What

Continues the strong-typing sweep started in #613. Replaces plain `z.string()` id-input fields with their branded `*IdSchema` across the remaining routers:

`billingRun` · `calendar` · `expense` · `invoice` · `expectedReceivable` · `documentTemplate` · `mail` · `matter` · `invoiceDispatch` · `reports` · `paymentPlan` · `organization` · `timeEntry` · `user` · `kostnadsrakning`

## Why

Branding is **type-only** (`brandedId` is runtime-identical to `z.string().min(1)`), so the demo's human-readable ids (`m-001-vardnad`, `current-user`, …) still parse unchanged. The win is purely at the type level: router inputs now carry the same branded id types the repositories already expect, closing a class of silent string/id mix-ups.

## Scope guard

External / non-entity ids left as plain strings on purpose: Microsoft Graph `outlookEventId` / `folderId` / `documentId` / `messageId`, `fortnoxId`, `mutationId`.

## Verification (local, CI mirrors)

- `bun run typecheck` — 0 errors (both root + test/tsconfig)
- `bun run lint` — 0 warnings
- `bun test --parallel test/unit/server/routers/` — 414 pass / 0 fail

Refs #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)