### PR TITLE
feat(capabilities): hide server-only integrations in demo (#643)

### DIFF
--- a/src/components/settings/integrations-section.tsx
+++ b/src/components/settings/integrations-section.tsx
@@ -12,14 +12,19 @@
 
 import { Plug } from "lucide-react";
 import { useEffect, useState } from "react";
+import { useCapabilities } from "@/lib/client/capabilities/use-capabilities";
 import "@/lib/client/integrations/office365-connector"; // ⚠ side-effect: registrerar
 import { listConnectors } from "@/lib/client/integrations/registry";
 import type { ConnectionStatus, IntegrationConnector } from "@/lib/client/integrations/types";
 
 export function IntegrationsSection() {
+  const caps = useCapabilities();
   const [connectors] = useState(() => listConnectors());
 
   if (connectors.length === 0) return null;
+  // ADR 0027: externa tjänst-anslutningar (mejl/kalender/ledger) kräver en
+  // server → dölj affordansen i demon (capabilities.mailSync/ledger = false).
+  if (!caps.mailSync && !caps.ledger) return null;
 
   return (
     <div className="bg-white border border-gray-200 rounded-lg p-5 mb-5">

--- a/test/unit/components/integrations-section.test.tsx
+++ b/test/unit/components/integrations-section.test.tsx
@@ -41,6 +41,16 @@ describe("IntegrationsSection", () => {
     expect(container.firstChild).toBeNull();
   });
 
+  it("döljs i demo-tier (inga server-integrationer, ADR 0027)", () => {
+    window.localStorage.setItem("ava.firma", JSON.stringify({ tier: "demo", repo: "u/r" }));
+    try {
+      const { container } = render(<IntegrationsSection />);
+      expect(container.firstChild).toBeNull();
+    } finally {
+      window.localStorage.removeItem("ava.firma");
+    }
+  });
+
   it("visar connector med namn + capabilities + 'Ej ansluten'", () => {
     render(<IntegrationsSection />);
     expect(screen.getByText("Microsoft 365")).toBeInTheDocument();


### PR DESCRIPTION
Closes #643. ADR 0027 slice 3.

Gate `IntegrationsSection` (Fortnox/Office365 external-service connectors) on the integration capabilities (`mailSync`/`ledger`) → **hidden in demo** (no server to back them), shown in self-hosted. UI gates on the capability, not `if (isDemo)`.

Jobs and sync are deliberately **not** gated — the demo runs client-side job workers + loopback sync (ADR 0025), so those aren't purely server-only.

New demo-tier test asserts the section renders null; existing self-hosted tests still assert it renders. Gate green (typecheck/lint/test:cov/knip/dep-cruiser/jscpd).

Builds on #639 (descriptor) + #641 (probe). Remaining: principal switcher (retire `useAuthMode`/"@okänd"), demo blob-cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)