### PR TITLE
fix(self-hosted): server-first OIDC-login fastnade på "AVA Laddar…" (#628)

### DIFF
--- a/src/components/shell/demo-bootstrap.tsx
+++ b/src/components/shell/demo-bootstrap.tsx
@@ -442,7 +442,11 @@ async function bindOidcFirstLogin(a: {
   setStatus: (s: Status) => void; setErrorMsg: (m: string | null) => void;
 }): Promise<boolean> {
   if (!a.needsOidc) return false;
-  const users = await a.client.user.list.query();
+  // `user.list` returnerar `{ users }` (router-formen) — plocka ut ARRAYEN.
+  // (Tidigare skickades hela objektet → `OidcAuthProvider.find` kastade →
+  // boot:en fastnade tyst på "AVA Laddar…" eftersom denna väg lämnar
+  // trpcClient null, så fel-skärmen aldrig renderas.)
+  const { users } = await a.client.user.list.query();
   return finishOidcLogin({ needsOidc: a.needsOidc, oidcClaims: a.oidcClaims, users, setStatus: a.setStatus, setErrorMsg: a.setErrorMsg });
 }
 

--- a/src/lib/client/firma/firma-config.ts
+++ b/src/lib/client/firma/firma-config.ts
@@ -79,15 +79,18 @@ const DEMO_DEFAULT: FirmaConfig = {
  * export), eller cross-origin när dev-servern körs på `:3000` — `pickProvider`
  * + same-origin-detektor hanterar bägge.
  *
- * Default-org "firma-ab" matchar git-repo:t som docker startar (firma.git i
- * `tooling/docker/git-ssh`). Författar-identiteten är generisk; användaren
- * uppdaterar via `/settings`.
+ * Default-org matchar server-first-runtimens default `AVA_ORGANIZATION_ID`
+ * (server-first docker-stacken, #410/#626) så klientens in-process-queries
+ * (allowlist vid OIDC-login, data) scopar mot SAMMA org som servern seedar.
+ * (Det gamla "firma-ab" var git-tierns repo-namn, #500–502-pensionerat, och
+ * matchade aldrig en server-first-org — org-kolumnen är ett uuid.)
+ * Författar-identiteten är generisk; användaren uppdaterar via `/settings`.
  */
 const SELF_HOSTED_LOCALHOST_DEFAULT: FirmaConfig = {
   tier: "self-hosted",
   repo: "http://localhost:8080/git/firma.git",
   token: "",
-  organizationId: "firma-ab",
+  organizationId: "00000000-0000-0000-0000-000000000001",
   authorName: "Lokal användare",
   authorEmail: "user@firma.local",
 };

--- a/test/unit/components/bootstrap-self-hosted.test.tsx
+++ b/test/unit/components/bootstrap-self-hosted.test.tsx
@@ -4,6 +4,9 @@
  * injiceras så vi testar orkestreringen utan riktig server/IndexedDB:
  *   - happy path: bygger store + klient, anropar onStoreReady + ready
  *   - OIDC-first-login (ingen principalId): läser allowlisten ur storens klient
+ *   - #628: user.list returnerar `{ users }` (router-formen) → bind:en måste
+ *     skicka ARRAYEN till classify, inte hela objektet (annars kastar
+ *     OidcAuthProvider.find → boot fastnar tyst på "AVA Laddar…")
  *   - fel i store-bygget → error-status
  *   - avbruten (unmount) innan klar → ingen onStoreReady
  */
@@ -18,8 +21,12 @@ const baseConfig: FirmaConfig = {
 // Utan principalId → OIDC-first-login-grenen aktiveras.
 const { principalId: _omit, ...noPrincipal } = baseConfig;
 
-// Minimal fejk-store + fejk-klient (vi testar bara orkestreringen).
+// `user.list` returnerar router-formen `{ users }` (INTE en naken array) —
+// matchar produktionen så bind-shapen testas på riktigt.
 const fakeStore = { store: {} } as never;
+function clientReturning(users: unknown[]) {
+  return vi.fn(() => ({ user: { list: { query: vi.fn(async () => ({ users })) } } }) as never);
+}
 function makeArgs(over: Partial<Parameters<typeof bootstrapSelfHosted>[0]> = {}) {
   return {
     firmaConfig: baseConfig,
@@ -29,18 +36,24 @@ function makeArgs(over: Partial<Parameters<typeof bootstrapSelfHosted>[0]> = {})
     onStoreReady: vi.fn(),
     isCancelled: () => false,
     makeStore: vi.fn(async () => fakeStore),
-    makeClient: vi.fn(() => ({ user: { list: { query: vi.fn(async () => []) } } }) as never),
+    makeClient: clientReturning([]),
     ...over,
   };
 }
 
-// fetchOidcClaims (anropas bara i OIDC-grenen) → mocka bort nätverket.
+// Konfigurerbara OIDC-mocks (sätts per test).
+const fetchOidcClaims = vi.fn(async () => null);
+const classifyOidcLogin = vi.fn(() => ({ kind: "no-session" }) as unknown);
 vi.mock("@/lib/client/backend/oidc-principal", () => ({
-  fetchOidcClaims: vi.fn(async () => null),
-  classifyOidcLogin: vi.fn(() => ({ kind: "no-session" })),
+  fetchOidcClaims: (...a: unknown[]) => fetchOidcClaims(...(a as [])),
+  classifyOidcLogin: (...a: unknown[]) => classifyOidcLogin(...(a as [])),
 }));
 
-beforeEach(() => vi.clearAllMocks());
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchOidcClaims.mockResolvedValue(null);
+  classifyOidcLogin.mockReturnValue({ kind: "no-session" });
+});
 
 describe("bootstrapSelfHosted", () => {
   it("happy path: bygger store + klient, signalerar redo", async () => {
@@ -69,15 +82,26 @@ describe("bootstrapSelfHosted", () => {
   });
 
   it("OIDC-first-login (ingen principalId): frågar storens user.list", async () => {
-    const listQuery = vi.fn(async () => []);
+    const listQuery = vi.fn(async () => ({ users: [] }));
     const args = makeArgs({
       firmaConfig: noPrincipal as FirmaConfig,
       makeClient: vi.fn(() => ({ user: { list: { query: listQuery } } }) as never),
     });
     await bootstrapSelfHosted(args);
     expect(listQuery).toHaveBeenCalledTimes(1);
-    // no-session-utfall → går vidare till ready (ingen reload/deny).
     expect(args.onStoreReady).toHaveBeenCalled();
     expect(args.setStatus).toHaveBeenCalledWith("ready");
+  });
+
+  it("#628: skickar user.list-ARRAYEN (inte {users}-objektet) till classify", async () => {
+    fetchOidcClaims.mockResolvedValueOnce({ email: "lawyer@ava.test", subject: "", issuer: "", name: "" } as never);
+    const allowlist = [{ id: "u1", email: "lawyer@ava.test", name: "Lena", role: "LAWYER" }];
+    const args = makeArgs({
+      firmaConfig: noPrincipal as FirmaConfig,
+      makeClient: clientReturning(allowlist),
+    });
+    await bootstrapSelfHosted(args);
+    // Andra argumentet MÅSTE vara arrayen — inte `{ users: [...] }`.
+    expect(classifyOidcLogin).toHaveBeenCalledWith(expect.anything(), allowlist);
   });
 });

--- a/test/unit/lib/firma/firma-config.test.tsx
+++ b/test/unit/lib/firma/firma-config.test.tsx
@@ -45,7 +45,9 @@ describe("firma-config", () => {
       const cfg = loadFirmaConfig();
       expect(cfg.tier).toBe("self-hosted");
       expect(cfg.repo).toBe("http://localhost:8080/git/firma.git");
-      expect(cfg.organizationId).toBe("firma-ab");
+      // #628: org alignad med server-first-runtimens default AVA_ORGANIZATION_ID
+      // (klientens in-process-queries scopar mot samma org som servern seedar).
+      expect(cfg.organizationId).toBe("00000000-0000-0000-0000-000000000001");
     });
 
     it("returnerar sparad config", () => {

--- a/tooling/scripts/seed-selfhosted-local.ts
+++ b/tooling/scripts/seed-selfhosted-local.ts
@@ -1,18 +1,29 @@
 #!/usr/bin/env bun
 /**
- * Seed för den lokala self-hosted-stacken (#626) — skapar byrå-org:en +
- * allowlistade användare som matchar Keycloak-testrealm:ens emails, så att
- * OIDC-inloggningen (`lawyer@ava.test` / `admin@ava.test`) binder en principal
- * (server-context: forwardedClaims → users.listByOrg → OidcAuthProvider).
+ * Seed för den lokala self-hosted-stacken (#626/#628) — skapar byrå-org:en +
+ * allowlistade användare som matchar Keycloak-testrealm:ens emails.
  *
- * Idempotent: ON CONFLICT DO NOTHING. Kör efter `db:migrate`.
+ * KRITISKT (#628): seedas via REPO-lagret (`buildDrizzleRepositories` +
+ * change-log-recorder), INTE rå-SQL. Annars skrivs ingen `change_log`-rad →
+ * klientens `sync.pull` (ren change_log-delta, `seq > cursor`) levererar aldrig
+ * användarna → klient-sidans OIDC-first-login-allowlist blir tom → inloggningen
+ * hänger på "AVA Laddar…". Med repo-vägen får varje user en change_log-rad →
+ * pull:as till klienten → principalen kan bindas.
+ * (Server-SIDANS allowlist funkar oavsett: den läser users.listByOrg direkt.)
+ *
+ * Idempotent: hoppar org/användare som redan finns. Kör efter `db:migrate`.
  *
  *   AVA_DATABASE_URL=postgres://ava:ava@localhost:5433/ava_test \
  *   AVA_ORGANIZATION_ID=00000000-0000-0000-0000-000000000001 \
  *     bun tooling/scripts/seed-selfhosted-local.ts
  */
 
-import postgres from "postgres";
+import { createPostgresDb } from "@/lib/server/db/client";
+import { createDbChangeLogRecorder, enableChangeLogOnAll } from "@/lib/server/repositories/change-log-recorder";
+import { buildDrizzleRepositories } from "@/lib/server/repositories/drizzle-repositories";
+import { asId } from "@/lib/shared/schemas/ids";
+import type { Organization } from "@/lib/shared/schemas/organization";
+import type { User } from "@/lib/shared/schemas/user";
 import { uuidv7 } from "@/lib/shared/uuid";
 
 const DB_URL = process.env.AVA_DATABASE_URL ?? "postgres://ava:ava@localhost:5433/ava_test";
@@ -20,26 +31,37 @@ const ORG = process.env.AVA_ORGANIZATION_ID ?? "00000000-0000-0000-0000-00000000
 
 /** KC-realm:ens (realm-ava.json) allowlistade testanvändare. `outsider` seedas
  *  MEDVETET INTE → demonstrerar att autentiserad ≠ auktoriserad (nekas). */
-const USERS = [
+const USERS: ReadonlyArray<{ email: string; name: string; role: "LAWYER" | "ADMIN" }> = [
   { email: "lawyer@ava.test", name: "Lena Lawyer", role: "LAWYER" },
   { email: "admin@ava.test", name: "Alva Admin", role: "ADMIN" },
 ];
 
 async function main(): Promise<void> {
-  const sql = postgres(DB_URL, { max: 1, onnotice: () => {} });
+  const { db, close } = createPostgresDb(DB_URL);
+  // change-log-recorder PÅ → create() skriver både raden OCH en change_log-rad
+  // (det som gör users pull-bara till klienten).
+  const repos = buildDrizzleRepositories(db);
+  enableChangeLogOnAll(repos, createDbChangeLogRecorder(db));
   try {
-    await sql`INSERT INTO organizations (id, name) VALUES (${ORG}, ${"Demobyrå AB"})
-              ON CONFLICT (id) DO NOTHING`;
+    if (!(await repos.organizations.getById(ORG))) {
+      await repos.organizations.create({ id: asId<"OrganizationId">(ORG), name: "Demobyrå AB" } satisfies Partial<Organization>);
+    }
+    const existing = new Set((await repos.users.listByOrg(ORG)).map((u) => u.email));
     for (const u of USERS) {
-      const existing = await sql<Array<{ id: string }>>`SELECT id FROM users WHERE email = ${u.email} LIMIT 1`;
-      if (existing[0]) { console.log(`• ${u.email} finns redan`); continue; }
-      await sql`INSERT INTO users (id, organization_id, email, name, role, active)
-                VALUES (${uuidv7()}, ${ORG}, ${u.email}, ${u.name}, ${u.role}, ${true})`;
-      console.log(`✓ seedade ${u.email} (${u.role})`);
+      if (existing.has(u.email)) { console.log(`• ${u.email} finns redan`); continue; }
+      await repos.users.create({
+        id: asId<"UserId">(uuidv7()),
+        organizationId: asId<"OrganizationId">(ORG),
+        email: u.email,
+        name: u.name,
+        role: u.role,
+        active: true,
+      } satisfies Partial<User>);
+      console.log(`✓ seedade ${u.email} (${u.role}) + change_log → pull-bar`);
     }
     console.log(`✓ seed klar (org ${ORG}). 'outsider@ava.test' lämnas utanför allowlisten med flit.`);
   } finally {
-    await sql.end({ timeout: 5 });
+    await close();
   }
 }
 


### PR DESCRIPTION
Self-hosted (server-first) browser-login via OIDC fastnade på **"AVA Laddar…"** efter lyckad Keycloak-login. Upptäckt vid lokalt manuellt test (#626-runnern); verifierat end-to-end headless att fixen löser det.

## Rotorsak (tre samverkande buggar)
`bootstrapSelfHosted` → `bindOidcFirstLogin` band aldrig principalen klient-sidan → returnerade utan `onStoreReady` → `trpcClient` förblev null → `!trpcClient`-grinden visar "AVA Laddar…" (fel-skärmen lever i en gren som aldrig renderas).

1. **Fel form till matcharen** — `user.list.query()` returnerar `{ users }` (router-formen), men hela objektet skickades till `classifyOidcLogin` → `OidcAuthProvider.find(...)` på ett objekt → matchade aldrig. → plockar ut `.users`-arrayen. *(Befintligt test maskerade buggen: fejk-klienten returnerade en naken array, inte `{users}`. Uppdaterat + regr-test.)*
2. **Org-mismatch** — localhost-default-org var `"firma-ab"` (git-tier-arv) ≠ server-first-orgens uuid → in-process `user.list` (org-scopad) blev tom. → alignad med server-first `AVA_ORGANIZATION_ID`.
3. **Seed utan change_log** — `seed-selfhosted-local` rå-SQL:ade → ingen change_log → `sync.pull` (ren `seq>cursor`-delta) levererade aldrig användarna till klientens store. → seedar via repos (change_log-medvetet).

## Verifiering
- **Headless reproduktion + fix**: KC-login (lawyer/lawyer) → tidigare "AVA Laddar…" → nu full app-shell.
- Regr-test (`bootstrap-self-hosted.test.tsx`): `user.list` returnerar `{users}` → assert att **arrayen** (ej objektet) når `classify`.
- `firma-config.test`: localhost-default-org = server-uuid.
- Full svit **3179 tester, 0 fail**; typecheck + lint + knip + deps + jscpd gröna.

Closes #628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)