### PR TITLE
refactor(tooling): återanvänd kanoniska enum-typer i seed/demo-data (A4-tooling)

### DIFF
--- a/tooling/demo-generator/populate-billing.ts
+++ b/tooling/demo-generator/populate-billing.ts
@@ -16,6 +16,7 @@
  * Belopp/fakturanummer/OCR genereras organiskt av billing-run-routern (ADR 0012).
  */
 
+import type { BillingRunRecipient } from "@/lib/shared/schemas/enums";
 import { demoFinalInvoiceId, demoAccontoInvoiceId, demoCreditInvoiceId, demoPaymentPlanId } from "../scripts/demo-billing-ids";
 import type { SeedDataset } from "../scripts/seed-data";
 import type { GeneratorCaller } from "./backend-target";
@@ -43,7 +44,7 @@ interface Ctx {
 /** En skapad slutfaktura. `matterId` bärs med så plan-/kredit-id:n blir deterministiska (uuidv5 på matterId). */
 type FinalInv = { id: string; amount: number; matterId: string };
 
-const BILLING_RUN_RECIPIENT: Record<string, "KLIENT" | "FORSAKRING" | "RATTSHJALPSMYNDIGHET"> = {
+const BILLING_RUN_RECIPIENT: Record<string, BillingRunRecipient> = {
   RATTSSKYDD: "FORSAKRING",
   RATTSHJALP: "RATTSHJALPSMYNDIGHET",
 };
@@ -77,7 +78,7 @@ async function acconto(ctx: Ctx, matterId: string, bips: number, amountOre: numb
 }
 
 /** Slutfaktura via billing-run → SENT. Returnerar {id, amount}. */
-async function finalSent(ctx: Ctx, matterId: string, recipient: string, deducted: string[], daysAgo: number): Promise<FinalInv> {
+async function finalSent(ctx: Ctx, matterId: string, recipient: BillingRunRecipient, deducted: string[], daysAgo: number): Promise<FinalInv> {
   const { invoice } = await ctx.c.billingRun.createFinal({
     id: demoFinalInvoiceId(matterId), matterId, recipient, deductedBillingRunIds: deducted,
     invoiceDate: isoDaysAgo(daysAgo), dueDate: isoDaysAgo(daysAgo - 30),
@@ -88,7 +89,7 @@ async function finalSent(ctx: Ctx, matterId: string, recipient: string, deducted
 }
 
 /** Slutfaktura som LÄMNAS draft (ej skickad). */
-async function finalDraft(ctx: Ctx, matterId: string, recipient: string, daysAgo: number): Promise<void> {
+async function finalDraft(ctx: Ctx, matterId: string, recipient: BillingRunRecipient, daysAgo: number): Promise<void> {
   await ctx.c.billingRun.createFinal({
     id: demoFinalInvoiceId(matterId), matterId, recipient, deductedBillingRunIds: [],
     invoiceDate: isoDaysAgo(daysAgo),

--- a/tooling/scripts/seed-data.ts
+++ b/tooling/scripts/seed-data.ts
@@ -15,7 +15,15 @@ import {
   KOSTNADSRAKNING_TEMPLATE_CATEGORY,
   KOSTNADSRAKNING_DEFAULT_HTML,
 } from "@/lib/shared/kostnadsrakning-template";
-import { ENTITY_REGISTRY } from "@/lib/shared/schemas";
+import {
+  ENTITY_REGISTRY,
+  type ContactType,
+  type InvoiceStatus,
+  type MatterStatus,
+  type PaymentMethod,
+  type PaymentPlanStatus,
+  type UserRole,
+} from "@/lib/shared/schemas";
 
 export const ORG_ID = "firma-ab";
 
@@ -53,7 +61,7 @@ function isoDate(daysFromNow: number, hour = 9): Date {
 }
 
 interface UserSeed {
-  id: string; email: string; name: string; role: "ADMIN" | "LAWYER" | "ASSISTANT";
+  id: string; email: string; name: string; role: UserRole;
   hourlyRate: number; title: string;
 }
 
@@ -72,7 +80,7 @@ export const USERS: UserSeed[] = buildUsers("current-user", "firma.local");
 
 interface ContactSeed {
   id: string; name: string;
-  contactType: "PERSON" | "COMPANY" | "COURT" | "AUTHORITY" | "INSURANCE_COMPANY" | "LAW_FIRM";
+  contactType: ContactType;
   personalNumber?: string; orgNumber?: string; email?: string; phone?: string;
 }
 
@@ -98,8 +106,8 @@ export const CONTACTS: ContactSeed[] = [
 
 interface MatterSeed {
   id: string; matterNumber: string; title: string;
-  status: "ACTIVE" | "CLOSED" | "ARCHIVED"; matterType: string;
-  paymentMethod: "PENDING" | "RATTSHJALP" | "RATTSSKYDD" | "OFFENTLIGT_UPPDRAG" | "PRIVAT" | "MIX";
+  status: MatterStatus; matterType: string;
+  paymentMethod: PaymentMethod;
   description: string;
   klientId: string; motpartId?: string; domstolId?: string;
   createdDaysAgo: number;
@@ -410,7 +418,7 @@ function buildExpenses(orgId: string, users: UserSeed[]): SeedDataset["expenses"
 function buildInvoices(orgId: string): SeedDataset["invoices"] {
   const out: SeedDataset["invoices"] = [];
   // invoices
-  const statuses: Array<"DRAFT" | "SENT" | "PAID" | "INSTALLMENT_PLAN"> = ["DRAFT", "SENT", "PAID", "INSTALLMENT_PLAN"];
+  const statuses: InvoiceStatus[] = ["DRAFT", "SENT", "PAID", "INSTALLMENT_PLAN"];
   for (let i = 0; i < 12; i++) {
     const matter = MATTERS[i % MATTERS.length];
     if (!matter) continue;
@@ -465,7 +473,7 @@ interface PlanBundle {
 // buildPaymentPlans patchar fakturornas status så det stämmer.
 interface PlanTarget {
   invoiceId: string;
-  status: "ACTIVE" | "COMPLETED" | "CANCELLED";
+  status: PaymentPlanStatus;
   monthlyAmount: number;
   dayOfMonth: number;
   startsDaysAgo: number;
@@ -503,7 +511,7 @@ function planReminders(p: PlanTarget, planId: string): SeedDataset["paymentPlanR
 }
 
 /** Invoice-status som matchar planens livscykel. */
-function invoiceStatusForPlan(planStatus: PlanTarget["status"]): string {
+function invoiceStatusForPlan(planStatus: PlanTarget["status"]): InvoiceStatus {
   if (planStatus === "ACTIVE") return "INSTALLMENT_PLAN";
   if (planStatus === "COMPLETED") return "PAID";
   return "SENT";

--- a/tooling/scripts/seed-selfhosted-local.ts
+++ b/tooling/scripts/seed-selfhosted-local.ts
@@ -21,6 +21,7 @@
 import { createPostgresDb } from "@/lib/server/db/client";
 import { createDbChangeLogRecorder, enableChangeLogOnAll } from "@/lib/server/repositories/change-log-recorder";
 import { buildDrizzleRepositories } from "@/lib/server/repositories/drizzle-repositories";
+import type { UserRole } from "@/lib/shared/schemas/enums";
 import { asId } from "@/lib/shared/schemas/ids";
 import type { Organization } from "@/lib/shared/schemas/organization";
 import type { User } from "@/lib/shared/schemas/user";
@@ -31,7 +32,7 @@ const ORG = process.env.AVA_ORGANIZATION_ID ?? "00000000-0000-0000-0000-00000000
 
 /** KC-realm:ens (realm-ava.json) allowlistade testanvändare. `outsider` seedas
  *  MEDVETET INTE → demonstrerar att autentiserad ≠ auktoriserad (nekas). */
-const USERS: ReadonlyArray<{ email: string; name: string; role: "LAWYER" | "ADMIN" }> = [
+const USERS: ReadonlyArray<{ email: string; name: string; role: UserRole }> = [
   { email: "lawyer@ava.test", name: "Lena Lawyer", role: "LAWYER" },
   { email: "admin@ava.test", name: "Alva Admin", role: "ADMIN" },
 ];

--- a/tooling/scripts/write-demo-meta.ts
+++ b/tooling/scripts/write-demo-meta.ts
@@ -13,6 +13,7 @@
  */
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+import type { UserRole } from "@/lib/shared/schemas/enums";
 import { CURRENT_SCHEMA_VERSION } from "../../src/lib/shared/schema-version";
 import { DEMO_META_PATH } from "../demo-config";
 import type { IdTranslator } from "../demo-generator/id-translator";
@@ -22,7 +23,7 @@ export interface DemoMetaUser {
   id: string;
   name: string;
   email: string;
-  role: "ADMIN" | "LAWYER" | "ASSISTANT";
+  role: UserRole;
   title?: string;
 }
 
@@ -56,7 +57,7 @@ export function buildDemoMeta(seed: SeedShape, translator: IdTranslator, now: Da
     id: translator.toUuid(String(u.id ?? "")),
     name: String(u.name ?? ""),
     email: String(u.email ?? ""),
-    role: u.role as "ADMIN" | "LAWYER" | "ASSISTANT",
+    role: u.role as UserRole,
     ...(u.title ? { title: String(u.title) } : {}),
   }));
   if (users.some((u) => !u.id || !u.name || !u.role)) {


### PR DESCRIPTION
Del av strong-typing-svepet (#750), slice **A4-tooling**. Seed/demo-data re-deklarerade enum-värden som inline string-unioner.

- **seed-data.ts** — `UserSeed.role`→`UserRole`, `ContactSeed.contactType`→`ContactType`, `MatterSeed.status`→`MatterStatus` + `paymentMethod`→`PaymentMethod`, `buildInvoices` statuses→`InvoiceStatus[]`, `PlanTarget.status`→`PaymentPlanStatus`, `invoiceStatusForPlan`→`InvoiceStatus`.
- **write-demo-meta.ts** — `DemoMetaUser.role` + cast→`UserRole`.
- **seed-selfhosted-local.ts** — `USERS.role`→`UserRole`.
- **populate-billing.ts** — `BILLING_RUN_RECIPIENT`-värde + `finalSent`/`finalDraft` recipient→`BillingRunRecipient`.

Seed är en datakälla → ingen kaskad utåt. Shared pure-konsumenterna (läser rå DB-värden) tightas efter A2 (repo-DTO:er).

## Test
Typecheck + lint grön; 132 seed/demo/script-tester gröna.

Refs #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)