### PR TITLE
feat(helper): keep-both vid konflikt — syskon-dokument (ADR 0033 §4)

### DIFF
--- a/docs/adr/0033-konflikthantering-mjuk-lease-keep-both.md
+++ b/docs/adr/0033-konflikthantering-mjuk-lease-keep-both.md
@@ -129,8 +129,14 @@ gör att ingenting någonsin försvinner — man kan alltid backa.
    `baseVersion` persisteras durabelt på kö-posten. Anchor = `version` (metadata-
    skrivningar går via `updateMetadata` som inte bumpar → inga falska 409). En äkta
    konflikt markeras `conflict` i kön + ytläggs i synk-bannern. *(#718)*
-2. **Keep-both vid 409:** kö-posten i `conflict` materialiseras som en separat
-   version/kopia + klarspråks-meddelande i UI (ersätter dagens "vägrar tyst").
+2. ✅ **Keep-both vid 409:** användarens version materialiseras som ett **syskon-
+   dokument** (`document.saveConflictCopy` → nytt dok i samma ärende/mapp, namn
+   `Original (din ändring <label>).ext`, pekar på de uppladdade bytsen). Helpern
+   anropar det när kön får 409 och ytlägger `conflictCopy {id,fileName}` på posten.
+   Misslyckas materialiseringen (offline) retr:as hela vägen via backoff — bytsen
+   är durabelt köade tills kopian kan skapas. Syskonet syns direkt i dokument-
+   listan med självförklarande namn; klarspråks-banner + Word-Jämför-länk i steg 5.
+   *(#720)*
 3. **Lease-store + endpoints** (acquire/renew/release/reclaim/takeover), heartbeat
    + TTL. tRPC-procedurer.
 4. **Helper:** ta/förnya/släpp lease vid öppna/stäng; själv-återtagande; öppna
@@ -143,7 +149,9 @@ gör att ingenting någonsin försvinner — man kan alltid backa.
 - TTL/heartbeat-värden (förslag: heartbeat 30 s, lease-TTL 3–5 min, "stale" efter
   ~2 min) — finjusteras mot verkligt beteende.
 - Var leasen lagras (tunn server, ADR 0013/0016) + hur den exponeras tier-agnostiskt.
-- Keep-both som ny **dokument-version** vs **syskon-dokument** ("(din version …)").
+- ~~Keep-both som ny **dokument-version** vs **syskon-dokument**~~ → **beslutat:
+  syskon-dokument** (matchar Dropbox/iCloud-konfliktkopia, kräver ingen versions-
+  kedje-schema, mest idiotsäkert). Implementerat i steg 2 (#720).
 - Beror på att server-first har dokument-versionering som kan hålla två grenar.
 
 ## Relaterat

--- a/helper-ui/src/engine/document-source.ts
+++ b/helper-ui/src/engine/document-source.ts
@@ -9,7 +9,15 @@
 
 import type { HelperDocumentRef } from "@/lib/shared/helper/protocol";
 
-import { createDocumentClient, downloadDocumentBytes, uploadDocumentBytes, type FetchLike, type UploadDocResult } from "./trpc-client.ts";
+import {
+  createDocumentClient,
+  downloadDocumentBytes,
+  saveConflictCopyBytes,
+  uploadDocumentBytes,
+  type ConflictCopy,
+  type FetchLike,
+  type UploadDocResult,
+} from "./trpc-client.ts";
 
 /** En dokument-källa: tRPC (`document`) ELLER statisk URL (`downloadUrl`). */
 export interface SourceRef {
@@ -110,4 +118,23 @@ export async function uploadViaTrpc(
     ...(deps.fetch ? { fetch: deps.fetch } : {}),
   });
   return uploadDocumentBytes(client, document.id, bytes, baseVersion);
+}
+
+/**
+ * Materialisera en keep-both-kopia (ADR 0033 §4) via tRPC `saveConflictCopy`.
+ * `label` = lokal tidsstämpel (blir del av syskon-dokumentets namn server-side).
+ */
+export async function saveConflictCopyViaTrpc(
+  document: HelperDocumentRef,
+  bytes: Uint8Array,
+  label: string,
+  deps: FetchSourceDeps = {},
+): Promise<ConflictCopy> {
+  const token = (deps.authHeader ?? "").replace(/^Bearer\s+/i, "");
+  const client = createDocumentClient({
+    trpcUrl: document.trpcUrl,
+    token,
+    ...(deps.fetch ? { fetch: deps.fetch } : {}),
+  });
+  return saveConflictCopyBytes(client, document.id, bytes, label);
 }

--- a/helper-ui/src/engine/queue.ts
+++ b/helper-ui/src/engine/queue.ts
@@ -19,9 +19,9 @@ import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import type { HelperDocumentRef, HelperStatusResponse, HelperSyncEntry } from "@/lib/shared/helper/protocol";
-import { uploadTargetKey, uploadViaTrpc } from "./document-source.ts";
+import { saveConflictCopyViaTrpc, uploadTargetKey, uploadViaTrpc } from "./document-source.ts";
 import { log } from "./log.ts";
-import type { UploadDocResult } from "./trpc-client.ts";
+import type { ConflictCopy, UploadDocResult } from "./trpc-client.ts";
 
 /**
  * En köad upload som väntar på att nå servern. Delar form med det publika
@@ -56,6 +56,11 @@ export interface QueueDeps {
    * (framskriver basen) eller `conflict`. Kastar bara vid nät/auth-fel.
    */
   uploadDoc: (document: HelperDocumentRef, body: Uint8Array, authHeader?: string, baseVersion?: number) => Promise<UploadDocResult>;
+  /**
+   * Materialisera keep-both-kopia (ADR 0033 §4) efter ett 409 — sparar
+   * användarens bytes som ett syskon-dokument. `label` = lokal tidsstämpel.
+   */
+  saveConflictCopy: (document: HelperDocumentRef, body: Uint8Array, authHeader: string | undefined, label: string) => Promise<ConflictCopy>;
 }
 
 export const defaultQueueDeps: QueueDeps = {
@@ -70,6 +75,8 @@ export const defaultQueueDeps: QueueDeps = {
   },
   uploadDoc: (document, body, authHeader, baseVersion) =>
     uploadViaTrpc(document, body, baseVersion, authHeader !== undefined ? { authHeader } : {}),
+  saveConflictCopy: (document, body, authHeader, label) =>
+    saveConflictCopyViaTrpc(document, body, label, authHeader !== undefined ? { authHeader } : {}),
 };
 
 const BASE_BACKOFF_MS = 5_000;
@@ -258,9 +265,7 @@ export class UploadQueue {
         // nät/auth-fel kastar → markFailed nedan.
         const result = await this.deps.uploadDoc(entry.document, bytes, auth, entry.baseVersion);
         if (result.status === "conflict") {
-          await this.markConflict(entry);
-          res.conflicted++;
-          log(`queue: KONFLIKT på ${entry.fileName} — server gått förbi, kräver beslut`);
+          await this.handleConflict(entry, bytes, auth, res);
           return;
         }
         // Framskriv basen så nästa save på samma dokument inte self-konflikt:ar.
@@ -284,6 +289,26 @@ export class UploadQueue {
       log(`queue: KONFLIKT på ${entry.fileName} — server gått förbi, kräver beslut`);
     } else {
       await this.markFailed(entry, `HTTP ${status}`);
+      res.failed++;
+    }
+  }
+
+  /**
+   * Keep-both (ADR 0033 §4): materialisera användarens bytes som ett syskon-
+   * dokument och ytlägg det på posten. Misslyckas materialiseringen (offline)
+   * → markera failed så HELA vägen (upload-409 → keep-both) retr:as via backoff;
+   * bytsen ligger durabelt kvar tills kopian kan skapas. Inget förloras.
+   */
+  private async handleConflict(entry: QueueEntry, bytes: Uint8Array, auth: string | undefined, res: DrainResult): Promise<void> {
+    if (!entry.document) return;
+    try {
+      const copy = await this.deps.saveConflictCopy(entry.document, bytes, auth, conflictLabel(this.deps.now()));
+      entry.conflictCopy = copy;
+      await this.markConflict(entry);
+      res.conflicted++;
+      log(`queue: KONFLIKT på ${entry.fileName} — sparade din version separat som "${copy.fileName}"`);
+    } catch (err) {
+      await this.markFailed(entry, `keep-both: ${msg(err)}`);
       res.failed++;
     }
   }
@@ -355,4 +380,11 @@ export class UploadQueue {
 
 function msg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+/** Lokal tidsstämpel-etikett "YYYY-MM-DD HH:mm" för keep-both-kopians namn. */
+export function conflictLabel(ms: number): string {
+  const d = new Date(ms);
+  const pad = (n: number): string => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }

--- a/helper-ui/src/engine/trpc-client.ts
+++ b/helper-ui/src/engine/trpc-client.ts
@@ -112,3 +112,24 @@ export async function uploadDocumentBytes(
     throw err;
   }
 }
+
+/** En materialiserad keep-both-kopia (ADR 0033 §4): syskon-dokumentets id + namn. */
+export interface ConflictCopy {
+  id: string;
+  fileName: string;
+}
+
+/**
+ * Materialisera användarens version som ett syskon-dokument via
+ * `document.saveConflictCopy` (ADR 0033 §4) — anropas efter ett 409 så inget
+ * skrivs över. `label` = lokal tidsstämpel som blir del av kopians namn.
+ */
+export async function saveConflictCopyBytes(
+  client: TRPCClient<AppRouter>,
+  documentId: string,
+  bytes: Uint8Array,
+  label: string,
+): Promise<ConflictCopy> {
+  const copy = await client.document.saveConflictCopy.mutate({ documentId, contentBase64: bytesToBase64(bytes), label });
+  return { id: copy.id, fileName: copy.fileName };
+}

--- a/helper-ui/test/auth-orchestration.test.ts
+++ b/helper-ui/test/auth-orchestration.test.ts
@@ -151,7 +151,7 @@ describe("UploadQueue tokenProvider (autonom Bearer vid drain)", () => {
 
   test("post utan egen authHeader → använder färsk token vid upload", async () => {
     const puts: Array<string | undefined> = [];
-    const deps = { now: () => 1000, newId: () => "id1", put: async (_u: string, _b: Uint8Array, auth?: string) => { puts.push(auth); return 200; }, uploadDoc: async () => ({ status: "ok" as const, version: 1 }) };
+    const deps = { now: () => 1000, newId: () => "id1", put: async (_u: string, _b: Uint8Array, auth?: string) => { puts.push(auth); return 200; }, uploadDoc: async () => ({ status: "ok" as const, version: 1 }), saveConflictCopy: async () => ({ id: "c", fileName: "k" }) };
     const q = new UploadQueue(await qdir(), deps, async () => "Bearer FRESH");
     await q.enqueue({ uploadUrl: "http://s/u/1", fileName: "a", bytes: new TextEncoder().encode("x") });
     await q.drainOnce();
@@ -161,7 +161,7 @@ describe("UploadQueue tokenProvider (autonom Bearer vid drain)", () => {
 
   test("post MED egen authHeader → den vinner över token-providern", async () => {
     const puts: Array<string | undefined> = [];
-    const deps = { now: () => 1000, newId: () => "id2", put: async (_u: string, _b: Uint8Array, auth?: string) => { puts.push(auth); return 200; }, uploadDoc: async () => ({ status: "ok" as const, version: 1 }) };
+    const deps = { now: () => 1000, newId: () => "id2", put: async (_u: string, _b: Uint8Array, auth?: string) => { puts.push(auth); return 200; }, uploadDoc: async () => ({ status: "ok" as const, version: 1 }), saveConflictCopy: async () => ({ id: "c", fileName: "k" }) };
     const q = new UploadQueue(await qdir(), deps, async () => "Bearer FRESH");
     await q.enqueue({ uploadUrl: "http://s/u/2", fileName: "a", bytes: new TextEncoder().encode("x"), authHeader: "Bearer BROWSER" });
     await q.drainOnce();

--- a/helper-ui/test/queue.test.ts
+++ b/helper-ui/test/queue.test.ts
@@ -11,7 +11,7 @@ import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 
 import superjson from "superjson";
 
-import { backoffMs, defaultQueueDeps, UploadQueue, type QueueDeps } from "../src/engine/queue.ts";
+import { backoffMs, conflictLabel, defaultQueueDeps, UploadQueue, type QueueDeps } from "../src/engine/queue.ts";
 import type { UploadDocResult } from "../src/engine/trpc-client.ts";
 
 const dirs: string[] = [];
@@ -25,17 +25,26 @@ afterAll(async () => {
 });
 
 interface UploadDocCall { document: { id: string; trpcUrl: string }; body: Uint8Array; auth?: string; baseVersion?: number }
+interface ConflictCopyCall { document: { id: string; trpcUrl: string }; body: Uint8Array; label: string }
 
 /** Injicerbara deps: räknande klocka + förutsägbara id:n + skript-styrd PUT + tRPC-upload. */
 function fakeDeps(
   putStatuses: number[] | (() => Promise<number>),
   uploadDocFails = false,
   uploadDocConflicts = false,
-): { deps: QueueDeps; puts: Array<{ url: string; body: Uint8Array; auth?: string }>; uploadDocs: UploadDocCall[]; tick: () => void } {
+  saveCopyFails = false,
+): {
+  deps: QueueDeps;
+  puts: Array<{ url: string; body: Uint8Array; auth?: string }>;
+  uploadDocs: UploadDocCall[];
+  conflictCopies: ConflictCopyCall[];
+  tick: () => void;
+} {
   let t = 1000;
   let n = 0;
   const puts: Array<{ url: string; body: Uint8Array; auth?: string }> = [];
   const uploadDocs: UploadDocCall[] = [];
+  const conflictCopies: ConflictCopyCall[] = [];
   const put = async (url: string, body: Uint8Array, auth?: string): Promise<number> => {
     puts.push({ url, body, ...(auth !== undefined ? { auth } : {}) });
     if (typeof putStatuses === "function") return putStatuses();
@@ -50,10 +59,18 @@ function fakeDeps(
     // Framskriven version = base + 1 (gör advancing-base testbar).
     return { status: "ok", version: (baseVersion ?? 0) + 1 };
   };
+  const saveConflictCopy = async (
+    document: { id: string; trpcUrl: string }, body: Uint8Array, _auth: string | undefined, label: string,
+  ): Promise<{ id: string; fileName: string }> => {
+    if (saveCopyFails) throw new Error("offline");
+    conflictCopies.push({ document, body, label });
+    return { id: `copy-${document.id}`, fileName: `kopia (din ändring ${label})` };
+  };
   return {
-    deps: { now: () => t, newId: () => `id-${++n}`, put, uploadDoc },
+    deps: { now: () => t, newId: () => `id-${++n}`, put, uploadDoc, saveConflictCopy },
     puts,
     uploadDocs,
+    conflictCopies,
     tick: () => { t += 10 * 60_000; }, // hoppa förbi all backoff
   };
 }
@@ -61,6 +78,14 @@ function fakeDeps(
 function bytes(s: string): Uint8Array {
   return new TextEncoder().encode(s);
 }
+
+describe("conflictLabel", () => {
+  test("formaterar lokal tid som YYYY-MM-DD HH:mm (nollpaddat)", () => {
+    expect(conflictLabel(Date.parse("2026-06-22T14:32:09"))).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/);
+    // Nollpaddning av en-siffriga månad/dag/timme/minut.
+    expect(conflictLabel(Date.parse("2026-01-02T03:04:00"))).toBe("2026-01-02 03:04");
+  });
+});
 
 describe("UploadQueue.enqueue", () => {
   let dir: string;
@@ -171,13 +196,29 @@ describe("UploadQueue.drainOnce", () => {
     expect(f.uploadDocs.map((c) => c.baseVersion)).toEqual([5, 6]);
   });
 
-  test("document-konflikt (409) → markerar conflict, behåller base för beslut", async () => {
+  test("document-konflikt (409) → keep-both: materialiserar syskon-kopia + markerar conflict", async () => {
     const f = fakeDeps([200], false, true); // uploadDoc → conflict
     const q = new UploadQueue(dir, f.deps);
     await q.enqueue({ document: { id: "d1", trpcUrl: "http://s/api/trpc" }, fileName: "a.docx", bytes: bytes("min"), baseVersion: 3 });
     expect((await q.drainOnce()).conflicted).toBe(1);
     expect(q.snapshot()).toMatchObject({ pending: 0, conflict: 1 });
-    expect(q.snapshot().entries[0]).toMatchObject({ status: "conflict", baseVersion: 3 });
+    // Användarens bytes sparades som en separat kopia (inget förlorat).
+    expect(f.conflictCopies).toHaveLength(1);
+    expect(new TextDecoder().decode(f.conflictCopies[0]!.body)).toBe("min");
+    expect(q.snapshot().entries[0]).toMatchObject({
+      status: "conflict", baseVersion: 3, conflictCopy: { id: "copy-d1", fileName: expect.stringContaining("din ändring") },
+    });
+  });
+
+  test("keep-both materialisering misslyckas (offline) → failed, retr:as (bytsen säkra)", async () => {
+    const f = fakeDeps([200], false, true, true); // conflict + saveConflictCopy kastar
+    const q = new UploadQueue(dir, f.deps);
+    await q.enqueue({ document: { id: "d1", trpcUrl: "http://s/api/trpc" }, fileName: "a.docx", bytes: bytes("min"), baseVersion: 3 });
+    expect((await q.drainOnce()).failed).toBe(1);
+    const entry = q.snapshot().entries[0]!;
+    expect(entry.status).toBe("pending"); // kvar för retry
+    expect(entry.conflictCopy).toBeUndefined();
+    expect(entry.lastError).toContain("keep-both");
   });
 
   test("återställd post seedar om den framskrivande basen (omstart-durabilitet)", async () => {

--- a/helper-ui/test/trpc-client.test.ts
+++ b/helper-ui/test/trpc-client.test.ts
@@ -12,6 +12,7 @@ import {
   createDocumentClient,
   documentTrpcEndpoint,
   downloadDocumentBytes,
+  saveConflictCopyBytes,
   uploadDocumentBytes,
   type FetchLike,
 } from "../src/engine/trpc-client.ts";
@@ -95,5 +96,24 @@ describe("uploadDocumentBytes (ADR 0033 §1 — optimistisk version)", () => {
   test("annat fel (t.ex. INTERNAL_SERVER_ERROR) → kastar vidare (→ kö-backoff)", async () => {
     const client = clientWith(async () => batchError("INTERNAL_SERVER_ERROR", 500));
     await expect(uploadDocumentBytes(client, "doc-1", new TextEncoder().encode("x"), 3)).rejects.toThrow();
+  });
+});
+
+describe("saveConflictCopyBytes (ADR 0033 §4 — keep-both)", () => {
+  test("anropar document.saveConflictCopy och returnerar kopians id+namn", async () => {
+    let url = "";
+    let body = "";
+    const client = createDocumentClient({
+      trpcUrl: "http://h:8080/api/trpc", token: "t",
+      fetch: async (input, init) => {
+        url = String(input);
+        body = String(init?.body ?? "");
+        return batchOk({ id: "copy-1", fileName: "Avtal (din ändring 2026-06-22 14:32).docx" });
+      },
+    });
+    const copy = await saveConflictCopyBytes(client, "doc-1", new TextEncoder().encode("min"), "2026-06-22 14:32");
+    expect(copy).toEqual({ id: "copy-1", fileName: "Avtal (din ändring 2026-06-22 14:32).docx" });
+    expect(url).toContain("document.saveConflictCopy");
+    expect(body).toContain("\"label\"");
   });
 });

--- a/src/lib/server/routers/document/core.ts
+++ b/src/lib/server/routers/document/core.ts
@@ -5,11 +5,13 @@
 
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import { conflictCopyName } from "@/lib/shared/conflict-copy";
 import { base64ToBytes, bytesToBase64, contentStoragePath, sha256Hex } from "@/lib/shared/content-address";
 import { isJunkFileName } from "@/lib/shared/junk-files";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import type { Document } from "@/lib/shared/schemas/document";
 import { asId } from "@/lib/shared/schemas/ids";
+import { uuidv7 } from "@/lib/shared/uuid";
 import { orgProcedure } from "../../trpc";
 import { assertDocAccess } from "./shared";
 
@@ -217,6 +219,45 @@ export const coreProcedures = {
       if (!bytes) throw new TRPCError({ code: "NOT_FOUND", message: "Innehåll saknas på servern." });
       // `version` = basversion klienten bär in i uploadContent (ADR 0033 §1).
       return { contentBase64: bytesToBase64(bytes), mimeType: doc.mimeType, fileName: doc.fileName, version: doc.version };
+    }),
+
+  /**
+   * `saveConflictCopy` (ADR 0033 §4 — keep-both) — när uploadContent 409:at
+   * (server gått förbi) sparas användarens version som ett SYSKON-dokument
+   * bredvid originalet: inget skrivs över, inget förloras. Nytt dokument i samma
+   * ärende/mapp, namn `Original (din ändring <label>).ext`, pekar på de
+   * uppladdade bytsen (innehålls-adresserat). Returnerar kopian.
+   */
+  saveConflictCopy: orgProcedure
+    .input(z.object({
+      documentId: z.string(),
+      contentBase64: z.string(),
+      /** Lokal tidsstämpel-etikett för kopians namn (klienten kan lokal tid). */
+      label: z.string().min(1).max(40),
+    }))
+    .mutation(async ({ ctx, input }) => {
+      await assertDocAccess(ctx, input.documentId);
+      const original = (await ctx.repos.documents.getById(input.documentId)) as Document | null;
+      if (!original) throw new TRPCError({ code: "NOT_FOUND" });
+      const bytes = base64ToBytes(input.contentBase64);
+      const storagePath = contentStoragePath(await sha256Hex(bytes));
+      await ctx.ports.content.write(storagePath, bytes);
+      const copy = await ctx.repos.documents.create(omitUndefined({
+        id: asId<"DocumentId">(uuidv7()),
+        matterId: asId<"MatterId">(original.matterId),
+        fileName: conflictCopyName(original.fileName, input.label),
+        mimeType: original.mimeType,
+        sizeBytes: bytes.byteLength,
+        storagePath,
+        folderId: original.folderId ?? null,
+        organizationId: ctx.orgId,
+        analysisStatus: "PENDING" as const,
+        uploadedById: asId<"UserId">(ctx.user.id),
+      }));
+      ctx.ports.documentAnalyzer.analyze(copy.id).catch((e: unknown) =>
+        console.error("classify after conflict-copy failed:", e),
+      );
+      return copy;
     }),
 
   /**

--- a/src/lib/shared/conflict-copy.ts
+++ b/src/lib/shared/conflict-copy.ts
@@ -1,0 +1,16 @@
+/**
+ * Namnger en keep-both-kopia (ADR 0033 §4): när en 409-konflikt sker sparas
+ * användarens version som ett SYSKON-dokument bredvid originalet — inget skrivs
+ * över. Namnet ska göra det självklart för en icke-teknisk jurist vilket som är
+ * deras egen ändring: `Avtal (din ändring 2026-06-22 14:32).docx`.
+ *
+ * Ren funktion (ingen IO/klocka) → `label` (lokal tidsstämpel) matas in av
+ * anroparen, testbar deterministiskt.
+ */
+export function conflictCopyName(fileName: string, label: string): string {
+  const suffix = ` (din ändring ${label})`;
+  const dot = fileName.lastIndexOf(".");
+  // dot <= 0 → ingen ändelse (eller en dotfile som ".gitignore"): lägg suffixet sist.
+  if (dot <= 0) return `${fileName}${suffix}`;
+  return `${fileName.slice(0, dot)}${suffix}${fileName.slice(dot)}`;
+}

--- a/src/lib/shared/helper/protocol.ts
+++ b/src/lib/shared/helper/protocol.ts
@@ -160,6 +160,12 @@ export interface HelperSyncEntry {
    * post som återställs efter omstart fortfarande versionskollas korrekt.
    */
   baseVersion?: number;
+  /**
+   * Keep-both-kopian (ADR 0033 §4): vid konflikt materialiseras användarens
+   * version som ett syskon-dokument — här id+namn så UI kan säga på klarspråk
+   * "din version sparades som <fileName>". Satt först när kopian skapats.
+   */
+  conflictCopy?: { id: string; fileName: string };
   /** Senaste felet (om något). */
   lastError?: string;
 }

--- a/test/unit/lib/shared/conflict-copy.test.ts
+++ b/test/unit/lib/shared/conflict-copy.test.ts
@@ -1,0 +1,26 @@
+/**
+ * conflictCopyName (ADR 0033 §4) — namnger keep-both-syskonet så det är
+ * självklart vilket dokument som är användarens egen ändring.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { conflictCopyName } from "@/lib/shared/conflict-copy";
+
+describe("conflictCopyName", () => {
+  it("infogar etiketten före filändelsen", () => {
+    expect(conflictCopyName("Avtal.docx", "2026-06-22 14:32")).toBe("Avtal (din ändring 2026-06-22 14:32).docx");
+    expect(conflictCopyName("rapport.pdf", "2026-01-02 03:04")).toBe("rapport (din ändring 2026-01-02 03:04).pdf");
+  });
+
+  it("hanterar filer utan ändelse (suffix sist)", () => {
+    expect(conflictCopyName("README", "L")).toBe("README (din ändring L)");
+  });
+
+  it("behandlar dotfiler som utan ändelse (lägger suffixet sist)", () => {
+    expect(conflictCopyName(".gitignore", "L")).toBe(".gitignore (din ändring L)");
+  });
+
+  it("delar på SISTA punkten (flera punkter)", () => {
+    expect(conflictCopyName("v1.2.docx", "L")).toBe("v1.2 (din ändring L).docx");
+  });
+});

--- a/test/unit/server/routers/document/upload-content.test.ts
+++ b/test/unit/server/routers/document/upload-content.test.ts
@@ -134,6 +134,33 @@ describe("document.uploadContent — optimistisk version (ADR 0033 §1)", () => 
   });
 });
 
+describe("document.saveConflictCopy (ADR 0033 §4 — keep-both)", () => {
+  it("skapar syskon-dokument i samma ärende, namnger det, rör inte originalet", async () => {
+    const { caller, blobs } = makeCaller();
+    const mine = new Uint8Array([4, 5, 6]);
+    const copy = await caller.saveConflictCopy({ documentId: "d1", contentBase64: bytesToBase64(mine), label: "2026-06-22 14:32" });
+
+    expect(copy.id).not.toBe("d1"); // nytt dokument
+    expect(copy.matterId).toBe("m1"); // samma ärende
+    expect(copy.fileName).toBe("avtal (din ändring 2026-06-22 14:32).pdf");
+    expect(copy.mimeType).toBe("application/pdf");
+    // Kopians bytes finns content-adresserat.
+    const dl = await caller.downloadContent({ documentId: copy.id });
+    expect(Array.from(Buffer.from(dl.contentBase64, "base64"))).toEqual([4, 5, 6]);
+    // Originalet är orört (pekar fortfarande på sin gamla path).
+    expect(blobs.has("documents/content/old")).toBe(false); // original-blob laddades aldrig upp
+    const orig = await caller.list({ matterId: "m1", folderId: null, page: 1, pageSize: 50 });
+    expect(orig.documents.find((d) => d.id === "d1")!.fileName).toBe("avtal.pdf"); // oförändrat namn
+  });
+
+  it("org-scope: original i annan org → NOT_FOUND", async () => {
+    const { caller } = makeCaller("org-b");
+    await expect(
+      caller.saveConflictCopy({ documentId: "d1", contentBase64: bytesToBase64(new Uint8Array([1])), label: "x" }),
+    ).rejects.toThrow();
+  });
+});
+
 describe("document.missingContent", () => {
   it("returnerar bara sökvägar servern saknar (byte-synk-dedup)", async () => {
     const { caller } = makeCaller();


### PR DESCRIPTION
Steg 2 av ADR 0033. När en 409-konflikt sker (steg 1, #719) **förloras aldrig** användarens version — den materialiseras som ett syskon-dokument bredvid originalet.

## Vad
- **Server:** `document.saveConflictCopy({ documentId, contentBase64, label })` skapar ett nytt dokument i samma ärende/mapp, namn `Original (din ändring <label>).ext`, content-adresserat. Originalet (den andras version) förblir kanoniskt och orört.
- **Helper:** när kön får `conflict` från uploadContent materialiserar den kopian och ytlägger `conflictCopy {id, fileName}` på köposten. Misslyckas materialiseringen (offline) → `failed` så HELA vägen (upload-409 → keep-both) retr:as via backoff; bytsen ligger durabelt köade tills kopian kan skapas.
- **Protokoll:** `HelperSyncEntry.conflictCopy` bär id+namn så UI kan säga klarspråk.

## UX
Syskonet syns direkt i dokumentlistan med självförklarande namn ("Avtal (din ändring 2026-06-22 14:32).docx") → ingen ny UI krävs för "inget är borta". Den dedikerade klarspråks-bannern + Word-Jämför-länken landar i steg 5 (web-UI).

## Keep-both = syskon-dokument
ADR:ns öppna fråga, nu beslutad (matchar Dropbox/iCloud-konfliktkopia; ingen versions-kedje-schema; mest idiotsäkert).

## Test
- Server: skapar syskon i samma ärende, namnger korrekt, rör inte originalet, org-scope.
- Helper: materialiserar på 409, offline-materialisering → retry, `conflictLabel`-format, `saveConflictCopyBytes` tRPC-anrop.
- Delad `conflictCopyName` (ext/dotfile/multi-punkt). Helper 284 tester, server 15, typecheck/lint/deps/knip rena.

Closes #720