### PR TITLE
feat(billing): kreditfaktura visar full spec + avdragna aconton (#895)

### DIFF
--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -634,19 +634,12 @@ function buildSettlementViews(b: SettlementBreakdown, method: PaymentMethod): { 
   return { clientView: buildClientView(b, isRattshjalp, feeTerm), payerView: buildPayerView(b, payerLabel, payerNoun, feeTerm) };
 }
 
-/** Kreditvy (#878): klienten har via aconton betalat mer än sin slutliga andel
- *  (myndighetens helhetsbeslut < de löpande aconto-satserna) → mellanskillnaden
- *  krediteras. Betalda aconton − slutlig andel = kreditering. */
-function buildCreditView(deductionOre: number, clientGrossOre: number, overpaidOre: number, feeTerm: string): SettlementView {
-  return {
-    timeLines: [],
-    rows: [
-      { label: "Betalda aconton (inkl moms)", amountOre: deductionOre, kind: "add" },
-      { label: `Avgår slutlig ${feeTerm} (inkl moms)`, amountOre: clientGrossOre, kind: "deduct" },
-    ],
-    totalLabel: "Kreditering till klienten (inkl moms)",
-    totalOre: overpaidOre,
-  };
+/** Kreditvy (#895): SAMMA fulla specifikation som klientens slutfaktura (tidsspec
+ *  med á-pris + rättshjälpsavgift-trappan + avdragna aconton, jfr domstolsvyn) — men
+ *  eftersom betalda aconton översteg klientens slutliga andel blir nettot NEGATIVT →
+ *  en kreditering. Återanvänder `clientView` och byter bara total-etikett + belopp. */
+function buildCreditView(clientView: SettlementView, creditNetOre: number): SettlementView {
+  return { ...clientView, totalLabel: "Kreditering till klienten (inkl moms)", totalOre: creditNetOre };
 }
 
 /**
@@ -671,7 +664,8 @@ async function createClientSettlementInvoice(repos: Repositories, ctx: EmitCtx, 
         ...base,
         // Kredit-moms = 25 %-andelen av det överbetalda bruttot (arvode dominerar).
         vatOre: -Math.round(overpaidOre - overpaidOre / 1.25),
-        settlementBreakdown: buildCreditView(a.deductionOre, a.clientGrossOre, overpaidOre, feeTerm),
+        // #895: full spec (tidsspec + rättshjälpsavgift + avdragna aconton) → kredit-netto.
+        settlementBreakdown: buildCreditView(a.clientView, clientNet),
         invoiceType: "CREDIT" as const, status: "SENT" as const,
         notes: `Rättshjälps-överfakturering: betalda aconton (${(a.deductionOre / 100).toLocaleString("sv-SE")} kr) översteg slutlig ${feeTerm} — mellanskillnaden krediteras klienten.`,
       }

--- a/test/scripts/demo-generator-invoice-docs.test.ts
+++ b/test/scripts/demo-generator-invoice-docs.test.ts
@@ -60,10 +60,12 @@ describe("populateInvoiceDocs", () => {
     await populate(target.caller, seed);
     await populateBilling(target.caller, seed);
     await populateInvoiceDocs(target.caller, (_p, b) => { htmls.push(new TextDecoder().decode(b)); return b.byteLength; });
-    // Kreditfakturan (varierande rättshjälp, m-020) renderar kredit-trappan — inte en tom vy.
+    // Kreditfakturan (varierande rättshjälp, m-020) renderar FULLA specifikationen
+    // (#895): upparbetat arvode + avdragna aconton → kredit-netto, inte en tom vy.
     const credit = htmls.find((h) => h.includes("Kreditfaktura") && h.includes("Kreditering till klienten"));
     expect(credit, "en kreditfaktura-doc ska genereras ur settlementBreakdown").toBeDefined();
-    expect(credit).toContain("Betalda aconton");
+    expect(credit).toContain("Upparbetat arvode");
+    expect(credit).toContain("Avgår aconto");
     // Aconto-fakturan renderar sin andels-nedbrytning.
     const acconto = htmls.find((h) => h.includes("Aconto-faktura") && h.includes("Klientens andel"));
     expect(acconto, "aconto-doc ska visa andels-nedbrytningen").toBeDefined();

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -588,7 +588,13 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
     expect(res.clientInvoice.invoiceType).toBe("CREDIT");
     expect(res.clientInvoice.amount).toBe(-29_675);      // negativ = kreditering
     expect(res.creditInvoice).toBe(res.clientInvoice);   // krediten ÄR klientfakturan
-    expect(res.clientInvoice.settlementBreakdown!.totalOre).toBe(29_675);
+    // #895: kreditfakturan visar FULLA specifikationen (tidsspec + avdragna aconton) →
+    // netto = kredit (negativt), inte den gamla minimala 2-rads-vyn.
+    const bd = res.clientInvoice.settlementBreakdown!;
+    expect(bd.totalOre).toBe(-29_675);
+    expect(bd.totalLabel).toMatch(/Kreditering/i);
+    expect(bd.timeLines.length).toBeGreaterThan(0);
+    expect(bd.rows.some((r) => /Avgår aconto/i.test(r.label))).toBe(true);
   });
 
   it("rättshjälp: aconton < slutlig rättshjälpsavgift → INGEN kreditfaktura", async () => {


### PR DESCRIPTION
## Vad
När klientens slutfaktura blir en **KREDIT** (betalda aconton översteg den slutliga rättshjälpsavgiften) visade den tidigare bara en minimal 2-rads-vy ("Betalda aconton" / "Avgår slutlig avgift"). Nu visar den **samma fulla specifikation som domstolsfakturan**:

- Tidsspecifikation per rad (á-pris · antal · totalt, arbete + tidsspillan).
- Upparbetat arvode → klientens rättshjälpsavgift (%) → moms → rättshjälpsavgift inkl moms → klientens utläggsandel.
- **Avgår aconto — faktura F-… (datum)** per aconto-faktura.
- Total → negativt netto → **Kreditering till klienten**.

## Hur
`buildCreditView` återanvänder nu klientens `clientView` (som redan bär tidsspec + trappa + aconto-avdrag) och byter bara total-etikett + belopp till kredit-nettot — i stället för en egen minimal vy.

## Verifierat
- `bun run quality:fast` grönt + `lint --max-warnings 0`/`knip`/`deps:check` rena.
- `build:demo`: m-020-krediten **F-2026-0041 (−3 466,51 kr)** visar **13 tidsspec-rader** + trappan + "Avgår aconto" för alla tre aconton (F-2026-0038/0039/0040), totaletikett "Kreditering till klienten (inkl moms)".

Closes #895

🤖 Generated with [Claude Code](https://claude.com/claude-code)