### PR TITLE
feat(billing): lagra utlägg netto (exkl moms) + grossa upp vid fakturering (#782)

### DIFF
--- a/src/app/invoices/[id]/_client.tsx
+++ b/src/app/invoices/[id]/_client.tsx
@@ -18,6 +18,7 @@ import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { computeMatterSettlement, computeRadgivningsavgift, type MatterSettlement } from "@/lib/shared/rattshjalp";
 import { asId } from "@/lib/shared/schemas/ids";
+import { splitVat } from "@/lib/shared/vat";
 import { computeInvoiceLedger } from "@/lib/shared/write-off-calc";
 import { CreditModal } from "./_credit-modal";
 import { DispatchHistory } from "./_dispatch-history";
@@ -484,8 +485,11 @@ function InvoiceDocumentsCard({ documents }: { documents: InvoiceDocRow[] }) {
 function SpecificationCard({ timeEntries, expenses }: { timeEntries: SpecTimeRow[]; expenses: SpecExpenseRow[] }) {
   if (timeEntries.length === 0 && expenses.length === 0) return null;
   const lineFor = (t: SpecTimeRow) => Math.round((t.minutes / 60) * (t.hourlyRate ?? 0));
+  // Utlägg lagras netto (#782) → räkna fram brutto (inkl moms) för det fakturerade.
+  const expenseInclOf = (e: SpecExpenseRow) =>
+    splitVat({ amount: e.amount, vatRate: e.vatRate ?? 2500, vatIncluded: e.vatIncluded ?? false }).inclVat;
   const timeTotal = timeEntries.reduce((s, t) => s + lineFor(t), 0);
-  const expenseTotal = expenses.reduce((s, e) => s + e.amount, 0);
+  const expenseTotal = expenses.reduce((s, e) => s + expenseInclOf(e), 0);
   // Arvode lagras exkl. moms; alla fakturor lägger på 25 % moms på arvodet (#782).
   const arvodeMomsOre = arvodeInclVatOre(timeTotal) - timeTotal;
   const summaUnderlag = arvodeInclVatOre(timeTotal) + expenseTotal;
@@ -532,7 +536,7 @@ function SpecificationCard({ timeEntries, expenses }: { timeEntries: SpecTimeRow
                 <tr key={e.id}>
                   <td className="py-1.5 whitespace-nowrap">{new Date(e.date).toLocaleDateString("sv-SE")}</td>
                   <td className="py-1.5">{e.description}</td>
-                  <td className="py-1.5 text-right"><Money ore={e.amount} basis="gross" className="font-mono" /></td>
+                  <td className="py-1.5 text-right"><Money ore={expenseInclOf(e)} basis="gross" className="font-mono" /></td>
                 </tr>
               ))}
             </tbody>

--- a/src/app/matters/[id]/_expense-section.tsx
+++ b/src/app/matters/[id]/_expense-section.tsx
@@ -66,18 +66,15 @@ function payloadOf(f: ExpenseForm): {
   vatRate: VatRate;
   vatIncluded: boolean;
 } {
-  // Advokaten matar in exkl. moms; AVA lägger på momsen. Lagring hålls
-  // tillsvidare som brutto (vatIncluded=true) så billing/verifikat är
-  // oförändrade — lagringen flippas till netto i #782.
-  const netOre = Math.round(f.amount * 100);
-  const grossOre = splitVat({ amount: netOre, vatRate: f.vatRate, vatIncluded: false }).inclVat;
+  // Advokaten matar in exkl. moms; utlägg lagras netto (#782) och AVA lägger
+  // på momsen vid fakturering.
   return {
     date: f.date,
-    amount: grossOre,
+    amount: Math.round(f.amount * 100),
     description: f.description,
     billable: f.billable,
     vatRate: f.vatRate,
-    vatIncluded: true,
+    vatIncluded: false,
   };
 }
 

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -178,7 +178,8 @@ export const expenses = pgTable("expenses", {
   billable: boolDefault("billable", true),
   invoiceId: uuid("invoice_id").$type<InvoiceId>(),
   vatRate: integer("vat_rate").notNull().default(2500),
-  vatIncluded: boolDefault("vat_included", true),
+  // Utlägg lagras netto (exkl moms) — AVA lägger på momsen (#782).
+  vatIncluded: boolDefault("vat_included", false),
   kind: text("kind").notNull().default("EXPENSE").$type<ExpenseKind>(),
   frozenAt: timestamp("frozen_at", { withTimezone: true }),
   frozenByBillingRunId: uuid("frozen_by_billing_run_id").$type<BillingRunId>(),

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -36,13 +36,14 @@ import {
   type OrganizationId,
   type TimeEntryId,
 } from "@/lib/shared/schemas/ids";
+import { splitVat, DEFAULT_VAT_RATE } from "@/lib/shared/vat";
 import { emit } from "../events/emit";
 import type { Repositories } from "../repositories/repositories";
 import { router, orgProcedure } from "../trpc";
 
 interface UnfrozenWork {
   timeEntries: Array<{ id: TimeEntryId; minutes: number; hourlyRate: number; billable: boolean }>;
-  expenses: Array<{ id: ExpenseId; amount: number; billable: boolean }>;
+  expenses: Array<{ id: ExpenseId; amount: number; billable: boolean; vatRate?: number | null; vatIncluded?: boolean | null }>;
 }
 
 /** En itemiserad rad i fakturaförslaget (#397) — tidspost med beräknat värde. */
@@ -88,17 +89,26 @@ function arvodeNetOre(work: UnfrozenWork): number {
     .reduce((sum, t) => sum + timeEntryValueOre(t.minutes, t.hourlyRate), 0);
 }
 
-/** Debiterbara utlägg (brutto idag — netto-lagring kommer i senare #782-steg). */
-function expenseGrossOre(work: UnfrozenWork): number {
-  return work.expenses
-    .filter((e) => e.billable)
-    .reduce((sum, e) => sum + e.amount, 0);
+/** Ett utläggs moms-split (#782). Utlägg lagras netto (vatIncluded=false); äldre
+ *  brutto-rader (vatIncluded=true) hanteras via flaggan så bruttot bevaras. */
+function expenseSplit(e: { amount: number; vatRate?: number | null; vatIncluded?: boolean | null }) {
+  return splitVat({ amount: e.amount, vatRate: e.vatRate ?? DEFAULT_VAT_RATE, vatIncluded: e.vatIncluded ?? false });
 }
 
-/** Nettovärde på arbetet: arvode (exkl moms) + utlägg. Bas för acconto-förslag
- *  och "upparbetat ofakturerat" — INTE fakturabeloppet (se invoiceGrossOre). */
+/** Debiterbara utlägg, netto (exkl. moms). */
+function expenseNetOre(work: UnfrozenWork): number {
+  return work.expenses.filter((e) => e.billable).reduce((sum, e) => sum + expenseSplit(e).exclVat, 0);
+}
+
+/** Debiterbara utlägg, brutto (inkl. moms) — det klienten/domstolen betalar. */
+function expenseGrossOre(work: UnfrozenWork): number {
+  return work.expenses.filter((e) => e.billable).reduce((sum, e) => sum + expenseSplit(e).inclVat, 0);
+}
+
+/** Nettovärde på arbetet: arvode (exkl moms) + utlägg (exkl moms). Bas för
+ *  acconto-förslag och "upparbetat ofakturerat" — INTE fakturabeloppet (se invoiceGrossOre). */
 function workValueOre(work: UnfrozenWork): number {
-  return arvodeNetOre(work) + expenseGrossOre(work);
+  return arvodeNetOre(work) + expenseNetOre(work);
 }
 
 /** Fakturans bruttobelopp: arvode + 25 % moms + utlägg. Alla fakturor lägger
@@ -183,7 +193,7 @@ async function resolveFinalWork(
   return {
     work: {
       timeEntries: selTime.map((t) => ({ id: t.id, minutes: t.minutes, hourlyRate: t.user.hourlyRate ?? 0, billable: t.billable })),
-      expenses: selExp.filter((e) => e.kind !== "PRUTNING").map((e) => ({ id: e.id, amount: e.amount, billable: e.billable })),
+      expenses: selExp.filter((e) => e.kind !== "PRUTNING").map((e) => ({ id: e.id, amount: e.amount, billable: e.billable, vatRate: e.vatRate, vatIncluded: e.vatIncluded })),
     },
     selected: true,
   };

--- a/src/lib/server/routers/expense.ts
+++ b/src/lib/server/routers/expense.ts
@@ -44,8 +44,8 @@ export const expenseRouter = router({
         billable: z.boolean().default(true),
         /** Moms-sats i basis points (0/600/1200/2500). Default 25 %. */
         vatRate: z.number().int().nonnegative().max(10000).default(2500),
-        /** True om `amount` är inkl moms (kvitto-fall). Default true. */
-        vatIncluded: z.boolean().default(true),
+        /** True om `amount` är inkl moms. Default false — utlägg lagras netto (#782). */
+        vatIncluded: z.boolean().default(false),
         // Valfria setup-fält (demo-generator/fixtures, ADR 0003).
         id: expenseIdSchema.optional(),
         userId: userIdSchema.optional(),

--- a/src/lib/shared/invoice-calc.ts
+++ b/src/lib/shared/invoice-calc.ts
@@ -10,6 +10,7 @@
  */
 
 import { Temporal } from "@js-temporal/polyfill";
+import { splitVat } from "./vat";
 
 export interface TimeEntryForInvoice {
   minutes: number;
@@ -17,8 +18,12 @@ export interface TimeEntryForInvoice {
 }
 
 export interface ExpenseForInvoice {
-  amount: number; // öre
+  amount: number; // öre (netto om vatIncluded=false, annars brutto)
   billable: boolean;
+  /** Moms-sats i bips. Default 25 %. */
+  vatRate?: number;
+  /** Är `amount` redan inkl moms? Default true (bakåtkompat; netto-rader sätter false). */
+  vatIncluded?: boolean;
 }
 
 export interface AccontoForDeduction {
@@ -72,8 +77,8 @@ export function computeFinalInvoiceBreakdown(
   );
   const expenseTotal = expenses
     .filter((e) => e.billable)
-    .reduce((sum, e) => sum + e.amount, 0);
-  // Arvodet (timmar × timpris) är exkl. moms → lägg på 25 % (#782); utlägg är brutto.
+    .reduce((sum, e) => sum + splitVat({ amount: e.amount, vatRate: e.vatRate ?? 2500, vatIncluded: e.vatIncluded ?? true }).inclVat, 0);
+  // Arvodet (timmar × timpris) är exkl. moms → lägg på 25 % (#782); utlägg är brutto (inkl moms).
   const arvodeInclVat = arvodeInclVatOre(timeTotal);
   const arvodeVatOre = arvodeInclVat - timeTotal;
   const grossAmount = arvodeInclVat + expenseTotal;

--- a/src/lib/shared/schemas/billing.ts
+++ b/src/lib/shared/schemas/billing.ts
@@ -58,17 +58,16 @@ export type TimeEntry = z.infer<typeof timeEntrySchema>;
 /**
  * Expense (Utlägg) — `amount` i öre. Lagras i `expenses/<id>.json`.
  *
- * Moms-modellen:
- *   - `amount` är beloppet som står på kvittot (i öre)
+ * Moms-modellen (#782 — allt lagras exkl. moms):
+ *   - `amount` är beloppet EXKL moms (i öre); AVA lägger på momsen
  *   - `vatRate` i basis points: 0/600/1200/2500 (= 0/6/12/25 %)
- *   - `vatIncluded=true` → `amount` inkluderar redan moms (vanligaste fallet)
- *   - `vatIncluded=false` → `amount` är exkl moms, moms läggs ovanpå
+ *   - `vatIncluded=false` (default) → `amount` är netto, moms läggs ovanpå
+ *   - `vatIncluded=true` → `amount` inkluderar redan moms (äldre rader)
  *
  * `splitVat({amount, vatRate, vatIncluded})` returnerar `{exclVat, vat, inclVat}`
  * deterministiskt. Se `src/shared/vat.ts`.
  *
- * Backwards-compat: gamla rader utan vatRate/vatIncluded ska tolkas som
- * 25 % inkl moms (default-fallet för svenska kvitton). zod-defaults gör jobbet.
+ * Äldre brutto-rader migreras till netto (migration 0006).
  */
 export const expenseSchema = z.object({
   ...baseFields,
@@ -83,8 +82,8 @@ export const expenseSchema = z.object({
   invoiceId: invoiceIdSchema.nullish(),
   /** Moms-sats i basis points (0/600/1200/2500). Default 25 %. */
   vatRate: z.number().int().nonnegative().max(10000).default(2500),
-  /** Är `amount` redan inkl moms? Default true (kvitto-fall). */
-  vatIncluded: z.boolean().default(true),
+  /** Är `amount` redan inkl moms? Default false — utlägg lagras netto (#782). */
+  vatIncluded: z.boolean().default(false),
   /** Skiljer vanligt utlägg (EXPENSE) från PRUTNING (domstols-justering).
    *  PRUTNING har negativt amount, vatRate=0, vatIncluded=false. Default
    *  EXPENSE för bakåtkompatibilitet med befintliga rader. */

--- a/test/unit/app/matters/[id]/page.test.tsx
+++ b/test/unit/app/matters/[id]/page.test.tsx
@@ -367,7 +367,7 @@ describe("MatterDetailPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /^Spara$/i }));
     expect(stubs.createExpense.mutate).toHaveBeenCalled();
     const arg = stubs.createExpense.mutate.mock.calls[0]![0];
-    expect(arg.amount).toBe(18750); // 150 kr exkl. @ 25 % → lagras brutto 187,50 kr (#781)
+    expect(arg.amount).toBe(15000); // 150 kr exkl. → lagras netto 150 kr (#782)
     expect(arg.description).toBe("Domstolsavgift");
   });
 

--- a/test/unit/app/matters/expense-section.test.tsx
+++ b/test/unit/app/matters/expense-section.test.tsx
@@ -99,9 +99,9 @@ describe("ExpenseSection", () => {
     // VatPreview-grenen (amount>0) renderar moms-uppdelningen (exkl-inmatning).
     expect(screen.getByText(/Exkl:.*moms:.*inkl:/)).toBeInTheDocument();
     fireEvent.click(screen.getByText("Spara"));
-    // Inmatat exkl. 150 kr @ 25 % → lagras brutto 187,50 kr (#781).
+    // Inmatat exkl. 150 kr → lagras NETTO 150 kr, vatIncluded=false (#782).
     expect(createMutate).toHaveBeenCalledWith(
-      expect.objectContaining({ matterId: "m1", description: "Parkering", amount: 18750, vatRate: 2500, vatIncluded: true }),
+      expect.objectContaining({ matterId: "m1", description: "Parkering", amount: 15000, vatRate: 2500, vatIncluded: false }),
     );
   });
 

--- a/tooling/db/migrations/0006_expenses_net.sql
+++ b/tooling/db/migrations/0006_expenses_net.sql
@@ -1,0 +1,12 @@
+-- #782: utlägg lagras netto (exkl moms). Konvertera befintliga brutto-rader
+-- (vat_included = true) till netto och behåll per-utlägg momssats. AVA lägger
+-- på momsen vid fakturering. PRUTNING-rader (vat_included redan false, vat_rate 0)
+-- lämnas orörda.
+UPDATE expenses
+SET amount = round(amount::numeric * 10000 / (10000 + vat_rate)),
+    vat_included = false
+WHERE kind = 'EXPENSE' AND vat_included = true AND vat_rate <> 0;
+
+UPDATE expenses
+SET vat_included = false
+WHERE kind = 'EXPENSE' AND vat_included = true AND vat_rate = 0;

--- a/tooling/scripts/seed-data.ts
+++ b/tooling/scripts/seed-data.ts
@@ -379,8 +379,9 @@ function buildTimeEntries(orgId: string, users: UserSeed[]): SeedDataset["timeEn
 function buildExpenses(orgId: string, users: UserSeed[]): SeedDataset["expenses"] {
   const out: SeedDataset["expenses"] = [];
   // expenses
-  // Moms-modellen följer Skatteverket: persontransporter + restaurang 12 %,
-  // myndighetsavgifter 0 %, övrigt 25 %. Kvitto-beloppet är inkl moms.
+  // Moms-modellen följer Skatteverket: persontransporter 6 %, restaurang 12 %,
+  // myndighetsavgifter 0 %, övrigt 25 %. `amount` nedan är kvitto-beloppet inkl
+  // moms — lagras dock NETTO (exkl moms) per #782; AVA lägger på momsen.
   const cats: Array<{ amount: number; description: string; vatRate: number }> = [
     { amount: 12500, description: "Domstolsavgift", vatRate: 0 },         // momsfritt
     { amount: 4500, description: "Tåg Stockholm-Göteborg", vatRate: 600 }, // 6 % persontransport
@@ -401,12 +402,14 @@ function buildExpenses(orgId: string, users: UserSeed[]): SeedDataset["expenses"
       const cat = cats[exSeq % cats.length];
       if (!user || !cat) continue;
       const daysAgo = (exSeq * 3) + 2;
+      // Lagra netto: härled exkl-moms ur kvittots inkl-belopp (#782).
+      const netAmount = cat.vatRate === 0 ? cat.amount : Math.round((cat.amount * 10000) / (10000 + cat.vatRate));
       out.push({
         id: `ex-${String(exSeq).padStart(3, "0")}`,
         organizationId: orgId,
         userId: user.id, matterId: matter.id, date: isoDate(-daysAgo, 12),
-        amount: cat.amount, description: cat.description,
-        vatRate: cat.vatRate, vatIncluded: true,
+        amount: netAmount, description: cat.description,
+        vatRate: cat.vatRate, vatIncluded: false,
         billable: true, invoiceId: null,
         createdAt: isoDate(-daysAgo, 12), updatedAt: isoDate(-daysAgo, 12),
       });


### PR DESCRIPTION
**Steg 2 av netto-lagringsmodellen (#782).** Utlägg lagras nu netto (exkl. moms).

## Vad
- **Lagring netto:** `vatIncluded` default `false` (schema + zod + expense-router); utläggs-entry sparar netto. "Allt lagras exkl. moms" uppnått för utlägg.
- **Grossa upp vid fakturering:** `billingRun.invoiceGrossOre` grossar upp varje utlägg per dess sats (`splitVat`) in i fakturans bruttobelopp, så klienten/domstolen debiteras inkl. moms. `workValueOre`/proposal blir rent netto (arvode exkl + utlägg exkl) — bas för acconto-förslag/"upparbetat".
- **resolveFinalWork** bär nu `vatRate`/`vatIncluded` (annars tappades satsen vid per-post-val → fel moms).
- **Reconciliation:** `computeFinalInvoiceBreakdown` + faktura-underlaget (specifikationen) grossar upp utlägg så raderna summerar till fakturabeloppet.
- **Migration 0006:** konverterar befintliga brutto-utläggsrader → netto (behåller per-utlägg sats; PRUTNING orört). `seed-data` lagrar netto.

## Bakåtkompat
Äldre rader med `vatIncluded=true` (brutto) hanteras fortsatt korrekt via flaggan — `splitVat` bevarar bruttot — så fakturabelopp ändras inte under övergången. Scenario-/billing-tester (som skapar brutto-fixtures) förblir gröna utan omräkning.

## Verifierat
- `tsc` (root+test) rent, ESLint rent.
- Full svit: oförändrad baslinje (3595 pass; endast miljöberoende helper/CORS-fel kvar). `build:demo` OK.

## Kvar i #782
Exakt per-sats momsbokföring i `semantic-voucher` (idag split @25 % incl på totalen — följdpunkt #233) och ev. invoice `vatOre`-fält. Arvodets moms är redan korrekt (steg 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)