### PR TITLE
fix(billing): rådgivningstimmen faktureras samma dag som mötet + utanför aconto-basen (#880)

### DIFF
--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -122,7 +122,7 @@ export const invoiceRouter = router({
    * DRAFT-aconto exkluderas automatiskt. Idempotent: avvisar om redan registrerad.
    */
   createRadgivning: orgProcedure
-    .input(z.object({ matterId: matterIdSchema, hasFTax: z.boolean().optional() }))
+    .input(z.object({ matterId: matterIdSchema, hasFTax: z.boolean().optional(), invoiceDate: z.string().optional() }))
     // Migrerad till repository-sömmen (ADR 0020): matters + invoices via typade repos.
     .mutation(({ ctx, input }) =>
       ctx.repos.transaction(async (repos) => {
@@ -138,13 +138,15 @@ export const invoiceRouter = router({
         const grossOre = arvodeInclVatOre(netOre);
         const vatOre = grossOre - netOre;
         const invoiceNumber = await repos.invoices.nextInvoiceNumber(ctx.orgId);
+        // Datum = mötesdagen om angivet (#880: rådgivning faktureras samma dag som mötet), annars idag.
+        const when = input.invoiceDate ? new Date(input.invoiceDate) : new Date();
         const invoice = await repos.invoices.create({
           matterId: input.matterId, invoiceNumber, ocrReference: ocrFromInvoiceNumber(invoiceNumber),
           amount: grossOre, vatOre, vatBreakdown: [{ kind: "arvode", vatRate: 2500, netOre, vatOre }],
-          invoiceType: "STANDARD", status: "SENT", invoiceDate: new Date(), dueDate: null,
+          invoiceType: "STANDARD", status: "SENT", invoiceDate: when, dueDate: null,
           notes: "Rådgivningstimme enligt rättshjälpstaxan (1 tim).",
         } satisfies Partial<Invoice>);
-        await repos.matters.update(input.matterId, { radgivningBetaldAt: new Date() } satisfies Partial<Matter>);
+        await repos.matters.update(input.matterId, { radgivningBetaldAt: when } satisfies Partial<Matter>);
         await emit.invoiceCreated(ctx, invoice);
         return { invoice, beloppExclVatOre: netOre };
       }),

--- a/test/scripts/simulate-runner.test.ts
+++ b/test/scripts/simulate-runner.test.ts
@@ -60,6 +60,11 @@ describe("runScenario (#880)", () => {
     const firstAcc = calls.findIndex((x) => x.method === "billingRun.createAcconto");
     expect(radIdx).toBeGreaterThanOrEqual(0);
     expect(radIdx).toBeLessThan(firstAcc);
+    // #880: rådgivningen faktureras SAMMA DAG (invoiceDate satt) + som egen tidspost.
+    const rad = calls[radIdx]!;
+    expect(rad.args.invoiceDate).toBeTruthy();
+    const radTime = calls.find((x) => x.method === "timeEntry.create" && String(x.args.description).includes("Rådgivning"));
+    expect(radTime?.args.date).toBe(rad.args.invoiceDate); // samma dag som mötet
 
     // Tre aconton vid varierande satser (5/75/5 %), belopp härlett ur upparbetat.
     const accontos = calls.filter((x) => x.method === "billingRun.createAcconto");

--- a/tooling/demo-generator/simulate/runner.ts
+++ b/tooling/demo-generator/simulate/runner.ts
@@ -80,8 +80,16 @@ async function hDoc(ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimState
   ctx.res.documents++;
 }
 
-async function hRadgivning(ctx: RunCtx, m: SimMatter, _e: Any, _iso: string): Promise<void> {
-  await ctx.c.invoice.createRadgivning({ matterId: m.id });
+async function hRadgivning(ctx: RunCtx, m: SimMatter, _e: Any, iso: string): Promise<void> {
+  // Rådgivningstimmen (#880): en debiterbar tidspost — så settlementens coverageBaseMinutes
+  // −60 stämmer — MEN utanför aconto-basen (rör INTE accruedNetOre; allt EFTER rådgivningen
+  // går på aconto). Faktureras separat SAMMA DAG som mötet.
+  await ctx.c.timeEntry.create({
+    matterId: m.id, date: iso, minutes: 60, description: "Rådgivning — första möte med klient",
+    billable: true, userId: m.lawyerId, hourlyRate: m.arvodeRateOre, createdAt: iso,
+  });
+  ctx.res.timeEntries++;
+  await ctx.c.invoice.createRadgivning({ matterId: m.id, invoiceDate: iso });
   ctx.res.invoices++;
 }
 

--- a/tooling/demo-generator/simulate/scenarios/rattshjalp.ts
+++ b/tooling/demo-generator/simulate/scenarios/rattshjalp.ts
@@ -11,8 +11,9 @@ import type { Parties, SimEvent } from "../events";
 export function buildRattshjalpScenario(parties: Parties): SimEvent[] {
   const ev: SimEvent[] = [
     { kind: "note", dayOffset: 0, text: "Klientbesök — första möte i ärendet. Rådgivning enligt rättshjälpstaxan." },
-    { kind: "time", dayOffset: 0, minutes: 60, description: "Första möte med klient (rådgivning)" },
-    { kind: "radgivning", dayOffset: 1 },
+    // Rådgivningstimmen skapas + faktureras SAMMA DAG som mötet (#880); allt arbete EFTER
+    // detta går på aconto. (hRadgivning skapar tidsposten + rådgivningsfakturan.)
+    { kind: "radgivning", dayOffset: 0 },
     { kind: "doc", dayOffset: 1, template: "fullmakt" },
   ];
   if (parties.motpart) ev.push({ kind: "party", dayOffset: 2, contactId: parties.motpart, role: "MOTPART" });


### PR DESCRIPTION
Uppföljning på #880. Rådgivningstimmen ska alltid faktureras separat SAMMA DAG som mötet, och allt upparbetat därefter går på aconto.

- createRadgivning tar valfritt invoiceDate → rådgivningsfakturan dateras på mötesdagen.
- Simuleringens rådgivnings-event (dag 0) skapar rådgivnings-tidsposten + fakturan samma dag, men utanför aconto-basen → rådgivningstimmen hamnar aldrig på ett aconto.

quality:fast grönt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)