### PR TITLE
fix(demo): visa rådgivningsraden i seedade rättshjälps-KR-dokument

### DIFF
--- a/tooling/demo-generator/populate-kostnadsrakning-docs.ts
+++ b/tooling/demo-generator/populate-kostnadsrakning-docs.ts
@@ -17,6 +17,7 @@
  * sätter i prod, så `findKrDocument` i billing-panelen hittar den).
  */
 
+import { radgivningTextRad } from "@/lib/shared/rattshjalp";
 import type { GeneratorCaller } from "./backend-target";
 import type { BinarySink } from "./populate-documents";
 
@@ -35,6 +36,11 @@ function renderKrHtml(run: Any): string {
   const matter = run.matter ?? {};
   const amountOre = run.proposedAmountOre ?? run.amountOre ?? 0;
   const date = run.createdAt ? new Date(run.createdAt) : new Date();
+  // Rättshjälp (#383/#848): rådgivningstimmen redovisas som textrad (utan belopp)
+  // — mötet ägt rum men timmen ingår inte i KR-totalen (faktureras klienten separat).
+  const radgivningRad = matter.paymentMethod === "RATTSHJALP"
+    ? `<p style="color:#555;font-size:13px;margin-top:1rem">${escapeHtml(radgivningTextRad())}</p>`
+    : "";
   return `<!DOCTYPE html><html lang="sv"><head><meta charset="utf-8"><title>Kostnadsräkning ${escapeHtml(matter.matterNumber)}</title></head>
 <body style="font-family:system-ui,sans-serif;max-width:720px;margin:2rem auto;color:#111">
 <h1 style="margin-bottom:0">Kostnadsräkning</h1>
@@ -43,10 +49,11 @@ Ställd till: Domstol<br>
 Datum: ${date.toLocaleDateString("sv-SE")}</p>
 <table cellpadding="6" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:14px">
 <tbody>
-<tr><td>Begärt belopp (offentligt försvar)</td><td style="text-align:right">${fmtKr(amountOre)}</td></tr>
+<tr><td>Begärt belopp</td><td style="text-align:right">${fmtKr(amountOre)}</td></tr>
 </tbody>
 <tfoot><tr style="border-top:2px solid #333"><td style="font-weight:bold">Summa att fastställa av rätten</td><td style="text-align:right;font-weight:bold">${fmtKr(amountOre)}</td></tr></tfoot>
 </table>
+${radgivningRad}
 <p style="color:#777;font-size:13px;margin-top:1.5rem">Kostnadsräkningen är inlämnad och väntar på rättens prövning (dom).</p>
 </body></html>`;
 }


### PR DESCRIPTION
Vid verifiering av rådgivningsbeteendet i "Umgängestvist Carlsson" stämde 2 av 3 spec-punkter; den tredje ("i kostnadsräkningen visas att rådgivningmötet ägt rum") saknades i det **seedade** KR-dokumentet.

Runtime-vägen (`generateKrDoc` → `radgivningNotice`) visade redan raden, men det seedade KR-dokumentet (`populateKostnadsrakningDocs`, enklare HTML) utelämnade den.

`renderKrHtml` lägger nu till rådgivnings-textraden (`radgivningTextRad`, utan belopp) för RATTSHJALP-ärenden. Totalen är oförändrad (rådgivningstimmen exkluderas redan via `coverageBaseMinutes`). Etiketten "(offentligt försvar)" → generisk "Begärt belopp" eftersom dokumentet nu även används för rättshjälp.

## Verifierat (Umgängestvist Carlsson, live HTTP-seed)
- Rådgivning debiterad klienten vid start: F-2026-NNNN STANDARD 1626 kr ✅
- KR-total exkluderar timmen: 700313 = 195 min (255−60) @1626/h inkl moms + utlägg (med hela 255 min vore det 903563) ✅
- KR-dokumentet visar nu: *"Klienten har betalat en rådgivningstimme (1 tim) … Ingår ej i denna kostnadsräkning."* ✅

Gröna: typecheck, lint --max-warnings 0, knip, deps, duplicates, `bun run test` (3378+19), build:demo.

Refs #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)