### PR TITLE
feat(billing): registrera domstolsbeslut + överklagan på kostnadsräkningen (#828 steg 3a)

### DIFF
--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -22,6 +22,7 @@ import { proposedAccontoOre } from "@/lib/shared/billing-proposal";
 import { TIMKOSTNADSNORM_FTAX_ORE_PER_H, TIMKOSTNADSNORM_NO_FTAX_ORE_PER_H } from "@/lib/shared/brottmalstaxa";
 import { computeCoverageSplit, partitionRattsskyddMinutes, type CoverageSplit } from "@/lib/shared/coverage-billing";
 import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
+import { applyKrAction, type KostnadsrakningAction, type KostnadsrakningState, type KostnadsrakningStatus } from "@/lib/shared/kostnadsrakning-flow";
 import { ocrFromInvoiceNumber } from "@/lib/shared/ocr-reference";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { RADGIVNING_MINUTES } from "@/lib/shared/rattshjalp";
@@ -44,7 +45,7 @@ import {
 } from "@/lib/shared/schemas/ids";
 import { splitVat, DEFAULT_VAT_RATE } from "@/lib/shared/vat";
 import { emit } from "../events/emit";
-import type { BillingRunListRow } from "../repositories/billing-run-repository";
+import type { BillingRunDetailRow, BillingRunListRow } from "../repositories/billing-run-repository";
 import type { Repositories } from "../repositories/repositories";
 import { router, orgProcedure } from "../trpc";
 
@@ -389,6 +390,28 @@ async function freezeSelectedWork(
   await repos.expenses.freezeByIds(work.expenses.map((e) => e.id), runId, now);
 }
 
+/** KR-tillstånd ur en körning (#828); saknad status → INSKICKAD (äldre KR). */
+function krStateOf(run: { kostnadsrakningStatus?: KostnadsrakningStatus | null | undefined; beslutSlutgiltigt?: boolean | null | undefined }): KostnadsrakningState {
+  return { status: run.kostnadsrakningStatus ?? "INSKICKAD", slutgiltigt: run.beslutSlutgiltigt ?? false };
+}
+
+/** Hämta en KOSTNADSRAKNING-körning org-scopat; kastar om saknad/fel typ. */
+async function assertKostnadsrakning(repos: Repositories, billingRunId: BillingRunId, orgId: OrganizationId): Promise<BillingRunDetailRow> {
+  const run = await repos.billingRuns.getByIdInOrg(billingRunId, orgId);
+  if (!run) throw new TRPCError({ code: "NOT_FOUND", message: "Kostnadsräkningen finns inte." });
+  if (run.type !== "KOSTNADSRAKNING") throw new TRPCError({ code: "BAD_REQUEST", message: "Åtgärden gäller bara kostnadsräkningar." });
+  return run;
+}
+
+/** Applicera en KR-övergång; översätt otillåten övergång till TRPCError. */
+function applyKrTransition(state: KostnadsrakningState, action: KostnadsrakningAction): KostnadsrakningState {
+  try {
+    return applyKrAction(state, action);
+  } catch (e) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: e instanceof Error ? e.message : "Otillåten kostnadsräknings-övergång." });
+  }
+}
+
 /**
  * Flödes-guard (#816 fas 3): säkerställer att ärendet finns OCH att `action` är
  * laglig i ärendets nuvarande fas enligt billing-flow-modellen (samma sanningskälla
@@ -567,7 +590,7 @@ export const billingRunRouter = router({
         const grossValue = invoiceGrossOre(work);
         const run = await tx.billingRuns.create({
           matterId: input.matterId, type: "KOSTNADSRAKNING", recipient: "DOMSTOL",
-          status: "PENDING_VERDICT", workValueOreAtRun: grossValue,
+          status: "PENDING_VERDICT", kostnadsrakningStatus: "INSKICKAD", workValueOreAtRun: grossValue,
           proposedAmountOre: grossValue, amountOre: grossValue,
           invoiceId: null, deductedBillingRunIds: [],
           periodTo: new Date(), notes: input.notes,
@@ -577,6 +600,47 @@ export const billingRunRouter = router({
         // körningen (fetchWorkByRun), inte som ofryst.
         await freezeWork(tx, input.matterId, run.id);
         return { run };
+      });
+    }),
+
+  /**
+   * Registrera domstolens beslut PÅ kostnadsräkningen (#828): dömt belopp +
+   * ev. prutning. INSKICKAD → BESLUTAD (tingsrätten); ÖVERKLAGAD → BESLUTAD
+   * slutgiltigt (hovrätten). Skapar INGEN faktura — det är ett separat steg.
+   */
+  recordKostnadsrakningBeslut: orgProcedure
+    .input(z.object({
+      billingRunId: billingRunIdSchema,
+      awardedOre: z.number().int().nonnegative(),
+      prutningOre: z.number().int().nonpositive().optional(),
+    }))
+    .mutation(async ({ ctx, input }) => {
+      return ctx.repos.transaction(async (tx) => {
+        const run = await assertKostnadsrakning(tx, input.billingRunId, ctx.orgId);
+        const state = krStateOf(run);
+        const action: KostnadsrakningAction = state.status === "OVERKLAGAD" ? "REGISTRERA_HOVRATT_BESLUT" : "REGISTRERA_BESLUT";
+        const next = applyKrTransition(state, action);
+        const updated = await tx.billingRuns.update(run.id, {
+          kostnadsrakningStatus: next.status, beslutSlutgiltigt: next.slutgiltigt,
+          awardedOre: input.awardedOre, prutningOre: input.prutningOre ?? null,
+        });
+        return { run: updated };
+      });
+    }),
+
+  /**
+   * Överklaga prutningen på en kostnadsräkning (#828): BESLUTAD → ÖVERKLAGAD.
+   * Inlagan (Word) bifogas som dokument (steg 4). Ingen ny KR — hovrättens beslut
+   * registreras sedan på SAMMA körning via recordKostnadsrakningBeslut.
+   */
+  appealKostnadsrakning: orgProcedure
+    .input(z.object({ billingRunId: billingRunIdSchema }))
+    .mutation(async ({ ctx, input }) => {
+      return ctx.repos.transaction(async (tx) => {
+        const run = await assertKostnadsrakning(tx, input.billingRunId, ctx.orgId);
+        const next = applyKrTransition(krStateOf(run), "OVERKLAGA");
+        const updated = await tx.billingRuns.update(run.id, { kostnadsrakningStatus: next.status, beslutSlutgiltigt: next.slutgiltigt });
+        return { run: updated };
       });
     }),
 

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -289,6 +289,46 @@ describe("billingRun.setVerdict", () => {
   });
 });
 
+describe("billingRun — KR-livscykel (#828): beslut + överklagan", () => {
+  const kr = async () => {
+    const { caller } = makeCaller({ workMinutes: 60, paymentMethod: "OFFENTLIGT_UPPDRAG" });
+    const created = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
+    return { caller, runId: created.run.id, created };
+  };
+
+  it("createKostnadsrakning startar i INSKICKAD", async () => {
+    const { created } = await kr();
+    expect((created.run as { kostnadsrakningStatus?: string }).kostnadsrakningStatus).toBe("INSKICKAD");
+  });
+
+  it("recordKostnadsrakningBeslut: INSKICKAD → BESLUTAD + sparar dömt belopp/prutning", async () => {
+    const { caller, runId } = await kr();
+    const res = await caller.billingRun.recordKostnadsrakningBeslut({ billingRunId: runId, awardedOre: 200000, prutningOre: -50000 });
+    const r = res.run as { kostnadsrakningStatus: string; awardedOre: number; beslutSlutgiltigt: boolean };
+    expect(r.kostnadsrakningStatus).toBe("BESLUTAD");
+    expect(r.awardedOre).toBe(200000);
+    expect(r.beslutSlutgiltigt).toBe(false);
+  });
+
+  it("överklagan → hovrättsbeslut (slutgiltigt), ingen dubbel-överklagan", async () => {
+    const { caller, runId } = await kr();
+    await caller.billingRun.recordKostnadsrakningBeslut({ billingRunId: runId, awardedOre: 200000 });
+    const appealed = await caller.billingRun.appealKostnadsrakning({ billingRunId: runId });
+    expect((appealed.run as { kostnadsrakningStatus: string }).kostnadsrakningStatus).toBe("OVERKLAGAD");
+    const hovr = await caller.billingRun.recordKostnadsrakningBeslut({ billingRunId: runId, awardedOre: 250000 });
+    const r = hovr.run as { kostnadsrakningStatus: string; beslutSlutgiltigt: boolean; awardedOre: number };
+    expect(r.kostnadsrakningStatus).toBe("BESLUTAD");
+    expect(r.beslutSlutgiltigt).toBe(true);
+    expect(r.awardedOre).toBe(250000);
+    await expect(caller.billingRun.appealKostnadsrakning({ billingRunId: runId })).rejects.toThrow(/inte tillåten/);
+  });
+
+  it("överklagan innan beslut är otillåten", async () => {
+    const { caller, runId } = await kr();
+    await expect(caller.billingRun.appealKostnadsrakning({ billingRunId: runId })).rejects.toThrow(/inte tillåten/);
+  });
+});
+
 describe("billingRun — flödes-guard (#816 fas 3)", () => {
   it("avvisar kostnadsräkning på ett RÄTTSSKYDD-ärende (otillåten övergång)", async () => {
     const { caller } = makeCaller({ workMinutes: 60, paymentMethod: "RATTSSKYDD" });


### PR DESCRIPTION
## Vad (steg 3a av epic #828)

Server-mutationer för att registrera domstolsbeslut + överklaga **på kostnadsräkningen** — additivt, ingen reshape av `settleCoverage` än (det är 3b).

- `createKostnadsrakning` startar nu i `kostnadsrakningStatus=INSKICKAD`.
- **`recordKostnadsrakningBeslut`**: registrerar domstolens beslut (dömt belopp + ev. prutning) PÅ KR:n. `INSKICKAD→BESLUTAD` (tingsrätt); `ÖVERKLAGAD→BESLUTAD` slutgiltigt (hovrätt). Skapar **ingen faktura**.
- **`appealKostnadsrakning`**: `BESLUTAD→ÖVERKLAGAD` (ingen ny KR). Inlaga-dokument bifogas i steg 4.
- Drivs av `kostnadsrakning-flow`:s state-maskin → otillåten övergång ger `BAD_REQUEST` (faktura före beslut, dubbel överklagan).

## Verifiering
- `tsc` (root+test) · ESLint · knip · dep-cruiser: rent
- `bun test --parallel`: 3673 pass (21 = kända miljö-fel). 4 nya KR-livscykel-tester.
- `build:demo`: OK

refs #828 · nästa: 3b (faktura-steget kräver BESLUTAD + slutar konsumera KR:n + demo-uppdatering), 4 (KR-dokument), 5 (UI), 6 (demodata).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
