### PR TITLE
feat(matter): klientens %-andel synlig + redigerbar, förifyller acconto (#778)

### DIFF
--- a/src/app/matters/[id]/_billing-dialog.tsx
+++ b/src/app/matters/[id]/_billing-dialog.tsx
@@ -30,6 +30,8 @@ export interface BillingMeta {
   clientName?: string;
   organizationName?: string;
   organizationOrgNumber?: string;
+  /** Klientens andel i bips (2500 = 25 %); förifyller acconto-förslaget (#778). */
+  clientShareBips?: number | null;
 }
 
 interface Props {
@@ -75,7 +77,8 @@ function AccontoForm({ matterId, meta, onDone }: { matterId: MatterId; meta: Bil
   const proposal = trpc.billingRun.proposal.useQuery({ matterId });
   const workValueOre = proposal.data?.workValueOre ?? 0;
   const priorOre = proposal.data?.priorAccontoSumOre ?? 0;
-  const [clientShareBips, setBips] = useState(2000); // 20% default
+  // Förifyll med ärendets %-sats (#778); 20 % som fallback om ej satt.
+  const [clientShareBips, setBips] = useState(meta.clientShareBips ?? 2000);
   const [amountKr, setAmountKr] = useState<number | null>(null); // null → följ förslaget
   const makeDoc = useFakturaDoc(matterId, meta);
   const suggestedOre = proposedAccontoOre(workValueOre, clientShareBips, priorOre);

--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -35,6 +35,7 @@ interface MatterContext {
   taxaHufStart?: string | Date | null | undefined;
   isTaxeArende?: boolean | null | undefined;
   paymentMethod?: PaymentMethod | null | undefined;
+  clientShareBips?: number | null | undefined;
   radgivningBetaldAt?: string | Date | null | undefined;
   contacts?: ReadonlyArray<{ role: string; contact?: { name?: string | null | undefined; email?: string | null | undefined } | null | undefined }> | undefined;
 }
@@ -146,7 +147,7 @@ function useBillingMeta(matter: MatterContext): BillingMeta {
   const org = orgProps(trpc.organization.getSettings.useQuery().data ?? undefined);
   return {
     matterNumber: matter.matterNumber, matterTitle: matter.title,
-    ...omitUndefined({ clientName: clientOf(matter) || undefined, organizationName: org.name, organizationOrgNumber: org.orgNumber }),
+    ...omitUndefined({ clientName: clientOf(matter) || undefined, organizationName: org.name, organizationOrgNumber: org.orgNumber, clientShareBips: matter.clientShareBips ?? undefined }),
   };
 }
 

--- a/src/app/matters/[id]/_client.tsx
+++ b/src/app/matters/[id]/_client.tsx
@@ -65,12 +65,7 @@ export default function MatterDetailClient({ id: paramId }: { id: string }) {
       />
 
       <div className="mb-6">
-        <PaymentMethodCard
-          matterId={id}
-          paymentMethod={m.paymentMethod}
-          paymentMethodNote={m.paymentMethodNote ?? null}
-          paymentMethodDecidedAt={m.paymentMethodDecidedAt ?? null}
-        />
+        <MatterPaymentMethod matterId={id} matter={m} />
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -93,6 +88,28 @@ export default function MatterDetailClient({ id: paramId }: { id: string }) {
         />
       )}
     </div>
+  );
+}
+
+/** Adapter: samlar nullish-coalescing för betalkortet så MatterDetailClient
+ *  håller sig under komplexitetsgränsen (#199). */
+function MatterPaymentMethod({ matterId, matter }: {
+  matterId: ReturnType<typeof asId<"MatterId">>;
+  matter: {
+    paymentMethod: PaymentMethod;
+    paymentMethodNote?: string | null | undefined;
+    paymentMethodDecidedAt?: Date | string | null | undefined;
+    clientShareBips?: number | null | undefined;
+  };
+}) {
+  return (
+    <PaymentMethodCard
+      matterId={matterId}
+      paymentMethod={matter.paymentMethod}
+      paymentMethodNote={matter.paymentMethodNote ?? null}
+      paymentMethodDecidedAt={matter.paymentMethodDecidedAt ?? null}
+      clientShareBips={matter.clientShareBips ?? null}
+    />
   );
 }
 

--- a/src/components/matter/payment-method-card.tsx
+++ b/src/components/matter/payment-method-card.tsx
@@ -32,6 +32,13 @@ interface Props {
   paymentMethod: PaymentMethod;
   paymentMethodNote: string | null;
   paymentMethodDecidedAt: Date | string | null;
+  /** Klientens andel i bips (2500 = 25 %); null = ej satt (#778). */
+  clientShareBips: number | null;
+}
+
+/** Betalningssätt där klienten betalar en %-sats → visa/redigera andelen. */
+function usesClientShare(method: PaymentMethod): boolean {
+  return method === "RATTSSKYDD" || method === "RATTSHJALP";
 }
 
 /** Läsvy: nuvarande betalningssätt + kreditrisk-badge + ev. notering/datum. */
@@ -39,16 +46,19 @@ function PaymentMethodView({
   paymentMethod,
   paymentMethodNote,
   paymentMethodDecidedAt,
+  clientShareBips,
   onEdit,
 }: {
   paymentMethod: PaymentMethod;
   paymentMethodNote: string | null;
   paymentMethodDecidedAt: Date | string | null;
+  clientShareBips: number | null;
   onEdit: () => void;
 }) {
   const risk = creditRiskFor(paymentMethod);
   const badgeClass = RISK_BADGE[risk];
   const label = PAYMENT_METHOD_LABELS[paymentMethod as keyof typeof PAYMENT_METHOD_LABELS] ?? paymentMethod;
+  const showShare = usesClientShare(paymentMethod);
   return (
     <div className="bg-white rounded-lg border border-gray-200 p-4">
       <div className="flex items-start justify-between gap-3">
@@ -61,6 +71,11 @@ function PaymentMethodView({
             <span className={`text-xs rounded-full px-2 py-0.5 border ${badgeClass}`}>
               Kreditrisk: {CREDIT_RISK_LABELS[risk]}
             </span>
+            {showShare && (
+              <span className="text-xs rounded-full px-2 py-0.5 border border-blue-200 bg-blue-50 text-blue-700">
+                Klientens andel: {clientShareBips != null ? `${clientShareBips / 100} %` : "ej satt"}
+              </span>
+            )}
           </div>
           {paymentMethodNote && <p className="text-sm text-gray-600 mt-1">{paymentMethodNote}</p>}
           {paymentMethodDecidedAt && (
@@ -77,6 +92,29 @@ function PaymentMethodView({
   );
 }
 
+/** %-andels-fältet (självrisk/avgift). Utbrutet så editorn håller sig ≤100 rader. */
+function ClientShareField({ id, value, onChange }: { id: string; value: string; onChange: (v: string) => void }) {
+  return (
+    <div>
+      <label htmlFor={id} className="block text-xs font-medium mb-1">
+        Klientens andel att betala (%)
+      </label>
+      <input
+        id={id}
+        type="text"
+        inputMode="decimal"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="t.ex. 25"
+        className="w-full border border-gray-300 rounded px-2 py-1.5 text-sm"
+      />
+      <p className="mt-1 text-[11px] text-gray-400">
+        Självrisk/avgift av upparbetat värde. Kan ändras under ärendets gång (t.ex. vid ändrad inkomst).
+      </p>
+    </div>
+  );
+}
+
 /** Redigeringsformulär: äger sitt formulär-state + spar-mutationen. */
 function PaymentMethodEditor({ matterId, initial, onDone }: { matterId: MatterId; initial: Props; onDone: () => void }) {
   const [method, setMethod] = useState(initial.paymentMethod);
@@ -84,9 +122,12 @@ function PaymentMethodEditor({ matterId, initial, onDone }: { matterId: MatterId
   const [decidedAt, setDecidedAt] = useState(
     initial.paymentMethodDecidedAt ? new Date(initial.paymentMethodDecidedAt).toISOString().slice(0, 10) : "",
   );
+  // %-sats redigeras i procent (bips/100); tomt fält → null. Tillåt komma-decimal.
+  const [sharePct, setSharePct] = useState(initial.clientShareBips != null ? String(initial.clientShareBips / 100) : "");
   const methodId = useId();
   const decidedAtId = useId();
   const noteId = useId();
+  const shareId = useId();
 
   const utils = trpc.useUtils();
   const update = trpc.matter.update.useMutation({
@@ -113,6 +154,9 @@ function PaymentMethodEditor({ matterId, initial, onDone }: { matterId: MatterId
             ))}
           </select>
         </div>
+        {usesClientShare(method) && (
+          <ClientShareField id={shareId} value={sharePct} onChange={setSharePct} />
+        )}
         <div>
           <label htmlFor={decidedAtId} className="block text-xs font-medium mb-1">
             Beslutsdatum (om rättshjälp/rättsskydd beviljats)
@@ -150,6 +194,7 @@ function PaymentMethodEditor({ matterId, initial, onDone }: { matterId: MatterId
                 paymentMethod: method as Parameters<typeof update.mutate>[0]["paymentMethod"],
                 paymentMethodNote: note || null,
                 paymentMethodDecidedAt: decidedAt || null,
+                clientShareBips: clientShareFromPct(sharePct),
               })
             }
             className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
@@ -172,7 +217,17 @@ export function PaymentMethodCard(props: Props) {
       paymentMethod={props.paymentMethod}
       paymentMethodNote={props.paymentMethodNote}
       paymentMethodDecidedAt={props.paymentMethodDecidedAt}
+      clientShareBips={props.clientShareBips}
       onEdit={() => setEditing(true)}
     />
   );
+}
+
+/** Procent-textfält → bips (null om tomt/ogiltigt). Tillåter komma-decimal. */
+function clientShareFromPct(pct: string): number | null {
+  const trimmed = pct.trim().replace(",", ".");
+  if (trimmed === "") return null;
+  const n = Number.parseFloat(trimmed);
+  if (!Number.isFinite(n) || n < 0 || n > 100) return null;
+  return Math.round(n * 100);
 }

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -116,6 +116,8 @@ export const matters = pgTable("matters", {
   taxaHasFTax: boolDefault("taxa_has_f_tax", false),
   taxaHufStart: timestamp("taxa_huf_start", { withTimezone: true }),
   radgivningBetaldAt: timestamp("radgivning_betald_at", { withTimezone: true }),
+  /** Klientens andel (självrisk/avgift) i bips — rättsskydd/rättshjälp (#778). */
+  clientShareBips: integer("client_share_bips"),
 }, (t) => [index("matters_org_idx").on(t.organizationId)]);
 
 /**

--- a/src/lib/server/routers/matter.ts
+++ b/src/lib/server/routers/matter.ts
@@ -224,6 +224,7 @@ export const matterRouter = router({
         paymentMethod: paymentMethodSchema.optional(),
         paymentMethodNote: z.string().nullable().optional(),
         paymentMethodDecidedAt: z.string().nullable().optional(),
+        clientShareBips: z.number().int().min(0).max(10000).nullable().optional(),
         isTaxeArende: z.boolean().optional(),
         taxaLevel: z.number().int().min(1).max(4).nullable().optional(),
         taxaHuvudforhandlingMin: z.number().int().nonnegative().nullable().optional(),

--- a/src/lib/shared/schemas/matter.ts
+++ b/src/lib/shared/schemas/matter.ts
@@ -32,6 +32,12 @@ export const matterSchema = z.object({
   paymentMethodNote: z.string().nullish(),
   paymentMethodDecidedAt: optionalDateLike,
   /**
+   * Klientens andel (självrisk/avgift) i basis points (2500 = 25 %) — relevant
+   * för rättsskydd/rättshjälp där klienten betalar en %-sats av upparbetat
+   * värde. Driver acconto-förslaget; kan ändras under ärendets gång (#778).
+   */
+  clientShareBips: z.number().int().min(0).max(10000).nullish(),
+  /**
    * `isTaxeArende` — ärendet ersätts enligt Domstolsverkets fastställda
    * taxa (schablon) istället för löpande timdebitering.
    *

--- a/test/unit/app/matters/billing-dialog.test.tsx
+++ b/test/unit/app/matters/billing-dialog.test.tsx
@@ -73,6 +73,13 @@ describe("BillingDialog — ACCONTO (#397 avdragsmedvetet förslag)", () => {
     });
   });
 
+  it("förifyller med ärendets %-sats istället för 20 %: 25 % × 5000 = 1250 kr (#778)", () => {
+    const metaWithShare = { ...meta, clientShareBips: 2500 };
+    render(<BillingDialog matterId={asId<"MatterId">("m1")} type="ACCONTO" existingAccontos={[]} meta={metaWithShare} onClose={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: "Skapa aconto-faktura" }));
+    expect(accontoMutate).toHaveBeenCalledWith(expect.objectContaining({ clientShareBips: 2500, amountOre: 125_000 }));
+  });
+
   it("drar av tidigare aconton i förslaget: 20 % × 5000 − 600 = 400 kr", () => {
     proposalData = {
       workValueOre: 500_000, priorAccontoSumOre: 60_000, // 600 kr tidigare

--- a/test/unit/components/payment-method-card.test.tsx
+++ b/test/unit/components/payment-method-card.test.tsx
@@ -1,6 +1,7 @@
 /**
  * Komponenttest för PaymentMethodCard. Verifierar att rätt label + kreditrisk
- * renderas för varje paymentMethod-värde, plus att en notering syns när satt.
+ * renderas för varje paymentMethod-värde, plus att en notering syns när satt
+ * och att klientens %-andel visas/redigeras vid rättshjälp/rättsskydd (#778).
  *
  * Vi mockar trpc-hooken så testet inte behöver en riktig server.
  */
@@ -35,6 +36,7 @@ describe("PaymentMethodCard", () => {
         paymentMethod="RATTSHJALP"
         paymentMethodNote="Diarienr RH-2026-0217"
         paymentMethodDecidedAt={new Date("2026-03-02")}
+        clientShareBips={null}
       />,
     );
     expect(screen.getByText("Rättshjälp")).toBeInTheDocument();
@@ -49,6 +51,7 @@ describe("PaymentMethodCard", () => {
         paymentMethod="PRIVAT"
         paymentMethodNote={null}
         paymentMethodDecidedAt={null}
+        clientShareBips={null}
       />,
     );
     expect(screen.getByText("Privat betalning")).toBeInTheDocument();
@@ -62,6 +65,7 @@ describe("PaymentMethodCard", () => {
         paymentMethod="PENDING"
         paymentMethodNote={null}
         paymentMethodDecidedAt={null}
+        clientShareBips={null}
       />,
     );
     expect(screen.getByText("Ej fastställt")).toBeInTheDocument();
@@ -75,6 +79,7 @@ describe("PaymentMethodCard", () => {
         paymentMethod="RATTSSKYDD"
         paymentMethodNote="Trygg-Hansa"
         paymentMethodDecidedAt={null}
+        clientShareBips={null}
       />,
     );
     expect(screen.getByRole("button", { name: /Ändra/i })).toBeInTheDocument();
@@ -87,6 +92,7 @@ describe("PaymentMethodCard", () => {
         paymentMethod="RATTSHJALP"
         paymentMethodNote={null}
         paymentMethodDecidedAt={null}
+        clientShareBips={null}
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: /Ändra/i }));
@@ -101,6 +107,7 @@ describe("PaymentMethodCard", () => {
         paymentMethod="RATTSHJALP"
         paymentMethodNote={null}
         paymentMethodDecidedAt={null}
+        clientShareBips={null}
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: /Ändra/i }));
@@ -115,6 +122,7 @@ describe("PaymentMethodCard", () => {
         paymentMethod="RATTSHJALP"
         paymentMethodNote={null}
         paymentMethodDecidedAt={null}
+        clientShareBips={null}
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: /Ändra/i }));
@@ -139,8 +147,74 @@ describe("PaymentMethodCard", () => {
         paymentMethod="RATTSHJALP"
         paymentMethodNote={null}
         paymentMethodDecidedAt={new Date("2026-04-15")}
+        clientShareBips={null}
       />,
     );
     expect(screen.getByText(/Beslut mottaget/)).toBeInTheDocument();
+  });
+
+  it("visar klientens andel som procent vid rättsskydd (#778)", () => {
+    render(
+      <PaymentMethodCard
+        matterId={asId<"MatterId">("m1")}
+        paymentMethod="RATTSSKYDD"
+        paymentMethodNote={null}
+        paymentMethodDecidedAt={null}
+        clientShareBips={2500}
+      />,
+    );
+    expect(screen.getByText(/Klientens andel: 25 %/)).toBeInTheDocument();
+  });
+
+  it("visar 'ej satt' när andelen saknas men metoden använder %-sats (#778)", () => {
+    render(
+      <PaymentMethodCard
+        matterId={asId<"MatterId">("m1")}
+        paymentMethod="RATTSHJALP"
+        paymentMethodNote={null}
+        paymentMethodDecidedAt={null}
+        clientShareBips={null}
+      />,
+    );
+    expect(screen.getByText(/Klientens andel: ej satt/)).toBeInTheDocument();
+  });
+
+  it("redigerar och sparar klientens %-andel som bips (#778)", () => {
+    render(
+      <PaymentMethodCard
+        matterId={asId<"MatterId">("m1")}
+        paymentMethod="RATTSSKYDD"
+        paymentMethodNote={null}
+        paymentMethodDecidedAt={null}
+        clientShareBips={2000}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Ändra/i }));
+    const shareInput = screen.getByPlaceholderText(/t\.ex\. 25/i) as HTMLInputElement;
+    expect(shareInput.value).toBe("20");
+    fireEvent.change(shareInput, { target: { value: "30" } });
+    fireEvent.click(screen.getByRole("button", { name: /^Spara$/i }));
+    expect(updateMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "m1", clientShareBips: 3000 }),
+    );
+  });
+
+  it("tomt andels-fält sparas som null (#778)", () => {
+    render(
+      <PaymentMethodCard
+        matterId={asId<"MatterId">("m1")}
+        paymentMethod="RATTSSKYDD"
+        paymentMethodNote={null}
+        paymentMethodDecidedAt={null}
+        clientShareBips={2000}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Ändra/i }));
+    const shareInput = screen.getByPlaceholderText(/t\.ex\. 25/i) as HTMLInputElement;
+    fireEvent.change(shareInput, { target: { value: "" } });
+    fireEvent.click(screen.getByRole("button", { name: /^Spara$/i }));
+    expect(updateMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "m1", clientShareBips: null }),
+    );
   });
 });

--- a/tooling/db/migrations/0005_add_matter_client_share.sql
+++ b/tooling/db/migrations/0005_add_matter_client_share.sql
@@ -1,0 +1,5 @@
+-- #778: klientens andel (självrisk/avgift) i basis points på ärendet.
+-- Relevant för rättsskydd/rättshjälp där klienten betalar en %-sats av
+-- upparbetat värde. Nullable — bara satt när paymentMethod kräver det. Kan
+-- ändras under ärendets gång (klientens inkomst kan ändras → ändrad andel).
+ALTER TABLE matters ADD COLUMN IF NOT EXISTS client_share_bips integer;


### PR DESCRIPTION
## Vad

Del 2+3 av #778. Rättsskydd/rättshjälp där klienten betalar en självrisk-/avgifts-%-sats:

1. **Synlig %-andel** på ärendet — badge i betalkortet ("Klientens andel: 25 %").
2. **Redigerbar under ärendets gång** — textfält i editorn (klientens inkomst kan ändras → ändrad %-sats). Tomt fält = inte satt.
3. **Acconto-förslaget förifylls** med ärendets %-sats × upparbetat ofakturerat (tidigare hårdkodat 20 %). Fortfarande justerbart innan utskick.

## Hur

- `matters.client_share_bips` (bips, 2500 = 25 %): migration `0005` + drizzle-schema + zod (`matterSchema`).
- `matter.update` tar emot `clientShareBips`.
- `PaymentMethodCard`: andels-badge i läsvyn + utbrutet `ClientShareField` i editorn (komplexitet ≤8).
- `BillingMeta.clientShareBips` → `AccontoForm` defaultar state från ärendet i stället för `2000`.

## Verifierat

- `tsc --noEmit` + `tsc -p test/tsconfig.json` rena (efter rensad tsbuildinfo).
- ESLint rent (komplexitet ≤8, ≤100 rader/funktion).
- `bun test --parallel` på matter/billing-sviterna: 177 pass. Nya tester: andels-visning/redigering i `payment-method-card.test.tsx`, acconto-prefill i `billing-dialog.test.tsx`.

Del 1+4 (tomt belopps-fält utan spinner + inkl/exkl moms-tydlighet) kommer i en följd-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)