### PR TITLE
feat(tooling): lokal self-hosted-runner (server-first + OIDC på en origin) (#626)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "e2e:install": "playwright install --with-deps chromium",
     "e2e:oidc": "bash tooling/scripts/e2e-oidc.sh",
     "e2e:doc-pipeline": "bash tooling/scripts/document-pipeline-e2e.sh",
+    "selfhosted:local": "bash tooling/scripts/selfhosted-local.sh",
     "diagnose-ui": "bun tooling/scripts/diagnose-ui.ts",
     "smoke:tier3": "bash tooling/scripts/test-tier3-smoke.sh",
     "test:all": "bash tooling/scripts/test-all.sh",

--- a/tooling/docker/docker-compose.selfhosted-local.yml
+++ b/tooling/docker/docker-compose.selfhosted-local.yml
@@ -1,0 +1,114 @@
+# Lokal SELF-HOSTED-stack för manuellt test (#626) — hela kedjan på en origin:
+#
+#   Browser → nginx (:8080)
+#     ├─ /ava/      statisk app (auth_request → oauth2-proxy)
+#     ├─ /api/trpc  → server-first (Postgres-backend), med X-Auth-Request-Email
+#     └─ /oauth2/   → oauth2-proxy ── OIDC-dans ──→ Keycloak (:8089)
+#
+# Self-contained (ingen -f-merge): kör via tooling/scripts/selfhosted-local.sh.
+# Bygg först: `bun run server-first:build` + `bun run build:demo` (out/).
+
+name: ava-selfhosted-local
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: ava
+      POSTGRES_PASSWORD: ava
+      POSTGRES_DB: ava_test
+    ports:
+      - "5433:5432" # host-exponerad så `db:migrate` + seed kan nå den
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ava -d ava_test"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+    tmpfs:
+      - /var/lib/postgresql/data
+
+  server-first:
+    build:
+      context: ../..
+      dockerfile: tooling/docker/server-first/Dockerfile
+    environment:
+      AVA_DATABASE_URL: postgres://ava:ava@postgres:5432/ava_test
+      AVA_ORGANIZATION_ID: "${AVA_ORGANIZATION_ID:-00000000-0000-0000-0000-000000000001}"
+      AVA_HTTP_HOST: 0.0.0.0
+      AVA_HTTP_PORT: "3001"
+      AVA_CONTENT_DIR: /data/content
+    volumes:
+      - content_repo:/data/content
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.0
+    restart: unless-stopped
+    command: ["start-dev", "--import-realm"]
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: "admin"
+      KC_BOOTSTRAP_ADMIN_PASSWORD: "admin"
+      KC_HOSTNAME: "${OIDC_KC_HOSTNAME:-http://localhost:8089}"
+      KC_HOSTNAME_STRICT: "false"
+      KC_HTTP_ENABLED: "true"
+      KC_HEALTH_ENABLED: "true"
+    ports:
+      - "${KC_PORT:-8089}:8080"
+    volumes:
+      - ./keycloak/realm-ava.json:/opt/keycloak/data/import/realm-ava.json:ro
+
+  oauth2-proxy:
+    image: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
+    restart: unless-stopped
+    environment:
+      OAUTH2_PROXY_HTTP_ADDRESS: "0.0.0.0:4180"
+      OAUTH2_PROXY_PROVIDER: "keycloak-oidc"
+      OAUTH2_PROXY_CLIENT_ID: "${OAUTH2_PROXY_CLIENT_ID:-ava}"
+      OAUTH2_PROXY_CLIENT_SECRET: "${OAUTH2_PROXY_CLIENT_SECRET:-ava-test-secret}"
+      OAUTH2_PROXY_COOKIE_SECRET: "${OAUTH2_PROXY_COOKIE_SECRET:-ava-dev-cookie-secret-0123456789}"
+      OAUTH2_PROXY_REDIRECT_URL: "${OIDC_REDIRECT_URL:-http://localhost:8080/oauth2/callback}"
+      OAUTH2_PROXY_OIDC_ISSUER_URL: "${OIDC_ISSUER_PUBLIC:-http://localhost:8089/realms/ava}"
+      OAUTH2_PROXY_LOGIN_URL: "${OIDC_ISSUER_PUBLIC:-http://localhost:8089/realms/ava}/protocol/openid-connect/auth"
+      OAUTH2_PROXY_SKIP_OIDC_DISCOVERY: "true"
+      OAUTH2_PROXY_REDEEM_URL: "http://keycloak:8080/realms/ava/protocol/openid-connect/token"
+      OAUTH2_PROXY_OIDC_JWKS_URL: "http://keycloak:8080/realms/ava/protocol/openid-connect/certs"
+      OAUTH2_PROXY_PROFILE_URL: "http://keycloak:8080/realms/ava/protocol/openid-connect/userinfo"
+      OAUTH2_PROXY_VALIDATE_URL: "http://keycloak:8080/realms/ava/protocol/openid-connect/userinfo"
+      OAUTH2_PROXY_EMAIL_DOMAINS: "*"
+      OAUTH2_PROXY_UPSTREAMS: "static://202"
+      OAUTH2_PROXY_REVERSE_PROXY: "true"
+      OAUTH2_PROXY_SET_XAUTHREQUEST: "true"
+      OAUTH2_PROXY_SKIP_PROVIDER_BUTTON: "true"
+      OAUTH2_PROXY_COOKIE_SECURE: "false"
+      OAUTH2_PROXY_INSECURE_OIDC_ALLOW_UNVERIFIED_EMAIL: "true"
+    depends_on:
+      - keycloak
+
+  web:
+    build:
+      context: ./web
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    ports:
+      - "${AVA_WEB_PORT:-8080}:80"
+    volumes:
+      - ../../out:/usr/share/nginx/html:ro
+      - ./nginx-selfhosted.conf:/etc/nginx/conf.d/default.conf:ro
+      - git_repos:/srv/git
+      - auth_data:/auth-data
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 40s
+    depends_on:
+      - oauth2-proxy
+      - server-first
+
+volumes:
+  git_repos:
+  auth_data:
+  content_repo:

--- a/tooling/docker/nginx-selfhosted.conf
+++ b/tooling/docker/nginx-selfhosted.conf
@@ -1,0 +1,100 @@
+# nginx-config för AVA — lokal SELF-HOSTED-stack (server-first + OIDC).
+#
+# Som nginx-oidc.conf (människo-auth via oauth2-proxy/Keycloak) MEN fronterar
+# dessutom server-first-backenden på `/api/` → den localhost-defaultade
+# self-hosted-appen (firma-config) får en RIKTIG tRPC-backend same-origin.
+# Endast för lokalt manuellt test (tooling/scripts/selfhosted-local.sh).
+#
+# Principal-säkerhet: `/api/` auth_request:ar mot oauth2-proxy, fångar den
+# verifierade emailen ur subrequestens `X-Auth-Request-Email` och SÄTTER den
+# på upstream-headern (skriver över ev. klient-skickad → ingen spoofing).
+# server-first läser den via forwardedClaims (ADR 0009 förtroendegräns).
+
+server {
+  listen 80;
+  server_name _;
+  index index.html;
+  absolute_redirect off;
+  resolver 127.0.0.11 ipv6=off valid=30s;
+
+  # ─── oauth2-proxy endpoints (OIDC-dansen + /oauth2/userinfo) ────────
+  location /oauth2/ {
+    set $oauth2_upstream "http://oauth2-proxy:4180";
+    proxy_pass $oauth2_upstream;
+    proxy_set_header Host                    $host;
+    proxy_set_header X-Real-IP               $remote_addr;
+    proxy_set_header X-Forwarded-Uri         $request_uri;
+    proxy_set_header X-Forwarded-Proto       $scheme;
+    proxy_http_version 1.1;
+    proxy_buffering off;
+  }
+
+  location = /oauth2/auth {
+    internal;
+    set $oauth2_upstream "http://oauth2-proxy:4180";
+    proxy_pass $oauth2_upstream;
+    proxy_pass_request_body off;
+    proxy_set_header Content-Length "";
+    proxy_set_header X-Original-URI $request_uri;
+  }
+
+  location = /healthz {
+    auth_basic off;
+    return 200 "ok\n";
+    default_type text/plain;
+  }
+
+  # ─── server-first tRPC-API (skyddat: kräver inloggad OIDC-session) ──
+  # auth_request → oauth2-proxy; den verifierade emailen vidarebefordras som
+  # X-Auth-Request-Email (överskriver klient-headern → ingen spoofing).
+  location /api/ {
+    auth_request /oauth2/auth;
+    auth_request_set $auth_email $upstream_http_x_auth_request_email;
+    error_page 401 = @api_401;
+    set $sf_upstream "http://server-first:3001";
+    proxy_pass $sf_upstream;
+    proxy_set_header Host                  $host;
+    proxy_set_header X-Auth-Request-Email  $auth_email;
+    proxy_http_version 1.1;
+    proxy_buffering off;
+  }
+  location @api_401 { return 401; }
+
+  # ─── /ava/_next/static/ — oskyddade hashade assets ─────────────────
+  location ~ ^/ava/_next/static/(.+\.mjs)$ {
+    alias /usr/share/nginx/html/_next/static/$1;
+    default_type application/javascript;
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+  }
+  location /ava/_next/static/ {
+    alias /usr/share/nginx/html/_next/static/;
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+    try_files $uri =404;
+  }
+
+  # ─── Appen (skyddad: kräver inloggad OIDC-session) ─────────────────
+  location /ava/ {
+    auth_request /oauth2/auth;
+    error_page 401 = @oidc_signin;
+    alias /usr/share/nginx/html/;
+    try_files $uri $uri.html $uri/index.html /index.html =404;
+  }
+
+  location = / { return 302 /ava/; }
+
+  location @oidc_signin {
+    return 302 /oauth2/start?rd=$scheme://$http_host$request_uri;
+  }
+
+  # Hårda navigeringar till runtime-id:n (shell-routing-shim).
+  location ~ "^/ava/(matters|contacts|invoices|payment-plans|users|templates)/([^/]+)(/edit)?/?$" {
+    auth_request /oauth2/auth;
+    error_page 401 = @oidc_signin;
+    alias /usr/share/nginx/html/;
+    try_files /$1/$2$3/index.html /$1/__shell__$3/index.html /index.html =404;
+  }
+
+  location ~ /\. { deny all; }
+}

--- a/tooling/scripts/seed-selfhosted-local.ts
+++ b/tooling/scripts/seed-selfhosted-local.ts
@@ -1,0 +1,49 @@
+#!/usr/bin/env bun
+/**
+ * Seed för den lokala self-hosted-stacken (#626) — skapar byrå-org:en +
+ * allowlistade användare som matchar Keycloak-testrealm:ens emails, så att
+ * OIDC-inloggningen (`lawyer@ava.test` / `admin@ava.test`) binder en principal
+ * (server-context: forwardedClaims → users.listByOrg → OidcAuthProvider).
+ *
+ * Idempotent: ON CONFLICT DO NOTHING. Kör efter `db:migrate`.
+ *
+ *   AVA_DATABASE_URL=postgres://ava:ava@localhost:5433/ava_test \
+ *   AVA_ORGANIZATION_ID=00000000-0000-0000-0000-000000000001 \
+ *     bun tooling/scripts/seed-selfhosted-local.ts
+ */
+
+import postgres from "postgres";
+import { uuidv7 } from "@/lib/shared/uuid";
+
+const DB_URL = process.env.AVA_DATABASE_URL ?? "postgres://ava:ava@localhost:5433/ava_test";
+const ORG = process.env.AVA_ORGANIZATION_ID ?? "00000000-0000-0000-0000-000000000001";
+
+/** KC-realm:ens (realm-ava.json) allowlistade testanvändare. `outsider` seedas
+ *  MEDVETET INTE → demonstrerar att autentiserad ≠ auktoriserad (nekas). */
+const USERS = [
+  { email: "lawyer@ava.test", name: "Lena Lawyer", role: "LAWYER" },
+  { email: "admin@ava.test", name: "Alva Admin", role: "ADMIN" },
+];
+
+async function main(): Promise<void> {
+  const sql = postgres(DB_URL, { max: 1, onnotice: () => {} });
+  try {
+    await sql`INSERT INTO organizations (id, name) VALUES (${ORG}, ${"Demobyrå AB"})
+              ON CONFLICT (id) DO NOTHING`;
+    for (const u of USERS) {
+      const existing = await sql<Array<{ id: string }>>`SELECT id FROM users WHERE email = ${u.email} LIMIT 1`;
+      if (existing[0]) { console.log(`• ${u.email} finns redan`); continue; }
+      await sql`INSERT INTO users (id, organization_id, email, name, role, active)
+                VALUES (${uuidv7()}, ${ORG}, ${u.email}, ${u.name}, ${u.role}, ${true})`;
+      console.log(`✓ seedade ${u.email} (${u.role})`);
+    }
+    console.log(`✓ seed klar (org ${ORG}). 'outsider@ava.test' lämnas utanför allowlisten med flit.`);
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`✗ seed-selfhosted-local: ${String(err)}\n`);
+  process.exitCode = 1;
+});

--- a/tooling/scripts/selfhosted-local.sh
+++ b/tooling/scripts/selfhosted-local.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Lokal SELF-HOSTED-stack för manuellt test (#626): hela kedjan på en origin —
+# nginx (:8080) → statisk app + /api/trpc → server-first (Postgres) bakom
+# oauth2-proxy + Keycloak (:8089). Lämnas KÖRANDE (ingen teardown).
+#
+#   bash tooling/scripts/selfhosted-local.sh          # starta + lämna uppe
+#   bash tooling/scripts/selfhosted-local.sh --down   # riv ner
+#
+# Login (Keycloak realm "ava"): lawyer/lawyer (allowlistad) · admin/admin ·
+# outsider/outsider (nekas — ej i allowlisten). Verifierad principal-bindning.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+export PATH="$HOME/.bun/bin:$PATH"
+
+export AVA_WEB_PORT="${AVA_WEB_PORT:-8080}"
+export KC_PORT="${KC_PORT:-8089}"
+export OIDC_KC_HOSTNAME="http://localhost:${KC_PORT}"
+export OIDC_ISSUER_PUBLIC="http://localhost:${KC_PORT}/realms/ava"
+export OIDC_REDIRECT_URL="http://localhost:${AVA_WEB_PORT}/oauth2/callback"
+export AVA_ORGANIZATION_ID="${AVA_ORGANIZATION_ID:-00000000-0000-0000-0000-000000000001}"
+DB_URL="postgres://ava:ava@localhost:5433/ava_test"
+COMPOSE=(docker compose -p ava-selfhosted-local -f tooling/docker/docker-compose.selfhosted-local.yml)
+
+if [[ "${1:-}" == "--down" ]]; then
+  echo "▸ River ner self-hosted-stacken…"
+  "${COMPOSE[@]}" down -v --remove-orphans
+  exit 0
+fi
+
+echo "▸ [1/6] Bygger server-first-binär…"
+bun run server-first:build >/dev/null
+
+echo "▸ [2/6] Bygger statisk app (out/)…"
+bun run build:demo >/dev/null 2>&1
+
+echo "▸ [3/6] Startar stacken (postgres + server-first + keycloak + oauth2-proxy + web)…"
+"${COMPOSE[@]}" up -d --build --wait --wait-timeout 240
+
+echo "▸ [4/6] Migrerar schemat…"
+AVA_DATABASE_URL="$DB_URL" bun run db:migrate
+
+echo "▸ [5/6] Seedar org + allowlistade användare…"
+AVA_DATABASE_URL="$DB_URL" AVA_ORGANIZATION_ID="$AVA_ORGANIZATION_ID" bun tooling/scripts/seed-selfhosted-local.ts
+
+echo "▸ [6/6] Väntar in Keycloak + web…"
+for _ in $(seq 1 40); do
+  if curl -sf "http://localhost:${KC_PORT}/realms/ava/.well-known/openid-configuration" >/dev/null 2>&1 \
+     && curl -sf "http://localhost:${AVA_WEB_PORT}/healthz" >/dev/null 2>&1; then break; fi
+  sleep 2
+done
+
+# Sanity: /api/trpc ska finnas + vara auth-gated (401 utan cookie, ej 404).
+API_CODE=$(curl -sS -o /dev/null -w "%{http_code}" "http://localhost:${AVA_WEB_PORT}/api/trpc/user.current" 2>/dev/null || echo "ERR")
+
+cat <<EOF
+
+✅ Self-hosted-stacken kör.
+
+   Öppna:   http://localhost:${AVA_WEB_PORT}/ava
+   Login:   lawyer / lawyer   (eller admin / admin)
+            outsider / outsider → nekas (ej i byråns allowlist)
+   Keycloak admin: http://localhost:${KC_PORT}  (admin/admin)
+
+   /api/trpc auth-gate (utan cookie): HTTP ${API_CODE}  (401 = rätt: finns + skyddad)
+
+   Riv ner:  bash tooling/scripts/selfhosted-local.sh --down
+EOF


### PR DESCRIPTION
Lokal runner som wirar ihop **hela self-hosted-kedjan** på en origin, för manuellt test:

```
Browser → nginx (:8080)
  ├─ /ava/      statisk app (auth_request → oauth2-proxy)
  ├─ /api/trpc  → server-first (Postgres), med forwardad X-Auth-Request-Email
  └─ /oauth2/   → oauth2-proxy ── OIDC ──→ Keycloak (:8089)
```

Bakgrund: localhost-appen defaultar till `self-hosted` (`defaultConfigForHost`) och syncar `createServerFirstStore` mot same-origin `/api/trpc`. Det fanns ingen färdig stack som serverade både den statiska appen och en server-first-backend bakom oauth2-proxy → appen fastnade på "AVA Laddar…".

## Vad
- `docker-compose.selfhosted-local.yml` — self-contained (postgres, server-first, keycloak, oauth2-proxy, web).
- `nginx-selfhosted.conf` — OIDC-gatead app + ny `/api/`-route till server-first med forwardad `X-Auth-Request-Email` (skriver över klient-headern → ingen spoofing; server-first verifierar mot allowlisten, ADR 0009).
- `seed-selfhosted-local.ts` — org + allowlistade users (`lawyer@`/`admin@ava.test`; `outsider` lämnas utanför → nekas).
- `selfhosted-local.sh` + `bun run selfhosted:local` — bygg/starta/migrera/seed, lämnas körande; `--down` river ner.

## Verifierat (lokalt)
- Stacken: alla containrar healthy; migrering + seed OK; `/api/trpc` 401 utan cookie (route finns + skyddad).
- Server-side principal-kedjan: `lawyer@ava.test` → **200 + data**; ingen email + `outsider@ava.test` → **UNAUTHORIZED**.
- `typecheck` + `lint` gröna.

Login (KC realm `ava`): `lawyer/lawyer`, `admin/admin`, `outsider/outsider` (nekas).

Closes #626.

🤖 Generated with [Claude Code](https://claude.com/claude-code)