### PR TITLE
feat(demo): seeda byråns bulkdata via serverns HTTP-API (hybrid)

### DIFF
--- a/test/scripts/http-target.test.ts
+++ b/test/scripts/http-target.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tester för http-target (#846): proxyn ska dispatcha query vs mutation rätt
+ * (ur appRouter._def.procedures) och mintToken ska retrya transienta fel men
+ * INTE icke-transienta (fel creds → kasta direkt).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+
+import { createHttpCaller, mintToken } from "../../tooling/demo-generator/http-target";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+const calls: Array<[string, string, Any]> = [];
+
+vi.mock("@trpc/client", () => ({
+  httpBatchLink: (o: Any) => o,
+  createTRPCClient: () =>
+    new Proxy({}, {
+      get: (_t, k1: string) =>
+        new Proxy({}, {
+          get: (_t2, k2: string) => ({
+            query: (input: Any) => { calls.push(["query", `${k1}.${k2}`, input]); return Promise.resolve({ ok: "query" }); },
+            mutate: (input: Any) => { calls.push(["mutate", `${k1}.${k2}`, input]); return Promise.resolve({ ok: "mutate" }); },
+          }),
+        }),
+    }),
+}));
+
+beforeEach(() => { calls.length = 0; });
+
+describe("createHttpCaller — dispatch query vs mutation", () => {
+  it("matter.create → mutate; billingRun.list → query (ur routerns def)", async () => {
+    const caller = createHttpCaller({ trpcUrl: "http://x/api/trpc", token: "t" }) as Any;
+    await caller.matter.create({ id: "m1" });
+    await caller.billingRun.list({});
+    await caller.invoice.getById({ id: "i1" });
+    expect(calls).toContainEqual(["mutate", "matter.create", { id: "m1" }]);
+    expect(calls).toContainEqual(["query", "billingRun.list", {}]);
+    expect(calls).toContainEqual(["query", "invoice.getById", { id: "i1" }]);
+  });
+});
+
+describe("mintToken", () => {
+  it("200 med access_token → returnerar token", async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ access_token: "abc" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const tok = await mintToken({ kcBaseUrl: "http://kc", realm: "ava", clientId: "ava", clientSecret: "s", username: "u", password: "p" });
+    expect(tok).toBe("abc");
+    vi.unstubAllGlobals();
+  });
+
+  it("401 (fel creds) → kastar direkt, ingen retry", async () => {
+    const fetchMock = vi.fn(async () => new Response("bad", { status: 401 }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(mintToken({ kcBaseUrl: "http://kc", realm: "ava", clientId: "ava", clientSecret: "s", username: "u", password: "p" }, 5))
+      .rejects.toThrow(/401/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    vi.unstubAllGlobals();
+  });
+
+  it("nät-fel → retry tills det lyckas", async () => {
+    let n = 0;
+    const fetchMock = vi.fn(async () => {
+      n++;
+      if (n < 3) throw new Error("socket closed");
+      return new Response(JSON.stringify({ access_token: "late" }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const tok = await mintToken({ kcBaseUrl: "http://kc", realm: "ava", clientId: "ava", clientSecret: "s", username: "u", password: "p" }, 5);
+    expect(tok).toBe("late");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    vi.unstubAllGlobals();
+  });
+});

--- a/tooling/demo-generator/http-target.ts
+++ b/tooling/demo-generator/http-target.ts
@@ -1,0 +1,94 @@
+/**
+ * `createHttpCaller` (#846) — en `GeneratorCaller` som kör demo-populeringen via
+ * serverns RIKTIGA HTTP-API (`/api/trpc`) i stället för in-process `createCaller`.
+ *
+ * Varför: då testas hela kedjan som UI:t faktiskt använder — superjson-transport,
+ * oauth2-proxy + Bearer-JWT-auth (ADR 0009/0028) och server-routrarna mot Postgres
+ * — inte bara routrarna isolerat. Samma `populate*`-kod återanvänds oförändrat.
+ *
+ * Formen speglar `appRouter.createCaller`: `caller.x.y(input) => Promise`. En Proxy
+ * slår upp om `x.y` är query/mutation (ur `appRouter._def.procedures`) och anropar
+ * httpBatchLink-klientens `.query`/`.mutate`. Transformern (superjson) + auth-headern
+ * matchar `HttpBackendRuntime`.
+ */
+
+import { createTRPCClient, httpBatchLink } from "@trpc/client";
+import superjson from "superjson";
+import { appRouter, type AppRouter } from "@/lib/server/routers/_app";
+import type { GeneratorCaller } from "./backend-target";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+/** query/mutation för en dotted procedure-path, ur routerns definition. */
+function procType(path: string): "query" | "mutation" | undefined {
+  return (appRouter as Any)._def.procedures[path]?._def?.type;
+}
+
+export interface HttpCallerOpts {
+  /** Full tRPC-endpoint, t.ex. `http://localhost:8080/api/trpc`. */
+  trpcUrl: string;
+  /** Bearer-JWT — verifieras av servern mot IdP:ns JWKS (ADR 0028 §1). */
+  token: string;
+}
+
+export function createHttpCaller(opts: HttpCallerOpts): GeneratorCaller {
+  const client = createTRPCClient<AppRouter>({
+    links: [httpBatchLink({
+      url: opts.trpcUrl,
+      transformer: superjson,
+      headers: () => ({ authorization: `Bearer ${opts.token}` }),
+    })],
+  });
+  const make = (path: string): Any =>
+    new Proxy(() => {}, {
+      get: (_t, key) => (typeof key === "string" ? make(path ? `${path}.${key}` : key) : undefined),
+      apply: (_t, _this, args: Any[]) => {
+        const node = path.split(".").reduce((o: Any, k) => o[k], client as Any);
+        return procType(path) === "query" ? node.query(args[0]) : node.mutate(args[0]);
+      },
+    });
+  return make("") as GeneratorCaller;
+}
+
+export interface MintTokenOpts {
+  kcBaseUrl: string; realm: string; clientId: string; clientSecret: string;
+  username: string; password: string;
+}
+
+/** Hämta en access-token via OIDC password-grant (dev-fixturen: `ava`-klienten
+ *  har directAccessGrants + secret). Endast för lokal seedning, aldrig i prod.
+ *
+ *  Retry med backoff: seedningen kan köra innan Keycloaks realm-token-endpoint
+ *  är helt redo (#846) → nät-/5xx-fel rätas ut av ett par försök. */
+/** Ett token-försök. Returnerar token, eller "retry" vid transient fel (nät/5xx).
+ *  Kastar vid icke-transient fel (fel creds/klient, saknad token). */
+async function attemptToken(url: string, body: URLSearchParams): Promise<string | "retry"> {
+  let res: Response;
+  try {
+    res = await fetch(url, { method: "POST", headers: { "content-type": "application/x-www-form-urlencoded" }, body });
+  } catch {
+    return "retry"; // KC ej uppe än
+  }
+  if (res.ok) {
+    const json = (await res.json()) as { access_token?: string };
+    if (json.access_token) return json.access_token;
+    throw new Error("Keycloak: inget access_token i svaret");
+  }
+  if (res.status < 500) throw new Error(`Keycloak token ${res.status}: ${await res.text()}`);
+  return "retry"; // 5xx
+}
+
+export async function mintToken(opts: MintTokenOpts, retries = 15): Promise<string> {
+  const url = `${opts.kcBaseUrl}/realms/${opts.realm}/protocol/openid-connect/token`;
+  const body = new URLSearchParams({
+    grant_type: "password", client_id: opts.clientId, client_secret: opts.clientSecret,
+    username: opts.username, password: opts.password, scope: "openid email profile",
+  });
+  for (let attempt = 1; ; attempt++) {
+    const result = await attemptToken(url, body);
+    if (result !== "retry") return result;
+    if (attempt >= retries) throw new Error("Keycloak: token-endpoint ej redo efter retries");
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+}

--- a/tooling/demo-generator/populate.ts
+++ b/tooling/demo-generator/populate.ts
@@ -141,7 +141,28 @@ async function runConflictChecks(c: AnyCaller, rows: Row[]): Promise<void> {
   }
 }
 
-export async function populate(caller: GeneratorCaller, seed: SeedDataset): Promise<PopulateResult> {
+export interface PopulateOptions {
+  /** Hoppa över org + users (de bootstrappas separat). HTTP-seedningen (#846)
+   *  kräver att admin-användaren redan finns (OIDC + assertAdmin), så org/users
+   *  skapas in-process först; resten körs via HTTP-API:t. */
+  skipOrgUsers?: boolean;
+}
+
+/**
+ * Skapa BARA org + users (#846) — bootstrappen HTTP-seedningen kör in-process
+ * innan den växlar till HTTP-API:t (admin-användaren måste finnas för att en
+ * OIDC-token ska resolva + `user.create` är assertAdmin-gated). Returnerar antal.
+ */
+export async function bootstrapOrgUsers(caller: GeneratorCaller, seed: SeedDataset): Promise<{ organizations: number; users: number }> {
+  const c = caller as AnyCaller;
+  const organizations = pick(seed, "organizations");
+  const users = pick(seed, "users");
+  await createOrganizations(c, organizations);
+  await createUsers(c, users);
+  return { organizations: organizations.length, users: users.length };
+}
+
+export async function populate(caller: GeneratorCaller, seed: SeedDataset, opts: PopulateOptions = {}): Promise<PopulateResult> {
   const c = caller as AnyCaller;
   const organizations = pick(seed, "organizations");
   const users = pick(seed, "users");
@@ -155,8 +176,10 @@ export async function populate(caller: GeneratorCaller, seed: SeedDataset): Prom
   const documentTemplates = pick(seed, "documentTemplates");
   const conflictChecks = pick(seed, "conflictChecks");
 
-  await createOrganizations(c, organizations); // rot — måste finnas före org-scopat
-  await createUsers(c, users); // kräver ADMIN-principal (generatorns principal)
+  if (!opts.skipOrgUsers) {
+    await createOrganizations(c, organizations); // rot — måste finnas före org-scopat
+    await createUsers(c, users); // kräver ADMIN-principal (generatorns principal)
+  }
   await createContacts(c, contacts);
   await createMatters(c, matters); // före matter-contacts + allt matterId-refererande
   await createMatterContacts(c, matterContacts);

--- a/tooling/scripts/seed-demo-into-server.ts
+++ b/tooling/scripts/seed-demo-into-server.ts
@@ -29,18 +29,19 @@ import { createPostgresDb } from "@/lib/server/db/client";
 import { serverFirstEventLog } from "@/lib/server/http/server-context";
 import { createDbChangeLogRecorder, enableChangeLogOnAll } from "@/lib/server/repositories/change-log-recorder";
 import { buildDrizzleRepositories } from "@/lib/server/repositories/drizzle-repositories";
-import type { Repositories } from "@/lib/server/repositories/repositories";
 import { appRouter } from "@/lib/server/routers/_app";
 import { asId } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
+import type { GeneratorCaller } from "../demo-generator/backend-target";
+import { createHttpCaller, mintToken } from "../demo-generator/http-target";
 import { createIdTranslator, translateSeed } from "../demo-generator/id-translator";
-import { populate } from "../demo-generator/populate";
+import { bootstrapOrgUsers, populate } from "../demo-generator/populate";
 import { populateBilling } from "../demo-generator/populate-billing";
 import { populateDocuments } from "../demo-generator/populate-documents";
 import { populateInvoiceDocs } from "../demo-generator/populate-invoice-docs";
 import { populateKostnadsrakningDocs } from "../demo-generator/populate-kostnadsrakning-docs";
 import { populateUnbilledTime } from "../demo-generator/populate-unbilled-time";
-import { buildSeed } from "./seed-data";
+import { buildSeed, type SeedDataset } from "./seed-data";
 
 const DB_URL = process.env.AVA_DATABASE_URL ?? "postgres://ava:ava@localhost:5433/ava_test";
 const ORG = asId<"OrganizationId">(process.env.AVA_ORGANIZATION_ID ?? "00000000-0000-0000-0000-000000000001");
@@ -48,6 +49,14 @@ const ORG = asId<"OrganizationId">(process.env.AVA_ORGANIZATION_ID ?? "00000000-
 // dit skrivs dokument-bytes så serverns GitContentStore kan läsa dem. Saknas
 // den → dokument-metadata hoppas (bytes har ingenstans att ta vägen).
 const CONTENT_DIR = process.env.AVA_CONTENT_HOST_DIR;
+
+/** HTTP-läge (#846): driv den BULK-seedade datan via serverns riktiga
+ *  /api/trpc (transport + oauth2-proxy + Bearer-JWT-auth + routrar), inte bara
+ *  in-process. Org+users bootstrappas ändå in-process (OIDC/assertAdmin). */
+const VIA_HTTP = process.env.AVA_SEED_VIA_HTTP === "1";
+const WEB_ORIGIN = process.env.AVA_WEB_ORIGIN ?? "http://localhost:8080";
+const KC_BASE = process.env.OIDC_KC_HOSTNAME ?? "http://localhost:8089";
+const OIDC_CLIENT_SECRET = process.env.AVA_OIDC_CLIENT_SECRET ?? "ava-test-secret";
 
 /** KC-realm:ens allowlistade login-emails (realm-ava.json). */
 const LOGIN_ADMIN_EMAIL = "admin@ava.test";
@@ -76,7 +85,9 @@ function remapLoginUsers(users: Row[]): { adminId: string | undefined; lawyerId:
  * dagsvy ("Idag") blir annars tom. Tasks/kalender landar redan på idag via
  * seedens offset-logik, så bara tid behöver kompletteras.
  */
-async function addTodayTimeEntries(repos: Repositories, timeEntries: Row[], matters: Row[], ids: { adminId: string | undefined; lawyerId: string | undefined }): Promise<void> {
+async function addTodayTimeEntries(caller: GeneratorCaller, timeEntries: Row[], matters: Row[], ids: { adminId: string | undefined; lawyerId: string | undefined }): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const c = caller as any;
   const tes = timeEntries;
   // Föredra ett PRIVAT-ärende: det är alltid i ARBETE-fasen (fakturerbart), så
   // "idag"-tiden blir inte ofakturerat arbete på ett redan slutreglerat ärende
@@ -87,17 +98,11 @@ async function addTodayTimeEntries(repos: Repositories, timeEntries: Row[], matt
     const worked = tes.filter((t) => t.userId === userId).map((t) => String(t.matterId));
     const matterId = worked.find((id) => pmById.get(id) === "PRIVAT") ?? worked[0];
     if (!matterId) continue;
-    await repos.timeEntries.create({
-      id: asId<"TimeEntryId">(uuidv7()),
-      organizationId: ORG,
-      userId: asId<"UserId">(userId),
-      matterId: asId<"MatterId">(matterId),
-      date: new Date(),
-      minutes: 60,
-      description: "Löpande arbete (idag)",
-      billable: true,
-      hourlyRate: 220_000,
-    } as never);
+    // Via tRPC-API:t (#846) → funkar oavsett in-process/HTTP-caller.
+    await c.timeEntry.create({
+      id: uuidv7(), userId, matterId, date: new Date().toISOString(),
+      minutes: 60, description: "Löpande arbete (idag)", billable: true, hourlyRate: 220_000,
+    });
   }
 }
 
@@ -144,48 +149,66 @@ async function seedDocuments(
   return populateDocuments(caller, seed, sink);
 }
 
+type LoginIds = { adminId: string | undefined; lawyerId: string | undefined };
+
+/** Allt utom org+users (#846) — körs antingen in-process eller via HTTP-caller.
+ *  `skipOrgUsers` styr om populate hoppar org/users (HTTP: bootstrappade separat). */
+async function runRest(caller: GeneratorCaller, seed: SeedDataset, loginIds: LoginIds, skipOrgUsers: boolean): Promise<Record<string, unknown>> {
+  const core = await populate(caller, seed, { skipOrgUsers });
+  await addTodayTimeEntries(caller, seed.timeEntries as Row[], seed.matters as Row[], loginIds); // "idag"-tid för dashboarden
+  // Fakturering (#647/#736): ETT billing-run-flöde per ärende; unbilled = färsk
+  // upparbetad tid efter fakturering.
+  const billing = await populateBilling(caller, seed);
+  const unbilled = await populateUnbilledTime(caller, seed);
+  const documents = await seedDocuments(caller, seed);
+  const kostnadsrakningDocs = await seedKostnadsrakningDocs(caller);
+  const invoiceDocs = await seedInvoiceDocs(caller);
+  return { ...core, billing, unbilled, documents, kostnadsrakningDocs, invoiceDocs };
+}
+
+/** HTTP-läget (#846): org+users bootstrappas in-process (OIDC/assertAdmin kräver
+ *  att admin finns), sedan körs resten via serverns /api/trpc som admin@ava.test. */
+async function seedViaHttp(inProcess: GeneratorCaller, seed: SeedDataset, loginIds: LoginIds): Promise<Record<string, unknown>> {
+  const boot = await bootstrapOrgUsers(inProcess, seed);
+  const token = await mintToken({ kcBaseUrl: KC_BASE, realm: "ava", clientId: "ava", clientSecret: OIDC_CLIENT_SECRET, username: "admin", password: "admin" });
+  const httpCaller = createHttpCaller({ trpcUrl: `${WEB_ORIGIN}/api/trpc`, token });
+  const rest = await runRest(httpCaller, seed, loginIds, true);
+  console.log("  (bulk-data seedad via HTTP-API:t — transport + oauth2-proxy/Bearer + routrar)");
+  return { ...rest, organizations: boot.organizations, users: boot.users };
+}
+
+/** In-process ADMIN-principal (org-scopad mot ORG): återanvänd en allowlistad
+ *  admin om en finns, annars en generator-identitet. */
+function seedPrincipal(admin: { id: Principal["id"]; email: string; name: string } | undefined): Principal {
+  return {
+    id: admin?.id ?? asId<"UserId">("00000000-0000-0000-0000-0000000000a1"),
+    email: admin?.email ?? "generator@ava.local",
+    name: admin?.name ?? "Demo Generator",
+    role: "ADMIN",
+    organizationId: ORG,
+  };
+}
+
 async function main(): Promise<void> {
   const { db, close } = createPostgresDb(DB_URL);
   const repos = buildDrizzleRepositories(db);
   enableChangeLogOnAll(repos, createDbChangeLogRecorder(db)); // → allt pull-bart
   try {
-    // ADMIN-principal i serverns org. Återanvänd den allowlistade admin-användaren
-    // (seed-selfhosted-local) om den finns, annars en generator-identitet.
+    // Alltid byggd: fallback (in-process-läge) OCH HTTP-lägets org/user-bootstrap.
     const admin = (await repos.users.listByOrg(ORG)).find((u) => u.role === "ADMIN");
-    const principal: Principal = {
-      id: admin?.id ?? asId<"UserId">("00000000-0000-0000-0000-0000000000a1"),
-      email: admin?.email ?? "generator@ava.local",
-      name: admin?.name ?? "Demo Generator",
-      role: "ADMIN",
-      organizationId: ORG,
-    };
+    const principal = seedPrincipal(admin);
     const ctx = buildContext({ repos, eventLog: serverFirstEventLog, ports: noopPorts, principal });
-    const caller = appRouter.createCaller(ctx as never) as ReturnType<typeof appRouter.createCaller>;
+    const inProcess = appRouter.createCaller(ctx as never) as GeneratorCaller;
 
-    // Slug-seed → UUID:er (samma som demo-generatorn/prod, ADR 0003). Org-/user-
-    // raderna skapas också, men create-mutationerna org-scopar mot PRINCIPALENS
-    // org (ORG), så allt hamnar i serverns org oavsett seedens org-fält.
+    // Slug-seed → UUID:er (ADR 0003) + mappa admin/huvud-jurist till KC-login-emailen.
     const seed = translateSeed(buildSeed({}), createIdTranslator());
-
-    // Mappa demons admin + huvud-jurist till KC-login-emailen → login äger data.
     const loginIds = remapLoginUsers(seed.users as Row[]);
 
-    // Kärnentiteter (org/users/contacts/matters/matter-contacts/tid/utlägg/
-    // kalender/uppgifter/mallar/jävskontroller).
-    const core = await populate(caller, seed);
-    await addTodayTimeEntries(repos, seed.timeEntries as Row[], seed.matters as Row[], loginIds); // "idag"-tid för dashboarden
+    const result = VIA_HTTP
+      ? await seedViaHttp(inProcess, seed, loginIds)
+      : await runRest(inProcess, seed, loginIds, false);
 
-    // Fakturering (#647/#736): billing-id:na är deterministiska uuid:er
-    // (demo-billing-ids). populateBilling driver nu ETT billing-run-flöde per
-    // ärende (aconto/slutfaktura/kostnadsräkning + livscykel); unbilled = färsk
-    // upparbetad tid efter fakturering.
-    const billing = await populateBilling(caller, seed);
-    const unbilled = await populateUnbilledTime(caller, seed);
-
-    const documents = await seedDocuments(caller, seed);
-    const kostnadsrakningDocs = await seedKostnadsrakningDocs(caller);
-    const invoiceDocs = await seedInvoiceDocs(caller);
-    console.log("✓ demo-data seedad i server-first (org", ORG, "):", { ...core, billing, unbilled, documents, kostnadsrakningDocs, invoiceDocs });
+    console.log("✓ demo-data seedad i server-first (org", ORG, "):", result);
     console.log(`  login: ${LOGIN_LAWYER_EMAIL} + ${LOGIN_ADMIN_EMAIL} äger nu data (+ idag-tidpost)`);
     console.log(CONTENT_DIR ? `  dokument-bytes → ${CONTENT_DIR}` : "  (dokument hoppade — sätt AVA_CONTENT_HOST_DIR)");
   } finally {

--- a/tooling/scripts/selfhosted-local.sh
+++ b/tooling/scripts/selfhosted-local.sh
@@ -55,8 +55,11 @@ if [[ "${1:-}" == "--demo" ]]; then
   # fylls för den inloggade). Separata allowlist-users skulle bli dubbletter.
   echo "▸ [5/6] Seedar org (login-users kommer från demodatan)…"
   SEED_ORG_ONLY=1 AVA_DATABASE_URL="$DB_URL" AVA_ORGANIZATION_ID="$AVA_ORGANIZATION_ID" bun tooling/scripts/seed-selfhosted-local.ts
-  echo "▸ [5b] Fyller byrån med demodata (ärenden/kontakter/tid/uppgifter…)…"
-  AVA_DATABASE_URL="$DB_URL" AVA_ORGANIZATION_ID="$AVA_ORGANIZATION_ID" bun tooling/scripts/seed-demo-into-server.ts
+  # Bulk-datan seedas via serverns HTTP-API (#846) — testar transport + oauth2-
+  # proxy/Bearer + routrar, inte bara in-process. Override: AVA_SEED_VIA_HTTP=0.
+  echo "▸ [5b] Fyller byrån med demodata via HTTP-API:t (ärenden/kontakter/tid/uppgifter…)…"
+  AVA_SEED_VIA_HTTP="${AVA_SEED_VIA_HTTP:-1}" OIDC_KC_HOSTNAME="$OIDC_KC_HOSTNAME" AVA_WEB_ORIGIN="http://localhost:${AVA_WEB_PORT}" \
+    AVA_DATABASE_URL="$DB_URL" AVA_ORGANIZATION_ID="$AVA_ORGANIZATION_ID" bun tooling/scripts/seed-demo-into-server.ts
 else
   echo "▸ [5/6] Seedar org + allowlistade användare…"
   AVA_DATABASE_URL="$DB_URL" AVA_ORGANIZATION_ID="$AVA_ORGANIZATION_ID" bun tooling/scripts/seed-selfhosted-local.ts


### PR DESCRIPTION
Demodatan i den lokala self-hosted-stacken skapas nu via serverns **riktiga `/api/trpc`** (httpBatchLink + superjson + oauth2-proxy/Bearer-JWT + routrarna mot Postgres) i stället för enbart in-process `createCaller` → hela kedjan UI:t använder testas, inte bara routrarna isolerat.

## Hybrid (pga auth-modellen)
Serverns OIDC-provider JIT-provisionerar inte (kräver känd allowlistad användare) och `user.create` är `assertAdmin` → ren "allt via HTTP" är omöjligt. Lösning:
- **org + users bootstrappas in-process** (det minimala, oundvikliga).
- **allt annat** — kontakter, ärenden, matter-contacts, tid, utlägg, fakturering, dokument — körs via HTTP som `admin@ava.test`.

## Delar
- `http-target.ts`:
  - `mintToken` — OIDC password-grant mot Keycloak (`ava`-klientens directAccessGrants + secret), med **retry** för realm-readiness-racet (seedningen kan köra innan KC:s token-endpoint är redo). 4xx (fel creds) retryas inte.
  - `createHttpCaller` — en Proxy som speglar `createCaller`-formen (`caller.x.y(input)`) och dispatchar query/mutation ur `appRouter._def.procedures` till httpBatchLink-klienten. Transformer/auth matchar `HttpBackendRuntime`.
- `populate`: ny `skipOrgUsers`-option + `bootstrapOrgUsers`.
- `seed-demo-into-server`: HTTP-läge (`AVA_SEED_VIA_HTTP`, default **på** i `selfhosted-local --demo`; `AVA_SEED_VIA_HTTP=0` = in-process-fallback). `addTodayTimeEntries` går via `caller.timeEntry.create`.

## Verifierat
- **Live**: `selfhosted-local --demo` (HTTP-läge) seedar identiska antal som in-process — 18 ärenden, 50 matter-contacts, 75 tidposter, 37 utlägg, full fakturering (19 fakturor m.m.), 40 + 4 KR + 13 faktura-dokument — allt via HTTP-API:t.
- `typecheck`, `lint --max-warnings 0`, `knip`, `deps:check`, `duplicates` — gröna
- `bun run test` — 3378 + 19 pass / 0 fail (ny `http-target.test.ts`: proxy-dispatch + mintToken retry/non-retry)
- `build:demo` — OK (GH Pages-demon oförändrad: in-process git-target)

Refs #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)