### PR TITLE
feat(helper): fil-backad token-store för headless/Linux-auth

### DIFF
--- a/helper-ui/src/engine/auth/token-store.ts
+++ b/helper-ui/src/engine/auth/token-store.ts
@@ -11,7 +11,10 @@
  */
 
 import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 
+import type { Platform } from "../platform/runtime.ts";
 import type { TokenSet } from "./oidc.ts";
 
 const ACCOUNT = "ava-helper";
@@ -97,4 +100,51 @@ export class InMemoryTokenStore implements TokenStore {
     this.tokens = null;
     return Promise.resolve();
   }
+}
+
+/**
+ * Fil-backad token-store (headless/Linux). macOS-keychain finns inte på Linux,
+ * och en GUI-keychain passar ändå inte en headless-körning (CI, server-helper,
+ * #742). Tokens läggs då i en fil (0600) i data-katalogen. Känsligt men det är
+ * priset för headless utan keychain — på macOS föredras alltid keychain.
+ */
+export class FileTokenStore implements TokenStore {
+  constructor(private readonly path: string) {}
+  load(): Promise<TokenSet | null> {
+    try {
+      return Promise.resolve(parseStored(readFileSync(this.path, "utf8")));
+    } catch {
+      return Promise.resolve(null); // saknad/oläsbar fil → ej parad
+    }
+  }
+  save(tokens: TokenSet): Promise<void> {
+    mkdirSync(dirname(this.path), { recursive: true });
+    writeFileSync(this.path, JSON.stringify(tokens), { mode: 0o600 });
+    return Promise.resolve();
+  }
+  clear(): Promise<void> {
+    try { rmSync(this.path); } catch { /* redan borta */ }
+    return Promise.resolve();
+  }
+}
+
+/** Filnamn för fil-storen i data-katalogen. */
+export const TOKEN_FILE_NAME = "oidc-token.json";
+
+/**
+ * Välj token-store: explicit fil via `AVA_HELPER_TOKEN_FILE` (headless/test),
+ * annars keychain på macOS, annars en fil i data-katalogen (Linux/headless —
+ * keychain saknas). Utan data-katalog (`dir === null`) faller vi tillbaka på
+ * in-memory (ingen persistens, men auth fungerar inom processens livstid).
+ * Ren funktion (platform + dir + env in) → testbar utan riktig fs/keychain.
+ */
+export function selectTokenStore(
+  platform: Platform,
+  dir: string | null,
+  env: { tokenFile?: string | undefined } = {},
+): TokenStore {
+  if (env.tokenFile) return new FileTokenStore(env.tokenFile);
+  if (platform === "darwin") return new KeychainTokenStore();
+  if (dir !== null) return new FileTokenStore(join(dir, TOKEN_FILE_NAME));
+  return new InMemoryTokenStore();
 }

--- a/helper-ui/src/engine/main.ts
+++ b/helper-ui/src/engine/main.ts
@@ -23,7 +23,8 @@ import { HELPER_HTTPS_PORT, HELPER_PORT } from "@/lib/shared/helper/protocol";
 import { serveFetchHandler } from "@/lib/shared/http/node-http-adapter";
 
 import { buildAuthHeaderProvider } from "./auth/auth-provider.ts";
-import { loginConfigFromEnv, runLogin, type LoginConfig } from "./auth/login.ts";
+import { defaultLoginDeps, loginConfigFromEnv, runLogin, type LoginConfig } from "./auth/login.ts";
+import { selectTokenStore } from "./auth/token-store.ts";
 import { handleConfig } from "./config-endpoint.ts";
 import { ContentStore, resolveCacheTtlMs } from "./content-store.ts";
 import { fetchAndCacheContent, handleContent } from "./content.ts";
@@ -267,7 +268,8 @@ export function startEngine(opts: EngineOpts = {}): EngineHandle {
 
   // Helperns egen OIDC-auth (om parad/konfigurerad) → autonom Bearer mot servern.
   const loginCfg = loginConfigFromEnv(helperEnvFor(dir));
-  const authHeader: AuthHeaderProvider | undefined = loginCfg ? buildAuthHeaderProvider(loginCfg) : undefined;
+  const tokenStore = selectTokenStore(currentPlatform(), dir, { tokenFile: process.env.AVA_HELPER_TOKEN_FILE });
+  const authHeader: AuthHeaderProvider | undefined = loginCfg ? buildAuthHeaderProvider(loginCfg, tokenStore) : undefined;
 
   const stores = startStores(dir, abort.signal, authHeader);
   const handler = createHandler({
@@ -336,7 +338,10 @@ async function handleLogin(): Promise<void> {
     return;
   }
   try {
-    await runLogin(cfg);
+    // Samma store-val som motorn (main vs login måste vara överens om var
+    // tokens bor — keychain på macOS, annars fil/headless).
+    const store = selectTokenStore(currentPlatform(), dataDir(), { tokenFile: process.env.AVA_HELPER_TOKEN_FILE });
+    await runLogin(cfg, { ...defaultLoginDeps(), store });
     process.stdout.write("Inloggning klar — helpern är parad.\n");
   } catch (err) {
     process.stderr.write(`Inloggning misslyckades: ${err instanceof Error ? err.message : String(err)}\n`);

--- a/helper-ui/test/auth.test.ts
+++ b/helper-ui/test/auth.test.ts
@@ -5,6 +5,9 @@
  */
 
 import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
 import {
@@ -19,11 +22,14 @@ import { generatePkce, randomState } from "../src/engine/auth/pkce.ts";
 import { TokenManager } from "../src/engine/auth/token-manager.ts";
 import {
   clearArgs,
+  FileTokenStore,
   InMemoryTokenStore,
   KeychainTokenStore,
   loadArgs,
   parseStored,
   saveArgs,
+  selectTokenStore,
+  TOKEN_FILE_NAME,
   type CaptureRunner,
 } from "../src/engine/auth/token-store.ts";
 
@@ -225,5 +231,62 @@ describe("TokenManager", () => {
     await store.save({ accessToken: "AT", refreshToken: "RT", expiresAt: Date.now() + 3_600_000 });
     const m = new TokenManager(store, EP, "ava"); // inga deps → default now/refresh
     expect(await m.getAccessToken()).toBe("AT");
+  });
+});
+
+describe("FileTokenStore (headless/Linux, #742)", () => {
+  test("save → load round-trip (skapar saknad katalog)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ava-token-"));
+    try {
+      const path = join(dir, "nested", TOKEN_FILE_NAME);
+      const store = new FileTokenStore(path);
+      expect(await store.load()).toBeNull(); // saknad fil → ej parad
+      await store.save({ accessToken: "AT", refreshToken: "RT", expiresAt: 123 });
+      expect(JSON.parse(readFileSync(path, "utf8"))).toMatchObject({ accessToken: "AT", expiresAt: 123 });
+      expect(await store.load()).toMatchObject({ accessToken: "AT", refreshToken: "RT", expiresAt: 123 });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("clear tar bort filen (idempotent)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ava-token-"));
+    try {
+      const store = new FileTokenStore(join(dir, TOKEN_FILE_NAME));
+      await store.save({ accessToken: "AT", expiresAt: 1 });
+      await store.clear();
+      expect(await store.load()).toBeNull();
+      await store.clear(); // redan borta → kastar inte
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("trasig fil → null (ej parad)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ava-token-"));
+    try {
+      const path = join(dir, TOKEN_FILE_NAME);
+      const store = new FileTokenStore(path);
+      await store.save({ accessToken: "AT", expiresAt: 1 });
+      rmSync(path);
+      await Bun.write(path, "{ inte json"); // skriv skräp
+      expect(await store.load()).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("selectTokenStore", () => {
+  test("explicit AVA_HELPER_TOKEN_FILE → FileTokenStore (alla plattformar)", () => {
+    expect(selectTokenStore("darwin", "/data", { tokenFile: "/t.json" })).toBeInstanceOf(FileTokenStore);
+    expect(selectTokenStore("linux", null, { tokenFile: "/t.json" })).toBeInstanceOf(FileTokenStore);
+  });
+  test("macOS utan override → keychain", () => {
+    expect(selectTokenStore("darwin", "/data")).toBeInstanceOf(KeychainTokenStore);
+  });
+  test("Linux med data-katalog → fil; utan → in-memory", () => {
+    expect(selectTokenStore("linux", "/data")).toBeInstanceOf(FileTokenStore);
+    expect(selectTokenStore("linux", null)).toBeInstanceOf(InMemoryTokenStore);
   });
 });

--- a/src/lib/client/helper/use-helper.ts
+++ b/src/lib/client/helper/use-helper.ts
@@ -37,6 +37,28 @@ export type { HelperStatus, HelperStatusResponse };
 const PROBE_ORDER = [HELPER_HTTPS_BASE, HELPER_BASE] as const;
 let cachedBase: string | undefined;
 
+/** localStorage-nyckel för per-flik helper-bas-override (se `probeBases`). */
+export const HELPER_BASE_OVERRIDE_KEY = "ava.helperBase";
+
+/**
+ * Probe-ordning. En per-flik-override (localStorage `ava.helperBase`, t.ex.
+ * `http://127.0.0.1:48771`) låter flera flikar/sessioner peka på VAR SIN
+ * helper-instans. Utan den probar alla flikar den hårdkodade default-porten →
+ * samma helper = samma identitet, vilket gör t.ex. ett 2-användares konflikt-
+ * e2e omöjligt (#742). Saknas override: HTTPS först (Safari), sedan HTTP.
+ */
+function probeBases(): readonly string[] {
+  try {
+    if (typeof localStorage !== "undefined") {
+      const override = localStorage.getItem(HELPER_BASE_OVERRIDE_KEY);
+      if (override) return [override];
+    }
+  } catch {
+    // localStorage kan kasta i sandbox/privacy-läge — falla tillbaka på default.
+  }
+  return PROBE_ORDER;
+}
+
 /**
  * Skydd mot probe-storm (#653): en MISS cachas inte (helpern kan startas
  * senare), men utan broms kan en anropare i en render-loop fyra av tusentals
@@ -67,7 +89,7 @@ async function probeHelper(now: () => number = Date.now): Promise<{ base: string
   if (inFlight) return inFlight; // dedup: dela pågående probe
   if (cachedBase === undefined && now() - lastMissAt < MISS_TTL_MS) return null; // negativ-cache
   inFlight = (async () => {
-    const bases = cachedBase !== undefined ? [cachedBase] : PROBE_ORDER;
+    const bases = cachedBase !== undefined ? [cachedBase] : probeBases();
     for (const base of bases) {
       const text = await pingText(base);
       if (text !== null) {

--- a/test/unit/lib/helper/use-helper.test.tsx
+++ b/test/unit/lib/helper/use-helper.test.tsx
@@ -18,6 +18,7 @@ import {
   syncBadgeMap,
   emptySyncTracker,
   SYNCED_TTL_MS,
+  HELPER_BASE_OVERRIDE_KEY,
 } from "@/lib/client/helper/use-helper";
 import type { HelperStatusResponse, HelperSyncEntry } from "@/lib/shared/helper/protocol";
 
@@ -29,6 +30,7 @@ beforeEach(() => {
   vi.restoreAllMocks();
   global.fetch = originalFetch;
   resetHelperBaseCache();
+  localStorage.removeItem(HELPER_BASE_OVERRIDE_KEY);
 });
 
 /** fetch-mock som svarar per URL-fragment; okända URL:er rejectar. */
@@ -75,6 +77,17 @@ describe("useHelper / transport", () => {
     global.fetch = routeFetch([[`${HTTPS}/ping`, () => new Response("garbage", { status: 200 })]]);
     render(<Probe />);
     await waitFor(() => expect(screen.getByText("absent")).toBeInTheDocument());
+  });
+
+  it("per-flik-override (localStorage) pekar på en egen helper-bas (#742)", async () => {
+    const OTHER = "http://127.0.0.1:48771";
+    localStorage.setItem(HELPER_BASE_OVERRIDE_KEY, OTHER);
+    const fetchMock = routeFetch([[`${OTHER}/ping`, () => new Response("ava-helper v9\n", { status: 200 })]]);
+    global.fetch = fetchMock;
+    render(<Probe />);
+    await waitFor(() => expect(screen.getByText("v9")).toBeInTheDocument());
+    // Default-portarna (48761/48762) ska ALDRIG probas när en override finns.
+    expect(fetchMock.mock.calls.every(([u]: [string]) => String(u).startsWith(OTHER))).toBe(true);
   });
 
   it("negativ-cachar en miss → ingen probe-storm (#653)", async () => {


### PR DESCRIPTION
Steg 2 av #742 (UI-drivet konflikt-e2e), men fixar en reell produkt-lucka på vägen.

## Problem
Helperns OIDC-auth lagrade tokens **enbart** i macOS-keychain (`security`-CLI). På Linux/headless (CI, server-helper) fanns alltså **ingen** fungerande token-store — `buildAuthHeaderProvider` fick aldrig en Bearer och helpern kunde inte autentisera mot servern. Helpern påstås kunna köra headless (ADR 0029/0030), men kunde i praktiken inte logga in på Linux.

## Lösning
- `FileTokenStore` — token-JSON i data-katalogen (mode `0600`), återanvänder `parseStored`.
- `selectTokenStore(platform, dir, env)` (ren funktion): explicit `AVA_HELPER_TOKEN_FILE` → fil (headless/test); macOS → keychain; Linux med data-dir → fil; annars in-memory.
- Både motorn (`startEngine`) och `--login` (`handleLogin`) använder samma val → överens om var tokens bor.

## Varför det behövs för #742
Det headless 2-användar-konflikt-e2e:t kör två helper-instanser som två olika Keycloak-användare i CI (Linux). Utan en seedbar fil-store går det inte att ge varje helper sin identitet utan interaktiv browser-PKCE.

## Test
`FileTokenStore` round-trip / clear / trasig-fil, + `selectTokenStore`-matris (env/macOS/Linux/ingen-dir). 31/31 i auth-sviten, helper- + root-typecheck + lint gröna.

Refs #742

🤖 Generated with [Claude Code](https://claude.com/claude-code)