### PR TITLE
feat(billing): generera kostnadsräknings-dokument för rättshjälp (steg 4)

### DIFF
--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -19,6 +19,7 @@ import { Money } from "@/components/ui/money";
 import { EntityLink } from "@/lib/client/demo/entity-link";
 import { hasGeneratedDoc, openGeneratedDoc } from "@/lib/client/demo/generated-doc-cache";
 import { useMatterInvariants } from "@/lib/client/diagnostics/use-matter-invariants";
+import { generateKrDoc } from "@/lib/client/kostnadsrakning/generate-kr-doc";
 import { trpc } from "@/lib/client/trpc";
 import { formatCurrency } from "@/lib/client/utils";
 import type { AppRouter } from "@/lib/server/routers/_app";
@@ -306,7 +307,7 @@ function useKrModalData(matterId: MatterId): KrModalData {
  *  bekräftelse (timkostnadsnorm), övriga (offentligt uppdrag) brottmåls-modalen. */
 function KostnadsrakningEntry({ matterId, matter, open, onClose, onRecorded }: KrTriggerProps) {
   if (matter.paymentMethod === "RATTSHJALP") {
-    return open ? <RattshjalpKrDialog matterId={matterId} onClose={onClose} onRecorded={onRecorded} /> : null;
+    return open ? <RattshjalpKrDialog matterId={matterId} matter={matter} onClose={onClose} onRecorded={onRecorded} /> : null;
   }
   return <KostnadsrakningTrigger matterId={matterId} matter={matter} open={open} onClose={onClose} onRecorded={onRecorded} />;
 }
@@ -462,11 +463,42 @@ function BillingSummary({ matterId }: { matterId: MatterId }) {
  * kostnadsräkningen, vilket fryser det upparbetade direkt; domen slutregleras
  * separat (klientens självrisk, statens del, ev. byrå-förlust).
  */
-function RattshjalpKrDialog({ matterId, onClose, onRecorded }: { matterId: MatterId; onClose: () => void; onRecorded: () => void }) {
+/** Samlar rättshjälps-KR:ns data + skapar billing-run:en OCH ett KR-dokument
+ *  (#828 steg 4). Utbrutet ur dialogen så den håller sig under complexity 8. */
+function useRattshjalpKr(matterId: MatterId, matter: MatterContext, onClose: () => void, onRecorded: () => void) {
   const proposal = trpc.billingRun.proposal.useQuery({ matterId });
+  const krData = useKrModalData(matterId);
+  const timeEntries = trpc.timeEntry.list.useQuery({ matterId, pageSize: 100 });
+  const register = trpc.document.register.useMutation();
+  const utils = trpc.useUtils();
   const create = trpc.billingRun.createKostnadsrakning.useMutation({
-    onSuccess: () => { onRecorded(); onClose(); },
+    onSuccess: async () => {
+      // KR-dokumentet är en presentation av det inskickade — misslyckas det
+      // ska billing-run:en ändå stå kvar (best-effort), så fånga felet.
+      try {
+        await generateKrDoc({
+          matterId, register, utils,
+          meta: {
+            matterNumber: matter.matterNumber, matterTitle: matter.title, defenderName: krData.defenderName,
+            ...omitUndefined({
+              clientName: clientOf(matter) || undefined, courtName: courtOf(matter),
+              defenderEmail: krData.defenderEmail, organizationName: krData.organizationName,
+              organizationOrgNumber: krData.organizationOrgNumber, organizationAddress: krData.organizationAddress,
+              radgivningPaid: matter.radgivningBetaldAt ? true : undefined,
+            }),
+          },
+          expenses: krData.expenses,
+          timeEntries: (timeEntries.data?.entries ?? []) as ReadonlyArray<{ id: string; date: string | Date; description: string; minutes: number; billable?: boolean }>,
+        });
+      } catch (e) { console.warn("[rättshjälp-kr] dokument misslyckades:", e); }
+      onRecorded(); onClose();
+    },
   });
+  return { proposal, create };
+}
+
+function RattshjalpKrDialog({ matterId, matter, onClose, onRecorded }: { matterId: MatterId; matter: MatterContext; onClose: () => void; onRecorded: () => void }) {
+  const { proposal, create } = useRattshjalpKr(matterId, matter, onClose, onRecorded);
   const d = proposal.data;
   const arvodeOre = d ? d.timeEntries.filter((t) => t.billable).reduce((s, t) => s + t.valueOre, 0) : 0;
   const utlaggOre = d ? d.expenses.filter((e) => e.billable).reduce((s, e) => s + e.amount, 0) : 0;

--- a/src/lib/client/kostnadsrakning/generate-kr-doc.ts
+++ b/src/lib/client/kostnadsrakning/generate-kr-doc.ts
@@ -1,0 +1,95 @@
+"use client";
+
+/**
+ * `generateKrDoc` (#828 steg 4) — generera ett kostnadsräknings-DOKUMENT (PDF)
+ * för rättshjälp och lägg det i ärendets fil-lista, parallellt med
+ * KOSTNADSRAKNING-billing-run:en.
+ *
+ * Rättshjälpens KR värderas på timkostnadsnormen (inte brottmålstaxan) →
+ * `isTaxeArende: false` i `buildKostnadsrakningContext` ger arvode =
+ * timkostnadsnorm × billable tid. Ingen huvudförhandling (hufStart = hufEnd).
+ *
+ * Använder `document.register` (inga events → ingen read-only-trap) precis som
+ * `generateFakturaDoc`, så det funkar i både demo- och git/server-backend.
+ */
+
+import { omitUndefined } from "@/lib/shared/omit-undefined";
+import { KOSTNADSRAKNING_DOCUMENT_TYPE } from "@/lib/shared/schemas/document";
+import { asId, type MatterId } from "@/lib/shared/schemas/ids";
+import type { DocUtils, RegisterMut } from "./generate-faktura-doc";
+
+export interface KrDocMeta {
+  matterNumber: string;
+  matterTitle: string;
+  clientName?: string;
+  courtName?: string;
+  defenderName: string;
+  defenderEmail?: string;
+  organizationName?: string;
+  organizationOrgNumber?: string;
+  organizationAddress?: string;
+  /** Rättshjälp: rådgivningstimmen betald separat → transparens-rad. */
+  radgivningPaid?: boolean;
+}
+
+export interface KrDocExpense {
+  id: string; date: string | Date; description: string;
+  amount: number; vatRate?: number; vatIncluded?: boolean; billable?: boolean;
+}
+export interface KrDocTimeEntry {
+  id: string; date: string | Date; description: string; minutes: number; billable?: boolean;
+}
+
+export interface GenerateKrDocArgs {
+  matterId: MatterId;
+  meta: KrDocMeta;
+  expenses: readonly KrDocExpense[];
+  timeEntries: readonly KrDocTimeEntry[];
+  register: RegisterMut;
+  utils: DocUtils;
+}
+
+export async function generateKrDoc(args: GenerateKrDocArgs): Promise<void> {
+  const { matterId, meta, expenses, timeEntries, register, utils } = args;
+  const { buildKostnadsrakningContext } = await import("@/lib/shared/kostnadsrakning");
+  const { renderKostnadsrakningPdf } = await import("@/lib/client/kostnadsrakning/render-pdf");
+  const { persistGeneratedDoc } = await import("@/lib/client/demo/persist-generated-doc");
+
+  const now = new Date();
+  const ctx = buildKostnadsrakningContext({
+    matter: { matterNumber: meta.matterNumber, title: meta.matterTitle, ...omitUndefined({ clientName: meta.clientName, radgivningPaid: meta.radgivningPaid }) },
+    defender: { name: meta.defenderName, ...omitUndefined({ email: meta.defenderEmail }) },
+    organization: omitUndefined({ name: meta.organizationName, orgNumber: meta.organizationOrgNumber, address: meta.organizationAddress }),
+    ...omitUndefined({ courtName: meta.courtName }),
+    // Ingen huvudförhandling i rättshjälps-KR:n — arvodet kommer ur tidsposterna.
+    hufStart: now, hufEnd: now,
+    isTaxeArende: false,
+    expenses,
+    timeEntries,
+  });
+
+  const bytes = await renderKostnadsrakningPdf({
+    result: ctx,
+    meta: {
+      matterNumber: meta.matterNumber, matterTitle: meta.matterTitle,
+      clientName: meta.clientName ?? "", courtName: meta.courtName ?? "",
+      defenderName: meta.defenderName,
+      ...omitUndefined({ organizationName: meta.organizationName, organizationOrgNumber: meta.organizationOrgNumber }),
+    },
+  });
+
+  const docId = `kostn-${matterId}-${now.getTime().toString(36)}`;
+  const fileName = `Kostnadsräkning ${meta.matterNumber} ${now.toISOString().slice(0, 10)}.pdf`;
+  const storagePath = `documents/content/${docId}.pdf`;
+  await register.mutateAsync({
+    id: asId<"DocumentId">(docId), matterId, fileName, mimeType: "application/pdf",
+    sizeBytes: bytes.byteLength, storagePath, documentType: KOSTNADSRAKNING_DOCUMENT_TYPE,
+    analysisStatus: "DONE",
+  });
+  await persistGeneratedDoc({ id: docId, storagePath, fileName, mimeType: "application/pdf", bytes });
+  try {
+    await utils.document.tree.invalidate({ matterId });
+    await utils.document.tree.refetch({ matterId });
+    await utils.document.list.invalidate();
+  } catch { /* best-effort */ }
+}

--- a/test/unit/app/matters/billing-panel.test.tsx
+++ b/test/unit/app/matters/billing-panel.test.tsx
@@ -55,7 +55,11 @@ vi.mock("@/lib/client/trpc", () => ({
     },
     user: { current: { useQuery: () => ({ data: { name: "Adv. Anna", email: "anna@byra.se" } }) } },
     expense: { list: { useQuery: () => ({ data: { expenses: [] } }) } },
-    document: { list: { useQuery: () => ({ data: documentListData }) } },
+    timeEntry: { list: { useQuery: () => ({ data: { entries: [] } }) } },
+    document: {
+      list: { useQuery: () => ({ data: documentListData }) },
+      register: { useMutation: () => ({ mutateAsync: vi.fn(async () => {}) }) },
+    },
     invoice: {
       list: { useQuery: () => ({ data: invoiceListData }) },
       createRadgivning: {

--- a/test/unit/lib/kostnadsrakning/generate-kr-doc.test.ts
+++ b/test/unit/lib/kostnadsrakning/generate-kr-doc.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Tester för generateKrDoc (#828 steg 4) — rättshjälpens KR-dokument:
+ * bygger en non-taxa-kontext (timkostnadsnorm), renderar PDF och registrerar
+ * ett document med documentType "Kostnadsräkning" så panelens doc-länk hittar det.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { generateKrDoc } from "@/lib/client/kostnadsrakning/generate-kr-doc";
+import { asId } from "@/lib/shared/schemas/ids";
+
+const renderKostnadsrakningPdf = vi.fn(async () => new Uint8Array([1, 2, 3, 4]));
+const persistGeneratedDoc = vi.fn(async () => {});
+
+vi.mock("@/lib/client/kostnadsrakning/render-pdf", () => ({ renderKostnadsrakningPdf }));
+vi.mock("@/lib/client/demo/persist-generated-doc", () => ({ persistGeneratedDoc }));
+
+const registerMutateAsync = vi.fn(async () => {});
+const utils = {
+  document: {
+    tree: { invalidate: vi.fn(async () => {}), refetch: vi.fn(async () => {}) },
+    list: { invalidate: vi.fn(async () => {}) },
+  },
+};
+
+const baseArgs = {
+  matterId: asId<"MatterId">("m1"),
+  meta: { matterNumber: "Ä-2026-1", matterTitle: "Vårdnadstvist", defenderName: "Anna Advokat", clientName: "Klient AB", courtName: "Stockholms TR" },
+  expenses: [{ id: "e1", date: "2026-03-01", description: "Ansökningsavgift", amount: 90000, billable: true }],
+  timeEntries: [{ id: "t1", date: "2026-03-01", description: "Möte", minutes: 120, billable: true }],
+  register: { mutateAsync: registerMutateAsync },
+  utils,
+};
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe("generateKrDoc", () => {
+  it("registrerar ett Kostnadsräkning-dokument + persisterar bytes:erna", async () => {
+    await generateKrDoc(baseArgs);
+    expect(renderKostnadsrakningPdf).toHaveBeenCalled();
+    expect(registerMutateAsync).toHaveBeenCalledWith(expect.objectContaining({
+      matterId: "m1", documentType: "Kostnadsräkning", mimeType: "application/pdf", sizeBytes: 4,
+    }));
+    const arg = registerMutateAsync.mock.calls[0]![0] as { fileName: string };
+    expect(arg.fileName).toMatch(/^Kostnadsräkning Ä-2026-1/);
+    expect(persistGeneratedDoc).toHaveBeenCalled();
+  });
+
+  it("dokument-registreringen får DONE-analysstatus (ingen AI-körning behövs)", async () => {
+    await generateKrDoc(baseArgs);
+    expect(registerMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ analysisStatus: "DONE" }));
+  });
+});


### PR DESCRIPTION
## Vad

Steg 4 i epic #828: **kostnadsräknings-dokument för rättshjälp + dokument-länk i panelen.**

När rättshjälps-KR:n skickas in (`RattshjalpKrDialog`) genereras nu ett kostnadsräknings-PDF parallellt med KOSTNADSRAKNING-billing-run:en och registreras som `documentType=Kostnadsräkning`. Panelens KR-kort (`findKrDocument` → doc-länk) hittar det automatiskt — tidigare fick bara offentligt uppdrag (`KostnadsrakningModal`) ett dokument, så rättshjälpsärenden visade KR-kortet utan länk.

- Ny `generateKrDoc`-helper (`src/lib/client/kostnadsrakning/generate-kr-doc.ts`) bygger en **non-taxa-kontext** (`isTaxeArende: false` → arvode = timkostnadsnorm × billable tid, ingen huvudförhandling), renderar PDF via befintlig `renderKostnadsrakningPdf` och registrerar via `document.register` (inga events → ingen read-only-trap; funkar i demo + git/server).
- `RattshjalpKrDialog` får matter-kontext + genererar dokumentet i `createKostnadsrakning.onSuccess` (best-effort: misslyckas dokumentet står billing-run:en kvar). Datainsamlingen utbruten till `useRattshjalpKr`-hook (complexity ≤8).
- Demo: `populateKostnadsrakningDocs` skapar redan ett KR-dokument per KR-run (alla betalningssätt), så demo-doc-länken för rättshjälp funkar.

## Verifierat lokalt (CI-spegel)

- `typecheck`, `lint --max-warnings 0`, `knip`, `deps:check`, `duplicates` — gröna
- `bun run test` — 3372 pass / 4 skip / 0 fail (+19 fil-isolerade); ny `generate-kr-doc.test.ts`
- `build:demo` — OK

Refs #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)