### PR TITLE
fix(billing): visa utlägg i slutreglera-dialogen

### DIFF
--- a/src/app/matters/[id]/_settlement-dialog.tsx
+++ b/src/app/matters/[id]/_settlement-dialog.tsx
@@ -24,6 +24,8 @@ interface SplitData {
   payerOre: number;
   firmLossOre: number;
   totalOre: number;
+  /** Utlägg (netto) — bokas på betalaren tillsammans med dess arvodesdel (#849). */
+  expensesOre: number;
 }
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
@@ -45,8 +47,10 @@ function SplitPreview({ data, payerLabel }: { data: SplitData; payerLabel: strin
   return (
     <div className="rounded border border-gray-200 bg-gray-50 px-3 py-2 space-y-1">
       <Row label="Upparbetat (aktuellt timarvode)" ore={data.totalOre} />
+      {data.expensesOre > 0 && <Row label="Utlägg" ore={data.expensesOre} />}
       <Row label="Klientens del" ore={data.clientOre} />
-      <Row label={payerLabel} ore={data.payerOre} />
+      {/* Betalaren står för sin arvodesdel + utläggen (coverageInvoiceLines, #849). */}
+      <Row label={payerLabel} ore={data.payerOre + data.expensesOre} />
       {data.firmLossOre > 0 && <Row label="Byrån bär (prutning)" ore={data.firmLossOre} dim />}
       <p className="text-[11px] text-gray-400 pt-1">Klicka på ett belopp för att växla inkl./exkl. moms.</p>
     </div>

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -689,19 +689,22 @@ export const billingRunRouter = router({
       const matter = await ctx.repos.matters.getByIdInOrg(input.matterId, ctx.orgId);
       if (!matter) throw new TRPCError({ code: "NOT_FOUND", message: "Ärendet finns inte." });
       const { billableMinutes } = await ctx.repos.timeEntries.coverageUsageForMatter(input.matterId);
-      const entries = await ctx.repos.timeEntries.listUnfrozenForMatter(input.matterId);
+      const work = await fetchUnfrozenWork(ctx.repos, input.matterId);
       const currentRateOre = await currentArvodeRateOre(ctx.repos, ctx.orgId, matter);
       const baseMinutes = coverageBaseMinutes(matter.paymentMethod, billableMinutes);
       const totalOre = Math.round((baseMinutes / 60) * currentRateOre);
+      // Utlägg (netto) bokas på betalaren i settlement-flödet (coverageInvoiceLines)
+      // → måste med i förhandsvisningen (#849), annars syns bara timarvodet.
+      const expensesOre = expenseNetOre(work);
       const split = computeCoverageSplit({
         method: matter.paymentMethod,
         totalOre,
         clientShareBips: matter.clientShareBips ?? 0,
         ...(input.awardedOre != null ? { awardedOre: input.awardedOre } : {}),
         ...(input.insurerPrutningOre != null ? { insurerPrutningOre: input.insurerPrutningOre } : {}),
-        ...rattsskyddCoverage(matter, entries, currentRateOre),
+        ...rattsskyddCoverage(matter, work.timeEntries, currentRateOre),
       });
-      return { ...split, totalOre, currentRateOre, billableMinutes };
+      return { ...split, totalOre, expensesOre, currentRateOre, billableMinutes };
     }),
 
   setVerdict: orgProcedure

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -415,6 +415,21 @@ describe("billingRun.coverageSplit — prutning/självrisk på aktuellt timarvod
     const r = await c.billingRun.coverageSplit({ matterId: "m-1" });
     expect(r.totalOre).toBe(162600);
   });
+
+  it("returnerar utlägg (netto) separat så de syns i settlement-dialogen (#849)", async () => {
+    const ds = new DemoDataStore({
+      organizations: [{ id: "org-1", name: "X" }],
+      matters: [{ id: "m-1", organizationId: "org-1", matterNumber: "2026-0001", title: "T", status: "ACTIVE", responsibleLawyerId: "u-1", paymentMethod: "RATTSSKYDD", clientShareBips: 2000, createdAt: new Date() }],
+      users: [{ id: "u-1", organizationId: "org-1", email: "a@x", name: "Anna", role: "ADMIN", hourlyRate: 300000 }],
+      timeEntries: [{ id: "te-1", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), minutes: 120, description: "M", hourlyRate: 200000, billable: true }],
+      expenses: [{ id: "ex-1", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), amount: 90000, description: "Ansökningsavgift", billable: true, vatRate: 0, vatIncluded: false, kind: "EXPENSE" }],
+    }, async () => {});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const c = appRouter.createCaller(buildContext({ dataStore: ds, ports: noopPorts, principal: PRINCIPAL }) as any);
+    const r = await c.billingRun.coverageSplit({ matterId: "m-1" });
+    expect(r.totalOre).toBe(600000); // arvode 2h × 3000 kr
+    expect(r.expensesOre).toBe(90000); // utlägg netto — med i förhandsvisningen
+  });
 });
 
 describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", () => {


### PR DESCRIPTION
"Slutreglera ärende"-dialogen visade bara **timarvodet** — utläggen saknades, trots att settlement-flödet (`coverageInvoiceLines`) faktiskt bokar dem på betalaren. `coverageSplit`-queryn beräknade bara arvode (`baseMinutes × taxa`) och returnerade inga utlägg.

## Fix
- `coverageSplit` hämtar nu `fetchUnfrozenWork` och returnerar **`expensesOre`** (utlägg netto, `expenseNetOre`).
- `SettlementDialog` visar en **"Utlägg"-rad** och lägger utläggen på betalarens belopp (arvodesdel + utlägg) → klient + betalare summerar nu till arvode + utlägg. Följer den globala moms-växlingen.

## Verifierat
- Ny test: `coverageSplit` returnerar `expensesOre: 90000` för ett ärende med ett billable utlägg.
- `typecheck`, `lint --max-warnings 0`, `knip`, `deps`, `duplicates` — gröna
- `bun run test` — 3379 + 19 pass / 0 fail
- `build:demo` — OK

Refs #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)