### PR TITLE
feat(server): bearer-JWT-väg via JWKS för helper/add-in (#674)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "cron-parser": "^5.5.0",
         "handlebars": "^4.7.9",
         "html-to-docx": "^1.8.0",
+        "jose": "^6.2.3",
         "json-logic-js": "^2.0.5",
         "lucide-react": "^1.17.0",
         "mammoth": "^1.12.0",
@@ -1076,6 +1077,8 @@
     "iterator.prototype": ["iterator.prototype@1.1.5", "", { "dependencies": { "define-data-property": "^1.1.4", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "get-proto": "^1.0.0", "has-symbols": "^1.1.0", "set-function-name": "^2.0.2" } }, "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g=="],
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "cron-parser": "^5.5.0",
     "handlebars": "^4.7.9",
     "html-to-docx": "^1.8.0",
+    "jose": "^6.2.3",
     "json-logic-js": "^2.0.5",
     "lucide-react": "^1.17.0",
     "mammoth": "^1.12.0",

--- a/src/lib/server/http/bearer-claims.ts
+++ b/src/lib/server/http/bearer-claims.ts
@@ -1,0 +1,88 @@
+/**
+ * Bearer-JWT-väg (ADR 0028 §1/§2, ADR 0009) — verifiera en access-token från
+ * byråns OIDC-IdP mot dess JWKS och härled SAMMA `OidcClaims` som
+ * oauth2-proxy-cookie-vägen (`forwarded-claims`). Används av klienter som inte
+ * bär OIDC-cookien: den autonoma helpern (ADR 0028) och Office-add-insen
+ * (ADR 0013) — samma tunn-klient-behov, samma server-väg.
+ *
+ * **IdP-agnostiskt (BYO-IdP):** issuer + JWKS-URL kommer ur konfiguration/OIDC-
+ * discovery (Keycloak-fixturen i dev; Entra/Google/Okta i produktion). AVA kör
+ * aldrig egen IdP. `jose.jwtVerify` validerar signatur + issuer + (ev.) audience
+ * + exp/nbf kryptografiskt — en token utan giltig signatur ger `null` (anonym),
+ * precis som en saknad cookie. Inget Keycloak-beroende i koden.
+ *
+ * `jwks` injiceras (`JWTVerifyGetKey`) → testas med en lokalt signerad token.
+ */
+
+import { createRemoteJWKSet, jwtVerify, type JWTPayload, type JWTVerifyGetKey } from "jose";
+import type { OidcClaims } from "@/lib/server/auth/oidc-auth-provider";
+import { parseBearerToken } from "./pat";
+
+export interface BearerVerifyConfig {
+  /** Förväntad issuer (`iss`) — IdP:ns issuer-URL. */
+  issuer: string;
+  /** Förväntad audience (`aud`). Utelämnad → ingen aud-kontroll. */
+  audience?: string;
+  /** Nyckelkälla (JWKS). Injicerbar för test (`createLocalJWKSet`). */
+  jwks: JWTVerifyGetKey;
+}
+
+/**
+ * Verifiera `Authorization: Bearer <jwt>` → `OidcClaims`, eller `null` om
+ * headern saknas eller token:en inte validerar (signatur/issuer/audience/exp).
+ * Email-only-modellen (#224/ADR 0009): saknas `email`-claim → `null`.
+ */
+export async function bearerClaims(headers: Headers, config: BearerVerifyConfig): Promise<OidcClaims | null> {
+  const token = parseBearerToken(headers.get("authorization"));
+  if (!token) return null;
+  try {
+    const { payload } = await jwtVerify(token, config.jwks, {
+      issuer: config.issuer,
+      ...(config.audience !== undefined ? { audience: config.audience } : {}),
+    });
+    return claimsFromPayload(payload);
+  } catch {
+    return null; // ogiltig signatur/issuer/audience/utgången → anonym (UNAUTHORIZED)
+  }
+}
+
+/** Plocka OidcClaims ur en verifierad JWT-payload; null om email-claim saknas. */
+function claimsFromPayload(payload: JWTPayload): OidcClaims | null {
+  const email = typeof payload.email === "string" ? payload.email : undefined;
+  if (!email) return null; // email-only-modellen (#224/ADR 0009)
+  return {
+    email,
+    subject: typeof payload.sub === "string" ? payload.sub : "",
+    issuer: typeof payload.iss === "string" ? payload.iss : "",
+    ...(typeof payload.name === "string" ? { name: payload.name } : {}),
+  };
+}
+
+/**
+ * JWKS-källa för en OIDC-issuer. Standardväg = Keycloak/OIDC
+ * `<issuer>/protocol/openid-connect/certs`; override:as med explicit `jwksUri`
+ * (BYO-IdP: hämtas ur IdP:ns `.well-known/openid-configuration`).
+ */
+export function remoteJwksForIssuer(issuer: string, jwksUri?: string): JWTVerifyGetKey {
+  const uri = jwksUri ?? `${issuer.replace(/\/$/, "")}/protocol/openid-connect/certs`;
+  return createRemoteJWKSet(new URL(uri));
+}
+
+/**
+ * Bygg `BearerVerifyConfig` ur miljön, eller `null` om Bearer-vägen inte är
+ * konfigurerad (då är beteendet oförändrat — bara oauth2-proxy-cookien gäller).
+ *   - `AVA_OIDC_ISSUER`   (krävs) — IdP:ns issuer-URL.
+ *   - `AVA_OIDC_JWKS_URI` (valfri) — explicit JWKS-URL (annars Keycloak-vägen).
+ *   - `AVA_OIDC_AUDIENCE` (valfri) — förväntad `aud`.
+ */
+export function bearerConfigFromEnv(env: Record<string, string | undefined> = process.env): BearerVerifyConfig | null {
+  const issuer = env.AVA_OIDC_ISSUER?.trim();
+  if (!issuer) return null;
+  const jwksUri = env.AVA_OIDC_JWKS_URI?.trim();
+  const audience = env.AVA_OIDC_AUDIENCE?.trim();
+  return {
+    issuer,
+    ...(audience ? { audience } : {}),
+    jwks: remoteJwksForIssuer(issuer, jwksUri || undefined),
+  };
+}

--- a/src/lib/server/http/server-context.ts
+++ b/src/lib/server/http/server-context.ts
@@ -29,6 +29,7 @@ import type { SyncStore } from "@/lib/server/sync/sync-store";
 import type { Context } from "@/lib/server/trpc-core";
 import type { Capabilities } from "@/lib/shared/capabilities";
 import type { User } from "@/lib/shared/schemas/user";
+import { bearerClaims, type BearerVerifyConfig } from "./bearer-claims";
 import { forwardedClaims, type ForwardedHeaderNames } from "./forwarded-claims";
 
 /**
@@ -89,6 +90,11 @@ export interface ServerContextDeps {
   headerNames?: ForwardedHeaderNames;
   /** Server-sidans delta-sync-port (ADR 0017) — driver `sync`-routern. */
   sync?: SyncStore;
+  /**
+   * Bearer-JWT-verifiering (ADR 0028/0013) för klienter utan OIDC-cookie
+   * (helper, Office-add-in). Utelämnad → bara cookie-vägen (oförändrat).
+   */
+  bearer?: BearerVerifyConfig;
 }
 
 /** Mappa en allowlist-rad ur full `User` → den delmängd `OidcAuthProvider` behöver. */
@@ -107,7 +113,11 @@ function toAllowlist(users: readonly User[]): AllowlistedUser[] {
 
 /** Bygg en server-first-`Context` för en inkommande HTTP-request. */
 export async function createServerContext(req: Request, deps: ServerContextDeps): Promise<Context> {
-  const claims = forwardedClaims(req.headers, deps.headerNames);
+  // Cookie-vägen (oauth2-proxy forwarded headers) först; annars Bearer-JWT
+  // (helper/add-in) om konfigurerad. Båda → samma OidcClaims → samma allowlist.
+  const claims =
+    forwardedClaims(req.headers, deps.headerNames) ??
+    (deps.bearer ? await bearerClaims(req.headers, deps.bearer) : null);
   const users = await deps.repos.users.listByOrg(deps.organizationId);
   const principal = new OidcAuthProvider(claims, toAllowlist(users)).getPrincipal();
   return buildContext({

--- a/src/lib/server/http/server-first-api.ts
+++ b/src/lib/server/http/server-first-api.ts
@@ -17,6 +17,7 @@ import type { IPorts } from "@/lib/server/ports";
 import { createDbChangeLogRecorder, enableChangeLogOnAll } from "@/lib/server/repositories/change-log-recorder";
 import { buildDrizzleRepositories } from "@/lib/server/repositories/drizzle-repositories";
 import { DrizzleSyncStore } from "@/lib/server/sync/drizzle-sync-store";
+import { bearerConfigFromEnv, type BearerVerifyConfig } from "./bearer-claims";
 import { createServerTrpcHandler } from "./server-trpc-handler";
 
 export interface ServerFirstApiConfig {
@@ -32,6 +33,11 @@ export interface ServerFirstApiConfig {
   maxConnections?: number;
   /** Server-side fel-logg. */
   onError?: (err: unknown) => void;
+  /**
+   * Bearer-JWT-verifiering för icke-cookie-klienter (helper/add-in, ADR
+   * 0028/0013). Default: härled ur miljön (`AVA_OIDC_*`); null → av.
+   */
+  bearer?: BearerVerifyConfig | null;
 }
 
 export interface ServerFirstApi {
@@ -53,6 +59,8 @@ export function buildServerFirstApi(config: ServerFirstApiConfig): ServerFirstAp
   // Driv delta-sync: varje accepterad skrivning loggas i change_log (pull),
   // och `ctx.sync` ger sync-routern dess pull/push (ADR 0017).
   enableChangeLogOnAll(repos, createDbChangeLogRecorder(db));
+  // Bearer-JWT-väg: explicit config, annars ur miljön (AVA_OIDC_*). Av som default.
+  const bearer = config.bearer === undefined ? bearerConfigFromEnv() : config.bearer;
   const handler = createServerTrpcHandler({
     repos,
     ports: config.ports ?? noopPorts,
@@ -60,6 +68,7 @@ export function buildServerFirstApi(config: ServerFirstApiConfig): ServerFirstAp
     sync: new DrizzleSyncStore(db, repos),
     ...(config.endpoint ? { endpoint: config.endpoint } : {}),
     ...(config.onError ? { onError: config.onError } : {}),
+    ...(bearer ? { bearer } : {}),
   });
   return { handler, repos, close };
 }

--- a/src/lib/server/http/server-trpc-handler.ts
+++ b/src/lib/server/http/server-trpc-handler.ts
@@ -40,6 +40,7 @@ export function createServerTrpcHandler(
     organizationId: deps.organizationId,
     ...(deps.headerNames ? { headerNames: deps.headerNames } : {}),
     ...(deps.sync ? { sync: deps.sync } : {}),
+    ...(deps.bearer ? { bearer: deps.bearer } : {}),
   };
   return (req: Request): Promise<Response> =>
     fetchRequestHandler({

--- a/test/unit/server/http/bearer-claims.test.ts
+++ b/test/unit/server/http/bearer-claims.test.ts
@@ -1,0 +1,112 @@
+/**
+ * bearerClaims (ADR 0028 §1, ADR 0009) — verifiera IdP-JWT mot JWKS → OidcClaims.
+ * Signerar tokens lokalt (jose) och verifierar mot en lokal JWKS, så testet är
+ * IdP-oberoende och kräver ingen Keycloak.
+ */
+
+import { SignJWT, exportJWK, generateKeyPair, createLocalJWKSet, type JWTVerifyGetKey } from "jose";
+import { describe, it, expect, beforeAll } from "vitest-compat";
+import { bearerClaims, bearerConfigFromEnv } from "@/lib/server/http/bearer-claims";
+
+const ISSUER = "https://idp.example/realms/ava";
+const AUDIENCE = "ava";
+
+let privateKey: CryptoKey;
+let jwks: JWTVerifyGetKey;
+
+beforeAll(async () => {
+  const pair = await generateKeyPair("RS256");
+  privateKey = pair.privateKey;
+  const pub = await exportJWK(pair.publicKey);
+  pub.kid = "test-key";
+  pub.alg = "RS256";
+  jwks = createLocalJWKSet({ keys: [pub] });
+});
+
+interface TokenOpts {
+  issuer?: string;
+  audience?: string;
+  email?: string | undefined;
+  name?: string;
+  expiresIn?: string | number; // jose-format ("1h") eller epoch-sekunder
+  signKey?: CryptoKey;
+}
+
+async function token(opts: TokenOpts = {}): Promise<string> {
+  const claims: Record<string, unknown> = { sub: "user-123" };
+  if (opts.email !== undefined) claims.email = opts.email;
+  if (opts.name) claims.name = opts.name;
+  return new SignJWT(claims)
+    .setProtectedHeader({ alg: "RS256", kid: "test-key" })
+    .setIssuedAt()
+    .setIssuer(opts.issuer ?? ISSUER)
+    .setAudience(opts.audience ?? AUDIENCE)
+    .setExpirationTime(opts.expiresIn ?? "1h")
+    .sign(opts.signKey ?? privateKey);
+}
+
+function authHeaders(jwt: string | null): Headers {
+  const h = new Headers();
+  if (jwt) h.set("authorization", `Bearer ${jwt}`);
+  return h;
+}
+
+function cfg(): { issuer: string; audience: string; jwks: JWTVerifyGetKey } {
+  return { issuer: ISSUER, audience: AUDIENCE, jwks };
+}
+
+describe("bearerClaims", () => {
+  it("giltig token → OidcClaims (email/sub/iss/name)", async () => {
+    const claims = await bearerClaims(authHeaders(await token({ email: "anna@firma.se", name: "Anna A" })), cfg());
+    expect(claims).toEqual({ email: "anna@firma.se", subject: "user-123", issuer: ISSUER, name: "Anna A" });
+  });
+
+  it("ingen Authorization-header → null", async () => {
+    expect(await bearerClaims(authHeaders(null), cfg())).toBeNull();
+  });
+
+  it("fel issuer → null", async () => {
+    expect(await bearerClaims(authHeaders(await token({ issuer: "https://evil.example", email: "a@b.se" })), cfg())).toBeNull();
+  });
+
+  it("fel audience → null", async () => {
+    expect(await bearerClaims(authHeaders(await token({ audience: "annan-app", email: "a@b.se" })), cfg())).toBeNull();
+  });
+
+  it("utgången token → null", async () => {
+    const expired = await token({ email: "a@b.se", expiresIn: Math.floor(Date.now() / 1000) - 60 });
+    expect(await bearerClaims(authHeaders(expired), cfg())).toBeNull();
+  });
+
+  it("fel signatur (annan nyckel) → null", async () => {
+    const other = (await generateKeyPair("RS256")).privateKey;
+    expect(await bearerClaims(authHeaders(await token({ email: "a@b.se", signKey: other })), cfg())).toBeNull();
+  });
+
+  it("saknad email-claim → null (email-only-modellen)", async () => {
+    expect(await bearerClaims(authHeaders(await token({})), cfg())).toBeNull();
+  });
+
+  it("utan audience-konfig hoppas aud-kontrollen över", async () => {
+    const claims = await bearerClaims(authHeaders(await token({ audience: "vad-som-helst", email: "a@b.se" })), { issuer: ISSUER, jwks });
+    expect(claims?.email).toBe("a@b.se");
+  });
+});
+
+describe("bearerConfigFromEnv", () => {
+  it("null utan AVA_OIDC_ISSUER", () => {
+    expect(bearerConfigFromEnv({})).toBeNull();
+  });
+
+  it("config med issuer + audience", () => {
+    const c = bearerConfigFromEnv({ AVA_OIDC_ISSUER: ISSUER, AVA_OIDC_AUDIENCE: AUDIENCE });
+    expect(c?.issuer).toBe(ISSUER);
+    expect(c?.audience).toBe(AUDIENCE);
+    expect(c?.jwks).toBeTypeOf("function");
+  });
+
+  it("utan audience → ingen aud i config", () => {
+    const c = bearerConfigFromEnv({ AVA_OIDC_ISSUER: ISSUER });
+    expect(c?.audience).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Vad

Genomförande-steg **1** av ADR 0028 (#655): en server-side **Bearer-väg** så icke-cookie-klienter — den autonoma helpern (ADR 0028) och Office-add-insen (ADR 0013) — kan auktorisera mot **byråns OIDC-IdP**. Förbereder helperns device/PKCE-auth (steg 2, #14) som producerar token:en denna väg validerar.

## Hur

- **`bearer-claims.ts`**: `bearerClaims(headers, config)` verifierar `Authorization: Bearer <jwt>` mot IdP:ns **JWKS** med `jose` (signatur + issuer + ev. audience + exp/nbf) → samma **`OidcClaims`** (email-only, #224/ADR 0009) som oauth2-proxy-cookie-vägen (`forwarded-claims`) → samma allowlist (`OidcAuthProvider`). Ogiltig token → `null` (anonym → `UNAUTHORIZED`), precis som saknad cookie. Återanvänder `parseBearerToken` (DRY).
- **IdP-agnostiskt (BYO-IdP):** issuer/JWKS/audience ur `AVA_OIDC_ISSUER` / `AVA_OIDC_JWKS_URI` / `AVA_OIDC_AUDIENCE`. **Keycloak-fixturen** i dev, **Entra/Google/Okta** i produktion — **inget Keycloak-beroende i koden**.
- Wiras i `createServerContext` som **fallback efter** forwarded-claims (cookie först, Bearer sen). `buildServerFirstApi` härleder config ur miljön; **av som default → oförändrat beteende** (befintliga deploys/tester opåverkade).
- `jose@6` tillagt.

## Test

`bearer-claims.test.ts` (11 fall) signerar tokens lokalt mot en lokal JWKS (IdP-oberoende, ingen Keycloak krävs): giltig token → claims; ingen header / fel issuer / fel audience / utgången / fel signatur / saknad email → `null`; audience-kontroll hoppas över utan konfig; `bearerConfigFromEnv` (null utan issuer, med/utan audience). Full enhetssvit grön (exit 0, coverage-golv passerat); typecheck + lint + knip rena.

Closes #674. Refs #655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)