### PR TITLE
feat(documents): transient "Synkad"-bekräftelse + tydligare synk-terminologi

### DIFF
--- a/src/components/documents/_sync-badge.tsx
+++ b/src/components/documents/_sync-badge.tsx
@@ -1,33 +1,44 @@
 /**
  * `SyncStatusBadge` — per-dokument-markering driven av AVA Helperns lokala
- * upload-kö (ADR 0031 §write-back). Visar "ändringar på ingång" medan en
- * sparning väntar på att synkas till servern (så användaren inte förvirras av
- * att återöppna och se det GAMLA innehållet), och "konflikt" vid 409.
- *
- * Funkar bäst i vanliga fallet: man redigerar på samma dator som helpern kör på
- * (juristen är ofta ensam i ärendet) → kön är lokal. Ren presentationskomponent.
+ * upload-kö (ADR 0031 §write-back). Tre tillstånd:
+ *   - `pending`  → "⟳ Väntar på server" (ändringar sparade lokalt, ej uppladdade)
+ *   - `synced`   → "✓ Synkad" (transient bekräftelse ~1 min efter lyckad upload)
+ *   - `conflict` → "⚠ Konflikt" (server gått förbi; 409)
+ * Synkade-i-vila-dokument får ingen badge (ren lista). Funkar bäst när helpern
+ * kör på samma dator (lokal kö). Ren presentationskomponent.
  */
 
-export type SyncStatus = "pending" | "conflict";
+import type { DocSyncStatus } from "@/lib/client/helper/use-helper";
+
+export type SyncStatus = DocSyncStatus;
+
+const BADGE = "inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded";
 
 export function SyncStatusBadge({ status }: { status?: SyncStatus | undefined }) {
   if (status === undefined) return null;
   if (status === "conflict") {
     return (
       <span
-        className="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded bg-red-100 text-red-800"
+        className={`${BADGE} bg-red-100 text-red-800`}
         title="Versionskonflikt — serverns version har gått förbi dina lokala ändringar. Öppna och spara igen."
       >
         ⚠ Konflikt
       </span>
     );
   }
+  if (status === "synced") {
+    return (
+      <span className={`${BADGE} bg-green-100 text-green-800`} title="Dina ändringar är synkade till servern.">
+        ✓ Synkad
+      </span>
+    );
+  }
   return (
     <span
-      className="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded bg-blue-100 text-blue-700"
-      title="Ändringar väntar på att synkas till servern (AVA Helper). Vänta tills det är klart innan du öppnar igen — annars ser du den gamla versionen."
+      className={`${BADGE} bg-amber-100 text-amber-800`}
+      title="Ändringar sparade lokalt och väntar på att synkas till servern (AVA Helper). Vänta tills det är klart innan du öppnar igen — annars ser du den gamla versionen."
     >
-      <span className="animate-pulse">⟳</span> Ändringar på ingång
+      <span className="animate-pulse">⟳</span> Väntar på server
     </span>
   );
 }

--- a/src/components/documents/document-browser.tsx
+++ b/src/components/documents/document-browser.tsx
@@ -2,7 +2,7 @@
 
 import type { inferRouterInputs } from "@trpc/server";
 import { useState, useRef, useCallback, useMemo } from "react";
-import { docSyncStatusMap, useHelperSyncStatus } from "@/lib/client/helper/use-helper";
+import { useDocSyncStatus } from "@/lib/client/helper/use-helper";
 import { trpc } from "@/lib/client/trpc";
 import type { AppRouter } from "@/lib/server/routers/_app";
 import { DocumentRow, type DocumentRecord } from "./_document-row";
@@ -56,10 +56,9 @@ export function DocumentBrowser({ matterId }: DocumentBrowserProps) {
     [tree.data],
   );
 
-  // Per-dokument write-back-status ur AVA Helperns lokala kö (ADR 0031): markerar
-  // "ändringar på ingång" så man inte återöppnar och ser gamla innehållet.
-  const helperSync = useHelperSyncStatus();
-  const docSync = useMemo(() => docSyncStatusMap(helperSync), [helperSync]);
+  // Per-dokument write-back-status ur AVA Helperns lokala kö (ADR 0031): "väntar
+  // på server", transient "synkad"-bekräftelse, och "konflikt".
+  const docSync = useDocSyncStatus();
 
   const mutations = useDocumentMutations({
     matterId,

--- a/src/lib/client/helper/use-helper.ts
+++ b/src/lib/client/helper/use-helper.ts
@@ -16,7 +16,7 @@
  * `@/lib/shared/helper/protocol` (#78).
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import {
   HELPER_BASE,
@@ -200,6 +200,76 @@ export function useHelperSyncStatus(intervalMs = 5_000): HelperStatusResponse | 
   }, [intervalMs]);
 
   return sync;
+}
+
+/** Per-dokument synk-tillstånd i UI:t: väntar på server / konflikt / nyss synkad. */
+export type DocSyncStatus = "pending" | "conflict" | "synced";
+
+/** Hur länge den gröna "Synkad"-bekräftelsen visas efter en lyckad upload. */
+export const SYNCED_TTL_MS = 60_000;
+
+/**
+ * Spårar synk-tillstånd över tid. Kön (helperns `/status`) rensar en post när
+ * den laddats upp, så "var pending → nu borta" = nyss synkad. Vi minns den
+ * tidpunkten per dokument för att kunna visa en transient "Synkad"-bekräftelse.
+ */
+export interface SyncTracker {
+  pending: Set<string>;
+  conflict: Set<string>;
+  /** documentId → tidpunkt (ms) då uppladdningen blev klar. */
+  syncedAt: Map<string, number>;
+}
+
+export function emptySyncTracker(): SyncTracker {
+  return { pending: new Set(), conflict: new Set(), syncedAt: new Map() };
+}
+
+/**
+ * Avancera spåraren med en ny `/status`-ögonblicksbild. Dokument som var
+ * `pending` och nu varken är pending eller conflict har laddats upp → stämpla
+ * `syncedAt = now`. Utgångna "synkad"-stämplar (> TTL) rensas. Ren funktion.
+ */
+export function advanceSyncTracker(prev: SyncTracker, status: HelperStatusResponse | null, now: number): SyncTracker {
+  const cur = docSyncStatusMap(status);
+  const pending = new Set<string>();
+  const conflict = new Set<string>();
+  for (const [id, s] of cur) (s === "conflict" ? conflict : pending).add(id);
+
+  const syncedAt = new Map(prev.syncedAt);
+  for (const id of prev.pending) {
+    if (!pending.has(id) && !conflict.has(id)) syncedAt.set(id, now);
+  }
+  for (const [id, ts] of syncedAt) if (now - ts > SYNCED_TTL_MS) syncedAt.delete(id);
+  return { pending, conflict, syncedAt };
+}
+
+/** Bygg per-dokument-badge-kartan ur spåraren. Pending/conflict slår "synkad". */
+export function syncBadgeMap(t: SyncTracker, now: number): Map<string, DocSyncStatus> {
+  const m = new Map<string, DocSyncStatus>();
+  for (const [id, ts] of t.syncedAt) if (now - ts <= SYNCED_TTL_MS) m.set(id, "synced");
+  for (const id of t.pending) m.set(id, "pending");
+  for (const id of t.conflict) m.set(id, "conflict");
+  return m;
+}
+
+/**
+ * Per-dokument synk-status för dokumentlistan (ADR 0031): `pending` (väntar på
+ * server), `conflict`, och en transient `synced`-bekräftelse ~1 min efter att en
+ * uppladdning blivit klar. Pollar helperns lokala kö var 5:e s (driver även
+ * utgången av "synkad"-stämplar). Tunn hook ovanpå de rena spår-funktionerna.
+ */
+export function useDocSyncStatus(intervalMs = 5_000): Map<string, DocSyncStatus> {
+  const status = useHelperSyncStatus(intervalMs);
+  const trackerRef = useRef<SyncTracker>(emptySyncTracker());
+  const [badges, setBadges] = useState<Map<string, DocSyncStatus>>(new Map());
+
+  useEffect(() => {
+    const now = Date.now();
+    trackerRef.current = advanceSyncTracker(trackerRef.current, status, now);
+    setBadges(syncBadgeMap(trackerRef.current, now));
+  }, [status]);
+
+  return badges;
 }
 
 /**

--- a/test/unit/lib/helper/use-helper.test.tsx
+++ b/test/unit/lib/helper/use-helper.test.tsx
@@ -14,6 +14,10 @@ import {
   fetchContentViaHelper,
   configureHelper,
   docSyncStatusMap,
+  advanceSyncTracker,
+  syncBadgeMap,
+  emptySyncTracker,
+  SYNCED_TTL_MS,
 } from "@/lib/client/helper/use-helper";
 import type { HelperStatusResponse, HelperSyncEntry } from "@/lib/shared/helper/protocol";
 
@@ -258,5 +262,49 @@ describe("docSyncStatusMap", () => {
       { document: { id: "a", trpcUrl: "x" }, status: "conflict" },
     ]));
     expect(m.get("a")).toBe("conflict");
+  });
+});
+
+describe("advanceSyncTracker + syncBadgeMap (transient 'synkad')", () => {
+  function status(entries: Partial<HelperSyncEntry>[]): HelperStatusResponse {
+    const full = entries.map((e, i) => ({
+      id: `q${i}`, fileName: "f", enqueuedAt: 0, attempts: 0, nextAttemptAt: 0,
+      status: "pending" as const, ...e,
+    })) as HelperSyncEntry[];
+    return { pending: 0, conflict: 0, total: full.length, entries: full };
+  }
+  const docPending = (id: string) => ({ document: { id, trpcUrl: "x" }, status: "pending" as const });
+  const docConflict = (id: string) => ({ document: { id, trpcUrl: "x" }, status: "conflict" as const });
+
+  it("pending → borta = 'synced' (transient), pending/conflict speglas", () => {
+    let t = emptySyncTracker();
+    t = advanceSyncTracker(t, status([docPending("a"), docConflict("b")]), 1000);
+    expect(syncBadgeMap(t, 1000).get("a")).toBe("pending");
+    expect(syncBadgeMap(t, 1000).get("b")).toBe("conflict");
+
+    // 'a' laddas upp (försvinner ur kön) → synced; 'b' kvar i konflikt.
+    t = advanceSyncTracker(t, status([docConflict("b")]), 2000);
+    const m = syncBadgeMap(t, 2000);
+    expect(m.get("a")).toBe("synced");
+    expect(m.get("b")).toBe("conflict");
+  });
+
+  it("'synced' försvinner efter TTL", () => {
+    let t = emptySyncTracker();
+    t = advanceSyncTracker(t, status([docPending("a")]), 1000);
+    t = advanceSyncTracker(t, status([]), 2000); // a synkad vid 2000
+    expect(syncBadgeMap(t, 2000).get("a")).toBe("synced");
+    expect(syncBadgeMap(t, 2000 + SYNCED_TTL_MS + 1).has("a")).toBe(false); // utgången
+    // nästa advance rensar stämpeln helt
+    t = advanceSyncTracker(t, status([]), 2000 + SYNCED_TTL_MS + 1);
+    expect(t.syncedAt.has("a")).toBe(false);
+  });
+
+  it("pending som blir conflict räknas INTE som synced", () => {
+    let t = emptySyncTracker();
+    t = advanceSyncTracker(t, status([docPending("a")]), 1000);
+    t = advanceSyncTracker(t, status([docConflict("a")]), 2000);
+    expect(syncBadgeMap(t, 2000).get("a")).toBe("conflict");
+    expect(t.syncedAt.has("a")).toBe(false);
   });
 });


### PR DESCRIPTION
## Bakgrund (du rapporterade)
Offline-edit + spara gav ingen **positiv bekräftelse** att ändringarna nått servern → osäkerhet. (Och i din lokala setup syncade det direkt eftersom servern också kör på localhost.)

## Vad
Tre tillstånd på dokument-raden (badge, ingen kolumn), **transient bekräftelse**:
- amber **"⟳ Väntar på server"** — sparat lokalt, ej uppladdat (durabla kön).
- grön **"✓ Synkad"** — visas ~1 min efter lyckad upload, försvinner sen → ren lista i vila.
- röd **"⚠ Konflikt"** — server gått förbi (409).

## Hur "Synkad" detekteras
Kön rensar en post när den laddats upp. Så **"var pending → nu borta ur kön" = nyss synkad** → vi stämplar `syncedAt` och visar grön bekräftelse i `SYNCED_TTL_MS` (60 s). Ren logik i `advanceSyncTracker`/`syncBadgeMap` (testad); `useDocSyncStatus` är en tunn hook ovanpå 5s-pollen (som även driver TTL-utgången).

## Verifierat
- main `tsc`, use-helper-tester (pending→borta=synced, TTL-utgång, pending→conflict räknas ej som synced) + **34** komponenttester, eslint, `deps:check` 0 brott.

Svar på din oro: den durabla kön garanterar att servern får allt även efter offline/omstart (retry+backoff, testat) — och nu **ser** du det via den gröna bekräftelsen.

Closes #712

🤖 Generated with [Claude Code](https://claude.com/claude-code)