### PR TITLE
fix(matter): visa domstolsbetalnings-panelen bara i domstolsärenden

### DIFF
--- a/src/app/matters/[id]/_client.tsx
+++ b/src/app/matters/[id]/_client.tsx
@@ -25,6 +25,15 @@ function courtCaseOf(m: unknown): string {
   return (m as { courtCaseNumber?: string | null }).courtCaseNumber ?? "";
 }
 
+/**
+ * Domstolsärende = domstolen betalar dig utan AVA-faktura (offentlig försvarare
+ * eller taxeärende). Styr om Domstolsbetalnings-panelen visas — i andra ärenden
+ * är den bara förvirrande.
+ */
+function isCourtMatter(m: { paymentMethod?: string | null; isTaxeArende?: boolean | null }): boolean {
+  return m.paymentMethod === "OFFENTLIG_FORSVARARE" || m.isTaxeArende === true;
+}
+
 export default function MatterDetailClient({ id: paramId }: { id: string }) {
   // Static export serverar en sentinel-shell för nya id:n → läs riktiga
   // id:t ur URL:en (faller tillbaka till build-time-param i server-mode).
@@ -68,7 +77,7 @@ export default function MatterDetailClient({ id: paramId }: { id: string }) {
         <ContactsSection matterId={id} contacts={m.contacts} />
         <DocumentBrowser matterId={id} />
         <BillingPanel matterId={id} matter={m} />
-        <ExpectedReceivablesSection matterId={id} courtCaseNumber={courtCaseOf(m)} />
+        <ExpectedReceivablesSection matterId={id} courtCaseNumber={courtCaseOf(m)} isCourtMatter={isCourtMatter(m)} />
         <TimeSection matterId={id} isTaxeArende={m.isTaxeArende} />
         <ExpenseSection matterId={id} isTaxeArende={m.isTaxeArende} />
         <ServiceNotesSection matterId={id} />

--- a/src/app/matters/[id]/_expected-receivables-section.tsx
+++ b/src/app/matters/[id]/_expected-receivables-section.tsx
@@ -115,11 +115,19 @@ function ReceivableRow({ r, onChanged }: { r: Receivable; onChanged: () => void 
   );
 }
 
-export function ExpectedReceivablesSection({ matterId, courtCaseNumber }: { matterId: string; courtCaseNumber: string }) {
+/**
+ * Panelen är bara relevant i ärenden där DOMSTOLEN betalar dig utan AVA-faktura
+ * (förordnat: offentlig försvarare / taxeärende). I andra ärenden — privat
+ * betalning, rättsskydd, vanlig tvist mot privat klient — betalar inte domstolen
+ * dig, så panelen är bara förvirrande och döljs. Säkerhetsnät: redan registrerade
+ * fordringar visas alltid (annars går de inte att se/pricka av/avbryta).
+ */
+export function ExpectedReceivablesSection({ matterId, courtCaseNumber, isCourtMatter }: { matterId: string; courtCaseNumber: string; isCourtMatter: boolean }) {
   const list = trpc.expectedReceivable.list.useQuery({ matterId });
   const utils = trpc.useUtils();
   const refetch = () => void utils.expectedReceivable.list.invalidate({ matterId });
   const rows = (list.data ?? []) as Receivable[];
+  if (!isCourtMatter && rows.length === 0) return null;
   return (
     <div className="bg-white rounded-lg border border-gray-200 p-6">
       <h2 className="font-semibold text-gray-900 mb-1">Domstolsbetalningar (utan faktura)</h2>

--- a/test/unit/app/matters/expected-receivables-section.test.tsx
+++ b/test/unit/app/matters/expected-receivables-section.test.tsx
@@ -35,12 +35,25 @@ beforeEach(() => { vi.clearAllMocks(); listQuery.data = []; });
 
 describe("ExpectedReceivablesSection", () => {
   it("tomtillstånd när inga fordringar finns", () => {
-    render(<ExpectedReceivablesSection matterId="m1" courtCaseNumber="" />);
+    render(<ExpectedReceivablesSection matterId="m1" courtCaseNumber="" isCourtMatter />);
     expect(screen.getByText(/Inga registrerade ännu/)).toBeInTheDocument();
   });
 
+  it("icke-domstolsärende utan fordringar → döljs helt (ej förvirrande)", () => {
+    const { container } = render(<ExpectedReceivablesSection matterId="m1" courtCaseNumber="" isCourtMatter={false} />);
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText(/Domstolsbetalningar/)).not.toBeInTheDocument();
+  });
+
+  it("icke-domstolsärende MEN med registrerad fordran → visas ändå (strandar inte data)", () => {
+    listQuery.data = [{ id: "er-1", description: "Mål B 1-26", expectedAmount: 200_000, status: "PENDING" }];
+    render(<ExpectedReceivablesSection matterId="m1" courtCaseNumber="" isCourtMatter={false} />);
+    expect(screen.getByText(/Domstolsbetalningar/)).toBeInTheDocument();
+    expect(screen.getByText("Mål B 1-26")).toBeInTheDocument();
+  });
+
   it("målnummer: Spara disabled när oförändrat, enabled + sparar efter ändring", () => {
-    render(<ExpectedReceivablesSection matterId="m1" courtCaseNumber="B 1-26" />);
+    render(<ExpectedReceivablesSection matterId="m1" courtCaseNumber="B 1-26" isCourtMatter />);
     const save = screen.getByRole("button", { name: "Spara målnummer" }) as HTMLButtonElement;
     expect(save.disabled).toBe(true);
     fireEvent.change(screen.getByLabelText("Domstolens målnummer"), { target: { value: "B 9-26" } });
@@ -50,7 +63,7 @@ describe("ExpectedReceivablesSection", () => {
   });
 
   it("registrera fordran skickar description + belopp i öre", () => {
-    render(<ExpectedReceivablesSection matterId="m1" courtCaseNumber="" />);
+    render(<ExpectedReceivablesSection matterId="m1" courtCaseNumber="" isCourtMatter />);
     fireEvent.change(screen.getByPlaceholderText(/Kostnadsräkning/), { target: { value: "Svea HovR" } });
     fireEvent.change(screen.getByPlaceholderText(/Begärt belopp/), { target: { value: "1500" } });
     fireEvent.click(screen.getByRole("button", { name: "Lägg till fordran" }));
@@ -59,7 +72,7 @@ describe("ExpectedReceivablesSection", () => {
 
   it("PENDING-rad: markera mottagen bokar utbetalt belopp, avbryt avbryter", () => {
     listQuery.data = [{ id: "er-1", description: "Mål B 1-26", expectedAmount: 200_000, status: "PENDING" }];
-    render(<ExpectedReceivablesSection matterId="m1" courtCaseNumber="" />);
+    render(<ExpectedReceivablesSection matterId="m1" courtCaseNumber="" isCourtMatter />);
     fireEvent.change(screen.getByPlaceholderText("Utbetalt (kr)"), { target: { value: "1800" } });
     fireEvent.click(screen.getByRole("button", { name: "Markera mottagen" }));
     expect(settleMutate).toHaveBeenCalledWith({ id: "er-1", settledAmount: 180_000 });
@@ -69,7 +82,7 @@ describe("ExpectedReceivablesSection", () => {
 
   it("SETTLED-rad visar mottaget belopp och ingen avprickning", () => {
     listQuery.data = [{ id: "er-2", description: "Mål B 2-26", expectedAmount: 200_000, status: "SETTLED", settledAmount: 190_000 }];
-    render(<ExpectedReceivablesSection matterId="m1" courtCaseNumber="" />);
+    render(<ExpectedReceivablesSection matterId="m1" courtCaseNumber="" isCourtMatter />);
     expect(screen.getByText(/Mottaget:/)).toBeInTheDocument();
     expect(screen.getByText("Mottagen")).toBeInTheDocument(); // status-label
     expect(screen.queryByRole("button", { name: "Markera mottagen" })).not.toBeInTheDocument();


### PR DESCRIPTION
## Problem
Panelen **"Domstolsbetalningar (utan faktura)"** visades i *alla* ärenden. Den är bara relevant där domstolen/Domstolsverket betalar dig utan AVA-faktura. I privata ärenden, rättsskydd och vanlig tvist mot privat klient betalar inte domstolen dig → panelen var bara förvirrande.

## Fix
Visa panelen bara i **domstolsärenden** = `paymentMethod === "OFFENTLIG_FORSVARARE"` eller `isTaxeArende` (de fall där domstolen faktiskt betalar ersättning utan faktura). En vanlig tvist har visserligen en DOMSTOL-kontakt men domstolen betalar inte dig där — därför gatar vi på betalningssätt, inte på att en domstol är part.

**Säkerhetsnät:** redan registrerade fordringar visas alltid, även i icke-domstolsärenden (annars skulle befintlig data inte gå att se/pricka av/avbryta).

## Test
- icke-domstolsärende utan fordringar → panelen döljs helt
- icke-domstolsärende *med* fordran → visas ändå (strandar inte data)
- befintliga funktions-tester körs nu med `isCourtMatter`

Closes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)