### PR TITLE
feat(billing): rättshjälp slutfaktura till domstol + auto-avdrag av klient-aconton

### DIFF
--- a/src/app/matters/[id]/_settlement-dialog.tsx
+++ b/src/app/matters/[id]/_settlement-dialog.tsx
@@ -101,11 +101,12 @@ async function generateSettlementDocs(res: SettleResult, opts: {
 
 /** Härleder alla metod-beroende texter/argument (håller komponenten ≤8). */
 function settlementConfig(isRattshjalp: boolean, matterId: MatterId, ore: number | undefined) {
-  const payerRecipient = isRattshjalp ? ("RATTSHJALPSMYNDIGHET" as const) : ("FORSAKRING" as const);
+  // Rättshjälp: slutfakturan går till DOMSTOL (#856), inte rättshjälpsmyndigheten.
+  const payerRecipient = isRattshjalp ? ("DOMSTOL" as const) : ("FORSAKRING" as const);
   return {
     payerRecipient,
     fieldLabel: isRattshjalp ? "Dömt belopp (kr)" : "Försäkringens prutning (kr)",
-    payerLabel: isRattshjalp ? "Staten betalar" : "Försäkringen betalar",
+    payerLabel: isRattshjalp ? "Domstolen betalar" : "Försäkringen betalar",
     help: isRattshjalp
       ? "Ange beloppet domen beviljade. Byrån bär eventuell prutning; klientens självrisk räknas på det beviljade beloppet."
       : "Ange försäkringsbolagets prutning ur beskedet. Klienten tar mellanskillnaden (självrisk + prutning).",

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -799,8 +799,12 @@ export const billingRunRouter = router({
         const { clientLines, payerLines } = coverageInvoiceLines(split, work);
 
         // Klient: självrisk (+ ev. prutning), moms 25 %, minus tidigare aconton.
+        // Auto-dra av ALLA skickade klient-aconton (#856): de har redan betalats,
+        // så slutfakturan reduceras med dem (utöver ev. explicit valda).
+        const sentAccontoIds = (await tx.billingRuns.listAccontoSent(input.matterId)).map((r) => r.id);
+        const deductIds = [...new Set([...input.deductedBillingRunIds, ...sentAccontoIds])];
         const clientGross = grossOreOf(clientLines);
-        const deductedRuns = await fetchDeductedAccontoRuns(tx, input.matterId, input.deductedBillingRunIds);
+        const deductedRuns = await fetchDeductedAccontoRuns(tx, input.matterId, deductIds);
         const deductionOre = deductedRuns.reduce((s, r) => s + (r.amountOre ?? 0), 0);
         const clientAmount = Math.max(0, clientGross - deductionOre);
         const payerGross = grossOreOf(payerLines);
@@ -817,7 +821,7 @@ export const billingRunRouter = router({
         const clientRun = await tx.billingRuns.create({
           matterId: input.matterId, type: "FINAL", recipient: "KLIENT", status: "SENT",
           workValueOreAtRun: clientGross, proposedAmountOre: clientGross, amountOre: clientAmount,
-          invoiceId: clientInvoice.id, deductedBillingRunIds: input.deductedBillingRunIds, periodTo: new Date(), notes: input.notes,
+          invoiceId: clientInvoice.id, deductedBillingRunIds: deductIds, periodTo: new Date(), notes: input.notes,
         });
         const payerRun = await bookPayerRun(tx, {
           matterId: input.matterId, payerRecipient: input.payerRecipient, payerInvoiceId: payerInvoice.id,

--- a/src/lib/shared/billing-flow.ts
+++ b/src/lib/shared/billing-flow.ts
@@ -91,10 +91,10 @@ export const BILLING_FLOWS: Record<PaymentMethod, BillingFlow> = {
       ARBETE: [
         aconto(),
         { type: "KOSTNADSRAKNING", label: "Kostnadsräkning till domstol", toPhase: "VANTAR_DOM", recipient: "DOMSTOL", dialog: "kostnadsrakning" },
-        { type: "SETTLE", label: "Slutreglera (dom)", toPhase: "SLUTREGLERAD", recipient: "RATTSHJALPSMYNDIGHET", dialog: "settlement" },
+        { type: "SETTLE", label: "Slutreglera (dom)", toPhase: "SLUTREGLERAD", recipient: "DOMSTOL", dialog: "settlement" },
       ],
       VANTAR_DOM: [
-        { type: "SETTLE", label: "Slutreglera (dom)", toPhase: "SLUTREGLERAD", recipient: "RATTSHJALPSMYNDIGHET", dialog: "settlement" },
+        { type: "SETTLE", label: "Slutreglera (dom)", toPhase: "SLUTREGLERAD", recipient: "DOMSTOL", dialog: "settlement" },
       ],
       SLUTREGLERAD: [],
     },

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -483,6 +483,16 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
     expect(prutning.billable).toBe(false);
   });
 
+  it("rättshjälp: skickade klient-aconton dras AUTO av från klientfakturan; betalare = DOMSTOL (#856)", async () => {
+    const { caller: c } = caller({ paymentMethod: "RATTSHJALP", clientShareBips: 2000, taxaHasFTax: true }, 999999, 180);
+    const ac = await c.billingRun.createAcconto({ matterId: "m-1", clientShareBips: 2000, amountOre: 50000 }); // SENT aconto
+    const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "DOMSTOL" });
+    // Klientens självrisk 20 % × 325 200 = 65 040 netto → ×1,25 = 81 300; minus aconto 50 000 = 31 300.
+    expect(res.clientInvoice.amount).toBe(31_300);
+    expect(res.clientRun.deductedBillingRunIds).toContain(ac.run.id); // auto-avdraget
+    expect(res.payerRun.recipient).toBe("DOMSTOL"); // slutfaktura till domstol
+  });
+
   it("rättshjälp via KR (#828): kräver registrerat beslut; domsbeloppet läses från KR:n; KR konsumeras EJ utan markeras FAKTURERAD", async () => {
     const { ds, caller: c } = caller({ paymentMethod: "RATTSHJALP", clientShareBips: 2000, taxaHasFTax: true }, 999999, 180);
     const kr = await c.billingRun.createKostnadsrakning({ matterId: "m-1" });


### PR DESCRIPTION
## Vad

Del 3 av rättshjälps-faktureringsflödet (efter rådgivning STANDARD/SENT och slutregleringens utlägg-fix).

- **Slutfakturan går till DOMSTOL**, inte rättshjälpsmyndigheten. `billing-flow.ts` SETTLE-recipient + `_settlement-dialog.tsx` `payerRecipient`/`payerLabel` → `DOMSTOL` / "Domstolen betalar". Klient/stat-uppdelningen behålls.
- **Auto-avdrag av skickade självrisk-aconton**: alla `SENT` KLIENT-aconton dras automatiskt av från klientens slutfaktura via `listAccontoSent`, så en synlig aconto inte dubbelfaktureras vid slutregleringen.

## Test

- Nytt test i `billingRun.test.ts`: skickade klient-aconton dras AUTO av; betalare = DOMSTOL.
- Full svit grön (3385 pass), typecheck/lint/knip/deps/duplicates/build:demo grönt.

Refs #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)