### PR TITLE
feat(helper): durabelt content-adresserat lager — offline-reopen (#661)

### DIFF
--- a/helper-app/src/content-store.ts
+++ b/helper-app/src/content-store.ts
@@ -1,0 +1,151 @@
+/**
+ * Durabelt, content-adresserat lokalt dokument-lager (ADR 0028 §3, ADR 0023).
+ *
+ * Läs-sidan av offline-first: när helpern laddat ner ett dokument cachas
+ * bytsen durabelt så att SAMMA dokument kan **öppnas igen offline** utan nät.
+ * Bytsen lagras under sin egen SHA-256 (content-adresserat → automatisk dedup
+ * + integritet: samma version = samma hash = samma fil), och ett index mappar
+ * den logiska nyckeln (download-URL:en, som identifierar dokument+version) →
+ * hashen. `lastUsedAt` stämplas vid varje store/load och är substratet för
+ * 30-dagars-vräkningen (steg 7).
+ *
+ * Klockan injiceras (`ContentStoreDeps.now`) → deterministiska tester. Filsystem
+ * används direkt mot lager-katalogen.
+ */
+
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { log } from "./log.ts";
+
+/** En indexpost: vilken blob en logisk nyckel pekar på + metadata. */
+export interface ContentIndexEntry {
+  /** SHA-256 (hex) av bytsen = blob-filnamnets stam. */
+  hash: string;
+  /** Användarsynligt filnamn (för logg/UI). */
+  fileName: string;
+  /** Antal bytes. */
+  size: number;
+  /** Senast använd (ms sedan epoch) — driver tids-vräkning (steg 7). */
+  lastUsedAt: number;
+}
+
+type ContentIndex = Record<string, ContentIndexEntry>;
+
+export interface ContentStoreDeps {
+  now: () => number;
+}
+
+export const defaultContentStoreDeps: ContentStoreDeps = { now: () => Date.now() };
+
+/** SHA-256 (hex) av bytes. Content-adress-nyckeln. */
+export function sha256Hex(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+/**
+ * Content-adresserat dokument-lager på disk. Konstruera med lager-katalogen;
+ * `store()` efter nedladdning, `load()` vid offline-öppning.
+ */
+export class ContentStore {
+  private readonly dir: string;
+  private readonly deps: ContentStoreDeps;
+  private index: ContentIndex | undefined;
+
+  constructor(dir: string, deps: ContentStoreDeps = defaultContentStoreDeps) {
+    this.dir = dir;
+    this.deps = deps;
+  }
+
+  private indexPath(): string {
+    return join(this.dir, "index.json");
+  }
+
+  private blobPath(hash: string): string {
+    return join(this.dir, "blobs", `${hash}.bin`);
+  }
+
+  /** Läs in (eller initiera) indexet — lat, en gång. */
+  private async ensureIndex(): Promise<ContentIndex> {
+    if (this.index !== undefined) return this.index;
+    try {
+      this.index = JSON.parse(await readFile(this.indexPath(), "utf8")) as ContentIndex;
+    } catch {
+      this.index = {};
+    }
+    return this.index;
+  }
+
+  private async persistIndex(index: ContentIndex): Promise<void> {
+    await mkdir(this.dir, { recursive: true });
+    await writeFile(this.indexPath(), JSON.stringify(index), "utf8");
+  }
+
+  /**
+   * Cacha bytes durabelt under sin hash och peka nyckeln dit. Skriver inte om
+   * en blob som redan finns (dedup). Returnerar hashen.
+   */
+  async store(key: string, bytes: Uint8Array, fileName: string): Promise<string> {
+    const index = await this.ensureIndex();
+    const hash = sha256Hex(bytes);
+    const path = this.blobPath(hash);
+    if (!(await Bun.file(path).exists())) {
+      await mkdir(join(this.dir, "blobs"), { recursive: true });
+      await writeFile(path, bytes);
+    }
+    index[key] = { hash, fileName, size: bytes.byteLength, lastUsedAt: this.deps.now() };
+    await this.persistIndex(index);
+    log(`content: cachade ${fileName} (${bytes.byteLength} B, ${hash.slice(0, 8)})`);
+    return hash;
+  }
+
+  /**
+   * Hämta cachade bytes för en nyckel, eller null om de saknas. Bumpar
+   * `lastUsedAt`. Städar bort en index-post vars blob försvunnit.
+   */
+  async load(key: string): Promise<Uint8Array | null> {
+    const index = await this.ensureIndex();
+    const entry = index[key];
+    if (entry === undefined) return null;
+    let bytes: Uint8Array;
+    try {
+      bytes = await readFile(this.blobPath(entry.hash));
+    } catch {
+      delete index[key]; // blob borta (t.ex. vräkt) → städa indexet
+      await this.persistIndex(index);
+      return null;
+    }
+    entry.lastUsedAt = this.deps.now();
+    await this.persistIndex(index);
+    return bytes;
+  }
+
+  /** Finns bytes cachade för nyckeln (utan att läsa dem)? */
+  async has(key: string): Promise<boolean> {
+    const index = await this.ensureIndex();
+    return index[key] !== undefined;
+  }
+
+  /**
+   * Vräk poster som inte använts på `maxAgeMs` (ADR 0028 §7, default-driver
+   * wiras i steg 7). Tar bort en blob bara när ingen kvarvarande nyckel
+   * pekar på den (content-adresserat → delad). Returnerar antal vräkta nycklar.
+   */
+  async evictUnusedOlderThan(maxAgeMs: number): Promise<number> {
+    const index = await this.ensureIndex();
+    const cutoff = this.deps.now() - maxAgeMs;
+    const stale = Object.entries(index).filter(([, e]) => e.lastUsedAt < cutoff);
+    for (const [key, entry] of stale) {
+      delete index[key];
+      if (!Object.values(index).some((e) => e.hash === entry.hash)) {
+        await rm(this.blobPath(entry.hash), { force: true });
+      }
+    }
+    if (stale.length > 0) {
+      await this.persistIndex(index);
+      log(`content: vräkte ${stale.length} oanvänd(a) post(er)`);
+    }
+    return stale.length;
+  }
+}

--- a/helper-app/src/main.ts
+++ b/helper-app/src/main.ts
@@ -21,9 +21,19 @@ import { join } from "node:path";
 
 import { HELPER_HTTPS_PORT, HELPER_PORT } from "@/lib/shared/helper/protocol";
 
+import { ContentStore } from "./content-store.ts";
 import { installService, uninstallService, type InstallDeps } from "./install.ts";
 import { initLog, log } from "./log.ts";
-import { defaultOpenDeps, defaultWatchDeps, enqueueSavedFile, handleOpen, watchAndUpload, type OpenDeps } from "./open.ts";
+import {
+  defaultOpenDeps,
+  defaultWatchDeps,
+  enqueueSavedFile,
+  handleOpen,
+  persistDownloaded,
+  restoreCached,
+  watchAndUpload,
+  type OpenDeps,
+} from "./open.ts";
 import { dataDir } from "./paths.ts";
 import { currentPlatform } from "./platform/runtime.ts";
 import { UploadQueue } from "./queue.ts";
@@ -135,11 +145,12 @@ function buildUpdateConfig(): UpdateConfig {
 }
 
 /**
- * `/open`-hanterare vars watch-loop ENQUEUE:ar varje save i den durabla
- * kön i stället för att PUT:a direkt. Sparningen blir därmed durabel innan
- * den når nätet (ADR 0028 §3) — kön dränerar autonomt och överlever omstart.
+ * `/open`-hanterare som gör dokument-livscykeln offline-first (ADR 0028 §3):
+ * watch-loopen ENQUEUE:ar varje save i den durabla kön (i st.f. direkt-PUT),
+ * nedladdade bytes cachas content-adresserat (persist) och en cachad kopia
+ * återställs (restore) om nedladdning misslyckas offline.
  */
-export function queueBackedOnOpen(queue: UploadQueue): (req: Request) => Promise<Response> {
+export function queueBackedOnOpen(queue: UploadQueue, content: ContentStore): (req: Request) => Promise<Response> {
   const deps: OpenDeps = {
     ...defaultOpenDeps,
     startWatch: (path, uploadUrl, authHeader, timeoutMs) =>
@@ -147,20 +158,29 @@ export function queueBackedOnOpen(queue: UploadQueue): (req: Request) => Promise
         ...defaultWatchDeps,
         upload: (p, url, auth) => enqueueSavedFile(queue, p, url, auth),
       }),
+    persist: (url, path, fileName) => persistDownloaded(content, url, path, fileName),
+    restore: (url, path) => restoreCached(content, url, path),
   };
   return (req) => handleOpen(req, deps);
 }
 
-/** Skapa + återställ upload-kön (om data-dir finns) och starta dränerings-loopen. */
-function startUploadQueue(signal: AbortSignal): UploadQueue | undefined {
+/** De durabla lagren (kö + content) när data-dir finns. */
+interface Stores {
+  queue: UploadQueue;
+  content: ContentStore;
+}
+
+/** Skapa + återställ kön + content-lagret (om data-dir finns) och starta dränerings-loopen. */
+function startStores(signal: AbortSignal): Stores | undefined {
   const dir = dataDir();
   if (dir === null) {
-    log("ingen data-dir → upload-kö inaktiverad (direkt-upload)");
+    log("ingen data-dir → durabla lager inaktiverade (direkt-upload, ingen offline-cache)");
     return undefined;
   }
   const queue = new UploadQueue(join(dir, "queue"));
   void queue.recover().then(() => queue.startDrainLoop(signal));
-  return queue;
+  const content = new ContentStore(join(dir, "content"));
+  return { queue, content };
 }
 
 function main(): void {
@@ -193,12 +213,12 @@ function main(): void {
   const abort = new AbortController();
   void runUpdateLoop(updateCfg, abort.signal);
 
-  const queue = startUploadQueue(abort.signal);
+  const stores = startStores(abort.signal);
   const handler = createHandler({
     version: VERSION,
     extraOrigins: extraOrigins(),
     onCheckUpdate: () => { void checkOnce(updateCfg).catch((err) => log(`check-update: ${String(err)}`)); },
-    ...(queue ? { onOpen: queueBackedOnOpen(queue), onStatus: () => queue.snapshot() } : {}),
+    ...(stores ? { onOpen: queueBackedOnOpen(stores.queue, stores.content), onStatus: () => stores.queue.snapshot() } : {}),
   });
 
   const httpServer = Bun.serve({ port, hostname: "127.0.0.1", fetch: handler });

--- a/helper-app/src/open.ts
+++ b/helper-app/src/open.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 
 import { isSafeFileName, type HelperOpenRequest } from "@/lib/shared/helper/protocol";
+import type { ContentStore } from "./content-store.ts";
 import { json, parseJsonBody, textError } from "./http.ts";
 import { log } from "./log.ts";
 import { openWithDefaultApp } from "./platform/open-app.ts";
@@ -25,6 +26,10 @@ export interface OpenDeps {
   openApp: (path: string) => Promise<void>;
   makeSessionDir: () => Promise<string>;
   startWatch: (path: string, uploadUrl: string, authHeader: string | undefined, timeoutMs: number) => void;
+  /** Cacha nedladdade bytes durabelt (offline-reopen, ADR 0028 §3). Valfri. */
+  persist?: (downloadUrl: string, path: string, fileName: string) => Promise<void>;
+  /** Återställ cachade bytes till `path` när nedladdning misslyckas (offline). Valfri. */
+  restore?: (downloadUrl: string, path: string) => Promise<boolean>;
 }
 
 export const defaultOpenDeps: OpenDeps = {
@@ -55,13 +60,38 @@ async function runOpen(body: HelperOpenRequest, deps: OpenDeps): Promise<Respons
   const sessionDir = await deps.makeSessionDir();
   const tmpFile = join(sessionDir, body.fileName);
 
-  const dlErr = await tryStep(() => deps.download(tmpFile, body.downloadUrl, body.authHeader), 502, "download failed");
-  if (dlErr) return dlErr;
+  const obtainErr = await obtainFile(body, tmpFile, deps);
+  if (obtainErr) return obtainErr;
   const openErr = await tryStep(() => deps.openApp(tmpFile), 500, "open failed");
   if (openErr) return openErr;
 
   startWatchIfNeeded(body, tmpFile, deps);
   return json({ path: tmpFile, status: "opened" });
+}
+
+/**
+ * Skaffa filen till `tmpFile`: ladda ner och cacha (för offline-reopen), eller
+ * — om nedladdning misslyckas (offline) — återställ en tidigare cachad kopia.
+ * Returnerar en fel-Response om filen inte kan skaffas, annars null.
+ */
+async function obtainFile(body: HelperOpenRequest, tmpFile: string, deps: OpenDeps): Promise<Response | null> {
+  try {
+    await deps.download(tmpFile, body.downloadUrl, body.authHeader);
+  } catch (err) {
+    if (deps.restore && (await deps.restore(body.downloadUrl, tmpFile))) {
+      log(`offline: öppnar cachad kopia av ${body.fileName}`);
+      return null;
+    }
+    return textError(502, `download failed: ${errMsg(err)}`);
+  }
+  if (deps.persist) {
+    try {
+      await deps.persist(body.downloadUrl, tmpFile, body.fileName);
+    } catch (err) {
+      log(`content-cache misslyckades (${body.fileName}): ${errMsg(err)}`);
+    }
+  }
+  return null;
 }
 
 /** Kör ett IO-steg; null vid framgång, annars en fel-Response. */
@@ -99,6 +129,34 @@ export async function uploadFile(path: string, uploadUrl: string, authHeader: st
   if (authHeader) headers.Authorization = authHeader;
   const resp = await fetch(uploadUrl, { method: "PUT", headers, body: Bun.file(path) });
   if (resp.status >= 400) throw new Error(`upload HTTP ${resp.status}`);
+}
+
+/**
+ * Cacha nedladdade bytes durabelt (ADR 0028 §3, läs-sidan): efter en lyckad
+ * nedladdning sparas bytsen content-adresserat så samma dokument kan öppnas
+ * igen OFFLINE. Wiras in som `OpenDeps.persist` i `main`.
+ */
+export async function persistDownloaded(
+  store: ContentStore,
+  downloadUrl: string,
+  path: string,
+  fileName: string,
+): Promise<void> {
+  const bytes = await Bun.file(path).bytes();
+  await store.store(downloadUrl, bytes, fileName);
+}
+
+/**
+ * Återställ cachade bytes till `path` (ADR 0028 §3): när nedladdning misslyckas
+ * (offline) och en tidigare cachad kopia finns skrivs den ut så dokumentet kan
+ * öppnas ändå. Returnerar false om inget cachat finns. Wiras in som
+ * `OpenDeps.restore` i `main`.
+ */
+export async function restoreCached(store: ContentStore, downloadUrl: string, path: string): Promise<boolean> {
+  const bytes = await store.load(downloadUrl);
+  if (bytes === null) return false;
+  await Bun.write(path, bytes);
+  return true;
 }
 
 /**

--- a/helper-app/test/content-store.test.ts
+++ b/helper-app/test/content-store.test.ts
@@ -1,0 +1,167 @@
+/**
+ * ContentStore (ADR 0028 §3, ADR 0023) — durabelt content-adresserat
+ * dokument-lager. Testar mot riktig temp-katalog (durabiliteten ÄR poängen)
+ * med injicerad klocka för deterministisk lastUsedAt/vräkning.
+ */
+
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+
+import { ContentStore, sha256Hex, type ContentStoreDeps } from "../src/content-store.ts";
+
+const dirs: string[] = [];
+async function tmpDir(): Promise<string> {
+  const d = await mkdtemp(join(tmpdir(), "ava-content-"));
+  dirs.push(d);
+  return d;
+}
+afterAll(async () => { await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true }))); });
+
+function bytes(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+function clockDeps(start = 1_000): { deps: ContentStoreDeps; set: (t: number) => void } {
+  let t = start;
+  return { deps: { now: () => t }, set: (v) => { t = v; } };
+}
+
+const URL1 = "https://s/api/documents/1/download";
+const URL2 = "https://s/api/documents/2/download";
+
+describe("ContentStore.store + load", () => {
+  let dir: string;
+  beforeEach(async () => { dir = await tmpDir(); });
+
+  test("cachar bytes och hämtar dem igen (offline-reopen)", async () => {
+    const store = new ContentStore(dir, clockDeps().deps);
+    const data = bytes("PDF-innehåll");
+    const hash = await store.store(URL1, data, "avtal.pdf");
+
+    expect(hash).toBe(sha256Hex(data));
+    const loaded = await store.load(URL1);
+    expect(loaded).not.toBeNull();
+    expect(new TextDecoder().decode(loaded!)).toBe("PDF-innehåll");
+  });
+
+  test("blob namnges efter sin hash + index.json skrivs", async () => {
+    const store = new ContentStore(dir, clockDeps().deps);
+    const data = bytes("x");
+    const hash = await store.store(URL1, data, "a.pdf");
+    expect((await readdir(join(dir, "blobs")))).toEqual([`${hash}.bin`]);
+    expect((await readdir(dir))).toContain("index.json");
+  });
+
+  test("dedup: samma bytes under två nycklar → en blob", async () => {
+    const store = new ContentStore(dir, clockDeps().deps);
+    await store.store(URL1, bytes("samma"), "a.pdf");
+    await store.store(URL2, bytes("samma"), "b.pdf");
+    expect((await readdir(join(dir, "blobs")))).toHaveLength(1);
+    expect(await store.has(URL1)).toBe(true);
+    expect(await store.has(URL2)).toBe(true);
+  });
+
+  test("ny version på samma nyckel → ny blob, nyckeln pekar om", async () => {
+    const store = new ContentStore(dir, clockDeps().deps);
+    await store.store(URL1, bytes("v1"), "a.pdf");
+    await store.store(URL1, bytes("v2"), "a.pdf");
+    expect(new TextDecoder().decode((await store.load(URL1))!)).toBe("v2");
+  });
+
+  test("load på okänd nyckel → null", async () => {
+    const store = new ContentStore(dir, clockDeps().deps);
+    expect(await store.load("https://s/saknas")).toBeNull();
+  });
+
+  test("has speglar närvaro", async () => {
+    const store = new ContentStore(dir, clockDeps().deps);
+    expect(await store.has(URL1)).toBe(false);
+    await store.store(URL1, bytes("x"), "a.pdf");
+    expect(await store.has(URL1)).toBe(true);
+  });
+
+  test("load bumpar lastUsedAt", async () => {
+    const clock = clockDeps(1_000);
+    const store = new ContentStore(dir, clock.deps);
+    await store.store(URL1, bytes("x"), "a.pdf");
+    clock.set(5_000);
+    await store.load(URL1);
+    // En ny store-instans läser samma index från disk → lastUsedAt persisterat.
+    const reloaded = new ContentStore(dir, clockDeps(9_999).deps);
+    // 9_999 - 4_999 < cutoff → överlever; men 9_999 - 0 (om ej bumpat) hade vräkts.
+    expect(await reloaded.evictUnusedOlderThan(6_000)).toBe(0);
+  });
+});
+
+describe("ContentStore — durabilitet över omstart", () => {
+  let dir: string;
+  beforeEach(async () => { dir = await tmpDir(); });
+
+  test("ny instans läser cachade bytes (helper-omstart)", async () => {
+    await new ContentStore(dir, clockDeps().deps).store(URL1, bytes("kvar"), "a.pdf");
+    const fresh = new ContentStore(dir, clockDeps().deps);
+    expect(new TextDecoder().decode((await fresh.load(URL1))!)).toBe("kvar");
+  });
+
+  test("borttappad blob → index-posten städas, load ger null", async () => {
+    const store = new ContentStore(dir, clockDeps().deps);
+    const hash = await store.store(URL1, bytes("x"), "a.pdf");
+    await rm(join(dir, "blobs", `${hash}.bin`), { force: true });
+    expect(await store.load(URL1)).toBeNull();
+    expect(await store.has(URL1)).toBe(false); // städat
+  });
+
+  test("trasigt index → behandlas som tomt (ingen krasch)", async () => {
+    await Bun.write(join(dir, "index.json"), "{ not json");
+    const store = new ContentStore(dir, clockDeps().deps);
+    expect(await store.load(URL1)).toBeNull();
+  });
+});
+
+describe("ContentStore.evictUnusedOlderThan (ADR 0028 §7)", () => {
+  let dir: string;
+  beforeEach(async () => { dir = await tmpDir(); });
+
+  test("vräker poster äldre än maxAge, behåller färska", async () => {
+    const clock = clockDeps(0);
+    const store = new ContentStore(dir, clock.deps);
+    await store.store(URL1, bytes("gammal"), "old.pdf"); // lastUsedAt 0
+    clock.set(100);
+    await store.store(URL2, bytes("ny"), "new.pdf"); // lastUsedAt 100
+
+    clock.set(1_000);
+    const evicted = await store.evictUnusedOlderThan(950); // cutoff 50 → URL1 (0) vräks, URL2 (100) kvar
+    expect(evicted).toBe(1);
+    expect(await store.has(URL1)).toBe(false);
+    expect(await store.has(URL2)).toBe(true);
+    expect((await readdir(join(dir, "blobs")))).toHaveLength(1); // gammal blob borttagen
+  });
+
+  test("delad blob raderas inte medan en kvarvarande nyckel pekar på den", async () => {
+    const clock = clockDeps(0);
+    const store = new ContentStore(dir, clock.deps);
+    await store.store(URL1, bytes("delad"), "a.pdf"); // lastUsedAt 0
+    clock.set(100);
+    await store.store(URL2, bytes("delad"), "b.pdf"); // samma bytes, lastUsedAt 100
+
+    clock.set(1_000);
+    await store.evictUnusedOlderThan(950); // URL1 vräks, URL2 kvar
+    expect((await readdir(join(dir, "blobs")))).toHaveLength(1); // blob lever (URL2 pekar)
+    expect(new TextDecoder().decode((await store.load(URL2))!)).toBe("delad");
+  });
+
+  test("inget att vräka → 0", async () => {
+    const store = new ContentStore(dir, clockDeps(0).deps);
+    await store.store(URL1, bytes("x"), "a.pdf");
+    expect(await store.evictUnusedOlderThan(1_000_000)).toBe(0);
+  });
+});
+
+describe("sha256Hex", () => {
+  test("deterministisk + skiljer på olika bytes", () => {
+    expect(sha256Hex(bytes("a"))).toBe(sha256Hex(bytes("a")));
+    expect(sha256Hex(bytes("a"))).not.toBe(sha256Hex(bytes("b")));
+  });
+});

--- a/helper-app/test/open.test.ts
+++ b/helper-app/test/open.test.ts
@@ -3,7 +3,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, describe, expect, test } from "bun:test";
 
-import { enqueueSavedFile, handleOpen, type OpenDeps } from "../src/open.ts";
+import { ContentStore } from "../src/content-store.ts";
+import { enqueueSavedFile, handleOpen, persistDownloaded, restoreCached, type OpenDeps } from "../src/open.ts";
 import { UploadQueue } from "../src/queue.ts";
 import { jsonRequest } from "./helpers.ts";
 
@@ -81,6 +82,73 @@ describe("handleOpen", () => {
     const rec = recorder({ openApp: async () => { throw new Error("no app"); } });
     const res = await handleOpen(openReq({ downloadUrl: "http://x/f", fileName: "a.pdf" }), rec.deps);
     expect(res.status).toBe(500);
+  });
+});
+
+describe("offline content-cache (ADR 0028 §3)", () => {
+  test("cachar nedladdade bytes via persist", async () => {
+    const persisted: Array<{ url: string; path: string; fileName: string }> = [];
+    const rec = recorder({
+      persist: async (url, path, fileName) => { persisted.push({ url, path, fileName }); },
+    });
+    const res = await handleOpen(openReq({ downloadUrl: "http://x/f", fileName: "a.pdf" }), rec.deps);
+    expect(res.status).toBe(200);
+    expect(persisted).toEqual([{ url: "http://x/f", path: "/tmp/ava-session/a.pdf", fileName: "a.pdf" }]);
+  });
+
+  test("nedladdning misslyckas men cache finns → öppnar cachad kopia (offline)", async () => {
+    const rec = recorder({
+      download: async () => { throw new Error("offline"); },
+      restore: async () => true,
+    });
+    const res = await handleOpen(openReq({ downloadUrl: "http://x/f", fileName: "a.pdf" }), rec.deps);
+    expect(res.status).toBe(200);
+    expect(rec.opened).toEqual(["/tmp/ava-session/a.pdf"]); // öppnades trots download-fel
+  });
+
+  test("nedladdning misslyckas + ingen cache → 502", async () => {
+    const rec = recorder({
+      download: async () => { throw new Error("offline"); },
+      restore: async () => false,
+    });
+    const res = await handleOpen(openReq({ downloadUrl: "http://x/f", fileName: "a.pdf" }), rec.deps);
+    expect(res.status).toBe(502);
+    expect(rec.opened).toHaveLength(0);
+  });
+
+  test("persist-fel kraschar inte öppningen (cache best-effort)", async () => {
+    const rec = recorder({ persist: async () => { throw new Error("disk full"); } });
+    const res = await handleOpen(openReq({ downloadUrl: "http://x/f", fileName: "a.pdf" }), rec.deps);
+    expect(res.status).toBe(200);
+    expect(rec.opened).toHaveLength(1);
+  });
+});
+
+describe("persistDownloaded + restoreCached", () => {
+  const dirs: string[] = [];
+  afterAll(async () => { await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true }))); });
+
+  test("round-trip: persist en nedladdad fil, restore till ny path", async () => {
+    const work = await mkdtemp(join(tmpdir(), "ava-dl-"));
+    const cdir = await mkdtemp(join(tmpdir(), "ava-cs-"));
+    dirs.push(work, cdir);
+    const dl = join(work, "doc.pdf");
+    await writeFile(dl, "nedladdat innehåll", "utf8");
+
+    const store = new ContentStore(cdir);
+    await persistDownloaded(store, "http://s/d/1", dl, "doc.pdf");
+
+    const out = join(work, "restored.pdf");
+    const ok = await restoreCached(store, "http://s/d/1", out);
+    expect(ok).toBe(true);
+    expect(await Bun.file(out).text()).toBe("nedladdat innehåll");
+  });
+
+  test("restoreCached → false när inget cachat finns", async () => {
+    const cdir = await mkdtemp(join(tmpdir(), "ava-cs-"));
+    dirs.push(cdir);
+    const store = new ContentStore(cdir);
+    expect(await restoreCached(store, "http://s/saknas", join(cdir, "x"))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Vad

Resten av genomförande-steg **3** av ADR 0028 (#655): **läs-sidan** av offline-first. Tillsammans med upload-kön (#658) är hela dokument-loopen nu offline-användbar — öppna, ändra, spara, öppna igen, allt utan nät.

Idag laddas ett dokument ner till en temp-katalog vid varje öppning → kräver nät, och en redan öppnad fil kan inte öppnas igen offline.

## Hur

`helper-app/src/content-store.ts` — `ContentStore` (ADR 0023-princip):
- Nedladdade bytes cachas durabelt under sin **SHA-256** (`blobs/<hash>.bin`) → automatisk **dedup + integritet** (samma version = samma hash). Ett `index.json` mappar logisk nyckel (download-URL) → hash + `fileName`/`size`/`lastUsedAt`.
- `/open` (`obtainFile`): efter lyckad nedladdning **cachas** bytsen (`persist`); misslyckas nedladdningen (offline) och en cachad kopia finns **återställs** den till temp-filen (`restore`) → dokumentet öppnas ändå. Saknas cache → 502 som förr.
- `lastUsedAt` stämplas vid `store`/`load` → substrat för 30-dagars-vräkningen (steg 7). `evictUnusedOlderThan()` tar bort oanvända poster; en **delad blob** lever så länge någon kvarvarande nyckel pekar på den. (Driver:n med 30-dagars-config wiras i steg 7.)
- Robust: borttappad blob städar sin index-post; trasigt index behandlas som tomt.

`open.ts` fick `persist?`/`restore?` (valfria `OpenDeps`) + `persistDownloaded`/`restoreCached`; `main` skapar `ContentStore` i data-dir och wirar dem (tillsammans med kön) i `/open`.

## Test

`test/content-store.test.ts` mot riktig temp-katalog + injicerad klocka: store/load/dedup/omversionering/has, durabilitet över omstart, borttappad blob + trasigt index, eviction (vräker gammalt, behåller färskt, delad blob lever). `open.test.ts`: offline-restore-fallback, persist-on-download, persist-fel är best-effort, persist/restore round-trip. `content-store.ts` 100% rader/funktioner; helper-svit 188 grön; typecheck + dep-cruiser + cross-build rena.

Closes #661. Refs #655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)