### PR TITLE
feat(billing): lägg på 25 % moms på arvodet i alla fakturor (#782)

### DIFF
--- a/src/app/invoices/[id]/_client.tsx
+++ b/src/app/invoices/[id]/_client.tsx
@@ -12,7 +12,9 @@ import type { DownloadClient } from "@/lib/client/backend/load-document-blob";
 import { EntityLink } from "@/lib/client/demo/entity-link";
 import { useRouteId } from "@/lib/client/demo/use-route-id";
 import { trpc } from "@/lib/client/trpc";
+import { formatCurrency } from "@/lib/client/utils";
 import type { AppRouter } from "@/lib/server/routers/_app";
+import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { computeMatterSettlement, computeRadgivningsavgift, type MatterSettlement } from "@/lib/shared/rattshjalp";
 import { asId } from "@/lib/shared/schemas/ids";
@@ -484,6 +486,9 @@ function SpecificationCard({ timeEntries, expenses }: { timeEntries: SpecTimeRow
   const lineFor = (t: SpecTimeRow) => Math.round((t.minutes / 60) * (t.hourlyRate ?? 0));
   const timeTotal = timeEntries.reduce((s, t) => s + lineFor(t), 0);
   const expenseTotal = expenses.reduce((s, e) => s + e.amount, 0);
+  // Arvode lagras exkl. moms; alla fakturor lägger på 25 % moms på arvodet (#782).
+  const arvodeMomsOre = arvodeInclVatOre(timeTotal) - timeTotal;
+  const summaUnderlag = arvodeInclVatOre(timeTotal) + expenseTotal;
   return (
     <div className="bg-white rounded-lg border border-gray-200 p-6">
       <h2 className="font-semibold mb-3">Underlag (specifikation)</h2>
@@ -506,12 +511,16 @@ function SpecificationCard({ timeEntries, expenses }: { timeEntries: SpecTimeRow
                   <td className="py-1.5 whitespace-nowrap">{new Date(t.date).toLocaleDateString("sv-SE")}</td>
                   <td className="py-1.5">{t.description}</td>
                   <td className="py-1.5 text-right whitespace-nowrap">{(t.minutes / 60).toFixed(1)} h</td>
-                  <td className="py-1.5 text-right"><Money ore={t.hourlyRate ?? 0} basis="gross" className="font-mono" /></td>
-                  <td className="py-1.5 text-right"><Money ore={lineFor(t)} basis="gross" className="font-mono" /></td>
+                  <td className="py-1.5 text-right"><Money ore={t.hourlyRate ?? 0} basis="net" className="font-mono" /></td>
+                  <td className="py-1.5 text-right"><Money ore={lineFor(t)} basis="net" className="font-mono" /></td>
                 </tr>
               ))}
             </tbody>
           </table>
+          <div className="flex justify-between text-xs text-gray-500 mt-1">
+            <span>Moms på arvodet (25 %)</span>
+            <span className="font-mono">{formatCurrency(arvodeMomsOre)}</span>
+          </div>
         </div>
       )}
       {expenses.length > 0 && (
@@ -532,7 +541,7 @@ function SpecificationCard({ timeEntries, expenses }: { timeEntries: SpecTimeRow
       )}
       <div className="border-t pt-2 flex justify-between text-sm font-semibold">
         <span>Summa underlag</span>
-        <Money ore={timeTotal + expenseTotal} basis="gross" className="font-mono" />
+        <Money ore={summaUnderlag} basis="gross" className="font-mono" />
       </div>
     </div>
   );

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -17,6 +17,7 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { proposedAccontoOre } from "@/lib/shared/billing-proposal";
+import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
 import { ocrFromInvoiceNumber } from "@/lib/shared/ocr-reference";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import type { BillingRun } from "@/lib/shared/schemas/billing";
@@ -80,14 +81,30 @@ async function fetchUnfrozenWork(repos: Repositories, matterId: MatterId): Promi
   return { timeEntries: te, expenses: ex.filter((e) => e.kind !== "PRUTNING") };
 }
 
-function workValueOre(work: UnfrozenWork): number {
-  const time = work.timeEntries
+/** Arvode netto (exkl. moms) — summa av debiterbara tidsposter. */
+function arvodeNetOre(work: UnfrozenWork): number {
+  return work.timeEntries
     .filter((t) => t.billable)
     .reduce((sum, t) => sum + timeEntryValueOre(t.minutes, t.hourlyRate), 0);
-  const exp = work.expenses
+}
+
+/** Debiterbara utlägg (brutto idag — netto-lagring kommer i senare #782-steg). */
+function expenseGrossOre(work: UnfrozenWork): number {
+  return work.expenses
     .filter((e) => e.billable)
     .reduce((sum, e) => sum + e.amount, 0);
-  return time + exp;
+}
+
+/** Nettovärde på arbetet: arvode (exkl moms) + utlägg. Bas för acconto-förslag
+ *  och "upparbetat ofakturerat" — INTE fakturabeloppet (se invoiceGrossOre). */
+function workValueOre(work: UnfrozenWork): number {
+  return arvodeNetOre(work) + expenseGrossOre(work);
+}
+
+/** Fakturans bruttobelopp: arvode + 25 % moms + utlägg. Alla fakturor lägger
+ *  på moms på arvodet oavsett mottagare (#782). */
+function invoiceGrossOre(work: UnfrozenWork): number {
+  return arvodeInclVatOre(arvodeNetOre(work)) + expenseGrossOre(work);
 }
 
 /** Bygg ett itemiserat fakturaförslag ur ofrysta tids-/utläggsrader (#397). */
@@ -313,10 +330,11 @@ export const billingRunRouter = router({
       return ctx.repos.transaction(async (tx) => {
         await assertMatterInOrg(tx, input.matterId, ctx.orgId);
         const { work, selected } = await resolveFinalWork(tx, input.matterId, input.timeEntryIds, input.expenseIds);
-        const value = workValueOre(work);
+        // Brutto = arvode inkl. 25 % moms + utlägg (#782).
+        const grossValue = invoiceGrossOre(work);
         const deductedRuns = await fetchDeductedAccontoRuns(tx, input.matterId, input.deductedBillingRunIds);
         const deductionOre = deductedRuns.reduce((sum, r) => sum + (r.amountOre ?? 0), 0);
-        const finalAmount = Math.max(0, value - deductionOre);
+        const finalAmount = Math.max(0, grossValue - deductionOre);
         const invoice = await tx.invoices.create({
           matterId: input.matterId, amount: finalAmount,
           invoiceType: "FINAL", status: "DRAFT",
@@ -325,8 +343,8 @@ export const billingRunRouter = router({
         });
         const run = await tx.billingRuns.create({
           matterId: input.matterId, type: "FINAL", recipient: input.recipient,
-          status: "SENT", workValueOreAtRun: value,
-          proposedAmountOre: value, amountOre: finalAmount,
+          status: "SENT", workValueOreAtRun: grossValue,
+          proposedAmountOre: grossValue, amountOre: finalAmount,
           invoiceId: invoice.id, deductedBillingRunIds: input.deductedBillingRunIds,
           periodTo: new Date(), notes: input.notes,
         });
@@ -344,11 +362,12 @@ export const billingRunRouter = router({
       return ctx.repos.transaction(async (tx) => {
         await assertMatterInOrg(tx, input.matterId, ctx.orgId);
         const work = await fetchUnfrozenWork(tx, input.matterId);
-        const value = workValueOre(work);
+        // Brutto = arvode inkl. 25 % moms + utlägg (#782) — matchar kostnadsräkningens PDF.
+        const grossValue = invoiceGrossOre(work);
         const run = await tx.billingRuns.create({
           matterId: input.matterId, type: "KOSTNADSRAKNING", recipient: "DOMSTOL",
-          status: "PENDING_VERDICT", workValueOreAtRun: value,
-          proposedAmountOre: value, amountOre: value,
+          status: "PENDING_VERDICT", workValueOreAtRun: grossValue,
+          proposedAmountOre: grossValue, amountOre: grossValue,
           invoiceId: null, deductedBillingRunIds: [],
           periodTo: new Date(), notes: input.notes,
         });

--- a/src/lib/shared/invoice-calc.ts
+++ b/src/lib/shared/invoice-calc.ts
@@ -26,9 +26,22 @@ export interface AccontoForDeduction {
   amount: number; // öre
 }
 
+/**
+ * Moms på arvode i basis points. Alla fakturor lägger på 25 % moms på arvodet
+ * oavsett mottagare (#782) — timpriset anges exkl. moms.
+ */
+export const ARVODE_VAT_BIPS = 2500;
+
+/** Arvode netto (exkl. moms, öre) → inkl. moms (öre). Deterministisk rundning. */
+export function arvodeInclVatOre(arvodeNetOre: number): number {
+  return arvodeNetOre + Math.round((arvodeNetOre * ARVODE_VAT_BIPS) / 10000);
+}
+
 export interface FinalInvoiceBreakdown {
-  /** Brutto: alla debiterbara timmar + utlägg före accontoavdrag. */
+  /** Brutto: arvode inkl. 25 % moms + debiterbara utlägg, före accontoavdrag (#782). */
   grossAmount: number;
+  /** Arvodets moms (öre) — del av grossAmount. */
+  arvodeVatOre: number;
   /** Summan av alla accontoavdrag (positivt tal). */
   accontoDeductionTotal: number;
   /** Nettot som klienten faktiskt ska betala: grossAmount − accontoDeductionTotal. */
@@ -60,7 +73,10 @@ export function computeFinalInvoiceBreakdown(
   const expenseTotal = expenses
     .filter((e) => e.billable)
     .reduce((sum, e) => sum + e.amount, 0);
-  const grossAmount = timeTotal + expenseTotal;
+  // Arvodet (timmar × timpris) är exkl. moms → lägg på 25 % (#782); utlägg är brutto.
+  const arvodeInclVat = arvodeInclVatOre(timeTotal);
+  const arvodeVatOre = arvodeInclVat - timeTotal;
+  const grossAmount = arvodeInclVat + expenseTotal;
 
   const deductions = accontos.map((a) => ({
     accontoInvoiceId: a.id,
@@ -75,7 +91,7 @@ export function computeFinalInvoiceBreakdown(
     );
   }
 
-  return { grossAmount, accontoDeductionTotal, netAmount, deductions };
+  return { grossAmount, arvodeVatOre, accontoDeductionTotal, netAmount, deductions };
 }
 
 /**

--- a/test/integration/scenario-civilmal.test.ts
+++ b/test/integration/scenario-civilmal.test.ts
@@ -320,9 +320,10 @@ describe("Scenario: civilmål (bostadsrättstvist) på löpande räkning", () =>
       exps.expenses.map((e) => ({ amount: e.amount, billable: e.billable })),
       [{ id: state.accontoInvoiceId!, amount: 1_500_000 }],
     );
-    expect(breakdown.grossAmount).toBe(3_687_500 + 56_250); // 3 743 750 öre
+    // Arvode 36 875 kr + 25 % moms = 46 093,75 kr + utlägg 562,50 kr = 46 656,25 kr (#782).
+    expect(breakdown.grossAmount).toBe(4_609_375 + 56_250); // 4 665 625 öre
     expect(breakdown.accontoDeductionTotal).toBe(1_500_000);
-    expect(breakdown.netAmount).toBe(3_743_750 - 1_500_000); // 2 243 750 öre = 22 437,50 kr
+    expect(breakdown.netAmount).toBe(4_665_625 - 1_500_000); // 3 165 625 öre = 31 656,25 kr
 
     // Skapa slutfaktura via billing-run (acconto-körningen dras av).
     const result = await state.caller.billingRun.createFinal({
@@ -354,7 +355,7 @@ describe("Scenario: civilmål (bostadsrättstvist) på löpande räkning", () =>
     const inv = await state.caller.invoice.getById({ id: state.finalInvoiceId! });
     // billing-run: invoice.amount är redan NETTO (acconto avräknat) → klienten
     // betalar hela beloppet och fakturan blir PAID (inget separat avdrag i ledgern).
-    expect(inv.amount).toBe(2_243_750);
+    expect(inv.amount).toBe(3_165_625);
 
     const pay = await state.caller.invoice.recordPayment({
       invoiceId: state.finalInvoiceId!,
@@ -362,8 +363,8 @@ describe("Scenario: civilmål (bostadsrättstvist) på löpande räkning", () =>
       paidAt: D.slutPayment.toISOString(),
       note: "Bankgiro — slutbetalning (netto efter acconto-avräkning)",
     });
-    expect(pay.payment.amount).toBe(2_243_750);
-    expect(pay.paidSum).toBe(2_243_750);
+    expect(pay.payment.amount).toBe(3_165_625);
+    expect(pay.paidSum).toBe(3_165_625);
     expect(pay.settled).toBe(true);
 
     const after = await state.caller.invoice.getById({ id: state.finalInvoiceId! });
@@ -380,12 +381,12 @@ describe("Scenario: civilmål (bostadsrättstvist) på löpande räkning", () =>
     const acconto = invoices.find((i) => i.invoiceType === "ACCONTO");
     const final = invoices.find((i) => i.invoiceType === "FINAL");
     expect(acconto?.amount).toBe(1_500_000);
-    // billing-run: FINAL-beloppet är NETTO (brutto 3 743 750 − acconto 1 500 000).
-    expect(final?.amount).toBe(2_243_750);
+    // billing-run: FINAL-beloppet är NETTO (brutto 4 665 625 − acconto 1 500 000).
+    expect(final?.amount).toBe(3_165_625);
 
-    // Total fakturerat klient = acconto (15 000) + netto-slutfaktura (22 437,50)
-    // = 37 437,50 kr = brutto-arbetet. Ingen dubbelräkning.
+    // Total fakturerat klient = acconto (15 000) + netto-slutfaktura (31 656,25)
+    // = 46 656,25 kr = brutto-arbetet (arvode inkl moms + utlägg). Ingen dubbelräkning.
     const totalBilled = (acconto!.amount) + (final!.amount);
-    expect(totalBilled).toBe(3_743_750);
+    expect(totalBilled).toBe(4_665_625);
   });
 });

--- a/test/integration/scenario-rattshjalp.test.ts
+++ b/test/integration/scenario-rattshjalp.test.ts
@@ -34,6 +34,7 @@ import {
   TAXA_MAX_MINUTES,
 } from "@/lib/shared/brottmalstaxa";
 import { prebakeJoins } from "@/lib/shared/demo-source";
+import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
 
 const ORG_ID = "firma-ab";
 const ADMIN_USER = {
@@ -282,9 +283,11 @@ describe("Scenario: komplext brottmål — offentlig försvarare men EJ taxemål
       (s, t) => s + Math.round((t.minutes * TIMKOSTNADSNORM_FTAX_ORE_PER_H) / 60), 0,
     );
     expect(expectedTime).toBe(8_279_050);
+    // Alla fakturor lägger på 25 % moms på arvodet (#782); utlägg 28 650 öre brutto.
     // Inget acconto-avdrag → fakturabeloppet (netto) = brutto; run bär brutto-värdet.
-    expect(r.run.workValueOreAtRun).toBe(expectedTime + 28_650);
-    expect(r.invoice.amount).toBe(expectedTime + 28_650);
+    const expectedGross = arvodeInclVatOre(expectedTime) + 28_650;
+    expect(r.run.workValueOreAtRun).toBe(expectedGross);
+    expect(r.invoice.amount).toBe(expectedGross);
     state.invoiceId = r.invoice.id;
   });
 

--- a/test/unit/lib/invoice-calc.test.ts
+++ b/test/unit/lib/invoice-calc.test.ts
@@ -7,14 +7,15 @@ import {
 } from "@/lib/shared/invoice-calc";
 
 describe("computeFinalInvoiceBreakdown", () => {
-  it("räknar time × rate / 60 per post", () => {
+  it("räknar time × rate / 60 per post + 25 % moms på arvodet (#782)", () => {
     const r = computeFinalInvoiceBreakdown(
-      [{ minutes: 90, hourlyRate: 150_000 }], // 1,5 tim × 1500 kr = 2250 kr
+      [{ minutes: 90, hourlyRate: 150_000 }], // 1,5 tim × 1500 kr = 2250 kr exkl
       [],
       [],
     );
-    expect(r.grossAmount).toBe(225_000);
-    expect(r.netAmount).toBe(225_000);
+    expect(r.grossAmount).toBe(281_250); // 2250 kr + 25 % moms
+    expect(r.arvodeVatOre).toBe(56_250);
+    expect(r.netAmount).toBe(281_250);
   });
 
   it("utelämnar icke-debiterbara utlägg", () => {
@@ -38,9 +39,10 @@ describe("computeFinalInvoiceBreakdown", () => {
         { id: "acc2", amount: 300_000 }, // 3000 kr
       ],
     );
-    expect(r.grossAmount).toBe(1_500_000);
+    expect(r.grossAmount).toBe(1_875_000); // 15 000 kr + 25 % moms
+    expect(r.arvodeVatOre).toBe(375_000);
     expect(r.accontoDeductionTotal).toBe(800_000);
-    expect(r.netAmount).toBe(700_000);
+    expect(r.netAmount).toBe(1_075_000);
     expect(r.deductions).toHaveLength(2);
   });
 
@@ -58,6 +60,7 @@ describe("computeFinalInvoiceBreakdown", () => {
     const r = computeFinalInvoiceBreakdown([], [], []);
     expect(r).toEqual({
       grossAmount: 0,
+      arvodeVatOre: 0,
       accontoDeductionTotal: 0,
       netAmount: 0,
       deductions: [],

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -100,7 +100,7 @@ describe("billingRun.createFinal", () => {
       matterId: "m-1", recipient: "KLIENT",
     });
     expect(res.run.type).toBe("FINAL");
-    expect(res.run.amountOre).toBe(250000 + 12500); // 1h × 2500 + 125 = 2625 kr
+    expect(res.run.amountOre).toBe(312500 + 12500); // 1h × 2500 + 25 % moms + 125 utlägg (#782)
     const te = await ds.timeEntries.findFirst({ where: { id: "te-1" } }) as { frozenAt?: Date | null; frozenByBillingRunId?: string | null };
     expect(te.frozenAt).toBeInstanceOf(Date);
     expect(te.frozenByBillingRunId).toBe(res.run.id);
@@ -136,14 +136,14 @@ describe("billingRun.createFinal", () => {
     const nb = await ds.timeEntries.findFirst({ where: { id: "te-nb" } }) as { invoiceId?: string | null; frozenAt?: Date | null };
     expect(nb.invoiceId).toBeFalsy(); // ej fakturerad
     expect(nb.frozenAt).toBeInstanceOf(Date); // men ändå fryst (med i körningen)
-    expect(res.run.amountOre).toBe(250000); // bara debiterbar tid räknas
+    expect(res.run.amountOre).toBe(312500); // bara debiterbar tid räknas (arvode inkl 25 % moms, #782)
   });
 
   it("per-post-val: fakturerar ENBART valda poster, lämnar resten ofryst (#734)", async () => {
     const { ds, caller } = makeCaller({ workMinutes: 60, expenseOre: 5000 }); // te-1 (2500kr) + ex-1 (50kr)
     await ds.timeEntries.create({ data: { id: asId<"TimeEntryId">("te-2"), organizationId: "org-1", userId: asId<"UserId">("u-1"), matterId: asId<"MatterId">("m-1"), date: new Date(), minutes: 60, description: "B", hourlyRate: 250000, billable: true } });
     const res = await caller.billingRun.createFinal({ matterId: "m-1", recipient: "KLIENT", timeEntryIds: ["te-1"], expenseIds: [] });
-    expect(res.invoice.amount).toBe(250000); // bara te-1, inget utlägg
+    expect(res.invoice.amount).toBe(312500); // bara te-1 (arvode inkl 25 % moms), inget utlägg
     const t1 = await ds.timeEntries.findFirst({ where: { id: "te-1" } }) as { invoiceId?: string | null; frozenAt?: Date | null };
     const t2 = await ds.timeEntries.findFirst({ where: { id: "te-2" } }) as { invoiceId?: string | null; frozenAt?: Date | null };
     const e1 = await ds.expenses.findFirst({ where: { id: "ex-1" } }) as { frozenAt?: Date | null };
@@ -164,7 +164,7 @@ describe("billingRun.createFinal", () => {
   it("utan per-post-val → fakturerar allt ofryst (default oförändrat)", async () => {
     const { ds, caller } = makeCaller({ workMinutes: 60, expenseOre: 5000 });
     const res = await caller.billingRun.createFinal({ matterId: "m-1", recipient: "KLIENT" });
-    expect(res.invoice.amount).toBe(250000 + 5000);
+    expect(res.invoice.amount).toBe(312500 + 5000); // arvode inkl 25 % moms + utlägg (#782)
     const t1 = await ds.timeEntries.findFirst({ where: { id: "te-1" } }) as { frozenAt?: Date | null };
     expect(t1.frozenAt).toBeInstanceOf(Date);
   });
@@ -178,8 +178,8 @@ describe("billingRun.createFinal", () => {
       matterId: "m-1", recipient: "FORSAKRING",
       deductedBillingRunIds: [acc.run.id],
     });
-    // 500000 - 100000 = 400000
-    expect(fin.run.amountOre).toBe(400000);
+    // arvode 5000 kr + 25 % moms = 625000 öre, − acconto 100000 = 525000 (#782)
+    expect(fin.run.amountOre).toBe(525000);
     expect(fin.run.deductedBillingRunIds).toEqual([acc.run.id]);
     // Acconto-avdraget materialiseras så slutfaktura-vyns "att betala" stämmer.
     const ded = await ds.accontoDeductions.findFirst({ where: { finalInvoiceId: fin.invoice.id } }) as { accontoInvoiceId?: string } | null;
@@ -202,7 +202,7 @@ describe("billingRun.createKostnadsrakning", () => {
     expect(res.run.type).toBe("KOSTNADSRAKNING");
     expect(res.run.status).toBe("PENDING_VERDICT");
     expect(res.run.invoiceId).toBeFalsy();
-    expect(res.run.workValueOreAtRun).toBe(750000); // 3h × 2500 kr
+    expect(res.run.workValueOreAtRun).toBe(937500); // 3h × 2500 kr + 25 % moms (#782)
   });
 
   it("fryser INTE rader (väntar tills setVerdict)", async () => {
@@ -246,7 +246,7 @@ describe("billingRun.setVerdict", () => {
     const res = await caller.billingRun.setVerdict({
       billingRunId: kr.run.id, prutningOre: -100000,
     });
-    expect(res.invoice.amount).toBe(400000); // 500 - 100
+    expect(res.invoice.amount).toBe(525000); // arvode 5000 kr + moms = 625000, − prutning 1000 = 525000 (#782)
   });
 
   it("LÄNKAR poster + PRUTNING till fakturan → vyn reconciler mot beloppet (#732)", async () => {
@@ -259,8 +259,8 @@ describe("billingRun.setVerdict", () => {
     expect(te.invoiceId).toBe(res.invoice.id); // arvode länkad
     expect(ex.invoiceId).toBe(res.invoice.id); // utlägg länkad
     expect(prut.invoiceId).toBe(res.invoice.id); // PRUTNING länkad (reducerar totalen)
-    // Summa länkade poster = arvode 5000 + utlägg 50 − prutning 300 = invoice 4750 kr.
-    expect(res.invoice.amount).toBe(500000 + 5000 - 30000);
+    // Arvode 5000 kr + 25 % moms = 625000, + utlägg 50 kr − prutning 300 kr (#782).
+    expect(res.invoice.amount).toBe(625000 + 5000 - 30000);
   });
 
   it("DOMSTOL-faktura får inget fakturanummer (ADR 0012)", async () => {


### PR DESCRIPTION
**Steg 1 av netto-lagringsmodellen (#782).** Du beslutade: alla fakturor lägger på 25 % moms på arvodet oavsett mottagare.

## Vad
Tidigare summerade FINAL-/kostnadsräknings-fakturan bara `timmar × timpris` **utan moms på arvodet** (under-debitering), medan kostnadsräkningens PDF redan la på 25 %. Nu lägger **alla** fakturatyper på 25 % moms på arvodet (timpris = exkl. moms).

- Ny delad helper `arvodeInclVatOre()` i `invoice-calc` (DRY — routern och `computeFinalInvoiceBreakdown` använder samma).
- `billingRun`: `invoiceGrossOre()` = arvode inkl. moms + utlägg; `createFinal` / `createKostnadsrakning` / `setVerdict` sätter bruttobeloppet. `workValueOre` (netto) behålls som bas för acconto-förslag och "upparbetat ofakturerat".
- Faktura-underlaget (specifikationen) visar arvode (exkl), en **moms-rad** och en summa som nu reconciler mot fakturabeloppet.

## Effekt
FINAL-fakturornas arvodesdel ökar 25 % mot tidigare (rättar under-debiteringen). Bokföringsverifikatet (`semantic-voucher`, split @25 % incl) blir korrekt för arvodesmomsen.

## Verifierat
- `tsc` (root+test) rent, ESLint rent.
- Berörda sviter gröna: `invoice-calc`, `billingRun`, scenario civilmål/brottmål/rättshjälp, kostnadsräkning, invoice-detaljsidan (alla belopp omräknade till de nya, verifierade värdena). Full svit: oförändrad baslinje (endast miljöberoende helper/CORS-fel kvar).
- `build:demo` OK.

## Nästa steg i #782
Utläggens netto-lagring (migrera brutto→netto) + invoice `vatOre`-fält / härledd bruttototal för exakt per-sats-bokföring + `<Money basis>` gross→net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)