### PR TITLE
refactor(auth): branda Principal vid källan (id/role/organizationId) (B1b)

### DIFF
--- a/src/components/shell/demo-bootstrap.tsx
+++ b/src/components/shell/demo-bootstrap.tsx
@@ -39,6 +39,7 @@ import { GitAuthProvider } from "@/lib/server/auth/git-auth-provider";
 import type { IDataStore } from "@/lib/server/data-store/IDataStore";
 import type { CachingSyncDataStore } from "@/lib/server/data-store/in-memory/caching-sync-data-store";
 import { resolveGhPagesUrl } from "@/lib/shared/gh-pages-url";
+import { asId } from "@/lib/shared/schemas/ids";
 import { AppShell } from "./app-shell";
 import { AuthStatusBanner } from "./auth-status-banner";
 import { AutoSync } from "./auto-sync";
@@ -114,12 +115,12 @@ function createDemoTrpcClient(dataStore: IDataStore, firmaConfig: FirmaConfig) {
           // principal → guest-id (datakällan filtrerar bort user-bundna
           // queries tills login gjorts). Self-hosted-seed:en använder
           // "current-user" tills self-hosted-login är implementerad.
-          id: firmaConfig.principalId
-            || (firmaConfig.tier === "self-hosted" ? "current-user" : ""),
+          id: asId<"UserId">(firmaConfig.principalId
+            || (firmaConfig.tier === "self-hosted" ? "current-user" : "")),
           email: firmaConfig.authorEmail,
           name: firmaConfig.authorName,
           role: "ADMIN",
-          organizationId: firmaConfig.organizationId,
+          organizationId: asId<"OrganizationId">(firmaConfig.organizationId),
         }),
       }).createLink(),
     ],

--- a/src/lib/server/auth/git-auth-provider.ts
+++ b/src/lib/server/auth/git-auth-provider.ts
@@ -12,26 +12,27 @@
  * faktiska värden från `.ava/meta.json` + login-flow.
  */
 
+import { asId } from "@/lib/shared/schemas/ids";
 import type { AuthProvider, Principal } from "./principal";
 
 /** Test-fixture: explicit principal som tester ska passera till
  *  `new GitAuthProvider(TEST_PRINCIPAL)`. INTE för produktion. */
 export const TEST_PRINCIPAL: Principal = {
-  id: "00000000-0000-0000-0000-000000000001",
+  id: asId<"UserId">("00000000-0000-0000-0000-000000000001"),
   email: "test@ava.local",
   name: "Test User",
   role: "ADMIN",
-  organizationId: "00000000-0000-0000-0000-000000000000",
+  organizationId: asId<"OrganizationId">("00000000-0000-0000-0000-000000000000"),
 };
 
 /** Neutral fallback när varken config eller test-fixture ges. INGA demo-
  *  identifierare läcks via denna väg. */
 const NEUTRAL_PRINCIPAL: Principal = {
-  id: "",
+  id: asId<"UserId">(""),
   email: "",
   name: "",
   role: "ADMIN",
-  organizationId: "",
+  organizationId: asId<"OrganizationId">(""),
 };
 
 export type GitPrincipalConfig = Partial<Principal>;

--- a/src/lib/server/auth/oidc-auth-provider.ts
+++ b/src/lib/server/auth/oidc-auth-provider.ts
@@ -20,6 +20,8 @@
  *     allowlist-rader får `oidcSubject` satt.
  */
 
+import { userRoleSchema } from "@/lib/shared/schemas/enums";
+import { asId } from "@/lib/shared/schemas/ids";
 import type { AuthProvider, Principal } from "./principal";
 
 /** Claims oauth2-proxy/IdP:n levererar (#222 fyller dessa ur headers/userinfo). */
@@ -61,11 +63,11 @@ function bindingOk(user: AllowlistedUser, claims: OidcClaims): boolean {
 
 function toPrincipal(user: AllowlistedUser, claims: OidcClaims): Principal {
   return {
-    id: user.id,
+    id: asId<"UserId">(user.id),
     email: user.email,
     name: user.name || claims.name || user.email,
-    role: user.role,
-    organizationId: user.organizationId,
+    role: userRoleSchema.parse(user.role),
+    organizationId: asId<"OrganizationId">(user.organizationId),
   };
 }
 

--- a/src/lib/server/auth/principal.ts
+++ b/src/lib/server/auth/principal.ts
@@ -10,13 +10,15 @@
  * (se `Context` i `trpc-core.ts`).
  */
 
+import type { UserRole } from "@/lib/shared/schemas/enums";
+import type { OrganizationId, UserId } from "@/lib/shared/schemas/ids";
+
 export interface Principal {
-  id: string;
+  id: UserId;
   email: string;
   name: string;
-  /** "ADMIN" | "LAWYER" | "ASSISTANT" — strängtypad här, enum i schemas. */
-  role: string;
-  organizationId: string;
+  role: UserRole;
+  organizationId: OrganizationId;
 }
 
 export interface AuthProvider {

--- a/test/scripts/demo-deployed-path-repro.test.ts
+++ b/test/scripts/demo-deployed-path-repro.test.ts
@@ -7,6 +7,8 @@
 
 import { describe, it, expect } from "vitest-compat";
 import { prebakeJoins } from "@/lib/shared/demo-source";
+import { userRoleSchema } from "@/lib/shared/schemas/enums";
+import { asId } from "@/lib/shared/schemas/ids";
 import { noopPorts } from "../../src/lib/server/adapters/noop-ports";
 import { buildContext } from "../../src/lib/server/build-context";
 import { DemoDataStore, type DemoSource } from "../../src/lib/server/data-store/DemoDataStore";
@@ -27,7 +29,7 @@ const ENTITY_TO_KEY: Record<string, string> = {
   calendarEvent: "calendarEvents", task: "tasks", conflictCheck: "conflictChecks",
 };
 
-const ADMIN = { id: "u-anna", email: "a@a.se", name: "A", role: "ADMIN", organizationId: "firma-ab" };
+const ADMIN = { id: asId<"UserId">("u-anna"), email: "a@a.se", name: "A", role: userRoleSchema.parse("ADMIN"), organizationId: asId<"OrganizationId">("firma-ab") };
 
 describe("deployed-path repro (prebakeJoins + ny store)", () => {
   it("org-scopade list-queries returnerar data", async () => {

--- a/test/scripts/demo-generator-billing.test.ts
+++ b/test/scripts/demo-generator-billing.test.ts
@@ -8,12 +8,14 @@
  */
 
 import { describe, it, expect } from "vitest-compat";
+import { userRoleSchema } from "@/lib/shared/schemas/enums";
+import { asId } from "@/lib/shared/schemas/ids";
 import { createGitTarget } from "../../tooling/demo-generator/backend-target";
 import { populate } from "../../tooling/demo-generator/populate";
 import { populateBilling } from "../../tooling/demo-generator/populate-billing";
 import { buildSeed } from "../../tooling/scripts/seed-data";
 
-const ADMIN = { id: "gen", email: "gen@ava.local", name: "Generator", role: "ADMIN", organizationId: "firma-ab" };
+const ADMIN = { id: asId<"UserId">("gen"), email: "gen@ava.local", name: "Generator", role: userRoleSchema.parse("ADMIN"), organizationId: asId<"OrganizationId">("firma-ab") };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Inv = any;

--- a/test/scripts/demo-generator-documents.test.ts
+++ b/test/scripts/demo-generator-documents.test.ts
@@ -4,13 +4,15 @@
  */
 
 import { describe, it, expect } from "vitest-compat";
+import { userRoleSchema } from "@/lib/shared/schemas/enums";
+import { asId } from "@/lib/shared/schemas/ids";
 import { createGitTarget } from "../../tooling/demo-generator/backend-target";
 import { populate } from "../../tooling/demo-generator/populate";
 import { populateDocuments } from "../../tooling/demo-generator/populate-documents";
 import type { SeedDataset } from "../../tooling/scripts/seed-data";
 
 const now = new Date("2026-01-01T00:00:00Z");
-const ADMIN = { id: "gen", email: "gen@ava.local", name: "Generator", role: "ADMIN", organizationId: "org-test" };
+const ADMIN = { id: asId<"UserId">("gen"), email: "gen@ava.local", name: "Generator", role: userRoleSchema.parse("ADMIN"), organizationId: asId<"OrganizationId">("org-test") };
 
 const seed = {
   organizations: [{ id: "org-test", name: "T AB", createdAt: now, updatedAt: now }],

--- a/test/scripts/demo-generator-invoice-docs.test.ts
+++ b/test/scripts/demo-generator-invoice-docs.test.ts
@@ -4,13 +4,15 @@
  */
 
 import { describe, it, expect } from "vitest-compat";
+import { userRoleSchema } from "@/lib/shared/schemas/enums";
+import { asId } from "@/lib/shared/schemas/ids";
 import { createGitTarget } from "../../tooling/demo-generator/backend-target";
 import { populate } from "../../tooling/demo-generator/populate";
 import { populateBilling } from "../../tooling/demo-generator/populate-billing";
 import { populateInvoiceDocs } from "../../tooling/demo-generator/populate-invoice-docs";
 import { buildSeed } from "../../tooling/scripts/seed-data";
 
-const ADMIN = { id: "gen", email: "g@a.se", name: "G", role: "ADMIN", organizationId: "firma-ab" };
+const ADMIN = { id: asId<"UserId">("gen"), email: "g@a.se", name: "G", role: userRoleSchema.parse("ADMIN"), organizationId: asId<"OrganizationId">("firma-ab") };
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Any = any;
 

--- a/test/scripts/demo-generator-kostnadsrakning-docs.test.ts
+++ b/test/scripts/demo-generator-kostnadsrakning-docs.test.ts
@@ -6,13 +6,15 @@
  */
 
 import { describe, it, expect } from "vitest-compat";
+import { userRoleSchema } from "@/lib/shared/schemas/enums";
+import { asId } from "@/lib/shared/schemas/ids";
 import { createGitTarget } from "../../tooling/demo-generator/backend-target";
 import { populate } from "../../tooling/demo-generator/populate";
 import { populateBilling } from "../../tooling/demo-generator/populate-billing";
 import { populateKostnadsrakningDocs } from "../../tooling/demo-generator/populate-kostnadsrakning-docs";
 import { buildSeed } from "../../tooling/scripts/seed-data";
 
-const ADMIN = { id: "gen", email: "g@a.se", name: "G", role: "ADMIN", organizationId: "firma-ab" };
+const ADMIN = { id: asId<"UserId">("gen"), email: "g@a.se", name: "G", role: userRoleSchema.parse("ADMIN"), organizationId: asId<"OrganizationId">("firma-ab") };
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Any = any;
 

--- a/test/scripts/demo-generator-template-docs.test.ts
+++ b/test/scripts/demo-generator-template-docs.test.ts
@@ -4,13 +4,15 @@
  */
 
 import { describe, it, expect } from "vitest-compat";
+import { userRoleSchema } from "@/lib/shared/schemas/enums";
+import { asId } from "@/lib/shared/schemas/ids";
 import { createGitTarget } from "../../tooling/demo-generator/backend-target";
 import { populate } from "../../tooling/demo-generator/populate";
 import { populateTemplateDocs } from "../../tooling/demo-generator/populate-template-docs";
 import type { SeedDataset } from "../../tooling/scripts/seed-data";
 
 const now = new Date("2026-01-01T00:00:00Z");
-const ADMIN = { id: "gen", email: "gen@ava.local", name: "Generator", role: "ADMIN", organizationId: "org-test" };
+const ADMIN = { id: asId<"UserId">("gen"), email: "gen@ava.local", name: "Generator", role: userRoleSchema.parse("ADMIN"), organizationId: asId<"OrganizationId">("org-test") };
 
 const seed = {
   organizations: [{ id: "org-test", name: "Byrå AB", orgNumber: "556000-0000", createdAt: now, updatedAt: now }],

--- a/test/scripts/demo-generator.test.ts
+++ b/test/scripts/demo-generator.test.ts
@@ -10,6 +10,8 @@ import { mkdtempSync, readFileSync, existsSync, rmSync } from "node:fs";
 import os from "node:os";
 import { join } from "node:path";
 import { describe, it, expect } from "vitest-compat";
+import { userRoleSchema } from "@/lib/shared/schemas/enums";
+import { asId } from "@/lib/shared/schemas/ids";
 import { createGitTarget, createPostgresTarget } from "../../tooling/demo-generator/backend-target";
 import { makeNodeGitWriteBack } from "../../tooling/demo-generator/node-git-writeback";
 import { populate } from "../../tooling/demo-generator/populate";
@@ -30,7 +32,7 @@ const tinySeed = {
   conflictChecks: [{ id: "cc-test", searchTerm: "Klient", searchType: "name", results: [], checkedById: "u-test", createdAt: now }],
 } as unknown as SeedDataset;
 
-const ADMIN = { id: "gen", email: "gen@ava.local", name: "Generator", role: "ADMIN", organizationId: "org-test" };
+const ADMIN = { id: asId<"UserId">("gen"), email: "gen@ava.local", name: "Generator", role: userRoleSchema.parse("ADMIN"), organizationId: asId<"OrganizationId">("org-test") };
 
 describe("demo-generator — populate (org/users/contacts via tRPC)", () => {
   it("skapar entiteterna via create-mutationerna med klient-genererade id:n", async () => {

--- a/test/scripts/populate-unbilled-time.test.ts
+++ b/test/scripts/populate-unbilled-time.test.ts
@@ -3,6 +3,7 @@
  * utan invoiceId (= "upparbetad men inte fakturerad").
  */
 import { describe, it, expect } from "vitest-compat";
+import { asId } from "@/lib/shared/schemas/ids";
 import { createGitTarget } from "../../tooling/demo-generator/backend-target";
 import { translateSeed, createIdTranslator } from "../../tooling/demo-generator/id-translator";
 import { populateUnbilledTime } from "../../tooling/demo-generator/populate-unbilled-time";
@@ -14,7 +15,7 @@ async function runTarget() {
   const orgId = String(seed.organizations[0]?.id);
   const userId = String(seed.users[0]?.id);
   const target = createGitTarget({
-    principal: { id: userId, email: "g@a", name: "G", role: "ADMIN", organizationId: orgId },
+    principal: { id: asId<"UserId">(userId), email: "g@a", name: "G", role: "ADMIN", organizationId: asId<"OrganizationId">(orgId) },
     writeBack: async () => {},
   });
   return { target, seed };

--- a/test/unit/lib/backend/backend-runtime-pluggability.test.ts
+++ b/test/unit/lib/backend/backend-runtime-pluggability.test.ts
@@ -20,6 +20,7 @@ import { GitBackendRuntime } from "@/lib/client/backend/git-backend-runtime";
 import { GitAuthProvider } from "@/lib/server/auth/git-auth-provider";
 import { DemoDataStore } from "@/lib/server/data-store/DemoDataStore";
 import type { AppRouter } from "@/lib/server/routers/_app";
+import { asId } from "@/lib/shared/schemas/ids";
 
 /**
  * En fejk-backend som INTE rör git/DemoDataStore alls — den simulerar en
@@ -66,7 +67,7 @@ describe("BackendRuntime — pluggbarhet (kloss-socket)", () => {
         dataStore: new DemoDataStore({
           matters: [{ id: "m1", title: "T", organizationId: "demo-firma-ab", status: "ACTIVE", matterNumber: "2025-0001", createdAt: new Date() }],
         }),
-        authProvider: new GitAuthProvider({ organizationId: "demo-firma-ab", id: "t" }),
+        authProvider: new GitAuthProvider({ organizationId: asId<"OrganizationId">("demo-firma-ab"), id: asId<"UserId">("t") }),
       }),
       new FakeServerBackendRuntime({ matters: [{ id: "srv-1" }], total: 1 }),
     ];

--- a/test/unit/lib/backend/git-backend-runtime.test.ts
+++ b/test/unit/lib/backend/git-backend-runtime.test.ts
@@ -13,6 +13,7 @@ import { GitBackendRuntime } from "@/lib/client/backend/git-backend-runtime";
 import { GitAuthProvider } from "@/lib/server/auth/git-auth-provider";
 import { DemoDataStore } from "@/lib/server/data-store/DemoDataStore";
 import type { AppRouter } from "@/lib/server/routers/_app";
+import { asId } from "@/lib/shared/schemas/ids";
 
 const matters = [
   { id: "m1", title: "Demo Avtal", organizationId: "demo-firma-ab", status: "ACTIVE", matterNumber: "2025-0001", createdAt: new Date("2025-01-01") },
@@ -32,7 +33,7 @@ function buildClient(runtime: GitBackendRuntime) {
   };
 }
 
-const seedOrgPrincipal = new GitAuthProvider({ organizationId: "demo-firma-ab", id: "test-user" });
+const seedOrgPrincipal = new GitAuthProvider({ organizationId: asId<"OrganizationId">("demo-firma-ab"), id: asId<"UserId">("test-user") });
 
 describe("GitBackendRuntime", () => {
   it("query går igenom appRouter till DemoDataStore (explicit principal scopar demo-firma-ab)", async () => {
@@ -50,7 +51,7 @@ describe("GitBackendRuntime", () => {
   it("injicerad AuthProvider styr org-scoping → fel org ger 0 träffar", async () => {
     const runtime = new GitBackendRuntime({
       dataStore: new DemoDataStore({ matters, contacts }),
-      authProvider: new GitAuthProvider({ organizationId: "annan-org" }),
+      authProvider: new GitAuthProvider({ organizationId: asId<"OrganizationId">("annan-org") }),
     });
     const result = await buildClient(runtime).matter.list.query({});
     expect(result.matters).toHaveLength(0);

--- a/test/unit/lib/backend/in-process-link.test.ts
+++ b/test/unit/lib/backend/in-process-link.test.ts
@@ -17,6 +17,7 @@ import { GitAuthProvider } from "@/lib/server/auth/git-auth-provider";
 import { buildContext } from "@/lib/server/build-context";
 import { DemoDataStore } from "@/lib/server/data-store/DemoDataStore";
 import type { AppRouter } from "@/lib/server/routers/_app";
+import { asId } from "@/lib/shared/schemas/ids";
 
 const store = () => new DemoDataStore({
   matters: [{ id: "m1", title: "T", organizationId: "demo-firma-ab", status: "ACTIVE", matterNumber: "2025-0001", createdAt: new Date() }],
@@ -64,7 +65,7 @@ describe("inProcessLink — felvägar", () => {
     const runtime = new GitBackendRuntime({
       dataStore: ds,
       ports,
-      authProvider: new GitAuthProvider({ organizationId: "demo-firma-ab", id: "t" }),
+      authProvider: new GitAuthProvider({ organizationId: asId<"OrganizationId">("demo-firma-ab"), id: asId<"UserId">("t") }),
     });
     const client = rawClient(runtime) as unknown as {
       matter: { list: { query: (i: unknown) => Promise<{ matters: unknown[] }> } };

--- a/test/unit/server/auth/cached-session-auth-provider.test.ts
+++ b/test/unit/server/auth/cached-session-auth-provider.test.ts
@@ -9,9 +9,10 @@ import {
   DEFAULT_OFFLINE_GRACE_MS,
 } from "@/lib/server/auth/cached-session-auth-provider";
 import type { Principal } from "@/lib/server/auth/principal";
+import { asId } from "@/lib/shared/schemas/ids";
 
 const PRINCIPAL: Principal = {
-  id: "u-1", email: "anna@byra.se", name: "Anna", role: "LAWYER", organizationId: "org-1",
+  id: asId<"UserId">("u-1"), email: "anna@byra.se", name: "Anna", role: "LAWYER", organizationId: asId<"OrganizationId">("org-1"),
 };
 
 describe("CachedSessionAuthProvider", () => {

--- a/test/unit/server/auth/git-auth-provider.test.ts
+++ b/test/unit/server/auth/git-auth-provider.test.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect } from "vitest-compat";
 import { GitAuthProvider, TEST_PRINCIPAL } from "@/lib/server/auth/git-auth-provider";
 import type { AuthProvider, Principal } from "@/lib/server/auth/principal";
+import { asId } from "@/lib/shared/schemas/ids";
 
 describe("GitAuthProvider", () => {
   it("uppfyller AuthProvider-interfacet", () => {
@@ -27,8 +28,8 @@ describe("GitAuthProvider", () => {
 
   it("med config → överrider per fält, neutral för resten", () => {
     const p = new GitAuthProvider({
-      id: "current-user",
-      organizationId: "firma-ab",
+      id: asId<"UserId">("current-user"),
+      organizationId: asId<"OrganizationId">("firma-ab"),
       name: "Lokal användare",
       email: "user@firma.local",
     }).getPrincipal();
@@ -55,7 +56,7 @@ describe("GitAuthProvider", () => {
   });
 
   it("är ren — upprepade anrop ger samma resultat (ingen mutation)", () => {
-    const provider = new GitAuthProvider({ id: "u-bjorn" });
+    const provider = new GitAuthProvider({ id: asId<"UserId">("u-bjorn") });
     expect(provider.getPrincipal()).toEqual(provider.getPrincipal());
   });
 });

--- a/test/unit/server/build-context.test.ts
+++ b/test/unit/server/build-context.test.ts
@@ -12,12 +12,13 @@ import { buildContext } from "@/lib/server/build-context";
 import type { IDataStore } from "@/lib/server/data-store/IDataStore";
 import type { IPorts } from "@/lib/server/ports";
 import { DEMO_CAPABILITIES } from "@/lib/shared/capabilities";
+import { asId } from "@/lib/shared/schemas/ids";
 
 const fakeEvents = { marker: "events" };
 const fakeStore = { marker: "store", events: fakeEvents } as unknown as IDataStore;
 const fakePorts = { marker: "ports" } as unknown as IPorts;
 const principal: Principal = {
-  id: "u-anna", email: "a@b.se", name: "Anna", role: "ADMIN", organizationId: "org-1",
+  id: asId<"UserId">("u-anna"), email: "a@b.se", name: "Anna", role: "ADMIN", organizationId: asId<"OrganizationId">("org-1"),
 };
 
 describe("buildContext", () => {

--- a/test/unit/server/http/pat.test.ts
+++ b/test/unit/server/http/pat.test.ts
@@ -8,10 +8,11 @@ import type { Principal } from "@/lib/server/auth/principal";
 import {
   sha256Hex, parseBearerToken, StaticPatVerifier, patRecord, type PatRecord,
 } from "@/lib/server/http/pat";
+import { asId } from "@/lib/shared/schemas/ids";
 
 const PRINCIPAL: Principal = {
-  id: "p-1", email: "advokat@byra.se", name: "Ada Advokat",
-  role: "LAWYER", organizationId: "org-1",
+  id: asId<"UserId">("p-1"), email: "advokat@byra.se", name: "Ada Advokat",
+  role: "LAWYER", organizationId: asId<"OrganizationId">("org-1"),
 };
 
 describe("sha256Hex", () => {
@@ -58,7 +59,7 @@ describe("StaticPatVerifier", () => {
     expect(verifier.verify("")).toBeNull();
   });
   it("väljer rätt principal bland flera poster", () => {
-    const other: Principal = { ...PRINCIPAL, id: "p-2", email: "b@b.se" };
+    const other: Principal = { ...PRINCIPAL, id: asId<"UserId">("p-2"), email: "b@b.se" };
     const multi = new StaticPatVerifier([
       patRecord("token-a", PRINCIPAL),
       patRecord("token-b", other),

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -15,7 +15,7 @@ import { appRouter } from "@/lib/server/routers/_app";
 import { asId } from "@/lib/shared/schemas/ids";
 
 const PRINCIPAL: Principal = {
-  id: "u-1", email: "a@x", name: "Anna", role: "ADMIN", organizationId: "org-1",
+  id: asId<"UserId">("u-1"), email: "a@x", name: "Anna", role: "ADMIN", organizationId: asId<"OrganizationId">("org-1"),
 };
 
 function makeCaller(opts?: { workMinutes?: number; expenseOre?: number }) {

--- a/test/unit/server/routers/expectedReceivable.test.ts
+++ b/test/unit/server/routers/expectedReceivable.test.ts
@@ -10,8 +10,9 @@ import type { Principal } from "@/lib/server/auth/principal";
 import { buildContext } from "@/lib/server/build-context";
 import { DemoDataStore } from "@/lib/server/data-store/DemoDataStore";
 import { appRouter } from "@/lib/server/routers/_app";
+import { asId } from "@/lib/shared/schemas/ids";
 
-const PRINCIPAL: Principal = { id: "u-1", email: "a@x", name: "Anna", role: "ADMIN", organizationId: "org-1" };
+const PRINCIPAL: Principal = { id: asId<"UserId">("u-1"), email: "a@x", name: "Anna", role: "ADMIN", organizationId: asId<"OrganizationId">("org-1") };
 
 function makeCaller() {
   const ds = new DemoDataStore({

--- a/test/unit/server/routers/invoiceDispatch.test.ts
+++ b/test/unit/server/routers/invoiceDispatch.test.ts
@@ -4,8 +4,9 @@ import type { Principal } from "@/lib/server/auth/principal";
 import { buildContext } from "@/lib/server/build-context";
 import { DemoDataStore } from "@/lib/server/data-store/DemoDataStore";
 import { appRouter } from "@/lib/server/routers/_app";
+import { asId } from "@/lib/shared/schemas/ids";
 
-const PRINCIPAL: Principal = { id: "u-1", email: "a@x", name: "Anna", role: "ADMIN", organizationId: "org-1" };
+const PRINCIPAL: Principal = { id: asId<"UserId">("u-1"), email: "a@x", name: "Anna", role: "ADMIN", organizationId: asId<"OrganizationId">("org-1") };
 
 function makeCaller() {
   const ds = new DemoDataStore({

--- a/test/unit/server/routers/matter.test.ts
+++ b/test/unit/server/routers/matter.test.ts
@@ -11,6 +11,7 @@ import { buildContext } from "@/lib/server/build-context";
 import { DemoDataStore } from "@/lib/server/data-store/DemoDataStore";
 import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
 import { appRouter } from "@/lib/server/routers/_app";
+import { asId } from "@/lib/shared/schemas/ids";
 
 const ORG = "org-a";
 const YEAR = new Date().getFullYear();
@@ -24,7 +25,7 @@ function makeCaller(seed: Partial<DemoSource> = {}, orgId = ORG, userId = "user-
     matterContacts: [],
     ...seed,
   } as DemoSource, async () => { /* writable */ });
-  const principal: Principal = { id: userId, email: "a@b.com", name: "Test", role: "LAWYER", organizationId: orgId };
+  const principal: Principal = { id: asId<"UserId">(userId), email: "a@b.com", name: "Test", role: "LAWYER", organizationId: asId<"OrganizationId">(orgId) };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const caller = appRouter.createCaller(buildContext({ dataStore: ds, ports: noopPorts, principal }) as any);
   return { ds, caller: caller.matter };

--- a/test/unit/server/routers/payment-scan.test.ts
+++ b/test/unit/server/routers/payment-scan.test.ts
@@ -8,8 +8,9 @@ import type { Principal } from "@/lib/server/auth/principal";
 import { buildContext } from "@/lib/server/build-context";
 import { DemoDataStore } from "@/lib/server/data-store/DemoDataStore";
 import { appRouter } from "@/lib/server/routers/_app";
+import { asId } from "@/lib/shared/schemas/ids";
 
-const PRINCIPAL: Principal = { id: "u-1", email: "a@x", name: "Anna", role: "ADMIN", organizationId: "org-1" };
+const PRINCIPAL: Principal = { id: asId<"UserId">("u-1"), email: "a@x", name: "Anna", role: "ADMIN", organizationId: asId<"OrganizationId">("org-1") };
 
 function makeCaller(opts: { startDate: string; paidOre?: number }) {
   const ds = new DemoDataStore({

--- a/tooling/demo-generator/generate-into.ts
+++ b/tooling/demo-generator/generate-into.ts
@@ -14,6 +14,7 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import type { Principal } from "@/lib/server/auth/principal";
+import { asId } from "@/lib/shared/schemas/ids";
 import { buildSeed, type BuildSeedOpts } from "../scripts/seed-data";
 import { createGitTarget } from "./backend-target";
 import { createIdTranslator, translateSeed, type IdTranslator } from "./id-translator";
@@ -48,8 +49,8 @@ export async function generateInto(outDir: string, seedOpts: BuildSeedOpts = {})
   const currentUserIdSlug = seedOpts.currentUserId ?? "current-user";
   const currentUserId = translator.toUuid(currentUserIdSlug);
   const principal: Principal = {
-    id: currentUserId, email: "generator@ava.local", name: "Demo Generator",
-    role: "ADMIN", organizationId: orgId,
+    id: asId<"UserId">(currentUserId), email: "generator@ava.local", name: "Demo Generator",
+    role: "ADMIN", organizationId: asId<"OrganizationId">(orgId),
   };
   const target = createGitTarget({ principal, writeBack: makeNodeGitWriteBack(outDir) });
 


### PR DESCRIPTION
Högleverage-källbrandning i ID-fasen (#750). `Principal` är single source of truth för `ctx.user`, så branding den gör att user/org-id:n flödar **brandade** in i routrar + repos och krymper kvarvarande B1-kaskad.

- **principal.ts** — `id`→`UserId`, `role`→`UserRole`, `organizationId`→`OrganizationId`.
- Brandade Principal-konstruktionens trust-boundaries: `git-auth-provider` (TEST/NEUTRAL-fixtures), `oidc-auth-provider` (`userRoleSchema.parse` på allowlist-roll + `asId`), `demo-bootstrap`, `generate-into`.
- **43 test-fixtures** — `asId` på id/organizationId (+ `userRoleSchema.parse` där oannoterade literaler widenade `role`).

`ctx.orgId` var redan brandad (trpc-core:91); detta brandar `Principal`-formen bakom den.

## Test
Ren tsc (root+test, 0), lint grön, 586 auth/router/script-tester gröna.

Refs #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)