### PR TITLE
feat(billing): hård flödes-enforcement + reconcilierad demo-generator (#816 fas 3)

### DIFF
--- a/docs/adr/0034-faktureringsfloden-per-arendetyp.md
+++ b/docs/adr/0034-faktureringsfloden-per-arendetyp.md
@@ -1,7 +1,8 @@
 # ADR 0034 — Deklarativa faktureringsflöden per ärendetyp (state-maskin)
 
-- **Status:** Accepterad (2026-06-28). Fas 1–2 **implementerade** (#818 modell,
-  #821 UI); fas 3 (hård API-enforcement) **uppskjuten** — se beslut nedan.
+- **Status:** Accepterad och **implementerad** (2026-06-28): fas 1 (modell, #818),
+  fas 2 (UI, #821), fas 4 (denna ADR, #822) och fas 3 (hård API-enforcement +
+  reconciliering av demo-generatorn/scenarierna).
 - **Beslutsfattare:** Ulrik Sjölin
 - **Berör:** fakturapanelen (`_billing-panel.tsx`), billingRun-routern,
   betalningssätts-kortet.
@@ -55,23 +56,26 @@ En **enda deklarativ sanningskälla**: `src/lib/shared/billing-flow.ts`.
    styrningen användaren möter.
 2. **Ren guard (fas 1):** `canBillingTransition`/`assertBillingTransition` finns
    som ren, testad funktion (server/klient/tester delar den).
-3. **Hård API-enforcement i mutationerna (fas 3): UPPSKJUTEN.** Att låta
-   `createFinal`/`createAcconto`/`createKostnadsrakning`/`settleCoverage` avvisa
-   actions som inte matchar flödet visade sig **bryta demo-generatorn och
-   `build:demo`** (USP: demon måste fungera): generatorn + scenariotester driver
-   faktureringen **mekaniskt** över betalningssätt (t.ex. PRIVAT med aconto+final,
-   brottmål som fakturerar ett `PENDING`-ärende), i ordningar som de nuvarande
-   descriptorerna inte tillåter. Eftersom flödena dessutom fortfarande ändras vore
-   en hård spärr för stel. Hård enforcement införs först när (a) demo-generatorn
-   följer flödena, eller (b) vi medvetet väljer att bara hård-spärra
-   täckningsflödena (rättsskydd/rättshjälp), där ordningen är domänkritisk.
+3. **Hård API-enforcement i mutationerna (fas 3): IMPLEMENTERAD.**
+   `createAcconto`/`createFinal`/`createKostnadsrakning`/`settleCoverage` kör
+   `assertFlowAction` som avvisar (BAD_REQUEST) en action som inte är laglig i
+   ärendets nuvarande fas — för ALLA betalningssätt. Ett första försök bröt
+   demo-generatorn + `build:demo` (USP) eftersom generatorn/scenariotester drev
+   faktureringen mekaniskt i ordningar descriptorerna inte tillät. Det löstes genom
+   att **reconciliera modellen mot verkligt bruk** i stället för att backa spärren:
+   - PRIVAT/MIX vidgades till **aconto + slutfaktura** (löpande räkning).
+   - OFFENTLIGT_UPPDRAG vidgades till **kostnadsräkning + klient-FINAL**
+     (återbetalningsskyldighet enligt domen).
+   - Demo-generatorns rättshjälp-väg gör nu **aconto → kostnadsräkning →
+     slutreglering** (ej en otillåten direkt-FINAL till myndigheten).
+   - Brottmåls-/rättshjälps-scenarierna sätter `paymentMethod=OFFENTLIGT_UPPDRAG`.
 
 ## Konsekvenser
 
 - **+** En plats att ändra när ett flöde ändras; UI + (framtida) guard delar den.
 - **+** Faserna är härledda → ingen migration, ingen osynk mot verkligheten.
 - **+** Inte för flexibelt: ändlig enum, ingen runtime-config.
-- **−** UI och hård API-spärr kan tillfälligt divergera (API:t är friare än menyn)
-  tills fas 3 landar — medvetet, för att inte bryta demon.
-- **−** Descriptorn måste hållas i synk med verkligt bruk (demo-generatorn är i
-  praktiken ett andra "API-användare" vars flöden inte alltid matchar).
+- **−** Descriptorn måste hållas i synk med verkligt bruk — demo-generatorn +
+  scenariotester är i praktiken ett andra "API-användare", och en hård spärr
+  bryter dem direkt om descriptorn är fel/för snäv (vilket är poängen: spärren
+  tvingar fram att modellen är korrekt, men varje ny övergång måste läggas till).

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -17,6 +17,7 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import type { VatBreakdownLine } from "@/lib/shared/accounting/semantic-voucher";
+import { assertBillingTransition, type BillingActionType } from "@/lib/shared/billing-flow";
 import { proposedAccontoOre } from "@/lib/shared/billing-proposal";
 import { TIMKOSTNADSNORM_FTAX_ORE_PER_H, TIMKOSTNADSNORM_NO_FTAX_ORE_PER_H } from "@/lib/shared/brottmalstaxa";
 import { computeCoverageSplit, partitionRattsskyddMinutes, type CoverageSplit } from "@/lib/shared/coverage-billing";
@@ -388,9 +389,22 @@ async function freezeSelectedWork(
   await repos.expenses.freezeByIds(work.expenses.map((e) => e.id), runId, now);
 }
 
-async function assertMatterInOrg(repos: Repositories, matterId: MatterId, orgId: OrganizationId): Promise<void> {
-  const m = await repos.matters.getByIdInOrg(matterId, orgId);
-  if (!m) throw new TRPCError({ code: "NOT_FOUND", message: "Ärendet finns inte." });
+/**
+ * Flödes-guard (#816 fas 3): säkerställer att ärendet finns OCH att `action` är
+ * laglig i ärendets nuvarande fas enligt billing-flow-modellen (samma sanningskälla
+ * som UI:t). Hård enforcement för ALLA betalningssätt — skyddar mot stale klienter
+ * / direkt-API som tar ett otillåtet steg (t.ex. slutreglera ett PRIVAT-ärende
+ * eller fakturera ett nekat rättsskydd).
+ */
+async function assertFlowAction(repos: Repositories, orgId: OrganizationId, matterId: MatterId, action: BillingActionType): Promise<void> {
+  const matter = await repos.matters.getByIdInOrg(matterId, orgId);
+  if (!matter) throw new TRPCError({ code: "NOT_FOUND", message: "Ärendet finns inte." });
+  const runs = await repos.billingRuns.listForOrg(orgId, matterId);
+  try {
+    assertBillingTransition({ paymentMethod: matter.paymentMethod, rattsskyddNekadAt: matter.rattsskyddNekadAt }, runs, action);
+  } catch (e) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: e instanceof Error ? e.message : "Otillåten faktureringsåtgärd." });
+  }
 }
 
 /**
@@ -469,7 +483,7 @@ export const billingRunRouter = router({
     }))
     .mutation(async ({ ctx, input }) => {
       return ctx.repos.transaction(async (tx) => {
-        await assertMatterInOrg(tx, input.matterId, ctx.orgId);
+        await assertFlowAction(tx, ctx.orgId, input.matterId, "ACCONTO");
         const work = await fetchUnfrozenWork(tx, input.matterId);
         const value = workValueOre(work);
         // #397: dra av tidigare aconton i det FÖRESLAGNA beloppet —
@@ -514,7 +528,7 @@ export const billingRunRouter = router({
     }))
     .mutation(async ({ ctx, input }) => {
       return ctx.repos.transaction(async (tx) => {
-        await assertMatterInOrg(tx, input.matterId, ctx.orgId);
+        await assertFlowAction(tx, ctx.orgId, input.matterId, "FINAL");
         const { work, selected } = await resolveFinalWork(tx, input.matterId, input.timeEntryIds, input.expenseIds);
         // Brutto = arvode inkl. 25 % moms + utlägg (#782).
         const grossValue = invoiceGrossOre(work);
@@ -547,7 +561,7 @@ export const billingRunRouter = router({
     .input(z.object({ matterId: matterIdSchema, notes: z.string().nullish() }))
     .mutation(async ({ ctx, input }) => {
       return ctx.repos.transaction(async (tx) => {
-        await assertMatterInOrg(tx, input.matterId, ctx.orgId);
+        await assertFlowAction(tx, ctx.orgId, input.matterId, "KOSTNADSRAKNING");
         const work = await fetchUnfrozenWork(tx, input.matterId);
         // Brutto = arvode inkl. 25 % moms + utlägg (#782) — matchar kostnadsräkningens PDF.
         const grossValue = invoiceGrossOre(work);
@@ -662,6 +676,7 @@ export const billingRunRouter = router({
     }))
     .mutation(async ({ ctx, input }) => {
       return ctx.repos.transaction(async (tx) => {
+        await assertFlowAction(tx, ctx.orgId, input.matterId, "SETTLE");
         const matter = await tx.matters.getByIdInOrg(input.matterId, ctx.orgId);
         if (!matter) throw new TRPCError({ code: "NOT_FOUND", message: "Ärendet finns inte." });
         if (matter.paymentMethod !== "RATTSSKYDD" && matter.paymentMethod !== "RATTSHJALP") {

--- a/src/lib/shared/billing-flow.ts
+++ b/src/lib/shared/billing-flow.ts
@@ -53,11 +53,15 @@ export interface BillingFlow {
 
 const aconto = (): BillingAction => ({ type: "ACCONTO", label: "Aconto till klient", toPhase: "ARBETE", recipient: "KLIENT", dialog: "billing" });
 
-/** PRIVAT/MIX: löpande FINAL till klienten, ingen besluts-/domslivscykel. */
+/** PRIVAT/MIX: löpande räkning till klienten — à-conto under arbetets gång +
+ *  slutfaktura. Ingen besluts-/domslivscykel (stannar i ARBETE). */
 const PRIVAT_FLOW: BillingFlow = {
   initialPhase: "ARBETE",
   actionsByPhase: {
-    ARBETE: [{ type: "FINAL", label: "Faktura till klient", toPhase: "ARBETE", recipient: "KLIENT", dialog: "billing" }],
+    ARBETE: [
+      aconto(),
+      { type: "FINAL", label: "Faktura till klient", toPhase: "ARBETE", recipient: "KLIENT", dialog: "billing" },
+    ],
   },
 };
 
@@ -97,13 +101,17 @@ export const BILLING_FLOWS: Record<PaymentMethod, BillingFlow> = {
     pendingBanner: { phase: "VANTAR_DOM", dialog: "settlement", label: "Slutreglera (dom)" },
   },
   // Offentligt uppdrag: kostnadsräkning till domstol → dom (prutning) via verdict.
+  // Klienten kan dessutom faktureras (återbetalningsskyldighet enligt domen).
   OFFENTLIGT_UPPDRAG: {
     initialPhase: "ARBETE",
     actionsByPhase: {
       ARBETE: [
         { type: "KOSTNADSRAKNING", label: "Kostnadsräkning till domstol", toPhase: "VANTAR_DOM", recipient: "DOMSTOL", dialog: "kostnadsrakning" },
+        { type: "FINAL", label: "Faktura till klient (återbetalning)", toPhase: "ARBETE", recipient: "KLIENT", dialog: "billing" },
       ],
-      VANTAR_DOM: [],
+      VANTAR_DOM: [
+        { type: "FINAL", label: "Faktura till klient (återbetalning)", toPhase: "VANTAR_DOM", recipient: "KLIENT", dialog: "billing" },
+      ],
       SLUTREGLERAD: [],
     },
     pendingBanner: { phase: "VANTAR_DOM", dialog: "verdict", label: "Ange dom + prutning" },

--- a/test/integration/scenario-brottmal.test.ts
+++ b/test/integration/scenario-brottmal.test.ts
@@ -141,9 +141,11 @@ describe("Scenario: brottmål från förordnande till betald faktura", () => {
     expect(matter.isTaxeArende).toBe(true);
     state.matterId = matter.id;
 
-    // Uppdatera taxa-fälten (level, F-skatt) på matter
+    // Uppdatera taxa-fälten (level, F-skatt) + betalningssätt (offentligt uppdrag;
+    // klienten kan faktureras återbetalning → FINAL tillåts av flödet, #816).
     const upd = await state.caller.matter.update({
       id: matter.id,
+      paymentMethod: "OFFENTLIGT_UPPDRAG",
       taxaLevel: 1,
       taxaHasFTax: true,
     });

--- a/test/integration/scenario-rattshjalp.test.ts
+++ b/test/integration/scenario-rattshjalp.test.ts
@@ -109,6 +109,9 @@ describe("Scenario: komplext brottmål — offentlig försvarare men EJ taxemål
       isTaxeArende: true,
     });
     state.matterId = matter.id;
+    // Offentligt uppdrag (offentlig försvarare) — domstolen ersätter; flödet
+    // tillåter FINAL (#816). Sätts explicit så fakturerings-guarden passerar.
+    await state.caller.matter.update({ id: matter.id, paymentMethod: "OFFENTLIGT_UPPDRAG" });
     await state.caller.matter.addContact({
       matterId: matter.id, contactId: state.domstolId!, role: "DOMSTOL",
     });

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -18,10 +18,10 @@ const PRINCIPAL: Principal = {
   id: asId<"UserId">("u-1"), email: "a@x", name: "Anna", role: "ADMIN", organizationId: asId<"OrganizationId">("org-1"),
 };
 
-function makeCaller(opts?: { workMinutes?: number; expenseOre?: number }) {
+function makeCaller(opts?: { workMinutes?: number; expenseOre?: number; paymentMethod?: string }) {
   const ds = new DemoDataStore({
     organizations: [{ id: "org-1", name: "X" }],
-    matters: [{ id: "m-1", organizationId: "org-1", matterNumber: "2026-0001", title: "Test", status: "ACTIVE", paymentMethod: "RATTSSKYDD", createdAt: new Date() }],
+    matters: [{ id: "m-1", organizationId: "org-1", matterNumber: "2026-0001", title: "Test", status: "ACTIVE", paymentMethod: opts?.paymentMethod ?? "RATTSSKYDD", createdAt: new Date() }],
     users: [{ id: "u-1", organizationId: "org-1", email: "a@x", name: "Anna", role: "ADMIN", hourlyRate: 250000 }],
     timeEntries: [{ id: "te-1", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), minutes: opts?.workMinutes ?? 120, description: "Möte", hourlyRate: 250000, billable: true }],
     expenses: opts?.expenseOre != null ? [{ id: "ex-1", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), amount: opts.expenseOre, description: "Avgift", billable: true, vatRate: 0, vatIncluded: false, kind: "EXPENSE" }] : [],
@@ -203,7 +203,7 @@ describe("billingRun.createFinal", () => {
 
 describe("billingRun.createKostnadsrakning", () => {
   it("skapar BillingRun i PENDING_VERDICT utan Invoice", async () => {
-    const { caller } = makeCaller({ workMinutes: 180 });
+    const { caller } = makeCaller({ workMinutes: 180, paymentMethod: "OFFENTLIGT_UPPDRAG" });
     const res = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
     expect(res.run.type).toBe("KOSTNADSRAKNING");
     expect(res.run.status).toBe("PENDING_VERDICT");
@@ -212,7 +212,7 @@ describe("billingRun.createKostnadsrakning", () => {
   });
 
   it("fryser raderna vid inskick mot körningen (#806 — lämnar 'upparbetat ofakturerat')", async () => {
-    const { ds, caller } = makeCaller({ workMinutes: 60 });
+    const { ds, caller } = makeCaller({ workMinutes: 60, paymentMethod: "OFFENTLIGT_UPPDRAG" });
     const res = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
     const te = await ds.timeEntries.findFirst({ where: { id: "te-1" } }) as { frozenAt?: Date | null; frozenByBillingRunId?: string | null };
     expect(te.frozenAt).toBeTruthy();
@@ -222,7 +222,7 @@ describe("billingRun.createKostnadsrakning", () => {
 
 describe("billingRun.setVerdict", () => {
   it("transitionar PENDING_VERDICT → SENT, skapar Invoice + fryser rader", async () => {
-    const { ds, caller } = makeCaller({ workMinutes: 60 }); // 2500 kr
+    const { ds, caller } = makeCaller({ workMinutes: 60, paymentMethod: "OFFENTLIGT_UPPDRAG" }); // 2500 kr
     const kr = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
     const res = await caller.billingRun.setVerdict({
       billingRunId: kr.run.id, prutningOre: 0,
@@ -236,7 +236,7 @@ describe("billingRun.setVerdict", () => {
   });
 
   it("skapar Expense(kind=PRUTNING) när prutning angiven", async () => {
-    const { ds, caller } = makeCaller({ workMinutes: 60 });
+    const { ds, caller } = makeCaller({ workMinutes: 60, paymentMethod: "OFFENTLIGT_UPPDRAG" });
     const kr = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
     await caller.billingRun.setVerdict({
       billingRunId: kr.run.id, prutningOre: -50000,
@@ -248,7 +248,7 @@ describe("billingRun.setVerdict", () => {
   });
 
   it("invoice-beloppet är workValue + prutning (prutning negativ)", async () => {
-    const { caller } = makeCaller({ workMinutes: 120 }); // 5000 kr
+    const { caller } = makeCaller({ workMinutes: 120, paymentMethod: "OFFENTLIGT_UPPDRAG" }); // 5000 kr
     const kr = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
     const res = await caller.billingRun.setVerdict({
       billingRunId: kr.run.id, prutningOre: -100000,
@@ -257,7 +257,7 @@ describe("billingRun.setVerdict", () => {
   });
 
   it("LÄNKAR poster + PRUTNING till fakturan → vyn reconciler mot beloppet (#732)", async () => {
-    const { ds, caller } = makeCaller({ workMinutes: 120, expenseOre: 5000 }); // 5000 kr + 50 kr utlägg
+    const { ds, caller } = makeCaller({ workMinutes: 120, expenseOre: 5000, paymentMethod: "OFFENTLIGT_UPPDRAG" }); // 5000 kr + 50 kr utlägg
     const kr = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
     const res = await caller.billingRun.setVerdict({ billingRunId: kr.run.id, prutningOre: -30000 });
     const te = await ds.timeEntries.findFirst({ where: { id: "te-1" } }) as { invoiceId?: string | null };
@@ -271,7 +271,7 @@ describe("billingRun.setVerdict", () => {
   });
 
   it("DOMSTOL-faktura får inget fakturanummer (ADR 0012)", async () => {
-    const { caller } = makeCaller({ workMinutes: 60 });
+    const { caller } = makeCaller({ workMinutes: 60, paymentMethod: "OFFENTLIGT_UPPDRAG" });
     const kr = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
     const res = await caller.billingRun.setVerdict({ billingRunId: kr.run.id, prutningOre: 0 });
     expect(res.invoice.invoiceNumber).toBeFalsy();
@@ -286,6 +286,25 @@ describe("billingRun.setVerdict", () => {
     await expect(caller.billingRun.setVerdict({
       billingRunId: acc.run.id, prutningOre: 0,
     })).rejects.toThrow(/KOSTNADSRAKNING/);
+  });
+});
+
+describe("billingRun — flödes-guard (#816 fas 3)", () => {
+  it("avvisar kostnadsräkning på ett RÄTTSSKYDD-ärende (otillåten övergång)", async () => {
+    const { caller } = makeCaller({ workMinutes: 60, paymentMethod: "RATTSSKYDD" });
+    await expect(caller.billingRun.createKostnadsrakning({ matterId: "m-1" })).rejects.toThrow(/inte tillåten/);
+  });
+
+  it("avvisar slutreglering på ett PRIVAT-ärende (SETTLE saknas i flödet)", async () => {
+    const { caller } = makeCaller({ workMinutes: 60, paymentMethod: "PRIVAT" });
+    await expect(caller.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "KLIENT" })).rejects.toThrow(/inte tillåten/);
+  });
+
+  it("tillåter aconto + slutfaktura på ett PRIVAT-ärende (löpande räkning)", async () => {
+    const { caller } = makeCaller({ workMinutes: 60, paymentMethod: "PRIVAT" });
+    await caller.billingRun.createAcconto({ matterId: "m-1", clientShareBips: 0, amountOre: 50000 });
+    const res = await caller.billingRun.createFinal({ matterId: "m-1", recipient: "KLIENT" });
+    expect(res.run.type).toBe("FINAL");
   });
 });
 

--- a/tooling/demo-generator/populate-billing.ts
+++ b/tooling/demo-generator/populate-billing.ts
@@ -181,10 +181,27 @@ async function runKostnadsrakning(ctx: Ctx, matterId: string, withVerdict: boole
   }
 }
 
+/**
+ * Rättshjälp följer flödesmodellen (#816): aconto till klient → kostnadsräkning
+ * till domstol (fryser arbetet) → slutreglering (dom) som skapar klient- +
+ * stat-faktura och konsumerar kostnadsräkningen. INGEN direkt slutfaktura till
+ * myndigheten (det vore en otillåten övergång).
+ */
+async function runRattshjalpBilling(ctx: Ctx, matterId: string, daysAgo: number): Promise<void> {
+  const accontoRun = await acconto(ctx, matterId, 3000, 150_000, daysAgo);
+  await ctx.c.billingRun.createKostnadsrakning({ matterId, notes: "Kostnadsräkning till domstol (rättshjälp)" });
+  ctx.res.kostnadsrakningSent++;
+  const res = await ctx.c.billingRun.settleCoverage({ matterId, payerRecipient: "RATTSHJALPSMYNDIGHET", deductedBillingRunIds: [accontoRun] });
+  ctx.res.invoices += 2; // klient- + stat-faktura
+  await ctx.c.invoice.setStatus({ invoiceId: res.clientInvoice.id, status: "SENT" });
+  await ctx.c.invoice.setStatus({ invoiceId: res.payerInvoice.id, status: "SENT" });
+}
+
 async function runClientBilling(ctx: Ctx, matterId: string, pm: string, clientIdx: number): Promise<void> {
   const daysAgo = 30 + clientIdx * 6;
-  const deducted = (pm === "RATTSSKYDD" || pm === "RATTSHJALP")
-    ? [await acconto(ctx, matterId, pm === "RATTSHJALP" ? 3000 : 2000, pm === "RATTSHJALP" ? 150_000 : 200_000, daysAgo)]
+  if (pm === "RATTSHJALP") { await runRattshjalpBilling(ctx, matterId, daysAgo); return; }
+  const deducted = pm === "RATTSSKYDD"
+    ? [await acconto(ctx, matterId, 2000, 200_000, daysAgo)]
     : [];
   const recipient = BILLING_RUN_RECIPIENT[pm] ?? "KLIENT";
   // Försäkring/myndighet betalar i sin helhet; privatklienter får varierad livscykel.


### PR DESCRIPTION
## Vad (fas 3 av epic #816 — option 2: reconciliera + hård-enforce överallt)

Mutationerna (`createAcconto`/`createFinal`/`createKostnadsrakning`/`settleCoverage`) kör nu `assertFlowAction` som avvisar (BAD_REQUEST) en action som inte är laglig i ärendets nuvarande fas enligt `billing-flow.ts` — **hård enforcement för alla betalningssätt**.

Ett första försök bröt demo-generatorn + `build:demo` (USP). Löst genom att **reconciliera modellen mot verkligt bruk** i stället för att backa spärren:

- **PRIVAT/MIX** vidgade → **aconto + slutfaktura** (löpande räkning à-conto).
- **OFFENTLIGT_UPPDRAG** vidgade → **kostnadsräkning + klient-FINAL** (återbetalningsskyldighet enligt domen).
- **Demo-generatorns rättshjälp-väg**: gör nu **aconto → kostnadsräkning → slutreglering (`settleCoverage`)** i stället för en otillåten direkt-FINAL till myndigheten.
- **Scenariotester** (brottmål/rättshjälp): sätter `paymentMethod=OFFENTLIGT_UPPDRAG`.
- ADR 0034 uppdaterad: fas 3 implementerad.

## Verifiering

- `tsc` (root + test): rent · ESLint + knip + dep-cruiser: rent
- `bun test --parallel`: 3659 pass (21 = kända miljö-fel). Nya guard-tester (avvisar KR på rättsskydd, SETTLE på privat; tillåter aconto+final på privat) + de tidigare KR/setVerdict-testerna pekar nu på OFFENTLIGT_UPPDRAG.
- **`build:demo`: OK** (demo-generatorn följer nu flödena — det var blockeraren).

Avslutar epic #816 (fas 1–4 klara).

Closes #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)
