### PR TITLE
refactor(billing): offentligt uppdrag följer KR→beslut→faktura (3c)

### DIFF
--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -228,8 +228,16 @@ function useBillingMeta(matter: MatterContext): BillingMeta {
   };
 }
 
+/** KR:ns föreslagna + dömda belopp till verdict-dialogen (faller tillbaka på
+ *  föreslaget när dömt ännu saknas) — utbrutet så BillingDialogs håller sig ≤8. */
+function verdictAmounts(pending: BillingRunRow | undefined): { workValueOre: number; awardedOre: number } {
+  const workValueOre = pending?.amountOre ?? 0;
+  return { workValueOre, awardedOre: pending?.awardedOre ?? workValueOre };
+}
+
 function BillingDialogs({ matterId, matter, rows, dialog, setDialog, verdictRunId, setVerdictRunId, onRefetch }: DialogsProps) {
   const pending = findPendingVerdict(rows);
+  const amounts = verdictAmounts(pending);
   const meta = useBillingMeta(matter);
   return (
     <>
@@ -239,7 +247,8 @@ function BillingDialogs({ matterId, matter, rows, dialog, setDialog, verdictRunI
           onClose={() => { setDialog("NONE"); onRefetch(); }} />
       )}
       {verdictRunId && (
-        <VerdictDialog billingRunId={verdictRunId} workValueOre={pending?.amountOre ?? 0}
+        <VerdictDialog billingRunId={verdictRunId} workValueOre={amounts.workValueOre}
+          awardedOre={amounts.awardedOre}
           matterId={matterId} matterNumber={matter.matterNumber} matterTitle={matter.title}
           clientName={clientOf(matter)}
           onClose={() => { setVerdictRunId(null); onRefetch(); }} />

--- a/src/app/matters/[id]/_verdict-dialog.tsx
+++ b/src/app/matters/[id]/_verdict-dialog.tsx
@@ -1,19 +1,15 @@
 "use client";
 
 /**
- * `VerdictDialog` — andra steget för OFFENTLIG_FÖRSVARARE-flowet.
+ * `VerdictDialog` — sista steget för OFFENTLIG_FÖRSVARARE/offentligt uppdrag.
  *
- * Kostnadsräkningen ligger i PENDING_VERDICT efter att advokaten skickat
- * den. Här anger advokaten det belopp som domen beviljade. Systemet
- * räknar baklänges till prutningen (= dömt − föreslaget) och skapar
- * Invoice + ev. Expense(kind=PRUTNING) + fryser raderna.
- *
- * Domen anger det FAKTISKA beloppet, inte hur mycket som prutats — så
- * det är vad advokaten skriver in.
+ * Domstolens beslut (dömt belopp + ev. prutning) registreras redan på
+ * kostnadsräkningen (RecordBeslutDialog) → KR:n är BESLUTAD. Här bekräftar
+ * advokaten bara att fakturan ska skapas; servern läser prutningen ur KR:ns
+ * beslut (`setVerdict` tar inget belopp som input) och skapar Invoice +
+ * ev. Expense(kind=PRUTNING) + fryser raderna.
  */
-import { useState } from "react";
 import { VatBreakdown } from "@/components/billing/vat-breakdown";
-import { DecimalInput } from "@/components/ui/decimal-input";
 import { Modal } from "@/components/ui/modal";
 import { generateFakturaDoc } from "@/lib/client/kostnadsrakning/generate-faktura-doc";
 import { trpc } from "@/lib/client/trpc";
@@ -24,6 +20,7 @@ import type { BillingRunId, MatterId } from "@/lib/shared/schemas/ids";
 interface Props {
   billingRunId: BillingRunId;
   workValueOre: number;
+  awardedOre: number;
   matterId: MatterId;
   matterNumber: string;
   matterTitle: string;
@@ -33,20 +30,9 @@ interface Props {
   onClose: () => void;
 }
 
-/** Härleder belopp/prutning/vakt. Utbrutet ur VerdictDialog så komponenten
- *  håller sig under komplexitetsgränsen (#199). */
-function verdictAmounts(workValueOre: number, awardedKr: number | null) {
-  const proposedKr = workValueOre > 0 ? workValueOre / 100 : null;
-  const fieldKr = awardedKr ?? proposedKr;
-  const awardedOre = Math.max(0, Math.round((fieldKr ?? 0) * 100));
-  return { fieldKr, awardedOre, prutningOre: awardedOre - workValueOre, tooHigh: awardedOre > workValueOre };
-}
-
 export function VerdictDialog(props: Props) {
-  const { billingRunId, workValueOre, onClose } = props;
-  // null → följ det föreslagna beloppet (förifyllt); tomt fält tillåts (#778).
-  const [awardedKr, setAwardedKr] = useState<number | null>(null);
-  const { fieldKr, awardedOre, prutningOre, tooHigh } = verdictAmounts(workValueOre, awardedKr);
+  const { billingRunId, workValueOre, awardedOre, onClose } = props;
+  const prutningOre = awardedOre - workValueOre;
   const register = trpc.document.register.useMutation();
   const utils = trpc.useUtils();
   const mut = trpc.billingRun.setVerdict.useMutation({
@@ -71,33 +57,24 @@ export function VerdictDialog(props: Props) {
     },
   });
   return (
-    <Modal open title="Ange dom" onClose={onClose} widthClass="max-w-md">
-      <form onSubmit={(e) => { e.preventDefault(); if (!tooHigh) mut.mutate({ billingRunId, prutningOre }); }}
+    <Modal open title="Skapa faktura från beslut" onClose={onClose} widthClass="max-w-md">
+      <form onSubmit={(e) => { e.preventDefault(); mut.mutate({ billingRunId }); }}
         className="space-y-3">
         <p className="text-sm text-gray-600">
-          Skriv in det belopp som domen beviljade. Är det lägre än det
-          föreslagna räknas mellanskillnaden automatiskt som prutning.
+          Domstolens beslut är registrerat på kostnadsräkningen. Fakturan skapas
+          på det dömda beloppet — ev. prutning bokförs automatiskt.
         </p>
         <Pair label="Föreslaget belopp" value={formatCurrency(workValueOre)} />
-        <div>
-          <label className="block text-xs text-gray-500 mb-1">Dömt belopp (kr) — inkl. moms</label>
-          <DecimalInput value={fieldKr} onChange={setAwardedKr} placeholder="Skriv in belopp"
-            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm" />
-          {!tooHigh && <VatBreakdown inclOre={awardedOre} />}
-          {tooHigh && (
-            <p className="mt-1 text-xs text-red-600">
-              Dömt belopp kan inte överstiga föreslaget — kontrollera siffran från domen.
-            </p>
-          )}
-        </div>
-        {prutningOre < 0 && !tooHigh && (
+        <Pair label="Dömt belopp — inkl. moms" value={formatCurrency(awardedOre)} />
+        <VatBreakdown inclOre={awardedOre} />
+        {prutningOre < 0 && (
           <Pair label="Prutning" value={formatCurrency(prutningOre)} dim />
         )}
         {mut.error && <p className="text-sm text-red-700">{mut.error.message}</p>}
         <div className="flex justify-end gap-2 pt-2">
           <button type="button" onClick={onClose}
             className="px-3 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50">Avbryt</button>
-          <button type="submit" disabled={mut.isPending || tooHigh}
+          <button type="submit" disabled={mut.isPending}
             className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50">
             {mut.isPending ? "Sparar…" : "Skapa faktura"}
           </button>

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -684,23 +684,22 @@ export const billingRunRouter = router({
     }),
 
   setVerdict: orgProcedure
-    .input(z.object({
-      billingRunId: billingRunIdSchema,
-      prutningOre: z.number().int().nonpositive(),
-    }))
+    .input(z.object({ billingRunId: billingRunIdSchema }))
     .mutation(async ({ ctx, input }) => {
       return ctx.repos.transaction(async (tx) => {
-        const run = await tx.billingRuns.getByIdInOrg(input.billingRunId, ctx.orgId);
-        if (!run) throw new TRPCError({ code: "NOT_FOUND", message: "Faktureringshändelsen finns inte." });
-        if (run.type !== "KOSTNADSRAKNING" || run.status !== "PENDING_VERDICT") {
-          throw new TRPCError({ code: "BAD_REQUEST", message: "Bara KOSTNADSRAKNING i PENDING_VERDICT kan domsläggas." });
+        const run = await assertKostnadsrakning(tx, input.billingRunId, ctx.orgId);
+        // Faktura skapas EFTER beslutet (#828): KR:n måste vara BESLUTAD; prutningen
+        // läses från KR:ns registrerade beslut, inte som input.
+        if (run.kostnadsrakningStatus !== "BESLUTAD") {
+          throw new TRPCError({ code: "BAD_REQUEST", message: "Registrera domstolens beslut innan du skapar fakturan." });
         }
-        const finalAmount = Math.max(0, run.workValueOreAtRun + input.prutningOre);
+        const prutningOre = run.prutningOre ?? 0;
+        const finalAmount = Math.max(0, run.workValueOreAtRun + prutningOre);
         let prutningExpenseId: ExpenseId | undefined;
-        if (input.prutningOre < 0) {
+        if (prutningOre < 0) {
           const prutning = await tx.expenses.create({
             matterId: run.matterId, userId: ctx.user.id, date: new Date(),
-            amount: input.prutningOre, description: "Prutning enligt dom",
+            amount: prutningOre, description: "Prutning enligt dom",
             billable: true, vatRate: 0, vatIncluded: false, kind: "PRUTNING",
           });
           prutningExpenseId = prutning.id;
@@ -713,10 +712,10 @@ export const billingRunRouter = router({
           invoiceType: "FINAL", status: "DRAFT", // DOMSTOL → inget nummer/OCR (ADR 0012)
           invoiceDate: new Date(),
         });
+        const next = applyKrTransition(krStateOf(run), "SKAPA_FAKTURA");
         await tx.billingRuns.update(run.id, {
-          status: "SENT", invoiceId: invoice.id, amountOre: finalAmount, prutningOre: input.prutningOre,
-          // KR-livscykeln klar (#828) → kortet visar inte längre stale "Registrera beslut".
-          kostnadsrakningStatus: "FAKTURERAD",
+          status: "SENT", invoiceId: invoice.id, amountOre: finalAmount,
+          kostnadsrakningStatus: next.status, beslutSlutgiltigt: next.slutgiltigt,
         });
         await freezeWork(tx, run.matterId, run.id);
         // Länka poster + PRUTNING-utlägget → kostnadsräknings-vyn visar uppdelning

--- a/test/unit/app/matters/verdict-dialog.test.tsx
+++ b/test/unit/app/matters/verdict-dialog.test.tsx
@@ -1,7 +1,8 @@
 /**
- * Tester för VerdictDialog (#27 coverage) — OFFENTLIG_FÖRSVARARE-flowets
- * steg 2: ange dömt belopp → prutning räknas baklänges, vakt mot för högt
- * belopp, och onSuccess genererar ett faktura-dokument.
+ * Tester för VerdictDialog (#27/#828 coverage) — offentligt uppdrags sista steg:
+ * domstolens beslut är redan registrerat på KR:n, så dialogen bekräftar bara att
+ * fakturan ska skapas (inget belopp matas in), visar prutning och genererar ett
+ * faktura-dokument onSuccess.
  */
 
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
@@ -38,6 +39,7 @@ vi.mock("@/lib/client/demo/persist-generated-doc", () => ({ persistGeneratedDoc 
 const baseProps = {
   billingRunId: asId<"BillingRunId">("br-1"),
   workValueOre: 500_000,
+  awardedOre: 400_000,
   matterId: asId<"MatterId">("m1"),
   matterNumber: "B-2026-1",
   matterTitle: "Brottmål",
@@ -47,30 +49,22 @@ const baseProps = {
 beforeEach(() => { vi.clearAllMocks(); verdictOnSuccess = undefined; });
 
 describe("VerdictDialog", () => {
-  it("visar föreslaget belopp och initierar dömt = föreslaget (ingen prutning)", () => {
+  it("visar föreslaget + dömt belopp och prutningen (dömt < föreslaget)", () => {
     render(<VerdictDialog {...baseProps} />);
     expect(screen.getByText("Föreslaget belopp")).toBeInTheDocument();
-    const input = screen.getByRole("textbox") as HTMLInputElement;
-    expect(input.value).toBe("5000"); // 500 000 öre / 100
+    expect(screen.getByText("Dömt belopp — inkl. moms")).toBeInTheDocument();
+    expect(screen.getByText("Prutning")).toBeInTheDocument();
+  });
+
+  it("ingen prutning visas när dömt = föreslaget", () => {
+    render(<VerdictDialog {...baseProps} awardedOre={500_000} />);
     expect(screen.queryByText("Prutning")).not.toBeInTheDocument();
   });
 
-  it("dömt < föreslaget → visar prutning och submit skickar negativ prutningOre", () => {
+  it("submit skapar fakturan utan belopp-input (prutning läses ur KR:ns beslut)", () => {
     render(<VerdictDialog {...baseProps} />);
-    fireEvent.change(screen.getByRole("textbox"), { target: { value: "4000" } }); // 400 000 öre
-    expect(screen.getByText("Prutning")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Skapa faktura" }));
-    expect(verdictMutate).toHaveBeenCalledWith({ billingRunId: "br-1", prutningOre: -100_000 });
-  });
-
-  it("dömt > föreslaget → fel-text, submit disabled, ingen mutation", () => {
-    render(<VerdictDialog {...baseProps} />);
-    fireEvent.change(screen.getByRole("textbox"), { target: { value: "6000" } });
-    expect(screen.getByText(/kan inte överstiga föreslaget/)).toBeInTheDocument();
-    const submit = screen.getByRole("button", { name: "Skapa faktura" }) as HTMLButtonElement;
-    expect(submit.disabled).toBe(true);
-    fireEvent.submit(submit.closest("form")!);
-    expect(verdictMutate).not.toHaveBeenCalled();
+    expect(verdictMutate).toHaveBeenCalledWith({ billingRunId: "br-1" });
   });
 
   it("onSuccess genererar faktura-dokument + registrerar det + stänger", async () => {

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -221,26 +221,27 @@ describe("billingRun.createKostnadsrakning", () => {
 });
 
 describe("billingRun.setVerdict", () => {
-  it("transitionar PENDING_VERDICT → SENT, skapar Invoice + fryser rader", async () => {
+  // #828: fakturan skapas EFTER domstolens beslut — prutningen registreras på
+  // KR:n (recordKostnadsrakningBeslut) och läses sedan ur körningen, inte som input.
+  it("transitionar BESLUTAD → SENT, skapar Invoice + fryser rader", async () => {
     const { ds, caller } = makeCaller({ workMinutes: 60, paymentMethod: "OFFENTLIGT_UPPDRAG" }); // 2500 kr
     const kr = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
-    const res = await caller.billingRun.setVerdict({
-      billingRunId: kr.run.id, prutningOre: 0,
-    });
+    await caller.billingRun.recordKostnadsrakningBeslut({ billingRunId: kr.run.id, awardedOre: 312500 });
+    const res = await caller.billingRun.setVerdict({ billingRunId: kr.run.id });
     expect(res.run.id).toBe(kr.run.id);
-    const updated = await ds.billingRuns.findFirst({ where: { id: kr.run.id } }) as { status: string; invoiceId: string };
+    const updated = await ds.billingRuns.findFirst({ where: { id: kr.run.id } }) as { status: string; invoiceId: string; kostnadsrakningStatus: string };
     expect(updated.status).toBe("SENT");
+    expect(updated.kostnadsrakningStatus).toBe("FAKTURERAD");
     expect(updated.invoiceId).toBe(res.invoice.id);
     const te = await ds.timeEntries.findFirst({ where: { id: "te-1" } }) as { frozenByBillingRunId?: string | null };
     expect(te.frozenByBillingRunId).toBe(kr.run.id);
   });
 
-  it("skapar Expense(kind=PRUTNING) när prutning angiven", async () => {
+  it("skapar Expense(kind=PRUTNING) när prutning registrerats på beslutet", async () => {
     const { ds, caller } = makeCaller({ workMinutes: 60, paymentMethod: "OFFENTLIGT_UPPDRAG" });
     const kr = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
-    await caller.billingRun.setVerdict({
-      billingRunId: kr.run.id, prutningOre: -50000,
-    });
+    await caller.billingRun.recordKostnadsrakningBeslut({ billingRunId: kr.run.id, awardedOre: 262500, prutningOre: -50000 });
+    await caller.billingRun.setVerdict({ billingRunId: kr.run.id });
     const prutning = await ds.expenses.findFirst({ where: { matterId: "m-1", kind: "PRUTNING" } }) as { amount: number; description: string };
     expect(prutning).toBeTruthy();
     expect(prutning.amount).toBe(-50000);
@@ -250,16 +251,16 @@ describe("billingRun.setVerdict", () => {
   it("invoice-beloppet är workValue + prutning (prutning negativ)", async () => {
     const { caller } = makeCaller({ workMinutes: 120, paymentMethod: "OFFENTLIGT_UPPDRAG" }); // 5000 kr
     const kr = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
-    const res = await caller.billingRun.setVerdict({
-      billingRunId: kr.run.id, prutningOre: -100000,
-    });
+    await caller.billingRun.recordKostnadsrakningBeslut({ billingRunId: kr.run.id, awardedOre: 525000, prutningOre: -100000 });
+    const res = await caller.billingRun.setVerdict({ billingRunId: kr.run.id });
     expect(res.invoice.amount).toBe(525000); // arvode 5000 kr + moms = 625000, − prutning 1000 = 525000 (#782)
   });
 
   it("LÄNKAR poster + PRUTNING till fakturan → vyn reconciler mot beloppet (#732)", async () => {
     const { ds, caller } = makeCaller({ workMinutes: 120, expenseOre: 5000, paymentMethod: "OFFENTLIGT_UPPDRAG" }); // 5000 kr + 50 kr utlägg
     const kr = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
-    const res = await caller.billingRun.setVerdict({ billingRunId: kr.run.id, prutningOre: -30000 });
+    await caller.billingRun.recordKostnadsrakningBeslut({ billingRunId: kr.run.id, awardedOre: 595000, prutningOre: -30000 });
+    const res = await caller.billingRun.setVerdict({ billingRunId: kr.run.id });
     const te = await ds.timeEntries.findFirst({ where: { id: "te-1" } }) as { invoiceId?: string | null };
     const ex = await ds.expenses.findFirst({ where: { id: "ex-1" } }) as { invoiceId?: string | null };
     const prut = await ds.expenses.findFirst({ where: { matterId: "m-1", kind: "PRUTNING" } }) as { invoiceId?: string | null };
@@ -273,9 +274,16 @@ describe("billingRun.setVerdict", () => {
   it("DOMSTOL-faktura får inget fakturanummer (ADR 0012)", async () => {
     const { caller } = makeCaller({ workMinutes: 60, paymentMethod: "OFFENTLIGT_UPPDRAG" });
     const kr = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
-    const res = await caller.billingRun.setVerdict({ billingRunId: kr.run.id, prutningOre: 0 });
+    await caller.billingRun.recordKostnadsrakningBeslut({ billingRunId: kr.run.id, awardedOre: 312500 });
+    const res = await caller.billingRun.setVerdict({ billingRunId: kr.run.id });
     expect(res.invoice.invoiceNumber).toBeFalsy();
     expect(res.invoice.ocrReference).toBeFalsy();
+  });
+
+  it("kastar om fakturan skapas innan beslutet registrerats (INSKICKAD)", async () => {
+    const { caller } = makeCaller({ workMinutes: 60, paymentMethod: "OFFENTLIGT_UPPDRAG" });
+    const kr = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
+    await expect(caller.billingRun.setVerdict({ billingRunId: kr.run.id })).rejects.toThrow(/beslut/i);
   });
 
   it("kastar om billing-run inte är KOSTNADSRAKNING", async () => {
@@ -284,8 +292,8 @@ describe("billingRun.setVerdict", () => {
       matterId: "m-1", clientShareBips: 2000, amountOre: 50000,
     });
     await expect(caller.billingRun.setVerdict({
-      billingRunId: acc.run.id, prutningOre: 0,
-    })).rejects.toThrow(/KOSTNADSRAKNING/);
+      billingRunId: acc.run.id,
+    })).rejects.toThrow(/kostnadsräkning/i);
   });
 });
 

--- a/tooling/demo-generator/populate-billing.ts
+++ b/tooling/demo-generator/populate-billing.ts
@@ -173,7 +173,12 @@ const PRIVATE_LIFECYCLES = [
 async function runKostnadsrakning(ctx: Ctx, matterId: string, withVerdict: boolean): Promise<void> {
   const kr = await ctx.c.billingRun.createKostnadsrakning({ matterId, notes: "Kostnadsräkning för offentligt försvarsuppdrag" });
   if (withVerdict) {
-    await ctx.c.billingRun.setVerdict({ billingRunId: kr.run.id, prutningOre: -50_000 });
+    // Domstolens beslut registreras på KR:n (prutning −500 kr) → BESLUTAD,
+    // sedan skapas fakturan (prutningen läses ur beslutet, inte som input).
+    await ctx.c.billingRun.recordKostnadsrakningBeslut({
+      billingRunId: kr.run.id, awardedOre: Math.max(0, kr.run.workValueOreAtRun - 50_000), prutningOre: -50_000,
+    });
+    await ctx.c.billingRun.setVerdict({ billingRunId: kr.run.id });
     ctx.res.invoices++;
     ctx.res.kostnadsrakningSent++;
   } else {


### PR DESCRIPTION
## Vad

Offentligt uppdrag (OFFENTLIG_FÖRSVARARE / offentligt uppdrag) följer nu samma kostnadsräknings-livscykel som rättshjälp (#828): **KR → beslut → faktura**.

- `setVerdict` tar inte längre `prutningOre` som input. Den läser prutningen ur kostnadsräkningens **registrerade beslut** (`recordKostnadsrakningBeslut`) och kräver att KR:n är `BESLUTAD` — annars `BAD_REQUEST` ("Registrera domstolens beslut innan du skapar fakturan."). KR:n markeras `FAKTURERAD` när fakturan skapas.
- `VerdictDialog` blir en **bekräftelse** (visar föreslaget/dömt belopp + prutning) i stället för ett belopps-fält — beloppet anges redan i KR-kortets beslut-dialog. Faktura-dokumentet genereras fortfarande onSuccess.
- Demo-generatorn registrerar domstolens beslut (prutning −500 kr) före `setVerdict` för offentliga uppdrag.

## Verifierat lokalt (CI-spegel)

- `typecheck` (main + test), `lint --max-warnings 0`, `knip`, `deps:check`, `duplicates` — gröna
- `bun run test` — 3370 pass / 4 skip / 0 fail (+ 19 i fil-isolerade)
- `build:demo` — OK; demo-generatorns offentligt-KR-flöde (4 kostnadsräkningar) kör beslut→faktura utan fel

Refs #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)