### PR TITLE
feat(demo): kronologisk simulerad seedning per ärende (#880)

### DIFF
--- a/src/components/documents/_document-row.tsx
+++ b/src/components/documents/_document-row.tsx
@@ -27,6 +27,7 @@ export interface DocumentRecord {
   uploadedBy: { name: string | null } | null;
   title?: string | null | undefined;
   documentType?: string | null | undefined;
+  direction?: "INKOMMANDE" | "UTGAENDE" | null | undefined;
   tags?: readonly string[] | undefined;
   summary?: string | null | undefined;
   analyzedAt?: string | Date | null | undefined;
@@ -272,11 +273,24 @@ interface NameButtonProps {
   onOpen: () => void;
 }
 
+/** Riktnings-badge (#880): inkommande (blå) / utgående (grön). Null → inget. */
+function DirectionBadge({ direction }: { direction?: "INKOMMANDE" | "UTGAENDE" | null | undefined }) {
+  if (!direction) return null;
+  const incoming = direction === "INKOMMANDE";
+  return (
+    <span className={`inline-block rounded-full px-1.5 py-0.5 text-[10px] font-medium flex-shrink-0 ${incoming ? "bg-sky-50 text-sky-700" : "bg-emerald-50 text-emerald-700"}`}
+      title={incoming ? "Inkommande dokument" : "Utgående dokument"}>
+      {incoming ? "↓ Ink." : "↑ Utg."}
+    </span>
+  );
+}
+
 /** Meta-raden under filnamnet (typ-badge, filnamn, analys-status). Utbruten
  *  ur DocumentNameButton — alla villkorade `&&`-render-grenar bor här. */
 function DocumentNameMeta({ doc, isAnalyzing, isWaitingAnalysis }: { doc: DocumentRecord; isAnalyzing: boolean; isWaitingAnalysis: boolean }) {
   return (
     <span className="flex items-center gap-1.5 text-xs text-gray-500 font-normal min-w-0">
+      <DirectionBadge direction={doc.direction} />
       {doc.documentType && (
         <span className="inline-block rounded-full bg-purple-50 text-purple-700 px-1.5 py-0.5 text-[10px] font-medium flex-shrink-0">
           {doc.documentType}

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -340,6 +340,8 @@ export const documents = pgTable("documents", {
   uploadedById: uuid("uploaded_by_id").notNull().$type<UserId>(),
   title: text("title"),
   documentType: text("document_type"),
+  /** Riktning (#880): INKOMMANDE / UTGAENDE — null där det saknar mening. */
+  direction: text("direction").$type<"INKOMMANDE" | "UTGAENDE">(),
   /** Fria etiketter ur byråns vokabulär (#621) — komplement till documentType.
    *  Sätts av LLM (förslag) + användare; skrivs via updateMetadata (ingen
    *  version-bump, #619). */

--- a/src/lib/server/routers/document/core.ts
+++ b/src/lib/server/routers/document/core.ts
@@ -9,7 +9,7 @@ import { conflictCopyName } from "@/lib/shared/conflict-copy";
 import { base64ToBytes, bytesToBase64, contentStoragePath, sha256Hex } from "@/lib/shared/content-address";
 import { isJunkFileName } from "@/lib/shared/junk-files";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
-import { documentAnalysisStatusSchema, type Document } from "@/lib/shared/schemas/document";
+import { documentAnalysisStatusSchema, documentDirectionSchema, type Document } from "@/lib/shared/schemas/document";
 import { asId, documentFolderIdSchema, documentIdSchema, invoiceIdSchema, matterIdSchema, userIdSchema } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
 import { orgProcedure } from "../../trpc";
@@ -113,6 +113,7 @@ export const coreProcedures = {
       version: z.number().int().positive().optional(),
       title: z.string().nullable().optional(),
       documentType: z.string().nullable().optional(),
+      direction: documentDirectionSchema.nullable().optional(),
       summary: z.string().nullable().optional(),
       analysisStatus: documentAnalysisStatusSchema.optional(),
       analyzedAt: z.string().optional(),
@@ -138,6 +139,7 @@ export const coreProcedures = {
         version: input.version,
         title: input.title,
         documentType: input.documentType,
+        direction: input.direction,
         summary: input.summary,
         analyzedAt: input.analyzedAt ? new Date(input.analyzedAt) : undefined,
         createdAt: input.createdAt ? new Date(input.createdAt) : undefined,

--- a/src/lib/shared/schemas/document.ts
+++ b/src/lib/shared/schemas/document.ts
@@ -16,6 +16,10 @@ import {
 export const documentAnalysisStatusSchema = z.enum(["PENDING", "RUNNING", "DONE", "ERROR"]);
 export type DocumentAnalysisStatus = z.infer<typeof documentAnalysisStatusSchema>;
 
+/** Dokumentets riktning (#880): inkommande (från motpart/domstol) vs utgående (byrån skickar). */
+export const documentDirectionSchema = z.enum(["INKOMMANDE", "UTGAENDE"]);
+export type DocumentDirection = z.infer<typeof documentDirectionSchema>;
+
 /**
  * DocumentFolder — hierarkisk mapp inom ett matter. `parentId` = null → root.
  * Lagras i `document-folders/<id>.json`.
@@ -49,6 +53,10 @@ export const documentSchema = z.object({
   // AI-genererad metadata (fylls async efter upload)
   title: z.string().nullish(),
   documentType: z.string().nullish(),
+  /** Riktning (#880): inkommande (t.ex. svaromål från motpartsombud, dom) vs
+   *  utgående (inlaga, brev byrån skickar). Nullish på dok där det saknar mening
+   *  (genererade fakturor/underlag). */
+  direction: documentDirectionSchema.nullish(),
   /** Etiketter ur byråns vokabulär (#621) — flera per dokument, satta av
    *  LLM (förslag) + användare. Komplement till `documentType`. */
   tags: z.array(z.string()).default([]),

--- a/test/scripts/simulate-orchestrate.test.ts
+++ b/test/scripts/simulate-orchestrate.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Integration för den kronologiska seedningen (#880): populate(kärnentiteter) +
+ * runSimulation mot ett git-target (in-memory). Speglar generateInto — verifierar
+ * att simuleringen faktiskt skapar tid/dokument/fakturor per ärende, kronologiskt,
+ * med inkommande dokument och kredit vid överfakturering.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { userRoleSchema } from "@/lib/shared/schemas/enums";
+import { asId } from "@/lib/shared/schemas/ids";
+import { createGitTarget } from "../../tooling/demo-generator/backend-target";
+import { createIdTranslator, translateSeed } from "../../tooling/demo-generator/id-translator";
+import { populate } from "../../tooling/demo-generator/populate";
+import { runSimulation } from "../../tooling/demo-generator/simulate/orchestrate";
+import type { RunCtx } from "../../tooling/demo-generator/simulate/runner";
+import { buildSeed } from "../../tooling/scripts/seed-data";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+describe("runSimulation (#880 integration)", () => {
+  it("seedar kronologiskt per ärende: tid, in/ut-dokument, fakturor + kredit", async () => {
+    const seed = translateSeed(buildSeed(), createIdTranslator()) as Any;
+    const orgId = String(seed.organizations[0].id);
+    const admin = { id: asId<"UserId">("gen"), email: "g@a.se", name: "G", role: userRoleSchema.parse("ADMIN"), organizationId: asId<"OrganizationId">(orgId) };
+    const target = createGitTarget({ principal: admin, writeBack: async () => {} });
+    const coreSeed = { ...seed, matters: seed.matters.map((m: Any) => ({ ...m, status: "ACTIVE" })), timeEntries: [], expenses: [], matterContacts: [], documents: [], serviceNotes: [] };
+    await populate(target.caller, coreSeed);
+
+    const ctx: RunCtx = { c: target.caller, res: { invoices: 0, documents: 0, timeEntries: 0, notes: 0, credits: 0 } };
+    await runSimulation(ctx, seed);
+
+    // Simuleringen skapade faktiskt saker (fångar "0 av allt"-regressionen).
+    expect(ctx.res.timeEntries).toBeGreaterThan(10);
+    expect(ctx.res.invoices).toBeGreaterThan(5);
+    expect(ctx.res.documents).toBeGreaterThan(5);
+    expect(ctx.res.credits).toBeGreaterThanOrEqual(1); // rättshjälp varierande → överfakturerad → kredit
+
+    // Något dokument är INKOMMANDE (inkommande dok skapas per scenario).
+    const c = target.caller as Any;
+    const mres = await c.matter.list({});
+    const matters = mres.matters ?? mres.items ?? mres;
+    const rh = matters.find((m: Any) => m.paymentMethod === "RATTSHJALP" && m.matterNumber === "2026-0020");
+    expect(rh, "varierande-rättshjälp-ärendet finns").toBeTruthy();
+    const docs = await c.document.list({ matterId: rh.id, folderId: null, pageSize: 100 });
+    const list = docs.documents ?? docs;
+    expect(list.some((d: Any) => d.direction === "INKOMMANDE")).toBe(true);
+    expect(list.some((d: Any) => d.direction === "UTGAENDE")).toBe(true);
+
+    // Ärendet har flera tidsposter (kronologin i sig täcks av runner-enhetstestet).
+    const te = await c.timeEntry.list({ matterId: rh.id, pageSize: 100 });
+    const teRows = te.timeEntries ?? te.items ?? te.entries ?? (Array.isArray(te) ? te : []);
+    expect(teRows.length).toBeGreaterThan(2);
+  });
+});

--- a/test/scripts/simulate-runner.test.ts
+++ b/test/scripts/simulate-runner.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Kronologisk scenario-runner (#880): spelar upp ett ärendes SimEvent[] i tidsordning
+ * via tRPC-callern. Här testas runnern mot en INSPELNINGS-STUB (ingen riktig backend)
+ * — verifierar ordning, härledda aconto-belopp och att inkommande dok får direction.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import type { SimMatter } from "../../tooling/demo-generator/simulate/events";
+import { runScenario, type RunCtx } from "../../tooling/demo-generator/simulate/runner";
+import { buildRattshjalpScenario } from "../../tooling/demo-generator/simulate/scenarios/rattshjalp";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+/** Bygg en caller-stub som spelar in varje mutation + returnerar minsta rimliga svar. */
+function recordingCaller() {
+  const calls: Array<{ method: string; args: Any }> = [];
+  const rec = (method: string) => async (args: Any) => {
+    calls.push({ method, args });
+    if (method === "billingRun.createAcconto") return { run: { id: "run" }, invoice: { id: `inv-${calls.length}` } };
+    if (method === "billingRun.createKostnadsrakning") return { run: { id: "kr", workValueOreAtRun: 1_544_700 } };
+    if (method === "billingRun.createFinal") return { invoice: { id: "fin", amount: 100_000 } };
+    if (method === "billingRun.settleCoverage") return { creditInvoice: { id: "cred", amount: -50_000 }, clientInvoice: {}, payerInvoice: {} };
+    return {};
+  };
+  const c = {
+    matter: { addContact: rec("matter.addContact") },
+    timeEntry: { create: rec("timeEntry.create") },
+    serviceNote: { create: rec("serviceNote.create") },
+    expense: { create: rec("expense.create") },
+    document: { register: rec("document.register") },
+    invoice: { createRadgivning: rec("invoice.createRadgivning"), setStatus: rec("invoice.setStatus"), recordPayment: rec("invoice.recordPayment") },
+    billingRun: {
+      createAcconto: rec("billingRun.createAcconto"), createKostnadsrakning: rec("billingRun.createKostnadsrakning"),
+      recordKostnadsrakningBeslut: rec("billingRun.recordKostnadsrakningBeslut"), settleCoverage: rec("billingRun.settleCoverage"),
+      createFinal: rec("billingRun.createFinal"),
+    },
+  };
+  return { c, calls };
+}
+
+const MATTER: SimMatter = {
+  id: "m-1", paymentMethod: "RATTSHJALP", clientShareBips: 500, lawyerId: "u-1",
+  startDaysAgo: 120, arvodeRateOre: 162_600,
+};
+
+describe("runScenario (#880)", () => {
+  it("spelar upp rättshjälps-scenariot kronologiskt med härledda aconto-belopp", async () => {
+    const { c, calls } = recordingCaller();
+    const ctx: RunCtx = { c, res: { invoices: 0, documents: 0, timeEntries: 0, notes: 0, credits: 0 } };
+    const events = buildRattshjalpScenario({ motpart: "c-mot", motpartsombud: "c-omb", domstol: "c-dom" });
+    await runScenario(ctx, MATTER, events);
+
+    // Kronologi: varje mutations datum-arg (date/invoiceDate/createdAt) är icke-avtagande.
+    const dates = calls.map((x) => x.args.date ?? x.args.invoiceDate ?? x.args.createdAt).filter(Boolean).map((d: string) => new Date(d).getTime());
+    for (let i = 1; i < dates.length; i++) expect(dates[i]).toBeGreaterThanOrEqual(dates[i - 1]!);
+
+    // Rådgivning skapas FÖRE första acontot.
+    const radIdx = calls.findIndex((x) => x.method === "invoice.createRadgivning");
+    const firstAcc = calls.findIndex((x) => x.method === "billingRun.createAcconto");
+    expect(radIdx).toBeGreaterThanOrEqual(0);
+    expect(radIdx).toBeLessThan(firstAcc);
+
+    // Tre aconton vid varierande satser (5/75/5 %), belopp härlett ur upparbetat.
+    const accontos = calls.filter((x) => x.method === "billingRun.createAcconto");
+    expect(accontos.map((a) => a.args.clientShareBips)).toEqual([500, 7500, 500]);
+    expect(accontos.every((a) => a.args.amountOre > 0)).toBe(true);
+
+    // Inkommande svaromål registreras med direction INKOMMANDE.
+    const svaromal = calls.find((x) => x.method === "document.register" && x.args.documentType === "Svaromål");
+    expect(svaromal?.args.direction).toBe("INKOMMANDE");
+    // Utgående inlaga med direction UTGAENDE.
+    const inlaga = calls.find((x) => x.method === "document.register" && x.args.documentType === "Inlaga");
+    expect(inlaga?.args.direction).toBe("UTGAENDE");
+
+    // Avslutas med kostnadsräkning → beslut → slutreglering.
+    expect(calls.some((x) => x.method === "billingRun.createKostnadsrakning")).toBe(true);
+    expect(calls.some((x) => x.method === "billingRun.recordKostnadsrakningBeslut")).toBe(true);
+    expect(calls.some((x) => x.method === "billingRun.settleCoverage")).toBe(true);
+    expect(ctx.res.credits).toBe(1);
+  });
+});

--- a/tooling/db/migrations/0014_document_direction.sql
+++ b/tooling/db/migrations/0014_document_direction.sql
@@ -1,0 +1,3 @@
+-- #880: dokumentets riktning — inkommande (svaromål/dom från motpart/domstol) vs
+-- utgående (inlaga/brev byrån skickar). NULL där det saknar mening (fakturor/underlag).
+ALTER TABLE documents ADD COLUMN IF NOT EXISTS direction text;

--- a/tooling/demo-generator/generate-into.ts
+++ b/tooling/demo-generator/generate-into.ts
@@ -20,20 +20,18 @@ import { createGitTarget } from "./backend-target";
 import { createIdTranslator, translateSeed, type IdTranslator } from "./id-translator";
 import { makeNodeGitWriteBack } from "./node-git-writeback";
 import { populate, type PopulateResult } from "./populate";
-import { populateBilling, type BillingResult } from "./populate-billing";
-import { populateDocuments } from "./populate-documents";
 import { populateInvoiceDocs } from "./populate-invoice-docs";
 import { populateKostnadsrakningDocs } from "./populate-kostnadsrakning-docs";
-import { populateTemplateDocs } from "./populate-template-docs";
-import { populateUnbilledTime } from "./populate-unbilled-time";
+import { runSimulation } from "./simulate/orchestrate";
+import type { RunCtx } from "./simulate/runner";
 
 export interface GenerateResult extends PopulateResult {
+  /** Narrativa dokument (in/ut) skapade av simuleringen. */
   documents: number;
-  templateDocs: number;
   invoiceDocs: number;
   kostnadsrakningDocs: number;
-  billing: BillingResult;
-  unbilledTimeEntries: number;
+  /** Räknare från den kronologiska simuleringen (#880). */
+  sim: RunCtx["res"];
   /** Reverse-mappning UUID → slug. meta.json + URL-routing använder den. */
   translator: IdTranslator;
 }
@@ -54,25 +52,32 @@ export async function generateInto(outDir: string, seedOpts: BuildSeedOpts = {})
   };
   const target = createGitTarget({ principal, writeBack: makeNodeGitWriteBack(outDir) });
 
-  const res = await populate(target.caller, seed);
-  // Ett faktureringsflöde per ärende via billing-run (#736) — acconto/slutfaktura/
-  // kostnadsräkning per paymentMethod + livscykel. Ersätter de tidigare två passen.
-  const billing = await populateBilling(target.caller, seed); // efter time/expenses
-  // Färsk upparbetad tid EFTER billing → entries med invoiceId=null.
-  // Simulerar löpande arbete som inte hunnit faktureras ännu.
-  const unbilledTimeEntries = await populateUnbilledTime(target.caller, seed);
+  // Kärnentiteter FÖRE ärende-arbetet: org/users/contacts/matters/kalender/tasks/
+  // mallar/jäv. Tid/utlägg/kontakter(motpart)/dokument skapas kronologiskt av
+  // simuleringen (#880), inte ur seedens statiska rader → tomma här. Ärenden skapas
+  // som ACTIVE (annars blockerar flödes-guarden scenariot); stängs sen i runSimulation.
+  const coreSeed = {
+    ...seed,
+    matters: (seed.matters ?? []).map((m) => ({ ...m, status: "ACTIVE" })),
+    timeEntries: [], expenses: [], matterContacts: [], documents: [], serviceNotes: [],
+  };
+  const res = await populate(target.caller, coreSeed);
+
   const sink = (storagePath: string, bytes: Uint8Array): number => {
     const full = join(outDir, storagePath);
     mkdirSync(dirname(full), { recursive: true });
     writeFileSync(full, bytes);
     return bytes.byteLength;
   };
-  const documents = await populateDocuments(target.caller, seed, sink);
-  const templateDocs = await populateTemplateDocs(target.caller, seed, sink); // mall→ärende-flödet
-  const invoiceDocs = await populateInvoiceDocs(target.caller, sink); // faktura-dokument länkade till fakturan
-  // KR-dokument per KOSTNADSRAKNING-run → ärendet visar inte "väntar på dom"
-  // utan att kostnadsräkningen faktiskt finns (kohärent demo-state).
+  // Kronologisk simulering per ärende (#880): parter → rådgivning → arbete/dokument
+  // (in/ut) → aconton → kostnadsräkning/slutreglering, i tidsordning.
+  const ctx: RunCtx = { c: target.caller, sink, res: { invoices: 0, documents: 0, timeEntries: 0, notes: 0, credits: 0 } };
+  await runSimulation(ctx, seed);
+
+  // Faktura-/KR-HTML-dokument som EFTER-pass (läser skapade fakturor/runs; renderar
+  // settlementBreakdown efter #878).
+  const invoiceDocs = await populateInvoiceDocs(target.caller, sink);
   const kostnadsrakningDocs = await populateKostnadsrakningDocs(target.caller, sink);
   await target.finalize();
-  return { ...res, documents, templateDocs, invoiceDocs, kostnadsrakningDocs, billing, unbilledTimeEntries, translator };
+  return { ...res, documents: ctx.res.documents, invoiceDocs, kostnadsrakningDocs, sim: ctx.res, translator };
 }

--- a/tooling/demo-generator/simulate/clock.ts
+++ b/tooling/demo-generator/simulate/clock.ts
@@ -1,0 +1,22 @@
+/**
+ * Deterministisk händelse-klocka för den kronologiska simuleringen (#880).
+ *
+ * Ett ärende "startar" `startDaysAgo` dagar sedan (ur seedens createdDaysAgo). Ett
+ * events datum = ärendestart + `dayOffset` dagar, klampat till ≤ idag (aldrig i
+ * framtiden). Enda "nu" är detta `new Date()` — ingen `Math.random`; variation i
+ * scenarierna härleds ur ärende-index (determinism krävs av demot + CI).
+ */
+
+/** ISO-datum för ett event: ärendestart (startDaysAgo sedan) + dayOffset dagar. */
+export function eventIso(startDaysAgo: number, dayOffset: number, hour = 10): string {
+  const daysAgo = Math.max(0, startDaysAgo - dayOffset);
+  const d = new Date();
+  d.setHours(hour, 0, 0, 0);
+  d.setDate(d.getDate() - daysAgo);
+  return d.toISOString();
+}
+
+/** Klockslag (HH:MM) för en tjänsteanteckning, härlett ur timmen. */
+export function eventTime(hour = 10): string {
+  return `${String(hour).padStart(2, "0")}:00`;
+}

--- a/tooling/demo-generator/simulate/events.ts
+++ b/tooling/demo-generator/simulate/events.ts
@@ -25,6 +25,8 @@ export type SimEvent =
   | { kind: "kostnadsrakning"; dayOffset: number }
   /** Domstolens beslut på KR:n — recordKostnadsrakningBeslut. */
   | { kind: "beslut"; dayOffset: number }
+  /** Skapa domstolsfakturan EFTER beslut (offentligt uppdrag) — setVerdict. */
+  | { kind: "verdict"; dayOffset: number }
   /** Slutreglering (rättshjälp/-skydd) — settleCoverage (→ klient FINAL/CREDIT + betalare). */
   | { kind: "settle"; dayOffset: number; payerRecipient: string }
   /** Vanlig slutfaktura (privat/offentligt) — createFinal + SENT. */
@@ -45,4 +47,11 @@ export interface SimMatter {
   /** Arvode-sats (öre/tim) som ackumulerat arbete värderas på — driver aconto-belopp
    *  (rättshjälp: timkostnadsnormen; annars ansvarig jurists timtaxa). */
   arvodeRateOre: number;
+}
+
+/** Motparter/instans att länka in via `party`-events (översatta UUID:n). */
+export interface Parties {
+  motpart?: string | undefined;
+  motpartsombud?: string | undefined;
+  domstol?: string | undefined;
 }

--- a/tooling/demo-generator/simulate/events.ts
+++ b/tooling/demo-generator/simulate/events.ts
@@ -1,0 +1,48 @@
+/**
+ * Händelse-modell för den kronologiska demo-simuleringen (#880). Varje `SimEvent`
+ * motsvarar en "user action" som spelas upp via tRPC med eventets datum. Belopp som
+ * beror på ackumulerat arbete (aconto, slutreglering) HÄRLEDS i runnern, inte här.
+ */
+
+import type { MatterRole } from "@/lib/shared/schemas/enums";
+
+export type SimEvent =
+  /** Länka en part (motpart/ombud/domstol) till ärendet — matter.addContact. */
+  | { kind: "party"; dayOffset: number; contactId: string; role: MatterRole }
+  /** Debiterbar (eller ej) tidspost — timeEntry.create. */
+  | { kind: "time"; dayOffset: number; minutes: number; description: string; billable?: boolean }
+  /** Tjänsteanteckning (händelselogg) — serviceNote.create. */
+  | { kind: "note"; dayOffset: number; text: string }
+  /** Utlägg — expense.create. */
+  | { kind: "expense"; dayOffset: number; amountOre: number; description: string; vatRate?: number }
+  /** Dokument (in/ut) ur DOC_TEMPLATES — document.register + bytes via sink. */
+  | { kind: "doc"; dayOffset: number; template: string }
+  /** Rådgivningstimmen faktureras — invoice.createRadgivning. */
+  | { kind: "radgivning"; dayOffset: number }
+  /** Aconto på klientens andel vid `clientShareBips` (belopp härlett) — createAcconto. */
+  | { kind: "acconto"; dayOffset: number; clientShareBips: number }
+  /** Kostnadsräkning till domstol — createKostnadsrakning. */
+  | { kind: "kostnadsrakning"; dayOffset: number }
+  /** Domstolens beslut på KR:n — recordKostnadsrakningBeslut. */
+  | { kind: "beslut"; dayOffset: number }
+  /** Slutreglering (rättshjälp/-skydd) — settleCoverage (→ klient FINAL/CREDIT + betalare). */
+  | { kind: "settle"; dayOffset: number; payerRecipient: string }
+  /** Vanlig slutfaktura (privat/offentligt) — createFinal + SENT. */
+  | { kind: "final"; dayOffset: number; recipient: string }
+  /** Betala den senast skapade slutfakturan — invoice.recordPayment. */
+  | { kind: "payment"; dayOffset: number };
+
+/** Det runnern behöver veta om ärendet för att spela upp dess scenario. */
+export interface SimMatter {
+  /** Översatt (UUID) ärende-id. */
+  id: string;
+  paymentMethod: string;
+  clientShareBips?: number | null;
+  /** Ansvarig jurist (userId) — sätts som tidsposternas användare. */
+  lawyerId: string;
+  /** Ärendets startålder i dagar (seedens createdDaysAgo). */
+  startDaysAgo: number;
+  /** Arvode-sats (öre/tim) som ackumulerat arbete värderas på — driver aconto-belopp
+   *  (rättshjälp: timkostnadsnormen; annars ansvarig jurists timtaxa). */
+  arvodeRateOre: number;
+}

--- a/tooling/demo-generator/simulate/fake-content.ts
+++ b/tooling/demo-generator/simulate/fake-content.ts
@@ -1,0 +1,52 @@
+/**
+ * Sparsamt, fejkat dokumentinnehåll för den kronologiska seedningen (#880). Korta
+ * svenska mallsträngar per dokumenttyp — matas som `summary`/body till
+ * `generateDocumentBytes` (PDF/DOCX). Det är seed-data; innehållet behöver bara
+ * vara begripligt, inte juridiskt korrekt.
+ */
+
+import type { DocumentDirection } from "@/lib/shared/schemas/document";
+
+export interface DocTemplate {
+  documentType: string;
+  direction: DocumentDirection;
+  /** Titel/filnamnsbas. `{m}` ersätts med ärende-titel av anroparen om önskat. */
+  title: string;
+  summary: string;
+}
+
+/** Fördefinierade dokument-mallar (nyckel → mall). Utökas per scenariobehov. */
+export const DOC_TEMPLATES: Record<string, DocTemplate> = {
+  fullmakt: {
+    documentType: "Fullmakt", direction: "UTGAENDE",
+    title: "Fullmakt", summary: "Klienten befullmäktigar ombudet att företräda i ärendet.",
+  },
+  stamningsansokan: {
+    documentType: "Stämningsansökan", direction: "UTGAENDE",
+    title: "Stämningsansökan", summary: "Ansökan om stämning ges in till tingsrätten med yrkanden och grunder.",
+  },
+  inlaga: {
+    documentType: "Inlaga", direction: "UTGAENDE",
+    title: "Inlaga till tingsrätten", summary: "Komplettering av talan samt bemötande av motpartens invändningar.",
+  },
+  brevTillOmbud: {
+    documentType: "Korrespondens", direction: "UTGAENDE",
+    title: "Brev till motpartsombud", summary: "Förfrågan om förlikning samt begäran om handlingar.",
+  },
+  svaromal: {
+    documentType: "Svaromål", direction: "INKOMMANDE",
+    title: "Svaromål från motpartsombud", summary: "Motparten bestrider käromålet och åberopar egen bevisning.",
+  },
+  brevFranOmbud: {
+    documentType: "Korrespondens", direction: "INKOMMANDE",
+    title: "Brev från motpartsombud", summary: "Motpartsombudet återkommer angående förlikning och tidplan.",
+  },
+  dom: {
+    documentType: "Dom", direction: "INKOMMANDE",
+    title: "Dom från tingsrätten", summary: "Tingsrätten meddelar dom i målet. Se domslut och domskäl.",
+  },
+  beslutRattshjalp: {
+    documentType: "Beslut", direction: "INKOMMANDE",
+    title: "Beslut om rättshjälp", summary: "Rättshjälpsmyndighetens beslut om rättshjälpsavgiftens procentsats för ärendet.",
+  },
+};

--- a/tooling/demo-generator/simulate/orchestrate.ts
+++ b/tooling/demo-generator/simulate/orchestrate.ts
@@ -1,0 +1,72 @@
+/**
+ * Orkestrering av den kronologiska seedningen (#880): för varje ärende härleds en
+ * `SimMatter` + parter ur (den översatta) seeden, ett scenario byggs efter ärendetyp
+ * och spelas upp kronologiskt via `runScenario`. Ärenden som ska vara avslutade körs
+ * som ACTIVE under scenariot (annars blockerar flödes-guarden) och stängs på slutet.
+ *
+ * Ersätter de gamla kategori-passen (populateBilling/populateUnbilledTime + seedens
+ * statiska tid/utlägg/kontakter/dokument).
+ */
+
+import { TIMKOSTNADSNORM_FTAX_ORE_PER_H } from "@/lib/shared/brottmalstaxa";
+import { AVA_NAMESPACE, uuidv5 } from "@/lib/shared/uuid-derive";
+import type { Parties, SimMatter } from "./events";
+import type { RunCtx } from "./runner";
+import { runScenario } from "./runner";
+import { buildScenario } from "./scenarios";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+const MS_DAY = 86_400_000;
+const OMBUD_SLUG = "c-advokatbyran-nord";
+const DEFAULT_RATE_ORE = 250_000;
+
+function daysSince(iso: unknown): number {
+  const t = new Date(String(iso)).getTime();
+  return Number.isFinite(t) ? Math.max(0, Math.round((Date.now() - t) / MS_DAY)) : 30;
+}
+
+function deriveSim(m: Any, lawyerId: string, rateOre: number): SimMatter {
+  const isRh = String(m.paymentMethod) === "RATTSHJALP";
+  return {
+    id: String(m.id), paymentMethod: String(m.paymentMethod), clientShareBips: m.clientShareBips ?? null,
+    lawyerId, startDaysAgo: daysSince(m.createdAt),
+    arvodeRateOre: isRh ? TIMKOSTNADSNORM_FTAX_ORE_PER_H : (rateOre || DEFAULT_RATE_ORE),
+  };
+}
+
+function deriveParties(m: Any, ombudId: string): Parties {
+  const hasMotpart = Boolean(m.motpartId);
+  return {
+    motpart: hasMotpart ? String(m.motpartId) : undefined,
+    motpartsombud: hasMotpart ? ombudId : undefined,
+    domstol: m.domstolId ? String(m.domstolId) : undefined,
+  };
+}
+
+/** Kör ett ärendes scenario + stäng det om seedens status inte är ACTIVE. */
+async function simulateMatter(ctx: RunCtx, m: Any, users: { id: string; rateOre: number }[], ombudId: string, index: number): Promise<void> {
+  // Seed-ärenden saknar responsibleLawyerId → välj ansvarig jurist deterministiskt ur
+  // användarlistan (som gamla buildTimeEntries: round-robin per ärende-index).
+  const u = users[index % Math.max(1, users.length)];
+  if (!u) return;
+  const sim = deriveSim(m, u.id, u.rateOre);
+  await runScenario(ctx, sim, buildScenario(sim, deriveParties(m, ombudId), index));
+  if (String(m.status) !== "ACTIVE") await ctx.c.matter.update({ id: sim.id, status: String(m.status) });
+}
+
+/** Spela upp alla ärendens scenarier. `seed` = den ÖVERSATTA seeden (UUID-id). */
+export async function runSimulation(ctx: RunCtx, seed: Any): Promise<void> {
+  const users: { id: string; rateOre: number }[] = (seed.users ?? [])
+    .filter((u: Any) => typeof u.id === "string")
+    .map((u: Any) => ({ id: String(u.id), rateOre: Number(u.hourlyRate ?? 0) || 0 }));
+  // Motpartsombudet är hårdkopplat till c-advokatbyran-nord (jfr buildMatterContacts);
+  // samma uuid som translateSeed ger (uuidv5(slug)).
+  const ombudId = uuidv5(OMBUD_SLUG, AVA_NAMESPACE);
+  let index = 0;
+  for (const m of seed.matters ?? []) {
+    await simulateMatter(ctx, m, users, ombudId, index);
+    index++;
+  }
+}

--- a/tooling/demo-generator/simulate/runner.ts
+++ b/tooling/demo-generator/simulate/runner.ts
@@ -108,6 +108,12 @@ async function hBeslut(ctx: RunCtx, _m: SimMatter, _e: Any, _iso: string, st: Si
   await ctx.c.billingRun.recordKostnadsrakningBeslut({ billingRunId: st.krRunId, awardedOre: st.krWorkValueOre });
 }
 
+async function hVerdict(ctx: RunCtx, _m: SimMatter, _e: Any, _iso: string, st: SimState): Promise<void> {
+  if (!st.krRunId) return;
+  await ctx.c.billingRun.setVerdict({ billingRunId: st.krRunId });
+  ctx.res.invoices++;
+}
+
 async function hSettle(ctx: RunCtx, m: SimMatter, e: Any, _iso: string): Promise<void> {
   const res = await ctx.c.billingRun.settleCoverage({ matterId: m.id, payerRecipient: e.payerRecipient });
   ctx.res.invoices += 2;
@@ -129,7 +135,7 @@ async function hPayment(ctx: RunCtx, _m: SimMatter, _e: Any, iso: string, st: Si
 /** kind → handler. Håller runnern platt (undviker en stor switch = hög komplexitet). */
 const HANDLERS: Record<SimEvent["kind"], (ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimState) => Promise<void>> = {
   party: hParty, time: hTime, note: hNote, expense: hExpense, doc: hDoc, radgivning: hRadgivning,
-  acconto: hAcconto, kostnadsrakning: hKostnadsrakning, beslut: hBeslut, settle: hSettle, final: hFinal, payment: hPayment,
+  acconto: hAcconto, kostnadsrakning: hKostnadsrakning, beslut: hBeslut, verdict: hVerdict, settle: hSettle, final: hFinal, payment: hPayment,
 };
 
 /** Spela upp ett ärendes scenario kronologiskt. */

--- a/tooling/demo-generator/simulate/runner.ts
+++ b/tooling/demo-generator/simulate/runner.ts
@@ -1,0 +1,143 @@
+/**
+ * Kronologisk scenario-runner (#880). Spelar upp ett ärendes `SimEvent[]` i
+ * tidsordning via tRPC-callern med varje events datum — så demodatan byggs som om
+ * en användare gjort stegen i tur och ordning. Belopp som beror på ackumulerat
+ * arbete (aconto) härleds här ur `state`; dokumentbytes skrivs via `BinarySink`.
+ */
+
+import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
+import { AVA_NAMESPACE, uuidv5 } from "@/lib/shared/uuid-derive";
+import type { BinarySink } from "../populate-documents";
+import { eventIso, eventTime } from "./clock";
+import type { SimEvent, SimMatter } from "./events";
+import { DOC_TEMPLATES } from "./fake-content";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+export interface RunCtx {
+  c: Any; // GeneratorCaller (tRPC) — samma lösa typ som övriga demo-generator-moduler
+  sink?: BinarySink;
+  res: { invoices: number; documents: number; timeEntries: number; notes: number; credits: number };
+}
+
+interface SimState {
+  accruedNetOre: number;      // ackumulerat debiterbart arvode (netto)
+  billedNetOre: number;       // arvode-netto som redan täckts av aconton
+  krRunId: string | null;
+  krWorkValueOre: number;
+  lastFinal: { id: string; amount: number } | null;
+  docSeq: number;
+}
+
+const isBillable = (e: { billable?: boolean }): boolean => e.billable !== false;
+
+async function hParty(ctx: RunCtx, m: SimMatter, e: Any, iso: string): Promise<void> {
+  await ctx.c.matter.addContact({ matterId: m.id, contactId: e.contactId, role: e.role, createdAt: iso });
+}
+
+async function hTime(ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimState): Promise<void> {
+  await ctx.c.timeEntry.create({
+    matterId: m.id, date: iso, minutes: e.minutes, description: e.description,
+    billable: isBillable(e), userId: m.lawyerId, hourlyRate: m.arvodeRateOre, createdAt: iso,
+  });
+  ctx.res.timeEntries++;
+  if (isBillable(e)) st.accruedNetOre += Math.round((e.minutes / 60) * m.arvodeRateOre);
+}
+
+async function hNote(ctx: RunCtx, m: SimMatter, e: Any, iso: string): Promise<void> {
+  await ctx.c.serviceNote.create({ matterId: m.id, date: iso, time: eventTime(), text: e.text, createdAt: iso });
+  ctx.res.notes++;
+}
+
+async function hExpense(ctx: RunCtx, m: SimMatter, e: Any, iso: string): Promise<void> {
+  await ctx.c.expense.create({
+    matterId: m.id, date: iso, amount: e.amountOre, description: e.description,
+    billable: true, vatRate: e.vatRate ?? 2500, vatIncluded: false, userId: m.lawyerId, createdAt: iso,
+  });
+}
+
+async function hDoc(ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimState): Promise<void> {
+  const t = DOC_TEMPLATES[e.template];
+  if (!t) return;
+  const id = uuidv5(`simdoc:${m.id}:${st.docSeq++}`, AVA_NAMESPACE);
+  const storagePath = `documents/content/${id}.pdf`;
+  const fileName = `${t.title}.pdf`;
+  const { generateDocumentBytes } = await import("../../scripts/seed-data");
+  const bytes = await generateDocumentBytes({ id, title: t.title, fileName, documentType: t.documentType, summary: t.summary, mimeType: "application/pdf", storagePath });
+  const size = ctx.sink ? ctx.sink(storagePath, bytes) : bytes.byteLength;
+  await ctx.c.document.register({
+    id, matterId: m.id, fileName, mimeType: "application/pdf", sizeBytes: size, storagePath,
+    documentType: t.documentType, direction: t.direction, title: t.title, summary: t.summary,
+    analysisStatus: "DONE", createdAt: iso,
+  });
+  ctx.res.documents++;
+}
+
+async function hRadgivning(ctx: RunCtx, m: SimMatter, _e: Any, _iso: string): Promise<void> {
+  await ctx.c.invoice.createRadgivning({ matterId: m.id });
+  ctx.res.invoices++;
+}
+
+async function hAcconto(ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimState): Promise<void> {
+  // Klientens andel av NYTT arbete sedan förra acontot, vid periodens sats (#880).
+  // (Varje period fakturas för sig → varierande satser syns; slutregleringen jämkar
+  // mot myndighetens helhetsbeslut och ger ev. kredit vid överfakturering, #878.)
+  const newWorkNet = st.accruedNetOre - st.billedNetOre;
+  if (newWorkNet <= 0) return;
+  const clientNet = Math.round((e.clientShareBips / 10000) * newWorkNet);
+  const amountOre = arvodeInclVatOre(clientNet);
+  if (amountOre <= 0) return;
+  const { invoice } = await ctx.c.billingRun.createAcconto({
+    matterId: m.id, recipient: "KLIENT", clientShareBips: e.clientShareBips, amountOre,
+    invoiceDate: iso, notes: `Aconto — klientens andel ${e.clientShareBips / 100} % (löpande)`,
+  });
+  await ctx.c.invoice.setStatus({ invoiceId: invoice.id, status: "SENT" });
+  st.billedNetOre = st.accruedNetOre;
+  ctx.res.invoices++;
+}
+
+async function hKostnadsrakning(ctx: RunCtx, m: SimMatter, _e: Any, _iso: string, st: SimState): Promise<void> {
+  const { run } = await ctx.c.billingRun.createKostnadsrakning({ matterId: m.id, notes: "Kostnadsräkning till domstol" });
+  st.krRunId = run.id;
+  st.krWorkValueOre = run.workValueOreAtRun ?? 0;
+}
+
+async function hBeslut(ctx: RunCtx, _m: SimMatter, _e: Any, _iso: string, st: SimState): Promise<void> {
+  if (!st.krRunId) return;
+  await ctx.c.billingRun.recordKostnadsrakningBeslut({ billingRunId: st.krRunId, awardedOre: st.krWorkValueOre });
+}
+
+async function hSettle(ctx: RunCtx, m: SimMatter, e: Any, _iso: string): Promise<void> {
+  const res = await ctx.c.billingRun.settleCoverage({ matterId: m.id, payerRecipient: e.payerRecipient });
+  ctx.res.invoices += 2;
+  if (res.creditInvoice) ctx.res.credits++;
+}
+
+async function hFinal(ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimState): Promise<void> {
+  const { invoice } = await ctx.c.billingRun.createFinal({ matterId: m.id, recipient: e.recipient, deductedBillingRunIds: [], invoiceDate: iso });
+  await ctx.c.invoice.setStatus({ invoiceId: invoice.id, status: "SENT" });
+  st.lastFinal = { id: invoice.id, amount: invoice.amount };
+  ctx.res.invoices++;
+}
+
+async function hPayment(ctx: RunCtx, _m: SimMatter, _e: Any, iso: string, st: SimState): Promise<void> {
+  if (!st.lastFinal || st.lastFinal.amount <= 0) return;
+  await ctx.c.invoice.recordPayment({ invoiceId: st.lastFinal.id, amount: st.lastFinal.amount, paidAt: iso, note: "Full betalning" });
+}
+
+/** kind → handler. Håller runnern platt (undviker en stor switch = hög komplexitet). */
+const HANDLERS: Record<SimEvent["kind"], (ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimState) => Promise<void>> = {
+  party: hParty, time: hTime, note: hNote, expense: hExpense, doc: hDoc, radgivning: hRadgivning,
+  acconto: hAcconto, kostnadsrakning: hKostnadsrakning, beslut: hBeslut, settle: hSettle, final: hFinal, payment: hPayment,
+};
+
+/** Spela upp ett ärendes scenario kronologiskt. */
+export async function runScenario(ctx: RunCtx, matter: SimMatter, events: SimEvent[]): Promise<void> {
+  const st: SimState = { accruedNetOre: 0, billedNetOre: 0, krRunId: null, krWorkValueOre: 0, lastFinal: null, docSeq: 0 };
+  const sorted = [...events].sort((a, b) => a.dayOffset - b.dayOffset);
+  for (const e of sorted) {
+    const iso = eventIso(matter.startDaysAgo, e.dayOffset, 9 + (e.dayOffset % 6));
+    await HANDLERS[e.kind](ctx, matter, e, iso, st);
+  }
+}

--- a/tooling/demo-generator/simulate/scenarios/index.ts
+++ b/tooling/demo-generator/simulate/scenarios/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Scenario-dispatcher (#880): väljer kronologisk mall efter ärendets betalningssätt.
+ */
+
+import type { Parties, SimEvent, SimMatter } from "../events";
+import { buildOffentligtScenario } from "./offentligt";
+import { buildPrivatScenario } from "./privat";
+import { buildRattshjalpScenario } from "./rattshjalp";
+import { buildRattsskyddScenario } from "./rattsskydd";
+
+export function buildScenario(matter: SimMatter, parties: Parties, index: number): SimEvent[] {
+  switch (matter.paymentMethod) {
+    case "RATTSHJALP": return buildRattshjalpScenario(parties);
+    case "RATTSSKYDD": return buildRattsskyddScenario(parties);
+    case "OFFENTLIGT_UPPDRAG": return buildOffentligtScenario(parties);
+    default: return buildPrivatScenario(parties, index);
+  }
+}

--- a/tooling/demo-generator/simulate/scenarios/offentligt.ts
+++ b/tooling/demo-generator/simulate/scenarios/offentligt.ts
@@ -1,0 +1,26 @@
+/**
+ * Scenariomall för OFFENTLIGT_UPPDRAG (brottmål, #880): förordnande → genomgång av
+ * förundersökning → klientmöte + huvudförhandling → kostnadsräkning till domstol →
+ * domstolens beslut → domstolsfaktura (setVerdict). Taxa vs frångång styrs av
+ * matterns fält; flödet (KR → beslut → verdict) är detsamma.
+ */
+
+import type { Parties, SimEvent } from "../events";
+
+export function buildOffentligtScenario(parties: Parties): SimEvent[] {
+  const ev: SimEvent[] = [
+    { kind: "note", dayOffset: 0, text: "Förordnad som offentlig försvarare." },
+    { kind: "time", dayOffset: 1, minutes: 120, description: "Genomgång av förundersökningsprotokoll" },
+  ];
+  if (parties.domstol) ev.push({ kind: "party", dayOffset: 2, contactId: parties.domstol, role: "DOMSTOL" });
+  ev.push(
+    { kind: "doc", dayOffset: 4, template: "brevTillOmbud" },
+    { kind: "time", dayOffset: 12, minutes: 180, description: "Klientmöte + förberedelse inför huvudförhandling" },
+    { kind: "time", dayOffset: 20, minutes: 120, description: "Huvudförhandling i tingsrätten" },
+    { kind: "kostnadsrakning", dayOffset: 22 },
+    { kind: "beslut", dayOffset: 30 },
+    { kind: "doc", dayOffset: 31, template: "dom" },
+    { kind: "verdict", dayOffset: 32 },
+  );
+  return ev;
+}

--- a/tooling/demo-generator/simulate/scenarios/privat.ts
+++ b/tooling/demo-generator/simulate/scenarios/privat.ts
@@ -1,0 +1,29 @@
+/**
+ * Scenariomall för PRIVAT (#880): uppdrag → löpande arbete/utlägg/dokument →
+ * slutfaktura till klienten → (oftast) betalning. Variation ur `index` så demon
+ * får både betalda och obetalda slutfakturor.
+ */
+
+import type { Parties, SimEvent } from "../events";
+
+export function buildPrivatScenario(parties: Parties, index: number): SimEvent[] {
+  const ev: SimEvent[] = [
+    { kind: "note", dayOffset: 0, text: "Nytt uppdrag — inledande klientmöte och uppdragsbekräftelse." },
+    { kind: "time", dayOffset: 0, minutes: 90, description: "Inledande rådgivning och uppdragsbekräftelse" },
+    { kind: "doc", dayOffset: 1, template: "fullmakt" },
+  ];
+  if (parties.motpart) ev.push({ kind: "party", dayOffset: 2, contactId: parties.motpart, role: "MOTPART" });
+  if (parties.motpartsombud) ev.push({ kind: "party", dayOffset: 2, contactId: parties.motpartsombud, role: "MOTPARTSOMBUD" });
+  if (parties.domstol) ev.push({ kind: "party", dayOffset: 3, contactId: parties.domstol, role: "DOMSTOL" });
+  ev.push(
+    { kind: "doc", dayOffset: 4, template: parties.domstol ? "stamningsansokan" : "brevTillOmbud" },
+    { kind: "time", dayOffset: 10, minutes: 120, description: "Utredning och skriftväxling" },
+    { kind: "expense", dayOffset: 12, amountOre: 45_000, description: "Registerutdrag och kopior" },
+    { kind: "doc", dayOffset: 16, template: "brevFranOmbud" },
+    { kind: "time", dayOffset: 24, minutes: 90, description: "Förhandling och uppföljning" },
+    { kind: "final", dayOffset: 30, recipient: "KLIENT" },
+  );
+  // ~2 av 3 slutfakturor betalas; resten lämnas utestående (varierad demo).
+  if (index % 3 !== 2) ev.push({ kind: "payment", dayOffset: 44 });
+  return ev;
+}

--- a/tooling/demo-generator/simulate/scenarios/rattshjalp.ts
+++ b/tooling/demo-generator/simulate/scenarios/rattshjalp.ts
@@ -6,13 +6,7 @@
  * → beslut → slutreglering (→ kreditfaktura vid överfakturering, jfr #878).
  */
 
-import type { SimEvent } from "../events";
-
-export interface Parties {
-  motpart?: string | undefined;
-  motpartsombud?: string | undefined;
-  domstol?: string | undefined;
-}
+import type { Parties, SimEvent } from "../events";
 
 export function buildRattshjalpScenario(parties: Parties): SimEvent[] {
   const ev: SimEvent[] = [

--- a/tooling/demo-generator/simulate/scenarios/rattshjalp.ts
+++ b/tooling/demo-generator/simulate/scenarios/rattshjalp.ts
@@ -1,0 +1,52 @@
+/**
+ * Scenariomall för RÄTTSHJÄLP (#880) — kronologisk narrativ som subsumerar den
+ * tidigare m-020-varierande-sats-flödet: klientbesök + rådgivningstimme → fakturera
+ * → länka motpart/ombud → inkommande svaromål → löpande arbete → aconton vid
+ * VARIERANDE avgift (arbetslös 5 % → anställd 75 % → arbetslös 5 %) → kostnadsräkning
+ * → beslut → slutreglering (→ kreditfaktura vid överfakturering, jfr #878).
+ */
+
+import type { SimEvent } from "../events";
+
+export interface Parties {
+  motpart?: string | undefined;
+  motpartsombud?: string | undefined;
+  domstol?: string | undefined;
+}
+
+export function buildRattshjalpScenario(parties: Parties): SimEvent[] {
+  const ev: SimEvent[] = [
+    { kind: "note", dayOffset: 0, text: "Klientbesök — första möte i ärendet. Rådgivning enligt rättshjälpstaxan." },
+    { kind: "time", dayOffset: 0, minutes: 60, description: "Första möte med klient (rådgivning)" },
+    { kind: "radgivning", dayOffset: 1 },
+    { kind: "doc", dayOffset: 1, template: "fullmakt" },
+  ];
+  if (parties.motpart) ev.push({ kind: "party", dayOffset: 2, contactId: parties.motpart, role: "MOTPART" });
+  if (parties.motpartsombud) ev.push({ kind: "party", dayOffset: 2, contactId: parties.motpartsombud, role: "MOTPARTSOMBUD" });
+  if (parties.domstol) ev.push({ kind: "party", dayOffset: 2, contactId: parties.domstol, role: "DOMSTOL" });
+
+  ev.push(
+    { kind: "time", dayOffset: 6, minutes: 90, description: "Genomgång av handlingar (klient arbetslös, 5 % avgift)" },
+    { kind: "doc", dayOffset: 7, template: "brevTillOmbud" },
+    { kind: "doc", dayOffset: 14, template: "svaromal" },
+    { kind: "note", dayOffset: 14, text: "Svaromål inkommet från motpartsombudet." },
+    // Period 1 (arbetslös, 5 %) → aconto på upparbetat.
+    { kind: "acconto", dayOffset: 20, clientShareBips: 500 },
+    { kind: "time", dayOffset: 40, minutes: 120, description: "Förhandlingsförberedelse och inlaga" },
+    { kind: "doc", dayOffset: 41, template: "inlaga" },
+    { kind: "note", dayOffset: 45, text: "Klienten har fått anställning — rättshjälpsavgiften höjs till 75 %." },
+    // Period 2 (anställd, 75 %) → aconto (överfakturerar mot slutligt beslut).
+    { kind: "acconto", dayOffset: 55, clientShareBips: 7500 },
+    { kind: "time", dayOffset: 70, minutes: 120, description: "Sammanträde i tingsrätten" },
+    { kind: "note", dayOffset: 85, text: "Klienten åter arbetslös — avgiften tillbaka till 5 %." },
+    // Period 3 (arbetslös, 5 %).
+    { kind: "acconto", dayOffset: 90, clientShareBips: 500 },
+    { kind: "time", dayOffset: 100, minutes: 90, description: "Uppföljning och korrespondens" },
+    // Kostnadsräkning → myndighetens/domstolens beslut → slutreglering.
+    { kind: "kostnadsrakning", dayOffset: 105 },
+    { kind: "doc", dayOffset: 106, template: "beslutRattshjalp" },
+    { kind: "beslut", dayOffset: 107 },
+    { kind: "settle", dayOffset: 110, payerRecipient: "DOMSTOL" },
+  );
+  return ev;
+}

--- a/tooling/demo-generator/simulate/scenarios/rattsskydd.ts
+++ b/tooling/demo-generator/simulate/scenarios/rattsskydd.ts
@@ -1,0 +1,29 @@
+/**
+ * Scenariomall för RÄTTSSKYDD (#880): klientbesök → rättsskyddsansökan → skriftväxling
+ * med motpart/ombud → arbete/utlägg → aconto på självrisken → slutreglering mot
+ * försäkringsbolaget (settleCoverage, FORSAKRING). Ingen kostnadsräkning (den vägen
+ * gäller domstol/rättshjälp).
+ */
+
+import type { Parties, SimEvent } from "../events";
+
+export function buildRattsskyddScenario(parties: Parties): SimEvent[] {
+  const ev: SimEvent[] = [
+    { kind: "note", dayOffset: 0, text: "Klientbesök — genomgång av försäkringens rättsskydd." },
+    { kind: "time", dayOffset: 0, minutes: 60, description: "Inledande genomgång och rättsskyddsansökan" },
+    { kind: "doc", dayOffset: 1, template: "fullmakt" },
+  ];
+  if (parties.motpart) ev.push({ kind: "party", dayOffset: 2, contactId: parties.motpart, role: "MOTPART" });
+  if (parties.motpartsombud) ev.push({ kind: "party", dayOffset: 2, contactId: parties.motpartsombud, role: "MOTPARTSOMBUD" });
+  if (parties.domstol) ev.push({ kind: "party", dayOffset: 2, contactId: parties.domstol, role: "DOMSTOL" });
+  ev.push(
+    { kind: "doc", dayOffset: 5, template: "brevTillOmbud" },
+    { kind: "time", dayOffset: 12, minutes: 120, description: "Skriftväxling och förhandlingsförberedelse" },
+    { kind: "expense", dayOffset: 14, amountOre: 90_000, description: "Ansökningsavgift tingsrätten" },
+    { kind: "doc", dayOffset: 18, template: "brevFranOmbud" },
+    { kind: "acconto", dayOffset: 30, clientShareBips: 2000 }, // 20 % självrisk
+    { kind: "time", dayOffset: 45, minutes: 90, description: "Sammanträde och uppföljning" },
+    { kind: "settle", dayOffset: 60, payerRecipient: "FORSAKRING" },
+  );
+  return ev;
+}

--- a/tooling/scripts/build-demo-repo.ts
+++ b/tooling/scripts/build-demo-repo.ts
@@ -88,9 +88,8 @@ async function main(): Promise<void> {
 
   console.log(`[demo-repo] klart. Innehåll i ${outDir}:`);
   console.log(`  • ${result.users} användare, ${result.contacts} kontakter, ${result.matters} ärenden`);
-  console.log(`  • ${result.documents} dokument (PDF/DOCX)`);
-  console.log(`  • genererade dokument: ${result.invoiceDocs} faktura, ${result.kostnadsrakningDocs} kostnadsräkning`);
-  console.log(`  • fakturering: ${result.billing.invoices} fakturor, ${result.billing.paymentPlans} planer, ${result.billing.payments} betalningar, ${result.billing.reminders} påminnelser`);
+  console.log(`  • simulering: ${result.sim.timeEntries} tidsposter, ${result.sim.notes} tjänsteanteckningar, ${result.documents} inkommande/utgående dokument`);
+  console.log(`  • fakturering: ${result.sim.invoices} fakturor (${result.sim.credits} kreditfakturor), ${result.invoiceDocs} faktura-dok, ${result.kostnadsrakningDocs} kostnadsräkning-dok`);
   console.log(`  • ${result.calendarEvents} kalender-events, ${result.tasks} tasks`);
   console.log("");
   console.log("Nästa steg (om du vill pusha till ulrik-s/ava-demo):");

--- a/tooling/scripts/seed-demo-into-server.ts
+++ b/tooling/scripts/seed-demo-into-server.ts
@@ -36,11 +36,10 @@ import type { GeneratorCaller } from "../demo-generator/backend-target";
 import { createHttpCaller, mintToken } from "../demo-generator/http-target";
 import { createIdTranslator, translateSeed } from "../demo-generator/id-translator";
 import { bootstrapOrgUsers, populate } from "../demo-generator/populate";
-import { populateBilling } from "../demo-generator/populate-billing";
-import { populateDocuments } from "../demo-generator/populate-documents";
 import { populateInvoiceDocs } from "../demo-generator/populate-invoice-docs";
 import { populateKostnadsrakningDocs } from "../demo-generator/populate-kostnadsrakning-docs";
-import { populateUnbilledTime } from "../demo-generator/populate-unbilled-time";
+import { runSimulation } from "../demo-generator/simulate/orchestrate";
+import type { RunCtx } from "../demo-generator/simulate/runner";
 import { buildSeed, type SeedDataset } from "./seed-data";
 
 const DB_URL = process.env.AVA_DATABASE_URL ?? "postgres://ava:ava@localhost:5433/ava_test";
@@ -140,30 +139,27 @@ async function seedInvoiceDocs(caller: Parameters<typeof populateInvoiceDocs>[0]
   return populateInvoiceDocs(caller, contentSink() ?? undefined, () => uuidv7());
 }
 
-async function seedDocuments(
-  caller: Parameters<typeof populateDocuments>[0],
-  seed: Parameters<typeof populateDocuments>[1],
-): Promise<number> {
-  const sink = contentSink();
-  if (!sink) return 0;
-  return populateDocuments(caller, seed, sink);
-}
-
 type LoginIds = { adminId: string | undefined; lawyerId: string | undefined };
 
 /** Allt utom org+users (#846) — körs antingen in-process eller via HTTP-caller.
  *  `skipOrgUsers` styr om populate hoppar org/users (HTTP: bootstrappade separat). */
 async function runRest(caller: GeneratorCaller, seed: SeedDataset, loginIds: LoginIds, skipOrgUsers: boolean): Promise<Record<string, unknown>> {
-  const core = await populate(caller, seed, { skipOrgUsers });
+  // Kärnentiteter (ACTIVE-ärenden) — tid/utlägg/kontakter/dokument skapas kronologiskt
+  // av simuleringen (#880), inte ur seedens statiska rader.
+  const coreSeed = {
+    ...seed,
+    matters: (seed.matters as Row[]).map((m) => ({ ...m, status: "ACTIVE" })),
+    timeEntries: [], expenses: [], matterContacts: [], documents: [], serviceNotes: [],
+  } as SeedDataset;
+  const core = await populate(caller, coreSeed, { skipOrgUsers });
+  // Kronologisk simulering — SAMMA motor som GH Pages-demon; doc-bytes → content-katalogen.
+  const sink = contentSink();
+  const ctx: RunCtx = { c: caller, res: { invoices: 0, documents: 0, timeEntries: 0, notes: 0, credits: 0 }, ...(sink ? { sink } : {}) };
+  await runSimulation(ctx, seed);
   await addTodayTimeEntries(caller, seed.timeEntries as Row[], seed.matters as Row[], loginIds); // "idag"-tid för dashboarden
-  // Fakturering (#647/#736): ETT billing-run-flöde per ärende; unbilled = färsk
-  // upparbetad tid efter fakturering.
-  const billing = await populateBilling(caller, seed);
-  const unbilled = await populateUnbilledTime(caller, seed);
-  const documents = await seedDocuments(caller, seed);
   const kostnadsrakningDocs = await seedKostnadsrakningDocs(caller);
   const invoiceDocs = await seedInvoiceDocs(caller);
-  return { ...core, billing, unbilled, documents, kostnadsrakningDocs, invoiceDocs };
+  return { ...core, sim: ctx.res, kostnadsrakningDocs, invoiceDocs };
 }
 
 /** HTTP-läget (#846): org+users bootstrappas in-process (OIDC/assertAdmin kräver


### PR DESCRIPTION
Bygger om demo-seedningen till en linjär, kronologisk simulering per ärende (issue #880). Fas 1: dokument-riktningsfält (inkommande/utgående). Fler faser följer: simuleringsmotor, scenariomallar per ärendetyp, omkoppling av generate-into + seed-demo-into-server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)