### PR TITLE
refactor(repos): branda document-domänens id-params (B1d)

### DIFF
--- a/src/lib/server/repositories/document-folder-repository.ts
+++ b/src/lib/server/repositories/document-folder-repository.ts
@@ -4,6 +4,7 @@
  */
 
 import type { DocumentFolder } from "@/lib/shared/schemas/document";
+import type { DocumentFolderId, MatterId } from "@/lib/shared/schemas/ids";
 import type { Repository } from "./types";
 
 /** Mapp + antal direkta dokument/undermappar (dokumentlistan). */
@@ -13,9 +14,9 @@ export interface DocumentFolderWithCounts extends DocumentFolder {
 
 export interface DocumentFolderRepository extends Repository<DocumentFolder> {
   /** Direkta undermappar i ett ärende/parent (namn asc) med `_count`. */
-  listInParent(matterId: string, parentId: string | null): Promise<DocumentFolderWithCounts[]>;
+  listInParent(matterId: MatterId, parentId: DocumentFolderId | null): Promise<DocumentFolderWithCounts[]>;
   /** Alla mappar i ett ärende (namn asc) — för trädvyn. */
-  listByMatter(matterId: string): Promise<DocumentFolder[]>;
+  listByMatter(matterId: MatterId): Promise<DocumentFolder[]>;
   /** Flytta alla direkta undermappar till en annan parent (vid radering). */
-  reassignParent(fromParentId: string, toParentId: string | null): Promise<void>;
+  reassignParent(fromParentId: DocumentFolderId, toParentId: DocumentFolderId | null): Promise<void>;
 }

--- a/src/lib/server/repositories/document-repository.ts
+++ b/src/lib/server/repositories/document-repository.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Document } from "@/lib/shared/schemas/document";
+import type { DocumentFolderId, DocumentId, MatterId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { Repository } from "./types";
 
 /** Dokument + uppladdare (listvyn). */
@@ -14,21 +15,21 @@ export interface DocumentListRow extends Document {
 
 /** Smal access-projektion (assertDocAccess). */
 export interface DocumentAccessRow {
-  id: string;
-  matterId: string;
+  id: DocumentId;
+  matterId: MatterId;
 }
 
 export interface DocumentRepository extends Repository<Document> {
   /** Paginerad lista i ett ärende/folder (createdAt desc) + total. */
   listInFolder(
-    matterId: string, folderId: string | null, page: number, pageSize: number,
+    matterId: MatterId, folderId: DocumentFolderId | null, page: number, pageSize: number,
   ): Promise<{ documents: DocumentListRow[]; total: number }>;
   /** Alla dokument i ett ärende (createdAt desc) — för trädvyn. */
-  listByMatter(matterId: string): Promise<DocumentListRow[]>;
+  listByMatter(matterId: MatterId): Promise<DocumentListRow[]>;
   /** Distinkta documentType-värden i org:en + antal per typ (namn-sorterat, sv). */
-  listDocumentTypesForOrg(organizationId: string): Promise<Array<{ type: string; count: number }>>;
+  listDocumentTypesForOrg(organizationId: OrganizationId): Promise<Array<{ type: string; count: number }>>;
   /** Dokument by id, org-scopat via ärendet. Null om saknas/annan org/raderat. */
-  getByIdInOrg(id: string, organizationId: string): Promise<DocumentAccessRow | null>;
+  getByIdInOrg(id: DocumentId, organizationId: OrganizationId): Promise<DocumentAccessRow | null>;
   /** Flytta alla dokument i en folder till en annan (vid folder-radering). */
-  reassignFolder(fromFolderId: string, toFolderId: string | null): Promise<void>;
+  reassignFolder(fromFolderId: DocumentFolderId, toFolderId: DocumentFolderId | null): Promise<void>;
 }

--- a/src/lib/server/repositories/document-suggestion-repository.ts
+++ b/src/lib/server/repositories/document-suggestion-repository.ts
@@ -6,27 +6,28 @@
  */
 
 import type { DocumentAnalysisSuggestion } from "@/lib/shared/schemas/document";
+import type { DocumentAnalysisSuggestionId, DocumentId, MatterId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { Repository } from "./types";
 
 /** Förslag + ursprungsärendet (accept-flödet behöver matterId). */
 export interface SuggestionWithMatter extends DocumentAnalysisSuggestion {
-  document: { matterId: string };
+  document: { matterId: MatterId };
 }
 
 /** Förslag + dokument-metadata (listvyn/gruppning). */
 export interface SuggestionListRow extends DocumentAnalysisSuggestion {
-  document: { id: string; fileName: string; title: string | null };
+  document: { id: DocumentId; fileName: string; title: string | null };
 }
 
 export interface DocumentSuggestionRepository extends Repository<DocumentAnalysisSuggestion> {
   /** Förslag by id, org-scopat via dokument→ärende (med matterId). Null om saknas/annan org. */
-  getByIdInOrg(id: string, organizationId: string): Promise<SuggestionWithMatter | null>;
+  getByIdInOrg(id: DocumentAnalysisSuggestionId, organizationId: OrganizationId): Promise<SuggestionWithMatter | null>;
   /** Pending-förslag för ett ärende (dokument-include), sorterade createdAt. */
-  listPendingForMatter(matterId: string, organizationId: string, order: "asc" | "desc"): Promise<SuggestionListRow[]>;
+  listPendingForMatter(matterId: MatterId, organizationId: OrganizationId, order: "asc" | "desc"): Promise<SuggestionListRow[]>;
   /** Pending-förslag med givna id:n, org-scopat (grupp-accept). */
-  listPendingByIds(ids: string[], organizationId: string): Promise<SuggestionWithMatter[]>;
+  listPendingByIds(ids: DocumentAnalysisSuggestionId[], organizationId: OrganizationId): Promise<SuggestionWithMatter[]>;
   /** Förslag (oavsett status) med givna id:n, org-scopat — id:n (grupp-reject-validering). */
-  listByIdsInOrg(ids: string[], organizationId: string): Promise<Array<{ id: string }>>;
+  listByIdsInOrg(ids: DocumentAnalysisSuggestionId[], organizationId: OrganizationId): Promise<Array<{ id: DocumentAnalysisSuggestionId }>>;
   /** Sätt status (+ ev. acceptedContactId) på flera förslag (grupp). No-op vid tomma ids. */
-  updateManyByIds(ids: string[], patch: Partial<DocumentAnalysisSuggestion>): Promise<void>;
+  updateManyByIds(ids: DocumentAnalysisSuggestionId[], patch: Partial<DocumentAnalysisSuggestion>): Promise<void>;
 }

--- a/src/lib/server/repositories/document-template-repository.ts
+++ b/src/lib/server/repositories/document-template-repository.ts
@@ -3,6 +3,7 @@
  * Org-scopas direkt. Bas-CRUD ärvs; list/detalj tar med skaparens namn.
  */
 
+import type { DocumentTemplateId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { DocumentTemplate } from "@/lib/shared/schemas/misc";
 import type { Repository } from "./types";
 
@@ -13,7 +14,7 @@ export interface DocumentTemplateRow extends DocumentTemplate {
 
 /** Listrad (smal projektion, utan content). */
 export interface DocumentTemplateListRow {
-  id: string;
+  id: DocumentTemplateId;
   name: string;
   description: string | null;
   category: string | null;
@@ -24,7 +25,7 @@ export interface DocumentTemplateListRow {
 
 export interface DocumentTemplateRepository extends Repository<DocumentTemplate> {
   /** Org:ens mallar (kategori asc, namn asc), smal projektion med skapar-namn. */
-  listForOrg(organizationId: string): Promise<DocumentTemplateListRow[]>;
+  listForOrg(organizationId: OrganizationId): Promise<DocumentTemplateListRow[]>;
   /** Mall by id, org-scopad, med skapare. Null om saknas/annan org/raderad. */
-  getByIdInOrg(id: string, organizationId: string): Promise<DocumentTemplateRow | null>;
+  getByIdInOrg(id: DocumentTemplateId, organizationId: OrganizationId): Promise<DocumentTemplateRow | null>;
 }

--- a/src/lib/server/repositories/drizzle-document-folder-repository.ts
+++ b/src/lib/server/repositories/drizzle-document-folder-repository.ts
@@ -5,7 +5,7 @@
 
 import { and, asc, eq, inArray, isNull, sql } from "drizzle-orm";
 import type { DocumentFolder } from "@/lib/shared/schemas/document";
-import { asId } from "@/lib/shared/schemas/ids";
+import type { DocumentFolderId, MatterId } from "@/lib/shared/schemas/ids";
 import { documentFolders, documents } from "../db/schema";
 import type { AppDb } from "../db/types";
 import type {
@@ -15,8 +15,8 @@ import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import { matterOrg } from "./matter-org";
 
 /** documentFolders.parentId = X, eller IS NULL för rot. */
-function parentEq(parentId: string | null) {
-  return parentId === null ? isNull(documentFolders.parentId) : eq(documentFolders.parentId, asId<"DocumentFolderId">(parentId));
+function parentEq(parentId: DocumentFolderId | null) {
+  return parentId === null ? isNull(documentFolders.parentId) : eq(documentFolders.parentId, parentId);
 }
 
 export class DrizzleDocumentFolderRepository
@@ -31,10 +31,10 @@ export class DrizzleDocumentFolderRepository
     return matterOrg(this.db, (row as { matterId?: string }).matterId);
   }
 
-  async listInParent(matterId: string, parentId: string | null): Promise<DocumentFolderWithCounts[]> {
+  async listInParent(matterId: MatterId, parentId: DocumentFolderId | null): Promise<DocumentFolderWithCounts[]> {
     const rows = await this.db
       .select().from(documentFolders)
-      .where(and(eq(documentFolders.matterId, asId<"MatterId">(matterId)), parentEq(parentId), isNull(documentFolders.deletedAt)))
+      .where(and(eq(documentFolders.matterId, matterId), parentEq(parentId), isNull(documentFolders.deletedAt)))
       .orderBy(asc(documentFolders.name));
     const ids = rows.map((r) => r.id);
     // Grupperade count-queries (robustare än korrelerade subqueries, jfr #).
@@ -44,16 +44,16 @@ export class DrizzleDocumentFolderRepository
     }));
   }
 
-  private async countsFor(folderIds: string[]): Promise<Map<string, { documents: number; children: number }>> {
-    const out = new Map<string, { documents: number; children: number }>();
+  private async countsFor(folderIds: DocumentFolderId[]): Promise<Map<DocumentFolderId, { documents: number; children: number }>> {
+    const out = new Map<DocumentFolderId, { documents: number; children: number }>();
     if (folderIds.length === 0) return out;
     const docRows = await this.db
       .select({ id: documents.folderId, n: sql<number>`count(*)` }).from(documents)
-      .where(and(inArray(documents.folderId, folderIds.map((i) => asId<"DocumentFolderId">(i))), isNull(documents.deletedAt)))
+      .where(and(inArray(documents.folderId, folderIds), isNull(documents.deletedAt)))
       .groupBy(documents.folderId);
     const childRows = await this.db
       .select({ id: documentFolders.parentId, n: sql<number>`count(*)` }).from(documentFolders)
-      .where(and(inArray(documentFolders.parentId, folderIds.map((i) => asId<"DocumentFolderId">(i))), isNull(documentFolders.deletedAt)))
+      .where(and(inArray(documentFolders.parentId, folderIds), isNull(documentFolders.deletedAt)))
       .groupBy(documentFolders.parentId);
     for (const id of folderIds) out.set(id, { documents: 0, children: 0 });
     for (const r of docRows) if (r.id) out.get(r.id)!.documents = Number(r.n);
@@ -61,17 +61,17 @@ export class DrizzleDocumentFolderRepository
     return out;
   }
 
-  async listByMatter(matterId: string): Promise<DocumentFolder[]> {
+  async listByMatter(matterId: MatterId): Promise<DocumentFolder[]> {
     const rows = await this.db
       .select().from(documentFolders)
-      .where(and(eq(documentFolders.matterId, asId<"MatterId">(matterId)), isNull(documentFolders.deletedAt)))
+      .where(and(eq(documentFolders.matterId, matterId), isNull(documentFolders.deletedAt)))
       .orderBy(asc(documentFolders.name));
     return rows;
   }
 
-  async reassignParent(fromParentId: string, toParentId: string | null): Promise<void> {
+  async reassignParent(fromParentId: DocumentFolderId, toParentId: DocumentFolderId | null): Promise<void> {
     await this.db.update(documentFolders)
-      .set({ parentId: toParentId === null ? null : asId<"DocumentFolderId">(toParentId) })
-      .where(eq(documentFolders.parentId, asId<"DocumentFolderId">(fromParentId)));
+      .set({ parentId: toParentId })
+      .where(eq(documentFolders.parentId, fromParentId));
   }
 }

--- a/src/lib/server/repositories/drizzle-document-repository.ts
+++ b/src/lib/server/repositories/drizzle-document-repository.ts
@@ -5,7 +5,9 @@
 
 import { and, desc, eq, isNull, sql } from "drizzle-orm";
 import type { Document } from "@/lib/shared/schemas/document";
-import { asId } from "@/lib/shared/schemas/ids";
+import type {
+  DocumentFolderId, DocumentId, MatterId, OrganizationId,
+} from "@/lib/shared/schemas/ids";
 import { documents, matters, users } from "../db/schema";
 import type { AppDb } from "../db/types";
 import type {
@@ -15,8 +17,8 @@ import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 import { matterOrg } from "./matter-org";
 
 /** documents.folderId = X, eller IS NULL för rot. */
-function folderEq(folderId: string | null) {
-  return folderId === null ? isNull(documents.folderId) : eq(documents.folderId, asId<"DocumentFolderId">(folderId));
+function folderEq(folderId: DocumentFolderId | null) {
+  return folderId === null ? isNull(documents.folderId) : eq(documents.folderId, folderId);
 }
 
 function toListRow(r: { doc: typeof documents.$inferSelect; ubName: string | null }): DocumentListRow {
@@ -39,9 +41,9 @@ export class DrizzleDocumentRepository
   }
 
   async listInFolder(
-    matterId: string, folderId: string | null, page: number, pageSize: number,
+    matterId: MatterId, folderId: DocumentFolderId | null, page: number, pageSize: number,
   ): Promise<{ documents: DocumentListRow[]; total: number }> {
-    const where = and(eq(documents.matterId, asId<"MatterId">(matterId)), folderEq(folderId), isNull(documents.deletedAt));
+    const where = and(eq(documents.matterId, matterId), folderEq(folderId), isNull(documents.deletedAt));
     const rows = await this.db
       .select({ doc: documents, ubName: users.name }).from(documents)
       .leftJoin(users, eq(documents.uploadedById, users.id))
@@ -52,20 +54,20 @@ export class DrizzleDocumentRepository
     return { documents: rows.map(toListRow), total: Number(agg?.total ?? 0) };
   }
 
-  async listByMatter(matterId: string): Promise<DocumentListRow[]> {
+  async listByMatter(matterId: MatterId): Promise<DocumentListRow[]> {
     const rows = await this.db
       .select({ doc: documents, ubName: users.name }).from(documents)
       .leftJoin(users, eq(documents.uploadedById, users.id))
-      .where(and(eq(documents.matterId, asId<"MatterId">(matterId)), isNull(documents.deletedAt)))
+      .where(and(eq(documents.matterId, matterId), isNull(documents.deletedAt)))
       .orderBy(desc(documents.createdAt));
     return rows.map(toListRow);
   }
 
-  async listDocumentTypesForOrg(organizationId: string): Promise<Array<{ type: string; count: number }>> {
+  async listDocumentTypesForOrg(organizationId: OrganizationId): Promise<Array<{ type: string; count: number }>> {
     const rows = await this.db
       .select({ type: documents.documentType, count: sql<number>`count(*)` })
       .from(documents).innerJoin(matters, eq(documents.matterId, matters.id))
-      .where(and(eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(documents.deletedAt)))
+      .where(and(eq(matters.organizationId, organizationId), isNull(documents.deletedAt)))
       .groupBy(documents.documentType);
     return rows
       .filter((r): r is { type: string; count: number } => Boolean(r.type))
@@ -73,19 +75,19 @@ export class DrizzleDocumentRepository
       .sort((a, b) => a.type.localeCompare(b.type, "sv"));
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<DocumentAccessRow | null> {
+  async getByIdInOrg(id: DocumentId, organizationId: OrganizationId): Promise<DocumentAccessRow | null> {
     const rows = await this.db
       .select({ id: documents.id, matterId: documents.matterId }).from(documents)
       .innerJoin(matters, eq(documents.matterId, matters.id))
-      .where(and(eq(documents.id, asId<"DocumentId">(id)), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(documents.deletedAt)))
+      .where(and(eq(documents.id, id), eq(matters.organizationId, organizationId), isNull(documents.deletedAt)))
       .limit(1);
     const row = rows[0];
     return row ? { id: row.id, matterId: row.matterId } : null;
   }
 
-  async reassignFolder(fromFolderId: string, toFolderId: string | null): Promise<void> {
+  async reassignFolder(fromFolderId: DocumentFolderId, toFolderId: DocumentFolderId | null): Promise<void> {
     await this.db.update(documents)
-      .set({ folderId: toFolderId === null ? null : asId<"DocumentFolderId">(toFolderId) })
-      .where(eq(documents.folderId, asId<"DocumentFolderId">(fromFolderId)));
+      .set({ folderId: toFolderId })
+      .where(eq(documents.folderId, fromFolderId));
   }
 }

--- a/src/lib/server/repositories/drizzle-document-suggestion-repository.ts
+++ b/src/lib/server/repositories/drizzle-document-suggestion-repository.ts
@@ -5,7 +5,9 @@
 
 import { and, asc, desc, eq, inArray, isNull } from "drizzle-orm";
 import type { DocumentAnalysisSuggestion } from "@/lib/shared/schemas/document";
-import { asId } from "@/lib/shared/schemas/ids";
+import type {
+  DocumentAnalysisSuggestionId, MatterId, OrganizationId,
+} from "@/lib/shared/schemas/ids";
 import { documentAnalysisSuggestions, documents, matters } from "../db/schema";
 import type { AppDb } from "../db/types";
 import type {
@@ -22,25 +24,25 @@ export class DrizzleDocumentSuggestionRepository
     super(db, versionedTable(S), now);
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<SuggestionWithMatter | null> {
+  async getByIdInOrg(id: DocumentAnalysisSuggestionId, organizationId: OrganizationId): Promise<SuggestionWithMatter | null> {
     const rows = await this.db
       .select({ s: S, matterId: documents.matterId }).from(S)
       .innerJoin(documents, eq(S.documentId, documents.id))
       .innerJoin(matters, eq(documents.matterId, matters.id))
-      .where(and(eq(S.id, asId<"DocumentAnalysisSuggestionId">(id)), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(S.deletedAt)))
+      .where(and(eq(S.id, id), eq(matters.organizationId, organizationId), isNull(S.deletedAt)))
       .limit(1);
     const r = rows[0];
     return r ? ({ ...r.s, document: { matterId: r.matterId } }) : null;
   }
 
-  async listPendingForMatter(matterId: string, organizationId: string, order: "asc" | "desc"): Promise<SuggestionListRow[]> {
+  async listPendingForMatter(matterId: MatterId, organizationId: OrganizationId, order: "asc" | "desc"): Promise<SuggestionListRow[]> {
     const rows = await this.db
       .select({ s: S, dId: documents.id, dFile: documents.fileName, dTitle: documents.title }).from(S)
       .innerJoin(documents, eq(S.documentId, documents.id))
       .innerJoin(matters, eq(documents.matterId, matters.id))
       .where(and(
-        eq(S.status, "PENDING"), eq(documents.matterId, asId<"MatterId">(matterId)),
-        eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(S.deletedAt),
+        eq(S.status, "PENDING"), eq(documents.matterId, matterId),
+        eq(matters.organizationId, organizationId), isNull(S.deletedAt),
       ))
       .orderBy(order === "asc" ? asc(S.createdAt) : desc(S.createdAt));
     return rows.map((r) => ({
@@ -49,28 +51,28 @@ export class DrizzleDocumentSuggestionRepository
     }));
   }
 
-  async listPendingByIds(ids: string[], organizationId: string): Promise<SuggestionWithMatter[]> {
+  async listPendingByIds(ids: DocumentAnalysisSuggestionId[], organizationId: OrganizationId): Promise<SuggestionWithMatter[]> {
     if (!ids.length) return [];
     const rows = await this.db
       .select({ s: S, matterId: documents.matterId }).from(S)
       .innerJoin(documents, eq(S.documentId, documents.id))
       .innerJoin(matters, eq(documents.matterId, matters.id))
-      .where(and(inArray(S.id, ids.map((i) => asId<"DocumentAnalysisSuggestionId">(i))), eq(S.status, "PENDING"), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(S.deletedAt)));
+      .where(and(inArray(S.id, ids), eq(S.status, "PENDING"), eq(matters.organizationId, organizationId), isNull(S.deletedAt)));
     return rows.map((r) => ({ ...r.s, document: { matterId: r.matterId } }));
   }
 
-  async listByIdsInOrg(ids: string[], organizationId: string): Promise<Array<{ id: string }>> {
+  async listByIdsInOrg(ids: DocumentAnalysisSuggestionId[], organizationId: OrganizationId): Promise<Array<{ id: DocumentAnalysisSuggestionId }>> {
     if (!ids.length) return [];
     const rows = await this.db
       .select({ id: S.id }).from(S)
       .innerJoin(documents, eq(S.documentId, documents.id))
       .innerJoin(matters, eq(documents.matterId, matters.id))
-      .where(and(inArray(S.id, ids.map((i) => asId<"DocumentAnalysisSuggestionId">(i))), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(S.deletedAt)));
-    return rows.map((r) => ({ id: r.id as string }));
+      .where(and(inArray(S.id, ids), eq(matters.organizationId, organizationId), isNull(S.deletedAt)));
+    return rows.map((r) => ({ id: r.id }));
   }
 
-  async updateManyByIds(ids: string[], patch: Partial<DocumentAnalysisSuggestion>): Promise<void> {
+  async updateManyByIds(ids: DocumentAnalysisSuggestionId[], patch: Partial<DocumentAnalysisSuggestion>): Promise<void> {
     if (!ids.length) return;
-    await this.db.update(S).set(patch as never).where(inArray(S.id, ids.map((i) => asId<"DocumentAnalysisSuggestionId">(i))));
+    await this.db.update(S).set(patch as never).where(inArray(S.id, ids));
   }
 }

--- a/src/lib/server/repositories/drizzle-document-template-repository.ts
+++ b/src/lib/server/repositories/drizzle-document-template-repository.ts
@@ -4,7 +4,7 @@
  */
 
 import { and, asc, eq, isNull } from "drizzle-orm";
-import { asId } from "@/lib/shared/schemas/ids";
+import type { DocumentTemplateId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { DocumentTemplate } from "@/lib/shared/schemas/misc";
 import { documentTemplates, users } from "../db/schema";
 import type { AppDb } from "../db/types";
@@ -20,7 +20,7 @@ export class DrizzleDocumentTemplateRepository
     super(db, versionedTable(documentTemplates), now);
   }
 
-  async listForOrg(organizationId: string): Promise<DocumentTemplateListRow[]> {
+  async listForOrg(organizationId: OrganizationId): Promise<DocumentTemplateListRow[]> {
     const rows = await this.db
       .select({
         id: documentTemplates.id, name: documentTemplates.name,
@@ -30,7 +30,7 @@ export class DrizzleDocumentTemplateRepository
       })
       .from(documentTemplates)
       .leftJoin(users, eq(documentTemplates.createdById, users.id))
-      .where(and(eq(documentTemplates.organizationId, asId<"OrganizationId">(organizationId)), isNull(documentTemplates.deletedAt)))
+      .where(and(eq(documentTemplates.organizationId, organizationId), isNull(documentTemplates.deletedAt)))
       .orderBy(asc(documentTemplates.category), asc(documentTemplates.name));
     return rows.map((r): DocumentTemplateListRow => ({
       id: r.id, name: r.name,
@@ -40,11 +40,11 @@ export class DrizzleDocumentTemplateRepository
     }));
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<DocumentTemplateRow | null> {
+  async getByIdInOrg(id: DocumentTemplateId, organizationId: OrganizationId): Promise<DocumentTemplateRow | null> {
     const rows = await this.db
       .select({ tpl: documentTemplates, cbName: users.name }).from(documentTemplates)
       .leftJoin(users, eq(documentTemplates.createdById, users.id))
-      .where(and(eq(documentTemplates.id, asId<"DocumentTemplateId">(id)), eq(documentTemplates.organizationId, asId<"OrganizationId">(organizationId)), isNull(documentTemplates.deletedAt)))
+      .where(and(eq(documentTemplates.id, id), eq(documentTemplates.organizationId, organizationId), isNull(documentTemplates.deletedAt)))
       .limit(1);
     const row = rows[0];
     if (!row) return null;

--- a/src/lib/server/repositories/in-memory-document-folder-repository.ts
+++ b/src/lib/server/repositories/in-memory-document-folder-repository.ts
@@ -4,6 +4,7 @@
  */
 
 import type { DocumentFolder } from "@/lib/shared/schemas/document";
+import type { DocumentFolderId, MatterId } from "@/lib/shared/schemas/ids";
 import type { IDataStore } from "../data-store/IDataStore";
 import type {
   DocumentFolderRepository, DocumentFolderWithCounts,
@@ -19,7 +20,7 @@ export class InMemoryDocumentFolderRepository
     super(store.documentFolders, now ?? (() => new Date()));
   }
 
-  async listInParent(matterId: string, parentId: string | null): Promise<DocumentFolderWithCounts[]> {
+  async listInParent(matterId: MatterId, parentId: DocumentFolderId | null): Promise<DocumentFolderWithCounts[]> {
     return (await this.delegate.findMany({
       where: { matterId, parentId },
       orderBy: { name: "asc" },
@@ -27,14 +28,14 @@ export class InMemoryDocumentFolderRepository
     })) as DocumentFolderWithCounts[];
   }
 
-  async listByMatter(matterId: string): Promise<DocumentFolder[]> {
+  async listByMatter(matterId: MatterId): Promise<DocumentFolder[]> {
     return (await this.delegate.findMany({
       where: { matterId },
       orderBy: { name: "asc" },
     })) as DocumentFolder[];
   }
 
-  async reassignParent(fromParentId: string, toParentId: string | null): Promise<void> {
+  async reassignParent(fromParentId: DocumentFolderId, toParentId: DocumentFolderId | null): Promise<void> {
     await this.delegate.updateMany({
       where: { parentId: fromParentId },
       data: { parentId: toParentId } as Partial<DocumentFolder>,

--- a/src/lib/server/repositories/in-memory-document-repository.ts
+++ b/src/lib/server/repositories/in-memory-document-repository.ts
@@ -4,6 +4,9 @@
  */
 
 import type { Document } from "@/lib/shared/schemas/document";
+import type {
+  DocumentFolderId, DocumentId, MatterId, OrganizationId,
+} from "@/lib/shared/schemas/ids";
 import type { IDataStore } from "../data-store/IDataStore";
 import type {
   DocumentAccessRow, DocumentListRow, DocumentRepository,
@@ -20,7 +23,7 @@ export class InMemoryDocumentRepository
   }
 
   async listInFolder(
-    matterId: string, folderId: string | null, page: number, pageSize: number,
+    matterId: MatterId, folderId: DocumentFolderId | null, page: number, pageSize: number,
   ): Promise<{ documents: DocumentListRow[]; total: number }> {
     const where = { matterId, folderId };
     const [documents, total] = await Promise.all([
@@ -36,7 +39,7 @@ export class InMemoryDocumentRepository
     return { documents, total };
   }
 
-  async listByMatter(matterId: string): Promise<DocumentListRow[]> {
+  async listByMatter(matterId: MatterId): Promise<DocumentListRow[]> {
     return (await this.delegate.findMany({
       where: { matterId },
       orderBy: { createdAt: "desc" },
@@ -44,7 +47,7 @@ export class InMemoryDocumentRepository
     })) as DocumentListRow[];
   }
 
-  async listDocumentTypesForOrg(organizationId: string): Promise<Array<{ type: string; count: number }>> {
+  async listDocumentTypesForOrg(organizationId: OrganizationId): Promise<Array<{ type: string; count: number }>> {
     const docs = (await this.delegate.findMany({
       where: { matter: { organizationId } },
     })) as Array<{ documentType?: string | null }>;
@@ -58,7 +61,7 @@ export class InMemoryDocumentRepository
       .sort((a, b) => a.type.localeCompare(b.type, "sv"));
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<DocumentAccessRow | null> {
+  async getByIdInOrg(id: DocumentId, organizationId: OrganizationId): Promise<DocumentAccessRow | null> {
     const row = (await this.delegate.findFirst({
       where: { id, matter: { organizationId } },
       select: { id: true, matterId: true, deletedAt: true },
@@ -66,7 +69,7 @@ export class InMemoryDocumentRepository
     return row && !row.deletedAt ? { id: row.id, matterId: row.matterId } : null;
   }
 
-  async reassignFolder(fromFolderId: string, toFolderId: string | null): Promise<void> {
+  async reassignFolder(fromFolderId: DocumentFolderId, toFolderId: DocumentFolderId | null): Promise<void> {
     await this.delegate.updateMany({
       where: { folderId: fromFolderId },
       data: { folderId: toFolderId } as Partial<Document>,

--- a/src/lib/server/repositories/in-memory-document-suggestion-repository.ts
+++ b/src/lib/server/repositories/in-memory-document-suggestion-repository.ts
@@ -4,6 +4,9 @@
  */
 
 import type { DocumentAnalysisSuggestion } from "@/lib/shared/schemas/document";
+import type {
+  DocumentAnalysisSuggestionId, MatterId, OrganizationId,
+} from "@/lib/shared/schemas/ids";
 import type { IDataStore } from "../data-store/IDataStore";
 import type {
   DocumentSuggestionRepository, SuggestionListRow, SuggestionWithMatter,
@@ -19,14 +22,14 @@ export class InMemoryDocumentSuggestionRepository
     super(store.documentAnalysisSuggestions, now ?? (() => new Date()));
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<SuggestionWithMatter | null> {
+  async getByIdInOrg(id: DocumentAnalysisSuggestionId, organizationId: OrganizationId): Promise<SuggestionWithMatter | null> {
     return (await this.delegate.findFirst({
       where: { id, document: { matter: { organizationId } } },
       include: { document: { select: { matterId: true } } },
     })) as SuggestionWithMatter | null;
   }
 
-  async listPendingForMatter(matterId: string, organizationId: string, order: "asc" | "desc"): Promise<SuggestionListRow[]> {
+  async listPendingForMatter(matterId: MatterId, organizationId: OrganizationId, order: "asc" | "desc"): Promise<SuggestionListRow[]> {
     return (await this.delegate.findMany({
       where: { status: "PENDING", document: { matterId, matter: { organizationId } } },
       include: { document: { select: { id: true, fileName: true, title: true } } },
@@ -34,7 +37,7 @@ export class InMemoryDocumentSuggestionRepository
     })) as SuggestionListRow[];
   }
 
-  async listPendingByIds(ids: string[], organizationId: string): Promise<SuggestionWithMatter[]> {
+  async listPendingByIds(ids: DocumentAnalysisSuggestionId[], organizationId: OrganizationId): Promise<SuggestionWithMatter[]> {
     if (!ids.length) return [];
     return (await this.delegate.findMany({
       where: { id: { in: ids }, status: "PENDING", document: { matter: { organizationId } } },
@@ -42,15 +45,15 @@ export class InMemoryDocumentSuggestionRepository
     })) as SuggestionWithMatter[];
   }
 
-  async listByIdsInOrg(ids: string[], organizationId: string): Promise<Array<{ id: string }>> {
+  async listByIdsInOrg(ids: DocumentAnalysisSuggestionId[], organizationId: OrganizationId): Promise<Array<{ id: DocumentAnalysisSuggestionId }>> {
     if (!ids.length) return [];
     return (await this.delegate.findMany({
       where: { id: { in: ids }, document: { matter: { organizationId } } },
       select: { id: true },
-    })) as Array<{ id: string }>;
+    })) as Array<{ id: DocumentAnalysisSuggestionId }>;
   }
 
-  async updateManyByIds(ids: string[], patch: Partial<DocumentAnalysisSuggestion>): Promise<void> {
+  async updateManyByIds(ids: DocumentAnalysisSuggestionId[], patch: Partial<DocumentAnalysisSuggestion>): Promise<void> {
     if (!ids.length) return;
     await this.delegate.updateMany({ where: { id: { in: ids } }, data: patch });
   }

--- a/src/lib/server/repositories/in-memory-document-template-repository.ts
+++ b/src/lib/server/repositories/in-memory-document-template-repository.ts
@@ -2,6 +2,7 @@
  * In-memory `DocumentTemplateRepository` (ADR 0020) — browser/offline-impl.
  */
 
+import type { DocumentTemplateId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { DocumentTemplate } from "@/lib/shared/schemas/misc";
 import type { IDataStore } from "../data-store/IDataStore";
 import type {
@@ -18,7 +19,7 @@ export class InMemoryDocumentTemplateRepository
     super(source.documentTemplates, now ?? (() => new Date()));
   }
 
-  async listForOrg(organizationId: string): Promise<DocumentTemplateListRow[]> {
+  async listForOrg(organizationId: OrganizationId): Promise<DocumentTemplateListRow[]> {
     const rows = await this.source.documentTemplates.findMany({
       where: { organizationId },
       select: {
@@ -38,7 +39,7 @@ export class InMemoryDocumentTemplateRepository
     }));
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<DocumentTemplateRow | null> {
+  async getByIdInOrg(id: DocumentTemplateId, organizationId: OrganizationId): Promise<DocumentTemplateRow | null> {
     const row = (await this.delegate.findFirst({
       where: { id, organizationId },
       include: { createdBy: { select: { name: true } } },

--- a/src/lib/server/routers/document/lease.ts
+++ b/src/lib/server/routers/document/lease.ts
@@ -11,10 +11,11 @@
  */
 
 import { z } from "zod";
+import { documentIdSchema } from "@/lib/shared/schemas/ids";
 import { orgProcedure } from "../../trpc";
 import { assertDocAccess } from "./shared";
 
-const docInput = z.object({ documentId: z.string() });
+const docInput = z.object({ documentId: documentIdSchema });
 
 export const leaseProcedures = {
   /** Ta leasen (fri/utgången/egen → din; annars `acquired:false` + annan hållare). */

--- a/src/lib/server/routers/document/shared.ts
+++ b/src/lib/server/routers/document/shared.ts
@@ -9,13 +9,13 @@
  */
 
 import { TRPCError } from "@trpc/server";
-import type { MatterId, OrganizationId } from "@/lib/shared/schemas/ids";
+import type { DocumentId, MatterId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { Repositories } from "../../repositories/repositories";
 
 export type DocCtx = { repos: Repositories; orgId: OrganizationId };
 
 /** Verifiera att dokumentet finns och tillhör anropande org. */
-export async function assertDocAccess(ctx: DocCtx, documentId: string) {
+export async function assertDocAccess(ctx: DocCtx, documentId: DocumentId) {
   const doc = await ctx.repos.documents.getByIdInOrg(documentId, ctx.orgId);
   if (!doc) throw new TRPCError({ code: "NOT_FOUND" });
   return doc;

--- a/src/lib/server/routers/document/suggestions.ts
+++ b/src/lib/server/routers/document/suggestions.ts
@@ -15,7 +15,10 @@ import {
 } from "@/lib/shared/contact-dedup";
 import type { DocumentAnalysisSuggestion } from "@/lib/shared/schemas/document";
 import { matterRoleSchema, contactTypeSchema, type SuggestionStatus } from "@/lib/shared/schemas/enums";
-import { asId, type ContactId, type OrganizationId } from "@/lib/shared/schemas/ids";
+import {
+  asId, documentAnalysisSuggestionIdSchema, matterIdSchema,
+  type ContactId, type DocumentAnalysisSuggestionId, type MatterId, type OrganizationId,
+} from "@/lib/shared/schemas/ids";
 import type { MatterContact } from "@/lib/shared/schemas/matter";
 import { groupSuggestions } from "@/lib/shared/suggestion-grouping";
 import type { Repositories } from "../../repositories/repositories";
@@ -35,7 +38,7 @@ type SuggOverride = {
   personalNumber?: string | null | undefined;
 };
 type Suggestion = {
-  id: string;
+  id: DocumentAnalysisSuggestionId;
   status: SuggestionStatus;
   role: string;
   name: string;
@@ -45,10 +48,10 @@ type Suggestion = {
   personalNumber: string | null;
   orgNumber: string | null;
   notes: string | null;
-  document: { matterId: string };
+  document: { matterId: MatterId };
 };
 
-async function loadPendingSuggestion(ctx: Ctx, suggestionId: string): Promise<Suggestion> {
+async function loadPendingSuggestion(ctx: Ctx, suggestionId: DocumentAnalysisSuggestionId): Promise<Suggestion> {
   const sugg = (await ctx.repos.documentAnalysisSuggestions.getByIdInOrg(suggestionId, ctx.orgId)) as Suggestion | null;
   if (!sugg) throw new TRPCError({ code: "NOT_FOUND" });
   if (sugg.status !== "PENDING") {
@@ -142,7 +145,7 @@ async function ensureMatterContactLink(
 // ─── Helpers för acceptSuggestionGroup ──────────────────────────────────
 
 /** Hämta + validera en grupp av förslag (existerar, pending, samma ärende). */
-async function loadPendingGroup(ctx: Ctx, suggestionIds: string[]): Promise<Suggestion[]> {
+async function loadPendingGroup(ctx: Ctx, suggestionIds: DocumentAnalysisSuggestionId[]): Promise<Suggestion[]> {
   const suggs = (await ctx.repos.documentAnalysisSuggestions.listPendingByIds(suggestionIds, ctx.orgId)) as Suggestion[];
 
   if (suggs.length === 0) throw new TRPCError({ code: "NOT_FOUND" });
@@ -243,7 +246,7 @@ async function linkGroupRoles(
 export const suggestionProcedures = {
   /** Platt lista över pending-förslag för ett ärende. */
   pendingSuggestions: orgProcedure
-    .input(z.object({ matterId: z.string() }))
+    .input(z.object({ matterId: matterIdSchema }))
     .query(({ ctx, input }) =>
       ctx.repos.documentAnalysisSuggestions.listPendingForMatter(input.matterId, ctx.orgId, "desc"),
     ),
@@ -253,7 +256,7 @@ export const suggestionProcedures = {
    * som förekommer i flera dokument/roller blir en rad i UI:t.
    */
   pendingSuggestionsGrouped: orgProcedure
-    .input(z.object({ matterId: z.string() }))
+    .input(z.object({ matterId: matterIdSchema }))
     .query(async ({ ctx, input }) => {
       const rows = await ctx.repos.documentAnalysisSuggestions.listPendingForMatter(input.matterId, ctx.orgId, "asc");
       return groupSuggestions(rows);
@@ -267,7 +270,7 @@ export const suggestionProcedures = {
   acceptSuggestion: orgProcedure
     .input(
       z.object({
-        suggestionId: z.string(),
+        suggestionId: documentAnalysisSuggestionIdSchema,
         /** Om satt — länka till denna kontakt istället för att skapa ny. */
         existingContactId: z.string().optional(),
         /** User-overrides innan accept. */
@@ -296,13 +299,13 @@ export const suggestionProcedures = {
 
       await ensureMatterContactLink(ctx, matterId, contactId, finalRole, sugg.notes);
       await ctx.repos.documentAnalysisSuggestions.update(
-        asId<"DocumentAnalysisSuggestionId">(sugg.id), { status: "ACCEPTED", acceptedContactId: contactId } as Partial<DocumentAnalysisSuggestion>,
+        sugg.id, { status: "ACCEPTED", acceptedContactId: contactId } as Partial<DocumentAnalysisSuggestion>,
       );
       return { contactId };
     }),
 
   rejectSuggestion: orgProcedure
-    .input(z.object({ suggestionId: z.string() }))
+    .input(z.object({ suggestionId: documentAnalysisSuggestionIdSchema }))
     .mutation(async ({ ctx, input }) => {
       const sugg = await ctx.repos.documentAnalysisSuggestions.getByIdInOrg(input.suggestionId, ctx.orgId);
       if (!sugg) throw new TRPCError({ code: "NOT_FOUND" });
@@ -319,7 +322,7 @@ export const suggestionProcedures = {
   acceptSuggestionGroup: orgProcedure
     .input(
       z.object({
-        suggestionIds: z.array(z.string()).min(1),
+        suggestionIds: z.array(documentAnalysisSuggestionIdSchema).min(1),
         /** Om satt — återanvänd befintlig kontakt istället för att skapa ny. */
         existingContactId: z.string().optional(),
       }),
@@ -344,7 +347,7 @@ export const suggestionProcedures = {
 
   /** Avvisa en hel grupp av förslag. */
   rejectSuggestionGroup: orgProcedure
-    .input(z.object({ suggestionIds: z.array(z.string()).min(1) }))
+    .input(z.object({ suggestionIds: z.array(documentAnalysisSuggestionIdSchema).min(1) }))
     .mutation(async ({ ctx, input }) => {
       const suggs = await ctx.repos.documentAnalysisSuggestions.listByIdsInOrg(input.suggestionIds, ctx.orgId);
       if (suggs.length === 0) throw new TRPCError({ code: "NOT_FOUND" });

--- a/test/unit/server/repositories/document-folder-repository.test.ts
+++ b/test/unit/server/repositories/document-folder-repository.test.ts
@@ -11,16 +11,18 @@ import { documentFolders, documents, matters, users } from "@/lib/server/db/sche
 import { DrizzleDocumentFolderRepository } from "@/lib/server/repositories/drizzle-document-folder-repository";
 import { InMemoryDocumentFolderRepository } from "@/lib/server/repositories/in-memory-document-folder-repository";
 import { prebakeJoins } from "@/lib/shared/demo-source";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
-const ORG = "66666666-6666-7666-8666-666666666666";
+const ORG = asId<"OrganizationId">("66666666-6666-7666-8666-666666666666");
 
 // Delat träd: matter med 2 rotmappar (A, B); A har 2 undermappar; 2 dok i A, 1 i A1.
 function tree() {
-  const mId = uuidv7();
-  const uId = uuidv7();
-  const fA = uuidv7(), fB = uuidv7(), fA1 = uuidv7(), fA2 = uuidv7();
+  const mId = asId<"MatterId">(uuidv7());
+  const uId = asId<"UserId">(uuidv7());
+  const fA = asId<"DocumentFolderId">(uuidv7()), fB = asId<"DocumentFolderId">(uuidv7()),
+    fA1 = asId<"DocumentFolderId">(uuidv7()), fA2 = asId<"DocumentFolderId">(uuidv7());
   const folders = [
     { id: fA, matterId: mId, name: "A Avtal", parentId: null },
     { id: fB, matterId: mId, name: "B Bilagor", parentId: null },

--- a/test/unit/server/repositories/document-repository.test.ts
+++ b/test/unit/server/repositories/document-repository.test.ts
@@ -16,15 +16,15 @@ import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
-const ORG = "11111111-1111-7111-8111-111111111111";
+const ORG = asId<"OrganizationId">("11111111-1111-7111-8111-111111111111");
 
 describe("DocumentRepository / DocumentFolderRepository — in-memory", () => {
   it("list/getByIdInOrg/reassign + folder _count", async () => {
-    const mId = uuidv7();
-    const uId = uuidv7();
-    const root = uuidv7();
-    const sub = uuidv7();
-    const d1 = uuidv7();
+    const mId = asId<"MatterId">(uuidv7());
+    const uId = asId<"UserId">(uuidv7());
+    const root = asId<"DocumentFolderId">(uuidv7());
+    const sub = asId<"DocumentFolderId">(uuidv7());
+    const d1 = asId<"DocumentId">(uuidv7());
     const source = prebakeJoins({
       matters: [{ id: mId, organizationId: ORG, matterNumber: "2026-1", title: "T" }],
       users: [{ id: uId, name: "Anna" }],
@@ -47,7 +47,7 @@ describe("DocumentRepository / DocumentFolderRepository — in-memory", () => {
     expect(inRoot.total).toBe(1);
     expect(inRoot.documents[0]!.uploadedBy?.name).toBe("Anna");
     expect(await docs.getByIdInOrg(d1, ORG)).toMatchObject({ id: d1, matterId: mId });
-    expect(await docs.getByIdInOrg(d1, uuidv7())).toBeNull();
+    expect(await docs.getByIdInOrg(d1, asId<"OrganizationId">(uuidv7()))).toBeNull();
     expect((await docs.listByMatter(mId)).length).toBe(2);
     expect(await docs.listDocumentTypesForOrg(ORG)).toEqual([
       { type: "Avtal", count: 1 }, { type: "Faktura", count: 1 },
@@ -71,12 +71,12 @@ describe("DocumentRepository / DocumentFolderRepository — Drizzle (pglite)", (
 
   it("list/getByIdInOrg/reassign + folder _count", async () => {
     const db = handle.db;
-    const org = uuidv7();
-    const mId = uuidv7();
-    const uId = uuidv7();
-    const root = uuidv7();
-    const sub = uuidv7();
-    const d1 = uuidv7();
+    const org = asId<"OrganizationId">(uuidv7());
+    const mId = asId<"MatterId">(uuidv7());
+    const uId = asId<"UserId">(uuidv7());
+    const root = asId<"DocumentFolderId">(uuidv7());
+    const sub = asId<"DocumentFolderId">(uuidv7());
+    const d1 = asId<"DocumentId">(uuidv7());
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
     await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
@@ -94,7 +94,7 @@ describe("DocumentRepository / DocumentFolderRepository — Drizzle (pglite)", (
     expect(inRoot.total).toBe(1);
     expect(inRoot.documents[0]!.uploadedBy?.name).toBe("Anna");
     expect(await docs.getByIdInOrg(d1, org)).toMatchObject({ id: d1, matterId: mId });
-    expect(await docs.getByIdInOrg(d1, uuidv7())).toBeNull();
+    expect(await docs.getByIdInOrg(d1, asId<"OrganizationId">(uuidv7()))).toBeNull();
     expect((await docs.listByMatter(mId)).length).toBe(2);
     expect(await docs.listDocumentTypesForOrg(org)).toEqual([
       { type: "Avtal", count: 1 }, { type: "Faktura", count: 1 },

--- a/test/unit/server/repositories/document-suggestion-repository.test.ts
+++ b/test/unit/server/repositories/document-suggestion-repository.test.ts
@@ -11,17 +11,18 @@ import { documentAnalysisSuggestions, documents, matters } from "@/lib/server/db
 import { DrizzleDocumentSuggestionRepository } from "@/lib/server/repositories/drizzle-document-suggestion-repository";
 import { InMemoryDocumentSuggestionRepository } from "@/lib/server/repositories/in-memory-document-suggestion-repository";
 import { prebakeJoins } from "@/lib/shared/demo-source";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
-const ORG = "77777777-7777-7777-8777-777777777777";
+const ORG = asId<"OrganizationId">("77777777-7777-7777-8777-777777777777");
 
 describe("DocumentSuggestionRepository — in-memory", () => {
   it("getByIdInOrg/listPending*/listByIds/updateMany", async () => {
-    const mId = uuidv7();
-    const dId = uuidv7();
-    const s1 = uuidv7();
-    const s2 = uuidv7();
+    const mId = asId<"MatterId">(uuidv7());
+    const dId = asId<"DocumentId">(uuidv7());
+    const s1 = asId<"DocumentAnalysisSuggestionId">(uuidv7());
+    const s2 = asId<"DocumentAnalysisSuggestionId">(uuidv7());
     const source = prebakeJoins({
       matters: [{ id: mId, organizationId: ORG, matterNumber: "2026-1", title: "T" }],
       documents: [{ id: dId, matterId: mId, fileName: "f.pdf", title: "F" }],
@@ -34,7 +35,7 @@ describe("DocumentSuggestionRepository — in-memory", () => {
     const repo = new InMemoryDocumentSuggestionRepository(store);
 
     expect(await repo.getByIdInOrg(s1, ORG)).toMatchObject({ id: s1, document: { matterId: mId } });
-    expect(await repo.getByIdInOrg(s1, uuidv7())).toBeNull();
+    expect(await repo.getByIdInOrg(s1, asId<"OrganizationId">(uuidv7()))).toBeNull();
     expect((await repo.listPendingForMatter(mId, ORG, "asc")).map((s) => s.id)).toEqual([s1]);
     expect((await repo.listPendingByIds([s1, s2], ORG)).map((s) => s.id)).toEqual([s1]);
     expect((await repo.listByIdsInOrg([s1, s2], ORG)).length).toBe(2);
@@ -51,11 +52,11 @@ describe("DocumentSuggestionRepository — Drizzle (pglite)", () => {
 
   it("getByIdInOrg/listPending*/listByIds/updateMany", async () => {
     const db = handle.db;
-    const org = uuidv7();
-    const mId = uuidv7();
-    const dId = uuidv7();
-    const s1 = uuidv7();
-    const s2 = uuidv7();
+    const org = asId<"OrganizationId">(uuidv7());
+    const mId = asId<"MatterId">(uuidv7());
+    const dId = asId<"DocumentId">(uuidv7());
+    const s1 = asId<"DocumentAnalysisSuggestionId">(uuidv7());
+    const s2 = asId<"DocumentAnalysisSuggestionId">(uuidv7());
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
     await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
@@ -65,7 +66,7 @@ describe("DocumentSuggestionRepository — Drizzle (pglite)", () => {
     const repo = new DrizzleDocumentSuggestionRepository(db);
 
     expect(await repo.getByIdInOrg(s1, org)).toMatchObject({ id: s1, document: { matterId: mId } });
-    expect(await repo.getByIdInOrg(s1, uuidv7())).toBeNull();
+    expect(await repo.getByIdInOrg(s1, asId<"OrganizationId">(uuidv7()))).toBeNull();
     expect((await repo.listPendingForMatter(mId, org, "asc")).map((s) => s.id)).toEqual([s1]);
     expect((await repo.listPendingByIds([s1, s2], org)).map((s) => s.id)).toEqual([s1]);
     expect((await repo.listByIdsInOrg([s1, s2], org)).length).toBe(2);

--- a/test/unit/server/repositories/document-template-repository.test.ts
+++ b/test/unit/server/repositories/document-template-repository.test.ts
@@ -9,12 +9,13 @@ import { documentTemplates, users } from "@/lib/server/db/schema";
 import { DrizzleDocumentTemplateRepository } from "@/lib/server/repositories/drizzle-document-template-repository";
 import { InMemoryDocumentTemplateRepository } from "@/lib/server/repositories/in-memory-document-template-repository";
 import { prebakeJoins } from "@/lib/shared/demo-source";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
 describe("DocumentTemplateRepository — in-memory", () => {
   it("listForOrg + getByIdInOrg (med skapar-namn)", async () => {
-    const t1 = uuidv7();
+    const t1 = asId<"DocumentTemplateId">(uuidv7());
     const userId = uuidv7();
     const source = prebakeJoins({
       users: [{ id: userId, name: "Anna" }],
@@ -23,11 +24,11 @@ describe("DocumentTemplateRepository — in-memory", () => {
       ],
     } as DemoSource);
     const repo = new InMemoryDocumentTemplateRepository(new LocalStore(source, async () => {}));
-    const list = await repo.listForOrg("org-1");
+    const list = await repo.listForOrg(asId<"OrganizationId">("org-1"));
     expect(list).toHaveLength(1);
     expect(list[0]!.createdBy?.name).toBe("Anna");
-    expect(await repo.getByIdInOrg(t1, "org-1")).toMatchObject({ id: t1 });
-    expect(await repo.getByIdInOrg(t1, "org-2")).toBeNull();
+    expect(await repo.getByIdInOrg(t1, asId<"OrganizationId">("org-1"))).toMatchObject({ id: t1 });
+    expect(await repo.getByIdInOrg(t1, asId<"OrganizationId">("org-2"))).toBeNull();
   });
 });
 
@@ -38,9 +39,9 @@ describe("DocumentTemplateRepository — Drizzle (pglite)", () => {
 
   it("listForOrg (join skapare) + getByIdInOrg", async () => {
     const db = handle.db;
-    const org = uuidv7();
+    const org = asId<"OrganizationId">(uuidv7());
     const userId = uuidv7();
-    const t1 = uuidv7();
+    const t1 = asId<"DocumentTemplateId">(uuidv7());
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
     await db.insert(users).values(v({ id: userId, organizationId: org, email: "a@x", name: "Anna" }));
@@ -50,6 +51,6 @@ describe("DocumentTemplateRepository — Drizzle (pglite)", () => {
     expect(list).toHaveLength(1);
     expect(list[0]!.createdBy?.name).toBe("Anna");
     expect(await repo.getByIdInOrg(t1, org)).toMatchObject({ id: t1 });
-    expect(await repo.getByIdInOrg(t1, uuidv7())).toBeNull();
+    expect(await repo.getByIdInOrg(t1, asId<"OrganizationId">(uuidv7()))).toBeNull();
   });
 });


### PR DESCRIPTION
ID-brandning per domängrupp (B1, #750). document / document-folder / document-suggestion / document-template-repos (interface + drizzle + in-memory): id/documentId/folderId/parentId/matterId/organizationId/uploadedById-params + id-array-params + DTO-id-fält → branded.

Kaskad: `assertDocAccess(documentId: DocumentId)`, document/lease+suggestions router-inputs → `*IdSchema`, lokala `Suggestion`-typen brandad, borttagna redundanta drizzle-cast, test-id-literaler brandade. Inga typer försvagade.

## Test
Ren tsc (root+test, 0), lint grön, repo/document-router-tester gröna.

Refs #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)