### PR TITLE
fix(selfhosted): låt oauth2-proxy acceptera AVA Helpers Bearer-token

### DIFF
--- a/tooling/docker/docker-compose.selfhosted-local.yml
+++ b/tooling/docker/docker-compose.selfhosted-local.yml
@@ -93,6 +93,12 @@ services:
       OAUTH2_PROXY_SKIP_PROVIDER_BUTTON: "true"
       OAUTH2_PROXY_COOKIE_SECURE: "false"
       OAUTH2_PROXY_INSECURE_OIDC_ALLOW_UNVERIFIED_EMAIL: "true"
+      # Acceptera en giltig `Authorization: Bearer <JWT>` vid sidan av session-
+      # cookien (ADR 0028): AVA Helper kör utanför browser-sessionen och
+      # autentiserar med sin EGNA OIDC-token (aud=ava, samma issuer). Utan detta
+      # 401:ar oauth2-proxy helperns /api/documents-anrop → 1-klicks-öppning i
+      # native-app faller tillbaka. Token verifieras mot samma JWKS/issuer.
+      OAUTH2_PROXY_SKIP_JWT_BEARER_TOKENS: "true"
     depends_on:
       - keycloak
 


### PR DESCRIPTION
## Problem
Den lokala self-hosted-stacken gatear `/api/` via oauth2-proxy `auth_request`, som **bara** godkänner sin session-cookie. AVA Helper kör utanför browser-sessionen och autentiserar med sin **egna** OIDC-token (ADR 0028 §2), så helperns `/api/documents/<id>/download` fick **401** → 1-klicks-öppning i native-app (Word/PDF Gear) föll tillbaka till nedladdning.

## Fix
`OAUTH2_PROXY_SKIP_JWT_BEARER_TOKENS: "true"` på oauth2-proxy → en giltig `Authorization: Bearer <JWT>` accepteras vid sidan av cookien. Token verifieras mot **samma** issuer (`http://localhost:8089/realms/ava`) och JWKS som cookie-flödet, och dess `aud` måste matcha `OAUTH2_PROXY_CLIENT_ID=ava` — vilket helper-klienten (`ava-helper`) redan ger via sin audience=ava-mapper.

Bara local-self-hosted-compose (dev/test-fixtur) berörs.

Closes #698

🤖 Generated with [Claude Code](https://claude.com/claude-code)