### PR TITLE
feat(demo): seeda KR-dokument i lokala server-first-stacken (steg 4)

### DIFF
--- a/tooling/demo-generator/populate-kostnadsrakning-docs.ts
+++ b/tooling/demo-generator/populate-kostnadsrakning-docs.ts
@@ -51,7 +51,11 @@ Datum: ${date.toLocaleDateString("sv-SE")}</p>
 </body></html>`;
 }
 
-export async function populateKostnadsrakningDocs(caller: GeneratorCaller, sink?: BinarySink): Promise<number> {
+/** Dokument-id för en KR-run. Default = läsbar `krdoc-<runId>` (in-memory demo +
+ *  GH Pages). Server-first (Postgres uuid-kolumn) skickar in en uuid-generator. */
+export type KrDocIdFn = (runId: string) => string;
+
+export async function populateKostnadsrakningDocs(caller: GeneratorCaller, sink?: BinarySink, idFor?: KrDocIdFn): Promise<number> {
   const c = caller as Any;
   const { runs } = await c.billingRun.list({});
   let count = 0;
@@ -59,7 +63,7 @@ export async function populateKostnadsrakningDocs(caller: GeneratorCaller, sink?
     if (summary.type !== "KOSTNADSRAKNING") continue;
     const run = await c.billingRun.byId({ id: summary.id });
     const html = renderKrHtml(run);
-    const id = `krdoc-${run.id}`;
+    const id = idFor ? idFor(run.id) : `krdoc-${run.id}`;
     const storagePath = `documents/content/${id}.html`;
     const bytes = new TextEncoder().encode(html);
     const size = sink ? sink(storagePath, bytes) : bytes.byteLength;

--- a/tooling/scripts/seed-demo-into-server.ts
+++ b/tooling/scripts/seed-demo-into-server.ts
@@ -37,6 +37,7 @@ import { createIdTranslator, translateSeed } from "../demo-generator/id-translat
 import { populate } from "../demo-generator/populate";
 import { populateBilling } from "../demo-generator/populate-billing";
 import { populateDocuments } from "../demo-generator/populate-documents";
+import { populateKostnadsrakningDocs } from "../demo-generator/populate-kostnadsrakning-docs";
 import { populateUnbilledTime } from "../demo-generator/populate-unbilled-time";
 import { buildSeed } from "./seed-data";
 
@@ -107,18 +108,32 @@ async function addTodayTimeEntries(repos: Repositories, timeEntries: Row[], matt
  * (icke-uuid-id:n `invdoc-/kr-/gendoc-` + faktura-scopade — uppföljning likt
  * #647). No-op utan CONTENT_DIR (bytes har då ingenstans att ta vägen).
  */
-async function seedDocuments(
-  caller: Parameters<typeof populateDocuments>[0],
-  seed: Parameters<typeof populateDocuments>[1],
-): Promise<number> {
-  if (!CONTENT_DIR) return 0;
+/** Bytes-sink mot den bind-mountade content-katalogen (#649), eller null när
+ *  ingen CONTENT_DIR är satt (då har bytes ingenstans att ta vägen). */
+function contentSink(): ((storagePath: string, bytes: Uint8Array) => number) | null {
+  if (!CONTENT_DIR) return null;
   const dir = CONTENT_DIR;
-  const sink = (storagePath: string, bytes: Uint8Array): number => {
+  return (storagePath: string, bytes: Uint8Array): number => {
     const abs = join(dir, storagePath);
     mkdirSync(dirname(abs), { recursive: true });
     writeFileSync(abs, bytes);
     return bytes.byteLength;
   };
+}
+
+/** KR-dokument per KOSTNADSRAKNING-run (#828) — speglar build:demo så panelens
+ *  doc-länk finns på förseedade KR-körningar (annars saknar de dokument lokalt). */
+async function seedKostnadsrakningDocs(caller: Parameters<typeof populateKostnadsrakningDocs>[0]): Promise<number> {
+  // Postgres documents.id är uuid → generera uuid (default `krdoc-<id>` är ej uuid).
+  return populateKostnadsrakningDocs(caller, contentSink() ?? undefined, () => uuidv7());
+}
+
+async function seedDocuments(
+  caller: Parameters<typeof populateDocuments>[0],
+  seed: Parameters<typeof populateDocuments>[1],
+): Promise<number> {
+  const sink = contentSink();
+  if (!sink) return 0;
   return populateDocuments(caller, seed, sink);
 }
 
@@ -161,7 +176,8 @@ async function main(): Promise<void> {
     const unbilled = await populateUnbilledTime(caller, seed);
 
     const documents = await seedDocuments(caller, seed);
-    console.log("✓ demo-data seedad i server-first (org", ORG, "):", { ...core, billing, unbilled, documents });
+    const kostnadsrakningDocs = await seedKostnadsrakningDocs(caller);
+    console.log("✓ demo-data seedad i server-first (org", ORG, "):", { ...core, billing, unbilled, documents, kostnadsrakningDocs });
     console.log(`  login: ${LOGIN_LAWYER_EMAIL} + ${LOGIN_ADMIN_EMAIL} äger nu data (+ idag-tidpost)`);
     console.log(CONTENT_DIR ? `  dokument-bytes → ${CONTENT_DIR}` : "  (dokument hoppade — sätt AVA_CONTENT_HOST_DIR)");
   } finally {


### PR DESCRIPTION
## Vad

Komplement till #837: den lokala **server-first**-seeden (`seed-demo-into-server.ts`) hoppade genererade dokument, så förseedade KOSTNADSRAKNING-körningar saknade dokument-länk i panelens KR-kort lokalt (till skillnad från GH Pages-demon som seedar dem via `build:demo`).

- Seeden kör nu `populateKostnadsrakningDocs` → ett KR-dokument per KR-run.
- Postgres `documents.id` är en uuid-kolumn (`krdoc-<runId>` är inte giltig uuid → insert failar). `populateKostnadsrakningDocs` fick därför en valfri `idFor`-parameter; server-seeden skickar in en `uuidv7()`-generator medan in-memory-demon/`build:demo` behåller den läsbara `krdoc-<id>`-defaulten.
- Bytes skrivs till den bind-mountade content-katalogen (samma sink som övriga seed-dokument) så serverns GitContentStore kan servera dem.

## Verifierat

- `typecheck`, `lint --max-warnings 0`, `knip`, `deps:check`, `duplicates` — gröna
- `bun run test` — 3370 + 19 pass / 0 fail
- `build:demo` — OK (oförändrat: 4 kostnadsräkning-dokument)
- **Live**: `selfhosted-local.sh --down && --demo` → `kostnadsrakningDocs: 4`, 4 uuid-namngivna HTML-filer i content-katalogen, web nås på :8080

Refs #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)