### PR TITLE
feat(tooling): local demo login users own data + today entry (#635)

### DIFF
--- a/tooling/scripts/seed-demo-into-server.ts
+++ b/tooling/scripts/seed-demo-into-server.ts
@@ -27,14 +27,63 @@ import { createPostgresDb } from "@/lib/server/db/client";
 import { serverFirstEventLog } from "@/lib/server/http/server-context";
 import { createDbChangeLogRecorder, enableChangeLogOnAll } from "@/lib/server/repositories/change-log-recorder";
 import { buildDrizzleRepositories } from "@/lib/server/repositories/drizzle-repositories";
+import type { Repositories } from "@/lib/server/repositories/repositories";
 import { appRouter } from "@/lib/server/routers/_app";
 import { asId } from "@/lib/shared/schemas/ids";
+import { uuidv7 } from "@/lib/shared/uuid";
 import { createIdTranslator, translateSeed } from "../demo-generator/id-translator";
 import { populate } from "../demo-generator/populate";
 import { buildSeed } from "./seed-data";
 
 const DB_URL = process.env.AVA_DATABASE_URL ?? "postgres://ava:ava@localhost:5433/ava_test";
 const ORG = process.env.AVA_ORGANIZATION_ID ?? "00000000-0000-0000-0000-000000000001";
+
+/** KC-realm:ens allowlistade login-emails (realm-ava.json). */
+const LOGIN_ADMIN_EMAIL = "admin@ava.test";
+const LOGIN_LAWYER_EMAIL = "lawyer@ava.test";
+
+type Row = Record<string, unknown>;
+
+/**
+ * Mappa demons huvud-admin + en huvud-jurist till KC-login-emailen (#633-uppf.):
+ * så OIDC-login binder till en user som ÄGER data (matters/tid/uppgifter) →
+ * dashboarden/"min tid"/todo fylls. Utan detta äger demo-användarna
+ * (@firma.local) all data medan login:en (lawyer@ava.test) äger ingenting.
+ * Returnerar de mappade rad-id:na (för "idag"-tidposterna nedan).
+ */
+function remapLoginUsers(users: Row[]): { adminId: string | undefined; lawyerId: string | undefined } {
+  const admin = users.find((u) => u.role === "ADMIN");
+  const lawyer = users.find((u) => u.role === "LAWYER");
+  if (admin) admin.email = LOGIN_ADMIN_EMAIL;
+  if (lawyer) lawyer.email = LOGIN_LAWYER_EMAIL;
+  return { adminId: admin?.id as string | undefined, lawyerId: lawyer?.id as string | undefined };
+}
+
+/**
+ * Lägg en "idag"-tidpost per login-user på ett ärende de redan arbetat i
+ * (#633-uppf., B): seedens tidposter är alla ≥3 dagar gamla → dashboardens
+ * dagsvy ("Idag") blir annars tom. Tasks/kalender landar redan på idag via
+ * seedens offset-logik, så bara tid behöver kompletteras.
+ */
+async function addTodayTimeEntries(repos: Repositories, timeEntries: Row[], ids: { adminId: string | undefined; lawyerId: string | undefined }): Promise<void> {
+  const tes = timeEntries;
+  for (const userId of [ids.lawyerId, ids.adminId]) {
+    if (!userId) continue;
+    const matterId = (tes.find((t) => t.userId === userId)?.matterId) as string | undefined;
+    if (!matterId) continue;
+    await repos.timeEntries.create({
+      id: asId<"TimeEntryId">(uuidv7()),
+      organizationId: asId<"OrganizationId">(ORG),
+      userId: asId<"UserId">(userId),
+      matterId: asId<"MatterId">(matterId),
+      date: new Date(),
+      minutes: 60,
+      description: "Löpande arbete (idag)",
+      billable: true,
+      hourlyRate: 220_000,
+    } as never);
+  }
+}
 
 async function main(): Promise<void> {
   const { db, close } = createPostgresDb(DB_URL);
@@ -59,13 +108,18 @@ async function main(): Promise<void> {
     // org (ORG), så allt hamnar i serverns org oavsett seedens org-fält.
     const seed = translateSeed(buildSeed({}), createIdTranslator());
 
+    // Mappa demons admin + huvud-jurist till KC-login-emailen → login äger data.
+    const loginIds = remapLoginUsers(seed.users as Row[]);
+
     // v1: bara kärnentiteterna (org/users/contacts/matters/matter-contacts/
     // tid/utlägg/kalender/uppgifter/mallar/jävskontroller). Fakturering +
     // dokument hoppas — populateBilling synthesizar icke-uuid-id:n
     // (`inv-<matterId>-acc`) som Postgres-uuid-kolumnen avvisar, och dokument
     // kräver content-store-porten. Båda är uppföljning (#630).
     const core = await populate(caller, seed);
+    await addTodayTimeEntries(repos, seed.timeEntries as Row[], loginIds); // "idag"-tid för dashboarden
     console.log("✓ demo-data (kärna) seedad i server-first (org", ORG, "):", core);
+    console.log(`  login: ${LOGIN_LAWYER_EMAIL} + ${LOGIN_ADMIN_EMAIL} äger nu data (+ idag-tidpost)`);
     console.log("  (fakturering + dokument hoppade i v1 — kräver uuid-id-coercion resp. content-store)");
   } finally {
     await close();

--- a/tooling/scripts/seed-selfhosted-local.ts
+++ b/tooling/scripts/seed-selfhosted-local.ts
@@ -46,6 +46,13 @@ async function main(): Promise<void> {
     if (!(await repos.organizations.getById(ORG))) {
       await repos.organizations.create({ id: asId<"OrganizationId">(ORG), name: "Demobyrå AB" } satisfies Partial<Organization>);
     }
+    // --demo (#633-uppf.): demo-seeden mappar sin admin + huvud-jurist till
+    // KC-login-emailen (admin@/lawyer@ava.test) och ÄGER datan → skapa INTE
+    // separata tomma allowlist-users här (skulle ge dubbletter på samma email).
+    if (process.env.SEED_ORG_ONLY === "1") {
+      console.log(`✓ org ${ORG} klar (SEED_ORG_ONLY — allowlist-users kommer från demo-seeden).`);
+      return;
+    }
     const existing = new Set((await repos.users.listByOrg(ORG)).map((u) => u.email));
     for (const u of USERS) {
       if (existing.has(u.email)) { console.log(`• ${u.email} finns redan`); continue; }

--- a/tooling/scripts/selfhosted-local.sh
+++ b/tooling/scripts/selfhosted-local.sh
@@ -43,12 +43,17 @@ echo "▸ [3/6] Startar stacken (postgres + server-first + keycloak + oauth2-pro
 echo "▸ [4/6] Migrerar schemat…"
 AVA_DATABASE_URL="$DB_URL" bun run db:migrate
 
-echo "▸ [5/6] Seedar org + allowlistade användare…"
-AVA_DATABASE_URL="$DB_URL" AVA_ORGANIZATION_ID="$AVA_ORGANIZATION_ID" bun tooling/scripts/seed-selfhosted-local.ts
-
 if [[ "${1:-}" == "--demo" ]]; then
-  echo "▸ [5b] Fyller byrån med demodata (ärenden/kontakter/tid/fakturering)…"
+  # --demo: skapa bara org:en här — demo-seeden mappar sin admin + huvud-jurist
+  # till KC-login-emailen (admin@/lawyer@ava.test) och äger datan (dashboarden
+  # fylls för den inloggade). Separata allowlist-users skulle bli dubbletter.
+  echo "▸ [5/6] Seedar org (login-users kommer från demodatan)…"
+  SEED_ORG_ONLY=1 AVA_DATABASE_URL="$DB_URL" AVA_ORGANIZATION_ID="$AVA_ORGANIZATION_ID" bun tooling/scripts/seed-selfhosted-local.ts
+  echo "▸ [5b] Fyller byrån med demodata (ärenden/kontakter/tid/uppgifter…)…"
   AVA_DATABASE_URL="$DB_URL" AVA_ORGANIZATION_ID="$AVA_ORGANIZATION_ID" bun tooling/scripts/seed-demo-into-server.ts
+else
+  echo "▸ [5/6] Seedar org + allowlistade användare…"
+  AVA_DATABASE_URL="$DB_URL" AVA_ORGANIZATION_ID="$AVA_ORGANIZATION_ID" bun tooling/scripts/seed-selfhosted-local.ts
 fi
 
 echo "▸ [6/6] Väntar in Keycloak + web…"


### PR DESCRIPTION
Closes #635.

## Problem

In the local server-first demo, all seeded data is owned by demo-generated users (`@firma.local`), but OIDC login is `lawyer@ava.test` / `admin@ava.test` — who own nothing. User-scoped views (dashboard, "my time", todo) filter by the principal id → empty. Seeded time entries are also all ≥3 days old, so the dashboard's default "Idag" view is empty even for data owners.

## Fix

- `seed-demo-into-server.ts`: after `translateSeed`, remap the demo's main ADMIN (Anna) → `admin@ava.test` and main LAWYER (Björn) → `lawyer@ava.test` so OIDC login binds to a data-owning user; add one "today" time entry per login user (tasks/events already land on today via the seed's per-user offset logic).
- `seed-selfhosted-local.ts`: `SEED_ORG_ONLY=1` skips creating the separate empty allowlist users (the demo provides them now) → no duplicate emails.
- `selfhosted-local.sh --demo`: seeds org-only, then the demo.

## Verification

Live: logging in as `lawyer@ava.test` (binds to Björn Bauer) shows a populated dashboard — **Att göra (2)** today's tasks, **Tidrapportering (1:00)** today's entry, **Senaste ärenden** with 5 matters. DB: each login user owns 16 time entries / 16 tasks / 1 today entry; no duplicate emails. typecheck + lint clean.

Tooling-only (no `src/` change); verified end-to-end against the running stack rather than unit-tested (these are integration seed scripts).

> Note: depends on the contacts-prebake fix (#633 / PR #634) for matter contacts to render; that's a separate PR. Documents + billing seeding are the remaining #630 follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)