### PR TITLE
refactor(matter): byt OFFENTLIG_FORSVARARE→OFFENTLIGT_UPPDRAG + strikta paymentMethod-typer

### DIFF
--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -21,7 +21,7 @@ import { formatCurrency } from "@/lib/client/utils";
 import type { AppRouter } from "@/lib/server/routers/_app";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { computeRadgivningsavgift } from "@/lib/shared/rattshjalp";
-import { BILLING_RUN_TYPE_LABELS, BILLING_RUN_STATUS_LABELS } from "@/lib/shared/schemas/enums";
+import { BILLING_RUN_TYPE_LABELS, BILLING_RUN_STATUS_LABELS, type PaymentMethod } from "@/lib/shared/schemas/enums";
 import { BillingDialog, type BillingMeta } from "./_billing-dialog";
 import { KostnadsrakningModal } from "./_kostnadsrakning-modal";
 import { VerdictDialog } from "./_verdict-dialog";
@@ -33,7 +33,7 @@ interface MatterContext {
   taxaHasFTax?: boolean | null | undefined;
   taxaHufStart?: string | Date | null | undefined;
   isTaxeArende?: boolean | null | undefined;
-  paymentMethod?: string | null | undefined;
+  paymentMethod?: PaymentMethod | null | undefined;
   radgivningBetaldAt?: string | Date | null | undefined;
   contacts?: ReadonlyArray<{ role: string; contact?: { name?: string | null | undefined; email?: string | null | undefined } | null | undefined }> | undefined;
 }
@@ -258,7 +258,7 @@ export function BillingPanel({ matterId, matter }: Props) {
     <div className="bg-white rounded-lg border border-gray-200 lg:col-span-2">
       <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
         <h2 className="font-semibold text-gray-900">Fakturering</h2>
-        <BillingActions paymentMethod={matter.paymentMethod ?? ""} onPick={onPick} />
+        <BillingActions paymentMethod={matter.paymentMethod ?? undefined} onPick={onPick} />
       </div>
       <SummaryCards totals={computeTotals(rows)} />
       <UnbilledSummary matterId={matterId} />
@@ -365,7 +365,7 @@ function Card({ label, value, dim }: { label: string; value: number; dim?: boole
   );
 }
 
-function BillingActions({ paymentMethod, onPick }: { paymentMethod: string; onPick: (t: ActionPick) => void }) {
+function BillingActions({ paymentMethod, onPick }: { paymentMethod: PaymentMethod | undefined; onPick: (t: ActionPick) => void }) {
   const [open, setOpen] = useState(false);
   const options = optionsFor(paymentMethod);
   return (
@@ -391,14 +391,14 @@ function BillingActions({ paymentMethod, onPick }: { paymentMethod: string; onPi
   );
 }
 
-function optionsFor(pm: string): Array<{ type: ActionPick; label: string }> {
+function optionsFor(pm: PaymentMethod | undefined): Array<{ type: ActionPick; label: string }> {
   if (pm === "RATTSSKYDD" || pm === "RATTSHJALP") {
     return [
       { type: "ACCONTO", label: "Aconto till klient" },
       { type: "FINAL", label: pm === "RATTSSKYDD" ? "Faktura till försäkring" : "Faktura till myndighet" },
     ];
   }
-  if (pm === "OFFENTLIG_FORSVARARE") {
+  if (pm === "OFFENTLIGT_UPPDRAG") {
     return [{ type: "KOSTNADSRAKNING", label: "Kostnadsräkning till domstol" }];
   }
   return [{ type: "FINAL", label: "Faktura till klient" }];

--- a/src/app/matters/[id]/_client.tsx
+++ b/src/app/matters/[id]/_client.tsx
@@ -11,6 +11,7 @@ import { EntityLink } from "@/lib/client/demo/entity-link";
 import { useRouteId } from "@/lib/client/demo/use-route-id";
 import { useEagerCacheMatterDocuments } from "@/lib/client/firma/use-eager-cache-matter-documents";
 import { trpc } from "@/lib/client/trpc";
+import type { PaymentMethod } from "@/lib/shared/schemas/enums";
 import { BillingPanel } from "./_billing-panel";
 import { ContactsSection } from "./_contacts-section";
 import { ExpectedReceivablesSection } from "./_expected-receivables-section";
@@ -26,12 +27,12 @@ function courtCaseOf(m: unknown): string {
 }
 
 /**
- * Domstolsärende = domstolen betalar dig utan AVA-faktura (offentlig försvarare
+ * Domstolsärende = domstolen betalar dig utan AVA-faktura (offentligt uppdrag
  * eller taxeärende). Styr om Domstolsbetalnings-panelen visas — i andra ärenden
  * är den bara förvirrande.
  */
-function isCourtMatter(m: { paymentMethod?: string | null; isTaxeArende?: boolean | null }): boolean {
-  return m.paymentMethod === "OFFENTLIG_FORSVARARE" || m.isTaxeArende === true;
+function isCourtMatter(m: { paymentMethod?: PaymentMethod | null; isTaxeArende?: boolean | null }): boolean {
+  return m.paymentMethod === "OFFENTLIGT_UPPDRAG" || m.isTaxeArende === true;
 }
 
 export default function MatterDetailClient({ id: paramId }: { id: string }) {

--- a/src/components/matter/payment-method-card.tsx
+++ b/src/components/matter/payment-method-card.tsx
@@ -17,6 +17,7 @@ import {
   type CreditRisk,
 } from "@/lib/client/labels";
 import { trpc } from "@/lib/client/trpc";
+import { paymentMethodSchema, type PaymentMethod } from "@/lib/shared/schemas/enums";
 
 const RISK_BADGE: Record<CreditRisk, string> = {
   LOW: "bg-green-50 text-green-700 border-green-200",
@@ -27,7 +28,7 @@ const RISK_BADGE: Record<CreditRisk, string> = {
 
 interface Props {
   matterId: string;
-  paymentMethod: string;
+  paymentMethod: PaymentMethod;
   paymentMethodNote: string | null;
   paymentMethodDecidedAt: Date | string | null;
 }
@@ -39,7 +40,7 @@ function PaymentMethodView({
   paymentMethodDecidedAt,
   onEdit,
 }: {
-  paymentMethod: string;
+  paymentMethod: PaymentMethod;
   paymentMethodNote: string | null;
   paymentMethodDecidedAt: Date | string | null;
   onEdit: () => void;
@@ -103,7 +104,7 @@ function PaymentMethodEditor({ matterId, initial, onDone }: { matterId: string; 
           <select
             id={methodId}
             value={method}
-            onChange={(e) => setMethod(e.target.value)}
+            onChange={(e) => setMethod(paymentMethodSchema.parse(e.target.value))}
             className="w-full border border-gray-300 rounded px-2 py-1.5 text-sm"
           >
             {paymentMethodOptions.map((opt) => (

--- a/src/lib/client/labels.ts
+++ b/src/lib/client/labels.ts
@@ -113,7 +113,7 @@ export type CreditRisk = "LOW" | "MEDIUM" | "HIGH" | "UNKNOWN";
 export function creditRiskFor(method: string): CreditRisk {
   switch (method) {
     case "RATTSHJALP":
-    case "OFFENTLIG_FORSVARARE":
+    case "OFFENTLIGT_UPPDRAG":
     case "RATTSSKYDD":
       return "LOW";       // staten eller försäkringsbolag betalar
     case "MIX":

--- a/src/lib/server/routers/matter.ts
+++ b/src/lib/server/routers/matter.ts
@@ -219,9 +219,7 @@ export const matterRouter = router({
         responsibleLawyerId: userIdSchema.nullable().optional(),
         /** Domstolens målnummer (#173) — för avprickning av domstolsbetalningar. */
         courtCaseNumber: z.string().nullable().optional(),
-        paymentMethod: z
-          .enum(["PENDING", "RATTSHJALP", "RATTSSKYDD", "OFFENTLIG_FORSVARARE", "PRIVAT", "MIX"])
-          .optional(),
+        paymentMethod: paymentMethodSchema.optional(),
         paymentMethodNote: z.string().nullable().optional(),
         paymentMethodDecidedAt: z.string().nullable().optional(),
         isTaxeArende: z.boolean().optional(),

--- a/src/lib/shared/schemas/enums.ts
+++ b/src/lib/shared/schemas/enums.ts
@@ -40,7 +40,7 @@ export const PAYMENT_METHOD_LABELS = {
   PENDING: "Ej fastställt",
   RATTSHJALP: "Rättshjälp",
   RATTSSKYDD: "Rättsskydd",
-  OFFENTLIG_FORSVARARE: "Offentlig försvarare",
+  OFFENTLIGT_UPPDRAG: "Offentligt uppdrag",
   PRIVAT: "Privat betalning",
   MIX: "Kombinerad",
 } as const satisfies Record<string, string>;

--- a/test/integration/seed-smoke.test.ts
+++ b/test/integration/seed-smoke.test.ts
@@ -108,10 +108,10 @@ describe("Seed-data smoke — varje meny-sida körs mot riktig DemoDataStore", (
     const list = await trpc.matter.list({ page: 1, pageSize: 50 });
     const taxa = list.matters.filter((m: { isTaxeArende?: boolean }) => m.isTaxeArende === true);
     expect(taxa.length).toBeGreaterThan(0);
-    // Och minst ETT brottmål med offentlig försvarare som INTE är taxa
+    // Och minst ETT brottmål med offentligt uppdrag som INTE är taxa
     // (frångångstaxa-fall — bekräftar att flaggan är ortogonal mot paymentMethod)
     const nonTaxaOff = list.matters.filter((m: { paymentMethod?: string; isTaxeArende?: boolean }) =>
-      m.paymentMethod === "OFFENTLIG_FORSVARARE" && m.isTaxeArende !== true,
+      m.paymentMethod === "OFFENTLIGT_UPPDRAG" && m.isTaxeArende !== true,
     );
     expect(nonTaxaOff.length).toBeGreaterThan(0);
   });

--- a/test/unit/app/matters/billing-panel.test.tsx
+++ b/test/unit/app/matters/billing-panel.test.tsx
@@ -187,8 +187,8 @@ describe("BillingPanel — pending verdict", () => {
 });
 
 describe("BillingPanel — Skapa-faktura-menyn (optionsFor)", () => {
-  it("KLIENT-default: bara 'Faktura till klient' → öppnar FINAL-dialogen", () => {
-    render(<BillingPanel matterId="m1" matter={{ ...baseMatter, paymentMethod: "KLIENT" }} />);
+  it("PRIVAT-default: bara 'Faktura till klient' → öppnar FINAL-dialogen", () => {
+    render(<BillingPanel matterId="m1" matter={{ ...baseMatter, paymentMethod: "PRIVAT" }} />);
     fireEvent.click(screen.getByRole("button", { name: "+ Skapa faktura" }));
     fireEvent.click(screen.getByRole("button", { name: "Faktura till klient" }));
     expect(screen.getByTestId("billing-dialog")).toHaveTextContent("FINAL");
@@ -201,8 +201,8 @@ describe("BillingPanel — Skapa-faktura-menyn (optionsFor)", () => {
     expect(screen.getByRole("button", { name: "Faktura till försäkring" })).toBeInTheDocument();
   });
 
-  it("OFFENTLIG_FORSVARARE: kostnadsräkning → öppnar KR-modalen", () => {
-    render(<BillingPanel matterId="m1" matter={{ ...baseMatter, paymentMethod: "OFFENTLIG_FORSVARARE" }} />);
+  it("OFFENTLIGT_UPPDRAG: kostnadsräkning → öppnar KR-modalen", () => {
+    render(<BillingPanel matterId="m1" matter={{ ...baseMatter, paymentMethod: "OFFENTLIGT_UPPDRAG" }} />);
     fireEvent.click(screen.getByRole("button", { name: "+ Skapa faktura" }));
     fireEvent.click(screen.getByRole("button", { name: "Kostnadsräkning till domstol" }));
     expect(screen.getByTestId("kr-modal")).toBeInTheDocument();
@@ -224,7 +224,7 @@ describe("BillingPanel — rådgivnings-banner (rättshjälp)", () => {
   });
 
   it("icke-rättshjälp → ingen rådgivnings-banner", () => {
-    render(<BillingPanel matterId="m1" matter={{ ...baseMatter, paymentMethod: "KLIENT" }} />);
+    render(<BillingPanel matterId="m1" matter={{ ...baseMatter, paymentMethod: "PRIVAT" }} />);
     expect(screen.queryByText(/Rådgivningstimme/)).not.toBeInTheDocument();
   });
 });

--- a/tooling/demo-generator/populate-billing.ts
+++ b/tooling/demo-generator/populate-billing.ts
@@ -10,7 +10,7 @@
  *                           aktiv/slutförd/avbruten plan, kredit, avskrivning, draft)
  *   RATTSSKYDD            → klient-aconto + slutfaktura till FÖRSÄKRING (betald)
  *   RATTSHJALP            → klient-aconto + slutfaktura till RÄTTSHJÄLPSMYNDIGHET (betald)
- *   OFFENTLIG_FORSVARARE  → kostnadsräkning till domstol (varannan dömd m. prutning)
+ *   OFFENTLIGT_UPPDRAG    → kostnadsräkning till domstol (varannan dömd m. prutning)
  *   (taxe-ärenden hoppas över — egen brottmålstaxa-väg)
  *
  * Belopp/fakturanummer/OCR genereras organiskt av billing-run-routern (ADR 0012).
@@ -213,7 +213,7 @@ export async function populateBilling(caller: GeneratorCaller, seed: SeedDataset
   for (const m of active) {
     const pm = String(m.paymentMethod);
     const matterId = String(m.id);
-    if (pm === "OFFENTLIG_FORSVARARE") {
+    if (pm === "OFFENTLIGT_UPPDRAG") {
       if (m.isTaxeArende === true) continue; // taxe-ärenden: egen brottmålstaxa-väg
       await runKostnadsrakning(ctx, matterId, krIdx % 2 === 0); // kostnadsräkning byggs på arbetet (0 ok)
       krIdx++;

--- a/tooling/scripts/seed-data.ts
+++ b/tooling/scripts/seed-data.ts
@@ -99,7 +99,7 @@ export const CONTACTS: ContactSeed[] = [
 interface MatterSeed {
   id: string; matterNumber: string; title: string;
   status: "ACTIVE" | "CLOSED" | "ARCHIVED"; matterType: string;
-  paymentMethod: "PENDING" | "RATTSHJALP" | "RATTSSKYDD" | "OFFENTLIG_FORSVARARE" | "PRIVAT" | "MIX";
+  paymentMethod: "PENDING" | "RATTSHJALP" | "RATTSSKYDD" | "OFFENTLIGT_UPPDRAG" | "PRIVAT" | "MIX";
   description: string;
   klientId: string; motpartId?: string; domstolId?: string;
   createdDaysAgo: number;
@@ -128,9 +128,9 @@ export const MATTERS: MatterSeed[] = [
   { id: "m-015-immaterialratt", matterNumber: "2026-0015", title: "Varumärkesintrång Stenhammar", status: "ACTIVE", matterType: "Immaterialrätt", paymentMethod: "PRIVAT", description: "Påstått varumärkesintrång på \"Stenhammar\".", klientId: "c-byggfirma", createdDaysAgo: 22 },
   // Brottmål — offentlig försvarare. Brottmålstaxan tillämpas som default;
   // domstolen kan frångå taxan ifall avsevärt mer arbete krävts.
-  { id: "m-016-brottmal-rh", matterNumber: "2026-0016", title: "Brottmål — rattfylleri Falk", status: "ACTIVE", matterType: "Brottmål", paymentMethod: "OFFENTLIG_FORSVARARE", description: "Förordnad offentlig försvarare vid Stockholms tingsrätt.", klientId: "c-falk", domstolId: "c-tingsratten-sthlm", createdDaysAgo: 18, isTaxeArende: true, taxaLevel: 1, taxaHuvudforhandlingMin: 95, taxaHasFTax: true },
-  { id: "m-017-brottmal-omf", matterNumber: "2026-0017", title: "Brottmål — omfattande utredning Davidsson", status: "ACTIVE", matterType: "Brottmål", paymentMethod: "OFFENTLIG_FORSVARARE", description: "Frångångstaxa pga väsentligt mer arbete (komplex bevisning).", klientId: "c-davidsson", domstolId: "c-hovratten-svea", createdDaysAgo: 35, isTaxeArende: false },
-  { id: "m-018-brottmal-ekobrott", matterNumber: "2026-0018", title: "Brottmål — ekobrott Carlsson", status: "ACTIVE", matterType: "Brottmål", paymentMethod: "OFFENTLIG_FORSVARARE", description: "Misstanke om grovt bokföringsbrott. Omfattande material — kostnadsräkning skickas till domstol istället för enligt taxa.", klientId: "c-carlsson", domstolId: "c-tingsratten-sthlm", createdDaysAgo: 28, isTaxeArende: false },
+  { id: "m-016-brottmal-rh", matterNumber: "2026-0016", title: "Brottmål — rattfylleri Falk", status: "ACTIVE", matterType: "Brottmål", paymentMethod: "OFFENTLIGT_UPPDRAG", description: "Förordnad offentlig försvarare vid Stockholms tingsrätt.", klientId: "c-falk", domstolId: "c-tingsratten-sthlm", createdDaysAgo: 18, isTaxeArende: true, taxaLevel: 1, taxaHuvudforhandlingMin: 95, taxaHasFTax: true },
+  { id: "m-017-brottmal-omf", matterNumber: "2026-0017", title: "Brottmål — omfattande utredning Davidsson", status: "ACTIVE", matterType: "Brottmål", paymentMethod: "OFFENTLIGT_UPPDRAG", description: "Frångångstaxa pga väsentligt mer arbete (komplex bevisning).", klientId: "c-davidsson", domstolId: "c-hovratten-svea", createdDaysAgo: 35, isTaxeArende: false },
+  { id: "m-018-brottmal-ekobrott", matterNumber: "2026-0018", title: "Brottmål — ekobrott Carlsson", status: "ACTIVE", matterType: "Brottmål", paymentMethod: "OFFENTLIGT_UPPDRAG", description: "Misstanke om grovt bokföringsbrott. Omfattande material — kostnadsräkning skickas till domstol istället för enligt taxa.", klientId: "c-carlsson", domstolId: "c-tingsratten-sthlm", createdDaysAgo: 28, isTaxeArende: false },
 ];
 
 // ASSIGN_USERS härleds inuti buildSeed() från de aktuella users — så ifall


### PR DESCRIPTION
## 1. Bättre namn
`OFFENTLIG_FORSVARARE` → **`OFFENTLIGT_UPPDRAG`** (label: "Offentligt uppdrag"). Offentligt uppdrag är bredare och mer korrekt — täcker offentlig försvarare, målsägandebiträde, offentligt biträde m.fl. där domstolen betalar ersättning. Värde + label + demo/seed bytt; inga statiska data-blobbar bär det gamla värdet (demon reseedas).

## 2. Strikta paymentMethod-typer
`paymentMethod` **är** redan en strikt zod-enum (`paymentMethodSchema` / `type PaymentMethod`) — looseheten låg i två ställen:
- **`matter.update`-routern** re-deklarerade en hårdkodad `z.enum(["PENDING", …])` i st.f. att återanvända `paymentMethodSchema` → driftrisk när enum:en ändras. Nu återanvänds schemat.
- **UI-props** typade `paymentMethod: string`. Nu `PaymentMethod`: `MatterContext`, `BillingActions`, `optionsFor`, `isCourtMatter`, `PaymentMethodCard`. Select-värdet parsas via `paymentMethodSchema.parse` (strikt boundary, ingen cast).

### Bonus: strikt typning fångade en latent bugg
Två tester satte `paymentMethod: "KLIENT"` — ogiltigt (KLIENT är en *recipient*, inte ett betalningssätt). De passerade bara för att värdet föll till default-grenen i `optionsFor` (= samma som PRIVAT). Rättat till `PRIVAT`. Exakt den sorts fel strikt typning ska fånga.

## Kvar (egen uppföljning)
Server-DTO-rader som kommer rått från DB utan zod-parse (`reports.ts`, `billing-run-/time-entry-repository`, invoice-klientens `as`-cast) är fortfarande `string`. Att smalna dem sunt kräver parsning vid DB-boundary → separat strikt-typnings-svep, inte en cast här.

Closes #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)