### PR TITLE
feat(billing): exkludera rådgivningstimmen ur rättshjälpens avgiftsbas (#809)

### DIFF
--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -23,8 +23,9 @@ import { computeCoverageSplit, type CoverageSplit } from "@/lib/shared/coverage-
 import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
 import { ocrFromInvoiceNumber } from "@/lib/shared/ocr-reference";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
+import { RADGIVNING_MINUTES } from "@/lib/shared/rattshjalp";
 import type { BillingRun } from "@/lib/shared/schemas/billing";
-import { billingRunRecipientSchema, type BillingRunRecipient, type ExpenseKind } from "@/lib/shared/schemas/enums";
+import { billingRunRecipientSchema, type BillingRunRecipient, type ExpenseKind, type PaymentMethod } from "@/lib/shared/schemas/enums";
 import {
   matterIdSchema,
   billingRunIdSchema,
@@ -79,6 +80,16 @@ interface BillingProposal {
 /** Värdet på en (debiterbar) tidspost i öre — speglar workValueOre:s ton. */
 function timeEntryValueOre(minutes: number, hourlyRate: number): number {
   return Math.round((minutes / 60) * hourlyRate);
+}
+
+/**
+ * Minuter som rättshjälpsavgiften/coverage-splitten baseras på (#809): rättshjälp
+ * exkluderar rådgivningstimmen — ärendets första timme loggas som vanlig tidspost
+ * men faktureras klienten separat (rådgivningsavgiften) och ingår INTE i avgifts-
+ * basen. Övriga betalningssätt: oförändrat.
+ */
+function coverageBaseMinutes(method: PaymentMethod, billableMinutes: number): number {
+  return method === "RATTSHJALP" ? Math.max(0, billableMinutes - RADGIVNING_MINUTES) : billableMinutes;
 }
 
 async function fetchUnfrozenWork(repos: Repositories, matterId: MatterId): Promise<UnfrozenWork> {
@@ -548,7 +559,8 @@ export const billingRunRouter = router({
       if (!matter) throw new TRPCError({ code: "NOT_FOUND", message: "Ärendet finns inte." });
       const { billableMinutes } = await ctx.repos.timeEntries.coverageUsageForMatter(input.matterId);
       const currentRateOre = await currentArvodeRateOre(ctx.repos, ctx.orgId, matter);
-      const totalOre = Math.round((billableMinutes / 60) * currentRateOre);
+      const baseMinutes = coverageBaseMinutes(matter.paymentMethod, billableMinutes);
+      const totalOre = Math.round((baseMinutes / 60) * currentRateOre);
       const split = computeCoverageSplit({
         method: matter.paymentMethod,
         totalOre,
@@ -630,7 +642,8 @@ export const billingRunRouter = router({
         const { work, krRun } = await resolveSettlementWork(tx, ctx.orgId, input.matterId);
         const billableMinutes = work.timeEntries.filter((t) => t.billable).reduce((s, t) => s + t.minutes, 0);
         const rateOre = await currentArvodeRateOre(tx, ctx.orgId, matter);
-        const totalArvodeNet = Math.round((billableMinutes / 60) * rateOre);
+        const baseMinutes = coverageBaseMinutes(matter.paymentMethod, billableMinutes);
+        const totalArvodeNet = Math.round((baseMinutes / 60) * rateOre);
         const split = computeCoverageSplit({
           method: matter.paymentMethod, totalOre: totalArvodeNet, clientShareBips: matter.clientShareBips ?? 0,
           awardedOre: input.awardedOre ?? null, insurerPrutningOre: input.insurerPrutningOre ?? null,

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -300,13 +300,13 @@ describe("billingRun.list / byId", () => {
 });
 
 describe("billingRun.coverageSplit — prutning/självrisk på aktuellt timarvode (#800)", () => {
-  function caller(matterExtra: Record<string, unknown>, currentRate: number) {
+  function caller(matterExtra: Record<string, unknown>, currentRate: number, minutes = 120) {
     const ds = new DemoDataStore({
       organizations: [{ id: "org-1", name: "X" }],
       matters: [{ id: "m-1", organizationId: "org-1", matterNumber: "2026-0001", title: "T", status: "ACTIVE", responsibleLawyerId: "u-1", ...matterExtra, createdAt: new Date() }],
       // Juristens AKTUELLA timtaxa = currentRate (skiljer sig från tidspostens snapshot 200000).
       users: [{ id: "u-1", organizationId: "org-1", email: "a@x", name: "Anna", role: "ADMIN", hourlyRate: currentRate }],
-      timeEntries: [{ id: "te-1", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), minutes: 120, description: "M", hourlyRate: 200000, billable: true }],
+      timeEntries: [{ id: "te-1", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), minutes, description: "M", hourlyRate: 200000, billable: true }],
     }, async () => {});
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return appRouter.createCaller(buildContext({ dataStore: ds, ports: noopPorts, principal: PRINCIPAL }) as any);
@@ -323,23 +323,31 @@ describe("billingRun.coverageSplit — prutning/självrisk på aktuellt timarvod
   });
 
   it("rättshjälp: värderar på timkostnadsnormen; dom-prutning → byrå-förlust + klient på reducerat", async () => {
-    // 2 tim × 1626 kr = 325 200 öre total; dom 300 000 → förlust 25 200; klient 20 % × 300 000.
-    const c = caller({ paymentMethod: "RATTSHJALP", clientShareBips: 2000, taxaHasFTax: true }, 999999);
+    // 3 tim loggat, varav 1 tim rådgivning (exkl, #809) → 2 effektiva tim × 1626 kr =
+    // 325 200 öre bas; dom 300 000 → förlust 25 200; klient 20 % × 300 000.
+    const c = caller({ paymentMethod: "RATTSHJALP", clientShareBips: 2000, taxaHasFTax: true }, 999999, 180);
     const r = await c.billingRun.coverageSplit({ matterId: "m-1", awardedOre: 300000 });
     expect(r.totalOre).toBe(325200);
     expect(r.firmLossOre).toBe(25200);
     expect(r.clientOre).toBe(60000);
     expect(r.payerOre).toBe(240000);
   });
+
+  it("rättshjälp: rådgivningstimmen exkluderas ur avgiftsbasen (#809)", async () => {
+    // 2 tim loggat, 1 tim rådgivning exkl → bas = 1 effektiv tim × 1626 kr = 162 600.
+    const c = caller({ paymentMethod: "RATTSHJALP", clientShareBips: 2000, taxaHasFTax: true }, 999999, 120);
+    const r = await c.billingRun.coverageSplit({ matterId: "m-1" });
+    expect(r.totalOre).toBe(162600);
+  });
 });
 
 describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", () => {
-  function caller(matterExtra: Record<string, unknown>, currentRate: number) {
+  function caller(matterExtra: Record<string, unknown>, currentRate: number, minutes = 120) {
     const ds = new DemoDataStore({
       organizations: [{ id: "org-1", name: "X" }],
       matters: [{ id: "m-1", organizationId: "org-1", matterNumber: "2026-0001", title: "T", status: "ACTIVE", responsibleLawyerId: "u-1", ...matterExtra, createdAt: new Date() }],
       users: [{ id: "u-1", organizationId: "org-1", email: "a@x", name: "Anna", role: "ADMIN", hourlyRate: currentRate }],
-      timeEntries: [{ id: "te-1", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), minutes: 120, description: "M", hourlyRate: 200000, billable: true }],
+      timeEntries: [{ id: "te-1", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), minutes, description: "M", hourlyRate: 200000, billable: true }],
     }, async () => {});
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return { ds, caller: appRouter.createCaller(buildContext({ dataStore: ds, ports: noopPorts, principal: PRINCIPAL }) as any) };
@@ -355,7 +363,8 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
   });
 
   it("rättshjälp: timkostnadsnorm; dom prutar → byrå-förlust bokas (icke-debiterbar PRUTNING), klient på reducerat", async () => {
-    const { ds, caller: c } = caller({ paymentMethod: "RATTSHJALP", clientShareBips: 2000, taxaHasFTax: true }, 999999);
+    // 3 tim loggat − 1 tim rådgivning (#809) = 2 effektiva tim → bas 325 200.
+    const { ds, caller: c } = caller({ paymentMethod: "RATTSHJALP", clientShareBips: 2000, taxaHasFTax: true }, 999999, 180);
     const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "RATTSHJALPSMYNDIGHET", awardedOre: 300000 });
     // total 325200; dom 300000 → förlust 25200; klient 60000 → 75000; stat 240000 → 300000.
     expect(res.split).toMatchObject({ clientOre: 60000, payerOre: 240000, firmLossOre: 25200 });
@@ -367,7 +376,7 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
   });
 
   it("rättshjälp via kostnadsräkning (#806): läser de frysta raderna och KONSUMERAR den väntande körningen (ingen dubbelräkning)", async () => {
-    const { ds, caller: c } = caller({ paymentMethod: "RATTSHJALP", clientShareBips: 2000, taxaHasFTax: true }, 999999);
+    const { ds, caller: c } = caller({ paymentMethod: "RATTSHJALP", clientShareBips: 2000, taxaHasFTax: true }, 999999, 180);
     const kr = await c.billingRun.createKostnadsrakning({ matterId: "m-1" });
     expect(kr.run.status).toBe("PENDING_VERDICT");
     const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "RATTSHJALPSMYNDIGHET", awardedOre: 300000 });


### PR DESCRIPTION
## Vad

I rättshjälp loggas ärendets **första timme** som vanlig tidspost men faktureras klienten separat (rådgivningsavgiften, `createRadgivning`). Den ska **inte** ingå i det belopp som rättshjälpsavgiften (klientens `clientShareBips`-andel) baseras på.

`coverageSplit` (förhandsvisning) + `settleCoverage` (bokning) drar nu av en rådgivningstimme från basen för rättshjälp:

```
bas-minuter = paymentMethod === RATTSHJALP ? max(0, billableMinutes − 60) : billableMinutes
```

Övriga betalningssätt oförändrade. Täcknings-**taket** (#793) lämnas orört — kravet gäller uttryckligen avgiftsbasen.

## Verifiering

- `tsc --noEmit`: rent · ESLint + knip + dep-cruiser: rent
- `bun test --parallel`: 3626 pass (21 = kända miljö-fel: helper-ui/CORS). Nya/uppdaterade:
  - "rådgivningstimmen exkluderas ur avgiftsbasen" (2 tim loggat → bas 1 effektiv tim)
  - rättshjälps-scenarierna i coverageSplit/settleCoverage loggar nu 3 tim (1 rådgivning + 2 effektiva) → samma belopp som förr
- `build:demo`: OK

Del 1 av 3 (rättshjälp/rättsskydd-spec). Nästa: #810 (rättsskydd tidsuppdelad split), #811 (rättsskydd nekat → rättshjälp).

Closes #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)
