### PR TITLE
feat(billing): settleCoverage-bokning + SettlementDialog (#801)

### DIFF
--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -26,6 +26,7 @@ import { BILLING_RUN_TYPE_LABELS, BILLING_RUN_STATUS_LABELS, type BillingRunReci
 import type { BillingRunId, InvoiceId, MatterId } from "@/lib/shared/schemas/ids";
 import { BillingDialog, type BillingMeta } from "./_billing-dialog";
 import { KostnadsrakningModal } from "./_kostnadsrakning-modal";
+import { SettlementDialog } from "./_settlement-dialog";
 import { VerdictDialog } from "./_verdict-dialog";
 
 interface MatterContext {
@@ -123,7 +124,7 @@ function PendingVerdictBanner({ matterId, run, onClick }: { matterId: MatterId; 
 }
 
 type DialogState = "NONE" | "ACCONTO" | "FINAL";
-type ActionPick = "ACCONTO" | "FINAL" | "KOSTNADSRAKNING";
+type ActionPick = "ACCONTO" | "FINAL" | "KOSTNADSRAKNING" | "SETTLE";
 
 function findPendingVerdict(rows: BillingRunRow[]): BillingRunRow | undefined {
   return rows.find((r) => r.type === "KOSTNADSRAKNING" && r.status === "PENDING_VERDICT");
@@ -249,12 +250,14 @@ export function BillingPanel({ matterId, matter }: Props) {
   useMatterInvariants({ matterId, matterNumber: matter.matterNumber });
   const [dialog, setDialog] = useState<DialogState>("NONE");
   const [showKr, setShowKr] = useState(false);
+  const [showSettle, setShowSettle] = useState(false);
   const [verdictRunId, setVerdictRunId] = useState<BillingRunId | null>(null);
   const rows = (runs.data?.runs ?? []) as BillingRunRow[];
   const pending = findPendingVerdict(rows);
   const refetch = () => { void runs.refetch(); };
   const onPick = (t: ActionPick) => {
     if (t === "KOSTNADSRAKNING") setShowKr(true);
+    else if (t === "SETTLE") setShowSettle(true);
     else setDialog(t);
   };
   return (
@@ -278,6 +281,10 @@ export function BillingPanel({ matterId, matter }: Props) {
         onClose={() => setShowKr(false)}
         onRecorded={refetch}
       />
+      {showSettle && matter.paymentMethod && (
+        <SettlementDialog matterId={matterId} paymentMethod={matter.paymentMethod}
+          onClose={() => { setShowSettle(false); refetch(); }} />
+      )}
     </div>
   );
 }
@@ -399,6 +406,7 @@ function optionsFor(pm: PaymentMethod | undefined): Array<{ type: ActionPick; la
     return [
       { type: "ACCONTO", label: "Aconto till klient" },
       { type: "FINAL", label: pm === "RATTSSKYDD" ? "Faktura till försäkring" : "Faktura till myndighet" },
+      { type: "SETTLE", label: pm === "RATTSSKYDD" ? "Slutreglera (försäkringsbesked)" : "Slutreglera (dom)" },
     ];
   }
   if (pm === "OFFENTLIGT_UPPDRAG") {

--- a/src/app/matters/[id]/_settlement-dialog.tsx
+++ b/src/app/matters/[id]/_settlement-dialog.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+/**
+ * `SettlementDialog` (#801) — slutreglera ett rättsskydds-/rättshjälpsärende när
+ * betalaren svarat:
+ *   - Rättshjälp: domen anger beviljat belopp → byrån bär ev. prutning, klientens
+ *     självrisk räknas på det beviljade.
+ *   - Rättsskydd: försäkringsbrevet anger prutning → klienten tar mellanskillnaden.
+ *
+ * Arbetet värderas om på det då gällande timarvodet (server: coverageSplit).
+ * Skapar klient- + betalar-faktura och bokar ev. byrå-förlust.
+ */
+
+import { useState } from "react";
+import { DecimalInput } from "@/components/ui/decimal-input";
+import { Modal } from "@/components/ui/modal";
+import { trpc } from "@/lib/client/trpc";
+import { formatCurrency } from "@/lib/client/utils";
+import type { PaymentMethod } from "@/lib/shared/schemas/enums";
+import type { MatterId } from "@/lib/shared/schemas/ids";
+
+interface SplitData {
+  clientOre: number;
+  payerOre: number;
+  firmLossOre: number;
+  totalOre: number;
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return <div><label className="block text-xs text-gray-500 mb-1">{label}</label>{children}</div>;
+}
+
+function Row({ label, ore, dim }: { label: string; ore: number; dim?: boolean }) {
+  return (
+    <div className={`flex justify-between text-sm ${dim ? "text-amber-700" : "text-gray-700"}`}>
+      <span>{label}</span><span className="font-mono">{formatCurrency(ore)}</span>
+    </div>
+  );
+}
+
+/** Förhandsvisning av uppdelningen (netto, exkl moms). */
+function SplitPreview({ data, payerLabel }: { data: SplitData; payerLabel: string }) {
+  return (
+    <div className="rounded border border-gray-200 bg-gray-50 px-3 py-2 space-y-1">
+      <Row label="Upparbetat (aktuellt timarvode)" ore={data.totalOre} />
+      <Row label="Klientens del" ore={data.clientOre} />
+      <Row label={payerLabel} ore={data.payerOre} />
+      {data.firmLossOre > 0 && <Row label="Byrån bär (prutning)" ore={data.firmLossOre} dim />}
+      <p className="text-[11px] text-gray-400 pt-1">Belopp exkl. moms — moms läggs på fakturorna.</p>
+    </div>
+  );
+}
+
+/** Härleder alla metod-beroende texter/argument (håller komponenten ≤8). */
+function settlementConfig(isRattshjalp: boolean, matterId: MatterId, ore: number | undefined) {
+  const payerRecipient = isRattshjalp ? ("RATTSHJALPSMYNDIGHET" as const) : ("FORSAKRING" as const);
+  return {
+    payerRecipient,
+    fieldLabel: isRattshjalp ? "Dömt belopp (kr)" : "Försäkringens prutning (kr)",
+    payerLabel: isRattshjalp ? "Staten betalar" : "Försäkringen betalar",
+    help: isRattshjalp
+      ? "Ange beloppet domen beviljade. Byrån bär eventuell prutning; klientens självrisk räknas på det beviljade beloppet."
+      : "Ange försäkringsbolagets prutning ur beskedet. Klienten tar mellanskillnaden (självrisk + prutning).",
+    splitArg: isRattshjalp ? { matterId, awardedOre: ore } : { matterId, insurerPrutningOre: ore },
+    settleArg: isRattshjalp ? { matterId, payerRecipient, awardedOre: ore } : { matterId, payerRecipient, insurerPrutningOre: ore },
+  };
+}
+
+export function SettlementDialog({ matterId, paymentMethod, onClose }: { matterId: MatterId; paymentMethod: PaymentMethod; onClose: () => void }) {
+  const [kr, setKr] = useState<number | null>(null);
+  const ore = kr != null ? Math.round(kr * 100) : undefined;
+  const cfg = settlementConfig(paymentMethod === "RATTSHJALP", matterId, ore);
+  const split = trpc.billingRun.coverageSplit.useQuery(cfg.splitArg);
+  const utils = trpc.useUtils();
+  const settle = trpc.billingRun.settleCoverage.useMutation({
+    onSuccess: () => {
+      void utils.billingRun.list.invalidate({ matterId });
+      void utils.invoice.list.invalidate();
+      onClose();
+    },
+  });
+  return (
+    <Modal open title="Slutreglera ärende" onClose={onClose} widthClass="max-w-md">
+      <form onSubmit={(e) => { e.preventDefault(); settle.mutate(cfg.settleArg); }} className="space-y-3">
+        <p className="text-sm text-gray-600">{cfg.help}</p>
+        <Field label={cfg.fieldLabel}>
+          <DecimalInput value={kr} onChange={setKr} placeholder="Skriv in belopp"
+            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm" />
+        </Field>
+        {split.data && <SplitPreview data={split.data} payerLabel={cfg.payerLabel} />}
+        {settle.error && <p className="text-sm text-red-700">{settle.error.message}</p>}
+        <div className="flex justify-end gap-2 pt-2">
+          <button type="button" onClick={onClose} className="px-3 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50">Avbryt</button>
+          <button type="submit" disabled={settle.isPending}
+            className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50">
+            {settle.isPending ? "Skapar…" : "Skapa fakturor"}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -19,7 +19,7 @@ import { z } from "zod";
 import type { VatBreakdownLine } from "@/lib/shared/accounting/semantic-voucher";
 import { proposedAccontoOre } from "@/lib/shared/billing-proposal";
 import { TIMKOSTNADSNORM_FTAX_ORE_PER_H, TIMKOSTNADSNORM_NO_FTAX_ORE_PER_H } from "@/lib/shared/brottmalstaxa";
-import { computeCoverageSplit } from "@/lib/shared/coverage-billing";
+import { computeCoverageSplit, type CoverageSplit } from "@/lib/shared/coverage-billing";
 import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
 import { ocrFromInvoiceNumber } from "@/lib/shared/ocr-reference";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
@@ -130,14 +130,14 @@ function invoiceVatOre(work: UnfrozenWork): number {
   return arvodeVat + expenseVat;
 }
 
-/** Fakturans moms-uppdelning per sats (#790): en arvode-rad (25 %) + en utläggs-
- *  rad per förekommande momssats. Driver per-sats bokföring i verifikat/SIE. */
-function invoiceVatBreakdown(work: UnfrozenWork): VatBreakdownLine[] {
-  const lines: VatBreakdownLine[] = [];
-  const arvodeNet = arvodeNetOre(work);
-  if (arvodeNet > 0) {
-    lines.push({ kind: "arvode", vatRate: DEFAULT_VAT_RATE, netOre: arvodeNet, vatOre: arvodeInclVatOre(arvodeNet) - arvodeNet });
-  }
+/** En arvode-breakdown-rad (25 % moms) ur ett netto-arvode; null om 0. */
+function arvodeLine(arvodeNet: number): VatBreakdownLine | null {
+  if (arvodeNet <= 0) return null;
+  return { kind: "arvode", vatRate: DEFAULT_VAT_RATE, netOre: arvodeNet, vatOre: arvodeInclVatOre(arvodeNet) - arvodeNet };
+}
+
+/** Utläggens moms-uppdelning, en rad per förekommande momssats. */
+function expenseBreakdownLines(work: UnfrozenWork): VatBreakdownLine[] {
   const byRate = new Map<number, { netOre: number; vatOre: number }>();
   for (const e of work.expenses.filter((x) => x.billable)) {
     const rate = e.vatRate ?? DEFAULT_VAT_RATE;
@@ -145,10 +145,24 @@ function invoiceVatBreakdown(work: UnfrozenWork): VatBreakdownLine[] {
     const acc = byRate.get(rate) ?? { netOre: 0, vatOre: 0 };
     byRate.set(rate, { netOre: acc.netOre + s.exclVat, vatOre: acc.vatOre + s.vat });
   }
-  for (const [vatRate, { netOre, vatOre }] of byRate) {
-    lines.push({ kind: "utlagg", vatRate, netOre, vatOre });
-  }
-  return lines;
+  return [...byRate].map(([vatRate, v]) => ({ kind: "utlagg" as const, vatRate, netOre: v.netOre, vatOre: v.vatOre }));
+}
+
+/** Fakturans moms-uppdelning per sats (#790): en arvode-rad (25 %) + en utläggs-
+ *  rad per förekommande momssats. Driver per-sats bokföring i verifikat/SIE. */
+function invoiceVatBreakdown(work: UnfrozenWork): VatBreakdownLine[] {
+  const arvode = arvodeLine(arvodeNetOre(work));
+  return [...(arvode ? [arvode] : []), ...expenseBreakdownLines(work)];
+}
+
+/** Summa moms (öre) ur en breakdown. */
+function vatOreOf(lines: VatBreakdownLine[]): number {
+  return lines.reduce((s, l) => s + l.vatOre, 0);
+}
+
+/** Brutto (öre) ur en breakdown: netto + moms. */
+function grossOreOf(lines: VatBreakdownLine[]): number {
+  return lines.reduce((s, l) => s + l.netOre + l.vatOre, 0);
 }
 
 /**
@@ -167,6 +181,18 @@ async function currentArvodeRateOre(
   if (!matter.responsibleLawyerId) return 0;
   const lawyer = await repos.users.getByIdInOrg(matter.responsibleLawyerId, orgId);
   return lawyer?.hourlyRate ?? 0;
+}
+
+/** Faktura-rader (moms-breakdown) för klient- resp. betalar-fakturan ur en
+ *  prutnings-/självrisk-uppdelning (#801). Klient = sin arvode-del; betalare =
+ *  sin arvode-del + utläggen. */
+function coverageInvoiceLines(split: CoverageSplit, work: UnfrozenWork): { clientLines: VatBreakdownLine[]; payerLines: VatBreakdownLine[] } {
+  const clientArvode = arvodeLine(split.clientOre);
+  const payerArvode = arvodeLine(split.payerOre);
+  return {
+    clientLines: clientArvode ? [clientArvode] : [],
+    payerLines: [...(payerArvode ? [payerArvode] : []), ...expenseBreakdownLines(work)],
+  };
 }
 
 /** Bygg ett itemiserat fakturaförslag ur ofrysta tids-/utläggsrader (#397). */
@@ -511,6 +537,80 @@ export const billingRunRouter = router({
         if (prutningExpenseId) await tx.expenses.flagBilled([prutningExpenseId], invoice.id);
         await emit.invoiceCreated(ctx, invoice);
         return { run, invoice };
+      });
+    }),
+
+  /**
+   * Settlement (#800/#801) för rättsskydd & rättshjälp: betalaren har svarat
+   * (försäkringsbrev med prutning / dom med beviljat belopp). Arbetet värderas
+   * om på AKTUELLT timarvode, delas upp via `computeCoverageSplit`, och bokas:
+   *   - KLIENT-faktura (självrisk + ev. prutning, minus tidigare aconton)
+   *   - BETALAR-faktura (försäkring/stat) + utlägg
+   *   - byrå-förlust (rättshjälp) som icke-debiterbar PRUTNING-post
+   * Allt arbete fryses. Moms enligt #782 (arvode 25 %, utlägg per sats).
+   */
+  settleCoverage: orgProcedure
+    .input(z.object({
+      matterId: matterIdSchema,
+      payerRecipient: billingRunRecipientSchema,
+      awardedOre: z.number().int().nonnegative().optional(),
+      insurerPrutningOre: z.number().int().nonnegative().optional(),
+      deductedBillingRunIds: z.array(billingRunIdSchema).default([]),
+      notes: z.string().nullish(),
+    }))
+    .mutation(async ({ ctx, input }) => {
+      return ctx.repos.transaction(async (tx) => {
+        const matter = await tx.matters.getByIdInOrg(input.matterId, ctx.orgId);
+        if (!matter) throw new TRPCError({ code: "NOT_FOUND", message: "Ärendet finns inte." });
+        if (matter.paymentMethod !== "RATTSSKYDD" && matter.paymentMethod !== "RATTSHJALP") {
+          throw new TRPCError({ code: "BAD_REQUEST", message: "Settlement gäller bara rättsskydd/rättshjälp." });
+        }
+        const work = await fetchUnfrozenWork(tx, input.matterId);
+        const billableMinutes = work.timeEntries.filter((t) => t.billable).reduce((s, t) => s + t.minutes, 0);
+        const rateOre = await currentArvodeRateOre(tx, ctx.orgId, matter);
+        const totalArvodeNet = Math.round((billableMinutes / 60) * rateOre);
+        const split = computeCoverageSplit({
+          method: matter.paymentMethod, totalOre: totalArvodeNet, clientShareBips: matter.clientShareBips ?? 0,
+          awardedOre: input.awardedOre ?? null, insurerPrutningOre: input.insurerPrutningOre ?? null,
+        });
+        const { clientLines, payerLines } = coverageInvoiceLines(split, work);
+
+        // Klient: självrisk (+ ev. prutning), moms 25 %, minus tidigare aconton.
+        const clientGross = grossOreOf(clientLines);
+        const deductedRuns = await fetchDeductedAccontoRuns(tx, input.matterId, input.deductedBillingRunIds);
+        const deductionOre = deductedRuns.reduce((s, r) => s + (r.amountOre ?? 0), 0);
+        const clientAmount = Math.max(0, clientGross - deductionOre);
+        const payerGross = grossOreOf(payerLines);
+
+        const clientInvoice = await tx.invoices.create({
+          matterId: input.matterId, amount: clientAmount, vatOre: vatOreOf(clientLines), vatBreakdown: clientLines,
+          invoiceType: "FINAL", status: "DRAFT", ...(await invoiceNumbering(tx, ctx.orgId, "KLIENT")), invoiceDate: new Date(), notes: input.notes,
+        });
+        const payerInvoice = await tx.invoices.create({
+          matterId: input.matterId, amount: payerGross, vatOre: vatOreOf(payerLines), vatBreakdown: payerLines,
+          invoiceType: "FINAL", status: "DRAFT", ...(await invoiceNumbering(tx, ctx.orgId, input.payerRecipient)), invoiceDate: new Date(), notes: input.notes,
+        });
+        if (split.firmLossOre > 0) {
+          await tx.expenses.create({
+            matterId: input.matterId, userId: ctx.user.id, date: new Date(),
+            amount: -split.firmLossOre, description: "Prutning — byrån bär (rättshjälp)",
+            billable: false, vatRate: 0, vatIncluded: false, kind: "PRUTNING",
+          });
+        }
+        const clientRun = await tx.billingRuns.create({
+          matterId: input.matterId, type: "FINAL", recipient: "KLIENT", status: "SENT",
+          workValueOreAtRun: clientGross, proposedAmountOre: clientGross, amountOre: clientAmount,
+          invoiceId: clientInvoice.id, deductedBillingRunIds: input.deductedBillingRunIds, periodTo: new Date(), notes: input.notes,
+        });
+        const payerRun = await tx.billingRuns.create({
+          matterId: input.matterId, type: "FINAL", recipient: input.payerRecipient, status: "SENT",
+          workValueOreAtRun: payerGross, proposedAmountOre: payerGross, amountOre: payerGross,
+          invoiceId: payerInvoice.id, deductedBillingRunIds: [], periodTo: new Date(), notes: input.notes,
+        });
+        await freezeWork(tx, input.matterId, payerRun.id);
+        await emit.invoiceCreated(ctx, clientInvoice);
+        await emit.invoiceCreated(ctx, payerInvoice);
+        return { split, clientInvoice, payerInvoice, clientRun, payerRun };
       });
     }),
 });

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -331,3 +331,37 @@ describe("billingRun.coverageSplit — prutning/självrisk på aktuellt timarvod
     expect(r.payerOre).toBe(240000);
   });
 });
+
+describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", () => {
+  function caller(matterExtra: Record<string, unknown>, currentRate: number) {
+    const ds = new DemoDataStore({
+      organizations: [{ id: "org-1", name: "X" }],
+      matters: [{ id: "m-1", organizationId: "org-1", matterNumber: "2026-0001", title: "T", status: "ACTIVE", responsibleLawyerId: "u-1", ...matterExtra, createdAt: new Date() }],
+      users: [{ id: "u-1", organizationId: "org-1", email: "a@x", name: "Anna", role: "ADMIN", hourlyRate: currentRate }],
+      timeEntries: [{ id: "te-1", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), minutes: 120, description: "M", hourlyRate: 200000, billable: true }],
+    }, async () => {});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { ds, caller: appRouter.createCaller(buildContext({ dataStore: ds, ports: noopPorts, principal: PRINCIPAL }) as any) };
+  }
+
+  it("rättsskydd: klient = (självrisk + prutning) inkl moms; försäkring = resten; ingen byrå-förlust", async () => {
+    const { caller: c } = caller({ paymentMethod: "RATTSSKYDD", clientShareBips: 2000 }, 300000);
+    const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "FORSAKRING", insurerPrutningOre: 50000 });
+    // total 600000; klient netto 170000 → ×1.25 = 212500; försäkring netto 430000 → 537500.
+    expect(res.split).toMatchObject({ clientOre: 170000, payerOre: 430000, firmLossOre: 0 });
+    expect(res.clientInvoice.amount).toBe(212500);
+    expect(res.payerInvoice.amount).toBe(537500);
+  });
+
+  it("rättshjälp: timkostnadsnorm; dom prutar → byrå-förlust bokas (icke-debiterbar PRUTNING), klient på reducerat", async () => {
+    const { ds, caller: c } = caller({ paymentMethod: "RATTSHJALP", clientShareBips: 2000, taxaHasFTax: true }, 999999);
+    const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "RATTSHJALPSMYNDIGHET", awardedOre: 300000 });
+    // total 325200; dom 300000 → förlust 25200; klient 60000 → 75000; stat 240000 → 300000.
+    expect(res.split).toMatchObject({ clientOre: 60000, payerOre: 240000, firmLossOre: 25200 });
+    expect(res.clientInvoice.amount).toBe(75000);
+    expect(res.payerInvoice.amount).toBe(300000);
+    const prutning = await ds.expenses.findFirst({ where: { matterId: "m-1", kind: "PRUTNING" } }) as { amount: number; billable: boolean };
+    expect(prutning.amount).toBe(-25200);
+    expect(prutning.billable).toBe(false);
+  });
+});


### PR DESCRIPTION
## Vad

Steg 2 av prutnings-/självrisk-modellen (#800, steg 1 = #802). Bokar
slutregleringen av ett rättsskydds-/rättshjälpsärende när betalaren svarat.

- **`settleCoverage`-mutation** (`billingRun`): värderar om hela arvodet på det
  *då gällande* timarvodet (rättshjälp → timkostnadsnormen, rättsskydd →
  ansvarig jurists aktuella `hourlyRate`), delar via `computeCoverageSplit` och:
  - skapar **klient-faktura** (FINAL, numrerad) på klientens del, minus redan
    fakturerade acconton,
  - skapar **betalar-faktura** (FINAL) — staten resp. försäkringen,
  - bokar byråns förlust som ett **icke-debiterbart PRUTNING-utlägg** vid
    rättshjälps-prutning (rättsskydd → ingen förlust, klienten tar
    mellanskillnaden),
  - fryser arbetet.
- **`SettlementDialog`** (`_settlement-dialog.tsx`): ett fält — dömt belopp
  (rättshjälp) resp. försäkringens prutning (rättsskydd) — med live-
  förhandsvisning av uppdelningen och knapp som skapar fakturorna.
- **BillingPanel**: ny `SETTLE`-action ("Slutreglera (dom)" / "Slutreglera
  (försäkringsbesked)") för rättsskydds-/rättshjälpsärenden.

## Verifiering

- `tsc --noEmit` (root + test): rent
- ESLint: rent · knip: rent · dep-cruiser: rent (1056 moduler)
- `bun test billingRun + coverage-billing`: 37 pass
- `build:demo`: OK (92 HTML, 474 entiteter)

Closes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)
