### PR TITLE
feat(matter): tak för rättshjälp/rättsskydd + 90 %-varningsbadge (#793)

### DIFF
--- a/src/app/matters/[id]/_client.tsx
+++ b/src/app/matters/[id]/_client.tsx
@@ -4,6 +4,7 @@ import { FileDown } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 import { DocumentBrowser } from "@/components/documents/document-browser";
+import { CoverageCapWarning } from "@/components/matter/coverage-cap-warning";
 import { EventsPanel } from "@/components/matter/events-panel";
 import { PaymentMethodCard } from "@/components/matter/payment-method-card";
 import { SuggestionsPanel } from "@/components/matter/suggestions-panel";
@@ -100,16 +101,30 @@ function MatterPaymentMethod({ matterId, matter }: {
     paymentMethodNote?: string | null | undefined;
     paymentMethodDecidedAt?: Date | string | null | undefined;
     clientShareBips?: number | null | undefined;
+    rattsskyddMaxOre?: number | null | undefined;
+    rattshjalpMaxTimmar?: number | null | undefined;
   };
 }) {
+  const rattsskyddMaxOre = matter.rattsskyddMaxOre ?? null;
+  const rattshjalpMaxTimmar = matter.rattshjalpMaxTimmar ?? null;
   return (
-    <PaymentMethodCard
-      matterId={matterId}
-      paymentMethod={matter.paymentMethod}
-      paymentMethodNote={matter.paymentMethodNote ?? null}
-      paymentMethodDecidedAt={matter.paymentMethodDecidedAt ?? null}
-      clientShareBips={matter.clientShareBips ?? null}
-    />
+    <>
+      <CoverageCapWarning
+        matterId={matterId}
+        paymentMethod={matter.paymentMethod}
+        rattsskyddMaxOre={rattsskyddMaxOre}
+        rattshjalpMaxTimmar={rattshjalpMaxTimmar}
+      />
+      <PaymentMethodCard
+        matterId={matterId}
+        paymentMethod={matter.paymentMethod}
+        paymentMethodNote={matter.paymentMethodNote ?? null}
+        paymentMethodDecidedAt={matter.paymentMethodDecidedAt ?? null}
+        clientShareBips={matter.clientShareBips ?? null}
+        rattsskyddMaxOre={rattsskyddMaxOre}
+        rattshjalpMaxTimmar={rattshjalpMaxTimmar}
+      />
+    </>
   );
 }
 

--- a/src/components/matter/coverage-cap-warning.tsx
+++ b/src/components/matter/coverage-cap-warning.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+/**
+ * Varningsbadge när ett rättshjälps-/rättsskyddsärende närmar sig taket (#793).
+ * Visas vid ≥ 90 % av taket — påminner om att begära utökad rättshjälp / utökat
+ * rättsskydd. Self-gating: renderar null för andra betalningssätt / under taket.
+ */
+
+import { trpc } from "@/lib/client/trpc";
+import { formatCurrency } from "@/lib/client/utils";
+import { coverageStatus, type CoverageStatus } from "@/lib/shared/coverage-cap";
+import type { PaymentMethod } from "@/lib/shared/schemas/enums";
+import type { MatterId } from "@/lib/shared/schemas/ids";
+
+interface Props {
+  matterId: MatterId;
+  paymentMethod: PaymentMethod | null | undefined;
+  rattsskyddMaxOre: number | null;
+  rattshjalpMaxTimmar: number | null;
+}
+
+function usesCap(method: PaymentMethod | null | undefined): boolean {
+  return method === "RATTSSKYDD" || method === "RATTSHJALP";
+}
+
+/** Upparbetat/tak som text (belopp resp. timmar). */
+function usageText(s: CoverageStatus): { used: string; cap: string } {
+  if (s.kind === "amount") return { used: formatCurrency(s.usedOre), cap: formatCurrency(s.capOre) };
+  return { used: `${Math.round((s.usedOre / 60) * 10) / 10} tim`, cap: `${s.capOre / 60} tim` };
+}
+
+export function CoverageCapWarning({ matterId, paymentMethod, rattsskyddMaxOre, rattshjalpMaxTimmar }: Props) {
+  const enabled = usesCap(paymentMethod);
+  const usage = trpc.matter.coverageUsage.useQuery({ matterId }, { enabled });
+  if (!enabled || !usage.data) return null;
+  const status = coverageStatus({
+    method: paymentMethod,
+    rattsskyddMaxOre,
+    rattshjalpMaxTimmar,
+    billableMinutes: usage.data.billableMinutes,
+    billableValueOre: usage.data.billableValueOre,
+  });
+  if (!status || !status.nearCap) return null;
+
+  const { used, cap } = usageText(status);
+  const pct = Math.round(status.ratio * 100);
+  const what = paymentMethod === "RATTSHJALP" ? "utökad rättshjälp" : "utökat rättsskydd";
+  const heading = status.overCap ? `Taket passerat (${pct} %)` : `Närmar sig taket (${pct} %)`;
+  return (
+    <div className="mb-6 rounded-lg border border-amber-300 bg-amber-50 px-4 py-2 text-sm text-amber-900 flex flex-wrap items-center gap-x-2 gap-y-1">
+      <span className="font-semibold">⚠ {heading}</span>
+      <span>{used} av {cap} upparbetat — be om {what}.</span>
+    </div>
+  );
+}

--- a/src/components/matter/payment-method-card.tsx
+++ b/src/components/matter/payment-method-card.tsx
@@ -34,6 +34,10 @@ interface Props {
   paymentMethodDecidedAt: Date | string | null;
   /** Klientens andel i bips (2500 = 25 %); null = ej satt (#778). */
   clientShareBips: number | null;
+  /** Rättsskyddets maxbelopp i öre; null = ej satt (#793). */
+  rattsskyddMaxOre: number | null;
+  /** Rättshjälpens timtak; null → 100 tim (#793). */
+  rattshjalpMaxTimmar: number | null;
 }
 
 /** Betalningssätt där klienten betalar en %-sats → visa/redigera andelen. */
@@ -42,23 +46,35 @@ function usesClientShare(method: PaymentMethod): boolean {
 }
 
 /** Läsvy: nuvarande betalningssätt + kreditrisk-badge + ev. notering/datum. */
+/** Tak-text för läsvyn: belopp (rättsskydd) eller timmar (rättshjälp). */
+function capLabel(method: PaymentMethod, rattsskyddMaxOre: number | null, rattshjalpMaxTimmar: number | null): string | null {
+  if (method === "RATTSSKYDD") return rattsskyddMaxOre != null ? `Tak: ${rattsskyddMaxOre / 100} kr` : "Tak: ej satt";
+  if (method === "RATTSHJALP") return `Tak: ${rattshjalpMaxTimmar ?? 100} tim`;
+  return null;
+}
+
 function PaymentMethodView({
   paymentMethod,
   paymentMethodNote,
   paymentMethodDecidedAt,
   clientShareBips,
+  rattsskyddMaxOre,
+  rattshjalpMaxTimmar,
   onEdit,
 }: {
   paymentMethod: PaymentMethod;
   paymentMethodNote: string | null;
   paymentMethodDecidedAt: Date | string | null;
   clientShareBips: number | null;
+  rattsskyddMaxOre: number | null;
+  rattshjalpMaxTimmar: number | null;
   onEdit: () => void;
 }) {
   const risk = creditRiskFor(paymentMethod);
   const badgeClass = RISK_BADGE[risk];
   const label = PAYMENT_METHOD_LABELS[paymentMethod as keyof typeof PAYMENT_METHOD_LABELS] ?? paymentMethod;
   const showShare = usesClientShare(paymentMethod);
+  const cap = showShare ? capLabel(paymentMethod, rattsskyddMaxOre, rattshjalpMaxTimmar) : null;
   return (
     <div className="bg-white rounded-lg border border-gray-200 p-4">
       <div className="flex items-start justify-between gap-3">
@@ -76,6 +92,11 @@ function PaymentMethodView({
                 Klientens andel: {clientShareBips != null ? `${clientShareBips / 100} %` : "ej satt"}
               </span>
             )}
+            {cap && (
+              <span className="text-xs rounded-full px-2 py-0.5 border border-blue-200 bg-blue-50 text-blue-700">
+                {cap}
+              </span>
+            )}
           </div>
           {paymentMethodNote && <p className="text-sm text-gray-600 mt-1">{paymentMethodNote}</p>}
           {paymentMethodDecidedAt && (
@@ -90,6 +111,42 @@ function PaymentMethodView({
       </div>
     </div>
   );
+}
+
+/** Tak-fältet: rättsskyddets maxbelopp (kr) eller rättshjälpens timtak. */
+function CoverageCapField({ method, value, onChange }: { method: PaymentMethod; value: string; onChange: (v: string) => void }) {
+  const isAmount = method === "RATTSSKYDD";
+  return (
+    <div>
+      <label className="block text-xs font-medium mb-1">
+        {isAmount ? "Försäkringens maxbelopp (kr)" : "Rättshjälpens tak (timmar)"}
+      </label>
+      <input
+        type="text"
+        inputMode="decimal"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={isAmount ? "t.ex. 75000" : "100"}
+        className="w-full border border-gray-300 rounded px-2 py-1.5 text-sm"
+      />
+      <p className="mt-1 text-[11px] text-gray-400">
+        {isAmount
+          ? "Taket ur försäkringsbeslutet. Ärendet varnar vid 90 % av upparbetat värde."
+          : "Rättshjälpslagen: 100 tim (höj vid beviljad utökad rättshjälp). Varnar vid 90 %."}
+      </p>
+    </div>
+  );
+}
+
+/** Visar rätt tak-fält för valt betalningssätt (utbrutet → editor-komplexitet ≤8). */
+function CoverageCapFields({ method, rsMaxKr, setRsMaxKr, rhMaxTim, setRhMaxTim }: {
+  method: PaymentMethod;
+  rsMaxKr: string; setRsMaxKr: (v: string) => void;
+  rhMaxTim: string; setRhMaxTim: (v: string) => void;
+}) {
+  if (method === "RATTSSKYDD") return <CoverageCapField method={method} value={rsMaxKr} onChange={setRsMaxKr} />;
+  if (method === "RATTSHJALP") return <CoverageCapField method={method} value={rhMaxTim} onChange={setRhMaxTim} />;
+  return null;
 }
 
 /** %-andels-fältet (självrisk/avgift). Utbrutet så editorn håller sig ≤100 rader. */
@@ -124,6 +181,9 @@ function PaymentMethodEditor({ matterId, initial, onDone }: { matterId: MatterId
   );
   // %-sats redigeras i procent (bips/100); tomt fält → null. Tillåt komma-decimal.
   const [sharePct, setSharePct] = useState(initial.clientShareBips != null ? String(initial.clientShareBips / 100) : "");
+  // Tak: rättsskydd i kr (öre/100), rättshjälp i timmar. Tomt fält → null.
+  const [rsMaxKr, setRsMaxKr] = useState(initial.rattsskyddMaxOre != null ? String(initial.rattsskyddMaxOre / 100) : "");
+  const [rhMaxTim, setRhMaxTim] = useState(initial.rattshjalpMaxTimmar != null ? String(initial.rattshjalpMaxTimmar) : "");
   const methodId = useId();
   const decidedAtId = useId();
   const noteId = useId();
@@ -157,6 +217,7 @@ function PaymentMethodEditor({ matterId, initial, onDone }: { matterId: MatterId
         {usesClientShare(method) && (
           <ClientShareField id={shareId} value={sharePct} onChange={setSharePct} />
         )}
+        <CoverageCapFields method={method} rsMaxKr={rsMaxKr} setRsMaxKr={setRsMaxKr} rhMaxTim={rhMaxTim} setRhMaxTim={setRhMaxTim} />
         <div>
           <label htmlFor={decidedAtId} className="block text-xs font-medium mb-1">
             Beslutsdatum (om rättshjälp/rättsskydd beviljats)
@@ -195,6 +256,8 @@ function PaymentMethodEditor({ matterId, initial, onDone }: { matterId: MatterId
                 paymentMethodNote: note || null,
                 paymentMethodDecidedAt: decidedAt || null,
                 clientShareBips: clientShareFromPct(sharePct),
+                rattsskyddMaxOre: oreFromKr(rsMaxKr),
+                rattshjalpMaxTimmar: positiveIntOrNull(rhMaxTim),
               })
             }
             className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
@@ -218,6 +281,8 @@ export function PaymentMethodCard(props: Props) {
       paymentMethodNote={props.paymentMethodNote}
       paymentMethodDecidedAt={props.paymentMethodDecidedAt}
       clientShareBips={props.clientShareBips}
+      rattsskyddMaxOre={props.rattsskyddMaxOre}
+      rattshjalpMaxTimmar={props.rattshjalpMaxTimmar}
       onEdit={() => setEditing(true)}
     />
   );
@@ -230,4 +295,22 @@ function clientShareFromPct(pct: string): number | null {
   const n = Number.parseFloat(trimmed);
   if (!Number.isFinite(n) || n < 0 || n > 100) return null;
   return Math.round(n * 100);
+}
+
+/** Kr-textfält → öre (null om tomt/ogiltigt/negativt). Tillåter komma-decimal. */
+function oreFromKr(kr: string): number | null {
+  const trimmed = kr.trim().replace(/\s/g, "").replace(",", ".");
+  if (trimmed === "") return null;
+  const n = Number.parseFloat(trimmed);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return Math.round(n * 100);
+}
+
+/** Heltals-textfält → positivt heltal (null om tomt/ogiltigt/≤0). */
+function positiveIntOrNull(s: string): number | null {
+  const trimmed = s.trim().replace(",", ".");
+  if (trimmed === "") return null;
+  const n = Number.parseFloat(trimmed);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return Math.round(n);
 }

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -118,6 +118,9 @@ export const matters = pgTable("matters", {
   radgivningBetaldAt: timestamp("radgivning_betald_at", { withTimezone: true }),
   /** Klientens andel (självrisk/avgift) i bips — rättsskydd/rättshjälp (#778). */
   clientShareBips: integer("client_share_bips"),
+  /** Rättsskyddets maxbelopp (öre) resp. rättshjälpens timtak — täcknings-tak (#793). */
+  rattsskyddMaxOre: integer("rattsskydd_max_ore"),
+  rattshjalpMaxTimmar: integer("rattshjalp_max_timmar"),
 }, (t) => [index("matters_org_idx").on(t.organizationId)]);
 
 /**

--- a/src/lib/server/repositories/drizzle-time-entry-repository.ts
+++ b/src/lib/server/repositories/drizzle-time-entry-repository.ts
@@ -133,6 +133,20 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
     return rows;
   }
 
+  async coverageUsageForMatter(matterId: MatterId): Promise<{ billableMinutes: number; billableValueOre: number }> {
+    const rows = await this.db
+      .select({ minutes: timeEntries.minutes, hourlyRate: timeEntries.hourlyRate })
+      .from(timeEntries)
+      .where(and(eq(timeEntries.matterId, matterId), eq(timeEntries.billable, true), isNull(timeEntries.deletedAt)));
+    let billableMinutes = 0;
+    let billableValueOre = 0;
+    for (const r of rows) {
+      billableMinutes += r.minutes;
+      billableValueOre += Math.round((r.minutes / 60) * (r.hourlyRate ?? 0));
+    }
+    return { billableMinutes, billableValueOre };
+  }
+
   async listForLawyerInPeriod(
     organizationId: OrganizationId, userId: UserId, from: Date, to: Date,
   ): Promise<LawyerReportTimeEntry[]> {

--- a/src/lib/server/repositories/in-memory-time-entry-repository.ts
+++ b/src/lib/server/repositories/in-memory-time-entry-repository.ts
@@ -105,6 +105,18 @@ export class InMemoryTimeEntryRepository extends InMemoryRepository<TimeEntry> i
     })) as TimeEntry[];
   }
 
+  async coverageUsageForMatter(matterId: MatterId): Promise<{ billableMinutes: number; billableValueOre: number }> {
+    const rows = (await this.delegate.findMany({ where: { matterId } })) as TimeEntry[];
+    let billableMinutes = 0;
+    let billableValueOre = 0;
+    for (const t of rows) {
+      if (!t.billable) continue;
+      billableMinutes += t.minutes;
+      billableValueOre += Math.round((t.minutes / 60) * (t.hourlyRate ?? 0));
+    }
+    return { billableMinutes, billableValueOre };
+  }
+
   async freezeForMatter(matterId: MatterId, billingRunId: BillingRunId, now: Date): Promise<void> {
     await this.delegate.updateMany({
       where: { matterId, frozenByBillingRunId: null },

--- a/src/lib/server/repositories/time-entry-repository.ts
+++ b/src/lib/server/repositories/time-entry-repository.ts
@@ -36,6 +36,14 @@ export interface TimeEntryListResult {
   totalMinutes: number;
 }
 
+/** Upparbetat (debiterbart) i ett ärende — underlag för täcknings-tak (#793). */
+export interface CoverageUsage {
+  /** Summa debiterbara minuter (rättshjälpens 100-tim-tak). */
+  billableMinutes: number;
+  /** Summa debiterbart arvode-värde i öre, exkl moms (rättsskyddets belopps-tak). */
+  billableValueOre: number;
+}
+
 /** Tidspost för tidsrapporten — med jurist + ärende inkl. klient-kontakten (KLIENT). */
 export interface TimeEntryReportRow extends TimeEntry {
   user: { id: UserId; name: string };
@@ -79,6 +87,8 @@ export interface TimeEntryRepository extends Repository<TimeEntry> {
   flagBilled(ids: TimeEntryId[], invoiceId: InvoiceId): Promise<void>;
   /** Ofrysta tidsposter i ett ärende (date asc) — underlag för billing-run. */
   listUnfrozenForMatter(matterId: MatterId): Promise<TimeEntry[]>;
+  /** Summa debiterbara minuter + arvode-värde (öre) i ett ärende — täcknings-tak (#793). */
+  coverageUsageForMatter(matterId: MatterId): Promise<CoverageUsage>;
   /** Frys alla ofrysta tidsposter i ett ärende mot en billing-run (bulk). */
   freezeForMatter(matterId: MatterId, billingRunId: BillingRunId, now: Date): Promise<void>;
   /** Frys ENBART de angivna (ofrysta) tidsposterna mot en billing-run — per-post-val. */

--- a/src/lib/server/routers/matter.ts
+++ b/src/lib/server/routers/matter.ts
@@ -225,6 +225,8 @@ export const matterRouter = router({
         paymentMethodNote: z.string().nullable().optional(),
         paymentMethodDecidedAt: z.string().nullable().optional(),
         clientShareBips: z.number().int().min(0).max(10000).nullable().optional(),
+        rattsskyddMaxOre: z.number().int().nonnegative().nullable().optional(),
+        rattshjalpMaxTimmar: z.number().int().positive().nullable().optional(),
         isTaxeArende: z.boolean().optional(),
         taxaLevel: z.number().int().min(1).max(4).nullable().optional(),
         taxaHuvudforhandlingMin: z.number().int().nonnegative().nullable().optional(),
@@ -251,6 +253,14 @@ export const matterRouter = router({
         if (input.status === "ARCHIVED") await emit.matterArchived(ctx, id);
       }
       return updated;
+    }),
+
+  /** Upparbetat (debiterbart) i ärendet — driver täcknings-takets varningsbadge (#793). */
+  coverageUsage: orgProcedure
+    .input(z.object({ matterId: matterIdSchema }))
+    .query(async ({ ctx, input }) => {
+      await assertMatterInOrg(ctx, input.matterId);
+      return ctx.repos.timeEntries.coverageUsageForMatter(input.matterId);
     }),
 
   addContact: orgProcedure

--- a/src/lib/shared/coverage-cap.ts
+++ b/src/lib/shared/coverage-cap.ts
@@ -1,0 +1,66 @@
+/**
+ * Täcknings-tak för rättshjälp/rättsskydd (#793) — ren logik, ingen I/O.
+ *
+ * Myndigheten/försäkringen betalar bara upp till ett TAK:
+ *   - Rättsskydd: ett BELOPP (försäkringens maxbelopp, ur beslutet).
+ *   - Rättshjälp: 100 TIMMAR (rättshjälpslagen; kan utökas → konfigurerbart).
+ *
+ * När upparbetat arbete når ≥ 90 % av taket ska ärendet varnas (begär utökat
+ * rättsskydd / utökad rättshjälp).
+ */
+
+import type { PaymentMethod } from "./schemas/enums";
+
+/** Tröskel (andel av taket) där ärendet ska varnas. */
+export const COVERAGE_WARN_RATIO = 0.9;
+
+/** Rättshjälpens lagstadgade timtak (default tills utökat). */
+export const DEFAULT_RATTSHJALP_TIMMAR = 100;
+
+export interface CoverageCapInput {
+  method?: PaymentMethod | null | undefined;
+  /** Rättsskyddets maxbelopp i öre (null = ej satt → inget tak att mäta mot). */
+  rattsskyddMaxOre?: number | null;
+  /** Rättshjälpens timtak (null → 100 tim). */
+  rattshjalpMaxTimmar?: number | null;
+  /** Upparbetade debiterbara minuter. */
+  billableMinutes: number;
+  /** Upparbetat debiterbart arvode-värde i öre (exkl moms). */
+  billableValueOre: number;
+}
+
+export interface CoverageStatus {
+  kind: "amount" | "hours";
+  /** Upparbetat (öre för amount, minuter för hours). */
+  usedOre: number;
+  /** Taket (öre för amount, minuter för hours). */
+  capOre: number;
+  /** used / cap (0..∞). */
+  ratio: number;
+  /** ratio ≥ 90 % — visa varning. */
+  nearCap: boolean;
+  /** ratio ≥ 100 % — taket passerat. */
+  overCap: boolean;
+}
+
+/**
+ * Beräknar takstatus för ett ärende, eller `null` när inget tak gäller
+ * (annat betalningssätt, eller rättsskydd utan satt maxbelopp).
+ */
+export function coverageStatus(input: CoverageCapInput): CoverageStatus | null {
+  if (input.method === "RATTSSKYDD") {
+    const capOre = input.rattsskyddMaxOre ?? 0;
+    if (capOre <= 0) return null; // taket okänt tills beloppet matas in
+    return statusOf("amount", input.billableValueOre, capOre);
+  }
+  if (input.method === "RATTSHJALP") {
+    const capMinutes = (input.rattshjalpMaxTimmar ?? DEFAULT_RATTSHJALP_TIMMAR) * 60;
+    return statusOf("hours", input.billableMinutes, capMinutes);
+  }
+  return null;
+}
+
+function statusOf(kind: "amount" | "hours", usedOre: number, capOre: number): CoverageStatus {
+  const ratio = capOre > 0 ? usedOre / capOre : 0;
+  return { kind, usedOre, capOre, ratio, nearCap: ratio >= COVERAGE_WARN_RATIO, overCap: ratio >= 1 };
+}

--- a/src/lib/shared/schemas/matter.ts
+++ b/src/lib/shared/schemas/matter.ts
@@ -38,6 +38,17 @@ export const matterSchema = z.object({
    */
   clientShareBips: z.number().int().min(0).max(10000).nullish(),
   /**
+   * Rättsskyddets maxbelopp i öre (försäkringens tak, ur beslutet). När
+   * upparbetat arvode-värde närmar sig (≥90 %) taket flaggas ärendet (#793).
+   * Null = ej satt.
+   */
+  rattsskyddMaxOre: z.number().int().nonnegative().nullish(),
+  /**
+   * Rättshjälpens timtak (rättshjälpslagen: 100 tim, kan utökas). Null = ej satt;
+   * UI defaultar 100 för rättshjälpsärenden. Vid ≥90 % flaggas ärendet (#793).
+   */
+  rattshjalpMaxTimmar: z.number().int().positive().nullish(),
+  /**
    * `isTaxeArende` — ärendet ersätts enligt Domstolsverkets fastställda
    * taxa (schablon) istället för löpande timdebitering.
    *

--- a/test/unit/app/matters/[id]/page.test.tsx
+++ b/test/unit/app/matters/[id]/page.test.tsx
@@ -51,6 +51,7 @@ vi.mock("@/lib/client/trpc", () => ({
       addNewContact: { useMutation: () => stubs.addNewContact },
       removeContact: { useMutation: () => stubs.removeContact },
       update: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      coverageUsage: { useQuery: () => ({ data: { billableMinutes: 0, billableValueOre: 0 }, isLoading: false }) },
     },
     timeEntry: {
       list: { useQuery: () => timeQuery },

--- a/test/unit/components/payment-method-card.test.tsx
+++ b/test/unit/components/payment-method-card.test.tsx
@@ -37,6 +37,8 @@ describe("PaymentMethodCard", () => {
         paymentMethodNote="Diarienr RH-2026-0217"
         paymentMethodDecidedAt={new Date("2026-03-02")}
         clientShareBips={null}
+        rattsskyddMaxOre={null}
+        rattshjalpMaxTimmar={null}
       />,
     );
     expect(screen.getByText("Rättshjälp")).toBeInTheDocument();
@@ -52,6 +54,8 @@ describe("PaymentMethodCard", () => {
         paymentMethodNote={null}
         paymentMethodDecidedAt={null}
         clientShareBips={null}
+        rattsskyddMaxOre={null}
+        rattshjalpMaxTimmar={null}
       />,
     );
     expect(screen.getByText("Privat betalning")).toBeInTheDocument();
@@ -66,6 +70,8 @@ describe("PaymentMethodCard", () => {
         paymentMethodNote={null}
         paymentMethodDecidedAt={null}
         clientShareBips={null}
+        rattsskyddMaxOre={null}
+        rattshjalpMaxTimmar={null}
       />,
     );
     expect(screen.getByText("Ej fastställt")).toBeInTheDocument();
@@ -80,6 +86,8 @@ describe("PaymentMethodCard", () => {
         paymentMethodNote="Trygg-Hansa"
         paymentMethodDecidedAt={null}
         clientShareBips={null}
+        rattsskyddMaxOre={null}
+        rattshjalpMaxTimmar={null}
       />,
     );
     expect(screen.getByRole("button", { name: /Ändra/i })).toBeInTheDocument();
@@ -93,6 +101,8 @@ describe("PaymentMethodCard", () => {
         paymentMethodNote={null}
         paymentMethodDecidedAt={null}
         clientShareBips={null}
+        rattsskyddMaxOre={null}
+        rattshjalpMaxTimmar={null}
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: /Ändra/i }));
@@ -108,6 +118,8 @@ describe("PaymentMethodCard", () => {
         paymentMethodNote={null}
         paymentMethodDecidedAt={null}
         clientShareBips={null}
+        rattsskyddMaxOre={null}
+        rattshjalpMaxTimmar={null}
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: /Ändra/i }));
@@ -123,6 +135,8 @@ describe("PaymentMethodCard", () => {
         paymentMethodNote={null}
         paymentMethodDecidedAt={null}
         clientShareBips={null}
+        rattsskyddMaxOre={null}
+        rattshjalpMaxTimmar={null}
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: /Ändra/i }));
@@ -148,6 +162,8 @@ describe("PaymentMethodCard", () => {
         paymentMethodNote={null}
         paymentMethodDecidedAt={new Date("2026-04-15")}
         clientShareBips={null}
+        rattsskyddMaxOre={null}
+        rattshjalpMaxTimmar={null}
       />,
     );
     expect(screen.getByText(/Beslut mottaget/)).toBeInTheDocument();
@@ -161,6 +177,8 @@ describe("PaymentMethodCard", () => {
         paymentMethodNote={null}
         paymentMethodDecidedAt={null}
         clientShareBips={2500}
+        rattsskyddMaxOre={null}
+        rattshjalpMaxTimmar={null}
       />,
     );
     expect(screen.getByText(/Klientens andel: 25 %/)).toBeInTheDocument();
@@ -174,6 +192,8 @@ describe("PaymentMethodCard", () => {
         paymentMethodNote={null}
         paymentMethodDecidedAt={null}
         clientShareBips={null}
+        rattsskyddMaxOre={null}
+        rattshjalpMaxTimmar={null}
       />,
     );
     expect(screen.getByText(/Klientens andel: ej satt/)).toBeInTheDocument();
@@ -187,6 +207,8 @@ describe("PaymentMethodCard", () => {
         paymentMethodNote={null}
         paymentMethodDecidedAt={null}
         clientShareBips={2000}
+        rattsskyddMaxOre={null}
+        rattshjalpMaxTimmar={null}
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: /Ändra/i }));
@@ -207,6 +229,8 @@ describe("PaymentMethodCard", () => {
         paymentMethodNote={null}
         paymentMethodDecidedAt={null}
         clientShareBips={2000}
+        rattsskyddMaxOre={null}
+        rattshjalpMaxTimmar={null}
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: /Ändra/i }));

--- a/test/unit/lib/shared/coverage-cap.test.ts
+++ b/test/unit/lib/shared/coverage-cap.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tester för täcknings-takets tröskel-logik (#793): rättsskydd (belopp) vs
+ * rättshjälp (timmar), 90 %-varning, och null när inget tak gäller.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { coverageStatus, DEFAULT_RATTSHJALP_TIMMAR } from "@/lib/shared/coverage-cap";
+
+const base = { rattsskyddMaxOre: null, rattshjalpMaxTimmar: null, billableMinutes: 0, billableValueOre: 0 };
+
+describe("coverageStatus", () => {
+  it("annat betalningssätt → null (inget tak)", () => {
+    expect(coverageStatus({ ...base, method: "PRIVAT", billableValueOre: 999_999 })).toBeNull();
+  });
+
+  it("rättsskydd utan satt maxbelopp → null (taket okänt)", () => {
+    expect(coverageStatus({ ...base, method: "RATTSSKYDD" })).toBeNull();
+  });
+
+  it("rättsskydd: varnar vid ≥ 90 % av beloppstaket", () => {
+    // Tak 100 000 kr, upparbetat 90 000 kr → 90 %.
+    const s = coverageStatus({ ...base, method: "RATTSSKYDD", rattsskyddMaxOre: 10_000_000, billableValueOre: 9_000_000 })!;
+    expect(s.kind).toBe("amount");
+    expect(s.nearCap).toBe(true);
+    expect(s.overCap).toBe(false);
+  });
+
+  it("rättsskydd: under 90 % → ingen varning", () => {
+    const s = coverageStatus({ ...base, method: "RATTSSKYDD", rattsskyddMaxOre: 10_000_000, billableValueOre: 8_000_000 })!;
+    expect(s.nearCap).toBe(false);
+  });
+
+  it("rättshjälp: default 100 tim, varnar vid 90 tim", () => {
+    const s = coverageStatus({ ...base, method: "RATTSHJALP", billableMinutes: 90 * 60 })!;
+    expect(s.kind).toBe("hours");
+    expect(s.capOre).toBe(DEFAULT_RATTSHJALP_TIMMAR * 60);
+    expect(s.nearCap).toBe(true);
+    expect(s.overCap).toBe(false);
+  });
+
+  it("rättshjälp: över taket → overCap", () => {
+    const s = coverageStatus({ ...base, method: "RATTSHJALP", billableMinutes: 105 * 60 })!;
+    expect(s.overCap).toBe(true);
+  });
+
+  it("rättshjälp: utökat tak (150 tim) flyttar varningsgränsen", () => {
+    // 100 tim upparbetat mot 150-tim-tak = 67 % → ingen varning.
+    const s = coverageStatus({ ...base, method: "RATTSHJALP", rattshjalpMaxTimmar: 150, billableMinutes: 100 * 60 })!;
+    expect(s.nearCap).toBe(false);
+  });
+});

--- a/tooling/db/migrations/0009_matter_coverage_cap.sql
+++ b/tooling/db/migrations/0009_matter_coverage_cap.sql
@@ -1,0 +1,4 @@
+-- #793: täcknings-tak för rättsskydd (maxbelopp i öre) resp. rättshjälp (timtak,
+-- default 100 i UI). Driver 90 %-varningsbadgen. NULL = ej satt.
+ALTER TABLE matters ADD COLUMN IF NOT EXISTS rattsskydd_max_ore integer;
+ALTER TABLE matters ADD COLUMN IF NOT EXISTS rattshjalp_max_timmar integer;


### PR DESCRIPTION
Rättshjälp/rättsskydd har ett TAK för hur mycket myndigheten/försäkringen betalar. När ärendets upparbetade arbete når **≥ 90 %** av taket visas en **varningsbadge** som påminner om att begära **utökad rättshjälp / utökat rättsskydd**.

## Tak
- **Rättsskydd:** ett **belopp** (försäkringens maxbelopp, ur beslutet) — mäts mot upparbetat arvode-värde (kr, exkl moms).
- **Rättshjälp:** **100 timmar** (rättshjälpslagen; redigerbart → höj vid beviljad utökning) — mäts mot upparbetade debiterbara timmar.

## Vad
- matter-fält `rattsskyddMaxOre` + `rattshjalpMaxTimmar` (migration 0009) + `matter.update`.
- Ren logik `src/lib/shared/coverage-cap.ts` (`coverageStatus`: belopp vs timmar, 90 %-tröskel, over/nearCap) — enhetstestad.
- Repo: `timeEntries.coverageUsageForMatter` (exakt summa debiterbara minuter + arvode-värde över ALLA poster, ej sidbegränsat).
- `matter.coverageUsage`-query driver `CoverageCapWarning`-badgen på ärendesidan (self-gating, enabled bara för rättshjälp/rättsskydd).
- `PaymentMethodCard`: sätt taket i editorn (belopp/timmar) + visa det som badge i läsvyn.

Default 100 tim för rättshjälp även utan satt värde; rättsskydd kräver satt maxbelopp för att kunna mäta.

## Verifierat
- `tsc` (root+test) rent, ESLint rent (komplexitet ≤8 — bröt ut `CoverageCapFields`/`CoverageCapField`), **knip + dep-cruiser + jscpd** rent (denna gång körda lokalt), full svit 3611 pass (+ nya tester: coverage-cap-logik, payment-card cap-props, page-mock). `build:demo` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)