### PR TITLE
fix(helper): config-fil + synligt login-fel för GUI-start (#684)

### DIFF
--- a/helper-app/src/helper-config.ts
+++ b/helper-app/src/helper-config.ts
@@ -1,0 +1,76 @@
+/**
+ * Helper-config-fil (ADR 0029 §config-leverans) — en GUI-app startad från
+ * Finder/Start ärver INTE användarens shell-env, så `AVA_OIDC_ISSUER` m.fl. är
+ * osatta. Därför läser motorn även en config-fil i data-dir:en
+ * (`<dataDir>/helper-config.json`), och env vinner över filen (dev/CLI).
+ *
+ *   { "oidcIssuer": "https://idp.exempel/realms/ava", "oidcClientId": "ava-helper" }
+ *
+ * Ren parsning (injicerbar läsare) → testbar. Filen kan i framtiden skrivas av
+ * en Inställnings-vy i skalet eller bakas per byrå.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface HelperFileConfig {
+  oidcIssuer?: string;
+  oidcClientId?: string;
+  oidcAudience?: string;
+  oidcJwksUri?: string;
+  oidcScope?: string;
+  redirectPort?: number;
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === "string" && v.trim() !== "" ? v.trim() : undefined;
+}
+
+/** Tolka rå JSON → HelperFileConfig (tomt vid trasig JSON). */
+function parseConfig(raw: string): HelperFileConfig {
+  let o: Record<string, unknown>;
+  try {
+    o = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+  const cfg: HelperFileConfig = {};
+  const setStr = (key: "oidcIssuer" | "oidcClientId" | "oidcAudience" | "oidcJwksUri" | "oidcScope", v: unknown): void => {
+    const s = str(v);
+    if (s) cfg[key] = s;
+  };
+  setStr("oidcIssuer", o.oidcIssuer);
+  setStr("oidcClientId", o.oidcClientId);
+  setStr("oidcAudience", o.oidcAudience);
+  setStr("oidcJwksUri", o.oidcJwksUri);
+  setStr("oidcScope", o.oidcScope);
+  const port = Number(o.redirectPort);
+  if (Number.isInteger(port) && port > 0) cfg.redirectPort = port;
+  return cfg;
+}
+
+/** Läs `helper-config.json` ur data-dir:en; tomt objekt om den saknas/är trasig. */
+export function loadHelperConfig(dir: string | null, readText: (p: string) => string = (p) => readFileSync(p, "utf8")): HelperFileConfig {
+  if (!dir) return {};
+  try {
+    return parseConfig(readText(join(dir, "helper-config.json")));
+  } catch {
+    return {}; // ingen fil → tom config
+  }
+}
+
+/**
+ * Lägg fil-configen UNDER env (env vinner) på de `AVA_*`-nycklar motorn läser,
+ * så `loginConfigFromEnv` / auth fungerar oavsett hur appen startats.
+ */
+export function envWithConfig(env: Record<string, string | undefined>, file: HelperFileConfig): Record<string, string | undefined> {
+  return {
+    ...env,
+    AVA_OIDC_ISSUER: env.AVA_OIDC_ISSUER ?? file.oidcIssuer,
+    AVA_OIDC_CLIENT_ID: env.AVA_OIDC_CLIENT_ID ?? file.oidcClientId,
+    AVA_OIDC_AUDIENCE: env.AVA_OIDC_AUDIENCE ?? file.oidcAudience,
+    AVA_OIDC_JWKS_URI: env.AVA_OIDC_JWKS_URI ?? file.oidcJwksUri,
+    AVA_OIDC_SCOPE: env.AVA_OIDC_SCOPE ?? file.oidcScope,
+    AVA_HELPER_REDIRECT_PORT: env.AVA_HELPER_REDIRECT_PORT ?? file.redirectPort?.toString(),
+  };
+}

--- a/helper-app/src/main.ts
+++ b/helper-app/src/main.ts
@@ -25,6 +25,7 @@ import { buildAuthHeaderProvider } from "./auth/auth-provider.ts";
 import { loginConfigFromEnv, runLogin } from "./auth/login.ts";
 import { ContentStore, resolveCacheTtlMs } from "./content-store.ts";
 import { fetchAndCacheContent, handleContent } from "./content.ts";
+import { envWithConfig, loadHelperConfig } from "./helper-config.ts";
 import { installService, uninstallService, type InstallDeps } from "./install.ts";
 import { initLog, log } from "./log.ts";
 import {
@@ -197,10 +198,19 @@ function startStores(signal: AbortSignal, authHeader?: AuthHeaderProvider): Stor
 }
 
 /** `--login`: para helpern mot byråns IdP via loopback-PKCE (ADR 0028 §2). */
+/** Env överlagrad med config-filen (data-dir) — så config funkar för en
+ *  GUI-app som inte ärver shell-env (ADR 0029). */
+function helperEnv(): Record<string, string | undefined> {
+  return envWithConfig(process.env, loadHelperConfig(dataDir()));
+}
+
 async function handleLogin(): Promise<void> {
-  const cfg = loginConfigFromEnv();
+  const cfg = loginConfigFromEnv(helperEnv());
   if (!cfg) {
-    process.stderr.write("AVA_OIDC_ISSUER krävs för --login\n");
+    process.stderr.write(
+      "Ingen server konfigurerad. Sätt AVA_OIDC_ISSUER, eller skapa helper-config.json " +
+        "(t.ex. {\"oidcIssuer\":\"http://localhost:8089/realms/ava\"}) i AVA:s data-katalog.\n",
+    );
     process.exitCode = 1;
     return;
   }
@@ -236,7 +246,7 @@ function main(): void {
   void runUpdateLoop(updateCfg, abort.signal);
 
   // Helperns egen OIDC-auth (om parad/konfigurerad) → autonom Bearer mot servern.
-  const loginCfg = loginConfigFromEnv();
+  const loginCfg = loginConfigFromEnv(helperEnv());
   const authHeader: AuthHeaderProvider | undefined = loginCfg ? buildAuthHeaderProvider(loginCfg) : undefined;
 
   const stores = startStores(abort.signal, authHeader);

--- a/helper-app/test/helper-config.test.ts
+++ b/helper-app/test/helper-config.test.ts
@@ -1,0 +1,57 @@
+/**
+ * helper-config (ADR 0029) — config-fil för GUI-appar som inte ärver shell-env.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { envWithConfig, loadHelperConfig } from "../src/helper-config.ts";
+
+function reader(map: Record<string, string>): (p: string) => string {
+  return (p) => {
+    const hit = Object.entries(map).find(([k]) => p.endsWith(k));
+    if (!hit) throw new Error("ENOENT");
+    return hit[1];
+  };
+}
+
+describe("loadHelperConfig", () => {
+  test("läser giltiga fält", () => {
+    const cfg = loadHelperConfig("/dir", reader({ "helper-config.json": JSON.stringify({ oidcIssuer: "https://idp/realms/ava", oidcClientId: "ava-helper", redirectPort: 48765 }) }));
+    expect(cfg).toEqual({ oidcIssuer: "https://idp/realms/ava", oidcClientId: "ava-helper", redirectPort: 48765 });
+  });
+
+  test("dir = null → tomt", () => {
+    expect(loadHelperConfig(null)).toEqual({});
+  });
+
+  test("saknad fil → tomt", () => {
+    expect(loadHelperConfig("/dir", () => { throw new Error("ENOENT"); })).toEqual({});
+  });
+
+  test("trasig JSON → tomt", () => {
+    expect(loadHelperConfig("/dir", reader({ "helper-config.json": "{ trasig" }))).toEqual({});
+  });
+
+  test("ignorerar tomma/fel-typade fält", () => {
+    const cfg = loadHelperConfig("/dir", reader({ "helper-config.json": JSON.stringify({ oidcIssuer: "  ", redirectPort: "nope", oidcClientId: "ava-helper" }) }));
+    expect(cfg).toEqual({ oidcClientId: "ava-helper" });
+  });
+});
+
+describe("envWithConfig", () => {
+  test("env vinner över filen", () => {
+    const merged = envWithConfig({ AVA_OIDC_ISSUER: "https://env" }, { oidcIssuer: "https://file", oidcClientId: "ava-helper" });
+    expect(merged.AVA_OIDC_ISSUER).toBe("https://env");
+    expect(merged.AVA_OIDC_CLIENT_ID).toBe("ava-helper"); // fyller där env saknas
+  });
+
+  test("filen fyller när env saknas (GUI-app utan shell-env)", () => {
+    const merged = envWithConfig({}, { oidcIssuer: "https://file", redirectPort: 9000 });
+    expect(merged.AVA_OIDC_ISSUER).toBe("https://file");
+    expect(merged.AVA_HELPER_REDIRECT_PORT).toBe("9000");
+  });
+
+  test("varken env eller fil → undefined (login no-op:ar synligt)", () => {
+    expect(envWithConfig({}, {}).AVA_OIDC_ISSUER).toBeUndefined();
+  });
+});

--- a/helper-ui/README.md
+++ b/helper-ui/README.md
@@ -46,7 +46,22 @@ Slå på signering i release-bygget när cert finns (electron-builder `mac.ident
 
 ## Konfiguration
 
-Skalet skickar miljön vidare till motorn. Sätt åtminstone `AVA_OIDC_ISSUER`
-(byråns IdP — Keycloak-fixturen: `http://localhost:8089/realms/ava`) så *Logga in*
-fungerar. Hur configen levereras till icke-tekniska användare (bakad/inställnings-
-vy/hämtad) är en öppen fråga i ADR 0029.
+En app startad **från Finder/Applications ärver inte ditt shell-env**, så
+`AVA_OIDC_ISSUER` är inte satt där. Motorn läser därför även en **config-fil**:
+
+```
+~/Library/Application Support/AVA/helper-config.json
+```
+```json
+{ "oidcIssuer": "http://localhost:8089/realms/ava" }
+```
+
+(env vinner över filen — så `bun run dev` med `AVA_OIDC_ISSUER` satt fungerar
+också). Fält: `oidcIssuer` (krävs för *Logga in*), valfria `oidcClientId`
+(default `ava-helper`), `oidcAudience`, `oidcJwksUri`, `oidcScope`, `redirectPort`
+(default 48765). Utan issuer visar *Logga in* numera ett **felmeddelande** i
+stället för att misslyckas tyst.
+
+Hur configen levereras till icke-tekniska användare i skala (bakad per byrå /
+Inställnings-vy som skriver filen / hämtad från web-appen) är fortsatt en öppen
+fråga i ADR 0029.

--- a/helper-ui/src/main.ts
+++ b/helper-ui/src/main.ts
@@ -13,7 +13,7 @@
 import { spawn } from "node:child_process";
 import { join } from "node:path";
 
-import { app, Menu, Tray, nativeImage } from "electron";
+import { app, dialog, Menu, Tray, nativeImage } from "electron";
 
 import { HELPER_BASE } from "@/lib/shared/helper/protocol";
 import { EngineSupervisor, type SpawnedProcess } from "./engine.ts";
@@ -39,9 +39,22 @@ function spawnEngine(binPath: string, args: readonly string[]): SpawnedProcess {
   };
 }
 
-/** Starta inloggnings-flödet (loopback-PKCE) som en transient motor-invokation. */
+/**
+ * Starta inloggnings-flödet (loopback-PKCE) som en transient motor-invokation.
+ * Fångar stderr och YTLÄGGER fel i en dialog — login får aldrig misslyckas
+ * tyst (motsatsen till KATS-HIIT). Motorn läser config ur env ELLER
+ * helper-config.json, så en Finder-startad app (utan shell-env) fungerar.
+ */
 function startLogin(binPath: string): void {
-  spawn(binPath, ["--login"], { stdio: "ignore", detached: true, env: process.env }).unref();
+  const child = spawn(binPath, ["--login"], { stdio: ["ignore", "ignore", "pipe"], env: process.env });
+  let stderr = "";
+  child.stderr?.on("data", (d: Buffer) => { stderr += d.toString(); });
+  child.on("error", (e) => dialog.showErrorBox("AVA Helper — inloggning", `Kunde inte starta inloggningen: ${e.message}`));
+  child.on("exit", (code) => {
+    if (code !== null && code !== 0) {
+      dialog.showErrorBox("AVA Helper — inloggning", stderr.trim() || `Inloggningen avslutades (kod ${code}).`);
+    }
+  });
 }
 
 async function triggerUpdateCheck(): Promise<void> {


### PR DESCRIPTION
## Buggen (du hittade den live)

Installerade `.app` startad från Finder/Applications **ärver inte ditt shell-env** → `AVA_OIDC_ISSUER` är osatt → motorns `--login` skrev "AVA_OIDC_ISSUER krävs" och avslutade med kod 1, men tray-skalet spawnade den med `stdio: "ignore"` → **"Logga in" gjorde ingenting, inget fel**. (Bekräftat: binären körs fint, ingen quarantine, Keycloak-fixturen nåbar — det var enbart config + osynligt fel.)

## Fixar

1. **Config-fil** (`helper-app/src/helper-config.ts`): motorn läser `<dataDir>/helper-config.json` som **fallback till env** (env vinner). Funkar för Finder-startade appar. Fält: `oidcIssuer` (krävs), `oidcClientId`/`oidcAudience`/`oidcJwksUri`/`oidcScope`/`redirectPort` (valfria). Wiras in i både `--login` och auth-providern via `envWithConfig`.
2. **Synligt fel** (`helper-ui/src/main.ts`): "Logga in" fångar `--login`-stderr och visar `dialog.showErrorBox` i st.f. tyst no-op (motsatsen till KATS-HIIT). Felmeddelandet pekar på `helper-config.json`.

## Så här validerar du efter detta

Skapa `~/Library/Application Support/AVA/helper-config.json`:
```json
{ "oidcIssuer": "http://localhost:8089/realms/ava" }
```
Bygg om (`cd helper-ui && bun run dist`), installera, *Logga in* → browsern öppnas mot Keycloak. Saknas filen → en tydlig dialog i st.f. tystnad.

## Test

`helper-config.test.ts` (8 fall): läsning (giltig/saknad/trasig/fel-typad), `envWithConfig` (env vinner / fil fyller / tomt). helper-app-svit **256 grön**, coverage över golv; helper-ui typecheck+test+bunt; cross-build + alla gates rena.

Closes #684. Refs #655 #680.

🤖 Generated with [Claude Code](https://claude.com/claude-code)