### PR TITLE
fix(documents): öppna dokument via AVA Helper på primärklick (native-app)

### DIFF
--- a/src/components/documents/_document-row.tsx
+++ b/src/components/documents/_document-row.tsx
@@ -72,6 +72,12 @@ export function DocumentRow({
     if (handled) return;
     setModal(await runExternalEdit({ id: doc.id, fileName: doc.fileName, storagePath: doc.storagePath }));
   };
+  // Primärklick: AVA Helper (native-app) → FSA → browser-tab. Samma delade
+  // logik som list-vyn (open-document-externally) så vyerna inte glider isär.
+  const openPrimary = async () => {
+    const { openDocumentSmart } = await import("@/lib/client/firma/open-document-externally");
+    await openDocumentSmart({ id: doc.id, fileName: doc.fileName, storagePath: doc.storagePath }, setModal);
+  };
   return (
     <Fragment>
       <ExternalEditModal state={modal} onClose={() => setModal({ kind: "closed" })} />
@@ -86,7 +92,7 @@ export function DocumentRow({
           <div style={{ paddingLeft: `${depth * 16 + 4}px` }} className="min-w-0">
             <div className="flex items-center gap-2 min-w-0">
               <DocumentNameButton doc={doc} isAnalyzing={isAnalyzing} disabled={!!isUploading}
-                onExternalEdit={() => void triggerExternalEdit()} />
+                onOpen={() => void openPrimary()} />
               {isUploading && (
                 <span
                   className="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded bg-amber-100 text-amber-800"
@@ -252,10 +258,9 @@ interface NameButtonProps {
   doc: DocumentRecord;
   isAnalyzing: boolean;
   disabled?: boolean;
-  /** Påkallad av PDF/Office-klick när FSA är tillgänglig: kör external-
-   *  edit-flödet via parent (modal-state ligger där). Om null → faller
-   *  vi alltid tillbaka till browser-tab. */
-  onExternalEdit?: () => void;
+  /** Primärklick: smart öppning (AVA Helper → FSA → browser-tab) via parent
+   *  (modal-state ligger där). */
+  onOpen: () => void;
 }
 
 /** Meta-raden under filnamnet (typ-badge, filnamn, analys-status). Utbruten
@@ -279,33 +284,13 @@ function DocumentNameMeta({ doc, isAnalyzing, isWaitingAnalysis }: { doc: Docume
   );
 }
 
-function DocumentNameButton({ doc, isAnalyzing, disabled, onExternalEdit }: NameButtonProps) {
+function DocumentNameButton({ doc, isAnalyzing, disabled, onOpen }: NameButtonProps) {
   const isWaitingAnalysis = isAnalyzing || isWithinAnalysisGrace(doc);
-
-  const onClick = async () => {
-    if (disabled) return;
-    // PDF/Office-filer öppnas i extern editor (PDF Gear, Preview, Word…)
-    // när FSA är konfigurerad. Browser-tabben är fallback.
-    if (onExternalEdit) {
-      const { shouldPreferExternalEdit } = await import("@/lib/client/firma/open-document-externally");
-      const { isFsaSupported, loadHandle } = await import("@/lib/client/fsa/handle-store");
-      if (shouldPreferExternalEdit(doc.fileName) && isFsaSupported() && await loadHandle("repo-root")) {
-        onExternalEdit();
-        return;
-      }
-    }
-    // Runtime-tier (#651): self-hosted hämtar bytes från servern (+ cache),
-    // demo öppnar GH-Pages-blobben. (Ej bygg-tids-NEXT_PUBLIC_DEMO_BUILD, som är
-    // sant även i den lokala self-hosted-builden → länkade fel till GH.)
-    const rec = doc as DocumentRecord & { storagePath?: string };
-    const { openMatterDocument } = await import("@/lib/client/firma/open-matter-document");
-    await openMatterDocument({ id: doc.id, storagePath: rec.storagePath ?? null, fileName: doc.fileName });
-  };
 
   return (
     <button
       type="button"
-      onClick={() => void onClick()}
+      onClick={() => { if (!disabled) onOpen(); }}
       disabled={disabled}
       className="flex items-start gap-2 text-blue-600 hover:underline text-left disabled:opacity-50 disabled:cursor-not-allowed disabled:no-underline"
       title={disabled ? "Laddar upp — vänta tills filen är registrerad" : (doc.summary || "Öppna i extern app (PDFGear för PDF)")}

--- a/src/components/documents/_documents-list-view.tsx
+++ b/src/components/documents/_documents-list-view.tsx
@@ -11,6 +11,7 @@
 import { useState } from "react";
 import { ActionMenu, type ActionMenuItem } from "@/components/ui/action-menu";
 import { DataTable, type Column } from "@/components/ui/data-table";
+import { openDocumentSmart } from "@/lib/client/firma/open-document-externally";
 import { trpc } from "@/lib/client/trpc";
 import type { DocumentRecord } from "./_document-row";
 import { formatFileSize } from "./_drag-helpers";
@@ -35,31 +36,6 @@ function folderPath(folderId: string | null, folders: FolderRecord[]): string {
     current = parentId ? folders.find((f) => f.id === parentId) : undefined;
   }
   return "/" + parts.join("/");
-}
-
-async function openDocumentSmart(doc: DocumentRecord, setModal: (m: ModalState) => void): Promise<void> {
-  // Klient-genererade dokument (kostnadsräkning m.fl.) öppnas som blob:-URL ur
-  // cachen (rehydreras från demo-slaben efter reload). Annars skulle demo-grenen
-  // nedan öppna en storagePath som 404:ar på GH Pages → app:en hamnar på
-  // dashboarden. (Träd-vyn gör redan detta via open-document.ts.)
-  const { hasGeneratedDoc, openGeneratedDoc } = await import("@/lib/client/demo/generated-doc-cache");
-  if (hasGeneratedDoc(doc.id)) { openGeneratedDoc(doc.id); return; }
-  const { shouldPreferExternalEdit, runExternalEdit, tryHelperOpen } = await import("@/lib/client/firma/open-document-externally");
-  if (shouldPreferExternalEdit(doc.fileName)) {
-    // Försök 1-klicks via AVA Helper först (funkar i alla browsers)
-    const handled = await tryHelperOpen({ id: doc.id, fileName: doc.fileName, storagePath: doc.storagePath });
-    if (handled) return;
-    // Fallback: FSA + ExternalEditModal (Chrome/Edge med vald mapp)
-    const { isFsaSupported, loadHandle } = await import("@/lib/client/fsa/handle-store");
-    if (isFsaSupported() && await loadHandle("repo-root")) {
-      setModal(await runExternalEdit({ id: doc.id, fileName: doc.fileName, storagePath: doc.storagePath }));
-      return;
-    }
-  }
-  // Fallback: öppna i browser-tab. Runtime-tier (#651): self-hosted via servern
-  // (cache-medveten), demo via GH-Pages-blobben — ej bygg-tids-NEXT_PUBLIC_DEMO_BUILD.
-  const { openMatterDocument } = await import("@/lib/client/firma/open-matter-document");
-  await openMatterDocument({ id: doc.id, storagePath: doc.storagePath ?? null, fileName: doc.fileName });
 }
 
 export function DocumentsListView({ matterId, documents, folders, onDelete, onReanalyze }: Props) {

--- a/src/lib/client/demo/generated-doc-idb.ts
+++ b/src/lib/client/demo/generated-doc-idb.ts
@@ -11,7 +11,7 @@
  * (`generated-doc-cache`) vid boot.
  *
  * Seed-dokument (shippade i demo-repot) berörs inte — de öppnas direkt mot
- * CDN-URL:en (se `_documents-list-view.openDocumentSmart`).
+ * CDN-URL:en (se `open-document-externally.openDocumentSmart`).
  *
  * Best-effort: saknas IndexedDB (SSR/privat flik) → no-op / tom lista, precis
  * som `IndexedDbFsPersistence`. IndexedDB strukturklonar `Uint8Array` direkt,

--- a/src/lib/client/firma/open-document-externally.ts
+++ b/src/lib/client/firma/open-document-externally.ts
@@ -130,3 +130,34 @@ export async function runExternalEdit(doc: Doc): Promise<ModalState> {
 export function shouldPreferExternalEdit(fileName: string): boolean {
   return /\.(pdf|docx?|xlsx?|pptx?)$/i.test(fileName);
 }
+
+/**
+ * Smart primärklick-öppning av ett dokument. Ordningen är medvetet:
+ *   1. **AVA Helper** (1-klick, native-app: PDF Gear/Word/Preview) — funkar i
+ *      ALLA browsers och kräver INGEN FSA-mapp. Provas FÖRST.
+ *   2. **FSA** (Chrome/Edge med vald lokal mapp) → ExternalEditModal.
+ *   3. **Browser-tab** (self-hosted hämtar via servern, demo via GH-Pages-blob).
+ *
+ * Delad mellan träd-vyn (DocumentRow) och list-vyn (DocumentsListView) så de
+ * inte glider isär — tidigare gjorde de det: träd-vyn krävde FSA *innan* helpern
+ * ens försöktes, så ett klick på en .docx/.pdf laddade bara ner / öppnade
+ * browser-tab i stället för att öppna i native-appen.
+ */
+export async function openDocumentSmart(doc: Doc, onModal: (m: ModalState) => void): Promise<void> {
+  // Klient-genererade demo-dok (kostnadsräkning m.fl.) öppnas ur cachen — annars
+  // 404:ar deras storagePath på GH Pages → app:en hamnar på dashboarden.
+  const { hasGeneratedDoc, openGeneratedDoc } = await import("@/lib/client/demo/generated-doc-cache");
+  if (hasGeneratedDoc(doc.id)) { openGeneratedDoc(doc.id); return; }
+
+  if (shouldPreferExternalEdit(doc.fileName)) {
+    if (await tryHelperOpen(doc)) return; // 1) helpern
+    const { isFsaSupported, loadHandle } = await import("@/lib/client/fsa/handle-store");
+    if (isFsaSupported() && await loadHandle("repo-root")) {
+      onModal(await runExternalEdit(doc)); // 2) FSA
+      return;
+    }
+  }
+  // 3) browser-tab
+  const { openMatterDocument } = await import("@/lib/client/firma/open-matter-document");
+  await openMatterDocument({ id: doc.id, storagePath: doc.storagePath, fileName: doc.fileName });
+}


### PR DESCRIPTION
## Symtom
Klick på en **.docx** i ett ärende laddar ner filen; **.pdf** öppnas i en browser-flik — i stället för att öppnas i Word / PDF Gear via AVA Helper (som kör lokalt).

## Root cause
Träd-vyns primärklick (`_document-row.tsx` → `DocumentNameButton`) provade external-edit **enbart** om `isFsaSupported() && loadHandle("repo-root")` — dvs en lokal FSA-mapp måste vara vald *innan* helpern ens försöktes. Utan vald mapp föll klicket rakt till `openMatterDocument` → `window.open`/nedladdning. List-vyn (`openDocumentSmart`) gjorde redan rätt (helper först) → de två vyerna hade **glidit isär**.

## Fix (DRY)
Lyft den korrekta ordningen till en delad `openDocumentSmart` i `open-document-externally.ts`, använd den i **båda** vyerna:
1. **AVA Helper** — 1-klick, native-app (PDF Gear/Word/Preview). Funkar i alla browsers, kräver **ingen** FSA-mapp. Provas **först**.
2. **FSA** + `ExternalEditModal` (Chrome/Edge med vald mapp).
3. **Browser-tab** (self-hosted via servern, demo via GH-Pages-blob).

Kebab-menyns *"Editera externt"* (explicit) behåller helper→FSA-modal; *"Öppna i webbläsaren"* är fortsatt browser-tab.

## Verifierat
- `tsc --noEmit` rent (huvudrepo via lint-staged)
- 9 dokument-komponenttester gröna (`documents-list-view`, `document-row-upload-guard`)
- eslint rent på ändrade filer

## Not (self-hosted)
I self-hosted-tiern är dokument-bytes auth-skyddade (`/api/documents/<id>/download` bakom oauth2-proxy). Helpern hämtar med sin **egen** OIDC-token (ADR 0028 §2), så den måste vara **inloggad** (tray "Logga in" / `--login`) för att 1-klicks-öppningen ska lyckas; annars faller den tillbaka. I demo-tiern är URL:erna publika → inget login krävs.

Closes #696

🤖 Generated with [Claude Code](https://claude.com/claude-code)