### PR TITLE
fix(demo): tydlig rådgivningsfaktura (märkt + specificerad)

### DIFF
--- a/test/scripts/demo-generator-invoice-docs.test.ts
+++ b/test/scripts/demo-generator-invoice-docs.test.ts
@@ -37,4 +37,19 @@ describe("populateInvoiceDocs", () => {
     expect(inv.documents[0].invoiceId).toBe(final.id);
     expect(String(inv.documents[0].fileName)).toContain("Faktura");
   });
+
+  it("rådgivnings-fakturan är tydligt märkt + specificerad, ej tom (#870)", async () => {
+    const seed = buildSeed();
+    const htmls: string[] = [];
+    const target = createGitTarget({ principal: ADMIN, writeBack: async () => {} });
+    await populate(target.caller, seed);
+    await populateBilling(target.caller, seed);
+    await populateInvoiceDocs(target.caller, (_p, b) => { htmls.push(new TextDecoder().decode(b)); return b.byteLength; });
+    const radg = htmls.find((h) => h.includes("Rådgivningsfaktura"));
+    expect(radg, "en rådgivningsfaktura-doc ska genereras").toBeDefined();
+    // Specifikationen är inte tom längre — raden ur notes framgår, med belopp.
+    expect(radg).toContain("Rådgivningstimme enligt rättshjälpstaxan");
+    // Klargör (spegel av KR-notisen) att timmen INTE ligger i domstolens KR.
+    expect(radg).toContain("ingår INTE i kostnadsräkningen till domstolen");
+  });
 });

--- a/tooling/demo-generator/populate-invoice-docs.ts
+++ b/tooling/demo-generator/populate-invoice-docs.ts
@@ -31,21 +31,41 @@ function expenseRow(e: Any): string {
   return `<tr><td>${new Date(e.date).toLocaleDateString("sv-SE")}</td><td>${escapeHtml(e.description)} (utlägg)</td><td></td><td></td><td style="text-align:right">${fmtKr(e.amount)}</td></tr>`;
 }
 
+/** Är detta rådgivnings-fakturan (klientens separata rådgivningstimme)? */
+function isRadgivning(inv: Any): boolean {
+  return String(inv.notes ?? "").startsWith("Rådgivningstimme");
+}
+
 function renderInvoiceHtml(inv: Any): string {
-  const rows = [
+  const itemized = [
     ...(inv.timeEntries ?? []).map(timeRow),
     ...(inv.expenses ?? []).map(expenseRow),
-  ].join("");
-  return `<!DOCTYPE html><html lang="sv"><head><meta charset="utf-8"><title>Faktura ${escapeHtml(inv.matter.matterNumber)}</title></head>
+  ];
+  // Fakturor utan länkade tids-/utläggsposter (t.ex. rådgivnings-fakturan) fick en
+  // TOM specifikation → oklart vad beloppet avser (#870). Fall tillbaka på en rad
+  // ur `notes` så det alltid framgår vad som faktureras.
+  const fallback = itemized.length === 0
+    ? `<tr><td>${new Date(inv.invoiceDate).toLocaleDateString("sv-SE")}</td><td>${escapeHtml(inv.notes ?? "Arvode")}</td><td></td><td></td><td style="text-align:right">${fmtKr(inv.amount)}</td></tr>`
+    : "";
+  const rows = itemized.join("") || fallback;
+  const radgivning = isRadgivning(inv);
+  const heading = radgivning ? "Rådgivningsfaktura" : "Faktura";
+  // Spegel av KR-notisen, sett från klientens sida: klargör att detta är den
+  // separata rådgivningsdebiteringen och att den INTE ligger i domstolens KR.
+  const radgivningNote = radgivning
+    ? `<p style="color:#555;font-size:13px;margin-top:1rem">Rådgivningstimmen (1 tim enligt rättshjälpstaxan) faktureras klienten separat och ingår INTE i kostnadsräkningen till domstolen.</p>`
+    : "";
+  return `<!DOCTYPE html><html lang="sv"><head><meta charset="utf-8"><title>${heading} ${escapeHtml(inv.matter.matterNumber)}</title></head>
 <body style="font-family:system-ui,sans-serif;max-width:720px;margin:2rem auto;color:#111">
-<h1 style="margin-bottom:0">Faktura</h1>
+<h1 style="margin-bottom:0">${heading}</h1>
 <p style="color:#555">Ärende ${escapeHtml(inv.matter.matterNumber)} — ${escapeHtml(inv.matter.title)}<br>
 Datum: ${new Date(inv.invoiceDate).toLocaleDateString("sv-SE")}</p>
 <table cellpadding="6" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:14px">
 <thead><tr style="border-bottom:2px solid #333;text-align:left"><th>Datum</th><th>Beskrivning</th><th style="text-align:right">Tid</th><th style="text-align:right">Timpris</th><th style="text-align:right">Belopp</th></tr></thead>
 <tbody>${rows}</tbody>
 <tfoot><tr style="border-top:2px solid #333"><td colspan="4" style="text-align:right;font-weight:bold">Summa</td><td style="text-align:right;font-weight:bold">${fmtKr(inv.amount)}</td></tr></tfoot>
-</table></body></html>`;
+</table>
+${radgivningNote}</body></html>`;
 }
 
 /** Dokument-id för en faktura. Default = läsbar `invdoc-<id>` (in-memory demo +
@@ -72,11 +92,14 @@ export async function populateInvoiceDocs(caller: GeneratorCaller, sink?: Binary
     const storagePath = `documents/content/${id}.html`;
     const bytes = new TextEncoder().encode(html);
     const size = sink ? sink(storagePath, bytes) : bytes.byteLength;
+    // Rådgivnings-fakturan märks tydligt i fil-listan så den inte förväxlas med
+    // slutfakturan/kostnadsräkningen (#870).
+    const label = isRadgivning(inv) ? "Rådgivningsfaktura" : "Faktura";
     await c.document.register({
       id, matterId: inv.matter.id, invoiceId: inv.id,
-      fileName: `Faktura ${inv.matter.matterNumber}.html`,
+      fileName: `${label} ${inv.matter.matterNumber}.html`,
       mimeType: "text/html; charset=utf-8", sizeBytes: size, storagePath,
-      title: `Faktura — ${inv.matter.matterNumber}`,
+      title: `${label} — ${inv.matter.matterNumber}`,
       documentType: "Faktura", analysisStatus: "DONE",
       createdAt: inv.invoiceDate ? new Date(inv.invoiceDate).toISOString() : undefined,
     });


### PR DESCRIPTION
## Bakgrund (live-test)

"Konstigt: nu stämmer kostnadsräkningen, men på fakturan är rådgivningstimmen fortfarande med." — Jag surfade ut och läste den deployade fakturan: **"Faktura 2026-0010"** är i själva verket klientens separata **rådgivningsfaktura** (STANDARD, F-2026-0012, 2 032,50 kr). Den SKA innehålla rådgivningen — det är den separata klientdebiteringen, och KR:n exkluderar timmen → ingen dubbel-debitering.

Problemet var att dokumentet var **otydligt renderat**: generisk titel "Faktura" + **tom** specifikations-tabell (fakturan har inga länkade tidsposter) → bara "Summa 2 032,50 kr" utan förklaring.

## Fix (demo-seed-rendering)

- Fakturor utan länkade poster får nu en **fallback-rad ur `notes`** → beloppet är alltid specificerat.
- Rådgivningsfakturan märks tydligt: rubrik + filnamn **"Rådgivningsfaktura"**, plus en notis (spegel av KR-notisen): *"Rådgivningstimmen (1 tim enligt rättshjälpstaxan) faktureras klienten separat och ingår INTE i kostnadsräkningen till domstolen."*

Verifierat i genererad demo: `Rådgivningsfaktura 2026-0010.html` med rad "Rådgivningstimme enligt rättshjälpstaxan (1 tim). — 2 032,50 kr" + notisen.

## Test

Nytt test: rådgivningsfaktura-doc genereras, är märkt "Rådgivningsfaktura", specad (ej tom), med notisen. Full svit 3395 pass, alla gates gröna.

Closes #870
Refs #868

🤖 Generated with [Claude Code](https://claude.com/claude-code)