### PR TITLE
feat(helper): leverera dokument-bytes via /content ur durabla cachen (#666)

### DIFF
--- a/helper-app/src/content.ts
+++ b/helper-app/src/content.ts
@@ -1,0 +1,87 @@
+/**
+ * `POST /content` (ADR 0028 §3/§5) — leverera dokument-bytes till webbappen ur
+ * helperns durabla, content-adresserade lager.
+ *
+ * Cache-hit → servera direkt (fungerar OFFLINE). Miss → ladda ner + cacha +
+ * servera. Offline utan cache → 502. Gör helpern till den enda lokala
+ * dokument-auktoriteten: web-appen delegerar läsningar hit, så in-browser-vyn
+ * och extern-editor-öppningen (samma /open-cache) aldrig divergerar.
+ *
+ * IO injiceras (`ContentDeps`) → testas utan riktig nedladdning/fs.
+ */
+
+import type { HelperContentRequest } from "@/lib/shared/helper/protocol";
+import type { ContentStore } from "./content-store.ts";
+import { parseJsonBody, textError } from "./http.ts";
+import { log } from "./log.ts";
+
+export interface ContentDeps {
+  /** Hämta cachade bytes för download-URL:en, eller null. */
+  load: (downloadUrl: string) => Promise<Uint8Array | null>;
+  /** Ladda ner + cacha vid miss; null om nedladdning misslyckas (offline). */
+  fetchAndCache: (downloadUrl: string, authHeader: string | undefined, fileName: string) => Promise<Uint8Array | null>;
+}
+
+export async function handleContent(req: Request, deps: ContentDeps): Promise<Response> {
+  if (req.method !== "POST") return textError(405, "method not allowed");
+  const body = await parseJsonBody<HelperContentRequest>(req);
+  if (!body?.downloadUrl) return textError(400, "downloadUrl required");
+
+  const cached = await deps.load(body.downloadUrl);
+  if (cached) return bytesResponse(cached);
+
+  const fetched = await deps.fetchAndCache(body.downloadUrl, body.authHeader, body.fileName ?? fileNameFromUrl(body.downloadUrl));
+  if (fetched) return bytesResponse(fetched);
+  return textError(502, "content unavailable (offline, not cached)");
+}
+
+function bytesResponse(bytes: Uint8Array): Response {
+  // Blob kräver ArrayBuffer-backade bytes (ej SharedArrayBuffer); kopiera.
+  return new Response(new Blob([new Uint8Array(bytes)]), {
+    status: 200,
+    headers: { "Content-Type": "application/octet-stream" },
+  });
+}
+
+/**
+ * Sista path-segmentet som filnamn (utan query/host), fallback "dokument".
+ * `URL`-parsning (dummy-bas hanterar både absoluta och relativa URL:er) så
+ * host:en aldrig misstas för ett segment.
+ */
+export function fileNameFromUrl(url: string): string {
+  try {
+    const path = new URL(url, "http://_").pathname;
+    const last = path.split("/").filter((s) => s !== "").pop();
+    return last ? decodeURIComponent(last) : "dokument";
+  } catch {
+    return "dokument";
+  }
+}
+
+/**
+ * Ladda ner bytes och cacha dem i content-lagret (cache-miss-vägen för
+ * `/content`). Returnerar bytsen, eller null om nedladdning misslyckas (offline
+ * → caller svarar 502). Wiras som `ContentDeps.fetchAndCache` i `main`.
+ */
+export async function fetchAndCacheContent(
+  store: ContentStore,
+  downloadUrl: string,
+  authHeader: string | undefined,
+  fileName: string,
+): Promise<Uint8Array | null> {
+  try {
+    const headers: Record<string, string> = {};
+    if (authHeader) headers.Authorization = authHeader;
+    const resp = await fetch(downloadUrl, { headers });
+    if (resp.status >= 400) {
+      log(`content: nedladdning ${downloadUrl} → HTTP ${resp.status}`);
+      return null;
+    }
+    const bytes = new Uint8Array(await resp.arrayBuffer());
+    await store.store(downloadUrl, bytes, fileName);
+    return bytes;
+  } catch (err) {
+    log(`content: nedladdning misslyckades (${downloadUrl}): ${err instanceof Error ? err.message : String(err)}`);
+    return null;
+  }
+}

--- a/helper-app/src/main.ts
+++ b/helper-app/src/main.ts
@@ -22,6 +22,7 @@ import { join } from "node:path";
 import { HELPER_HTTPS_PORT, HELPER_PORT } from "@/lib/shared/helper/protocol";
 
 import { ContentStore, resolveCacheTtlMs } from "./content-store.ts";
+import { fetchAndCacheContent, handleContent } from "./content.ts";
 import { installService, uninstallService, type InstallDeps } from "./install.ts";
 import { initLog, log } from "./log.ts";
 import {
@@ -219,7 +220,17 @@ function main(): void {
     version: VERSION,
     extraOrigins: extraOrigins(),
     onCheckUpdate: () => { void checkOnce(updateCfg).catch((err) => log(`check-update: ${String(err)}`)); },
-    ...(stores ? { onOpen: queueBackedOnOpen(stores.queue, stores.content), onStatus: () => stores.queue.snapshot() } : {}),
+    ...(stores
+      ? {
+          onOpen: queueBackedOnOpen(stores.queue, stores.content),
+          onStatus: () => stores.queue.snapshot(),
+          onContent: (req: Request) =>
+            handleContent(req, {
+              load: (url) => stores.content.load(url),
+              fetchAndCache: (url, auth, fileName) => fetchAndCacheContent(stores.content, url, auth, fileName),
+            }),
+        }
+      : {}),
   });
 
   const httpServer = Bun.serve({ port, hostname: "127.0.0.1", fetch: handler });

--- a/helper-app/src/server.ts
+++ b/helper-app/src/server.ts
@@ -8,6 +8,7 @@
  *   POST /compose-mail  → skriv bilaga → öppna mail-app
  *   POST /check-update  → trigga omedelbar self-update-kontroll
  *   GET  /status        → JSON ögonblicksbild av upload-kön (ADR 0028 §8)
+ *   POST /content       → dokument-bytes ur durabla cachen (ADR 0028 §3/§5)
  *
  * Säkerhet: lyssnar bara på localhost; CORS-whitelist (localhost-portar
  * + *.github.io + custom via AVA_HELPER_ORIGINS); inga endpoints som
@@ -34,6 +35,8 @@ export interface ServerDeps {
   onCheckUpdate?: () => void;
   /** Ögonblicksbild av upload-kön. undefined → tom kö (kön avstängd). */
   onStatus?: () => HelperStatusResponse;
+  /** Leverera dokument-bytes (POST /content). undefined → 503 (ej konfigurerad). */
+  onContent?: (req: Request) => Promise<Response>;
 }
 
 const EMPTY_STATUS: HelperStatusResponse = { pending: 0, conflict: 0, total: 0, entries: [] };
@@ -65,6 +68,7 @@ const ROUTES: Record<string, (req: Request, deps: ServerDeps) => Response | Prom
   "/compose-mail": (req, deps) => (deps.onComposeMail ?? handleComposeMail)(req),
   "/check-update": (_req, deps) => handleCheckUpdate(deps),
   "/status": (_req, deps) => json(deps.onStatus?.() ?? EMPTY_STATUS),
+  "/content": (req, deps) => deps.onContent?.(req) ?? textError(503, "content store not configured"),
 };
 
 async function route(req: Request, deps: ServerDeps): Promise<Response> {

--- a/helper-app/test/content-store.test.ts
+++ b/helper-app/test/content-store.test.ts
@@ -185,7 +185,8 @@ describe("ContentStore.startEvictionLoop", () => {
     clock.set(10_000);
     const ctrl = new AbortController();
     store.startEvictionLoop(ctrl.signal, 5_000, 5); // ttl 5_000 → URL1 (0) vräks vid första tick
-    await new Promise((r) => setTimeout(r, 20));
+    // Poll tills vräkt (robust mot lastad CI-runner) i st.f. fast väntan.
+    for (let i = 0; i < 100 && (await store.has(URL1)); i++) await new Promise((r) => setTimeout(r, 10));
     ctrl.abort();
     expect(await store.has(URL1)).toBe(false);
   });

--- a/helper-app/test/content.test.ts
+++ b/helper-app/test/content.test.ts
@@ -1,0 +1,138 @@
+/**
+ * `POST /content` (ADR 0028 §3/§5) — leverera dokument-bytes ur durabla cachen.
+ * handleContent testas med injicerade deps; fetchAndCacheContent mot riktig
+ * ContentStore + mockad fetch.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, test } from "bun:test";
+
+import { ContentStore } from "../src/content-store.ts";
+import { fetchAndCacheContent, fileNameFromUrl, handleContent, type ContentDeps } from "../src/content.ts";
+import { jsonRequest } from "./helpers.ts";
+
+function bytes(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+function contentReq(body: unknown): Request {
+  return jsonRequest("/content", body);
+}
+
+describe("handleContent", () => {
+  const base: ContentDeps = {
+    load: async () => null,
+    fetchAndCache: async () => null,
+  };
+
+  test("kräver POST", async () => {
+    const res = await handleContent(new Request("http://h/content"), base);
+    expect(res.status).toBe(405);
+  });
+
+  test("kräver downloadUrl", async () => {
+    const res = await handleContent(contentReq({ authHeader: "x" }), base);
+    expect(res.status).toBe(400);
+  });
+
+  test("cache-hit → 200 + bytes (offline-ok), ingen nedladdning", async () => {
+    let fetched = false;
+    const res = await handleContent(contentReq({ downloadUrl: "http://s/d/1" }), {
+      load: async () => bytes("cachat"),
+      fetchAndCache: async () => { fetched = true; return null; },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/octet-stream");
+    expect(await res.text()).toBe("cachat");
+    expect(fetched).toBe(false); // hit → ingen fetch
+  });
+
+  test("cache-miss → laddar ner + servar bytsen", async () => {
+    const res = await handleContent(contentReq({ downloadUrl: "http://s/d/1", authHeader: "Bearer t" }), {
+      load: async () => null,
+      fetchAndCache: async (url, auth) => {
+        expect(url).toBe("http://s/d/1");
+        expect(auth).toBe("Bearer t");
+        return bytes("nedladdat");
+      },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("nedladdat");
+  });
+
+  test("miss + offline (nedladdning ger null) → 502", async () => {
+    const res = await handleContent(contentReq({ downloadUrl: "http://s/d/1" }), base);
+    expect(res.status).toBe(502);
+  });
+
+  test("vidarebefordrar fileName till fetchAndCache (annars härlett ur URL)", async () => {
+    let seenName = "";
+    await handleContent(contentReq({ downloadUrl: "http://s/api/documents/9/download" }), {
+      load: async () => null,
+      fetchAndCache: async (_url, _auth, fileName) => { seenName = fileName; return bytes("x"); },
+    });
+    expect(seenName).toBe("download"); // sista segmentet
+  });
+});
+
+describe("fileNameFromUrl", () => {
+  test("plockar sista path-segmentet", () => {
+    expect(fileNameFromUrl("http://s/api/documents/9/avtal.pdf")).toBe("avtal.pdf");
+    expect(fileNameFromUrl("http://s/a/b/c.docx?token=xyz")).toBe("c.docx");
+    expect(fileNameFromUrl("http://s/file%20namn.pdf")).toBe("file namn.pdf");
+  });
+  test("fallback när inget segment finns", () => {
+    expect(fileNameFromUrl("http://s/")).toBe("dokument");
+  });
+});
+
+describe("fetchAndCacheContent", () => {
+  const dirs: string[] = [];
+  afterAll(async () => { await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true }))); });
+
+  async function store(): Promise<ContentStore> {
+    const d = await mkdtemp(join(tmpdir(), "ava-cc-"));
+    dirs.push(d);
+    return new ContentStore(d);
+  }
+
+  function mockFetch(fn: (url: string, init?: RequestInit) => Response): () => void {
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => fn(String(url), init)) as typeof fetch;
+    return () => { globalThis.fetch = orig; };
+  }
+
+  test("laddar ner, cachar och returnerar bytsen", async () => {
+    const s = await store();
+    const restore = mockFetch((url, init) => {
+      expect(url).toBe("http://s/d/1");
+      expect((init?.headers as Record<string, string>).Authorization).toBe("Bearer t");
+      return new Response("hämtat", { status: 200 });
+    });
+    try {
+      const got = await fetchAndCacheContent(s, "http://s/d/1", "Bearer t", "a.pdf");
+      expect(new TextDecoder().decode(got!)).toBe("hämtat");
+      // cachat → en andra load (utan nät) ger samma bytes
+      expect(new TextDecoder().decode((await s.load("http://s/d/1"))!)).toBe("hämtat");
+    } finally { restore(); }
+  });
+
+  test("4xx → null (cachar inte)", async () => {
+    const s = await store();
+    const restore = mockFetch(() => new Response("nope", { status: 404 }));
+    try {
+      expect(await fetchAndCacheContent(s, "http://s/d/1", undefined, "a.pdf")).toBeNull();
+      expect(await s.has("http://s/d/1")).toBe(false);
+    } finally { restore(); }
+  });
+
+  test("nätfel → null (offline)", async () => {
+    const s = await store();
+    const restore = mockFetch(() => { throw new Error("ECONNREFUSED"); });
+    try {
+      expect(await fetchAndCacheContent(s, "http://s/d/1", undefined, "a.pdf")).toBeNull();
+    } finally { restore(); }
+  });
+});

--- a/helper-app/test/queue.test.ts
+++ b/helper-app/test/queue.test.ts
@@ -214,7 +214,8 @@ describe("startDrainLoop", () => {
     await q.enqueue({ uploadUrl: "http://s/u/1", fileName: "a", bytes: bytes("x") });
     const ctrl = new AbortController();
     q.startDrainLoop(ctrl.signal, 5);
-    await new Promise((r) => setTimeout(r, 30));
+    // Poll tills dränerad (robust mot lastad CI-runner) i st.f. fast väntan.
+    for (let i = 0; i < 100 && q.snapshot().total > 0; i++) await new Promise((r) => setTimeout(r, 10));
     ctrl.abort();
     expect(q.snapshot().total).toBe(0); // hann dränera
   });

--- a/helper-app/test/server.test.ts
+++ b/helper-app/test/server.test.ts
@@ -112,6 +112,20 @@ describe("GET /status", () => {
   });
 });
 
+describe("POST /content", () => {
+  test("503 när onContent ej konfigurerad", async () => {
+    const res = await handler()(req("/content", { method: "POST" }));
+    expect(res.status).toBe(503);
+  });
+
+  test("delegerar till onContent när konfigurerad", async () => {
+    const h = handler({ onContent: async () => new Response("bytes", { status: 200 }) });
+    const res = await h(req("/content", { method: "POST" }));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("bytes");
+  });
+});
+
 describe("okänd route", () => {
   test("404", async () => {
     const res = await handler()(req("/nope"));

--- a/src/lib/shared/helper/protocol.ts
+++ b/src/lib/shared/helper/protocol.ts
@@ -81,6 +81,22 @@ export interface HelperVersionResponse {
 }
 
 /**
+ * `POST /content` — be helpern leverera dokument-bytes ur sitt durabla,
+ * content-adresserade lager (ADR 0028 §3/§5). Cache-hit servas direkt (även
+ * offline); miss laddas ner + cachas. Web-appen delegerar dokument-läsningar
+ * hit när helpern finns → en enda lokal dokument-auktoritet, ingen divergens
+ * mot extern-editor-öppningar.
+ */
+export interface HelperContentRequest {
+  /** Varifrån bytsen laddas (identifierar dokument+version) — även cache-nyckel. */
+  downloadUrl: string;
+  /** Vidarebefordras orörd till nedladdning vid cache-miss. */
+  authHeader?: string;
+  /** Användarsynligt filnamn (för helperns logg/cache-metadata). */
+  fileName?: string;
+}
+
+/**
  * En köad (ännu ej synkad) dokument-upload i helperns durabla kö (ADR 0028 §3).
  * Exponeras via `GET /status` så webbappen kan visa synk-status. Innehåller
  * ALDRIG authHeader (känsligt) — bara det UI:t behöver.


### PR DESCRIPTION
## Vad

Helper-sidan av genomförande-steg **5** av ADR 0028 (#655): ett `POST /content`-endpoint som låter web-appen läsa dokument-bytes **ur helperns durabla, content-adresserade cache**. Förutsättningen för att web-appen ska kunna delegera dokument-läsningar till helpern → en **enda lokal dokument-auktoritet** (ingen divergens mot extern-editor-öppningar) och **offline-läsning**.

## Hur

- **`POST /content`** body `{ downloadUrl, authHeader?, fileName? }` → dokument-bytes (`application/octet-stream`):
  - **cache-hit** → servera direkt (fungerar **offline**),
  - **miss** → ladda ner (`fetchAndCacheContent`) + cacha + servera,
  - **offline + ej cachat** → `502`.
- Delar `HelperContentRequest`-typen helper↔web (`src/lib/shared/helper/protocol.ts`).
- `main` wirar `onContent` mot `ContentStore` (samma lager som `/open` fyller, så in-browser-vy och extern-editor delar exakt samma bytes).
- Härdade på vägen de två `setInterval`-baserade loop-testerna (drain/eviction) till **poll-tills-klar** i st.f. fast väntan (robust mot lastad CI-runner).

## Test

`test/content.test.ts`: `handleContent` (405/400/cache-hit-utan-fetch/miss-fetch/502/fileName-vidarebefordran), `fileNameFromUrl` (path/query/host/encodade/tom), `fetchAndCacheContent` mot riktig `ContentStore` + mockad fetch (cachar+returnerar / 4xx→null / nätfel→null). `server.test.ts`: `/content` 503-ej-konfigurerad + delegering. `content.ts` 100% funktioner; helper-svit 205 grön (3× rena körningar); typecheck + dep-cruiser + cross-build rena.

## Återstår i steg 5 (separat PR)

Web-sidan: `loadDocumentBlob` föredrar helpern som byte-källa när den finns, fallback till dagens IndexedDB-cache + server. (Task #15 fortsätter.)

Closes #666. Refs #655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)