### PR TITLE
feat(web): kapabilitets-tierad dokumentsök — lokalt vs server (#670)

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -2,7 +2,10 @@
 
 import { useState } from "react";
 import { DataTable, type Column } from "@/components/ui/data-table";
+import { useCapabilities } from "@/lib/client/capabilities/use-capabilities";
 import { EntityLink } from "@/lib/client/demo/entity-link";
+import { searchScope, searchScopeLabel, type SearchScope } from "@/lib/client/search/search-scope";
+import { useOnlineStatus } from "@/lib/client/sync/use-online-status";
 import { trpc } from "@/lib/client/trpc";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 
@@ -150,17 +153,84 @@ function SearchResults({ searchTerm, data }: { searchTerm: string; data: SearchD
   );
 }
 
+interface SearchFormProps {
+  query: string;
+  onQueryChange: (v: string) => void;
+  onSubmit: (e: React.FormEvent) => void;
+  scope: SearchScope;
+  isFetching: boolean;
+  docTypes: DocTypeCount[] | undefined;
+  resultsData: SearchData | undefined;
+  searchTerm: string;
+  selectedTypes: string[];
+  onToggleType: (type: string) => void;
+  onClearTypes: () => void;
+}
+
+function SearchForm(p: SearchFormProps) {
+  const offline = p.scope === "offline";
+  return (
+    <form onSubmit={p.onSubmit} className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
+      <p className="text-sm text-gray-500 mb-4">
+        Sök i innehållet i alla uppladdade dokument (PDF, Word, etc.).
+        Texten extraheras automatiskt vid uppladdning.{" "}
+        <span className="text-gray-400">
+          Använd <code className="font-mono text-xs bg-gray-100 px-1 rounded">*</code> som
+          wildcard, t.ex. <code className="font-mono text-xs bg-gray-100 px-1 rounded">stäm*ansökan</code>.
+        </span>
+      </p>
+      <p className={`text-xs mb-4 ${offline ? "text-amber-700" : "text-gray-500"}`}>{searchScopeLabel(p.scope)}</p>
+      <div className="flex flex-col sm:flex-row gap-3">
+        <input
+          type="text"
+          required
+          value={p.query}
+          onChange={(e) => p.onQueryChange(e.target.value)}
+          placeholder="Sök i dokument..."
+          disabled={offline}
+          className="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm disabled:bg-gray-50 disabled:text-gray-400"
+        />
+        <button
+          type="submit"
+          disabled={p.isFetching || offline}
+          className="px-6 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 disabled:opacity-50 whitespace-nowrap"
+        >
+          {p.isFetching ? "Söker..." : "Sök"}
+        </button>
+      </div>
+
+      {p.docTypes && p.docTypes.length > 0 && (
+        <DocTypeFilter
+          types={p.docTypes}
+          data={p.resultsData}
+          searchTerm={p.searchTerm}
+          selectedTypes={p.selectedTypes}
+          onToggle={p.onToggleType}
+          onClear={p.onClearTypes}
+        />
+      )}
+    </form>
+  );
+}
+
 export default function DocumentSearchPage() {
   const [query, setQuery] = useState("");
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
   const [searchedTypes, setSearchedTypes] = useState<string[]>([]);
 
+  // Kapabilitets-tierat sök-omfång (ADR 0028 §4c): server (online) / lokalt
+  // i cachen (demo) / offline-notis (server-first utan nät). Gate:as på
+  // kapabilitet + online — aldrig på `if (isDemo)` (ADR 0027).
+  const { sync } = useCapabilities();
+  const online = useOnlineStatus();
+  const scope = searchScope(sync, online);
+
   const docTypes = trpc.document.listDocumentTypes.useQuery();
 
   const results = trpc.document.search.useQuery(
     { query: searchTerm, documentTypes: searchedTypes.length > 0 ? searchedTypes : undefined },
-    { enabled: searchTerm.length > 0 }
+    { enabled: searchTerm.length > 0 && scope !== "offline" }
   );
 
   function handleSearch(e: React.FormEvent) {
@@ -177,44 +247,19 @@ export default function DocumentSearchPage() {
     <div>
       <h1 className="text-2xl font-bold text-gray-900 mb-6">Dokumentsökning</h1>
 
-      <form onSubmit={handleSearch} className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
-        <p className="text-sm text-gray-500 mb-4">
-          Sök i innehållet i alla uppladdade dokument (PDF, Word, etc.).
-          Texten extraheras automatiskt vid uppladdning.{" "}
-          <span className="text-gray-400">
-            Använd <code className="font-mono text-xs bg-gray-100 px-1 rounded">*</code> som
-            wildcard, t.ex. <code className="font-mono text-xs bg-gray-100 px-1 rounded">stäm*ansökan</code>.
-          </span>
-        </p>
-        <div className="flex flex-col sm:flex-row gap-3">
-          <input
-            type="text"
-            required
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Sök i dokument..."
-            className="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm"
-          />
-          <button
-            type="submit"
-            disabled={results.isFetching}
-            className="px-6 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 disabled:opacity-50 whitespace-nowrap"
-          >
-            {results.isFetching ? "Söker..." : "Sök"}
-          </button>
-        </div>
-
-        {docTypes.data && docTypes.data.length > 0 && (
-          <DocTypeFilter
-            types={docTypes.data}
-            data={results.data as SearchData | undefined}
-            searchTerm={searchTerm}
-            selectedTypes={selectedTypes}
-            onToggle={toggleType}
-            onClear={() => setSelectedTypes([])}
-          />
-        )}
-      </form>
+      <SearchForm
+        query={query}
+        onQueryChange={setQuery}
+        onSubmit={handleSearch}
+        scope={scope}
+        isFetching={results.isFetching}
+        docTypes={docTypes.data}
+        resultsData={results.data as SearchData | undefined}
+        searchTerm={searchTerm}
+        selectedTypes={selectedTypes}
+        onToggleType={toggleType}
+        onClearTypes={() => setSelectedTypes([])}
+      />
 
       {searchTerm && results.data && <SearchResults searchTerm={searchTerm} data={results.data as SearchData} />}
 

--- a/src/lib/client/search/search-scope.ts
+++ b/src/lib/client/search/search-scope.ts
@@ -1,0 +1,34 @@
+/**
+ * Dokumentsökningens omfång (ADR 0028 §4c, kapabilitets-tierad enligt ADR 0027).
+ *
+ * Två lägen, plus ett offline-tillstånd:
+ *   - `"server"` — online mot en server-backend (`sync`-kapabilitet + nät):
+ *     sök i serverns FULLA index (alla dokument).
+ *   - `"local"`  — ingen server (demon, som vi betraktar som offline): sök
+ *     lokalt genom dokumenten i cachen (demons in-process-index kör redan så).
+ *   - `"offline"` — server finns men nätet är nere: serverns index går inte att
+ *     nå och det finns inget lokalt textindex → ytlägg ett offline-meddelande
+ *     i st.f. att avfyra en dömd nät-fråga.
+ *
+ * Gate:as på KAPABILITET (`sync`) + online-status — aldrig på `if (isDemo)`
+ * (ADR 0027). Ren funktion → trivialt testbar.
+ */
+
+export type SearchScope = "server" | "local" | "offline";
+
+export function searchScope(sync: boolean, online: boolean): SearchScope {
+  if (!sync) return "local"; // ingen server (demo) → lokal sökning i cachen
+  return online ? "server" : "offline"; // server: nätet avgör
+}
+
+/** Användarsynlig etikett för sök-omfånget. */
+export function searchScopeLabel(scope: SearchScope): string {
+  switch (scope) {
+    case "server":
+      return "Söker på servern — alla dokument.";
+    case "local":
+      return "Söker lokalt i cachade dokument.";
+    case "offline":
+      return "Offline — dokumentsök kräver serveranslutning. Återanslut för att söka.";
+  }
+}

--- a/test/unit/lib/search/search-scope.test.ts
+++ b/test/unit/lib/search/search-scope.test.ts
@@ -1,0 +1,35 @@
+/**
+ * searchScope (ADR 0028 §4c / ADR 0027) — kapabilitets-tierat sök-omfång.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { searchScope, searchScopeLabel } from "@/lib/client/search/search-scope";
+
+describe("searchScope", () => {
+  it("demo (ingen sync) → local oavsett online-flagga", () => {
+    expect(searchScope(false, true)).toBe("local");
+    expect(searchScope(false, false)).toBe("local");
+  });
+
+  it("server-first online → server", () => {
+    expect(searchScope(true, true)).toBe("server");
+  });
+
+  it("server-first offline → offline (ingen dömd nät-fråga)", () => {
+    expect(searchScope(true, false)).toBe("offline");
+  });
+});
+
+describe("searchScopeLabel", () => {
+  it("ger distinkt etikett per omfång", () => {
+    const labels = new Set([
+      searchScopeLabel("server"),
+      searchScopeLabel("local"),
+      searchScopeLabel("offline"),
+    ]);
+    expect(labels.size).toBe(3);
+    expect(searchScopeLabel("local")).toMatch(/lokalt/i);
+    expect(searchScopeLabel("server")).toMatch(/servern/i);
+    expect(searchScopeLabel("offline")).toMatch(/[Oo]ffline/);
+  });
+});


### PR DESCRIPTION
## Vad

Genomförande-steg **6** av ADR 0028 (#655): dokumentsök blir **kapabilitets-tierad** (ADR 0027) i stället för att alltid träffa servern.

Per ditt beslut: **demon betraktas som offline → lokal sökning i cachen; online → fråga servern.** Det här mappar rent på vad som redan finns: i **demo kör `trpc.document.search` in-process** över de cachade dokumenten (det *är* lokal sökning), och i **server-first online** träffar den servern. Enda verkliga luckan var server-first *utan* nät → nu en ärlig offline-notis i st.f. en dömd nät-fråga.

## Hur

- **`searchScope(sync, online)`** (ren, testad) → `"server" | "local" | "offline"`:
  - `!sync` (demo) → **local** (in-process-index, oavsett nät),
  - `sync && online` → **server** (fulla indexet),
  - `sync && !online` → **offline** (server finns men nätet är nere).
- Sök-sidan: query:n är `enabled` bara när `scope !== "offline"` (ingen hängande nät-fråga offline), visar en **omfångs-etikett** (`searchScopeLabel`) och avaktiverar fältet/knappen offline.
- Gate:at på **kapabilitet + online — aldrig `if (isDemo)`** (ADR 0027).
- Formuläret bröts ut till `SearchForm` för att hålla `DocumentSearchPage` ≤ 8 i komplexitet.

**Jävskontroll förblir online-only** (per ditt beslut) — ingen kontakt-sync eller klient-konflikt-logik; den risken är borta.

## Test

`test/unit/lib/search/search-scope.test.ts`: alla tre omfången + distinkta etiketter. Full enhetssvit grön (exit 0, coverage-golv passerat); typecheck + lint + knip rena.

Closes #670. Refs #655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)