### PR TITLE
fix(demo): full specifikation i seedad kostnadsräkning

### DIFF
--- a/test/scripts/demo-generator-kostnadsrakning-docs.test.ts
+++ b/test/scripts/demo-generator-kostnadsrakning-docs.test.ts
@@ -64,4 +64,22 @@ describe("populateKostnadsrakningDocs", () => {
     expect(docs).toHaveLength(1);
     expect(String(docs[0].fileName)).toContain("Kostnadsräkning");
   });
+
+  it("KR-dokumentet innehåller en FULL specifikation (tidsspec + arvode + total) (#864)", async () => {
+    const seed = buildSeed();
+    const target = createGitTarget({ principal: ADMIN, writeBack: async () => {} });
+    await populate(target.caller, seed);
+    await populateBilling(target.caller, seed);
+    const htmls: string[] = [];
+    await populateKostnadsrakningDocs(target.caller, (_p, b) => { htmls.push(new TextDecoder().decode(b)); return b.byteLength; });
+    // Minst en KR har en tidsspecifikation + summering (ej längre "ospecificerad").
+    const withSpec = htmls.find((h) => h.includes("Tidsspecifikation"));
+    expect(withSpec, "minst en KR ska ha en tidsspecifikation").toBeDefined();
+    expect(withSpec).toContain("Summa att fastställa av rätten");
+    // Rättshjälps-KR:n (den med rådgivningsnotis) värderas på timkostnadsnormen.
+    const rattshjalp = htmls.find((h) => h.includes("Rådgivningstimme"));
+    expect(rattshjalp, "en rättshjälps-KR ska ha rådgivningsnotis").toBeDefined();
+    expect(rattshjalp).toContain("Arvode (timkostnadsnormen)");
+    expect(rattshjalp).toContain("Tidsspecifikation");
+  });
 });

--- a/tooling/demo-generator/populate-kostnadsrakning-docs.ts
+++ b/tooling/demo-generator/populate-kostnadsrakning-docs.ts
@@ -17,45 +17,94 @@
  * sätter i prod, så `findKrDocument` i billing-panelen hittar den).
  */
 
-import { radgivningTextRad } from "@/lib/shared/rattshjalp";
+import { buildKostnadsrakningContext } from "@/lib/shared/kostnadsrakning";
 import type { GeneratorCaller } from "./backend-target";
 import type { BinarySink } from "./populate-documents";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Any = any;
 
-function fmtKr(ore: number): string {
-  return (ore / 100).toLocaleString("sv-SE", { minimumFractionDigits: 2 }) + " kr";
-}
-
 function escapeHtml(s: unknown): string {
   return String(s ?? "").replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" }[c] ?? c));
 }
 
-function renderKrHtml(run: Any): string {
+/** Tidsspecifikations-tabell (datum · åtgärd · tid + summa). Tom om inga rader. */
+function timeSpecHtml(tc: Any): string {
+  const lines = (tc.timeLines as Any[]) ?? [];
+  if (lines.length === 0) return "";
+  const rows = lines.map((l) => `<tr><td>${escapeHtml(l.date)}</td><td>${escapeHtml(l.description)}</td><td style="text-align:right">${escapeHtml(l.minutesFormatted)}</td></tr>`).join("");
+  return `<h2 style="font-size:15px;margin-top:1.5rem;margin-bottom:.25rem">Tidsspecifikation</h2>
+<table cellpadding="5" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:13px">
+<thead><tr style="border-bottom:1px solid #ccc;text-align:left"><th>Datum</th><th>Åtgärd</th><th style="text-align:right">Tid</th></tr></thead>
+<tbody>${rows}</tbody>
+<tfoot><tr style="border-top:1px solid #ccc"><td colspan="2" style="font-weight:bold">Summa arbetstid</td><td style="text-align:right;font-weight:bold">${escapeHtml(tc.billableArbetsFormatted)}</td></tr></tfoot>
+</table>`;
+}
+
+/** Utläggsspecifikations-tabell (datum · beskrivning · moms · netto · brutto). */
+function expenseSpecHtml(tc: Any): string {
+  const lines = (tc.expenseLines as Any[]) ?? [];
+  if (lines.length === 0) return "";
+  const rows = lines.map((l) => `<tr><td>${escapeHtml(l.date)}</td><td>${escapeHtml(l.description)}</td><td style="text-align:right">${escapeHtml(l.vatRateLabel)}</td><td style="text-align:right">${escapeHtml(l.exclVatFormatted)}</td><td style="text-align:right">${escapeHtml(l.inclVatFormatted)}</td></tr>`).join("");
+  const s = tc.expenseSummary as Any;
+  return `<h2 style="font-size:15px;margin-top:1.5rem;margin-bottom:.25rem">Utläggsspecifikation</h2>
+<table cellpadding="5" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:13px">
+<thead><tr style="border-bottom:1px solid #ccc;text-align:left"><th>Datum</th><th>Beskrivning</th><th style="text-align:right">Moms</th><th style="text-align:right">Netto</th><th style="text-align:right">Brutto</th></tr></thead>
+<tbody>${rows}</tbody>
+<tfoot><tr style="border-top:1px solid #ccc"><td colspan="3" style="font-weight:bold">Summa utlägg</td><td style="text-align:right;font-weight:bold">${escapeHtml(s.exclVatFormatted)}</td><td style="text-align:right;font-weight:bold">${escapeHtml(s.inclVatFormatted)}</td></tr></tfoot>
+</table>`;
+}
+
+/** Full KR-specifikation (#864): tidsspec + arvode + utlägg + total + rådgivnings-
+ *  notis — samma innehåll som klient-PDF:en, byggd ur den delade contexten. */
+function renderKrHtml(run: Any, tc: Any): string {
   const matter = run.matter ?? {};
-  const amountOre = run.proposedAmountOre ?? run.amountOre ?? 0;
   const date = run.createdAt ? new Date(run.createdAt) : new Date();
-  // Rättshjälp (#383/#848): rådgivningstimmen redovisas som textrad (utan belopp)
-  // — mötet ägt rum men timmen ingår inte i KR-totalen (faktureras klienten separat).
-  const radgivningRad = matter.paymentMethod === "RATTSHJALP"
-    ? `<p style="color:#555;font-size:13px;margin-top:1rem">${escapeHtml(radgivningTextRad())}</p>`
-    : "";
+  const arvodeTitle = tc.isTimkostnadsnorm ? "Arvode (timkostnadsnormen)" : "Arvode (brottmålstaxa)";
+  const note = (tc.taxaNotes as string[] | undefined)?.[0];
+  const noteRad = note ? `<p style="color:#888;font-size:11px;margin:.25rem 0">${escapeHtml(note)}</p>` : "";
+  const radgivningRad = tc.radgivningNotice ? `<p style="color:#555;font-size:13px;margin-top:1rem">${escapeHtml(tc.radgivningNotice)}</p>` : "";
   return `<!DOCTYPE html><html lang="sv"><head><meta charset="utf-8"><title>Kostnadsräkning ${escapeHtml(matter.matterNumber)}</title></head>
 <body style="font-family:system-ui,sans-serif;max-width:720px;margin:2rem auto;color:#111">
 <h1 style="margin-bottom:0">Kostnadsräkning</h1>
 <p style="color:#555">Ärende ${escapeHtml(matter.matterNumber)} — ${escapeHtml(matter.title)}<br>
 Ställd till: Domstol<br>
 Datum: ${date.toLocaleDateString("sv-SE")}</p>
-<table cellpadding="6" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:14px">
+${timeSpecHtml(tc)}
+<h2 style="font-size:15px;margin-top:1.5rem;margin-bottom:.25rem">${arvodeTitle}</h2>
+${noteRad}
+<table cellpadding="5" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:14px">
 <tbody>
-<tr><td>Begärt belopp</td><td style="text-align:right">${fmtKr(amountOre)}</td></tr>
-</tbody>
-<tfoot><tr style="border-top:2px solid #333"><td style="font-weight:bold">Summa att fastställa av rätten</td><td style="text-align:right;font-weight:bold">${fmtKr(amountOre)}</td></tr></tfoot>
+<tr><td>Arvode exkl moms</td><td style="text-align:right">${escapeHtml(tc.arvodeExclFormatted)}</td></tr>
+<tr><td>+ Moms 25 %</td><td style="text-align:right">${escapeHtml(tc.arvodeMomsFormatted)}</td></tr>
+<tr style="border-top:1px solid #ccc"><td style="font-weight:bold">Arvode inkl moms</td><td style="text-align:right;font-weight:bold">${escapeHtml(tc.arvodeInclFormatted)}</td></tr>
+</tbody></table>
+${expenseSpecHtml(tc)}
+<table cellpadding="6" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:14px;margin-top:1rem">
+<tfoot><tr style="border-top:2px solid #333"><td style="font-weight:bold">Summa att fastställa av rätten</td><td style="text-align:right;font-weight:bold">${escapeHtml(tc.totalInclFormatted)}</td></tr></tfoot>
 </table>
 ${radgivningRad}
 <p style="color:#777;font-size:13px;margin-top:1.5rem">Kostnadsräkningen är inlämnad och väntar på rättens prövning (dom).</p>
 </body></html>`;
+}
+
+/** Bygg KR-contexten för en run ur ärendets tids-/utläggsposter (#864). */
+async function krContextFor(c: Any, run: Any): Promise<Any> {
+  const matter = run.matter ?? {};
+  const date = run.createdAt ? new Date(run.createdAt) : new Date();
+  const [te, ex] = await Promise.all([
+    c.timeEntry.list({ matterId: matter.id, pageSize: 100 }),
+    c.expense.list({ matterId: matter.id }),
+  ]);
+  const result = buildKostnadsrakningContext({
+    matter: { matterNumber: matter.matterNumber, title: matter.title, clientName: matter.clientName ?? undefined, radgivningPaid: matter.paymentMethod === "RATTSHJALP" },
+    defender: { name: matter.responsibleLawyerName ?? "Ansvarig jurist" },
+    hufStart: date, hufEnd: date, // ingen huvudförhandling i dessa KR:er
+    isTaxeArende: false, hasFTax: true,
+    timeEntries: (te.entries ?? []) as Any,
+    expenses: (ex.expenses ?? []) as Any,
+  });
+  return result.templateContext;
 }
 
 /** Dokument-id för en KR-run. Default = läsbar `krdoc-<runId>` (in-memory demo +
@@ -69,7 +118,8 @@ export async function populateKostnadsrakningDocs(caller: GeneratorCaller, sink?
   for (const summary of runs as Any[]) {
     if (summary.type !== "KOSTNADSRAKNING") continue;
     const run = await c.billingRun.byId({ id: summary.id });
-    const html = renderKrHtml(run);
+    const tc = await krContextFor(c, run);
+    const html = renderKrHtml(run, tc);
     const id = idFor ? idFor(run.id) : `krdoc-${run.id}`;
     const storagePath = `documents/content/${id}.html`;
     const bytes = new TextEncoder().encode(html);


### PR DESCRIPTION
## Problem

Efter #864 hade den **live-genererade** KR:n en specifikation, men den **demo-seedade** KR:n — den som öppnas via "Kostnadsräkning"-länken på GH Pages — genererades av `populate-kostnadsrakning-docs.ts` och visade bara **"Begärt belopp"**. Det var den "ospecificerade" KR:n användaren såg.

## Fix

Seed-generatorn hämtar nu ärendets tids-/utläggsposter (via `timeEntry.list`/`expense.list`) och bygger KR-dokumentet ur den **delade `buildKostnadsrakningContext`** (samma källa som klient-PDF:en) → full HTML-specifikation:
- **Tidsspecifikation** (datum · åtgärd · tid + summa arbetstid)
- **Arvode** (timkostnadsnormen för rättshjälp/övrigt, annars brottmålstaxa) med belopp
- **Utläggsspecifikation** (per rad + summa)
- **Summa att fastställa av rätten**
- **Rådgivningsnotis** för rättshjälp (rådgivningstimmen exkluderas ur arvodet)

Verifierat i genererad demo-seed: Umgängestvist Carlsson-KR:n innehåller nu alla sektionerna.

## Test

Nytt test: KR-dokumentet innehåller full specifikation (tidsspec + arvode + total); rättshjälps-KR:n har rådgivningsnotis + timkostnadsnorm. Full svit 3393 pass, alla gates gröna.

Closes #866
Refs #864

🤖 Generated with [Claude Code](https://claude.com/claude-code)