### PR TITLE
refactor(types): eliminera non-null assertions (AGENTS.md strict-mode)

### DIFF
--- a/src/app/invoices/[id]/_client.tsx
+++ b/src/app/invoices/[id]/_client.tsx
@@ -110,7 +110,7 @@ export default function InvoiceDetailClient({ id: paramId }: { id: string }) {
     <div className="space-y-6">
       <InvoiceHeader inv={inv} />
       <InvoiceSummaryCard inv={inv} ledger={ledger} s={s} />
-      <InvoiceSections inv={inv} ledger={ledger} onCancelPlan={() => s.cancelPlan.mutate({ planId: inv.paymentPlan!.id })} />
+      <InvoiceSections inv={inv} ledger={ledger} onCancelPlan={() => { if (inv.paymentPlan) s.cancelPlan.mutate({ planId: inv.paymentPlan.id }); }} />
       <InvoiceModals inv={inv} ledger={ledger} s={s} />
     </div>
   );

--- a/src/lib/server/data-store/in-memory/query-engine.ts
+++ b/src/lib/server/data-store/in-memory/query-engine.ts
@@ -56,7 +56,8 @@ export class InMemoryQueryEngine<T extends Record<string, unknown>> {
    * Muterar inte inputen.
    */
   query(rows: readonly T[], opts: QueryOptions = {}): T[] {
-    let out = opts.where ? rows.filter((r) => this.matches(r, opts.where!)) : [...rows];
+    const where = opts.where;
+    let out = where ? rows.filter((r) => this.matches(r, where)) : [...rows];
     if (opts.orderBy) out = this.sort(out, opts.orderBy);
     if (opts.skip) out = out.slice(opts.skip);
     if (opts.take !== undefined) out = out.slice(0, opts.take);
@@ -64,8 +65,9 @@ export class InMemoryQueryEngine<T extends Record<string, unknown>> {
   }
 
   count(rows: readonly T[], opts: QueryOptions = {}): number {
-    if (!opts.where) return rows.length;
-    return rows.filter((r) => this.matches(r, opts.where!)).length;
+    const where = opts.where;
+    if (!where) return rows.length;
+    return rows.filter((r) => this.matches(r, where)).length;
   }
 
   findFirst(rows: readonly T[], opts: QueryOptions = {}): T | null {
@@ -193,7 +195,7 @@ export class InMemoryQueryEngine<T extends Record<string, unknown>> {
   // ─── OrderBy ──────────────────────────────────────────────────────
 
   private sort(rows: T[], orderBy: QueryOptions["orderBy"]): T[] {
-    const clauses = Array.isArray(orderBy) ? orderBy : [orderBy!];
+    const clauses = Array.isArray(orderBy) ? orderBy : orderBy ? [orderBy] : [];
     return [...rows].sort((a, b) => {
       for (const clause of clauses) {
         for (const [field, dir] of Object.entries(clause)) {

--- a/src/lib/server/data-store/in-memory/read-only-delegate.ts
+++ b/src/lib/server/data-store/in-memory/read-only-delegate.ts
@@ -193,8 +193,9 @@ export class ReadOnlyDelegate<T extends Record<string, unknown>> implements Dele
     let children = rc.collection().filter((c) => this.engine.matches(c, finalWhere));
 
     const subTree = subTreeFor(spec, mode);
-    if (subTree && rc.relations) {
-      children = children.map((c) => this.hydrateWith(c, rc.relations!, subTree, mode));
+    const relations = rc.relations;
+    if (subTree && relations) {
+      children = children.map((c) => this.hydrateWith(c, relations, subTree, mode));
     }
     children = applyTake(children, spec, mode);
     return rc.kind === "one" ? (children[0] ?? null) : children;


### PR DESCRIPTION
Första åtgärden från analysen mot nya AGENTS.md **TypeScript Strict Mode**-sektionen.

## Analys-resultat (hela kodbasen mot nya mandatet)
- ✅ Compiler-flaggor: `strict` (→ strictNullChecks + noImplicitAny), `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes` — **alla redan på.**
- ✅ **0 `any`** i src (No-Any-policy uppfylld — #562 + #750).
- ✅ **0 äkta `as unknown as`** i src (de 6 träffarna var doc-kommentarer som förklarar helpers som finns för att UNDVIKA casten).
- ⚠️ **5 genuina non-null assertions (`!`)** → denna PR.

## Fix
De 5 `!` var logiskt guardade men TS tappar narrowing över closures/ternarier → sound hoist-to-const / guardad callback:
- `query-engine.ts`: `opts.where!` (query+count) → `const where = opts.where`; `orderBy!` → ternary-guard.
- `read-only-delegate.ts`: `rc.relations!` → `const relations` efter if-guarden.
- `invoices/[id]/_client.tsx`: `inv.paymentPlan!.id` → guardad callback.

**0 non-null assertions kvar i src.** Ren tsc (root+test), lint grön, 184 data-store/invoice-tester gröna.

Closes #774
Refs AGENTS.md TypeScript Strict Mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)