### PR TITLE
refactor(client): strikta BillingRun*/MatterRole/ContactType (A3c)

### DIFF
--- a/src/app/conflicts/page.tsx
+++ b/src/app/conflicts/page.tsx
@@ -5,21 +5,22 @@ import { DataTable, type Column } from "@/components/ui/data-table";
 import { EntityLink } from "@/lib/client/demo/entity-link";
 import { labelForContactType, labelForMatterRole } from "@/lib/client/labels";
 import { trpc } from "@/lib/client/trpc";
+import type { ContactType, MatterRole } from "@/lib/shared/schemas/enums";
 
 interface ConflictRow {
   contactId: string;
   contactName: string;
-  contactType: string;
+  contactType: ContactType;
   personalNumber?: string | null;
   orgNumber?: string | null;
   matterId: string;
   matterNumber: string;
   matterTitle: string;
-  role: string;
+  role: MatterRole;
   klient?: string | null;
 }
 
-function rolePillClass(role: string): string {
+function rolePillClass(role: MatterRole): string {
   if (role === "KLIENT") return "bg-blue-50 text-blue-700";
   if (role === "MOTPART") return "bg-orange-50 text-orange-700";
   if (role === "MOTPARTSOMBUD") return "bg-orange-50 text-orange-600";

--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -21,7 +21,7 @@ import { formatCurrency } from "@/lib/client/utils";
 import type { AppRouter } from "@/lib/server/routers/_app";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { computeRadgivningsavgift } from "@/lib/shared/rattshjalp";
-import { BILLING_RUN_TYPE_LABELS, BILLING_RUN_STATUS_LABELS, type PaymentMethod } from "@/lib/shared/schemas/enums";
+import { BILLING_RUN_TYPE_LABELS, BILLING_RUN_STATUS_LABELS, type BillingRunRecipient, type BillingRunStatus, type BillingRunType, type PaymentMethod } from "@/lib/shared/schemas/enums";
 import { BillingDialog, type BillingMeta } from "./_billing-dialog";
 import { KostnadsrakningModal } from "./_kostnadsrakning-modal";
 import { VerdictDialog } from "./_verdict-dialog";
@@ -45,9 +45,9 @@ interface Props {
 
 interface BillingRunRow {
   id: string;
-  type: string;
-  status: string;
-  recipient: string;
+  type: BillingRunType;
+  status: BillingRunStatus;
+  recipient: BillingRunRecipient;
   amountOre: number;
   createdAt: string | Date;
   invoiceId?: string | null;


### PR DESCRIPTION
Del av strong-typing-svepet (#750), klient display-widenings.

- **_billing-panel.tsx** — `BillingRunRow.type/status/recipient` → `BillingRunType/BillingRunStatus/BillingRunRecipient`.
- **conflicts/page.tsx** — `ConflictRow.contactType/role` + `rolePillClass` → `ContactType/MatterRole`.

Fler klient display-widenings (contacts/users/payment-plans) + editerbara form-typer följer.

Refs #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)