### PR TITLE
feat(tooling): seed demo-data into local server-first backend + fix matter-scoped sync (#630, #632)

### DIFF
--- a/src/lib/server/repositories/drizzle-expense-repository.ts
+++ b/src/lib/server/repositories/drizzle-expense-repository.ts
@@ -15,10 +15,16 @@ import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import type {
   ExpenseListOptions, ExpenseListResult, ExpenseListRow, ExpenseRepository, LawyerReportExpense,
 } from "./expense-repository";
+import { matterOrg } from "./matter-org";
 
 export class DrizzleExpenseRepository extends DrizzleRepository<Expense> implements ExpenseRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
     super(db, versionedTable(expenses), now);
+  }
+
+  /** expenses saknar org-kolumn → härled via ärendet (#528/#632) så change_log/pull funkar. */
+  protected override resolveOrg(row: unknown): Promise<string | undefined> {
+    return matterOrg(this.db, (row as { matterId?: string }).matterId);
   }
 
   async listForOrg(organizationId: string, opts: ExpenseListOptions): Promise<ExpenseListResult> {

--- a/src/lib/server/repositories/drizzle-matter-contact-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-contact-repository.ts
@@ -15,12 +15,18 @@ import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import type {
   ConflictContactRow, MatterContactRepository, MatterContactWithContact,
 } from "./matter-contact-repository";
+import { matterOrg } from "./matter-org";
 
 export class DrizzleMatterContactRepository
   extends DrizzleRepository<MatterContact>
   implements MatterContactRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
     super(db, versionedTable(matterContacts), now);
+  }
+
+  /** matter_contacts saknar org-kolumn → härled via ärendet (#528/#632) så change_log/pull funkar. */
+  protected override resolveOrg(row: unknown): Promise<string | undefined> {
+    return matterOrg(this.db, (row as { matterId?: string }).matterId);
   }
 
   async findForConflict(organizationId: string, numberTerm?: string): Promise<ConflictContactRow[]> {

--- a/src/lib/server/repositories/drizzle-repository.ts
+++ b/src/lib/server/repositories/drizzle-repository.ts
@@ -18,6 +18,7 @@
 
 import { and, eq, getTableName, isNull, type AnyColumn } from "drizzle-orm";
 import type { PgTable } from "drizzle-orm/pg-core";
+import { uuidv7 } from "@/lib/shared/uuid";
 import { ENTITY_NAME_BY_SOURCE_KEY } from "../data-store/in-memory/entity-source-keys";
 import type { AppDb } from "../db/types";
 import type { ChangeLogRecorder, ChangeOp } from "./change-log-recorder";
@@ -81,8 +82,12 @@ export class DrizzleRepository<Row extends RowBase> implements Repository<Row> {
   }
 
   async create(data: Partial<Row>): Promise<Row> {
+    // Klient-genererat id är normen (ADR 0003); server-genererade creates
+    // (demo-seed, framtida server-side-flöden) saknar id → generera ett uuidv7
+    // (uuid-PK:n har inget DB-default). Speglar in-memory-delegatens id-gen.
+    const id = (data as { id?: string }).id ?? uuidv7();
     const [row] = await this.db.insert(this.table)
-      .values({ ...data, version: 1 } as never).returning();
+      .values({ ...data, id, version: 1 } as never).returning();
     await this.logChange(row, "create");
     return this.asRow(row) as Row;
   }

--- a/src/lib/server/repositories/drizzle-time-entry-repository.ts
+++ b/src/lib/server/repositories/drizzle-time-entry-repository.ts
@@ -15,6 +15,7 @@ import { asId } from "@/lib/shared/schemas/ids";
 import { matters, timeEntries, users } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
+import { matterOrg } from "./matter-org";
 import type {
   LawyerReportTimeEntry, TimeEntryListFilter, TimeEntryListResult, TimeEntryListRow,
   TimeEntryReportFilter, TimeEntryReportRow, TimeEntryRepository, UnbilledTimeEntry,
@@ -35,6 +36,11 @@ function listWhere(organizationId: string, opts: TimeEntryListFilter) {
 export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> implements TimeEntryRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
     super(db, versionedTable(timeEntries), now);
+  }
+
+  /** time_entries saknar org-kolumn → härled via ärendet (#528/#632) så change_log/pull funkar. */
+  protected override resolveOrg(row: unknown): Promise<string | undefined> {
+    return matterOrg(this.db, (row as { matterId?: string }).matterId);
   }
 
   async listForOrg(organizationId: string, opts: TimeEntryListFilter): Promise<TimeEntryListResult> {

--- a/test/unit/server/repositories/drizzle-repositories.test.ts
+++ b/test/unit/server/repositories/drizzle-repositories.test.ts
@@ -42,6 +42,17 @@ describe("buildDrizzleRepositories — kontrakt (pglite)", () => {
     expect(await repos.organizations.getById(id)).toMatchObject({ id, name: "Aggregat AB" });
   });
 
+  it("create utan id → genererar ett uuid (server-genererad create, #630)", async () => {
+    const repos = buildDrizzleRepositories(handle.db);
+    const orgId = uuidv7();
+    await repos.organizations.create(org(orgId));
+    // Ingen `id` → repo:t ska generera ett uuidv7 (uuid-PK har inget DB-default).
+    const created = await repos.contacts.create({ organizationId: orgId, name: "Utan id", contactType: "PERSON" } as never);
+    const id = (created as { id?: string }).id;
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(await repos.contacts.getById(id!)).toMatchObject({ name: "Utan id" });
+  });
+
   it("transaction committar vid success", async () => {
     const repos = buildDrizzleRepositories(handle.db);
     const id = uuidv7();

--- a/test/unit/server/sync/drizzle-sync-store.test.ts
+++ b/test/unit/server/sync/drizzle-sync-store.test.ts
@@ -102,4 +102,27 @@ describe("DrizzleSyncStore (#sync-bridge)", () => {
     expect(changes.find((c) => c.row.id === folder)).toMatchObject({ entity: "documentFolder" });
     expect(changes.find((c) => c.row.id === doc)).toMatchObject({ entity: "document" });
   });
+
+  // #632: matter_contacts/time_entries/expenses saknar org-kolumn (samma form som
+  // document, #528) men missades — utan resolveOrg-override loggas de aldrig →
+  // ärendet visar inga kontakter/tid/utlägg trots att raderna finns server-side.
+  it("matterContact + timeEntry + expense delta-synkas via pull (org härledd ur ärendet, #632)", async () => {
+    const m4 = uuidv7(), contact = uuidv7(), link = uuidv7(), te = uuidv7(), exp = uuidv7(), user = uuidv7();
+    await repos.matters.create({ id: m4, organizationId: ORG, title: "Kontakt-synk", status: "ACTIVE", matterNumber: "2026-0012" } as never);
+    await repos.contacts.create({ id: contact, organizationId: ORG, name: "Klient AB", contactType: "ORGANIZATION" } as never);
+    const cursor = (await sync.pull(ORG, 0)).cursor;
+
+    await repos.matterContacts.create({ id: link, matterId: m4, contactId: contact, role: "KLIENT" } as never);
+    await repos.timeEntries.create({
+      id: te, matterId: m4, userId: user, date: new Date(), minutes: 60, description: "Möte", hourlyRate: 2000,
+    } as never);
+    await repos.expenses.create({
+      id: exp, matterId: m4, userId: user, date: new Date(), description: "Ansökningsavgift", amount: 900, kind: "DISBURSEMENT",
+    } as never);
+
+    const changes = (await sync.pull(ORG, cursor)).changes;
+    expect(changes.find((c) => c.row.id === link)).toMatchObject({ entity: "matterContact" });
+    expect(changes.find((c) => c.row.id === te)).toMatchObject({ entity: "timeEntry" });
+    expect(changes.find((c) => c.row.id === exp)).toMatchObject({ entity: "expense" });
+  });
 });

--- a/tooling/scripts/seed-demo-into-server.ts
+++ b/tooling/scripts/seed-demo-into-server.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env bun
+/**
+ * Populerar den lokala server-first-Postgres-backenden med DEMO-DATA (#630) via
+ * de riktiga tRPC-flödena — så self-hosted-appen visar en "full" byrå i st.f.
+ * en tom. Kör demo-generatorns populate-sekvens mot en in-process-caller bunden
+ * till Drizzle-repos:en (change-log PÅ → varje rad blir pull-bar till klienten)
+ * med en ADMIN-principal i SERVERNS org. Create-mutationerna org-scopar mot
+ * principalens org, så all data hamnar i `AVA_ORGANIZATION_ID` (samma org som
+ * klienten frågar + KC-användarna ligger i).
+ *
+ * Dokument hoppas i v1 (kräver content-store-port + binär-sink) — kärnan
+ * (ärenden/kontakter/tid/utlägg/kalender/uppgifter/mallar + faktureringsflöden)
+ * räcker för att se hur appen ser ut.
+ *
+ * ENGÅNGS: seed-id:n är fixa → kör mot en FÄRSK DB (annars id-krockar). Kör
+ * efter `seed-selfhosted-local.ts` (org + allowlist).
+ *
+ *   AVA_DATABASE_URL=postgres://ava:ava@localhost:5433/ava_test \
+ *   AVA_ORGANIZATION_ID=00000000-0000-0000-0000-000000000001 \
+ *     bun tooling/scripts/seed-demo-into-server.ts
+ */
+
+import { noopPorts } from "@/lib/server/adapters/noop-ports";
+import type { Principal } from "@/lib/server/auth/principal";
+import { buildContext } from "@/lib/server/build-context";
+import { createPostgresDb } from "@/lib/server/db/client";
+import { serverFirstEventLog } from "@/lib/server/http/server-context";
+import { createDbChangeLogRecorder, enableChangeLogOnAll } from "@/lib/server/repositories/change-log-recorder";
+import { buildDrizzleRepositories } from "@/lib/server/repositories/drizzle-repositories";
+import { appRouter } from "@/lib/server/routers/_app";
+import { asId } from "@/lib/shared/schemas/ids";
+import { createIdTranslator, translateSeed } from "../demo-generator/id-translator";
+import { populate } from "../demo-generator/populate";
+import { buildSeed } from "./seed-data";
+
+const DB_URL = process.env.AVA_DATABASE_URL ?? "postgres://ava:ava@localhost:5433/ava_test";
+const ORG = process.env.AVA_ORGANIZATION_ID ?? "00000000-0000-0000-0000-000000000001";
+
+async function main(): Promise<void> {
+  const { db, close } = createPostgresDb(DB_URL);
+  const repos = buildDrizzleRepositories(db);
+  enableChangeLogOnAll(repos, createDbChangeLogRecorder(db)); // → allt pull-bart
+  try {
+    // ADMIN-principal i serverns org. Återanvänd den allowlistade admin-användaren
+    // (seed-selfhosted-local) om den finns, annars en generator-identitet.
+    const admin = (await repos.users.listByOrg(ORG)).find((u) => u.role === "ADMIN");
+    const principal: Principal = {
+      id: admin?.id ?? asId<"UserId">("00000000-0000-0000-0000-0000000000a1"),
+      email: admin?.email ?? "generator@ava.local",
+      name: admin?.name ?? "Demo Generator",
+      role: "ADMIN",
+      organizationId: asId<"OrganizationId">(ORG),
+    };
+    const ctx = buildContext({ repos, eventLog: serverFirstEventLog, ports: noopPorts, principal });
+    const caller = appRouter.createCaller(ctx as never) as ReturnType<typeof appRouter.createCaller>;
+
+    // Slug-seed → UUID:er (samma som demo-generatorn/prod, ADR 0003). Org-/user-
+    // raderna skapas också, men create-mutationerna org-scopar mot PRINCIPALENS
+    // org (ORG), så allt hamnar i serverns org oavsett seedens org-fält.
+    const seed = translateSeed(buildSeed({}), createIdTranslator());
+
+    // v1: bara kärnentiteterna (org/users/contacts/matters/matter-contacts/
+    // tid/utlägg/kalender/uppgifter/mallar/jävskontroller). Fakturering +
+    // dokument hoppas — populateBilling synthesizar icke-uuid-id:n
+    // (`inv-<matterId>-acc`) som Postgres-uuid-kolumnen avvisar, och dokument
+    // kräver content-store-porten. Båda är uppföljning (#630).
+    const core = await populate(caller, seed);
+    console.log("✓ demo-data (kärna) seedad i server-first (org", ORG, "):", core);
+    console.log("  (fakturering + dokument hoppade i v1 — kräver uuid-id-coercion resp. content-store)");
+  } finally {
+    await close();
+  }
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`✗ seed-demo-into-server: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`);
+  process.exitCode = 1;
+});

--- a/tooling/scripts/selfhosted-local.sh
+++ b/tooling/scripts/selfhosted-local.sh
@@ -4,8 +4,9 @@
 # nginx (:8080) → statisk app + /api/trpc → server-first (Postgres) bakom
 # oauth2-proxy + Keycloak (:8089). Lämnas KÖRANDE (ingen teardown).
 #
-#   bash tooling/scripts/selfhosted-local.sh          # starta + lämna uppe
-#   bash tooling/scripts/selfhosted-local.sh --down   # riv ner
+#   bash tooling/scripts/selfhosted-local.sh          # starta (tom byrå) + lämna uppe
+#   bash tooling/scripts/selfhosted-local.sh --demo    # + fyll med demodata
+#   bash tooling/scripts/selfhosted-local.sh --down    # riv ner
 #
 # Login (Keycloak realm "ava"): lawyer/lawyer (allowlistad) · admin/admin ·
 # outsider/outsider (nekas — ej i allowlisten). Verifierad principal-bindning.
@@ -44,6 +45,11 @@ AVA_DATABASE_URL="$DB_URL" bun run db:migrate
 
 echo "▸ [5/6] Seedar org + allowlistade användare…"
 AVA_DATABASE_URL="$DB_URL" AVA_ORGANIZATION_ID="$AVA_ORGANIZATION_ID" bun tooling/scripts/seed-selfhosted-local.ts
+
+if [[ "${1:-}" == "--demo" ]]; then
+  echo "▸ [5b] Fyller byrån med demodata (ärenden/kontakter/tid/fakturering)…"
+  AVA_DATABASE_URL="$DB_URL" AVA_ORGANIZATION_ID="$AVA_ORGANIZATION_ID" bun tooling/scripts/seed-demo-into-server.ts
+fi
 
 echo "▸ [6/6] Väntar in Keycloak + web…"
 for _ in $(seq 1 40); do


### PR DESCRIPTION
Closes #630. Closes #632.

## What

`bun run selfhosted:local --demo` now populates the local server-first Postgres with **demo data** via the real tRPC populate flows, so the self-hosted app shows a realistic byrå instead of an empty one — and the seeded data now actually **shows inside a matter** (contacts/time/expenses), which exposed a latent sync bug (#632).

### Changes

- **`fix(repositories)` (#630)** — `DrizzleRepository.create` generates a `uuidv7` when no `id` is passed. Client-generated ids are the norm (ADR 0003), but server-generated creates (demo-seed, future server-side flows) have none and the uuid PK has no DB default → insert failed. Mirrors the in-memory delegate's id-gen.
- **`feat(tooling)` (#630)** — `seed-demo-into-server.ts` drives `appRouter.createCaller(ctx)` against a Drizzle-repos caller (change-log ON → every row pull-able) with an ADMIN principal in the server's org. `translateSeed` maps slug→UUIDv5. Wired behind `selfhosted-local.sh --demo`.
- **`fix(sync)` (#632)** — `matter_contacts`, `time_entries`, `expenses` are matter-scoped tables with **no `organization_id` column** (same shape as document/documentFolder, #528) but were missed. Without a `resolveOrg` override, `DrizzleRepository.logChange` can't derive an org → the rows are never appended to `change_log` → `sync.pull` never delivers them → **a matter shows no contacts/time/expenses despite the rows existing server-side**. Added the same `resolveOrg` override (via `matterOrg`) to all three repos, mirroring `DrizzleDocumentRepository`.

## v1 scope / follow-up

Seed: core entities only — billing + documents skipped (`populateBilling` synthesizes non-UUID ids; documents need the content-store port). `conflict_checks` sync (org via `checked_by_id`, not a matter) is a noted follow-up.

## Verification

- Full local gate green: typecheck (fresh, no tsbuildinfo) · lint · `test:cov` 3177 pass / 0 fail, coverage src/ lines 92.82% (floor 90.00%), funcs 87.54% (floor 85.90%) · jscpd exit 0 · dep-cruiser clean · knip clean.
- New `#632` test in `drizzle-sync-store.test.ts`: matterContact/timeEntry/expense delta-sync via pull (org derived from matter).
- End-to-end on the live local stack: truncated + re-seeded with fixed code → `change_log` now contains matterContact=50, timeEntry=75, expense=37 (previously absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)