### PR TITLE
feat(billing): rådgivningstimmen blir ett aconto i ärendets faktura-lista

### DIFF
--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -30,7 +30,7 @@ import { availableActions, currentPhase, type BillingAction, type BillingPhase, 
 import { availableKrActions, KOSTNADSRAKNING_STATUS_LABELS, type KostnadsrakningState, type KostnadsrakningStatus } from "@/lib/shared/kostnadsrakning-flow";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { computeRadgivningsavgift } from "@/lib/shared/rattshjalp";
-import { BILLING_RUN_TYPE_LABELS, BILLING_RUN_STATUS_LABELS, INVOICE_STATUS_LABELS, type BillingRunRecipient, type BillingRunStatus, type BillingRunType, type InvoiceStatus, type PaymentMethod } from "@/lib/shared/schemas/enums";
+import { BILLING_RUN_TYPE_LABELS, BILLING_RUN_STATUS_LABELS, type BillingRunRecipient, type BillingRunStatus, type BillingRunType, type PaymentMethod } from "@/lib/shared/schemas/enums";
 import type { BillingRunId, DocumentId, InvoiceId, MatterId } from "@/lib/shared/schemas/ids";
 import { BillingDialog, type BillingMeta } from "./_billing-dialog";
 import { KostnadsrakningModal } from "./_kostnadsrakning-modal";
@@ -435,9 +435,6 @@ function RadgivningBanner({ matterId, matter, onRecorded }: { matterId: MatterId
   const fired = useRef(false);
   const isRattshjalp = matter.paymentMethod === "RATTSHJALP";
   const registered = !!matter.radgivningBetaldAt;
-  // Rådgivnings-fakturan är den enda STANDARD-fakturan på ärendet → hämta den
-  // för status + länk (den skapas som utkast, inte "fakturerad" automatiskt).
-  const radgivningInv = trpc.invoice.list.useQuery({ matterId, invoiceType: "STANDARD" }).data?.[0];
   const create = trpc.invoice.createRadgivning.useMutation({
     onSuccess: async (res) => {
       // Stäng luckan (#845): ingen faktura utan dokument — generera faktura-PDF:en
@@ -465,28 +462,12 @@ function RadgivningBanner({ matterId, matter, onRecorded }: { matterId: MatterId
         <strong>Rådgivningstimme (rättshjälp)</strong> — klientens 1 tim enligt rättshjälpstaxan,{" "}
         <span className="font-mono">{formatCurrency(avgift.beloppExclVatOre)}</span> exkl moms, faktureras separat till klienten.
       </div>
-      <RadgivningStatus invoice={radgivningInv} pending={create.isPending} failed={!!create.error} />
+      {/* Rådgivningen är nu ett ACCONTO som syns i faktura-listan nedan (#851). */}
+      <span className="text-xs whitespace-nowrap text-blue-700">
+        {registered ? "✓ Registrerad (se aconto nedan)" : create.error ? "Kunde inte skapas" : "Skapas automatiskt…"}
+      </span>
     </div>
   );
-}
-
-/** Rådgivnings-fakturans status + länk (#841). Skapas som utkast → visa rätt
- *  status (inte "fakturerad") och länka till fakturan så den går att granska/skicka. */
-function RadgivningStatus({ invoice, pending, failed }: {
-  invoice?: { id: InvoiceId; invoiceNumber?: string | null | undefined; status: InvoiceStatus } | undefined;
-  pending: boolean; failed: boolean;
-}) {
-  if (invoice) {
-    return (
-      <span className="text-xs whitespace-nowrap">
-        <EntityLink route="invoices" id={invoice.id} className="text-blue-700 hover:underline">
-          {invoice.invoiceNumber ?? "Faktura"}
-        </EntityLink>{" "}
-        <span className="text-gray-500">({INVOICE_STATUS_LABELS[invoice.status]})</span>
-      </span>
-    );
-  }
-  return <span className="text-xs text-blue-700 whitespace-nowrap">{failed ? "Kunde inte skapas" : pending ? "Skapas…" : "Skapas automatiskt…"}</span>;
 }
 
 /**

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -15,7 +15,7 @@
 
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { isPaymentPlanSettled } from "@/lib/shared/invoice-calc";
+import { arvodeInclVatOre, isPaymentPlanSettled } from "@/lib/shared/invoice-calc";
 import { canTransition, transitionErrorMessage } from "@/lib/shared/invoice-state-machine";
 import { ocrFromInvoiceNumber } from "@/lib/shared/ocr-reference";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
@@ -111,17 +111,20 @@ export const invoiceRouter = router({
 
   /** ACCONTO: advokaten anger belopp. Inga time entries/expenses kopplas. */
   /**
-   * RÅDGIVNING (#383, rättshjälp del A): registrera klientens betalda
-   * rådgivningstimme (1 tim enligt rättshjälpstaxan) som en SEPARAT klient-
-   * faktura (STANDARD mot KLIENT) + märk ärendet (`radgivningBetaldAt`) så
-   * domstolens kostnadsräkning visar text-raden. Timmen ingår ALDRIG i
-   * domstolens kostnadsräkning som debiterbar post. Idempotent: avvisar om
-   * redan registrerad.
+   * RÅDGIVNING (#383/#851, rättshjälp del A): klientens betalda rådgivningstimme
+   * (1 tim enligt rättshjälpstaxan) som en ACCONTO-klientfaktura + billing-run så
+   * den syns i ärendets faktura-lista. Märker `radgivningBetaldAt` så domstolens
+   * kostnadsräkning visar text-raden; timmen ingår ALDRIG i KR-totalen.
+   *
+   * Hålls i DRAFT MED FLIT: rådgivningstimmen är en ADDITIV klientkostnad utöver
+   * självrisken och ska ALDRIG dras av på en slutfaktura. Aconto-deduktionerna
+   * kräver status SENT (`listAccontoSent` / panelens deduktions-val), så ett
+   * DRAFT-aconto exkluderas automatiskt. Idempotent: avvisar om redan registrerad.
    */
   createRadgivning: orgProcedure
     .input(z.object({ matterId: matterIdSchema, hasFTax: z.boolean().optional() }))
-    // Migrerad till repository-sömmen (ADR 0020): matters + invoices via typade
-    // repos i transaktionen (rör inga ännu omigrerade entiteter).
+    // Migrerad till repository-sömmen (ADR 0020): matters + invoices + billing-runs
+    // via typade repos i transaktionen.
     .mutation(({ ctx, input }) =>
       ctx.repos.transaction(async (repos) => {
         const matter = await repos.matters.getByIdInOrg(input.matterId, ctx.orgId);
@@ -129,22 +132,24 @@ export const invoiceRouter = router({
         if ((matter as { radgivningBetaldAt?: unknown }).radgivningBetaldAt) {
           throw new TRPCError({ code: "BAD_REQUEST", message: "Rådgivningstimmen är redan registrerad för detta ärende." });
         }
-        const avgift = computeRadgivningsavgift({ ...omitUndefined({ hasFTax: input.hasFTax }) });
+        const netOre = computeRadgivningsavgift({ ...omitUndefined({ hasFTax: input.hasFTax }) }).beloppExclVatOre;
+        const grossOre = arvodeInclVatOre(netOre);
+        const vatOre = grossOre - netOre;
         const invoiceNumber = await repos.invoices.nextInvoiceNumber(ctx.orgId);
+        const notes = "Rådgivningstimme enligt rättshjälpstaxan (1 tim).";
         const invoice = await repos.invoices.create({
-          matterId: input.matterId,
-          invoiceNumber,
-          ocrReference: ocrFromInvoiceNumber(invoiceNumber),
-          amount: avgift.beloppExclVatOre,
-          invoiceType: "STANDARD",
-          status: "DRAFT",
-          invoiceDate: new Date(),
-          dueDate: null,
-          notes: "Rådgivningstimme enligt rättshjälpstaxan (1 tim).",
+          matterId: input.matterId, invoiceNumber, ocrReference: ocrFromInvoiceNumber(invoiceNumber),
+          amount: grossOre, vatOre, vatBreakdown: [{ kind: "arvode", vatRate: 2500, netOre, vatOre }],
+          invoiceType: "ACCONTO", status: "DRAFT", invoiceDate: new Date(), dueDate: null, notes,
         } satisfies Partial<Invoice>);
+        const run = await repos.billingRuns.create({
+          matterId: input.matterId, type: "ACCONTO", recipient: "KLIENT", status: "DRAFT",
+          workValueOreAtRun: grossOre, proposedAmountOre: grossOre, amountOre: grossOre,
+          invoiceId: invoice.id, deductedBillingRunIds: [], periodTo: new Date(), notes,
+        });
         await repos.matters.update(input.matterId, { radgivningBetaldAt: new Date() } satisfies Partial<Matter>);
         await emit.invoiceCreated(ctx, invoice);
-        return { invoice, beloppExclVatOre: avgift.beloppExclVatOre };
+        return { invoice, run, beloppExclVatOre: netOre };
       }),
     ),
 

--- a/test/unit/app/matters/billing-panel.test.tsx
+++ b/test/unit/app/matters/billing-panel.test.tsx
@@ -264,12 +264,11 @@ describe("BillingPanel — rådgivnings-banner (rättshjälp)", () => {
     expect(radgivningMutate).toHaveBeenCalledWith(expect.objectContaining({ matterId: "m1" }));
   });
 
-  it("RATTSHJALP med registrerad rådgivning → länk till fakturan + status, auto-skapar inte (#841)", () => {
-    invoiceListData = [{ id: "inv-rad", invoiceNumber: "F-2026-0012", status: "DRAFT", amount: 162600, payments: [] }];
+  it("RATTSHJALP med registrerad rådgivning → visar registrerad, auto-skapar inte (#851)", () => {
+    // Rådgivningen är nu ett ACCONTO som syns i faktura-listan (RunsList), inte
+    // en länk i banderollen.
     render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={{ ...baseMatter, paymentMethod: "RATTSHJALP", radgivningBetaldAt: "2026-01-05" }} />);
-    // Inte "Fakturerad" — fakturan är ett utkast; visa numret + faktisk status + länk.
-    expect(screen.getByText("F-2026-0012")).toBeInTheDocument();
-    expect(screen.getByText(/Utkast/)).toBeInTheDocument();
+    expect(screen.getByText(/Registrerad/)).toBeInTheDocument();
     expect(radgivningMutate).not.toHaveBeenCalled();
   });
 

--- a/test/unit/server/routers/invoice.test.ts
+++ b/test/unit/server/routers/invoice.test.ts
@@ -43,6 +43,12 @@ const mockPrisma = {
   invoiceAccontoDeduction: {
     create: vi.fn(),
   },
+  billingRun: {
+    create: vi.fn(),
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    update: vi.fn(),
+  },
   payment: {
     findMany: vi.fn(),
     create: vi.fn(),
@@ -98,20 +104,26 @@ describe("invoice.createRadgivning", () => {
   beforeEach(() => {
     mockPrisma.invoice.findFirst.mockResolvedValue(null); // nextInvoiceNumber → seq 1
     mockPrisma.invoice.create.mockImplementation(async (a: { data: Record<string, unknown> }) => ({ id: "rad-1", ...a.data }));
+    mockPrisma.billingRun.create.mockImplementation(async (a: { data: Record<string, unknown> }) => ({ id: "run-1", ...a.data }));
     mockPrisma.matter.update.mockResolvedValue({});
   });
 
-  it("skapar en separat STANDARD-klientfaktura för rådgivningstimmen + märker ärendet", async () => {
+  it("skapar ett ACCONTO (DRAFT) + billing-run för rådgivningstimmen + märker ärendet (#851)", async () => {
     mockPrisma.matter.findFirst.mockResolvedValue({ id: "m1", organizationId: "org-a", radgivningBetaldAt: null });
 
     const res = await makeCaller().createRadgivning({ matterId: "m1" });
 
-    // 1 tim × timkostnadsnorm (F-skatt default) = 162 600 öre.
+    // 1 tim × timkostnadsnorm (F-skatt default) = 162 600 netto; brutto = 203 250 (inkl 25 %).
     expect(res.beloppExclVatOre).toBe(162_600);
     const data = mockPrisma.invoice.create.mock.calls[0]![0].data;
-    expect(data.invoiceType).toBe("STANDARD");
-    expect(data.amount).toBe(162_600);
-    expect(data.status).toBe("DRAFT");
+    expect(data.invoiceType).toBe("ACCONTO");
+    expect(data.amount).toBe(203_250); // brutto (inkl moms) — som ett aconto
+    expect(data.status).toBe("DRAFT"); // DRAFT → dras ALDRIG av (additivt)
+    // Billing-run så det syns i ärendets faktura-lista.
+    const run = mockPrisma.billingRun.create.mock.calls[0]![0].data;
+    expect(run.type).toBe("ACCONTO");
+    expect(run.recipient).toBe("KLIENT");
+    expect(run.status).toBe("DRAFT");
     // Ärendet märks som registrerat.
     expect(mockPrisma.matter.update).toHaveBeenCalledWith(
       expect.objectContaining({ where: { id: "m1" }, data: expect.objectContaining({ radgivningBetaldAt: expect.any(Date) }) }),

--- a/tooling/demo-generator/populate-invoice-docs.ts
+++ b/tooling/demo-generator/populate-invoice-docs.ts
@@ -52,16 +52,20 @@ Datum: ${new Date(inv.invoiceDate).toLocaleDateString("sv-SE")}</p>
  *  GH Pages). Server-first (Postgres uuid-kolumn) skickar in en uuid-generator. */
 export type InvoiceDocIdFn = (invoiceId: string) => string;
 
-/** Fakturatyper som får ett genererat dokument: slutfakturor + rådgivnings-
- *  fakturan (STANDARD) så den syns i ärendets dokumentlista (#843). */
-const DOC_INVOICE_TYPES = new Set(["FINAL", "STANDARD"]);
+/** Får ett genererat dokument: slutfakturor (FINAL) + rådgivnings-fakturan, som
+ *  nu är ett ACCONTO (#851) men ska synas i dokumentlistan (#843). Övriga aconton
+ *  (självrisk) genererar inte dokument. */
+function shouldGenerateDoc(summary: Any): boolean {
+  if (summary.invoiceType === "FINAL") return true;
+  return String(summary.notes ?? "").startsWith("Rådgivningstimme");
+}
 
 export async function populateInvoiceDocs(caller: GeneratorCaller, sink?: BinarySink, idFor?: InvoiceDocIdFn): Promise<number> {
   const c = caller as Any;
   const invoices: Any[] = await c.invoice.list({});
   let count = 0;
   for (const summary of invoices) {
-    if (!DOC_INVOICE_TYPES.has(summary.invoiceType)) continue;
+    if (!shouldGenerateDoc(summary)) continue;
     const inv = await c.invoice.getById({ id: summary.id });
     const html = renderInvoiceHtml(inv);
     const id = idFor ? idFor(inv.id) : `invdoc-${inv.id}`;


### PR DESCRIPTION
Du ville att rådgivningstimmen ska vara en **aconto-faktura** i ärendets faktura-lista. Den skapades tidigare som en fristående STANDARD-klientfaktura och syntes därför inte i panelen (som visar billing-runs).

## Ändring
`createRadgivning` skapar nu ett **ACCONTO** (billing-run + faktura, recipient KLIENT) → syns som "Aconto" i faktura-listan. Beloppet lagras brutto (inkl moms) som ett vanligt aconto.

## Additivt — dras ALDRIG av (din andra punkt)
Acontot hålls i **DRAFT med flit**. Aconto-deduktionerna (`listAccontoSent` + panelens deduktions-val) kräver status **SENT**, så ett DRAFT-aconto exkluderas automatiskt från avdrag på slutfaktura. Ingen risk för dubbelräkning, och inget nytt schema-fält behövdes.

- Banderollen förenklas (status + hänvisning till listan; länken finns i listan nu).
- `populateInvoiceDocs` genererar fortsatt rådgivnings-dokumentet (matchar på noten, inte typen) → ingen regress av #843.

## Verifierat
- createRadgivning-test: ACCONTO/DRAFT-faktura (203 250 brutto) + ACCONTO/KLIENT/DRAFT billing-run.
- Panel/demo/invoice-docs-tester uppdaterade. typecheck, lint, knip, deps, duplicates, `bun run test` (3380+19), build:demo — gröna.

Refs #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)