### PR TITLE
fix(billing): giltig rättshjälpsavgift (max 40%) + rådgivning på mötesdagens taxa (#897)

### DIFF
--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -134,12 +134,13 @@ export const invoiceRouter = router({
         // Rådgivningstimmen är en RIKTIG klientfaktura (STANDARD), inte ett aconto
         // (#853): ärendets första händelse, betalas direkt av klienten → skapas
         // SKICKAD. Brutto (inkl moms) som alla klientfakturor. Dras ALDRIG av.
-        const netOre = computeRadgivningsavgift({ ...omitUndefined({ hasFTax: input.hasFTax }) }).beloppExclVatOre;
+        // Datum = mötesdagen om angivet (#880: rådgivning faktureras samma dag som mötet), annars idag.
+        const when = input.invoiceDate ? new Date(input.invoiceDate) : new Date();
+        // Norm efter mötesdagen (#897): rådgivning i nov 2025 → 2025 års timkostnadsnorm.
+        const netOre = computeRadgivningsavgift({ ...omitUndefined({ hasFTax: input.hasFTax }), date: when }).beloppExclVatOre;
         const grossOre = arvodeInclVatOre(netOre);
         const vatOre = grossOre - netOre;
         const invoiceNumber = await repos.invoices.nextInvoiceNumber(ctx.orgId);
-        // Datum = mötesdagen om angivet (#880: rådgivning faktureras samma dag som mötet), annars idag.
-        const when = input.invoiceDate ? new Date(input.invoiceDate) : new Date();
         const invoice = await repos.invoices.create({
           matterId: input.matterId, invoiceNumber, ocrReference: ocrFromInvoiceNumber(invoiceNumber),
           amount: grossOre, vatOre, vatBreakdown: [{ kind: "arvode", vatRate: 2500, netOre, vatOre }],

--- a/src/lib/shared/rattshjalp.ts
+++ b/src/lib/shared/rattshjalp.ts
@@ -14,7 +14,7 @@
  * {@link computeTimkostnadsnorm} här i stället för en egen hårdkodad sats.
  */
 
-import { computeTimkostnadsnorm } from "@/lib/shared/brottmalstaxa";
+import { computeTimkostnadsnorm, timkostnadsnormFtaxForDate } from "@/lib/shared/brottmalstaxa";
 
 /** Rådgivning enligt rättshjälpslagen = 1 timme. */
 export const RADGIVNING_MINUTES = 60;
@@ -40,9 +40,14 @@ export interface Radgivningsavgift {
  * Rådgivningsavgiften för den klient-betalda rådgivningstimmen: 1 h enligt
  * timkostnadsnormen (F-skatt-justerad om advokaten saknar F-skatt).
  */
-export function computeRadgivningsavgift(opts: { hasFTax?: boolean } = {}): Radgivningsavgift {
-  const norm = computeTimkostnadsnorm({ arbetsMinutes: RADGIVNING_MINUTES, ...opts });
-  return { minutes: RADGIVNING_MINUTES, rateOrePerH: norm.rateOrePerH, beloppExclVatOre: norm.arbete };
+export function computeRadgivningsavgift(opts: { hasFTax?: boolean; date?: Date | string } = {}): Radgivningsavgift {
+  const hasFTax = opts.hasFTax ?? true;
+  // Rådgivningstimmen värderas på den timkostnadsnorm som gällde MÖTESDAGEN (#897):
+  // ett möte i nov 2025 debiteras 2025 års norm (1 602 kr), inte innevarande års.
+  const rateOrePerH = opts.date && hasFTax
+    ? timkostnadsnormFtaxForDate(opts.date)
+    : computeTimkostnadsnorm({ arbetsMinutes: RADGIVNING_MINUTES, hasFTax }).rateOrePerH;
+  return { minutes: RADGIVNING_MINUTES, rateOrePerH, beloppExclVatOre: Math.round((RADGIVNING_MINUTES / 60) * rateOrePerH) };
 }
 
 /**

--- a/test/scripts/simulate-runner.test.ts
+++ b/test/scripts/simulate-runner.test.ts
@@ -70,9 +70,9 @@ describe("runScenario (#880)", () => {
     const radTime = calls.find((x) => x.method === "timeEntry.create" && String(x.args.description).includes("Rådgivning"));
     expect(radTime?.args.date).toBe(rad.args.invoiceDate); // samma dag som mötet
 
-    // Tre aconton vid varierande satser (5/75/5 %), belopp härlett ur upparbetat.
+    // Tre aconton vid varierande satser (5/40/5 %), belopp härlett ur upparbetat.
     const accontos = calls.filter((x) => x.method === "billingRun.createAcconto");
-    expect(accontos.map((a) => a.args.clientShareBips)).toEqual([500, 7500, 500]);
+    expect(accontos.map((a) => a.args.clientShareBips)).toEqual([500, 4000, 500]);
     expect(accontos.every((a) => a.args.amountOre > 0)).toBe(true);
     // #885: aconto skickas FÖRST när klientens ackumulerade andel nått tröskeln
     // (default 150000 öre) — varje acontos klient-andel-rad ligger på/över den.

--- a/test/unit/lib/shared/timkostnadsnorm-schedule.test.ts
+++ b/test/unit/lib/shared/timkostnadsnorm-schedule.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, it, expect } from "vitest-compat";
 import { timkostnadsnormFtaxForDate, tidsspillanFtaxForDate } from "@/lib/shared/brottmalstaxa";
+import { computeRadgivningsavgift } from "@/lib/shared/rattshjalp";
 
 describe("timkostnadsnorm per år (#891)", () => {
   it("timkostnadsnormen följer året (2025 = 1 602 kr, 2026 = 1 626 kr)", () => {
@@ -19,5 +20,11 @@ describe("timkostnadsnorm per år (#891)", () => {
 
   it("okänt/framtida år faller tillbaka på senaste kända normen", () => {
     expect(timkostnadsnormFtaxForDate("2030-01-01")).toBe(162_600);
+  });
+
+  it("rådgivningsavgiften värderas på mötesdagens norm (#897)", () => {
+    // Möte nov 2025 → 2025 års norm (1 602 kr), inte innevarande års (1 626 kr).
+    expect(computeRadgivningsavgift({ date: "2025-11-03" }).beloppExclVatOre).toBe(160_200);
+    expect(computeRadgivningsavgift({ date: "2026-03-01" }).beloppExclVatOre).toBe(162_600);
   });
 });

--- a/tooling/demo-generator/populate-billing.ts
+++ b/tooling/demo-generator/populate-billing.ts
@@ -220,15 +220,15 @@ async function accontoVarying(ctx: Ctx, matterId: string, bips: number, amountOr
 
 /**
  * Rättshjälp med TIDSVARIERANDE avgift → kreditfaktura (#878). Hela förfarandet:
- * rådgivning → 3 aconton vid löpande satser (5 % / 75 % / 5 %) → kostnadsräkning till
+ * rådgivning → 3 aconton vid löpande satser (5 % / 40 % / 5 %) → kostnadsräkning till
  * domstol → myndighetens SLUTLIGA helhetsbeslut (5 %) via settlement → klienten har
- * överfakturerats (särskilt 75 %-acontot) → `settleCoverage` skapar en KREDITfaktura.
+ * överfakturerats (särskilt 40 %-acontot) → `settleCoverage` skapar en KREDITfaktura.
  */
 async function runRattshjalpVaryingRate(ctx: Ctx, matterId: string): Promise<void> {
   await ctx.c.invoice.createRadgivning({ matterId });
   ctx.res.invoices++;
   await accontoVarying(ctx, matterId, 500, 30_000, 105);   // period 1: arbetslös, 5 %
-  await accontoVarying(ctx, matterId, 7500, 600_000, 55);  // period 2: anställd, 75 % (överfakturerar)
+  await accontoVarying(ctx, matterId, 4000, 600_000, 55);  // period 2: anställd, 40 % (överfakturerar)
   await accontoVarying(ctx, matterId, 500, 30_000, 20);    // period 3: åter arbetslös, 5 %
   const kr = await ctx.c.billingRun.createKostnadsrakning({ matterId, notes: "Kostnadsräkning till domstol (rättshjälp, varierande avgift)" });
   ctx.res.kostnadsrakningPending++;

--- a/tooling/demo-generator/simulate/scenarios/rattshjalp-arsskifte.ts
+++ b/tooling/demo-generator/simulate/scenarios/rattshjalp-arsskifte.ts
@@ -6,7 +6,7 @@
  * (även 2025-timmarna), och skillnaden mot de aconton som ställdes ut på 2025-taxan
  * regleras på slutfakturorna till klient + domstol.
  *
- * Behåller den varierande rättshjälpsavgiften (arbetslös 5 % → anställd 75 % →
+ * Behåller den varierande rättshjälpsavgiften (arbetslös 5 % → anställd 40 % →
  * arbetslös 5 %, `rateChange`) OCH innehåller tidsspillan (egen, lägre norm).
  * Dag 0 ≈ nov 2025; årsgränsen (31 dec 2025) infaller runt dag 60.
  */
@@ -38,10 +38,10 @@ export function buildRattshjalpArsskifteScenario(parties: Parties): SimEvent[] {
     { kind: "time", dayOffset: 45, minutes: 240, description: "Korrespondens med motpartsombud" },
     { kind: "time", dayOffset: 55, minutes: 240, description: "Fördjupad rättsutredning" }, // → aconto #1 (5 %, 2025-taxa)
     // ── Årsskifte passeras (~dag 60) → 2026 års normer gäller nya poster ──
-    { kind: "note", dayOffset: 75, text: "Klienten har fått anställning — rättshjälpsavgiften höjs till 75 % (jan 2026)." },
-    { kind: "rateChange", dayOffset: 75, clientShareBips: 7500 },
-    // ── Period 2: anställd 75 %, 2026 (norm 1 626) ──
-    { kind: "time", dayOffset: 85, minutes: 150, description: "Sammanträde i tingsrätten" }, // → aconto #2 (75 %, 2026-taxa)
+    { kind: "note", dayOffset: 75, text: "Klienten har fått anställning — rättshjälpsavgiften höjs till 40 % (jan 2026)." },
+    { kind: "rateChange", dayOffset: 75, clientShareBips: 4000 },
+    // ── Period 2: anställd 40 %, 2026 (norm 1 626) ──
+    { kind: "time", dayOffset: 85, minutes: 150, description: "Sammanträde i tingsrätten" }, // → aconto #2 (40 %, 2026-taxa)
     { kind: "note", dayOffset: 150, text: "Klienten åter arbetslös — avgiften tillbaka till 5 %." },
     { kind: "rateChange", dayOffset: 150, clientShareBips: 500 },
     // ── Period 3: arbetslös 5 %, 2026 ──

--- a/tooling/demo-generator/simulate/scenarios/rattshjalp.ts
+++ b/tooling/demo-generator/simulate/scenarios/rattshjalp.ts
@@ -1,10 +1,10 @@
 /**
  * Scenariomall för RÄTTSHJÄLP (#880/#885) — kronologisk narrativ med VARIERANDE
- * självrisk-avgift (arbetslös 5 % → anställd 75 % → arbetslös 5 %). Aconto skickas
+ * självrisk-avgift (arbetslös 5 % → anställd 40 % → arbetslös 5 %). Aconto skickas
  * INTE på skriptade dagar utan TRÖSKELSTYRT (#885): runnern ackumulerar klientens
  * andel vid aktuell sats och fyr ett aconto FÖRST när den nått byråns gränsbelopp
  * (default 1500 kr). Satsbyten sker via `rateChange`; arbetsvolymen per period är
- * tilltagen så var period hinner passera tröskeln → de tre aconton (5/75/5 %) syns.
+ * tilltagen så var period hinner passera tröskeln → de tre aconton (5/40/5 %) syns.
  * Avslutas med kostnadsräkning → beslut → slutreglering (→ kredit vid överfakturering).
  */
 
@@ -38,11 +38,11 @@ export function buildRattshjalpScenario(parties: Parties): SimEvent[] {
     { kind: "doc", dayOffset: 23, template: "inlaga" },
     { kind: "time", dayOffset: 30, minutes: 240, description: "Korrespondens med motpartsombud" },
     { kind: "time", dayOffset: 38, minutes: 240, description: "Fördjupad rättsutredning" }, // → aconto #1 (5 %)
-    { kind: "note", dayOffset: 45, text: "Klienten har fått anställning — rättshjälpsavgiften höjs till 75 %." },
-    // Period 2 (anställd, 75 %) — en insats räcker för att passera tröskeln (överfakturerar
+    { kind: "note", dayOffset: 45, text: "Klienten har fått anställning — rättshjälpsavgiften höjs till 40 %." },
+    // Period 2 (anställd, 40 %) — en insats räcker för att passera tröskeln (överfakturerar
     // mot slutligt beslut → kredit vid slutreglering).
-    { kind: "rateChange", dayOffset: 45, clientShareBips: 7500 },
-    { kind: "time", dayOffset: 50, minutes: 150, description: "Sammanträde i tingsrätten" }, // → aconto #2 (75 %)
+    { kind: "rateChange", dayOffset: 45, clientShareBips: 4000 },
+    { kind: "time", dayOffset: 50, minutes: 150, description: "Sammanträde i tingsrätten" }, // → aconto #2 (40 %)
     { kind: "note", dayOffset: 85, text: "Klienten åter arbetslös — avgiften tillbaka till 5 %." },
     // Period 3 (arbetslös, 5 %) — löpande arbete tills tröskeln nås igen.
     { kind: "rateChange", dayOffset: 85, clientShareBips: 500 },

--- a/tooling/scripts/seed-data.ts
+++ b/tooling/scripts/seed-data.ts
@@ -146,11 +146,11 @@ export const MATTERS: MatterSeed[] = [
   { id: "m-017-brottmal-omf", matterNumber: "2026-0017", title: "Brottmål — omfattande utredning Davidsson", status: "ACTIVE", matterType: "Brottmål", paymentMethod: "OFFENTLIGT_UPPDRAG", description: "Frångångstaxa pga väsentligt mer arbete (komplex bevisning).", klientId: "c-davidsson", domstolId: "c-hovratten-svea", createdDaysAgo: 35, isTaxeArende: false },
   { id: "m-018-brottmal-ekobrott", matterNumber: "2026-0018", title: "Brottmål — ekobrott Carlsson", status: "ACTIVE", matterType: "Brottmål", paymentMethod: "OFFENTLIGT_UPPDRAG", description: "Misstanke om grovt bokföringsbrott. Omfattande material — kostnadsräkning skickas till domstol istället för enligt taxa.", klientId: "c-carlsson", domstolId: "c-tingsratten-sthlm", createdDaysAgo: 28, isTaxeArende: false },
   // Rättshjälp med TIDSVARIERANDE avgift (#878): klienten var arbetslös (5 %), fick
-  // jobb (75 %) och blev arbetslös igen (5 %). Aconton ställdes ut vid de löpande
+  // jobb (40 %) och blev arbetslös igen (5 %). Aconton ställdes ut vid de löpande
   // satserna; rättshjälpsmyndighetens SLUTLIGA helhetsbeslut blev 5 % → klienten
-  // överfakturerades (särskilt via 75 %-acontot) → kreditfaktura. clientShareBips =
+  // överfakturerades (särskilt via 40 %-acontot) → kreditfaktura. clientShareBips =
   // det slutliga helhetsbeslutet (5 %). Egen tidslogg (nedan) → deterministiskt arvode.
-  { id: "m-020-rattshjalp-varierande", matterNumber: "2026-0020", title: "Vårdnadstvist — varierande rättshjälp Falk", status: "ACTIVE", matterType: "Familjerätt", paymentMethod: "RATTSHJALP", description: "Rättshjälp över ett årsskifte (start nov 2025, norm 1 602 kr → 2026 norm 1 626 kr) med varierande avgift (arbetslös 5 % → anställd 75 % → arbetslös 5 %) och tidsspillan. Vid slutregleringen räknas HELA ärendet om på 2026 års norm (retroaktiv höjning) — skillnaden regleras på slutfakturorna till klient + domstol. Myndighetens slutliga avgift: 5 %.", klientId: "c-falk", motpartId: "c-bergman", domstolId: "c-tingsratten-sthlm", createdDaysAgo: 255, clientShareBips: 500, rattshjalpMaxTimmar: 100 },
+  { id: "m-020-rattshjalp-varierande", matterNumber: "2026-0020", title: "Vårdnadstvist — varierande rättshjälp Falk", status: "ACTIVE", matterType: "Familjerätt", paymentMethod: "RATTSHJALP", description: "Rättshjälp över ett årsskifte (start nov 2025, norm 1 602 kr → 2026 norm 1 626 kr) med varierande avgift (arbetslös 5 % → anställd 40 % → arbetslös 5 %) och tidsspillan. Vid slutregleringen räknas HELA ärendet om på 2026 års norm (retroaktiv höjning) — skillnaden regleras på slutfakturorna till klient + domstol. Myndighetens slutliga avgift: 5 %.", klientId: "c-falk", motpartId: "c-bergman", domstolId: "c-tingsratten-sthlm", createdDaysAgo: 255, clientShareBips: 500, rattshjalpMaxTimmar: 100 },
 ];
 
 // ASSIGN_USERS härleds inuti buildSeed() från de aktuella users — så ifall
@@ -409,7 +409,7 @@ function appendVaryingRattshjalpTimeEntries(out: SeedDataset["timeEntries"], org
     { daysAgo: 118, minutes: 60, description: "Första möte med klient i ärendet" }, // rådgivningstimmen — FÖRST
     { daysAgo: 100, minutes: 90, description: "Genomgång av handlingar (klient arbetslös, 5 % avgift)" },
     { daysAgo: 70, minutes: 120, description: "Förhandlingsförberedelse och inlaga" },
-    { daysAgo: 55, minutes: 90, description: "Klientmöte (klient fått anställning, 75 % avgift)" },
+    { daysAgo: 55, minutes: 90, description: "Klientmöte (klient fått anställning, 40 % avgift)" },
     { daysAgo: 40, minutes: 120, description: "Sammanträde i tingsrätten" },
     { daysAgo: 20, minutes: 90, description: "Uppföljning och korrespondens (klient åter arbetslös, 5 %)" },
     { daysAgo: 8, minutes: 60, description: "Slutförberedelse inför avgörande" },


### PR DESCRIPTION
## Två fel i 2026-0020

**1. 75 % är ingen giltig rättshjälpsavgift.** Enligt [rättshjälpslag (1996:1619) 23 §](https://lagen.nu/1996:1619#P23) är avgiftsnivåerna **2 / 5 / 10 / 20 / 30 / 40 %** (efter ekonomiskt underlag) — **max 40 %**. Scenariot använde 75 %. Bytt till högsta tillåtna **40 %** i båda rättshjälps-scenarierna (varierande + årsskifte) samt legacy `populate-billing`. 2026-0020 behåller slutlig avgift **5 %** så slutregleringen ger **domstolsfaktura + kreditfaktura** till klienten.

**2. Rådgivningstimmen (skickad nov 2025) debiterades på 2026 års timkostnadsnorm** (1 626 kr) i stället för 2025 års (1 602 kr) — `computeRadgivningsavgift` använde den flata konstanten oavsett datum. Den tar nu ett `date` och slår upp normen för mötesdagen; `createRadgivning` skickar mötesdagen. (Aconton var redan datum-korrekta.)

## Verifierat
- `bun run quality:fast` + `lint --max-warnings 0` / `knip` / `deps:check` rena.
- `build:demo` (2026-0020): rådgivning **2025-11-03 = 2 002,50 kr** (2025-taxa), aconto-satser **40 / 5 / 5 %** (inga 75 %), **domstolsfaktura 91 870,94 kr + kreditfaktura −1 688,07 kr**.

Closes #897

🤖 Generated with [Claude Code](https://claude.com/claude-code)