### PR TITLE
feat(helper): tunn tRPC-klient-grund (ADR 0031 steg 1)

### DIFF
--- a/.github/workflows/helper-ui-ci.yml
+++ b/.github/workflows/helper-ui-ci.yml
@@ -9,14 +9,14 @@ on:
     branches: [main]
     paths:
       - "helper-ui/**"
-      - "src/lib/shared/helper/**"
-      - "src/lib/shared/http/**"
+      - "src/lib/shared/**"
+      - "src/lib/server/routers/**" # helpern type-beror på AppRouter (ADR 0031)
       - ".github/workflows/helper-ui-ci.yml"
   pull_request:
     paths:
       - "helper-ui/**"
-      - "src/lib/shared/helper/**"
-      - "src/lib/shared/http/**"
+      - "src/lib/shared/**"
+      - "src/lib/server/routers/**" # helpern type-beror på AppRouter (ADR 0031)
       - ".github/workflows/helper-ui-ci.yml"
 
 jobs:
@@ -33,6 +33,13 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      # Root-deps krävs för att typkolla den tunna tRPC-klienten: `AppRouter`
+      # (type-only, ADR 0031) drar in serverns typ-graf (zod, jose, @trpc/server
+      # …) som bor i repo-rotens node_modules. tsc i helper-ui resolver uppåt dit.
+      - name: Install root deps
+        working-directory: ${{ github.workspace }}
+        run: bun install --frozen-lockfile
 
       - name: Install
         run: bun install --frozen-lockfile

--- a/docs/adr/0031-helpern-som-tunn-trpc-klient.md
+++ b/docs/adr/0031-helpern-som-tunn-trpc-klient.md
@@ -1,0 +1,90 @@
+# ADR 0031 — Helpern som tunn tRPC-klient (tRPC överallt, delade typer i alla tiers)
+
+- **Status:** Accepterad (2026-06-22)
+- **Beslutsfattare:** Ulrik Sjölin
+- **Berör:** helper-ui (motorn), helper-protokollet, web-appens dokument-öppnings-flöde,
+  dependency-cruiser, server-first document-procedurer.
+- **Knyter an:** [ADR 0013](0013-tunn-server-trpc-over-http-add-ins.md) (add-ins =
+  tunna tRPC-over-HTTP-klienter — **samma mönster**), [ADR 0028](0028-autonom-offline-first-helper.md)
+  (helperns egna Bearer), [ADR 0027](0027-kapabilitets-tierad-klient.md) (tiers),
+  [ADR 0030](0030-konsolidera-helper-till-ett-paket.md) (ett paket).
+
+## Kontext
+
+När web-appen ber AVA Helper öppna ett dokument fick helpern en **REST-URL**
+(`/api/documents/<id>/download`) som downloadUrl. Men server-first exponerar
+**bara tRPC** (`/api/trpc`) — dokument-bytes hämtas via den typade proceduren
+`document.downloadContent` och skrivs via `document.uploadContent`. REST-URL:en
+fanns aldrig → **404**, och 1-klicks-öppning i native-app föll tillbaka i
+self-hosted.
+
+Att lägga till en bespoke REST-yta i server-first vore att skapa ett **andra,
+otypat kontrakt** vid sidan av tRPC — raka motsatsen till projektets princip att
+**alla lager och tiers delar datatyper** (strikt zod + `AppRouter`). Dessutom är
+mönstret redan etablerat: **Office-add-ins är tunna tRPC-over-HTTP-klienter**
+(ADR 0013). Och auth-gaten accepterar numera helperns egna Bearer (oauth2-proxy
+`SKIP_JWT_BEARER_TOKENS`, #699 + `offline_access`-roll #700) — bevisat med 202 mot
+`/api/trpc`-gaten.
+
+## Beslut
+
+### 1. Helpern är en tunn tRPC-over-HTTP-klient
+
+Helpern hämtar dokument via `document.downloadContent` och skriver via
+`document.uploadContent` — samma typade procedurer som web-appen och add-ins
+använder. **Ingen bespoke REST-yta.** Helpern bygger en `createTRPCClient<AppRouter>`
+(httpBatchLink + superjson), exakt som `createAddinClient` (ADR 0013).
+
+### 2. Web-appen skickar `documentId`, inte en REST-URL
+
+Web-appen slutar konstruera `/api/documents/<id>/download`-URL:er åt helpern. Den
+skickar **`documentId` + tRPC-endpoint** (`<origin>/api/trpc`); helpern bär sin
+**egna** Bearer (OIDC-token, ADR 0028 §2) i `Authorization`-headern. Allt typat
+end-to-end via `AppRouter`.
+
+### 3. Delade datatyper i ALLA tiers; transport = tRPC där en server finns
+
+`AppRouter` + zod-scheman delas i alla tiers. **Transporten** är tRPC-over-HTTP
+överallt det finns en server (self-hosted + framtida hosted). **Demo-tiern har
+ingen server** — hela routern kör i webbläsaren mot `DemoDataStore`, och
+dokument-bytsen är statiska filer i GH-Pages-exporten. Där hämtar helpern en
+**statisk blob-URL** (oförändrat). Det är ett transport-undantag, inte ett
+typ-undantag: typerna/kontraktet delas även i demo.
+
+### 4. dep-cruiser: helper-ui får type-only-importera `server/`
+
+Som add-ins (`addin-imports-server-by-type-only`) får `helper-ui` **type-only**-
+importera `src/lib/server/` (enbart `AppRouter`-typen, raderas vid kompilering —
+ingen runtime-koppling). Värde-importer av server- eller client-kod förblir
+förbjudna; helpern har sin **egen** tRPC-klient-factory (kan inte återanvända
+`src/lib/client/addin/`, som ligger bakom client-gränsen).
+
+## Konsekvenser
+
+- **Ett enda typat kontrakt** för dokument-IO i alla server-tiers; ingen otypad
+  REST att hålla i synk.
+- `helper-ui` får dependencies `@trpc/client` + `superjson` (+ `@trpc/server` som
+  typ-dev-dep) och en type-only `AppRouter`-import.
+- Helper-protokollet byter `downloadUrl`/`uploadUrl` mot en **document-descriptor**
+  (`{ documentId, trpcUrl }`) för server-tier; demo behåller en `staticUrl`. Den
+  durabla upload-kön lagrar descriptorn i st.f. en PUT-URL.
+- Web-appens öppnings-flöde (`tryHelperOpen`, `fetchContentViaHelper`) slutar bygga
+  REST-URL:er.
+
+## Genomförande (en PR per steg)
+
+1. **ADR + tRPC-klient-grund:** den här ADR:n, dep-cruiser type-only-allowance för
+   helper-ui, helperns tRPC-klient-factory + deps.
+2. **Läsväg (download) via tRPC:** `/open` + `/content` hämtar via
+   `downloadContent` när en document-descriptor finns; statisk URL kvar för demo.
+   → klick→öppna-i-native funkar self-hosted (read).
+3. **Skrivväg (write-back) via tRPC:** save → `uploadContent`; durabla kön lagrar
+   document-descriptorn.
+4. **Städning:** ta bort REST-antagandet + `downloadUrl`/`uploadUrl`-fälten ur
+   protokollet när inget längre använder dem.
+
+## Relaterat
+
+ADR 0013 (tunn server + tRPC-over-HTTP-add-ins; helpern följer samma mönster),
+0028 (helperns egna Bearer), 0030 (ett paket). Föranlett av att helpern fick en
+REST-URL som inte fanns, och önskan om tRPC + delade typer överallt.

--- a/helper-ui/bun.lock
+++ b/helper-ui/bun.lock
@@ -5,9 +5,12 @@
     "": {
       "name": "@ava/helper-ui",
       "dependencies": {
+        "@trpc/client": "^11.17.0",
         "node-forge": "^1.4.0",
+        "superjson": "^2.2.6",
       },
       "devDependencies": {
+        "@trpc/server": "^11.17.0",
         "@types/node-forge": "^1.3.14",
         "bun-types": "^1.3.14",
         "electron": "^42.4.1",
@@ -53,6 +56,10 @@
     "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
     "@szmarczak/http-timer": ["@szmarczak/http-timer@4.0.6", "", { "dependencies": { "defer-to-connect": "^2.0.0" } }, "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w=="],
+
+    "@trpc/client": ["@trpc/client@11.18.0", "", { "peerDependencies": { "@trpc/server": "11.18.0", "typescript": ">=5.7.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-wOqeg3Fvl25V1ZisQhUD3K8G60ZJDlSGJNSyeXrLH24xAo5w6GSR2Kzb1cSNY9Y+IQ2YZvYGZstBU+V/ulo/ow=="],
+
+    "@trpc/server": ["@trpc/server@11.18.0", "", { "peerDependencies": { "typescript": ">=5.7.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-JAvXOuNTxgXjIDfQaOvDq1j66LMNfDJUH1IU7Slfn8EvRv2EkH6ehu3A7zpYhjO0syHHiYg77v2lG2JFJgvw7Q=="],
 
     "@types/cacheable-request": ["@types/cacheable-request@6.0.3", "", { "dependencies": { "@types/http-cache-semantics": "*", "@types/keyv": "^3.1.4", "@types/node": "*", "@types/responselike": "^1.0.0" } }, "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw=="],
 
@@ -149,6 +156,8 @@
     "compare-version": ["compare-version@0.1.2", "", {}, "sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "copy-anything": ["copy-anything@4.0.5", "", { "dependencies": { "is-what": "^5.2.0" } }, "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA=="],
 
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
 
@@ -279,6 +288,8 @@
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-what": ["is-what@5.5.0", "", {}, "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw=="],
 
     "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
@@ -448,6 +459,8 @@
 
     "sumchecker": ["sumchecker@3.0.1", "", { "dependencies": { "debug": "^4.1.0" } }, "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg=="],
 
+    "superjson": ["superjson@2.2.6", "", { "dependencies": { "copy-anything": "^4" } }, "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA=="],
+
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "tar": ["tar@7.5.16", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w=="],
@@ -469,6 +482,8 @@
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 

--- a/helper-ui/package.json
+++ b/helper-ui/package.json
@@ -14,13 +14,16 @@
     "dist": "bun run icons && bun run bundle && electron-builder"
   },
   "devDependencies": {
+    "@trpc/server": "^11.17.0",
     "@types/node-forge": "^1.3.14",
     "bun-types": "^1.3.14",
     "electron": "^42.4.1",
     "electron-builder": "^26.15.3"
   },
   "dependencies": {
-    "node-forge": "^1.4.0"
+    "@trpc/client": "^11.17.0",
+    "node-forge": "^1.4.0",
+    "superjson": "^2.2.6"
   },
   "build": {
     "appId": "se.ava.helper",

--- a/helper-ui/src/engine/trpc-client.ts
+++ b/helper-ui/src/engine/trpc-client.ts
@@ -1,0 +1,81 @@
+/**
+ * `trpc-client` — helperns tunna tRPC-over-HTTP-klient (ADR 0031).
+ *
+ * Helpern äger ingen db och inget eget API: den pratar med server-first:ens
+ * tRPC-over-HTTP (`/api/trpc`) via `httpBatchLink` + `superjson` (matchar serverns
+ * transformer) och bär sin EGNA Bearer-token (OIDC, ADR 0028 §2). Exakt samma
+ * mönster som Office-add-ins (`createAddinClient`, ADR 0013) — samma `AppRouter`-
+ * typer end-to-end, ingen bespoke REST-yta.
+ *
+ * `AppRouter` importeras type-only → ingen server-kod i bundlen (respekterar
+ * `helper-ui-imports-server-by-type-only`). Helpern kan inte återanvända
+ * `src/lib/client/addin/`-factoryn (bakom client-gränsen), därav en egen.
+ */
+
+import { createTRPCClient, httpBatchLink, type TRPCClient } from "@trpc/client";
+import superjson from "superjson";
+
+import type { AppRouter } from "@/lib/server/routers/_app";
+import { base64ToBytes } from "@/lib/shared/content-address";
+
+/** tRPC-endpointens suffix på serverns origin (matchar DEFAULT_TRPC_ENDPOINT). */
+export const TRPC_PATH = "/api/trpc";
+
+/** Full endpoint-URL ur serverns bas-URL/origin (trimmar avslutande "/"). */
+export function documentTrpcEndpoint(baseUrl: string): string {
+  return `${baseUrl.replace(/\/+$/, "")}${TRPC_PATH}`;
+}
+
+/** En DOM-kompatibel fetch (det test/runtime injicerar). */
+export type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+/** tRPC:s fetch-typ för `httpBatchLink` (`FetchEsque`). */
+type LinkFetch = NonNullable<NonNullable<Parameters<typeof httpBatchLink<AppRouter>>[0]>["fetch"]>;
+
+/**
+ * Adaptera en injicerad DOM-fetch till tRPC:s länk-fetch. `httpBatchLink` anropar
+ * med URL-sträng/URL, men `FetchEsque` tillåter även `Request` → normalisera till
+ * `.url`. `init` bryggas med en lokal `as` för signal-varianten (null vs
+ * undefined under exactOptional) — samma mönster som `src/lib/client/link-fetch`.
+ */
+function toLinkFetch(fetchImpl: FetchLike): LinkFetch {
+  return (url, init) => fetchImpl(url instanceof Request ? url.url : url, init as RequestInit | undefined);
+}
+
+export interface DocumentClientOptions {
+  /** Full tRPC-endpoint, t.ex. `http://localhost:8080/api/trpc`. */
+  trpcUrl: string;
+  /** Helperns Bearer-token (OIDC). */
+  token: string;
+  /** Valfri fetch-override (default: global fetch). */
+  fetch?: FetchLike;
+}
+
+/** Skapa en typad tRPC-klient mot AVA-serverns API (hela `AppRouter`-ytan). */
+export function createDocumentClient(opts: DocumentClientOptions): TRPCClient<AppRouter> {
+  return createTRPCClient<AppRouter>({
+    links: [
+      httpBatchLink({
+        url: opts.trpcUrl,
+        transformer: superjson,
+        headers: () => ({ authorization: `Bearer ${opts.token}` }),
+        ...(opts.fetch ? { fetch: toLinkFetch(opts.fetch) } : {}),
+      }),
+    ],
+  });
+}
+
+export interface DocumentBytes {
+  bytes: Uint8Array;
+  mimeType: string;
+  fileName: string;
+}
+
+/** Hämta dokument-bytes via den typade `document.downloadContent`-proceduren. */
+export async function downloadDocumentBytes(
+  client: TRPCClient<AppRouter>,
+  documentId: string,
+): Promise<DocumentBytes> {
+  const res = await client.document.downloadContent.query({ documentId });
+  return { bytes: base64ToBytes(res.contentBase64), mimeType: res.mimeType, fileName: res.fileName };
+}

--- a/helper-ui/test/trpc-client.test.ts
+++ b/helper-ui/test/trpc-client.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Helperns tunna tRPC-klient (ADR 0031). Driver `createDocumentClient` via en
+ * injicerad fetch som returnerar ett superjson-kodat httpBatchLink-svar →
+ * bevisar wire-kompatibilitet (samma `/api/trpc`-endpoint, superjson, Bearer)
+ * och att `downloadDocumentBytes` avkodar base64 → bytes.
+ */
+
+import { describe, expect, test } from "bun:test";
+import superjson from "superjson";
+
+import {
+  createDocumentClient,
+  documentTrpcEndpoint,
+  downloadDocumentBytes,
+  type FetchLike,
+} from "../src/engine/trpc-client.ts";
+
+describe("documentTrpcEndpoint", () => {
+  test("lägger på /api/trpc och trimmar avslutande slash", () => {
+    expect(documentTrpcEndpoint("http://h:8080")).toBe("http://h:8080/api/trpc");
+    expect(documentTrpcEndpoint("http://h:8080/")).toBe("http://h:8080/api/trpc");
+    expect(documentTrpcEndpoint("http://h:8080///")).toBe("http://h:8080/api/trpc");
+  });
+});
+
+describe("createDocumentClient + downloadDocumentBytes", () => {
+  test("anropar document.downloadContent med Bearer och avkodar base64 → bytes", async () => {
+    const captured: { url: string; auth: string | null } = { url: "", auth: null };
+    const fetchImpl: FetchLike = async (input, init) => {
+      captured.url = String(input);
+      captured.auth = new Headers(init?.headers).get("authorization");
+      const out = {
+        contentBase64: Buffer.from("PDF-BYTES").toString("base64"),
+        mimeType: "application/pdf",
+        fileName: "x.pdf",
+      };
+      // httpBatchLink-svar: array (batch) av { result: { data: <superjson> } }.
+      return new Response(JSON.stringify([{ result: { data: superjson.serialize(out) } }]), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    const client = createDocumentClient({
+      trpcUrl: "http://h:8080/api/trpc",
+      token: "tok-123",
+      fetch: fetchImpl,
+    });
+    const res = await downloadDocumentBytes(client, "doc-1");
+
+    expect(new TextDecoder().decode(res.bytes)).toBe("PDF-BYTES");
+    expect(res.mimeType).toBe("application/pdf");
+    expect(res.fileName).toBe("x.pdf");
+    expect(captured.url).toContain("/api/trpc");
+    expect(captured.url).toContain("document.downloadContent");
+    expect(captured.auth).toBe("Bearer tok-123");
+  });
+});

--- a/tooling/config/dependency-cruiser.cjs
+++ b/tooling/config/dependency-cruiser.cjs
@@ -181,10 +181,23 @@ module.exports = {
       severity: "error",
       comment:
         "helper-ui får bara importera från src/lib/shared/ (delad, framework-" +
-        "agnostisk kärna) — aldrig client/ eller server/. Delad kod som helpern " +
-        "behöver hör hemma i shared/. (Se #85.)",
+        "agnostisk kärna) — aldrig client/. server/ får type-only-importeras " +
+        "(AppRouter), se nästa regel. (Se #85.)",
       from: { path: "^helper-ui/" },
-      to: { path: "^src/lib/(client|server)/" },
+      to: { path: "^src/lib/client/" },
+    },
+    {
+      // Helpern är en TUNN tRPC-over-HTTP-klient (ADR 0031), precis som Office-
+      // add-ins (ADR 0013). Den får referera backend-lagret ENBART via TYPER
+      // (AppRouter-kontraktet) — aldrig dra in körbar server-kod i bundlen.
+      // Speglar `addin-imports-server-by-type-only`.
+      name: "helper-ui-imports-server-by-type-only",
+      severity: "error",
+      comment:
+        "helper-ui får bara type-only-importera src/lib/server/ (tRPC-kontraktet " +
+        "AppRouter, ADR 0031) — aldrig värde-importera server-kod.",
+      from: { path: "^helper-ui/" },
+      to: { path: "^src/lib/server/", dependencyTypesNot: ["type-only"] },
     },
     {
       // Add-in-gräns (#72, ADR 0013): Outlook-add-in:en är en TUNN HTTP-klient.


### PR DESCRIPTION
## Bakgrund
Helpern fick en REST-URL (`/api/documents/<id>/download`) som server-first inte exponerar — den serverar bara **tRPC**. Att lägga till en REST-yta vore ett andra, otypat kontrakt. I stället: helpern blir en **tunn tRPC-over-HTTP-klient**, precis som Office-add-ins (ADR 0013). **ADR 0031** fastställer principen; den här PR:en är **steg 1 (grunden)**.

## Innehåll
- **ADR 0031** — helpern = tunn tRPC-klient; delade datatyper i ALLA tiers; transport = tRPC-over-HTTP där en server finns, statisk blob-URL i demo (ingen server att tRPC:a mot).
- **dep-cruiser** — ny regel `helper-ui-imports-server-by-type-only` (type-only `AppRouter`, speglar `addin-imports-server-by-type-only`); `helper-ui-only-imports-shared` snävas till att förbjuda `client/` (server/ tillåts type-only).
- **helper-ui-deps** — `@trpc/client` + `superjson` (+ `@trpc/server` som typ-dev-dep).
- **`trpc-client.ts`** — `createDocumentClient` (httpBatchLink + superjson + Bearer, egen `toLinkFetch`-adapter) + `downloadDocumentBytes` (`document.downloadContent` → base64 → bytes). **100% täckt.**

## Verifierat
- helper-ui `tsc` rent (type-only `AppRouter`-import + @trpc-typer löser sig)
- 263 helper-ui-tester gröna (coverage-grind ok)
- `deps:check`: 0 brott — type-only-importen tillåts, ingen runtime-server läcker in i helper-bundlen

## Följs av (per ADR:ns Genomförande)
- Steg 2: download-wiring i `/open` + `/content` (klick→öppna-i-native, self-hosted).
- Steg 3: write-back via `uploadContent` (durabla kön lagrar document-descriptorn).
- Steg 4: ta bort REST-antagandet + `downloadUrl`/`uploadUrl`-fälten.

Refs #702

🤖 Generated with [Claude Code](https://claude.com/claude-code)