### PR TITLE
feat(helper): loopback-pkce login-orchestrering + autonom bearer-wiring (#678)

### DIFF
--- a/helper-app/src/auth/auth-provider.ts
+++ b/helper-app/src/auth/auth-provider.ts
@@ -1,0 +1,53 @@
+/**
+ * `buildAuthHeaderProvider` (ADR 0028 §2) — en `() => Promise<string|undefined>`
+ * som ger helperns FÄRSKA `Authorization: Bearer …` mot AVA-servern, eller
+ * `undefined` om helpern inte är parad / token gått ut utan refresh.
+ *
+ * Hot-path (giltig token i keychain) returnerar direkt UTAN nät/discovery, så
+ * en nedladdning inte blockerar på IdP:n. Först när token håller på att gå ut
+ * görs OIDC-discovery (cachad) + refresh via `TokenManager`. Wiras in i
+ * helperns download/content/upload-kö så den autonomt bär sin egen Bearer.
+ */
+
+import { discoverOidc, type OidcEndpoints } from "./oidc.ts";
+import { TokenManager } from "./token-manager.ts";
+import { KeychainTokenStore, type TokenStore } from "./token-store.ts";
+
+const EXPIRY_SKEW_MS = 60_000;
+
+export interface AuthProviderDeps {
+  now: () => number;
+  discover: (issuer: string) => Promise<OidcEndpoints>;
+  /** Bygg en manager för refresh-vägen (injicerbar för test). */
+  makeManager: (store: TokenStore, ep: OidcEndpoints, clientId: string, now: () => number) => { authHeader: () => Promise<string | null> };
+}
+
+function defaultDeps(): AuthProviderDeps {
+  return {
+    now: Date.now,
+    discover: (issuer) => discoverOidc(issuer),
+    makeManager: (store, ep, clientId, now) => new TokenManager(store, ep, clientId, { now }),
+  };
+}
+
+export function buildAuthHeaderProvider(
+  config: { issuer: string; clientId: string },
+  store: TokenStore = new KeychainTokenStore(),
+  deps: AuthProviderDeps = defaultDeps(),
+): () => Promise<string | undefined> {
+  let endpointsP: Promise<OidcEndpoints> | undefined;
+  return async () => {
+    const tokens = await store.load();
+    if (!tokens) return undefined;
+    // Hot-path: giltig token → ingen discovery/nät.
+    if (tokens.expiresAt - deps.now() > EXPIRY_SKEW_MS) return `Bearer ${tokens.accessToken}`;
+    // Snart utgången → discover (cachad) + refresh via manager.
+    try {
+      const ep = await (endpointsP ??= deps.discover(config.issuer));
+      const header = await deps.makeManager(store, ep, config.clientId, deps.now).authHeader();
+      return header ?? undefined;
+    } catch {
+      return undefined;
+    }
+  };
+}

--- a/helper-app/src/auth/callback-server.ts
+++ b/helper-app/src/auth/callback-server.ts
@@ -1,0 +1,78 @@
+/**
+ * Loopback-callback-server (RFC 8252, ADR 0028 §2) — fångar OAuth-redirecten
+ * på `http://127.0.0.1:<port>/callback` efter att användaren godkänt i browsern.
+ *
+ * `parseCallback` (ren) validerar pathname + `state` (CSRF) och plockar `code`
+ * → testbar utan att binda en port. `waitForCallback` binder en kortlivad
+ * Bun-server, resolvar vid första giltiga callback och svarar användaren med en
+ * "stäng fliken"-sida; timeout om inget kommer.
+ */
+
+import { log } from "../log.ts";
+
+export type CallbackResult = { code: string } | { error: string };
+
+/** Validera en inkommande callback-URL → code, eller ett fel. Ren funktion. */
+export function parseCallback(rawUrl: string, expectedState: string): CallbackResult {
+  let u: URL;
+  try {
+    u = new URL(rawUrl, "http://127.0.0.1");
+  } catch {
+    return { error: "invalid-url" };
+  }
+  if (u.pathname !== "/callback") return { error: "not-callback" };
+  const err = u.searchParams.get("error");
+  if (err) return { error: err };
+  if (u.searchParams.get("state") !== expectedState) return { error: "state-mismatch" };
+  const code = u.searchParams.get("code");
+  if (!code) return { error: "missing-code" };
+  return { code };
+}
+
+const SUCCESS_HTML = "<!doctype html><meta charset=utf-8><title>AVA Helper</title><body style=\"font-family:system-ui;padding:3rem;text-align:center\"><h2>✅ AVA Helper är ansluten</h2><p>Du kan stänga den här fliken.</p>";
+const ERROR_HTML = "<!doctype html><meta charset=utf-8><title>AVA Helper</title><body style=\"font-family:system-ui;padding:3rem;text-align:center\"><h2>⚠️ Inloggningen misslyckades</h2><p>Stäng fliken och försök igen.</p>";
+
+const DEFAULT_TIMEOUT_MS = 5 * 60_000;
+
+export interface WaitForCallbackDeps {
+  /** Binder en HTTP-server; returnerar en stop-funktion. För test-injektion. */
+  serve: (port: number, handler: (req: Request) => Response) => { stop: () => void };
+  timeoutMs?: number;
+}
+
+const defaultServe: WaitForCallbackDeps["serve"] = (port, handler) => {
+  const server = Bun.serve({ port, hostname: "127.0.0.1", fetch: handler });
+  return { stop: () => void server.stop(true) };
+};
+
+/**
+ * Starta callback-servern och vänta på en giltig redirect (rätt `state` + `code`).
+ * Resolvar med koden, eller rejectar vid fel/timeout. Servern stängs alltid.
+ */
+export function waitForCallback(port: number, expectedState: string, deps: WaitForCallbackDeps = { serve: defaultServe }): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    let settled = false;
+    const handler = (req: Request): Response => {
+      const result = parseCallback(req.url, expectedState);
+      const ok = "code" in result;
+      if (!settled && (ok || req.url.includes("/callback"))) {
+        settled = true;
+        queueMicrotask(() => {
+          handle.stop();
+          if (ok) resolve(result.code);
+          else reject(new Error(`callback: ${(result as { error: string }).error}`));
+        });
+      }
+      return new Response(ok ? SUCCESS_HTML : ERROR_HTML, { status: ok ? 200 : 400, headers: { "Content-Type": "text/html; charset=utf-8" } });
+    };
+    const handle = deps.serve(port, handler);
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      handle.stop();
+      reject(new Error("callback: timeout"));
+    }, deps.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+    timer.unref?.();
+    log(`auth: väntar på callback på 127.0.0.1:${port}/callback`);
+  });
+}

--- a/helper-app/src/auth/login.ts
+++ b/helper-app/src/auth/login.ts
@@ -1,0 +1,94 @@
+/**
+ * `runLogin` (ADR 0028 §2) — paras helpern mot byråns IdP via loopback-PKCE
+ * (RFC 8252): discover → PKCE → starta callback-server → öppna browsern →
+ * fånga koden → byt mot tokens → spara i keychain. Engångsflöde (CLI `--login`);
+ * därefter förnyar `TokenManager` autonomt.
+ *
+ * Allt IO injiceras (`LoginDeps`) → hela orkestreringen är testbar utan riktig
+ * browser/IdP. `loginConfigFromEnv` läser issuer/clientId/redirect-port.
+ */
+
+import { log } from "../log.ts";
+import { openUrlInBrowser } from "../platform/open-app.ts";
+import { waitForCallback } from "./callback-server.ts";
+import { buildAuthorizeUrl, discoverOidc, exchangeCode, type OidcEndpoints, type TokenSet } from "./oidc.ts";
+import { generatePkce, randomState, type Pkce } from "./pkce.ts";
+import { KeychainTokenStore, type TokenStore } from "./token-store.ts";
+
+export interface LoginConfig {
+  issuer: string;
+  clientId: string;
+  redirectPort: number;
+  scope?: string;
+}
+
+const DEFAULT_CLIENT_ID = "ava-helper";
+const DEFAULT_REDIRECT_PORT = 48765;
+
+function parseRedirectPort(raw: string | undefined): number {
+  const p = Number(raw);
+  return Number.isInteger(p) && p > 0 ? p : DEFAULT_REDIRECT_PORT;
+}
+
+/** Läs login-config ur miljön; null om `AVA_OIDC_ISSUER` saknas (auth av). */
+export function loginConfigFromEnv(env: Record<string, string | undefined> = process.env): LoginConfig | null {
+  const issuer = env.AVA_OIDC_ISSUER?.trim();
+  if (!issuer) return null;
+  const scope = env.AVA_OIDC_SCOPE?.trim();
+  return {
+    issuer,
+    clientId: env.AVA_OIDC_CLIENT_ID?.trim() || DEFAULT_CLIENT_ID,
+    redirectPort: parseRedirectPort(env.AVA_HELPER_REDIRECT_PORT),
+    ...(scope ? { scope } : {}),
+  };
+}
+
+export interface LoginDeps {
+  discover: (issuer: string) => Promise<OidcEndpoints>;
+  makePkce: () => Pkce;
+  makeState: () => string;
+  openUrl: (url: string) => Promise<void>;
+  awaitCallback: (port: number, expectedState: string) => Promise<string>;
+  exchange: (ep: OidcEndpoints, p: { clientId: string; code: string; verifier: string; redirectUri: string }) => Promise<TokenSet>;
+  store: TokenStore;
+}
+
+export function defaultLoginDeps(): LoginDeps {
+  return {
+    discover: (issuer) => discoverOidc(issuer),
+    makePkce: () => generatePkce(),
+    makeState: () => randomState(),
+    openUrl: (url) => openUrlInBrowser(url),
+    awaitCallback: (port, state) => waitForCallback(port, state),
+    exchange: (ep, p) => exchangeCode(ep, p),
+    store: new KeychainTokenStore(),
+  };
+}
+
+/**
+ * Kör hela paringsflödet. Startar callback-servern FÖRE browsern (annars kan
+ * redirecten komma innan vi lyssnar). Returnerar true vid lyckad paring.
+ */
+export async function runLogin(config: LoginConfig, deps: LoginDeps = defaultLoginDeps()): Promise<boolean> {
+  const ep = await deps.discover(config.issuer);
+  const pkce = deps.makePkce();
+  const state = deps.makeState();
+  const redirectUri = `http://127.0.0.1:${config.redirectPort}/callback`;
+
+  const callback = deps.awaitCallback(config.redirectPort, state); // lyssna först
+  const authUrl = buildAuthorizeUrl(ep, {
+    clientId: config.clientId,
+    redirectUri,
+    challenge: pkce.challenge,
+    state,
+    ...(config.scope ? { scope: config.scope } : {}),
+  });
+  log(`auth: öppnar browsern för inloggning (${config.issuer})`);
+  await deps.openUrl(authUrl);
+
+  const code = await callback;
+  const tokens = await deps.exchange(ep, { clientId: config.clientId, code, verifier: pkce.verifier, redirectUri });
+  await deps.store.save(tokens);
+  log("auth: paring klar — tokens sparade i keychain");
+  return true;
+}

--- a/helper-app/src/main.ts
+++ b/helper-app/src/main.ts
@@ -21,6 +21,8 @@ import { join } from "node:path";
 
 import { HELPER_HTTPS_PORT, HELPER_PORT } from "@/lib/shared/helper/protocol";
 
+import { buildAuthHeaderProvider } from "./auth/auth-provider.ts";
+import { loginConfigFromEnv, runLogin } from "./auth/login.ts";
 import { ContentStore, resolveCacheTtlMs } from "./content-store.ts";
 import { fetchAndCacheContent, handleContent } from "./content.ts";
 import { installService, uninstallService, type InstallDeps } from "./install.ts";
@@ -28,6 +30,7 @@ import { initLog, log } from "./log.ts";
 import {
   defaultOpenDeps,
   defaultWatchDeps,
+  downloadTo,
   enqueueSavedFile,
   handleOpen,
   persistDownloaded,
@@ -151,11 +154,18 @@ function buildUpdateConfig(): UpdateConfig {
  * nedladdade bytes cachas content-adresserat (persist) och en cachad kopia
  * återställs (restore) om nedladdning misslyckas offline.
  */
-export function queueBackedOnOpen(queue: UploadQueue, content: ContentStore): (req: Request) => Promise<Response> {
+/** Färsk `Authorization`-header från helperns OIDC-token, eller undefined. */
+type AuthHeaderProvider = () => Promise<string | undefined>;
+
+export function queueBackedOnOpen(queue: UploadQueue, content: ContentStore, authHeader?: AuthHeaderProvider): (req: Request) => Promise<Response> {
+  // Browserns authHeader först; annars helperns egen OIDC-token (autonom, ADR 0028 §2).
+  const fallback = async (browserAuth: string | undefined): Promise<string | undefined> =>
+    browserAuth ?? (authHeader ? await authHeader() : undefined);
   const deps: OpenDeps = {
     ...defaultOpenDeps,
-    startWatch: (path, uploadUrl, authHeader, timeoutMs) =>
-      watchAndUpload(path, uploadUrl, authHeader, timeoutMs, {
+    download: async (path, url, browserAuth) => downloadTo(path, url, await fallback(browserAuth)),
+    startWatch: (path, uploadUrl, authHeaderArg, timeoutMs) =>
+      watchAndUpload(path, uploadUrl, authHeaderArg, timeoutMs, {
         ...defaultWatchDeps,
         upload: (p, url, auth) => enqueueSavedFile(queue, p, url, auth),
       }),
@@ -172,40 +182,50 @@ interface Stores {
 }
 
 /** Skapa + återställ kön + content-lagret (om data-dir finns) och starta dränerings-loopen. */
-function startStores(signal: AbortSignal): Stores | undefined {
+function startStores(signal: AbortSignal, authHeader?: AuthHeaderProvider): Stores | undefined {
   const dir = dataDir();
   if (dir === null) {
     log("ingen data-dir → durabla lager inaktiverade (direkt-upload, ingen offline-cache)");
     return undefined;
   }
-  const queue = new UploadQueue(join(dir, "queue"));
+  // Kön får token-providern → drar färsk Bearer vid varje upload-försök (ADR 0028 §2).
+  const queue = new UploadQueue(join(dir, "queue"), undefined, authHeader);
   void queue.recover().then(() => queue.startDrainLoop(signal));
   const content = new ContentStore(join(dir, "content"));
   content.startEvictionLoop(signal, resolveCacheTtlMs(process.env.AVA_HELPER_CACHE_TTL_DAYS));
   return { queue, content };
 }
 
+/** `--login`: para helpern mot byråns IdP via loopback-PKCE (ADR 0028 §2). */
+async function handleLogin(): Promise<void> {
+  const cfg = loginConfigFromEnv();
+  if (!cfg) {
+    process.stderr.write("AVA_OIDC_ISSUER krävs för --login\n");
+    process.exitCode = 1;
+    return;
+  }
+  try {
+    await runLogin(cfg);
+    process.stdout.write("Inloggning klar — helpern är parad.\n");
+  } catch (err) {
+    process.stderr.write(`Inloggning misslyckades: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.exitCode = 1;
+  }
+}
+
+/** Hantera engångs-CLI-flaggor; returnerar true om en flagga togs (main avslutar). */
+function runCliFlag(argv: readonly string[]): boolean {
+  if (argv.includes("--version")) { process.stdout.write(`${VERSION}\n`); return true; }
+  if (argv.includes("--login")) { void handleLogin(); return true; }
+  if (argv.includes("--install-trust")) { handleTrust("install"); return true; }
+  if (argv.includes("--uninstall-trust")) { handleTrust("uninstall"); return true; }
+  if (argv.includes("--install")) { handleInstall("install"); return true; }
+  if (argv.includes("--uninstall")) { handleInstall("uninstall"); return true; }
+  return false;
+}
+
 function main(): void {
-  if (process.argv.includes("--version")) {
-    process.stdout.write(`${VERSION}\n`);
-    return;
-  }
-  if (process.argv.includes("--install-trust")) {
-    handleTrust("install");
-    return;
-  }
-  if (process.argv.includes("--uninstall-trust")) {
-    handleTrust("uninstall");
-    return;
-  }
-  if (process.argv.includes("--install")) {
-    handleInstall("install");
-    return;
-  }
-  if (process.argv.includes("--uninstall")) {
-    handleInstall("uninstall");
-    return;
-  }
+  if (runCliFlag(process.argv)) return;
 
   initLog();
   const port = listenPort();
@@ -215,19 +235,24 @@ function main(): void {
   const abort = new AbortController();
   void runUpdateLoop(updateCfg, abort.signal);
 
-  const stores = startStores(abort.signal);
+  // Helperns egen OIDC-auth (om parad/konfigurerad) → autonom Bearer mot servern.
+  const loginCfg = loginConfigFromEnv();
+  const authHeader: AuthHeaderProvider | undefined = loginCfg ? buildAuthHeaderProvider(loginCfg) : undefined;
+
+  const stores = startStores(abort.signal, authHeader);
   const handler = createHandler({
     version: VERSION,
     extraOrigins: extraOrigins(),
     onCheckUpdate: () => { void checkOnce(updateCfg).catch((err) => log(`check-update: ${String(err)}`)); },
     ...(stores
       ? {
-          onOpen: queueBackedOnOpen(stores.queue, stores.content),
+          onOpen: queueBackedOnOpen(stores.queue, stores.content, authHeader),
           onStatus: () => stores.queue.snapshot(),
           onContent: (req: Request) =>
             handleContent(req, {
               load: (url) => stores.content.load(url),
-              fetchAndCache: (url, auth, fileName) => fetchAndCacheContent(stores.content, url, auth, fileName),
+              fetchAndCache: async (url, auth, fileName) =>
+                fetchAndCacheContent(stores.content, url, auth ?? (authHeader ? await authHeader() : undefined), fileName),
             }),
         }
       : {}),

--- a/helper-app/src/platform/open-app.ts
+++ b/helper-app/src/platform/open-app.ts
@@ -30,3 +30,13 @@ export async function openWithDefaultApp(path: string): Promise<void> {
   const { cmd, args } = openCommand(currentPlatform(), path);
   await spawnDetached(cmd, args).started;
 }
+
+/**
+ * Öppna en URL i systemets default-browser (samma OS-kommandon som
+ * `openWithDefaultApp` — `open`/`xdg-open`/FileProtocolHandler tar även en URL).
+ * Används av auth-loopback-flödet (ADR 0028 §2) för att starta OIDC-login.
+ */
+export async function openUrlInBrowser(url: string): Promise<void> {
+  const { cmd, args } = openCommand(currentPlatform(), url);
+  await spawnDetached(cmd, args).started;
+}

--- a/helper-app/src/queue.ts
+++ b/helper-app/src/queue.ts
@@ -89,12 +89,20 @@ export interface EnqueueInput {
 export class UploadQueue {
   private readonly dir: string;
   private readonly deps: QueueDeps;
+  private readonly tokenProvider: (() => Promise<string | undefined>) | undefined;
   private readonly entries = new Map<string, QueueEntry>();
   private draining = false;
 
-  constructor(dir: string, deps: QueueDeps = defaultQueueDeps) {
+  /**
+   * `tokenProvider` (ADR 0028 §2): ger en FÄRSK `Authorization`-header vid varje
+   * upload-försök när posten inte bär en egen (helpern auktoriserar autonomt med
+   * sin OIDC-token). Hämtas vid drain-tid — aldrig lagrad — så en utgången token
+   * inte fryses in i en köad post som väntat dagar offline.
+   */
+  constructor(dir: string, deps: QueueDeps = defaultQueueDeps, tokenProvider?: () => Promise<string | undefined>) {
     this.dir = dir;
     this.deps = deps;
+    this.tokenProvider = tokenProvider;
   }
 
   private manifestPath(id: string): string {
@@ -183,7 +191,9 @@ export class UploadQueue {
     let status: number;
     try {
       const bytes = await readFile(this.contentPath(entry.id));
-      status = await this.deps.put(entry.uploadUrl, bytes, entry.authHeader);
+      // Egen authHeader (från browsern) först; annars helperns färska OIDC-token.
+      const auth = entry.authHeader ?? (this.tokenProvider ? await this.tokenProvider() : undefined);
+      status = await this.deps.put(entry.uploadUrl, bytes, auth);
     } catch (err) {
       await this.markFailed(entry, msg(err));
       res.failed++;

--- a/helper-app/test/auth-orchestration.test.ts
+++ b/helper-app/test/auth-orchestration.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Auth-orchestrering (ADR 0028 §2 del 2): callback-parsing/-server, login-flödet,
+ * auth-header-providern och kö-token-injektionen. Allt IO injicerat → testbart
+ * utan browser/IdP/keychain.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import { buildAuthHeaderProvider } from "../src/auth/auth-provider.ts";
+import { parseCallback, waitForCallback } from "../src/auth/callback-server.ts";
+import { loginConfigFromEnv, runLogin, type LoginDeps } from "../src/auth/login.ts";
+import type { OidcEndpoints } from "../src/auth/oidc.ts";
+import { InMemoryTokenStore } from "../src/auth/token-store.ts";
+import { UploadQueue } from "../src/queue.ts";
+
+const EP: OidcEndpoints = {
+  issuer: "https://idp/realms/ava",
+  authorizationEndpoint: "https://idp/realms/ava/auth",
+  tokenEndpoint: "https://idp/realms/ava/token",
+};
+
+describe("parseCallback", () => {
+  test("giltig → code", () => {
+    expect(parseCallback("http://127.0.0.1:48765/callback?code=C&state=ST", "ST")).toEqual({ code: "C" });
+  });
+  test("fel state → state-mismatch", () => {
+    expect(parseCallback("/callback?code=C&state=BAD", "ST")).toEqual({ error: "state-mismatch" });
+  });
+  test("error-param vidarebefordras", () => {
+    expect(parseCallback("/callback?error=access_denied&state=ST", "ST")).toEqual({ error: "access_denied" });
+  });
+  test("fel path → not-callback", () => {
+    expect(parseCallback("/nope?code=C&state=ST", "ST")).toEqual({ error: "not-callback" });
+  });
+  test("saknad code → missing-code", () => {
+    expect(parseCallback("/callback?state=ST", "ST")).toEqual({ error: "missing-code" });
+  });
+});
+
+describe("waitForCallback (injicerad serve)", () => {
+  test("giltig callback → resolvar code + svarar 200 + stänger servern", async () => {
+    let handler!: (req: Request) => Response;
+    let stopped = false;
+    const serve = (_port: number, h: (req: Request) => Response) => { handler = h; return { stop: () => { stopped = true; } }; };
+    const p = waitForCallback(48765, "ST", { serve, timeoutMs: 1000 });
+    const res = handler(new Request("http://127.0.0.1:48765/callback?code=C&state=ST"));
+    expect(res.status).toBe(200);
+    expect(await p).toBe("C");
+    expect(stopped).toBe(true);
+  });
+
+  test("fel state → rejectar + svarar 400", async () => {
+    let handler!: (req: Request) => Response;
+    const serve = (_p: number, h: (req: Request) => Response) => { handler = h; return { stop: () => {} }; };
+    const p = waitForCallback(48765, "ST", { serve, timeoutMs: 1000 });
+    const res = handler(new Request("http://127.0.0.1:48765/callback?code=C&state=WRONG"));
+    expect(res.status).toBe(400);
+    await expect(p).rejects.toThrow(/state-mismatch/);
+  });
+
+  test("ingen callback → timeout rejectar", async () => {
+    const serve = () => ({ stop: () => {} });
+    await expect(waitForCallback(48765, "ST", { serve, timeoutMs: 10 })).rejects.toThrow(/timeout/);
+  });
+});
+
+describe("loginConfigFromEnv", () => {
+  test("null utan issuer", () => {
+    expect(loginConfigFromEnv({})).toBeNull();
+  });
+  test("defaultar clientId + redirect-port", () => {
+    expect(loginConfigFromEnv({ AVA_OIDC_ISSUER: EP.issuer })).toMatchObject({ issuer: EP.issuer, clientId: "ava-helper", redirectPort: 48765 });
+  });
+  test("respekterar overrides", () => {
+    const c = loginConfigFromEnv({ AVA_OIDC_ISSUER: EP.issuer, AVA_OIDC_CLIENT_ID: "custom", AVA_HELPER_REDIRECT_PORT: "9000" });
+    expect(c).toMatchObject({ clientId: "custom", redirectPort: 9000 });
+  });
+});
+
+describe("runLogin (injicerade deps)", () => {
+  test("discover→pkce→authorize→callback→exchange→store", async () => {
+    const store = new InMemoryTokenStore();
+    let openedUrl = "";
+    let exchangeArgs: { code: string; verifier: string; redirectUri: string } | undefined;
+    const deps: LoginDeps = {
+      discover: async () => EP,
+      makePkce: () => ({ verifier: "V", challenge: "CH", method: "S256" }),
+      makeState: () => "ST",
+      openUrl: async (u) => { openedUrl = u; },
+      awaitCallback: async () => "CODE",
+      exchange: async (_ep, p) => { exchangeArgs = { code: p.code, verifier: p.verifier, redirectUri: p.redirectUri }; return { accessToken: "AT", refreshToken: "RT", expiresAt: 1 }; },
+      store,
+    };
+    expect(await runLogin({ issuer: EP.issuer, clientId: "ava-helper", redirectPort: 48765 }, deps)).toBe(true);
+
+    const u = new URL(openedUrl);
+    expect(u.searchParams.get("code_challenge")).toBe("CH");
+    expect(u.searchParams.get("state")).toBe("ST");
+    expect(u.searchParams.get("redirect_uri")).toBe("http://127.0.0.1:48765/callback");
+    expect(exchangeArgs).toEqual({ code: "CODE", verifier: "V", redirectUri: "http://127.0.0.1:48765/callback" });
+    expect(await store.load()).toMatchObject({ accessToken: "AT" });
+  });
+});
+
+describe("buildAuthHeaderProvider", () => {
+  const NOW = 1_000_000;
+  function deps(discoverImpl: () => Promise<OidcEndpoints>, managerHeader: string | null) {
+    return {
+      now: () => NOW,
+      discover: discoverImpl,
+      makeManager: () => ({ authHeader: async () => managerHeader }),
+    };
+  }
+
+  test("ej parad → undefined", async () => {
+    const provider = buildAuthHeaderProvider({ issuer: EP.issuer, clientId: "ava-helper" }, new InMemoryTokenStore(), deps(async () => EP, null));
+    expect(await provider()).toBeUndefined();
+  });
+
+  test("giltig token → Bearer UTAN discovery (hot-path)", async () => {
+    const store = new InMemoryTokenStore();
+    await store.save({ accessToken: "AT", expiresAt: NOW + 3_600_000 });
+    let discovered = false;
+    const provider = buildAuthHeaderProvider({ issuer: EP.issuer, clientId: "ava-helper" }, store, deps(async () => { discovered = true; return EP; }, null));
+    expect(await provider()).toBe("Bearer AT");
+    expect(discovered).toBe(false);
+  });
+
+  test("snart utgången → discover + manager-refresh", async () => {
+    const store = new InMemoryTokenStore();
+    await store.save({ accessToken: "OLD", refreshToken: "RT", expiresAt: NOW + 1000 });
+    const provider = buildAuthHeaderProvider({ issuer: EP.issuer, clientId: "ava-helper" }, store, deps(async () => EP, "Bearer NEW"));
+    expect(await provider()).toBe("Bearer NEW");
+  });
+
+  test("discovery kastar → undefined (faller tillbaka)", async () => {
+    const store = new InMemoryTokenStore();
+    await store.save({ accessToken: "OLD", refreshToken: "RT", expiresAt: NOW });
+    const provider = buildAuthHeaderProvider({ issuer: EP.issuer, clientId: "ava-helper" }, store, deps(async () => { throw new Error("idp down"); }, "Bearer NEW"));
+    expect(await provider()).toBeUndefined();
+  });
+});
+
+describe("UploadQueue tokenProvider (autonom Bearer vid drain)", () => {
+  const dirs: string[] = [];
+  async function qdir(): Promise<string> { const d = await mkdtemp(join(tmpdir(), "ava-q-tok-")); dirs.push(d); return d; }
+  async function cleanup(): Promise<void> { await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true }))); }
+
+  test("post utan egen authHeader → använder färsk token vid upload", async () => {
+    const puts: Array<string | undefined> = [];
+    const deps = { now: () => 1000, newId: () => "id1", put: async (_u: string, _b: Uint8Array, auth?: string) => { puts.push(auth); return 200; } };
+    const q = new UploadQueue(await qdir(), deps, async () => "Bearer FRESH");
+    await q.enqueue({ uploadUrl: "http://s/u/1", fileName: "a", bytes: new TextEncoder().encode("x") });
+    await q.drainOnce();
+    expect(puts[0]).toBe("Bearer FRESH");
+    await cleanup();
+  });
+
+  test("post MED egen authHeader → den vinner över token-providern", async () => {
+    const puts: Array<string | undefined> = [];
+    const deps = { now: () => 1000, newId: () => "id2", put: async (_u: string, _b: Uint8Array, auth?: string) => { puts.push(auth); return 200; } };
+    const q = new UploadQueue(await qdir(), deps, async () => "Bearer FRESH");
+    await q.enqueue({ uploadUrl: "http://s/u/2", fileName: "a", bytes: new TextEncoder().encode("x"), authHeader: "Bearer BROWSER" });
+    await q.drainOnce();
+    expect(puts[0]).toBe("Bearer BROWSER");
+    await cleanup();
+  });
+});

--- a/tooling/docker/docker-compose.selfhosted-local.yml
+++ b/tooling/docker/docker-compose.selfhosted-local.yml
@@ -37,6 +37,13 @@ services:
       AVA_HTTP_HOST: 0.0.0.0
       AVA_HTTP_PORT: "3001"
       AVA_CONTENT_DIR: /data/content
+      # Bearer-JWT-väg för helpern/add-insen (ADR 0028 §1). Dual-URL (jfr
+      # oauth2-proxy nedan): issuer = PUBLIK hostname (matchar token-`iss` som
+      # browsern + helpern på host:en ser), JWKS = INTERN backchannel (server →
+      # keycloak:8080). Ingen audience-kontroll i fixturen (token bär aud=ava
+      # via mappern men vi sätter inte AVA_OIDC_AUDIENCE → signatur+iss+exp räcker).
+      AVA_OIDC_ISSUER: "${OIDC_KC_HOSTNAME:-http://localhost:8089}/realms/ava"
+      AVA_OIDC_JWKS_URI: "http://keycloak:8080/realms/ava/protocol/openid-connect/certs"
     volumes:
       # Bind-mount (#649): demo-seeden (host) skriver dokument-bytes hit och
       # servern (GitContentStore) läser dem från samma katalog → /documents +

--- a/tooling/docker/keycloak/realm-ava.json
+++ b/tooling/docker/keycloak/realm-ava.json
@@ -39,6 +39,41 @@
           }
         }
       ]
+    },
+    {
+      "clientId": "ava-helper",
+      "name": "AVA Helper (loopback-PKCE, ADR 0028)",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "redirectUris": [
+        "http://127.0.0.1:48765/callback",
+        "http://localhost:48765/callback"
+      ],
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "defaultClientScopes": [
+        "openid",
+        "email",
+        "profile",
+        "roles",
+        "offline_access"
+      ],
+      "protocolMappers": [
+        {
+          "name": "audience-ava",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "included.client.audience": "ava",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        }
+      ]
     }
   ],
   "users": [


### PR DESCRIPTION
## Vad

Sista biten av ADR 0028 (#655) — **steg 2 del 2**: orchestreringen som gör helpern självständigt auktoriserad. Ovanpå auth-kärnan (#677) + serverns JWKS-Bearer-väg (#675) kan helpern nu paras mot byråns IdP och autonomt bära sin egen Bearer mot AVA-servern. **Validera live mot den körande Keycloak-fixturen.**

## Hur

- **`--login`** (`auth/login.ts` `runLogin`): discover → PKCE → starta **loopback-callback-server** (`auth/callback-server.ts`, `127.0.0.1:48765/callback`) → öppna systembrowsern (`openUrlInBrowser`, återanvänder `openCommand`) → fånga koden (state-validerad) → `exchangeCode` → spara i keychain. Hela flödet är dep-injicerat → testat utan browser/IdP.
- **`auth/auth-provider.ts`** `buildAuthHeaderProvider`: färsk `Authorization: Bearer …` — **hot-path utan nät** för giltig token; OIDC-discovery (cachad) + refresh via `TokenManager` när den går ut. Wiras in i `/open`-nedladdning, `/content` och **upload-kön** (`UploadQueue` drar färsk token vid *varje* drain → en token fryses aldrig in i en post som väntat dagar offline). Browserns authHeader vinner när den finns; annars helperns egen.
- **Keycloak-fixtur** (`realm-ava.json`): publik `ava-helper`-klient (PKCE S256, loopback-redirect `:48765`, `offline_access` för refresh, aud=`ava`).
- **Server-first-stacken** (`docker-compose.selfhosted-local.yml`): `AVA_OIDC_ISSUER` (publik issuer, matchar token-`iss`) + `AVA_OIDC_JWKS_URI` (intern backchannel) → helperns token valideras (dual-URL, som oauth2-proxy).

## Validera (fixturen körande)

1. `bun run server-first:build && docker compose -f tooling/docker/docker-compose.selfhosted-local.yml up -d --build`
2. Bygg + starta helpern på host:en med `AVA_OIDC_ISSUER=http://localhost:8089/realms/ava` (clientId default `ava-helper`), kör `ava-helper --login` → browsern öppnas, godkänn → "helpern är parad".
3. Öppna ett self-hosted-dokument → helpern hämtar bytes med sin egen Bearer; spara offline → köas; återanslut → synkas.

## Test

`test/auth-orchestration.test.ts` (17 fall): `parseCallback` (alla utfall), `waitForCallback` (resolve/reject/timeout via injicerad serve), `loginConfigFromEnv`, `runLogin` (verifierar authorize-URL + exchange-args + keychain-save), `buildAuthHeaderProvider` (hot-path/ej-parad/refresh/discovery-fel), `UploadQueue` token-injektion. Helper-svit **248 grön**, coverage över golv; typecheck + lint + dep-cruiser + jscpd + cross-build rena.

Closes #678. Refs #655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)