### PR TITLE
feat(helper): per-flik helper-bas-override via localStorage

### DIFF
--- a/src/lib/client/helper/use-helper.ts
+++ b/src/lib/client/helper/use-helper.ts
@@ -37,6 +37,28 @@ export type { HelperStatus, HelperStatusResponse };
 const PROBE_ORDER = [HELPER_HTTPS_BASE, HELPER_BASE] as const;
 let cachedBase: string | undefined;
 
+/** localStorage-nyckel för per-flik helper-bas-override (se `probeBases`). */
+export const HELPER_BASE_OVERRIDE_KEY = "ava.helperBase";
+
+/**
+ * Probe-ordning. En per-flik-override (localStorage `ava.helperBase`, t.ex.
+ * `http://127.0.0.1:48771`) låter flera flikar/sessioner peka på VAR SIN
+ * helper-instans. Utan den probar alla flikar den hårdkodade default-porten →
+ * samma helper = samma identitet, vilket gör t.ex. ett 2-användares konflikt-
+ * e2e omöjligt (#742). Saknas override: HTTPS först (Safari), sedan HTTP.
+ */
+function probeBases(): readonly string[] {
+  try {
+    if (typeof localStorage !== "undefined") {
+      const override = localStorage.getItem(HELPER_BASE_OVERRIDE_KEY);
+      if (override) return [override];
+    }
+  } catch {
+    // localStorage kan kasta i sandbox/privacy-läge — falla tillbaka på default.
+  }
+  return PROBE_ORDER;
+}
+
 /**
  * Skydd mot probe-storm (#653): en MISS cachas inte (helpern kan startas
  * senare), men utan broms kan en anropare i en render-loop fyra av tusentals
@@ -67,7 +89,7 @@ async function probeHelper(now: () => number = Date.now): Promise<{ base: string
   if (inFlight) return inFlight; // dedup: dela pågående probe
   if (cachedBase === undefined && now() - lastMissAt < MISS_TTL_MS) return null; // negativ-cache
   inFlight = (async () => {
-    const bases = cachedBase !== undefined ? [cachedBase] : PROBE_ORDER;
+    const bases = cachedBase !== undefined ? [cachedBase] : probeBases();
     for (const base of bases) {
       const text = await pingText(base);
       if (text !== null) {

--- a/test/unit/lib/helper/use-helper.test.tsx
+++ b/test/unit/lib/helper/use-helper.test.tsx
@@ -18,6 +18,7 @@ import {
   syncBadgeMap,
   emptySyncTracker,
   SYNCED_TTL_MS,
+  HELPER_BASE_OVERRIDE_KEY,
 } from "@/lib/client/helper/use-helper";
 import type { HelperStatusResponse, HelperSyncEntry } from "@/lib/shared/helper/protocol";
 
@@ -29,6 +30,7 @@ beforeEach(() => {
   vi.restoreAllMocks();
   global.fetch = originalFetch;
   resetHelperBaseCache();
+  localStorage.removeItem(HELPER_BASE_OVERRIDE_KEY);
 });
 
 /** fetch-mock som svarar per URL-fragment; okända URL:er rejectar. */
@@ -75,6 +77,17 @@ describe("useHelper / transport", () => {
     global.fetch = routeFetch([[`${HTTPS}/ping`, () => new Response("garbage", { status: 200 })]]);
     render(<Probe />);
     await waitFor(() => expect(screen.getByText("absent")).toBeInTheDocument());
+  });
+
+  it("per-flik-override (localStorage) pekar på en egen helper-bas (#742)", async () => {
+    const OTHER = "http://127.0.0.1:48771";
+    localStorage.setItem(HELPER_BASE_OVERRIDE_KEY, OTHER);
+    const fetchMock = routeFetch([[`${OTHER}/ping`, () => new Response("ava-helper v9\n", { status: 200 })]]);
+    global.fetch = fetchMock;
+    render(<Probe />);
+    await waitFor(() => expect(screen.getByText("v9")).toBeInTheDocument());
+    // Default-portarna (48761/48762) ska ALDRIG probas när en override finns.
+    expect(fetchMock.mock.calls.every(([u]: [string]) => String(u).startsWith(OTHER))).toBe(true);
   });
 
   it("negativ-cachar en miss → ingen probe-storm (#653)", async () => {


### PR DESCRIPTION
Steg 1 av #742 (UI-drivet konflikt-e2e).

## Vad
Webb-appens helper-probe (`use-helper.ts`) tittar nu på en valfri per-flik override i `localStorage` (`ava.helperBase`, t.ex. `http://127.0.0.1:48771`) innan den faller tillbaka på det hårdkodade default-paret (48762/48761).

## Varför
För att kunna köra **två** användare med var sin helper-instans i samma e2e behöver varje browser-kontext kunna peka på sin egen helper. Annars probar alla flikar default-porten → samma helper → samma identitet, och 2-användares konflikt-scenariot går inte att återskapa. Helpern honorerar redan `AVA_HELPER_PORT`, så detta är den sista biten.

## Hur
`probeBases()` läser overriden (try/catch mot sandbox/privacy-läge). Påverkar bara probe-ordningen; cache + storm-broms oförändrade.

## Test
Nytt test: override → bara den basen probas, default-portarna rörs aldrig. 27/27 gröna, typecheck + lint ok.

Refs #742

🤖 Generated with [Claude Code](https://claude.com/claude-code)