### PR TITLE
refactor(helper): branda HelperDocumentRef.id + ConflictCopy.id → DocumentId (B4)

### DIFF
--- a/helper-ui/src/engine/trpc-client.ts
+++ b/helper-ui/src/engine/trpc-client.ts
@@ -17,6 +17,7 @@ import superjson from "superjson";
 
 import type { AppRouter } from "@/lib/server/routers/_app";
 import { base64ToBytes, bytesToBase64 } from "@/lib/shared/content-address";
+import type { DocumentId } from "@/lib/shared/schemas/ids";
 
 /** tRPC-endpointens suffix på serverns origin (matchar DEFAULT_TRPC_ENDPOINT). */
 export const TRPC_PATH = "/api/trpc";
@@ -115,7 +116,7 @@ export async function uploadDocumentBytes(
 
 /** En materialiserad keep-both-kopia (ADR 0033 §4): syskon-dokumentets id + namn. */
 export interface ConflictCopy {
-  id: string;
+  id: DocumentId;
   fileName: string;
 }
 

--- a/helper-ui/test/auth-orchestration.test.ts
+++ b/helper-ui/test/auth-orchestration.test.ts
@@ -9,6 +9,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
+import { asId } from "@/lib/shared/schemas/ids";
+
 import { buildAuthHeaderProvider } from "../src/engine/auth/auth-provider.ts";
 import { parseCallback, waitForCallback } from "../src/engine/auth/callback-server.ts";
 import { loginConfigFromEnv, runLogin, type LoginDeps } from "../src/engine/auth/login.ts";
@@ -151,7 +153,7 @@ describe("UploadQueue tokenProvider (autonom Bearer vid drain)", () => {
 
   test("post utan egen authHeader → använder färsk token vid upload", async () => {
     const puts: Array<string | undefined> = [];
-    const deps = { now: () => 1000, newId: () => "id1", put: async (_u: string, _b: Uint8Array, auth?: string) => { puts.push(auth); return 200; }, uploadDoc: async () => ({ status: "ok" as const, version: 1 }), saveConflictCopy: async () => ({ id: "c", fileName: "k" }) };
+    const deps = { now: () => 1000, newId: () => "id1", put: async (_u: string, _b: Uint8Array, auth?: string) => { puts.push(auth); return 200; }, uploadDoc: async () => ({ status: "ok" as const, version: 1 }), saveConflictCopy: async () => ({ id: asId<"DocumentId">("c"), fileName: "k" }) };
     const q = new UploadQueue(await qdir(), deps, async () => "Bearer FRESH");
     await q.enqueue({ uploadUrl: "http://s/u/1", fileName: "a", bytes: new TextEncoder().encode("x") });
     await q.drainOnce();
@@ -161,7 +163,7 @@ describe("UploadQueue tokenProvider (autonom Bearer vid drain)", () => {
 
   test("post MED egen authHeader → den vinner över token-providern", async () => {
     const puts: Array<string | undefined> = [];
-    const deps = { now: () => 1000, newId: () => "id2", put: async (_u: string, _b: Uint8Array, auth?: string) => { puts.push(auth); return 200; }, uploadDoc: async () => ({ status: "ok" as const, version: 1 }), saveConflictCopy: async () => ({ id: "c", fileName: "k" }) };
+    const deps = { now: () => 1000, newId: () => "id2", put: async (_u: string, _b: Uint8Array, auth?: string) => { puts.push(auth); return 200; }, uploadDoc: async () => ({ status: "ok" as const, version: 1 }), saveConflictCopy: async () => ({ id: asId<"DocumentId">("c"), fileName: "k" }) };
     const q = new UploadQueue(await qdir(), deps, async () => "Bearer FRESH");
     await q.enqueue({ uploadUrl: "http://s/u/2", fileName: "a", bytes: new TextEncoder().encode("x"), authHeader: "Bearer BROWSER" });
     await q.drainOnce();

--- a/helper-ui/test/open.test.ts
+++ b/helper-ui/test/open.test.ts
@@ -3,6 +3,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, describe, expect, test } from "bun:test";
 
+import { asId } from "@/lib/shared/schemas/ids";
+
 import { ContentStore } from "../src/engine/content-store.ts";
 import type { UploadTarget } from "../src/engine/document-source.ts";
 import { enqueueSavedFile, handleOpen, persistDownloaded, restoreCached, type OpenDeps } from "../src/engine/open.ts";
@@ -261,7 +263,7 @@ describe("enqueueSavedFile", () => {
     await writeFile(filePath, "ändrat innehåll", "utf8");
 
     const queue = new UploadQueue(qdir);
-    await enqueueSavedFile(queue, filePath, { document: { id: "doc-7", trpcUrl: "http://s/api/trpc" }, baseVersion: 4 }, "Bearer tok");
+    await enqueueSavedFile(queue, filePath, { document: { id: asId<"DocumentId">("doc-7"), trpcUrl: "http://s/api/trpc" }, baseVersion: 4 }, "Bearer tok");
 
     const snap = queue.snapshot();
     expect(snap.total).toBe(1);

--- a/helper-ui/test/queue.test.ts
+++ b/helper-ui/test/queue.test.ts
@@ -11,6 +11,8 @@ import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 
 import superjson from "superjson";
 
+import { asId, type DocumentId } from "@/lib/shared/schemas/ids";
+
 import { backoffMs, conflictLabel, defaultQueueDeps, UploadQueue, type QueueDeps } from "../src/engine/queue.ts";
 import type { UploadDocResult } from "../src/engine/trpc-client.ts";
 
@@ -61,10 +63,10 @@ function fakeDeps(
   };
   const saveConflictCopy = async (
     document: { id: string; trpcUrl: string }, body: Uint8Array, _auth: string | undefined, label: string,
-  ): Promise<{ id: string; fileName: string }> => {
+  ): Promise<{ id: DocumentId; fileName: string }> => {
     if (saveCopyFails) throw new Error("offline");
     conflictCopies.push({ document, body, label });
-    return { id: `copy-${document.id}`, fileName: `kopia (din ändring ${label})` };
+    return { id: asId<"DocumentId">(`copy-${document.id}`), fileName: `kopia (din ändring ${label})` };
   };
   return {
     deps: { now: () => t, newId: () => `id-${++n}`, put, uploadDoc, saveConflictCopy },
@@ -129,7 +131,7 @@ describe("UploadQueue.peekByKey (ADR 0032 local-first)", () => {
   test("returnerar köade bytes för dokumentet (osynkad lokal ändring)", async () => {
     const { deps } = fakeDeps([200]);
     const q = new UploadQueue(dir, deps);
-    await q.enqueue({ document: { id: "d1", trpcUrl: "x" }, fileName: "a.docx", bytes: bytes("EDIT") });
+    await q.enqueue({ document: { id: asId<"DocumentId">("d1"), trpcUrl: "x" }, fileName: "a.docx", bytes: bytes("EDIT") });
     const got = await q.peekByKey("doc:d1");
     expect(got).not.toBeNull();
     expect(new TextDecoder().decode(got!)).toBe("EDIT");
@@ -162,7 +164,7 @@ describe("UploadQueue.drainOnce", () => {
   test("document-mål → uploadDoc (tRPC), raderar posten (ADR 0031 write-back)", async () => {
     const f = fakeDeps([200]);
     const q = new UploadQueue(dir, f.deps);
-    await q.enqueue({ document: { id: "d1", trpcUrl: "http://s/api/trpc" }, fileName: "a.docx", bytes: bytes("data"), authHeader: "Bearer t" });
+    await q.enqueue({ document: { id: asId<"DocumentId">("d1"), trpcUrl: "http://s/api/trpc" }, fileName: "a.docx", bytes: bytes("data"), authHeader: "Bearer t" });
 
     const res = await q.drainOnce();
     expect(res.uploaded).toBe(1);
@@ -175,7 +177,7 @@ describe("UploadQueue.drainOnce", () => {
   test("bär baseVersion till uploadDoc + persisterar den på posten (ADR 0033 §1)", async () => {
     const f = fakeDeps([200]);
     const q = new UploadQueue(dir, f.deps);
-    await q.enqueue({ document: { id: "d1", trpcUrl: "http://s/api/trpc" }, fileName: "a.docx", bytes: bytes("v1"), baseVersion: 5 });
+    await q.enqueue({ document: { id: asId<"DocumentId">("d1"), trpcUrl: "http://s/api/trpc" }, fileName: "a.docx", bytes: bytes("v1"), baseVersion: 5 });
     // Posten bär basversionen (durabelt) innan den dräneras.
     expect(q.snapshot().entries[0]).toMatchObject({ baseVersion: 5 });
     await q.drainOnce();
@@ -185,7 +187,7 @@ describe("UploadQueue.drainOnce", () => {
   test("framskriver basen från lyckad upload → andra save self-konflikt:ar inte", async () => {
     const f = fakeDeps([200]);
     const q = new UploadQueue(dir, f.deps);
-    const target = { document: { id: "d1", trpcUrl: "http://s/api/trpc" }, fileName: "a.docx" };
+    const target = { document: { id: asId<"DocumentId">("d1"), trpcUrl: "http://s/api/trpc" }, fileName: "a.docx" };
     // Save 1: base 5 → server bekräftar v6 (fakeDeps: version = base+1).
     await q.enqueue({ ...target, bytes: bytes("v1"), baseVersion: 5 });
     await q.drainOnce();
@@ -199,7 +201,7 @@ describe("UploadQueue.drainOnce", () => {
   test("document-konflikt (409) → keep-both: materialiserar syskon-kopia + markerar conflict", async () => {
     const f = fakeDeps([200], false, true); // uploadDoc → conflict
     const q = new UploadQueue(dir, f.deps);
-    await q.enqueue({ document: { id: "d1", trpcUrl: "http://s/api/trpc" }, fileName: "a.docx", bytes: bytes("min"), baseVersion: 3 });
+    await q.enqueue({ document: { id: asId<"DocumentId">("d1"), trpcUrl: "http://s/api/trpc" }, fileName: "a.docx", bytes: bytes("min"), baseVersion: 3 });
     expect((await q.drainOnce()).conflicted).toBe(1);
     expect(q.snapshot()).toMatchObject({ pending: 0, conflict: 1 });
     // Användarens bytes sparades som en separat kopia (inget förlorat).
@@ -213,7 +215,7 @@ describe("UploadQueue.drainOnce", () => {
   test("keep-both materialisering misslyckas (offline) → failed, retr:as (bytsen säkra)", async () => {
     const f = fakeDeps([200], false, true, true); // conflict + saveConflictCopy kastar
     const q = new UploadQueue(dir, f.deps);
-    await q.enqueue({ document: { id: "d1", trpcUrl: "http://s/api/trpc" }, fileName: "a.docx", bytes: bytes("min"), baseVersion: 3 });
+    await q.enqueue({ document: { id: asId<"DocumentId">("d1"), trpcUrl: "http://s/api/trpc" }, fileName: "a.docx", bytes: bytes("min"), baseVersion: 3 });
     expect((await q.drainOnce()).failed).toBe(1);
     const entry = q.snapshot().entries[0]!;
     expect(entry.status).toBe("pending"); // kvar för retry
@@ -224,7 +226,7 @@ describe("UploadQueue.drainOnce", () => {
   test("återställd post seedar om den framskrivande basen (omstart-durabilitet)", async () => {
     const f = fakeDeps([200]);
     const q1 = new UploadQueue(dir, f.deps);
-    await q1.enqueue({ document: { id: "d1", trpcUrl: "http://s/api/trpc" }, fileName: "a.docx", bytes: bytes("v1"), baseVersion: 9 });
+    await q1.enqueue({ document: { id: asId<"DocumentId">("d1"), trpcUrl: "http://s/api/trpc" }, fileName: "a.docx", bytes: bytes("v1"), baseVersion: 9 });
     // Simulera omstart: ny kö läser posten från disk.
     const q2 = new UploadQueue(dir, f.deps);
     await q2.recover();
@@ -235,7 +237,7 @@ describe("UploadQueue.drainOnce", () => {
   test("document-upload kastar → failed, behålls för retry", async () => {
     const f = fakeDeps([200], true); // uploadDoc kastar
     const q = new UploadQueue(dir, f.deps);
-    await q.enqueue({ document: { id: "d1", trpcUrl: "http://s/api/trpc" }, fileName: "a.docx", bytes: bytes("x") });
+    await q.enqueue({ document: { id: asId<"DocumentId">("d1"), trpcUrl: "http://s/api/trpc" }, fileName: "a.docx", bytes: bytes("x") });
     expect((await q.drainOnce()).failed).toBe(1);
     const entry = q.snapshot().entries[0]!;
     expect(entry.status).toBe("pending");
@@ -412,7 +414,7 @@ describe("defaultQueueDeps", () => {
       });
     }) as typeof fetch;
     try {
-      const result = await defaultQueueDeps.uploadDoc({ id: "d1", trpcUrl: "http://s/api/trpc" }, bytes("x"), "Bearer t", 3);
+      const result = await defaultQueueDeps.uploadDoc({ id: asId<"DocumentId">("d1"), trpcUrl: "http://s/api/trpc" }, bytes("x"), "Bearer t", 3);
       expect(result).toEqual({ status: "ok", version: 4 });
       expect(calls[0]!.url).toContain("/api/trpc");
       expect(calls[0]!.url).toContain("document.uploadContent");

--- a/helper-ui/test/trpc-client.test.ts
+++ b/helper-ui/test/trpc-client.test.ts
@@ -8,6 +8,8 @@
 import { describe, expect, test } from "bun:test";
 import superjson from "superjson";
 
+import { asId } from "@/lib/shared/schemas/ids";
+
 import {
   createDocumentClient,
   documentTrpcEndpoint,
@@ -112,7 +114,7 @@ describe("saveConflictCopyBytes (ADR 0033 §4 — keep-both)", () => {
       },
     });
     const copy = await saveConflictCopyBytes(client, "doc-1", new TextEncoder().encode("min"), "2026-06-22 14:32");
-    expect(copy).toEqual({ id: "copy-1", fileName: "Avtal (din ändring 2026-06-22 14:32).docx" });
+    expect(copy).toEqual({ id: asId<"DocumentId">("copy-1"), fileName: "Avtal (din ändring 2026-06-22 14:32).docx" });
     expect(url).toContain("document.saveConflictCopy");
     expect(body).toContain("\"label\"");
   });

--- a/src/lib/client/firma/open-document-externally.ts
+++ b/src/lib/client/firma/open-document-externally.ts
@@ -23,6 +23,7 @@ import { loadFirmaConfig } from "@/lib/client/firma/firma-config";
 import { openViaHelper } from "@/lib/client/helper/use-helper";
 import type { HelperOpenRequest } from "@/lib/shared/helper/protocol";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
+import { asId } from "@/lib/shared/schemas/ids";
 
 /** Runtime-tier-beslut (ej bygg-tids-NEXT_PUBLIC_DEMO_BUILD, som är sant även i
  *  den lokala self-hosted-builden → länkade fel till GH Pages). Se #651. */
@@ -71,7 +72,7 @@ export async function tryHelperOpen(doc: Doc, opts: OpenOpts = {}): Promise<Open
     ? { fileName: doc.fileName, downloadUrl: demoUrl(doc) }
     : {
         fileName: doc.fileName,
-        document: { id: doc.id, trpcUrl: helperTrpcUrl() },
+        document: { id: asId<"DocumentId">(doc.id), trpcUrl: helperTrpcUrl() },
         ...(opts.forceEdit ? { forceEdit: true } : {}),
         ...(opts.readOnly ? { readOnly: true } : {}),
       };

--- a/src/lib/client/firma/open-matter-document.ts
+++ b/src/lib/client/firma/open-matter-document.ts
@@ -15,6 +15,7 @@
  */
 
 import { loadFirmaConfig } from "@/lib/client/firma/firma-config";
+import { asId } from "@/lib/shared/schemas/ids";
 
 export type OpenableDoc = { id: string; storagePath?: string | null; fileName?: string };
 
@@ -36,7 +37,7 @@ export async function openMatterDocument(doc: OpenableDoc): Promise<void> {
       // Föredra helpern (durabelt, offline-ok, samma lokala lager som extern-
       // editor-öppning) → annars server-vägen + IndexedDB-cache (ADR 0028 §5).
       // Server-tier: helpern hämtar via tRPC document.downloadContent (ADR 0031).
-      const viaHelper = await fetchContentViaHelper({ document: { id: doc.id, trpcUrl }, fileName });
+      const viaHelper = await fetchContentViaHelper({ document: { id: asId<"DocumentId">(doc.id), trpcUrl }, fileName });
       if (viaHelper) return new Blob([viaHelper as BlobPart], { type: mimeFromName(fileName) });
       return loadDocumentBlob(client, { id: doc.id, storagePath: doc.storagePath ?? null, fileName });
     };

--- a/src/lib/shared/helper/protocol.ts
+++ b/src/lib/shared/helper/protocol.ts
@@ -11,6 +11,8 @@
  * kod-/arkitektur-regler, så helpern kan dela typer rakt av (#78).
  */
 
+import type { DocumentId } from "@/lib/shared/schemas/ids";
+
 /** Porten helpern lyssnar på (127.0.0.1). Aldrig extern. */
 export const HELPER_PORT = 48761;
 
@@ -39,7 +41,7 @@ export const HELPER_PING_PREFIX = "ava-helper";
  */
 export interface HelperDocumentRef {
   /** Dokumentets id (input till `document.downloadContent`/`uploadContent`). */
-  id: string;
+  id: DocumentId;
   /** Serverns tRPC-endpoint, t.ex. `http://localhost:8080/api/trpc`. */
   trpcUrl: string;
 }
@@ -181,7 +183,7 @@ export interface HelperSyncEntry {
    * version som ett syskon-dokument — här id+namn så UI kan säga på klarspråk
    * "din version sparades som <fileName>". Satt först när kopian skapats.
    */
-  conflictCopy?: { id: string; fileName: string };
+  conflictCopy?: { id: DocumentId; fileName: string };
   /** Senaste felet (om något). */
   lastError?: string;
 }

--- a/test/unit/lib/helper/use-helper.test.tsx
+++ b/test/unit/lib/helper/use-helper.test.tsx
@@ -21,6 +21,7 @@ import {
   HELPER_BASE_OVERRIDE_KEY,
 } from "@/lib/client/helper/use-helper";
 import type { HelperStatusResponse, HelperSyncEntry } from "@/lib/shared/helper/protocol";
+import { asId } from "@/lib/shared/schemas/ids";
 
 const HTTPS = "https://localhost:48762";
 const HTTP = "http://127.0.0.1:48761";
@@ -261,9 +262,9 @@ describe("docSyncStatusMap", () => {
 
   it("mappar document.id → status; hoppar över poster utan document (demo/PUT)", () => {
     const m = docSyncStatusMap(status([
-      { document: { id: "a", trpcUrl: "x" }, status: "pending" },
+      { document: { id: asId<"DocumentId">("a"), trpcUrl: "x" }, status: "pending" },
       { uploadUrl: "http://s/u", status: "pending" }, // demo → ingen doc-id → hoppas
-      { document: { id: "b", trpcUrl: "x" }, status: "conflict" },
+      { document: { id: asId<"DocumentId">("b"), trpcUrl: "x" }, status: "conflict" },
     ]));
     expect(m.get("a")).toBe("pending");
     expect(m.get("b")).toBe("conflict");
@@ -272,8 +273,8 @@ describe("docSyncStatusMap", () => {
 
   it("conflict prioriteras över pending för samma dokument", () => {
     const m = docSyncStatusMap(status([
-      { document: { id: "a", trpcUrl: "x" }, status: "pending" },
-      { document: { id: "a", trpcUrl: "x" }, status: "conflict" },
+      { document: { id: asId<"DocumentId">("a"), trpcUrl: "x" }, status: "pending" },
+      { document: { id: asId<"DocumentId">("a"), trpcUrl: "x" }, status: "conflict" },
     ]));
     expect(m.get("a")).toBe("conflict");
   });
@@ -287,8 +288,8 @@ describe("advanceSyncTracker + syncBadgeMap (transient 'synkad')", () => {
     })) as HelperSyncEntry[];
     return { pending: 0, conflict: 0, total: full.length, entries: full };
   }
-  const docPending = (id: string) => ({ document: { id, trpcUrl: "x" }, status: "pending" as const });
-  const docConflict = (id: string) => ({ document: { id, trpcUrl: "x" }, status: "conflict" as const });
+  const docPending = (id: string) => ({ document: { id: asId<"DocumentId">(id), trpcUrl: "x" }, status: "pending" as const });
+  const docConflict = (id: string) => ({ document: { id: asId<"DocumentId">(id), trpcUrl: "x" }, status: "conflict" as const });
 
   it("pending → borta = 'synced' (transient), pending/conflict speglas", () => {
     let t = emptySyncTracker();


### PR DESCRIPTION
ID-brandning (B4, #750) — helper-protokollets dokument-id:n (rotfixen från ursprungs-audit:en).

- **protocol.ts** — `HelperDocumentRef.id` + `HelperSyncEntry.conflictCopy.id` → `DocumentId` (delas av web-appen + helper-motorn). `HelperSyncEntry.id` förblir `string` (intern kö-katalog-id, `crypto.randomUUID` — ej domän-id).
- **Kaskad:** `trpc-client` `ConflictCopy.id` → `DocumentId` (källa → fixar `queue.handleConflict`); web-klienterna (`open-document-externally`/`open-matter-document`) wrappar `doc.id` (loose view-model) med `asId` vid descriptor-bygget; helper- + web-test-fixtures brandade.

Inga typer försvagade. Verifierat rent i **alla tre tsc-projekt** (root / test / helper-ui), helper-svit (299) + web-helper-tester (39) gröna.

→ Med detta är ID-brandnings-fasen (B0–B4) i allt väsentligt klar: repo-bas + alla repo-grupper + router-inputs + Principal + helper-protokoll brandade.

Refs #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)