### PR TITLE
fix(billing): rådgivningstimmen är en riktig STANDARD-faktura (skickad)

### DIFF
--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -30,7 +30,7 @@ import { availableActions, currentPhase, type BillingAction, type BillingPhase, 
 import { availableKrActions, KOSTNADSRAKNING_STATUS_LABELS, type KostnadsrakningState, type KostnadsrakningStatus } from "@/lib/shared/kostnadsrakning-flow";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { computeRadgivningsavgift } from "@/lib/shared/rattshjalp";
-import { BILLING_RUN_TYPE_LABELS, BILLING_RUN_STATUS_LABELS, type BillingRunRecipient, type BillingRunStatus, type BillingRunType, type PaymentMethod } from "@/lib/shared/schemas/enums";
+import { BILLING_RUN_TYPE_LABELS, BILLING_RUN_STATUS_LABELS, INVOICE_STATUS_LABELS, type BillingRunRecipient, type BillingRunStatus, type BillingRunType, type PaymentMethod } from "@/lib/shared/schemas/enums";
 import type { BillingRunId, DocumentId, InvoiceId, MatterId } from "@/lib/shared/schemas/ids";
 import { BillingDialog, type BillingMeta } from "./_billing-dialog";
 import { KostnadsrakningModal } from "./_kostnadsrakning-modal";
@@ -68,6 +68,15 @@ interface BillingRunRow {
   kostnadsrakningStatus?: KostnadsrakningStatus | null;
   awardedOre?: number | null;
   beslutSlutgiltigt?: boolean | null;
+}
+
+/** Fristående klientfaktura (utan billing-run) som visas i faktura-listan (#853). */
+interface StandaloneInvoiceRow { id: InvoiceId; invoiceNumber?: string | null; status: string; amount: number }
+
+/** Fakturor som INTE är kopplade till en billing-run (t.ex. rådgivningstimmen). */
+function standaloneInvoices(invoices: StandaloneInvoiceRow[] | undefined, rows: BillingRunRow[]): StandaloneInvoiceRow[] {
+  const runInvoiceIds = new Set(rows.map((r) => String(r.invoiceId)).filter((id) => id !== "null" && id !== "undefined"));
+  return (invoices ?? []).filter((i) => !runInvoiceIds.has(String(i.id)));
 }
 
 interface KrDocInfo { id: DocumentId; fileName: string; storagePath: string | null }
@@ -369,6 +378,9 @@ export function BillingPanel({ matterId, matter }: Props) {
   const [verdictRunId, setVerdictRunId] = useState<BillingRunId | null>(null);
   const [beslutRunId, setBeslutRunId] = useState<BillingRunId | null>(null);
   const rows = (runs.data?.runs ?? []) as BillingRunRow[];
+  // Fristående klientfakturor (#853) — t.ex. rådgivningstimmen (STANDARD, ingen
+  // billing-run). Visas i faktura-listan utöver billing-runs.
+  const standalone = standaloneInvoices(trpc.invoice.list.useQuery({ matterId }).data as StandaloneInvoiceRow[] | undefined, rows);
   // Aktiv kostnadsräkning (#828): KR vars livscykel inte är klar (≠ FAKTURERAD).
   const activeKr = rows.find((r) => r.type === "KOSTNADSRAKNING" && !!r.kostnadsrakningStatus && r.kostnadsrakningStatus !== "FAKTURERAD");
   // Flödesmodellen (#816) styr menyn + dom-bannern: fasen härleds ur runs+matter
@@ -406,7 +418,7 @@ export function BillingPanel({ matterId, matter }: Props) {
         onOverklaga={() => appeal.mutate({ billingRunId: activeKr.id })}
         onSkapaFaktura={() => matter.paymentMethod === "RATTSHJALP" ? setShowSettle(true) : setVerdictRunId(activeKr.id)} />}
       {beslutRunId && <RecordBeslutDialog billingRunId={beslutRunId} onClose={() => setBeslutRunId(null)} onDone={refetch} />}
-      <RunsList matterId={matterId} rows={rows} loading={runs.isLoading} />
+      <RunsList matterId={matterId} rows={rows} standalone={standalone} loading={runs.isLoading} />
       <BillingDialogs matterId={matterId} matter={matter} rows={rows}
         dialog={dialog} setDialog={setDialog}
         verdictRunId={verdictRunId} setVerdictRunId={setVerdictRunId}
@@ -619,13 +631,13 @@ function BillingActions({ actions, onPick }: { actions: readonly BillingAction[]
   );
 }
 
-function RunsList({ matterId, rows, loading }: { matterId: MatterId; rows: BillingRunRow[]; loading: boolean }) {
+function RunsList({ matterId, rows, standalone, loading }: { matterId: MatterId; rows: BillingRunRow[]; standalone: StandaloneInvoiceRow[]; loading: boolean }) {
   // Dokumentlistan hämtas en gång → KOSTNADSRAKNING-raden kan länka till sitt
   // KR-dokument (#843). utils.client krävs för openKrDoc:s server-hämtning.
   const docs = trpc.document.list.useQuery({ matterId, folderId: null, pageSize: 100 }).data?.documents ?? [];
   const utils = trpc.useUtils();
   if (loading) return <p className="px-6 py-3 text-sm text-gray-500">Laddar…</p>;
-  if (rows.length === 0) return <p className="px-6 py-3 text-sm text-gray-500">Inga billing-runs ännu.</p>;
+  if (rows.length === 0 && standalone.length === 0) return <p className="px-6 py-3 text-sm text-gray-500">Inga fakturor ännu.</p>;
   return (
     <div className="px-6 py-2">
       <table className="min-w-full text-sm">
@@ -661,6 +673,20 @@ function RunsList({ matterId, rows, loading }: { matterId: MatterId; rows: Billi
             </tr>
             );
           })}
+          {/* Fristående klientfakturor utan billing-run (#853), t.ex. rådgivningstimmen. */}
+          {standalone.map((inv) => (
+            <tr key={inv.id}>
+              <td className="py-2 text-sm">Faktura</td>
+              <td className="text-sm text-gray-600">KLIENT</td>
+              <td className="text-sm">{INVOICE_STATUS_LABELS[inv.status as keyof typeof INVOICE_STATUS_LABELS] ?? inv.status}</td>
+              <td className="text-right text-sm font-mono"><Money ore={inv.amount} basis="gross" /></td>
+              <td className="text-right whitespace-nowrap">
+                <EntityLink route="invoices" id={inv.id} className="text-xs text-blue-600 hover:underline">
+                  {inv.invoiceNumber ?? "Faktura"}
+                </EntityLink>
+              </td>
+            </tr>
+          ))}
         </tbody>
       </table>
     </div>

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -123,8 +123,7 @@ export const invoiceRouter = router({
    */
   createRadgivning: orgProcedure
     .input(z.object({ matterId: matterIdSchema, hasFTax: z.boolean().optional() }))
-    // Migrerad till repository-sömmen (ADR 0020): matters + invoices + billing-runs
-    // via typade repos i transaktionen.
+    // Migrerad till repository-sömmen (ADR 0020): matters + invoices via typade repos.
     .mutation(({ ctx, input }) =>
       ctx.repos.transaction(async (repos) => {
         const matter = await repos.matters.getByIdInOrg(input.matterId, ctx.orgId);
@@ -132,24 +131,22 @@ export const invoiceRouter = router({
         if ((matter as { radgivningBetaldAt?: unknown }).radgivningBetaldAt) {
           throw new TRPCError({ code: "BAD_REQUEST", message: "Rådgivningstimmen är redan registrerad för detta ärende." });
         }
+        // Rådgivningstimmen är en RIKTIG klientfaktura (STANDARD), inte ett aconto
+        // (#853): ärendets första händelse, betalas direkt av klienten → skapas
+        // SKICKAD. Brutto (inkl moms) som alla klientfakturor. Dras ALDRIG av.
         const netOre = computeRadgivningsavgift({ ...omitUndefined({ hasFTax: input.hasFTax }) }).beloppExclVatOre;
         const grossOre = arvodeInclVatOre(netOre);
         const vatOre = grossOre - netOre;
         const invoiceNumber = await repos.invoices.nextInvoiceNumber(ctx.orgId);
-        const notes = "Rådgivningstimme enligt rättshjälpstaxan (1 tim).";
         const invoice = await repos.invoices.create({
           matterId: input.matterId, invoiceNumber, ocrReference: ocrFromInvoiceNumber(invoiceNumber),
           amount: grossOre, vatOre, vatBreakdown: [{ kind: "arvode", vatRate: 2500, netOre, vatOre }],
-          invoiceType: "ACCONTO", status: "DRAFT", invoiceDate: new Date(), dueDate: null, notes,
+          invoiceType: "STANDARD", status: "SENT", invoiceDate: new Date(), dueDate: null,
+          notes: "Rådgivningstimme enligt rättshjälpstaxan (1 tim).",
         } satisfies Partial<Invoice>);
-        const run = await repos.billingRuns.create({
-          matterId: input.matterId, type: "ACCONTO", recipient: "KLIENT", status: "DRAFT",
-          workValueOreAtRun: grossOre, proposedAmountOre: grossOre, amountOre: grossOre,
-          invoiceId: invoice.id, deductedBillingRunIds: [], periodTo: new Date(), notes,
-        });
         await repos.matters.update(input.matterId, { radgivningBetaldAt: new Date() } satisfies Partial<Matter>);
         await emit.invoiceCreated(ctx, invoice);
-        return { invoice, run, beloppExclVatOre: netOre };
+        return { invoice, beloppExclVatOre: netOre };
       }),
     ),
 

--- a/test/unit/app/matters/billing-panel.test.tsx
+++ b/test/unit/app/matters/billing-panel.test.tsx
@@ -115,7 +115,7 @@ describe("BillingPanel — översikt", () => {
   it("renderar rubrik och tomtext utan runs", () => {
     render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={baseMatter} />);
     expect(screen.getByText("Fakturering")).toBeInTheDocument();
-    expect(screen.getByText("Inga billing-runs ännu.")).toBeInTheDocument();
+    expect(screen.getByText("Inga fakturor ännu.")).toBeInTheDocument();
   });
 
   it("visar laddtext medan runs hämtas", () => {
@@ -132,6 +132,14 @@ describe("BillingPanel — översikt", () => {
     };
     render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={baseMatter} />);
     expect(screen.getByText("F-1")).toBeInTheDocument();
+  });
+
+  it("fristående klientfaktura (rådgivning, ingen run) visas i faktura-listan (#853)", () => {
+    runsData = { runs: [] };
+    invoiceListData = [{ id: "inv-rad", invoiceNumber: "F-2026-0012", status: "SENT", amount: 203_250, payments: [] }];
+    render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={baseMatter} />);
+    expect(screen.getByText("F-2026-0012")).toBeInTheDocument(); // länk i listan
+    expect(screen.getByText(/Skickad/)).toBeInTheDocument(); // status-etikett
   });
 });
 

--- a/test/unit/server/routers/invoice.test.ts
+++ b/test/unit/server/routers/invoice.test.ts
@@ -108,7 +108,7 @@ describe("invoice.createRadgivning", () => {
     mockPrisma.matter.update.mockResolvedValue({});
   });
 
-  it("skapar ett ACCONTO (DRAFT) + billing-run för rådgivningstimmen + märker ärendet (#851)", async () => {
+  it("skapar en STANDARD-klientfaktura (SKICKAD) för rådgivningstimmen + märker ärendet (#853)", async () => {
     mockPrisma.matter.findFirst.mockResolvedValue({ id: "m1", organizationId: "org-a", radgivningBetaldAt: null });
 
     const res = await makeCaller().createRadgivning({ matterId: "m1" });
@@ -116,14 +116,11 @@ describe("invoice.createRadgivning", () => {
     // 1 tim × timkostnadsnorm (F-skatt default) = 162 600 netto; brutto = 203 250 (inkl 25 %).
     expect(res.beloppExclVatOre).toBe(162_600);
     const data = mockPrisma.invoice.create.mock.calls[0]![0].data;
-    expect(data.invoiceType).toBe("ACCONTO");
-    expect(data.amount).toBe(203_250); // brutto (inkl moms) — som ett aconto
-    expect(data.status).toBe("DRAFT"); // DRAFT → dras ALDRIG av (additivt)
-    // Billing-run så det syns i ärendets faktura-lista.
-    const run = mockPrisma.billingRun.create.mock.calls[0]![0].data;
-    expect(run.type).toBe("ACCONTO");
-    expect(run.recipient).toBe("KLIENT");
-    expect(run.status).toBe("DRAFT");
+    expect(data.invoiceType).toBe("STANDARD"); // riktig faktura, inte aconto
+    expect(data.amount).toBe(203_250); // brutto (inkl moms)
+    expect(data.status).toBe("SENT"); // ärendets första händelse, går ut direkt
+    // Ingen billing-run skapas (det är en fristående klientfaktura).
+    expect(mockPrisma.billingRun.create).not.toHaveBeenCalled();
     // Ärendet märks som registrerat.
     expect(mockPrisma.matter.update).toHaveBeenCalledWith(
       expect.objectContaining({ where: { id: "m1" }, data: expect.objectContaining({ radgivningBetaldAt: expect.any(Date) }) }),

--- a/tooling/demo-generator/populate-billing.ts
+++ b/tooling/demo-generator/populate-billing.ts
@@ -194,10 +194,11 @@ async function runKostnadsrakning(ctx: Ctx, matterId: string, withVerdict: boole
  * testas — fakturasteget görs av användaren.
  */
 async function runRattshjalpBilling(ctx: Ctx, matterId: string, daysAgo: number, stage: "INSKICKAD" | "BESLUTAD"): Promise<void> {
-  // Rådgivningstimmen (ärendets första timme) debiteras alltid klienten i
-  // rättshjälp (#839) — separat klientfaktura, oberoende av domstolens KR.
-  await ctx.c.invoice.createRadgivning({ matterId });
-  ctx.res.invoices++;
+  // Rådgivningstimmen (ärendets FÖRSTA händelse) är en riktig STANDARD-klient-
+  // faktura som skapas SKICKAD och betalas direkt (#853) — separat från KR:n.
+  const radg = await ctx.c.invoice.createRadgivning({ matterId });
+  await ctx.c.invoice.recordPayment({ invoiceId: radg.invoice.id, amount: radg.invoice.amount, paidAt: isoDaysAgo(daysAgo + 25), note: "Betald av klient" });
+  ctx.res.invoices++; ctx.res.payments++;
   await acconto(ctx, matterId, 3000, 150_000, daysAgo);
   const kr = await ctx.c.billingRun.createKostnadsrakning({ matterId, notes: "Kostnadsräkning till domstol (rättshjälp)" });
   ctx.res.kostnadsrakningPending++;


### PR DESCRIPTION
Rättelse: rådgivningstimmen är **inte** ett aconto (vänder #851) utan en **riktig klientfaktura** — ärendets första händelse, betalas direkt av klienten. Den ska stå som skickad.

## Ändring (del 1 av 3 från din spec)
- `createRadgivning` skapar nu en **STANDARD-faktura, status SENT** (brutto inkl moms), ingen billing-run.
- Faktura-listan i panelen visar nu även **fristående klientfakturor** (utan billing-run) → rådgivningsfakturan syns där (länk + status). Banderollen visar status.
- Demon: rådgivningen skapas skickad + en **betalning registreras** (Carlsson visar den som betald). `populateInvoiceDocs` matchar fortsatt på noten → dokumentet finns kvar.

Återstår (kommer som separata PR:er): (2) självrisk-aconto med konfigurerbar tröskel (~1500 kr) + manuell knapp, (3) slutfaktura till DOMSTOL med klient-acontot avdraget.

## Verifierat
- createRadgivning-test: STANDARD/SENT, ingen billing-run. Ny panel-test: fristående faktura syns i listan.
- typecheck, lint, knip, deps, duplicates, `bun run test` (3382+19), build:demo — gröna.

Refs #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)