### PR TITLE
feat(billing): per-post-val på billing-run-slutfaktura (3/5)

### DIFF
--- a/src/app/matters/[id]/_billing-dialog.tsx
+++ b/src/app/matters/[id]/_billing-dialog.tsx
@@ -10,7 +10,7 @@
  * Båda flödena skapar ett DRAFT-utkast OCH ett faktura-PDF-dokument i ärendets
  * dokumentlista (via `generateFakturaDoc`), redo för utskick.
  */
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Modal } from "@/components/ui/modal";
 import {
   generateFakturaDoc,
@@ -130,19 +130,25 @@ function FinalForm({ matterId, meta, accontos, onDone }: { matterId: string; met
   const proposal = trpc.billingRun.proposal.useQuery({ matterId });
   const [recipient, setRecipient] = useState<"KLIENT" | "FORSAKRING" | "RATTSHJALPSMYNDIGHET">("KLIENT");
   const [selected, setSelected] = useState<string[]>(accontos.map((a) => a.id));
+  // Per-post-val (#734): null = inte rört → fakturera allt (server-default). När
+  // användaren bockar ur en post går vi över till explicit lista.
+  const allPostKeys = useMemo(() => unbilledRows(proposal.data).map((p) => p.id), [proposal.data]);
+  const [posts, setPosts] = useState<string[] | null>(null);
+  const togglePost = (key: string, checked: boolean): void =>
+    setPosts((prev) => { const base = prev ?? allPostKeys; return checked ? [...base, key] : base.filter((k) => k !== key); });
   const makeDoc = useFakturaDoc(matterId, meta);
   const mut = trpc.billingRun.createFinal.useMutation({
     onSuccess: async (res) => { await makeDoc(res.invoice); onDone(); },
   });
   return (
     <form onSubmit={(e) => { e.preventDefault(); mut.mutate({
-      matterId, recipient, deductedBillingRunIds: selected,
+      matterId, recipient, deductedBillingRunIds: selected, ...splitSelectedPosts(posts),
     }); }} className="space-y-3">
       <p className="text-sm text-gray-600">
-        Faktura med full specifikation av tid och utlägg. Alla obetalda
-        tids- och utläggsrader fryses och tas med nedan.
+        Faktura med full specifikation av tid och utlägg. Bocka i exakt vilka
+        poster som ska med — ikryssade fryses och tas med på fakturan.
       </p>
-      <UnbilledPosts proposal={proposal.data} loading={proposal.isLoading} />
+      <UnbilledPosts proposal={proposal.data} loading={proposal.isLoading} selected={posts ?? allPostKeys} onToggle={togglePost} />
       <Field label="Mottagare">
         <select value={recipient} onChange={(e) => setRecipient(e.target.value as typeof recipient)}
           className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm">
@@ -177,26 +183,42 @@ interface ProposalData {
   expenses: Array<{ id: string; description: string; amount: number; billable: boolean }>;
 }
 
-function UnbilledPosts({ proposal, loading }: { proposal: ProposalData | undefined; loading: boolean }) {
+function UnbilledPosts(
+  { proposal, loading, selected, onToggle }:
+  { proposal: ProposalData | undefined; loading: boolean; selected: string[]; onToggle: (key: string, checked: boolean) => void },
+) {
   if (loading) return <p className="text-xs text-gray-500">Laddar ofakturerade poster…</p>;
   const posts = unbilledRows(proposal);
   if (posts.length === 0) return <p className="text-xs text-gray-500">Inga ofakturerade poster i ärendet.</p>;
+  const chosenOre = posts.filter((p) => selected.includes(p.id)).reduce((s, p) => s + p.valueOre, 0);
   return (
-    <Field label={`Ofakturerade poster (${posts.length}) — föreslås i fakturan`}>
+    <Field label={`Poster att fakturera (${selected.length}/${posts.length} valda)`}>
       <div className="space-y-1 max-h-40 overflow-y-auto rounded border border-gray-200 bg-gray-50 px-2 py-1.5">
         {posts.map((p) => (
-          <div key={p.id} className="flex items-center justify-between text-xs">
-            <span className="truncate text-gray-700">{p.label}</span>
+          <label key={p.id} className="flex items-center justify-between gap-2 text-xs cursor-pointer">
+            <span className="flex items-center gap-2 min-w-0">
+              <input type="checkbox" checked={selected.includes(p.id)} onChange={(e) => onToggle(p.id, e.target.checked)} />
+              <span className="truncate text-gray-700">{p.label}</span>
+            </span>
             <span className="font-mono text-gray-900">{formatCurrency(p.valueOre)}</span>
-          </div>
+          </label>
         ))}
         <div className="flex items-center justify-between border-t border-gray-300 pt-1 text-xs font-semibold">
-          <span>Upparbetat värde</span>
-          <span className="font-mono">{formatCurrency(proposal?.workValueOre ?? 0)}</span>
+          <span>Valt värde</span>
+          <span className="font-mono">{formatCurrency(chosenOre)}</span>
         </div>
       </div>
     </Field>
   );
+}
+
+/** Dela upp valda post-nycklar (`te-…`/`ex-…`) i id-listor för createFinal. `null` → utelämna (allt). */
+function splitSelectedPosts(posts: string[] | null): { timeEntryIds: string[]; expenseIds: string[] } | Record<string, never> {
+  if (posts === null) return {};
+  return {
+    timeEntryIds: posts.filter((k) => k.startsWith("te-")).map((k) => k.slice(3)),
+    expenseIds: posts.filter((k) => k.startsWith("ex-")).map((k) => k.slice(3)),
+  };
 }
 
 interface PostRow { id: string; label: string; valueOre: number }

--- a/src/lib/server/repositories/drizzle-expense-repository.ts
+++ b/src/lib/server/repositories/drizzle-expense-repository.ts
@@ -98,6 +98,13 @@ export class DrizzleExpenseRepository extends DrizzleRepository<Expense> impleme
       .where(and(eq(expenses.matterId, asId<"MatterId">(matterId)), isNull(expenses.frozenByBillingRunId)));
   }
 
+  async freezeByIds(ids: string[], billingRunId: string, now: Date): Promise<void> {
+    if (ids.length === 0) return;
+    await this.db.update(expenses)
+      .set({ frozenAt: now, frozenByBillingRunId: asId<"BillingRunId">(billingRunId) })
+      .where(and(inArray(expenses.id, ids.map((i) => asId<"ExpenseId">(i))), isNull(expenses.frozenByBillingRunId)));
+  }
+
   async listForLawyerInPeriod(
     organizationId: string, userId: string, from: Date, to: Date,
   ): Promise<LawyerReportExpense[]> {

--- a/src/lib/server/repositories/drizzle-time-entry-repository.ts
+++ b/src/lib/server/repositories/drizzle-time-entry-repository.ts
@@ -175,4 +175,11 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
       .set({ frozenAt: now, frozenByBillingRunId: asId<"BillingRunId">(billingRunId) })
       .where(and(eq(timeEntries.matterId, asId<"MatterId">(matterId)), isNull(timeEntries.frozenByBillingRunId)));
   }
+
+  async freezeByIds(ids: string[], billingRunId: string, now: Date): Promise<void> {
+    if (ids.length === 0) return;
+    await this.db.update(timeEntries)
+      .set({ frozenAt: now, frozenByBillingRunId: asId<"BillingRunId">(billingRunId) })
+      .where(and(inArray(timeEntries.id, ids.map((i) => asId<"TimeEntryId">(i))), isNull(timeEntries.frozenByBillingRunId)));
+  }
 }

--- a/src/lib/server/repositories/expense-repository.ts
+++ b/src/lib/server/repositories/expense-repository.ts
@@ -47,6 +47,8 @@ export interface ExpenseRepository extends Repository<Expense> {
   listUnfrozenForMatter(matterId: string): Promise<Expense[]>;
   /** Frys alla ofrysta utlägg i ett ärende mot en billing-run (bulk). */
   freezeForMatter(matterId: string, billingRunId: string, now: Date): Promise<void>;
+  /** Frys ENBART de angivna (ofrysta) utläggen mot en billing-run — per-post-val. */
+  freezeByIds(ids: string[], billingRunId: string, now: Date): Promise<void>;
   /** En advokats utlägg i en period (date asc), med ärende-ref (perLawyer-rapporten). */
   listForLawyerInPeriod(organizationId: string, userId: string, from: Date, to: Date): Promise<LawyerReportExpense[]>;
 }

--- a/src/lib/server/repositories/in-memory-expense-repository.ts
+++ b/src/lib/server/repositories/in-memory-expense-repository.ts
@@ -72,6 +72,14 @@ export class InMemoryExpenseRepository extends InMemoryRepository<Expense> imple
     });
   }
 
+  async freezeByIds(ids: string[], billingRunId: string, now: Date): Promise<void> {
+    if (!ids.length) return;
+    await this.delegate.updateMany({
+      where: { id: { in: ids }, frozenByBillingRunId: null },
+      data: { frozenAt: now, frozenByBillingRunId: billingRunId } as Partial<Expense>,
+    });
+  }
+
   async listForLawyerInPeriod(
     organizationId: string, userId: string, from: Date, to: Date,
   ): Promise<LawyerReportExpense[]> {

--- a/src/lib/server/repositories/in-memory-time-entry-repository.ts
+++ b/src/lib/server/repositories/in-memory-time-entry-repository.ts
@@ -111,6 +111,14 @@ export class InMemoryTimeEntryRepository extends InMemoryRepository<TimeEntry> i
     });
   }
 
+  async freezeByIds(ids: string[], billingRunId: string, now: Date): Promise<void> {
+    if (!ids.length) return;
+    await this.delegate.updateMany({
+      where: { id: { in: ids }, frozenByBillingRunId: null },
+      data: { frozenAt: now, frozenByBillingRunId: billingRunId } as Partial<TimeEntry>,
+    });
+  }
+
   async listForLawyerInPeriod(
     organizationId: string, userId: string, from: Date, to: Date,
   ): Promise<LawyerReportTimeEntry[]> {

--- a/src/lib/server/repositories/time-entry-repository.ts
+++ b/src/lib/server/repositories/time-entry-repository.ts
@@ -79,6 +79,8 @@ export interface TimeEntryRepository extends Repository<TimeEntry> {
   listUnfrozenForMatter(matterId: string): Promise<TimeEntry[]>;
   /** Frys alla ofrysta tidsposter i ett ärende mot en billing-run (bulk). */
   freezeForMatter(matterId: string, billingRunId: string, now: Date): Promise<void>;
+  /** Frys ENBART de angivna (ofrysta) tidsposterna mot en billing-run — per-post-val. */
+  freezeByIds(ids: string[], billingRunId: string, now: Date): Promise<void>;
   /** En advokats tidsposter i en period (date asc), med ärende-ref (perLawyer-rapporten). */
   listForLawyerInPeriod(organizationId: string, userId: string, from: Date, to: Date): Promise<LawyerReportTimeEntry[]>;
   /** Alla debiterbara tidsposter i org:en (för fakturerat/AR-attribuering). */

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -132,6 +132,54 @@ async function linkFinalInvoice(
   }
 }
 
+/**
+ * Vilket arbete ska slutfaktureras (#734)? Anges `timeEntryIds`/`expenseIds`
+ * fakturerar vi ENBART dem (per-post-val, validerade som ofakturerade i ärendet);
+ * utelämnas båda tar vi allt ofryst (modellens default). PRUTNING-utlägg utesluts
+ * (de länkas separat i kostnadsräknings-flödet).
+ */
+async function resolveFinalWork(
+  repos: Repositories,
+  matterId: string,
+  timeEntryIds: string[] | undefined,
+  expenseIds: string[] | undefined,
+): Promise<{ work: UnfrozenWork; selected: boolean }> {
+  if (timeEntryIds === undefined && expenseIds === undefined) {
+    return { work: await fetchUnfrozenWork(repos, matterId), selected: false };
+  }
+  const teIds = timeEntryIds ?? [];
+  const exIds = expenseIds ?? [];
+  const selTime = await repos.timeEntries.listUnbilled(matterId, teIds);
+  const selExp = await repos.expenses.listUnbilled(matterId, exIds);
+  if (selTime.length !== teIds.length || selExp.length !== exIds.length) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: "Någon vald post är redan fakturerad eller tillhör annat ärende." });
+  }
+  return {
+    work: {
+      timeEntries: selTime.map((t) => ({ id: t.id, minutes: t.minutes, hourlyRate: t.user.hourlyRate ?? 0, billable: t.billable })),
+      expenses: selExp.filter((e) => e.kind !== "PRUTNING").map((e) => ({ id: e.id, amount: e.amount, billable: e.billable })),
+    },
+    selected: true,
+  };
+}
+
+/** Frys valda poster (per-post) eller hela ärendet (default). */
+async function freezeSelectedWork(
+  repos: Repositories,
+  matterId: string,
+  work: UnfrozenWork,
+  selected: boolean,
+  runId: BillingRunId,
+): Promise<void> {
+  if (!selected) {
+    await freezeWork(repos, matterId, runId);
+    return;
+  }
+  const now = new Date();
+  await repos.timeEntries.freezeByIds(work.timeEntries.map((t) => t.id), runId, now);
+  await repos.expenses.freezeByIds(work.expenses.map((e) => e.id), runId, now);
+}
+
 async function assertMatterInOrg(repos: Repositories, matterId: string, orgId: string): Promise<void> {
   const m = await repos.matters.getByIdInOrg(matterId, orgId);
   if (!m) throw new TRPCError({ code: "NOT_FOUND", message: "Ärendet finns inte." });
@@ -226,12 +274,15 @@ export const billingRunRouter = router({
       matterId: matterIdSchema,
       recipient: billingRunRecipientSchema,
       deductedBillingRunIds: z.array(billingRunIdSchema).default([]),
+      // Per-post-val (#734): anges → fakturera/frys ENBART dessa; utelämnas → allt ofryst.
+      timeEntryIds: z.array(z.string()).optional(),
+      expenseIds: z.array(z.string()).optional(),
       notes: z.string().nullish(),
     }))
     .mutation(async ({ ctx, input }) => {
       return ctx.repos.transaction(async (tx) => {
         await assertMatterInOrg(tx, input.matterId, ctx.orgId);
-        const work = await fetchUnfrozenWork(tx, input.matterId);
+        const { work, selected } = await resolveFinalWork(tx, input.matterId, input.timeEntryIds, input.expenseIds);
         const value = workValueOre(work);
         const deductedRuns = await fetchDeductedAccontoRuns(tx, input.matterId, input.deductedBillingRunIds);
         const deductionOre = deductedRuns.reduce((sum, r) => sum + (r.amountOre ?? 0), 0);
@@ -249,7 +300,7 @@ export const billingRunRouter = router({
           invoiceId: invoice.id, deductedBillingRunIds: input.deductedBillingRunIds,
           periodTo: new Date(), notes: input.notes,
         });
-        await freezeWork(tx, input.matterId, run.id as BillingRunId);
+        await freezeSelectedWork(tx, input.matterId, work, selected, run.id as BillingRunId);
         // Länka posterna + acconto-avdrag → slutfaktura-vyn visar rätt arvode/utlägg (#728).
         await linkFinalInvoice(tx, invoice.id, work, accontoInvoiceIds(deductedRuns));
         await emit.invoiceCreated(ctx, invoice);

--- a/test/unit/app/matters/billing-dialog.test.tsx
+++ b/test/unit/app/matters/billing-dialog.test.tsx
@@ -119,10 +119,10 @@ describe("BillingDialog — FINAL", () => {
 
   it("visar de ofakturerade posterna + upparbetat värde", () => {
     render(<BillingDialog matterId="m1" type="FINAL" existingAccontos={[]} meta={meta} onClose={() => {}} />);
-    expect(screen.getByText(/Ofakturerade poster \(2\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Poster att fakturera \(2\/2 valda\)/)).toBeInTheDocument();
     expect(screen.getByText("Möte med klient")).toBeInTheDocument();
     expect(screen.getByText("Ansökningsavgift")).toBeInTheDocument();
-    expect(screen.getByText("Upparbetat värde")).toBeInTheDocument();
+    expect(screen.getByText("Valt värde")).toBeInTheDocument();
   });
 
   it("visar tomtext när inga ofakturerade poster finns", () => {
@@ -142,10 +142,26 @@ describe("BillingDialog — FINAL", () => {
 
   it("avmarkera ett aconto → utesluts ur avdragen", () => {
     render(<BillingDialog matterId="m1" type="FINAL" existingAccontos={accontos} meta={meta} onClose={() => {}} />);
-    const boxes = screen.getAllByRole("checkbox");
-    fireEvent.click(boxes[0]!); // avmarkera br-1
+    const boxes = screen.getAllByRole("checkbox"); // [post te-1, post ex-1, aconto br-1, aconto br-2]
+    fireEvent.click(boxes[2]!); // avmarkera br-1 (första aconto efter de 2 posterna)
     fireEvent.click(screen.getByRole("button", { name: "Skapa faktura" }));
     expect(finalMutate).toHaveBeenCalledWith(expect.objectContaining({ deductedBillingRunIds: ["br-2"] }));
+  });
+
+  it("per-post-val: avmarkera en post → bara valda id:n i payloaden (#734)", () => {
+    render(<BillingDialog matterId="m1" type="FINAL" existingAccontos={[]} meta={meta} onClose={() => {}} />);
+    const boxes = screen.getAllByRole("checkbox"); // [post te-1, post ex-1]
+    fireEvent.click(boxes[1]!); // avmarkera utlägget ex-1
+    fireEvent.click(screen.getByRole("button", { name: "Skapa faktura" }));
+    expect(finalMutate).toHaveBeenCalledWith(expect.objectContaining({ timeEntryIds: ["te-1"], expenseIds: [] }));
+  });
+
+  it("default (inga poster avmarkerade) → inga post-id:n i payloaden (allt faktureras)", () => {
+    render(<BillingDialog matterId="m1" type="FINAL" existingAccontos={[]} meta={meta} onClose={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: "Skapa faktura" }));
+    const call = finalMutate.mock.calls[0]![0] as Record<string, unknown>;
+    expect(call.timeEntryIds).toBeUndefined();
+    expect(call.expenseIds).toBeUndefined();
   });
 
   it("byt mottagare → skickas i payloaden", () => {

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -139,6 +139,36 @@ describe("billingRun.createFinal", () => {
     expect(res.run.amountOre).toBe(250000); // bara debiterbar tid räknas
   });
 
+  it("per-post-val: fakturerar ENBART valda poster, lämnar resten ofryst (#734)", async () => {
+    const { ds, caller } = makeCaller({ workMinutes: 60, expenseOre: 5000 }); // te-1 (2500kr) + ex-1 (50kr)
+    await ds.timeEntries.create({ data: { id: asId<"TimeEntryId">("te-2"), organizationId: "org-1", userId: asId<"UserId">("u-1"), matterId: asId<"MatterId">("m-1"), date: new Date(), minutes: 60, description: "B", hourlyRate: 250000, billable: true } });
+    const res = await caller.billingRun.createFinal({ matterId: "m-1", recipient: "KLIENT", timeEntryIds: ["te-1"], expenseIds: [] });
+    expect(res.invoice.amount).toBe(250000); // bara te-1, inget utlägg
+    const t1 = await ds.timeEntries.findFirst({ where: { id: "te-1" } }) as { invoiceId?: string | null; frozenAt?: Date | null };
+    const t2 = await ds.timeEntries.findFirst({ where: { id: "te-2" } }) as { invoiceId?: string | null; frozenAt?: Date | null };
+    const e1 = await ds.expenses.findFirst({ where: { id: "ex-1" } }) as { frozenAt?: Date | null };
+    expect(t1.invoiceId).toBe(res.invoice.id);
+    expect(t1.frozenAt).toBeInstanceOf(Date);
+    expect(t2.invoiceId).toBeFalsy(); // ej vald → kvar ofryst för senare
+    expect(t2.frozenAt).toBeFalsy();
+    expect(e1.frozenAt).toBeFalsy(); // expenseIds=[] → utlägg ej med
+  });
+
+  it("per-post-val validerar id:n (okänt/fel-scopat → fel)", async () => {
+    const { caller } = makeCaller({ workMinutes: 60 });
+    await expect(caller.billingRun.createFinal({
+      matterId: "m-1", recipient: "KLIENT", timeEntryIds: ["finns-ej"], expenseIds: [],
+    })).rejects.toThrow(/redan fakturerad|annat ärende/);
+  });
+
+  it("utan per-post-val → fakturerar allt ofryst (default oförändrat)", async () => {
+    const { ds, caller } = makeCaller({ workMinutes: 60, expenseOre: 5000 });
+    const res = await caller.billingRun.createFinal({ matterId: "m-1", recipient: "KLIENT" });
+    expect(res.invoice.amount).toBe(250000 + 5000);
+    const t1 = await ds.timeEntries.findFirst({ where: { id: "te-1" } }) as { frozenAt?: Date | null };
+    expect(t1.frozenAt).toBeInstanceOf(Date);
+  });
+
   it("drar av tidigare ACCONTO-runs på slutbeloppet + skapar acconto_deduction-rad (#728)", async () => {
     const { ds, caller } = makeCaller({ workMinutes: 120 }); // 5000 kr värde
     const acc = await caller.billingRun.createAcconto({


### PR DESCRIPTION
Konsolidering mot billing-run, **steg 3/5**. Bevarar legacy-UI:ts per-post-val så legacy kan pensioneras (steg 5).

- `billingRun.createFinal` tar valfria `timeEntryIds`/`expenseIds` → frys + länka ENBART dem (validerade som ofakturerade i ärendet); utelämnas båda → allt ofryst (default oförändrat).
- Nytt repo-metod `freezeByIds` (time-entries + expenses, interface + drizzle + in-memory).
- `FinalForm` får per-post-kryssrutor (default alla valda; skickar explicita id:n bara när man bockar ur).

Test: server per-post frys/länk + validering + default-väg; UI uncheck→id:n i payload + default→inga id:n. 25 billing- + 13 dialog-tester gröna.

Steg: 1 numrering ✓ · 2 setVerdict ✓ · **3 per-post-val** · 4 demo en-flöde · 5 pensionera legacy.

Closes #734