### PR TITLE
feat(billing): generera fakturadokument vid slutreglering via template-motorn

### DIFF
--- a/src/app/matters/[id]/_settlement-dialog.tsx
+++ b/src/app/matters/[id]/_settlement-dialog.tsx
@@ -11,12 +11,15 @@
  * Skapar klient- + betalar-faktura och bokar ev. byrå-förlust.
  */
 
+import type { inferRouterOutputs } from "@trpc/server";
 import { useState } from "react";
 import { DecimalInput } from "@/components/ui/decimal-input";
 import { Modal } from "@/components/ui/modal";
+import { generateFakturaFromTemplate, type DocUtils, type FakturaDocMeta, type RegisterMut } from "@/lib/client/kostnadsrakning/generate-faktura-doc";
 import { trpc } from "@/lib/client/trpc";
 import { formatCurrency } from "@/lib/client/utils";
 import { useVatDisplay } from "@/lib/client/vat/vat-display-context";
+import type { AppRouter } from "@/lib/server/routers/_app";
 import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
 import type { PaymentMethod } from "@/lib/shared/schemas/enums";
 import type { MatterId } from "@/lib/shared/schemas/ids";
@@ -68,6 +71,34 @@ function SplitPreview({ data, payerLabel }: { data: SplitData; payerLabel: strin
   );
 }
 
+type SettleResult = inferRouterOutputs<AppRouter>["billingRun"]["settleCoverage"];
+type MatterDetail = inferRouterOutputs<AppRouter>["matter"]["getById"];
+type OrgSettings = inferRouterOutputs<AppRouter>["organization"]["getSettings"];
+
+/** Generera faktura-dokument (template-motorn) för klient- + betalar-fakturan
+ *  efter slutreglering (#852). Utbrutet så dialogen håller sig ≤8 i komplexitet. */
+function settlementMeta(matter: MatterDetail | undefined, org: OrgSettings | undefined): FakturaDocMeta {
+  const meta: FakturaDocMeta = { matterNumber: "", matterTitle: "" };
+  if (matter) { meta.matterNumber = matter.matterNumber; meta.matterTitle = matter.title; }
+  if (org?.name) meta.organizationName = org.name;
+  if (org?.orgNumber) meta.organizationOrgNumber = org.orgNumber;
+  return meta;
+}
+
+function clientNameOf(matter: MatterDetail | undefined): string {
+  return matter?.contacts?.find((c) => c.role === "KLIENT")?.contact?.name ?? "Klient";
+}
+
+async function generateSettlementDocs(res: SettleResult, opts: {
+  matterId: MatterId; matter: MatterDetail | undefined; org: OrgSettings | undefined;
+  payerLabel: string; register: RegisterMut; utils: DocUtils;
+}): Promise<void> {
+  const { matterId, matter, org, payerLabel, register, utils } = opts;
+  const meta = settlementMeta(matter, org);
+  await generateFakturaFromTemplate({ invoice: res.clientInvoice, matterId, recipient: clientNameOf(matter), meta, register, utils });
+  await generateFakturaFromTemplate({ invoice: res.payerInvoice, matterId, recipient: payerLabel, meta, register, utils });
+}
+
 /** Härleder alla metod-beroende texter/argument (håller komponenten ≤8). */
 function settlementConfig(isRattshjalp: boolean, matterId: MatterId, ore: number | undefined) {
   const payerRecipient = isRattshjalp ? ("RATTSHJALPSMYNDIGHET" as const) : ("FORSAKRING" as const);
@@ -89,8 +120,16 @@ export function SettlementDialog({ matterId, paymentMethod, onClose }: { matterI
   const cfg = settlementConfig(paymentMethod === "RATTSHJALP", matterId, ore);
   const split = trpc.billingRun.coverageSplit.useQuery(cfg.splitArg);
   const utils = trpc.useUtils();
+  const matterQ = trpc.matter.getById.useQuery({ id: matterId });
+  const orgQ = trpc.organization.getSettings.useQuery();
+  const register = trpc.document.register.useMutation();
   const settle = trpc.billingRun.settleCoverage.useMutation({
-    onSuccess: () => {
+    onSuccess: async (res) => {
+      // Generera faktura-DOKUMENT (via template-motorn, #852) för båda fakturorna
+      // → syns i fil-listan + länkas från faktura-objektet. Best-effort.
+      try {
+        await generateSettlementDocs(res, { matterId, matter: matterQ.data, org: orgQ.data, payerLabel: cfg.payerLabel, register, utils });
+      } catch (e) { console.warn("[settlement] fakturadokument misslyckades:", e); }
       void utils.billingRun.list.invalidate({ matterId });
       void utils.invoice.list.invalidate();
       onClose();

--- a/src/lib/client/kostnadsrakning/generate-faktura-doc.ts
+++ b/src/lib/client/kostnadsrakning/generate-faktura-doc.ts
@@ -55,6 +55,78 @@ export interface GenerateFakturaDocArgs {
   utils: DocUtils;
 }
 
+/** Inbyggd faktura-mall (Handlebars) — används av template-motorn (#852) när
+ *  ingen byrå-mall finns. HTML → öppningsbar + skrivbar. */
+const FAKTURA_TEMPLATE = `<!DOCTYPE html><html lang="sv"><head><meta charset="utf-8"><title>Faktura {{invoiceNumber}}</title></head>
+<body style="font-family:system-ui,sans-serif;max-width:720px;margin:2rem auto;color:#111">
+<h1 style="margin-bottom:0">Faktura</h1>
+<p style="color:#555">Fakturanr: {{invoiceNumber}}{{#if ocr}} · OCR: {{ocr}}{{/if}}<br>Datum: {{date}}</p>
+<p style="color:#555">Ärende {{matterNumber}} — {{matterTitle}}<br>Mottagare: {{recipient}}</p>
+<table cellpadding="6" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:14px;margin-top:1rem">
+<tbody>
+<tr><td>Netto (exkl moms)</td><td style="text-align:right">{{net}}</td></tr>
+<tr><td>Moms</td><td style="text-align:right">{{vat}}</td></tr>
+</tbody>
+<tfoot><tr style="border-top:2px solid #333"><td style="font-weight:bold">Att betala (inkl moms)</td><td style="text-align:right;font-weight:bold">{{total}}</td></tr></tfoot>
+</table>
+{{#if organizationName}}<p style="color:#777;font-size:13px;margin-top:1.5rem">{{organizationName}}{{#if organizationOrgNumber}} · {{organizationOrgNumber}}{{/if}}</p>{{/if}}
+</body></html>`;
+
+export interface GenerateFakturaFromTemplateArgs {
+  invoice: FakturaDocInvoice;
+  matterId: MatterId;
+  recipient: string;
+  meta: FakturaDocMeta;
+  register: RegisterMut;
+  utils: DocUtils;
+}
+
+/**
+ * Generera ett faktura-DOKUMENT via TEMPLATE-MOTORN (#852): renderar
+ * `FAKTURA_TEMPLATE` med Handlebars mot fakturans kontext → HTML, registrerar
+ * (documentType=Faktura, invoiceId) och persisterar bytes:erna. Används av
+ * slutreglerings-flödet så klient-/betalar-fakturorna får dokument i fil-listan
+ * + länk på faktura-objektet. `document.register` emittar inga events (ingen
+ * read-only-trap), funkar i demo + server.
+ */
+/** Handlebars-kontext för faktura-mallen (utbruten → håller generatorn ≤8). */
+function fakturaTemplateContext(
+  invoice: FakturaDocInvoice, recipient: string, meta: FakturaDocMeta,
+  formatCurrency: (ore: number) => string,
+): Record<string, unknown> {
+  const vatOre = invoice.vatOre ?? 0;
+  const date = (invoice.invoiceDate ? new Date(invoice.invoiceDate) : new Date()).toLocaleDateString("sv-SE");
+  return {
+    invoiceNumber: invoice.invoiceNumber ?? "—",
+    ocr: invoice.ocrReference ?? "",
+    date, matterNumber: meta.matterNumber, matterTitle: meta.matterTitle, recipient,
+    net: formatCurrency(invoice.amount - vatOre), vat: formatCurrency(vatOre), total: formatCurrency(invoice.amount),
+    organizationName: meta.organizationName ?? "", organizationOrgNumber: meta.organizationOrgNumber ?? "",
+  };
+}
+
+export async function generateFakturaFromTemplate(args: GenerateFakturaFromTemplateArgs): Promise<void> {
+  const { invoice, matterId, recipient, meta, register, utils } = args;
+  const { renderHandlebars } = await import("@/lib/client/kostnadsrakning/render-handlebars");
+  const { persistGeneratedDoc } = await import("@/lib/client/demo/persist-generated-doc");
+  const { formatCurrency } = await import("@/lib/client/utils");
+  const html = renderHandlebars(FAKTURA_TEMPLATE, fakturaTemplateContext(invoice, recipient, meta, formatCurrency));
+  const bytes = new TextEncoder().encode(html);
+  const docId = `faktura-${invoice.id}`;
+  const fileName = `Faktura ${invoice.invoiceNumber ?? meta.matterNumber} ${new Date().toISOString().slice(0, 10)}.html`;
+  const storagePath = `documents/content/${docId}.html`;
+  await register.mutateAsync({
+    id: asId<"DocumentId">(docId), matterId, fileName, mimeType: "text/html; charset=utf-8",
+    sizeBytes: bytes.byteLength, storagePath, documentType: "Faktura", invoiceId: invoice.id, analysisStatus: "DONE",
+  });
+  await persistGeneratedDoc({ id: docId, storagePath, fileName, mimeType: "text/html; charset=utf-8", bytes });
+  try {
+    await utils.document.tree.invalidate({ matterId });
+    await utils.document.tree.refetch({ matterId });
+    await utils.document.list.invalidate();
+  } catch { /* best-effort */ }
+}
+
 export async function generateFakturaDoc(args: GenerateFakturaDocArgs): Promise<void> {
   const { invoice, matterId, meta, register, utils } = args;
   const { renderFakturaPdf } = await import("@/lib/client/kostnadsrakning/render-faktura-pdf");

--- a/test/unit/lib/kostnadsrakning/generate-faktura-from-template.test.ts
+++ b/test/unit/lib/kostnadsrakning/generate-faktura-from-template.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Tester för generateFakturaFromTemplate (#852) — faktura-dokument via template-
+ * motorn (Handlebars): registrerar documentType=Faktura + invoiceId och renderar
+ * fakturanummer/mottagare/belopp i HTML:en.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest-compat";
+import { generateFakturaFromTemplate } from "@/lib/client/kostnadsrakning/generate-faktura-doc";
+import { asId } from "@/lib/shared/schemas/ids";
+
+const persistGeneratedDoc = vi.fn(async () => {});
+vi.mock("@/lib/client/demo/persist-generated-doc", () => ({ persistGeneratedDoc }));
+
+const registerMutateAsync = vi.fn(async () => {});
+const utils = {
+  document: {
+    tree: { invalidate: vi.fn(async () => {}), refetch: vi.fn(async () => {}) },
+    list: { invalidate: vi.fn(async () => {}) },
+  },
+};
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe("generateFakturaFromTemplate", () => {
+  it("registrerar Faktura-dokument (HTML) kopplat till invoiceId + renderar mall-data", async () => {
+    await generateFakturaFromTemplate({
+      invoice: { id: asId<"InvoiceId">("inv-9"), amount: 203_250, vatOre: 40_650, invoiceNumber: "F-2026-0099", invoiceDate: "2026-06-30" },
+      matterId: asId<"MatterId">("m1"),
+      recipient: "Staten",
+      meta: { matterNumber: "Ä-1", matterTitle: "Vårdnadstvist", organizationName: "Byrå AB" },
+      register: { mutateAsync: registerMutateAsync },
+      utils,
+    });
+    expect(registerMutateAsync).toHaveBeenCalledWith(expect.objectContaining({
+      matterId: "m1", documentType: "Faktura", invoiceId: "inv-9", mimeType: "text/html; charset=utf-8",
+    }));
+    expect(persistGeneratedDoc).toHaveBeenCalled();
+    const html = new TextDecoder().decode(persistGeneratedDoc.mock.calls[0]![0].bytes as Uint8Array);
+    expect(html).toContain("F-2026-0099"); // fakturanummer ur mallen
+    expect(html).toContain("Staten");      // mottagare
+    expect(html).toContain("Vårdnadstvist");
+  });
+});


### PR DESCRIPTION
Du rapporterade: i "Umgängestvist Carlsson" skapar "Skapa faktura" (Slutreglera ärende) faktura-objekten, MEN inga filer hamnar i fil-listan och inga länkar finns på faktura-objektet. Du ville att **template-motorn** används för att skapa dem.

## Orsak
`settleCoverage` skapar klient- + betalar-fakturorna server-side men genererade **inga dokument** (`onSuccess` invaliderade bara + stängde).

## Fix
`settleCoverage.onSuccess` genererar nu ett **faktura-dokument per faktura via template-motorn**:
- Ny `generateFakturaFromTemplate` — renderar en inbyggd `FAKTURA_TEMPLATE` med **`renderHandlebars`** (samma motor som "Generera dokument"), registrerar (documentType=Faktura, **invoiceId**) och persisterar bytes:erna.
- Dialogen hämtar matter/org för mall-kontexten; klient-fakturan får klientens namn, betalar-fakturan "Staten/Försäkringen".
- Dokumenten syns nu i ärendets fil-lista och länkas från faktura-objektet (`InvoiceDocumentsCard` listar på invoiceId).

## Verifierat
- Ny test: registrerar Faktura/HTML kopplat till invoiceId + renderar fakturanummer/mottagare/titel ur mallen.
- typecheck, lint, knip, deps, duplicates, `bun run test` (3381+19), build:demo — gröna.

Refs #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)