### PR TITLE
fix(billing): settlement inkl moms + rådgivningsbanner länkar till fakturan

### DIFF
--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -28,7 +28,7 @@ import { availableActions, currentPhase, type BillingAction, type BillingPhase, 
 import { availableKrActions, KOSTNADSRAKNING_STATUS_LABELS, type KostnadsrakningState, type KostnadsrakningStatus } from "@/lib/shared/kostnadsrakning-flow";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { computeRadgivningsavgift } from "@/lib/shared/rattshjalp";
-import { BILLING_RUN_TYPE_LABELS, BILLING_RUN_STATUS_LABELS, type BillingRunRecipient, type BillingRunStatus, type BillingRunType, type PaymentMethod } from "@/lib/shared/schemas/enums";
+import { BILLING_RUN_TYPE_LABELS, BILLING_RUN_STATUS_LABELS, INVOICE_STATUS_LABELS, type BillingRunRecipient, type BillingRunStatus, type BillingRunType, type InvoiceStatus, type PaymentMethod } from "@/lib/shared/schemas/enums";
 import type { BillingRunId, DocumentId, InvoiceId, MatterId } from "@/lib/shared/schemas/ids";
 import { BillingDialog, type BillingMeta } from "./_billing-dialog";
 import { KostnadsrakningModal } from "./_kostnadsrakning-modal";
@@ -427,6 +427,9 @@ function RadgivningBanner({ matterId, matter, onRecorded }: { matterId: MatterId
   const fired = useRef(false);
   const isRattshjalp = matter.paymentMethod === "RATTSHJALP";
   const registered = !!matter.radgivningBetaldAt;
+  // Rådgivnings-fakturan är den enda STANDARD-fakturan på ärendet → hämta den
+  // för status + länk (den skapas som utkast, inte "fakturerad" automatiskt).
+  const radgivningInv = trpc.invoice.list.useQuery({ matterId, invoiceType: "STANDARD" }).data?.[0];
   useEffect(() => {
     // Auto-skapa en gång när den saknas (#839): rådgivningstimmen är obligatorisk
     // i rättshjälp, så användaren ska inte behöva trycka på en knapp. Alltid
@@ -444,13 +447,28 @@ function RadgivningBanner({ matterId, matter, onRecorded }: { matterId: MatterId
         <strong>Rådgivningstimme (rättshjälp)</strong> — klientens 1 tim enligt rättshjälpstaxan,{" "}
         <span className="font-mono">{formatCurrency(avgift.beloppExclVatOre)}</span> exkl moms, faktureras separat till klienten.
       </div>
-      {registered ? (
-        <span className="text-xs text-green-700 whitespace-nowrap">✓ Fakturerad</span>
-      ) : (
-        <span className="text-xs text-blue-700 whitespace-nowrap">{create.error ? "Kunde inte skapas" : "Skapas automatiskt…"}</span>
-      )}
+      <RadgivningStatus invoice={radgivningInv} pending={create.isPending} failed={!!create.error} />
     </div>
   );
+}
+
+/** Rådgivnings-fakturans status + länk (#841). Skapas som utkast → visa rätt
+ *  status (inte "fakturerad") och länka till fakturan så den går att granska/skicka. */
+function RadgivningStatus({ invoice, pending, failed }: {
+  invoice?: { id: InvoiceId; invoiceNumber?: string | null | undefined; status: InvoiceStatus } | undefined;
+  pending: boolean; failed: boolean;
+}) {
+  if (invoice) {
+    return (
+      <span className="text-xs whitespace-nowrap">
+        <EntityLink route="invoices" id={invoice.id} className="text-blue-700 hover:underline">
+          {invoice.invoiceNumber ?? "Faktura"}
+        </EntityLink>{" "}
+        <span className="text-gray-500">({INVOICE_STATUS_LABELS[invoice.status]})</span>
+      </span>
+    );
+  }
+  return <span className="text-xs text-blue-700 whitespace-nowrap">{failed ? "Kunde inte skapas" : pending ? "Skapas…" : "Skapas automatiskt…"}</span>;
 }
 
 /**

--- a/src/app/matters/[id]/_settlement-dialog.tsx
+++ b/src/app/matters/[id]/_settlement-dialog.tsx
@@ -14,8 +14,8 @@
 import { useState } from "react";
 import { DecimalInput } from "@/components/ui/decimal-input";
 import { Modal } from "@/components/ui/modal";
+import { Money } from "@/components/ui/money";
 import { trpc } from "@/lib/client/trpc";
-import { formatCurrency } from "@/lib/client/utils";
 import type { PaymentMethod } from "@/lib/shared/schemas/enums";
 import type { MatterId } from "@/lib/shared/schemas/ids";
 
@@ -33,12 +33,14 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 function Row({ label, ore, dim }: { label: string; ore: number; dim?: boolean }) {
   return (
     <div className={`flex justify-between text-sm ${dim ? "text-amber-700" : "text-gray-700"}`}>
-      <span>{label}</span><span className="font-mono">{formatCurrency(ore)}</span>
+      {/* Beloppen lagras netto (exkl moms); <Money basis="net"> visar dem på samma
+          momsbasis som resten av panelen och följer den globala incl/excl-växlingen (#841). */}
+      <span>{label}</span><Money ore={ore} basis="net" className="font-mono" />
     </div>
   );
 }
 
-/** Förhandsvisning av uppdelningen (netto, exkl moms). */
+/** Förhandsvisning av uppdelningen — följer den globala momsväxlingen (#841). */
 function SplitPreview({ data, payerLabel }: { data: SplitData; payerLabel: string }) {
   return (
     <div className="rounded border border-gray-200 bg-gray-50 px-3 py-2 space-y-1">
@@ -46,7 +48,7 @@ function SplitPreview({ data, payerLabel }: { data: SplitData; payerLabel: strin
       <Row label="Klientens del" ore={data.clientOre} />
       <Row label={payerLabel} ore={data.payerOre} />
       {data.firmLossOre > 0 && <Row label="Byrån bär (prutning)" ore={data.firmLossOre} dim />}
-      <p className="text-[11px] text-gray-400 pt-1">Belopp exkl. moms — moms läggs på fakturorna.</p>
+      <p className="text-[11px] text-gray-400 pt-1">Klicka på ett belopp för att växla inkl./exkl. moms.</p>
     </div>
   );
 }

--- a/test/unit/app/matters/billing-panel.test.tsx
+++ b/test/unit/app/matters/billing-panel.test.tsx
@@ -24,7 +24,7 @@ let runsData: { runs: BillingRunRow[] } = { runs: [] };
 let runsLoading = false;
 interface ProposalData { workValueOre: number; priorAccontoSumOre: number; timeEntries: Array<{ id: string; description: string; minutes: number; hourlyRate: number; billable: boolean; valueOre: number }>; expenses: Array<{ id: string; description: string; amount: number; billable: boolean }> }
 let proposalData: ProposalData = { workValueOre: 0, priorAccontoSumOre: 0, timeEntries: [], expenses: [] };
-interface InvoiceRow { id: string; amount: number; status: string; payments: Array<{ amount: number }> }
+interface InvoiceRow { id: string; amount: number; status: string; payments: Array<{ amount: number }>; invoiceNumber?: string }
 let invoiceListData: InvoiceRow[] = [];
 const refetch = vi.fn();
 const radgivningMutate = vi.fn();
@@ -254,9 +254,12 @@ describe("BillingPanel — rådgivnings-banner (rättshjälp)", () => {
     expect(radgivningMutate).toHaveBeenCalledWith(expect.objectContaining({ matterId: "m1" }));
   });
 
-  it("RATTSHJALP med registrerad rådgivning → visar bock, auto-skapar inte", () => {
+  it("RATTSHJALP med registrerad rådgivning → länk till fakturan + status, auto-skapar inte (#841)", () => {
+    invoiceListData = [{ id: "inv-rad", invoiceNumber: "F-2026-0012", status: "DRAFT", amount: 162600, payments: [] }];
     render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={{ ...baseMatter, paymentMethod: "RATTSHJALP", radgivningBetaldAt: "2026-01-05" }} />);
-    expect(screen.getByText(/Fakturerad/)).toBeInTheDocument();
+    // Inte "Fakturerad" — fakturan är ett utkast; visa numret + faktisk status + länk.
+    expect(screen.getByText("F-2026-0012")).toBeInTheDocument();
+    expect(screen.getByText(/Utkast/)).toBeInTheDocument();
     expect(radgivningMutate).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Två fynd från lokal testning.

## 1. Settlement-dialogen konsekvent inkl moms
`SettlementDialog` visade split-beloppen hårdkodat exkl moms (`formatCurrency`), medan panelens kort visar inkl moms (global växling). Nu renderas beloppen via `<Money basis="net">` → följer den globala incl/excl-växlingen (default inkl), konsekvent med resten av panelen. Klick på ett belopp växlar.

## 2. Rådgivningsbanderollen: korrekt status + länk
Banderollen påstod "✓ Fakturerad" trots att rådgivningsfakturan skapas som **utkast** (DRAFT). Nu visar den fakturanumret + **faktisk status** (Utkast/Skickad/Betald) som en **länk till fakturan**, så den går att granska och skicka. Hämtas som ärendets enda STANDARD-faktura.

## Verifierat (CI-spegel)
- `typecheck`, `lint --max-warnings 0`, `knip`, `deps:check`, `duplicates` — gröna
- `bun run test` — 3373 + 19 pass / 0 fail
- `build:demo` — OK

Refs #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)