### PR TITLE
feat(billing): domstolsposter visar referens i fakturaformat (#889)

### DIFF
--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -67,6 +67,8 @@ interface BillingRunRow {
   clientShareBips?: number | null;
   invoiceId?: InvoiceId | null;
   invoice?: { id: InvoiceId; invoiceNumber?: string | null; invoiceDate?: string | Date | null } | null;
+  /** KR-referens `KR-YYYY-NNNN` (#889) — visas i ref-kolumnen för kostnadsräkningen. */
+  reference?: string | null;
   kostnadsrakningStatus?: KostnadsrakningStatus | null;
   awardedOre?: number | null;
   beslutSlutgiltigt?: boolean | null;
@@ -666,12 +668,15 @@ const runDateOf = (r: BillingRunRow): string | Date => r.invoice?.invoiceDate ??
 /** Åtgärds-cellen: KR-dokument-länk + faktura-länk. Utbruten → RunRow ≤8. */
 function RunActions({ r, docs, client }: { r: BillingRunRow; docs: DocumentListOutput["documents"]; client: DownloadClient }) {
   const krDoc = r.type === "KOSTNADSRAKNING" ? pickKrDoc(docs, r) : null;
+  // KR:ns referens `KR-YYYY-NNNN` (#889) i samma format som fakturornas F-nummer;
+  // länken öppnar KR-dokumentet (faller tillbaka på etikett om referens saknas).
+  const krLabel = r.reference ?? "Kostnadsräkning";
   return (
     <td className="text-right space-x-2 whitespace-nowrap">
-      {krDoc && (
-        <button type="button" onClick={() => void openKrDoc(krDoc, client)}
-          className="text-xs text-blue-600 hover:underline">Kostnadsräkning</button>
-      )}
+      {r.type === "KOSTNADSRAKNING" && (krDoc
+        ? <button type="button" onClick={() => void openKrDoc(krDoc, client)}
+            className="text-xs text-blue-600 hover:underline">{krLabel}</button>
+        : <span className="text-xs text-gray-500">{krLabel}</span>)}
       {/* EntityLink (hård nav) — runtime-skapade UUID:n finns ej i generateStaticParams;
           __shell__-shimen/nginx try_files resolvar dem (se [[entity-link]]). */}
       {r.invoiceId && (

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -298,6 +298,8 @@ export const billingRuns = pgTable("billing_runs", {
   prutningOre: ore("prutning_ore"),
   /** KR-livscykel (#828): status + dömt belopp + slutgiltigt (efter hovrätten). */
   kostnadsrakningStatus: text("kostnadsrakning_status").$type<KostnadsrakningStatus>(),
+  /** KR-referensnummer `KR-YYYY-NNNN` (#889). Null för icke-KR-körningar. */
+  reference: text("reference"),
   awardedOre: ore("awarded_ore"),
   beslutSlutgiltigt: boolean("beslut_slutgiltigt").notNull().default(false),
   invoiceId: uuid("invoice_id").$type<InvoiceId>(),

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -48,6 +48,7 @@ import type { SettlementRow, SettlementView, SettlementViewLine } from "@/lib/sh
 import { splitVat, DEFAULT_VAT_RATE } from "@/lib/shared/vat";
 import { emit, type EmitCtx } from "../events/emit";
 import type { BillingRunDetailRow, BillingRunListRow } from "../repositories/billing-run-repository";
+import { nextInvoiceNumberFrom } from "../repositories/invoice-repository";
 import type { Repositories } from "../repositories/repositories";
 import { router, orgProcedure } from "../trpc";
 
@@ -769,19 +770,30 @@ async function assertFlowAction(repos: Repositories, orgId: OrganizationId, matt
 }
 
 /**
- * Tilldela fakturanummer + OCR (ADR 0012) — klient-/försäkringsfakturor får
- * `F-YYYY-NNNN` + härledd OCR; kostnadsräkningar till DOMSTOL får varken nummer
- * eller OCR (domstolen betalar inte via OCR). Matchar legacy `invoice.createFinal`
- * så en billing-run-faktura blir likvärdig. Tomt objekt → faktura utan nummer.
+ * Tilldela fakturanummer + OCR (ADR 0012). Alla fakturor får `F-YYYY-NNNN`
+ * (#889 — så domstolsfakturan syns i samma format som övriga i listan), MEN
+ * domstolsfakturor får ingen OCR: domstolen betalar på beslut, inte via OCR.
  */
 async function invoiceNumbering(
   repos: Repositories,
   orgId: OrganizationId,
   recipient: BillingRunRecipient,
-): Promise<{ invoiceNumber: string; ocrReference: string | null } | Record<string, never>> {
-  if (recipient === "DOMSTOL") return {};
+): Promise<{ invoiceNumber: string; ocrReference: string | null }> {
   const invoiceNumber = await repos.invoices.nextInvoiceNumber(orgId);
-  return { invoiceNumber, ocrReference: ocrFromInvoiceNumber(invoiceNumber) };
+  return { invoiceNumber, ocrReference: recipient === "DOMSTOL" ? null : ocrFromInvoiceNumber(invoiceNumber) };
+}
+
+/** Nästa kostnadsräknings-referens `KR-YYYY-NNNN` (#889) — firmagemensam sekvens
+ *  per år, härledd ur befintliga KR-körningars referens. */
+async function nextKrReference(repos: Repositories, orgId: OrganizationId): Promise<string> {
+  const prefix = `KR-${new Date().getFullYear()}-`;
+  const runs = await repos.billingRuns.listForOrg(orgId);
+  const last = runs
+    .map((r) => (r as { reference?: string | null }).reference)
+    .filter((ref): ref is string => !!ref && ref.startsWith(prefix))
+    .sort()
+    .pop();
+  return nextInvoiceNumberFrom(prefix, last);
 }
 
 /**
@@ -974,6 +986,7 @@ export const billingRunRouter = router({
         const run = await tx.billingRuns.create({
           matterId: input.matterId, type: "KOSTNADSRAKNING", recipient: "DOMSTOL",
           status: "PENDING_VERDICT", kostnadsrakningStatus: "INSKICKAD", workValueOreAtRun: grossValue,
+          reference: await nextKrReference(tx, ctx.orgId),
           proposedAmountOre: grossValue, amountOre: grossValue,
           invoiceId: null, deductedBillingRunIds: [],
           periodTo: new Date(), notes: input.notes,
@@ -1095,7 +1108,9 @@ export const billingRunRouter = router({
         const work = await fetchWorkByRun(tx, run.id);
         const invoice = await tx.invoices.create({
           matterId: run.matterId, amount: finalAmount,
-          invoiceType: "FINAL", status: "DRAFT", // DOMSTOL → inget nummer/OCR (ADR 0012)
+          invoiceType: "FINAL", status: "DRAFT",
+          // DOMSTOL → F-nummer (samma format som övriga, #889) men ingen OCR.
+          ...(await invoiceNumbering(tx, ctx.orgId, "DOMSTOL")),
           invoiceDate: new Date(),
         });
         const next = applyKrTransition(krStateOf(run), "SKAPA_FAKTURA");

--- a/src/lib/shared/schemas/billing.ts
+++ b/src/lib/shared/schemas/billing.ts
@@ -321,6 +321,9 @@ export const billingRunSchema = z.object({
   /** KOSTNADSRAKNING:ens egen livscykel (#828): INSKICKAD→BESLUTAD→FAKTURERAD
    *  + överklagan-grenen. Null för icke-KR-körningar. */
   kostnadsrakningStatus: kostnadsrakningStatusSchema.nullish(),
+  /** KOSTNADSRAKNING:ens referensnummer `KR-YYYY-NNNN` (#889) — visas i
+   *  faktureringslistan i samma format som fakturornas F-nummer. */
+  reference: z.string().nullish(),
   /** Domstolens beslutade (dömda) belopp i öre — registreras vid beslutet,
    *  uppdateras av hovrättens beslut vid överklagan (#828). */
   awardedOre: z.number().int().nullish(),

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -119,10 +119,10 @@ describe("billingRun.createFinal", () => {
     expect(res.invoice.ocrReference).toBeTruthy();
   });
 
-  it("DOMSTOL-mottagare → inget fakturanummer/OCR (ADR 0012)", async () => {
+  it("DOMSTOL-mottagare → fakturanummer men INGEN OCR (#889: samma format som övriga, men domstolen betalar på beslut)", async () => {
     const { caller } = makeCaller({ workMinutes: 60 });
     const res = await caller.billingRun.createFinal({ matterId: "m-1", recipient: "DOMSTOL" });
-    expect(res.invoice.invoiceNumber).toBeFalsy();
+    expect(res.invoice.invoiceNumber).toMatch(/^F-\d{4}-\d+$/);
     expect(res.invoice.ocrReference).toBeFalsy();
   });
 
@@ -211,6 +211,12 @@ describe("billingRun.createKostnadsrakning", () => {
     expect(res.run.workValueOreAtRun).toBe(937500); // 3h × 2500 kr + 25 % moms (#782)
   });
 
+  it("tilldelar en KR-referens KR-YYYY-NNNN (#889 — samma format som fakturornas F-nummer)", async () => {
+    const { caller } = makeCaller({ workMinutes: 180, paymentMethod: "OFFENTLIGT_UPPDRAG" });
+    const res = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
+    expect((res.run as { reference?: string }).reference).toMatch(/^KR-\d{4}-\d{4}$/);
+  });
+
   it("fryser raderna vid inskick mot körningen (#806 — lämnar 'upparbetat ofakturerat')", async () => {
     const { ds, caller } = makeCaller({ workMinutes: 60, paymentMethod: "OFFENTLIGT_UPPDRAG" });
     const res = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
@@ -280,12 +286,12 @@ describe("billingRun.setVerdict", () => {
     expect(res.invoice.amount).toBe(625000 + 5000 - 30000);
   });
 
-  it("DOMSTOL-faktura får inget fakturanummer (ADR 0012)", async () => {
+  it("DOMSTOL-faktura får F-nummer men ingen OCR (#889 — samma format som övriga)", async () => {
     const { caller } = makeCaller({ workMinutes: 60, paymentMethod: "OFFENTLIGT_UPPDRAG" });
     const kr = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
     await caller.billingRun.recordKostnadsrakningBeslut({ billingRunId: kr.run.id, awardedOre: 312500 });
     const res = await caller.billingRun.setVerdict({ billingRunId: kr.run.id });
-    expect(res.invoice.invoiceNumber).toBeFalsy();
+    expect(res.invoice.invoiceNumber).toMatch(/^F-\d{4}-\d+$/);
     expect(res.invoice.ocrReference).toBeFalsy();
   });
 

--- a/tooling/db/migrations/0016_billing_run_reference.sql
+++ b/tooling/db/migrations/0016_billing_run_reference.sql
@@ -1,0 +1,3 @@
+-- #889: kostnadsräkningens referensnummer (KR-YYYY-NNNN) — visas i
+-- faktureringslistan i samma format som fakturornas F-nummer.
+ALTER TABLE billing_runs ADD COLUMN IF NOT EXISTS reference text;


### PR DESCRIPTION
## Problem
I faktureringspanelens högerkolumn visade domstolsposterna generiska etiketter (**"Faktura"**, **"Kostnadsräkning"**) i stället för ett referensnummer i samma format som klientfakturornas `F-YYYY-NNNN`.

## Fix (efter val i dialog med Ulrik)
- **Domstolsfaktura** (slutreglering + verdict för offentligt uppdrag): får nu `F-YYYY-NNNN` i **samma serie** som klient-/försäkringsfakturor, men **fortsatt ingen OCR** (domstolen betalar på beslut, inte via OCR). `invoiceNumbering` ger nummer åt alla mottagare; `setVerdict`-vägen (som tidigare hoppade över numrering) använder den nu också.
- **Kostnadsräkning**: får en egen referens `KR-YYYY-NNNN` (nytt persisterat fält `billing_runs.reference`, firmagemensam sekvens per år via `listForOrg` + `nextInvoiceNumberFrom`). Visas i kolumnen; länken öppnar fortfarande KR-dokumentet.

## Ändringar
- `billingRun.ts`: `invoiceNumbering` (nummer åt alla, OCR ej för DOMSTOL), `nextKrReference`, `createKostnadsrakning` + `setVerdict` tilldelar referens/nummer.
- Schema: `billingRunSchema.reference` + drizzle-kolumn + migration `0016`.
- Panel: `RunActions` visar KR-referensen (fallback "Kostnadsräkning"); domstolsfakturan visar sitt F-nummer automatiskt.

## Verifierat
- `bun run quality:fast` grönt (typecheck + lint + 3243 tester). Uppdaterade DOMSTOL-nummer-testerna + nytt KR-referens-test.
- `build:demo`: **6/6** kostnadsräkningar med `KR-2026-NNNN`, **6/6** domstolsfakturor med `F-2026-NNNN` och **0** OCR.

Closes #889

🤖 Generated with [Claude Code](https://claude.com/claude-code)