### PR TITLE
feat(helper): hämta dokument via tRPC downloadContent (ADR 0031 steg 2)

### DIFF
--- a/helper-ui/src/engine/content.ts
+++ b/helper-ui/src/engine/content.ts
@@ -12,27 +12,35 @@
 
 import type { HelperContentRequest } from "@/lib/shared/helper/protocol";
 import type { ContentStore } from "./content-store.ts";
+import { fetchSourceBytes, sourceCacheKey, toSourceRef, type SourceRef } from "./document-source.ts";
 import { parseJsonBody, textError } from "./http.ts";
 import { log } from "./log.ts";
 
 export interface ContentDeps {
-  /** Hämta cachade bytes för download-URL:en, eller null. */
-  load: (downloadUrl: string) => Promise<Uint8Array | null>;
-  /** Ladda ner + cacha vid miss; null om nedladdning misslyckas (offline). */
-  fetchAndCache: (downloadUrl: string, authHeader: string | undefined, fileName: string) => Promise<Uint8Array | null>;
+  /** Hämta cachade bytes för `cacheKey`, eller null. */
+  load: (cacheKey: string) => Promise<Uint8Array | null>;
+  /** Hämta + cacha vid miss; null om hämtning misslyckas (offline). */
+  fetchAndCache: (ref: SourceRef, cacheKey: string, authHeader: string | undefined, fileName: string) => Promise<Uint8Array | null>;
 }
 
 export async function handleContent(req: Request, deps: ContentDeps): Promise<Response> {
   if (req.method !== "POST") return textError(405, "method not allowed");
   const body = await parseJsonBody<HelperContentRequest>(req);
-  if (!body?.downloadUrl) return textError(400, "downloadUrl required");
+  if (body === null) return textError(400, "invalid JSON");
+  const ref = toSourceRef(body);
+  const key = sourceCacheKey(ref);
+  if (!key) return textError(400, "source (document|downloadUrl) required");
 
-  const cached = await deps.load(body.downloadUrl);
+  const cached = await deps.load(key);
   if (cached) return bytesResponse(cached);
 
-  const fetched = await deps.fetchAndCache(body.downloadUrl, body.authHeader, body.fileName ?? fileNameFromUrl(body.downloadUrl));
-  if (fetched) return bytesResponse(fetched);
-  return textError(502, "content unavailable (offline, not cached)");
+  const fetched = await deps.fetchAndCache(ref, key, body.authHeader, contentFileName(body, ref));
+  return fetched ? bytesResponse(fetched) : textError(502, "content unavailable (offline, not cached)");
+}
+
+/** Användarsynligt filnamn: uttryckligt → annars härlett ur statisk URL → fallback. */
+function contentFileName(body: HelperContentRequest, ref: SourceRef): string {
+  return body.fileName ?? (ref.downloadUrl ? fileNameFromUrl(ref.downloadUrl) : "dokument");
 }
 
 function bytesResponse(bytes: Uint8Array): Response {
@@ -65,23 +73,17 @@ export function fileNameFromUrl(url: string): string {
  */
 export async function fetchAndCacheContent(
   store: ContentStore,
-  downloadUrl: string,
+  ref: SourceRef,
+  cacheKey: string,
   authHeader: string | undefined,
   fileName: string,
 ): Promise<Uint8Array | null> {
   try {
-    const headers: Record<string, string> = {};
-    if (authHeader) headers.Authorization = authHeader;
-    const resp = await fetch(downloadUrl, { headers });
-    if (resp.status >= 400) {
-      log(`content: nedladdning ${downloadUrl} → HTTP ${resp.status}`);
-      return null;
-    }
-    const bytes = new Uint8Array(await resp.arrayBuffer());
-    await store.store(downloadUrl, bytes, fileName);
+    const bytes = await fetchSourceBytes(ref, authHeader !== undefined ? { authHeader } : {});
+    await store.store(cacheKey, bytes, fileName);
     return bytes;
   } catch (err) {
-    log(`content: nedladdning misslyckades (${downloadUrl}): ${err instanceof Error ? err.message : String(err)}`);
+    log(`content: hämtning misslyckades (${cacheKey}): ${err instanceof Error ? err.message : String(err)}`);
     return null;
   }
 }

--- a/helper-ui/src/engine/document-source.ts
+++ b/helper-ui/src/engine/document-source.ts
@@ -1,0 +1,71 @@
+/**
+ * `document-source` (ADR 0031) — enad dokument-hämtning för `/open` + `/content`.
+ *
+ * Server-tier: hämta via den typade tRPC-proceduren `document.downloadContent`
+ * (helpern bär sin egna Bearer). Demo/statisk: hämta en blob-URL direkt (ingen
+ * server att tRPC:a mot). Web-appen väljer källa per tier; här grenar vi på vilket
+ * fält som finns. Returnerar alltid rena bytes — anroparen skriver/cachar.
+ */
+
+import type { HelperDocumentRef } from "@/lib/shared/helper/protocol";
+
+import { createDocumentClient, downloadDocumentBytes, type FetchLike } from "./trpc-client.ts";
+
+/** En dokument-källa: tRPC (`document`) ELLER statisk URL (`downloadUrl`). */
+export interface SourceRef {
+  document?: HelperDocumentRef;
+  downloadUrl?: string;
+}
+
+/** Bygg en `SourceRef` ur ett request-objekt (utelämnar undefined-fält, exactOptional). */
+export function toSourceRef(x: { document?: HelperDocumentRef; downloadUrl?: string }): SourceRef {
+  return {
+    ...(x.document ? { document: x.document } : {}),
+    ...(x.downloadUrl ? { downloadUrl: x.downloadUrl } : {}),
+  };
+}
+
+/**
+ * Stabil cache-nyckel för content-lagret: `doc:<id>` i server-tier (oberoende av
+ * URL/origin), annars statisk `downloadUrl`. `null` om ingen källa anges.
+ */
+export function sourceCacheKey(ref: SourceRef): string | null {
+  if (ref.document) return `doc:${ref.document.id}`;
+  return ref.downloadUrl ?? null;
+}
+
+export interface FetchSourceDeps {
+  /** Helperns `Authorization: Bearer …` (tRPC-token härleds, statisk-header sätts). */
+  authHeader?: string;
+  /** Fetch-override (test). Default: global fetch. */
+  fetch?: FetchLike;
+}
+
+/** Hämta dokument-bytes för en källa: tRPC (server) eller statisk URL (demo). */
+export async function fetchSourceBytes(ref: SourceRef, deps: FetchSourceDeps = {}): Promise<Uint8Array> {
+  if (ref.document) return fetchViaTrpc(ref.document, deps);
+  if (!ref.downloadUrl) throw new Error("ingen källa (varken document eller downloadUrl)");
+  return fetchViaUrl(ref.downloadUrl, deps);
+}
+
+/** Server-tier: hämta via den typade tRPC-proceduren `document.downloadContent`. */
+async function fetchViaTrpc(ref: HelperDocumentRef, deps: FetchSourceDeps): Promise<Uint8Array> {
+  // tRPC vill ha rå token; helperns authHeader är "Bearer <token>".
+  const token = (deps.authHeader ?? "").replace(/^Bearer\s+/i, "");
+  const client = createDocumentClient({
+    trpcUrl: ref.trpcUrl,
+    token,
+    ...(deps.fetch ? { fetch: deps.fetch } : {}),
+  });
+  return (await downloadDocumentBytes(client, ref.id)).bytes;
+}
+
+/** Demo/statisk: hämta bytes från en blob-URL (valfri Authorization-header). */
+async function fetchViaUrl(url: string, deps: FetchSourceDeps): Promise<Uint8Array> {
+  const headers: Record<string, string> = {};
+  if (deps.authHeader) headers.Authorization = deps.authHeader;
+  const fetchFn = deps.fetch ?? fetch;
+  const resp = await fetchFn(url, { headers });
+  if (resp.status >= 400) throw new Error(`HTTP ${resp.status}`);
+  return new Uint8Array(await resp.arrayBuffer());
+}

--- a/helper-ui/src/engine/main.ts
+++ b/helper-ui/src/engine/main.ts
@@ -27,13 +27,13 @@ import { loginConfigFromEnv, runLogin, type LoginConfig } from "./auth/login.ts"
 import { handleConfig } from "./config-endpoint.ts";
 import { ContentStore, resolveCacheTtlMs } from "./content-store.ts";
 import { fetchAndCacheContent, handleContent } from "./content.ts";
+import { fetchSourceBytes } from "./document-source.ts";
 import { envWithConfig, loadHelperConfig, saveHelperConfig } from "./helper-config.ts";
 import { installService, uninstallService, type InstallDeps } from "./install.ts";
 import { initLog, log } from "./log.ts";
 import {
   defaultOpenDeps,
   defaultWatchDeps,
-  downloadTo,
   enqueueSavedFile,
   handleOpen,
   persistDownloaded,
@@ -164,14 +164,17 @@ export function queueBackedOnOpen(queue: UploadQueue, content: ContentStore, aut
     browserAuth ?? (authHeader ? await authHeader() : undefined);
   const deps: OpenDeps = {
     ...defaultOpenDeps,
-    download: async (path, url, browserAuth) => downloadTo(path, url, await fallback(browserAuth)),
+    download: async (ref, browserAuth) => {
+      const auth = await fallback(browserAuth);
+      return fetchSourceBytes(ref, auth !== undefined ? { authHeader: auth } : {});
+    },
     startWatch: (path, uploadUrl, authHeaderArg, timeoutMs) =>
       watchAndUpload(path, uploadUrl, authHeaderArg, timeoutMs, {
         ...defaultWatchDeps,
         upload: (p, url, auth) => enqueueSavedFile(queue, p, url, auth),
       }),
-    persist: (url, path, fileName) => persistDownloaded(content, url, path, fileName),
-    restore: (url, path) => restoreCached(content, url, path),
+    persist: (cacheKey, bytes, fileName) => persistDownloaded(content, cacheKey, bytes, fileName),
+    restore: (cacheKey, path) => restoreCached(content, cacheKey, path),
   };
   return (req) => handleOpen(req, deps);
 }
@@ -254,9 +257,9 @@ export function startEngine(opts: EngineOpts = {}): EngineHandle {
           onStatus: () => stores.queue.snapshot(),
           onContent: (req: Request) =>
             handleContent(req, {
-              load: (url) => stores.content.load(url),
-              fetchAndCache: async (url, auth, fileName) =>
-                fetchAndCacheContent(stores.content, url, auth ?? (authHeader ? await authHeader() : undefined), fileName),
+              load: (cacheKey) => stores.content.load(cacheKey),
+              fetchAndCache: async (ref, cacheKey, auth, fileName) =>
+                fetchAndCacheContent(stores.content, ref, cacheKey, auth ?? (authHeader ? await authHeader() : undefined), fileName),
             }),
         }
       : {}),

--- a/helper-ui/src/engine/open.ts
+++ b/helper-ui/src/engine/open.ts
@@ -13,6 +13,7 @@ import { basename, join } from "node:path";
 
 import { isSafeFileName, type HelperOpenRequest } from "@/lib/shared/helper/protocol";
 import type { ContentStore } from "./content-store.ts";
+import { fetchSourceBytes, sourceCacheKey, toSourceRef, type SourceRef } from "./document-source.ts";
 import { json, parseJsonBody, textError } from "./http.ts";
 import { log } from "./log.ts";
 import { openWithDefaultApp } from "./platform/open-app.ts";
@@ -22,18 +23,19 @@ const DEFAULT_WATCH_MINUTES = 60;
 const POLL_INTERVAL_MS = 2_000;
 
 export interface OpenDeps {
-  download: (path: string, url: string, authHeader?: string) => Promise<void>;
+  /** Hämta dokument-bytes för en källa (tRPC server-tier / statisk demo, ADR 0031). */
+  download: (ref: SourceRef, authHeader?: string) => Promise<Uint8Array>;
   openApp: (path: string) => Promise<void>;
   makeSessionDir: () => Promise<string>;
   startWatch: (path: string, uploadUrl: string, authHeader: string | undefined, timeoutMs: number) => void;
-  /** Cacha nedladdade bytes durabelt (offline-reopen, ADR 0028 §3). Valfri. */
-  persist?: (downloadUrl: string, path: string, fileName: string) => Promise<void>;
-  /** Återställ cachade bytes till `path` när nedladdning misslyckas (offline). Valfri. */
-  restore?: (downloadUrl: string, path: string) => Promise<boolean>;
+  /** Cacha nedladdade bytes durabelt under `cacheKey` (offline-reopen, ADR 0028 §3). Valfri. */
+  persist?: (cacheKey: string, bytes: Uint8Array, fileName: string) => Promise<void>;
+  /** Återställ cachade bytes (under `cacheKey`) till `path` när nedladdning misslyckas (offline). Valfri. */
+  restore?: (cacheKey: string, path: string) => Promise<boolean>;
 }
 
 export const defaultOpenDeps: OpenDeps = {
-  download: downloadTo,
+  download: (ref, authHeader) => fetchSourceBytes(ref, authHeader !== undefined ? { authHeader } : {}),
   openApp: openWithDefaultApp,
   makeSessionDir: () => mkdtemp(join(tmpdir(), "ava-helper-")),
   startWatch: watchAndUpload,
@@ -50,7 +52,9 @@ async function parseOpenRequest(req: Request): Promise<HelperOpenRequest | Respo
   if (req.method !== "POST") return textError(405, "method not allowed");
   const body = await parseJsonBody<HelperOpenRequest>(req);
   if (body === null) return textError(400, "invalid JSON");
-  if (!body.downloadUrl || !body.fileName) return textError(400, "downloadUrl and fileName required");
+  if ((!body.downloadUrl && !body.document) || !body.fileName) {
+    return textError(400, "source (document|downloadUrl) and fileName required");
+  }
   if (!isSafeFileName(body.fileName)) return textError(400, "invalid fileName");
   return body;
 }
@@ -75,23 +79,38 @@ async function runOpen(body: HelperOpenRequest, deps: OpenDeps): Promise<Respons
  * Returnerar en fel-Response om filen inte kan skaffas, annars null.
  */
 async function obtainFile(body: HelperOpenRequest, tmpFile: string, deps: OpenDeps): Promise<Response | null> {
+  const ref: SourceRef = toSourceRef(body);
+  const key = sourceCacheKey(ref) ?? "";
+  let bytes: Uint8Array;
   try {
-    await deps.download(tmpFile, body.downloadUrl, body.authHeader);
+    bytes = await deps.download(ref, body.authHeader);
   } catch (err) {
-    if (deps.restore && (await deps.restore(body.downloadUrl, tmpFile))) {
-      log(`offline: öppnar cachad kopia av ${body.fileName}`);
-      return null;
-    }
-    return textError(502, `download failed: ${errMsg(err)}`);
+    return downloadFailureFallback(body, tmpFile, key, deps, err);
   }
-  if (deps.persist) {
-    try {
-      await deps.persist(body.downloadUrl, tmpFile, body.fileName);
-    } catch (err) {
-      log(`content-cache misslyckades (${body.fileName}): ${errMsg(err)}`);
-    }
-  }
+  await writeFile(tmpFile, bytes);
+  await cacheBytes(deps, key, bytes, body.fileName);
   return null;
+}
+
+/** Nedladdning misslyckades → öppna cachad kopia om möjligt (offline), annars 502. */
+async function downloadFailureFallback(
+  body: HelperOpenRequest, tmpFile: string, key: string, deps: OpenDeps, err: unknown,
+): Promise<Response | null> {
+  if (deps.restore && key && (await deps.restore(key, tmpFile))) {
+    log(`offline: öppnar cachad kopia av ${body.fileName}`);
+    return null;
+  }
+  return textError(502, `download failed: ${errMsg(err)}`);
+}
+
+/** Cacha bytsen durabelt (best-effort; ett cache-fel får aldrig fälla öppningen). */
+async function cacheBytes(deps: OpenDeps, key: string, bytes: Uint8Array, fileName: string): Promise<void> {
+  if (!deps.persist || !key) return;
+  try {
+    await deps.persist(key, bytes, fileName);
+  } catch (err) {
+    log(`content-cache misslyckades (${fileName}): ${errMsg(err)}`);
+  }
 }
 
 /** Kör ett IO-steg; null vid framgång, annars en fel-Response. */
@@ -115,15 +134,6 @@ function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-/** GET med valfri Authorization-header → skriv body till `path`. */
-export async function downloadTo(path: string, url: string, authHeader?: string): Promise<void> {
-  const headers: Record<string, string> = {};
-  if (authHeader) headers.Authorization = authHeader;
-  const resp = await fetch(url, { headers });
-  if (resp.status >= 400) throw new Error(`HTTP ${resp.status}`);
-  await writeFile(path, new Uint8Array(await resp.arrayBuffer()));
-}
-
 export async function uploadFile(path: string, uploadUrl: string, authHeader: string | undefined): Promise<void> {
   const headers: Record<string, string> = { "Content-Type": "application/octet-stream" };
   if (authHeader) headers.Authorization = authHeader;
@@ -138,12 +148,11 @@ export async function uploadFile(path: string, uploadUrl: string, authHeader: st
  */
 export async function persistDownloaded(
   store: ContentStore,
-  downloadUrl: string,
-  path: string,
+  cacheKey: string,
+  bytes: Uint8Array,
   fileName: string,
 ): Promise<void> {
-  const bytes = new Uint8Array(await readFile(path));
-  await store.store(downloadUrl, bytes, fileName);
+  await store.store(cacheKey, bytes, fileName);
 }
 
 /**

--- a/helper-ui/test/content.test.ts
+++ b/helper-ui/test/content.test.ts
@@ -32,7 +32,7 @@ describe("handleContent", () => {
     expect(res.status).toBe(405);
   });
 
-  test("kräver downloadUrl", async () => {
+  test("kräver källa (varken document eller downloadUrl)", async () => {
     const res = await handleContent(contentReq({ authHeader: "x" }), base);
     expect(res.status).toBe(400);
   });
@@ -49,11 +49,12 @@ describe("handleContent", () => {
     expect(fetched).toBe(false); // hit → ingen fetch
   });
 
-  test("cache-miss → laddar ner + servar bytsen", async () => {
+  test("cache-miss (statisk) → hämtar via downloadUrl-källan + servar bytsen", async () => {
     const res = await handleContent(contentReq({ downloadUrl: "http://s/d/1", authHeader: "Bearer t" }), {
       load: async () => null,
-      fetchAndCache: async (url, auth) => {
-        expect(url).toBe("http://s/d/1");
+      fetchAndCache: async (ref, cacheKey, auth) => {
+        expect(ref.downloadUrl).toBe("http://s/d/1");
+        expect(cacheKey).toBe("http://s/d/1"); // demo: nyckel = URL
         expect(auth).toBe("Bearer t");
         return bytes("nedladdat");
       },
@@ -62,7 +63,23 @@ describe("handleContent", () => {
     expect(await res.text()).toBe("nedladdat");
   });
 
-  test("miss + offline (nedladdning ger null) → 502", async () => {
+  test("document-källa (server-tier) → cache-nyckel doc:<id>, ref vidarebefordras", async () => {
+    let seenKey = "";
+    let seenId = "";
+    const res = await handleContent(contentReq({ document: { id: "abc", trpcUrl: "http://s/api/trpc" } }), {
+      load: async () => null,
+      fetchAndCache: async (ref, cacheKey) => {
+        seenKey = cacheKey;
+        seenId = ref.document?.id ?? "";
+        return bytes("trpc-bytes");
+      },
+    });
+    expect(res.status).toBe(200);
+    expect(seenKey).toBe("doc:abc");
+    expect(seenId).toBe("abc");
+  });
+
+  test("miss + offline (hämtning ger null) → 502", async () => {
     const res = await handleContent(contentReq({ downloadUrl: "http://s/d/1" }), base);
     expect(res.status).toBe(502);
   });
@@ -71,7 +88,7 @@ describe("handleContent", () => {
     let seenName = "";
     await handleContent(contentReq({ downloadUrl: "http://s/api/documents/9/download" }), {
       load: async () => null,
-      fetchAndCache: async (_url, _auth, fileName) => { seenName = fileName; return bytes("x"); },
+      fetchAndCache: async (_ref, _key, _auth, fileName) => { seenName = fileName; return bytes("x"); },
     });
     expect(seenName).toBe("download"); // sista segmentet
   });
@@ -112,7 +129,7 @@ describe("fetchAndCacheContent", () => {
       return new Response("hämtat", { status: 200 });
     });
     try {
-      const got = await fetchAndCacheContent(s, "http://s/d/1", "Bearer t", "a.pdf");
+      const got = await fetchAndCacheContent(s, { downloadUrl: "http://s/d/1" }, "http://s/d/1", "Bearer t", "a.pdf");
       expect(new TextDecoder().decode(got!)).toBe("hämtat");
       // cachat → en andra load (utan nät) ger samma bytes
       expect(new TextDecoder().decode((await s.load("http://s/d/1"))!)).toBe("hämtat");
@@ -123,7 +140,7 @@ describe("fetchAndCacheContent", () => {
     const s = await store();
     const restore = mockFetch(() => new Response("nope", { status: 404 }));
     try {
-      expect(await fetchAndCacheContent(s, "http://s/d/1", undefined, "a.pdf")).toBeNull();
+      expect(await fetchAndCacheContent(s, { downloadUrl: "http://s/d/1" }, "http://s/d/1", undefined, "a.pdf")).toBeNull();
       expect(await s.has("http://s/d/1")).toBe(false);
     } finally { restore(); }
   });
@@ -132,7 +149,7 @@ describe("fetchAndCacheContent", () => {
     const s = await store();
     const restore = mockFetch(() => { throw new Error("ECONNREFUSED"); });
     try {
-      expect(await fetchAndCacheContent(s, "http://s/d/1", undefined, "a.pdf")).toBeNull();
+      expect(await fetchAndCacheContent(s, { downloadUrl: "http://s/d/1" }, "http://s/d/1", undefined, "a.pdf")).toBeNull();
     } finally { restore(); }
   });
 });

--- a/helper-ui/test/io.test.ts
+++ b/helper-ui/test/io.test.ts
@@ -1,9 +1,10 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, describe, expect, test } from "bun:test";
 
-import { downloadTo, uploadFile } from "../src/engine/open.ts";
+import { fetchSourceBytes } from "../src/engine/document-source.ts";
+import { uploadFile } from "../src/engine/open.ts";
 import { expectRejection } from "./helpers.ts";
 
 const dirs: string[] = [];
@@ -17,13 +18,12 @@ async function tmpFile(name: string): Promise<string> {
   return join(dir, name);
 }
 
-describe("downloadTo (integration)", () => {
-  test("laddar ner body till fil", async () => {
+describe("fetchSourceBytes (statisk källa, integration)", () => {
+  test("hämtar bytes från downloadUrl", async () => {
     const server = Bun.serve({ port: 0, fetch: () => new Response("PDF-bytes") });
     try {
-      const path = await tmpFile("a.pdf");
-      await downloadTo(path, `http://127.0.0.1:${server.port}/f`);
-      expect(await readFile(path, "utf8")).toBe("PDF-bytes");
+      const got = await fetchSourceBytes({ downloadUrl: `http://127.0.0.1:${server.port}/f` });
+      expect(new TextDecoder().decode(got)).toBe("PDF-bytes");
     } finally {
       void server.stop(true);
     }
@@ -39,7 +39,7 @@ describe("downloadTo (integration)", () => {
       },
     });
     try {
-      await downloadTo(await tmpFile("b.txt"), `http://127.0.0.1:${server.port}/f`, "Bearer tok");
+      await fetchSourceBytes({ downloadUrl: `http://127.0.0.1:${server.port}/f` }, { authHeader: "Bearer tok" });
       expect(cap.auth).toBe("Bearer tok");
     } finally {
       void server.stop(true);
@@ -49,7 +49,7 @@ describe("downloadTo (integration)", () => {
   test("HTTP >= 400 → kastar", async () => {
     const server = Bun.serve({ port: 0, fetch: () => new Response("no", { status: 404 }) });
     try {
-      const err = await expectRejection(downloadTo(await tmpFile("c.txt"), `http://127.0.0.1:${server.port}/f`));
+      const err = await expectRejection(fetchSourceBytes({ downloadUrl: `http://127.0.0.1:${server.port}/f` }));
       expect(String(err)).toContain("HTTP 404");
     } finally {
       void server.stop(true);

--- a/helper-ui/test/open.test.ts
+++ b/helper-ui/test/open.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, describe, expect, test } from "bun:test";
@@ -8,24 +8,32 @@ import { enqueueSavedFile, handleOpen, persistDownloaded, restoreCached, type Op
 import { UploadQueue } from "../src/engine/queue.ts";
 import { jsonRequest } from "./helpers.ts";
 
+const sessionDirs: string[] = [];
+afterAll(async () => { await Promise.all(sessionDirs.map((d) => rm(d, { recursive: true, force: true }))); });
+
 interface Recorder {
-  downloaded: string[];
+  sessionDir: string;
+  downloaded: string[]; // källnyckel (downloadUrl eller doc:<id>)
   opened: string[];
   watched: Array<{ path: string; uploadUrl: string; timeoutMs: number }>;
   deps: OpenDeps;
 }
 
 function recorder(overrides: Partial<OpenDeps> = {}): Recorder {
-  const rec: Recorder = {
-    downloaded: [],
-    opened: [],
-    watched: [],
-    deps: {} as OpenDeps,
-  };
+  const rec: Recorder = { sessionDir: "", downloaded: [], opened: [], watched: [], deps: {} as OpenDeps };
   rec.deps = {
-    download: async (path) => { rec.downloaded.push(path); },
+    // Returnerar bytes (ADR 0031); obtainFile skriver filen.
+    download: async (ref) => {
+      rec.downloaded.push(ref.downloadUrl ?? `doc:${ref.document?.id ?? ""}`);
+      return new TextEncoder().encode("DL");
+    },
     openApp: async (path) => { rec.opened.push(path); },
-    makeSessionDir: async () => "/tmp/ava-session",
+    makeSessionDir: async () => {
+      const d = await mkdtemp(join(tmpdir(), "ava-open-"));
+      sessionDirs.push(d);
+      rec.sessionDir = d;
+      return d;
+    },
     startWatch: (path, uploadUrl, _auth, timeoutMs) => { rec.watched.push({ path, uploadUrl, timeoutMs }); },
     ...overrides,
   };
@@ -37,16 +45,28 @@ function openReq(body: unknown): Request {
 }
 
 describe("handleOpen", () => {
-  test("laddar ner + öppnar + svarar 200 med path", async () => {
+  test("hämtar + öppnar + svarar 200 med path (statisk källa)", async () => {
     const rec = recorder();
     const res = await handleOpen(openReq({ downloadUrl: "http://x/f", fileName: "a.pdf" }), rec.deps);
     expect(res.status).toBe(200);
     const body = (await res.json()) as { path: string; status: string };
     expect(body.status).toBe("opened");
-    expect(body.path).toBe("/tmp/ava-session/a.pdf");
-    expect(rec.downloaded).toEqual(["/tmp/ava-session/a.pdf"]);
-    expect(rec.opened).toEqual(["/tmp/ava-session/a.pdf"]);
+    expect(body.path).toBe(join(rec.sessionDir, "a.pdf"));
+    expect(rec.downloaded).toEqual(["http://x/f"]);
+    expect(rec.opened).toEqual([join(rec.sessionDir, "a.pdf")]);
     expect(rec.watched).toHaveLength(0);
+    // Filen skrevs till disk med de hämtade bytsen.
+    expect(await readFile(join(rec.sessionDir, "a.pdf"), "utf8")).toBe("DL");
+  });
+
+  test("document-källa (server-tier, tRPC) → download får ref.document", async () => {
+    const rec = recorder();
+    const res = await handleOpen(
+      openReq({ document: { id: "doc-7", trpcUrl: "http://s/api/trpc" }, fileName: "a.pdf" }),
+      rec.deps,
+    );
+    expect(res.status).toBe(200);
+    expect(rec.downloaded).toEqual(["doc:doc-7"]);
   });
 
   test("startar watch när uploadUrl satt (default 60 min)", async () => {
@@ -65,13 +85,13 @@ describe("handleOpen", () => {
     expect(rec.watched[0]?.timeoutMs).toBe(5 * 60_000);
   });
 
-  test("kräver downloadUrl + fileName", async () => {
+  test("kräver källa + fileName", async () => {
     const rec = recorder();
     const res = await handleOpen(openReq({ fileName: "a.pdf" }), rec.deps);
     expect(res.status).toBe(400);
   });
 
-  test("502 vid nedladdningsfel", async () => {
+  test("502 vid hämtningsfel", async () => {
     const rec = recorder({ download: async () => { throw new Error("HTTP 404"); } });
     const res = await handleOpen(openReq({ downloadUrl: "http://x/f", fileName: "a.pdf" }), rec.deps);
     expect(res.status).toBe(502);
@@ -86,27 +106,29 @@ describe("handleOpen", () => {
 });
 
 describe("offline content-cache (ADR 0028 §3)", () => {
-  test("cachar nedladdade bytes via persist", async () => {
-    const persisted: Array<{ url: string; path: string; fileName: string }> = [];
+  test("cachar hämtade bytes via persist (nyckel + bytes)", async () => {
+    const persisted: Array<{ cacheKey: string; fileName: string; content: string }> = [];
     const rec = recorder({
-      persist: async (url, path, fileName) => { persisted.push({ url, path, fileName }); },
+      persist: async (cacheKey, bytes, fileName) => {
+        persisted.push({ cacheKey, fileName, content: new TextDecoder().decode(bytes) });
+      },
     });
     const res = await handleOpen(openReq({ downloadUrl: "http://x/f", fileName: "a.pdf" }), rec.deps);
     expect(res.status).toBe(200);
-    expect(persisted).toEqual([{ url: "http://x/f", path: "/tmp/ava-session/a.pdf", fileName: "a.pdf" }]);
+    expect(persisted).toEqual([{ cacheKey: "http://x/f", fileName: "a.pdf", content: "DL" }]);
   });
 
-  test("nedladdning misslyckas men cache finns → öppnar cachad kopia (offline)", async () => {
+  test("hämtning misslyckas men cache finns → öppnar cachad kopia (offline)", async () => {
     const rec = recorder({
       download: async () => { throw new Error("offline"); },
       restore: async () => true,
     });
     const res = await handleOpen(openReq({ downloadUrl: "http://x/f", fileName: "a.pdf" }), rec.deps);
     expect(res.status).toBe(200);
-    expect(rec.opened).toEqual(["/tmp/ava-session/a.pdf"]); // öppnades trots download-fel
+    expect(rec.opened).toEqual([join(rec.sessionDir, "a.pdf")]); // öppnades trots hämtningsfel
   });
 
-  test("nedladdning misslyckas + ingen cache → 502", async () => {
+  test("hämtning misslyckas + ingen cache → 502", async () => {
     const rec = recorder({
       download: async () => { throw new Error("offline"); },
       restore: async () => false,
@@ -128,18 +150,16 @@ describe("persistDownloaded + restoreCached", () => {
   const dirs: string[] = [];
   afterAll(async () => { await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true }))); });
 
-  test("round-trip: persist en nedladdad fil, restore till ny path", async () => {
+  test("round-trip: persist hämtade bytes under nyckel, restore till ny path", async () => {
     const work = await mkdtemp(join(tmpdir(), "ava-dl-"));
     const cdir = await mkdtemp(join(tmpdir(), "ava-cs-"));
     dirs.push(work, cdir);
-    const dl = join(work, "doc.pdf");
-    await writeFile(dl, "nedladdat innehåll", "utf8");
 
     const store = new ContentStore(cdir);
-    await persistDownloaded(store, "http://s/d/1", dl, "doc.pdf");
+    await persistDownloaded(store, "doc:1", new TextEncoder().encode("nedladdat innehåll"), "doc.pdf");
 
     const out = join(work, "restored.pdf");
-    const ok = await restoreCached(store, "http://s/d/1", out);
+    const ok = await restoreCached(store, "doc:1", out);
     expect(ok).toBe(true);
     expect(await Bun.file(out).text()).toBe("nedladdat innehåll");
   });
@@ -148,7 +168,7 @@ describe("persistDownloaded + restoreCached", () => {
     const cdir = await mkdtemp(join(tmpdir(), "ava-cs-"));
     dirs.push(cdir);
     const store = new ContentStore(cdir);
-    expect(await restoreCached(store, "http://s/saknas", join(cdir, "x"))).toBe(false);
+    expect(await restoreCached(store, "doc:saknas", join(cdir, "x"))).toBe(false);
   });
 });
 

--- a/src/lib/client/firma/open-document-externally.ts
+++ b/src/lib/client/firma/open-document-externally.ts
@@ -20,6 +20,7 @@
 
 import type { ModalState } from "@/components/documents/external-edit-modal";
 import { openViaHelper } from "@/lib/client/helper/use-helper";
+import type { HelperOpenRequest } from "@/lib/shared/helper/protocol";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 
 interface Doc {
@@ -44,27 +45,28 @@ const DEFAULT_DEMO_REPO_FALLBACK = "ulrik-s/ava-demo";
  * AVA-backend som körs (git-http eller REST). Helpern är tier-agnostisk.
  */
 export async function tryHelperOpen(doc: Doc): Promise<boolean> {
-  // openViaHelper löser transporten (https→http, ADR 0006) och kastar om
-  // helpern saknas → vi fångar och faller tillbaka. Beräkna download/upload-URLs. För git-tier serverar nginx (eller
-  // demo-build) filerna under storagePath. För Postgres-tier blir det
-  // /api/documents/<id>/download. Vi använder befintliga konstruktioner.
+  // openViaHelper löser transporten (https→http, ADR 0006) och kastar om helpern
+  // saknas → vi fångar och faller tillbaka. Källan väljs per tier (ADR 0031):
+  //   - server-tier: `document`-descriptor → helpern hämtar via tRPC
+  //     `document.downloadContent` med sin EGNA Bearer (typat, ingen REST-yta).
+  //   - demo: statisk GH-Pages-blob-URL (ingen server att tRPC:a mot).
+  // Write-back (uploadUrl) är ännu inte påkopplad i server-tier (ADR 0031 steg 3).
   const isDemo = process.env.NEXT_PUBLIC_DEMO_BUILD === "1";
-  const downloadUrl = isDemo ? demoUrl(doc) : `/api/documents/${doc.id}/download`;
-  // Skicka absolute URL — helpern kör utanför browser-sessionen och
-  // har ingen referens till "origin".
-  const absDownload = downloadUrl.startsWith("http") ? downloadUrl : new URL(downloadUrl, window.location.origin).toString();
-  const uploadUrl = isDemo ? undefined : new URL(`/api/documents/${doc.id}/upload`, window.location.origin).toString();
+  const req: HelperOpenRequest = isDemo
+    ? { fileName: doc.fileName, downloadUrl: demoUrl(doc) }
+    : { fileName: doc.fileName, document: { id: doc.id, trpcUrl: helperTrpcUrl() } };
   try {
-    await openViaHelper({
-      fileName: doc.fileName,
-      downloadUrl: absDownload,
-      ...omitUndefined({ uploadUrl }),
-    });
+    await openViaHelper(req);
     return true;
   } catch (err) {
     console.warn("[helper] /open misslyckades, fallback:", err);
     return false;
   }
+}
+
+/** Serverns tRPC-endpoint på nuvarande origin (helpern bär sin egna Bearer). */
+function helperTrpcUrl(): string {
+  return new URL("/api/trpc", window.location.origin).toString();
 }
 
 function demoUrl(doc: Doc): string {

--- a/src/lib/client/firma/open-matter-document.ts
+++ b/src/lib/client/firma/open-matter-document.ts
@@ -31,11 +31,12 @@ export async function openMatterDocument(doc: OpenableDoc): Promise<void> {
     const { fetchContentViaHelper } = await import("@/lib/client/helper/use-helper");
     const client = createServerDownloadClient();
     const fileName = doc.fileName ?? doc.id;
+    const trpcUrl = new URL("/api/trpc", window.location.origin).toString();
     fetchBlob = async () => {
       // Föredra helpern (durabelt, offline-ok, samma lokala lager som extern-
       // editor-öppning) → annars server-vägen + IndexedDB-cache (ADR 0028 §5).
-      const downloadUrl = new URL(`/api/documents/${doc.id}/download`, window.location.origin).toString();
-      const viaHelper = await fetchContentViaHelper({ downloadUrl, fileName });
+      // Server-tier: helpern hämtar via tRPC document.downloadContent (ADR 0031).
+      const viaHelper = await fetchContentViaHelper({ document: { id: doc.id, trpcUrl }, fileName });
       if (viaHelper) return new Blob([viaHelper as BlobPart], { type: mimeFromName(fileName) });
       return loadDocumentBlob(client, { id: doc.id, storagePath: doc.storagePath ?? null, fileName });
     };

--- a/src/lib/shared/helper/protocol.ts
+++ b/src/lib/shared/helper/protocol.ts
@@ -31,17 +31,34 @@ export const HELPER_HTTPS_BASE = `https://localhost:${HELPER_HTTPS_PORT}`;
 export const HELPER_PING_PREFIX = "ava-helper";
 
 /**
- * `POST /open` — be helpern ladda ner en fil, öppna den i OS:ets
- * default-app och (om `uploadUrl` satt) synka tillbaka ändringar.
+ * Hur helpern hämtar dokument-bytes (ADR 0031). EXAKT en källa anges:
+ *   - `document` (server-tier): hämta via tRPC `document.downloadContent` mot
+ *     `trpcUrl`; helpern bär sin EGNA Bearer (OIDC). Typat kontrakt, ingen REST.
+ *   - `downloadUrl` (demo): statisk blob-URL (ingen server att tRPC:a mot).
+ * Web-appen väljer per tier; helpern grenar på vilket fält som finns.
+ */
+export interface HelperDocumentRef {
+  /** Dokumentets id (input till `document.downloadContent`/`uploadContent`). */
+  id: string;
+  /** Serverns tRPC-endpoint, t.ex. `http://localhost:8080/api/trpc`. */
+  trpcUrl: string;
+}
+
+/**
+ * `POST /open` — be helpern hämta en fil, öppna den i OS:ets default-app och
+ * (om write-back är på) synka tillbaka ändringar. Källan är `document` (tRPC,
+ * server-tier) ELLER `downloadUrl` (statisk, demo).
  */
 export interface HelperOpenRequest {
-  /** Varifrån fil-bytsen laddas ner. */
-  downloadUrl: string;
-  /** Vart ändrade bytes PUT:as efter save. Utelämnad → read-only. */
+  /** Server-tier: hämta via tRPC (ADR 0031). Utesluter `downloadUrl`. */
+  document?: HelperDocumentRef;
+  /** Demo/statisk: varifrån fil-bytsen laddas ner. Utesluter `document`. */
+  downloadUrl?: string;
+  /** Vart ändrade bytes PUT:as efter save (demo/statisk). Utelämnad → read-only. */
   uploadUrl?: string;
   /** Namnet användaren ser i editorn. */
   fileName: string;
-  /** Vidarebefordras orörd till download + upload. */
+  /** Vidarebefordras orörd till download + upload (statisk väg). */
   authHeader?: string;
   /** Hur länge helpern lyssnar på save-events. Default 60 min. */
   maxWatchMinutes?: number;
@@ -106,9 +123,11 @@ export interface HelperConfigRequest {
  * mot extern-editor-öppningar.
  */
 export interface HelperContentRequest {
-  /** Varifrån bytsen laddas (identifierar dokument+version) — även cache-nyckel. */
-  downloadUrl: string;
-  /** Vidarebefordras orörd till nedladdning vid cache-miss. */
+  /** Server-tier: hämta via tRPC (ADR 0031). Utesluter `downloadUrl`. */
+  document?: HelperDocumentRef;
+  /** Demo/statisk: varifrån bytsen laddas — även cache-nyckel. Utesluter `document`. */
+  downloadUrl?: string;
+  /** Vidarebefordras orörd till nedladdning vid cache-miss (statisk väg). */
   authHeader?: string;
   /** Användarsynligt filnamn (för helperns logg/cache-metadata). */
   fileName?: string;


### PR DESCRIPTION
## Vad
ADR 0031 **steg 2**: helperns läs-väg (`/open` + `/content`) hämtar dokument-bytes via den **typade tRPC-proceduren `document.downloadContent`** i server-tier — ingen bespoke REST. Demo behåller statisk blob-URL (ingen server att tRPC:a mot).

- **protokoll**: `HelperOpenRequest`/`HelperContentRequest` får `document?: {id, trpcUrl}` vid sidan av `downloadUrl` (demo); exakt en källa anges.
- **`engine/document-source.ts`** (ny): `fetchSourceBytes` (`fetchViaTrpc` / `fetchViaUrl`) + `toSourceRef` + `sourceCacheKey` (`doc:<id>` resp. `downloadUrl`).
- **`open.ts`**: download-dep returnerar **bytes** (källa-medvetet); `obtainFile` skriver + cachar (extraherade `downloadFailureFallback`/`cacheBytes` för komplexitet ≤8).
- **`content.ts`** + **`main.ts`**: källa-medvetna; wiring via `fetchSourceBytes` + cacheKey.
- **web**: `tryHelperOpen` + `open-matter-document` skickar `document`-descriptor i server-tier (read-only tills steg 3 — write-back), `downloadUrl` i demo.

## Verifierat
- helper-ui `tsc` + **265 tester** (coverage-grind), main `tsc`, web helper-tester, `deps:check` 0 brott, bundle.
- **LIVE end-to-end** mot self-hosted-stacken: `POST /content` med `{document:{id,trpcUrl}}` → **HTTP 200, äkta `%PDF-1.7`-bytes** via tRPC `downloadContent` + oauth2-proxy-Bearer (verifierat 202).

## Följs av
- Steg 3: write-back via `document.uploadContent` (durabla kön lagrar descriptorn).
- Steg 4: ta bort REST-antagandet + `downloadUrl`/`uploadUrl` när inget använder dem.

Closes #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)