### PR TITLE
fix(billing): aconto-stavning, á-pris per rad på KR/faktura, korrekt Fakturerat (#893)

### DIFF
--- a/src/app/invoices/[id]/_client.tsx
+++ b/src/app/invoices/[id]/_client.tsx
@@ -174,6 +174,11 @@ function PrimarySpecCard({ inv }: { inv: Inv }) {
  *  renderad ur `settlementBreakdown` så den är IDENTISK med faktura-dokumentet. */
 function SettlementBreakdownCard({ view }: { view: SettlementView }) {
   const hours = (m: number) => (m / 60).toLocaleString("sv-SE", { maximumFractionDigits: 2 });
+  // Á-pris (#891): härlett per rad (belopp/timmar) — arbete och tidsspillan har olika
+  // taxor, så per-rad-priset visas i stället för en gemensam timkostnad.
+  const aPrisOre = (l: SettlementView["timeLines"][number]) => (l.minutes > 0 ? Math.round(l.amountOre / (l.minutes / 60)) : 0);
+  const totalMinutes = view.timeLines.reduce((s, l) => s + l.minutes, 0);
+  const totalAmount = view.timeLines.reduce((s, l) => s + l.amountOre, 0);
   return (
     <div className="bg-white rounded-lg border border-gray-200 p-6">
       <h2 className="font-semibold text-gray-900 mb-1">Specifikation</h2>
@@ -184,8 +189,9 @@ function SettlementBreakdownCard({ view }: { view: SettlementView }) {
             <tr className="text-left text-xs text-gray-500">
               <th className="py-1 font-normal">Datum</th>
               <th className="py-1 font-normal">Beskrivning</th>
-              <th className="py-1 font-normal text-right">Tid</th>
-              <th className="py-1 font-normal text-right">Belopp</th>
+              <th className="py-1 font-normal text-right">Á-pris</th>
+              <th className="py-1 font-normal text-right">Antal</th>
+              <th className="py-1 font-normal text-right">Totalt</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-100">
@@ -193,11 +199,20 @@ function SettlementBreakdownCard({ view }: { view: SettlementView }) {
               <tr key={i}>
                 <td className="py-1.5 whitespace-nowrap">{new Date(l.date).toLocaleDateString("sv-SE")}</td>
                 <td className="py-1.5">{l.description}</td>
+                <td className="py-1.5 text-right font-mono whitespace-nowrap">{formatCurrency(aPrisOre(l))}/h</td>
                 <td className="py-1.5 text-right whitespace-nowrap">{hours(l.minutes)} h</td>
                 <td className="py-1.5 text-right font-mono whitespace-nowrap">{formatCurrency(l.amountOre)}</td>
               </tr>
             ))}
           </tbody>
+          <tfoot>
+            <tr className="border-t border-gray-200 font-medium">
+              <td className="py-1.5" colSpan={2}>Summa</td>
+              <td></td>
+              <td className="py-1.5 text-right whitespace-nowrap">{hours(totalMinutes)} h</td>
+              <td className="py-1.5 text-right font-mono whitespace-nowrap">{formatCurrency(totalAmount)}</td>
+            </tr>
+          </tfoot>
         </table>
       )}
       <dl className="divide-y divide-gray-100">
@@ -294,7 +309,7 @@ const creditNoteOf = (inv: Inv): CreditRefView => inv.creditNote ?? null;
 const creditedInvoiceOf = (inv: Inv): CreditRefView => inv.creditedInvoice ?? null;
 
 function InvoiceHeader({ inv }: { inv: Inv }) {
-  const heading = inv.invoiceType === "ACCONTO" ? "Acconto-faktura"
+  const heading = inv.invoiceType === "ACCONTO" ? "Aconto-faktura"
     : inv.invoiceType === "FINAL" ? "Slutfaktura"
     : inv.invoiceType === "CREDIT" ? "Kreditfaktura"
     : "Faktura";
@@ -334,7 +349,7 @@ function SummaryGrid({
       <div><p className="text-xs text-gray-500">Belopp (brutto)</p><p><Money ore={inv.amount} basis="gross" className="font-mono" /></p></div>
       {inv.invoiceType === "FINAL" && (
         <>
-          <div><p className="text-xs text-gray-500">Accontoavdrag</p><p>−<Money ore={accontoDeductionTotal} basis="gross" className="font-mono" /></p></div>
+          <div><p className="text-xs text-gray-500">Acontoavdrag</p><p>−<Money ore={accontoDeductionTotal} basis="gross" className="font-mono" /></p></div>
           <div><p className="text-xs text-gray-500">Netto att betala</p><p><Money ore={netAmount} basis="gross" className="font-mono font-semibold" /></p></div>
         </>
       )}
@@ -451,7 +466,7 @@ function settlementRows(s: MatterSettlement): Array<{ label: string; ore: number
   ];
   if (s.prutningOre !== 0) rows.push({ label: "Prutning (domstol)", ore: s.prutningOre });
   rows.push({ label: "Brutto", ore: s.bruttoOre, strong: true });
-  if (s.accontoPaidOre !== 0) rows.push({ label: "Avgår betalda acconton", ore: -s.accontoPaidOre });
+  if (s.accontoPaidOre !== 0) rows.push({ label: "Avgår betalda aconton", ore: -s.accontoPaidOre });
   rows.push({ label: "Slutfaktura", ore: s.slutfakturaOre, strong: true });
   if (s.paymentsOre !== 0) rows.push({ label: "Avgår inbetalt", ore: -s.paymentsOre });
   if (s.radgivningOre !== 0) {
@@ -614,14 +629,14 @@ function SpecificationCard({ timeEntries, expenses }: { timeEntries: SpecTimeRow
 function AccontoDeductions({ deductions }: { deductions: AccontoDeductionRow[] }) {
   return (
     <div className="bg-white rounded-lg border border-gray-200 p-6">
-      <h2 className="font-semibold mb-3">Accontoavdrag</h2>
+      <h2 className="font-semibold mb-3">Acontoavdrag</h2>
       <table className="min-w-full text-sm">
         <tbody className="divide-y divide-gray-100">
           {deductions.map((d: AccontoDeductionRow) => d.accontoInvoice && (
             <tr key={d.id}>
               <td className="py-2">
                 <EntityLink route="invoices" id={d.accontoInvoice.id} className="text-blue-600 hover:underline">
-                  Acconto {new Date(d.accontoInvoice.invoiceDate).toLocaleDateString("sv-SE")}
+                  Aconto {new Date(d.accontoInvoice.invoiceDate).toLocaleDateString("sv-SE")}
                 </EntityLink>
               </td>
               <td className="py-2 text-right">−<Money ore={d.accontoInvoice.amount} basis="gross" className="font-mono" /></td>

--- a/src/app/invoices/page.tsx
+++ b/src/app/invoices/page.tsx
@@ -18,7 +18,7 @@ const STATUS_LABELS: Record<string, string> = {
 };
 const TYPE_LABELS: Record<string, string> = {
   STANDARD: "Faktura",
-  ACCONTO: "Acconto",
+  ACCONTO: "Aconto",
   FINAL: "Slutfaktura",
 };
 

--- a/src/lib/shared/kostnadsrakning-template.ts
+++ b/src/lib/shared/kostnadsrakning-template.ts
@@ -211,30 +211,27 @@ export const KOSTNADSRAKNING_ICKE_TAXA_DEFAULT_HTML = `<!DOCTYPE html>
     <tr>
       <th>Datum</th>
       <th>Beskrivning</th>
-      <th class="num">Tid</th>
+      <th class="num">Á-pris</th>
+      <th class="num">Antal</th>
+      <th class="num">Totalt (exkl moms)</th>
     </tr>
   </thead>
   <tbody>
     {{#each timeLines}}
     <tr>
       <td>{{date}}</td>
-      <td>{{description}}</td>
-      <td class="num">{{minutesFormatted}}</td>
+      <td>{{description}}{{#if isTidsspillan}} (tidsspillan){{/if}}</td>
+      <td class="num">{{rateFormatted}}</td>
+      <td class="num">{{hoursFormatted}}</td>
+      <td class="num">{{amountFormatted}}</td>
     </tr>
     {{/each}}
   </tbody>
   <tfoot>
     <tr>
-      <td colspan="2">Summa registrerad tid</td>
-      <td class="num">{{billableArbetsFormatted}}</td>
-    </tr>
-    <tr>
-      <td colspan="2">+ Huvudförhandling</td>
-      <td class="num">{{huvudforhandlingFormatted}}</td>
-    </tr>
-    <tr>
-      <td colspan="2"><strong>Total arbetstid</strong></td>
-      <td class="num"><strong>{{totalArbetsFormatted}}</strong></td>
+      <td colspan="3"><strong>Summa arbetstid</strong></td>
+      <td class="num"><strong>{{billableArbetsFormatted}}</strong></td>
+      <td class="num"><strong>{{arvodeExclFormatted}}</strong></td>
     </tr>
   </tfoot>
 </table>
@@ -242,11 +239,12 @@ export const KOSTNADSRAKNING_ICKE_TAXA_DEFAULT_HTML = `<!DOCTYPE html>
 
 <h2>Arvode — Timkostnadsnorm (icke-taxa)</h2>
 <div class="note">
-  Brottmålstaxan är inte tillämplig — ersättning enligt timkostnadsnorm
-  × faktiskt nedlagd tid (DVFS 2025:6 § 8 + RB 21:10).
+  Brottmålstaxan är inte tillämplig — ersättning enligt timkostnadsnorm för
+  arbete och tidsspillan-norm för tidsspillan (DVFS 2025:6 § 8 + RB 21:10).
+  Á-pris per rad ovan; olika taxor summeras inte till en gemensam timkostnad.
 </div>
 <div class="totalsRow">
-  <span>Arbetstid <strong>{{totalArbetsFormatted}}</strong> × timkostnadsnorm (1 626 kr/h)</span>
+  <span>Arvode exkl moms (enligt tidsspecifikationen)</span>
   <span class="num">{{arvodeExclFormatted}}</span>
 </div>
 <div class="totalsRow">

--- a/src/lib/shared/kostnadsrakning.ts
+++ b/src/lib/shared/kostnadsrakning.ts
@@ -17,7 +17,7 @@
  *   - `templateContext` — Handlebars-context (matchar default-mallen)
  */
 
-import { computeBrottmalstaxa, computeTimkostnadsnorm, type TaxaLevel, type TaxaResult } from "./brottmalstaxa";
+import { computeBrottmalstaxa, computeTimkostnadsnorm, TIMKOSTNADSNORM_NO_FTAX_ORE_PER_H, timkostnadsnormFtaxForDate, tidsspillanFtaxForDate, type TaxaLevel, type TaxaResult } from "./brottmalstaxa";
 import { RADGIVNING_MINUTES, radgivningTextRad } from "./rattshjalp";
 import { splitVat } from "./vat";
 
@@ -79,6 +79,8 @@ export interface TimeEntryInput {
   description: string;
   minutes: number;
   billable?: boolean;
+  /** ARBETE (default) eller TIDSSPILLAN — värderas på tidsspillan-normen (#891). */
+  kind?: "ARBETE" | "TIDSSPILLAN" | null;
 }
 
 export interface ExpenseLine {
@@ -96,6 +98,13 @@ export interface TimeLine {
   date: string;
   description: string;
   minutes: number;
+  /** Á-pris (öre/tim) raden värderas på (#891): arbete = timkostnadsnormen,
+   *  tidsspillan = tidsspillan-normen. 0 för taxa-ärenden (beloppet styrs av taxan). */
+  rateOrePerH: number;
+  /** Radens belopp exkl moms (öre) = minutes/60 × rateOrePerH. 0 för taxa-ärenden. */
+  amountOre: number;
+  /** TIDSSPILLAN → visas som tidsspillan-rad; annars arbete. */
+  isTidsspillan: boolean;
 }
 
 export interface KostnadsrakningResult {
@@ -130,7 +139,7 @@ function timkostnadsnormResult(totalArbetsMinutes: number, hasFTax: boolean): Ta
     intervalLabel: "Timkostnadsnorm",
     ersattningExclVat: tk.total,
     gransvardeExclVat: 0,
-    notes: [`Icke-taxa-ärende — timkostnadsnorm ${tk.rateOrePerH / 100} kr/h × ${(totalArbetsMinutes / 60).toFixed(2)} h (HUF + tidsregistreringar)`],
+    notes: ["Icke-taxa-ärende — ersättning enligt timkostnadsnorm (arbete) resp. tidsspillan-norm; á-pris per rad i tidsspecifikationen."],
   };
 }
 
@@ -248,12 +257,41 @@ function buildKrTemplateContext(a: KrTemplateArgs): Record<string, unknown> {
     timeLines: a.timeLines.map((t) => ({
       ...t,
       minutesFormatted: formatMinutes(t.minutes),
+      // Per rad (#891): antal (h), á-pris (kr/h) och totalt (kr). Tomt á-pris/totalt
+      // för taxa-ärenden (rateOrePerH = 0) → mallen visar bara tiden.
+      hoursFormatted: formatHoursDecimal(t.minutes),
+      rateFormatted: t.rateOrePerH > 0 ? `${formatOreAsKr(t.rateOrePerH)}/h` : "",
+      amountFormatted: t.rateOrePerH > 0 ? formatOreAsKr(t.amountOre) : "",
     })),
     billableArbetsMinutes: a.billableArbetsMinutes,
     billableArbetsFormatted: formatMinutes(a.billableArbetsMinutes),
     totalArbetsMinutes: a.totalArbetsMinutes,
     totalArbetsFormatted: formatMinutes(a.totalArbetsMinutes),
   };
+}
+
+/**
+ * Värdera tidsraderna per kategori (#891): icke-taxa → arbete på timkostnadsnormen
+ * och tidsspillan på tidsspillan-normen (vid KR-datumet `hufEnd`, retroaktivt), så
+ * olika taxor aldrig summeras till en gemensam timkostnad. Taxa-ärenden → rateOrePerH
+ * = 0 (raderna är informativa; beloppet styrs av taxan). Utbruten så
+ * `buildKostnadsrakningContext` håller komplexitet ≤ 8 (#199).
+ */
+function valuateTimeLines(entries: readonly TimeEntryInput[], input: BuildInput): { timeLines: TimeLine[]; arvodeNorm: number } {
+  const isTaxe = input.isTaxeArende ?? true;
+  const hasFTax = input.hasFTax ?? true;
+  const valDate = new Date(input.hufEnd);
+  const arvodeNorm = hasFTax ? timkostnadsnormFtaxForDate(valDate) : TIMKOSTNADSNORM_NO_FTAX_ORE_PER_H;
+  const tidsNorm = hasFTax ? tidsspillanFtaxForDate(valDate) : TIMKOSTNADSNORM_NO_FTAX_ORE_PER_H;
+  const timeLines = entries.map((t): TimeLine => {
+    const isTids = t.kind === "TIDSSPILLAN";
+    const rateOrePerH = isTaxe ? 0 : (isTids ? tidsNorm : arvodeNorm);
+    return {
+      id: t.id, date: toIsoDate(t.date), description: t.description, minutes: t.minutes,
+      rateOrePerH, amountOre: Math.round((t.minutes / 60) * rateOrePerH), isTidsspillan: isTids,
+    };
+  });
+  return { timeLines, arvodeNorm };
 }
 
 export function buildKostnadsrakningContext(input: BuildInput): KostnadsrakningResult {
@@ -270,9 +308,7 @@ export function buildKostnadsrakningContext(input: BuildInput): KostnadsrakningR
   const billableTimeEntries = input.matter.radgivningPaid
     ? carveEarliestMinutes(allBillable, RADGIVNING_MINUTES)
     : allBillable;
-  const timeLines: TimeLine[] = billableTimeEntries.map((t) => ({
-    id: t.id, date: toIsoDate(t.date), description: t.description, minutes: t.minutes,
-  }));
+  const { timeLines, arvodeNorm } = valuateTimeLines(billableTimeEntries, input);
   const billableArbetsMinutes = billableTimeEntries.reduce((s, t) => s + t.minutes, 0);
   const totalArbetsMinutes = billableArbetsMinutes + huvudforhandlingMinutes;
 
@@ -304,7 +340,13 @@ export function buildKostnadsrakningContext(input: BuildInput): KostnadsrakningR
     { exclVat: 0, vat: 0, inclVat: 0 },
   );
 
-  const arvodeExclVat = taxa.kind === "taxa-applies" ? taxa.ersattningExclVat : 0;
+  // Icke-taxa: arvodet = Σ per-rad-belopp (arbete + tidsspillan på sina normer) +
+  // ev. huvudförhandling (arbete-norm). Taxa-ärenden: taxans fasta belopp (#891).
+  const icketaxaArvode = timeLines.reduce((s, l) => s + l.amountOre, 0)
+    + Math.round((huvudforhandlingMinutes / 60) * arvodeNorm);
+  const arvodeExclVat = (input.isTaxeArende ?? true)
+    ? (taxa.kind === "taxa-applies" ? taxa.ersattningExclVat : 0)
+    : icketaxaArvode;
   const arvodeMoms = Math.round(arvodeExclVat * 0.25);
   const arvodeInclVat = arvodeExclVat + arvodeMoms;
   const totalInclVat = arvodeInclVat + expenseSummary.inclVat;
@@ -350,6 +392,11 @@ function toIsoDateTime(d: Date): string {
 
 function pad(n: number): string {
   return String(n).padStart(2, "0");
+}
+
+/** Minuter → decimaltimmar, "4,00 h" (antal-kolumnen i tidsspecifikationen, #891). */
+export function formatHoursDecimal(m: number): string {
+  return `${new Intl.NumberFormat("sv-SE", { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(m / 60)} h`;
 }
 
 export function formatMinutes(m: number): string {

--- a/src/lib/shared/schemas/enums.ts
+++ b/src/lib/shared/schemas/enums.ts
@@ -62,7 +62,7 @@ export type InvoiceStatus = z.infer<typeof invoiceStatusSchema>;
 
 export const INVOICE_TYPE_LABELS = {
   STANDARD: "Standard",
-  ACCONTO: "Acconto",
+  ACCONTO: "Aconto",
   FINAL: "Slutfaktura",
   CREDIT: "Kreditfaktura",
 } as const satisfies Record<string, string>;

--- a/test/integration/scenario-civilmal.test.ts
+++ b/test/integration/scenario-civilmal.test.ts
@@ -228,7 +228,7 @@ describe("Scenario: civilmål (bostadsrättstvist) på löpande räkning", () =>
   });
 
   // ─── 7. ACCONTO-faktura skickas ──────────────────────────────────
-  it("7. Acconto-faktura — 15 000 kr", async () => {
+  it("7. Aconto-faktura — 15 000 kr", async () => {
     const result = await state.caller.billingRun.createAcconto({
       matterId: state.matterId!,
       recipient: "KLIENT",

--- a/test/unit/app/invoices/[id]/page.test.tsx
+++ b/test/unit/app/invoices/[id]/page.test.tsx
@@ -125,7 +125,7 @@ describe("InvoiceDetailPage", () => {
     invoiceQuery.data = { ...baseInvoice, invoiceType: "ACCONTO" };
     renderPage();
     await waitFor(() =>
-      expect(screen.getByRole("heading", { name: /Acconto-faktura/i })).toBeInTheDocument(),
+      expect(screen.getByRole("heading", { name: /Aconto-faktura/i })).toBeInTheDocument(),
     );
   });
 
@@ -348,9 +348,9 @@ describe("InvoiceDetailPage", () => {
     };
     renderPage();
     await waitFor(() =>
-      expect(screen.getByRole("heading", { name: /Accontoavdrag/i })).toBeInTheDocument(),
+      expect(screen.getByRole("heading", { name: /Acontoavdrag/i })).toBeInTheDocument(),
     );
-    expect(screen.getByText(/Acconto 2026-03-01/)).toBeInTheDocument();
+    expect(screen.getByText(/Aconto 2026-03-01/)).toBeInTheDocument();
   });
 
   it("renderar PAID-status utan Registrera betalning-knapp", async () => {

--- a/test/unit/app/invoices/page.test.tsx
+++ b/test/unit/app/invoices/page.test.tsx
@@ -79,7 +79,7 @@ describe("InvoicesPage", () => {
     ];
     render(<InvoicesPage />);
     expect(screen.getByText("Faktura")).toBeInTheDocument();
-    expect(screen.getByText("Acconto")).toBeInTheDocument();
+    expect(screen.getByText("Aconto")).toBeInTheDocument();
     expect(screen.getByText("Betald")).toBeInTheDocument();
     expect(screen.getByText("Skickad")).toBeInTheDocument();
     expect(screen.getByText(/2026-0001 — Bodelning/)).toBeInTheDocument();

--- a/test/unit/lib/shared/kostnadsrakning-template-select.test.ts
+++ b/test/unit/lib/shared/kostnadsrakning-template-select.test.ts
@@ -40,10 +40,11 @@ describe("defaultTemplateFor", () => {
 });
 
 describe("icke-taxa-template ska visa tidsspecifikationen", () => {
-  it("innehåller timeLines-loop + summering med Total arbetstid", () => {
+  it("innehåller timeLines-loop + per-rad á-pris/antal/totalt + summering (#891)", () => {
     expect(KOSTNADSRAKNING_ICKE_TAXA_DEFAULT_HTML).toMatch(/{{#each timeLines}}/);
-    expect(KOSTNADSRAKNING_ICKE_TAXA_DEFAULT_HTML).toMatch(/Total arbetstid/);
-    expect(KOSTNADSRAKNING_ICKE_TAXA_DEFAULT_HTML).toMatch(/totalArbetsFormatted/);
+    expect(KOSTNADSRAKNING_ICKE_TAXA_DEFAULT_HTML).toMatch(/Summa arbetstid/);
+    expect(KOSTNADSRAKNING_ICKE_TAXA_DEFAULT_HTML).toMatch(/rateFormatted/);
+    expect(KOSTNADSRAKNING_ICKE_TAXA_DEFAULT_HTML).toMatch(/amountFormatted/);
   });
   it("innehåller INTE taxaIntervalLabel (det är taxa-only)", () => {
     expect(KOSTNADSRAKNING_ICKE_TAXA_DEFAULT_HTML).not.toMatch(/taxaIntervalLabel/);

--- a/test/unit/lib/shared/kostnadsrakning-tidsspillan.test.ts
+++ b/test/unit/lib/shared/kostnadsrakning-tidsspillan.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Kostnadsräkningens per-kategori-värdering (#891): arbete på timkostnadsnormen,
+ * tidsspillan på tidsspillan-normen — INTE "summa timmar × en taxa". Varje rad får
+ * á-pris + belopp; arvodet = summan av raderna.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { buildKostnadsrakningContext } from "@/lib/shared/kostnadsrakning";
+
+describe("kostnadsräkning per kategori (#891)", () => {
+  it("värderar arbete och tidsspillan på olika normer och summerar radvis", () => {
+    const res = buildKostnadsrakningContext({
+      matter: { matterNumber: "2026-0020", title: "Test", radgivningPaid: false },
+      defender: { name: "Adv" },
+      hufStart: "2026-05-01T09:00:00", hufEnd: "2026-05-01T09:00:00", // ingen HUF
+      isTaxeArende: false, hasFTax: true,
+      expenses: [],
+      timeEntries: [
+        { id: "t1", date: "2026-03-01", description: "Arbete", minutes: 60, billable: true, kind: "ARBETE" },
+        { id: "t2", date: "2026-03-02", description: "Restid", minutes: 60, billable: true, kind: "TIDSSPILLAN" },
+      ],
+    });
+    const lines = res.templateContext.timeLines as Array<{ rateOrePerH: number; amountOre: number; isTidsspillan: boolean }>;
+    const arbete = lines.find((l) => !l.isTidsspillan)!;
+    const tids = lines.find((l) => l.isTidsspillan)!;
+    expect(arbete.rateOrePerH).toBe(162_600); // 1 626 kr/h
+    expect(tids.rateOrePerH).toBe(147_200);   // 1 472 kr/h (egen, lägre norm)
+    // Arvodet = summan av raderna, INTE 2h × 1626.
+    expect(res.arvodeExclVat).toBe(162_600 + 147_200);
+    expect(res.arvodeExclVat).not.toBe(2 * 162_600);
+  });
+
+  it("2025-daterade poster värderas ändå på KR-datumets (2026) norm — retroaktivt", () => {
+    const res = buildKostnadsrakningContext({
+      matter: { matterNumber: "x", title: "T", radgivningPaid: false },
+      defender: { name: "A" },
+      hufStart: "2026-06-01T09:00:00", hufEnd: "2026-06-01T09:00:00",
+      isTaxeArende: false, hasFTax: true, expenses: [],
+      timeEntries: [{ id: "t1", date: "2025-11-15", description: "Arbete 2025", minutes: 60, billable: true, kind: "ARBETE" }],
+    });
+    expect(res.arvodeExclVat).toBe(162_600); // 2026 års norm, inte 2025 (160 200)
+  });
+});

--- a/test/unit/shared/kostnadsrakning.test.ts
+++ b/test/unit/shared/kostnadsrakning.test.ts
@@ -177,9 +177,11 @@ describe("buildKostnadsrakningContext — icke-taxa-ärende (timkostnadsnorm)", 
     expect(r.arvodeInclVat).toBe(829938);
   });
 
-  it("noten beskriver timkostnadsnorm-beräkningen", () => {
+  it("noten beskriver timkostnadsnorm-beräkningen (á-pris per rad, #891)", () => {
     expect(r.taxa.notes.join(" ")).toMatch(/Icke-taxa/i);
-    expect(r.taxa.notes.join(" ")).toMatch(/1626 kr\/h/);
+    expect(r.taxa.notes.join(" ")).toMatch(/timkostnadsnorm/i);
+    // Á-pris ligger per rad (arbete/tidsspillan olika taxor) — inte en enda kr/h i noten.
+    expect((r.templateContext.timeLines as Array<{ rateOrePerH: number }>).every((l) => l.rateOrePerH === 162_600)).toBe(true);
   });
 
   it("icke-taxa utan F-skatt → lägre timkostnadsnorm (1 237 kr\/h)", () => {
@@ -189,9 +191,9 @@ describe("buildKostnadsrakningContext — icke-taxa-ärende (timkostnadsnorm)", 
       hasFTax: false,
       timeEntries: [{ id: "t1", date: "2026-05-20", description: "Arbete", minutes: 60, billable: true }],
     });
-    // 60 + 95 = 155 min × 1237 kr/h
+    // 60 + 95 = 155 min × 1237 kr/h — per-rad-normen (arbete) är no-FTax-normen (#891).
     expect(noFtax.arvodeExclVat).toBe(Math.round((155 * 123700) / 60));
-    expect(noFtax.taxa.notes.join(" ")).toMatch(/1237 kr\/h/);
+    expect((noFtax.templateContext.timeLines as Array<{ rateOrePerH: number }>)[0]!.rateOrePerH).toBe(123_700);
   });
 });
 

--- a/tooling/demo-generator/populate-kostnadsrakning-docs.ts
+++ b/tooling/demo-generator/populate-kostnadsrakning-docs.ts
@@ -28,16 +28,28 @@ function escapeHtml(s: unknown): string {
   return String(s ?? "").replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" }[c] ?? c));
 }
 
-/** Tidsspecifikations-tabell (datum · åtgärd · tid + summa). Tom om inga rader. */
+/** Tidsspecifikations-tabell. Icke-taxa (#891): datum · åtgärd · á-pris · antal ·
+ *  totalt (arbete resp. tidsspillan på sin taxa) + summa (timmar + belopp, INGET
+ *  á-pris på summaraden). Taxa-ärenden: datum · åtgärd · tid (beloppet styrs av taxan). */
 function timeSpecHtml(tc: Any): string {
   const lines = (tc.timeLines as Any[]) ?? [];
   if (lines.length === 0) return "";
-  const rows = lines.map((l) => `<tr><td>${escapeHtml(l.date)}</td><td>${escapeHtml(l.description)}</td><td style="text-align:right">${escapeHtml(l.minutesFormatted)}</td></tr>`).join("");
+  const num = "text-align:right";
+  if (!tc.isTimkostnadsnorm) {
+    const rows = lines.map((l) => `<tr><td>${escapeHtml(l.date)}</td><td>${escapeHtml(l.description)}</td><td style="${num}">${escapeHtml(l.minutesFormatted)}</td></tr>`).join("");
+    return `<h2 style="font-size:15px;margin-top:1.5rem;margin-bottom:.25rem">Tidsspecifikation</h2>
+<table cellpadding="5" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:13px">
+<thead><tr style="border-bottom:1px solid #ccc;text-align:left"><th>Datum</th><th>Åtgärd</th><th style="${num}">Tid</th></tr></thead>
+<tbody>${rows}</tbody>
+<tfoot><tr style="border-top:1px solid #ccc"><td colspan="2" style="font-weight:bold">Summa arbetstid</td><td style="${num};font-weight:bold">${escapeHtml(tc.billableArbetsFormatted)}</td></tr></tfoot>
+</table>`;
+  }
+  const rows = lines.map((l) => `<tr><td>${escapeHtml(l.date)}</td><td>${escapeHtml(l.description)}${l.isTidsspillan ? " <span style=\"color:#888\">(tidsspillan)</span>" : ""}</td><td style="${num}">${escapeHtml(l.rateFormatted)}</td><td style="${num}">${escapeHtml(l.hoursFormatted)}</td><td style="${num}">${escapeHtml(l.amountFormatted)}</td></tr>`).join("");
   return `<h2 style="font-size:15px;margin-top:1.5rem;margin-bottom:.25rem">Tidsspecifikation</h2>
 <table cellpadding="5" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:13px">
-<thead><tr style="border-bottom:1px solid #ccc;text-align:left"><th>Datum</th><th>Åtgärd</th><th style="text-align:right">Tid</th></tr></thead>
+<thead><tr style="border-bottom:1px solid #ccc;text-align:left"><th>Datum</th><th>Åtgärd</th><th style="${num}">Á-pris</th><th style="${num}">Antal</th><th style="${num}">Totalt (exkl moms)</th></tr></thead>
 <tbody>${rows}</tbody>
-<tfoot><tr style="border-top:1px solid #ccc"><td colspan="2" style="font-weight:bold">Summa arbetstid</td><td style="text-align:right;font-weight:bold">${escapeHtml(tc.billableArbetsFormatted)}</td></tr></tfoot>
+<tfoot><tr style="border-top:1px solid #ccc"><td colspan="2" style="font-weight:bold">Summa</td><td></td><td style="${num};font-weight:bold">${escapeHtml(tc.billableArbetsFormatted)}</td><td style="${num};font-weight:bold">${escapeHtml(tc.arvodeExclFormatted)}</td></tr></tfoot>
 </table>`;
 }
 

--- a/tooling/demo-generator/simulate/runner.ts
+++ b/tooling/demo-generator/simulate/runner.ts
@@ -182,6 +182,11 @@ async function hSettle(ctx: RunCtx, m: SimMatter, e: Any, _iso: string): Promise
   const res = await ctx.c.billingRun.settleCoverage({ matterId: m.id, payerRecipient: e.payerRecipient });
   ctx.res.invoices += 2;
   if (res.creditInvoice) ctx.res.credits++;
+  // Slutfakturorna (klient + domstol) är utställda i demon → SENT, annars räknas de
+  // inte i "Fakturerat" (t.ex. domstolens slutfaktura blev kvar som DRAFT).
+  for (const inv of [res.clientInvoice, res.payerInvoice]) {
+    if (inv && inv.status !== "SENT") await ctx.c.invoice.setStatus({ invoiceId: inv.id, status: "SENT" });
+  }
 }
 
 async function hFinal(ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimState): Promise<void> {


### PR DESCRIPTION
## Tre fixar

**1. Stavning 'Acconto' → 'Aconto'** — `INVOICE_TYPE_LABELS`, fakturalistan och faktura-objekt-sidan (rubrik, avdrag, aconto-rader). `BILLING_RUN_TYPE_LABELS` var redan rätt.

**2. KR + faktura-objekt-sidan: á-pris/antal/totalt per rad + korrekt per-kategori-värdering.** Tidsspecifikationen innehåller både arbete (timkostnadsnorm) och tidsspillan (egen, lägre norm). KR-dokumentet summerade ALLA timmar och multiplicerade med EN taxa (47,5 h × 1 626 = **77 235 kr**, fel). Nu:
- `buildKostnadsrakningContext` värderar varje rad per kategori (arbete/tidsspillan) på KR-datumets norm (retroaktivt), arvode = Σ rader.
- KR-mallen (Handlebars) + demo-renderaren + `SettlementBreakdownCard` (faktura-objekt-sidan) visar **Á-pris · Antal · Totalt** per rad; summaraden summerar timmar + belopp men har **inget** á-pris.
- m-020 KR-arvode: 77 235 → **76 465 kr** = exakt billing-run-värdet.

**3. 'Fakturerat' för lågt (6 867,81 kr).** Domstolens slutfaktura blev kvar som DRAFT → exkluderad. Simuleringens `hSettle` SENT:ar nu både klient- och domstols-slutfakturan → **98 738,75 kr**.

## Verifierat
- `bun run quality:fast` (mina tester gröna), `lint --max-warnings 0`, `knip`, `deps:check` rena. (5 orelaterade helper-ui-nätverkstester faller lokalt på ren main också — miljö, ej mina ändringar; CI grön.)
- `build:demo`: KR visar á-pris 1 626 (arbete) / 1 472 (tidsspillan), arvode 76 465 kr; alla m-020-fakturor SENT, Fakturerat 98 738,75 kr.

Closes #893

🤖 Generated with [Claude Code](https://claude.com/claude-code)