### PR TITLE
feat(billing): persistera KR-livscykeln på BillingRun (#828 steg 2)

### DIFF
--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -12,7 +12,8 @@
  */
 
 import { relations } from "drizzle-orm";
-import { bigint, bigserial, index, integer, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { bigint, bigserial, boolean, index, integer, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import type { KostnadsrakningStatus } from "@/lib/shared/kostnadsrakning-flow";
 import type { DispatchChannel, DispatchStatus, ExpectedReceivableStatus } from "@/lib/shared/schemas/billing";
 import type {
   CalendarEventKind, CalendarEventVisibility, TaskPriority, TaskStatus,
@@ -289,6 +290,10 @@ export const billingRuns = pgTable("billing_runs", {
   proposedAmountOre: ore("proposed_amount_ore").notNull(),
   amountOre: ore("amount_ore").notNull(),
   prutningOre: ore("prutning_ore"),
+  /** KR-livscykel (#828): status + dömt belopp + slutgiltigt (efter hovrätten). */
+  kostnadsrakningStatus: text("kostnadsrakning_status").$type<KostnadsrakningStatus>(),
+  awardedOre: ore("awarded_ore"),
+  beslutSlutgiltigt: boolean("beslut_slutgiltigt").notNull().default(false),
   invoiceId: uuid("invoice_id").$type<InvoiceId>(),
   deductedBillingRunIds: jsonb("deducted_billing_run_ids").notNull().default([]).$type<BillingRunId[]>(),
   periodFrom: timestamp("period_from", { withTimezone: true }),

--- a/src/lib/shared/kostnadsrakning-flow.ts
+++ b/src/lib/shared/kostnadsrakning-flow.ts
@@ -16,7 +16,11 @@
  * Speglar mönstret i {@link file://./invoice-state-machine.ts}.
  */
 
-export type KostnadsrakningStatus = "INSKICKAD" | "BESLUTAD" | "OVERKLAGAD" | "FAKTURERAD";
+import { z } from "zod";
+
+/** KR-statusarna som zod-enum (en sanningskälla, används av billing-schemat). */
+export const kostnadsrakningStatusSchema = z.enum(["INSKICKAD", "BESLUTAD", "OVERKLAGAD", "FAKTURERAD"]);
+export type KostnadsrakningStatus = z.infer<typeof kostnadsrakningStatusSchema>;
 
 export type KostnadsrakningAction =
   | "REGISTRERA_BESLUT"

--- a/src/lib/shared/schemas/billing.ts
+++ b/src/lib/shared/schemas/billing.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { kostnadsrakningStatusSchema } from "../kostnadsrakning-flow";
 import { baseFields, orgScopedFields, dateLike, optionalDateLike } from "./common";
 import {
   billingRunRecipientSchema,
@@ -294,6 +295,14 @@ export const billingRunSchema = z.object({
   /** För KOSTNADSRAKNING: advokatens prutning-belopp (negativt). Sätts
    *  när dom kommit. Driver Expense(kind=PRUTNING) som skapas vid SENT. */
   prutningOre: z.number().int().nullish(),
+  /** KOSTNADSRAKNING:ens egen livscykel (#828): INSKICKAD→BESLUTAD→FAKTURERAD
+   *  + överklagan-grenen. Null för icke-KR-körningar. */
+  kostnadsrakningStatus: kostnadsrakningStatusSchema.nullish(),
+  /** Domstolens beslutade (dömda) belopp i öre — registreras vid beslutet,
+   *  uppdateras av hovrättens beslut vid överklagan (#828). */
+  awardedOre: z.number().int().nullish(),
+  /** Sant efter hovrättens beslut → kostnadsräkningen får ej överklagas igen. */
+  beslutSlutgiltigt: z.boolean().default(false),
   /** Resulterande Invoice — null tills status=SENT. */
   invoiceId: invoiceIdSchema.nullish(),
   /** För FINAL: lista av ACCONTO-runs som dras av. */

--- a/tooling/db/migrations/0012_billing_run_kostnadsrakning_lifecycle.sql
+++ b/tooling/db/migrations/0012_billing_run_kostnadsrakning_lifecycle.sql
@@ -1,0 +1,6 @@
+-- #828: kostnadsräkningens egen livscykel på billing_runs. KR-status
+-- (INSKICKAD/BESLUTAD/OVERKLAGAD/FAKTURERAD), domstolens dömda belopp, och om
+-- beslutet är slutgiltigt (efter hovrättens beslut → får ej överklagas igen).
+ALTER TABLE billing_runs ADD COLUMN IF NOT EXISTS kostnadsrakning_status text;
+ALTER TABLE billing_runs ADD COLUMN IF NOT EXISTS awarded_ore integer;
+ALTER TABLE billing_runs ADD COLUMN IF NOT EXISTS beslut_slutgiltigt boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
## Vad (steg 2 av epic #828)

Persisterar kostnadsräkningens livscykel på `BillingRun`:
- `kostnadsrakning-flow.ts` exporterar nu **`kostnadsrakningStatusSchema`** (zod) som enda sanningskälla för statusvärdena (typen härleds därifrån).
- **`billingRunSchema`** + drizzle **`billing_runs`** får: `kostnadsrakningStatus`, `awardedOre` (domstolens dömda belopp), `beslutSlutgiltigt` (sant efter hovrättens beslut).
- **Migration 0012** (idempotent).

Ingen mutationslogik än (steg 3). Bakåtkompatibelt — fälten är nullish/default.

## Verifiering
- `tsc` · ESLint · knip · dep-cruiser: rent
- `bun test --parallel`: 3669 pass (21 = kända miljö-fel)
- `build:demo`: OK

refs #828
🤖 Generated with [Claude Code](https://claude.com/claude-code)
