### PR TITLE
feat(server): mjuk lease-store + tRPC (ADR 0033 §2)

### DIFF
--- a/docs/adr/0033-konflikthantering-mjuk-lease-keep-both.md
+++ b/docs/adr/0033-konflikthantering-mjuk-lease-keep-both.md
@@ -137,8 +137,11 @@ gör att ingenting någonsin försvinner — man kan alltid backa.
    är durabelt köade tills kopian kan skapas. Syskonet syns direkt i dokument-
    listan med självförklarande namn; klarspråks-banner + Word-Jämför-länk i steg 5.
    *(#720)*
-3. **Lease-store + endpoints** (acquire/renew/release/reclaim/takeover), heartbeat
-   + TTL. tRPC-procedurer.
+3. ✅ **Lease-store + endpoints** (acquire/renew/release/takeover/get), heartbeat
+   + stale/expire-trösklar. In-memory på den tunna servern (efemär koordinering;
+   omstart löper ut alla leases = korrekt). Port `ILeaseStore` (server-first =
+   `InMemoryLeaseStore`, demo = no-op). tRPC i document-routern, org-scopat. Själv-
+   återtagande + ta-över ingår i store-logiken. *(#722)*
 4. **Helper:** ta/förnya/släpp lease vid öppna/stäng; själv-återtagande; öppna
    skrivskyddat (ingen watch) när leasat av annan.
 5. **Web-UI:** "X redigerar" + "Ta över redigeringen" + "Öppna skrivskyddat"/
@@ -146,9 +149,13 @@ gör att ingenting någonsin försvinner — man kan alltid backa.
 
 ## Öppna frågor
 
-- TTL/heartbeat-värden (förslag: heartbeat 30 s, lease-TTL 3–5 min, "stale" efter
-  ~2 min) — finjusteras mot verkligt beteende.
-- Var leasen lagras (tunn server, ADR 0013/0016) + hur den exponeras tier-agnostiskt.
+- TTL/heartbeat-värden — implementerat: heartbeat 30 s (klient, steg 4), stale
+  efter 2 min (`LEASE_STALE_MS`), expire efter 5 min (`LEASE_EXPIRE_MS`).
+  Finjusteras mot verkligt beteende.
+- ~~Var leasen lagras~~ → **beslutat: in-memory på den tunna servern** (efemär
+  koordinering; en omstart löper ut alla leases, vilket är korrekt). Exponeras
+  tier-agnostiskt som `ILeaseStore`-port (demo = no-op). Takhöjd: multi-instans-
+  server skulle kräva delad store (Redis/tabell) — byts då ut bakom porten. (#722)
 - ~~Keep-both som ny **dokument-version** vs **syskon-dokument**~~ → **beslutat:
   syskon-dokument** (matchar Dropbox/iCloud-konfliktkopia, kräver ingen versions-
   kedje-schema, mest idiotsäkert). Implementerat i steg 2 (#720).

--- a/src/bin/server-first.ts
+++ b/src/bin/server-first.ts
@@ -26,6 +26,7 @@ import { startJobRuntime, type JobRuntime } from "@/lib/server/jobs/job-worker-r
 import { QueueBackedDocumentAnalyzer } from "@/lib/server/jobs/queue-backed-document-analyzer";
 import { QueueBackedEmailSender } from "@/lib/server/jobs/queue-backed-email-sender";
 import { buildServerFirstJobHandlers, loadSmtpConfigFromEnv } from "@/lib/server/jobs/server-first-handlers";
+import { InMemoryLeaseStore } from "@/lib/server/lease/lease-store";
 import { loadLlmConfigFromEnv } from "@/lib/server/llm/ollama-classifier";
 import { serveFetchHandler } from "@/lib/shared/http/node-http-adapter";
 
@@ -65,6 +66,9 @@ function main(): void {
     // classify-document-jobb durabelt på pg-boss i st.f. noop.
     documentAnalyzer: new QueueBackedDocumentAnalyzer(() => jobRuntime?.boss ?? null, config.organizationId),
     ...(contentStore ? { content: contentStore } : {}),
+    // Mjuk lease (ADR 0033 §2): in-memory process-singleton — efemär koordinering,
+    // en omstart löper ut alla leases (korrekt). Ett enda objekt delas av alla requests.
+    lease: new InMemoryLeaseStore(),
   };
 
   const api = buildServerFirstApi({

--- a/src/lib/server/adapters/noop-ports.ts
+++ b/src/lib/server/adapters/noop-ports.ts
@@ -9,6 +9,7 @@ import type {
   ISearchIndex,
   IPaymentScanner,
   IContentStore,
+  ILeaseStore,
   IPorts,
 } from "../ports";
 
@@ -44,10 +45,29 @@ export const noopContentStore: IContentStore = {
   async exists() { return false; },
 };
 
+/**
+ * No-op lease-store: demo har ingen server → inga leases (ADR 0033 §Offline
+ * & tiers). `acquire` rapporterar alltid "fritt + din" så ev. stray-anrop är
+ * ofarliga; `get` ger null. Klienten anropar ändå aldrig dessa i demo
+ * (kapabilitets-gating, steg 4/5). Server-first ersätter med InMemoryLeaseStore.
+ */
+export const noopLeaseStore: ILeaseStore = {
+  acquire(documentId, holderId, holderName) {
+    return { acquired: true, lease: { documentId, holderId, holderName, acquiredAt: 0, lastHeartbeatAt: 0, stale: false } };
+  },
+  renew() { return true; },
+  release() { /* no-op */ },
+  takeover(documentId, holderId, holderName) {
+    return { documentId, holderId, holderName, acquiredAt: 0, lastHeartbeatAt: 0, stale: false };
+  },
+  get() { return null; },
+};
+
 export const noopPorts: IPorts = {
   email: noopEmail,
   documentAnalyzer: noopDocumentAnalyzer,
   searchIndex: noopSearchIndex,
   paymentScanner: noopPaymentScanner,
   content: noopContentStore,
+  lease: noopLeaseStore,
 };

--- a/src/lib/server/lease/lease-store.ts
+++ b/src/lib/server/lease/lease-store.ts
@@ -1,0 +1,89 @@
+/**
+ * `InMemoryLeaseStore` (ADR 0033 §2) — den mjuka leasen (osynligt check-out)
+ * som förebygger redigerings-konflikter på dokument.
+ *
+ * In-memory på den tunna servern med flit: en lease är efemär online-
+ * koordinering, inte durabel domändata. En server-omstart = alla helpers
+ * slutar heartbeata = alla leases löper ut — exakt samma utfall som om alla
+ * stängde sina dokument. Inget att persistera. (Takhöjd: en multi-instans-
+ * server skulle behöva delad store (Redis/tabell) — då byts denna adapter ut.)
+ *
+ * Tre trösklar (ADR 0033, "Öppna frågor"):
+ *   - heartbeat ~30 s: klienten förnyar (sköts klient-sidigt, steg 4).
+ *   - STALE ~2 min utan heartbeat: leasen visas som "verkar inte redigera
+ *     längre" → en annan användare erbjuds "Ta över".
+ *   - EXPIRE ~5 min utan heartbeat: leasen finns inte längre → dokumentet är
+ *     fritt att ta utan ta-över.
+ *
+ * `now` injiceras → deterministiska tester utan riktig tid.
+ */
+
+import type { AcquireLeaseResult, ILeaseStore, LeaseView } from "../ports";
+
+export const LEASE_STALE_MS = 2 * 60_000;
+export const LEASE_EXPIRE_MS = 5 * 60_000;
+
+/** Lagrad lease (utan det härledda `stale`-fältet). */
+type StoredLease = Omit<LeaseView, "stale">;
+
+export class InMemoryLeaseStore implements ILeaseStore {
+  private readonly leases = new Map<string, StoredLease>();
+
+  constructor(private readonly now: () => number = () => Date.now()) {}
+
+  acquire(documentId: string, holderId: string, holderName: string): AcquireLeaseResult {
+    const current = this.live(documentId);
+    // Fri, utgången, eller redan din (själv-återtagande) → ta/förnya leasen.
+    if (!current || current.holderId === holderId) {
+      const lease: StoredLease = {
+        documentId,
+        holderId,
+        holderName,
+        acquiredAt: current?.holderId === holderId ? current.acquiredAt : this.now(),
+        lastHeartbeatAt: this.now(),
+      };
+      this.leases.set(documentId, lease);
+      return { acquired: true, lease: this.view(lease) };
+    }
+    // Levande lease hos någon annan → skrivskyddat (UI:t styr dit, steg 4/5).
+    return { acquired: false, lease: this.view(current) };
+  }
+
+  renew(documentId: string, holderId: string): boolean {
+    const current = this.live(documentId);
+    if (!current || current.holderId !== holderId) return false;
+    current.lastHeartbeatAt = this.now();
+    return true;
+  }
+
+  release(documentId: string, holderId: string): void {
+    const current = this.leases.get(documentId);
+    if (current && current.holderId === holderId) this.leases.delete(documentId);
+  }
+
+  takeover(documentId: string, holderId: string, holderName: string): LeaseView {
+    const lease: StoredLease = { documentId, holderId, holderName, acquiredAt: this.now(), lastHeartbeatAt: this.now() };
+    this.leases.set(documentId, lease);
+    return this.view(lease);
+  }
+
+  get(documentId: string): LeaseView | null {
+    const current = this.live(documentId);
+    return current ? this.view(current) : null;
+  }
+
+  /** Aktuell lease om den inte löpt ut; rensar och returnerar null annars. */
+  private live(documentId: string): StoredLease | null {
+    const lease = this.leases.get(documentId);
+    if (!lease) return null;
+    if (this.now() - lease.lastHeartbeatAt >= LEASE_EXPIRE_MS) {
+      this.leases.delete(documentId);
+      return null;
+    }
+    return lease;
+  }
+
+  private view(lease: StoredLease): LeaseView {
+    return { ...lease, stale: this.now() - lease.lastHeartbeatAt >= LEASE_STALE_MS };
+  }
+}

--- a/src/lib/server/ports.ts
+++ b/src/lib/server/ports.ts
@@ -130,6 +130,51 @@ export interface IContentStore {
 
 // ─── Aggregat ──────────────────────────────────────────────────────
 
+// ─── LeaseStore (ADR 0033 §2 — mjuk lease) ─────────────────────────
+
+/**
+ * En aktiv (eller nyss utgången) lease på ett dokument — den mjuka
+ * check-out:en som förebygger konflikter (ADR 0033 §2). `holderName`
+ * denormaliseras för UI:t ("Anna redigerar"). Tider i ms sedan epoch.
+ */
+export interface LeaseView {
+  documentId: string;
+  holderId: string;
+  holderName: string;
+  acquiredAt: number;
+  lastHeartbeatAt: number;
+  /** `now − lastHeartbeatAt ≥ stale-tröskeln` → "verkar inte redigera längre" (ta-över-bar). */
+  stale: boolean;
+}
+
+/** Utfall av {@link ILeaseStore.acquire}. */
+export interface AcquireLeaseResult {
+  /** Fick/håller anroparen leasen? `false` = någon ANNAN håller en levande lease. */
+  acquired: boolean;
+  /** Aktuell lease: anroparens (om `acquired`), annars den andra hållarens. */
+  lease: LeaseView;
+}
+
+/**
+ * Mjuk lease-store (ADR 0033 §2). In-memory på den tunna servern — leases
+ * är efemär online-koordinering, inte durabel domändata; en omstart =
+ * alla heartbeats slutar = alla leases löper ut (korrekt semantik).
+ */
+export interface ILeaseStore {
+  /** Ta leasen om fri/utgången/redan din (själv-återtagande); annars rapportera annan hållare. */
+  acquire(documentId: string, holderId: string, holderName: string): AcquireLeaseResult;
+  /** Heartbeat: förnya din lease. `false` = du håller den inte längre (utgången/övertagen). */
+  renew(documentId: string, holderId: string): boolean;
+  /** Släpp din lease (idempotent; no-op om du inte håller den). */
+  release(documentId: string, holderId: string): void;
+  /** Permanent omtilldelning till anroparen (ta-över ett stale/dött lås). */
+  takeover(documentId: string, holderId: string, holderName: string): LeaseView;
+  /** Aktuell lease, eller `null` om fri/utgången. */
+  get(documentId: string): LeaseView | null;
+}
+
+// ─── Aggregat ──────────────────────────────────────────────────────
+
 /**
  * Alla ports som tillhör en tRPC-`Context`. Routrar deklarerar bara
  * de ports de behöver via property-access; oanvända ports kostar
@@ -141,6 +186,7 @@ export interface IPorts {
   searchIndex: ISearchIndex;
   paymentScanner: IPaymentScanner;
   content: IContentStore;
+  lease: ILeaseStore;
 }
 
 // Buffer-typen exporteras så impl:erna kan importera utan Node:

--- a/src/lib/server/routers/document.ts
+++ b/src/lib/server/routers/document.ts
@@ -10,12 +10,14 @@
  *   • folders      — mappar, flytt, breadcrumb
  *   • suggestions  — AI-kontaktförslag (accept/reject, grupp-accept, dedup)
  *   • events       — AI-extraherade kalenderhändelser
+ *   • lease        — mjuk lease (acquire/renew/release/takeover/get, ADR 0033 §2)
  */
 
 import { router } from "../trpc";
 import { coreProcedures } from "./document/core";
 import { eventProcedures } from "./document/events";
 import { folderProcedures } from "./document/folders";
+import { leaseProcedures } from "./document/lease";
 import { suggestionProcedures } from "./document/suggestions";
 
 export const documentRouter = router({
@@ -23,4 +25,5 @@ export const documentRouter = router({
   ...folderProcedures,
   ...suggestionProcedures,
   ...eventProcedures,
+  ...leaseProcedures,
 });

--- a/src/lib/server/routers/document/lease.ts
+++ b/src/lib/server/routers/document/lease.ts
@@ -1,0 +1,60 @@
+/**
+ * Lease-procedurer (ADR 0033 §2) — den mjuka leasen som förebygger konflikter.
+ *
+ * Tunna wrappers runt `ctx.ports.lease` (server-first = InMemoryLeaseStore,
+ * demo = no-op). Alla org-scopas via `assertDocAccess` så ingen kan ta en lease
+ * på ett annat byrås dokument-id. Hållaren = den inloggade principalen
+ * (`ctx.user.id` + `ctx.user.name` för "Anna redigerar").
+ *
+ * Helper-livscykeln (steg 4) tar/förnyar/släpper; web-UI:t (steg 5) visar
+ * "X redigerar" + "Ta över redigeringen".
+ */
+
+import { z } from "zod";
+import { orgProcedure } from "../../trpc";
+import { assertDocAccess } from "./shared";
+
+const docInput = z.object({ documentId: z.string() });
+
+export const leaseProcedures = {
+  /** Ta leasen (fri/utgången/egen → din; annars `acquired:false` + annan hållare). */
+  acquireLease: orgProcedure
+    .input(docInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertDocAccess(ctx, input.documentId);
+      return ctx.ports.lease.acquire(input.documentId, ctx.user.id, ctx.user.name);
+    }),
+
+  /** Heartbeat: förnya din lease. `renewed:false` = du håller den inte längre. */
+  renewLease: orgProcedure
+    .input(docInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertDocAccess(ctx, input.documentId);
+      return { renewed: ctx.ports.lease.renew(input.documentId, ctx.user.id) };
+    }),
+
+  /** Släpp din lease (vid stäng). Idempotent. */
+  releaseLease: orgProcedure
+    .input(docInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertDocAccess(ctx, input.documentId);
+      ctx.ports.lease.release(input.documentId, ctx.user.id);
+      return { ok: true };
+    }),
+
+  /** Ta över ett stale/dött lås — permanent omtilldelning till anroparen. */
+  takeoverLease: orgProcedure
+    .input(docInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertDocAccess(ctx, input.documentId);
+      return ctx.ports.lease.takeover(input.documentId, ctx.user.id, ctx.user.name);
+    }),
+
+  /** Aktuell lease (vem redigerar, sedan när, stale?) — `null` om fri. */
+  getLease: orgProcedure
+    .input(docInput)
+    .query(async ({ ctx, input }) => {
+      await assertDocAccess(ctx, input.documentId);
+      return { lease: ctx.ports.lease.get(input.documentId) };
+    }),
+};

--- a/test/unit/server/lease-store.test.ts
+++ b/test/unit/server/lease-store.test.ts
@@ -1,0 +1,119 @@
+/**
+ * InMemoryLeaseStore (ADR 0033 §2) — mjuk lease med heartbeat/stale/expire.
+ * Injicerad klocka → deterministiska trösklar.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { InMemoryLeaseStore, LEASE_EXPIRE_MS, LEASE_STALE_MS } from "@/lib/server/lease/lease-store";
+
+function clock(start = 1_000_000): { now: () => number; advance: (ms: number) => void } {
+  let t = start;
+  return { now: () => t, advance: (ms) => { t += ms; } };
+}
+
+describe("InMemoryLeaseStore.acquire", () => {
+  it("tar en fri lease → acquired, hållare satt", () => {
+    const store = new InMemoryLeaseStore(clock().now);
+    const res = store.acquire("d1", "u1", "Anna");
+    expect(res.acquired).toBe(true);
+    expect(res.lease).toMatchObject({ documentId: "d1", holderId: "u1", holderName: "Anna", stale: false });
+  });
+
+  it("leasad av annan (levande) → acquired:false + den andras lease", () => {
+    const store = new InMemoryLeaseStore(clock().now);
+    store.acquire("d1", "u1", "Anna");
+    const res = store.acquire("d1", "u2", "Bo");
+    expect(res.acquired).toBe(false);
+    expect(res.lease.holderId).toBe("u1");
+    expect(res.lease.holderName).toBe("Anna");
+  });
+
+  it("själv-återtagande: egen lease → acquired, behåller acquiredAt", () => {
+    const c = clock();
+    const store = new InMemoryLeaseStore(c.now);
+    const first = store.acquire("d1", "u1", "Anna");
+    c.advance(60_000);
+    const again = store.acquire("d1", "u1", "Anna");
+    expect(again.acquired).toBe(true);
+    expect(again.lease.acquiredAt).toBe(first.lease.acquiredAt); // samma session
+    expect(again.lease.lastHeartbeatAt).toBeGreaterThan(first.lease.lastHeartbeatAt);
+  });
+
+  it("utgången lease (annans) → fri att ta", () => {
+    const c = clock();
+    const store = new InMemoryLeaseStore(c.now);
+    store.acquire("d1", "u1", "Anna");
+    c.advance(LEASE_EXPIRE_MS);
+    const res = store.acquire("d1", "u2", "Bo");
+    expect(res.acquired).toBe(true);
+    expect(res.lease.holderId).toBe("u2");
+  });
+});
+
+describe("InMemoryLeaseStore stale/expire-trösklar", () => {
+  it("stale efter STALE_MS men före EXPIRE_MS (fortf. hållen)", () => {
+    const c = clock();
+    const store = new InMemoryLeaseStore(c.now);
+    store.acquire("d1", "u1", "Anna");
+    c.advance(LEASE_STALE_MS);
+    const lease = store.get("d1");
+    expect(lease).not.toBeNull();
+    expect(lease!.stale).toBe(true); // erbjuder ta-över
+  });
+
+  it("get efter EXPIRE_MS → null (fritt)", () => {
+    const c = clock();
+    const store = new InMemoryLeaseStore(c.now);
+    store.acquire("d1", "u1", "Anna");
+    c.advance(LEASE_EXPIRE_MS);
+    expect(store.get("d1")).toBeNull();
+  });
+});
+
+describe("InMemoryLeaseStore.renew", () => {
+  it("hållaren förnyar → true, nollställer stale", () => {
+    const c = clock();
+    const store = new InMemoryLeaseStore(c.now);
+    store.acquire("d1", "u1", "Anna");
+    c.advance(LEASE_STALE_MS);
+    expect(store.renew("d1", "u1")).toBe(true);
+    expect(store.get("d1")!.stale).toBe(false); // heartbeat → färsk igen
+  });
+
+  it("icke-hållare förnyar → false", () => {
+    const store = new InMemoryLeaseStore(clock().now);
+    store.acquire("d1", "u1", "Anna");
+    expect(store.renew("d1", "u2")).toBe(false);
+  });
+
+  it("utgången lease förnyas inte → false", () => {
+    const c = clock();
+    const store = new InMemoryLeaseStore(c.now);
+    store.acquire("d1", "u1", "Anna");
+    c.advance(LEASE_EXPIRE_MS);
+    expect(store.renew("d1", "u1")).toBe(false);
+  });
+});
+
+describe("InMemoryLeaseStore.release / takeover", () => {
+  it("hållaren släpper → fritt; icke-hållare kan inte släppa", () => {
+    const store = new InMemoryLeaseStore(clock().now);
+    store.acquire("d1", "u1", "Anna");
+    store.release("d1", "u2"); // fel hållare → no-op
+    expect(store.get("d1")).not.toBeNull();
+    store.release("d1", "u1");
+    expect(store.get("d1")).toBeNull();
+  });
+
+  it("takeover tar över ett levande lås permanent (annan användare)", () => {
+    const c = clock();
+    const store = new InMemoryLeaseStore(c.now);
+    store.acquire("d1", "u1", "Anna");
+    c.advance(LEASE_STALE_MS); // stale men ej utgången
+    const taken = store.takeover("d1", "u2", "Bo");
+    expect(taken.holderId).toBe("u2");
+    expect(taken.stale).toBe(false);
+    // u1 har förlorat den → renew misslyckas.
+    expect(store.renew("d1", "u1")).toBe(false);
+  });
+});

--- a/test/unit/server/routers/document/lease.test.ts
+++ b/test/unit/server/routers/document/lease.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Lease-procedurer (ADR 0033 §2) — acquire/renew/release/takeover/get över en
+ * riktig InMemoryLeaseStore. Verifierar hållar-identitet (ctx.user), org-scope
+ * och två-användar-interaktion (en delad store).
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { InMemoryLeaseStore } from "@/lib/server/lease/lease-store";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
+import { documentRouter } from "@/lib/server/routers/document";
+import { prebakeJoins } from "@/lib/shared/demo-source";
+
+const ORG = "org-a";
+
+function makeStore(): { source: DemoSource; lease: InMemoryLeaseStore } {
+  const source = prebakeJoins({
+    matters: [{ id: "m1", organizationId: ORG, matterNumber: "2026-1", title: "T" }],
+    documents: [{ id: "d1", matterId: "m1", fileName: "avtal.docx" }],
+  } as DemoSource);
+  return { source, lease: new InMemoryLeaseStore() };
+}
+
+function caller(source: DemoSource, lease: InMemoryLeaseStore, user: { id: string; name: string }, orgId = ORG) {
+  const store = new LocalStore(source, async () => {});
+  const repos = buildInMemoryRepositories(store);
+  const ctx = {
+    user: { id: user.id, email: `${user.id}@b.se`, name: user.name, role: "LAWYER", organizationId: orgId },
+    dataStore: store, repos, orgId, ports: { lease },
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return documentRouter.createCaller(ctx as any);
+}
+
+describe("document lease-procedurer", () => {
+  it("acquire sätter hållaren till inloggad principal (id + namn)", async () => {
+    const { source, lease } = makeStore();
+    const res = await caller(source, lease, { id: "u1", name: "Anna" }).acquireLease({ documentId: "d1" });
+    expect(res.acquired).toBe(true);
+    expect(res.lease).toMatchObject({ holderId: "u1", holderName: "Anna" });
+  });
+
+  it("andra användaren ser acquired:false + Annas lease", async () => {
+    const { source, lease } = makeStore();
+    await caller(source, lease, { id: "u1", name: "Anna" }).acquireLease({ documentId: "d1" });
+    const res = await caller(source, lease, { id: "u2", name: "Bo" }).acquireLease({ documentId: "d1" });
+    expect(res.acquired).toBe(false);
+    expect(res.lease.holderName).toBe("Anna");
+  });
+
+  it("renew från hållaren → true; från annan → false", async () => {
+    const { source, lease } = makeStore();
+    await caller(source, lease, { id: "u1", name: "Anna" }).acquireLease({ documentId: "d1" });
+    expect((await caller(source, lease, { id: "u1", name: "Anna" }).renewLease({ documentId: "d1" })).renewed).toBe(true);
+    expect((await caller(source, lease, { id: "u2", name: "Bo" }).renewLease({ documentId: "d1" })).renewed).toBe(false);
+  });
+
+  it("release frigör; getLease → null efteråt", async () => {
+    const { source, lease } = makeStore();
+    await caller(source, lease, { id: "u1", name: "Anna" }).acquireLease({ documentId: "d1" });
+    await caller(source, lease, { id: "u1", name: "Anna" }).releaseLease({ documentId: "d1" });
+    expect((await caller(source, lease, { id: "u1", name: "Anna" }).getLease({ documentId: "d1" })).lease).toBeNull();
+  });
+
+  it("takeover ger leasen till anroparen (Bo tar över Annas)", async () => {
+    const { source, lease } = makeStore();
+    await caller(source, lease, { id: "u1", name: "Anna" }).acquireLease({ documentId: "d1" });
+    const taken = await caller(source, lease, { id: "u2", name: "Bo" }).takeoverLease({ documentId: "d1" });
+    expect(taken.holderId).toBe("u2");
+    expect((await caller(source, lease, { id: "u1", name: "Anna" }).renewLease({ documentId: "d1" })).renewed).toBe(false);
+  });
+
+  it("org-scope: dokument i annan org → NOT_FOUND, ingen lease tas", async () => {
+    const { source, lease } = makeStore();
+    await expect(
+      caller(source, lease, { id: "x", name: "X" }, "org-b").acquireLease({ documentId: "d1" }),
+    ).rejects.toThrow();
+    expect(lease.get("d1")).toBeNull();
+  });
+});


### PR DESCRIPTION
Steg 3 av ADR 0033 — den server-side **mjuka leasen** (osynligt check-out) som förebygger konflikter.

## Vad
- **`InMemoryLeaseStore`** bakom porten `ILeaseStore`. In-memory på den tunna servern med flit: en lease är efemär online-koordinering, inte durabel domändata — en omstart = alla helpers slutar heartbeata = alla leases löper ut (samma utfall som att alla stänger sina dokument). Ett process-singleton delas av alla requests.
- **Trösklar:** stale efter 2 min (`LEASE_STALE_MS` → erbjuder "Ta över"), expire efter 5 min (`LEASE_EXPIRE_MS` → fritt). Heartbeat 30s sköts klient-sidigt (steg 4).
- **Logik:** `acquire` tar en fri/utgången/egen lease (själv-återtagande efter krasch) annars rapporterar annan hållare; `renew` = heartbeat (false om förlorad); `release`; `takeover` = permanent omtilldelning av ett stale/dött lås; `get`.
- **tRPC** i document-routern, alla org-scopade via `assertDocAccess`; hållare = inloggad principal (`ctx.user.id`/`.name` → "Anna redigerar").
- **Tiers:** server-first wirar store:n; demo/git = no-op (demo har ingen server → inga leases).

## Beslutad öppen fråga
Var leasen lagras → **in-memory på tunna servern** (takhöjd: multi-instans skulle kräva delad store bakom samma port).

## Test
- Store-logik (injicerad klocka): fri/leasad/själv-återtagande/utgången, stale-vs-expire-trösklar, renew-ägarskap, release, takeover. Router: hållar-identitet, två-användar-interaktion, org-scope. 1067 server-tester gröna; typecheck/lint/deps/knip rena.

Helper-livscykeln (steg 4) tar/förnyar/släpper; web-UI (steg 5) visar "X redigerar"/"Ta över".

Closes #722