### PR TITLE
fix(settings): sync org to client + helper /ping storm-guard (#653)

### DIFF
--- a/src/lib/client/helper/use-helper.ts
+++ b/src/lib/client/helper/use-helper.ts
@@ -33,6 +33,18 @@ export type { HelperStatus };
 const PROBE_ORDER = [HELPER_HTTPS_BASE, HELPER_BASE] as const;
 let cachedBase: string | undefined;
 
+/**
+ * Skydd mot probe-storm (#653): en MISS cachas inte (helpern kan startas
+ * senare), men utan broms kan en anropare i en render-loop fyra av tusentals
+ * `/ping` per sekund → socket-svält (ERR_INSUFFICIENT_RESOURCES) som svälter
+ * resten av appen (t.ex. fastnade "Laddar inställningar…"). Vi
+ *   1. dedupar samtidiga probar (in-flight) → en faktisk probe åt gången, och
+ *   2. negativ-cachar en miss i `MISS_TTL_MS` → max ~1 probe/intervall.
+ */
+const MISS_TTL_MS = 10_000;
+let inFlight: Promise<{ base: string; version: string | null } | null> | null = null;
+let lastMissAt = 0;
+
 async function pingText(base: string, timeoutMs = 500): Promise<string | null> {
   try {
     const r = await fetch(`${base}/ping`, { signal: AbortSignal.timeout(timeoutMs) });
@@ -44,20 +56,30 @@ async function pingText(base: string, timeoutMs = 500): Promise<string | null> {
 
 /**
  * Pinga helpern och returnera fungerande transport + version. En cachad bas
- * provas direkt (bekräftar liveness); annars provas PROBE_ORDER. En miss
- * cachas INTE — helpern kan startas senare, så nästa anrop provar om.
+ * provas direkt (bekräftar liveness); annars provas PROBE_ORDER. Miss-broms +
+ * in-flight-dedup enligt ovan; `now()` injicerbar för test.
  */
-async function probeHelper(): Promise<{ base: string; version: string | null } | null> {
-  const bases = cachedBase !== undefined ? [cachedBase] : PROBE_ORDER;
-  for (const base of bases) {
-    const text = await pingText(base);
-    if (text !== null) {
-      cachedBase = base;
-      return { base, version: parsePingVersion(text) };
+async function probeHelper(now: () => number = Date.now): Promise<{ base: string; version: string | null } | null> {
+  if (inFlight) return inFlight; // dedup: dela pågående probe
+  if (cachedBase === undefined && now() - lastMissAt < MISS_TTL_MS) return null; // negativ-cache
+  inFlight = (async () => {
+    const bases = cachedBase !== undefined ? [cachedBase] : PROBE_ORDER;
+    for (const base of bases) {
+      const text = await pingText(base);
+      if (text !== null) {
+        cachedBase = base;
+        return { base, version: parsePingVersion(text) };
+      }
     }
+    cachedBase = undefined; // cachad bas svarar inte → prova om efter MISS_TTL_MS
+    lastMissAt = now();
+    return null;
+  })();
+  try {
+    return await inFlight;
+  } finally {
+    inFlight = null;
   }
-  cachedBase = undefined; // cachad bas svarar inte längre → prova om nästa gång
-  return null;
 }
 
 /** Den transport (https/http) helpern svarar på, eller null. */
@@ -65,9 +87,11 @@ export async function resolveHelperBase(): Promise<string | null> {
   return (await probeHelper())?.base ?? null;
 }
 
-/** Endast för tester: nollställ transport-cachen. */
+/** Endast för tester: nollställ transport-cachen + storm-broms-staten. */
 export function resetHelperBaseCache(): void {
   cachedBase = undefined;
+  inFlight = null;
+  lastMissAt = 0;
 }
 
 export function useHelper(): HelperStatus {

--- a/src/lib/server/repositories/drizzle-organization-repository.ts
+++ b/src/lib/server/repositories/drizzle-organization-repository.ts
@@ -12,4 +12,15 @@ export class DrizzleOrganizationRepository extends DrizzleRepository<Organizatio
   constructor(db: AppDb, now: () => Date = () => new Date()) {
     super(db, versionedTable(organizations), now);
   }
+
+  /**
+   * Org-raden saknar `organizationId`-kolumn — den ÄR org:en. Utan override
+   * härleder bas-`resolveOrg` ingen org → raden loggas aldrig i change_log →
+   * synkas aldrig till klienten → `organization.getSettings` (organizations.
+   * getById) hittar inget → "Laddar inställningar…" hänger (#653). Org:ens
+   * egna `id` är dess org-scope.
+   */
+  protected override resolveOrg(row: unknown): string | undefined {
+    return (row as { id?: string }).id;
+  }
 }

--- a/test/unit/components/helper-section.test.tsx
+++ b/test/unit/components/helper-section.test.tsx
@@ -5,11 +5,13 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
 import { HelperSection } from "@/components/settings/helper-section";
+import { resetHelperBaseCache } from "@/lib/client/helper/use-helper";
 
 const originalFetch = global.fetch;
 beforeEach(() => {
   vi.restoreAllMocks();
   global.fetch = originalFetch;
+  resetHelperBaseCache(); // nollställ probe-cache/in-flight/miss-broms (#653) mellan tester
 });
 
 describe("HelperSection", () => {

--- a/test/unit/lib/helper/use-helper.test.tsx
+++ b/test/unit/lib/helper/use-helper.test.tsx
@@ -9,6 +9,7 @@ import {
   openViaHelper,
   triggerHelperUpdateCheck,
   resetHelperBaseCache,
+  resolveHelperBase,
 } from "@/lib/client/helper/use-helper";
 
 const HTTPS = "https://localhost:48762";
@@ -65,6 +66,17 @@ describe("useHelper / transport", () => {
     global.fetch = routeFetch([[`${HTTPS}/ping`, () => new Response("garbage", { status: 200 })]]);
     render(<Probe />);
     await waitFor(() => expect(screen.getByText("absent")).toBeInTheDocument());
+  });
+
+  it("negativ-cachar en miss → ingen probe-storm (#653)", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("down"));
+    global.fetch = fetchMock;
+    expect(await resolveHelperBase()).toBeNull();
+    const afterFirst = fetchMock.mock.calls.length; // PROBE_ORDER (https + http)
+    expect(afterFirst).toBeGreaterThan(0);
+    // En andra probe inom MISS_TTL ska INTE fyra av fler /ping (negativ-cache).
+    expect(await resolveHelperBase()).toBeNull();
+    expect(fetchMock.mock.calls.length).toBe(afterFirst);
   });
 });
 

--- a/test/unit/server/sync/drizzle-sync-store.test.ts
+++ b/test/unit/server/sync/drizzle-sync-store.test.ts
@@ -53,6 +53,16 @@ describe("DrizzleSyncStore (#sync-bridge)", () => {
     expect((await sync.pull(ORG, res.cursor)).changes).toHaveLength(0);
   });
 
+  // #653: org-raden saknar organizationId-kolumn (den ÄR org:en) → utan
+  // resolveOrg-override (→ egna id:t) loggas den aldrig → synkas aldrig →
+  // klientens organization.getSettings hittar inget → "Laddar inställningar…".
+  it("organization delta-synkas via pull (org = sitt eget org-scope, #653)", async () => {
+    const org2 = uuidv7();
+    await repos.organizations.create({ id: org2, name: "Synk-byrå AB" } as never);
+    const change = (await sync.pull(org2, 0)).changes.find((c) => c.row.id === org2);
+    expect(change).toMatchObject({ entity: "organization", row: { id: org2, name: "Synk-byrå AB" } });
+  });
+
   it("isolerar per org (pull ser inte en annan byrås ändringar)", async () => {
     expect((await sync.pull(uuidv7(), 0)).changes).toHaveLength(0);
   });


### PR DESCRIPTION
Closes #653.

## "Laddar inställningar…" hang — two root causes
1. **Organization never synced.** `organization.getSettings` → `organizations.getById(orgId)`, but the org row has no `organizationId` column (it *is* the org) → `logChange`'s `resolveOrg` returned `undefined` → the org was never written to `change_log` → never synced → the client had no org → `getSettings` hung. Fix: `DrizzleOrganizationRepository.resolveOrg` returns the org's own `id`.
2. **Helper `/ping` storm.** `probeHelper` never cached a miss → a caller in a render-loop fired ~24,000 `/ping`/s → socket exhaustion. Fix: in-flight dedup + short negative-cache TTL.

## Verification (live)
`/settings` now renders (Datakälla / Byråns uppgifter / AVA Helper / Standardvyer) — no hang. `/ping` failures during `/settings`: **2** (was ~24,000). New tests: org delta-sync (#653), helper negative-cache, helper-section reset. Gate green (typecheck/lint/test:cov coverage above floors/knip/dep-cruiser/jscpd).

> The second reported issue (open docs in PDF Gear/Word from Firefox via the helper) is a separate, larger feature gap — see PR description notes / my message. Not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)