### PR TITLE
refactor(repos): brandat repo-bas-kontrakt + branda alla bas-CRUD-anrop (B0)

### DIFF
--- a/src/bin/server-first.ts
+++ b/src/bin/server-first.ts
@@ -29,6 +29,7 @@ import { buildServerFirstJobHandlers, loadSmtpConfigFromEnv } from "@/lib/server
 import { InMemoryLeaseStore } from "@/lib/server/lease/lease-store";
 import { loadLlmConfigFromEnv } from "@/lib/server/llm/ollama-classifier";
 import { serveFetchHandler } from "@/lib/shared/http/node-http-adapter";
+import { asId } from "@/lib/shared/schemas/ids";
 
 function log(msg: string): void {
   console.log(`[server-first] ${msg}`);
@@ -93,7 +94,7 @@ function main(): void {
     ...(contentStore ? { content: contentStore } : {}),
     ...(llm ? { llm } : {}),
     // #621 B2: LLM föreslår taggar ur byråns vokabulär (läses lazy per jobb).
-    vocabulary: async () => (await api.repos.organizations.getById(config.organizationId))?.documentTags ?? [],
+    vocabulary: async () => (await api.repos.organizations.getById(asId<"OrganizationId">(config.organizationId)))?.documentTags ?? [],
   });
   void startJobRuntime({ connectionString: config.databaseUrl, handlers })
     .then((rt) => { jobRuntime = rt; log(`jobb-kö startad (pg-boss; ${Object.keys(handlers).length} handlers)`); })

--- a/src/lib/server/jobs/handlers/classify-document-handler.ts
+++ b/src/lib/server/jobs/handlers/classify-document-handler.ts
@@ -13,12 +13,13 @@
 import { z } from "zod";
 import { type DocumentKind, guessFromFilename } from "@/lib/shared/document-kind";
 import type { Document } from "@/lib/shared/schemas/document";
+import { documentIdSchema, organizationIdSchema } from "@/lib/shared/schemas/ids";
 import type { DocumentRepository } from "../../repositories/document-repository";
 import type { JobHandler } from "../job-worker-runtime";
 
 const classifyJobSchema = z.object({
-  documentId: z.string(),
-  organizationId: z.string().optional(),
+  documentId: documentIdSchema,
+  organizationId: organizationIdSchema.optional(),
 });
 
 /** Dokument-fälten klassificeraren behöver (filnamn + var bytes ligger). */

--- a/src/lib/server/repositories/drizzle-invoice-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-repository.ts
@@ -179,7 +179,7 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
   }
 
   async getByIdWithLedger(id: string): Promise<InvoiceWithLedger | null> {
-    const invoice = await this.getById(id);
+    const invoice = await this.getById(asId<"InvoiceId">(id));
     if (!invoice) return null;
     const pays = await this.db.select().from(payments).where(eq(payments.invoiceId, asId<"InvoiceId">(id)));
     const wos = await this.db.select().from(writeOffs).where(eq(writeOffs.invoiceId, asId<"InvoiceId">(id)));

--- a/src/lib/server/repositories/drizzle-repository.ts
+++ b/src/lib/server/repositories/drizzle-repository.ts
@@ -68,14 +68,14 @@ export class DrizzleRepository<Row extends RowBase> implements Repository<Row> {
     return raw as Row[];
   }
 
-  async getById(id: string): Promise<Row | null> {
+  async getById(id: Row["id"]): Promise<Row | null> {
     const rows = await this.db
       .select().from(this.table)
       .where(and(eq(this.table.id, id), isNull(this.table.deletedAt))).limit(1);
     return this.asRow(rows[0]);
   }
 
-  async getByIdOrThrow(id: string): Promise<Row> {
+  async getByIdOrThrow(id: Row["id"]): Promise<Row> {
     const row = await this.getById(id);
     if (!row) throw new Error(`Ingen rad med id ${id}`);
     return row;
@@ -92,7 +92,7 @@ export class DrizzleRepository<Row extends RowBase> implements Repository<Row> {
     return this.asRow(row) as Row;
   }
 
-  async update(id: string, patch: Partial<Row>): Promise<Row> {
+  async update(id: Row["id"], patch: Partial<Row>): Promise<Row> {
     const current = await this.getByIdOrThrow(id);
     const [row] = await this.db.update(this.table)
       .set({ ...patch, version: nextVersion(current), updatedAt: this.now() } as never)
@@ -102,7 +102,7 @@ export class DrizzleRepository<Row extends RowBase> implements Repository<Row> {
   }
 
   /** Metadata-skrivning utan version-bump (se `Repository.updateMetadata`). */
-  async updateMetadata(id: string, patch: Partial<Row>): Promise<Row> {
+  async updateMetadata(id: Row["id"], patch: Partial<Row>): Promise<Row> {
     await this.getByIdOrThrow(id);
     const [row] = await this.db.update(this.table)
       .set({ ...patch, updatedAt: this.now() } as never)
@@ -111,7 +111,7 @@ export class DrizzleRepository<Row extends RowBase> implements Repository<Row> {
     return this.asRow(row) as Row;
   }
 
-  async softDelete(id: string): Promise<Row> {
+  async softDelete(id: Row["id"]): Promise<Row> {
     const current = await this.getByIdOrThrow(id);
     const [row] = await this.db.update(this.table)
       .set({ deletedAt: this.now(), version: nextVersion(current) } as never)
@@ -121,7 +121,7 @@ export class DrizzleRepository<Row extends RowBase> implements Repository<Row> {
   }
 
   /** Hård delete — se `Repository.hardDelete` (medvetet ADR 0017-undantag). */
-  async hardDelete(id: string): Promise<void> {
+  async hardDelete(id: Row["id"]): Promise<void> {
     await this.db.delete(this.table).where(eq(this.table.id, id));
   }
 

--- a/src/lib/server/repositories/in-memory-invoice-repository.ts
+++ b/src/lib/server/repositories/in-memory-invoice-repository.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Invoice } from "@/lib/shared/schemas/billing";
+import { asId } from "@/lib/shared/schemas/ids";
 import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import {
@@ -67,7 +68,7 @@ export class InMemoryInvoiceRepository extends InMemoryRepository<Invoice> imple
   }
 
   async getByIdWithLedger(id: string): Promise<InvoiceWithLedger | null> {
-    const invoice = await this.getById(id);
+    const invoice = await this.getById(asId<"InvoiceId">(id));
     if (!invoice) return null;
     const payments = (await this.store.payments
       .findMany({ where: { invoiceId: id } })) as InvoiceWithLedger["payments"];

--- a/src/lib/server/repositories/in-memory-repository.ts
+++ b/src/lib/server/repositories/in-memory-repository.ts
@@ -19,12 +19,12 @@ export class InMemoryRepository<Row extends RowBase> implements Repository<Row> 
   ) {}
 
   /** Hämta icke-mjukraderad rad (frånvarande `deletedAt` = ej raderad). */
-  async getById(id: string): Promise<Row | null> {
+  async getById(id: Row["id"]): Promise<Row | null> {
     const row = (await this.delegate.findFirst({ where: { id } })) as Row | null;
     return row && !row.deletedAt ? row : null;
   }
 
-  async getByIdOrThrow(id: string): Promise<Row> {
+  async getByIdOrThrow(id: Row["id"]): Promise<Row> {
     const row = await this.getById(id);
     if (!row) throw new Error(`Ingen rad med id ${id}`);
     return row;
@@ -34,27 +34,27 @@ export class InMemoryRepository<Row extends RowBase> implements Repository<Row> 
     return (await this.delegate.create({ data: { version: 1, ...data } as Partial<Row> })) as Row;
   }
 
-  async update(id: string, patch: Partial<Row>): Promise<Row> {
+  async update(id: Row["id"], patch: Partial<Row>): Promise<Row> {
     const current = await this.getByIdOrThrow(id);
     const data = { ...patch, version: (current.version ?? 1) + 1, updatedAt: this.now() } as Partial<Row>;
     return (await this.delegate.update({ where: { id }, data })) as Row;
   }
 
   /** Metadata-skrivning utan version-bump (se `Repository.updateMetadata`). */
-  async updateMetadata(id: string, patch: Partial<Row>): Promise<Row> {
+  async updateMetadata(id: Row["id"], patch: Partial<Row>): Promise<Row> {
     await this.getByIdOrThrow(id);
     const data = { ...patch, updatedAt: this.now() } as Partial<Row>;
     return (await this.delegate.update({ where: { id }, data })) as Row;
   }
 
-  async softDelete(id: string): Promise<Row> {
+  async softDelete(id: Row["id"]): Promise<Row> {
     const current = await this.getByIdOrThrow(id);
     const data = { deletedAt: this.now(), version: (current.version ?? 1) + 1 } as Partial<Row>;
     return (await this.delegate.update({ where: { id }, data })) as Row;
   }
 
   /** Hård delete — se `Repository.hardDelete` (medvetet ADR 0017-undantag). */
-  async hardDelete(id: string): Promise<void> {
+  async hardDelete(id: Row["id"]): Promise<void> {
     await this.delegate.delete({ where: { id } });
   }
 }

--- a/src/lib/server/repositories/types.ts
+++ b/src/lib/server/repositories/types.ts
@@ -9,9 +9,14 @@
  * Entitets-repositories + Drizzle-impl följer per-entitet (fan-out).
  */
 
-/** Minsta form en repository-rad har (reconcile-konventioner, ADR 0017/0019). */
-export interface RowBase {
-  id: string;
+/**
+ * Minsta form en repository-rad har (reconcile-konventioner, ADR 0017/0019).
+ * Generisk över id-brandet (`Id`) så bas-CRUD branda hela vägen ner: en entitet
+ * med `id: MatterId` ger `Repository<Matter>` brandade `getById(id: MatterId)` osv.
+ * — ingen naken `string` i id-vägen ([[feedback-minimize-raw-string]]).
+ */
+export interface RowBase<Id extends string = string> {
+  id: Id;
   version?: number;
   createdAt?: Date | string;
   updatedAt?: Date | string;
@@ -21,13 +26,13 @@ export interface RowBase {
 /**
  * Bas-CRUD som varje entitets-repository ärver. Entiteter LÄGGER TILL egna
  * typade metoder (t.ex. `invoices.getByIdWithLedger`, `matters.listByOrg`) —
- * inga dynamiska arg-objekt.
+ * inga dynamiska arg-objekt. `Id` härleds ur radens brandade `id`.
  */
-export interface Repository<Row extends RowBase> {
-  getById(id: string): Promise<Row | null>;
-  getByIdOrThrow(id: string): Promise<Row>;
+export interface Repository<Row extends RowBase, Id extends string = Row["id"]> {
+  getById(id: Id): Promise<Row | null>;
+  getByIdOrThrow(id: Id): Promise<Row>;
   create(data: Partial<Row>): Promise<Row>;
-  update(id: string, patch: Partial<Row>): Promise<Row>;
+  update(id: Id, patch: Partial<Row>): Promise<Row>;
   /**
    * Uppdatera metadata UTAN att bumpa `version`. `version` är radens
    * INNEHÅLLS-version (för dokument: ADR 0023) — den bumpas BARA av faktiska
@@ -36,14 +41,14 @@ export interface Repository<Row extends RowBase> {
    * INTE och får därför inte bumpa versionen. `updatedAt` uppdateras dock
    * fortfarande (radens senaste skrivning), och ändringen delta-synkas som vanligt.
    */
-  updateMetadata(id: string, patch: Partial<Row>): Promise<Row>;
+  updateMetadata(id: Id, patch: Partial<Row>): Promise<Row>;
   /** Mjuk delete (sätter `deletedAt`, bumpar `version`) — tombstone, ADR 0017. */
-  softDelete(id: string): Promise<Row>;
+  softDelete(id: Id): Promise<Row>;
   /**
    * Hård delete (tar bort raden helt). MEDVETEN ADR 0017-undantag: en hård
    * delete kan inte reconcile:as/replikeras (raden bara försvinner). Använd
    * BARA där en unik-constraint kräver det (t.ex. PaymentPlan.invoiceId @unique
    * när en gammal CANCELLED-plan måste ge plats åt en ny). Default = softDelete.
    */
-  hardDelete(id: string): Promise<void>;
+  hardDelete(id: Id): Promise<void>;
 }

--- a/src/lib/server/routers/document/core.ts
+++ b/src/lib/server/routers/document/core.ts
@@ -10,7 +10,7 @@ import { base64ToBytes, bytesToBase64, contentStoragePath, sha256Hex } from "@/l
 import { isJunkFileName } from "@/lib/shared/junk-files";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { documentAnalysisStatusSchema, type Document } from "@/lib/shared/schemas/document";
-import { asId } from "@/lib/shared/schemas/ids";
+import { asId, documentFolderIdSchema, documentIdSchema, invoiceIdSchema, matterIdSchema, userIdSchema } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { orgProcedure } from "../../trpc";
 import { assertDocAccess } from "./shared";
@@ -20,8 +20,8 @@ export const coreProcedures = {
   list: orgProcedure
     .input(
       z.object({
-        matterId: z.string(),
-        folderId: z.string().nullable().default(null),
+        matterId: matterIdSchema,
+        folderId: documentFolderIdSchema.nullable().default(null),
         page: z.number().min(1).default(1),
         pageSize: z.number().min(1).max(100).default(50),
       }),
@@ -37,7 +37,7 @@ export const coreProcedures = {
 
   /** Komplett träd (alla mappar + dokument) för ett ärende i en query. */
   tree: orgProcedure
-    .input(z.object({ matterId: z.string() }))
+    .input(z.object({ matterId: matterIdSchema }))
     .query(async ({ ctx, input }) => {
       const [folders, documents] = await Promise.all([
         ctx.repos.documentFolders.listByMatter(input.matterId),
@@ -83,7 +83,7 @@ export const coreProcedures = {
     .query(({ ctx }) => ctx.repos.documents.listDocumentTypesForOrg(ctx.orgId)),
 
   delete: orgProcedure
-    .input(z.object({ id: z.string() }))
+    .input(z.object({ id: documentIdSchema }))
     .mutation(async ({ ctx, input }) => {
       const doc = await assertDocAccess(ctx, input.id);
       await ctx.repos.documents.hardDelete(input.id);
@@ -100,16 +100,16 @@ export const coreProcedures = {
    */
   register: orgProcedure
     .input(z.object({
-      id: z.string(),
-      matterId: z.string(),
+      id: documentIdSchema,
+      matterId: matterIdSchema,
       fileName: z.string(),
       mimeType: z.string(),
       sizeBytes: z.number(),
       storagePath: z.string(),
-      folderId: z.string().nullable().optional(),
+      folderId: documentFolderIdSchema.nullable().optional(),
       // Valfri AI-analys-metadata + setup-fält (demo-generator/fixtures,
       // ADR 0003). I appens upload-flöde sätts analysen async av `analyze`.
-      uploadedById: z.string().optional(),
+      uploadedById: userIdSchema.optional(),
       version: z.number().int().positive().optional(),
       title: z.string().nullable().optional(),
       documentType: z.string().nullable().optional(),
@@ -118,7 +118,7 @@ export const coreProcedures = {
       analyzedAt: z.string().optional(),
       createdAt: z.string().optional(),
       /** Koppla dokumentet till en faktura (t.ex. genererad faktura/underlag). */
-      invoiceId: z.string().nullable().optional(),
+      invoiceId: invoiceIdSchema.nullable().optional(),
     }))
     .mutation(async ({ ctx, input }) => {
       // Verifiera matter:n tillhör org:n
@@ -148,7 +148,7 @@ export const coreProcedures = {
 
   /** Kör (eller kör om) AI-analys på ett dokument. Returnerar omedelbart. */
   analyze: orgProcedure
-    .input(z.object({ documentId: z.string() }))
+    .input(z.object({ documentId: documentIdSchema }))
     .mutation(async ({ ctx, input }) => {
       await assertDocAccess(ctx, input.documentId);
       // Fire-and-forget — användaren får svar direkt; UI pollar för resultat.
@@ -167,7 +167,7 @@ export const coreProcedures = {
    */
   uploadContent: orgProcedure
     .input(z.object({
-      documentId: z.string(),
+      documentId: documentIdSchema,
       contentBase64: z.string(),
       /**
        * Optimistisk version (ADR 0033 §1): versionen klienten redigerade från.
@@ -210,7 +210,7 @@ export const coreProcedures = {
    * resultatet innehålls-adresserat (immutabelt → cacha för evigt).
    */
   downloadContent: orgProcedure
-    .input(z.object({ documentId: z.string() }))
+    .input(z.object({ documentId: documentIdSchema }))
     .query(async ({ ctx, input }) => {
       await assertDocAccess(ctx, input.documentId);
       const doc = (await ctx.repos.documents.getById(input.documentId)) as Document | null;
@@ -230,7 +230,7 @@ export const coreProcedures = {
    */
   saveConflictCopy: orgProcedure
     .input(z.object({
-      documentId: z.string(),
+      documentId: documentIdSchema,
       contentBase64: z.string(),
       /** Lokal tidsstämpel-etikett för kopians namn (klienten kan lokal tid). */
       label: z.string().min(1).max(40),
@@ -282,7 +282,7 @@ export const coreProcedures = {
   updateMetadata: orgProcedure
     .input(
       z.object({
-        documentId: z.string(),
+        documentId: documentIdSchema,
         title: z.string().nullable().optional(),
         documentType: z.string().nullable().optional(),
         summary: z.string().nullable().optional(),
@@ -317,7 +317,7 @@ export const coreProcedures = {
    * konsekvent. Etiketter är metadata → bumpar INTE versionen (#619).
    */
   setTags: orgProcedure
-    .input(z.object({ documentId: z.string(), tags: z.array(z.string()) }))
+    .input(z.object({ documentId: documentIdSchema, tags: z.array(z.string()) }))
     .mutation(async ({ ctx, input }) => {
       await assertDocAccess(ctx, input.documentId);
       const org = await ctx.repos.organizations.getById(ctx.orgId);
@@ -341,7 +341,7 @@ export const coreProcedures = {
   markExternallyEdited: orgProcedure
     .input(
       z.object({
-        id: z.string(),
+        id: documentIdSchema,
         saves: z.number().int().min(1),
         sessionStartedAt: z.union([z.string(), z.date()]),
         sizeBytes: z.number().int().min(0).optional(),

--- a/src/lib/server/routers/document/suggestions.ts
+++ b/src/lib/server/routers/document/suggestions.ts
@@ -296,7 +296,7 @@ export const suggestionProcedures = {
 
       await ensureMatterContactLink(ctx, matterId, contactId, finalRole, sugg.notes);
       await ctx.repos.documentAnalysisSuggestions.update(
-        sugg.id, { status: "ACCEPTED", acceptedContactId: contactId } as Partial<DocumentAnalysisSuggestion>,
+        asId<"DocumentAnalysisSuggestionId">(sugg.id), { status: "ACCEPTED", acceptedContactId: contactId } as Partial<DocumentAnalysisSuggestion>,
       );
       return { contactId };
     }),

--- a/src/lib/server/routers/invoiceDispatch.ts
+++ b/src/lib/server/routers/invoiceDispatch.ts
@@ -32,7 +32,7 @@ async function assertInvoiceInOrg(ctx: DispatchCtx, invoiceId: string): Promise<
  */
 async function markSentIfDraft(ctx: DispatchCtx, inv: { id: string; status: string }): Promise<void> {
   if (inv.status !== "DRAFT" || !canTransition("DRAFT", "SENT")) return;
-  await ctx.repos.invoices.update(inv.id, { status: "SENT" satisfies InvoiceStatus });
+  await ctx.repos.invoices.update(asId<"InvoiceId">(inv.id), { status: "SENT" satisfies InvoiceStatus });
 }
 
 /** Tidsstämpelfältet som en statusövergång sätter (queued sätts vid skapande). */

--- a/src/lib/server/routers/organization.ts
+++ b/src/lib/server/routers/organization.ts
@@ -2,7 +2,7 @@ import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { ledgerAccountMapSchema } from "@/lib/shared/accounting/account-map";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
-import { organizationIdSchema, asId } from "@/lib/shared/schemas/ids";
+import { officeIdSchema, organizationIdSchema, asId } from "@/lib/shared/schemas/ids";
 import type { Office, Organization } from "@/lib/shared/schemas/organization";
 import { router, protectedProcedure } from "../trpc";
 
@@ -36,7 +36,7 @@ export const organizationRouter = router({
 
   // Migrerad till repository-sömmen (ADR 0020). Org är rot-entiteten (scope:n).
   getSettings: protectedProcedure.query(async ({ ctx }) => {
-    const org = await ctx.repos.organizations.getById(ctx.user.organizationId);
+    const org = await ctx.repos.organizations.getById(asId<"OrganizationId">(ctx.user.organizationId));
     if (!org) throw new TRPCError({ code: "NOT_FOUND" });
     return toOrgSettings(org);
   }),
@@ -63,7 +63,7 @@ export const organizationRouter = router({
       if (patch.documentTags) {
         patch.documentTags = [...new Set(patch.documentTags.map((t) => t.trim()).filter(Boolean))];
       }
-      return ctx.repos.organizations.update(ctx.user.organizationId, patch satisfies Partial<Organization>);
+      return ctx.repos.organizations.update(asId<"OrganizationId">(ctx.user.organizationId), patch satisfies Partial<Organization>);
     }),
 
   /**
@@ -116,7 +116,7 @@ export const organizationRouter = router({
   updateOffice: protectedProcedure
     .input(
       z.object({
-        id: organizationIdSchema,
+        id: officeIdSchema,
         name: z.string().min(1).optional(),
         address: z.string().optional(),
         phone: z.string().optional(),
@@ -134,7 +134,7 @@ export const organizationRouter = router({
     }),
 
   deleteOffice: protectedProcedure
-    .input(z.object({ id: organizationIdSchema }))
+    .input(z.object({ id: officeIdSchema }))
     .mutation(async ({ ctx, input }) => {
       const office = await ctx.repos.offices.getByIdInOrg(input.id, ctx.user.organizationId);
       if (!office) throw new TRPCError({ code: "NOT_FOUND" });

--- a/test/unit/client/backend/server-first-store.test.ts
+++ b/test/unit/client/backend/server-first-store.test.ts
@@ -16,6 +16,7 @@ import { createDbChangeLogRecorder, enableChangeLogOnAll } from "@/lib/server/re
 import { buildDrizzleRepositories } from "@/lib/server/repositories/drizzle-repositories";
 import type { Repositories } from "@/lib/server/repositories/repositories";
 import { DrizzleSyncStore } from "@/lib/server/sync/drizzle-sync-store";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../../server/db/pg-test-db";
 
@@ -71,6 +72,6 @@ describe("createServerFirstStore (#2b)", () => {
 
     await ds.reconcile();
     expect(ds.pendingCount()).toBe(0); // pushad + ack:ad
-    expect(await repos.matters.getById(m2)).toMatchObject({ id: m2, title: "Klient-ärende" }); // server fick den
+    expect(await repos.matters.getById(asId<"MatterId">(m2))).toMatchObject({ id: m2, title: "Klient-ärende" }); // server fick den
   });
 });

--- a/test/unit/client/sync/trpc-sync-transport.test.ts
+++ b/test/unit/client/sync/trpc-sync-transport.test.ts
@@ -17,6 +17,7 @@ import { buildDrizzleRepositories } from "@/lib/server/repositories/drizzle-repo
 import type { Repositories } from "@/lib/server/repositories/repositories";
 import type { AppRouter } from "@/lib/server/routers/_app";
 import { DrizzleSyncStore } from "@/lib/server/sync/drizzle-sync-store";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../../server/db/pg-test-db";
 
@@ -79,6 +80,6 @@ describe("TrpcSyncTransport (#sync-bridge, end-to-end)", () => {
     };
     const res = await transport.push(mutation);
     expect(res.status).toBe("accepted");
-    expect(await repos.contacts.getById(c1)).toMatchObject({ id: c1, name: "E2E-kontakt" });
+    expect(await repos.contacts.getById(asId<"ContactId">(c1))).toMatchObject({ id: c1, name: "E2E-kontakt" });
   });
 });

--- a/test/unit/server/http/server-first-http-e2e.test.ts
+++ b/test/unit/server/http/server-first-http-e2e.test.ts
@@ -26,6 +26,7 @@ import type { Repositories } from "@/lib/server/repositories/repositories";
 import type { AppRouter } from "@/lib/server/routers/_app";
 import { DrizzleSyncStore } from "@/lib/server/sync/drizzle-sync-store";
 import { serveFetchHandler } from "@/lib/shared/http/node-http-adapter";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
@@ -116,7 +117,7 @@ describe("server-first E2E över riktig HTTP-socket (#470)", () => {
       row: { id: c1, organizationId: ORG, name: "Wire-kontakt" }, enqueuedAt: 0,
     };
     expect((await transport.push(mutation)).status).toBe("accepted");
-    expect(await repos.contacts.getById(c1)).toMatchObject({ id: c1, name: "Wire-kontakt" });
+    expect(await repos.contacts.getById(asId<"ContactId">(c1))).toMatchObject({ id: c1, name: "Wire-kontakt" });
   });
 
   it("orgProcedure-grind: ingen forwarded identitet → klienten kastar", async () => {

--- a/test/unit/server/repositories/acconto-deduction-repository.test.ts
+++ b/test/unit/server/repositories/acconto-deduction-repository.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { DrizzleAccontoDeductionRepository } from "@/lib/server/repositories/drizzle-acconto-deduction-repository";
 import { InMemoryAccontoDeductionRepository } from "@/lib/server/repositories/in-memory-acconto-deduction-repository";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
@@ -17,7 +18,7 @@ describe("AccontoDeductionRepository — in-memory", () => {
     const id = uuidv7();
     const created = await repo.create({ id, finalInvoiceId: uuidv7(), accontoInvoiceId: uuidv7() } as never);
     expect((created as { version?: number }).version).toBe(1);
-    expect(await repo.getById(id)).toMatchObject({ id });
+    expect(await repo.getById(asId<"AccontoDeductionId">(id))).toMatchObject({ id });
   });
 });
 
@@ -31,6 +32,6 @@ describe("AccontoDeductionRepository — Drizzle (pglite)", () => {
     const id = uuidv7();
     const created = await repo.create({ id, finalInvoiceId: uuidv7(), accontoInvoiceId: uuidv7() } as never);
     expect((created as { version?: number }).version).toBe(1);
-    expect(await repo.getById(id)).toMatchObject({ id });
+    expect(await repo.getById(asId<"AccontoDeductionId">(id))).toMatchObject({ id });
   });
 });

--- a/test/unit/server/repositories/document-repository.test.ts
+++ b/test/unit/server/repositories/document-repository.test.ts
@@ -12,6 +12,7 @@ import { DrizzleDocumentRepository } from "@/lib/server/repositories/drizzle-doc
 import { InMemoryDocumentFolderRepository } from "@/lib/server/repositories/in-memory-document-folder-repository";
 import { InMemoryDocumentRepository } from "@/lib/server/repositories/in-memory-document-repository";
 import { prebakeJoins } from "@/lib/shared/demo-source";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
@@ -59,7 +60,7 @@ describe("DocumentRepository / DocumentFolderRepository — in-memory", () => {
     await docs.reassignFolder(root, null);
     expect((await docs.listInFolder(mId, root, 1, 50)).total).toBe(0);
     await folders.reassignParent(root, null);
-    expect((await folders.getById(sub))!.parentId).toBeNull();
+    expect((await folders.getById(asId<"DocumentFolderId">(sub)))!.parentId).toBeNull();
   });
 });
 
@@ -106,6 +107,6 @@ describe("DocumentRepository / DocumentFolderRepository — Drizzle (pglite)", (
     await docs.reassignFolder(root, null);
     expect((await docs.listInFolder(mId, root, 1, 50)).total).toBe(0);
     await folders.reassignParent(root, null);
-    expect((await folders.getById(sub))!.parentId).toBeNull();
+    expect((await folders.getById(asId<"DocumentFolderId">(sub)))!.parentId).toBeNull();
   });
 });

--- a/test/unit/server/repositories/drizzle-repositories.test.ts
+++ b/test/unit/server/repositories/drizzle-repositories.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import { buildDrizzleRepositories } from "@/lib/server/repositories/drizzle-repositories";
+import { asId } from "@/lib/shared/schemas/ids";
 import type { Organization } from "@/lib/shared/schemas/organization";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
@@ -39,7 +40,7 @@ describe("buildDrizzleRepositories — kontrakt (pglite)", () => {
     const id = uuidv7();
     const created = await repos.organizations.create(org(id, "Aggregat AB"));
     expect((created as { version?: number }).version).toBe(1);
-    expect(await repos.organizations.getById(id)).toMatchObject({ id, name: "Aggregat AB" });
+    expect(await repos.organizations.getById(asId<"OrganizationId">(id))).toMatchObject({ id, name: "Aggregat AB" });
   });
 
   it("create utan id → genererar ett uuid (server-genererad create, #630)", async () => {
@@ -50,14 +51,14 @@ describe("buildDrizzleRepositories — kontrakt (pglite)", () => {
     const created = await repos.contacts.create({ organizationId: orgId, name: "Utan id", contactType: "PERSON" } as never);
     const id = (created as { id?: string }).id;
     expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
-    expect(await repos.contacts.getById(id!)).toMatchObject({ name: "Utan id" });
+    expect(await repos.contacts.getById(asId<"ContactId">(id!))).toMatchObject({ name: "Utan id" });
   });
 
   it("transaction committar vid success", async () => {
     const repos = buildDrizzleRepositories(handle.db);
     const id = uuidv7();
     await repos.transaction(async (tx) => { await tx.organizations.create(org(id)); });
-    expect(await repos.organizations.getById(id)).toMatchObject({ id });
+    expect(await repos.organizations.getById(asId<"OrganizationId">(id))).toMatchObject({ id });
   });
 
   it("transaction rullar tillbaka vid kast (inget delvis committat)", async () => {
@@ -69,7 +70,7 @@ describe("buildDrizzleRepositories — kontrakt (pglite)", () => {
         throw new Error("boom");
       }),
     ).rejects.toThrow("boom");
-    expect(await repos.organizations.getById(id)).toBeNull();
+    expect(await repos.organizations.getById(asId<"OrganizationId">(id))).toBeNull();
   });
 
   it("nästlad transaction är reentrant (delar samma tx → committar tillsammans)", async () => {
@@ -80,7 +81,7 @@ describe("buildDrizzleRepositories — kontrakt (pglite)", () => {
       await tx.organizations.create(org(a, "Yttre"));
       await tx.transaction(async (inner) => { await inner.organizations.create(org(b, "Inre")); });
     });
-    expect(await repos.organizations.getById(a)).toMatchObject({ id: a });
-    expect(await repos.organizations.getById(b)).toMatchObject({ id: b });
+    expect(await repos.organizations.getById(asId<"OrganizationId">(a))).toMatchObject({ id: a });
+    expect(await repos.organizations.getById(asId<"OrganizationId">(b))).toMatchObject({ id: b });
   });
 });

--- a/test/unit/server/repositories/invoice-repository.test.ts
+++ b/test/unit/server/repositories/invoice-repository.test.ts
@@ -13,6 +13,7 @@ import {
 import { DrizzleInvoiceRepository } from "@/lib/server/repositories/drizzle-invoice-repository";
 import { InMemoryInvoiceRepository } from "@/lib/server/repositories/in-memory-invoice-repository";
 import type { InvoiceRepository } from "@/lib/server/repositories/invoice-repository";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
@@ -31,17 +32,17 @@ async function assertContract(repo: InvoiceRepository): Promise<void> {
   expect(created.amount).toBe(100_000);
   expect((created as { version?: number }).version).toBe(1);
 
-  expect(await repo.getById(invId)).toMatchObject({ id: invId, status: "DRAFT" });
-  expect(await repo.getById(uuidv7())).toBeNull();
+  expect(await repo.getById(asId<"InvoiceId">(invId))).toMatchObject({ id: invId, status: "DRAFT" });
+  expect(await repo.getById(asId<"InvoiceId">(uuidv7()))).toBeNull();
 
   expect((await repo.listByMatter(matterId)).map((i) => i.id)).toContain(invId);
 
-  const updated = await repo.update(invId, { status: "SENT" });
+  const updated = await repo.update(asId<"InvoiceId">(invId), { status: "SENT" });
   expect(updated.status).toBe("SENT");
   expect((updated as { version?: number }).version).toBe(2);
 
-  await repo.softDelete(invId);
-  expect(await repo.getById(invId)).toBeNull();
+  await repo.softDelete(asId<"InvoiceId">(invId));
+  expect(await repo.getById(asId<"InvoiceId">(invId))).toBeNull();
   expect(await repo.listByMatter(matterId)).toHaveLength(0);
 }
 

--- a/test/unit/server/repositories/matter-repository.test.ts
+++ b/test/unit/server/repositories/matter-repository.test.ts
@@ -10,6 +10,7 @@ import { matters } from "@/lib/server/db/schema";
 import { DrizzleMatterRepository } from "@/lib/server/repositories/drizzle-matter-repository";
 import { InMemoryMatterRepository } from "@/lib/server/repositories/in-memory-matter-repository";
 import type { MatterRepository } from "@/lib/server/repositories/matter-repository";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
@@ -25,15 +26,15 @@ async function assertContract(repo: MatterRepository): Promise<void> {
   expect(created.matterNumber).toBe("2026-0001");
   expect((created as { version?: number }).version).toBe(1);
 
-  expect(await repo.getById(matterId)).toMatchObject({ id: matterId });
-  expect(await repo.getById(uuidv7())).toBeNull();
+  expect(await repo.getById(asId<"MatterId">(matterId))).toMatchObject({ id: matterId });
+  expect(await repo.getById(asId<"MatterId">(uuidv7()))).toBeNull();
 
-  const updated = await repo.update(matterId, { title: "Ny titel" });
+  const updated = await repo.update(asId<"MatterId">(matterId), { title: "Ny titel" });
   expect(updated.title).toBe("Ny titel");
   expect((updated as { version?: number }).version).toBe(2);
 
-  await repo.softDelete(matterId);
-  expect(await repo.getById(matterId)).toBeNull();
+  await repo.softDelete(asId<"MatterId">(matterId));
+  expect(await repo.getById(asId<"MatterId">(matterId))).toBeNull();
 }
 
 describe("MatterRepository — in-memory", () => {
@@ -63,10 +64,10 @@ describe("MatterRepository — Drizzle (pglite)", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const created = await repo.create({ id, organizationId: org, matterNumber: "2026-9", title: "T" } as any);
     expect((created as { version?: number }).version).toBe(1);
-    const updated = await repo.update(id, { title: "Ny" });
+    const updated = await repo.update(asId<"MatterId">(id), { title: "Ny" });
     expect((updated as { version?: number }).version).toBe(2);
-    await repo.softDelete(id);
-    expect(await repo.getById(id)).toBeNull();
+    await repo.softDelete(asId<"MatterId">(id));
+    expect(await repo.getById(asId<"MatterId">(id))).toBeNull();
   });
 
   it("getByIdInOrg org-scopar direkt på organizationId", async () => {

--- a/test/unit/server/repositories/organization-office-repository.test.ts
+++ b/test/unit/server/repositories/organization-office-repository.test.ts
@@ -9,6 +9,7 @@ import { DrizzleOfficeRepository } from "@/lib/server/repositories/drizzle-offic
 import { DrizzleOrganizationRepository } from "@/lib/server/repositories/drizzle-organization-repository";
 import { InMemoryOfficeRepository } from "@/lib/server/repositories/in-memory-office-repository";
 import { InMemoryOrganizationRepository } from "@/lib/server/repositories/in-memory-organization-repository";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
@@ -25,7 +26,7 @@ describe("Organization/Office — in-memory", () => {
       ],
     }, async () => {});
     const orgRepo = new InMemoryOrganizationRepository(store);
-    expect(await orgRepo.getById(org)).toMatchObject({ id: org });
+    expect(await orgRepo.getById(asId<"OrganizationId">(org))).toMatchObject({ id: org });
     const offRepo = new InMemoryOfficeRepository(store);
     const list = await offRepo.listByOrg(org);
     // In-memory query-engine sorterar inte boolean isMain desc (routern litar på
@@ -54,7 +55,7 @@ describe("Organization/Office — Drizzle (pglite)", () => {
     await db.insert(offices).values(v({ id: main, organizationId: org, name: "Sthlm", isMain: true }));
     await db.insert(offices).values(v({ id: branch, organizationId: org, name: "Gbg", isMain: false }));
     const offRepo = new DrizzleOfficeRepository(handle.db);
-    expect(await new DrizzleOrganizationRepository(handle.db).getById(org)).toMatchObject({ id: org });
+    expect(await new DrizzleOrganizationRepository(handle.db).getById(asId<"OrganizationId">(org))).toMatchObject({ id: org });
     expect((await offRepo.listByOrg(org)).map((o) => o.id)).toEqual([main, branch]);
     expect(await offRepo.getByIdInOrg(branch, org)).toMatchObject({ id: branch });
     expect(await offRepo.getByIdInOrg(branch, uuidv7())).toBeNull();

--- a/test/unit/server/repositories/payment-plan-reminder-repository.test.ts
+++ b/test/unit/server/repositories/payment-plan-reminder-repository.test.ts
@@ -9,6 +9,7 @@ import { paymentPlanReminders } from "@/lib/server/db/schema";
 import { DrizzlePaymentPlanReminderRepository } from "@/lib/server/repositories/drizzle-payment-plan-reminder-repository";
 import { InMemoryPaymentPlanReminderRepository } from "@/lib/server/repositories/in-memory-payment-plan-reminder-repository";
 import type { PaymentPlanReminderRepository } from "@/lib/server/repositories/payment-plan-reminder-repository";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
@@ -20,7 +21,7 @@ async function assertContract(repo: PaymentPlanReminderRepository): Promise<void
   } as any);
   expect(created.dueMonth).toBe("2026-06");
   expect((created as { version?: number }).version).toBe(1);
-  expect(await repo.getById(id)).toMatchObject({ id, type: "DUE" });
+  expect(await repo.getById(asId<"PaymentPlanReminderId">(id))).toMatchObject({ id, type: "DUE" });
 }
 
 describe("PaymentPlanReminderRepository — in-memory", () => {

--- a/test/unit/server/repositories/payment-plan-repository.test.ts
+++ b/test/unit/server/repositories/payment-plan-repository.test.ts
@@ -10,6 +10,7 @@ import { contacts, invoices, matterContacts, matters, paymentPlanReminders, paym
 import { DrizzlePaymentPlanRepository } from "@/lib/server/repositories/drizzle-payment-plan-repository";
 import { InMemoryPaymentPlanRepository } from "@/lib/server/repositories/in-memory-payment-plan-repository";
 import type { PaymentPlanRepository } from "@/lib/server/repositories/payment-plan-repository";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
@@ -28,22 +29,22 @@ async function assertContract(repo: PaymentPlanRepository): Promise<void> {
   expect(created.status).toBe("ACTIVE");
   expect((created as { version?: number }).version).toBe(1);
 
-  expect(await repo.getById(planId)).toMatchObject({ id: planId });
-  expect(await repo.getById(uuidv7())).toBeNull();
+  expect(await repo.getById(asId<"PaymentPlanId">(planId))).toMatchObject({ id: planId });
+  expect(await repo.getById(asId<"PaymentPlanId">(uuidv7()))).toBeNull();
 
-  const updated = await repo.update(planId, { status: "CANCELLED" });
+  const updated = await repo.update(asId<"PaymentPlanId">(planId), { status: "CANCELLED" });
   expect(updated.status).toBe("CANCELLED");
   expect((updated as { version?: number }).version).toBe(2);
 
-  await repo.softDelete(planId);
-  expect(await repo.getById(planId)).toBeNull();
+  await repo.softDelete(asId<"PaymentPlanId">(planId));
+  expect(await repo.getById(asId<"PaymentPlanId">(planId))).toBeNull();
 
   // hardDelete (ADR 0017-undantag, används av createPaymentPlan): raden försvinner helt.
   const hardId = uuidv7();
   await repo.create(plan({ id: hardId }));
-  expect(await repo.getById(hardId)).toMatchObject({ id: hardId });
-  await repo.hardDelete(hardId);
-  expect(await repo.getById(hardId)).toBeNull();
+  expect(await repo.getById(asId<"PaymentPlanId">(hardId))).toMatchObject({ id: hardId });
+  await repo.hardDelete(asId<"PaymentPlanId">(hardId));
+  expect(await repo.getById(asId<"PaymentPlanId">(hardId))).toBeNull();
 }
 
 describe("PaymentPlanRepository — in-memory", () => {

--- a/test/unit/server/repositories/repos-wiring.test.ts
+++ b/test/unit/server/repositories/repos-wiring.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect } from "vitest-compat";
 import { noopPorts } from "@/lib/server/adapters/noop-ports";
 import { buildContext } from "@/lib/server/build-context";
 import { DemoDataStore } from "@/lib/server/data-store/DemoDataStore";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -30,7 +31,7 @@ describe("buildContext — repos-wiring", () => {
     expect(ctx.repos).toBeDefined();
     const created = await ctx.repos.invoices.create(inv(id, matterId));
     expect(created.amount).toBe(1_000);
-    expect(await ctx.repos.invoices.getById(id)).toMatchObject({ id });
+    expect(await ctx.repos.invoices.getById(asId<"InvoiceId">(id))).toMatchObject({ id });
     expect((await ctx.repos.invoices.listByMatter(matterId)).map((i) => i.id)).toContain(id);
   });
 
@@ -43,7 +44,7 @@ describe("buildContext — repos-wiring", () => {
         throw new Error("boom");
       }),
     ).rejects.toThrow("boom");
-    expect(await ctx.repos.invoices.getById(id)).toBeNull(); // rullades tillbaka
+    expect(await ctx.repos.invoices.getById(asId<"InvoiceId">(id))).toBeNull(); // rullades tillbaka
   });
 
   it("ctx.repos.transaction commit:ar vid framgång", async () => {
@@ -52,6 +53,6 @@ describe("buildContext — repos-wiring", () => {
     await ctx.repos.transaction(async (tx) => {
       await tx.invoices.create(inv(id, uuidv7()));
     });
-    expect(await ctx.repos.invoices.getById(id)).toMatchObject({ id });
+    expect(await ctx.repos.invoices.getById(asId<"InvoiceId">(id))).toMatchObject({ id });
   });
 });

--- a/test/unit/server/sync/drizzle-sync-store.test.ts
+++ b/test/unit/server/sync/drizzle-sync-store.test.ts
@@ -9,6 +9,7 @@ import { createDbChangeLogRecorder, enableChangeLogOnAll } from "@/lib/server/re
 import { buildDrizzleRepositories } from "@/lib/server/repositories/drizzle-repositories";
 import type { Repositories } from "@/lib/server/repositories/repositories";
 import { DrizzleSyncStore } from "@/lib/server/sync/drizzle-sync-store";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
@@ -74,7 +75,7 @@ describe("DrizzleSyncStore (#sync-bridge)", () => {
     expect(first.status).toBe("accepted");
     const again = await sync.push(ORG, mut("contact", "create", row));
     expect(again.status).toBe("accepted");
-    expect(await repos.contacts.getById(c1)).toMatchObject({ id: c1, name: "Köad kontakt" });
+    expect(await repos.contacts.getById(asId<"ContactId">(c1))).toMatchObject({ id: c1, name: "Köad kontakt" });
   });
 
   it("push update på surface-entitet med stale baseVersion → conflict", async () => {
@@ -92,7 +93,7 @@ describe("DrizzleSyncStore (#sync-bridge)", () => {
     await sync.push(ORG, mut("matter", "delete", { id: m2 }));
     const change = (await sync.pull(ORG, cursor)).changes.find((c) => c.row.id === m2);
     expect(change).toMatchObject({ entity: "matter", deleted: true });
-    expect(await repos.matters.getById(m2)).toBeNull();
+    expect(await repos.matters.getById(asId<"MatterId">(m2))).toBeNull();
   });
 
   // #528: document/documentFolder saknar org-kolumn → org härleds via ärendet

--- a/tooling/scripts/seed-selfhosted-local.ts
+++ b/tooling/scripts/seed-selfhosted-local.ts
@@ -44,7 +44,7 @@ async function main(): Promise<void> {
   const repos = buildDrizzleRepositories(db);
   enableChangeLogOnAll(repos, createDbChangeLogRecorder(db));
   try {
-    if (!(await repos.organizations.getById(ORG))) {
+    if (!(await repos.organizations.getById(asId<"OrganizationId">(ORG)))) {
       await repos.organizations.create({ id: asId<"OrganizationId">(ORG), name: "Demobyrå AB" } satisfies Partial<Organization>);
     }
     // --demo (#633-uppf.): demo-seeden mappar sin admin + huvud-jurist till


### PR DESCRIPTION
Start på **ID-brandnings-fasen (B)** av strong-typing-svepet (#750). Grundsyn ([feedback]): minimera rå `string` — id-vägen brandad hela vägen ner.

## Kärna
`RowBase<Id>` / `Repository<Row, Id = Row["id"]>` — bas-CRUD (`getById`/`update`/`softDelete`/…) tar nu radens **brandade** id. En entitet med `id: MatterId` ger automatiskt `getById(id: MatterId)`. Bas-impl (in-memory + drizzle) → `Row["id"]`.

## Kaskad (branda anropsställena kontraktet nu kräver)
- **document/core.ts** — ALLA router-id-inputs → `*IdSchema` (documentId/matterId/folderId/uploadedById/invoiceId). Källbrandning fixar 8 bas-CRUD-anrop.
- **classify-document-handler** — `classifyJobSchema` → `documentIdSchema`/`organizationIdSchema`.
- suggestions / invoiceDispatch / organization / bin/server-first / seed / invoice-repos — `asId` vid gräns/intern-anrop.
- **42 test-fixtures** — id-literaler brandade med `asId`.

## 🐛 Bugg fångad
`organization.updateOffice`/`deleteOffice` tog `organizationIdSchema` för ett **kontor**-id → rättat till `officeIdSchema`. Exakt den sortens fel brandning ska fånga.

## Test
Ren `tsc` (root + test, 0 fel), lint grön, 1109 tester gröna.

Refs #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)