### PR TITLE
fix(sync): re-bake relations-joins after reconcile (#633)

### DIFF
--- a/src/lib/server/data-store/in-memory/caching-sync-data-store.ts
+++ b/src/lib/server/data-store/in-memory/caching-sync-data-store.ts
@@ -22,7 +22,7 @@
  * kommer från en cachad session (D2/ADR 0018, `CachedSessionAuthProvider`).
  */
 
-import type { DemoSource } from "@/lib/shared/demo-source";
+import { type DemoSource, prebakeJoins } from "@/lib/shared/demo-source";
 import type { CursorStore } from "./cursor-store";
 import { InMemoryCursorStore } from "./cursor-store";
 import { SOURCE_KEY_BY_ENTITY } from "./entity-source-keys";
@@ -146,9 +146,27 @@ export class CachingSyncDataStore {
   async reconcile(): Promise<ReconcileResult> {
     const result = await this.engine.reconcile();
     if (result.pulled > 0 || result.pushed > 0 || result.rebased > 0) {
+      this.rebakeJoins();
       await this.persistSnapshot();
     }
     return result;
+  }
+
+  /**
+   * Re-baka relations-joins (#633) på source efter en reconcile. `apply`/
+   * `writeCanonical` skriver RÅA kanoniska server-rader (matterContact utan
+   * `.contact`, timeEntry utan `.matter`, …) — men UI:t/routrarna förlitar sig
+   * på de förbakade join-fälten (samma som demo-vägens `prebakeJoins` vid
+   * laddning), och query-motorns nested-include täcker inte alla dessa relationer
+   * (t.ex. `matters.contacts.contact`). Lokala mutationer bakas redan via
+   * `LocalStore.enrichRowForEntity`; bara pullade rader är råa. `prebakeJoins`
+   * är en ren `DemoSource → DemoSource` och idempotent → skriv tillbaka varje
+   * bakad array in-place så `getSource`-closuren (LocalStore) ser dem.
+   */
+  private rebakeJoins(): void {
+    const src = this.store.currentSource as Record<string, unknown>;
+    const baked = prebakeJoins(this.store.currentSource) as Record<string, unknown>;
+    for (const key of Object.keys(baked)) src[key] = baked[key];
   }
 
   /** Antal ej-synkade (köade) mutationer. */

--- a/test/unit/server/data-store/caching-sync-data-store.test.ts
+++ b/test/unit/server/data-store/caching-sync-data-store.test.ts
@@ -9,6 +9,7 @@ import { CachingSyncDataStore, noSyncTransport } from "@/lib/server/data-store/i
 import { InMemoryPersistence } from "@/lib/server/data-store/in-memory/local-store-persistence";
 import type { QueuedMutation } from "@/lib/server/data-store/in-memory/mutation-queue";
 import type { PullResult, PushResult, SyncTransport } from "@/lib/server/data-store/in-memory/sync-transport";
+import { InMemoryMatterRepository } from "@/lib/server/repositories/in-memory-matter-repository";
 import { uuidv7 } from "@/lib/shared/uuid";
 
 class FakeTransport implements SyncTransport {
@@ -100,6 +101,49 @@ describe("CachingSyncDataStore (#415)", () => {
       await ds.reconcile();
 
       expect(await ds.store.matters.findUnique({ where: { id: m1 } })).toBeNull();
+    });
+  });
+
+  // #633: synk-vägen levererar RÅA rader (writeCanonical), men demo-vägen
+  // pre-bakar joins (prebakeJoins) → matterContact.contact mm. UI:t (matter-
+  // detalj `include: { contact: true }`) förlitar sig på den bakade joinen
+  // (matters.contacts-relationen saknar nested contact). Utan prebake på pull
+  // visas "(kontakt saknas)". Reconcile måste re-baka source efter apply.
+  describe("join-prebake på pull (server-first-paritet, #633)", () => {
+    it("pullade matterContacts får bakad contact → matter-detalj resolver namnet", async () => {
+      const mId = uuidv7(), cId = uuidv7(), mcId = uuidv7();
+      const transport = new FakeTransport();
+      transport.pullResult = {
+        changes: [
+          { entity: "matter", row: matter(mId) },
+          { entity: "contact", row: { id: cId, organizationId: ORG, name: "Anna Andersson", contactType: "PERSON" } },
+          { entity: "matterContact", row: { id: mcId, matterId: mId, contactId: cId, role: "KLIENT" } },
+        ],
+        cursor: 10,
+      };
+      const ds = await CachingSyncDataStore.create({ transport, persistence: new InMemoryPersistence() });
+      await ds.reconcile();
+
+      const detail = await new InMemoryMatterRepository(ds.store).getByIdWithContacts(mId, ORG);
+      expect(detail?.contacts).toHaveLength(1);
+      expect(detail?.contacts[0]?.contact?.name).toBe("Anna Andersson");
+    });
+
+    it("pullade timeEntries får bakad matter (te.matter.title resolver)", async () => {
+      const mId = uuidv7(), teId = uuidv7();
+      const transport = new FakeTransport();
+      transport.pullResult = {
+        changes: [
+          { entity: "matter", row: matter(mId, "Vårdnadstvist") },
+          { entity: "timeEntry", row: { id: teId, organizationId: ORG, matterId: mId, minutes: 60, billable: true, hourlyRate: 2000 } },
+        ],
+        cursor: 11,
+      };
+      const ds = await CachingSyncDataStore.create({ transport, persistence: new InMemoryPersistence() });
+      await ds.reconcile();
+
+      const te = await ds.store.timeEntries.findFirst({ where: { id: teId } }) as { matter?: { title?: string } } | null;
+      expect(te?.matter?.title).toBe("Vårdnadstvist");
     });
   });
 


### PR DESCRIPTION
Closes #633.

## Problem

After seeding demo data into the local server-first backend, a matter showed its contacts as **"(kontakt saknas)"** — links present, names never resolving.

## Root cause

The demo path runs `prebakeJoins` on the `DemoSource` at load (bakes `matterContact.contact`/`.matter`, `document/timeEntry/expense/invoice.matter`). The UI/routers rely on those pre-baked fields, and the in-memory query engine does **not** resolve `matters.contacts.contact` (that relation has no nested config). The server-first sync path (`CachingSyncDataStore.writeCanonical`) writes the **raw** canonical rows from `sync.pull` — never prebaked → `matterContact.contact` undefined → "(kontakt saknas)". Local mutations were fine (`enrichRowForEntity`); only pulled rows were raw.

## Fix

Re-bake joins after each reconcile in `CachingSyncDataStore.reconcile()`. `prebakeJoins` is a pure, idempotent `DemoSource → DemoSource`; write the baked arrays back in-place so the `getSource` closure sees them. One place, restores demo parity for **all** join-dependent reads (contacts, `timeEntry.matter`, etc.).

## Verification

- TDD: two new `caching-sync-data-store.test.ts` cases drive the real reconcile and assert `matter.contacts.contact` and `timeEntry.matter` resolve (red before, green after).
- Live: authenticated crawl of the running self-hosted stack — matter detail now shows all contacts (names + personnr/orgnr), no "(kontakt saknas)".
- Gate green: typecheck (fresh) · lint · `test:cov` 0 fail, coverage src/ lines 92.82% (floor 90.00%) / funcs 87.54% (floor 85.90%) · jscpd exit 0 · dep-cruiser clean · knip clean.

## Audit findings (separate, NOT in this PR)

A full authenticated crawl of all routes found every page renders without crashes. Remaining non-bugs / design decisions:
- **Empty dashboard / "my time" / todo** — demo data owned by demo users (`@firma.local`), login is `lawyer@ava.test` → user-scoped views empty; seed dated Jan–Jun 17 so "today" empty. Needs an identity/ownership decision.
- **Documents / billing / invoices / payments empty** — not seeded (v1 content-store + non-UUID-id skips, #630).
- **"Inloggad som @okänd" banner** — `AuthStatusBanner` reads legacy GitHub `user.login`; cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)