### PR TITLE
feat(billing): Carlsson 40% klientandel + 100h-tak (create-input tappade fälten)

### DIFF
--- a/src/lib/server/routers/matter.ts
+++ b/src/lib/server/routers/matter.ts
@@ -54,6 +54,11 @@ const matterCreateInput = z.object({
   taxaLevel: z.number().int().min(1).max(4).nullable().optional(),
   taxaHuvudforhandlingMin: z.number().int().nonnegative().nullable().optional(),
   taxaHasFTax: z.boolean().nullable().optional(),
+  /** Klientens självrisk-/kostnadsandel i bips (#801) — sätts vid skapande i
+   *  seed/fixtures; annars via `update`. */
+  clientShareBips: z.number().int().min(0).max(10000).nullable().optional(),
+  /** Rättshjälpens timtak (rättshjälpslagen: 100 tim). */
+  rattshjalpMaxTimmar: z.number().int().positive().nullable().optional(),
   /** Ansvarig advokat/biträdande jurist (#174) — styr ärendenummerserien. */
   responsibleLawyerId: userIdSchema.optional(),
   /** Domstolens målnummer (#173) — matchningsnyckel för domstolsbetalningar. */
@@ -142,6 +147,8 @@ function buildMatterData(
     taxaLevel: input.taxaLevel,
     taxaHuvudforhandlingMin: input.taxaHuvudforhandlingMin,
     taxaHasFTax: input.taxaHasFTax,
+    clientShareBips: input.clientShareBips,
+    rattshjalpMaxTimmar: input.rattshjalpMaxTimmar,
     createdAt: input.createdAt ? new Date(input.createdAt) : undefined,
   };
   const data: Record<string, unknown> = {

--- a/test/unit/server/routers/matter.test.ts
+++ b/test/unit/server/routers/matter.test.ts
@@ -126,6 +126,14 @@ describe("matter.create", () => {
     expect((await caller.create({ title: "T" })).matterNumber).toBe(`${YEAR}-0043`);
   });
 
+  it("persisterar clientShareBips + rattshjalpMaxTimmar vid skapande (#872)", async () => {
+    const { caller } = makeCaller();
+    const created = await caller.create({ title: "Rättshjälp", paymentMethod: "RATTSHJALP", clientShareBips: 4000, rattshjalpMaxTimmar: 100 });
+    const fetched = await caller.getById({ id: created.id });
+    expect(fetched.clientShareBips).toBe(4000);
+    expect(fetched.rattshjalpMaxTimmar).toBe(100);
+  });
+
   it("prefixar med ansvarig jurists prefix (#174)", async () => {
     const { caller } = makeCaller({
       users: [{ id: "user-1", organizationId: ORG, email: "a@b.com", name: "T", role: "LAWYER", matterNumberPrefix: "AA" }],

--- a/tooling/demo-generator/populate.ts
+++ b/tooling/demo-generator/populate.ts
@@ -79,7 +79,7 @@ async function createContacts(c: AnyCaller, rows: Row[]): Promise<void> {
 async function createMatters(c: AnyCaller, rows: Row[]): Promise<void> {
   for (const m of rows) {
     await c.matter.create(
-      defined({ id: m.id, matterNumber: m.matterNumber, title: m.title, description: m.description, matterType: m.matterType, status: m.status, paymentMethod: m.paymentMethod, paymentMethodNote: m.paymentMethodNote, paymentMethodDecidedAt: isoOrUndef(m.paymentMethodDecidedAt), isTaxeArende: m.isTaxeArende, taxaLevel: m.taxaLevel, taxaHuvudforhandlingMin: m.taxaHuvudforhandlingMin, taxaHasFTax: m.taxaHasFTax, createdAt: isoOrUndef(m.createdAt) }),
+      defined({ id: m.id, matterNumber: m.matterNumber, title: m.title, description: m.description, matterType: m.matterType, status: m.status, paymentMethod: m.paymentMethod, paymentMethodNote: m.paymentMethodNote, paymentMethodDecidedAt: isoOrUndef(m.paymentMethodDecidedAt), isTaxeArende: m.isTaxeArende, taxaLevel: m.taxaLevel, taxaHuvudforhandlingMin: m.taxaHuvudforhandlingMin, taxaHasFTax: m.taxaHasFTax, clientShareBips: m.clientShareBips, rattshjalpMaxTimmar: m.rattshjalpMaxTimmar, createdAt: isoOrUndef(m.createdAt) }),
     );
   }
 }

--- a/tooling/scripts/seed-data.ts
+++ b/tooling/scripts/seed-data.ts
@@ -116,6 +116,10 @@ interface MatterSeed {
   taxaLevel?: 1 | 2 | 3 | 4;
   taxaHuvudforhandlingMin?: number;
   taxaHasFTax?: boolean;
+  /** Klientens självrisk-/kostnadsandel i bips (4000 = 40 %). */
+  clientShareBips?: number;
+  /** Rättshjälpens timtak (rättshjälpslagen: 100 tim). */
+  rattshjalpMaxTimmar?: number;
 }
 
 export const MATTERS: MatterSeed[] = [
@@ -128,7 +132,7 @@ export const MATTERS: MatterSeed[] = [
   { id: "m-007-bodelning", matterNumber: "2026-0007", title: "Bodelning Bergman", status: "ACTIVE", matterType: "Familjerätt", paymentMethod: "PRIVAT", description: "Bodelning efter äktenskapsskillnad.", klientId: "c-bergman", motpartId: "c-andersson", createdDaysAgo: 30 },
   { id: "m-008-skattetvist", matterNumber: "2026-0008", title: "Skattetvist Tand & Trä AB", status: "ACTIVE", matterType: "Skatterätt", paymentMethod: "PRIVAT", description: "Överklagan av Skatteverkets omprövningsbeslut.", klientId: "c-aktiebolaget-tand", motpartId: "c-skatteverket", createdDaysAgo: 25 },
   { id: "m-009-konsumenttvist", matterNumber: "2026-0009", title: "Konsumenttvist Ek mot byggfirma", status: "CLOSED", matterType: "Konsumenträtt", paymentMethod: "RATTSSKYDD", description: "Felaktigt utförd badrumsrenovering.", klientId: "c-ek", motpartId: "c-byggfirma", createdDaysAgo: 220 },
-  { id: "m-010-vardnad-2", matterNumber: "2026-0010", title: "Umgängestvist Carlsson", status: "ACTIVE", matterType: "Familjerätt", paymentMethod: "RATTSHJALP", description: "Umgänge med boförälder efter separation.", klientId: "c-carlsson", motpartId: "c-davidsson", domstolId: "c-tingsratten-sthlm", createdDaysAgo: 15 },
+  { id: "m-010-vardnad-2", matterNumber: "2026-0010", title: "Umgängestvist Carlsson", status: "ACTIVE", matterType: "Familjerätt", paymentMethod: "RATTSHJALP", description: "Umgänge med boförälder efter separation.", klientId: "c-carlsson", motpartId: "c-davidsson", domstolId: "c-tingsratten-sthlm", createdDaysAgo: 15, clientShareBips: 4000, rattshjalpMaxTimmar: 100 },
   { id: "m-011-overklagan", matterNumber: "2026-0011", title: "Överklagan Bergman", status: "ACTIVE", matterType: "Förvaltningsrätt", paymentMethod: "PRIVAT", description: "Överklagan av beslut från Migrationsverket.", klientId: "c-bergman", motpartId: "c-skatteverket", createdDaysAgo: 8 },
   { id: "m-012-skadestand-tha", matterNumber: "2026-0012", title: "Skadestånd Trygg-Hansa", status: "ACTIVE", matterType: "Skadestånd", paymentMethod: "RATTSSKYDD", description: "Inbrottsskada och tvist om självrisk.", klientId: "c-gustafsson", motpartId: "c-trygg-hansa", createdDaysAgo: 5 },
   { id: "m-013-hyra", matterNumber: "2025-0013", title: "Hyresvärdstvist Falk", status: "ARCHIVED", matterType: "Hyresrätt", paymentMethod: "PRIVAT", description: "Avhysning pga obetalda hyror — avgjort 2025.", klientId: "c-falk", createdDaysAgo: 400 },
@@ -207,6 +211,8 @@ export function buildSeed(opts: BuildSeedOpts = {}): SeedDataset {
       taxaLevel: m.taxaLevel ?? null,
       taxaHuvudforhandlingMin: m.taxaHuvudforhandlingMin ?? null,
       taxaHasFTax: m.taxaHasFTax ?? null,
+      clientShareBips: m.clientShareBips ?? null,
+      rattshjalpMaxTimmar: m.rattshjalpMaxTimmar ?? null,
       createdAt: isoDate(-m.createdDaysAgo),
       updatedAt: isoDate(-Math.max(1, m.createdDaysAgo - 7)),
     })),


### PR DESCRIPTION
## Vad

Sätter "Umgängestvist Carlsson" (m-010): klienten betalar **40 %** (clientShareBips 4000) och **rättshjälpstaket 100 tim** (rattshjalpMaxTimmar).

## Bugg som upptäcktes

`matter.create` (`matterCreateInput` + `buildMatterData`) **saknade** `clientShareBips` och `rattshjalpMaxTimmar` — de kunde bara sättas via `update`, aldrig vid skapande. Seed-mappningen + demo-generatorn tappade dem också. Åtgärdat i **alla tre lager** så fälten persisteras vid skapande.

## Effekt (verifierat via reproduktion)

Efter slutreglering av m-010:
- **Klientens självrisk 40 %**: 3 861,75 kr (− aconto 1 500 = 2 361,75 kr att betala)
- **Domstolen 60 % + utlägg**: 6 190,13 kr
- **Rådgivningstimmen exkluderas ur arvodesbasen** (285 min, ej 345) → domstols-fakturans arvode = 9 654,38 kr, matchar KR:n. (Detta bekräftar också att rådgivningen INTE ligger på domstols-fakturan i nuvarande kod.)

## Om taket

`rattshjalpMaxTimmar=100` lagras nu, men **enforsas ännu inte** i coverage-splitten (och binder ändå inte på 4,75 tim arbete). Separat uppföljning om taket ska påverka billing för stora ärenden.

## Test

Nytt regressions-test: `matter.create` persisterar clientShareBips + rattshjalpMaxTimmar. Full svit 3396 pass, alla gates gröna.

Closes #872

🤖 Generated with [Claude Code](https://claude.com/claude-code)