### PR TITLE
feat(billing): deklarativa faktureringsflöden + härledd fas (ren modell) (#817)

### DIFF
--- a/src/lib/shared/billing-flow.ts
+++ b/src/lib/shared/billing-flow.ts
@@ -1,0 +1,181 @@
+/**
+ * Faktureringsflöden per ärendetyp (#816/#817) — EN deklarativ sanningskälla för
+ * vad som får faktureras NÄR, per `paymentMethod`. Driver både UI-panelen
+ * (tillgängliga actions + dom-banner + vilken dialog en knapp öppnar) och
+ * server-guards (att en action är laglig i ärendets nuvarande fas). Ren logik,
+ * inga I/O — delas av server, klient och tester.
+ *
+ * Designval (2026-06): **härledd fas** (stateless, ur billing-runs + matter —
+ * ingen kolumn, ingen osynk), **in-kod-descriptors** (ändlig enum av flöden,
+ * ingen runtime/DB-konfiguration), **minimal MIX/PENDING**. Speglar mönstret i
+ * {@link file://./invoice-state-machine.ts} (deklarativ map + assert).
+ *
+ * Statemaskinen: `actionsByPhase[fas]` = de actions som är lagliga i fasen, och
+ * varje action:s `toPhase` är kanten till nästa fas. Faserna härleds av
+ * {@link currentPhase}; terminala faser (SLUTREGLERAD/NEKAD) har tomma action-
+ * listor men finns som nycklar så flödet "äger" fasen.
+ */
+
+import type { BillingRunRecipient, BillingRunStatus, BillingRunType, PaymentMethod } from "./schemas/enums";
+
+/** Ärendets faktureringsfas (härledd, ej lagrad). */
+export type BillingPhase = "ARBETE" | "VANTAR_DOM" | "SLUTREGLERAD" | "NEKAD";
+
+/** UI-action i fakturapanelen (≠ BillingRunType — SETTLE är ingen run-typ). */
+export type BillingActionType = "ACCONTO" | "FINAL" | "KOSTNADSRAKNING" | "SETTLE";
+
+/** Vilken dialog en action/dom-knapp öppnar i panelen. */
+export type BillingDialog = "billing" | "settlement" | "kostnadsrakning" | "verdict";
+
+export interface BillingAction {
+  type: BillingActionType;
+  label: string;
+  /** Fasen ärendet hamnar i när action:en utförs (statemaskinens kant). */
+  toPhase: BillingPhase;
+  /** Mottagare för den faktura/körning som skapas (utelämnad för ACCONTO=KLIENT). */
+  recipient?: BillingRunRecipient;
+  dialog: BillingDialog;
+}
+
+/** "Väntar på dom"-bannern: när ärendet är i `phase`, vad domsknappen öppnar. */
+export interface PendingBanner {
+  phase: BillingPhase;
+  dialog: Extract<BillingDialog, "settlement" | "verdict">;
+  label: string;
+}
+
+export interface BillingFlow {
+  initialPhase: BillingPhase;
+  /** Lagliga actions per fas. Nycklarna = de faser flödet äger. */
+  actionsByPhase: Partial<Record<BillingPhase, readonly BillingAction[]>>;
+  pendingBanner?: PendingBanner;
+}
+
+const aconto = (): BillingAction => ({ type: "ACCONTO", label: "Aconto till klient", toPhase: "ARBETE", recipient: "KLIENT", dialog: "billing" });
+
+/** PRIVAT/MIX: löpande FINAL till klienten, ingen besluts-/domslivscykel. */
+const PRIVAT_FLOW: BillingFlow = {
+  initialPhase: "ARBETE",
+  actionsByPhase: {
+    ARBETE: [{ type: "FINAL", label: "Faktura till klient", toPhase: "ARBETE", recipient: "KLIENT", dialog: "billing" }],
+  },
+};
+
+export const BILLING_FLOWS: Record<PaymentMethod, BillingFlow> = {
+  // Betalningssätt ej fastställt → inga faktureringsåtgärder ännu.
+  PENDING: { initialPhase: "ARBETE", actionsByPhase: { ARBETE: [] } },
+  PRIVAT: PRIVAT_FLOW,
+  MIX: PRIVAT_FLOW,
+  // Rättsskydd: aconto under väntan, sedan slutreglering på försäkringsbeskedet
+  // (eller direktfaktura till bolaget). Nekat → NEKAD (banner föreslår rättshjälp).
+  RATTSSKYDD: {
+    initialPhase: "ARBETE",
+    actionsByPhase: {
+      ARBETE: [
+        aconto(),
+        { type: "FINAL", label: "Faktura till försäkring", toPhase: "SLUTREGLERAD", recipient: "FORSAKRING", dialog: "billing" },
+        { type: "SETTLE", label: "Slutreglera (försäkringsbesked)", toPhase: "SLUTREGLERAD", recipient: "FORSAKRING", dialog: "settlement" },
+      ],
+      SLUTREGLERAD: [],
+      NEKAD: [],
+    },
+  },
+  // Rättshjälp: aconto + kostnadsräkning till domstol (väntar på dom) + slutreglering.
+  RATTSHJALP: {
+    initialPhase: "ARBETE",
+    actionsByPhase: {
+      ARBETE: [
+        aconto(),
+        { type: "KOSTNADSRAKNING", label: "Kostnadsräkning till domstol", toPhase: "VANTAR_DOM", recipient: "DOMSTOL", dialog: "kostnadsrakning" },
+        { type: "SETTLE", label: "Slutreglera (dom)", toPhase: "SLUTREGLERAD", recipient: "RATTSHJALPSMYNDIGHET", dialog: "settlement" },
+      ],
+      VANTAR_DOM: [
+        { type: "SETTLE", label: "Slutreglera (dom)", toPhase: "SLUTREGLERAD", recipient: "RATTSHJALPSMYNDIGHET", dialog: "settlement" },
+      ],
+      SLUTREGLERAD: [],
+    },
+    pendingBanner: { phase: "VANTAR_DOM", dialog: "settlement", label: "Slutreglera (dom)" },
+  },
+  // Offentligt uppdrag: kostnadsräkning till domstol → dom (prutning) via verdict.
+  OFFENTLIGT_UPPDRAG: {
+    initialPhase: "ARBETE",
+    actionsByPhase: {
+      ARBETE: [
+        { type: "KOSTNADSRAKNING", label: "Kostnadsräkning till domstol", toPhase: "VANTAR_DOM", recipient: "DOMSTOL", dialog: "kostnadsrakning" },
+      ],
+      VANTAR_DOM: [],
+      SLUTREGLERAD: [],
+    },
+    pendingBanner: { phase: "VANTAR_DOM", dialog: "verdict", label: "Ange dom + prutning" },
+  },
+};
+
+/** Minimal vy av en billing-run för fas-härledningen. */
+export interface FlowRun {
+  type: BillingRunType;
+  status: BillingRunStatus;
+}
+
+/** Minimal vy av ärendet för fas-härledningen. */
+export interface FlowMatter {
+  paymentMethod: PaymentMethod;
+  rattsskyddNekadAt?: Date | string | null | undefined;
+}
+
+function flowHasPhase(flow: BillingFlow, phase: BillingPhase): boolean {
+  return phase in flow.actionsByPhase;
+}
+
+function hasPendingVerdict(runs: ReadonlyArray<FlowRun>): boolean {
+  return runs.some((r) => r.type === "KOSTNADSRAKNING" && r.status === "PENDING_VERDICT");
+}
+
+/** Slutreglerat = en utställd slutfaktura/kostnadsräkning finns (aconto räknas ej). */
+function isSettled(runs: ReadonlyArray<FlowRun>): boolean {
+  return runs.some((r) => (r.type === "FINAL" || r.type === "KOSTNADSRAKNING") && r.status === "SENT");
+}
+
+/**
+ * Härleder ärendets faktureringsfas (stateless) ur flödet + matter + runs:
+ * NEKAD (avslagsdatum) → VANTAR_DOM (kostnadsräkning väntar) → SLUTREGLERAD
+ * (utställd slutfaktura, inget väntar) → annars flödets initialfas (ARBETE).
+ * Faser som flödet inte äger hoppas över.
+ */
+export function currentPhase(matter: FlowMatter, runs: ReadonlyArray<FlowRun>): BillingPhase {
+  const flow = BILLING_FLOWS[matter.paymentMethod];
+  if (flowHasPhase(flow, "NEKAD") && matter.rattsskyddNekadAt) return "NEKAD";
+  if (flowHasPhase(flow, "VANTAR_DOM") && hasPendingVerdict(runs)) return "VANTAR_DOM";
+  if (flowHasPhase(flow, "SLUTREGLERAD") && isSettled(runs)) return "SLUTREGLERAD";
+  return flow.initialPhase;
+}
+
+/** Tillgängliga actions i ärendets nuvarande fas (driver panelmenyn). */
+export function availableActions(matter: FlowMatter, runs: ReadonlyArray<FlowRun>): readonly BillingAction[] {
+  const flow = BILLING_FLOWS[matter.paymentMethod];
+  return flow.actionsByPhase[currentPhase(matter, runs)] ?? [];
+}
+
+/** Dom-bannern för ärendet, om flödet har en och ärendet är i dess fas. */
+export function pendingBannerFor(matter: FlowMatter, runs: ReadonlyArray<FlowRun>): PendingBanner | null {
+  const flow = BILLING_FLOWS[matter.paymentMethod];
+  if (flow.pendingBanner && currentPhase(matter, runs) === flow.pendingBanner.phase) return flow.pendingBanner;
+  return null;
+}
+
+/** Är `action` laglig i `phase` för flödet? (server-guard, fas 3.) */
+export function canBillingTransition(method: PaymentMethod, phase: BillingPhase, action: BillingActionType): boolean {
+  return (BILLING_FLOWS[method].actionsByPhase[phase] ?? []).some((a) => a.type === action);
+}
+
+/**
+ * Säkerställer att `action` är laglig i ärendets nuvarande fas; kastar annars
+ * (ren Error — serverlagret översätter till TRPCError i fas 3). Används av
+ * mutationerna så ett flöde inte kan ta ett otillåtet steg (t.ex. slutreglera
+ * ett PRIVAT-ärende eller fakturera ett nekat rättsskydd).
+ */
+export function assertBillingTransition(matter: FlowMatter, runs: ReadonlyArray<FlowRun>, action: BillingActionType): void {
+  const phase = currentPhase(matter, runs);
+  if (!canBillingTransition(matter.paymentMethod, phase, action)) {
+    throw new Error(`Åtgärden "${action}" är inte tillåten i fasen "${phase}" för ${matter.paymentMethod}.`);
+  }
+}

--- a/test/unit/lib/shared/billing-flow.test.ts
+++ b/test/unit/lib/shared/billing-flow.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Faktureringsflöden (#817) — deklarativa flöden, härledd fas och state-maskin.
+ */
+import { describe, it, expect } from "vitest-compat";
+import {
+  BILLING_FLOWS, availableActions, currentPhase, pendingBannerFor,
+  canBillingTransition, assertBillingTransition, type FlowRun,
+} from "@/lib/shared/billing-flow";
+
+const sentFinal: FlowRun = { type: "FINAL", status: "SENT" };
+const sentAcconto: FlowRun = { type: "ACCONTO", status: "SENT" };
+const pendingKr: FlowRun = { type: "KOSTNADSRAKNING", status: "PENDING_VERDICT" };
+
+describe("currentPhase — härledning", () => {
+  it("inga runs → flödets initialfas (ARBETE)", () => {
+    expect(currentPhase({ paymentMethod: "PRIVAT" }, [])).toBe("ARBETE");
+    expect(currentPhase({ paymentMethod: "RATTSHJALP" }, [])).toBe("ARBETE");
+  });
+
+  it("aconto ensam håller kvar i ARBETE (ej slutreglerat)", () => {
+    expect(currentPhase({ paymentMethod: "RATTSSKYDD" }, [sentAcconto])).toBe("ARBETE");
+  });
+
+  it("kostnadsräkning som väntar på dom → VANTAR_DOM", () => {
+    expect(currentPhase({ paymentMethod: "RATTSHJALP" }, [pendingKr])).toBe("VANTAR_DOM");
+    expect(currentPhase({ paymentMethod: "OFFENTLIGT_UPPDRAG" }, [pendingKr])).toBe("VANTAR_DOM");
+  });
+
+  it("utställd slutfaktura utan väntande → SLUTREGLERAD", () => {
+    expect(currentPhase({ paymentMethod: "RATTSSKYDD" }, [sentFinal])).toBe("SLUTREGLERAD");
+  });
+
+  it("rättsskydd nekat → NEKAD (även om arbete finns)", () => {
+    expect(currentPhase({ paymentMethod: "RATTSSKYDD", rattsskyddNekadAt: "2026-05-01" }, [sentAcconto])).toBe("NEKAD");
+  });
+
+  it("PRIVAT saknar SLUTREGLERAD → stannar i ARBETE även efter FINAL (löpande fakturering)", () => {
+    expect(currentPhase({ paymentMethod: "PRIVAT" }, [sentFinal])).toBe("ARBETE");
+  });
+});
+
+describe("availableActions — statemaskinens kanter", () => {
+  it("PENDING: inga åtgärder förrän betalningssätt valts", () => {
+    expect(availableActions({ paymentMethod: "PENDING" }, [])).toEqual([]);
+  });
+
+  it("rättshjälp ARBETE: aconto + kostnadsräkning + slutreglera", () => {
+    const types = availableActions({ paymentMethod: "RATTSHJALP" }, []).map((a) => a.type);
+    expect(types).toEqual(["ACCONTO", "KOSTNADSRAKNING", "SETTLE"]);
+  });
+
+  it("rättshjälp VANTAR_DOM: bara slutreglera (ingen ny kostnadsräkning)", () => {
+    const types = availableActions({ paymentMethod: "RATTSHJALP" }, [pendingKr]).map((a) => a.type);
+    expect(types).toEqual(["SETTLE"]);
+  });
+
+  it("rättsskydd: kostnadsräkning till domstol erbjuds INTE (det är försäkring/slutreglering)", () => {
+    const types = availableActions({ paymentMethod: "RATTSSKYDD" }, []).map((a) => a.type);
+    expect(types).toEqual(["ACCONTO", "FINAL", "SETTLE"]);
+    expect(types).not.toContain("KOSTNADSRAKNING");
+  });
+
+  it("nekat rättsskydd: inga faktureringsåtgärder", () => {
+    expect(availableActions({ paymentMethod: "RATTSSKYDD", rattsskyddNekadAt: "2026-05-01" }, [])).toEqual([]);
+  });
+
+  it("SETTLE-action i rättshjälp öppnar settlement-dialogen", () => {
+    const settle = availableActions({ paymentMethod: "RATTSHJALP" }, []).find((a) => a.type === "SETTLE");
+    expect(settle?.dialog).toBe("settlement");
+  });
+});
+
+describe("pendingBannerFor — dom-banner-routing", () => {
+  it("rättshjälp i VANTAR_DOM → settlement-banner", () => {
+    expect(pendingBannerFor({ paymentMethod: "RATTSHJALP" }, [pendingKr])).toMatchObject({ dialog: "settlement" });
+  });
+
+  it("offentligt uppdrag i VANTAR_DOM → verdict-banner (annan modell)", () => {
+    expect(pendingBannerFor({ paymentMethod: "OFFENTLIGT_UPPDRAG" }, [pendingKr])).toMatchObject({ dialog: "verdict" });
+  });
+
+  it("ingen banner utan väntande kostnadsräkning", () => {
+    expect(pendingBannerFor({ paymentMethod: "RATTSHJALP" }, [])).toBeNull();
+    expect(pendingBannerFor({ paymentMethod: "PRIVAT" }, [])).toBeNull();
+  });
+});
+
+describe("canBillingTransition / assertBillingTransition — guards", () => {
+  it("tillåtet steg passerar", () => {
+    expect(canBillingTransition("RATTSHJALP", "ARBETE", "KOSTNADSRAKNING")).toBe(true);
+    expect(() => assertBillingTransition({ paymentMethod: "RATTSHJALP" }, [], "KOSTNADSRAKNING")).not.toThrow();
+  });
+
+  it("otillåtet steg kastar (slutreglera privat)", () => {
+    expect(canBillingTransition("PRIVAT", "ARBETE", "SETTLE")).toBe(false);
+    expect(() => assertBillingTransition({ paymentMethod: "PRIVAT" }, [], "SETTLE")).toThrow(/inte tillåten/);
+  });
+
+  it("otillåtet steg kastar (fakturera nekat rättsskydd)", () => {
+    expect(() => assertBillingTransition({ paymentMethod: "RATTSSKYDD", rattsskyddNekadAt: "2026-05-01" }, [], "FINAL")).toThrow(/NEKAD/);
+  });
+
+  it("varje flöde har en initialfas som finns i actionsByPhase", () => {
+    for (const flow of Object.values(BILLING_FLOWS)) {
+      expect(flow.initialPhase in flow.actionsByPhase).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Vad (fas 1 av epic #816)

EN deklarativ sanningskälla för faktureringsflöden per ärendetyp — `src/lib/shared/billing-flow.ts`. **Ren modell + tester, parallellt med befintligt: ingen beteendeändring, inget wiring än** (UI/server kopplas in i fas 2/3).

- **`BILLING_FLOWS: Record<PaymentMethod, BillingFlow>`** — per flöde: faser, lagliga **actions per fas** (statemaskinens kanter, varje action har `toPhase` + `dialog`-routing) och ev. **dom-banner**. Minimal PENDING (inga åtgärder) / MIX (= privat).
- **`currentPhase(matter, runs)`** — härleder fasen **stateless** ur billing-runs + matter: `NEKAD` (avslagsdatum) > `VANTAR_DOM` (kostnadsräkning väntar) > `SLUTREGLERAD` (utställd slutfaktura, inget väntar) > `ARBETE`. Ingen kolumn, ingen osynk.
- **`availableActions` / `pendingBannerFor`** (driver panelen i fas 2), **`canBillingTransition` / `assertBillingTransition`** (server-guards i fas 3).
- Speglar `invoice-state-machine.ts`-mönstret (deklarativ map + assert, ren, delad server/klient/tester).

Konfigurerbart men bundet: flödena är **data i kod** (ändra ett block per nytt besked) — ändlig enum, ingen runtime/DB-konfiguration.

## Verifiering

- `tsc --noEmit` (root + test): rent · ESLint + knip + dep-cruiser: rent (komplexitet ≤8)
- `bun test --parallel`: 3656 pass (21 = kända miljö-fel). 19 nya tester: fas-härledning (alla flöden), actions/fas, banner-routing, guards.

refs #816 · nästa: fas 2 (BillingPanel drivs av descriptorn), fas 3 (server-guards), fas 4 (ADR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
