### PR TITLE
refactor(server): dedupa inline z.enum i routrar mot kanoniska scheman (A1)

### DIFF
--- a/src/lib/client/jobs/analyze-dispatch.ts
+++ b/src/lib/client/jobs/analyze-dispatch.ts
@@ -10,14 +10,16 @@
  * vid mount. Workern kallar `dispatchAnalyze()`.
  */
 
+import type { DocumentAnalysisStatus } from "@/lib/shared/schemas/document";
+
 export interface AnalyzeArgs {
   documentId: string;
   kind: string;
   /** ISO-timestamp när analysen körde. UI:n förlitar sig på detta
    *  för att stänga "⏳ analyseras..."-state:n. */
   analyzedAt?: string;
-  /** "DONE" | "FAILED" — sätts av workern. UI:n inspekterar fältet. */
-  analysisStatus?: string;
+  /** Sätts av workern (i praktiken "DONE"). UI:n inspekterar fältet. */
+  analysisStatus?: DocumentAnalysisStatus;
   signal?: AbortSignal;
 }
 

--- a/src/lib/server/routers/calendar.ts
+++ b/src/lib/server/routers/calendar.ts
@@ -13,7 +13,7 @@
  */
 
 import { z } from "zod";
-import { calendarEventKindSchema, calendarEventVisibilitySchema, type CalendarEvent } from "@/lib/shared/schemas";
+import { calendarEventKindSchema, calendarEventVisibilitySchema, calendarMirrorStatusSchema, type CalendarEvent } from "@/lib/shared/schemas";
 import {
   asId,
   calendarEventIdSchema,
@@ -210,7 +210,7 @@ export const calendarRouter = router({
       z.object({
         id: calendarEventIdSchema,
         outlookEventId: z.string().nullish(),
-        mirrorStatus: z.enum(["synced", "failed", "pending"]).nullable(),
+        mirrorStatus: calendarMirrorStatusSchema.nullable(),
         mirrorError: z.string().nullish(),
         mirrorLastSyncedAt: z.date().nullish(),
       }),

--- a/src/lib/server/routers/document/core.ts
+++ b/src/lib/server/routers/document/core.ts
@@ -9,7 +9,7 @@ import { conflictCopyName } from "@/lib/shared/conflict-copy";
 import { base64ToBytes, bytesToBase64, contentStoragePath, sha256Hex } from "@/lib/shared/content-address";
 import { isJunkFileName } from "@/lib/shared/junk-files";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
-import type { Document } from "@/lib/shared/schemas/document";
+import { documentAnalysisStatusSchema, type Document } from "@/lib/shared/schemas/document";
 import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { orgProcedure } from "../../trpc";
@@ -114,7 +114,7 @@ export const coreProcedures = {
       title: z.string().nullable().optional(),
       documentType: z.string().nullable().optional(),
       summary: z.string().nullable().optional(),
-      analysisStatus: z.enum(["PENDING", "RUNNING", "DONE", "ERROR"]).optional(),
+      analysisStatus: documentAnalysisStatusSchema.optional(),
       analyzedAt: z.string().optional(),
       createdAt: z.string().optional(),
       /** Koppla dokumentet till en faktura (t.ex. genererad faktura/underlag). */
@@ -287,7 +287,7 @@ export const coreProcedures = {
         documentType: z.string().nullable().optional(),
         summary: z.string().nullable().optional(),
         analyzedAt: z.union([z.string(), z.date()]).nullable().optional(),
-        analysisStatus: z.string().nullable().optional(),
+        analysisStatus: documentAnalysisStatusSchema.nullable().optional(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -296,10 +296,7 @@ export const coreProcedures = {
       const data = {
         ...rest,
         ...omitUndefined({
-          analysisStatus:
-            analysisStatus === undefined
-              ? undefined
-              : (analysisStatus as "PENDING" | "RUNNING" | "DONE" | "ERROR" | null),
+          analysisStatus,
           analyzedAt:
             analyzedAt === undefined
               ? undefined

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -21,7 +21,7 @@ import { ocrFromInvoiceNumber } from "@/lib/shared/ocr-reference";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { computeRadgivningsavgift } from "@/lib/shared/rattshjalp";
 import type { Invoice, Payment, PaymentPlan, WriteOff } from "@/lib/shared/schemas/billing";
-import type { InvoiceStatus } from "@/lib/shared/schemas/enums";
+import { invoiceStatusSchema, invoiceTypeSchema, type InvoiceStatus } from "@/lib/shared/schemas/enums";
 import {
   asId,
   matterIdSchema,
@@ -83,16 +83,6 @@ function resolveWriteOffAmount(outstanding: number, requested?: number): number 
   }
   return amount;
 }
-
-const invoiceTypeSchema = z.enum(["STANDARD", "ACCONTO", "FINAL"]);
-const invoiceStatusSchema = z.enum([
-  "DRAFT",
-  "SENT",
-  "PAID",
-  "CANCELLED",
-  "BAD_DEBT",
-  "INSTALLMENT_PLAN",
-]);
 
 export const invoiceRouter = router({
   list: orgProcedure
@@ -417,7 +407,7 @@ export const invoiceRouter = router({
     .input(
       z.object({
         invoiceId: invoiceIdSchema,
-        status: z.enum(["SENT", "CANCELLED", "BAD_DEBT"]),
+        status: invoiceStatusSchema.extract(["SENT", "CANCELLED", "BAD_DEBT"]),
       }),
     )
     .mutation(async ({ ctx, input }) => {

--- a/src/lib/server/routers/matter.ts
+++ b/src/lib/server/routers/matter.ts
@@ -161,7 +161,7 @@ export const matterRouter = router({
     .input(
       z.object({
         search: z.string().optional(),
-        status: z.enum(["ACTIVE", "CLOSED", "ARCHIVED"]).optional(),
+        status: matterStatusSchema.optional(),
         /** Filtrera till ärenden som medarbetaren har arbetat på (har tidsposter på). */
         employeeId: userIdSchema.optional(),
         page: z.number().min(1).default(1),
@@ -213,7 +213,7 @@ export const matterRouter = router({
         id: matterIdSchema,
         title: z.string().min(1).optional(),
         description: z.string().optional(),
-        status: z.enum(["ACTIVE", "CLOSED", "ARCHIVED"]).optional(),
+        status: matterStatusSchema.optional(),
         matterType: z.string().optional(),
         /** Byt ansvarig jurist (#174). Befintligt ärendenummer ändras EJ. */
         responsibleLawyerId: userIdSchema.nullable().optional(),

--- a/src/lib/server/routers/user.ts
+++ b/src/lib/server/routers/user.ts
@@ -1,5 +1,6 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import { userRoleSchema } from "@/lib/shared/schemas/enums";
 import { userIdSchema, asId } from "@/lib/shared/schemas/ids";
 import { matterNumberPrefixSchema, type User } from "@/lib/shared/schemas/user";
 import { router, protectedProcedure } from "../trpc";
@@ -96,7 +97,7 @@ export const userRouter = router({
       email: z.string().email(),
       name: z.string().min(1),
       title: z.string().optional(),
-      role: z.enum(["ADMIN", "LAWYER", "ASSISTANT"]).default("LAWYER"),
+      role: userRoleSchema.default("LAWYER"),
       hourlyRate: z.number().nullable().optional(),
       mileageRate: z.number().nullable().optional(),
       /** Ärendenummer-prefix (#174) — juristens egen serie. */
@@ -131,7 +132,7 @@ export const userRouter = router({
       email: z.string().email().optional(),
       name: z.string().min(1).optional(),
       title: z.string().nullable().optional(),
-      role: z.enum(["ADMIN", "LAWYER", "ASSISTANT"]).optional(),
+      role: userRoleSchema.optional(),
       hourlyRate: z.number().nullable().optional(),
       mileageRate: z.number().nullable().optional(),
       /** Ärendenummer-prefix (#174); null rensar den. Byte fortsätter serien. */

--- a/src/lib/shared/schemas/calendar.ts
+++ b/src/lib/shared/schemas/calendar.ts
@@ -30,6 +30,11 @@ export type CalendarEventKind = z.infer<typeof calendarEventKindSchema>;
 export const calendarEventVisibilitySchema = z.enum(["normal", "private"]);
 export type CalendarEventVisibility = z.infer<typeof calendarEventVisibilitySchema>;
 
+/** Outlook-speglingens status (för UI-banner). Single source of truth så
+ *  router-input + entitet inte driftar isär (medlems-ordning m.m.). */
+export const calendarMirrorStatusSchema = z.enum(["pending", "synced", "failed"]);
+export type CalendarMirrorStatus = z.infer<typeof calendarMirrorStatusSchema>;
+
 export const calendarEventSchema = z.object({
   ...baseFields,
   id: calendarEventIdSchema,
@@ -60,7 +65,7 @@ export const calendarEventSchema = z.object({
   /** Vilken Outlook-kalender (default = primär). */
   outlookCalendarId: z.string().nullish(),
   /** Senaste mirror-status (för UI-banner). */
-  mirrorStatus: z.enum(["pending", "synced", "failed"]).nullish(),
+  mirrorStatus: calendarMirrorStatusSchema.nullish(),
   mirrorError: z.string().nullish(),
   mirrorLastSyncedAt: optionalDateLike,
 }).passthrough();

--- a/src/lib/shared/schemas/document.ts
+++ b/src/lib/shared/schemas/document.ts
@@ -11,6 +11,11 @@ import {
   userIdSchema,
 } from "./ids";
 
+/** Dokumentets AI-analys-status. Single source of truth så router-input
+ *  (document.upsert/metadata-write) och entiteten inte driftar isär. */
+export const documentAnalysisStatusSchema = z.enum(["PENDING", "RUNNING", "DONE", "ERROR"]);
+export type DocumentAnalysisStatus = z.infer<typeof documentAnalysisStatusSchema>;
+
 /**
  * DocumentFolder — hierarkisk mapp inom ett matter. `parentId` = null → root.
  * Lagras i `document-folders/<id>.json`.
@@ -49,7 +54,7 @@ export const documentSchema = z.object({
   tags: z.array(z.string()).default([]),
   summary: z.string().nullish(),
   analyzedAt: optionalDateLike,
-  analysisStatus: z.enum(["PENDING", "RUNNING", "DONE", "ERROR"]).nullish(),
+  analysisStatus: documentAnalysisStatusSchema.nullish(),
   analysisModel: z.string().nullish(),
   analysisError: z.string().nullish(),
 }).passthrough();


### PR DESCRIPTION
Del **A1** av strong-typing-svepet (#750). Routrar re-deklarerade enum-värden inline i stället för att återanvända de kanoniska zod-schemana → driftrisk.

## Ändringar
- **invoice.ts** — tog bort lokala `invoiceType`/`invoiceStatus`-shadows, återanvänder de kanoniska. Den lokala `invoiceTypeSchema` **saknade `CREDIT`** (latent drift) → list-filtret täcker nu alla typer. `setStatus` härleder sin subset via `.extract([...])` i st.f. en ny literal.
- **matter.ts** — `list`/`update` status → `matterStatusSchema`.
- **user.ts** — `create`/`update` role → `userRoleSchema`.
- **Orphan-enums → namngivna scheman** (single source of truth): `documentAnalysisStatusSchema` (`schemas/document`) + `calendarMirrorStatusSchema` (`schemas/calendar`, **fixar en medlems-ordnings-drift**). Återanvänds i `document/core.ts` (slopar en onödig cast) + `calendar.ts`.
- **analyze-dispatch** — `AnalyzeArgs.analysisStatus` → `DocumentAnalysisStatus`. Kommentaren påstod `"FAILED"` (finns inte i enum:en); enda anroparen sätter `"DONE"`.

## Test
Typecheck grön, lint grön, 693 server/shared/integration-tester gröna.

Refs #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)