### PR TITLE
fix(billing): exakt moms på utlägg i slutreglera-dialogen

### DIFF
--- a/src/app/matters/[id]/_settlement-dialog.tsx
+++ b/src/app/matters/[id]/_settlement-dialog.tsx
@@ -14,8 +14,10 @@
 import { useState } from "react";
 import { DecimalInput } from "@/components/ui/decimal-input";
 import { Modal } from "@/components/ui/modal";
-import { Money } from "@/components/ui/money";
 import { trpc } from "@/lib/client/trpc";
+import { formatCurrency } from "@/lib/client/utils";
+import { useVatDisplay } from "@/lib/client/vat/vat-display-context";
+import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
 import type { PaymentMethod } from "@/lib/shared/schemas/enums";
 import type { MatterId } from "@/lib/shared/schemas/ids";
 
@@ -24,34 +26,43 @@ interface SplitData {
   payerOre: number;
   firmLossOre: number;
   totalOre: number;
-  /** Utlägg (netto) — bokas på betalaren tillsammans med dess arvodesdel (#849). */
-  expensesOre: number;
+  /** Utlägg netto + brutto — separat eftersom utlägg har BLANDADE momssatser och
+   *  bruttot inte kan räknas ur nettot med en platt 25 %-sats (#850). */
+  expensesNetOre: number;
+  expensesGrossOre: number;
 }
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return <div><label className="block text-xs text-gray-500 mb-1">{label}</label>{children}</div>;
 }
 
-function Row({ label, ore, dim }: { label: string; ore: number; dim?: boolean }) {
+/** Rad som visar EXAKT netto/brutto (ej platt sats) och följer den globala
+ *  incl/excl-växlingen (#841/#850) — krävs då utlägg kan ha olika momssatser. */
+function Row({ label, netOre, grossOre, dim }: { label: string; netOre: number; grossOre: number; dim?: boolean }) {
+  const { mode, toggle } = useVatDisplay();
+  const shown = mode === "incl" ? grossOre : netOre;
   return (
     <div className={`flex justify-between text-sm ${dim ? "text-amber-700" : "text-gray-700"}`}>
-      {/* Beloppen lagras netto (exkl moms); <Money basis="net"> visar dem på samma
-          momsbasis som resten av panelen och följer den globala incl/excl-växlingen (#841). */}
-      <span>{label}</span><Money ore={ore} basis="net" className="font-mono" />
+      <span>{label}</span>
+      <button type="button" onClick={toggle} title={`Visar ${mode === "incl" ? "inkl." : "exkl."} moms — klicka för att växla`}
+        className="font-mono underline decoration-dotted decoration-gray-300 underline-offset-2 hover:decoration-gray-500">
+        {formatCurrency(shown)}
+      </button>
     </div>
   );
 }
 
-/** Förhandsvisning av uppdelningen — följer den globala momsväxlingen (#841). */
+/** Förhandsvisning av uppdelningen — följer den globala momsväxlingen (#841).
+ *  Arvodesrader har enhetlig 25 % (arvodeInclVatOre); utläggen exakt brutto (#850). */
 function SplitPreview({ data, payerLabel }: { data: SplitData; payerLabel: string }) {
   return (
     <div className="rounded border border-gray-200 bg-gray-50 px-3 py-2 space-y-1">
-      <Row label="Upparbetat (aktuellt timarvode)" ore={data.totalOre} />
-      {data.expensesOre > 0 && <Row label="Utlägg" ore={data.expensesOre} />}
-      <Row label="Klientens del" ore={data.clientOre} />
+      <Row label="Upparbetat (aktuellt timarvode)" netOre={data.totalOre} grossOre={arvodeInclVatOre(data.totalOre)} />
+      {data.expensesNetOre > 0 && <Row label="Utlägg" netOre={data.expensesNetOre} grossOre={data.expensesGrossOre} />}
+      <Row label="Klientens del" netOre={data.clientOre} grossOre={arvodeInclVatOre(data.clientOre)} />
       {/* Betalaren står för sin arvodesdel + utläggen (coverageInvoiceLines, #849). */}
-      <Row label={payerLabel} ore={data.payerOre + data.expensesOre} />
-      {data.firmLossOre > 0 && <Row label="Byrån bär (prutning)" ore={data.firmLossOre} dim />}
+      <Row label={payerLabel} netOre={data.payerOre + data.expensesNetOre} grossOre={arvodeInclVatOre(data.payerOre) + data.expensesGrossOre} />
+      {data.firmLossOre > 0 && <Row label="Byrån bär (prutning)" netOre={data.firmLossOre} grossOre={arvodeInclVatOre(data.firmLossOre)} dim />}
       <p className="text-[11px] text-gray-400 pt-1">Klicka på ett belopp för att växla inkl./exkl. moms.</p>
     </div>
   );

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -696,9 +696,12 @@ export const billingRunRouter = router({
       const currentRateOre = await currentArvodeRateOre(ctx.repos, ctx.orgId, matter);
       const baseMinutes = coverageBaseMinutes(matter.paymentMethod, billableMinutes);
       const totalOre = Math.round((baseMinutes / 60) * currentRateOre);
-      // Utlägg (netto) bokas på betalaren i settlement-flödet (coverageInvoiceLines)
-      // → måste med i förhandsvisningen (#849), annars syns bara timarvodet.
-      const expensesOre = expenseNetOre(work);
+      // Utlägg bokas på betalaren i settlement-flödet (coverageInvoiceLines) →
+      // måste med i förhandsvisningen (#849). Både netto OCH brutto returneras:
+      // utläggen har BLANDADE momssatser (6/12/25 %), så bruttot kan inte räknas
+      // ur nettot med en platt sats — då blir totalen fel (#850).
+      const expensesNetOre = expenseNetOre(work);
+      const expensesGrossOre = expenseGrossOre(work);
       const split = computeCoverageSplit({
         method: matter.paymentMethod,
         totalOre,
@@ -707,7 +710,7 @@ export const billingRunRouter = router({
         ...(input.insurerPrutningOre != null ? { insurerPrutningOre: input.insurerPrutningOre } : {}),
         ...rattsskyddCoverage(matter, work.timeEntries, currentRateOre),
       });
-      return { ...split, totalOre, expensesOre, currentRateOre, billableMinutes };
+      return { ...split, totalOre, expensesNetOre, expensesGrossOre, currentRateOre, billableMinutes };
     }),
 
   setVerdict: orgProcedure

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -416,19 +416,26 @@ describe("billingRun.coverageSplit — prutning/självrisk på aktuellt timarvod
     expect(r.totalOre).toBe(162600);
   });
 
-  it("returnerar utlägg (netto) separat så de syns i settlement-dialogen (#849)", async () => {
+  it("returnerar utläggens netto OCH brutto exakt vid BLANDADE momssatser (#849/#850)", async () => {
+    // Speglar Carlsson: 7920+22400 @25 % + 1745 @6 %. Netto 32065; brutto =
+    // 9900+28000+1850 = 39750 (≠ 32065×1.25=40081 → platt sats vore fel).
     const ds = new DemoDataStore({
       organizations: [{ id: "org-1", name: "X" }],
       matters: [{ id: "m-1", organizationId: "org-1", matterNumber: "2026-0001", title: "T", status: "ACTIVE", responsibleLawyerId: "u-1", paymentMethod: "RATTSSKYDD", clientShareBips: 2000, createdAt: new Date() }],
       users: [{ id: "u-1", organizationId: "org-1", email: "a@x", name: "Anna", role: "ADMIN", hourlyRate: 300000 }],
       timeEntries: [{ id: "te-1", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), minutes: 120, description: "M", hourlyRate: 200000, billable: true }],
-      expenses: [{ id: "ex-1", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), amount: 90000, description: "Ansökningsavgift", billable: true, vatRate: 0, vatIncluded: false, kind: "EXPENSE" }],
+      expenses: [
+        { id: "ex-1", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), amount: 7920, description: "Kopiering", billable: true, vatRate: 2500, vatIncluded: false, kind: "EXPENSE" },
+        { id: "ex-2", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), amount: 22400, description: "Översättning", billable: true, vatRate: 2500, vatIncluded: false, kind: "EXPENSE" },
+        { id: "ex-3", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), amount: 1745, description: "Taxi", billable: true, vatRate: 600, vatIncluded: false, kind: "EXPENSE" },
+      ],
     }, async () => {});
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const c = appRouter.createCaller(buildContext({ dataStore: ds, ports: noopPorts, principal: PRINCIPAL }) as any);
     const r = await c.billingRun.coverageSplit({ matterId: "m-1" });
     expect(r.totalOre).toBe(600000); // arvode 2h × 3000 kr
-    expect(r.expensesOre).toBe(90000); // utlägg netto — med i förhandsvisningen
+    expect(r.expensesNetOre).toBe(32065);
+    expect(r.expensesGrossOre).toBe(39750); // exakt per sats — INTE 40081 (platt 25 %)
   });
 
   it("KR inskickad (rader frysta) → utläggen räknas ändå (Carlsson-regression, #849)", async () => {
@@ -438,7 +445,7 @@ describe("billingRun.coverageSplit — prutning/självrisk på aktuellt timarvod
     const { caller } = makeCaller({ workMinutes: 120, expenseOre: 90000, paymentMethod: "RATTSHJALP" });
     await caller.billingRun.createKostnadsrakning({ matterId: "m-1" }); // fryser tid + utlägg
     const r = await caller.billingRun.coverageSplit({ matterId: "m-1" });
-    expect(r.expensesOre).toBe(90000); // frysta utlägg syns fortfarande
+    expect(r.expensesNetOre).toBe(90000); // frysta utlägg syns fortfarande
   });
 });
 


### PR DESCRIPTION
Du rapporterade att utläggen i "Slutreglera ärende" visades som **400,81** men de verkliga utläggen är **397,50** (inkl moms).

## Orsak
Carlssons utlägg: 79,20 + 224,00 @ 25 % + **17,45 @ 6 %** (taxi). `coverageSplit` returnerade bara **nettot** (32065), och dialogen räknade brutto med en platt **25 %** → 40081 (400,81). Med blandade momssatser blir det fel — rätt brutto är 9900+28000+1850 = **39750 (397,50)**.

## Fix
- `coverageSplit` returnerar nu både `expensesNetOre` (32065) och `expensesGrossOre` (39750) — exakt per sats.
- `SettlementDialog` visar exakt netto/brutto per rad och följer den globala incl/excl-växlingen; ingen platt-sats-härledning. Arvodesrader är fortsatt enhetliga 25 %.

## Verifierat
- Ny test (blandade satser): `expensesNetOre=32065`, `expensesGrossOre=39750` (≠ 40081).
- typecheck, lint, knip, deps, duplicates, `bun run test` (3380+19), build:demo — gröna.

Refs #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)