### PR TITLE
fix(billing): billing-run slutfaktura länkar poster + acconto-avdrag (#728)

### DIFF
--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -17,6 +17,7 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { proposedAccontoOre } from "@/lib/shared/billing-proposal";
+import type { BillingRun } from "@/lib/shared/schemas/billing";
 import { billingRunRecipientSchema, type ExpenseKind } from "@/lib/shared/schemas/enums";
 import {
   matterIdSchema,
@@ -109,6 +110,27 @@ async function freezeWork(repos: Repositories, matterId: string, billingRunId: B
   await repos.expenses.freezeForMatter(matterId, billingRunId, now);
 }
 
+/**
+ * Koppla de DEBITERBARA frysta posterna till FINAL-fakturan (invoice_id) +
+ * registrera acconto-avdrag. Utan detta härleder slutfaktura-vyn `0.00` för
+ * arvode/utlägg (den summerar bara fakture-länkade poster) trots korrekt
+ * totalbelopp — frysning ensam räcker inte. Gör en billing-run-faktura
+ * identisk (för vy/ledger) med en legacy-skapad (#728). `work` är de poster
+ * som precis frystes; bara `billable` ingår i fakturabeloppet (jfr workValueOre).
+ */
+async function linkFinalInvoice(
+  repos: Repositories,
+  invoiceId: string,
+  work: UnfrozenWork,
+  deductedAccontoInvoiceIds: ReadonlyArray<string>,
+): Promise<void> {
+  await repos.timeEntries.flagBilled(work.timeEntries.filter((t) => t.billable).map((t) => t.id), invoiceId);
+  await repos.expenses.flagBilled(work.expenses.filter((e) => e.billable).map((e) => e.id), invoiceId);
+  for (const accontoInvoiceId of deductedAccontoInvoiceIds) {
+    await repos.accontoDeductions.create({ finalInvoiceId: asId<"InvoiceId">(invoiceId), accontoInvoiceId: asId<"InvoiceId">(accontoInvoiceId) });
+  }
+}
+
 async function assertMatterInOrg(repos: Repositories, matterId: string, orgId: string): Promise<void> {
   const m = await repos.matters.getByIdInOrg(matterId, orgId);
   if (!m) throw new TRPCError({ code: "NOT_FOUND", message: "Ärendet finns inte." });
@@ -193,7 +215,8 @@ export const billingRunRouter = router({
         await assertMatterInOrg(tx, input.matterId, ctx.orgId);
         const work = await fetchUnfrozenWork(tx, input.matterId);
         const value = workValueOre(work);
-        const deductionOre = await sumDeductions(tx, input.matterId, input.deductedBillingRunIds);
+        const deductedRuns = await fetchDeductedAccontoRuns(tx, input.matterId, input.deductedBillingRunIds);
+        const deductionOre = deductedRuns.reduce((sum, r) => sum + (r.amountOre ?? 0), 0);
         const finalAmount = Math.max(0, value - deductionOre);
         const invoice = await tx.invoices.create({
           matterId: input.matterId, amount: finalAmount,
@@ -208,6 +231,8 @@ export const billingRunRouter = router({
           periodTo: new Date(), notes: input.notes,
         });
         await freezeWork(tx, input.matterId, run.id as BillingRunId);
+        // Länka posterna + acconto-avdrag → slutfaktura-vyn visar rätt arvode/utlägg (#728).
+        await linkFinalInvoice(tx, invoice.id, work, accontoInvoiceIds(deductedRuns));
         await emit.invoiceCreated(ctx, invoice);
         return { run, invoice };
       });
@@ -266,15 +291,18 @@ export const billingRunRouter = router({
     }),
 });
 
-async function sumDeductions(
+/**
+ * Validera + hämta de avdragna ACCONTO-körningarna. Säkerhet (#60): de måste
+ * tillhöra SAMMA ärende och vara ACCONTO-körningar — annars kunde en FINAL dra
+ * av främmande/fel-typade billing-runs och förvanska beloppet. Returnerar
+ * körningarna (anroparen summerar `amountOre` + plockar deras `invoiceId`).
+ */
+async function fetchDeductedAccontoRuns(
   repos: Repositories,
   matterId: string,
   ids: ReadonlyArray<string>,
-): Promise<number> {
-  if (ids.length === 0) return 0;
-  // Säkerhet (#60): avdragsposterna måste tillhöra SAMMA ärende och vara
-  // ACCONTO-körningar — annars kunde en FINAL dra av främmande/fel-typade
-  // billing-runs och förvanska beloppet. Kasta om någon id inte matchar.
+): Promise<BillingRun[]> {
+  if (ids.length === 0) return [];
   const runs = await repos.billingRuns.listAccontoByIds(matterId, [...ids]);
   if (runs.length !== ids.length) {
     throw new TRPCError({
@@ -282,5 +310,10 @@ async function sumDeductions(
       message: "Någon avdragspost tillhör inte detta ärende eller är ingen ACCONTO-körning.",
     });
   }
-  return runs.reduce((sum, r) => sum + ((r as { amountOre: number }).amountOre ?? 0), 0);
+  return runs;
+}
+
+/** Acconto-fakturornas id ur avdragna körningar (för acconto_deductions-raderna). */
+function accontoInvoiceIds(runs: ReadonlyArray<BillingRun>): string[] {
+  return runs.map((r) => r.invoiceId).filter((id): id is NonNullable<typeof id> => id != null);
 }

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -12,6 +12,7 @@ import type { Principal } from "@/lib/server/auth/principal";
 import { buildContext } from "@/lib/server/build-context";
 import { DemoDataStore } from "@/lib/server/data-store/DemoDataStore";
 import { appRouter } from "@/lib/server/routers/_app";
+import { asId } from "@/lib/shared/schemas/ids";
 
 const PRINCIPAL: Principal = {
   id: "u-1", email: "a@x", name: "Anna", role: "ADMIN", organizationId: "org-1",
@@ -114,7 +115,7 @@ describe("billingRun.createFinal", () => {
 
   it("länkar INTE icke-debiterbara poster (de ingår inte i fakturabeloppet)", async () => {
     const { ds, caller } = makeCaller({ workMinutes: 60 });
-    await ds.timeEntries.create({ data: { id: "te-nb", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), minutes: 30, description: "Intern", hourlyRate: 250000, billable: false } });
+    await ds.timeEntries.create({ data: { id: asId<"TimeEntryId">("te-nb"), organizationId: "org-1", userId: asId<"UserId">("u-1"), matterId: asId<"MatterId">("m-1"), date: new Date(), minutes: 30, description: "Intern", hourlyRate: 250000, billable: false } });
     const res = await caller.billingRun.createFinal({ matterId: "m-1", recipient: "KLIENT" });
     const nb = await ds.timeEntries.findFirst({ where: { id: "te-nb" } }) as { invoiceId?: string | null; frozenAt?: Date | null };
     expect(nb.invoiceId).toBeFalsy(); // ej fakturerad

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -103,8 +103,27 @@ describe("billingRun.createFinal", () => {
     expect(te.frozenByBillingRunId).toBe(res.run.id);
   });
 
-  it("drar av tidigare ACCONTO-runs på slutbeloppet", async () => {
-    const { caller } = makeCaller({ workMinutes: 120 }); // 5000 kr värde
+  it("LÄNKAR de debiterbara posterna till fakturan (invoice_id) → vyn visar arvode/utlägg (#728)", async () => {
+    const { ds, caller } = makeCaller({ workMinutes: 60, expenseOre: 12500 });
+    const res = await caller.billingRun.createFinal({ matterId: "m-1", recipient: "KLIENT" });
+    const te = await ds.timeEntries.findFirst({ where: { id: "te-1" } }) as { invoiceId?: string | null };
+    const ex = await ds.expenses.findFirst({ where: { id: "ex-1" } }) as { invoiceId?: string | null };
+    expect(te.invoiceId).toBe(res.invoice.id); // FÖRR: null → arvode 0.00 i slutfaktura-vyn
+    expect(ex.invoiceId).toBe(res.invoice.id); // FÖRR: null → utlägg 0.00
+  });
+
+  it("länkar INTE icke-debiterbara poster (de ingår inte i fakturabeloppet)", async () => {
+    const { ds, caller } = makeCaller({ workMinutes: 60 });
+    await ds.timeEntries.create({ data: { id: "te-nb", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), minutes: 30, description: "Intern", hourlyRate: 250000, billable: false } });
+    const res = await caller.billingRun.createFinal({ matterId: "m-1", recipient: "KLIENT" });
+    const nb = await ds.timeEntries.findFirst({ where: { id: "te-nb" } }) as { invoiceId?: string | null; frozenAt?: Date | null };
+    expect(nb.invoiceId).toBeFalsy(); // ej fakturerad
+    expect(nb.frozenAt).toBeInstanceOf(Date); // men ändå fryst (med i körningen)
+    expect(res.run.amountOre).toBe(250000); // bara debiterbar tid räknas
+  });
+
+  it("drar av tidigare ACCONTO-runs på slutbeloppet + skapar acconto_deduction-rad (#728)", async () => {
+    const { ds, caller } = makeCaller({ workMinutes: 120 }); // 5000 kr värde
     const acc = await caller.billingRun.createAcconto({
       matterId: "m-1", clientShareBips: 2000, amountOre: 100000,
     });
@@ -115,6 +134,9 @@ describe("billingRun.createFinal", () => {
     // 500000 - 100000 = 400000
     expect(fin.run.amountOre).toBe(400000);
     expect(fin.run.deductedBillingRunIds).toEqual([acc.run.id]);
+    // Acconto-avdraget materialiseras så slutfaktura-vyns "att betala" stämmer.
+    const ded = await ds.accontoDeductions.findFirst({ where: { finalInvoiceId: fin.invoice.id } }) as { accontoInvoiceId?: string } | null;
+    expect(ded?.accontoInvoiceId).toBe(acc.invoice.id);
   });
 
   it("vägrar avdrag mot okänt/fel-scopat billing-run-id (#60)", async () => {


### PR DESCRIPTION
## Problem
Slutfakturor skapade via `billingRun.createFinal` visade **Upparbetat arvode 0.00 / Utlägg 0.00** trots korrekt totalbelopp. Vyn (`buildSettlement`) summerar bara fakture-länkade poster (`invoice_id`), men billing-run-flödet **frös** bara arbetet (`frozen_by_billing_run_id`) — det satte aldrig `invoice_id` och skapade inga `acconto_deductions`.

## Fix
`billingRun.createFinal` länkar nu de **debiterbara** frysta posterna till fakturan (`flagBilled`) + materialiserar `acconto_deductions` för avdragna acconto-körningar. En billing-run-faktura blir därmed identisk (för vy + ledger) med en legacy-skapad → billing-run kan ersätta legacy. Icke-debiterbara poster fryses men länkas ej (ingår inte i beloppet).

## Varför fanns problemet (svar på 'varför inte bara billing-run')
Vi är **mitt i en migration**: legacy `invoice.createFinal` (länkar korrekt) används fortfarande av live-UI:t (matter invoices-section); billing-run-modellen (nyare — acconto/prutning/rättshjälp som händelser) är ofullständigt inkopplad. Demo-generatorn kör t.o.m. **båda** flödena över samma ärenden → dubbla fakturor (t.ex. 2026-0001 har både en legacy-FINAL 11 388,50 kr OCH en billing-run-FINAL-DRAFT 15 788,50 kr).

## Test
3 nya: länkar debiterbara poster, länkar INTE icke-debiterbara, skapar acconto_deduction-rad. 194 server-tester gröna; typecheck/lint/deps/knip rena.

## Uppföljning (separat)
- Samma länkning i `setVerdict` (kostnadsräkning + PRUTNING-hänsyn).
- Peka om matter-UI → billing-run, pensionera legacy `invoice.createFinal`.
- Demo-generatorn: kör ETT flöde per ärende (slipp dubbelfakturor).

Closes #728