### PR TITLE
feat(helper-ui): electron tray-skal — testbar logik-kärna (#680)

### DIFF
--- a/.github/workflows/helper-ui-ci.yml
+++ b/.github/workflows/helper-ui-ci.yml
@@ -1,0 +1,42 @@
+name: Helper UI CI
+
+# Typecheck + test för helper-ui (Electron-tray-skalet, ADR 0029) vid varje PR
+# som rör dess kod. Steg 1 = de Electron-fria logik-modulerna; paketering
+# (electron-builder) + main.ts kommer i ett senare steg.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "helper-ui/**"
+      - "src/lib/shared/helper/**"
+      - ".github/workflows/helper-ui-ci.yml"
+  pull_request:
+    paths:
+      - "helper-ui/**"
+      - "src/lib/shared/helper/**"
+      - ".github/workflows/helper-ui-ci.yml"
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: helper-ui
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test + coverage-grind
+        # bunfig.toml: coverage=true + coverageThreshold (ratchet).
+        run: bun test

--- a/helper-ui/.gitignore
+++ b/helper-ui/.gitignore
@@ -1,0 +1,7 @@
+# Dependencies (bun.lock committas; node_modules ignoreras)
+node_modules/
+
+# Build artefacts (Electron-paketering, ADR 0029 steg 2)
+dist/
+out/
+*.tsbuildinfo

--- a/helper-ui/bun.lock
+++ b/helper-ui/bun.lock
@@ -1,0 +1,19 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@ava/helper-ui",
+      "devDependencies": {
+        "bun-types": "^1.3.14",
+      },
+    },
+  },
+  "packages": {
+    "@types/node": ["@types/node@26.0.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+  }
+}

--- a/helper-ui/bunfig.toml
+++ b/helper-ui/bunfig.toml
@@ -1,0 +1,9 @@
+# Test-/coverage-konfig för helper-ui (jfr helper-app). Coverage-grind = ratchet.
+[test]
+coverage = true
+coverageReporter = ["text"]
+coverageSkipTestFiles = true
+# Mät bara helper-ui:s egen logik: hoppa över det delade protokollet (../src),
+# Electron-skalet (main.ts, typas i paketerings-steget) och test-fixturer.
+coveragePathIgnorePatterns = ["../src/**", "**/main.ts", "**/helpers.ts"]
+coverageThreshold = { line = 0.90, function = 0.85 }

--- a/helper-ui/package.json
+++ b/helper-ui/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@ava/helper-ui",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "AVA Helper UI — Electron tray-skal runt Bun-helper-motorn (ADR 0029).",
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "devDependencies": {
+    "bun-types": "^1.3.14"
+  }
+}

--- a/helper-ui/src/engine.ts
+++ b/helper-ui/src/engine.ts
@@ -1,0 +1,86 @@
+/**
+ * `EngineSupervisor` (ADR 0029) — startar och övervakar den medföljande Bun-
+ * helper-motorn som child-process. Startar om vid oväntad krasch (med en
+ * broms: ger upp efter för många omstarter i ett fönster), och dödar den rent
+ * vid `stop()`. Spawn/klocka/timer injiceras → testbart utan riktig process.
+ *
+ * Sökvägen till binären (Electron `resourcesPath`) löses i skalet (`main.ts`);
+ * den här klassen bryr sig bara om livscykeln.
+ */
+
+export interface SpawnedProcess {
+  kill(): void;
+  /** Registrera exit-callback (anropas en gång när processen dör). */
+  onExit(cb: () => void): void;
+}
+
+export interface EngineDeps {
+  spawn: (binPath: string, args: readonly string[]) => SpawnedProcess;
+  now: () => number;
+  /** Schemalägg en omstart; returnerar en avbryt-funktion. */
+  setTimer: (fn: () => void, ms: number) => () => void;
+}
+
+const RESTART_DELAY_MS = 1_000;
+const MAX_RESTARTS = 5;
+const WINDOW_MS = 60_000;
+
+export class EngineSupervisor {
+  private proc: SpawnedProcess | null = null;
+  private wantRunning = false;
+  private restartTimes: number[] = [];
+  private gaveUp = false;
+
+  constructor(
+    private readonly binPath: string,
+    private readonly args: readonly string[],
+    private readonly deps: EngineDeps,
+  ) {}
+
+  start(): void {
+    if (this.wantRunning) return;
+    this.wantRunning = true;
+    this.gaveUp = false;
+    this.spawnOnce();
+  }
+
+  stop(): void {
+    this.wantRunning = false;
+    this.proc?.kill();
+    this.proc = null;
+  }
+
+  isRunning(): boolean {
+    return this.proc !== null;
+  }
+
+  /** Gav upp omstarter (för många kraschar) — skalet kan visa ett fel. */
+  hasGivenUp(): boolean {
+    return this.gaveUp;
+  }
+
+  private spawnOnce(): void {
+    const proc = this.deps.spawn(this.binPath, this.args);
+    this.proc = proc;
+    proc.onExit(() => this.handleExit());
+  }
+
+  private handleExit(): void {
+    this.proc = null;
+    if (!this.wantRunning) return; // medvetet stoppad
+    if (this.tooManyRestarts()) {
+      this.gaveUp = true;
+      return;
+    }
+    this.restartTimes.push(this.deps.now());
+    this.deps.setTimer(() => {
+      if (this.wantRunning) this.spawnOnce();
+    }, RESTART_DELAY_MS);
+  }
+
+  private tooManyRestarts(): boolean {
+    const cutoff = this.deps.now() - WINDOW_MS;
+    this.restartTimes = this.restartTimes.filter((t) => t >= cutoff);
+    return this.restartTimes.length >= MAX_RESTARTS;
+  }
+}

--- a/helper-ui/src/status-poller.ts
+++ b/helper-ui/src/status-poller.ts
@@ -1,0 +1,44 @@
+/**
+ * Pollar helper-motorn (ADR 0029) — närvaro (`/ping`) + synk-status (`/status`).
+ * Electron-fri, injicerbar `fetch` → testbar. Skalet pollar localhost direkt
+ * (samma maskin, ingen Safari-mixed-content-fråga → bara HTTP-basen behövs).
+ */
+
+import { HELPER_BASE, parsePingVersion, type HelperStatusResponse } from "@/lib/shared/helper/protocol";
+
+export interface HelperSnapshot {
+  present: boolean;
+  version: string | null;
+  status: HelperStatusResponse | null;
+}
+
+const ABSENT: HelperSnapshot = { present: false, version: null, status: null };
+
+type FetchLike = (url: string) => Promise<Response>;
+
+/** En ögonblicksbild av motorn; `present:false` om den inte svarar. */
+export async function pollHelper(fetchFn: FetchLike = fetch, base: string = HELPER_BASE): Promise<HelperSnapshot> {
+  let version: string | null;
+  try {
+    const ping = await fetchFn(`${base}/ping`);
+    if (!ping.ok) return ABSENT;
+    version = parsePingVersion(await ping.text());
+  } catch {
+    return ABSENT;
+  }
+  return { present: true, version, status: await fetchStatus(fetchFn, base) };
+}
+
+async function fetchStatus(fetchFn: FetchLike, base: string): Promise<HelperStatusResponse | null> {
+  try {
+    const r = await fetchFn(`${base}/status`);
+    if (!r.ok) return null;
+    const d = (await r.json()) as Partial<HelperStatusResponse>;
+    if (typeof d.pending !== "number" || typeof d.conflict !== "number" || typeof d.total !== "number" || !Array.isArray(d.entries)) {
+      return null;
+    }
+    return { pending: d.pending, conflict: d.conflict, total: d.total, entries: d.entries };
+  } catch {
+    return null;
+  }
+}

--- a/helper-ui/src/tray-status.ts
+++ b/helper-ui/src/tray-status.ts
@@ -1,0 +1,28 @@
+/**
+ * Tray-presentation (ADR 0029) — ren mappning från helperns synk-status till
+ * vad menyrads-ikonen ska visa. Electron-fri → testbar utan display.
+ *
+ * Prioritet: ej ansluten → konflikt → väntande → allt synkat (samma ordning
+ * som web-appens HelperSection, ADR 0028 §8).
+ */
+
+import type { HelperStatusResponse } from "@/lib/shared/helper/protocol";
+
+export type TrayState = "absent" | "synced" | "pending" | "conflict";
+
+export interface TrayView {
+  state: TrayState;
+  /** Kort badge bredvid ikonen (tom = ingen). */
+  title: string;
+  /** Tooltip / menyrubrik. */
+  tooltip: string;
+}
+
+export function trayView(present: boolean, status: HelperStatusResponse | null): TrayView {
+  if (!present) return { state: "absent", title: "", tooltip: "AVA Helper — inte igång" };
+  if (status === null || status.total === 0) return { state: "synced", title: "", tooltip: "AVA Helper — allt synkat" };
+  if (status.conflict > 0) {
+    return { state: "conflict", title: `!${status.conflict}`, tooltip: `${status.conflict} dokument i konflikt — öppna och spara igen` };
+  }
+  return { state: "pending", title: String(status.pending), tooltip: `${status.pending} ändring(ar) väntar på synk` };
+}

--- a/helper-ui/test/helper-ui.test.ts
+++ b/helper-ui/test/helper-ui.test.ts
@@ -1,0 +1,134 @@
+/**
+ * helper-ui-logiken (ADR 0029) — tray-presentation, status-polling och
+ * engine-supervisor. Allt IO injicerat → testbart utan Electron/display/process.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { EngineSupervisor, type EngineDeps, type SpawnedProcess } from "../src/engine.ts";
+import { pollHelper } from "../src/status-poller.ts";
+import { trayView } from "../src/tray-status.ts";
+
+function status(pending: number, conflict: number) {
+  return { pending, conflict, total: pending + conflict, entries: [] };
+}
+
+describe("trayView", () => {
+  test("ej igång → absent", () => {
+    expect(trayView(false, null)).toMatchObject({ state: "absent", title: "" });
+  });
+  test("tom kö → synced", () => {
+    expect(trayView(true, status(0, 0))).toMatchObject({ state: "synced", title: "" });
+    expect(trayView(true, null)).toMatchObject({ state: "synced" });
+  });
+  test("väntande → pending med antal", () => {
+    expect(trayView(true, status(3, 0))).toMatchObject({ state: "pending", title: "3" });
+  });
+  test("konflikt prioriteras över väntande", () => {
+    const v = trayView(true, status(1, 2));
+    expect(v.state).toBe("conflict");
+    expect(v.title).toBe("!2");
+  });
+});
+
+describe("pollHelper", () => {
+  function res(body: string, status = 200, json?: unknown): Response {
+    return json !== undefined
+      ? new Response(JSON.stringify(json), { status, headers: { "Content-Type": "application/json" } })
+      : new Response(body, { status });
+  }
+
+  test("ping ok + status → present med version + status", async () => {
+    const fetchFn = async (url: string) =>
+      url.endsWith("/ping") ? res("ava-helper v1.2.3\n") : res("", 200, status(2, 0));
+    const snap = await pollHelper(fetchFn, "http://h");
+    expect(snap).toMatchObject({ present: true, version: "v1.2.3" });
+    expect(snap.status).toMatchObject({ pending: 2 });
+  });
+
+  test("ping fel → absent (ingen status-fråga behövs)", async () => {
+    const snap = await pollHelper(async () => res("down", 500), "http://h");
+    expect(snap).toEqual({ present: false, version: null, status: null });
+  });
+
+  test("ping kastar → absent", async () => {
+    const snap = await pollHelper(async () => { throw new Error("ECONNREFUSED"); }, "http://h");
+    expect(snap.present).toBe(false);
+  });
+
+  test("ping ok men status trasig → present men status null", async () => {
+    const fetchFn = async (url: string) => (url.endsWith("/ping") ? res("ava-helper v1\n") : res("garbage"));
+    const snap = await pollHelper(fetchFn, "http://h");
+    expect(snap).toMatchObject({ present: true, status: null });
+  });
+});
+
+describe("EngineSupervisor", () => {
+  interface FakeProc extends SpawnedProcess { fireExit: () => void; killed: boolean; }
+  function fakeDeps(): { deps: EngineDeps; spawns: FakeProc[]; runTimers: () => void; t: { now: number } } {
+    const spawns: FakeProc[] = [];
+    const timers: Array<() => void> = [];
+    const t = { now: 0 };
+    const deps: EngineDeps = {
+      spawn: () => {
+        let exitCb = (): void => {};
+        const p: FakeProc = { killed: false, kill() { this.killed = true; }, onExit(cb) { exitCb = cb; }, fireExit() { exitCb(); } };
+        spawns.push(p);
+        return p;
+      },
+      now: () => t.now,
+      setTimer: (fn) => { timers.push(fn); return () => {}; },
+    };
+    return { deps, spawns, runTimers: () => { const fns = timers.splice(0); fns.forEach((f) => f()); }, t };
+  }
+
+  test("start spawnar motorn", () => {
+    const h = fakeDeps();
+    const sup = new EngineSupervisor("/bin/engine", [], h.deps);
+    sup.start();
+    expect(h.spawns).toHaveLength(1);
+    expect(sup.isRunning()).toBe(true);
+  });
+
+  test("krasch → startar om (efter timern)", () => {
+    const h = fakeDeps();
+    const sup = new EngineSupervisor("/bin/engine", [], h.deps);
+    sup.start();
+    h.spawns[0]!.fireExit();
+    expect(sup.isRunning()).toBe(false); // dog
+    h.runTimers(); // omstart-timern
+    expect(h.spawns).toHaveLength(2);
+    expect(sup.isRunning()).toBe(true);
+  });
+
+  test("stop dödar processen och hindrar omstart", () => {
+    const h = fakeDeps();
+    const sup = new EngineSupervisor("/bin/engine", [], h.deps);
+    sup.start();
+    sup.stop();
+    expect(h.spawns[0]!.killed).toBe(true);
+    h.spawns[0]!.fireExit();
+    h.runTimers();
+    expect(h.spawns).toHaveLength(1); // ingen omstart efter stop
+  });
+
+  test("för många kraschar i fönstret → ger upp", () => {
+    const h = fakeDeps();
+    const sup = new EngineSupervisor("/bin/engine", [], h.deps);
+    sup.start();
+    for (let i = 0; i < 6; i++) {
+      h.spawns[h.spawns.length - 1]!.fireExit();
+      h.runTimers();
+    }
+    expect(sup.hasGivenUp()).toBe(true);
+    expect(sup.isRunning()).toBe(false);
+  });
+
+  test("dubbel start är idempotent", () => {
+    const h = fakeDeps();
+    const sup = new EngineSupervisor("/bin/engine", [], h.deps);
+    sup.start();
+    sup.start();
+    expect(h.spawns).toHaveLength(1);
+  });
+});

--- a/helper-ui/tsconfig.json
+++ b/helper-ui/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  // Ärver repots strikta regler (ADR 0005 §Språk). Som helper-app: Bun-globaler,
+  // egen paths-bas (delar protokoll-typer med webbappen + motorn), egen include.
+  // Electron-skalets `main.ts` typcheckas i paketerings-steget (ADR 0029 steg 2)
+  // när `electron` är installerat; steg 1 är de Electron-fria logik-modulerna.
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun-types"],
+    "paths": {
+      "@/*": ["../src/*"]
+    },
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["node_modules", "src/main.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -44,5 +44,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", "helper-app", "test", "office-addin"]
+  "exclude": ["node_modules", "helper-app", "helper-ui", "test", "office-addin"]
 }


### PR DESCRIPTION
## Vad

**Steg 1 av ADR 0029** — grunden för Electron-tray-appen som ger icke-tekniska användare en app med ikon i st.f. kommandoraden. Det här steget lägger den **fullt testbara, Electron-fria logik-kärnan** i ett nytt `helper-ui/`-paket (Bun/TS, som `helper-app/`).

## Moduler (alla unit-testade utan display/process)

- **`tray-status.ts`** — `trayView(present, status)` → `{ state, title, tooltip }`. Prioritet ej-igång → konflikt → väntande → synkat (samma som HelperSection, ADR 0028 §8).
- **`status-poller.ts`** — `pollHelper()` mot localhost (`/ping` närvaro+version, `/status` synk-läge); validerar svarsformen, `absent` vid fel.
- **`engine.ts`** — `EngineSupervisor`: spawnar + övervakar den medföljande Bun-motorn, **startar om vid krasch** (broms: ger upp efter 5 omstarter/min), dödar rent vid `stop()`. Spawn/klocka/timer injicerade.

## CI / scope

- Ny **`helper-ui-ci`** (typecheck + `bun test` + coverage-grind). Root-tsconfig exkluderar `helper-ui` (som `helper-app`) så main-typecheck inte drar in Bun-paketet.
- `helper-ui`-svit: **13 tester, 100% funktioner / 98% rader**. Root-typecheck + dep-cruiser rena.

## Återstår (steg 2, körs/valideras på måldatorn)

`main.ts` (Electron Tray/Menu som binder ihop modulerna ovan + löser binär-sökväg via `resourcesPath`) + `electron-builder`-paketering (`.app`/`.exe`, ikon, `extraResources`=motorn, signering bakom flagga). Det kräver `electron` (~100 MB) och en display — kan inte köras headless i CI/här, så det landar separat och verifieras live.

Refs #655 #680.

🤖 Generated with [Claude Code](https://claude.com/claude-code)