### PR TITLE
fix(billing): rättshjälp-slutreglering — självrisk-spec, moms-trappa, rådgivning omnämnd (#876)

### DIFF
--- a/src/app/invoices/[id]/_client.tsx
+++ b/src/app/invoices/[id]/_client.tsx
@@ -19,6 +19,7 @@ import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { computeMatterSettlement, computeRadgivningsavgift, type MatterSettlement } from "@/lib/shared/rattshjalp";
 import { asId } from "@/lib/shared/schemas/ids";
+import type { SettlementView } from "@/lib/shared/settlement-view";
 import { splitVat } from "@/lib/shared/vat";
 import { computeInvoiceLedger } from "@/lib/shared/write-off-calc";
 import { CreditModal } from "./_credit-modal";
@@ -150,7 +151,7 @@ function InvoiceSummaryCard({ inv, ledger, s }: { inv: Inv; ledger: LedgerView; 
 function InvoiceSections({ inv, ledger, onCancelPlan }: { inv: Inv; ledger: LedgerView; onCancelPlan: () => void }) {
   return (
     <>
-      <SpecificationCard timeEntries={inv.timeEntries ?? []} expenses={inv.expenses ?? []} />
+      <PrimarySpecCard inv={inv} />
       <InvoiceDocumentsCard documents={inv.documents ?? []} />
       <CreditBanners inv={inv} />
       {inv.paymentPlan && <PaymentPlanCard plan={inv.paymentPlan} onCancel={onCancelPlan} />}
@@ -159,6 +160,61 @@ function InvoiceSections({ inv, ledger, onCancelPlan }: { inv: Inv; ledger: Ledg
       <DispatchHistory invoiceId={inv.id} />
       {ledger.writeOffs.length > 0 && <WriteOffsCard writeOffs={ledger.writeOffs} />}
     </>
+  );
+}
+
+/** Primär specifikation: slutregleringsfakturor (#876) visar den PERSISTERADE vyn
+ *  (identisk med faktura-dokumentet), övriga fakturor den vanliga tids-/utläggsspecen. */
+function PrimarySpecCard({ inv }: { inv: Inv }) {
+  if (inv.settlementBreakdown) return <SettlementBreakdownCard view={inv.settlementBreakdown} />;
+  return <SpecificationCard timeEntries={inv.timeEntries ?? []} expenses={inv.expenses ?? []} />;
+}
+
+/** Slutregleringens persisterade vy (#876): tidsspec-tabell + beloppstrappa + total,
+ *  renderad ur `settlementBreakdown` så den är IDENTISK med faktura-dokumentet. */
+function SettlementBreakdownCard({ view }: { view: SettlementView }) {
+  const hours = (m: number) => (m / 60).toLocaleString("sv-SE", { maximumFractionDigits: 2 });
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6">
+      <h2 className="font-semibold text-gray-900 mb-1">Specifikation</h2>
+      <p className="text-sm text-gray-500 mb-4">Samma underlag och belopp som faktura-dokumentet.</p>
+      {view.timeLines.length > 0 && (
+        <table className="min-w-full text-sm mb-4">
+          <thead>
+            <tr className="text-left text-xs text-gray-500">
+              <th className="py-1 font-normal">Datum</th>
+              <th className="py-1 font-normal">Beskrivning</th>
+              <th className="py-1 font-normal text-right">Tid</th>
+              <th className="py-1 font-normal text-right">Belopp</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {view.timeLines.map((l, i) => (
+              <tr key={i}>
+                <td className="py-1.5 whitespace-nowrap">{new Date(l.date).toLocaleDateString("sv-SE")}</td>
+                <td className="py-1.5">{l.description}</td>
+                <td className="py-1.5 text-right whitespace-nowrap">{hours(l.minutes)} h</td>
+                <td className="py-1.5 text-right font-mono whitespace-nowrap">{formatCurrency(l.amountOre)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      <dl className="divide-y divide-gray-100">
+        {view.rows.map((r, i) => (
+          <div key={i} className="flex items-center justify-between py-1.5">
+            <dt className={`text-sm ${r.kind === "info" ? "text-gray-400" : "text-gray-600"}`}>{r.label}</dt>
+            <dd className={`text-sm font-mono ${r.kind === "deduct" ? "text-amber-700" : r.kind === "info" ? "text-gray-400" : "text-gray-700"}`}>
+              {r.kind === "deduct" ? "−" : r.kind === "info" ? "(" : ""}{formatCurrency(r.amountOre)}{r.kind === "info" ? ")" : ""}
+            </dd>
+          </div>
+        ))}
+        <div className="flex items-center justify-between border-t border-gray-300 mt-1 pt-2">
+          <dt className="text-sm font-semibold text-gray-900">{view.totalLabel}</dt>
+          <dd className="text-sm font-mono font-semibold text-gray-900">{formatCurrency(view.totalOre)}</dd>
+        </div>
+      </dl>
+    </div>
   );
 }
 
@@ -407,7 +463,8 @@ function settlementRows(s: MatterSettlement): Array<{ label: string; ore: number
 
 /** FINAL-fakturans extra sektioner: accontoavdrag + ärende-sammanställning (#349). */
 function FinalInvoiceExtras({ inv, ledger }: { inv: Inv; ledger: LedgerView }) {
-  if (inv.invoiceType !== "FINAL") return null;
+  // Slutregleringsfakturor (#876) visar redan allt i SettlementBreakdownCard.
+  if (inv.invoiceType !== "FINAL" || inv.settlementBreakdown) return null;
   return (
     <>
       {ledger.accontoDeductions.length > 0 && <AccontoDeductions deductions={ledger.accontoDeductions} />}

--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -421,6 +421,7 @@ export function BillingPanel({ matterId, matter }: Props) {
         onOverklaga={() => appeal.mutate({ billingRunId: activeKr.id })}
         onSkapaFaktura={() => matter.paymentMethod === "RATTSHJALP" ? setShowSettle(true) : setVerdictRunId(activeKr.id)} />}
       {beslutRunId && <RecordBeslutDialog billingRunId={beslutRunId} onClose={() => setBeslutRunId(null)} onDone={refetch} />}
+      <RattshjalpRateSchedule matter={matter} rows={rows} />
       <RunsList matterId={matterId} rows={rows} standalone={standalone} loading={runs.isLoading} />
       <BillingDialogs matterId={matterId} matter={matter} rows={rows}
         dialog={dialog} setDialog={setDialog}
@@ -711,6 +712,42 @@ function StandaloneRow({ inv }: { inv: StandaloneInvoiceRow }) {
         </EntityLink>
       </td>
     </tr>
+  );
+}
+
+/** Rättshjälpsavgiften ÖVER TID (#878): satsen varierar (arbetslös/anställd) och
+ *  ställs ut per aconto vid den då gällande satsen. Härleds ur ACCONTO-körningarna
+ *  (sats + fakturadatum) — varje sats gäller från sitt datum till nästa acontos;
+ *  matterns clientShareBips = myndighetens slutliga helhetsbeslut för hela ärendet. */
+function RattshjalpRateSchedule({ matter, rows }: { matter: MatterContext; rows: BillingRunRow[] }) {
+  if (matter.paymentMethod !== "RATTSHJALP") return null;
+  const accontos = rows
+    .filter((r) => r.type === "ACCONTO" && r.clientShareBips != null)
+    .map((r) => ({ bips: r.clientShareBips as number, date: runDateOf(r) }))
+    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+  if (accontos.length === 0) return null;
+  return (
+    <div className="px-6 py-3 border-t border-gray-100">
+      <h3 className="text-sm font-semibold text-gray-900 mb-2">Rättshjälpsavgift över tid</h3>
+      <table className="min-w-full text-sm">
+        <thead className="text-xs text-gray-500"><tr><th className="text-left py-1">Från</th><th className="text-left">Till</th><th className="text-right">Avgift</th></tr></thead>
+        <tbody className="divide-y divide-gray-100">
+          {accontos.map((a, i) => (
+            <tr key={i}>
+              <td className="py-1.5 whitespace-nowrap text-gray-600">{svDate(a.date)}</td>
+              <td className="whitespace-nowrap text-gray-600">{i + 1 < accontos.length ? svDate(accontos[i + 1]!.date) : "pågående"}</td>
+              <td className="text-right font-mono">{a.bips / 100} %</td>
+            </tr>
+          ))}
+          {matter.clientShareBips != null && (
+            <tr className="border-t border-gray-300">
+              <td className="py-1.5 font-medium text-gray-900" colSpan={2}>Slutligt myndighetsbeslut (hela ärendet)</td>
+              <td className="text-right font-mono font-semibold">{matter.clientShareBips / 100} %</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
   );
 }
 

--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -63,15 +63,17 @@ interface BillingRunRow {
   recipient: BillingRunRecipient;
   amountOre: number;
   createdAt: string | Date;
+  /** Aconto-satsen (bips) som gällde när acontot ställdes ut (#878) — visas i listan. */
+  clientShareBips?: number | null;
   invoiceId?: InvoiceId | null;
-  invoice?: { id: InvoiceId; invoiceNumber?: string | null } | null;
+  invoice?: { id: InvoiceId; invoiceNumber?: string | null; invoiceDate?: string | Date | null } | null;
   kostnadsrakningStatus?: KostnadsrakningStatus | null;
   awardedOre?: number | null;
   beslutSlutgiltigt?: boolean | null;
 }
 
 /** Fristående klientfaktura (utan billing-run) som visas i faktura-listan (#853). */
-interface StandaloneInvoiceRow { id: InvoiceId; invoiceNumber?: string | null; status: string; amount: number }
+interface StandaloneInvoiceRow { id: InvoiceId; invoiceNumber?: string | null; status: string; amount: number; invoiceDate?: string | Date | null }
 
 /** Fakturor som INTE är kopplade till en billing-run (t.ex. rådgivningstimmen). */
 function standaloneInvoices(invoices: StandaloneInvoiceRow[] | undefined, rows: BillingRunRow[]): StandaloneInvoiceRow[] {
@@ -653,62 +655,85 @@ function BillingActions({ actions, onPick }: { actions: readonly BillingAction[]
   );
 }
 
+const svDate = (d: string | Date | null | undefined): string => (d ? new Date(d).toLocaleDateString("sv-SE") : "—");
+/** Radens kronologiska datum: fakturadatum (backdaterat i demon) före createdAt (#878). */
+const runDateOf = (r: BillingRunRow): string | Date => r.invoice?.invoiceDate ?? r.createdAt;
+
+/** Åtgärds-cellen: KR-dokument-länk + faktura-länk. Utbruten → RunRow ≤8. */
+function RunActions({ r, docs, client }: { r: BillingRunRow; docs: DocumentListOutput["documents"]; client: DownloadClient }) {
+  const krDoc = r.type === "KOSTNADSRAKNING" ? pickKrDoc(docs, r) : null;
+  return (
+    <td className="text-right space-x-2 whitespace-nowrap">
+      {krDoc && (
+        <button type="button" onClick={() => void openKrDoc(krDoc, client)}
+          className="text-xs text-blue-600 hover:underline">Kostnadsräkning</button>
+      )}
+      {/* EntityLink (hård nav) — runtime-skapade UUID:n finns ej i generateStaticParams;
+          __shell__-shimen/nginx try_files resolvar dem (se [[entity-link]]). */}
+      {r.invoiceId && (
+        <EntityLink route="invoices" id={r.invoiceId} className="text-xs text-blue-600 hover:underline">
+          {r.invoice?.invoiceNumber ?? "Faktura"}
+        </EntityLink>
+      )}
+    </td>
+  );
+}
+
+/** En billing-run-rad. Aconto visar sin sats (#878) så den varierande rättshjälps-
+ *  avgiften syns per period; KR-raden länkar till sitt dokument. */
+function RunRow({ r, docs, client }: { r: BillingRunRow; docs: DocumentListOutput["documents"]; client: DownloadClient }) {
+  const typeLabel = BILLING_RUN_TYPE_LABELS[r.type as keyof typeof BILLING_RUN_TYPE_LABELS] ?? r.type;
+  const rate = r.type === "ACCONTO" && r.clientShareBips != null ? ` (${r.clientShareBips / 100} %)` : "";
+  return (
+    <tr>
+      <td className="py-2 text-sm whitespace-nowrap text-gray-600">{svDate(runDateOf(r))}</td>
+      <td className="text-sm">{typeLabel}{rate}</td>
+      <td className="text-sm text-gray-600">{r.recipient}</td>
+      <td className="text-sm">{BILLING_RUN_STATUS_LABELS[r.status as keyof typeof BILLING_RUN_STATUS_LABELS] ?? r.status}</td>
+      <td className="text-right text-sm font-mono"><Money ore={r.amountOre} basis="gross" /></td>
+      <RunActions r={r} docs={docs} client={client} />
+    </tr>
+  );
+}
+
+/** Fristående klientfaktura utan billing-run (#853), t.ex. rådgivningstimmen. */
+function StandaloneRow({ inv }: { inv: StandaloneInvoiceRow }) {
+  return (
+    <tr>
+      <td className="py-2 text-sm whitespace-nowrap text-gray-600">{svDate(inv.invoiceDate)}</td>
+      <td className="text-sm">Faktura</td>
+      <td className="text-sm text-gray-600">KLIENT</td>
+      <td className="text-sm">{INVOICE_STATUS_LABELS[inv.status as keyof typeof INVOICE_STATUS_LABELS] ?? inv.status}</td>
+      <td className="text-right text-sm font-mono"><Money ore={inv.amount} basis="gross" /></td>
+      <td className="text-right whitespace-nowrap">
+        <EntityLink route="invoices" id={inv.id} className="text-xs text-blue-600 hover:underline">
+          {inv.invoiceNumber ?? "Faktura"}
+        </EntityLink>
+      </td>
+    </tr>
+  );
+}
+
 function RunsList({ matterId, rows, standalone, loading }: { matterId: MatterId; rows: BillingRunRow[]; standalone: StandaloneInvoiceRow[]; loading: boolean }) {
-  // Dokumentlistan hämtas en gång → KOSTNADSRAKNING-raden kan länka till sitt
-  // KR-dokument (#843). utils.client krävs för openKrDoc:s server-hämtning.
+  // Dokumentlistan hämtas en gång → KOSTNADSRAKNING-raden kan länka till sitt KR-dokument (#843).
   const docs = trpc.document.list.useQuery({ matterId, folderId: null, pageSize: 100 }).data?.documents ?? [];
   const utils = trpc.useUtils();
   if (loading) return <p className="px-6 py-3 text-sm text-gray-500">Laddar…</p>;
   if (rows.length === 0 && standalone.length === 0) return <p className="px-6 py-3 text-sm text-gray-500">Inga fakturor ännu.</p>;
+  // Slå ihop billing-runs + fristående fakturor och sortera KRONOLOGISKT på fakturadatum
+  // (#878) — annars blandas createdAt-ordning med en påklistrad standalone-grupp.
+  const items = [
+    ...rows.map((r) => ({ key: r.id, date: runDateOf(r), node: <RunRow key={r.id} r={r} docs={docs} client={utils.client} /> })),
+    ...standalone.map((inv) => ({ key: inv.id, date: inv.invoiceDate ?? 0, node: <StandaloneRow key={inv.id} inv={inv} /> })),
+  ].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
   return (
-    <div className="px-6 py-2">
+    <div className="px-6 py-2 overflow-x-auto">
       <table className="min-w-full text-sm">
         <thead className="text-xs text-gray-500">
-          <tr><th className="text-left py-1">Typ</th><th className="text-left">Mottagare</th><th className="text-left">Status</th><th className="text-right">Belopp</th><th></th></tr>
+          <tr><th className="text-left py-1">Datum</th><th className="text-left">Typ</th><th className="text-left">Mottagare</th><th className="text-left">Status</th><th className="text-right">Belopp</th><th></th></tr>
         </thead>
         <tbody className="divide-y divide-gray-100">
-          {rows.map((r) => {
-            const krDoc = r.type === "KOSTNADSRAKNING" ? pickKrDoc(docs, r) : null;
-            return (
-            <tr key={r.id}>
-              <td className="py-2 text-sm">{BILLING_RUN_TYPE_LABELS[r.type as keyof typeof BILLING_RUN_TYPE_LABELS] ?? r.type}</td>
-              <td className="text-sm text-gray-600">{r.recipient}</td>
-              <td className="text-sm">{BILLING_RUN_STATUS_LABELS[r.status as keyof typeof BILLING_RUN_STATUS_LABELS] ?? r.status}</td>
-              <td className="text-right text-sm font-mono"><Money ore={r.amountOre} basis="gross" /></td>
-              <td className="text-right space-x-2 whitespace-nowrap">
-                {krDoc && (
-                  <button type="button" onClick={() => void openKrDoc(krDoc, utils.client)}
-                    className="text-xs text-blue-600 hover:underline">Kostnadsräkning</button>
-                )}
-                {r.invoiceId && (
-                  // EntityLink (inte Next-Link) — runtime-skapade UUIDs finns
-                  // inte i generateStaticParams. Nuvarande 404.html är en
-                  // __shell__ routing-shim (se [[entity-link]]); EntityLink gör
-                  // en hård navigering så shim/nginx try_files kan resolva
-                  // runtime-skapade faktura-id:n.
-                  <EntityLink route="invoices" id={r.invoiceId}
-                    className="text-xs text-blue-600 hover:underline">
-                    {r.invoice?.invoiceNumber ?? "Faktura"}
-                  </EntityLink>
-                )}
-              </td>
-            </tr>
-            );
-          })}
-          {/* Fristående klientfakturor utan billing-run (#853), t.ex. rådgivningstimmen. */}
-          {standalone.map((inv) => (
-            <tr key={inv.id}>
-              <td className="py-2 text-sm">Faktura</td>
-              <td className="text-sm text-gray-600">KLIENT</td>
-              <td className="text-sm">{INVOICE_STATUS_LABELS[inv.status as keyof typeof INVOICE_STATUS_LABELS] ?? inv.status}</td>
-              <td className="text-right text-sm font-mono"><Money ore={inv.amount} basis="gross" /></td>
-              <td className="text-right whitespace-nowrap">
-                <EntityLink route="invoices" id={inv.id} className="text-xs text-blue-600 hover:underline">
-                  {inv.invoiceNumber ?? "Faktura"}
-                </EntityLink>
-              </td>
-            </tr>
-          ))}
+          {items.map((it) => it.node)}
         </tbody>
       </table>
     </div>

--- a/src/app/matters/[id]/_settlement-dialog.tsx
+++ b/src/app/matters/[id]/_settlement-dialog.tsx
@@ -15,12 +15,13 @@ import type { inferRouterOutputs } from "@trpc/server";
 import { useState } from "react";
 import { DecimalInput } from "@/components/ui/decimal-input";
 import { Modal } from "@/components/ui/modal";
-import { generateFakturaFromTemplate, type BreakdownRow, type DocUtils, type FakturaBreakdown, type FakturaDocMeta, type RegisterMut } from "@/lib/client/kostnadsrakning/generate-faktura-doc";
+import { generateFakturaFromTemplate, type BreakdownRow, type DocUtils, type FakturaBreakdown, type FakturaDocMeta, type InvoiceSpecification, type RegisterMut } from "@/lib/client/kostnadsrakning/generate-faktura-doc";
 import { trpc } from "@/lib/client/trpc";
 import { formatCurrency } from "@/lib/client/utils";
 import { useVatDisplay } from "@/lib/client/vat/vat-display-context";
 import type { AppRouter } from "@/lib/server/routers/_app";
 import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
+import { radgivningTextRad } from "@/lib/shared/rattshjalp";
 import type { PaymentMethod } from "@/lib/shared/schemas/enums";
 import type { MatterId } from "@/lib/shared/schemas/ids";
 
@@ -102,6 +103,9 @@ function payerBreakdown(b: Breakdown, payerLabel: string): FakturaBreakdown {
   if (b.expensesGrossOre > 0) rows.push({ label: "Utlägg", amountOre: b.expensesGrossOre, kind: "add" });
   rows.push({ label: "Klientens självrisk", amountOre: b.sjalvriskGrossOre, kind: "deduct" });
   if (b.prutningGrossOre > 0) rows.push({ label: "Prutning (byrån bär)", amountOre: b.prutningGrossOre, kind: "deduct" });
+  // Rådgivningstimmen omnämns (#876): klienten har betalat den separat → beloppet
+  // visas som info (parentes, grå) så det syns att det INTE ingår i domstolens total.
+  if (b.radgivningGrossOre > 0) rows.push({ label: radgivningTextRad("faktura"), amountOre: b.radgivningGrossOre, kind: "info" });
   for (const d of b.deductedAccontos) rows.push({ label: `Betalt via aconto — faktura ${d.invoiceNumber}${d.date ? ` (${svd(d.date)})` : ""}`, amountOre: d.amountOre, kind: "info" });
   return { rows, totalLabel: `${payerLabel} — att betala (inkl moms)`, totalOre: b.payerPayableOre };
 }
@@ -110,12 +114,30 @@ function payerBreakdown(b: Breakdown, payerLabel: string): FakturaBreakdown {
  *  (betalda) aconton, som avräknas här → att betala. */
 function clientBreakdown(b: Breakdown, isRattshjalp: boolean): FakturaBreakdown {
   const share = (b.clientShareBips / 100).toLocaleString("sv-SE", { maximumFractionDigits: 2 });
-  const label = isRattshjalp
-    ? `Självrisk (${share} % av upparbetat arvode ${formatCurrency(b.arvodeBaseNetOre)}, inkl moms)`
-    : "Klientens del / självrisk (inkl moms)";
-  const rows: BreakdownRow[] = [{ label, amountOre: b.sjalvriskGrossOre, kind: "add" }];
+  const rows: BreakdownRow[] = [];
+  // Moms-trappa (#876): visa netto → andel → moms → inkl, så momsen syns EXAKT en
+  // gång och basen inte felmärks som "inkl moms" (upparbetat arvode ÄR exkl moms).
+  if (isRattshjalp) {
+    rows.push({ label: "Upparbetat arvode (exkl moms)", amountOre: b.arvodeBaseNetOre, kind: "add" });
+    rows.push({ label: `Klientens självrisk ${share} % (exkl moms)`, amountOre: b.sjalvriskNetOre, kind: "add" });
+    rows.push({ label: "Moms 25 %", amountOre: b.sjalvriskGrossOre - b.sjalvriskNetOre, kind: "add" });
+  }
+  rows.push({ label: isRattshjalp ? "Självrisk (inkl moms)" : "Klientens del / självrisk (inkl moms)", amountOre: b.sjalvriskGrossOre, kind: "add" });
   for (const d of b.deductedAccontos) rows.push({ label: `Avgår aconto — faktura ${d.invoiceNumber}${d.date ? ` (${svd(d.date)})` : ""}`, amountOre: d.amountOre, kind: "deduct" });
   return { rows, totalLabel: "Att betala (inkl moms)", totalOre: b.clientPayableOre };
+}
+
+/** Klientfakturans tidsspec (#876) → mall-spec. Bara tids-TABELLEN renderas (spec-
+ *  summeringen undertrycks när `breakdown` finns); moms/summa ligger i trappan. */
+function clientSpec(b: Breakdown): InvoiceSpecification {
+  return {
+    timeLines: b.clientArvodeLines,
+    expenseLines: [],
+    totalMinutes: b.clientArvodeLines.reduce((s, l) => s + l.minutes, 0),
+    arvodeNetOre: b.arvodeBaseNetOre, arvodeVatOre: 0,
+    expensesNetOre: 0, expensesVatOre: 0,
+    grossOre: 0, deductions: [], deductionOre: 0, adjustmentOre: 0, payableOre: 0,
+  };
 }
 
 async function generateSettlementDocs(res: SettleResult, opts: {
@@ -127,7 +149,7 @@ async function generateSettlementDocs(res: SettleResult, opts: {
   // Båda fakturorna renderas ur den itemiserade nedbrytningen (#858/#860) — inga
   // per-rad-tidslistor här (de + rådgivningsnotisen bor i kostnadsräkningen).
   await generateFakturaFromTemplate({ invoice: res.payerInvoice, matterId, recipient: payerLabel, meta, register, utils, breakdown: payerBreakdown(res.breakdown, payerLabel) });
-  await generateFakturaFromTemplate({ invoice: res.clientInvoice, matterId, recipient: clientNameOf(matter), meta, register, utils, breakdown: clientBreakdown(res.breakdown, isRattshjalp) });
+  await generateFakturaFromTemplate({ invoice: res.clientInvoice, matterId, recipient: clientNameOf(matter), meta, register, utils, spec: clientSpec(res.breakdown), breakdown: clientBreakdown(res.breakdown, isRattshjalp) });
 }
 
 /** Härleder alla metod-beroende texter/argument (håller komponenten ≤8). */

--- a/src/app/matters/[id]/_settlement-dialog.tsx
+++ b/src/app/matters/[id]/_settlement-dialog.tsx
@@ -15,15 +15,15 @@ import type { inferRouterOutputs } from "@trpc/server";
 import { useState } from "react";
 import { DecimalInput } from "@/components/ui/decimal-input";
 import { Modal } from "@/components/ui/modal";
-import { generateFakturaFromTemplate, type BreakdownRow, type DocUtils, type FakturaBreakdown, type FakturaDocMeta, type InvoiceSpecification, type RegisterMut } from "@/lib/client/kostnadsrakning/generate-faktura-doc";
+import { generateFakturaFromTemplate, type DocUtils, type FakturaDocMeta, type InvoiceSpecification, type RegisterMut } from "@/lib/client/kostnadsrakning/generate-faktura-doc";
 import { trpc } from "@/lib/client/trpc";
 import { formatCurrency } from "@/lib/client/utils";
 import { useVatDisplay } from "@/lib/client/vat/vat-display-context";
 import type { AppRouter } from "@/lib/server/routers/_app";
 import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
-import { radgivningTextRad } from "@/lib/shared/rattshjalp";
 import type { PaymentMethod } from "@/lib/shared/schemas/enums";
 import type { MatterId } from "@/lib/shared/schemas/ids";
+import type { SettlementView } from "@/lib/shared/settlement-view";
 
 interface SplitData {
   clientOre: number;
@@ -90,66 +90,35 @@ function clientNameOf(matter: MatterDetail | undefined): string {
   return matter?.contacts?.find((c) => c.role === "KLIENT")?.contact?.name ?? "Klient";
 }
 
-type Breakdown = SettleResult["breakdown"];
+type FakturaViewArgs = Pick<Parameters<typeof generateFakturaFromTemplate>[0], "spec" | "breakdown">;
 
-const svd = (d: string | Date | null | undefined): string => (d ? new Date(d).toLocaleDateString("sv-SE") : "");
-
-/** Betalar-fakturans (domstol/försäkring) nedbrytning (#858/#860): arvode (på
- *  BAS-minuter, exkl rådgivning) + utlägg − självrisk − prutning + aconton som
- *  info-rader (avräknas på klientfakturan, ej här). Rådgivningstimmen syns ALDRIG
- *  här — bara i kostnadsräkningen (#860). */
-function payerBreakdown(b: Breakdown, payerLabel: string): FakturaBreakdown {
-  const rows: BreakdownRow[] = [{ label: "Arvode (timkostnadsnorm)", amountOre: b.baseArvodeGrossOre, kind: "add" }];
-  if (b.expensesGrossOre > 0) rows.push({ label: "Utlägg", amountOre: b.expensesGrossOre, kind: "add" });
-  rows.push({ label: "Klientens självrisk", amountOre: b.sjalvriskGrossOre, kind: "deduct" });
-  if (b.prutningGrossOre > 0) rows.push({ label: "Prutning (byrån bär)", amountOre: b.prutningGrossOre, kind: "deduct" });
-  // Rådgivningstimmen omnämns (#876): klienten har betalat den separat → beloppet
-  // visas som info (parentes, grå) så det syns att det INTE ingår i domstolens total.
-  if (b.radgivningGrossOre > 0) rows.push({ label: radgivningTextRad("faktura"), amountOre: b.radgivningGrossOre, kind: "info" });
-  for (const d of b.deductedAccontos) rows.push({ label: `Betalt via aconto — faktura ${d.invoiceNumber}${d.date ? ` (${svd(d.date)})` : ""}`, amountOre: d.amountOre, kind: "info" });
-  return { rows, totalLabel: `${payerLabel} — att betala (inkl moms)`, totalOre: b.payerPayableOre };
-}
-
-/** Klientfakturans nedbrytning (#858): självrisk-uträkningen + de avdragna
- *  (betalda) aconton, som avräknas här → att betala. */
-function clientBreakdown(b: Breakdown, isRattshjalp: boolean): FakturaBreakdown {
-  const share = (b.clientShareBips / 100).toLocaleString("sv-SE", { maximumFractionDigits: 2 });
-  const rows: BreakdownRow[] = [];
-  // Moms-trappa (#876): visa netto → andel → moms → inkl, så momsen syns EXAKT en
-  // gång och basen inte felmärks som "inkl moms" (upparbetat arvode ÄR exkl moms).
-  if (isRattshjalp) {
-    rows.push({ label: "Upparbetat arvode (exkl moms)", amountOre: b.arvodeBaseNetOre, kind: "add" });
-    rows.push({ label: `Klientens självrisk ${share} % (exkl moms)`, amountOre: b.sjalvriskNetOre, kind: "add" });
-    rows.push({ label: "Moms 25 %", amountOre: b.sjalvriskGrossOre - b.sjalvriskNetOre, kind: "add" });
-  }
-  rows.push({ label: isRattshjalp ? "Självrisk (inkl moms)" : "Klientens del / självrisk (inkl moms)", amountOre: b.sjalvriskGrossOre, kind: "add" });
-  for (const d of b.deductedAccontos) rows.push({ label: `Avgår aconto — faktura ${d.invoiceNumber}${d.date ? ` (${svd(d.date)})` : ""}`, amountOre: d.amountOre, kind: "deduct" });
-  return { rows, totalLabel: "Att betala (inkl moms)", totalOre: b.clientPayableOre };
-}
-
-/** Klientfakturans tidsspec (#876) → mall-spec. Bara tids-TABELLEN renderas (spec-
- *  summeringen undertrycks när `breakdown` finns); moms/summa ligger i trappan. */
-function clientSpec(b: Breakdown): InvoiceSpecification {
-  return {
-    timeLines: b.clientArvodeLines,
-    expenseLines: [],
-    totalMinutes: b.clientArvodeLines.reduce((s, l) => s + l.minutes, 0),
-    arvodeNetOre: b.arvodeBaseNetOre, arvodeVatOre: 0,
-    expensesNetOre: 0, expensesVatOre: 0,
-    grossOre: 0, deductions: [], deductionOre: 0, adjustmentOre: 0, payableOre: 0,
-  };
+/** Persisterad slutregleringsvy (#876) → faktura-mallens argument. Servern äger nu
+ *  raderna (buildClientView/buildPayerView) och sparar dem på fakturan → EN källa
+ *  för både dokumentet och Slutfaktura-sidan. `timeLines` ger tidsspec-tabellen;
+ *  `rows` ger beloppstrappan (spec-summeringen undertrycks när breakdown finns). */
+function viewToFakturaArgs(view: SettlementView | null | undefined): FakturaViewArgs {
+  if (!view) return {};
+  const spec: InvoiceSpecification | null = view.timeLines.length
+    ? {
+        timeLines: view.timeLines, expenseLines: [],
+        totalMinutes: view.timeLines.reduce((s, l) => s + l.minutes, 0),
+        arvodeNetOre: 0, arvodeVatOre: 0, expensesNetOre: 0, expensesVatOre: 0,
+        grossOre: 0, deductions: [], deductionOre: 0, adjustmentOre: 0, payableOre: 0,
+      }
+    : null;
+  return { spec, breakdown: { rows: view.rows, totalLabel: view.totalLabel, totalOre: view.totalOre } };
 }
 
 async function generateSettlementDocs(res: SettleResult, opts: {
   matterId: MatterId; matter: MatterDetail | undefined; org: OrgSettings | undefined;
-  payerLabel: string; isRattshjalp: boolean; register: RegisterMut; utils: DocUtils;
+  payerLabel: string; register: RegisterMut; utils: DocUtils;
 }): Promise<void> {
-  const { matterId, matter, org, payerLabel, isRattshjalp, register, utils } = opts;
+  const { matterId, matter, org, payerLabel, register, utils } = opts;
   const meta = settlementMeta(matter, org);
-  // Båda fakturorna renderas ur den itemiserade nedbrytningen (#858/#860) — inga
-  // per-rad-tidslistor här (de + rådgivningsnotisen bor i kostnadsräkningen).
-  await generateFakturaFromTemplate({ invoice: res.payerInvoice, matterId, recipient: payerLabel, meta, register, utils, breakdown: payerBreakdown(res.breakdown, payerLabel) });
-  await generateFakturaFromTemplate({ invoice: res.clientInvoice, matterId, recipient: clientNameOf(matter), meta, register, utils, spec: clientSpec(res.breakdown), breakdown: clientBreakdown(res.breakdown, isRattshjalp) });
+  // Båda fakturorna renderas ur den PERSISTERADE vyn (#876) — exakt samma rader som
+  // Slutfaktura-sidan visar, så dokument och detaljsida aldrig glider isär.
+  await generateFakturaFromTemplate({ invoice: res.payerInvoice, matterId, recipient: payerLabel, meta, register, utils, ...viewToFakturaArgs(res.payerInvoice.settlementBreakdown) });
+  await generateFakturaFromTemplate({ invoice: res.clientInvoice, matterId, recipient: clientNameOf(matter), meta, register, utils, ...viewToFakturaArgs(res.clientInvoice.settlementBreakdown) });
 }
 
 /** Härleder alla metod-beroende texter/argument (håller komponenten ≤8). */
@@ -183,8 +152,7 @@ export function SettlementDialog({ matterId, paymentMethod, onClose }: { matterI
       // → syns i fil-listan + länkas från faktura-objektet. Best-effort.
       try {
         await generateSettlementDocs(res, {
-          matterId, matter: matterQ.data, org: orgQ.data, payerLabel: cfg.payerLabel,
-          isRattshjalp: paymentMethod === "RATTSHJALP", register, utils,
+          matterId, matter: matterQ.data, org: orgQ.data, payerLabel: cfg.payerLabel, register, utils,
         });
       } catch (e) { console.warn("[settlement] fakturadokument misslyckades:", e); }
       void utils.billingRun.list.invalidate({ matterId });

--- a/src/lib/client/backend/server-first-store.ts
+++ b/src/lib/client/backend/server-first-store.ts
@@ -62,7 +62,15 @@ export async function createServerFirstStore(deps: ServerFirstStoreDeps = {}): P
     queuePersistence: deps.queuePersistence ?? new IndexedDbMutationQueuePersistence(),
   });
   if (!deps.skipInitialReconcile) {
-    await cachingSync.reconcile();
+    // Best-effort (#879): reconcile kör pull→apply→replay, så pullad data är redan
+    // hydrerad i in-memory-storen innan en ev. replay-throw. Ett sync-fel (t.ex. en
+    // köad mutation med ogiltigt id) får ALDRIG ta ned bootstrappen (offline-first,
+    // ADR 0016) — annars fastnar appen på "AVA loading". Kön retrias vid nästa reconcile.
+    try {
+      await cachingSync.reconcile();
+    } catch (e) {
+      console.warn("[server-first] initial reconcile misslyckades (best-effort, storen kommer ändå upp):", e);
+    }
     // Byte-synk (#518, ADR 0023): ladda upp dokument-blobbar servern saknar.
     // Best-effort — får aldrig ta ned bootstrappen (tom pending → no-op).
     const { syncDocumentContent } = await import("./content-sync");

--- a/src/lib/client/kostnadsrakning/generate-faktura-doc.ts
+++ b/src/lib/client/kostnadsrakning/generate-faktura-doc.ts
@@ -83,7 +83,7 @@ const FAKTURA_TEMPLATE = `<!DOCTYPE html><html lang="sv"><head><meta charset="ut
 </table>{{/if}}
 <table cellpadding="6" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:14px;margin-top:1.5rem">
 <tbody>
-{{#if useSpec}}
+{{#if showSpecTotals}}
 {{#if hasSpec}}
 <tr><td>Arvode{{#if hoursTotal}} ({{hoursTotal}} tim){{/if}} (exkl moms)</td><td style="text-align:right">{{arvodeNet}}</td></tr>
 {{#if hasExpenses}}<tr><td>Utlägg (exkl moms)</td><td style="text-align:right">{{expensesNet}}</td></tr>{{/if}}
@@ -204,6 +204,10 @@ function fakturaTemplateContext(a: FakturaTemplateArgs, formatCurrency: (ore: nu
     ...headerContext(a, formatCurrency),
     ...specContext(a.spec, formatCurrency),
     ...breakdownContext(a.breakdown, formatCurrency),
+    // Spec-summeringen (arvode/moms/delsumma) visas bara när spec körs UTAN breakdown
+    // (#876) — annars äger breakdown-trappan beloppen och summeringen skulle dubbleras.
+    // Tids-/utläggstabellerna renderas oberoende (på timeLines/expenseLines-längd).
+    showSpecTotals: !!a.spec && !a.breakdown,
   };
 }
 

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -30,6 +30,7 @@ import type {
   MatterId, OfficeId, OrganizationId, OrgPreferenceId, PaymentId, PaymentPlanId, PaymentPlanReminderId,
   ServiceNoteId, TaskId, TimeEntryId, UserId, UserPreferenceId, WriteOffId,
 } from "@/lib/shared/schemas/ids";
+import type { SettlementView } from "@/lib/shared/settlement-view";
 import { baseColumns, boolDefault, orgScopedColumns } from "./columns";
 
 /** Monetärt öre-belopp (bigint → ingen int4-overflow för stora fakturor). */
@@ -203,6 +204,8 @@ export const invoices = pgTable("invoices", {
   vatOre: integer("vat_ore"),
   // Moms-uppdelning per sats (#790) — driver per-sats bokföring i verifikat/SIE.
   vatBreakdown: jsonb("vat_breakdown").$type<Array<{ kind: "arvode" | "utlagg"; vatRate: number; netOre: number; vatOre: number }>>(),
+  // Persisterad slutregleringsvy (#876) — EN källa för faktura-dokument + Slutfaktura-sida.
+  settlementBreakdown: jsonb("settlement_breakdown").$type<SettlementView>(),
   status: text("status").notNull().default("DRAFT").$type<InvoiceStatus>(),
   invoiceType: text("invoice_type").notNull().default("STANDARD").$type<InvoiceType>(),
   invoiceNumber: text("invoice_number"),

--- a/src/lib/server/repositories/billing-run-repository.ts
+++ b/src/lib/server/repositories/billing-run-repository.ts
@@ -12,7 +12,7 @@ import type { Repository } from "./types";
 
 /** Billing-run + faktura (listvyn). */
 export interface BillingRunListRow extends BillingRun {
-  invoice: { id: InvoiceId; invoiceNumber: string | null; status: InvoiceStatus } | null;
+  invoice: { id: InvoiceId; invoiceNumber: string | null; status: InvoiceStatus; invoiceDate: Date | string | null } | null;
 }
 
 /** Billing-run + faktura + ärende (detaljvyn). */

--- a/src/lib/server/repositories/drizzle-billing-run-repository.ts
+++ b/src/lib/server/repositories/drizzle-billing-run-repository.ts
@@ -30,7 +30,7 @@ export class DrizzleBillingRunRepository
     const rows = await this.db
       .select({
         run: billingRuns,
-        invId: invoices.id, invNum: invoices.invoiceNumber, invStatus: invoices.status,
+        invId: invoices.id, invNum: invoices.invoiceNumber, invStatus: invoices.status, invDate: invoices.invoiceDate,
       })
       .from(billingRuns)
       .innerJoin(matters, eq(billingRuns.matterId, matters.id))
@@ -43,7 +43,7 @@ export class DrizzleBillingRunRepository
       .orderBy(desc(billingRuns.createdAt));
     return rows.map((r): BillingRunListRow => ({
       ...r.run,
-      invoice: r.invId && r.invStatus ? { id: r.invId, invoiceNumber: r.invNum, status: r.invStatus } : null,
+      invoice: r.invId && r.invStatus ? { id: r.invId, invoiceNumber: r.invNum, status: r.invStatus, invoiceDate: r.invDate } : null,
     }));
   }
 

--- a/src/lib/server/repositories/in-memory-billing-run-repository.ts
+++ b/src/lib/server/repositories/in-memory-billing-run-repository.ts
@@ -24,7 +24,7 @@ export class InMemoryBillingRunRepository
     return (await this.delegate.findMany({
       where: { ...(matterId ? { matterId } : {}), matter: { organizationId } },
       orderBy: { createdAt: "desc" },
-      include: { invoice: { select: { id: true, invoiceNumber: true, status: true } } },
+      include: { invoice: { select: { id: true, invoiceNumber: true, status: true, invoiceDate: true } } },
     })) as BillingRunListRow[];
   }
 

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -624,25 +624,39 @@ function buildCreditView(deductionOre: number, clientGrossOre: number, overpaidO
   };
 }
 
-/** Skapa KREDITfaktura vid överfakturering (#878): har klienten via aconton betalat
- *  mer än sin slutliga andel krediteras mellanskillnaden. null om ingen överbetalning.
- *  Utbrutet så settleCoverage-handlern håller sig ≤8 i komplexitet. */
-async function createOverpaymentCredit(repos: Repositories, ctx: EmitCtx, orgId: OrganizationId, a: {
-  matterId: MatterId; deductionOre: number; clientGrossOre: number; method: PaymentMethod;
-}): Promise<Invoice | null> {
-  const overpaidOre = Math.max(0, a.deductionOre - a.clientGrossOre);
-  if (overpaidOre <= 0) return null;
+/**
+ * Klientens slutfaktura vid slutreglering (#878): EN faktura, aldrig en 0.00-rad.
+ * Nettot = klientens slutliga andel − betalda aconton:
+ *   - > 0 → FINAL (klienten är skyldig resten),
+ *   - < 0 → CREDIT (överfakturerad via aconton → mellanskillnaden krediteras),
+ *   - = 0 → FINAL 0 (exakt avräknad; ovanligt).
+ * Utbrutet så settleCoverage-handlern håller sig ≤8 i komplexitet.
+ */
+async function createClientSettlementInvoice(repos: Repositories, ctx: EmitCtx, orgId: OrganizationId, a: {
+  matterId: MatterId; clientGrossOre: number; deductionOre: number;
+  clientLines: VatBreakdownLine[]; clientView: SettlementView; method: PaymentMethod; notes: string | null | undefined;
+}): Promise<{ invoice: Invoice; creditInvoice: Invoice | null }> {
+  const clientNet = a.clientGrossOre - a.deductionOre; // kan vara negativt (överbetald)
+  const isCredit = clientNet < 0;
   const feeTerm = a.method === "RATTSHJALP" ? "rättshjälpsavgift" : "självrisk";
-  const credit = await repos.invoices.create({
-    // Moms = 25 %-andelen av det överbetalda bruttot (arvode = dominerande komponenten).
-    matterId: a.matterId, amount: -overpaidOre, vatOre: -Math.round(overpaidOre - overpaidOre / 1.25),
-    settlementBreakdown: buildCreditView(a.deductionOre, a.clientGrossOre, overpaidOre, feeTerm),
-    invoiceType: "CREDIT", status: "SENT", ...(await invoiceNumbering(repos, orgId, "KLIENT")),
-    invoiceDate: new Date(),
-    notes: `Rättshjälps-överfakturering: betalda aconton (${(a.deductionOre / 100).toLocaleString("sv-SE")} kr) översteg slutlig ${feeTerm} — mellanskillnaden krediteras klienten.`,
-  });
-  await emit.invoiceCreated(ctx, credit);
-  return credit;
+  const overpaidOre = -clientNet;
+  const base = { matterId: a.matterId, amount: clientNet, ...(await invoiceNumbering(repos, orgId, "KLIENT")), invoiceDate: new Date() };
+  const payload = isCredit
+    ? {
+        ...base,
+        // Kredit-moms = 25 %-andelen av det överbetalda bruttot (arvode dominerar).
+        vatOre: -Math.round(overpaidOre - overpaidOre / 1.25),
+        settlementBreakdown: buildCreditView(a.deductionOre, a.clientGrossOre, overpaidOre, feeTerm),
+        invoiceType: "CREDIT" as const, status: "SENT" as const,
+        notes: `Rättshjälps-överfakturering: betalda aconton (${(a.deductionOre / 100).toLocaleString("sv-SE")} kr) översteg slutlig ${feeTerm} — mellanskillnaden krediteras klienten.`,
+      }
+    : {
+        ...base, vatOre: vatOreOf(a.clientLines), vatBreakdown: a.clientLines,
+        settlementBreakdown: a.clientView, invoiceType: "FINAL" as const, status: "DRAFT" as const, notes: a.notes,
+      };
+  const invoice = await repos.invoices.create(payload);
+  await emit.invoiceCreated(ctx, invoice);
+  return { invoice, creditInvoice: isCredit ? invoice : null };
 }
 
 /**
@@ -1147,10 +1161,10 @@ export const billingRunRouter = router({
         });
         const { clientView, payerView } = buildSettlementViews(breakdown, matter.paymentMethod);
 
-        const clientInvoice = await tx.invoices.create({
-          matterId: input.matterId, amount: clientAmount, vatOre: vatOreOf(clientLines), vatBreakdown: clientLines,
-          settlementBreakdown: clientView,
-          invoiceType: "FINAL", status: "DRAFT", ...(await invoiceNumbering(tx, ctx.orgId, "KLIENT")), invoiceDate: new Date(), notes: input.notes,
+        // Klientfakturan: EN faktura (FINAL om skyldig, CREDIT om överbetald) — aldrig 0.00 (#878).
+        const { invoice: clientInvoice, creditInvoice } = await createClientSettlementInvoice(tx, ctx, ctx.orgId, {
+          matterId: input.matterId, clientGrossOre: clientGross, deductionOre, clientLines, clientView,
+          method: matter.paymentMethod, notes: input.notes,
         });
         const payerInvoice = await tx.invoices.create({
           matterId: input.matterId, amount: payerGross, vatOre: vatOreOf(payerLines), vatBreakdown: payerLines,
@@ -1160,7 +1174,7 @@ export const billingRunRouter = router({
         await bookFirmLoss(tx, ctx.user.id, input.matterId, split.firmLossOre);
         const clientRun = await tx.billingRuns.create({
           matterId: input.matterId, type: "FINAL", recipient: "KLIENT", status: "SENT",
-          workValueOreAtRun: clientGross, proposedAmountOre: clientGross, amountOre: clientAmount,
+          workValueOreAtRun: clientGross, proposedAmountOre: clientGross, amountOre: clientInvoice.amount,
           invoiceId: clientInvoice.id, deductedBillingRunIds: deductIds, periodTo: new Date(), notes: input.notes,
         });
         const payerRun = await bookPayerRun(tx, {
@@ -1174,15 +1188,8 @@ export const billingRunRouter = router({
           const next = applyKrTransition(krStateOf(krRun), "SKAPA_FAKTURA");
           await tx.billingRuns.update(krRun.id, { status: "SENT", kostnadsrakningStatus: next.status, beslutSlutgiltigt: next.slutgiltigt });
         }
-        await emit.invoiceCreated(ctx, clientInvoice);
-        await emit.invoiceCreated(ctx, payerInvoice);
-
-        // Överfakturering (#878): har klienten via aconton betalat MER än sin slutliga
-        // andel (myndighetens helhetsbeslut < de löpande aconto-satserna) krediteras
-        // mellanskillnaden. Slutfakturan är 0 (klampat ovan) + en KREDITfaktura.
-        const creditInvoice = await createOverpaymentCredit(tx, ctx, ctx.orgId, {
-          matterId: input.matterId, deductionOre, clientGrossOre: clientGross, method: matter.paymentMethod,
-        });
+        await emit.invoiceCreated(ctx, payerInvoice); // klientfakturan emittas i helpern
+        // `creditInvoice` = klientfakturan när den blev en CREDIT (överfakturerad), annars null.
         return { split, clientInvoice, payerInvoice, creditInvoice, clientRun, payerRun, breakdown };
       });
     }),

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -22,6 +22,7 @@ import { proposedAccontoOre } from "@/lib/shared/billing-proposal";
 import { TIMKOSTNADSNORM_FTAX_ORE_PER_H } from "@/lib/shared/brottmalstaxa";
 import { computeCoverageSplit, partitionRattsskyddMinutes, type CoverageSplit } from "@/lib/shared/coverage-billing";
 import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
+import { carveEarliestMinutes } from "@/lib/shared/kostnadsrakning";
 import { applyKrAction, type KostnadsrakningAction, type KostnadsrakningState, type KostnadsrakningStatus } from "@/lib/shared/kostnadsrakning-flow";
 import { ocrFromInvoiceNumber } from "@/lib/shared/ocr-reference";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
@@ -50,7 +51,7 @@ import type { Repositories } from "../repositories/repositories";
 import { router, orgProcedure } from "../trpc";
 
 interface UnfrozenWork {
-  timeEntries: Array<{ id: TimeEntryId; minutes: number; hourlyRate: number; billable: boolean; date: Date | string }>;
+  timeEntries: Array<{ id: TimeEntryId; minutes: number; hourlyRate: number; billable: boolean; date: Date | string; description: string }>;
   expenses: Array<{ id: ExpenseId; amount: number; billable: boolean; vatRate?: number | null; vatIncluded?: boolean | null }>;
 }
 
@@ -454,16 +455,40 @@ export interface SettlementBreakdown {
   arvodeBaseNetOre: number;      // bas-arvode (exkl rådgivning), netto — "andel × X"
   baseArvodeGrossOre: number;    // bas-arvode (exkl rådgivning), brutto — domstolens arvode-rad
   expensesGrossOre: number;      // utlägg brutto — domstol
+  sjalvriskNetOre: number;       // klientens självrisk NETTO (andel × arvodeBaseNet) — moms-trappan (#876)
   sjalvriskGrossOre: number;     // klientens självrisk brutto
   prutningGrossOre: number;      // byrå-förlust/prutning brutto
+  radgivningGrossOre: number;    // klient-betald rådgivningstimme brutto — omnämns på domstolsfakturan, ej i totalen (#876)
   payerPayableOre: number;       // domstolen att betala
   clientPayableOre: number;      // klienten att betala (självrisk − aconton)
+  // Klientens självrisk-faktura specificeras med den arbetade tiden (#876). Raderna
+  // är carvade (rättshjälp: rådgivningstimmen bort) + avstämda så summan = arvodeBaseNetOre.
+  clientArvodeLines: SpecTimeLine[];
   deductedAccontos: SpecDeduction[];
+}
+
+/** Klientfakturans tidsspec (#876): arbetad tid, rådgivningstimmen carvad bort
+ *  (rättshjälp), värderad på samma rate som arvodesbasen och AVSTÄMD så radernas
+ *  summa exakt = `totalArvodeNet` (per-rad-avrundning läggs på sista raden). */
+function buildClientArvodeLines(
+  method: PaymentMethod, rateOre: number, work: UnfrozenWork, totalArvodeNet: number,
+): SpecTimeLine[] {
+  const billable = work.timeEntries.filter((t) => t.billable);
+  const entries = method === "RATTSHJALP" ? carveEarliestMinutes(billable, RADGIVNING_MINUTES) : billable;
+  const lines: SpecTimeLine[] = entries.map((t) => ({
+    date: t.date, description: t.description, minutes: t.minutes,
+    amountOre: timeEntryValueOre(t.minutes, rateOre),
+  }));
+  const sum = lines.reduce((s, l) => s + l.amountOre, 0);
+  const last = lines[lines.length - 1];
+  if (last && sum !== totalArvodeNet) last.amountOre += totalArvodeNet - sum; // avstämning (öre)
+  return lines;
 }
 
 async function buildSettlementBreakdown(repos: Repositories, orgId: OrganizationId, a: {
   clientShareBips: number; totalArvodeNet: number; split: CoverageSplit; work: UnfrozenWork;
-  payerGross: number; clientPayable: number; deductedRuns: ReadonlyArray<{ invoiceId?: InvoiceId | null | undefined }>;
+  payerGross: number; clientPayable: number; method: PaymentMethod; rateOre: number;
+  deductedRuns: ReadonlyArray<{ invoiceId?: InvoiceId | null | undefined }>;
 }): Promise<SettlementBreakdown> {
   // Rådgivningstimmen ingår ALDRIG i domstolens arvode (#860) — arvodet värderas
   // på bas-minuterna (exkl rådgivning). Rådgivningen syns bara i kostnadsräkningen.
@@ -479,10 +504,15 @@ async function buildSettlementBreakdown(repos: Repositories, orgId: Organization
     arvodeBaseNetOre: a.totalArvodeNet,
     baseArvodeGrossOre: arvodeInclVatOre(a.totalArvodeNet),
     expensesGrossOre,
+    sjalvriskNetOre: a.split.clientOre,
     sjalvriskGrossOre: arvodeInclVatOre(a.split.clientOre),
     prutningGrossOre: arvodeInclVatOre(a.split.firmLossOre),
+    // Rådgivningstimmen (1 h) betalas av klienten separat; värdet = en timme på samma
+    // norm som arvodesbasen (jfr coverageBaseMinutes −60). 0 för icke-rättshjälp.
+    radgivningGrossOre: a.method === "RATTSHJALP" ? arvodeInclVatOre(a.rateOre) : 0,
     payerPayableOre: a.payerGross,
     clientPayableOre: a.clientPayable,
+    clientArvodeLines: buildClientArvodeLines(a.method, a.rateOre, a.work, a.totalArvodeNet),
     deductedAccontos,
   };
 }
@@ -532,7 +562,7 @@ async function resolveFinalWork(
   }
   return {
     work: {
-      timeEntries: selTime.map((t) => ({ id: t.id, minutes: t.minutes, hourlyRate: t.user.hourlyRate ?? 0, billable: t.billable, date: t.date })),
+      timeEntries: selTime.map((t) => ({ id: t.id, minutes: t.minutes, hourlyRate: t.user.hourlyRate ?? 0, billable: t.billable, date: t.date, description: t.description })),
       expenses: selExp.filter((e) => e.kind !== "PRUTNING").map((e) => ({ id: e.id, amount: e.amount, billable: e.billable, vatRate: e.vatRate, vatIncluded: e.vatIncluded })),
     },
     selected: true,
@@ -1009,7 +1039,8 @@ export const billingRunRouter = router({
         await emit.invoiceCreated(ctx, payerInvoice);
         const breakdown = await buildSettlementBreakdown(tx, ctx.orgId, {
           clientShareBips: matter.clientShareBips ?? 0, totalArvodeNet,
-          split, work, payerGross, clientPayable: clientAmount, deductedRuns,
+          split, work, payerGross, clientPayable: clientAmount,
+          method: matter.paymentMethod, rateOre, deductedRuns,
         });
         return { split, clientInvoice, payerInvoice, clientRun, payerRun, breakdown };
       });

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -458,7 +458,9 @@ export interface SettlementBreakdown {
   expensesGrossOre: number;      // utlägg brutto — domstol
   sjalvriskNetOre: number;       // klientens självrisk NETTO (andel × arvodeBaseNet) — moms-trappan (#876)
   sjalvriskGrossOre: number;     // klientens självrisk brutto
+  firmLossNetOre: number;        // byrå-förlust/prutning NETTO — domstolens trappa (#876)
   prutningGrossOre: number;      // byrå-förlust/prutning brutto
+  payerArvodeNetOre: number;     // domstolens/försäkringens andel av arvodet NETTO — trappan (#876)
   radgivningGrossOre: number;    // klient-betald rådgivningstimme brutto — omnämns på domstolsfakturan, ej i totalen (#876)
   payerPayableOre: number;       // domstolen att betala
   clientPayableOre: number;      // klienten att betala (självrisk − aconton)
@@ -507,7 +509,9 @@ async function buildSettlementBreakdown(repos: Repositories, orgId: Organization
     expensesGrossOre,
     sjalvriskNetOre: a.split.clientOre,
     sjalvriskGrossOre: arvodeInclVatOre(a.split.clientOre),
+    firmLossNetOre: a.split.firmLossOre,
     prutningGrossOre: arvodeInclVatOre(a.split.firmLossOre),
+    payerArvodeNetOre: a.split.payerOre,
     // Rådgivningstimmen (1 h) betalas av klienten separat; värdet = en timme på samma
     // norm som arvodesbasen (jfr coverageBaseMinutes −60). 0 för icke-rättshjälp.
     radgivningGrossOre: a.method === "RATTSHJALP" ? arvodeInclVatOre(a.rateOre) : 0,
@@ -545,26 +549,33 @@ function buildClientView(b: SettlementBreakdown, isRattshjalp: boolean): Settlem
 }
 
 /**
- * BETALARE (domstol/försäkring): arvode (bas, exkl rådgivning) + utlägg − självrisk
- * − prutning + aconto-info. Rådgivningstimmen omnämns som info-rad (klienten har
- * betalat den separat) men ligger UTANFÖR totalen (#876). Ingen tidsspec-tabell —
- * itemiseringen bor i kostnadsräkningen till domstolen.
+ * BETALARE (domstol/försäkring): SAMMA upplägg som klientfakturan (#876) — tidsspec
+ * + moms-trappa, fast med betalarens ANDEL. Bas-arvode − klientens självrisk −
+ * ev. prutning = betalarens andel (netto) → moms → inkl + utlägg. Rådgivningstimmen
+ * omnämns som info-rad men ligger UTANFÖR totalen.
  */
-function buildPayerView(b: SettlementBreakdown, payerLabel: string): SettlementView {
-  const rows: SettlementRow[] = [{ label: "Arvode (timkostnadsnorm)", amountOre: b.baseArvodeGrossOre, kind: "add" }];
-  if (b.expensesGrossOre > 0) rows.push({ label: "Utlägg", amountOre: b.expensesGrossOre, kind: "add" });
-  rows.push({ label: "Klientens självrisk", amountOre: b.sjalvriskGrossOre, kind: "deduct" });
-  if (b.prutningGrossOre > 0) rows.push({ label: "Prutning (byrån bär)", amountOre: b.prutningGrossOre, kind: "deduct" });
+function buildPayerView(b: SettlementBreakdown, payerLabel: string, payerNoun: string): SettlementView {
+  const payerArvodeGross = arvodeInclVatOre(b.payerArvodeNetOre);
+  const rows: SettlementRow[] = [
+    { label: "Upparbetat arvode (exkl moms)", amountOre: b.arvodeBaseNetOre, kind: "add" },
+    { label: "Avgår klientens självrisk (exkl moms)", amountOre: b.sjalvriskNetOre, kind: "deduct" },
+  ];
+  if (b.firmLossNetOre > 0) rows.push({ label: "Avgår prutning (byrån bär) (exkl moms)", amountOre: b.firmLossNetOre, kind: "deduct" });
+  rows.push({ label: `${payerNoun} andel av arvodet (exkl moms)`, amountOre: b.payerArvodeNetOre, kind: "add" });
+  rows.push({ label: "Moms 25 %", amountOre: payerArvodeGross - b.payerArvodeNetOre, kind: "add" });
+  rows.push({ label: `${payerNoun} arvode (inkl moms)`, amountOre: payerArvodeGross, kind: "add" });
+  if (b.expensesGrossOre > 0) rows.push({ label: "Utlägg (inkl moms)", amountOre: b.expensesGrossOre, kind: "add" });
   if (b.radgivningGrossOre > 0) rows.push({ label: radgivningTextRad("faktura"), amountOre: b.radgivningGrossOre, kind: "info" });
   for (const d of b.deductedAccontos) rows.push({ label: `Betalt via aconto — faktura ${d.invoiceNumber}${d.date ? ` (${svd(d.date)})` : ""}`, amountOre: d.amountOre, kind: "info" });
-  return { timeLines: [], rows, totalLabel: `${payerLabel} — att betala (inkl moms)`, totalOre: b.payerPayableOre };
+  return { timeLines: b.clientArvodeLines.map(toViewLine), rows, totalLabel: `${payerLabel} — att betala (inkl moms)`, totalOre: b.payerPayableOre };
 }
 
-/** Klient- + betalar-vy ur nedbrytningen (#876) — betalar-etiketten följer metoden. */
+/** Klient- + betalar-vy ur nedbrytningen (#876) — etiketterna följer metoden. */
 function buildSettlementViews(b: SettlementBreakdown, method: PaymentMethod): { clientView: SettlementView; payerView: SettlementView } {
   const isRattshjalp = method === "RATTSHJALP";
   const payerLabel = isRattshjalp ? "Domstolen betalar" : "Försäkringen betalar";
-  return { clientView: buildClientView(b, isRattshjalp), payerView: buildPayerView(b, payerLabel) };
+  const payerNoun = isRattshjalp ? "Domstolens" : "Försäkringens";
+  return { clientView: buildClientView(b, isRattshjalp), payerView: buildPayerView(b, payerLabel, payerNoun) };
 }
 
 /**

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -883,6 +883,15 @@ export const billingRunRouter = router({
         const invoice = await tx.invoices.create({
           matterId: input.matterId, amount: input.amountOre, vatOre: accontoVatOre,
           vatBreakdown: [{ kind: "arvode", vatRate: DEFAULT_VAT_RATE, netOre: accontoNetOre, vatOre: accontoVatOre }],
+          // Nedbrytning så aconto-detaljsidan inte blir tom (#878): klientens andel + moms.
+          settlementBreakdown: {
+            timeLines: [],
+            rows: [
+              { label: `Klientens andel ${input.clientShareBips / 100} % av upparbetat arbete (exkl moms)`, amountOre: accontoNetOre, kind: "add" },
+              { label: "Moms 25 %", amountOre: accontoVatOre, kind: "add" },
+            ],
+            totalLabel: "Att betala (inkl moms)", totalOre: input.amountOre,
+          },
           invoiceType: "ACCONTO", status: "DRAFT",
           ...(await invoiceNumbering(tx, ctx.orgId, input.recipient)),
           ...invoiceMeta(input), notes: input.notes,

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -26,7 +26,7 @@ import { carveEarliestMinutes } from "@/lib/shared/kostnadsrakning";
 import { applyKrAction, type KostnadsrakningAction, type KostnadsrakningState, type KostnadsrakningStatus } from "@/lib/shared/kostnadsrakning-flow";
 import { ocrFromInvoiceNumber } from "@/lib/shared/ocr-reference";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
-import { RADGIVNING_MINUTES } from "@/lib/shared/rattshjalp";
+import { RADGIVNING_MINUTES, radgivningTextRad } from "@/lib/shared/rattshjalp";
 import type { BillingRun } from "@/lib/shared/schemas/billing";
 import { billingRunRecipientSchema, type BillingRunRecipient, type ExpenseKind, type PaymentMethod } from "@/lib/shared/schemas/enums";
 import {
@@ -44,6 +44,7 @@ import {
   type TimeEntryId,
   type UserId,
 } from "@/lib/shared/schemas/ids";
+import type { SettlementRow, SettlementView, SettlementViewLine } from "@/lib/shared/settlement-view";
 import { splitVat, DEFAULT_VAT_RATE } from "@/lib/shared/vat";
 import { emit } from "../events/emit";
 import type { BillingRunDetailRow, BillingRunListRow } from "../repositories/billing-run-repository";
@@ -515,6 +516,55 @@ async function buildSettlementBreakdown(repos: Repositories, orgId: Organization
     clientArvodeLines: buildClientArvodeLines(a.method, a.rateOre, a.work, a.totalArvodeNet),
     deductedAccontos,
   };
+}
+
+const svd = (d: Date | string | null | undefined): string => (d ? new Date(d).toLocaleDateString("sv-SE") : "");
+const toViewLine = (l: SpecTimeLine): SettlementViewLine => ({
+  date: new Date(l.date).toISOString().slice(0, 10), description: l.description, minutes: l.minutes, amountOre: l.amountOre,
+});
+
+/**
+ * Persisterad slutregleringsvy (#876) — EN källa för både faktura-dokumentet och
+ * Slutfaktura-sidan. Byggdes tidigare i `_settlement-dialog.tsx`; flyttad hit så
+ * servern äger raderna och sparar dem på fakturan (`settlementBreakdown`).
+ *
+ * KLIENT (självrisk): tidsspec + moms-trappa (netto → andel → moms → inkl) så
+ * momsen redovisas exakt en gång och basen inte felmärks som "inkl moms" (#876).
+ */
+function buildClientView(b: SettlementBreakdown, isRattshjalp: boolean): SettlementView {
+  const share = (b.clientShareBips / 100).toLocaleString("sv-SE", { maximumFractionDigits: 2 });
+  const rows: SettlementRow[] = [];
+  if (isRattshjalp) {
+    rows.push({ label: "Upparbetat arvode (exkl moms)", amountOre: b.arvodeBaseNetOre, kind: "add" });
+    rows.push({ label: `Klientens självrisk ${share} % (exkl moms)`, amountOre: b.sjalvriskNetOre, kind: "add" });
+    rows.push({ label: "Moms 25 %", amountOre: b.sjalvriskGrossOre - b.sjalvriskNetOre, kind: "add" });
+  }
+  rows.push({ label: isRattshjalp ? "Självrisk (inkl moms)" : "Klientens del / självrisk (inkl moms)", amountOre: b.sjalvriskGrossOre, kind: "add" });
+  for (const d of b.deductedAccontos) rows.push({ label: `Avgår aconto — faktura ${d.invoiceNumber}${d.date ? ` (${svd(d.date)})` : ""}`, amountOre: d.amountOre, kind: "deduct" });
+  return { timeLines: b.clientArvodeLines.map(toViewLine), rows, totalLabel: "Att betala (inkl moms)", totalOre: b.clientPayableOre };
+}
+
+/**
+ * BETALARE (domstol/försäkring): arvode (bas, exkl rådgivning) + utlägg − självrisk
+ * − prutning + aconto-info. Rådgivningstimmen omnämns som info-rad (klienten har
+ * betalat den separat) men ligger UTANFÖR totalen (#876). Ingen tidsspec-tabell —
+ * itemiseringen bor i kostnadsräkningen till domstolen.
+ */
+function buildPayerView(b: SettlementBreakdown, payerLabel: string): SettlementView {
+  const rows: SettlementRow[] = [{ label: "Arvode (timkostnadsnorm)", amountOre: b.baseArvodeGrossOre, kind: "add" }];
+  if (b.expensesGrossOre > 0) rows.push({ label: "Utlägg", amountOre: b.expensesGrossOre, kind: "add" });
+  rows.push({ label: "Klientens självrisk", amountOre: b.sjalvriskGrossOre, kind: "deduct" });
+  if (b.prutningGrossOre > 0) rows.push({ label: "Prutning (byrån bär)", amountOre: b.prutningGrossOre, kind: "deduct" });
+  if (b.radgivningGrossOre > 0) rows.push({ label: radgivningTextRad("faktura"), amountOre: b.radgivningGrossOre, kind: "info" });
+  for (const d of b.deductedAccontos) rows.push({ label: `Betalt via aconto — faktura ${d.invoiceNumber}${d.date ? ` (${svd(d.date)})` : ""}`, amountOre: d.amountOre, kind: "info" });
+  return { timeLines: [], rows, totalLabel: `${payerLabel} — att betala (inkl moms)`, totalOre: b.payerPayableOre };
+}
+
+/** Klient- + betalar-vy ur nedbrytningen (#876) — betalar-etiketten följer metoden. */
+function buildSettlementViews(b: SettlementBreakdown, method: PaymentMethod): { clientView: SettlementView; payerView: SettlementView } {
+  const isRattshjalp = method === "RATTSHJALP";
+  const payerLabel = isRattshjalp ? "Domstolen betalar" : "Försäkringen betalar";
+  return { clientView: buildClientView(b, isRattshjalp), payerView: buildPayerView(b, payerLabel) };
 }
 
 /**
@@ -1010,12 +1060,23 @@ export const billingRunRouter = router({
         const clientAmount = Math.max(0, clientGross - deductionOre);
         const payerGross = grossOreOf(payerLines);
 
+        // Bygg slutregleringsvyerna FÖRE fakturorna (#876) så de kan persisteras på
+        // respektive faktura → EN källa för både dokumentet och Slutfaktura-sidan.
+        const breakdown = await buildSettlementBreakdown(tx, ctx.orgId, {
+          clientShareBips: matter.clientShareBips ?? 0, totalArvodeNet,
+          split, work, payerGross, clientPayable: clientAmount,
+          method: matter.paymentMethod, rateOre, deductedRuns,
+        });
+        const { clientView, payerView } = buildSettlementViews(breakdown, matter.paymentMethod);
+
         const clientInvoice = await tx.invoices.create({
           matterId: input.matterId, amount: clientAmount, vatOre: vatOreOf(clientLines), vatBreakdown: clientLines,
+          settlementBreakdown: clientView,
           invoiceType: "FINAL", status: "DRAFT", ...(await invoiceNumbering(tx, ctx.orgId, "KLIENT")), invoiceDate: new Date(), notes: input.notes,
         });
         const payerInvoice = await tx.invoices.create({
           matterId: input.matterId, amount: payerGross, vatOre: vatOreOf(payerLines), vatBreakdown: payerLines,
+          settlementBreakdown: payerView,
           invoiceType: "FINAL", status: "DRAFT", ...(await invoiceNumbering(tx, ctx.orgId, input.payerRecipient)), invoiceDate: new Date(), notes: input.notes,
         });
         await bookFirmLoss(tx, ctx.user.id, input.matterId, split.firmLossOre);
@@ -1037,11 +1098,6 @@ export const billingRunRouter = router({
         }
         await emit.invoiceCreated(ctx, clientInvoice);
         await emit.invoiceCreated(ctx, payerInvoice);
-        const breakdown = await buildSettlementBreakdown(tx, ctx.orgId, {
-          clientShareBips: matter.clientShareBips ?? 0, totalArvodeNet,
-          split, work, payerGross, clientPayable: clientAmount,
-          method: matter.paymentMethod, rateOre, deductedRuns,
-        });
         return { split, clientInvoice, payerInvoice, clientRun, payerRun, breakdown };
       });
     }),

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -27,7 +27,7 @@ import { applyKrAction, type KostnadsrakningAction, type KostnadsrakningState, t
 import { ocrFromInvoiceNumber } from "@/lib/shared/ocr-reference";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { RADGIVNING_MINUTES, radgivningTextRad } from "@/lib/shared/rattshjalp";
-import type { BillingRun } from "@/lib/shared/schemas/billing";
+import type { BillingRun, Invoice } from "@/lib/shared/schemas/billing";
 import { billingRunRecipientSchema, type BillingRunRecipient, type ExpenseKind, type PaymentMethod } from "@/lib/shared/schemas/enums";
 import {
   matterIdSchema,
@@ -46,7 +46,7 @@ import {
 } from "@/lib/shared/schemas/ids";
 import type { SettlementRow, SettlementView, SettlementViewLine } from "@/lib/shared/settlement-view";
 import { splitVat, DEFAULT_VAT_RATE } from "@/lib/shared/vat";
-import { emit } from "../events/emit";
+import { emit, type EmitCtx } from "../events/emit";
 import type { BillingRunDetailRow, BillingRunListRow } from "../repositories/billing-run-repository";
 import type { Repositories } from "../repositories/repositories";
 import { router, orgProcedure } from "../trpc";
@@ -302,15 +302,34 @@ async function currentArvodeRateOre(
   return lawyer?.hourlyRate ?? 0;
 }
 
+/** Dela utläggs-raderna mellan klient och betalare med SAMMA andel som arvodet
+ *  (#878): klientens andel = clientOre/effectiveTotal. Betalaren får resten (så
+ *  öre-avrundning aldrig tappas). Per momssats-rad delas netto + moms var för sig. */
+function apportionExpenseLines(lines: VatBreakdownLine[], split: CoverageSplit): { clientLines: VatBreakdownLine[]; payerLines: VatBreakdownLine[] } {
+  const denom = split.effectiveTotalOre;
+  const clientLines: VatBreakdownLine[] = [];
+  const payerLines: VatBreakdownLine[] = [];
+  for (const l of lines) {
+    const clientNet = denom > 0 ? Math.round((l.netOre * split.clientOre) / denom) : 0;
+    const clientVat = denom > 0 ? Math.round((l.vatOre * split.clientOre) / denom) : 0;
+    if (clientNet + clientVat > 0) clientLines.push({ ...l, netOre: clientNet, vatOre: clientVat });
+    const payerNet = l.netOre - clientNet;
+    const payerVat = l.vatOre - clientVat;
+    if (payerNet + payerVat > 0) payerLines.push({ ...l, netOre: payerNet, vatOre: payerVat });
+  }
+  return { clientLines, payerLines };
+}
+
 /** Faktura-rader (moms-breakdown) för klient- resp. betalar-fakturan ur en
- *  prutnings-/självrisk-uppdelning (#801). Klient = sin arvode-del; betalare =
- *  sin arvode-del + utläggen. */
+ *  prutnings-/rättshjälpsavgifts-uppdelning (#801). Både arvode OCH utlägg delas
+ *  per samma klient/betalar-andel (#878). */
 function coverageInvoiceLines(split: CoverageSplit, work: UnfrozenWork): { clientLines: VatBreakdownLine[]; payerLines: VatBreakdownLine[] } {
   const clientArvode = arvodeLine(split.clientOre);
   const payerArvode = arvodeLine(split.payerOre);
+  const exp = apportionExpenseLines(expenseBreakdownLines(work), split);
   return {
-    clientLines: clientArvode ? [clientArvode] : [],
-    payerLines: [...(payerArvode ? [payerArvode] : []), ...expenseBreakdownLines(work)],
+    clientLines: [...(clientArvode ? [clientArvode] : []), ...exp.clientLines],
+    payerLines: [...(payerArvode ? [payerArvode] : []), ...exp.payerLines],
   };
 }
 
@@ -455,7 +474,8 @@ export interface SettlementBreakdown {
   clientShareBips: number;
   arvodeBaseNetOre: number;      // bas-arvode (exkl rådgivning), netto — "andel × X"
   baseArvodeGrossOre: number;    // bas-arvode (exkl rådgivning), brutto — domstolens arvode-rad
-  expensesGrossOre: number;      // utlägg brutto — domstol
+  expensesGrossOre: number;      // utlägg brutto — BETALARENS andel (#878)
+  clientExpensesGrossOre: number; // utlägg brutto — KLIENTENS andel (#878)
   sjalvriskNetOre: number;       // klientens självrisk NETTO (andel × arvodeBaseNet) — moms-trappan (#876)
   sjalvriskGrossOre: number;     // klientens självrisk brutto
   firmLossNetOre: number;        // byrå-förlust/prutning NETTO — domstolens trappa (#876)
@@ -495,7 +515,10 @@ async function buildSettlementBreakdown(repos: Repositories, orgId: Organization
 }): Promise<SettlementBreakdown> {
   // Rådgivningstimmen ingår ALDRIG i domstolens arvode (#860) — arvodet värderas
   // på bas-minuterna (exkl rådgivning). Rådgivningen syns bara i kostnadsräkningen.
-  const expensesGrossOre = grossOreOf(expenseBreakdownLines(a.work));
+  // Utlägg delas per samma andel som arvodet (#878): klientens del + betalarens del.
+  const exp = apportionExpenseLines(expenseBreakdownLines(a.work), a.split);
+  const clientExpensesGrossOre = grossOreOf(exp.clientLines);
+  const payerExpensesGrossOre = grossOreOf(exp.payerLines);
   const deductedAccontos: SpecDeduction[] = [];
   for (const r of a.deductedRuns) {
     if (!r.invoiceId) continue;
@@ -506,7 +529,8 @@ async function buildSettlementBreakdown(repos: Repositories, orgId: Organization
     clientShareBips: a.clientShareBips,
     arvodeBaseNetOre: a.totalArvodeNet,
     baseArvodeGrossOre: arvodeInclVatOre(a.totalArvodeNet),
-    expensesGrossOre,
+    expensesGrossOre: payerExpensesGrossOre,
+    clientExpensesGrossOre,
     sjalvriskNetOre: a.split.clientOre,
     sjalvriskGrossOre: arvodeInclVatOre(a.split.clientOre),
     firmLossNetOre: a.split.firmLossOre,
@@ -532,50 +556,93 @@ const toViewLine = (l: SpecTimeLine): SettlementViewLine => ({
  * Slutfaktura-sidan. Byggdes tidigare i `_settlement-dialog.tsx`; flyttad hit så
  * servern äger raderna och sparar dem på fakturan (`settlementBreakdown`).
  *
- * KLIENT (självrisk): tidsspec + moms-trappa (netto → andel → moms → inkl) så
- * momsen redovisas exakt en gång och basen inte felmärks som "inkl moms" (#876).
+ * KLIENT (rättshjälpsavgift/självrisk): tidsspec + moms-trappa (netto → andel →
+ * moms → inkl) + klientens utläggsandel (#878). `feeTerm` = "rättshjälpsavgift"
+ * (rättshjälp) eller "självrisk" (rättsskydd).
  */
-function buildClientView(b: SettlementBreakdown, isRattshjalp: boolean): SettlementView {
+function buildClientView(b: SettlementBreakdown, isRattshjalp: boolean, feeTerm: string): SettlementView {
   const share = (b.clientShareBips / 100).toLocaleString("sv-SE", { maximumFractionDigits: 2 });
+  const feeCap = feeTerm.charAt(0).toUpperCase() + feeTerm.slice(1);
   const rows: SettlementRow[] = [];
   if (isRattshjalp) {
     rows.push({ label: "Upparbetat arvode (exkl moms)", amountOre: b.arvodeBaseNetOre, kind: "add" });
-    rows.push({ label: `Klientens självrisk ${share} % (exkl moms)`, amountOre: b.sjalvriskNetOre, kind: "add" });
+    rows.push({ label: `Klientens ${feeTerm} ${share} % (exkl moms)`, amountOre: b.sjalvriskNetOre, kind: "add" });
     rows.push({ label: "Moms 25 %", amountOre: b.sjalvriskGrossOre - b.sjalvriskNetOre, kind: "add" });
+    rows.push({ label: `${feeCap} (inkl moms)`, amountOre: b.sjalvriskGrossOre, kind: "add" });
+  } else {
+    rows.push({ label: "Klientens del / självrisk (inkl moms)", amountOre: b.sjalvriskGrossOre, kind: "add" });
   }
-  rows.push({ label: isRattshjalp ? "Självrisk (inkl moms)" : "Klientens del / självrisk (inkl moms)", amountOre: b.sjalvriskGrossOre, kind: "add" });
+  if (b.clientExpensesGrossOre > 0) rows.push({ label: "Utlägg (klientens andel, inkl moms)", amountOre: b.clientExpensesGrossOre, kind: "add" });
   for (const d of b.deductedAccontos) rows.push({ label: `Avgår aconto — faktura ${d.invoiceNumber}${d.date ? ` (${svd(d.date)})` : ""}`, amountOre: d.amountOre, kind: "deduct" });
   return { timeLines: b.clientArvodeLines.map(toViewLine), rows, totalLabel: "Att betala (inkl moms)", totalOre: b.clientPayableOre };
 }
 
 /**
  * BETALARE (domstol/försäkring): SAMMA upplägg som klientfakturan (#876) — tidsspec
- * + moms-trappa, fast med betalarens ANDEL. Bas-arvode − klientens självrisk −
- * ev. prutning = betalarens andel (netto) → moms → inkl + utlägg. Rådgivningstimmen
- * omnämns som info-rad men ligger UTANFÖR totalen.
+ * + moms-trappa, fast med betalarens ANDEL. Bas-arvode − klientens rättshjälpsavgift
+ * − ev. prutning = betalarens andel (netto) → moms → inkl + betalarens utläggsandel
+ * (#878). Rådgivningstimmen omnämns som info-rad men ligger UTANFÖR totalen.
  */
-function buildPayerView(b: SettlementBreakdown, payerLabel: string, payerNoun: string): SettlementView {
+function buildPayerView(b: SettlementBreakdown, payerLabel: string, payerNoun: string, feeTerm: string): SettlementView {
   const payerArvodeGross = arvodeInclVatOre(b.payerArvodeNetOre);
   const rows: SettlementRow[] = [
     { label: "Upparbetat arvode (exkl moms)", amountOre: b.arvodeBaseNetOre, kind: "add" },
-    { label: "Avgår klientens självrisk (exkl moms)", amountOre: b.sjalvriskNetOre, kind: "deduct" },
+    { label: `Avgår klientens ${feeTerm} (exkl moms)`, amountOre: b.sjalvriskNetOre, kind: "deduct" },
   ];
   if (b.firmLossNetOre > 0) rows.push({ label: "Avgår prutning (byrån bär) (exkl moms)", amountOre: b.firmLossNetOre, kind: "deduct" });
   rows.push({ label: `${payerNoun} andel av arvodet (exkl moms)`, amountOre: b.payerArvodeNetOre, kind: "add" });
   rows.push({ label: "Moms 25 %", amountOre: payerArvodeGross - b.payerArvodeNetOre, kind: "add" });
   rows.push({ label: `${payerNoun} arvode (inkl moms)`, amountOre: payerArvodeGross, kind: "add" });
-  if (b.expensesGrossOre > 0) rows.push({ label: "Utlägg (inkl moms)", amountOre: b.expensesGrossOre, kind: "add" });
+  if (b.expensesGrossOre > 0) rows.push({ label: `Utlägg (${payerNoun.toLowerCase()} andel, inkl moms)`, amountOre: b.expensesGrossOre, kind: "add" });
   if (b.radgivningGrossOre > 0) rows.push({ label: radgivningTextRad("faktura"), amountOre: b.radgivningGrossOre, kind: "info" });
   for (const d of b.deductedAccontos) rows.push({ label: `Betalt via aconto — faktura ${d.invoiceNumber}${d.date ? ` (${svd(d.date)})` : ""}`, amountOre: d.amountOre, kind: "info" });
   return { timeLines: b.clientArvodeLines.map(toViewLine), rows, totalLabel: `${payerLabel} — att betala (inkl moms)`, totalOre: b.payerPayableOre };
 }
 
-/** Klient- + betalar-vy ur nedbrytningen (#876) — etiketterna följer metoden. */
+/** Klient- + betalar-vy ur nedbrytningen (#876) — etiketterna följer metoden.
+ *  Rättshjälp: klientens del = "rättshjälpsavgift"; rättsskydd: "självrisk" (#878). */
 function buildSettlementViews(b: SettlementBreakdown, method: PaymentMethod): { clientView: SettlementView; payerView: SettlementView } {
   const isRattshjalp = method === "RATTSHJALP";
   const payerLabel = isRattshjalp ? "Domstolen betalar" : "Försäkringen betalar";
   const payerNoun = isRattshjalp ? "Domstolens" : "Försäkringens";
-  return { clientView: buildClientView(b, isRattshjalp), payerView: buildPayerView(b, payerLabel, payerNoun) };
+  const feeTerm = isRattshjalp ? "rättshjälpsavgift" : "självrisk";
+  return { clientView: buildClientView(b, isRattshjalp, feeTerm), payerView: buildPayerView(b, payerLabel, payerNoun, feeTerm) };
+}
+
+/** Kreditvy (#878): klienten har via aconton betalat mer än sin slutliga andel
+ *  (myndighetens helhetsbeslut < de löpande aconto-satserna) → mellanskillnaden
+ *  krediteras. Betalda aconton − slutlig andel = kreditering. */
+function buildCreditView(deductionOre: number, clientGrossOre: number, overpaidOre: number, feeTerm: string): SettlementView {
+  return {
+    timeLines: [],
+    rows: [
+      { label: "Betalda aconton (inkl moms)", amountOre: deductionOre, kind: "add" },
+      { label: `Avgår slutlig ${feeTerm} (inkl moms)`, amountOre: clientGrossOre, kind: "deduct" },
+    ],
+    totalLabel: "Kreditering till klienten (inkl moms)",
+    totalOre: overpaidOre,
+  };
+}
+
+/** Skapa KREDITfaktura vid överfakturering (#878): har klienten via aconton betalat
+ *  mer än sin slutliga andel krediteras mellanskillnaden. null om ingen överbetalning.
+ *  Utbrutet så settleCoverage-handlern håller sig ≤8 i komplexitet. */
+async function createOverpaymentCredit(repos: Repositories, ctx: EmitCtx, orgId: OrganizationId, a: {
+  matterId: MatterId; deductionOre: number; clientGrossOre: number; method: PaymentMethod;
+}): Promise<Invoice | null> {
+  const overpaidOre = Math.max(0, a.deductionOre - a.clientGrossOre);
+  if (overpaidOre <= 0) return null;
+  const feeTerm = a.method === "RATTSHJALP" ? "rättshjälpsavgift" : "självrisk";
+  const credit = await repos.invoices.create({
+    // Moms = 25 %-andelen av det överbetalda bruttot (arvode = dominerande komponenten).
+    matterId: a.matterId, amount: -overpaidOre, vatOre: -Math.round(overpaidOre - overpaidOre / 1.25),
+    settlementBreakdown: buildCreditView(a.deductionOre, a.clientGrossOre, overpaidOre, feeTerm),
+    invoiceType: "CREDIT", status: "SENT", ...(await invoiceNumbering(repos, orgId, "KLIENT")),
+    invoiceDate: new Date(),
+    notes: `Rättshjälps-överfakturering: betalda aconton (${(a.deductionOre / 100).toLocaleString("sv-SE")} kr) översteg slutlig ${feeTerm} — mellanskillnaden krediteras klienten.`,
+  });
+  await emit.invoiceCreated(ctx, credit);
+  return credit;
 }
 
 /**
@@ -1109,7 +1176,14 @@ export const billingRunRouter = router({
         }
         await emit.invoiceCreated(ctx, clientInvoice);
         await emit.invoiceCreated(ctx, payerInvoice);
-        return { split, clientInvoice, payerInvoice, clientRun, payerRun, breakdown };
+
+        // Överfakturering (#878): har klienten via aconton betalat MER än sin slutliga
+        // andel (myndighetens helhetsbeslut < de löpande aconto-satserna) krediteras
+        // mellanskillnaden. Slutfakturan är 0 (klampat ovan) + en KREDITfaktura.
+        const creditInvoice = await createOverpaymentCredit(tx, ctx, ctx.orgId, {
+          matterId: input.matterId, deductionOre, clientGrossOre: clientGross, method: matter.paymentMethod,
+        });
+        return { split, clientInvoice, payerInvoice, creditInvoice, clientRun, payerRun, breakdown };
       });
     }),
 });

--- a/src/lib/server/sync/drizzle-sync-store.ts
+++ b/src/lib/server/sync/drizzle-sync-store.ts
@@ -53,6 +53,12 @@ function rowId(m: QueuedMutation): string {
   return typeof m.row.id === "string" ? m.row.id : "";
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+/** Alla server-tabeller är uuid-nycklade (#879). Ett icke-uuid rowId (t.ex. ett
+ *  lokalt genererat nanoid) kan aldrig lagras → `getById` skulle kasta 22P02 och
+ *  abortera hela reconcile-batchen. */
+function isUuidRowId(id: string): boolean { return UUID_RE.test(id); }
+
 function versionOf(row: Row | null): number {
   return row && typeof row.version === "number" ? row.version : 1;
 }
@@ -105,6 +111,10 @@ export class DrizzleSyncStore implements SyncStore {
   async push(_organizationId: string, m: QueuedMutation): Promise<PushResult> {
     const repo = this.repoFor(m.entity);
     if (!repo) return { status: "conflict", reason: `okänd entitet: ${m.entity}` };
+    // Ogiltigt (icke-uuid) rowId (#879): kan aldrig lagras i de uuid-nycklade
+    // tabellerna — skippa som "accepted" så klienten ackar och slutar retry:a
+    // (annars kastar getById 22P02 och aborterar hela reconcile-batchen → hänget).
+    if (!isUuidRowId(rowId(m))) return { status: "accepted", row: m.row };
     if (m.kind === "delete") return this.applyDelete(repo, m);
     if (m.kind === "create") return this.applyCreate(repo, m);
     return this.applyUpdate(repo, m);

--- a/src/lib/shared/kostnadsrakning.ts
+++ b/src/lib/shared/kostnadsrakning.ts
@@ -140,10 +140,13 @@ function timkostnadsnormResult(totalArbetsMinutes: number, hasFTax: boolean): Ta
  * domstolens kostnadsräkning. Hela poster utelämnas tills kvoten är uppfylld; en
  * post som delvis överlappar krymps med resterande minuter.
  */
-function carveEarliestMinutes(entries: readonly TimeEntryInput[], carveMinutes: number): TimeEntryInput[] {
+export function carveEarliestMinutes<T extends { date: Date | string; minutes: number }>(
+  entries: readonly T[],
+  carveMinutes: number,
+): T[] {
   const sorted = [...entries].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
   let left = carveMinutes;
-  const out: TimeEntryInput[] = [];
+  const out: T[] = [];
   for (const t of sorted) {
     if (left <= 0) { out.push(t); continue; }
     if (t.minutes <= left) { left -= t.minutes; continue; } // hela posten är rådgivning → utelämna

--- a/src/lib/shared/rattshjalp.ts
+++ b/src/lib/shared/rattshjalp.ts
@@ -49,9 +49,9 @@ export function computeRadgivningsavgift(opts: { hasFTax?: boolean } = {}): Radg
  * Textraden om den klient-betalda rådgivningstimmen som ska synas på domstolens
  * kostnadsräkning (#383): transparens, inget belopp domstolen ska betala.
  */
-export function radgivningTextRad(): string {
+export function radgivningTextRad(context: "kostnadsräkning" | "faktura" = "kostnadsräkning"): string {
   return "Rådgivningstimme (1 tim) fakturerad och betald av klienten separat enligt " +
-    "rättshjälpstaxan — ingår ej i denna kostnadsräkning.";
+    `rättshjälpstaxan — ingår ej i denna ${context}.`;
 }
 
 export interface MatterSettlementInput {

--- a/src/lib/shared/schemas/billing.ts
+++ b/src/lib/shared/schemas/billing.ts
@@ -117,6 +117,24 @@ export const invoiceSchema = z.object({
     netOre: z.number().int(),
     vatOre: z.number().int(),
   })).nullish(),
+  /** Persisterad slutregleringsvy (#876) — EN källa för både faktura-dokumentet
+   *  och Slutfaktura-sidan (`/invoices/[id]`). Sätts vid settleCoverage på klient-/
+   *  betalar-fakturan; null på övriga fakturor. Matchar `SettlementView`. */
+  settlementBreakdown: z.object({
+    timeLines: z.array(z.object({
+      date: z.string(),
+      description: z.string(),
+      minutes: z.number().int(),
+      amountOre: z.number().int(),
+    })),
+    rows: z.array(z.object({
+      label: z.string(),
+      amountOre: z.number().int(),
+      kind: z.enum(["add", "deduct", "info"]),
+    })),
+    totalLabel: z.string(),
+    totalOre: z.number().int(),
+  }).nullish(),
   status: invoiceStatusSchema.default("DRAFT"),
   invoiceType: invoiceTypeSchema.default("STANDARD"),
   /** Per-byrå löpande fakturanummer (F-YYYY-NNNN), genereras vid skapande.

--- a/src/lib/shared/settlement-view.ts
+++ b/src/lib/shared/settlement-view.ts
@@ -1,0 +1,35 @@
+/**
+ * `SettlementView` (#876) — den persisterade slutregleringsvyn. EN källa för
+ * BÅDE faktura-dokumentet (generateFakturaFromTemplate) och Slutfaktura-sidan
+ * (`/invoices/[id]`), så de aldrig glider isär. Byggs server-side i settleCoverage
+ * ur `SettlementBreakdown` och sparas på respektive faktura (`settlementBreakdown`
+ * jsonb). Rena display-siffror i öre — ändrar inga belopp.
+ */
+
+/** `add` = delbelopp/steg i trappan, `deduct` = avgår (−), `info` = spårbarhets-
+ *  rad utan beloppspåverkan (visas i parentes/grått, t.ex. rådgivnings-omnämnandet). */
+export type SettlementRowKind = "add" | "deduct" | "info";
+
+export interface SettlementRow {
+  label: string;
+  amountOre: number;
+  kind: SettlementRowKind;
+}
+
+/** En rad i tidsspecifikations-tabellen (arbetad tid). */
+export interface SettlementViewLine {
+  date: string;
+  description: string;
+  minutes: number;
+  amountOre: number;
+}
+
+export interface SettlementView {
+  /** Tidsspec-tabellen (arbetad tid). Tom → ingen tabell renderas. */
+  timeLines: SettlementViewLine[];
+  /** Nedbrytningsraderna (beloppstrappan). */
+  rows: SettlementRow[];
+  /** Etikett på total-raden ("Att betala (inkl moms)" / "DOMSTOL — att betala …"). */
+  totalLabel: string;
+  totalOre: number;
+}

--- a/test/scripts/demo-generator-invoice-docs.test.ts
+++ b/test/scripts/demo-generator-invoice-docs.test.ts
@@ -52,4 +52,20 @@ describe("populateInvoiceDocs", () => {
     // Klargör (spegel av KR-notisen) att timmen INTE ligger i domstolens KR.
     expect(radg).toContain("ingår INTE i kostnadsräkningen till domstolen");
   });
+
+  it("settlement-/kredit-/aconto-fakturor får doc ur den persisterade nedbrytningen (#878)", async () => {
+    const seed = buildSeed();
+    const htmls: string[] = [];
+    const target = createGitTarget({ principal: ADMIN, writeBack: async () => {} });
+    await populate(target.caller, seed);
+    await populateBilling(target.caller, seed);
+    await populateInvoiceDocs(target.caller, (_p, b) => { htmls.push(new TextDecoder().decode(b)); return b.byteLength; });
+    // Kreditfakturan (varierande rättshjälp, m-020) renderar kredit-trappan — inte en tom vy.
+    const credit = htmls.find((h) => h.includes("Kreditfaktura") && h.includes("Kreditering till klienten"));
+    expect(credit, "en kreditfaktura-doc ska genereras ur settlementBreakdown").toBeDefined();
+    expect(credit).toContain("Betalda aconton");
+    // Aconto-fakturan renderar sin andels-nedbrytning.
+    const acconto = htmls.find((h) => h.includes("Aconto-faktura") && h.includes("Klientens andel"));
+    expect(acconto, "aconto-doc ska visa andels-nedbrytningen").toBeDefined();
+  });
 });

--- a/test/unit/lib/kostnadsrakning/generate-faktura-from-template.test.ts
+++ b/test/unit/lib/kostnadsrakning/generate-faktura-from-template.test.ts
@@ -97,4 +97,41 @@ describe("generateFakturaFromTemplate", () => {
     expect(html).not.toContain("Nedsättning"); // lumpen ersatt av itemiserade rader
     expect(html).not.toContain("Rådgivning"); // rådgivningstimmen syns ALDRIG på domstols-fakturan (#860)
   });
+
+  it("klientens självrisk-faktura (#876): tidsspec-TABELL + moms-trappa, spec-summeringen undertryckt", async () => {
+    await generateFakturaFromTemplate({
+      invoice: { id: asId<"InvoiceId">("inv-s"), amount: 31_300, vatOre: 16_260, invoiceNumber: "F-2026-0019", invoiceDate: "2026-07-10" },
+      matterId: asId<"MatterId">("m1"),
+      recipient: "Cecilia Carlsson",
+      meta: { matterNumber: "2026-0010", matterTitle: "Umgängestvist Carlsson" },
+      register: { mutateAsync: registerMutateAsync },
+      utils,
+      // Tidsspec ger TABELLEN (bug #1); breakdown ger moms-trappan (bug #3).
+      spec: {
+        timeLines: [{ date: "2026-03-02", description: "Genomgång av handlingar", minutes: 120, amountOre: 325_200 }],
+        expenseLines: [], totalMinutes: 120,
+        arvodeNetOre: 325_200, arvodeVatOre: 0, expensesNetOre: 0, expensesVatOre: 0,
+        grossOre: 0, deductions: [], deductionOre: 0, adjustmentOre: 0, payableOre: 0,
+      },
+      breakdown: {
+        rows: [
+          { label: "Upparbetat arvode (exkl moms)", amountOre: 325_200, kind: "add" },
+          { label: "Klientens självrisk 20 % (exkl moms)", amountOre: 65_040, kind: "add" },
+          { label: "Moms 25 %", amountOre: 16_260, kind: "add" },
+          { label: "Självrisk (inkl moms)", amountOre: 81_300, kind: "add" },
+          { label: "Avgår aconto — faktura F-2026-0013 (2026-05-15)", amountOre: 50_000, kind: "deduct" },
+        ],
+        totalLabel: "Att betala (inkl moms)", totalOre: 31_300,
+      },
+    });
+    const html = new TextDecoder().decode(persistGeneratedDoc.mock.calls[0]![0].bytes as Uint8Array);
+    expect(html).toContain("Tidsspecifikation");               // #1 — underlaget syns
+    expect(html).toContain("Genomgång av handlingar");
+    expect(html).toContain("Upparbetat arvode (exkl moms)");    // #3 — basen märkt EXKL moms
+    expect(html).toContain("Moms 25 %");                        // momsen redovisad …
+    expect(html).toContain("Självrisk (inkl moms)");
+    expect(html).toContain("Avgår aconto — faktura F-2026-0013");
+    // … men spec-summeringen undertrycks när breakdown finns → ingen dubbel moms/summa.
+    expect(html).not.toContain("Delsumma (inkl moms)");
+  });
 });

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -529,7 +529,11 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
     expect(cv.rows.some((r) => r.kind === "deduct" && r.label.startsWith("Avgår aconto"))).toBe(true);
     const pv = res.payerInvoice.settlementBreakdown!;
     expect(pv.totalOre).toBe(b.payerPayableOre);
-    expect(pv.timeLines).toHaveLength(0);                         // domstolsfakturan itemiserar ej (bor i KR:n)
+    // #876 — domstolsfakturan har SAMMA upplägg som klienten: tidsspec + andel-trappa.
+    expect(pv.timeLines).toHaveLength(1);
+    expect(pv.timeLines[0]!.amountOre).toBe(325_200);
+    expect(pv.rows.find((r) => r.label.includes("andel av arvodet"))?.amountOre).toBe(260_160); // 325 200 − 65 040 självrisk
+    expect(pv.rows.find((r) => r.label === "Moms 25 %")?.amountOre).toBe(65_040);               // moms på domstolens andel
     expect(pv.rows.some((r) => r.kind === "info" && r.label.includes("Rådgivningstimme"))).toBe(true);
   });
 

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -519,6 +519,18 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
     expect(b.clientArvodeLines).toHaveLength(1);
     expect(b.clientArvodeLines[0]!.minutes).toBe(120);            // 180 − 60 rådgivning
     expect(b.clientArvodeLines.reduce((s, l) => s + l.amountOre, 0)).toBe(b.arvodeBaseNetOre);
+
+    // #876 — persisterad vy på BÅDA fakturorna = EN källa för dokument + Slutfaktura-sida.
+    const cv = res.clientInvoice.settlementBreakdown!;
+    expect(cv.totalOre).toBe(b.clientPayableOre);
+    expect(cv.timeLines).toHaveLength(1);
+    expect(cv.timeLines[0]!.amountOre).toBe(325_200);             // tidsspec-tabellen på klientfakturan
+    expect(cv.rows.find((r) => r.label === "Moms 25 %")?.amountOre).toBe(16_260);
+    expect(cv.rows.some((r) => r.kind === "deduct" && r.label.startsWith("Avgår aconto"))).toBe(true);
+    const pv = res.payerInvoice.settlementBreakdown!;
+    expect(pv.totalOre).toBe(b.payerPayableOre);
+    expect(pv.timeLines).toHaveLength(0);                         // domstolsfakturan itemiserar ej (bor i KR:n)
+    expect(pv.rows.some((r) => r.kind === "info" && r.label.includes("Rådgivningstimme"))).toBe(true);
   });
 
   it("rättshjälp via KR (#828): kräver registrerat beslut; domsbeloppet läses från KR:n; KR konsumeras EJ utan markeras FAKTURERAD", async () => {

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -567,11 +567,11 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
     await c.billingRun.createAcconto({ matterId: "m-1", clientShareBips: 7500, amountOre: 50_000 }); // SENT-aconto
     const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "DOMSTOL" });
     // Slutlig andel: 5 % × 325 200 = 16 260 net → 20 325 brutto. Betalt 50 000 → kredit 29 675.
-    expect(res.clientInvoice.amount).toBe(0);            // slutfakturan klampad
-    expect(res.creditInvoice).not.toBeNull();
-    expect(res.creditInvoice!.amount).toBe(-29_675);    // negativ = kreditering
-    expect(res.creditInvoice!.invoiceType).toBe("CREDIT");
-    expect(res.creditInvoice!.settlementBreakdown!.totalOre).toBe(29_675);
+    // #878: EN klientfaktura (blir CREDIT vid överbetalning) — INGEN 0.00-slutfaktura.
+    expect(res.clientInvoice.invoiceType).toBe("CREDIT");
+    expect(res.clientInvoice.amount).toBe(-29_675);      // negativ = kreditering
+    expect(res.creditInvoice).toBe(res.clientInvoice);   // krediten ÄR klientfakturan
+    expect(res.clientInvoice.settlementBreakdown!.totalOre).toBe(29_675);
   });
 
   it("rättshjälp: aconton < slutlig rättshjälpsavgift → INGEN kreditfaktura", async () => {
@@ -579,6 +579,7 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
     await c.billingRun.createAcconto({ matterId: "m-1", clientShareBips: 2000, amountOre: 10_000 });
     const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "DOMSTOL" });
     expect(res.creditInvoice).toBeNull();               // 20 % × 325 200 = 65 040 > 10 000 aconto
+    expect(res.clientInvoice.invoiceType).toBe("FINAL");
     expect(res.clientInvoice.amount).toBeGreaterThan(0);
   });
 

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -537,6 +537,51 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
     expect(pv.rows.some((r) => r.kind === "info" && r.label.includes("Rådgivningstimme"))).toBe(true);
   });
 
+  it("rättshjälp (#878): utlägg delas per andel; klientens del heter 'rättshjälpsavgift'", async () => {
+    const ds = new DemoDataStore({
+      organizations: [{ id: "org-1", name: "X" }],
+      matters: [{ id: "m-1", organizationId: "org-1", matterNumber: "2026-0001", title: "T", status: "ACTIVE", responsibleLawyerId: "u-1", paymentMethod: "RATTSHJALP", clientShareBips: 2000, taxaHasFTax: true, createdAt: new Date() }],
+      users: [{ id: "u-1", organizationId: "org-1", email: "a@x", name: "Anna", role: "ADMIN", hourlyRate: 999999 }],
+      timeEntries: [{ id: "te-1", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), minutes: 180, description: "M", hourlyRate: 200000, billable: true }],
+      expenses: [{ id: "ex-1", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), amount: 10000, description: "Ansökningsavgift", billable: true, vatRate: 2500, vatIncluded: false }],
+    }, async () => {});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const c = appRouter.createCaller(buildContext({ dataStore: ds, ports: noopPorts, principal: PRINCIPAL }) as any);
+    const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "DOMSTOL" });
+    // Klienten (20 %) bär 20 % av utlägget: net 2 000 + moms 500 = 2 500 brutto; domstolen resten (10 000).
+    expect(res.clientInvoice.amount).toBe(83_800);   // rättshjälpsavgift 81 300 + utläggsandel 2 500
+    expect(res.payerInvoice.amount).toBe(335_200);   // domstolens arvode 325 200 + utläggsandel 10 000
+    const cv = res.clientInvoice.settlementBreakdown!;
+    expect(cv.rows.some((r) => r.label.includes("rättshjälpsavgift"))).toBe(true);        // #878 — EJ "självrisk"
+    expect(cv.rows.some((r) => r.label.toLowerCase().includes("självrisk"))).toBe(false);
+    expect(cv.rows.find((r) => r.label.includes("Utlägg (klientens andel"))?.amountOre).toBe(2_500);
+    const pv = res.payerInvoice.settlementBreakdown!;
+    expect(pv.rows.some((r) => r.label.includes("Avgår klientens rättshjälpsavgift"))).toBe(true);
+    expect(pv.rows.find((r) => r.label.includes("Utlägg"))?.amountOre).toBe(10_000);
+  });
+
+  it("rättshjälp (#878): aconton > slutlig rättshjälpsavgift → KREDITfaktura till klienten", async () => {
+    // Slutlig helhetssats 5 % (myndighetsbeslut), men klienten har betalat ett aconto
+    // på 50 000 (utställt vid en högre period-sats) → överfakturerat → kredit.
+    const { caller: c } = caller({ paymentMethod: "RATTSHJALP", clientShareBips: 500, taxaHasFTax: true }, 999999, 180);
+    await c.billingRun.createAcconto({ matterId: "m-1", clientShareBips: 7500, amountOre: 50_000 }); // SENT-aconto
+    const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "DOMSTOL" });
+    // Slutlig andel: 5 % × 325 200 = 16 260 net → 20 325 brutto. Betalt 50 000 → kredit 29 675.
+    expect(res.clientInvoice.amount).toBe(0);            // slutfakturan klampad
+    expect(res.creditInvoice).not.toBeNull();
+    expect(res.creditInvoice!.amount).toBe(-29_675);    // negativ = kreditering
+    expect(res.creditInvoice!.invoiceType).toBe("CREDIT");
+    expect(res.creditInvoice!.settlementBreakdown!.totalOre).toBe(29_675);
+  });
+
+  it("rättshjälp: aconton < slutlig rättshjälpsavgift → INGEN kreditfaktura", async () => {
+    const { caller: c } = caller({ paymentMethod: "RATTSHJALP", clientShareBips: 2000, taxaHasFTax: true }, 999999, 180);
+    await c.billingRun.createAcconto({ matterId: "m-1", clientShareBips: 2000, amountOre: 10_000 });
+    const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "DOMSTOL" });
+    expect(res.creditInvoice).toBeNull();               // 20 % × 325 200 = 65 040 > 10 000 aconto
+    expect(res.clientInvoice.amount).toBeGreaterThan(0);
+  });
+
   it("rättshjälp via KR (#828): kräver registrerat beslut; domsbeloppet läses från KR:n; KR konsumeras EJ utan markeras FAKTURERAD", async () => {
     const { ds, caller: c } = caller({ paymentMethod: "RATTSHJALP", clientShareBips: 2000, taxaHasFTax: true }, 999999, 180);
     const kr = await c.billingRun.createKostnadsrakning({ matterId: "m-1" });

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -509,6 +509,16 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
     expect(b.baseArvodeGrossOre + b.expensesGrossOre - b.sjalvriskGrossOre - b.prutningGrossOre).toBe(b.payerPayableOre);
     // Klient: självrisk − avräknade aconton = klientens belopp.
     expect(b.sjalvriskGrossOre - b.deductedAccontos.reduce((s, d) => s + d.amountOre, 0)).toBe(b.clientPayableOre);
+    // #876 — moms-trappan: självrisk NETTO + moms EN gång = brutto (ingen dubbelmoms).
+    expect(b.sjalvriskNetOre).toBe(65_040);                       // 20 % × 325 200 netto
+    expect(b.sjalvriskGrossOre - b.sjalvriskNetOre).toBe(16_260); // moms 25 %, redovisad exakt en gång
+    // #876 — rådgivningstimmen omnämns på domstolsfakturan (1 h × norm 162 600 × 1,25) men
+    // ligger UTANFÖR domstolens total (bekräftas av reconcile-raden ovan som ej rör den).
+    expect(b.radgivningGrossOre).toBe(203_250);
+    // #876 — klientens självrisk-spec: rådgivningstimmen carvad bort, summan == arvodesbasen.
+    expect(b.clientArvodeLines).toHaveLength(1);
+    expect(b.clientArvodeLines[0]!.minutes).toBe(120);            // 180 − 60 rådgivning
+    expect(b.clientArvodeLines.reduce((s, l) => s + l.amountOre, 0)).toBe(b.arvodeBaseNetOre);
   });
 
   it("rättshjälp via KR (#828): kräver registrerat beslut; domsbeloppet läses från KR:n; KR konsumeras EJ utan markeras FAKTURERAD", async () => {
@@ -554,6 +564,7 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
     expect(res.split).toMatchObject({ clientOre: 840_000, payerOre: 960_000, firmLossOre: 0 });
     expect(res.clientInvoice.amount).toBe(1_050_000); // 840 000 × 1,25 moms
     expect(res.payerInvoice.amount).toBe(1_200_000); // 960 000 × 1,25 moms
+    expect(res.breakdown.radgivningGrossOre).toBe(0); // #876 — rådgivning gäller bara rättshjälp
   });
 });
 

--- a/test/unit/server/sync/drizzle-sync-store.test.ts
+++ b/test/unit/server/sync/drizzle-sync-store.test.ts
@@ -171,4 +171,13 @@ describe("DrizzleSyncStore (#sync-bridge)", () => {
     const changes = (await sync.pull(ORG, cursor)).changes;
     expect(changes.find((c) => c.row.id === inv)).toMatchObject({ entity: "invoice" });
   });
+
+  // #879: en köad mutation med ett icke-uuid rowId (lokalt genererat nanoid) får
+  // ALDRIG kasta 22P02 och abortera reconcile-batchen → skippas som "accepted".
+  it("push med icke-uuid rowId skippas som accepted (kastar ej) (#879)", async () => {
+    const res = await sync.push(ORG, mut("invoice", "create", {
+      id: "mrg6gvmu-gbvt9s", matterId: uuidv7(), amount: 100, invoiceDate: new Date(), status: "DRAFT",
+    }));
+    expect(res.status).toBe("accepted"); // klienten ackar → slutar retry:a, ingen loop/hang
+  });
 });

--- a/tooling/db/migrations/0013_invoice_settlement_breakdown.sql
+++ b/tooling/db/migrations/0013_invoice_settlement_breakdown.sql
@@ -1,0 +1,4 @@
+-- #876: persisterad slutregleringsvy på fakturan — EN källa för både faktura-
+-- dokumentet och Slutfaktura-sidan (/invoices/[id]), så de aldrig glider isär.
+-- Sätts vid settleCoverage på klient-/betalar-fakturan; NULL på övriga fakturor.
+ALTER TABLE invoices ADD COLUMN IF NOT EXISTS settlement_breakdown jsonb;

--- a/tooling/demo-generator/populate-billing.ts
+++ b/tooling/demo-generator/populate-billing.ts
@@ -281,7 +281,9 @@ export async function populateBilling(caller: GeneratorCaller, seed: SeedDataset
       continue;
     }
     if (!hasWork(seed, matterId)) continue; // klientfaktura kräver fakturerbart arbete
-    if (matterId === "m-020-rattshjalp-varierande") {
+    // OBS: `matterId` är det ÖVERSATTA UUID:t (translateSeed), inte slug:en — matcha
+    // därför på `matterNumber` (ett affärsfält som INTE översätts).
+    if (String(m.matterNumber) === "2026-0020") {
       // Dedikerat flöde (#878): varierande avgift → settlement → kreditfaktura.
       await runRattshjalpVaryingRate(ctx, matterId);
       continue;

--- a/tooling/demo-generator/populate-billing.ts
+++ b/tooling/demo-generator/populate-billing.ts
@@ -206,6 +206,40 @@ async function runRattshjalpBilling(ctx: Ctx, matterId: string, daysAgo: number,
   await ctx.c.billingRun.recordKostnadsrakningBeslut({ billingRunId: kr.run.id, awardedOre: kr.run.workValueOreAtRun });
 }
 
+/** Aconto med ORGANISKT id (#878) — så flera aconton kan ställas ut på SAMMA ärende
+ *  (den delade `acconto`-helpern har ett enda deterministiskt id per ärende). */
+async function accontoVarying(ctx: Ctx, matterId: string, bips: number, amountOre: number, daysAgo: number): Promise<void> {
+  const { invoice } = await ctx.c.billingRun.createAcconto({
+    matterId, recipient: "KLIENT", clientShareBips: bips, amountOre,
+    invoiceDate: isoDaysAgo(daysAgo + 20), dueDate: isoDaysAgo(daysAgo - 10),
+    notes: `Aconto — rättshjälpsavgift ${bips / 100} % (löpande sats)`,
+  });
+  ctx.res.invoices++;
+  await ctx.c.invoice.setStatus({ invoiceId: invoice.id, status: "SENT" });
+}
+
+/**
+ * Rättshjälp med TIDSVARIERANDE avgift → kreditfaktura (#878). Hela förfarandet:
+ * rådgivning → 3 aconton vid löpande satser (5 % / 75 % / 5 %) → kostnadsräkning till
+ * domstol → myndighetens SLUTLIGA helhetsbeslut (5 %) via settlement → klienten har
+ * överfakturerats (särskilt 75 %-acontot) → `settleCoverage` skapar en KREDITfaktura.
+ */
+async function runRattshjalpVaryingRate(ctx: Ctx, matterId: string): Promise<void> {
+  await ctx.c.invoice.createRadgivning({ matterId });
+  ctx.res.invoices++;
+  await accontoVarying(ctx, matterId, 500, 30_000, 105);   // period 1: arbetslös, 5 %
+  await accontoVarying(ctx, matterId, 7500, 600_000, 55);  // period 2: anställd, 75 % (överfakturerar)
+  await accontoVarying(ctx, matterId, 500, 30_000, 20);    // period 3: åter arbetslös, 5 %
+  const kr = await ctx.c.billingRun.createKostnadsrakning({ matterId, notes: "Kostnadsräkning till domstol (rättshjälp, varierande avgift)" });
+  ctx.res.kostnadsrakningPending++;
+  // Myndighetens slutliga helhetsbeslut = 5 % (matterns clientShareBips); domstolen
+  // fastställer totalbeloppet (hela det yrkade i demon, ingen prutning).
+  await ctx.c.billingRun.recordKostnadsrakningBeslut({ billingRunId: kr.run.id, awardedOre: kr.run.workValueOreAtRun });
+  const res = await ctx.c.billingRun.settleCoverage({ matterId, payerRecipient: "DOMSTOL" });
+  ctx.res.invoices += res.creditInvoice ? 3 : 2; // klient-final + domstols-final (+ ev. kredit)
+  if (res.creditInvoice) ctx.res.credits++;
+}
+
 async function runClientBilling(ctx: Ctx, matterId: string, pm: string, clientIdx: number): Promise<void> {
   const daysAgo = 30 + clientIdx * 6;
   const deducted = pm === "RATTSSKYDD"
@@ -247,6 +281,11 @@ export async function populateBilling(caller: GeneratorCaller, seed: SeedDataset
       continue;
     }
     if (!hasWork(seed, matterId)) continue; // klientfaktura kräver fakturerbart arbete
+    if (matterId === "m-020-rattshjalp-varierande") {
+      // Dedikerat flöde (#878): varierande avgift → settlement → kreditfaktura.
+      await runRattshjalpVaryingRate(ctx, matterId);
+      continue;
+    }
     if (pm === "RATTSHJALP") {
       // Visa KR-kortets båda actionabla lägen: första ärendet väntar på beslut,
       // nästa har beslut registrerat (redo att faktureras/överklagas).

--- a/tooling/demo-generator/populate-billing.ts
+++ b/tooling/demo-generator/populate-billing.ts
@@ -236,8 +236,8 @@ async function runRattshjalpVaryingRate(ctx: Ctx, matterId: string): Promise<voi
   // fastställer totalbeloppet (hela det yrkade i demon, ingen prutning).
   await ctx.c.billingRun.recordKostnadsrakningBeslut({ billingRunId: kr.run.id, awardedOre: kr.run.workValueOreAtRun });
   const res = await ctx.c.billingRun.settleCoverage({ matterId, payerRecipient: "DOMSTOL" });
-  ctx.res.invoices += res.creditInvoice ? 3 : 2; // klient-final + domstols-final (+ ev. kredit)
-  if (res.creditInvoice) ctx.res.credits++;
+  ctx.res.invoices += 2; // klientfaktura (FINAL/CREDIT) + domstols-faktura
+  if (res.creditInvoice) ctx.res.credits++; // klientfakturan blev en CREDIT (överfakturerad)
 }
 
 async function runClientBilling(ctx: Ctx, matterId: string, pm: string, clientIdx: number): Promise<void> {

--- a/tooling/demo-generator/populate-invoice-docs.ts
+++ b/tooling/demo-generator/populate-invoice-docs.ts
@@ -36,7 +36,44 @@ function isRadgivning(inv: Any): boolean {
   return String(inv.notes ?? "").startsWith("Rådgivningstimme");
 }
 
-function renderInvoiceHtml(inv: Any): string {
+function fmtHours(minutes: number): string {
+  return (minutes / 60).toLocaleString("sv-SE", { maximumFractionDigits: 2 });
+}
+
+/** En rad ur den persisterade slutregleringsvyn (#878): add=svart, deduct=−(amber),
+ *  info=(parentes, grå) — speglar SettlementBreakdownCard/faktura-mallen. */
+function settlementRowHtml(r: Any): string {
+  const amt = r.kind === "deduct" ? `−${fmtKr(r.amountOre)}` : r.kind === "info" ? `(${fmtKr(r.amountOre)})` : fmtKr(r.amountOre);
+  const color = r.kind === "deduct" ? "color:#b45309" : r.kind === "info" ? "color:#9ca3af" : "";
+  return `<tr style="${color}"><td>${escapeHtml(r.label)}</td><td style="text-align:right">${amt}</td></tr>`;
+}
+
+/** Rendera fakturan ur den persisterade `settlementBreakdown` (#878) — samma
+ *  nedbrytning som detaljsidan + live-genererade dokumentet (tidsspec + trappa). */
+function renderSettlementHtml(inv: Any): string {
+  const b = inv.settlementBreakdown;
+  const heading = inv.invoiceType === "CREDIT" ? "Kreditfaktura" : inv.invoiceType === "ACCONTO" ? "Aconto-faktura" : "Faktura";
+  const timeTable = (b.timeLines ?? []).length
+    ? `<h2 style="font-size:15px;margin-top:1.5rem;margin-bottom:.25rem">Underlag (arbetad tid)</h2>
+<table cellpadding="5" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:13px">
+<thead><tr style="border-bottom:1px solid #ccc;text-align:left"><th>Datum</th><th>Beskrivning</th><th style="text-align:right">Tid</th><th style="text-align:right">Belopp</th></tr></thead>
+<tbody>${b.timeLines.map((l: Any) => `<tr><td>${new Date(l.date).toLocaleDateString("sv-SE")}</td><td>${escapeHtml(l.description)}</td><td style="text-align:right">${fmtHours(l.minutes)} h</td><td style="text-align:right">${fmtKr(l.amountOre)}</td></tr>`).join("")}</tbody>
+</table>`
+    : "";
+  return `<!DOCTYPE html><html lang="sv"><head><meta charset="utf-8"><title>${heading} ${escapeHtml(inv.matter.matterNumber)}</title></head>
+<body style="font-family:system-ui,sans-serif;max-width:720px;margin:2rem auto;color:#111">
+<h1 style="margin-bottom:0">${heading}</h1>
+<p style="color:#555">${escapeHtml(inv.invoiceNumber ?? "")}${inv.ocrReference ? ` · OCR: ${escapeHtml(inv.ocrReference)}` : ""}<br>Ärende ${escapeHtml(inv.matter.matterNumber)} — ${escapeHtml(inv.matter.title)}<br>Datum: ${new Date(inv.invoiceDate).toLocaleDateString("sv-SE")}</p>
+${timeTable}
+<table cellpadding="6" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:14px;margin-top:1.5rem">
+<tbody>${(b.rows ?? []).map(settlementRowHtml).join("")}</tbody>
+<tfoot><tr style="border-top:2px solid #333"><td style="font-weight:bold">${escapeHtml(b.totalLabel)}</td><td style="text-align:right;font-weight:bold">${fmtKr(b.totalOre)}</td></tr></tfoot>
+</table>
+</body></html>`;
+}
+
+/** Faktura ur tids-/utläggstabellen (fallback för fakturor utan nedbrytning). */
+function renderTimeTableHtml(inv: Any): string {
   const itemized = [
     ...(inv.timeEntries ?? []).map(timeRow),
     ...(inv.expenses ?? []).map(expenseRow),
@@ -68,16 +105,31 @@ Datum: ${new Date(inv.invoiceDate).toLocaleDateString("sv-SE")}</p>
 ${radgivningNote}</body></html>`;
 }
 
+/** Settlement-/aconto-/kreditfakturor har en persisterad nedbrytning (#878) → rendera
+ *  den (tidsspec + moms-trappa); övriga faller tillbaka på tids-/utläggstabellen. */
+function renderInvoiceHtml(inv: Any): string {
+  return inv.settlementBreakdown ? renderSettlementHtml(inv) : renderTimeTableHtml(inv);
+}
+
 /** Dokument-id för en faktura. Default = läsbar `invdoc-<id>` (in-memory demo +
  *  GH Pages). Server-first (Postgres uuid-kolumn) skickar in en uuid-generator. */
 export type InvoiceDocIdFn = (invoiceId: string) => string;
 
-/** Får ett genererat dokument: slutfakturor (FINAL) + rådgivnings-fakturan, som
- *  nu är ett ACCONTO (#851) men ska synas i dokumentlistan (#843). Övriga aconton
- *  (självrisk) genererar inte dokument. */
+/** Får ett genererat dokument (#878): slutfakturor (FINAL), kreditfakturor (CREDIT),
+ *  allt med en persisterad nedbrytning (aconton m. settlementBreakdown) + rådgivnings-
+ *  fakturan. Så alla fakturor på ett slutreglerat ärende blir öppningsbara på GH Pages. */
 function shouldGenerateDoc(summary: Any): boolean {
-  if (summary.invoiceType === "FINAL") return true;
+  if (summary.invoiceType === "FINAL" || summary.invoiceType === "CREDIT") return true;
+  if (summary.settlementBreakdown != null) return true;
   return String(summary.notes ?? "").startsWith("Rådgivningstimme");
+}
+
+/** Filnamns-/titel-etikett per fakturatyp (#878). */
+function docLabel(inv: Any): string {
+  if (isRadgivning(inv)) return "Rådgivningsfaktura";
+  if (inv.invoiceType === "CREDIT") return "Kreditfaktura";
+  if (inv.invoiceType === "ACCONTO") return "Aconto-faktura";
+  return "Faktura";
 }
 
 export async function populateInvoiceDocs(caller: GeneratorCaller, sink?: BinarySink, idFor?: InvoiceDocIdFn): Promise<number> {
@@ -92,9 +144,8 @@ export async function populateInvoiceDocs(caller: GeneratorCaller, sink?: Binary
     const storagePath = `documents/content/${id}.html`;
     const bytes = new TextEncoder().encode(html);
     const size = sink ? sink(storagePath, bytes) : bytes.byteLength;
-    // Rådgivnings-fakturan märks tydligt i fil-listan så den inte förväxlas med
-    // slutfakturan/kostnadsräkningen (#870).
-    const label = isRadgivning(inv) ? "Rådgivningsfaktura" : "Faktura";
+    // Tydlig etikett per fakturatyp så den inte förväxlas i fil-listan (#870/#878).
+    const label = docLabel(inv);
     await c.document.register({
       id, matterId: inv.matter.id, invoiceId: inv.id,
       fileName: `${label} ${inv.matter.matterNumber}.html`,

--- a/tooling/scripts/seed-data.ts
+++ b/tooling/scripts/seed-data.ts
@@ -145,6 +145,12 @@ export const MATTERS: MatterSeed[] = [
   { id: "m-016-brottmal-rh", matterNumber: "2026-0016", title: "Brottmål — rattfylleri Falk", status: "ACTIVE", matterType: "Brottmål", paymentMethod: "OFFENTLIGT_UPPDRAG", description: "Förordnad offentlig försvarare vid Stockholms tingsrätt.", klientId: "c-falk", domstolId: "c-tingsratten-sthlm", createdDaysAgo: 18, isTaxeArende: true, taxaLevel: 1, taxaHuvudforhandlingMin: 95, taxaHasFTax: true },
   { id: "m-017-brottmal-omf", matterNumber: "2026-0017", title: "Brottmål — omfattande utredning Davidsson", status: "ACTIVE", matterType: "Brottmål", paymentMethod: "OFFENTLIGT_UPPDRAG", description: "Frångångstaxa pga väsentligt mer arbete (komplex bevisning).", klientId: "c-davidsson", domstolId: "c-hovratten-svea", createdDaysAgo: 35, isTaxeArende: false },
   { id: "m-018-brottmal-ekobrott", matterNumber: "2026-0018", title: "Brottmål — ekobrott Carlsson", status: "ACTIVE", matterType: "Brottmål", paymentMethod: "OFFENTLIGT_UPPDRAG", description: "Misstanke om grovt bokföringsbrott. Omfattande material — kostnadsräkning skickas till domstol istället för enligt taxa.", klientId: "c-carlsson", domstolId: "c-tingsratten-sthlm", createdDaysAgo: 28, isTaxeArende: false },
+  // Rättshjälp med TIDSVARIERANDE avgift (#878): klienten var arbetslös (5 %), fick
+  // jobb (75 %) och blev arbetslös igen (5 %). Aconton ställdes ut vid de löpande
+  // satserna; rättshjälpsmyndighetens SLUTLIGA helhetsbeslut blev 5 % → klienten
+  // överfakturerades (särskilt via 75 %-acontot) → kreditfaktura. clientShareBips =
+  // det slutliga helhetsbeslutet (5 %). Egen tidslogg (nedan) → deterministiskt arvode.
+  { id: "m-020-rattshjalp-varierande", matterNumber: "2026-0020", title: "Vårdnadstvist — varierande rättshjälp Falk", status: "ACTIVE", matterType: "Familjerätt", paymentMethod: "RATTSHJALP", description: "Rättshjälp med varierande avgift (arbetslös 5 % → anställd 75 % → arbetslös 5 %). Myndighetens slutliga beslut: 5 % för hela ärendet.", klientId: "c-falk", motpartId: "c-bergman", domstolId: "c-tingsratten-sthlm", createdDaysAgo: 120, clientShareBips: 500, rattshjalpMaxTimmar: 100 },
 ];
 
 // ASSIGN_USERS härleds inuti buildSeed() från de aktuella users — så ifall
@@ -364,9 +370,9 @@ function buildTimeEntries(orgId: string, users: UserSeed[]): SeedDataset["timeEn
   const activeMatters = MATTERS.filter((m) => m.status === "ACTIVE");
   let teSeq = 0;
   activeMatters.forEach((matter, mi) => {
-    // Umgängestvist Carlsson har en dedikerad, kronologiskt koherent tidslogg
-    // (rådgivningstimmen först) — se nedan (#862).
-    if (matter.id === "m-010-vardnad-2") return;
+    // Umgängestvist Carlsson (m-010) + varierande-rättshjälp (m-020) har dedikerade,
+    // kronologiskt koherenta tidsloggar (rådgivningstimmen först) — se nedan (#862/#878).
+    if (matter.id === "m-010-vardnad-2" || matter.id === "m-020-rattshjalp-varierande") return;
     const count = 4 + (mi % 3); // 4,5,6,4,5,6…
     for (let j = 0; j < count; j++) {
       teSeq++;
@@ -385,7 +391,38 @@ function buildTimeEntries(orgId: string, users: UserSeed[]): SeedDataset["timeEn
     }
   });
   appendVardnad2TimeEntries(out, orgId, users);
+  appendVaryingRattshjalpTimeEntries(out, orgId, users);
   return out;
+}
+
+/**
+ * Dedikerad tidslogg för "Vårdnadstvist — varierande rättshjälp" (m-020) (#878):
+ * rådgivningstimmen först, sedan arbete spritt över ~120 dagar så aconton hinner
+ * ställas ut vid olika rättshjälpsavgifts-satser (arbetslös/anställd/arbetslös).
+ * Totalt 10,5 tim (−1 tim rådgivning = 9,5 tim debiterbart arvode).
+ */
+function appendVaryingRattshjalpTimeEntries(out: SeedDataset["timeEntries"], orgId: string, users: UserSeed[]): void {
+  const lawyer = users.find((u) => u.role === "LAWYER") ?? users[0];
+  if (!lawyer) return;
+  const rows: Array<{ daysAgo: number; minutes: number; description: string }> = [
+    { daysAgo: 118, minutes: 60, description: "Första möte med klient i ärendet" }, // rådgivningstimmen — FÖRST
+    { daysAgo: 100, minutes: 90, description: "Genomgång av handlingar (klient arbetslös, 5 % avgift)" },
+    { daysAgo: 70, minutes: 120, description: "Förhandlingsförberedelse och inlaga" },
+    { daysAgo: 55, minutes: 90, description: "Klientmöte (klient fått anställning, 75 % avgift)" },
+    { daysAgo: 40, minutes: 120, description: "Sammanträde i tingsrätten" },
+    { daysAgo: 20, minutes: 90, description: "Uppföljning och korrespondens (klient åter arbetslös, 5 %)" },
+    { daysAgo: 8, minutes: 60, description: "Slutförberedelse inför avgörande" },
+  ];
+  rows.forEach((r, i) => {
+    out.push({
+      id: `te-m020-${i + 1}`,
+      organizationId: orgId,
+      userId: lawyer.id, matterId: "m-020-rattshjalp-varierande", date: isoDate(-r.daysAgo, 9),
+      minutes: r.minutes, description: r.description,
+      hourlyRate: lawyer.hourlyRate, billable: true,
+      invoiceId: null, createdAt: isoDate(-r.daysAgo, 9), updatedAt: isoDate(-r.daysAgo, 9),
+    });
+  });
 }
 
 /**


### PR DESCRIPTION
Fixar tre fel på rättshjälps-slutregleringen (ärende 2026-0010 Umgängestvist Carlsson), rapporterade vid manuell test av live-slutreglera-flödet. Closes #876.

## #1 — Klientens självrisk-faktura saknade specifikation
Fakturan renderades bara med summeringsrader. Nu skickas tidsspecen (arbetad tid) till mallen: rådgivningstimmen carvas bort (rättshjälp), raderna värderas på timkostnadsnormen och **stäms av** så radernas summa exakt == arvodesbasen.

## #2 — Rådgivningstimmen omnämns nu på domstolsfakturan
Domstolens total exkluderade redan rådgivningen (`coverageBaseMinutes` −60), men det fanns ingen rad om det → såg ut som inbakat. `payerBreakdown` får nu en **info-rad** (grå/parentes) som visar rådgivningsbeloppet och att klienten betalat det separat — **totalen orörd**.

## #3 — Moms dubbelmärktes på självrisk-raden
Netto-basen (upparbetat arvode) var felmärkt "inkl moms". Klientens självrisk-nedbrytning visar nu en **moms-trappa**: netto → andel → moms 25 % → inkl → avgår aconto → att betala. Momsen redovisas exakt en gång.

## Övrigt
- Mallen: `showSpecTotals` undertrycker spec-summeringen när en breakdown finns → tids-TABELLEN renderas utan att dubblera arvode/moms-summeringen. Befintliga spec-fakturor (KR) opåverkade.
- `carveEarliestMinutes` exporteras + generaliseras och återanvänds server-side (DRY).

## Tester
- `billingRun.test.ts`: assertions för `sjalvriskNetOre` (65 040), moms en gång (16 260), `radgivningGrossOre` (203 250 för rättshjälp, 0 för rättsskydd), och att `clientArvodeLines` är carvade (120 min) + summerar till arvodesbasen.
- `generate-faktura-from-template.test.ts`: självrisk-fakturan renderar tidsspec-TABELL + moms-trappa och **inte** spec-summeringen ("Delsumma (inkl moms)").
- `bun run quality:fast` grönt (typecheck + lint + 3225 tester, 0 fail).

## Not
Slutregleringsdokumenten genereras bara i live-appen (`settleCoverage` anropas ej av demo-generatorn), så fixen syns när man kör Slutreglera på nytt — inte i redan seedad data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)