### PR TITLE
fix(billing): rättshjälp värderas på timkostnadsnormen (F-skatt) hela vägen

### DIFF
--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -427,17 +427,17 @@ function RadgivningBanner({ matterId, matter, onRecorded }: { matterId: MatterId
   const fired = useRef(false);
   const isRattshjalp = matter.paymentMethod === "RATTSHJALP";
   const registered = !!matter.radgivningBetaldAt;
-  const hasFTaxArg = omitUndefined({ hasFTax: matter.taxaHasFTax ?? undefined });
   useEffect(() => {
     // Auto-skapa en gång när den saknas (#839): rådgivningstimmen är obligatorisk
-    // i rättshjälp, så användaren ska inte behöva trycka på en knapp.
+    // i rättshjälp, så användaren ska inte behöva trycka på en knapp. Alltid
+    // F-skatt-normen (alla advokater har F-skatt) → ingen hasFTax skickas.
     if (!isRattshjalp || registered || fired.current || create.isPending) return;
     fired.current = true;
-    create.mutate({ matterId, ...hasFTaxArg });
+    create.mutate({ matterId });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isRattshjalp, registered, matterId]);
   if (!isRattshjalp) return null;
-  const avgift = computeRadgivningsavgift(hasFTaxArg);
+  const avgift = computeRadgivningsavgift();
   return (
     <div className="mx-6 mb-4 rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 flex items-center justify-between gap-3">
       <div className="text-xs text-blue-900">

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -19,7 +19,7 @@ import { z } from "zod";
 import type { VatBreakdownLine } from "@/lib/shared/accounting/semantic-voucher";
 import { assertBillingTransition, type BillingActionType } from "@/lib/shared/billing-flow";
 import { proposedAccontoOre } from "@/lib/shared/billing-proposal";
-import { TIMKOSTNADSNORM_FTAX_ORE_PER_H, TIMKOSTNADSNORM_NO_FTAX_ORE_PER_H } from "@/lib/shared/brottmalstaxa";
+import { TIMKOSTNADSNORM_FTAX_ORE_PER_H } from "@/lib/shared/brottmalstaxa";
 import { computeCoverageSplit, partitionRattsskyddMinutes, type CoverageSplit } from "@/lib/shared/coverage-billing";
 import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
 import { applyKrAction, type KostnadsrakningAction, type KostnadsrakningState, type KostnadsrakningStatus } from "@/lib/shared/kostnadsrakning-flow";
@@ -223,6 +223,19 @@ function invoiceGrossOre(work: UnfrozenWork): number {
   return arvodeInclVatOre(arvodeNetOre(work)) + expenseGrossOre(work);
 }
 
+/**
+ * Rättshjälpens KR-anspråk till domstol, brutto (#839): arbetet värderas på
+ * TIMKOSTNADSNORMEN (inte byråns privata timtaxor — staten ersätter bara normen)
+ * och rådgivningstimmen exkluderas (faktureras klienten separat). Utlägg ersätts
+ * brutto. Speglar settlement-revärderingen (currentArvodeRateOre × coverageBaseMinutes).
+ */
+function rattshjalpKrGrossOre(work: UnfrozenWork, rateOrePerH: number): number {
+  const billableMin = work.timeEntries.filter((t) => t.billable).reduce((s, t) => s + t.minutes, 0);
+  const claimMin = coverageBaseMinutes("RATTSHJALP", billableMin);
+  const arvodeNet = Math.round((claimMin / 60) * rateOrePerH);
+  return arvodeInclVatOre(arvodeNet) + expenseGrossOre(work);
+}
+
 /** Fakturans exakta momsbelopp (öre) per sats: arvodets moms (25 %) +
  *  varje utläggs moms (dess sats). Lagras på fakturan för korrekt bokföring (#782). */
 function invoiceVatOre(work: UnfrozenWork): number {
@@ -278,7 +291,9 @@ async function currentArvodeRateOre(
   matter: { paymentMethod: string; taxaHasFTax?: boolean | null | undefined; responsibleLawyerId?: UserId | null | undefined },
 ): Promise<number> {
   if (matter.paymentMethod === "RATTSHJALP") {
-    return matter.taxaHasFTax === false ? TIMKOSTNADSNORM_NO_FTAX_ORE_PER_H : TIMKOSTNADSNORM_FTAX_ORE_PER_H;
+    // Alla advokater har F-skatt (#839) → alltid F-skatt-normen, oberoende av
+    // matter.taxaHasFTax (ett brottmåls-taxefält som är meningslöst här).
+    return TIMKOSTNADSNORM_FTAX_ORE_PER_H;
   }
   if (!matter.responsibleLawyerId) return 0;
   const lawyer = await repos.users.getByIdInOrg(matter.responsibleLawyerId, orgId);
@@ -592,8 +607,14 @@ export const billingRunRouter = router({
       return ctx.repos.transaction(async (tx) => {
         await assertFlowAction(tx, ctx.orgId, input.matterId, "KOSTNADSRAKNING");
         const work = await fetchUnfrozenWork(tx, input.matterId);
-        // Brutto = arvode inkl. 25 % moms + utlägg (#782) — matchar kostnadsräkningens PDF.
-        const grossValue = invoiceGrossOre(work);
+        const matter = await tx.matters.getByIdInOrg(input.matterId, ctx.orgId);
+        if (!matter) throw new TRPCError({ code: "NOT_FOUND", message: "Ärendet finns inte." });
+        // Rättshjälp värderas på timkostnadsnormen (#839) — staten ersätter inte
+        // byråns privata timtaxa. Övriga (offentligt uppdrag/taxa): arvode inkl moms
+        // + utlägg som tidigare. Brutto matchar kostnadsräkningens PDF (#782).
+        const grossValue = matter.paymentMethod === "RATTSHJALP"
+          ? rattshjalpKrGrossOre(work, await currentArvodeRateOre(tx, ctx.orgId, matter))
+          : invoiceGrossOre(work);
         const run = await tx.billingRuns.create({
           matterId: input.matterId, type: "KOSTNADSRAKNING", recipient: "DOMSTOL",
           status: "PENDING_VERDICT", kostnadsrakningStatus: "INSKICKAD", workValueOreAtRun: grossValue,

--- a/test/unit/app/matters/billing-panel.test.tsx
+++ b/test/unit/app/matters/billing-panel.test.tsx
@@ -8,7 +8,7 @@
  * dialogerna stubbas (de har egna tester) så panelens egen logik isoleras.
  */
 
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
 import { BillingPanel } from "@/app/matters/[id]/_billing-panel";
 import { asId } from "@/lib/shared/schemas/ids";
@@ -80,6 +80,8 @@ vi.mock("@/lib/client/demo/generated-doc-cache", () => ({
   hasGeneratedDoc: () => hasDoc,
   openGeneratedDoc: (id: string) => openGeneratedDocFn(id),
 }));
+const openDocumentFn = vi.fn(async () => "opened-blob" as const);
+vi.mock("@/lib/client/firma/open-document", () => ({ openDocument: openDocumentFn }));
 vi.mock("@/app/matters/[id]/_billing-dialog", () => ({
   BillingDialog: ({ type }: { type: string }) => <div data-testid="billing-dialog">{type}</div>,
 }));
@@ -192,13 +194,14 @@ describe("BillingPanel — kostnadsräknings-kort (#828)", () => {
     expect(openGeneratedDocFn).toHaveBeenCalledWith("doc-1");
   });
 
-  it("seedat/server-dokument (ej i blob-cachen) → går server-vägen, inte blob-cachen (#839)", () => {
+  it("seedat/server-dokument (ej i blob-cachen) → går server-vägen, inte blob-cachen (#839)", async () => {
     documentListData = { documents: [{ id: "doc-1", fileName: "kostnadsrakning.docx", documentType: "Kostnadsräkning", storagePath: "documents/content/doc-1.html", createdAt: "2026-03-01" }] };
     hasDoc = false;
     render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={verdictMatter} />);
     fireEvent.click(screen.getByRole("button", { name: "kostnadsrakning.docx" }));
-    // Faller inte tillbaka på blob-cachen → öppnas via openDocument/downloadContent.
+    // Faller inte tillbaka på blob-cachen → öppnas via openDocument (downloadContent).
     expect(openGeneratedDocFn).not.toHaveBeenCalled();
+    await waitFor(() => expect(openDocumentFn).toHaveBeenCalled());
   });
 });
 

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -218,6 +218,15 @@ describe("billingRun.createKostnadsrakning", () => {
     expect(te.frozenAt).toBeTruthy();
     expect(te.frozenByBillingRunId).toBe(res.run.id);
   });
+
+  it("rättshjälp värderas på timkostnadsnormen (F-skatt) minus rådgivningstimmen (#839)", async () => {
+    // 120 min billable, INTE byråns 2500 kr/h: rättshjälp → timkostnadsnorm 1626 kr/h.
+    // Rådgivningstimmen (60 min) exkluderas → 60 min kvar = 1 h × 162600 = 162600 netto,
+    // + 25 % moms = 203250 brutto (inga utlägg). Byråns privata taxa ignoreras.
+    const { caller } = makeCaller({ workMinutes: 120, paymentMethod: "RATTSHJALP" });
+    const res = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
+    expect(res.run.workValueOreAtRun).toBe(203250);
+  });
 });
 
 describe("billingRun.setVerdict", () => {


### PR DESCRIPTION
Uppföljning på #839 från lokal testning av "Umgängestvist Carlsson": beloppen var osammanhängande för att ärendet blandade **byråns privata timtaxor** (på tidsposterna) med **timkostnadsnormen** (settlement-revärderingen).

| Vy | Tidigare basis | Belopp |
|---|---|---|
| KR "Dömt belopp" | privata timtaxor | 10835 |
| Settlement "Upparbetat" | timkostnadsnorm utan F-skatt (1237/h) − rådgivning | 4020 |
| Rådgivning (UI vs faktura) | utan vs med F-skatt | 1237 / 1626 |

Rättshjälp ersätts bara enligt **timkostnadsnormen**, så nu värderas allt på samma basis (beslut bekräftat med användaren: timkostnadsnorm + alltid F-skatt 1626 kr/h):

- `createKostnadsrakning` värderar rättshjälpens KR-anspråk på `timkostnadsnorm × (billable − rådgivningstimmen)` i st.f. de loggade taxorna (ny `rattshjalpKrGrossOre`). Övriga betalningssätt (offentligt uppdrag/taxa) oförändrade.
- `currentArvodeRateOre` använder alltid F-skatt-normen för rättshjälp — `matter.taxaHasFTax` (ett brottmåls-taxefält) ignoreras.
- Rådgivningsbanderollen räknar/auto-skapar alltid på F-skatt-normen → UI och faktura visar nu samma belopp (1626).

Nu sammanfaller rådgivning (1626), KR-anspråk och settlement på samma timkostnadsnorm-basis.

## Verifierat (CI-spegel)
- `typecheck`, `lint --max-warnings 0`, `knip`, `deps:check`, `duplicates` — gröna
- `bun run test` — 3373 + 19 pass / 0 fail (ny test: rättshjälp-KR = 203250 vid 120 min)
- `build:demo` — OK

Refs #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)