### PR TITLE
fix(billing): rådgivningstimmen bara i kostnadsräkningen, ej på domstols-fakturan

### DIFF
--- a/src/app/matters/[id]/_settlement-dialog.tsx
+++ b/src/app/matters/[id]/_settlement-dialog.tsx
@@ -15,14 +15,14 @@ import type { inferRouterOutputs } from "@trpc/server";
 import { useState } from "react";
 import { DecimalInput } from "@/components/ui/decimal-input";
 import { Modal } from "@/components/ui/modal";
-import { generateFakturaFromTemplate, type BreakdownRow, type DocUtils, type FakturaBreakdown, type FakturaDocMeta, type InvoiceSpecification, type RegisterMut } from "@/lib/client/kostnadsrakning/generate-faktura-doc";
+import { generateFakturaFromTemplate, type BreakdownRow, type DocUtils, type FakturaBreakdown, type FakturaDocMeta, type RegisterMut } from "@/lib/client/kostnadsrakning/generate-faktura-doc";
 import { trpc } from "@/lib/client/trpc";
 import { formatCurrency } from "@/lib/client/utils";
 import { useVatDisplay } from "@/lib/client/vat/vat-display-context";
 import type { AppRouter } from "@/lib/server/routers/_app";
 import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
 import type { PaymentMethod } from "@/lib/shared/schemas/enums";
-import type { InvoiceId, MatterId } from "@/lib/shared/schemas/ids";
+import type { MatterId } from "@/lib/shared/schemas/ids";
 
 interface SplitData {
   clientOre: number;
@@ -93,12 +93,14 @@ type Breakdown = SettleResult["breakdown"];
 
 const svd = (d: string | Date | null | undefined): string => (d ? new Date(d).toLocaleDateString("sv-SE") : "");
 
-/** Betalar-fakturans (domstol/försäkring) nedbrytning (#858): tids-/utläggsraderna
- *  kommer ur `spec`; här bara AVDRAGEN — självrisk/rådgivning/prutning (belopps-
- *  påverkande) + aconton som info-rader (avräknas på klientfakturan, ej här). */
+/** Betalar-fakturans (domstol/försäkring) nedbrytning (#858/#860): arvode (på
+ *  BAS-minuter, exkl rådgivning) + utlägg − självrisk − prutning + aconton som
+ *  info-rader (avräknas på klientfakturan, ej här). Rådgivningstimmen syns ALDRIG
+ *  här — bara i kostnadsräkningen (#860). */
 function payerBreakdown(b: Breakdown, payerLabel: string): FakturaBreakdown {
-  const rows: BreakdownRow[] = [{ label: "Klientens självrisk", amountOre: b.sjalvriskGrossOre, kind: "deduct" }];
-  if (b.radgivningGrossOre > 0) rows.push({ label: "Rådgivning (faktureras klienten)", amountOre: b.radgivningGrossOre, kind: "deduct" });
+  const rows: BreakdownRow[] = [{ label: "Arvode (timkostnadsnorm)", amountOre: b.baseArvodeGrossOre, kind: "add" }];
+  if (b.expensesGrossOre > 0) rows.push({ label: "Utlägg", amountOre: b.expensesGrossOre, kind: "add" });
+  rows.push({ label: "Klientens självrisk", amountOre: b.sjalvriskGrossOre, kind: "deduct" });
   if (b.prutningGrossOre > 0) rows.push({ label: "Prutning (byrån bär)", amountOre: b.prutningGrossOre, kind: "deduct" });
   for (const d of b.deductedAccontos) rows.push({ label: `Betalt via aconto — faktura ${d.invoiceNumber}${d.date ? ` (${svd(d.date)})` : ""}`, amountOre: d.amountOre, kind: "info" });
   return { rows, totalLabel: `${payerLabel} — att betala (inkl moms)`, totalOre: b.payerPayableOre };
@@ -119,14 +121,12 @@ function clientBreakdown(b: Breakdown, isRattshjalp: boolean): FakturaBreakdown 
 async function generateSettlementDocs(res: SettleResult, opts: {
   matterId: MatterId; matter: MatterDetail | undefined; org: OrgSettings | undefined;
   payerLabel: string; isRattshjalp: boolean; register: RegisterMut; utils: DocUtils;
-  fetchSpec: (invoiceId: InvoiceId) => Promise<InvoiceSpecification>;
 }): Promise<void> {
-  const { matterId, matter, org, payerLabel, isRattshjalp, register, utils, fetchSpec } = opts;
+  const { matterId, matter, org, payerLabel, isRattshjalp, register, utils } = opts;
   const meta = settlementMeta(matter, org);
-  // Betalar-fakturan: tids-/utläggsspec (#856) + itemiserad nedbrytning (#858).
-  const payerSpec = await fetchSpec(res.payerInvoice.id);
-  await generateFakturaFromTemplate({ invoice: res.payerInvoice, matterId, recipient: payerLabel, meta, register, utils, spec: payerSpec, breakdown: payerBreakdown(res.breakdown, payerLabel) });
-  // Klientfakturan: självrisk-uträkning + aconto-avdrag (ingen tidslista).
+  // Båda fakturorna renderas ur den itemiserade nedbrytningen (#858/#860) — inga
+  // per-rad-tidslistor här (de + rådgivningsnotisen bor i kostnadsräkningen).
+  await generateFakturaFromTemplate({ invoice: res.payerInvoice, matterId, recipient: payerLabel, meta, register, utils, breakdown: payerBreakdown(res.breakdown, payerLabel) });
   await generateFakturaFromTemplate({ invoice: res.clientInvoice, matterId, recipient: clientNameOf(matter), meta, register, utils, breakdown: clientBreakdown(res.breakdown, isRattshjalp) });
 }
 
@@ -163,7 +163,6 @@ export function SettlementDialog({ matterId, paymentMethod, onClose }: { matterI
         await generateSettlementDocs(res, {
           matterId, matter: matterQ.data, org: orgQ.data, payerLabel: cfg.payerLabel,
           isRattshjalp: paymentMethod === "RATTSHJALP", register, utils,
-          fetchSpec: (invoiceId) => utils.billingRun.invoiceSpecification.fetch({ matterId, invoiceId }),
         });
       } catch (e) { console.warn("[settlement] fakturadokument misslyckades:", e); }
       void utils.billingRun.list.invalidate({ matterId });

--- a/src/lib/client/kostnadsrakning/render-pdf.ts
+++ b/src/lib/client/kostnadsrakning/render-pdf.ts
@@ -147,6 +147,13 @@ export async function renderKostnadsrakningPdf(input: RenderInput): Promise<Uint
   page.drawText(String(c.totalInclFormatted), { x: MARGIN + 350, y, size: 12, font: bold });
   y -= 28;
 
+  // Rådgivningstimme-notis (#860): visas ENDAST här (ej på domstols-fakturan),
+  // som en textrad utan belopp — klienten har betalat den separat.
+  if (typeof c.radgivningNotice === "string" && c.radgivningNotice) {
+    page.drawText(c.radgivningNotice, { x: MARGIN, y, size: 9, font, color: rgb(0.3, 0.3, 0.3) });
+    y -= 20;
+  }
+
   // Sidfot
   const footerParts = [
     input.meta.defenderName,

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -451,11 +451,10 @@ async function fetchSpecDeductions(repos: Repositories, orgId: OrganizationId, f
  */
 export interface SettlementBreakdown {
   clientShareBips: number;
-  arvodeBaseNetOre: number;      // bas-arvode (exkl rådgivning) — "andel × X"
-  fullArvodeGrossOre: number;    // allt debiterbart arvode (inkl rådgivning), brutto — domstolens delsumma
+  arvodeBaseNetOre: number;      // bas-arvode (exkl rådgivning), netto — "andel × X"
+  baseArvodeGrossOre: number;    // bas-arvode (exkl rådgivning), brutto — domstolens arvode-rad
   expensesGrossOre: number;      // utlägg brutto — domstol
   sjalvriskGrossOre: number;     // klientens självrisk brutto
-  radgivningGrossOre: number;    // rådgivning brutto (0 utom rättshjälp)
   prutningGrossOre: number;      // byrå-förlust/prutning brutto
   payerPayableOre: number;       // domstolen att betala
   clientPayableOre: number;      // klienten att betala (självrisk − aconton)
@@ -463,12 +462,11 @@ export interface SettlementBreakdown {
 }
 
 async function buildSettlementBreakdown(repos: Repositories, orgId: OrganizationId, a: {
-  clientShareBips: number; billableMinutes: number; rateOre: number; totalArvodeNet: number;
-  split: CoverageSplit; work: UnfrozenWork; payerGross: number; clientPayable: number;
-  deductedRuns: ReadonlyArray<{ invoiceId?: InvoiceId | null | undefined }>;
+  clientShareBips: number; totalArvodeNet: number; split: CoverageSplit; work: UnfrozenWork;
+  payerGross: number; clientPayable: number; deductedRuns: ReadonlyArray<{ invoiceId?: InvoiceId | null | undefined }>;
 }): Promise<SettlementBreakdown> {
-  const fullArvodeNet = Math.round((a.billableMinutes / 60) * a.rateOre);
-  const radgivningNet = Math.max(0, fullArvodeNet - a.totalArvodeNet);
+  // Rådgivningstimmen ingår ALDRIG i domstolens arvode (#860) — arvodet värderas
+  // på bas-minuterna (exkl rådgivning). Rådgivningen syns bara i kostnadsräkningen.
   const expensesGrossOre = grossOreOf(expenseBreakdownLines(a.work));
   const deductedAccontos: SpecDeduction[] = [];
   for (const r of a.deductedRuns) {
@@ -479,10 +477,9 @@ async function buildSettlementBreakdown(repos: Repositories, orgId: Organization
   return {
     clientShareBips: a.clientShareBips,
     arvodeBaseNetOre: a.totalArvodeNet,
-    fullArvodeGrossOre: arvodeInclVatOre(fullArvodeNet),
+    baseArvodeGrossOre: arvodeInclVatOre(a.totalArvodeNet),
     expensesGrossOre,
     sjalvriskGrossOre: arvodeInclVatOre(a.split.clientOre),
-    radgivningGrossOre: arvodeInclVatOre(radgivningNet),
     prutningGrossOre: arvodeInclVatOre(a.split.firmLossOre),
     payerPayableOre: a.payerGross,
     clientPayableOre: a.clientPayable,
@@ -1011,7 +1008,7 @@ export const billingRunRouter = router({
         await emit.invoiceCreated(ctx, clientInvoice);
         await emit.invoiceCreated(ctx, payerInvoice);
         const breakdown = await buildSettlementBreakdown(tx, ctx.orgId, {
-          clientShareBips: matter.clientShareBips ?? 0, billableMinutes, rateOre, totalArvodeNet,
+          clientShareBips: matter.clientShareBips ?? 0, totalArvodeNet,
           split, work, payerGross, clientPayable: clientAmount, deductedRuns,
         });
         return { split, clientInvoice, payerInvoice, clientRun, payerRun, breakdown };

--- a/src/lib/shared/rattshjalp.ts
+++ b/src/lib/shared/rattshjalp.ts
@@ -50,8 +50,8 @@ export function computeRadgivningsavgift(opts: { hasFTax?: boolean } = {}): Radg
  * kostnadsräkning (#383): transparens, inget belopp domstolen ska betala.
  */
 export function radgivningTextRad(): string {
-  return "Klienten har betalat en rådgivningstimme (1 tim) enligt rättshjälpstaxan separat. " +
-    "Ingår ej i denna kostnadsräkning.";
+  return "Rådgivningstimme (1 tim) fakturerad och betald av klienten separat enligt " +
+    "rättshjälpstaxan — ingår ej i denna kostnadsräkning.";
 }
 
 export interface MatterSettlementInput {

--- a/test/unit/lib/kostnadsrakning/generate-faktura-from-template.test.ts
+++ b/test/unit/lib/kostnadsrakning/generate-faktura-from-template.test.ts
@@ -81,8 +81,8 @@ describe("generateFakturaFromTemplate", () => {
       utils,
       breakdown: {
         rows: [
+          { label: "Arvode (timkostnadsnorm)", amountOre: 406_500, kind: "add" },
           { label: "Klientens självrisk", amountOre: 81_300, kind: "deduct" },
-          { label: "Rådgivning (faktureras klienten)", amountOre: 203_250, kind: "deduct" },
           { label: "Betalt via aconto — faktura F-2026-0001 (2026-04-01)", amountOre: 50_000, kind: "info" },
         ],
         totalLabel: "Domstolen betalar — att betala (inkl moms)",
@@ -90,10 +90,11 @@ describe("generateFakturaFromTemplate", () => {
       },
     });
     const html = new TextDecoder().decode(persistGeneratedDoc.mock.calls[0]![0].bytes as Uint8Array);
+    expect(html).toContain("Arvode (timkostnadsnorm)");
     expect(html).toContain("Klientens självrisk");
-    expect(html).toContain("Rådgivning (faktureras klienten)");
     expect(html).toContain("Betalt via aconto — faktura F-2026-0001");
     expect(html).toContain("Domstolen betalar — att betala");
     expect(html).not.toContain("Nedsättning"); // lumpen ersatt av itemiserade rader
+    expect(html).not.toContain("Rådgivning"); // rådgivningstimmen syns ALDRIG på domstols-fakturan (#860)
   });
 });

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -498,16 +498,15 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
     await c.billingRun.createAcconto({ matterId: "m-1", clientShareBips: 2000, amountOre: 50000 });
     const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "DOMSTOL" });
     const b = res.breakdown;
-    // 3 tim × 162 600 = 487 800 net arvode; bas (2 tim) 325 200; rådgivning 162 600.
+    // Domstolens arvode värderas på BAS-minuterna (2 tim, exkl rådgivning) = 325 200 net.
     expect(b.arvodeBaseNetOre).toBe(325_200);
-    expect(b.fullArvodeGrossOre).toBe(609_750);   // 487 800 × 1,25
+    expect(b.baseArvodeGrossOre).toBe(406_500);   // 325 200 × 1,25 — rådgivning ingår EJ (#860)
     expect(b.sjalvriskGrossOre).toBe(81_300);     // 65 040 × 1,25
-    expect(b.radgivningGrossOre).toBe(203_250);   // 162 600 × 1,25
     expect(b.prutningGrossOre).toBe(0);
     expect(b.deductedAccontos).toHaveLength(1);
     expect(b.deductedAccontos[0]!.amountOre).toBe(50_000);
-    // Domstol: full arvode − självrisk − rådgivning − prutning = domstolens belopp.
-    expect(b.fullArvodeGrossOre + b.expensesGrossOre - b.sjalvriskGrossOre - b.radgivningGrossOre - b.prutningGrossOre).toBe(b.payerPayableOre);
+    // Domstol: bas-arvode + utlägg − självrisk − prutning = domstolens belopp (rådgivning ingår ej).
+    expect(b.baseArvodeGrossOre + b.expensesGrossOre - b.sjalvriskGrossOre - b.prutningGrossOre).toBe(b.payerPayableOre);
     // Klient: självrisk − avräknade aconton = klientens belopp.
     expect(b.sjalvriskGrossOre - b.deductedAccontos.reduce((s, d) => s + d.amountOre, 0)).toBe(b.clientPayableOre);
   });


### PR DESCRIPTION
## Problem (live-test)

I rättshjälpsärenden syntes rådgivningstimmen på **domstols-fakturan** (både i tidslistan och som en "Rådgivning"-avdragsrad, #859). Den ska inte finnas där alls — bara i kostnadsräkningen, som en notis.

## Fix

- **Domstols-fakturan**: arvodet värderas på **bas-minuterna** (exkl rådgivning) och visas som en arvode-rad. Ingen rådgivnings-rad, och ingen per-rad-tidslista (den bäddade in rådgivningstimmen — 60 min är en värderings-carve-out, ingen egen post). Bas-arvode + utlägg − självrisk − prutning = domstolens belopp. **Beloppet är oförändrat** (statens andel).
- **Kostnadsräkningen (PDF)**: renderar nu `radgivningNotice` — den var beräknad i contexten men ritades aldrig ut. Notistexten uppdaterad till "Rådgivningstimme (1 tim) fakturerad och betald av klienten separat …".

## Test

- Breakdown-reconciliation uppdaterad: `baseArvodeGross + utlägg − självrisk − prutning = domstol` (rådgivning ingår ej).
- Mall-test: domstols-fakturan innehåller arvode-rad + självrisk + aconto-info, och **inte** "Rådgivning".
- Full svit grön (3390 pass), typecheck/lint/knip/deps/duplicates/build:demo grönt.

Closes #860
Refs #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)