### PR TITLE
feat(helper): synlig synk-status för upload-kön (#659)

### DIFF
--- a/helper-app/src/main.ts
+++ b/helper-app/src/main.ts
@@ -198,7 +198,7 @@ function main(): void {
     version: VERSION,
     extraOrigins: extraOrigins(),
     onCheckUpdate: () => { void checkOnce(updateCfg).catch((err) => log(`check-update: ${String(err)}`)); },
-    ...(queue ? { onOpen: queueBackedOnOpen(queue) } : {}),
+    ...(queue ? { onOpen: queueBackedOnOpen(queue), onStatus: () => queue.snapshot() } : {}),
   });
 
   const httpServer = Bun.serve({ port, hostname: "127.0.0.1", fetch: handler });

--- a/helper-app/src/queue.ts
+++ b/helper-app/src/queue.ts
@@ -18,37 +18,21 @@
 import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
+import type { HelperStatusResponse, HelperSyncEntry } from "@/lib/shared/helper/protocol";
 import { log } from "./log.ts";
 
-/** En köad upload som väntar på att nå servern. */
-export interface QueueEntry {
-  /** Stabilt id (= filnamn-stam i kö-katalogen). */
-  id: string;
-  /** PUT-mål på servern. */
-  uploadUrl: string;
-  /** Användarsynligt filnamn (status-UI). */
-  fileName: string;
+/**
+ * En köad upload som väntar på att nå servern. Delar form med det publika
+ * {@link HelperSyncEntry} (status-API:t) + en intern `authHeader` som ALDRIG
+ * exponeras i snapshots.
+ */
+export interface QueueEntry extends HelperSyncEntry {
   /** Vidarebefordras orörd till upload (ersätts av device-token i steg 2). */
   authHeader?: string;
-  /** När den först köades (ms). */
-  enqueuedAt: number;
-  /** Antal misslyckade försök. */
-  attempts: number;
-  /** Tidigast nästa försök får ske (ms) — exponentiell backoff. */
-  nextAttemptAt: number;
-  /** `pending` = väntar/retr:as; `conflict` = server gått förbi, kräver beslut. */
-  status: "pending" | "conflict";
-  /** Senaste felet (för status-UI/loggning). */
-  lastError?: string;
 }
 
 /** Ögonblicksbild för status-UI (helper-meny + web-app-banner, steg 8). */
-export interface QueueSnapshot {
-  pending: number;
-  conflict: number;
-  total: number;
-  entries: ReadonlyArray<Omit<QueueEntry, "authHeader">>;
-}
+export type QueueSnapshot = HelperStatusResponse;
 
 /** Vad en dränerings-runda gjorde (för loggning/test). */
 export interface DrainResult {

--- a/helper-app/src/server.ts
+++ b/helper-app/src/server.ts
@@ -7,6 +7,7 @@
  *   POST /open          → ladda ner → spawn default-app → watch+upload
  *   POST /compose-mail  → skriv bilaga → öppna mail-app
  *   POST /check-update  → trigga omedelbar self-update-kontroll
+ *   GET  /status        → JSON ögonblicksbild av upload-kön (ADR 0028 §8)
  *
  * Säkerhet: lyssnar bara på localhost; CORS-whitelist (localhost-portar
  * + *.github.io + custom via AVA_HELPER_ORIGINS); inga endpoints som
@@ -16,6 +17,7 @@
 import {
   formatPing,
   isAllowedOrigin,
+  type HelperStatusResponse,
   type HelperVersionResponse,
 } from "@/lib/shared/helper/protocol";
 import { handleComposeMail } from "./compose-mail.ts";
@@ -30,7 +32,11 @@ export interface ServerDeps {
   onComposeMail?: (req: Request) => Promise<Response>;
   /** Trigga self-update. undefined → endpointen svarar 500 (ej konfigurerad). */
   onCheckUpdate?: () => void;
+  /** Ögonblicksbild av upload-kön. undefined → tom kö (kön avstängd). */
+  onStatus?: () => HelperStatusResponse;
 }
+
+const EMPTY_STATUS: HelperStatusResponse = { pending: 0, conflict: 0, total: 0, entries: [] };
 
 /** Bygg en fetch-handler (testbar utan att binda en port). */
 export function createHandler(deps: ServerDeps): (req: Request) => Promise<Response> {
@@ -45,24 +51,26 @@ export function createHandler(deps: ServerDeps): (req: Request) => Promise<Respo
   };
 }
 
+/**
+ * Dispatch-tabell pathname → hanterare. Tabell i st.f. switch håller `route`
+ * platt (cyklomatisk komplexitet ≤ 8) när endpoints växer; varje hanterare
+ * bär sin egen lilla logik.
+ */
+const ROUTES: Record<string, (req: Request, deps: ServerDeps) => Response | Promise<Response>> = {
+  "/ping": (_req, deps) =>
+    new Response(formatPing(deps.version), { headers: { "Content-Type": "text/plain; charset=utf-8" } }),
+  "/version": (_req, deps) =>
+    json({ current: deps.version, updateAvailable: false } satisfies HelperVersionResponse),
+  "/open": (req, deps) => (deps.onOpen ?? handleOpen)(req),
+  "/compose-mail": (req, deps) => (deps.onComposeMail ?? handleComposeMail)(req),
+  "/check-update": (_req, deps) => handleCheckUpdate(deps),
+  "/status": (_req, deps) => json(deps.onStatus?.() ?? EMPTY_STATUS),
+};
+
 async function route(req: Request, deps: ServerDeps): Promise<Response> {
   const { pathname } = new URL(req.url);
-  switch (pathname) {
-    case "/ping":
-      return new Response(formatPing(deps.version), {
-        headers: { "Content-Type": "text/plain; charset=utf-8" },
-      });
-    case "/version":
-      return json({ current: deps.version, updateAvailable: false } satisfies HelperVersionResponse);
-    case "/open":
-      return (deps.onOpen ?? handleOpen)(req);
-    case "/compose-mail":
-      return (deps.onComposeMail ?? handleComposeMail)(req);
-    case "/check-update":
-      return handleCheckUpdate(deps);
-    default:
-      return textError(404, "not found");
-  }
+  const handler = ROUTES[pathname];
+  return handler ? handler(req, deps) : textError(404, "not found");
 }
 
 function handleCheckUpdate(deps: ServerDeps): Response {

--- a/helper-app/test/server.test.ts
+++ b/helper-app/test/server.test.ts
@@ -89,6 +89,29 @@ describe("/check-update", () => {
   });
 });
 
+describe("GET /status", () => {
+  test("tom kö när onStatus ej konfigurerad", async () => {
+    const res = await handler()(req("/status"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ pending: 0, conflict: 0, total: 0, entries: [] });
+  });
+
+  test("returnerar kö-ögonblicksbilden från onStatus", async () => {
+    const snapshot = {
+      pending: 1,
+      conflict: 1,
+      total: 2,
+      entries: [
+        { id: "a", uploadUrl: "http://s/1", fileName: "x.docx", enqueuedAt: 1, attempts: 0, nextAttemptAt: 1, status: "pending" as const },
+        { id: "b", uploadUrl: "http://s/2", fileName: "y.docx", enqueuedAt: 2, attempts: 3, nextAttemptAt: 9, status: "conflict" as const, lastError: "HTTP 409" },
+      ],
+    };
+    const h = handler({ onStatus: () => snapshot });
+    const res = await h(req("/status"));
+    expect(await res.json()).toEqual(snapshot);
+  });
+});
+
 describe("okänd route", () => {
   test("404", async () => {
     const res = await handler()(req("/nope"));

--- a/src/components/settings/helper-section.tsx
+++ b/src/components/settings/helper-section.tsx
@@ -8,8 +8,8 @@
  * användaren om helpern är installerad och kör.
  */
 
-import { ExternalLink, CheckCircle2, XCircle, Loader2 } from "lucide-react";
-import { useHelper, triggerHelperUpdateCheck } from "@/lib/client/helper/use-helper";
+import { ExternalLink, CheckCircle2, XCircle, Loader2, CloudUpload, AlertTriangle, CloudCheck } from "lucide-react";
+import { useHelper, useHelperSyncStatus, triggerHelperUpdateCheck } from "@/lib/client/helper/use-helper";
 
 const RELEASES_URL = "https://github.com/ulrik-s/ava/releases?q=helper-&expanded=true";
 
@@ -29,6 +29,7 @@ export function HelperSection() {
       </p>
 
       <Status status={status} />
+      {status.version ? <SyncStatus /> : null}
 
       <div className="mt-4 flex flex-wrap items-center gap-3 text-sm">
         <a href={RELEASES_URL} target="_blank" rel="noreferrer"
@@ -43,6 +44,38 @@ export function HelperSection() {
           </button>
         )}
       </div>
+    </div>
+  );
+}
+
+/**
+ * Synk-status för helperns durabla upload-kö (ADR 0028 §8): offline-sparningar
+ * får ALDRIG vara osynliga. Visar konflikt > väntande > allt-synkat (i den
+ * prioritetsordningen). Renderar inget innan första pollen / utan /status.
+ */
+function SyncStatus() {
+  const sync = useHelperSyncStatus();
+  if (sync === null) return null;
+  if (sync.conflict > 0) {
+    return (
+      <div className="mt-2 inline-flex items-center gap-2 text-sm text-amber-700">
+        <AlertTriangle size={14} />
+        <span>{sync.conflict} dokument i konflikt — servern har en nyare version. Öppna och spara igen för att lösa.</span>
+      </div>
+    );
+  }
+  if (sync.pending > 0) {
+    return (
+      <div className="mt-2 inline-flex items-center gap-2 text-sm text-blue-700">
+        <CloudUpload size={14} />
+        <span>{sync.pending} {sync.pending === 1 ? "ändring väntar" : "ändringar väntar"} på synk — sparas så fort servern går att nå.</span>
+      </div>
+    );
+  }
+  return (
+    <div className="mt-2 inline-flex items-center gap-2 text-sm text-green-700">
+      <CloudCheck size={14} />
+      <span>Allt synkat — inga väntande ändringar.</span>
     </div>
   );
 }

--- a/src/lib/client/helper/use-helper.ts
+++ b/src/lib/client/helper/use-helper.ts
@@ -25,9 +25,10 @@ import {
   type ComposeMailRequest,
   type HelperOpenRequest,
   type HelperStatus,
+  type HelperStatusResponse,
 } from "@/lib/shared/helper/protocol";
 
-export type { HelperStatus };
+export type { HelperStatus, HelperStatusResponse };
 
 // HTTPS först (Safari kräver det), sedan HTTP (Chromium/Firefox).
 const PROBE_ORDER = [HELPER_HTTPS_BASE, HELPER_BASE] as const;
@@ -133,6 +134,52 @@ export async function openViaHelper(input: HelperOpenRequest): Promise<void> {
   if (!r.ok) {
     throw new Error(`helper /open: HTTP ${r.status} ${await r.text()}`);
   }
+}
+
+/**
+ * Hämta helperns upload-kö-status (`GET /status`, ADR 0028 §8). Returnerar
+ * null om helpern saknas eller svaret inte går att tolka — så anroparen kan
+ * dölja synk-status helt när ingen helper finns.
+ */
+export async function fetchHelperStatus(): Promise<HelperStatusResponse | null> {
+  try {
+    const r = await helperFetch("/status", { signal: AbortSignal.timeout(2_000) });
+    if (r === null || !r.ok) return null;
+    const data = (await r.json()) as Partial<HelperStatusResponse>;
+    if (typeof data.pending !== "number" || typeof data.conflict !== "number" || typeof data.total !== "number" || !Array.isArray(data.entries)) {
+      return null;
+    }
+    return { pending: data.pending, conflict: data.conflict, total: data.total, entries: data.entries };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pollar helperns synk-status periodiskt (default var 5:e sekund) så
+ * webbappen kan visa "väntar på synk / konflikt". null tills första svaret,
+ * och om helpern saknas. Pollningen stannar när komponenten avmonteras.
+ */
+export function useHelperSyncStatus(intervalMs = 5_000): HelperStatusResponse | null {
+  const [sync, setSync] = useState<HelperStatusResponse | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    async function poll(): Promise<void> {
+      const s = await fetchHelperStatus();
+      if (cancelled) return;
+      setSync(s);
+      timer = setTimeout(() => void poll(), intervalMs);
+    }
+    void poll();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [intervalMs]);
+
+  return sync;
 }
 
 /** Trigga omedelbar self-update-kontroll. */

--- a/src/lib/shared/helper/protocol.ts
+++ b/src/lib/shared/helper/protocol.ts
@@ -81,6 +81,46 @@ export interface HelperVersionResponse {
 }
 
 /**
+ * En köad (ännu ej synkad) dokument-upload i helperns durabla kö (ADR 0028 §3).
+ * Exponeras via `GET /status` så webbappen kan visa synk-status. Innehåller
+ * ALDRIG authHeader (känsligt) — bara det UI:t behöver.
+ */
+export interface HelperSyncEntry {
+  /** Stabilt id i kö-katalogen. */
+  id: string;
+  /** PUT-mål på servern (identifierar dokumentet). */
+  uploadUrl: string;
+  /** Användarsynligt filnamn. */
+  fileName: string;
+  /** När den först köades (ms sedan epoch). */
+  enqueuedAt: number;
+  /** Antal misslyckade upload-försök hittills. */
+  attempts: number;
+  /** Tidigast nästa försök (ms) — backoff. */
+  nextAttemptAt: number;
+  /** `pending` = väntar/retr:as; `conflict` = server gått förbi, kräver beslut. */
+  status: "pending" | "conflict";
+  /** Senaste felet (om något). */
+  lastError?: string;
+}
+
+/**
+ * Svar på `GET /status` — ögonblicksbild av helperns upload-kö (ADR 0028 §8).
+ * Webbappen pollar detta för att visa "väntar på synk / konflikt"-status så
+ * offline-sparningar aldrig är osynliga (motsatsen till KATS-HIIT).
+ */
+export interface HelperStatusResponse {
+  /** Antal poster som väntar/retr:as. */
+  pending: number;
+  /** Antal poster i versions-konflikt (kräver beslut). */
+  conflict: number;
+  /** Totalt antal poster i kön. */
+  total: number;
+  /** Posterna (utan authHeaders). */
+  entries: HelperSyncEntry[];
+}
+
+/**
  * Webbappens vy av helper-status: undefined = ej kontrollerat,
  * null = inte tillgänglig, string = installerad version.
  */

--- a/test/unit/components/helper-section.test.tsx
+++ b/test/unit/components/helper-section.test.tsx
@@ -1,11 +1,14 @@
 /**
- * HelperSection — visar AVA Helper-status i Inställningar.
+ * HelperSection — visar AVA Helper-status + synk-status (ADR 0028 §8) i Inställningar.
  */
 
 import { render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
 import { HelperSection } from "@/components/settings/helper-section";
 import { resetHelperBaseCache } from "@/lib/client/helper/use-helper";
+
+const HTTPS = "https://localhost:48762";
+const HTTP = "http://127.0.0.1:48761";
 
 const originalFetch = global.fetch;
 beforeEach(() => {
@@ -14,7 +17,25 @@ beforeEach(() => {
   resetHelperBaseCache(); // nollställ probe-cache/in-flight/miss-broms (#653) mellan tester
 });
 
-describe("HelperSection", () => {
+/** fetch-mock som svarar per URL-fragment; okända URL:er rejectar (helper-saknas). */
+function routeFetch(routes: Array<[string, () => Response]>): ReturnType<typeof vi.fn> {
+  return vi.fn((url: string | URL) => {
+    const u = String(url);
+    for (const [frag, make] of routes) {
+      if (u.includes(frag)) return Promise.resolve(make());
+    }
+    return Promise.reject(new Error(`unmocked: ${u}`));
+  });
+}
+
+function pingOk(): Response {
+  return new Response("ava-helper v1.0.0\n", { status: 200 });
+}
+function statusBody(snap: { pending: number; conflict: number; total: number }): Response {
+  return new Response(JSON.stringify({ ...snap, entries: [] }), { status: 200 });
+}
+
+describe("HelperSection — installations-status", () => {
   it("visar 'Kontrollerar…' först", () => {
     global.fetch = vi.fn(() => new Promise<Response>(() => { /* hänger */ }));
     render(<HelperSection />);
@@ -22,9 +43,7 @@ describe("HelperSection", () => {
   });
 
   it("visar version när helpern svarar", async () => {
-    global.fetch = vi.fn().mockResolvedValueOnce(
-      new Response("ava-helper v1.0.0\n", { status: 200 })
-    );
+    global.fetch = routeFetch([[`${HTTPS}/ping`, pingOk], [`${HTTPS}/status`, () => statusBody({ pending: 0, conflict: 0, total: 0 })]]);
     render(<HelperSection />);
     await waitFor(() => expect(screen.getByText(/Installerad/)).toBeInTheDocument());
     expect(screen.getByText("v1.0.0")).toBeInTheDocument();
@@ -36,12 +55,38 @@ describe("HelperSection", () => {
     await waitFor(() => expect(screen.getByText(/Inte installerad/)).toBeInTheDocument());
   });
 
-  it("alltid visar länk till release-sidan", () => {
-    global.fetch = vi.fn().mockResolvedValueOnce(
-      new Response("ava-helper v1.0.0\n", { status: 200 })
-    );
+  it("alltid visar länk till release-sidan", async () => {
+    global.fetch = routeFetch([[`${HTTP}/ping`, pingOk], [`${HTTP}/status`, () => statusBody({ pending: 0, conflict: 0, total: 0 })]]);
     render(<HelperSection />);
-    const link = screen.getByRole("link", { name: /Ladda ner/ });
+    const link = await screen.findByRole("link", { name: /Ladda ner/ });
     expect(link.getAttribute("href")).toMatch(/github\.com\/ulrik-s\/ava\/releases/);
+  });
+});
+
+describe("HelperSection — synk-status (ADR 0028 §8)", () => {
+  it("visar 'Allt synkat' när kön är tom", async () => {
+    global.fetch = routeFetch([[`${HTTPS}/ping`, pingOk], [`${HTTPS}/status`, () => statusBody({ pending: 0, conflict: 0, total: 0 })]]);
+    render(<HelperSection />);
+    await waitFor(() => expect(screen.getByText(/Allt synkat/)).toBeInTheDocument());
+  });
+
+  it("visar antal väntande ändringar", async () => {
+    global.fetch = routeFetch([[`${HTTPS}/ping`, pingOk], [`${HTTPS}/status`, () => statusBody({ pending: 3, conflict: 0, total: 3 })]]);
+    render(<HelperSection />);
+    await waitFor(() => expect(screen.getByText(/3 ändringar väntar/)).toBeInTheDocument());
+  });
+
+  it("visar konflikt-varning (prioriteras över väntande)", async () => {
+    global.fetch = routeFetch([[`${HTTPS}/ping`, pingOk], [`${HTTPS}/status`, () => statusBody({ pending: 1, conflict: 2, total: 3 })]]);
+    render(<HelperSection />);
+    await waitFor(() => expect(screen.getByText(/2 dokument i konflikt/)).toBeInTheDocument());
+  });
+
+  it("döljer synk-status helt när helpern saknas", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("down"));
+    render(<HelperSection />);
+    await waitFor(() => expect(screen.getByText(/Inte installerad/)).toBeInTheDocument());
+    expect(screen.queryByText(/Allt synkat/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/väntar/)).not.toBeInTheDocument();
   });
 });

--- a/test/unit/lib/helper/use-helper.test.tsx
+++ b/test/unit/lib/helper/use-helper.test.tsx
@@ -10,6 +10,7 @@ import {
   triggerHelperUpdateCheck,
   resetHelperBaseCache,
   resolveHelperBase,
+  fetchHelperStatus,
 } from "@/lib/client/helper/use-helper";
 
 const HTTPS = "https://localhost:48762";
@@ -105,6 +106,31 @@ describe("openViaHelper", () => {
   it("kastar 'inte tillgänglig' när helpern saknas", async () => {
     global.fetch = vi.fn().mockRejectedValue(new Error("down"));
     await expect(openViaHelper({ fileName: "x.pdf", downloadUrl: "u" })).rejects.toThrow(/inte tillgänglig/);
+  });
+});
+
+describe("fetchHelperStatus", () => {
+  const SNAP = { pending: 2, conflict: 1, total: 3, entries: [] };
+
+  it("returnerar kö-status från /status", async () => {
+    global.fetch = routeFetch([
+      [`${HTTPS}/ping`, () => new Response("ava-helper v1\n", { status: 200 })],
+      [`${HTTPS}/status`, () => new Response(JSON.stringify(SNAP), { status: 200 })],
+    ]);
+    expect(await fetchHelperStatus()).toEqual(SNAP);
+  });
+
+  it("null när helpern saknas", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("down"));
+    expect(await fetchHelperStatus()).toBeNull();
+  });
+
+  it("null vid trasigt status-svar (fel form)", async () => {
+    global.fetch = routeFetch([
+      [`${HTTPS}/ping`, () => new Response("ava-helper v1\n", { status: 200 })],
+      [`${HTTPS}/status`, () => new Response(JSON.stringify({ pending: "nope" }), { status: 200 })],
+    ]);
+    expect(await fetchHelperStatus()).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Vad

Genomförande-steg **8** av ADR 0028 (#655): gör helperns durabla upload-kö (#657) **synlig**. Offline-sparningar får aldrig vara osynliga — det var kärnlärdomen från KATS-HIIT-fällan (tyst synk-fel = arga användare).

## Hur

- **Helper `GET /status`** returnerar en ögonblicksbild av kön: `{ pending, conflict, total, entries }` (utan authHeaders). Route-switchen blev en **dispatch-tabell** (pathname → hanterare) så cyklomatisk komplexitet hålls ≤8 när endpoints växer.
- **Delade typer** `HelperSyncEntry` / `HelperStatusResponse` i `src/lib/shared/helper/protocol.ts` — single source of truth helper↔web. `UploadQueue`-snapshoten återanvänder dem (ingen drift).
- **Web:** `fetchHelperStatus()` (validerar svarsformen, null om helper saknas) + `useHelperSyncStatus()` (pollar var 5:e sek, stannar vid unmount). `HelperSection` i Inställningar visar i prioritetsordning: **konflikt** (⚠ servern har nyare version → öppna+spara igen) > **väntande** (⏳ N ändringar synkas när servern nås) > **allt synkat** (✓). Visas bara när helpern finns.

Helper-menyrad-status (native tray) noteras som framtida — helpern kör i dag headless som service.

## Test

Helper: `/status`-route (tom kö + ifylld snapshot); helper-svit 168 grön, coverage över golv. Web: `fetchHelperStatus` (ok/saknas/trasig form) + `HelperSection`-synk-status (synkat/väntande/konflikt/dold). Full enhetssvit 3213 grön; typecheck/lint/knip/dep-cruiser/jscpd rena; cross-build ok.

Closes #659. Refs #655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)