### PR TITLE
feat(documents): låt llm föreslå taggar ur org-vokabulären (#621 B2)

### DIFF
--- a/src/bin/server-first.ts
+++ b/src/bin/server-first.ts
@@ -88,6 +88,8 @@ function main(): void {
     // läses bytes → text extraheras (PDF/DOCX) → ollama klassificerar.
     ...(contentStore ? { content: contentStore } : {}),
     ...(llm ? { llm } : {}),
+    // #621 B2: LLM föreslår taggar ur byråns vokabulär (läses lazy per jobb).
+    vocabulary: async () => (await api.repos.organizations.getById(config.organizationId))?.documentTags ?? [],
   });
   void startJobRuntime({ connectionString: config.databaseUrl, handlers })
     .then((rt) => { jobRuntime = rt; log(`jobb-kö startad (pg-boss; ${Object.keys(handlers).length} handlers)`); })

--- a/src/lib/server/jobs/handlers/classify-document-handler.ts
+++ b/src/lib/server/jobs/handlers/classify-document-handler.ts
@@ -34,6 +34,12 @@ export interface ClassifyDocumentDeps {
   documents: Pick<DocumentRepository, "getById" | "updateMetadata">;
   /** Klassificerare; default = filnamns-heuristik. Fas 3 injicerar LLM-varianten. */
   classify?: (doc: ClassifiableDoc) => Promise<DocumentKind>;
+  /**
+   * Föreslå etiketter ur byråns vokabulär (#621 B2, LLM-väg). Returnerar en
+   * delmängd av vokabulären; slås ihop (union) med dokumentets befintliga
+   * taggar så manuellt satta taggar ALDRIG skrivs över. Saknas → taggar rörs ej.
+   */
+  suggestTags?: (doc: ClassifiableDoc) => Promise<string[]>;
   /** Modell-etikett som sparas i `analysisModel`. */
   model?: string;
   /** Injicerbar nu-tid för deterministiska tester. */
@@ -49,13 +55,16 @@ export function createClassifyDocumentHandler(deps: ClassifyDocumentDeps): JobHa
     const { documentId } = classifyJobSchema.parse(job.data);
     const doc = (await deps.documents.getById(documentId)) as Document | null;
     if (!doc) return; // raderat innan jobbet kördes → no-op
-    const kind = await classify({
-      fileName: doc.fileName,
-      storagePath: doc.storagePath,
-      mimeType: doc.mimeType,
-    });
+    const fields: ClassifiableDoc = { fileName: doc.fileName, storagePath: doc.storagePath, mimeType: doc.mimeType };
+    const kind = await classify(fields);
+    // LLM-föreslagna taggar slås ihop med befintliga (union) → AI lägger till,
+    // användarens manuella taggar bevaras. Utan suggestTags rörs taggarna inte.
+    const tagPatch = deps.suggestTags
+      ? { tags: [...new Set([...(doc.tags ?? []), ...(await deps.suggestTags(fields))])] }
+      : {};
     await deps.documents.updateMetadata(documentId, {
       documentType: kind,
+      ...tagPatch,
       analyzedAt: now(),
       analysisStatus: "DONE",
       analysisModel: model,

--- a/src/lib/server/jobs/server-first-handlers.ts
+++ b/src/lib/server/jobs/server-first-handlers.ts
@@ -8,7 +8,7 @@
  */
 
 import { createSmtpSender, type SmtpConfig } from "@/lib/server/integrations/email/smtp-sender";
-import { createOllamaClassifier, type LlmConfig } from "@/lib/server/llm/ollama-classifier";
+import { createOllamaClassifier, createOllamaTagSuggester, type LlmConfig } from "@/lib/server/llm/ollama-classifier";
 import type { IContentStore } from "@/lib/server/ports";
 import { extractText } from "@/lib/shared/extract-text";
 import { createClassifyDocumentHandler, type ClassifiableDoc, type ClassifyDocumentDeps } from "./handlers/classify-document-handler";
@@ -25,24 +25,33 @@ export interface JobHandlerConfig {
    *  (läs bytes → extrahera text → ollama); annars filnamns-heuristik. */
   content?: IContentStore;
   llm?: LlmConfig;
+  /** Byråns etikett-vokabulär (#621 B2). Satt + content + llm → LLM föreslår
+   *  taggar ur listan vid klassificeringen. Lazy så den läses per jobb. */
+  vocabulary?: () => Promise<readonly string[]>;
 }
 
 /**
- * Bygg `classify`-funktionen för dokumentjobbet. Med content-store + LLM-konfig:
- * läs bytes → extrahera text (PDF/DOCX/text) → klassificera via ollama (fail-soft
- * till filnamns-heuristik). Utan dem → handlerns default (ren heuristik).
+ * Bygg `classify` (+ `suggestTags`) för dokumentjobbet. Med content-store +
+ * LLM-konfig: läs bytes → extrahera text (PDF/DOCX/text) → klassificera via
+ * ollama (fail-soft till filnamns-heuristik). Med dessutom en vokabulär (#621
+ * B2): föreslå taggar ur listan. Utan content/llm → handlerns default (heuristik).
  */
-function buildClassify(cfg: JobHandlerConfig): Pick<ClassifyDocumentDeps, "classify" | "model"> {
+function buildClassify(cfg: JobHandlerConfig): Pick<ClassifyDocumentDeps, "classify" | "suggestTags" | "model"> {
   if (!cfg.content || !cfg.llm) return {};
   const content = cfg.content;
   const ollama = createOllamaClassifier(cfg.llm);
+  const tagger = createOllamaTagSuggester(cfg.llm);
+  const { vocabulary } = cfg;
+  const textOf = async (doc: ClassifiableDoc): Promise<string> => {
+    const bytes = await content.read(doc.storagePath);
+    return bytes ? await extractText({ bytes, mimeType: doc.mimeType, fileName: doc.fileName }) : "";
+  };
   return {
     model: `ollama:${cfg.llm.model}`,
-    classify: async (doc: ClassifiableDoc) => {
-      const bytes = await content.read(doc.storagePath);
-      const text = bytes ? await extractText({ bytes, mimeType: doc.mimeType, fileName: doc.fileName }) : "";
-      return ollama(text, doc.fileName);
-    },
+    classify: async (doc: ClassifiableDoc) => ollama(await textOf(doc), doc.fileName),
+    ...(vocabulary ? {
+      suggestTags: async (doc: ClassifiableDoc) => tagger(await textOf(doc), await vocabulary()),
+    } : {}),
   };
 }
 

--- a/src/lib/server/llm/ollama-classifier.ts
+++ b/src/lib/server/llm/ollama-classifier.ts
@@ -40,8 +40,12 @@ function matchKind(raw: string): DocumentKind | null {
   return (KNOWN_KINDS as readonly string[]).find((k) => upper.includes(k)) as DocumentKind ?? null;
 }
 
-/** POST:a klassificerings-prompten till endpointen; null vid fel/okänt svar. */
-async function askOllama(config: LlmConfig, doFetch: FetchLike, text: string): Promise<DocumentKind | null> {
+/**
+ * POST:a en chat-completion (system + user) och returnera svaret som text.
+ * null vid nät-/HTTP-/parse-fel. Delas av klassificeraren och tagg-förslagaren
+ * (en enda POST-yta mot den OpenAI-kompatibla endpointen).
+ */
+async function chat(config: LlmConfig, doFetch: FetchLike, system: string, user: string): Promise<string | null> {
   try {
     const res = await doFetch(`${config.endpoint.replace(/\/$/, "")}/chat/completions`, {
       method: "POST",
@@ -54,20 +58,37 @@ async function askOllama(config: LlmConfig, doFetch: FetchLike, text: string): P
         stream: false,
         temperature: 0,
         messages: [
-          { role: "system", content: "Du klassificerar svenska juridiska dokument. Svara med EXAKT ETT ord — en av kategorierna." },
-          {
-            role: "user",
-            content: `Kategorier: ${KNOWN_KINDS.join(", ")}.\nVälj den som bäst beskriver dokumentet (OKLASSIFICERAT om ingen passar).\n\nDokument:\n"""${text.slice(0, MAX_TEXT)}"""`,
-          },
+          { role: "system", content: system },
+          { role: "user", content: user },
         ],
       }),
     });
     if (!res.ok) return null;
     const body = (await res.json()) as { choices?: Array<{ message?: { content?: string } }> };
-    return matchKind(body.choices?.[0]?.message?.content ?? "");
+    return body.choices?.[0]?.message?.content ?? null;
   } catch {
-    return null; // nät-/parse-fel → anroparen faller tillbaka på heuristik
+    return null; // nät-/parse-fel → anroparen faller tillbaka (heuristik / tom lista)
   }
+}
+
+/** Klassificera till EN kategori; null vid fel/okänt svar. */
+async function askOllama(config: LlmConfig, doFetch: FetchLike, text: string): Promise<DocumentKind | null> {
+  const out = await chat(
+    config, doFetch,
+    "Du klassificerar svenska juridiska dokument. Svara med EXAKT ETT ord — en av kategorierna.",
+    `Kategorier: ${KNOWN_KINDS.join(", ")}.\nVälj den som bäst beskriver dokumentet (OKLASSIFICERAT om ingen passar).\n\nDokument:\n"""${text.slice(0, MAX_TEXT)}"""`,
+  );
+  return out ? matchKind(out) : null;
+}
+
+/**
+ * De vokabulär-taggar LLM:en nämner (skiftlägesokänslig delsträngsmatchning mot
+ * den giltiga listan). Garanterar resultat ⊆ vokabulären (hallucinationer
+ * filtreras bort), i vokabulärens ordning.
+ */
+function matchTags(raw: string, vocabulary: readonly string[]): string[] {
+  const upper = raw.toUpperCase();
+  return vocabulary.filter((tag) => tag.trim() !== "" && upper.includes(tag.toUpperCase()));
 }
 
 /**
@@ -84,5 +105,27 @@ export function createOllamaClassifier(
     const heuristic = guessFromFilename(fileName);
     if (text.trim().length < MIN_TEXT) return heuristic;
     return (await askOllama(config, doFetch, text)) ?? heuristic;
+  };
+}
+
+/**
+ * Bygg en tagg-förslagare bunden till `config` (#621 B2). Returnerar en funktion
+ * `(text, vocabulary) → string[]` som föreslår en DELMÄNGD av byråns vokabulär.
+ * Fail-soft: tom vokabulär / för kort text / LLM-fel → tom lista (användaren
+ * taggar då manuellt). Resultatet är garanterat ⊆ vokabulären.
+ */
+export function createOllamaTagSuggester(
+  config: LlmConfig,
+  opts: { fetch?: FetchLike } = {},
+): (text: string, vocabulary: readonly string[]) => Promise<string[]> {
+  const doFetch: FetchLike = opts.fetch ?? ((url, init) => fetch(url, init));
+  return async (text: string, vocabulary: readonly string[]): Promise<string[]> => {
+    if (vocabulary.length === 0 || text.trim().length < MIN_TEXT) return [];
+    const out = await chat(
+      config, doFetch,
+      "Du etiketterar svenska juridiska dokument. Välj BARA bland de givna etiketterna. Svara med en kommaseparerad lista (eller tomt om ingen passar).",
+      `Giltiga etiketter: ${vocabulary.join(", ")}.\nVilka av dessa passar dokumentet? Hitta inte på egna.\n\nDokument:\n"""${text.slice(0, MAX_TEXT)}"""`,
+    );
+    return out ? matchTags(out, vocabulary) : [];
   };
 }

--- a/test/unit/server/jobs/classify-document-handler.test.ts
+++ b/test/unit/server/jobs/classify-document-handler.test.ts
@@ -53,4 +53,28 @@ describe("createClassifyDocumentHandler", () => {
     expect(classify).toHaveBeenCalledWith({ fileName: "x.bin" });
     expect(documents.updateMetadata.mock.calls[0]![1]).toMatchObject({ documentType: "AVTAL", analysisModel: "ollama:llama" });
   });
+
+  it("suggestTags (#621 B2) slår ihop förslag med befintliga taggar (union, ingen clobber)", async () => {
+    const documents = {
+      getById: vi.fn(async () => ({ id: "d1", fileName: "x.pdf", tags: ["Manuell", "Sekretess"] })),
+      updateMetadata: vi.fn(async () => ({})),
+    };
+    const suggestTags = vi.fn(async () => ["Sekretess", "Brådskande"]);
+    const handler = createClassifyDocumentHandler({ documents: documents as never, suggestTags });
+    await handler(jobFor("d1"));
+    // union(["Manuell","Sekretess"], ["Sekretess","Brådskande"]) → dedupat
+    expect(documents.updateMetadata.mock.calls[0]![1]).toMatchObject({
+      tags: ["Manuell", "Sekretess", "Brådskande"],
+    });
+  });
+
+  it("utan suggestTags rörs `tags` inte (ingen tags-nyckel i patchen)", async () => {
+    const documents = {
+      getById: vi.fn(async () => ({ id: "d1", fileName: "x.pdf", tags: ["Manuell"] })),
+      updateMetadata: vi.fn(async () => ({})),
+    };
+    const handler = createClassifyDocumentHandler({ documents: documents as never });
+    await handler(jobFor("d1"));
+    expect(documents.updateMetadata.mock.calls[0]![1]).not.toHaveProperty("tags");
+  });
 });

--- a/test/unit/server/llm/ollama-classifier.test.ts
+++ b/test/unit/server/llm/ollama-classifier.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, expect, it, vi } from "vitest-compat";
-import { createOllamaClassifier, loadLlmConfigFromEnv } from "@/lib/server/llm/ollama-classifier";
+import { createOllamaClassifier, createOllamaTagSuggester, loadLlmConfigFromEnv } from "@/lib/server/llm/ollama-classifier";
 
 const cfg = { endpoint: "http://ollama:11434/v1", model: "llama3.2" };
 const LONG = "Detta är ett juridiskt dokument med tillräckligt mycket text för att skickas till modellen för klassificering.";
@@ -55,6 +55,42 @@ describe("createOllamaClassifier", () => {
     await classify(LONG, "x.pdf");
     const headers = (fetchFn.mock.calls[0]![1] as RequestInit).headers as Record<string, string>;
     expect(headers.authorization).toBe("Bearer sk-1");
+  });
+});
+
+describe("createOllamaTagSuggester (#621 B2)", () => {
+  const VOCAB = ["Sekretess", "Brådskande", "Original"];
+
+  it("returnerar delmängden LLM:en nämner (⊆ vokabulären)", async () => {
+    const fetchFn = vi.fn(async () => res("Sekretess, Original"));
+    const suggest = createOllamaTagSuggester(cfg, { fetch: fetchFn });
+    expect(await suggest(LONG, VOCAB)).toEqual(["Sekretess", "Original"]);
+  });
+
+  it("filtrerar bort hallucinerade taggar utanför vokabulären", async () => {
+    const fetchFn = vi.fn(async () => res("Sekretess, Påhittad, Topphemlig"));
+    const suggest = createOllamaTagSuggester(cfg, { fetch: fetchFn });
+    expect(await suggest(LONG, VOCAB)).toEqual(["Sekretess"]);
+  });
+
+  it("tom vokabulär → ingen LLM, tom lista", async () => {
+    const fetchFn = vi.fn(async () => res("x"));
+    const suggest = createOllamaTagSuggester(cfg, { fetch: fetchFn });
+    expect(await suggest(LONG, [])).toEqual([]);
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("för kort text → ingen LLM, tom lista", async () => {
+    const fetchFn = vi.fn(async () => res("Sekretess"));
+    const suggest = createOllamaTagSuggester(cfg, { fetch: fetchFn });
+    expect(await suggest("kort", VOCAB)).toEqual([]);
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("nät-fel → tom lista (fail-soft)", async () => {
+    const fetchFn = vi.fn(async () => { throw new Error("net down"); });
+    const suggest = createOllamaTagSuggester(cfg, { fetch: fetchFn });
+    expect(await suggest(LONG, VOCAB)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
**B2 of #621** (completes the feature). At server-side classification, the LLM now proposes **multiple tags** from the org vocabulary, alongside the single `documentType`.

## What
- **`createOllamaTagSuggester(config)`** → `(text, vocabulary) => string[]`. Shares an extracted `chat()` helper with the classifier (one POST surface). Output is filtered to ⊆ the vocabulary (hallucinations dropped); fail-soft → empty list on empty vocabulary / short text / LLM error (the user then tags manually, B1).
- **classify-handler**: optional `suggestTags` dep. Suggestions are **merged (union) with the document's existing tags** → the AI *adds*, manually-set tags are never overwritten. Without `suggestTags`, `tags` is left untouched. Metadata write → no version bump (#619).
- **server-first**: builds `suggestTags` (content → extractText → ollama) + a lazy vocabulary thunk (`organization.documentTags`) and wires it in.

## Verification (local; CI mirrors)
- tag-suggester tests: subset selection, hallucination filtering, empty-vocab / short-text → no LLM call, net-error → empty.
- handler tests: union-merge with existing tags + no-clobber + "no `tags` key without suggestTags".
- **Full suite 3165 tests, 0 fail**; coverage gate + lint + knip + deps + jscpd all green.

Closes #621.

🤖 Generated with [Claude Code](https://claude.com/claude-code)