### PR TITLE
fix(matter): ta bort målnummer ur skapa-ärende-formuläret (#796)

### DIFF
--- a/src/app/matters/page.tsx
+++ b/src/app/matters/page.tsx
@@ -120,7 +120,6 @@ interface MatterForm {
   matterType: string;
   klientId: string;
   responsibleLawyerId: string;
-  courtCaseNumber: string;
   isTaxeArende: boolean;
 }
 
@@ -154,7 +153,6 @@ function NewMatterForm({ form, setForm, contactsData, employeesData, onSubmit, i
   const matterTypeId = useId();
   const descriptionId = useId();
   const responsibleId = useId();
-  const courtCaseId = useId();
   return (
     <form onSubmit={onSubmit} className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
       <h2 className="font-semibold text-gray-900 mb-4">Nytt ärende</h2>
@@ -194,14 +192,6 @@ function NewMatterForm({ form, setForm, contactsData, employeesData, onSubmit, i
             ))}
           </select>
           <p className="mt-1 text-xs text-gray-500">Styr ärendenummerserien (juristens prefix).</p>
-        </div>
-        <div>
-          <label htmlFor={courtCaseId} className="block text-sm font-medium text-gray-700 mb-1">Domstolens målnummer</label>
-          <input id={courtCaseId} type="text" value={form.courtCaseNumber}
-            onChange={(e) => setForm({ ...form, courtCaseNumber: e.target.value })}
-            placeholder="t.ex. B 1234-26 (valfritt)"
-            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm font-mono" />
-          <p className="mt-1 text-xs text-gray-500">Matchningsnyckel för domstolsbetalningar (#173).</p>
         </div>
         <div className="md:col-span-2">
           <label htmlFor={descriptionId} className="block text-sm font-medium text-gray-700 mb-1">Beskrivning</label>
@@ -305,7 +295,6 @@ function MattersContent() {
     matterType: "",
     klientId: "",
     responsibleLawyerId: "",
-    courtCaseNumber: "",
     isTaxeArende: false,
   });
 
@@ -317,7 +306,6 @@ function MattersContent() {
       matterType: form.matterType || undefined,
       klientId: form.klientId || undefined,
       responsibleLawyerId: form.responsibleLawyerId || undefined,
-      courtCaseNumber: form.courtCaseNumber || undefined,
       isTaxeArende: form.isTaxeArende || undefined,
     });
   }

--- a/test/unit/app/matters/page.test.tsx
+++ b/test/unit/app/matters/page.test.tsx
@@ -174,16 +174,16 @@ describe("MattersPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /\+ Nytt ärende/i }));
     fireEvent.change(screen.getByLabelText(/Titel/), { target: { value: "Tvist AB" } });
     fireEvent.change(screen.getByLabelText("Ärendetyp"), { target: { value: "Brottmål" } });
-    fireEvent.change(screen.getByLabelText(/målnummer/), { target: { value: "B 1234-26" } });
     fireEvent.change(screen.getByLabelText("Beskrivning"), { target: { value: "Misshandel" } });
     fireEvent.click(screen.getByRole("checkbox")); // Taxeärende
     fireEvent.click(screen.getByRole("button", { name: /Skapa ärende/i }));
+    // Målnummer sätts INTE vid uppläggning (#796) — det fylls i senare.
     expect(createMatterMutate).toHaveBeenCalledWith(
       expect.objectContaining({
-        title: "Tvist AB", matterType: "Brottmål",
-        courtCaseNumber: "B 1234-26", description: "Misshandel", isTaxeArende: true,
+        title: "Tvist AB", matterType: "Brottmål", description: "Misshandel", isTaxeArende: true,
       }),
     );
+    expect(screen.queryByLabelText(/målnummer/)).not.toBeInTheDocument();
   });
 
   it("paginering: Nästa följt av Föregående går tillbaka till sida 1", () => {


### PR DESCRIPTION
Domstolens målnummer är **okänt vid uppläggning** av ett ärende (alla ärenden går inte ens till domstol). Fältet tas bort ur Nytt ärende-formuläret och fylls i **senare** — via domstols-sektionens `CourtCaseNumberField` när målnumret blir känt.

- Tar bort fältet "Domstolens målnummer" ur `NewMatterForm` + form-state + create-mutationen (`src/app/matters/page.tsx`).
- `matter.create`-input behåller `courtCaseNumber` (valfritt) för demo-generator/fixtures — bara UIt ändras.

**Maxtak** (`rattsskyddMaxOre`/`rattshjalpMaxTimmar`) och **%-sats** (`clientShareBips`) sätts redan bara i betalkortets editor (senare), inte vid uppläggning — så de var redan korrekta (inget att ta bort).

## Verifierat
- `tsc` (root+test) + ESLint + knip rent; full svit 3612 pass (uppdaterade list-sidans skapa-test: ingen målnummer-inmatning, assert att fältet inte finns). `build:demo` OK.

Closes #796

🤖 Generated with [Claude Code](https://claude.com/claude-code)