### PR TITLE
feat(billing): visa "upparbetat ofakturerat" i faktureringspanelen

### DIFF
--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -261,6 +261,7 @@ export function BillingPanel({ matterId, matter }: Props) {
         <BillingActions paymentMethod={matter.paymentMethod ?? ""} onPick={onPick} />
       </div>
       <SummaryCards totals={computeTotals(rows)} />
+      <UnbilledSummary matterId={matterId} />
       <RadgivningBanner matterId={matterId} matter={matter} onRecorded={refetch} />
       {pending && <PendingVerdictBanner matterId={matterId} run={pending} onClick={() => setVerdictRunId(pending.id)} />}
       <RunsList rows={rows} loading={runs.isLoading} />
@@ -298,6 +299,38 @@ function RadgivningBanner({ matterId, matter, onRecorded }: { matterId: string; 
           className="text-xs px-2 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 whitespace-nowrap">
           {create.isPending ? "Registrerar…" : "Registrera betald"}
         </button>
+      )}
+    </div>
+  );
+}
+
+/**
+ * "Upparbetat ofakturerat" (#740) — debiterbart arbete som ännu inte frysts/
+ * fakturerats, så juristen lätt ser om något behöver faktureras. Visar arvode
+ * (exkl utlägg) + utlägg separat + totalt (inkl utlägg). Datan = billingRun.proposal
+ * (ofrysta debiterbara poster). PRUTNING är redan exkluderad i proposal.
+ */
+function UnbilledSummary({ matterId }: { matterId: string }) {
+  const proposal = trpc.billingRun.proposal.useQuery({ matterId });
+  const d = proposal.data;
+  if (proposal.isLoading || !d) return null;
+  const arvodeOre = d.timeEntries.filter((t) => t.billable).reduce((s, t) => s + t.valueOre, 0);
+  const utlaggOre = d.expenses.filter((e) => e.billable).reduce((s, e) => s + e.amount, 0);
+  const totalOre = arvodeOre + utlaggOre;
+  const has = totalOre > 0;
+  return (
+    <div className={`mx-6 mb-4 rounded-lg border px-4 py-3 ${has ? "border-blue-200 bg-blue-50" : "border-gray-200 bg-gray-50"}`}>
+      <div className="flex items-center justify-between">
+        <span className="text-[10px] uppercase tracking-wide text-gray-500">Upparbetat ofakturerat</span>
+        <span className="font-mono font-semibold text-sm text-gray-900">{formatCurrency(totalOre)}</span>
+      </div>
+      {has ? (
+        <div className="mt-1 flex flex-wrap gap-x-5 gap-y-1 text-xs text-gray-600">
+          <span>Arvode (exkl utlägg): <span className="font-mono text-gray-800">{formatCurrency(arvodeOre)}</span></span>
+          <span>Utlägg: <span className="font-mono text-gray-800">{formatCurrency(utlaggOre)}</span></span>
+        </div>
+      ) : (
+        <div className="mt-1 text-xs text-gray-500">Inget ofakturerat — allt debiterbart arbete är fakturerat.</div>
       )}
     </div>
   );

--- a/test/unit/app/matters/billing-panel.test.tsx
+++ b/test/unit/app/matters/billing-panel.test.tsx
@@ -20,6 +20,8 @@ interface BillingRunRow {
 
 let runsData: { runs: BillingRunRow[] } = { runs: [] };
 let runsLoading = false;
+interface ProposalData { workValueOre: number; priorAccontoSumOre: number; timeEntries: Array<{ id: string; description: string; minutes: number; hourlyRate: number; billable: boolean; valueOre: number }>; expenses: Array<{ id: string; description: string; amount: number; billable: boolean }> }
+let proposalData: ProposalData = { workValueOre: 0, priorAccontoSumOre: 0, timeEntries: [], expenses: [] };
 const refetch = vi.fn();
 const radgivningMutate = vi.fn();
 const krMutate = vi.fn();
@@ -31,6 +33,7 @@ vi.mock("@/lib/client/trpc", () => ({
   trpc: {
     billingRun: {
       list: { useQuery: () => ({ data: runsData, isLoading: runsLoading, refetch }) },
+      proposal: { useQuery: () => ({ data: proposalData, isLoading: false }) },
       createKostnadsrakning: { useMutation: () => ({ mutate: krMutate, isPending: false }) },
     },
     organization: {
@@ -82,6 +85,7 @@ beforeEach(() => {
   runsData = { runs: [] };
   runsLoading = false;
   documentListData = { documents: [] };
+  proposalData = { workValueOre: 0, priorAccontoSumOre: 0, timeEntries: [], expenses: [] };
   hasDoc = false;
 });
 
@@ -115,6 +119,35 @@ describe("BillingPanel — översikt", () => {
     expect(screen.getByText("Aconto fakturerat")).toBeInTheDocument();
     // Faktura-länk för run med invoiceId (EntityLink-stub)
     expect(screen.getByText("F-1")).toBeInTheDocument();
+  });
+});
+
+describe("BillingPanel — Upparbetat ofakturerat", () => {
+  it("visar arvode/utlägg/total när det finns ofakturerat debiterbart arbete", () => {
+    proposalData = {
+      workValueOre: 120_000,
+      priorAccontoSumOre: 0,
+      timeEntries: [
+        { id: "t1", description: "Arbete", minutes: 60, hourlyRate: 1200, billable: true, valueOre: 120_000 },
+        { id: "t2", description: "Ej deb", minutes: 30, hourlyRate: 1200, billable: false, valueOre: 60_000 },
+      ],
+      expenses: [
+        { id: "e1", description: "Ansökningsavgift", amount: 90_000, billable: true },
+        { id: "e2", description: "Ej deb", amount: 10_000, billable: false },
+      ],
+    };
+    render(<BillingPanel matterId="m1" matter={baseMatter} />);
+    expect(screen.getByText("Upparbetat ofakturerat")).toBeInTheDocument();
+    // Arvode 1200,00 (bara billable), Utlägg 900,00, Total 2100,00.
+    expect(screen.getByText(/1\s*200,00/)).toBeInTheDocument();
+    expect(screen.getByText(/900,00/)).toBeInTheDocument();
+    expect(screen.getByText(/2\s*100,00/)).toBeInTheDocument();
+  });
+
+  it("visar tomtext när inget ofakturerat finns", () => {
+    render(<BillingPanel matterId="m1" matter={baseMatter} />);
+    expect(screen.getByText("Upparbetat ofakturerat")).toBeInTheDocument();
+    expect(screen.getByText(/Inget ofakturerat/)).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Vad
Lägger till en summa-ruta överst i ärendets faktureringspanel ("Upparbetat ofakturerat") som visar debiterbart arbete som ännu inte frysts/fakturerats:
- **Arvode** (exkl utlägg)
- **Utlägg** separat
- **Totalt** (inkl utlägg)

Tom-tillstånd visar "Inget ofakturerat — allt debiterbart arbete är fakturerat."

## Varför
Juristen ska lätt kunna se om något behöver faktureras direkt i ärendet, utan att gå in i en fakturadialog.

## Hur
Datan kommer från `billingRun.proposal` (ofrysta debiterbara poster; PRUTNING redan exkluderad i proposal). Komponenten speglar `buildProposal`s `workValueOre`-beräkning (bara `billable` räknas).

## Test
2 nya tester i `billing-panel.test.tsx`: belopp-fall (arvode/utlägg/total, exkluderar ej-debiterbart) + tom-text-fall. 14/14 gröna, typecheck ok.

Closes #740

🤖 Generated with [Claude Code](https://claude.com/claude-code)