### PR TITLE
refactor(repos): branda billing/finance-domänens id-params (B1e)

### DIFF
--- a/src/lib/server/repositories/billing-run-repository.ts
+++ b/src/lib/server/repositories/billing-run-repository.ts
@@ -7,26 +7,27 @@
 
 import type { BillingRun } from "@/lib/shared/schemas/billing";
 import type { InvoiceStatus, PaymentMethod } from "@/lib/shared/schemas/enums";
+import type { BillingRunId, InvoiceId, MatterId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { Repository } from "./types";
 
 /** Billing-run + faktura (listvyn). */
 export interface BillingRunListRow extends BillingRun {
-  invoice: { id: string; invoiceNumber: string | null; status: InvoiceStatus } | null;
+  invoice: { id: InvoiceId; invoiceNumber: string | null; status: InvoiceStatus } | null;
 }
 
 /** Billing-run + faktura + ärende (detaljvyn). */
 export interface BillingRunDetailRow extends BillingRun {
-  invoice: { id: string; invoiceNumber: string | null; status: InvoiceStatus; amount: number } | null;
-  matter: { id: string; matterNumber: string; title: string; paymentMethod: PaymentMethod | null } | null;
+  invoice: { id: InvoiceId; invoiceNumber: string | null; status: InvoiceStatus; amount: number } | null;
+  matter: { id: MatterId; matterNumber: string; title: string; paymentMethod: PaymentMethod | null } | null;
 }
 
 export interface BillingRunRepository extends Repository<BillingRun> {
   /** Org:ens billing-runs (createdAt desc), valfritt ärende-filtrerade, med faktura. */
-  listForOrg(organizationId: string, matterId?: string): Promise<BillingRunListRow[]>;
+  listForOrg(organizationId: OrganizationId, matterId?: MatterId): Promise<BillingRunListRow[]>;
   /** En billing-run by id, org-scopad, med faktura + ärende. Null om saknas. */
-  getByIdInOrg(id: string, organizationId: string): Promise<BillingRunDetailRow | null>;
+  getByIdInOrg(id: BillingRunId, organizationId: OrganizationId): Promise<BillingRunDetailRow | null>;
   /** Utställda ACCONTO-runs i ett ärende (för Σ tidigare aconto, #397). */
-  listAccontoSent(matterId: string): Promise<BillingRun[]>;
+  listAccontoSent(matterId: MatterId): Promise<BillingRun[]>;
   /** ACCONTO-runs i ett ärende med givna id:n (FINAL-avdrag, #60-validering). */
-  listAccontoByIds(matterId: string, ids: string[]): Promise<BillingRun[]>;
+  listAccontoByIds(matterId: MatterId, ids: BillingRunId[]): Promise<BillingRun[]>;
 }

--- a/src/lib/server/repositories/drizzle-billing-run-repository.ts
+++ b/src/lib/server/repositories/drizzle-billing-run-repository.ts
@@ -5,7 +5,7 @@
 
 import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 import type { BillingRun } from "@/lib/shared/schemas/billing";
-import { asId } from "@/lib/shared/schemas/ids";
+import type { BillingRunId, MatterId, OrganizationId } from "@/lib/shared/schemas/ids";
 import { billingRuns, invoices, matters } from "../db/schema";
 import type { AppDb } from "../db/types";
 import type {
@@ -26,7 +26,7 @@ export class DrizzleBillingRunRepository
     return matterOrg(this.db, (row as { matterId?: string }).matterId);
   }
 
-  async listForOrg(organizationId: string, matterId?: string): Promise<BillingRunListRow[]> {
+  async listForOrg(organizationId: OrganizationId, matterId?: MatterId): Promise<BillingRunListRow[]> {
     const rows = await this.db
       .select({
         run: billingRuns,
@@ -36,8 +36,8 @@ export class DrizzleBillingRunRepository
       .innerJoin(matters, eq(billingRuns.matterId, matters.id))
       .leftJoin(invoices, eq(billingRuns.invoiceId, invoices.id))
       .where(and(
-        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
-        matterId ? eq(billingRuns.matterId, asId<"MatterId">(matterId)) : undefined,
+        eq(matters.organizationId, organizationId),
+        matterId ? eq(billingRuns.matterId, matterId) : undefined,
         isNull(billingRuns.deletedAt),
       ))
       .orderBy(desc(billingRuns.createdAt));
@@ -47,7 +47,7 @@ export class DrizzleBillingRunRepository
     }));
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<BillingRunDetailRow | null> {
+  async getByIdInOrg(id: BillingRunId, organizationId: OrganizationId): Promise<BillingRunDetailRow | null> {
     const rows = await this.db
       .select({
         run: billingRuns,
@@ -57,7 +57,7 @@ export class DrizzleBillingRunRepository
       .from(billingRuns)
       .innerJoin(matters, eq(billingRuns.matterId, matters.id))
       .leftJoin(invoices, eq(billingRuns.invoiceId, invoices.id))
-      .where(and(eq(billingRuns.id, asId<"BillingRunId">(id)), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(billingRuns.deletedAt)))
+      .where(and(eq(billingRuns.id, id), eq(matters.organizationId, organizationId), isNull(billingRuns.deletedAt)))
       .limit(1);
     const r = rows[0];
     if (!r) return null;
@@ -72,22 +72,22 @@ export class DrizzleBillingRunRepository
     };
   }
 
-  async listAccontoSent(matterId: string): Promise<BillingRun[]> {
+  async listAccontoSent(matterId: MatterId): Promise<BillingRun[]> {
     const rows = await this.db
       .select().from(billingRuns)
       .where(and(
-        eq(billingRuns.matterId, asId<"MatterId">(matterId)), eq(billingRuns.type, "ACCONTO"),
+        eq(billingRuns.matterId, matterId), eq(billingRuns.type, "ACCONTO"),
         eq(billingRuns.status, "SENT"), isNull(billingRuns.deletedAt),
       ));
     return rows;
   }
 
-  async listAccontoByIds(matterId: string, ids: string[]): Promise<BillingRun[]> {
+  async listAccontoByIds(matterId: MatterId, ids: BillingRunId[]): Promise<BillingRun[]> {
     if (!ids.length) return [];
     const rows = await this.db
       .select().from(billingRuns)
       .where(and(
-        inArray(billingRuns.id, ids.map((i) => asId<"BillingRunId">(i))), eq(billingRuns.matterId, asId<"MatterId">(matterId)),
+        inArray(billingRuns.id, ids), eq(billingRuns.matterId, matterId),
         eq(billingRuns.type, "ACCONTO"), isNull(billingRuns.deletedAt),
       ));
     return rows;

--- a/src/lib/server/repositories/drizzle-expected-receivable-repository.ts
+++ b/src/lib/server/repositories/drizzle-expected-receivable-repository.ts
@@ -4,6 +4,7 @@
 
 import { and, desc, eq, isNull } from "drizzle-orm";
 import type { ExpectedReceivable } from "@/lib/shared/schemas/billing";
+import type { ExpectedReceivableId, OrganizationId } from "@/lib/shared/schemas/ids";
 import { expectedReceivables } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
@@ -16,7 +17,7 @@ export class DrizzleExpectedReceivableRepository
     super(db, versionedTable(expectedReceivables), now);
   }
 
-  async listForOrg(organizationId: string, filter?: ExpectedReceivableListFilter): Promise<ExpectedReceivable[]> {
+  async listForOrg(organizationId: OrganizationId, filter?: ExpectedReceivableListFilter): Promise<ExpectedReceivable[]> {
     const rows = await this.db
       .select().from(expectedReceivables)
       .where(and(
@@ -29,7 +30,7 @@ export class DrizzleExpectedReceivableRepository
     return this.asRows(rows);
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<ExpectedReceivable | null> {
+  async getByIdInOrg(id: ExpectedReceivableId, organizationId: OrganizationId): Promise<ExpectedReceivable | null> {
     const rows = await this.db
       .select().from(expectedReceivables)
       .where(and(eq(expectedReceivables.id, id), eq(expectedReceivables.organizationId, organizationId), isNull(expectedReceivables.deletedAt)))

--- a/src/lib/server/repositories/drizzle-expense-repository.ts
+++ b/src/lib/server/repositories/drizzle-expense-repository.ts
@@ -8,7 +8,7 @@
 
 import { and, asc, desc, eq, gte, inArray, isNull, lte, sql } from "drizzle-orm";
 import type { Expense } from "@/lib/shared/schemas/billing";
-import { asId } from "@/lib/shared/schemas/ids";
+import { asId, type BillingRunId, type ExpenseId, type InvoiceId, type MatterId, type OrganizationId, type UserId } from "@/lib/shared/schemas/ids";
 import { expenses, invoices, matters, users } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
@@ -27,10 +27,10 @@ export class DrizzleExpenseRepository extends DrizzleRepository<Expense> impleme
     return matterOrg(this.db, (row as { matterId?: string }).matterId);
   }
 
-  async listForOrg(organizationId: string, opts: ExpenseListOptions): Promise<ExpenseListResult> {
+  async listForOrg(organizationId: OrganizationId, opts: ExpenseListOptions): Promise<ExpenseListResult> {
     const where = and(
-      eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
-      opts.matterId ? eq(expenses.matterId, asId<"MatterId">(opts.matterId)) : undefined,
+      eq(matters.organizationId, organizationId),
+      opts.matterId ? eq(expenses.matterId, opts.matterId) : undefined,
     );
     const rows = await this.db
       .select({
@@ -52,7 +52,7 @@ export class DrizzleExpenseRepository extends DrizzleRepository<Expense> impleme
     return {
       expenses: rows.map((r): ExpenseListRow => ({
         ...r.exp,
-        user: r.uId ? { id: r.uId, name: r.uName ?? "" } : null,
+        user: r.uId ? { id: asId<"UserId">(r.uId), name: r.uName ?? "" } : null,
         matter: r.mId ? { id: r.mId, matterNumber: r.mNum ?? "", title: r.mTitle ?? "" } : null,
         invoice: r.invId ? { id: r.invId, invoiceNumber: r.invNum } : null,
       })),
@@ -61,52 +61,52 @@ export class DrizzleExpenseRepository extends DrizzleRepository<Expense> impleme
     };
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<Expense | null> {
+  async getByIdInOrg(id: ExpenseId, organizationId: OrganizationId): Promise<Expense | null> {
     const rows = await this.db
       .select({ exp: expenses }).from(expenses)
       .innerJoin(matters, eq(expenses.matterId, matters.id))
-      .where(and(eq(expenses.id, asId<"ExpenseId">(id)), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(expenses.deletedAt)))
+      .where(and(eq(expenses.id, id), eq(matters.organizationId, organizationId), isNull(expenses.deletedAt)))
       .limit(1);
     return rows[0]?.exp ?? null;
   }
 
-  async listUnbilled(matterId: string, ids: string[]): Promise<Expense[]> {
+  async listUnbilled(matterId: MatterId, ids: ExpenseId[]): Promise<Expense[]> {
     if (!ids.length) return [];
     const rows = await this.db
       .select().from(expenses)
-      .where(and(inArray(expenses.id, ids.map((i) => asId<"ExpenseId">(i))), eq(expenses.matterId, asId<"MatterId">(matterId)), isNull(expenses.invoiceId)));
+      .where(and(inArray(expenses.id, ids), eq(expenses.matterId, matterId), isNull(expenses.invoiceId)));
     return rows;
   }
 
-  async flagBilled(ids: string[], invoiceId: string): Promise<void> {
+  async flagBilled(ids: ExpenseId[], invoiceId: InvoiceId): Promise<void> {
     if (!ids.length) return;
-    await this.db.update(expenses).set({ invoiceId: asId<"InvoiceId">(invoiceId) })
-      .where(inArray(expenses.id, ids.map((i) => asId<"ExpenseId">(i))));
+    await this.db.update(expenses).set({ invoiceId })
+      .where(inArray(expenses.id, ids));
   }
 
-  async listUnfrozenForMatter(matterId: string): Promise<Expense[]> {
+  async listUnfrozenForMatter(matterId: MatterId): Promise<Expense[]> {
     const rows = await this.db
       .select().from(expenses)
-      .where(and(eq(expenses.matterId, asId<"MatterId">(matterId)), isNull(expenses.frozenByBillingRunId), isNull(expenses.deletedAt)))
+      .where(and(eq(expenses.matterId, matterId), isNull(expenses.frozenByBillingRunId), isNull(expenses.deletedAt)))
       .orderBy(asc(expenses.date));
     return rows;
   }
 
-  async freezeForMatter(matterId: string, billingRunId: string, now: Date): Promise<void> {
+  async freezeForMatter(matterId: MatterId, billingRunId: BillingRunId, now: Date): Promise<void> {
     await this.db.update(expenses)
-      .set({ frozenAt: now, frozenByBillingRunId: asId<"BillingRunId">(billingRunId) })
-      .where(and(eq(expenses.matterId, asId<"MatterId">(matterId)), isNull(expenses.frozenByBillingRunId)));
+      .set({ frozenAt: now, frozenByBillingRunId: billingRunId })
+      .where(and(eq(expenses.matterId, matterId), isNull(expenses.frozenByBillingRunId)));
   }
 
-  async freezeByIds(ids: string[], billingRunId: string, now: Date): Promise<void> {
+  async freezeByIds(ids: ExpenseId[], billingRunId: BillingRunId, now: Date): Promise<void> {
     if (ids.length === 0) return;
     await this.db.update(expenses)
-      .set({ frozenAt: now, frozenByBillingRunId: asId<"BillingRunId">(billingRunId) })
-      .where(and(inArray(expenses.id, ids.map((i) => asId<"ExpenseId">(i))), isNull(expenses.frozenByBillingRunId)));
+      .set({ frozenAt: now, frozenByBillingRunId: billingRunId })
+      .where(and(inArray(expenses.id, ids), isNull(expenses.frozenByBillingRunId)));
   }
 
   async listForLawyerInPeriod(
-    organizationId: string, userId: string, from: Date, to: Date,
+    organizationId: OrganizationId, userId: UserId, from: Date, to: Date,
   ): Promise<LawyerReportExpense[]> {
     const klient = sql<string | null>`(select c.name from matter_contacts mc join contacts c on mc.contact_id = c.id where mc.matter_id = ${matters.id} and mc.role = 'KLIENT' limit 1)`;
     const rows = await this.db
@@ -119,7 +119,7 @@ export class DrizzleExpenseRepository extends DrizzleRepository<Expense> impleme
       .from(expenses)
       .innerJoin(matters, eq(expenses.matterId, matters.id))
       .where(and(
-        eq(matters.organizationId, asId<"OrganizationId">(organizationId)), eq(expenses.userId, asId<"UserId">(userId)),
+        eq(matters.organizationId, organizationId), eq(expenses.userId, userId),
         gte(expenses.date, from), lte(expenses.date, to), isNull(expenses.deletedAt),
       ))
       .orderBy(asc(expenses.date));

--- a/src/lib/server/repositories/drizzle-payment-plan-repository.ts
+++ b/src/lib/server/repositories/drizzle-payment-plan-repository.ts
@@ -10,7 +10,7 @@
 import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 import type { PaymentPlan, PaymentPlanReminder } from "@/lib/shared/schemas/billing";
 import type { PaymentPlanStatus } from "@/lib/shared/schemas/enums";
-import { asId } from "@/lib/shared/schemas/ids";
+import type { InvoiceId, OrganizationId, PaymentPlanId } from "@/lib/shared/schemas/ids";
 import { invoices, matters, paymentPlanReminders, paymentPlans } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
@@ -29,45 +29,45 @@ export class DrizzlePaymentPlanRepository extends DrizzleRepository<PaymentPlan>
     return invoiceOrg(this.db, (row as { invoiceId?: string }).invoiceId);
   }
 
-  async getByIdInOrg(planId: string, organizationId: string): Promise<PaymentPlan | null> {
+  async getByIdInOrg(planId: PaymentPlanId, organizationId: OrganizationId): Promise<PaymentPlan | null> {
     const rows = await this.db
       .select({ plan: paymentPlans }).from(paymentPlans)
       .innerJoin(invoices, eq(paymentPlans.invoiceId, invoices.id))
       .innerJoin(matters, eq(invoices.matterId, matters.id))
       .where(and(
-        eq(paymentPlans.id, asId<"PaymentPlanId">(planId)),
-        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
+        eq(paymentPlans.id, planId),
+        eq(matters.organizationId, organizationId),
         isNull(paymentPlans.deletedAt),
       )).limit(1);
     return this.asRow(rows[0]?.plan);
   }
 
-  async getByInvoiceId(invoiceId: string): Promise<PaymentPlan | null> {
+  async getByInvoiceId(invoiceId: InvoiceId): Promise<PaymentPlan | null> {
     const rows = await this.db
       .select().from(paymentPlans)
-      .where(and(eq(paymentPlans.invoiceId, asId<"InvoiceId">(invoiceId)), isNull(paymentPlans.deletedAt))).limit(1);
+      .where(and(eq(paymentPlans.invoiceId, invoiceId), isNull(paymentPlans.deletedAt))).limit(1);
     return this.asRow(rows[0]);
   }
 
   /** Plan-id:n i org:en (via faktura→ärende), valfritt status-filtrerade. */
-  private async planIdsInOrg(organizationId: string, status?: PaymentPlanStatus): Promise<string[]> {
+  private async planIdsInOrg(organizationId: OrganizationId, status?: PaymentPlanStatus): Promise<PaymentPlanId[]> {
     const rows = await this.db
       .select({ id: paymentPlans.id }).from(paymentPlans)
       .innerJoin(invoices, eq(paymentPlans.invoiceId, invoices.id))
       .innerJoin(matters, eq(invoices.matterId, matters.id))
       .where(and(
-        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
+        eq(matters.organizationId, organizationId),
         status ? eq(paymentPlans.status, status as PaymentPlanStatus) : undefined,
         isNull(paymentPlans.deletedAt),
       ));
-    return rows.map((r) => r.id as string);
+    return rows.map((r) => r.id);
   }
 
   /** Hämta joinade planer (faktura + ärende inkl. KLIENT + betalningar + avskrivningar). */
-  private async fetchJoined(ids: string[]): Promise<JoinedPaymentPlan[]> {
+  private async fetchJoined(ids: PaymentPlanId[]): Promise<JoinedPaymentPlan[]> {
     if (ids.length === 0) return [];
     const rows = await this.db.query.paymentPlans.findMany({
-      where: inArray(paymentPlans.id, ids.map((i) => asId<"PaymentPlanId">(i))),
+      where: inArray(paymentPlans.id, ids),
       orderBy: (pp, { desc: d }) => [d(pp.createdAt)],
       with: {
         invoice: {
@@ -87,12 +87,12 @@ export class DrizzlePaymentPlanRepository extends DrizzleRepository<PaymentPlan>
   }
 
   /** Påminnelser per plan (sentAt desc), grupperade. */
-  private async remindersByPlan(ids: string[]): Promise<Map<string, PaymentPlanReminder[]>> {
-    const out = new Map<string, PaymentPlanReminder[]>();
+  private async remindersByPlan(ids: PaymentPlanId[]): Promise<Map<PaymentPlanId, PaymentPlanReminder[]>> {
+    const out = new Map<PaymentPlanId, PaymentPlanReminder[]>();
     if (ids.length === 0) return out;
     const rows = await this.db
       .select().from(paymentPlanReminders)
-      .where(inArray(paymentPlanReminders.planId, ids.map((id) => asId<"PaymentPlanId">(id))))
+      .where(inArray(paymentPlanReminders.planId, ids))
       .orderBy(desc(paymentPlanReminders.sentAt));
     for (const r of rows) {
       (out.get(r.planId) ?? out.set(r.planId, []).get(r.planId)!).push(r);
@@ -100,11 +100,11 @@ export class DrizzlePaymentPlanRepository extends DrizzleRepository<PaymentPlan>
     return out;
   }
 
-  async listForOrg(organizationId: string, status?: PaymentPlanStatus): Promise<JoinedPaymentPlan[]> {
+  async listForOrg(organizationId: OrganizationId, status?: PaymentPlanStatus): Promise<JoinedPaymentPlan[]> {
     return this.fetchJoined(await this.planIdsInOrg(organizationId, status));
   }
 
-  async getByIdWithDetails(id: string, organizationId: string): Promise<JoinedPaymentPlanWithReminders | null> {
+  async getByIdWithDetails(id: PaymentPlanId, organizationId: OrganizationId): Promise<JoinedPaymentPlanWithReminders | null> {
     if (!(await this.getByIdInOrg(id, organizationId))) return null;
     const [plan] = await this.fetchJoined([id]);
     if (!plan) return null;
@@ -112,7 +112,7 @@ export class DrizzlePaymentPlanRepository extends DrizzleRepository<PaymentPlan>
     return { ...plan, reminders };
   }
 
-  async listActiveForScan(organizationId: string): Promise<JoinedPaymentPlanWithReminders[]> {
+  async listActiveForScan(organizationId: OrganizationId): Promise<JoinedPaymentPlanWithReminders[]> {
     const ids = await this.planIdsInOrg(organizationId, "ACTIVE");
     const plans = await this.fetchJoined(ids);
     const byPlan = await this.remindersByPlan(ids);

--- a/src/lib/server/repositories/drizzle-payment-repository.ts
+++ b/src/lib/server/repositories/drizzle-payment-repository.ts
@@ -5,7 +5,7 @@
 
 import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import type { Payment } from "@/lib/shared/schemas/billing";
-import { asId } from "@/lib/shared/schemas/ids";
+import type { InvoiceId } from "@/lib/shared/schemas/ids";
 import { payments } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
@@ -22,18 +22,18 @@ export class DrizzlePaymentRepository extends DrizzleRepository<Payment> impleme
     return invoiceOrg(this.db, (row as { invoiceId?: string }).invoiceId);
   }
 
-  async sumByInvoice(invoiceId: string): Promise<number> {
+  async sumByInvoice(invoiceId: InvoiceId): Promise<number> {
     const rows = await this.db
       .select({ total: sql<number>`coalesce(sum(${payments.amount}), 0)` }).from(payments)
-      .where(and(eq(payments.invoiceId, asId<"InvoiceId">(invoiceId)), isNull(payments.deletedAt)));
+      .where(and(eq(payments.invoiceId, invoiceId), isNull(payments.deletedAt)));
     return Number(rows[0]?.total ?? 0);
   }
 
-  async listByInvoiceIds(invoiceIds: string[]): Promise<Payment[]> {
+  async listByInvoiceIds(invoiceIds: InvoiceId[]): Promise<Payment[]> {
     if (!invoiceIds.length) return [];
     const rows = await this.db
       .select().from(payments)
-      .where(and(inArray(payments.invoiceId, invoiceIds.map((id) => asId<"InvoiceId">(id))), isNull(payments.deletedAt)));
+      .where(and(inArray(payments.invoiceId, invoiceIds), isNull(payments.deletedAt)));
     return rows;
   }
 }

--- a/src/lib/server/repositories/drizzle-time-entry-repository.ts
+++ b/src/lib/server/repositories/drizzle-time-entry-repository.ts
@@ -11,7 +11,7 @@
 
 import { and, asc, desc, eq, gte, inArray, isNull, lte, sql } from "drizzle-orm";
 import type { TimeEntry } from "@/lib/shared/schemas/billing";
-import { asId } from "@/lib/shared/schemas/ids";
+import { asId, type BillingRunId, type InvoiceId, type MatterId, type OrganizationId, type TimeEntryId, type UserId } from "@/lib/shared/schemas/ids";
 import { matters, timeEntries, users } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
@@ -22,12 +22,12 @@ import type {
 } from "./time-entry-repository";
 
 /** Org-scopat where för `listForOrg` (utbruten för komplexitet ≤8). */
-function listWhere(organizationId: string, opts: TimeEntryListFilter) {
+function listWhere(organizationId: OrganizationId, opts: TimeEntryListFilter) {
   return and(
-    eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
+    eq(matters.organizationId, organizationId),
     isNull(timeEntries.deletedAt),
-    opts.matterId ? eq(timeEntries.matterId, asId<"MatterId">(opts.matterId)) : undefined,
-    opts.userId ? eq(timeEntries.userId, asId<"UserId">(opts.userId)) : undefined,
+    opts.matterId ? eq(timeEntries.matterId, opts.matterId) : undefined,
+    opts.userId ? eq(timeEntries.userId, opts.userId) : undefined,
     opts.from ? gte(timeEntries.date, opts.from) : undefined,
     opts.to ? lte(timeEntries.date, opts.to) : undefined,
   );
@@ -43,7 +43,7 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
     return matterOrg(this.db, (row as { matterId?: string }).matterId);
   }
 
-  async listForOrg(organizationId: string, opts: TimeEntryListFilter): Promise<TimeEntryListResult> {
+  async listForOrg(organizationId: OrganizationId, opts: TimeEntryListFilter): Promise<TimeEntryListResult> {
     const where = listWhere(organizationId, opts);
     const base = this.db.select({
       te: timeEntries,
@@ -59,7 +59,7 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
     return {
       entries: rows.map((r): TimeEntryListRow => ({
         ...r.te,
-        user: r.uId ? { id: r.uId, name: r.uName ?? "" } : null,
+        user: r.uId ? { id: asId<"UserId">(r.uId), name: r.uName ?? "" } : null,
         matter: { id: r.mId, matterNumber: r.mNum, title: r.mTitle },
         invoice: null,
       })),
@@ -68,16 +68,16 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
     };
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<TimeEntry | null> {
+  async getByIdInOrg(id: TimeEntryId, organizationId: OrganizationId): Promise<TimeEntry | null> {
     const rows = await this.db
       .select({ te: timeEntries }).from(timeEntries)
       .innerJoin(matters, eq(timeEntries.matterId, matters.id))
-      .where(and(eq(timeEntries.id, asId<"TimeEntryId">(id)), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(timeEntries.deletedAt)))
+      .where(and(eq(timeEntries.id, id), eq(matters.organizationId, organizationId), isNull(timeEntries.deletedAt)))
       .limit(1);
     return rows[0]?.te ?? null;
   }
 
-  async listForReport(organizationId: string, filter: TimeEntryReportFilter): Promise<TimeEntryReportRow[]> {
+  async listForReport(organizationId: OrganizationId, filter: TimeEntryReportFilter): Promise<TimeEntryReportRow[]> {
     const klient = sql<string | null>`(select c.name from matter_contacts mc join contacts c on mc.contact_id = c.id where mc.matter_id = ${matters.id} and mc.role = 'KLIENT' limit 1)`;
     const rows = await this.db
       .select({
@@ -88,19 +88,19 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
       .innerJoin(matters, eq(timeEntries.matterId, matters.id))
       .leftJoin(users, eq(timeEntries.userId, users.id))
       .where(and(
-        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
+        eq(matters.organizationId, organizationId),
         isNull(timeEntries.deletedAt),
         gte(timeEntries.date, filter.from),
         lte(timeEntries.date, filter.to),
-        filter.matterId ? eq(timeEntries.matterId, asId<"MatterId">(filter.matterId)) : undefined,
+        filter.matterId ? eq(timeEntries.matterId, filter.matterId) : undefined,
         filter.userIds && filter.userIds.length > 0
-          ? inArray(timeEntries.userId, filter.userIds.map((u) => asId<"UserId">(u)))
-          : filter.userId ? eq(timeEntries.userId, asId<"UserId">(filter.userId)) : undefined,
+          ? inArray(timeEntries.userId, filter.userIds)
+          : filter.userId ? eq(timeEntries.userId, filter.userId) : undefined,
       ))
       .orderBy(asc(timeEntries.userId), asc(timeEntries.date));
     return rows.map((r): TimeEntryReportRow => ({
       ...r.te,
-      user: { id: r.uId ?? "", name: r.uName ?? "" },
+      user: { id: asId<"UserId">(r.uId ?? ""), name: r.uName ?? "" },
       matter: {
         id: r.mId, matterNumber: r.mNum, title: r.mTitle,
         contacts: r.klient ? [{ contact: { name: r.klient } }] : [],
@@ -108,33 +108,33 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
     }));
   }
 
-  async listUnbilled(matterId: string, ids: string[]): Promise<UnbilledTimeEntry[]> {
+  async listUnbilled(matterId: MatterId, ids: TimeEntryId[]): Promise<UnbilledTimeEntry[]> {
     if (!ids.length) return [];
     const rows = await this.db
       .select({ te: timeEntries, hourlyRate: users.hourlyRate }).from(timeEntries)
       .innerJoin(users, eq(timeEntries.userId, users.id))
-      .where(and(inArray(timeEntries.id, ids.map((i) => asId<"TimeEntryId">(i))), eq(timeEntries.matterId, asId<"MatterId">(matterId)), isNull(timeEntries.invoiceId)));
+      .where(and(inArray(timeEntries.id, ids), eq(timeEntries.matterId, matterId), isNull(timeEntries.invoiceId)));
     return rows.map((r): UnbilledTimeEntry => ({
       ...r.te, user: { hourlyRate: r.hourlyRate },
     }));
   }
 
-  async flagBilled(ids: string[], invoiceId: string): Promise<void> {
+  async flagBilled(ids: TimeEntryId[], invoiceId: InvoiceId): Promise<void> {
     if (!ids.length) return;
-    await this.db.update(timeEntries).set({ invoiceId: asId<"InvoiceId">(invoiceId) })
-      .where(inArray(timeEntries.id, ids.map((i) => asId<"TimeEntryId">(i))));
+    await this.db.update(timeEntries).set({ invoiceId })
+      .where(inArray(timeEntries.id, ids));
   }
 
-  async listUnfrozenForMatter(matterId: string): Promise<TimeEntry[]> {
+  async listUnfrozenForMatter(matterId: MatterId): Promise<TimeEntry[]> {
     const rows = await this.db
       .select().from(timeEntries)
-      .where(and(eq(timeEntries.matterId, asId<"MatterId">(matterId)), isNull(timeEntries.frozenByBillingRunId), isNull(timeEntries.deletedAt)))
+      .where(and(eq(timeEntries.matterId, matterId), isNull(timeEntries.frozenByBillingRunId), isNull(timeEntries.deletedAt)))
       .orderBy(asc(timeEntries.date));
     return rows;
   }
 
   async listForLawyerInPeriod(
-    organizationId: string, userId: string, from: Date, to: Date,
+    organizationId: OrganizationId, userId: UserId, from: Date, to: Date,
   ): Promise<LawyerReportTimeEntry[]> {
     const klient = sql<string | null>`(select c.name from matter_contacts mc join contacts c on mc.contact_id = c.id where mc.matter_id = ${matters.id} and mc.role = 'KLIENT' limit 1)`;
     const rows = await this.db
@@ -147,7 +147,7 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
       .from(timeEntries)
       .innerJoin(matters, eq(timeEntries.matterId, matters.id))
       .where(and(
-        eq(matters.organizationId, asId<"OrganizationId">(organizationId)), eq(timeEntries.userId, asId<"UserId">(userId)),
+        eq(matters.organizationId, organizationId), eq(timeEntries.userId, userId),
         gte(timeEntries.date, from), lte(timeEntries.date, to), isNull(timeEntries.deletedAt),
       ))
       .orderBy(asc(timeEntries.date));
@@ -162,24 +162,24 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
     }));
   }
 
-  async listBillableForOrg(organizationId: string): Promise<TimeEntry[]> {
+  async listBillableForOrg(organizationId: OrganizationId): Promise<TimeEntry[]> {
     const rows = await this.db
       .select({ te: timeEntries }).from(timeEntries)
       .innerJoin(matters, eq(timeEntries.matterId, matters.id))
-      .where(and(eq(matters.organizationId, asId<"OrganizationId">(organizationId)), eq(timeEntries.billable, true), isNull(timeEntries.deletedAt)));
+      .where(and(eq(matters.organizationId, organizationId), eq(timeEntries.billable, true), isNull(timeEntries.deletedAt)));
     return rows.map((r) => r.te);
   }
 
-  async freezeForMatter(matterId: string, billingRunId: string, now: Date): Promise<void> {
+  async freezeForMatter(matterId: MatterId, billingRunId: BillingRunId, now: Date): Promise<void> {
     await this.db.update(timeEntries)
-      .set({ frozenAt: now, frozenByBillingRunId: asId<"BillingRunId">(billingRunId) })
-      .where(and(eq(timeEntries.matterId, asId<"MatterId">(matterId)), isNull(timeEntries.frozenByBillingRunId)));
+      .set({ frozenAt: now, frozenByBillingRunId: billingRunId })
+      .where(and(eq(timeEntries.matterId, matterId), isNull(timeEntries.frozenByBillingRunId)));
   }
 
-  async freezeByIds(ids: string[], billingRunId: string, now: Date): Promise<void> {
+  async freezeByIds(ids: TimeEntryId[], billingRunId: BillingRunId, now: Date): Promise<void> {
     if (ids.length === 0) return;
     await this.db.update(timeEntries)
-      .set({ frozenAt: now, frozenByBillingRunId: asId<"BillingRunId">(billingRunId) })
-      .where(and(inArray(timeEntries.id, ids.map((i) => asId<"TimeEntryId">(i))), isNull(timeEntries.frozenByBillingRunId)));
+      .set({ frozenAt: now, frozenByBillingRunId: billingRunId })
+      .where(and(inArray(timeEntries.id, ids), isNull(timeEntries.frozenByBillingRunId)));
   }
 }

--- a/src/lib/server/repositories/drizzle-write-off-repository.ts
+++ b/src/lib/server/repositories/drizzle-write-off-repository.ts
@@ -5,7 +5,7 @@
 
 import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import type { WriteOff } from "@/lib/shared/schemas/billing";
-import { asId } from "@/lib/shared/schemas/ids";
+import type { InvoiceId } from "@/lib/shared/schemas/ids";
 import { writeOffs } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
@@ -22,18 +22,18 @@ export class DrizzleWriteOffRepository extends DrizzleRepository<WriteOff> imple
     return invoiceOrg(this.db, (row as { invoiceId?: string }).invoiceId);
   }
 
-  async sumByInvoice(invoiceId: string): Promise<number> {
+  async sumByInvoice(invoiceId: InvoiceId): Promise<number> {
     const rows = await this.db
       .select({ total: sql<number>`coalesce(sum(${writeOffs.amount}), 0)` }).from(writeOffs)
-      .where(and(eq(writeOffs.invoiceId, asId<"InvoiceId">(invoiceId)), isNull(writeOffs.deletedAt)));
+      .where(and(eq(writeOffs.invoiceId, invoiceId), isNull(writeOffs.deletedAt)));
     return Number(rows[0]?.total ?? 0);
   }
 
-  async listByInvoiceIds(invoiceIds: string[]): Promise<WriteOff[]> {
+  async listByInvoiceIds(invoiceIds: InvoiceId[]): Promise<WriteOff[]> {
     if (!invoiceIds.length) return [];
     const rows = await this.db
       .select().from(writeOffs)
-      .where(and(inArray(writeOffs.invoiceId, invoiceIds.map((id) => asId<"InvoiceId">(id))), isNull(writeOffs.deletedAt)));
+      .where(and(inArray(writeOffs.invoiceId, invoiceIds), isNull(writeOffs.deletedAt)));
     return rows;
   }
 }

--- a/src/lib/server/repositories/expected-receivable-repository.ts
+++ b/src/lib/server/repositories/expected-receivable-repository.ts
@@ -4,16 +4,17 @@
  */
 
 import type { ExpectedReceivable, ExpectedReceivableStatus } from "@/lib/shared/schemas/billing";
+import type { ExpectedReceivableId, MatterId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { Repository } from "./types";
 
 export interface ExpectedReceivableListFilter {
-  matterId?: string | undefined;
+  matterId?: MatterId | undefined;
   status?: ExpectedReceivableStatus | undefined;
 }
 
 export interface ExpectedReceivableRepository extends Repository<ExpectedReceivable> {
   /** Org:ens fordringar (nyaste först), valfritt filtrerade på ärende/status. */
-  listForOrg(organizationId: string, filter?: ExpectedReceivableListFilter): Promise<ExpectedReceivable[]>;
+  listForOrg(organizationId: OrganizationId, filter?: ExpectedReceivableListFilter): Promise<ExpectedReceivable[]>;
   /** Fordran by id, org-scopad (null om saknas/annan org/raderad). */
-  getByIdInOrg(id: string, organizationId: string): Promise<ExpectedReceivable | null>;
+  getByIdInOrg(id: ExpectedReceivableId, organizationId: OrganizationId): Promise<ExpectedReceivable | null>;
 }

--- a/src/lib/server/repositories/expense-repository.ts
+++ b/src/lib/server/repositories/expense-repository.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Expense } from "@/lib/shared/schemas/billing";
+import type { BillingRunId, ExpenseId, InvoiceId, MatterId, OrganizationId, UserId } from "@/lib/shared/schemas/ids";
 import type { ReportMatterRef } from "./time-entry-repository";
 import type { Repository } from "./types";
 
@@ -15,14 +16,14 @@ export interface LawyerReportExpense extends Expense {
 
 /** Utlägg + listvyns relationer (motsvarar `expense.list`-routerns include). */
 export interface ExpenseListRow extends Expense {
-  user: { id: string; name: string } | null;
-  matter: { id: string; matterNumber: string; title: string } | null;
-  invoice: { id: string; invoiceNumber: string | null } | null;
+  user: { id: UserId; name: string } | null;
+  matter: { id: MatterId; matterNumber: string; title: string } | null;
+  invoice: { id: InvoiceId; invoiceNumber: string | null } | null;
 }
 
 /** Filter/paginering för `listForOrg`. */
 export interface ExpenseListOptions {
-  matterId?: string | undefined;
+  matterId?: MatterId | undefined;
   page: number;
   pageSize: number;
 }
@@ -36,19 +37,19 @@ export interface ExpenseListResult {
 
 export interface ExpenseRepository extends Repository<Expense> {
   /** Org-scopad, paginerad utläggslista (nyaste först) + total + summa belopp. */
-  listForOrg(organizationId: string, opts: ExpenseListOptions): Promise<ExpenseListResult>;
+  listForOrg(organizationId: OrganizationId, opts: ExpenseListOptions): Promise<ExpenseListResult>;
   /** Utlägg by id, org-scopat via ärendet (null om saknas/annan org/raderat). */
-  getByIdInOrg(id: string, organizationId: string): Promise<Expense | null>;
+  getByIdInOrg(id: ExpenseId, organizationId: OrganizationId): Promise<Expense | null>;
   /** Valda ofakturerade utlägg i ett ärende. Tom lista vid tomma ids. */
-  listUnbilled(matterId: string, ids: string[]): Promise<Expense[]>;
+  listUnbilled(matterId: MatterId, ids: ExpenseId[]): Promise<Expense[]>;
   /** Koppla utlägg till en faktura (sätter invoiceId). No-op vid tomma ids. */
-  flagBilled(ids: string[], invoiceId: string): Promise<void>;
+  flagBilled(ids: ExpenseId[], invoiceId: InvoiceId): Promise<void>;
   /** Ofrysta utlägg i ett ärende (date asc) — underlag för billing-run. */
-  listUnfrozenForMatter(matterId: string): Promise<Expense[]>;
+  listUnfrozenForMatter(matterId: MatterId): Promise<Expense[]>;
   /** Frys alla ofrysta utlägg i ett ärende mot en billing-run (bulk). */
-  freezeForMatter(matterId: string, billingRunId: string, now: Date): Promise<void>;
+  freezeForMatter(matterId: MatterId, billingRunId: BillingRunId, now: Date): Promise<void>;
   /** Frys ENBART de angivna (ofrysta) utläggen mot en billing-run — per-post-val. */
-  freezeByIds(ids: string[], billingRunId: string, now: Date): Promise<void>;
+  freezeByIds(ids: ExpenseId[], billingRunId: BillingRunId, now: Date): Promise<void>;
   /** En advokats utlägg i en period (date asc), med ärende-ref (perLawyer-rapporten). */
-  listForLawyerInPeriod(organizationId: string, userId: string, from: Date, to: Date): Promise<LawyerReportExpense[]>;
+  listForLawyerInPeriod(organizationId: OrganizationId, userId: UserId, from: Date, to: Date): Promise<LawyerReportExpense[]>;
 }

--- a/src/lib/server/repositories/in-memory-billing-run-repository.ts
+++ b/src/lib/server/repositories/in-memory-billing-run-repository.ts
@@ -4,6 +4,7 @@
  */
 
 import type { BillingRun } from "@/lib/shared/schemas/billing";
+import type { BillingRunId, MatterId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { IDataStore } from "../data-store/IDataStore";
 import type {
   BillingRunDetailRow, BillingRunListRow, BillingRunRepository,
@@ -19,7 +20,7 @@ export class InMemoryBillingRunRepository
     super(store.billingRuns, now ?? (() => new Date()));
   }
 
-  async listForOrg(organizationId: string, matterId?: string): Promise<BillingRunListRow[]> {
+  async listForOrg(organizationId: OrganizationId, matterId?: MatterId): Promise<BillingRunListRow[]> {
     return (await this.delegate.findMany({
       where: { ...(matterId ? { matterId } : {}), matter: { organizationId } },
       orderBy: { createdAt: "desc" },
@@ -27,7 +28,7 @@ export class InMemoryBillingRunRepository
     })) as BillingRunListRow[];
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<BillingRunDetailRow | null> {
+  async getByIdInOrg(id: BillingRunId, organizationId: OrganizationId): Promise<BillingRunDetailRow | null> {
     const row = (await this.delegate.findFirst({
       where: { id, matter: { organizationId } },
       include: {
@@ -38,13 +39,13 @@ export class InMemoryBillingRunRepository
     return row && !row.deletedAt ? row : null;
   }
 
-  async listAccontoSent(matterId: string): Promise<BillingRun[]> {
+  async listAccontoSent(matterId: MatterId): Promise<BillingRun[]> {
     return (await this.delegate.findMany({
       where: { matterId, type: "ACCONTO", status: "SENT" },
     })) as BillingRun[];
   }
 
-  async listAccontoByIds(matterId: string, ids: string[]): Promise<BillingRun[]> {
+  async listAccontoByIds(matterId: MatterId, ids: BillingRunId[]): Promise<BillingRun[]> {
     if (!ids.length) return [];
     return (await this.delegate.findMany({
       where: { id: { in: ids }, matterId, type: "ACCONTO" },

--- a/src/lib/server/repositories/in-memory-expected-receivable-repository.ts
+++ b/src/lib/server/repositories/in-memory-expected-receivable-repository.ts
@@ -3,6 +3,7 @@
  */
 
 import type { ExpectedReceivable } from "@/lib/shared/schemas/billing";
+import type { ExpectedReceivableId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { IDataStore } from "../data-store/IDataStore";
 import type { ExpectedReceivableListFilter, ExpectedReceivableRepository } from "./expected-receivable-repository";
 import { InMemoryRepository } from "./in-memory-repository";
@@ -16,7 +17,7 @@ export class InMemoryExpectedReceivableRepository
     super(store.expectedReceivables, now ?? (() => new Date()));
   }
 
-  async listForOrg(organizationId: string, filter?: ExpectedReceivableListFilter): Promise<ExpectedReceivable[]> {
+  async listForOrg(organizationId: OrganizationId, filter?: ExpectedReceivableListFilter): Promise<ExpectedReceivable[]> {
     return (await this.delegate.findMany({
       where: {
         organizationId,
@@ -27,7 +28,7 @@ export class InMemoryExpectedReceivableRepository
     })) as ExpectedReceivable[];
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<ExpectedReceivable | null> {
+  async getByIdInOrg(id: ExpectedReceivableId, organizationId: OrganizationId): Promise<ExpectedReceivable | null> {
     const row = (await this.delegate.findFirst({ where: { id, organizationId } })) as ExpectedReceivable | null;
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }

--- a/src/lib/server/repositories/in-memory-expense-repository.ts
+++ b/src/lib/server/repositories/in-memory-expense-repository.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Expense } from "@/lib/shared/schemas/billing";
+import type { BillingRunId, ExpenseId, InvoiceId, MatterId, OrganizationId, UserId } from "@/lib/shared/schemas/ids";
 import type { IDataStore } from "../data-store/IDataStore";
 import type {
   ExpenseListOptions, ExpenseListResult, ExpenseListRow, ExpenseRepository, LawyerReportExpense,
@@ -18,7 +19,7 @@ export class InMemoryExpenseRepository extends InMemoryRepository<Expense> imple
     super(store.expenses, now ?? (() => new Date()));
   }
 
-  async listForOrg(organizationId: string, opts: ExpenseListOptions): Promise<ExpenseListResult> {
+  async listForOrg(organizationId: OrganizationId, opts: ExpenseListOptions): Promise<ExpenseListResult> {
     const where = {
       matter: { organizationId },
       ...(opts.matterId ? { matterId: opts.matterId } : {}),
@@ -41,38 +42,38 @@ export class InMemoryExpenseRepository extends InMemoryRepository<Expense> imple
     return { expenses, total, totalAmount: (agg as { _sum?: { amount?: number } })._sum?.amount ?? 0 };
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<Expense | null> {
+  async getByIdInOrg(id: ExpenseId, organizationId: OrganizationId): Promise<Expense | null> {
     const row = (await this.delegate
       .findFirst({ where: { id, matter: { organizationId } } })) as Expense | null;
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }
 
-  async listUnbilled(matterId: string, ids: string[]): Promise<Expense[]> {
+  async listUnbilled(matterId: MatterId, ids: ExpenseId[]): Promise<Expense[]> {
     if (!ids.length) return [];
     return (await this.delegate.findMany({
       where: { id: { in: ids }, matterId, invoiceId: null },
     })) as Expense[];
   }
 
-  async flagBilled(ids: string[], invoiceId: string): Promise<void> {
+  async flagBilled(ids: ExpenseId[], invoiceId: InvoiceId): Promise<void> {
     if (!ids.length) return;
     await this.delegate.updateMany({ where: { id: { in: ids } }, data: { invoiceId } as Partial<Expense> });
   }
 
-  async listUnfrozenForMatter(matterId: string): Promise<Expense[]> {
+  async listUnfrozenForMatter(matterId: MatterId): Promise<Expense[]> {
     return (await this.delegate.findMany({
       where: { matterId, frozenByBillingRunId: null }, orderBy: { date: "asc" },
     })) as Expense[];
   }
 
-  async freezeForMatter(matterId: string, billingRunId: string, now: Date): Promise<void> {
+  async freezeForMatter(matterId: MatterId, billingRunId: BillingRunId, now: Date): Promise<void> {
     await this.delegate.updateMany({
       where: { matterId, frozenByBillingRunId: null },
       data: { frozenAt: now, frozenByBillingRunId: billingRunId } as Partial<Expense>,
     });
   }
 
-  async freezeByIds(ids: string[], billingRunId: string, now: Date): Promise<void> {
+  async freezeByIds(ids: ExpenseId[], billingRunId: BillingRunId, now: Date): Promise<void> {
     if (!ids.length) return;
     await this.delegate.updateMany({
       where: { id: { in: ids }, frozenByBillingRunId: null },
@@ -81,7 +82,7 @@ export class InMemoryExpenseRepository extends InMemoryRepository<Expense> imple
   }
 
   async listForLawyerInPeriod(
-    organizationId: string, userId: string, from: Date, to: Date,
+    organizationId: OrganizationId, userId: UserId, from: Date, to: Date,
   ): Promise<LawyerReportExpense[]> {
     return (await this.delegate.findMany({
       where: { matter: { organizationId }, userId, date: { gte: from, lte: to } },

--- a/src/lib/server/repositories/in-memory-payment-plan-repository.ts
+++ b/src/lib/server/repositories/in-memory-payment-plan-repository.ts
@@ -7,6 +7,7 @@
 
 import type { PaymentPlan } from "@/lib/shared/schemas/billing";
 import type { PaymentPlanStatus } from "@/lib/shared/schemas/enums";
+import type { InvoiceId, OrganizationId, PaymentPlanId } from "@/lib/shared/schemas/ids";
 import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type {
@@ -42,18 +43,18 @@ export class InMemoryPaymentPlanRepository extends InMemoryRepository<PaymentPla
     super(store.paymentPlans, now ?? (() => new Date()));
   }
 
-  async getByIdInOrg(planId: string, organizationId: string): Promise<PaymentPlan | null> {
+  async getByIdInOrg(planId: PaymentPlanId, organizationId: OrganizationId): Promise<PaymentPlan | null> {
     const row = (await this.delegate
       .findFirst({ where: { id: planId, invoice: { matter: { organizationId } } } })) as PaymentPlan | null;
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }
 
-  async getByInvoiceId(invoiceId: string): Promise<PaymentPlan | null> {
+  async getByInvoiceId(invoiceId: InvoiceId): Promise<PaymentPlan | null> {
     const row = (await this.delegate.findFirst({ where: { invoiceId } })) as PaymentPlan | null;
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }
 
-  async listForOrg(organizationId: string, status?: PaymentPlanStatus): Promise<JoinedPaymentPlan[]> {
+  async listForOrg(organizationId: OrganizationId, status?: PaymentPlanStatus): Promise<JoinedPaymentPlan[]> {
     return (await this.delegate.findMany({
       where: { ...(status ? { status } : {}), invoice: { matter: { organizationId } } },
       orderBy: { createdAt: "desc" },
@@ -61,7 +62,7 @@ export class InMemoryPaymentPlanRepository extends InMemoryRepository<PaymentPla
     })) as JoinedPaymentPlan[];
   }
 
-  async getByIdWithDetails(id: string, organizationId: string): Promise<JoinedPaymentPlanWithReminders | null> {
+  async getByIdWithDetails(id: PaymentPlanId, organizationId: OrganizationId): Promise<JoinedPaymentPlanWithReminders | null> {
     const row = (await this.delegate.findFirst({
       where: { id, invoice: { matter: { organizationId } } },
       include: {
@@ -72,7 +73,7 @@ export class InMemoryPaymentPlanRepository extends InMemoryRepository<PaymentPla
     return row && !row.deletedAt ? row : null;
   }
 
-  async listActiveForScan(organizationId: string): Promise<JoinedPaymentPlanWithReminders[]> {
+  async listActiveForScan(organizationId: OrganizationId): Promise<JoinedPaymentPlanWithReminders[]> {
     return (await this.delegate.findMany({
       where: { status: "ACTIVE", invoice: { matter: { organizationId } } },
       include: {

--- a/src/lib/server/repositories/in-memory-payment-repository.ts
+++ b/src/lib/server/repositories/in-memory-payment-repository.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Payment } from "@/lib/shared/schemas/billing";
+import type { InvoiceId } from "@/lib/shared/schemas/ids";
 import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type { PaymentRepository } from "./payment-repository";
@@ -16,14 +17,14 @@ export class InMemoryPaymentRepository extends InMemoryRepository<Payment> imple
     super(source.payments, now ?? (() => new Date()));
   }
 
-  async sumByInvoice(invoiceId: string): Promise<number> {
+  async sumByInvoice(invoiceId: InvoiceId): Promise<number> {
     const rows = await this.source.payments.findMany({ where: { invoiceId } });
     return rows
       .filter((r) => !(r as { deletedAt?: unknown }).deletedAt)
       .reduce((s, p) => s + p.amount, 0);
   }
 
-  async listByInvoiceIds(invoiceIds: string[]): Promise<Payment[]> {
+  async listByInvoiceIds(invoiceIds: InvoiceId[]): Promise<Payment[]> {
     if (!invoiceIds.length) return [];
     return this.source.payments.findMany({ where: { invoiceId: { in: invoiceIds } } });
   }

--- a/src/lib/server/repositories/in-memory-time-entry-repository.ts
+++ b/src/lib/server/repositories/in-memory-time-entry-repository.ts
@@ -5,6 +5,7 @@
  */
 
 import type { TimeEntry } from "@/lib/shared/schemas/billing";
+import type { BillingRunId, InvoiceId, MatterId, OrganizationId, TimeEntryId, UserId } from "@/lib/shared/schemas/ids";
 import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type {
@@ -25,7 +26,7 @@ export class InMemoryTimeEntryRepository extends InMemoryRepository<TimeEntry> i
     super(store.timeEntries, now ?? (() => new Date()));
   }
 
-  async listForOrg(organizationId: string, opts: TimeEntryListFilter): Promise<TimeEntryListResult> {
+  async listForOrg(organizationId: OrganizationId, opts: TimeEntryListFilter): Promise<TimeEntryListResult> {
     const where = {
       matter: { organizationId },
       ...(opts.matterId ? { matterId: opts.matterId } : {}),
@@ -50,12 +51,12 @@ export class InMemoryTimeEntryRepository extends InMemoryRepository<TimeEntry> i
     return { entries, total, totalMinutes: (agg as { _sum?: { minutes?: number } })._sum?.minutes ?? 0 };
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<TimeEntry | null> {
+  async getByIdInOrg(id: TimeEntryId, organizationId: OrganizationId): Promise<TimeEntry | null> {
     const row = (await this.delegate.findFirst({ where: { id, matter: { organizationId } } })) as TimeEntry | null;
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }
 
-  async listForReport(organizationId: string, filter: TimeEntryReportFilter): Promise<TimeEntryReportRow[]> {
+  async listForReport(organizationId: OrganizationId, filter: TimeEntryReportFilter): Promise<TimeEntryReportRow[]> {
     const userFilter = filter.userIds && filter.userIds.length > 0
       ? { userId: { in: filter.userIds } }
       : filter.userId
@@ -85,7 +86,7 @@ export class InMemoryTimeEntryRepository extends InMemoryRepository<TimeEntry> i
     })) as TimeEntryReportRow[];
   }
 
-  async listUnbilled(matterId: string, ids: string[]): Promise<UnbilledTimeEntry[]> {
+  async listUnbilled(matterId: MatterId, ids: TimeEntryId[]): Promise<UnbilledTimeEntry[]> {
     if (!ids.length) return [];
     return (await this.delegate.findMany({
       where: { id: { in: ids }, matterId, invoiceId: null },
@@ -93,25 +94,25 @@ export class InMemoryTimeEntryRepository extends InMemoryRepository<TimeEntry> i
     })) as UnbilledTimeEntry[];
   }
 
-  async flagBilled(ids: string[], invoiceId: string): Promise<void> {
+  async flagBilled(ids: TimeEntryId[], invoiceId: InvoiceId): Promise<void> {
     if (!ids.length) return;
     await this.delegate.updateMany({ where: { id: { in: ids } }, data: { invoiceId } as Partial<TimeEntry> });
   }
 
-  async listUnfrozenForMatter(matterId: string): Promise<TimeEntry[]> {
+  async listUnfrozenForMatter(matterId: MatterId): Promise<TimeEntry[]> {
     return (await this.delegate.findMany({
       where: { matterId, frozenByBillingRunId: null }, orderBy: { date: "asc" },
     })) as TimeEntry[];
   }
 
-  async freezeForMatter(matterId: string, billingRunId: string, now: Date): Promise<void> {
+  async freezeForMatter(matterId: MatterId, billingRunId: BillingRunId, now: Date): Promise<void> {
     await this.delegate.updateMany({
       where: { matterId, frozenByBillingRunId: null },
       data: { frozenAt: now, frozenByBillingRunId: billingRunId } as Partial<TimeEntry>,
     });
   }
 
-  async freezeByIds(ids: string[], billingRunId: string, now: Date): Promise<void> {
+  async freezeByIds(ids: TimeEntryId[], billingRunId: BillingRunId, now: Date): Promise<void> {
     if (!ids.length) return;
     await this.delegate.updateMany({
       where: { id: { in: ids }, frozenByBillingRunId: null },
@@ -120,7 +121,7 @@ export class InMemoryTimeEntryRepository extends InMemoryRepository<TimeEntry> i
   }
 
   async listForLawyerInPeriod(
-    organizationId: string, userId: string, from: Date, to: Date,
+    organizationId: OrganizationId, userId: UserId, from: Date, to: Date,
   ): Promise<LawyerReportTimeEntry[]> {
     return (await this.delegate.findMany({
       where: { matter: { organizationId }, userId, date: { gte: from, lte: to } },
@@ -129,7 +130,7 @@ export class InMemoryTimeEntryRepository extends InMemoryRepository<TimeEntry> i
     })) as LawyerReportTimeEntry[];
   }
 
-  async listBillableForOrg(organizationId: string): Promise<TimeEntry[]> {
+  async listBillableForOrg(organizationId: OrganizationId): Promise<TimeEntry[]> {
     return (await this.delegate.findMany({
       where: { matter: { organizationId }, billable: true },
     })) as TimeEntry[];

--- a/src/lib/server/repositories/in-memory-write-off-repository.ts
+++ b/src/lib/server/repositories/in-memory-write-off-repository.ts
@@ -4,6 +4,7 @@
  */
 
 import type { WriteOff } from "@/lib/shared/schemas/billing";
+import type { InvoiceId } from "@/lib/shared/schemas/ids";
 import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type { WriteOffRepository } from "./write-off-repository";
@@ -16,14 +17,14 @@ export class InMemoryWriteOffRepository extends InMemoryRepository<WriteOff> imp
     super(source.writeOffs, now ?? (() => new Date()));
   }
 
-  async sumByInvoice(invoiceId: string): Promise<number> {
+  async sumByInvoice(invoiceId: InvoiceId): Promise<number> {
     const rows = await this.source.writeOffs.findMany({ where: { invoiceId } });
     return rows
       .filter((r) => !(r as { deletedAt?: unknown }).deletedAt)
       .reduce((s, w) => s + w.amount, 0);
   }
 
-  async listByInvoiceIds(invoiceIds: string[]): Promise<WriteOff[]> {
+  async listByInvoiceIds(invoiceIds: InvoiceId[]): Promise<WriteOff[]> {
     if (!invoiceIds.length) return [];
     return this.source.writeOffs.findMany({ where: { invoiceId: { in: invoiceIds } } });
   }

--- a/src/lib/server/repositories/payment-plan-repository.ts
+++ b/src/lib/server/repositories/payment-plan-repository.ts
@@ -10,12 +10,13 @@
 
 import type { Invoice, Payment, PaymentPlan, PaymentPlanReminder, WriteOff } from "@/lib/shared/schemas/billing";
 import type { PaymentPlanStatus } from "@/lib/shared/schemas/enums";
+import type { ContactId, InvoiceId, OrganizationId, PaymentPlanId } from "@/lib/shared/schemas/ids";
 import type { Matter } from "@/lib/shared/schemas/matter";
 import type { Repository } from "./types";
 
 /** Ärende + KLIENT-kontakten (namn/email för påminnelse-mottagaren). */
 export interface PlanMatter extends Matter {
-  contacts: Array<{ contact: { id: string; name: string; email?: string | null } }>;
+  contacts: Array<{ contact: { id: ContactId; name: string; email?: string | null } }>;
 }
 
 /** Faktura med ledger-rader + ärende (det list-/scan-vyn räknar på). */
@@ -37,13 +38,13 @@ export interface JoinedPaymentPlanWithReminders extends JoinedPaymentPlan {
 
 export interface PaymentPlanRepository extends Repository<PaymentPlan> {
   /** Plan by id, org-scopad via faktura→ärende (null om saknas/annan org/raderad). */
-  getByIdInOrg(planId: string, organizationId: string): Promise<PaymentPlan | null>;
+  getByIdInOrg(planId: PaymentPlanId, organizationId: OrganizationId): Promise<PaymentPlan | null>;
   /** Plan för en faktura (invoiceId är unik på planen) — null om ingen/raderad. */
-  getByInvoiceId(invoiceId: string): Promise<PaymentPlan | null>;
+  getByInvoiceId(invoiceId: InvoiceId): Promise<PaymentPlan | null>;
   /** Org:ens planer (createdAt desc), valfritt status-filtrerade, joinade. */
-  listForOrg(organizationId: string, status?: PaymentPlanStatus): Promise<JoinedPaymentPlan[]>;
+  listForOrg(organizationId: OrganizationId, status?: PaymentPlanStatus): Promise<JoinedPaymentPlan[]>;
   /** En plan med full join + påminnelse-historik, org-scopad. Null om saknas. */
-  getByIdWithDetails(id: string, organizationId: string): Promise<JoinedPaymentPlanWithReminders | null>;
+  getByIdWithDetails(id: PaymentPlanId, organizationId: OrganizationId): Promise<JoinedPaymentPlanWithReminders | null>;
   /** Aktiva planer i org:en (join + påminnelser) för påminnelse-skannern. */
-  listActiveForScan(organizationId: string): Promise<JoinedPaymentPlanWithReminders[]>;
+  listActiveForScan(organizationId: OrganizationId): Promise<JoinedPaymentPlanWithReminders[]>;
 }

--- a/src/lib/server/repositories/payment-repository.ts
+++ b/src/lib/server/repositories/payment-repository.ts
@@ -5,11 +5,12 @@
  */
 
 import type { Payment } from "@/lib/shared/schemas/billing";
+import type { InvoiceId } from "@/lib/shared/schemas/ids";
 import type { Repository } from "./types";
 
 export interface PaymentRepository extends Repository<Payment> {
   /** Summa av alla (icke-raderade) betalningar på en faktura (öre). */
-  sumByInvoice(invoiceId: string): Promise<number>;
+  sumByInvoice(invoiceId: InvoiceId): Promise<number>;
   /** Betalningar för en uppsättning fakturor (rapporter). Tom lista vid tomma ids. */
-  listByInvoiceIds(invoiceIds: string[]): Promise<Payment[]>;
+  listByInvoiceIds(invoiceIds: InvoiceId[]): Promise<Payment[]>;
 }

--- a/src/lib/server/repositories/time-entry-repository.ts
+++ b/src/lib/server/repositories/time-entry-repository.ts
@@ -6,6 +6,7 @@
 
 import type { TimeEntry } from "@/lib/shared/schemas/billing";
 import type { PaymentMethod } from "@/lib/shared/schemas/enums";
+import type { BillingRunId, InvoiceId, MatterId, OrganizationId, TimeEntryId, UserId } from "@/lib/shared/schemas/ids";
 import type { Repository } from "./types";
 
 /** Tidspost + juristens timtaxa (det fakturaberäkningen behöver). */
@@ -15,14 +16,14 @@ export interface UnbilledTimeEntry extends TimeEntry {
 
 /** Tidspost + relationer för listvyn. matter alltid satt (matterId NOT NULL FK). */
 export interface TimeEntryListRow extends TimeEntry {
-  user: { id: string; name: string } | null;
-  matter: { id: string; matterNumber: string; title: string };
-  invoice: { id: string; invoiceNumber: string | null } | null;
+  user: { id: UserId; name: string } | null;
+  matter: { id: MatterId; matterNumber: string; title: string };
+  invoice: { id: InvoiceId; invoiceNumber: string | null } | null;
 }
 
 export interface TimeEntryListFilter {
-  matterId?: string | undefined;
-  userId?: string | undefined;
+  matterId?: MatterId | undefined;
+  userId?: UserId | undefined;
   from?: Date | undefined;
   to?: Date | undefined;
   page: number;
@@ -37,21 +38,21 @@ export interface TimeEntryListResult {
 
 /** Tidspost för tidsrapporten — med jurist + ärende inkl. klient-kontakten (KLIENT). */
 export interface TimeEntryReportRow extends TimeEntry {
-  user: { id: string; name: string };
-  matter: { id: string; matterNumber: string; title: string; contacts: Array<{ contact: { name: string } }> } | null;
+  user: { id: UserId; name: string };
+  matter: { id: MatterId; matterNumber: string; title: string; contacts: Array<{ contact: { name: string } }> } | null;
 }
 
 export interface TimeEntryReportFilter {
   from: Date;
   to: Date;
-  userId?: string | undefined;
-  userIds?: string[] | undefined;
-  matterId?: string | undefined;
+  userId?: UserId | undefined;
+  userIds?: UserId[] | undefined;
+  matterId?: MatterId | undefined;
 }
 
 /** Ärende-projektionen advokatrapporten (reports.perLawyer) läser. */
 export interface ReportMatterRef {
-  id: string;
+  id: MatterId;
   matterNumber: string;
   title: string;
   paymentMethod: PaymentMethod;
@@ -67,23 +68,23 @@ export interface LawyerReportTimeEntry extends TimeEntry {
 
 export interface TimeEntryRepository extends Repository<TimeEntry> {
   /** Org-scopad paginerad lista (datum desc) + total + summa minuter. */
-  listForOrg(organizationId: string, filter: TimeEntryListFilter): Promise<TimeEntryListResult>;
+  listForOrg(organizationId: OrganizationId, filter: TimeEntryListFilter): Promise<TimeEntryListResult>;
   /** Tidspost by id, org-scopad via ärendet (null om saknas/annan org/raderad). */
-  getByIdInOrg(id: string, organizationId: string): Promise<TimeEntry | null>;
+  getByIdInOrg(id: TimeEntryId, organizationId: OrganizationId): Promise<TimeEntry | null>;
   /** Tidsrapport-rader (jurist + ärende + KLIENT-kontakt), org-scopat, userId asc / date asc. */
-  listForReport(organizationId: string, filter: TimeEntryReportFilter): Promise<TimeEntryReportRow[]>;
+  listForReport(organizationId: OrganizationId, filter: TimeEntryReportFilter): Promise<TimeEntryReportRow[]>;
   /** Valda ofakturerade tidsposter i ett ärende (med user.hourlyRate). Tom lista vid tomma ids. */
-  listUnbilled(matterId: string, ids: string[]): Promise<UnbilledTimeEntry[]>;
+  listUnbilled(matterId: MatterId, ids: TimeEntryId[]): Promise<UnbilledTimeEntry[]>;
   /** Koppla tidsposter till en faktura (sätter invoiceId). No-op vid tomma ids. */
-  flagBilled(ids: string[], invoiceId: string): Promise<void>;
+  flagBilled(ids: TimeEntryId[], invoiceId: InvoiceId): Promise<void>;
   /** Ofrysta tidsposter i ett ärende (date asc) — underlag för billing-run. */
-  listUnfrozenForMatter(matterId: string): Promise<TimeEntry[]>;
+  listUnfrozenForMatter(matterId: MatterId): Promise<TimeEntry[]>;
   /** Frys alla ofrysta tidsposter i ett ärende mot en billing-run (bulk). */
-  freezeForMatter(matterId: string, billingRunId: string, now: Date): Promise<void>;
+  freezeForMatter(matterId: MatterId, billingRunId: BillingRunId, now: Date): Promise<void>;
   /** Frys ENBART de angivna (ofrysta) tidsposterna mot en billing-run — per-post-val. */
-  freezeByIds(ids: string[], billingRunId: string, now: Date): Promise<void>;
+  freezeByIds(ids: TimeEntryId[], billingRunId: BillingRunId, now: Date): Promise<void>;
   /** En advokats tidsposter i en period (date asc), med ärende-ref (perLawyer-rapporten). */
-  listForLawyerInPeriod(organizationId: string, userId: string, from: Date, to: Date): Promise<LawyerReportTimeEntry[]>;
+  listForLawyerInPeriod(organizationId: OrganizationId, userId: UserId, from: Date, to: Date): Promise<LawyerReportTimeEntry[]>;
   /** Alla debiterbara tidsposter i org:en (för fakturerat/AR-attribuering). */
-  listBillableForOrg(organizationId: string): Promise<TimeEntry[]>;
+  listBillableForOrg(organizationId: OrganizationId): Promise<TimeEntry[]>;
 }

--- a/src/lib/server/repositories/write-off-repository.ts
+++ b/src/lib/server/repositories/write-off-repository.ts
@@ -5,11 +5,12 @@
  */
 
 import type { WriteOff } from "@/lib/shared/schemas/billing";
+import type { InvoiceId } from "@/lib/shared/schemas/ids";
 import type { Repository } from "./types";
 
 export interface WriteOffRepository extends Repository<WriteOff> {
   /** Summa av alla (icke-raderade) avskrivningar på en faktura (öre). */
-  sumByInvoice(invoiceId: string): Promise<number>;
+  sumByInvoice(invoiceId: InvoiceId): Promise<number>;
   /** Avskrivningar för en uppsättning fakturor (rapporter). Tom lista vid tomma ids. */
-  listByInvoiceIds(invoiceIds: string[]): Promise<WriteOff[]>;
+  listByInvoiceIds(invoiceIds: InvoiceId[]): Promise<WriteOff[]>;
 }

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -25,18 +25,23 @@ import {
   matterIdSchema,
   billingRunIdSchema,
   invoiceIdSchema,
+  timeEntryIdSchema,
+  expenseIdSchema,
   asId,
   type BillingRunId,
+  type ExpenseId,
+  type InvoiceId,
   type MatterId,
   type OrganizationId,
+  type TimeEntryId,
 } from "@/lib/shared/schemas/ids";
 import { emit } from "../events/emit";
 import type { Repositories } from "../repositories/repositories";
 import { router, orgProcedure } from "../trpc";
 
 interface UnfrozenWork {
-  timeEntries: Array<{ id: string; minutes: number; hourlyRate: number; billable: boolean }>;
-  expenses: Array<{ id: string; amount: number; billable: boolean }>;
+  timeEntries: Array<{ id: TimeEntryId; minutes: number; hourlyRate: number; billable: boolean }>;
+  expenses: Array<{ id: ExpenseId; amount: number; billable: boolean }>;
 }
 
 /** En itemiserad rad i fakturaförslaget (#397) — tidspost med beräknat värde. */
@@ -69,7 +74,7 @@ function timeEntryValueOre(minutes: number, hourlyRate: number): number {
   return Math.round((minutes / 60) * hourlyRate);
 }
 
-async function fetchUnfrozenWork(repos: Repositories, matterId: string): Promise<UnfrozenWork> {
+async function fetchUnfrozenWork(repos: Repositories, matterId: MatterId): Promise<UnfrozenWork> {
   const te = await repos.timeEntries.listUnfrozenForMatter(matterId);
   const ex = await repos.expenses.listUnfrozenForMatter(matterId);
   return { timeEntries: te, expenses: ex.filter((e) => e.kind !== "PRUTNING") };
@@ -104,12 +109,12 @@ function buildProposal(
 }
 
 /** Summan av tidigare utställda ACCONTO-fakturors belopp för ett ärende (#397). */
-async function sumPriorAccontos(repos: Repositories, matterId: string): Promise<number> {
+async function sumPriorAccontos(repos: Repositories, matterId: MatterId): Promise<number> {
   const runs = (await repos.billingRuns.listAccontoSent(matterId)) as ReadonlyArray<{ amountOre?: number }>;
   return runs.reduce((sum, r) => sum + (r.amountOre ?? 0), 0);
 }
 
-async function freezeWork(repos: Repositories, matterId: string, billingRunId: BillingRunId): Promise<void> {
+async function freezeWork(repos: Repositories, matterId: MatterId, billingRunId: BillingRunId): Promise<void> {
   const now = new Date();
   await repos.timeEntries.freezeForMatter(matterId, billingRunId, now);
   await repos.expenses.freezeForMatter(matterId, billingRunId, now);
@@ -125,14 +130,14 @@ async function freezeWork(repos: Repositories, matterId: string, billingRunId: B
  */
 async function linkFinalInvoice(
   repos: Repositories,
-  invoiceId: string,
+  invoiceId: InvoiceId,
   work: UnfrozenWork,
-  deductedAccontoInvoiceIds: ReadonlyArray<string>,
+  deductedAccontoInvoiceIds: ReadonlyArray<InvoiceId>,
 ): Promise<void> {
   await repos.timeEntries.flagBilled(work.timeEntries.filter((t) => t.billable).map((t) => t.id), invoiceId);
   await repos.expenses.flagBilled(work.expenses.filter((e) => e.billable).map((e) => e.id), invoiceId);
   for (const accontoInvoiceId of deductedAccontoInvoiceIds) {
-    await repos.accontoDeductions.create({ finalInvoiceId: asId<"InvoiceId">(invoiceId), accontoInvoiceId: asId<"InvoiceId">(accontoInvoiceId) });
+    await repos.accontoDeductions.create({ finalInvoiceId: invoiceId, accontoInvoiceId });
   }
 }
 
@@ -144,9 +149,9 @@ async function linkFinalInvoice(
  */
 async function resolveFinalWork(
   repos: Repositories,
-  matterId: string,
-  timeEntryIds: string[] | undefined,
-  expenseIds: string[] | undefined,
+  matterId: MatterId,
+  timeEntryIds: TimeEntryId[] | undefined,
+  expenseIds: ExpenseId[] | undefined,
 ): Promise<{ work: UnfrozenWork; selected: boolean }> {
   if (timeEntryIds === undefined && expenseIds === undefined) {
     return { work: await fetchUnfrozenWork(repos, matterId), selected: false };
@@ -170,7 +175,7 @@ async function resolveFinalWork(
 /** Frys valda poster (per-post) eller hela ärendet (default). */
 async function freezeSelectedWork(
   repos: Repositories,
-  matterId: string,
+  matterId: MatterId,
   work: UnfrozenWork,
   selected: boolean,
   runId: BillingRunId,
@@ -197,11 +202,11 @@ async function assertMatterInOrg(repos: Repositories, matterId: MatterId, orgId:
  */
 async function invoiceNumbering(
   repos: Repositories,
-  orgId: string,
+  orgId: OrganizationId,
   recipient: BillingRunRecipient,
 ): Promise<{ invoiceNumber: string; ocrReference: string | null } | Record<string, never>> {
   if (recipient === "DOMSTOL") return {};
-  const invoiceNumber = await repos.invoices.nextInvoiceNumber(asId<"OrganizationId">(orgId));
+  const invoiceNumber = await repos.invoices.nextInvoiceNumber(orgId);
   return { invoiceNumber, ocrReference: ocrFromInvoiceNumber(invoiceNumber) };
 }
 
@@ -296,8 +301,8 @@ export const billingRunRouter = router({
       recipient: billingRunRecipientSchema,
       deductedBillingRunIds: z.array(billingRunIdSchema).default([]),
       // Per-post-val (#734): anges → fakturera/frys ENBART dessa; utelämnas → allt ofryst.
-      timeEntryIds: z.array(z.string()).optional(),
-      expenseIds: z.array(z.string()).optional(),
+      timeEntryIds: z.array(timeEntryIdSchema).optional(),
+      expenseIds: z.array(expenseIdSchema).optional(),
       // Valfri paritet med legacy (demo/fixtures): klient-id + datum.
       id: invoiceIdSchema.optional(),
       invoiceDate: z.string().optional(),
@@ -325,7 +330,7 @@ export const billingRunRouter = router({
           invoiceId: invoice.id, deductedBillingRunIds: input.deductedBillingRunIds,
           periodTo: new Date(), notes: input.notes,
         });
-        await freezeSelectedWork(tx, input.matterId, work, selected, run.id as BillingRunId);
+        await freezeSelectedWork(tx, input.matterId, work, selected, run.id);
         // Länka posterna + acconto-avdrag → slutfaktura-vyn visar rätt arvode/utlägg (#728).
         await linkFinalInvoice(tx, invoice.id, work, accontoInvoiceIds(deductedRuns));
         await emit.invoiceCreated(ctx, invoice);
@@ -364,10 +369,10 @@ export const billingRunRouter = router({
           throw new TRPCError({ code: "BAD_REQUEST", message: "Bara KOSTNADSRAKNING i PENDING_VERDICT kan domsläggas." });
         }
         const finalAmount = Math.max(0, run.workValueOreAtRun + input.prutningOre);
-        let prutningExpenseId: string | undefined;
+        let prutningExpenseId: ExpenseId | undefined;
         if (input.prutningOre < 0) {
           const prutning = await tx.expenses.create({
-            matterId: run.matterId, userId: asId<"UserId">(ctx.user.id), date: new Date(),
+            matterId: run.matterId, userId: ctx.user.id, date: new Date(),
             amount: input.prutningOre, description: "Prutning enligt dom",
             billable: true, vatRate: 0, vatIncluded: false, kind: "PRUTNING",
           });
@@ -383,7 +388,7 @@ export const billingRunRouter = router({
         await tx.billingRuns.update(run.id, {
           status: "SENT", invoiceId: invoice.id, amountOre: finalAmount, prutningOre: input.prutningOre,
         });
-        await freezeWork(tx, run.matterId, run.id as BillingRunId);
+        await freezeWork(tx, run.matterId, run.id);
         // Länka poster + PRUTNING-utlägget → kostnadsräknings-vyn visar uppdelning
         // och totalen (arvode + utlägg − prutning) reconciler mot beloppet (#732).
         await linkFinalInvoice(tx, invoice.id, work, []);
@@ -402,8 +407,8 @@ export const billingRunRouter = router({
  */
 async function fetchDeductedAccontoRuns(
   repos: Repositories,
-  matterId: string,
-  ids: ReadonlyArray<string>,
+  matterId: MatterId,
+  ids: ReadonlyArray<BillingRunId>,
 ): Promise<BillingRun[]> {
   if (ids.length === 0) return [];
   const runs = await repos.billingRuns.listAccontoByIds(matterId, [...ids]);
@@ -417,6 +422,6 @@ async function fetchDeductedAccontoRuns(
 }
 
 /** Acconto-fakturornas id ur avdragna körningar (för acconto_deductions-raderna). */
-function accontoInvoiceIds(runs: ReadonlyArray<BillingRun>): string[] {
+function accontoInvoiceIds(runs: ReadonlyArray<BillingRun>): InvoiceId[] {
   return runs.map((r) => r.invoiceId).filter((id): id is NonNullable<typeof id> => id != null);
 }

--- a/src/lib/server/routers/expectedReceivable.ts
+++ b/src/lib/server/routers/expectedReceivable.ts
@@ -17,12 +17,12 @@ import { z } from "zod";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import type { ExpectedReceivable } from "@/lib/shared/schemas/billing";
 import { expectedReceivableStatusSchema } from "@/lib/shared/schemas/billing";
-import { asId, expectedReceivableIdSchema, matterIdSchema } from "@/lib/shared/schemas/ids";
+import { expectedReceivableIdSchema, matterIdSchema, type ExpectedReceivableId, type OrganizationId } from "@/lib/shared/schemas/ids";
 import type { Repositories } from "../repositories/repositories";
 import { router, orgProcedure } from "../trpc";
 
 /** Hämta en fordran och verifiera org-tillhörighet (repository-sömmen, ADR 0020). */
-async function assertInOrg(repos: Repositories, orgId: string, id: string): Promise<ExpectedReceivable> {
+async function assertInOrg(repos: Repositories, orgId: OrganizationId, id: ExpectedReceivableId): Promise<ExpectedReceivable> {
   const row = await repos.expectedReceivables.getByIdInOrg(id, orgId);
   if (!row) throw new TRPCError({ code: "NOT_FOUND", message: "Fordran finns inte i organisationen." });
   return row;
@@ -74,12 +74,12 @@ export const expectedReceivableRouter = router({
 
       const now = new Date();
       return ctx.repos.expectedReceivables.create({
-        matterId: asId<"MatterId">(input.matterId),
+        matterId: input.matterId,
         description: input.description,
         expectedAmount: input.expectedAmount,
         status: "PENDING",
-        organizationId: asId<"OrganizationId">(ctx.orgId),
-        recordedById: asId<"UserId">(ctx.user.id),
+        organizationId: ctx.orgId,
+        recordedById: ctx.user.id,
         createdAt: now,
         updatedAt: now,
       } satisfies Partial<ExpectedReceivable>);

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -27,6 +27,8 @@ import {
   matterIdSchema,
   invoiceIdSchema,
   paymentPlanIdSchema,
+  type InvoiceId,
+  type OrganizationId,
 } from "@/lib/shared/schemas/ids";
 import type { Matter } from "@/lib/shared/schemas/matter";
 import { computeInvoiceLedger, deriveInvoiceStatus, invoicePartitionViolation } from "@/lib/shared/write-off-calc";
@@ -57,11 +59,11 @@ function ensureWritableOff<T extends { status?: string } | null>(inv: T): NonNul
  */
 async function gatherInvoiceLedger(
   repos: Repositories,
-  orgId: string,
-  inv: { id: string; amount: number },
+  orgId: OrganizationId,
+  inv: { id: InvoiceId; amount: number },
 ): Promise<{ paid: number; credited: number; writtenOff: number; ledger: ReturnType<typeof computeInvoiceLedger> }> {
   const paid = await repos.payments.sumByInvoice(inv.id);
-  const credited = await repos.invoices.sumCreditNotesFor(asId<"InvoiceId">(inv.id), asId<"OrganizationId">(orgId));
+  const credited = await repos.invoices.sumCreditNotesFor(inv.id, orgId);
   const writtenOff = await repos.writeOffs.sumByInvoice(inv.id);
   return { paid, credited, writtenOff, ledger: computeInvoiceLedger(inv.amount, paid, credited, writtenOff) };
 }

--- a/src/lib/server/routers/reports.ts
+++ b/src/lib/server/routers/reports.ts
@@ -6,7 +6,7 @@ import {
   type FrozenWorkInput,
 } from "@/lib/shared/billed-per-lawyer";
 import type { InvoiceStatus, PaymentMethod } from "@/lib/shared/schemas/enums";
-import { asId, userIdSchema } from "@/lib/shared/schemas/ids";
+import { asId, userIdSchema, type InvoiceId } from "@/lib/shared/schemas/ids";
 import { router, protectedProcedure } from "../trpc";
 
 /**
@@ -387,7 +387,7 @@ export const reportsRouter = router({
       ]);
       // Avskrivningar org-scopas via fakturornas id:n (tidigare global findMany).
       const writeOffs = await ctx.repos.writeOffs.listByInvoiceIds(
-        (invoices as Array<{ id: string }>).map((i) => i.id),
+        (invoices as Array<{ id: InvoiceId }>).map((i) => i.id),
       );
 
       if (!user) return null;
@@ -443,7 +443,7 @@ export const reportsRouter = router({
       toDate.setUTCHours(23, 59, 59, 999);
       const org = ctx.user.organizationId;
       const invoices = await ctx.repos.invoices.listForOrg(asId<"OrganizationId">(org));
-      const ids = (invoices as Array<{ id: string }>).map((i) => i.id);
+      const ids = (invoices as Array<{ id: InvoiceId }>).map((i) => i.id);
       const [payments, writeOffs] = await Promise.all([
         ctx.repos.payments.listByInvoiceIds(ids),
         ctx.repos.writeOffs.listByInvoiceIds(ids),

--- a/src/lib/server/routers/timeEntry.ts
+++ b/src/lib/server/routers/timeEntry.ts
@@ -117,7 +117,7 @@ export const timeEntryRouter = router({
         from: z.string(),
         to: z.string(),
         userId: userIdSchema.optional(),
-        userIds: z.array(z.string()).optional(),
+        userIds: z.array(userIdSchema).optional(),
         matterId: matterIdSchema.optional(),
       })
     )

--- a/test/unit/server/repositories/billing-run-repository.test.ts
+++ b/test/unit/server/repositories/billing-run-repository.test.ts
@@ -10,6 +10,7 @@ import { billingRuns, invoices, matters } from "@/lib/server/db/schema";
 import { DrizzleBillingRunRepository } from "@/lib/server/repositories/drizzle-billing-run-repository";
 import { InMemoryBillingRunRepository } from "@/lib/server/repositories/in-memory-billing-run-repository";
 import { prebakeJoins } from "@/lib/shared/demo-source";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
@@ -36,20 +37,20 @@ describe("BillingRunRepository — in-memory", () => {
     } as DemoSource);
     const repo = new InMemoryBillingRunRepository(new LocalStore(source, async () => {}));
 
-    const list = await repo.listForOrg(ORG);
+    const list = await repo.listForOrg(asId<"OrganizationId">(ORG));
     expect(list).toHaveLength(2);
     expect(list.find((r) => r.id === r1)!.invoice?.invoiceNumber).toBe("F-1");
-    expect(await repo.listForOrg(ORG, mId)).toHaveLength(2);
-    expect(await repo.listForOrg(uuidv7())).toHaveLength(0);
+    expect(await repo.listForOrg(asId<"OrganizationId">(ORG), asId<"MatterId">(mId))).toHaveLength(2);
+    expect(await repo.listForOrg(asId<"OrganizationId">(uuidv7()))).toHaveLength(0);
 
-    const detail = await repo.getByIdInOrg(r1, ORG);
+    const detail = await repo.getByIdInOrg(asId<"BillingRunId">(r1), asId<"OrganizationId">(ORG));
     expect(detail?.matter?.paymentMethod).toBe("RATTSSKYDD");
     expect(detail?.invoice?.amount).toBe(500);
-    expect(await repo.getByIdInOrg(r1, uuidv7())).toBeNull();
+    expect(await repo.getByIdInOrg(asId<"BillingRunId">(r1), asId<"OrganizationId">(uuidv7()))).toBeNull();
 
-    expect((await repo.listAccontoSent(mId)).map((r) => r.id)).toEqual([r1]);
-    expect((await repo.listAccontoByIds(mId, [r1, r2])).map((r) => r.id)).toEqual([r1]); // r2 = FINAL filtreras
-    expect(await repo.listAccontoByIds(mId, [])).toHaveLength(0);
+    expect((await repo.listAccontoSent(asId<"MatterId">(mId))).map((r) => r.id)).toEqual([r1]);
+    expect((await repo.listAccontoByIds(asId<"MatterId">(mId), [asId<"BillingRunId">(r1), asId<"BillingRunId">(r2)])).map((r) => r.id)).toEqual([r1]); // r2 = FINAL filtreras
+    expect(await repo.listAccontoByIds(asId<"MatterId">(mId), [])).toHaveLength(0);
   });
 });
 
@@ -73,19 +74,19 @@ describe("BillingRunRepository — Drizzle (pglite)", () => {
     await db.insert(billingRuns).values(v(run({ id: r2, matterId: mId, invoiceId: null, type: "FINAL", status: "SENT" })));
     const repo = new DrizzleBillingRunRepository(db);
 
-    const list = await repo.listForOrg(org);
+    const list = await repo.listForOrg(asId<"OrganizationId">(org));
     expect(list).toHaveLength(2);
     expect(list.find((r) => r.id === r1)!.invoice?.invoiceNumber).toBe("F-1");
-    expect(await repo.listForOrg(org, mId)).toHaveLength(2);
-    expect(await repo.listForOrg(uuidv7())).toHaveLength(0);
+    expect(await repo.listForOrg(asId<"OrganizationId">(org), asId<"MatterId">(mId))).toHaveLength(2);
+    expect(await repo.listForOrg(asId<"OrganizationId">(uuidv7()))).toHaveLength(0);
 
-    const detail = await repo.getByIdInOrg(r1, org);
+    const detail = await repo.getByIdInOrg(asId<"BillingRunId">(r1), asId<"OrganizationId">(org));
     expect(detail?.matter?.paymentMethod).toBe("RATTSSKYDD");
     expect(detail?.invoice?.amount).toBe(500);
-    expect(await repo.getByIdInOrg(r1, uuidv7())).toBeNull();
+    expect(await repo.getByIdInOrg(asId<"BillingRunId">(r1), asId<"OrganizationId">(uuidv7()))).toBeNull();
 
-    expect((await repo.listAccontoSent(mId)).map((r) => r.id)).toEqual([r1]);
-    expect((await repo.listAccontoByIds(mId, [r1, r2])).map((r) => r.id)).toEqual([r1]);
-    expect(await repo.listAccontoByIds(mId, [])).toHaveLength(0);
+    expect((await repo.listAccontoSent(asId<"MatterId">(mId))).map((r) => r.id)).toEqual([r1]);
+    expect((await repo.listAccontoByIds(asId<"MatterId">(mId), [asId<"BillingRunId">(r1), asId<"BillingRunId">(r2)])).map((r) => r.id)).toEqual([r1]);
+    expect(await repo.listAccontoByIds(asId<"MatterId">(mId), [])).toHaveLength(0);
   });
 });

--- a/test/unit/server/repositories/expected-receivable-repository.test.ts
+++ b/test/unit/server/repositories/expected-receivable-repository.test.ts
@@ -26,10 +26,10 @@ describe("ExpectedReceivableRepository — in-memory", () => {
       ],
     }, async () => {});
     const repo = new InMemoryExpectedReceivableRepository(store);
-    expect(await repo.listForOrg("org-1")).toHaveLength(2);
-    expect(await repo.listForOrg("org-1", { status: "PENDING" })).toHaveLength(1);
-    expect(await repo.getByIdInOrg(r1, "org-1")).toMatchObject({ id: r1 });
-    expect(await repo.getByIdInOrg(r1, "org-2")).toBeNull();
+    expect(await repo.listForOrg(asId<"OrganizationId">("org-1"))).toHaveLength(2);
+    expect(await repo.listForOrg(asId<"OrganizationId">("org-1"), { status: "PENDING" })).toHaveLength(1);
+    expect(await repo.getByIdInOrg(asId<"ExpectedReceivableId">(r1), asId<"OrganizationId">("org-1"))).toMatchObject({ id: r1 });
+    expect(await repo.getByIdInOrg(asId<"ExpectedReceivableId">(r1), asId<"OrganizationId">("org-2"))).toBeNull();
     expect(await new InMemoryMatterRepository(store).listByOrg(asId<"OrganizationId">("org-1"))).toHaveLength(1);
   });
 });
@@ -50,10 +50,10 @@ describe("ExpectedReceivableRepository — Drizzle (pglite)", () => {
     await db.insert(expectedReceivables).values(v({ id: r1, organizationId: org, matterId: mId, description: "A", expectedAmount: 100, status: "PENDING", recordedById: uuidv7() }));
     await db.insert(expectedReceivables).values(v({ id: uuidv7(), organizationId: org, matterId: mId, description: "B", expectedAmount: 50, status: "SETTLED", recordedById: uuidv7() }));
     const repo = new DrizzleExpectedReceivableRepository(handle.db);
-    expect(await repo.listForOrg(org)).toHaveLength(2);
-    expect(await repo.listForOrg(org, { status: "PENDING" })).toHaveLength(1);
-    expect(await repo.getByIdInOrg(r1, org)).toMatchObject({ id: r1 });
-    expect(await repo.getByIdInOrg(r1, uuidv7())).toBeNull();
+    expect(await repo.listForOrg(asId<"OrganizationId">(org))).toHaveLength(2);
+    expect(await repo.listForOrg(asId<"OrganizationId">(org), { status: "PENDING" })).toHaveLength(1);
+    expect(await repo.getByIdInOrg(asId<"ExpectedReceivableId">(r1), asId<"OrganizationId">(org))).toMatchObject({ id: r1 });
+    expect(await repo.getByIdInOrg(asId<"ExpectedReceivableId">(r1), asId<"OrganizationId">(uuidv7()))).toBeNull();
     expect(await new DrizzleMatterRepository(handle.db).listByOrg(asId<"OrganizationId">(org))).toHaveLength(1);
   });
 });

--- a/test/unit/server/repositories/expense-repository.test.ts
+++ b/test/unit/server/repositories/expense-repository.test.ts
@@ -8,6 +8,7 @@ import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { contacts, expenses, matterContacts, matters, users } from "@/lib/server/db/schema";
 import { DrizzleExpenseRepository } from "@/lib/server/repositories/drizzle-expense-repository";
 import { InMemoryExpenseRepository } from "@/lib/server/repositories/in-memory-expense-repository";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
@@ -25,11 +26,11 @@ describe("ExpenseRepository — in-memory", () => {
     }, async () => {});
     const repo = new InMemoryExpenseRepository(store);
 
-    expect(await repo.listUnbilled(matterId, [e1, e2])).toHaveLength(2);
-    expect(await repo.listUnbilled(matterId, [])).toEqual([]);
+    expect(await repo.listUnbilled(asId<"MatterId">(matterId), [asId<"ExpenseId">(e1), asId<"ExpenseId">(e2)])).toHaveLength(2);
+    expect(await repo.listUnbilled(asId<"MatterId">(matterId), [])).toEqual([]);
 
-    await repo.flagBilled([e1], uuidv7());
-    expect(await repo.listUnbilled(matterId, [e1, e2])).toHaveLength(1); // e1 nu fakturerad
+    await repo.flagBilled([asId<"ExpenseId">(e1)], asId<"InvoiceId">(uuidv7()));
+    expect(await repo.listUnbilled(asId<"MatterId">(matterId), [asId<"ExpenseId">(e1), asId<"ExpenseId">(e2)])).toHaveLength(1); // e1 nu fakturerad
   });
 
   it("listForOrg paginerar, summerar och inkluderar relationer", async () => {
@@ -44,12 +45,12 @@ describe("ExpenseRepository — in-memory", () => {
       ],
     }, async () => {});
     const repo = new InMemoryExpenseRepository(store);
-    const res = await repo.listForOrg("org-1", { page: 1, pageSize: 50 });
+    const res = await repo.listForOrg(asId<"OrganizationId">("org-1"), { page: 1, pageSize: 50 });
     expect(res.total).toBe(2);
     expect(res.totalAmount).toBe(80_000);
     expect(res.expenses[0]!.matter?.matterNumber).toBe("2026-1");
     expect(res.expenses[0]!.user?.name).toBe("Anna");
-    expect((await repo.listForOrg("org-2", { page: 1, pageSize: 50 })).total).toBe(0); // fel org
+    expect((await repo.listForOrg(asId<"OrganizationId">("org-2"), { page: 1, pageSize: 50 })).total).toBe(0); // fel org
   });
 
   it("getByIdInOrg org-scopar via ärendet", async () => {
@@ -60,8 +61,8 @@ describe("ExpenseRepository — in-memory", () => {
       expenses: [{ id: eId, matterId: mId, amount: 1, date: new Date(), description: "x" }],
     }, async () => {});
     const repo = new InMemoryExpenseRepository(store);
-    expect(await repo.getByIdInOrg(eId, "org-1")).toMatchObject({ id: eId });
-    expect(await repo.getByIdInOrg(eId, "org-2")).toBeNull(); // fel org
+    expect(await repo.getByIdInOrg(asId<"ExpenseId">(eId), asId<"OrganizationId">("org-1"))).toMatchObject({ id: eId });
+    expect(await repo.getByIdInOrg(asId<"ExpenseId">(eId), asId<"OrganizationId">("org-2"))).toBeNull(); // fel org
   });
 });
 
@@ -85,9 +86,9 @@ describe("ExpenseRepository — Drizzle (pglite)", () => {
     await db.insert(expenses).values(v({ id: e2, userId, matterId: mId, date: new Date(), amount: 30_000, description: "y" }));
     const repo = new DrizzleExpenseRepository(handle.db);
 
-    expect(await repo.listUnbilled(mId, [e1, e2])).toHaveLength(2);
-    await repo.flagBilled([e1], uuidv7());
-    expect(await repo.listUnbilled(mId, [e1, e2])).toHaveLength(1);
+    expect(await repo.listUnbilled(asId<"MatterId">(mId), [asId<"ExpenseId">(e1), asId<"ExpenseId">(e2)])).toHaveLength(2);
+    await repo.flagBilled([asId<"ExpenseId">(e1)], asId<"InvoiceId">(uuidv7()));
+    expect(await repo.listUnbilled(asId<"MatterId">(mId), [asId<"ExpenseId">(e1), asId<"ExpenseId">(e2)])).toHaveLength(1);
   });
 
   it("listForOrg joinar relationer + summerar i SQL", async () => {
@@ -102,7 +103,7 @@ describe("ExpenseRepository — Drizzle (pglite)", () => {
     await db.insert(expenses).values(v({ id: uuidv7(), userId, matterId: mId, date: new Date("2026-06-02"), amount: 50_000, description: "a" }));
     await db.insert(expenses).values(v({ id: uuidv7(), userId, matterId: mId, date: new Date("2026-06-01"), amount: 30_000, description: "b" }));
     const repo = new DrizzleExpenseRepository(handle.db);
-    const res = await repo.listForOrg(org, { page: 1, pageSize: 50 });
+    const res = await repo.listForOrg(asId<"OrganizationId">(org), { page: 1, pageSize: 50 });
     expect(res.total).toBe(2);
     expect(res.totalAmount).toBe(80_000);
     expect(res.expenses[0]!.matter?.matterNumber).toBe("2026-1");
@@ -122,8 +123,8 @@ describe("ExpenseRepository — Drizzle (pglite)", () => {
     await db.insert(users).values(v({ id: userId, organizationId: org, email: "a@x", name: "Anna" }));
     await db.insert(expenses).values(v({ id: eId, userId, matterId: mId, date: new Date(), amount: 1, description: "x" }));
     const repo = new DrizzleExpenseRepository(handle.db);
-    expect(await repo.getByIdInOrg(eId, org)).toMatchObject({ id: eId });
-    expect(await repo.getByIdInOrg(eId, uuidv7())).toBeNull();
+    expect(await repo.getByIdInOrg(asId<"ExpenseId">(eId), asId<"OrganizationId">(org))).toMatchObject({ id: eId });
+    expect(await repo.getByIdInOrg(asId<"ExpenseId">(eId), asId<"OrganizationId">(uuidv7()))).toBeNull();
   });
 });
 
@@ -150,15 +151,15 @@ describe("ExpenseRepository — frysning + perLawyer-period (in-memory)", () => 
     const repo = new InMemoryExpenseRepository(store);
 
     // listUnfrozenForMatter: bara de ofrysta, date asc (ej den frusna)
-    const unfrozen = await repo.listUnfrozenForMatter(mId);
+    const unfrozen = await repo.listUnfrozenForMatter(asId<"MatterId">(mId));
     expect(unfrozen.map((e) => e.id)).toEqual([eOutside, eEarly, eLate]); // 2026-05-01 < 06-01 < 06-10
 
     // freezeForMatter: fryser alla ofrysta → inga ofrysta kvar
-    await repo.freezeForMatter(mId, uuidv7(), new Date("2026-06-30"));
-    expect(await repo.listUnfrozenForMatter(mId)).toHaveLength(0);
+    await repo.freezeForMatter(asId<"MatterId">(mId), asId<"BillingRunId">(uuidv7()), new Date("2026-06-30"));
+    expect(await repo.listUnfrozenForMatter(asId<"MatterId">(mId))).toHaveLength(0);
 
     // listForLawyerInPeriod: juni-perioden, date asc, med KLIENT-namn på ärendet
-    const rows = await repo.listForLawyerInPeriod("org-1", uId, new Date("2026-06-01"), new Date("2026-06-30"));
+    const rows = await repo.listForLawyerInPeriod(asId<"OrganizationId">("org-1"), asId<"UserId">(uId), new Date("2026-06-01"), new Date("2026-06-30"));
     expect(rows.map((e) => e.id)).toEqual([eEarly, eFrozen, eLate]); // eOutside (maj) exkluderas
     expect(rows[0]!.matter?.contacts[0]?.contact.name).toBe("Klient AB");
   });
@@ -189,14 +190,14 @@ describe("ExpenseRepository — frysning + perLawyer-period (Drizzle/pglite)", (
     const repo = new DrizzleExpenseRepository(db);
 
     // listUnfrozenForMatter: ofrysta (eLate/eEarly/eOutside), date asc
-    expect((await repo.listUnfrozenForMatter(mId)).map((e) => e.id)).toEqual([eOutside, eEarly, eLate]);
+    expect((await repo.listUnfrozenForMatter(asId<"MatterId">(mId))).map((e) => e.id)).toEqual([eOutside, eEarly, eLate]);
 
     // freezeForMatter: fryser alla ofrysta i ärendet
-    await repo.freezeForMatter(mId, uuidv7(), new Date("2026-06-30"));
-    expect(await repo.listUnfrozenForMatter(mId)).toHaveLength(0);
+    await repo.freezeForMatter(asId<"MatterId">(mId), asId<"BillingRunId">(uuidv7()), new Date("2026-06-30"));
+    expect(await repo.listUnfrozenForMatter(asId<"MatterId">(mId))).toHaveLength(0);
 
     // listForLawyerInPeriod: juni → eEarly/eFrozen/eLate (date asc), KLIENT-namn joinas
-    const rows = await repo.listForLawyerInPeriod(org, uId, new Date("2026-06-01"), new Date("2026-06-30"));
+    const rows = await repo.listForLawyerInPeriod(asId<"OrganizationId">(org), asId<"UserId">(uId), new Date("2026-06-01"), new Date("2026-06-30"));
     expect(rows.map((e) => e.id)).toEqual([eEarly, eFrozen, eLate]);
     expect(rows[0]!.matter?.contacts[0]?.contact.name).toBe("Klient AB");
     expect(rows[0]!.matter?.paymentMethod).toBe("PRIVAT");

--- a/test/unit/server/repositories/payment-plan-repository.test.ts
+++ b/test/unit/server/repositories/payment-plan-repository.test.ts
@@ -61,15 +61,15 @@ describe("PaymentPlanRepository — in-memory", () => {
       paymentPlans: [plan({ id: planId, invoiceId })],
     }, async () => {});
     const repo = new InMemoryPaymentPlanRepository(store);
-    expect(await repo.getByIdInOrg(planId, "org-1")).toMatchObject({ id: planId });
-    expect(await repo.getByIdInOrg(planId, "org-2")).toBeNull(); // fel org
+    expect(await repo.getByIdInOrg(asId<"PaymentPlanId">(planId), asId<"OrganizationId">("org-1"))).toMatchObject({ id: planId });
+    expect(await repo.getByIdInOrg(asId<"PaymentPlanId">(planId), asId<"OrganizationId">("org-2"))).toBeNull(); // fel org
   });
 
   it("getByInvoiceId hämtar planen för en faktura", async () => {
     const store = new LocalStore({ paymentPlans: [plan({ id: planId, invoiceId })] }, async () => {});
     const repo = new InMemoryPaymentPlanRepository(store);
-    expect(await repo.getByInvoiceId(invoiceId)).toMatchObject({ id: planId });
-    expect(await repo.getByInvoiceId(uuidv7())).toBeNull(); // ingen plan
+    expect(await repo.getByInvoiceId(asId<"InvoiceId">(invoiceId))).toMatchObject({ id: planId });
+    expect(await repo.getByInvoiceId(asId<"InvoiceId">(uuidv7()))).toBeNull(); // ingen plan
   });
 
   it("listForOrg/getByIdWithDetails/listActiveForScan joinar faktura+KLIENT+påminnelser", async () => {
@@ -86,16 +86,16 @@ describe("PaymentPlanRepository — in-memory", () => {
     }, async () => {});
     const repo = new InMemoryPaymentPlanRepository(store);
 
-    const list = await repo.listForOrg("org-1");
+    const list = await repo.listForOrg(asId<"OrganizationId">("org-1"));
     expect(list).toHaveLength(1);
     expect(list[0]!.invoice?.matter?.contacts[0]?.contact.name).toBe("Klient AB");
     expect(list[0]!.invoice?.payments[0]?.amount).toBe(200);
-    expect(await repo.listForOrg("org-2")).toHaveLength(0);
+    expect(await repo.listForOrg(asId<"OrganizationId">("org-2"))).toHaveLength(0);
 
-    const detail = await repo.getByIdWithDetails(planId, "org-1");
+    const detail = await repo.getByIdWithDetails(asId<"PaymentPlanId">(planId), asId<"OrganizationId">("org-1"));
     expect(detail?.reminders[0]?.dueMonth).toBe("2026-06");
 
-    const scan = await repo.listActiveForScan("org-1");
+    const scan = await repo.listActiveForScan(asId<"OrganizationId">("org-1"));
     expect(scan).toHaveLength(1);
     expect(scan[0]!.invoice?.matter?.contacts[0]?.contact.email).toBe("k@x.se");
     expect(scan[0]!.reminders).toHaveLength(1);
@@ -124,8 +124,8 @@ describe("PaymentPlanRepository — Drizzle (pglite)", () => {
     await db.insert(paymentPlans).values(v({ id: pId, invoiceId: invId, monthlyAmount: 100, dayOfMonth: 15, startDate: new Date(), status: "ACTIVE" }));
 
     const repo = new DrizzlePaymentPlanRepository(handle.db);
-    expect(await repo.getByIdInOrg(pId, org)).toMatchObject({ id: pId });
-    expect(await repo.getByIdInOrg(pId, uuidv7())).toBeNull(); // fel org
+    expect(await repo.getByIdInOrg(asId<"PaymentPlanId">(pId), asId<"OrganizationId">(org))).toMatchObject({ id: pId });
+    expect(await repo.getByIdInOrg(asId<"PaymentPlanId">(pId), asId<"OrganizationId">(uuidv7()))).toBeNull(); // fel org
   });
 
   it("getByInvoiceId hämtar planen för en faktura", async () => {
@@ -136,8 +136,8 @@ describe("PaymentPlanRepository — Drizzle (pglite)", () => {
     const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
     await db.insert(paymentPlans).values(v({ id: pId, invoiceId: invId, monthlyAmount: 100, dayOfMonth: 15, startDate: new Date(), status: "ACTIVE" }));
     const repo = new DrizzlePaymentPlanRepository(handle.db);
-    expect(await repo.getByInvoiceId(invId)).toMatchObject({ id: pId });
-    expect(await repo.getByInvoiceId(uuidv7())).toBeNull(); // ingen plan
+    expect(await repo.getByInvoiceId(asId<"InvoiceId">(invId))).toMatchObject({ id: pId });
+    expect(await repo.getByInvoiceId(asId<"InvoiceId">(uuidv7()))).toBeNull(); // ingen plan
   });
 
   it("listForOrg/getByIdWithDetails/listActiveForScan joinar faktura+KLIENT+påminnelser", async () => {
@@ -158,16 +158,16 @@ describe("PaymentPlanRepository — Drizzle (pglite)", () => {
     await db.insert(paymentPlanReminders).values(v({ id: uuidv7(), planId: pId, dueMonth: "2026-06", type: "DUE", sentAt: new Date() }));
     const repo = new DrizzlePaymentPlanRepository(handle.db);
 
-    const list = await repo.listForOrg(org);
+    const list = await repo.listForOrg(asId<"OrganizationId">(org));
     expect(list).toHaveLength(1);
     expect(list[0]!.invoice?.matter?.contacts[0]?.contact.name).toBe("Klient AB");
     expect(list[0]!.invoice?.payments[0]?.amount).toBe(200);
-    expect(await repo.listForOrg(uuidv7())).toHaveLength(0);
+    expect(await repo.listForOrg(asId<"OrganizationId">(uuidv7()))).toHaveLength(0);
 
-    const detail = await repo.getByIdWithDetails(pId, org);
+    const detail = await repo.getByIdWithDetails(asId<"PaymentPlanId">(pId), asId<"OrganizationId">(org));
     expect(detail?.reminders[0]?.dueMonth).toBe("2026-06");
 
-    const scan = await repo.listActiveForScan(org);
+    const scan = await repo.listActiveForScan(asId<"OrganizationId">(org));
     expect(scan).toHaveLength(1);
     expect(scan[0]!.invoice?.matter?.contacts[0]?.contact.email).toBe("k@x.se");
     expect(scan[0]!.reminders).toHaveLength(1);

--- a/test/unit/server/repositories/payment-repository.test.ts
+++ b/test/unit/server/repositories/payment-repository.test.ts
@@ -9,6 +9,7 @@ import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { payments } from "@/lib/server/db/schema";
 import { DrizzlePaymentRepository } from "@/lib/server/repositories/drizzle-payment-repository";
 import { InMemoryPaymentRepository } from "@/lib/server/repositories/in-memory-payment-repository";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
@@ -20,8 +21,8 @@ describe("PaymentRepository — in-memory", () => {
     await repo.create({ id: uuidv7(), invoiceId, amount: 30_000, paidAt: new Date(), recordedById: uuidv7() } as never);
     await repo.create({ id: uuidv7(), invoiceId, amount: 20_000, paidAt: new Date(), recordedById: uuidv7() } as never);
     await repo.create({ id: uuidv7(), invoiceId: uuidv7(), amount: 99_000, paidAt: new Date(), recordedById: uuidv7() } as never);
-    expect(await repo.sumByInvoice(invoiceId)).toBe(50_000);
-    expect(await repo.sumByInvoice(uuidv7())).toBe(0); // ingen betalning
+    expect(await repo.sumByInvoice(asId<"InvoiceId">(invoiceId))).toBe(50_000);
+    expect(await repo.sumByInvoice(asId<"InvoiceId">(uuidv7()))).toBe(0); // ingen betalning
   });
 });
 
@@ -36,8 +37,8 @@ describe("PaymentRepository — Drizzle (pglite)", () => {
     await repo.create({ id: uuidv7(), invoiceId, amount: 30_000, paidAt: new Date(), recordedById: uuidv7() } as never);
     await repo.create({ id: uuidv7(), invoiceId, amount: 20_000, paidAt: new Date(), recordedById: uuidv7() } as never);
     await repo.create({ id: uuidv7(), invoiceId: uuidv7(), amount: 99_000, paidAt: new Date(), recordedById: uuidv7() } as never);
-    expect(await repo.sumByInvoice(invoiceId)).toBe(50_000);
-    expect(await repo.sumByInvoice(uuidv7())).toBe(0);
+    expect(await repo.sumByInvoice(asId<"InvoiceId">(invoiceId))).toBe(50_000);
+    expect(await repo.sumByInvoice(asId<"InvoiceId">(uuidv7()))).toBe(0);
     // Kontroll att raderna skrevs (sanity för pglite-insert).
     expect((await handle.db.select().from(payments)).length).toBeGreaterThanOrEqual(3);
   });

--- a/test/unit/server/repositories/report-reads-repository.test.ts
+++ b/test/unit/server/repositories/report-reads-repository.test.ts
@@ -17,6 +17,7 @@ import { InMemoryPaymentRepository } from "@/lib/server/repositories/in-memory-p
 import { InMemoryTimeEntryRepository } from "@/lib/server/repositories/in-memory-time-entry-repository";
 import { InMemoryWriteOffRepository } from "@/lib/server/repositories/in-memory-write-off-repository";
 import { prebakeJoins } from "@/lib/shared/demo-source";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
@@ -55,15 +56,15 @@ describe("Report-läsningar — in-memory", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const wo = new InMemoryWriteOffRepository(store as any);
 
-    const lawyerTime = await te.listForLawyerInPeriod(ORG, uId, FROM, TO);
+    const lawyerTime = await te.listForLawyerInPeriod(asId<"OrganizationId">(ORG), asId<"UserId">(uId), FROM, TO);
     expect(lawyerTime).toHaveLength(2); // jan-posten utanför perioden
     expect(lawyerTime[0]!.matter?.paymentMethod).toBe("RATTSHJALP");
     expect(lawyerTime[0]!.matter?.contacts[0]?.contact.name).toBe("Klient AB");
-    expect((await te.listBillableForOrg(ORG)).length).toBe(2); // 2 billable totalt
-    expect(await ex.listForLawyerInPeriod(ORG, uId, FROM, TO)).toHaveLength(1);
-    expect((await pay.listByInvoiceIds([invId]))[0]!.amount).toBe(200);
+    expect((await te.listBillableForOrg(asId<"OrganizationId">(ORG))).length).toBe(2); // 2 billable totalt
+    expect(await ex.listForLawyerInPeriod(asId<"OrganizationId">(ORG), asId<"UserId">(uId), FROM, TO)).toHaveLength(1);
+    expect((await pay.listByInvoiceIds([asId<"InvoiceId">(invId)]))[0]!.amount).toBe(200);
     expect(await pay.listByInvoiceIds([])).toHaveLength(0);
-    expect((await wo.listByInvoiceIds([invId]))[0]!.amount).toBe(100);
+    expect((await wo.listByInvoiceIds([asId<"InvoiceId">(invId)]))[0]!.amount).toBe(100);
   });
 });
 
@@ -97,14 +98,14 @@ describe("Report-läsningar — Drizzle (pglite)", () => {
     const pay = new DrizzlePaymentRepository(db);
     const wo = new DrizzleWriteOffRepository(db);
 
-    const lawyerTime = await te.listForLawyerInPeriod(org, uId, FROM, TO);
+    const lawyerTime = await te.listForLawyerInPeriod(asId<"OrganizationId">(org), asId<"UserId">(uId), FROM, TO);
     expect(lawyerTime).toHaveLength(2);
     expect(lawyerTime[0]!.matter?.paymentMethod).toBe("RATTSHJALP");
     expect(lawyerTime[0]!.matter?.contacts[0]?.contact.name).toBe("Klient AB");
-    expect((await te.listBillableForOrg(org)).length).toBe(2);
-    expect(await ex.listForLawyerInPeriod(org, uId, FROM, TO)).toHaveLength(1);
-    expect((await pay.listByInvoiceIds([invId]))[0]!.amount).toBe(200);
+    expect((await te.listBillableForOrg(asId<"OrganizationId">(org))).length).toBe(2);
+    expect(await ex.listForLawyerInPeriod(asId<"OrganizationId">(org), asId<"UserId">(uId), FROM, TO)).toHaveLength(1);
+    expect((await pay.listByInvoiceIds([asId<"InvoiceId">(invId)]))[0]!.amount).toBe(200);
     expect(await pay.listByInvoiceIds([])).toHaveLength(0);
-    expect((await wo.listByInvoiceIds([invId]))[0]!.amount).toBe(100);
+    expect((await wo.listByInvoiceIds([asId<"InvoiceId">(invId)]))[0]!.amount).toBe(100);
   });
 });

--- a/test/unit/server/repositories/time-entry-list-report-repository.test.ts
+++ b/test/unit/server/repositories/time-entry-list-report-repository.test.ts
@@ -10,6 +10,7 @@ import { contacts, matterContacts, matters, timeEntries, users } from "@/lib/ser
 import { DrizzleTimeEntryRepository } from "@/lib/server/repositories/drizzle-time-entry-repository";
 import { InMemoryTimeEntryRepository } from "@/lib/server/repositories/in-memory-time-entry-repository";
 import { prebakeJoins } from "@/lib/shared/demo-source";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
@@ -31,14 +32,14 @@ describe("TimeEntryRepository list/report — in-memory", () => {
     } as DemoSource);
     const repo = new InMemoryTimeEntryRepository(new LocalStore(source, async () => {}));
 
-    const list = await repo.listForOrg("org-1", { page: 1, pageSize: 50 });
+    const list = await repo.listForOrg(asId<"OrganizationId">("org-1"), { page: 1, pageSize: 50 });
     expect(list.total).toBe(2);
     expect(list.totalMinutes).toBe(90);
     expect(list.entries[0]!.matter.matterNumber).toBe("2026-1");
-    expect(await repo.getByIdInOrg(t1, "org-1")).toMatchObject({ id: t1 });
-    expect(await repo.getByIdInOrg(t1, "org-2")).toBeNull();
+    expect(await repo.getByIdInOrg(asId<"TimeEntryId">(t1), asId<"OrganizationId">("org-1"))).toMatchObject({ id: t1 });
+    expect(await repo.getByIdInOrg(asId<"TimeEntryId">(t1), asId<"OrganizationId">("org-2"))).toBeNull();
 
-    const report = await repo.listForReport("org-1", { from: new Date("2026-06-01"), to: new Date("2026-06-30") });
+    const report = await repo.listForReport(asId<"OrganizationId">("org-1"), { from: new Date("2026-06-01"), to: new Date("2026-06-30") });
     expect(report).toHaveLength(2);
     expect(report[0]!.matter?.contacts[0]?.contact.name).toBe("Klient AB");
   });
@@ -66,14 +67,14 @@ describe("TimeEntryRepository list/report — Drizzle (pglite)", () => {
     await db.insert(timeEntries).values(v({ id: uuidv7(), userId, matterId: mId, minutes: 30, description: "b", hourlyRate: 1000, date: new Date("2026-06-03") }));
     const repo = new DrizzleTimeEntryRepository(handle.db);
 
-    const list = await repo.listForOrg(org, { page: 1, pageSize: 50 });
+    const list = await repo.listForOrg(asId<"OrganizationId">(org), { page: 1, pageSize: 50 });
     expect(list.total).toBe(2);
     expect(list.totalMinutes).toBe(90);
     expect(list.entries[0]!.matter.matterNumber).toBe("2026-1");
-    expect(await repo.getByIdInOrg(t1, org)).toMatchObject({ id: t1 });
-    expect(await repo.getByIdInOrg(t1, uuidv7())).toBeNull();
+    expect(await repo.getByIdInOrg(asId<"TimeEntryId">(t1), asId<"OrganizationId">(org))).toMatchObject({ id: t1 });
+    expect(await repo.getByIdInOrg(asId<"TimeEntryId">(t1), asId<"OrganizationId">(uuidv7()))).toBeNull();
 
-    const report = await repo.listForReport(org, { from: new Date("2026-06-01"), to: new Date("2026-06-30") });
+    const report = await repo.listForReport(asId<"OrganizationId">(org), { from: new Date("2026-06-01"), to: new Date("2026-06-30") });
     expect(report).toHaveLength(2);
     expect(report[0]!.matter?.contacts[0]?.contact.name).toBe("Klient AB");
   });

--- a/test/unit/server/repositories/time-entry-repository.test.ts
+++ b/test/unit/server/repositories/time-entry-repository.test.ts
@@ -8,6 +8,7 @@ import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { contacts, matterContacts, matters, timeEntries, users } from "@/lib/server/db/schema";
 import { DrizzleTimeEntryRepository } from "@/lib/server/repositories/drizzle-time-entry-repository";
 import { InMemoryTimeEntryRepository } from "@/lib/server/repositories/in-memory-time-entry-repository";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
@@ -27,13 +28,13 @@ describe("TimeEntryRepository — in-memory", () => {
     }, async () => {});
     const repo = new InMemoryTimeEntryRepository(store);
 
-    const unbilled = await repo.listUnbilled(matterId, [t1, t2]);
+    const unbilled = await repo.listUnbilled(asId<"MatterId">(matterId), [asId<"TimeEntryId">(t1), asId<"TimeEntryId">(t2)]);
     expect(unbilled).toHaveLength(2);
     expect(unbilled[0]!.user.hourlyRate).toBe(150_000);
-    expect(await repo.listUnbilled(matterId, [])).toEqual([]);
+    expect(await repo.listUnbilled(asId<"MatterId">(matterId), [])).toEqual([]);
 
-    await repo.flagBilled([t1], uuidv7());
-    expect(await repo.listUnbilled(matterId, [t1, t2])).toHaveLength(1); // t1 nu fakturerad
+    await repo.flagBilled([asId<"TimeEntryId">(t1)], asId<"InvoiceId">(uuidv7()));
+    expect(await repo.listUnbilled(asId<"MatterId">(matterId), [asId<"TimeEntryId">(t1), asId<"TimeEntryId">(t2)])).toHaveLength(1); // t1 nu fakturerad
   });
 });
 
@@ -57,12 +58,12 @@ describe("TimeEntryRepository — Drizzle (pglite)", () => {
     await db.insert(timeEntries).values(v({ id: t2, userId, matterId: mId, date: new Date(), minutes: 30, description: "y", hourlyRate: 1000 }));
     const repo = new DrizzleTimeEntryRepository(handle.db);
 
-    const unbilled = await repo.listUnbilled(mId, [t1, t2]);
+    const unbilled = await repo.listUnbilled(asId<"MatterId">(mId), [asId<"TimeEntryId">(t1), asId<"TimeEntryId">(t2)]);
     expect(unbilled).toHaveLength(2);
     expect(unbilled[0]!.user.hourlyRate).toBe(150_000);
 
-    await repo.flagBilled([t1], uuidv7());
-    expect(await repo.listUnbilled(mId, [t1, t2])).toHaveLength(1);
+    await repo.flagBilled([asId<"TimeEntryId">(t1)], asId<"InvoiceId">(uuidv7()));
+    expect(await repo.listUnbilled(asId<"MatterId">(mId), [asId<"TimeEntryId">(t1), asId<"TimeEntryId">(t2)])).toHaveLength(1);
   });
 });
 
@@ -98,21 +99,21 @@ describe("TimeEntryRepository — frysning/perLawyer/billable (in-memory)", () =
     const repo = new InMemoryTimeEntryRepository(store);
 
     // listUnfrozenForMatter: alla ofrysta (oavsett billable), date asc; ej den frusna.
-    expect((await repo.listUnfrozenForMatter(f.mId)).map((t) => t.id))
+    expect((await repo.listUnfrozenForMatter(asId<"MatterId">(f.mId))).map((t) => t.id))
       .toEqual([f.teOutside, f.teEarly, f.teNonBill, f.teLate]);
 
     // listForLawyerInPeriod: juni → exkl maj, date asc, med KLIENT-namn.
-    const period = await repo.listForLawyerInPeriod(ORG, f.uId, new Date("2026-06-01"), new Date("2026-06-30"));
+    const period = await repo.listForLawyerInPeriod(asId<"OrganizationId">(ORG), asId<"UserId">(f.uId), new Date("2026-06-01"), new Date("2026-06-30"));
     expect(period.map((t) => t.id)).toEqual([f.teEarly, f.teNonBill, f.teFrozen, f.teLate]);
     expect(period[0]!.matter?.contacts[0]?.contact.name).toBe("Klient AB");
 
     // listBillableForOrg: bara billable i org (ej teNonBill).
-    expect((await repo.listBillableForOrg(ORG)).map((t) => t.id).sort())
+    expect((await repo.listBillableForOrg(asId<"OrganizationId">(ORG))).map((t) => t.id).sort())
       .toEqual([f.teEarly, f.teLate, f.teFrozen, f.teOutside].sort());
 
     // freezeForMatter: fryser alla ofrysta → inga ofrysta kvar.
-    await repo.freezeForMatter(f.mId, uuidv7(), new Date("2026-06-30"));
-    expect(await repo.listUnfrozenForMatter(f.mId)).toHaveLength(0);
+    await repo.freezeForMatter(asId<"MatterId">(f.mId), asId<"BillingRunId">(uuidv7()), new Date("2026-06-30"));
+    expect(await repo.listUnfrozenForMatter(asId<"MatterId">(f.mId))).toHaveLength(0);
   });
 });
 
@@ -134,17 +135,17 @@ describe("TimeEntryRepository — frysning/perLawyer/billable (Drizzle/pglite)",
     for (const r of f.rows) await db.insert(timeEntries).values(v({ ...r, organizationId: org, hourlyRate: 1000 }));
     const repo = new DrizzleTimeEntryRepository(db);
 
-    expect((await repo.listUnfrozenForMatter(f.mId)).map((t) => t.id))
+    expect((await repo.listUnfrozenForMatter(asId<"MatterId">(f.mId))).map((t) => t.id))
       .toEqual([f.teOutside, f.teEarly, f.teNonBill, f.teLate]);
 
-    const period = await repo.listForLawyerInPeriod(org, f.uId, new Date("2026-06-01"), new Date("2026-06-30"));
+    const period = await repo.listForLawyerInPeriod(asId<"OrganizationId">(org), asId<"UserId">(f.uId), new Date("2026-06-01"), new Date("2026-06-30"));
     expect(period.map((t) => t.id)).toEqual([f.teEarly, f.teNonBill, f.teFrozen, f.teLate]);
     expect(period[0]!.matter?.contacts[0]?.contact.name).toBe("Klient AB");
 
-    expect((await repo.listBillableForOrg(org)).map((t) => t.id).sort())
+    expect((await repo.listBillableForOrg(asId<"OrganizationId">(org))).map((t) => t.id).sort())
       .toEqual([f.teEarly, f.teLate, f.teFrozen, f.teOutside].sort());
 
-    await repo.freezeForMatter(f.mId, uuidv7(), new Date("2026-06-30"));
-    expect(await repo.listUnfrozenForMatter(f.mId)).toHaveLength(0);
+    await repo.freezeForMatter(asId<"MatterId">(f.mId), asId<"BillingRunId">(uuidv7()), new Date("2026-06-30"));
+    expect(await repo.listUnfrozenForMatter(asId<"MatterId">(f.mId))).toHaveLength(0);
   });
 });

--- a/test/unit/server/repositories/write-off-repository.test.ts
+++ b/test/unit/server/repositories/write-off-repository.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
 import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { DrizzleWriteOffRepository } from "@/lib/server/repositories/drizzle-write-off-repository";
 import { InMemoryWriteOffRepository } from "@/lib/server/repositories/in-memory-write-off-repository";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
@@ -18,8 +19,8 @@ describe("WriteOffRepository — in-memory", () => {
     const repo = new InMemoryWriteOffRepository(store);
     await repo.create({ id: uuidv7(), invoiceId, amount: 70_000, writtenOffAt: new Date(), recordedById: uuidv7() } as never);
     await repo.create({ id: uuidv7(), invoiceId: uuidv7(), amount: 5_000, writtenOffAt: new Date(), recordedById: uuidv7() } as never);
-    expect(await repo.sumByInvoice(invoiceId)).toBe(70_000);
-    expect(await repo.sumByInvoice(uuidv7())).toBe(0);
+    expect(await repo.sumByInvoice(asId<"InvoiceId">(invoiceId))).toBe(70_000);
+    expect(await repo.sumByInvoice(asId<"InvoiceId">(uuidv7()))).toBe(0);
   });
 });
 
@@ -33,7 +34,7 @@ describe("WriteOffRepository — Drizzle (pglite)", () => {
     const repo = new DrizzleWriteOffRepository(handle.db);
     await repo.create({ id: uuidv7(), invoiceId, amount: 70_000, writtenOffAt: new Date(), recordedById: uuidv7() } as never);
     await repo.create({ id: uuidv7(), invoiceId: uuidv7(), amount: 5_000, writtenOffAt: new Date(), recordedById: uuidv7() } as never);
-    expect(await repo.sumByInvoice(invoiceId)).toBe(70_000);
-    expect(await repo.sumByInvoice(uuidv7())).toBe(0);
+    expect(await repo.sumByInvoice(asId<"InvoiceId">(invoiceId))).toBe(70_000);
+    expect(await repo.sumByInvoice(asId<"InvoiceId">(uuidv7()))).toBe(0);
   });
 });


### PR DESCRIPTION
ID-brandning per domängrupp (B1, #750). payment / payment-plan / payment-plan-reminder / billing-run / write-off / expected-receivable / acconto-deduction / expense / time-entry-repos (interface + drizzle + in-memory): id/organizationId/matterId/invoiceId(s)/userId/billingRunId/planId/expenseId(s)/timeEntryId(s)-params + id-array-params + DTO/nested-id-fält → respektive brandad `XId`.

Kaskad: billingRun/invoice/expectedReceivable/reports/timeEntry-routrarnas lokala helpers (resolveFinalWork/freezeWork/linkFinalInvoice/fetchUnfrozenWork/sumPriorAccontos m.fl.) trädar nu brandade id:n; freeze/flagBilled-inputs → `*IdSchema`-arrayer; borttagna redundanta drizzle-cast. `users.id` är enda obrandade kolumnen → `asId<"UserId">` vid den projektions-gränsen. Inga typer försvagade.

## Test
Ren tsc (root+test, 0), lint grön, 1134 server/integration-tester gröna.

Refs #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)