### PR TITLE
feat(helper): lease-livscykel — skrivskyddat när leasat (ADR 0033 §4)

### DIFF
--- a/docs/adr/0033-konflikthantering-mjuk-lease-keep-both.md
+++ b/docs/adr/0033-konflikthantering-mjuk-lease-keep-both.md
@@ -142,8 +142,12 @@ gör att ingenting någonsin försvinner — man kan alltid backa.
    omstart löper ut alla leases = korrekt). Port `ILeaseStore` (server-first =
    `InMemoryLeaseStore`, demo = no-op). tRPC i document-routern, org-scopat. Själv-
    återtagande + ta-över ingår i store-logiken. *(#722)*
-4. **Helper:** ta/förnya/släpp lease vid öppna/stäng; själv-återtagande; öppna
-   skrivskyddat (ingen watch) när leasat av annan.
+4. ✅ **Helper:** tar leasen vid öppning (server-dok); fri/egen → redigerbart +
+   watch + **heartbeat** (renew 30s, släpp vid watch-slut). Leasat av annan →
+   **skrivskyddat** (ingen lease, ingen watch → oavsiktlig redigering laddas
+   aldrig upp); svaret bär hållarens namn. Flaggor: `readOnly` (medvetet
+   skrivskyddat), `forceEdit` (lånar — redigera utan att ta leasen). Tappad lease
+   mid-edit → slutar förnya, nästa save 409:ar → keep-both. *(#724)*
 5. **Web-UI:** "X redigerar" + "Ta över redigeringen" + "Öppna skrivskyddat"/
    "Öppna ändå"; konflikt-meddelande + länk till Word Jämför.
 

--- a/helper-ui/src/engine/document-source.ts
+++ b/helper-ui/src/engine/document-source.ts
@@ -10,14 +10,20 @@
 import type { HelperDocumentRef } from "@/lib/shared/helper/protocol";
 
 import {
+  acquireLease,
   createDocumentClient,
   downloadDocumentBytes,
+  releaseLease,
+  renewLease,
   saveConflictCopyBytes,
   uploadDocumentBytes,
   type ConflictCopy,
   type FetchLike,
+  type LeaseInfo,
   type UploadDocResult,
 } from "./trpc-client.ts";
+
+export type { LeaseInfo } from "./trpc-client.ts";
 
 /** En dokument-källa: tRPC (`document`) ELLER statisk URL (`downloadUrl`). */
 export interface SourceRef {
@@ -137,4 +143,28 @@ export async function saveConflictCopyViaTrpc(
     ...(deps.fetch ? { fetch: deps.fetch } : {}),
   });
   return saveConflictCopyBytes(client, document.id, bytes, label);
+}
+
+/** Bygg en tRPC-klient för ett dokument-ref (rå token ur "Bearer <token>"). */
+function clientFor(document: HelperDocumentRef, deps: FetchSourceDeps): ReturnType<typeof createDocumentClient> {
+  return createDocumentClient({
+    trpcUrl: document.trpcUrl,
+    token: (deps.authHeader ?? "").replace(/^Bearer\s+/i, ""),
+    ...(deps.fetch ? { fetch: deps.fetch } : {}),
+  });
+}
+
+/** Ta leasen (ADR 0033 §2) via tRPC — helpern tar den vid öppning för redigering. */
+export function acquireLeaseViaTrpc(document: HelperDocumentRef, deps: FetchSourceDeps = {}): Promise<LeaseInfo> {
+  return acquireLease(clientFor(document, deps), document.id);
+}
+
+/** Heartbeat: förnya leasen via tRPC (`false` = förlorad). */
+export function renewLeaseViaTrpc(document: HelperDocumentRef, deps: FetchSourceDeps = {}): Promise<boolean> {
+  return renewLease(clientFor(document, deps), document.id);
+}
+
+/** Släpp leasen via tRPC (vid watch-slut). */
+export function releaseLeaseViaTrpc(document: HelperDocumentRef, deps: FetchSourceDeps = {}): Promise<void> {
+  return releaseLease(clientFor(document, deps), document.id);
 }

--- a/helper-ui/src/engine/lease-session.ts
+++ b/helper-ui/src/engine/lease-session.ts
@@ -1,0 +1,59 @@
+/**
+ * Lease-heartbeat (ADR 0033 §2/§4) — håller helperns lease levande medan
+ * dokumentet är öppet för redigering, och släpper den när sessionen tar slut.
+ *
+ * Förnyar leasen var ~30 s tills `timeoutMs` löpt ut (samma livslängd som
+ * watch-loopen), släpper sedan i en `finally` (även vid förlorad lease eller
+ * fel) så ett dött lås aldrig blir kvar längre än serverns expire-tröskel.
+ * Tappas leasen (övertagen av annan) slutar vi förnya — användarens fortsatta
+ * sparningar 409:ar då och hamnar i keep-both (steg 2).
+ *
+ * IO/klocka injiceras (`LeaseHeartbeatDeps`) → deterministiska tester.
+ */
+
+import { log } from "./log.ts";
+
+const RENEW_INTERVAL_MS = 30_000;
+
+export interface LeaseHeartbeatDeps {
+  /** Förnya leasen; `false` = vi håller den inte längre (övertagen/utgången). */
+  renew: () => Promise<boolean>;
+  /** Släpp leasen (anropas en gång när sessionen slutar). */
+  release: () => Promise<void>;
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+}
+
+export const defaultLeaseTimers = {
+  sleep: (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms)),
+  now: (): number => Date.now(),
+};
+
+/** Starta heartbeaten (fire-and-forget); den släpper leasen vid timeout/förlust. */
+export function startLeaseHeartbeat(deps: LeaseHeartbeatDeps, timeoutMs: number): void {
+  void runLeaseHeartbeat(deps, timeoutMs);
+}
+
+export async function runLeaseHeartbeat(deps: LeaseHeartbeatDeps, timeoutMs: number): Promise<void> {
+  const deadline = deps.now() + timeoutMs;
+  try {
+    while (deps.now() < deadline) {
+      await deps.sleep(RENEW_INTERVAL_MS);
+      if (deps.now() >= deadline) break;
+      let held: boolean;
+      try {
+        held = await deps.renew();
+      } catch (err) {
+        // Nätfel → försök igen nästa varv (leasen löper ut server-side om vi tystnar).
+        log(`lease-renew fel (försöker igen): ${err instanceof Error ? err.message : String(err)}`);
+        continue;
+      }
+      if (!held) {
+        log("lease förlorad (övertagen?) — slutar förnya");
+        return;
+      }
+    }
+  } finally {
+    await deps.release().catch(() => { /* best-effort; leasen löper ut ändå */ });
+  }
+}

--- a/helper-ui/src/engine/main.ts
+++ b/helper-ui/src/engine/main.ts
@@ -27,9 +27,17 @@ import { loginConfigFromEnv, runLogin, type LoginConfig } from "./auth/login.ts"
 import { handleConfig } from "./config-endpoint.ts";
 import { ContentStore, resolveCacheTtlMs } from "./content-store.ts";
 import { fetchAndCacheContent, handleContent } from "./content.ts";
-import { fetchSourceBytes, sourceCacheKey } from "./document-source.ts";
+import {
+  acquireLeaseViaTrpc,
+  fetchSourceBytes,
+  releaseLeaseViaTrpc,
+  renewLeaseViaTrpc,
+  sourceCacheKey,
+  type FetchSourceDeps,
+} from "./document-source.ts";
 import { envWithConfig, loadHelperConfig, saveHelperConfig } from "./helper-config.ts";
 import { installService, uninstallService, type InstallDeps } from "./install.ts";
+import { defaultLeaseTimers, startLeaseHeartbeat } from "./lease-session.ts";
 import { initLog, log } from "./log.ts";
 import {
   defaultOpenDeps,
@@ -162,6 +170,11 @@ export function queueBackedOnOpen(queue: UploadQueue, content: ContentStore, aut
   // Browserns authHeader först; annars helperns egen OIDC-token (autonom, ADR 0028 §2).
   const fallback = async (browserAuth: string | undefined): Promise<string | undefined> =>
     browserAuth ?? (authHeader ? await authHeader() : undefined);
+  // Lease-anrop måste bära samma färska token som download/upload (autonom).
+  const leaseDeps = async (browserAuth: string | undefined): Promise<FetchSourceDeps> => {
+    const auth = await fallback(browserAuth);
+    return auth !== undefined ? { authHeader: auth } : {};
+  };
   const deps: OpenDeps = {
     ...defaultOpenDeps,
     // Local-first (ADR 0032): osynkad lokal ändring i kön slår serverns version.
@@ -177,6 +190,17 @@ export function queueBackedOnOpen(queue: UploadQueue, content: ContentStore, aut
       }),
     persist: (cacheKey, bytes, fileName) => persistDownloaded(content, cacheKey, bytes, fileName),
     restore: (cacheKey, path) => restoreCached(content, cacheKey, path),
+    // Lease (ADR 0033 §2/§4): ta vid öppning, förnya/släpp med färsk token.
+    acquireLease: async (document, browserAuth) => acquireLeaseViaTrpc(document, await leaseDeps(browserAuth)),
+    startLeaseHeartbeat: (document, browserAuth, timeoutMs) =>
+      startLeaseHeartbeat(
+        {
+          renew: async () => renewLeaseViaTrpc(document, await leaseDeps(browserAuth)),
+          release: async () => releaseLeaseViaTrpc(document, await leaseDeps(browserAuth)),
+          ...defaultLeaseTimers,
+        },
+        timeoutMs,
+      ),
   };
   return (req) => handleOpen(req, deps);
 }

--- a/helper-ui/src/engine/open.ts
+++ b/helper-ui/src/engine/open.ts
@@ -11,10 +11,23 @@ import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 
-import { isSafeFileName, type HelperOpenRequest } from "@/lib/shared/helper/protocol";
+import { isSafeFileName, type HelperDocumentRef, type HelperOpenRequest } from "@/lib/shared/helper/protocol";
 import type { ContentStore } from "./content-store.ts";
-import { fetchSourceBytes, sourceCacheKey, toSourceRef, uploadViaTrpc, type SourceBytes, type SourceRef, type UploadTarget } from "./document-source.ts";
+import {
+  acquireLeaseViaTrpc,
+  fetchSourceBytes,
+  releaseLeaseViaTrpc,
+  renewLeaseViaTrpc,
+  sourceCacheKey,
+  toSourceRef,
+  uploadViaTrpc,
+  type LeaseInfo,
+  type SourceBytes,
+  type SourceRef,
+  type UploadTarget,
+} from "./document-source.ts";
 import { json, parseJsonBody, textError } from "./http.ts";
+import { defaultLeaseTimers, startLeaseHeartbeat } from "./lease-session.ts";
 import { log } from "./log.ts";
 import { openWithDefaultApp } from "./platform/open-app.ts";
 import type { UploadQueue } from "./queue.ts";
@@ -34,6 +47,10 @@ export interface OpenDeps {
   persist?: (cacheKey: string, bytes: Uint8Array, fileName: string) => Promise<void>;
   /** Återställ cachade bytes (under `cacheKey`) till `path` när nedladdning misslyckas (offline). Valfri. */
   restore?: (cacheKey: string, path: string) => Promise<boolean>;
+  /** Ta leasen för ett server-dokument (ADR 0033 §2). Saknas → redigera utan lease. Valfri. */
+  acquireLease?: (document: HelperDocumentRef, authHeader?: string) => Promise<LeaseInfo>;
+  /** Starta lease-heartbeat (förnya + släpp vid timeout) när vi äger leasen. Valfri. */
+  startLeaseHeartbeat?: (document: HelperDocumentRef, authHeader: string | undefined, timeoutMs: number) => void;
 }
 
 export const defaultOpenDeps: OpenDeps = {
@@ -41,6 +58,16 @@ export const defaultOpenDeps: OpenDeps = {
   openApp: openWithDefaultApp,
   makeSessionDir: () => mkdtemp(join(tmpdir(), "ava-helper-")),
   startWatch: watchAndUpload,
+  acquireLease: (document, authHeader) => acquireLeaseViaTrpc(document, authHeader !== undefined ? { authHeader } : {}),
+  startLeaseHeartbeat: (document, authHeader, timeoutMs) =>
+    startLeaseHeartbeat(
+      {
+        renew: () => renewLeaseViaTrpc(document, authHeader !== undefined ? { authHeader } : {}),
+        release: () => releaseLeaseViaTrpc(document, authHeader !== undefined ? { authHeader } : {}),
+        ...defaultLeaseTimers,
+      },
+      timeoutMs,
+    ),
 };
 
 export async function handleOpen(req: Request, deps: OpenDeps = defaultOpenDeps): Promise<Response> {
@@ -66,13 +93,63 @@ async function runOpen(body: HelperOpenRequest, deps: OpenDeps): Promise<Respons
   const sessionDir = await deps.makeSessionDir();
   const tmpFile = join(sessionDir, body.fileName);
 
+  // Lease-beslut FÖRE nedladdning (ADR 0033 §2): redigerbart, skrivskyddat
+  // (leasat av annan), eller lånat (forceEdit). Skrivskyddat → ingen write-back.
+  const lease = await resolveLease(body, deps);
+
   const obtained = await obtainFile(body, tmpFile, deps);
   if (obtained instanceof Response) return obtained;
   const openErr = await tryStep(() => deps.openApp(tmpFile), 500, "open failed");
   if (openErr) return openErr;
 
-  startWatchIfNeeded(body, tmpFile, deps, obtained.version);
+  if (!lease.editable) {
+    // Skrivskyddat: ingen watch, ingen lease → även oavsiktlig redigering laddas aldrig upp.
+    log(`öppnar skrivskyddat${lease.holderName ? ` (${lease.holderName} redigerar)` : ""}: ${body.fileName}`);
+    return json({ path: tmpFile, status: "read-only", readOnly: true, ...(lease.holderName ? { leaseHolder: lease.holderName } : {}) });
+  }
+
+  armEditing(body, tmpFile, deps, obtained.version, lease.ownLease);
   return json({ path: tmpFile, status: "opened" });
+}
+
+/** Arma write-back (watch) + lease-heartbeat (bara när VI äger leasen). */
+function armEditing(body: HelperOpenRequest, tmpFile: string, deps: OpenDeps, baseVersion: number | undefined, ownLease: boolean): void {
+  const timeoutMs = watchTimeoutMs(body);
+  startWatchIfNeeded(body, tmpFile, deps, baseVersion, timeoutMs);
+  // Heartbeat bara när VI äger leasen (ej lån/demo) så ett stale lås läker av sig självt.
+  if (ownLease && body.document && deps.startLeaseHeartbeat) {
+    deps.startLeaseHeartbeat(body.document, body.authHeader, timeoutMs);
+  }
+}
+
+/** Hur länge watch + lease-heartbeat lever (default 60 min). */
+function watchTimeoutMs(body: HelperOpenRequest): number {
+  const m = body.maxWatchMinutes;
+  return (m !== undefined && m > 0 ? m : DEFAULT_WATCH_MINUTES) * 60_000;
+}
+
+/** Vad lease-beslutet blev (ADR 0033 §2). */
+interface LeaseDecision {
+  /** Redigerbart (watch armas)? false = skrivskyddat. */
+  editable: boolean;
+  /** Äger VI leasen (→ heartbeat)? false vid lån/demo/ingen lease. */
+  ownLease: boolean;
+  /** Vem håller leasen, när skrivskyddat/lånat pga annans lease. */
+  holderName?: string;
+}
+
+/**
+ * Avgör läs/skriv (ADR 0033 §2). Lease gäller bara server-dokument; demo/statisk
+ * behåller gammalt beteende (redigerbart, watch styrs av write-back-mål).
+ */
+async function resolveLease(body: HelperOpenRequest, deps: OpenDeps): Promise<LeaseDecision> {
+  if (body.readOnly) return { editable: false, ownLease: false }; // medvetet "öppna skrivskyddat"
+  if (!body.document || !deps.acquireLease) return { editable: true, ownLease: false };
+  const lease = await deps.acquireLease(body.document, body.authHeader);
+  if (lease.acquired) return { editable: true, ownLease: true }; // fri/egen (själv-återtagande)
+  // Leasat av annan: "öppna ändå" lånar (redigera utan lease), annars skrivskyddat.
+  if (body.forceEdit) return { editable: true, ownLease: false, holderName: lease.holderName };
+  return { editable: false, ownLease: false, holderName: lease.holderName };
 }
 
 /** Filen är skaffad; `version` = serverns basversion (ADR 0033), om känd. */
@@ -141,7 +218,7 @@ async function tryStep(fn: () => Promise<void>, status: number, label: string): 
   }
 }
 
-function startWatchIfNeeded(body: HelperOpenRequest, tmpFile: string, deps: OpenDeps, baseVersion?: number): void {
+function startWatchIfNeeded(body: HelperOpenRequest, tmpFile: string, deps: OpenDeps, baseVersion: number | undefined, timeoutMs: number): void {
   // Write-back-mål: tRPC-dokument (server, ADR 0031) ELLER PUT-URL (demo). Server-
   // målet bär basversionen (ADR 0033 §1) som kön versionskollar uploaden mot.
   const target: UploadTarget | null = body.document
@@ -150,9 +227,7 @@ function startWatchIfNeeded(body: HelperOpenRequest, tmpFile: string, deps: Open
       ? { uploadUrl: body.uploadUrl }
       : null;
   if (!target) return;
-  const m = body.maxWatchMinutes;
-  const minutes = m !== undefined && m > 0 ? m : DEFAULT_WATCH_MINUTES;
-  deps.startWatch(tmpFile, target, body.authHeader, minutes * 60_000);
+  deps.startWatch(tmpFile, target, body.authHeader, timeoutMs);
 }
 
 function errMsg(err: unknown): string {

--- a/helper-ui/src/engine/trpc-client.ts
+++ b/helper-ui/src/engine/trpc-client.ts
@@ -133,3 +133,27 @@ export async function saveConflictCopyBytes(
   const copy = await client.document.saveConflictCopy.mutate({ documentId, contentBase64: bytesToBase64(bytes), label });
   return { id: copy.id, fileName: copy.fileName };
 }
+
+/** Utfall av {@link acquireLease}: fick vi leasen, och vem håller den (för UI). */
+export interface LeaseInfo {
+  acquired: boolean;
+  holderId: string;
+  holderName: string;
+  stale: boolean;
+}
+
+/** Ta leasen (ADR 0033 §2) — helpern tar den vid öppning för redigering. */
+export async function acquireLease(client: TRPCClient<AppRouter>, documentId: string): Promise<LeaseInfo> {
+  const r = await client.document.acquireLease.mutate({ documentId });
+  return { acquired: r.acquired, holderId: r.lease.holderId, holderName: r.lease.holderName, stale: r.lease.stale };
+}
+
+/** Heartbeat: förnya leasen. `false` = vi håller den inte längre (övertagen/utgången). */
+export async function renewLease(client: TRPCClient<AppRouter>, documentId: string): Promise<boolean> {
+  return (await client.document.renewLease.mutate({ documentId })).renewed;
+}
+
+/** Släpp leasen (vid stäng/watch-slut). */
+export async function releaseLease(client: TRPCClient<AppRouter>, documentId: string): Promise<void> {
+  await client.document.releaseLease.mutate({ documentId });
+}

--- a/helper-ui/test/lease-session.test.ts
+++ b/helper-ui/test/lease-session.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Lease-heartbeat (ADR 0033 §2/§4) — förnyar tills timeout, släpper alltid.
+ * Klocka/sleep injiceras (sleep avancerar nu) → deterministiskt utan riktig tid.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { runLeaseHeartbeat, type LeaseHeartbeatDeps } from "../src/engine/lease-session.ts";
+
+/** Fake där `sleep(ms)` flyttar klockan framåt `ms` → loopen blir deterministisk. */
+function fakeTimers(): { now: () => number; sleep: (ms: number) => Promise<void> } {
+  let t = 0;
+  return { now: () => t, sleep: async (ms) => { t += ms; } };
+}
+
+describe("runLeaseHeartbeat", () => {
+  test("förnyar var 30 s tills timeout, släpper sedan en gång", async () => {
+    const timers = fakeTimers();
+    let renews = 0;
+    let released = 0;
+    const deps: LeaseHeartbeatDeps = {
+      ...timers,
+      renew: async () => { renews++; return true; },
+      release: async () => { released++; },
+    };
+    await runLeaseHeartbeat(deps, 90_000); // förnyar vid 30s, 60s; vid 90s → deadline
+    expect(renews).toBe(2);
+    expect(released).toBe(1);
+  });
+
+  test("tappar leasen (renew → false) → slutar förnya men släpper ändå", async () => {
+    const timers = fakeTimers();
+    let released = 0;
+    await runLeaseHeartbeat(
+      { ...timers, renew: async () => false, release: async () => { released++; } },
+      300_000,
+    );
+    expect(released).toBe(1);
+  });
+
+  test("renew kastar (nätfel) → fortsätter nästa varv (släpper inte i förtid)", async () => {
+    const timers = fakeTimers();
+    let calls = 0;
+    await runLeaseHeartbeat(
+      {
+        ...timers,
+        renew: async () => { calls++; if (calls === 1) throw new Error("ECONNREFUSED"); return calls < 3; },
+        release: async () => { /* noop */ },
+      },
+      200_000,
+    );
+    expect(calls).toBe(3); // kastade vid #1, fortsatte, #3 gav false → stopp
+  });
+
+  test("release-fel fäller inte heartbeaten", async () => {
+    const timers = fakeTimers();
+    await expect(
+      runLeaseHeartbeat(
+        { ...timers, renew: async () => true, release: async () => { throw new Error("net"); } },
+        60_000,
+      ),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/helper-ui/test/open.test.ts
+++ b/helper-ui/test/open.test.ts
@@ -17,11 +17,12 @@ interface Recorder {
   downloaded: string[]; // källnyckel (downloadUrl eller doc:<id>)
   opened: string[];
   watched: Array<{ path: string; target: UploadTarget; timeoutMs: number }>;
+  heartbeats: Array<{ documentId: string; timeoutMs: number }>;
   deps: OpenDeps;
 }
 
 function recorder(overrides: Partial<OpenDeps> = {}): Recorder {
-  const rec: Recorder = { sessionDir: "", downloaded: [], opened: [], watched: [], deps: {} as OpenDeps };
+  const rec: Recorder = { sessionDir: "", downloaded: [], opened: [], watched: [], heartbeats: [], deps: {} as OpenDeps };
   rec.deps = {
     // Returnerar bytes + basversion (ADR 0031/0033); obtainFile skriver filen.
     download: async (ref) => {
@@ -36,6 +37,8 @@ function recorder(overrides: Partial<OpenDeps> = {}): Recorder {
       return d;
     },
     startWatch: (path, target, _auth, timeoutMs) => { rec.watched.push({ path, target, timeoutMs }); },
+    // Heartbeat-default registrerar bara (anropas när VI äger leasen).
+    startLeaseHeartbeat: (document, _auth, timeoutMs) => { rec.heartbeats.push({ documentId: document.id, timeoutMs }); },
     ...overrides,
   };
   return rec;
@@ -125,6 +128,57 @@ describe("handleOpen", () => {
     const rec = recorder({ openApp: async () => { throw new Error("no app"); } });
     const res = await handleOpen(openReq({ downloadUrl: "http://x/f", fileName: "a.pdf" }), rec.deps);
     expect(res.status).toBe(500);
+  });
+});
+
+describe("lease (ADR 0033 §2/§4)", () => {
+  const docReq = { document: { id: "d7", trpcUrl: "http://s/api/trpc" }, fileName: "a.docx" };
+
+  test("fri lease (acquired) → redigerbart: watch + heartbeat startas", async () => {
+    const rec = recorder({ acquireLease: async () => ({ acquired: true, holderId: "u1", holderName: "Jag", stale: false }) });
+    const res = await handleOpen(openReq(docReq), rec.deps);
+    const body = (await res.json()) as { status: string; readOnly?: boolean };
+    expect(body.status).toBe("opened");
+    expect(body.readOnly).toBeUndefined();
+    expect(rec.watched).toHaveLength(1);
+    expect(rec.heartbeats).toEqual([{ documentId: "d7", timeoutMs: 60 * 60_000 }]);
+  });
+
+  test("leasat av annan → skrivskyddat: ingen watch, ingen heartbeat, hållare i svaret", async () => {
+    const rec = recorder({ acquireLease: async () => ({ acquired: false, holderId: "u2", holderName: "Anna", stale: false }) });
+    const res = await handleOpen(openReq(docReq), rec.deps);
+    const body = (await res.json()) as { status: string; readOnly?: boolean; leaseHolder?: string };
+    expect(body.status).toBe("read-only");
+    expect(body.readOnly).toBe(true);
+    expect(body.leaseHolder).toBe("Anna");
+    expect(rec.opened).toHaveLength(1); // öppnas ändå (för läsning)
+    expect(rec.watched).toHaveLength(0);
+    expect(rec.heartbeats).toHaveLength(0);
+  });
+
+  test("forceEdit + leasat av annan → lånar: redigerbart + watch men INGEN heartbeat", async () => {
+    const rec = recorder({ acquireLease: async () => ({ acquired: false, holderId: "u2", holderName: "Anna", stale: false }) });
+    const res = await handleOpen(openReq({ ...docReq, forceEdit: true }), rec.deps);
+    expect(((await res.json()) as { status: string }).status).toBe("opened");
+    expect(rec.watched).toHaveLength(1);
+    expect(rec.heartbeats).toHaveLength(0); // lånat → äger inte leasen
+  });
+
+  test("readOnly-flagga → skrivskyddat utan att ens ta leasen", async () => {
+    let acquireCalled = false;
+    const rec = recorder({ acquireLease: async () => { acquireCalled = true; return { acquired: true, holderId: "u1", holderName: "Jag", stale: false }; } });
+    const res = await handleOpen(openReq({ ...docReq, readOnly: true }), rec.deps);
+    expect(((await res.json()) as { status: string }).status).toBe("read-only");
+    expect(acquireCalled).toBe(false);
+    expect(rec.watched).toHaveLength(0);
+  });
+
+  test("ingen lease-dep wirad → redigerbart (bakåtkompatibelt)", async () => {
+    const rec = recorder(); // ingen acquireLease
+    const res = await handleOpen(openReq(docReq), rec.deps);
+    expect(((await res.json()) as { status: string }).status).toBe("opened");
+    expect(rec.watched).toHaveLength(1);
+    expect(rec.heartbeats).toHaveLength(0); // äger ingen lease → ingen heartbeat
   });
 });
 

--- a/src/lib/shared/helper/protocol.ts
+++ b/src/lib/shared/helper/protocol.ts
@@ -62,12 +62,28 @@ export interface HelperOpenRequest {
   authHeader?: string;
   /** Hur länge helpern lyssnar på save-events. Default 60 min. */
   maxWatchMinutes?: number;
+  /**
+   * Medvetet skrivskyddat (ADR 0033 §2, "Öppna skrivskyddat"): ingen lease,
+   * ingen watch — även oavsiktlig redigering laddas aldrig upp. Server-tier.
+   */
+  readOnly?: boolean;
+  /**
+   * "Öppna ändå för redigering" (ADR 0033 §2): redigera trots att någon annan
+   * har leasen. LÅNAR (tar inte över leasen) → redigerbart + watch, men ingen
+   * egen lease/heartbeat. Nästa save kan 409:a → keep-both.
+   */
+  forceEdit?: boolean;
 }
 
 /** Svar på `POST /open`. */
 export interface HelperOpenResponse {
   path: string;
+  /** `opened` (redigerbart) eller `read-only` (leasat av annan / medvetet). */
   status: string;
+  /** Är dokumentet öppnat skrivskyddat? (ingen write-back armad). */
+  readOnly?: boolean;
+  /** Namnet på den som håller leasen, när det öppnades skrivskyddat pga lease. */
+  leaseHolder?: string;
 }
 
 /**


### PR DESCRIPTION
Steg 4 av ADR 0033 — helpern äger leasens livscykel (#722-store).

## Vad
- **Öppna server-dok (redigera = default):** helpern `acquireLease` först.
  - Fri/egen lease (själv-återtagande efter krasch) → **redigerbart**: watch armas + **heartbeat** (`lease-session`: renew var 30s, släpp vid watch-slut).
  - Leasat av **annan** → **skrivskyddat**: ingen lease, ingen watch → även oavsiktlig redigering i Word laddas aldrig upp (äkta garanti, inte etikett). Svaret bär `leaseHolder` så web kan visa "Anna redigerar".
- **Flaggor** (web skickar i steg 5): `readOnly` (medvetet "öppna skrivskyddat" — tar inte ens leasen), `forceEdit` ("öppna ändå" = **lånar**: redigerbart + watch men ingen egen lease/heartbeat).
- Tappas leasen mid-edit (övertagen) → slutar förnya; nästa save 409:ar → keep-both (steg 2).
- Lease-anropen bär samma färska OIDC-token som download/upload (autonom drift).

## Test
- `lease-session`: förnyar tills timeout + släpper alltid (finally), stoppar på förlorad lease, fortsätter vid nätfel, release-fel fäller inte.
- `open`: acquired→watch+heartbeat; leasat→read-only (ingen watch/heartbeat, öppnas för läsning, hållare i svaret); forceEdit→lånar (watch, ingen heartbeat); readOnly→tar ej leasen; ingen lease-dep→bakåtkompatibelt.
- 293 helper-tester gröna; typecheck/lint/deps/knip rena.

Web-UI (steg 5) konsumerar `leaseHolder` + skickar flaggorna + visar "Ta över".

Closes #724