### PR TITLE
refactor(routers): swap `as Partial<X>` casts for `satisfies` (#27)

### DIFF
--- a/src/lib/server/routers/calendar.ts
+++ b/src/lib/server/routers/calendar.ts
@@ -161,7 +161,7 @@ export const calendarRouter = router({
         userId: input.userId ?? asId<"UserId">(ctx.user.id),
         organizationId: asId<"OrganizationId">(ctx.user.organizationId),
         mirrorStatus: input.mirrorToOutlook ? "pending" : null,
-      } as Partial<CalendarEvent>);
+      } satisfies Partial<CalendarEvent>);
     }),
 
   /** Alla events kopplade till ett specifikt ärende, kronologiskt. */
@@ -185,7 +185,7 @@ export const calendarRouter = router({
       );
       return ctx.repos.calendarEvents.update(id, {
         ...writeData, ...computeMirrorPatch(data, existing),
-      } as Partial<CalendarEvent>);
+      } satisfies Partial<CalendarEvent>);
     }),
 
   delete: protectedProcedure
@@ -219,6 +219,6 @@ export const calendarRouter = router({
       const owned = await ctx.repos.calendarEvents.getOwned(input.id, ctx.user.id, ctx.user.organizationId);
       if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
       const { id, ...data } = input;
-      return ctx.repos.calendarEvents.update(id, data as Partial<CalendarEvent>);
+      return ctx.repos.calendarEvents.update(id, data satisfies Partial<CalendarEvent>);
     }),
 });

--- a/src/lib/server/routers/contact.ts
+++ b/src/lib/server/routers/contact.ts
@@ -60,7 +60,7 @@ export const contactRouter = router({
         ...omitUndefined(input),
         email: input.email || null,
         organizationId: asId<"OrganizationId">(ctx.orgId),
-      } as Partial<Contact>);
+      } satisfies Partial<Contact>);
       await emit.contactCreated(ctx, contact);
       return contact;
     }),
@@ -90,7 +90,7 @@ export const contactRouter = router({
       const updated = await ctx.repos.contacts.update(id, {
         ...omitUndefined(data),
         email: input.email || null,
-      } as Partial<Contact>);
+      } satisfies Partial<Contact>);
       await emit.contactUpdated(ctx, id, data);
       return updated;
     }),
@@ -134,6 +134,6 @@ export const contactRouter = router({
         notes: input.notes,
         parentId: input.parentId,
         organizationId: asId<"OrganizationId">(ctx.orgId),
-      } as Partial<Contact>);
+      } satisfies Partial<Contact>);
     }),
 });

--- a/src/lib/server/routers/documentTemplate.ts
+++ b/src/lib/server/routers/documentTemplate.ts
@@ -48,7 +48,7 @@ export const documentTemplateRouter = router({
           createdById: input.createdById ?? asId<"UserId">(ctx.user.id),
         }),
         ...(input.createdAt ? { createdAt: new Date(input.createdAt) } : {}),
-      } as Partial<DocumentTemplate>);
+      } satisfies Partial<DocumentTemplate>);
     }),
 
   update: protectedProcedure
@@ -65,7 +65,7 @@ export const documentTemplateRouter = router({
       const existing = await ctx.repos.documentTemplates.getByIdInOrg(input.id, ctx.user.organizationId);
       if (!existing) throw new TRPCError({ code: "NOT_FOUND" });
       const { id, name, description, category, content } = input;
-      return ctx.repos.documentTemplates.update(id, omitUndefined({ name, description, category, content }) as Partial<DocumentTemplate>);
+      return ctx.repos.documentTemplates.update(id, omitUndefined({ name, description, category, content }) satisfies Partial<DocumentTemplate>);
     }),
 
   delete: protectedProcedure

--- a/src/lib/server/routers/expectedReceivable.ts
+++ b/src/lib/server/routers/expectedReceivable.ts
@@ -82,7 +82,7 @@ export const expectedReceivableRouter = router({
         recordedById: asId<"UserId">(ctx.user.id),
         createdAt: now,
         updatedAt: now,
-      } as Partial<ExpectedReceivable>);
+      } satisfies Partial<ExpectedReceivable>);
     }),
 
   /**
@@ -105,7 +105,7 @@ export const expectedReceivableRouter = router({
         settledAt: input.settledAt ? new Date(input.settledAt) : new Date(),
         ...(input.paymentReference !== undefined ? { paymentReference: input.paymentReference } : {}),
         updatedAt: new Date(),
-      } as Partial<ExpectedReceivable>);
+      } satisfies Partial<ExpectedReceivable>);
     }),
 
   /** Avbryt en fordran (t.ex. felregistrerad eller domstolen avslog helt). */
@@ -113,7 +113,7 @@ export const expectedReceivableRouter = router({
     .input(z.object({ id: expectedReceivableIdSchema }))
     .mutation(async ({ ctx, input }) => {
       await assertInOrg(ctx.repos, ctx.orgId, input.id);
-      return ctx.repos.expectedReceivables.update(input.id, { status: "CANCELLED", updatedAt: new Date() } as Partial<ExpectedReceivable>);
+      return ctx.repos.expectedReceivables.update(input.id, { status: "CANCELLED", updatedAt: new Date() } satisfies Partial<ExpectedReceivable>);
     }),
 
   /** Uppdatera memo-fälten (begärt belopp/beskrivning) medan PENDING. */
@@ -127,6 +127,6 @@ export const expectedReceivableRouter = router({
     .mutation(async ({ ctx, input }) => {
       await assertInOrg(ctx.repos, ctx.orgId, input.id);
       const { id, ...rest } = input;
-      return ctx.repos.expectedReceivables.update(id, { ...omitUndefined(rest), updatedAt: new Date() } as Partial<ExpectedReceivable>);
+      return ctx.repos.expectedReceivables.update(id, { ...omitUndefined(rest), updatedAt: new Date() } satisfies Partial<ExpectedReceivable>);
     }),
 });

--- a/src/lib/server/routers/expense.ts
+++ b/src/lib/server/routers/expense.ts
@@ -66,7 +66,7 @@ export const expenseRouter = router({
         vatIncluded: input.vatIncluded,
         invoiceId: input.invoiceId ?? null,
         ...(input.createdAt ? { createdAt: new Date(input.createdAt) } : {}),
-      }) as Partial<Expense>);
+      }) satisfies Partial<Expense>);
     }),
 
   update: orgProcedure
@@ -94,7 +94,7 @@ export const expenseRouter = router({
         vatRate,
         vatIncluded,
         ...(date ? { date: new Date(date) } : {}),
-      }) as Partial<Expense>);
+      }) satisfies Partial<Expense>);
     }),
 
   delete: orgProcedure

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -80,7 +80,7 @@ async function linkBilledItems(
   await repos.timeEntries.flagBilled(timeEntries.map((t) => t.id), invoiceId);
   await repos.expenses.flagBilled(expenses.map((e) => e.id), invoiceId);
   for (const a of accontos) {
-    await repos.accontoDeductions.create({ finalInvoiceId: invoiceId, accontoInvoiceId: a.id } as Partial<AccontoDeduction>);
+    await repos.accontoDeductions.create({ finalInvoiceId: invoiceId, accontoInvoiceId: a.id } satisfies Partial<AccontoDeduction>);
   }
 }
 
@@ -199,7 +199,7 @@ export const invoiceRouter = router({
           invoiceDate: input.invoiceDate ? new Date(input.invoiceDate) : new Date(),
           dueDate: input.dueDate ? new Date(input.dueDate) : null,
           notes: input.notes,
-        }) as Partial<Invoice>,
+        }) satisfies Partial<Invoice>,
       );
       await emit.invoiceCreated(ctx, invoice);
       return invoice;
@@ -236,8 +236,8 @@ export const invoiceRouter = router({
           invoiceDate: new Date(),
           dueDate: null,
           notes: "Rådgivningstimme enligt rättshjälpstaxan (1 tim).",
-        } as Partial<Invoice>);
-        await repos.matters.update(input.matterId, { radgivningBetaldAt: new Date() } as Partial<Matter>);
+        } satisfies Partial<Invoice>);
+        await repos.matters.update(input.matterId, { radgivningBetaldAt: new Date() } satisfies Partial<Matter>);
         await emit.invoiceCreated(ctx, invoice);
         return { invoice, beloppExclVatOre: avgift.beloppExclVatOre };
       }),
@@ -291,7 +291,7 @@ export const invoiceRouter = router({
           invoiceDate: input.invoiceDate ? new Date(input.invoiceDate) : new Date(),
           dueDate: input.dueDate ? new Date(input.dueDate) : null,
           notes: input.notes,
-        }) as Partial<Invoice>);
+        }) satisfies Partial<Invoice>);
 
         await linkBilledItems(repos, invoice.id as InvoiceId, timeEntries, expenses, accontos);
         return { invoice, breakdown };
@@ -356,7 +356,7 @@ export const invoiceRouter = router({
           status: "SENT", // kreditfaktura är "färdig" direkt
           invoiceDate: new Date(),
           creditedInvoiceId: original.id,
-        }) as Partial<Invoice>);
+        }) satisfies Partial<Invoice>);
 
         await repos.invoices.update(original.id, { status: "CANCELLED" });
         return credit;
@@ -411,7 +411,7 @@ export const invoiceRouter = router({
           note: input.note,
           reference: input.reference,
           recordedById: asId<"UserId">(ctx.user.id),
-        }) as Partial<Payment>);
+        }) satisfies Partial<Payment>);
 
         // `paid` = betalt FÖRE denna betalning (sumByInvoice) → + input.amount.
         const paidSum = paid + input.amount;
@@ -475,7 +475,7 @@ export const invoiceRouter = router({
           startDate: new Date(input.startDate),
           // Explicit (Prisma schema-default appliceras inte av in-memory-store:n).
           status: "ACTIVE",
-        }) as Partial<PaymentPlan>);
+        }) satisfies Partial<PaymentPlan>);
         await repos.invoices.update(inv.id, { status: "INSTALLMENT_PLAN" });
         return plan;
       }),
@@ -530,7 +530,7 @@ export const invoiceRouter = router({
           writtenOffAt: input.writtenOffAt ? new Date(input.writtenOffAt) : new Date(),
           reason: input.reason,
           recordedById: asId<"UserId">(ctx.user.id),
-        }) as Partial<WriteOff>);
+        }) satisfies Partial<WriteOff>);
 
         // Härled status efter avskrivningen och persistera om återstoden stängdes.
         const after = computeInvoiceLedger(inv.amount, paid, credited, writtenOff + amount);

--- a/src/lib/server/routers/invoiceDispatch.ts
+++ b/src/lib/server/routers/invoiceDispatch.ts
@@ -73,7 +73,7 @@ export const invoiceDispatchRouter = router({
         queuedAt: now,
         recordedById: asId<"UserId">(ctx.user.id),
         createdAt: now,
-      } as Partial<InvoiceDispatch>);
+      } satisfies Partial<InvoiceDispatch>);
       // Köad för automatiskt utskick → fakturan är inte längre ett utkast (#392).
       await markSentIfDraft(ctx, inv);
       return dispatch;
@@ -105,7 +105,7 @@ export const invoiceDispatchRouter = router({
         sentAt: now,
         recordedById: asId<"UserId">(ctx.user.id),
         createdAt: now,
-      } as Partial<InvoiceDispatch>);
+      } satisfies Partial<InvoiceDispatch>);
       // Manuellt skickad → fakturan är inte längre ett utkast (#392).
       await markSentIfDraft(ctx, inv);
       return dispatch;
@@ -129,6 +129,6 @@ export const invoiceDispatchRouter = router({
         ...(tsField ? { [tsField]: new Date() } : {}),
         ...(input.messageId !== undefined ? { messageId: input.messageId } : {}),
         ...(input.error !== undefined ? { error: input.error } : {}),
-      } as Partial<InvoiceDispatch>);
+      } satisfies Partial<InvoiceDispatch>);
     }),
 });

--- a/src/lib/server/routers/matter.ts
+++ b/src/lib/server/routers/matter.ts
@@ -153,7 +153,7 @@ function buildMatterData(
 async function linkKlient(ctx: MatterCtx, matterId: MatterId, klientId: ContactId): Promise<void> {
   const contact = await ctx.repos.contacts.getByIdFull(klientId, ctx.orgId);
   if (!contact) throw new TRPCError({ code: "NOT_FOUND" });
-  await ctx.repos.matterContacts.create({ matterId, contactId: klientId, role: "KLIENT" } as Partial<MatterContact>);
+  await ctx.repos.matterContacts.create({ matterId, contactId: klientId, role: "KLIENT" } satisfies Partial<MatterContact>);
 }
 
 export const matterRouter = router({
@@ -196,7 +196,7 @@ export const matterRouter = router({
       const responsibleLawyerId = input.responsibleLawyerId ?? ctx.user.id;
       const matterNumber = input.matterNumber ?? (await nextMatterNumber(ctx, responsibleLawyerId));
       const matter = await ctx.repos.matters.create(
-        buildMatterData(ctx.orgId, matterNumber, responsibleLawyerId, input) as Partial<Matter>,
+        buildMatterData(ctx.orgId, matterNumber, responsibleLawyerId, input) satisfies Partial<Matter>,
       );
       await emit.matterCreated(ctx, matter);
       // matter.id washar till `any` via Joined<>; brand explicit. klientId
@@ -243,7 +243,7 @@ export const matterRouter = router({
       if (taxaHufStart !== undefined) {
         data.taxaHufStart = taxaHufStart ? new Date(taxaHufStart) : null;
       }
-      const updated = await ctx.repos.matters.update(id, data as Partial<Matter>);
+      const updated = await ctx.repos.matters.update(id, data satisfies Partial<Matter>);
       await emit.matterUpdated(ctx, id, data);
       if (input.status && input.status !== before.status) {
         await emit.matterStatusChanged(ctx, id, before.status, input.status);
@@ -275,7 +275,7 @@ export const matterRouter = router({
         id,
         notes,
         ...(createdAt ? { createdAt: new Date(createdAt) } : {}),
-      }) as Partial<MatterContact>);
+      }) satisfies Partial<MatterContact>);
     }),
 
   // Create a new contact and link it to the matter in one step
@@ -310,7 +310,7 @@ export const matterRouter = router({
       }
 
       return ctx.repos.matterContacts.linkContact(
-        { matterId, contactId: contact.id, role, notes } as Partial<MatterContact>,
+        { matterId, contactId: asId<"ContactId">(contact.id), role, notes } satisfies Partial<MatterContact>,
       );
     }),
 

--- a/src/lib/server/routers/organization.ts
+++ b/src/lib/server/routers/organization.ts
@@ -45,7 +45,7 @@ export const organizationRouter = router({
       })
     )
     .mutation(({ ctx, input }) =>
-      ctx.repos.organizations.update(ctx.user.organizationId, omitUndefined(input) as Partial<Organization>),
+      ctx.repos.organizations.update(ctx.user.organizationId, omitUndefined(input) satisfies Partial<Organization>),
     ),
 
   /**
@@ -67,7 +67,7 @@ export const organizationRouter = router({
       })
     )
     .mutation(({ ctx, input }) =>
-      ctx.repos.organizations.create(input as Partial<Organization>),
+      ctx.repos.organizations.create(input satisfies Partial<Organization>),
     ),
 
   // ── Offices ─────────────────────────────────────────────────────
@@ -92,7 +92,7 @@ export const organizationRouter = router({
       return ctx.repos.offices.create({
         ...input,
         organizationId: asId<"OrganizationId">(ctx.user.organizationId),
-      } as Partial<Office>);
+      } satisfies Partial<Office>);
     }),
 
   updateOffice: protectedProcedure
@@ -112,7 +112,7 @@ export const organizationRouter = router({
       if (!office) throw new TRPCError({ code: "NOT_FOUND" });
       // If setting as main, demote others first
       if (data.isMain) await ctx.repos.offices.demoteMains(ctx.user.organizationId);
-      return ctx.repos.offices.update(id, omitUndefined(data) as Partial<Office>);
+      return ctx.repos.offices.update(id, omitUndefined(data) satisfies Partial<Office>);
     }),
 
   deleteOffice: protectedProcedure

--- a/src/lib/server/routers/paymentPlan.ts
+++ b/src/lib/server/routers/paymentPlan.ts
@@ -118,8 +118,8 @@ export const paymentPlanRouter = router({
         if (plan.status !== "ACTIVE") {
           throw new TRPCError({ code: "BAD_REQUEST", message: "Endast aktiva planer kan avbrytas" });
         }
-        await tx.paymentPlans.update(plan.id, { status: "CANCELLED" } as Partial<PaymentPlan>);
-        await tx.invoices.update(plan.invoiceId, { status: "SENT" } as Partial<Invoice>);
+        await tx.paymentPlans.update(plan.id, { status: "CANCELLED" } satisfies Partial<PaymentPlan>);
+        await tx.invoices.update(plan.invoiceId, { status: "SENT" } satisfies Partial<Invoice>);
         return { ok: true };
       });
     }),

--- a/src/lib/server/routers/preference.ts
+++ b/src/lib/server/routers/preference.ts
@@ -10,6 +10,7 @@
 
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import { asId } from "@/lib/shared/schemas/ids";
 import type { OrgPreferenceRow } from "../repositories/org-preference-repository";
 import type { UserPreferenceRow } from "../repositories/user-preference-repository";
 import { router, orgProcedure, protectedProcedure } from "../trpc";
@@ -37,11 +38,13 @@ export const preferenceRouter = router({
     .mutation(async ({ ctx, input }) => {
       const existing = await ctx.repos.userPreferences.getByUserKey(ctx.user.id, ctx.user.organizationId, input.key);
       if (existing) {
-        return ctx.repos.userPreferences.update(existing.id, { prefs: input.prefs } as Partial<UserPreferenceRow>);
+        return ctx.repos.userPreferences.update(existing.id, { prefs: input.prefs } satisfies Partial<UserPreferenceRow>);
       }
       return ctx.repos.userPreferences.create({
-        userId: ctx.user.id, organizationId: ctx.user.organizationId, key: input.key, prefs: input.prefs,
-      } as Partial<UserPreferenceRow>);
+        userId: asId<"UserId">(ctx.user.id),
+        organizationId: asId<"OrganizationId">(ctx.user.organizationId),
+        key: input.key, prefs: input.prefs,
+      } satisfies Partial<UserPreferenceRow>);
     }),
 
   /** Återställ user-pref (faller tillbaka till org/komponent-default). */
@@ -61,11 +64,12 @@ export const preferenceRouter = router({
       requireAdmin(ctx.user.role);
       const existing = await ctx.repos.orgPreferences.getByOrgKey(ctx.user.organizationId, input.key);
       if (existing) {
-        return ctx.repos.orgPreferences.update(existing.id, { prefs: input.prefs, createdById: ctx.user.id } as Partial<OrgPreferenceRow>);
+        return ctx.repos.orgPreferences.update(existing.id, { prefs: input.prefs, createdById: asId<"UserId">(ctx.user.id) } satisfies Partial<OrgPreferenceRow>);
       }
       return ctx.repos.orgPreferences.create({
-        organizationId: ctx.user.organizationId, key: input.key, prefs: input.prefs, createdById: ctx.user.id,
-      } as Partial<OrgPreferenceRow>);
+        organizationId: asId<"OrganizationId">(ctx.user.organizationId),
+        key: input.key, prefs: input.prefs, createdById: asId<"UserId">(ctx.user.id),
+      } satisfies Partial<OrgPreferenceRow>);
     }),
 
   /** Rensa org-default (endast ADMIN). */

--- a/src/lib/server/routers/serviceNote.ts
+++ b/src/lib/server/routers/serviceNote.ts
@@ -46,7 +46,7 @@ export const serviceNoteRouter = router({
         time: input.time,
         text: input.text,
         ...(input.createdAt ? { createdAt: new Date(input.createdAt) } : {}),
-      }) as Partial<ServiceNote>);
+      }) satisfies Partial<ServiceNote>);
     }),
 
   update: orgProcedure
@@ -64,7 +64,7 @@ export const serviceNoteRouter = router({
       const owned = await ctx.repos.serviceNotes.getByIdInOrg(input.id, ctx.orgId);
       if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
       const { id, date, time, text } = input;
-      return ctx.repos.serviceNotes.update(id, omitUndefined({ date, time, text }) as Partial<ServiceNote>);
+      return ctx.repos.serviceNotes.update(id, omitUndefined({ date, time, text }) satisfies Partial<ServiceNote>);
     }),
 
   delete: orgProcedure

--- a/src/lib/server/routers/task.ts
+++ b/src/lib/server/routers/task.ts
@@ -59,7 +59,7 @@ export const taskRouter = router({
         organizationId: asId<"OrganizationId">(ctx.user.organizationId),
         ...omitUndefined({ id }),
         ...(createdAt != null ? { createdAt } : {}),
-      } as Partial<Task>);
+      } satisfies Partial<Task>);
     }),
 
   update: protectedProcedure
@@ -73,7 +73,7 @@ export const taskRouter = router({
       const patch: Record<string, unknown> = { ...data };
       if (data.status === "DONE") patch.completedAt = new Date();
       if (data.status && data.status !== "DONE") patch.completedAt = null;
-      return ctx.repos.tasks.update(id, patch as Partial<Task>);
+      return ctx.repos.tasks.update(id, patch satisfies Partial<Task>);
     }),
 
   complete: protectedProcedure
@@ -81,7 +81,7 @@ export const taskRouter = router({
     .mutation(async ({ ctx, input }) => {
       const owned = await ctx.repos.tasks.getOwned(input.id, ctx.user.id, ctx.user.organizationId);
       if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
-      return ctx.repos.tasks.update(input.id, { status: "DONE", completedAt: new Date() } as Partial<Task>);
+      return ctx.repos.tasks.update(input.id, { status: "DONE", completedAt: new Date() } satisfies Partial<Task>);
     }),
 
   delete: protectedProcedure

--- a/src/lib/server/routers/timeEntry.ts
+++ b/src/lib/server/routers/timeEntry.ts
@@ -69,7 +69,7 @@ export const timeEntryRouter = router({
         billable: input.billable,
         invoiceId: input.invoiceId ?? null,
         ...(input.createdAt ? { createdAt: new Date(input.createdAt) } : {}),
-      }) as Partial<TimeEntry>);
+      }) satisfies Partial<TimeEntry>);
       await emit.timeEntryAdded(ctx, { id: entry.id, matterId: entry.matterId, minutes: entry.minutes });
       return entry;
     }),
@@ -95,7 +95,7 @@ export const timeEntryRouter = router({
         description,
         billable,
         ...(date ? { date: new Date(date) } : {}),
-      }) as Partial<TimeEntry>);
+      }) satisfies Partial<TimeEntry>);
       await emit.timeEntryUpdated(ctx, { id: updated.id, matterId: updated.matterId });
       return updated;
     }),

--- a/src/lib/server/routers/user.ts
+++ b/src/lib/server/routers/user.ts
@@ -117,7 +117,7 @@ export const userRouter = router({
         ...(input.matterNumberPrefix ? { matterNumberPrefix: input.matterNumberPrefix } : {}),
         passwordHash,
         organizationId: asId<"OrganizationId">(ctx.user.organizationId),
-      } as Partial<User>);
+      } satisfies Partial<User>);
     }),
 
   /**
@@ -153,7 +153,7 @@ export const userRouter = router({
       if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
       const updateData: Record<string, unknown> = { ...data };
       if (password) updateData.passwordHash = await hashPassword(password);
-      return ctx.repos.users.update(id, updateData as Partial<User>);
+      return ctx.repos.users.update(id, updateData satisfies Partial<User>);
     }),
 
   /**


### PR DESCRIPTION
## What

Strong-typing directive, **item 2**. Every router `create`/`update` call wrapped its data object in `as Partial<Entity>`, force-casting past the type checker. Since the repository `create`/`update` methods already accept `Partial<Row>`, the cast was only hiding whether the object was actually well-typed.

Replaced all ~53 router `as Partial<X>` casts with `satisfies Partial<X>`.

## Result

- **47** compiled unchanged — they were needless casts over already-correct objects (the branded-id sweep in #613/#614 made most inputs line up).
- **6** surfaced genuine gaps where a raw `string` (`ctx.user.id`, `ctx.user.organizationId`, `contact.id`) flowed into a branded id field. Fixed at the **source** with `asId<…>`:
  - `preference.ts` — brand `userId` / `organizationId` / `createdById` in the user-/org-preference upserts.
  - `matter.ts` — brand `contactId` in `linkContact`.

`satisfies` keeps the narrow inferred type while enforcing assignability, so future drift is caught at the call site instead of being silently cast away.

## Verification (local, CI mirrors)

- `bun run typecheck` — 0 errors (both root + test/tsconfig)
- `bun run lint` — 0 warnings
- `bun test --parallel test/unit/server/routers/` — 414 pass / 0 fail

Refs #27. Completes the strong-typing sweep (items 1–3) from the architecture review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)