### PR TITLE
fix(documents): runtime-tier doc open — server not GH in self-hosted (#651)

### DIFF
--- a/src/components/documents/_document-row.tsx
+++ b/src/components/documents/_document-row.tsx
@@ -4,32 +4,11 @@ import { Trash2 } from "lucide-react";
 import { Fragment, useState } from "react";
 import { ActionMenu, type ActionMenuItem } from "@/components/ui/action-menu";
 import { useCapabilities } from "@/lib/client/capabilities/use-capabilities";
-import type { OpenDocumentDeps } from "@/lib/client/firma/open-document";
-import { readFromFsa } from "@/lib/client/fsa/read-from-fsa";
+import { loadFirmaConfig } from "@/lib/client/firma/firma-config";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { DocumentTags } from "./_document-tags";
 import { formatFileSize } from "./_drag-helpers";
 import { ExternalEditModal, type ModalState } from "./external-edit-modal";
-
-/**
- * Försök öppna dokumentet från den lokala FSA-working-copyn som blob:-URL
- * (nyligen uppladdade filer hinner inte till remote än). Returnerar `true`
- * om filen öppnades, annars `false` (→ caller faller tillbaka på GH Pages-URL).
- * Platta tidiga returer håller nästlingsdjupet under gränsen.
- */
-async function tryOpenViaFsa(path: string): Promise<boolean> {
-  const { isFsaSupported, loadHandle } = await import("@/lib/client/fsa/handle-store");
-  if (!isFsaSupported()) return false;
-  const handle = await loadHandle("repo-root");
-  if (!handle) return false;
-  const blob = await readFromFsa(handle, path);
-  if (!blob) return false;
-  const url = URL.createObjectURL(blob);
-  window.open(url, "_blank", "noopener,noreferrer");
-  // Återvinn URL:n efter en stund (browsern behåller den medan tab:n öppen)
-  setTimeout(() => URL.revokeObjectURL(url), 60_000);
-  return true;
-}
 
 export interface DocumentRecord {
   id: string;
@@ -185,10 +164,29 @@ interface ActionItemsOpts {
   uploadingTitle: string | undefined;
   /** LLM-kapabilitet (ADR 0027): false (demon) → "Analysera (AI)" döljs. */
   llm: boolean;
+  /** Self-hosted (#651): "Visa"/"Ladda ner" öppnar via servern (cache-medveten)
+   *  i st.f. en GH-Pages-href (som bara funkar i demon). */
+  serverMode: boolean;
   onOpenInEditor: () => void;
+  onView: () => void;
   onExternal: () => void;
   onReanalyze: () => void;
   onDelete: () => void;
+}
+
+/** "Visa"/"Ladda ner": demo → direkt GH-href; self-hosted → hämta via servern
+ *  (cache-medvetet) och öppna blob:-URL:en. */
+function viewDownloadItems(o: ActionItemsOpts): ActionMenuItem[] {
+  if (o.serverMode) {
+    return [
+      { key: "view", label: "Visa", icon: <span aria-hidden>👁</span>, onSelect: o.onView, disabled: o.isDisabled, title: o.uploadingTitle ?? "Visa i webbläsaren" },
+      { key: "download", label: "Ladda ner", icon: <span aria-hidden>⬇</span>, onSelect: o.onView, disabled: o.isDisabled, title: o.uploadingTitle ?? "Hämta från servern" },
+    ];
+  }
+  return [
+    { key: "view", label: "Visa", icon: <span aria-hidden>👁</span>, href: o.viewHref, newTab: true, disabled: o.isDisabled, title: o.uploadingTitle ?? "Visa i webbläsaren" },
+    { key: "download", label: "Ladda ner", icon: <span aria-hidden>⬇</span>, href: o.downloadHref, download: true, disabled: o.isDisabled, title: o.uploadingTitle ?? "Ladda ner" },
+  ];
 }
 
 /** Bygg kebab-menyns rader. Utbruten ur DocumentActions — alla `uploadingTitle
@@ -197,8 +195,7 @@ function buildActionItems(o: ActionItemsOpts): ActionMenuItem[] {
   return [
     { key: "open", label: "Öppna i webbläsaren", icon: <span aria-hidden>🖊</span>, onSelect: o.onOpenInEditor, disabled: o.isDisabled, title: o.uploadingTitle ?? "Öppna i din browser" },
     { key: "external", label: "Editera externt (PDF Gear, Preview…)", icon: <span aria-hidden>🖥</span>, onSelect: o.onExternal, disabled: o.isDisabled, title: o.uploadingTitle ?? "AVA committar dina ändringar automatiskt" },
-    { key: "view", label: "Visa", icon: <span aria-hidden>👁</span>, href: o.viewHref, newTab: true, disabled: o.isDisabled, title: o.uploadingTitle ?? "Visa i webbläsaren" },
-    { key: "download", label: "Ladda ner", icon: <span aria-hidden>⬇</span>, href: o.downloadHref, download: true, disabled: o.isDisabled, title: o.uploadingTitle ?? "Ladda ner" },
+    ...viewDownloadItems(o),
     // ADR 0027: LLM-analys är en server-förmåga → dölj affordansen utan den.
     ...(o.llm
       ? [{ key: "reanalyze", label: "Analysera (AI)", icon: <span aria-hidden>🧠</span>, onSelect: o.onReanalyze, disabled: o.isDisabled || o.reanalyzePending, title: o.uploadingTitle ?? "Kör AI-analys på nytt" }]
@@ -223,38 +220,24 @@ function DocumentActions({
   onExternalEdit: () => Promise<void>;
 }) {
   const { viewHref, downloadHref } = buildDocHrefs(doc);
+  // Runtime-tier (#651): self-hosted öppnar via servern (cache-medveten), demo
+  // via GH-Pages-href. Bygg-tids-NEXT_PUBLIC_DEMO_BUILD duger inte — den är sann
+  // även i den lokala self-hosted-builden (→ tidigare GH-länkar i self-hosted).
+  const serverMode = loadFirmaConfig().tier !== "demo";
 
-
-  const openInEditor = async () => {
-    // Web/demo: läs lokal kopia från FSA om den finns (nyligen uppladdade
-    // filer hinner inte till remote än), annars GH Pages-URL.
-    // Browser kan EJ navigera till file:// från https://, så vi öppnar
-    // som blob:-URL i ny tab → Chrome visar PDF inline.
-    // För PDFGear/Preview/Acrobat → använd "Editera externt" (FSA).
+  const openViaServerOrGh = async () => {
     const rec = doc as DocumentRecord & { storagePath?: string };
-    const path = rec.storagePath ?? "";
-
-    if (path) {
-      try {
-        if (await tryOpenViaFsa(path)) return;
-      } catch (err) {
-        console.warn("[open] FSA-läsning misslyckades, faller tillbaka till GH Pages:", err);
-      }
-    }
-
-    // Fallback: GH Pages (för pushade dokument i demo) eller server-URL.
-    // Vill användaren redigera i en extern app (PDF Gear/Preview/Acrobat)
-    // är vägen "Editera externt" (öppnar filen från din lokala mapp via
-    // File System Access) — inte detta visnings-flöde.
-    window.open(viewHref, "_blank", "noopener,noreferrer");
+    const { openMatterDocument } = await import("@/lib/client/firma/open-matter-document");
+    await openMatterDocument({ id: doc.id, storagePath: rec.storagePath ?? null, fileName: doc.fileName });
   };
 
   const isDisabled = !!disabled;
   const uploadingTitle = isDisabled ? "Vänta tills uppladdningen är klar" : undefined;
   const { llm } = useCapabilities();
   const items = buildActionItems({
-    isDisabled, reanalyzePending, viewHref, downloadHref, uploadingTitle, llm,
-    onOpenInEditor: () => void openInEditor(),
+    isDisabled, reanalyzePending, viewHref, downloadHref, uploadingTitle, llm, serverMode,
+    onOpenInEditor: () => void openViaServerOrGh(),
+    onView: () => void openViaServerOrGh(),
     onExternal: () => void onExternalEdit(),
     onReanalyze, onDelete,
   });
@@ -299,7 +282,6 @@ function DocumentNameMeta({ doc, isAnalyzing, isWaitingAnalysis }: { doc: Docume
 function DocumentNameButton({ doc, isAnalyzing, disabled, onExternalEdit }: NameButtonProps) {
   const isWaitingAnalysis = isAnalyzing || isWithinAnalysisGrace(doc);
 
-  const isDemo = process.env.NEXT_PUBLIC_DEMO_BUILD === "1";
   const onClick = async () => {
     if (disabled) return;
     // PDF/Office-filer öppnas i extern editor (PDF Gear, Preview, Word…)
@@ -312,20 +294,12 @@ function DocumentNameButton({ doc, isAnalyzing, disabled, onExternalEdit }: Name
         return;
       }
     }
-    const { openDocument } = await import("@/lib/client/firma/open-document");
-    const { loadHandle } = await import("@/lib/client/fsa/handle-store");
+    // Runtime-tier (#651): self-hosted hämtar bytes från servern (+ cache),
+    // demo öppnar GH-Pages-blobben. (Ej bygg-tids-NEXT_PUBLIC_DEMO_BUILD, som är
+    // sant även i den lokala self-hosted-builden → länkade fel till GH.)
     const rec = doc as DocumentRecord & { storagePath?: string };
-    const demoRepo = process.env.NEXT_PUBLIC_DEFAULT_DEMO_REPO;
-    const deps: OpenDocumentDeps = {
-      doc: omitUndefined({ id: doc.id, storagePath: rec.storagePath, fileName: doc.fileName }) as OpenDocumentDeps["doc"],
-      isDemo,
-      loadHandle: () => loadHandle("repo-root"),
-      readFromHandle: readFromFsa,
-      openUrl: (u) => window.open(u, "_blank", "noopener,noreferrer"),
-      notifyError: (m) => alert(m),
-      ...omitUndefined({ demoRepo }),
-    };
-    await openDocument(deps);
+    const { openMatterDocument } = await import("@/lib/client/firma/open-matter-document");
+    await openMatterDocument({ id: doc.id, storagePath: rec.storagePath ?? null, fileName: doc.fileName });
   };
 
   return (

--- a/src/components/documents/_documents-list-view.tsx
+++ b/src/components/documents/_documents-list-view.tsx
@@ -56,17 +56,10 @@ async function openDocumentSmart(doc: DocumentRecord, setModal: (m: ModalState) 
       return;
     }
   }
-  // Fallback: öppna i browser-tab
-  const isDemo = process.env.NEXT_PUBLIC_DEMO_BUILD === "1";
-  const url = isDemo
-    ? (() => {
-        const repo = process.env.NEXT_PUBLIC_DEFAULT_DEMO_REPO ?? "ulrik-s/ava-demo";
-        const m = repo.match(/^([^/\s]+)\/([^/\s]+)$/);
-        const base = m ? `https://${m[1]}.github.io/${m[2]}` : repo.replace(/\/+$/, "");
-        return `${base}/${doc.storagePath}`;
-      })()
-    : `/api/documents/${doc.id}/download`;
-  window.open(url, "_blank", "noopener,noreferrer");
+  // Fallback: öppna i browser-tab. Runtime-tier (#651): self-hosted via servern
+  // (cache-medveten), demo via GH-Pages-blobben — ej bygg-tids-NEXT_PUBLIC_DEMO_BUILD.
+  const { openMatterDocument } = await import("@/lib/client/firma/open-matter-document");
+  await openMatterDocument({ id: doc.id, storagePath: doc.storagePath ?? null, fileName: doc.fileName });
 }
 
 export function DocumentsListView({ matterId, documents, folders, onDelete, onReanalyze }: Props) {

--- a/src/lib/client/backend/server-download-client.ts
+++ b/src/lib/client/backend/server-download-client.ts
@@ -1,0 +1,25 @@
+"use client";
+
+/**
+ * `createServerDownloadClient` (#651) — en tRPC-klient mot den DEPLOYADE servern
+ * (`/api/trpc`, samma-origin-cookie via oauth2-proxy) för att hämta
+ * dokument-bytes i self-hosted. Den IN-PROCESS-klienten (GitBackendRuntime) har
+ * `StaticContentStore` som pekar på GH Pages — fel källa i self-hosted. Här
+ * läser `document.downloadContent` serverns GitContentStore (#518), och
+ * `loadDocumentBlob` cachar resultatet i IndexedDB (öppna→cache-populering).
+ */
+
+import { createTRPCClient, httpBatchLink } from "@trpc/client";
+import superjson from "superjson";
+import type { AppRouter } from "@/lib/server/routers/_app";
+import { serverTrpcEndpoint } from "./http-backend-runtime";
+import type { DownloadClient } from "./load-document-blob";
+
+/** Den deployade serverns tRPC-klient, smalnad till `DownloadClient`-ytan
+ *  `loadDocumentBlob` behöver (full klient är strukturellt tilldelningsbar). */
+export function createServerDownloadClient(baseUrl?: string): DownloadClient {
+  const client = createTRPCClient<AppRouter>({
+    links: [httpBatchLink({ url: serverTrpcEndpoint(baseUrl), transformer: superjson })],
+  });
+  return client;
+}

--- a/src/lib/client/firma/open-matter-document.ts
+++ b/src/lib/client/firma/open-matter-document.ts
@@ -1,0 +1,44 @@
+"use client";
+
+/**
+ * `openMatterDocument` (#651) — öppna ett dokument med RUNTIME-tier-beslut
+ * (ej bygg-tids-`NEXT_PUBLIC_DEMO_BUILD`, som är sant även i den lokala
+ * self-hosted-builden → länkade fel till GH Pages).
+ *
+ *   - demo (ingen server): öppna mot GH Pages-URL:en (bundlade blobbar).
+ *   - self-hosted (server finns): hämta bytes via serverns
+ *     `document.downloadContent` (GitContentStore) + cacha i IndexedDB
+ *     (`loadDocumentBlob`) → blob:-URL. Saknas i cachen → populeras först.
+ *
+ * FSA-lokal kopia (nyligen uppladdad) provas före nätet i båda lägena.
+ */
+
+import { loadFirmaConfig } from "@/lib/client/firma/firma-config";
+
+export type OpenableDoc = { id: string; storagePath?: string | null; fileName?: string };
+
+export async function openMatterDocument(doc: OpenableDoc): Promise<void> {
+  const { openDocument } = await import("./open-document");
+  const { loadHandle } = await import("@/lib/client/fsa/handle-store");
+  const { readFromFsa } = await import("@/lib/client/fsa/read-from-fsa");
+  const isDemo = loadFirmaConfig().tier === "demo";
+
+  let fetchBlob: (() => Promise<Blob | null>) | undefined;
+  if (!isDemo) {
+    const { createServerDownloadClient } = await import("@/lib/client/backend/server-download-client");
+    const { loadDocumentBlob } = await import("@/lib/client/backend/load-document-blob");
+    const client = createServerDownloadClient();
+    fetchBlob = () => loadDocumentBlob(client, { id: doc.id, storagePath: doc.storagePath ?? null, fileName: doc.fileName ?? doc.id });
+  }
+
+  await openDocument({
+    doc,
+    isDemo,
+    ...(process.env.NEXT_PUBLIC_DEFAULT_DEMO_REPO ? { demoRepo: process.env.NEXT_PUBLIC_DEFAULT_DEMO_REPO } : {}),
+    loadHandle: () => loadHandle("repo-root"),
+    readFromHandle: readFromFsa,
+    ...(fetchBlob ? { fetchBlob } : {}),
+    openUrl: (u) => window.open(u, "_blank", "noopener,noreferrer"),
+    notifyError: (m) => { if (typeof window !== "undefined") window.alert(m); },
+  });
+}

--- a/test/unit/components/document-browser.test.tsx
+++ b/test/unit/components/document-browser.test.tsx
@@ -400,19 +400,23 @@ describe("DocumentBrowser", () => {
     expect(screen.getByText("sub.pdf")).toBeInTheDocument();
   });
 
-  it("klick på dokumentnamnet i self-hosted utan FSA-handle → alert om saknad working copy", async () => {
-    // Self-hosted i jsdom har ingen indexedDB-handle → openDocument:s
-    // notifyError-gren körs istället för att fetcha ett api som inte finns.
+  it("klick på dokumentnamnet i demo öppnar GH-Pages-blobben (runtime-tier, #651)", async () => {
+    // #651: namn-klicket går via openMatterDocument med RUNTIME-tier. I demo →
+    // öppna GH-Pages-URL:en (self-hosted skulle i st.f. hämta via servern).
+    window.localStorage.setItem("ava.firma", JSON.stringify({ tier: "demo", repo: "ulrik-s/ava-demo" }));
     treeQuery.data = { folders: [], documents: [baseDoc()] };
-    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
-    render(<DocumentBrowser matterId="m1" />);
-    fireEvent.click(screen.getByText("test.pdf"));
-    // openDocument är async + dynamic-import:ar två moduler → vänta med waitFor
-    await import("@testing-library/react").then(({ waitFor }) =>
-      waitFor(() => expect(alertSpy).toHaveBeenCalled(), { timeout: 1000 }),
-    );
-    expect(alertSpy.mock.calls[0]![0]).toMatch(/working copy/i);
-    alertSpy.mockRestore();
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+    try {
+      render(<DocumentBrowser matterId="m1" />);
+      fireEvent.click(screen.getByText("test.pdf"));
+      await import("@testing-library/react").then(({ waitFor }) =>
+        waitFor(() => expect(openSpy).toHaveBeenCalled(), { timeout: 2000 }),
+      );
+      expect(String(openSpy.mock.calls[0]![0])).toMatch(/github\.io\/ava-demo\//);
+    } finally {
+      openSpy.mockRestore();
+      window.localStorage.removeItem("ava.firma");
+    }
   });
 
   it("formaterar filstorlek korrekt (KB, MB)", () => {

--- a/test/unit/components/document-row-upload-guard.test.tsx
+++ b/test/unit/components/document-row-upload-guard.test.tsx
@@ -91,13 +91,20 @@ describe("DocumentRow — kebab-meny + isUploading-guard", () => {
     expect(onDelete).toHaveBeenCalledTimes(1);
   });
 
-  it("Visa + Ladda ner renderas som riktiga länkar (a[href])", () => {
+  it("Visa + Ladda ner renderas som riktiga länkar (a[href]) i demo-tier (#651)", () => {
+    // #651: i demo → direkta GH-href:ar. (Self-hosted öppnar i st.f. via servern
+    // — cache-medvetet — så där är de knappar, inte länkar.)
+    window.localStorage.setItem("ava.firma", JSON.stringify({ tier: "demo", repo: "u/r" }));
+    try {
     renderRow({ isUploading: false });
     openMenu();
     expect(screen.getByText("Visa").closest("a")).toHaveAttribute("href");
     const dl = screen.getByText("Ladda ner").closest("a");
     expect(dl).toHaveAttribute("href");
     expect(dl).toHaveAttribute("download");
+    } finally {
+      window.localStorage.removeItem("ava.firma");
+    }
   });
 
   it("isUploading=true: kebab-trigger är disabled → menyn kan inte öppnas", () => {

--- a/test/unit/lib/firma/open-matter-document.test.ts
+++ b/test/unit/lib/firma/open-matter-document.test.ts
@@ -1,0 +1,41 @@
+/**
+ * `openMatterDocument` (#651) — RUNTIME-tier-routing: demo → GH-Pages-blob,
+ * self-hosted → server-backad cache-medveten fetch (ej bygg-tids-flagga).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { openMatterDocument } from "@/lib/client/firma/open-matter-document";
+
+let tier = "demo";
+const openDocumentSpy = vi.fn(async () => "opened-gh-pages");
+const createServerDownloadClientSpy = vi.fn(() => ({}));
+const loadDocumentBlobSpy = vi.fn(async () => null);
+
+vi.mock("@/lib/client/firma/firma-config", () => ({ loadFirmaConfig: () => ({ tier }) }));
+vi.mock("@/lib/client/firma/open-document", () => ({ openDocument: openDocumentSpy }));
+vi.mock("@/lib/client/fsa/handle-store", () => ({ loadHandle: async () => null }));
+vi.mock("@/lib/client/fsa/read-from-fsa", () => ({ readFromFsa: async () => null }));
+vi.mock("@/lib/client/backend/server-download-client", () => ({ createServerDownloadClient: createServerDownloadClientSpy }));
+vi.mock("@/lib/client/backend/load-document-blob", () => ({ loadDocumentBlob: loadDocumentBlobSpy }));
+
+describe("openMatterDocument (#651)", () => {
+  beforeEach(() => { openDocumentSpy.mockClear(); createServerDownloadClientSpy.mockClear(); });
+
+  it("demo → isDemo=true, ingen server-fetch (GH-Pages-blob)", async () => {
+    tier = "demo";
+    await openMatterDocument({ id: "d1", storagePath: "documents/content/d1.pdf", fileName: "d1.pdf" });
+    const deps = openDocumentSpy.mock.calls[0]![0] as { isDemo: boolean; fetchBlob?: unknown };
+    expect(deps.isDemo).toBe(true);
+    expect(deps.fetchBlob).toBeUndefined();
+    expect(createServerDownloadClientSpy).not.toHaveBeenCalled();
+  });
+
+  it("self-hosted → isDemo=false + server-backad fetchBlob", async () => {
+    tier = "self-hosted";
+    await openMatterDocument({ id: "d1", fileName: "d1.pdf" });
+    const deps = openDocumentSpy.mock.calls[0]![0] as { isDemo: boolean; fetchBlob?: unknown };
+    expect(deps.isDemo).toBe(false);
+    expect(typeof deps.fetchBlob).toBe("function");
+    expect(createServerDownloadClientSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #651.

## Bug
Clicking a document in a matter opened `https://ulrik-s.github.io/ava-demo/documents/content/<x>.pdf` instead of the local server — because doc URLs were decided by the **build-time** `NEXT_PUBLIC_DEMO_BUILD` flag (true in the self-hosted build) and the in-process content port is `StaticContentStore(GH)`.

## Fix
`openMatterDocument` decides at **runtime** (`firma-config.tier`):
- **demo** → open the bundled GH-Pages blob.
- **self-hosted** → fetch bytes from the **server** (`document.downloadContent` → GitContentStore) via a server tRPC client, **cache in IndexedDB** (`loadDocumentBlob`), open the `blob:` URL. Cache-miss populates first, then opens — the behaviour you asked for.

Routed the matter doc-row (name click + Visa/Ladda ner) and the list view through it; removed the dead build-time GH / `/api/documents/download` (non-existent) paths.

## Verification
- Live: clicking a doc opens `blob:http://localhost:8080/...` (not github.io).
- New `open-matter-document.test.ts` covers both tiers; updated doc-browser/upload-guard tests for the runtime behaviour. Full gate green (typecheck/lint/test:cov coverage above floors/knip/dep-cruiser/jscpd).

## Search (your related question)
In self-hosted, search **already covers all documents** — metadata syncs to the client and the in-process `makeDemoSearchIndex` searches the full synced store. Full file-*content* full-text for all docs would need the server's Meilisearch index (not in the local stack) — a separate infra addition, noted for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)