### PR TITLE
test(matters): cover BillingPanel + bump FUNC floor 85.6→85.8 (#27)

### DIFF
--- a/test/unit/app/matters/billing-panel.test.tsx
+++ b/test/unit/app/matters/billing-panel.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * Tester för `BillingPanel` (#27) — översikts-/action-panelen per ärende.
+ *
+ * Täcker de rena hjälparna (computeTotals, optionsFor, findPendingVerdict,
+ * clientOf/courtOf) via render + de villkorade vyerna: summa-kort, runs-lista,
+ * pending-verdict-banner, rådgivnings-banner (rättshjälp) och "+ Skapa
+ * faktura"-menyn vars alternativ beror på matter:s paymentMethod. Barn-
+ * dialogerna stubbas (de har egna tester) så panelens egen logik isoleras.
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { BillingPanel } from "@/app/matters/[id]/_billing-panel";
+
+interface BillingRunRow {
+  id: string; type: string; status: string; recipient: string;
+  amountOre: number; createdAt: string | Date;
+  invoiceId?: string | null; invoice?: { id: string; invoiceNumber?: string | null } | null;
+}
+
+let runsData: { runs: BillingRunRow[] } = { runs: [] };
+let runsLoading = false;
+const refetch = vi.fn();
+const radgivningMutate = vi.fn();
+const krMutate = vi.fn();
+let documentListData: { documents: Array<Record<string, unknown>> } = { documents: [] };
+let hasDoc = false;
+const openGeneratedDocFn = vi.fn();
+
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: {
+    billingRun: {
+      list: { useQuery: () => ({ data: runsData, isLoading: runsLoading, refetch }) },
+      createKostnadsrakning: { useMutation: () => ({ mutate: krMutate, isPending: false }) },
+    },
+    organization: {
+      getSettings: { useQuery: () => ({ data: { name: "Byrå AB", orgNumber: "556677-8899", address: "Storgatan 1" } }) },
+    },
+    user: { current: { useQuery: () => ({ data: { name: "Adv. Anna", email: "anna@byra.se" } }) } },
+    expense: { list: { useQuery: () => ({ data: { expenses: [] } }) } },
+    document: { list: { useQuery: () => ({ data: documentListData }) } },
+    invoice: {
+      createRadgivning: {
+        useMutation: (opts?: { onSuccess?: () => void }) => {
+          void opts;
+          return { mutate: radgivningMutate, isPending: false };
+        },
+      },
+    },
+  },
+}));
+
+vi.mock("@/lib/client/diagnostics/use-matter-invariants", () => ({ useMatterInvariants: vi.fn() }));
+vi.mock("@/lib/client/demo/entity-link", () => ({
+  EntityLink: ({ children }: { children: React.ReactNode }) => <a href="#">{children}</a>,
+}));
+vi.mock("@/lib/client/demo/generated-doc-cache", () => ({
+  hasGeneratedDoc: () => hasDoc,
+  openGeneratedDoc: (id: string) => openGeneratedDocFn(id),
+}));
+vi.mock("@/app/matters/[id]/_billing-dialog", () => ({
+  BillingDialog: ({ type }: { type: string }) => <div data-testid="billing-dialog">{type}</div>,
+}));
+vi.mock("@/app/matters/[id]/_verdict-dialog", () => ({
+  VerdictDialog: () => <div data-testid="verdict-dialog" />,
+}));
+vi.mock("@/app/matters/[id]/_kostnadsrakning-modal", () => ({
+  KostnadsrakningModal: () => <div data-testid="kr-modal" />,
+}));
+
+const baseMatter = {
+  matterNumber: "2026-0001",
+  title: "Tvist mot motpart",
+  contacts: [
+    { role: "KLIENT", contact: { name: "Anna Andersson", email: "anna@klient.se" } },
+    { role: "DOMSTOL", contact: { name: "Stockholms tingsrätt" } },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  runsData = { runs: [] };
+  runsLoading = false;
+  documentListData = { documents: [] };
+  hasDoc = false;
+});
+
+describe("BillingPanel — översikt", () => {
+  it("renderar rubrik och tomtext utan runs", () => {
+    render(<BillingPanel matterId="m1" matter={baseMatter} />);
+    expect(screen.getByText("Fakturering")).toBeInTheDocument();
+    expect(screen.getByText("Inga billing-runs ännu.")).toBeInTheDocument();
+  });
+
+  it("visar laddtext medan runs hämtas", () => {
+    runsLoading = true;
+    render(<BillingPanel matterId="m1" matter={baseMatter} />);
+    expect(screen.getByText("Laddar…")).toBeInTheDocument();
+  });
+
+  it("summerar acconto/fakturerat/väntar-på-dom korrekt (computeTotals)", () => {
+    runsData = {
+      runs: [
+        { id: "r1", type: "ACCONTO", status: "SENT", recipient: "KLIENT", amountOre: 100_000, createdAt: "2026-01-01", invoiceId: "inv-1", invoice: { id: "inv-1", invoiceNumber: "F-1" } },
+        { id: "r2", type: "FINAL", status: "SENT", recipient: "KLIENT", amountOre: 250_000, createdAt: "2026-02-01" },
+        { id: "r3", type: "KOSTNADSRAKNING", status: "PENDING_VERDICT", recipient: "DOMSTOL", amountOre: 50_000, createdAt: "2026-03-01" },
+      ],
+    };
+    render(<BillingPanel matterId="m1" matter={baseMatter} />);
+    // Aconto = 1000 kr, Fakturerat = 2500 kr, Väntar = 500 kr. Varje belopp
+    // syns två gånger (summa-kort + run-rad); Intl använder no-break-space
+    // → matcha tolerant via regex + getAllByText.
+    expect(screen.getAllByText(/1\s*000,00/).length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText(/2\s*500,00/).length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText("Aconto fakturerat")).toBeInTheDocument();
+    // Faktura-länk för run med invoiceId (EntityLink-stub)
+    expect(screen.getByText("F-1")).toBeInTheDocument();
+  });
+});
+
+describe("BillingPanel — pending verdict", () => {
+  beforeEach(() => {
+    runsData = {
+      runs: [
+        { id: "r3", type: "KOSTNADSRAKNING", status: "PENDING_VERDICT", recipient: "DOMSTOL", amountOre: 50_000, createdAt: "2026-03-01" },
+      ],
+    };
+  });
+
+  it("visar banner och öppnar verdict-dialogen", () => {
+    render(<BillingPanel matterId="m1" matter={baseMatter} />);
+    expect(screen.getByText(/Kostnadsräkning väntar på dom/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Ange dom \+ prutning/ }));
+    expect(screen.getByTestId("verdict-dialog")).toBeInTheDocument();
+  });
+
+  it("öppnar KR-dokumentet ur blob-cachen när det finns", () => {
+    documentListData = { documents: [{ id: "doc-1", fileName: "kostnadsrakning.docx", documentType: "Kostnadsräkning", createdAt: "2026-03-01" }] };
+    hasDoc = true;
+    render(<BillingPanel matterId="m1" matter={baseMatter} />);
+    fireEvent.click(screen.getByRole("button", { name: "kostnadsrakning.docx" }));
+    expect(openGeneratedDocFn).toHaveBeenCalledWith("doc-1");
+  });
+
+  it("varnar när KR-dokumentet inte längre är i minnet", () => {
+    documentListData = { documents: [{ id: "doc-1", fileName: "kostnadsrakning.docx", documentType: "Kostnadsräkning", createdAt: "2026-03-01" }] };
+    hasDoc = false;
+    const alertSpy = vi.spyOn(globalThis, "alert").mockImplementation(() => {});
+    render(<BillingPanel matterId="m1" matter={baseMatter} />);
+    fireEvent.click(screen.getByRole("button", { name: "kostnadsrakning.docx" }));
+    expect(alertSpy).toHaveBeenCalled();
+    alertSpy.mockRestore();
+  });
+});
+
+describe("BillingPanel — Skapa-faktura-menyn (optionsFor)", () => {
+  it("KLIENT-default: bara 'Faktura till klient' → öppnar FINAL-dialogen", () => {
+    render(<BillingPanel matterId="m1" matter={{ ...baseMatter, paymentMethod: "KLIENT" }} />);
+    fireEvent.click(screen.getByRole("button", { name: "+ Skapa faktura" }));
+    fireEvent.click(screen.getByRole("button", { name: "Faktura till klient" }));
+    expect(screen.getByTestId("billing-dialog")).toHaveTextContent("FINAL");
+  });
+
+  it("RATTSSKYDD: aconto + faktura till försäkring", () => {
+    render(<BillingPanel matterId="m1" matter={{ ...baseMatter, paymentMethod: "RATTSSKYDD" }} />);
+    fireEvent.click(screen.getByRole("button", { name: "+ Skapa faktura" }));
+    expect(screen.getByRole("button", { name: "Aconto till klient" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Faktura till försäkring" })).toBeInTheDocument();
+  });
+
+  it("OFFENTLIG_FORSVARARE: kostnadsräkning → öppnar KR-modalen", () => {
+    render(<BillingPanel matterId="m1" matter={{ ...baseMatter, paymentMethod: "OFFENTLIG_FORSVARARE" }} />);
+    fireEvent.click(screen.getByRole("button", { name: "+ Skapa faktura" }));
+    fireEvent.click(screen.getByRole("button", { name: "Kostnadsräkning till domstol" }));
+    expect(screen.getByTestId("kr-modal")).toBeInTheDocument();
+  });
+});
+
+describe("BillingPanel — rådgivnings-banner (rättshjälp)", () => {
+  it("RATTSHJALP utan registrerad rådgivning → knappen registrerar", () => {
+    render(<BillingPanel matterId="m1" matter={{ ...baseMatter, paymentMethod: "RATTSHJALP" }} />);
+    expect(screen.getByText(/Rådgivningstimme \(rättshjälp\)/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Registrera betald" }));
+    expect(radgivningMutate).toHaveBeenCalledWith(expect.objectContaining({ matterId: "m1" }));
+  });
+
+  it("RATTSHJALP med registrerad rådgivning → visar bock", () => {
+    render(<BillingPanel matterId="m1" matter={{ ...baseMatter, paymentMethod: "RATTSHJALP", radgivningBetaldAt: "2026-01-05" }} />);
+    expect(screen.getByText(/Registrerad/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Registrera betald" })).not.toBeInTheDocument();
+  });
+
+  it("icke-rättshjälp → ingen rådgivnings-banner", () => {
+    render(<BillingPanel matterId="m1" matter={{ ...baseMatter, paymentMethod: "KLIENT" }} />);
+    expect(screen.queryByText(/Rådgivningstimme/)).not.toBeInTheDocument();
+  });
+});

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -117,9 +117,16 @@ const FAST = process.argv.includes("--fast");
 // funktioner (#27: CalendarPage lista-vy + Nytt event/Ny task-formulär + rad-
 // åtgärder → lokalt 92.34% rader / 87.21% funktioner. Rad-täckningen har stigit
 // stadigt över ~14 steg (90.86 → 92.34) → LINE-golvet dras ÄNTLIGEN upp 89.5 →
-// 90.0 (~2.34% marginal, fortsatt generös Node-buffert). FUNC 85.5 → 85.6).
+// 90.0 (~2.34% marginal, fortsatt generös Node-buffert). FUNC 85.5 → 85.6) →
+// 90.0 rader / 85.8 funktioner (#27: BillingPanel render-test — summa-kort/
+// computeTotals, runs-lista, pending-verdict-banner + KR-dok-öppning,
+// rådgivnings-banner (rättshjälp) och optionsFor-menyn per paymentMethod →
+// _billing-panel.tsx (tidigare otestad) → lokalt 92.80% rader / 87.50%
+// funktioner. FUNC dras upp 85.6 → 85.8 (~1.70% marginal; funktions-täckning
+// är Node-version-stabil). LINE oförändrat — dess marginal är en avsiktlig
+// Node-version-buffert + lcov-line-brus).
 const LINE_FLOOR = 0.900;
-const FUNC_FLOOR = 0.856;
+const FUNC_FLOOR = 0.858;
 
 /**
  * SERIAL_FILES — testfiler som SYNKRONT spawnar en barnprocess via


### PR DESCRIPTION
## What

`src/app/matters/[id]/_billing-panel.tsx` (410 lines) had **no test**. Adds a focused render test that exercises the panel's own logic with the three child dialogs stubbed (they have their own tests):

- **`computeTotals`** → summary cards (acconto / fakturerat / väntar på dom)
- **runs list** → rows, invoice `EntityLink`, loading + empty states
- **pending-verdict banner** → opens the verdict dialog; opens the KR document from the blob cache (`hasGeneratedDoc`) with the alert fallback
- **rådgivnings-banner** (rättshjälp) → register flow, ✓ state, and gating for non-rättshjälp
- **"+ Skapa faktura" menu** (`optionsFor`) per `paymentMethod`: `KLIENT` / `RATTSSKYDD` / `OFFENTLIG_FORSVARARE` → correct dialog/modal opens

## Coverage / ratchet

Local: **92.80% lines / 87.50% functions** (from 92.41% / 87.26%).

`FUNC_FLOOR` 85.6 → **85.8** (~1.70% margin; function coverage is Node-version-stable). `LINE_FLOOR` unchanged — its margin is a deliberate Node-version + lcov-line-noise buffer. Comment trail in `run-tests.ts` extended in the established style.

## Verification (local, CI mirrors)

- `bun run test:cov` — gate green: lines 92.79% (floor 90.00%), functions 87.50% (floor 85.80%)
- `bun run typecheck` — 0 errors (both configs)
- `bun run lint` — 0 warnings
- new test: 12 pass / 0 fail

Refs #27 (ratchet-step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)