### PR TITLE
feat(fortnox): bifoga faktura-PDF + ärendenummer som titel på konteringen (#785)

### DIFF
--- a/src/lib/server/integrations/fortnox/client.ts
+++ b/src/lib/server/integrations/fortnox/client.ts
@@ -8,6 +8,7 @@
 
 import { refreshTokens, type FetchFn } from "./oauth";
 import {
+  fortnoxInboxResponseSchema,
   fortnoxVoucherResponseSchema,
   type FortnoxConfig,
   type FortnoxVoucher,
@@ -71,17 +72,50 @@ export class FortnoxClient {
     });
   }
 
+  /** POST med 401→forcerad-refresh-och-omförsök. `doPost` bygger requesten per token. */
+  private async withRetry(doPost: (token: string) => Promise<Response>, what: string): Promise<Response> {
+    let res = await doPost(await this.accessToken());
+    if (res.status === 401) res = await doPost(await this.forceRefresh());
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(`Fortnox ${what} ${res.status}: ${detail.slice(0, 300)}`);
+    }
+    return res;
+  }
+
   /** Skapa ett verifikat. Returnerar serie + nummer (för idempotens/spårning). */
   async createVoucher(voucher: FortnoxVoucher): Promise<FortnoxVoucherResponse> {
     const body = { Voucher: toWireVoucher(voucher) };
-    let res = await this.apiPost("/3/vouchers", await this.accessToken(), body);
-    if (res.status === 401) {
-      res = await this.apiPost("/3/vouchers", await this.forceRefresh(), body);
-    }
-    if (!res.ok) {
-      const detail = await res.text().catch(() => "");
-      throw new Error(`Fortnox voucher-fel ${res.status}: ${detail.slice(0, 300)}`);
-    }
+    const res = await this.withRetry((t) => this.apiPost("/3/vouchers", t, body), "voucher-fel");
     return fortnoxVoucherResponseSchema.parse(await res.json());
+  }
+
+  /**
+   * Ladda upp en fil (faktura-PDF) till Fortnox inbox → returnerar fil-id (#785).
+   * Multipart/form-data: vi sätter INTE Content-Type själva så fetch lägger
+   * boundary:n. Wire-detaljer (fältnamn "file", svarsnästling) bekräftas mot
+   * sandbox; isolerat här för enkel justering.
+   */
+  async uploadInboxFile(fileName: string, bytes: Uint8Array, contentType?: string): Promise<string> {
+    const url = new URL("/3/inbox", this.config.apiBase).toString();
+    const type = contentType ?? "application/pdf";
+    const doPost = (token: string): Promise<Response> => {
+      const form = new FormData();
+      // Uint8Array.from → färsk ArrayBuffer-backad vy (undviker SharedArrayBuffer-
+      // ovissheten i BlobPart-typen utan cast).
+      form.append("file", new Blob([Uint8Array.from(bytes)], { type }), fileName);
+      return this.fetchFn(url, { method: "POST", headers: { Authorization: `Bearer ${token}`, Accept: "application/json" }, body: form });
+    };
+    const res = await this.withRetry(doPost, "fil-uppladdning");
+    return fortnoxInboxResponseSchema.parse(await res.json()).File.Id;
+  }
+
+  /**
+   * Koppla en uppladdad fil till ett verifikat (#785). Lagkrav: originalet
+   * (fakturan) ska arkiveras tillsammans med verifikatet.
+   */
+  async connectFileToVoucher(fileId: string, voucherSeries: string, voucherNumber: string): Promise<void> {
+    const body = { VoucherFileConnection: { FileId: fileId, VoucherSeries: voucherSeries, VoucherNumber: voucherNumber } };
+    await this.withRetry((t) => this.apiPost("/3/voucherfileconnections", t, body), "fil-koppling");
   }
 }

--- a/src/lib/server/integrations/fortnox/connector.ts
+++ b/src/lib/server/integrations/fortnox/connector.ts
@@ -17,6 +17,7 @@ import type { SemanticVoucher } from "@/lib/shared/accounting/semantic-voucher";
 import type {
   LedgerCapabilities,
   LedgerConnector,
+  LedgerPushContext,
   PushVoucherResult,
 } from "../ledger/port";
 import type { FortnoxClient } from "./client";
@@ -24,7 +25,7 @@ import type { FortnoxKontoMappning } from "./schema";
 import { renderFortnoxVoucher } from "./voucher";
 
 export interface FortnoxConnectorDeps {
-  client: Pick<FortnoxClient, "createVoucher">;
+  client: Pick<FortnoxClient, "createVoucher" | "uploadInboxFile" | "connectFileToVoucher">;
   /** Byråns roll→konto-mappning (#217), läst ur firma.git. */
   mapping: FortnoxKontoMappning;
 }
@@ -45,9 +46,16 @@ export class FortnoxLedgerConnector implements LedgerConnector {
     return FORTNOX_CAPABILITIES;
   }
 
-  async pushVoucher(voucher: SemanticVoucher): Promise<PushVoucherResult> {
+  async pushVoucher(voucher: SemanticVoucher, ctx?: LedgerPushContext): Promise<PushVoucherResult> {
     const fortnoxVoucher = renderFortnoxVoucher(voucher, this.deps.mapping);
     const resp = await this.deps.client.createVoucher(fortnoxVoucher);
-    return { externalId: `${resp.Voucher.VoucherSeries}/${resp.Voucher.VoucherNumber}` };
+    const series = resp.Voucher.VoucherSeries;
+    const number = String(resp.Voucher.VoucherNumber);
+    // Bifoga faktura-PDF:en till konteringen (#785) — lagkrav att originalet arkiveras.
+    if (ctx?.attachment) {
+      const fileId = await this.deps.client.uploadInboxFile(ctx.attachment.fileName, ctx.attachment.bytes, ctx.attachment.contentType);
+      await this.deps.client.connectFileToVoucher(fileId, series, number);
+    }
+    return { externalId: `${series}/${number}` };
   }
 }

--- a/src/lib/server/integrations/fortnox/schema.ts
+++ b/src/lib/server/integrations/fortnox/schema.ts
@@ -148,3 +148,11 @@ export const fortnoxVoucherResponseSchema = z.object({
   }),
 });
 export type FortnoxVoucherResponse = z.infer<typeof fortnoxVoucherResponseSchema>;
+
+// ─── Filbilaga (#785) ───────────────────────────────────────────────────────
+
+/** Svar från `POST /3/inbox` (fil-uppladdning) — vi behöver fil-id:t (GUID). */
+export const fortnoxInboxResponseSchema = z.object({
+  File: z.object({ Id: z.string().min(1) }).passthrough(),
+});
+export type FortnoxInboxResponse = z.infer<typeof fortnoxInboxResponseSchema>;

--- a/src/lib/server/integrations/fortnox/schema.ts
+++ b/src/lib/server/integrations/fortnox/schema.ts
@@ -155,4 +155,3 @@ export type FortnoxVoucherResponse = z.infer<typeof fortnoxVoucherResponseSchema
 export const fortnoxInboxResponseSchema = z.object({
   File: z.object({ Id: z.string().min(1) }).passthrough(),
 });
-export type FortnoxInboxResponse = z.infer<typeof fortnoxInboxResponseSchema>;

--- a/src/lib/server/integrations/ledger/port.ts
+++ b/src/lib/server/integrations/ledger/port.ts
@@ -42,10 +42,20 @@ export interface LedgerCapabilities {
 
 // ─── Utbound DTO:er (byggs internt) ─────────────────────────────────────────
 
+/** En bilaga att arkivera med verifikatet (t.ex. faktura-PDF, #785). */
+export interface LedgerAttachment {
+  fileName: string;
+  bytes: Uint8Array;
+  /** MIME-typ; default application/pdf hos connectorn. */
+  contentType?: string;
+}
+
 /** Kontext för en verifikat-push (idempotens-nyckel + spårning). */
 export interface LedgerPushContext {
   /** Idempotens-nyckel (t.ex. billingRunId) — connectorn får ej dubbel-bokföra. */
   idempotencyKey: string;
+  /** Bilaga att koppla till verifikatet (faktura-PDF) om connectorn stöder det (#785). */
+  attachment?: LedgerAttachment;
 }
 
 /** Resultat av en verifikat-push — det vi behöver för idempotens/spårning. */

--- a/src/lib/shared/accounting/semantic-voucher.ts
+++ b/src/lib/shared/accounting/semantic-voucher.ts
@@ -82,6 +82,8 @@ export interface SemanticVoucherInput {
   vatBreakdown?: VatBreakdownLine[] | null;
   invoiceDate: Date | string;
   invoiceNumber?: string | null;
+  /** AVA-ärendenummer — skrivs i verifikatets titel/beskrivning (#785). */
+  matterNumber?: string | null;
 }
 
 function semanticRow(role: VoucherRole, ore: number, debit: boolean): SemanticVoucherRow {
@@ -127,9 +129,15 @@ export function buildSemanticVoucher(
 
   return {
     date: invoice.invoiceDate,
-    description: invoice.invoiceNumber ? `Faktura ${invoice.invoiceNumber}` : "Kundfaktura (AVA)",
+    description: voucherDescription(invoice),
     rows,
   };
+}
+
+/** Verifikatets titel: AVA-ärendenumret först (#785), sedan ev. fakturanummer. */
+function voucherDescription(invoice: SemanticVoucherInput): string {
+  const faktura = invoice.invoiceNumber ? `Faktura ${invoice.invoiceNumber}` : "Kundfaktura (AVA)";
+  return invoice.matterNumber ? `Ärende ${invoice.matterNumber} · ${faktura}` : faktura;
 }
 
 /** Enkel-rads-verifikat (äldre fakturor/fixtures): moms ur vatOre, annars split. */

--- a/test/unit/server/integrations/fortnox/client.test.ts
+++ b/test/unit/server/integrations/fortnox/client.test.ts
@@ -111,3 +111,37 @@ describe("FortnoxClient.createVoucher", () => {
     await expect(client.createVoucher(VOUCHER)).rejects.toThrow(/inga tokens/);
   });
 });
+
+describe("FortnoxClient fil-bilaga (#785)", () => {
+  it("uploadInboxFile → POST /3/inbox (multipart) och returnerar fil-id", async () => {
+    let url = ""; let auth = ""; let isForm = false;
+    const fetchFn = (async (u: string | URL | Request, init?: RequestInit) => {
+      url = String(u);
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      auth = headers.Authorization ?? "";
+      isForm = typeof FormData !== "undefined" && init?.body instanceof FormData;
+      return new Response(JSON.stringify({ File: { Id: "guid-9" } }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof globalThis.fetch;
+    const client = new FortnoxClient(config, new InMemoryFortnoxTokenStore(fresh()), fetchFn);
+
+    const id = await client.uploadInboxFile("Faktura.pdf", new Uint8Array([1, 2, 3]));
+    expect(id).toBe("guid-9");
+    expect(url).toBe("https://api.test/3/inbox");
+    expect(auth).toBe("Bearer at-fresh");
+    expect(isForm).toBe(true);
+  });
+
+  it("connectFileToVoucher → POST /3/voucherfileconnections med FileId/serie/nummer", async () => {
+    let url = ""; let body: unknown;
+    const fetchFn = (async (u: string | URL | Request, init?: RequestInit) => {
+      url = String(u);
+      body = typeof init?.body === "string" ? JSON.parse(init.body) : undefined;
+      return new Response(JSON.stringify({}), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof globalThis.fetch;
+    const client = new FortnoxClient(config, new InMemoryFortnoxTokenStore(fresh()), fetchFn);
+
+    await client.connectFileToVoucher("guid-9", "A", "7");
+    expect(url).toBe("https://api.test/3/voucherfileconnections");
+    expect(body).toEqual({ VoucherFileConnection: { FileId: "guid-9", VoucherSeries: "A", VoucherNumber: "7" } });
+  });
+});

--- a/test/unit/server/integrations/fortnox/connector.test.ts
+++ b/test/unit/server/integrations/fortnox/connector.test.ts
@@ -14,13 +14,22 @@ const MAPPING: FortnoxKontoMappning = {
 
 function makeClient() {
   const calls: FortnoxVoucher[] = [];
-  const client: Pick<FortnoxClient, "createVoucher"> = {
+  const uploads: Array<{ fileName: string; size: number }> = [];
+  const connections: Array<{ fileId: string; series: string; number: string }> = [];
+  const client: Pick<FortnoxClient, "createVoucher" | "uploadInboxFile" | "connectFileToVoucher"> = {
     createVoucher: async (v: FortnoxVoucher): Promise<FortnoxVoucherResponse> => {
       calls.push(v);
       return { Voucher: { VoucherSeries: v.VoucherSeries, VoucherNumber: 7 } };
     },
+    uploadInboxFile: async (fileName: string, bytes: Uint8Array): Promise<string> => {
+      uploads.push({ fileName, size: bytes.length });
+      return "file-guid-1";
+    },
+    connectFileToVoucher: async (fileId: string, series: string, number: string): Promise<void> => {
+      connections.push({ fileId, series, number });
+    },
   };
-  return { client, calls };
+  return { client, calls, uploads, connections };
 }
 
 const semantic: SemanticVoucher = {
@@ -62,5 +71,28 @@ describe("FortnoxLedgerConnector", () => {
     expect(byAcct(1510)).toMatchObject({ Debit: 125, Credit: 0 });
     expect(byAcct(3041)).toMatchObject({ Debit: 0, Credit: 100 });
     expect(byAcct(2611)).toMatchObject({ Debit: 0, Credit: 25 });
+  });
+
+  it("bifogar faktura-PDF till konteringen när attachment finns (#785)", async () => {
+    const { client, uploads, connections } = makeClient();
+    const connector = new FortnoxLedgerConnector({ client, mapping: MAPPING });
+
+    const res = await connector.pushVoucher(semantic, {
+      idempotencyKey: "br-1",
+      attachment: { fileName: "Faktura AA2026-0001.pdf", bytes: new Uint8Array([1, 2, 3, 4]) },
+    });
+
+    expect(res).toEqual({ externalId: "A/7" });
+    expect(uploads).toEqual([{ fileName: "Faktura AA2026-0001.pdf", size: 4 }]);
+    // Filen kopplas till det skapade verifikatet (serie/nummer från svaret).
+    expect(connections).toEqual([{ fileId: "file-guid-1", series: "A", number: "7" }]);
+  });
+
+  it("utan attachment laddas ingen fil upp", async () => {
+    const { client, uploads, connections } = makeClient();
+    const connector = new FortnoxLedgerConnector({ client, mapping: MAPPING });
+    await connector.pushVoucher(semantic, { idempotencyKey: "br-1" });
+    expect(uploads).toHaveLength(0);
+    expect(connections).toHaveLength(0);
   });
 });

--- a/test/unit/shared/accounting/semantic-voucher.test.ts
+++ b/test/unit/shared/accounting/semantic-voucher.test.ts
@@ -47,6 +47,11 @@ describe("buildSemanticVoucher", () => {
     expect(sum(v.rows, "debit")).toBe(10_600);
   });
 
+  it("titeln innehåller AVA-ärendenumret när det finns (#785)", () => {
+    const v = buildSemanticVoucher({ amount: 12_500, invoiceDate: "2026-05-25", invoiceNumber: "F-2026-0042", matterNumber: "AA2026-0001" });
+    expect(v.description).toBe("Ärende AA2026-0001 · Faktura F-2026-0042");
+  });
+
   it("per-sats breakdown (#790): moms bokförs per sats + intäkt delas arvode/utlägg", () => {
     // Arvode 10 000 + 25 % = 2500 moms; utlägg 1000 @ 6 % = 60 moms.
     const v = buildSemanticVoucher({


### PR DESCRIPTION
När en AVA-faktura bokförs som verifikat i Fortnox: sätt **AVA-ärendenumret som titel** på konteringen och **bifoga faktura-PDF:en** (lagkrav att originalet arkiveras).

Bygger på den befintliga Fortnox-connectorn (#82). Live-push är ännu inte inkopplad (kräver credentials) — det här gör connectorn *kapabel* + enhetstestad, som resten av #82.

## Vad
- **Titel = ärendenummer:** `semantic-voucher` sätter `description = "Ärende <matterNumber> · Faktura <invoiceNumber>"` när `matterNumber` finns (`SemanticVoucherInput.matterNumber`).
- **PDF-bilaga:** `FortnoxClient.uploadInboxFile` (POST `/3/inbox`, multipart/form-data) + `connectFileToVoucher` (POST `/3/voucherfileconnections` med `{VoucherFileConnection:{FileId, VoucherSeries, VoucherNumber}}`). Gemensam `withRetry` (401→refresh→omförsök).
- **Port:** `LedgerPushContext.attachment` (faktura-PDF) → `FortnoxLedgerConnector.pushVoucher` laddar upp filen och kopplar den till det skapade verifikatet (serie/nummer ur svaret).

## API-källor
Wire-shapes mot Fortnox: inbox-upload + `voucherfileconnections` ([Fortnox – Vouchers best practices](https://www.fortnox.se/developer/guides-and-good-to-know/best-practices/vouchers), [voucher-file-connections](https://developer.fortnox.se/documentation/resources/voucher-file-connections/)). De exakta detaljerna (inbox-fältnamn, svarsnästling) är isolerade i `client.ts` + enhetstestade med injicerad fetch, och bekräftas mot sandbox när live-wiringen kopplas in.

## Verifierat
- `tsc` (root+test) rent, ESLint rent (komplexitet ≤8 — `accountForRole` redan refaktorerad i #790; `withRetry` delas).
- Full svit: 3604 pass (+ nya tester: voucher-titel m. ärendenummer, connector bifogar/ej bifogar, client upload/connect-wire). Endast miljöberoende helper/CORS-fel kvar. `build:demo` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)