### PR TITLE
refactor(repos): branda återstående repo-grupp + sista db-kolumn-luckorna (B1f)

### DIFF
--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -26,7 +26,7 @@ import type {
   AccontoDeductionId, BillingRunId, CalendarEventId, ConflictCheckId, ContactId,
   DocumentAnalysisSuggestionId, DocumentFolderId, DocumentId,
   DocumentTemplateId, ExpenseId, InvoiceDispatchId, InvoiceId, MatterContactId, MatterEventSuggestionId,
-  MatterId, OrganizationId, OrgPreferenceId, PaymentId, PaymentPlanId, PaymentPlanReminderId,
+  MatterId, OfficeId, OrganizationId, OrgPreferenceId, PaymentId, PaymentPlanId, PaymentPlanReminderId,
   ServiceNoteId, TaskId, TimeEntryId, UserId, UserPreferenceId, WriteOffId,
 } from "@/lib/shared/schemas/ids";
 import { baseColumns, boolDefault, orgScopedColumns } from "./columns";
@@ -36,6 +36,7 @@ const ore = (name: string) => bigint(name, { mode: "number" });
 
 export const organizations = pgTable("organizations", {
   ...baseColumns,
+  id: uuid("id").primaryKey().$type<OrganizationId>(),
   name: text("name").notNull(),
   orgNumber: text("org_number"),
   address: text("address"),
@@ -52,6 +53,8 @@ export const organizations = pgTable("organizations", {
 
 export const offices = pgTable("offices", {
   ...orgScopedColumns,
+  id: uuid("id").primaryKey().$type<OfficeId>(),
+  organizationId: uuid("organization_id").notNull().$type<OrganizationId>(),
   name: text("name").notNull(),
   address: text("address"),
   phone: text("phone"),
@@ -61,6 +64,8 @@ export const offices = pgTable("offices", {
 
 export const users = pgTable("users", {
   ...orgScopedColumns,
+  id: uuid("id").primaryKey().$type<UserId>(),
+  organizationId: uuid("organization_id").notNull().$type<OrganizationId>(),
   email: text("email").notNull(),
   name: text("name").notNull(),
   title: text("title"),

--- a/src/lib/server/http/server-context.ts
+++ b/src/lib/server/http/server-context.ts
@@ -28,6 +28,7 @@ import type { Repositories } from "@/lib/server/repositories/repositories";
 import type { SyncStore } from "@/lib/server/sync/sync-store";
 import type { Context } from "@/lib/server/trpc-core";
 import type { Capabilities } from "@/lib/shared/capabilities";
+import { asId } from "@/lib/shared/schemas/ids";
 import type { User } from "@/lib/shared/schemas/user";
 import { bearerClaims, type BearerVerifyConfig } from "./bearer-claims";
 import { forwardedClaims, type ForwardedHeaderNames } from "./forwarded-claims";
@@ -118,7 +119,7 @@ export async function createServerContext(req: Request, deps: ServerContextDeps)
   const claims =
     forwardedClaims(req.headers, deps.headerNames) ??
     (deps.bearer ? await bearerClaims(req.headers, deps.bearer) : null);
-  const users = await deps.repos.users.listByOrg(deps.organizationId);
+  const users = await deps.repos.users.listByOrg(asId<"OrganizationId">(deps.organizationId));
   const principal = new OidcAuthProvider(claims, toAllowlist(users)).getPrincipal();
   return buildContext({
     eventLog: serverFirstEventLog,

--- a/src/lib/server/repositories/calendar-event-repository.ts
+++ b/src/lib/server/repositories/calendar-event-repository.ts
@@ -6,22 +6,23 @@
  */
 
 import type { CalendarEvent } from "@/lib/shared/schemas/calendar";
+import type { CalendarEventId, MatterId, OrganizationId, UserId } from "@/lib/shared/schemas/ids";
 import type { Repository } from "./types";
 
 /** Händelse + ärende-subsetet vyerna visar. */
 export interface CalendarEventRow extends CalendarEvent {
-  matter: { id: string; matterNumber: string; title: string } | null;
+  matter: { id: MatterId; matterNumber: string; title: string } | null;
 }
 
 export interface CalendarEventRepository extends Repository<CalendarEvent> {
   /** Den aktiva användarens händelser (startAt asc), med ärende-subset. */
-  listForUser(userId: string, organizationId: string): Promise<CalendarEventRow[]>;
+  listForUser(userId: UserId, organizationId: OrganizationId): Promise<CalendarEventRow[]>;
   /** Flera användares händelser (multi-user-vy), org-scopat, med ärende-subset. */
-  listForUsers(userIds: string[], organizationId: string): Promise<CalendarEventRow[]>;
+  listForUsers(userIds: UserId[], organizationId: OrganizationId): Promise<CalendarEventRow[]>;
   /** Alla händelser för ett ärende, kronologiskt (utan ärende-subset). */
-  listForMatter(matterId: string, organizationId: string): Promise<CalendarEvent[]>;
+  listForMatter(matterId: MatterId, organizationId: OrganizationId): Promise<CalendarEvent[]>;
   /** Händelse by id, ägar-scopad (id + userId + org). Null om saknas/ej ägd/raderad. */
-  getOwned(id: string, userId: string, organizationId: string): Promise<CalendarEvent | null>;
+  getOwned(id: CalendarEventId, userId: UserId, organizationId: OrganizationId): Promise<CalendarEvent | null>;
   /** Som `getOwned` men med ärende-subset (detaljvyn). */
-  getOwnedWithMatter(id: string, userId: string, organizationId: string): Promise<CalendarEventRow | null>;
+  getOwnedWithMatter(id: CalendarEventId, userId: UserId, organizationId: OrganizationId): Promise<CalendarEventRow | null>;
 }

--- a/src/lib/server/repositories/drizzle-calendar-event-repository.ts
+++ b/src/lib/server/repositories/drizzle-calendar-event-repository.ts
@@ -5,13 +5,13 @@
 
 import { and, asc, eq, inArray, isNull } from "drizzle-orm";
 import type { CalendarEvent } from "@/lib/shared/schemas/calendar";
-import { asId } from "@/lib/shared/schemas/ids";
+import type { CalendarEventId, MatterId, OrganizationId, UserId } from "@/lib/shared/schemas/ids";
 import { calendarEvents, matters } from "../db/schema";
 import type { AppDb } from "../db/types";
 import type { CalendarEventRepository, CalendarEventRow } from "./calendar-event-repository";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
 
-type MatterCols = { mId: string | null; mNum: string | null; mTitle: string | null };
+type MatterCols = { mId: MatterId | null; mNum: string | null; mTitle: string | null };
 
 function withMatter(r: MatterCols & { ev: typeof calendarEvents.$inferSelect }): CalendarEventRow {
   return {
@@ -32,46 +32,46 @@ export class DrizzleCalendarEventRepository extends DrizzleRepository<CalendarEv
     };
   }
 
-  async listForUser(userId: string, organizationId: string): Promise<CalendarEventRow[]> {
+  async listForUser(userId: UserId, organizationId: OrganizationId): Promise<CalendarEventRow[]> {
     const rows = await this.db
       .select(this.matterSelect()).from(calendarEvents)
       .leftJoin(matters, eq(calendarEvents.matterId, matters.id))
-      .where(and(eq(calendarEvents.userId, asId<"UserId">(userId)), eq(calendarEvents.organizationId, asId<"OrganizationId">(organizationId)), isNull(calendarEvents.deletedAt)))
+      .where(and(eq(calendarEvents.userId, userId), eq(calendarEvents.organizationId, organizationId), isNull(calendarEvents.deletedAt)))
       .orderBy(asc(calendarEvents.startAt));
     return rows.map(withMatter);
   }
 
-  async listForUsers(userIds: string[], organizationId: string): Promise<CalendarEventRow[]> {
+  async listForUsers(userIds: UserId[], organizationId: OrganizationId): Promise<CalendarEventRow[]> {
     if (!userIds.length) return [];
     const rows = await this.db
       .select(this.matterSelect()).from(calendarEvents)
       .leftJoin(matters, eq(calendarEvents.matterId, matters.id))
-      .where(and(eq(calendarEvents.organizationId, asId<"OrganizationId">(organizationId)), inArray(calendarEvents.userId, userIds.map((u) => asId<"UserId">(u))), isNull(calendarEvents.deletedAt)))
+      .where(and(eq(calendarEvents.organizationId, organizationId), inArray(calendarEvents.userId, userIds), isNull(calendarEvents.deletedAt)))
       .orderBy(asc(calendarEvents.startAt));
     return rows.map(withMatter);
   }
 
-  async listForMatter(matterId: string, organizationId: string): Promise<CalendarEvent[]> {
+  async listForMatter(matterId: MatterId, organizationId: OrganizationId): Promise<CalendarEvent[]> {
     const rows = await this.db
       .select().from(calendarEvents)
-      .where(and(eq(calendarEvents.matterId, asId<"MatterId">(matterId)), eq(calendarEvents.organizationId, asId<"OrganizationId">(organizationId)), isNull(calendarEvents.deletedAt)))
+      .where(and(eq(calendarEvents.matterId, matterId), eq(calendarEvents.organizationId, organizationId), isNull(calendarEvents.deletedAt)))
       .orderBy(asc(calendarEvents.startAt));
     return rows;
   }
 
-  async getOwned(id: string, userId: string, organizationId: string): Promise<CalendarEvent | null> {
+  async getOwned(id: CalendarEventId, userId: UserId, organizationId: OrganizationId): Promise<CalendarEvent | null> {
     const rows = await this.db
       .select().from(calendarEvents)
-      .where(and(eq(calendarEvents.id, asId<"CalendarEventId">(id)), eq(calendarEvents.userId, asId<"UserId">(userId)), eq(calendarEvents.organizationId, asId<"OrganizationId">(organizationId)), isNull(calendarEvents.deletedAt)))
+      .where(and(eq(calendarEvents.id, id), eq(calendarEvents.userId, userId), eq(calendarEvents.organizationId, organizationId), isNull(calendarEvents.deletedAt)))
       .limit(1);
     return rows[0] ?? null;
   }
 
-  async getOwnedWithMatter(id: string, userId: string, organizationId: string): Promise<CalendarEventRow | null> {
+  async getOwnedWithMatter(id: CalendarEventId, userId: UserId, organizationId: OrganizationId): Promise<CalendarEventRow | null> {
     const rows = await this.db
       .select(this.matterSelect()).from(calendarEvents)
       .leftJoin(matters, eq(calendarEvents.matterId, matters.id))
-      .where(and(eq(calendarEvents.id, asId<"CalendarEventId">(id)), eq(calendarEvents.userId, asId<"UserId">(userId)), eq(calendarEvents.organizationId, asId<"OrganizationId">(organizationId)), isNull(calendarEvents.deletedAt)))
+      .where(and(eq(calendarEvents.id, id), eq(calendarEvents.userId, userId), eq(calendarEvents.organizationId, organizationId), isNull(calendarEvents.deletedAt)))
       .limit(1);
     return rows[0] ? withMatter(rows[0]) : null;
   }

--- a/src/lib/server/repositories/drizzle-office-repository.ts
+++ b/src/lib/server/repositories/drizzle-office-repository.ts
@@ -3,6 +3,7 @@
  */
 
 import { and, asc, desc, eq, isNull } from "drizzle-orm";
+import type { OfficeId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { Office } from "@/lib/shared/schemas/organization";
 import { offices } from "../db/schema";
 import type { AppDb } from "../db/types";
@@ -14,7 +15,7 @@ export class DrizzleOfficeRepository extends DrizzleRepository<Office> implement
     super(db, versionedTable(offices), now);
   }
 
-  async listByOrg(organizationId: string): Promise<Office[]> {
+  async listByOrg(organizationId: OrganizationId): Promise<Office[]> {
     const rows = await this.db
       .select().from(offices)
       .where(and(eq(offices.organizationId, organizationId), isNull(offices.deletedAt)))
@@ -22,7 +23,7 @@ export class DrizzleOfficeRepository extends DrizzleRepository<Office> implement
     return this.asRows(rows);
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<Office | null> {
+  async getByIdInOrg(id: OfficeId, organizationId: OrganizationId): Promise<Office | null> {
     const rows = await this.db
       .select().from(offices)
       .where(and(eq(offices.id, id), eq(offices.organizationId, organizationId), isNull(offices.deletedAt)))
@@ -30,7 +31,7 @@ export class DrizzleOfficeRepository extends DrizzleRepository<Office> implement
     return this.asRow(rows[0]);
   }
 
-  async demoteMains(organizationId: string): Promise<void> {
+  async demoteMains(organizationId: OrganizationId): Promise<void> {
     await this.db.update(offices).set({ isMain: false } as never)
       .where(and(eq(offices.organizationId, organizationId), eq(offices.isMain, true)));
   }

--- a/src/lib/server/repositories/drizzle-org-preference-repository.ts
+++ b/src/lib/server/repositories/drizzle-org-preference-repository.ts
@@ -1,7 +1,7 @@
 /** Drizzle `OrgPreferenceRepository` (ADR 0020). */
 
 import { and, asc, eq, isNull } from "drizzle-orm";
-import { asId } from "@/lib/shared/schemas/ids";
+import type { OrganizationId } from "@/lib/shared/schemas/ids";
 import type { OrgPreference } from "@/lib/shared/schemas/preference";
 import { orgPreferences } from "../db/schema";
 import type { AppDb } from "../db/types";
@@ -13,18 +13,18 @@ export class DrizzleOrgPreferenceRepository extends DrizzleRepository<OrgPrefere
     super(db, versionedTable(orgPreferences), now);
   }
 
-  async getByOrgKey(organizationId: string, key: string): Promise<OrgPreference | null> {
+  async getByOrgKey(organizationId: OrganizationId, key: string): Promise<OrgPreference | null> {
     const rows = await this.db
       .select().from(orgPreferences)
-      .where(and(eq(orgPreferences.organizationId, asId<"OrganizationId">(organizationId)), eq(orgPreferences.key, key), isNull(orgPreferences.deletedAt)))
+      .where(and(eq(orgPreferences.organizationId, organizationId), eq(orgPreferences.key, key), isNull(orgPreferences.deletedAt)))
       .limit(1);
     return rows[0] ?? null;
   }
 
-  async listByOrg(organizationId: string): Promise<OrgPreference[]> {
+  async listByOrg(organizationId: OrganizationId): Promise<OrgPreference[]> {
     const rows = await this.db
       .select().from(orgPreferences)
-      .where(and(eq(orgPreferences.organizationId, asId<"OrganizationId">(organizationId)), isNull(orgPreferences.deletedAt)))
+      .where(and(eq(orgPreferences.organizationId, organizationId), isNull(orgPreferences.deletedAt)))
       .orderBy(asc(orgPreferences.key));
     return rows;
   }

--- a/src/lib/server/repositories/drizzle-service-note-repository.ts
+++ b/src/lib/server/repositories/drizzle-service-note-repository.ts
@@ -4,7 +4,7 @@
  */
 
 import { and, desc, eq, isNull } from "drizzle-orm";
-import { asId } from "@/lib/shared/schemas/ids";
+import type { MatterId, OrganizationId, ServiceNoteId } from "@/lib/shared/schemas/ids";
 import type { ServiceNote } from "@/lib/shared/schemas/service-note";
 import { matters, serviceNotes, users } from "../db/schema";
 import type { AppDb } from "../db/types";
@@ -16,14 +16,14 @@ export class DrizzleServiceNoteRepository extends DrizzleRepository<ServiceNote>
     super(db, versionedTable(serviceNotes), now);
   }
 
-  async listByMatter(matterId: string, organizationId: string): Promise<ServiceNoteRow[]> {
+  async listByMatter(matterId: MatterId, organizationId: OrganizationId): Promise<ServiceNoteRow[]> {
     const rows = await this.db
       .select({ note: serviceNotes, aId: users.id, aName: users.name }).from(serviceNotes)
       .innerJoin(matters, eq(serviceNotes.matterId, matters.id))
       .leftJoin(users, eq(serviceNotes.authorId, users.id))
       .where(and(
-        eq(serviceNotes.matterId, asId<"MatterId">(matterId)),
-        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
+        eq(serviceNotes.matterId, matterId),
+        eq(matters.organizationId, organizationId),
         isNull(serviceNotes.deletedAt),
       ))
       .orderBy(desc(serviceNotes.createdAt));
@@ -33,11 +33,11 @@ export class DrizzleServiceNoteRepository extends DrizzleRepository<ServiceNote>
     }));
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<ServiceNote | null> {
+  async getByIdInOrg(id: ServiceNoteId, organizationId: OrganizationId): Promise<ServiceNote | null> {
     const rows = await this.db
       .select({ note: serviceNotes }).from(serviceNotes)
       .innerJoin(matters, eq(serviceNotes.matterId, matters.id))
-      .where(and(eq(serviceNotes.id, asId<"ServiceNoteId">(id)), eq(matters.organizationId, asId<"OrganizationId">(organizationId)), isNull(serviceNotes.deletedAt)))
+      .where(and(eq(serviceNotes.id, id), eq(matters.organizationId, organizationId), isNull(serviceNotes.deletedAt)))
       .limit(1);
     return rows[0]?.note ?? null;
   }

--- a/src/lib/server/repositories/drizzle-task-repository.ts
+++ b/src/lib/server/repositories/drizzle-task-repository.ts
@@ -5,7 +5,7 @@
 
 import { and, asc, eq, isNull } from "drizzle-orm";
 import type { Task } from "@/lib/shared/schemas/calendar";
-import { asId } from "@/lib/shared/schemas/ids";
+import type { OrganizationId, TaskId, UserId } from "@/lib/shared/schemas/ids";
 import { matters, tasks } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
@@ -16,7 +16,7 @@ export class DrizzleTaskRepository extends DrizzleRepository<Task> implements Ta
     super(db, versionedTable(tasks), now);
   }
 
-  async listForUser(userId: string, organizationId: string, filter: TaskListFilter): Promise<TaskListRow[]> {
+  async listForUser(userId: UserId, organizationId: OrganizationId, filter: TaskListFilter): Promise<TaskListRow[]> {
     const rows = await this.db
       .select({
         t: tasks,
@@ -25,11 +25,11 @@ export class DrizzleTaskRepository extends DrizzleRepository<Task> implements Ta
       .from(tasks)
       .leftJoin(matters, eq(tasks.matterId, matters.id))
       .where(and(
-        eq(tasks.userId, asId<"UserId">(userId)),
-        eq(tasks.organizationId, asId<"OrganizationId">(organizationId)),
+        eq(tasks.userId, userId),
+        eq(tasks.organizationId, organizationId),
         isNull(tasks.deletedAt),
         filter.status ? eq(tasks.status, filter.status) : undefined,
-        filter.matterId ? eq(tasks.matterId, asId<"MatterId">(filter.matterId)) : undefined,
+        filter.matterId ? eq(tasks.matterId, filter.matterId) : undefined,
       ))
       .orderBy(asc(tasks.dueAt));
     return rows.map((r): TaskListRow => ({
@@ -38,12 +38,12 @@ export class DrizzleTaskRepository extends DrizzleRepository<Task> implements Ta
     }));
   }
 
-  async getOwned(id: string, userId: string, organizationId: string): Promise<Task | null> {
+  async getOwned(id: TaskId, userId: UserId, organizationId: OrganizationId): Promise<Task | null> {
     const rows = await this.db
       .select().from(tasks)
       .where(and(
-        eq(tasks.id, asId<"TaskId">(id)), eq(tasks.userId, asId<"UserId">(userId)),
-        eq(tasks.organizationId, asId<"OrganizationId">(organizationId)), isNull(tasks.deletedAt),
+        eq(tasks.id, id), eq(tasks.userId, userId),
+        eq(tasks.organizationId, organizationId), isNull(tasks.deletedAt),
       )).limit(1);
     return rows[0] ?? null;
   }

--- a/src/lib/server/repositories/drizzle-user-preference-repository.ts
+++ b/src/lib/server/repositories/drizzle-user-preference-repository.ts
@@ -1,7 +1,7 @@
 /** Drizzle `UserPreferenceRepository` (ADR 0020). */
 
 import { and, eq, isNull } from "drizzle-orm";
-import { asId } from "@/lib/shared/schemas/ids";
+import type { OrganizationId, UserId } from "@/lib/shared/schemas/ids";
 import type { UserPreference } from "@/lib/shared/schemas/preference";
 import { userPreferences } from "../db/schema";
 import type { AppDb } from "../db/types";
@@ -13,10 +13,10 @@ export class DrizzleUserPreferenceRepository extends DrizzleRepository<UserPrefe
     super(db, versionedTable(userPreferences), now);
   }
 
-  async getByUserKey(userId: string, organizationId: string, key: string): Promise<UserPreference | null> {
+  async getByUserKey(userId: UserId, organizationId: OrganizationId, key: string): Promise<UserPreference | null> {
     const rows = await this.db
       .select().from(userPreferences)
-      .where(and(eq(userPreferences.userId, asId<"UserId">(userId)), eq(userPreferences.organizationId, asId<"OrganizationId">(organizationId)), eq(userPreferences.key, key), isNull(userPreferences.deletedAt)))
+      .where(and(eq(userPreferences.userId, userId), eq(userPreferences.organizationId, organizationId), eq(userPreferences.key, key), isNull(userPreferences.deletedAt)))
       .limit(1);
     return rows[0] ?? null;
   }

--- a/src/lib/server/repositories/drizzle-user-repository.ts
+++ b/src/lib/server/repositories/drizzle-user-repository.ts
@@ -4,6 +4,7 @@
  */
 
 import { and, asc, eq, isNull } from "drizzle-orm";
+import type { OrganizationId, UserId } from "@/lib/shared/schemas/ids";
 import type { User } from "@/lib/shared/schemas/user";
 import { users } from "../db/schema";
 import type { AppDb } from "../db/types";
@@ -15,7 +16,7 @@ export class DrizzleUserRepository extends DrizzleRepository<User> implements Us
     super(db, versionedTable(users), now);
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<User | null> {
+  async getByIdInOrg(id: UserId, organizationId: OrganizationId): Promise<User | null> {
     const rows = await this.db
       .select().from(users)
       .where(and(eq(users.id, id), eq(users.organizationId, organizationId), isNull(users.deletedAt)))
@@ -23,7 +24,7 @@ export class DrizzleUserRepository extends DrizzleRepository<User> implements Us
     return this.asRow(rows[0]);
   }
 
-  async listByOrg(organizationId: string): Promise<User[]> {
+  async listByOrg(organizationId: OrganizationId): Promise<User[]> {
     const rows = await this.db
       .select().from(users)
       .where(and(eq(users.organizationId, organizationId), isNull(users.deletedAt)))

--- a/src/lib/server/repositories/in-memory-calendar-event-repository.ts
+++ b/src/lib/server/repositories/in-memory-calendar-event-repository.ts
@@ -4,6 +4,7 @@
  */
 
 import type { CalendarEvent } from "@/lib/shared/schemas/calendar";
+import type { CalendarEventId, MatterId, OrganizationId, UserId } from "@/lib/shared/schemas/ids";
 import type { IDataStore } from "../data-store/IDataStore";
 import type { CalendarEventRepository, CalendarEventRow } from "./calendar-event-repository";
 import { InMemoryRepository } from "./in-memory-repository";
@@ -18,7 +19,7 @@ export class InMemoryCalendarEventRepository extends InMemoryRepository<Calendar
     super(store.calendarEvents, now ?? (() => new Date()));
   }
 
-  async listForUser(userId: string, organizationId: string): Promise<CalendarEventRow[]> {
+  async listForUser(userId: UserId, organizationId: OrganizationId): Promise<CalendarEventRow[]> {
     return (await this.delegate.findMany({
       where: { userId, organizationId },
       orderBy: { startAt: "asc" },
@@ -26,7 +27,7 @@ export class InMemoryCalendarEventRepository extends InMemoryRepository<Calendar
     })) as CalendarEventRow[];
   }
 
-  async listForUsers(userIds: string[], organizationId: string): Promise<CalendarEventRow[]> {
+  async listForUsers(userIds: UserId[], organizationId: OrganizationId): Promise<CalendarEventRow[]> {
     return (await this.delegate.findMany({
       where: { organizationId, userId: { in: userIds } },
       orderBy: { startAt: "asc" },
@@ -34,19 +35,19 @@ export class InMemoryCalendarEventRepository extends InMemoryRepository<Calendar
     })) as CalendarEventRow[];
   }
 
-  async listForMatter(matterId: string, organizationId: string): Promise<CalendarEvent[]> {
+  async listForMatter(matterId: MatterId, organizationId: OrganizationId): Promise<CalendarEvent[]> {
     return (await this.delegate.findMany({
       where: { matterId, organizationId },
       orderBy: { startAt: "asc" },
     })) as CalendarEvent[];
   }
 
-  async getOwned(id: string, userId: string, organizationId: string): Promise<CalendarEvent | null> {
+  async getOwned(id: CalendarEventId, userId: UserId, organizationId: OrganizationId): Promise<CalendarEvent | null> {
     const row = (await this.delegate.findFirst({ where: { id, userId, organizationId } })) as CalendarEvent | null;
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }
 
-  async getOwnedWithMatter(id: string, userId: string, organizationId: string): Promise<CalendarEventRow | null> {
+  async getOwnedWithMatter(id: CalendarEventId, userId: UserId, organizationId: OrganizationId): Promise<CalendarEventRow | null> {
     const row = (await this.delegate.findFirst({
       where: { id, userId, organizationId },
       include: MATTER_INCLUDE,

--- a/src/lib/server/repositories/in-memory-office-repository.ts
+++ b/src/lib/server/repositories/in-memory-office-repository.ts
@@ -2,6 +2,7 @@
  * In-memory `OfficeRepository` (ADR 0020) — browser/offline-impl.
  */
 
+import type { OfficeId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { Office } from "@/lib/shared/schemas/organization";
 import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
@@ -14,19 +15,19 @@ export class InMemoryOfficeRepository extends InMemoryRepository<Office> impleme
     super(store.offices, now ?? (() => new Date()));
   }
 
-  async listByOrg(organizationId: string): Promise<Office[]> {
+  async listByOrg(organizationId: OrganizationId): Promise<Office[]> {
     return (await this.delegate.findMany({
       where: { organizationId },
       orderBy: [{ isMain: "desc" }, { name: "asc" }],
     })) as Office[];
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<Office | null> {
+  async getByIdInOrg(id: OfficeId, organizationId: OrganizationId): Promise<Office | null> {
     const row = (await this.delegate.findFirst({ where: { id, organizationId } })) as Office | null;
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }
 
-  async demoteMains(organizationId: string): Promise<void> {
+  async demoteMains(organizationId: OrganizationId): Promise<void> {
     await this.delegate.updateMany({
       where: { organizationId, isMain: true },
       data: { isMain: false } as Partial<Office>,

--- a/src/lib/server/repositories/in-memory-org-preference-repository.ts
+++ b/src/lib/server/repositories/in-memory-org-preference-repository.ts
@@ -1,5 +1,6 @@
 /** In-memory `OrgPreferenceRepository` (ADR 0020). */
 
+import type { OrganizationId } from "@/lib/shared/schemas/ids";
 import type { OrgPreference } from "@/lib/shared/schemas/preference";
 import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
@@ -12,12 +13,12 @@ export class InMemoryOrgPreferenceRepository extends InMemoryRepository<OrgPrefe
     super(store.orgPreferences, now ?? (() => new Date()));
   }
 
-  async getByOrgKey(organizationId: string, key: string): Promise<OrgPreference | null> {
+  async getByOrgKey(organizationId: OrganizationId, key: string): Promise<OrgPreference | null> {
     const row = (await this.delegate.findFirst({ where: { organizationId, key } })) as OrgPreference | null;
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }
 
-  async listByOrg(organizationId: string): Promise<OrgPreference[]> {
+  async listByOrg(organizationId: OrganizationId): Promise<OrgPreference[]> {
     return (await this.delegate.findMany({ where: { organizationId }, orderBy: { key: "asc" } })) as OrgPreference[];
   }
 }

--- a/src/lib/server/repositories/in-memory-service-note-repository.ts
+++ b/src/lib/server/repositories/in-memory-service-note-repository.ts
@@ -3,6 +3,7 @@
  * bas-CRUD; list/ägar-vakt org-scopar via ärendet (samma relations-where som routern).
  */
 
+import type { MatterId, OrganizationId, ServiceNoteId } from "@/lib/shared/schemas/ids";
 import type { ServiceNote } from "@/lib/shared/schemas/service-note";
 import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
@@ -16,7 +17,7 @@ export class InMemoryServiceNoteRepository extends InMemoryRepository<ServiceNot
     super(store.serviceNotes, now ?? (() => new Date()));
   }
 
-  async listByMatter(matterId: string, organizationId: string): Promise<ServiceNoteRow[]> {
+  async listByMatter(matterId: MatterId, organizationId: OrganizationId): Promise<ServiceNoteRow[]> {
     return (await this.delegate.findMany({
       where: { matterId, matter: { organizationId } },
       orderBy: { createdAt: "desc" },
@@ -24,7 +25,7 @@ export class InMemoryServiceNoteRepository extends InMemoryRepository<ServiceNot
     })) as ServiceNoteRow[];
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<ServiceNote | null> {
+  async getByIdInOrg(id: ServiceNoteId, organizationId: OrganizationId): Promise<ServiceNote | null> {
     const row = (await this.delegate
       .findFirst({ where: { id, matter: { organizationId } } })) as ServiceNote | null;
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;

--- a/src/lib/server/repositories/in-memory-task-repository.ts
+++ b/src/lib/server/repositories/in-memory-task-repository.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Task } from "@/lib/shared/schemas/calendar";
+import type { OrganizationId, TaskId, UserId } from "@/lib/shared/schemas/ids";
 import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type { TaskListFilter, TaskListRow, TaskRepository } from "./task-repository";
@@ -16,7 +17,7 @@ export class InMemoryTaskRepository extends InMemoryRepository<Task> implements 
     super(store.tasks, now ?? (() => new Date()));
   }
 
-  async listForUser(userId: string, organizationId: string, filter: TaskListFilter): Promise<TaskListRow[]> {
+  async listForUser(userId: UserId, organizationId: OrganizationId, filter: TaskListFilter): Promise<TaskListRow[]> {
     return (await this.delegate.findMany({
       where: {
         userId,
@@ -29,7 +30,7 @@ export class InMemoryTaskRepository extends InMemoryRepository<Task> implements 
     })) as TaskListRow[];
   }
 
-  async getOwned(id: string, userId: string, organizationId: string): Promise<Task | null> {
+  async getOwned(id: TaskId, userId: UserId, organizationId: OrganizationId): Promise<Task | null> {
     const row = (await this.delegate.findFirst({ where: { id, userId, organizationId } })) as Task | null;
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }

--- a/src/lib/server/repositories/in-memory-user-preference-repository.ts
+++ b/src/lib/server/repositories/in-memory-user-preference-repository.ts
@@ -1,5 +1,6 @@
 /** In-memory `UserPreferenceRepository` (ADR 0020). */
 
+import type { OrganizationId, UserId } from "@/lib/shared/schemas/ids";
 import type { UserPreference } from "@/lib/shared/schemas/preference";
 import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
@@ -12,7 +13,7 @@ export class InMemoryUserPreferenceRepository extends InMemoryRepository<UserPre
     super(store.userPreferences, now ?? (() => new Date()));
   }
 
-  async getByUserKey(userId: string, organizationId: string, key: string): Promise<UserPreference | null> {
+  async getByUserKey(userId: UserId, organizationId: OrganizationId, key: string): Promise<UserPreference | null> {
     const row = (await this.delegate.findFirst({ where: { userId, organizationId, key } })) as UserPreference | null;
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }

--- a/src/lib/server/repositories/in-memory-user-repository.ts
+++ b/src/lib/server/repositories/in-memory-user-repository.ts
@@ -3,6 +3,7 @@
  * org-scopar direkt på `organizationId`.
  */
 
+import type { OrganizationId, UserId } from "@/lib/shared/schemas/ids";
 import type { User } from "@/lib/shared/schemas/user";
 import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
@@ -16,12 +17,12 @@ export class InMemoryUserRepository extends InMemoryRepository<User> implements 
     super(store.users, now ?? (() => new Date()));
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<User | null> {
+  async getByIdInOrg(id: UserId, organizationId: OrganizationId): Promise<User | null> {
     const row = (await this.delegate.findFirst({ where: { id, organizationId } })) as User | null;
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }
 
-  async listByOrg(organizationId: string): Promise<User[]> {
+  async listByOrg(organizationId: OrganizationId): Promise<User[]> {
     return (await this.delegate.findMany({ where: { organizationId }, orderBy: { name: "asc" } })) as User[];
   }
 }

--- a/src/lib/server/repositories/office-repository.ts
+++ b/src/lib/server/repositories/office-repository.ts
@@ -3,14 +3,15 @@
  * Bas-CRUD ärvs; `demoteMains` nollar huvudkontors-flaggan (en main åt gången).
  */
 
+import type { OfficeId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { Office } from "@/lib/shared/schemas/organization";
 import type { Repository } from "./types";
 
 export interface OfficeRepository extends Repository<Office> {
   /** Org:ens kontor (huvudkontor först, sedan namn). */
-  listByOrg(organizationId: string): Promise<Office[]>;
+  listByOrg(organizationId: OrganizationId): Promise<Office[]>;
   /** Kontor by id, org-scopat (null om saknas/annan org/raderat). */
-  getByIdInOrg(id: string, organizationId: string): Promise<Office | null>;
+  getByIdInOrg(id: OfficeId, organizationId: OrganizationId): Promise<Office | null>;
   /** Nolla `isMain` på alla nuvarande huvudkontor i org:en (innan ett nytt sätts). */
-  demoteMains(organizationId: string): Promise<void>;
+  demoteMains(organizationId: OrganizationId): Promise<void>;
 }

--- a/src/lib/server/repositories/org-preference-repository.ts
+++ b/src/lib/server/repositories/org-preference-repository.ts
@@ -3,6 +3,7 @@
  * (ADMIN). Bas-CRUD ärvs; `getByOrgKey` upsert-uppslag, `listByOrg` admin-UI:t.
  */
 
+import type { OrganizationId } from "@/lib/shared/schemas/ids";
 import type { OrgPreference } from "@/lib/shared/schemas/preference";
 import type { Repository, RowBase } from "./types";
 
@@ -11,7 +12,7 @@ export type OrgPreferenceRow = OrgPreference & RowBase;
 
 export interface OrgPreferenceRepository extends Repository<OrgPreferenceRow> {
   /** Org-default för (org, key) — null om ingen/raderad. */
-  getByOrgKey(organizationId: string, key: string): Promise<OrgPreference | null>;
+  getByOrgKey(organizationId: OrganizationId, key: string): Promise<OrgPreference | null>;
   /** Alla org-defaults (key asc). */
-  listByOrg(organizationId: string): Promise<OrgPreference[]>;
+  listByOrg(organizationId: OrganizationId): Promise<OrgPreference[]>;
 }

--- a/src/lib/server/repositories/service-note-repository.ts
+++ b/src/lib/server/repositories/service-note-repository.ts
@@ -4,17 +4,18 @@
  * ärendets noteringar med författar-subset, `getByIdInOrg` är ägarskaps-vakten.
  */
 
+import type { MatterId, OrganizationId, ServiceNoteId, UserId } from "@/lib/shared/schemas/ids";
 import type { ServiceNote } from "@/lib/shared/schemas/service-note";
 import type { Repository } from "./types";
 
 /** Notering + författar-subsetet listvyn visar. */
 export interface ServiceNoteRow extends ServiceNote {
-  author: { id: string; name: string } | null;
+  author: { id: UserId; name: string } | null;
 }
 
 export interface ServiceNoteRepository extends Repository<ServiceNote> {
   /** Ärendets noteringar (nyaste först), org-scopat via ärendet, med författare. */
-  listByMatter(matterId: string, organizationId: string): Promise<ServiceNoteRow[]>;
+  listByMatter(matterId: MatterId, organizationId: OrganizationId): Promise<ServiceNoteRow[]>;
   /** Notering by id, org-scopad via ärendet (null om saknas/annan org/raderad). */
-  getByIdInOrg(id: string, organizationId: string): Promise<ServiceNote | null>;
+  getByIdInOrg(id: ServiceNoteId, organizationId: OrganizationId): Promise<ServiceNote | null>;
 }

--- a/src/lib/server/repositories/task-repository.ts
+++ b/src/lib/server/repositories/task-repository.ts
@@ -6,22 +6,23 @@
  */
 
 import type { Task, TaskStatus } from "@/lib/shared/schemas/calendar";
+import type { MatterId, OrganizationId, TaskId, UserId } from "@/lib/shared/schemas/ids";
 import type { Repository } from "./types";
 
 /** Task + ärende-subsetet listvyn visar. */
 export interface TaskListRow extends Task {
-  matter: { id: string; matterNumber: string; title: string } | null;
+  matter: { id: MatterId; matterNumber: string; title: string } | null;
 }
 
 /** Filter för `listForUser`. */
 export interface TaskListFilter {
   status?: TaskStatus | undefined;
-  matterId?: string | undefined;
+  matterId?: MatterId | undefined;
 }
 
 export interface TaskRepository extends Repository<Task> {
   /** Användarens uppgifter i org:en (dueAt asc), med ärende-subset. */
-  listForUser(userId: string, organizationId: string, filter: TaskListFilter): Promise<TaskListRow[]>;
+  listForUser(userId: UserId, organizationId: OrganizationId, filter: TaskListFilter): Promise<TaskListRow[]>;
   /** Uppgift by id, ägar-scopad (id + userId + org). Null om saknas/ej ägd/raderad. */
-  getOwned(id: string, userId: string, organizationId: string): Promise<Task | null>;
+  getOwned(id: TaskId, userId: UserId, organizationId: OrganizationId): Promise<Task | null>;
 }

--- a/src/lib/server/repositories/user-preference-repository.ts
+++ b/src/lib/server/repositories/user-preference-repository.ts
@@ -3,6 +3,7 @@
  * (kolumn/sort/vy per UI-key). Bas-CRUD ärvs; `getByUserKey` är upsert-uppslaget.
  */
 
+import type { OrganizationId, UserId } from "@/lib/shared/schemas/ids";
 import type { UserPreference } from "@/lib/shared/schemas/preference";
 import type { Repository, RowBase } from "./types";
 
@@ -11,5 +12,5 @@ export type UserPreferenceRow = UserPreference & RowBase;
 
 export interface UserPreferenceRepository extends Repository<UserPreferenceRow> {
   /** User-pref för (userId, org, key) — null om ingen/raderad. */
-  getByUserKey(userId: string, organizationId: string, key: string): Promise<UserPreference | null>;
+  getByUserKey(userId: UserId, organizationId: OrganizationId, key: string): Promise<UserPreference | null>;
 }

--- a/src/lib/server/repositories/user-repository.ts
+++ b/src/lib/server/repositories/user-repository.ts
@@ -5,12 +5,13 @@
  * bor kvar i routern, så känsliga fält inte läcker av misstag.
  */
 
+import type { OrganizationId, UserId } from "@/lib/shared/schemas/ids";
 import type { User } from "@/lib/shared/schemas/user";
 import type { Repository } from "./types";
 
 export interface UserRepository extends Repository<User> {
   /** Användare by id, org-scopad (null om saknas/annan org/raderad). */
-  getByIdInOrg(id: string, organizationId: string): Promise<User | null>;
+  getByIdInOrg(id: UserId, organizationId: OrganizationId): Promise<User | null>;
   /** Alla (icke-raderade) användare i org:en, namn-sorterade. */
-  listByOrg(organizationId: string): Promise<User[]>;
+  listByOrg(organizationId: OrganizationId): Promise<User[]>;
 }

--- a/src/lib/server/routers/calendar.ts
+++ b/src/lib/server/routers/calendar.ts
@@ -121,7 +121,7 @@ export const calendarRouter = router({
    */
   listForUsers: protectedProcedure
     .input(z.object({
-      userIds: z.array(z.string()),
+      userIds: z.array(userIdSchema),
       from: z.date().optional(),
       to: z.date().optional(),
     }))

--- a/src/lib/server/routers/matter.ts
+++ b/src/lib/server/routers/matter.ts
@@ -15,6 +15,7 @@ import {
   type MatterId,
   type ContactId,
   type OrganizationId,
+  type UserId,
 } from "@/lib/shared/schemas/ids";
 import type { Matter, MatterContact } from "@/lib/shared/schemas/matter";
 import { emit } from "../events/emit";
@@ -79,7 +80,7 @@ function maxSeq(matters: ReadonlyArray<{ matterNumber: string }>, year: number):
 }
 
 /** Den ansvariga juristens prefix (tom om okänd/ej i org:en/ingen prefix satt). */
-async function lawyerPrefix(ctx: MatterCtx, userId: string): Promise<string> {
+async function lawyerPrefix(ctx: MatterCtx, userId: UserId): Promise<string> {
   const u = (await ctx.repos.users.getByIdInOrg(userId, ctx.orgId)) as
     | { matterNumberPrefix?: string | null }
     | null;
@@ -102,7 +103,7 @@ async function lawyerPrefix(ctx: MatterCtx, userId: string): Promise<string> {
  */
 async function nextMatterNumber(ctx: MatterCtx, responsibleLawyerId?: string): Promise<string> {
   const year = new Date().getFullYear();
-  const prefix = responsibleLawyerId ? await lawyerPrefix(ctx, responsibleLawyerId) : "";
+  const prefix = responsibleLawyerId ? await lawyerPrefix(ctx, asId<"UserId">(responsibleLawyerId)) : "";
 
   const ownMatters = responsibleLawyerId
     ? await ctx.repos.matters.listByResponsibleLawyer(ctx.orgId, asId<"UserId">(responsibleLawyerId))

--- a/src/lib/server/routers/todo.ts
+++ b/src/lib/server/routers/todo.ts
@@ -12,6 +12,7 @@
 
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import { userIdSchema } from "@/lib/shared/schemas/ids";
 import { router, orgProcedure } from "../trpc";
 
 export interface TodoItem {
@@ -36,7 +37,7 @@ export const todoRouter = router({
       from: z.date(),
       to: z.date(),
       /** Default = anropande user; annars måste user:n vara i samma org. */
-      userId: z.string().optional(),
+      userId: userIdSchema.optional(),
     }))
     .query(async ({ ctx, input }) => {
       const userId = input.userId ?? ctx.user.id;

--- a/test/unit/server/repositories/calendar-event-repository.test.ts
+++ b/test/unit/server/repositories/calendar-event-repository.test.ts
@@ -8,30 +8,32 @@ import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { calendarEvents, matters } from "@/lib/server/db/schema";
 import { DrizzleCalendarEventRepository } from "@/lib/server/repositories/drizzle-calendar-event-repository";
 import { InMemoryCalendarEventRepository } from "@/lib/server/repositories/in-memory-calendar-event-repository";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
 describe("CalendarEventRepository — in-memory", () => {
   it("list-varianter + ägar-vakt", async () => {
-    const userId = uuidv7();
-    const other = uuidv7();
-    const mId = uuidv7();
-    const e1 = uuidv7();
+    const userId = asId<"UserId">(uuidv7());
+    const other = asId<"UserId">(uuidv7());
+    const mId = asId<"MatterId">(uuidv7());
+    const e1 = asId<"CalendarEventId">(uuidv7());
+    const org = asId<"OrganizationId">("org-1");
     const store = new LocalStore({
-      matters: [{ id: mId, organizationId: "org-1", matterNumber: "2026-1", title: "T" }],
+      matters: [{ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }],
       calendarEvents: [
-        { id: e1, userId, organizationId: "org-1", title: "A", startAt: new Date("2026-06-02"), matterId: mId },
-        { id: uuidv7(), userId, organizationId: "org-1", title: "B", startAt: new Date("2026-06-01"), matterId: null },
-        { id: uuidv7(), userId: other, organizationId: "org-1", title: "C", startAt: new Date("2026-06-03"), matterId: mId },
+        { id: e1, userId, organizationId: org, title: "A", startAt: new Date("2026-06-02"), matterId: mId },
+        { id: asId<"CalendarEventId">(uuidv7()), userId, organizationId: org, title: "B", startAt: new Date("2026-06-01"), matterId: null },
+        { id: asId<"CalendarEventId">(uuidv7()), userId: other, organizationId: org, title: "C", startAt: new Date("2026-06-03"), matterId: mId },
       ],
     }, async () => {});
     const repo = new InMemoryCalendarEventRepository(store);
-    expect(await repo.listForUser(userId, "org-1")).toHaveLength(2);
-    expect(await repo.listForUsers([userId, other], "org-1")).toHaveLength(3);
-    expect(await repo.listForMatter(mId, "org-1")).toHaveLength(2); // e1 + other's C
-    expect(await repo.getOwned(e1, userId, "org-1")).toMatchObject({ id: e1 });
-    expect(await repo.getOwned(e1, other, "org-1")).toBeNull(); // annan user
-    expect((await repo.getOwnedWithMatter(e1, userId, "org-1"))?.matter?.matterNumber).toBe("2026-1");
+    expect(await repo.listForUser(userId, org)).toHaveLength(2);
+    expect(await repo.listForUsers([userId, other], org)).toHaveLength(3);
+    expect(await repo.listForMatter(mId, org)).toHaveLength(2); // e1 + other's C
+    expect(await repo.getOwned(e1, userId, org)).toMatchObject({ id: e1 });
+    expect(await repo.getOwned(e1, other, org)).toBeNull(); // annan user
+    expect((await repo.getOwnedWithMatter(e1, userId, org))?.matter?.matterNumber).toBe("2026-1");
   });
 });
 
@@ -42,11 +44,11 @@ describe("CalendarEventRepository — Drizzle (pglite)", () => {
 
   it("list-varianter (left-join matter) + ägar-vakt", async () => {
     const db = handle.db;
-    const org = uuidv7();
-    const userId = uuidv7();
-    const other = uuidv7();
-    const mId = uuidv7();
-    const e1 = uuidv7();
+    const org = asId<"OrganizationId">(uuidv7());
+    const userId = asId<"UserId">(uuidv7());
+    const other = asId<"UserId">(uuidv7());
+    const mId = asId<"MatterId">(uuidv7());
+    const e1 = asId<"CalendarEventId">(uuidv7());
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
     await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));

--- a/test/unit/server/repositories/organization-office-repository.test.ts
+++ b/test/unit/server/repositories/organization-office-repository.test.ts
@@ -15,9 +15,9 @@ import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
 describe("Organization/Office — in-memory", () => {
   it("org getById/update; offices listByOrg (main först) + getByIdInOrg + demoteMains", async () => {
-    const org = "org-1";
-    const main = uuidv7();
-    const branch = uuidv7();
+    const org = asId<"OrganizationId">("org-1");
+    const main = asId<"OfficeId">(uuidv7());
+    const branch = asId<"OfficeId">(uuidv7());
     const store = new LocalStore({
       organizations: [{ id: org, name: "Byrå AB" }],
       offices: [
@@ -26,14 +26,14 @@ describe("Organization/Office — in-memory", () => {
       ],
     }, async () => {});
     const orgRepo = new InMemoryOrganizationRepository(store);
-    expect(await orgRepo.getById(asId<"OrganizationId">(org))).toMatchObject({ id: org });
+    expect(await orgRepo.getById(org)).toMatchObject({ id: org });
     const offRepo = new InMemoryOfficeRepository(store);
     const list = await offRepo.listByOrg(org);
     // In-memory query-engine sorterar inte boolean isMain desc (routern litar på
     // att orderBy skickas; Drizzle/SQL-vägen ordnar). Verifiera medlemskap här.
     expect(list.map((o) => o.id).sort()).toEqual([main, branch].sort());
     expect(await offRepo.getByIdInOrg(branch, org)).toMatchObject({ id: branch });
-    expect(await offRepo.getByIdInOrg(branch, "org-2")).toBeNull();
+    expect(await offRepo.getByIdInOrg(branch, asId<"OrganizationId">("org-2"))).toBeNull();
     await offRepo.demoteMains(org);
     expect((await offRepo.getByIdInOrg(main, org))!.isMain).toBe(false);
   });
@@ -46,19 +46,19 @@ describe("Organization/Office — Drizzle (pglite)", () => {
 
   it("org + offices med demoteMains", async () => {
     const db = handle.db;
-    const org = uuidv7();
-    const main = uuidv7();
-    const branch = uuidv7();
+    const org = asId<"OrganizationId">(uuidv7());
+    const main = asId<"OfficeId">(uuidv7());
+    const branch = asId<"OfficeId">(uuidv7());
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
     await db.insert(organizations).values(v({ id: org, name: "Byrå AB" }));
     await db.insert(offices).values(v({ id: main, organizationId: org, name: "Sthlm", isMain: true }));
     await db.insert(offices).values(v({ id: branch, organizationId: org, name: "Gbg", isMain: false }));
     const offRepo = new DrizzleOfficeRepository(handle.db);
-    expect(await new DrizzleOrganizationRepository(handle.db).getById(asId<"OrganizationId">(org))).toMatchObject({ id: org });
+    expect(await new DrizzleOrganizationRepository(handle.db).getById(org)).toMatchObject({ id: org });
     expect((await offRepo.listByOrg(org)).map((o) => o.id)).toEqual([main, branch]);
     expect(await offRepo.getByIdInOrg(branch, org)).toMatchObject({ id: branch });
-    expect(await offRepo.getByIdInOrg(branch, uuidv7())).toBeNull();
+    expect(await offRepo.getByIdInOrg(branch, asId<"OrganizationId">(uuidv7()))).toBeNull();
     await offRepo.demoteMains(org);
     expect((await offRepo.getByIdInOrg(main, org))!.isMain).toBe(false);
   });

--- a/test/unit/server/repositories/preference-repository.test.ts
+++ b/test/unit/server/repositories/preference-repository.test.ts
@@ -9,24 +9,26 @@ import { DrizzleOrgPreferenceRepository } from "@/lib/server/repositories/drizzl
 import { DrizzleUserPreferenceRepository } from "@/lib/server/repositories/drizzle-user-preference-repository";
 import { InMemoryOrgPreferenceRepository } from "@/lib/server/repositories/in-memory-org-preference-repository";
 import { InMemoryUserPreferenceRepository } from "@/lib/server/repositories/in-memory-user-preference-repository";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
 describe("Preference repos — in-memory", () => {
   it("getByUserKey + getByOrgKey + listByOrg", async () => {
-    const userId = uuidv7();
+    const userId = asId<"UserId">(uuidv7());
+    const org = asId<"OrganizationId">("org-1");
     const up = uuidv7();
     const op = uuidv7();
     const store = new LocalStore({
-      userPreferences: [{ id: up, userId, organizationId: "org-1", key: "list.contacts", prefs: { sort: "name" } }],
-      orgPreferences: [{ id: op, organizationId: "org-1", key: "list.contacts", prefs: { sort: "createdAt" } }],
+      userPreferences: [{ id: up, userId, organizationId: org, key: "list.contacts", prefs: { sort: "name" } }],
+      orgPreferences: [{ id: op, organizationId: org, key: "list.contacts", prefs: { sort: "createdAt" } }],
     }, async () => {});
     const uRepo = new InMemoryUserPreferenceRepository(store);
     const oRepo = new InMemoryOrgPreferenceRepository(store);
-    expect((await uRepo.getByUserKey(userId, "org-1", "list.contacts"))?.id).toBe(up);
-    expect(await uRepo.getByUserKey(userId, "org-1", "list.x")).toBeNull();
-    expect((await oRepo.getByOrgKey("org-1", "list.contacts"))?.id).toBe(op);
-    expect(await oRepo.listByOrg("org-1")).toHaveLength(1);
+    expect((await uRepo.getByUserKey(userId, org, "list.contacts"))?.id).toBe(up);
+    expect(await uRepo.getByUserKey(userId, org, "list.x")).toBeNull();
+    expect((await oRepo.getByOrgKey(org, "list.contacts"))?.id).toBe(op);
+    expect(await oRepo.listByOrg(org)).toHaveLength(1);
   });
 });
 
@@ -37,8 +39,8 @@ describe("Preference repos — Drizzle (pglite)", () => {
 
   it("getByUserKey + getByOrgKey + listByOrg", async () => {
     const db = handle.db;
-    const org = uuidv7();
-    const userId = uuidv7();
+    const org = asId<"OrganizationId">(uuidv7());
+    const userId = asId<"UserId">(uuidv7());
     const up = uuidv7();
     const op = uuidv7();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/unit/server/repositories/service-note-repository.test.ts
+++ b/test/unit/server/repositories/service-note-repository.test.ts
@@ -10,28 +10,30 @@ import { matters, serviceNotes, users } from "@/lib/server/db/schema";
 import { DrizzleServiceNoteRepository } from "@/lib/server/repositories/drizzle-service-note-repository";
 import { InMemoryServiceNoteRepository } from "@/lib/server/repositories/in-memory-service-note-repository";
 import { prebakeJoins } from "@/lib/shared/demo-source";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
 describe("ServiceNoteRepository — in-memory", () => {
   it("listByMatter (org-scope via ärende + author) + getByIdInOrg", async () => {
-    const mId = uuidv7();
+    const mId = asId<"MatterId">(uuidv7());
     const userId = uuidv7();
-    const sn1 = uuidv7();
+    const sn1 = asId<"ServiceNoteId">(uuidv7());
+    const org = asId<"OrganizationId">("org-1");
     // prebakeJoins → nästlade relationer (author, matter) resolvas som i prod.
     const source = prebakeJoins({
-      matters: [{ id: mId, organizationId: "org-1", matterNumber: "2026-1", title: "T" }],
+      matters: [{ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }],
       users: [{ id: userId, name: "Anna" }],
       serviceNotes: [
-        { id: sn1, matterId: mId, organizationId: "org-1", authorId: userId, date: "2026-06-15", time: "09:30", text: "A" },
+        { id: sn1, matterId: mId, organizationId: org, authorId: userId, date: "2026-06-15", time: "09:30", text: "A" },
       ],
     } as DemoSource);
     const repo = new InMemoryServiceNoteRepository(new LocalStore(source, async () => {}));
-    const list = await repo.listByMatter(mId, "org-1");
+    const list = await repo.listByMatter(mId, org);
     expect(list).toHaveLength(1);
     expect(list[0]!.author?.name).toBe("Anna");
-    expect(await repo.getByIdInOrg(sn1, "org-1")).toMatchObject({ id: sn1 });
-    expect(await repo.getByIdInOrg(sn1, "org-2")).toBeNull(); // fel org
+    expect(await repo.getByIdInOrg(sn1, org)).toMatchObject({ id: sn1 });
+    expect(await repo.getByIdInOrg(sn1, asId<"OrganizationId">("org-2"))).toBeNull(); // fel org
   });
 });
 
@@ -42,10 +44,10 @@ describe("ServiceNoteRepository — Drizzle (pglite)", () => {
 
   it("listByMatter (join ärende/author) + getByIdInOrg", async () => {
     const db = handle.db;
-    const org = uuidv7();
-    const mId = uuidv7();
+    const org = asId<"OrganizationId">(uuidv7());
+    const mId = asId<"MatterId">(uuidv7());
     const userId = uuidv7();
-    const sn1 = uuidv7();
+    const sn1 = asId<"ServiceNoteId">(uuidv7());
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
     await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
@@ -56,6 +58,6 @@ describe("ServiceNoteRepository — Drizzle (pglite)", () => {
     expect(list).toHaveLength(1);
     expect(list[0]!.author?.name).toBe("Anna");
     expect(await repo.getByIdInOrg(sn1, org)).toMatchObject({ id: sn1 });
-    expect(await repo.getByIdInOrg(sn1, uuidv7())).toBeNull(); // fel org
+    expect(await repo.getByIdInOrg(sn1, asId<"OrganizationId">(uuidv7()))).toBeNull(); // fel org
   });
 });

--- a/test/unit/server/repositories/task-repository.test.ts
+++ b/test/unit/server/repositories/task-repository.test.ts
@@ -8,29 +8,31 @@ import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { matters, tasks } from "@/lib/server/db/schema";
 import { DrizzleTaskRepository } from "@/lib/server/repositories/drizzle-task-repository";
 import { InMemoryTaskRepository } from "@/lib/server/repositories/in-memory-task-repository";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
 describe("TaskRepository — in-memory", () => {
   it("listForUser (ägar-scope + filter + matter) och getOwned", async () => {
-    const userId = uuidv7();
-    const mId = uuidv7();
-    const t1 = uuidv7();
+    const userId = asId<"UserId">(uuidv7());
+    const mId = asId<"MatterId">(uuidv7());
+    const t1 = asId<"TaskId">(uuidv7());
+    const org = asId<"OrganizationId">("org-1");
     const store = new LocalStore({
-      matters: [{ id: mId, organizationId: "org-1", matterNumber: "2026-1", title: "T" }],
+      matters: [{ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }],
       tasks: [
-        { id: t1, userId, organizationId: "org-1", title: "A", status: "TODO", matterId: mId },
-        { id: uuidv7(), userId, organizationId: "org-1", title: "B", status: "DONE", matterId: null },
-        { id: uuidv7(), userId: uuidv7(), organizationId: "org-1", title: "Annan", status: "TODO" },
+        { id: t1, userId, organizationId: org, title: "A", status: "TODO", matterId: mId },
+        { id: asId<"TaskId">(uuidv7()), userId, organizationId: org, title: "B", status: "DONE", matterId: null },
+        { id: asId<"TaskId">(uuidv7()), userId: asId<"UserId">(uuidv7()), organizationId: org, title: "Annan", status: "TODO" },
       ],
     }, async () => {});
     const repo = new InMemoryTaskRepository(store);
-    expect(await repo.listForUser(userId, "org-1", {})).toHaveLength(2); // bara egna
-    expect(await repo.listForUser(userId, "org-1", { status: "DONE" })).toHaveLength(1);
-    const withMatter = (await repo.listForUser(userId, "org-1", { status: "TODO" }))[0]!;
+    expect(await repo.listForUser(userId, org, {})).toHaveLength(2); // bara egna
+    expect(await repo.listForUser(userId, org, { status: "DONE" })).toHaveLength(1);
+    const withMatter = (await repo.listForUser(userId, org, { status: "TODO" }))[0]!;
     expect(withMatter.matter?.matterNumber).toBe("2026-1");
-    expect(await repo.getOwned(t1, userId, "org-1")).toMatchObject({ id: t1 });
-    expect(await repo.getOwned(t1, uuidv7(), "org-1")).toBeNull(); // annan user
+    expect(await repo.getOwned(t1, userId, org)).toMatchObject({ id: t1 });
+    expect(await repo.getOwned(t1, asId<"UserId">(uuidv7()), org)).toBeNull(); // annan user
   });
 });
 
@@ -41,10 +43,10 @@ describe("TaskRepository — Drizzle (pglite)", () => {
 
   it("listForUser (left-join matter) och getOwned", async () => {
     const db = handle.db;
-    const org = uuidv7();
-    const userId = uuidv7();
-    const mId = uuidv7();
-    const t1 = uuidv7();
+    const org = asId<"OrganizationId">(uuidv7());
+    const userId = asId<"UserId">(uuidv7());
+    const mId = asId<"MatterId">(uuidv7());
+    const t1 = asId<"TaskId">(uuidv7());
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
     await db.insert(matters).values(v({ id: mId, organizationId: org, matterNumber: "2026-1", title: "T" }));
@@ -57,6 +59,6 @@ describe("TaskRepository — Drizzle (pglite)", () => {
     const withMatter = (await repo.listForUser(userId, org, { status: "TODO" }))[0]!;
     expect(withMatter.matter?.matterNumber).toBe("2026-1");
     expect(await repo.getOwned(t1, userId, org)).toMatchObject({ id: t1 });
-    expect(await repo.getOwned(t1, uuidv7(), org)).toBeNull();
+    expect(await repo.getOwned(t1, asId<"UserId">(uuidv7()), org)).toBeNull();
   });
 });

--- a/test/unit/server/repositories/user-repository.test.ts
+++ b/test/unit/server/repositories/user-repository.test.ts
@@ -8,24 +8,27 @@ import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
 import { users } from "@/lib/server/db/schema";
 import { DrizzleUserRepository } from "@/lib/server/repositories/drizzle-user-repository";
 import { InMemoryUserRepository } from "@/lib/server/repositories/in-memory-user-repository";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
 describe("UserRepository — in-memory", () => {
   it("getByIdInOrg + listByOrg org-scopar", async () => {
-    const u1 = uuidv7();
-    const u2 = uuidv7();
+    const u1 = asId<"UserId">(uuidv7());
+    const u2 = asId<"UserId">(uuidv7());
+    const org1 = asId<"OrganizationId">("org-1");
+    const org2 = asId<"OrganizationId">("org-2");
     const store = new LocalStore({
       users: [
-        { id: u1, organizationId: "org-1", email: "a@x", name: "Beta" },
-        { id: u2, organizationId: "org-1", email: "b@x", name: "Alfa" },
-        { id: uuidv7(), organizationId: "org-2", email: "c@x", name: "Gamma" },
+        { id: u1, organizationId: org1, email: "a@x", name: "Beta" },
+        { id: u2, organizationId: org1, email: "b@x", name: "Alfa" },
+        { id: asId<"UserId">(uuidv7()), organizationId: org2, email: "c@x", name: "Gamma" },
       ],
     }, async () => {});
     const repo = new InMemoryUserRepository(store);
-    expect(await repo.getByIdInOrg(u1, "org-1")).toMatchObject({ id: u1 });
-    expect(await repo.getByIdInOrg(u1, "org-2")).toBeNull(); // fel org
-    const list = await repo.listByOrg("org-1");
+    expect(await repo.getByIdInOrg(u1, org1)).toMatchObject({ id: u1 });
+    expect(await repo.getByIdInOrg(u1, org2)).toBeNull(); // fel org
+    const list = await repo.listByOrg(org1);
     expect(list).toHaveLength(2);
     expect(list.map((u) => u.name)).toEqual(["Alfa", "Beta"]); // namn-sorterat
   });
@@ -38,9 +41,9 @@ describe("UserRepository — Drizzle (pglite)", () => {
 
   it("getByIdInOrg + listByOrg org-scopar (namn asc)", async () => {
     const db = handle.db;
-    const org = uuidv7();
-    const u1 = uuidv7();
-    const u2 = uuidv7();
+    const org = asId<"OrganizationId">(uuidv7());
+    const u1 = asId<"UserId">(uuidv7());
+    const u2 = asId<"UserId">(uuidv7());
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const v = (o: Record<string, unknown>) => ({ version: 1, ...o }) as any;
     await db.insert(users).values(v({ id: u1, organizationId: org, email: "a@x", name: "Beta" }));
@@ -48,7 +51,7 @@ describe("UserRepository — Drizzle (pglite)", () => {
     await db.insert(users).values(v({ id: uuidv7(), organizationId: uuidv7(), email: "c@x", name: "Gamma" }));
     const repo = new DrizzleUserRepository(handle.db);
     expect(await repo.getByIdInOrg(u1, org)).toMatchObject({ id: u1 });
-    expect(await repo.getByIdInOrg(u1, uuidv7())).toBeNull();
+    expect(await repo.getByIdInOrg(u1, asId<"OrganizationId">(uuidv7()))).toBeNull();
     const list = await repo.listByOrg(org);
     expect(list).toHaveLength(2);
     expect(list.map((u) => u.name)).toEqual(["Alfa", "Beta"]);

--- a/tooling/scripts/seed-demo-into-server.ts
+++ b/tooling/scripts/seed-demo-into-server.ts
@@ -41,7 +41,7 @@ import { populateUnbilledTime } from "../demo-generator/populate-unbilled-time";
 import { buildSeed } from "./seed-data";
 
 const DB_URL = process.env.AVA_DATABASE_URL ?? "postgres://ava:ava@localhost:5433/ava_test";
-const ORG = process.env.AVA_ORGANIZATION_ID ?? "00000000-0000-0000-0000-000000000001";
+const ORG = asId<"OrganizationId">(process.env.AVA_ORGANIZATION_ID ?? "00000000-0000-0000-0000-000000000001");
 // Host-katalogen som är bind-mountad till serverns AVA_CONTENT_DIR (#649) —
 // dit skrivs dokument-bytes så serverns GitContentStore kan läsa dem. Saknas
 // den → dokument-metadata hoppas (bytes har ingenstans att ta vägen).
@@ -82,7 +82,7 @@ async function addTodayTimeEntries(repos: Repositories, timeEntries: Row[], ids:
     if (!matterId) continue;
     await repos.timeEntries.create({
       id: asId<"TimeEntryId">(uuidv7()),
-      organizationId: asId<"OrganizationId">(ORG),
+      organizationId: ORG,
       userId: asId<"UserId">(userId),
       matterId: asId<"MatterId">(matterId),
       date: new Date(),
@@ -130,7 +130,7 @@ async function main(): Promise<void> {
       email: admin?.email ?? "generator@ava.local",
       name: admin?.name ?? "Demo Generator",
       role: "ADMIN",
-      organizationId: asId<"OrganizationId">(ORG),
+      organizationId: ORG,
     };
     const ctx = buildContext({ repos, eventLog: serverFirstEventLog, ports: noopPorts, principal });
     const caller = appRouter.createCaller(ctx as never) as ReturnType<typeof appRouter.createCaller>;

--- a/tooling/scripts/seed-selfhosted-local.ts
+++ b/tooling/scripts/seed-selfhosted-local.ts
@@ -28,7 +28,7 @@ import type { User } from "@/lib/shared/schemas/user";
 import { uuidv7 } from "@/lib/shared/uuid";
 
 const DB_URL = process.env.AVA_DATABASE_URL ?? "postgres://ava:ava@localhost:5433/ava_test";
-const ORG = process.env.AVA_ORGANIZATION_ID ?? "00000000-0000-0000-0000-000000000001";
+const ORG = asId<"OrganizationId">(process.env.AVA_ORGANIZATION_ID ?? "00000000-0000-0000-0000-000000000001");
 
 /** KC-realm:ens (realm-ava.json) allowlistade testanvändare. `outsider` seedas
  *  MEDVETET INTE → demonstrerar att autentiserad ≠ auktoriserad (nekas). */
@@ -44,8 +44,8 @@ async function main(): Promise<void> {
   const repos = buildDrizzleRepositories(db);
   enableChangeLogOnAll(repos, createDbChangeLogRecorder(db));
   try {
-    if (!(await repos.organizations.getById(asId<"OrganizationId">(ORG)))) {
-      await repos.organizations.create({ id: asId<"OrganizationId">(ORG), name: "Demobyrå AB" } satisfies Partial<Organization>);
+    if (!(await repos.organizations.getById(ORG))) {
+      await repos.organizations.create({ id: ORG, name: "Demobyrå AB" } satisfies Partial<Organization>);
     }
     // --demo (#633-uppf.): demo-seeden mappar sin admin + huvud-jurist till
     // KC-login-emailen (admin@/lawyer@ava.test) och ÄGER datan → skapa INTE
@@ -59,7 +59,7 @@ async function main(): Promise<void> {
       if (existing.has(u.email)) { console.log(`• ${u.email} finns redan`); continue; }
       await repos.users.create({
         id: asId<"UserId">(uuidv7()),
-        organizationId: asId<"OrganizationId">(ORG),
+        organizationId: ORG,
         email: u.email,
         name: u.name,
         role: u.role,


### PR DESCRIPTION
ID-brandning per domängrupp (B1, #750), **sista repo-gruppen**. user / user-preference / org-preference / office / calendar-event / task / service-note-repos (interface + drizzle + in-memory): id/organizationId/userId(s)/matterId/officeId/calendarEventId/taskId/serviceNoteId-params + id-array + nested-DTO-id → respektive brandad `XId`. organization/conflict-check krävde inga ändringar.

**Fyllde sista db/schema.ts-luckorna:** `organizations.id`, `offices.id`/`organizationId`, `users.id`/`organizationId` saknade `.$type<>()` (samma mönster som matter/contact/document-tabellerna redan hade) — rotorsaken till join-widening + cast.

Kaskad: server-context/matter/calendar/todo-routrar + seed-scripts. Inga typer försvagade.

## Test
Ren tsc (root+test, 0), lint grön, 1134 server/integration-tester gröna.

→ **Alla repo-grupper (B1) nu brandade.** Kvar i B: resterande router-id-inputs (B2), klient-props (B3), helper (B4).

Refs #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)