### PR TITLE
feat(billing): exakt momsbelopp per faktura (vatOre) + moms-spec på faktura-PDF (#782)

### DIFF
--- a/src/lib/client/kostnadsrakning/generate-faktura-doc.ts
+++ b/src/lib/client/kostnadsrakning/generate-faktura-doc.ts
@@ -40,6 +40,8 @@ export interface FakturaDocMeta {
 export interface FakturaDocInvoice {
   id: InvoiceId;
   amount: number;
+  /** Momsbelopp (öre) i `amount`, exakt per sats (#782). Saknas → 25 %-split. */
+  vatOre?: number | null | undefined;
   invoiceNumber?: string | null | undefined;
   ocrReference?: string | null | undefined;
   invoiceDate?: string | Date | null | undefined;

--- a/src/lib/client/kostnadsrakning/render-faktura-pdf.ts
+++ b/src/lib/client/kostnadsrakning/render-faktura-pdf.ts
@@ -9,10 +9,13 @@
  */
 
 import { formatCurrency } from "@/lib/client/utils";
+import { DEFAULT_VAT_RATE, splitVat } from "@/lib/shared/vat";
 
 export interface FakturaInput {
   invoice: {
-    amount: number; // öre
+    amount: number; // öre (brutto, inkl moms)
+    /** Momsbelopp (öre) i `amount`, exakt per sats (#782). Saknas → 25 %-split. */
+    vatOre?: number | null | undefined;
     invoiceNumber?: string | null | undefined;
     /** Bankgiro-OCR (#182). Null på kostnadsräkningar/CREDIT → raden utelämnas. */
     ocrReference?: string | null | undefined;
@@ -67,10 +70,22 @@ export async function renderFakturaPdf(input: FakturaInput): Promise<Uint8Array>
   drawIdentityLines(line, input);
   y -= 10;
   page.drawLine({ start: { x: M, y }, end: { x: RIGHT, y }, thickness: 0.5, color: rgb(0.7, 0.7, 0.7) });
-  y -= 26;
-  page.drawText("Att betala", { x: M, y, size: 12, font: bold });
-  page.drawText(formatCurrency(input.invoice.amount), { x: RIGHT - 130, y, size: 14, font: bold });
-  y -= 28;
+  y -= 22;
+  // Moms-specifikation: netto + moms + att betala (brutto). Momsen är exakt per
+  // sats när vatOre finns (#782), annars 25 %-split av bruttot.
+  const bruttoOre = input.invoice.amount;
+  const momsOre = input.invoice.vatOre != null
+    ? input.invoice.vatOre
+    : bruttoOre - splitVat({ amount: bruttoOre, vatRate: DEFAULT_VAT_RATE, vatIncluded: true }).exclVat;
+  const amountRow = (label: string, ore: number, opts: { size?: number; b?: boolean } = {}): void => {
+    page.drawText(label, { x: M, y, size: opts.size ?? 10, font: opts.b ? bold : font });
+    page.drawText(formatCurrency(ore), { x: RIGHT - 130, y, size: opts.size ?? 10, font: opts.b ? bold : font });
+    y -= opts.b ? 22 : 16;
+  };
+  amountRow("Belopp exkl. moms", bruttoOre - momsOre);
+  amountRow("Moms", momsOre);
+  amountRow("Att betala (inkl. moms)", bruttoOre, { size: 12, b: true });
+  y -= 6;
   if (input.invoice.ocrReference) line(`OCR-referens: ${input.invoice.ocrReference}`, { size: 11, b: true, gap: 16 });
   line("Belopp enligt domstolens beslut / fakturaunderlag.", { size: 9, gray: true });
 

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -190,6 +190,8 @@ export const invoices = pgTable("invoices", {
   id: uuid("id").primaryKey().$type<InvoiceId>(),
   matterId: uuid("matter_id").notNull().$type<MatterId>(),
   amount: ore("amount").notNull(),
+  // Momsbeloppet i `amount`, exakt per sats vid skapande (#782); netto = amount − vatOre.
+  vatOre: integer("vat_ore"),
   status: text("status").notNull().default("DRAFT").$type<InvoiceStatus>(),
   invoiceType: text("invoice_type").notNull().default("STANDARD").$type<InvoiceType>(),
   invoiceNumber: text("invoice_number"),

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -117,6 +117,15 @@ function invoiceGrossOre(work: UnfrozenWork): number {
   return arvodeInclVatOre(arvodeNetOre(work)) + expenseGrossOre(work);
 }
 
+/** Fakturans exakta momsbelopp (öre) per sats: arvodets moms (25 %) +
+ *  varje utläggs moms (dess sats). Lagras på fakturan för korrekt bokföring (#782). */
+function invoiceVatOre(work: UnfrozenWork): number {
+  const arvodeNet = arvodeNetOre(work);
+  const arvodeVat = arvodeInclVatOre(arvodeNet) - arvodeNet;
+  const expenseVat = work.expenses.filter((e) => e.billable).reduce((sum, e) => sum + expenseSplit(e).vat, 0);
+  return arvodeVat + expenseVat;
+}
+
 /** Bygg ett itemiserat fakturaförslag ur ofrysta tids-/utläggsrader (#397). */
 function buildProposal(
   te: ReadonlyArray<{ id: string; description?: string | null; minutes: number; hourlyRate: number; billable: boolean }>,
@@ -304,8 +313,10 @@ export const billingRunRouter = router({
         // belopp = %-sats × upparbetat − Σ tidigare aconto-fakturor.
         const priorAccontoSumOre = await sumPriorAccontos(tx, input.matterId);
         const proposedOre = proposedAccontoOre(value, input.clientShareBips, priorAccontoSumOre);
+        // Acconto är ett brutto-förskott på arvode (25 % moms ingår, #782).
+        const accontoVatOre = input.amountOre - splitVat({ amount: input.amountOre, vatRate: DEFAULT_VAT_RATE, vatIncluded: true }).exclVat;
         const invoice = await tx.invoices.create({
-          matterId: input.matterId, amount: input.amountOre,
+          matterId: input.matterId, amount: input.amountOre, vatOre: accontoVatOre,
           invoiceType: "ACCONTO", status: "DRAFT",
           ...(await invoiceNumbering(tx, ctx.orgId, input.recipient)),
           ...invoiceMeta(input), notes: input.notes,
@@ -346,7 +357,7 @@ export const billingRunRouter = router({
         const deductionOre = deductedRuns.reduce((sum, r) => sum + (r.amountOre ?? 0), 0);
         const finalAmount = Math.max(0, grossValue - deductionOre);
         const invoice = await tx.invoices.create({
-          matterId: input.matterId, amount: finalAmount,
+          matterId: input.matterId, amount: finalAmount, vatOre: invoiceVatOre(work),
           invoiceType: "FINAL", status: "DRAFT",
           ...(await invoiceNumbering(tx, ctx.orgId, input.recipient)),
           ...invoiceMeta(input), notes: input.notes,

--- a/src/lib/shared/accounting/semantic-voucher.ts
+++ b/src/lib/shared/accounting/semantic-voucher.ts
@@ -47,6 +47,8 @@ export interface SemanticVoucher {
 export interface SemanticVoucherInput {
   /** Brutto i öre (negativt = kreditfaktura). */
   amount: number;
+  /** Exakt momsbelopp i öre (per sats, #782). Saknas på äldre fakturor → 25 %-split. */
+  vatOre?: number | null;
   invoiceDate: Date | string;
   invoiceNumber?: string | null;
 }
@@ -57,16 +59,20 @@ function semanticRow(role: VoucherRole, ore: number, debit: boolean): SemanticVo
 
 /**
  * Bygg ett semantiskt verifikat ur en kundfaktura. Ren funktion, noll I/O.
- * Endast en VAT-sats i taget (default 25 %); flersats-/utläggs-uppdelning
- * läggs till när fakturarader kopplas in (uppföljning på #233).
+ *
+ * Momsen tas exakt från `invoice.vatOre` när den finns (beräknad per sats vid
+ * skapande, #782) — annars faller vi tillbaka på en `vatRate`-split av bruttot
+ * (äldre fakturor / fixtures). Balans garanteras: moms = brutto − netto.
  */
 export function buildSemanticVoucher(
   invoice: SemanticVoucherInput,
   vatRate: VatRate = 2500,
 ): SemanticVoucher {
   const bruttoOre = Math.abs(invoice.amount);
-  const { exclVat } = splitVat({ amount: bruttoOre, vatRate, vatIncluded: true });
-  const momsOre = bruttoOre - exclVat; // balans-säker rest
+  const momsOre = invoice.vatOre != null
+    ? Math.min(Math.abs(invoice.vatOre), bruttoOre)
+    : bruttoOre - splitVat({ amount: bruttoOre, vatRate, vatIncluded: true }).exclVat;
+  const exclVat = bruttoOre - momsOre; // balans-säker rest
   const kundfordranIsDebit = invoice.amount >= 0; // kreditfaktura vänder
 
   const rows = [

--- a/src/lib/shared/schemas/billing.ts
+++ b/src/lib/shared/schemas/billing.ts
@@ -104,6 +104,10 @@ export const invoiceSchema = z.object({
   id: invoiceIdSchema,
   matterId: matterIdSchema,
   amount: z.number().int(),
+  /** Momsbeloppet (öre) i `amount`, exakt beräknat per momssats vid skapande
+   *  (#782). `amount` är brutto ("att betala"); netto = amount − vatOre. Nullish
+   *  på äldre fakturor → bokföring/PDF faller tillbaka på 25 %-split. */
+  vatOre: z.number().int().nullish(),
   status: invoiceStatusSchema.default("DRAFT"),
   invoiceType: invoiceTypeSchema.default("STANDARD"),
   /** Per-byrå löpande fakturanummer (F-YYYY-NNNN), genereras vid skapande.

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -106,6 +106,12 @@ describe("billingRun.createFinal", () => {
     expect(te.frozenByBillingRunId).toBe(res.run.id);
   });
 
+  it("sätter invoice.vatOre = arvodets moms exakt (per sats, #782)", async () => {
+    const { caller } = makeCaller({ workMinutes: 60 }); // arvode 2500 kr netto
+    const res = await caller.billingRun.createFinal({ matterId: "m-1", recipient: "KLIENT" });
+    expect(res.invoice.vatOre).toBe(62500); // 25 % på 250000 öre
+  });
+
   it("tilldelar fakturanummer + OCR (klient) — ADR 0012 (#730)", async () => {
     const { caller } = makeCaller({ workMinutes: 60 });
     const res = await caller.billingRun.createFinal({ matterId: "m-1", recipient: "KLIENT" });

--- a/test/unit/shared/accounting/semantic-voucher.test.ts
+++ b/test/unit/shared/accounting/semantic-voucher.test.ts
@@ -32,6 +32,27 @@ describe("buildSemanticVoucher", () => {
     expect(sum(v.rows, "debit")).toBe(12_500);
   });
 
+  it("använder exakt vatOre när den finns (per-sats, #782) i st.f. 25 %-split", () => {
+    // Blandad faktura: brutto 10 600 öre med EXAKT moms 600 (t.ex. 6 %-utlägg)
+    // — 25 %-split skulle felaktigt ge 2120 moms.
+    const v = buildSemanticVoucher({
+      amount: 10_600,
+      vatOre: 600,
+      invoiceDate: "2026-05-25",
+      invoiceNumber: "F-2026-0050",
+    });
+    expect(byRole(v.rows, "momsUtgaende")).toEqual({ role: "momsUtgaende", debit: 0, credit: 600 });
+    expect(byRole(v.rows, "intaktArvode")).toEqual({ role: "intaktArvode", debit: 0, credit: 10_000 });
+    expect(sum(v.rows, "debit")).toBe(sum(v.rows, "credit"));
+    expect(sum(v.rows, "debit")).toBe(10_600);
+  });
+
+  it("vatOre = 0 (momsfritt) → ingen moms-rad, balanserat", () => {
+    const v = buildSemanticVoucher({ amount: 12_500, vatOre: 0, invoiceDate: "2026-05-25" });
+    expect(v.rows.find((r) => r.role === "momsUtgaende")).toBeUndefined();
+    expect(byRole(v.rows, "intaktArvode").credit).toBe(12_500);
+  });
+
   it("kreditfaktura (negativt belopp) vänder debet/kredit men håller balans", () => {
     const v = buildSemanticVoucher({
       amount: -12_500,

--- a/tooling/db/migrations/0007_invoice_vat_ore.sql
+++ b/tooling/db/migrations/0007_invoice_vat_ore.sql
@@ -1,0 +1,4 @@
+-- #782: exakt momsbelopp per faktura (öre), beräknat per momssats vid skapande.
+-- netto = amount − vat_ore. NULL på äldre fakturor → bokföring/PDF faller tillbaka
+-- på 25 %-split (oförändrat beteende).
+ALTER TABLE invoices ADD COLUMN IF NOT EXISTS vat_ore integer;


### PR DESCRIPTION
**Steg 3 av #782.** Gör momsbokföringen och faktura-PDF:en exakta även vid blandade momssatser.

## Vad
Fakturan bär nu **`invoice.vatOre`** — det exakta momsbeloppet, beräknat **per momssats vid skapande** (arvode 25 % + varje utläggs egen sats). Då blir verifikatet och PDF:en exakta utan att tråckla fakturarader genom SIE-/Fortnox-exporten.

- `invoices.vat_ore` (migration 0007, nullable) + zod. netto = `amount − vatOre`.
- `billingRun`: `createFinal` → `vatOre = arvodets moms + Σ utläggens moms (per sats)`; `createAcconto` → 25 %-andelen av brutto-förskottet.
- `semantic-voucher`: använder exakt `vatOre` när den finns, annars 25 %-split (äldre fakturor/fixtures). Balans bevaras (moms = brutto − netto).
- **Faktura-PDF**: moms-specifikation — *Belopp exkl. moms / Moms / Att betala (inkl. moms)*.

## Bakåtkompat
Äldre fakturor utan `vatOre` faller tillbaka på 25 %-split → oförändrat beteende, alla befintliga voucher/SIE-tester gröna.

## Verifierat
- `tsc` (root+test) rent, ESLint rent.
- Full svit: 3598 pass (baslinje + nya tester: vatOre-exakt voucher, 0 %-momsfritt, createFinal-vatOre); endast miljöberoende helper/CORS-fel kvar. `build:demo` OK.

## Kvar i #782
Per-sats moms-REDOVISNING (separata moms-rader per sats i SIE/verifikat) = #233. Allt klient-/bokföringspåverkande är nu korrekt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)