### PR TITLE
feat(billing): prutnings-/självrisk-modell + omräkning på aktuellt timarvode (#800)

### DIFF
--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -18,6 +18,8 @@ import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import type { VatBreakdownLine } from "@/lib/shared/accounting/semantic-voucher";
 import { proposedAccontoOre } from "@/lib/shared/billing-proposal";
+import { TIMKOSTNADSNORM_FTAX_ORE_PER_H, TIMKOSTNADSNORM_NO_FTAX_ORE_PER_H } from "@/lib/shared/brottmalstaxa";
+import { computeCoverageSplit } from "@/lib/shared/coverage-billing";
 import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
 import { ocrFromInvoiceNumber } from "@/lib/shared/ocr-reference";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
@@ -36,6 +38,7 @@ import {
   type MatterId,
   type OrganizationId,
   type TimeEntryId,
+  type UserId,
 } from "@/lib/shared/schemas/ids";
 import { splitVat, DEFAULT_VAT_RATE } from "@/lib/shared/vat";
 import { emit } from "../events/emit";
@@ -146,6 +149,24 @@ function invoiceVatBreakdown(work: UnfrozenWork): VatBreakdownLine[] {
     lines.push({ kind: "utlagg", vatRate, netOre, vatOre });
   }
   return lines;
+}
+
+/**
+ * Det DÅ GÄLLANDE timarvodet (öre/tim) som arbetet ska värderas om på vid
+ * fakturering (#800): rättshjälp → timkostnadsnormen (F-skatt-variant);
+ * rättsskydd m.fl. → ansvariga juristens AKTUELLA timtaxa (ej snapshot).
+ */
+async function currentArvodeRateOre(
+  repos: Repositories,
+  orgId: OrganizationId,
+  matter: { paymentMethod: string; taxaHasFTax?: boolean | null | undefined; responsibleLawyerId?: UserId | null | undefined },
+): Promise<number> {
+  if (matter.paymentMethod === "RATTSHJALP") {
+    return matter.taxaHasFTax === false ? TIMKOSTNADSNORM_NO_FTAX_ORE_PER_H : TIMKOSTNADSNORM_FTAX_ORE_PER_H;
+  }
+  if (!matter.responsibleLawyerId) return 0;
+  const lawyer = await repos.users.getByIdInOrg(matter.responsibleLawyerId, orgId);
+  return lawyer?.hourlyRate ?? 0;
 }
 
 /** Bygg ett itemiserat fakturaförslag ur ofrysta tids-/utläggsrader (#397). */
@@ -419,6 +440,36 @@ export const billingRunRouter = router({
         });
         return { run };
       });
+    }),
+
+  /**
+   * Prutnings-/självrisk-fördelning (#800): värderar om arbetet på DET DÅ
+   * GÄLLANDE timarvodet (rättshjälp = timkostnadsnorm; rättsskydd = ansvariga
+   * juristens aktuella timtaxa) och delar upp i klient/betalare/byrå-förlust.
+   * Read-only — driver UIt; faktiska fakturorna skapas i settlement-flödet.
+   */
+  coverageSplit: orgProcedure
+    .input(z.object({
+      matterId: matterIdSchema,
+      /** Rättshjälp: domens beviljade belopp (öre). */
+      awardedOre: z.number().int().nonnegative().optional(),
+      /** Rättsskydd: försäkringsbolagets prutning (öre, ur brevet). */
+      insurerPrutningOre: z.number().int().nonnegative().optional(),
+    }))
+    .query(async ({ ctx, input }) => {
+      const matter = await ctx.repos.matters.getByIdInOrg(input.matterId, ctx.orgId);
+      if (!matter) throw new TRPCError({ code: "NOT_FOUND", message: "Ärendet finns inte." });
+      const { billableMinutes } = await ctx.repos.timeEntries.coverageUsageForMatter(input.matterId);
+      const currentRateOre = await currentArvodeRateOre(ctx.repos, ctx.orgId, matter);
+      const totalOre = Math.round((billableMinutes / 60) * currentRateOre);
+      const split = computeCoverageSplit({
+        method: matter.paymentMethod,
+        totalOre,
+        clientShareBips: matter.clientShareBips ?? 0,
+        ...(input.awardedOre != null ? { awardedOre: input.awardedOre } : {}),
+        ...(input.insurerPrutningOre != null ? { insurerPrutningOre: input.insurerPrutningOre } : {}),
+      });
+      return { ...split, totalOre, currentRateOre, billableMinutes };
     }),
 
   setVerdict: orgProcedure

--- a/src/lib/shared/coverage-billing.ts
+++ b/src/lib/shared/coverage-billing.ts
@@ -1,0 +1,75 @@
+/**
+ * Prutnings-/självrisk-fördelning för rättshjälp & rättsskydd (#800) — ren
+ * logik, inga I/O. Alla belopp i öre och i NETTO (exkl moms) — momsen läggs på
+ * när fakturorna skapas (#782).
+ *
+ * Två regimer beroende på vem som prutar:
+ *
+ *  RÄTTSSKYDD (försäkring prutar): klienten tar mellanskillnaden, byrån blir hel.
+ *    självrisk S = andel% × total (omvärderat på aktuellt timarvode)
+ *    försäkringen betalar = total − S − prutning   (prutning ur bolagets brev)
+ *    klient = S + prutning = total − det försäkringen betalar
+ *    byrå-förlust = 0
+ *
+ *  RÄTTSHJÄLP (domstol/myndighet prutar): byrån TAPPAR mellanskillnaden (får ej
+ *  ta ut den av klienten); klientens självrisk räknas om på det NYA beloppet.
+ *    reducerat = domens beviljade belopp (≤ total)
+ *    klient = andel% × reducerat
+ *    staten betalar = reducerat − klient
+ *    byrå-förlust = total − reducerat
+ *
+ * `total` ska vara arvodet omvärderat på det DÅ GÄLLANDE timarvodet (#800):
+ * rättshjälp → timkostnadsnormen; rättsskydd → juristens aktuella timtaxa.
+ */
+
+import type { PaymentMethod } from "./schemas/enums";
+
+export interface CoverageSplitInput {
+  method: PaymentMethod;
+  /** Arvode (netto) omvärderat på aktuellt timarvode. */
+  totalOre: number;
+  /** Klientens självrisk-/avgifts-andel i bips (2500 = 25 %). */
+  clientShareBips: number;
+  /** Rättshjälp: domens beviljade belopp (öre). Saknas → ingen reduktion (= total). */
+  awardedOre?: number | null;
+  /** Rättsskydd: försäkringsbolagets prutning (öre, ur brevet). Saknas → 0. */
+  insurerPrutningOre?: number | null;
+}
+
+export interface CoverageSplit {
+  /** Vad klienten ska betala (netto, öre). */
+  clientOre: number;
+  /** Vad betalaren (försäkring/stat) betalar (netto, öre). */
+  payerOre: number;
+  /** Byråns förlust (netto, öre) — endast vid rättshjälps-prutning. */
+  firmLossOre: number;
+  /** Den faktiska total som fördelas (efter ev. rättshjälps-reduktion). */
+  effectiveTotalOre: number;
+}
+
+function shareOf(ore: number, bips: number): number {
+  return Math.round((ore * bips) / 10000);
+}
+
+export function computeCoverageSplit(input: CoverageSplitInput): CoverageSplit {
+  const total = Math.max(0, input.totalOre);
+  if (input.method === "RATTSHJALP") {
+    const reduced = clampReduction(input.awardedOre, total);
+    const clientOre = shareOf(reduced, input.clientShareBips);
+    return { clientOre, payerOre: reduced - clientOre, firmLossOre: total - reduced, effectiveTotalOre: reduced };
+  }
+  if (input.method === "RATTSSKYDD") {
+    const sjalvrisk = shareOf(total, input.clientShareBips);
+    const prutning = Math.max(0, input.insurerPrutningOre ?? 0);
+    const clientOre = Math.min(total, sjalvrisk + prutning);
+    return { clientOre, payerOre: total - clientOre, firmLossOre: 0, effectiveTotalOre: total };
+  }
+  // Andra betalningssätt: ingen självrisks-/prutnings-uppdelning.
+  return { clientOre: total, payerOre: 0, firmLossOre: 0, effectiveTotalOre: total };
+}
+
+/** Domens belopp klampat till [0, total]; saknas → ingen reduktion. */
+function clampReduction(awardedOre: number | null | undefined, total: number): number {
+  if (awardedOre == null) return total;
+  return Math.max(0, Math.min(awardedOre, total));
+}

--- a/test/unit/lib/shared/coverage-billing.test.ts
+++ b/test/unit/lib/shared/coverage-billing.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tester för prutnings-/självrisk-fördelningen (#800): rättsskydd (klient tar
+ * mellanskillnaden, byrån hel) vs rättshjälp (byrån tappar, klient på reducerat).
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { computeCoverageSplit } from "@/lib/shared/coverage-billing";
+
+describe("computeCoverageSplit — rättsskydd (försäkring prutar)", () => {
+  it("utan prutning: klient = självrisk, försäkring = resten, byrå hel", () => {
+    // Total 100 000 kr, självrisk 20 % = 20 000 → försäkring 80 000.
+    const r = computeCoverageSplit({ method: "RATTSSKYDD", totalOre: 10_000_000, clientShareBips: 2000, insurerPrutningOre: 0 });
+    expect(r).toEqual({ clientOre: 2_000_000, payerOre: 8_000_000, firmLossOre: 0, effectiveTotalOre: 10_000_000 });
+  });
+
+  it("med prutning: klienten tar mellanskillnaden (självrisk + prutning), byrå hel", () => {
+    // Självrisk 20 000 + bolagets prutning 15 000 = klient 35 000; försäkring 65 000.
+    const r = computeCoverageSplit({ method: "RATTSSKYDD", totalOre: 10_000_000, clientShareBips: 2000, insurerPrutningOre: 1_500_000 });
+    expect(r.clientOre).toBe(3_500_000);
+    expect(r.payerOre).toBe(6_500_000);
+    expect(r.firmLossOre).toBe(0);
+    expect(r.clientOre + r.payerOre).toBe(10_000_000); // byrån blir hel
+  });
+
+  it("prutning större än försäkringens del → klient kapas vid total (aldrig > total)", () => {
+    const r = computeCoverageSplit({ method: "RATTSSKYDD", totalOre: 10_000_000, clientShareBips: 2000, insurerPrutningOre: 99_000_000 });
+    expect(r.clientOre).toBe(10_000_000);
+    expect(r.payerOre).toBe(0);
+  });
+});
+
+describe("computeCoverageSplit — rättshjälp (domstol prutar)", () => {
+  it("utan reduktion (dom = total): klient = andel, stat = resten, ingen förlust", () => {
+    const r = computeCoverageSplit({ method: "RATTSHJALP", totalOre: 10_000_000, clientShareBips: 2000, awardedOre: 10_000_000 });
+    expect(r).toEqual({ clientOre: 2_000_000, payerOre: 8_000_000, firmLossOre: 0, effectiveTotalOre: 10_000_000 });
+  });
+
+  it("dom prutar: byrån tappar mellanskillnaden, klientens andel på det NYA beloppet", () => {
+    // Total 100 000, dom 70 000 → byrå-förlust 30 000; klient 20 % × 70 000 = 14 000; stat 56 000.
+    const r = computeCoverageSplit({ method: "RATTSHJALP", totalOre: 10_000_000, clientShareBips: 2000, awardedOre: 7_000_000 });
+    expect(r.clientOre).toBe(1_400_000);
+    expect(r.payerOre).toBe(5_600_000);
+    expect(r.firmLossOre).toBe(3_000_000);
+    expect(r.effectiveTotalOre).toBe(7_000_000);
+    expect(r.clientOre + r.payerOre).toBe(7_000_000); // byrån får bara det reducerade
+  });
+
+  it("inget dombelopp angivet → ingen reduktion", () => {
+    const r = computeCoverageSplit({ method: "RATTSHJALP", totalOre: 5_000_000, clientShareBips: 3000 });
+    expect(r.firmLossOre).toBe(0);
+    expect(r.clientOre).toBe(1_500_000);
+  });
+});
+
+describe("computeCoverageSplit — övriga betalningssätt", () => {
+  it("PRIVAT: hela totalen på klienten, ingen uppdelning", () => {
+    const r = computeCoverageSplit({ method: "PRIVAT", totalOre: 4_000_000, clientShareBips: 0 });
+    expect(r).toEqual({ clientOre: 4_000_000, payerOre: 0, firmLossOre: 0, effectiveTotalOre: 4_000_000 });
+  });
+});

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -297,3 +297,37 @@ describe("billingRun.list / byId", () => {
     expect(runs[0]!.type).toBe("ACCONTO");
   });
 });
+
+describe("billingRun.coverageSplit — prutning/självrisk på aktuellt timarvode (#800)", () => {
+  function caller(matterExtra: Record<string, unknown>, currentRate: number) {
+    const ds = new DemoDataStore({
+      organizations: [{ id: "org-1", name: "X" }],
+      matters: [{ id: "m-1", organizationId: "org-1", matterNumber: "2026-0001", title: "T", status: "ACTIVE", responsibleLawyerId: "u-1", ...matterExtra, createdAt: new Date() }],
+      // Juristens AKTUELLA timtaxa = currentRate (skiljer sig från tidspostens snapshot 200000).
+      users: [{ id: "u-1", organizationId: "org-1", email: "a@x", name: "Anna", role: "ADMIN", hourlyRate: currentRate }],
+      timeEntries: [{ id: "te-1", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), minutes: 120, description: "M", hourlyRate: 200000, billable: true }],
+    }, async () => {});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return appRouter.createCaller(buildContext({ dataStore: ds, ports: noopPorts, principal: PRINCIPAL }) as any);
+  }
+
+  it("rättsskydd: värderar på juristens AKTUELLA timtaxa (ej snapshot) + klient tar prutningen", async () => {
+    // 2 tim × aktuell 3000 kr/h = 6000 kr total (INTE snapshot 2000 kr/h = 4000).
+    const c = caller({ paymentMethod: "RATTSSKYDD", clientShareBips: 2000 }, 300000);
+    const r = await c.billingRun.coverageSplit({ matterId: "m-1", insurerPrutningOre: 50000 });
+    expect(r.totalOre).toBe(600000); // 2h × 3000 kr (aktuell taxa)
+    expect(r.clientOre).toBe(120000 + 50000); // självrisk 20 % (120000) + prutning 50000
+    expect(r.payerOre).toBe(600000 - 170000);
+    expect(r.firmLossOre).toBe(0);
+  });
+
+  it("rättshjälp: värderar på timkostnadsnormen; dom-prutning → byrå-förlust + klient på reducerat", async () => {
+    // 2 tim × 1626 kr = 325 200 öre total; dom 300 000 → förlust 25 200; klient 20 % × 300 000.
+    const c = caller({ paymentMethod: "RATTSHJALP", clientShareBips: 2000, taxaHasFTax: true }, 999999);
+    const r = await c.billingRun.coverageSplit({ matterId: "m-1", awardedOre: 300000 });
+    expect(r.totalOre).toBe(325200);
+    expect(r.firmLossOre).toBe(25200);
+    expect(r.clientOre).toBe(60000);
+    expect(r.payerOre).toBe(240000);
+  });
+});


### PR DESCRIPTION
**Steg 1 av #800** — den pengakritiska *modellen* + omvärdering på aktuellt timarvode. (Faktura-bokningen + UIt görs i en separat följd-PR, se nedan.)

## Modell (`coverage-billing.ts`, ren + testad)
`computeCoverageSplit`:
- **Rättsskydd (försäkring prutar):** klienten tar mellanskillnaden, byrån blir hel → **klient = total − det försäkringen betalar** (självrisk + bolagets prutning); försäkring betalar resten.
- **Rättshjälp (domstol prutar):** byrån **tappar** mellanskillnaden; klientens självrisk räknas om på det **reducerade** (dom-)beloppet; staten betalar resten.

## Omräkning på aktuellt timarvode (`billingRun.coverageSplit`-query)
Värderar arbetet på **det då gällande timarvodet** (inte snapshot per tidspost):
- Rättshjälp → timkostnadsnormen (DVFS, F-skatt-variant).
- Rättsskydd → **ansvariga juristens aktuella** `users.hourlyRate`.

## Tester
- `coverage-billing.test.ts`: alla regler (självrisk, prutning bägge håll, kapning, byrå-förlust).
- `billingRun.test.ts`: end-to-end — snapshot 2000 kr/h men aktuell taxa 3000 → självrisk på 3000; rättshjälp på timkostnadsnorm + dom-prutning → byrå-förlust + klient på reducerat.
- `tsc`/ESLint/knip/dep-cruiser rent, full svit 3621 pass, `build:demo` OK.

## Följd-PR (separat — pengakritiskt fakturaflöde)
Boka uppdelningen: klient-/betalar-fakturor + byrå-förlust + settlement-UI (dombelopp/prutnings-inmatning). Spårad i uppföljnings-issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)