### PR TITLE
feat(helper): web-appen auto-konfigurerar helpern (zero-touch) (#686)

### DIFF
--- a/helper-app/src/config-endpoint.ts
+++ b/helper-app/src/config-endpoint.ts
@@ -1,0 +1,26 @@
+/**
+ * `POST /config` (ADR 0029) — web-appen auto-konfigurerar helpern: den postar
+ * serverns OIDC-config hit och helpern skriver sin `helper-config.json`, så
+ * icke-tekniska användare slipper skapa config-filer för hand. Endast localhost
+ * + AVA-origins (CORS i server.ts). IO injicerat → testbart.
+ */
+
+import type { HelperConfigRequest } from "@/lib/shared/helper/protocol";
+import { json, parseJsonBody, textError } from "./http.ts";
+import { log } from "./log.ts";
+
+export interface ConfigDeps {
+  /** Spara configen; returnerar något sanningsenligt vid framgång, null annars. */
+  save: (input: HelperConfigRequest) => object | null;
+}
+
+export async function handleConfig(req: Request, deps: ConfigDeps): Promise<Response> {
+  if (req.method !== "POST") return textError(405, "method not allowed");
+  const body = await parseJsonBody<HelperConfigRequest>(req);
+  if (!body || typeof body.oidcIssuer !== "string" || body.oidcIssuer.trim() === "") {
+    return textError(400, "oidcIssuer required");
+  }
+  if (!deps.save(body)) return textError(500, "could not persist config");
+  log(`config: konfigurerad av web-appen (issuer ${body.oidcIssuer})`);
+  return json({ status: "configured", oidcIssuer: body.oidcIssuer });
+}

--- a/helper-app/src/helper-config.ts
+++ b/helper-app/src/helper-config.ts
@@ -10,7 +10,7 @@
  * en Inställnings-vy i skalet eller bakas per byrå.
  */
 
-import { readFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 export interface HelperFileConfig {
@@ -57,6 +57,39 @@ export function loadHelperConfig(dir: string | null, readText: (p: string) => st
   } catch {
     return {}; // ingen fil → tom config
   }
+}
+
+export interface SaveDeps {
+  mkdirp: (dir: string) => void;
+  writeText: (path: string, text: string) => void;
+}
+
+const defaultSaveDeps: SaveDeps = {
+  mkdirp: (dir) => mkdirSync(dir, { recursive: true }),
+  writeText: (path, text) => writeFileSync(path, text, "utf8"),
+};
+
+/**
+ * Skriv `helper-config.json` (ADR 0029) — web-appen postar serverns config hit
+ * (`POST /config`) så användaren slipper skapa filen för hand. Returnerar den
+ * sparade configen, eller null om `oidcIssuer` saknas / data-dir är otillgänglig.
+ */
+export function saveHelperConfig(dir: string | null, input: Partial<HelperFileConfig>, deps: SaveDeps = defaultSaveDeps): HelperFileConfig | null {
+  if (!dir) return null;
+  const issuer = str(input.oidcIssuer);
+  if (!issuer) return null; // issuer är minsta nödvändiga
+  const clientId = str(input.oidcClientId);
+  const audience = str(input.oidcAudience);
+  const jwksUri = str(input.oidcJwksUri);
+  const cfg: HelperFileConfig = {
+    oidcIssuer: issuer,
+    ...(clientId ? { oidcClientId: clientId } : {}),
+    ...(audience ? { oidcAudience: audience } : {}),
+    ...(jwksUri ? { oidcJwksUri: jwksUri } : {}),
+  };
+  deps.mkdirp(dir);
+  deps.writeText(join(dir, "helper-config.json"), JSON.stringify(cfg, null, 2));
+  return cfg;
 }
 
 /**

--- a/helper-app/src/main.ts
+++ b/helper-app/src/main.ts
@@ -23,9 +23,10 @@ import { HELPER_HTTPS_PORT, HELPER_PORT } from "@/lib/shared/helper/protocol";
 
 import { buildAuthHeaderProvider } from "./auth/auth-provider.ts";
 import { loginConfigFromEnv, runLogin } from "./auth/login.ts";
+import { handleConfig } from "./config-endpoint.ts";
 import { ContentStore, resolveCacheTtlMs } from "./content-store.ts";
 import { fetchAndCacheContent, handleContent } from "./content.ts";
-import { envWithConfig, loadHelperConfig } from "./helper-config.ts";
+import { envWithConfig, loadHelperConfig, saveHelperConfig } from "./helper-config.ts";
 import { installService, uninstallService, type InstallDeps } from "./install.ts";
 import { initLog, log } from "./log.ts";
 import {
@@ -254,6 +255,8 @@ function main(): void {
     version: VERSION,
     extraOrigins: extraOrigins(),
     onCheckUpdate: () => { void checkOnce(updateCfg).catch((err) => log(`check-update: ${String(err)}`)); },
+    // Auto-konfigurering från web-appen (ADR 0029) — alltid på (skriver helper-config.json).
+    onConfig: (req: Request) => handleConfig(req, { save: (input) => saveHelperConfig(dataDir(), input) }),
     ...(stores
       ? {
           onOpen: queueBackedOnOpen(stores.queue, stores.content, authHeader),

--- a/helper-app/src/server.ts
+++ b/helper-app/src/server.ts
@@ -9,6 +9,7 @@
  *   POST /check-update  → trigga omedelbar self-update-kontroll
  *   GET  /status        → JSON ögonblicksbild av upload-kön (ADR 0028 §8)
  *   POST /content       → dokument-bytes ur durabla cachen (ADR 0028 §3/§5)
+ *   POST /config        → auto-konfigurering från web-appen (ADR 0029)
  *
  * Säkerhet: lyssnar bara på localhost; CORS-whitelist (localhost-portar
  * + *.github.io + custom via AVA_HELPER_ORIGINS); inga endpoints som
@@ -37,6 +38,8 @@ export interface ServerDeps {
   onStatus?: () => HelperStatusResponse;
   /** Leverera dokument-bytes (POST /content). undefined → 503 (ej konfigurerad). */
   onContent?: (req: Request) => Promise<Response>;
+  /** Auto-konfigurering från web-appen (POST /config). undefined → 503. */
+  onConfig?: (req: Request) => Promise<Response>;
 }
 
 const EMPTY_STATUS: HelperStatusResponse = { pending: 0, conflict: 0, total: 0, entries: [] };
@@ -69,6 +72,7 @@ const ROUTES: Record<string, (req: Request, deps: ServerDeps) => Response | Prom
   "/check-update": (_req, deps) => handleCheckUpdate(deps),
   "/status": (_req, deps) => json(deps.onStatus?.() ?? EMPTY_STATUS),
   "/content": (req, deps) => deps.onContent?.(req) ?? textError(503, "content store not configured"),
+  "/config": (req, deps) => deps.onConfig?.(req) ?? textError(503, "config endpoint not configured"),
 };
 
 async function route(req: Request, deps: ServerDeps): Promise<Response> {

--- a/helper-app/test/config-endpoint.test.ts
+++ b/helper-app/test/config-endpoint.test.ts
@@ -1,0 +1,36 @@
+/**
+ * POST /config (ADR 0029) — web-appens auto-konfigurering av helpern.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { handleConfig, type ConfigDeps } from "../src/config-endpoint.ts";
+import { jsonRequest } from "./helpers.ts";
+
+const saving: ConfigDeps = { save: (i) => ({ oidcIssuer: i.oidcIssuer }) };
+
+describe("handleConfig", () => {
+  test("kräver POST", async () => {
+    expect((await handleConfig(new Request("http://h/config"), saving)).status).toBe(405);
+  });
+
+  test("kräver oidcIssuer", async () => {
+    expect((await handleConfig(jsonRequest("/config", { oidcClientId: "x" }), saving)).status).toBe(400);
+    expect((await handleConfig(jsonRequest("/config", { oidcIssuer: "   " }), saving)).status).toBe(400);
+  });
+
+  test("sparar + svarar configured", async () => {
+    let savedInput: unknown;
+    const res = await handleConfig(jsonRequest("/config", { oidcIssuer: "https://idp/realms/ava", oidcClientId: "ava-helper" }), {
+      save: (i) => { savedInput = i; return { oidcIssuer: i.oidcIssuer }; },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ status: "configured", oidcIssuer: "https://idp/realms/ava" });
+    expect(savedInput).toMatchObject({ oidcClientId: "ava-helper" });
+  });
+
+  test("500 när save misslyckas (null)", async () => {
+    const res = await handleConfig(jsonRequest("/config", { oidcIssuer: "https://idp" }), { save: () => null });
+    expect(res.status).toBe(500);
+  });
+});

--- a/helper-app/test/helper-config.test.ts
+++ b/helper-app/test/helper-config.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { envWithConfig, loadHelperConfig } from "../src/helper-config.ts";
+import { envWithConfig, loadHelperConfig, saveHelperConfig, type SaveDeps } from "../src/helper-config.ts";
 
 function reader(map: Record<string, string>): (p: string) => string {
   return (p) => {
@@ -35,6 +35,37 @@ describe("loadHelperConfig", () => {
   test("ignorerar tomma/fel-typade fält", () => {
     const cfg = loadHelperConfig("/dir", reader({ "helper-config.json": JSON.stringify({ oidcIssuer: "  ", redirectPort: "nope", oidcClientId: "ava-helper" }) }));
     expect(cfg).toEqual({ oidcClientId: "ava-helper" });
+  });
+});
+
+describe("saveHelperConfig", () => {
+  function spyDeps(): { deps: SaveDeps; written: { path?: string; text?: string } } {
+    const written: { path?: string; text?: string } = {};
+    return { deps: { mkdirp: () => {}, writeText: (p, t) => { written.path = p; written.text = t; } }, written };
+  }
+
+  test("skriver helper-config.json med issuer + valfria fält", () => {
+    const { deps, written } = spyDeps();
+    const saved = saveHelperConfig("/data", { oidcIssuer: "https://idp/realms/ava", oidcClientId: "ava-helper" }, deps);
+    expect(saved).toMatchObject({ oidcIssuer: "https://idp/realms/ava", oidcClientId: "ava-helper" });
+    expect(written.path).toMatch(/helper-config\.json$/);
+    expect(JSON.parse(written.text!)).toMatchObject({ oidcIssuer: "https://idp/realms/ava" });
+  });
+
+  test("null + ingen skrivning utan issuer", () => {
+    const { deps, written } = spyDeps();
+    expect(saveHelperConfig("/data", { oidcClientId: "x" }, deps)).toBeNull();
+    expect(written.path).toBeUndefined();
+  });
+
+  test("null när data-dir saknas", () => {
+    expect(saveHelperConfig(null, { oidcIssuer: "https://idp" }, spyDeps().deps)).toBeNull();
+  });
+
+  test("round-trip: sparad config kan läsas tillbaka", () => {
+    let stored = "";
+    saveHelperConfig("/data", { oidcIssuer: "https://idp/realms/ava" }, { mkdirp: () => {}, writeText: (_p, t) => { stored = t; } });
+    expect(loadHelperConfig("/data", () => stored)).toEqual({ oidcIssuer: "https://idp/realms/ava" });
   });
 });
 

--- a/helper-app/test/server.test.ts
+++ b/helper-app/test/server.test.ts
@@ -126,6 +126,19 @@ describe("POST /content", () => {
   });
 });
 
+describe("POST /config", () => {
+  test("503 när onConfig ej konfigurerad", async () => {
+    const res = await handler()(req("/config", { method: "POST" }));
+    expect(res.status).toBe(503);
+  });
+
+  test("delegerar till onConfig", async () => {
+    const h = handler({ onConfig: async () => new Response("ok", { status: 200 }) });
+    const res = await h(req("/config", { method: "POST" }));
+    expect(res.status).toBe(200);
+  });
+});
+
 describe("okänd route", () => {
   test("404", async () => {
     const res = await handler()(req("/nope"));

--- a/src/components/shell/demo-bootstrap.tsx
+++ b/src/components/shell/demo-bootstrap.tsx
@@ -22,6 +22,7 @@ import superjson from "superjson";
 import { AnalyzeDispatcherRegistrar } from "@/components/documents/analyze-dispatcher-registrar";
 import { ExtractTextDispatcherRegistrar } from "@/components/documents/extract-text-dispatcher-registrar";
 import { MirrorOutlookRegistrar } from "@/components/matter/mirror-outlook-registrar";
+import { HelperAutoConfig } from "@/components/shell/helper-auto-config";
 import { RenderErrorBoundary } from "@/components/ui/render-error-boundary";
 import { AuthProvider, useAuthMode } from "@/lib/client/auth/use-auth-mode";
 import { createDemoStore } from "@/lib/client/backend/create-demo-store";
@@ -304,6 +305,7 @@ function AuthGatedDemoTree(props: TreeProps) {
           <AnalyzeDispatcherRegistrar />
           <ExtractTextDispatcherRegistrar />
           <MirrorOutlookRegistrar />
+          <HelperAutoConfig />
           <div className="flex items-center justify-between gap-2 border-b border-gray-200 bg-white">
             <div className="flex-1 min-w-0">
               <AuthStatusBanner />

--- a/src/components/shell/helper-auto-config.tsx
+++ b/src/components/shell/helper-auto-config.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+/**
+ * `HelperAutoConfig` (ADR 0029) — när den lokala helpern finns OCH servern har
+ * en OIDC-config (server-first, `system.helperConfig` ≠ null), pushar web-appen
+ * configen till helpern över localhost (`POST /config`) EN gång. Då slipper
+ * icke-tekniska användare skapa config-filer för hand — de bara använder AVA i
+ * webbläsaren som vanligt och helpern blir konfigurerad.
+ *
+ * Renderar inget. Monteras app-brett (i DemoBootstrap, inuti CapabilitiesProvider).
+ */
+
+import { useEffect, useRef } from "react";
+import { configureHelper, useHelper } from "@/lib/client/helper/use-helper";
+import { trpc } from "@/lib/client/trpc";
+
+export function HelperAutoConfig(): null {
+  const helper = useHelper();
+  const present = helper.version != null;
+  const cfg = trpc.system.helperConfig.useQuery(undefined, { enabled: present, staleTime: Number.POSITIVE_INFINITY });
+  const pushed = useRef(false);
+
+  useEffect(() => {
+    if (pushed.current || !present || !cfg.data) return; // null = servern saknar helper-auth (demo)
+    pushed.current = true;
+    void configureHelper(cfg.data);
+  }, [present, cfg.data]);
+
+  return null;
+}

--- a/src/lib/client/helper/use-helper.ts
+++ b/src/lib/client/helper/use-helper.ts
@@ -23,6 +23,7 @@ import {
   HELPER_HTTPS_BASE,
   parsePingVersion,
   type ComposeMailRequest,
+  type HelperConfigRequest,
   type HelperContentRequest,
   type HelperOpenRequest,
   type HelperStatus,
@@ -203,6 +204,25 @@ export async function fetchContentViaHelper(req: HelperContentRequest): Promise<
     return new Uint8Array(await r.arrayBuffer());
   } catch {
     return null;
+  }
+}
+
+/**
+ * Auto-konfigurera helpern (`POST /config`, ADR 0029) — web-appen pushar
+ * serverns OIDC-config så användaren slipper skapa config-filer för hand.
+ * Returnerar true om helpern tog emot configen, annars false (helper saknas/fel).
+ */
+export async function configureHelper(config: HelperConfigRequest): Promise<boolean> {
+  try {
+    const r = await helperFetch("/config", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(config),
+      signal: AbortSignal.timeout(3_000),
+    });
+    return r?.ok ?? false;
+  } catch {
+    return false;
   }
 }
 

--- a/src/lib/server/http/bearer-claims.ts
+++ b/src/lib/server/http/bearer-claims.ts
@@ -16,6 +16,7 @@
 
 import { createRemoteJWKSet, jwtVerify, type JWTPayload, type JWTVerifyGetKey } from "jose";
 import type { OidcClaims } from "@/lib/server/auth/oidc-auth-provider";
+import type { HelperConfigRequest } from "@/lib/shared/helper/protocol";
 import { parseBearerToken } from "./pat";
 
 export interface BearerVerifyConfig {
@@ -75,6 +76,24 @@ export function remoteJwksForIssuer(issuer: string, jwksUri?: string): JWTVerify
  *   - `AVA_OIDC_JWKS_URI` (valfri) — explicit JWKS-URL (annars Keycloak-vägen).
  *   - `AVA_OIDC_AUDIENCE` (valfri) — förväntad `aud`.
  */
+/**
+ * Den OIDC-config web-appen ska auto-pusha till helpern (ADR 0029) — den
+ * PUBLIKA issuern (som helpern på host:en + browsern når) + klient-id, eller
+ * `null` om servern inte har någon helper-/Bearer-auth konfigurerad (demon).
+ * Ingen JWKS-URI: helpern gör sin egen discovery ur issuern (serverns interna
+ * backchannel-JWKS angår inte helpern).
+ */
+export function helperOidcConfig(env: Record<string, string | undefined> = process.env): HelperConfigRequest | null {
+  const issuer = env.AVA_OIDC_ISSUER?.trim();
+  if (!issuer) return null;
+  const audience = env.AVA_OIDC_AUDIENCE?.trim();
+  return {
+    oidcIssuer: issuer,
+    oidcClientId: env.AVA_OIDC_CLIENT_ID?.trim() || "ava-helper",
+    ...(audience ? { oidcAudience: audience } : {}),
+  };
+}
+
 export function bearerConfigFromEnv(env: Record<string, string | undefined> = process.env): BearerVerifyConfig | null {
   const issuer = env.AVA_OIDC_ISSUER?.trim();
   if (!issuer) return null;

--- a/src/lib/server/routers/system.ts
+++ b/src/lib/server/routers/system.ts
@@ -8,8 +8,15 @@
  */
 
 import { DEMO_CAPABILITIES } from "@/lib/shared/capabilities";
+import { helperOidcConfig } from "../http/bearer-claims";
 import { publicProcedure, router } from "../trpc-core";
 
 export const systemRouter = router({
   capabilities: publicProcedure.query(({ ctx }) => ctx.capabilities ?? DEMO_CAPABILITIES),
+  /**
+   * OIDC-config web-appen auto-pushar till den lokala helpern (ADR 0029) så
+   * användaren slipper konfigurera den för hand; `null` om servern saknar
+   * helper-auth (demon). `publicProcedure` — behövs innan helper-login.
+   */
+  helperConfig: publicProcedure.query(() => helperOidcConfig()),
 });

--- a/src/lib/shared/helper/protocol.ts
+++ b/src/lib/shared/helper/protocol.ts
@@ -81,6 +81,24 @@ export interface HelperVersionResponse {
 }
 
 /**
+ * `POST /config` (ADR 0029) — web-appen auto-konfigurerar helpern över localhost
+ * så icke-tekniska användare slipper skapa config-filer. Web-appen hämtar serverns
+ * OIDC-config (`system.helperConfig`) och postar den hit; helpern skriver sin
+ * `helper-config.json` → *Logga in* fungerar utan inmatning. Samma form returneras
+ * av serverns `system.helperConfig` (null = servern har ingen helper-auth).
+ */
+export interface HelperConfigRequest {
+  /** Byråns OIDC-issuer (helpern gör discovery + login mot den). */
+  oidcIssuer: string;
+  /** OIDC-klient (default `ava-helper`). */
+  oidcClientId?: string;
+  /** Förväntad audience (valfri). */
+  oidcAudience?: string;
+  /** Explicit JWKS-URL (valfri; annars härleds ur issuern). */
+  oidcJwksUri?: string;
+}
+
+/**
  * `POST /content` — be helpern leverera dokument-bytes ur sitt durabla,
  * content-adresserade lager (ADR 0028 §3/§5). Cache-hit servas direkt (även
  * offline); miss laddas ner + cachas. Web-appen delegerar dokument-läsningar

--- a/test/unit/lib/helper/use-helper.test.tsx
+++ b/test/unit/lib/helper/use-helper.test.tsx
@@ -12,6 +12,7 @@ import {
   resolveHelperBase,
   fetchHelperStatus,
   fetchContentViaHelper,
+  configureHelper,
 } from "@/lib/client/helper/use-helper";
 
 const HTTPS = "https://localhost:48762";
@@ -171,6 +172,35 @@ describe("fetchContentViaHelper", () => {
       [`${HTTPS}/content`, () => new Response("unavailable", { status: 502 })],
     ]);
     expect(await fetchContentViaHelper(REQ)).toBeNull();
+  });
+});
+
+describe("configureHelper (ADR 0029)", () => {
+  const CFG = { oidcIssuer: "https://idp/realms/ava", oidcClientId: "ava-helper" };
+
+  it("POST:ar configen till /config → true", async () => {
+    const fetchMock = routeFetch([
+      [`${HTTPS}/ping`, () => new Response("ava-helper v1\n", { status: 200 })],
+      [`${HTTPS}/config`, () => new Response(JSON.stringify({ status: "configured" }), { status: 200 })],
+    ]);
+    global.fetch = fetchMock;
+    expect(await configureHelper(CFG)).toBe(true);
+    const call = fetchMock.mock.calls.find(([u]: [string]) => String(u).endsWith("/config"))!;
+    expect(call[1].method).toBe("POST");
+    expect(JSON.parse(call[1].body)).toMatchObject({ oidcIssuer: CFG.oidcIssuer });
+  });
+
+  it("false när helpern saknas", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("down"));
+    expect(await configureHelper(CFG)).toBe(false);
+  });
+
+  it("false vid 4xx", async () => {
+    global.fetch = routeFetch([
+      [`${HTTPS}/ping`, () => new Response("ava-helper v1\n", { status: 200 })],
+      [`${HTTPS}/config`, () => new Response("bad", { status: 400 })],
+    ]);
+    expect(await configureHelper(CFG)).toBe(false);
   });
 });
 

--- a/test/unit/server/http/bearer-claims.test.ts
+++ b/test/unit/server/http/bearer-claims.test.ts
@@ -6,7 +6,7 @@
 
 import { SignJWT, exportJWK, generateKeyPair, createLocalJWKSet, type JWTVerifyGetKey } from "jose";
 import { describe, it, expect, beforeAll } from "vitest-compat";
-import { bearerClaims, bearerConfigFromEnv } from "@/lib/server/http/bearer-claims";
+import { bearerClaims, bearerConfigFromEnv, helperOidcConfig } from "@/lib/server/http/bearer-claims";
 
 const ISSUER = "https://idp.example/realms/ava";
 const AUDIENCE = "ava";
@@ -108,5 +108,19 @@ describe("bearerConfigFromEnv", () => {
   it("utan audience → ingen aud i config", () => {
     const c = bearerConfigFromEnv({ AVA_OIDC_ISSUER: ISSUER });
     expect(c?.audience).toBeUndefined();
+  });
+});
+
+describe("helperOidcConfig (ADR 0029)", () => {
+  it("null utan issuer (demo)", () => {
+    expect(helperOidcConfig({})).toBeNull();
+  });
+
+  it("issuer + default clientId ava-helper", () => {
+    expect(helperOidcConfig({ AVA_OIDC_ISSUER: ISSUER })).toEqual({ oidcIssuer: ISSUER, oidcClientId: "ava-helper" });
+  });
+
+  it("respekterar AVA_OIDC_CLIENT_ID + AVA_OIDC_AUDIENCE", () => {
+    expect(helperOidcConfig({ AVA_OIDC_ISSUER: ISSUER, AVA_OIDC_CLIENT_ID: "c", AVA_OIDC_AUDIENCE: "a" })).toEqual({ oidcIssuer: ISSUER, oidcClientId: "c", oidcAudience: "a" });
   });
 });


### PR DESCRIPTION
## Vad

Svaret på "mina användare kan inte skapa mappar/config" — **web-appen konfigurerar helpern automatiskt** (config-leverans-beslutet i ADR 0029). Användaren öppnar AVA i webbläsaren som vanligt → den lokala helpern blir konfigurerad → *Logga in* fungerar. **Noll filer, noll inmatning.**

## Hur (3 komponenter)

1. **Server:** `system.helperConfig` (publik query) exponerar serverns OIDC-config — `{ oidcIssuer, oidcClientId }` ur env (`helperOidcConfig`), eller **null** om servern saknar helper-auth (demon).
2. **Helper:** `POST /config` tar emot configen och skriver `helper-config.json` (`saveHelperConfig`). Localhost + AVA-origins (befintlig CORS).
3. **Web:** `<HelperAutoConfig/>` (monterad i `DemoBootstrap`, inuti `CapabilitiesProvider`) — när helpern finns **och** servern har config (≠ null), POST:ar den till helpern **en gång** (`configureHelper`).

Flöde: `öppna AVA i browsern → web-appen ser helpern → POST /config { oidcIssuer } → helpern skriver sin config → Logga in fungerar`.

## Test

Helper: `saveHelperConfig` (skriver/round-trip/null utan issuer/null utan dir), `POST /config`-handler (405/400/configured/500), server-route. Main: `helperOidcConfig` (null i demo / issuer+default-clientId / env-overrides), `configureHelper` (POST → true / saknas → false / 4xx → false). Helper-svit **266 grön**; full enhetssvit grön (exit 0, coverage-golv); typecheck + lint + knip rena.

## Validera (efter merge + pull + ombygge)

1. Starta server-first-stacken (Keycloak-fixturen) — den har redan `AVA_OIDC_ISSUER`.
2. Installera/kör helper-appen (ingen config-fil behövs).
3. Öppna AVA i webbläsaren → helpern auto-konfigureras → klicka *Logga in* i menyraden → browsern öppnas mot Keycloak.

Closes #686. Refs #655 #680.

🤖 Generated with [Claude Code](https://claude.com/claude-code)