### PR TITLE
fix(ui): ta bort alla number-spinners i hela UIt (#798)

### DIFF
--- a/src/app/invoices/[id]/_payment-modal.tsx
+++ b/src/app/invoices/[id]/_payment-modal.tsx
@@ -27,7 +27,7 @@ export function PaymentModal({ invoiceId, isPending, error, onSubmit, onClose }:
         <div className="space-y-3">
           <div>
             <label htmlFor={paymentAmountId} className="block text-xs font-medium mb-1">Belopp (kr)</label>
-            <input id={paymentAmountId} type="number" min={1} value={paymentAmountSek} onChange={(e) => setPaymentAmountSek(e.target.value)} className="w-full border border-gray-300 rounded px-2 py-1.5 text-sm" />
+            <input id={paymentAmountId} type="text" inputMode="decimal" value={paymentAmountSek} onChange={(e) => setPaymentAmountSek(e.target.value)} className="w-full border border-gray-300 rounded px-2 py-1.5 text-sm" />
           </div>
           <div>
             <label htmlFor={paymentDateId} className="block text-xs font-medium mb-1">Betalningsdatum</label>

--- a/src/app/invoices/[id]/_plan-modal.tsx
+++ b/src/app/invoices/[id]/_plan-modal.tsx
@@ -35,11 +35,11 @@ export function PlanModal({ invoiceId, isPending, error, onSubmit, onClose }: Pr
         <div className="space-y-3">
           <div>
             <label htmlFor={planMonthlyId} className="block text-xs font-medium mb-1">Månadsbelopp (kr)</label>
-            <input id={planMonthlyId} type="number" min={1} value={planMonthlySek} onChange={(e) => setPlanMonthlySek(e.target.value)} className="w-full border border-gray-300 rounded px-2 py-1.5 text-sm" />
+            <input id={planMonthlyId} type="text" inputMode="decimal" value={planMonthlySek} onChange={(e) => setPlanMonthlySek(e.target.value)} className="w-full border border-gray-300 rounded px-2 py-1.5 text-sm" />
           </div>
           <div>
             <label htmlFor={planDayOfMonthId} className="block text-xs font-medium mb-1">Förfallodag i månaden (1-28)</label>
-            <input id={planDayOfMonthId} type="number" min={1} max={28} value={planDayOfMonth} onChange={(e) => setPlanDayOfMonth(e.target.value)} className="w-full border border-gray-300 rounded px-2 py-1.5 text-sm" />
+            <input id={planDayOfMonthId} type="text" inputMode="numeric" value={planDayOfMonth} onChange={(e) => setPlanDayOfMonth(e.target.value)} className="w-full border border-gray-300 rounded px-2 py-1.5 text-sm" />
           </div>
           <div>
             <label htmlFor={planStartId} className="block text-xs font-medium mb-1">Startdatum</label>

--- a/src/app/invoices/[id]/_write-off-modal.tsx
+++ b/src/app/invoices/[id]/_write-off-modal.tsx
@@ -38,7 +38,7 @@ export function WriteOffModal({ invoiceId, outstanding, isPending, error, onSubm
         <div className="space-y-3">
           <div>
             <label htmlFor={amountId} className="block text-xs font-medium mb-1">Belopp att skriva av (kr)</label>
-            <input id={amountId} type="number" min={1} value={amountSek} onChange={(e) => setAmountSek(e.target.value)} className="w-full border border-gray-300 rounded px-2 py-1.5 text-sm" />
+            <input id={amountId} type="text" inputMode="decimal" value={amountSek} onChange={(e) => setAmountSek(e.target.value)} className="w-full border border-gray-300 rounded px-2 py-1.5 text-sm" />
           </div>
           <div>
             <label htmlFor={reasonId} className="block text-xs font-medium mb-1">Anledning</label>

--- a/src/app/matters/[id]/_expected-receivables-section.tsx
+++ b/src/app/matters/[id]/_expected-receivables-section.tsx
@@ -68,7 +68,7 @@ function AddReceivableForm({ matterId, onAdded }: { matterId: MatterId; onAdded:
         placeholder="Kostnadsräkning t.ex. Svea HovR mål B 1234-26"
         className="w-full rounded border border-gray-300 px-2 py-1.5 text-sm" />
       <div className="flex gap-2">
-        <input value={kr} onChange={(e) => setKr(e.target.value)} type="number" aria-labelledby={amtId}
+        <input value={kr} onChange={(e) => setKr(e.target.value)} type="text" inputMode="decimal" aria-labelledby={amtId}
           placeholder="Begärt belopp (kr)"
           className="flex-1 rounded border border-gray-300 px-2 py-1.5 text-sm" />
         <button onClick={submit} disabled={create.isPending || !desc || !kr}
@@ -99,7 +99,7 @@ function ReceivableRow({ r, onChanged }: { r: Receivable; onChanged: () => void 
       </div>
       {r.status === "PENDING" && (
         <div className="flex gap-2 mt-1.5">
-          <input value={kr} onChange={(e) => setKr(e.target.value)} type="number" placeholder="Utbetalt (kr)"
+          <input value={kr} onChange={(e) => setKr(e.target.value)} type="text" inputMode="decimal" placeholder="Utbetalt (kr)"
             className="w-32 rounded border border-gray-300 px-2 py-1 text-sm" />
           <button onClick={() => settle.mutate({ id: r.id, settledAmount: Math.round(Number(kr) * 100) })}
             disabled={settle.isPending || !kr}

--- a/src/app/matters/[id]/_expense-section.tsx
+++ b/src/app/matters/[id]/_expense-section.tsx
@@ -254,7 +254,7 @@ function ExpenseForm({ form, setForm, submitLabel, isPending, isTaxeArende, onSu
         </div>
         <div>
           <label className="block text-xs text-gray-500 mb-1">Belopp (SEK, exkl. moms) *</label>
-          <input type="number" required min={0} step="0.01" value={form.amount || ""}
+          <input type="text" inputMode="decimal" required value={form.amount || ""}
             onChange={(e) => setForm({ ...form, amount: parseFloat(e.target.value) || 0 })}
             placeholder="0,00"
             className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm" />

--- a/src/app/matters/[id]/_time-section.tsx
+++ b/src/app/matters/[id]/_time-section.tsx
@@ -219,7 +219,7 @@ function TimeForm({ form, setForm, submitLabel, isPending, isTaxeArende, onSubmi
         </div>
         <div>
           <label className="block text-xs text-gray-500 mb-1">Tid (minuter) *</label>
-          <input type="number" required min={1} value={form.minutes}
+          <input type="text" inputMode="numeric" required value={form.minutes}
             onChange={(e) => setForm({ ...form, minutes: parseInt(e.target.value) || 0 })}
             className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm" />
         </div>

--- a/src/app/time/page.tsx
+++ b/src/app/time/page.tsx
@@ -122,7 +122,7 @@ function TimeEntryForm({ form, setForm, mattersData, isPending, onSubmit }: Time
         </div>
         <div>
           <label htmlFor={minutesFieldId} className="block text-sm text-gray-500 mb-1">Tid (minuter) *</label>
-          <input id={minutesFieldId} type="number" required min={1} value={form.minutes}
+          <input id={minutesFieldId} type="text" inputMode="numeric" required value={form.minutes}
             onChange={(e) => setForm({ ...form, minutes: parseInt(e.target.value) || 0 })}
             className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" />
         </div>

--- a/src/app/users/_user-form.tsx
+++ b/src/app/users/_user-form.tsx
@@ -87,12 +87,12 @@ export function UserForm({
           </p>
         </FormField>
         <FormField id={hourlyRateId} label="Timtaxa (kr/h)">
-          <input id={hourlyRateId} type="number" value={form.hourlyRate}
+          <input id={hourlyRateId} type="text" inputMode="decimal" value={form.hourlyRate}
             onChange={(e) => setForm({ ...form, hourlyRate: e.target.value })}
             className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" />
         </FormField>
         <FormField id={mileageRateId} label="Milersättning (kr/km)">
-          <input id={mileageRateId} type="number" step="0.01" value={form.mileageRate}
+          <input id={mileageRateId} type="text" inputMode="decimal" value={form.mileageRate}
             onChange={(e) => setForm({ ...form, mileageRate: e.target.value })}
             className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" />
         </FormField>

--- a/test/unit/app/invoices/[id]/page.test.tsx
+++ b/test/unit/app/invoices/[id]/page.test.tsx
@@ -193,8 +193,7 @@ describe("InvoiceDetailPage", () => {
     fireEvent.click(
       await waitFor(() => screen.getByRole("button", { name: /Registrera betalning/i })),
     );
-    const numbers = screen.getAllByRole("spinbutton") as HTMLInputElement[];
-    fireEvent.change(numbers[0]!, { target: { value: "5000" } });
+    fireEvent.change(screen.getByLabelText("Belopp (kr)"), { target: { value: "5000" } });
     const sparaBtns = screen.getAllByRole("button", { name: /^Spara$/i });
     fireEvent.click(sparaBtns[sparaBtns.length - 1]!);
     expect(stubs.recordPayment.mutate).toHaveBeenCalled();
@@ -219,8 +218,7 @@ describe("InvoiceDetailPage", () => {
     fireEvent.click(
       await waitFor(() => screen.getByRole("button", { name: /Skapa avbetalningsplan/i })),
     );
-    const numberInputs = screen.getAllByRole("spinbutton") as HTMLInputElement[];
-    fireEvent.change(numberInputs[0]!, { target: { value: "1000" } });
+    fireEvent.change(screen.getByLabelText("Månadsbelopp (kr)"), { target: { value: "1000" } });
     fireEvent.click(screen.getByRole("button", { name: /Skapa plan/i }));
     expect(stubs.createPaymentPlan.mutate).toHaveBeenCalled();
     expect(stubs.createPaymentPlan.mutate.mock.calls[0]![0]).toMatchObject({

--- a/test/unit/app/time-section-invoiced.test.tsx
+++ b/test/unit/app/time-section-invoiced.test.tsx
@@ -90,7 +90,7 @@ describe("TimeSection — registrera/ändra/ta-bort-flöden", () => {
     expect(screen.getByText("Registrera tid")).toBeInTheDocument();
     const dateInput = document.querySelector('input[type="date"]') as HTMLInputElement;
     fireEvent.change(dateInput, { target: { value: "2026-05-20" } });
-    fireEvent.change(document.querySelector('input[type="number"]') as HTMLInputElement, { target: { value: "45" } });
+    fireEvent.change(document.querySelector('input[inputmode="numeric"]') as HTMLInputElement, { target: { value: "45" } });
     fireEvent.change(screen.getByPlaceholderText("Beskrivning *"), { target: { value: "Telefonsamtal" } });
     fireEvent.click(screen.getByText("Spara"));
     expect(createMut).toHaveBeenCalledWith(

--- a/test/unit/app/time/page.test.tsx
+++ b/test/unit/app/time/page.test.tsx
@@ -98,7 +98,7 @@ describe("TimePage", () => {
     // ("<nr> — <titel>") → komponenten anropar onChange(matterId).
     const matterInput = screen.getByRole("combobox") as HTMLInputElement;
     fireEvent.change(matterInput, { target: { value: "2026-0001 — Test" } });
-    const desc = screen.getAllByRole("textbox")[0] as HTMLInputElement;
+    const desc = screen.getByLabelText(/Beskrivning/i) as HTMLInputElement;
     fireEvent.change(desc, { target: { value: "Klientmöte" } });
     fireEvent.click(screen.getByRole("button", { name: /^Spara$/i }));
     expect(createMutate).toHaveBeenCalled();
@@ -117,10 +117,11 @@ describe("TimePage", () => {
     expect(checkbox.checked).toBe(false);
   });
 
-  it("ändrar minuter via number-input", () => {
+  it("ändrar minuter via text-input (utan spinner, #798)", () => {
     render(<TimePage />);
     fireEvent.click(screen.getByRole("button", { name: /\+ Registrera tid/i }));
-    const numberInput = screen.getByRole("spinbutton") as HTMLInputElement;
+    expect(screen.queryByRole("spinbutton")).not.toBeInTheDocument();
+    const numberInput = screen.getByLabelText(/minuter/i) as HTMLInputElement;
     fireEvent.change(numberInput, { target: { value: "120" } });
     expect(numberInput.value).toBe("120");
   });

--- a/test/unit/app/users/new/page.test.tsx
+++ b/test/unit/app/users/new/page.test.tsx
@@ -101,7 +101,7 @@ describe("NewUserPage", () => {
 
   it("ändrar timtaxa och milersättning", () => {
     const { container } = render(<NewUserPage />);
-    const numberInputs = container.querySelectorAll('input[type="number"]');
+    const numberInputs = container.querySelectorAll('input[inputmode="decimal"]');
     fireEvent.change(numberInputs[0]!, { target: { value: "3500" } });
     fireEvent.change(numberInputs[1]!, { target: { value: "3.50" } });
     fireEvent.change(container.querySelectorAll("input")[0]!, { target: { value: "X" } });


### PR DESCRIPTION
Inga fält använder längre `type="number"` (webbläsarens upp/ner-pilar). Användaren skriver in värdet själv.

## Vad
Alla `type="number"`-inputs → `type="text"` + `inputMode="decimal"` (belopp/taxor) resp. `inputMode="numeric"` (minuter, förfallodag). Befintlig value/onChange-parsning oförändrad; spinner-specifika `min`/`max`/`step` borttagna.

Berörda fält:
- Faktura: betalnings-, avskrivnings- och avbetalningsmodal (belopp, månadsbelopp, förfallodag).
- Tid: både `/time`-sidan och ärendets tid-sektion (minuter).
- Användarformulär: timtaxa + milersättning.
- Utlägg (belopp), förväntade domstolsbetalningar (begärt/utbetalt).

(Acconto-belopp, dom-belopp och %-andel gjordes redan spinner-fria i #778/#780 via `DecimalInput`.)

## Tester
Uppdaterade de tester som targetade `role="spinbutton"` / `input[type=number]` → nu via label (`getByLabelText`) eller `input[inputmode=...]`. Behöll "ingen spinbutton finns"-assertions.

## Verifierat
- `tsc` (root+test) + ESLint rent; full svit 3612 pass; `build:demo` OK.

Closes #798

🤖 Generated with [Claude Code](https://claude.com/claude-code)