### PR TITLE
feat(billing): rättshjälp-faktura kräver beslut, KR konsumeras ej (#828 steg 3b)

### DIFF
--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -163,23 +163,29 @@ interface PayerRunInput {
   payerGross: number; notes: string | null | undefined; krRun: BillingRunListRow | undefined;
 }
 
-/** Betalar-körningen vid slutreglering (#806): konsumerar en väntande kostnads-
- *  räkning (→ SENT, faktura länkad — arbetet redan fryst mot den), annars en ny
- *  FINAL + frysning av det ofrysta arbetet (rättsskydd). */
+/** Betalar-körningen vid slutreglering (#828): ALLTID en egen FINAL — kostnads-
+ *  räkningen konsumeras inte längre in i fakturan (KR:n förblir distinkt med sitt
+ *  dokument/beslut). Finns ingen KR (rättsskydd) fryses det ofrysta arbetet nu;
+ *  finns en KR är arbetet redan fryst mot den. */
 async function bookPayerRun(repos: Repositories, p: PayerRunInput): Promise<BillingRun> {
-  if (p.krRun) {
-    return repos.billingRuns.update(p.krRun.id, {
-      status: "SENT", invoiceId: p.payerInvoiceId,
-      amountOre: p.payerGross, proposedAmountOre: p.payerGross, workValueOreAtRun: p.payerGross,
-    });
-  }
   const run = await repos.billingRuns.create({
     matterId: p.matterId, type: "FINAL", recipient: p.payerRecipient, status: "SENT",
     workValueOreAtRun: p.payerGross, proposedAmountOre: p.payerGross, amountOre: p.payerGross,
     invoiceId: p.payerInvoiceId, deductedBillingRunIds: [], periodTo: new Date(), notes: p.notes,
   });
-  await freezeWork(repos, p.matterId, run.id);
+  if (!p.krRun) await freezeWork(repos, p.matterId, run.id);
   return run;
+}
+
+/** Domsbeloppet för slutregleringen (#828): finns en kostnadsräkning måste den
+ *  vara BESLUTAD (beslutet registrerat) och beloppet läses därifrån; annars
+ *  (rättsskydd, ingen KR) används det inmatade beloppet. */
+function resolveAwardedOre(krRun: BillingRunListRow | undefined, inputAwardedOre: number | undefined): number | null {
+  if (!krRun) return inputAwardedOre ?? null;
+  if (krRun.kostnadsrakningStatus !== "BESLUTAD") {
+    throw new TRPCError({ code: "BAD_REQUEST", message: "Registrera domstolens beslut innan du skapar fakturan." });
+  }
+  return krRun.awardedOre ?? null;
 }
 
 /** Arvode netto (exkl. moms) — summa av debiterbara tidsposter. */
@@ -747,13 +753,16 @@ export const billingRunRouter = router({
           throw new TRPCError({ code: "BAD_REQUEST", message: "Settlement gäller bara rättsskydd/rättshjälp." });
         }
         const { work, krRun } = await resolveSettlementWork(tx, ctx.orgId, input.matterId);
+        // Finns en kostnadsräkning måste den vara BESLUTAD först — fakturan skapas
+        // EFTER domstolens beslut (#828). Domsbeloppet läses då från KR:n, inte input.
+        const awardedOre = resolveAwardedOre(krRun, input.awardedOre);
         const billableMinutes = work.timeEntries.filter((t) => t.billable).reduce((s, t) => s + t.minutes, 0);
         const rateOre = await currentArvodeRateOre(tx, ctx.orgId, matter);
         const baseMinutes = coverageBaseMinutes(matter.paymentMethod, billableMinutes);
         const totalArvodeNet = Math.round((baseMinutes / 60) * rateOre);
         const split = computeCoverageSplit({
           method: matter.paymentMethod, totalOre: totalArvodeNet, clientShareBips: matter.clientShareBips ?? 0,
-          awardedOre: input.awardedOre ?? null, insurerPrutningOre: input.insurerPrutningOre ?? null,
+          awardedOre, insurerPrutningOre: input.insurerPrutningOre ?? null,
           ...rattsskyddCoverage(matter, work.timeEntries, rateOre),
         });
         const { clientLines, payerLines } = coverageInvoiceLines(split, work);
@@ -783,6 +792,12 @@ export const billingRunRouter = router({
           matterId: input.matterId, payerRecipient: input.payerRecipient, payerInvoiceId: payerInvoice.id,
           payerGross, notes: input.notes, krRun,
         });
+        // KR:n förblir en distinkt kostnadsräkning (med sitt dokument/beslut) —
+        // konsumeras EJ in i fakturan; markeras FAKTURERAD (#828).
+        if (krRun) {
+          const next = applyKrTransition(krStateOf(krRun), "SKAPA_FAKTURA");
+          await tx.billingRuns.update(krRun.id, { status: "SENT", kostnadsrakningStatus: next.status, beslutSlutgiltigt: next.slutgiltigt });
+        }
         await emit.invoiceCreated(ctx, clientInvoice);
         await emit.invoiceCreated(ctx, payerInvoice);
         return { split, clientInvoice, payerInvoice, clientRun, payerRun };

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -434,21 +434,24 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
     expect(prutning.billable).toBe(false);
   });
 
-  it("rättshjälp via kostnadsräkning (#806): läser de frysta raderna och KONSUMERAR den väntande körningen (ingen dubbelräkning)", async () => {
+  it("rättshjälp via KR (#828): kräver registrerat beslut; domsbeloppet läses från KR:n; KR konsumeras EJ utan markeras FAKTURERAD", async () => {
     const { ds, caller: c } = caller({ paymentMethod: "RATTSHJALP", clientShareBips: 2000, taxaHasFTax: true }, 999999, 180);
     const kr = await c.billingRun.createKostnadsrakning({ matterId: "m-1" });
-    expect(kr.run.status).toBe("PENDING_VERDICT");
-    const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "RATTSHJALPSMYNDIGHET", awardedOre: 300000 });
-    // Samma split som utan KR — arbetet är fryst mot körningen och läses via den.
+    // Faktura före beslut är otillåtet.
+    await expect(c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "RATTSHJALPSMYNDIGHET" }))
+      .rejects.toThrow(/Registrera domstolens beslut/);
+    // Registrera domstolens beslut PÅ KR:n (dömt 300 000), sedan fakturera.
+    await c.billingRun.recordKostnadsrakningBeslut({ billingRunId: kr.run.id, awardedOre: 300000 });
+    const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "RATTSHJALPSMYNDIGHET" });
+    // Domsbeloppet (300 000) tas från KR:n → samma split.
     expect(res.split).toMatchObject({ clientOre: 60000, payerOre: 240000, firmLossOre: 25200 });
     expect(res.clientInvoice.amount).toBe(75000);
     expect(res.payerInvoice.amount).toBe(300000);
-    // Den väntande kostnadsräkningen blir betalar-körningen (→ SENT, faktura länkad)
-    // i stället för en ny FINAL → "Väntar på dom" släcks utan dubbelräkning.
-    expect(res.payerRun.id).toBe(kr.run.id);
-    const consumed = await ds.billingRuns.findFirst({ where: { id: kr.run.id } }) as { status: string; invoiceId: string };
-    expect(consumed.status).toBe("SENT");
-    expect(consumed.invoiceId).toBe(res.payerInvoice.id);
+    // Betalar-körningen är en EGEN FINAL (ej KR:n) → KR:n förblir distinkt.
+    expect(res.payerRun.id).not.toBe(kr.run.id);
+    const krAfter = await ds.billingRuns.findFirst({ where: { id: kr.run.id } }) as { kostnadsrakningStatus: string; invoiceId: string | null };
+    expect(krAfter.kostnadsrakningStatus).toBe("FAKTURERAD");
+    expect(krAfter.invoiceId).toBeFalsy(); // KR länkar aldrig till en slutfaktura
   });
 
   it("rättsskydd tidsuppdelat (#810): arbete före tvist → klient 100 %, retro+efter beslut täckt", async () => {

--- a/tooling/demo-generator/populate-billing.ts
+++ b/tooling/demo-generator/populate-billing.ts
@@ -182,15 +182,17 @@ async function runKostnadsrakning(ctx: Ctx, matterId: string, withVerdict: boole
 }
 
 /**
- * Rättshjälp följer flödesmodellen (#816): aconto till klient → kostnadsräkning
- * till domstol (fryser arbetet) → slutreglering (dom) som skapar klient- +
- * stat-faktura och konsumerar kostnadsräkningen. INGEN direkt slutfaktura till
- * myndigheten (det vore en otillåten övergång).
+ * Rättshjälp följer KR-livscykeln (#828): aconto → kostnadsräkning till domstol
+ * (fryser arbetet) → registrera domstolens beslut → slutreglering (faktura) som
+ * skapar klient- + stat-faktura. Kostnadsräkningen förblir distinkt (markeras
+ * FAKTURERAD) — ingen direkt slutfaktura till myndigheten.
  */
 async function runRattshjalpBilling(ctx: Ctx, matterId: string, daysAgo: number): Promise<void> {
   const accontoRun = await acconto(ctx, matterId, 3000, 150_000, daysAgo);
-  await ctx.c.billingRun.createKostnadsrakning({ matterId, notes: "Kostnadsräkning till domstol (rättshjälp)" });
+  const kr = await ctx.c.billingRun.createKostnadsrakning({ matterId, notes: "Kostnadsräkning till domstol (rättshjälp)" });
   ctx.res.kostnadsrakningSent++;
+  // Domstolens beslut (dömt belopp = hela det yrkade i demon, ingen prutning).
+  await ctx.c.billingRun.recordKostnadsrakningBeslut({ billingRunId: kr.run.id, awardedOre: kr.run.workValueOreAtRun });
   const res = await ctx.c.billingRun.settleCoverage({ matterId, payerRecipient: "RATTSHJALPSMYNDIGHET", deductedBillingRunIds: [accontoRun] });
   ctx.res.invoices += 2; // klient- + stat-faktura
   await ctx.c.invoice.setStatus({ invoiceId: res.clientInvoice.id, status: "SENT" });


### PR DESCRIPTION
## Vad (steg 3b av epic #828 — rättshjälp)

Frikopplar beslut från faktura i rättshjälpsflödet (**KR→Beslut→Faktura**), och fixar att kostnadsräkningen länkade till en slutfaktura:

- **`settleCoverage`**: finns en kostnadsräkning måste den vara `BESLUTAD` (annars `BAD_REQUEST` "Registrera domstolens beslut..."). Domsbeloppet läses då **från KR:n**, inte från input. Saknas KR (rättsskydd) används inmatat belopp (bakåtkompat).
- **KR konsumeras inte längre** in i betalar-fakturan — den förblir en distinkt kostnadsräkning (länkar **aldrig** till en slutfaktura) och markeras `FAKTURERAD`. Betalar-fakturan är alltid en egen `FINAL`-körning.
- **Demo-generatorns rättshjälp-väg** registrerar nu domstolens beslut innan fakturan.

Offentligt uppdrag (`setVerdict`) reshapas i 3c.

## Verifiering
- `tsc` (root+test) · ESLint · knip · dep-cruiser: rent
- `bun test --parallel`: 3673 pass (21 = kända miljö-fel). #806-testet omskrivet: faktura-före-beslut avvisas; domsbelopp läses från KR:n; KR blir FAKTURERAD utan faktura-länk; betalar-körningen är separat.
- `build:demo`: OK (rättshjälp har nu distinkt KR + separat betalar-faktura)

refs #828
🤖 Generated with [Claude Code](https://claude.com/claude-code)
