### PR TITLE
feat(billing): per-sats moms-redovisning i verifikat/SIE/Fortnox (#790)

### DIFF
--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -192,6 +192,8 @@ export const invoices = pgTable("invoices", {
   amount: ore("amount").notNull(),
   // Momsbeloppet i `amount`, exakt per sats vid skapande (#782); netto = amount − vatOre.
   vatOre: integer("vat_ore"),
+  // Moms-uppdelning per sats (#790) — driver per-sats bokföring i verifikat/SIE.
+  vatBreakdown: jsonb("vat_breakdown").$type<Array<{ kind: "arvode" | "utlagg"; vatRate: number; netOre: number; vatOre: number }>>(),
   status: text("status").notNull().default("DRAFT").$type<InvoiceStatus>(),
   invoiceType: text("invoice_type").notNull().default("STANDARD").$type<InvoiceType>(),
   invoiceNumber: text("invoice_number"),

--- a/src/lib/server/integrations/fortnox/schema.ts
+++ b/src/lib/server/integrations/fortnox/schema.ts
@@ -86,6 +86,9 @@ export const fortnoxKontoMappningSchema = z.object({
   intaktArvode: z.string().min(1),
   /** Utgående moms 25 % (kredit), t.ex. 2611. */
   momsUtgaende: z.string().min(1),
+  /** Utgående moms 12 % resp. 6 % (kredit) — vidarefakturerade utlägg (#790), valfria. */
+  momsUtgaende12: z.string().min(1).optional(),
+  momsUtgaende06: z.string().min(1).optional(),
   /** Intäktskonto för vidarefakturerade utlägg (kredit), valfritt. */
   intaktUtlagg: z.string().min(1).optional(),
 });
@@ -108,6 +111,8 @@ export function fortnoxMappingFromLedgerMap(
     kundfordran: map.kundfordran.number,
     intaktArvode: map.intaktArvode.number,
     momsUtgaende: map.momsUtgaende.number,
+    ...(map.momsUtgaende12 ? { momsUtgaende12: map.momsUtgaende12.number } : {}),
+    ...(map.momsUtgaende06 ? { momsUtgaende06: map.momsUtgaende06.number } : {}),
     ...(map.intaktUtlagg ? { intaktUtlagg: map.intaktUtlagg.number } : {}),
   });
 }

--- a/src/lib/server/integrations/fortnox/voucher.ts
+++ b/src/lib/server/integrations/fortnox/voucher.ts
@@ -33,17 +33,18 @@ function oreToSek(ore: number): number {
 
 /** Roll → Fortnox-kontonummer via byråns mappning. Kastar om rollen är omappad. */
 function accountForRole(role: VoucherRole, mapping: FortnoxKontoMappning): string {
-  switch (role) {
-    case "kundfordran":
-      return mapping.kundfordran;
-    case "intaktArvode":
-      return mapping.intaktArvode;
-    case "momsUtgaende":
-      return mapping.momsUtgaende;
-    case "intaktUtlagg":
-      if (!mapping.intaktUtlagg) throw new Error("Rollen 'intaktUtlagg' saknar kontomappning");
-      return mapping.intaktUtlagg;
-  }
+  // Roll→konto-uppslag; de valfria rollerna (utlägg/reducerad moms) är undefined
+  // om byrån inte mappat dem → completeness-gate kastar.
+  const account: string | undefined = {
+    kundfordran: mapping.kundfordran,
+    intaktArvode: mapping.intaktArvode,
+    momsUtgaende: mapping.momsUtgaende,
+    momsUtgaende12: mapping.momsUtgaende12,
+    momsUtgaende06: mapping.momsUtgaende06,
+    intaktUtlagg: mapping.intaktUtlagg,
+  }[role];
+  if (!account) throw new Error(`Rollen '${role}' saknar kontomappning`);
+  return account;
 }
 
 function renderRow(row: SemanticVoucherRow, mapping: FortnoxKontoMappning): FortnoxVoucherRow {

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -16,6 +16,7 @@
  */
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import type { VatBreakdownLine } from "@/lib/shared/accounting/semantic-voucher";
 import { proposedAccontoOre } from "@/lib/shared/billing-proposal";
 import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
 import { ocrFromInvoiceNumber } from "@/lib/shared/ocr-reference";
@@ -124,6 +125,27 @@ function invoiceVatOre(work: UnfrozenWork): number {
   const arvodeVat = arvodeInclVatOre(arvodeNet) - arvodeNet;
   const expenseVat = work.expenses.filter((e) => e.billable).reduce((sum, e) => sum + expenseSplit(e).vat, 0);
   return arvodeVat + expenseVat;
+}
+
+/** Fakturans moms-uppdelning per sats (#790): en arvode-rad (25 %) + en utläggs-
+ *  rad per förekommande momssats. Driver per-sats bokföring i verifikat/SIE. */
+function invoiceVatBreakdown(work: UnfrozenWork): VatBreakdownLine[] {
+  const lines: VatBreakdownLine[] = [];
+  const arvodeNet = arvodeNetOre(work);
+  if (arvodeNet > 0) {
+    lines.push({ kind: "arvode", vatRate: DEFAULT_VAT_RATE, netOre: arvodeNet, vatOre: arvodeInclVatOre(arvodeNet) - arvodeNet });
+  }
+  const byRate = new Map<number, { netOre: number; vatOre: number }>();
+  for (const e of work.expenses.filter((x) => x.billable)) {
+    const rate = e.vatRate ?? DEFAULT_VAT_RATE;
+    const s = expenseSplit(e);
+    const acc = byRate.get(rate) ?? { netOre: 0, vatOre: 0 };
+    byRate.set(rate, { netOre: acc.netOre + s.exclVat, vatOre: acc.vatOre + s.vat });
+  }
+  for (const [vatRate, { netOre, vatOre }] of byRate) {
+    lines.push({ kind: "utlagg", vatRate, netOre, vatOre });
+  }
+  return lines;
 }
 
 /** Bygg ett itemiserat fakturaförslag ur ofrysta tids-/utläggsrader (#397). */
@@ -314,9 +336,11 @@ export const billingRunRouter = router({
         const priorAccontoSumOre = await sumPriorAccontos(tx, input.matterId);
         const proposedOre = proposedAccontoOre(value, input.clientShareBips, priorAccontoSumOre);
         // Acconto är ett brutto-förskott på arvode (25 % moms ingår, #782).
-        const accontoVatOre = input.amountOre - splitVat({ amount: input.amountOre, vatRate: DEFAULT_VAT_RATE, vatIncluded: true }).exclVat;
+        const accontoNetOre = splitVat({ amount: input.amountOre, vatRate: DEFAULT_VAT_RATE, vatIncluded: true }).exclVat;
+        const accontoVatOre = input.amountOre - accontoNetOre;
         const invoice = await tx.invoices.create({
           matterId: input.matterId, amount: input.amountOre, vatOre: accontoVatOre,
+          vatBreakdown: [{ kind: "arvode", vatRate: DEFAULT_VAT_RATE, netOre: accontoNetOre, vatOre: accontoVatOre }],
           invoiceType: "ACCONTO", status: "DRAFT",
           ...(await invoiceNumbering(tx, ctx.orgId, input.recipient)),
           ...invoiceMeta(input), notes: input.notes,
@@ -358,6 +382,7 @@ export const billingRunRouter = router({
         const finalAmount = Math.max(0, grossValue - deductionOre);
         const invoice = await tx.invoices.create({
           matterId: input.matterId, amount: finalAmount, vatOre: invoiceVatOre(work),
+          vatBreakdown: invoiceVatBreakdown(work),
           invoiceType: "FINAL", status: "DRAFT",
           ...(await invoiceNumbering(tx, ctx.orgId, input.recipient)),
           ...invoiceMeta(input), notes: input.notes,

--- a/src/lib/shared/accounting/account-map.ts
+++ b/src/lib/shared/accounting/account-map.ts
@@ -26,7 +26,12 @@ export const ledgerAccountMapSchema = z.object({
   voucherSeries: z.string().min(1),
   kundfordran: ledgerAccountSchema,
   intaktArvode: ledgerAccountSchema,
+  /** Utgående moms 25 %. */
   momsUtgaende: ledgerAccountSchema,
+  /** Utgående moms 12 % resp. 6 % — bara byråer som vidarefakturerar utlägg med
+   *  reducerad moms behöver dem (#790); valfria. */
+  momsUtgaende12: ledgerAccountSchema.optional(),
+  momsUtgaende06: ledgerAccountSchema.optional(),
   intaktUtlagg: ledgerAccountSchema.optional(),
 });
 export type LedgerAccountMap = z.infer<typeof ledgerAccountMapSchema>;
@@ -37,6 +42,8 @@ export const DEFAULT_LEDGER_ACCOUNT_MAP: LedgerAccountMap = {
   kundfordran: { number: "1510", name: "Kundfordringar" },
   intaktArvode: { number: "3041", name: "Advokatarvoden" },
   momsUtgaende: { number: "2611", name: "Utgående moms 25 %" },
+  momsUtgaende12: { number: "2621", name: "Utgående moms 12 %" },
+  momsUtgaende06: { number: "2631", name: "Utgående moms 6 %" },
   intaktUtlagg: { number: "3590", name: "Övriga sidointäkter" },
 };
 
@@ -46,6 +53,8 @@ export function toSieAccountMap(map: LedgerAccountMap): SieAccountMap {
     kundfordran: map.kundfordran,
     intaktArvode: map.intaktArvode,
     momsUtgaende: map.momsUtgaende,
+    ...(map.momsUtgaende12 ? { momsUtgaende12: map.momsUtgaende12 } : {}),
+    ...(map.momsUtgaende06 ? { momsUtgaende06: map.momsUtgaende06 } : {}),
     ...(map.intaktUtlagg ? { intaktUtlagg: map.intaktUtlagg } : {}),
   };
 }

--- a/src/lib/shared/accounting/semantic-voucher.ts
+++ b/src/lib/shared/accounting/semantic-voucher.ts
@@ -21,8 +21,36 @@
 
 import { splitVat, type VatRate } from "@/lib/shared/vat";
 
-/** Bokföringsroller som faktura-domänen känner till (systemoberoende). */
-export type VoucherRole = "kundfordran" | "intaktArvode" | "momsUtgaende" | "intaktUtlagg";
+/** Bokföringsroller som faktura-domänen känner till (systemoberoende).
+ *  Utgående moms är uppdelad per sats (#790) så SIE/verifikat bokför på rätt
+ *  momskonto (25 % → 2611, 12 % → 2612, 6 % → 2613). `momsUtgaende` = 25 %. */
+export type VoucherRole =
+  | "kundfordran"
+  | "intaktArvode"
+  | "intaktUtlagg"
+  | "momsUtgaende"
+  | "momsUtgaende12"
+  | "momsUtgaende06";
+
+/** En rad i fakturans moms-uppdelning per sats (#790). */
+export interface VatBreakdownLine {
+  /** Arvode (alltid 25 %) eller (vidarefakturerat) utlägg (egen sats). */
+  kind: "arvode" | "utlagg";
+  /** Moms-sats i basis points (0/600/1200/2500). */
+  vatRate: number;
+  /** Netto (exkl moms) i öre. */
+  netOre: number;
+  /** Moms i öre. */
+  vatOre: number;
+}
+
+/** Moms-roll för en sats; null = momsfritt (ingen moms-rad). */
+function momsRoleForRate(vatRate: number): VoucherRole | null {
+  if (vatRate >= 2500) return "momsUtgaende";
+  if (vatRate >= 1200) return "momsUtgaende12";
+  if (vatRate >= 600) return "momsUtgaende06";
+  return null;
+}
 
 /** En verifikatrad mot en roll. Exakt EN av debit/credit > 0 (öre, heltal). */
 export interface SemanticVoucherRow {
@@ -49,12 +77,36 @@ export interface SemanticVoucherInput {
   amount: number;
   /** Exakt momsbelopp i öre (per sats, #782). Saknas på äldre fakturor → 25 %-split. */
   vatOre?: number | null;
+  /** Moms-uppdelning per sats (#790). Finns → verifikatet bokför moms per
+   *  momskonto + delar intäkt i arvode/utlägg. Saknas → enkel rad via vatOre. */
+  vatBreakdown?: VatBreakdownLine[] | null;
   invoiceDate: Date | string;
   invoiceNumber?: string | null;
 }
 
 function semanticRow(role: VoucherRole, ore: number, debit: boolean): SemanticVoucherRow {
   return { role, debit: debit ? ore : 0, credit: debit ? 0 : ore };
+}
+
+/** Per-sats-verifikat (#790): intäkt delas arvode/utlägg, moms per momskonto.
+ *  Balans följer av att brutto = Σnetto + Σmoms ur samma breakdown.
+ *  `kundfordranDebit` = positiv faktura (kreditfaktura vänder debet/kredit). */
+function buildPerRateRows(breakdown: VatBreakdownLine[], kundfordranDebit: boolean): SemanticVoucherRow[] {
+  const arvodeNet = breakdown.filter((l) => l.kind === "arvode").reduce((s, l) => s + l.netOre, 0);
+  const utlaggNet = breakdown.filter((l) => l.kind === "utlagg").reduce((s, l) => s + l.netOre, 0);
+  const momsByRole = new Map<VoucherRole, number>();
+  for (const l of breakdown) {
+    const role = momsRoleForRate(l.vatRate);
+    if (role && l.vatOre !== 0) momsByRole.set(role, (momsByRole.get(role) ?? 0) + l.vatOre);
+  }
+  const brutto = arvodeNet + utlaggNet + breakdown.reduce((s, l) => s + l.vatOre, 0);
+  const rows = [
+    semanticRow("kundfordran", brutto, kundfordranDebit),
+    semanticRow("intaktArvode", arvodeNet, !kundfordranDebit),
+    semanticRow("intaktUtlagg", utlaggNet, !kundfordranDebit),
+  ];
+  for (const [role, ore] of momsByRole) rows.push(semanticRow(role, ore, !kundfordranDebit));
+  return rows.filter((r) => r.debit > 0 || r.credit > 0);
 }
 
 /**
@@ -68,22 +120,28 @@ export function buildSemanticVoucher(
   invoice: SemanticVoucherInput,
   vatRate: VatRate = 2500,
 ): SemanticVoucher {
-  const bruttoOre = Math.abs(invoice.amount);
-  const momsOre = invoice.vatOre != null
-    ? Math.min(Math.abs(invoice.vatOre), bruttoOre)
-    : bruttoOre - splitVat({ amount: bruttoOre, vatRate, vatIncluded: true }).exclVat;
-  const exclVat = bruttoOre - momsOre; // balans-säker rest
-  const kundfordranIsDebit = invoice.amount >= 0; // kreditfaktura vänder
-
-  const rows = [
-    semanticRow("kundfordran", bruttoOre, kundfordranIsDebit),
-    semanticRow("intaktArvode", exclVat, !kundfordranIsDebit),
-    semanticRow("momsUtgaende", momsOre, !kundfordranIsDebit),
-  ].filter((r) => r.debit > 0 || r.credit > 0); // släng 0-rader (t.ex. moms vid 0 %)
+  const kundfordranDebit = invoice.amount >= 0; // kreditfaktura vänder debet/kredit
+  const rows = invoice.vatBreakdown && invoice.vatBreakdown.length > 0
+    ? buildPerRateRows(invoice.vatBreakdown, kundfordranDebit)
+    : buildSingleRateRows(invoice, vatRate, kundfordranDebit);
 
   return {
     date: invoice.invoiceDate,
     description: invoice.invoiceNumber ? `Faktura ${invoice.invoiceNumber}` : "Kundfaktura (AVA)",
     rows,
   };
+}
+
+/** Enkel-rads-verifikat (äldre fakturor/fixtures): moms ur vatOre, annars split. */
+function buildSingleRateRows(invoice: SemanticVoucherInput, vatRate: VatRate, kundfordranDebit: boolean): SemanticVoucherRow[] {
+  const bruttoOre = Math.abs(invoice.amount);
+  const momsOre = invoice.vatOre != null
+    ? Math.min(Math.abs(invoice.vatOre), bruttoOre)
+    : bruttoOre - splitVat({ amount: bruttoOre, vatRate, vatIncluded: true }).exclVat;
+  const exclVat = bruttoOre - momsOre; // balans-säker rest
+  return [
+    semanticRow("kundfordran", bruttoOre, kundfordranDebit),
+    semanticRow("intaktArvode", exclVat, !kundfordranDebit),
+    semanticRow("momsUtgaende", momsOre, !kundfordranDebit),
+  ].filter((r) => r.debit > 0 || r.credit > 0); // släng 0-rader (t.ex. moms vid 0 %)
 }

--- a/src/lib/shared/schemas/billing.ts
+++ b/src/lib/shared/schemas/billing.ts
@@ -108,6 +108,14 @@ export const invoiceSchema = z.object({
    *  (#782). `amount` är brutto ("att betala"); netto = amount − vatOre. Nullish
    *  på äldre fakturor → bokföring/PDF faller tillbaka på 25 %-split. */
   vatOre: z.number().int().nullish(),
+  /** Moms-uppdelning per sats (#790) — driver per-sats bokföring i verifikat/SIE.
+   *  En rad per {kind: arvode/utlägg, sats, netto, moms}. Nullish → enkel-rad. */
+  vatBreakdown: z.array(z.object({
+    kind: z.enum(["arvode", "utlagg"]),
+    vatRate: z.number().int().nonnegative().max(10000),
+    netOre: z.number().int(),
+    vatOre: z.number().int(),
+  })).nullish(),
   status: invoiceStatusSchema.default("DRAFT"),
   invoiceType: invoiceTypeSchema.default("STANDARD"),
   /** Per-byrå löpande fakturanummer (F-YYYY-NNNN), genereras vid skapande.

--- a/test/unit/server/integrations/fortnox/schema.test.ts
+++ b/test/unit/server/integrations/fortnox/schema.test.ts
@@ -9,6 +9,8 @@ describe("fortnoxMappingFromLedgerMap", () => {
       kundfordran: "1510",
       intaktArvode: "3041",
       momsUtgaende: "2611",
+      momsUtgaende12: "2621",
+      momsUtgaende06: "2631",
       intaktUtlagg: "3590",
     });
   });

--- a/test/unit/shared/accounting/semantic-voucher.test.ts
+++ b/test/unit/shared/accounting/semantic-voucher.test.ts
@@ -47,6 +47,26 @@ describe("buildSemanticVoucher", () => {
     expect(sum(v.rows, "debit")).toBe(10_600);
   });
 
+  it("per-sats breakdown (#790): moms bokförs per sats + intäkt delas arvode/utlägg", () => {
+    // Arvode 10 000 + 25 % = 2500 moms; utlägg 1000 @ 6 % = 60 moms.
+    const v = buildSemanticVoucher({
+      amount: 13_560,
+      vatBreakdown: [
+        { kind: "arvode", vatRate: 2500, netOre: 10_000, vatOre: 2_500 },
+        { kind: "utlagg", vatRate: 600, netOre: 1_000, vatOre: 60 },
+      ],
+      invoiceDate: "2026-05-25",
+      invoiceNumber: "F-2026-0060",
+    });
+    expect(byRole(v.rows, "kundfordran")).toEqual({ role: "kundfordran", debit: 13_560, credit: 0 });
+    expect(byRole(v.rows, "intaktArvode")).toEqual({ role: "intaktArvode", debit: 0, credit: 10_000 });
+    expect(byRole(v.rows, "intaktUtlagg")).toEqual({ role: "intaktUtlagg", debit: 0, credit: 1_000 });
+    expect(byRole(v.rows, "momsUtgaende")).toEqual({ role: "momsUtgaende", debit: 0, credit: 2_500 });
+    expect(byRole(v.rows, "momsUtgaende06")).toEqual({ role: "momsUtgaende06", debit: 0, credit: 60 });
+    expect(sum(v.rows, "debit")).toBe(sum(v.rows, "credit"));
+    expect(sum(v.rows, "debit")).toBe(13_560);
+  });
+
   it("vatOre = 0 (momsfritt) → ingen moms-rad, balanserat", () => {
     const v = buildSemanticVoucher({ amount: 12_500, vatOre: 0, invoiceDate: "2026-05-25" });
     expect(v.rows.find((r) => r.role === "momsUtgaende")).toBeUndefined();

--- a/test/unit/shared/accounting/sie-from-invoices.test.ts
+++ b/test/unit/shared/accounting/sie-from-invoices.test.ts
@@ -56,9 +56,9 @@ describe("invoicesToSie", () => {
     expect(sie).toContain("   #TRANS 1510 {} -125.00");
   });
 
-  it("DEFAULT_BAS_ACCOUNT_MAP täcker alla fyra roller", () => {
+  it("DEFAULT_BAS_ACCOUNT_MAP täcker alla roller inkl. per-sats moms (#790)", () => {
     expect(Object.keys(DEFAULT_BAS_ACCOUNT_MAP).sort()).toEqual(
-      ["intaktArvode", "intaktUtlagg", "kundfordran", "momsUtgaende"].sort(),
+      ["intaktArvode", "intaktUtlagg", "kundfordran", "momsUtgaende", "momsUtgaende06", "momsUtgaende12"].sort(),
     );
   });
 });

--- a/tooling/db/migrations/0008_invoice_vat_breakdown.sql
+++ b/tooling/db/migrations/0008_invoice_vat_breakdown.sql
@@ -1,0 +1,4 @@
+-- #790: moms-uppdelning per sats på fakturan (driver per-sats bokföring i
+-- verifikat/SIE). En rad per {kind, vatRate, netOre, vatOre}. NULL på äldre
+-- fakturor → bokföring faller tillbaka på enkel-rad (oförändrat beteende).
+ALTER TABLE invoices ADD COLUMN IF NOT EXISTS vat_breakdown jsonb;


### PR DESCRIPTION
Bokför utgående moms **per momssats** i stället för en klumpsumma på 25 %-kontot. (#790 — den korrekta följdissuen; #233 som jag tidigare nämnde är en *stängd* arkitektur-epic, min felreferens.)

## Varför
Utlägg behåller sin egen momssats (6/12/25 %, #782). Tidigare bokförde verifikatet/SIE all moms på 25 %-kontot (2611) → ett 6 %-utläggs moms hamnade fel → fel momsruta hos Skatteverket.

## Vad
- **`invoice.vatBreakdown`** (jsonb, migration 0008): en rad per `{kind: arvode/utlägg, vatRate, netOre, vatOre}`, beräknad vid skapande (`createFinal`/`createAcconto`).
- **`semantic-voucher`**: när breakdown finns → `intaktArvode` + `intaktUtlagg` + en `momsUtgaende`-rad **per sats** (roller `momsUtgaende`/`momsUtgaende12`/`momsUtgaende06`). Annars enkel-rad (äldre fakturor) — balans bevaras öre för öre.
- **`account-map`** + Fortnox-mappning: per-sats momskonton (2611 / 2621 / 2631), valfria.
- SIE-export + Fortnox-renderare mappar de nya rollerna; `accountForRole` refaktorerad till uppslag (komplexitet ≤8).

## Bakåtkompat
Äldre fakturor utan `vatBreakdown` → enkel-rad som förut. Befintliga voucher/SIE-tester gröna (uppdaterade där de hårdkodade roll-uppsättningen).

## Verifierat
- `tsc` (root+test) rent, ESLint rent.
- Full svit: 3599 pass (+ nya tester: per-sats voucher, uppdaterad account-/Fortnox-map). Endast miljöberoende helper/CORS-fel kvar. `build:demo` OK.

Med detta är #782-modellens bokföring **exakt per sats** hela vägen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)