### PR TITLE
feat(web): delegera dokument-läsning till helpern m. fallback (#668)

### DIFF
--- a/src/lib/client/backend/load-document-blob.ts
+++ b/src/lib/client/backend/load-document-blob.ts
@@ -25,7 +25,8 @@ const MIME_BY_EXT: Record<string, string> = {
   doc: "application/msword",
 };
 
-function mimeFromName(fileName: string): string {
+/** MIME-typ ur filändelsen (delas med helper-content-vägen, ADR 0028 §5). */
+export function mimeFromName(fileName: string): string {
   const ext = fileName.toLowerCase().match(/\.([a-z0-9]+)$/)?.[1] ?? "";
   return MIME_BY_EXT[ext] ?? "application/octet-stream";
 }

--- a/src/lib/client/firma/open-matter-document.ts
+++ b/src/lib/client/firma/open-matter-document.ts
@@ -6,7 +6,8 @@
  * self-hosted-builden → länkade fel till GH Pages).
  *
  *   - demo (ingen server): öppna mot GH Pages-URL:en (bundlade blobbar).
- *   - self-hosted (server finns): hämta bytes via serverns
+ *   - self-hosted (server finns): hämta bytes via helpern om den kör
+ *     (`POST /content` — durabelt, offline-ok), annars serverns
  *     `document.downloadContent` (GitContentStore) + cacha i IndexedDB
  *     (`loadDocumentBlob`) → blob:-URL. Saknas i cachen → populeras först.
  *
@@ -26,9 +27,18 @@ export async function openMatterDocument(doc: OpenableDoc): Promise<void> {
   let fetchBlob: (() => Promise<Blob | null>) | undefined;
   if (!isDemo) {
     const { createServerDownloadClient } = await import("@/lib/client/backend/server-download-client");
-    const { loadDocumentBlob } = await import("@/lib/client/backend/load-document-blob");
+    const { loadDocumentBlob, mimeFromName } = await import("@/lib/client/backend/load-document-blob");
+    const { fetchContentViaHelper } = await import("@/lib/client/helper/use-helper");
     const client = createServerDownloadClient();
-    fetchBlob = () => loadDocumentBlob(client, { id: doc.id, storagePath: doc.storagePath ?? null, fileName: doc.fileName ?? doc.id });
+    const fileName = doc.fileName ?? doc.id;
+    fetchBlob = async () => {
+      // Föredra helpern (durabelt, offline-ok, samma lokala lager som extern-
+      // editor-öppning) → annars server-vägen + IndexedDB-cache (ADR 0028 §5).
+      const downloadUrl = new URL(`/api/documents/${doc.id}/download`, window.location.origin).toString();
+      const viaHelper = await fetchContentViaHelper({ downloadUrl, fileName });
+      if (viaHelper) return new Blob([viaHelper as BlobPart], { type: mimeFromName(fileName) });
+      return loadDocumentBlob(client, { id: doc.id, storagePath: doc.storagePath ?? null, fileName });
+    };
   }
 
   await openDocument({

--- a/src/lib/client/helper/use-helper.ts
+++ b/src/lib/client/helper/use-helper.ts
@@ -23,6 +23,7 @@ import {
   HELPER_HTTPS_BASE,
   parsePingVersion,
   type ComposeMailRequest,
+  type HelperContentRequest,
   type HelperOpenRequest,
   type HelperStatus,
   type HelperStatusResponse,
@@ -180,6 +181,29 @@ export function useHelperSyncStatus(intervalMs = 5_000): HelperStatusResponse | 
   }, [intervalMs]);
 
   return sync;
+}
+
+/**
+ * Hämta dokument-bytes via helpern (`POST /content`, ADR 0028 §5). Helpern
+ * servar ur sitt durabla, content-adresserade lager (offline-ok) och laddar ner
+ * + cachar vid miss. Returnerar `null` om helpern saknas eller inte kunde
+ * leverera (offline + ej cachat, eller saknad auth) → anroparen faller då
+ * tillbaka på sin egen cache + server. Gör helpern till den enda lokala
+ * dokument-auktoriteten när den finns (ingen divergens mot extern-editor-vägen).
+ */
+export async function fetchContentViaHelper(req: HelperContentRequest): Promise<Uint8Array | null> {
+  try {
+    const r = await helperFetch("/content", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(req),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (r === null || !r.ok) return null;
+    return new Uint8Array(await r.arrayBuffer());
+  } catch {
+    return null;
+  }
 }
 
 /** Trigga omedelbar self-update-kontroll. */

--- a/test/unit/lib/helper/use-helper.test.tsx
+++ b/test/unit/lib/helper/use-helper.test.tsx
@@ -11,6 +11,7 @@ import {
   resetHelperBaseCache,
   resolveHelperBase,
   fetchHelperStatus,
+  fetchContentViaHelper,
 } from "@/lib/client/helper/use-helper";
 
 const HTTPS = "https://localhost:48762";
@@ -131,6 +132,45 @@ describe("fetchHelperStatus", () => {
       [`${HTTPS}/status`, () => new Response(JSON.stringify({ pending: "nope" }), { status: 200 })],
     ]);
     expect(await fetchHelperStatus()).toBeNull();
+  });
+});
+
+describe("fetchContentViaHelper", () => {
+  const REQ = { downloadUrl: "https://srv/api/documents/9/download", fileName: "a.pdf" };
+
+  it("returnerar bytes från /content", async () => {
+    global.fetch = routeFetch([
+      [`${HTTPS}/ping`, () => new Response("ava-helper v1\n", { status: 200 })],
+      [`${HTTPS}/content`, () => new Response(new Uint8Array([1, 2, 3]), { status: 200 })],
+    ]);
+    const bytes = await fetchContentViaHelper(REQ);
+    expect(bytes).not.toBeNull();
+    expect(Array.from(bytes!)).toEqual([1, 2, 3]);
+  });
+
+  it("POST:ar request-bodyn till /content", async () => {
+    const fetchMock = routeFetch([
+      [`${HTTPS}/ping`, () => new Response("ava-helper v1\n", { status: 200 })],
+      [`${HTTPS}/content`, () => new Response(new Uint8Array([9]), { status: 200 })],
+    ]);
+    global.fetch = fetchMock;
+    await fetchContentViaHelper(REQ);
+    const call = fetchMock.mock.calls.find(([u]: [string]) => String(u).endsWith("/content"))!;
+    expect(call[1].method).toBe("POST");
+    expect(JSON.parse(call[1].body)).toMatchObject({ downloadUrl: REQ.downloadUrl, fileName: "a.pdf" });
+  });
+
+  it("null när helpern saknas (→ caller faller tillbaka)", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("down"));
+    expect(await fetchContentViaHelper(REQ)).toBeNull();
+  });
+
+  it("null vid 502 (offline + ej cachat)", async () => {
+    global.fetch = routeFetch([
+      [`${HTTPS}/ping`, () => new Response("ava-helper v1\n", { status: 200 })],
+      [`${HTTPS}/content`, () => new Response("unavailable", { status: 502 })],
+    ]);
+    expect(await fetchContentViaHelper(REQ)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Vad

Web-sidan av genomförande-steg **5** av ADR 0028 (#655) — slutför steget ovanpå helperns `POST /content` (#667). När helpern kör läser web-appen dokument-bytes **via helpern** (durabelt lokalt lager, offline-ok, **samma** lager som extern-editor-öppningen → ingen divergens). Saknas helpern: oförändrat beteende.

## Hur

- **`fetchContentViaHelper({ downloadUrl, fileName, authHeader? })`** (i `use-helper.ts`) → bytes ur helperns `/content`, eller `null` om helpern saknas / inte kan leverera (offline + ej cachat).
- **`openMatterDocument`** (self-hosted-grenen) bygger `fetchBlob` som **föredrar helpern**, annars dagens `loadDocumentBlob` (server `downloadContent` + IndexedDB-cache). **Additivt:** identiskt beteende när helpern inte kör → noll regressionsrisk i doc-öppningen.
- `mimeFromName` exporteras (typad blob för helper-bytesen).

## Begränsning (medveten, additiv)

Cache-miss i self-hosted kräver **helper-auth** (#13/#14) för att helpern själv ska kunna ladda ner. Tills dess servar helpern det den redan cachat (via `/open`) och faller annars tillbaka på server-vägen. Helt säkert — ingen försämring.

## Test

`use-helper.test`: `fetchContentViaHelper` (bytes / POST-body / helper saknas→null / 502→null). Full enhetssvit grön (exit 0, coverage-golv passerat); typecheck + lint + knip rena. Komposition i `openMatterDocument` är tunn (dynamiska imports, otestad som tidigare) — den testbara logiken ligger i `fetchContentViaHelper`.

Closes #668. Refs #655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)