### PR TITLE
refactor(repos): branda InvoiceRepository-metodernas id-params (B1-invoice)

### DIFF
--- a/src/lib/server/repositories/invoice-repository.ts
+++ b/src/lib/server/repositories/invoice-repository.ts
@@ -14,6 +14,7 @@ import type {
   AccontoDeduction, Expense, Invoice, Payment, PaymentPlan, PaymentPlanReminder, TimeEntry, WriteOff,
 } from "@/lib/shared/schemas/billing";
 import type { Document } from "@/lib/shared/schemas/document";
+import type { InvoiceId, MatterId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { Matter } from "@/lib/shared/schemas/matter";
 import type { Repository } from "./types";
 
@@ -49,7 +50,7 @@ export interface InvoiceFull extends InvoiceWithRelations {
 
 /** Filter för `listForOrg` (alla optional → org-bred lista). */
 export interface InvoiceListFilter {
-  matterId?: string | undefined;
+  matterId?: MatterId | undefined;
   invoiceType?: Invoice["invoiceType"] | undefined;
   status?: Invoice["status"] | undefined;
 }
@@ -84,23 +85,23 @@ export function nextInvoiceNumberFrom(prefix: string, lastNumber: string | null 
 
 export interface InvoiceRepository extends Repository<Invoice> {
   /** Faktura by id, org-scopad via ärendet (null om saknas/annan org/raderad). */
-  getByIdInOrg(id: string, organizationId: string): Promise<Invoice | null>;
+  getByIdInOrg(id: InvoiceId, organizationId: OrganizationId): Promise<Invoice | null>;
   /** Full faktura-detalj (alla relationer inkl. aconto-avdrag/kredit), org-scopad. */
-  getByIdFull(id: string, organizationId: string): Promise<InvoiceFull | null>;
+  getByIdFull(id: InvoiceId, organizationId: OrganizationId): Promise<InvoiceFull | null>;
   /** Faktura med betalningar + avskrivningar (ledger). Null om saknas/raderad. */
-  getByIdWithLedger(id: string): Promise<InvoiceWithLedger | null>;
+  getByIdWithLedger(id: InvoiceId): Promise<InvoiceWithLedger | null>;
   /** Faktura + huvudrelationer (matter/payments/writeOffs/plan/tid/utlägg/dok), org-scopad. */
-  getByIdWithRelations(id: string, organizationId: string): Promise<InvoiceWithRelations | null>;
+  getByIdWithRelations(id: InvoiceId, organizationId: OrganizationId): Promise<InvoiceWithRelations | null>;
   /** Org-bred fakturalista (listvyns include), nyaste först, valfritt filtrerad. */
-  listForOrg(organizationId: string, filter?: InvoiceListFilter): Promise<InvoiceListRow[]>;
+  listForOrg(organizationId: OrganizationId, filter?: InvoiceListFilter): Promise<InvoiceListRow[]>;
   /** Nästa lediga fakturanummer (`F-YYYY-NNNN`) för org:en (året från repots klocka). */
-  nextInvoiceNumber(organizationId: string): Promise<string>;
+  nextInvoiceNumber(organizationId: OrganizationId): Promise<string>;
   /** Summa krediterat på en faktura: |belopp| av dess kreditnotor, org-scopat (öre). */
-  sumCreditNotesFor(invoiceId: string, organizationId: string): Promise<number>;
+  sumCreditNotesFor(invoiceId: InvoiceId, organizationId: OrganizationId): Promise<number>;
   /** Kreditnotan för en faktura (`creditedInvoiceId = id`) — null om ej krediterad. */
-  getCreditNoteFor(invoiceId: string): Promise<Invoice | null>;
+  getCreditNoteFor(invoiceId: InvoiceId): Promise<Invoice | null>;
   /** Valda ACCONTO-fakturor i ett ärende som ÄNNU INTE dragits av på en FINAL. Tom vid tomma ids. */
-  listDeductibleAccontos(matterId: string, ids: string[]): Promise<Invoice[]>;
+  listDeductibleAccontos(matterId: MatterId, ids: InvoiceId[]): Promise<Invoice[]>;
   /** Alla (icke-raderade) fakturor i ett ärende, nyaste först. */
-  listByMatter(matterId: string): Promise<Invoice[]>;
+  listByMatter(matterId: MatterId): Promise<Invoice[]>;
 }

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -199,7 +199,7 @@ async function invoiceNumbering(
   recipient: BillingRunRecipient,
 ): Promise<{ invoiceNumber: string; ocrReference: string | null } | Record<string, never>> {
   if (recipient === "DOMSTOL") return {};
-  const invoiceNumber = await repos.invoices.nextInvoiceNumber(orgId);
+  const invoiceNumber = await repos.invoices.nextInvoiceNumber(asId<"OrganizationId">(orgId));
   return { invoiceNumber, ocrReference: ocrFromInvoiceNumber(invoiceNumber) };
 }
 

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -61,7 +61,7 @@ async function gatherInvoiceLedger(
   inv: { id: string; amount: number },
 ): Promise<{ paid: number; credited: number; writtenOff: number; ledger: ReturnType<typeof computeInvoiceLedger> }> {
   const paid = await repos.payments.sumByInvoice(inv.id);
-  const credited = await repos.invoices.sumCreditNotesFor(inv.id, orgId);
+  const credited = await repos.invoices.sumCreditNotesFor(asId<"InvoiceId">(inv.id), asId<"OrganizationId">(orgId));
   const writtenOff = await repos.writeOffs.sumByInvoice(inv.id);
   return { paid, credited, writtenOff, ledger: computeInvoiceLedger(inv.amount, paid, credited, writtenOff) };
 }

--- a/src/lib/server/routers/invoiceDispatch.ts
+++ b/src/lib/server/routers/invoiceDispatch.ts
@@ -21,7 +21,7 @@ type DispatchCtx = { repos: Repositories; orgId: string };
 
 /** Verifiera org-tillhörighet + returnera fakturans id/status (repository-sömmen, ADR 0020). */
 async function assertInvoiceInOrg(ctx: DispatchCtx, invoiceId: string): Promise<{ id: string; status: string }> {
-  const inv = await ctx.repos.invoices.getByIdInOrg(invoiceId, ctx.orgId);
+  const inv = await ctx.repos.invoices.getByIdInOrg(asId<"InvoiceId">(invoiceId), asId<"OrganizationId">(ctx.orgId));
   if (!inv) throw new TRPCError({ code: "NOT_FOUND", message: "Fakturan finns inte i organisationen." });
   return inv;
 }

--- a/src/lib/server/routers/reports.ts
+++ b/src/lib/server/routers/reports.ts
@@ -6,7 +6,7 @@ import {
   type FrozenWorkInput,
 } from "@/lib/shared/billed-per-lawyer";
 import type { InvoiceStatus, PaymentMethod } from "@/lib/shared/schemas/enums";
-import { userIdSchema } from "@/lib/shared/schemas/ids";
+import { asId, userIdSchema } from "@/lib/shared/schemas/ids";
 import { router, protectedProcedure } from "../trpc";
 
 /**
@@ -381,7 +381,7 @@ export const reportsRouter = router({
 
       const [user, invoices, billingRuns, timeEntries] = await Promise.all([
         ctx.repos.users.getByIdInOrg(input.userId, org),
-        ctx.repos.invoices.listForOrg(org),
+        ctx.repos.invoices.listForOrg(asId<"OrganizationId">(org)),
         ctx.repos.billingRuns.listForOrg(org),
         ctx.repos.timeEntries.listBillableForOrg(org),
       ]);
@@ -442,7 +442,7 @@ export const reportsRouter = router({
       const toDate = new Date(input.to);
       toDate.setUTCHours(23, 59, 59, 999);
       const org = ctx.user.organizationId;
-      const invoices = await ctx.repos.invoices.listForOrg(org);
+      const invoices = await ctx.repos.invoices.listForOrg(asId<"OrganizationId">(org));
       const ids = (invoices as Array<{ id: string }>).map((i) => i.id);
       const [payments, writeOffs] = await Promise.all([
         ctx.repos.payments.listByInvoiceIds(ids),

--- a/test/unit/server/repositories/invoice-repository.test.ts
+++ b/test/unit/server/repositories/invoice-repository.test.ts
@@ -35,7 +35,7 @@ async function assertContract(repo: InvoiceRepository): Promise<void> {
   expect(await repo.getById(asId<"InvoiceId">(invId))).toMatchObject({ id: invId, status: "DRAFT" });
   expect(await repo.getById(asId<"InvoiceId">(uuidv7()))).toBeNull();
 
-  expect((await repo.listByMatter(matterId)).map((i) => i.id)).toContain(invId);
+  expect((await repo.listByMatter(asId<"MatterId">(matterId))).map((i) => i.id)).toContain(invId);
 
   const updated = await repo.update(asId<"InvoiceId">(invId), { status: "SENT" });
   expect(updated.status).toBe("SENT");
@@ -43,7 +43,7 @@ async function assertContract(repo: InvoiceRepository): Promise<void> {
 
   await repo.softDelete(asId<"InvoiceId">(invId));
   expect(await repo.getById(asId<"InvoiceId">(invId))).toBeNull();
-  expect(await repo.listByMatter(matterId)).toHaveLength(0);
+  expect(await repo.listByMatter(asId<"MatterId">(matterId))).toHaveLength(0);
 }
 
 describe("InvoiceRepository — in-memory", () => {

--- a/test/unit/server/repositories/repos-wiring.test.ts
+++ b/test/unit/server/repositories/repos-wiring.test.ts
@@ -32,7 +32,7 @@ describe("buildContext — repos-wiring", () => {
     const created = await ctx.repos.invoices.create(inv(id, matterId));
     expect(created.amount).toBe(1_000);
     expect(await ctx.repos.invoices.getById(asId<"InvoiceId">(id))).toMatchObject({ id });
-    expect((await ctx.repos.invoices.listByMatter(matterId)).map((i) => i.id)).toContain(id);
+    expect((await ctx.repos.invoices.listByMatter(asId<"MatterId">(matterId))).map((i) => i.id)).toContain(id);
   });
 
   it("ctx.repos.transaction rullar tillbaka vid fel (ärver store-snapshot)", async () => {


### PR DESCRIPTION
ID-brandning per domängrupp (B1, #750). `InvoiceRepository`-kontraktet: `id`/`organizationId`/`invoiceId`/`matterId`-params + `InvoiceListFilter.matterId` → `InvoiceId`/`OrganizationId`/`MatterId`. Anropare brandade (`asId` vid `ctx.orgId`/string-gränser i billingRun/invoice/invoiceDispatch/reports) + 3 test-fixtures.

**Insikt för nästa slice:** `ctx.orgId` är `string` och passas brett → branda den vid källan (tRPC-context) för att kollapsa org-kaskaden innan fler repo-grupper.

## Test
Ren tsc (root+test), lint grön, repo/router-tester gröna.

Refs #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)