### PR TITLE
fix(billing): setVerdict länkar poster + PRUTNING (2/5)

### DIFF
--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -288,22 +288,30 @@ export const billingRunRouter = router({
           throw new TRPCError({ code: "BAD_REQUEST", message: "Bara KOSTNADSRAKNING i PENDING_VERDICT kan domsläggas." });
         }
         const finalAmount = Math.max(0, run.workValueOreAtRun + input.prutningOre);
+        let prutningExpenseId: string | undefined;
         if (input.prutningOre < 0) {
-          await tx.expenses.create({
+          const prutning = await tx.expenses.create({
             matterId: run.matterId, userId: asId<"UserId">(ctx.user.id), date: new Date(),
             amount: input.prutningOre, description: "Prutning enligt dom",
             billable: true, vatRate: 0, vatIncluded: false, kind: "PRUTNING",
           });
+          prutningExpenseId = prutning.id;
         }
+        // Debiterbara poster INNAN frysning (ex. PRUTNING, som länkas separat nedan).
+        const work = await fetchUnfrozenWork(tx, run.matterId);
         const invoice = await tx.invoices.create({
           matterId: run.matterId, amount: finalAmount,
-          invoiceType: "FINAL", status: "DRAFT",
+          invoiceType: "FINAL", status: "DRAFT", // DOMSTOL → inget nummer/OCR (ADR 0012)
           invoiceDate: new Date(),
         });
         await tx.billingRuns.update(run.id, {
           status: "SENT", invoiceId: invoice.id, amountOre: finalAmount, prutningOre: input.prutningOre,
         });
         await freezeWork(tx, run.matterId, run.id as BillingRunId);
+        // Länka poster + PRUTNING-utlägget → kostnadsräknings-vyn visar uppdelning
+        // och totalen (arvode + utlägg − prutning) reconciler mot beloppet (#732).
+        await linkFinalInvoice(tx, invoice.id, work, []);
+        if (prutningExpenseId) await tx.expenses.flagBilled([prutningExpenseId], invoice.id);
         await emit.invoiceCreated(ctx, invoice);
         return { run, invoice };
       });

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -219,6 +219,28 @@ describe("billingRun.setVerdict", () => {
     expect(res.invoice.amount).toBe(400000); // 500 - 100
   });
 
+  it("LÄNKAR poster + PRUTNING till fakturan → vyn reconciler mot beloppet (#732)", async () => {
+    const { ds, caller } = makeCaller({ workMinutes: 120, expenseOre: 5000 }); // 5000 kr + 50 kr utlägg
+    const kr = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
+    const res = await caller.billingRun.setVerdict({ billingRunId: kr.run.id, prutningOre: -30000 });
+    const te = await ds.timeEntries.findFirst({ where: { id: "te-1" } }) as { invoiceId?: string | null };
+    const ex = await ds.expenses.findFirst({ where: { id: "ex-1" } }) as { invoiceId?: string | null };
+    const prut = await ds.expenses.findFirst({ where: { matterId: "m-1", kind: "PRUTNING" } }) as { invoiceId?: string | null };
+    expect(te.invoiceId).toBe(res.invoice.id); // arvode länkad
+    expect(ex.invoiceId).toBe(res.invoice.id); // utlägg länkad
+    expect(prut.invoiceId).toBe(res.invoice.id); // PRUTNING länkad (reducerar totalen)
+    // Summa länkade poster = arvode 5000 + utlägg 50 − prutning 300 = invoice 4750 kr.
+    expect(res.invoice.amount).toBe(500000 + 5000 - 30000);
+  });
+
+  it("DOMSTOL-faktura får inget fakturanummer (ADR 0012)", async () => {
+    const { caller } = makeCaller({ workMinutes: 60 });
+    const kr = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
+    const res = await caller.billingRun.setVerdict({ billingRunId: kr.run.id, prutningOre: 0 });
+    expect(res.invoice.invoiceNumber).toBeFalsy();
+    expect(res.invoice.ocrReference).toBeFalsy();
+  });
+
   it("kastar om billing-run inte är KOSTNADSRAKNING", async () => {
     const { caller } = makeCaller({ workMinutes: 60 });
     const acc = await caller.billingRun.createAcconto({


### PR DESCRIPTION
Konsolidering mot billing-run, **steg 2/5**. `setVerdict` (domstols-kostnadsräkning) frös arbetet men länkade aldrig poster → kostnadsräknings-vyn visade 0.00. Nu länkas debiterbara poster + PRUTNING-utlägget till fakturan så uppdelningen visas och totalen (arvode + utlägg − prutning) reconciler. Inget nummer/OCR (DOMSTOL, ADR 0012).

Test: poster + PRUTNING länkas, total reconciler, court-faktura saknar nummer. 22 billing-tester gröna.

Steg: 1 numrering ✓ · **2 setVerdict** · 3 per-post-val · 4 demo en-flöde · 5 pensionera legacy.

Closes #732