### PR TITLE
refactor(repos): branda matter/contact-domänens id-params (B1c)

### DIFF
--- a/src/lib/server/repositories/contact-repository.ts
+++ b/src/lib/server/repositories/contact-repository.ts
@@ -7,6 +7,7 @@
 
 import type { Contact } from "@/lib/shared/schemas/contact";
 import type { ContactType, MatterRole, MatterStatus } from "@/lib/shared/schemas/enums";
+import type { ContactId, MatterContactId, MatterId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { Repository } from "./types";
 
 /** Kontakt + antal relationer (listvyns _count). */
@@ -16,19 +17,19 @@ export interface ContactListRow extends Contact {
 
 /** En ärende-koppling med ärendets sammanfattning (detaljvyns matterLinks). */
 export interface ContactMatterLink {
-  id: string;
-  matterId: string;
-  contactId: string;
+  id: MatterContactId;
+  matterId: MatterId;
+  contactId: ContactId;
   role: MatterRole;
   notes: string | null;
   /** Alltid satt — `matterId` är NOT NULL FK, så ärendet finns alltid. */
-  matter: { id: string; matterNumber: string; title: string; status: MatterStatus };
+  matter: { id: MatterId; matterNumber: string; title: string; status: MatterStatus };
 }
 
 /** Full kontakt-detalj (motsvarar `contact.getById`-routerns include). */
 export interface ContactFull extends Contact {
   children: Contact[];
-  parent: { id: string; name: string } | null;
+  parent: { id: ContactId; name: string } | null;
   matterLinks: ContactMatterLink[];
 }
 
@@ -47,11 +48,11 @@ export interface ContactListResult {
 
 export interface ContactRepository extends Repository<Contact> {
   /** Topp-nivå-kontakter (parentId null) i org:en, paginerat + sökbart, med _count. */
-  listForOrg(organizationId: string, opts: ContactListOptions): Promise<ContactListResult>;
+  listForOrg(organizationId: OrganizationId, opts: ContactListOptions): Promise<ContactListResult>;
   /** Full kontakt-detalj (barn/förälder/ärende-kopplingar), org-scopad. Null om saknas/raderad. */
-  getByIdFull(id: string, organizationId: string): Promise<ContactFull | null>;
+  getByIdFull(id: ContactId, organizationId: OrganizationId): Promise<ContactFull | null>;
   /** Kontakt med givet personnummer i org:en (dedup). Null om ingen. */
-  findByPersonalNumber(organizationId: string, personalNumber: string): Promise<Contact | null>;
+  findByPersonalNumber(organizationId: OrganizationId, personalNumber: string): Promise<Contact | null>;
   /** Kontakt med givet org-nummer i org:en (dedup). Null om ingen. */
-  findByOrgNumber(organizationId: string, orgNumber: string): Promise<Contact | null>;
+  findByOrgNumber(organizationId: OrganizationId, orgNumber: string): Promise<Contact | null>;
 }

--- a/src/lib/server/repositories/drizzle-contact-repository.ts
+++ b/src/lib/server/repositories/drizzle-contact-repository.ts
@@ -7,7 +7,7 @@
 import { and, asc, desc, eq, ilike, inArray, isNull, like, or, sql } from "drizzle-orm";
 import type { PgColumn, PgTable } from "drizzle-orm/pg-core";
 import type { Contact } from "@/lib/shared/schemas/contact";
-import { asId } from "@/lib/shared/schemas/ids";
+import type { ContactId, OrganizationId } from "@/lib/shared/schemas/ids";
 import { contacts, matterContacts, matters } from "../db/schema";
 import type { AppDb } from "../db/types";
 import type {
@@ -20,9 +20,9 @@ export class DrizzleContactRepository extends DrizzleRepository<Contact> impleme
     super(db, versionedTable(contacts), now);
   }
 
-  async listForOrg(organizationId: string, opts: ContactListOptions): Promise<ContactListResult> {
+  async listForOrg(organizationId: OrganizationId, opts: ContactListOptions): Promise<ContactListResult> {
     const where = and(
-      eq(contacts.organizationId, asId<"OrganizationId">(organizationId)),
+      eq(contacts.organizationId, organizationId),
       isNull(contacts.parentId), // bara topp-nivå
       isNull(contacts.deletedAt),
       opts.contactType ? eq(contacts.contactType, opts.contactType) : undefined,
@@ -66,15 +66,15 @@ export class DrizzleContactRepository extends DrizzleRepository<Contact> impleme
     return new Map(rows.map((r) => [String(r.key), Number(r.n)]));
   }
 
-  async getByIdFull(id: string, organizationId: string): Promise<ContactFull | null> {
+  async getByIdFull(id: ContactId, organizationId: OrganizationId): Promise<ContactFull | null> {
     const [c] = await this.db
       .select().from(contacts)
-      .where(and(eq(contacts.id, asId<"ContactId">(id)), eq(contacts.organizationId, asId<"OrganizationId">(organizationId)), isNull(contacts.deletedAt)))
+      .where(and(eq(contacts.id, id), eq(contacts.organizationId, organizationId), isNull(contacts.deletedAt)))
       .limit(1);
     if (!c) return null;
     const children = await this.db
       .select().from(contacts)
-      .where(and(eq(contacts.parentId, asId<"ContactId">(id)), isNull(contacts.deletedAt))).orderBy(asc(contacts.name));
+      .where(and(eq(contacts.parentId, id), isNull(contacts.deletedAt))).orderBy(asc(contacts.name));
     const parentId = c.parentId;
     const parentRows = parentId
       ? await this.db.select({ id: contacts.id, name: contacts.name }).from(contacts).where(eq(contacts.id, parentId)).limit(1)
@@ -86,7 +86,7 @@ export class DrizzleContactRepository extends DrizzleRepository<Contact> impleme
       })
       .from(matterContacts)
       .innerJoin(matters, eq(matterContacts.matterId, matters.id)) // matterId NOT NULL FK → matter finns alltid
-      .where(eq(matterContacts.contactId, asId<"ContactId">(id)))
+      .where(eq(matterContacts.contactId, id))
       .orderBy(desc(matterContacts.createdAt));
     return {
       ...c,
@@ -99,16 +99,16 @@ export class DrizzleContactRepository extends DrizzleRepository<Contact> impleme
     };
   }
 
-  async findByPersonalNumber(organizationId: string, personalNumber: string): Promise<Contact | null> {
+  async findByPersonalNumber(organizationId: OrganizationId, personalNumber: string): Promise<Contact | null> {
     const rows = await this.db.select().from(contacts)
-      .where(and(eq(contacts.organizationId, asId<"OrganizationId">(organizationId)), eq(contacts.personalNumber, personalNumber), isNull(contacts.deletedAt)))
+      .where(and(eq(contacts.organizationId, organizationId), eq(contacts.personalNumber, personalNumber), isNull(contacts.deletedAt)))
       .limit(1);
     return this.asRow(rows[0]);
   }
 
-  async findByOrgNumber(organizationId: string, orgNumber: string): Promise<Contact | null> {
+  async findByOrgNumber(organizationId: OrganizationId, orgNumber: string): Promise<Contact | null> {
     const rows = await this.db.select().from(contacts)
-      .where(and(eq(contacts.organizationId, asId<"OrganizationId">(organizationId)), eq(contacts.orgNumber, orgNumber), isNull(contacts.deletedAt)))
+      .where(and(eq(contacts.organizationId, organizationId), eq(contacts.orgNumber, orgNumber), isNull(contacts.deletedAt)))
       .limit(1);
     return this.asRow(rows[0]);
   }

--- a/src/lib/server/repositories/drizzle-matter-contact-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-contact-repository.ts
@@ -7,7 +7,7 @@
 import { and, eq, isNull, or, sql } from "drizzle-orm";
 import type { Contact } from "@/lib/shared/schemas/contact";
 import type { MatterRole } from "@/lib/shared/schemas/enums";
-import { asId } from "@/lib/shared/schemas/ids";
+import type { ContactId, MatterContactId, MatterId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { MatterContact } from "@/lib/shared/schemas/matter";
 import { contacts, matterContacts, matters } from "../db/schema";
 import type { AppDb } from "../db/types";
@@ -29,7 +29,7 @@ export class DrizzleMatterContactRepository
     return matterOrg(this.db, (row as { matterId?: string }).matterId);
   }
 
-  async findForConflict(organizationId: string, numberTerm?: string): Promise<ConflictContactRow[]> {
+  async findForConflict(organizationId: OrganizationId, numberTerm?: string): Promise<ConflictContactRow[]> {
     const klient = sql<string | null>`(select c.name from matter_contacts mc join contacts c on mc.contact_id = c.id where mc.matter_id = ${matters.id} and mc.role = 'KLIENT' limit 1)`;
     const numberFilter = numberTerm
       ? or(
@@ -47,25 +47,25 @@ export class DrizzleMatterContactRepository
       .from(matterContacts)
       .innerJoin(contacts, eq(matterContacts.contactId, contacts.id))
       .innerJoin(matters, eq(matterContacts.matterId, matters.id))
-      .where(and(eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(matterContacts.deletedAt), numberFilter));
+      .where(and(eq(matters.organizationId, organizationId), isNull(matterContacts.deletedAt), numberFilter));
     return rows.map((r) => ({
       role: r.role,
       contact: {
-        id: r.cId as string, name: r.cName as string, contactType: r.cType,
-        personalNumber: (r.cPnr as string | null) ?? null, orgNumber: (r.cOrg as string | null) ?? null,
+        id: r.cId, name: r.cName, contactType: r.cType,
+        personalNumber: r.cPnr ?? null, orgNumber: r.cOrg ?? null,
       },
       matter: {
-        id: r.mId as string, matterNumber: r.mNum as string, title: r.mTitle as string,
-        contacts: r.klient ? [{ contact: { name: r.klient as string } }] : [],
+        id: r.mId, matterNumber: r.mNum, title: r.mTitle,
+        contacts: r.klient ? [{ contact: { name: r.klient } }] : [],
       },
     }));
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<MatterContact | null> {
+  async getByIdInOrg(id: MatterContactId, organizationId: OrganizationId): Promise<MatterContact | null> {
     const rows = await this.db
       .select({ mc: matterContacts }).from(matterContacts)
       .innerJoin(matters, eq(matterContacts.matterId, matters.id))
-      .where(and(eq(matterContacts.id, asId<"MatterContactId">(id)), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(matterContacts.deletedAt)))
+      .where(and(eq(matterContacts.id, id), eq(matters.organizationId, organizationId), isNull(matterContacts.deletedAt)))
       .limit(1);
     return rows[0]?.mc ?? null;
   }
@@ -77,20 +77,20 @@ export class DrizzleMatterContactRepository
     return { ...link, contact: contact as Contact };
   }
 
-  async findLink(matterId: string, contactId: string, role: string): Promise<MatterContact | null> {
+  async findLink(matterId: MatterId, contactId: ContactId, role: string): Promise<MatterContact | null> {
     const rows = await this.db.select().from(matterContacts)
       .where(and(
-        eq(matterContacts.matterId, asId<"MatterId">(matterId)), eq(matterContacts.contactId, asId<"ContactId">(contactId)),
+        eq(matterContacts.matterId, matterId), eq(matterContacts.contactId, contactId),
         eq(matterContacts.role, role as MatterRole), isNull(matterContacts.deletedAt),
       )).limit(1);
     return rows[0] ?? null;
   }
 
-  async listContactsForMatter(matterId: string): Promise<Contact[]> {
+  async listContactsForMatter(matterId: MatterId): Promise<Contact[]> {
     const rows = await this.db
       .select({ contact: contacts }).from(matterContacts)
       .innerJoin(contacts, eq(matterContacts.contactId, contacts.id))
-      .where(and(eq(matterContacts.matterId, asId<"MatterId">(matterId)), isNull(matterContacts.deletedAt)));
+      .where(and(eq(matterContacts.matterId, matterId), isNull(matterContacts.deletedAt)));
     return rows.map((r) => r.contact);
   }
 }

--- a/src/lib/server/repositories/drizzle-matter-event-suggestion-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-event-suggestion-repository.ts
@@ -5,7 +5,7 @@
 
 import { and, asc, eq, isNull, ne } from "drizzle-orm";
 import type { MatterEventSuggestion } from "@/lib/shared/schemas/document";
-import { asId } from "@/lib/shared/schemas/ids";
+import type { MatterEventSuggestionId, MatterId, OrganizationId } from "@/lib/shared/schemas/ids";
 import { documents, matterEventSuggestions, matters } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
@@ -20,7 +20,7 @@ export class DrizzleMatterEventSuggestionRepository
     super(db, versionedTable(matterEventSuggestions), now);
   }
 
-  async listForMatter(matterId: string, organizationId: string): Promise<MatterEventSuggestionRow[]> {
+  async listForMatter(matterId: MatterId, organizationId: OrganizationId): Promise<MatterEventSuggestionRow[]> {
     const rows = await this.db
       .select({
         ev: matterEventSuggestions,
@@ -30,8 +30,8 @@ export class DrizzleMatterEventSuggestionRepository
       .innerJoin(documents, eq(matterEventSuggestions.documentId, documents.id))
       .innerJoin(matters, eq(documents.matterId, matters.id))
       .where(and(
-        eq(documents.matterId, asId<"MatterId">(matterId)),
-        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
+        eq(documents.matterId, matterId),
+        eq(matters.organizationId, organizationId),
         ne(matterEventSuggestions.status, "REJECTED"),
         isNull(matterEventSuggestions.deletedAt),
       ))
@@ -42,14 +42,14 @@ export class DrizzleMatterEventSuggestionRepository
     }));
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<MatterEventSuggestion | null> {
+  async getByIdInOrg(id: MatterEventSuggestionId, organizationId: OrganizationId): Promise<MatterEventSuggestion | null> {
     const rows = await this.db
       .select({ ev: matterEventSuggestions }).from(matterEventSuggestions)
       .innerJoin(documents, eq(matterEventSuggestions.documentId, documents.id))
       .innerJoin(matters, eq(documents.matterId, matters.id))
       .where(and(
-        eq(matterEventSuggestions.id, asId<"MatterEventSuggestionId">(id)),
-        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
+        eq(matterEventSuggestions.id, id),
+        eq(matters.organizationId, organizationId),
         isNull(matterEventSuggestions.deletedAt),
       ))
       .limit(1);

--- a/src/lib/server/repositories/drizzle-matter-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-repository.ts
@@ -6,7 +6,7 @@
  */
 
 import { and, asc, desc, eq, ilike, inArray, isNull, or, sql } from "drizzle-orm";
-import { asId } from "@/lib/shared/schemas/ids";
+import type { ContactId, MatterId, OrganizationId, UserId } from "@/lib/shared/schemas/ids";
 import type { Matter } from "@/lib/shared/schemas/matter";
 import { contacts, documents, matterContacts, matters, timeEntries } from "../db/schema";
 import type { AppDb } from "../db/types";
@@ -20,25 +20,25 @@ export class DrizzleMatterRepository extends DrizzleRepository<Matter> implement
     super(db, versionedTable(matters), now);
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<Matter | null> {
+  async getByIdInOrg(id: MatterId, organizationId: OrganizationId): Promise<Matter | null> {
     const rows = await this.db
       .select().from(matters)
-      .where(and(eq(matters.id, asId<"MatterId">(id)), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(matters.deletedAt)))
+      .where(and(eq(matters.id, id), eq(matters.organizationId, organizationId), isNull(matters.deletedAt)))
       .limit(1);
     return this.asRow(rows[0]);
   }
 
-  async listByOrg(organizationId: string): Promise<Matter[]> {
+  async listByOrg(organizationId: OrganizationId): Promise<Matter[]> {
     const rows = await this.db
       .select().from(matters)
-      .where(and(eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(matters.deletedAt)));
+      .where(and(eq(matters.organizationId, organizationId), isNull(matters.deletedAt)));
     return this.asRows(rows);
   }
 
-  private listWhere(organizationId: string, f: MatterListFilter) {
+  private listWhere(organizationId: OrganizationId, f: MatterListFilter) {
     const pat = f.search ? `%${f.search}%` : "";
     return and(
-      eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
+      eq(matters.organizationId, organizationId),
       isNull(matters.deletedAt),
       f.status ? eq(matters.status, f.status) : undefined,
       f.employeeId
@@ -54,7 +54,7 @@ export class DrizzleMatterRepository extends DrizzleRepository<Matter> implement
     );
   }
 
-  async listForOrg(organizationId: string, filter: MatterListFilter): Promise<MatterListResult> {
+  async listForOrg(organizationId: OrganizationId, filter: MatterListFilter): Promise<MatterListResult> {
     const where = this.listWhere(organizationId, filter);
     const rows = await this.db.select().from(matters).where(where)
       .orderBy(desc(matters.createdAt))
@@ -74,7 +74,7 @@ export class DrizzleMatterRepository extends DrizzleRepository<Matter> implement
   }
 
   /** Grupperade relations-antal per ärende-id (documents/timeEntries/contacts). */
-  private async countsFor(ids: string[]): Promise<Map<string, { documents: number; timeEntries: number; contacts: number }>> {
+  private async countsFor(ids: MatterId[]): Promise<Map<string, { documents: number; timeEntries: number; contacts: number }>> {
     const out = new Map<string, { documents: number; timeEntries: number; contacts: number }>();
     if (ids.length === 0) return out;
     for (const id of ids) out.set(id, { documents: 0, timeEntries: 0, contacts: 0 });
@@ -83,11 +83,11 @@ export class DrizzleMatterRepository extends DrizzleRepository<Matter> implement
     };
     const [docs, tes, mcs] = await Promise.all([
       this.db.select({ id: documents.matterId, n: sql<number>`count(*)` }).from(documents)
-        .where(and(inArray(documents.matterId, ids.map((i) => asId<"MatterId">(i))), isNull(documents.deletedAt))).groupBy(documents.matterId),
+        .where(and(inArray(documents.matterId, ids), isNull(documents.deletedAt))).groupBy(documents.matterId),
       this.db.select({ id: timeEntries.matterId, n: sql<number>`count(*)` }).from(timeEntries)
-        .where(and(inArray(timeEntries.matterId, ids.map((i) => asId<"MatterId">(i))), isNull(timeEntries.deletedAt))).groupBy(timeEntries.matterId),
+        .where(and(inArray(timeEntries.matterId, ids), isNull(timeEntries.deletedAt))).groupBy(timeEntries.matterId),
       this.db.select({ id: matterContacts.matterId, n: sql<number>`count(*)` }).from(matterContacts)
-        .where(and(inArray(matterContacts.matterId, ids.map((i) => asId<"MatterId">(i))), isNull(matterContacts.deletedAt))).groupBy(matterContacts.matterId),
+        .where(and(inArray(matterContacts.matterId, ids), isNull(matterContacts.deletedAt))).groupBy(matterContacts.matterId),
     ]);
     apply(docs, "documents");
     apply(tes, "timeEntries");
@@ -96,29 +96,29 @@ export class DrizzleMatterRepository extends DrizzleRepository<Matter> implement
   }
 
   /** KLIENT-kontakt (id+namn) per ärende-id (första). */
-  private async klientFor(ids: string[]): Promise<Map<string, { id: string; name: string }>> {
-    const out = new Map<string, { id: string; name: string }>();
+  private async klientFor(ids: MatterId[]): Promise<Map<string, { id: ContactId; name: string }>> {
+    const out = new Map<string, { id: ContactId; name: string }>();
     if (ids.length === 0) return out;
     const rows = await this.db
       .select({ matterId: matterContacts.matterId, cId: contacts.id, cName: contacts.name })
       .from(matterContacts)
       .innerJoin(contacts, eq(matterContacts.contactId, contacts.id))
-      .where(and(inArray(matterContacts.matterId, ids.map((i) => asId<"MatterId">(i))), eq(matterContacts.role, "KLIENT")));
+      .where(and(inArray(matterContacts.matterId, ids), eq(matterContacts.role, "KLIENT")));
     for (const r of rows) {
-      const mid = r.matterId as string;
-      if (!out.has(mid)) out.set(mid, { id: r.cId as string, name: r.cName as string });
+      const mid = r.matterId;
+      if (!out.has(mid)) out.set(mid, { id: r.cId, name: r.cName });
     }
     return out;
   }
 
-  async getByIdWithContacts(id: string, organizationId: string): Promise<MatterDetailRow | null> {
+  async getByIdWithContacts(id: MatterId, organizationId: OrganizationId): Promise<MatterDetailRow | null> {
     const base = await this.getByIdInOrg(id, organizationId);
     if (!base) return null;
     const rows = await this.db
       .select({ mc: matterContacts, contact: contacts })
       .from(matterContacts)
       .innerJoin(contacts, eq(matterContacts.contactId, contacts.id))
-      .where(and(eq(matterContacts.matterId, asId<"MatterId">(id)), isNull(matterContacts.deletedAt)))
+      .where(and(eq(matterContacts.matterId, id), isNull(matterContacts.deletedAt)))
       .orderBy(asc(matterContacts.createdAt));
     const linkContacts = rows.map((r) => ({ ...r.mc, contact: r.contact }));
     const counts = (await this.countsFor([id])).get(id) ?? { documents: 0, timeEntries: 0, contacts: 0 };
@@ -129,20 +129,20 @@ export class DrizzleMatterRepository extends DrizzleRepository<Matter> implement
     };
   }
 
-  async listByResponsibleLawyer(organizationId: string, responsibleLawyerId: string): Promise<Matter[]> {
+  async listByResponsibleLawyer(organizationId: OrganizationId, responsibleLawyerId: UserId): Promise<Matter[]> {
     const rows = await this.db.select().from(matters)
       .where(and(
-        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
-        eq(matters.responsibleLawyerId, asId<"UserId">(responsibleLawyerId)),
+        eq(matters.organizationId, organizationId),
+        eq(matters.responsibleLawyerId, responsibleLawyerId),
         isNull(matters.deletedAt),
       ));
     return this.asRows(rows);
   }
 
-  async listByNumberPrefix(organizationId: string, prefix: string): Promise<Matter[]> {
+  async listByNumberPrefix(organizationId: OrganizationId, prefix: string): Promise<Matter[]> {
     const rows = await this.db.select().from(matters)
       .where(and(
-        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
+        eq(matters.organizationId, organizationId),
         ilike(matters.matterNumber, `${prefix}%`),
         isNull(matters.deletedAt),
       ));

--- a/src/lib/server/repositories/in-memory-contact-repository.ts
+++ b/src/lib/server/repositories/in-memory-contact-repository.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Contact } from "@/lib/shared/schemas/contact";
+import type { ContactId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { IDataStore } from "../data-store/IDataStore";
 import type {
   ContactFull, ContactListOptions, ContactListResult, ContactListRow, ContactRepository,
@@ -19,7 +20,7 @@ export class InMemoryContactRepository extends InMemoryRepository<Contact> imple
     super(store.contacts, now ?? (() => new Date()));
   }
 
-  async listForOrg(organizationId: string, opts: ContactListOptions): Promise<ContactListResult> {
+  async listForOrg(organizationId: OrganizationId, opts: ContactListOptions): Promise<ContactListResult> {
     const where = {
       organizationId,
       parentId: null,
@@ -48,7 +49,7 @@ export class InMemoryContactRepository extends InMemoryRepository<Contact> imple
     return { contacts, total };
   }
 
-  async getByIdFull(id: string, organizationId: string): Promise<ContactFull | null> {
+  async getByIdFull(id: ContactId, organizationId: OrganizationId): Promise<ContactFull | null> {
     const row = (await this.delegate.findFirst({
       where: { id, organizationId },
       include: {
@@ -63,11 +64,11 @@ export class InMemoryContactRepository extends InMemoryRepository<Contact> imple
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }
 
-  async findByPersonalNumber(organizationId: string, personalNumber: string): Promise<Contact | null> {
+  async findByPersonalNumber(organizationId: OrganizationId, personalNumber: string): Promise<Contact | null> {
     return (await this.delegate.findFirst({ where: { personalNumber, organizationId } })) as Contact | null;
   }
 
-  async findByOrgNumber(organizationId: string, orgNumber: string): Promise<Contact | null> {
+  async findByOrgNumber(organizationId: OrganizationId, orgNumber: string): Promise<Contact | null> {
     return (await this.delegate.findFirst({ where: { orgNumber, organizationId } })) as Contact | null;
   }
 }

--- a/src/lib/server/repositories/in-memory-matter-contact-repository.ts
+++ b/src/lib/server/repositories/in-memory-matter-contact-repository.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Contact } from "@/lib/shared/schemas/contact";
+import type { ContactId, MatterContactId, MatterId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { MatterContact } from "@/lib/shared/schemas/matter";
 import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
@@ -30,7 +31,7 @@ export class InMemoryMatterContactRepository
     super(source.matterContacts, now ?? (() => new Date()));
   }
 
-  async findForConflict(organizationId: string, numberTerm?: string): Promise<ConflictContactRow[]> {
+  async findForConflict(organizationId: OrganizationId, numberTerm?: string): Promise<ConflictContactRow[]> {
     const where = numberTerm
       ? {
           matter: { organizationId },
@@ -47,7 +48,7 @@ export class InMemoryMatterContactRepository
     }));
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<MatterContact | null> {
+  async getByIdInOrg(id: MatterContactId, organizationId: OrganizationId): Promise<MatterContact | null> {
     const row = (await this.delegate.findFirst({
       where: { id, matter: { organizationId } },
     })) as (MatterContact & { deletedAt?: unknown }) | null;
@@ -61,11 +62,11 @@ export class InMemoryMatterContactRepository
     return row as MatterContactWithContact;
   }
 
-  async findLink(matterId: string, contactId: string, role: string): Promise<MatterContact | null> {
+  async findLink(matterId: MatterId, contactId: ContactId, role: string): Promise<MatterContact | null> {
     return (await this.delegate.findFirst({ where: { matterId, contactId, role } })) as MatterContact | null;
   }
 
-  async listContactsForMatter(matterId: string): Promise<Contact[]> {
+  async listContactsForMatter(matterId: MatterId): Promise<Contact[]> {
     const rows = (await this.delegate.findMany({
       where: { matterId }, include: { contact: true },
     })) as Array<{ contact: Contact }>;

--- a/src/lib/server/repositories/in-memory-matter-event-suggestion-repository.ts
+++ b/src/lib/server/repositories/in-memory-matter-event-suggestion-repository.ts
@@ -4,6 +4,7 @@
  */
 
 import type { MatterEventSuggestion } from "@/lib/shared/schemas/document";
+import type { MatterEventSuggestionId, MatterId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type {
@@ -19,7 +20,7 @@ export class InMemoryMatterEventSuggestionRepository
     super(store.matterEventSuggestions, now ?? (() => new Date()));
   }
 
-  async listForMatter(matterId: string, organizationId: string): Promise<MatterEventSuggestionRow[]> {
+  async listForMatter(matterId: MatterId, organizationId: OrganizationId): Promise<MatterEventSuggestionRow[]> {
     return (await this.delegate.findMany({
       where: {
         status: { not: "REJECTED" },
@@ -30,7 +31,7 @@ export class InMemoryMatterEventSuggestionRepository
     })) as MatterEventSuggestionRow[];
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<MatterEventSuggestion | null> {
+  async getByIdInOrg(id: MatterEventSuggestionId, organizationId: OrganizationId): Promise<MatterEventSuggestion | null> {
     const row = (await this.delegate.findFirst({
       where: { id, document: { matter: { organizationId } } },
     })) as (MatterEventSuggestion & { deletedAt?: unknown }) | null;

--- a/src/lib/server/repositories/in-memory-matter-repository.ts
+++ b/src/lib/server/repositories/in-memory-matter-repository.ts
@@ -3,6 +3,7 @@
  * och org-scopar direkt på `organizationId` (ärenden saknar relations-beroende).
  */
 
+import type { MatterId, OrganizationId, UserId } from "@/lib/shared/schemas/ids";
 import type { Matter } from "@/lib/shared/schemas/matter";
 import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
@@ -14,7 +15,7 @@ import type {
 export type MatterRepoSource = Pick<IDataStore, "matters">;
 
 /** Org-scopat where för listan (replikerar routerns Prisma-where). */
-function listWhere(organizationId: string, f: MatterListFilter): Record<string, unknown> {
+function listWhere(organizationId: OrganizationId, f: MatterListFilter): Record<string, unknown> {
   const ins = (s: string) => ({ contains: s, mode: "insensitive" as const });
   return {
     organizationId,
@@ -37,17 +38,17 @@ export class InMemoryMatterRepository extends InMemoryRepository<Matter> impleme
     super(store.matters, now ?? (() => new Date()));
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<Matter | null> {
+  async getByIdInOrg(id: MatterId, organizationId: OrganizationId): Promise<Matter | null> {
     const row = (await this.delegate.findFirst({ where: { id, organizationId } })) as Matter | null;
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }
 
-  async listByOrg(organizationId: string): Promise<Matter[]> {
+  async listByOrg(organizationId: OrganizationId): Promise<Matter[]> {
     const rows = (await this.delegate.findMany({ where: { organizationId } })) as Matter[];
     return rows.filter((r) => !(r as { deletedAt?: unknown }).deletedAt);
   }
 
-  async listForOrg(organizationId: string, filter: MatterListFilter): Promise<MatterListResult> {
+  async listForOrg(organizationId: OrganizationId, filter: MatterListFilter): Promise<MatterListResult> {
     const where = listWhere(organizationId, filter);
     const [matters, total] = await Promise.all([
       this.delegate.findMany({
@@ -65,7 +66,7 @@ export class InMemoryMatterRepository extends InMemoryRepository<Matter> impleme
     return { matters, total };
   }
 
-  async getByIdWithContacts(id: string, organizationId: string): Promise<MatterDetailRow | null> {
+  async getByIdWithContacts(id: MatterId, organizationId: OrganizationId): Promise<MatterDetailRow | null> {
     const row = (await this.delegate.findFirst({
       where: { id, organizationId },
       include: {
@@ -76,11 +77,11 @@ export class InMemoryMatterRepository extends InMemoryRepository<Matter> impleme
     return row && !row.deletedAt ? row : null;
   }
 
-  async listByResponsibleLawyer(organizationId: string, responsibleLawyerId: string): Promise<Matter[]> {
+  async listByResponsibleLawyer(organizationId: OrganizationId, responsibleLawyerId: UserId): Promise<Matter[]> {
     return (await this.delegate.findMany({ where: { organizationId, responsibleLawyerId } })) as Matter[];
   }
 
-  async listByNumberPrefix(organizationId: string, prefix: string): Promise<Matter[]> {
+  async listByNumberPrefix(organizationId: OrganizationId, prefix: string): Promise<Matter[]> {
     return (await this.delegate.findMany({
       where: { organizationId, matterNumber: { startsWith: prefix } },
     })) as Matter[];

--- a/src/lib/server/repositories/matter-contact-repository.ts
+++ b/src/lib/server/repositories/matter-contact-repository.ts
@@ -6,6 +6,7 @@
 
 import type { Contact } from "@/lib/shared/schemas/contact";
 import type { ContactType, MatterRole } from "@/lib/shared/schemas/enums";
+import type { ContactId, MatterContactId, MatterId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { MatterContact } from "@/lib/shared/schemas/matter";
 import type { Repository } from "./types";
 
@@ -18,11 +19,11 @@ export interface MatterContactWithContact extends MatterContact {
 export interface ConflictContactRow {
   role: MatterRole;
   contact: {
-    id: string; name: string; contactType: ContactType;
+    id: ContactId; name: string; contactType: ContactType;
     personalNumber: string | null; orgNumber: string | null;
   };
   matter: {
-    id: string; matterNumber: string; title: string;
+    id: MatterId; matterNumber: string; title: string;
     contacts: Array<{ contact: { name: string } }>;
   };
 }
@@ -33,14 +34,14 @@ export interface MatterContactRepository extends Repository<MatterContact> {
    * filtrerar på contact.personalNumber/orgNumber (delsträng); annars alla
    * (namn-fuzzy görs i routern).
    */
-  findForConflict(organizationId: string, numberTerm?: string): Promise<ConflictContactRow[]>;
+  findForConflict(organizationId: OrganizationId, numberTerm?: string): Promise<ConflictContactRow[]>;
   /** Länk by id, org-scopad via ärendet. Null om saknas/annan org/raderad. */
-  getByIdInOrg(id: string, organizationId: string): Promise<MatterContact | null>;
+  getByIdInOrg(id: MatterContactId, organizationId: OrganizationId): Promise<MatterContact | null>;
   /** Skapa en länk och returnera den med kontakten (matter.addContact/addNewContact). */
   linkContact(data: Partial<MatterContact>): Promise<MatterContactWithContact>;
   /** Befintlig länk (ärende, kontakt, roll) — för idempotent koppling. Null om ingen. */
   // role förblir `string` tills suggestions-flödets roll-typ tightas (A3, #750)
-  findLink(matterId: string, contactId: string, role: string): Promise<MatterContact | null>;
+  findLink(matterId: MatterId, contactId: ContactId, role: string): Promise<MatterContact | null>;
   /** Kontakterna kopplade till ett ärende (dedup-underlag i förslags-flödet). */
-  listContactsForMatter(matterId: string): Promise<Contact[]>;
+  listContactsForMatter(matterId: MatterId): Promise<Contact[]>;
 }

--- a/src/lib/server/repositories/matter-event-suggestion-repository.ts
+++ b/src/lib/server/repositories/matter-event-suggestion-repository.ts
@@ -4,16 +4,17 @@
  */
 
 import type { MatterEventSuggestion } from "@/lib/shared/schemas/document";
+import type { DocumentId, MatterEventSuggestionId, MatterId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { Repository } from "./types";
 
 /** Händelse + ursprungsdokumentet (listvyn). */
 export interface MatterEventSuggestionRow extends MatterEventSuggestion {
-  document: { id: string; fileName: string; title: string | null };
+  document: { id: DocumentId; fileName: string; title: string | null };
 }
 
 export interface MatterEventSuggestionRepository extends Repository<MatterEventSuggestion> {
   /** Icke-avvisade händelser för ett ärende (startAt asc), org-scopat via dokumentet. */
-  listForMatter(matterId: string, organizationId: string): Promise<MatterEventSuggestionRow[]>;
+  listForMatter(matterId: MatterId, organizationId: OrganizationId): Promise<MatterEventSuggestionRow[]>;
   /** Händelse by id, org-scopad via dokument→ärende. Null om saknas/annan org/raderad. */
-  getByIdInOrg(id: string, organizationId: string): Promise<MatterEventSuggestion | null>;
+  getByIdInOrg(id: MatterEventSuggestionId, organizationId: OrganizationId): Promise<MatterEventSuggestion | null>;
 }

--- a/src/lib/server/repositories/matter-repository.ts
+++ b/src/lib/server/repositories/matter-repository.ts
@@ -6,6 +6,7 @@
  */
 
 import type { MatterStatus } from "@/lib/shared/schemas/enums";
+import type { ContactId, MatterId, OrganizationId, UserId } from "@/lib/shared/schemas/ids";
 import type { Matter, MatterContact } from "@/lib/shared/schemas/matter";
 import type { Repository } from "./types";
 
@@ -22,7 +23,7 @@ export interface MatterContactContactView {
 
 /** Listrad: ärende + KLIENT-kontakt + relations-antal (matter.list). */
 export interface MatterListRow extends Matter {
-  contacts: Array<{ contact: { id: string; name: string } }>;
+  contacts: Array<{ contact: { id: ContactId; name: string } }>;
   _count: { documents: number; timeEntries: number; contacts: number };
 }
 
@@ -36,7 +37,7 @@ export interface MatterDetailRow extends Matter {
 export interface MatterListFilter {
   search?: string | undefined;
   status?: MatterStatus | undefined;
-  employeeId?: string | undefined;
+  employeeId?: UserId | undefined;
   page: number;
   pageSize: number;
 }
@@ -48,15 +49,15 @@ export interface MatterListResult {
 
 export interface MatterRepository extends Repository<Matter> {
   /** Ärende by id, org-scopat (null om saknas/annan org/raderat). */
-  getByIdInOrg(id: string, organizationId: string): Promise<Matter | null>;
+  getByIdInOrg(id: MatterId, organizationId: OrganizationId): Promise<Matter | null>;
   /** Alla (icke-raderade) ärenden i org:en. */
-  listByOrg(organizationId: string): Promise<Matter[]>;
+  listByOrg(organizationId: OrganizationId): Promise<Matter[]>;
   /** Org-scopad, paginerad/sökbar lista (createdAt desc) med KLIENT + _count + total. */
-  listForOrg(organizationId: string, filter: MatterListFilter): Promise<MatterListResult>;
+  listForOrg(organizationId: OrganizationId, filter: MatterListFilter): Promise<MatterListResult>;
   /** Ärende by id med alla kontakter + _count, org-scopat. Null om saknas. */
-  getByIdWithContacts(id: string, organizationId: string): Promise<MatterDetailRow | null>;
+  getByIdWithContacts(id: MatterId, organizationId: OrganizationId): Promise<MatterDetailRow | null>;
   /** Ärenden för en ansvarig jurist i org:en (#174 ärendenummer-serie). */
-  listByResponsibleLawyer(organizationId: string, responsibleLawyerId: string): Promise<Matter[]>;
+  listByResponsibleLawyer(organizationId: OrganizationId, responsibleLawyerId: UserId): Promise<Matter[]>;
   /** Ärenden i org:en vars nummer börjar med ett prefix (#174 kollisionsfritt). */
-  listByNumberPrefix(organizationId: string, prefix: string): Promise<Matter[]>;
+  listByNumberPrefix(organizationId: OrganizationId, prefix: string): Promise<Matter[]>;
 }

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -27,6 +27,8 @@ import {
   invoiceIdSchema,
   asId,
   type BillingRunId,
+  type MatterId,
+  type OrganizationId,
 } from "@/lib/shared/schemas/ids";
 import { emit } from "../events/emit";
 import type { Repositories } from "../repositories/repositories";
@@ -182,7 +184,7 @@ async function freezeSelectedWork(
   await repos.expenses.freezeByIds(work.expenses.map((e) => e.id), runId, now);
 }
 
-async function assertMatterInOrg(repos: Repositories, matterId: string, orgId: string): Promise<void> {
+async function assertMatterInOrg(repos: Repositories, matterId: MatterId, orgId: OrganizationId): Promise<void> {
   const m = await repos.matters.getByIdInOrg(matterId, orgId);
   if (!m) throw new TRPCError({ code: "NOT_FOUND", message: "Ärendet finns inte." });
 }

--- a/src/lib/server/routers/conflict.ts
+++ b/src/lib/server/routers/conflict.ts
@@ -40,7 +40,7 @@ function toResult(mc: ConflictRow): ConflictResult {
 
 /** Exakt delsträngsmatch på person-/org-nummer. */
 async function searchByNumber(ctx: ConflictCtx, term: string): Promise<ConflictResult[]> {
-  const rows = await ctx.repos.matterContacts.findForConflict(ctx.user.organizationId, term);
+  const rows = await ctx.repos.matterContacts.findForConflict(asId<"OrganizationId">(ctx.user.organizationId), term);
   return rows.map(toResult);
 }
 
@@ -51,7 +51,7 @@ async function searchByNumber(ctx: ConflictCtx, term: string): Promise<ConflictR
  */
 async function searchByName(ctx: ConflictCtx, term: string): Promise<ConflictResult[]> {
   const SIM_THRESHOLD = 0.4;
-  const rows = await ctx.repos.matterContacts.findForConflict(ctx.user.organizationId);
+  const rows = await ctx.repos.matterContacts.findForConflict(asId<"OrganizationId">(ctx.user.organizationId));
   return rows
     .map((row) => ({ row, score: similarity(row.contact.name, term) }))
     .filter((s) => s.score > SIM_THRESHOLD)

--- a/src/lib/server/routers/document/events.ts
+++ b/src/lib/server/routers/document/events.ts
@@ -9,6 +9,7 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import type { MatterEventSuggestion } from "@/lib/shared/schemas/document";
+import { asId } from "@/lib/shared/schemas/ids";
 import { orgProcedure } from "../../trpc";
 
 export const eventProcedures = {
@@ -16,13 +17,13 @@ export const eventProcedures = {
   events: orgProcedure
     .input(z.object({ matterId: z.string() }))
     .query(({ ctx, input }) =>
-      ctx.repos.matterEventSuggestions.listForMatter(input.matterId, ctx.orgId),
+      ctx.repos.matterEventSuggestions.listForMatter(asId<"MatterId">(input.matterId), ctx.orgId),
     ),
 
   rejectEvent: orgProcedure
     .input(z.object({ eventId: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      const ev = await ctx.repos.matterEventSuggestions.getByIdInOrg(input.eventId, ctx.orgId);
+      const ev = await ctx.repos.matterEventSuggestions.getByIdInOrg(asId<"MatterEventSuggestionId">(input.eventId), ctx.orgId);
       if (!ev) throw new TRPCError({ code: "NOT_FOUND" });
       return ctx.repos.matterEventSuggestions.update(ev.id, { status: "REJECTED" } as Partial<MatterEventSuggestion>);
     }),
@@ -31,7 +32,7 @@ export const eventProcedures = {
   markEventAdded: orgProcedure
     .input(z.object({ eventId: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      const ev = await ctx.repos.matterEventSuggestions.getByIdInOrg(input.eventId, ctx.orgId);
+      const ev = await ctx.repos.matterEventSuggestions.getByIdInOrg(asId<"MatterEventSuggestionId">(input.eventId), ctx.orgId);
       if (!ev) throw new TRPCError({ code: "NOT_FOUND" });
       return ctx.repos.matterEventSuggestions.update(ev.id, { status: "ACCEPTED" } as Partial<MatterEventSuggestion>);
     }),

--- a/src/lib/server/routers/document/shared.ts
+++ b/src/lib/server/routers/document/shared.ts
@@ -9,9 +9,10 @@
  */
 
 import { TRPCError } from "@trpc/server";
+import type { MatterId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { Repositories } from "../../repositories/repositories";
 
-export type DocCtx = { repos: Repositories; orgId: string };
+export type DocCtx = { repos: Repositories; orgId: OrganizationId };
 
 /** Verifiera att dokumentet finns och tillhör anropande org. */
 export async function assertDocAccess(ctx: DocCtx, documentId: string) {
@@ -21,7 +22,7 @@ export async function assertDocAccess(ctx: DocCtx, documentId: string) {
 }
 
 /** Verifiera att ärendet finns och tillhör anropande org. */
-export async function assertMatterAccess(ctx: DocCtx, matterId: string) {
+export async function assertMatterAccess(ctx: DocCtx, matterId: MatterId) {
   const m = await ctx.repos.matters.getByIdInOrg(matterId, ctx.orgId);
   if (!m) throw new TRPCError({ code: "NOT_FOUND" });
   return m;

--- a/src/lib/server/routers/document/suggestions.ts
+++ b/src/lib/server/routers/document/suggestions.ts
@@ -15,7 +15,7 @@ import {
 } from "@/lib/shared/contact-dedup";
 import type { DocumentAnalysisSuggestion } from "@/lib/shared/schemas/document";
 import { matterRoleSchema, contactTypeSchema, type SuggestionStatus } from "@/lib/shared/schemas/enums";
-import { asId, type ContactId } from "@/lib/shared/schemas/ids";
+import { asId, type ContactId, type OrganizationId } from "@/lib/shared/schemas/ids";
 import type { MatterContact } from "@/lib/shared/schemas/matter";
 import { groupSuggestions } from "@/lib/shared/suggestion-grouping";
 import type { Repositories } from "../../repositories/repositories";
@@ -24,7 +24,7 @@ import { orgProcedure } from "../../trpc";
 // ─── Helpers för acceptSuggestion ─────────────────────────────────────────
 
 // Migrerad till repository-sömmen (ADR 0020): all IO går via ctx.repos.
-type Ctx = { repos: Repositories; orgId: string };
+type Ctx = { repos: Repositories; orgId: OrganizationId };
 type SuggOverride = {
   name?: string | undefined;
   role?: string | undefined;
@@ -58,7 +58,7 @@ async function loadPendingSuggestion(ctx: Ctx, suggestionId: string): Promise<Su
 }
 
 async function resolveExistingContact(ctx: Ctx, contactId: string): Promise<ContactId> {
-  const existing = (await ctx.repos.contacts.getByIdFull(contactId, ctx.orgId)) as { id: ContactId } | null;
+  const existing = (await ctx.repos.contacts.getByIdFull(asId<"ContactId">(contactId), ctx.orgId)) as { id: ContactId } | null;
   if (!existing) throw new TRPCError({ code: "NOT_FOUND" });
   return existing.id;
 }
@@ -78,7 +78,7 @@ async function findContactByNumberOrName(
   if (on) {
     return (await ctx.repos.contacts.findByOrgNumber(ctx.orgId, on)) as ContactCandidate | null;
   }
-  const matterContacts = (await ctx.repos.matterContacts.listContactsForMatter(matterId)) as ContactCandidate[];
+  const matterContacts = (await ctx.repos.matterContacts.listContactsForMatter(asId<"MatterId">(matterId))) as ContactCandidate[];
   const dedup = findExistingContactForSuggestion(
     {
       name: o.name ?? sugg.name,
@@ -133,7 +133,7 @@ async function ensureMatterContactLink(
   role: string,
   notes: string | null,
 ): Promise<void> {
-  const existing = await ctx.repos.matterContacts.findLink(matterId, contactId, role);
+  const existing = await ctx.repos.matterContacts.findLink(asId<"MatterId">(matterId), asId<"ContactId">(contactId), role);
   if (!existing) {
     await ctx.repos.matterContacts.create({ matterId, contactId, role, notes } as Partial<MatterContact>);
   }
@@ -207,7 +207,7 @@ async function findGroupContact(
     return (await ctx.repos.contacts.findByOrgNumber(ctx.orgId, orgNumber)) as ContactCandidate | null;
   }
   // Namn-fallback scopad till ärendet (se contact-dedup.ts).
-  const matterContacts = (await ctx.repos.matterContacts.listContactsForMatter(matterId)) as ContactCandidate[];
+  const matterContacts = (await ctx.repos.matterContacts.listContactsForMatter(asId<"MatterId">(matterId))) as ContactCandidate[];
   const first = suggs[0];
   if (!first) return null;
   const dedup = findExistingContactForSuggestion(

--- a/src/lib/server/routers/matter.ts
+++ b/src/lib/server/routers/matter.ts
@@ -14,13 +14,14 @@ import {
   asId,
   type MatterId,
   type ContactId,
+  type OrganizationId,
 } from "@/lib/shared/schemas/ids";
 import type { Matter, MatterContact } from "@/lib/shared/schemas/matter";
 import { emit } from "../events/emit";
 import type { Repositories } from "../repositories/repositories";
 import { router, orgProcedure, TRPCError } from "../trpc";
 
-type MatterCtx = { repos: Repositories; orgId: string };
+type MatterCtx = { repos: Repositories; orgId: OrganizationId };
 
 /**
  * Hjälpare: hämta matter och verifiera att den tillhör anropande org.
@@ -104,7 +105,7 @@ async function nextMatterNumber(ctx: MatterCtx, responsibleLawyerId?: string): P
   const prefix = responsibleLawyerId ? await lawyerPrefix(ctx, responsibleLawyerId) : "";
 
   const ownMatters = responsibleLawyerId
-    ? await ctx.repos.matters.listByResponsibleLawyer(ctx.orgId, responsibleLawyerId)
+    ? await ctx.repos.matters.listByResponsibleLawyer(ctx.orgId, asId<"UserId">(responsibleLawyerId))
     : [];
   const prefixMatters = await ctx.repos.matters.listByNumberPrefix(ctx.orgId, `${prefix}${year}-`);
 

--- a/test/unit/server/data-store/caching-sync-data-store.test.ts
+++ b/test/unit/server/data-store/caching-sync-data-store.test.ts
@@ -10,6 +10,7 @@ import { InMemoryPersistence } from "@/lib/server/data-store/in-memory/local-sto
 import type { QueuedMutation } from "@/lib/server/data-store/in-memory/mutation-queue";
 import type { PullResult, PushResult, SyncTransport } from "@/lib/server/data-store/in-memory/sync-transport";
 import { InMemoryMatterRepository } from "@/lib/server/repositories/in-memory-matter-repository";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 
 class FakeTransport implements SyncTransport {
@@ -124,7 +125,7 @@ describe("CachingSyncDataStore (#415)", () => {
       const ds = await CachingSyncDataStore.create({ transport, persistence: new InMemoryPersistence() });
       await ds.reconcile();
 
-      const detail = await new InMemoryMatterRepository(ds.store).getByIdWithContacts(mId, ORG);
+      const detail = await new InMemoryMatterRepository(ds.store).getByIdWithContacts(asId<"MatterId">(mId), asId<"OrganizationId">(ORG));
       expect(detail?.contacts).toHaveLength(1);
       expect(detail?.contacts[0]?.contact?.name).toBe("Anna Andersson");
     });

--- a/test/unit/server/repositories/conflict-matter-contact-repository.test.ts
+++ b/test/unit/server/repositories/conflict-matter-contact-repository.test.ts
@@ -12,10 +12,11 @@ import { DrizzleMatterContactRepository } from "@/lib/server/repositories/drizzl
 import { InMemoryConflictCheckRepository } from "@/lib/server/repositories/in-memory-conflict-check-repository";
 import { InMemoryMatterContactRepository } from "@/lib/server/repositories/in-memory-matter-contact-repository";
 import { prebakeJoins } from "@/lib/shared/demo-source";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
-const ORG = "33333333-3333-7333-8333-333333333333";
+const ORG = asId<"OrganizationId">("33333333-3333-7333-8333-333333333333");
 
 describe("Conflict/MatterContact repos — in-memory", () => {
   it("findForConflict (nummer + alla) + listHistory", async () => {
@@ -64,7 +65,7 @@ describe("Conflict/MatterContact repos — Drizzle (pglite)", () => {
 
   it("findForConflict (nummer + alla) + listHistory", async () => {
     const db = handle.db;
-    const org = uuidv7();
+    const org = asId<"OrganizationId">(uuidv7());
     const mId = uuidv7();
     const cMot = uuidv7();
     const cKli = uuidv7();
@@ -97,15 +98,15 @@ describe("Conflict/MatterContact repos — Drizzle (pglite)", () => {
 // ─── MatterContactRepository: CRUD-/läs-metoderna (getByIdInOrg, findLink,
 //     listContactsForMatter, linkContact) — paritet in-memory + Drizzle. ───
 
-const ORG2 = "44444444-4444-7444-8444-444444444444";
-const OTHER_ORG = "55555555-5555-7555-8555-555555555555";
+const ORG2 = asId<"OrganizationId">("44444444-4444-7444-8444-444444444444");
+const OTHER_ORG = asId<"OrganizationId">("55555555-5555-7555-8555-555555555555");
 
 describe("MatterContactRepository — läs-/skriv-metoder (in-memory)", () => {
-  const mId = uuidv7();
-  const cKli = uuidv7();
-  const cMot = uuidv7();
-  const linkKli = uuidv7();
-  const linkMot = uuidv7();
+  const mId = asId<"MatterId">(uuidv7());
+  const cKli = asId<"ContactId">(uuidv7());
+  const cMot = asId<"ContactId">(uuidv7());
+  const linkKli = asId<"MatterContactId">(uuidv7());
+  const linkMot = asId<"MatterContactId">(uuidv7());
 
   function buildStore(): LocalStore {
     const source = prebakeJoins({
@@ -132,7 +133,7 @@ describe("MatterContactRepository — läs-/skriv-metoder (in-memory)", () => {
     const found = await mc.getByIdInOrg(linkKli, ORG2);
     expect(found?.id).toBe(linkKli);
     expect(await mc.getByIdInOrg(linkKli, OTHER_ORG)).toBeNull();
-    expect(await mc.getByIdInOrg(uuidv7(), ORG2)).toBeNull();
+    expect(await mc.getByIdInOrg(asId<"MatterContactId">(uuidv7()), ORG2)).toBeNull();
   });
 
   it("findLink: matchar (ärende, kontakt, roll); null vid annan roll", async () => {
@@ -151,7 +152,7 @@ describe("MatterContactRepository — läs-/skriv-metoder (in-memory)", () => {
   it("linkContact: skapar länk + går att slå upp via findLink", async () => {
     const store = buildStore();
     const mc = repo(store);
-    const cNew = uuidv7();
+    const cNew = asId<"ContactId">(uuidv7());
     // Lägg in kontakten så enrichment har något att joina mot.
     await store.contacts.create({ data: { id: cNew, organizationId: ORG2, name: "Vittne", contactType: "PERSON" } as never });
     const created = await mc.linkContact({ id: uuidv7(), matterId: mId, contactId: cNew, role: "VITTNE" } as never);
@@ -168,12 +169,12 @@ describe("MatterContactRepository — läs-/skriv-metoder (Drizzle/pglite)", () 
 
   it("getByIdInOrg / findLink / listContactsForMatter / linkContact", async () => {
     const db = handle.db;
-    const org = uuidv7();
-    const mId = uuidv7();
-    const cKli = uuidv7();
-    const cMot = uuidv7();
-    const linkKli = uuidv7();
-    const linkMot = uuidv7();
+    const org = asId<"OrganizationId">(uuidv7());
+    const mId = asId<"MatterId">(uuidv7());
+    const cKli = asId<"ContactId">(uuidv7());
+    const cMot = asId<"ContactId">(uuidv7());
+    const linkKli = asId<"MatterContactId">(uuidv7());
+    const linkMot = asId<"MatterContactId">(uuidv7());
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
     await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-9", title: "Y" }));
@@ -185,7 +186,7 @@ describe("MatterContactRepository — läs-/skriv-metoder (Drizzle/pglite)", () 
 
     // getByIdInOrg
     expect((await mc.getByIdInOrg(linkKli, org))?.id).toBe(linkKli);
-    expect(await mc.getByIdInOrg(linkKli, uuidv7())).toBeNull();
+    expect(await mc.getByIdInOrg(linkKli, asId<"OrganizationId">(uuidv7()))).toBeNull();
 
     // findLink
     expect((await mc.findLink(mId, cKli, "KLIENT"))?.id).toBe(linkKli);
@@ -196,7 +197,7 @@ describe("MatterContactRepository — läs-/skriv-metoder (Drizzle/pglite)", () 
     expect(list.map((c) => c.id).sort()).toEqual([cKli, cMot].sort());
 
     // linkContact — skapar länk + returnerar med kontakten joinad
-    const cNew = uuidv7();
+    const cNew = asId<"ContactId">(uuidv7());
     await db.insert(contacts).values(v({ id: cNew, organizationId: org, name: "Vittne", contactType: "PERSON" }));
     const created = await mc.linkContact({ id: uuidv7(), matterId: mId, contactId: cNew, role: "VITTNE" } as never);
     expect(created.contactId).toBe(cNew);

--- a/test/unit/server/repositories/contact-repository.test.ts
+++ b/test/unit/server/repositories/contact-repository.test.ts
@@ -11,13 +11,14 @@ import { contacts, matterContacts, matters } from "@/lib/server/db/schema";
 import { DrizzleContactRepository } from "@/lib/server/repositories/drizzle-contact-repository";
 import { InMemoryContactRepository } from "@/lib/server/repositories/in-memory-contact-repository";
 import { prebakeJoins } from "@/lib/shared/demo-source";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
 describe("ContactRepository — in-memory", () => {
   function seed() {
-    const c1 = uuidv7();
-    const child = uuidv7();
+    const c1 = asId<"ContactId">(uuidv7());
+    const child = asId<"ContactId">(uuidv7());
     const mId = uuidv7();
     // prebakeJoins speglar demo-runtime → nästlade relationer (matterLinks.matter)
     // resolvas, precis som i produktion.
@@ -36,24 +37,24 @@ describe("ContactRepository — in-memory", () => {
   it("listForOrg: topp-nivå + _count + sök", async () => {
     const { store, c1 } = seed();
     const repo = new InMemoryContactRepository(store);
-    const res = await repo.listForOrg("org-1", { page: 1, pageSize: 50 });
+    const res = await repo.listForOrg(asId<"OrganizationId">("org-1"), { page: 1, pageSize: 50 });
     expect(res.total).toBe(1); // child (parentId satt) exkluderad
     expect(res.contacts[0]!.id).toBe(c1);
     expect(res.contacts[0]!._count.children).toBe(1);
     expect(res.contacts[0]!._count.matterLinks).toBe(1);
-    expect((await repo.listForOrg("org-1", { search: "Anna", page: 1, pageSize: 50 })).total).toBe(1);
-    expect((await repo.listForOrg("org-1", { search: "Zzz", page: 1, pageSize: 50 })).total).toBe(0);
-    expect((await repo.listForOrg("org-2", { page: 1, pageSize: 50 })).total).toBe(0); // fel org
+    expect((await repo.listForOrg(asId<"OrganizationId">("org-1"), { search: "Anna", page: 1, pageSize: 50 })).total).toBe(1);
+    expect((await repo.listForOrg(asId<"OrganizationId">("org-1"), { search: "Zzz", page: 1, pageSize: 50 })).total).toBe(0);
+    expect((await repo.listForOrg(asId<"OrganizationId">("org-2"), { page: 1, pageSize: 50 })).total).toBe(0); // fel org
   });
 
   it("getByIdFull: barn + ärende-kopplingar, org-scopad", async () => {
     const { store, c1 } = seed();
     const repo = new InMemoryContactRepository(store);
-    const full = await repo.getByIdFull(c1, "org-1");
+    const full = await repo.getByIdFull(c1, asId<"OrganizationId">("org-1"));
     expect(full?.children).toHaveLength(1);
     expect(full?.matterLinks).toHaveLength(1);
     expect(full?.matterLinks[0]!.matter?.matterNumber).toBe("2026-1");
-    expect(await repo.getByIdFull(c1, "org-2")).toBeNull(); // fel org
+    expect(await repo.getByIdFull(c1, asId<"OrganizationId">("org-2"))).toBeNull(); // fel org
   });
 });
 
@@ -64,9 +65,9 @@ describe("ContactRepository — Drizzle (pglite)", () => {
 
   it("listForOrg + getByIdFull (subquery-_count, join-detalj)", async () => {
     const db = handle.db;
-    const org = uuidv7();
-    const c1 = uuidv7();
-    const child = uuidv7();
+    const org = asId<"OrganizationId">(uuidv7());
+    const c1 = asId<"ContactId">(uuidv7());
+    const child = asId<"ContactId">(uuidv7());
     const mId = uuidv7();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
@@ -88,6 +89,6 @@ describe("ContactRepository — Drizzle (pglite)", () => {
     expect(full?.children).toHaveLength(1);
     expect(full?.matterLinks).toHaveLength(1);
     expect(full?.matterLinks[0]!.matter.matterNumber).toBe("2026-1");
-    expect(await repo.getByIdFull(c1, uuidv7())).toBeNull();
+    expect(await repo.getByIdFull(c1, asId<"OrganizationId">(uuidv7()))).toBeNull();
   });
 });

--- a/test/unit/server/repositories/expected-receivable-repository.test.ts
+++ b/test/unit/server/repositories/expected-receivable-repository.test.ts
@@ -10,6 +10,7 @@ import { DrizzleExpectedReceivableRepository } from "@/lib/server/repositories/d
 import { DrizzleMatterRepository } from "@/lib/server/repositories/drizzle-matter-repository";
 import { InMemoryExpectedReceivableRepository } from "@/lib/server/repositories/in-memory-expected-receivable-repository";
 import { InMemoryMatterRepository } from "@/lib/server/repositories/in-memory-matter-repository";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
@@ -29,7 +30,7 @@ describe("ExpectedReceivableRepository — in-memory", () => {
     expect(await repo.listForOrg("org-1", { status: "PENDING" })).toHaveLength(1);
     expect(await repo.getByIdInOrg(r1, "org-1")).toMatchObject({ id: r1 });
     expect(await repo.getByIdInOrg(r1, "org-2")).toBeNull();
-    expect(await new InMemoryMatterRepository(store).listByOrg("org-1")).toHaveLength(1);
+    expect(await new InMemoryMatterRepository(store).listByOrg(asId<"OrganizationId">("org-1"))).toHaveLength(1);
   });
 });
 
@@ -53,6 +54,6 @@ describe("ExpectedReceivableRepository — Drizzle (pglite)", () => {
     expect(await repo.listForOrg(org, { status: "PENDING" })).toHaveLength(1);
     expect(await repo.getByIdInOrg(r1, org)).toMatchObject({ id: r1 });
     expect(await repo.getByIdInOrg(r1, uuidv7())).toBeNull();
-    expect(await new DrizzleMatterRepository(handle.db).listByOrg(org)).toHaveLength(1);
+    expect(await new DrizzleMatterRepository(handle.db).listByOrg(asId<"OrganizationId">(org))).toHaveLength(1);
   });
 });

--- a/test/unit/server/repositories/matter-event-suggestion-repository.test.ts
+++ b/test/unit/server/repositories/matter-event-suggestion-repository.test.ts
@@ -10,16 +10,17 @@ import { documents, matterEventSuggestions, matters } from "@/lib/server/db/sche
 import { DrizzleMatterEventSuggestionRepository } from "@/lib/server/repositories/drizzle-matter-event-suggestion-repository";
 import { InMemoryMatterEventSuggestionRepository } from "@/lib/server/repositories/in-memory-matter-event-suggestion-repository";
 import { prebakeJoins } from "@/lib/shared/demo-source";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
-const ORG = "22222222-2222-7222-8222-222222222222";
+const ORG = asId<"OrganizationId">("22222222-2222-7222-8222-222222222222");
 
 describe("MatterEventSuggestionRepository — in-memory", () => {
   it("listForMatter (ej REJECTED, sorterad) + getByIdInOrg", async () => {
-    const mId = uuidv7();
+    const mId = asId<"MatterId">(uuidv7());
     const dId = uuidv7();
-    const e1 = uuidv7();
+    const e1 = asId<"MatterEventSuggestionId">(uuidv7());
     const source = prebakeJoins({
       matters: [{ id: mId, organizationId: ORG, matterNumber: "2026-1", title: "T" }],
       documents: [{ id: dId, matterId: mId, fileName: "s.pdf", title: "Stämning" }],
@@ -36,7 +37,7 @@ describe("MatterEventSuggestionRepository — in-memory", () => {
     expect(list.map((r) => r.title)).toEqual(["Tidig", "Sen"]);
     expect(list[0]!.document.fileName).toBe("s.pdf");
     expect(await repo.getByIdInOrg(e1, ORG)).toMatchObject({ id: e1 });
-    expect(await repo.getByIdInOrg(e1, uuidv7())).toBeNull();
+    expect(await repo.getByIdInOrg(e1, asId<"OrganizationId">(uuidv7()))).toBeNull();
   });
 });
 
@@ -47,10 +48,10 @@ describe("MatterEventSuggestionRepository — Drizzle (pglite)", () => {
 
   it("listForMatter + getByIdInOrg", async () => {
     const db = handle.db;
-    const org = uuidv7();
-    const mId = uuidv7();
+    const org = asId<"OrganizationId">(uuidv7());
+    const mId = asId<"MatterId">(uuidv7());
     const dId = uuidv7();
-    const e1 = uuidv7();
+    const e1 = asId<"MatterEventSuggestionId">(uuidv7());
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
     await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
@@ -64,6 +65,6 @@ describe("MatterEventSuggestionRepository — Drizzle (pglite)", () => {
     expect(list.map((r) => r.title)).toEqual(["Tidig", "Sen"]);
     expect(list[0]!.document.fileName).toBe("s.pdf");
     expect(await repo.getByIdInOrg(e1, org)).toMatchObject({ id: e1 });
-    expect(await repo.getByIdInOrg(e1, uuidv7())).toBeNull();
+    expect(await repo.getByIdInOrg(e1, asId<"OrganizationId">(uuidv7()))).toBeNull();
   });
 });

--- a/test/unit/server/repositories/matter-reads-repository.test.ts
+++ b/test/unit/server/repositories/matter-reads-repository.test.ts
@@ -16,17 +16,18 @@ import { InMemoryContactRepository } from "@/lib/server/repositories/in-memory-c
 import { InMemoryMatterContactRepository } from "@/lib/server/repositories/in-memory-matter-contact-repository";
 import { InMemoryMatterRepository } from "@/lib/server/repositories/in-memory-matter-repository";
 import { prebakeJoins } from "@/lib/shared/demo-source";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
-const ORG = "66666666-6666-7666-8666-666666666666";
+const ORG = asId<"OrganizationId">("66666666-6666-7666-8666-666666666666");
 
 describe("Matter-läsningar — in-memory", () => {
   it("listForOrg/_count + getByIdWithContacts + serie-läsningar + contact-dedup", async () => {
-    const mId = uuidv7();
-    const cId = uuidv7();
-    const uId = uuidv7();
-    const mcId = uuidv7();
+    const mId = asId<"MatterId">(uuidv7());
+    const cId = asId<"ContactId">(uuidv7());
+    const uId = asId<"UserId">(uuidv7());
+    const mcId = asId<"MatterContactId">(uuidv7());
     const source = prebakeJoins({
       matters: [
         { id: mId, organizationId: ORG, matterNumber: "AA2026-0001", title: "Tvist", status: "ACTIVE", responsibleLawyerId: uId, createdAt: new Date("2026-01-01") },
@@ -52,13 +53,13 @@ describe("Matter-läsningar — in-memory", () => {
 
     const detail = await mRepo.getByIdWithContacts(mId, ORG);
     expect(detail?.contacts).toHaveLength(1);
-    expect(await mRepo.getByIdWithContacts(mId, uuidv7())).toBeNull();
+    expect(await mRepo.getByIdWithContacts(mId, asId<"OrganizationId">(uuidv7()))).toBeNull();
 
     expect((await mRepo.listByResponsibleLawyer(ORG, uId)).length).toBe(1);
     expect((await mRepo.listByNumberPrefix(ORG, "AA2026-")).length).toBe(1);
 
     expect(await mcRepo.getByIdInOrg(mcId, ORG)).toMatchObject({ id: mcId });
-    expect(await mcRepo.getByIdInOrg(mcId, uuidv7())).toBeNull();
+    expect(await mcRepo.getByIdInOrg(mcId, asId<"OrganizationId">(uuidv7()))).toBeNull();
 
     expect((await cRepo.findByOrgNumber(ORG, "556-1"))?.id).toBe(cId);
     expect(await cRepo.findByPersonalNumber(ORG, "x")).toBeNull();
@@ -72,11 +73,11 @@ describe("Matter-läsningar — Drizzle (pglite)", () => {
 
   it("listForOrg/_count + getByIdWithContacts + serie + contact-dedup + linkContact", async () => {
     const db = handle.db;
-    const org = uuidv7();
-    const mId = uuidv7();
-    const cId = uuidv7();
-    const uId = uuidv7();
-    const mcId = uuidv7();
+    const org = asId<"OrganizationId">(uuidv7());
+    const mId = asId<"MatterId">(uuidv7());
+    const cId = asId<"ContactId">(uuidv7());
+    const uId = asId<"UserId">(uuidv7());
+    const mcId = asId<"MatterContactId">(uuidv7());
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
     await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "AA2026-0001", title: "Tvist", status: "ACTIVE", responsibleLawyerId: uId }));
@@ -100,13 +101,13 @@ describe("Matter-läsningar — Drizzle (pglite)", () => {
     const detail = await mRepo.getByIdWithContacts(mId, org);
     expect(detail?.contacts).toHaveLength(1);
     expect(detail?._count.documents).toBe(1);
-    expect(await mRepo.getByIdWithContacts(mId, uuidv7())).toBeNull();
+    expect(await mRepo.getByIdWithContacts(mId, asId<"OrganizationId">(uuidv7()))).toBeNull();
 
     expect((await mRepo.listByResponsibleLawyer(org, uId)).length).toBe(1);
     expect((await mRepo.listByNumberPrefix(org, "AA2026-")).length).toBe(1);
 
     expect(await mcRepo.getByIdInOrg(mcId, org)).toMatchObject({ id: mcId });
-    expect(await mcRepo.getByIdInOrg(mcId, uuidv7())).toBeNull();
+    expect(await mcRepo.getByIdInOrg(mcId, asId<"OrganizationId">(uuidv7()))).toBeNull();
     expect((await cRepo.findByOrgNumber(org, "556-1"))?.id).toBe(cId);
 
     const link = await mcRepo.linkContact({ id: uuidv7(), matterId: mId, contactId: cId, role: "MOTPART" } as never);

--- a/test/unit/server/repositories/matter-repository.test.ts
+++ b/test/unit/server/repositories/matter-repository.test.ts
@@ -14,7 +14,7 @@ import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
-const matterId = uuidv7();
+const matterId = asId<"MatterId">(uuidv7());
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const matter = (o: Record<string, unknown> = {}): any => ({
@@ -46,8 +46,8 @@ describe("MatterRepository — in-memory", () => {
   it("getByIdInOrg org-scopar direkt på organizationId", async () => {
     const store = new LocalStore({ matters: [matter({ id: matterId, organizationId: "org-1" })] }, async () => {});
     const repo = new InMemoryMatterRepository(store);
-    expect(await repo.getByIdInOrg(matterId, "org-1")).toMatchObject({ id: matterId });
-    expect(await repo.getByIdInOrg(matterId, "org-2")).toBeNull(); // fel org
+    expect(await repo.getByIdInOrg(matterId, asId<"OrganizationId">("org-1"))).toMatchObject({ id: matterId });
+    expect(await repo.getByIdInOrg(matterId, asId<"OrganizationId">("org-2"))).toBeNull(); // fel org
   });
 });
 
@@ -72,12 +72,12 @@ describe("MatterRepository — Drizzle (pglite)", () => {
 
   it("getByIdInOrg org-scopar direkt på organizationId", async () => {
     const db = handle.db;
-    const org = uuidv7();
-    const id = uuidv7();
+    const org = asId<"OrganizationId">(uuidv7());
+    const id = asId<"MatterId">(uuidv7());
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await db.insert(matters).values({ id, organizationId: org, matterNumber: "2026-2", title: "T", version: 1 } as any);
     const repo = new DrizzleMatterRepository(handle.db);
     expect(await repo.getByIdInOrg(id, org)).toMatchObject({ id });
-    expect(await repo.getByIdInOrg(id, uuidv7())).toBeNull(); // fel org
+    expect(await repo.getByIdInOrg(id, asId<"OrganizationId">(uuidv7()))).toBeNull(); // fel org
   });
 });


### PR DESCRIPTION
ID-brandning per domängrupp (B1, #750). matter / contact / matter-contact / matter-event-suggestion-repos (interface + drizzle + in-memory): id/organizationId/matterId/contactId/responsibleLawyerId/employeeId-params + DTO-id-fält → `MatterId`/`ContactId`/`MatterContactId`/`MatterEventSuggestionId`/`OrganizationId`/`UserId`/`DocumentId`.

Kaskad fixad: lokala `Ctx`-alias `orgId` → `OrganizationId`, `asId` vid loosa projektioner/string-gränser i matter/conflict/document-routrar, borttagna redundanta drizzle-cast, + test-id-literaler brandade. `role`/`prefix` förblir `string` (deferred). Inga typer försvagade.

## Test
Ren tsc (root+test, 0), lint grön, 1134 server/integration-tester gröna.

Refs #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)