### PR TITLE
feat(billing): fakturaspecifikation — tider, utlägg + avdragna aconton

### DIFF
--- a/src/app/matters/[id]/_billing-dialog.tsx
+++ b/src/app/matters/[id]/_billing-dialog.tsx
@@ -16,6 +16,7 @@ import { DecimalInput } from "@/components/ui/decimal-input";
 import { Modal } from "@/components/ui/modal";
 import {
   generateFakturaDoc,
+  generateFakturaFromTemplate,
   type FakturaDocInvoice,
   type FakturaDocMeta,
 } from "@/lib/client/kostnadsrakning/generate-faktura-doc";
@@ -58,19 +59,43 @@ function titleFor(type: string): string {
   return "Faktura";
 }
 
-/** Återanvändbar doc-generator: lägg ett faktura-PDF-dokument i fil-listan. */
-function useFakturaDoc(matterId: MatterId, meta: BillingMeta): (invoice: FakturaDocInvoice) => Promise<void> {
-  const register = trpc.document.register.useMutation();
-  const utils = trpc.useUtils();
-  const docMeta: FakturaDocMeta = {
+function docMetaFrom(meta: BillingMeta): FakturaDocMeta {
+  return {
     matterNumber: meta.matterNumber, matterTitle: meta.matterTitle,
     ...(meta.clientName ? { clientName: meta.clientName } : {}),
     ...(meta.organizationName ? { organizationName: meta.organizationName } : {}),
     ...(meta.organizationOrgNumber ? { organizationOrgNumber: meta.organizationOrgNumber } : {}),
   };
+}
+
+function recipientLabel(recipient: string, clientName?: string): string {
+  if (recipient === "KLIENT") return clientName ?? "Klient";
+  if (recipient === "FORSAKRING") return "Försäkringsbolag";
+  return "Rättshjälpsmyndigheten";
+}
+
+/** Aconto-doc (PDF via pdf-lib, ingen spec — en ren aconto specificeras inte). */
+function useFakturaDoc(matterId: MatterId, meta: BillingMeta): (invoice: FakturaDocInvoice) => Promise<void> {
+  const register = trpc.document.register.useMutation();
+  const utils = trpc.useUtils();
+  const docMeta = docMetaFrom(meta);
   return async (invoice: FakturaDocInvoice) => {
     try {
       await generateFakturaDoc({ invoice, matterId, meta: docMeta, register, utils });
+    } catch (e) { console.warn("[billing] faktura-dokument misslyckades:", e); }
+  };
+}
+
+/** Slutfaktura-doc (template-motorn + fullständig spec, #856): tider/utlägg +
+ *  avdragna aconto-fakturor hämtas från `invoiceSpecification` och renderas. */
+function useFinalFakturaDoc(matterId: MatterId, meta: BillingMeta): (invoice: FakturaDocInvoice, recipient: string) => Promise<void> {
+  const register = trpc.document.register.useMutation();
+  const utils = trpc.useUtils();
+  const docMeta = docMetaFrom(meta);
+  return async (invoice: FakturaDocInvoice, recipient: string) => {
+    try {
+      const spec = await utils.billingRun.invoiceSpecification.fetch({ matterId, invoiceId: invoice.id });
+      await generateFakturaFromTemplate({ invoice, matterId, recipient, meta: docMeta, register, utils, spec });
     } catch (e) { console.warn("[billing] faktura-dokument misslyckades:", e); }
   };
 }
@@ -154,9 +179,9 @@ function FinalForm({ matterId, meta, accontos, onDone }: { matterId: MatterId; m
   const [posts, setPosts] = useState<string[] | null>(null);
   const togglePost = (key: string, checked: boolean): void =>
     setPosts((prev) => { const base = prev ?? allPostKeys; return checked ? [...base, key] : base.filter((k) => k !== key); });
-  const makeDoc = useFakturaDoc(matterId, meta);
+  const makeDoc = useFinalFakturaDoc(matterId, meta);
   const mut = trpc.billingRun.createFinal.useMutation({
-    onSuccess: async (res) => { await makeDoc(res.invoice); onDone(); },
+    onSuccess: async (res) => { await makeDoc(res.invoice, recipientLabel(recipient, meta.clientName)); onDone(); },
   });
   return (
     <form onSubmit={(e) => { e.preventDefault(); mut.mutate({

--- a/src/app/matters/[id]/_settlement-dialog.tsx
+++ b/src/app/matters/[id]/_settlement-dialog.tsx
@@ -15,14 +15,14 @@ import type { inferRouterOutputs } from "@trpc/server";
 import { useState } from "react";
 import { DecimalInput } from "@/components/ui/decimal-input";
 import { Modal } from "@/components/ui/modal";
-import { generateFakturaFromTemplate, type DocUtils, type FakturaDocMeta, type RegisterMut } from "@/lib/client/kostnadsrakning/generate-faktura-doc";
+import { generateFakturaFromTemplate, type DocUtils, type FakturaDocMeta, type InvoiceSpecification, type RegisterMut } from "@/lib/client/kostnadsrakning/generate-faktura-doc";
 import { trpc } from "@/lib/client/trpc";
 import { formatCurrency } from "@/lib/client/utils";
 import { useVatDisplay } from "@/lib/client/vat/vat-display-context";
 import type { AppRouter } from "@/lib/server/routers/_app";
 import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
 import type { PaymentMethod } from "@/lib/shared/schemas/enums";
-import type { MatterId } from "@/lib/shared/schemas/ids";
+import type { InvoiceId, MatterId } from "@/lib/shared/schemas/ids";
 
 interface SplitData {
   clientOre: number;
@@ -92,11 +92,15 @@ function clientNameOf(matter: MatterDetail | undefined): string {
 async function generateSettlementDocs(res: SettleResult, opts: {
   matterId: MatterId; matter: MatterDetail | undefined; org: OrgSettings | undefined;
   payerLabel: string; register: RegisterMut; utils: DocUtils;
+  fetchSpec: (invoiceId: InvoiceId) => Promise<InvoiceSpecification>;
 }): Promise<void> {
-  const { matterId, matter, org, payerLabel, register, utils } = opts;
+  const { matterId, matter, org, payerLabel, register, utils, fetchSpec } = opts;
   const meta = settlementMeta(matter, org);
-  await generateFakturaFromTemplate({ invoice: res.clientInvoice, matterId, recipient: clientNameOf(matter), meta, register, utils });
-  await generateFakturaFromTemplate({ invoice: res.payerInvoice, matterId, recipient: payerLabel, meta, register, utils });
+  // Fakturaspecifikation per faktura (#856): betalar-fakturan bär tids-/utläggs-
+  // raderna, klientfakturan de avdragna aconton.
+  const [clientSpec, payerSpec] = await Promise.all([fetchSpec(res.clientInvoice.id), fetchSpec(res.payerInvoice.id)]);
+  await generateFakturaFromTemplate({ invoice: res.clientInvoice, matterId, recipient: clientNameOf(matter), meta, register, utils, spec: clientSpec });
+  await generateFakturaFromTemplate({ invoice: res.payerInvoice, matterId, recipient: payerLabel, meta, register, utils, spec: payerSpec });
 }
 
 /** Härleder alla metod-beroende texter/argument (håller komponenten ≤8). */
@@ -129,7 +133,10 @@ export function SettlementDialog({ matterId, paymentMethod, onClose }: { matterI
       // Generera faktura-DOKUMENT (via template-motorn, #852) för båda fakturorna
       // → syns i fil-listan + länkas från faktura-objektet. Best-effort.
       try {
-        await generateSettlementDocs(res, { matterId, matter: matterQ.data, org: orgQ.data, payerLabel: cfg.payerLabel, register, utils });
+        await generateSettlementDocs(res, {
+          matterId, matter: matterQ.data, org: orgQ.data, payerLabel: cfg.payerLabel, register, utils,
+          fetchSpec: (invoiceId) => utils.billingRun.invoiceSpecification.fetch({ matterId, invoiceId }),
+        });
       } catch (e) { console.warn("[settlement] fakturadokument misslyckades:", e); }
       void utils.billingRun.list.invalidate({ matterId });
       void utils.invoice.list.invalidate();

--- a/src/lib/client/kostnadsrakning/generate-faktura-doc.ts
+++ b/src/lib/client/kostnadsrakning/generate-faktura-doc.ts
@@ -10,12 +10,14 @@
  * `_billing-dialog.tsx` kan dela exakt samma kod (DRY).
  */
 
-import type { inferRouterInputs } from "@trpc/server";
+import type { inferRouterInputs, inferRouterOutputs } from "@trpc/server";
 import type { AppRouter } from "@/lib/server/routers/_app";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { asId, type InvoiceId, type MatterId } from "@/lib/shared/schemas/ids";
 
 type RouterInputs = inferRouterInputs<AppRouter>;
+/** Fakturaspecifikationen (#856) — router-outputen, återanvänd så typerna följs åt. */
+export type InvoiceSpecification = inferRouterOutputs<AppRouter>["billingRun"]["invoiceSpecification"];
 type RegisterInput = RouterInputs["document"]["register"];
 type TreeFilter = RouterInputs["document"]["tree"];
 type ListFilter = RouterInputs["document"]["list"];
@@ -62,10 +64,33 @@ const FAKTURA_TEMPLATE = `<!DOCTYPE html><html lang="sv"><head><meta charset="ut
 <h1 style="margin-bottom:0">Faktura</h1>
 <p style="color:#555">Fakturanr: {{invoiceNumber}}{{#if ocr}} · OCR: {{ocr}}{{/if}}<br>Datum: {{date}}</p>
 <p style="color:#555">Ärende {{matterNumber}} — {{matterTitle}}<br>Mottagare: {{recipient}}</p>
-<table cellpadding="6" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:14px;margin-top:1rem">
+{{#if timeLines.length}}
+<h2 style="font-size:15px;margin-top:1.5rem;margin-bottom:.25rem">Tidsspecifikation</h2>
+<table cellpadding="5" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:13px">
+<thead><tr style="border-bottom:1px solid #ccc;text-align:left"><th>Datum</th><th>Beskrivning</th><th style="text-align:right">Tim</th><th style="text-align:right">Belopp</th></tr></thead>
+<tbody>{{#each timeLines}}<tr><td>{{this.date}}</td><td>{{this.description}}</td><td style="text-align:right">{{this.hours}}</td><td style="text-align:right">{{this.amount}}</td></tr>{{/each}}</tbody>
+</table>{{/if}}
+{{#if expenseLines.length}}
+<h2 style="font-size:15px;margin-top:1.5rem;margin-bottom:.25rem">Utläggsspecifikation</h2>
+<table cellpadding="5" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:13px">
+<thead><tr style="border-bottom:1px solid #ccc;text-align:left"><th>Datum</th><th>Beskrivning</th><th style="text-align:right">Netto</th><th style="text-align:right">Brutto</th></tr></thead>
+<tbody>{{#each expenseLines}}<tr><td>{{this.date}}</td><td>{{this.description}}</td><td style="text-align:right">{{this.net}}</td><td style="text-align:right">{{this.gross}}</td></tr>{{/each}}</tbody>
+</table>{{/if}}
+<table cellpadding="6" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:14px;margin-top:1.5rem">
 <tbody>
+{{#if useSpec}}
+{{#if hasSpec}}
+<tr><td>Arvode{{#if hoursTotal}} ({{hoursTotal}} tim){{/if}} (exkl moms)</td><td style="text-align:right">{{arvodeNet}}</td></tr>
+{{#if hasExpenses}}<tr><td>Utlägg (exkl moms)</td><td style="text-align:right">{{expensesNet}}</td></tr>{{/if}}
+<tr><td>Moms</td><td style="text-align:right">{{vat}}</td></tr>
+{{/if}}
+<tr style="border-top:1px solid #ccc"><td>Delsumma (inkl moms)</td><td style="text-align:right">{{gross}}</td></tr>
+{{#each deductions}}<tr style="color:#b45309"><td>Avgår aconto — faktura {{this.invoiceNumber}}{{#if this.date}} ({{this.date}}){{/if}}</td><td style="text-align:right">−{{this.amount}}</td></tr>{{/each}}
+{{#if hasAdjustment}}<tr style="color:#555"><td>{{adjustmentLabel}}</td><td style="text-align:right">{{adjustment}}</td></tr>{{/if}}
+{{else}}
 <tr><td>Netto (exkl moms)</td><td style="text-align:right">{{net}}</td></tr>
 <tr><td>Moms</td><td style="text-align:right">{{vat}}</td></tr>
+{{/if}}
 </tbody>
 <tfoot><tr style="border-top:2px solid #333"><td style="font-weight:bold">Att betala (inkl moms)</td><td style="text-align:right;font-weight:bold">{{total}}</td></tr></tfoot>
 </table>
@@ -79,6 +104,9 @@ export interface GenerateFakturaFromTemplateArgs {
   meta: FakturaDocMeta;
   register: RegisterMut;
   utils: DocUtils;
+  /** Fakturaspecifikationen (#856) — tider/utlägg/avdragna aconton. Utelämnas
+   *  för rena aconto-fakturor → mallen faller tillbaka på netto/moms/summa. */
+  spec?: InvoiceSpecification | null | undefined;
 }
 
 /**
@@ -89,10 +117,33 @@ export interface GenerateFakturaFromTemplateArgs {
  * + länk på faktura-objektet. `document.register` emittar inga events (ingen
  * read-only-trap), funkar i demo + server.
  */
+const svDate = (d: Date | string | null | undefined): string => (d ? new Date(d).toLocaleDateString("sv-SE") : "");
+const svHours = (minutes: number): string => (minutes / 60).toLocaleString("sv-SE", { maximumFractionDigits: 2 });
+
+/** Spec-delen av kontexten (tider/utlägg/avdrag + summering, #856). Tom när
+ *  ingen spec finns → mallen (`useSpec`=false) faller tillbaka på netto/moms. */
+function specContext(spec: InvoiceSpecification | null | undefined, fc: (ore: number) => string): Record<string, unknown> {
+  if (!spec) return { useSpec: false };
+  const vat = spec.arvodeVatOre + spec.expensesVatOre;
+  return {
+    useSpec: true,
+    hasSpec: spec.timeLines.length > 0 || spec.expenseLines.length > 0,
+    hasExpenses: spec.expenseLines.length > 0,
+    hoursTotal: spec.totalMinutes > 0 ? svHours(spec.totalMinutes) : "",
+    timeLines: spec.timeLines.map((l) => ({ date: svDate(l.date), description: l.description, hours: svHours(l.minutes), amount: fc(l.amountOre) })),
+    expenseLines: spec.expenseLines.map((l) => ({ date: svDate(l.date), description: l.description, net: fc(l.netOre), gross: fc(l.grossOre) })),
+    deductions: spec.deductions.map((d) => ({ invoiceNumber: d.invoiceNumber, date: svDate(d.date), amount: fc(d.amountOre) })),
+    arvodeNet: fc(spec.arvodeNetOre), expensesNet: fc(spec.expensesNetOre), vat: fc(vat), gross: fc(spec.grossOre),
+    hasAdjustment: spec.adjustmentOre !== 0,
+    adjustmentLabel: spec.adjustmentOre < 0 ? "Nedsättning" : "Justering",
+    adjustment: fc(spec.adjustmentOre),
+  };
+}
+
 /** Handlebars-kontext för faktura-mallen (utbruten → håller generatorn ≤8). */
 function fakturaTemplateContext(
   invoice: FakturaDocInvoice, recipient: string, meta: FakturaDocMeta,
-  formatCurrency: (ore: number) => string,
+  formatCurrency: (ore: number) => string, spec?: InvoiceSpecification | null,
 ): Record<string, unknown> {
   const vatOre = invoice.vatOre ?? 0;
   const date = (invoice.invoiceDate ? new Date(invoice.invoiceDate) : new Date()).toLocaleDateString("sv-SE");
@@ -102,15 +153,16 @@ function fakturaTemplateContext(
     date, matterNumber: meta.matterNumber, matterTitle: meta.matterTitle, recipient,
     net: formatCurrency(invoice.amount - vatOre), vat: formatCurrency(vatOre), total: formatCurrency(invoice.amount),
     organizationName: meta.organizationName ?? "", organizationOrgNumber: meta.organizationOrgNumber ?? "",
+    ...specContext(spec, formatCurrency),
   };
 }
 
 export async function generateFakturaFromTemplate(args: GenerateFakturaFromTemplateArgs): Promise<void> {
-  const { invoice, matterId, recipient, meta, register, utils } = args;
+  const { invoice, matterId, recipient, meta, register, utils, spec } = args;
   const { renderHandlebars } = await import("@/lib/client/kostnadsrakning/render-handlebars");
   const { persistGeneratedDoc } = await import("@/lib/client/demo/persist-generated-doc");
   const { formatCurrency } = await import("@/lib/client/utils");
-  const html = renderHandlebars(FAKTURA_TEMPLATE, fakturaTemplateContext(invoice, recipient, meta, formatCurrency));
+  const html = renderHandlebars(FAKTURA_TEMPLATE, fakturaTemplateContext(invoice, recipient, meta, formatCurrency, spec));
   const bytes = new TextEncoder().encode(html);
   const docId = `faktura-${invoice.id}`;
   const fileName = `Faktura ${invoice.invoiceNumber ?? meta.matterNumber} ${new Date().toISOString().slice(0, 10)}.html`;

--- a/src/lib/server/repositories/acconto-deduction-repository.ts
+++ b/src/lib/server/repositories/acconto-deduction-repository.ts
@@ -6,6 +6,10 @@
  */
 
 import type { AccontoDeduction } from "@/lib/shared/schemas/billing";
+import type { InvoiceId } from "@/lib/shared/schemas/ids";
 import type { Repository } from "./types";
 
-export type AccontoDeductionRepository = Repository<AccontoDeduction>;
+export interface AccontoDeductionRepository extends Repository<AccontoDeduction> {
+  /** Alla acconto-avdrag som en slutfaktura drar av (fakturaspecifikationen, #856). */
+  listByFinalInvoice(finalInvoiceId: InvoiceId): Promise<AccontoDeduction[]>;
+}

--- a/src/lib/server/repositories/drizzle-acconto-deduction-repository.ts
+++ b/src/lib/server/repositories/drizzle-acconto-deduction-repository.ts
@@ -2,6 +2,7 @@
  * Drizzle `AccontoDeductionRepository` (ADR 0020) — server-impl. Endast bas-CRUD.
  */
 
+import { and, eq, isNull } from "drizzle-orm";
 import type { AccontoDeduction } from "@/lib/shared/schemas/billing";
 import type { InvoiceId } from "@/lib/shared/schemas/ids";
 import { accontoDeductions } from "../db/schema";
@@ -15,6 +16,11 @@ export class DrizzleAccontoDeductionRepository
   implements AccontoDeductionRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
     super(db, versionedTable(accontoDeductions), now);
+  }
+
+  async listByFinalInvoice(finalInvoiceId: InvoiceId): Promise<AccontoDeduction[]> {
+    return await this.db.select().from(accontoDeductions)
+      .where(and(eq(accontoDeductions.finalInvoiceId, finalInvoiceId), isNull(accontoDeductions.deletedAt)));
   }
 
   /** acconto-avdrag saknar org-kolumn → härled via (slut- el. aconto-)fakturan→ärendet (#647). */

--- a/src/lib/server/repositories/drizzle-expense-repository.ts
+++ b/src/lib/server/repositories/drizzle-expense-repository.ts
@@ -99,6 +99,13 @@ export class DrizzleExpenseRepository extends DrizzleRepository<Expense> impleme
       .orderBy(asc(expenses.date));
   }
 
+  async listByInvoice(invoiceId: InvoiceId): Promise<Expense[]> {
+    return await this.db
+      .select().from(expenses)
+      .where(and(eq(expenses.invoiceId, invoiceId), isNull(expenses.deletedAt)))
+      .orderBy(asc(expenses.date));
+  }
+
   async freezeForMatter(matterId: MatterId, billingRunId: BillingRunId, now: Date): Promise<void> {
     await this.db.update(expenses)
       .set({ frozenAt: now, frozenByBillingRunId: billingRunId })

--- a/src/lib/server/repositories/drizzle-time-entry-repository.ts
+++ b/src/lib/server/repositories/drizzle-time-entry-repository.ts
@@ -140,6 +140,13 @@ export class DrizzleTimeEntryRepository extends DrizzleRepository<TimeEntry> imp
       .orderBy(asc(timeEntries.date));
   }
 
+  async listByInvoice(invoiceId: InvoiceId): Promise<TimeEntry[]> {
+    return await this.db
+      .select().from(timeEntries)
+      .where(and(eq(timeEntries.invoiceId, invoiceId), isNull(timeEntries.deletedAt)))
+      .orderBy(asc(timeEntries.date));
+  }
+
   async coverageUsageForMatter(matterId: MatterId): Promise<{ billableMinutes: number; billableValueOre: number }> {
     const rows = await this.db
       .select({ minutes: timeEntries.minutes, hourlyRate: timeEntries.hourlyRate })

--- a/src/lib/server/repositories/expense-repository.ts
+++ b/src/lib/server/repositories/expense-repository.ts
@@ -44,6 +44,8 @@ export interface ExpenseRepository extends Repository<Expense> {
   listUnbilled(matterId: MatterId, ids: ExpenseId[]): Promise<Expense[]>;
   /** Koppla utlägg till en faktura (sätter invoiceId). No-op vid tomma ids. */
   flagBilled(ids: ExpenseId[], invoiceId: InvoiceId): Promise<void>;
+  /** Utlägg kopplade till en faktura (date asc) — fakturaspecifikationen (#856). */
+  listByInvoice(invoiceId: InvoiceId): Promise<Expense[]>;
   /** Ofrysta utlägg i ett ärende (date asc) — underlag för billing-run. */
   listUnfrozenForMatter(matterId: MatterId): Promise<Expense[]>;
   /** Utlägg frysta mot en specifik billing-run (date asc) — dom/slutreglering

--- a/src/lib/server/repositories/in-memory-acconto-deduction-repository.ts
+++ b/src/lib/server/repositories/in-memory-acconto-deduction-repository.ts
@@ -4,6 +4,7 @@
  */
 
 import type { AccontoDeduction } from "@/lib/shared/schemas/billing";
+import type { InvoiceId } from "@/lib/shared/schemas/ids";
 import type { IDataStore } from "../data-store/IDataStore";
 import type { AccontoDeductionRepository } from "./acconto-deduction-repository";
 import { InMemoryRepository } from "./in-memory-repository";
@@ -16,5 +17,9 @@ export class InMemoryAccontoDeductionRepository
   implements AccontoDeductionRepository {
   constructor(store: AccontoDeductionRepoSource, now?: () => Date) {
     super(store.accontoDeductions, now ?? (() => new Date()));
+  }
+
+  async listByFinalInvoice(finalInvoiceId: InvoiceId): Promise<AccontoDeduction[]> {
+    return (await this.delegate.findMany({ where: { finalInvoiceId } })) as AccontoDeduction[];
   }
 }

--- a/src/lib/server/repositories/in-memory-expense-repository.ts
+++ b/src/lib/server/repositories/in-memory-expense-repository.ts
@@ -72,6 +72,12 @@ export class InMemoryExpenseRepository extends InMemoryRepository<Expense> imple
     })) as Expense[];
   }
 
+  async listByInvoice(invoiceId: InvoiceId): Promise<Expense[]> {
+    return (await this.delegate.findMany({
+      where: { invoiceId }, orderBy: { date: "asc" },
+    })) as Expense[];
+  }
+
   async freezeForMatter(matterId: MatterId, billingRunId: BillingRunId, now: Date): Promise<void> {
     await this.delegate.updateMany({
       where: { matterId, frozenByBillingRunId: null },

--- a/src/lib/server/repositories/in-memory-time-entry-repository.ts
+++ b/src/lib/server/repositories/in-memory-time-entry-repository.ts
@@ -111,6 +111,12 @@ export class InMemoryTimeEntryRepository extends InMemoryRepository<TimeEntry> i
     })) as TimeEntry[];
   }
 
+  async listByInvoice(invoiceId: InvoiceId): Promise<TimeEntry[]> {
+    return (await this.delegate.findMany({
+      where: { invoiceId }, orderBy: { date: "asc" },
+    })) as TimeEntry[];
+  }
+
   async coverageUsageForMatter(matterId: MatterId): Promise<{ billableMinutes: number; billableValueOre: number }> {
     const rows = (await this.delegate.findMany({ where: { matterId } })) as TimeEntry[];
     let billableMinutes = 0;

--- a/src/lib/server/repositories/time-entry-repository.ts
+++ b/src/lib/server/repositories/time-entry-repository.ts
@@ -85,6 +85,8 @@ export interface TimeEntryRepository extends Repository<TimeEntry> {
   listUnbilled(matterId: MatterId, ids: TimeEntryId[]): Promise<UnbilledTimeEntry[]>;
   /** Koppla tidsposter till en faktura (sätter invoiceId). No-op vid tomma ids. */
   flagBilled(ids: TimeEntryId[], invoiceId: InvoiceId): Promise<void>;
+  /** Tidsposter kopplade till en faktura (date asc) — fakturaspecifikationen (#856). */
+  listByInvoice(invoiceId: InvoiceId): Promise<TimeEntry[]>;
   /** Ofrysta tidsposter i ett ärende (date asc) — underlag för billing-run. */
   listUnfrozenForMatter(matterId: MatterId): Promise<TimeEntry[]>;
   /** Tidsposter frysta mot en specifik billing-run (date asc) — underlag för

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -342,6 +342,105 @@ async function freezeWork(repos: Repositories, matterId: MatterId, billingRunId:
   await repos.expenses.freezeForMatter(matterId, billingRunId, now);
 }
 
+// ── Fakturaspecifikation (#856) ─────────────────────────────────────────────
+
+/** En rad i fakturans tidsspecifikation (belopp = timmar × gällande timarvode). */
+interface SpecTimeLine { date: Date | string; description: string; minutes: number; amountOre: number; }
+/** En rad i utläggsspecifikationen (netto + brutto, exakt per momssats). */
+interface SpecExpenseLine { date: Date | string; description: string; netOre: number; grossOre: number; }
+/** En avdragen (tidigare betald) aconto-faktura. */
+interface SpecDeduction { invoiceNumber: string; date: Date | string | null; amountOre: number; }
+
+/**
+ * Fakturans fullständiga specifikation (#856): itemiserade tider + utlägg,
+ * avdragna aconto-fakturor och summering. `payableOre` = fakturans FAKTISKA
+ * belopp; `adjustmentOre` fångar ev. differens (rättshjälps-/rättsskyddssplit,
+ * prutning) mellan brutto−avdrag och det som faktureras — visas på en egen rad.
+ */
+interface InvoiceSpecification {
+  timeLines: SpecTimeLine[];
+  expenseLines: SpecExpenseLine[];
+  totalMinutes: number;
+  arvodeNetOre: number; arvodeVatOre: number;
+  expensesNetOre: number; expensesVatOre: number;
+  grossOre: number;
+  deductions: SpecDeduction[];
+  deductionOre: number;
+  adjustmentOre: number;
+  payableOre: number;
+}
+
+function specTimeLines(
+  method: PaymentMethod, normRateOre: number,
+  entries: ReadonlyArray<{ date: Date | string; description: string; minutes: number; hourlyRate: number; billable: boolean }>,
+): SpecTimeLine[] {
+  return entries.filter((t) => t.billable).map((t) => ({
+    date: t.date, description: t.description, minutes: t.minutes,
+    // Rättshjälp värderas enhetligt på timkostnadsnormen (#839); övriga per post-taxa.
+    amountOre: timeEntryValueOre(t.minutes, method === "RATTSHJALP" ? normRateOre : t.hourlyRate),
+  }));
+}
+
+function specExpenseLines(
+  expenses: ReadonlyArray<{ date: Date | string; description: string; amount: number; billable: boolean; vatRate?: number | null; vatIncluded?: boolean | null }>,
+): SpecExpenseLine[] {
+  return expenses.filter((e) => e.billable).map((e) => {
+    const s = expenseSplit(e);
+    return { date: e.date, description: e.description, netOre: s.exclVat, grossOre: s.exclVat + s.vat };
+  });
+}
+
+function buildInvoiceSpecification(a: {
+  timeLines: SpecTimeLine[]; expenseLines: SpecExpenseLine[]; deductions: SpecDeduction[]; payableOre: number;
+}): InvoiceSpecification {
+  const arvodeNetOre = a.timeLines.reduce((s, l) => s + l.amountOre, 0);
+  const arvodeVatOre = arvodeInclVatOre(arvodeNetOre) - arvodeNetOre;
+  const expensesNetOre = a.expenseLines.reduce((s, l) => s + l.netOre, 0);
+  const expensesVatOre = a.expenseLines.reduce((s, l) => s + (l.grossOre - l.netOre), 0);
+  const deductionOre = a.deductions.reduce((s, d) => s + d.amountOre, 0);
+  // Brutto före avdrag. Har fakturan itemiserat arbete → summan av raderna.
+  // Saknas rader (t.ex. klientens självrisk-faktura, vars arbete ligger på
+  // betalar-fakturan) → härled ur det fakturerade + avdragen, så avdragen kan
+  // visas transparent (belopp − aconton = att betala) utan negativ justering.
+  const hasLines = a.timeLines.length > 0 || a.expenseLines.length > 0;
+  const grossOre = hasLines ? arvodeNetOre + arvodeVatOre + expensesNetOre + expensesVatOre : a.payableOre + deductionOre;
+  return {
+    timeLines: a.timeLines, expenseLines: a.expenseLines,
+    totalMinutes: a.timeLines.reduce((s, l) => s + l.minutes, 0),
+    arvodeNetOre, arvodeVatOre, expensesNetOre, expensesVatOre, grossOre,
+    deductions: a.deductions, deductionOre,
+    adjustmentOre: a.payableOre - (grossOre - deductionOre),
+    payableOre: a.payableOre,
+  };
+}
+
+/**
+ * Länka slutregleringens arbete + aconto-avdrag till fakturorna (#856): arbetet
+ * (arvode+utlägg) bärs av betalar-fakturan, aconto-avdragen registreras på
+ * klientfakturan → fakturaspecifikationen kan hämtas per faktura och slutfaktura-
+ * vyn slutar visa 0.00. Utbrutet så settleCoverage-handlern håller sig ≤8.
+ */
+async function linkSettlementInvoices(repos: Repositories, a: {
+  work: UnfrozenWork; payerInvoiceId: InvoiceId; clientInvoiceId: InvoiceId; deductedRuns: ReadonlyArray<{ invoiceId?: InvoiceId | null | undefined }>;
+}): Promise<void> {
+  await repos.timeEntries.flagBilled(a.work.timeEntries.filter((t) => t.billable).map((t) => t.id), a.payerInvoiceId);
+  await repos.expenses.flagBilled(a.work.expenses.filter((e) => e.billable).map((e) => e.id), a.payerInvoiceId);
+  for (const r of a.deductedRuns) {
+    if (r.invoiceId) await repos.accontoDeductions.create({ finalInvoiceId: a.clientInvoiceId, accontoInvoiceId: r.invoiceId });
+  }
+}
+
+/** Hämta + montera avdragna aconto-fakturor för en slutfaktura (#856). */
+async function fetchSpecDeductions(repos: Repositories, orgId: OrganizationId, finalInvoiceId: InvoiceId): Promise<SpecDeduction[]> {
+  const links = await repos.accontoDeductions.listByFinalInvoice(finalInvoiceId);
+  const out: SpecDeduction[] = [];
+  for (const link of links) {
+    const inv = await repos.invoices.getByIdInOrg(link.accontoInvoiceId, orgId);
+    if (inv) out.push({ invoiceNumber: inv.invoiceNumber ?? "—", date: inv.invoiceDate ?? null, amountOre: inv.amount });
+  }
+  return out;
+}
+
 /**
  * Koppla de DEBITERBARA frysta posterna till FINAL-fakturan (invoice_id) +
  * registrera acconto-avdrag. Utan detta härleder slutfaktura-vyn `0.00` för
@@ -511,6 +610,32 @@ export const billingRunRouter = router({
       const ex = await ctx.repos.expenses.listUnfrozenForMatter(input.matterId);
       const priorAccontoSumOre = await sumPriorAccontos(ctx.repos, input.matterId);
       return buildProposal(te, ex, priorAccontoSumOre);
+    }),
+
+  /**
+   * Fakturaspecifikation (#856): itemiserade tids-/utläggsrader KOPPLADE till
+   * fakturan (via `invoiceId`) + avdragna aconto-fakturor + summering. Driver
+   * faktura-DOKUMENTET (mallen). En ren aconto-faktura utan länkat arbete får
+   * tomma rader (aconton specificeras inte).
+   */
+  invoiceSpecification: orgProcedure
+    .input(z.object({ matterId: matterIdSchema, invoiceId: invoiceIdSchema }))
+    .query(async ({ ctx, input }): Promise<InvoiceSpecification> => {
+      const invoice = await ctx.repos.invoices.getByIdInOrg(input.invoiceId, ctx.orgId);
+      if (!invoice) throw new TRPCError({ code: "NOT_FOUND", message: "Fakturan finns inte." });
+      const matter = await ctx.repos.matters.getByIdInOrg(input.matterId, ctx.orgId);
+      if (!matter) throw new TRPCError({ code: "NOT_FOUND", message: "Ärendet finns inte." });
+      const rateOre = await currentArvodeRateOre(ctx.repos, ctx.orgId, matter);
+      const [te, ex, deductions] = await Promise.all([
+        ctx.repos.timeEntries.listByInvoice(input.invoiceId),
+        ctx.repos.expenses.listByInvoice(input.invoiceId),
+        fetchSpecDeductions(ctx.repos, ctx.orgId, input.invoiceId),
+      ]);
+      return buildInvoiceSpecification({
+        timeLines: specTimeLines(matter.paymentMethod, rateOre, te),
+        expenseLines: specExpenseLines(ex),
+        deductions, payableOre: invoice.amount,
+      });
     }),
 
   createAcconto: orgProcedure
@@ -827,6 +952,7 @@ export const billingRunRouter = router({
           matterId: input.matterId, payerRecipient: input.payerRecipient, payerInvoiceId: payerInvoice.id,
           payerGross, notes: input.notes, krRun,
         });
+        await linkSettlementInvoices(tx, { work, payerInvoiceId: payerInvoice.id, clientInvoiceId: clientInvoice.id, deductedRuns });
         // KR:n förblir en distinkt kostnadsräkning (med sitt dokument/beslut) —
         // konsumeras EJ in i fakturan; markeras FAKTURERAD (#828).
         if (krRun) {

--- a/test/unit/app/matters/billing-dialog.test.tsx
+++ b/test/unit/app/matters/billing-dialog.test.tsx
@@ -28,7 +28,13 @@ let proposalLoading = false;
 
 vi.mock("@/lib/client/trpc", () => ({
   trpc: {
-    useUtils: () => ({ document: { tree: { invalidate: vi.fn(), refetch: vi.fn() }, list: { invalidate: vi.fn() } } }),
+    useUtils: () => ({
+      document: { tree: { invalidate: vi.fn(), refetch: vi.fn() }, list: { invalidate: vi.fn() } },
+      billingRun: { invoiceSpecification: { fetch: vi.fn(async () => ({
+        timeLines: [], expenseLines: [], totalMinutes: 0, arvodeNetOre: 0, arvodeVatOre: 0,
+        expensesNetOre: 0, expensesVatOre: 0, grossOre: 0, deductions: [], deductionOre: 0, adjustmentOre: 0, payableOre: 0,
+      })) } },
+    }),
     document: { register: { useMutation: () => ({ mutateAsync: registerMutateAsync }) } },
     billingRun: {
       proposal: { useQuery: () => ({ data: proposalData, isLoading: proposalLoading }) },

--- a/test/unit/lib/kostnadsrakning/generate-faktura-from-template.test.ts
+++ b/test/unit/lib/kostnadsrakning/generate-faktura-from-template.test.ts
@@ -40,4 +40,34 @@ describe("generateFakturaFromTemplate", () => {
     expect(html).toContain("Staten");      // mottagare
     expect(html).toContain("Vårdnadstvist");
   });
+
+  it("renderar fullständig specifikation (tider, utlägg, avdragna aconton) — #856", async () => {
+    await generateFakturaFromTemplate({
+      invoice: { id: asId<"InvoiceId">("inv-1"), amount: 373_750, vatOre: 93_750, invoiceNumber: "F-2026-0001", invoiceDate: "2026-06-30" },
+      matterId: asId<"MatterId">("m1"),
+      recipient: "Klient AB",
+      meta: { matterNumber: "Ä-1", matterTitle: "Tvist" },
+      register: { mutateAsync: registerMutateAsync },
+      utils,
+      spec: {
+        timeLines: [{ date: "2026-05-02", description: "Genomgång av handlingar", minutes: 90, amountOre: 375_000 }],
+        expenseLines: [{ date: "2026-05-03", description: "Ansökningsavgift", netOre: 5_000, grossOre: 5_000 }],
+        totalMinutes: 90,
+        arvodeNetOre: 375_000, arvodeVatOre: 93_750,
+        expensesNetOre: 5_000, expensesVatOre: 0,
+        grossOre: 473_750,
+        deductions: [{ invoiceNumber: "F-2026-0000", date: "2026-04-01", amountOre: 100_000 }],
+        deductionOre: 100_000,
+        adjustmentOre: 0,
+        payableOre: 373_750,
+      },
+    });
+    const html = new TextDecoder().decode(persistGeneratedDoc.mock.calls[0]![0].bytes as Uint8Array);
+    expect(html).toContain("Tidsspecifikation");
+    expect(html).toContain("Genomgång av handlingar");
+    expect(html).toContain("Utläggsspecifikation");
+    expect(html).toContain("Ansökningsavgift");
+    expect(html).toContain("Avgår aconto");
+    expect(html).toContain("F-2026-0000"); // avdragen aconto-faktura listad i specifikationen
+  });
 });

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -538,3 +538,47 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
     expect(res.payerInvoice.amount).toBe(1_200_000); // 960 000 × 1,25 moms
   });
 });
+
+describe("billingRun.invoiceSpecification (#856)", () => {
+  it("slutfaktura (PRIVAT): itemiserade tider (per-post-taxa) + utlägg + avdragna aconton", async () => {
+    const { caller } = makeCaller({ paymentMethod: "PRIVAT", workMinutes: 120, expenseOre: 5000 });
+    const acc = await caller.billingRun.createAcconto({ matterId: "m-1", clientShareBips: 2000, amountOre: 100000 });
+    const fin = await caller.billingRun.createFinal({ matterId: "m-1", recipient: "KLIENT", deductedBillingRunIds: [acc.run.id] });
+    const spec = await caller.billingRun.invoiceSpecification({ matterId: "m-1", invoiceId: fin.invoice.id });
+    expect(spec.timeLines).toHaveLength(1);
+    expect(spec.timeLines[0]!.minutes).toBe(120);
+    expect(spec.timeLines[0]!.amountOre).toBe(500000); // 2 tim × 2500 kr (postens hourlyRate)
+    expect(spec.expenseLines).toHaveLength(1);
+    expect(spec.expenseLines[0]!.netOre).toBe(5000);
+    expect(spec.arvodeNetOre).toBe(500000);
+    expect(spec.arvodeVatOre).toBe(125000); // 25 %
+    expect(spec.grossOre).toBe(630000); // 625000 arvode inkl moms + 5000 utlägg
+    expect(spec.deductions).toHaveLength(1);
+    expect(spec.deductions[0]!.amountOre).toBe(100000);
+    expect(spec.deductionOre).toBe(100000);
+    expect(spec.adjustmentOre).toBe(0); // brutto − avdrag == fakturerat
+    expect(spec.payableOre).toBe(530000); // 630000 − 100000
+  });
+
+  it("rättshjälp settlement: betalar-fakturan bär tidsraderna (timkostnadsnorm), klientfakturan aconto-avdraget", async () => {
+    const ds = new DemoDataStore({
+      organizations: [{ id: "org-1", name: "X" }],
+      matters: [{ id: "m-1", organizationId: "org-1", matterNumber: "2026-0001", title: "T", status: "ACTIVE", responsibleLawyerId: "u-1", paymentMethod: "RATTSHJALP", clientShareBips: 2000, taxaHasFTax: true, createdAt: new Date() }],
+      users: [{ id: "u-1", organizationId: "org-1", email: "a@x", name: "Anna", role: "ADMIN", hourlyRate: 999999 }],
+      timeEntries: [{ id: "te-1", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), minutes: 180, description: "M", hourlyRate: 200000, billable: true }],
+    }, async () => {});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const c = appRouter.createCaller(buildContext({ dataStore: ds, ports: noopPorts, principal: PRINCIPAL }) as any);
+    await c.billingRun.createAcconto({ matterId: "m-1", clientShareBips: 2000, amountOre: 50000 }); // SENT-aconto som auto-dras av
+    const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "DOMSTOL" });
+    // Betalar-fakturan (domstol) har tidsraden värderad på timkostnadsnormen (162 600/tim × 3 tim).
+    const payerSpec = await c.billingRun.invoiceSpecification({ matterId: "m-1", invoiceId: res.payerInvoice.id });
+    expect(payerSpec.timeLines).toHaveLength(1);
+    expect(payerSpec.timeLines[0]!.amountOre).toBe(487800); // 180 min / 60 × 162600
+    // Klientfakturan listar den avdragna (betalda) aconton.
+    const clientSpec = await c.billingRun.invoiceSpecification({ matterId: "m-1", invoiceId: res.clientInvoice.id });
+    expect(clientSpec.deductions).toHaveLength(1);
+    expect(clientSpec.deductions[0]!.amountOre).toBe(50000);
+    expect(clientSpec.timeLines).toHaveLength(0); // arbetet ligger på betalar-fakturan
+  });
+});


### PR DESCRIPTION
## Vad

Faktura-dokumenten (via template-motorn, #852) får en **fullständig specifikation**:

- **Tidsspecifikation** per rad — datum, beskrivning, timmar, belopp. Belopp = timmar × gällande timarvode (rättshjälp: timkostnadsnormen #839; övriga: postens sparade timtaxa).
- **Utläggsspecifikation** per rad — netto/brutto, exakt per momssats.
- **Avdragna aconto-fakturor** — tidigare betalda aconton listas (fakturanr, datum, belopp) och räknas av från summan.

## Hur

- Ny query `billingRun.invoiceSpecification({ matterId, invoiceId })` monterar specen per faktura ur tids-/utläggsrader kopplade till fakturan (`listByInvoice`) + `acconto_deductions` (`listByFinalInvoice`).
- `settleCoverage` länkar nu arbetet till betalar-fakturan (`flagBilled`) och skapar avdragsraderna på klientfakturan — **uniformt med `createFinal`**, och fixar på köpet att slutfaktura-vyn visade `0.00` arvode/utlägg.
- FINAL-fakturans dokument genereras nu via template-motorn (med spec) i stället för pdf-lib; klient-/betalar-fakturorna vid slutreglering likaså.
- Rena aconto-fakturor får ingen spec (faller tillbaka på netto/moms/summa).

## Test

- `invoiceSpecification`: PRIVAT slutfaktura (per-post-taxa, utlägg, avdragen aconto, brutto/avdrag/att-betala) + rättshjälp settlement (betalar-fakturan bär tidsraderna på normen, klientfakturan aconto-avdraget).
- Template renderar tids-/utläggstabellerna + avdragsraderna.
- Full svit grön (3388 pass), typecheck/lint/knip/deps/duplicates/build:demo grönt.

Closes #856
Refs #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)