### PR TITLE
refactor: branda leaf-lagrets domän-id:n (emit/suggestions/pure-calc) (B5)

### DIFF
--- a/src/app/payments/import/page.tsx
+++ b/src/app/payments/import/page.tsx
@@ -26,6 +26,7 @@ import {
   type ReceivableCandidate,
   type ReceivableSuggestion,
 } from "@/lib/shared/payments/match-receivables";
+import { asId } from "@/lib/shared/schemas/ids";
 
 interface InvoiceRowData {
   id: string;
@@ -37,7 +38,7 @@ interface InvoiceRowData {
 
 function toCandidates(rows: readonly InvoiceRowData[]): InvoiceCandidate[] {
   return rows.map((r) => ({
-    id: r.id,
+    id: asId<"InvoiceId">(r.id),
     invoiceNumber: r.invoiceNumber ?? null,
     ocrReference: r.ocrReference ?? null,
     amount: r.amount,
@@ -90,7 +91,9 @@ export default function PaymentImportPage() {
   // #175: matcha domstolsbetalningar (fri text) mot förväntade fordringar.
   const receivableSuggestions = useMemo((): ReceivableSuggestion[] => {
     if (!parsed.file || !receivables.data) return [];
-    const cands: ReceivableCandidate[] = (receivables.data as Array<Omit<ReceivableCandidate, "settledReferences">>).map((c) => ({ ...c, settledReferences: [] }));
+    const cands: ReceivableCandidate[] = (receivables.data as Array<Omit<ReceivableCandidate, "id" | "settledReferences"> & { id: string }>).map(
+      (c) => ({ ...c, id: asId<"ExpectedReceivableId">(c.id), settledReferences: [] }),
+    );
     return matchReceivables(parsed.file.transactions, cands).suggestions;
   }, [parsed.file, receivables.data]);
 

--- a/src/lib/client/diagnostics/use-matter-invariants.ts
+++ b/src/lib/client/diagnostics/use-matter-invariants.ts
@@ -14,8 +14,9 @@ import { reportSelfDetected } from "@/lib/client/diagnostics";
 import { trpc } from "@/lib/client/trpc";
 import { detectMatterInvariants, type BillingRunView, type DocumentView } from "@/lib/shared/diagnostics/invariants";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
+import type { MatterId } from "@/lib/shared/schemas/ids";
 
-export function useMatterInvariants(input: { matterId: string; matterNumber?: string }): void {
+export function useMatterInvariants(input: { matterId: MatterId; matterNumber?: string }): void {
   const { matterId, matterNumber } = input;
   const runs = trpc.billingRun.list.useQuery({ matterId });
   const docs = trpc.document.list.useQuery({ matterId, folderId: null, pageSize: 100 });

--- a/src/lib/server/events/emit.ts
+++ b/src/lib/server/events/emit.ts
@@ -11,13 +11,16 @@
  */
 
 import type { MatterStatus } from "@/lib/shared/schemas/enums";
+import type {
+  ContactId, DocumentId, InvoiceId, MatterId, OrganizationId, TimeEntryId, UserId,
+} from "@/lib/shared/schemas/ids";
 import type { IDataStore } from "../data-store/IDataStore";
 import type { EventType, EmitInput } from "./schema";
 
 /** Den minimal subset av tRPC-context som emit-helpers behöver. */
 export interface EmitCtx {
   dataStore: Pick<IDataStore, "events">;
-  user: { id: string };
+  user: { id: UserId };
 }
 
 async function safeEmit(ctx: EmitCtx, input: EmitInput): Promise<void> {
@@ -32,7 +35,7 @@ async function safeEmit(ctx: EmitCtx, input: EmitInput): Promise<void> {
 }
 
 /** Bygg payload + emit för en användar-initierad mutation. */
-function emitUser(ctx: EmitCtx, type: EventType, payload: Record<string, unknown>, matterId?: string) {
+function emitUser(ctx: EmitCtx, type: EventType, payload: Record<string, unknown>, matterId?: MatterId) {
   return safeEmit(ctx, {
     type,
     source: "ui",
@@ -43,7 +46,7 @@ function emitUser(ctx: EmitCtx, type: EventType, payload: Record<string, unknown
 }
 
 /** Bygg payload + emit för en system-initierad händelse (payment-scan m.fl.). */
-function emitSystem(ctx: EmitCtx, type: EventType, payload: Record<string, unknown>, matterId?: string) {
+function emitSystem(ctx: EmitCtx, type: EventType, payload: Record<string, unknown>, matterId?: MatterId) {
   return safeEmit(ctx, {
     type,
     source: "system",
@@ -55,79 +58,79 @@ function emitSystem(ctx: EmitCtx, type: EventType, payload: Record<string, unkno
 
 export const emit = {
   // ── matter ─────────────────────────────────────────────────────
-  matterCreated: (ctx: EmitCtx, matter: { id: string; matterNumber: string; title: string }) =>
+  matterCreated: (ctx: EmitCtx, matter: { id: MatterId; matterNumber: string; title: string }) =>
     emitUser(ctx, "matter.created", { matterNumber: matter.matterNumber, title: matter.title }, matter.id),
 
-  matterUpdated: (ctx: EmitCtx, matterId: string, patch: Record<string, unknown>) =>
+  matterUpdated: (ctx: EmitCtx, matterId: MatterId, patch: Record<string, unknown>) =>
     emitUser(ctx, "matter.updated", { patch }, matterId),
 
-  matterStatusChanged: (ctx: EmitCtx, matterId: string, from: MatterStatus, to: MatterStatus) =>
+  matterStatusChanged: (ctx: EmitCtx, matterId: MatterId, from: MatterStatus, to: MatterStatus) =>
     emitUser(ctx, "matter.status_changed", { from, to }, matterId),
 
-  matterArchived: (ctx: EmitCtx, matterId: string) =>
+  matterArchived: (ctx: EmitCtx, matterId: MatterId) =>
     emitUser(ctx, "matter.archived", {}, matterId),
 
   // ── contact ────────────────────────────────────────────────────
-  contactCreated: (ctx: EmitCtx, contact: { id: string; name: string }) =>
+  contactCreated: (ctx: EmitCtx, contact: { id: ContactId; name: string }) =>
     emitUser(ctx, "contact.created", { contactId: contact.id, name: contact.name }),
 
-  contactUpdated: (ctx: EmitCtx, contactId: string, patch: Record<string, unknown>) =>
+  contactUpdated: (ctx: EmitCtx, contactId: ContactId, patch: Record<string, unknown>) =>
     emitUser(ctx, "contact.updated", { contactId, patch }),
 
-  contactDeleted: (ctx: EmitCtx, contactId: string) =>
+  contactDeleted: (ctx: EmitCtx, contactId: ContactId) =>
     emitUser(ctx, "contact.deleted", { contactId }),
 
   // ── document ───────────────────────────────────────────────────
-  documentUploaded: (ctx: EmitCtx, doc: { id: string; fileName: string; matterId: string }) =>
+  documentUploaded: (ctx: EmitCtx, doc: { id: DocumentId; fileName: string; matterId: MatterId }) =>
     emitUser(ctx, "document.uploaded", { documentId: doc.id, fileName: doc.fileName }, doc.matterId),
 
-  documentDeleted: (ctx: EmitCtx, doc: { id: string; matterId: string }) =>
+  documentDeleted: (ctx: EmitCtx, doc: { id: DocumentId; matterId: MatterId }) =>
     emitUser(ctx, "document.deleted", { documentId: doc.id }, doc.matterId),
 
-  documentAnalyzed: (ctx: EmitCtx, doc: { id: string; matterId: string }, result: Record<string, unknown>) =>
+  documentAnalyzed: (ctx: EmitCtx, doc: { id: DocumentId; matterId: MatterId }, result: Record<string, unknown>) =>
     emitUser(ctx, "document.analyzed", { documentId: doc.id, result }, doc.matterId),
 
   // ── invoice ────────────────────────────────────────────────────
-  invoiceCreated: (ctx: EmitCtx, inv: { id: string; matterId: string; amount: number }) =>
+  invoiceCreated: (ctx: EmitCtx, inv: { id: InvoiceId; matterId: MatterId; amount: number }) =>
     emitUser(ctx, "invoice.created", { invoiceId: inv.id, amount: inv.amount }, inv.matterId),
 
-  invoiceSent: (ctx: EmitCtx, invoiceId: string, matterId: string) =>
+  invoiceSent: (ctx: EmitCtx, invoiceId: InvoiceId, matterId: MatterId) =>
     emitUser(ctx, "invoice.sent", { invoiceId }, matterId),
 
-  invoicePaymentReceived: (ctx: EmitCtx, invoiceId: string, matterId: string, amount: number) =>
+  invoicePaymentReceived: (ctx: EmitCtx, invoiceId: InvoiceId, matterId: MatterId, amount: number) =>
     emitUser(ctx, "invoice.payment_received", { invoiceId, amount }, matterId),
 
-  invoiceWrittenOff: (ctx: EmitCtx, invoiceId: string, matterId: string, amount: number) =>
+  invoiceWrittenOff: (ctx: EmitCtx, invoiceId: InvoiceId, matterId: MatterId, amount: number) =>
     emitUser(ctx, "invoice.written_off", { invoiceId, amount }, matterId),
 
   // ── time-entry ─────────────────────────────────────────────────
-  timeEntryAdded: (ctx: EmitCtx, entry: { id: string; matterId: string; minutes: number }) =>
+  timeEntryAdded: (ctx: EmitCtx, entry: { id: TimeEntryId; matterId: MatterId; minutes: number }) =>
     emitUser(ctx, "time-entry.added", { entryId: entry.id, minutes: entry.minutes }, entry.matterId),
 
-  timeEntryUpdated: (ctx: EmitCtx, entry: { id: string; matterId: string }) =>
+  timeEntryUpdated: (ctx: EmitCtx, entry: { id: TimeEntryId; matterId: MatterId }) =>
     emitUser(ctx, "time-entry.updated", { entryId: entry.id }, entry.matterId),
 
-  timeEntryDeleted: (ctx: EmitCtx, entryId: string, matterId: string) =>
+  timeEntryDeleted: (ctx: EmitCtx, entryId: TimeEntryId, matterId: MatterId) =>
     emitUser(ctx, "time-entry.deleted", { entryId }, matterId),
 
   // ── kostnadsräkning ────────────────────────────────────────────
   kostnadsrakningGenerated: (
     ctx: EmitCtx,
-    matterId: string,
+    matterId: MatterId,
     payload: {
-      documentId: string;
+      documentId: DocumentId;
       fileName: string;
       totalInclVat: number;
       huvudforhandlingMinutes: number;
-      organizationId: string;
+      organizationId: OrganizationId;
     },
   ) => emitUser(ctx, "kostnadsrakning.generated", payload, matterId),
 
   // ── payment-plan-påminnelser (payment-scan, #23) ───────────────
-  paymentDue: (ctx: EmitCtx, payload: Record<string, unknown>, matterId?: string) =>
+  paymentDue: (ctx: EmitCtx, payload: Record<string, unknown>, matterId?: MatterId) =>
     emitSystem(ctx, "payment.due", payload, matterId),
 
-  paymentOverdue: (ctx: EmitCtx, payload: Record<string, unknown>, matterId?: string) =>
+  paymentOverdue: (ctx: EmitCtx, payload: Record<string, unknown>, matterId?: MatterId) =>
     emitSystem(ctx, "payment.overdue", payload, matterId),
 
   // ── user / generic ─────────────────────────────────────────────

--- a/src/lib/server/repositories/drizzle-acconto-deduction-repository.ts
+++ b/src/lib/server/repositories/drizzle-acconto-deduction-repository.ts
@@ -3,6 +3,7 @@
  */
 
 import type { AccontoDeduction } from "@/lib/shared/schemas/billing";
+import type { InvoiceId } from "@/lib/shared/schemas/ids";
 import { accontoDeductions } from "../db/schema";
 import type { AppDb } from "../db/types";
 import type { AccontoDeductionRepository } from "./acconto-deduction-repository";
@@ -18,7 +19,7 @@ export class DrizzleAccontoDeductionRepository
 
   /** acconto-avdrag saknar org-kolumn → härled via (slut- el. aconto-)fakturan→ärendet (#647). */
   protected override resolveOrg(row: unknown): Promise<string | undefined> {
-    const r = row as { finalInvoiceId?: string; accontoInvoiceId?: string };
+    const r = row as { finalInvoiceId?: InvoiceId; accontoInvoiceId?: InvoiceId };
     return invoiceOrg(this.db, r.finalInvoiceId ?? r.accontoInvoiceId);
   }
 }

--- a/src/lib/server/repositories/drizzle-billing-run-repository.ts
+++ b/src/lib/server/repositories/drizzle-billing-run-repository.ts
@@ -23,7 +23,7 @@ export class DrizzleBillingRunRepository
 
   /** billing_runs saknar org-kolumn → härled via ärendet (#647). */
   protected override resolveOrg(row: unknown): Promise<string | undefined> {
-    return matterOrg(this.db, (row as { matterId?: string }).matterId);
+    return matterOrg(this.db, (row as { matterId?: MatterId }).matterId);
   }
 
   async listForOrg(organizationId: OrganizationId, matterId?: MatterId): Promise<BillingRunListRow[]> {

--- a/src/lib/server/repositories/drizzle-document-folder-repository.ts
+++ b/src/lib/server/repositories/drizzle-document-folder-repository.ts
@@ -28,7 +28,7 @@ export class DrizzleDocumentFolderRepository
 
   /** Mappar saknar org-kolumn → härled via ärendet (#528) så change_log/pull funkar. */
   protected override resolveOrg(row: unknown): Promise<string | undefined> {
-    return matterOrg(this.db, (row as { matterId?: string }).matterId);
+    return matterOrg(this.db, (row as { matterId?: MatterId }).matterId);
   }
 
   async listInParent(matterId: MatterId, parentId: DocumentFolderId | null): Promise<DocumentFolderWithCounts[]> {

--- a/src/lib/server/repositories/drizzle-document-repository.ts
+++ b/src/lib/server/repositories/drizzle-document-repository.ts
@@ -37,7 +37,7 @@ export class DrizzleDocumentRepository
 
   /** Dokument saknar org-kolumn → härled via ärendet (#528) så change_log/pull funkar. */
   protected override resolveOrg(row: unknown): Promise<string | undefined> {
-    return matterOrg(this.db, (row as { matterId?: string }).matterId);
+    return matterOrg(this.db, (row as { matterId?: MatterId }).matterId);
   }
 
   async listInFolder(

--- a/src/lib/server/repositories/drizzle-expense-repository.ts
+++ b/src/lib/server/repositories/drizzle-expense-repository.ts
@@ -24,7 +24,7 @@ export class DrizzleExpenseRepository extends DrizzleRepository<Expense> impleme
 
   /** expenses saknar org-kolumn → härled via ärendet (#528/#632) så change_log/pull funkar. */
   protected override resolveOrg(row: unknown): Promise<string | undefined> {
-    return matterOrg(this.db, (row as { matterId?: string }).matterId);
+    return matterOrg(this.db, (row as { matterId?: MatterId }).matterId);
   }
 
   async listForOrg(organizationId: OrganizationId, opts: ExpenseListOptions): Promise<ExpenseListResult> {

--- a/src/lib/server/repositories/drizzle-invoice-dispatch-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-dispatch-repository.ts
@@ -5,7 +5,7 @@
 
 import { and, asc, desc, eq, isNull } from "drizzle-orm";
 import type { InvoiceDispatch } from "@/lib/shared/schemas/billing";
-import { asId } from "@/lib/shared/schemas/ids";
+import { asId, type InvoiceId } from "@/lib/shared/schemas/ids";
 import { invoiceDispatches, invoices, matters } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
@@ -17,7 +17,7 @@ export class DrizzleInvoiceDispatchRepository
   implements InvoiceDispatchRepository {
   /** invoice_dispatches saknar org-kolumn → härled via fakturan→ärendet (#647). */
   protected override resolveOrg(row: unknown): Promise<string | undefined> {
-    return invoiceOrg(this.db, (row as { invoiceId?: string }).invoiceId);
+    return invoiceOrg(this.db, (row as { invoiceId?: InvoiceId }).invoiceId);
   }
 
   constructor(db: AppDb, now: () => Date = () => new Date()) {

--- a/src/lib/server/repositories/drizzle-invoice-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-repository.ts
@@ -11,7 +11,7 @@
 
 import { and, desc, eq, inArray, isNull, like, sql } from "drizzle-orm";
 import type { Invoice } from "@/lib/shared/schemas/billing";
-import { asId } from "@/lib/shared/schemas/ids";
+import { asId, type MatterId } from "@/lib/shared/schemas/ids";
 import { accontoDeductions, invoices, matters, paymentPlans, payments, writeOffs } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
@@ -29,7 +29,7 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
 
   /** invoices saknar org-kolumn → härled via ärendet (#647) så change_log/pull funkar. */
   protected override resolveOrg(row: unknown): Promise<string | undefined> {
-    return matterOrg(this.db, (row as { matterId?: string }).matterId);
+    return matterOrg(this.db, (row as { matterId?: MatterId }).matterId);
   }
 
   async getByIdInOrg(id: string, organizationId: string): Promise<Invoice | null> {

--- a/src/lib/server/repositories/drizzle-matter-contact-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-contact-repository.ts
@@ -26,7 +26,7 @@ export class DrizzleMatterContactRepository
 
   /** matter_contacts saknar org-kolumn → härled via ärendet (#528/#632) så change_log/pull funkar. */
   protected override resolveOrg(row: unknown): Promise<string | undefined> {
-    return matterOrg(this.db, (row as { matterId?: string }).matterId);
+    return matterOrg(this.db, (row as { matterId?: MatterId }).matterId);
   }
 
   async findForConflict(organizationId: OrganizationId, numberTerm?: string): Promise<ConflictContactRow[]> {

--- a/src/lib/server/repositories/drizzle-payment-plan-reminder-repository.ts
+++ b/src/lib/server/repositories/drizzle-payment-plan-reminder-repository.ts
@@ -3,6 +3,7 @@
  */
 
 import type { PaymentPlanReminder } from "@/lib/shared/schemas/billing";
+import type { PaymentPlanId } from "@/lib/shared/schemas/ids";
 import { paymentPlanReminders } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
@@ -18,6 +19,6 @@ export class DrizzlePaymentPlanReminderRepository
 
   /** påminnelser saknar org-kolumn → härled via planen→fakturan→ärendet (#647). */
   protected override resolveOrg(row: unknown): Promise<string | undefined> {
-    return planOrg(this.db, (row as { planId?: string }).planId);
+    return planOrg(this.db, (row as { planId?: PaymentPlanId }).planId);
   }
 }

--- a/src/lib/server/repositories/drizzle-payment-plan-repository.ts
+++ b/src/lib/server/repositories/drizzle-payment-plan-repository.ts
@@ -26,7 +26,7 @@ export class DrizzlePaymentPlanRepository extends DrizzleRepository<PaymentPlan>
 
   /** payment_plans saknar org-kolumn → härled via fakturan→ärendet (#647). */
   protected override resolveOrg(row: unknown): Promise<string | undefined> {
-    return invoiceOrg(this.db, (row as { invoiceId?: string }).invoiceId);
+    return invoiceOrg(this.db, (row as { invoiceId?: InvoiceId }).invoiceId);
   }
 
   async getByIdInOrg(planId: PaymentPlanId, organizationId: OrganizationId): Promise<PaymentPlan | null> {

--- a/src/lib/server/repositories/drizzle-payment-repository.ts
+++ b/src/lib/server/repositories/drizzle-payment-repository.ts
@@ -19,7 +19,7 @@ export class DrizzlePaymentRepository extends DrizzleRepository<Payment> impleme
 
   /** payments saknar org-kolumn → härled via fakturan→ärendet (#647). */
   protected override resolveOrg(row: unknown): Promise<string | undefined> {
-    return invoiceOrg(this.db, (row as { invoiceId?: string }).invoiceId);
+    return invoiceOrg(this.db, (row as { invoiceId?: InvoiceId }).invoiceId);
   }
 
   async sumByInvoice(invoiceId: InvoiceId): Promise<number> {

--- a/src/lib/server/repositories/drizzle-time-entry-repository.ts
+++ b/src/lib/server/repositories/drizzle-time-entry-repository.ts
@@ -40,7 +40,7 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
 
   /** time_entries saknar org-kolumn → härled via ärendet (#528/#632) så change_log/pull funkar. */
   protected override resolveOrg(row: unknown): Promise<string | undefined> {
-    return matterOrg(this.db, (row as { matterId?: string }).matterId);
+    return matterOrg(this.db, (row as { matterId?: MatterId }).matterId);
   }
 
   async listForOrg(organizationId: OrganizationId, opts: TimeEntryListFilter): Promise<TimeEntryListResult> {

--- a/src/lib/server/repositories/drizzle-write-off-repository.ts
+++ b/src/lib/server/repositories/drizzle-write-off-repository.ts
@@ -19,7 +19,7 @@ export class DrizzleWriteOffRepository extends DrizzleRepository<WriteOff> imple
 
   /** write_offs saknar org-kolumn → härled via fakturan→ärendet (#647). */
   protected override resolveOrg(row: unknown): Promise<string | undefined> {
-    return invoiceOrg(this.db, (row as { invoiceId?: string }).invoiceId);
+    return invoiceOrg(this.db, (row as { invoiceId?: InvoiceId }).invoiceId);
   }
 
   async sumByInvoice(invoiceId: InvoiceId): Promise<number> {

--- a/src/lib/server/repositories/matter-org.ts
+++ b/src/lib/server/repositories/matter-org.ts
@@ -7,16 +7,16 @@
  */
 
 import { eq } from "drizzle-orm";
-import { asId } from "@/lib/shared/schemas/ids";
+import type { InvoiceId, MatterId, OrganizationId, PaymentPlanId } from "@/lib/shared/schemas/ids";
 import { invoices, matters, paymentPlans } from "../db/schema";
 import type { AppDb } from "../db/types";
 
-export async function matterOrg(db: AppDb, matterId: string | null | undefined): Promise<string | undefined> {
+export async function matterOrg(db: AppDb, matterId: MatterId | null | undefined): Promise<OrganizationId | undefined> {
   if (!matterId) return undefined;
   const [m] = await db
     .select({ org: matters.organizationId })
     .from(matters)
-    .where(eq(matters.id, asId<"MatterId">(matterId)))
+    .where(eq(matters.id, matterId))
     .limit(1);
   return m?.org ?? undefined;
 }
@@ -26,23 +26,23 @@ export async function matterOrg(db: AppDb, matterId: string | null | undefined):
  * matter-kolumn (payment/writeOff/paymentPlan/accontoDeduction/invoiceDispatch):
  * faktura → ärende → org. Annars loggas de aldrig i change_log → syns ej i klienten.
  */
-export async function invoiceOrg(db: AppDb, invoiceId: string | null | undefined): Promise<string | undefined> {
+export async function invoiceOrg(db: AppDb, invoiceId: InvoiceId | null | undefined): Promise<OrganizationId | undefined> {
   if (!invoiceId) return undefined;
   const [inv] = await db
     .select({ matterId: invoices.matterId })
     .from(invoices)
-    .where(eq(invoices.id, asId<"InvoiceId">(invoiceId)))
+    .where(eq(invoices.id, invoiceId))
     .limit(1);
   return matterOrg(db, inv?.matterId);
 }
 
 /** Org via avbetalningsplanen (#647): plan → faktura → ärende → org. */
-export async function planOrg(db: AppDb, planId: string | null | undefined): Promise<string | undefined> {
+export async function planOrg(db: AppDb, planId: PaymentPlanId | null | undefined): Promise<OrganizationId | undefined> {
   if (!planId) return undefined;
   const [plan] = await db
     .select({ invoiceId: paymentPlans.invoiceId })
     .from(paymentPlans)
-    .where(eq(paymentPlans.id, asId<"PaymentPlanId">(planId)))
+    .where(eq(paymentPlans.id, planId))
     .limit(1);
   return invoiceOrg(db, plan?.invoiceId);
 }

--- a/src/lib/server/routers/document/suggestions.ts
+++ b/src/lib/server/routers/document/suggestions.ts
@@ -60,8 +60,8 @@ async function loadPendingSuggestion(ctx: Ctx, suggestionId: DocumentAnalysisSug
   return sugg;
 }
 
-async function resolveExistingContact(ctx: Ctx, contactId: string): Promise<ContactId> {
-  const existing = (await ctx.repos.contacts.getByIdFull(asId<"ContactId">(contactId), ctx.orgId)) as { id: ContactId } | null;
+async function resolveExistingContact(ctx: Ctx, contactId: ContactId): Promise<ContactId> {
+  const existing = (await ctx.repos.contacts.getByIdFull(contactId, ctx.orgId)) as { id: ContactId } | null;
   if (!existing) throw new TRPCError({ code: "NOT_FOUND" });
   return existing.id;
 }
@@ -71,7 +71,7 @@ async function findContactByNumberOrName(
   ctx: Ctx,
   sugg: Suggestion,
   o: SuggOverride,
-  matterId: string,
+  matterId: MatterId,
 ): Promise<ContactCandidate | null> {
   const pn = o.personalNumber ?? sugg.personalNumber;
   const on = o.orgNumber ?? sugg.orgNumber;
@@ -81,7 +81,7 @@ async function findContactByNumberOrName(
   if (on) {
     return (await ctx.repos.contacts.findByOrgNumber(ctx.orgId, on)) as ContactCandidate | null;
   }
-  const matterContacts = (await ctx.repos.matterContacts.listContactsForMatter(asId<"MatterId">(matterId))) as ContactCandidate[];
+  const matterContacts = (await ctx.repos.matterContacts.listContactsForMatter(matterId)) as ContactCandidate[];
   const dedup = findExistingContactForSuggestion(
     {
       name: o.name ?? sugg.name,
@@ -119,7 +119,7 @@ async function resolveOrCreateContact(
   ctx: Ctx,
   sugg: Suggestion,
   o: SuggOverride,
-  matterId: string,
+  matterId: MatterId,
 ): Promise<ContactId> {
   const existing = await findContactByNumberOrName(ctx, sugg, o, matterId);
   if (existing) return asId<"ContactId">(existing.id);
@@ -131,12 +131,12 @@ async function resolveOrCreateContact(
 
 async function ensureMatterContactLink(
   ctx: Ctx,
-  matterId: string,
-  contactId: string,
+  matterId: MatterId,
+  contactId: ContactId,
   role: string,
   notes: string | null,
 ): Promise<void> {
-  const existing = await ctx.repos.matterContacts.findLink(asId<"MatterId">(matterId), asId<"ContactId">(contactId), role);
+  const existing = await ctx.repos.matterContacts.findLink(matterId, contactId, role);
   if (!existing) {
     await ctx.repos.matterContacts.create({ matterId, contactId, role, notes } as Partial<MatterContact>);
   }
@@ -176,7 +176,7 @@ function pickFirstFromGroup<K extends keyof Suggestion>(
 async function resolveOrCreateGroupContact(
   ctx: Ctx,
   suggs: Suggestion[],
-  matterId: string,
+  matterId: MatterId,
 ): Promise<ContactId> {
   const first = suggs[0];
   if (!first) throw new TRPCError({ code: "NOT_FOUND" });
@@ -199,7 +199,7 @@ async function resolveOrCreateGroupContact(
 async function findGroupContact(
   ctx: Ctx,
   suggs: Suggestion[],
-  matterId: string,
+  matterId: MatterId,
   personalNumber: string | null,
   orgNumber: string | null,
 ): Promise<ContactCandidate | null> {
@@ -210,7 +210,7 @@ async function findGroupContact(
     return (await ctx.repos.contacts.findByOrgNumber(ctx.orgId, orgNumber)) as ContactCandidate | null;
   }
   // Namn-fallback scopad till ärendet (se contact-dedup.ts).
-  const matterContacts = (await ctx.repos.matterContacts.listContactsForMatter(asId<"MatterId">(matterId))) as ContactCandidate[];
+  const matterContacts = (await ctx.repos.matterContacts.listContactsForMatter(matterId)) as ContactCandidate[];
   const first = suggs[0];
   if (!first) return null;
   const dedup = findExistingContactForSuggestion(
@@ -230,8 +230,8 @@ async function findGroupContact(
 async function linkGroupRoles(
   ctx: Ctx,
   suggs: Suggestion[],
-  matterId: string,
-  contactId: string,
+  matterId: MatterId,
+  contactId: ContactId,
 ): Promise<string[]> {
   const distinctRoles = Array.from(new Set(suggs.map((s) => s.role)));
   for (const role of distinctRoles) {
@@ -294,7 +294,7 @@ export const suggestionProcedures = {
       const finalRole = o.role ?? sugg.role;
 
       const contactId = input.existingContactId
-        ? await resolveExistingContact(ctx, input.existingContactId)
+        ? await resolveExistingContact(ctx, asId<"ContactId">(input.existingContactId))
         : await resolveOrCreateContact(ctx, sugg, o, matterId);
 
       await ensureMatterContactLink(ctx, matterId, contactId, finalRole, sugg.notes);
@@ -334,7 +334,7 @@ export const suggestionProcedures = {
       const matterId = first.document.matterId;
 
       const contactId = input.existingContactId
-        ? await resolveExistingContact(ctx, input.existingContactId)
+        ? await resolveExistingContact(ctx, asId<"ContactId">(input.existingContactId))
         : await resolveOrCreateGroupContact(ctx, suggs, matterId);
 
       const distinctRoles = await linkGroupRoles(ctx, suggs, matterId, contactId);

--- a/src/lib/server/routers/mail.ts
+++ b/src/lib/server/routers/mail.ts
@@ -93,7 +93,7 @@ export const mailRouter = router({
         createdAt: new Date(input.receivedAt),
       };
       const doc = await ctx.repos.documents.create(docData);
-      await emit.documentUploaded(ctx, { id, fileName, matterId: input.matterId });
+      await emit.documentUploaded(ctx, { id: docData.id, fileName, matterId: docData.matterId });
 
       // 4. Valfri tidspost kopplad till mailet.
       const timeEntry = input.time

--- a/src/lib/server/routers/paymentPlan.ts
+++ b/src/lib/server/routers/paymentPlan.ts
@@ -22,7 +22,7 @@ import {
   type PlanForScan,
 } from "@/lib/shared/payment-reminders";
 import { paymentPlanStatusSchema, reminderTypeSchema, type Invoice, type PaymentPlan } from "@/lib/shared/schemas";
-import { asId, paymentPlanIdSchema, paymentPlanReminderIdSchema } from "@/lib/shared/schemas/ids";
+import { asId, paymentPlanIdSchema, paymentPlanReminderIdSchema, type MatterId } from "@/lib/shared/schemas/ids";
 import { emit } from "../events/emit";
 import type {
   JoinedPaymentPlan, JoinedPaymentPlanWithReminders,
@@ -45,8 +45,8 @@ function resolveRecipient(matter: PlanMatter | null): { email: string; name: str
 }
 
 /** Ärende-fälten scannern behöver (tomma om ärendet saknas). */
-function scanMatterFields(m: PlanMatter | null): { matterId: string; matterNumber: string; matterTitle: string } {
-  return { matterId: m?.id ?? "", matterNumber: m?.matterNumber ?? "", matterTitle: m?.title ?? "" };
+function scanMatterFields(m: PlanMatter | null): { matterId: MatterId; matterNumber: string; matterTitle: string } {
+  return { matterId: m?.id ?? asId<"MatterId">(""), matterNumber: m?.matterNumber ?? "", matterTitle: m?.title ?? "" };
 }
 
 function toPlanForScan(p: JoinedPlan): PlanForScan {

--- a/src/lib/server/routers/reports.ts
+++ b/src/lib/server/routers/reports.ts
@@ -6,7 +6,7 @@ import {
   type FrozenWorkInput,
 } from "@/lib/shared/billed-per-lawyer";
 import type { InvoiceStatus, PaymentMethod } from "@/lib/shared/schemas/enums";
-import { asId, userIdSchema, type InvoiceId } from "@/lib/shared/schemas/ids";
+import { asId, userIdSchema, type InvoiceId, type UserId } from "@/lib/shared/schemas/ids";
 import { router, protectedProcedure } from "../trpc";
 
 /**
@@ -86,13 +86,17 @@ function buildFrozenWork(
   for (const te of timeEntries) {
     const invoiceId = te.invoiceId ?? (te.frozenByBillingRunId ? runToInvoice.get(te.frozenByBillingRunId) : undefined);
     if (!invoiceId) continue;
-    out.push({ invoiceId, userId: te.userId, workOre: Math.round((te.minutes / 60) * te.hourlyRate) });
+    out.push({
+      invoiceId: asId<"InvoiceId">(invoiceId),
+      userId: asId<"UserId">(te.userId),
+      workOre: Math.round((te.minutes / 60) * te.hourlyRate),
+    });
   }
   return out;
 }
 
 /** invoiceId → advokatens andel (userWork/totalWork ∈ [0,1]) ur frysta tidsposter. */
-function lawyerShareRatios(frozenWork: FrozenWorkInput[], userId: string): Map<string, number> {
+function lawyerShareRatios(frozenWork: FrozenWorkInput[], userId: UserId): Map<string, number> {
   const total = new Map<string, number>();
   const user = new Map<string, number>();
   for (const fw of frozenWork) {
@@ -118,7 +122,7 @@ function writtenOffDates(writeOffs: Array<{ invoiceId?: string; writtenOffAt?: u
 
 function toInvoiceInputs(invoices: RawInvoice[], writtenOff: Map<string, Date>): BilledInvoiceInput[] {
   return invoices.map((i) => ({
-    id: i.id,
+    id: asId<"InvoiceId">(i.id),
     amountOre: i.amount,
     invoiceDate: coerceDate(i.invoiceDate),
     status: i.status,

--- a/src/lib/shared/billed-per-lawyer.ts
+++ b/src/lib/shared/billed-per-lawyer.ts
@@ -18,11 +18,13 @@
  * Ren och ramverks-agnostisk → enhetstestbar isolerat. Alla belopp i öre.
  */
 
+import type { InvoiceId, UserId } from "@/lib/shared/schemas/ids";
+
 /** Utfärdade statusar som räknas som "gått ut" (fakturan har lämnat huset). */
 const ISSUED_STATUSES: ReadonlySet<string> = new Set(["SENT", "PAID", "BAD_DEBT", "INSTALLMENT_PLAN"]);
 
 export interface BilledInvoiceInput {
-  id: string;
+  id: InvoiceId;
   amountOre: number;
   invoiceDate: Date;
   status: string;
@@ -32,8 +34,8 @@ export interface BilledInvoiceInput {
 
 /** Frozen arbetsvärde per (faktura, advokat). Råposter aggregeras internt. */
 export interface FrozenWorkInput {
-  invoiceId: string;
-  userId: string;
+  invoiceId: InvoiceId;
+  userId: UserId;
   workOre: number;
 }
 
@@ -43,7 +45,7 @@ export interface DateRange {
 }
 
 export interface BilledInvoiceRow {
-  id: string;
+  id: InvoiceId;
   invoiceDate: Date;
   amountOre: number;
   /** Advokatens proportionella andel av fakturans belopp. */
@@ -84,7 +86,7 @@ function indexWork(frozenWork: FrozenWorkInput[]): Map<string, { total: number; 
 /** Advokatens proportionella andel av en fakturas belopp (öre, avrundat). */
 function lawyerShareOre(
   invoice: BilledInvoiceInput,
-  userId: string,
+  userId: UserId,
   work: Map<string, { total: number; perUser: Map<string, number> }>,
 ): number {
   const entry = work.get(invoice.id);
@@ -95,7 +97,7 @@ function lawyerShareOre(
 }
 
 export interface BilledPerLawyerOpts {
-  userId: string;
+  userId: UserId;
   invoices: BilledInvoiceInput[];
   frozenWork: FrozenWorkInput[];
   /** Rapportperioden. */

--- a/src/lib/shared/diagnostics/invariants.ts
+++ b/src/lib/shared/diagnostics/invariants.ts
@@ -13,6 +13,7 @@
  */
 
 import { KOSTNADSRAKNING_DOCUMENT_TYPE } from "@/lib/shared/schemas/document";
+import type { BillingRunId, MatterId } from "@/lib/shared/schemas/ids";
 
 /** Maskinläsbar kod per invariant — stabil, används för dedup + filtrering. */
 export type InvariantCode = "KR_PENDING_NO_DOC";
@@ -29,7 +30,7 @@ export interface InvariantViolation {
 
 /** Minimal vy av en BillingRun som invarianten behöver. */
 export interface BillingRunView {
-  id: string;
+  id: BillingRunId;
   type: string;
   status: string;
 }
@@ -40,7 +41,7 @@ export interface DocumentView {
 }
 
 export interface MatterInvariantInput {
-  matterId: string;
+  matterId: MatterId;
   /** Ärendenummer för läsbara meddelanden (valfritt). */
   matterNumber?: string;
   billingRuns: ReadonlyArray<BillingRunView>;

--- a/src/lib/shared/payment-reminders.ts
+++ b/src/lib/shared/payment-reminders.ts
@@ -23,18 +23,20 @@
  * per månad) → `remaining > 0` är grinden, enligt produktbeslut i #23.
  */
 
+import type { MatterId, PaymentPlanId } from "@/lib/shared/schemas/ids";
+
 export type ReminderKind = "DUE" | "OVERDUE";
 
 /** En aktiv plan med allt kärnan behöver för beslut + payload. */
 export interface PlanForScan {
-  planId: string;
+  planId: PaymentPlanId;
   status: string;
   monthlyAmount: number; // öre/månad
   dayOfMonth: number; // 1–28
   startDate: Date;
   invoiceTotalOre: number; // fakturans totalbelopp
   paidOre: number; // summa registrerade betalningar
-  matterId: string;
+  matterId: MatterId;
   matterNumber: string;
   matterTitle: string;
   recipientEmail: string;
@@ -43,15 +45,15 @@ export interface PlanForScan {
 
 /** Redan loggad påminnelse (idempotens-nyckel). */
 export interface LoggedReminder {
-  planId: string;
+  planId: PaymentPlanId;
   dueMonth: string; // "YYYY-MM"
   type: ReminderKind;
 }
 
 /** En påminnelse som ska skickas: loggas + emittas av anroparen. */
 export interface PlannedReminder {
-  planId: string;
-  matterId: string;
+  planId: PaymentPlanId;
+  matterId: MatterId;
   dueMonth: string; // "YYYY-MM"
   type: ReminderKind;
   eventType: "payment.due" | "payment.overdue";

--- a/src/lib/shared/payments/match-payments.ts
+++ b/src/lib/shared/payments/match-payments.ts
@@ -20,10 +20,11 @@
  * finns bland fakturornas betalningar flaggas som dubbletter och bokas inte.
  */
 
+import type { InvoiceId } from "@/lib/shared/schemas/ids";
 import type { CamtTransaction } from "./camt-parse";
 
 export interface InvoiceCandidate {
-  id: string;
+  id: InvoiceId;
   invoiceNumber: string | null;
   ocrReference: string | null;
   /** Fakturabelopp i öre (visning/rimlighetskoll — inte matchningsnyckel). */
@@ -34,7 +35,7 @@ export interface InvoiceCandidate {
 
 /** En bokningsbar betalning (en transaktion kan ge flera vid delbelopp). */
 export interface BookablePayment {
-  invoiceId: string;
+  invoiceId: InvoiceId;
   amountOre: number;
   /** Deterministisk referens för idempotens (txRef eller txRef#n). */
   reference: string;
@@ -46,7 +47,7 @@ export interface UnmatchedTransaction {
   tx: CamtTransaction;
   reason: "ingen-träff" | "tvetydig" | "dubblett" | "debet";
   /** Vid "tvetydig": de fakturor som träffades. */
-  candidateInvoiceIds?: string[];
+  candidateInvoiceIds?: InvoiceId[];
 }
 
 export interface MatchOutcome {
@@ -59,7 +60,7 @@ export function normalizeRef(raw: string): string {
   return raw.toUpperCase().replace(/[^A-Z0-9]/g, "");
 }
 
-type RefIndex = Map<string, { invoiceId: string; matchedBy: "ocr" | "invoiceNumber" }>;
+type RefIndex = Map<string, { invoiceId: InvoiceId; matchedBy: "ocr" | "invoiceNumber" }>;
 
 /** Index: normaliserad nyckel → faktura. OCR + fakturanr (med och utan F-prefix). */
 function buildRefIndex(invoices: readonly InvoiceCandidate[]): RefIndex {
@@ -78,7 +79,7 @@ function buildRefIndex(invoices: readonly InvoiceCandidate[]): RefIndex {
 }
 
 /** Slå upp en rå referens i indexet (normaliserad + siffervariant). */
-function lookup(index: RefIndex, raw: string): { invoiceId: string; matchedBy: "ocr" | "invoiceNumber" } | null {
+function lookup(index: RefIndex, raw: string): { invoiceId: InvoiceId; matchedBy: "ocr" | "invoiceNumber" } | null {
   const norm = normalizeRef(raw);
   if (norm === "") return null;
   const hit = index.get(norm) ?? index.get(norm.replace(/\D/g, ""));
@@ -92,7 +93,7 @@ function freeTextTokens(texts: readonly string[]): string[] {
 
 interface StructuredOutcome {
   payments?: BookablePayment[];
-  ambiguousInvoiceIds?: string[];
+  ambiguousInvoiceIds?: InvoiceId[];
 }
 
 /** Matcha en transaktions strukturerade referenser → bokningsbara delposter. */
@@ -132,15 +133,15 @@ function matchStructured(tx: CamtTransaction, index: RefIndex): StructuredOutcom
 }
 
 /** Matcha fri text: exakt EN unik faktura-träff krävs, annars null/tvetydig. */
-function matchFreeText(tx: CamtTransaction, index: RefIndex): { single?: BookablePayment; ambiguous?: string[] } {
-  const hits = new Map<string, "ocr" | "invoiceNumber">();
+function matchFreeText(tx: CamtTransaction, index: RefIndex): { single?: BookablePayment; ambiguous?: InvoiceId[] } {
+  const hits = new Map<InvoiceId, "ocr" | "invoiceNumber">();
   for (const token of freeTextTokens(tx.freeTexts)) {
     const hit = lookup(index, token);
     if (hit) hits.set(hit.invoiceId, hit.matchedBy);
   }
   if (hits.size === 0) return {};
   if (hits.size > 1) return { ambiguous: [...hits.keys()] };
-  const [invoiceId] = [...hits.keys()] as [string];
+  const [invoiceId] = [...hits.keys()] as [InvoiceId];
   return { single: { invoiceId, amountOre: tx.amountOre, reference: tx.reference, matchedBy: "freetext", tx } };
 }
 

--- a/src/lib/shared/payments/match-receivables.ts
+++ b/src/lib/shared/payments/match-receivables.ts
@@ -18,11 +18,12 @@
  * redan avprickade `paymentReference` → dubbletter filtreras.
  */
 
+import type { ExpectedReceivableId } from "@/lib/shared/schemas/ids";
 import type { CamtTransaction } from "./camt-parse";
 import { normalizeRef } from "./match-payments";
 
 export interface ReceivableCandidate {
-  id: string;
+  id: ExpectedReceivableId;
   /** Ärendenummer (AVA/KATS) — t.ex. "1154602" eller "F-2026-0001". */
   matterNumber: string | null;
   /** Domstolens målnummer — t.ex. "3288-26" (Matter.courtCaseNumber, #173). */
@@ -34,7 +35,7 @@ export interface ReceivableCandidate {
 }
 
 export interface ReceivableSuggestion {
-  receivableId: string;
+  receivableId: ExpectedReceivableId;
   /** Faktiskt utbetalt belopp (öre) — delbeloppet om split, annars tx-beloppet. */
   amountOre: number;
   /** Deterministisk referens (txRef / txRef#n) för idempotent settle. */
@@ -48,7 +49,7 @@ export interface ReceivableReviewItem {
   tx: CamtTransaction;
   matchedText: string;
   reason: "tvetydig" | "ingen-träff";
-  candidateReceivableIds?: string[];
+  candidateReceivableIds?: ExpectedReceivableId[];
 }
 
 export interface ReceivableMatchOutcome {

--- a/test/unit/lib/billed-per-lawyer.test.ts
+++ b/test/unit/lib/billed-per-lawyer.test.ts
@@ -5,13 +5,14 @@
 
 import { describe, it, expect } from "vitest-compat";
 import { billedPerLawyer, type BilledPerLawyerOpts, type BilledInvoiceInput } from "@/lib/shared/billed-per-lawyer";
+import { asId } from "@/lib/shared/schemas/ids";
 
 const PERIOD = { from: new Date("2026-06-01T00:00:00Z"), to: new Date("2026-06-30T23:59:59Z") };
 const PREV = { from: new Date("2026-05-01T00:00:00Z"), to: new Date("2026-05-31T23:59:59Z") };
 
 function run(over: Partial<BilledPerLawyerOpts>): ReturnType<typeof billedPerLawyer> {
   return billedPerLawyer({
-    userId: "anna",
+    userId: asId<"UserId">("anna"),
     invoices: [],
     frozenWork: [],
     period: PERIOD,
@@ -21,7 +22,7 @@ function run(over: Partial<BilledPerLawyerOpts>): ReturnType<typeof billedPerLaw
 }
 
 const inv = (o: Partial<BilledInvoiceInput> = {}) => ({
-  id: "i1", amountOre: 100_000, invoiceDate: new Date("2026-06-15T00:00:00Z"),
+  id: asId<"InvoiceId">("i1"), amountOre: 100_000, invoiceDate: new Date("2026-06-15T00:00:00Z"),
   status: "SENT", writtenOffAt: null, ...o,
 });
 
@@ -29,7 +30,7 @@ describe("billedPerLawyer", () => {
   it("attribuerar hela fakturan när bara en advokat har frozen tid", () => {
     const r = run({
       invoices: [inv()],
-      frozenWork: [{ invoiceId: "i1", userId: "anna", workOre: 80_000 }],
+      frozenWork: [{ invoiceId: asId<"InvoiceId">("i1"), userId: asId<"UserId">("anna"), workOre: 80_000 }],
     });
     expect(r.billedOre).toBe(100_000);
     expect(r.invoices).toHaveLength(1);
@@ -41,8 +42,8 @@ describe("billedPerLawyer", () => {
       invoices: [inv({ amountOre: 100_000 })],
       // Anna 75%, Björn 25% av arbetsvärdet.
       frozenWork: [
-        { invoiceId: "i1", userId: "anna", workOre: 75_000 },
-        { invoiceId: "i1", userId: "bjorn", workOre: 25_000 },
+        { invoiceId: asId<"InvoiceId">("i1"), userId: asId<"UserId">("anna"), workOre: 75_000 },
+        { invoiceId: asId<"InvoiceId">("i1"), userId: asId<"UserId">("bjorn"), workOre: 25_000 },
       ],
     });
     expect(r.billedOre).toBe(75_000); // Annas andel
@@ -51,7 +52,7 @@ describe("billedPerLawyer", () => {
   it("0 för advokat utan frozen tid i fakturan", () => {
     const r = run({
       invoices: [inv()],
-      frozenWork: [{ invoiceId: "i1", userId: "bjorn", workOre: 80_000 }],
+      frozenWork: [{ invoiceId: asId<"InvoiceId">("i1"), userId: asId<"UserId">("bjorn"), workOre: 80_000 }],
     });
     expect(r.billedOre).toBe(0);
     expect(r.invoices).toHaveLength(0);
@@ -66,14 +67,14 @@ describe("billedPerLawyer", () => {
   it("räknar bara utfärdade statusar — DRAFT/CANCELLED exkluderas", () => {
     const r = run({
       invoices: [
-        inv({ id: "draft", status: "DRAFT" }),
-        inv({ id: "cancelled", status: "CANCELLED" }),
-        inv({ id: "sent", status: "SENT" }),
+        inv({ id: asId<"InvoiceId">("draft"), status: "DRAFT" }),
+        inv({ id: asId<"InvoiceId">("cancelled"), status: "CANCELLED" }),
+        inv({ id: asId<"InvoiceId">("sent"), status: "SENT" }),
       ],
       frozenWork: [
-        { invoiceId: "draft", userId: "anna", workOre: 10_000 },
-        { invoiceId: "cancelled", userId: "anna", workOre: 10_000 },
-        { invoiceId: "sent", userId: "anna", workOre: 10_000 },
+        { invoiceId: asId<"InvoiceId">("draft"), userId: asId<"UserId">("anna"), workOre: 10_000 },
+        { invoiceId: asId<"InvoiceId">("cancelled"), userId: asId<"UserId">("anna"), workOre: 10_000 },
+        { invoiceId: asId<"InvoiceId">("sent"), userId: asId<"UserId">("anna"), workOre: 10_000 },
       ],
     });
     expect(r.invoices.map((i) => i.id)).toEqual(["sent"]);
@@ -83,14 +84,14 @@ describe("billedPerLawyer", () => {
   it("filtrerar på invoiceDate inom perioden", () => {
     const r = run({
       invoices: [
-        inv({ id: "before", invoiceDate: new Date("2026-05-20T00:00:00Z") }),
-        inv({ id: "inside", invoiceDate: new Date("2026-06-10T00:00:00Z") }),
-        inv({ id: "after", invoiceDate: new Date("2026-07-01T00:00:00Z") }),
+        inv({ id: asId<"InvoiceId">("before"), invoiceDate: new Date("2026-05-20T00:00:00Z") }),
+        inv({ id: asId<"InvoiceId">("inside"), invoiceDate: new Date("2026-06-10T00:00:00Z") }),
+        inv({ id: asId<"InvoiceId">("after"), invoiceDate: new Date("2026-07-01T00:00:00Z") }),
       ],
       frozenWork: [
-        { invoiceId: "before", userId: "anna", workOre: 1 },
-        { invoiceId: "inside", userId: "anna", workOre: 1 },
-        { invoiceId: "after", userId: "anna", workOre: 1 },
+        { invoiceId: asId<"InvoiceId">("before"), userId: asId<"UserId">("anna"), workOre: 1 },
+        { invoiceId: asId<"InvoiceId">("inside"), userId: asId<"UserId">("anna"), workOre: 1 },
+        { invoiceId: asId<"InvoiceId">("after"), userId: asId<"UserId">("anna"), workOre: 1 },
       ],
     });
     expect(r.invoices.map((i) => i.id)).toEqual(["inside"]);
@@ -99,13 +100,13 @@ describe("billedPerLawyer", () => {
   it("drar av advokatens andel av fakturor avskrivna i föregående period", () => {
     const r = run({
       invoices: [
-        inv({ id: "billed", amountOre: 100_000, invoiceDate: new Date("2026-06-15T00:00:00Z"), status: "SENT" }),
+        inv({ id: asId<"InvoiceId">("billed"), amountOre: 100_000, invoiceDate: new Date("2026-06-15T00:00:00Z"), status: "SENT" }),
         // Avskriven i maj (föregående period). Utfärdad tidigare, så inte med i denna periods "billed".
-        inv({ id: "writeoff", amountOre: 40_000, invoiceDate: new Date("2026-03-01T00:00:00Z"), status: "BAD_DEBT", writtenOffAt: new Date("2026-05-10T00:00:00Z") }),
+        inv({ id: asId<"InvoiceId">("writeoff"), amountOre: 40_000, invoiceDate: new Date("2026-03-01T00:00:00Z"), status: "BAD_DEBT", writtenOffAt: new Date("2026-05-10T00:00:00Z") }),
       ],
       frozenWork: [
-        { invoiceId: "billed", userId: "anna", workOre: 10_000 },
-        { invoiceId: "writeoff", userId: "anna", workOre: 10_000 },
+        { invoiceId: asId<"InvoiceId">("billed"), userId: asId<"UserId">("anna"), workOre: 10_000 },
+        { invoiceId: asId<"InvoiceId">("writeoff"), userId: asId<"UserId">("anna"), workOre: 10_000 },
       ],
     });
     expect(r.billedOre).toBe(100_000);
@@ -116,9 +117,9 @@ describe("billedPerLawyer", () => {
   it("avskrivning utanför föregående period påverkar inte avdraget", () => {
     const r = run({
       invoices: [
-        inv({ id: "writeoff-apr", amountOre: 40_000, status: "BAD_DEBT", invoiceDate: new Date("2026-02-01T00:00:00Z"), writtenOffAt: new Date("2026-04-10T00:00:00Z") }),
+        inv({ id: asId<"InvoiceId">("writeoff-apr"), amountOre: 40_000, status: "BAD_DEBT", invoiceDate: new Date("2026-02-01T00:00:00Z"), writtenOffAt: new Date("2026-04-10T00:00:00Z") }),
       ],
-      frozenWork: [{ invoiceId: "writeoff-apr", userId: "anna", workOre: 10_000 }],
+      frozenWork: [{ invoiceId: asId<"InvoiceId">("writeoff-apr"), userId: asId<"UserId">("anna"), workOre: 10_000 }],
     });
     expect(r.writeOffOre).toBe(0);
     expect(r.netOre).toBe(0);
@@ -127,11 +128,11 @@ describe("billedPerLawyer", () => {
   it("avskriven faktura fördelar avdraget proportionellt", () => {
     const r = run({
       invoices: [
-        inv({ id: "wo", amountOre: 100_000, status: "BAD_DEBT", invoiceDate: new Date("2026-03-01T00:00:00Z"), writtenOffAt: new Date("2026-05-15T00:00:00Z") }),
+        inv({ id: asId<"InvoiceId">("wo"), amountOre: 100_000, status: "BAD_DEBT", invoiceDate: new Date("2026-03-01T00:00:00Z"), writtenOffAt: new Date("2026-05-15T00:00:00Z") }),
       ],
       frozenWork: [
-        { invoiceId: "wo", userId: "anna", workOre: 30_000 },
-        { invoiceId: "wo", userId: "bjorn", workOre: 70_000 },
+        { invoiceId: asId<"InvoiceId">("wo"), userId: asId<"UserId">("anna"), workOre: 30_000 },
+        { invoiceId: asId<"InvoiceId">("wo"), userId: asId<"UserId">("bjorn"), workOre: 70_000 },
       ],
     });
     expect(r.writeOffOre).toBe(30_000); // Annas 30%

--- a/test/unit/lib/diagnostics/use-matter-invariants.test.tsx
+++ b/test/unit/lib/diagnostics/use-matter-invariants.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest-compat";
 
 import { issueStore } from "@/lib/client/diagnostics";
 import { useMatterInvariants } from "@/lib/client/diagnostics/use-matter-invariants";
+import { asId } from "@/lib/shared/schemas/ids";
 
 // Mockbara query-resultat — styrs per test via dessa variabler.
 let runsResult: { data?: { runs: unknown[] } } = {};
@@ -26,14 +27,14 @@ beforeEach(() => {
 
 describe("useMatterInvariants", () => {
   it("rapporterar inget innan datat laddats", () => {
-    renderHook(() => useMatterInvariants({ matterId: "m-1", matterNumber: "2026-1" }));
+    renderHook(() => useMatterInvariants({ matterId: asId<"MatterId">("m-1"), matterNumber: "2026-1" }));
     expect(issueStore.count()).toBe(0);
   });
 
   it("rapporterar KR_PENDING_NO_DOC när KR-dokument saknas", () => {
     runsResult = { data: { runs: [pendingKr] } };
     docsResult = { data: { documents: [] } };
-    renderHook(() => useMatterInvariants({ matterId: "m-1", matterNumber: "2026-1" }));
+    renderHook(() => useMatterInvariants({ matterId: asId<"MatterId">("m-1"), matterNumber: "2026-1" }));
     expect(issueStore.count()).toBe(1);
     expect(issueStore.list()[0]!.code).toBe("KR_PENDING_NO_DOC");
   });
@@ -41,7 +42,7 @@ describe("useMatterInvariants", () => {
   it("rapporterar inget när KR-dokument finns", () => {
     runsResult = { data: { runs: [pendingKr] } };
     docsResult = { data: { documents: [{ documentType: "Kostnadsräkning" }] } };
-    renderHook(() => useMatterInvariants({ matterId: "m-1" }));
+    renderHook(() => useMatterInvariants({ matterId: asId<"MatterId">("m-1") }));
     expect(issueStore.count()).toBe(0);
   });
 });

--- a/test/unit/lib/payments/match-payments.test.ts
+++ b/test/unit/lib/payments/match-payments.test.ts
@@ -13,15 +13,16 @@ import {
   normalizeRef,
   type InvoiceCandidate,
 } from "@/lib/shared/payments/match-payments";
+import { asId } from "@/lib/shared/schemas/ids";
 
 const OCR_1 = buildOcrReference("20260001");
 const OCR_2 = buildOcrReference("20260002");
 
 const INVOICES: InvoiceCandidate[] = [
-  { id: "inv-1", invoiceNumber: "F-2026-0001", ocrReference: OCR_1, amount: 100_000, paymentReferences: [] },
-  { id: "inv-2", invoiceNumber: "F-2026-0002", ocrReference: OCR_2, amount: 50_000, paymentReferences: [] },
+  { id: asId<"InvoiceId">("inv-1"), invoiceNumber: "F-2026-0001", ocrReference: OCR_1, amount: 100_000, paymentReferences: [] },
+  { id: asId<"InvoiceId">("inv-2"), invoiceNumber: "F-2026-0002", ocrReference: OCR_2, amount: 50_000, paymentReferences: [] },
   // Kostnadsräkning till domstol: varken OCR eller fakturanummer (#173).
-  { id: "inv-court", invoiceNumber: null, ocrReference: null, amount: 75_000, paymentReferences: [] },
+  { id: asId<"InvoiceId">("inv-court"), invoiceNumber: null, ocrReference: null, amount: 75_000, paymentReferences: [] },
 ];
 
 function tx(over: Partial<CamtTransaction>): CamtTransaction {

--- a/test/unit/lib/payments/match-receivables.test.ts
+++ b/test/unit/lib/payments/match-receivables.test.ts
@@ -11,12 +11,20 @@ import {
   matchReceivables,
   type ReceivableCandidate,
 } from "@/lib/shared/payments/match-receivables";
+import { asId } from "@/lib/shared/schemas/ids";
 
 const FIXTURES = resolve(__dirname, "../../../fixtures/camt-seb");
 const readDomstol = () => parseCamtXml(readFileSync(resolve(FIXTURES, "camt.053_domstolsverket.xml"), "utf8"));
 
-function cand(over: Partial<ReceivableCandidate> & { id: string }): ReceivableCandidate {
-  return { matterNumber: null, courtCaseNumber: null, expectedAmount: 0, settledReferences: [], ...over };
+function cand(over: Omit<Partial<ReceivableCandidate>, "id"> & { id: string }): ReceivableCandidate {
+  return {
+    matterNumber: null,
+    courtCaseNumber: null,
+    expectedAmount: 0,
+    settledReferences: [],
+    ...over,
+    id: asId<"ExpectedReceivableId">(over.id),
+  };
 }
 
 describe("matchReceivables — Domstolsverket-fixtur (#175)", () => {
@@ -28,7 +36,7 @@ describe("matchReceivables — Domstolsverket-fixtur (#175)", () => {
       cand({ id: "er-1", courtCaseNumber: "3288-26", expectedAmount: 8000_00 }),
     ]);
     expect(out.suggestions).toHaveLength(1);
-    expect(out.suggestions[0]!.receivableId).toBe("er-1");
+    expect(out.suggestions[0]!.receivableId).toBe(asId<"ExpectedReceivableId">("er-1"));
     expect(out.suggestions[0]!.matchedBy).toBe("courtCaseNumber");
     expect(out.suggestions[0]!.amountOre).toBe(7246_00); // delbeloppet, ej hela tx
   });
@@ -48,8 +56,8 @@ describe("matchReceivables — Domstolsverket-fixtur (#175)", () => {
       cand({ id: "b", courtCaseNumber: "5799-25" }), // "5291 5799-25 PARTNER MA" → 73143.00
     ]);
     const ids = out.suggestions.map((s) => s.receivableId).sort();
-    expect(ids).toEqual(["a", "b"]);
-    expect(out.suggestions.find((s) => s.receivableId === "b")!.amountOre).toBe(73143_00);
+    expect(ids).toEqual([asId<"ExpectedReceivableId">("a"), asId<"ExpectedReceivableId">("b")]);
+    expect(out.suggestions.find((s) => s.receivableId === asId<"ExpectedReceivableId">("b"))!.amountOre).toBe(73143_00);
   });
 
   it("redan avprickad referens (dubblett) ger inget förslag", () => {
@@ -86,7 +94,10 @@ describe("matchReceivables — syntetiska fall", () => {
     ]);
     expect(out.suggestions).toHaveLength(0);
     expect(out.review[0]!.reason).toBe("tvetydig");
-    expect(out.review[0]!.candidateReceivableIds!.sort()).toEqual(["x", "y"]);
+    expect(out.review[0]!.candidateReceivableIds!.sort()).toEqual([
+      asId<"ExpectedReceivableId">("x"),
+      asId<"ExpectedReceivableId">("y"),
+    ]);
   });
 
   it("DEBIT-transaktion ignoreras (bara inbetalningar)", () => {

--- a/test/unit/lib/shared/payment-reminders.test.ts
+++ b/test/unit/lib/shared/payment-reminders.test.ts
@@ -4,13 +4,14 @@
  */
 import { describe, it, expect } from "vitest-compat";
 import { computeDueReminders, type PlanForScan, type LoggedReminder } from "@/lib/shared/payment-reminders";
+import { asId } from "@/lib/shared/schemas/ids";
 
 function plan(over: Partial<PlanForScan> = {}): PlanForScan {
   return {
-    planId: "pp-1", status: "ACTIVE", monthlyAmount: 50000, dayOfMonth: 10,
+    planId: asId<"PaymentPlanId">("pp-1"), status: "ACTIVE", monthlyAmount: 50000, dayOfMonth: 10,
     startDate: new Date("2026-01-15T00:00:00Z"),
     invoiceTotalOre: 600000, paidOre: 0,
-    matterId: "m-1", matterNumber: "2026-0001", matterTitle: "Tvist",
+    matterId: asId<"MatterId">("m-1"), matterNumber: "2026-0001", matterTitle: "Tvist",
     recipientEmail: "klient@example.se", recipientName: "Klient AB",
     ...over,
   };
@@ -37,7 +38,7 @@ describe("computeDueReminders — DUE", () => {
   });
 
   it("idempotens: redan loggad DUE → ingen ny", () => {
-    const logged: LoggedReminder[] = [{ planId: "pp-1", dueMonth: "2026-03", type: "DUE" }];
+    const logged: LoggedReminder[] = [{ planId: asId<"PaymentPlanId">("pp-1"), dueMonth: "2026-03", type: "DUE" }];
     expect(computeDueReminders([thisMonth()], new Date("2026-03-10T09:00:00Z"), logged)).toHaveLength(0);
   });
 });
@@ -59,7 +60,7 @@ describe("computeDueReminders — OVERDUE", () => {
   });
 
   it("loggad OVERDUE för föreg. månad → faller igenom till DUE", () => {
-    const logged: LoggedReminder[] = [{ planId: "pp-1", dueMonth: "2026-02", type: "OVERDUE" }];
+    const logged: LoggedReminder[] = [{ planId: asId<"PaymentPlanId">("pp-1"), dueMonth: "2026-02", type: "OVERDUE" }];
     const out = computeDueReminders([plan()], new Date("2026-03-10T09:00:00Z"), logged);
     expect(out[0]!.type).toBe("DUE");
     expect(out[0]!.dueMonth).toBe("2026-03");
@@ -75,7 +76,7 @@ describe("computeDueReminders — grindar", () => {
     expect(computeDueReminders([plan({ status: "COMPLETED" })], new Date("2026-03-10T09:00:00Z"), NONE)).toHaveLength(0);
   });
   it("remaining beräknas som total − betalt", () => {
-    const out = computeDueReminders([plan({ paidOre: 100000 })], new Date("2026-03-10T09:00:00Z"), [{ planId: "pp-1", dueMonth: "2026-02", type: "OVERDUE" }]);
+    const out = computeDueReminders([plan({ paidOre: 100000 })], new Date("2026-03-10T09:00:00Z"), [{ planId: asId<"PaymentPlanId">("pp-1"), dueMonth: "2026-02", type: "OVERDUE" }]);
     expect(out[0]!.payload.remainingAmount).toBe(500000);
   });
 });

--- a/test/unit/server/events/emit.test.ts
+++ b/test/unit/server/events/emit.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi } from "vitest-compat";
 import { emit } from "@/lib/server/events/emit";
+import { asId } from "@/lib/shared/schemas/ids";
 
 function makeCtx() {
   const emitFn = vi.fn(async (input: unknown) => ({ id: "e1", ts: "now", ...input as object }));
   return {
     ctx: {
-      user: { id: "anna" },
+      user: { id: asId<"UserId">("anna") },
       dataStore: {
         events: { emit: emitFn, query: vi.fn(), iterate: vi.fn(), onNewEvent: vi.fn() },
       } as never,
@@ -17,7 +18,7 @@ function makeCtx() {
 describe("emit-helpers", () => {
   it("matterCreated skickar rätt payload + matterId", async () => {
     const { ctx, emitFn } = makeCtx();
-    await emit.matterCreated(ctx, { id: "m1", matterNumber: "2026-0001", title: "X" });
+    await emit.matterCreated(ctx, { id: asId<"MatterId">("m1"), matterNumber: "2026-0001", title: "X" });
     const arg = emitFn.mock.calls[0]![0] as Record<string, unknown>;
     expect(arg.type).toBe("matter.created");
     expect(arg.matterId).toBe("m1");
@@ -28,7 +29,7 @@ describe("emit-helpers", () => {
 
   it("matterStatusChanged loggar from + to", async () => {
     const { ctx, emitFn } = makeCtx();
-    await emit.matterStatusChanged(ctx, "m1", "ACTIVE", "ARCHIVED");
+    await emit.matterStatusChanged(ctx, asId<"MatterId">("m1"), "ACTIVE", "ARCHIVED");
     const arg = emitFn.mock.calls[0]![0] as Record<string, unknown>;
     expect(arg.type).toBe("matter.status_changed");
     expect(arg.payload).toEqual({ from: "ACTIVE", to: "ARCHIVED" });
@@ -36,7 +37,7 @@ describe("emit-helpers", () => {
 
   it("invoicePaymentReceived inkluderar amount", async () => {
     const { ctx, emitFn } = makeCtx();
-    await emit.invoicePaymentReceived(ctx, "inv-1", "m1", 5000);
+    await emit.invoicePaymentReceived(ctx, asId<"InvoiceId">("inv-1"), asId<"MatterId">("m1"), 5000);
     const arg = emitFn.mock.calls[0]![0] as Record<string, unknown>;
     expect(arg.type).toBe("invoice.payment_received");
     expect(arg.payload).toEqual({ invoiceId: "inv-1", amount: 5000 });
@@ -44,7 +45,7 @@ describe("emit-helpers", () => {
 
   it("timeEntryAdded inkluderar minutes och matterId", async () => {
     const { ctx, emitFn } = makeCtx();
-    await emit.timeEntryAdded(ctx, { id: "t1", matterId: "m1", minutes: 90 });
+    await emit.timeEntryAdded(ctx, { id: asId<"TimeEntryId">("t1"), matterId: asId<"MatterId">("m1"), minutes: 90 });
     const arg = emitFn.mock.calls[0]![0] as Record<string, unknown>;
     expect(arg.type).toBe("time-entry.added");
     expect(arg.matterId).toBe("m1");
@@ -53,24 +54,24 @@ describe("emit-helpers", () => {
 
   it("täcker alla emit-helpers (varje typ → ett event)", async () => {
     const { ctx, emitFn } = makeCtx();
-    await emit.matterUpdated(ctx, "m1", { title: "ny" });
-    await emit.matterArchived(ctx, "m1");
-    await emit.contactCreated(ctx, { id: "c1", name: "Anna" });
-    await emit.contactUpdated(ctx, "c1", { name: "Anna B" });
-    await emit.contactDeleted(ctx, "c1");
-    await emit.documentUploaded(ctx, { id: "d1", fileName: "f.pdf", matterId: "m1" });
-    await emit.documentDeleted(ctx, { id: "d1", matterId: "m1" });
-    await emit.documentAnalyzed(ctx, { id: "d1", matterId: "m1" }, { kind: "kontrakt" });
-    await emit.invoiceCreated(ctx, { id: "inv1", matterId: "m1", amount: 1000 });
-    await emit.invoiceSent(ctx, "inv1", "m1");
-    await emit.invoiceWrittenOff(ctx, "inv1", "m1", 250);
-    await emit.timeEntryUpdated(ctx, { id: "t1", matterId: "m1" });
-    await emit.timeEntryDeleted(ctx, "t1", "m1");
-    await emit.kostnadsrakningGenerated(ctx, "m1", {
-      documentId: "d1", fileName: "kr.pdf", totalInclVat: 5000,
-      huvudforhandlingMinutes: 120, organizationId: "org-1",
+    await emit.matterUpdated(ctx, asId<"MatterId">("m1"), { title: "ny" });
+    await emit.matterArchived(ctx, asId<"MatterId">("m1"));
+    await emit.contactCreated(ctx, { id: asId<"ContactId">("c1"), name: "Anna" });
+    await emit.contactUpdated(ctx, asId<"ContactId">("c1"), { name: "Anna B" });
+    await emit.contactDeleted(ctx, asId<"ContactId">("c1"));
+    await emit.documentUploaded(ctx, { id: asId<"DocumentId">("d1"), fileName: "f.pdf", matterId: asId<"MatterId">("m1") });
+    await emit.documentDeleted(ctx, { id: asId<"DocumentId">("d1"), matterId: asId<"MatterId">("m1") });
+    await emit.documentAnalyzed(ctx, { id: asId<"DocumentId">("d1"), matterId: asId<"MatterId">("m1") }, { kind: "kontrakt" });
+    await emit.invoiceCreated(ctx, { id: asId<"InvoiceId">("inv1"), matterId: asId<"MatterId">("m1"), amount: 1000 });
+    await emit.invoiceSent(ctx, asId<"InvoiceId">("inv1"), asId<"MatterId">("m1"));
+    await emit.invoiceWrittenOff(ctx, asId<"InvoiceId">("inv1"), asId<"MatterId">("m1"), 250);
+    await emit.timeEntryUpdated(ctx, { id: asId<"TimeEntryId">("t1"), matterId: asId<"MatterId">("m1") });
+    await emit.timeEntryDeleted(ctx, asId<"TimeEntryId">("t1"), asId<"MatterId">("m1"));
+    await emit.kostnadsrakningGenerated(ctx, asId<"MatterId">("m1"), {
+      documentId: asId<"DocumentId">("d1"), fileName: "kr.pdf", totalInclVat: 5000,
+      huvudforhandlingMinutes: 120, organizationId: asId<"OrganizationId">("org-1"),
     });
-    await emit.paymentDue(ctx, { invoiceId: "inv1" }, "m1");
+    await emit.paymentDue(ctx, { invoiceId: "inv1" }, asId<"MatterId">("m1"));
     await emit.paymentOverdue(ctx, { invoiceId: "inv1" });
     await emit.userAction(ctx, { action: "login" });
 
@@ -94,7 +95,7 @@ describe("emit-helpers", () => {
   it("emit-fel kraschar INTE caller (safeEmit sväljer)", async () => {
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const ctx = {
-      user: { id: "anna" },
+      user: { id: asId<"UserId">("anna") },
       dataStore: {
         events: {
           emit: vi.fn(async () => { throw new Error("DB-fel"); }),
@@ -104,7 +105,7 @@ describe("emit-helpers", () => {
         },
       } as never,
     };
-    await expect(emit.matterCreated(ctx, { id: "m1", matterNumber: "x", title: "y" })).resolves.toBeUndefined();
+    await expect(emit.matterCreated(ctx, { id: asId<"MatterId">("m1"), matterNumber: "x", title: "y" })).resolves.toBeUndefined();
     expect(errSpy).toHaveBeenCalled(); // oväntat fel → loggas
     errSpy.mockRestore();
   });
@@ -114,7 +115,7 @@ describe("emit-helpers", () => {
     const readOnly = new Error('Demo-läget är read-only — kan inte köra "events.emit".');
     readOnly.name = "ReadOnlyError";
     const ctx = {
-      user: { id: "anna" },
+      user: { id: asId<"UserId">("anna") },
       dataStore: {
         events: {
           emit: vi.fn(async () => { throw readOnly; }),
@@ -124,7 +125,7 @@ describe("emit-helpers", () => {
         },
       } as never,
     };
-    await expect(emit.matterCreated(ctx, { id: "m1", matterNumber: "x", title: "y" })).resolves.toBeUndefined();
+    await expect(emit.matterCreated(ctx, { id: asId<"MatterId">("m1"), matterNumber: "x", title: "y" })).resolves.toBeUndefined();
     expect(errSpy).not.toHaveBeenCalled(); // väntat → tyst
     errSpy.mockRestore();
   });

--- a/test/unit/shared/diagnostics/invariants.test.ts
+++ b/test/unit/shared/diagnostics/invariants.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from "vitest-compat";
 import { detectMatterInvariants, type MatterInvariantInput } from "@/lib/shared/diagnostics/invariants";
 import { KOSTNADSRAKNING_DOCUMENT_TYPE } from "@/lib/shared/schemas/document";
+import { asId } from "@/lib/shared/schemas/ids";
 
 function input(over: Partial<MatterInvariantInput> = {}): MatterInvariantInput {
   return {
-    matterId: "m-1",
+    matterId: asId<"MatterId">("m-1"),
     matterNumber: "2026-0001",
     billingRuns: [],
     documents: [],
@@ -12,7 +13,7 @@ function input(over: Partial<MatterInvariantInput> = {}): MatterInvariantInput {
   };
 }
 
-const pendingKr = { id: "br-1", type: "KOSTNADSRAKNING", status: "PENDING_VERDICT" };
+const pendingKr = { id: asId<"BillingRunId">("br-1"), type: "KOSTNADSRAKNING", status: "PENDING_VERDICT" };
 
 describe("detectMatterInvariants — KR_PENDING_NO_DOC", () => {
   it("flaggar pending kostnadsräkning utan KR-dokument", () => {
@@ -42,7 +43,7 @@ describe("detectMatterInvariants — KR_PENDING_NO_DOC", () => {
 
   it("flaggar inte KR-runs i annat status än PENDING_VERDICT", () => {
     const v = detectMatterInvariants(input({
-      billingRuns: [{ id: "br-2", type: "KOSTNADSRAKNING", status: "SENT" }],
+      billingRuns: [{ id: asId<"BillingRunId">("br-2"), type: "KOSTNADSRAKNING", status: "SENT" }],
       documents: [],
     }));
     expect(v).toHaveLength(0);
@@ -50,7 +51,7 @@ describe("detectMatterInvariants — KR_PENDING_NO_DOC", () => {
 
   it("flaggar inte andra billing-run-typer i PENDING_VERDICT", () => {
     const v = detectMatterInvariants(input({
-      billingRuns: [{ id: "br-3", type: "FINAL", status: "PENDING_VERDICT" }],
+      billingRuns: [{ id: asId<"BillingRunId">("br-3"), type: "FINAL", status: "PENDING_VERDICT" }],
       documents: [],
     }));
     expect(v).toHaveLength(0);
@@ -58,14 +59,14 @@ describe("detectMatterInvariants — KR_PENDING_NO_DOC", () => {
 
   it("ger en violation per pending KR-run när dokument saknas", () => {
     const v = detectMatterInvariants(input({
-      billingRuns: [pendingKr, { id: "br-9", type: "KOSTNADSRAKNING", status: "PENDING_VERDICT" }],
+      billingRuns: [pendingKr, { id: asId<"BillingRunId">("br-9"), type: "KOSTNADSRAKNING", status: "PENDING_VERDICT" }],
       documents: [],
     }));
     expect(v.map((x) => x.context.billingRunId).sort()).toEqual(["br-1", "br-9"]);
   });
 
   it("faller tillbaka på matterId i meddelandet när matterNumber saknas", () => {
-    const v = detectMatterInvariants({ matterId: "m-x", billingRuns: [pendingKr], documents: [] });
+    const v = detectMatterInvariants({ matterId: asId<"MatterId">("m-x"), billingRuns: [pendingKr], documents: [] });
     expect(v[0]!.message).toContain("m-x");
     expect(v[0]!.context.matterNumber).toBeUndefined();
   });


### PR DESCRIPTION
ID-brandning (B5, #750) — leaf-cleanup av kvarvarande genuina domän-id-strängar i leaf-lagret (ej kontrakt/props — de är redan klara).

- **events/emit.ts** — `EmitCtx.user.id` + alla emit-helper-params (matter/contact/document/invoice/timeEntry-id + matterId/documentId/organizationId) → brandade.
- **document/suggestions.ts** — lokala `Suggestion`-typen + helper-params → branded (slopar redundanta `asId`).
- **shared pure-calc** — billed-per-lawyer (`InvoiceId`/`UserId`), payment-reminders (`PaymentPlanId`/`MatterId`), match-payments/match-receivables (`InvoiceId`/`ExpectedReceivableId`), diagnostics/invariants (`MatterId`/`BillingRunId`).
- **matter-org.ts** — param + RETURN → `OrganizationId`; drizzle `resolveOrg` row-cast brandade.

**Medvetet kvar som `string`** (ej domän-id): storagePath/cache-keys/camt-referenser/dueMonth/invoiceNumber/OCR/queue-id.

Inga typer försvagade; rent i alla tre tsc-projekt, 1330 server/shared/integration-tester gröna.

→ Strong-typing-svepet (#750) i allt väsentligt klart: enum-fasen + hela ID-brandnings-fasen (bas-kontrakt → repos → router-inputs → Principal → klient-props → helper → leaf).

Refs #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)