### PR TITLE
fix(helper): tryHelperOpen väljer tier på runtime, inte bygg-flagga

### DIFF
--- a/helper-ui/src/engine/open.ts
+++ b/helper-ui/src/engine/open.ts
@@ -96,6 +96,7 @@ async function obtainFile(body: HelperOpenRequest, tmpFile: string, deps: OpenDe
 async function downloadFailureFallback(
   body: HelperOpenRequest, tmpFile: string, key: string, deps: OpenDeps, err: unknown,
 ): Promise<Response | null> {
+  log(`/open hämtning misslyckades (${body.fileName}, key=${key}): ${errMsg(err)}`);
   if (deps.restore && key && (await deps.restore(key, tmpFile))) {
     log(`offline: öppnar cachad kopia av ${body.fileName}`);
     return null;

--- a/src/lib/client/firma/open-document-externally.ts
+++ b/src/lib/client/firma/open-document-externally.ts
@@ -19,9 +19,16 @@
  */
 
 import type { ModalState } from "@/components/documents/external-edit-modal";
+import { loadFirmaConfig } from "@/lib/client/firma/firma-config";
 import { openViaHelper } from "@/lib/client/helper/use-helper";
 import type { HelperOpenRequest } from "@/lib/shared/helper/protocol";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
+
+/** Runtime-tier-beslut (ej bygg-tids-NEXT_PUBLIC_DEMO_BUILD, som är sant även i
+ *  den lokala self-hosted-builden → länkade fel till GH Pages). Se #651. */
+function isDemoTier(): boolean {
+  return loadFirmaConfig().tier === "demo";
+}
 
 interface Doc {
   id: string;
@@ -51,8 +58,7 @@ export async function tryHelperOpen(doc: Doc): Promise<boolean> {
   //     `document.downloadContent` med sin EGNA Bearer (typat, ingen REST-yta).
   //   - demo: statisk GH-Pages-blob-URL (ingen server att tRPC:a mot).
   // Write-back (uploadUrl) är ännu inte påkopplad i server-tier (ADR 0031 steg 3).
-  const isDemo = process.env.NEXT_PUBLIC_DEMO_BUILD === "1";
-  const req: HelperOpenRequest = isDemo
+  const req: HelperOpenRequest = isDemoTier()
     ? { fileName: doc.fileName, downloadUrl: demoUrl(doc) }
     : { fileName: doc.fileName, document: { id: doc.id, trpcUrl: helperTrpcUrl() } };
   try {
@@ -80,7 +86,7 @@ export async function runExternalEdit(doc: Doc): Promise<ModalState> {
   const { openInFinder } = await import("@/lib/client/fsa/open-in-finder");
   const { getExternalEditTracker } = await import("@/lib/client/fsa/external-edit-tracker");
 
-  const fallbackBase = process.env.NEXT_PUBLIC_DEMO_BUILD === "1"
+  const fallbackBase = isDemoTier()
     ? (() => {
         const repo = process.env.NEXT_PUBLIC_DEMO_REPO || process.env.NEXT_PUBLIC_DEFAULT_DEMO_REPO || DEFAULT_DEMO_REPO_FALLBACK;
         const m = repo.match(/^([^/\s]+)\/([^/\s]+)$/);


### PR DESCRIPTION
## Root cause (live-diagnostiserat)
I self-hosted-local (byggd med `build:demo`) är `NEXT_PUBLIC_DEMO_BUILD="1"`. `tryHelperOpen` använde den **bygg-tids-flaggan** för sitt `isDemo`-beslut → tog DEMO-grenen → skickade en GH-Pages-URL till helpern:

```
/open hämtning misslyckades (Avtal 2026-0014.docx,
  key=https://ulrik-s.github.io/ava-demo/.../doc-docx-14.docx): HTTP 404
```

→ helpern 404:ade → `/open` 502 → klick på .docx/.pdf föll tillbaka till nedladdning/flik i stället för att öppna i Word/PDF Gear. `/content` använde redan runtime-tiern (`loadFirmaConfig().tier`) och fungerade — därför var **bara** native-öppningen trasig.

Exakt den fälla `open-matter-document.ts` (#651) varnar för i sin header.

## Fix
- `open-document-externally`: `isDemoTier()` = `loadFirmaConfig().tier === "demo"` (runtime) för `tryHelperOpen` **och** `runExternalEdit`-fallbackBase.
- `open.ts`: logga `/open`-hämtningsfel (`downloadFailureFallback`) — var tyst (502 utan logg), vilket gjorde buggen svårdebuggad.

## Verifierat
- main `tsc`, 25 web helper-tester gröna.
- Live: helper-logg visade 404 mot GH-demo-URL (orsaken); `/open` + tRPC-hämtning bekräftat fungera i self-hosted (curl → 200 + Word öppnades).

Efter merge: bygg om `out/` → klick på .docx/.pdf öppnar i native-app i self-hosted.

Closes #706

🤖 Generated with [Claude Code](https://claude.com/claude-code)