### PR TITLE
feat(billing): rättsskydd tidsuppdelad split — wiring + UI (#810 steg 2)

### DIFF
--- a/src/app/matters/[id]/_client.tsx
+++ b/src/app/matters/[id]/_client.tsx
@@ -103,6 +103,8 @@ function MatterPaymentMethod({ matterId, matter }: {
     clientShareBips?: number | null | undefined;
     rattsskyddMaxOre?: number | null | undefined;
     rattshjalpMaxTimmar?: number | null | undefined;
+    tvistUppkomDatum?: Date | string | null | undefined;
+    rattsskyddBeslutDatum?: Date | string | null | undefined;
   };
 }) {
   const rattsskyddMaxOre = matter.rattsskyddMaxOre ?? null;
@@ -123,6 +125,8 @@ function MatterPaymentMethod({ matterId, matter }: {
         clientShareBips={matter.clientShareBips ?? null}
         rattsskyddMaxOre={rattsskyddMaxOre}
         rattshjalpMaxTimmar={rattshjalpMaxTimmar}
+        tvistUppkomDatum={matter.tvistUppkomDatum ?? null}
+        rattsskyddBeslutDatum={matter.rattsskyddBeslutDatum ?? null}
       />
     </>
   );

--- a/src/components/matter/payment-method-card.tsx
+++ b/src/components/matter/payment-method-card.tsx
@@ -38,6 +38,14 @@ interface Props {
   rattsskyddMaxOre: number | null;
   /** Rättshjälpens timtak; null → 100 tim (#793). */
   rattshjalpMaxTimmar: number | null;
+  /** Rättsskydd: tvistdatum (arbete före = ej täckt) + bolagets beslutsdatum (#810). */
+  tvistUppkomDatum?: Date | string | null;
+  rattsskyddBeslutDatum?: Date | string | null;
+}
+
+/** ISO-datum (yyyy-mm-dd) ur ett valfritt datumfält, tomt om saknas. */
+function isoDate(d: Date | string | null | undefined): string {
+  return d ? new Date(d).toISOString().slice(0, 10) : "";
 }
 
 /** Betalningssätt där klienten betalar en %-sats → visa/redigera andelen. */
@@ -149,6 +157,28 @@ function CoverageCapFields({ method, rsMaxKr, setRsMaxKr, rhMaxTim, setRhMaxTim 
   return null;
 }
 
+/** Rättsskyddets datum ur bolagets beslut (#810): tvistdatum (arbete före = ej
+ *  täckt) + beslutsdatum (retroaktivt täcks ≤6 h). Endast för rättsskydd. */
+function RattsskyddDates({ method, tvist, setTvist, beslut, setBeslut }: {
+  method: PaymentMethod;
+  tvist: string; setTvist: (v: string) => void;
+  beslut: string; setBeslut: (v: string) => void;
+}) {
+  if (method !== "RATTSSKYDD") return null;
+  return (
+    <div className="grid grid-cols-2 gap-2">
+      <label className="block text-xs font-medium">Tvist uppkom (datum)
+        <input type="date" value={tvist} onChange={(e) => setTvist(e.target.value)}
+          className="mt-1 w-full border border-gray-300 rounded px-2 py-1.5 text-sm" />
+      </label>
+      <label className="block text-xs font-medium">Försäkringens beslut (datum)
+        <input type="date" value={beslut} onChange={(e) => setBeslut(e.target.value)}
+          className="mt-1 w-full border border-gray-300 rounded px-2 py-1.5 text-sm" />
+      </label>
+    </div>
+  );
+}
+
 /** %-andels-fältet (självrisk/avgift). Utbrutet så editorn håller sig ≤100 rader. */
 function ClientShareField({ id, value, onChange }: { id: string; value: string; onChange: (v: string) => void }) {
   return (
@@ -184,6 +214,8 @@ function PaymentMethodEditor({ matterId, initial, onDone }: { matterId: MatterId
   // Tak: rättsskydd i kr (öre/100), rättshjälp i timmar. Tomt fält → null.
   const [rsMaxKr, setRsMaxKr] = useState(initial.rattsskyddMaxOre != null ? String(initial.rattsskyddMaxOre / 100) : "");
   const [rhMaxTim, setRhMaxTim] = useState(initial.rattshjalpMaxTimmar != null ? String(initial.rattshjalpMaxTimmar) : "");
+  const [tvist, setTvist] = useState(isoDate(initial.tvistUppkomDatum));
+  const [beslut, setBeslut] = useState(isoDate(initial.rattsskyddBeslutDatum));
   const methodId = useId();
   const decidedAtId = useId();
   const noteId = useId();
@@ -218,6 +250,7 @@ function PaymentMethodEditor({ matterId, initial, onDone }: { matterId: MatterId
           <ClientShareField id={shareId} value={sharePct} onChange={setSharePct} />
         )}
         <CoverageCapFields method={method} rsMaxKr={rsMaxKr} setRsMaxKr={setRsMaxKr} rhMaxTim={rhMaxTim} setRhMaxTim={setRhMaxTim} />
+        <RattsskyddDates method={method} tvist={tvist} setTvist={setTvist} beslut={beslut} setBeslut={setBeslut} />
         <div>
           <label htmlFor={decidedAtId} className="block text-xs font-medium mb-1">
             Beslutsdatum (om rättshjälp/rättsskydd beviljats)
@@ -258,6 +291,8 @@ function PaymentMethodEditor({ matterId, initial, onDone }: { matterId: MatterId
                 clientShareBips: clientShareFromPct(sharePct),
                 rattsskyddMaxOre: oreFromKr(rsMaxKr),
                 rattshjalpMaxTimmar: positiveIntOrNull(rhMaxTim),
+                tvistUppkomDatum: tvist || null,
+                rattsskyddBeslutDatum: beslut || null,
               })
             }
             className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -121,6 +121,9 @@ export const matters = pgTable("matters", {
   /** Rättsskyddets maxbelopp (öre) resp. rättshjälpens timtak — täcknings-tak (#793). */
   rattsskyddMaxOre: integer("rattsskydd_max_ore"),
   rattshjalpMaxTimmar: integer("rattshjalp_max_timmar"),
+  /** Rättsskydd (#810): tvistdatum (arbete före = ej täckt) + bolagets beslutsdatum (retro ≤6h). */
+  tvistUppkomDatum: timestamp("tvist_uppkom_datum", { withTimezone: true }),
+  rattsskyddBeslutDatum: timestamp("rattsskydd_beslut_datum", { withTimezone: true }),
 }, (t) => [index("matters_org_idx").on(t.organizationId)]);
 
 /**

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -19,7 +19,7 @@ import { z } from "zod";
 import type { VatBreakdownLine } from "@/lib/shared/accounting/semantic-voucher";
 import { proposedAccontoOre } from "@/lib/shared/billing-proposal";
 import { TIMKOSTNADSNORM_FTAX_ORE_PER_H, TIMKOSTNADSNORM_NO_FTAX_ORE_PER_H } from "@/lib/shared/brottmalstaxa";
-import { computeCoverageSplit, type CoverageSplit } from "@/lib/shared/coverage-billing";
+import { computeCoverageSplit, partitionRattsskyddMinutes, type CoverageSplit } from "@/lib/shared/coverage-billing";
 import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
 import { ocrFromInvoiceNumber } from "@/lib/shared/ocr-reference";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
@@ -48,7 +48,7 @@ import type { Repositories } from "../repositories/repositories";
 import { router, orgProcedure } from "../trpc";
 
 interface UnfrozenWork {
-  timeEntries: Array<{ id: TimeEntryId; minutes: number; hourlyRate: number; billable: boolean }>;
+  timeEntries: Array<{ id: TimeEntryId; minutes: number; hourlyRate: number; billable: boolean; date: Date | string }>;
   expenses: Array<{ id: ExpenseId; amount: number; billable: boolean; vatRate?: number | null; vatIncluded?: boolean | null }>;
 }
 
@@ -90,6 +90,32 @@ function timeEntryValueOre(minutes: number, hourlyRate: number): number {
  */
 function coverageBaseMinutes(method: PaymentMethod, billableMinutes: number): number {
   return method === "RATTSHJALP" ? Math.max(0, billableMinutes - RADGIVNING_MINUTES) : billableMinutes;
+}
+
+/** Matter-fält som styr rättsskyddets tidsuppdelning + tak. */
+interface RattsskyddMatter {
+  paymentMethod: PaymentMethod;
+  tvistUppkomDatum?: Date | string | null | undefined;
+  rattsskyddBeslutDatum?: Date | string | null | undefined;
+  rattsskyddMaxOre?: number | null | undefined;
+}
+
+/**
+ * Rättsskydds-tillägg till computeCoverageSplit (#810): tidsuppdelar arbetet
+ * (täckt del efter tvist/retro-tak) → `coveredOre`, samt försäkringens tak →
+ * `capOre`. Tom för andra betalningssätt (då gäller standard-splitten).
+ */
+function rattsskyddCoverage(
+  matter: RattsskyddMatter,
+  entries: ReadonlyArray<{ date: Date | string; minutes: number; billable: boolean }>,
+  rateOre: number,
+): { coveredOre?: number; capOre?: number } {
+  if (matter.paymentMethod !== "RATTSSKYDD") return {};
+  const p = partitionRattsskyddMinutes(entries, matter.tvistUppkomDatum ?? null, matter.rattsskyddBeslutDatum ?? null);
+  return omitUndefined({
+    coveredOre: Math.round((p.coveredMinutes / 60) * rateOre),
+    capOre: matter.rattsskyddMaxOre ?? undefined,
+  });
 }
 
 async function fetchUnfrozenWork(repos: Repositories, matterId: MatterId): Promise<UnfrozenWork> {
@@ -338,7 +364,7 @@ async function resolveFinalWork(
   }
   return {
     work: {
-      timeEntries: selTime.map((t) => ({ id: t.id, minutes: t.minutes, hourlyRate: t.user.hourlyRate ?? 0, billable: t.billable })),
+      timeEntries: selTime.map((t) => ({ id: t.id, minutes: t.minutes, hourlyRate: t.user.hourlyRate ?? 0, billable: t.billable, date: t.date })),
       expenses: selExp.filter((e) => e.kind !== "PRUTNING").map((e) => ({ id: e.id, amount: e.amount, billable: e.billable, vatRate: e.vatRate, vatIncluded: e.vatIncluded })),
     },
     selected: true,
@@ -558,6 +584,7 @@ export const billingRunRouter = router({
       const matter = await ctx.repos.matters.getByIdInOrg(input.matterId, ctx.orgId);
       if (!matter) throw new TRPCError({ code: "NOT_FOUND", message: "Ärendet finns inte." });
       const { billableMinutes } = await ctx.repos.timeEntries.coverageUsageForMatter(input.matterId);
+      const entries = await ctx.repos.timeEntries.listUnfrozenForMatter(input.matterId);
       const currentRateOre = await currentArvodeRateOre(ctx.repos, ctx.orgId, matter);
       const baseMinutes = coverageBaseMinutes(matter.paymentMethod, billableMinutes);
       const totalOre = Math.round((baseMinutes / 60) * currentRateOre);
@@ -567,6 +594,7 @@ export const billingRunRouter = router({
         clientShareBips: matter.clientShareBips ?? 0,
         ...(input.awardedOre != null ? { awardedOre: input.awardedOre } : {}),
         ...(input.insurerPrutningOre != null ? { insurerPrutningOre: input.insurerPrutningOre } : {}),
+        ...rattsskyddCoverage(matter, entries, currentRateOre),
       });
       return { ...split, totalOre, currentRateOre, billableMinutes };
     }),
@@ -647,6 +675,7 @@ export const billingRunRouter = router({
         const split = computeCoverageSplit({
           method: matter.paymentMethod, totalOre: totalArvodeNet, clientShareBips: matter.clientShareBips ?? 0,
           awardedOre: input.awardedOre ?? null, insurerPrutningOre: input.insurerPrutningOre ?? null,
+          ...rattsskyddCoverage(matter, work.timeEntries, rateOre),
         });
         const { clientLines, payerLines } = coverageInvoiceLines(split, work);
 

--- a/src/lib/server/routers/matter.ts
+++ b/src/lib/server/routers/matter.ts
@@ -119,6 +119,13 @@ function toDateOrNull(v: string | null | undefined): Date | null | undefined {
   return v ? new Date(v) : null;
 }
 
+/** Sätter ett datumfält (sträng → Date | null) på update-datat, men bara om
+ *  det skickades med (undefined = rör ej). Håller update-mutationen ≤8. */
+function applyOptionalDate(data: Record<string, unknown>, key: string, value: string | null | undefined): void {
+  const d = toDateOrNull(value);
+  if (d !== undefined) data[key] = d;
+}
+
 function buildMatterData(
   orgId: string,
   matterNumber: string,
@@ -231,6 +238,9 @@ export const matterRouter = router({
         clientShareBips: z.number().int().min(0).max(10000).nullable().optional(),
         rattsskyddMaxOre: z.number().int().nonnegative().nullable().optional(),
         rattshjalpMaxTimmar: z.number().int().positive().nullable().optional(),
+        /** Rättsskydd (#810): tvistdatum + bolagets beslutsdatum, ur beslutet. */
+        tvistUppkomDatum: z.string().nullable().optional(),
+        rattsskyddBeslutDatum: z.string().nullable().optional(),
         isTaxeArende: z.boolean().optional(),
         taxaLevel: z.number().int().min(1).max(4).nullable().optional(),
         taxaHuvudforhandlingMin: z.number().int().nonnegative().nullable().optional(),
@@ -240,16 +250,13 @@ export const matterRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       const before = await assertMatterInOrg(ctx, asId<"MatterId">(input.id));
-      const { id, paymentMethodDecidedAt, taxaHufStart, ...rest } = input;
+      const { id, paymentMethodDecidedAt, taxaHufStart, tvistUppkomDatum, rattsskyddBeslutDatum, ...rest } = input;
       const data: Record<string, unknown> = { ...rest };
-      if (paymentMethodDecidedAt !== undefined) {
-        data.paymentMethodDecidedAt = paymentMethodDecidedAt
-          ? new Date(paymentMethodDecidedAt)
-          : null;
-      }
-      if (taxaHufStart !== undefined) {
-        data.taxaHufStart = taxaHufStart ? new Date(taxaHufStart) : null;
-      }
+      // Datumsträngar (yyyy-mm-dd) → Date | null; lämna orörda om utelämnade.
+      applyOptionalDate(data, "paymentMethodDecidedAt", paymentMethodDecidedAt);
+      applyOptionalDate(data, "taxaHufStart", taxaHufStart);
+      applyOptionalDate(data, "tvistUppkomDatum", tvistUppkomDatum);
+      applyOptionalDate(data, "rattsskyddBeslutDatum", rattsskyddBeslutDatum);
       const updated = await ctx.repos.matters.update(id, data satisfies Partial<Matter>);
       await emit.matterUpdated(ctx, id, data);
       if (input.status && input.status !== before.status) {

--- a/src/lib/shared/schemas/matter.ts
+++ b/src/lib/shared/schemas/matter.ts
@@ -49,6 +49,17 @@ export const matterSchema = z.object({
    */
   rattshjalpMaxTimmar: z.number().int().positive().nullish(),
   /**
+   * Rättsskydd: det datum försäkringsbolaget fastställer att TVIST uppkom (ur
+   * beslutet). Arbete före detta datum täcks ALDRIG → klienten betalar 100 %
+   * fram till dess; därefter gäller självrisksandelen (#810). Null = ej satt.
+   */
+  tvistUppkomDatum: optionalDateLike,
+  /**
+   * Rättsskydd: datum för försäkringsbolagets POSITIVA beslut (ur beslutet).
+   * Arbete före beslutet är retroaktivt och täcks med högst 6 h (#810). Null = ej satt.
+   */
+  rattsskyddBeslutDatum: optionalDateLike,
+  /**
    * `isTaxeArende` — ärendet ersätts enligt Domstolsverkets fastställda
    * taxa (schablon) istället för löpande timdebitering.
    *

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -391,4 +391,29 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
     expect(consumed.status).toBe("SENT");
     expect(consumed.invoiceId).toBe(res.payerInvoice.id);
   });
+
+  it("rättsskydd tidsuppdelat (#810): arbete före tvist → klient 100 %, retro+efter beslut täckt", async () => {
+    const ds = new DemoDataStore({
+      organizations: [{ id: "org-1", name: "X" }],
+      matters: [{
+        id: "m-1", organizationId: "org-1", matterNumber: "2026-0001", title: "T", status: "ACTIVE",
+        responsibleLawyerId: "u-1", paymentMethod: "RATTSSKYDD", clientShareBips: 2000,
+        tvistUppkomDatum: new Date("2026-03-01"), rattsskyddBeslutDatum: new Date("2026-04-01"), createdAt: new Date(),
+      }],
+      users: [{ id: "u-1", organizationId: "org-1", email: "a@x", name: "Anna", role: "ADMIN", hourlyRate: 300000 }],
+      timeEntries: [
+        { id: "te-pre", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date("2026-02-01"), minutes: 120, description: "före tvist", hourlyRate: 200000, billable: true },
+        { id: "te-retro", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date("2026-03-15"), minutes: 120, description: "retroaktivt", hourlyRate: 200000, billable: true },
+        { id: "te-post", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date("2026-04-15"), minutes: 120, description: "efter beslut", hourlyRate: 200000, billable: true },
+      ],
+    }, async () => {});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const c = appRouter.createCaller(buildContext({ dataStore: ds, ports: noopPorts, principal: PRINCIPAL }) as any);
+    const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "FORSAKRING" });
+    // 6 tim × 3000 = 1 800 000 total; täckt 4 tim (retro 2 + efter 2) = 1 200 000.
+    // självrisk 20 % × 1 200 000 = 240 000; otäckt (2 tim före tvist) = 600 000.
+    expect(res.split).toMatchObject({ clientOre: 840_000, payerOre: 960_000, firmLossOre: 0 });
+    expect(res.clientInvoice.amount).toBe(1_050_000); // 840 000 × 1,25 moms
+    expect(res.payerInvoice.amount).toBe(1_200_000); // 960 000 × 1,25 moms
+  });
 });

--- a/tooling/db/migrations/0010_matter_rattsskydd_dates.sql
+++ b/tooling/db/migrations/0010_matter_rattsskydd_dates.sql
@@ -1,0 +1,5 @@
+-- #810: rättsskyddets tidsuppdelade självrisk-split. Tvistdatum (arbete före =
+-- aldrig täckt → klient 100 %) + bolagets positiva beslutsdatum (arbete före
+-- beslutet är retroaktivt och täcks med högst 6 h). NULL = ej satt.
+ALTER TABLE matters ADD COLUMN IF NOT EXISTS tvist_uppkom_datum timestamptz;
+ALTER TABLE matters ADD COLUMN IF NOT EXISTS rattsskydd_beslut_datum timestamptz;


### PR DESCRIPTION
## Vad (steg 2 av 2 — kopplar in #813)

Rättsskyddets tidsuppdelade självrisk-split, nu inkopplad i schema, router och UI.

- **Matter-fält:** `tvistUppkomDatum` + `rattsskyddBeslutDatum` (zod-schema + drizzle-kolumner + **migration 0010** + `matter.update` med datumkonvertering, utbruten `applyOptionalDate` för komplexitet ≤8).
- **billingRun:** `coverageSplit` (förhandsvisning) och `settleCoverage` (bokning) tidsuppdelar rättsskydds-arbetet via `rattsskyddCoverage` → `coveredOre` (`partitionRattsskyddMinutes`) och skickar försäkringens tak (`rattsskyddMaxOre` → `capOre`). `UnfrozenWork.timeEntries` bär nu `date`.
- **UI:** `payment-method-card` får datuminmatning (tvist + beslut) för rättsskydd; värdena trådas via matter-detaljvyn.

Resultat: arbete **före tvistdatum** → klient **100 %**; **retroaktivt** (tvist→beslut) täcks **≤6 h**; **efter beslut** täcks fullt; försäkringen kapas vid taket. Byrån blir hel.

## Verifiering

- `tsc --noEmit` (root + test): rent · ESLint + knip + dep-cruiser: rent (komplexitet ≤8 — `applyOptionalDate`/`RattsskyddDates`/`rattsskyddCoverage` utbrutna)
- `bun test --parallel`: 3634 pass (21 = kända miljö-fel). Nytt integrationstest: rättsskydd med tvist-/beslutsdatum + 3 daterade poster (före/retro/efter) → klient 840 000 (otäckt 600 000 + självrisk 240 000), försäkring 960 000; fakturor inkl moms.
- `build:demo`: OK

Avslutar #810 (steg 1 = #813). Kvar i spec: #811 (rättsskydd nekat → rättshjälp).

Closes #810

🤖 Generated with [Claude Code](https://claude.com/claude-code)
