### PR TITLE
fix(billing): räkna frysta utlägg i slutreglera-förhandsvisningen

### DIFF
--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -688,8 +688,11 @@ export const billingRunRouter = router({
     .query(async ({ ctx, input }) => {
       const matter = await ctx.repos.matters.getByIdInOrg(input.matterId, ctx.orgId);
       if (!matter) throw new TRPCError({ code: "NOT_FOUND", message: "Ärendet finns inte." });
-      const { billableMinutes } = await ctx.repos.timeEntries.coverageUsageForMatter(input.matterId);
-      const work = await fetchUnfrozenWork(ctx.repos, input.matterId);
+      // Använd SAMMA arbets-källa som settleCoverage (resolveSettlementWork): finns
+      // en kostnadsräkning är raderna FRYSTA mot den → fetchUnfrozenWork ger 0 (#849).
+      // Då matchar förhandsvisningen exakt det som bokas (arvode + utlägg).
+      const { work } = await resolveSettlementWork(ctx.repos, ctx.orgId, input.matterId);
+      const billableMinutes = work.timeEntries.filter((t) => t.billable).reduce((s, t) => s + t.minutes, 0);
       const currentRateOre = await currentArvodeRateOre(ctx.repos, ctx.orgId, matter);
       const baseMinutes = coverageBaseMinutes(matter.paymentMethod, billableMinutes);
       const totalOre = Math.round((baseMinutes / 60) * currentRateOre);

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -430,6 +430,16 @@ describe("billingRun.coverageSplit — prutning/självrisk på aktuellt timarvod
     expect(r.totalOre).toBe(600000); // arvode 2h × 3000 kr
     expect(r.expensesOre).toBe(90000); // utlägg netto — med i förhandsvisningen
   });
+
+  it("KR inskickad (rader frysta) → utläggen räknas ändå (Carlsson-regression, #849)", async () => {
+    // Speglar Umgängestvist Carlsson: kostnadsräkningen fryser tid + utlägg.
+    // coverageSplit måste läsa de FRYSTA raderna (resolveSettlementWork), annars
+    // blir utläggen 0 i slutreglera-dialogen.
+    const { caller } = makeCaller({ workMinutes: 120, expenseOre: 90000, paymentMethod: "RATTSHJALP" });
+    await caller.billingRun.createKostnadsrakning({ matterId: "m-1" }); // fryser tid + utlägg
+    const r = await caller.billingRun.coverageSplit({ matterId: "m-1" });
+    expect(r.expensesOre).toBe(90000); // frysta utlägg syns fortfarande
+  });
 });
 
 describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", () => {


### PR DESCRIPTION
Följdfix till #848. Du rapporterade att utläggen FORTFARANDE saknades i "Slutreglera ärende" för **Umgängestvist Carlsson**.

## Orsak
Carlsson har en inskickad kostnadsräkning → KR:n **fryser** tid + utlägg. #848 lät `coverageSplit` läsa utläggen via `fetchUnfrozenWork` (bara OFRYSTA) → 0. Timarvodet syntes ändå eftersom det räknades på `coverageUsageForMatter` (alla debiterbara minuter, oavsett frysning). Inkonsekvent.

## Fix
`coverageSplit` använder nu **samma arbets-källa som själva bokningen** (`settleCoverage` → `resolveSettlementWork` → `fetchWorkByRun` när en KR finns). Då ser förhandsvisningen exakt det som bokas — arvode **och** utlägg — för både frysta (KR) och ofrysta ärenden. `billableMinutes` härleds nu också ur den källan.

## Verifierat
- Ny regressionstest (speglar Carlsson): KR inskickad (rader frysta) → `coverageSplit.expensesOre = 90000` (frysta utlägg räknas).
- Befintlig test: ofrysta utlägg → 90000.
- `typecheck`, `lint`, `knip`, `deps`, `duplicates`, `bun run test` (3380+19), `build:demo` — gröna.

Refs #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)