### PR TITLE
feat(demo): staga rättshjälps-KR i olika lägen + markera verdict-KR FAKTURERAD (#828 steg 6)

### DIFF
--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -715,6 +715,8 @@ export const billingRunRouter = router({
         });
         await tx.billingRuns.update(run.id, {
           status: "SENT", invoiceId: invoice.id, amountOre: finalAmount, prutningOre: input.prutningOre,
+          // KR-livscykeln klar (#828) → kortet visar inte längre stale "Registrera beslut".
+          kostnadsrakningStatus: "FAKTURERAD",
         });
         await freezeWork(tx, run.matterId, run.id);
         // Länka poster + PRUTNING-utlägget → kostnadsräknings-vyn visar uppdelning

--- a/tooling/demo-generator/populate-billing.ts
+++ b/tooling/demo-generator/populate-billing.ts
@@ -183,25 +183,22 @@ async function runKostnadsrakning(ctx: Ctx, matterId: string, withVerdict: boole
 
 /**
  * Rättshjälp följer KR-livscykeln (#828): aconto → kostnadsräkning till domstol
- * (fryser arbetet) → registrera domstolens beslut → slutreglering (faktura) som
- * skapar klient- + stat-faktura. Kostnadsräkningen förblir distinkt (markeras
- * FAKTURERAD) — ingen direkt slutfaktura till myndigheten.
+ * (fryser arbetet) → registrera domstolens beslut → faktura/överklagan i UI:t.
+ * Demon lämnar ärendena i olika lägen (`INSKICKAD` = väntar på beslut, `BESLUTAD`
+ * = beslut registrerat, redo att faktureras/överklagas) så hela KR-kortet kan
+ * testas — fakturasteget görs av användaren.
  */
-async function runRattshjalpBilling(ctx: Ctx, matterId: string, daysAgo: number): Promise<void> {
-  const accontoRun = await acconto(ctx, matterId, 3000, 150_000, daysAgo);
+async function runRattshjalpBilling(ctx: Ctx, matterId: string, daysAgo: number, stage: "INSKICKAD" | "BESLUTAD"): Promise<void> {
+  await acconto(ctx, matterId, 3000, 150_000, daysAgo);
   const kr = await ctx.c.billingRun.createKostnadsrakning({ matterId, notes: "Kostnadsräkning till domstol (rättshjälp)" });
-  ctx.res.kostnadsrakningSent++;
+  ctx.res.kostnadsrakningPending++;
+  if (stage === "INSKICKAD") return; // väntar på domstolens beslut
   // Domstolens beslut (dömt belopp = hela det yrkade i demon, ingen prutning).
   await ctx.c.billingRun.recordKostnadsrakningBeslut({ billingRunId: kr.run.id, awardedOre: kr.run.workValueOreAtRun });
-  const res = await ctx.c.billingRun.settleCoverage({ matterId, payerRecipient: "RATTSHJALPSMYNDIGHET", deductedBillingRunIds: [accontoRun] });
-  ctx.res.invoices += 2; // klient- + stat-faktura
-  await ctx.c.invoice.setStatus({ invoiceId: res.clientInvoice.id, status: "SENT" });
-  await ctx.c.invoice.setStatus({ invoiceId: res.payerInvoice.id, status: "SENT" });
 }
 
 async function runClientBilling(ctx: Ctx, matterId: string, pm: string, clientIdx: number): Promise<void> {
   const daysAgo = 30 + clientIdx * 6;
-  if (pm === "RATTSHJALP") { await runRattshjalpBilling(ctx, matterId, daysAgo); return; }
   const deducted = pm === "RATTSSKYDD"
     ? [await acconto(ctx, matterId, 2000, 200_000, daysAgo)]
     : [];
@@ -230,6 +227,7 @@ export async function populateBilling(caller: GeneratorCaller, seed: SeedDataset
 
   let clientIdx = 0;
   let krIdx = 0;
+  let rhIdx = 0;
   for (const m of active) {
     const pm = String(m.paymentMethod);
     const matterId = String(m.id);
@@ -240,6 +238,13 @@ export async function populateBilling(caller: GeneratorCaller, seed: SeedDataset
       continue;
     }
     if (!hasWork(seed, matterId)) continue; // klientfaktura kräver fakturerbart arbete
+    if (pm === "RATTSHJALP") {
+      // Visa KR-kortets båda actionabla lägen: första ärendet väntar på beslut,
+      // nästa har beslut registrerat (redo att faktureras/överklagas).
+      await runRattshjalpBilling(ctx, matterId, 30 + rhIdx * 6, rhIdx % 2 === 0 ? "INSKICKAD" : "BESLUTAD");
+      rhIdx++;
+      continue;
+    }
     await runClientBilling(ctx, matterId, pm, clientIdx);
     clientIdx++;
   }


### PR DESCRIPTION
## Vad (steg 6 av epic #828 — demodata + setVerdict-justering)

- **Demo-generatorn** lämnar nu rättshjälps-ärenden i olika KR-lägen så hela KR-kortet kan testas i UI:t: ett **INSKICKAD** (→ "Registrera beslut") och ett **BESLUTAD** (→ "Skapa faktura" / "Överklaga prutning"). Fakturasteget görs av användaren.
- **`setVerdict`** (offentligt uppdrag) markerar nu KR:n `FAKTURERAD` när fakturan skapas → kortet visar inte längre ett stale "Registrera beslut" på en redan domslagen KR.

Seedens KR-fördelning: RATTSHJALP INSKICKAD + BESLUTAD, OFFENTLIGT INSKICKAD + FAKTURERAD.

## Verifiering
- `tsc` · `lint --max-warnings 0` · knip · dep-cruiser · jscpd (duplicates): rent (CI Static-analysis-spegel)
- `bun test --parallel` (billing + integration): grönt
- `build:demo`: OK

refs #828 · kvar: 3c (offentligt setVerdict → fullt KR-flöde recordBeslut+faktura), 4 (KR-dokument även rättshjälp), 7 (ADR).
🤖 Generated with [Claude Code](https://claude.com/claude-code)
