### PR TITLE
feat(matter): täcknings-tak som sorterbar/filterbar kolumn i ärendelistan (#793)

### DIFF
--- a/src/app/matters/page.tsx
+++ b/src/app/matters/page.tsx
@@ -7,7 +7,8 @@ import { Pager } from "@/components/ui/pager";
 import { useIsReadOnly } from "@/lib/client/demo/demo-mode-context";
 import { EntityLink } from "@/lib/client/demo/entity-link";
 import { trpc } from "@/lib/client/trpc";
-import type { MatterStatus } from "@/lib/shared/schemas/enums";
+import { coverageStatus } from "@/lib/shared/coverage-cap";
+import type { MatterStatus, PaymentMethod } from "@/lib/shared/schemas/enums";
 
 interface MatterRow {
   id: string;
@@ -15,8 +16,49 @@ interface MatterRow {
   title: string;
   status: MatterStatus;
   isTaxeArende?: boolean;
+  paymentMethod?: PaymentMethod | null;
+  rattsskyddMaxOre?: number | null;
+  rattshjalpMaxTimmar?: number | null;
+  coverageUsage?: { billableMinutes: number; billableValueOre: number };
   contacts: Array<{ contact: { name: string } }>;
   _count: { contacts: number };
+}
+
+/** Takstatus för ett listrad-ärende (rättshjälp/-skydd), eller null (#793). */
+function rowCoverage(m: MatterRow) {
+  return coverageStatus({
+    method: m.paymentMethod,
+    rattsskyddMaxOre: m.rattsskyddMaxOre ?? null,
+    rattshjalpMaxTimmar: m.rattshjalpMaxTimmar ?? null,
+    billableMinutes: m.coverageUsage?.billableMinutes ?? 0,
+    billableValueOre: m.coverageUsage?.billableValueOre ?? 0,
+  });
+}
+
+/** Filtrerbar/grupperbar etikett för täcknings-kolumnen. */
+function coverageLabel(m: MatterRow): string {
+  const s = rowCoverage(m);
+  if (!s) return "—";
+  if (s.overCap) return "Över tak";
+  if (s.nearCap) return "Närmar sig tak";
+  return "Inom tak";
+}
+
+/** Badge för täcknings-kolumnen: färgad procent + ⚠ vid ≥ 90 %. */
+function CoverageCell({ m }: { m: MatterRow }) {
+  const s = rowCoverage(m);
+  if (!s) return <span className="text-sm text-gray-400">—</span>;
+  const pct = Math.round(s.ratio * 100);
+  const cls = s.overCap
+    ? "bg-red-50 text-red-700 border-red-200"
+    : s.nearCap
+    ? "bg-amber-50 text-amber-800 border-amber-200"
+    : "bg-gray-50 text-gray-600 border-gray-200";
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs border ${cls}`} title={coverageLabel(m)}>
+      {s.nearCap ? "⚠ " : ""}{pct} %
+    </span>
+  );
 }
 
 function statusLabel(s: string): string {
@@ -62,6 +104,11 @@ const matterColumns: Column<MatterRow>[] = [
   },
   { key: "contactCount", label: "Kontakter", sortable: true, align: "right", sortValue: (m) => m._count.contacts,
     render: (m) => <span className="text-sm text-gray-500">{m._count.contacts}</span> },
+  { key: "coverage", label: "Täckning (tak)", sortable: true, filterable: true, groupable: true,
+    // Sortera ej-tillämpliga sist (negativ kvot); filtrera/gruppera på etiketten.
+    sortValue: (m) => { const s = rowCoverage(m); return s ? s.ratio : -1; },
+    filterValue: coverageLabel, groupValue: coverageLabel,
+    render: (m) => <CoverageCell m={m} /> },
 ];
 
 type StatusFilter = MatterStatus | "";

--- a/src/lib/server/repositories/drizzle-time-entry-repository.ts
+++ b/src/lib/server/repositories/drizzle-time-entry-repository.ts
@@ -147,6 +147,22 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
     return { billableMinutes, billableValueOre };
   }
 
+  async coverageUsageForMatters(matterIds: MatterId[]): Promise<Record<string, { billableMinutes: number; billableValueOre: number }>> {
+    const out: Record<string, { billableMinutes: number; billableValueOre: number }> = {};
+    if (matterIds.length === 0) return out;
+    const rows = await this.db
+      .select({ matterId: timeEntries.matterId, minutes: timeEntries.minutes, hourlyRate: timeEntries.hourlyRate })
+      .from(timeEntries)
+      .where(and(inArray(timeEntries.matterId, matterIds), eq(timeEntries.billable, true), isNull(timeEntries.deletedAt)));
+    for (const r of rows) {
+      const acc = out[r.matterId] ?? { billableMinutes: 0, billableValueOre: 0 };
+      acc.billableMinutes += r.minutes;
+      acc.billableValueOre += Math.round((r.minutes / 60) * (r.hourlyRate ?? 0));
+      out[r.matterId] = acc;
+    }
+    return out;
+  }
+
   async listForLawyerInPeriod(
     organizationId: OrganizationId, userId: UserId, from: Date, to: Date,
   ): Promise<LawyerReportTimeEntry[]> {

--- a/src/lib/server/repositories/in-memory-time-entry-repository.ts
+++ b/src/lib/server/repositories/in-memory-time-entry-repository.ts
@@ -117,6 +117,21 @@ export class InMemoryTimeEntryRepository extends InMemoryRepository<TimeEntry> i
     return { billableMinutes, billableValueOre };
   }
 
+  async coverageUsageForMatters(matterIds: MatterId[]): Promise<Record<string, { billableMinutes: number; billableValueOre: number }>> {
+    const out: Record<string, { billableMinutes: number; billableValueOre: number }> = {};
+    if (matterIds.length === 0) return out;
+    const wanted = new Set<string>(matterIds);
+    const rows = (await this.delegate.findMany({})) as TimeEntry[];
+    for (const t of rows) {
+      if (!t.billable || !wanted.has(t.matterId)) continue;
+      const acc = out[t.matterId] ?? { billableMinutes: 0, billableValueOre: 0 };
+      acc.billableMinutes += t.minutes;
+      acc.billableValueOre += Math.round((t.minutes / 60) * (t.hourlyRate ?? 0));
+      out[t.matterId] = acc;
+    }
+    return out;
+  }
+
   async freezeForMatter(matterId: MatterId, billingRunId: BillingRunId, now: Date): Promise<void> {
     await this.delegate.updateMany({
       where: { matterId, frozenByBillingRunId: null },

--- a/src/lib/server/repositories/time-entry-repository.ts
+++ b/src/lib/server/repositories/time-entry-repository.ts
@@ -89,6 +89,9 @@ export interface TimeEntryRepository extends Repository<TimeEntry> {
   listUnfrozenForMatter(matterId: MatterId): Promise<TimeEntry[]>;
   /** Summa debiterbara minuter + arvode-värde (öre) i ett ärende — täcknings-tak (#793). */
   coverageUsageForMatter(matterId: MatterId): Promise<CoverageUsage>;
+  /** Som ovan men batchat för flera ärenden (täcknings-kolumn i listan, #793).
+   *  Keyas på matterId; ärenden utan poster utelämnas (→ 0 hos anroparen). */
+  coverageUsageForMatters(matterIds: MatterId[]): Promise<Record<string, CoverageUsage>>;
   /** Frys alla ofrysta tidsposter i ett ärende mot en billing-run (bulk). */
   freezeForMatter(matterId: MatterId, billingRunId: BillingRunId, now: Date): Promise<void>;
   /** Frys ENBART de angivna (ofrysta) tidsposterna mot en billing-run — per-post-val. */

--- a/src/lib/server/routers/matter.ts
+++ b/src/lib/server/routers/matter.ts
@@ -180,7 +180,11 @@ export const matterRouter = router({
         page: input.page,
         pageSize: input.pageSize,
       });
-      return { matters, total, pages: Math.ceil(total / input.pageSize) };
+      // Täcknings-tak-kolumn (#793): bifoga upparbetat (debiterbart) per ärende
+      // batchat, så listan kan visa/sortera/filtrera mot rättshjälps-/rättsskyddstaket.
+      const usage = await ctx.repos.timeEntries.coverageUsageForMatters(matters.map((m) => asId<"MatterId">(m.id)));
+      const withUsage = matters.map((m) => ({ ...m, coverageUsage: usage[m.id] ?? { billableMinutes: 0, billableValueOre: 0 } }));
+      return { matters: withUsage, total, pages: Math.ceil(total / input.pageSize) };
     }),
 
   getById: orgProcedure

--- a/test/unit/server/repositories/time-entry-list-report-repository.test.ts
+++ b/test/unit/server/repositories/time-entry-list-report-repository.test.ts
@@ -79,3 +79,31 @@ describe("TimeEntryRepository list/report — Drizzle (pglite)", () => {
     expect(report[0]!.matter?.contacts[0]?.contact.name).toBe("Klient AB");
   });
 });
+
+describe("TimeEntryRepository coverageUsageForMatter(s) — täcknings-tak (#793)", () => {
+  it("in-memory: summerar debiterbara minuter + arvode-värde, batchat per ärende", async () => {
+    const mA = uuidv7(), mB = uuidv7(), userId = uuidv7();
+    const source = prebakeJoins({
+      matters: [
+        { id: mA, organizationId: "org-1", matterNumber: "2026-1", title: "A" },
+        { id: mB, organizationId: "org-1", matterNumber: "2026-2", title: "B" },
+      ],
+      users: [{ id: userId, name: "Anna", hourlyRate: 250000 }],
+      timeEntries: [
+        // mA: 90 min @ 2500 kr/h = 375000 öre (debiterbar) + 60 min ej debiterbar (räknas ej)
+        { id: uuidv7(), userId, matterId: mA, minutes: 90, hourlyRate: 250000, billable: true, date: new Date("2026-06-02") },
+        { id: uuidv7(), userId, matterId: mA, minutes: 60, hourlyRate: 250000, billable: false, date: new Date("2026-06-03") },
+        // mB: 120 min @ 2500 = 500000 öre
+        { id: uuidv7(), userId, matterId: mB, minutes: 120, hourlyRate: 250000, billable: true, date: new Date("2026-06-04") },
+      ],
+    } as DemoSource);
+    const repo = new InMemoryTimeEntryRepository(new LocalStore(source, async () => {}));
+
+    const single = await repo.coverageUsageForMatter(asId<"MatterId">(mA));
+    expect(single).toEqual({ billableMinutes: 90, billableValueOre: 375000 });
+
+    const batch = await repo.coverageUsageForMatters([asId<"MatterId">(mA), asId<"MatterId">(mB)]);
+    expect(batch[mA]).toEqual({ billableMinutes: 90, billableValueOre: 375000 });
+    expect(batch[mB]).toEqual({ billableMinutes: 120, billableValueOre: 500000 });
+  });
+});


### PR DESCRIPTION
Följd på #794 (täcknings-tak + badge på ärendesidan): nu finns det även i **ärendelistan** som en egen **kolumn** man kan **sortera och filtrera** på.

## Vad
- Ny kolumn **"Täckning (tak)"** i `/matters`: färgad procent-badge (⚠ vid ≥ 90 %, röd över tak, grå inom tak, "—" för ärenden utan rättshjälp/rättsskydd).
  - **Sorterbar** på andel av taket (ej-tillämpliga sorteras sist).
  - **Filtrerbar + grupperbar** på etikett: *Inom tak / Närmar sig tak / Över tak / —*.
- Återanvänder `coverage-cap.ts`-logiken (#793) — ingen dubbel sanning.

## Data (ingen N+1)
- `timeEntries.coverageUsageForMatters(matterIds)` — **batchad** aggregat (debiterbara minuter + arvode-värde) per ärende.
- `matter.list` bifogar `coverageUsage` per rad (org-scopat via listans egna ärenden) — en extra aggregat-query per sida, inte per rad.

## Verifierat
- `tsc` (root+test) + ESLint rent; **knip + dep-cruiser** rent; full svit 3612 pass (+ ny repo-test för batch-aggregatet, per-rad-rundning). `build:demo` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)