### PR TITLE
feat(billing): billing-run-fakturor får fakturanummer + OCR (1/5)

### DIFF
--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -17,8 +17,9 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { proposedAccontoOre } from "@/lib/shared/billing-proposal";
+import { ocrFromInvoiceNumber } from "@/lib/shared/ocr-reference";
 import type { BillingRun } from "@/lib/shared/schemas/billing";
-import { billingRunRecipientSchema, type ExpenseKind } from "@/lib/shared/schemas/enums";
+import { billingRunRecipientSchema, type BillingRunRecipient, type ExpenseKind } from "@/lib/shared/schemas/enums";
 import {
   matterIdSchema,
   billingRunIdSchema,
@@ -136,6 +137,22 @@ async function assertMatterInOrg(repos: Repositories, matterId: string, orgId: s
   if (!m) throw new TRPCError({ code: "NOT_FOUND", message: "Ärendet finns inte." });
 }
 
+/**
+ * Tilldela fakturanummer + OCR (ADR 0012) — klient-/försäkringsfakturor får
+ * `F-YYYY-NNNN` + härledd OCR; kostnadsräkningar till DOMSTOL får varken nummer
+ * eller OCR (domstolen betalar inte via OCR). Matchar legacy `invoice.createFinal`
+ * så en billing-run-faktura blir likvärdig. Tomt objekt → faktura utan nummer.
+ */
+async function invoiceNumbering(
+  repos: Repositories,
+  orgId: string,
+  recipient: BillingRunRecipient,
+): Promise<{ invoiceNumber: string; ocrReference: string | null } | Record<string, never>> {
+  if (recipient === "DOMSTOL") return {};
+  const invoiceNumber = await repos.invoices.nextInvoiceNumber(orgId);
+  return { invoiceNumber, ocrReference: ocrFromInvoiceNumber(invoiceNumber) };
+}
+
 export const billingRunRouter = router({
   list: orgProcedure
     .input(z.object({ matterId: matterIdSchema.optional() }))
@@ -189,6 +206,7 @@ export const billingRunRouter = router({
         const invoice = await tx.invoices.create({
           matterId: input.matterId, amount: input.amountOre,
           invoiceType: "ACCONTO", status: "DRAFT",
+          ...(await invoiceNumbering(tx, ctx.orgId, input.recipient)),
           invoiceDate: new Date(), notes: input.notes,
         });
         const run = await tx.billingRuns.create({
@@ -221,6 +239,7 @@ export const billingRunRouter = router({
         const invoice = await tx.invoices.create({
           matterId: input.matterId, amount: finalAmount,
           invoiceType: "FINAL", status: "DRAFT",
+          ...(await invoiceNumbering(tx, ctx.orgId, input.recipient)),
           invoiceDate: new Date(), notes: input.notes,
         });
         const run = await tx.billingRuns.create({

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -41,6 +41,8 @@ describe("billingRun.createAcconto", () => {
     expect(res.run.workValueOreAtRun).toBe(500000);
     expect(res.run.amountOre).toBe(100000);
     expect(res.invoice.invoiceType).toBe("ACCONTO");
+    expect(res.invoice.invoiceNumber).toMatch(/^F-\d{4}-\d+$/); // numreras (#730)
+    expect(res.invoice.ocrReference).toBeTruthy();
     // Rader är INTE frysta
     const te = await ds.timeEntries.findFirst({ where: { id: "te-1" } }) as { frozenAt?: Date | null };
     expect(te.frozenAt).toBeFalsy();
@@ -102,6 +104,20 @@ describe("billingRun.createFinal", () => {
     const te = await ds.timeEntries.findFirst({ where: { id: "te-1" } }) as { frozenAt?: Date | null; frozenByBillingRunId?: string | null };
     expect(te.frozenAt).toBeInstanceOf(Date);
     expect(te.frozenByBillingRunId).toBe(res.run.id);
+  });
+
+  it("tilldelar fakturanummer + OCR (klient) — ADR 0012 (#730)", async () => {
+    const { caller } = makeCaller({ workMinutes: 60 });
+    const res = await caller.billingRun.createFinal({ matterId: "m-1", recipient: "KLIENT" });
+    expect(res.invoice.invoiceNumber).toMatch(/^F-\d{4}-\d+$/);
+    expect(res.invoice.ocrReference).toBeTruthy();
+  });
+
+  it("DOMSTOL-mottagare → inget fakturanummer/OCR (ADR 0012)", async () => {
+    const { caller } = makeCaller({ workMinutes: 60 });
+    const res = await caller.billingRun.createFinal({ matterId: "m-1", recipient: "DOMSTOL" });
+    expect(res.invoice.invoiceNumber).toBeFalsy();
+    expect(res.invoice.ocrReference).toBeFalsy();
   });
 
   it("LÄNKAR de debiterbara posterna till fakturan (invoice_id) → vyn visar arvode/utlägg (#728)", async () => {


### PR DESCRIPTION
Konsolidering mot billing-run, **steg 1/5**. Billing-run skapade DRAFT-fakturor utan fakturanummer/OCR; legacy gör det vid skapande (ADR 0012). Nu tilldelar createAcconto + createFinal `F-YYYY-NNNN` + OCR → billing-run-fakturor blir riktiga kundfakturor. DOMSTOL (kostnadsräkning) → inget nummer/OCR (ADR 0012-regeln; setVerdict i steg 2).

Test: klient-final/acconto numreras, DOMSTOL-final inte. 20 billing-tester gröna.

Steg i konsolideringen: **1 numrering** · 2 setVerdict-länkning · 3 per-post-val · 4 demo en-flöde · 5 pensionera legacy.

Closes #730