### PR TITLE
feat(billing): belopp-fält utan spinner + tydlig moms-märkning (#778)

### DIFF
--- a/src/app/matters/[id]/_billing-dialog.tsx
+++ b/src/app/matters/[id]/_billing-dialog.tsx
@@ -11,6 +11,8 @@
  * dokumentlista (via `generateFakturaDoc`), redo för utskick.
  */
 import { useMemo, useState } from "react";
+import { VatBreakdown } from "@/components/billing/vat-breakdown";
+import { DecimalInput } from "@/components/ui/decimal-input";
 import { Modal } from "@/components/ui/modal";
 import {
   generateFakturaDoc,
@@ -73,6 +75,16 @@ function useFakturaDoc(matterId: MatterId, meta: BillingMeta): (invoice: Faktura
   };
 }
 
+/** Härleder förslag + det belopp som ska visas/skickas. Utbrutet ur
+ *  AccontoForm så formuläret håller sig under komplexitetsgränsen (#199). */
+function accontoAmounts(workValueOre: number, clientShareBips: number, priorOre: number, amountKr: number | null) {
+  const suggestedOre = proposedAccontoOre(workValueOre, clientShareBips, priorOre);
+  // Förifyllt förslag (#778) — visa det i fältet, men tomt om inget att föreslå.
+  const suggestionKr = suggestedOre > 0 ? suggestedOre / 100 : null;
+  const fieldKr = amountKr ?? suggestionKr;
+  return { suggestedOre, fieldKr, effectiveOre: Math.round((fieldKr ?? 0) * 100) };
+}
+
 function AccontoForm({ matterId, meta, onDone }: { matterId: MatterId; meta: BillingMeta; onDone: () => void }) {
   const proposal = trpc.billingRun.proposal.useQuery({ matterId });
   const workValueOre = proposal.data?.workValueOre ?? 0;
@@ -81,14 +93,13 @@ function AccontoForm({ matterId, meta, onDone }: { matterId: MatterId; meta: Bil
   const [clientShareBips, setBips] = useState(meta.clientShareBips ?? 2000);
   const [amountKr, setAmountKr] = useState<number | null>(null); // null → följ förslaget
   const makeDoc = useFakturaDoc(matterId, meta);
-  const suggestedOre = proposedAccontoOre(workValueOre, clientShareBips, priorOre);
-  const effectiveKr = amountKr ?? suggestedOre / 100;
+  const { suggestedOre, fieldKr, effectiveOre } = accontoAmounts(workValueOre, clientShareBips, priorOre, amountKr);
   const mut = trpc.billingRun.createAcconto.useMutation({
     onSuccess: async (res) => { await makeDoc(res.invoice); onDone(); },
   });
   return (
     <form onSubmit={(e) => { e.preventDefault(); mut.mutate({
-      matterId, clientShareBips, amountOre: Math.round(effectiveKr * 100), recipient: "KLIENT",
+      matterId, clientShareBips, amountOre: effectiveOre, recipient: "KLIENT",
     }); }} className="space-y-3">
       <p className="text-sm text-gray-600">
         Acconto baseras på klientens självrisk-/avgifts-procentsats × upparbetat värde,
@@ -96,14 +107,14 @@ function AccontoForm({ matterId, meta, onDone }: { matterId: MatterId; meta: Bil
       </p>
       <ProposalSummary workValueOre={workValueOre} priorOre={priorOre} suggestedOre={suggestedOre} />
       <Field label="Klientens andel (procent)">
-        <input type="number" min={0} max={100} step={1} value={clientShareBips / 100}
-          onChange={(e) => setBips(Math.round((parseFloat(e.target.value) || 0) * 100))}
+        <DecimalInput value={clientShareBips / 100} min={0}
+          onChange={(v) => setBips(Math.round((v ?? 0) * 100))}
           className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm" />
       </Field>
-      <Field label="Belopp (kr)">
-        <input type="number" min={0} step={1} value={effectiveKr}
-          onChange={(e) => setAmountKr(parseFloat(e.target.value) || 0)}
+      <Field label="Belopp (kr) — inkl. moms">
+        <DecimalInput value={fieldKr} onChange={setAmountKr} placeholder="Skriv in belopp"
           className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm" />
+        <VatBreakdown inclOre={effectiveOre} />
       </Field>
       {mut.error && <p className="text-sm text-red-700">{mut.error.message}</p>}
       <SubmitRow onDone={onDone} pending={mut.isPending} label="Skapa aconto-faktura" />
@@ -113,10 +124,13 @@ function AccontoForm({ matterId, meta, onDone }: { matterId: MatterId; meta: Bil
 
 function ProposalSummary({ workValueOre, priorOre, suggestedOre }: { workValueOre: number; priorOre: number; suggestedOre: number }) {
   return (
-    <div className="grid grid-cols-3 gap-2 rounded border border-gray-200 bg-gray-50 px-3 py-2 text-center">
-      <Stat label="Upparbetat" value={workValueOre} />
-      <Stat label="Tidigare aconton" value={priorOre} />
-      <Stat label="Förslag" value={suggestedOre} strong />
+    <div className="rounded border border-gray-200 bg-gray-50 px-3 py-2">
+      <div className="grid grid-cols-3 gap-2 text-center">
+        <Stat label="Upparbetat" value={workValueOre} />
+        <Stat label="Tidigare aconton" value={priorOre} />
+        <Stat label="Förslag" value={suggestedOre} strong />
+      </div>
+      <p className="mt-1 text-center text-[10px] uppercase tracking-wide text-gray-400">Belopp exkl. moms</p>
     </div>
   );
 }

--- a/src/app/matters/[id]/_verdict-dialog.tsx
+++ b/src/app/matters/[id]/_verdict-dialog.tsx
@@ -12,6 +12,8 @@
  * det är vad advokaten skriver in.
  */
 import { useState } from "react";
+import { VatBreakdown } from "@/components/billing/vat-breakdown";
+import { DecimalInput } from "@/components/ui/decimal-input";
 import { Modal } from "@/components/ui/modal";
 import { generateFakturaDoc } from "@/lib/client/kostnadsrakning/generate-faktura-doc";
 import { trpc } from "@/lib/client/trpc";
@@ -31,9 +33,20 @@ interface Props {
   onClose: () => void;
 }
 
+/** Härleder belopp/prutning/vakt. Utbrutet ur VerdictDialog så komponenten
+ *  håller sig under komplexitetsgränsen (#199). */
+function verdictAmounts(workValueOre: number, awardedKr: number | null) {
+  const proposedKr = workValueOre > 0 ? workValueOre / 100 : null;
+  const fieldKr = awardedKr ?? proposedKr;
+  const awardedOre = Math.max(0, Math.round((fieldKr ?? 0) * 100));
+  return { fieldKr, awardedOre, prutningOre: awardedOre - workValueOre, tooHigh: awardedOre > workValueOre };
+}
+
 export function VerdictDialog(props: Props) {
   const { billingRunId, workValueOre, onClose } = props;
-  const [awardedKr, setAwardedKr] = useState(workValueOre / 100);
+  // null → följ det föreslagna beloppet (förifyllt); tomt fält tillåts (#778).
+  const [awardedKr, setAwardedKr] = useState<number | null>(null);
+  const { fieldKr, awardedOre, prutningOre, tooHigh } = verdictAmounts(workValueOre, awardedKr);
   const register = trpc.document.register.useMutation();
   const utils = trpc.useUtils();
   const mut = trpc.billingRun.setVerdict.useMutation({
@@ -57,10 +70,6 @@ export function VerdictDialog(props: Props) {
       onClose();
     },
   });
-  const awardedOre = Math.max(0, Math.round(awardedKr * 100));
-  const prutningOre = awardedOre - workValueOre; // ≤ 0
-  const tooHigh = awardedOre > workValueOre;
-
   return (
     <Modal open title="Ange dom" onClose={onClose} widthClass="max-w-md">
       <form onSubmit={(e) => { e.preventDefault(); if (!tooHigh) mut.mutate({ billingRunId, prutningOre }); }}
@@ -71,10 +80,10 @@ export function VerdictDialog(props: Props) {
         </p>
         <Pair label="Föreslaget belopp" value={formatCurrency(workValueOre)} />
         <div>
-          <label className="block text-xs text-gray-500 mb-1">Dömt belopp (kr)</label>
-          <input type="number" min={0} step={1} value={awardedKr}
-            onChange={(e) => setAwardedKr(parseFloat(e.target.value) || 0)}
+          <label className="block text-xs text-gray-500 mb-1">Dömt belopp (kr) — inkl. moms</label>
+          <DecimalInput value={fieldKr} onChange={setAwardedKr} placeholder="Skriv in belopp"
             className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm" />
+          {!tooHigh && <VatBreakdown inclOre={awardedOre} />}
           {tooHigh && (
             <p className="mt-1 text-xs text-red-600">
               Dömt belopp kan inte överstiga föreslaget — kontrollera siffran från domen.

--- a/src/components/billing/vat-breakdown.tsx
+++ b/src/components/billing/vat-breakdown.tsx
@@ -1,0 +1,19 @@
+/**
+ * `VatBreakdown` — visar moms-uppdelningen för ett inkl-moms-belopp så det
+ * tydligt framgår vad som är moms respektive netto (#778). Advokattjänster
+ * = 25 %. Returnerar null för 0/negativa belopp.
+ */
+
+import { formatCurrency } from "@/lib/client/utils";
+import { DEFAULT_VAT_RATE, splitVat } from "@/lib/shared/vat";
+
+export function VatBreakdown({ inclOre }: { inclOre: number }) {
+  if (inclOre <= 0) return null;
+  const { exclVat, vat } = splitVat({ amount: inclOre, vatRate: DEFAULT_VAT_RATE, vatIncluded: true });
+  return (
+    <p className="mt-1 text-[11px] text-gray-500">
+      Varav moms (25 %): <span className="font-mono">{formatCurrency(vat)}</span>
+      {" · "}exkl. moms: <span className="font-mono">{formatCurrency(exclVat)}</span>
+    </p>
+  );
+}

--- a/src/components/ui/decimal-input.tsx
+++ b/src/components/ui/decimal-input.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+/**
+ * `DecimalInput` — numeriskt fält UTAN upp/ner-spinners (#778).
+ *
+ * `type="number"` ritar webbläsarens spinner-pilar och visar en envis "0".
+ * Det här fältet är `type="text"` med `inputMode="decimal"` (numeriskt
+ * tangentbord på mobil), tomt = `null`, och tillåter komma-decimal.
+ *
+ * Värdet styrs av `value` men ett lokalt text-buffert låter användaren
+ * skriva "12," eller radera till tomt utan att hoppa till 0. Buffern
+ * synkas om föräldern ändrar `value` utifrån (t.ex. förifyllt förslag som
+ * räknas om) — derived-state-from-props, ingen effect.
+ */
+
+import { useState } from "react";
+
+interface Props {
+  value: number | null;
+  onChange: (v: number | null) => void;
+  id?: string;
+  placeholder?: string;
+  className?: string;
+  /** Minsta tillåtna värde (lägre tolkas som tomt/ogiltigt). Default 0. */
+  min?: number;
+}
+
+export function DecimalInput({ value, onChange, id, placeholder, className, min = 0 }: Props) {
+  const [buf, setBuf] = useState<{ shown: number | null; text: string }>({ shown: value, text: fmt(value) });
+  // Föräldern har ändrat value utifrån → adoptera det; annars behåll råtexten.
+  const text = buf.shown === value ? buf.text : fmt(value);
+  return (
+    <input
+      id={id}
+      type="text"
+      inputMode="decimal"
+      value={text}
+      placeholder={placeholder}
+      className={className}
+      onChange={(e) => {
+        const raw = e.target.value;
+        const parsed = parseDecimal(raw, min);
+        setBuf({ shown: parsed, text: raw });
+        onChange(parsed);
+      }}
+    />
+  );
+}
+
+function fmt(v: number | null): string {
+  return v == null ? "" : String(v);
+}
+
+/** Text → tal eller null (tomt/ogiltigt/under min). Tillåter komma-decimal. */
+export function parseDecimal(raw: string, min = 0): number | null {
+  const t = raw.trim().replace(",", ".");
+  if (t === "") return null;
+  const n = Number.parseFloat(t);
+  if (!Number.isFinite(n) || n < min) return null;
+  return n;
+}

--- a/test/unit/app/matters/billing-dialog.test.tsx
+++ b/test/unit/app/matters/billing-dialog.test.tsx
@@ -92,7 +92,7 @@ describe("BillingDialog — ACCONTO (#397 avdragsmedvetet förslag)", () => {
 
   it("procent → bips + omräknat förslag: 30 % → 3000 bips, 1500 kr", () => {
     render(<BillingDialog matterId={asId<"MatterId">("m1")} type="ACCONTO" existingAccontos={[]} meta={meta} onClose={() => {}} />);
-    const [percent] = screen.getAllByRole("spinbutton");
+    const [percent] = screen.getAllByRole("textbox"); // [%-andel, belopp]
     fireEvent.change(percent!, { target: { value: "30" } });
     fireEvent.click(screen.getByRole("button", { name: "Skapa aconto-faktura" }));
     expect(accontoMutate).toHaveBeenCalledWith(expect.objectContaining({ clientShareBips: 3000, amountOre: 150_000 }));
@@ -100,10 +100,32 @@ describe("BillingDialog — ACCONTO (#397 avdragsmedvetet förslag)", () => {
 
   it("manuell justering av beloppet vinner över förslaget", () => {
     render(<BillingDialog matterId={asId<"MatterId">("m1")} type="ACCONTO" existingAccontos={[]} meta={meta} onClose={() => {}} />);
-    const spin = screen.getAllByRole("spinbutton");
-    fireEvent.change(spin[1]!, { target: { value: "750" } }); // belopp-fältet
+    const boxes = screen.getAllByRole("textbox"); // [%-andel, belopp]
+    fireEvent.change(boxes[1]!, { target: { value: "750" } }); // belopp-fältet
     fireEvent.click(screen.getByRole("button", { name: "Skapa aconto-faktura" }));
     expect(accontoMutate).toHaveBeenCalledWith(expect.objectContaining({ amountOre: 75_000 }));
+  });
+
+  it("belopps-fältet är ett text-fält utan spinner-pilar (#778)", () => {
+    render(<BillingDialog matterId={asId<"MatterId">("m1")} type="ACCONTO" existingAccontos={[]} meta={meta} onClose={() => {}} />);
+    // Inga number-spinners alls (type=number ger role 'spinbutton').
+    expect(screen.queryAllByRole("spinbutton")).toHaveLength(0);
+    const boxes = screen.getAllByRole("textbox") as HTMLInputElement[];
+    expect(boxes[1]!.getAttribute("inputmode")).toBe("decimal");
+  });
+
+  it("tomt belopp när inget förslag finns: rutan är tom från början (#778)", () => {
+    proposalData = { workValueOre: 0, priorAccontoSumOre: 0, timeEntries: [], expenses: [] };
+    render(<BillingDialog matterId={asId<"MatterId">("m1")} type="ACCONTO" existingAccontos={[]} meta={meta} onClose={() => {}} />);
+    const boxes = screen.getAllByRole("textbox") as HTMLInputElement[];
+    expect(boxes[1]!.value).toBe(""); // belopp tomt, inte "0"
+  });
+
+  it("visar moms-uppdelning för det inkl-moms-belopp som anges (#778)", () => {
+    render(<BillingDialog matterId={asId<"MatterId">("m1")} type="ACCONTO" existingAccontos={[]} meta={meta} onClose={() => {}} />);
+    // Förslag 1000 kr inkl moms → moms 200 kr, exkl 800 kr.
+    expect(screen.getByText(/Varav moms \(25 %\):/)).toBeInTheDocument();
+    expect(screen.getByText(/exkl\. moms:/)).toBeInTheDocument();
   });
 
   it("onSuccess genererar ett faktura-dokument", async () => {

--- a/test/unit/app/matters/verdict-dialog.test.tsx
+++ b/test/unit/app/matters/verdict-dialog.test.tsx
@@ -50,14 +50,14 @@ describe("VerdictDialog", () => {
   it("visar föreslaget belopp och initierar dömt = föreslaget (ingen prutning)", () => {
     render(<VerdictDialog {...baseProps} />);
     expect(screen.getByText("Föreslaget belopp")).toBeInTheDocument();
-    const input = screen.getByRole("spinbutton") as HTMLInputElement;
+    const input = screen.getByRole("textbox") as HTMLInputElement;
     expect(input.value).toBe("5000"); // 500 000 öre / 100
     expect(screen.queryByText("Prutning")).not.toBeInTheDocument();
   });
 
   it("dömt < föreslaget → visar prutning och submit skickar negativ prutningOre", () => {
     render(<VerdictDialog {...baseProps} />);
-    fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "4000" } }); // 400 000 öre
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "4000" } }); // 400 000 öre
     expect(screen.getByText("Prutning")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Skapa faktura" }));
     expect(verdictMutate).toHaveBeenCalledWith({ billingRunId: "br-1", prutningOre: -100_000 });
@@ -65,7 +65,7 @@ describe("VerdictDialog", () => {
 
   it("dömt > föreslaget → fel-text, submit disabled, ingen mutation", () => {
     render(<VerdictDialog {...baseProps} />);
-    fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "6000" } });
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "6000" } });
     expect(screen.getByText(/kan inte överstiga föreslaget/)).toBeInTheDocument();
     const submit = screen.getByRole("button", { name: "Skapa faktura" }) as HTMLButtonElement;
     expect(submit.disabled).toBe(true);

--- a/test/unit/components/decimal-input.test.tsx
+++ b/test/unit/components/decimal-input.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * Tester för DecimalInput (#778) — numeriskt fält utan spinner-pilar:
+ * tomt = null, komma-decimal tillåts, råtext-buffert hoppar inte till 0,
+ * och fältet adopterar nytt value när föräldern ändrar det utifrån.
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useState } from "react";
+import { describe, it, expect } from "vitest-compat";
+import { DecimalInput, parseDecimal } from "@/components/ui/decimal-input";
+
+describe("parseDecimal", () => {
+  it("tomt → null", () => expect(parseDecimal("")).toBeNull());
+  it("komma-decimal → tal", () => expect(parseDecimal("12,5")).toBe(12.5));
+  it("punkt-decimal → tal", () => expect(parseDecimal("12.5")).toBe(12.5));
+  it("under min → null", () => expect(parseDecimal("-3", 0)).toBeNull());
+  it("skräp → null", () => expect(parseDecimal("abc")).toBeNull());
+});
+
+describe("DecimalInput", () => {
+  it("renderar inget spinbutton (inga upp/ner-pilar)", () => {
+    render(<DecimalInput value={null} onChange={() => {}} />);
+    expect(screen.queryByRole("spinbutton")).not.toBeInTheDocument();
+    expect(screen.getByRole("textbox").getAttribute("inputmode")).toBe("decimal");
+  });
+
+  it("null → tom ruta från början", () => {
+    render(<DecimalInput value={null} onChange={() => {}} placeholder="Skriv in belopp" />);
+    expect((screen.getByRole("textbox") as HTMLInputElement).value).toBe("");
+  });
+
+  it("rapporterar parsat tal och null vid tomt", () => {
+    const seen: Array<number | null> = [];
+    function Harness() {
+      const [v, setV] = useState<number | null>(null);
+      return <DecimalInput value={v} onChange={(n) => { seen.push(n); setV(n); }} />;
+    }
+    render(<Harness />);
+    const box = screen.getByRole("textbox");
+    fireEvent.change(box, { target: { value: "750" } });
+    expect(seen.at(-1)).toBe(750);
+    fireEvent.change(box, { target: { value: "" } });
+    expect(seen.at(-1)).toBeNull();
+  });
+
+  it("behåller råtext (t.ex. '12,') utan att hoppa till 0", () => {
+    function Harness() {
+      const [v, setV] = useState<number | null>(null);
+      return <DecimalInput value={v} onChange={setV} />;
+    }
+    render(<Harness />);
+    const box = screen.getByRole("textbox") as HTMLInputElement;
+    fireEvent.change(box, { target: { value: "12," } });
+    expect(box.value).toBe("12,"); // inte "12" eller "0"
+  });
+
+  it("adopterar nytt value när föräldern ändrar det utifrån (förifyllning)", () => {
+    const { rerender } = render(<DecimalInput value={null} onChange={() => {}} />);
+    expect((screen.getByRole("textbox") as HTMLInputElement).value).toBe("");
+    rerender(<DecimalInput value={1000} onChange={() => {}} />);
+    expect((screen.getByRole("textbox") as HTMLInputElement).value).toBe("1000");
+  });
+});


### PR DESCRIPTION
## Vad

Del 1+4 av #778.

**Del 1 — inget spinner-"0", skriv in beloppet.** Belopps-fälten var `type="number"` → webbläsarens upp/ner-pilar + envis "0". Nytt återanvändbart `DecimalInput` (`type="text"` + `inputMode="decimal"`): tomt = `null`, komma-decimal tillåts, lokalt råtext-buffert så man kan skriva "12," / radera till tomt utan att hoppa till 0. När inget förslag finns är rutan **tom från början**. Acconto- och dom-beloppen förblir förifyllda (förslaget) men redigerbara.

**Del 4 — tydlig moms-märkning.** Belopps-fälten märks nu "inkl. moms" och visar moms-uppdelningen under fältet (`Varav moms (25 %): X · exkl. moms: Y`) via befintliga `splitVat`. Förslags-summorna (upparbetat/förslag) märks "exkl. moms" så det framgår vilka belopp som är vilka.

Berörda fält: acconto "Belopp (kr)" + "%-andel", verdict "Dömt belopp".

## Domän-notis (moms)

Arvodet (upparbetat) härleds från timpriser som anges **exkl. moms** (jfr kostnadsräkningens "1 626 kr/h ex moms"), medan faktura-beloppet lagras som ett enda brutto-tal (`invoice.amount`, märkt "brutto" på faktura-sidan) = **inkl. moms**. Märkningen speglar detta. Om aconto-beloppet i stället ska räknas på inkl-moms-underlag är det ett separat domän-beslut — säg till så fixar jag formeln.

## Verifierat

- `tsc --noEmit` + `tsc -p test/tsconfig.json` rena.
- ESLint rent (komplexitet ≤8 — bröt ut `accontoAmounts`/`verdictAmounts`).
- `bun test --parallel` på de berörda sviterna: 176 pass. Nya tester: `decimal-input.test.tsx` (buffert/tom/förifyllning/ingen spinner), acconto tom-ruta + moms-split, uppdaterade spinbutton→textbox-frågningar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)