### PR TITLE
feat(documents): lease-medveten öppning + konflikt-klarspråk (ADR 0033 §5)

### DIFF
--- a/docs/adr/0033-konflikthantering-mjuk-lease-keep-both.md
+++ b/docs/adr/0033-konflikthantering-mjuk-lease-keep-both.md
@@ -1,6 +1,8 @@
 # ADR 0033 — Konflikthantering: förebygg via mjuk lease, lös via keep-both (ingen merge)
 
-- **Status:** Accepterad (2026-06-22) — *riktning spikad, ännu ej implementerad.*
+- **Status:** Accepterad och **implementerad** (2026-06-22) — alla fem steg landade
+  (#718 optimistisk version, #720 keep-both, #722 lease-store, #724 helper-lease,
+  #726 web-UI).
 - **Beslutsfattare:** Ulrik Sjölin
 - **Berör:** helper-ui (öppning/watch/kö), server-first (dokument-skrivning),
   web-appens dokument-UI, capability-tiers.
@@ -148,8 +150,11 @@ gör att ingenting någonsin försvinner — man kan alltid backa.
    aldrig upp); svaret bär hållarens namn. Flaggor: `readOnly` (medvetet
    skrivskyddat), `forceEdit` (lånar — redigera utan att ta leasen). Tappad lease
    mid-edit → slutar förnya, nästa save 409:ar → keep-both. *(#724)*
-5. **Web-UI:** "X redigerar" + "Ta över redigeringen" + "Öppna skrivskyddat"/
-   "Öppna ändå"; konflikt-meddelande + länk till Word Jämför.
+5. ✅ **Web-UI:** lease-medveten öppning (`useLeaseAwareOpen`, delad träd+list):
+   skrivskyddat utfall → `LeaseModal` "X redigerar" med **Behåll skrivskyddat** /
+   **Ta över redigeringen** (`takeoverLease` + öppna om) / **Öppna ändå** (lånar,
+   forceEdit). Konflikt-badgen säger på klarspråk att din version sparats separat
+   + pekar mot Word → Granska → Jämför. *(#726)*
 
 ## Öppna frågor
 

--- a/src/components/documents/_document-row.tsx
+++ b/src/components/documents/_document-row.tsx
@@ -10,6 +10,7 @@ import { DocumentTags } from "./_document-tags";
 import { formatFileSize } from "./_drag-helpers";
 import { SyncStatusBadge, type SyncStatus } from "./_sync-badge";
 import { ExternalEditModal, type ModalState } from "./external-edit-modal";
+import { useLeaseAwareOpen } from "./use-lease-aware-open";
 
 export interface DocumentRecord {
   id: string;
@@ -67,6 +68,8 @@ export function DocumentRow({
   // och DocumentActions (kebab-meny) kan trigga "Editera externt" mot
   // samma modal.
   const [modal, setModal] = useState<ModalState>({ kind: "closed" });
+  // Lease-medveten öppning (ADR 0033 §2): visar "X redigerar" + Ta över / Öppna ändå.
+  const { openDocument, leaseModal } = useLeaseAwareOpen();
   const triggerExternalEdit = async () => {
     // Försök först via AVA Helper (1-klicks-flow). Om helpern inte kör
     // faller vi tillbaka till befintlig ExternalEditModal (download via
@@ -79,12 +82,12 @@ export function DocumentRow({
   // Primärklick: AVA Helper (native-app) → FSA → browser-tab. Samma delade
   // logik som list-vyn (open-document-externally) så vyerna inte glider isär.
   const openPrimary = async () => {
-    const { openDocumentSmart } = await import("@/lib/client/firma/open-document-externally");
-    await openDocumentSmart({ id: doc.id, fileName: doc.fileName, storagePath: doc.storagePath }, setModal);
+    await openDocument({ id: doc.id, fileName: doc.fileName, storagePath: doc.storagePath }, setModal);
   };
   return (
     <Fragment>
       <ExternalEditModal state={modal} onClose={() => setModal({ kind: "closed" })} />
+      {leaseModal}
       <tr
         draggable={!isUploading}
         onDragStart={onDragStart}

--- a/src/components/documents/_documents-list-view.tsx
+++ b/src/components/documents/_documents-list-view.tsx
@@ -11,13 +11,13 @@
 import { useState } from "react";
 import { ActionMenu, type ActionMenuItem } from "@/components/ui/action-menu";
 import { DataTable, type Column } from "@/components/ui/data-table";
-import { openDocumentSmart } from "@/lib/client/firma/open-document-externally";
 import { trpc } from "@/lib/client/trpc";
 import type { DocumentRecord } from "./_document-row";
 import { formatFileSize } from "./_drag-helpers";
 import type { FolderRecord } from "./_folder-row";
 import { SyncStatusBadge, type SyncStatus } from "./_sync-badge";
 import { ExternalEditModal, type ModalState } from "./external-edit-modal";
+import { useLeaseAwareOpen } from "./use-lease-aware-open";
 
 interface Props {
   matterId: string;
@@ -45,12 +45,14 @@ function folderPath(folderId: string | null, folders: FolderRecord[]): string {
 
 export function DocumentsListView({ matterId, documents, folders, docSync = NO_SYNC, onDelete, onReanalyze }: Props) {
   const [modal, setModal] = useState<ModalState>({ kind: "closed" });
+  // Lease-medveten öppning (ADR 0033 §2) — delad med träd-vyn.
+  const { openDocument, leaseModal } = useLeaseAwareOpen();
 
   const columns: Column<DocumentRecord>[] = [
     { key: "fileName", label: "Filnamn", sortable: true, sortValue: (d) => d.fileName,
       render: (d) => (
         <span className="flex items-center gap-2 min-w-0">
-          <button type="button" onClick={() => void openDocumentSmart(d, setModal)}
+          <button type="button" onClick={() => void openDocument(d, setModal)}
             className="text-sm font-medium text-blue-600 hover:underline text-left"
             title="PDF/Word/Excel → öppnas i extern editor om du har valt en lokal mapp">
             {d.fileName}
@@ -77,7 +79,7 @@ export function DocumentsListView({ matterId, documents, folders, docSync = NO_S
     { key: "actions", label: "", sortable: false, align: "right", hideable: false,
       render: (d) => {
         const items: ActionMenuItem[] = [
-          { key: "external", label: "Editera externt", onSelect: () => void openDocumentSmart(d, setModal) },
+          { key: "external", label: "Editera externt", onSelect: () => void openDocument(d, setModal) },
           { key: "reanalyze", label: "Analysera igen", onSelect: () => onReanalyze(d.id) },
           {
             key: "delete",
@@ -97,6 +99,7 @@ export function DocumentsListView({ matterId, documents, folders, docSync = NO_S
   return (
     <div className="p-4">
       <ExternalEditModal state={modal} onClose={() => setModal({ kind: "closed" })} />
+      {leaseModal}
       <DataTable
         prefKey={`list.matter-documents.${matterId}`}
         columns={columns}

--- a/src/components/documents/_sync-badge.tsx
+++ b/src/components/documents/_sync-badge.tsx
@@ -20,9 +20,13 @@ export function SyncStatusBadge({ status }: { status?: SyncStatus | undefined })
     return (
       <span
         className={`${BADGE} bg-red-100 text-red-800`}
-        title="Versionskonflikt — serverns version har gått förbi dina lokala ändringar. Öppna och spara igen."
+        title={
+          "Dokumentet ändrades av någon annan medan du redigerade. Din version har sparats " +
+          "SEPARAT som en \"(din ändring …)\"-kopia i listan — inget är borta. Öppna båda och " +
+          "kopiera över det du vill behålla (i Word: Granska → Jämför)."
+        }
       >
-        ⚠ Konflikt
+        ⚠ Konflikt — din version sparad separat
       </span>
     );
   }

--- a/src/components/documents/lease-modal.tsx
+++ b/src/components/documents/lease-modal.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+/**
+ * `LeaseModal` (ADR 0033 §2) — visas när helpern öppnade ett dokument
+ * skrivskyddat för att någon annan redigerar det (håller leasen). Ger
+ * juristen tre tydliga val på klarspråk, utan teknisk jargong:
+ *
+ *   - Behåll skrivskyddat (säkrast, default-knappen).
+ *   - Ta över redigeringen → omtilldelar leasen permanent (den andra blir
+ *     skrivskyddad). För när hen "verkar inte redigera längre".
+ *   - Öppna ändå för redigering → lånar (redigerar parallellt); krockar löses
+ *     genom att din version sparas separat (keep-both, §4).
+ *
+ * Dum komponent: actions injiceras (`useLeaseAwareOpen` äger mutation + re-open).
+ */
+
+interface Props {
+  fileName: string;
+  leaseHolder?: string;
+  busy?: boolean;
+  onTakeover: () => void;
+  onForceEdit: () => void;
+  onClose: () => void;
+}
+
+const PRIMARY = "px-4 py-2 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 disabled:opacity-50";
+const SECONDARY = "px-3 py-1.5 border border-gray-300 text-sm rounded hover:bg-gray-50 disabled:opacity-50";
+
+export function LeaseModal({ fileName, leaseHolder, busy, onTakeover, onForceEdit, onClose }: Props): React.ReactElement {
+  const who = leaseHolder ?? "Någon annan";
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4" onClick={onClose}>
+      <div onClick={(e) => e.stopPropagation()} className="bg-white rounded-lg shadow-2xl max-w-lg w-full p-5">
+        <h2 className="text-lg font-semibold text-gray-900 mb-2">{who} redigerar det här dokumentet</h2>
+        <p className="text-sm text-gray-700 mb-4">
+          <code className="text-sm bg-gray-100 px-1 rounded">{fileName}</code> öppnades
+          {" "}<strong>skrivskyddat</strong> så att era ändringar inte krockar.
+        </p>
+
+        <div className="space-y-3 mb-2">
+          <div>
+            <button type="button" onClick={onClose} disabled={busy} className={PRIMARY}>
+              Behåll skrivskyddat
+            </button>
+            <p className="text-xs text-gray-500 mt-1">Säkrast — du tittar utan att riskera att skriva över {who}s arbete.</p>
+          </div>
+          <div>
+            <button type="button" onClick={onTakeover} disabled={busy} className={SECONDARY}>
+              {busy ? "Tar över…" : "Ta över redigeringen"}
+            </button>
+            <p className="text-xs text-gray-500 mt-1">
+              Gör dig till den som redigerar (om {who} inte verkar jobba längre). {who} blir då skrivskyddad.
+            </p>
+          </div>
+          <div>
+            <button type="button" onClick={onForceEdit} disabled={busy} className={SECONDARY}>
+              Öppna ändå för redigering
+            </button>
+            <p className="text-xs text-gray-500 mt-1">
+              Ni redigerar parallellt. Krockar hanteras automatiskt — din version sparas då separat, inget går förlorat.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/documents/use-lease-aware-open.tsx
+++ b/src/components/documents/use-lease-aware-open.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+/**
+ * `useLeaseAwareOpen` (ADR 0033 §2) — delad öppnings-logik för träd- och list-
+ * vyn så de inte glider isär. Wrappar `openDocumentSmart` och, när helpern
+ * öppnade skrivskyddat (annans lease), visar `LeaseModal` med "Ta över" /
+ * "Öppna ändå". Tar över via `document.takeoverLease` och öppnar om.
+ */
+
+import { useState } from "react";
+import type { ModalState } from "@/components/documents/external-edit-modal";
+import { LeaseModal } from "@/components/documents/lease-modal";
+import type { OpenOpts } from "@/lib/client/firma/open-document-externally";
+import { trpc } from "@/lib/client/trpc";
+
+interface OpenableDoc {
+  id: string;
+  fileName: string;
+  storagePath: string;
+}
+
+interface Pending {
+  doc: OpenableDoc;
+  leaseHolder?: string;
+}
+
+export interface LeaseAwareOpen {
+  /** Öppna ett dokument (helper-first); visar lease-modalen vid skrivskyddat utfall. */
+  openDocument: (doc: OpenableDoc, onModal: (m: ModalState) => void) => Promise<void>;
+  /** Lease-modalen att rendera (null när ingen konflikt). */
+  leaseModal: React.ReactElement | null;
+}
+
+export function useLeaseAwareOpen(): LeaseAwareOpen {
+  const [pending, setPending] = useState<Pending | null>(null);
+  const takeover = trpc.document.takeoverLease.useMutation();
+
+  const run = async (doc: OpenableDoc, onModal: (m: ModalState) => void, opts: OpenOpts = {}): Promise<void> => {
+    const { openDocumentSmart } = await import("@/lib/client/firma/open-document-externally");
+    const outcome = await openDocumentSmart(doc, onModal, opts);
+    if (outcome.kind === "read-only") {
+      setPending({ doc, ...(outcome.leaseHolder !== undefined ? { leaseHolder: outcome.leaseHolder } : {}) });
+    }
+  };
+
+  const onTakeover = async (): Promise<void> => {
+    if (!pending) return;
+    const { doc } = pending;
+    await takeover.mutateAsync({ documentId: doc.id });
+    setPending(null);
+    await run(doc, () => { /* re-open: leasen är nu vår → redigerbart */ });
+  };
+
+  const onForceEdit = async (): Promise<void> => {
+    if (!pending) return;
+    const { doc } = pending;
+    setPending(null);
+    await run(doc, () => { /* lånar leasen */ }, { forceEdit: true });
+  };
+
+  const leaseModal = pending
+    ? (
+      <LeaseModal
+        fileName={pending.doc.fileName}
+        {...(pending.leaseHolder !== undefined ? { leaseHolder: pending.leaseHolder } : {})}
+        busy={takeover.isPending}
+        onTakeover={() => void onTakeover()}
+        onForceEdit={() => void onForceEdit()}
+        onClose={() => setPending(null)}
+      />
+    )
+    : null;
+
+  return { openDocument: (doc, onModal) => run(doc, onModal), leaseModal };
+}

--- a/src/lib/client/firma/open-document-externally.ts
+++ b/src/lib/client/firma/open-document-externally.ts
@@ -36,6 +36,17 @@ interface Doc {
   storagePath: string;
 }
 
+/** Hur dokumentet ska öppnas (ADR 0033 §2). */
+export interface OpenOpts {
+  /** "Öppna ändå för redigering" — lånar trots annans lease. */
+  forceEdit?: boolean;
+  /** Medvetet "öppna skrivskyddat" (kebab-val). */
+  readOnly?: boolean;
+}
+
+/** Utfall av en öppning (ADR 0033 §2): klar, eller skrivskyddad pga annans lease. */
+export type OpenOutcome = { kind: "done" } | { kind: "read-only"; leaseHolder?: string };
+
 const DEFAULT_DEMO_REPO_FALLBACK = "ulrik-s/ava-demo";
 
 /**
@@ -51,22 +62,28 @@ const DEFAULT_DEMO_REPO_FALLBACK = "ulrik-s/ava-demo";
  * Web-appens jobb är bara att konstruera rätt URLs baserat på vilken
  * AVA-backend som körs (git-http eller REST). Helpern är tier-agnostisk.
  */
-export async function tryHelperOpen(doc: Doc): Promise<boolean> {
+export async function tryHelperOpen(doc: Doc, opts: OpenOpts = {}): Promise<OpenOutcome | null> {
   // openViaHelper löser transporten (https→http, ADR 0006) och kastar om helpern
-  // saknas → vi fångar och faller tillbaka. Källan väljs per tier (ADR 0031):
-  //   - server-tier: `document`-descriptor → helpern hämtar via tRPC
-  //     `document.downloadContent` med sin EGNA Bearer (typat, ingen REST-yta).
-  //   - demo: statisk GH-Pages-blob-URL (ingen server att tRPC:a mot).
-  // Write-back (uploadUrl) är ännu inte påkopplad i server-tier (ADR 0031 steg 3).
+  // saknas → vi fångar och returnerar null (→ fallback). Källan väljs per tier:
+  //   - server-tier: `document`-descriptor → helpern hämtar via tRPC + tar lease.
+  //   - demo: statisk GH-Pages-blob-URL (ingen server, ingen lease).
   const req: HelperOpenRequest = isDemoTier()
     ? { fileName: doc.fileName, downloadUrl: demoUrl(doc) }
-    : { fileName: doc.fileName, document: { id: doc.id, trpcUrl: helperTrpcUrl() } };
+    : {
+        fileName: doc.fileName,
+        document: { id: doc.id, trpcUrl: helperTrpcUrl() },
+        ...(opts.forceEdit ? { forceEdit: true } : {}),
+        ...(opts.readOnly ? { readOnly: true } : {}),
+      };
   try {
-    await openViaHelper(req);
-    return true;
+    const resp = await openViaHelper(req);
+    // Skrivskyddat (leasat av annan) → ytlägg hållaren så UI:t kan visa "X redigerar".
+    return resp.readOnly
+      ? { kind: "read-only", ...(resp.leaseHolder !== undefined ? { leaseHolder: resp.leaseHolder } : {}) }
+      : { kind: "done" };
   } catch (err) {
     console.warn("[helper] /open misslyckades, fallback:", err);
-    return false;
+    return null;
   }
 }
 
@@ -151,21 +168,23 @@ export function shouldPreferExternalEdit(fileName: string): boolean {
  * ens försöktes, så ett klick på en .docx/.pdf laddade bara ner / öppnade
  * browser-tab i stället för att öppna i native-appen.
  */
-export async function openDocumentSmart(doc: Doc, onModal: (m: ModalState) => void): Promise<void> {
+export async function openDocumentSmart(doc: Doc, onModal: (m: ModalState) => void, opts: OpenOpts = {}): Promise<OpenOutcome> {
   // Klient-genererade demo-dok (kostnadsräkning m.fl.) öppnas ur cachen — annars
   // 404:ar deras storagePath på GH Pages → app:en hamnar på dashboarden.
   const { hasGeneratedDoc, openGeneratedDoc } = await import("@/lib/client/demo/generated-doc-cache");
-  if (hasGeneratedDoc(doc.id)) { openGeneratedDoc(doc.id); return; }
+  if (hasGeneratedDoc(doc.id)) { openGeneratedDoc(doc.id); return { kind: "done" }; }
 
   if (shouldPreferExternalEdit(doc.fileName)) {
-    if (await tryHelperOpen(doc)) return; // 1) helpern
+    const outcome = await tryHelperOpen(doc, opts); // 1) helpern (öppnar + tar/visar lease)
+    if (outcome) return outcome;
     const { isFsaSupported, loadHandle } = await import("@/lib/client/fsa/handle-store");
     if (isFsaSupported() && await loadHandle("repo-root")) {
       onModal(await runExternalEdit(doc)); // 2) FSA
-      return;
+      return { kind: "done" };
     }
   }
   // 3) browser-tab
   const { openMatterDocument } = await import("@/lib/client/firma/open-matter-document");
   await openMatterDocument({ id: doc.id, storagePath: doc.storagePath, fileName: doc.fileName });
+  return { kind: "done" };
 }

--- a/src/lib/client/helper/use-helper.ts
+++ b/src/lib/client/helper/use-helper.ts
@@ -26,6 +26,7 @@ import {
   type HelperConfigRequest,
   type HelperContentRequest,
   type HelperOpenRequest,
+  type HelperOpenResponse,
   type HelperStatus,
   type HelperStatusResponse,
 } from "@/lib/shared/helper/protocol";
@@ -125,7 +126,7 @@ async function helperFetch(path: string, init: RequestInit): Promise<Response | 
  * konstruerar absolute download/upload-URLs baserat på vilken backend
  * som körs (git-http eller REST).
  */
-export async function openViaHelper(input: HelperOpenRequest): Promise<void> {
+export async function openViaHelper(input: HelperOpenRequest): Promise<HelperOpenResponse> {
   const r = await helperFetch("/open", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -136,6 +137,8 @@ export async function openViaHelper(input: HelperOpenRequest): Promise<void> {
   if (!r.ok) {
     throw new Error(`helper /open: HTTP ${r.status} ${await r.text()}`);
   }
+  // Svaret bär läs/skriv-utfallet (ADR 0033 §2): status opened|read-only + leaseHolder.
+  return (await r.json()) as HelperOpenResponse;
 }
 
 /**

--- a/test/unit/components/document-browser.test.tsx
+++ b/test/unit/components/document-browser.test.tsx
@@ -66,6 +66,7 @@ vi.mock("@/lib/client/trpc", () => ({
       analyze: { useMutation: () => mutationStubs.analyze },
       register: { useMutation: () => mutationStubs.register },
       setTags: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      takeoverLease: { useMutation: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }) },
     },
     organization: { getSettings: { useQuery: () => ({ data: { documentTags: [] } }) } },
     prefs: {

--- a/test/unit/components/document-row-upload-guard.test.tsx
+++ b/test/unit/components/document-row-upload-guard.test.tsx
@@ -17,7 +17,10 @@ vi.mock("@/lib/client/trpc", () => ({
   trpc: {
     useUtils: () => ({ document: { tree: { invalidate: vi.fn() } } }),
     organization: { getSettings: { useQuery: () => ({ data: { documentTags: [] } }) } },
-    document: { setTags: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) } },
+    document: {
+      setTags: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      takeoverLease: { useMutation: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }) },
+    },
   },
 }));
 

--- a/test/unit/components/documents-list-view.test.tsx
+++ b/test/unit/components/documents-list-view.test.tsx
@@ -10,6 +10,7 @@ vi.mock("@/lib/client/trpc", () => ({
   trpc: {
     useUtils: () => ({ prefs: { get: { invalidate: vi.fn() } } }),
     user: { current: { useQuery: () => ({ data: { id: "u1", role: "LAWYER" } }) } },
+    document: { takeoverLease: { useMutation: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }) } },
     prefs: {
       get: { useQuery: () => ({ data: undefined, isLoading: false }) },
       save: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },

--- a/test/unit/components/lease-modal.test.tsx
+++ b/test/unit/components/lease-modal.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * LeaseModal (ADR 0033 §2) — "X redigerar" + Ta över / Öppna ändå / Behåll
+ * skrivskyddat. Dum komponent; verifierar text + att knapparna anropar rätt
+ * callback och att `busy` låser dem.
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest-compat";
+import { LeaseModal } from "@/components/documents/lease-modal";
+
+const noop = () => { /* */ };
+
+describe("LeaseModal", () => {
+  it("visar hållarens namn och filnamnet", () => {
+    render(<LeaseModal fileName="avtal.docx" leaseHolder="Anna" onTakeover={noop} onForceEdit={noop} onClose={noop} />);
+    expect(screen.getByText(/Anna redigerar det här dokumentet/)).toBeTruthy();
+    expect(screen.getByText("avtal.docx")).toBeTruthy();
+  });
+
+  it("faller tillbaka på 'Någon annan' utan namn", () => {
+    render(<LeaseModal fileName="a.docx" onTakeover={noop} onForceEdit={noop} onClose={noop} />);
+    expect(screen.getByText(/Någon annan redigerar/)).toBeTruthy();
+  });
+
+  it("knapparna anropar rätt callback", () => {
+    const onTakeover = vi.fn();
+    const onForceEdit = vi.fn();
+    const onClose = vi.fn();
+    render(<LeaseModal fileName="a.docx" leaseHolder="Bo" onTakeover={onTakeover} onForceEdit={onForceEdit} onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: "Ta över redigeringen" }));
+    fireEvent.click(screen.getByRole("button", { name: "Öppna ändå för redigering" }));
+    fireEvent.click(screen.getByRole("button", { name: "Behåll skrivskyddat" }));
+    expect(onTakeover).toHaveBeenCalledTimes(1);
+    expect(onForceEdit).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("busy låser knapparna och visar 'Tar över…'", () => {
+    render(<LeaseModal fileName="a.docx" leaseHolder="Bo" busy onTakeover={noop} onForceEdit={noop} onClose={noop} />);
+    expect((screen.getByRole("button", { name: "Tar över…" }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole("button", { name: "Behåll skrivskyddat" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/test/unit/components/use-lease-aware-open.test.tsx
+++ b/test/unit/components/use-lease-aware-open.test.tsx
@@ -7,8 +7,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
 import { useLeaseAwareOpen } from "@/components/documents/use-lease-aware-open";
 
-type Outcome = { kind: "done" } | { kind: "read-only"; leaseHolder?: string };
-const openMock = vi.fn<(doc: unknown, onModal: unknown, opts?: unknown) => Promise<Outcome>>();
+const openMock = vi.fn();
 const takeoverMock = { mutateAsync: vi.fn().mockResolvedValue({}), isPending: false };
 
 vi.mock("@/lib/client/trpc", () => ({

--- a/test/unit/components/use-lease-aware-open.test.tsx
+++ b/test/unit/components/use-lease-aware-open.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * useLeaseAwareOpen (ADR 0033 §2) — read-only-utfall → visar LeaseModal;
+ * "Ta över" → takeoverLease + öppnar om. openDocumentSmart + trpc mockas.
+ */
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { useLeaseAwareOpen } from "@/components/documents/use-lease-aware-open";
+
+type Outcome = { kind: "done" } | { kind: "read-only"; leaseHolder?: string };
+const openMock = vi.fn<(doc: unknown, onModal: unknown, opts?: unknown) => Promise<Outcome>>();
+const takeoverMock = { mutateAsync: vi.fn().mockResolvedValue({}), isPending: false };
+
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: { document: { takeoverLease: { useMutation: () => takeoverMock } } },
+}));
+vi.mock("@/lib/client/firma/open-document-externally", () => ({
+  openDocumentSmart: (doc: unknown, onModal: unknown, opts?: unknown) => openMock(doc, onModal, opts),
+}));
+
+function Harness() {
+  const { openDocument, leaseModal } = useLeaseAwareOpen();
+  const doc = { id: "d1", fileName: "avtal.docx", storagePath: "p" };
+  return (
+    <div>
+      <button onClick={() => void openDocument(doc, () => { /* */ })}>open</button>
+      {leaseModal}
+    </div>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  takeoverMock.mutateAsync.mockResolvedValue({});
+});
+
+describe("useLeaseAwareOpen", () => {
+  it("read-only-utfall → visar LeaseModal med hållaren", async () => {
+    openMock.mockResolvedValue({ kind: "read-only", leaseHolder: "Anna" });
+    render(<Harness />);
+    fireEvent.click(screen.getByRole("button", { name: "open" }));
+    expect(await screen.findByText(/Anna redigerar det här dokumentet/)).toBeTruthy();
+  });
+
+  it("'done'-utfall → ingen modal", async () => {
+    openMock.mockResolvedValue({ kind: "done" });
+    render(<Harness />);
+    fireEvent.click(screen.getByRole("button", { name: "open" }));
+    await waitFor(() => expect(openMock).toHaveBeenCalled());
+    expect(screen.queryByText(/redigerar det här dokumentet/)).toBeNull();
+  });
+
+  it("'Ta över' → takeoverLease(documentId) + öppnar om, modal stängs", async () => {
+    openMock.mockResolvedValueOnce({ kind: "read-only", leaseHolder: "Anna" }); // första öppningen
+    openMock.mockResolvedValueOnce({ kind: "done" }); // re-open efter takeover
+    render(<Harness />);
+    fireEvent.click(screen.getByRole("button", { name: "open" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Ta över redigeringen" }));
+    await waitFor(() => expect(takeoverMock.mutateAsync).toHaveBeenCalledWith({ documentId: "d1" }));
+    await waitFor(() => expect(openMock).toHaveBeenCalledTimes(2)); // öppnade om
+    await waitFor(() => expect(screen.queryByText(/Anna redigerar/)).toBeNull());
+  });
+
+  it("'Öppna ändå' → öppnar om med forceEdit", async () => {
+    openMock.mockResolvedValueOnce({ kind: "read-only", leaseHolder: "Anna" });
+    openMock.mockResolvedValueOnce({ kind: "done" });
+    render(<Harness />);
+    fireEvent.click(screen.getByRole("button", { name: "open" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Öppna ändå för redigering" }));
+    await waitFor(() => expect(openMock).toHaveBeenCalledTimes(2));
+    expect(openMock.mock.calls[1]?.[2]).toEqual({ forceEdit: true });
+  });
+});

--- a/test/unit/lib/helper/open-externally.test.tsx
+++ b/test/unit/lib/helper/open-externally.test.tsx
@@ -29,28 +29,37 @@ describe("shouldPreferExternalEdit", () => {
 });
 
 describe("tryHelperOpen", () => {
-  it("returnerar false när /ping inte svarar", async () => {
+  it("returnerar null när /ping inte svarar (→ fallback)", async () => {
     global.fetch = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
     const result = await tryHelperOpen({ id: "d1", fileName: "f.pdf", storagePath: "p" });
-    expect(result).toBe(false);
+    expect(result).toBeNull();
   });
 
-  it("returnerar true när helpern svarar OK på /ping och /open", async () => {
+  it("returnerar {kind:'done'} när helpern öppnade redigerbart", async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(new Response("ava-helper v1.0.0\n", { status: 200 })) // /ping
-      .mockResolvedValueOnce(new Response("", { status: 200 })); // /open
+      .mockResolvedValueOnce(new Response(JSON.stringify({ path: "/tmp/f.pdf", status: "opened" }), { status: 200 })); // /open
     global.fetch = fetchMock;
     const result = await tryHelperOpen({ id: "d1", fileName: "f.pdf", storagePath: "documents/d1.pdf" });
-    expect(result).toBe(true);
+    expect(result).toEqual({ kind: "done" });
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it("returnerar false när helpern svarar OK på /ping men /open kastar", async () => {
+  it("returnerar {kind:'read-only', leaseHolder} när leasat av annan (ADR 0033 §2)", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response("ava-helper v1.0.0\n", { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ path: "/tmp/f.pdf", status: "read-only", readOnly: true, leaseHolder: "Anna" }), { status: 200 }));
+    global.fetch = fetchMock;
+    const result = await tryHelperOpen({ id: "d1", fileName: "f.pdf", storagePath: "p" });
+    expect(result).toEqual({ kind: "read-only", leaseHolder: "Anna" });
+  });
+
+  it("returnerar null när helpern svarar OK på /ping men /open kastar (→ fallback)", async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(new Response("ava-helper v1.0.0\n", { status: 200 }))
       .mockResolvedValueOnce(new Response("error", { status: 500 }));
     global.fetch = fetchMock;
     const result = await tryHelperOpen({ id: "d1", fileName: "f.pdf", storagePath: "p" });
-    expect(result).toBe(false);
+    expect(result).toBeNull();
   });
 });

--- a/test/unit/lib/helper/use-helper.test.tsx
+++ b/test/unit/lib/helper/use-helper.test.tsx
@@ -93,10 +93,11 @@ describe("openViaHelper", () => {
   it("POST:ar /open på den upplösta basen (HTTPS)", async () => {
     const fetchMock = routeFetch([
       [`${HTTPS}/ping`, () => new Response("ava-helper v1\n", { status: 200 })],
-      [`${HTTPS}/open`, () => new Response("", { status: 200 })],
+      [`${HTTPS}/open`, () => new Response(JSON.stringify({ path: "/tmp/x.pdf", status: "opened" }), { status: 200 })],
     ]);
     global.fetch = fetchMock;
-    await openViaHelper({ fileName: "x.pdf", downloadUrl: "https://example.com/x" });
+    const resp = await openViaHelper({ fileName: "x.pdf", downloadUrl: "https://example.com/x" });
+    expect(resp).toMatchObject({ status: "opened" });
     const openCall = fetchMock.mock.calls.find(([u]: [string]) => String(u).endsWith("/open"))!;
     expect(openCall[0]).toBe(`${HTTPS}/open`);
     expect(openCall[1].method).toBe("POST");


### PR DESCRIPTION
Steg 5 (sista) av ADR 0033 — det användarsynliga lease/konflikt-UI:t. Avslutar ADR 0033.

## Vad
- **`useLeaseAwareOpen`** (delad träd- + list-vy) fångar helperns /open-svar. Skrivskyddat utfall (leasat av annan) → **`LeaseModal`** "X redigerar det här dokumentet" med tre klarspråks-val:
  - **Behåll skrivskyddat** (säkrast, default-knapp)
  - **Ta över redigeringen** → `document.takeoverLease` + öppnar om (nu redigerbart)
  - **Öppna ändå för redigering** → lånar (forceEdit; krockar → keep-both)
- **`openViaHelper`** returnerar nu `HelperOpenResponse`; **`openDocumentSmart`** returnerar utfall (`done` | `read-only{leaseHolder}`); flaggorna `readOnly`/`forceEdit` skickas till helpern.
- **Konflikt-badge** säger på klarspråk att din version sparats SEPARAT (keep-both-syskonet syns i listan med självförklarande namn) + pekar mot Word → Granska → Jämför.

## Test
- `LeaseModal`: hållarnamn/fallback, knappar→callbacks, busy låser.
- `useLeaseAwareOpen`: read-only→modal, done→ingen modal, Ta över→takeoverLease+re-open, Öppna ändå→forceEdit.
- Befintliga document-tester uppdaterade (takeoverLease i trpc-mock). Hela komponent+klient-sviten grön under --parallel (489); typecheck/lint/deps/knip rena.

## Avslutar ADR 0033
Steg 1 #719 (optimistisk version) · 2 #721 (keep-both) · 3 #723 (lease-store) · 4 #725 (helper-lease) · 5 (denna).

Closes #726