### PR TITLE
refactor(routers): branda sista router-id-inputsen (B2)

### DIFF
--- a/src/lib/server/routers/document/events.ts
+++ b/src/lib/server/routers/document/events.ts
@@ -9,30 +9,30 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import type { MatterEventSuggestion } from "@/lib/shared/schemas/document";
-import { asId } from "@/lib/shared/schemas/ids";
+import { matterEventSuggestionIdSchema, matterIdSchema } from "@/lib/shared/schemas/ids";
 import { orgProcedure } from "../../trpc";
 
 export const eventProcedures = {
   /** Lista icke-avvisade händelser för ett ärende, sorterat kronologiskt. */
   events: orgProcedure
-    .input(z.object({ matterId: z.string() }))
+    .input(z.object({ matterId: matterIdSchema }))
     .query(({ ctx, input }) =>
-      ctx.repos.matterEventSuggestions.listForMatter(asId<"MatterId">(input.matterId), ctx.orgId),
+      ctx.repos.matterEventSuggestions.listForMatter(input.matterId, ctx.orgId),
     ),
 
   rejectEvent: orgProcedure
-    .input(z.object({ eventId: z.string() }))
+    .input(z.object({ eventId: matterEventSuggestionIdSchema }))
     .mutation(async ({ ctx, input }) => {
-      const ev = await ctx.repos.matterEventSuggestions.getByIdInOrg(asId<"MatterEventSuggestionId">(input.eventId), ctx.orgId);
+      const ev = await ctx.repos.matterEventSuggestions.getByIdInOrg(input.eventId, ctx.orgId);
       if (!ev) throw new TRPCError({ code: "NOT_FOUND" });
       return ctx.repos.matterEventSuggestions.update(ev.id, { status: "REJECTED" } as Partial<MatterEventSuggestion>);
     }),
 
   /** Markera händelsen som tillagd i kalender (UI-indikator). */
   markEventAdded: orgProcedure
-    .input(z.object({ eventId: z.string() }))
+    .input(z.object({ eventId: matterEventSuggestionIdSchema }))
     .mutation(async ({ ctx, input }) => {
-      const ev = await ctx.repos.matterEventSuggestions.getByIdInOrg(asId<"MatterEventSuggestionId">(input.eventId), ctx.orgId);
+      const ev = await ctx.repos.matterEventSuggestions.getByIdInOrg(input.eventId, ctx.orgId);
       if (!ev) throw new TRPCError({ code: "NOT_FOUND" });
       return ctx.repos.matterEventSuggestions.update(ev.id, { status: "ACCEPTED" } as Partial<MatterEventSuggestion>);
     }),

--- a/src/lib/server/routers/mail.ts
+++ b/src/lib/server/routers/mail.ts
@@ -13,7 +13,7 @@
  */
 
 import { z } from "zod";
-import { asId, matterIdSchema } from "@/lib/shared/schemas/ids";
+import { asId, documentFolderIdSchema, matterIdSchema } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { emit, type EmitCtx } from "../events/emit";
 import type { Repositories } from "../repositories/repositories";
@@ -57,11 +57,11 @@ export const mailRouter = router({
         emlBase64: z.string().min(1),
         subject: z.string(),
         receivedAt: z.string(), // ISO
-        folderId: z.string().nullable().optional(),
+        folderId: documentFolderIdSchema.nullable().optional(),
         time: timeInput.optional(),
         /** Klient-genererat id (annars uuidv7). Begränsat till filnamns-säkra
          *  tecken — path:en byggs av det (defense-in-depth mot traversal). */
-        documentId: z.string().regex(/^[A-Za-z0-9_-]+$/).optional(),
+        documentId: z.string().regex(/^[A-Za-z0-9_-]+$/).brand<"DocumentId">().optional(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -84,7 +84,7 @@ export const mailRouter = router({
         mimeType: "message/rfc822",
         sizeBytes: bytes.byteLength,
         storagePath,
-        folderId: input.folderId ? asId<"DocumentFolderId">(input.folderId) : null,
+        folderId: input.folderId ?? null,
         organizationId: ctx.orgId,
         analysisStatus: "PENDING" as const,
         uploadedById: asId<"UserId">(ctx.user.id),


### PR DESCRIPTION
ID-brandning (B2, #750) — resterande råa `z.string()`-id-inputs i routrar:
- **mail.ingest** — `folderId`→`documentFolderIdSchema` (slopar `asId` vid bygget), `documentId`→`z.string().regex(...).brand<"DocumentId">()` (behåller path-safety-regexen som defense-in-depth + ger brandet).
- **document/events** — `matterId`→`matterIdSchema`, `eventId`→`matterEventSuggestionIdSchema` (slopar 3 `asId`-anrop vid repo-anropen).

B1:s repo-källbrandning täckte redan merparten; detta är de sista router-inputsen.

## Test
Ren tsc (root+test, 0), lint grön, 434 router-tester gröna.

Refs #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)