### PR TITLE
fix(billing): förklara tom fakturapanel i stället för att gömma knappen (#824)

### DIFF
--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -21,7 +21,7 @@ import { useMatterInvariants } from "@/lib/client/diagnostics/use-matter-invaria
 import { trpc } from "@/lib/client/trpc";
 import { formatCurrency } from "@/lib/client/utils";
 import type { AppRouter } from "@/lib/server/routers/_app";
-import { availableActions, pendingBannerFor, type BillingAction, type FlowMatter } from "@/lib/shared/billing-flow";
+import { availableActions, currentPhase, pendingBannerFor, type BillingAction, type BillingPhase, type FlowMatter } from "@/lib/shared/billing-flow";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { computeRadgivningsavgift } from "@/lib/shared/rattshjalp";
 import { BILLING_RUN_TYPE_LABELS, BILLING_RUN_STATUS_LABELS, type BillingRunRecipient, type BillingRunStatus, type BillingRunType, type PaymentMethod } from "@/lib/shared/schemas/enums";
@@ -291,7 +291,8 @@ export function BillingPanel({ matterId, matter }: Props) {
     <div className="bg-white rounded-lg border border-gray-200 lg:col-span-2">
       <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
         <h2 className="font-semibold text-gray-900">Fakturering</h2>
-        <BillingActions actions={actions} onPick={onPick} />
+        <BillingHeaderActions actions={actions} onPick={onPick}
+          hint={noActionsHint(currentPhase(flowMatter, rows), flowMatter.paymentMethod)} />
       </div>
       <BillingSummary matterId={matterId} />
       <RadgivningBanner matterId={matterId} matter={matter} onRecorded={refetch} />
@@ -414,6 +415,21 @@ function Card({ label, value, dim, basis = "gross" }: { label: string; value: nu
       <Money ore={value} basis={basis} className="font-mono font-semibold text-sm" />
     </div>
   );
+}
+
+/** Header-zonen: skapa-faktura-menyn när det finns åtgärder, annars en förklaring. */
+function BillingHeaderActions({ actions, onPick, hint }: { actions: readonly BillingAction[]; onPick: (a: BillingAction) => void; hint: string }) {
+  if (actions.length > 0) return <BillingActions actions={actions} onPick={onPick} />;
+  return <span className="text-xs text-gray-500">{hint}</span>;
+}
+
+/** Förklarar varför inga faktureringsåtgärder erbjuds i nuvarande fas (#824) —
+ *  annars försvinner knappen tyst och användaren tror fakturering saknas. */
+function noActionsHint(phase: BillingPhase, pm: PaymentMethod): string {
+  if (pm === "PENDING") return "Välj betalningssätt för att fakturera";
+  if (phase === "SLUTREGLERAD") return "Ärendet är slutreglerat";
+  if (phase === "NEKAD") return "Rättsskydd nekat — se förslag nedan";
+  return "Inga faktureringsåtgärder i nuvarande läge";
 }
 
 /** Skapa-faktura-menyn — alternativen kommer från flödesmodellen (#816); panelen

--- a/test/unit/app/matters/billing-panel.test.tsx
+++ b/test/unit/app/matters/billing-panel.test.tsx
@@ -211,6 +211,12 @@ describe("BillingPanel — Skapa-faktura-menyn (flödesmodellen)", () => {
     expect(screen.getByTestId("kr-modal")).toBeInTheDocument();
   });
 
+  it("PENDING: ingen knapp men en förklaring (#824)", () => {
+    render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={{ ...baseMatter, paymentMethod: "PENDING" }} />);
+    expect(screen.queryByRole("button", { name: "+ Skapa faktura" })).not.toBeInTheDocument();
+    expect(screen.getByText(/Välj betalningssätt för att fakturera/)).toBeInTheDocument();
+  });
+
   it("RATTSHJALP: kostnadsräkning till domstol (ej direktfaktura) — öppnar rättshjälps-dialogen", () => {
     render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={{ ...baseMatter, paymentMethod: "RATTSHJALP" }} />);
     fireEvent.click(screen.getByRole("button", { name: "+ Skapa faktura" }));


### PR DESCRIPTION
## Vad

Efter #816 fas 2 göms "+ Skapa faktura"-knappen helt när ärendets fas saknar åtgärder (SLUTREGLERAD / NEKAD / PENDING) → tyst tom panel, användaren tror fakturering saknas. Visar nu en **förklaring** i stället:

- PENDING → "Välj betalningssätt för att fakturera"
- SLUTREGLERAD → "Ärendet är slutreglerat"
- NEKAD → "Rättsskydd nekat — se förslag nedan"

Utbrutet `BillingHeaderActions` (knapp annars hint) för komplexitet ≤8.

## Verifiering

- `tsc` (root + test) + ESLint + knip + dep-cruiser: rent
- `bun test --parallel test/unit/app/matters`: 124 pass (nytt test: PENDING → ingen knapp, men förklaring)
- `build:demo`: OK

Closes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)
