### PR TITLE
feat(capabilities): show real principal in banner, not @okänd (#645)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -69,11 +69,6 @@
       "count": 1
     }
   },
-  "test/unit/components/auth-status-banner.test.tsx": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "test/unit/components/document-row-upload-guard.test.tsx": {
     "no-restricted-syntax": {
       "count": 1

--- a/src/components/shell/auth-status-banner.tsx
+++ b/src/components/shell/auth-status-banner.tsx
@@ -13,6 +13,7 @@
 
 import Link from "next/link";
 import { useAuthMode } from "@/lib/client/auth/use-auth-mode";
+import { trpc } from "@/lib/client/trpc";
 
 const STYLES: Record<string, string> = {
   anonymous: "bg-gray-50 text-gray-700",
@@ -26,15 +27,23 @@ const ICONS: Record<string, string> = {
   "identified-write": "✍️",
 };
 
+/** Banner-text per auth-mode. Utbruten ur komponenten för komplexitet ≤8. */
+function bannerLabel(mode: string, who: string): string {
+  if (mode === "anonymous") return "Demo-läge — endast läsning";
+  const suffix = mode === "identified-read" ? "endast läsning" : "kan spara";
+  return `Inloggad som ${who} — ${suffix}`;
+}
+
 export function AuthStatusBanner() {
   const { mode, user, loading } = useAuthMode();
+  // ADR 0027: visa den FAKTISKA inloggade principalen (demo-väljaren ELLER
+  // OIDC) i st.f. det pensionerade GitHub-`login`-fältet (som gav "@okänd" i
+  // server-first). Faller tillbaka på legacy-login → "okänd" om inget finns.
+  const me = trpc.user.current.useQuery();
   if (loading) return null;
 
-  const label = mode === "anonymous"
-    ? "Demo-läge — endast läsning"
-    : mode === "identified-read"
-    ? `Inloggad som @${user?.login ?? "okänd"} — endast läsning`
-    : `Inloggad som @${user?.login ?? "okänd"} — kan spara`;
+  const who = me.data?.name ?? me.data?.email ?? user?.login ?? "okänd";
+  const label = bannerLabel(mode, who);
 
   return (
     <Link

--- a/test/unit/components/auth-status-banner.test.tsx
+++ b/test/unit/components/auth-status-banner.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest-compat";
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
 import { AuthStatusBanner } from "@/components/shell/auth-status-banner";
 
 const mockState = {
@@ -16,11 +16,19 @@ const mockState = {
   refresh: async () => {},
 };
 
+// ADR 0027: bannern visar den faktiska principalen (trpc.user.current).
+let currentUser: { name?: string; email?: string } | undefined;
+
 vi.mock("@/lib/client/auth/use-auth-mode", () => ({
   useAuthMode: () => mockState,
 }));
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: { user: { current: { useQuery: () => ({ data: currentUser }) } } },
+}));
 
 describe("AuthStatusBanner", () => {
+  beforeEach(() => { currentUser = undefined; mockState.user = null; });
+
   it("renderar inget medan auth-mode laddas", () => {
     mockState.loading = true;
     const { container } = render(<AuthStatusBanner />);
@@ -30,23 +38,22 @@ describe("AuthStatusBanner", () => {
 
   it("anonymous → 'Demo-läge — endast läsning'", () => {
     mockState.mode = "anonymous";
-    mockState.user = null;
     render(<AuthStatusBanner />);
     expect(screen.getByText(/Demo-läge — endast läsning/i)).toBeInTheDocument();
   });
 
-  it("identified-read → '@user — endast läsning'", () => {
-    mockState.mode = "identified-read";
-    mockState.user = { login: "anna", id: 1 };
+  it("visar principalens namn (trpc.user.current) — inte GitHub-login", () => {
+    mockState.mode = "identified-write";
+    currentUser = { name: "Björn Bauer", email: "lawyer@ava.test" };
     render(<AuthStatusBanner />);
-    expect(screen.getByText(/Inloggad som @anna — endast läsning/i)).toBeInTheDocument();
+    expect(screen.getByText(/Inloggad som Björn Bauer — kan spara/i)).toBeInTheDocument();
   });
 
-  it("identified-write → '@user — kan spara'", () => {
-    mockState.mode = "identified-write";
-    mockState.user = { login: "ulrik", id: 2 };
+  it("faller tillbaka på email när namn saknas", () => {
+    mockState.mode = "identified-read";
+    currentUser = { email: "x@y.se" };
     render(<AuthStatusBanner />);
-    expect(screen.getByText(/Inloggad som @ulrik — kan spara/i)).toBeInTheDocument();
+    expect(screen.getByText(/Inloggad som x@y\.se — endast läsning/i)).toBeInTheDocument();
   });
 
   it("klick leder till /settings (Link-href)", () => {
@@ -56,10 +63,9 @@ describe("AuthStatusBanner", () => {
     expect(link).toHaveAttribute("href", "/settings");
   });
 
-  it("fallback till 'okänd' om user.login saknas", () => {
+  it("fallback till 'okänd' om varken principal eller legacy-login finns", () => {
     mockState.mode = "identified-read";
-    mockState.user = { login: undefined as unknown as string, id: 3 };
     render(<AuthStatusBanner />);
-    expect(screen.getByText(/Inloggad som @okänd/i)).toBeInTheDocument();
+    expect(screen.getByText(/Inloggad som okänd/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes #645. ADR 0027 slice 4 — retire the legacy "@okänd" banner.

The banner read the GitHub-era `user.login` (absent in OIDC/server-first → "@okänd"). It now shows the actual logged-in principal via `trpc.user.current` (name → email), falling back to legacy login then "okänd". Label-building extracted to a helper (complexity ≤8). Pruned the now-stale eslint suppression for the test.

The demo "log in as <user>" switcher (the ADR's demo-identity decision) already exists — `/login`'s user picker sets `principalId`.

New banner tests cover: shows principal name, falls back to email, "okänd" when nothing. Gate green (typecheck/lint/test:cov/knip/dep-cruiser/jscpd).

Builds on #639/#641/#643. **Remaining slice: demo blob-cache (OPFS)** — the heaviest, and it overlaps the deferred documents/content-store seeding (which itself awaits your call on the demo-id-scheme tradeoff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)