### PR TITLE
fix(selfhosted): ge lawyer/admin offline_access-roll + städa helper-klientens scopes

### DIFF
--- a/tooling/docker/keycloak/realm-ava.json
+++ b/tooling/docker/keycloak/realm-ava.json
@@ -56,10 +56,11 @@
         "pkce.code.challenge.method": "S256"
       },
       "defaultClientScopes": [
-        "openid",
         "email",
         "profile",
-        "roles",
+        "roles"
+      ],
+      "optionalClientScopes": [
         "offline_access"
       ],
       "protocolMappers": [
@@ -84,7 +85,8 @@
       "email": "admin@ava.test",
       "firstName": "Admin",
       "lastName": "Testsson",
-      "credentials": [{ "type": "password", "value": "admin", "temporary": false }]
+      "credentials": [{ "type": "password", "value": "admin", "temporary": false }],
+      "realmRoles": ["offline_access"]
     },
     {
       "username": "lawyer",
@@ -93,7 +95,8 @@
       "email": "lawyer@ava.test",
       "firstName": "Lena",
       "lastName": "Advokat",
-      "credentials": [{ "type": "password", "value": "lawyer", "temporary": false }]
+      "credentials": [{ "type": "password", "value": "lawyer", "temporary": false }],
+      "realmRoles": ["offline_access"]
     },
     {
       "username": "outsider",


### PR DESCRIPTION
## Problem
Realm-importen (`realm-ava.json`) gav användarna inga roller och definierade ingen default-roll → `lawyer`/`admin` saknade `offline_access`-rollen. AVA Helper begär `offline_access` (ADR 0028 — autonom, refresh-bar token) → Keycloak nekade token-utbytet: `Offline tokens not allowed for the user or client`. Utan offline-token dör helperns access-token efter ~5 min → 1-klicks-öppningen slutar fungera.

Dessutom hade `ava-helper`-klientens `defaultClientScopes` `"openid"` (inget giltigt client-scope i Keycloak) + `offline_access` som *default* — aldrig importtestat (klienten saknades i den körande realmen), riskerade haverera hela realm-importen.

## Fix
- `lawyer` + `admin`: `realmRoles: ["offline_access"]`.
- `ava-helper`: flytta `offline_access` → `optionalClientScopes` (helpern begär det explicit), ta bort `"openid"` ur `defaultClientScopes`.

Bara local-self-hosted-fixturen (Keycloak realm) berörs.

Closes #700

🤖 Generated with [Claude Code](https://claude.com/claude-code)