### PR TITLE
feat(matter): rättsskydd nekat → föreslå rättshjälp (#811)

### DIFF
--- a/src/app/matters/[id]/_client.tsx
+++ b/src/app/matters/[id]/_client.tsx
@@ -7,6 +7,7 @@ import { DocumentBrowser } from "@/components/documents/document-browser";
 import { CoverageCapWarning } from "@/components/matter/coverage-cap-warning";
 import { EventsPanel } from "@/components/matter/events-panel";
 import { PaymentMethodCard } from "@/components/matter/payment-method-card";
+import { RattsskyddNekadBanner } from "@/components/matter/rattsskydd-nekad-banner";
 import { SuggestionsPanel } from "@/components/matter/suggestions-panel";
 import { EntityLink } from "@/lib/client/demo/entity-link";
 import { useRouteId } from "@/lib/client/demo/use-route-id";
@@ -105,6 +106,7 @@ function MatterPaymentMethod({ matterId, matter }: {
     rattshjalpMaxTimmar?: number | null | undefined;
     tvistUppkomDatum?: Date | string | null | undefined;
     rattsskyddBeslutDatum?: Date | string | null | undefined;
+    rattsskyddNekadAt?: Date | string | null | undefined;
   };
 }) {
   const rattsskyddMaxOre = matter.rattsskyddMaxOre ?? null;
@@ -117,6 +119,11 @@ function MatterPaymentMethod({ matterId, matter }: {
         rattsskyddMaxOre={rattsskyddMaxOre}
         rattshjalpMaxTimmar={rattshjalpMaxTimmar}
       />
+      <RattsskyddNekadBanner
+        matterId={matterId}
+        paymentMethod={matter.paymentMethod}
+        rattsskyddNekadAt={matter.rattsskyddNekadAt}
+      />
       <PaymentMethodCard
         matterId={matterId}
         paymentMethod={matter.paymentMethod}
@@ -125,8 +132,9 @@ function MatterPaymentMethod({ matterId, matter }: {
         clientShareBips={matter.clientShareBips ?? null}
         rattsskyddMaxOre={rattsskyddMaxOre}
         rattshjalpMaxTimmar={rattshjalpMaxTimmar}
-        tvistUppkomDatum={matter.tvistUppkomDatum ?? null}
-        rattsskyddBeslutDatum={matter.rattsskyddBeslutDatum ?? null}
+        tvistUppkomDatum={matter.tvistUppkomDatum}
+        rattsskyddBeslutDatum={matter.rattsskyddBeslutDatum}
+        rattsskyddNekadAt={matter.rattsskyddNekadAt}
       />
     </>
   );

--- a/src/components/matter/payment-method-card.tsx
+++ b/src/components/matter/payment-method-card.tsx
@@ -39,8 +39,10 @@ interface Props {
   /** Rättshjälpens timtak; null → 100 tim (#793). */
   rattshjalpMaxTimmar: number | null;
   /** Rättsskydd: tvistdatum (arbete före = ej täckt) + bolagets beslutsdatum (#810). */
-  tvistUppkomDatum?: Date | string | null;
-  rattsskyddBeslutDatum?: Date | string | null;
+  tvistUppkomDatum?: Date | string | null | undefined;
+  rattsskyddBeslutDatum?: Date | string | null | undefined;
+  /** Rättsskydd: datum då rättsskydd nekades (#811). */
+  rattsskyddNekadAt?: Date | string | null | undefined;
 }
 
 /** ISO-datum (yyyy-mm-dd) ur ett valfritt datumfält, tomt om saknas. */
@@ -159,10 +161,11 @@ function CoverageCapFields({ method, rsMaxKr, setRsMaxKr, rhMaxTim, setRhMaxTim 
 
 /** Rättsskyddets datum ur bolagets beslut (#810): tvistdatum (arbete före = ej
  *  täckt) + beslutsdatum (retroaktivt täcks ≤6 h). Endast för rättsskydd. */
-function RattsskyddDates({ method, tvist, setTvist, beslut, setBeslut }: {
+function RattsskyddDates({ method, tvist, setTvist, beslut, setBeslut, nekad, setNekad }: {
   method: PaymentMethod;
   tvist: string; setTvist: (v: string) => void;
   beslut: string; setBeslut: (v: string) => void;
+  nekad: string; setNekad: (v: string) => void;
 }) {
   if (method !== "RATTSSKYDD") return null;
   return (
@@ -173,6 +176,10 @@ function RattsskyddDates({ method, tvist, setTvist, beslut, setBeslut }: {
       </label>
       <label className="block text-xs font-medium">Försäkringens beslut (datum)
         <input type="date" value={beslut} onChange={(e) => setBeslut(e.target.value)}
+          className="mt-1 w-full border border-gray-300 rounded px-2 py-1.5 text-sm" />
+      </label>
+      <label className="block text-xs font-medium col-span-2">Rättsskydd nekat (datum)
+        <input type="date" value={nekad} onChange={(e) => setNekad(e.target.value)}
           className="mt-1 w-full border border-gray-300 rounded px-2 py-1.5 text-sm" />
       </label>
     </div>
@@ -216,6 +223,7 @@ function PaymentMethodEditor({ matterId, initial, onDone }: { matterId: MatterId
   const [rhMaxTim, setRhMaxTim] = useState(initial.rattshjalpMaxTimmar != null ? String(initial.rattshjalpMaxTimmar) : "");
   const [tvist, setTvist] = useState(isoDate(initial.tvistUppkomDatum));
   const [beslut, setBeslut] = useState(isoDate(initial.rattsskyddBeslutDatum));
+  const [nekad, setNekad] = useState(isoDate(initial.rattsskyddNekadAt));
   const methodId = useId();
   const decidedAtId = useId();
   const noteId = useId();
@@ -250,7 +258,7 @@ function PaymentMethodEditor({ matterId, initial, onDone }: { matterId: MatterId
           <ClientShareField id={shareId} value={sharePct} onChange={setSharePct} />
         )}
         <CoverageCapFields method={method} rsMaxKr={rsMaxKr} setRsMaxKr={setRsMaxKr} rhMaxTim={rhMaxTim} setRhMaxTim={setRhMaxTim} />
-        <RattsskyddDates method={method} tvist={tvist} setTvist={setTvist} beslut={beslut} setBeslut={setBeslut} />
+        <RattsskyddDates method={method} tvist={tvist} setTvist={setTvist} beslut={beslut} setBeslut={setBeslut} nekad={nekad} setNekad={setNekad} />
         <div>
           <label htmlFor={decidedAtId} className="block text-xs font-medium mb-1">
             Beslutsdatum (om rättshjälp/rättsskydd beviljats)
@@ -293,6 +301,7 @@ function PaymentMethodEditor({ matterId, initial, onDone }: { matterId: MatterId
                 rattshjalpMaxTimmar: positiveIntOrNull(rhMaxTim),
                 tvistUppkomDatum: tvist || null,
                 rattsskyddBeslutDatum: beslut || null,
+                rattsskyddNekadAt: nekad || null,
               })
             }
             className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"

--- a/src/components/matter/rattsskydd-nekad-banner.tsx
+++ b/src/components/matter/rattsskydd-nekad-banner.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+/**
+ * `RattsskyddNekadBanner` (#811) — när försäkringen NEKAT rättsskydd är nästa
+ * steg att ansöka om rättshjälp, förutsatt att klientens ekonomiska underlag
+ * inte överstiger gränsen i 6 § rättshjälpslagen. Banner + snabbåtgärd som byter
+ * ärendets betalningssätt till rättshjälp. §6-prövningen är manuell (vi har ingen
+ * inkomstdata, och gränsbeloppet ändras) — texten påminner om kontrollen.
+ */
+
+import { trpc } from "@/lib/client/trpc";
+import type { PaymentMethod } from "@/lib/shared/schemas/enums";
+import type { MatterId } from "@/lib/shared/schemas/ids";
+
+function formatDate(d: Date | string): string {
+  return new Date(d).toISOString().slice(0, 10);
+}
+
+export function RattsskyddNekadBanner({ matterId, paymentMethod, rattsskyddNekadAt }: {
+  matterId: MatterId;
+  paymentMethod: PaymentMethod;
+  rattsskyddNekadAt: Date | string | null | undefined;
+}) {
+  const utils = trpc.useUtils();
+  const update = trpc.matter.update.useMutation({
+    onSuccess: () => { void utils.matter.getById.invalidate({ id: matterId }); },
+  });
+  if (paymentMethod !== "RATTSSKYDD" || !rattsskyddNekadAt) return null;
+  return (
+    <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+      <p className="font-medium">Rättsskydd nekades {formatDate(rattsskyddNekadAt)}</p>
+      <p className="mt-1 text-amber-800">
+        Nästa steg: ansök om rättshjälp om klientens ekonomiska underlag inte överstiger
+        gränsen i 6 § rättshjälpslagen (kontrollera aktuellt gränsbelopp).
+      </p>
+      <button type="button" disabled={update.isPending}
+        onClick={() => update.mutate({ id: matterId, paymentMethod: "RATTSHJALP" })}
+        className="mt-2 px-3 py-1.5 text-xs bg-amber-600 text-white rounded hover:bg-amber-700 disabled:opacity-50">
+        {update.isPending ? "Byter…" : "Byt till rättshjälp"}
+      </button>
+    </div>
+  );
+}

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -124,6 +124,8 @@ export const matters = pgTable("matters", {
   /** Rättsskydd (#810): tvistdatum (arbete före = ej täckt) + bolagets beslutsdatum (retro ≤6h). */
   tvistUppkomDatum: timestamp("tvist_uppkom_datum", { withTimezone: true }),
   rattsskyddBeslutDatum: timestamp("rattsskydd_beslut_datum", { withTimezone: true }),
+  /** Rättsskydd (#811): datum då rättsskydd nekades → föreslå rättshjälp. */
+  rattsskyddNekadAt: timestamp("rattsskydd_nekad_at", { withTimezone: true }),
 }, (t) => [index("matters_org_idx").on(t.organizationId)]);
 
 /**

--- a/src/lib/server/routers/matter.ts
+++ b/src/lib/server/routers/matter.ts
@@ -241,6 +241,8 @@ export const matterRouter = router({
         /** Rättsskydd (#810): tvistdatum + bolagets beslutsdatum, ur beslutet. */
         tvistUppkomDatum: z.string().nullable().optional(),
         rattsskyddBeslutDatum: z.string().nullable().optional(),
+        /** Rättsskydd (#811): datum då rättsskydd nekades. */
+        rattsskyddNekadAt: z.string().nullable().optional(),
         isTaxeArende: z.boolean().optional(),
         taxaLevel: z.number().int().min(1).max(4).nullable().optional(),
         taxaHuvudforhandlingMin: z.number().int().nonnegative().nullable().optional(),
@@ -250,13 +252,14 @@ export const matterRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       const before = await assertMatterInOrg(ctx, asId<"MatterId">(input.id));
-      const { id, paymentMethodDecidedAt, taxaHufStart, tvistUppkomDatum, rattsskyddBeslutDatum, ...rest } = input;
+      const { id, paymentMethodDecidedAt, taxaHufStart, tvistUppkomDatum, rattsskyddBeslutDatum, rattsskyddNekadAt, ...rest } = input;
       const data: Record<string, unknown> = { ...rest };
       // Datumsträngar (yyyy-mm-dd) → Date | null; lämna orörda om utelämnade.
       applyOptionalDate(data, "paymentMethodDecidedAt", paymentMethodDecidedAt);
       applyOptionalDate(data, "taxaHufStart", taxaHufStart);
       applyOptionalDate(data, "tvistUppkomDatum", tvistUppkomDatum);
       applyOptionalDate(data, "rattsskyddBeslutDatum", rattsskyddBeslutDatum);
+      applyOptionalDate(data, "rattsskyddNekadAt", rattsskyddNekadAt);
       const updated = await ctx.repos.matters.update(id, data satisfies Partial<Matter>);
       await emit.matterUpdated(ctx, id, data);
       if (input.status && input.status !== before.status) {

--- a/src/lib/shared/schemas/matter.ts
+++ b/src/lib/shared/schemas/matter.ts
@@ -60,6 +60,12 @@ export const matterSchema = z.object({
    */
   rattsskyddBeslutDatum: optionalDateLike,
   /**
+   * Rättsskydd: datum då försäkringen NEKADE rättsskydd (#811). Satt → nästa steg
+   * är att ansöka om rättshjälp (om klientens ekonomiska underlag ≤ 6 § rättshjälps-
+   * lagen). Null = ej nekat.
+   */
+  rattsskyddNekadAt: optionalDateLike,
+  /**
    * `isTaxeArende` — ärendet ersätts enligt Domstolsverkets fastställda
    * taxa (schablon) istället för löpande timdebitering.
    *

--- a/test/unit/components/matter/rattsskydd-nekad-banner.test.tsx
+++ b/test/unit/components/matter/rattsskydd-nekad-banner.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * RattsskyddNekadBanner (#811) — visas bara när rättsskydd nekats; "Byt till
+ * rättshjälp"-knappen byter ärendets betalningssätt.
+ */
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { RattsskyddNekadBanner } from "@/components/matter/rattsskydd-nekad-banner";
+import { asId } from "@/lib/shared/schemas/ids";
+
+const mutate = vi.fn();
+const invalidate = vi.fn();
+
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: {
+    useUtils: () => ({ matter: { getById: { invalidate } } }),
+    matter: { update: { useMutation: () => ({ mutate, isPending: false }) } },
+  },
+}));
+
+const matterId = asId<"MatterId">("m1");
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe("RattsskyddNekadBanner", () => {
+  it("visas inte för rättsskydd utan avslagsdatum", () => {
+    const { container } = render(<RattsskyddNekadBanner matterId={matterId} paymentMethod="RATTSSKYDD" rattsskyddNekadAt={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("visas inte för annat betalningssätt även med datum", () => {
+    const { container } = render(<RattsskyddNekadBanner matterId={matterId} paymentMethod="RATTSHJALP" rattsskyddNekadAt="2026-05-01" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("visar avslaget + 6 §-påminnelsen och byter till rättshjälp vid klick", () => {
+    render(<RattsskyddNekadBanner matterId={matterId} paymentMethod="RATTSSKYDD" rattsskyddNekadAt="2026-05-01" />);
+    expect(screen.getByText(/Rättsskydd nekades 2026-05-01/)).toBeInTheDocument();
+    expect(screen.getByText(/6 § rättshjälpslagen/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Byt till rättshjälp" }));
+    expect(mutate).toHaveBeenCalledWith({ id: matterId, paymentMethod: "RATTSHJALP" });
+  });
+});

--- a/tooling/db/migrations/0011_matter_rattsskydd_nekad.sql
+++ b/tooling/db/migrations/0011_matter_rattsskydd_nekad.sql
@@ -1,0 +1,3 @@
+-- #811: datum då rättsskydd NEKADES. Satt → nästa steg är att ansöka om
+-- rättshjälp (om klientens ekonomiska underlag ≤ 6 § rättshjälpslagen). NULL = ej nekat.
+ALTER TABLE matters ADD COLUMN IF NOT EXISTS rattsskydd_nekad_at timestamptz;


### PR DESCRIPTION
## Vad

När försäkringen **nekar rättsskydd** är nästa steg att ansöka om **rättshjälp**, förutsatt att klientens ekonomiska underlag inte överstiger gränsen i **6 § rättshjälpslagen**.

- **Matter-fält `rattsskyddNekadAt`** (zod-schema + drizzle-kolumn + **migration 0011** + `matter.update`).
- **payment-method-card:** datumfält "Rättsskydd nekat" (rättsskydd-only, samma mönster som tvist/beslut).
- **`RattsskyddNekadBanner`:** visas när rättsskydd + avslagsdatum satt — visar avslaget, påminner om 6 §-prövningen och har en snabbknapp **"Byt till rättshjälp"** (sätter `paymentMethod=RATTSHJALP`).

§6-prövningen är en **manuell påminnelse** — vi har ingen klient-inkomstdata i modellen och gränsbeloppet ändras, så texten ber juristen kontrollera aktuell gräns.

## Verifiering

- `tsc --noEmit` (root + test): rent · ESLint + knip + dep-cruiser: rent (komplexitet ≤8)
- `bun test --parallel`: 3637 pass (21 = kända miljö-fel). Ny komponenttest: banner döljs utan avslag/för annat betalningssätt, visar 6 §-texten, och "Byt till rättshjälp" anropar update.
- `build:demo`: OK

Avslutar rättshjälp/rättsskydd-spec:en (#809 + #810 + #811).

Closes #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)
