### PR TITLE
fix(demo): färsk ofakturerad tid bara på fakturerbara ärenden (#826)

### DIFF
--- a/test/scripts/populate-unbilled-time.test.ts
+++ b/test/scripts/populate-unbilled-time.test.ts
@@ -22,7 +22,7 @@ async function runTarget() {
 }
 
 describe("populateUnbilledTime", () => {
-  it("skapar 2-3 entries per aktivt ärende (alla utan invoiceId)", async () => {
+  it("skapar 2-3 entries per fakturerbart (PRIVAT/MIX) aktivt ärende, alla utan invoiceId", async () => {
     const { target, seed } = await runTarget();
     // Populera org+users+contacts+matters först så timeEntry.create hittar dem
     await target.caller.organization.create({ id: String(seed.organizations[0]!.id), name: "X" });
@@ -39,10 +39,12 @@ describe("populateUnbilledTime", () => {
       });
     }
     const count = await populateUnbilledTime(target.caller, seed);
-    const activeMatters = seed.matters.filter((m) => m.status === "ACTIVE");
+    // Bara PRIVAT/MIX (alltid fakturerbara) får färsk ofakturerad tid (#824).
+    const billableActive = seed.matters.filter((m) => m.status === "ACTIVE" && (m.paymentMethod === "PRIVAT" || m.paymentMethod === "MIX"));
+    expect(billableActive.length).toBeGreaterThan(0);
     // 2 + (mi%2) entries per matter → mellan 2*N och 3*N
-    expect(count).toBeGreaterThanOrEqual(2 * activeMatters.length);
-    expect(count).toBeLessThanOrEqual(3 * activeMatters.length);
+    expect(count).toBeGreaterThanOrEqual(2 * billableActive.length);
+    expect(count).toBeLessThanOrEqual(3 * billableActive.length);
   });
 
   it("returnerar 0 om inga aktiva ärenden finns", async () => {

--- a/tooling/demo-generator/populate-unbilled-time.ts
+++ b/tooling/demo-generator/populate-unbilled-time.ts
@@ -56,7 +56,12 @@ async function createFreshEntry(
 export async function populateUnbilledTime(caller: GeneratorCaller, seed: SeedDataset): Promise<number> {
   const c = caller as AnyCaller;
   const users = (seed.users ?? []) as Row[];
-  const activeMatters = ((seed.matters ?? []) as Row[]).filter((m) => m.status === "ACTIVE");
+  // Bara PRIVAT/MIX: de är alltid i ARBETE-fasen (fakturerbara), så färsk
+  // ofakturerad tid alltid kan faktureras via panelen. Täckningsflöden
+  // (rättsskydd/rättshjälp/offentligt) blir slutreglerade av populateBilling →
+  // att lägga ofakturerat där ger "upparbetat men ingen skapa-faktura-knapp" (#824).
+  const billable = (m: Row): boolean => m.paymentMethod === "PRIVAT" || m.paymentMethod === "MIX";
+  const activeMatters = ((seed.matters ?? []) as Row[]).filter((m) => m.status === "ACTIVE" && billable(m));
   if (users.length === 0 || activeMatters.length === 0) return 0;
 
   let count = 0;

--- a/tooling/scripts/seed-demo-into-server.ts
+++ b/tooling/scripts/seed-demo-into-server.ts
@@ -74,11 +74,16 @@ function remapLoginUsers(users: Row[]): { adminId: string | undefined; lawyerId:
  * dagsvy ("Idag") blir annars tom. Tasks/kalender landar redan på idag via
  * seedens offset-logik, så bara tid behöver kompletteras.
  */
-async function addTodayTimeEntries(repos: Repositories, timeEntries: Row[], ids: { adminId: string | undefined; lawyerId: string | undefined }): Promise<void> {
+async function addTodayTimeEntries(repos: Repositories, timeEntries: Row[], matters: Row[], ids: { adminId: string | undefined; lawyerId: string | undefined }): Promise<void> {
   const tes = timeEntries;
+  // Föredra ett PRIVAT-ärende: det är alltid i ARBETE-fasen (fakturerbart), så
+  // "idag"-tiden blir inte ofakturerat arbete på ett redan slutreglerat ärende
+  // (#824-uppf.) — annars syns upparbetat men ingen skapa-faktura-knapp.
+  const pmById = new Map(matters.map((m) => [String(m.id), String(m.paymentMethod)]));
   for (const userId of [ids.lawyerId, ids.adminId]) {
     if (!userId) continue;
-    const matterId = (tes.find((t) => t.userId === userId)?.matterId) as string | undefined;
+    const worked = tes.filter((t) => t.userId === userId).map((t) => String(t.matterId));
+    const matterId = worked.find((id) => pmById.get(id) === "PRIVAT") ?? worked[0];
     if (!matterId) continue;
     await repos.timeEntries.create({
       id: asId<"TimeEntryId">(uuidv7()),
@@ -146,7 +151,7 @@ async function main(): Promise<void> {
     // Kärnentiteter (org/users/contacts/matters/matter-contacts/tid/utlägg/
     // kalender/uppgifter/mallar/jävskontroller).
     const core = await populate(caller, seed);
-    await addTodayTimeEntries(repos, seed.timeEntries as Row[], loginIds); // "idag"-tid för dashboarden
+    await addTodayTimeEntries(repos, seed.timeEntries as Row[], seed.matters as Row[], loginIds); // "idag"-tid för dashboarden
 
     // Fakturering (#647/#736): billing-id:na är deterministiska uuid:er
     // (demo-billing-ids). populateBilling driver nu ETT billing-run-flöde per


### PR DESCRIPTION
## Vad

Demodatan lämnade **ofakturerat arbete på redan slutreglerade ärenden**: `populateUnbilledTime` gav färsk ofakturerad tid till *alla* aktiva ärenden, även täckningsflöden (rättshjälp/rättsskydd) som `populateBilling` redan slutreglerat. Då visade ärendet "Upparbetat ofakturerat" men var i `SLUTREGLERAD`-fasen → ingen "+ Skapa faktura"-knapp (t.ex. **Umgängestvist Carlsson**).

Fix: färsk ofakturerad tid läggs nu **bara på PRIVAT/MIX** (alltid i ARBETE → alltid fakturerbart, så det finns alltid en knapp att fakturera det med). `addTodayTimeEntries` föredrar också ett PRIVAT-ärende.

## Verifiering

- `tsc` + ESLint + knip: rent
- `bun test populate-unbilled-time`: grön (assertar nu mot PRIVAT/MIX-aktiva ärenden)
- `build:demo`: OK

Closes #826
🤖 Generated with [Claude Code](https://claude.com/claude-code)
