### PR TITLE
feat(billing): seed billing into server-first (uuid ids + sync) (#647)

### DIFF
--- a/src/lib/server/repositories/change-log-recorder.ts
+++ b/src/lib/server/repositories/change-log-recorder.ts
@@ -23,7 +23,14 @@ export interface ChangeLogEntry {
 }
 
 export interface ChangeLogRecorder {
-  record(entry: ChangeLogEntry): Promise<void>;
+  /**
+   * `exec` (#647): kör insert:en på en specifik db/tx-handle. Repo:t skickar
+   * `this.db` så loggningen sker på SAMMA connection som skrivningen — inne i en
+   * transaktion blir change_log-raden atomisk med raden (rullas tillbaka ihop)
+   * och undviker dödläge på single-connection-drivers (pglite). Default: den
+   * fångade db:n.
+   */
+  record(entry: ChangeLogEntry, exec?: AppDb): Promise<void>;
 }
 
 /**
@@ -40,8 +47,8 @@ export function enableChangeLogOnAll(repos: object, recorder: ChangeLogRecorder)
 /** Recorder som appendar till `change_log`-tabellen i samma db. */
 export function createDbChangeLogRecorder(db: AppDb): ChangeLogRecorder {
   return {
-    async record(entry: ChangeLogEntry): Promise<void> {
-      await db.insert(changeLog).values({
+    async record(entry: ChangeLogEntry, exec: AppDb = db): Promise<void> {
+      await exec.insert(changeLog).values({
         organizationId: entry.organizationId,
         entity: entry.entity,
         rowId: entry.rowId,

--- a/src/lib/server/repositories/drizzle-acconto-deduction-repository.ts
+++ b/src/lib/server/repositories/drizzle-acconto-deduction-repository.ts
@@ -7,11 +7,18 @@ import { accontoDeductions } from "../db/schema";
 import type { AppDb } from "../db/types";
 import type { AccontoDeductionRepository } from "./acconto-deduction-repository";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
+import { invoiceOrg } from "./matter-org";
 
 export class DrizzleAccontoDeductionRepository
   extends DrizzleRepository<AccontoDeduction>
   implements AccontoDeductionRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
     super(db, versionedTable(accontoDeductions), now);
+  }
+
+  /** acconto-avdrag saknar org-kolumn → härled via (slut- el. aconto-)fakturan→ärendet (#647). */
+  protected override resolveOrg(row: unknown): Promise<string | undefined> {
+    const r = row as { finalInvoiceId?: string; accontoInvoiceId?: string };
+    return invoiceOrg(this.db, r.finalInvoiceId ?? r.accontoInvoiceId);
   }
 }

--- a/src/lib/server/repositories/drizzle-billing-run-repository.ts
+++ b/src/lib/server/repositories/drizzle-billing-run-repository.ts
@@ -12,12 +12,18 @@ import type {
   BillingRunDetailRow, BillingRunListRow, BillingRunRepository,
 } from "./billing-run-repository";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
+import { matterOrg } from "./matter-org";
 
 export class DrizzleBillingRunRepository
   extends DrizzleRepository<BillingRun>
   implements BillingRunRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
     super(db, versionedTable(billingRuns), now);
+  }
+
+  /** billing_runs saknar org-kolumn → härled via ärendet (#647). */
+  protected override resolveOrg(row: unknown): Promise<string | undefined> {
+    return matterOrg(this.db, (row as { matterId?: string }).matterId);
   }
 
   async listForOrg(organizationId: string, matterId?: string): Promise<BillingRunListRow[]> {

--- a/src/lib/server/repositories/drizzle-invoice-dispatch-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-dispatch-repository.ts
@@ -10,10 +10,16 @@ import { invoiceDispatches, invoices, matters } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import type { InvoiceDispatchQueuedRow, InvoiceDispatchRepository } from "./invoice-dispatch-repository";
+import { invoiceOrg } from "./matter-org";
 
 export class DrizzleInvoiceDispatchRepository
   extends DrizzleRepository<InvoiceDispatch>
   implements InvoiceDispatchRepository {
+  /** invoice_dispatches saknar org-kolumn → härled via fakturan→ärendet (#647). */
+  protected override resolveOrg(row: unknown): Promise<string | undefined> {
+    return invoiceOrg(this.db, (row as { invoiceId?: string }).invoiceId);
+  }
+
   constructor(db: AppDb, now: () => Date = () => new Date()) {
     super(db, versionedTable(invoiceDispatches), now);
   }

--- a/src/lib/server/repositories/drizzle-invoice-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-repository.ts
@@ -20,10 +20,16 @@ import {
   type InvoiceFull, type InvoiceListFilter, type InvoiceListRow, type InvoiceRepository,
   type InvoiceWithLedger, type InvoiceWithRelations,
 } from "./invoice-repository";
+import { matterOrg } from "./matter-org";
 
 export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> implements InvoiceRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
     super(db, versionedTable(invoices), now);
+  }
+
+  /** invoices saknar org-kolumn → härled via ärendet (#647) så change_log/pull funkar. */
+  protected override resolveOrg(row: unknown): Promise<string | undefined> {
+    return matterOrg(this.db, (row as { matterId?: string }).matterId);
   }
 
   async getByIdInOrg(id: string, organizationId: string): Promise<Invoice | null> {

--- a/src/lib/server/repositories/drizzle-payment-plan-reminder-repository.ts
+++ b/src/lib/server/repositories/drizzle-payment-plan-reminder-repository.ts
@@ -6,6 +6,7 @@ import type { PaymentPlanReminder } from "@/lib/shared/schemas/billing";
 import { paymentPlanReminders } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
+import { planOrg } from "./matter-org";
 import type { PaymentPlanReminderRepository } from "./payment-plan-reminder-repository";
 
 export class DrizzlePaymentPlanReminderRepository
@@ -13,5 +14,10 @@ export class DrizzlePaymentPlanReminderRepository
   implements PaymentPlanReminderRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
     super(db, versionedTable(paymentPlanReminders), now);
+  }
+
+  /** påminnelser saknar org-kolumn → härled via planen→fakturan→ärendet (#647). */
+  protected override resolveOrg(row: unknown): Promise<string | undefined> {
+    return planOrg(this.db, (row as { planId?: string }).planId);
   }
 }

--- a/src/lib/server/repositories/drizzle-payment-plan-repository.ts
+++ b/src/lib/server/repositories/drizzle-payment-plan-repository.ts
@@ -14,6 +14,7 @@ import { asId } from "@/lib/shared/schemas/ids";
 import { invoices, matters, paymentPlanReminders, paymentPlans } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
+import { invoiceOrg } from "./matter-org";
 import type {
   JoinedPaymentPlan, JoinedPaymentPlanWithReminders, PaymentPlanRepository,
 } from "./payment-plan-repository";
@@ -21,6 +22,11 @@ import type {
 export class DrizzlePaymentPlanRepository extends DrizzleRepository<PaymentPlan> implements PaymentPlanRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
     super(db, versionedTable(paymentPlans), now);
+  }
+
+  /** payment_plans saknar org-kolumn → härled via fakturan→ärendet (#647). */
+  protected override resolveOrg(row: unknown): Promise<string | undefined> {
+    return invoiceOrg(this.db, (row as { invoiceId?: string }).invoiceId);
   }
 
   async getByIdInOrg(planId: string, organizationId: string): Promise<PaymentPlan | null> {

--- a/src/lib/server/repositories/drizzle-payment-repository.ts
+++ b/src/lib/server/repositories/drizzle-payment-repository.ts
@@ -9,11 +9,17 @@ import { asId } from "@/lib/shared/schemas/ids";
 import { payments } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
+import { invoiceOrg } from "./matter-org";
 import type { PaymentRepository } from "./payment-repository";
 
 export class DrizzlePaymentRepository extends DrizzleRepository<Payment> implements PaymentRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
     super(db, versionedTable(payments), now);
+  }
+
+  /** payments saknar org-kolumn → härled via fakturan→ärendet (#647). */
+  protected override resolveOrg(row: unknown): Promise<string | undefined> {
+    return invoiceOrg(this.db, (row as { invoiceId?: string }).invoiceId);
   }
 
   async sumByInvoice(invoiceId: string): Promise<number> {

--- a/src/lib/server/repositories/drizzle-repositories.ts
+++ b/src/lib/server/repositories/drizzle-repositories.ts
@@ -14,6 +14,7 @@
  */
 
 import type { AppDb } from "../db/types";
+import { enableChangeLogOnAll, type ChangeLogRecorder } from "./change-log-recorder";
 import { DrizzleAccontoDeductionRepository } from "./drizzle-acconto-deduction-repository";
 import { DrizzleBillingRunRepository } from "./drizzle-billing-run-repository";
 import { DrizzleCalendarEventRepository } from "./drizzle-calendar-event-repository";
@@ -78,15 +79,30 @@ function entityRepos(db: AppDb): Omit<Repositories, "transaction"> {
   };
 }
 
-/** Repos-vy bunden till en pågående tx — nästlad `transaction` är reentrant. */
-function reposForTx(tx: AppDb): Repositories {
-  const repos: Repositories = { ...entityRepos(tx), transaction: (fn) => fn(repos) };
+/** Repos-vy bunden till en pågående tx — nästlad `transaction` är reentrant.
+ *  `recorder` propageras till tx-repona (#647) så creates/updates INNE i en
+ *  transaktion också skrivs till change_log → delta-synkas (annars loggades
+ *  bara icke-transaktionella skrivningar; faktureringsflödena kör i tx). */
+function reposForTx(tx: AppDb, recorder?: ChangeLogRecorder): Repositories {
+  const entities = entityRepos(tx);
+  if (recorder) enableChangeLogOnAll(entities, recorder);
+  const repos: Repositories = { ...entities, transaction: (fn) => fn(repos) };
   return repos;
 }
 
 export function buildDrizzleRepositories(db: AppDb): Repositories {
+  // Fånga change-log-recordern när `enableChangeLogOnAll` slår på den, så
+  // `transaction` kan ge SAMMA recorder till tx-scopade repos (#647).
+  let recorder: ChangeLogRecorder | undefined;
+  const entities = entityRepos(db);
+  for (const value of Object.values(entities)) {
+    const repo = value as { enableChangeLog?: (r: ChangeLogRecorder) => void };
+    if (typeof repo.enableChangeLog !== "function") continue;
+    const orig = repo.enableChangeLog.bind(repo);
+    repo.enableChangeLog = (r: ChangeLogRecorder) => { recorder = r; orig(r); };
+  }
   return {
-    ...entityRepos(db),
-    transaction: (fn) => db.transaction((tx) => fn(reposForTx(tx))),
+    ...entities,
+    transaction: (fn) => db.transaction((tx) => fn(reposForTx(tx, recorder))),
   };
 }

--- a/src/lib/server/repositories/drizzle-repository.ts
+++ b/src/lib/server/repositories/drizzle-repository.ts
@@ -151,7 +151,7 @@ export class DrizzleRepository<Row extends RowBase> implements Repository<Row> {
       rowId: r.id,
       version: r.version ?? 1,
       op,
-    });
+    }, this.db); // logga på SAMMA connection (tx-atomiskt, inget dödläge, #647)
   }
 }
 

--- a/src/lib/server/repositories/drizzle-write-off-repository.ts
+++ b/src/lib/server/repositories/drizzle-write-off-repository.ts
@@ -9,11 +9,17 @@ import { asId } from "@/lib/shared/schemas/ids";
 import { writeOffs } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
+import { invoiceOrg } from "./matter-org";
 import type { WriteOffRepository } from "./write-off-repository";
 
 export class DrizzleWriteOffRepository extends DrizzleRepository<WriteOff> implements WriteOffRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
     super(db, versionedTable(writeOffs), now);
+  }
+
+  /** write_offs saknar org-kolumn → härled via fakturan→ärendet (#647). */
+  protected override resolveOrg(row: unknown): Promise<string | undefined> {
+    return invoiceOrg(this.db, (row as { invoiceId?: string }).invoiceId);
   }
 
   async sumByInvoice(invoiceId: string): Promise<number> {

--- a/src/lib/server/repositories/matter-org.ts
+++ b/src/lib/server/repositories/matter-org.ts
@@ -8,7 +8,7 @@
 
 import { eq } from "drizzle-orm";
 import { asId } from "@/lib/shared/schemas/ids";
-import { matters } from "../db/schema";
+import { invoices, matters, paymentPlans } from "../db/schema";
 import type { AppDb } from "../db/types";
 
 export async function matterOrg(db: AppDb, matterId: string | null | undefined): Promise<string | undefined> {
@@ -19,4 +19,30 @@ export async function matterOrg(db: AppDb, matterId: string | null | undefined):
     .where(eq(matters.id, asId<"MatterId">(matterId)))
     .limit(1);
   return m?.org ?? undefined;
+}
+
+/**
+ * Org via fakturan (#647) — för faktura-scopade entiteter utan egen org- eller
+ * matter-kolumn (payment/writeOff/paymentPlan/accontoDeduction/invoiceDispatch):
+ * faktura → ärende → org. Annars loggas de aldrig i change_log → syns ej i klienten.
+ */
+export async function invoiceOrg(db: AppDb, invoiceId: string | null | undefined): Promise<string | undefined> {
+  if (!invoiceId) return undefined;
+  const [inv] = await db
+    .select({ matterId: invoices.matterId })
+    .from(invoices)
+    .where(eq(invoices.id, asId<"InvoiceId">(invoiceId)))
+    .limit(1);
+  return matterOrg(db, inv?.matterId);
+}
+
+/** Org via avbetalningsplanen (#647): plan → faktura → ärende → org. */
+export async function planOrg(db: AppDb, planId: string | null | undefined): Promise<string | undefined> {
+  if (!planId) return undefined;
+  const [plan] = await db
+    .select({ invoiceId: paymentPlans.invoiceId })
+    .from(paymentPlans)
+    .where(eq(paymentPlans.id, asId<"PaymentPlanId">(planId)))
+    .limit(1);
+  return invoiceOrg(db, plan?.invoiceId);
 }

--- a/test/unit/server/sync/drizzle-sync-store.test.ts
+++ b/test/unit/server/sync/drizzle-sync-store.test.ts
@@ -125,4 +125,39 @@ describe("DrizzleSyncStore (#sync-bridge)", () => {
     expect(changes.find((c) => c.row.id === te)).toMatchObject({ entity: "timeEntry" });
     expect(changes.find((c) => c.row.id === exp)).toMatchObject({ entity: "expense" });
   });
+
+  // #647: faktura-entiteterna saknar org-kolumn → härled via ärendet (invoice/
+  // billingRun) resp. fakturan→ärendet (payment/writeOff/paymentPlan), annars
+  // syns ingen fakturering i klienten trots att raderna finns server-side.
+  it("invoice + payment + paymentPlan delta-synkas via pull (org härledd ur fakturan/ärendet, #647)", async () => {
+    const m5 = uuidv7(), inv = uuidv7(), pay = uuidv7(), plan = uuidv7(), wo = uuidv7(), user = uuidv7();
+    await repos.matters.create({ id: m5, organizationId: ORG, title: "Faktura-synk", status: "ACTIVE", matterNumber: "2026-0013" } as never);
+    const cursor = (await sync.pull(ORG, 0)).cursor;
+
+    await repos.invoices.create({ id: inv, matterId: m5, amount: 50000, invoiceDate: new Date(), status: "DRAFT" } as never);
+    await repos.payments.create({ id: pay, invoiceId: inv, amount: 20000, paidAt: new Date(), recordedById: user } as never);
+    await repos.paymentPlans.create({ id: plan, invoiceId: inv, monthlyAmount: 10000, dayOfMonth: 15, startDate: new Date(), status: "ACTIVE" } as never);
+    await repos.writeOffs.create({ id: wo, invoiceId: inv, amount: 5000, writtenOffAt: new Date(), recordedById: user } as never);
+
+    const changes = (await sync.pull(ORG, cursor)).changes;
+    expect(changes.find((c) => c.row.id === inv)).toMatchObject({ entity: "invoice" });
+    expect(changes.find((c) => c.row.id === pay)).toMatchObject({ entity: "payment" });
+    expect(changes.find((c) => c.row.id === plan)).toMatchObject({ entity: "paymentPlan" });
+    expect(changes.find((c) => c.row.id === wo)).toMatchObject({ entity: "writeOff" });
+  });
+
+  // #647: skrivningar INNE i en transaktion måste också loggas (tx-scopade repos
+  // ärver change-log-recordern) — faktureringsflödena kör i tx.
+  it("create inne i transaction loggas i change_log → delta-synkas (#647)", async () => {
+    const m6 = uuidv7(), inv = uuidv7();
+    await repos.matters.create({ id: m6, organizationId: ORG, title: "Tx-synk", status: "ACTIVE", matterNumber: "2026-0014" } as never);
+    const cursor = (await sync.pull(ORG, 0)).cursor;
+
+    await repos.transaction(async (tx) => {
+      await tx.invoices.create({ id: inv, matterId: m6, amount: 12345, invoiceDate: new Date(), status: "DRAFT" } as never);
+    });
+
+    const changes = (await sync.pull(ORG, cursor)).changes;
+    expect(changes.find((c) => c.row.id === inv)).toMatchObject({ entity: "invoice" });
+  });
 });

--- a/tooling/scripts/demo-billing-ids.ts
+++ b/tooling/scripts/demo-billing-ids.ts
@@ -14,12 +14,21 @@
  *
  * Delas mellan `populate-billing.ts` (skapar) och `static-params.ts`
  * (enumererar) så de inte kan komma ur synk.
+ *
+ * #647/ADR 0027: id:na är nu deterministiska UUID:er (uuidv5) i st.f.
+ * `inv-<id>-final`-strängar — så faktureringen kan seedas i Postgres
+ * server-first (uuid-kolumner avvisar strängarna) UTAN att tappa
+ * determinismen: static-params enumererar SAMMA uuid:er som populate-billing
+ * skapar (båda kallar dessa funktioner). `__shell__`-sentinellen fångar ändå
+ * okända id:n. Speglar id-translatorns uuidv5(slug, AVA_NAMESPACE).
  */
 
-export function demoFinalInvoiceId(matterId: string): string { return `inv-${matterId}-final`; }
-export function demoAccontoInvoiceId(matterId: string): string { return `inv-${matterId}-acc`; }
-export function demoCreditInvoiceId(matterId: string): string { return `inv-${matterId}-credit`; }
-export function demoPaymentPlanId(matterId: string): string { return `pp-${matterId}`; }
+import { AVA_NAMESPACE, uuidv5 } from "../../src/lib/shared/uuid-derive";
+
+export function demoFinalInvoiceId(matterId: string): string { return uuidv5(`invoice:${matterId}:final`, AVA_NAMESPACE); }
+export function demoAccontoInvoiceId(matterId: string): string { return uuidv5(`invoice:${matterId}:acc`, AVA_NAMESPACE); }
+export function demoCreditInvoiceId(matterId: string): string { return uuidv5(`invoice:${matterId}:credit`, AVA_NAMESPACE); }
+export function demoPaymentPlanId(matterId: string): string { return uuidv5(`paymentPlan:${matterId}`, AVA_NAMESPACE); }
 
 type MatterLike = { id?: unknown };
 

--- a/tooling/scripts/seed-demo-into-server.ts
+++ b/tooling/scripts/seed-demo-into-server.ts
@@ -33,6 +33,9 @@ import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createIdTranslator, translateSeed } from "../demo-generator/id-translator";
 import { populate } from "../demo-generator/populate";
+import { populateBilling } from "../demo-generator/populate-billing";
+import { populateBillingRuns } from "../demo-generator/populate-billing-runs";
+import { populateUnbilledTime } from "../demo-generator/populate-unbilled-time";
 import { buildSeed } from "./seed-data";
 
 const DB_URL = process.env.AVA_DATABASE_URL ?? "postgres://ava:ava@localhost:5433/ava_test";
@@ -111,16 +114,23 @@ async function main(): Promise<void> {
     // Mappa demons admin + huvud-jurist till KC-login-emailen → login äger data.
     const loginIds = remapLoginUsers(seed.users as Row[]);
 
-    // v1: bara kärnentiteterna (org/users/contacts/matters/matter-contacts/
-    // tid/utlägg/kalender/uppgifter/mallar/jävskontroller). Fakturering +
-    // dokument hoppas — populateBilling synthesizar icke-uuid-id:n
-    // (`inv-<matterId>-acc`) som Postgres-uuid-kolumnen avvisar, och dokument
-    // kräver content-store-porten. Båda är uppföljning (#630).
+    // Kärnentiteter (org/users/contacts/matters/matter-contacts/tid/utlägg/
+    // kalender/uppgifter/mallar/jävskontroller).
     const core = await populate(caller, seed);
     await addTodayTimeEntries(repos, seed.timeEntries as Row[], loginIds); // "idag"-tid för dashboarden
-    console.log("✓ demo-data (kärna) seedad i server-first (org", ORG, "):", core);
+
+    // Fakturering (#647): billing-id:na är nu deterministiska uuid:er
+    // (demo-billing-ids), så Postgres-uuid-kolumnerna accepterar dem.
+    // populateBilling = legacy-faktura-flöden; populateBillingRuns = nya
+    // BillingRun-modellen (aconto/slut/kostnadsräkning); unbilled = färsk
+    // upparbetad tid efter fakturering. Dokument hoppas fortfarande (kräver
+    // content-store-porten — nästa steg).
+    const billing = await populateBilling(caller, seed);
+    const billingRuns = await populateBillingRuns(caller, seed);
+    const unbilled = await populateUnbilledTime(caller, seed);
+    console.log("✓ demo-data seedad i server-first (org", ORG, "):", { ...core, billing, billingRuns, unbilled });
     console.log(`  login: ${LOGIN_LAWYER_EMAIL} + ${LOGIN_ADMIN_EMAIL} äger nu data (+ idag-tidpost)`);
-    console.log("  (fakturering + dokument hoppade i v1 — kräver uuid-id-coercion resp. content-store)");
+    console.log("  (dokument hoppas fortfarande — kräver content-store-porten)");
   } finally {
     await close();
   }


### PR DESCRIPTION
Closes #647. Implements **Alternative A** (your call) — unify demo billing ids on deterministic uuidv5 so billing seeds into the Postgres server-first demo, and make it actually sync.

## Changes
- **`demo-billing-ids.ts`**: `inv-<id>-final`/`pp-<id>` → `uuidv5(...)`. static-params and populate-billing use the same functions → stay in sync; `__shell__` sentinel catches unknown ids.
- **`seed-demo-into-server.ts`**: enable `populateBilling` + `populateBillingRuns` + `populateUnbilledTime`.
- **Billing sync (#632 trap, extended)**: invoices/payments/payment_plans/billing_runs/write_offs/reminders/acconto-deductions/invoice-dispatches have no `organization_id` → added `resolveOrg` overrides (`matterOrg`/`invoiceOrg`/`planOrg`) so they reach `change_log` and sync.
- **Transaction-recorder fix**: tx-scoped repos never inherited the change-log recorder → creates inside a transaction (all billing flows) weren't logged. Propagate the recorder into tx repos, and log on the repo's current connection (tx-atomic + no single-connection deadlock). This is a broad correctness win for *all* transactional writes.

## Verification
- Live: 28 invoices / 16 payments / 7 plans / 12 billing-runs seeded; all billing entities now in `change_log`; `/invoices` renders real invoices in the app.
- `build:demo` (GH-Pages static export) builds clean with uuid ids — no URL/pre-render breakage (browser-smoke runs on CI).
- New tests: billing delta-sync via pull + create-inside-transaction logs to change_log. Full gate green (typecheck/lint/test:cov 0 fail, coverage above floors/knip/dep-cruiser/jscpd).

Next: documents/content-store — the last ADR 0027 slice (demo blob-cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)