### PR TITLE
fix(demo): ärenden får kontakter, utlägg och tjänsteanteckningar igen (#887)

### DIFF
--- a/src/lib/client/demo/demo-source-keys.ts
+++ b/src/lib/client/demo/demo-source-keys.ts
@@ -37,6 +37,7 @@ const MATCHERS: Matcher[] = [
   { key: "accontoDeductions", owns: (p) => p.startsWith("acconto-deductions/") },
   { key: "expectedReceivables", owns: (p) => p.startsWith("expected-receivables/") },
   { key: "tasks", owns: (p) => p.startsWith("tasks/") },
+  { key: "serviceNotes", owns: (p) => p.startsWith("service-notes/") },
   { key: "conflictChecks", owns: (p) => p.startsWith("conflict-checks/") },
   { key: "documentTemplates", owns: (p) => p.startsWith(".ava/templates/") },
   { key: "organizations", owns: (p) => p.startsWith(".ava/organizations/") },

--- a/test/scripts/simulate-orchestrate.test.ts
+++ b/test/scripts/simulate-orchestrate.test.ts
@@ -51,5 +51,15 @@ describe("runSimulation (#880 integration)", () => {
     const te = await c.timeEntry.list({ matterId: rh.id, pageSize: 100 });
     const teRows = te.timeEntries ?? te.items ?? te.entries ?? (Array.isArray(te) ? te : []);
     expect(teRows.length).toBeGreaterThan(2);
+
+    // Regression: ärendet ska ha kontakter (inkl KLIENT), tjänsteanteckningar och
+    // utlägg — simuleringen återskapar dem kronologiskt (annars tomma i demon).
+    const full = await c.matter.getById({ id: rh.id });
+    const contactRows = full.contacts ?? full.matterContacts ?? [];
+    expect(contactRows.some((x: Any) => x.role === "KLIENT")).toBe(true);
+    const notes = await c.serviceNote.list({ matterId: rh.id });
+    expect((notes.serviceNotes ?? notes).length).toBeGreaterThan(0);
+    const exp = await c.expense.list({ matterId: rh.id, pageSize: 100 });
+    expect((exp.expenses ?? exp.items ?? exp).length).toBeGreaterThan(0);
   });
 });

--- a/test/scripts/simulate-runner.test.ts
+++ b/test/scripts/simulate-runner.test.ts
@@ -48,8 +48,12 @@ describe("runScenario (#880)", () => {
   it("spelar upp rättshjälps-scenariot kronologiskt med härledda aconto-belopp", async () => {
     const { c, calls } = recordingCaller();
     const ctx: RunCtx = { c, res: { invoices: 0, documents: 0, timeEntries: 0, notes: 0, credits: 0 } };
-    const events = buildRattshjalpScenario({ motpart: "c-mot", motpartsombud: "c-omb", domstol: "c-dom" });
+    const events = buildRattshjalpScenario({ klient: "c-klient", motpart: "c-mot", motpartsombud: "c-omb", domstol: "c-dom" });
     await runScenario(ctx, MATTER, events);
+
+    // Klienten länkas som KLIENT-kontakt (#886-följd: klient saknades tidigare).
+    const klientLink = calls.find((x) => x.method === "matter.addContact" && x.args.role === "KLIENT");
+    expect(klientLink?.args.contactId).toBe("c-klient");
 
     // Kronologi: varje mutations datum-arg (date/invoiceDate/createdAt) är icke-avtagande.
     const dates = calls.map((x) => x.args.date ?? x.args.invoiceDate ?? x.args.createdAt).filter(Boolean).map((d: string) => new Date(d).getTime());

--- a/tooling/demo-generator/simulate/events.ts
+++ b/tooling/demo-generator/simulate/events.ts
@@ -53,8 +53,10 @@ export interface SimMatter {
   arvodeRateOre: number;
 }
 
-/** Motparter/instans att länka in via `party`-events (översatta UUID:n). */
+/** Parter att länka in via `party`-events (översatta UUID:n) — ur seedens
+ *  matterContacts, så klient/motpart/ombud/domstol får riktiga kontakter. */
 export interface Parties {
+  klient?: string | undefined;
   motpart?: string | undefined;
   motpartsombud?: string | undefined;
   domstol?: string | undefined;

--- a/tooling/demo-generator/simulate/orchestrate.ts
+++ b/tooling/demo-generator/simulate/orchestrate.ts
@@ -9,7 +9,6 @@
  */
 
 import { TIMKOSTNADSNORM_FTAX_ORE_PER_H } from "@/lib/shared/brottmalstaxa";
-import { AVA_NAMESPACE, uuidv5 } from "@/lib/shared/uuid-derive";
 import type { Parties, SimMatter } from "./events";
 import type { RunCtx } from "./runner";
 import { runScenario } from "./runner";
@@ -19,7 +18,6 @@ import { buildScenario } from "./scenarios";
 type Any = any;
 
 const MS_DAY = 86_400_000;
-const OMBUD_SLUG = "c-advokatbyran-nord";
 const DEFAULT_RATE_ORE = 250_000;
 
 function daysSince(iso: unknown): number {
@@ -36,23 +34,24 @@ function deriveSim(m: Any, lawyerId: string, rateOre: number): SimMatter {
   };
 }
 
-function deriveParties(m: Any, ombudId: string): Parties {
-  const hasMotpart = Boolean(m.motpartId);
-  return {
-    motpart: hasMotpart ? String(m.motpartId) : undefined,
-    motpartsombud: hasMotpart ? ombudId : undefined,
-    domstol: m.domstolId ? String(m.domstolId) : undefined,
+/** Parter ur seedens matterContacts (klient/motpart/ombud/domstol) → party-events. */
+function deriveParties(matterId: string, seedContacts: Any[]): Parties {
+  const mine = seedContacts.filter((c) => String(c.matterId) === matterId);
+  const byRole = (role: string): string | undefined => {
+    const hit = mine.find((c) => String(c.role) === role);
+    return hit ? String(hit.contactId) : undefined;
   };
+  return { klient: byRole("KLIENT"), motpart: byRole("MOTPART"), motpartsombud: byRole("MOTPARTSOMBUD"), domstol: byRole("DOMSTOL") };
 }
 
 /** Kör ett ärendes scenario + stäng det om seedens status inte är ACTIVE. */
-async function simulateMatter(ctx: RunCtx, m: Any, users: { id: string; rateOre: number }[], ombudId: string, index: number): Promise<void> {
+async function simulateMatter(ctx: RunCtx, m: Any, users: { id: string; rateOre: number }[], seedContacts: Any[], index: number): Promise<void> {
   // Seed-ärenden saknar responsibleLawyerId → välj ansvarig jurist deterministiskt ur
   // användarlistan (som gamla buildTimeEntries: round-robin per ärende-index).
   const u = users[index % Math.max(1, users.length)];
   if (!u) return;
   const sim = deriveSim(m, u.id, u.rateOre);
-  await runScenario(ctx, sim, buildScenario(sim, deriveParties(m, ombudId), index));
+  await runScenario(ctx, sim, buildScenario(sim, deriveParties(String(m.id), seedContacts), index));
   if (String(m.status) !== "ACTIVE") await ctx.c.matter.update({ id: sim.id, status: String(m.status) });
 }
 
@@ -64,12 +63,11 @@ export async function runSimulation(ctx: RunCtx, seed: Any): Promise<void> {
   const users: { id: string; rateOre: number }[] = (seed.users ?? [])
     .filter((u: Any) => typeof u.id === "string")
     .map((u: Any) => ({ id: String(u.id), rateOre: Number(u.hourlyRate ?? 0) || 0 }));
-  // Motpartsombudet är hårdkopplat till c-advokatbyran-nord (jfr buildMatterContacts);
-  // samma uuid som translateSeed ger (uuidv5(slug)).
-  const ombudId = uuidv5(OMBUD_SLUG, AVA_NAMESPACE);
+  // Parterna länkas kronologiskt ur seedens matterContacts (klient/motpart/ombud/domstol).
+  const seedContacts: Any[] = seed.matterContacts ?? [];
   let index = 0;
   for (const m of seed.matters ?? []) {
-    await simulateMatter(ctx, m, users, ombudId, index);
+    await simulateMatter(ctx, m, users, seedContacts, index);
     index++;
   }
 }

--- a/tooling/demo-generator/simulate/scenarios/offentligt.ts
+++ b/tooling/demo-generator/simulate/scenarios/offentligt.ts
@@ -12,8 +12,10 @@ export function buildOffentligtScenario(parties: Parties): SimEvent[] {
     { kind: "note", dayOffset: 0, text: "Förordnad som offentlig försvarare." },
     { kind: "time", dayOffset: 1, minutes: 120, description: "Genomgång av förundersökningsprotokoll" },
   ];
+  if (parties.klient) ev.push({ kind: "party", dayOffset: 0, contactId: parties.klient, role: "KLIENT" });
   if (parties.domstol) ev.push({ kind: "party", dayOffset: 2, contactId: parties.domstol, role: "DOMSTOL" });
   ev.push(
+    { kind: "expense", dayOffset: 6, amountOre: 38_000, description: "Reskostnad häktesbesök" },
     { kind: "doc", dayOffset: 4, template: "brevTillOmbud" },
     { kind: "time", dayOffset: 12, minutes: 180, description: "Klientmöte + förberedelse inför huvudförhandling" },
     { kind: "time", dayOffset: 20, minutes: 120, description: "Huvudförhandling i tingsrätten" },

--- a/tooling/demo-generator/simulate/scenarios/privat.ts
+++ b/tooling/demo-generator/simulate/scenarios/privat.ts
@@ -12,6 +12,7 @@ export function buildPrivatScenario(parties: Parties, index: number): SimEvent[]
     { kind: "time", dayOffset: 0, minutes: 90, description: "Inledande rådgivning och uppdragsbekräftelse" },
     { kind: "doc", dayOffset: 1, template: "fullmakt" },
   ];
+  if (parties.klient) ev.push({ kind: "party", dayOffset: 0, contactId: parties.klient, role: "KLIENT" });
   if (parties.motpart) ev.push({ kind: "party", dayOffset: 2, contactId: parties.motpart, role: "MOTPART" });
   if (parties.motpartsombud) ev.push({ kind: "party", dayOffset: 2, contactId: parties.motpartsombud, role: "MOTPARTSOMBUD" });
   if (parties.domstol) ev.push({ kind: "party", dayOffset: 3, contactId: parties.domstol, role: "DOMSTOL" });

--- a/tooling/demo-generator/simulate/scenarios/rattshjalp.ts
+++ b/tooling/demo-generator/simulate/scenarios/rattshjalp.ts
@@ -19,11 +19,15 @@ export function buildRattshjalpScenario(parties: Parties): SimEvent[] {
     { kind: "radgivning", dayOffset: 0 },
     { kind: "doc", dayOffset: 1, template: "fullmakt" },
   ];
+  if (parties.klient) ev.push({ kind: "party", dayOffset: 0, contactId: parties.klient, role: "KLIENT" });
   if (parties.motpart) ev.push({ kind: "party", dayOffset: 2, contactId: parties.motpart, role: "MOTPART" });
   if (parties.motpartsombud) ev.push({ kind: "party", dayOffset: 2, contactId: parties.motpartsombud, role: "MOTPARTSOMBUD" });
   if (parties.domstol) ev.push({ kind: "party", dayOffset: 2, contactId: parties.domstol, role: "DOMSTOL" });
 
   ev.push(
+    // Utlägg i ärendet (ersätts av domstolen via kostnadsräkningen).
+    { kind: "expense", dayOffset: 8, amountOre: 90_000, description: "Ansökningsavgift tingsrätten" },
+    { kind: "expense", dayOffset: 60, amountOre: 42_000, description: "Reskostnad till sammanträde" },
     // Period 1 (arbetslös, 5 %) — löpande arbete tills klientens andel når tröskeln (→ aconto).
     { kind: "time", dayOffset: 6, minutes: 240, description: "Genomgång av handlingar och underlag" },
     { kind: "doc", dayOffset: 7, template: "brevTillOmbud" },

--- a/tooling/demo-generator/simulate/scenarios/rattsskydd.ts
+++ b/tooling/demo-generator/simulate/scenarios/rattsskydd.ts
@@ -13,6 +13,7 @@ export function buildRattsskyddScenario(parties: Parties): SimEvent[] {
     { kind: "time", dayOffset: 0, minutes: 60, description: "Inledande genomgång och rättsskyddsansökan" },
     { kind: "doc", dayOffset: 1, template: "fullmakt" },
   ];
+  if (parties.klient) ev.push({ kind: "party", dayOffset: 0, contactId: parties.klient, role: "KLIENT" });
   if (parties.motpart) ev.push({ kind: "party", dayOffset: 2, contactId: parties.motpart, role: "MOTPART" });
   if (parties.motpartsombud) ev.push({ kind: "party", dayOffset: 2, contactId: parties.motpartsombud, role: "MOTPARTSOMBUD" });
   if (parties.domstol) ev.push({ kind: "party", dayOffset: 2, contactId: parties.domstol, role: "DOMSTOL" });


### PR DESCRIPTION
## Problem
Efter den kronologiska seed-omskrivningen (#880) visade demo-ärenden **inga kontakter, inga utlägg och inga tjänsteanteckningar**.

## Rotorsaker + fix
1. **Tjänsteanteckningar föll bort ur exporten.** `pathToSourceKey` (demo-source-keys.ts) saknade en matcher för `service-notes/` → 28 skapade anteckningar (på disk + i manifest) grupperades aldrig in i `demo-seed.json`. **Fix:** matcher tillagd.
2. **Inga kontakter.** `deriveParties` läste `m.motpartId`/`m.domstolId` — fält som bara finns i MATTERS-mallen (konsumeras av buildMatterContacts), aldrig på matter-*rader*. → inga `party`-event → 0 kontakter. Dessutom länkades **klienten aldrig**. **Fix:** deriveParties läser parterna (klient/motpart/ombud/domstol) ur seedens `matterContacts`; scenarierna emitterar ett KLIENT-event.
3. **Inga utlägg på rättshjälp/offentligt.** De scenarierna saknade `expense`-event. **Fix:** utlägg tillagda (ansökningsavgift/reskostnad m.m.).

## Verifierat
- `bun run quality:fast` grönt (typecheck + lint + 3238 tester).
- `build:demo`: matterContacts **0→54**, serviceNotes **0→28**, expenses **13→22**, **0 ärenden med lucka** (alla har kontakter inkl KLIENT, utlägg, anteckningar).
- Orchestrate-integrationstestet vaktar nu kontakter (inkl KLIENT) + notes + utlägg per ärende.

Closes #887

🤖 Generated with [Claude Code](https://claude.com/claude-code)