### PR TITLE
feat(expenses): mata in utlägg exkl. moms, AVA lägger på momsen (#781)

### DIFF
--- a/src/app/matters/[id]/_expense-section.tsx
+++ b/src/app/matters/[id]/_expense-section.tsx
@@ -16,11 +16,11 @@ interface Props {
 
 interface ExpenseForm {
   date: string;
+  /** Belopp i kr EXKL. moms — advokaten matar in exkl., AVA lägger på momsen (#781). */
   amount: number;
   description: string;
   billable: boolean;
   vatRate: VatRate;
-  vatIncluded: boolean;
 }
 
 interface Expense {
@@ -43,18 +43,18 @@ function initialForm(): ExpenseForm {
     description: "",
     billable: true,
     vatRate: 2500,
-    vatIncluded: true,
   };
 }
 
 function toForm(e: Expense): ExpenseForm {
+  // Visa beloppet EXKL. moms i formuläret oavsett hur det lagrats.
+  const exclOre = splitVat({ amount: e.amount, vatRate: e.vatRate ?? 2500, vatIncluded: e.vatIncluded ?? true }).exclVat;
   return {
     date: new Date(e.date).toISOString().split("T")[0]!,
-    amount: e.amount / 100,
+    amount: exclOre / 100,
     description: e.description,
     billable: e.billable,
     vatRate: (e.vatRate ?? 2500) as VatRate,
-    vatIncluded: e.vatIncluded ?? true,
   };
 }
 
@@ -66,13 +66,18 @@ function payloadOf(f: ExpenseForm): {
   vatRate: VatRate;
   vatIncluded: boolean;
 } {
+  // Advokaten matar in exkl. moms; AVA lägger på momsen. Lagring hålls
+  // tillsvidare som brutto (vatIncluded=true) så billing/verifikat är
+  // oförändrade — lagringen flippas till netto i #782.
+  const netOre = Math.round(f.amount * 100);
+  const grossOre = splitVat({ amount: netOre, vatRate: f.vatRate, vatIncluded: false }).inclVat;
   return {
     date: f.date,
-    amount: Math.round(f.amount * 100),
+    amount: grossOre,
     description: f.description,
     billable: f.billable,
     vatRate: f.vatRate,
-    vatIncluded: f.vatIncluded,
+    vatIncluded: true,
   };
 }
 
@@ -251,7 +256,7 @@ function ExpenseForm({ form, setForm, submitLabel, isPending, isTaxeArende, onSu
             className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm" />
         </div>
         <div>
-          <label className="block text-xs text-gray-500 mb-1">Belopp (SEK) *</label>
+          <label className="block text-xs text-gray-500 mb-1">Belopp (SEK, exkl. moms) *</label>
           <input type="number" required min={0} step="0.01" value={form.amount || ""}
             onChange={(e) => setForm({ ...form, amount: parseFloat(e.target.value) || 0 })}
             placeholder="0,00"
@@ -265,26 +270,18 @@ function ExpenseForm({ form, setForm, submitLabel, isPending, isTaxeArende, onSu
           onChange={(e) => setForm({ ...form, description: e.target.value })}
           className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm" />
       </div>
-      <div className="grid grid-cols-2 gap-3 items-center">
+      <div>
+        <label className="block text-xs text-gray-500 mb-1">Momssats</label>
         <select value={form.vatRate}
           onChange={(e) => setForm({ ...form, vatRate: Number(e.target.value) as VatRate })}
-          className="rounded border border-gray-300 px-3 py-1.5 text-sm">
+          className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm">
           {VAT_RATES.map((r) => <option key={r} value={r}>Moms: {VAT_RATE_LABELS[r]}</option>)}
         </select>
-        <div className="flex items-center gap-3">
-          <label className="flex items-center gap-2 text-sm">
-            <input type="radio" name="vatIncl" checked={form.vatIncluded}
-              onChange={() => setForm({ ...form, vatIncluded: true })} />
-            Inkl moms
-          </label>
-          <label className="flex items-center gap-2 text-sm">
-            <input type="radio" name="vatIncl" checked={!form.vatIncluded}
-              onChange={() => setForm({ ...form, vatIncluded: false })} />
-            Exkl moms
-          </label>
-        </div>
+        <p className="mt-1 text-[11px] text-gray-400">
+          Ange beloppet exkl. moms — AVA lägger på momsen. Default 25 %; välj 0 % för momsfritt (t.ex. domstolsavgift).
+        </p>
       </div>
-      <VatPreview amount={form.amount} vatRate={form.vatRate} vatIncluded={form.vatIncluded} />
+      <VatPreview amount={form.amount} vatRate={form.vatRate} />
       <label className="flex items-center gap-2 text-sm">
         <input type="checkbox" checked={form.billable}
           onChange={(e) => setForm({ ...form, billable: e.target.checked })} />
@@ -304,12 +301,13 @@ function ExpenseForm({ form, setForm, submitLabel, isPending, isTaxeArende, onSu
   );
 }
 
-function VatPreview({ amount, vatRate, vatIncluded }: { amount: number; vatRate: number; vatIncluded: boolean }) {
+function VatPreview({ amount, vatRate }: { amount: number; vatRate: number }) {
   if (!amount) return <span className="text-xs text-gray-400">Förhandsvisning</span>;
-  const r = splitVat({ amount: Math.round(amount * 100), vatRate, vatIncluded });
+  // Inmatat belopp är exkl. moms → räkna fram moms + inkl.
+  const r = splitVat({ amount: Math.round(amount * 100), vatRate, vatIncluded: false });
   return (
     <span className="text-xs text-gray-600 font-mono">
-      Ex: {formatCurrency(r.exclVat)} · M: {formatCurrency(r.vat)} · In: {formatCurrency(r.inclVat)}
+      Exkl: {formatCurrency(r.exclVat)} · moms: {formatCurrency(r.vat)} · inkl: {formatCurrency(r.inclVat)}
     </span>
   );
 }

--- a/test/unit/app/matters/[id]/page.test.tsx
+++ b/test/unit/app/matters/[id]/page.test.tsx
@@ -367,7 +367,7 @@ describe("MatterDetailPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /^Spara$/i }));
     expect(stubs.createExpense.mutate).toHaveBeenCalled();
     const arg = stubs.createExpense.mutate.mock.calls[0]![0];
-    expect(arg.amount).toBe(15000); // SEK → öre
+    expect(arg.amount).toBe(18750); // 150 kr exkl. @ 25 % → lagras brutto 187,50 kr (#781)
     expect(arg.description).toBe("Domstolsavgift");
   });
 

--- a/test/unit/app/matters/expense-section.test.tsx
+++ b/test/unit/app/matters/expense-section.test.tsx
@@ -96,18 +96,20 @@ describe("ExpenseSection", () => {
     fireEvent.change(dateInput, { target: { value: "2026-03-15" } });
     fireEvent.change(screen.getByPlaceholderText("0,00"), { target: { value: "150" } });
     fireEvent.change(screen.getByPlaceholderText("Beskrivning *"), { target: { value: "Parkering" } });
-    // VatPreview-grenen (amount>0) renderar moms-uppdelningen.
-    expect(screen.getByText(/Ex:.*M:.*In:/)).toBeInTheDocument();
+    // VatPreview-grenen (amount>0) renderar moms-uppdelningen (exkl-inmatning).
+    expect(screen.getByText(/Exkl:.*moms:.*inkl:/)).toBeInTheDocument();
     fireEvent.click(screen.getByText("Spara"));
+    // Inmatat exkl. 150 kr @ 25 % → lagras brutto 187,50 kr (#781).
     expect(createMutate).toHaveBeenCalledWith(
-      expect.objectContaining({ matterId: "m1", description: "Parkering" }),
+      expect.objectContaining({ matterId: "m1", description: "Parkering", amount: 18750, vatRate: 2500, vatIncluded: true }),
     );
   });
 
-  it("växlar moms-radio (Exkl moms) + momssats-select utan att krascha", () => {
+  it("byter momssats-select + Debiterbar utan att krascha (ingen incl/excl-toggel längre)", () => {
     render(<ExpenseSection matterId={asId<"MatterId">("m1")} />);
     fireEvent.click(screen.getByText("+ Nytt utlägg"));
-    fireEvent.click(screen.getByRole("radio", { name: /Exkl moms/ }));
+    // Incl/excl-radions är borttagen — inmatning är alltid exkl. moms (#781).
+    expect(screen.queryByRole("radio")).not.toBeInTheDocument();
     fireEvent.change(screen.getByRole("combobox"), { target: { value: "1200" } });
     fireEvent.click(screen.getByRole("checkbox")); // Debiterbar av
     expect(screen.getByText("Spara")).toBeInTheDocument();


### PR DESCRIPTION
Del av #781 (moms-modell, stegvis).

## Vad
Utläggs-entry ändras så advokaten **matar in beloppet exkl. moms** och väljer momssats (default 25 %, 0 % för momsfritt t.ex. domstolsavgift). AVA räknar fram moms + inkl. och visar uppdelningen (`Exkl: … · moms: … · inkl: …`). **Incl/excl-toggeln är borttagen** — inmatning är alltid exkl. Per-utlägg-sats behålls (du valde det, för att inte tvinga 25 % på momsfria poster).

## Varför lagringen INTE flippas här
Billing-koden (`computeFinalInvoiceBreakdown`, `billingRun.workValueOre`, `semantic-voucher.ts`) summerar `expense.amount` **rått** in i fakturor/verifikat. Att lagra utlägg netto i isolering skulle tyst ta bort momsen från fakturerade utlägg. Därför hålls lagringen som brutto (`vatIncluded=true`) tillsvidare — det inmatade exkl-beloppet räknas upp till brutto vid sparning, och dekomponeras till exkl vid redigering. Flippen till netto-lagring görs **atomiskt** med faktura/billing-migreringen i **#782**.

Användarbeteendet du bad om ("advokaten lägger in exkl, AVA lägger på 25 %") är uppfyllt nu; "allt lagras exkl" landar i #782.

## Verifierat
- `tsc` (root + test) rena, ESLint rent.
- `bun test --parallel` på matter/kostnadsräkning/scenario/billingRun-sviterna: 215 pass. Uppdaterade tester: ny exkl→brutto-payload-assertion + borttagen radio-interaktion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)