### PR TITLE
feat(helper): 30-dagars last-use-vräkning av cache (#663)

### DIFF
--- a/helper-app/src/content-store.ts
+++ b/helper-app/src/content-store.ts
@@ -39,6 +39,23 @@ export interface ContentStoreDeps {
 
 export const defaultContentStoreDeps: ContentStoreDeps = { now: () => Date.now() };
 
+/** Standard-TTL för cachade dokument: oanvänt i 30 dagar → vräks (ADR 0028 §7). */
+export const DEFAULT_CACHE_TTL_DAYS = 30;
+const DAY_MS = 24 * 60 * 60_000;
+/** Hur ofta vräknings-varvet körs (en gång per dygn räcker för en dygns-TTL). */
+const DEFAULT_EVICTION_INTERVAL_MS = DAY_MS;
+
+/**
+ * Lös cache-TTL i ms ur ett (env-)värde. Konfigurerbart per enhet via
+ * `AVA_HELPER_CACHE_TTL_DAYS`; ogiltigt/saknat → {@link DEFAULT_CACHE_TTL_DAYS}.
+ * Ren funktion → testbar utan env.
+ */
+export function resolveCacheTtlMs(envValue: string | undefined, defaultDays = DEFAULT_CACHE_TTL_DAYS): number {
+  const n = Number(envValue);
+  const days = Number.isFinite(n) && n > 0 ? n : defaultDays;
+  return days * DAY_MS;
+}
+
 /** SHA-256 (hex) av bytes. Content-adress-nyckeln. */
 export function sha256Hex(bytes: Uint8Array): string {
   return createHash("sha256").update(bytes).digest("hex");
@@ -148,4 +165,22 @@ export class ContentStore {
     }
     return stale.length;
   }
+
+  /**
+   * Starta ett periodiskt vräknings-varv (default en gång/dygn) tills `signal`
+   * avbryts. Kör ett varv direkt vid start. Vräker poster oanvända > `ttlMs`.
+   */
+  startEvictionLoop(signal: AbortSignal, ttlMs: number, intervalMs = DEFAULT_EVICTION_INTERVAL_MS): void {
+    const tick = (): void => {
+      if (signal.aborted) return;
+      void this.evictUnusedOlderThan(ttlMs).catch((err) => log(`content eviction: ${msg(err)}`));
+    };
+    tick(); // ett varv direkt vid uppstart
+    const timer = setInterval(tick, intervalMs);
+    signal.addEventListener("abort", () => clearInterval(timer));
+  }
+}
+
+function msg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }

--- a/helper-app/src/main.ts
+++ b/helper-app/src/main.ts
@@ -21,7 +21,7 @@ import { join } from "node:path";
 
 import { HELPER_HTTPS_PORT, HELPER_PORT } from "@/lib/shared/helper/protocol";
 
-import { ContentStore } from "./content-store.ts";
+import { ContentStore, resolveCacheTtlMs } from "./content-store.ts";
 import { installService, uninstallService, type InstallDeps } from "./install.ts";
 import { initLog, log } from "./log.ts";
 import {
@@ -180,6 +180,7 @@ function startStores(signal: AbortSignal): Stores | undefined {
   const queue = new UploadQueue(join(dir, "queue"));
   void queue.recover().then(() => queue.startDrainLoop(signal));
   const content = new ContentStore(join(dir, "content"));
+  content.startEvictionLoop(signal, resolveCacheTtlMs(process.env.AVA_HELPER_CACHE_TTL_DAYS));
   return { queue, content };
 }
 

--- a/helper-app/test/content-store.test.ts
+++ b/helper-app/test/content-store.test.ts
@@ -9,7 +9,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 
-import { ContentStore, sha256Hex, type ContentStoreDeps } from "../src/content-store.ts";
+import { ContentStore, DEFAULT_CACHE_TTL_DAYS, resolveCacheTtlMs, sha256Hex, type ContentStoreDeps } from "../src/content-store.ts";
 
 const dirs: string[] = [];
 async function tmpDir(): Promise<string> {
@@ -156,6 +156,50 @@ describe("ContentStore.evictUnusedOlderThan (ADR 0028 §7)", () => {
     const store = new ContentStore(dir, clockDeps(0).deps);
     await store.store(URL1, bytes("x"), "a.pdf");
     expect(await store.evictUnusedOlderThan(1_000_000)).toBe(0);
+  });
+});
+
+describe("resolveCacheTtlMs", () => {
+  const DAY = 24 * 60 * 60_000;
+  test("default 30 dagar när env saknas/ogiltig", () => {
+    expect(resolveCacheTtlMs(undefined)).toBe(DEFAULT_CACHE_TTL_DAYS * DAY);
+    expect(resolveCacheTtlMs("")).toBe(DEFAULT_CACHE_TTL_DAYS * DAY);
+    expect(resolveCacheTtlMs("inte-ett-tal")).toBe(DEFAULT_CACHE_TTL_DAYS * DAY);
+    expect(resolveCacheTtlMs("0")).toBe(DEFAULT_CACHE_TTL_DAYS * DAY); // 0/negativt → default
+    expect(resolveCacheTtlMs("-5")).toBe(DEFAULT_CACHE_TTL_DAYS * DAY);
+  });
+  test("konfigurerbart antal dagar", () => {
+    expect(resolveCacheTtlMs("7")).toBe(7 * DAY);
+    expect(resolveCacheTtlMs("90")).toBe(90 * DAY);
+  });
+});
+
+describe("ContentStore.startEvictionLoop", () => {
+  let dir: string;
+  beforeEach(async () => { dir = await tmpDir(); });
+
+  test("vräker gamla poster direkt vid start + tills signalen avbryts", async () => {
+    const clock = clockDeps(0);
+    const store = new ContentStore(dir, clock.deps);
+    await store.store(URL1, bytes("gammal"), "a.pdf"); // lastUsedAt 0
+    clock.set(10_000);
+    const ctrl = new AbortController();
+    store.startEvictionLoop(ctrl.signal, 5_000, 5); // ttl 5_000 → URL1 (0) vräks vid första tick
+    await new Promise((r) => setTimeout(r, 20));
+    ctrl.abort();
+    expect(await store.has(URL1)).toBe(false);
+  });
+
+  test("avbruten signal innan tick → ingen vräkning", async () => {
+    const clock = clockDeps(0);
+    const store = new ContentStore(dir, clock.deps);
+    await store.store(URL1, bytes("x"), "a.pdf");
+    clock.set(10_000);
+    const ctrl = new AbortController();
+    ctrl.abort();
+    store.startEvictionLoop(ctrl.signal, 5_000, 5);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(await store.has(URL1)).toBe(true); // orörd
   });
 });
 


### PR DESCRIPTION
## Vad

Genomförande-steg **7** av ADR 0028 (#655): wirar drivaren för content-cache-vräkning. `ContentStore.evictUnusedOlderThan` (från #662) fick i den PR:en logiken — här kopplas den till en periodisk drivare så cachen inte växer obegränsat.

## Hur

- **`ContentStore.startEvictionLoop(signal, ttlMs, intervalMs?)`** kör ett vräknings-varv **direkt vid start** och sedan **en gång per dygn**; stannar när signalen avbryts (mirror av `UploadQueue.startDrainLoop`).
- **`resolveCacheTtlMs(env, default=30)`** — TTL konfigurerbar per enhet via `AVA_HELPER_CACHE_TTL_DAYS`; ogiltigt/saknat/≤0 → 30 dagars default.
- `main.startStores` wirar `content.startEvictionLoop(signal, resolveCacheTtlMs(process.env.AVA_HELPER_CACHE_TTL_DAYS))`.
- Vräker **bara oanvända dokument-bytes**: delade blobbar lever så länge någon nyckel pekar (content-adresserat), och kö-poster (väntande uploads) rörs inte — en offline-ändring blir aldrig "borta".

## Test

`resolveCacheTtlMs` (default/ogiltigt/konfigurerat) + `startEvictionLoop` (vräker direkt vid start tills signal avbryts; avbruten signal → orörd). helper-svit 192 grön; content-store.ts 98.8% rader; typecheck + cross-build rena.

Closes #663. Refs #655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)