### PR TITLE
refactor(reports): strikta PaymentMethod/InvoiceStatus i rapport-DTO:er + labels (A3-reports)

### DIFF
--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -9,6 +9,7 @@ import { trpc } from "@/lib/client/trpc";
 import { formatMinutes, formatCurrency } from "@/lib/client/utils";
 import type { AppRouter } from "@/lib/server/routers/_app";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
+import type { PaymentMethod } from "@/lib/shared/schemas/enums";
 import { ArSummarySection } from "./_ar-summary";
 
 const RISK_BADGE_CLASSES: Record<CreditRisk, string> = {
@@ -18,7 +19,7 @@ const RISK_BADGE_CLASSES: Record<CreditRisk, string> = {
   UNKNOWN: "bg-gray-100 text-gray-600 border-gray-200",
 };
 
-function PaymentBadge({ method }: { method: string }) {
+function PaymentBadge({ method }: { method: PaymentMethod }) {
   const risk = creditRiskFor(method);
   return (
     <div className="inline-flex flex-col gap-0.5 items-start">

--- a/src/lib/client/labels.ts
+++ b/src/lib/client/labels.ts
@@ -100,8 +100,8 @@ export const paymentMethodOptions: ReadonlyArray<PaymentMethodOption> = paymentM
   (value) => ({ value, label: PAYMENT_METHOD_LABELS[value] }),
 );
 
-export function labelForPaymentMethod(v: string): string {
-  return (PAYMENT_METHOD_LABELS as Record<string, string>)[v] ?? v;
+export function labelForPaymentMethod(v: PaymentMethod): string {
+  return PAYMENT_METHOD_LABELS[v];
 }
 
 /**
@@ -110,7 +110,7 @@ export function labelForPaymentMethod(v: string): string {
  */
 export type CreditRisk = "LOW" | "MEDIUM" | "HIGH" | "UNKNOWN";
 
-export function creditRiskFor(method: string): CreditRisk {
+export function creditRiskFor(method: PaymentMethod): CreditRisk {
   switch (method) {
     case "RATTSHJALP":
     case "OFFENTLIGT_UPPDRAG":

--- a/src/lib/server/repositories/time-entry-repository.ts
+++ b/src/lib/server/repositories/time-entry-repository.ts
@@ -5,6 +5,7 @@
  */
 
 import type { TimeEntry } from "@/lib/shared/schemas/billing";
+import type { PaymentMethod } from "@/lib/shared/schemas/enums";
 import type { Repository } from "./types";
 
 /** Tidspost + juristens timtaxa (det fakturaberäkningen behöver). */
@@ -53,7 +54,7 @@ export interface ReportMatterRef {
   id: string;
   matterNumber: string;
   title: string;
-  paymentMethod: string;
+  paymentMethod: PaymentMethod;
   paymentMethodNote: string | null;
   paymentMethodDecidedAt: Date | null;
   contacts: Array<{ contact: { name: string } }>;

--- a/src/lib/server/routers/reports.ts
+++ b/src/lib/server/routers/reports.ts
@@ -5,6 +5,7 @@ import {
   type BilledInvoiceInput,
   type FrozenWorkInput,
 } from "@/lib/shared/billed-per-lawyer";
+import type { InvoiceStatus, PaymentMethod } from "@/lib/shared/schemas/enums";
 import { userIdSchema } from "@/lib/shared/schemas/ids";
 import { router, protectedProcedure } from "../trpc";
 
@@ -73,7 +74,7 @@ interface RawTimeEntry {
   userId: string; minutes: number; hourlyRate: number;
   invoiceId: string | null | undefined; frozenByBillingRunId: string | null | undefined;
 }
-interface RawInvoice { id: string; amount: number; status: string; invoiceDate: unknown; updatedAt: unknown }
+interface RawInvoice { id: string; amount: number; status: InvoiceStatus; invoiceDate: unknown; updatedAt: unknown }
 
 /** Karta frozen tidsposter → arbetsvärde per (faktura, advokat). En post knyts
  *  till sin faktura via direkt `invoiceId` (legacy) eller via BillingRun. */
@@ -174,7 +175,7 @@ interface ReportMatterRef {
   id: string;
   matterNumber: string;
   title: string;
-  paymentMethod: string;
+  paymentMethod: PaymentMethod;
   paymentMethodNote: string | null;
   paymentMethodDecidedAt: Date | null;
   contacts: { contact: { name: string } }[];
@@ -190,14 +191,14 @@ interface ReportExpense {
 
 interface MatterAgg {
   matterId: string; matterNumber: string; title: string; client: string | null;
-  paymentMethod: string; paymentMethodNote: string | null; paymentMethodDecidedAt: Date | null;
+  paymentMethod: PaymentMethod; paymentMethodNote: string | null; paymentMethodDecidedAt: Date | null;
   totalMinutes: number; billableMinutes: number;
   workValueOre: number; // tid × timpris (öre)
   expenseOre: number;   // utlägg totalt (öre, bara billable)
 }
 interface UnbilledRow {
   matterId: string; matterNumber: string; title: string; client: string | null;
-  paymentMethod: string; timeOre: number; expenseOre: number; total: number;
+  paymentMethod: PaymentMethod; timeOre: number; expenseOre: number; total: number;
 }
 
 /** hourlyRate ÄR REDAN ÖRE (öre/h) → (min/60) × öre/h = öre. */


### PR DESCRIPTION
Del av strong-typing-svepet (#750).

- **reports.ts** — `ReportMatterRef`/`MatterAgg`/`UnbilledRow.paymentMethod` → `PaymentMethod`, `RawInvoice.status` → `InvoiceStatus`.
- **time-entry-repository.ts** — `ReportMatterRef.paymentMethod` → `PaymentMethod` (källan som matar per-lawyer-rapporten; värdet kommer från `matters.paymentMethod`-kolumnens `$type<PaymentMethod>`).
- **labels.ts** — `creditRiskFor` + `labelForPaymentMethod` → `PaymentMethod` (de kanoniska helperna slutade widena till `string`).
- **reports/page.tsx** — `PaymentBadge.method` → `PaymentMethod`.

Värdet flödar nu `PaymentMethod` hela vägen: kolumn → repo-DTO → router-DTO → page → helper.

## Test
Non-incremental `tsc` (root + test) rent, lint grön, reports/repo-tester gröna.

Refs #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)