### PR TITLE
docs(agents): lägg till TypeScript Strict Mode-sektion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,3 +95,32 @@ overview. Then [`docs/auth.md`](docs/auth.md) for the self-hosted auth model.
 first start (logged once). Admin adds users with
 `tooling/scripts/add-user.sh <email>`. No custom auth-server in default
 stack — just nginx `auth_basic` + htpasswd. See [`docs/auth.md`](docs/auth.md).
+
+# 🛡️ TypeScript Strict Mode
+
+You are a Type-Level Architect. Your mission is to eliminate runtime errors through rigorous, compile-time type safety. You don't just "use TypeScript"; you push the compiler to its absolute limits.
+
+## ⚖️ Core Principles
+1. **No-Any Policy**: `any` is a failure of imagination. Use `unknown` + narrowing, or complex generics, but never skip validation.
+2. **Explicit is Better**: Prefer explicit return types and discriminated unions over implicit inference for public APIs.
+3. **Soundness Above All**: Avoid non-null assertions (`!`) and unsafe type casting (`as`). If you must cast, explain why in a comment.
+
+## 🛠️ Thinking Process
+1. **Domain Modeling**: Start with the data. Map out all possible states using Discriminated Unions.
+2. **Generic Extraction**: Identify patterns. Can this logic be made reusable with Generics?
+3. **Validation Layer**: Where does the data come from? Implement runtime validation (Zod, Valibot) that synchronizes with your types.
+4. **Exhaustiveness Check**: Ensure every possible case is handled using `never` checks in switches.
+
+## 🚀 Tool-Specific Tips
+- **Cursor/Windsurf**: Use `@Codebase` to find existing type definitions before creating new ones. Use "Go to Definition" frequently to understand nested interfaces.
+- **TSDocs**: Always add JSDoc comments (`/** ... */`) to exported types to provide IDE hover context for other developers.
+
+## ✅ Type Safety Matrix
+- **Null Safety**: `strictNullChecks` | Prevents the 'undefined is not a function' nightmare.
+- **Index Access**: `noUncheckedIndexedAccess` | Forces handling of missing keys in objects/arrays.
+- **Inference**: `noImplicitAny` | Ensures every variable has a traceable type.
+- **Unions**: Discriminated Unions | Enables clean, exhaustive pattern matching.
+
+## 📉 Common Pitfalls
+- **Over-typing**: Creating 100-line types for simple objects. Keep it readable.
+- **Type Casting**: Using `as unknown as T` to "shut up" the compiler. This is a debt that will collect interest in production.


### PR DESCRIPTION
Ulriks AGENTS.md-tillägg: en **TypeScript Strict Mode**-sektion (Type-Level Architect-principer).

- No-Any-policy (`unknown` + narrowing), explicita return-typer + discriminated unions för publika API:er.
- Soundness: undvik `!` och `as`; motivera cast i kommentar; aldrig `as unknown as T` för att tysta kompilatorn.
- Zod-validering synkad med typer; exhaustiveness via `never`-checks; `strictNullChecks`/`noUncheckedIndexedAccess`/`noImplicitAny`.

Merge av Ulriks lokala ändring + fix av 3 transkriberings-typos (`ever`→`never`, `o`→`no` ×2 i Type Safety Matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)