### PR TITLE
feat(tooling): seed documents into local server-first (content bind-mount) (#649)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ reports/ui-diagnose/
 
 # Office add-in build-artefakt (#72)
 office-addin/dist/
+
+# Lokal self-hosted dokument-content (bind-mount, #649)
+tooling/docker/.selfhosted-content/

--- a/tooling/docker/docker-compose.selfhosted-local.yml
+++ b/tooling/docker/docker-compose.selfhosted-local.yml
@@ -38,7 +38,10 @@ services:
       AVA_HTTP_PORT: "3001"
       AVA_CONTENT_DIR: /data/content
     volumes:
-      - content_repo:/data/content
+      # Bind-mount (#649): demo-seeden (host) skriver dokument-bytes hit och
+      # servern (GitContentStore) läser dem från samma katalog → /documents +
+      # nedladdning funkar lokalt. Default-dir sätts av selfhosted-local.sh.
+      - "${AVA_CONTENT_HOST_DIR:-./.selfhosted-content}:/data/content"
     depends_on:
       postgres:
         condition: service_healthy
@@ -111,4 +114,3 @@ services:
 volumes:
   git_repos:
   auth_data:
-  content_repo:

--- a/tooling/scripts/seed-demo-into-server.ts
+++ b/tooling/scripts/seed-demo-into-server.ts
@@ -20,6 +20,8 @@
  *     bun tooling/scripts/seed-demo-into-server.ts
  */
 
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { noopPorts } from "@/lib/server/adapters/noop-ports";
 import type { Principal } from "@/lib/server/auth/principal";
 import { buildContext } from "@/lib/server/build-context";
@@ -35,11 +37,16 @@ import { createIdTranslator, translateSeed } from "../demo-generator/id-translat
 import { populate } from "../demo-generator/populate";
 import { populateBilling } from "../demo-generator/populate-billing";
 import { populateBillingRuns } from "../demo-generator/populate-billing-runs";
+import { populateDocuments } from "../demo-generator/populate-documents";
 import { populateUnbilledTime } from "../demo-generator/populate-unbilled-time";
 import { buildSeed } from "./seed-data";
 
 const DB_URL = process.env.AVA_DATABASE_URL ?? "postgres://ava:ava@localhost:5433/ava_test";
 const ORG = process.env.AVA_ORGANIZATION_ID ?? "00000000-0000-0000-0000-000000000001";
+// Host-katalogen som är bind-mountad till serverns AVA_CONTENT_DIR (#649) —
+// dit skrivs dokument-bytes så serverns GitContentStore kan läsa dem. Saknas
+// den → dokument-metadata hoppas (bytes har ingenstans att ta vägen).
+const CONTENT_DIR = process.env.AVA_CONTENT_HOST_DIR;
 
 /** KC-realm:ens allowlistade login-emails (realm-ava.json). */
 const LOGIN_ADMIN_EMAIL = "admin@ava.test";
@@ -88,6 +95,29 @@ async function addTodayTimeEntries(repos: Repositories, timeEntries: Row[], ids:
   }
 }
 
+/**
+ * Seeda ärende-scopade seed-dokument (#649): uuid-id:n (translateSeed) + matterId
+ * → synkas via resolveOrg-override (#528). Bytes skrivs till den bind-mountade
+ * content-katalogen (AVA_CONTENT_HOST_DIR) som serverns GitContentStore läser →
+ * öppna/ladda ner funkar lokalt. Genererade faktura-/KR-/mall-dokument hoppas
+ * (icke-uuid-id:n `invdoc-/kr-/gendoc-` + faktura-scopade — uppföljning likt
+ * #647). No-op utan CONTENT_DIR (bytes har då ingenstans att ta vägen).
+ */
+async function seedDocuments(
+  caller: Parameters<typeof populateDocuments>[0],
+  seed: Parameters<typeof populateDocuments>[1],
+): Promise<number> {
+  if (!CONTENT_DIR) return 0;
+  const dir = CONTENT_DIR;
+  const sink = (storagePath: string, bytes: Uint8Array): number => {
+    const abs = join(dir, storagePath);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, bytes);
+    return bytes.byteLength;
+  };
+  return populateDocuments(caller, seed, sink);
+}
+
 async function main(): Promise<void> {
   const { db, close } = createPostgresDb(DB_URL);
   const repos = buildDrizzleRepositories(db);
@@ -128,9 +158,11 @@ async function main(): Promise<void> {
     const billing = await populateBilling(caller, seed);
     const billingRuns = await populateBillingRuns(caller, seed);
     const unbilled = await populateUnbilledTime(caller, seed);
-    console.log("✓ demo-data seedad i server-first (org", ORG, "):", { ...core, billing, billingRuns, unbilled });
+
+    const documents = await seedDocuments(caller, seed);
+    console.log("✓ demo-data seedad i server-first (org", ORG, "):", { ...core, billing, billingRuns, unbilled, documents });
     console.log(`  login: ${LOGIN_LAWYER_EMAIL} + ${LOGIN_ADMIN_EMAIL} äger nu data (+ idag-tidpost)`);
-    console.log("  (dokument hoppas fortfarande — kräver content-store-porten)");
+    console.log(CONTENT_DIR ? `  dokument-bytes → ${CONTENT_DIR}` : "  (dokument hoppade — sätt AVA_CONTENT_HOST_DIR)");
   } finally {
     await close();
   }

--- a/tooling/scripts/selfhosted-local.sh
+++ b/tooling/scripts/selfhosted-local.sh
@@ -22,14 +22,20 @@ export OIDC_KC_HOSTNAME="http://localhost:${KC_PORT}"
 export OIDC_ISSUER_PUBLIC="http://localhost:${KC_PORT}/realms/ava"
 export OIDC_REDIRECT_URL="http://localhost:${AVA_WEB_PORT}/oauth2/callback"
 export AVA_ORGANIZATION_ID="${AVA_ORGANIZATION_ID:-00000000-0000-0000-0000-000000000001}"
+# Dokument-bytes (#649): host-katalog som bind-mountas till serverns
+# AVA_CONTENT_DIR. Demo-seeden skriver hit, serverns GitContentStore läser hit.
+export AVA_CONTENT_HOST_DIR="${AVA_CONTENT_HOST_DIR:-$ROOT/tooling/docker/.selfhosted-content}"
 DB_URL="postgres://ava:ava@localhost:5433/ava_test"
 COMPOSE=(docker compose -p ava-selfhosted-local -f tooling/docker/docker-compose.selfhosted-local.yml)
 
 if [[ "${1:-}" == "--down" ]]; then
   echo "▸ River ner self-hosted-stacken…"
   "${COMPOSE[@]}" down -v --remove-orphans
+  rm -rf "$AVA_CONTENT_HOST_DIR"
   exit 0
 fi
+
+mkdir -p "$AVA_CONTENT_HOST_DIR" # bind-mount-måletet måste finnas innan `up`
 
 echo "▸ [1/6] Bygger server-first-binär…"
 bun run server-first:build >/dev/null


### PR DESCRIPTION
Closes #649. The last ADR 0027 / local-demo gap: **documents**.

## What
The server-first binary already wires `GitContentStore` from `AVA_CONTENT_DIR`, but no documents were seeded.
- **Bind-mount** the server's content dir to a host path (`AVA_CONTENT_HOST_DIR`) — the seed (host) writes doc bytes; the server (`GitContentStore.read` = plain `readFile`) serves them from the same dir.
- `seed-demo-into-server.ts`: a content sink → `populateDocuments` (matter-scoped seed documents — UUID ids via `translateSeed`, `matterId` set → already sync via the #528 `resolveOrg` override).
- `selfhosted-local.sh`: create + gitignore the content dir; `--down` cleans it.

## Verification (live)
40 documents seeded + all in `change_log`; the server container reads the bytes (`/data/content/...`); a matter's Documents section renders the PDFs (Svaromål/Dom) — no "Inga dokument". `build:demo` (GH-Pages) unaffected. Tooling-only — full test suite green, coverage above floors.

## Deferred (follow-up, like #647)
Generated **faktura/KR/template** documents synthesize non-UUID ids (`invdoc-`/`kr-`/`gendoc-`) and are invoice-scoped → need uuidv5 ids + invoice-scoped `resolveOrg`. The bulk matter documents (this PR) are the core.

This completes the ADR 0027 implementation arc: capability descriptor (#640) → probe (#642) → integrations gating (#644) → banner (#646) → billing seed (#648) → documents (this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)