### PR TITLE
feat(billing): rättshjälp = kostnadsräkning till domstol, fryser vid inskick (#806)

### DIFF
--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -13,6 +13,7 @@
  */
 import type { inferRouterOutputs } from "@trpc/server";
 import { useState } from "react";
+import { Modal } from "@/components/ui/modal";
 import { Money } from "@/components/ui/money";
 import { EntityLink } from "@/lib/client/demo/entity-link";
 import { hasGeneratedDoc, openGeneratedDoc } from "@/lib/client/demo/generated-doc-cache";
@@ -218,6 +219,15 @@ function useKrModalData(matterId: MatterId): KrModalData {
   }) as KrModalData;
 }
 
+/** Väljer rätt kostnadsräknings-dialog: rättshjälp får en enkel inskicks-
+ *  bekräftelse (timkostnadsnorm), övriga (offentligt uppdrag) brottmåls-modalen. */
+function KostnadsrakningEntry({ matterId, matter, open, onClose, onRecorded }: KrTriggerProps) {
+  if (matter.paymentMethod === "RATTSHJALP") {
+    return open ? <RattshjalpKrDialog matterId={matterId} onClose={onClose} onRecorded={onRecorded} /> : null;
+  }
+  return <KostnadsrakningTrigger matterId={matterId} matter={matter} open={open} onClose={onClose} onRecorded={onRecorded} />;
+}
+
 function KostnadsrakningTrigger({ matterId, matter, open, onClose, onRecorded }: KrTriggerProps) {
   const data = useKrModalData(matterId);
   const createKr = trpc.billingRun.createKostnadsrakning.useMutation();
@@ -279,13 +289,14 @@ export function BillingPanel({ matterId, matter }: Props) {
       <SummaryCards totals={computeTotals(rows)} />
       <UnbilledSummary matterId={matterId} />
       <RadgivningBanner matterId={matterId} matter={matter} onRecorded={refetch} />
-      {pending && <PendingVerdictBanner matterId={matterId} run={pending} onClick={() => setVerdictRunId(pending.id)} />}
+      {pending && <PendingVerdictBanner matterId={matterId} run={pending}
+        onClick={() => matter.paymentMethod === "RATTSHJALP" ? setShowSettle(true) : setVerdictRunId(pending.id)} />}
       <RunsList rows={rows} loading={runs.isLoading} />
       <BillingDialogs matterId={matterId} matter={matter} rows={rows}
         dialog={dialog} setDialog={setDialog}
         verdictRunId={verdictRunId} setVerdictRunId={setVerdictRunId}
         onRefetch={refetch} />
-      <KostnadsrakningTrigger
+      <KostnadsrakningEntry
         matterId={matterId} matter={matter}
         open={showKr}
         onClose={() => setShowKr(false)}
@@ -356,6 +367,45 @@ function UnbilledSummary({ matterId }: { matterId: MatterId }) {
   );
 }
 
+/**
+ * Rättshjälpens kostnadsräkning till domstol (#806) — enkel bekräftelse (arbetet
+ * värderas på timkostnadsnormen vid domen, inte brottmålstaxan). Skickar in
+ * kostnadsräkningen, vilket fryser det upparbetade direkt; domen slutregleras
+ * separat (klientens självrisk, statens del, ev. byrå-förlust).
+ */
+function RattshjalpKrDialog({ matterId, onClose, onRecorded }: { matterId: MatterId; onClose: () => void; onRecorded: () => void }) {
+  const proposal = trpc.billingRun.proposal.useQuery({ matterId });
+  const create = trpc.billingRun.createKostnadsrakning.useMutation({
+    onSuccess: () => { onRecorded(); onClose(); },
+  });
+  const d = proposal.data;
+  const arvodeOre = d ? d.timeEntries.filter((t) => t.billable).reduce((s, t) => s + t.valueOre, 0) : 0;
+  const utlaggOre = d ? d.expenses.filter((e) => e.billable).reduce((s, e) => s + e.amount, 0) : 0;
+  return (
+    <Modal open title="Kostnadsräkning till domstol" onClose={onClose} widthClass="max-w-md">
+      <div className="space-y-3">
+        <p className="text-sm text-gray-600">
+          Kostnadsräkningen skickas till domstolen för bedömning — den är ingen faktura
+          ännu och kan prutas. Det upparbetade fryses nu; vid domen slutreglerar du
+          (klientens självrisk, statens del och ev. byrå-förlust).
+        </p>
+        <div className="rounded border border-gray-200 bg-gray-50 px-3 py-2 space-y-1 text-sm">
+          <div className="flex justify-between text-gray-700"><span>Arvode (exkl moms)</span><span className="font-mono">{formatCurrency(arvodeOre)}</span></div>
+          <div className="flex justify-between text-gray-700"><span>Utlägg</span><span className="font-mono">{formatCurrency(utlaggOre)}</span></div>
+        </div>
+        {create.error && <p className="text-sm text-red-700">{create.error.message}</p>}
+        <div className="flex justify-end gap-2 pt-2">
+          <button type="button" onClick={onClose} className="px-3 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50">Avbryt</button>
+          <button type="button" disabled={create.isPending} onClick={() => create.mutate({ matterId })}
+            className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50">
+            {create.isPending ? "Skickar…" : "Skicka kostnadsräkning"}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
 function computeTotals(rows: BillingRunRow[]) {
   let acconto = 0, finalSent = 0, pending = 0;
   for (const r of rows) {
@@ -413,9 +463,14 @@ function BillingActions({ paymentMethod, onPick }: { paymentMethod: PaymentMetho
 
 function optionsFor(pm: PaymentMethod | undefined): Array<{ type: ActionPick; label: string }> {
   if (pm === "RATTSSKYDD" || pm === "RATTSHJALP") {
+    // Rättsskydd faktureras direkt till försäkringen; rättshjälp skickas som
+    // kostnadsräkning till domstolen (bedöms, kan prutas) — ingen faktura ännu (#806).
+    const payerOption = pm === "RATTSSKYDD"
+      ? ({ type: "FINAL", label: "Faktura till försäkring" } as const)
+      : ({ type: "KOSTNADSRAKNING", label: "Kostnadsräkning till domstol" } as const);
     return [
       { type: "ACCONTO", label: "Aconto till klient" },
-      { type: "FINAL", label: pm === "RATTSSKYDD" ? "Faktura till försäkring" : "Faktura till myndighet" },
+      payerOption,
       { type: "SETTLE", label: pm === "RATTSSKYDD" ? "Slutreglera (försäkringsbesked)" : "Slutreglera (dom)" },
     ];
   }

--- a/src/lib/server/repositories/drizzle-expense-repository.ts
+++ b/src/lib/server/repositories/drizzle-expense-repository.ts
@@ -92,6 +92,13 @@ export class DrizzleExpenseRepository extends DrizzleRepository<Expense> impleme
     return rows;
   }
 
+  async listByBillingRun(billingRunId: BillingRunId): Promise<Expense[]> {
+    return await this.db
+      .select().from(expenses)
+      .where(and(eq(expenses.frozenByBillingRunId, billingRunId), isNull(expenses.deletedAt)))
+      .orderBy(asc(expenses.date));
+  }
+
   async freezeForMatter(matterId: MatterId, billingRunId: BillingRunId, now: Date): Promise<void> {
     await this.db.update(expenses)
       .set({ frozenAt: now, frozenByBillingRunId: billingRunId })

--- a/src/lib/server/repositories/drizzle-time-entry-repository.ts
+++ b/src/lib/server/repositories/drizzle-time-entry-repository.ts
@@ -133,6 +133,13 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
     return rows;
   }
 
+  async listByBillingRun(billingRunId: BillingRunId): Promise<TimeEntry[]> {
+    return await this.db
+      .select().from(timeEntries)
+      .where(and(eq(timeEntries.frozenByBillingRunId, billingRunId), isNull(timeEntries.deletedAt)))
+      .orderBy(asc(timeEntries.date));
+  }
+
   async coverageUsageForMatter(matterId: MatterId): Promise<{ billableMinutes: number; billableValueOre: number }> {
     const rows = await this.db
       .select({ minutes: timeEntries.minutes, hourlyRate: timeEntries.hourlyRate })

--- a/src/lib/server/repositories/expense-repository.ts
+++ b/src/lib/server/repositories/expense-repository.ts
@@ -46,6 +46,9 @@ export interface ExpenseRepository extends Repository<Expense> {
   flagBilled(ids: ExpenseId[], invoiceId: InvoiceId): Promise<void>;
   /** Ofrysta utlägg i ett ärende (date asc) — underlag för billing-run. */
   listUnfrozenForMatter(matterId: MatterId): Promise<Expense[]>;
+  /** Utlägg frysta mot en specifik billing-run (date asc) — dom/slutreglering
+   *  av en kostnadsräkning vars rader frystes vid inskick. */
+  listByBillingRun(billingRunId: BillingRunId): Promise<Expense[]>;
   /** Frys alla ofrysta utlägg i ett ärende mot en billing-run (bulk). */
   freezeForMatter(matterId: MatterId, billingRunId: BillingRunId, now: Date): Promise<void>;
   /** Frys ENBART de angivna (ofrysta) utläggen mot en billing-run — per-post-val. */

--- a/src/lib/server/repositories/in-memory-expense-repository.ts
+++ b/src/lib/server/repositories/in-memory-expense-repository.ts
@@ -66,6 +66,12 @@ export class InMemoryExpenseRepository extends InMemoryRepository<Expense> imple
     })) as Expense[];
   }
 
+  async listByBillingRun(billingRunId: BillingRunId): Promise<Expense[]> {
+    return (await this.delegate.findMany({
+      where: { frozenByBillingRunId: billingRunId }, orderBy: { date: "asc" },
+    })) as Expense[];
+  }
+
   async freezeForMatter(matterId: MatterId, billingRunId: BillingRunId, now: Date): Promise<void> {
     await this.delegate.updateMany({
       where: { matterId, frozenByBillingRunId: null },

--- a/src/lib/server/repositories/in-memory-time-entry-repository.ts
+++ b/src/lib/server/repositories/in-memory-time-entry-repository.ts
@@ -105,6 +105,12 @@ export class InMemoryTimeEntryRepository extends InMemoryRepository<TimeEntry> i
     })) as TimeEntry[];
   }
 
+  async listByBillingRun(billingRunId: BillingRunId): Promise<TimeEntry[]> {
+    return (await this.delegate.findMany({
+      where: { frozenByBillingRunId: billingRunId }, orderBy: { date: "asc" },
+    })) as TimeEntry[];
+  }
+
   async coverageUsageForMatter(matterId: MatterId): Promise<{ billableMinutes: number; billableValueOre: number }> {
     const rows = (await this.delegate.findMany({ where: { matterId } })) as TimeEntry[];
     let billableMinutes = 0;

--- a/src/lib/server/repositories/time-entry-repository.ts
+++ b/src/lib/server/repositories/time-entry-repository.ts
@@ -87,6 +87,9 @@ export interface TimeEntryRepository extends Repository<TimeEntry> {
   flagBilled(ids: TimeEntryId[], invoiceId: InvoiceId): Promise<void>;
   /** Ofrysta tidsposter i ett ärende (date asc) — underlag för billing-run. */
   listUnfrozenForMatter(matterId: MatterId): Promise<TimeEntry[]>;
+  /** Tidsposter frysta mot en specifik billing-run (date asc) — underlag för
+   *  dom/slutreglering av en kostnadsräkning, vars rader frystes vid inskick. */
+  listByBillingRun(billingRunId: BillingRunId): Promise<TimeEntry[]>;
   /** Summa debiterbara minuter + arvode-värde (öre) i ett ärende — täcknings-tak (#793). */
   coverageUsageForMatter(matterId: MatterId): Promise<CoverageUsage>;
   /** Som ovan men batchat för flera ärenden (täcknings-kolumn i listan, #793).

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -42,6 +42,7 @@ import {
 } from "@/lib/shared/schemas/ids";
 import { splitVat, DEFAULT_VAT_RATE } from "@/lib/shared/vat";
 import { emit } from "../events/emit";
+import type { BillingRunListRow } from "../repositories/billing-run-repository";
 import type { Repositories } from "../repositories/repositories";
 import { router, orgProcedure } from "../trpc";
 
@@ -84,6 +85,62 @@ async function fetchUnfrozenWork(repos: Repositories, matterId: MatterId): Promi
   const te = await repos.timeEntries.listUnfrozenForMatter(matterId);
   const ex = await repos.expenses.listUnfrozenForMatter(matterId);
   return { timeEntries: te, expenses: ex.filter((e) => e.kind !== "PRUTNING") };
+}
+
+/** Det arbete en kostnadsräkning frös vid inskick (#806) — underlag för dom/
+ *  slutreglering. PRUTNING-rader (skapas vid domen) länkas separat. */
+async function fetchWorkByRun(repos: Repositories, billingRunId: BillingRunId): Promise<UnfrozenWork> {
+  const te = await repos.timeEntries.listByBillingRun(billingRunId);
+  const ex = await repos.expenses.listByBillingRun(billingRunId);
+  return { timeEntries: te, expenses: ex.filter((e) => e.kind !== "PRUTNING") };
+}
+
+/**
+ * Underlag för slutreglering (#806): väntar en kostnadsräkning på dom använder
+ * vi dess frysta rader (rättshjälp), annars allt ofryst (rättsskydd har ingen
+ * kostnadsräkning). Returnerar även körningen så den kan konsumeras vid domen.
+ */
+async function resolveSettlementWork(
+  repos: Repositories, orgId: OrganizationId, matterId: MatterId,
+): Promise<{ work: UnfrozenWork; krRun: BillingRunListRow | undefined }> {
+  const runs = await repos.billingRuns.listForOrg(orgId, matterId);
+  const krRun = runs.find((r) => r.type === "KOSTNADSRAKNING" && r.status === "PENDING_VERDICT");
+  const work = krRun ? await fetchWorkByRun(repos, krRun.id) : await fetchUnfrozenWork(repos, matterId);
+  return { work, krRun };
+}
+
+/** Bokar byråns prutningsförlust (rättshjälp) som icke-debiterbart PRUTNING-utlägg. */
+async function bookFirmLoss(repos: Repositories, userId: UserId, matterId: MatterId, firmLossOre: number): Promise<void> {
+  if (firmLossOre <= 0) return;
+  await repos.expenses.create({
+    matterId, userId, date: new Date(),
+    amount: -firmLossOre, description: "Prutning — byrån bär (rättshjälp)",
+    billable: false, vatRate: 0, vatIncluded: false, kind: "PRUTNING",
+  });
+}
+
+interface PayerRunInput {
+  matterId: MatterId; payerRecipient: BillingRunRecipient; payerInvoiceId: InvoiceId;
+  payerGross: number; notes: string | null | undefined; krRun: BillingRunListRow | undefined;
+}
+
+/** Betalar-körningen vid slutreglering (#806): konsumerar en väntande kostnads-
+ *  räkning (→ SENT, faktura länkad — arbetet redan fryst mot den), annars en ny
+ *  FINAL + frysning av det ofrysta arbetet (rättsskydd). */
+async function bookPayerRun(repos: Repositories, p: PayerRunInput): Promise<BillingRun> {
+  if (p.krRun) {
+    return repos.billingRuns.update(p.krRun.id, {
+      status: "SENT", invoiceId: p.payerInvoiceId,
+      amountOre: p.payerGross, proposedAmountOre: p.payerGross, workValueOreAtRun: p.payerGross,
+    });
+  }
+  const run = await repos.billingRuns.create({
+    matterId: p.matterId, type: "FINAL", recipient: p.payerRecipient, status: "SENT",
+    workValueOreAtRun: p.payerGross, proposedAmountOre: p.payerGross, amountOre: p.payerGross,
+    invoiceId: p.payerInvoiceId, deductedBillingRunIds: [], periodTo: new Date(), notes: p.notes,
+  });
+  await freezeWork(repos, p.matterId, run.id);
+  return run;
 }
 
 /** Arvode netto (exkl. moms) — summa av debiterbara tidsposter. */
@@ -464,6 +521,10 @@ export const billingRunRouter = router({
           invoiceId: null, deductedBillingRunIds: [],
           periodTo: new Date(), notes: input.notes,
         });
+        // Kostnadsräkningen ÄR inskicket — frys arbetet direkt (#806) så det
+        // lämnar "Upparbetat ofakturerat". Dom/slutreglering läser raderna via
+        // körningen (fetchWorkByRun), inte som ofryst.
+        await freezeWork(tx, input.matterId, run.id);
         return { run };
       });
     }),
@@ -520,8 +581,9 @@ export const billingRunRouter = router({
           });
           prutningExpenseId = prutning.id;
         }
-        // Debiterbara poster INNAN frysning (ex. PRUTNING, som länkas separat nedan).
-        const work = await fetchUnfrozenWork(tx, run.matterId);
+        // Posterna frystes redan vid kostnadsräkningens inskick (#806) → läs dem
+        // via körningen. PRUTNING (nyss skapad) länkas separat nedan.
+        const work = await fetchWorkByRun(tx, run.id);
         const invoice = await tx.invoices.create({
           matterId: run.matterId, amount: finalAmount,
           invoiceType: "FINAL", status: "DRAFT", // DOMSTOL → inget nummer/OCR (ADR 0012)
@@ -565,7 +627,7 @@ export const billingRunRouter = router({
         if (matter.paymentMethod !== "RATTSSKYDD" && matter.paymentMethod !== "RATTSHJALP") {
           throw new TRPCError({ code: "BAD_REQUEST", message: "Settlement gäller bara rättsskydd/rättshjälp." });
         }
-        const work = await fetchUnfrozenWork(tx, input.matterId);
+        const { work, krRun } = await resolveSettlementWork(tx, ctx.orgId, input.matterId);
         const billableMinutes = work.timeEntries.filter((t) => t.billable).reduce((s, t) => s + t.minutes, 0);
         const rateOre = await currentArvodeRateOre(tx, ctx.orgId, matter);
         const totalArvodeNet = Math.round((billableMinutes / 60) * rateOre);
@@ -590,24 +652,16 @@ export const billingRunRouter = router({
           matterId: input.matterId, amount: payerGross, vatOre: vatOreOf(payerLines), vatBreakdown: payerLines,
           invoiceType: "FINAL", status: "DRAFT", ...(await invoiceNumbering(tx, ctx.orgId, input.payerRecipient)), invoiceDate: new Date(), notes: input.notes,
         });
-        if (split.firmLossOre > 0) {
-          await tx.expenses.create({
-            matterId: input.matterId, userId: ctx.user.id, date: new Date(),
-            amount: -split.firmLossOre, description: "Prutning — byrån bär (rättshjälp)",
-            billable: false, vatRate: 0, vatIncluded: false, kind: "PRUTNING",
-          });
-        }
+        await bookFirmLoss(tx, ctx.user.id, input.matterId, split.firmLossOre);
         const clientRun = await tx.billingRuns.create({
           matterId: input.matterId, type: "FINAL", recipient: "KLIENT", status: "SENT",
           workValueOreAtRun: clientGross, proposedAmountOre: clientGross, amountOre: clientAmount,
           invoiceId: clientInvoice.id, deductedBillingRunIds: input.deductedBillingRunIds, periodTo: new Date(), notes: input.notes,
         });
-        const payerRun = await tx.billingRuns.create({
-          matterId: input.matterId, type: "FINAL", recipient: input.payerRecipient, status: "SENT",
-          workValueOreAtRun: payerGross, proposedAmountOre: payerGross, amountOre: payerGross,
-          invoiceId: payerInvoice.id, deductedBillingRunIds: [], periodTo: new Date(), notes: input.notes,
+        const payerRun = await bookPayerRun(tx, {
+          matterId: input.matterId, payerRecipient: input.payerRecipient, payerInvoiceId: payerInvoice.id,
+          payerGross, notes: input.notes, krRun,
         });
-        await freezeWork(tx, input.matterId, payerRun.id);
         await emit.invoiceCreated(ctx, clientInvoice);
         await emit.invoiceCreated(ctx, payerInvoice);
         return { split, clientInvoice, payerInvoice, clientRun, payerRun };

--- a/test/unit/app/matters/billing-panel.test.tsx
+++ b/test/unit/app/matters/billing-panel.test.tsx
@@ -216,6 +216,17 @@ describe("BillingPanel — Skapa-faktura-menyn (optionsFor)", () => {
     fireEvent.click(screen.getByRole("button", { name: "Kostnadsräkning till domstol" }));
     expect(screen.getByTestId("kr-modal")).toBeInTheDocument();
   });
+
+  it("RATTSHJALP: kostnadsräkning till domstol (ej direktfaktura) — öppnar rättshjälps-dialogen", () => {
+    render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={{ ...baseMatter, paymentMethod: "RATTSHJALP" }} />);
+    fireEvent.click(screen.getByRole("button", { name: "+ Skapa faktura" }));
+    // Domstolen får en kostnadsräkning — INTE "Faktura till myndighet" (#806).
+    expect(screen.queryByRole("button", { name: /Faktura till myndighet/ })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Kostnadsräkning till domstol" }));
+    // Rättshjälps-dialogen (egen, ej brottmåls-KR-modalen) bekräftar inskicket.
+    expect(screen.getByRole("button", { name: "Skicka kostnadsräkning" })).toBeInTheDocument();
+    expect(screen.queryByTestId("kr-modal")).not.toBeInTheDocument();
+  });
 });
 
 describe("BillingPanel — rådgivnings-banner (rättshjälp)", () => {

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -211,11 +211,12 @@ describe("billingRun.createKostnadsrakning", () => {
     expect(res.run.workValueOreAtRun).toBe(937500); // 3h × 2500 kr + 25 % moms (#782)
   });
 
-  it("fryser INTE rader (väntar tills setVerdict)", async () => {
+  it("fryser raderna vid inskick mot körningen (#806 — lämnar 'upparbetat ofakturerat')", async () => {
     const { ds, caller } = makeCaller({ workMinutes: 60 });
-    await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
-    const te = await ds.timeEntries.findFirst({ where: { id: "te-1" } }) as { frozenAt?: Date | null };
-    expect(te.frozenAt).toBeFalsy();
+    const res = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
+    const te = await ds.timeEntries.findFirst({ where: { id: "te-1" } }) as { frozenAt?: Date | null; frozenByBillingRunId?: string | null };
+    expect(te.frozenAt).toBeTruthy();
+    expect(te.frozenByBillingRunId).toBe(res.run.id);
   });
 });
 
@@ -363,5 +364,22 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
     const prutning = await ds.expenses.findFirst({ where: { matterId: "m-1", kind: "PRUTNING" } }) as { amount: number; billable: boolean };
     expect(prutning.amount).toBe(-25200);
     expect(prutning.billable).toBe(false);
+  });
+
+  it("rättshjälp via kostnadsräkning (#806): läser de frysta raderna och KONSUMERAR den väntande körningen (ingen dubbelräkning)", async () => {
+    const { ds, caller: c } = caller({ paymentMethod: "RATTSHJALP", clientShareBips: 2000, taxaHasFTax: true }, 999999);
+    const kr = await c.billingRun.createKostnadsrakning({ matterId: "m-1" });
+    expect(kr.run.status).toBe("PENDING_VERDICT");
+    const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "RATTSHJALPSMYNDIGHET", awardedOre: 300000 });
+    // Samma split som utan KR — arbetet är fryst mot körningen och läses via den.
+    expect(res.split).toMatchObject({ clientOre: 60000, payerOre: 240000, firmLossOre: 25200 });
+    expect(res.clientInvoice.amount).toBe(75000);
+    expect(res.payerInvoice.amount).toBe(300000);
+    // Den väntande kostnadsräkningen blir betalar-körningen (→ SENT, faktura länkad)
+    // i stället för en ny FINAL → "Väntar på dom" släcks utan dubbelräkning.
+    expect(res.payerRun.id).toBe(kr.run.id);
+    const consumed = await ds.billingRuns.findFirst({ where: { id: kr.run.id } }) as { status: string; invoiceId: string };
+    expect(consumed.status).toBe("SENT");
+    expect(consumed.invoiceId).toBe(res.payerInvoice.id);
   });
 });


### PR DESCRIPTION
## Vad

I rättshjälpsärenden är det **domstolen** som ska ha en **kostnadsräkning** — inte en faktura. Den bedöms och kan prutas; beloppet vet man först vid domen. Tidigare hade rättshjälp en direktfaktura ("Faktura till myndighet"), vilket var fel.

- **Meny:** rättshjälp får *Aconto till klient* + **Kostnadsräkning till domstol** (ersätter "Faktura till myndighet") + *Slutreglera (dom)*.
- **Frys vid inskick:** `createKostnadsrakning` fryser nu det upparbetade direkt → posterna lämnar **"Upparbetat ofakturerat"** med en gång. Dom/slutreglering läser dem via körningen — ny repo-metod `listByBillingRun` (time-entry + expense, interface + drizzle + in-memory).
- **Verdict-routing:** "Väntar på dom"-bannern öppnar för rättshjälp **slutregleringen** (klient/stat/byrå-split via `computeCoverageSplit`) i stället för offentlig-försvararens `VerdictDialog`. `settleCoverage` **konsumerar** den väntande kostnadsräkningen (→ `SENT`, betalar-faktura länkad) så "Väntar på dom" släcks utan dubbelräkning; `setVerdict` (offentligt uppdrag) läser nu också den frysta körningens rader.
- **UI:** enkel `RattshjalpKrDialog` (timkostnadsnorm-baserad bekräftelse) i stället för brottmåls-modalen.

## Verifiering

- `tsc --noEmit` (root + test): rent
- ESLint + knip + dep-cruiser: rent (komplexitet ≤8 — extraherade `bookFirmLoss`/`bookPayerRun`/`KostnadsrakningEntry`)
- `bun test --parallel`: 3625 pass (21 fail = kända miljö-fel: helper-ui/CORS), inkl. nya tester:
  - createKostnadsrakning fryser vid inskick
  - settleCoverage via kostnadsräkning konsumerar körningen (ingen dubbelräkning)
  - panel: rättshjälp visar "Kostnadsräkning till domstol", ej "Faktura till myndighet"
- `build:demo`: OK

Följdärende: #807 (branda `contacts[].role: string` → ContactRole-enum).

Closes #806

🤖 Generated with [Claude Code](https://claude.com/claude-code)
