### PR TITLE
feat(billing): länka KR-raden till kostnadsräkningen + seeda fakturadokument

### DIFF
--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -72,14 +72,11 @@ interface KrDocInfo { id: DocumentId; fileName: string; storagePath: string | nu
 
 type DocumentListOutput = inferRouterOutputs<AppRouter>["document"]["list"];
 
-function findKrDocument(matterId: MatterId, run: BillingRunRow): KrDocInfo | null {
-  const docs: DocumentListOutput | undefined = trpc.document.list.useQuery({ matterId, folderId: null, pageSize: 100 }).data;
-  const list = docs?.documents ?? [];
+/** Väljer KR-dokumentet närmast en körning i tid (pure — ingen hook, så den kan
+ *  anropas per rad i listan). Vanligtvis 1 KR-dokument per ärende i MVP. */
+function pickKrDoc(list: DocumentListOutput["documents"], run: BillingRunRow): KrDocInfo | null {
   const kostn = list.filter((d) => d.documentType === "Kostnadsräkning");
   if (kostn.length === 0) return null;
-  // Senaste KR-dokumentet skapat innan/samtidigt med billing-run:n —
-  // räcker för MVP (vanligtvis 1 pending KR per matter). Vid framtida
-  // refactor: lagra documentId direkt på BillingRun-row.
   const runTs = new Date(run.createdAt).getTime();
   const sorted = [...kostn].sort((a, b) => {
     const at = a.createdAt ? new Date(a.createdAt).getTime() : 0;
@@ -88,6 +85,11 @@ function findKrDocument(matterId: MatterId, run: BillingRunRow): KrDocInfo | nul
   });
   const d = sorted[0];
   return d ? { id: d.id, fileName: d.fileName, storagePath: d.storagePath ?? null } : null;
+}
+
+function findKrDocument(matterId: MatterId, run: BillingRunRow): KrDocInfo | null {
+  const docs: DocumentListOutput | undefined = trpc.document.list.useQuery({ matterId, folderId: null, pageSize: 100 }).data;
+  return pickKrDoc(docs?.documents ?? [], run);
 }
 
 /**
@@ -400,7 +402,7 @@ export function BillingPanel({ matterId, matter }: Props) {
         onOverklaga={() => appeal.mutate({ billingRunId: activeKr.id })}
         onSkapaFaktura={() => matter.paymentMethod === "RATTSHJALP" ? setShowSettle(true) : setVerdictRunId(activeKr.id)} />}
       {beslutRunId && <RecordBeslutDialog billingRunId={beslutRunId} onClose={() => setBeslutRunId(null)} onDone={refetch} />}
-      <RunsList rows={rows} loading={runs.isLoading} />
+      <RunsList matterId={matterId} rows={rows} loading={runs.isLoading} />
       <BillingDialogs matterId={matterId} matter={matter} rows={rows}
         dialog={dialog} setDialog={setDialog}
         verdictRunId={verdictRunId} setVerdictRunId={setVerdictRunId}
@@ -620,7 +622,11 @@ function BillingActions({ actions, onPick }: { actions: readonly BillingAction[]
   );
 }
 
-function RunsList({ rows, loading }: { rows: BillingRunRow[]; loading: boolean }) {
+function RunsList({ matterId, rows, loading }: { matterId: MatterId; rows: BillingRunRow[]; loading: boolean }) {
+  // Dokumentlistan hämtas en gång → KOSTNADSRAKNING-raden kan länka till sitt
+  // KR-dokument (#843). utils.client krävs för openKrDoc:s server-hämtning.
+  const docs = trpc.document.list.useQuery({ matterId, folderId: null, pageSize: 100 }).data?.documents ?? [];
+  const utils = trpc.useUtils();
   if (loading) return <p className="px-6 py-3 text-sm text-gray-500">Laddar…</p>;
   if (rows.length === 0) return <p className="px-6 py-3 text-sm text-gray-500">Inga billing-runs ännu.</p>;
   return (
@@ -630,13 +636,19 @@ function RunsList({ rows, loading }: { rows: BillingRunRow[]; loading: boolean }
           <tr><th className="text-left py-1">Typ</th><th className="text-left">Mottagare</th><th className="text-left">Status</th><th className="text-right">Belopp</th><th></th></tr>
         </thead>
         <tbody className="divide-y divide-gray-100">
-          {rows.map((r) => (
+          {rows.map((r) => {
+            const krDoc = r.type === "KOSTNADSRAKNING" ? pickKrDoc(docs, r) : null;
+            return (
             <tr key={r.id}>
               <td className="py-2 text-sm">{BILLING_RUN_TYPE_LABELS[r.type as keyof typeof BILLING_RUN_TYPE_LABELS] ?? r.type}</td>
               <td className="text-sm text-gray-600">{r.recipient}</td>
               <td className="text-sm">{BILLING_RUN_STATUS_LABELS[r.status as keyof typeof BILLING_RUN_STATUS_LABELS] ?? r.status}</td>
               <td className="text-right text-sm font-mono"><Money ore={r.amountOre} basis="gross" /></td>
-              <td className="text-right">
+              <td className="text-right space-x-2 whitespace-nowrap">
+                {krDoc && (
+                  <button type="button" onClick={() => void openKrDoc(krDoc, utils.client)}
+                    className="text-xs text-blue-600 hover:underline">Kostnadsräkning</button>
+                )}
                 {r.invoiceId && (
                   // EntityLink (inte Next-Link) — runtime-skapade UUIDs finns
                   // inte i generateStaticParams. Nuvarande 404.html är en
@@ -650,7 +662,8 @@ function RunsList({ rows, loading }: { rows: BillingRunRow[]; loading: boolean }
                 )}
               </td>
             </tr>
-          ))}
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/test/unit/app/matters/billing-panel.test.tsx
+++ b/test/unit/app/matters/billing-panel.test.tsx
@@ -203,6 +203,16 @@ describe("BillingPanel — kostnadsräknings-kort (#828)", () => {
     expect(openGeneratedDocFn).not.toHaveBeenCalled();
     await waitFor(() => expect(openDocumentFn).toHaveBeenCalled());
   });
+
+  it("KOSTNADSRAKNING-raden i runs-listan länkar till KR-dokumentet (#843)", async () => {
+    // FAKTURERAD → inget aktivt KR-kort; länken ska finnas på själva raden.
+    runsData = { runs: [{ id: "r9", type: "KOSTNADSRAKNING", status: "SENT", kostnadsrakningStatus: "FAKTURERAD", recipient: "DOMSTOL", amountOre: 50_000, createdAt: "2026-03-01" }] };
+    documentListData = { documents: [{ id: "doc-9", fileName: "kostnadsrakning.docx", documentType: "Kostnadsräkning", storagePath: "documents/content/doc-9.html", createdAt: "2026-03-01" }] };
+    hasDoc = false;
+    render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={verdictMatter} />);
+    fireEvent.click(screen.getByRole("button", { name: "Kostnadsräkning" }));
+    await waitFor(() => expect(openDocumentFn).toHaveBeenCalled());
+  });
 });
 
 describe("BillingPanel — Skapa-faktura-menyn (flödesmodellen)", () => {

--- a/tooling/demo-generator/populate-invoice-docs.ts
+++ b/tooling/demo-generator/populate-invoice-docs.ts
@@ -48,15 +48,23 @@ Datum: ${new Date(inv.invoiceDate).toLocaleDateString("sv-SE")}</p>
 </table></body></html>`;
 }
 
-export async function populateInvoiceDocs(caller: GeneratorCaller, sink?: BinarySink): Promise<number> {
+/** Dokument-id för en faktura. Default = läsbar `invdoc-<id>` (in-memory demo +
+ *  GH Pages). Server-first (Postgres uuid-kolumn) skickar in en uuid-generator. */
+export type InvoiceDocIdFn = (invoiceId: string) => string;
+
+/** Fakturatyper som får ett genererat dokument: slutfakturor + rådgivnings-
+ *  fakturan (STANDARD) så den syns i ärendets dokumentlista (#843). */
+const DOC_INVOICE_TYPES = new Set(["FINAL", "STANDARD"]);
+
+export async function populateInvoiceDocs(caller: GeneratorCaller, sink?: BinarySink, idFor?: InvoiceDocIdFn): Promise<number> {
   const c = caller as Any;
   const invoices: Any[] = await c.invoice.list({});
   let count = 0;
   for (const summary of invoices) {
-    if (summary.invoiceType !== "FINAL") continue;
+    if (!DOC_INVOICE_TYPES.has(summary.invoiceType)) continue;
     const inv = await c.invoice.getById({ id: summary.id });
     const html = renderInvoiceHtml(inv);
-    const id = `invdoc-${inv.id}`;
+    const id = idFor ? idFor(inv.id) : `invdoc-${inv.id}`;
     const storagePath = `documents/content/${id}.html`;
     const bytes = new TextEncoder().encode(html);
     const size = sink ? sink(storagePath, bytes) : bytes.byteLength;

--- a/tooling/scripts/seed-demo-into-server.ts
+++ b/tooling/scripts/seed-demo-into-server.ts
@@ -37,6 +37,7 @@ import { createIdTranslator, translateSeed } from "../demo-generator/id-translat
 import { populate } from "../demo-generator/populate";
 import { populateBilling } from "../demo-generator/populate-billing";
 import { populateDocuments } from "../demo-generator/populate-documents";
+import { populateInvoiceDocs } from "../demo-generator/populate-invoice-docs";
 import { populateKostnadsrakningDocs } from "../demo-generator/populate-kostnadsrakning-docs";
 import { populateUnbilledTime } from "../demo-generator/populate-unbilled-time";
 import { buildSeed } from "./seed-data";
@@ -128,6 +129,12 @@ async function seedKostnadsrakningDocs(caller: Parameters<typeof populateKostnad
   return populateKostnadsrakningDocs(caller, contentSink() ?? undefined, () => uuidv7());
 }
 
+/** Faktura-dokument per slutfaktura + rådgivningsfaktura (#843) → de syns i
+ *  ärendets dokumentlista lokalt. uuid-id (default `invdoc-<id>` är ej uuid). */
+async function seedInvoiceDocs(caller: Parameters<typeof populateInvoiceDocs>[0]): Promise<number> {
+  return populateInvoiceDocs(caller, contentSink() ?? undefined, () => uuidv7());
+}
+
 async function seedDocuments(
   caller: Parameters<typeof populateDocuments>[0],
   seed: Parameters<typeof populateDocuments>[1],
@@ -177,7 +184,8 @@ async function main(): Promise<void> {
 
     const documents = await seedDocuments(caller, seed);
     const kostnadsrakningDocs = await seedKostnadsrakningDocs(caller);
-    console.log("✓ demo-data seedad i server-first (org", ORG, "):", { ...core, billing, unbilled, documents, kostnadsrakningDocs });
+    const invoiceDocs = await seedInvoiceDocs(caller);
+    console.log("✓ demo-data seedad i server-first (org", ORG, "):", { ...core, billing, unbilled, documents, kostnadsrakningDocs, invoiceDocs });
     console.log(`  login: ${LOGIN_LAWYER_EMAIL} + ${LOGIN_ADMIN_EMAIL} äger nu data (+ idag-tidpost)`);
     console.log(CONTENT_DIR ? `  dokument-bytes → ${CONTENT_DIR}` : "  (dokument hoppade — sätt AVA_CONTENT_HOST_DIR)");
   } finally {


### PR DESCRIPTION
Två fynd från lokal testning av "Umgängestvist Carlsson".

## 1. KOSTNADSRAKNING-raden länkar till kostnadsräkningen
Runs-listan i fakturapanelen visade bara en ev. fakturalänk. Nu länkar KOSTNADSRAKNING-raden till **KR-dokumentet** (öppnas via samma `openDocument`/`downloadContent`-väg som övriga dokument). `pickKrDoc` utbruten som pure-funktion så den kan användas per rad utan hook.

## 2. Rådgivningsfakturan saknades i dokumentlistan
I den lokala server-first-seeden genererades inga fakturadokument (`populateInvoiceDocs` kördes inte), så rådgivningsfakturan (F-2026-NNNN) fanns inte i ärendets dokumentlista. Nu:
- `seed-demo-into-server` kör `populateInvoiceDocs` med uuid-id (Postgres `documents.id` är uuid).
- `populateInvoiceDocs` utökad från enbart FINAL → **FINAL + STANDARD**, så rådgivningsfakturan får ett dokument.

## Verifierat (CI-spegel)
- `typecheck`, `lint --max-warnings 0`, `knip`, `deps:check`, `duplicates` — gröna
- `bun run test` — 3374 + 19 pass / 0 fail (ny test: KR-raden öppnar dokumentet)
- `build:demo` — OK (13 faktura-dokument, +2 rådgivning)

Refs #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)