### PR TITLE
refactor(matters): strikta MatterStatus/MatterRole i ärende-vyerna (A3b-matter)

### DIFF
--- a/src/app/matters/[id]/_client.tsx
+++ b/src/app/matters/[id]/_client.tsx
@@ -11,7 +11,7 @@ import { EntityLink } from "@/lib/client/demo/entity-link";
 import { useRouteId } from "@/lib/client/demo/use-route-id";
 import { useEagerCacheMatterDocuments } from "@/lib/client/firma/use-eager-cache-matter-documents";
 import { trpc } from "@/lib/client/trpc";
-import type { PaymentMethod } from "@/lib/shared/schemas/enums";
+import type { MatterRole, MatterStatus, PaymentMethod } from "@/lib/shared/schemas/enums";
 import { BillingPanel } from "./_billing-panel";
 import { ContactsSection } from "./_contacts-section";
 import { ExpectedReceivablesSection } from "./_expected-receivables-section";
@@ -97,7 +97,7 @@ export default function MatterDetailClient({ id: paramId }: { id: string }) {
 
 type MatterContact = {
   id: string;
-  role: string;
+  role: MatterRole;
   contact: { id: string; name: string };
 };
 
@@ -108,7 +108,7 @@ interface HeaderProps {
     title: string;
     matterType?: string | null | undefined;
     description?: string | null | undefined;
-    status: string;
+    status: MatterStatus;
     isTaxeArende?: boolean | undefined;
   };
   klient: MatterContact[];
@@ -207,7 +207,7 @@ function MatterHeader({ matter: m, klient, onOpenGenerate }: HeaderProps) {
   );
 }
 
-function StatusBadge({ status }: { status: string }) {
+function StatusBadge({ status }: { status: MatterStatus }) {
   const cls = status === "ACTIVE"
     ? "bg-green-50 text-green-700"
     : status === "CLOSED"

--- a/src/app/matters/page.tsx
+++ b/src/app/matters/page.tsx
@@ -7,12 +7,13 @@ import { Pager } from "@/components/ui/pager";
 import { useIsReadOnly } from "@/lib/client/demo/demo-mode-context";
 import { EntityLink } from "@/lib/client/demo/entity-link";
 import { trpc } from "@/lib/client/trpc";
+import type { MatterStatus } from "@/lib/shared/schemas/enums";
 
 interface MatterRow {
   id: string;
   matterNumber: string;
   title: string;
-  status: string;
+  status: MatterStatus;
   isTaxeArende?: boolean;
   contacts: Array<{ contact: { name: string } }>;
   _count: { contacts: number };
@@ -63,7 +64,7 @@ const matterColumns: Column<MatterRow>[] = [
     render: (m) => <span className="text-sm text-gray-500">{m._count.contacts}</span> },
 ];
 
-type StatusFilter = "ACTIVE" | "CLOSED" | "ARCHIVED" | "";
+type StatusFilter = MatterStatus | "";
 type NamedOption = { id: string; name: string };
 
 interface MatterForm {


### PR DESCRIPTION
Del av strong-typing-svepet (#750), klient-enum-widenings (matter-kluster).

- **matters/page.tsx** — `MatterRow.status`→`MatterStatus`, `StatusFilter`→`MatterStatus | ""`.
- **matters/[id]/_client.tsx** — `HeaderProps.matter.status` + `StatusBadge`→`MatterStatus`, `MatterContact.role`→`MatterRole`.

Editerbara form-typer (contact-forms, `_billing-dialog`-unioner) tas i egen slice.

## Test
Non-incremental `tsc` (root+test) rent, lint grön, matter-tester gröna.

Refs #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)