### PR TITLE
fix(helper): local-first läsning — servera osynkad lokal ändring först (ADR 0032)

### DIFF
--- a/docs/adr/0032-local-first-dokumentlasning-i-helpern.md
+++ b/docs/adr/0032-local-first-dokumentlasning-i-helpern.md
@@ -1,0 +1,71 @@
+# ADR 0032 — Local-first dokument-läsning i helpern
+
+- **Status:** Accepterad (2026-06-22)
+- **Beslutsfattare:** Ulrik Sjölin
+- **Berör:** helper-ui (`/open`, `/content`, upload-kön), läs-vägen.
+- **Knyter an:** [ADR 0028](0028-autonom-offline-first-helper.md) (helpern = den
+  enda lokala dokument-auktoriteten), [ADR 0031](0031-helpern-som-tunn-trpc-klient.md)
+  (tRPC-IO + durabel write-back-kö).
+
+## Kontext
+
+`/open` och `/content` är **server-first**: de hämtar alltid serverns version (via
+tRPC `downloadContent`) och faller bara tillbaka på den lokala cachen om
+nedladdningen *misslyckas* (offline). Men en sparning synkas **asynkront** —
+fil-watch upptäcker (~2 s), lägger i den durabla kön, och kön dräneras + laddar
+upp (var ~15 s).
+
+I glappet mellan save och uppladdning händer två fel om användaren återöppnar
+dokumentet:
+
+1. **Återöppning visar GAMLA versionen.** Servern har ännu inte den sparade
+   ändringen → `/open` hämtar den gamla bytsen. Förvirrande ("var tog mina
+   ändringar vägen?").
+2. **Re-redigering kan tappa den första ändringen.** Öppnar man den gamla
+   kopian, redigerar och sparar igen ersätter den nya kö-posten den väntande
+   (kön slår ihop per dokument, "senaste vinner") → den första, osynkade
+   ändringen skuggas/förloras.
+
+Båda bryter mot ADR 0028:s princip att helpern är den **enda lokala
+dokument-auktoriteten**. Auktoriteten är inte helt genomförd på läs-vägen.
+
+## Beslut
+
+**En väntande (osynkad) lokal ändring är auktoritativ tills den synkats.**
+Helperns läs-väg blir **local-first** med prioritetsordningen:
+
+1. **Lokal väntande kopia** — finns en kö-post (pending ELLER conflict) för
+   dokumentet, servera dess bytes. Det är den färskaste, osynkade versionen.
+2. **Server** — hämta via tRPC `downloadContent` (ingen väntande ändring).
+3. **Offline-cache** — content-adresserad cache när nedladdning misslyckas.
+
+Gäller både `/open` (öppna i native-app) och `/content` (in-browser-läsning), så
+de aldrig divergerar.
+
+## Konsekvenser
+
+- **Återöppning visar alltid din senaste ändring** — även sekunden efter save,
+  innan synken hunnit klart.
+- **Re-redigering bygger på din ändring** (inte serverns gamla) → ingen
+  skuggning/förlust; kö-sammanslagningen blir korrekt (edit-på-edit).
+- **Demo opåverkad** — read-only tier, ingen kö → ingen väntande kopia, faller
+  rakt till statisk URL.
+- **Efter synk** (kö-posten uppladdad + rensad) → `/open` hämtar servern, som nu
+  har ändringen. Samma resultat, server-auktoritativ igen.
+- **Konflikt-fallet:** en post i `conflict` serveras också lokalt → användaren
+  tappar inte sitt arbete; UI:t visar "⚠ Konflikt" och hen kan spara om.
+
+## Genomförande (en PR)
+
+1. `UploadQueue.peekByKey(key)` — läs de köade bytsen för ett dokument (eller
+   null).
+2. `obtainFile` (`/open`) + `handleContent` (`/content`): kolla väntande lokal
+   kopia FÖRST (via en injicerad dep), annars server, annars cache.
+3. Wiring i `startEngine` (`queueBackedOnOpen` + `onContent`) → `queue.peekByKey`.
+4. Tester (queue-peek + local-first-grenen i open/content).
+
+## Relaterat
+
+ADR 0028 (lokal dokument-auktoritet — den här slutför läs-vägen), 0031 (kön +
+tRPC-IO). Föranlett av att återöppning i synk-glappet visade den gamla versionen
+och kunde skugga en osynkad ändring.

--- a/helper-ui/src/engine/content.ts
+++ b/helper-ui/src/engine/content.ts
@@ -17,6 +17,8 @@ import { parseJsonBody, textError } from "./http.ts";
 import { log } from "./log.ts";
 
 export interface ContentDeps {
+  /** Väntande osynkad lokal kopia (ADR 0032 local-first); provas FÖRE cache/server. */
+  pending?: (cacheKey: string) => Promise<Uint8Array | null>;
   /** Hämta cachade bytes för `cacheKey`, eller null. */
   load: (cacheKey: string) => Promise<Uint8Array | null>;
   /** Hämta + cacha vid miss; null om hämtning misslyckas (offline). */
@@ -30,6 +32,10 @@ export async function handleContent(req: Request, deps: ContentDeps): Promise<Re
   const ref = toSourceRef(body);
   const key = sourceCacheKey(ref);
   if (!key) return textError(400, "source (document|downloadUrl) required");
+
+  // Local-first (ADR 0032): osynkad lokal ändring är auktoritativ tills synkad.
+  const local = deps.pending ? await deps.pending(key) : null;
+  if (local) return bytesResponse(local);
 
   const cached = await deps.load(key);
   if (cached) return bytesResponse(cached);

--- a/helper-ui/src/engine/main.ts
+++ b/helper-ui/src/engine/main.ts
@@ -27,7 +27,7 @@ import { loginConfigFromEnv, runLogin, type LoginConfig } from "./auth/login.ts"
 import { handleConfig } from "./config-endpoint.ts";
 import { ContentStore, resolveCacheTtlMs } from "./content-store.ts";
 import { fetchAndCacheContent, handleContent } from "./content.ts";
-import { fetchSourceBytes } from "./document-source.ts";
+import { fetchSourceBytes, sourceCacheKey } from "./document-source.ts";
 import { envWithConfig, loadHelperConfig, saveHelperConfig } from "./helper-config.ts";
 import { installService, uninstallService, type InstallDeps } from "./install.ts";
 import { initLog, log } from "./log.ts";
@@ -164,6 +164,8 @@ export function queueBackedOnOpen(queue: UploadQueue, content: ContentStore, aut
     browserAuth ?? (authHeader ? await authHeader() : undefined);
   const deps: OpenDeps = {
     ...defaultOpenDeps,
+    // Local-first (ADR 0032): osynkad lokal ändring i kön slår serverns version.
+    pendingBytes: (ref) => queue.peekByKey(sourceCacheKey(ref) ?? ""),
     download: async (ref, browserAuth) => {
       const auth = await fallback(browserAuth);
       return fetchSourceBytes(ref, auth !== undefined ? { authHeader: auth } : {});
@@ -257,6 +259,7 @@ export function startEngine(opts: EngineOpts = {}): EngineHandle {
           onStatus: () => stores.queue.snapshot(),
           onContent: (req: Request) =>
             handleContent(req, {
+              pending: (cacheKey) => stores.queue.peekByKey(cacheKey),
               load: (cacheKey) => stores.content.load(cacheKey),
               fetchAndCache: async (ref, cacheKey, auth, fileName) =>
                 fetchAndCacheContent(stores.content, ref, cacheKey, auth ?? (authHeader ? await authHeader() : undefined), fileName),

--- a/helper-ui/src/engine/open.ts
+++ b/helper-ui/src/engine/open.ts
@@ -23,6 +23,8 @@ const DEFAULT_WATCH_MINUTES = 60;
 const POLL_INTERVAL_MS = 2_000;
 
 export interface OpenDeps {
+  /** Väntande lokal (osynkad) kopia, eller null (ADR 0032 local-first). Provas FÖRE download. */
+  pendingBytes?: (ref: SourceRef) => Promise<Uint8Array | null>;
   /** Hämta dokument-bytes för en källa (tRPC server-tier / statisk demo, ADR 0031). */
   download: (ref: SourceRef, authHeader?: string) => Promise<Uint8Array>;
   openApp: (path: string) => Promise<void>;
@@ -81,6 +83,14 @@ async function runOpen(body: HelperOpenRequest, deps: OpenDeps): Promise<Respons
 async function obtainFile(body: HelperOpenRequest, tmpFile: string, deps: OpenDeps): Promise<Response | null> {
   const ref: SourceRef = toSourceRef(body);
   const key = sourceCacheKey(ref) ?? "";
+  // Local-first (ADR 0032): en osynkad lokal ändring är auktoritativ tills den
+  // synkats → öppna den i st.f. att hämta serverns (ännu) gamla version.
+  const local = deps.pendingBytes ? await deps.pendingBytes(ref) : null;
+  if (local) {
+    await writeFile(tmpFile, local);
+    log(`local-first: öppnar osynkad lokal version av ${body.fileName}`);
+    return null;
+  }
   let bytes: Uint8Array;
   try {
     bytes = await deps.download(ref, body.authHeader);

--- a/helper-ui/src/engine/queue.ts
+++ b/helper-ui/src/engine/queue.ts
@@ -251,6 +251,21 @@ export class UploadQueue {
     await writeFile(this.manifestPath(entry.id), JSON.stringify(entry), "utf8");
   }
 
+  /**
+   * De köade bytsen för ett dokument (väntande/osynkad lokal ändring), eller
+   * null om inget köat finns. Local-first läsning (ADR 0032): en osynkad ändring
+   * är auktoritativ tills den laddats upp.
+   */
+  async peekByKey(key: string): Promise<Uint8Array | null> {
+    const entry = this.entries.get(key);
+    if (entry === undefined) return null;
+    try {
+      return new Uint8Array(await readFile(this.contentPath(entry.id)));
+    } catch {
+      return null;
+    }
+  }
+
   /** Ta bort en post helt (klar eller manuellt löst). */
   async discard(entry: QueueEntry): Promise<void> {
     this.entries.delete(entryKey(entry));

--- a/helper-ui/test/content.test.ts
+++ b/helper-ui/test/content.test.ts
@@ -79,6 +79,20 @@ describe("handleContent", () => {
     expect(seenId).toBe("abc");
   });
 
+  test("local-first: väntande lokal kopia servas, ingen load/fetch (ADR 0032)", async () => {
+    let loaded = false;
+    let fetched = false;
+    const res = await handleContent(contentReq({ document: { id: "d1", trpcUrl: "x" } }), {
+      pending: async () => bytes("LOKAL"),
+      load: async () => { loaded = true; return null; },
+      fetchAndCache: async () => { fetched = true; return null; },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("LOKAL");
+    expect(loaded).toBe(false);
+    expect(fetched).toBe(false);
+  });
+
   test("miss + offline (hämtning ger null) → 502", async () => {
     const res = await handleContent(contentReq({ downloadUrl: "http://s/d/1" }), base);
     expect(res.status).toBe(502);

--- a/helper-ui/test/open.test.ts
+++ b/helper-ui/test/open.test.ts
@@ -70,6 +70,14 @@ describe("handleOpen", () => {
     expect(rec.downloaded).toEqual(["doc:doc-7"]);
   });
 
+  test("local-first: väntande lokal kopia öppnas, ingen download (ADR 0032)", async () => {
+    const rec = recorder({ pendingBytes: async () => new TextEncoder().encode("LOKAL-EDIT") });
+    const res = await handleOpen(openReq({ document: { id: "d1", trpcUrl: "x" }, fileName: "a.docx" }), rec.deps);
+    expect(res.status).toBe(200);
+    expect(rec.downloaded).toHaveLength(0); // download hoppades över
+    expect(await readFile(join(rec.sessionDir, "a.docx"), "utf8")).toBe("LOKAL-EDIT");
+  });
+
   test("startar watch när uploadUrl satt (default 60 min)", async () => {
     const rec = recorder();
     await handleOpen(openReq({ downloadUrl: "http://x/f", fileName: "a.pdf", uploadUrl: "http://x/u" }), rec.deps);

--- a/helper-ui/test/queue.test.ts
+++ b/helper-ui/test/queue.test.ts
@@ -90,6 +90,26 @@ describe("UploadQueue.enqueue", () => {
   });
 });
 
+describe("UploadQueue.peekByKey (ADR 0032 local-first)", () => {
+  let dir: string;
+  beforeEach(async () => { dir = await tmpDir(); });
+
+  test("returnerar köade bytes för dokumentet (osynkad lokal ändring)", async () => {
+    const { deps } = fakeDeps([200]);
+    const q = new UploadQueue(dir, deps);
+    await q.enqueue({ document: { id: "d1", trpcUrl: "x" }, fileName: "a.docx", bytes: bytes("EDIT") });
+    const got = await q.peekByKey("doc:d1");
+    expect(got).not.toBeNull();
+    expect(new TextDecoder().decode(got!)).toBe("EDIT");
+  });
+
+  test("null när inget köat finns för nyckeln", async () => {
+    const { deps } = fakeDeps([200]);
+    const q = new UploadQueue(dir, deps);
+    expect(await q.peekByKey("doc:saknas")).toBeNull();
+  });
+});
+
 describe("UploadQueue.drainOnce", () => {
   let dir: string;
   beforeEach(async () => { dir = await tmpDir(); });


### PR DESCRIPTION
## Problem (du rapporterade)
Klick på dokument → redigera → spara → stäng Word → **klicka igen direkt** gav serverns **gamla** version (synken hade inte hunnit). Värre: re-redigering av den gamla kopian kunde **skugga** den väntande kö-posten (senaste-vinner) → förlust.

## Fix (ADR 0032)
En osynkad lokal ändring är **auktoritativ** tills den synkats. Läs-prioritet i helpern: **väntande lokal kö-kopia → server → offline-cache**.

- `UploadQueue.peekByKey(key)` — läser de köade (osynkade) bytsen för ett dokument.
- `obtainFile` (`/open`) + `handleContent` (`/content`) — kollar väntande lokal kopia FÖRST.
- `startEngine`-wiring (`pendingBytes`/`pending` → `queue.peekByKey`).

Efter synk (kö-posten uppladdad/rensad) → läsning går tillbaka till servern, som då har ändringen. Demo opåverkad (read-only, ingen kö).

## Verifierat
- helper-ui `tsc` + **272 tester** (coverage-grind; nya: peekByKey + local-first-grenarna i open/content), main `tsc`, `deps:check` 0 brott, eslint.

Closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)