### PR TITLE
feat(helper): write-back via tRPC document.uploadContent (ADR 0031 steg 3)

### DIFF
--- a/helper-ui/src/engine/document-source.ts
+++ b/helper-ui/src/engine/document-source.ts
@@ -9,7 +9,7 @@
 
 import type { HelperDocumentRef } from "@/lib/shared/helper/protocol";
 
-import { createDocumentClient, downloadDocumentBytes, type FetchLike } from "./trpc-client.ts";
+import { createDocumentClient, downloadDocumentBytes, uploadDocumentBytes, type FetchLike } from "./trpc-client.ts";
 
 /** En dokument-källa: tRPC (`document`) ELLER statisk URL (`downloadUrl`). */
 export interface SourceRef {
@@ -68,4 +68,31 @@ async function fetchViaUrl(url: string, deps: FetchSourceDeps): Promise<Uint8Arr
   const resp = await fetchFn(url, { headers });
   if (resp.status >= 400) throw new Error(`HTTP ${resp.status}`);
   return new Uint8Array(await resp.arrayBuffer());
+}
+
+/** Ett upload-mål (write-back): tRPC-dokument (server) ELLER PUT-URL (demo). */
+export interface UploadTarget {
+  document?: HelperDocumentRef;
+  uploadUrl?: string;
+}
+
+/** Stabil kö-/cache-nyckel för ett upload-mål (matchar `sourceCacheKey`). */
+export function uploadTargetKey(t: UploadTarget): string | null {
+  if (t.document) return `doc:${t.document.id}`;
+  return t.uploadUrl ?? null;
+}
+
+/** Skriv tillbaka dokument-bytes via tRPC `document.uploadContent` (server-tier). */
+export async function uploadViaTrpc(
+  document: HelperDocumentRef,
+  bytes: Uint8Array,
+  deps: FetchSourceDeps = {},
+): Promise<void> {
+  const token = (deps.authHeader ?? "").replace(/^Bearer\s+/i, "");
+  const client = createDocumentClient({
+    trpcUrl: document.trpcUrl,
+    token,
+    ...(deps.fetch ? { fetch: deps.fetch } : {}),
+  });
+  await uploadDocumentBytes(client, document.id, bytes);
 }

--- a/helper-ui/src/engine/main.ts
+++ b/helper-ui/src/engine/main.ts
@@ -168,10 +168,10 @@ export function queueBackedOnOpen(queue: UploadQueue, content: ContentStore, aut
       const auth = await fallback(browserAuth);
       return fetchSourceBytes(ref, auth !== undefined ? { authHeader: auth } : {});
     },
-    startWatch: (path, uploadUrl, authHeaderArg, timeoutMs) =>
-      watchAndUpload(path, uploadUrl, authHeaderArg, timeoutMs, {
+    startWatch: (path, target, authHeaderArg, timeoutMs) =>
+      watchAndUpload(path, target, authHeaderArg, timeoutMs, {
         ...defaultWatchDeps,
-        upload: (p, url, auth) => enqueueSavedFile(queue, p, url, auth),
+        upload: (p, t, auth) => enqueueSavedFile(queue, p, t, auth),
       }),
     persist: (cacheKey, bytes, fileName) => persistDownloaded(content, cacheKey, bytes, fileName),
     restore: (cacheKey, path) => restoreCached(content, cacheKey, path),

--- a/helper-ui/src/engine/open.ts
+++ b/helper-ui/src/engine/open.ts
@@ -13,7 +13,7 @@ import { basename, join } from "node:path";
 
 import { isSafeFileName, type HelperOpenRequest } from "@/lib/shared/helper/protocol";
 import type { ContentStore } from "./content-store.ts";
-import { fetchSourceBytes, sourceCacheKey, toSourceRef, type SourceRef } from "./document-source.ts";
+import { fetchSourceBytes, sourceCacheKey, toSourceRef, uploadViaTrpc, type SourceRef, type UploadTarget } from "./document-source.ts";
 import { json, parseJsonBody, textError } from "./http.ts";
 import { log } from "./log.ts";
 import { openWithDefaultApp } from "./platform/open-app.ts";
@@ -27,7 +27,7 @@ export interface OpenDeps {
   download: (ref: SourceRef, authHeader?: string) => Promise<Uint8Array>;
   openApp: (path: string) => Promise<void>;
   makeSessionDir: () => Promise<string>;
-  startWatch: (path: string, uploadUrl: string, authHeader: string | undefined, timeoutMs: number) => void;
+  startWatch: (path: string, target: UploadTarget, authHeader: string | undefined, timeoutMs: number) => void;
   /** Cacha nedladdade bytes durabelt under `cacheKey` (offline-reopen, ADR 0028 §3). Valfri. */
   persist?: (cacheKey: string, bytes: Uint8Array, fileName: string) => Promise<void>;
   /** Återställ cachade bytes (under `cacheKey`) till `path` när nedladdning misslyckas (offline). Valfri. */
@@ -125,10 +125,16 @@ async function tryStep(fn: () => Promise<void>, status: number, label: string): 
 }
 
 function startWatchIfNeeded(body: HelperOpenRequest, tmpFile: string, deps: OpenDeps): void {
-  if (!body.uploadUrl) return;
+  // Write-back-mål: tRPC-dokument (server, ADR 0031) ELLER PUT-URL (demo).
+  const target: UploadTarget | null = body.document
+    ? { document: body.document }
+    : body.uploadUrl
+      ? { uploadUrl: body.uploadUrl }
+      : null;
+  if (!target) return;
   const m = body.maxWatchMinutes;
   const minutes = m !== undefined && m > 0 ? m : DEFAULT_WATCH_MINUTES;
-  deps.startWatch(tmpFile, body.uploadUrl, body.authHeader, minutes * 60_000);
+  deps.startWatch(tmpFile, target, body.authHeader, minutes * 60_000);
 }
 
 function errMsg(err: unknown): string {
@@ -140,6 +146,21 @@ export async function uploadFile(path: string, uploadUrl: string, authHeader: st
   if (authHeader) headers.Authorization = authHeader;
   const resp = await fetch(uploadUrl, { method: "PUT", headers, body: new Blob([new Uint8Array(await readFile(path))]) });
   if (resp.status >= 400) throw new Error(`upload HTTP ${resp.status}`);
+}
+
+/**
+ * Ladda upp en sparad fil till sitt mål (ADR 0031): server-tier via tRPC
+ * `document.uploadContent`, demo via PUT. Default-upload när ingen durabel kö
+ * är wirad (annars köas via `enqueueSavedFile`).
+ */
+export async function uploadSavedFile(path: string, target: UploadTarget, authHeader: string | undefined): Promise<void> {
+  if (target.document) {
+    const bytes = new Uint8Array(await readFile(path));
+    await uploadViaTrpc(target.document, bytes, authHeader !== undefined ? { authHeader } : {});
+    return;
+  }
+  if (!target.uploadUrl) throw new Error("inget upload-mål");
+  await uploadFile(path, target.uploadUrl, authHeader);
 }
 
 /**
@@ -178,11 +199,17 @@ export async function restoreCached(store: ContentStore, downloadUrl: string, pa
 export async function enqueueSavedFile(
   queue: UploadQueue,
   path: string,
-  uploadUrl: string,
+  target: UploadTarget,
   authHeader: string | undefined,
 ): Promise<void> {
   const bytes = new Uint8Array(await readFile(path));
-  await queue.enqueue({ uploadUrl, fileName: basename(path), bytes, ...(authHeader !== undefined ? { authHeader } : {}) });
+  await queue.enqueue({
+    ...(target.document ? { document: target.document } : {}),
+    ...(target.uploadUrl !== undefined ? { uploadUrl: target.uploadUrl } : {}),
+    fileName: basename(path),
+    bytes,
+    ...(authHeader !== undefined ? { authHeader } : {}),
+  });
 }
 
 /**
@@ -191,35 +218,35 @@ export async function enqueueSavedFile(
  */
 export interface WatchDeps {
   statMtime: (path: string) => Promise<number | null>;
-  upload: (path: string, uploadUrl: string, authHeader: string | undefined) => Promise<void>;
+  upload: (path: string, target: UploadTarget, authHeader: string | undefined) => Promise<void>;
   sleep: (ms: number) => Promise<void>;
   now: () => number;
 }
 
 export const defaultWatchDeps: WatchDeps = {
   statMtime,
-  upload: uploadFile,
+  upload: uploadSavedFile,
   sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   now: () => Date.now(),
 };
 
 /**
- * Pollar filens mtime och PUT:ar nya bytes vid varje save. Stänger efter
- * timeout utan aktivitet; varje save förlänger deadline.
+ * Pollar filens mtime och laddar upp nya bytes (tRPC/PUT) vid varje save.
+ * Stänger efter timeout utan aktivitet; varje save förlänger deadline.
  */
 export function watchAndUpload(
   path: string,
-  uploadUrl: string,
+  target: UploadTarget,
   authHeader: string | undefined,
   timeoutMs: number,
   deps: WatchDeps = defaultWatchDeps,
 ): void {
-  void runWatch(path, uploadUrl, authHeader, timeoutMs, deps);
+  void runWatch(path, target, authHeader, timeoutMs, deps);
 }
 
 export async function runWatch(
   path: string,
-  uploadUrl: string,
+  target: UploadTarget,
   authHeader: string | undefined,
   timeoutMs: number,
   deps: WatchDeps,
@@ -237,7 +264,7 @@ export async function runWatch(
     const mtime = await deps.statMtime(path);
     if (mtime === null || mtime <= lastMtime) continue;
     try {
-      await deps.upload(path, uploadUrl, authHeader);
+      await deps.upload(path, target, authHeader);
       log(`uploaded changes: ${path}`);
       lastMtime = mtime;
       deadline = deps.now() + timeoutMs; // aktivitet → förläng

--- a/helper-ui/src/engine/queue.ts
+++ b/helper-ui/src/engine/queue.ts
@@ -18,7 +18,8 @@
 import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
-import type { HelperStatusResponse, HelperSyncEntry } from "@/lib/shared/helper/protocol";
+import type { HelperDocumentRef, HelperStatusResponse, HelperSyncEntry } from "@/lib/shared/helper/protocol";
+import { uploadTargetKey, uploadViaTrpc } from "./document-source.ts";
 import { log } from "./log.ts";
 
 /**
@@ -46,8 +47,10 @@ export interface DrainResult {
 export interface QueueDeps {
   now: () => number;
   newId: () => string;
-  /** PUT bytes → returnera HTTP-status (kastar bara vid nätfel). */
+  /** PUT bytes (demo/legacy) → returnera HTTP-status (kastar bara vid nätfel). */
   put: (url: string, body: Uint8Array, authHeader?: string) => Promise<number>;
+  /** Write-back via tRPC `document.uploadContent` (server-tier); kastar vid fel. */
+  uploadDoc: (document: HelperDocumentRef, body: Uint8Array, authHeader?: string) => Promise<void>;
 }
 
 export const defaultQueueDeps: QueueDeps = {
@@ -60,6 +63,8 @@ export const defaultQueueDeps: QueueDeps = {
     const resp = await fetch(url, { method: "PUT", headers, body: new Blob([new Uint8Array(body)]) });
     return resp.status;
   },
+  uploadDoc: (document, body, authHeader) =>
+    uploadViaTrpc(document, body, authHeader !== undefined ? { authHeader } : {}),
 };
 
 const BASE_BACKOFF_MS = 5_000;
@@ -75,10 +80,18 @@ export function backoffMs(attempts: number): number {
 type StoredEntry = QueueEntry;
 
 export interface EnqueueInput {
-  uploadUrl: string;
+  /** Server-tier tRPC-mål. Exakt en av `document`/`uploadUrl` anges. */
+  document?: HelperDocumentRef;
+  /** Demo/legacy PUT-mål. */
+  uploadUrl?: string;
   fileName: string;
   bytes: Uint8Array;
   authHeader?: string;
+}
+
+/** Stabil identitet för en post (dedup-nyckel): `doc:<id>` eller PUT-URL. */
+function entryKey(e: { document?: HelperDocumentRef; uploadUrl?: string }): string {
+  return uploadTargetKey(e) ?? "";
 }
 
 /**
@@ -127,7 +140,7 @@ export class UploadQueue {
       try {
         const entry = JSON.parse(await readFile(this.manifestPath(id), "utf8")) as StoredEntry;
         await readFile(this.contentPath(id)); // bytes måste finnas, annars släng manifestet
-        this.entries.set(entry.uploadUrl, entry);
+        this.entries.set(entryKey(entry), entry);
       } catch (err) {
         log(`queue: hoppar trasig post ${id}: ${msg(err)}`);
       }
@@ -142,14 +155,16 @@ export class UploadQueue {
    */
   async enqueue(input: EnqueueInput): Promise<QueueEntry> {
     await mkdir(this.dir, { recursive: true });
-    const existing = this.entries.get(input.uploadUrl);
+    const key = entryKey(input);
+    const existing = this.entries.get(key);
     const id = existing?.id ?? this.deps.newId();
     const now = this.deps.now();
     // Bytes först (durabilitet), sedan manifest — manifestets närvaro = giltig post.
     await writeFile(this.contentPath(id), input.bytes);
     const entry: QueueEntry = {
       id,
-      uploadUrl: input.uploadUrl,
+      ...(input.document ? { document: input.document } : {}),
+      ...(input.uploadUrl !== undefined ? { uploadUrl: input.uploadUrl } : {}),
       fileName: input.fileName,
       ...(input.authHeader !== undefined ? { authHeader: input.authHeader } : {}),
       enqueuedAt: existing?.enqueuedAt ?? now,
@@ -158,7 +173,7 @@ export class UploadQueue {
       status: "pending",
     };
     await writeFile(this.manifestPath(id), JSON.stringify(entry), "utf8");
-    this.entries.set(input.uploadUrl, entry);
+    this.entries.set(key, entry);
     log(`queue: köade ${input.fileName} (${this.pendingCount()} väntar)`);
     return entry;
   }
@@ -193,7 +208,13 @@ export class UploadQueue {
       const bytes = await readFile(this.contentPath(entry.id));
       // Egen authHeader (från browsern) först; annars helperns färska OIDC-token.
       const auth = entry.authHeader ?? (this.tokenProvider ? await this.tokenProvider() : undefined);
-      status = await this.deps.put(entry.uploadUrl, bytes, auth);
+      if (entry.document) {
+        // Server-tier: tRPC uploadContent (kastar vid fel → markFailed nedan).
+        await this.deps.uploadDoc(entry.document, bytes, auth);
+        status = 200;
+      } else {
+        status = await this.deps.put(entry.uploadUrl ?? "", bytes, auth);
+      }
     } catch (err) {
       await this.markFailed(entry, msg(err));
       res.failed++;
@@ -232,7 +253,7 @@ export class UploadQueue {
 
   /** Ta bort en post helt (klar eller manuellt löst). */
   async discard(entry: QueueEntry): Promise<void> {
-    this.entries.delete(entry.uploadUrl);
+    this.entries.delete(entryKey(entry));
     await rm(this.manifestPath(entry.id), { force: true });
     await rm(this.contentPath(entry.id), { force: true });
   }

--- a/helper-ui/src/engine/trpc-client.ts
+++ b/helper-ui/src/engine/trpc-client.ts
@@ -16,7 +16,7 @@ import { createTRPCClient, httpBatchLink, type TRPCClient } from "@trpc/client";
 import superjson from "superjson";
 
 import type { AppRouter } from "@/lib/server/routers/_app";
-import { base64ToBytes } from "@/lib/shared/content-address";
+import { base64ToBytes, bytesToBase64 } from "@/lib/shared/content-address";
 
 /** tRPC-endpointens suffix på serverns origin (matchar DEFAULT_TRPC_ENDPOINT). */
 export const TRPC_PATH = "/api/trpc";
@@ -78,4 +78,13 @@ export async function downloadDocumentBytes(
 ): Promise<DocumentBytes> {
   const res = await client.document.downloadContent.query({ documentId });
   return { bytes: base64ToBytes(res.contentBase64), mimeType: res.mimeType, fileName: res.fileName };
+}
+
+/** Skriv tillbaka dokument-bytes via den typade `document.uploadContent`-mutationen. */
+export async function uploadDocumentBytes(
+  client: TRPCClient<AppRouter>,
+  documentId: string,
+  bytes: Uint8Array,
+): Promise<void> {
+  await client.document.uploadContent.mutate({ documentId, contentBase64: bytesToBase64(bytes) });
 }

--- a/helper-ui/test/auth-orchestration.test.ts
+++ b/helper-ui/test/auth-orchestration.test.ts
@@ -151,7 +151,7 @@ describe("UploadQueue tokenProvider (autonom Bearer vid drain)", () => {
 
   test("post utan egen authHeader → använder färsk token vid upload", async () => {
     const puts: Array<string | undefined> = [];
-    const deps = { now: () => 1000, newId: () => "id1", put: async (_u: string, _b: Uint8Array, auth?: string) => { puts.push(auth); return 200; } };
+    const deps = { now: () => 1000, newId: () => "id1", put: async (_u: string, _b: Uint8Array, auth?: string) => { puts.push(auth); return 200; }, uploadDoc: async () => undefined };
     const q = new UploadQueue(await qdir(), deps, async () => "Bearer FRESH");
     await q.enqueue({ uploadUrl: "http://s/u/1", fileName: "a", bytes: new TextEncoder().encode("x") });
     await q.drainOnce();
@@ -161,7 +161,7 @@ describe("UploadQueue tokenProvider (autonom Bearer vid drain)", () => {
 
   test("post MED egen authHeader → den vinner över token-providern", async () => {
     const puts: Array<string | undefined> = [];
-    const deps = { now: () => 1000, newId: () => "id2", put: async (_u: string, _b: Uint8Array, auth?: string) => { puts.push(auth); return 200; } };
+    const deps = { now: () => 1000, newId: () => "id2", put: async (_u: string, _b: Uint8Array, auth?: string) => { puts.push(auth); return 200; }, uploadDoc: async () => undefined };
     const q = new UploadQueue(await qdir(), deps, async () => "Bearer FRESH");
     await q.enqueue({ uploadUrl: "http://s/u/2", fileName: "a", bytes: new TextEncoder().encode("x"), authHeader: "Bearer BROWSER" });
     await q.drainOnce();

--- a/helper-ui/test/open.test.ts
+++ b/helper-ui/test/open.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterAll, describe, expect, test } from "bun:test";
 
 import { ContentStore } from "../src/engine/content-store.ts";
+import type { UploadTarget } from "../src/engine/document-source.ts";
 import { enqueueSavedFile, handleOpen, persistDownloaded, restoreCached, type OpenDeps } from "../src/engine/open.ts";
 import { UploadQueue } from "../src/engine/queue.ts";
 import { jsonRequest } from "./helpers.ts";
@@ -15,7 +16,7 @@ interface Recorder {
   sessionDir: string;
   downloaded: string[]; // källnyckel (downloadUrl eller doc:<id>)
   opened: string[];
-  watched: Array<{ path: string; uploadUrl: string; timeoutMs: number }>;
+  watched: Array<{ path: string; target: UploadTarget; timeoutMs: number }>;
   deps: OpenDeps;
 }
 
@@ -34,7 +35,7 @@ function recorder(overrides: Partial<OpenDeps> = {}): Recorder {
       rec.sessionDir = d;
       return d;
     },
-    startWatch: (path, uploadUrl, _auth, timeoutMs) => { rec.watched.push({ path, uploadUrl, timeoutMs }); },
+    startWatch: (path, target, _auth, timeoutMs) => { rec.watched.push({ path, target, timeoutMs }); },
     ...overrides,
   };
   return rec;
@@ -184,10 +185,10 @@ describe("enqueueSavedFile", () => {
     await writeFile(filePath, "ändrat innehåll", "utf8");
 
     const queue = new UploadQueue(qdir);
-    await enqueueSavedFile(queue, filePath, "http://s/api/documents/7/upload", "Bearer tok");
+    await enqueueSavedFile(queue, filePath, { document: { id: "doc-7", trpcUrl: "http://s/api/trpc" } }, "Bearer tok");
 
     const snap = queue.snapshot();
     expect(snap.total).toBe(1);
-    expect(snap.entries[0]).toMatchObject({ uploadUrl: "http://s/api/documents/7/upload", fileName: "avtal.docx", status: "pending" });
+    expect(snap.entries[0]).toMatchObject({ document: { id: "doc-7" }, fileName: "avtal.docx", status: "pending" });
   });
 });

--- a/helper-ui/test/queue.test.ts
+++ b/helper-ui/test/queue.test.ts
@@ -9,6 +9,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 
+import superjson from "superjson";
+
 import { backoffMs, defaultQueueDeps, UploadQueue, type QueueDeps } from "../src/engine/queue.ts";
 
 const dirs: string[] = [];
@@ -21,19 +23,30 @@ afterAll(async () => {
   await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true })));
 });
 
-/** Injicerbara deps: räknande klocka + förutsägbara id:n + skript-styrd PUT. */
-function fakeDeps(putStatuses: number[] | (() => Promise<number>)): { deps: QueueDeps; puts: Array<{ url: string; body: Uint8Array; auth?: string }>; tick: () => void } {
+interface UploadDocCall { document: { id: string; trpcUrl: string }; body: Uint8Array; auth?: string }
+
+/** Injicerbara deps: räknande klocka + förutsägbara id:n + skript-styrd PUT + tRPC-upload. */
+function fakeDeps(
+  putStatuses: number[] | (() => Promise<number>),
+  uploadDocFails = false,
+): { deps: QueueDeps; puts: Array<{ url: string; body: Uint8Array; auth?: string }>; uploadDocs: UploadDocCall[]; tick: () => void } {
   let t = 1000;
   let n = 0;
   const puts: Array<{ url: string; body: Uint8Array; auth?: string }> = [];
+  const uploadDocs: UploadDocCall[] = [];
   const put = async (url: string, body: Uint8Array, auth?: string): Promise<number> => {
     puts.push({ url, body, ...(auth !== undefined ? { auth } : {}) });
     if (typeof putStatuses === "function") return putStatuses();
     return putStatuses[Math.min(puts.length - 1, putStatuses.length - 1)] ?? 200;
   };
+  const uploadDoc = async (document: { id: string; trpcUrl: string }, body: Uint8Array, auth?: string): Promise<void> => {
+    uploadDocs.push({ document, body, ...(auth !== undefined ? { auth } : {}) });
+    if (uploadDocFails) throw new Error("trpc boom");
+  };
   return {
-    deps: { now: () => t, newId: () => `id-${++n}`, put },
+    deps: { now: () => t, newId: () => `id-${++n}`, put, uploadDoc },
     puts,
+    uploadDocs,
     tick: () => { t += 10 * 60_000; }, // hoppa förbi all backoff
   };
 }
@@ -92,6 +105,29 @@ describe("UploadQueue.drainOnce", () => {
     expect(new TextDecoder().decode(puts[0]!.body)).toBe("data");
     expect(q.snapshot().total).toBe(0);
     expect(await readdir(dir)).toEqual([]);
+  });
+
+  test("document-mål → uploadDoc (tRPC), raderar posten (ADR 0031 write-back)", async () => {
+    const f = fakeDeps([200]);
+    const q = new UploadQueue(dir, f.deps);
+    await q.enqueue({ document: { id: "d1", trpcUrl: "http://s/api/trpc" }, fileName: "a.docx", bytes: bytes("data"), authHeader: "Bearer t" });
+
+    const res = await q.drainOnce();
+    expect(res.uploaded).toBe(1);
+    expect(f.puts).toHaveLength(0); // tRPC, inte PUT
+    expect(f.uploadDocs[0]).toMatchObject({ document: { id: "d1" }, auth: "Bearer t" });
+    expect(new TextDecoder().decode(f.uploadDocs[0]!.body)).toBe("data");
+    expect(q.snapshot().total).toBe(0);
+  });
+
+  test("document-upload kastar → failed, behålls för retry", async () => {
+    const f = fakeDeps([200], true); // uploadDoc kastar
+    const q = new UploadQueue(dir, f.deps);
+    await q.enqueue({ document: { id: "d1", trpcUrl: "http://s/api/trpc" }, fileName: "a.docx", bytes: bytes("x") });
+    expect((await q.drainOnce()).failed).toBe(1);
+    const entry = q.snapshot().entries[0]!;
+    expect(entry.status).toBe("pending");
+    expect(entry.lastError).toContain("trpc boom");
   });
 
   test("409 → markerar conflict, slutar retr:a, skriver aldrig över", async () => {
@@ -252,5 +288,24 @@ describe("defaultQueueDeps", () => {
 
   test("newId ger unika id:n", () => {
     expect(defaultQueueDeps.newId()).not.toBe(defaultQueueDeps.newId());
+  });
+
+  test("uploadDoc gör en tRPC uploadContent-mutation med Bearer (mockad fetch)", async () => {
+    const calls: Array<{ url: string; auth: string | null }> = [];
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), auth: new Headers(init?.headers).get("authorization") });
+      return new Response(JSON.stringify([{ result: { data: superjson.serialize({ id: "d1" }) } }]), {
+        status: 200, headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+    try {
+      await defaultQueueDeps.uploadDoc({ id: "d1", trpcUrl: "http://s/api/trpc" }, bytes("x"), "Bearer t");
+      expect(calls[0]!.url).toContain("/api/trpc");
+      expect(calls[0]!.url).toContain("document.uploadContent");
+      expect(calls[0]!.auth).toBe("Bearer t");
+    } finally {
+      globalThis.fetch = orig;
+    }
   });
 });

--- a/helper-ui/test/watch.test.ts
+++ b/helper-ui/test/watch.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, test } from "bun:test";
 
+import type { UploadTarget } from "../src/engine/document-source.ts";
 import { runWatch, type WatchDeps } from "../src/engine/open.ts";
 import { fakeClock } from "./helpers.ts";
 
 interface Harness {
   deps: WatchDeps;
-  uploads: Array<{ path: string; url: string; auth: string | undefined }>;
+  uploads: Array<{ path: string; target: UploadTarget; auth: string | undefined }>;
 }
+
+const URL_TARGET: UploadTarget = { uploadUrl: "http://up" };
 
 /**
  * Bygg deterministiska watch-deps: `mtimes` matas ut i tur och ordning
@@ -19,8 +22,8 @@ function harness(mtimes: Array<number | null>, stepMs: number, failUpload = fals
   let i = 0;
   const deps: WatchDeps = {
     statMtime: async () => (i < mtimes.length ? mtimes[i++]! : mtimes[mtimes.length - 1]!),
-    upload: async (path, url, auth) => {
-      uploads.push({ path, url, auth });
+    upload: async (path, target, auth) => {
+      uploads.push({ path, target, auth });
       if (failUpload) throw new Error("upload boom");
     },
     sleep: async () => clock.advance(stepMs),
@@ -32,33 +35,33 @@ function harness(mtimes: Array<number | null>, stepMs: number, failUpload = fals
 describe("runWatch", () => {
   test("ingen ändring → ingen upload, stannar vid timeout", async () => {
     const h = harness([100, 100, 100, 100], 500);
-    await runWatch("/f", "http://up", undefined, 1000, h.deps);
+    await runWatch("/f", URL_TARGET, undefined, 1000, h.deps);
     expect(h.uploads).toHaveLength(0);
   });
 
   test("upptäckt ändring → laddar upp en gång + förlänger deadline", async () => {
     // initial 100, oförändrad, sedan 200 (save). timeout 1500, steg 500.
     const h = harness([100, 100, 200, 200, 200, 200, 200, 200], 500);
-    await runWatch("/doc.pdf", "http://up", "Bearer x", 1500, h.deps);
+    await runWatch("/doc.pdf", URL_TARGET, "Bearer x", 1500, h.deps);
     expect(h.uploads).toHaveLength(1);
-    expect(h.uploads[0]).toEqual({ path: "/doc.pdf", url: "http://up", auth: "Bearer x" });
+    expect(h.uploads[0]).toEqual({ path: "/doc.pdf", target: URL_TARGET, auth: "Bearer x" });
   });
 
   test("två separata sparningar → två uploads", async () => {
     const h = harness([100, 200, 300, 300, 300, 300], 400);
-    await runWatch("/f", "http://up", undefined, 2000, h.deps);
+    await runWatch("/f", URL_TARGET, undefined, 2000, h.deps);
     expect(h.uploads).toHaveLength(2);
   });
 
   test("upload-fel kraschar inte loopen", async () => {
     const h = harness([100, 200, 200, 200], 500, true);
-    await runWatch("/f", "http://up", undefined, 1000, h.deps);
+    await runWatch("/f", URL_TARGET, undefined, 1000, h.deps);
     expect(h.uploads.length).toBeGreaterThanOrEqual(1); // försökte, fångade felet
   });
 
   test("filen borta vid start (mtime 0) → returnerar utan watch", async () => {
     const h = harness([null], 500);
-    await runWatch("/gone", "http://up", undefined, 1000, h.deps);
+    await runWatch("/gone", URL_TARGET, undefined, 1000, h.deps);
     expect(h.uploads).toHaveLength(0);
   });
 });

--- a/src/lib/shared/helper/protocol.ts
+++ b/src/lib/shared/helper/protocol.ts
@@ -141,8 +141,10 @@ export interface HelperContentRequest {
 export interface HelperSyncEntry {
   /** Stabilt id i kö-katalogen. */
   id: string;
-  /** PUT-mål på servern (identifierar dokumentet). */
-  uploadUrl: string;
+  /** Server-tier upload-mål: tRPC `document.uploadContent` (ADR 0031). */
+  document?: HelperDocumentRef;
+  /** Demo/legacy PUT-mål. Exakt en av `document`/`uploadUrl` anges. */
+  uploadUrl?: string;
   /** Användarsynligt filnamn. */
   fileName: string;
   /** När den först köades (ms sedan epoch). */


### PR DESCRIPTION
## Vad
ADR 0031 **steg 3**: spara i extern editor → helpern synkar tillbaka via den typade tRPC-mutationen `document.uploadContent` (ingen REST). Tidigare startade `/open` ingen write-back i server-tier → ändringar i Word/PDF Gear **tappades** vid återöppning (det du såg).

- **protokoll**: `HelperSyncEntry` får valfri `document?`/`uploadUrl?` (exakt en).
- **`queue.ts`**: durabla kön generaliserad till `UploadTarget` (tRPC-dokument ELLER PUT-URL). Dedup-/kö-nyckel `doc:<id>` resp. `uploadUrl`. Drain: `uploadDoc` (uploadContent; kastar→retry) för dokument, `put` (PUT; 2xx/409) för URL.
- **`document-source.ts`**: `UploadTarget` + `uploadTargetKey` + `uploadViaTrpc`.
- **`open.ts`**: `startWatchIfNeeded` watchar när `document`/`uploadUrl` finns; watch/`enqueueSavedFile`/`uploadSavedFile` tar `UploadTarget`.
- **`main.ts`**: wiring → `UploadTarget`. Demo-vägen (statisk PUT) bevarad.

Offline-säkert: sparningen skrivs durabelt till kön FÖRST, dräneras autonomt (retry/backoff) — en ändring kan aldrig tappas (ADR 0028 §3).

## Verifierat
- helper-ui `tsc` + **268 tester** (coverage-grind), main `tsc`, `deps:check` 0 brott, eslint komplexitet ≤8.
- **LIVE end-to-end** mot self-hosted: `/open` document → editera temp-fil → watch+drain → `uploadContent` → serverns `size_bytes` gick **20568 → 137** (nya bytsen sparade). Helper-logg: `köade → uploaded changes → laddade upp`.

Med detta är **ADR 0031 komplett** (steg 1–3); kvar är steg 4 (städa bort legacy `downloadUrl`/`uploadUrl` när inget använder dem).

Closes #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)