### PR TITLE
refactor(client): strikta InvoiceStatus/InvoiceType i faktura-vyerna (A3a-invoices)

### DIFF
--- a/src/app/invoices/[id]/_invoice-actions.tsx
+++ b/src/app/invoices/[id]/_invoice-actions.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import type { InvoiceStatus, InvoiceType } from "@/lib/shared/schemas/enums";
+
 interface Props {
-  invoiceType: string;
-  status: string;
+  invoiceType: InvoiceType;
+  status: InvoiceStatus;
   hasPlan: boolean;
   hasCreditNote: boolean;
   /** Utestående (öre) > 0 → avskrivning möjlig (räkna-en-gång, ADR 0007). */
@@ -12,7 +14,7 @@ interface Props {
   onShowCredit: () => void;
   onShowWriteOff: () => void;
   onShowSend: () => void;
-  onSetStatus: (status: string) => void;
+  onSetStatus: (status: InvoiceStatus) => void;
 }
 
 interface Visibility {
@@ -25,19 +27,19 @@ interface Visibility {
   send: boolean;
 }
 
-const TERMINAL_STATUS: ReadonlySet<string> = new Set(["PAID", "CANCELLED"]);
+const TERMINAL_STATUS: ReadonlySet<InvoiceStatus> = new Set<InvoiceStatus>(["PAID", "CANCELLED"]);
 
 /**
  * Skicka-knappen (#179/#392): en faktura kan skickas i DRAFT (då blir den SENT),
  * är utställd (SENT/avbetalningsplan → kan skickas om), eller är en icke-annullerad
  * kreditfaktura. Modalen erbjuder automatiskt (köa → server) + manuellt utskick.
  */
-function canSend(isCredit: boolean, status: string): boolean {
+function canSend(isCredit: boolean, status: InvoiceStatus): boolean {
   if (status === "DRAFT" || status === "SENT" || status === "INSTALLMENT_PLAN") return true;
   return isCredit && status !== "CANCELLED";
 }
 
-function computeVisibility(invoiceType: string, status: string, hasPlan: boolean, hasCreditNote: boolean, outstanding: number): Visibility {
+function computeVisibility(invoiceType: InvoiceType, status: InvoiceStatus, hasPlan: boolean, hasCreditNote: boolean, outstanding: number): Visibility {
   const isCredit = invoiceType === "CREDIT";
   const sentNoPlan = !isCredit && status === "SENT" && !hasPlan;
   // Utställd & aktiv (SENT eller pågående avbetalningsplan, ej kreditfaktura).

--- a/src/app/invoices/page.tsx
+++ b/src/app/invoices/page.tsx
@@ -5,6 +5,7 @@ import { DataTable, type Column } from "@/components/ui/data-table";
 import { EntityLink } from "@/lib/client/demo/entity-link";
 import { trpc } from "@/lib/client/trpc";
 import { formatCurrency } from "@/lib/client/utils";
+import type { InvoiceStatus, InvoiceType } from "@/lib/shared/schemas/enums";
 import { SieExportButton } from "./_sie-export-button";
 
 const STATUS_LABELS: Record<string, string> = {
@@ -21,7 +22,7 @@ const TYPE_LABELS: Record<string, string> = {
   FINAL: "Slutfaktura",
 };
 
-function statusBadgeClass(status: string): string {
+function statusBadgeClass(status: InvoiceStatus): string {
   switch (status) {
     case "PAID": return "bg-green-100 text-green-700";
     case "SENT": return "bg-amber-100 text-amber-700";
@@ -36,8 +37,8 @@ interface InvoiceRow {
   id: string;
   invoiceNumber?: string | null;
   invoiceDate: string | Date;
-  invoiceType: string;
-  status: string;
+  invoiceType: InvoiceType;
+  status: InvoiceStatus;
   amount: number;
   matter: { id: string; matterNumber: string; title: string };
 }


### PR DESCRIPTION
Del av strong-typing-svepet (#750), första klient-slice.

- **invoices/page.tsx** — `InvoiceRow.status/invoiceType` + `statusBadgeClass` → `InvoiceStatus`/`InvoiceType`.
- **invoices/[id]/_invoice-actions.tsx** — `Props.status/invoiceType`, `onSetStatus`, `TERMINAL_STATUS`, `canSend`, `computeVisibility` → `InvoiceStatus`/`InvoiceType`. Flera handjämförda status-literaler typas nu mot enum:en (fångar stavfel/ogiltiga jämförelser).

`labels.ts`-helpers + reports `paymentMethod` togs ur denna PR — de kräver att `reports.ts`-DTO:erna tightas samtidigt (egen slice).

## Test
Ren `tsc` (root + test), lint grön, 979 klient/lib-tester gröna.

Refs #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)