### PR TITLE
feat(demo): rådgivningstimme först + fler timmar i Umgängestvist Carlsson

### DIFF
--- a/tooling/scripts/seed-data.ts
+++ b/tooling/scripts/seed-data.ts
@@ -356,6 +356,9 @@ function buildTimeEntries(orgId: string, users: UserSeed[]): SeedDataset["timeEn
   const activeMatters = MATTERS.filter((m) => m.status === "ACTIVE");
   let teSeq = 0;
   activeMatters.forEach((matter, mi) => {
+    // Umgängestvist Carlsson har en dedikerad, kronologiskt koherent tidslogg
+    // (rådgivningstimmen först) — se nedan (#862).
+    if (matter.id === "m-010-vardnad-2") return;
     const count = 4 + (mi % 3); // 4,5,6,4,5,6…
     for (let j = 0; j < count; j++) {
       teSeq++;
@@ -373,7 +376,36 @@ function buildTimeEntries(orgId: string, users: UserSeed[]): SeedDataset["timeEn
       });
     }
   });
+  appendVardnad2TimeEntries(out, orgId, users);
   return out;
+}
+
+/**
+ * Dedikerad tidslogg för "Umgängestvist Carlsson" (m-010, rättshjälp) (#862):
+ * rådgivningstimmen ("Första möte med klient i ärendet") ligger KRONOLOGISKT
+ * FÖRST (ärendets första händelse), följt av några arbetsposter — totalt ~5,75 tim
+ * så ärendet får ett rimligt antal timmar. Ärendet skapades för 15 dagar sedan.
+ */
+function appendVardnad2TimeEntries(out: SeedDataset["timeEntries"], orgId: string, users: UserSeed[]): void {
+  const lawyer = users.find((u) => u.role === "LAWYER") ?? users[0];
+  if (!lawyer) return;
+  const rows: Array<{ daysAgo: number; minutes: number; description: string }> = [
+    { daysAgo: 14, minutes: 60, description: "Första möte med klient i ärendet" }, // rådgivningstimmen — FÖRST
+    { daysAgo: 11, minutes: 60, description: "Genomgång av handlingar och underlag" },
+    { daysAgo: 8, minutes: 90, description: "Upprättande av inlaga till tingsrätten" },
+    { daysAgo: 4, minutes: 75, description: "Telefonkontakt med motpartens ombud" },
+    { daysAgo: 2, minutes: 60, description: "Förberedelse inför sammanträde" },
+  ];
+  rows.forEach((r, i) => {
+    out.push({
+      id: `te-m010-${i + 1}`,
+      organizationId: orgId,
+      userId: lawyer.id, matterId: "m-010-vardnad-2", date: isoDate(-r.daysAgo, 9),
+      minutes: r.minutes, description: r.description,
+      hourlyRate: lawyer.hourlyRate, billable: true,
+      invoiceId: null, createdAt: isoDate(-r.daysAgo, 9), updatedAt: isoDate(-r.daysAgo, 9),
+    });
+  });
 }
 
 function buildExpenses(orgId: string, users: UserSeed[]): SeedDataset["expenses"] {


### PR DESCRIPTION
## Vad

I demo-ärendet **"Umgängestvist Carlsson"** (m-010, rättshjälp):
- Rådgivningstimmen **"Första möte med klient i ärendet"** (60 min) finns nu som en tidspost och ligger **kronologiskt först** (ärendets första händelse, 14 dagar sedan).
- Ärendet fick fler timmar — totalt **5,75 tim** (rådgivning + fyra arbetsposter).

## Hur

Dedikerad, kronologiskt koherent tidslogg för m-010 i `seed-data.ts`. De tidigare procedurgenererade posterna för ärendet daterades ~71–79 dagar sedan (före ärendets skapande för 15 dagar sedan) — de ersätts av den nya loggen.

Verifierat i genererad `demo-seed.json`:
```
2026-06-18   60min Första möte med klient i ärendet   ← först
2026-06-21   60min Genomgång av handlingar och underlag
2026-06-24   90min Upprättande av inlaga till tingsrätten
2026-06-28   75min Telefonkontakt med motpartens ombud
2026-06-30   60min Förberedelse inför sammanträde
```

## Test

Seed-/demo-svit grön (seed-smoke, seed-hydration, invoice-coherence, build-demo-repo, demo-generator). Full svit 3390 pass, typecheck/lint/knip/deps/duplicates/build:demo grönt.

Closes #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)