### PR TITLE
feat(billing): aconto-gränsbelopp som byrå-inställning + tröskelstyrt aconto (#885)

### DIFF
--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -494,14 +494,17 @@ function RadgivningBanner({ matterId, matter, onRecorded }: { matterId: MatterId
 function SjalvriskAccontoHint({ matterId, matter, rows }: { matterId: MatterId; matter: MatterContext; rows: BillingRunRow[] }) {
   const isRattshjalp = matter.paymentMethod === "RATTSHJALP";
   const split = trpc.billingRun.coverageSplit.useQuery({ matterId }, { enabled: isRattshjalp }).data;
+  // Gränsbeloppet är en byrå-inställning (#885); faller tillbaka på default-konstanten.
+  const orgThreshold = trpc.organization.getSettings.useQuery(undefined, { enabled: isRattshjalp }).data?.accontoThresholdOre;
+  const threshold = orgThreshold ?? SJALVRISK_ACCONTO_THRESHOLD_ORE;
   if (!isRattshjalp || !split) return null;
   const hasSjalvriskAconto = rows.some((r) => r.type === "ACCONTO" && r.recipient === "KLIENT");
-  if (hasSjalvriskAconto || split.clientOre < SJALVRISK_ACCONTO_THRESHOLD_ORE) return null;
+  if (hasSjalvriskAconto || split.clientOre < threshold) return null;
   return (
     <div className="mx-6 mb-4 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900">
       Klientens självrisk har nått{" "}
       <span className="font-mono font-semibold">{formatCurrency(split.clientOre)}</span>{" "}
-      (tröskel {formatCurrency(SJALVRISK_ACCONTO_THRESHOLD_ORE)}) — dags att skicka ett självrisk-aconto via
+      (tröskel {formatCurrency(threshold)}) — dags att skicka ett självrisk-aconto via
       {" "}<strong>+ Skapa faktura → Aconto till klient</strong>.
     </div>
   );

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -229,17 +229,26 @@ interface OrgForm {
   phone: string;
   email: string;
   bankgiro: string;
+  /** Aconto-gränsbelopp i KRONOR (öre/100) — sparas som öre (#885). */
+  accontoThresholdKr: string;
 }
 
 type NullableStr = string | null | undefined;
 /** Settings-data → form (null/undefined → ""). Egen helper håller
  *  useOrgSettings under complexity@8 (annars 6× `??`). */
-function toOrgForm(d: { name?: NullableStr; orgNumber?: NullableStr; address?: NullableStr; phone?: NullableStr; email?: NullableStr; bankgiro?: NullableStr }): OrgForm {
+function toOrgForm(d: { name?: NullableStr; orgNumber?: NullableStr; address?: NullableStr; phone?: NullableStr; email?: NullableStr; bankgiro?: NullableStr; accontoThresholdOre?: number | null }): OrgForm {
   const s = (v: NullableStr): string => v ?? "";
   return {
     name: s(d.name), orgNumber: s(d.orgNumber), address: s(d.address),
     phone: s(d.phone), email: s(d.email), bankgiro: s(d.bankgiro),
+    accontoThresholdKr: d.accontoThresholdOre != null ? String(d.accontoThresholdOre / 100) : "",
   };
+}
+
+/** Kronor-sträng → öre (heltal), eller undefined om tomt/ogiltigt (#885). */
+function krToOre(kr: string): number | undefined {
+  const n = Number.parseFloat(kr.replace(",", "."));
+  return Number.isFinite(n) && n >= 0 ? Math.round(n * 100) : undefined;
 }
 
 /** Byrå-inställningar: query + auto-save (debounce 800ms) + form-state.
@@ -247,7 +256,7 @@ function toOrgForm(d: { name?: NullableStr; orgNumber?: NullableStr; address?: N
 function useOrgSettings() {
   const settings = trpc.organization.getSettings.useQuery();
   const utils = trpc.useUtils();
-  const [form, setForm] = useState<OrgForm>({ name: "", orgNumber: "", address: "", phone: "", email: "", bankgiro: "" });
+  const [form, setForm] = useState<OrgForm>({ name: "", orgNumber: "", address: "", phone: "", email: "", bankgiro: "", accontoThresholdKr: "" });
   const [formReady, setFormReady] = useState(false);
   const [saved, setSaved] = useState(false);
 
@@ -271,6 +280,7 @@ function useOrgSettings() {
         name: form.name || undefined, orgNumber: form.orgNumber || undefined,
         address: form.address || undefined, phone: form.phone || undefined,
         email: form.email || undefined, bankgiro: form.bankgiro || undefined,
+        accontoThresholdOre: krToOre(form.accontoThresholdKr),
       });
     }, 800);
     return () => clearTimeout(id);
@@ -411,6 +421,7 @@ function OrgFieldsForm({ form, setForm, isPending, saved, error }: OrgFieldsProp
   const phoneId = useId();
   const emailId = useId();
   const bankgiroId = useId();
+  const thresholdId = useId();
   return (
     <div className="bg-white border border-gray-200 rounded-lg p-5 mb-5">
       <h3 className="font-semibold text-gray-900 mb-4">Kontaktuppgifter</h3>
@@ -452,11 +463,20 @@ function OrgFieldsForm({ form, setForm, isPending, saved, error }: OrgFieldsProp
           </div>
         </div>
 
-        <div>
-          <label htmlFor={bankgiroId} className="block text-xs font-medium text-gray-700 mb-1">Bankgiro</label>
-          <input id={bankgiroId} type="text" value={form.bankgiro} placeholder="123-4567"
-            onChange={(e) => setForm({ ...form, bankgiro: e.target.value })}
-            className="w-full border border-gray-300 rounded px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500" />
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label htmlFor={bankgiroId} className="block text-xs font-medium text-gray-700 mb-1">Bankgiro</label>
+            <input id={bankgiroId} type="text" value={form.bankgiro} placeholder="123-4567"
+              onChange={(e) => setForm({ ...form, bankgiro: e.target.value })}
+              className="w-full border border-gray-300 rounded px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500" />
+          </div>
+          <div>
+            <label htmlFor={thresholdId} className="block text-xs font-medium text-gray-700 mb-1">Gränsbelopp aconto (kr)</label>
+            <input id={thresholdId} type="number" min={0} step={100} value={form.accontoThresholdKr} placeholder="1500"
+              onChange={(e) => setForm({ ...form, accontoThresholdKr: e.target.value })}
+              className="w-full border border-gray-300 rounded px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500" />
+            <p className="text-[11px] text-gray-500 mt-1">Aconto skickas när klientens självrisk nått detta belopp.</p>
+          </div>
         </div>
       </div>
 

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -51,6 +51,9 @@ export const organizations = pgTable("organizations", {
   /** Byråns vokabulär av giltiga dokument-etiketter (#621). Dokument får bara
    *  bära taggar ur denna lista; hanteras i org-inställningarna. */
   documentTags: jsonb("document_tags").notNull().default([]).$type<string[]>(),
+  /** Gränsbelopp (öre) för klientens ackumulerade självrisk innan ett aconto
+   *  skickas (#885). NULL = använd default (SJALVRISK_ACCONTO_THRESHOLD_ORE). */
+  accontoThresholdOre: integer("acconto_threshold_ore"),
 });
 
 export const offices = pgTable("offices", {

--- a/src/lib/server/routers/organization.ts
+++ b/src/lib/server/routers/organization.ts
@@ -28,6 +28,8 @@ function toOrgSettings(org: Organization) {
     ...nullableOrgFields(org),
     /** Byråns vokabulär av giltiga dokument-etiketter (#621). */
     documentTags: org.documentTags ?? [],
+    /** Gränsbelopp (öre) för aconto-utskick (#885). */
+    accontoThresholdOre: org.accontoThresholdOre ?? null,
   };
 }
 
@@ -55,6 +57,8 @@ export const organizationRouter = router({
         /** Byråns vokabulär av giltiga dokument-etiketter (#621). Hela listan
          *  ersätts (set-semantik); dedupas + tomma rensas. */
         documentTags: z.array(z.string()).optional(),
+        /** Gränsbelopp (öre) för aconto-utskick (#885). */
+        accontoThresholdOre: z.number().int().nonnegative().optional(),
       })
     )
     .mutation(({ ctx, input }) => {
@@ -82,6 +86,7 @@ export const organizationRouter = router({
         phone: z.string().optional(),
         email: z.string().optional(),
         bankgiro: z.string().optional(),
+        accontoThresholdOre: z.number().int().nonnegative().optional(),
       })
     )
     .mutation(({ ctx, input }) =>

--- a/src/lib/shared/schemas/organization.ts
+++ b/src/lib/shared/schemas/organization.ts
@@ -24,6 +24,9 @@ export const organizationSchema = z.object({
   /** Byråns vokabulär av giltiga dokument-etiketter (#621). Dokument får bara
    *  bära taggar ur denna lista; redigeras i org-inställningarna. */
   documentTags: z.array(z.string()).default([]),
+  /** Gränsbelopp (öre) för klientens ackumulerade självrisk innan ett aconto
+   *  skickas (#885). NULL = använd default (SJALVRISK_ACCONTO_THRESHOLD_ORE). */
+  accontoThresholdOre: z.number().int().nonnegative().nullish(),
 }).passthrough();
 
 export type Organization = z.infer<typeof organizationSchema>;

--- a/test/scripts/simulate-runner.test.ts
+++ b/test/scripts/simulate-runner.test.ts
@@ -70,6 +70,11 @@ describe("runScenario (#880)", () => {
     const accontos = calls.filter((x) => x.method === "billingRun.createAcconto");
     expect(accontos.map((a) => a.args.clientShareBips)).toEqual([500, 7500, 500]);
     expect(accontos.every((a) => a.args.amountOre > 0)).toBe(true);
+    // #885: aconto skickas FÖRST när klientens ackumulerade andel nått tröskeln
+    // (default 150000 öre) — varje acontos klient-andel-rad ligger på/över den.
+    const clientNet = (a: Any): number =>
+      a.args.settlementBreakdown.rows.find((r: Any) => r.label.includes("Klientens andel"))?.amountOre ?? 0;
+    expect(accontos.every((a) => clientNet(a) >= 150_000)).toBe(true);
     // #880: varje aconto bär tidsspecen för det upparbetade arbetet (klienten ser vad hen betalar för).
     expect(accontos.every((a) => (a.args.settlementBreakdown?.timeLines?.length ?? 0) > 0)).toBe(true);
     expect(accontos.every((a) => a.args.settlementBreakdown.rows.some((r: Any) => r.label.includes("Upparbetat arbete")))).toBe(true);
@@ -86,5 +91,17 @@ describe("runScenario (#880)", () => {
     expect(calls.some((x) => x.method === "billingRun.recordKostnadsrakningBeslut")).toBe(true);
     expect(calls.some((x) => x.method === "billingRun.settleCoverage")).toBe(true);
     expect(ctx.res.credits).toBe(1);
+  });
+
+  it("skickar INGA aconton om byråns gränsbelopp ligger över det upparbetade (#885)", async () => {
+    const { c, calls } = recordingCaller();
+    // Gränsbelopp långt över klientens totala andel → tröskeln nås aldrig.
+    const ctx: RunCtx = { c, accontoThresholdOre: 50_000_000, res: { invoices: 0, documents: 0, timeEntries: 0, notes: 0, credits: 0 } };
+    const events = buildRattshjalpScenario({ motpart: "c-mot", motpartsombud: "c-omb", domstol: "c-dom" });
+    await runScenario(ctx, MATTER, events);
+    expect(calls.filter((x) => x.method === "billingRun.createAcconto")).toHaveLength(0);
+    // Rådgivning + kostnadsräkning + slutreglering körs fortfarande.
+    expect(calls.some((x) => x.method === "invoice.createRadgivning")).toBe(true);
+    expect(calls.some((x) => x.method === "billingRun.settleCoverage")).toBe(true);
   });
 });

--- a/tooling/db/migrations/0015_org_acconto_threshold.sql
+++ b/tooling/db/migrations/0015_org_acconto_threshold.sql
@@ -1,0 +1,3 @@
+-- #885: gränsbelopp (öre) för klientens självrisk innan ett aconto skickas.
+-- NULL = använd default (SJALVRISK_ACCONTO_THRESHOLD_ORE, 150000).
+ALTER TABLE organizations ADD COLUMN IF NOT EXISTS acconto_threshold_ore integer;

--- a/tooling/demo-generator/populate.ts
+++ b/tooling/demo-generator/populate.ts
@@ -55,7 +55,7 @@ function pick(seed: SeedDataset, key: keyof SeedDataset): Row[] {
 async function createOrganizations(c: AnyCaller, rows: Row[]): Promise<void> {
   for (const o of rows) {
     await c.organization.create(
-      defined({ id: o.id, name: o.name, orgNumber: o.orgNumber, address: o.address, phone: o.phone, email: o.email, bankgiro: o.bankgiro }),
+      defined({ id: o.id, name: o.name, orgNumber: o.orgNumber, address: o.address, phone: o.phone, email: o.email, bankgiro: o.bankgiro, accontoThresholdOre: o.accontoThresholdOre }),
     );
   }
 }

--- a/tooling/demo-generator/simulate/events.ts
+++ b/tooling/demo-generator/simulate/events.ts
@@ -19,8 +19,12 @@ export type SimEvent =
   | { kind: "doc"; dayOffset: number; template: string }
   /** Rådgivningstimmen faktureras — invoice.createRadgivning. */
   | { kind: "radgivning"; dayOffset: number }
-  /** Aconto på klientens andel vid `clientShareBips` (belopp härlett) — createAcconto. */
+  /** Aconto på klientens andel vid `clientShareBips` (belopp härlett) — createAcconto.
+   *  FAST aconto (rättsskydd-självrisk); rättshjälp använder `rateChange` + tröskel. */
   | { kind: "acconto"; dayOffset: number; clientShareBips: number }
+  /** Ändra klientens självrisk-sats (bips) från denna dag (#885). Rättshjälp: satsen
+   *  varierar över tid; aconto skickas när klientens ackumulerade andel når tröskeln. */
+  | { kind: "rateChange"; dayOffset: number; clientShareBips: number }
   /** Kostnadsräkning till domstol — createKostnadsrakning. */
   | { kind: "kostnadsrakning"; dayOffset: number }
   /** Domstolens beslut på KR:n — recordKostnadsrakningBeslut. */

--- a/tooling/demo-generator/simulate/orchestrate.ts
+++ b/tooling/demo-generator/simulate/orchestrate.ts
@@ -58,6 +58,9 @@ async function simulateMatter(ctx: RunCtx, m: Any, users: { id: string; rateOre:
 
 /** Spela upp alla ärendens scenarier. `seed` = den ÖVERSATTA seeden (UUID-id). */
 export async function runSimulation(ctx: RunCtx, seed: Any): Promise<void> {
+  // Byråns aconto-gränsbelopp (#885) driver tröskelstyrda aconton i runnern.
+  const orgThreshold = seed.organizations?.[0]?.accontoThresholdOre;
+  if (typeof orgThreshold === "number") ctx.accontoThresholdOre = orgThreshold;
   const users: { id: string; rateOre: number }[] = (seed.users ?? [])
     .filter((u: Any) => typeof u.id === "string")
     .map((u: Any) => ({ id: String(u.id), rateOre: Number(u.hourlyRate ?? 0) || 0 }));

--- a/tooling/demo-generator/simulate/runner.ts
+++ b/tooling/demo-generator/simulate/runner.ts
@@ -6,6 +6,7 @@
  */
 
 import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
+import { SJALVRISK_ACCONTO_THRESHOLD_ORE } from "@/lib/shared/rattshjalp";
 import type { SettlementViewLine } from "@/lib/shared/settlement-view";
 import { AVA_NAMESPACE, uuidv5 } from "@/lib/shared/uuid-derive";
 import type { BinarySink } from "../populate-documents";
@@ -19,12 +20,15 @@ type Any = any;
 export interface RunCtx {
   c: Any; // GeneratorCaller (tRPC) — samma lösa typ som övriga demo-generator-moduler
   sink?: BinarySink;
+  /** Gränsbelopp (öre) för tröskelstyrd aconto-utskick (#885); default = konstanten. */
+  accontoThresholdOre?: number;
   res: { invoices: number; documents: number; timeEntries: number; notes: number; credits: number };
 }
 
 interface SimState {
   accruedNetOre: number;      // ackumulerat debiterbart arvode (netto)
   billedNetOre: number;       // arvode-netto som redan täckts av aconton
+  currentRateBips: number;    // klientens självrisk-sats just nu (#885, driver tröskel-aconto)
   periodLines: SettlementViewLine[]; // debiterbara tidsposter sedan förra acontot (#880)
   krRunId: string | null;
   krWorkValueOre: number;
@@ -48,6 +52,7 @@ async function hTime(ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimStat
     const amountOre = Math.round((e.minutes / 60) * m.arvodeRateOre);
     st.accruedNetOre += amountOre;
     st.periodLines.push({ date: iso.slice(0, 10), description: e.description, minutes: e.minutes, amountOre });
+    await maybeAcconto(ctx, m, iso, st); // #885: skicka aconto när klientens andel nått tröskeln
   }
 }
 
@@ -93,13 +98,13 @@ async function hRadgivning(ctx: RunCtx, m: SimMatter, _e: Any, iso: string): Pro
   ctx.res.invoices++;
 }
 
-async function hAcconto(ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimState): Promise<void> {
-  // Klientens andel av NYTT arbete sedan förra acontot, vid periodens sats (#880).
-  // (Varje period fakturas för sig → varierande satser syns; slutregleringen jämkar
-  // mot myndighetens helhetsbeslut och ger ev. kredit vid överfakturering, #878.)
+/** Skicka ett aconto på klientens andel av NYTT arbete sedan förra acontot, vid `bips`.
+ *  (Varje period faktureras för sig → varierande satser syns; slutregleringen jämkar
+ *  mot myndighetens helhetsbeslut och ger ev. kredit vid överfakturering, #878.) */
+async function sendAcconto(ctx: RunCtx, m: SimMatter, iso: string, st: SimState, bips: number): Promise<void> {
   const newWorkNet = st.accruedNetOre - st.billedNetOre;
   if (newWorkNet <= 0) return;
-  const clientNet = Math.round((e.clientShareBips / 10000) * newWorkNet);
+  const clientNet = Math.round((bips / 10000) * newWorkNet);
   const amountOre = arvodeInclVatOre(clientNet);
   if (amountOre <= 0) return;
   // Spec (#880): periodens arbete → klientens andel → moms, så klienten ser vad hen
@@ -108,19 +113,40 @@ async function hAcconto(ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimS
     timeLines: st.periodLines,
     rows: [
       { label: "Upparbetat arbete i perioden (exkl moms)", amountOre: newWorkNet, kind: "add" as const },
-      { label: `Klientens andel ${e.clientShareBips / 100} % (exkl moms)`, amountOre: clientNet, kind: "add" as const },
+      { label: `Klientens andel ${bips / 100} % (exkl moms)`, amountOre: clientNet, kind: "add" as const },
       { label: "Moms 25 %", amountOre: amountOre - clientNet, kind: "add" as const },
     ],
     totalLabel: "Att betala (inkl moms)", totalOre: amountOre,
   };
   const { invoice } = await ctx.c.billingRun.createAcconto({
-    matterId: m.id, recipient: "KLIENT", clientShareBips: e.clientShareBips, amountOre,
-    invoiceDate: iso, notes: `Aconto — klientens andel ${e.clientShareBips / 100} % (löpande)`, settlementBreakdown,
+    matterId: m.id, recipient: "KLIENT", clientShareBips: bips, amountOre,
+    invoiceDate: iso, notes: `Aconto — klientens andel ${bips / 100} % (löpande)`, settlementBreakdown,
   });
   await ctx.c.invoice.setStatus({ invoiceId: invoice.id, status: "SENT" });
   st.billedNetOre = st.accruedNetOre;
   st.periodLines = [];
   ctx.res.invoices++;
+}
+
+/** FAST aconto (rättsskydd-självrisk) — skickas oavsett tröskel vid scenariots dag. */
+async function hAcconto(ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimState): Promise<void> {
+  await sendAcconto(ctx, m, iso, st, e.clientShareBips);
+}
+
+/** Byt klientens självrisk-sats (#885). */
+async function hRateChange(_ctx: RunCtx, _m: SimMatter, e: Any, _iso: string, st: SimState): Promise<void> {
+  st.currentRateBips = e.clientShareBips;
+}
+
+/** Tröskelstyrt aconto (#885, rättshjälp): skicka FÖRST när klientens ackumulerade
+ *  o-fakturerade andel (vid aktuell sats) nått byråns gränsbelopp. */
+async function maybeAcconto(ctx: RunCtx, m: SimMatter, iso: string, st: SimState): Promise<void> {
+  if (m.paymentMethod !== "RATTSHJALP") return;
+  const newWorkNet = st.accruedNetOre - st.billedNetOre;
+  const clientNet = Math.round((st.currentRateBips / 10000) * newWorkNet);
+  const threshold = ctx.accontoThresholdOre ?? SJALVRISK_ACCONTO_THRESHOLD_ORE;
+  if (clientNet < threshold) return;
+  await sendAcconto(ctx, m, iso, st, st.currentRateBips);
 }
 
 async function hKostnadsrakning(ctx: RunCtx, m: SimMatter, _e: Any, _iso: string, st: SimState): Promise<void> {
@@ -161,12 +187,12 @@ async function hPayment(ctx: RunCtx, _m: SimMatter, _e: Any, iso: string, st: Si
 /** kind → handler. Håller runnern platt (undviker en stor switch = hög komplexitet). */
 const HANDLERS: Record<SimEvent["kind"], (ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimState) => Promise<void>> = {
   party: hParty, time: hTime, note: hNote, expense: hExpense, doc: hDoc, radgivning: hRadgivning,
-  acconto: hAcconto, kostnadsrakning: hKostnadsrakning, beslut: hBeslut, verdict: hVerdict, settle: hSettle, final: hFinal, payment: hPayment,
+  acconto: hAcconto, rateChange: hRateChange, kostnadsrakning: hKostnadsrakning, beslut: hBeslut, verdict: hVerdict, settle: hSettle, final: hFinal, payment: hPayment,
 };
 
 /** Spela upp ett ärendes scenario kronologiskt. */
 export async function runScenario(ctx: RunCtx, matter: SimMatter, events: SimEvent[]): Promise<void> {
-  const st: SimState = { accruedNetOre: 0, billedNetOre: 0, periodLines: [], krRunId: null, krWorkValueOre: 0, lastFinal: null, docSeq: 0 };
+  const st: SimState = { accruedNetOre: 0, billedNetOre: 0, currentRateBips: matter.clientShareBips ?? 0, periodLines: [], krRunId: null, krWorkValueOre: 0, lastFinal: null, docSeq: 0 };
   const sorted = [...events].sort((a, b) => a.dayOffset - b.dayOffset);
   for (const e of sorted) {
     const iso = eventIso(matter.startDaysAgo, e.dayOffset, 9 + (e.dayOffset % 6));

--- a/tooling/demo-generator/simulate/scenarios/rattshjalp.ts
+++ b/tooling/demo-generator/simulate/scenarios/rattshjalp.ts
@@ -1,9 +1,11 @@
 /**
- * Scenariomall för RÄTTSHJÄLP (#880) — kronologisk narrativ som subsumerar den
- * tidigare m-020-varierande-sats-flödet: klientbesök + rådgivningstimme → fakturera
- * → länka motpart/ombud → inkommande svaromål → löpande arbete → aconton vid
- * VARIERANDE avgift (arbetslös 5 % → anställd 75 % → arbetslös 5 %) → kostnadsräkning
- * → beslut → slutreglering (→ kreditfaktura vid överfakturering, jfr #878).
+ * Scenariomall för RÄTTSHJÄLP (#880/#885) — kronologisk narrativ med VARIERANDE
+ * självrisk-avgift (arbetslös 5 % → anställd 75 % → arbetslös 5 %). Aconto skickas
+ * INTE på skriptade dagar utan TRÖSKELSTYRT (#885): runnern ackumulerar klientens
+ * andel vid aktuell sats och fyr ett aconto FÖRST när den nått byråns gränsbelopp
+ * (default 1500 kr). Satsbyten sker via `rateChange`; arbetsvolymen per period är
+ * tilltagen så var period hinner passera tröskeln → de tre aconton (5/75/5 %) syns.
+ * Avslutas med kostnadsräkning → beslut → slutreglering (→ kredit vid överfakturering).
  */
 
 import type { Parties, SimEvent } from "../events";
@@ -11,6 +13,7 @@ import type { Parties, SimEvent } from "../events";
 export function buildRattshjalpScenario(parties: Parties): SimEvent[] {
   const ev: SimEvent[] = [
     { kind: "note", dayOffset: 0, text: "Klientbesök — första möte i ärendet. Rådgivning enligt rättshjälpstaxan." },
+    { kind: "rateChange", dayOffset: 0, clientShareBips: 500 }, // klient arbetslös → 5 %
     // Rådgivningstimmen skapas + faktureras SAMMA DAG som mötet (#880); allt arbete EFTER
     // detta går på aconto. (hRadgivning skapar tidsposten + rådgivningsfakturan.)
     { kind: "radgivning", dayOffset: 0 },
@@ -21,22 +24,29 @@ export function buildRattshjalpScenario(parties: Parties): SimEvent[] {
   if (parties.domstol) ev.push({ kind: "party", dayOffset: 2, contactId: parties.domstol, role: "DOMSTOL" });
 
   ev.push(
-    { kind: "time", dayOffset: 6, minutes: 90, description: "Genomgång av handlingar (klient arbetslös, 5 % avgift)" },
+    // Period 1 (arbetslös, 5 %) — löpande arbete tills klientens andel når tröskeln (→ aconto).
+    { kind: "time", dayOffset: 6, minutes: 240, description: "Genomgång av handlingar och underlag" },
     { kind: "doc", dayOffset: 7, template: "brevTillOmbud" },
     { kind: "doc", dayOffset: 14, template: "svaromal" },
     { kind: "note", dayOffset: 14, text: "Svaromål inkommet från motpartsombudet." },
-    // Period 1 (arbetslös, 5 %) → aconto på upparbetat.
-    { kind: "acconto", dayOffset: 20, clientShareBips: 500 },
-    { kind: "time", dayOffset: 40, minutes: 120, description: "Förhandlingsförberedelse och inlaga" },
-    { kind: "doc", dayOffset: 41, template: "inlaga" },
+    { kind: "time", dayOffset: 14, minutes: 240, description: "Analys av svaromål och förhandlingsförberedelse" },
+    { kind: "time", dayOffset: 22, minutes: 240, description: "Utkast till inlaga och yttrande" },
+    { kind: "doc", dayOffset: 23, template: "inlaga" },
+    { kind: "time", dayOffset: 30, minutes: 240, description: "Korrespondens med motpartsombud" },
+    { kind: "time", dayOffset: 38, minutes: 240, description: "Fördjupad rättsutredning" }, // → aconto #1 (5 %)
     { kind: "note", dayOffset: 45, text: "Klienten har fått anställning — rättshjälpsavgiften höjs till 75 %." },
-    // Period 2 (anställd, 75 %) → aconto (överfakturerar mot slutligt beslut).
-    { kind: "acconto", dayOffset: 55, clientShareBips: 7500 },
-    { kind: "time", dayOffset: 70, minutes: 120, description: "Sammanträde i tingsrätten" },
+    // Period 2 (anställd, 75 %) — en insats räcker för att passera tröskeln (överfakturerar
+    // mot slutligt beslut → kredit vid slutreglering).
+    { kind: "rateChange", dayOffset: 45, clientShareBips: 7500 },
+    { kind: "time", dayOffset: 50, minutes: 150, description: "Sammanträde i tingsrätten" }, // → aconto #2 (75 %)
     { kind: "note", dayOffset: 85, text: "Klienten åter arbetslös — avgiften tillbaka till 5 %." },
-    // Period 3 (arbetslös, 5 %).
-    { kind: "acconto", dayOffset: 90, clientShareBips: 500 },
-    { kind: "time", dayOffset: 100, minutes: 90, description: "Uppföljning och korrespondens" },
+    // Period 3 (arbetslös, 5 %) — löpande arbete tills tröskeln nås igen.
+    { kind: "rateChange", dayOffset: 85, clientShareBips: 500 },
+    { kind: "time", dayOffset: 88, minutes: 240, description: "Uppföljning efter sammanträde" },
+    { kind: "time", dayOffset: 92, minutes: 240, description: "Komplettering och inlaga" },
+    { kind: "time", dayOffset: 96, minutes: 240, description: "Korrespondens och bevisgenomgång" },
+    { kind: "time", dayOffset: 100, minutes: 240, description: "Förberedelse inför slutförhandling" },
+    { kind: "time", dayOffset: 103, minutes: 240, description: "Slutlig genomgång av ärendet" }, // → aconto #3 (5 %)
     // Kostnadsräkning → myndighetens/domstolens beslut → slutreglering.
     { kind: "kostnadsrakning", dayOffset: 105 },
     { kind: "doc", dayOffset: 106, template: "beslutRattshjalp" },

--- a/tooling/scripts/seed-data.ts
+++ b/tooling/scripts/seed-data.ts
@@ -190,6 +190,7 @@ export function buildSeed(opts: BuildSeedOpts = {}): SeedDataset {
       id: orgId, name: organizationName, orgNumber: "556999-9999",
       email: `kontor@${emailDomain}`, phone: "08-100 100",
       address: "Storgatan 1, 111 11 Stockholm",
+      accontoThresholdOre: 150_000, // 1500 kr — gränsbelopp för aconto-utskick (#885)
       createdAt: isoDate(-365), updatedAt: isoDate(-30),
     }],
     offices: [{


### PR DESCRIPTION
## Vad
Aconto till klient skickas **först när klientens ackumulerade (o-fakturerade) andel nått ett gränsbelopp** (default **1500 kr**). Gränsbeloppet är nu en **byrå-inställning**, redigerbar på inställningssidan.

## Ändringar
**Inställning (end-to-end):**
- `organizations.accontoThresholdOre` — drizzle-kolumn + migration `0015` + zod (`nullish`) + `get/updateSettings` + `create`-input.
- Settings-UI: "Gränsbelopp aconto (kr)" (visas i kr, sparas som öre), auto-save.
- Seed-default 150000 öre + skickas via demo-generatorns `organization.create`.

**Live-UI:** `SjalvriskAccontoHint` läser inställningen (fallback = `SJALVRISK_ACCONTO_THRESHOLD_ORE`).

**Demo-simulering (#880):** rättshjälps-scenariot byter skriptade `acconto`-event mot `rateChange` + **tröskelstyrt** aconto i `hTime` — fyr först när klientens andel vid aktuell sats ≥ gränsen. Arbetsvolymen per sats-period är tilltagen så 5/75/5-storyn fortfarande syns (3 aconton). Rättsskyddets fasta 20%-aconto är oförändrat.

## Verifierat
- `bun run quality:fast` grönt (typecheck + lint + 3238 tester).
- Nytt test: inga aconton om gränsbeloppet ligger över upparbetat.
- `build:demo`: `org.accontoThresholdOre=150000`; varje rättshjälps-ärende har 3 aconton (5/75/5 %) där klientandelen ≥ 1500 kr (2032,50 kr @5%, 3810,94 kr @75%).

Closes #885

🤖 Generated with [Claude Code](https://claude.com/claude-code)