### PR TITLE
test(addin): enhetstesta task-pane-logiken utan office-värd (#624)

### DIFF
--- a/office-addin/taskpane/taskpane.ts
+++ b/office-addin/taskpane/taskpane.ts
@@ -1,151 +1,18 @@
 /**
- * AVA Outlook task-pane — funktion 1 (#72, ADR 0013): spara det öppna mailet
- * som `.eml` i valt ärende + valfri tidspost.
+ * AVA Outlook task-pane — entry (#72, ADR 0013, funktion 1: spara öppet mail →
+ * ärende + tidspost).
  *
- * Detta är den TUNNA Office.js-glue:n (ej CI-verifierbar — kräver Office-värd).
- * All testad affärslogik ligger i `src/lib/client/`:
- *   - `createAddinClient` — typad tRPC-klient mot AVA-servern (Bearer-PAT).
- *   - `saveIncomingMail`  — Graph/Outlook-REST `$value` → `mail.saveIncoming`.
- *
- * Token-modell: AVA-servern auktoriseras med en PAT (klistras in, lagras i
- * Office roaming-settings, ADR 0013 §3 C1). MIME:n hämtas med en
- * `getCallbackTokenAsync`-REST-token mot mailboxens egen REST-URL — funkar vid
- * sideload UTAN Azure-app-registrering. (Alternativ: Graph + SSO/OBO; se README.)
+ * Detta är den ENDA Office.js-värd-kopplade biten (ej CI-verifierbar — kräver
+ * en Office-värd / OWA-smoke). All testbar logik bor i den injicerbara
+ * `taskpane-controller` (`@/lib/client/addin/`), enhetstestad utan Outlook.
  *
  * Build: `bun run office-addin/build.ts` → taskpane.js (HTTPS-serveras).
  */
 
-import { createAddinClient } from "@/lib/client/addin/addin-client";
-import { saveIncomingMail } from "@/lib/client/addin/save-incoming-mail";
+import { bootstrap, type OfficeLike } from "@/lib/client/addin/taskpane-controller";
 
-// Office.js laddas globalt via <script> i taskpane.html. Lös typning (denna
-// fil typecheckas inte av huvud-tsconfig:en — den byggs separat).
-declare const Office: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+// Office.js laddas globalt via <script> i taskpane.html. `OfficeLike` täcker
+// det subset vi rör; `onReady` läggs på för entry-punkten.
+declare const Office: OfficeLike & { onReady(callback: () => void): void };
 
-interface MatterHit { id: string; matterNumber: string; title: string }
-type AddinClient = ReturnType<typeof createAddinClient>;
-
-const $ = (id: string) => document.getElementById(id) as HTMLInputElement;
-const ROAM = () => Office.context.roamingSettings;
-
-Office.onReady(() => {
-  const app = document.getElementById("app")!;
-  const tpl = document.getElementById("form-tpl") as HTMLTemplateElement;
-  app.innerHTML = "";
-  app.appendChild(tpl.content.cloneNode(true));
-  initForm();
-});
-
-function initForm(): void {
-  // Förifyll server/PAT ur roaming-settings.
-  $("server").value = ROAM().get("ava_server") ?? "";
-  $("pat").value = ROAM().get("ava_pat") ?? "";
-
-  let selected: MatterHit | null = null;
-  const setStatus = (msg: string, cls = "") => {
-    const el = document.getElementById("status")!;
-    el.textContent = msg;
-    el.className = `status ${cls}`;
-  };
-  const refreshSaveEnabled = () => {
-    ($("save")).disabled = !(selected && $("server").value && $("pat").value);
-  };
-
-  const client = (): AddinClient =>
-    createAddinClient({ baseUrl: $("server").value.trim(), token: $("pat").value.trim() });
-
-  $("q").addEventListener("input", debounce(async () => {
-    const q = $("q").value.trim();
-    if (q.length < 2) return;
-    try {
-      const matters = await searchMatters(client(), q);
-      renderResults(matters, (m) => { selected = m; refreshSaveEnabled(); });
-    } catch (e) {
-      setStatus(`Sök misslyckades: ${errMsg(e)}`, "err");
-    }
-  }, 300));
-
-  ["server", "pat"].forEach((id) => $(id).addEventListener("input", refreshSaveEnabled));
-
-  $("save").addEventListener("click", () => {
-    if (!selected) return;
-    void doSave(client(), selected, setStatus);
-  });
-}
-
-/** Ärende-sök via tRPC (`matter.list` med fritext). */
-async function searchMatters(c: AddinClient, q: string): Promise<MatterHit[]> {
-  const res: any = await (c as any).matter.list.query({ search: q, pageSize: 8 }); // eslint-disable-line @typescript-eslint/no-explicit-any
-  const rows = Array.isArray(res) ? res : res.matters ?? res.items ?? [];
-  return rows.map((m: any) => ({ id: m.id, matterNumber: m.matterNumber, title: m.title })); // eslint-disable-line @typescript-eslint/no-explicit-any
-}
-
-function renderResults(matters: MatterHit[], onPick: (m: MatterHit) => void): void {
-  const box = document.getElementById("results")!;
-  box.innerHTML = "";
-  for (const m of matters) {
-    const div = document.createElement("div");
-    div.className = "matter";
-    div.textContent = `${m.matterNumber} — ${m.title}`;
-    div.addEventListener("click", () => {
-      box.querySelectorAll(".matter").forEach((e) => e.classList.remove("sel"));
-      div.classList.add("sel");
-      onPick(m);
-    });
-    box.appendChild(div);
-  }
-}
-
-/** Hämta REST-token + restId + ämne/datum ur Office och kör save-flödet. */
-async function doSave(c: AddinClient, matter: MatterHit, setStatus: (m: string, c?: string) => void): Promise<void> {
-  setStatus("Sparar…");
-  ($("save")).disabled = true;
-  try {
-    ROAM().set("ava_server", $("server").value.trim());
-    ROAM().set("ava_pat", $("pat").value.trim());
-    ROAM().saveAsync();
-
-    const item = Office.context.mailbox.item;
-    const restId = Office.context.mailbox.convertToRestId(item.itemId, Office.MailboxEnums.RestVersion.v2_0);
-    const restBase = `${Office.context.mailbox.restUrl}/v2.0`;
-    const token = await getRestToken();
-    const minutes = parseInt($("minutes").value, 10);
-
-    await saveIncomingMail({
-      client: c as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-      graphToken: token,
-      mimeBaseUrl: restBase,
-      restId,
-      matterId: matter.id,
-      subject: item.subject ?? "(utan ämne)",
-      receivedAt: (item.dateTimeCreated ?? new Date()).toISOString(),
-      ...(Number.isFinite(minutes) && minutes > 0 ? { time: { minutes } } : {}),
-    });
-    setStatus(`✓ Sparat i ${matter.matterNumber}`, "ok");
-  } catch (e) {
-    setStatus(`Misslyckades: ${errMsg(e)}`, "err");
-  } finally {
-    ($("save")).disabled = false;
-  }
-}
-
-/** REST-token mot mailboxens egen REST-URL (ingen Azure-app krävs). */
-function getRestToken(): Promise<string> {
-  return new Promise((resolve, reject) => {
-    Office.context.mailbox.getCallbackTokenAsync({ isRest: true }, (r: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
-      if (r.status === "succeeded") resolve(r.value);
-      else reject(new Error("Kunde inte hämta REST-token (getCallbackTokenAsync)"));
-    });
-  });
-}
-
-// fn får returnera Promise (async-handlers) — vi void:ar den i setTimeout så
-// no-misused-promises är nöjd och flytande promise:n är medveten.
-function debounce<A extends unknown[]>(fn: (...a: A) => unknown, ms: number): (...a: A) => void {
-  let t: ReturnType<typeof setTimeout>;
-  return (...a: A) => { clearTimeout(t); t = setTimeout(() => { void fn(...a); }, ms); };
-}
-
-function errMsg(e: unknown): string {
-  return e instanceof Error ? e.message : String(e);
-}
+Office.onReady(() => bootstrap(Office));

--- a/src/lib/client/addin/taskpane-controller.ts
+++ b/src/lib/client/addin/taskpane-controller.ts
@@ -1,0 +1,207 @@
+/**
+ * `taskpane-controller` — den testbara logiken bakom Outlook-add-in:ens
+ * task-pane (#72, ADR 0013, funktion 1: spara öppet mail → ärende + tidspost).
+ *
+ * Office.js-glue:n i `office-addin/taskpane/taskpane.ts` reducerades till en
+ * tunn entry (`Office.onReady(() => bootstrap(Office))`); ALL logik bor här och
+ * kan enhetstestas UTAN en Office-värd: `Office` injiceras via det smala
+ * `OfficeLike`-interfacet och DOM:en körs i happy-dom. Det enda som genuint
+ * kräver en värd (att de RIKTIGA Office-API:erna beter sig som interfacet
+ * antar) täcks separat av en OWA+Playwright-smoke.
+ */
+
+import { createAddinClient } from "@/lib/client/addin/addin-client";
+import { saveIncomingMail, type MailSaverClient } from "@/lib/client/addin/save-incoming-mail";
+
+// ─── Smal Office.js-yta (det subset task-panen faktiskt rör) ──────────
+
+export interface RoamingSettings {
+  get(key: string): string | undefined;
+  set(key: string, value: string): void;
+  saveAsync(): void;
+}
+export interface MailboxItem {
+  itemId: string;
+  subject?: string | null;
+  dateTimeCreated?: Date | null;
+}
+export interface CallbackTokenResult {
+  status: string;
+  value?: string;
+}
+export interface Mailbox {
+  item: MailboxItem;
+  restUrl: string;
+  convertToRestId(itemId: string, version: string): string;
+  getCallbackTokenAsync(options: { isRest: boolean }, callback: (result: CallbackTokenResult) => void): void;
+}
+export interface OfficeLike {
+  context: { roamingSettings: RoamingSettings; mailbox: Mailbox };
+  MailboxEnums: { RestVersion: { v2_0: string } };
+}
+
+export interface MatterHit { id: string; matterNumber: string; title: string }
+type StatusFn = (msg: string, cls?: string) => void;
+
+/** Smal klient-yta för ärende-söket (uppfylls av `createAddinClient(...)`s
+ *  `TRPCClient<AppRouter>`; smal så testdubbletter slipper casts). */
+export interface MatterSearchClient {
+  matter: {
+    list: {
+      query: (input: { search?: string; pageSize?: number }) => Promise<{
+        matters: ReadonlyArray<{ id: string; matterNumber: string; title: string }>;
+      }>;
+    };
+  };
+}
+
+// ─── Ren logik (Office injicerat / mockad fetch) ──────────────────────
+
+/** Ärende-sök via tRPC (`matter.list` med fritext) → vy-träffar. */
+export async function searchMatters(client: MatterSearchClient, q: string): Promise<MatterHit[]> {
+  const res = await client.matter.list.query({ search: q, pageSize: 8 });
+  return res.matters.map((m) => ({ id: m.id, matterNumber: m.matterNumber, title: m.title }));
+}
+
+/** REST-token mot mailboxens egen REST-URL (ingen Azure-app krävs). */
+export function getRestToken(office: OfficeLike): Promise<string> {
+  return new Promise((resolve, reject) => {
+    office.context.mailbox.getCallbackTokenAsync({ isRest: true }, (r) => {
+      if (r.status === "succeeded" && r.value) resolve(r.value);
+      else reject(new Error("Kunde inte hämta REST-token (getCallbackTokenAsync)"));
+    });
+  });
+}
+
+export interface MailContext { restId: string; restBase: string; subject: string; receivedAt: string }
+
+/** Plocka REST-id/-bas + ämne/datum ur Office-item:en. */
+export function mailContext(office: OfficeLike): MailContext {
+  const mb = office.context.mailbox;
+  const { item } = mb;
+  return {
+    restId: mb.convertToRestId(item.itemId, office.MailboxEnums.RestVersion.v2_0),
+    restBase: `${mb.restUrl}/v2.0`,
+    subject: item.subject ?? "(utan ämne)",
+    receivedAt: (item.dateTimeCreated ?? new Date()).toISOString(),
+  };
+}
+
+/** Persistera server-URL + PAT i Office roaming-settings (ADR 0013 §3 C1). */
+export function persistCreds(office: OfficeLike, server: string, pat: string): void {
+  const r = office.context.roamingSettings;
+  r.set("ava_server", server);
+  r.set("ava_pat", pat);
+  r.saveAsync();
+}
+
+/**
+ * Save-flödet: hämta Office-kontext + REST-token, kör `saveIncomingMail`, och
+ * rapportera status. `setSaving` (knapp-disable) injiceras så funktionen är
+ * DOM-fri och testbar. Fel fångas → felstatus (shell:en re-enablar via finally).
+ */
+export async function runSave(opts: {
+  office: OfficeLike;
+  client: MailSaverClient;
+  matter: MatterHit;
+  minutes: number;
+  setStatus: StatusFn;
+  setSaving: (saving: boolean) => void;
+}): Promise<void> {
+  const { office, client, matter, minutes, setStatus, setSaving } = opts;
+  setStatus("Sparar…");
+  setSaving(true);
+  try {
+    const ctx = mailContext(office);
+    const token = await getRestToken(office);
+    await saveIncomingMail({
+      client, graphToken: token, mimeBaseUrl: ctx.restBase, restId: ctx.restId,
+      matterId: matter.id, subject: ctx.subject, receivedAt: ctx.receivedAt,
+      ...(Number.isFinite(minutes) && minutes > 0 ? { time: { minutes } } : {}),
+    });
+    setStatus(`✓ Sparat i ${matter.matterNumber}`, "ok");
+  } catch (e) {
+    setStatus(`Misslyckades: ${errMsg(e)}`, "err");
+  } finally {
+    setSaving(false);
+  }
+}
+
+// ─── DOM-glue (happy-dom-testbar; använder global `document`) ──────────
+
+/** Rendera sök-träffarna som klickbara rader; markera vald + rapportera valet. */
+export function renderResults(box: HTMLElement, matters: MatterHit[], onPick: (m: MatterHit) => void): void {
+  box.innerHTML = "";
+  for (const m of matters) {
+    const div = document.createElement("div");
+    div.className = "matter";
+    div.textContent = `${m.matterNumber} — ${m.title}`;
+    div.addEventListener("click", () => {
+      box.querySelectorAll(".matter").forEach((e) => e.classList.remove("sel"));
+      div.classList.add("sel");
+      onPick(m);
+    });
+    box.appendChild(div);
+  }
+}
+
+/** Klona form-mallen in i #app och koppla upp formuläret. */
+export function bootstrap(office: OfficeLike): void {
+  const app = document.getElementById("app")!;
+  const tpl = document.getElementById("form-tpl") as HTMLTemplateElement;
+  app.innerHTML = "";
+  app.appendChild(tpl.content.cloneNode(true));
+  initForm(office);
+}
+
+/** Koppla upp formuläret: förifyll creds, sök (debounce), spara. */
+export function initForm(office: OfficeLike): void {
+  const $ = (id: string) => document.getElementById(id) as HTMLInputElement;
+  $("server").value = office.context.roamingSettings.get("ava_server") ?? "";
+  $("pat").value = office.context.roamingSettings.get("ava_pat") ?? "";
+
+  let selected: MatterHit | null = null;
+  const setStatus: StatusFn = (msg, cls = "") => {
+    const el = document.getElementById("status")!;
+    el.textContent = msg;
+    el.className = `status ${cls}`;
+  };
+  const setSaving = (saving: boolean) => { $("save").disabled = saving; };
+  const refreshSaveEnabled = () => {
+    $("save").disabled = !(selected && $("server").value && $("pat").value);
+  };
+  const client = () =>
+    createAddinClient({ baseUrl: $("server").value.trim(), token: $("pat").value.trim() });
+
+  $("q").addEventListener("input", debounce(async () => {
+    const q = $("q").value.trim();
+    if (q.length < 2) return;
+    try {
+      const matters = await searchMatters(client(), q);
+      renderResults(document.getElementById("results")!, matters, (m) => { selected = m; refreshSaveEnabled(); });
+    } catch (e) {
+      setStatus(`Sök misslyckades: ${errMsg(e)}`, "err");
+    }
+  }, 300));
+
+  ["server", "pat"].forEach((id) => $(id).addEventListener("input", refreshSaveEnabled));
+
+  $("save").addEventListener("click", () => {
+    if (!selected) return;
+    persistCreds(office, $("server").value.trim(), $("pat").value.trim());
+    void runSave({ office, client: client(), matter: selected, minutes: parseInt($("minutes").value, 10), setStatus, setSaving });
+  });
+}
+
+// ─── Småhjälpare ──────────────────────────────────────────────────────
+
+/** fn får returnera Promise (async-handlers) — vi void:ar den i setTimeout så
+ *  no-misused-promises är nöjd och den flytande promise:n är medveten. */
+export function debounce<A extends unknown[]>(fn: (...a: A) => unknown, ms: number): (...a: A) => void {
+  let t: ReturnType<typeof setTimeout>;
+  return (...a: A) => { clearTimeout(t); t = setTimeout(() => { void fn(...a); }, ms); };
+}
+
+export function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}

--- a/test/unit/client/addin/taskpane-controller.test.ts
+++ b/test/unit/client/addin/taskpane-controller.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tester för `taskpane-controller` (#624) — Outlook-add-in:ens task-pane-logik
+ * UTAN en Office-värd. `Office` injiceras via `OfficeLike`-interfacet och DOM:en
+ * körs i happy-dom; `saveIncomingMail`/`createAddinClient` mockas. Täcker sök,
+ * REST-token, mail-kontext, creds-persist, save-flödet (ok/fel/tidspost) +
+ * render/bootstrap. Det enda otestade kvar är den ~4-radiga Office-entry:n.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import {
+  searchMatters, getRestToken, mailContext, persistCreds, runSave, renderResults, bootstrap,
+  type OfficeLike, type MatterHit,
+} from "@/lib/client/addin/taskpane-controller";
+
+const saveIncomingMailMock = vi.fn(async () => ({ ok: true }));
+vi.mock("@/lib/client/addin/save-incoming-mail", () => ({
+  saveIncomingMail: (args: unknown) => saveIncomingMailMock(args),
+}));
+const listQueryMock = vi.fn();
+vi.mock("@/lib/client/addin/addin-client", () => ({
+  createAddinClient: () => ({
+    matter: { list: { query: (input: unknown) => listQueryMock(input) } },
+    mail: { saveIncoming: { mutate: vi.fn() } },
+  }),
+}));
+
+interface OfficeOverrides {
+  roaming?: Partial<Record<"ava_server" | "ava_pat", string>>;
+  subject?: string | null;
+  dateTimeCreated?: Date | null;
+  token?: { status: string; value?: string };
+}
+
+function makeOffice(o: OfficeOverrides = {}): { office: OfficeLike; set: ReturnType<typeof vi.fn>; saveAsync: ReturnType<typeof vi.fn> } {
+  const set = vi.fn();
+  const saveAsync = vi.fn();
+  const token = o.token ?? { status: "succeeded", value: "rest-token" };
+  const office: OfficeLike = {
+    context: {
+      roamingSettings: { get: (k: string) => o.roaming?.[k as "ava_server" | "ava_pat"], set, saveAsync },
+      mailbox: {
+        item: {
+          itemId: "AAMk-1",
+          subject: o.subject === undefined ? "Möte ang. tvist" : o.subject,
+          dateTimeCreated: o.dateTimeCreated === undefined ? new Date("2026-02-03T10:00:00.000Z") : o.dateTimeCreated,
+        },
+        restUrl: "https://outlook.office.com/api",
+        convertToRestId: (id: string) => `rest(${id})`,
+        getCallbackTokenAsync: (_opts, cb) => cb(token),
+      },
+    },
+    MailboxEnums: { RestVersion: { v2_0: "v2.0" } },
+  };
+  return { office, set, saveAsync };
+}
+
+const matter: MatterHit = { id: "m1", matterNumber: "2026-0007", title: "Tvist" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  document.body.innerHTML = "";
+});
+
+describe("searchMatters", () => {
+  it("mappar matter.list-svaret till vy-träffar", async () => {
+    const client = {
+      matter: { list: { query: vi.fn(async () => ({ matters: [
+        { id: "m1", matterNumber: "2026-1", title: "A" },
+        { id: "m2", matterNumber: "2026-2", title: "B" },
+      ] })) } },
+    };
+    expect(await searchMatters(client, "tvist")).toEqual([
+      { id: "m1", matterNumber: "2026-1", title: "A" },
+      { id: "m2", matterNumber: "2026-2", title: "B" },
+    ]);
+    expect(client.matter.list.query).toHaveBeenCalledWith({ search: "tvist", pageSize: 8 });
+  });
+});
+
+describe("getRestToken", () => {
+  it("resolvar token vid succeeded", async () => {
+    const { office } = makeOffice({ token: { status: "succeeded", value: "tok-123" } });
+    expect(await getRestToken(office)).toBe("tok-123");
+  });
+  it("rejectar vid icke-succeeded", async () => {
+    const { office } = makeOffice({ token: { status: "failed" } });
+    await expect(getRestToken(office)).rejects.toThrow(/REST-token/);
+  });
+});
+
+describe("mailContext", () => {
+  it("bygger restId/restBase/subject/receivedAt", () => {
+    const { office } = makeOffice();
+    expect(mailContext(office)).toEqual({
+      restId: "rest(AAMk-1)",
+      restBase: "https://outlook.office.com/api/v2.0",
+      subject: "Möte ang. tvist",
+      receivedAt: "2026-02-03T10:00:00.000Z",
+    });
+  });
+  it("faller tillbaka på '(utan ämne)' + nu-tid när fälten saknas", () => {
+    const { office } = makeOffice({ subject: null, dateTimeCreated: null });
+    const ctx = mailContext(office);
+    expect(ctx.subject).toBe("(utan ämne)");
+    expect(() => new Date(ctx.receivedAt).toISOString()).not.toThrow();
+  });
+});
+
+describe("persistCreds", () => {
+  it("skriver server + pat till roaming och sparar", () => {
+    const { office, set, saveAsync } = makeOffice();
+    persistCreds(office, "https://srv", "PAT-1");
+    expect(set).toHaveBeenCalledWith("ava_server", "https://srv");
+    expect(set).toHaveBeenCalledWith("ava_pat", "PAT-1");
+    expect(saveAsync).toHaveBeenCalled();
+  });
+});
+
+describe("runSave", () => {
+  const client = { mail: { saveIncoming: { mutate: vi.fn() } } };
+
+  it("kör save-flödet, inkluderar tidspost när minuter > 0, sätter ok-status", async () => {
+    const { office } = makeOffice();
+    const setStatus = vi.fn();
+    const setSaving = vi.fn();
+    await runSave({ office, client, matter, minutes: 30, setStatus, setSaving });
+    expect(saveIncomingMailMock).toHaveBeenCalledWith(expect.objectContaining({
+      graphToken: "rest-token", restId: "rest(AAMk-1)", matterId: "m1",
+      subject: "Möte ang. tvist", receivedAt: "2026-02-03T10:00:00.000Z",
+      mimeBaseUrl: "https://outlook.office.com/api/v2.0", time: { minutes: 30 },
+    }));
+    expect(setStatus).toHaveBeenCalledWith("Sparar…");
+    expect(setStatus).toHaveBeenLastCalledWith("✓ Sparat i 2026-0007", "ok");
+    expect(setSaving.mock.calls).toEqual([[true], [false]]);
+  });
+
+  it("utelämnar tidspost när minuter saknas/0", async () => {
+    const { office } = makeOffice();
+    await runSave({ office, client, matter, minutes: NaN, setStatus: vi.fn(), setSaving: vi.fn() });
+    expect(saveIncomingMailMock.mock.calls[0]![0]).not.toHaveProperty("time");
+  });
+
+  it("fångar fel → felstatus, re-enablar (setSaving false)", async () => {
+    saveIncomingMailMock.mockRejectedValueOnce(new Error("nätfel"));
+    const { office } = makeOffice();
+    const setStatus = vi.fn();
+    const setSaving = vi.fn();
+    await runSave({ office, client, matter, minutes: 0, setStatus, setSaving });
+    expect(setStatus).toHaveBeenLastCalledWith("Misslyckades: nätfel", "err");
+    expect(setSaving).toHaveBeenLastCalledWith(false);
+  });
+});
+
+describe("renderResults", () => {
+  it("renderar klickbara rader; klick markerar + rapporterar valet", () => {
+    const box = document.createElement("div");
+    const picked: MatterHit[] = [];
+    renderResults(box, [matter, { id: "m2", matterNumber: "2026-9", title: "B" }], (m) => picked.push(m));
+    const rows = box.querySelectorAll(".matter");
+    expect(rows).toHaveLength(2);
+    expect(rows[0]!.textContent).toBe("2026-0007 — Tvist");
+    (rows[1] as HTMLElement).click();
+    expect(picked).toEqual([{ id: "m2", matterNumber: "2026-9", title: "B" }]);
+    expect(rows[1]!.classList.contains("sel")).toBe(true);
+  });
+});
+
+describe("bootstrap/initForm", () => {
+  function setupDom(): void {
+    document.body.innerHTML = `
+      <div id="app"></div>
+      <template id="form-tpl">
+        <input id="server"><input id="pat"><input id="q"><input id="minutes">
+        <button id="save"></button>
+        <div id="results"></div>
+        <div id="status"></div>
+      </template>`;
+  }
+
+  it("klonar formuläret + förifyller creds ur roaming", () => {
+    setupDom();
+    const { office } = makeOffice({ roaming: { ava_server: "https://srv", ava_pat: "PAT-9" } });
+    bootstrap(office);
+    expect((document.getElementById("server") as HTMLInputElement).value).toBe("https://srv");
+    expect((document.getElementById("pat") as HTMLInputElement).value).toBe("PAT-9");
+  });
+
+  it("Spara är disabled tills ett ärende valts (även med server+pat)", () => {
+    setupDom();
+    const { office } = makeOffice({ roaming: { ava_server: "https://srv", ava_pat: "PAT-9" } });
+    bootstrap(office);
+    const save = document.getElementById("save") as HTMLButtonElement;
+    document.getElementById("server")!.dispatchEvent(new Event("input"));
+    expect(save.disabled).toBe(true); // inget ärende valt än
+  });
+
+  it("hela kedjan: skriv sök → debounce → välj träff → Spara → saveIncomingMail", async () => {
+    vi.useFakeTimers();
+    try {
+      setupDom();
+      listQueryMock.mockResolvedValue({ matters: [{ id: "m1", matterNumber: "2026-7", title: "Tvist" }] });
+      const { office, set } = makeOffice({ roaming: { ava_server: "https://srv", ava_pat: "PAT-9" } });
+      bootstrap(office);
+
+      const q = document.getElementById("q") as HTMLInputElement;
+      q.value = "tvist";
+      q.dispatchEvent(new Event("input"));
+      await vi.advanceTimersByTimeAsync(350); // debounce (300ms) + sök-resolve
+
+      const row = document.querySelector("#results .matter") as HTMLElement;
+      expect(row?.textContent).toBe("2026-7 — Tvist");
+      row.click(); // välj ärendet
+
+      const save = document.getElementById("save") as HTMLButtonElement;
+      expect(save.disabled).toBe(false); // server+pat+val → aktiv
+      save.click();
+      await vi.advanceTimersByTimeAsync(1); // flush runSave:s promise-kedja
+
+      expect(set).toHaveBeenCalledWith("ava_server", "https://srv"); // persistCreds
+      expect(saveIncomingMailMock).toHaveBeenCalledWith(expect.objectContaining({ matterId: "m1" }));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
Svar på frågan "hur mycket av add-in-koden kan vi testa utan Outlook?" → **i praktiken allt** efter den här refaktorn.

## Vad
Bröt ut Outlook-task-panens logik ur den otestade Office.js-glue:n till en **injicerbar `taskpane-controller`** i `src/lib/client/addin/` (där add-innets övriga testade logik redan bor). `Office` injiceras via ett smalt, typat `OfficeLike`-interface; DOM:en körs i happy-dom. `office-addin/taskpane/taskpane.ts` reduceras till en **~4-radig Office-entry** (`Office.onReady(() => bootstrap(Office))`) — den enda biten som genuint kräver en värd.

Som bonus föll **allt `any` bort** (`matter.list` är fullt typad end-to-end).

## Testbart utan Office-värd (allt detta testas nu)
- `searchMatters` (mappning), `getRestToken` (succeeded/failed), `mailContext` (restId/-bas/ämne/datum + fallbacks), `persistCreds`, `runSave` (ok / fel / tidspost-grenar), `renderResults` (klick + markering)
- **hela formulär-kedjan** via `bootstrap`/`initForm`: skriv sök → debounce → välj träff → Spara → `saveIncomingMail` (fake timers + mockad klient)

## Kvar (kräver värd — separat)
Bara att de **riktiga** Office-API:erna beter sig som `OfficeLike` antar (token funkar, restId korrekt, mailboxen accepterar). Det är OWA+Playwright-smoke-lagret — inte den här PR:en.

## Verifierat (lokalt; CI speglar)
- `bun run typecheck` (båda configs) + `bun run lint` + `knip` + `deps:check` + `jscpd` — grönt
- `office-addin/build.ts` bygger fortfarande (entry:n bundlar controllern via `@/`)
- Full svit **3178 tester, 0 fail**; coverage-grinden grön (92.78% rader / 87.58% funktioner)
- 13 nya controller-tester

Closes #624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)