### PR TITLE
feat(helper): optimistisk version på write-back — 409 vid drift (ADR 0033 §1)

### DIFF
--- a/docs/adr/0033-konflikthantering-mjuk-lease-keep-both.md
+++ b/docs/adr/0033-konflikthantering-mjuk-lease-keep-both.md
@@ -121,10 +121,14 @@ gör att ingenting någonsin försvinner — man kan alltid backa.
   lease-store (med heartbeat/TTL/omtilldelning), och dokument-versionering som
   bär två grenar vid keep-both.
 
-## Genomförande (en PR per steg, ej påbörjat)
+## Genomförande (en PR per steg)
 
-1. **Optimistisk version** på `document.uploadContent` (base-version in → 409 vid
-   drift). Helpern bär basversionen från `downloadContent`.
+1. ✅ **Optimistisk version** på `document.uploadContent` (base-version in → 409 vid
+   drift). Helpern bär basversionen från `downloadContent` och **framskriver** den
+   från varje lyckad uploads svar (annars self-konflikt vid upprepade saves);
+   `baseVersion` persisteras durabelt på kö-posten. Anchor = `version` (metadata-
+   skrivningar går via `updateMetadata` som inte bumpar → inga falska 409). En äkta
+   konflikt markeras `conflict` i kön + ytläggs i synk-bannern. *(#718)*
 2. **Keep-both vid 409:** kö-posten i `conflict` materialiseras som en separat
    version/kopia + klarspråks-meddelande i UI (ersätter dagens "vägrar tyst").
 3. **Lease-store + endpoints** (acquire/renew/release/reclaim/takeover), heartbeat

--- a/helper-ui/src/engine/content.ts
+++ b/helper-ui/src/engine/content.ts
@@ -85,7 +85,7 @@ export async function fetchAndCacheContent(
   fileName: string,
 ): Promise<Uint8Array | null> {
   try {
-    const bytes = await fetchSourceBytes(ref, authHeader !== undefined ? { authHeader } : {});
+    const { bytes } = await fetchSourceBytes(ref, authHeader !== undefined ? { authHeader } : {});
     await store.store(cacheKey, bytes, fileName);
     return bytes;
   } catch (err) {

--- a/helper-ui/src/engine/document-source.ts
+++ b/helper-ui/src/engine/document-source.ts
@@ -9,7 +9,7 @@
 
 import type { HelperDocumentRef } from "@/lib/shared/helper/protocol";
 
-import { createDocumentClient, downloadDocumentBytes, uploadDocumentBytes, type FetchLike } from "./trpc-client.ts";
+import { createDocumentClient, downloadDocumentBytes, uploadDocumentBytes, type FetchLike, type UploadDocResult } from "./trpc-client.ts";
 
 /** En dokument-källa: tRPC (`document`) ELLER statisk URL (`downloadUrl`). */
 export interface SourceRef {
@@ -41,15 +41,22 @@ export interface FetchSourceDeps {
   fetch?: FetchLike;
 }
 
+/** Bytes + (server-tier) basversion för optimistisk versionskontroll (ADR 0033 §1). */
+export interface SourceBytes {
+  bytes: Uint8Array;
+  /** Serverversionen vid hämtning; undefined för statisk/demo-källa. */
+  version?: number;
+}
+
 /** Hämta dokument-bytes för en källa: tRPC (server) eller statisk URL (demo). */
-export async function fetchSourceBytes(ref: SourceRef, deps: FetchSourceDeps = {}): Promise<Uint8Array> {
+export async function fetchSourceBytes(ref: SourceRef, deps: FetchSourceDeps = {}): Promise<SourceBytes> {
   if (ref.document) return fetchViaTrpc(ref.document, deps);
   if (!ref.downloadUrl) throw new Error("ingen källa (varken document eller downloadUrl)");
-  return fetchViaUrl(ref.downloadUrl, deps);
+  return { bytes: await fetchViaUrl(ref.downloadUrl, deps) };
 }
 
 /** Server-tier: hämta via den typade tRPC-proceduren `document.downloadContent`. */
-async function fetchViaTrpc(ref: HelperDocumentRef, deps: FetchSourceDeps): Promise<Uint8Array> {
+async function fetchViaTrpc(ref: HelperDocumentRef, deps: FetchSourceDeps): Promise<SourceBytes> {
   // tRPC vill ha rå token; helperns authHeader är "Bearer <token>".
   const token = (deps.authHeader ?? "").replace(/^Bearer\s+/i, "");
   const client = createDocumentClient({
@@ -57,7 +64,8 @@ async function fetchViaTrpc(ref: HelperDocumentRef, deps: FetchSourceDeps): Prom
     token,
     ...(deps.fetch ? { fetch: deps.fetch } : {}),
   });
-  return (await downloadDocumentBytes(client, ref.id)).bytes;
+  const dl = await downloadDocumentBytes(client, ref.id);
+  return { bytes: dl.bytes, version: dl.version };
 }
 
 /** Demo/statisk: hämta bytes från en blob-URL (valfri Authorization-header). */
@@ -74,6 +82,8 @@ async function fetchViaUrl(url: string, deps: FetchSourceDeps): Promise<Uint8Arr
 export interface UploadTarget {
   document?: HelperDocumentRef;
   uploadUrl?: string;
+  /** Basversionen sessionen redigerar från (ADR 0033 §1); bärs till kö-enqueue. */
+  baseVersion?: number;
 }
 
 /** Stabil kö-/cache-nyckel för ett upload-mål (matchar `sourceCacheKey`). */
@@ -82,17 +92,22 @@ export function uploadTargetKey(t: UploadTarget): string | null {
   return t.uploadUrl ?? null;
 }
 
-/** Skriv tillbaka dokument-bytes via tRPC `document.uploadContent` (server-tier). */
+/**
+ * Skriv tillbaka dokument-bytes via tRPC `document.uploadContent` (server-tier).
+ * `baseVersion` → optimistisk versionskontroll (ADR 0033 §1); returnerar
+ * utfallet (`ok` med ny version / `conflict`) så kön kan framskriva/markera.
+ */
 export async function uploadViaTrpc(
   document: HelperDocumentRef,
   bytes: Uint8Array,
+  baseVersion?: number,
   deps: FetchSourceDeps = {},
-): Promise<void> {
+): Promise<UploadDocResult> {
   const token = (deps.authHeader ?? "").replace(/^Bearer\s+/i, "");
   const client = createDocumentClient({
     trpcUrl: document.trpcUrl,
     token,
     ...(deps.fetch ? { fetch: deps.fetch } : {}),
   });
-  await uploadDocumentBytes(client, document.id, bytes);
+  return uploadDocumentBytes(client, document.id, bytes, baseVersion);
 }

--- a/helper-ui/src/engine/open.ts
+++ b/helper-ui/src/engine/open.ts
@@ -13,7 +13,7 @@ import { basename, join } from "node:path";
 
 import { isSafeFileName, type HelperOpenRequest } from "@/lib/shared/helper/protocol";
 import type { ContentStore } from "./content-store.ts";
-import { fetchSourceBytes, sourceCacheKey, toSourceRef, uploadViaTrpc, type SourceRef, type UploadTarget } from "./document-source.ts";
+import { fetchSourceBytes, sourceCacheKey, toSourceRef, uploadViaTrpc, type SourceBytes, type SourceRef, type UploadTarget } from "./document-source.ts";
 import { json, parseJsonBody, textError } from "./http.ts";
 import { log } from "./log.ts";
 import { openWithDefaultApp } from "./platform/open-app.ts";
@@ -25,8 +25,8 @@ const POLL_INTERVAL_MS = 2_000;
 export interface OpenDeps {
   /** Väntande lokal (osynkad) kopia, eller null (ADR 0032 local-first). Provas FÖRE download. */
   pendingBytes?: (ref: SourceRef) => Promise<Uint8Array | null>;
-  /** Hämta dokument-bytes för en källa (tRPC server-tier / statisk demo, ADR 0031). */
-  download: (ref: SourceRef, authHeader?: string) => Promise<Uint8Array>;
+  /** Hämta dokument-bytes + (server-tier) basversion för en källa (ADR 0031/0033). */
+  download: (ref: SourceRef, authHeader?: string) => Promise<SourceBytes>;
   openApp: (path: string) => Promise<void>;
   makeSessionDir: () => Promise<string>;
   startWatch: (path: string, target: UploadTarget, authHeader: string | undefined, timeoutMs: number) => void;
@@ -66,40 +66,47 @@ async function runOpen(body: HelperOpenRequest, deps: OpenDeps): Promise<Respons
   const sessionDir = await deps.makeSessionDir();
   const tmpFile = join(sessionDir, body.fileName);
 
-  const obtainErr = await obtainFile(body, tmpFile, deps);
-  if (obtainErr) return obtainErr;
+  const obtained = await obtainFile(body, tmpFile, deps);
+  if (obtained instanceof Response) return obtained;
   const openErr = await tryStep(() => deps.openApp(tmpFile), 500, "open failed");
   if (openErr) return openErr;
 
-  startWatchIfNeeded(body, tmpFile, deps);
+  startWatchIfNeeded(body, tmpFile, deps, obtained.version);
   return json({ path: tmpFile, status: "opened" });
+}
+
+/** Filen är skaffad; `version` = serverns basversion (ADR 0033), om känd. */
+interface Obtained {
+  version?: number;
 }
 
 /**
  * Skaffa filen till `tmpFile`: ladda ner och cacha (för offline-reopen), eller
  * — om nedladdning misslyckas (offline) — återställ en tidigare cachad kopia.
- * Returnerar en fel-Response om filen inte kan skaffas, annars null.
+ * Returnerar en fel-Response om filen inte kan skaffas, annars basversionen.
  */
-async function obtainFile(body: HelperOpenRequest, tmpFile: string, deps: OpenDeps): Promise<Response | null> {
+async function obtainFile(body: HelperOpenRequest, tmpFile: string, deps: OpenDeps): Promise<Response | Obtained> {
   const ref: SourceRef = toSourceRef(body);
   const key = sourceCacheKey(ref) ?? "";
   // Local-first (ADR 0032): en osynkad lokal ändring är auktoritativ tills den
-  // synkats → öppna den i st.f. att hämta serverns (ännu) gamla version.
+  // synkats → öppna den i st.f. att hämta serverns (ännu) gamla version. Basen
+  // hålls redan av kön (den väntande posten) → ingen download-version här.
   const local = deps.pendingBytes ? await deps.pendingBytes(ref) : null;
   if (local) {
     await writeFile(tmpFile, local);
     log(`local-first: öppnar osynkad lokal version av ${body.fileName}`);
-    return null;
+    return {};
   }
-  let bytes: Uint8Array;
+  let dl: SourceBytes;
   try {
-    bytes = await deps.download(ref, body.authHeader);
+    dl = await deps.download(ref, body.authHeader);
   } catch (err) {
-    return downloadFailureFallback(body, tmpFile, key, deps, err);
+    const fallback = await downloadFailureFallback(body, tmpFile, key, deps, err);
+    return fallback ?? {}; // null = återställd offline (ingen känd version)
   }
-  await writeFile(tmpFile, bytes);
-  await cacheBytes(deps, key, bytes, body.fileName);
-  return null;
+  await writeFile(tmpFile, dl.bytes);
+  await cacheBytes(deps, key, dl.bytes, body.fileName);
+  return dl.version !== undefined ? { version: dl.version } : {};
 }
 
 /** Nedladdning misslyckades → öppna cachad kopia om möjligt (offline), annars 502. */
@@ -134,10 +141,11 @@ async function tryStep(fn: () => Promise<void>, status: number, label: string): 
   }
 }
 
-function startWatchIfNeeded(body: HelperOpenRequest, tmpFile: string, deps: OpenDeps): void {
-  // Write-back-mål: tRPC-dokument (server, ADR 0031) ELLER PUT-URL (demo).
+function startWatchIfNeeded(body: HelperOpenRequest, tmpFile: string, deps: OpenDeps, baseVersion?: number): void {
+  // Write-back-mål: tRPC-dokument (server, ADR 0031) ELLER PUT-URL (demo). Server-
+  // målet bär basversionen (ADR 0033 §1) som kön versionskollar uploaden mot.
   const target: UploadTarget | null = body.document
-    ? { document: body.document }
+    ? { document: body.document, ...(baseVersion !== undefined ? { baseVersion } : {}) }
     : body.uploadUrl
       ? { uploadUrl: body.uploadUrl }
       : null;
@@ -166,7 +174,9 @@ export async function uploadFile(path: string, uploadUrl: string, authHeader: st
 export async function uploadSavedFile(path: string, target: UploadTarget, authHeader: string | undefined): Promise<void> {
   if (target.document) {
     const bytes = new Uint8Array(await readFile(path));
-    await uploadViaTrpc(target.document, bytes, authHeader !== undefined ? { authHeader } : {});
+    // Direkt-uppladdning (ingen durabel kö wirad) — versionskolla ändå (ADR 0033).
+    const result = await uploadViaTrpc(target.document, bytes, target.baseVersion, authHeader !== undefined ? { authHeader } : {});
+    if (result.status === "conflict") throw new Error("versions-konflikt (server gått förbi)");
     return;
   }
   if (!target.uploadUrl) throw new Error("inget upload-mål");
@@ -219,6 +229,7 @@ export async function enqueueSavedFile(
     fileName: basename(path),
     bytes,
     ...(authHeader !== undefined ? { authHeader } : {}),
+    ...(target.baseVersion !== undefined ? { baseVersion: target.baseVersion } : {}),
   });
 }
 

--- a/helper-ui/src/engine/queue.ts
+++ b/helper-ui/src/engine/queue.ts
@@ -21,6 +21,7 @@ import { join } from "node:path";
 import type { HelperDocumentRef, HelperStatusResponse, HelperSyncEntry } from "@/lib/shared/helper/protocol";
 import { uploadTargetKey, uploadViaTrpc } from "./document-source.ts";
 import { log } from "./log.ts";
+import type { UploadDocResult } from "./trpc-client.ts";
 
 /**
  * En köad upload som väntar på att nå servern. Delar form med det publika
@@ -49,8 +50,12 @@ export interface QueueDeps {
   newId: () => string;
   /** PUT bytes (demo/legacy) → returnera HTTP-status (kastar bara vid nätfel). */
   put: (url: string, body: Uint8Array, authHeader?: string) => Promise<number>;
-  /** Write-back via tRPC `document.uploadContent` (server-tier); kastar vid fel. */
-  uploadDoc: (document: HelperDocumentRef, body: Uint8Array, authHeader?: string) => Promise<void>;
+  /**
+   * Write-back via tRPC `document.uploadContent` (server-tier). `baseVersion` →
+   * optimistisk versionskontroll (ADR 0033 §1); returnerar `ok` med ny version
+   * (framskriver basen) eller `conflict`. Kastar bara vid nät/auth-fel.
+   */
+  uploadDoc: (document: HelperDocumentRef, body: Uint8Array, authHeader?: string, baseVersion?: number) => Promise<UploadDocResult>;
 }
 
 export const defaultQueueDeps: QueueDeps = {
@@ -63,8 +68,8 @@ export const defaultQueueDeps: QueueDeps = {
     const resp = await fetch(url, { method: "PUT", headers, body: new Blob([new Uint8Array(body)]) });
     return resp.status;
   },
-  uploadDoc: (document, body, authHeader) =>
-    uploadViaTrpc(document, body, authHeader !== undefined ? { authHeader } : {}),
+  uploadDoc: (document, body, authHeader, baseVersion) =>
+    uploadViaTrpc(document, body, baseVersion, authHeader !== undefined ? { authHeader } : {}),
 };
 
 const BASE_BACKOFF_MS = 5_000;
@@ -87,11 +92,32 @@ export interface EnqueueInput {
   fileName: string;
   bytes: Uint8Array;
   authHeader?: string;
+  /** Basversionen sessionen öppnade dokumentet på (ADR 0033 §1, server-tier). */
+  baseVersion?: number;
 }
 
 /** Stabil identitet för en post (dedup-nyckel): `doc:<id>` eller PUT-URL. */
 function entryKey(e: { document?: HelperDocumentRef; uploadUrl?: string }): string {
   return uploadTargetKey(e) ?? "";
+}
+
+/** Bygg en kö-post ur input + härledd metadata (utelämnar undefined-fält, exactOptional). */
+function buildEntry(
+  input: EnqueueInput,
+  meta: { id: string; baseVersion: number | undefined; enqueuedAt: number; now: number },
+): QueueEntry {
+  return {
+    id: meta.id,
+    ...(input.document ? { document: input.document } : {}),
+    ...(input.uploadUrl !== undefined ? { uploadUrl: input.uploadUrl } : {}),
+    fileName: input.fileName,
+    ...(input.authHeader !== undefined ? { authHeader: input.authHeader } : {}),
+    ...(meta.baseVersion !== undefined ? { baseVersion: meta.baseVersion } : {}),
+    enqueuedAt: meta.enqueuedAt,
+    attempts: 0,
+    nextAttemptAt: meta.now,
+    status: "pending",
+  };
 }
 
 /**
@@ -104,6 +130,14 @@ export class UploadQueue {
   private readonly deps: QueueDeps;
   private readonly tokenProvider: (() => Promise<string | undefined>) | undefined;
   private readonly entries = new Map<string, QueueEntry>();
+  /**
+   * Framskrivande basversion per dokument (ADR 0033 §1). Seedas med den version
+   * sessionen öppnade på och flyttas fram till varje LYCKAD uploads svar-version
+   * — annars skulle helperns egna upprepade saves (watch-loopen bumpar servern
+   * varje gång) falskt self-konflikta. In-memory: en undränerad post bär sin
+   * egen `baseVersion` på disk; vid återöppning seedas kartan om från servern.
+   */
+  private readonly serverVersions = new Map<string, number>();
   private draining = false;
 
   /**
@@ -140,7 +174,11 @@ export class UploadQueue {
       try {
         const entry = JSON.parse(await readFile(this.manifestPath(id), "utf8")) as StoredEntry;
         await readFile(this.contentPath(id)); // bytes måste finnas, annars släng manifestet
-        this.entries.set(entryKey(entry), entry);
+        const key = entryKey(entry);
+        this.entries.set(key, entry);
+        // Återställ den framskrivande basversionen (ADR 0033 §1) så en återöppning
+        // inte nollställer den till en äldre seed.
+        if (entry.baseVersion !== undefined) this.serverVersions.set(key, entry.baseVersion);
       } catch (err) {
         log(`queue: hoppar trasig post ${id}: ${msg(err)}`);
       }
@@ -159,23 +197,26 @@ export class UploadQueue {
     const existing = this.entries.get(key);
     const id = existing?.id ?? this.deps.newId();
     const now = this.deps.now();
+    const baseVersion = this.resolveBaseVersion(key, input.baseVersion);
     // Bytes först (durabilitet), sedan manifest — manifestets närvaro = giltig post.
     await writeFile(this.contentPath(id), input.bytes);
-    const entry: QueueEntry = {
-      id,
-      ...(input.document ? { document: input.document } : {}),
-      ...(input.uploadUrl !== undefined ? { uploadUrl: input.uploadUrl } : {}),
-      fileName: input.fileName,
-      ...(input.authHeader !== undefined ? { authHeader: input.authHeader } : {}),
-      enqueuedAt: existing?.enqueuedAt ?? now,
-      attempts: 0,
-      nextAttemptAt: now,
-      status: "pending",
-    };
+    const entry = buildEntry(input, { id, baseVersion, enqueuedAt: existing?.enqueuedAt ?? now, now });
     await writeFile(this.manifestPath(id), JSON.stringify(entry), "utf8");
     this.entries.set(key, entry);
     log(`queue: köade ${input.fileName} (${this.pendingCount()} väntar)`);
     return entry;
+  }
+
+  /**
+   * Seeda den framskrivande basversionen FÖRSTA gången vi ser dokumentet; senare
+   * saves behåller den version servern bekräftade på vår senaste lyckade upload
+   * (framskriven i {@link attempt}). Returnerar effektiv basversion för posten.
+   */
+  private resolveBaseVersion(key: string, inputBase?: number): number | undefined {
+    if (inputBase !== undefined && !this.serverVersions.has(key)) {
+      this.serverVersions.set(key, inputBase);
+    }
+    return this.serverVersions.get(key);
   }
 
   /**
@@ -202,15 +243,28 @@ export class UploadQueue {
     return res;
   }
 
+  /** Egen authHeader (från browsern) först; annars helperns färska OIDC-token. */
+  private async resolveAuth(entry: QueueEntry): Promise<string | undefined> {
+    return entry.authHeader ?? (this.tokenProvider ? await this.tokenProvider() : undefined);
+  }
+
   private async attempt(entry: QueueEntry, res: DrainResult): Promise<void> {
     let status: number;
     try {
       const bytes = await readFile(this.contentPath(entry.id));
-      // Egen authHeader (från browsern) först; annars helperns färska OIDC-token.
-      const auth = entry.authHeader ?? (this.tokenProvider ? await this.tokenProvider() : undefined);
+      const auth = await this.resolveAuth(entry);
       if (entry.document) {
-        // Server-tier: tRPC uploadContent (kastar vid fel → markFailed nedan).
-        await this.deps.uploadDoc(entry.document, bytes, auth);
+        // Server-tier: tRPC uploadContent. Konflikt signaleras i utfallet (ej kast);
+        // nät/auth-fel kastar → markFailed nedan.
+        const result = await this.deps.uploadDoc(entry.document, bytes, auth, entry.baseVersion);
+        if (result.status === "conflict") {
+          await this.markConflict(entry);
+          res.conflicted++;
+          log(`queue: KONFLIKT på ${entry.fileName} — server gått förbi, kräver beslut`);
+          return;
+        }
+        // Framskriv basen så nästa save på samma dokument inte self-konflikt:ar.
+        this.serverVersions.set(entryKey(entry), result.version);
         status = 200;
       } else {
         status = await this.deps.put(entry.uploadUrl ?? "", bytes, auth);

--- a/helper-ui/src/engine/trpc-client.ts
+++ b/helper-ui/src/engine/trpc-client.ts
@@ -12,7 +12,7 @@
  * `src/lib/client/addin/`-factoryn (bakom client-gränsen), därav en egen.
  */
 
-import { createTRPCClient, httpBatchLink, type TRPCClient } from "@trpc/client";
+import { createTRPCClient, httpBatchLink, TRPCClientError, type TRPCClient } from "@trpc/client";
 import superjson from "superjson";
 
 import type { AppRouter } from "@/lib/server/routers/_app";
@@ -69,6 +69,8 @@ export interface DocumentBytes {
   bytes: Uint8Array;
   mimeType: string;
   fileName: string;
+  /** Dokumentets serverversion = basversion för nästa uploadContent (ADR 0033 §1). */
+  version: number;
 }
 
 /** Hämta dokument-bytes via den typade `document.downloadContent`-proceduren. */
@@ -77,14 +79,36 @@ export async function downloadDocumentBytes(
   documentId: string,
 ): Promise<DocumentBytes> {
   const res = await client.document.downloadContent.query({ documentId });
-  return { bytes: base64ToBytes(res.contentBase64), mimeType: res.mimeType, fileName: res.fileName };
+  return { bytes: base64ToBytes(res.contentBase64), mimeType: res.mimeType, fileName: res.fileName, version: res.version };
 }
 
-/** Skriv tillbaka dokument-bytes via den typade `document.uploadContent`-mutationen. */
+/**
+ * Utfall av en write-back (ADR 0033 §1): `ok` med den nya serverversionen
+ * (framskriver klientens basversion) eller `conflict` (servern gått förbi →
+ * keep-both, steg 2). Andra fel kastas vidare (nät/auth → backoff i kön).
+ */
+export type UploadDocResult = { status: "ok"; version: number } | { status: "conflict" };
+
+/**
+ * Skriv tillbaka dokument-bytes via den typade `document.uploadContent`-mutationen.
+ * `baseVersion` (om satt) → servern 409:ar vid drift; vi mappar 409 till
+ * `{status:"conflict"}` i st.f. att kasta, så kön kan markera posten conflict.
+ */
 export async function uploadDocumentBytes(
   client: TRPCClient<AppRouter>,
   documentId: string,
   bytes: Uint8Array,
-): Promise<void> {
-  await client.document.uploadContent.mutate({ documentId, contentBase64: bytesToBase64(bytes) });
+  baseVersion?: number,
+): Promise<UploadDocResult> {
+  try {
+    const updated = await client.document.uploadContent.mutate({
+      documentId,
+      contentBase64: bytesToBase64(bytes),
+      ...(baseVersion !== undefined ? { baseVersion } : {}),
+    });
+    return { status: "ok", version: updated.version };
+  } catch (err) {
+    if (err instanceof TRPCClientError && err.data?.code === "CONFLICT") return { status: "conflict" };
+    throw err;
+  }
 }

--- a/helper-ui/test/auth-orchestration.test.ts
+++ b/helper-ui/test/auth-orchestration.test.ts
@@ -151,7 +151,7 @@ describe("UploadQueue tokenProvider (autonom Bearer vid drain)", () => {
 
   test("post utan egen authHeader → använder färsk token vid upload", async () => {
     const puts: Array<string | undefined> = [];
-    const deps = { now: () => 1000, newId: () => "id1", put: async (_u: string, _b: Uint8Array, auth?: string) => { puts.push(auth); return 200; }, uploadDoc: async () => undefined };
+    const deps = { now: () => 1000, newId: () => "id1", put: async (_u: string, _b: Uint8Array, auth?: string) => { puts.push(auth); return 200; }, uploadDoc: async () => ({ status: "ok" as const, version: 1 }) };
     const q = new UploadQueue(await qdir(), deps, async () => "Bearer FRESH");
     await q.enqueue({ uploadUrl: "http://s/u/1", fileName: "a", bytes: new TextEncoder().encode("x") });
     await q.drainOnce();
@@ -161,7 +161,7 @@ describe("UploadQueue tokenProvider (autonom Bearer vid drain)", () => {
 
   test("post MED egen authHeader → den vinner över token-providern", async () => {
     const puts: Array<string | undefined> = [];
-    const deps = { now: () => 1000, newId: () => "id2", put: async (_u: string, _b: Uint8Array, auth?: string) => { puts.push(auth); return 200; }, uploadDoc: async () => undefined };
+    const deps = { now: () => 1000, newId: () => "id2", put: async (_u: string, _b: Uint8Array, auth?: string) => { puts.push(auth); return 200; }, uploadDoc: async () => ({ status: "ok" as const, version: 1 }) };
     const q = new UploadQueue(await qdir(), deps, async () => "Bearer FRESH");
     await q.enqueue({ uploadUrl: "http://s/u/2", fileName: "a", bytes: new TextEncoder().encode("x"), authHeader: "Bearer BROWSER" });
     await q.drainOnce();

--- a/helper-ui/test/io.test.ts
+++ b/helper-ui/test/io.test.ts
@@ -22,8 +22,8 @@ describe("fetchSourceBytes (statisk källa, integration)", () => {
   test("hämtar bytes från downloadUrl", async () => {
     const server = Bun.serve({ port: 0, fetch: () => new Response("PDF-bytes") });
     try {
-      const got = await fetchSourceBytes({ downloadUrl: `http://127.0.0.1:${server.port}/f` });
-      expect(new TextDecoder().decode(got)).toBe("PDF-bytes");
+      const { bytes } = await fetchSourceBytes({ downloadUrl: `http://127.0.0.1:${server.port}/f` });
+      expect(new TextDecoder().decode(bytes)).toBe("PDF-bytes");
     } finally {
       void server.stop(true);
     }

--- a/helper-ui/test/open.test.ts
+++ b/helper-ui/test/open.test.ts
@@ -23,10 +23,10 @@ interface Recorder {
 function recorder(overrides: Partial<OpenDeps> = {}): Recorder {
   const rec: Recorder = { sessionDir: "", downloaded: [], opened: [], watched: [], deps: {} as OpenDeps };
   rec.deps = {
-    // Returnerar bytes (ADR 0031); obtainFile skriver filen.
+    // Returnerar bytes + basversion (ADR 0031/0033); obtainFile skriver filen.
     download: async (ref) => {
       rec.downloaded.push(ref.downloadUrl ?? `doc:${ref.document?.id ?? ""}`);
-      return new TextEncoder().encode("DL");
+      return { bytes: new TextEncoder().encode("DL"), ...(ref.document ? { version: 7 } : {}) };
     },
     openApp: async (path) => { rec.opened.push(path); },
     makeSessionDir: async () => {
@@ -76,6 +76,20 @@ describe("handleOpen", () => {
     expect(res.status).toBe(200);
     expect(rec.downloaded).toHaveLength(0); // download hoppades över
     expect(await readFile(join(rec.sessionDir, "a.docx"), "utf8")).toBe("LOKAL-EDIT");
+  });
+
+  test("document-källa → watch-målet bär nedladdningens basversion (ADR 0033 §1)", async () => {
+    const rec = recorder();
+    await handleOpen(openReq({ document: { id: "doc-7", trpcUrl: "http://s/api/trpc" }, fileName: "a.docx" }), rec.deps);
+    expect(rec.watched).toHaveLength(1);
+    expect(rec.watched[0]?.target).toMatchObject({ document: { id: "doc-7" }, baseVersion: 7 });
+  });
+
+  test("local-first lokal kopia → ingen download-version (kön äger basen)", async () => {
+    const rec = recorder({ pendingBytes: async () => new TextEncoder().encode("LOKAL") });
+    await handleOpen(openReq({ document: { id: "doc-7", trpcUrl: "http://s/api/trpc" }, fileName: "a.docx" }), rec.deps);
+    expect(rec.downloaded).toHaveLength(0); // hämtade aldrig (local-first)
+    expect(rec.watched[0]?.target.baseVersion).toBeUndefined();
   });
 
   test("startar watch när uploadUrl satt (default 60 min)", async () => {
@@ -193,10 +207,10 @@ describe("enqueueSavedFile", () => {
     await writeFile(filePath, "ändrat innehåll", "utf8");
 
     const queue = new UploadQueue(qdir);
-    await enqueueSavedFile(queue, filePath, { document: { id: "doc-7", trpcUrl: "http://s/api/trpc" } }, "Bearer tok");
+    await enqueueSavedFile(queue, filePath, { document: { id: "doc-7", trpcUrl: "http://s/api/trpc" }, baseVersion: 4 }, "Bearer tok");
 
     const snap = queue.snapshot();
     expect(snap.total).toBe(1);
-    expect(snap.entries[0]).toMatchObject({ document: { id: "doc-7" }, fileName: "avtal.docx", status: "pending" });
+    expect(snap.entries[0]).toMatchObject({ document: { id: "doc-7" }, fileName: "avtal.docx", status: "pending", baseVersion: 4 });
   });
 });

--- a/helper-ui/test/queue.test.ts
+++ b/helper-ui/test/queue.test.ts
@@ -12,6 +12,7 @@ import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 import superjson from "superjson";
 
 import { backoffMs, defaultQueueDeps, UploadQueue, type QueueDeps } from "../src/engine/queue.ts";
+import type { UploadDocResult } from "../src/engine/trpc-client.ts";
 
 const dirs: string[] = [];
 async function tmpDir(): Promise<string> {
@@ -23,12 +24,13 @@ afterAll(async () => {
   await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true })));
 });
 
-interface UploadDocCall { document: { id: string; trpcUrl: string }; body: Uint8Array; auth?: string }
+interface UploadDocCall { document: { id: string; trpcUrl: string }; body: Uint8Array; auth?: string; baseVersion?: number }
 
 /** Injicerbara deps: räknande klocka + förutsägbara id:n + skript-styrd PUT + tRPC-upload. */
 function fakeDeps(
   putStatuses: number[] | (() => Promise<number>),
   uploadDocFails = false,
+  uploadDocConflicts = false,
 ): { deps: QueueDeps; puts: Array<{ url: string; body: Uint8Array; auth?: string }>; uploadDocs: UploadDocCall[]; tick: () => void } {
   let t = 1000;
   let n = 0;
@@ -39,9 +41,14 @@ function fakeDeps(
     if (typeof putStatuses === "function") return putStatuses();
     return putStatuses[Math.min(puts.length - 1, putStatuses.length - 1)] ?? 200;
   };
-  const uploadDoc = async (document: { id: string; trpcUrl: string }, body: Uint8Array, auth?: string): Promise<void> => {
-    uploadDocs.push({ document, body, ...(auth !== undefined ? { auth } : {}) });
+  const uploadDoc = async (
+    document: { id: string; trpcUrl: string }, body: Uint8Array, auth?: string, baseVersion?: number,
+  ): Promise<UploadDocResult> => {
+    uploadDocs.push({ document, body, ...(auth !== undefined ? { auth } : {}), ...(baseVersion !== undefined ? { baseVersion } : {}) });
     if (uploadDocFails) throw new Error("trpc boom");
+    if (uploadDocConflicts) return { status: "conflict" };
+    // Framskriven version = base + 1 (gör advancing-base testbar).
+    return { status: "ok", version: (baseVersion ?? 0) + 1 };
   };
   return {
     deps: { now: () => t, newId: () => `id-${++n}`, put, uploadDoc },
@@ -138,6 +145,50 @@ describe("UploadQueue.drainOnce", () => {
     expect(f.uploadDocs[0]).toMatchObject({ document: { id: "d1" }, auth: "Bearer t" });
     expect(new TextDecoder().decode(f.uploadDocs[0]!.body)).toBe("data");
     expect(q.snapshot().total).toBe(0);
+  });
+
+  test("bär baseVersion till uploadDoc + persisterar den på posten (ADR 0033 §1)", async () => {
+    const f = fakeDeps([200]);
+    const q = new UploadQueue(dir, f.deps);
+    await q.enqueue({ document: { id: "d1", trpcUrl: "http://s/api/trpc" }, fileName: "a.docx", bytes: bytes("v1"), baseVersion: 5 });
+    // Posten bär basversionen (durabelt) innan den dräneras.
+    expect(q.snapshot().entries[0]).toMatchObject({ baseVersion: 5 });
+    await q.drainOnce();
+    expect(f.uploadDocs[0]).toMatchObject({ document: { id: "d1" }, baseVersion: 5 });
+  });
+
+  test("framskriver basen från lyckad upload → andra save self-konflikt:ar inte", async () => {
+    const f = fakeDeps([200]);
+    const q = new UploadQueue(dir, f.deps);
+    const target = { document: { id: "d1", trpcUrl: "http://s/api/trpc" }, fileName: "a.docx" };
+    // Save 1: base 5 → server bekräftar v6 (fakeDeps: version = base+1).
+    await q.enqueue({ ...target, bytes: bytes("v1"), baseVersion: 5 });
+    await q.drainOnce();
+    // Save 2: watch-loopen känner inte till den nya versionen (skickar ingen base);
+    // kön ska ändå hävda den FRAMSKRIVNA basen (6), inte den ursprungliga seeden (5).
+    await q.enqueue({ ...target, bytes: bytes("v2") });
+    await q.drainOnce();
+    expect(f.uploadDocs.map((c) => c.baseVersion)).toEqual([5, 6]);
+  });
+
+  test("document-konflikt (409) → markerar conflict, behåller base för beslut", async () => {
+    const f = fakeDeps([200], false, true); // uploadDoc → conflict
+    const q = new UploadQueue(dir, f.deps);
+    await q.enqueue({ document: { id: "d1", trpcUrl: "http://s/api/trpc" }, fileName: "a.docx", bytes: bytes("min"), baseVersion: 3 });
+    expect((await q.drainOnce()).conflicted).toBe(1);
+    expect(q.snapshot()).toMatchObject({ pending: 0, conflict: 1 });
+    expect(q.snapshot().entries[0]).toMatchObject({ status: "conflict", baseVersion: 3 });
+  });
+
+  test("återställd post seedar om den framskrivande basen (omstart-durabilitet)", async () => {
+    const f = fakeDeps([200]);
+    const q1 = new UploadQueue(dir, f.deps);
+    await q1.enqueue({ document: { id: "d1", trpcUrl: "http://s/api/trpc" }, fileName: "a.docx", bytes: bytes("v1"), baseVersion: 9 });
+    // Simulera omstart: ny kö läser posten från disk.
+    const q2 = new UploadQueue(dir, f.deps);
+    await q2.recover();
+    await q2.drainOnce();
+    expect(f.uploadDocs[0]).toMatchObject({ baseVersion: 9 });
   });
 
   test("document-upload kastar → failed, behålls för retry", async () => {
@@ -315,12 +366,13 @@ describe("defaultQueueDeps", () => {
     const orig = globalThis.fetch;
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       calls.push({ url: String(url), auth: new Headers(init?.headers).get("authorization") });
-      return new Response(JSON.stringify([{ result: { data: superjson.serialize({ id: "d1" }) } }]), {
+      return new Response(JSON.stringify([{ result: { data: superjson.serialize({ id: "d1", version: 4 }) } }]), {
         status: 200, headers: { "content-type": "application/json" },
       });
     }) as typeof fetch;
     try {
-      await defaultQueueDeps.uploadDoc({ id: "d1", trpcUrl: "http://s/api/trpc" }, bytes("x"), "Bearer t");
+      const result = await defaultQueueDeps.uploadDoc({ id: "d1", trpcUrl: "http://s/api/trpc" }, bytes("x"), "Bearer t", 3);
+      expect(result).toEqual({ status: "ok", version: 4 });
       expect(calls[0]!.url).toContain("/api/trpc");
       expect(calls[0]!.url).toContain("document.uploadContent");
       expect(calls[0]!.auth).toBe("Bearer t");

--- a/helper-ui/test/trpc-client.test.ts
+++ b/helper-ui/test/trpc-client.test.ts
@@ -12,8 +12,24 @@ import {
   createDocumentClient,
   documentTrpcEndpoint,
   downloadDocumentBytes,
+  uploadDocumentBytes,
   type FetchLike,
 } from "../src/engine/trpc-client.ts";
+
+/** Ett httpBatchLink-fel-svar: `{ error: <superjson(error-shape)> }` (se transformResult). */
+function batchError(code: string, httpStatus: number): Response {
+  const shape = { message: code, code: -32603, data: { code, httpStatus, path: "document.uploadContent" } };
+  return new Response(JSON.stringify([{ error: superjson.serialize(shape) }]), {
+    status: 200, headers: { "content-type": "application/json" },
+  });
+}
+
+/** Ett httpBatchLink-success-svar med superjson-kodad data. */
+function batchOk(data: unknown): Response {
+  return new Response(JSON.stringify([{ result: { data: superjson.serialize(data) } }]), {
+    status: 200, headers: { "content-type": "application/json" },
+  });
+}
 
 describe("documentTrpcEndpoint", () => {
   test("lägger på /api/trpc och trimmar avslutande slash", () => {
@@ -29,15 +45,12 @@ describe("createDocumentClient + downloadDocumentBytes", () => {
     const fetchImpl: FetchLike = async (input, init) => {
       captured.url = String(input);
       captured.auth = new Headers(init?.headers).get("authorization");
-      const out = {
+      // httpBatchLink-svar: array (batch) av { result: { data: <superjson> } }.
+      return batchOk({
         contentBase64: Buffer.from("PDF-BYTES").toString("base64"),
         mimeType: "application/pdf",
         fileName: "x.pdf",
-      };
-      // httpBatchLink-svar: array (batch) av { result: { data: <superjson> } }.
-      return new Response(JSON.stringify([{ result: { data: superjson.serialize(out) } }]), {
-        status: 200,
-        headers: { "content-type": "application/json" },
+        version: 5,
       });
     };
 
@@ -51,8 +64,36 @@ describe("createDocumentClient + downloadDocumentBytes", () => {
     expect(new TextDecoder().decode(res.bytes)).toBe("PDF-BYTES");
     expect(res.mimeType).toBe("application/pdf");
     expect(res.fileName).toBe("x.pdf");
+    expect(res.version).toBe(5); // basversion (ADR 0033 §1)
     expect(captured.url).toContain("/api/trpc");
     expect(captured.url).toContain("document.downloadContent");
     expect(captured.auth).toBe("Bearer tok-123");
+  });
+});
+
+describe("uploadDocumentBytes (ADR 0033 §1 — optimistisk version)", () => {
+  function clientWith(fetchImpl: FetchLike): ReturnType<typeof createDocumentClient> {
+    return createDocumentClient({ trpcUrl: "http://h:8080/api/trpc", token: "t", fetch: fetchImpl });
+  }
+
+  test("success → {status:'ok', version} och skickar med baseVersion", async () => {
+    let sentBody = "";
+    const client = clientWith(async (_input, init) => {
+      sentBody = String(init?.body ?? "");
+      return batchOk({ id: "doc-1", version: 9 });
+    });
+    const res = await uploadDocumentBytes(client, "doc-1", new TextEncoder().encode("x"), 8);
+    expect(res).toEqual({ status: "ok", version: 9 });
+    expect(sentBody).toContain("\"baseVersion\""); // basversionen bars med i mutationen
+  });
+
+  test("409 CONFLICT → {status:'conflict'} (kastar inte)", async () => {
+    const client = clientWith(async () => batchError("CONFLICT", 409));
+    expect(await uploadDocumentBytes(client, "doc-1", new TextEncoder().encode("x"), 3)).toEqual({ status: "conflict" });
+  });
+
+  test("annat fel (t.ex. INTERNAL_SERVER_ERROR) → kastar vidare (→ kö-backoff)", async () => {
+    const client = clientWith(async () => batchError("INTERNAL_SERVER_ERROR", 500));
+    await expect(uploadDocumentBytes(client, "doc-1", new TextEncoder().encode("x"), 3)).rejects.toThrow();
   });
 });

--- a/src/lib/server/routers/document/core.ts
+++ b/src/lib/server/routers/document/core.ts
@@ -164,9 +164,30 @@ export const coreProcedures = {
    * (analysen körs server-side via jobb-kön). Gamla bytes behålls (git-historik).
    */
   uploadContent: orgProcedure
-    .input(z.object({ documentId: z.string(), contentBase64: z.string() }))
+    .input(z.object({
+      documentId: z.string(),
+      contentBase64: z.string(),
+      /**
+       * Optimistisk version (ADR 0033 §1): versionen klienten redigerade från.
+       * Har servern gått förbi → 409, skriv ALDRIG över tyst. Utelämnad →
+       * ingen kontroll (bakåtkompatibelt; demo/FSA bär ingen basversion).
+       */
+      baseVersion: z.number().int().positive().optional(),
+    }))
     .mutation(async ({ ctx, input }) => {
       await assertDocAccess(ctx, input.documentId);
+      // 409 vid versions-drift: bara `version` flyttas av äkta innehållsskrivningar
+      // (uploadContent/markExternallyEdited); metadata/analys går via updateMetadata
+      // som inte bumpar → inga falska konflikter.
+      if (input.baseVersion !== undefined) {
+        const current = (await ctx.repos.documents.getById(input.documentId)) as Document | null;
+        if (current && current.version !== input.baseVersion) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: `Dokumentet ändrades av någon annan (server v${current.version}, du redigerade v${input.baseVersion}).`,
+          });
+        }
+      }
       const bytes = base64ToBytes(input.contentBase64);
       const storagePath = contentStoragePath(await sha256Hex(bytes));
       await ctx.ports.content.write(storagePath, bytes);
@@ -194,7 +215,8 @@ export const coreProcedures = {
       if (!doc) throw new TRPCError({ code: "NOT_FOUND" });
       const bytes = await ctx.ports.content.read(doc.storagePath);
       if (!bytes) throw new TRPCError({ code: "NOT_FOUND", message: "Innehåll saknas på servern." });
-      return { contentBase64: bytesToBase64(bytes), mimeType: doc.mimeType, fileName: doc.fileName };
+      // `version` = basversion klienten bär in i uploadContent (ADR 0033 §1).
+      return { contentBase64: bytesToBase64(bytes), mimeType: doc.mimeType, fileName: doc.fileName, version: doc.version };
     }),
 
   /**

--- a/src/lib/shared/helper/protocol.ts
+++ b/src/lib/shared/helper/protocol.ts
@@ -155,6 +155,11 @@ export interface HelperSyncEntry {
   nextAttemptAt: number;
   /** `pending` = väntar/retr:as; `conflict` = server gått förbi, kräver beslut. */
   status: "pending" | "conflict";
+  /**
+   * Basversionen uploaden hävdar (ADR 0033 §1, server-tier). Persisteras så en
+   * post som återställs efter omstart fortfarande versionskollas korrekt.
+   */
+  baseVersion?: number;
   /** Senaste felet (om något). */
   lastError?: string;
 }

--- a/test/unit/server/routers/document/upload-content.test.ts
+++ b/test/unit/server/routers/document/upload-content.test.ts
@@ -93,6 +93,45 @@ describe("document.downloadContent", () => {
     // Inget uppladdat → storagePath "documents/content/old" finns ej i content-store.
     await expect(caller.downloadContent({ documentId: "d1" })).rejects.toThrow(/saknas/i);
   });
+
+  it("returnerar dokumentets version (basversion för uploadContent, ADR 0033 §1)", async () => {
+    const { caller } = makeCaller();
+    await caller.uploadContent({ documentId: "d1", contentBase64: bytesToBase64(new Uint8Array([1])) });
+    const dl = await caller.downloadContent({ documentId: "d1" });
+    expect(dl.version).toBe(2); // seed v1 → uploadContent bumpar → v2
+  });
+});
+
+describe("document.uploadContent — optimistisk version (ADR 0033 §1)", () => {
+  it("matchande baseVersion → skriver (ingen konflikt)", async () => {
+    const { caller, blobs } = makeCaller(); // seed version = 1
+    await caller.uploadContent({ documentId: "d1", contentBase64: bytesToBase64(new Uint8Array([5])), baseVersion: 1 });
+    const dl = await caller.downloadContent({ documentId: "d1" });
+    expect(Array.from(Buffer.from(dl.contentBase64, "base64"))).toEqual([5]);
+    expect(blobs.size).toBeGreaterThan(0);
+  });
+
+  it("stale baseVersion (server gått förbi) → 409 CONFLICT, skriver ALDRIG över", async () => {
+    const { caller, blobs } = makeCaller();
+    // Bumpar servern till v2.
+    await caller.uploadContent({ documentId: "d1", contentBase64: bytesToBase64(new Uint8Array([1])) });
+    const blobsAfterFirst = blobs.size;
+    // Andra klient redigerade från v1 → drift.
+    await expect(
+      caller.uploadContent({ documentId: "d1", contentBase64: bytesToBase64(new Uint8Array([2, 2])), baseVersion: 1 }),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+    expect(blobs.size).toBe(blobsAfterFirst); // ingen ny blob → inget överskrivet
+    // Serverns innehåll är fortfarande första uploadens bytes.
+    expect(Array.from(Buffer.from((await caller.downloadContent({ documentId: "d1" })).contentBase64, "base64"))).toEqual([1]);
+  });
+
+  it("ingen baseVersion → ingen kontroll (bakåtkompatibelt; demo/FSA)", async () => {
+    const { caller } = makeCaller();
+    await caller.uploadContent({ documentId: "d1", contentBase64: bytesToBase64(new Uint8Array([1])) }); // → v2
+    // Utan baseVersion accepteras skrivningen trots att v1 passerats.
+    await caller.uploadContent({ documentId: "d1", contentBase64: bytesToBase64(new Uint8Array([3, 3, 3])) });
+    expect(Array.from(Buffer.from((await caller.downloadContent({ documentId: "d1" })).contentBase64, "base64"))).toEqual([3, 3, 3]);
+  });
 });
 
 describe("document.missingContent", () => {


### PR DESCRIPTION
Steg 1 av [ADR 0033](docs/adr/0033-konflikthantering-mjuk-lease-keep-both.md) — gör tyst överskrivning av dokument **omöjlig**.

## Vad
- **Server:** `document.uploadContent` tar emot valfri `baseVersion`; servern avvisar med **409 CONFLICT** om dess version gått förbi. `downloadContent` returnerar `version` (basversionen helpern bär in). Utelämnad baseVersion → som idag (bakåtkompatibelt; demo/FSA).
- **Helper:** bär basversionen från nedladdningen genom den durabla kön till uploaden och **framskriver** den från varje lyckad uploads svar — annars skulle helperns egna upprepade saves (watch-loopen bumpar servern varje gång) falskt self-konflikta. `baseVersion` persisteras på köposten → korrekt versionskoll även efter omstart.
- En äkta konflikt markeras `conflict` i kön och ytläggs i den befintliga synk-bannern (#713/#715). Keep-both-materialisering = steg 2 (separat PR).

## Varför `version` som ankare (inte content-hash)
Metadata-skrivningar (analys-status, taggar) går via `updateMetadata` som **inte** bumpar versionen — bara äkta innehållsskrivningar (`uploadContent`/`markExternallyEdited`) flyttar den. Alltså inga falska 409 från bakgrunds-analysen.

## Test
- Server: matchande/stale/utelämnad baseVersion (409 skriver aldrig över; verifierar att serverns bytes är orörda).
- Helper: framskriven base över två saves, konflikt-markering, omstart-durabilitet, tRPC-klientens 409→`conflict`-mappning (100% cov), local-first ingen download-version.
- Hela sviten grön: helper 281 tester, server document-router 53, typecheck + lint + deps:check + knip rena.

Closes #718