### PR TITLE
feat(billing): full specifikation i kostnadsräkningen (tider, arvode, utlägg)

### DIFF
--- a/src/lib/client/kostnadsrakning/render-pdf.ts
+++ b/src/lib/client/kostnadsrakning/render-pdf.ts
@@ -49,6 +49,13 @@ interface ExpenseRow {
   inclVatFormatted: string;
 }
 
+/** En formaterad tidsrad i templateContext.timeLines (#863). */
+interface TimeRow {
+  date: string;
+  description: string;
+  minutesFormatted: string;
+}
+
 export interface RenderInput {
   result: KostnadsrakningResult;
   meta: {
@@ -102,44 +109,27 @@ export async function renderKostnadsrakningPdf(input: RenderInput): Promise<Uint
   page.drawLine({ start: { x: MARGIN, y }, end: { x: PAGE_W - MARGIN, y }, thickness: 0.5, color: rgb(0.7, 0.7, 0.7) });
   y -= 18;
 
-  // Huvudförhandling
-  page.drawText("Huvudförhandling", { x: MARGIN, y, size: 11, font: bold });
-  y -= 14;
-  page.drawText(
-    `Start: ${String(c.hufStart)}   Slut: ${String(c.hufEnd)}   (${String(c.huvudforhandlingFormatted)})`,
-    { x: MARGIN, y, size: 10, font },
-  );
-  y -= 22;
+  const ctx: PdfCtx = { page, font, bold, marginX: MARGIN, pageW: PAGE_W, lineColor: rgb(0.7, 0.7, 0.7) };
 
-  // Arvode
-  page.drawText(`Arvode (DVFS 2025:6, nivå ${String(c.taxaLevel)})`, {
-    x: MARGIN, y, size: 11, font: bold,
-  });
-  y -= 14;
-  if (c.taxaApplies) {
-    drawRow(page, y, font, "Brottmålstaxa", String(c.arvodeExclFormatted));
+  // Tidsspecifikation (per-post) — #863
+  y = drawTimeSection(ctx, c, y);
+
+  // Huvudförhandling — bara om det finns någon (brottmål; rättshjälp har ingen).
+  if (typeof c.huvudforhandlingMinutes === "number" && c.huvudforhandlingMinutes > 0) {
+    page.drawText("Huvudförhandling", { x: MARGIN, y, size: 11, font: bold });
     y -= 14;
-    drawRow(page, y, font, "+ Moms 25 %", String(c.arvodeMomsFormatted));
-    y -= 14;
-    drawRow(page, y, bold, "Arvode inkl moms", String(c.arvodeInclFormatted));
-    y -= 22;
-  } else {
-    page.drawText(`Förhandlingstiden överstiger taxans maxgräns (3 tim 45 min).`, {
-      x: MARGIN, y, size: 9, font, color: rgb(0.7, 0.3, 0),
-    });
-    y -= 12;
-    page.drawText(`Ersättning enligt timkostnadsnormen 1 626 kr/h ex moms (DVFS 2025:6 § 8).`, {
-      x: MARGIN, y, size: 9, font, color: rgb(0.7, 0.3, 0),
-    });
+    page.drawText(
+      `Start: ${String(c.hufStart)}   Slut: ${String(c.hufEnd)}   (${String(c.huvudforhandlingFormatted)})`,
+      { x: MARGIN, y, size: 10, font },
+    );
     y -= 22;
   }
 
+  // Arvode — alltid med belopp (timkostnadsnorm för rättshjälp, annars brottmålstaxa).
+  y = drawArvodeSection(ctx, c, y);
+
   // Utlägg (tabell + summa) — egen sektion för att hålla komplexiteten nere.
-  y = drawExpenseSection(
-    { page, font, bold, marginX: MARGIN, pageW: PAGE_W, lineColor: rgb(0.7, 0.7, 0.7) },
-    c,
-    y,
-  );
+  y = drawExpenseSection(ctx, c, y);
 
   // TOTAL
   page.drawLine({ start: { x: MARGIN, y: y + 8 }, end: { x: PAGE_W - MARGIN, y: y + 8 }, thickness: 1, color: rgb(0, 0, 0) });
@@ -208,6 +198,56 @@ function drawExpenseSection(ctx: PdfCtx, c: Record<string, unknown>, startY: num
   page.drawText(s.exclVatFormatted, { x: ctx.marginX + 290, y, size: 10, font: bold });
   page.drawText(s.vatFormatted, { x: ctx.marginX + 370, y, size: 10, font: bold });
   page.drawText(s.inclVatFormatted, { x: ctx.marginX + 440, y, size: 10, font: bold });
+  y -= 22;
+  return y;
+}
+
+/** Rita arvode-sektionen (rubrik + ev. norm-not + belopp) (#863). Returnerar ny y. */
+function drawArvodeSection(ctx: PdfCtx, c: Record<string, unknown>, startY: number): number {
+  const { page, font, bold, marginX } = ctx;
+  let y = startY;
+  const norm = c.isTimkostnadsnorm === true;
+  page.drawText(norm ? "Arvode (timkostnadsnormen)" : `Arvode (DVFS 2025:6, nivå ${String(c.taxaLevel)})`, { x: marginX, y, size: 11, font: bold });
+  y -= 14;
+  const note = ((c.taxaNotes as string[] | undefined) ?? [])[0];
+  if (note) {
+    page.drawText(note, { x: marginX, y, size: 8, font, color: ctx.lineColor });
+    y -= 13;
+  }
+  drawRow(page, y, font, norm ? "Arvode exkl moms" : "Brottmålstaxa", String(c.arvodeExclFormatted));
+  y -= 14;
+  drawRow(page, y, font, "+ Moms 25 %", String(c.arvodeMomsFormatted));
+  y -= 14;
+  drawRow(page, y, bold, "Arvode inkl moms", String(c.arvodeInclFormatted));
+  return y - 22;
+}
+
+/** Rita tidsspecifikations-tabell (datum · åtgärd · tid) + summa arbetstid (#863).
+ *  Returnerar ny y-position. No-op om inga tidsrader. */
+function drawTimeSection(ctx: PdfCtx, c: Record<string, unknown>, startY: number): number {
+  const lines = (c.timeLines as TimeRow[] | undefined) ?? [];
+  let y = startY;
+  if (lines.length === 0) return y;
+  const { page, font, bold } = ctx;
+  page.drawText("Tidsspecifikation", { x: ctx.marginX, y, size: 11, font: bold });
+  y -= 14;
+  page.drawText("Datum", { x: ctx.marginX, y, size: 9, font: bold });
+  page.drawText("Åtgärd", { x: ctx.marginX + 80, y, size: 9, font: bold });
+  page.drawText("Tid", { x: ctx.marginX + 450, y, size: 9, font: bold });
+  y -= 14;
+  for (const l of lines) {
+    page.drawText(l.date, { x: ctx.marginX, y, size: 9, font });
+    const desc = l.description.length > 58 ? l.description.slice(0, 56) + "…" : l.description;
+    page.drawText(desc, { x: ctx.marginX + 80, y, size: 9, font });
+    page.drawText(l.minutesFormatted, { x: ctx.marginX + 450, y, size: 9, font });
+    y -= 12;
+    if (y < 120) break; // safety — single-page
+  }
+  y -= 6;
+  page.drawLine({ start: { x: ctx.marginX, y }, end: { x: ctx.pageW - ctx.marginX, y }, thickness: 0.5, color: ctx.lineColor });
+  y -= 14;
+  page.drawText("Summa arbetstid", { x: ctx.marginX, y, size: 10, font: bold });
+  page.drawText(String(c.billableArbetsFormatted), { x: ctx.marginX + 450, y, size: 10, font: bold });
   y -= 22;
   return y;
 }

--- a/src/lib/shared/kostnadsrakning.ts
+++ b/src/lib/shared/kostnadsrakning.ts
@@ -18,7 +18,7 @@
  */
 
 import { computeBrottmalstaxa, computeTimkostnadsnorm, type TaxaLevel, type TaxaResult } from "./brottmalstaxa";
-import { radgivningTextRad } from "./rattshjalp";
+import { RADGIVNING_MINUTES, radgivningTextRad } from "./rattshjalp";
 import { splitVat } from "./vat";
 
 export interface ExpenseInput {
@@ -195,6 +195,9 @@ function buildKrTemplateContext(a: KrTemplateArgs): Record<string, unknown> {
     huvudforhandlingFormatted: formatMinutes(a.huvudforhandlingMinutes),
     taxaLevel: a.level,
     taxaApplies: a.taxa.kind === "taxa-applies",
+    // Rättshjälp/övrigt värderas på timkostnadsnormen (ej brottmålstaxan) — styr
+    // rubrik/etiketter i dokumentet (#863).
+    isTimkostnadsnorm: !(a.input.isTaxeArende ?? true),
     taxaIntervalLabel: a.taxa.intervalLabel,
     taxaNotes: a.taxa.notes,
     arvodeExclVat: a.arvodeExclVat,
@@ -246,7 +249,11 @@ export function buildKostnadsrakningContext(input: BuildInput): KostnadsrakningR
   const totalArbetsMinutes = billableArbetsMinutes + huvudforhandlingMinutes;
 
   const level: TaxaLevel = input.taxaLevel ?? 1;
-  const taxa = resolveTaxa(input, huvudforhandlingMinutes, totalArbetsMinutes, level);
+  // Rådgivningstimmen faktureras klienten separat → ingår EJ i statens arvode
+  // (#860/#863) och dras därför av från arvodes-underlaget (matchar notisen).
+  const radgivningAvdrag = input.matter.radgivningPaid ? RADGIVNING_MINUTES : 0;
+  const arvodeArbetsMinutes = Math.max(0, totalArbetsMinutes - radgivningAvdrag);
+  const taxa = resolveTaxa(input, huvudforhandlingMinutes, arvodeArbetsMinutes, level);
 
   // Bara billable utlägg ska faktureras — non-billable är firmans egen kostnad.
   const expenses = input.expenses.filter((e) => e.billable !== false);

--- a/test/unit/lib/kostnadsrakning/render-pdf.test.ts
+++ b/test/unit/lib/kostnadsrakning/render-pdf.test.ts
@@ -49,4 +49,28 @@ describe("renderKostnadsrakningPdf", () => {
     });
     expect(pdfHeader(bytes)).toBe("%PDF");
   });
+
+  it("renderar rättshjälps-KR med tidsspecifikation + rådgivningsnotis (#863)", async () => {
+    const result = buildKostnadsrakningContext({
+      matter: { matterNumber: "2026-0010", title: "Umgängestvist Carlsson", clientName: "Cecilia Carlsson", radgivningPaid: true },
+      defender: { name: "Anna Advokat" },
+      isTaxeArende: false,
+      hufStart: new Date("2026-06-30T09:00:00Z"), hufEnd: new Date("2026-06-30T09:00:00Z"), // ingen HUF
+      taxaLevel: 1, hasFTax: true,
+      timeEntries: [
+        { id: "t1", date: "2026-06-18", description: "Första möte med klient i ärendet", minutes: 60, billable: true },
+        { id: "t2", date: "2026-06-24", description: "Upprättande av inlaga till tingsrätten", minutes: 90, billable: true },
+      ],
+      expenses: [{ id: "x1", date: new Date("2026-06-25T00:00:00Z"), description: "Ansökningsavgift", amount: 90000, vatRate: 0, vatIncluded: false }],
+    });
+    // Kontext: tidsspec finns, arvodet exkluderar rådgivningstimmen, notis satt.
+    expect(result.timeLines).toHaveLength(2);
+    expect((result.templateContext.radgivningNotice as string | null)).toMatch(/rådgivningstimme/i);
+    const bytes = await renderKostnadsrakningPdf({
+      result,
+      meta: { matterNumber: "2026-0010", matterTitle: "Umgängestvist Carlsson", clientName: "Cecilia Carlsson", courtName: "Stockholms tingsrätt", defenderName: "Anna Advokat" },
+    });
+    expect(pdfHeader(bytes)).toBe("%PDF");
+    expect(bytes.byteLength).toBeGreaterThan(800);
+  });
 });

--- a/test/unit/shared/kostnadsrakning.test.ts
+++ b/test/unit/shared/kostnadsrakning.test.ts
@@ -257,4 +257,23 @@ describe("buildKostnadsrakningContext — rådgivningstimme (#383)", () => {
     expect(withR.templateContext.arvodeInclVat).toBe(without.templateContext.arvodeInclVat);
     expect(withR.templateContext.totalInclVat).toBe(without.templateContext.totalInclVat);
   });
+
+  it("icke-taxa (rättshjälp) + radgivningPaid → arvodet exkluderar rådgivningstimmen (#863)", () => {
+    const input = {
+      ...baseInput,
+      isTaxeArende: false,
+      hufStart: new Date("2026-05-25T09:00:00"), hufEnd: new Date("2026-05-25T09:00:00"), // ingen HUF
+      timeEntries: [{ id: "t1", date: "2026-05-20", description: "Möte", minutes: 120, billable: true }],
+    };
+    const without = buildKostnadsrakningContext(input);
+    const withR = buildKostnadsrakningContext({ ...input, matter: { ...input.matter, radgivningPaid: true } });
+    // 120 min × timkostnadsnorm (F-skatt 1 626 kr/h) = 325 200; med rådgivning avgår
+    // 60 min → 60 min × norm = 162 600.
+    expect(without.arvodeExclVat).toBe(325_200);
+    expect(withR.arvodeExclVat).toBe(162_600);
+    expect(withR.templateContext.isTimkostnadsnorm).toBe(true);
+    // Tidsspecifikationen visar ändå ALLT arbete (transparens); bara arvodet reduceras.
+    expect(withR.timeLines).toHaveLength(1);
+    expect(withR.billableArbetsMinutes).toBe(120);
+  });
 });


### PR DESCRIPTION
## Problem (live-test)

Klick på **"Kostnadsräkning"** i Fakturering-panelen (Umgängestvist Carlsson) gav en **ospecificerad** KR: ingen tidsspecifikation, och för rättshjälp mislabelad som brottmålstaxa.

## Fix

- **Tidsspecifikation** renderas nu i KR-PDF:en (datum · åtgärd · tid + summa arbetstid). Datan fanns i contexten (`timeLines`) men ritades aldrig ut.
- **Arvode** visas alltid med belopp och rätt rubrik: rättshjälp/övrigt = **"Arvode (timkostnadsnormen)"** (ej "DVFS 2025:6 / Brottmålstaxa"). Huvudförhandlings-sektionen visas bara när en HUF finns (rättshjälp har ingen → dolde tidigare en meningslös "0 min"-rad).
- **Rådgivningstimmen exkluderas nu från statens arvode** när `radgivningPaid` — matchar notisen "ingår ej". Tidsspecen visar ändå allt arbete (transparens); bara arvodesunderlaget reduceras med 1 tim.

## Test

- Context: icke-taxa + radgivningPaid → arvode exkluderar rådgivningstimmen (120 min → 325 200; med rådgivning 60 min → 162 600), `isTimkostnadsnorm` satt, tidsspec visar allt arbete.
- render-pdf: rättshjälps-KR med tidsspec + rådgivningsnotis producerar giltig PDF.
- Full svit 3392 pass, typecheck/lint/knip/deps/duplicates/build:demo grönt.

Closes #864
Refs #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)