### PR TITLE
test(e2e): ui-driven keep-both-konflikt mot full self-hosted-stack (#742)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,3 +277,36 @@ jobs:
         with:
           name: playwright-demo-report
           path: reports/playwright-demo/
+
+  # ───────────────── Keep-both-konflikt-E2E (UI-driven) ─────────────────
+  # Verklighetstroget 2-användar-konflikt-test (#742) mot den FULLA self-hosted-
+  # stacken (server-first tRPC + oauth2-proxy + Keycloak). conflict-e2e.sh
+  # provocerar en RIKTIG dokument-konflikt över helperns nätväg (Keycloak-Bearer
+  # → oauth2-proxy → server-first), och Playwright loggar in via Keycloak-
+  # formuläret + bekräftar i UIt att ärendet har 2 filer (original + keep-both-
+  # syskon). Regressionsskydd för ADR 0033 keep-both end-to-end mot deployad
+  # artefakt. (Kör på PR; INTE required check — ingen branch-protection-ändring.)
+  conflict-e2e:
+    name: Keep-both konflikt-E2E
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    timeout-minutes: 25
+    env:
+      CI: "true"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - run: bun run e2e:install
+      - run: bun run e2e:conflict
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-conflict-report
+          path: reports/playwright-conflict/

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ office-addin/dist/
 
 # Lokal self-hosted dokument-content (bind-mount, #649)
 tooling/docker/.selfhosted-content/
+tooling/.conflict-seed.json

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "e2e:install": "playwright install --with-deps chromium",
     "e2e:oidc": "bash tooling/scripts/e2e-oidc.sh",
     "e2e:doc-pipeline": "bash tooling/scripts/document-pipeline-e2e.sh",
+    "e2e:conflict": "bash tooling/scripts/conflict-e2e.sh",
     "selfhosted:local": "bash tooling/scripts/selfhosted-local.sh",
     "diagnose-ui": "bun tooling/scripts/diagnose-ui.ts",
     "smoke:tier3": "bash tooling/scripts/test-tier3-smoke.sh",

--- a/test/e2e/conflict/keep-both.spec.ts
+++ b/test/e2e/conflict/keep-both.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * Keep-both-konflikt-e2e (#742) — UI-driven verifiering.
+ *
+ * Förutsättning (körs av tooling/scripts/conflict-e2e.sh): den fulla
+ * self-hosted-stacken (server-first tRPC + oauth2-proxy + Keycloak) är uppe och
+ * `conflict-seed.ts` har provocerat fram en RIKTIG dokument-konflikt mellan två
+ * användare (lawyer vann v2, admin fick 409 → keep-both-syskon). Seeden skrev
+ * ärende-/filnamn till tooling/.conflict-seed.json.
+ *
+ * Spec:en bevisar att en RIKTIG användare ser resultatet i webb-appen: logga in
+ * via Keycloaks formulär (lawyer), navigera till ärendet, och bekräfta att
+ * dokumentlistan visar BÅDA filerna — originalet + keep-both-syskonet
+ * ("… (din ändring …)"). Det uppfyller #742:s krav att testet ska UTGÅ FRÅN UIt
+ * (konflikten provoceras via helperns nätväg; verifieringen sker i UIt).
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { test, expect, type Page } from "@playwright/test";
+
+interface SeedInfo {
+  matterId: string;
+  matterNumber: string;
+  matterTitle: string;
+  originalFileName: string;
+  siblingFileName: string;
+  siblingId: string;
+}
+
+const seed: SeedInfo = JSON.parse(
+  readFileSync(join(__dirname, "..", "..", "..", "tooling", ".conflict-seed.json"), "utf8"),
+) as SeedInfo;
+
+const AUTHORIZE_RE = /realms\/ava\/protocol\/openid-connect\/auth/;
+const onKeycloak = (u: URL): boolean => AUTHORIZE_RE.test(u.toString());
+
+/** Driv Keycloaks login-formulär i browsern; vänta tillbaka till appen. */
+async function login(page: Page, username: string, password: string): Promise<void> {
+  await page.goto("/ava/");
+  await page.waitForURL(AUTHORIZE_RE);
+  await page.fill("#username", username);
+  await page.fill("#password", password);
+  await page.click("#kc-login");
+  await page.waitForURL((u) => !onKeycloak(u));
+}
+
+test.describe("keep-both-konflikt (#742)", () => {
+  test("ärendet visar 2 filer — originalet + keep-both-syskonet", async ({ page }) => {
+    await login(page, "lawyer", "lawyer");
+
+    // Hård-ladda den prerenderade ärendelistan, soft-navigera sen in i ärendet
+    // via TITEL-länken (ärendenr är bara en <span>) → klient-routing, ingen
+    // statisk 404 på den dynamiska detalj-routen.
+    await page.goto("/ava/matters/");
+    const matterLink = page.getByRole("link", { name: seed.matterTitle });
+    await expect(matterLink).toBeVisible({ timeout: 30_000 });
+    await matterLink.click();
+
+    // På ärende-sidan: dokumentlistan ska visa BÅDA filerna.
+    // - Originalet: substringen "minnesanteckning.txt" finns BARA i originalets
+    //   namn (syskonet bryter efter "minnesanteckning (din ändring …").
+    // - Syskonet: bär "(din ändring <label>)"-suffixet.
+    await expect(page.getByText(seed.originalFileName, { exact: false }).first())
+      .toBeVisible({ timeout: 30_000 });
+    await expect(page.getByText(/din ändring/).first())
+      .toBeVisible({ timeout: 30_000 });
+    await expect(page.getByText(seed.siblingFileName, { exact: false }).first())
+      .toBeVisible({ timeout: 30_000 });
+  });
+});

--- a/tooling/config/playwright.conflict.config.ts
+++ b/tooling/config/playwright.conflict.config.ts
@@ -1,0 +1,32 @@
+import path from "node:path";
+import { defineConfig, devices } from "@playwright/test";
+
+const projectRoot = path.resolve(__dirname, "..", "..");
+
+/**
+ * Keep-both-konflikt-e2e (#742) — UI-driven verifiering mot den FULLA
+ * self-hosted-stacken (server-first tRPC + OIDC), inte den statiska demon.
+ * Stacken + konflikt-seeden körs av `tooling/scripts/conflict-e2e.sh`; spec:en
+ * loggar in via Keycloaks riktiga formulär och bekräftar i webb-UIt att ärendet
+ * har 2 filer (originalet + keep-both-syskonet). Web på AVA_WEB_PORT (8080).
+ */
+export default defineConfig({
+  testDir: path.join(projectRoot, "test/e2e/conflict"),
+  timeout: 90_000,
+  expect: { timeout: 20_000 },
+  fullyParallel: false,
+  workers: 1,
+  retries: 1,
+  reporter: [
+    ["list"],
+    ["html", { open: "never", outputFolder: path.join(projectRoot, "reports/playwright-conflict") }],
+  ],
+  outputDir: path.join(projectRoot, "reports/playwright-conflict-results"),
+  use: {
+    baseURL: process.env.AVA_WEB_URL ?? "http://localhost:8080",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+});

--- a/tooling/docker/server-first/entrypoint.sh
+++ b/tooling/docker/server-first/entrypoint.sh
@@ -15,5 +15,14 @@ case "$(uname -m)" in
   *) echo "[server-first] okänd arkitektur: $(uname -m)" >&2; exit 1 ;;
 esac
 
+# git ≥2.35 vägrar operera i ett repo som ägs av en ANNAN uid än processen
+# ("detected dubious ownership"). När AVA_CONTENT_DIR är en host-bind-mount
+# (self-hosted-operatörer + selfhosted-local-stacken) ägs den av host-uid:t,
+# inte containerns → GitContentStore:s `git add`/commit i uploadContent kraschar.
+# Markera content-dir:en som betrodd (containern är enkel-tenant; repot där är
+# det enda). En named volume träffar inte detta, varför server-first-e2e:t
+# (named volume) missade buggen men selfhosted-local (bind-mount) träffar den.
+git config --global --add safe.directory "${AVA_CONTENT_DIR:-/data/content}" || true
+
 echo "[server-first] startar: $BIN $*"
 exec "$BIN" "$@"

--- a/tooling/scripts/conflict-e2e.sh
+++ b/tooling/scripts/conflict-e2e.sh
@@ -37,7 +37,11 @@ MATTER_ID="019ef800-0000-7000-8000-000000000742"
 
 cleanup() {
   "${COMPOSE[@]}" down -v --remove-orphans >/dev/null 2>&1 || true
-  rm -rf "$AVA_CONTENT_HOST_DIR"
+  # Content-dir:en fylls av server-first-containern (root) → host-rm kan nekas.
+  # Försök som vanlig användare, annars sudo (CI-runner), annars strunta i det.
+  rm -rf "$AVA_CONTENT_HOST_DIR" 2>/dev/null \
+    || sudo rm -rf "$AVA_CONTENT_HOST_DIR" 2>/dev/null \
+    || true
 }
 trap cleanup EXIT
 

--- a/tooling/scripts/conflict-e2e.sh
+++ b/tooling/scripts/conflict-e2e.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Keep-both-konflikt-E2E (#742) — UI-driven, mot den FULLA self-hosted-stacken
+# (server-first tRPC + oauth2-proxy + Keycloak på en origin, :8080).
+#
+# Flöde:
+#   1. bygg server-first-binär + statisk app (out/)
+#   2. starta stacken (postgres + server-first + keycloak + oauth2-proxy + web)
+#   3. migrera + seeda org + 2 allowlistade användare (lawyer + admin)
+#   4. conflict-seed.ts: provocera en RIKTIG dokument-konflikt över helperns
+#      nätväg (Keycloak-Bearer → oauth2-proxy → server-first) → keep-both-syskon
+#   5. Playwright: logga in via Keycloak-formuläret, navigera till ärendet,
+#      bekräfta i UIt att 2 filer finns (original + "(din ändring …)")
+#
+# Kräver: docker, bun, playwright chromium (`bun run e2e:install`). Kör ensamt
+# (samma 8080/8089-portar som OIDC-e2e:t) — egen compose-projekt-namn.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+export PATH="$HOME/.bun/bin:$PATH"
+
+export AVA_WEB_PORT="${AVA_WEB_PORT:-8080}"
+export KC_PORT="${KC_PORT:-8089}"
+export AVA_WEB_URL="http://localhost:${AVA_WEB_PORT}"
+export OIDC_KC_HOSTNAME="http://localhost:${KC_PORT}"
+export OIDC_ISSUER_PUBLIC="http://localhost:${KC_PORT}/realms/ava"
+export OIDC_REDIRECT_URL="http://localhost:${AVA_WEB_PORT}/oauth2/callback"
+export AVA_ORGANIZATION_ID="${AVA_ORGANIZATION_ID:-00000000-0000-0000-0000-000000000001}"
+export AVA_CONTENT_HOST_DIR="${AVA_CONTENT_HOST_DIR:-$ROOT/tooling/docker/.conflict-e2e-content}"
+DB_URL="postgres://ava:ava@localhost:5433/ava_test"
+PROJECT="${CONFLICT_E2E_PROJECT:-ava-conflict-e2e}"
+COMPOSE=(docker compose -p "$PROJECT" -f tooling/docker/docker-compose.selfhosted-local.yml)
+
+# Fast bordet rent: fixed-id-ärendet (#742-seeden) raderas så re-körning är idempotent.
+MATTER_ID="019ef800-0000-7000-8000-000000000742"
+
+cleanup() {
+  "${COMPOSE[@]}" down -v --remove-orphans >/dev/null 2>&1 || true
+  rm -rf "$AVA_CONTENT_HOST_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$AVA_CONTENT_HOST_DIR"
+
+echo "==> [1/6] Bygger server-first-binär + statisk app (out/)…"
+bun run server-first:build >/dev/null
+bun run build:demo >/dev/null 2>&1
+
+echo "==> [2/6] Startar self-hosted-stacken (postgres + server-first + keycloak + oauth2-proxy + web)…"
+"${COMPOSE[@]}" up -d --build --wait --wait-timeout 240 postgres server-first keycloak oauth2-proxy web
+
+echo "==> [3/6] Migrerar + seedar org + allowlistade användare (lawyer + admin)…"
+AVA_DATABASE_URL="$DB_URL" bun run db:migrate
+AVA_DATABASE_URL="$DB_URL" AVA_ORGANIZATION_ID="$AVA_ORGANIZATION_ID" bun tooling/scripts/seed-selfhosted-local.ts
+
+echo "==> [4/6] Väntar in Keycloak + web-origin…"
+for _ in $(seq 1 60); do
+  if curl -sf "http://localhost:${KC_PORT}/realms/ava/.well-known/openid-configuration" >/dev/null 2>&1 \
+     && curl -sf "http://localhost:${AVA_WEB_PORT}/healthz" >/dev/null 2>&1; then break; fi
+  sleep 2
+done
+
+# Idempotent: rensa ev. tidigare konflikt-ärende (fixed id) innan seeden.
+docker exec "${PROJECT}-postgres-1" psql -U ava -d ava_test -q \
+  -c "DELETE FROM documents WHERE matter_id='${MATTER_ID}'; DELETE FROM matters WHERE id='${MATTER_ID}';" >/dev/null 2>&1 || true
+
+echo "==> [5/6] Provocerar dokument-konflikt (2 användare, helperns nätväg)…"
+AVA_WEB_URL="$AVA_WEB_URL" OIDC_KC_HOSTNAME="$OIDC_KC_HOSTNAME" bun tooling/scripts/conflict-seed.ts
+
+echo "==> [6/6] Kör Playwright (UI-driven verifiering)…"
+AVA_WEB_URL="$AVA_WEB_URL" bun run playwright test --config tooling/config/playwright.conflict.config.ts
+echo "✅ keep-both-konflikt-E2E klart."

--- a/tooling/scripts/conflict-seed.ts
+++ b/tooling/scripts/conflict-seed.ts
@@ -1,0 +1,168 @@
+#!/usr/bin/env bun
+/**
+ * Konflikt-seed för det UI-drivna keep-both-e2e:t (#742) — provocerar fram en
+ * RIKTIG dokument-konflikt mot den deployade self-hosted-stacken
+ * (docker-compose.selfhosted-local.yml), över EXAKT helperns nätväg:
+ * Keycloak-Bearer → oauth2-proxy → server-first tRPC (`/api/trpc`).
+ *
+ * Två allowlistade användare (lawyer + admin, samma org → båda ser ärendet)
+ * öppnar samma textdokument på version 1 (= "tappar internet" var för sig),
+ * gör var sin ändring, och kommer tillbaka online:
+ *   1. lawyer skapar ärende + textdokument (v1).
+ *   2. båda "laddar ner" (baseVersion = 1).
+ *   3. lawyer laddar upp sin ändring från v1 → vinner (server → v2).
+ *   4. admin laddar upp SIN ändring från v1 → 409 (servern gått förbi).
+ *   5. admin materialiserar keep-both → syskon-dokument (ADR 0033 §4).
+ * Slut: ärendet har 2 filer (originalet + "(din ändring …)") med bådas innehåll.
+ *
+ * Detta är de tRPC-anrop helper-kön gör (`uploadViaTrpc`/`saveConflictCopyViaTrpc`
+ * i helper-ui/src/engine), men auth:at som 2 separata användare. UI-verifieringen
+ * (att 2 filer syns i ärendet) görs av Playwright-spec:en mot samma stack.
+ *
+ * Skriver ärende-/dok-fakta till `tooling/.conflict-seed.json` så spec:en vet
+ * vart den ska navigera. Kör via `tooling/scripts/conflict-e2e.sh`.
+ */
+
+import { writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createTRPCClient, httpBatchLink, TRPCClientError, type TRPCClient } from "@trpc/client";
+import superjson from "superjson";
+import type { AppRouter } from "@/lib/server/routers/_app";
+import { asId } from "@/lib/shared/schemas/ids";
+
+const WEB_URL = process.env.AVA_WEB_URL ?? "http://localhost:8080";
+const KC_URL = process.env.OIDC_KC_HOSTNAME ?? "http://localhost:8089";
+const OUT_FILE = join(dirname(fileURLToPath(import.meta.url)), "..", ".conflict-seed.json");
+
+/** Klient-genererat textdokument-id + ärende-id (delas med Playwright-spec:en). */
+const MATTER_ID = "019ef800-0000-7000-8000-000000000742";
+const DOC_ID = "019ef800-0000-7000-8000-0000000007d0";
+const MATTER_NUMBER = "2026-0742";
+const MATTER_TITLE = "Konflikt-e2e (#742)";
+const FILE_NAME = "minnesanteckning.txt";
+const ORIGINAL_TEXT = "Ursprunglig minnesanteckning (version 1).";
+const LAWYER_TEXT = "Lenas ändring: lägg till möte tisdag 10:00.";
+const ADMIN_TEXT = "Alvas ändring: kräv komplettering av motparten.";
+/** Server-side keep-both-namnet (conflictCopyName: "<bas> (din ändring <label>).<ext>"). */
+const CONFLICT_LABEL = "2026-03-14 09:15";
+
+function assert(cond: boolean, msg: string): void { if (!cond) throw new Error(`assert: ${msg}`); }
+function b64(text: string): string { return Buffer.from(text, "utf8").toString("base64"); }
+function sleep(ms: number): Promise<void> { return new Promise((r) => setTimeout(r, ms)); }
+
+/** Mynta en Keycloak access-token via password-grant (`ava`-klienten, direct-access). */
+async function mintToken(username: string, password: string): Promise<string> {
+  const res = await fetch(`${KC_URL}/realms/ava/protocol/openid-connect/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "password", client_id: "ava", client_secret: "ava-test-secret",
+      username, password, scope: "openid email profile",
+    }),
+  });
+  if (!res.ok) throw new Error(`token-mint ${username}: HTTP ${res.status} ${await res.text()}`);
+  const json = (await res.json()) as { access_token?: string };
+  if (!json.access_token) throw new Error(`token-mint ${username}: saknar access_token`);
+  return json.access_token;
+}
+
+/** tRPC-klient som bär en användares Bearer mot web-origin (oauth2-proxy → server-first). */
+function clientFor(token: string): TRPCClient<AppRouter> {
+  return createTRPCClient<AppRouter>({
+    links: [httpBatchLink({
+      url: `${WEB_URL}/api/trpc`,
+      transformer: superjson,
+      headers: () => ({ Authorization: `Bearer ${token}` }),
+    })],
+  });
+}
+
+async function waitForServer(client: TRPCClient<AppRouter>): Promise<void> {
+  for (let i = 0; i < 40; i++) {
+    try { await client.user.current.query(); return; } catch { await sleep(1000); }
+  }
+  throw new Error(`server-first svarade inte på ${WEB_URL} inom 40s`);
+}
+
+async function main(): Promise<void> {
+  const lawyerTok = await mintToken("lawyer", "lawyer");
+  const adminTok = await mintToken("admin", "admin");
+  const lawyer = clientFor(lawyerTok);
+  const admin = clientFor(adminTok);
+  await waitForServer(lawyer);
+
+  const lawyerMe = await lawyer.user.current.query();
+  console.log(`✓ auth: lawyer=${lawyerMe?.email} + admin (Bearer → oauth2-proxy → server-first)`);
+
+  // ── steg 1: lawyer skapar ärende + textdokument (v1) ─────────────
+  await lawyer.matter.create.mutate({
+    id: asId<"MatterId">(MATTER_ID), title: MATTER_TITLE, matterNumber: MATTER_NUMBER, status: "ACTIVE",
+  });
+  await lawyer.document.register.mutate({
+    id: asId<"DocumentId">(DOC_ID), matterId: asId<"MatterId">(MATTER_ID),
+    fileName: FILE_NAME, mimeType: "text/plain", sizeBytes: 0,
+    storagePath: "documents/content/placeholder", uploadedById: asId<"UserId">(lawyerMe!.id),
+  });
+  const v1 = await lawyer.document.uploadContent.mutate({
+    documentId: asId<"DocumentId">(DOC_ID), contentBase64: b64(ORIGINAL_TEXT),
+  });
+  console.log(`✓ steg 1: ärende + textdokument (version ${v1.version})`);
+
+  // ── steg 2: båda "öppnar" dokumentet → bär samma basversion (v1) ──
+  const lawyerOpen = await lawyer.document.downloadContent.query({ documentId: asId<"DocumentId">(DOC_ID) });
+  const adminOpen = await admin.document.downloadContent.query({ documentId: asId<"DocumentId">(DOC_ID) });
+  assert(lawyerOpen.version === adminOpen.version, "båda öppnar samma version");
+  const baseVersion = lawyerOpen.version;
+  console.log(`✓ steg 2: båda öppnade på basversion ${baseVersion} ("offline")`);
+
+  // ── steg 3: lawyer kommer online först → vinner ──────────────────
+  const win = await lawyer.document.uploadContent.mutate({
+    documentId: asId<"DocumentId">(DOC_ID), contentBase64: b64(LAWYER_TEXT), baseVersion,
+  });
+  assert(win.version > baseVersion, "lawyers skrivning bumpar versionen");
+  console.log(`✓ steg 3: lawyer vann (version ${baseVersion} → ${win.version})`);
+
+  // ── steg 4: admin kommer online → 409 (servern gått förbi) ───────
+  let got409 = false;
+  try {
+    await admin.document.uploadContent.mutate({
+      documentId: asId<"DocumentId">(DOC_ID), contentBase64: b64(ADMIN_TEXT), baseVersion,
+    });
+  } catch (err) {
+    got409 = err instanceof TRPCClientError && err.data?.code === "CONFLICT";
+    if (!got409) throw err;
+  }
+  assert(got409, "admins upload från stale basversion ger 409 CONFLICT");
+  console.log("✓ steg 4: admin fick KONFLIKT (409) — server skrevs ALDRIG över");
+
+  // ── steg 5: admin materialiserar keep-both → syskon-dokument ─────
+  const copy = await admin.document.saveConflictCopy.mutate({
+    documentId: asId<"DocumentId">(DOC_ID), contentBase64: b64(ADMIN_TEXT), label: CONFLICT_LABEL,
+  });
+  console.log(`✓ steg 5: keep-both → syskon-dokument "${copy.fileName}" (id ${copy.id})`);
+
+  // ── verifiera slut-tillståndet på server-sidan (UI-spec:en dubbelkollar) ──
+  const tree = await admin.document.tree.query({ matterId: asId<"MatterId">(MATTER_ID) });
+  const original = tree.documents.find((d) => d.id === DOC_ID);
+  const sibling = tree.documents.find((d) => d.id === copy.id);
+  assert(tree.documents.length === 2, `ärendet har 2 filer (fick ${tree.documents.length})`);
+  assert(original?.fileName === FILE_NAME, "originalet orört");
+  assert(sibling !== undefined && sibling.fileName.includes("din ändring"), "syskon-dokument med (din ändring …)-namn");
+  const origBytes = await admin.document.downloadContent.query({ documentId: asId<"DocumentId">(DOC_ID) });
+  const sibBytes = await admin.document.downloadContent.query({ documentId: asId<"DocumentId">(copy.id) });
+  assert(Buffer.from(origBytes.contentBase64, "base64").toString("utf8") === LAWYER_TEXT, "originalet bär lawyers innehåll");
+  assert(Buffer.from(sibBytes.contentBase64, "base64").toString("utf8") === ADMIN_TEXT, "syskonet bär admins innehåll");
+  console.log("✓ server-state: 2 filer, bådas innehåll bevarat");
+
+  writeFileSync(OUT_FILE, JSON.stringify({
+    matterId: MATTER_ID, matterNumber: MATTER_NUMBER, matterTitle: MATTER_TITLE,
+    originalFileName: FILE_NAME, siblingFileName: sibling!.fileName, siblingId: copy.id,
+  }, null, 2));
+  console.log(`✓ skrev ${OUT_FILE} (Playwright navigerar dit)`);
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`✗ konflikt-seed: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Det verklighetstrogna 2-användar-konflikt-e2e:t från #742 — mot den **deployade** self-hosted-stacken (server-first tRPC + oauth2-proxy + Keycloak på en origin), inte in-memory som #745.

## Hur
Konflikten provoceras över **exakt helperns nätväg**: Keycloak-Bearer → oauth2-proxy → server-first tRPC → Postgres + GitContentStore.

- **`conflict-seed.ts`** — 2 allowlistade användare (lawyer + admin, samma org) öppnar samma textdokument på v1; lawyer laddar upp sin ändring (vinner → v2); admin laddar upp från stale v1 → **409** → `saveConflictCopy` (keep-both-syskon). Asserterar server-state: 2 filer med bådas innehåll bevarat.
- **`keep-both.spec.ts`** — loggar in via Keycloaks **riktiga formulär** (lawyer), soft-navigerar in i ärendet via titel-länken, och bekräftar i **webb-UIt** att dokumentlistan visar **båda** filerna (`minnesanteckning.txt` + `minnesanteckning (din ändring …).txt`).
- **`conflict-e2e.sh`** — orkestrerar hela kedjan (bygg → stack-upp → migrera+seed → conflict-seed → Playwright → teardown), isolerat compose-projekt. `bun run e2e:conflict`.
- **`playwright.conflict.config.ts`** + CI-jobb "Keep-both konflikt-E2E" (PR, ej required check).

## Uppfyller #742
Testet **utgår från UIt** (verifiering via inloggad webb-app, riktig OIDC-inloggning). Konflikten triggas via helperns nätväg eftersom ingen in-browser-editor finns — byte-editen är helper-medierad i AVA, vilket detta speglar troget. Bygger på #743 (helper-bas-override) + #744 (FileTokenStore) + #745 (in-memory-kärnan).

## Verifiering
Seed + spec körda **gröna lokalt mot den körande stacken** (lawyer/admin auth → 409 → syskon → 2 filer i UIt). Hela harnessen valideras av CI-jobbet. Ren tsc (root+test) + lint.

Closes #742

🤖 Generated with [Claude Code](https://claude.com/claude-code)