### PR TITLE
feat(billing): fakturapanelens summa-vy = Upparbetat ofakturerat / Fakturerat / Betalt (#819)

### DIFF
--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -286,8 +286,7 @@ export function BillingPanel({ matterId, matter }: Props) {
         <h2 className="font-semibold text-gray-900">Fakturering</h2>
         <BillingActions paymentMethod={matter.paymentMethod ?? undefined} onPick={onPick} />
       </div>
-      <SummaryCards totals={computeTotals(rows)} />
-      <UnbilledSummary matterId={matterId} />
+      <BillingSummary matterId={matterId} />
       <RadgivningBanner matterId={matterId} matter={matter} onRecorded={refetch} />
       {pending && <PendingVerdictBanner matterId={matterId} run={pending}
         onClick={() => matter.paymentMethod === "RATTSHJALP" ? setShowSettle(true) : setVerdictRunId(pending.id)} />}
@@ -336,33 +335,28 @@ function RadgivningBanner({ matterId, matter, onRecorded }: { matterId: MatterId
 }
 
 /**
- * "Upparbetat ofakturerat" (#740) — debiterbart arbete som ännu inte frysts/
- * fakturerats, så juristen lätt ser om något behöver faktureras. Visar arvode
- * (exkl utlägg) + utlägg separat + totalt (inkl utlägg). Datan = billingRun.proposal
- * (ofrysta debiterbara poster). PRUTNING är redan exkluderad i proposal.
+ * Fakturapanelens summa-vy (#819) — exakt tre tal användaren bryr sig om:
+ *   - Upparbetat ofakturerat: debiterbart arbete (arvode netto + utlägg netto)
+ *     som ännu inte frysts/fakturerats (billingRun.proposal, PRUTNING exkl).
+ *   - Fakturerat: Σ utställda fakturors belopp (status ≠ DRAFT/CANCELLED).
+ *   - Betalt: Σ registrerade betalningar på ärendets fakturor.
  */
-function UnbilledSummary({ matterId }: { matterId: MatterId }) {
+function BillingSummary({ matterId }: { matterId: MatterId }) {
   const proposal = trpc.billingRun.proposal.useQuery({ matterId });
+  const invoices = trpc.invoice.list.useQuery({ matterId });
   const d = proposal.data;
-  if (proposal.isLoading || !d) return null;
-  const arvodeOre = d.timeEntries.filter((t) => t.billable).reduce((s, t) => s + t.valueOre, 0);
-  const utlaggOre = d.expenses.filter((e) => e.billable).reduce((s, e) => s + e.amount, 0);
-  const totalOre = arvodeOre + utlaggOre;
-  const has = totalOre > 0;
+  const unbilledOre = d
+    ? d.timeEntries.filter((t) => t.billable).reduce((s, t) => s + t.valueOre, 0)
+      + d.expenses.filter((e) => e.billable).reduce((s, e) => s + e.amount, 0)
+    : 0;
+  const list = invoices.data ?? [];
+  const fakturerat = list.filter((i) => i.status !== "DRAFT" && i.status !== "CANCELLED").reduce((s, i) => s + i.amount, 0);
+  const betalt = list.reduce((s, i) => s + (i.payments ?? []).reduce((p, pm) => p + pm.amount, 0), 0);
   return (
-    <div className={`mx-6 mb-4 rounded-lg border px-4 py-3 ${has ? "border-blue-200 bg-blue-50" : "border-gray-200 bg-gray-50"}`}>
-      <div className="flex items-center justify-between">
-        <span className="text-[10px] uppercase tracking-wide text-gray-500">Upparbetat ofakturerat</span>
-        <span className="font-mono font-semibold text-sm text-gray-900">{formatCurrency(totalOre)}</span>
-      </div>
-      {has ? (
-        <div className="mt-1 flex flex-wrap gap-x-5 gap-y-1 text-xs text-gray-600">
-          <span>Arvode (exkl utlägg): <span className="font-mono text-gray-800">{formatCurrency(arvodeOre)}</span></span>
-          <span>Utlägg: <span className="font-mono text-gray-800">{formatCurrency(utlaggOre)}</span></span>
-        </div>
-      ) : (
-        <div className="mt-1 text-xs text-gray-500">Inget ofakturerat — allt debiterbart arbete är fakturerat.</div>
-      )}
+    <div className="grid grid-cols-3 gap-3 px-6 py-4">
+      <Card label="Upparbetat ofakturerat" value={unbilledOre} basis="net" />
+      <Card label="Fakturerat" value={fakturerat} />
+      <Card label="Betalt" value={betalt} />
     </div>
   );
 }
@@ -406,31 +400,11 @@ function RattshjalpKrDialog({ matterId, onClose, onRecorded }: { matterId: Matte
   );
 }
 
-function computeTotals(rows: BillingRunRow[]) {
-  let acconto = 0, finalSent = 0, pending = 0;
-  for (const r of rows) {
-    if (r.type === "ACCONTO" && r.status === "SENT") acconto += r.amountOre;
-    if ((r.type === "FINAL" || r.type === "KOSTNADSRAKNING") && r.status === "SENT") finalSent += r.amountOre;
-    if (r.status === "PENDING_VERDICT") pending += r.amountOre;
-  }
-  return { acconto, finalSent, pending };
-}
-
-function SummaryCards({ totals }: { totals: { acconto: number; finalSent: number; pending: number } }) {
-  return (
-    <div className="grid grid-cols-3 gap-3 px-6 py-4">
-      <Card label="Aconto fakturerat" value={totals.acconto} />
-      <Card label="Fakturerat" value={totals.finalSent} />
-      <Card label="Väntar på dom" value={totals.pending} dim />
-    </div>
-  );
-}
-
-function Card({ label, value, dim }: { label: string; value: number; dim?: boolean }) {
+function Card({ label, value, dim, basis = "gross" }: { label: string; value: number; dim?: boolean; basis?: "net" | "gross" }) {
   return (
     <div className={`rounded-lg border ${dim ? "border-amber-200 bg-amber-50" : "border-gray-200 bg-gray-50"} px-3 py-2`}>
       <div className="text-[10px] uppercase text-gray-500">{label}</div>
-      <Money ore={value} basis="gross" className="font-mono font-semibold text-sm" />
+      <Money ore={value} basis={basis} className="font-mono font-semibold text-sm" />
     </div>
   );
 }

--- a/test/unit/app/matters/[id]/page.test.tsx
+++ b/test/unit/app/matters/[id]/page.test.tsx
@@ -94,6 +94,8 @@ vi.mock("@/lib/client/trpc", () => ({
       setVerdict: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
     },
     invoice: {
+      // #819: BillingPanel → BillingSummary summerar Fakturerat/Betalt ur list.
+      list: { useQuery: () => ({ data: [] }) },
       // #383: BillingPanel → RadgivningBanner använder createRadgivning.
       createRadgivning: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
     },

--- a/test/unit/app/matters/billing-panel.test.tsx
+++ b/test/unit/app/matters/billing-panel.test.tsx
@@ -1,7 +1,7 @@
 /**
  * Tester för `BillingPanel` (#27) — översikts-/action-panelen per ärende.
  *
- * Täcker de rena hjälparna (computeTotals, optionsFor, findPendingVerdict,
+ * Täcker summa-vyn (#819), optionsFor, findPendingVerdict,
  * clientOf/courtOf) via render + de villkorade vyerna: summa-kort, runs-lista,
  * pending-verdict-banner, rådgivnings-banner (rättshjälp) och "+ Skapa
  * faktura"-menyn vars alternativ beror på matter:s paymentMethod. Barn-
@@ -23,6 +23,8 @@ let runsData: { runs: BillingRunRow[] } = { runs: [] };
 let runsLoading = false;
 interface ProposalData { workValueOre: number; priorAccontoSumOre: number; timeEntries: Array<{ id: string; description: string; minutes: number; hourlyRate: number; billable: boolean; valueOre: number }>; expenses: Array<{ id: string; description: string; amount: number; billable: boolean }> }
 let proposalData: ProposalData = { workValueOre: 0, priorAccontoSumOre: 0, timeEntries: [], expenses: [] };
+interface InvoiceRow { id: string; amount: number; status: string; payments: Array<{ amount: number }> }
+let invoiceListData: InvoiceRow[] = [];
 const refetch = vi.fn();
 const radgivningMutate = vi.fn();
 const krMutate = vi.fn();
@@ -52,6 +54,7 @@ vi.mock("@/lib/client/trpc", () => ({
     expense: { list: { useQuery: () => ({ data: { expenses: [] } }) } },
     document: { list: { useQuery: () => ({ data: documentListData }) } },
     invoice: {
+      list: { useQuery: () => ({ data: invoiceListData }) },
       createRadgivning: {
         useMutation: (opts?: { onSuccess?: () => void }) => {
           void opts;
@@ -95,6 +98,7 @@ beforeEach(() => {
   runsLoading = false;
   documentListData = { documents: [] };
   proposalData = { workValueOre: 0, priorAccontoSumOre: 0, timeEntries: [], expenses: [] };
+  invoiceListData = [];
   hasDoc = false;
 });
 
@@ -111,52 +115,39 @@ describe("BillingPanel — översikt", () => {
     expect(screen.getByText("Laddar…")).toBeInTheDocument();
   });
 
-  it("summerar acconto/fakturerat/väntar-på-dom korrekt (computeTotals)", () => {
+  it("faktura-länk för run med invoiceId (EntityLink-stub)", () => {
     runsData = {
       runs: [
         { id: "r1", type: "ACCONTO", status: "SENT", recipient: "KLIENT", amountOre: 100_000, createdAt: "2026-01-01", invoiceId: "inv-1", invoice: { id: "inv-1", invoiceNumber: "F-1" } },
-        { id: "r2", type: "FINAL", status: "SENT", recipient: "KLIENT", amountOre: 250_000, createdAt: "2026-02-01" },
-        { id: "r3", type: "KOSTNADSRAKNING", status: "PENDING_VERDICT", recipient: "DOMSTOL", amountOre: 50_000, createdAt: "2026-03-01" },
       ],
     };
     render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={baseMatter} />);
-    // Aconto = 1000 kr, Fakturerat = 2500 kr, Väntar = 500 kr. Varje belopp
-    // syns två gånger (summa-kort + run-rad); Intl använder no-break-space
-    // → matcha tolerant via regex + getAllByText.
-    expect(screen.getAllByText(/1\s*000,00/).length).toBeGreaterThanOrEqual(2);
-    expect(screen.getAllByText(/2\s*500,00/).length).toBeGreaterThanOrEqual(2);
-    expect(screen.getByText("Aconto fakturerat")).toBeInTheDocument();
-    // Faktura-länk för run med invoiceId (EntityLink-stub)
     expect(screen.getByText("F-1")).toBeInTheDocument();
   });
 });
 
-describe("BillingPanel — Upparbetat ofakturerat", () => {
-  it("visar arvode/utlägg/total när det finns ofakturerat debiterbart arbete", () => {
-    proposalData = {
-      workValueOre: 120_000,
-      priorAccontoSumOre: 0,
-      timeEntries: [
-        { id: "t1", description: "Arbete", minutes: 60, hourlyRate: 1200, billable: true, valueOre: 120_000 },
-        { id: "t2", description: "Ej deb", minutes: 30, hourlyRate: 1200, billable: false, valueOre: 60_000 },
-      ],
-      expenses: [
-        { id: "e1", description: "Ansökningsavgift", amount: 90_000, billable: true },
-        { id: "e2", description: "Ej deb", amount: 10_000, billable: false },
-      ],
-    };
+describe("BillingPanel — summa-vy (#819: bara tre tal)", () => {
+  it("visar Upparbetat ofakturerat / Fakturerat / Betalt — inte de gamla korten", () => {
     render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={baseMatter} />);
     expect(screen.getByText("Upparbetat ofakturerat")).toBeInTheDocument();
-    // Arvode 1200,00 (bara billable), Utlägg 900,00, Total 2100,00.
-    expect(screen.getByText(/1\s*200,00/)).toBeInTheDocument();
-    expect(screen.getByText(/900,00/)).toBeInTheDocument();
-    expect(screen.getByText(/2\s*100,00/)).toBeInTheDocument();
+    expect(screen.getByText("Fakturerat")).toBeInTheDocument();
+    expect(screen.getByText("Betalt")).toBeInTheDocument();
+    expect(screen.queryByText("Aconto fakturerat")).not.toBeInTheDocument();
+    expect(screen.queryByText("Väntar på dom")).not.toBeInTheDocument();
   });
 
-  it("visar tomtext när inget ofakturerat finns", () => {
+  it("Fakturerat = Σ utställda fakturor (ej DRAFT/CANCELLED); Betalt = Σ betalningar", () => {
+    invoiceListData = [
+      { id: "i1", amount: 250_000, status: "SENT", payments: [{ amount: 100_000 }] },
+      { id: "i2", amount: 50_000, status: "PAID", payments: [{ amount: 50_000 }] },
+      { id: "i3", amount: 999_000, status: "DRAFT", payments: [] },
+      { id: "i4", amount: 888_000, status: "CANCELLED", payments: [] },
+    ];
     render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={baseMatter} />);
-    expect(screen.getByText("Upparbetat ofakturerat")).toBeInTheDocument();
-    expect(screen.getByText(/Inget ofakturerat/)).toBeInTheDocument();
+    // Fakturerat = 250000 + 50000 = 300000 → "3 000,00"; Betalt = 150000 → "1 500,00".
+    // (Brutto-basis + default inkl-läge visar lagrat belopp.)
+    expect(screen.getByText(/3\s*000,00/)).toBeInTheDocument();
+    expect(screen.getByText(/1\s*500,00/)).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Vad

Fakturapanelens summa-vy visar nu **exakt tre tal**:

| Kort | Källa | Bas |
|---|---|---|
| **Upparbetat ofakturerat** | `billingRun.proposal` (debiterbart, ej fryst) | netto |
| **Fakturerat** | Σ utställda fakturors belopp (status ≠ DRAFT/CANCELLED) | brutto |
| **Betalt** | Σ registrerade betalningar på ärendets fakturor | brutto |

Tar bort de gamla korten **Aconto fakturerat** + **Väntar på dom** och den separata **Upparbetat ofakturerat**-bannern (slås ihop till kort-raden). `computeTotals`/`SummaryCards`/`UnbilledSummary` borttagna. Funktionella delar (skapa-faktura-meny, dom-banner, runs-lista) oförändrade.

## Verifiering

- `tsc` (root + test): rent · ESLint + knip + dep-cruiser: rent
- `bun test --parallel`: 3656 pass (21 = kända miljö-fel). Uppdaterade panel-tester (tre kort, Fakturerat/Betalt-summering, gamla kort borta) + la till `invoice.list`-mock i matter-sidans test.
- `build:demo`: OK

Closes #819

🤖 Generated with [Claude Code](https://claude.com/claude-code)
