### PR TITLE
fix(billing): rådgivningstimmen ligger utanför kostnadsräkningen (ej i tidsspec)

### DIFF
--- a/src/lib/shared/kostnadsrakning.ts
+++ b/src/lib/shared/kostnadsrakning.ts
@@ -134,6 +134,25 @@ function timkostnadsnormResult(totalArbetsMinutes: number, hasFTax: boolean): Ta
   };
 }
 
+/**
+ * Ta bort de FÖRSTA `carveMinutes` (kronologiskt) ur listan (#868) — rådgivnings-
+ * timmen är ärendets första timme, faktureras klienten separat och ligger utanför
+ * domstolens kostnadsräkning. Hela poster utelämnas tills kvoten är uppfylld; en
+ * post som delvis överlappar krymps med resterande minuter.
+ */
+function carveEarliestMinutes(entries: readonly TimeEntryInput[], carveMinutes: number): TimeEntryInput[] {
+  const sorted = [...entries].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+  let left = carveMinutes;
+  const out: TimeEntryInput[] = [];
+  for (const t of sorted) {
+    if (left <= 0) { out.push(t); continue; }
+    if (t.minutes <= left) { left -= t.minutes; continue; } // hela posten är rådgivning → utelämna
+    out.push({ ...t, minutes: t.minutes - left }); // delvis → krymp
+    left = 0;
+  }
+  return out;
+}
+
 /** Arvode-beräkning: taxa-ärende → brottmålstaxa, annars timkostnadsnorm. */
 function resolveTaxa(
   input: BuildInput,
@@ -240,8 +259,14 @@ export function buildKostnadsrakningContext(input: BuildInput): KostnadsrakningR
   const huvudforhandlingMinutes = diffMinutes(start, end);
 
   // Tidsregistreringar — bara billable räknas (samma princip som utlägg).
-  // Visas alltid i specifikationen oavsett taxa-läge.
-  const billableTimeEntries = (input.timeEntries ?? []).filter((t) => t.billable !== false);
+  // Rådgivningstimmen (ärendets FÖRSTA timme) faktureras klienten separat och
+  // ligger HELT utanför kostnadsräkningen till domstolen (#868): den carvas bort
+  // ur BÅDE tidsspecifikationen och arvodes-underlaget — annars ser det ut som att
+  // domstolen debiteras för samma timme (dubbel-debitering). Notisen förklarar den.
+  const allBillable = (input.timeEntries ?? []).filter((t) => t.billable !== false);
+  const billableTimeEntries = input.matter.radgivningPaid
+    ? carveEarliestMinutes(allBillable, RADGIVNING_MINUTES)
+    : allBillable;
   const timeLines: TimeLine[] = billableTimeEntries.map((t) => ({
     id: t.id, date: toIsoDate(t.date), description: t.description, minutes: t.minutes,
   }));
@@ -249,11 +274,7 @@ export function buildKostnadsrakningContext(input: BuildInput): KostnadsrakningR
   const totalArbetsMinutes = billableArbetsMinutes + huvudforhandlingMinutes;
 
   const level: TaxaLevel = input.taxaLevel ?? 1;
-  // Rådgivningstimmen faktureras klienten separat → ingår EJ i statens arvode
-  // (#860/#863) och dras därför av från arvodes-underlaget (matchar notisen).
-  const radgivningAvdrag = input.matter.radgivningPaid ? RADGIVNING_MINUTES : 0;
-  const arvodeArbetsMinutes = Math.max(0, totalArbetsMinutes - radgivningAvdrag);
-  const taxa = resolveTaxa(input, huvudforhandlingMinutes, arvodeArbetsMinutes, level);
+  const taxa = resolveTaxa(input, huvudforhandlingMinutes, totalArbetsMinutes, level);
 
   // Bara billable utlägg ska faktureras — non-billable är firmans egen kostnad.
   const expenses = input.expenses.filter((e) => e.billable !== false);

--- a/test/unit/lib/kostnadsrakning/render-pdf.test.ts
+++ b/test/unit/lib/kostnadsrakning/render-pdf.test.ts
@@ -63,8 +63,10 @@ describe("renderKostnadsrakningPdf", () => {
       ],
       expenses: [{ id: "x1", date: new Date("2026-06-25T00:00:00Z"), description: "Ansökningsavgift", amount: 90000, vatRate: 0, vatIncluded: false }],
     });
-    // Kontext: tidsspec finns, arvodet exkluderar rådgivningstimmen, notis satt.
-    expect(result.timeLines).toHaveLength(2);
+    // Kontext: rådgivnings-posten (60 min, tidigast) carvas bort ur KR:n (#868) →
+    // bara arbetsposten (90 min) kvar; notis satt.
+    expect(result.timeLines).toHaveLength(1);
+    expect(result.timeLines[0]!.description).toBe("Upprättande av inlaga till tingsrätten");
     expect((result.templateContext.radgivningNotice as string | null)).toMatch(/rådgivningstimme/i);
     const bytes = await renderKostnadsrakningPdf({
       result,

--- a/test/unit/shared/kostnadsrakning.test.ts
+++ b/test/unit/shared/kostnadsrakning.test.ts
@@ -267,13 +267,30 @@ describe("buildKostnadsrakningContext — rådgivningstimme (#383)", () => {
     };
     const without = buildKostnadsrakningContext(input);
     const withR = buildKostnadsrakningContext({ ...input, matter: { ...input.matter, radgivningPaid: true } });
-    // 120 min × timkostnadsnorm (F-skatt 1 626 kr/h) = 325 200; med rådgivning avgår
-    // 60 min → 60 min × norm = 162 600.
+    // 120 min × timkostnadsnorm (F-skatt 1 626 kr/h) = 325 200; med rådgivning carvas
+    // första 60 min bort → 60 min × norm = 162 600.
     expect(without.arvodeExclVat).toBe(325_200);
     expect(withR.arvodeExclVat).toBe(162_600);
     expect(withR.templateContext.isTimkostnadsnorm).toBe(true);
-    // Tidsspecifikationen visar ändå ALLT arbete (transparens); bara arvodet reduceras.
+    // Rådgivningstimmen ligger UTANFÖR KR:n (#868): carvas ur både arvode OCH
+    // tidsspec → summa arbetstid = 60 min (ej 120), ingen dubbel-debitering.
+    expect(withR.billableArbetsMinutes).toBe(60);
+  });
+
+  it("carvar hela rådgivnings-posten ur tidsspecen när den är exakt 1 tim (#868)", () => {
+    const input = {
+      ...baseInput,
+      isTaxeArende: false,
+      hufStart: new Date("2026-05-25T09:00:00"), hufEnd: new Date("2026-05-25T09:00:00"),
+      timeEntries: [
+        { id: "radg", date: "2026-05-10", description: "Första möte med klient i ärendet", minutes: 60, billable: true },
+        { id: "arb", date: "2026-05-20", description: "Inlaga", minutes: 90, billable: true },
+      ],
+    };
+    const withR = buildKostnadsrakningContext({ ...input, matter: { ...input.matter, radgivningPaid: true } });
+    // Rådgivnings-posten (60 min, tidigast) utelämnas HELT → bara arbetsposten kvar.
     expect(withR.timeLines).toHaveLength(1);
-    expect(withR.billableArbetsMinutes).toBe(120);
+    expect(withR.timeLines[0]!.description).toBe("Inlaga");
+    expect(withR.billableArbetsMinutes).toBe(90);
   });
 });


### PR DESCRIPTION
## Problem (live-test)

Även efter #864 (arvodet exkluderade rådgivningen) framgick det av KR:n att rådgivningstimmen räknats mot domstolen: **Tidsspecifikationen listade "Första möte med klient i ärendet"** och **"Summa arbetstid 5 tim 45 min"** inkluderade den — medan arvodet var på 4,75 h. Det såg ut som dubbel-debitering (timmen faktureras redan klienten separat).

## Fix

Rådgivningstimmen (ärendets **första** timme) carvas nu bort ur **både** tidsspecifikationen och arvodes-underlaget i `buildKostnadsrakningContext` (`carveEarliestMinutes`). Resultat:
- Summa arbetstid = arvode-basen (t.ex. **4 tim 45 min**), ingen diskrepans.
- "Första möte" syns inte längre i KR:n — rådgivningen framgår bara av notisen ("ligger utanför, fakturerad/betald av klienten separat").
- Gäller **alla** KR-vägar: klient-PDF (`render-pdf`) och den demo-seedade HTML:en.

Verifierat i genererad demo: Carlsson-KR:n visar inte längre "Första möte", Summa arbetstid 4 tim 45 min, arvode 7 723,50 kr (× 4,75 h).

## Test

- `carveEarliestMinutes`: exakt-1-tim-post utelämnas helt; delvis post krymps; `billableArbetsMinutes` = 60 (ej 120).
- render-pdf: rättshjälps-KR med rådgivning → tidsspec har bara arbetsposten.
- Full svit 3394 pass, alla gates gröna.

Closes #868
Refs #864

🤖 Generated with [Claude Code](https://claude.com/claude-code)