### PR TITLE
fix(billing): invalidera "upparbetat ofakturerat" efter fakturering (#804)

### DIFF
--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -246,6 +246,7 @@ function KostnadsrakningTrigger({ matterId, matter, open, onClose, onRecorded }:
 
 export function BillingPanel({ matterId, matter }: Props) {
   const runs = trpc.billingRun.list.useQuery({ matterId });
+  const utils = trpc.useUtils();
   // Självupptäck inkonsistenser (t.ex. KR väntar på dom utan KR-dokument).
   useMatterInvariants({ matterId, matterNumber: matter.matterNumber });
   const [dialog, setDialog] = useState<DialogState>("NONE");
@@ -254,7 +255,16 @@ export function BillingPanel({ matterId, matter }: Props) {
   const [verdictRunId, setVerdictRunId] = useState<BillingRunId | null>(null);
   const rows = (runs.data?.runs ?? []) as BillingRunRow[];
   const pending = findPendingVerdict(rows);
-  const refetch = () => { void runs.refetch(); };
+  // Efter en fakturering ändras både körningarna OCH vad som är ofryst/ofakturerat
+  // — invalidera "Upparbetat ofakturerat" (proposal) + fakturalistan, annars visar
+  // panelen stale belopp tills sidan laddas om.
+  const refetch = () => {
+    void runs.refetch();
+    void utils.billingRun.proposal.invalidate({ matterId });
+    void utils.invoice.list.invalidate();
+    void utils.timeEntry.list.invalidate({ matterId });
+    void utils.expense.list.invalidate({ matterId });
+  };
   const onPick = (t: ActionPick) => {
     if (t === "KOSTNADSRAKNING") setShowKr(true);
     else if (t === "SETTLE") setShowSettle(true);

--- a/test/unit/app/matters/billing-panel.test.tsx
+++ b/test/unit/app/matters/billing-panel.test.tsx
@@ -30,8 +30,16 @@ let documentListData: { documents: Array<Record<string, unknown>> } = { document
 let hasDoc = false;
 const openGeneratedDocFn = vi.fn();
 
+const invalidate = vi.fn();
+
 vi.mock("@/lib/client/trpc", () => ({
   trpc: {
+    useUtils: () => ({
+      billingRun: { proposal: { invalidate } },
+      invoice: { list: { invalidate } },
+      timeEntry: { list: { invalidate } },
+      expense: { list: { invalidate } },
+    }),
     billingRun: {
       list: { useQuery: () => ({ data: runsData, isLoading: runsLoading, refetch }) },
       proposal: { useQuery: () => ({ data: proposalData, isLoading: false }) },


### PR DESCRIPTION
## Vad

Kortet **"Upparbetat ofakturerat"** i ärendets fakturapanel uppdaterades inte
efter en fakturering/slutreglering — det visade gammalt belopp tills sidan
laddades om.

**Orsak:** `BillingPanel.refetch` anropade bara `runs.refetch()`
(`billingRun.list`) och invaliderade aldrig `billingRun.proposal`, som driver
kortet. Servern fryser posterna korrekt vid FINAL/slutreglering, men
proposal-cachen blev stale.

**Fix:** `refetch` invaliderar nu även `billingRun.proposal` +
`invoice.list` + `timeEntry.list` + `expense.list` för ärendet.

## Verifiering

- `tsc --noEmit`: rent
- ESLint + knip: rent
- `bun test --parallel test/unit/app/matters`: 122 pass (lade till `useUtils` i
  panelens trpc-mock)

Closes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)
