### PR TITLE
feat(web): öppna ärende eager-cachar dokument-bytes för offline (#672)

### DIFF
--- a/src/app/matters/[id]/_client.tsx
+++ b/src/app/matters/[id]/_client.tsx
@@ -9,6 +9,7 @@ import { PaymentMethodCard } from "@/components/matter/payment-method-card";
 import { SuggestionsPanel } from "@/components/matter/suggestions-panel";
 import { EntityLink } from "@/lib/client/demo/entity-link";
 import { useRouteId } from "@/lib/client/demo/use-route-id";
+import { useEagerCacheMatterDocuments } from "@/lib/client/firma/use-eager-cache-matter-documents";
 import { trpc } from "@/lib/client/trpc";
 import { BillingPanel } from "./_billing-panel";
 import { ContactsSection } from "./_contacts-section";
@@ -30,6 +31,8 @@ export default function MatterDetailClient({ id: paramId }: { id: string }) {
   const id = useRouteId() ?? paramId;
   const matter = trpc.matter.getById.useQuery({ id });
   const [showGenerateModal, setShowGenerateModal] = useState(false);
+  // ADR 0028 §4a: öppna ärende → eager-cacha dess dokument-bytes (offline).
+  useEagerCacheMatterDocuments(id);
 
   if (matter.isLoading) return <p className="text-gray-500">Laddar...</p>;
   if (matter.error) return <p className="text-red-600">Fel: {matter.error.message}</p>;

--- a/src/lib/client/firma/prefetch-matter-documents.ts
+++ b/src/lib/client/firma/prefetch-matter-documents.ts
@@ -1,0 +1,42 @@
+"use client";
+
+/**
+ * `prefetchMatterDocuments` (ADR 0028 §4a) — "öppna ärende == ladda hem allt
+ * som rör ärendet i cachen". Eager-cachar ärendets dokument-bytes så de blir
+ * **offline-tillgängliga** efter att ärendet öppnats online.
+ *
+ * Best-effort + bounded-concurrency: en miss/fel på ett dokument stoppar inte
+ * de andra, och vi laddar högst `concurrency` samtidigt (annars skulle ett
+ * ärende med många/stora dokument fyra av en flod av nedladdningar vid varje
+ * öppning). `loadBlob` är cache-först (IndexedDB) → redan cachade dokument är
+ * gratis, så ett återbesök på ärendet laddar inte om något.
+ */
+
+export interface PrefetchableDoc {
+  id: string;
+  storagePath?: string | null;
+  fileName?: string;
+}
+
+export async function prefetchMatterDocuments(
+  docs: ReadonlyArray<PrefetchableDoc>,
+  loadBlob: (doc: { id: string; storagePath: string | null; fileName: string }) => Promise<Blob | null>,
+  concurrency = 3,
+): Promise<number> {
+  let next = 0;
+  let cached = 0;
+  async function worker(): Promise<void> {
+    while (next < docs.length) {
+      const doc = docs[next++]!;
+      try {
+        const blob = await loadBlob({ id: doc.id, storagePath: doc.storagePath ?? null, fileName: doc.fileName ?? doc.id });
+        if (blob) cached++;
+      } catch {
+        /* best-effort: hoppa över ett dokument som inte gick att hämta */
+      }
+    }
+  }
+  const workers = Math.max(1, Math.min(concurrency, docs.length));
+  await Promise.all(Array.from({ length: workers }, () => worker()));
+  return cached;
+}

--- a/src/lib/client/firma/use-eager-cache-matter-documents.ts
+++ b/src/lib/client/firma/use-eager-cache-matter-documents.ts
@@ -1,0 +1,35 @@
+"use client";
+
+/**
+ * `useEagerCacheMatterDocuments` (ADR 0028 §4a) — när ett ärende öppnas i
+ * server-first-läge, eager-cacha ärendets dokument-bytes i IndexedDB (via
+ * `loadDocumentBlob`, cache-först) så de blir offline-tillgängliga. Körs en
+ * gång per ärende, best-effort, och bara när en server finns (`sync`); demon
+ * har redan allt in-process så där behövs ingen prefetch.
+ */
+
+import { useEffect, useRef } from "react";
+import { useCapabilities } from "@/lib/client/capabilities/use-capabilities";
+import { trpc } from "@/lib/client/trpc";
+import { prefetchMatterDocuments, type PrefetchableDoc } from "./prefetch-matter-documents";
+
+export function useEagerCacheMatterDocuments(matterId: string): void {
+  const { sync } = useCapabilities();
+  const tree = trpc.document.tree.useQuery({ matterId }, { enabled: sync });
+  const started = useRef(false);
+
+  useEffect(() => {
+    if (!sync || started.current) return;
+    const docs = tree.data?.documents as PrefetchableDoc[] | undefined;
+    if (!docs || docs.length === 0) return;
+    started.current = true;
+    void (async () => {
+      const [{ createServerDownloadClient }, { loadDocumentBlob }] = await Promise.all([
+        import("@/lib/client/backend/server-download-client"),
+        import("@/lib/client/backend/load-document-blob"),
+      ]);
+      const client = createServerDownloadClient();
+      await prefetchMatterDocuments(docs, (d) => loadDocumentBlob(client, d));
+    })();
+  }, [sync, matterId, tree.data]);
+}

--- a/test/unit/app/matters/[id]/page.test.tsx
+++ b/test/unit/app/matters/[id]/page.test.tsx
@@ -75,6 +75,8 @@ vi.mock("@/lib/client/trpc", () => ({
       // useMatterInvariants (diagnostik) frågar dokument-listan för att
       // upptäcka KR-utan-dokument — måste finnas i mocken.
       list: { useQuery: () => ({ data: { documents: [] }, isLoading: false }) },
+      // useEagerCacheMatterDocuments (ADR 0028 §4a) frågar dokument-trädet.
+      tree: { useQuery: () => ({ data: { documents: [] }, isLoading: false }) },
     },
     organization: {
       getSettings: { useQuery: () => ({ data: undefined }) },

--- a/test/unit/lib/firma/prefetch-matter-documents.test.ts
+++ b/test/unit/lib/firma/prefetch-matter-documents.test.ts
@@ -1,0 +1,63 @@
+/**
+ * prefetchMatterDocuments (ADR 0028 §4a) — eager-cacha ärendets dokument-bytes.
+ */
+
+import { describe, it, expect, vi } from "vitest-compat";
+import { prefetchMatterDocuments } from "@/lib/client/firma/prefetch-matter-documents";
+
+const docs = [
+  { id: "1", storagePath: "documents/content/a", fileName: "a.pdf" },
+  { id: "2", storagePath: null, fileName: "b.docx" },
+  { id: "3" },
+];
+
+describe("prefetchMatterDocuments", () => {
+  it("laddar varje dokument och räknar cachade", async () => {
+    const seen: string[] = [];
+    const loadBlob = vi.fn(async (d: { id: string }) => { seen.push(d.id); return new Blob(["x"]); });
+    const n = await prefetchMatterDocuments(docs, loadBlob);
+    expect(n).toBe(3);
+    expect(seen.sort()).toEqual(["1", "2", "3"]);
+  });
+
+  it("normaliserar saknad storagePath/fileName", async () => {
+    const calls: Array<{ id: string; storagePath: string | null; fileName: string }> = [];
+    await prefetchMatterDocuments(docs, async (d) => { calls.push(d); return new Blob(["x"]); });
+    expect(calls.find((c) => c.id === "2")).toMatchObject({ storagePath: null, fileName: "b.docx" });
+    expect(calls.find((c) => c.id === "3")).toMatchObject({ storagePath: null, fileName: "3" }); // fileName→id
+  });
+
+  it("är best-effort: ett fel stoppar inte de andra", async () => {
+    const loadBlob = vi.fn(async (d: { id: string }) => {
+      if (d.id === "2") throw new Error("download failed");
+      return new Blob(["x"]);
+    });
+    const n = await prefetchMatterDocuments(docs, loadBlob);
+    expect(n).toBe(2); // 1 och 3 lyckades, 2 svaldes
+  });
+
+  it("räknar bara faktiskt cachade (null = miss)", async () => {
+    const n = await prefetchMatterDocuments(docs, async (d) => (d.id === "1" ? new Blob(["x"]) : null));
+    expect(n).toBe(1);
+  });
+
+  it("respekterar concurrency-taket (aldrig fler samtidiga än gränsen)", async () => {
+    let active = 0;
+    let peak = 0;
+    const many = Array.from({ length: 10 }, (_v, i) => ({ id: String(i) }));
+    await prefetchMatterDocuments(many, async () => {
+      active++;
+      peak = Math.max(peak, active);
+      await new Promise((r) => setTimeout(r, 5));
+      active--;
+      return new Blob(["x"]);
+    }, 3);
+    expect(peak).toBeLessThanOrEqual(3);
+  });
+
+  it("tom lista → 0, inga anrop", async () => {
+    const loadBlob = vi.fn(async () => new Blob(["x"]));
+    expect(await prefetchMatterDocuments([], loadBlob)).toBe(0);
+    expect(loadBlob).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Vad

Genomförande-steg **4** av ADR 0028 (#655), reducerat per ditt beslut: **jävskontroll förblir online-only** (ingen kontakt-sync / klient-konflikt-logik — den risken är borta). Kvar är ADR §4a: **"öppna ärende == ladda hem allt som rör ärendet i cachen"** för dokumenten.

## Hur

- **`prefetchMatterDocuments(docs, loadBlob, concurrency=3)`** — eager-cachar ärendets dokument-bytes. **Best-effort** (ett fel stoppar inte de andra) + **bounded concurrency** (ett ärende med många/stora dokument fyrar inte av en flod). `loadBlob` är cache-först → redan cachade dokument är gratis, så återbesök laddar inte om något.
- **`useEagerCacheMatterDocuments(matterId)`** mountas i ärendevyn (`_client.tsx`): i **server-first** (`sync`) prefetchar den ärendets dokument-bytes till IndexedDB via `loadDocumentBlob`, en gång per ärende. **Demon hoppas över** (allt finns redan in-process). Gate:at på kapabilitet, inte `if (isDemo)` (ADR 0027).

**Effekt:** efter att ett ärende öppnats online är dess dokument tillgängliga **offline**.

## Test

`test/unit/lib/firma/prefetch-matter-documents.test.ts` (6 fall): laddar alla + räknar cachade, normaliserar saknad storagePath/fileName, best-effort vid fel, räknar bara faktiskt cachade, **respekterar concurrency-taket**, tom lista → 0. Den tunna hook-kompositionen (dynamiska imports) är otestad som annan komposition i kodbasen; logiken ligger i den testade `prefetchMatterDocuments`. Full enhetssvit grön (exit 0, coverage-golv passerat); typecheck + lint + knip rena.

Closes #672. Refs #655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)