### PR TITLE
refactor(helper): porta motorn Bun→Node (steg 1 av ADR 0030) (#688)

### DIFF
--- a/helper-app/src/auth/callback-server.ts
+++ b/helper-app/src/auth/callback-server.ts
@@ -8,6 +8,7 @@
  * "stäng fliken"-sida; timeout om inget kommer.
  */
 
+import { serveFetchHandler } from "@/lib/shared/http/node-http-adapter";
 import { log } from "../log.ts";
 
 export type CallbackResult = { code: string } | { error: string };
@@ -41,8 +42,8 @@ export interface WaitForCallbackDeps {
 }
 
 const defaultServe: WaitForCallbackDeps["serve"] = (port, handler) => {
-  const server = Bun.serve({ port, hostname: "127.0.0.1", fetch: handler });
-  return { stop: () => void server.stop(true) };
+  const server = serveFetchHandler(async (req) => handler(req), { port, hostname: "127.0.0.1" });
+  return { stop: () => server.close() };
 };
 
 /**

--- a/helper-app/src/content-store.ts
+++ b/helper-app/src/content-store.ts
@@ -14,7 +14,7 @@
  */
 
 import { createHash } from "node:crypto";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { log } from "./log.ts";
@@ -59,6 +59,16 @@ export function resolveCacheTtlMs(envValue: string | undefined, defaultDays = DE
 /** SHA-256 (hex) av bytes. Content-adress-nyckeln. */
 export function sha256Hex(bytes: Uint8Array): string {
   return createHash("sha256").update(bytes).digest("hex");
+}
+
+/** Finns filen? (node:fs har ingen ren exists → access + fångst.) */
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -107,7 +117,7 @@ export class ContentStore {
     const index = await this.ensureIndex();
     const hash = sha256Hex(bytes);
     const path = this.blobPath(hash);
-    if (!(await Bun.file(path).exists())) {
+    if (!(await fileExists(path))) {
       await mkdir(join(this.dir, "blobs"), { recursive: true });
       await writeFile(path, bytes);
     }

--- a/helper-app/src/main.ts
+++ b/helper-app/src/main.ts
@@ -20,6 +20,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 import { HELPER_HTTPS_PORT, HELPER_PORT } from "@/lib/shared/helper/protocol";
+import { serveFetchHandler } from "@/lib/shared/http/node-http-adapter";
 
 import { buildAuthHeaderProvider } from "./auth/auth-provider.ts";
 import { loginConfigFromEnv, runLogin } from "./auth/login.ts";
@@ -48,8 +49,6 @@ import { loadOrCreateTls } from "./tls/certs.ts";
 import { installCaTrust, removeCaTrust } from "./tls/trust.ts";
 import { checkOnce, runUpdateLoop, type UpdateConfig } from "./update.ts";
 import { VERSION } from "./version.ts";
-
-const SHUTDOWN_TIMEOUT_MS = 5_000;
 
 function extraOrigins(): string[] {
   return (process.env.AVA_HELPER_ORIGINS ?? "").split(",").map((s) => s.trim()).filter((s) => s !== "");
@@ -114,7 +113,7 @@ type Handler = (req: Request) => Promise<Response>;
  * material i data-dir. Returnerar undefined om data-dir saknas eller TLS
  * inte kan startas — HTTP fortsätter ändå (Chromium/Firefox behöver inte HTTPS).
  */
-function startHttpsServer(handler: Handler): ReturnType<typeof Bun.serve> | undefined {
+function startHttpsServer(handler: Handler): ReturnType<typeof serveFetchHandler> | undefined {
   const dir = dataDir();
   if (dir === null) {
     log("ingen data-dir → hoppar över HTTPS (endast HTTP)");
@@ -122,11 +121,10 @@ function startHttpsServer(handler: Handler): ReturnType<typeof Bun.serve> | unde
   }
   try {
     const tls = loadOrCreateTls(join(dir, "tls"));
-    const server = Bun.serve({
+    const server = serveFetchHandler(handler, {
       port: httpsPort(),
       hostname: "127.0.0.1",
       tls: { cert: tls.leaf.cert, key: tls.leaf.key },
-      fetch: handler,
     });
     log(`ava-helper HTTPS på localhost:${httpsPort()}`);
     return server;
@@ -271,15 +269,16 @@ function main(): void {
       : {}),
   });
 
-  const httpServer = Bun.serve({ port, hostname: "127.0.0.1", fetch: handler });
+  const httpServer = serveFetchHandler(handler, { port, hostname: "127.0.0.1" });
   const httpsServer = startHttpsServer(handler);
 
   for (const sig of ["SIGTERM", "SIGINT"] as const) {
     process.on(sig, () => {
       log(`${sig} — avslutar`);
       abort.abort();
-      void Promise.all([httpServer.stop(), httpsServer?.stop()]).then(() => process.exit(0));
-      setTimeout(() => process.exit(0), SHUTDOWN_TIMEOUT_MS).unref();
+      httpServer.close();
+      httpsServer?.close();
+      process.exit(0);
     });
   }
 }

--- a/helper-app/src/open.ts
+++ b/helper-app/src/open.ts
@@ -7,7 +7,7 @@
  * nedladdningar/spawns.
  */
 
-import { mkdtemp, stat } from "node:fs/promises";
+import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 
@@ -121,13 +121,13 @@ export async function downloadTo(path: string, url: string, authHeader?: string)
   if (authHeader) headers.Authorization = authHeader;
   const resp = await fetch(url, { headers });
   if (resp.status >= 400) throw new Error(`HTTP ${resp.status}`);
-  await Bun.write(path, resp);
+  await writeFile(path, new Uint8Array(await resp.arrayBuffer()));
 }
 
 export async function uploadFile(path: string, uploadUrl: string, authHeader: string | undefined): Promise<void> {
   const headers: Record<string, string> = { "Content-Type": "application/octet-stream" };
   if (authHeader) headers.Authorization = authHeader;
-  const resp = await fetch(uploadUrl, { method: "PUT", headers, body: Bun.file(path) });
+  const resp = await fetch(uploadUrl, { method: "PUT", headers, body: new Blob([new Uint8Array(await readFile(path))]) });
   if (resp.status >= 400) throw new Error(`upload HTTP ${resp.status}`);
 }
 
@@ -142,7 +142,7 @@ export async function persistDownloaded(
   path: string,
   fileName: string,
 ): Promise<void> {
-  const bytes = await Bun.file(path).bytes();
+  const bytes = new Uint8Array(await readFile(path));
   await store.store(downloadUrl, bytes, fileName);
 }
 
@@ -155,7 +155,7 @@ export async function persistDownloaded(
 export async function restoreCached(store: ContentStore, downloadUrl: string, path: string): Promise<boolean> {
   const bytes = await store.load(downloadUrl);
   if (bytes === null) return false;
-  await Bun.write(path, bytes);
+  await writeFile(path, bytes);
   return true;
 }
 
@@ -171,7 +171,7 @@ export async function enqueueSavedFile(
   uploadUrl: string,
   authHeader: string | undefined,
 ): Promise<void> {
-  const bytes = await Bun.file(path).bytes();
+  const bytes = new Uint8Array(await readFile(path));
   await queue.enqueue({ uploadUrl, fileName: basename(path), bytes, ...(authHeader !== undefined ? { authHeader } : {}) });
 }
 

--- a/helper-app/src/update.ts
+++ b/helper-app/src/update.ts
@@ -11,7 +11,7 @@
  * Task Scheduler) startar om med nya bytsen.
  */
 
-import { chmod, rename } from "node:fs/promises";
+import { chmod, rename, writeFile } from "node:fs/promises";
 
 import { log } from "./log.ts";
 import { currentPlatform, type Platform } from "./platform/runtime.ts";
@@ -159,7 +159,7 @@ export async function downloadAndReplace(
   assertSignature(bytes, signature, keys); // kastar om osignerad/ej matchande
 
   const tmpPath = `${targetPath}.new`;
-  await Bun.write(tmpPath, bytes);
+  await writeFile(tmpPath, bytes);
   await chmod(tmpPath, 0o755);
   if (currentPlatform() === "windows") {
     await rename(targetPath, `${targetPath}.old`).catch(() => undefined);

--- a/src/bin/server-first.ts
+++ b/src/bin/server-first.ts
@@ -21,13 +21,13 @@
 
 import { loadContentDirFromEnv, makeContentStore } from "@/lib/server/adapters/git-content-store";
 import { noopPorts } from "@/lib/server/adapters/noop-ports";
-import { serveFetchHandler } from "@/lib/server/http/node-http-adapter";
 import { buildServerFirstApi, loadServerFirstConfig } from "@/lib/server/http/server-first-api";
 import { startJobRuntime, type JobRuntime } from "@/lib/server/jobs/job-worker-runtime";
 import { QueueBackedDocumentAnalyzer } from "@/lib/server/jobs/queue-backed-document-analyzer";
 import { QueueBackedEmailSender } from "@/lib/server/jobs/queue-backed-email-sender";
 import { buildServerFirstJobHandlers, loadSmtpConfigFromEnv } from "@/lib/server/jobs/server-first-handlers";
 import { loadLlmConfigFromEnv } from "@/lib/server/llm/ollama-classifier";
+import { serveFetchHandler } from "@/lib/shared/http/node-http-adapter";
 
 function log(msg: string): void {
   console.log(`[server-first] ${msg}`);

--- a/src/lib/shared/http/node-http-adapter.ts
+++ b/src/lib/shared/http/node-http-adapter.ts
@@ -10,6 +10,7 @@
  */
 
 import { createServer, type Server, type IncomingMessage, type ServerResponse } from "node:http";
+import { createServer as createHttpsServer } from "node:https";
 
 type FetchHandler = (req: Request) => Promise<Response>;
 
@@ -67,14 +68,19 @@ export interface ServeOpts {
   port: number;
   /** Lyssna-adress. Default 127.0.0.1 (loopback; nginx proxar utifrån). */
   hostname?: string;
+  /** TLS-material → https-server (ADR 0006: helperns lokala CA för Safari/add-in). */
+  tls?: { cert: string; key: string };
 }
 
 /**
- * Starta en `node:http`-server som serverar `handler`. Returnerar servern
- * (anropa `.close()` vid nedstängning).
+ * Starta en `node:http`(s)-server som serverar `handler`. Med `opts.tls` blir
+ * det en https-server (annars http). Returnerar servern (`.close()` vid nedstängning).
  */
 export function serveFetchHandler(handler: FetchHandler, opts: ServeOpts): Server {
-  const server = createServer((req, res) => { void handle(handler, req, res); });
+  const onReq = (req: IncomingMessage, res: ServerResponse): void => { void handle(handler, req, res); };
+  const server = opts.tls
+    ? createHttpsServer({ cert: opts.tls.cert, key: opts.tls.key }, onReq)
+    : createServer(onReq);
   server.listen(opts.port, opts.hostname ?? "127.0.0.1");
   return server;
 }

--- a/test/unit/server/db/server-first-deploy.test.ts
+++ b/test/unit/server/db/server-first-deploy.test.ts
@@ -18,9 +18,9 @@ import postgres from "postgres";
 import superjson from "superjson";
 import { describe, it, expect } from "vitest-compat";
 import { TrpcSyncTransport } from "@/lib/client/sync/trpc-sync-transport";
-import { serveFetchHandler } from "@/lib/server/http/node-http-adapter";
 import { buildServerFirstApi } from "@/lib/server/http/server-first-api";
 import type { AppRouter } from "@/lib/server/routers/_app";
+import { serveFetchHandler } from "@/lib/shared/http/node-http-adapter";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { applyMigrations } from "../../../../tooling/scripts/db-migrate";
 

--- a/test/unit/server/http/node-http-adapter.test.ts
+++ b/test/unit/server/http/node-http-adapter.test.ts
@@ -8,7 +8,7 @@ import { once } from "node:events";
 import { request, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import { describe, it, expect, afterEach } from "vitest-compat";
-import { serveFetchHandler } from "@/lib/server/http/node-http-adapter";
+import { serveFetchHandler } from "@/lib/shared/http/node-http-adapter";
 
 let server: Server | undefined;
 afterEach(() => { server?.close(); server = undefined; });

--- a/test/unit/server/http/server-first-http-e2e.test.ts
+++ b/test/unit/server/http/server-first-http-e2e.test.ts
@@ -19,13 +19,13 @@ import { TrpcSyncTransport } from "@/lib/client/sync/trpc-sync-transport";
 import { noopPorts } from "@/lib/server/adapters/noop-ports";
 import type { QueuedMutation } from "@/lib/server/data-store/in-memory/mutation-queue";
 import { users } from "@/lib/server/db/schema";
-import { serveFetchHandler } from "@/lib/server/http/node-http-adapter";
 import { createServerTrpcHandler } from "@/lib/server/http/server-trpc-handler";
 import { createDbChangeLogRecorder, enableChangeLogOnAll } from "@/lib/server/repositories/change-log-recorder";
 import { buildDrizzleRepositories } from "@/lib/server/repositories/drizzle-repositories";
 import type { Repositories } from "@/lib/server/repositories/repositories";
 import type { AppRouter } from "@/lib/server/routers/_app";
 import { DrizzleSyncStore } from "@/lib/server/sync/drizzle-sync-store";
+import { serveFetchHandler } from "@/lib/shared/http/node-http-adapter";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 


### PR DESCRIPTION
## Vad

**Steg 1 av ADR 0030** (konsolidering): porta motorns Bun-specifika IO till Node, så den snart kan köras **in-process i Electron** (Node). Den här PR:en ändrar inte arkitekturen ännu — `helper-app` byggs fortfarande som Bun-binär (Bun kör Node-API:erna) och förblir grön. Ren förberedelse.

## Hur

- **`node-http-adapter` → `src/lib/shared/http/`** (så helpern får importera den; den enda main-app-importen (`server-first.ts`) + 3 testimporter uppdaterade). Gav den **TLS-stöd** (`opts.tls` → `node:https`) för helperns lokala-CA-väg (ADR 0006).
- **`Bun.serve`** (helperns http+https + auth-callback-servern) → **`serveFetchHandler`** (node:http/https).
- **`Bun.file`/`Bun.write`/`Bun.file().exists()`** (open, content-store, update) → **`node:fs`** (`readFile`/`writeFile`/`access`).
- Inga `Bun.*` kvar i `helper-app/src`.

## Verifierat

helper-typecheck + **266 helper-tester** gröna; **cross-build (5 binärer)** ok (Bun kompilerar Node-API-koden); main-typecheck + **full enhetssvit** gröna (coverage-golv); lint + dep-cruiser (shared→node:http ok) + knip rena. Logiken är oförändrad — bara IO-sömmarna bytte runtime-API.

## Härnäst (ADR 0030)

Steg 2: slå ihop till `helper-ui` (motorn in-process i Electron-main, ta bort binär/supervisor/extraResources). Steg 3: update-notis. Steg 4: ta bort `helper-app` + `helper-ci`.

Refs #680 #688.

🤖 Generated with [Claude Code](https://claude.com/claude-code)