### PR TITLE
refactor(client): branda id-props i faktura- + ärende-detalj-vyerna (B3a)

### DIFF
--- a/src/app/invoices/[id]/_client.tsx
+++ b/src/app/invoices/[id]/_client.tsx
@@ -15,6 +15,7 @@ import { formatCurrency } from "@/lib/client/utils";
 import type { AppRouter } from "@/lib/server/routers/_app";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { computeMatterSettlement, computeRadgivningsavgift, type MatterSettlement } from "@/lib/shared/rattshjalp";
+import { asId } from "@/lib/shared/schemas/ids";
 import { computeInvoiceLedger } from "@/lib/shared/write-off-calc";
 import { CreditModal } from "./_credit-modal";
 import { DispatchHistory } from "./_dispatch-history";
@@ -96,7 +97,7 @@ function invoiceLedger(inv: Inv): LedgerView {
 
 export default function InvoiceDetailClient({ id: paramId }: { id: string }) {
   // Static export: sentinel-shell för nya id:n → läs riktiga id:t ur URL:en.
-  const id = useRouteId() ?? paramId;
+  const id = asId<"InvoiceId">(useRouteId() ?? paramId);
   const invoice = trpc.invoice.getById.useQuery({ id });
   const s = useInvoiceDetail(id);
 

--- a/src/app/invoices/[id]/_credit-modal.tsx
+++ b/src/app/invoices/[id]/_credit-modal.tsx
@@ -2,14 +2,15 @@
 
 import { useId, useState } from "react";
 import { formatCurrency } from "@/lib/client/utils";
+import type { InvoiceId } from "@/lib/shared/schemas/ids";
 
 interface Props {
-  invoiceId: string;
+  invoiceId: InvoiceId;
   amount: number;
   hasActivePlan: boolean;
   isPending: boolean;
   error: string | null;
-  onSubmit: (data: { invoiceId: string; notes?: string }) => void;
+  onSubmit: (data: { invoiceId: InvoiceId; notes?: string }) => void;
   onClose: () => void;
 }
 

--- a/src/app/invoices/[id]/_dispatch-history.tsx
+++ b/src/app/invoices/[id]/_dispatch-history.tsx
@@ -7,6 +7,7 @@
  */
 
 import { trpc } from "@/lib/client/trpc";
+import type { InvoiceId } from "@/lib/shared/schemas/ids";
 
 const CHANNEL_LABEL: Record<string, string> = {
   email: "E-post",
@@ -41,7 +42,7 @@ interface DispatchRow {
   error?: string | null;
 }
 
-export function DispatchHistory({ invoiceId }: { invoiceId: string }) {
+export function DispatchHistory({ invoiceId }: { invoiceId: InvoiceId }) {
   const dispatches = trpc.invoiceDispatch.list.useQuery({ invoiceId });
   const rows = (dispatches.data ?? []) as DispatchRow[];
 

--- a/src/app/invoices/[id]/_payment-modal.tsx
+++ b/src/app/invoices/[id]/_payment-modal.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useId, useState } from "react";
+import type { InvoiceId } from "@/lib/shared/schemas/ids";
 
 interface Props {
-  invoiceId: string;
+  invoiceId: InvoiceId;
   isPending: boolean;
   error: string | null;
-  onSubmit: (data: { invoiceId: string; amount: number; paidAt: string; note?: string }) => void;
+  onSubmit: (data: { invoiceId: InvoiceId; amount: number; paidAt: string; note?: string }) => void;
   onClose: () => void;
 }
 

--- a/src/app/invoices/[id]/_plan-modal.tsx
+++ b/src/app/invoices/[id]/_plan-modal.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { useId, useState } from "react";
+import type { InvoiceId } from "@/lib/shared/schemas/ids";
 
 interface Props {
-  invoiceId: string;
+  invoiceId: InvoiceId;
   isPending: boolean;
   error: string | null;
   onSubmit: (data: {
-    invoiceId: string;
+    invoiceId: InvoiceId;
     monthlyAmount: number;
     dayOfMonth: number;
     startDate: string;

--- a/src/app/invoices/[id]/_send-invoice-modal.tsx
+++ b/src/app/invoices/[id]/_send-invoice-modal.tsx
@@ -17,9 +17,10 @@ import { useHelper, composeMailViaHelper } from "@/lib/client/helper/use-helper"
 import { renderFakturaPdf } from "@/lib/client/kostnadsrakning/render-faktura-pdf";
 import { trpc } from "@/lib/client/trpc";
 import { formatCurrency } from "@/lib/client/utils";
+import type { InvoiceId } from "@/lib/shared/schemas/ids";
 
 export interface SendInvoiceModalProps {
-  invoiceId: string;
+  invoiceId: InvoiceId;
   invoiceNumber?: string | null | undefined;
   amount: number;
   ocrReference?: string | null | undefined;

--- a/src/app/invoices/[id]/_write-off-modal.tsx
+++ b/src/app/invoices/[id]/_write-off-modal.tsx
@@ -6,14 +6,15 @@
  */
 
 import { useId, useState } from "react";
+import type { InvoiceId } from "@/lib/shared/schemas/ids";
 
 interface Props {
-  invoiceId: string;
+  invoiceId: InvoiceId;
   /** Utestående i öre — default-belopp för avskrivningen. */
   outstanding: number;
   isPending: boolean;
   error: string | null;
-  onSubmit: (data: { invoiceId: string; amount: number; reason?: string; writtenOffAt: string }) => void;
+  onSubmit: (data: { invoiceId: InvoiceId; amount: number; reason?: string; writtenOffAt: string }) => void;
   onClose: () => void;
 }
 

--- a/src/app/matters/[id]/_billing-dialog.tsx
+++ b/src/app/matters/[id]/_billing-dialog.tsx
@@ -20,6 +20,7 @@ import {
 import { trpc } from "@/lib/client/trpc";
 import { formatCurrency } from "@/lib/client/utils";
 import { proposedAccontoOre } from "@/lib/shared/billing-proposal";
+import type { MatterId } from "@/lib/shared/schemas/ids";
 
 interface AccontoRow { id: string; amountOre: number; recipient: string }
 
@@ -32,7 +33,7 @@ export interface BillingMeta {
 }
 
 interface Props {
-  matterId: string;
+  matterId: MatterId;
   type: "ACCONTO" | "FINAL";
   existingAccontos: AccontoRow[];
   meta: BillingMeta;
@@ -54,7 +55,7 @@ function titleFor(type: string): string {
 }
 
 /** Återanvändbar doc-generator: lägg ett faktura-PDF-dokument i fil-listan. */
-function useFakturaDoc(matterId: string, meta: BillingMeta): (invoice: FakturaDocInvoice) => Promise<void> {
+function useFakturaDoc(matterId: MatterId, meta: BillingMeta): (invoice: FakturaDocInvoice) => Promise<void> {
   const register = trpc.document.register.useMutation();
   const utils = trpc.useUtils();
   const docMeta: FakturaDocMeta = {
@@ -70,7 +71,7 @@ function useFakturaDoc(matterId: string, meta: BillingMeta): (invoice: FakturaDo
   };
 }
 
-function AccontoForm({ matterId, meta, onDone }: { matterId: string; meta: BillingMeta; onDone: () => void }) {
+function AccontoForm({ matterId, meta, onDone }: { matterId: MatterId; meta: BillingMeta; onDone: () => void }) {
   const proposal = trpc.billingRun.proposal.useQuery({ matterId });
   const workValueOre = proposal.data?.workValueOre ?? 0;
   const priorOre = proposal.data?.priorAccontoSumOre ?? 0;
@@ -126,7 +127,7 @@ function Stat({ label, value, strong }: { label: string; value: number; strong?:
   );
 }
 
-function FinalForm({ matterId, meta, accontos, onDone }: { matterId: string; meta: BillingMeta; accontos: AccontoRow[]; onDone: () => void }) {
+function FinalForm({ matterId, meta, accontos, onDone }: { matterId: MatterId; meta: BillingMeta; accontos: AccontoRow[]; onDone: () => void }) {
   const proposal = trpc.billingRun.proposal.useQuery({ matterId });
   const [recipient, setRecipient] = useState<"KLIENT" | "FORSAKRING" | "RATTSHJALPSMYNDIGHET">("KLIENT");
   const [selected, setSelected] = useState<string[]>(accontos.map((a) => a.id));

--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -22,6 +22,7 @@ import type { AppRouter } from "@/lib/server/routers/_app";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { computeRadgivningsavgift } from "@/lib/shared/rattshjalp";
 import { BILLING_RUN_TYPE_LABELS, BILLING_RUN_STATUS_LABELS, type BillingRunRecipient, type BillingRunStatus, type BillingRunType, type PaymentMethod } from "@/lib/shared/schemas/enums";
+import type { BillingRunId, InvoiceId, MatterId } from "@/lib/shared/schemas/ids";
 import { BillingDialog, type BillingMeta } from "./_billing-dialog";
 import { KostnadsrakningModal } from "./_kostnadsrakning-modal";
 import { VerdictDialog } from "./_verdict-dialog";
@@ -39,26 +40,26 @@ interface MatterContext {
 }
 
 interface Props {
-  matterId: string;
+  matterId: MatterId;
   matter: MatterContext;
 }
 
 interface BillingRunRow {
-  id: string;
+  id: BillingRunId;
   type: BillingRunType;
   status: BillingRunStatus;
   recipient: BillingRunRecipient;
   amountOre: number;
   createdAt: string | Date;
-  invoiceId?: string | null;
-  invoice?: { id: string; invoiceNumber?: string | null } | null;
+  invoiceId?: InvoiceId | null;
+  invoice?: { id: InvoiceId; invoiceNumber?: string | null } | null;
 }
 
 interface KrDocInfo { id: string; fileName: string }
 
 type DocumentListOutput = inferRouterOutputs<AppRouter>["document"]["list"];
 
-function findKrDocument(matterId: string, run: BillingRunRow): KrDocInfo | null {
+function findKrDocument(matterId: MatterId, run: BillingRunRow): KrDocInfo | null {
   const docs: DocumentListOutput | undefined = trpc.document.list.useQuery({ matterId, folderId: null, pageSize: 100 }).data;
   const list = docs?.documents ?? [];
   const kostn = list.filter((d) => d.documentType === "Kostnadsräkning");
@@ -90,7 +91,7 @@ function openKrDocument(doc: KrDocInfo): void {
   );
 }
 
-function PendingVerdictBanner({ matterId, run, onClick }: { matterId: string; run: BillingRunRow; onClick: () => void }) {
+function PendingVerdictBanner({ matterId, run, onClick }: { matterId: MatterId; run: BillingRunRow; onClick: () => void }) {
   const doc = findKrDocument(matterId, run);
   return (
     <div className="mx-6 my-3 rounded border border-amber-300 bg-amber-50 px-4 py-3 flex flex-col sm:flex-row sm:items-center justify-between gap-2">
@@ -135,9 +136,9 @@ function courtOf(matter: MatterContext): string | undefined {
 }
 
 interface DialogsProps {
-  matterId: string; matter: MatterContext; rows: BillingRunRow[];
+  matterId: MatterId; matter: MatterContext; rows: BillingRunRow[];
   dialog: DialogState; setDialog: (s: DialogState) => void;
-  verdictRunId: string | null; setVerdictRunId: (id: string | null) => void;
+  verdictRunId: BillingRunId | null; setVerdictRunId: (id: BillingRunId | null) => void;
   onRefetch: () => void;
 }
 
@@ -170,7 +171,7 @@ function BillingDialogs({ matterId, matter, rows, dialog, setDialog, verdictRunI
 }
 
 interface KrTriggerProps {
-  matterId: string;
+  matterId: MatterId;
   matter: MatterContext;
   open: boolean;
   onClose: () => void;
@@ -198,7 +199,7 @@ function orgProps(org: { name?: string | null | undefined; orgNumber?: string | 
   return omitUndefined({ name, orgNumber, address });
 }
 
-function useKrModalData(matterId: string): KrModalData {
+function useKrModalData(matterId: MatterId): KrModalData {
   const me = trpc.user.current.useQuery().data;
   const org = orgProps(trpc.organization.getSettings.useQuery().data ?? undefined);
   const expenses = trpc.expense.list.useQuery({ matterId }).data?.expenses ?? [];
@@ -246,7 +247,7 @@ export function BillingPanel({ matterId, matter }: Props) {
   useMatterInvariants({ matterId, matterNumber: matter.matterNumber });
   const [dialog, setDialog] = useState<DialogState>("NONE");
   const [showKr, setShowKr] = useState(false);
-  const [verdictRunId, setVerdictRunId] = useState<string | null>(null);
+  const [verdictRunId, setVerdictRunId] = useState<BillingRunId | null>(null);
   const rows = (runs.data?.runs ?? []) as BillingRunRow[];
   const pending = findPendingVerdict(rows);
   const refetch = () => { void runs.refetch(); };
@@ -281,7 +282,7 @@ export function BillingPanel({ matterId, matter }: Props) {
 
 /** Rättshjälp (#383): registrera klientens betalda rådgivningstimme som en
  *  separat klientfaktura. Self-gating — null för icke-rättshjälpsärenden. */
-function RadgivningBanner({ matterId, matter, onRecorded }: { matterId: string; matter: MatterContext; onRecorded: () => void }) {
+function RadgivningBanner({ matterId, matter, onRecorded }: { matterId: MatterId; matter: MatterContext; onRecorded: () => void }) {
   const create = trpc.invoice.createRadgivning.useMutation({ onSuccess: onRecorded });
   if (matter.paymentMethod !== "RATTSHJALP") return null;
   const hasFTaxArg = omitUndefined({ hasFTax: matter.taxaHasFTax ?? undefined });
@@ -310,7 +311,7 @@ function RadgivningBanner({ matterId, matter, onRecorded }: { matterId: string; 
  * (exkl utlägg) + utlägg separat + totalt (inkl utlägg). Datan = billingRun.proposal
  * (ofrysta debiterbara poster). PRUTNING är redan exkluderad i proposal.
  */
-function UnbilledSummary({ matterId }: { matterId: string }) {
+function UnbilledSummary({ matterId }: { matterId: MatterId }) {
   const proposal = trpc.billingRun.proposal.useQuery({ matterId });
   const d = proposal.data;
   if (proposal.isLoading || !d) return null;

--- a/src/app/matters/[id]/_client.tsx
+++ b/src/app/matters/[id]/_client.tsx
@@ -12,6 +12,7 @@ import { useRouteId } from "@/lib/client/demo/use-route-id";
 import { useEagerCacheMatterDocuments } from "@/lib/client/firma/use-eager-cache-matter-documents";
 import { trpc } from "@/lib/client/trpc";
 import type { MatterRole, MatterStatus, PaymentMethod } from "@/lib/shared/schemas/enums";
+import { asId } from "@/lib/shared/schemas/ids";
 import { BillingPanel } from "./_billing-panel";
 import { ContactsSection } from "./_contacts-section";
 import { ExpectedReceivablesSection } from "./_expected-receivables-section";
@@ -38,7 +39,7 @@ function isCourtMatter(m: { paymentMethod?: PaymentMethod | null; isTaxeArende?:
 export default function MatterDetailClient({ id: paramId }: { id: string }) {
   // Static export serverar en sentinel-shell för nya id:n → läs riktiga
   // id:t ur URL:en (faller tillbaka till build-time-param i server-mode).
-  const id = useRouteId() ?? paramId;
+  const id = asId<"MatterId">(useRouteId() ?? paramId);
   const matter = trpc.matter.getById.useQuery({ id });
   const [showGenerateModal, setShowGenerateModal] = useState(false);
   // ADR 0028 §4a: öppna ärende → eager-cacha dess dokument-bytes (offline).

--- a/src/app/matters/[id]/_contacts-section.tsx
+++ b/src/app/matters/[id]/_contacts-section.tsx
@@ -5,6 +5,7 @@ import { DataTable, type Column } from "@/components/ui/data-table";
 import { EntityLink } from "@/lib/client/demo/entity-link";
 import { labelForMatterRole, matterRoleOptions, contactTypeOptions } from "@/lib/client/labels";
 import { trpc } from "@/lib/client/trpc";
+import type { MatterId } from "@/lib/shared/schemas/ids";
 
 type Contact = {
   id: string;
@@ -21,7 +22,7 @@ type MatterContact = {
 };
 
 interface Props {
-  matterId: string;
+  matterId: MatterId;
   contacts: MatterContact[];
 }
 
@@ -131,7 +132,7 @@ function ContactsList({
   contacts,
   onRemove,
 }: {
-  matterId: string;
+  matterId: MatterId;
   contacts: MatterContact[];
   onRemove: (matterContactId: string) => void;
 }) {
@@ -181,11 +182,11 @@ function ExistingContactForm({
   onSubmit,
   isPending,
 }: {
-  matterId: string;
+  matterId: MatterId;
   form: ExistingForm;
   setForm: (f: ExistingForm) => void;
   contacts: Array<{ id: string; name: string }>;
-  onSubmit: (data: ExistingForm & { matterId: string }) => void;
+  onSubmit: (data: ExistingForm & { matterId: MatterId }) => void;
   isPending: boolean;
 }) {
   return (
@@ -231,10 +232,10 @@ function NewContactForm({
   onSubmit,
   isPending,
 }: {
-  matterId: string;
+  matterId: MatterId;
   form: NewForm;
   setForm: (f: NewForm) => void;
-  onSubmit: (data: NewForm & { matterId: string }) => void;
+  onSubmit: (data: NewForm & { matterId: MatterId }) => void;
   isPending: boolean;
 }) {
   return (

--- a/src/app/matters/[id]/_expense-section.tsx
+++ b/src/app/matters/[id]/_expense-section.tsx
@@ -6,10 +6,11 @@ import { Modal } from "@/components/ui/modal";
 import { EntityLink } from "@/lib/client/demo/entity-link";
 import { trpc } from "@/lib/client/trpc";
 import { formatCurrency } from "@/lib/client/utils";
+import type { ExpenseId, InvoiceId, MatterId } from "@/lib/shared/schemas/ids";
 import { splitVat, VAT_RATES, VAT_RATE_LABELS, type VatRate } from "@/lib/shared/vat";
 
 interface Props {
-  matterId: string;
+  matterId: MatterId;
   isTaxeArende?: boolean;
 }
 
@@ -23,7 +24,7 @@ interface ExpenseForm {
 }
 
 interface Expense {
-  id: string;
+  id: ExpenseId;
   date: Date | string;
   amount: number;
   description: string;
@@ -31,8 +32,8 @@ interface Expense {
   user?: { name: string };
   vatRate?: number;
   vatIncluded?: boolean;
-  invoiceId?: string | null;
-  invoice?: { id: string; invoiceNumber?: string | null } | null;
+  invoiceId?: InvoiceId | null;
+  invoice?: { id: InvoiceId; invoiceNumber?: string | null } | null;
 }
 
 function initialForm(): ExpenseForm {
@@ -98,7 +99,7 @@ function isInvoiced(e: Expense): boolean {
 
 /** Tabell-kolumnerna för utläggslistan. Redigera/ta-bort låsta för
  *  fakturerade utlägg (de sitter på en utställd faktura). */
-function expenseColumns({ onEdit, onDelete }: { onEdit: (e: Expense) => void; onDelete: (id: string) => void }): Column<Expense>[] {
+function expenseColumns({ onEdit, onDelete }: { onEdit: (e: Expense) => void; onDelete: (id: ExpenseId) => void }): Column<Expense>[] {
   return [
     { key: "date", label: "Datum", sortable: true, filterable: true, sortValue: (e) => new Date(e.date),
       filterValue: (e) => new Date(e.date).toLocaleDateString("sv-SE"),
@@ -157,7 +158,7 @@ export function ExpenseSection({ matterId, isTaxeArende }: Props) {
   const utils = trpc.useUtils();
   const expenses = trpc.expense.list.useQuery({ matterId });
   const [showCreate, setShowCreate] = useState(false);
-  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<ExpenseId | null>(null);
   const [form, setForm] = useState<ExpenseForm>(initialForm);
 
   function resetClose(): void {

--- a/src/app/matters/[id]/_generate-modal.tsx
+++ b/src/app/matters/[id]/_generate-modal.tsx
@@ -8,12 +8,13 @@ import { labelForMatterRole } from "@/lib/client/labels";
 import { buildTemplateContext } from "@/lib/client/templates/build-template-context";
 import { trpc } from "@/lib/client/trpc";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
+import type { MatterId } from "@/lib/shared/schemas/ids";
 
 type Contact = { id: string; name: string; email?: string | null; phone?: string | null };
 type MatterContact = { id: string; role: string; contact: Contact };
 
 interface Props {
-  matterId: string;
+  matterId: MatterId;
   contacts: MatterContact[];
   onClose: () => void;
 }
@@ -21,7 +22,7 @@ interface Props {
 type Recipient = { name: string; email?: string | null; phone?: string | null };
 type GenMatter = { matterNumber: string; title: string; matterType?: string | null; contacts?: Array<{ role: string; contact: { name: string } }> };
 type GenOrg = { name: string; orgNumber?: string | null; address?: string | null; email?: string | null } | undefined;
-type RegisterDocInput = { id: string; matterId: string; fileName: string; mimeType: string; sizeBytes: number; storagePath: string };
+type RegisterDocInput = { id: string; matterId: MatterId; fileName: string; mimeType: string; sizeBytes: number; storagePath: string };
 
 interface GenerateArgs {
   templateId: string;
@@ -31,7 +32,7 @@ interface GenerateArgs {
   matter: GenMatter | undefined;
   org: GenOrg;
   contacts: MatterContact[];
-  matterId: string;
+  matterId: MatterId;
   registerDoc: (d: RegisterDocInput) => Promise<unknown>;
 }
 
@@ -49,7 +50,7 @@ function buildDocCtx(m: GenMatter, recipient: Recipient | null, org: GenOrg) {
 /** Rendera + öppna print-flik + skriv till FSA + registrera ETT dokument. */
 async function generateOneDoc(opts: {
   content: string; name: string; ctx: ReturnType<typeof buildTemplateContext>;
-  format: "pdf" | "docx"; recipient: Recipient | null; matterId: string;
+  format: "pdf" | "docx"; recipient: Recipient | null; matterId: MatterId;
   registerDoc: (d: RegisterDocInput) => Promise<unknown>;
 }): Promise<void> {
   const { content, name, ctx, format, recipient, matterId, registerDoc } = opts;

--- a/src/app/matters/[id]/_kostnadsrakning-modal.tsx
+++ b/src/app/matters/[id]/_kostnadsrakning-modal.tsx
@@ -29,9 +29,10 @@ import type { AppRouter } from "@/lib/server/routers/_app";
 import type { TaxaLevel } from "@/lib/shared/brottmalstaxa";
 import { buildKostnadsrakningContext } from "@/lib/shared/kostnadsrakning";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
+import type { MatterId } from "@/lib/shared/schemas/ids";
 
 interface Props {
-  matterId: string;
+  matterId: MatterId;
   matterNumber: string;
   matterTitle: string;
   clientName: string;
@@ -84,7 +85,7 @@ interface RecordDocOpts {
     };
   };
   docId: string;
-  matterId: string;
+  matterId: MatterId;
   fileName: string;
   storagePath: string;
   bytes: Uint8Array;

--- a/src/app/matters/[id]/_service-notes-section.tsx
+++ b/src/app/matters/[id]/_service-notes-section.tsx
@@ -9,9 +9,10 @@ import { NotebookPen, Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { DataTable, type Column } from "@/components/ui/data-table";
 import { trpc } from "@/lib/client/trpc";
+import type { MatterId, ServiceNoteId } from "@/lib/shared/schemas/ids";
 
 interface ServiceNote {
-  id: string;
+  id: ServiceNoteId;
   date: string;
   time: string;
   text: string;
@@ -39,7 +40,7 @@ function authorName(n: ServiceNote): string {
 /** Kolumnerna för tjänsteanteckningstabellen — en rad per anteckning, alla
  *  sorterbara/filterbara precis som övriga AVA-tabeller (#367). Anteckning-
  *  kolumnen wrappar lång text + en actions-kolumn med redigera/ta-bort (#375). */
-function noteColumns(opts: { onEdit: (n: ServiceNote) => void; onDelete: (id: string) => void }): Column<ServiceNote>[] {
+function noteColumns(opts: { onEdit: (n: ServiceNote) => void; onDelete: (id: ServiceNoteId) => void }): Column<ServiceNote>[] {
   return [
     { key: "date", label: "Datum", sortable: true, filterable: true,
       sortValue: (n) => n.date, filterValue: (n) => n.date,
@@ -72,7 +73,7 @@ function initialValues(initial?: ServiceNote | null): { date: string; time: stri
   return { date: n.date, time: n.time, text: "" };
 }
 
-export function ServiceNotesSection({ matterId }: { matterId: string }) {
+export function ServiceNotesSection({ matterId }: { matterId: MatterId }) {
   const utils = trpc.useUtils();
   const notes = trpc.serviceNote.list.useQuery({ matterId });
   const [adding, setAdding] = useState(false);
@@ -126,7 +127,7 @@ export function ServiceNotesSection({ matterId }: { matterId: string }) {
 }
 
 function NoteForm({ matterId, initial, onDone, onCancel }: {
-  matterId: string; initial?: ServiceNote | null; onDone: () => void; onCancel: () => void;
+  matterId: MatterId; initial?: ServiceNote | null; onDone: () => void; onCancel: () => void;
 }) {
   const start = initialValues(initial);
   const [date, setDate] = useState(start.date);

--- a/src/app/matters/[id]/_time-section.tsx
+++ b/src/app/matters/[id]/_time-section.tsx
@@ -5,9 +5,10 @@ import { DataTable, type Column } from "@/components/ui/data-table";
 import { Modal } from "@/components/ui/modal";
 import { trpc } from "@/lib/client/trpc";
 import { formatMinutes } from "@/lib/client/utils";
+import type { InvoiceId, MatterId, TimeEntryId } from "@/lib/shared/schemas/ids";
 
 interface Props {
-  matterId: string;
+  matterId: MatterId;
   isTaxeArende?: boolean;
 }
 
@@ -19,15 +20,15 @@ interface EditForm {
 }
 
 interface TimeEntryRow {
-  id: string;
+  id: TimeEntryId;
   date: Date | string;
   minutes: number;
   description: string | null;
   billable: boolean;
   hourlyRate?: number | null;
   user?: { name?: string | null } | null;
-  invoiceId?: string | null;
-  invoice?: { id: string; invoiceNumber?: string | null } | null;
+  invoiceId?: InvoiceId | null;
+  invoice?: { id: InvoiceId; invoiceNumber?: string | null } | null;
   createdAt?: Date | string | null;
   updatedAt?: Date | string | null;
 }
@@ -56,7 +57,7 @@ export function TimeSection({ matterId, isTaxeArende }: Props) {
   const utils = trpc.useUtils();
   const timeEntries = trpc.timeEntry.list.useQuery({ matterId });
   const [showCreate, setShowCreate] = useState(false);
-  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<TimeEntryId | null>(null);
   const [editForm, setEditForm] = useState<EditForm | null>(null);
   const [createForm, setCreateForm] = useState<EditForm>(emptyForm);
 
@@ -90,7 +91,7 @@ export function TimeSection({ matterId, isTaxeArende }: Props) {
     updateTimeEntry.mutate({ id: editingId, ...editForm });
   }
 
-  function confirmDelete(id: string): void {
+  function confirmDelete(id: TimeEntryId): void {
     if (confirm("Ta bort tidregistreringen?")) deleteTimeEntry.mutate({ id });
   }
 

--- a/src/app/matters/[id]/_verdict-dialog.tsx
+++ b/src/app/matters/[id]/_verdict-dialog.tsx
@@ -17,11 +17,12 @@ import { generateFakturaDoc } from "@/lib/client/kostnadsrakning/generate-faktur
 import { trpc } from "@/lib/client/trpc";
 import { formatCurrency } from "@/lib/client/utils";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
+import type { BillingRunId, MatterId } from "@/lib/shared/schemas/ids";
 
 interface Props {
-  billingRunId: string;
+  billingRunId: BillingRunId;
   workValueOre: number;
-  matterId: string;
+  matterId: MatterId;
   matterNumber: string;
   matterTitle: string;
   clientName?: string;

--- a/test/unit/app/dispatch-history.test.tsx
+++ b/test/unit/app/dispatch-history.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest-compat";
 import { DispatchHistory } from "@/app/invoices/[id]/_dispatch-history";
+import { asId } from "@/lib/shared/schemas/ids";
 
 const listQuery = { data: undefined as unknown[] | undefined, isLoading: false };
 
@@ -13,7 +14,7 @@ vi.mock("@/lib/client/trpc", () => ({
 describe("DispatchHistory", () => {
   it("visar tomt-läge när inga utskick finns", () => {
     listQuery.data = [];
-    render(<DispatchHistory invoiceId="inv-1" />);
+    render(<DispatchHistory invoiceId={asId<"InvoiceId">("inv-1")} />);
     expect(screen.getByText(/Inga utskick registrerade/)).toBeTruthy();
   });
 
@@ -22,7 +23,7 @@ describe("DispatchHistory", () => {
       { id: "d-1", channel: "email", recipient: "klient@x.se", status: "sent", queuedAt: "2026-06-01T10:00:00Z" },
       { id: "d-2", channel: "kivra", recipient: "199001011234", status: "failed", queuedAt: "2026-06-02T10:00:00Z", error: "okänd mottagare" },
     ];
-    render(<DispatchHistory invoiceId="inv-1" />);
+    render(<DispatchHistory invoiceId={asId<"InvoiceId">("inv-1")} />);
     expect(screen.getByText(/klient@x\.se/)).toBeTruthy();
     expect(screen.getByText(/Skickad/)).toBeTruthy();
     expect(screen.getByText(/Misslyckad/)).toBeTruthy();

--- a/test/unit/app/invoices/send-invoice-modal.test.tsx
+++ b/test/unit/app/invoices/send-invoice-modal.test.tsx
@@ -7,6 +7,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
 
 import { SendInvoiceModal } from "@/app/invoices/[id]/_send-invoice-modal";
+import { asId } from "@/lib/shared/schemas/ids";
 
 const recordMutate = vi.fn();
 const queueMutate = vi.fn();
@@ -31,7 +32,7 @@ vi.mock("@/lib/client/download-text", () => ({ downloadBytes: (...a: unknown[]) 
 vi.mock("@/lib/client/kostnadsrakning/render-faktura-pdf", () => ({ renderFakturaPdf: (...a: unknown[]) => renderFakturaPdf(...a) }));
 
 const baseProps = {
-  invoiceId: "inv-1",
+  invoiceId: asId<"InvoiceId">("inv-1"),
   invoiceNumber: "F-2026-0001",
   amount: 12_500,
   ocrReference: "1234567894",

--- a/test/unit/app/matters/billing-dialog.test.tsx
+++ b/test/unit/app/matters/billing-dialog.test.tsx
@@ -8,6 +8,7 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
 import { BillingDialog } from "@/app/matters/[id]/_billing-dialog";
+import { asId } from "@/lib/shared/schemas/ids";
 
 const accontoMutate = vi.fn();
 const finalMutate = vi.fn();
@@ -64,7 +65,7 @@ beforeEach(() => {
 
 describe("BillingDialog — ACCONTO (#397 avdragsmedvetet förslag)", () => {
   it("förfyller beloppet enligt formeln: 20 % × 5000 kr − 0 = 1000 kr", () => {
-    render(<BillingDialog matterId="m1" type="ACCONTO" existingAccontos={[]} meta={meta} onClose={() => {}} />);
+    render(<BillingDialog matterId={asId<"MatterId">("m1")} type="ACCONTO" existingAccontos={[]} meta={meta} onClose={() => {}} />);
     expect(screen.getByText("Aconto till klient")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Skapa aconto-faktura" }));
     expect(accontoMutate).toHaveBeenCalledWith({
@@ -77,13 +78,13 @@ describe("BillingDialog — ACCONTO (#397 avdragsmedvetet förslag)", () => {
       workValueOre: 500_000, priorAccontoSumOre: 60_000, // 600 kr tidigare
       timeEntries: [], expenses: [],
     };
-    render(<BillingDialog matterId="m1" type="ACCONTO" existingAccontos={[]} meta={meta} onClose={() => {}} />);
+    render(<BillingDialog matterId={asId<"MatterId">("m1")} type="ACCONTO" existingAccontos={[]} meta={meta} onClose={() => {}} />);
     fireEvent.click(screen.getByRole("button", { name: "Skapa aconto-faktura" }));
     expect(accontoMutate).toHaveBeenCalledWith(expect.objectContaining({ amountOre: 40_000 }));
   });
 
   it("procent → bips + omräknat förslag: 30 % → 3000 bips, 1500 kr", () => {
-    render(<BillingDialog matterId="m1" type="ACCONTO" existingAccontos={[]} meta={meta} onClose={() => {}} />);
+    render(<BillingDialog matterId={asId<"MatterId">("m1")} type="ACCONTO" existingAccontos={[]} meta={meta} onClose={() => {}} />);
     const [percent] = screen.getAllByRole("spinbutton");
     fireEvent.change(percent!, { target: { value: "30" } });
     fireEvent.click(screen.getByRole("button", { name: "Skapa aconto-faktura" }));
@@ -91,7 +92,7 @@ describe("BillingDialog — ACCONTO (#397 avdragsmedvetet förslag)", () => {
   });
 
   it("manuell justering av beloppet vinner över förslaget", () => {
-    render(<BillingDialog matterId="m1" type="ACCONTO" existingAccontos={[]} meta={meta} onClose={() => {}} />);
+    render(<BillingDialog matterId={asId<"MatterId">("m1")} type="ACCONTO" existingAccontos={[]} meta={meta} onClose={() => {}} />);
     const spin = screen.getAllByRole("spinbutton");
     fireEvent.change(spin[1]!, { target: { value: "750" } }); // belopp-fältet
     fireEvent.click(screen.getByRole("button", { name: "Skapa aconto-faktura" }));
@@ -100,7 +101,7 @@ describe("BillingDialog — ACCONTO (#397 avdragsmedvetet förslag)", () => {
 
   it("onSuccess genererar ett faktura-dokument", async () => {
     const onClose = vi.fn();
-    render(<BillingDialog matterId="m1" type="ACCONTO" existingAccontos={[]} meta={meta} onClose={onClose} />);
+    render(<BillingDialog matterId={asId<"MatterId">("m1")} type="ACCONTO" existingAccontos={[]} meta={meta} onClose={onClose} />);
     await accontoOnSuccess!({ invoice: { id: "inv-1", amount: 100_000 } });
     expect(renderFakturaPdf).toHaveBeenCalled();
     expect(registerMutateAsync).toHaveBeenCalledWith(expect.objectContaining({
@@ -118,7 +119,7 @@ describe("BillingDialog — FINAL", () => {
   ];
 
   it("visar de ofakturerade posterna + upparbetat värde", () => {
-    render(<BillingDialog matterId="m1" type="FINAL" existingAccontos={[]} meta={meta} onClose={() => {}} />);
+    render(<BillingDialog matterId={asId<"MatterId">("m1")} type="FINAL" existingAccontos={[]} meta={meta} onClose={() => {}} />);
     expect(screen.getByText(/Poster att fakturera \(2\/2 valda\)/)).toBeInTheDocument();
     expect(screen.getByText("Möte med klient")).toBeInTheDocument();
     expect(screen.getByText("Ansökningsavgift")).toBeInTheDocument();
@@ -127,12 +128,12 @@ describe("BillingDialog — FINAL", () => {
 
   it("visar tomtext när inga ofakturerade poster finns", () => {
     proposalData = { workValueOre: 0, priorAccontoSumOre: 0, timeEntries: [], expenses: [] };
-    render(<BillingDialog matterId="m1" type="FINAL" existingAccontos={[]} meta={meta} onClose={() => {}} />);
+    render(<BillingDialog matterId={asId<"MatterId">("m1")} type="FINAL" existingAccontos={[]} meta={meta} onClose={() => {}} />);
     expect(screen.getByText(/Inga ofakturerade poster/)).toBeInTheDocument();
   });
 
   it("default: alla aconton förvalda, submit drar av dem alla", () => {
-    render(<BillingDialog matterId="m1" type="FINAL" existingAccontos={accontos} meta={meta} onClose={() => {}} />);
+    render(<BillingDialog matterId={asId<"MatterId">("m1")} type="FINAL" existingAccontos={accontos} meta={meta} onClose={() => {}} />);
     expect(screen.getByText("Faktura")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Skapa faktura" }));
     expect(finalMutate).toHaveBeenCalledWith({
@@ -141,7 +142,7 @@ describe("BillingDialog — FINAL", () => {
   });
 
   it("avmarkera ett aconto → utesluts ur avdragen", () => {
-    render(<BillingDialog matterId="m1" type="FINAL" existingAccontos={accontos} meta={meta} onClose={() => {}} />);
+    render(<BillingDialog matterId={asId<"MatterId">("m1")} type="FINAL" existingAccontos={accontos} meta={meta} onClose={() => {}} />);
     const boxes = screen.getAllByRole("checkbox"); // [post te-1, post ex-1, aconto br-1, aconto br-2]
     fireEvent.click(boxes[2]!); // avmarkera br-1 (första aconto efter de 2 posterna)
     fireEvent.click(screen.getByRole("button", { name: "Skapa faktura" }));
@@ -149,7 +150,7 @@ describe("BillingDialog — FINAL", () => {
   });
 
   it("per-post-val: avmarkera en post → bara valda id:n i payloaden (#734)", () => {
-    render(<BillingDialog matterId="m1" type="FINAL" existingAccontos={[]} meta={meta} onClose={() => {}} />);
+    render(<BillingDialog matterId={asId<"MatterId">("m1")} type="FINAL" existingAccontos={[]} meta={meta} onClose={() => {}} />);
     const boxes = screen.getAllByRole("checkbox"); // [post te-1, post ex-1]
     fireEvent.click(boxes[1]!); // avmarkera utlägget ex-1
     fireEvent.click(screen.getByRole("button", { name: "Skapa faktura" }));
@@ -157,7 +158,7 @@ describe("BillingDialog — FINAL", () => {
   });
 
   it("default (inga poster avmarkerade) → inga post-id:n i payloaden (allt faktureras)", () => {
-    render(<BillingDialog matterId="m1" type="FINAL" existingAccontos={[]} meta={meta} onClose={() => {}} />);
+    render(<BillingDialog matterId={asId<"MatterId">("m1")} type="FINAL" existingAccontos={[]} meta={meta} onClose={() => {}} />);
     fireEvent.click(screen.getByRole("button", { name: "Skapa faktura" }));
     const call = finalMutate.mock.calls[0]![0] as Record<string, unknown>;
     expect(call.timeEntryIds).toBeUndefined();
@@ -165,7 +166,7 @@ describe("BillingDialog — FINAL", () => {
   });
 
   it("byt mottagare → skickas i payloaden", () => {
-    render(<BillingDialog matterId="m1" type="FINAL" existingAccontos={[]} meta={meta} onClose={() => {}} />);
+    render(<BillingDialog matterId={asId<"MatterId">("m1")} type="FINAL" existingAccontos={[]} meta={meta} onClose={() => {}} />);
     fireEvent.change(screen.getByRole("combobox"), { target: { value: "FORSAKRING" } });
     fireEvent.click(screen.getByRole("button", { name: "Skapa faktura" }));
     expect(finalMutate).toHaveBeenCalledWith(expect.objectContaining({ recipient: "FORSAKRING" }));
@@ -173,7 +174,7 @@ describe("BillingDialog — FINAL", () => {
 
   it("onSuccess genererar ett faktura-dokument", async () => {
     const onClose = vi.fn();
-    render(<BillingDialog matterId="m1" type="FINAL" existingAccontos={[]} meta={meta} onClose={onClose} />);
+    render(<BillingDialog matterId={asId<"MatterId">("m1")} type="FINAL" existingAccontos={[]} meta={meta} onClose={onClose} />);
     await finalOnSuccess!({ invoice: { id: "inv-7", amount: 590_000 } });
     expect(registerMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ id: "faktura-inv-7", invoiceId: "inv-7" }));
     await waitFor(() => expect(onClose).toHaveBeenCalled());

--- a/test/unit/app/matters/billing-panel.test.tsx
+++ b/test/unit/app/matters/billing-panel.test.tsx
@@ -11,6 +11,7 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
 import { BillingPanel } from "@/app/matters/[id]/_billing-panel";
+import { asId } from "@/lib/shared/schemas/ids";
 
 interface BillingRunRow {
   id: string; type: string; status: string; recipient: string;
@@ -91,14 +92,14 @@ beforeEach(() => {
 
 describe("BillingPanel — översikt", () => {
   it("renderar rubrik och tomtext utan runs", () => {
-    render(<BillingPanel matterId="m1" matter={baseMatter} />);
+    render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={baseMatter} />);
     expect(screen.getByText("Fakturering")).toBeInTheDocument();
     expect(screen.getByText("Inga billing-runs ännu.")).toBeInTheDocument();
   });
 
   it("visar laddtext medan runs hämtas", () => {
     runsLoading = true;
-    render(<BillingPanel matterId="m1" matter={baseMatter} />);
+    render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={baseMatter} />);
     expect(screen.getByText("Laddar…")).toBeInTheDocument();
   });
 
@@ -110,7 +111,7 @@ describe("BillingPanel — översikt", () => {
         { id: "r3", type: "KOSTNADSRAKNING", status: "PENDING_VERDICT", recipient: "DOMSTOL", amountOre: 50_000, createdAt: "2026-03-01" },
       ],
     };
-    render(<BillingPanel matterId="m1" matter={baseMatter} />);
+    render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={baseMatter} />);
     // Aconto = 1000 kr, Fakturerat = 2500 kr, Väntar = 500 kr. Varje belopp
     // syns två gånger (summa-kort + run-rad); Intl använder no-break-space
     // → matcha tolerant via regex + getAllByText.
@@ -136,7 +137,7 @@ describe("BillingPanel — Upparbetat ofakturerat", () => {
         { id: "e2", description: "Ej deb", amount: 10_000, billable: false },
       ],
     };
-    render(<BillingPanel matterId="m1" matter={baseMatter} />);
+    render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={baseMatter} />);
     expect(screen.getByText("Upparbetat ofakturerat")).toBeInTheDocument();
     // Arvode 1200,00 (bara billable), Utlägg 900,00, Total 2100,00.
     expect(screen.getByText(/1\s*200,00/)).toBeInTheDocument();
@@ -145,7 +146,7 @@ describe("BillingPanel — Upparbetat ofakturerat", () => {
   });
 
   it("visar tomtext när inget ofakturerat finns", () => {
-    render(<BillingPanel matterId="m1" matter={baseMatter} />);
+    render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={baseMatter} />);
     expect(screen.getByText("Upparbetat ofakturerat")).toBeInTheDocument();
     expect(screen.getByText(/Inget ofakturerat/)).toBeInTheDocument();
   });
@@ -161,7 +162,7 @@ describe("BillingPanel — pending verdict", () => {
   });
 
   it("visar banner och öppnar verdict-dialogen", () => {
-    render(<BillingPanel matterId="m1" matter={baseMatter} />);
+    render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={baseMatter} />);
     expect(screen.getByText(/Kostnadsräkning väntar på dom/)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /Ange dom \+ prutning/ }));
     expect(screen.getByTestId("verdict-dialog")).toBeInTheDocument();
@@ -170,7 +171,7 @@ describe("BillingPanel — pending verdict", () => {
   it("öppnar KR-dokumentet ur blob-cachen när det finns", () => {
     documentListData = { documents: [{ id: "doc-1", fileName: "kostnadsrakning.docx", documentType: "Kostnadsräkning", createdAt: "2026-03-01" }] };
     hasDoc = true;
-    render(<BillingPanel matterId="m1" matter={baseMatter} />);
+    render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={baseMatter} />);
     fireEvent.click(screen.getByRole("button", { name: "kostnadsrakning.docx" }));
     expect(openGeneratedDocFn).toHaveBeenCalledWith("doc-1");
   });
@@ -179,7 +180,7 @@ describe("BillingPanel — pending verdict", () => {
     documentListData = { documents: [{ id: "doc-1", fileName: "kostnadsrakning.docx", documentType: "Kostnadsräkning", createdAt: "2026-03-01" }] };
     hasDoc = false;
     const alertSpy = vi.spyOn(globalThis, "alert").mockImplementation(() => {});
-    render(<BillingPanel matterId="m1" matter={baseMatter} />);
+    render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={baseMatter} />);
     fireEvent.click(screen.getByRole("button", { name: "kostnadsrakning.docx" }));
     expect(alertSpy).toHaveBeenCalled();
     alertSpy.mockRestore();
@@ -188,21 +189,21 @@ describe("BillingPanel — pending verdict", () => {
 
 describe("BillingPanel — Skapa-faktura-menyn (optionsFor)", () => {
   it("PRIVAT-default: bara 'Faktura till klient' → öppnar FINAL-dialogen", () => {
-    render(<BillingPanel matterId="m1" matter={{ ...baseMatter, paymentMethod: "PRIVAT" }} />);
+    render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={{ ...baseMatter, paymentMethod: "PRIVAT" }} />);
     fireEvent.click(screen.getByRole("button", { name: "+ Skapa faktura" }));
     fireEvent.click(screen.getByRole("button", { name: "Faktura till klient" }));
     expect(screen.getByTestId("billing-dialog")).toHaveTextContent("FINAL");
   });
 
   it("RATTSSKYDD: aconto + faktura till försäkring", () => {
-    render(<BillingPanel matterId="m1" matter={{ ...baseMatter, paymentMethod: "RATTSSKYDD" }} />);
+    render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={{ ...baseMatter, paymentMethod: "RATTSSKYDD" }} />);
     fireEvent.click(screen.getByRole("button", { name: "+ Skapa faktura" }));
     expect(screen.getByRole("button", { name: "Aconto till klient" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Faktura till försäkring" })).toBeInTheDocument();
   });
 
   it("OFFENTLIGT_UPPDRAG: kostnadsräkning → öppnar KR-modalen", () => {
-    render(<BillingPanel matterId="m1" matter={{ ...baseMatter, paymentMethod: "OFFENTLIGT_UPPDRAG" }} />);
+    render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={{ ...baseMatter, paymentMethod: "OFFENTLIGT_UPPDRAG" }} />);
     fireEvent.click(screen.getByRole("button", { name: "+ Skapa faktura" }));
     fireEvent.click(screen.getByRole("button", { name: "Kostnadsräkning till domstol" }));
     expect(screen.getByTestId("kr-modal")).toBeInTheDocument();
@@ -211,20 +212,20 @@ describe("BillingPanel — Skapa-faktura-menyn (optionsFor)", () => {
 
 describe("BillingPanel — rådgivnings-banner (rättshjälp)", () => {
   it("RATTSHJALP utan registrerad rådgivning → knappen registrerar", () => {
-    render(<BillingPanel matterId="m1" matter={{ ...baseMatter, paymentMethod: "RATTSHJALP" }} />);
+    render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={{ ...baseMatter, paymentMethod: "RATTSHJALP" }} />);
     expect(screen.getByText(/Rådgivningstimme \(rättshjälp\)/)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Registrera betald" }));
     expect(radgivningMutate).toHaveBeenCalledWith(expect.objectContaining({ matterId: "m1" }));
   });
 
   it("RATTSHJALP med registrerad rådgivning → visar bock", () => {
-    render(<BillingPanel matterId="m1" matter={{ ...baseMatter, paymentMethod: "RATTSHJALP", radgivningBetaldAt: "2026-01-05" }} />);
+    render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={{ ...baseMatter, paymentMethod: "RATTSHJALP", radgivningBetaldAt: "2026-01-05" }} />);
     expect(screen.getByText(/Registrerad/)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Registrera betald" })).not.toBeInTheDocument();
   });
 
   it("icke-rättshjälp → ingen rådgivnings-banner", () => {
-    render(<BillingPanel matterId="m1" matter={{ ...baseMatter, paymentMethod: "PRIVAT" }} />);
+    render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={{ ...baseMatter, paymentMethod: "PRIVAT" }} />);
     expect(screen.queryByText(/Rådgivningstimme/)).not.toBeInTheDocument();
   });
 });

--- a/test/unit/app/matters/contacts-section.test.tsx
+++ b/test/unit/app/matters/contacts-section.test.tsx
@@ -6,6 +6,7 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest-compat";
 import { ContactsSection } from "@/app/matters/[id]/_contacts-section";
+import { asId } from "@/lib/shared/schemas/ids";
 
 vi.mock("@/lib/client/demo/entity-link", () => ({
   EntityLink: ({ children }: { children: React.ReactNode }) => <a href="#">{children}</a>,
@@ -48,26 +49,26 @@ beforeEach(() => vi.clearAllMocks());
 
 describe("ContactsSection", () => {
   it("visar rubrik med antal + kontaktraderna (namn, roll, nummer)", () => {
-    render(<ContactsSection matterId="m1" contacts={contacts} />);
+    render(<ContactsSection matterId={asId<"MatterId">("m1")} contacts={contacts} />);
     expect(screen.getByText("Kontakter (1)")).toBeInTheDocument();
     expect(screen.getByText("Klient Karlsson")).toBeInTheDocument();
     expect(screen.getByText("19800101-1234")).toBeInTheDocument();
   });
 
   it("tomt → tomtillstånd", () => {
-    render(<ContactsSection matterId="m1" contacts={[]} />);
+    render(<ContactsSection matterId={asId<"MatterId">("m1")} contacts={[]} />);
     expect(screen.getByText("Kontakter (0)")).toBeInTheDocument();
     expect(screen.getByText("Inga kontakter kopplade")).toBeInTheDocument();
   });
 
   it("'+ Lägg till' öppnar ny-kontakt-formuläret (default-läge)", () => {
-    render(<ContactsSection matterId="m1" contacts={[]} />);
+    render(<ContactsSection matterId={asId<"MatterId">("m1")} contacts={[]} />);
     fireEvent.click(screen.getByText("+ Lägg till"));
     expect(screen.getByPlaceholderText("Namn *")).toBeInTheDocument();
   });
 
   it("skapar ny kontakt → addNewContact.mutate med matterId + fält", () => {
-    render(<ContactsSection matterId="m1" contacts={[]} />);
+    render(<ContactsSection matterId={asId<"MatterId">("m1")} contacts={[]} />);
     fireEvent.click(screen.getByText("+ Lägg till"));
     fireEvent.change(screen.getByPlaceholderText("Namn *"), { target: { value: "Ny Person" } });
     fireEvent.click(screen.getByRole("button", { name: /Skapa & lägg till/ }));
@@ -75,7 +76,7 @@ describe("ContactsSection", () => {
   });
 
   it("växlar till befintlig kontakt och kopplar → addContact.mutate", () => {
-    render(<ContactsSection matterId="m1" contacts={[]} />);
+    render(<ContactsSection matterId={asId<"MatterId">("m1")} contacts={[]} />);
     fireEvent.click(screen.getByText("+ Lägg till"));
     fireEvent.click(screen.getByText("Befintlig kontakt"));
     // Första comboboxen i befintlig-formuläret = kontakt-väljaren.
@@ -85,13 +86,13 @@ describe("ContactsSection", () => {
   });
 
   it("Ta bort → removeContact.mutate med matterContactId", () => {
-    render(<ContactsSection matterId="m1" contacts={contacts} />);
+    render(<ContactsSection matterId={asId<"MatterId">("m1")} contacts={contacts} />);
     fireEvent.click(screen.getByText("Ta bort"));
     expect(removeContact).toHaveBeenCalledWith({ matterContactId: "mc1" });
   });
 
   it("ny ORGANISATION-kontakt: typ-byte → orgnummer-fältet + roll-select", () => {
-    render(<ContactsSection matterId="m1" contacts={[]} />);
+    render(<ContactsSection matterId={asId<"MatterId">("m1")} contacts={[]} />);
     fireEvent.click(screen.getByText("+ Lägg till"));
     fireEvent.change(screen.getByPlaceholderText("Namn *"), { target: { value: "Org AB" } });
     const [roleSel, typeSel] = screen.getAllByRole("combobox") as HTMLSelectElement[];
@@ -108,7 +109,7 @@ describe("ContactsSection", () => {
   });
 
   it("ny PERSON-kontakt: personnummer-fältet skrivs (PERSON-grenen)", () => {
-    render(<ContactsSection matterId="m1" contacts={[]} />);
+    render(<ContactsSection matterId={asId<"MatterId">("m1")} contacts={[]} />);
     fireEvent.click(screen.getByText("+ Lägg till"));
     fireEvent.change(screen.getByPlaceholderText("Namn *"), { target: { value: "Per Person" } });
     fireEvent.change(screen.getByPlaceholderText("Personnummer"), { target: { value: "19900101-1234" } });
@@ -119,7 +120,7 @@ describe("ContactsSection", () => {
   });
 
   it("befintlig-formuläret: roll-select exerceras + koppling", () => {
-    render(<ContactsSection matterId="m1" contacts={[]} />);
+    render(<ContactsSection matterId={asId<"MatterId">("m1")} contacts={[]} />);
     fireEvent.click(screen.getByText("+ Lägg till"));
     fireEvent.click(screen.getByText("Befintlig kontakt"));
     const [contactSel, roleSel] = screen.getAllByRole("combobox") as HTMLSelectElement[];

--- a/test/unit/app/matters/expense-section.test.tsx
+++ b/test/unit/app/matters/expense-section.test.tsx
@@ -7,6 +7,7 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest-compat";
 import { ExpenseSection } from "@/app/matters/[id]/_expense-section";
+import { asId } from "@/lib/shared/schemas/ids";
 
 vi.mock("@/lib/client/demo/entity-link", () => ({
   EntityLink: ({ children }: { children: React.ReactNode }) => <a href="#">{children}</a>,
@@ -53,7 +54,7 @@ beforeEach(() => {
 
 describe("ExpenseSection", () => {
   it("renderar rubrik med total och utläggsraderna", () => {
-    render(<ExpenseSection matterId="m1" />);
+    render(<ExpenseSection matterId={asId<"MatterId">("m1")} />);
     expect(screen.getByText("Utlägg")).toBeInTheDocument();
     expect(screen.getByText(/totalt/)).toBeInTheDocument();
     expect(screen.getByText("Tågbiljett")).toBeInTheDocument();
@@ -61,12 +62,12 @@ describe("ExpenseSection", () => {
   });
 
   it("visar summa-footer", () => {
-    render(<ExpenseSection matterId="m1" />);
+    render(<ExpenseSection matterId={asId<"MatterId">("m1")} />);
     expect(screen.getByText("Summa")).toBeInTheDocument();
   });
 
   it("låser fakturerade utlägg (ingen ändra/ta-bort) men tillåter åtgärder på ej fakturerade", () => {
-    render(<ExpenseSection matterId="m1" />);
+    render(<ExpenseSection matterId={asId<"MatterId">("m1")} />);
     expect(screen.getByText("Låst (på faktura)")).toBeInTheDocument();
     // Endast det ofakturerade utlägget (e1) har Ändra/Ta bort.
     expect(screen.getByText("Ändra")).toBeInTheDocument();
@@ -75,21 +76,21 @@ describe("ExpenseSection", () => {
 
   it("Ta bort med confirm → delete.mutate med utläggets id", () => {
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    render(<ExpenseSection matterId="m1" />);
+    render(<ExpenseSection matterId={asId<"MatterId">("m1")} />);
     fireEvent.click(screen.getByText("Ta bort"));
     expect(deleteMutate).toHaveBeenCalledWith({ id: "e1" });
     confirmSpy.mockRestore();
   });
 
   it("'+ Nytt utlägg' öppnar skapa-modalen", () => {
-    render(<ExpenseSection matterId="m1" />);
+    render(<ExpenseSection matterId={asId<"MatterId">("m1")} />);
     fireEvent.click(screen.getByText("+ Nytt utlägg"));
     expect(screen.getByText("Nytt utlägg")).toBeInTheDocument();
     expect(screen.getByText("Debiterbar")).toBeInTheDocument();
   });
 
   it("fyller i skapa-formuläret + Spara → create.mutate med matterId + payload", () => {
-    render(<ExpenseSection matterId="m1" />);
+    render(<ExpenseSection matterId={asId<"MatterId">("m1")} />);
     fireEvent.click(screen.getByText("+ Nytt utlägg"));
     const dateInput = document.querySelector('input[type="date"]') as HTMLInputElement;
     fireEvent.change(dateInput, { target: { value: "2026-03-15" } });
@@ -104,7 +105,7 @@ describe("ExpenseSection", () => {
   });
 
   it("växlar moms-radio (Exkl moms) + momssats-select utan att krascha", () => {
-    render(<ExpenseSection matterId="m1" />);
+    render(<ExpenseSection matterId={asId<"MatterId">("m1")} />);
     fireEvent.click(screen.getByText("+ Nytt utlägg"));
     fireEvent.click(screen.getByRole("radio", { name: /Exkl moms/ }));
     fireEvent.change(screen.getByRole("combobox"), { target: { value: "1200" } });
@@ -113,7 +114,7 @@ describe("ExpenseSection", () => {
   });
 
   it("'Ändra' öppnar förifyllt edit-formulär → Spara ändring → update.mutate med id", () => {
-    render(<ExpenseSection matterId="m1" />);
+    render(<ExpenseSection matterId={asId<"MatterId">("m1")} />);
     fireEvent.click(screen.getByText("Ändra"));
     expect(screen.getByText("Ändra utlägg")).toBeInTheDocument();
     expect(screen.getByDisplayValue("Tågbiljett")).toBeInTheDocument(); // förifyllt ur e1
@@ -122,7 +123,7 @@ describe("ExpenseSection", () => {
   });
 
   it("Avbryt stänger skapa-modalen", () => {
-    render(<ExpenseSection matterId="m1" />);
+    render(<ExpenseSection matterId={asId<"MatterId">("m1")} />);
     fireEvent.click(screen.getByText("+ Nytt utlägg"));
     fireEvent.click(screen.getByText("Avbryt"));
     expect(screen.queryByText("Nytt utlägg")).not.toBeInTheDocument();

--- a/test/unit/app/matters/generate-modal.test.tsx
+++ b/test/unit/app/matters/generate-modal.test.tsx
@@ -12,6 +12,7 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
 import { GenerateModal } from "@/app/matters/[id]/_generate-modal";
+import { asId } from "@/lib/shared/schemas/ids";
 
 interface Tpl { id: string; name: string; category: string | null; content: string | null }
 let templatesData: Tpl[] | undefined;
@@ -63,7 +64,7 @@ beforeEach(() => {
 
 describe("GenerateModal — vyer", () => {
   it("renderar rubrik + väljare", () => {
-    render(<GenerateModal matterId="m1" contacts={contacts} onClose={() => {}} />);
+    render(<GenerateModal matterId={asId<"MatterId">("m1")} contacts={contacts} onClose={() => {}} />);
     expect(screen.getByText("Generera dokument")).toBeInTheDocument();
     expect(screen.getByText("Mall")).toBeInTheDocument();
     expect(screen.getByText(/Mottagare \(0\)/)).toBeInTheDocument();
@@ -72,19 +73,19 @@ describe("GenerateModal — vyer", () => {
 
   it("visar laddtext medan mallar hämtas", () => {
     templatesLoading = true;
-    render(<GenerateModal matterId="m1" contacts={contacts} onClose={() => {}} />);
+    render(<GenerateModal matterId={asId<"MatterId">("m1")} contacts={contacts} onClose={() => {}} />);
     expect(screen.getByText("Laddar mallar…")).toBeInTheDocument();
   });
 
   it("tom mall-lista → länk till att skapa mall", () => {
     templatesData = [];
-    render(<GenerateModal matterId="m1" contacts={contacts} onClose={() => {}} />);
+    render(<GenerateModal matterId={asId<"MatterId">("m1")} contacts={contacts} onClose={() => {}} />);
     expect(screen.getByText(/Inga mallar skapade/)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Skapa en mall" })).toBeInTheDocument();
   });
 
   it("inga kontakter → tomtext i mottagar-pickern", () => {
-    render(<GenerateModal matterId="m1" contacts={[]} onClose={() => {}} />);
+    render(<GenerateModal matterId={asId<"MatterId">("m1")} contacts={[]} onClose={() => {}} />);
     expect(screen.getByText("Inga kontakter kopplade till ärendet.")).toBeInTheDocument();
   });
 });
@@ -92,7 +93,7 @@ describe("GenerateModal — vyer", () => {
 describe("GenerateModal — generering", () => {
   it("utan vald mottagare → ETT generellt dokument registreras + stänger", async () => {
     const onClose = vi.fn();
-    render(<GenerateModal matterId="m1" contacts={contacts} onClose={onClose} />);
+    render(<GenerateModal matterId={asId<"MatterId">("m1")} contacts={contacts} onClose={onClose} />);
     fireEvent.change(screen.getByRole("combobox"), { target: { value: "t1" } });
     fireEvent.click(screen.getByRole("button", { name: /Generera/ }));
     await waitFor(() => expect(registerMutateAsync).toHaveBeenCalledTimes(1));
@@ -103,7 +104,7 @@ describe("GenerateModal — generering", () => {
   });
 
   it("två valda mottagare → ETT dokument per mottagare", async () => {
-    render(<GenerateModal matterId="m1" contacts={contacts} onClose={() => {}} />);
+    render(<GenerateModal matterId={asId<"MatterId">("m1")} contacts={contacts} onClose={() => {}} />);
     fireEvent.change(screen.getByRole("combobox"), { target: { value: "t1" } });
     const boxes = screen.getAllByRole("checkbox");
     fireEvent.click(boxes[0]!);
@@ -114,7 +115,7 @@ describe("GenerateModal — generering", () => {
   });
 
   it("av/på-toggle av mottagare uppdaterar antalet", () => {
-    render(<GenerateModal matterId="m1" contacts={contacts} onClose={() => {}} />);
+    render(<GenerateModal matterId={asId<"MatterId">("m1")} contacts={contacts} onClose={() => {}} />);
     const boxes = screen.getAllByRole("checkbox");
     fireEvent.click(boxes[0]!);
     expect(screen.getByText(/Mottagare \(1\)/)).toBeInTheDocument();
@@ -124,7 +125,7 @@ describe("GenerateModal — generering", () => {
 
   it("mall utan innehåll → felmeddelande, stänger inte", async () => {
     const onClose = vi.fn();
-    render(<GenerateModal matterId="m1" contacts={contacts} onClose={onClose} />);
+    render(<GenerateModal matterId={asId<"MatterId">("m1")} contacts={contacts} onClose={onClose} />);
     fireEvent.change(screen.getByRole("combobox"), { target: { value: "t-empty" } });
     fireEvent.click(screen.getByRole("button", { name: /Generera/ }));
     await waitFor(() => expect(screen.getByText("Mallen saknar innehåll.")).toBeInTheDocument());
@@ -133,7 +134,7 @@ describe("GenerateModal — generering", () => {
   });
 
   it("format docx går att välja", () => {
-    render(<GenerateModal matterId="m1" contacts={contacts} onClose={() => {}} />);
+    render(<GenerateModal matterId={asId<"MatterId">("m1")} contacts={contacts} onClose={() => {}} />);
     const docx = screen.getByRole("radio", { name: /HTML-fil/ }) as HTMLInputElement;
     fireEvent.click(docx);
     expect(docx.checked).toBe(true);

--- a/test/unit/app/matters/kostnadsrakning-modal.test.tsx
+++ b/test/unit/app/matters/kostnadsrakning-modal.test.tsx
@@ -10,6 +10,7 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest-compat";
 import { KostnadsrakningModal } from "@/app/matters/[id]/_kostnadsrakning-modal";
+import { asId } from "@/lib/shared/schemas/ids";
 
 vi.mock("@/lib/client/helper/use-helper", () => ({
   useHelper: () => ({ checked: true, version: null }),
@@ -34,7 +35,7 @@ vi.mock("@/lib/client/trpc", () => ({
 }));
 
 const baseProps = {
-  matterId: "m1",
+  matterId: asId<"MatterId">("m1"),
   matterNumber: "2026-0017",
   matterTitle: "Brottmål Davidsson",
   clientName: "Erik Davidsson",

--- a/test/unit/app/matters/service-notes-section.test.tsx
+++ b/test/unit/app/matters/service-notes-section.test.tsx
@@ -7,6 +7,7 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest-compat";
 import { ServiceNotesSection } from "@/app/matters/[id]/_service-notes-section";
+import { asId } from "@/lib/shared/schemas/ids";
 
 const listQuery = { data: [] as unknown[], isLoading: false };
 const createMutate = vi.fn();
@@ -53,7 +54,7 @@ beforeEach(() => {
 
 describe("ServiceNotesSection", () => {
   it("visar tomtillstånd när inga anteckningar finns", () => {
-    render(<ServiceNotesSection matterId="m1" />);
+    render(<ServiceNotesSection matterId={asId<"MatterId">("m1")} />);
     expect(screen.getByText("Tjänsteanteckningar")).toBeInTheDocument();
     expect(screen.getByText(/Inga tjänsteanteckningar ännu/)).toBeInTheDocument();
   });
@@ -63,14 +64,14 @@ describe("ServiceNotesSection", () => {
       { id: "a", date: "2026-06-10", time: "08:00", text: "Äldre", author: { name: "Anna" } },
       { id: "b", date: "2026-06-15", time: "14:00", text: "Nyare", author: { name: "Björn" } },
     ];
-    render(<ServiceNotesSection matterId="m1" />);
+    render(<ServiceNotesSection matterId={asId<"MatterId">("m1")} />);
     const texts = screen.getAllByText(/Äldre|Nyare/).map((e) => e.textContent);
     expect(texts).toEqual(["Nyare", "Äldre"]); // fallande på datum+tid
     expect(screen.getByText(/Björn/)).toBeInTheDocument();
   });
 
   it("'+ Ny anteckning' öppnar formuläret, Avbryt stänger det", () => {
-    render(<ServiceNotesSection matterId="m1" />);
+    render(<ServiceNotesSection matterId={asId<"MatterId">("m1")} />);
     fireEvent.click(screen.getByText("+ Ny anteckning"));
     expect(screen.getByPlaceholderText(/Vad hände/)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Avbryt" }));
@@ -78,7 +79,7 @@ describe("ServiceNotesSection", () => {
   });
 
   it("submit skickar create med matterId + text och invaliderar listan vid success", () => {
-    render(<ServiceNotesSection matterId="m1" />);
+    render(<ServiceNotesSection matterId={asId<"MatterId">("m1")} />);
     fireEvent.click(screen.getByText("+ Ny anteckning"));
     fireEvent.change(screen.getByPlaceholderText(/Vad hände/), { target: { value: "Ringde klienten" } });
     fireEvent.click(screen.getByRole("button", { name: "Spara" }));
@@ -88,7 +89,7 @@ describe("ServiceNotesSection", () => {
   });
 
   it("submit utan text gör ingen mutation (required + trim-vakt)", () => {
-    render(<ServiceNotesSection matterId="m1" />);
+    render(<ServiceNotesSection matterId={asId<"MatterId">("m1")} />);
     fireEvent.click(screen.getByText("+ Ny anteckning"));
     const form = screen.getByPlaceholderText(/Vad hände/).closest("form")!;
     fireEvent.submit(form);
@@ -99,7 +100,7 @@ describe("ServiceNotesSection", () => {
     listQuery.data = [
       { id: "a", date: "2026-06-10", time: "08:00", text: "Gammal text", author: { name: "Anna" } },
     ];
-    render(<ServiceNotesSection matterId="m1" />);
+    render(<ServiceNotesSection matterId={asId<"MatterId">("m1")} />);
     fireEvent.click(screen.getByTitle("Redigera"));
     const textarea = screen.getByPlaceholderText(/Vad hände/) as HTMLTextAreaElement;
     expect(textarea.value).toBe("Gammal text"); // förifyllt
@@ -114,7 +115,7 @@ describe("ServiceNotesSection", () => {
       { id: "a", date: "2026-06-10", time: "08:00", text: "Text", author: { name: "Anna" } },
     ];
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    render(<ServiceNotesSection matterId="m1" />);
+    render(<ServiceNotesSection matterId={asId<"MatterId">("m1")} />);
     fireEvent.click(screen.getByTitle("Ta bort"));
     expect(deleteMutate).toHaveBeenCalledWith({ id: "a" });
     confirmSpy.mockRestore();
@@ -125,7 +126,7 @@ describe("ServiceNotesSection", () => {
       { id: "a", date: "2026-06-10", time: "08:00", text: "Text", author: { name: "Anna" } },
     ];
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
-    render(<ServiceNotesSection matterId="m1" />);
+    render(<ServiceNotesSection matterId={asId<"MatterId">("m1")} />);
     fireEvent.click(screen.getByTitle("Ta bort"));
     expect(deleteMutate).not.toHaveBeenCalled();
     confirmSpy.mockRestore();

--- a/test/unit/app/matters/verdict-dialog.test.tsx
+++ b/test/unit/app/matters/verdict-dialog.test.tsx
@@ -7,6 +7,7 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
 import { VerdictDialog } from "@/app/matters/[id]/_verdict-dialog";
+import { asId } from "@/lib/shared/schemas/ids";
 
 let verdictOnSuccess: ((res: unknown) => Promise<void>) | undefined;
 const verdictMutate = vi.fn();
@@ -35,9 +36,9 @@ vi.mock("@/lib/client/kostnadsrakning/render-faktura-pdf", () => ({ renderFaktur
 vi.mock("@/lib/client/demo/persist-generated-doc", () => ({ persistGeneratedDoc }));
 
 const baseProps = {
-  billingRunId: "br-1",
+  billingRunId: asId<"BillingRunId">("br-1"),
   workValueOre: 500_000,
-  matterId: "m1",
+  matterId: asId<"MatterId">("m1"),
   matterNumber: "B-2026-1",
   matterTitle: "Brottmål",
   onClose: vi.fn(),

--- a/test/unit/app/time-section-invoiced.test.tsx
+++ b/test/unit/app/time-section-invoiced.test.tsx
@@ -7,6 +7,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
 import { TimeSection } from "@/app/matters/[id]/_time-section";
+import { asId } from "@/lib/shared/schemas/ids";
 
 const createMut = vi.fn();
 const updateMut = vi.fn();
@@ -57,7 +58,7 @@ function renderSection() {
   const client = new QueryClient();
   return render(
     <QueryClientProvider client={client}>
-      <TimeSection matterId="m-1" />
+      <TimeSection matterId={asId<"MatterId">("m-1")} />
     </QueryClientProvider>,
   );
 }


### PR DESCRIPTION
ID-brandning (B3a, #750) — klient-komponenters id-props i de sammanhängande subträden `invoices/[id]` + `matters/[id]`: `matterId`→`MatterId`, `invoiceId`→`InvoiceId`, `billingRunId`→`BillingRunId`, `contactId`→`ContactId` m.fl. (17 komponentfiler).

**Entry-boundary:** `MatterDetailClient` wrappar `useRouteId() ?? paramId` med `asId<"MatterId">` EN gång → brandet trädar genom alla sektioner/dialoger via props. tRPC-inputs tar redan `*IdSchema` så branded props passar rakt in. Test-fixtures (11 filer) brandade med `asId`. Inga typer försvagade; rent i alla tre tsc-projekt.

Återstår (B3b): övriga klient-subträd (~41 props: contacts/payment-plans/conflicts/calendar/search).

## Test
Ren tsc (root/test/helper-ui, 0), lint grön, 794 app/komponent-tester gröna.

Refs #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)