### PR TITLE
feat(billing): bryt ned domstols-/klientfakturans belopp i itemiserade rader

### DIFF
--- a/src/app/matters/[id]/_settlement-dialog.tsx
+++ b/src/app/matters/[id]/_settlement-dialog.tsx
@@ -15,7 +15,7 @@ import type { inferRouterOutputs } from "@trpc/server";
 import { useState } from "react";
 import { DecimalInput } from "@/components/ui/decimal-input";
 import { Modal } from "@/components/ui/modal";
-import { generateFakturaFromTemplate, type DocUtils, type FakturaDocMeta, type InvoiceSpecification, type RegisterMut } from "@/lib/client/kostnadsrakning/generate-faktura-doc";
+import { generateFakturaFromTemplate, type BreakdownRow, type DocUtils, type FakturaBreakdown, type FakturaDocMeta, type InvoiceSpecification, type RegisterMut } from "@/lib/client/kostnadsrakning/generate-faktura-doc";
 import { trpc } from "@/lib/client/trpc";
 import { formatCurrency } from "@/lib/client/utils";
 import { useVatDisplay } from "@/lib/client/vat/vat-display-context";
@@ -89,18 +89,45 @@ function clientNameOf(matter: MatterDetail | undefined): string {
   return matter?.contacts?.find((c) => c.role === "KLIENT")?.contact?.name ?? "Klient";
 }
 
+type Breakdown = SettleResult["breakdown"];
+
+const svd = (d: string | Date | null | undefined): string => (d ? new Date(d).toLocaleDateString("sv-SE") : "");
+
+/** Betalar-fakturans (domstol/försäkring) nedbrytning (#858): tids-/utläggsraderna
+ *  kommer ur `spec`; här bara AVDRAGEN — självrisk/rådgivning/prutning (belopps-
+ *  påverkande) + aconton som info-rader (avräknas på klientfakturan, ej här). */
+function payerBreakdown(b: Breakdown, payerLabel: string): FakturaBreakdown {
+  const rows: BreakdownRow[] = [{ label: "Klientens självrisk", amountOre: b.sjalvriskGrossOre, kind: "deduct" }];
+  if (b.radgivningGrossOre > 0) rows.push({ label: "Rådgivning (faktureras klienten)", amountOre: b.radgivningGrossOre, kind: "deduct" });
+  if (b.prutningGrossOre > 0) rows.push({ label: "Prutning (byrån bär)", amountOre: b.prutningGrossOre, kind: "deduct" });
+  for (const d of b.deductedAccontos) rows.push({ label: `Betalt via aconto — faktura ${d.invoiceNumber}${d.date ? ` (${svd(d.date)})` : ""}`, amountOre: d.amountOre, kind: "info" });
+  return { rows, totalLabel: `${payerLabel} — att betala (inkl moms)`, totalOre: b.payerPayableOre };
+}
+
+/** Klientfakturans nedbrytning (#858): självrisk-uträkningen + de avdragna
+ *  (betalda) aconton, som avräknas här → att betala. */
+function clientBreakdown(b: Breakdown, isRattshjalp: boolean): FakturaBreakdown {
+  const share = (b.clientShareBips / 100).toLocaleString("sv-SE", { maximumFractionDigits: 2 });
+  const label = isRattshjalp
+    ? `Självrisk (${share} % av upparbetat arvode ${formatCurrency(b.arvodeBaseNetOre)}, inkl moms)`
+    : "Klientens del / självrisk (inkl moms)";
+  const rows: BreakdownRow[] = [{ label, amountOre: b.sjalvriskGrossOre, kind: "add" }];
+  for (const d of b.deductedAccontos) rows.push({ label: `Avgår aconto — faktura ${d.invoiceNumber}${d.date ? ` (${svd(d.date)})` : ""}`, amountOre: d.amountOre, kind: "deduct" });
+  return { rows, totalLabel: "Att betala (inkl moms)", totalOre: b.clientPayableOre };
+}
+
 async function generateSettlementDocs(res: SettleResult, opts: {
   matterId: MatterId; matter: MatterDetail | undefined; org: OrgSettings | undefined;
-  payerLabel: string; register: RegisterMut; utils: DocUtils;
+  payerLabel: string; isRattshjalp: boolean; register: RegisterMut; utils: DocUtils;
   fetchSpec: (invoiceId: InvoiceId) => Promise<InvoiceSpecification>;
 }): Promise<void> {
-  const { matterId, matter, org, payerLabel, register, utils, fetchSpec } = opts;
+  const { matterId, matter, org, payerLabel, isRattshjalp, register, utils, fetchSpec } = opts;
   const meta = settlementMeta(matter, org);
-  // Fakturaspecifikation per faktura (#856): betalar-fakturan bär tids-/utläggs-
-  // raderna, klientfakturan de avdragna aconton.
-  const [clientSpec, payerSpec] = await Promise.all([fetchSpec(res.clientInvoice.id), fetchSpec(res.payerInvoice.id)]);
-  await generateFakturaFromTemplate({ invoice: res.clientInvoice, matterId, recipient: clientNameOf(matter), meta, register, utils, spec: clientSpec });
-  await generateFakturaFromTemplate({ invoice: res.payerInvoice, matterId, recipient: payerLabel, meta, register, utils, spec: payerSpec });
+  // Betalar-fakturan: tids-/utläggsspec (#856) + itemiserad nedbrytning (#858).
+  const payerSpec = await fetchSpec(res.payerInvoice.id);
+  await generateFakturaFromTemplate({ invoice: res.payerInvoice, matterId, recipient: payerLabel, meta, register, utils, spec: payerSpec, breakdown: payerBreakdown(res.breakdown, payerLabel) });
+  // Klientfakturan: självrisk-uträkning + aconto-avdrag (ingen tidslista).
+  await generateFakturaFromTemplate({ invoice: res.clientInvoice, matterId, recipient: clientNameOf(matter), meta, register, utils, breakdown: clientBreakdown(res.breakdown, isRattshjalp) });
 }
 
 /** Härleder alla metod-beroende texter/argument (håller komponenten ≤8). */
@@ -134,7 +161,8 @@ export function SettlementDialog({ matterId, paymentMethod, onClose }: { matterI
       // → syns i fil-listan + länkas från faktura-objektet. Best-effort.
       try {
         await generateSettlementDocs(res, {
-          matterId, matter: matterQ.data, org: orgQ.data, payerLabel: cfg.payerLabel, register, utils,
+          matterId, matter: matterQ.data, org: orgQ.data, payerLabel: cfg.payerLabel,
+          isRattshjalp: paymentMethod === "RATTSHJALP", register, utils,
           fetchSpec: (invoiceId) => utils.billingRun.invoiceSpecification.fetch({ matterId, invoiceId }),
         });
       } catch (e) { console.warn("[settlement] fakturadokument misslyckades:", e); }

--- a/src/lib/client/kostnadsrakning/generate-faktura-doc.ts
+++ b/src/lib/client/kostnadsrakning/generate-faktura-doc.ts
@@ -18,6 +18,11 @@ import { asId, type InvoiceId, type MatterId } from "@/lib/shared/schemas/ids";
 type RouterInputs = inferRouterInputs<AppRouter>;
 /** Fakturaspecifikationen (#856) — router-outputen, återanvänd så typerna följs åt. */
 export type InvoiceSpecification = inferRouterOutputs<AppRouter>["billingRun"]["invoiceSpecification"];
+
+/** En rad i den itemiserade summeringen (#858): `add` = delbelopp, `deduct` =
+ *  avgår (−), `info` = spårbarhets-rad utan beloppspåverkan (visas parentes). */
+export interface BreakdownRow { label: string; amountOre: number; kind: "add" | "deduct" | "info" }
+export interface FakturaBreakdown { rows: BreakdownRow[]; totalLabel: string; totalOre: number }
 type RegisterInput = RouterInputs["document"]["register"];
 type TreeFilter = RouterInputs["document"]["tree"];
 type ListFilter = RouterInputs["document"]["list"];
@@ -85,14 +90,20 @@ const FAKTURA_TEMPLATE = `<!DOCTYPE html><html lang="sv"><head><meta charset="ut
 <tr><td>Moms</td><td style="text-align:right">{{vat}}</td></tr>
 {{/if}}
 <tr style="border-top:1px solid #ccc"><td>Delsumma (inkl moms)</td><td style="text-align:right">{{gross}}</td></tr>
+{{/if}}
+{{#if useBreakdown}}
+{{#each breakdownRows}}<tr style="{{this.style}}"><td>{{this.label}}</td><td style="text-align:right;{{this.style}}">{{this.amount}}</td></tr>{{/each}}
+{{else}}
+{{#if useSpec}}
 {{#each deductions}}<tr style="color:#b45309"><td>Avgår aconto — faktura {{this.invoiceNumber}}{{#if this.date}} ({{this.date}}){{/if}}</td><td style="text-align:right">−{{this.amount}}</td></tr>{{/each}}
 {{#if hasAdjustment}}<tr style="color:#555"><td>{{adjustmentLabel}}</td><td style="text-align:right">{{adjustment}}</td></tr>{{/if}}
 {{else}}
 <tr><td>Netto (exkl moms)</td><td style="text-align:right">{{net}}</td></tr>
 <tr><td>Moms</td><td style="text-align:right">{{vat}}</td></tr>
 {{/if}}
+{{/if}}
 </tbody>
-<tfoot><tr style="border-top:2px solid #333"><td style="font-weight:bold">Att betala (inkl moms)</td><td style="text-align:right;font-weight:bold">{{total}}</td></tr></tfoot>
+<tfoot><tr style="border-top:2px solid #333"><td style="font-weight:bold">{{totalLabel}}</td><td style="text-align:right;font-weight:bold">{{total}}</td></tr></tfoot>
 </table>
 {{#if organizationName}}<p style="color:#777;font-size:13px;margin-top:1.5rem">{{organizationName}}{{#if organizationOrgNumber}} · {{organizationOrgNumber}}{{/if}}</p>{{/if}}
 </body></html>`;
@@ -107,6 +118,10 @@ export interface GenerateFakturaFromTemplateArgs {
   /** Fakturaspecifikationen (#856) — tider/utlägg/avdragna aconton. Utelämnas
    *  för rena aconto-fakturor → mallen faller tillbaka på netto/moms/summa. */
   spec?: InvoiceSpecification | null | undefined;
+  /** Itemiserad summering (#858) — självförklarande nedbrytning (självrisk,
+   *  rådgivning, prutning, aconton). När satt renderas den i stället för spec-
+   *  summeringen. Tids-/utläggstabellerna kommer fortsatt ur `spec`. */
+  breakdown?: FakturaBreakdown | null | undefined;
 }
 
 /**
@@ -140,29 +155,64 @@ function specContext(spec: InvoiceSpecification | null | undefined, fc: (ore: nu
   };
 }
 
-/** Handlebars-kontext för faktura-mallen (utbruten → håller generatorn ≤8). */
-function fakturaTemplateContext(
-  invoice: FakturaDocInvoice, recipient: string, meta: FakturaDocMeta,
-  formatCurrency: (ore: number) => string, spec?: InvoiceSpecification | null,
-): Record<string, unknown> {
+/** Itemiserad summering (#858) → mall-rader. `deduct`=−, `info`=(parentes), färgad. */
+function breakdownContext(breakdown: FakturaBreakdown | null | undefined, fc: (ore: number) => string): Record<string, unknown> {
+  if (!breakdown) return { useBreakdown: false };
+  return {
+    useBreakdown: true,
+    breakdownRows: breakdown.rows.map((r) => ({
+      label: r.label,
+      amount: r.kind === "deduct" ? `−${fc(r.amountOre)}` : r.kind === "info" ? `(${fc(r.amountOre)})` : fc(r.amountOre),
+      style: r.kind === "deduct" ? "color:#b45309" : r.kind === "info" ? "color:#9ca3af" : "",
+    })),
+  };
+}
+
+/** Belopps-kontexten (netto/moms/summa) — `total` följer breakdown om satt. */
+function amountContext(a: FakturaTemplateArgs, fc: (ore: number) => string): Record<string, unknown> {
+  const { invoice, breakdown } = a;
   const vatOre = invoice.vatOre ?? 0;
-  const date = (invoice.invoiceDate ? new Date(invoice.invoiceDate) : new Date()).toLocaleDateString("sv-SE");
+  return {
+    net: fc(invoice.amount - vatOre), vat: fc(vatOre),
+    total: fc(breakdown ? breakdown.totalOre : invoice.amount),
+    totalLabel: breakdown?.totalLabel ?? "Att betala (inkl moms)",
+  };
+}
+
+/** Faktura-huvudets kontext (nr/datum/mottagare/org + belopp). Utbruten → håller
+ *  `fakturaTemplateContext` under param- och komplexitetsgränsen. */
+function headerContext(a: FakturaTemplateArgs, fc: (ore: number) => string): Record<string, unknown> {
+  const { invoice, recipient, meta } = a;
   return {
     invoiceNumber: invoice.invoiceNumber ?? "—",
     ocr: invoice.ocrReference ?? "",
-    date, matterNumber: meta.matterNumber, matterTitle: meta.matterTitle, recipient,
-    net: formatCurrency(invoice.amount - vatOre), vat: formatCurrency(vatOre), total: formatCurrency(invoice.amount),
+    date: (invoice.invoiceDate ? new Date(invoice.invoiceDate) : new Date()).toLocaleDateString("sv-SE"),
+    matterNumber: meta.matterNumber, matterTitle: meta.matterTitle, recipient,
     organizationName: meta.organizationName ?? "", organizationOrgNumber: meta.organizationOrgNumber ?? "",
-    ...specContext(spec, formatCurrency),
+    ...amountContext(a, fc),
+  };
+}
+
+interface FakturaTemplateArgs {
+  invoice: FakturaDocInvoice; recipient: string; meta: FakturaDocMeta;
+  spec?: InvoiceSpecification | null | undefined; breakdown?: FakturaBreakdown | null | undefined;
+}
+
+/** Handlebars-kontext för faktura-mallen (utbruten → håller generatorn ≤8). */
+function fakturaTemplateContext(a: FakturaTemplateArgs, formatCurrency: (ore: number) => string): Record<string, unknown> {
+  return {
+    ...headerContext(a, formatCurrency),
+    ...specContext(a.spec, formatCurrency),
+    ...breakdownContext(a.breakdown, formatCurrency),
   };
 }
 
 export async function generateFakturaFromTemplate(args: GenerateFakturaFromTemplateArgs): Promise<void> {
-  const { invoice, matterId, recipient, meta, register, utils, spec } = args;
+  const { invoice, matterId, recipient, meta, register, utils, spec, breakdown } = args;
   const { renderHandlebars } = await import("@/lib/client/kostnadsrakning/render-handlebars");
   const { persistGeneratedDoc } = await import("@/lib/client/demo/persist-generated-doc");
   const { formatCurrency } = await import("@/lib/client/utils");
-  const html = renderHandlebars(FAKTURA_TEMPLATE, fakturaTemplateContext(invoice, recipient, meta, formatCurrency, spec));
+  const html = renderHandlebars(FAKTURA_TEMPLATE, fakturaTemplateContext({ invoice, recipient, meta, spec, breakdown }, formatCurrency));
   const bytes = new TextEncoder().encode(html);
   const docId = `faktura-${invoice.id}`;
   const fileName = `Faktura ${invoice.invoiceNumber ?? meta.matterNumber} ${new Date().toISOString().slice(0, 10)}.html`;

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -442,6 +442,55 @@ async function fetchSpecDeductions(repos: Repositories, orgId: OrganizationId, f
 }
 
 /**
+ * Slutregleringens itemiserade nedbrytning (#858) — så BÅDE domstols- och
+ * klientfakturan blir självförklarande. Rena display-siffror (brutto, öre); ÄNDRAR
+ * inga belopp (klient = självrisk − aconton, domstol = statens andel, oförändrat):
+ *   - domstolsfakturan bryter ned "Nedsättning" i självrisk/rådgivning/prutning,
+ *   - klientfakturan visar självrisk-uträkningen (andel × upparbetat),
+ *   - avdragna aconton listas (avräknas EN gång, på klientfakturan; info på domstol).
+ */
+export interface SettlementBreakdown {
+  clientShareBips: number;
+  arvodeBaseNetOre: number;      // bas-arvode (exkl rådgivning) — "andel × X"
+  fullArvodeGrossOre: number;    // allt debiterbart arvode (inkl rådgivning), brutto — domstolens delsumma
+  expensesGrossOre: number;      // utlägg brutto — domstol
+  sjalvriskGrossOre: number;     // klientens självrisk brutto
+  radgivningGrossOre: number;    // rådgivning brutto (0 utom rättshjälp)
+  prutningGrossOre: number;      // byrå-förlust/prutning brutto
+  payerPayableOre: number;       // domstolen att betala
+  clientPayableOre: number;      // klienten att betala (självrisk − aconton)
+  deductedAccontos: SpecDeduction[];
+}
+
+async function buildSettlementBreakdown(repos: Repositories, orgId: OrganizationId, a: {
+  clientShareBips: number; billableMinutes: number; rateOre: number; totalArvodeNet: number;
+  split: CoverageSplit; work: UnfrozenWork; payerGross: number; clientPayable: number;
+  deductedRuns: ReadonlyArray<{ invoiceId?: InvoiceId | null | undefined }>;
+}): Promise<SettlementBreakdown> {
+  const fullArvodeNet = Math.round((a.billableMinutes / 60) * a.rateOre);
+  const radgivningNet = Math.max(0, fullArvodeNet - a.totalArvodeNet);
+  const expensesGrossOre = grossOreOf(expenseBreakdownLines(a.work));
+  const deductedAccontos: SpecDeduction[] = [];
+  for (const r of a.deductedRuns) {
+    if (!r.invoiceId) continue;
+    const inv = await repos.invoices.getByIdInOrg(r.invoiceId, orgId);
+    if (inv) deductedAccontos.push({ invoiceNumber: inv.invoiceNumber ?? "—", date: inv.invoiceDate ?? null, amountOre: inv.amount });
+  }
+  return {
+    clientShareBips: a.clientShareBips,
+    arvodeBaseNetOre: a.totalArvodeNet,
+    fullArvodeGrossOre: arvodeInclVatOre(fullArvodeNet),
+    expensesGrossOre,
+    sjalvriskGrossOre: arvodeInclVatOre(a.split.clientOre),
+    radgivningGrossOre: arvodeInclVatOre(radgivningNet),
+    prutningGrossOre: arvodeInclVatOre(a.split.firmLossOre),
+    payerPayableOre: a.payerGross,
+    clientPayableOre: a.clientPayable,
+    deductedAccontos,
+  };
+}
+
+/**
  * Koppla de DEBITERBARA frysta posterna till FINAL-fakturan (invoice_id) +
  * registrera acconto-avdrag. Utan detta härleder slutfaktura-vyn `0.00` för
  * arvode/utlägg (den summerar bara fakture-länkade poster) trots korrekt
@@ -961,7 +1010,11 @@ export const billingRunRouter = router({
         }
         await emit.invoiceCreated(ctx, clientInvoice);
         await emit.invoiceCreated(ctx, payerInvoice);
-        return { split, clientInvoice, payerInvoice, clientRun, payerRun };
+        const breakdown = await buildSettlementBreakdown(tx, ctx.orgId, {
+          clientShareBips: matter.clientShareBips ?? 0, billableMinutes, rateOre, totalArvodeNet,
+          split, work, payerGross, clientPayable: clientAmount, deductedRuns,
+        });
+        return { split, clientInvoice, payerInvoice, clientRun, payerRun, breakdown };
       });
     }),
 });

--- a/test/unit/lib/kostnadsrakning/generate-faktura-from-template.test.ts
+++ b/test/unit/lib/kostnadsrakning/generate-faktura-from-template.test.ts
@@ -70,4 +70,30 @@ describe("generateFakturaFromTemplate", () => {
     expect(html).toContain("Avgår aconto");
     expect(html).toContain("F-2026-0000"); // avdragen aconto-faktura listad i specifikationen
   });
+
+  it("renderar itemiserad nedbrytning (självrisk/rådgivning/prutning + aconto-info) — #858", async () => {
+    await generateFakturaFromTemplate({
+      invoice: { id: asId<"InvoiceId">("inv-d"), amount: 325_200, vatOre: 65_040, invoiceNumber: "F-2026-0002", invoiceDate: "2026-06-30" },
+      matterId: asId<"MatterId">("m1"),
+      recipient: "Domstolen",
+      meta: { matterNumber: "Ä-1", matterTitle: "Tvist" },
+      register: { mutateAsync: registerMutateAsync },
+      utils,
+      breakdown: {
+        rows: [
+          { label: "Klientens självrisk", amountOre: 81_300, kind: "deduct" },
+          { label: "Rådgivning (faktureras klienten)", amountOre: 203_250, kind: "deduct" },
+          { label: "Betalt via aconto — faktura F-2026-0001 (2026-04-01)", amountOre: 50_000, kind: "info" },
+        ],
+        totalLabel: "Domstolen betalar — att betala (inkl moms)",
+        totalOre: 325_200,
+      },
+    });
+    const html = new TextDecoder().decode(persistGeneratedDoc.mock.calls[0]![0].bytes as Uint8Array);
+    expect(html).toContain("Klientens självrisk");
+    expect(html).toContain("Rådgivning (faktureras klienten)");
+    expect(html).toContain("Betalt via aconto — faktura F-2026-0001");
+    expect(html).toContain("Domstolen betalar — att betala");
+    expect(html).not.toContain("Nedsättning"); // lumpen ersatt av itemiserade rader
+  });
 });

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -493,6 +493,25 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
     expect(res.payerRun.recipient).toBe("DOMSTOL"); // slutfaktura till domstol
   });
 
+  it("returnerar itemiserad nedbrytning som reconcilar mot båda beloppen (#858)", async () => {
+    const { caller: c } = caller({ paymentMethod: "RATTSHJALP", clientShareBips: 2000, taxaHasFTax: true }, 999999, 180);
+    await c.billingRun.createAcconto({ matterId: "m-1", clientShareBips: 2000, amountOre: 50000 });
+    const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "DOMSTOL" });
+    const b = res.breakdown;
+    // 3 tim × 162 600 = 487 800 net arvode; bas (2 tim) 325 200; rådgivning 162 600.
+    expect(b.arvodeBaseNetOre).toBe(325_200);
+    expect(b.fullArvodeGrossOre).toBe(609_750);   // 487 800 × 1,25
+    expect(b.sjalvriskGrossOre).toBe(81_300);     // 65 040 × 1,25
+    expect(b.radgivningGrossOre).toBe(203_250);   // 162 600 × 1,25
+    expect(b.prutningGrossOre).toBe(0);
+    expect(b.deductedAccontos).toHaveLength(1);
+    expect(b.deductedAccontos[0]!.amountOre).toBe(50_000);
+    // Domstol: full arvode − självrisk − rådgivning − prutning = domstolens belopp.
+    expect(b.fullArvodeGrossOre + b.expensesGrossOre - b.sjalvriskGrossOre - b.radgivningGrossOre - b.prutningGrossOre).toBe(b.payerPayableOre);
+    // Klient: självrisk − avräknade aconton = klientens belopp.
+    expect(b.sjalvriskGrossOre - b.deductedAccontos.reduce((s, d) => s + d.amountOre, 0)).toBe(b.clientPayableOre);
+  });
+
   it("rättshjälp via KR (#828): kräver registrerat beslut; domsbeloppet läses från KR:n; KR konsumeras EJ utan markeras FAKTURERAD", async () => {
     const { ds, caller: c } = caller({ paymentMethod: "RATTSHJALP", clientShareBips: 2000, taxaHasFTax: true }, 999999, 180);
     const kr = await c.billingRun.createKostnadsrakning({ matterId: "m-1" });


### PR DESCRIPTION
## Problem (från live-test av demon)

Vid rättshjälps-slutreglering var fakturorna otydliga:
- **Domstols-fakturan** visade en enda lump **"Nedsättning"** + belopp — man förstod inte hur beloppet räknats fram.
- **Klientens Slutfaktura** visade varken de betalda aconton eller hur självrisken räknats.

## Fix (rent display — beloppen är oförändrade)

- **Domstols-fakturan** bryter ned residualen i **Klientens självrisk / Rådgivning / Prutning** (en rad var) och listar avdragna aconton som **info-rader** (spårbarhet; avräknas ej här).
- **Klientens Slutfaktura** visar **självrisk-uträkningen** ("andel % av upparbetat arvode X, inkl moms") + de avräknade aconton per rad → att betala.
- Aconton avräknas **en gång**, på klientfakturan (bekräftat med användaren).

`billingRun.settleCoverage` returnerar en `breakdown` med de itemiserade komponenterna (brutto); dokumentgeneratorn renderar dem via mallen. Inga belopp ändras — klient = självrisk − aconton, domstol = statens andel.

## Test

- `settleCoverage`-breakdown reconcilar mot båda beloppen (full arvode − självrisk − rådgivning − prutning = domstol; självrisk − aconton = klient).
- Mall renderar de itemiserade raderna + info-rader, ingen "Nedsättning"-lump.
- Full svit grön (3390 pass), typecheck/lint/knip/deps/duplicates/build:demo grönt.

Closes #858
Refs #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)