### PR TITLE
feat(billing): kostnadsräkningens state-maskin (ren modell) (#829)

### DIFF
--- a/src/lib/shared/kostnadsrakning-flow.ts
+++ b/src/lib/shared/kostnadsrakning-flow.ts
@@ -1,0 +1,66 @@
+/**
+ * Kostnadsräkningens livscykel (#828) — domstols-flödet (rättshjälp + offentligt
+ * uppdrag) där **Beslut, Faktura och Överklagan är distinkta steg PÅ kostnads-
+ * räkningen**. Ren logik, inga I/O — delas av server, klient och tester.
+ *
+ * Faktura skapas ALDRIG förrän domstolen beslutat beloppet (KR→Beslut→Faktura).
+ * Överklagan av prutningen är en inlaga (Word) som mailas in; hovrättens beslut
+ * (PDF) är slutgiltigt och kan inte överklagas igen — ingen ny kostnadsräkning.
+ *
+ * State-maskin:
+ *   INSKICKAD  ──registrera beslut──▶ BESLUTAD
+ *   BESLUTAD   ──skapa faktura──────▶ FAKTURERAD
+ *   BESLUTAD   ──överklaga──────────▶ ÖVERKLAGAD            (endast om ej slutgiltigt)
+ *   ÖVERKLAGAD ──hovrättens beslut──▶ BESLUTAD (slutgiltigt → bara faktura kvar)
+ *
+ * Speglar mönstret i {@link file://./invoice-state-machine.ts}.
+ */
+
+export type KostnadsrakningStatus = "INSKICKAD" | "BESLUTAD" | "OVERKLAGAD" | "FAKTURERAD";
+
+export type KostnadsrakningAction =
+  | "REGISTRERA_BESLUT"
+  | "SKAPA_FAKTURA"
+  | "OVERKLAGA"
+  | "REGISTRERA_HOVRATT_BESLUT";
+
+/** KR:ns tillstånd: status + om beslutet är slutgiltigt (efter hovrätten). */
+export interface KostnadsrakningState {
+  status: KostnadsrakningStatus;
+  /** Sant efter hovrättens beslut → får ej överklagas igen. */
+  slutgiltigt: boolean;
+}
+
+// Status-/action-etiketter (UI) introduceras i UI-steget (epic #828, steg 5) när
+// de har en konsument — knip-ratchet tillåter inga oanvända exports.
+
+/** Lagliga åtgärder i ett givet KR-tillstånd (state-maskinens kanter). */
+export function availableKrActions(state: KostnadsrakningState): readonly KostnadsrakningAction[] {
+  switch (state.status) {
+    case "INSKICKAD": return ["REGISTRERA_BESLUT"];
+    // Slutgiltigt beslut (hovrätten) → bara fakturera; annars även överklaga.
+    case "BESLUTAD": return state.slutgiltigt ? ["SKAPA_FAKTURA"] : ["SKAPA_FAKTURA", "OVERKLAGA"];
+    case "OVERKLAGAD": return ["REGISTRERA_HOVRATT_BESLUT"];
+    case "FAKTURERAD": return [];
+  }
+}
+
+/** Är `action` laglig i `state`? */
+export function canKrAction(state: KostnadsrakningState, action: KostnadsrakningAction): boolean {
+  return availableKrActions(state).includes(action);
+}
+
+/** Tillämpar en åtgärd och returnerar det nya tillståndet; kastar vid otillåten
+ *  övergång (ren Error — serverlagret översätter till TRPCError). */
+export function applyKrAction(state: KostnadsrakningState, action: KostnadsrakningAction): KostnadsrakningState {
+  if (!canKrAction(state, action)) {
+    throw new Error(`Åtgärden "${action}" är inte tillåten i kostnadsräknings-status "${state.status}".`);
+  }
+  switch (action) {
+    case "REGISTRERA_BESLUT": return { status: "BESLUTAD", slutgiltigt: false };
+    case "OVERKLAGA": return { status: "OVERKLAGAD", slutgiltigt: false };
+    // Hovrättens beslut är slutgiltigt.
+    case "REGISTRERA_HOVRATT_BESLUT": return { status: "BESLUTAD", slutgiltigt: true };
+    case "SKAPA_FAKTURA": return { status: "FAKTURERAD", slutgiltigt: state.slutgiltigt };
+  }
+}

--- a/test/unit/lib/shared/kostnadsrakning-flow.test.ts
+++ b/test/unit/lib/shared/kostnadsrakning-flow.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Kostnadsräkningens state-maskin (#829): KR→Beslut→Faktura + överklagan-grenen.
+ */
+import { describe, it, expect } from "vitest-compat";
+import {
+  availableKrActions, canKrAction, applyKrAction,
+  type KostnadsrakningState,
+} from "@/lib/shared/kostnadsrakning-flow";
+
+const inskickad: KostnadsrakningState = { status: "INSKICKAD", slutgiltigt: false };
+
+describe("availableKrActions", () => {
+  it("INSKICKAD → bara registrera beslut", () => {
+    expect(availableKrActions(inskickad)).toEqual(["REGISTRERA_BESLUT"]);
+  });
+
+  it("BESLUTAD (ej slutgiltigt) → skapa faktura ELLER överklaga", () => {
+    expect(availableKrActions({ status: "BESLUTAD", slutgiltigt: false })).toEqual(["SKAPA_FAKTURA", "OVERKLAGA"]);
+  });
+
+  it("BESLUTAD slutgiltigt (efter hovrätten) → bara faktura, ingen ny överklagan", () => {
+    expect(availableKrActions({ status: "BESLUTAD", slutgiltigt: true })).toEqual(["SKAPA_FAKTURA"]);
+  });
+
+  it("ÖVERKLAGAD → bara registrera hovrättens beslut", () => {
+    expect(availableKrActions({ status: "OVERKLAGAD", slutgiltigt: false })).toEqual(["REGISTRERA_HOVRATT_BESLUT"]);
+  });
+
+  it("FAKTURERAD → inga åtgärder (terminalt)", () => {
+    expect(availableKrActions({ status: "FAKTURERAD", slutgiltigt: true })).toEqual([]);
+  });
+});
+
+describe("applyKrAction — övergångar", () => {
+  it("hela vägen utan överklagan: inskickad → beslutad → fakturerad", () => {
+    const beslutad = applyKrAction(inskickad, "REGISTRERA_BESLUT");
+    expect(beslutad).toEqual({ status: "BESLUTAD", slutgiltigt: false });
+    const fakturerad = applyKrAction(beslutad, "SKAPA_FAKTURA");
+    expect(fakturerad).toEqual({ status: "FAKTURERAD", slutgiltigt: false });
+  });
+
+  it("överklagan-grenen: beslutad → överklagad → hovrättsbeslut (slutgiltigt) → fakturerad", () => {
+    const beslutad = applyKrAction(inskickad, "REGISTRERA_BESLUT");
+    const overklagad = applyKrAction(beslutad, "OVERKLAGA");
+    expect(overklagad.status).toBe("OVERKLAGAD");
+    const slutgiltig = applyKrAction(overklagad, "REGISTRERA_HOVRATT_BESLUT");
+    expect(slutgiltig).toEqual({ status: "BESLUTAD", slutgiltigt: true });
+    // Får inte överklaga igen
+    expect(canKrAction(slutgiltig, "OVERKLAGA")).toBe(false);
+    expect(applyKrAction(slutgiltig, "SKAPA_FAKTURA").status).toBe("FAKTURERAD");
+  });
+
+  it("kastar vid otillåten övergång (faktura innan beslut)", () => {
+    expect(() => applyKrAction(inskickad, "SKAPA_FAKTURA")).toThrow(/inte tillåten/);
+  });
+
+  it("kastar vid dubbel överklagan (slutgiltigt beslut)", () => {
+    expect(() => applyKrAction({ status: "BESLUTAD", slutgiltigt: true }, "OVERKLAGA")).toThrow(/inte tillåten/);
+  });
+});


### PR DESCRIPTION
## Vad (steg 1 av epic #828)

Ren modul `src/lib/shared/kostnadsrakning-flow.ts` — kostnadsräkningens livscykel som state-maskin. **Ingen wiring, parallellt med befintligt.**

```
INSKICKAD ──registrera beslut──▶ BESLUTAD
BESLUTAD  ──skapa faktura──────▶ FAKTURERAD
BESLUTAD  ──överklaga──────────▶ ÖVERKLAGAD   (endast om ej slutgiltigt)
ÖVERKLAGAD ──hovrättens beslut─▶ BESLUTAD (slutgiltigt → bara faktura kvar)
```

`availableKrActions` / `canKrAction` / `applyKrAction` (kastar vid otillåten övergång). Faktura kan aldrig skapas före beslut; hovrättens beslut är slutgiltigt (ingen ny överklagan, ingen ny KR).

## Verifiering

- `tsc` (root + test) · ESLint · knip · dep-cruiser: rent
- `bun test`: 9 tester (hela vägen, överklagan-grenen, otillåtna övergångar, dubbel-överklagan-skydd)

refs #828 · nästa: steg 2 (schema/migration + KR-status på BillingRun), steg 3 (mutationer), steg 4 (KR-dokument), steg 5 (UI), steg 6 (demodata).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
