### PR TITLE
refactor(server): strikta enum-typer i repo-DTO:er + db-schema (A2)

### DIFF
--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -13,14 +13,14 @@
 
 import { relations } from "drizzle-orm";
 import { bigint, bigserial, index, integer, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
-import type { DispatchChannel, DispatchStatus } from "@/lib/shared/schemas/billing";
+import type { DispatchChannel, DispatchStatus, ExpectedReceivableStatus } from "@/lib/shared/schemas/billing";
 import type {
   CalendarEventKind, CalendarEventVisibility, TaskPriority, TaskStatus,
 } from "@/lib/shared/schemas/calendar";
 import type {
   BillingRunRecipient, BillingRunStatus, BillingRunType, ContactType, ExpenseKind, InvoiceStatus,
   InvoiceType, MatterRole, MatterStatus, PaymentMethod, PaymentPlanStatus, ReminderType,
-  SuggestionStatus,
+  SuggestionStatus, UserRole,
 } from "@/lib/shared/schemas/enums";
 import type {
   AccontoDeductionId, BillingRunId, CalendarEventId, ConflictCheckId, ContactId,
@@ -64,7 +64,7 @@ export const users = pgTable("users", {
   email: text("email").notNull(),
   name: text("name").notNull(),
   title: text("title"),
-  role: text("role").notNull().default("LAWYER"),
+  role: text("role").notNull().default("LAWYER").$type<UserRole>(),
   matterNumberPrefix: text("matter_number_prefix"),
   hourlyRate: integer("hourly_rate"),
   mileageRate: integer("mileage_rate"),
@@ -281,7 +281,7 @@ export const expectedReceivables = pgTable("expected_receivables", {
   matterId: uuid("matter_id").notNull(),
   description: text("description").notNull(),
   expectedAmount: ore("expected_amount").notNull(),
-  status: text("status").notNull().default("PENDING"),
+  status: text("status").notNull().default("PENDING").$type<ExpectedReceivableStatus>(),
   settledAmount: ore("settled_amount"),
   settledAt: timestamp("settled_at", { withTimezone: true }),
   paymentReference: text("payment_reference"),

--- a/src/lib/server/events/emit.ts
+++ b/src/lib/server/events/emit.ts
@@ -10,6 +10,7 @@
  * men vi har minst en upstream-rad i Postgres-loggen om felet.
  */
 
+import type { MatterStatus } from "@/lib/shared/schemas/enums";
 import type { IDataStore } from "../data-store/IDataStore";
 import type { EventType, EmitInput } from "./schema";
 
@@ -60,7 +61,7 @@ export const emit = {
   matterUpdated: (ctx: EmitCtx, matterId: string, patch: Record<string, unknown>) =>
     emitUser(ctx, "matter.updated", { patch }, matterId),
 
-  matterStatusChanged: (ctx: EmitCtx, matterId: string, from: string, to: string) =>
+  matterStatusChanged: (ctx: EmitCtx, matterId: string, from: MatterStatus, to: MatterStatus) =>
     emitUser(ctx, "matter.status_changed", { from, to }, matterId),
 
   matterArchived: (ctx: EmitCtx, matterId: string) =>

--- a/src/lib/server/repositories/billing-run-repository.ts
+++ b/src/lib/server/repositories/billing-run-repository.ts
@@ -6,17 +6,18 @@
  */
 
 import type { BillingRun } from "@/lib/shared/schemas/billing";
+import type { InvoiceStatus, PaymentMethod } from "@/lib/shared/schemas/enums";
 import type { Repository } from "./types";
 
 /** Billing-run + faktura (listvyn). */
 export interface BillingRunListRow extends BillingRun {
-  invoice: { id: string; invoiceNumber: string | null; status: string } | null;
+  invoice: { id: string; invoiceNumber: string | null; status: InvoiceStatus } | null;
 }
 
 /** Billing-run + faktura + ärende (detaljvyn). */
 export interface BillingRunDetailRow extends BillingRun {
-  invoice: { id: string; invoiceNumber: string | null; status: string; amount: number } | null;
-  matter: { id: string; matterNumber: string; title: string; paymentMethod: string | null } | null;
+  invoice: { id: string; invoiceNumber: string | null; status: InvoiceStatus; amount: number } | null;
+  matter: { id: string; matterNumber: string; title: string; paymentMethod: PaymentMethod | null } | null;
 }
 
 export interface BillingRunRepository extends Repository<BillingRun> {

--- a/src/lib/server/repositories/contact-repository.ts
+++ b/src/lib/server/repositories/contact-repository.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Contact } from "@/lib/shared/schemas/contact";
-import type { ContactType } from "@/lib/shared/schemas/enums";
+import type { ContactType, MatterRole, MatterStatus } from "@/lib/shared/schemas/enums";
 import type { Repository } from "./types";
 
 /** Kontakt + antal relationer (listvyns _count). */
@@ -19,10 +19,10 @@ export interface ContactMatterLink {
   id: string;
   matterId: string;
   contactId: string;
-  role: string;
+  role: MatterRole;
   notes: string | null;
   /** Alltid satt — `matterId` är NOT NULL FK, så ärendet finns alltid. */
-  matter: { id: string; matterNumber: string; title: string; status: string };
+  matter: { id: string; matterNumber: string; title: string; status: MatterStatus };
 }
 
 /** Full kontakt-detalj (motsvarar `contact.getById`-routerns include). */

--- a/src/lib/server/repositories/drizzle-billing-run-repository.ts
+++ b/src/lib/server/repositories/drizzle-billing-run-repository.ts
@@ -43,7 +43,7 @@ export class DrizzleBillingRunRepository
       .orderBy(desc(billingRuns.createdAt));
     return rows.map((r): BillingRunListRow => ({
       ...r.run,
-      invoice: r.invId ? { id: r.invId, invoiceNumber: r.invNum, status: r.invStatus as string } : null,
+      invoice: r.invId && r.invStatus ? { id: r.invId, invoiceNumber: r.invNum, status: r.invStatus } : null,
     }));
   }
 
@@ -63,8 +63,8 @@ export class DrizzleBillingRunRepository
     if (!r) return null;
     return {
       ...r.run,
-      invoice: r.invId
-        ? { id: r.invId, invoiceNumber: r.invNum, status: r.invStatus as string, amount: Number(r.invAmount ?? 0) }
+      invoice: r.invId && r.invStatus
+        ? { id: r.invId, invoiceNumber: r.invNum, status: r.invStatus, amount: Number(r.invAmount ?? 0) }
         : null,
       matter: r.mId
         ? { id: r.mId, matterNumber: r.mNum, title: r.mTitle, paymentMethod: r.mPay ?? null }

--- a/src/lib/server/repositories/drizzle-matter-contact-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-contact-repository.ts
@@ -49,9 +49,9 @@ export class DrizzleMatterContactRepository
       .innerJoin(matters, eq(matterContacts.matterId, matters.id))
       .where(and(eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(matterContacts.deletedAt), numberFilter));
     return rows.map((r) => ({
-      role: r.role as string,
+      role: r.role,
       contact: {
-        id: r.cId as string, name: r.cName as string, contactType: r.cType as string,
+        id: r.cId as string, name: r.cName as string, contactType: r.cType,
         personalNumber: (r.cPnr as string | null) ?? null, orgNumber: (r.cOrg as string | null) ?? null,
       },
       matter: {

--- a/src/lib/server/repositories/drizzle-payment-plan-repository.ts
+++ b/src/lib/server/repositories/drizzle-payment-plan-repository.ts
@@ -50,7 +50,7 @@ export class DrizzlePaymentPlanRepository extends DrizzleRepository<PaymentPlan>
   }
 
   /** Plan-id:n i org:en (via faktura→ärende), valfritt status-filtrerade. */
-  private async planIdsInOrg(organizationId: string, status?: string): Promise<string[]> {
+  private async planIdsInOrg(organizationId: string, status?: PaymentPlanStatus): Promise<string[]> {
     const rows = await this.db
       .select({ id: paymentPlans.id }).from(paymentPlans)
       .innerJoin(invoices, eq(paymentPlans.invoiceId, invoices.id))
@@ -100,7 +100,7 @@ export class DrizzlePaymentPlanRepository extends DrizzleRepository<PaymentPlan>
     return out;
   }
 
-  async listForOrg(organizationId: string, status?: string): Promise<JoinedPaymentPlan[]> {
+  async listForOrg(organizationId: string, status?: PaymentPlanStatus): Promise<JoinedPaymentPlan[]> {
     return this.fetchJoined(await this.planIdsInOrg(organizationId, status));
   }
 

--- a/src/lib/server/repositories/expected-receivable-repository.ts
+++ b/src/lib/server/repositories/expected-receivable-repository.ts
@@ -3,12 +3,12 @@
  * domstolsbetalningar (#173). Org-scopas direkt. Bas-CRUD ärvs.
  */
 
-import type { ExpectedReceivable } from "@/lib/shared/schemas/billing";
+import type { ExpectedReceivable, ExpectedReceivableStatus } from "@/lib/shared/schemas/billing";
 import type { Repository } from "./types";
 
 export interface ExpectedReceivableListFilter {
   matterId?: string | undefined;
-  status?: string | undefined;
+  status?: ExpectedReceivableStatus | undefined;
 }
 
 export interface ExpectedReceivableRepository extends Repository<ExpectedReceivable> {

--- a/src/lib/server/repositories/in-memory-payment-plan-repository.ts
+++ b/src/lib/server/repositories/in-memory-payment-plan-repository.ts
@@ -6,6 +6,7 @@
  */
 
 import type { PaymentPlan } from "@/lib/shared/schemas/billing";
+import type { PaymentPlanStatus } from "@/lib/shared/schemas/enums";
 import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type {
@@ -52,7 +53,7 @@ export class InMemoryPaymentPlanRepository extends InMemoryRepository<PaymentPla
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }
 
-  async listForOrg(organizationId: string, status?: string): Promise<JoinedPaymentPlan[]> {
+  async listForOrg(organizationId: string, status?: PaymentPlanStatus): Promise<JoinedPaymentPlan[]> {
     return (await this.delegate.findMany({
       where: { ...(status ? { status } : {}), invoice: { matter: { organizationId } } },
       orderBy: { createdAt: "desc" },

--- a/src/lib/server/repositories/matter-contact-repository.ts
+++ b/src/lib/server/repositories/matter-contact-repository.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Contact } from "@/lib/shared/schemas/contact";
+import type { ContactType, MatterRole } from "@/lib/shared/schemas/enums";
 import type { MatterContact } from "@/lib/shared/schemas/matter";
 import type { Repository } from "./types";
 
@@ -15,9 +16,9 @@ export interface MatterContactWithContact extends MatterContact {
 
 /** Jävskontroll-rad: länk + kontakt + ärende (med KLIENT-namn). */
 export interface ConflictContactRow {
-  role: string;
+  role: MatterRole;
   contact: {
-    id: string; name: string; contactType: string;
+    id: string; name: string; contactType: ContactType;
     personalNumber: string | null; orgNumber: string | null;
   };
   matter: {
@@ -38,6 +39,7 @@ export interface MatterContactRepository extends Repository<MatterContact> {
   /** Skapa en länk och returnera den med kontakten (matter.addContact/addNewContact). */
   linkContact(data: Partial<MatterContact>): Promise<MatterContactWithContact>;
   /** Befintlig länk (ärende, kontakt, roll) — för idempotent koppling. Null om ingen. */
+  // role förblir `string` tills suggestions-flödets roll-typ tightas (A3, #750)
   findLink(matterId: string, contactId: string, role: string): Promise<MatterContact | null>;
   /** Kontakterna kopplade till ett ärende (dedup-underlag i förslags-flödet). */
   listContactsForMatter(matterId: string): Promise<Contact[]>;

--- a/src/lib/server/repositories/payment-plan-repository.ts
+++ b/src/lib/server/repositories/payment-plan-repository.ts
@@ -9,6 +9,7 @@
  */
 
 import type { Invoice, Payment, PaymentPlan, PaymentPlanReminder, WriteOff } from "@/lib/shared/schemas/billing";
+import type { PaymentPlanStatus } from "@/lib/shared/schemas/enums";
 import type { Matter } from "@/lib/shared/schemas/matter";
 import type { Repository } from "./types";
 
@@ -40,7 +41,7 @@ export interface PaymentPlanRepository extends Repository<PaymentPlan> {
   /** Plan för en faktura (invoiceId är unik på planen) — null om ingen/raderad. */
   getByInvoiceId(invoiceId: string): Promise<PaymentPlan | null>;
   /** Org:ens planer (createdAt desc), valfritt status-filtrerade, joinade. */
-  listForOrg(organizationId: string, status?: string): Promise<JoinedPaymentPlan[]>;
+  listForOrg(organizationId: string, status?: PaymentPlanStatus): Promise<JoinedPaymentPlan[]>;
   /** En plan med full join + påminnelse-historik, org-scopad. Null om saknas. */
   getByIdWithDetails(id: string, organizationId: string): Promise<JoinedPaymentPlanWithReminders | null>;
   /** Aktiva planer i org:en (join + påminnelser) för påminnelse-skannern. */

--- a/src/lib/server/rules/schema.ts
+++ b/src/lib/server/rules/schema.ts
@@ -11,7 +11,7 @@
  */
 
 import { z } from "zod";
-import { eventTypeSchema } from "../events/schema";
+import { eventTypeSchema, type EventType } from "../events/schema";
 
 // ─── JsonLogic predikat — minimal Zod-validering ─────────────────────
 //
@@ -79,7 +79,7 @@ const valueRefSchema = z.union([z.string(), z.number(), z.boolean(), z.null(), z
 
 interface BaseStep { do: string; }
 
-interface EmitStep extends BaseStep { do: "emit"; eventType: string; payload: Record<string, unknown>; }
+interface EmitStep extends BaseStep { do: "emit"; eventType: EventType; payload: Record<string, unknown>; }
 interface EmailSendStep extends BaseStep { do: "email.send"; template: string; to: string; vars?: Record<string, unknown> | undefined; idempotencyKey?: string | undefined; }
 interface MatterUpdateStep extends BaseStep { do: "matter.update"; matterId: string; patch: Record<string, unknown>; }
 interface AuditLogStep extends BaseStep { do: "audit.log"; message: string; }
@@ -101,7 +101,7 @@ export type RuleStep =
   | TaskCreateStep;
 
 // Zod-scheman per step. `if` och `for-each` är rekursiva.
-const emitStepSchema = z.object({ do: z.literal("emit"), eventType: z.string(), payload: z.record(z.string(), z.unknown()) });
+const emitStepSchema = z.object({ do: z.literal("emit"), eventType: eventTypeSchema, payload: z.record(z.string(), z.unknown()) });
 const emailSendStepSchema = z.object({ do: z.literal("email.send"), template: z.string(), to: z.string(), vars: z.record(z.string(), z.unknown()).optional(), idempotencyKey: z.string().optional() });
 const matterUpdateStepSchema = z.object({ do: z.literal("matter.update"), matterId: z.string(), patch: z.record(z.string(), z.unknown()) });
 const auditLogStepSchema = z.object({ do: z.literal("audit.log"), message: z.string() });

--- a/test/unit/server/rules/execute.test.ts
+++ b/test/unit/server/rules/execute.test.ts
@@ -57,12 +57,12 @@ describe("executeRule — grundflöde", () => {
 describe("executeRule — steg-typer", () => {
   it("emit: emittar event med templatead payload", async () => {
     const { ctx, emit } = makeCtx(
-      [{ do: "emit", eventType: "custom.thing", payload: { who: "{{payload.name}}" } }] as RuleStep[],
+      [{ do: "emit", eventType: "matter.created", payload: { who: "{{payload.name}}" } }] as RuleStep[],
       { payload: { name: "Anna" } },
     );
     await executeRule(ctx);
     const emitted = emit.mock.calls.map((c: unknown[]) => c[0] as { type: string; payload?: Record<string, unknown> });
-    const custom = emitted.find((e: { type: string; payload?: Record<string, unknown> }) => e.type === "custom.thing");
+    const custom = emitted.find((e: { type: string; payload?: Record<string, unknown> }) => e.type === "matter.created");
     expect(custom?.payload).toEqual({ who: "Anna" });
   });
 

--- a/test/unit/server/rules/schema.test.ts
+++ b/test/unit/server/rules/schema.test.ts
@@ -72,7 +72,7 @@ describe("avaRuleSchema", () => {
 
   it("känner igen alla 9 step-typer", () => {
     const steps = [
-      { do: "emit", eventType: "x", payload: {} },
+      { do: "emit", eventType: "matter.created", payload: {} },
       { do: "email.send", template: "x", to: "a@b" },
       { do: "matter.update", matterId: "m", patch: {} },
       { do: "audit.log", message: "x" },


### PR DESCRIPTION
Del **A2** av strong-typing-svepet (#750). Repo-DTO-fält + två db-kolumner var `string` fast värdena är slutna enums.

## Ändringar
- **db/schema.ts** — `users.role`→`.$type<UserRole>()`, `expectedReceivables.status`→`.$type<ExpectedReceivableStatus>()` (de sista enum-kolumnerna utan `$type`, mot filens egen 108-gångers konvention).
- **billing-run-repository** DTO — `invoice.status`→`InvoiceStatus`, `matter.paymentMethod`→`PaymentMethod`. Drizzle-impl: **tog bort `as string`-cast** som aktivt slängde kolumnens `$type<InvoiceStatus>`-brand (+ guarda `invStatus`-null från leftJoin).
- **matter-contact** `ConflictContactRow.role/contactType`→`MatterRole/ContactType` (tog bort `as string`-cast i drizzle-mappningen).
- **expected-receivable** `filter.status`→`ExpectedReceivableStatus`.
- **payment-plan** `listForOrg`/`planIdsInOrg` status→`PaymentPlanStatus` (interface + drizzle + in-memory).
- **contact** `ContactMatterLink.role/matter.status`→`MatterRole/MatterStatus`.
- **events/emit.ts** `matterStatusChanged` from/to→`MatterStatus`.
- **rules/schema.ts** emit-stegets `eventType`→`eventTypeSchema/EventType` (fixade 2 test-fixtures med ogiltig eventType).

`matterContacts.findLink(role)` lämnas `string` tills suggestions-flödets roll-typ tightas (A3).

## Test
Ren `tsc` (root + test, cache-trap kringgången), lint grön, server-/repo-/integration-tester gröna.

Refs #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)