### PR TITLE
refactor: branda sista domän-id-svansen (invoice-dispatch/dispatchers/adapters) (B7)

### DIFF
--- a/src/lib/client/addin/save-incoming-mail.ts
+++ b/src/lib/client/addin/save-incoming-mail.ts
@@ -12,6 +12,7 @@
 import type { inferRouterInputs } from "@trpc/server";
 import { fetchMessageEml, type GraphFetch } from "@/lib/client/graph/graph-mail";
 import type { AppRouter } from "@/lib/server/routers/_app";
+import type { MatterId } from "@/lib/shared/schemas/ids";
 
 type SaveIncomingInput = inferRouterInputs<AppRouter>["mail"]["saveIncoming"];
 
@@ -29,7 +30,7 @@ export interface SaveIncomingMailDeps {
   /** Meddelandets REST-id (konverterat från Office `itemId` av shell:en). */
   restId: string;
   /** Valt ärende. */
-  matterId: string;
+  matterId: MatterId;
   /** Mejlets ämne (ur Office `item.subject`). */
   subject: string;
   /** Mottaget-datum, ISO (ur Office `item.dateTimeCreated`). */

--- a/src/lib/client/addin/taskpane-controller.ts
+++ b/src/lib/client/addin/taskpane-controller.ts
@@ -12,6 +12,7 @@
 
 import { createAddinClient } from "@/lib/client/addin/addin-client";
 import { saveIncomingMail, type MailSaverClient } from "@/lib/client/addin/save-incoming-mail";
+import type { MatterId } from "@/lib/shared/schemas/ids";
 
 // ─── Smal Office.js-yta (det subset task-panen faktiskt rör) ──────────
 
@@ -40,7 +41,7 @@ export interface OfficeLike {
   MailboxEnums: { RestVersion: { v2_0: string } };
 }
 
-export interface MatterHit { id: string; matterNumber: string; title: string }
+export interface MatterHit { id: MatterId; matterNumber: string; title: string }
 type StatusFn = (msg: string, cls?: string) => void;
 
 /** Smal klient-yta för ärende-söket (uppfylls av `createAddinClient(...)`s
@@ -49,7 +50,7 @@ export interface MatterSearchClient {
   matter: {
     list: {
       query: (input: { search?: string; pageSize?: number }) => Promise<{
-        matters: ReadonlyArray<{ id: string; matterNumber: string; title: string }>;
+        matters: ReadonlyArray<{ id: MatterId; matterNumber: string; title: string }>;
       }>;
     };
   };

--- a/src/lib/client/backend/load-document-blob.ts
+++ b/src/lib/client/backend/load-document-blob.ts
@@ -8,13 +8,14 @@
  */
 
 import { base64ToBytes } from "@/lib/shared/content-address";
+import type { DocumentId } from "@/lib/shared/schemas/ids";
 import { DocumentContentCache } from "./content-cache";
 
 /** tRPC-ytan primitiven behöver (strukturell → ingen hård klient-typ-koppling). */
 export interface DownloadClient {
   document: {
     downloadContent: {
-      query: (input: { documentId: string }) => Promise<{ contentBase64: string; mimeType: string }>;
+      query: (input: { documentId: DocumentId }) => Promise<{ contentBase64: string; mimeType: string }>;
     };
   };
 }
@@ -32,13 +33,13 @@ export function mimeFromName(fileName: string): string {
 }
 
 /** Cache-nyckel ur storagePath (sista segmentet = sha, content-adresserat). */
-function cacheKey(doc: { id: string; storagePath?: string | null }): string {
+function cacheKey(doc: { id: DocumentId; storagePath?: string | null }): string {
   return doc.storagePath?.split("/").pop() ?? doc.id;
 }
 
 export async function loadDocumentBlob(
   client: DownloadClient,
-  doc: { id: string; storagePath?: string | null; fileName: string },
+  doc: { id: DocumentId; storagePath?: string | null; fileName: string },
   cache: DocumentContentCache = new DocumentContentCache(),
 ): Promise<Blob | null> {
   const key = cacheKey(doc);

--- a/src/lib/client/firma/open-matter-document.ts
+++ b/src/lib/client/firma/open-matter-document.ts
@@ -39,7 +39,7 @@ export async function openMatterDocument(doc: OpenableDoc): Promise<void> {
       // Server-tier: helpern hämtar via tRPC document.downloadContent (ADR 0031).
       const viaHelper = await fetchContentViaHelper({ document: { id: asId<"DocumentId">(doc.id), trpcUrl }, fileName });
       if (viaHelper) return new Blob([viaHelper as BlobPart], { type: mimeFromName(fileName) });
-      return loadDocumentBlob(client, { id: doc.id, storagePath: doc.storagePath ?? null, fileName });
+      return loadDocumentBlob(client, { id: asId<"DocumentId">(doc.id), storagePath: doc.storagePath ?? null, fileName });
     };
   }
 

--- a/src/lib/client/firma/prefetch-matter-documents.ts
+++ b/src/lib/client/firma/prefetch-matter-documents.ts
@@ -12,15 +12,17 @@
  * gratis, så ett återbesök på ärendet laddar inte om något.
  */
 
+import type { DocumentId } from "@/lib/shared/schemas/ids";
+
 export interface PrefetchableDoc {
-  id: string;
+  id: DocumentId;
   storagePath?: string | null;
   fileName?: string;
 }
 
 export async function prefetchMatterDocuments(
   docs: ReadonlyArray<PrefetchableDoc>,
-  loadBlob: (doc: { id: string; storagePath: string | null; fileName: string }) => Promise<Blob | null>,
+  loadBlob: (doc: { id: DocumentId; storagePath: string | null; fileName: string }) => Promise<Blob | null>,
   concurrency = 3,
 ): Promise<number> {
   let next = 0;

--- a/src/lib/client/firma/use-eager-cache-matter-documents.ts
+++ b/src/lib/client/firma/use-eager-cache-matter-documents.ts
@@ -11,9 +11,10 @@
 import { useEffect, useRef } from "react";
 import { useCapabilities } from "@/lib/client/capabilities/use-capabilities";
 import { trpc } from "@/lib/client/trpc";
+import type { MatterId } from "@/lib/shared/schemas/ids";
 import { prefetchMatterDocuments, type PrefetchableDoc } from "./prefetch-matter-documents";
 
-export function useEagerCacheMatterDocuments(matterId: string): void {
+export function useEagerCacheMatterDocuments(matterId: MatterId): void {
   const { sync } = useCapabilities();
   const tree = trpc.document.tree.useQuery({ matterId }, { enabled: sync });
   const started = useRef(false);

--- a/src/lib/client/fsa/upload-document.ts
+++ b/src/lib/client/fsa/upload-document.ts
@@ -13,6 +13,7 @@
  * tRPC-anrop. Caller wirar in:nytt-document genom mutation efteråt.
  */
 
+import type { MatterId } from "@/lib/shared/schemas/ids";
 import { FsaIsoGitAdapter } from "./fs-adapter";
 
 export interface UploadResult {
@@ -25,7 +26,7 @@ export interface UploadResult {
 
 export interface UploadOptions {
   handle: FileSystemDirectoryHandle;
-  matterId: string;
+  matterId: MatterId;
   file: File;
   /** Optional id-generator (för deterministiska tester). */
   generateId?: () => string;

--- a/src/lib/client/jobs/analyze-dispatch.ts
+++ b/src/lib/client/jobs/analyze-dispatch.ts
@@ -11,9 +11,10 @@
  */
 
 import type { DocumentAnalysisStatus } from "@/lib/shared/schemas/document";
+import type { DocumentId } from "@/lib/shared/schemas/ids";
 
 export interface AnalyzeArgs {
-  documentId: string;
+  documentId: DocumentId;
   kind: string;
   /** ISO-timestamp när analysen körde. UI:n förlitar sig på detta
    *  för att stänga "⏳ analyseras..."-state:n. */

--- a/src/lib/client/jobs/extract-text-dispatch.ts
+++ b/src/lib/client/jobs/extract-text-dispatch.ts
@@ -6,8 +6,10 @@
  * samma pattern som analyze-dispatch.
  */
 
+import type { DocumentId } from "@/lib/shared/schemas/ids";
+
 export interface ExtractTextArgs {
-  documentId: string;
+  documentId: DocumentId;
   text: string;
   signal?: AbortSignal;
 }

--- a/src/lib/client/jobs/register-workers.ts
+++ b/src/lib/client/jobs/register-workers.ts
@@ -10,16 +10,17 @@
  */
 
 import { omitUndefined } from "@/lib/shared/omit-undefined";
+import type { DocumentId } from "@/lib/shared/schemas/ids";
 import { jobQueue } from "./job-queue";
 
 interface ClassifyPayload extends Record<string, unknown> {
-  documentId: string;
+  documentId: DocumentId;
   fileName: string;
   storagePath?: string;
 }
 
 interface ExtractTextPayload extends Record<string, unknown> {
-  documentId: string;
+  documentId: DocumentId;
   fileName: string;
   storagePath: string;
   mimeType?: string;

--- a/src/lib/client/kostnadsrakning/generate-faktura-doc.ts
+++ b/src/lib/client/kostnadsrakning/generate-faktura-doc.ts
@@ -13,6 +13,7 @@
 import type { inferRouterInputs } from "@trpc/server";
 import type { AppRouter } from "@/lib/server/routers/_app";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
+import { asId, type InvoiceId, type MatterId } from "@/lib/shared/schemas/ids";
 
 type RouterInputs = inferRouterInputs<AppRouter>;
 type RegisterInput = RouterInputs["document"]["register"];
@@ -37,7 +38,7 @@ export interface FakturaDocMeta {
 }
 
 export interface FakturaDocInvoice {
-  id: string;
+  id: InvoiceId;
   amount: number;
   invoiceNumber?: string | null | undefined;
   ocrReference?: string | null | undefined;
@@ -46,7 +47,7 @@ export interface FakturaDocInvoice {
 
 export interface GenerateFakturaDocArgs {
   invoice: FakturaDocInvoice;
-  matterId: string;
+  matterId: MatterId;
   meta: FakturaDocMeta;
   register: RegisterMut;
   utils: DocUtils;
@@ -72,7 +73,7 @@ export async function generateFakturaDoc(args: GenerateFakturaDocArgs): Promise<
   const fileName = `Faktura ${meta.matterNumber} ${new Date().toISOString().slice(0, 10)}.pdf`;
   const storagePath = `documents/content/${docId}.pdf`;
   await register.mutateAsync({
-    id: docId, matterId, fileName, mimeType: "application/pdf",
+    id: asId<"DocumentId">(docId), matterId, fileName, mimeType: "application/pdf",
     sizeBytes: bytes.byteLength, storagePath, documentType: "Faktura",
     invoiceId: invoice.id, analysisStatus: "DONE",
   });

--- a/src/lib/server/adapters/demo-document-analyzer.ts
+++ b/src/lib/server/adapters/demo-document-analyzer.ts
@@ -10,10 +10,11 @@
  * pipeline som auto-classify-vid-upload.
  */
 
+import type { DocumentId } from "@/lib/shared/schemas/ids";
 import type { IDocumentAnalyzer } from "../ports";
 
 export const demoDocumentAnalyzer: IDocumentAnalyzer = {
-  async analyze(documentId: string): Promise<void> {
+  async analyze(documentId: DocumentId): Promise<void> {
     if (typeof window === "undefined") return;
     const { jobQueue } = await import("@/lib/client/jobs/job-queue");
     // Vi vet bara id:t här, inte filnamnet. Workern hämtar fileName via

--- a/src/lib/server/integrations/ledger/reconcile-payments.ts
+++ b/src/lib/server/integrations/ledger/reconcile-payments.ts
@@ -15,11 +15,12 @@
  */
 
 import { normalizeRef } from "@/lib/shared/payments/match-payments";
+import type { InvoiceId } from "@/lib/shared/schemas/ids";
 import type { LedgerPayment } from "./port";
 
 /** Faktura-delmängd avprickningen behöver. */
 export interface ReconcileInvoice {
-  id: string;
+  id: InvoiceId;
   ocrReference: string | null;
   /** Referenser på redan bokförda betalningar (Payment.reference) — dubblettskydd. */
   paymentReferences: readonly string[];
@@ -27,7 +28,7 @@ export interface ReconcileInvoice {
 
 /** En avprickningsbar betalning (matchad mot en faktura). */
 export interface ReconciledPayment {
-  invoiceId: string;
+  invoiceId: InvoiceId;
   amountOre: number;
   /** Idempotens-referens (= LedgerPayment.externalId). */
   reference: string;
@@ -47,15 +48,15 @@ export interface ReconcileOutcome {
 }
 
 /** OCR-referens (normaliserad) → faktura-id. */
-function buildOcrIndex(invoices: readonly ReconcileInvoice[]): Map<string, string> {
-  const index = new Map<string, string>();
+function buildOcrIndex(invoices: readonly ReconcileInvoice[]): Map<string, InvoiceId> {
+  const index = new Map<string, InvoiceId>();
   for (const inv of invoices) {
     if (inv.ocrReference) index.set(normalizeRef(inv.ocrReference), inv.id);
   }
   return index;
 }
 
-function toReconciled(payment: LedgerPayment, invoiceId: string): ReconciledPayment {
+function toReconciled(payment: LedgerPayment, invoiceId: InvoiceId): ReconciledPayment {
   return {
     invoiceId,
     amountOre: payment.amount,

--- a/src/lib/server/jobs/queue-backed-document-analyzer.ts
+++ b/src/lib/server/jobs/queue-backed-document-analyzer.ts
@@ -12,6 +12,7 @@
 
 import type { PgBoss } from "pg-boss";
 import type { IDocumentAnalyzer } from "@/lib/server/ports";
+import type { DocumentId } from "@/lib/shared/schemas/ids";
 import { JOB_QUEUES } from "./job-queue";
 
 export class QueueBackedDocumentAnalyzer implements IDocumentAnalyzer {
@@ -20,7 +21,7 @@ export class QueueBackedDocumentAnalyzer implements IDocumentAnalyzer {
     private readonly organizationId: string,
   ) {}
 
-  async analyze(documentId: string): Promise<void> {
+  async analyze(documentId: DocumentId): Promise<void> {
     const boss = this.getBoss();
     if (!boss) throw new Error("jobb-kön är inte redo — dokumentet kunde inte köas för klassificering");
     // Idempotens (#504, ADR 0024): `singletonKey = documentId` → som mest ETT

--- a/src/lib/server/repositories/drizzle-invoice-dispatch-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-dispatch-repository.ts
@@ -5,7 +5,7 @@
 
 import { and, asc, desc, eq, isNull } from "drizzle-orm";
 import type { InvoiceDispatch } from "@/lib/shared/schemas/billing";
-import { asId, type InvoiceId } from "@/lib/shared/schemas/ids";
+import type { InvoiceId, OrganizationId } from "@/lib/shared/schemas/ids";
 import { invoiceDispatches, invoices, matters } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
@@ -24,15 +24,15 @@ export class DrizzleInvoiceDispatchRepository
     super(db, versionedTable(invoiceDispatches), now);
   }
 
-  async listByInvoice(invoiceId: string): Promise<InvoiceDispatch[]> {
+  async listByInvoice(invoiceId: InvoiceId): Promise<InvoiceDispatch[]> {
     const rows = await this.db
       .select().from(invoiceDispatches)
-      .where(and(eq(invoiceDispatches.invoiceId, asId<"InvoiceId">(invoiceId)), isNull(invoiceDispatches.deletedAt)))
+      .where(and(eq(invoiceDispatches.invoiceId, invoiceId), isNull(invoiceDispatches.deletedAt)))
       .orderBy(desc(invoiceDispatches.queuedAt));
     return rows;
   }
 
-  async listQueuedForOrg(organizationId: string): Promise<InvoiceDispatchQueuedRow[]> {
+  async listQueuedForOrg(organizationId: OrganizationId): Promise<InvoiceDispatchQueuedRow[]> {
     const rows = await this.db
       .select({
         d: invoiceDispatches,
@@ -44,7 +44,7 @@ export class DrizzleInvoiceDispatchRepository
       .innerJoin(matters, eq(invoices.matterId, matters.id))
       .where(and(
         eq(invoiceDispatches.status, "queued"),
-        eq(matters.organizationId, asId<"OrganizationId">(organizationId)),
+        eq(matters.organizationId, organizationId),
         isNull(invoiceDispatches.deletedAt),
       ))
       .orderBy(asc(invoiceDispatches.queuedAt));

--- a/src/lib/server/repositories/in-memory-invoice-dispatch-repository.ts
+++ b/src/lib/server/repositories/in-memory-invoice-dispatch-repository.ts
@@ -3,6 +3,7 @@
  */
 
 import type { InvoiceDispatch } from "@/lib/shared/schemas/billing";
+import type { InvoiceId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type { InvoiceDispatchQueuedRow, InvoiceDispatchRepository } from "./invoice-dispatch-repository";
@@ -16,14 +17,14 @@ export class InMemoryInvoiceDispatchRepository
     super(store.invoiceDispatches, now ?? (() => new Date()));
   }
 
-  async listByInvoice(invoiceId: string): Promise<InvoiceDispatch[]> {
+  async listByInvoice(invoiceId: InvoiceId): Promise<InvoiceDispatch[]> {
     return (await this.delegate.findMany({
       where: { invoiceId },
       orderBy: { queuedAt: "desc" },
     })) as InvoiceDispatch[];
   }
 
-  async listQueuedForOrg(organizationId: string): Promise<InvoiceDispatchQueuedRow[]> {
+  async listQueuedForOrg(organizationId: OrganizationId): Promise<InvoiceDispatchQueuedRow[]> {
     return (await this.delegate.findMany({
       where: { status: "queued", invoice: { matter: { organizationId } } },
       include: { invoice: { select: { id: true, invoiceNumber: true, amount: true, ocrReference: true, dueDate: true } } },

--- a/src/lib/server/repositories/invoice-dispatch-repository.ts
+++ b/src/lib/server/repositories/invoice-dispatch-repository.ts
@@ -4,19 +4,20 @@
  */
 
 import type { InvoiceDispatch } from "@/lib/shared/schemas/billing";
+import type { InvoiceId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { Repository } from "./types";
 
 /** Köad utskickspost + fakturans fält som dispatch-workern (#180) behöver. */
 export interface InvoiceDispatchQueuedRow extends InvoiceDispatch {
   invoice: {
-    id: string; invoiceNumber: string | null; amount: number;
+    id: InvoiceId; invoiceNumber: string | null; amount: number;
     ocrReference: string | null; dueDate: Date | string | null;
   } | null;
 }
 
 export interface InvoiceDispatchRepository extends Repository<InvoiceDispatch> {
   /** Alla utskick för en faktura (nyaste först). Org-koll görs av anroparen. */
-  listByInvoice(invoiceId: string): Promise<InvoiceDispatch[]>;
+  listByInvoice(invoiceId: InvoiceId): Promise<InvoiceDispatch[]>;
   /** Alla köade utskick i org:en (äldsta först), med faktura-subset för workern. */
-  listQueuedForOrg(organizationId: string): Promise<InvoiceDispatchQueuedRow[]>;
+  listQueuedForOrg(organizationId: OrganizationId): Promise<InvoiceDispatchQueuedRow[]>;
 }

--- a/src/lib/server/routers/conflict.ts
+++ b/src/lib/server/routers/conflict.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { similarity } from "@/lib/shared/fuzzy-similarity";
-import { asId } from "@/lib/shared/schemas/ids";
+import { asId, type ContactId, type MatterId } from "@/lib/shared/schemas/ids";
 import type { ConflictContactRow } from "../repositories/matter-contact-repository";
 import type { Repositories } from "../repositories/repositories";
 import { router, protectedProcedure } from "../trpc";
@@ -8,12 +8,12 @@ import { router, protectedProcedure } from "../trpc";
 type ConflictCtx = { repos: Repositories; user: { id: string; organizationId: string } };
 
 interface ConflictResult {
-  contactId: string;
+  contactId: ContactId;
   contactName: string;
   contactType: string;
   personalNumber: string | null;
   orgNumber: string | null;
-  matterId: string;
+  matterId: MatterId;
   matterNumber: string;
   matterTitle: string;
   role: string;

--- a/src/lib/server/routers/expectedReceivable.ts
+++ b/src/lib/server/routers/expectedReceivable.ts
@@ -17,7 +17,7 @@ import { z } from "zod";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import type { ExpectedReceivable } from "@/lib/shared/schemas/billing";
 import { expectedReceivableStatusSchema } from "@/lib/shared/schemas/billing";
-import { expectedReceivableIdSchema, matterIdSchema, type ExpectedReceivableId, type OrganizationId } from "@/lib/shared/schemas/ids";
+import { expectedReceivableIdSchema, matterIdSchema, type ExpectedReceivableId, type MatterId, type OrganizationId } from "@/lib/shared/schemas/ids";
 import type { Repositories } from "../repositories/repositories";
 import { router, orgProcedure } from "../trpc";
 
@@ -43,9 +43,9 @@ export const expectedReceivableRouter = router({
    */
   candidates: orgProcedure.query(async ({ ctx }) => {
     const rows = (await ctx.repos.expectedReceivables.listForOrg(ctx.orgId, { status: "PENDING" })) as
-      Array<{ id: string; matterId: string; description: string; expectedAmount: number }>;
+      Array<{ id: ExpectedReceivableId; matterId: MatterId; description: string; expectedAmount: number }>;
     const matters = (await ctx.repos.matters.listByOrg(ctx.orgId)) as
-      Array<{ id: string; matterNumber?: string | null; courtCaseNumber?: string | null }>;
+      Array<{ id: MatterId; matterNumber?: string | null; courtCaseNumber?: string | null }>;
     const byId = new Map(matters.map((m) => [String(m.id), m]));
     return rows.map((r) => {
       const m = byId.get(String(r.matterId));

--- a/src/lib/server/routers/invoiceDispatch.ts
+++ b/src/lib/server/routers/invoiceDispatch.ts
@@ -13,15 +13,15 @@ import { z } from "zod";
 import { canTransition } from "@/lib/shared/invoice-state-machine";
 import { dispatchChannelSchema, dispatchStatusSchema, type DispatchStatus, type InvoiceDispatch } from "@/lib/shared/schemas/billing";
 import type { InvoiceStatus } from "@/lib/shared/schemas/enums";
-import { asId, invoiceDispatchIdSchema, invoiceIdSchema } from "@/lib/shared/schemas/ids";
+import { asId, type InvoiceId, invoiceDispatchIdSchema, invoiceIdSchema } from "@/lib/shared/schemas/ids";
 import type { Repositories } from "../repositories/repositories";
 import { router, orgProcedure } from "../trpc";
 
 type DispatchCtx = { repos: Repositories; orgId: string };
 
 /** Verifiera org-tillhörighet + returnera fakturans id/status (repository-sömmen, ADR 0020). */
-async function assertInvoiceInOrg(ctx: DispatchCtx, invoiceId: string): Promise<{ id: string; status: string }> {
-  const inv = await ctx.repos.invoices.getByIdInOrg(asId<"InvoiceId">(invoiceId), asId<"OrganizationId">(ctx.orgId));
+async function assertInvoiceInOrg(ctx: DispatchCtx, invoiceId: InvoiceId): Promise<{ id: InvoiceId; status: string }> {
+  const inv = await ctx.repos.invoices.getByIdInOrg(invoiceId, asId<"OrganizationId">(ctx.orgId));
   if (!inv) throw new TRPCError({ code: "NOT_FOUND", message: "Fakturan finns inte i organisationen." });
   return inv;
 }
@@ -30,9 +30,9 @@ async function assertInvoiceInOrg(ctx: DispatchCtx, invoiceId: string): Promise<
  * En köad/skickad faktura är inte längre ett utkast (#392). Flippa DRAFT → SENT
  * via tillståndsmaskinen (#350); redan utställd faktura lämnas oförändrad.
  */
-async function markSentIfDraft(ctx: DispatchCtx, inv: { id: string; status: string }): Promise<void> {
+async function markSentIfDraft(ctx: DispatchCtx, inv: { id: InvoiceId; status: string }): Promise<void> {
   if (inv.status !== "DRAFT" || !canTransition("DRAFT", "SENT")) return;
-  await ctx.repos.invoices.update(asId<"InvoiceId">(inv.id), { status: "SENT" satisfies InvoiceStatus });
+  await ctx.repos.invoices.update(inv.id, { status: "SENT" satisfies InvoiceStatus });
 }
 
 /** Tidsstämpelfältet som en statusövergång sätter (queued sätts vid skapande). */
@@ -53,7 +53,7 @@ export const invoiceDispatchRouter = router({
 
   /** Alla köade utskick i org:en — server-runtime-dispatch-workern (#180) plockar dessa. */
   listQueued: orgProcedure.query(({ ctx }) =>
-    ctx.repos.invoiceDispatches.listQueuedForOrg(ctx.orgId),
+    ctx.repos.invoiceDispatches.listQueuedForOrg(asId<"OrganizationId">(ctx.orgId)),
   ),
 
   queue: orgProcedure
@@ -66,7 +66,7 @@ export const invoiceDispatchRouter = router({
       const inv = await assertInvoiceInOrg(ctx, input.invoiceId);
       const now = new Date();
       const dispatch = await ctx.repos.invoiceDispatches.create({
-        invoiceId: asId<"InvoiceId">(input.invoiceId),
+        invoiceId: input.invoiceId,
         channel: input.channel,
         recipient: input.recipient,
         status: "queued",
@@ -97,7 +97,7 @@ export const invoiceDispatchRouter = router({
       const inv = await assertInvoiceInOrg(ctx, input.invoiceId);
       const now = new Date();
       const dispatch = await ctx.repos.invoiceDispatches.create({
-        invoiceId: asId<"InvoiceId">(input.invoiceId),
+        invoiceId: input.invoiceId,
         channel: input.channel,
         recipient: input.recipient,
         status: "sent",
@@ -121,7 +121,7 @@ export const invoiceDispatchRouter = router({
     .mutation(async ({ ctx, input }) => {
       const dispatch = await ctx.repos.invoiceDispatches.getById(input.dispatchId);
       if (!dispatch) throw new TRPCError({ code: "NOT_FOUND" });
-      await assertInvoiceInOrg(ctx, String(dispatch.invoiceId));
+      await assertInvoiceInOrg(ctx, dispatch.invoiceId);
 
       const tsField = STATUS_TIMESTAMP[input.status];
       return ctx.repos.invoiceDispatches.update(input.dispatchId, {

--- a/src/lib/server/routers/mail.ts
+++ b/src/lib/server/routers/mail.ts
@@ -13,7 +13,7 @@
  */
 
 import { z } from "zod";
-import { asId, documentFolderIdSchema, matterIdSchema } from "@/lib/shared/schemas/ids";
+import { asId, documentFolderIdSchema, type MatterId, matterIdSchema } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { emit, type EmitCtx } from "../events/emit";
 import type { Repositories } from "../repositories/repositories";
@@ -79,7 +79,7 @@ export const mailRouter = router({
       const fileName = emlFileName(input.subject);
       const docData = {
         id: asId<"DocumentId">(id),
-        matterId: asId<"MatterId">(input.matterId),
+        matterId: input.matterId,
         fileName,
         mimeType: "message/rfc822",
         sizeBytes: bytes.byteLength,
@@ -107,7 +107,7 @@ export const mailRouter = router({
 /** Bokför tidsposten som hör ihop med ett sparat mail (#72 funktion 1). */
 async function createMailTimeEntry(
   ctx: MailCtx,
-  matterId: string,
+  matterId: MatterId,
   receivedAt: string,
   subject: string,
   time: z.infer<typeof timeInput>,
@@ -116,7 +116,7 @@ async function createMailTimeEntry(
   const user = await ctx.repos.users.getByIdOrThrow(userId);
   const entryData = {
     userId,
-    matterId: asId<"MatterId">(matterId),
+    matterId,
     date: new Date(receivedAt),
     minutes: time.minutes,
     description: time.description ?? subject,

--- a/test/unit/client/addin/save-incoming-mail.test.ts
+++ b/test/unit/client/addin/save-incoming-mail.test.ts
@@ -6,6 +6,7 @@
 import { describe, it, expect, vi } from "vitest-compat";
 import { saveIncomingMail, type MailSaverClient } from "@/lib/client/addin/save-incoming-mail";
 import type { GraphFetch } from "@/lib/client/graph/graph-mail";
+import { asId } from "@/lib/shared/schemas/ids";
 
 const RAW = "Subject: Hej\r\n\r\nKropp";
 const graphOk: GraphFetch = vi.fn(async () => new Response(new TextEncoder().encode(RAW), { status: 200 }));
@@ -21,7 +22,7 @@ describe("saveIncomingMail", () => {
     const { client, mutate } = mockClient();
     await saveIncomingMail({
       client, graphToken: "gtok", restId: "id1",
-      matterId: "m1", subject: "Hej", receivedAt: "2026-06-14T08:00:00Z", fetch: graphOk,
+      matterId: asId<"MatterId">("m1"), subject: "Hej", receivedAt: "2026-06-14T08:00:00Z", fetch: graphOk,
     });
     expect(mutate).toHaveBeenCalledWith({
       matterId: "m1",
@@ -34,7 +35,7 @@ describe("saveIncomingMail", () => {
   it("skickar med time + folderId när de anges", async () => {
     const { client, mutate } = mockClient();
     await saveIncomingMail({
-      client, graphToken: "g", restId: "id1", matterId: "m1", subject: "S",
+      client, graphToken: "g", restId: "id1", matterId: asId<"MatterId">("m1"), subject: "S",
       receivedAt: "2026-06-14T08:00:00Z", time: { minutes: 15, description: "Läsning" },
       folderId: "f1", fetch: graphOk,
     });
@@ -47,7 +48,7 @@ describe("saveIncomingMail", () => {
     const { client, mutate } = mockClient();
     const fail: GraphFetch = vi.fn(async () => new Response("no", { status: 403 }));
     await expect(saveIncomingMail({
-      client, graphToken: "g", restId: "id1", matterId: "m1", subject: "S",
+      client, graphToken: "g", restId: "id1", matterId: asId<"MatterId">("m1"), subject: "S",
       receivedAt: "2026-06-14T08:00:00Z", fetch: fail,
     })).rejects.toThrow(/\$value.*403/);
     expect(mutate).not.toHaveBeenCalled();

--- a/test/unit/client/addin/taskpane-controller.test.ts
+++ b/test/unit/client/addin/taskpane-controller.test.ts
@@ -11,6 +11,7 @@ import {
   searchMatters, getRestToken, mailContext, persistCreds, runSave, renderResults, bootstrap,
   type OfficeLike, type MatterHit,
 } from "@/lib/client/addin/taskpane-controller";
+import { asId } from "@/lib/shared/schemas/ids";
 
 const saveIncomingMailMock = vi.fn(async () => ({ ok: true }));
 vi.mock("@/lib/client/addin/save-incoming-mail", () => ({
@@ -54,7 +55,7 @@ function makeOffice(o: OfficeOverrides = {}): { office: OfficeLike; set: ReturnT
   return { office, set, saveAsync };
 }
 
-const matter: MatterHit = { id: "m1", matterNumber: "2026-0007", title: "Tvist" };
+const matter: MatterHit = { id: asId<"MatterId">("m1"), matterNumber: "2026-0007", title: "Tvist" };
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -155,7 +156,7 @@ describe("renderResults", () => {
   it("renderar klickbara rader; klick markerar + rapporterar valet", () => {
     const box = document.createElement("div");
     const picked: MatterHit[] = [];
-    renderResults(box, [matter, { id: "m2", matterNumber: "2026-9", title: "B" }], (m) => picked.push(m));
+    renderResults(box, [matter, { id: asId<"MatterId">("m2"), matterNumber: "2026-9", title: "B" }], (m) => picked.push(m));
     const rows = box.querySelectorAll(".matter");
     expect(rows).toHaveLength(2);
     expect(rows[0]!.textContent).toBe("2026-0007 — Tvist");

--- a/test/unit/client/backend/load-document-blob.test.ts
+++ b/test/unit/client/backend/load-document-blob.test.ts
@@ -8,11 +8,12 @@ import { IDBFactory } from "fake-indexeddb";
 import { beforeEach, describe, expect, it, vi } from "vitest-compat";
 import { DocumentContentCache } from "@/lib/client/backend/content-cache";
 import { loadDocumentBlob } from "@/lib/client/backend/load-document-blob";
+import { asId } from "@/lib/shared/schemas/ids";
 
 let cache: DocumentContentCache;
 beforeEach(() => { cache = new DocumentContentCache(new IDBFactory()); });
 
-const doc = { id: "d1", storagePath: "documents/content/sha-abc", fileName: "avtal.pdf" };
+const doc = { id: asId<"DocumentId">("d1"), storagePath: "documents/content/sha-abc", fileName: "avtal.pdf" };
 
 function clientReturning(contentBase64: string, mimeType = "application/pdf") {
   return { document: { downloadContent: { query: vi.fn(async () => ({ contentBase64, mimeType })) } } };

--- a/test/unit/client/jobs/extract-text-dispatch.test.ts
+++ b/test/unit/client/jobs/extract-text-dispatch.test.ts
@@ -5,13 +5,14 @@
  */
 import { describe, it, expect, vi, afterEach } from "vitest-compat";
 import { setExtractTextDispatcher, dispatchExtractText } from "@/lib/client/jobs/extract-text-dispatch";
+import { asId } from "@/lib/shared/schemas/ids";
 
 afterEach(() => setExtractTextDispatcher(null));
 
 describe("dispatchExtractText", () => {
   it("kastar när ingen dispatcher registrerats", async () => {
     setExtractTextDispatcher(null);
-    await expect(dispatchExtractText({ documentId: "d1", text: "x" }))
+    await expect(dispatchExtractText({ documentId: asId<"DocumentId">("d1"), text: "x" }))
       .rejects.toThrow(/Ingen extract-text-dispatcher/);
   });
 
@@ -19,14 +20,14 @@ describe("dispatchExtractText", () => {
     setExtractTextDispatcher(vi.fn(async () => {}));
     const ac = new AbortController();
     ac.abort();
-    await expect(dispatchExtractText({ documentId: "d1", text: "x", signal: ac.signal }))
+    await expect(dispatchExtractText({ documentId: asId<"DocumentId">("d1"), text: "x", signal: ac.signal }))
       .rejects.toThrow("Aborted");
   });
 
   it("anropar registrerad dispatcher med args", async () => {
     const fn = vi.fn(async () => {});
     setExtractTextDispatcher(fn);
-    await dispatchExtractText({ documentId: "d1", text: "hej" });
+    await dispatchExtractText({ documentId: asId<"DocumentId">("d1"), text: "hej" });
     expect(fn).toHaveBeenCalledWith({ documentId: "d1", text: "hej" });
   });
 });

--- a/test/unit/components/analyze-dispatcher-registrar.test.tsx
+++ b/test/unit/components/analyze-dispatcher-registrar.test.tsx
@@ -8,6 +8,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest-compat";
 
 import { AnalyzeDispatcherRegistrar } from "@/components/documents/analyze-dispatcher-registrar";
 import { dispatchAnalyze, setAnalyzeDispatcher } from "@/lib/client/jobs/analyze-dispatch";
+import { asId } from "@/lib/shared/schemas/ids";
 
 const mutateAsync = vi.fn(async () => {});
 const treeInvalidate = vi.fn(async () => {});
@@ -24,7 +25,7 @@ afterEach(() => setAnalyzeDispatcher(null));
 describe("AnalyzeDispatcherRegistrar", () => {
   it("registrerar dispatcher → updateMetadata.mutateAsync + tree.invalidate", async () => {
     const { unmount } = render(<AnalyzeDispatcherRegistrar />);
-    await dispatchAnalyze({ documentId: "d1", kind: "INVOICE", analyzedAt: "2026-01-01T00:00:00Z", analysisStatus: "DONE" });
+    await dispatchAnalyze({ documentId: asId<"DocumentId">("d1"), kind: "INVOICE", analyzedAt: "2026-01-01T00:00:00Z", analysisStatus: "DONE" });
     expect(mutateAsync).toHaveBeenCalledWith({
       documentId: "d1",
       documentType: "INVOICE",
@@ -34,7 +35,7 @@ describe("AnalyzeDispatcherRegistrar", () => {
     expect(treeInvalidate).toHaveBeenCalled();
 
     unmount();
-    await expect(dispatchAnalyze({ documentId: "d2", kind: "OTHER" }))
+    await expect(dispatchAnalyze({ documentId: asId<"DocumentId">("d2"), kind: "OTHER" }))
       .rejects.toThrow(/Ingen analyze-dispatcher/);
   });
 });

--- a/test/unit/components/extract-text-dispatcher-registrar.test.tsx
+++ b/test/unit/components/extract-text-dispatcher-registrar.test.tsx
@@ -7,6 +7,7 @@ import { render } from "@testing-library/react";
 import { describe, it, expect, afterEach } from "vitest-compat";
 import { ExtractTextDispatcherRegistrar } from "@/components/documents/extract-text-dispatcher-registrar";
 import { dispatchExtractText, setExtractTextDispatcher } from "@/lib/client/jobs/extract-text-dispatch";
+import { asId } from "@/lib/shared/schemas/ids";
 
 afterEach(() => setExtractTextDispatcher(null));
 
@@ -17,12 +18,12 @@ describe("ExtractTextDispatcherRegistrar", () => {
     window.addEventListener("ava:document-text-extracted", listener);
 
     const { unmount } = render(<ExtractTextDispatcherRegistrar />);
-    await dispatchExtractText({ documentId: "d1", text: "hej världen" });
+    await dispatchExtractText({ documentId: asId<"DocumentId">("d1"), text: "hej världen" });
     expect(events).toHaveLength(1);
     expect(events[0]!.detail).toEqual({ documentId: "d1", text: "hej världen" });
 
     unmount();
-    await expect(dispatchExtractText({ documentId: "d2", text: "x" }))
+    await expect(dispatchExtractText({ documentId: asId<"DocumentId">("d2"), text: "x" }))
       .rejects.toThrow(/Ingen extract-text-dispatcher/);
 
     window.removeEventListener("ava:document-text-extracted", listener);

--- a/test/unit/lib/firma/prefetch-matter-documents.test.ts
+++ b/test/unit/lib/firma/prefetch-matter-documents.test.ts
@@ -4,11 +4,12 @@
 
 import { describe, it, expect, vi } from "vitest-compat";
 import { prefetchMatterDocuments } from "@/lib/client/firma/prefetch-matter-documents";
+import { asId } from "@/lib/shared/schemas/ids";
 
 const docs = [
-  { id: "1", storagePath: "documents/content/a", fileName: "a.pdf" },
-  { id: "2", storagePath: null, fileName: "b.docx" },
-  { id: "3" },
+  { id: asId<"DocumentId">("1"), storagePath: "documents/content/a", fileName: "a.pdf" },
+  { id: asId<"DocumentId">("2"), storagePath: null, fileName: "b.docx" },
+  { id: asId<"DocumentId">("3") },
 ];
 
 describe("prefetchMatterDocuments", () => {
@@ -44,7 +45,7 @@ describe("prefetchMatterDocuments", () => {
   it("respekterar concurrency-taket (aldrig fler samtidiga än gränsen)", async () => {
     let active = 0;
     let peak = 0;
-    const many = Array.from({ length: 10 }, (_v, i) => ({ id: String(i) }));
+    const many = Array.from({ length: 10 }, (_v, i) => ({ id: asId<"DocumentId">(String(i)) }));
     await prefetchMatterDocuments(many, async () => {
       active++;
       peak = Math.max(peak, active);

--- a/test/unit/lib/fsa/upload-document.integration.test.tsx
+++ b/test/unit/lib/fsa/upload-document.integration.test.tsx
@@ -12,6 +12,7 @@
 
 import { describe, it, expect } from "vitest-compat";
 import { uploadDocumentToFsa } from "@/lib/client/fsa/upload-document";
+import { asId } from "@/lib/shared/schemas/ids";
 import { makeFakeFsa } from "../../../helpers/fake-fsa";
 
 describe("Document upload — integration mot fake FSA", () => {
@@ -22,7 +23,7 @@ describe("Document upload — integration mot fake FSA", () => {
 
     const result = await uploadDocumentToFsa({
       handle: fsa.root,
-      matterId: "m1",
+      matterId: asId<"MatterId">("m1"),
       file,
       generateId: () => "d-1",
     });

--- a/test/unit/lib/fsa/upload-document.test.tsx
+++ b/test/unit/lib/fsa/upload-document.test.tsx
@@ -6,6 +6,7 @@
 import { describe, it, expect, vi } from "vitest-compat";
 import { FsaIsoGitAdapter } from "@/lib/client/fsa/fs-adapter";
 import { uploadDocumentToFsa } from "@/lib/client/fsa/upload-document";
+import { asId } from "@/lib/shared/schemas/ids";
 
 
 interface MockFs {
@@ -24,7 +25,7 @@ describe("uploadDocumentToFsa", () => {
     const handle = {} as FileSystemDirectoryHandle;
     const file = new File(["%PDF-1.4 fake bytes"], "test.pdf", { type: "application/pdf" });
     const result = await uploadDocumentToFsa({
-      handle, matterId: "m1", file,
+      handle, matterId: asId<"MatterId">("m1"), file,
       generateId: () => "d-test-1",
     });
     expect(result).toEqual({
@@ -44,7 +45,7 @@ describe("uploadDocumentToFsa", () => {
     const handle = {} as FileSystemDirectoryHandle;
     const file = new File(["data"], "noext", { type: "application/octet-stream" });
     const result = await uploadDocumentToFsa({
-      handle, matterId: "m1", file,
+      handle, matterId: asId<"MatterId">("m1"), file,
       generateId: () => "d2",
     });
     expect(result.storagePath).toBe("documents/content/d2.bin");
@@ -54,7 +55,7 @@ describe("uploadDocumentToFsa", () => {
     const handle = {} as FileSystemDirectoryHandle;
     const file = new File(["data"], "Document.PDF", { type: "application/pdf" });
     const result = await uploadDocumentToFsa({
-      handle, matterId: "m1", file,
+      handle, matterId: asId<"MatterId">("m1"), file,
       generateId: () => "d3",
     });
     expect(result.storagePath).toBe("documents/content/d3.pdf");
@@ -64,7 +65,7 @@ describe("uploadDocumentToFsa", () => {
     const handle = {} as FileSystemDirectoryHandle;
     const file = new File(["data"], "x.dat", { type: "" });
     const result = await uploadDocumentToFsa({
-      handle, matterId: "m1", file,
+      handle, matterId: asId<"MatterId">("m1"), file,
       generateId: () => "d4",
     });
     expect(result.mimeType).toBe("application/octet-stream");

--- a/test/unit/server/integrations/ledger/reconcile-payments.test.ts
+++ b/test/unit/server/integrations/ledger/reconcile-payments.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest-compat";
 import type { LedgerPayment } from "@/lib/server/integrations/ledger/port";
 import { reconcileLedgerPayments, type ReconcileInvoice } from "@/lib/server/integrations/ledger/reconcile-payments";
+import { asId } from "@/lib/shared/schemas/ids";
 
 const pay = (over: Partial<LedgerPayment> = {}): LedgerPayment => ({
   externalId: "tx-1",
@@ -10,7 +11,7 @@ const pay = (over: Partial<LedgerPayment> = {}): LedgerPayment => ({
 });
 
 const inv = (over: Partial<ReconcileInvoice> = {}): ReconcileInvoice => ({
-  id: "inv-1",
+  id: asId<"InvoiceId">("inv-1"),
   ocrReference: "2026004206",
   paymentReferences: [],
   ...over,

--- a/test/unit/server/jobs/queue-backed-document-analyzer.test.ts
+++ b/test/unit/server/jobs/queue-backed-document-analyzer.test.ts
@@ -6,12 +6,13 @@
 import type { PgBoss } from "pg-boss";
 import { describe, expect, it, vi } from "vitest-compat";
 import { QueueBackedDocumentAnalyzer } from "@/lib/server/jobs/queue-backed-document-analyzer";
+import { asId } from "@/lib/shared/schemas/ids";
 
 describe("QueueBackedDocumentAnalyzer", () => {
   it("enqueue:ar classify-document med documentId + organizationId + singletonKey (idempotens)", async () => {
     const send = vi.fn(async () => "job-1");
     const analyzer = new QueueBackedDocumentAnalyzer(() => ({ send } as unknown as PgBoss), "org-1");
-    await analyzer.analyze("doc-9");
+    await analyzer.analyze(asId<"DocumentId">("doc-9"));
     // singletonKey = documentId → som mest ett väntande classify-jobb per dokument (#504).
     expect(send).toHaveBeenCalledWith(
       "classify-document",
@@ -22,6 +23,6 @@ describe("QueueBackedDocumentAnalyzer", () => {
 
   it("kastar tydligt när boss saknas (kön ej redo)", async () => {
     const analyzer = new QueueBackedDocumentAnalyzer(() => null, "org-1");
-    await expect(analyzer.analyze("doc-9")).rejects.toThrow(/jobb-kön är inte redo/);
+    await expect(analyzer.analyze(asId<"DocumentId">("doc-9"))).rejects.toThrow(/jobb-kön är inte redo/);
   });
 });

--- a/test/unit/server/repositories/invoice-dispatch-repository.test.ts
+++ b/test/unit/server/repositories/invoice-dispatch-repository.test.ts
@@ -10,6 +10,7 @@ import { invoiceDispatches, invoices, matters } from "@/lib/server/db/schema";
 import { DrizzleInvoiceDispatchRepository } from "@/lib/server/repositories/drizzle-invoice-dispatch-repository";
 import { InMemoryInvoiceDispatchRepository } from "@/lib/server/repositories/in-memory-invoice-dispatch-repository";
 import { prebakeJoins } from "@/lib/shared/demo-source";
+import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
@@ -27,11 +28,11 @@ describe("InvoiceDispatchRepository — in-memory", () => {
       ],
     } as DemoSource);
     const repo = new InMemoryInvoiceDispatchRepository(new LocalStore(source, async () => {}));
-    expect(await repo.listByInvoice(invId)).toHaveLength(2);
-    const queued = await repo.listQueuedForOrg("org-1");
+    expect(await repo.listByInvoice(asId<"InvoiceId">(invId))).toHaveLength(2);
+    const queued = await repo.listQueuedForOrg(asId<"OrganizationId">("org-1"));
     expect(queued).toHaveLength(1);
     expect(queued[0]!.invoice?.invoiceNumber).toBe("F-1");
-    expect(await repo.listQueuedForOrg("org-2")).toHaveLength(0);
+    expect(await repo.listQueuedForOrg(asId<"OrganizationId">("org-2"))).toHaveLength(0);
   });
 });
 
@@ -53,10 +54,10 @@ describe("InvoiceDispatchRepository — Drizzle (pglite)", () => {
     await db.insert(invoiceDispatches).values(v({ id: d1, invoiceId: invId, channel: "email", recipient: "a@x", status: "queued", queuedAt: new Date(), recordedById: uuidv7() }));
     await db.insert(invoiceDispatches).values(v({ id: uuidv7(), invoiceId: invId, channel: "email", recipient: "b@x", status: "sent", queuedAt: new Date(), recordedById: uuidv7() }));
     const repo = new DrizzleInvoiceDispatchRepository(handle.db);
-    expect(await repo.listByInvoice(invId)).toHaveLength(2);
-    const queued = await repo.listQueuedForOrg(org);
+    expect(await repo.listByInvoice(asId<"InvoiceId">(invId))).toHaveLength(2);
+    const queued = await repo.listQueuedForOrg(asId<"OrganizationId">(org));
     expect(queued).toHaveLength(1);
     expect(queued[0]!.invoice?.invoiceNumber).toBe("F-1");
-    expect(await repo.listQueuedForOrg(uuidv7())).toHaveLength(0);
+    expect(await repo.listQueuedForOrg(asId<"OrganizationId">(uuidv7()))).toHaveLength(0);
   });
 });


### PR DESCRIPTION
ID-brandning (B7, #750) — sista svansen (~30→9 domän-id-`string`).

- **invoice-dispatch-repo-gruppen** (interface+drizzle+in-memory — missad tidigare): invoiceId/organizationId/dispatch-id → branded.
- **router-helpers**: conflict/mail/invoiceDispatch/expectedReceivable.
- **reconcile-payments** (InvoiceId), **dokument-analyzer-portar** (DocumentId), **klient-dispatchers** (analyze/extract-text), **fsa-upload/eager-cache/load-blob/generate-faktura/save-incoming-mail**.

**Kvar (medvetet, ej domän-id):** search-subsystemet (`ISearchIndex`/`SearchHit`), rules-DSL authored-config-placeholders, ar-summary/demo-source loose row-keys. Inga typer försvagade; rent i alla tre tsc-projekt, 3177 tester gröna.

→ **Strong-typing-svepet (#750) komplett:** enum-fasen + hela ID-brandnings-fasen. Återstående `string` = medvetna icke-id:n (paths/keys/hashar/refs/DSL/sök).

Refs #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)