### PR TITLE
fix(demo): auto-heal lokala web-bind-mounten efter build:demo

### DIFF
--- a/tooling/scripts/build-demo.sh
+++ b/tooling/scripts/build-demo.sh
@@ -183,3 +183,13 @@ echo "[build-demo] Klar. Output: $ROOT/out/"
 echo "  • App: $(find "$ROOT/out" -name '*.html' | wc -l | tr -d ' ') HTML-filer"
 echo "  • Data: $(grep -c '"' "$ROOT/out/manifest.json" 2>/dev/null || echo 0) entiteter i manifest"
 echo "  • Binärer: $(find "$ROOT/out/documents/content" -type f 2>/dev/null | wc -l | tr -d ' ') PDF/DOCX"
+
+# Auto-heal den lokala self-hosted-stacken (#847): `next build` återskapar out/
+# med ett NYTT inode → Docker Desktops bind-mount (../../out) blir då inaktuell
+# tills containern startas om, och appen 404:ar efter login. Om web-containern
+# kör (bara lokalt; i CI finns den inte → no-op) startar vi om den så mounten
+# pekar på den nybyggda out/ igen. Idempotent + icke-fatal.
+if command -v docker >/dev/null 2>&1 && docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^ava-selfhosted-local-web-1$'; then
+  echo "[build-demo] Startar om lokala web-containern (bind-mount-refresh efter out/-ombygge)…"
+  docker compose -p ava-selfhosted-local -f "$ROOT/tooling/docker/docker-compose.selfhosted-local.yml" restart web >/dev/null 2>&1 || true
+fi


### PR DESCRIPTION
## Återkommande bugg (3:e gången)
404 efter login i den lokala self-hosted-stacken. Orsak: `bunx next build` (i `build:demo`) **återskapar `out/` med ett nytt inode**, så Docker Desktops bind-mount `../../out:/usr/share/nginx/html` blir inaktuell tills web-containern startas om → nginx ser en tom html-katalog → `GET /ava/` ger 404 efter inloggning.

`selfhosted-local.sh --demo` undgick det (`up -d --build` återskapar containern → fräsch mount), men ett **fristående `bun run build:demo`** medan stacken kör (t.ex. gate-verifiering före PR) lämnade en trasig mount → användaren 404:ar.

## Fix
`build-demo.sh` startar nu om den lokala web-containern i slutet **om den kör** — guardat så CI/icke-docker-miljöer blir no-op, icke-fatalt, idempotent. Vem som än bygger om `out/` auto-helar den körande stacken.

Verifierat: `bun run build:demo` med stacken uppe → "Startar om lokala web-containern…" → mounten intakt (49 filer), `/ava/` → 302 (login) i st.f. 404.

Refs #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)