### PR TITLE
refactor: slutstäd leaf-domän-id:n (ports/lease/invoice-impl/reports/client-cache) (B6)

### DIFF
--- a/src/components/documents/document-browser.tsx
+++ b/src/components/documents/document-browser.tsx
@@ -329,7 +329,7 @@ function useFileUpload({ matterId, mutations, fileInputRef }: {
         // registrerats → repekar storagePath + triggar server-klassificering.
         if (serverBytes) {
           const { saveDocumentContent } = await import("@/lib/client/backend/save-document-content");
-          await saveDocumentContent(utils.client, result.id, serverBytes);
+          await saveDocumentContent(utils.client, asId<"DocumentId">(result.id), serverBytes);
         }
       } finally {
         await utils.document.tree.invalidate({ matterId });

--- a/src/lib/client/backend/content-cache.ts
+++ b/src/lib/client/backend/content-cache.ts
@@ -14,6 +14,7 @@
  */
 
 import { IdbKv } from "@/lib/server/data-store/in-memory/idb-kv";
+import { asId, type DocumentId } from "@/lib/shared/schemas/ids";
 
 const DB_NAME = "ava-doc-content";
 const STORE = "kv";
@@ -30,7 +31,7 @@ export class DocumentContentCache {
   }
 
   /** Cacha bytes (by sha) + markera dokumentet som väntande på upload. */
-  async cache(documentId: string, sha: string, bytes: Uint8Array): Promise<void> {
+  async cache(documentId: DocumentId, sha: string, bytes: Uint8Array): Promise<void> {
     await this.kv.put(blobKey(sha), bytes);
     const pending = (await this.kv.get<PendingMap>(PENDING_KEY)) ?? {};
     pending[documentId] = sha; // coalesce: senaste sha per dokument
@@ -49,13 +50,13 @@ export class DocumentContentCache {
   }
 
   /** Dokument som väntar på byte-upload ({documentId, sha}). */
-  async pendingUploads(): Promise<Array<{ documentId: string; sha: string }>> {
+  async pendingUploads(): Promise<Array<{ documentId: DocumentId; sha: string }>> {
     const pending = (await this.kv.get<PendingMap>(PENDING_KEY)) ?? {};
-    return Object.entries(pending).map(([documentId, sha]) => ({ documentId, sha }));
+    return Object.entries(pending).map(([documentId, sha]) => ({ documentId: asId<"DocumentId">(documentId), sha }));
   }
 
   /** Ta bort dokumentet ur pending-manifestet (blobben behålls i läs-cachen). */
-  async markUploaded(documentId: string): Promise<void> {
+  async markUploaded(documentId: DocumentId): Promise<void> {
     const pending = (await this.kv.get<PendingMap>(PENDING_KEY)) ?? {};
     delete pending[documentId];
     await this.kv.put(PENDING_KEY, pending);

--- a/src/lib/client/backend/content-sync.ts
+++ b/src/lib/client/backend/content-sync.ts
@@ -13,19 +13,20 @@
  */
 
 import { bytesToBase64, contentStoragePath } from "@/lib/shared/content-address";
+import type { DocumentId } from "@/lib/shared/schemas/ids";
 import { DocumentContentCache } from "./content-cache";
 
 export interface ContentSyncDeps {
   /** Väntande {documentId, sha}. */
-  pending: () => Promise<Array<{ documentId: string; sha: string }>>;
+  pending: () => Promise<Array<{ documentId: DocumentId; sha: string }>>;
   /** Vilka av dessa storagePaths saknar servern? */
   missing: (storagePaths: string[]) => Promise<string[]>;
   /** Cachade bytes för en sha (null = borta → hoppa). */
   getBytes: (sha: string) => Promise<Uint8Array | null>;
   /** Ladda upp bytes för ett dokument. */
-  upload: (documentId: string, bytes: Uint8Array) => Promise<void>;
+  upload: (documentId: DocumentId, bytes: Uint8Array) => Promise<void>;
   /** Markera dokumentet som synkat (ta ur pending). */
-  markUploaded: (documentId: string) => Promise<void>;
+  markUploaded: (documentId: DocumentId) => Promise<void>;
 }
 
 /** Ladda upp saknade blobbar. Returnerar sha:n som faktiskt laddades upp. */
@@ -49,7 +50,7 @@ export async function runContentSync(deps: ContentSyncDeps): Promise<string[]> {
 export interface ContentSyncClient {
   document: {
     missingContent: { query: (input: { storagePaths: string[] }) => Promise<{ missing: string[] }> };
-    uploadContent: { mutate: (input: { documentId: string; contentBase64: string }) => Promise<unknown> };
+    uploadContent: { mutate: (input: { documentId: DocumentId; contentBase64: string }) => Promise<unknown> };
   };
 }
 

--- a/src/lib/client/backend/save-document-content.ts
+++ b/src/lib/client/backend/save-document-content.ts
@@ -11,18 +11,19 @@
  */
 
 import { bytesToBase64, sha256Hex } from "@/lib/shared/content-address";
+import type { DocumentId } from "@/lib/shared/schemas/ids";
 import { DocumentContentCache } from "./content-cache";
 
 /** tRPC-ytan primitiven behöver (strukturell). */
 export interface UploadClient {
   document: {
-    uploadContent: { mutate: (input: { documentId: string; contentBase64: string }) => Promise<unknown> };
+    uploadContent: { mutate: (input: { documentId: DocumentId; contentBase64: string }) => Promise<unknown> };
   };
 }
 
 export async function saveDocumentContent(
   client: UploadClient,
-  documentId: string,
+  documentId: DocumentId,
   bytes: Uint8Array,
   cache: DocumentContentCache = new DocumentContentCache(),
 ): Promise<string> {

--- a/src/lib/client/template-recipients.ts
+++ b/src/lib/client/template-recipients.ts
@@ -11,12 +11,13 @@
  * filskrivning).
  */
 
+import type { ContactId, MatterId } from "@/lib/shared/schemas/ids";
 import { labelForMatterRole } from "./labels";
 
 // template-context modulen är borttagen (Prisma-dependent). En kontakts
 // data i template-rendering är en sub-set av Contact-schemat.
 export interface RecipientContactData {
-  id?: string;
+  id?: ContactId;
   name: string;
   email: string | null;
   phone: string | null;
@@ -29,12 +30,12 @@ export interface RecipientContactData {
 }
 
 export interface ResolvedRecipient {
-  contactId: string;
+  contactId: ContactId;
   data: RecipientContactData;
 }
 
 export interface MatterContactLink {
-  contactId: string;
+  contactId: ContactId;
   role: string;
   notes: string | null;
   contact: {
@@ -48,7 +49,7 @@ export interface MatterContactLink {
 }
 
 export class RecipientNotLinkedError extends Error {
-  constructor(public readonly recipientId: string, public readonly matterId: string) {
+  constructor(public readonly recipientId: ContactId, public readonly matterId: MatterId) {
     super(`Recipient ${recipientId} is not linked to matter ${matterId}`);
     this.name = "RecipientNotLinkedError";
   }
@@ -63,14 +64,14 @@ export class RecipientNotLinkedError extends Error {
  * - Dubbletter i `recipientIds` bevaras som separata poster (kallaren väljer).
  */
 export function resolveRecipients(
-  recipientIds: string[],
+  recipientIds: ContactId[],
   links: MatterContactLink[],
-  matterId: string,
+  matterId: MatterId,
 ): ResolvedRecipient[] {
   // Om samma kontakt råkar ha flera MatterContact-länkar (t.ex. två roller)
   // tar vi första träffen — template-context har bara ett recipient-fält per
   // dokument, och första länken är typiskt den primära rollen.
-  const byId = new Map<string, MatterContactLink>();
+  const byId = new Map<ContactId, MatterContactLink>();
   for (const l of links) {
     if (!byId.has(l.contactId)) byId.set(l.contactId, l);
   }

--- a/src/lib/client/working-set/working-set-cache.ts
+++ b/src/lib/client/working-set/working-set-cache.ts
@@ -8,6 +8,7 @@
  * när server-first-backenden aktiveras (#419).
  */
 
+import { asId, type MatterId } from "@/lib/shared/schemas/ids";
 import { LruBudget } from "./lru-budget";
 import { computeWorkingSet, type WorkingSet, type WorkingSetInput } from "./working-set";
 
@@ -15,11 +16,11 @@ export interface WorkingSetCacheDeps {
   /** Max antal ärenden i den lokala cachen. */
   budget: number;
   /** Hämta ett ärendes subträd till lokal store (prefetch/on-demand). */
-  loadMatter: (matterId: string) => Promise<void>;
+  loadMatter: (matterId: MatterId) => Promise<void>;
   /** Vräk ett ärendes subträd ur lokal store. */
-  evictMatter: (matterId: string) => Promise<void>;
+  evictMatter: (matterId: MatterId) => Promise<void>;
   /** Ärenden med icke-uppspelad lokal mutation (vräks ALDRIG, ADR 0017). */
-  pendingMatterIds?: () => ReadonlySet<string>;
+  pendingMatterIds?: () => ReadonlySet<MatterId>;
 }
 
 export class WorkingSetCache {
@@ -35,7 +36,7 @@ export class WorkingSetCache {
     const ws: WorkingSet = computeWorkingSet({ ...input, budget: this.deps.budget });
     this.pinned = ws.pinned;
     for (const id of ws.matterIds) {
-      await this.deps.loadMatter(id);
+      await this.deps.loadMatter(asId<"MatterId">(id));
       this.lru.touch(id);
     }
     await this.enforceBudget();
@@ -43,7 +44,7 @@ export class WorkingSetCache {
   }
 
   /** Öppna ett ärende — hämtar on-demand om det är utanför cachen, touch:ar LRU. */
-  async openMatter(matterId: string): Promise<void> {
+  async openMatter(matterId: MatterId): Promise<void> {
     if (!this.lru.has(matterId)) await this.deps.loadMatter(matterId);
     this.lru.touch(matterId);
     await this.enforceBudget();
@@ -59,7 +60,7 @@ export class WorkingSetCache {
     const pins = new Set(this.pinned);
     for (const id of this.deps.pendingMatterIds?.() ?? []) pins.add(id);
     for (const id of this.lru.overflow(pins)) {
-      await this.deps.evictMatter(id);
+      await this.deps.evictMatter(asId<"MatterId">(id));
       this.lru.forget(id);
     }
   }

--- a/src/lib/server/lease/lease-store.ts
+++ b/src/lib/server/lease/lease-store.ts
@@ -18,6 +18,7 @@
  * `now` injiceras → deterministiska tester utan riktig tid.
  */
 
+import type { DocumentId, UserId } from "@/lib/shared/schemas/ids";
 import type { AcquireLeaseResult, ILeaseStore, LeaseView } from "../ports";
 
 export const LEASE_STALE_MS = 2 * 60_000;
@@ -31,7 +32,7 @@ export class InMemoryLeaseStore implements ILeaseStore {
 
   constructor(private readonly now: () => number = () => Date.now()) {}
 
-  acquire(documentId: string, holderId: string, holderName: string): AcquireLeaseResult {
+  acquire(documentId: DocumentId, holderId: UserId, holderName: string): AcquireLeaseResult {
     const current = this.live(documentId);
     // Fri, utgången, eller redan din (själv-återtagande) → ta/förnya leasen.
     if (!current || current.holderId === holderId) {
@@ -49,31 +50,31 @@ export class InMemoryLeaseStore implements ILeaseStore {
     return { acquired: false, lease: this.view(current) };
   }
 
-  renew(documentId: string, holderId: string): boolean {
+  renew(documentId: DocumentId, holderId: UserId): boolean {
     const current = this.live(documentId);
     if (!current || current.holderId !== holderId) return false;
     current.lastHeartbeatAt = this.now();
     return true;
   }
 
-  release(documentId: string, holderId: string): void {
+  release(documentId: DocumentId, holderId: UserId): void {
     const current = this.leases.get(documentId);
     if (current && current.holderId === holderId) this.leases.delete(documentId);
   }
 
-  takeover(documentId: string, holderId: string, holderName: string): LeaseView {
+  takeover(documentId: DocumentId, holderId: UserId, holderName: string): LeaseView {
     const lease: StoredLease = { documentId, holderId, holderName, acquiredAt: this.now(), lastHeartbeatAt: this.now() };
     this.leases.set(documentId, lease);
     return this.view(lease);
   }
 
-  get(documentId: string): LeaseView | null {
+  get(documentId: DocumentId): LeaseView | null {
     const current = this.live(documentId);
     return current ? this.view(current) : null;
   }
 
   /** Aktuell lease om den inte löpt ut; rensar och returnerar null annars. */
-  private live(documentId: string): StoredLease | null {
+  private live(documentId: DocumentId): StoredLease | null {
     const lease = this.leases.get(documentId);
     if (!lease) return null;
     if (this.now() - lease.lastHeartbeatAt >= LEASE_EXPIRE_MS) {

--- a/src/lib/server/ports.ts
+++ b/src/lib/server/ports.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Buffer } from "node:buffer";
+import type { DocumentId, UserId } from "@/lib/shared/schemas/ids";
 
 // ─── EmailSender ───────────────────────────────────────────────────
 
@@ -35,7 +36,7 @@ export interface IDocumentAnalyzer {
    * job-kö. Returnerar void; eventuella suggestions postas via
    * dataStore.documentAnalysisSuggestions.
    */
-  analyze(documentId: string): Promise<void>;
+  analyze(documentId: DocumentId): Promise<void>;
 }
 
 // ─── SearchIndex ───────────────────────────────────────────────────
@@ -138,8 +139,8 @@ export interface IContentStore {
  * denormaliseras för UI:t ("Anna redigerar"). Tider i ms sedan epoch.
  */
 export interface LeaseView {
-  documentId: string;
-  holderId: string;
+  documentId: DocumentId;
+  holderId: UserId;
   holderName: string;
   acquiredAt: number;
   lastHeartbeatAt: number;
@@ -162,15 +163,15 @@ export interface AcquireLeaseResult {
  */
 export interface ILeaseStore {
   /** Ta leasen om fri/utgången/redan din (själv-återtagande); annars rapportera annan hållare. */
-  acquire(documentId: string, holderId: string, holderName: string): AcquireLeaseResult;
+  acquire(documentId: DocumentId, holderId: UserId, holderName: string): AcquireLeaseResult;
   /** Heartbeat: förnya din lease. `false` = du håller den inte längre (utgången/övertagen). */
-  renew(documentId: string, holderId: string): boolean;
+  renew(documentId: DocumentId, holderId: UserId): boolean;
   /** Släpp din lease (idempotent; no-op om du inte håller den). */
-  release(documentId: string, holderId: string): void;
+  release(documentId: DocumentId, holderId: UserId): void;
   /** Permanent omtilldelning till anroparen (ta-över ett stale/dött lås). */
-  takeover(documentId: string, holderId: string, holderName: string): LeaseView;
+  takeover(documentId: DocumentId, holderId: UserId, holderName: string): LeaseView;
   /** Aktuell lease, eller `null` om fri/utgången. */
-  get(documentId: string): LeaseView | null;
+  get(documentId: DocumentId): LeaseView | null;
 }
 
 // ─── Aggregat ──────────────────────────────────────────────────────

--- a/src/lib/server/repositories/drizzle-invoice-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-repository.ts
@@ -11,7 +11,7 @@
 
 import { and, desc, eq, inArray, isNull, like, sql } from "drizzle-orm";
 import type { Invoice } from "@/lib/shared/schemas/billing";
-import { asId, type MatterId } from "@/lib/shared/schemas/ids";
+import type { InvoiceId, MatterId, OrganizationId } from "@/lib/shared/schemas/ids";
 import { accontoDeductions, invoices, matters, paymentPlans, payments, writeOffs } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
@@ -32,31 +32,31 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
     return matterOrg(this.db, (row as { matterId?: MatterId }).matterId);
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<Invoice | null> {
+  async getByIdInOrg(id: InvoiceId, organizationId: OrganizationId): Promise<Invoice | null> {
     const rows = await this.db
       .select({ inv: invoices }).from(invoices)
       .innerJoin(matters, eq(invoices.matterId, matters.id))
       .where(and(
-        eq(invoices.id, asId<"InvoiceId">(id)),
-        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
+        eq(invoices.id, id),
+        eq(matters.organizationId, organizationId),
         isNull(invoices.deletedAt),
       )).limit(1);
     return this.asRow(rows[0]?.inv);
   }
 
   /** Bar faktura-rad utan org/delete-filter (för self-ref-uppslag). */
-  private async rawInvoice(id: string | null | undefined): Promise<Invoice | null> {
+  private async rawInvoice(id: InvoiceId | null | undefined): Promise<Invoice | null> {
     if (!id) return null;
-    const rows = await this.db.select().from(invoices).where(eq(invoices.id, asId<"InvoiceId">(id))).limit(1);
+    const rows = await this.db.select().from(invoices).where(eq(invoices.id, id)).limit(1);
     return this.asRow(rows[0]);
   }
 
-  async getByIdFull(id: string, organizationId: string): Promise<InvoiceFull | null> {
+  async getByIdFull(id: InvoiceId, organizationId: OrganizationId): Promise<InvoiceFull | null> {
     const base = await this.getByIdWithRelations(id, organizationId);
     if (!base) return null;
     // Self-ref/dubbel-FK via sekundär-queries (relations() täcker dem inte).
-    const deductions = await this.db.select().from(accontoDeductions).where(eq(accontoDeductions.finalInvoiceId, asId<"InvoiceId">(id)));
-    const usages = await this.db.select().from(accontoDeductions).where(eq(accontoDeductions.accontoInvoiceId, asId<"InvoiceId">(id)));
+    const deductions = await this.db.select().from(accontoDeductions).where(eq(accontoDeductions.finalInvoiceId, id));
+    const usages = await this.db.select().from(accontoDeductions).where(eq(accontoDeductions.accontoInvoiceId, id));
     const accontoDeductionsFull = await Promise.all(
       deductions.map(async (d) => ({ ...d, accontoInvoice: await this.rawInvoice(d.accontoInvoiceId) })),
     );
@@ -64,7 +64,7 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
       usages.map(async (d) => ({ ...d, finalInvoice: await this.rawInvoice(d.finalInvoiceId) })),
     );
     const creditedInvoice = await this.rawInvoice(base.creditedInvoiceId);
-    const creditNoteRows = await this.db.select().from(invoices).where(eq(invoices.creditedInvoiceId, asId<"InvoiceId">(id))).limit(1);
+    const creditNoteRows = await this.db.select().from(invoices).where(eq(invoices.creditedInvoiceId, id)).limit(1);
     return {
       ...base,
       accontoDeductions: accontoDeductionsFull,
@@ -74,9 +74,9 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
     };
   }
 
-  async getByIdWithRelations(id: string, organizationId: string): Promise<InvoiceWithRelations | null> {
+  async getByIdWithRelations(id: InvoiceId, organizationId: OrganizationId): Promise<InvoiceWithRelations | null> {
     const row = await this.db.query.invoices.findFirst({
-      where: eq(invoices.id, asId<"InvoiceId">(id)),
+      where: eq(invoices.id, id),
       with: {
         matter: true,
         payments: { with: { recordedBy: true }, orderBy: (p, { desc }) => [desc(p.paidAt)] },
@@ -94,31 +94,31 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
     return row;
   }
 
-  async listForOrg(organizationId: string, filter?: InvoiceListFilter): Promise<InvoiceListRow[]> {
+  async listForOrg(organizationId: OrganizationId, filter?: InvoiceListFilter): Promise<InvoiceListRow[]> {
     // Bas-rader: org-scope via inner-join på ärendet + valfria filter (undefined
     // ignoreras av `and`). Relationerna berikas per rad (self-ref → sekundär-queries).
     const baseRows = await this.db
       .select({ inv: invoices, matter: matters }).from(invoices)
       .innerJoin(matters, eq(invoices.matterId, matters.id))
       .where(and(
-        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
+        eq(matters.organizationId, organizationId),
         isNull(invoices.deletedAt),
-        filter?.matterId ? eq(invoices.matterId, asId<"MatterId">(filter.matterId)) : undefined,
+        filter?.matterId ? eq(invoices.matterId, filter.matterId) : undefined,
         filter?.invoiceType ? eq(invoices.invoiceType, filter.invoiceType) : undefined,
         filter?.status ? eq(invoices.status, filter.status) : undefined,
       ))
       .orderBy(desc(invoices.invoiceDate));
     return Promise.all(baseRows.map(async ({ inv, matter }): Promise<InvoiceListRow> => {
       const id = inv.id;
-      const plan = await this.db.select().from(paymentPlans).where(eq(paymentPlans.invoiceId, asId<"InvoiceId">(id))).limit(1);
-      const pays = await this.db.select().from(payments).where(eq(payments.invoiceId, asId<"InvoiceId">(id))).orderBy(desc(payments.paidAt));
-      const deductions = await this.db.select().from(accontoDeductions).where(eq(accontoDeductions.finalInvoiceId, asId<"InvoiceId">(id)));
+      const plan = await this.db.select().from(paymentPlans).where(eq(paymentPlans.invoiceId, id)).limit(1);
+      const pays = await this.db.select().from(payments).where(eq(payments.invoiceId, id)).orderBy(desc(payments.paidAt));
+      const deductions = await this.db.select().from(accontoDeductions).where(eq(accontoDeductions.finalInvoiceId, id));
       const accontoDeductionsFull = await Promise.all(
         deductions.map(async (d) => ({ ...d, accontoInvoice: await this.rawInvoice(d.accontoInvoiceId) })),
       );
-      const usages = await this.db.select({ id: accontoDeductions.id }).from(accontoDeductions).where(eq(accontoDeductions.accontoInvoiceId, asId<"InvoiceId">(id)));
+      const usages = await this.db.select({ id: accontoDeductions.id }).from(accontoDeductions).where(eq(accontoDeductions.accontoInvoiceId, id));
       const creditedInvoice = await this.rawInvoice(inv.creditedInvoiceId);
-      const creditNoteRows = await this.db.select().from(invoices).where(eq(invoices.creditedInvoiceId, asId<"InvoiceId">(id))).limit(1);
+      const creditNoteRows = await this.db.select().from(invoices).where(eq(invoices.creditedInvoiceId, id)).limit(1);
       return {
         ...inv,
         matter: { id: matter.id, matterNumber: matter.matterNumber, title: matter.title },
@@ -132,36 +132,36 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
     }));
   }
 
-  async nextInvoiceNumber(organizationId: string): Promise<string> {
+  async nextInvoiceNumber(organizationId: OrganizationId): Promise<string> {
     const prefix = invoiceNumberPrefix(this.now().getFullYear());
     const rows = await this.db
       .select({ invoiceNumber: invoices.invoiceNumber }).from(invoices)
       .innerJoin(matters, eq(invoices.matterId, matters.id))
-      .where(and(eq(matters.organizationId, asId<"OrganizationId">(organizationId)), like(invoices.invoiceNumber, `${prefix}%`)))
+      .where(and(eq(matters.organizationId, organizationId), like(invoices.invoiceNumber, `${prefix}%`)))
       .orderBy(desc(invoices.invoiceNumber)).limit(1);
     return nextInvoiceNumberFrom(prefix, rows[0]?.invoiceNumber);
   }
 
-  async sumCreditNotesFor(invoiceId: string, organizationId: string): Promise<number> {
+  async sumCreditNotesFor(invoiceId: InvoiceId, organizationId: OrganizationId): Promise<number> {
     const rows = await this.db
       .select({ total: sql<number>`coalesce(sum(abs(${invoices.amount})), 0)` }).from(invoices)
       .innerJoin(matters, eq(invoices.matterId, matters.id))
       .where(and(
-        eq(invoices.creditedInvoiceId, asId<"InvoiceId">(invoiceId)),
-        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
+        eq(invoices.creditedInvoiceId, invoiceId),
+        eq(matters.organizationId, organizationId),
         isNull(invoices.deletedAt),
       ));
     return Number(rows[0]?.total ?? 0);
   }
 
-  async getCreditNoteFor(invoiceId: string): Promise<Invoice | null> {
+  async getCreditNoteFor(invoiceId: InvoiceId): Promise<Invoice | null> {
     const rows = await this.db
       .select().from(invoices)
-      .where(and(eq(invoices.creditedInvoiceId, asId<"InvoiceId">(invoiceId)), isNull(invoices.deletedAt))).limit(1);
+      .where(and(eq(invoices.creditedInvoiceId, invoiceId), isNull(invoices.deletedAt))).limit(1);
     return this.asRow(rows[0]);
   }
 
-  async listDeductibleAccontos(matterId: string, ids: string[]): Promise<Invoice[]> {
+  async listDeductibleAccontos(matterId: MatterId, ids: InvoiceId[]): Promise<Invoice[]> {
     if (!ids.length) return [];
     // ACCONTO i ärendet som ännu inte dragits av: left-join acconto_deductions
     // på accontoInvoiceId + filtrera bort träffar (deductedOnFinals = none).
@@ -169,8 +169,8 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
       .select({ inv: invoices }).from(invoices)
       .leftJoin(accontoDeductions, eq(accontoDeductions.accontoInvoiceId, invoices.id))
       .where(and(
-        inArray(invoices.id, ids.map((i) => asId<"InvoiceId">(i))),
-        eq(invoices.matterId, asId<"MatterId">(matterId)),
+        inArray(invoices.id, ids),
+        eq(invoices.matterId, matterId),
         eq(invoices.invoiceType, "ACCONTO"),
         isNull(invoices.deletedAt),
         isNull(accontoDeductions.id),
@@ -178,18 +178,18 @@ export class DrizzleInvoiceRepository extends DrizzleRepository<Invoice> impleme
     return rows.map((r) => r.inv);
   }
 
-  async getByIdWithLedger(id: string): Promise<InvoiceWithLedger | null> {
-    const invoice = await this.getById(asId<"InvoiceId">(id));
+  async getByIdWithLedger(id: InvoiceId): Promise<InvoiceWithLedger | null> {
+    const invoice = await this.getById(id);
     if (!invoice) return null;
-    const pays = await this.db.select().from(payments).where(eq(payments.invoiceId, asId<"InvoiceId">(id)));
-    const wos = await this.db.select().from(writeOffs).where(eq(writeOffs.invoiceId, asId<"InvoiceId">(id)));
+    const pays = await this.db.select().from(payments).where(eq(payments.invoiceId, id));
+    const wos = await this.db.select().from(writeOffs).where(eq(writeOffs.invoiceId, id));
     return { ...invoice, payments: pays, writeOffs: wos };
   }
 
-  async listByMatter(matterId: string): Promise<Invoice[]> {
+  async listByMatter(matterId: MatterId): Promise<Invoice[]> {
     const rows = await this.db
       .select().from(invoices)
-      .where(and(eq(invoices.matterId, asId<"MatterId">(matterId)), isNull(invoices.deletedAt)))
+      .where(and(eq(invoices.matterId, matterId), isNull(invoices.deletedAt)))
       .orderBy(desc(invoices.invoiceDate));
     return this.asRows(rows);
   }

--- a/src/lib/server/repositories/in-memory-invoice-repository.ts
+++ b/src/lib/server/repositories/in-memory-invoice-repository.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Invoice } from "@/lib/shared/schemas/billing";
-import { asId } from "@/lib/shared/schemas/ids";
+import type { InvoiceId, MatterId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import {
@@ -22,14 +22,14 @@ export class InMemoryInvoiceRepository extends InMemoryRepository<Invoice> imple
     super(store.invoices, now ?? (() => new Date()));
   }
 
-  async getByIdInOrg(id: string, organizationId: string): Promise<Invoice | null> {
+  async getByIdInOrg(id: InvoiceId, organizationId: OrganizationId): Promise<Invoice | null> {
     // Samma relations-filter som routern använde mot DemoDataStore (org via ärende).
     const row = (await this.store.invoices
       .findFirst({ where: { id, matter: { organizationId } } })) as Invoice | null;
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }
 
-  async getByIdFull(id: string, organizationId: string): Promise<InvoiceFull | null> {
+  async getByIdFull(id: InvoiceId, organizationId: OrganizationId): Promise<InvoiceFull | null> {
     // In-memory query-engine resolvar alla relationer (samma include som routern
     // använt) i ETT anrop — inga sekundär-queries behövs (jfr Drizzle-impl:en).
     const row = (await this.store.invoices.findFirst({
@@ -51,7 +51,7 @@ export class InMemoryInvoiceRepository extends InMemoryRepository<Invoice> imple
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }
 
-  async getByIdWithRelations(id: string, organizationId: string): Promise<InvoiceWithRelations | null> {
+  async getByIdWithRelations(id: InvoiceId, organizationId: OrganizationId): Promise<InvoiceWithRelations | null> {
     const row = (await this.store.invoices.findFirst({
       where: { id, matter: { organizationId } },
       include: {
@@ -67,8 +67,8 @@ export class InMemoryInvoiceRepository extends InMemoryRepository<Invoice> imple
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }
 
-  async getByIdWithLedger(id: string): Promise<InvoiceWithLedger | null> {
-    const invoice = await this.getById(asId<"InvoiceId">(id));
+  async getByIdWithLedger(id: InvoiceId): Promise<InvoiceWithLedger | null> {
+    const invoice = await this.getById(id);
     if (!invoice) return null;
     const payments = (await this.store.payments
       .findMany({ where: { invoiceId: id } })) as InvoiceWithLedger["payments"];
@@ -77,7 +77,7 @@ export class InMemoryInvoiceRepository extends InMemoryRepository<Invoice> imple
     return { ...invoice, payments, writeOffs };
   }
 
-  async listForOrg(organizationId: string, filter?: InvoiceListFilter): Promise<InvoiceListRow[]> {
+  async listForOrg(organizationId: OrganizationId, filter?: InvoiceListFilter): Promise<InvoiceListRow[]> {
     // Samma where/include som routern använde mot DemoDataStore — query-engine:n
     // resolvar relationerna i ett anrop (jfr Drizzle-impl:ens sekundär-queries).
     const rows = (await this.store.invoices.findMany({
@@ -101,7 +101,7 @@ export class InMemoryInvoiceRepository extends InMemoryRepository<Invoice> imple
     return rows.filter((r) => !(r as { deletedAt?: unknown }).deletedAt);
   }
 
-  async nextInvoiceNumber(organizationId: string): Promise<string> {
+  async nextInvoiceNumber(organizationId: OrganizationId): Promise<string> {
     const prefix = invoiceNumberPrefix(this.now().getFullYear());
     const last = (await this.store.invoices.findFirst({
       where: { matter: { organizationId }, invoiceNumber: { startsWith: prefix } },
@@ -110,7 +110,7 @@ export class InMemoryInvoiceRepository extends InMemoryRepository<Invoice> imple
     return nextInvoiceNumberFrom(prefix, last?.invoiceNumber);
   }
 
-  async sumCreditNotesFor(invoiceId: string, organizationId: string): Promise<number> {
+  async sumCreditNotesFor(invoiceId: InvoiceId, organizationId: OrganizationId): Promise<number> {
     const rows = (await this.store.invoices
       .findMany({ where: { creditedInvoiceId: invoiceId, matter: { organizationId } } })) as ReadonlyArray<Invoice>;
     return rows
@@ -118,20 +118,20 @@ export class InMemoryInvoiceRepository extends InMemoryRepository<Invoice> imple
       .reduce((s, c) => s + Math.abs(c.amount), 0);
   }
 
-  async getCreditNoteFor(invoiceId: string): Promise<Invoice | null> {
+  async getCreditNoteFor(invoiceId: InvoiceId): Promise<Invoice | null> {
     const row = (await this.store.invoices
       .findFirst({ where: { creditedInvoiceId: invoiceId } })) as Invoice | null;
     return row && !(row as { deletedAt?: unknown }).deletedAt ? row : null;
   }
 
-  async listDeductibleAccontos(matterId: string, ids: string[]): Promise<Invoice[]> {
+  async listDeductibleAccontos(matterId: MatterId, ids: InvoiceId[]): Promise<Invoice[]> {
     if (!ids.length) return [];
     return (await this.store.invoices.findMany({
       where: { id: { in: ids }, matterId, invoiceType: "ACCONTO", deductedOnFinals: { none: {} } },
     })) as Invoice[];
   }
 
-  async listByMatter(matterId: string): Promise<Invoice[]> {
+  async listByMatter(matterId: MatterId): Promise<Invoice[]> {
     const rows = (await this.store.invoices
       .findMany({ where: { matterId }, orderBy: { invoiceDate: "desc" } })) as Invoice[];
     return rows.filter((r) => !(r as { deletedAt?: unknown }).deletedAt);

--- a/src/lib/server/routers/reports.ts
+++ b/src/lib/server/routers/reports.ts
@@ -6,7 +6,7 @@ import {
   type FrozenWorkInput,
 } from "@/lib/shared/billed-per-lawyer";
 import type { InvoiceStatus, PaymentMethod } from "@/lib/shared/schemas/enums";
-import { asId, userIdSchema, type InvoiceId, type UserId } from "@/lib/shared/schemas/ids";
+import { asId, userIdSchema, type BillingRunId, type InvoiceId, type MatterId, type UserId } from "@/lib/shared/schemas/ids";
 import { router, protectedProcedure } from "../trpc";
 
 /**
@@ -71,8 +71,8 @@ function coerceDate(v: unknown): Date {
 }
 
 interface RawTimeEntry {
-  userId: string; minutes: number; hourlyRate: number;
-  invoiceId: string | null | undefined; frozenByBillingRunId: string | null | undefined;
+  userId: UserId; minutes: number; hourlyRate: number;
+  invoiceId: InvoiceId | null | undefined; frozenByBillingRunId: BillingRunId | null | undefined;
 }
 interface RawInvoice { id: string; amount: number; status: InvoiceStatus; invoiceDate: unknown; updatedAt: unknown }
 
@@ -145,8 +145,8 @@ function previousCalendarMonth(periodStart: Date): { from: Date; to: Date } {
 // ─── Router ──────────────────────────────────────────────────────────
 
 /** Per-faktura-rader för Kundfordrings-tabellen (slår ihop "Fakturerat"-tabellen). */
-interface ArRowMeta { invoiceNumber: string; invoiceDate: string; matterId: string; matterNumber: string; title: string }
-const EMPTY_AR_META: ArRowMeta = { invoiceNumber: "", invoiceDate: "", matterId: "", matterNumber: "", title: "" };
+interface ArRowMeta { invoiceNumber: string; invoiceDate: string; matterId: MatterId; matterNumber: string; title: string }
+const EMPTY_AR_META: ArRowMeta = { invoiceNumber: "", invoiceDate: "", matterId: asId<"MatterId">(""), matterNumber: "", title: "" };
 
 /** Förresolva faktura-metadata (nummer + datum + ärende) per id — håller rad-mappningen trivial. */
 function arMetaById(invoices: Record<string, unknown>[]): Map<string, ArRowMeta> {
@@ -156,7 +156,7 @@ function arMetaById(invoices: Record<string, unknown>[]): Map<string, ArRowMeta>
     m.set(String(inv.id ?? ""), {
       invoiceNumber: inv.invoiceNumber ?? "",
       invoiceDate: coerceDate(inv.invoiceDate).toISOString(),
-      matterId: mt.id ?? "",
+      matterId: asId<"MatterId">(mt.id ?? ""),
       matterNumber: mt.matterNumber ?? "",
       title: mt.title ?? "",
     });
@@ -176,7 +176,7 @@ function arRowsFrom(scoped: { invoices: Record<string, unknown>[]; payments: Rec
 
 /** Den delmängd av matter-selecten delrapporterna läser. */
 interface ReportMatterRef {
-  id: string;
+  id: MatterId;
   matterNumber: string;
   title: string;
   paymentMethod: PaymentMethod;
@@ -186,22 +186,22 @@ interface ReportMatterRef {
 }
 interface ReportTimeEntry {
   date: Date; minutes: number; billable: boolean; hourlyRate: number;
-  invoiceId?: string | null | undefined; matter?: ReportMatterRef | null | undefined;
+  invoiceId?: InvoiceId | null | undefined; matter?: ReportMatterRef | null | undefined;
 }
 interface ReportExpense {
   date: Date; amount: number; billable: boolean;
-  invoiceId?: string | null | undefined; matter?: ReportMatterRef | null | undefined;
+  invoiceId?: InvoiceId | null | undefined; matter?: ReportMatterRef | null | undefined;
 }
 
 interface MatterAgg {
-  matterId: string; matterNumber: string; title: string; client: string | null;
+  matterId: MatterId; matterNumber: string; title: string; client: string | null;
   paymentMethod: PaymentMethod; paymentMethodNote: string | null; paymentMethodDecidedAt: Date | null;
   totalMinutes: number; billableMinutes: number;
   workValueOre: number; // tid × timpris (öre)
   expenseOre: number;   // utlägg totalt (öre, bara billable)
 }
 interface UnbilledRow {
-  matterId: string; matterNumber: string; title: string; client: string | null;
+  matterId: MatterId; matterNumber: string; title: string; client: string | null;
   paymentMethod: PaymentMethod; timeOre: number; expenseOre: number; total: number;
 }
 

--- a/test/unit/client/backend/content-cache.test.ts
+++ b/test/unit/client/backend/content-cache.test.ts
@@ -7,28 +7,31 @@
 import { IDBFactory } from "fake-indexeddb";
 import { beforeEach, describe, expect, it } from "vitest-compat";
 import { DocumentContentCache } from "@/lib/client/backend/content-cache";
+import { asId } from "@/lib/shared/schemas/ids";
+
+const docId = (s: string) => asId<"DocumentId">(s);
 
 let cache: DocumentContentCache;
 beforeEach(() => { cache = new DocumentContentCache(new IDBFactory()); });
 
 describe("DocumentContentCache", () => {
   it("cachar bytes + listar pending + roundtrip", async () => {
-    await cache.cache("d1", "sha-a", new Uint8Array([1, 2, 3]));
+    await cache.cache(docId("d1"), "sha-a", new Uint8Array([1, 2, 3]));
     expect(await cache.pendingUploads()).toEqual([{ documentId: "d1", sha: "sha-a" }]);
     expect(Array.from((await cache.getBytes("sha-a"))!)).toEqual([1, 2, 3]);
   });
 
   it("coalesce: ny sparning av samma dokument → bara senaste sha pending", async () => {
-    await cache.cache("d1", "sha-v1", new Uint8Array([1]));
-    await cache.cache("d1", "sha-v2", new Uint8Array([2]));
+    await cache.cache(docId("d1"), "sha-v1", new Uint8Array([1]));
+    await cache.cache(docId("d1"), "sha-v2", new Uint8Array([2]));
     expect(await cache.pendingUploads()).toEqual([{ documentId: "d1", sha: "sha-v2" }]);
     // Gamla blobben finns kvar i läs-cachen (immutabel), bara manifestet slogs ihop.
     expect(await cache.getBytes("sha-v1")).not.toBeNull();
   });
 
   it("markUploaded tar bort ur pending men behåller blobben", async () => {
-    await cache.cache("d1", "sha-a", new Uint8Array([9]));
-    await cache.markUploaded("d1");
+    await cache.cache(docId("d1"), "sha-a", new Uint8Array([9]));
+    await cache.markUploaded(docId("d1"));
     expect(await cache.pendingUploads()).toEqual([]);
     expect(await cache.getBytes("sha-a")).not.toBeNull();
   });

--- a/test/unit/client/backend/content-sync.test.ts
+++ b/test/unit/client/backend/content-sync.test.ts
@@ -9,6 +9,9 @@ import { describe, expect, it, vi } from "vitest-compat";
 import { DocumentContentCache } from "@/lib/client/backend/content-cache";
 import { runContentSync, syncDocumentContent } from "@/lib/client/backend/content-sync";
 import { base64ToBytes, contentStoragePath, sha256Hex } from "@/lib/shared/content-address";
+import { asId, type DocumentId } from "@/lib/shared/schemas/ids";
+
+const docId = (s: string) => asId<"DocumentId">(s);
 
 describe("runContentSync", () => {
   it("tom pending → no-op", async () => {
@@ -22,8 +25,8 @@ describe("runContentSync", () => {
 
   it("laddar bara upp sha:n servern saknar (dedup) + markUploaded för alla", async () => {
     const pending = [
-      { documentId: "d1", sha: "aaa" },
-      { documentId: "d2", sha: "bbb" }, // servern har redan denna
+      { documentId: docId("d1"), sha: "aaa" },
+      { documentId: docId("d2"), sha: "bbb" }, // servern har redan denna
     ];
     const upload = vi.fn(async () => {});
     const markUploaded = vi.fn(async () => {});
@@ -44,7 +47,7 @@ describe("runContentSync", () => {
     const upload = vi.fn(async () => {});
     const markUploaded = vi.fn(async () => {});
     const out = await runContentSync({
-      pending: async () => [{ documentId: "d1", sha: "ccc" }],
+      pending: async () => [{ documentId: docId("d1"), sha: "ccc" }],
       missing: async () => [contentStoragePath("ccc")],
       getBytes: async () => null,
       upload,
@@ -61,13 +64,13 @@ describe("syncDocumentContent (wirad mot tRPC + cache)", () => {
     const cache = new DocumentContentCache(new IDBFactory());
     const bytes = new Uint8Array([5, 6, 7]);
     const sha = await sha256Hex(bytes);
-    await cache.cache("d1", sha, bytes);
+    await cache.cache(docId("d1"), sha, bytes);
 
-    const uploads: Array<{ documentId: string; contentBase64: string }> = [];
+    const uploads: Array<{ documentId: DocumentId; contentBase64: string }> = [];
     const client = {
       document: {
         missingContent: { query: async (i: { storagePaths: string[] }) => ({ missing: i.storagePaths }) },
-        uploadContent: { mutate: async (i: { documentId: string; contentBase64: string }) => { uploads.push(i); } },
+        uploadContent: { mutate: async (i: { documentId: DocumentId; contentBase64: string }) => { uploads.push(i); } },
       },
     };
 
@@ -81,7 +84,7 @@ describe("syncDocumentContent (wirad mot tRPC + cache)", () => {
 
   it("servern har redan blobben → ingen upload, pending rensas", async () => {
     const cache = new DocumentContentCache(new IDBFactory());
-    await cache.cache("d2", await sha256Hex(new Uint8Array([1])), new Uint8Array([1]));
+    await cache.cache(docId("d2"), await sha256Hex(new Uint8Array([1])), new Uint8Array([1]));
     const uploads: unknown[] = [];
     const client = {
       document: {

--- a/test/unit/client/backend/save-document-content.test.ts
+++ b/test/unit/client/backend/save-document-content.test.ts
@@ -8,17 +8,18 @@ import { beforeEach, describe, expect, it } from "vitest-compat";
 import { DocumentContentCache } from "@/lib/client/backend/content-cache";
 import { saveDocumentContent } from "@/lib/client/backend/save-document-content";
 import { base64ToBytes, sha256Hex } from "@/lib/shared/content-address";
+import { asId, type DocumentId } from "@/lib/shared/schemas/ids";
 
 let cache: DocumentContentCache;
 beforeEach(() => { cache = new DocumentContentCache(new IDBFactory()); });
 
 describe("saveDocumentContent", () => {
   it("cachar bytes (pending) + laddar upp via uploadContent (base64)", async () => {
-    const uploads: Array<{ documentId: string; contentBase64: string }> = [];
-    const client = { document: { uploadContent: { mutate: async (i: { documentId: string; contentBase64: string }) => { uploads.push(i); } } } };
+    const uploads: Array<{ documentId: DocumentId; contentBase64: string }> = [];
+    const client = { document: { uploadContent: { mutate: async (i: { documentId: DocumentId; contentBase64: string }) => { uploads.push(i); } } } };
     const bytes = new Uint8Array([1, 2, 3, 4]);
 
-    const sha = await saveDocumentContent(client, "doc-1", bytes, cache);
+    const sha = await saveDocumentContent(client, asId<"DocumentId">("doc-1"), bytes, cache);
 
     expect(sha).toBe(await sha256Hex(bytes));
     // Pending → byte-synken laddar upp vid reconnect (offline-säkert).

--- a/test/unit/client/working-set/working-set-cache.test.ts
+++ b/test/unit/client/working-set/working-set-cache.test.ts
@@ -6,8 +6,10 @@
 import { describe, it, expect } from "vitest-compat";
 import type { WorkingSetMatter } from "@/lib/client/working-set/working-set";
 import { WorkingSetCache } from "@/lib/client/working-set/working-set-cache";
+import { asId } from "@/lib/shared/schemas/ids";
 
 const ME = "u-1";
+const mId = (s: string) => asId<"MatterId">(s);
 
 function fakes() {
   const loaded: string[] = [];
@@ -42,7 +44,7 @@ describe("WorkingSetCache (#418)", () => {
     const cache = new WorkingSetCache({ budget: 3, loadMatter: f.loadMatter, evictMatter: f.evictMatter });
     await cache.prefetch({ userId: ME, matters, recentMatterIds: ["r1", "r2"] });
     // Öppna "extra" (utanför set) → hämtas, och äldsta icke-pinnade (r1) vräks.
-    await cache.openMatter("extra");
+    await cache.openMatter(mId("extra"));
     expect(f.loaded).toContain("extra");
     expect(f.evicted).toEqual(["r1"]); // mine pinnad, r1 äldst icke-pinnad
     expect(cache.size()).toBe(3);
@@ -50,12 +52,12 @@ describe("WorkingSetCache (#418)", () => {
 
   it("vräker aldrig ett ärende med icke-uppspelad mutation (pending)", async () => {
     const f = fakes();
-    const pending = new Set(["r1"]);
+    const pending = new Set([mId("r1")]);
     const cache = new WorkingSetCache({
       budget: 3, loadMatter: f.loadMatter, evictMatter: f.evictMatter, pendingMatterIds: () => pending,
     });
     await cache.prefetch({ userId: ME, matters, recentMatterIds: ["r1", "r2"] });
-    await cache.openMatter("extra");
+    await cache.openMatter(mId("extra"));
     expect(f.evicted).toEqual(["r2"]); // r1 pending → skyddad, r2 vräks istället
   });
 
@@ -64,7 +66,7 @@ describe("WorkingSetCache (#418)", () => {
     const cache = new WorkingSetCache({ budget: 5, loadMatter: f.loadMatter, evictMatter: f.evictMatter });
     await cache.prefetch({ userId: ME, matters, recentMatterIds: ["r1"] });
     const before = f.loaded.length;
-    await cache.openMatter("mine");
+    await cache.openMatter(mId("mine"));
     expect(f.loaded.length).toBe(before); // redan i cachen
   });
 });

--- a/test/unit/lib/template-recipients.test.ts
+++ b/test/unit/lib/template-recipients.test.ts
@@ -5,8 +5,12 @@ import {
   RecipientNotLinkedError,
   type MatterContactLink,
 } from "@/lib/client/template-recipients";
+import { asId, type ContactId } from "@/lib/shared/schemas/ids";
 
-function link(overrides: Partial<MatterContactLink> & { contactId: string }): MatterContactLink {
+const cId = (s: string) => asId<"ContactId">(s);
+const mId = (s: string) => asId<"MatterId">(s);
+
+function link(overrides: Partial<MatterContactLink> & { contactId: ContactId }): MatterContactLink {
   return {
     contactId: overrides.contactId,
     role: overrides.role ?? "KLIENT",
@@ -26,20 +30,20 @@ function link(overrides: Partial<MatterContactLink> & { contactId: string }): Ma
 
 describe("resolveRecipients", () => {
   it("returnerar tom lista när inga recipientIds anges", () => {
-    const links = [link({ contactId: "c1" })];
-    expect(resolveRecipients([], links, "m1")).toEqual([]);
+    const links = [link({ contactId: cId("c1") })];
+    expect(resolveRecipients([], links, mId("m1"))).toEqual([]);
   });
 
   it("mappar contact-id till full mottagardata med roll-label", () => {
     const links = [
       link({
-        contactId: "c1",
+        contactId: cId("c1"),
         role: "KLIENT",
         notes: "Huvudkontakt",
         contact: { name: "Anna", email: "a@b.se", phone: null, address: "Gatan 1", personalNumber: null, orgNumber: null },
       }),
     ];
-    const result = resolveRecipients(["c1"], links, "m1");
+    const result = resolveRecipients([cId("c1")], links, mId("m1"));
     expect(result).toEqual([
       {
         contactId: "c1",
@@ -59,32 +63,32 @@ describe("resolveRecipients", () => {
   });
 
   it("faller tillbaka på rå roll-sträng om ingen label finns", () => {
-    const links = [link({ contactId: "c1", role: "UNKNOWN_ROLE" })];
-    const result = resolveRecipients(["c1"], links, "m1");
+    const links = [link({ contactId: cId("c1"), role: "UNKNOWN_ROLE" })];
+    const result = resolveRecipients([cId("c1")], links, mId("m1"));
     expect(result[0]!.data.roleLabel).toBe("UNKNOWN_ROLE");
   });
 
   it("bevarar ordningen från recipientIds (inte från links)", () => {
     const links = [
-      link({ contactId: "c1", contact: { name: "Anna", email: null, phone: null, address: null, personalNumber: null, orgNumber: null } }),
-      link({ contactId: "c2", contact: { name: "Bo", email: null, phone: null, address: null, personalNumber: null, orgNumber: null } }),
-      link({ contactId: "c3", contact: { name: "Cecilia", email: null, phone: null, address: null, personalNumber: null, orgNumber: null } }),
+      link({ contactId: cId("c1"), contact: { name: "Anna", email: null, phone: null, address: null, personalNumber: null, orgNumber: null } }),
+      link({ contactId: cId("c2"), contact: { name: "Bo", email: null, phone: null, address: null, personalNumber: null, orgNumber: null } }),
+      link({ contactId: cId("c3"), contact: { name: "Cecilia", email: null, phone: null, address: null, personalNumber: null, orgNumber: null } }),
     ];
 
     // Begär i omvänd ordning
-    const result = resolveRecipients(["c3", "c1", "c2"], links, "m1");
+    const result = resolveRecipients([cId("c3"), cId("c1"), cId("c2")], links, mId("m1"));
     expect(result.map((r) => r.data.name)).toEqual(["Cecilia", "Anna", "Bo"]);
   });
 
   it("kastar RecipientNotLinkedError när ID saknas i ärendet", () => {
-    const links = [link({ contactId: "c1" })];
-    expect(() => resolveRecipients(["c1", "c999"], links, "m42")).toThrow(RecipientNotLinkedError);
+    const links = [link({ contactId: cId("c1") })];
+    expect(() => resolveRecipients([cId("c1"), cId("c999")], links, mId("m42"))).toThrow(RecipientNotLinkedError);
   });
 
   it("felet innehåller matter-id och recipient-id", () => {
-    const links = [link({ contactId: "c1" })];
+    const links = [link({ contactId: cId("c1") })];
     try {
-      resolveRecipients(["c999"], links, "m42");
+      resolveRecipients([cId("c999")], links, mId("m42"));
       throw new Error("Should have thrown");
     } catch (e) {
       expect(e).toBeInstanceOf(RecipientNotLinkedError);
@@ -97,8 +101,8 @@ describe("resolveRecipients", () => {
   });
 
   it("tillåter dubbletter i recipientIds (genererar två dokument för samma person)", () => {
-    const links = [link({ contactId: "c1" })];
-    const result = resolveRecipients(["c1", "c1"], links, "m1");
+    const links = [link({ contactId: cId("c1") })];
+    const result = resolveRecipients([cId("c1"), cId("c1")], links, mId("m1"));
     expect(result).toHaveLength(2);
     expect(result[0]!.contactId).toBe("c1");
     expect(result[1]!.contactId).toBe("c1");
@@ -108,10 +112,10 @@ describe("resolveRecipients", () => {
     // Ovanligt fall: samma kontakt med två roller i samma ärende. Vi tar bara
     // första länken vi ser — template-context har redan en flat kontakts-lista.
     const links = [
-      link({ contactId: "c1", role: "KLIENT" }),
-      link({ contactId: "c1", role: "VITTNE" }),
+      link({ contactId: cId("c1"), role: "KLIENT" }),
+      link({ contactId: cId("c1"), role: "VITTNE" }),
     ];
-    const result = resolveRecipients(["c1"], links, "m1");
+    const result = resolveRecipients([cId("c1")], links, mId("m1"));
     expect(result).toHaveLength(1);
     expect(result[0]!.data.role).toBe("KLIENT");
   });

--- a/test/unit/server/adapters/demo-document-analyzer.test.ts
+++ b/test/unit/server/adapters/demo-document-analyzer.test.ts
@@ -7,6 +7,9 @@
 import { describe, it, expect, beforeEach } from "vitest-compat";
 import { jobQueue } from "@/lib/client/jobs/job-queue";
 import { demoDocumentAnalyzer } from "@/lib/server/adapters/demo-document-analyzer";
+import { asId } from "@/lib/shared/schemas/ids";
+
+const docId = (s: string) => asId<"DocumentId">(s);
 
 beforeEach(() => {
   // Rensa kön mellan testen
@@ -18,7 +21,7 @@ beforeEach(() => {
 
 describe("demoDocumentAnalyzer", () => {
   it("analyze() lägger till ett classify-document-jobb i kön", async () => {
-    await demoDocumentAnalyzer.analyze("d-test-1");
+    await demoDocumentAnalyzer.analyze(docId("d-test-1"));
     const jobs = jobQueue.list();
     const classifyJobs = jobs.filter((j) => j.kind === "classify-document");
     expect(classifyJobs.length).toBe(1);
@@ -26,14 +29,14 @@ describe("demoDocumentAnalyzer", () => {
   });
 
   it("jobb-label innehåller en del av documentId så användaren känner igen det", async () => {
-    await demoDocumentAnalyzer.analyze("d-abcdef123456");
+    await demoDocumentAnalyzer.analyze(docId("d-abcdef123456"));
     const job = jobQueue.list().find((j) => j.kind === "classify-document");
     expect(job?.label).toContain("d-abcdef1234");
   });
 
   it("två analyze-anrop → två jobb (single-flight per kind är queue-nivå)", async () => {
-    await demoDocumentAnalyzer.analyze("d-1");
-    await demoDocumentAnalyzer.analyze("d-2");
+    await demoDocumentAnalyzer.analyze(docId("d-1"));
+    await demoDocumentAnalyzer.analyze(docId("d-2"));
     expect(jobQueue.list().filter((j) => j.kind === "classify-document").length).toBe(2);
   });
 });

--- a/test/unit/server/adapters/noop-ports.test.ts
+++ b/test/unit/server/adapters/noop-ports.test.ts
@@ -14,6 +14,7 @@ import {
   noopContentStore,
   noopPorts,
 } from "@/lib/server/adapters/noop-ports";
+import { asId } from "@/lib/shared/schemas/ids";
 
 describe("noop-ports", () => {
   it("noopEmail.send är en tyst no-op", async () => {
@@ -23,7 +24,7 @@ describe("noop-ports", () => {
   });
 
   it("noopDocumentAnalyzer.analyze är en tyst no-op", async () => {
-    await expect(noopDocumentAnalyzer.analyze("doc-1")).resolves.toBeUndefined();
+    await expect(noopDocumentAnalyzer.analyze(asId<"DocumentId">("doc-1"))).resolves.toBeUndefined();
   });
 
   it("noopSearchIndex.search returnerar tomt men välformat svar", async () => {

--- a/test/unit/server/lease-store.test.ts
+++ b/test/unit/server/lease-store.test.ts
@@ -5,6 +5,11 @@
 
 import { describe, it, expect } from "vitest-compat";
 import { InMemoryLeaseStore, LEASE_EXPIRE_MS, LEASE_STALE_MS } from "@/lib/server/lease/lease-store";
+import { asId } from "@/lib/shared/schemas/ids";
+
+const d1 = asId<"DocumentId">("d1");
+const u1 = asId<"UserId">("u1");
+const u2 = asId<"UserId">("u2");
 
 function clock(start = 1_000_000): { now: () => number; advance: (ms: number) => void } {
   let t = start;
@@ -14,15 +19,15 @@ function clock(start = 1_000_000): { now: () => number; advance: (ms: number) =>
 describe("InMemoryLeaseStore.acquire", () => {
   it("tar en fri lease → acquired, hållare satt", () => {
     const store = new InMemoryLeaseStore(clock().now);
-    const res = store.acquire("d1", "u1", "Anna");
+    const res = store.acquire(d1, u1, "Anna");
     expect(res.acquired).toBe(true);
     expect(res.lease).toMatchObject({ documentId: "d1", holderId: "u1", holderName: "Anna", stale: false });
   });
 
   it("leasad av annan (levande) → acquired:false + den andras lease", () => {
     const store = new InMemoryLeaseStore(clock().now);
-    store.acquire("d1", "u1", "Anna");
-    const res = store.acquire("d1", "u2", "Bo");
+    store.acquire(d1, u1, "Anna");
+    const res = store.acquire(d1, u2, "Bo");
     expect(res.acquired).toBe(false);
     expect(res.lease.holderId).toBe("u1");
     expect(res.lease.holderName).toBe("Anna");
@@ -31,9 +36,9 @@ describe("InMemoryLeaseStore.acquire", () => {
   it("själv-återtagande: egen lease → acquired, behåller acquiredAt", () => {
     const c = clock();
     const store = new InMemoryLeaseStore(c.now);
-    const first = store.acquire("d1", "u1", "Anna");
+    const first = store.acquire(d1, u1, "Anna");
     c.advance(60_000);
-    const again = store.acquire("d1", "u1", "Anna");
+    const again = store.acquire(d1, u1, "Anna");
     expect(again.acquired).toBe(true);
     expect(again.lease.acquiredAt).toBe(first.lease.acquiredAt); // samma session
     expect(again.lease.lastHeartbeatAt).toBeGreaterThan(first.lease.lastHeartbeatAt);
@@ -42,9 +47,9 @@ describe("InMemoryLeaseStore.acquire", () => {
   it("utgången lease (annans) → fri att ta", () => {
     const c = clock();
     const store = new InMemoryLeaseStore(c.now);
-    store.acquire("d1", "u1", "Anna");
+    store.acquire(d1, u1, "Anna");
     c.advance(LEASE_EXPIRE_MS);
-    const res = store.acquire("d1", "u2", "Bo");
+    const res = store.acquire(d1, u2, "Bo");
     expect(res.acquired).toBe(true);
     expect(res.lease.holderId).toBe("u2");
   });
@@ -54,9 +59,9 @@ describe("InMemoryLeaseStore stale/expire-trösklar", () => {
   it("stale efter STALE_MS men före EXPIRE_MS (fortf. hållen)", () => {
     const c = clock();
     const store = new InMemoryLeaseStore(c.now);
-    store.acquire("d1", "u1", "Anna");
+    store.acquire(d1, u1, "Anna");
     c.advance(LEASE_STALE_MS);
-    const lease = store.get("d1");
+    const lease = store.get(d1);
     expect(lease).not.toBeNull();
     expect(lease!.stale).toBe(true); // erbjuder ta-över
   });
@@ -64,9 +69,9 @@ describe("InMemoryLeaseStore stale/expire-trösklar", () => {
   it("get efter EXPIRE_MS → null (fritt)", () => {
     const c = clock();
     const store = new InMemoryLeaseStore(c.now);
-    store.acquire("d1", "u1", "Anna");
+    store.acquire(d1, u1, "Anna");
     c.advance(LEASE_EXPIRE_MS);
-    expect(store.get("d1")).toBeNull();
+    expect(store.get(d1)).toBeNull();
   });
 });
 
@@ -74,46 +79,46 @@ describe("InMemoryLeaseStore.renew", () => {
   it("hållaren förnyar → true, nollställer stale", () => {
     const c = clock();
     const store = new InMemoryLeaseStore(c.now);
-    store.acquire("d1", "u1", "Anna");
+    store.acquire(d1, u1, "Anna");
     c.advance(LEASE_STALE_MS);
-    expect(store.renew("d1", "u1")).toBe(true);
-    expect(store.get("d1")!.stale).toBe(false); // heartbeat → färsk igen
+    expect(store.renew(d1, u1)).toBe(true);
+    expect(store.get(d1)!.stale).toBe(false); // heartbeat → färsk igen
   });
 
   it("icke-hållare förnyar → false", () => {
     const store = new InMemoryLeaseStore(clock().now);
-    store.acquire("d1", "u1", "Anna");
-    expect(store.renew("d1", "u2")).toBe(false);
+    store.acquire(d1, u1, "Anna");
+    expect(store.renew(d1, u2)).toBe(false);
   });
 
   it("utgången lease förnyas inte → false", () => {
     const c = clock();
     const store = new InMemoryLeaseStore(c.now);
-    store.acquire("d1", "u1", "Anna");
+    store.acquire(d1, u1, "Anna");
     c.advance(LEASE_EXPIRE_MS);
-    expect(store.renew("d1", "u1")).toBe(false);
+    expect(store.renew(d1, u1)).toBe(false);
   });
 });
 
 describe("InMemoryLeaseStore.release / takeover", () => {
   it("hållaren släpper → fritt; icke-hållare kan inte släppa", () => {
     const store = new InMemoryLeaseStore(clock().now);
-    store.acquire("d1", "u1", "Anna");
-    store.release("d1", "u2"); // fel hållare → no-op
-    expect(store.get("d1")).not.toBeNull();
-    store.release("d1", "u1");
-    expect(store.get("d1")).toBeNull();
+    store.acquire(d1, u1, "Anna");
+    store.release(d1, u2); // fel hållare → no-op
+    expect(store.get(d1)).not.toBeNull();
+    store.release(d1, u1);
+    expect(store.get(d1)).toBeNull();
   });
 
   it("takeover tar över ett levande lås permanent (annan användare)", () => {
     const c = clock();
     const store = new InMemoryLeaseStore(c.now);
-    store.acquire("d1", "u1", "Anna");
+    store.acquire(d1, u1, "Anna");
     c.advance(LEASE_STALE_MS); // stale men ej utgången
-    const taken = store.takeover("d1", "u2", "Bo");
+    const taken = store.takeover(d1, u2, "Bo");
     expect(taken.holderId).toBe("u2");
     expect(taken.stale).toBe(false);
     // u1 har förlorat den → renew misslyckas.
-    expect(store.renew("d1", "u1")).toBe(false);
+    expect(store.renew(d1, u1)).toBe(false);
   });
 });

--- a/test/unit/server/repositories/invoice-repository.test.ts
+++ b/test/unit/server/repositories/invoice-repository.test.ts
@@ -58,7 +58,7 @@ describe("InvoiceRepository — in-memory", () => {
       payments: [{ id: uuidv7(), invoiceId: invId, amount: 5_000 }],
       writeOffs: [{ id: uuidv7(), invoiceId: invId, amount: 1_000 }],
     }, async () => {});
-    const ledger = await new InMemoryInvoiceRepository(store).getByIdWithLedger(invId);
+    const ledger = await new InMemoryInvoiceRepository(store).getByIdWithLedger(asId<"InvoiceId">(invId));
     expect(ledger?.payments).toHaveLength(1);
     expect(ledger?.writeOffs).toHaveLength(1);
     expect(ledger?.payments[0]!.amount).toBe(5_000);
@@ -71,8 +71,8 @@ describe("InvoiceRepository — in-memory", () => {
       payments: [], writeOffs: [],
     }, async () => {});
     const repo = new InMemoryInvoiceRepository(store);
-    expect(await repo.getByIdInOrg(invId, "org-1")).toMatchObject({ id: invId });
-    expect(await repo.getByIdInOrg(invId, "org-2")).toBeNull(); // fel org
+    expect(await repo.getByIdInOrg(asId<"InvoiceId">(invId), asId<"OrganizationId">("org-1"))).toMatchObject({ id: invId });
+    expect(await repo.getByIdInOrg(asId<"InvoiceId">(invId), asId<"OrganizationId">("org-2"))).toBeNull(); // fel org
   });
 
   it("getByIdWithRelations hämtar huvudrelationerna", async () => {
@@ -91,7 +91,7 @@ describe("InvoiceRepository — in-memory", () => {
       documents: [{ id: uuidv7(), invoiceId: invId, matterId, fileName: "f.pdf" }],
     }, async () => {});
     const repo = new InMemoryInvoiceRepository(store);
-    const full = await repo.getByIdWithRelations(invId, "org-1");
+    const full = await repo.getByIdWithRelations(asId<"InvoiceId">(invId), asId<"OrganizationId">("org-1"));
     expect(full?.matter?.matterNumber).toBe("2026-1");
     expect(full?.payments).toHaveLength(1);
     expect(full?.payments[0]?.recordedBy?.name).toBe("Anna");
@@ -100,7 +100,7 @@ describe("InvoiceRepository — in-memory", () => {
     expect(full?.timeEntries).toHaveLength(1);
     expect(full?.expenses).toHaveLength(1);
     expect(full?.documents).toHaveLength(1);
-    expect(await repo.getByIdWithRelations(invId, "org-2")).toBeNull(); // fel org
+    expect(await repo.getByIdWithRelations(asId<"InvoiceId">(invId), asId<"OrganizationId">("org-2"))).toBeNull(); // fel org
   });
 
   it("getByIdFull tar med aconto-avdrag + kreditnota (self-refs)", async () => {
@@ -114,7 +114,7 @@ describe("InvoiceRepository — in-memory", () => {
       accontoDeductions: [{ id: uuidv7(), finalInvoiceId: invId, accontoInvoiceId: accontoId }],
       payments: [], writeOffs: [],
     }, async () => {});
-    const full = await new InMemoryInvoiceRepository(store).getByIdFull(invId, "org-1");
+    const full = await new InMemoryInvoiceRepository(store).getByIdFull(asId<"InvoiceId">(invId), asId<"OrganizationId">("org-1"));
     expect(full?.accontoDeductions).toHaveLength(1);
     expect((full?.accontoDeductions[0]?.accontoInvoice as { id?: string } | null)?.id).toBe(accontoId);
   });
@@ -138,14 +138,14 @@ describe("InvoiceRepository — in-memory", () => {
       paymentPlans: [], writeOffs: [],
     }, async () => {});
     const repo = new InMemoryInvoiceRepository(store);
-    const all = await repo.listForOrg("org-1");
+    const all = await repo.listForOrg(asId<"OrganizationId">("org-1"));
     expect(all.map((i) => i.id).sort()).toEqual([invId, accontoId].sort()); // org-2-fakturan exkluderad
     const final = all.find((i) => i.id === invId)!;
     expect(final.matter.matterNumber).toBe("2026-1");
     expect(final.payments).toHaveLength(1);
     expect((final.accontoDeductions[0]?.accontoInvoice as { id?: string } | null)?.id).toBe(accontoId);
-    expect((await repo.listForOrg("org-1", { status: "PAID" })).map((i) => i.id)).toEqual([accontoId]);
-    expect((await repo.listForOrg("org-1", { invoiceType: "FINAL" })).map((i) => i.id)).toEqual([invId]);
+    expect((await repo.listForOrg(asId<"OrganizationId">("org-1"), { status: "PAID" })).map((i) => i.id)).toEqual([accontoId]);
+    expect((await repo.listForOrg(asId<"OrganizationId">("org-1"), { invoiceType: "FINAL" })).map((i) => i.id)).toEqual([invId]);
   });
 
   it("nextInvoiceNumber ökar sekvensen per org/år", async () => {
@@ -159,8 +159,8 @@ describe("InvoiceRepository — in-memory", () => {
       payments: [], writeOffs: [],
     }, async () => {});
     const repo = new InMemoryInvoiceRepository(store, () => new Date("2026-06-01T00:00:00.000Z"));
-    expect(await repo.nextInvoiceNumber("org-1")).toBe("F-2026-0003");
-    expect(await repo.nextInvoiceNumber("org-2")).toBe("F-2026-0001"); // tom org → 0001
+    expect(await repo.nextInvoiceNumber(asId<"OrganizationId">("org-1"))).toBe("F-2026-0003");
+    expect(await repo.nextInvoiceNumber(asId<"OrganizationId">("org-2"))).toBe("F-2026-0001"); // tom org → 0001
   });
 
   it("sumCreditNotesFor summerar |belopp| av kreditnotor, org-scopat", async () => {
@@ -176,9 +176,9 @@ describe("InvoiceRepository — in-memory", () => {
       payments: [], writeOffs: [],
     }, async () => {});
     const repo = new InMemoryInvoiceRepository(store);
-    expect(await repo.sumCreditNotesFor(finalId, "org-1")).toBe(50_000); // |−40000| + |−10000|
-    expect(await repo.sumCreditNotesFor(finalId, "org-2")).toBe(0); // fel org
-    expect(await repo.sumCreditNotesFor(uuidv7(), "org-1")).toBe(0); // inga kreditnotor
+    expect(await repo.sumCreditNotesFor(asId<"InvoiceId">(finalId), asId<"OrganizationId">("org-1"))).toBe(50_000); // |−40000| + |−10000|
+    expect(await repo.sumCreditNotesFor(asId<"InvoiceId">(finalId), asId<"OrganizationId">("org-2"))).toBe(0); // fel org
+    expect(await repo.sumCreditNotesFor(asId<"InvoiceId">(uuidv7()), asId<"OrganizationId">("org-1"))).toBe(0); // inga kreditnotor
   });
 
   it("getCreditNoteFor hittar kreditnotan för en faktura", async () => {
@@ -194,8 +194,8 @@ describe("InvoiceRepository — in-memory", () => {
       payments: [], writeOffs: [],
     }, async () => {});
     const repo = new InMemoryInvoiceRepository(store);
-    expect((await repo.getCreditNoteFor(origId))?.id).toBe(creditId);
-    expect(await repo.getCreditNoteFor(uuidv7())).toBeNull(); // ej krediterad
+    expect((await repo.getCreditNoteFor(asId<"InvoiceId">(origId)))?.id).toBe(creditId);
+    expect(await repo.getCreditNoteFor(asId<"InvoiceId">(uuidv7()))).toBeNull(); // ej krediterad
   });
 
   it("listDeductibleAccontos: ACCONTO i ärendet som ej redan avdragits", async () => {
@@ -214,8 +214,8 @@ describe("InvoiceRepository — in-memory", () => {
       payments: [], writeOffs: [],
     }, async () => {});
     const repo = new InMemoryInvoiceRepository(store);
-    expect((await repo.listDeductibleAccontos(mId, [acc1, acc2])).map((a) => a.id)).toEqual([acc1]); // acc2 utesluten
-    expect(await repo.listDeductibleAccontos(mId, [])).toEqual([]);
+    expect((await repo.listDeductibleAccontos(asId<"MatterId">(mId), [acc1, acc2].map((i) => asId<"InvoiceId">(i)))).map((a) => a.id)).toEqual([acc1]); // acc2 utesluten
+    expect(await repo.listDeductibleAccontos(asId<"MatterId">(mId), [])).toEqual([]);
   });
 });
 
@@ -237,7 +237,7 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
       id: uuidv7(), invoiceId: id, amount: 7_500, paidAt: new Date(), recordedById: uuidv7(), version: 1,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
-    const ledger = await new DrizzleInvoiceRepository(handle.db).getByIdWithLedger(id);
+    const ledger = await new DrizzleInvoiceRepository(handle.db).getByIdWithLedger(asId<"InvoiceId">(id));
     expect(ledger?.payments).toHaveLength(1);
     expect(ledger?.payments[0]!.amount).toBe(7_500);
   });
@@ -252,8 +252,8 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await db.insert(invoices).values(inv({ id, matterId: mId }) as any);
     const repo = new DrizzleInvoiceRepository(handle.db);
-    expect(await repo.getByIdInOrg(id, org)).toMatchObject({ id });
-    expect(await repo.getByIdInOrg(id, uuidv7())).toBeNull();
+    expect(await repo.getByIdInOrg(asId<"InvoiceId">(id), asId<"OrganizationId">(org))).toMatchObject({ id });
+    expect(await repo.getByIdInOrg(asId<"InvoiceId">(id), asId<"OrganizationId">(uuidv7()))).toBeNull();
   });
 
   it("getByIdWithRelations hämtar huvudrelationerna (with-query)", async () => {
@@ -277,7 +277,7 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
     await db.insert(documents).values(v({ id: uuidv7(), matterId: mId, invoiceId: id, fileName: "f.pdf", mimeType: "application/pdf", sizeBytes: 1, storagePath: "p", uploadedById: userId }));
 
     const repo = new DrizzleInvoiceRepository(handle.db);
-    const full = await repo.getByIdWithRelations(id, org);
+    const full = await repo.getByIdWithRelations(asId<"InvoiceId">(id), asId<"OrganizationId">(org));
     expect(full?.matter?.matterNumber).toBe("2026-1");
     expect(full?.payments).toHaveLength(1);
     expect(full?.payments[0]?.recordedBy?.name).toBe("Anna");
@@ -286,7 +286,7 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
     expect(full?.timeEntries).toHaveLength(1);
     expect(full?.expenses).toHaveLength(1);
     expect(full?.documents).toHaveLength(1);
-    expect(await repo.getByIdWithRelations(id, uuidv7())).toBeNull(); // fel org
+    expect(await repo.getByIdWithRelations(asId<"InvoiceId">(id), asId<"OrganizationId">(uuidv7()))).toBeNull(); // fel org
   });
 
   it("getByIdFull: self-refs via sekundär-queries (aconto-avdrag + kreditnota)", async () => {
@@ -304,7 +304,7 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
     await db.insert(invoices).values(inv({ id: creditId, matterId: mId, invoiceType: "CREDIT", creditedInvoiceId: finalId }) as never);
     await db.insert(accontoDeductions).values(v({ id: uuidv7(), finalInvoiceId: finalId, accontoInvoiceId: accontoId }));
 
-    const full = await new DrizzleInvoiceRepository(handle.db).getByIdFull(finalId, org);
+    const full = await new DrizzleInvoiceRepository(handle.db).getByIdFull(asId<"InvoiceId">(finalId), asId<"OrganizationId">(org));
     expect(full?.accontoDeductions).toHaveLength(1);
     expect(full?.accontoDeductions[0]?.accontoInvoice?.id).toBe(accontoId);
     expect(full?.creditNote?.id).toBe(creditId);
@@ -330,13 +330,13 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
     await db.insert(payments).values(v({ id: uuidv7(), invoiceId: finalId, amount: 400, paidAt: new Date(), recordedById: uuidv7() }));
 
     const repo = new DrizzleInvoiceRepository(handle.db);
-    const all = await repo.listForOrg(org);
+    const all = await repo.listForOrg(asId<"OrganizationId">(org));
     expect(all.map((i) => i.id).sort()).toEqual([finalId, accontoId].sort()); // annan org exkluderad
     const final = all.find((i) => i.id === finalId)!;
     expect(final.matter.matterNumber).toBe("2026-1");
     expect(final.payments).toHaveLength(1);
     expect(final.accontoDeductions[0]?.accontoInvoice?.id).toBe(accontoId);
-    expect((await repo.listForOrg(org, { status: "PAID" })).map((i) => i.id)).toEqual([accontoId]);
+    expect((await repo.listForOrg(asId<"OrganizationId">(org), { status: "PAID" })).map((i) => i.id)).toEqual([accontoId]);
   });
 
   it("nextInvoiceNumber ökar sekvensen per org/år (join mot matters)", async () => {
@@ -349,8 +349,8 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
     await db.insert(invoices).values(inv({ id: uuidv7(), matterId: mId, invoiceNumber: "F-2026-0001" }) as never);
     await db.insert(invoices).values(inv({ id: uuidv7(), matterId: mId, invoiceNumber: "F-2026-0002" }) as never);
     const repo = new DrizzleInvoiceRepository(handle.db, () => new Date("2026-06-01T00:00:00.000Z"));
-    expect(await repo.nextInvoiceNumber(org)).toBe("F-2026-0003");
-    expect(await repo.nextInvoiceNumber(uuidv7())).toBe("F-2026-0001"); // tom org → 0001
+    expect(await repo.nextInvoiceNumber(asId<"OrganizationId">(org))).toBe("F-2026-0003");
+    expect(await repo.nextInvoiceNumber(asId<"OrganizationId">(uuidv7()))).toBe("F-2026-0001"); // tom org → 0001
   });
 
   it("sumCreditNotesFor summerar |belopp| av kreditnotor (join mot matters)", async () => {
@@ -366,8 +366,8 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
     await db.insert(invoices).values(inv({ id: uuidv7(), matterId: mId, invoiceType: "CREDIT", amount: -10_000, creditedInvoiceId: finalId }) as never);
 
     const repo = new DrizzleInvoiceRepository(handle.db);
-    expect(await repo.sumCreditNotesFor(finalId, org)).toBe(50_000);
-    expect(await repo.sumCreditNotesFor(finalId, uuidv7())).toBe(0); // fel org
+    expect(await repo.sumCreditNotesFor(asId<"InvoiceId">(finalId), asId<"OrganizationId">(org))).toBe(50_000);
+    expect(await repo.sumCreditNotesFor(asId<"InvoiceId">(finalId), asId<"OrganizationId">(uuidv7()))).toBe(0); // fel org
   });
 
   it("getCreditNoteFor hittar kreditnotan (creditedInvoiceId)", async () => {
@@ -381,8 +381,8 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
     await db.insert(invoices).values(inv({ id: origId, matterId: mId, invoiceType: "STANDARD" }) as never);
     await db.insert(invoices).values(inv({ id: creditId, matterId: mId, invoiceType: "CREDIT", amount: -100, creditedInvoiceId: origId }) as never);
     const repo = new DrizzleInvoiceRepository(handle.db);
-    expect((await repo.getCreditNoteFor(origId))?.id).toBe(creditId);
-    expect(await repo.getCreditNoteFor(uuidv7())).toBeNull();
+    expect((await repo.getCreditNoteFor(asId<"InvoiceId">(origId)))?.id).toBe(creditId);
+    expect(await repo.getCreditNoteFor(asId<"InvoiceId">(uuidv7()))).toBeNull();
   });
 
   it("listDeductibleAccontos: ACCONTO ej redan avdragna (left-join)", async () => {
@@ -399,6 +399,6 @@ describe("InvoiceRepository — Drizzle (pglite)", () => {
     await db.insert(invoices).values(inv({ id: finalId, matterId: mId, invoiceType: "FINAL" }) as never);
     await db.insert(accontoDeductions).values(v({ id: uuidv7(), finalInvoiceId: finalId, accontoInvoiceId: acc2 }));
     const repo = new DrizzleInvoiceRepository(handle.db);
-    expect((await repo.listDeductibleAccontos(mId, [acc1, acc2])).map((a) => a.id)).toEqual([acc1]);
+    expect((await repo.listDeductibleAccontos(asId<"MatterId">(mId), [acc1, acc2].map((i) => asId<"InvoiceId">(i)))).map((a) => a.id)).toEqual([acc1]);
   });
 });

--- a/test/unit/server/routers/document/lease.test.ts
+++ b/test/unit/server/routers/document/lease.test.ts
@@ -11,6 +11,7 @@ import { InMemoryLeaseStore } from "@/lib/server/lease/lease-store";
 import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
 import { documentRouter } from "@/lib/server/routers/document";
 import { prebakeJoins } from "@/lib/shared/demo-source";
+import { asId } from "@/lib/shared/schemas/ids";
 
 const ORG = "org-a";
 
@@ -76,6 +77,6 @@ describe("document lease-procedurer", () => {
     await expect(
       caller(source, lease, { id: "x", name: "X" }, "org-b").acquireLease({ documentId: "d1" }),
     ).rejects.toThrow();
-    expect(lease.get("d1")).toBeNull();
+    expect(lease.get(asId<"DocumentId">("d1"))).toBeNull();
   });
 });


### PR DESCRIPTION
ID-brandning (B6, #750) — sista leaf-tailen, driver kvarvarande domän-id-`string` mot ~0.

- **ports.ts** `IDocumentAnalyzer.analyze` + `ILeaseStore` (`documentId`→`DocumentId`, `holderId`→`UserId`) + lease-store-impl matchad.
- **invoice-repo-impl-signaturerna** (drizzle + in-memory) matchade till sitt redan brandade interface (var `string`, nu `InvoiceId`/`MatterId`/`OrganizationId`) + slopade ~22 redundanta interna `asId`-wraps.
- **reports** interna DTO-rader (`ReportTimeEntry`/`MatterAgg`/`ArRowMeta`/`RawTimeEntry`) → branded.
- **klient** template-recipients + content-sync/cache + working-set: domän-id-fält brandade (cache-keys/sha/storagePath lämnade `string`).

**Medvetet kvar `string`:** search-subsystemet (`ISearchIndex`/`SearchHit` — egen subsystem-kaskad), cache-keys/paths/hashar. Inga typer försvagade; rent i alla tre tsc-projekt, 1434 tester gröna.

→ **Strong-typing-svepet (#750) klart:** enum-fasen + hela ID-brandnings-fasen (bas-kontrakt → repos+impls → router-inputs → Principal → klient-props → helper → leaf). Kvarvarande `string` är medvetna icke-id:n (paths/keys/hashar/refs) + sök-subsystemet.

Refs #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)