### PR TITLE
feat(capabilities): descriptor + hide server-only affordance in demo (#639)

### DIFF
--- a/src/components/documents/_document-row.tsx
+++ b/src/components/documents/_document-row.tsx
@@ -3,6 +3,7 @@
 import { Trash2 } from "lucide-react";
 import { Fragment, useState } from "react";
 import { ActionMenu, type ActionMenuItem } from "@/components/ui/action-menu";
+import { useCapabilities } from "@/lib/client/capabilities/use-capabilities";
 import type { OpenDocumentDeps } from "@/lib/client/firma/open-document";
 import { readFromFsa } from "@/lib/client/fsa/read-from-fsa";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
@@ -182,6 +183,8 @@ interface ActionItemsOpts {
   viewHref: string;
   downloadHref: string;
   uploadingTitle: string | undefined;
+  /** LLM-kapabilitet (ADR 0027): false (demon) → "Analysera (AI)" döljs. */
+  llm: boolean;
   onOpenInEditor: () => void;
   onExternal: () => void;
   onReanalyze: () => void;
@@ -196,7 +199,10 @@ function buildActionItems(o: ActionItemsOpts): ActionMenuItem[] {
     { key: "external", label: "Editera externt (PDF Gear, Preview…)", icon: <span aria-hidden>🖥</span>, onSelect: o.onExternal, disabled: o.isDisabled, title: o.uploadingTitle ?? "AVA committar dina ändringar automatiskt" },
     { key: "view", label: "Visa", icon: <span aria-hidden>👁</span>, href: o.viewHref, newTab: true, disabled: o.isDisabled, title: o.uploadingTitle ?? "Visa i webbläsaren" },
     { key: "download", label: "Ladda ner", icon: <span aria-hidden>⬇</span>, href: o.downloadHref, download: true, disabled: o.isDisabled, title: o.uploadingTitle ?? "Ladda ner" },
-    { key: "reanalyze", label: "Analysera (AI)", icon: <span aria-hidden>🧠</span>, onSelect: o.onReanalyze, disabled: o.isDisabled || o.reanalyzePending, title: o.uploadingTitle ?? "Kör AI-analys på nytt" },
+    // ADR 0027: LLM-analys är en server-förmåga → dölj affordansen utan den.
+    ...(o.llm
+      ? [{ key: "reanalyze", label: "Analysera (AI)", icon: <span aria-hidden>🧠</span>, onSelect: o.onReanalyze, disabled: o.isDisabled || o.reanalyzePending, title: o.uploadingTitle ?? "Kör AI-analys på nytt" }]
+      : []),
     omitUndefined({ key: "delete", label: "Ta bort", icon: <Trash2 size={15} />, onSelect: o.onDelete, danger: true, disabled: o.isDisabled, title: o.uploadingTitle }) as ActionMenuItem,
   ];
 }
@@ -245,8 +251,9 @@ function DocumentActions({
 
   const isDisabled = !!disabled;
   const uploadingTitle = isDisabled ? "Vänta tills uppladdningen är klar" : undefined;
+  const { llm } = useCapabilities();
   const items = buildActionItems({
-    isDisabled, reanalyzePending, viewHref, downloadHref, uploadingTitle,
+    isDisabled, reanalyzePending, viewHref, downloadHref, uploadingTitle, llm,
     onOpenInEditor: () => void openInEditor(),
     onExternal: () => void onExternalEdit(),
     onReanalyze, onDelete,

--- a/src/lib/client/capabilities/use-capabilities.ts
+++ b/src/lib/client/capabilities/use-capabilities.ts
@@ -1,0 +1,16 @@
+"use client";
+
+/**
+ * `useCapabilities` (ADR 0027 / #639) — vad den aktiva runtimen kan, för
+ * UI-gating. Slice 1: härleds ur `firma-config.tier`. Nästa slice byter detta
+ * mot en server-annonserad `system.capabilities`-probe — konsumenterna
+ * (`useCapabilities()`-anropen) ändras inte, bara resolvern här.
+ */
+
+import { useMemo } from "react";
+import { loadFirmaConfig } from "@/lib/client/firma/firma-config";
+import { capabilitiesForTier, type Capabilities } from "@/lib/shared/capabilities";
+
+export function useCapabilities(): Capabilities {
+  return useMemo(() => capabilitiesForTier(loadFirmaConfig().tier), []);
+}

--- a/src/lib/shared/capabilities.ts
+++ b/src/lib/shared/capabilities.ts
@@ -1,0 +1,42 @@
+/**
+ * `Capabilities` (ADR 0027) — kapabilitets-tier för den kapabilitets-tierade
+ * klienten: SAMMA web-app, men funktionsuppsättningen avgörs vid bootstrap av
+ * vad runtimen kan. Server-beroende förmågor är PÅ i self-hosted (det finns en
+ * server) och AV i demon (ingen server). UI:t gate:ar på dessa flaggor —
+ * ALDRIG på `if (isDemo)` — så demo och server-väg inte kan driva isär.
+ *
+ * Slice 1 (#639) härleder tiern ur `firma-config.tier`. Nästa slice byter
+ * resolvern mot en server-annonserad `system.capabilities`-probe (ADR 0027
+ * beslut 1) — konsumenterna rörs inte, bara hur deskriptorn fylls.
+ */
+
+/** Vad den aktiva runtimen kan. Server-beroende förmågor = false i demon. */
+export interface Capabilities {
+  /** Synk mot en server-auktoritativ backend (annars cache-lokal). */
+  sync: boolean;
+  /** LLM-dokumentanalys / etikett-förslag (server-jobb, ADR 0024). */
+  llm: boolean;
+  /** Durabel server-jobbkö. */
+  jobs: boolean;
+  /** Ledger-/Fortnox-connector (ADR 0011). */
+  ledger: boolean;
+  /** E-post-/kalender-spegling. */
+  mailSync: boolean;
+  /** Server-OIDC-auth (annars demo-principal). */
+  oidc: boolean;
+}
+
+/** Demon: ingen server → alla server-beroende förmågor av. */
+export const DEMO_CAPABILITIES: Capabilities = {
+  sync: false, llm: false, jobs: false, ledger: false, mailSync: false, oidc: false,
+};
+
+/** Self-hosted: en server finns → alla förmågor på (förfinas av probe i nästa slice). */
+export const SELF_HOSTED_CAPABILITIES: Capabilities = {
+  sync: true, llm: true, jobs: true, ledger: true, mailSync: true, oidc: true,
+};
+
+/** Härled kapabiliteterna ur deploy-tiern (slice 1; ersätts av server-probe). */
+export function capabilitiesForTier(tier: "demo" | "self-hosted"): Capabilities {
+  return tier === "self-hosted" ? SELF_HOSTED_CAPABILITIES : DEMO_CAPABILITIES;
+}

--- a/test/unit/components/document-browser.test.tsx
+++ b/test/unit/components/document-browser.test.tsx
@@ -193,6 +193,21 @@ describe("DocumentBrowser", () => {
     expect(screen.getByText("Ta bort")).toBeInTheDocument();
   });
 
+  it("döljer 'Analysera (AI)' i demo-tier (LLM-kapabilitet saknas, ADR 0027)", () => {
+    // demo-tier → capabilities.llm = false → analys-affordansen renderas inte.
+    window.localStorage.setItem("ava.firma", JSON.stringify({ tier: "demo", repo: "u/r" }));
+    try {
+      treeQuery.data = { folders: [], documents: [baseDoc()] };
+      render(<DocumentBrowser matterId="m1" />);
+      fireEvent.click(screen.getByLabelText("Dokumentåtgärder"));
+      expect(screen.getByText("Visa")).toBeInTheDocument(); // övriga finns kvar
+      expect(screen.getByText("Ta bort")).toBeInTheDocument();
+      expect(screen.queryByText(/Analysera/)).not.toBeInTheDocument();
+    } finally {
+      window.localStorage.removeItem("ava.firma"); // återställ jsdom-default (self-hosted)
+    }
+  });
+
   it("submittar Ny mapp-formuläret med mappnamn", () => {
     render(<DocumentBrowser matterId="m1" />);
     fireEvent.click(screen.getByRole("button", { name: /\+ Ny mapp/i }));

--- a/test/unit/lib/capabilities.test.ts
+++ b/test/unit/lib/capabilities.test.ts
@@ -1,0 +1,24 @@
+/**
+ * `capabilitiesForTier` (ADR 0027 / #639) — server-beroende förmågor är AV i
+ * demon, PÅ i self-hosted.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { capabilitiesForTier, DEMO_CAPABILITIES, SELF_HOSTED_CAPABILITIES } from "@/lib/shared/capabilities";
+
+describe("capabilitiesForTier (ADR 0027)", () => {
+  it("demo → alla server-beroende förmågor av", () => {
+    expect(capabilitiesForTier("demo")).toEqual(DEMO_CAPABILITIES);
+    expect(Object.values(DEMO_CAPABILITIES).every((v) => v === false)).toBe(true);
+  });
+
+  it("self-hosted → alla förmågor på", () => {
+    expect(capabilitiesForTier("self-hosted")).toEqual(SELF_HOSTED_CAPABILITIES);
+    expect(Object.values(SELF_HOSTED_CAPABILITIES).every((v) => v === true)).toBe(true);
+  });
+
+  it("llm-flaggan styr den enda demo-dolda affordansen i slice 1", () => {
+    expect(capabilitiesForTier("demo").llm).toBe(false);
+    expect(capabilitiesForTier("self-hosted").llm).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #639. First slice of ADR 0027 (capability-tiered client).

## What

- `src/lib/shared/capabilities.ts` — `Capabilities` descriptor + `DEMO_CAPABILITIES` / `SELF_HOSTED_CAPABILITIES` + `capabilitiesForTier(tier)`.
- `useCapabilities()` client hook.
- **Consumer (ADR 0027 "hidden" rule):** the document **"Analysera (AI)"** action is gated on `capabilities.llm` → hidden in demo, present in self-hosted. The UI gates on the *capability*, never `if (isDemo)` — the discipline that structurally prevents the demo↔server divergence behind #633.

## Deferred (next slices, noted in the issue)

- **Probe** (the chosen detection): this slice derives capabilities from `firma-config.tier`; the server-advertised `system.capabilities` probe is next. `useCapabilities` is the swap point — consumers don't change.
- Principal switcher / retire `useAuthMode`, blob-cache in demo, gating remaining server-only affordances.

## Verification

- New `capabilities.test.ts` (tier → flags). New demo-tier test in `document-browser.test.tsx` asserts "Analysera (AI)" is hidden; the existing self-hosted test still asserts it's present.
- Gate green: typecheck (fresh) · lint · `test:cov` 0 fail, coverage src/ lines 92.82% (floor 90.00%) / funcs 87.55% (floor 85.90%) · knip · dep-cruiser · jscpd all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)