### PR TITLE
refactor(types): zod-parse the two raw-JSON boundaries (#27)

### DIFF
--- a/src/app/demo/_demo-client.tsx
+++ b/src/app/demo/_demo-client.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useEffect, useRef, useState } from "react";
+import { z } from "zod";
 import { loadBundledSeed } from "@/lib/client/demo/bundled-seed-loader";
 import { useDemoSeed } from "@/lib/client/demo/use-demo-seed";
 import type { DemoSource } from "@/lib/shared/demo-source";
@@ -41,9 +42,44 @@ export interface DemoClientProps {
   defaultRepo?: string;
 }
 
-interface MatterLike { id: string; matterNumber: string; title: string; status: string }
-interface ContactLike { id: string; name: string; contactType: string; email?: string | null }
-interface UserLike { id: string; email: string; name: string; role: string }
+// `DemoSource`-fälten är medvetet otypad JSON (`Record<string, unknown>`).
+// Vi zod-parsar varje rad vid konsumtions-gränsen (extern data → strikt
+// parsning) och härleder vy-typerna via `z.infer` i stället för handskrivna
+// interfaces. Okända fält strippas; en rad som inte matchar droppas (se
+// `narrowRows`) i stället för att krascha hela demon.
+const matterRowSchema = z.object({
+  id: z.string(),
+  matterNumber: z.string(),
+  title: z.string(),
+  status: z.string(),
+});
+const contactRowSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  contactType: z.string(),
+  email: z.string().nullish().transform((v) => v ?? null),
+});
+const userRowSchema = z.object({
+  id: z.string(),
+  email: z.string(),
+  name: z.string(),
+  role: z.string(),
+});
+
+type MatterLike = z.infer<typeof matterRowSchema>;
+type ContactLike = z.infer<typeof contactRowSchema>;
+type UserLike = z.infer<typeof userRowSchema>;
+
+/** Parsa varje rad; behåll bara de som matchar schemat (drop-on-mismatch). */
+function narrowRows<T>(
+  rows: readonly Record<string, unknown>[] | undefined,
+  schema: z.ZodType<T>,
+): readonly T[] {
+  return (rows ?? []).flatMap((row) => {
+    const parsed = schema.safeParse(row);
+    return parsed.success ? [parsed.data] : [];
+  });
+}
 
 export function DemoClient({
   loader = loadBundledSeed,
@@ -54,26 +90,10 @@ export function DemoClient({
   // Ref istället för state — vi vill inte trigga rerender när flaggan sätts.
   const autoLoadAttempted = useRef(false);
 
-  // `DemoSource`-fälten är medvetet otypad JSON (`Record<string, unknown>`) —
-  // narrowa varje fält till vy-typen vid konsumtions-gränsen.
-  const matters: readonly MatterLike[] = (source.matters ?? []).map((m) => ({
-    id: m.id as string,
-    matterNumber: m.matterNumber as string,
-    title: m.title as string,
-    status: m.status as string,
-  }));
-  const contacts: readonly ContactLike[] = (source.contacts ?? []).map((c) => ({
-    id: c.id as string,
-    name: c.name as string,
-    contactType: c.contactType as string,
-    email: (c.email ?? null) as string | null,
-  }));
-  const users: readonly UserLike[] = (source.users ?? []).map((u) => ({
-    id: u.id as string,
-    email: u.email as string,
-    name: u.name as string,
-    role: u.role as string,
-  }));
+  // Narrowa de otypade JSON-raderna till vy-typerna via zod (se schemana ovan).
+  const matters = narrowRows(source.matters, matterRowSchema);
+  const contacts = narrowRows(source.contacts, contactRowSchema);
+  const users = narrowRows(source.users, userRowSchema);
 
   async function handleLoad(): Promise<void> {
     if (!url.trim()) return;

--- a/src/lib/server/secrets/vault.ts
+++ b/src/lib/server/secrets/vault.ts
@@ -12,7 +12,16 @@
  *   - **fs injicerad** (`VaultFs`) → testbar utan riktig disk.
  */
 
+import { z } from "zod";
 import { decryptSecret, encryptSecret, loadMasterKey } from "./crypto";
+
+/**
+ * Valvets på-disk-form: en platt sträng→sträng-karta. Vi zod-parsar den
+ * efter dekryptering (extern data → strikt parsning) så en korrupt eller
+ * manipulerad blob ger ett tydligt fel istället för att tyst flöda vidare
+ * som en feltypad `Record`.
+ */
+const secretsMapSchema = z.record(z.string(), z.string());
 
 export interface SecretsVault {
   get(key: string): Promise<string | null>;
@@ -36,7 +45,7 @@ export class EncryptedFileVault implements SecretsVault {
   private async loadMap(): Promise<Record<string, string>> {
     const blob = await this.fs.read(this.filePath);
     if (!blob) return {};
-    return JSON.parse(decryptSecret(blob, this.key)) as Record<string, string>;
+    return secretsMapSchema.parse(JSON.parse(decryptSecret(blob, this.key)));
   }
 
   private async saveMap(map: Record<string, string>): Promise<void> {


### PR DESCRIPTION
## What

Strong-typing directive, **item 3**: replace untyped casts at the two remaining raw-JSON ingestion points with strict zod parsing.

### `src/lib/server/secrets/vault.ts`
The decrypted blob was `JSON.parse(...) as Record<string, string>`. Now parsed with `z.record(z.string(), z.string())` — a corrupt or tampered vault file fails loudly at the boundary instead of flowing on mistyped.

### `src/app/demo/_demo-client.tsx`
The `DemoSource` rows (deliberately `Record<string, unknown>`) were narrowed field-by-field with `as string`. Replaced with zod schemas whose view types are derived via `z.infer` (no more handwritten `MatterLike`/`ContactLike`/`UserLike` interfaces). A small `narrowRows` helper `safeParse`s each row and drops mismatches, so one malformed row can't crash the whole demo render.

## Why

> "använd zod maximalt vid parsning av extern data; z.infer i stället för handskrivna interfaces; strikta datatyper är mottot"

These were the last two spots reading external/untrusted JSON without schema validation.

## Verification (local, CI mirrors)

- `bun run typecheck` — 0 errors (both root + test/tsconfig)
- `bun run lint` — 0 warnings
- `bun test` vault + demo-client — 21 pass / 0 fail

Refs #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)