### PR TITLE
feat(billing): självrisk-aconto-hint vid tröskel + rådgivning skickad i demon

### DIFF
--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -29,7 +29,7 @@ import type { AppRouter } from "@/lib/server/routers/_app";
 import { availableActions, currentPhase, type BillingAction, type BillingPhase, type FlowMatter } from "@/lib/shared/billing-flow";
 import { availableKrActions, KOSTNADSRAKNING_STATUS_LABELS, type KostnadsrakningState, type KostnadsrakningStatus } from "@/lib/shared/kostnadsrakning-flow";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
-import { computeRadgivningsavgift } from "@/lib/shared/rattshjalp";
+import { computeRadgivningsavgift, SJALVRISK_ACCONTO_THRESHOLD_ORE } from "@/lib/shared/rattshjalp";
 import { BILLING_RUN_TYPE_LABELS, BILLING_RUN_STATUS_LABELS, INVOICE_STATUS_LABELS, type BillingRunRecipient, type BillingRunStatus, type BillingRunType, type PaymentMethod } from "@/lib/shared/schemas/enums";
 import type { BillingRunId, DocumentId, InvoiceId, MatterId } from "@/lib/shared/schemas/ids";
 import { BillingDialog, type BillingMeta } from "./_billing-dialog";
@@ -413,6 +413,7 @@ export function BillingPanel({ matterId, matter }: Props) {
       </div>
       <BillingSummary matterId={matterId} />
       <RadgivningBanner matterId={matterId} matter={matter} onRecorded={refetch} />
+      <SjalvriskAccontoHint matterId={matterId} matter={matter} rows={rows} />
       {activeKr && <KostnadsrakningCard matterId={matterId} run={activeKr}
         onRegistreraBeslut={() => setBeslutRunId(activeKr.id)}
         onOverklaga={() => appeal.mutate({ billingRunId: activeKr.id })}
@@ -474,10 +475,31 @@ function RadgivningBanner({ matterId, matter, onRecorded }: { matterId: MatterId
         <strong>Rådgivningstimme (rättshjälp)</strong> — klientens 1 tim enligt rättshjälpstaxan,{" "}
         <span className="font-mono">{formatCurrency(avgift.beloppExclVatOre)}</span> exkl moms, faktureras separat till klienten.
       </div>
-      {/* Rådgivningen är nu ett ACCONTO som syns i faktura-listan nedan (#851). */}
+      {/* Rådgivningen är en riktig faktura som syns i faktura-listan nedan (#853). */}
       <span className="text-xs whitespace-nowrap text-blue-700">
-        {registered ? "✓ Registrerad (se aconto nedan)" : create.error ? "Kunde inte skapas" : "Skapas automatiskt…"}
+        {registered ? "✓ Fakturerad (se faktura nedan)" : create.error ? "Kunde inte skapas" : "Skapas automatiskt…"}
       </span>
+    </div>
+  );
+}
+
+/**
+ * Självrisk-aconto-hint (#854): när klientens ackumulerade självrisk (rättshjälp)
+ * nått tröskeln flaggar vi att det är dags att skicka ett aconto. Acontot skapas
+ * via "+ Skapa faktura → Aconto till klient" (finns redan). Self-gating.
+ */
+function SjalvriskAccontoHint({ matterId, matter, rows }: { matterId: MatterId; matter: MatterContext; rows: BillingRunRow[] }) {
+  const isRattshjalp = matter.paymentMethod === "RATTSHJALP";
+  const split = trpc.billingRun.coverageSplit.useQuery({ matterId }, { enabled: isRattshjalp }).data;
+  if (!isRattshjalp || !split) return null;
+  const hasSjalvriskAconto = rows.some((r) => r.type === "ACCONTO" && r.recipient === "KLIENT");
+  if (hasSjalvriskAconto || split.clientOre < SJALVRISK_ACCONTO_THRESHOLD_ORE) return null;
+  return (
+    <div className="mx-6 mb-4 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+      Klientens självrisk har nått{" "}
+      <span className="font-mono font-semibold">{formatCurrency(split.clientOre)}</span>{" "}
+      (tröskel {formatCurrency(SJALVRISK_ACCONTO_THRESHOLD_ORE)}) — dags att skicka ett självrisk-aconto via
+      {" "}<strong>+ Skapa faktura → Aconto till klient</strong>.
     </div>
   );
 }

--- a/src/lib/shared/rattshjalp.ts
+++ b/src/lib/shared/rattshjalp.ts
@@ -19,6 +19,14 @@ import { computeTimkostnadsnorm } from "@/lib/shared/brottmalstaxa";
 /** Rådgivning enligt rättshjälpslagen = 1 timme. */
 export const RADGIVNING_MINUTES = 60;
 
+/**
+ * Tröskel (öre) för klientens självrisk innan ett självrisk-aconto skickas (#854):
+ * när den ackumulerade självrisken nått hit flaggar panelen att det är dags att
+ * skicka ett aconto till klienten. Default 1500 kr.
+ * ponytail: konstant nu; flytta till byrå-inställning om byråer vill olika tröskel.
+ */
+export const SJALVRISK_ACCONTO_THRESHOLD_ORE = 150_000;
+
 export interface Radgivningsavgift {
   /** Antal minuter (alltid 60 — en rådgivningstimme). */
   minutes: number;

--- a/test/unit/app/matters/[id]/page.test.tsx
+++ b/test/unit/app/matters/[id]/page.test.tsx
@@ -94,6 +94,7 @@ vi.mock("@/lib/client/trpc", () => ({
       setVerdict: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
       appealKostnadsrakning: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
       recordKostnadsrakningBeslut: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      coverageSplit: { useQuery: () => ({ data: undefined }) },
     },
     invoice: {
       // #819: BillingPanel → BillingSummary summerar Fakturerat/Betalt ur list.

--- a/test/unit/app/matters/billing-panel.test.tsx
+++ b/test/unit/app/matters/billing-panel.test.tsx
@@ -26,6 +26,7 @@ interface ProposalData { workValueOre: number; priorAccontoSumOre: number; timeE
 let proposalData: ProposalData = { workValueOre: 0, priorAccontoSumOre: 0, timeEntries: [], expenses: [] };
 interface InvoiceRow { id: string; amount: number; status: string; payments: Array<{ amount: number }>; invoiceNumber?: string }
 let invoiceListData: InvoiceRow[] = [];
+let coverageSplitData: { clientOre: number } | undefined = undefined;
 const refetch = vi.fn();
 const radgivningMutate = vi.fn();
 const krMutate = vi.fn();
@@ -49,6 +50,7 @@ vi.mock("@/lib/client/trpc", () => ({
       createKostnadsrakning: { useMutation: () => ({ mutate: krMutate, isPending: false }) },
       appealKostnadsrakning: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
       recordKostnadsrakningBeslut: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      coverageSplit: { useQuery: () => ({ data: coverageSplitData }) },
     },
     organization: {
       getSettings: { useQuery: () => ({ data: { name: "Byrå AB", orgNumber: "556677-8899", address: "Storgatan 1" } }) },
@@ -108,6 +110,7 @@ beforeEach(() => {
   documentListData = { documents: [] };
   proposalData = { workValueOre: 0, priorAccontoSumOre: 0, timeEntries: [], expenses: [] };
   invoiceListData = [];
+  coverageSplitData = undefined;
   hasDoc = false;
 });
 
@@ -276,8 +279,20 @@ describe("BillingPanel — rådgivnings-banner (rättshjälp)", () => {
     // Rådgivningen är nu ett ACCONTO som syns i faktura-listan (RunsList), inte
     // en länk i banderollen.
     render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={{ ...baseMatter, paymentMethod: "RATTSHJALP", radgivningBetaldAt: "2026-01-05" }} />);
-    expect(screen.getByText(/Registrerad/)).toBeInTheDocument();
+    expect(screen.getByText(/Fakturerad/)).toBeInTheDocument();
     expect(radgivningMutate).not.toHaveBeenCalled();
+  });
+
+  it("självrisk-aconto-hint visas när självrisken nått tröskeln (#854)", () => {
+    coverageSplitData = { clientOre: 160_000 }; // > 150 000 (tröskel)
+    render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={{ ...baseMatter, paymentMethod: "RATTSHJALP", radgivningBetaldAt: "2026-01-05" }} />);
+    expect(screen.getByText(/Klientens självrisk har nått/)).toBeInTheDocument();
+  });
+
+  it("ingen hint under tröskeln", () => {
+    coverageSplitData = { clientOre: 100_000 }; // < 150 000
+    render(<BillingPanel matterId={asId<"MatterId">("m1")} matter={{ ...baseMatter, paymentMethod: "RATTSHJALP", radgivningBetaldAt: "2026-01-05" }} />);
+    expect(screen.queryByText(/Klientens självrisk har nått/)).not.toBeInTheDocument();
   });
 
   it("icke-rättshjälp → ingen rådgivnings-banner", () => {

--- a/tooling/demo-generator/populate-billing.ts
+++ b/tooling/demo-generator/populate-billing.ts
@@ -195,10 +195,9 @@ async function runKostnadsrakning(ctx: Ctx, matterId: string, withVerdict: boole
  */
 async function runRattshjalpBilling(ctx: Ctx, matterId: string, daysAgo: number, stage: "INSKICKAD" | "BESLUTAD"): Promise<void> {
   // Rådgivningstimmen (ärendets FÖRSTA händelse) är en riktig STANDARD-klient-
-  // faktura som skapas SKICKAD och betalas direkt (#853) — separat från KR:n.
-  const radg = await ctx.c.invoice.createRadgivning({ matterId });
-  await ctx.c.invoice.recordPayment({ invoiceId: radg.invoice.id, amount: radg.invoice.amount, paidAt: isoDaysAgo(daysAgo + 25), note: "Betald av klient" });
-  ctx.res.invoices++; ctx.res.payments++;
+  // faktura som skapas SKICKAD (#853) — separat från KR:n.
+  await ctx.c.invoice.createRadgivning({ matterId });
+  ctx.res.invoices++;
   await acconto(ctx, matterId, 3000, 150_000, daysAgo);
   const kr = await ctx.c.billingRun.createKostnadsrakning({ matterId, notes: "Kostnadsräkning till domstol (rättshjälp)" });
   ctx.res.kostnadsrakningPending++;


### PR DESCRIPTION
PR 2 av din spec.

## Självrisk-aconto-hint
När klientens ackumulerade självrisk (rättshjälp) nått tröskeln (`SJALVRISK_ACCONTO_THRESHOLD_ORE`, default **1500 kr**) visar panelen en hint: "Klientens självrisk har nått X — dags att skicka ett självrisk-aconto". Acontot skapas via den **befintliga** "+ Skapa faktura → Aconto till klient"-åtgärden (fanns redan i rättshjälps-flödet).

Tröskeln är en delad konstant nu (ponytail-kommentar markerar var den flyttas till en byrå-inställning om byråer vill ha olika tröskel).

## SENT (#853-uppföljning)
Du sa "skall stå som skickad" — demon skapar nu rådgivningsfakturan **SENT** (tog bort den auto-registrerade betalningen), så den står som skickad i st.f. betald.

## Verifierat
- Nya panel-tester: hint visas över tröskeln, döljs under. typecheck, lint, knip, deps, duplicates, `bun run test` (3384+19), build:demo — gröna.

Återstår: **PR 3** — slutfaktura till DOMSTOL med klient-acontot avdraget (jag återkommer med en fråga om exakt avräknings-aritmetik).

Refs #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)