### PR TITLE
fix(billing): aconto-fakturan listar det upparbetade arbetet (#880)

### DIFF
--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -27,7 +27,7 @@ import { applyKrAction, type KostnadsrakningAction, type KostnadsrakningState, t
 import { ocrFromInvoiceNumber } from "@/lib/shared/ocr-reference";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { RADGIVNING_MINUTES, radgivningTextRad } from "@/lib/shared/rattshjalp";
-import type { BillingRun, Invoice } from "@/lib/shared/schemas/billing";
+import { settlementBreakdownSchema, type BillingRun, type Invoice } from "@/lib/shared/schemas/billing";
 import { billingRunRecipientSchema, type BillingRunRecipient, type ExpenseKind, type PaymentMethod } from "@/lib/shared/schemas/enums";
 import {
   matterIdSchema,
@@ -867,6 +867,9 @@ export const billingRunRouter = router({
       invoiceDate: z.string().optional(),
       dueDate: z.string().optional(),
       notes: z.string().nullish(),
+      /** Valfri nedbrytning (#880) — simuleringen skickar det upparbetade arbetet
+       *  (tidsspec) så klienten ser vad acontot avser. Utelämnas → default nedan. */
+      settlementBreakdown: settlementBreakdownSchema.nullish(),
     }))
     .mutation(async ({ ctx, input }) => {
       return ctx.repos.transaction(async (tx) => {
@@ -883,8 +886,9 @@ export const billingRunRouter = router({
         const invoice = await tx.invoices.create({
           matterId: input.matterId, amount: input.amountOre, vatOre: accontoVatOre,
           vatBreakdown: [{ kind: "arvode", vatRate: DEFAULT_VAT_RATE, netOre: accontoNetOre, vatOre: accontoVatOre }],
-          // Nedbrytning så aconto-detaljsidan inte blir tom (#878): klientens andel + moms.
-          settlementBreakdown: {
+          // Nedbrytning (#878/#880): anroparen (simuleringen) skickar en spec med det
+          // upparbetade arbetet så klienten ser vad acontot avser; annars en enkel default.
+          settlementBreakdown: input.settlementBreakdown ?? {
             timeLines: [],
             rows: [
               { label: `Klientens andel ${input.clientShareBips / 100} % av upparbetat arbete (exkl moms)`, amountOre: accontoNetOre, kind: "add" },

--- a/src/lib/shared/schemas/billing.ts
+++ b/src/lib/shared/schemas/billing.ts
@@ -96,6 +96,25 @@ export const expenseSchema = z.object({
 
 export type Expense = z.infer<typeof expenseSchema>;
 
+/** Persisterad nedbrytningsvy på en faktura (#876/#880) — matchar `SettlementView`.
+ *  Tidsspec-tabell (arbetad tid) + rader (trappa) + total. Delas av slutreglering
+ *  OCH aconto (aconton visar det upparbetade arbetet klienten betalar för). */
+export const settlementBreakdownSchema = z.object({
+  timeLines: z.array(z.object({
+    date: z.string(),
+    description: z.string(),
+    minutes: z.number().int(),
+    amountOre: z.number().int(),
+  })),
+  rows: z.array(z.object({
+    label: z.string(),
+    amountOre: z.number().int(),
+    kind: z.enum(["add", "deduct", "info"]),
+  })),
+  totalLabel: z.string(),
+  totalOre: z.number().int(),
+});
+
 /**
  * Invoice — `amount` i öre (brutto för FINAL, negativt för CREDIT).
  * Lagras i `invoices/<id>.json`.
@@ -120,21 +139,7 @@ export const invoiceSchema = z.object({
   /** Persisterad slutregleringsvy (#876) — EN källa för både faktura-dokumentet
    *  och Slutfaktura-sidan (`/invoices/[id]`). Sätts vid settleCoverage på klient-/
    *  betalar-fakturan; null på övriga fakturor. Matchar `SettlementView`. */
-  settlementBreakdown: z.object({
-    timeLines: z.array(z.object({
-      date: z.string(),
-      description: z.string(),
-      minutes: z.number().int(),
-      amountOre: z.number().int(),
-    })),
-    rows: z.array(z.object({
-      label: z.string(),
-      amountOre: z.number().int(),
-      kind: z.enum(["add", "deduct", "info"]),
-    })),
-    totalLabel: z.string(),
-    totalOre: z.number().int(),
-  }).nullish(),
+  settlementBreakdown: settlementBreakdownSchema.nullish(),
   status: invoiceStatusSchema.default("DRAFT"),
   invoiceType: invoiceTypeSchema.default("STANDARD"),
   /** Per-byrå löpande fakturanummer (F-YYYY-NNNN), genereras vid skapande.

--- a/test/scripts/simulate-runner.test.ts
+++ b/test/scripts/simulate-runner.test.ts
@@ -65,6 +65,9 @@ describe("runScenario (#880)", () => {
     const accontos = calls.filter((x) => x.method === "billingRun.createAcconto");
     expect(accontos.map((a) => a.args.clientShareBips)).toEqual([500, 7500, 500]);
     expect(accontos.every((a) => a.args.amountOre > 0)).toBe(true);
+    // #880: varje aconto bär tidsspecen för det upparbetade arbetet (klienten ser vad hen betalar för).
+    expect(accontos.every((a) => (a.args.settlementBreakdown?.timeLines?.length ?? 0) > 0)).toBe(true);
+    expect(accontos.every((a) => a.args.settlementBreakdown.rows.some((r: Any) => r.label.includes("Upparbetat arbete")))).toBe(true);
 
     // Inkommande svaromål registreras med direction INKOMMANDE.
     const svaromal = calls.find((x) => x.method === "document.register" && x.args.documentType === "Svaromål");

--- a/tooling/demo-generator/simulate/runner.ts
+++ b/tooling/demo-generator/simulate/runner.ts
@@ -6,6 +6,7 @@
  */
 
 import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
+import type { SettlementViewLine } from "@/lib/shared/settlement-view";
 import { AVA_NAMESPACE, uuidv5 } from "@/lib/shared/uuid-derive";
 import type { BinarySink } from "../populate-documents";
 import { eventIso, eventTime } from "./clock";
@@ -24,6 +25,7 @@ export interface RunCtx {
 interface SimState {
   accruedNetOre: number;      // ackumulerat debiterbart arvode (netto)
   billedNetOre: number;       // arvode-netto som redan täckts av aconton
+  periodLines: SettlementViewLine[]; // debiterbara tidsposter sedan förra acontot (#880)
   krRunId: string | null;
   krWorkValueOre: number;
   lastFinal: { id: string; amount: number } | null;
@@ -42,7 +44,11 @@ async function hTime(ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimStat
     billable: isBillable(e), userId: m.lawyerId, hourlyRate: m.arvodeRateOre, createdAt: iso,
   });
   ctx.res.timeEntries++;
-  if (isBillable(e)) st.accruedNetOre += Math.round((e.minutes / 60) * m.arvodeRateOre);
+  if (isBillable(e)) {
+    const amountOre = Math.round((e.minutes / 60) * m.arvodeRateOre);
+    st.accruedNetOre += amountOre;
+    st.periodLines.push({ date: iso.slice(0, 10), description: e.description, minutes: e.minutes, amountOre });
+  }
 }
 
 async function hNote(ctx: RunCtx, m: SimMatter, e: Any, iso: string): Promise<void> {
@@ -88,12 +94,24 @@ async function hAcconto(ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimS
   const clientNet = Math.round((e.clientShareBips / 10000) * newWorkNet);
   const amountOre = arvodeInclVatOre(clientNet);
   if (amountOre <= 0) return;
+  // Spec (#880): periodens arbete → klientens andel → moms, så klienten ser vad hen
+  // betalar för. timeLines listar tidsposterna som utgör det upparbetade arbetet.
+  const settlementBreakdown = {
+    timeLines: st.periodLines,
+    rows: [
+      { label: "Upparbetat arbete i perioden (exkl moms)", amountOre: newWorkNet, kind: "add" as const },
+      { label: `Klientens andel ${e.clientShareBips / 100} % (exkl moms)`, amountOre: clientNet, kind: "add" as const },
+      { label: "Moms 25 %", amountOre: amountOre - clientNet, kind: "add" as const },
+    ],
+    totalLabel: "Att betala (inkl moms)", totalOre: amountOre,
+  };
   const { invoice } = await ctx.c.billingRun.createAcconto({
     matterId: m.id, recipient: "KLIENT", clientShareBips: e.clientShareBips, amountOre,
-    invoiceDate: iso, notes: `Aconto — klientens andel ${e.clientShareBips / 100} % (löpande)`,
+    invoiceDate: iso, notes: `Aconto — klientens andel ${e.clientShareBips / 100} % (löpande)`, settlementBreakdown,
   });
   await ctx.c.invoice.setStatus({ invoiceId: invoice.id, status: "SENT" });
   st.billedNetOre = st.accruedNetOre;
+  st.periodLines = [];
   ctx.res.invoices++;
 }
 
@@ -140,7 +158,7 @@ const HANDLERS: Record<SimEvent["kind"], (ctx: RunCtx, m: SimMatter, e: Any, iso
 
 /** Spela upp ett ärendes scenario kronologiskt. */
 export async function runScenario(ctx: RunCtx, matter: SimMatter, events: SimEvent[]): Promise<void> {
-  const st: SimState = { accruedNetOre: 0, billedNetOre: 0, krRunId: null, krWorkValueOre: 0, lastFinal: null, docSeq: 0 };
+  const st: SimState = { accruedNetOre: 0, billedNetOre: 0, periodLines: [], krRunId: null, krWorkValueOre: 0, lastFinal: null, docSeq: 0 };
   const sorted = [...events].sort((a, b) => a.dayOffset - b.dayOffset);
   for (const e of sorted) {
     const iso = eventIso(matter.startDaysAgo, e.dayOffset, 9 + (e.dayOffset % 6));


### PR DESCRIPTION
Uppföljning på #880. Aconto-fakturorna (t.ex. F-2026-0033 i 2026-0020) visade bara "Klientens andel X % av upparbetat arbete" som en klumpsumma — klienten såg inte vad arbetet var.

Nu bär acontot en tidsspecifikation: tidsposterna (datum/beskrivning/tid/belopp) → upparbetat arbete i perioden (exkl moms) → klientens andel % → moms → att betala. Renderas på både fakturadetaljsidan och HTML-dokumentet.

createAcconto tar en valfri `settlementBreakdown` (annars enkel default); simuleringens runner spårar periodens tidsposter och bygger specen. quality:fast grönt.

Closes #880 (uppföljning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)