### PR TITLE
feat(billing): årsvis timkostnadsnorm + tidsspillan + retroaktiv höjning (#891)

### DIFF
--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -174,6 +174,8 @@ export const timeEntries = pgTable("time_entries", {
   minutes: integer("minutes").notNull(),
   description: text("description").notNull(),
   hourlyRate: integer("hourly_rate").notNull(),
+  /** ARBETE (default) eller TIDSSPILLAN (#891) — styr slutregleringens norm. */
+  kind: text("kind").$type<"ARBETE" | "TIDSSPILLAN">(),
   billable: boolDefault("billable", true),
   invoiceId: uuid("invoice_id").$type<InvoiceId>(),
   frozenAt: timestamp("frozen_at", { withTimezone: true }),

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -19,7 +19,7 @@ import { z } from "zod";
 import type { VatBreakdownLine } from "@/lib/shared/accounting/semantic-voucher";
 import { assertBillingTransition, type BillingActionType } from "@/lib/shared/billing-flow";
 import { proposedAccontoOre } from "@/lib/shared/billing-proposal";
-import { TIMKOSTNADSNORM_FTAX_ORE_PER_H } from "@/lib/shared/brottmalstaxa";
+import { TIMKOSTNADSNORM_FTAX_ORE_PER_H, timkostnadsnormFtaxForDate, tidsspillanFtaxForDate } from "@/lib/shared/brottmalstaxa";
 import { computeCoverageSplit, partitionRattsskyddMinutes, type CoverageSplit } from "@/lib/shared/coverage-billing";
 import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
 import { carveEarliestMinutes } from "@/lib/shared/kostnadsrakning";
@@ -53,7 +53,7 @@ import type { Repositories } from "../repositories/repositories";
 import { router, orgProcedure } from "../trpc";
 
 interface UnfrozenWork {
-  timeEntries: Array<{ id: TimeEntryId; minutes: number; hourlyRate: number; billable: boolean; date: Date | string; description: string }>;
+  timeEntries: Array<{ id: TimeEntryId; minutes: number; hourlyRate: number; billable: boolean; date: Date | string; description: string; kind?: "ARBETE" | "TIDSSPILLAN" | null | undefined }>;
   expenses: Array<{ id: ExpenseId; amount: number; billable: boolean; vatRate?: number | null; vatIncluded?: boolean | null }>;
 }
 
@@ -226,17 +226,37 @@ function invoiceGrossOre(work: UnfrozenWork): number {
   return arvodeInclVatOre(arvodeNetOre(work)) + expenseGrossOre(work);
 }
 
+/** Timarvodet (öre/tim) för en tidspost vid slutreglering (#891): rättshjälp
+ *  värderas retroaktivt på SLUTREGLERINGSÅRETS norm — arbete på timkostnadsnormen,
+ *  tidsspillan på den (lägre) tidsspillan-normen. */
+function rattshjalpEntryRateOre(kind: "ARBETE" | "TIDSSPILLAN" | null | undefined, settleDate: Date | string): number {
+  return kind === "TIDSSPILLAN" ? tidsspillanFtaxForDate(settleDate) : timkostnadsnormFtaxForDate(settleDate);
+}
+
 /**
- * Rättshjälpens KR-anspråk till domstol, brutto (#839): arbetet värderas på
- * TIMKOSTNADSNORMEN (inte byråns privata timtaxor — staten ersätter bara normen)
- * och rådgivningstimmen exkluderas (faktureras klienten separat). Utlägg ersätts
- * brutto. Speglar settlement-revärderingen (currentArvodeRateOre × coverageBaseMinutes).
+ * Slutregleringens arvode-netto (#891). RÄTTSHJÄLP: räkna om HELA ärendet på
+ * SLUTREGLERINGSÅRETS normer — den retroaktiva höjningen över ett årsskifte (arbete
+ * 2025 värderas på 2026 års norm). Arbete värderas på timkostnadsnormen (minus
+ * rådgivningstimmen), tidsspillan på tidsspillan-normen. Övriga metoder: platt
+ * `flatRateOre` × alla debiterbara minuter (oförändrat).
  */
-function rattshjalpKrGrossOre(work: UnfrozenWork, rateOrePerH: number): number {
-  const billableMin = work.timeEntries.filter((t) => t.billable).reduce((s, t) => s + t.minutes, 0);
-  const claimMin = coverageBaseMinutes("RATTSHJALP", billableMin);
-  const arvodeNet = Math.round((claimMin / 60) * rateOrePerH);
-  return arvodeInclVatOre(arvodeNet) + expenseGrossOre(work);
+function settlementArvodeNet(method: PaymentMethod, work: UnfrozenWork, settleDate: Date | string, flatRateOre: number): number {
+  const billable = work.timeEntries.filter((t) => t.billable);
+  const billableMin = billable.reduce((s, t) => s + t.minutes, 0);
+  if (method !== "RATTSHJALP") return Math.round((billableMin / 60) * flatRateOre);
+  const tidsMin = billable.filter((t) => t.kind === "TIDSSPILLAN").reduce((s, t) => s + t.minutes, 0);
+  const arbeteMin = coverageBaseMinutes("RATTSHJALP", billableMin - tidsMin); // − rådgivningstimmen
+  return Math.round((arbeteMin / 60) * timkostnadsnormFtaxForDate(settleDate))
+    + Math.round((tidsMin / 60) * tidsspillanFtaxForDate(settleDate));
+}
+
+/**
+ * Rättshjälpens KR-anspråk till domstol, brutto (#839/#891): arbetet värderas på
+ * TIMKOSTNADSNORMEN (staten ersätter bara normen, ej byråns taxa), tidsspillan på
+ * tidsspillan-normen, rådgivningstimmen exkluderas. Utlägg ersätts brutto.
+ */
+function rattshjalpKrGrossOre(work: UnfrozenWork, settleDate: Date | string): number {
+  return arvodeInclVatOre(settlementArvodeNet("RATTSHJALP", work, settleDate, 0)) + expenseGrossOre(work);
 }
 
 /** Fakturans exakta momsbelopp (öre) per sats: arvodets moms (25 %) +
@@ -495,13 +515,17 @@ export interface SettlementBreakdown {
  *  (rättshjälp), värderad på samma rate som arvodesbasen och AVSTÄMD så radernas
  *  summa exakt = `totalArvodeNet` (per-rad-avrundning läggs på sista raden). */
 function buildClientArvodeLines(
-  method: PaymentMethod, rateOre: number, work: UnfrozenWork, totalArvodeNet: number,
+  method: PaymentMethod, rateOre: number, work: UnfrozenWork, totalArvodeNet: number, settleDate: Date | string,
 ): SpecTimeLine[] {
   const billable = work.timeEntries.filter((t) => t.billable);
   const entries = method === "RATTSHJALP" ? carveEarliestMinutes(billable, RADGIVNING_MINUTES) : billable;
+  // #891: rättshjälp värderar varje rad på slutregleringsårets norm per kategori
+  // (arbete vs tidsspillan); övriga metoder → den platta raten.
+  const lineRate = (kind: "ARBETE" | "TIDSSPILLAN" | null | undefined): number =>
+    method === "RATTSHJALP" ? rattshjalpEntryRateOre(kind, settleDate) : rateOre;
   const lines: SpecTimeLine[] = entries.map((t) => ({
     date: t.date, description: t.description, minutes: t.minutes,
-    amountOre: timeEntryValueOre(t.minutes, rateOre),
+    amountOre: timeEntryValueOre(t.minutes, lineRate(t.kind)),
   }));
   const sum = lines.reduce((s, l) => s + l.amountOre, 0);
   const last = lines[lines.length - 1];
@@ -511,7 +535,7 @@ function buildClientArvodeLines(
 
 async function buildSettlementBreakdown(repos: Repositories, orgId: OrganizationId, a: {
   clientShareBips: number; totalArvodeNet: number; split: CoverageSplit; work: UnfrozenWork;
-  payerGross: number; clientPayable: number; method: PaymentMethod; rateOre: number;
+  payerGross: number; clientPayable: number; method: PaymentMethod; rateOre: number; settleDate: Date | string;
   deductedRuns: ReadonlyArray<{ invoiceId?: InvoiceId | null | undefined }>;
 }): Promise<SettlementBreakdown> {
   // Rådgivningstimmen ingår ALDRIG i domstolens arvode (#860) — arvodet värderas
@@ -542,7 +566,7 @@ async function buildSettlementBreakdown(repos: Repositories, orgId: Organization
     radgivningGrossOre: a.method === "RATTSHJALP" ? arvodeInclVatOre(a.rateOre) : 0,
     payerPayableOre: a.payerGross,
     clientPayableOre: a.clientPayable,
-    clientArvodeLines: buildClientArvodeLines(a.method, a.rateOre, a.work, a.totalArvodeNet),
+    clientArvodeLines: buildClientArvodeLines(a.method, a.rateOre, a.work, a.totalArvodeNet, a.settleDate),
     deductedAccontos,
   };
 }
@@ -981,7 +1005,7 @@ export const billingRunRouter = router({
         // byråns privata timtaxa. Övriga (offentligt uppdrag/taxa): arvode inkl moms
         // + utlägg som tidigare. Brutto matchar kostnadsräkningens PDF (#782).
         const grossValue = matter.paymentMethod === "RATTSHJALP"
-          ? rattshjalpKrGrossOre(work, await currentArvodeRateOre(tx, ctx.orgId, matter))
+          ? rattshjalpKrGrossOre(work, new Date()) // #891: retroaktiv norm per slutregleringsdatum
           : invoiceGrossOre(work);
         const run = await tx.billingRuns.create({
           matterId: input.matterId, type: "KOSTNADSRAKNING", recipient: "DOMSTOL",
@@ -1158,10 +1182,11 @@ export const billingRunRouter = router({
         // Finns en kostnadsräkning måste den vara BESLUTAD först — fakturan skapas
         // EFTER domstolens beslut (#828). Domsbeloppet läses då från KR:n, inte input.
         const awardedOre = resolveAwardedOre(krRun, input.awardedOre);
-        const billableMinutes = work.timeEntries.filter((t) => t.billable).reduce((s, t) => s + t.minutes, 0);
         const rateOre = await currentArvodeRateOre(tx, ctx.orgId, matter);
-        const baseMinutes = coverageBaseMinutes(matter.paymentMethod, billableMinutes);
-        const totalArvodeNet = Math.round((baseMinutes / 60) * rateOre);
+        // #891: rättshjälp räknas om på slutregleringsårets normer (retroaktiv höjning
+        // över årsskifte + tidsspillan på egen norm); övriga metoder → platt rate.
+        const settleDate = new Date();
+        const totalArvodeNet = settlementArvodeNet(matter.paymentMethod, work, settleDate, rateOre);
         const split = computeCoverageSplit({
           method: matter.paymentMethod, totalOre: totalArvodeNet, clientShareBips: matter.clientShareBips ?? 0,
           awardedOre, insurerPrutningOre: input.insurerPrutningOre ?? null,
@@ -1185,7 +1210,7 @@ export const billingRunRouter = router({
         const breakdown = await buildSettlementBreakdown(tx, ctx.orgId, {
           clientShareBips: matter.clientShareBips ?? 0, totalArvodeNet,
           split, work, payerGross, clientPayable: clientAmount,
-          method: matter.paymentMethod, rateOre, deductedRuns,
+          method: matter.paymentMethod, rateOre, settleDate, deductedRuns,
         });
         const { clientView, payerView } = buildSettlementViews(breakdown, matter.paymentMethod);
 

--- a/src/lib/server/routers/timeEntry.ts
+++ b/src/lib/server/routers/timeEntry.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
-import type { TimeEntry } from "@/lib/shared/schemas/billing";
+import { timeEntryKindSchema, type TimeEntry } from "@/lib/shared/schemas/billing";
 import {
   asId,
   matterIdSchema,
@@ -45,6 +45,8 @@ export const timeEntryRouter = router({
         minutes: z.number().min(1),
         description: z.string().min(1),
         billable: z.boolean().default(true),
+        /** ARBETE (default) eller TIDSSPILLAN (#891). */
+        kind: timeEntryKindSchema.optional(),
         // Valfria setup-fält (demo-generator/fixtures, ADR 0003).
         id: timeEntryIdSchema.optional(),
         userId: userIdSchema.optional(),
@@ -66,6 +68,7 @@ export const timeEntryRouter = router({
         minutes: input.minutes,
         description: input.description,
         hourlyRate: input.hourlyRate ?? user.hourlyRate ?? 0,
+        ...(input.kind ? { kind: input.kind } : {}),
         billable: input.billable,
         invoiceId: input.invoiceId ?? null,
         ...(input.createdAt ? { createdAt: new Date(input.createdAt) } : {}),

--- a/src/lib/shared/brottmalstaxa.ts
+++ b/src/lib/shared/brottmalstaxa.ts
@@ -44,8 +44,46 @@ export const NO_FTAX_FACTOR_DENOMINATOR = 1626;
  *
  * Belopp i öre per timme, exkl moms.
  */
-export const TIMKOSTNADSNORM_FTAX_ORE_PER_H = 162_600; // 1 626 kr/h
+export const TIMKOSTNADSNORM_FTAX_ORE_PER_H = 162_600; // 1 626 kr/h (senaste = 2026)
 export const TIMKOSTNADSNORM_NO_FTAX_ORE_PER_H = 123_700; // 1 237 kr/h
+
+/**
+ * Timkostnadsnormen (F-skatt) per år, öre/tim exkl moms (#891). Domstolsverket
+ * fastställer den årligen; ett ärende som sträcker sig över ett årsskifte får en
+ * RETROAKTIV HÖJNING → hela ärendet värderas om på det år normen gäller när
+ * slutregleringen sker (se `timkostnadsnormFtaxForDate`).
+ */
+const TIMKOSTNADSNORM_FTAX_BY_YEAR: Readonly<Record<number, number>> = {
+  2025: 160_200, // 1 602 kr/h
+  2026: 162_600, // 1 626 kr/h
+};
+
+/**
+ * Tidsspillan-ersättning (F-skatt) per år, öre/tim exkl moms (#891). Egen, lägre
+ * norm än arvodet. OBS: 2026-värdet (1 472 kr) är en uppskattning (+1,5 % från
+ * 2025) — verifiera mot Domstolsverkets föreskrift och justera vid behov.
+ */
+const TIDSSPILLAN_FTAX_BY_YEAR: Readonly<Record<number, number>> = {
+  2025: 145_000, // 1 450 kr/h
+  2026: 147_200, // 1 472 kr/h (uppskattat — verifiera)
+};
+
+/** Året ur ett datum (ISO-sträng eller Date). Ogiltigt → senaste kända året. */
+function yearOf(date: Date | string): number {
+  const y = new Date(date).getFullYear();
+  return Number.isFinite(y) ? y : 2026;
+}
+
+/** Timkostnadsnormen (F-skatt) som gäller ett givet datum (#891). Okänt år →
+ *  senaste kända normen (den retroaktiva höjningen landar alltid på senaste). */
+export function timkostnadsnormFtaxForDate(date: Date | string): number {
+  return TIMKOSTNADSNORM_FTAX_BY_YEAR[yearOf(date)] ?? TIMKOSTNADSNORM_FTAX_ORE_PER_H;
+}
+
+/** Tidsspillan-normen (F-skatt) som gäller ett givet datum (#891). */
+export function tidsspillanFtaxForDate(date: Date | string): number {
+  return TIDSSPILLAN_FTAX_BY_YEAR[yearOf(date)] ?? TIDSSPILLAN_FTAX_BY_YEAR[2026] ?? TIMKOSTNADSNORM_FTAX_ORE_PER_H;
+}
 
 /**
  * Beräkna ersättning enligt timkostnadsnorm × tid (öre, exkl moms).

--- a/src/lib/shared/schemas/billing.ts
+++ b/src/lib/shared/schemas/billing.ts
@@ -27,6 +27,11 @@ import {
   userIdSchema,
 } from "./ids";
 
+/** Tidspostens kategori (#891): vanligt arbete vs tidsspillan (restid/väntetid),
+ *  som ersätts på en egen, lägre norm i statligt betalda ärenden. */
+export const timeEntryKindSchema = z.enum(["ARBETE", "TIDSSPILLAN"]);
+export type TimeEntryKind = z.infer<typeof timeEntryKindSchema>;
+
 /**
  * TimeEntry — tidsregistrering på ärende. Lagras i `time-entries/<id>.json`.
  * `minutes` är heltal; `hourlyRate` är öre per timme.
@@ -41,6 +46,9 @@ export const timeEntrySchema = z.object({
   description: z.string(),
   /** öre per timme — snapshotad vid registrering så historik inte påverkas av taxan-byten. */
   hourlyRate: z.number().int().nonnegative(),
+  /** Arbete (null/undefined = ARBETE) eller TIDSSPILLAN — styr vilken norm
+   *  slutregleringen värderar minuterna på för rättshjälp (#891). */
+  kind: timeEntryKindSchema.nullish(),
   billable: z.boolean().default(true),
   /** @deprecated Använd `frozenByBillingRunId`. invoiceId behålls för
    *  bakåt­kompatibilitet med befintlig demo/billing — nya flöden ska

--- a/test/scripts/simulate-orchestrate.test.ts
+++ b/test/scripts/simulate-orchestrate.test.ts
@@ -61,5 +61,17 @@ describe("runSimulation (#880 integration)", () => {
     expect((notes.serviceNotes ?? notes).length).toBeGreaterThan(0);
     const exp = await c.expense.list({ matterId: rh.id, pageSize: 100 });
     expect((exp.expenses ?? exp.items ?? exp).length).toBeGreaterThan(0);
+
+    // #891: 2026-0020 spänner över ett årsskifte, innehåller tidsspillan och
+    // slutregleras retroaktivt på nya normen (klient- + domstolsfaktura).
+    const teAll = await c.timeEntry.list({ matterId: rh.id, pageSize: 100 });
+    const teRows2 = teAll.timeEntries ?? teAll.items ?? teAll.entries ?? (Array.isArray(teAll) ? teAll : []);
+    const years = new Set(teRows2.map((t: Any) => new Date(t.date).getFullYear()));
+    expect(years.size).toBeGreaterThan(1); // korsar årsgränsen
+    expect(teRows2.some((t: Any) => t.kind === "TIDSSPILLAN")).toBe(true);
+    const settlementRuns = (await c.billingRun.list({ matterId: rh.id })).runs as Any[];
+    const recips = new Set(settlementRuns.filter((r) => r.type === "FINAL").map((r) => r.recipient));
+    expect(recips.has("KLIENT")).toBe(true);
+    expect(recips.has("DOMSTOL")).toBe(true);
   });
 });

--- a/test/unit/lib/shared/timkostnadsnorm-schedule.test.ts
+++ b/test/unit/lib/shared/timkostnadsnorm-schedule.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Årsvis timkostnadsnorm + tidsspillan (#891) — den retroaktiva höjningen bygger
+ * på att normen slås upp per datum/år.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { timkostnadsnormFtaxForDate, tidsspillanFtaxForDate } from "@/lib/shared/brottmalstaxa";
+
+describe("timkostnadsnorm per år (#891)", () => {
+  it("timkostnadsnormen följer året (2025 = 1 602 kr, 2026 = 1 626 kr)", () => {
+    expect(timkostnadsnormFtaxForDate("2025-11-15")).toBe(160_200);
+    expect(timkostnadsnormFtaxForDate("2026-03-01")).toBe(162_600);
+  });
+
+  it("tidsspillan-normen följer året (2025 = 1 450 kr) och är lägre än arvodesnormen", () => {
+    expect(tidsspillanFtaxForDate("2025-11-15")).toBe(145_000);
+    expect(tidsspillanFtaxForDate("2026-03-01")).toBeLessThan(timkostnadsnormFtaxForDate("2026-03-01"));
+  });
+
+  it("okänt/framtida år faller tillbaka på senaste kända normen", () => {
+    expect(timkostnadsnormFtaxForDate("2030-01-01")).toBe(162_600);
+  });
+});

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -18,12 +18,15 @@ const PRINCIPAL: Principal = {
   id: asId<"UserId">("u-1"), email: "a@x", name: "Anna", role: "ADMIN", organizationId: asId<"OrganizationId">("org-1"),
 };
 
-function makeCaller(opts?: { workMinutes?: number; expenseOre?: number; paymentMethod?: string }) {
+function makeCaller(opts?: { workMinutes?: number; expenseOre?: number; paymentMethod?: string; tidsspillanMin?: number }) {
+  const tids = opts?.tidsspillanMin != null
+    ? [{ id: "te-2", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), minutes: opts.tidsspillanMin, description: "Restid", hourlyRate: 250000, billable: true, kind: "TIDSSPILLAN" as const }]
+    : [];
   const ds = new DemoDataStore({
     organizations: [{ id: "org-1", name: "X" }],
     matters: [{ id: "m-1", organizationId: "org-1", matterNumber: "2026-0001", title: "Test", status: "ACTIVE", paymentMethod: opts?.paymentMethod ?? "RATTSSKYDD", createdAt: new Date() }],
     users: [{ id: "u-1", organizationId: "org-1", email: "a@x", name: "Anna", role: "ADMIN", hourlyRate: 250000 }],
-    timeEntries: [{ id: "te-1", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), minutes: opts?.workMinutes ?? 120, description: "Möte", hourlyRate: 250000, billable: true }],
+    timeEntries: [{ id: "te-1", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), minutes: opts?.workMinutes ?? 120, description: "Möte", hourlyRate: 250000, billable: true }, ...tids],
     expenses: opts?.expenseOre != null ? [{ id: "ex-1", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), amount: opts.expenseOre, description: "Avgift", billable: true, vatRate: 0, vatIncluded: false, kind: "EXPENSE" }] : [],
   }, async () => { /* writable: noop write-back */ });
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -223,6 +226,14 @@ describe("billingRun.createKostnadsrakning", () => {
     const te = await ds.timeEntries.findFirst({ where: { id: "te-1" } }) as { frozenAt?: Date | null; frozenByBillingRunId?: string | null };
     expect(te.frozenAt).toBeTruthy();
     expect(te.frozenByBillingRunId).toBe(res.run.id);
+  });
+
+  it("tidsspillan värderas på tidsspillan-normen, arbete på timkostnadsnormen (#891)", async () => {
+    // 120 min arbete (−60 rådgivning = 60 kvar) på 1 626 kr + 60 min tidsspillan på 1 472 kr.
+    // netto: 60/60×162600 + 60/60×147200 = 309800; brutto ×1.25 = 387250.
+    const { caller } = makeCaller({ workMinutes: 120, tidsspillanMin: 60, paymentMethod: "RATTSHJALP" });
+    const res = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
+    expect(res.run.workValueOreAtRun).toBe(387250);
   });
 
   it("rättshjälp värderas på timkostnadsnormen (F-skatt) minus rådgivningstimmen (#839)", async () => {

--- a/tooling/db/migrations/0017_time_entry_kind.sql
+++ b/tooling/db/migrations/0017_time_entry_kind.sql
@@ -1,0 +1,3 @@
+-- #891: tidspostens kategori (ARBETE/TIDSSPILLAN). NULL behandlas som ARBETE.
+-- Tidsspillan ersätts på en egen, lägre norm i statligt betalda ärenden.
+ALTER TABLE time_entries ADD COLUMN IF NOT EXISTS kind text;

--- a/tooling/demo-generator/simulate/events.ts
+++ b/tooling/demo-generator/simulate/events.ts
@@ -9,8 +9,9 @@ import type { MatterRole } from "@/lib/shared/schemas/enums";
 export type SimEvent =
   /** Länka en part (motpart/ombud/domstol) till ärendet — matter.addContact. */
   | { kind: "party"; dayOffset: number; contactId: string; role: MatterRole }
-  /** Debiterbar (eller ej) tidspost — timeEntry.create. */
-  | { kind: "time"; dayOffset: number; minutes: number; description: string; billable?: boolean }
+  /** Debiterbar (eller ej) tidspost — timeEntry.create. `entryKind` = ARBETE (default)
+   *  eller TIDSSPILLAN (#891, egen norm vid rättshjälps-slutreglering). */
+  | { kind: "time"; dayOffset: number; minutes: number; description: string; billable?: boolean; entryKind?: "ARBETE" | "TIDSSPILLAN" }
   /** Tjänsteanteckning (händelselogg) — serviceNote.create. */
   | { kind: "note"; dayOffset: number; text: string }
   /** Utlägg — expense.create. */
@@ -42,6 +43,8 @@ export type SimEvent =
 export interface SimMatter {
   /** Översatt (UUID) ärende-id. */
   id: string;
+  /** Ärendenummer (t.ex. "2026-0020") — dispatchern väljer scenariovariant på det. */
+  matterNumber?: string;
   paymentMethod: string;
   clientShareBips?: number | null;
   /** Ansvarig jurist (userId) — sätts som tidsposternas användare. */

--- a/tooling/demo-generator/simulate/orchestrate.ts
+++ b/tooling/demo-generator/simulate/orchestrate.ts
@@ -28,7 +28,9 @@ function daysSince(iso: unknown): number {
 function deriveSim(m: Any, lawyerId: string, rateOre: number): SimMatter {
   const isRh = String(m.paymentMethod) === "RATTSHJALP";
   return {
-    id: String(m.id), paymentMethod: String(m.paymentMethod), clientShareBips: m.clientShareBips ?? null,
+    id: String(m.id),
+    ...(m.matterNumber ? { matterNumber: String(m.matterNumber) } : {}),
+    paymentMethod: String(m.paymentMethod), clientShareBips: m.clientShareBips ?? null,
     lawyerId, startDaysAgo: daysSince(m.createdAt),
     arvodeRateOre: isRh ? TIMKOSTNADSNORM_FTAX_ORE_PER_H : (rateOre || DEFAULT_RATE_ORE),
   };

--- a/tooling/demo-generator/simulate/runner.ts
+++ b/tooling/demo-generator/simulate/runner.ts
@@ -5,6 +5,7 @@
  * arbete (aconto) härleds här ur `state`; dokumentbytes skrivs via `BinarySink`.
  */
 
+import { timkostnadsnormFtaxForDate, tidsspillanFtaxForDate } from "@/lib/shared/brottmalstaxa";
 import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
 import { SJALVRISK_ACCONTO_THRESHOLD_ORE } from "@/lib/shared/rattshjalp";
 import type { SettlementViewLine } from "@/lib/shared/settlement-view";
@@ -42,14 +43,25 @@ async function hParty(ctx: RunCtx, m: SimMatter, e: Any, iso: string): Promise<v
   await ctx.c.matter.addContact({ matterId: m.id, contactId: e.contactId, role: e.role, createdAt: iso });
 }
 
+/** Timarvodet (öre/tim) en tidspost värderas på i simuleringen. Rättshjälp: den
+ *  norm som gällde postens DATUM (#891) — arbete på timkostnadsnormen, tidsspillan
+ *  på tidsspillan-normen → 2025-poster får 2025-taxan, 2026-poster 2026-taxan, så
+ *  aconton speglar tidpunkten och slutregleringens retroaktiva höjning syns. */
+function simTimeRateOre(m: SimMatter, e: Any, iso: string): number {
+  if (m.paymentMethod !== "RATTSHJALP") return m.arvodeRateOre;
+  return e.entryKind === "TIDSSPILLAN" ? tidsspillanFtaxForDate(iso) : timkostnadsnormFtaxForDate(iso);
+}
+
 async function hTime(ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimState): Promise<void> {
+  const rateOre = simTimeRateOre(m, e, iso);
   await ctx.c.timeEntry.create({
     matterId: m.id, date: iso, minutes: e.minutes, description: e.description,
-    billable: isBillable(e), userId: m.lawyerId, hourlyRate: m.arvodeRateOre, createdAt: iso,
+    billable: isBillable(e), userId: m.lawyerId, hourlyRate: rateOre,
+    ...(e.entryKind ? { kind: e.entryKind } : {}), createdAt: iso,
   });
   ctx.res.timeEntries++;
   if (isBillable(e)) {
-    const amountOre = Math.round((e.minutes / 60) * m.arvodeRateOre);
+    const amountOre = Math.round((e.minutes / 60) * rateOre);
     st.accruedNetOre += amountOre;
     st.periodLines.push({ date: iso.slice(0, 10), description: e.description, minutes: e.minutes, amountOre });
     await maybeAcconto(ctx, m, iso, st); // #885: skicka aconto när klientens andel nått tröskeln
@@ -91,7 +103,7 @@ async function hRadgivning(ctx: RunCtx, m: SimMatter, _e: Any, iso: string): Pro
   // går på aconto). Faktureras separat SAMMA DAG som mötet.
   await ctx.c.timeEntry.create({
     matterId: m.id, date: iso, minutes: 60, description: "Rådgivning — första möte med klient",
-    billable: true, userId: m.lawyerId, hourlyRate: m.arvodeRateOre, createdAt: iso,
+    billable: true, userId: m.lawyerId, hourlyRate: simTimeRateOre(m, {}, iso), createdAt: iso,
   });
   ctx.res.timeEntries++;
   await ctx.c.invoice.createRadgivning({ matterId: m.id, invoiceDate: iso });

--- a/tooling/demo-generator/simulate/scenarios/index.ts
+++ b/tooling/demo-generator/simulate/scenarios/index.ts
@@ -6,11 +6,15 @@ import type { Parties, SimEvent, SimMatter } from "../events";
 import { buildOffentligtScenario } from "./offentligt";
 import { buildPrivatScenario } from "./privat";
 import { buildRattshjalpScenario } from "./rattshjalp";
+import { buildRattshjalpArsskifteScenario } from "./rattshjalp-arsskifte";
 import { buildRattsskyddScenario } from "./rattsskydd";
 
 export function buildScenario(matter: SimMatter, parties: Parties, index: number): SimEvent[] {
   switch (matter.paymentMethod) {
-    case "RATTSHJALP": return buildRattshjalpScenario(parties);
+    // 2026-0020 spänner över ett årsskifte + tidsspillan + retroaktiv höjning (#891).
+    case "RATTSHJALP": return matter.matterNumber === "2026-0020"
+      ? buildRattshjalpArsskifteScenario(parties)
+      : buildRattshjalpScenario(parties);
     case "RATTSSKYDD": return buildRattsskyddScenario(parties);
     case "OFFENTLIGT_UPPDRAG": return buildOffentligtScenario(parties);
     default: return buildPrivatScenario(parties, index);

--- a/tooling/demo-generator/simulate/scenarios/rattshjalp-arsskifte.ts
+++ b/tooling/demo-generator/simulate/scenarios/rattshjalp-arsskifte.ts
@@ -1,0 +1,61 @@
+/**
+ * Scenariovariant för RÄTTSHJÄLP som spänner över ett ÅRSSKIFTE (#891, ärende
+ * 2026-0020). Ärendet börjar i november 2025 (timkostnadsnorm 1 602 kr, tidsspillan
+ * 1 450 kr) och sträcker sig fram till nu (2026, norm 1 626 kr). Vid slutregleringen
+ * får ärendet en RETROAKTIV HÖJNING: HELA ärendet räknas om på 2026 års normer
+ * (även 2025-timmarna), och skillnaden mot de aconton som ställdes ut på 2025-taxan
+ * regleras på slutfakturorna till klient + domstol.
+ *
+ * Behåller den varierande rättshjälpsavgiften (arbetslös 5 % → anställd 75 % →
+ * arbetslös 5 %, `rateChange`) OCH innehåller tidsspillan (egen, lägre norm).
+ * Dag 0 ≈ nov 2025; årsgränsen (31 dec 2025) infaller runt dag 60.
+ */
+
+import type { Parties, SimEvent } from "../events";
+
+export function buildRattshjalpArsskifteScenario(parties: Parties): SimEvent[] {
+  const ev: SimEvent[] = [
+    { kind: "note", dayOffset: 0, text: "Klientbesök nov 2025 — första möte. Rådgivning enligt rättshjälpstaxan (2025 års norm 1 602 kr)." },
+    { kind: "rateChange", dayOffset: 0, clientShareBips: 500 }, // klient arbetslös → 5 %
+    { kind: "radgivning", dayOffset: 0 },
+    { kind: "doc", dayOffset: 1, template: "fullmakt" },
+  ];
+  if (parties.klient) ev.push({ kind: "party", dayOffset: 0, contactId: parties.klient, role: "KLIENT" });
+  if (parties.motpart) ev.push({ kind: "party", dayOffset: 2, contactId: parties.motpart, role: "MOTPART" });
+  if (parties.motpartsombud) ev.push({ kind: "party", dayOffset: 2, contactId: parties.motpartsombud, role: "MOTPARTSOMBUD" });
+  if (parties.domstol) ev.push({ kind: "party", dayOffset: 2, contactId: parties.domstol, role: "DOMSTOL" });
+
+  ev.push(
+    { kind: "expense", dayOffset: 8, amountOre: 90_000, description: "Ansökningsavgift tingsrätten" },
+    // ── Period 1: arbetslös 5 %, HELA i 2025 (norm 1 602 / tidsspillan 1 450) ──
+    { kind: "time", dayOffset: 6, minutes: 240, description: "Genomgång av handlingar och underlag" },
+    { kind: "doc", dayOffset: 14, template: "svaromal" },
+    { kind: "note", dayOffset: 14, text: "Svaromål inkommet från motpartsombudet." },
+    { kind: "time", dayOffset: 16, minutes: 240, description: "Analys av svaromål och förhandlingsförberedelse" },
+    { kind: "time", dayOffset: 28, minutes: 180, description: "Restid och väntetid — sammanträde i Göteborg", entryKind: "TIDSSPILLAN" },
+    { kind: "time", dayOffset: 35, minutes: 240, description: "Utkast till inlaga och yttrande" },
+    { kind: "doc", dayOffset: 36, template: "inlaga" },
+    { kind: "time", dayOffset: 45, minutes: 240, description: "Korrespondens med motpartsombud" },
+    { kind: "time", dayOffset: 55, minutes: 240, description: "Fördjupad rättsutredning" }, // → aconto #1 (5 %, 2025-taxa)
+    // ── Årsskifte passeras (~dag 60) → 2026 års normer gäller nya poster ──
+    { kind: "note", dayOffset: 75, text: "Klienten har fått anställning — rättshjälpsavgiften höjs till 75 % (jan 2026)." },
+    { kind: "rateChange", dayOffset: 75, clientShareBips: 7500 },
+    // ── Period 2: anställd 75 %, 2026 (norm 1 626) ──
+    { kind: "time", dayOffset: 85, minutes: 150, description: "Sammanträde i tingsrätten" }, // → aconto #2 (75 %, 2026-taxa)
+    { kind: "note", dayOffset: 150, text: "Klienten åter arbetslös — avgiften tillbaka till 5 %." },
+    { kind: "rateChange", dayOffset: 150, clientShareBips: 500 },
+    // ── Period 3: arbetslös 5 %, 2026 ──
+    { kind: "time", dayOffset: 160, minutes: 240, description: "Uppföljning efter sammanträde" },
+    { kind: "time", dayOffset: 175, minutes: 120, description: "Restid — möte med klient och socialtjänst", entryKind: "TIDSSPILLAN" },
+    { kind: "time", dayOffset: 185, minutes: 240, description: "Komplettering och inlaga" },
+    { kind: "time", dayOffset: 200, minutes: 240, description: "Korrespondens och bevisgenomgång" },
+    { kind: "time", dayOffset: 215, minutes: 240, description: "Förberedelse inför slutförhandling" },
+    { kind: "time", dayOffset: 225, minutes: 240, description: "Slutlig genomgång av ärendet" }, // → aconto #3 (5 %, 2026-taxa)
+    // ── Kostnadsräkning → beslut → slutreglering (retroaktiv höjning till 2026 års norm) ──
+    { kind: "kostnadsrakning", dayOffset: 235 },
+    { kind: "doc", dayOffset: 236, template: "beslutRattshjalp" },
+    { kind: "beslut", dayOffset: 238 },
+    { kind: "settle", dayOffset: 245, payerRecipient: "DOMSTOL" },
+  );
+  return ev;
+}

--- a/tooling/scripts/seed-data.ts
+++ b/tooling/scripts/seed-data.ts
@@ -150,7 +150,7 @@ export const MATTERS: MatterSeed[] = [
   // satserna; rättshjälpsmyndighetens SLUTLIGA helhetsbeslut blev 5 % → klienten
   // överfakturerades (särskilt via 75 %-acontot) → kreditfaktura. clientShareBips =
   // det slutliga helhetsbeslutet (5 %). Egen tidslogg (nedan) → deterministiskt arvode.
-  { id: "m-020-rattshjalp-varierande", matterNumber: "2026-0020", title: "Vårdnadstvist — varierande rättshjälp Falk", status: "ACTIVE", matterType: "Familjerätt", paymentMethod: "RATTSHJALP", description: "Rättshjälp med varierande avgift (arbetslös 5 % → anställd 75 % → arbetslös 5 %). Myndighetens slutliga beslut: 5 % för hela ärendet.", klientId: "c-falk", motpartId: "c-bergman", domstolId: "c-tingsratten-sthlm", createdDaysAgo: 120, clientShareBips: 500, rattshjalpMaxTimmar: 100 },
+  { id: "m-020-rattshjalp-varierande", matterNumber: "2026-0020", title: "Vårdnadstvist — varierande rättshjälp Falk", status: "ACTIVE", matterType: "Familjerätt", paymentMethod: "RATTSHJALP", description: "Rättshjälp över ett årsskifte (start nov 2025, norm 1 602 kr → 2026 norm 1 626 kr) med varierande avgift (arbetslös 5 % → anställd 75 % → arbetslös 5 %) och tidsspillan. Vid slutregleringen räknas HELA ärendet om på 2026 års norm (retroaktiv höjning) — skillnaden regleras på slutfakturorna till klient + domstol. Myndighetens slutliga avgift: 5 %.", klientId: "c-falk", motpartId: "c-bergman", domstolId: "c-tingsratten-sthlm", createdDaysAgo: 255, clientShareBips: 500, rattshjalpMaxTimmar: 100 },
 ];
 
 // ASSIGN_USERS härleds inuti buildSeed() från de aktuella users — så ifall


### PR DESCRIPTION
## Vad
2026-0020 demonstrerar nu ett rättshjälpsärende **över ett årsskifte**: börjar nov 2025 (timkostnadsnorm **1 602 kr**, tidsspillan **1 450 kr**), sträcker sig till nu (2026 norm **1 626 kr**). Vid slutregleringen räknas **HELA ärendet om på 2026 års normer** (retroaktiv höjning) — även 2025-timmarna — och skillnaden mot de aconton som ställdes ut på 2025-taxan regleras på slutfakturorna till **klient + domstol**. Den varierande avgiften (5/75/5 %) finns kvar i samma ärende.

## Ändringar
- **`brottmalstaxa.ts`**: årsschema för timkostnadsnormen (2025 = 160 200, 2026 = 162 600) + egen tidsspillan-norm (2025 = 145 000, 2026 = 147 200*) + `timkostnadsnormFtaxForDate`/`tidsspillanFtaxForDate`.
- **Tidspost `kind`** (ARBETE/TIDSSPILLAN): zod + drizzle-kolumn + migration `0017` + `timeEntry.create`.
- **`billingRun.ts`**: `settlementArvodeNet` värderar arbete på timkostnadsnormen och tidsspillan på tidsspillan-normen, på **slutregleringsårets** normer (retroaktivt). KR-anspråket, slutregleringen och klientfakturans per-rad-värde följer normen per kategori.
- **Simulering**: datum-styrd ränta i `hTime`/`hRadgivning` (2025→1602, 2026→1626); årsöverspännande scenariovariant för 2026-0020 (`rattshjalp-arsskifte.ts`) med tidsspillan + 5/75/5; `SimMatter.matterNumber` styr dispatchern.
- **Seed**: 2026-0020 börjar nov 2025 (`createdDaysAgo: 255`).

\* 2026 tidsspillan-normen (1 472 kr) är en **uppskattning** — verifiera mot DVFS och justera konstanten vid behov.

## Verifierat
- `bun run quality:fast` grönt (typecheck + lint + 3247 tester) + `knip`/`deps:check`/`lint --max-warnings 0` rena.
- `build:demo`: 2026-0020 har tidsposter i **både 2025 och 2026**, tidsspillan på egen norm (145 000/147 200), aconton på tidpunktens taxa (2025-aconto daterat 2025-12-26), och **domstolsfakturans arvodesbas = alla timmar på 2026 års norm** (7 646 500 öre) — den retroaktiva höjningen. Slutfakturor till både KLIENT + DOMSTOL.

Closes #891

🤖 Generated with [Claude Code](https://claude.com/claude-code)