### PR TITLE
feat(billing): rättsskydd-först-flödet + positivt besked med självrisk-golv (#899)

### DIFF
--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -125,6 +125,8 @@ export const matters = pgTable("matters", {
   clientShareBips: integer("client_share_bips"),
   /** Rättsskyddets maxbelopp (öre) resp. rättshjälpens timtak — täcknings-tak (#793). */
   rattsskyddMaxOre: integer("rattsskydd_max_ore"),
+  /** Rättsskyddets lägsta självrisk (öre) — "dock lägst 1 800 kr" (#899). */
+  rattsskyddSjalvriskMinOre: integer("rattsskydd_sjalvrisk_min_ore"),
   rattshjalpMaxTimmar: integer("rattshjalp_max_timmar"),
   /** Rättsskydd (#810): tvistdatum (arbete före = ej täckt) + bolagets beslutsdatum (retro ≤6h). */
   tvistUppkomDatum: timestamp("tvist_uppkom_datum", { withTimezone: true }),

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -103,6 +103,7 @@ interface RattsskyddMatter {
   tvistUppkomDatum?: Date | string | null | undefined;
   rattsskyddBeslutDatum?: Date | string | null | undefined;
   rattsskyddMaxOre?: number | null | undefined;
+  rattsskyddSjalvriskMinOre?: number | null | undefined;
 }
 
 /**
@@ -120,6 +121,7 @@ function rattsskyddCoverage(
   return omitUndefined({
     coveredOre: Math.round((p.coveredMinutes / 60) * rateOre),
     capOre: matter.rattsskyddMaxOre ?? undefined,
+    minSjalvriskOre: matter.rattsskyddSjalvriskMinOre ?? undefined,
   });
 }
 

--- a/src/lib/server/routers/matter.ts
+++ b/src/lib/server/routers/matter.ts
@@ -59,6 +59,9 @@ const matterCreateInput = z.object({
   clientShareBips: z.number().int().min(0).max(10000).nullable().optional(),
   /** Rättshjälpens timtak (rättshjälpslagen: 100 tim). */
   rattshjalpMaxTimmar: z.number().int().positive().nullable().optional(),
+  /** Rättsskyddets tak (öre) + lägsta självrisk (öre) — ur försäkringsbeslutet (#899). */
+  rattsskyddMaxOre: z.number().int().nonnegative().nullable().optional(),
+  rattsskyddSjalvriskMinOre: z.number().int().nonnegative().nullable().optional(),
   /** Ansvarig advokat/biträdande jurist (#174) — styr ärendenummerserien. */
   responsibleLawyerId: userIdSchema.optional(),
   /** Domstolens målnummer (#173) — matchningsnyckel för domstolsbetalningar. */
@@ -149,6 +152,8 @@ function buildMatterData(
     taxaHasFTax: input.taxaHasFTax,
     clientShareBips: input.clientShareBips,
     rattshjalpMaxTimmar: input.rattshjalpMaxTimmar,
+    rattsskyddMaxOre: input.rattsskyddMaxOre,
+    rattsskyddSjalvriskMinOre: input.rattsskyddSjalvriskMinOre,
     createdAt: input.createdAt ? new Date(input.createdAt) : undefined,
   };
   const data: Record<string, unknown> = {

--- a/src/lib/shared/coverage-billing.ts
+++ b/src/lib/shared/coverage-billing.ts
@@ -43,6 +43,9 @@ export interface CoverageSplitInput {
   /** Rättsskydd: försäkringens maxbelopp (öre, ur beslutet). Försäkringen betalar
    *  högst detta; överskott → klienten. Saknas → inget tak. */
   capOre?: number | null;
+  /** Rättsskydd: lägsta självrisk (öre) — "dock lägst 1 800 kr" (#899). Klientens
+   *  självrisk = max(detta, andel% × täckt). Saknas → 0. */
+  minSjalvriskOre?: number | null;
 }
 
 export interface CoverageSplit {
@@ -82,7 +85,9 @@ export function computeCoverageSplit(input: CoverageSplitInput): CoverageSplit {
  */
 function rattsskyddSplit(total: number, input: CoverageSplitInput): CoverageSplit {
   const covered = Math.max(0, Math.min(input.coveredOre ?? total, total));
-  const sjalvrisk = shareOf(covered, input.clientShareBips);
+  // Självrisk = andel% × täckt, dock LÄGST beslutets golv-belopp (#899), men aldrig
+  // mer än den täckta delen (annars skulle försäkringen betala negativt).
+  const sjalvrisk = Math.min(covered, Math.max(input.minSjalvriskOre ?? 0, shareOf(covered, input.clientShareBips)));
   const prutning = Math.max(0, input.insurerPrutningOre ?? 0);
   const insurerRaw = Math.max(0, covered - sjalvrisk - prutning);
   const overCap = input.capOre != null ? Math.max(0, insurerRaw - input.capOre) : 0;

--- a/src/lib/shared/schemas/matter.ts
+++ b/src/lib/shared/schemas/matter.ts
@@ -44,6 +44,12 @@ export const matterSchema = z.object({
    */
   rattsskyddMaxOre: z.number().int().nonnegative().nullish(),
   /**
+   * Rättsskydd: lägsta självrisk i öre (#899). Försäkringsbeslutet anger ofta
+   * "självrisk 20 %, dock lägst 1 800 kr" → klientens självrisk = max(detta belopp,
+   * andel% × täckt arvode). Null = ingen golv-självrisk.
+   */
+  rattsskyddSjalvriskMinOre: z.number().int().nonnegative().nullish(),
+  /**
    * Rättshjälpens timtak (rättshjälpslagen: 100 tim, kan utökas). Null = ej satt;
    * UI defaultar 100 för rättshjälpsärenden. Vid ≥90 % flaggas ärendet (#793).
    */

--- a/test/unit/lib/shared/coverage-billing.test.ts
+++ b/test/unit/lib/shared/coverage-billing.test.ts
@@ -27,6 +27,19 @@ describe("computeCoverageSplit — rättsskydd (försäkring prutar)", () => {
     expect(r.clientOre).toBe(10_000_000);
     expect(r.payerOre).toBe(0);
   });
+
+  it("golv-självrisk (#899): 'lägst 1 800 kr' slår in när 20 % är lägre", () => {
+    // Arvode 6 504 kr → 20 % = 1 300,80 kr < 1 800 kr → självrisk = 1 800 kr (golvet).
+    const r = computeCoverageSplit({ method: "RATTSSKYDD", totalOre: 650_400, clientShareBips: 2000, minSjalvriskOre: 180_000 });
+    expect(r.clientOre).toBe(180_000);          // golvet 1 800 kr
+    expect(r.payerOre).toBe(650_400 - 180_000); // försäkringen resten
+  });
+
+  it("golv-självrisk påverkar inte när 20 % redan överstiger golvet", () => {
+    // Arvode 100 000 kr → 20 % = 20 000 kr > 1 800 kr → självrisk = 20 000 kr.
+    const r = computeCoverageSplit({ method: "RATTSSKYDD", totalOre: 10_000_000, clientShareBips: 2000, minSjalvriskOre: 180_000 });
+    expect(r.clientOre).toBe(2_000_000);
+  });
 });
 
 describe("computeCoverageSplit — rättshjälp (domstol prutar)", () => {

--- a/tooling/db/migrations/0018_rattsskydd_sjalvrisk_min.sql
+++ b/tooling/db/migrations/0018_rattsskydd_sjalvrisk_min.sql
@@ -1,0 +1,3 @@
+-- #899: rättsskyddets lägsta självrisk (öre) — försäkringsbeslut anger ofta
+-- "självrisk 20 %, dock lägst 1 800 kr". NULL = ingen golv-självrisk.
+ALTER TABLE matters ADD COLUMN IF NOT EXISTS rattsskydd_sjalvrisk_min_ore integer;

--- a/tooling/demo-generator/populate.ts
+++ b/tooling/demo-generator/populate.ts
@@ -79,7 +79,7 @@ async function createContacts(c: AnyCaller, rows: Row[]): Promise<void> {
 async function createMatters(c: AnyCaller, rows: Row[]): Promise<void> {
   for (const m of rows) {
     await c.matter.create(
-      defined({ id: m.id, matterNumber: m.matterNumber, title: m.title, description: m.description, matterType: m.matterType, status: m.status, paymentMethod: m.paymentMethod, paymentMethodNote: m.paymentMethodNote, paymentMethodDecidedAt: isoOrUndef(m.paymentMethodDecidedAt), isTaxeArende: m.isTaxeArende, taxaLevel: m.taxaLevel, taxaHuvudforhandlingMin: m.taxaHuvudforhandlingMin, taxaHasFTax: m.taxaHasFTax, clientShareBips: m.clientShareBips, rattshjalpMaxTimmar: m.rattshjalpMaxTimmar, createdAt: isoOrUndef(m.createdAt) }),
+      defined({ id: m.id, matterNumber: m.matterNumber, title: m.title, description: m.description, matterType: m.matterType, status: m.status, paymentMethod: m.paymentMethod, paymentMethodNote: m.paymentMethodNote, paymentMethodDecidedAt: isoOrUndef(m.paymentMethodDecidedAt), isTaxeArende: m.isTaxeArende, taxaLevel: m.taxaLevel, taxaHuvudforhandlingMin: m.taxaHuvudforhandlingMin, taxaHasFTax: m.taxaHasFTax, clientShareBips: m.clientShareBips, rattshjalpMaxTimmar: m.rattshjalpMaxTimmar, rattsskyddMaxOre: m.rattsskyddMaxOre, rattsskyddSjalvriskMinOre: m.rattsskyddSjalvriskMinOre, createdAt: isoOrUndef(m.createdAt) }),
     );
   }
 }

--- a/tooling/demo-generator/simulate/fake-content.ts
+++ b/tooling/demo-generator/simulate/fake-content.ts
@@ -49,4 +49,16 @@ export const DOC_TEMPLATES: Record<string, DocTemplate> = {
     documentType: "Beslut", direction: "INKOMMANDE",
     title: "Beslut om rättshjälp", summary: "Rättshjälpsmyndighetens beslut om rättshjälpsavgiftens procentsats för ärendet.",
   },
+  rattsskyddsansokan: {
+    documentType: "Ansökan", direction: "UTGAENDE",
+    title: "Ansökan om rättsskydd", summary: "Begäran till försäkringsbolaget om att rättsskyddet i hemförsäkringen ska tas i anspråk för tvisten.",
+  },
+  rattsskyddAvslag: {
+    documentType: "Beslut", direction: "INKOMMANDE",
+    title: "Avslag på rättsskydd", summary: "Försäkringsbolaget avslår rättsskydd — tvist anses ännu inte ha uppkommit. Ärendet drivs istället med rättshjälp.",
+  },
+  rattsskyddBeslutPositivt: {
+    documentType: "Beslut", direction: "INKOMMANDE",
+    title: "Beslut om rättsskydd", summary: "Försäkringsbolaget beviljar rättsskydd: ersätter högst 100 timmar arvode till eget ombud. Från ersättningen avräknas självrisk 20 %, dock lägst 1 800 kr.",
+  },
 };

--- a/tooling/demo-generator/simulate/scenarios/index.ts
+++ b/tooling/demo-generator/simulate/scenarios/index.ts
@@ -8,6 +8,7 @@ import { buildPrivatScenario } from "./privat";
 import { buildRattshjalpScenario } from "./rattshjalp";
 import { buildRattshjalpArsskifteScenario } from "./rattshjalp-arsskifte";
 import { buildRattsskyddScenario } from "./rattsskydd";
+import { buildRattsskyddPositivtScenario } from "./rattsskydd-positivt";
 
 export function buildScenario(matter: SimMatter, parties: Parties, index: number): SimEvent[] {
   switch (matter.paymentMethod) {
@@ -15,7 +16,10 @@ export function buildScenario(matter: SimMatter, parties: Parties, index: number
     case "RATTSHJALP": return matter.matterNumber === "2026-0020"
       ? buildRattshjalpArsskifteScenario(parties)
       : buildRattshjalpScenario(parties);
-    case "RATTSSKYDD": return buildRattsskyddScenario(parties);
+    // 2026-0021 = positivt rättsskyddsbesked (100 tim, självrisk 20 % lägst 1 800 kr, #899).
+    case "RATTSSKYDD": return matter.matterNumber === "2026-0021"
+      ? buildRattsskyddPositivtScenario(parties)
+      : buildRattsskyddScenario(parties);
     case "OFFENTLIGT_UPPDRAG": return buildOffentligtScenario(parties);
     default: return buildPrivatScenario(parties, index);
   }

--- a/tooling/demo-generator/simulate/scenarios/rattshjalp-arsskifte.ts
+++ b/tooling/demo-generator/simulate/scenarios/rattshjalp-arsskifte.ts
@@ -26,6 +26,12 @@ export function buildRattshjalpArsskifteScenario(parties: Parties): SimEvent[] {
   if (parties.domstol) ev.push({ kind: "party", dayOffset: 2, contactId: parties.domstol, role: "DOMSTOL" });
 
   ev.push(
+    // Normalflödet: klienten söker FÖRST rättsskydd hos försäkringsbolaget; först
+    // vid avslag (här: tvist anses ej uppkommen) drivs ärendet med rättshjälp (#899).
+    { kind: "doc", dayOffset: 2, template: "rattsskyddsansokan" },
+    { kind: "note", dayOffset: 2, text: "Ansökan om rättsskydd inskickad till försäkringsbolaget." },
+    { kind: "doc", dayOffset: 9, template: "rattsskyddAvslag" },
+    { kind: "note", dayOffset: 9, text: "Avslag på rättsskydd — tvist anses ännu inte ha uppkommit. Ärendet drivs vidare med rättshjälp." },
     { kind: "expense", dayOffset: 8, amountOre: 90_000, description: "Ansökningsavgift tingsrätten" },
     // ── Period 1: arbetslös 5 %, HELA i 2025 (norm 1 602 / tidsspillan 1 450) ──
     { kind: "time", dayOffset: 6, minutes: 240, description: "Genomgång av handlingar och underlag" },

--- a/tooling/demo-generator/simulate/scenarios/rattsskydd-positivt.ts
+++ b/tooling/demo-generator/simulate/scenarios/rattsskydd-positivt.ts
@@ -1,0 +1,40 @@
+/**
+ * Scenariovariant för RÄTTSSKYDD med POSITIVT försäkringsbesked (#899, ärende
+ * 2026-0021). Normalflödet: klientbesök → ansökan om rättsskydd → försäkringsbolaget
+ * BEVILJAR ("ersätter högst 100 tim arvode; självrisk 20 %, dock lägst 1 800 kr") →
+ * arbete → slutreglering mot försäkringen. Vid slutregleringen betalar klienten
+ * självrisken (golvet 1 800 kr slår in när 20 % av arvodet är lägre) och försäkringen
+ * resten. Ingen kostnadsräkning (den vägen gäller domstol/rättshjälp).
+ *
+ * Matterns fält (seed): clientShareBips 2000 (20 %), rattsskyddSjalvriskMinOre 180000
+ * (1 800 kr), rattsskyddMaxOre ~100 tim. Arbetet hålls litet så självrisks-golvet syns.
+ */
+
+import type { Parties, SimEvent } from "../events";
+
+export function buildRattsskyddPositivtScenario(parties: Parties): SimEvent[] {
+  const ev: SimEvent[] = [
+    { kind: "note", dayOffset: 0, text: "Klientbesök — genomgång av tvisten och hemförsäkringens rättsskydd." },
+    { kind: "time", dayOffset: 0, minutes: 60, description: "Inledande genomgång och rådgivning" },
+    { kind: "doc", dayOffset: 1, template: "fullmakt" },
+    { kind: "doc", dayOffset: 2, template: "rattsskyddsansokan" },
+    { kind: "note", dayOffset: 2, text: "Ansökan om rättsskydd inskickad till försäkringsbolaget." },
+  ];
+  if (parties.klient) ev.push({ kind: "party", dayOffset: 0, contactId: parties.klient, role: "KLIENT" });
+  if (parties.motpart) ev.push({ kind: "party", dayOffset: 2, contactId: parties.motpart, role: "MOTPART" });
+  if (parties.motpartsombud) ev.push({ kind: "party", dayOffset: 2, contactId: parties.motpartsombud, role: "MOTPARTSOMBUD" });
+  if (parties.domstol) ev.push({ kind: "party", dayOffset: 2, contactId: parties.domstol, role: "DOMSTOL" });
+  ev.push(
+    { kind: "doc", dayOffset: 10, template: "rattsskyddBeslutPositivt" },
+    { kind: "note", dayOffset: 10, text: "Rättsskydd beviljat: högst 100 tim arvode, självrisk 20 % dock lägst 1 800 kr." },
+    { kind: "expense", dayOffset: 14, amountOre: 90_000, description: "Ansökningsavgift tingsrätten" },
+    { kind: "time", dayOffset: 15, minutes: 90, description: "Skriftväxling och kravbrev till motpart" },
+    { kind: "doc", dayOffset: 18, template: "brevTillOmbud" },
+    { kind: "note", dayOffset: 30, text: "Förlikning nådd — tvisten avslutas utan huvudförhandling." },
+    { kind: "time", dayOffset: 30, minutes: 90, description: "Förlikningsförhandling och överenskommelse" },
+    // Slutreglering mot försäkringen: klienten betalar självrisken (golvet 1 800 kr),
+    // försäkringen resten. Klienten har inte betalat aconto → självrisken blir slutfakturan.
+    { kind: "settle", dayOffset: 45, payerRecipient: "FORSAKRING" },
+  );
+  return ev;
+}

--- a/tooling/scripts/seed-data.ts
+++ b/tooling/scripts/seed-data.ts
@@ -122,6 +122,9 @@ interface MatterSeed {
   clientShareBips?: number;
   /** Rättshjälpens timtak (rättshjälpslagen: 100 tim). */
   rattshjalpMaxTimmar?: number;
+  /** Rättsskyddets tak (öre) + lägsta självrisk (öre) ur försäkringsbeslutet (#899). */
+  rattsskyddMaxOre?: number;
+  rattsskyddSjalvriskMinOre?: number;
 }
 
 export const MATTERS: MatterSeed[] = [
@@ -150,6 +153,10 @@ export const MATTERS: MatterSeed[] = [
   // satserna; rättshjälpsmyndighetens SLUTLIGA helhetsbeslut blev 5 % → klienten
   // överfakturerades (särskilt via 40 %-acontot) → kreditfaktura. clientShareBips =
   // det slutliga helhetsbeslutet (5 %). Egen tidslogg (nedan) → deterministiskt arvode.
+  // 2026-0021 (#899): klienten söker FÖRST rättsskydd som BEVILJAS (positivt besked:
+  // högst 100 tim arvode, självrisk 20 % dock lägst 1 800 kr). Slutregleras mot
+  // försäkringen; självrisks-golvet (1 800 kr) slår in eftersom arbetet är litet.
+  { id: "m-021-rattsskydd-positivt", matterNumber: "2026-0021", title: "Fastighetstvist — rättsskydd beviljat Gustafsson", status: "ACTIVE", matterType: "Fastighetsrätt", paymentMethod: "RATTSSKYDD", description: "Klienten ansökte om rättsskydd som beviljades: försäkringen ersätter högst 100 tim arvode till eget ombud, från ersättningen avräknas självrisk 20 %, dock lägst 1 800 kr. Slutregleras mot försäkringsbolaget — klienten betalar självrisken (golvet 1 800 kr).", klientId: "c-gustafsson", motpartId: "c-brf-eken", domstolId: "c-tingsratten-sthlm", createdDaysAgo: 70, clientShareBips: 2000, rattsskyddMaxOre: 16_260_000, rattsskyddSjalvriskMinOre: 180_000 },
   { id: "m-020-rattshjalp-varierande", matterNumber: "2026-0020", title: "Vårdnadstvist — varierande rättshjälp Falk", status: "ACTIVE", matterType: "Familjerätt", paymentMethod: "RATTSHJALP", description: "Rättshjälp över ett årsskifte (start nov 2025, norm 1 602 kr → 2026 norm 1 626 kr) med varierande avgift (arbetslös 5 % → anställd 40 % → arbetslös 5 %) och tidsspillan. Vid slutregleringen räknas HELA ärendet om på 2026 års norm (retroaktiv höjning) — skillnaden regleras på slutfakturorna till klient + domstol. Myndighetens slutliga avgift: 5 %.", klientId: "c-falk", motpartId: "c-bergman", domstolId: "c-tingsratten-sthlm", createdDaysAgo: 255, clientShareBips: 500, rattshjalpMaxTimmar: 100 },
 ];
 
@@ -175,6 +182,27 @@ export interface SeedDataset {
   paymentPlans: Record<string, unknown>[];
   paymentPlanReminders: Record<string, unknown>[];
   serviceNotes: Record<string, unknown>[];
+}
+
+/** Nullbara matter-fält som defaultar till null i seed-raden. */
+const MATTER_NULLABLE_FIELDS: readonly (keyof MatterSeed)[] = [
+  "taxaLevel", "taxaHuvudforhandlingMin", "taxaHasFTax", "clientShareBips",
+  "rattshjalpMaxTimmar", "rattsskyddMaxOre", "rattsskyddSjalvriskMinOre",
+];
+
+/** MATTERS-mall → matter-rad. Nullbara fält via loop (håller komplexitet ≤8, #199). */
+function toMatterRow(m: MatterSeed, orgId: string): Record<string, unknown> {
+  const row: Record<string, unknown> = {
+    id: m.id, organizationId: orgId, matterNumber: m.matterNumber, title: m.title,
+    description: m.description, status: m.status, matterType: m.matterType,
+    paymentMethod: m.paymentMethod, paymentMethodNote: null,
+    paymentMethodDecidedAt: isoDate(-m.createdDaysAgo + 5),
+    isTaxeArende: m.isTaxeArende ?? false,
+    createdAt: isoDate(-m.createdDaysAgo),
+    updatedAt: isoDate(-Math.max(1, m.createdDaysAgo - 7)),
+  };
+  for (const f of MATTER_NULLABLE_FIELDS) row[f] = m[f] ?? null;
+  return row;
 }
 
 export function buildSeed(opts: BuildSeedOpts = {}): SeedDataset {
@@ -211,20 +239,7 @@ export function buildSeed(opts: BuildSeedOpts = {}): SeedDataset {
       address: null, notes: null,
       createdAt: isoDate(-180), updatedAt: isoDate(-30),
     })),
-    matters: MATTERS.map((m) => ({
-      id: m.id, organizationId: orgId, matterNumber: m.matterNumber, title: m.title,
-      description: m.description, status: m.status, matterType: m.matterType,
-      paymentMethod: m.paymentMethod, paymentMethodNote: null,
-      paymentMethodDecidedAt: isoDate(-m.createdDaysAgo + 5),
-      isTaxeArende: m.isTaxeArende ?? false,
-      taxaLevel: m.taxaLevel ?? null,
-      taxaHuvudforhandlingMin: m.taxaHuvudforhandlingMin ?? null,
-      taxaHasFTax: m.taxaHasFTax ?? null,
-      clientShareBips: m.clientShareBips ?? null,
-      rattshjalpMaxTimmar: m.rattshjalpMaxTimmar ?? null,
-      createdAt: isoDate(-m.createdDaysAgo),
-      updatedAt: isoDate(-Math.max(1, m.createdDaysAgo - 7)),
-    })),
+    matters: MATTERS.map((m) => toMatterRow(m, orgId)),
     matterContacts: [],
     documents: [],
     timeEntries: [],


### PR DESCRIPTION
## Normalflödet
Klienten söker **först rättsskydd** (försäkring); först vid avslag / ingen försäkring söker man **rättshjälp**.

**A) 2026-0020 kompletteras** med en ansökan om rättsskydd + ett avslag (tvist anses ännu inte ha uppkommit) → ärendet drivs vidare med rättshjälp. Nya dok-mallar `rattsskyddsansokan` (utgående) + `rattsskyddAvslag` (inkommande); ärendet förblir RATTSHJALP.

**B) Nytt ärende 2026-0021** (RATTSSKYDD) där försäkringen ger **positivt besked**: *"ersätter högst 100 tim arvode till eget ombud; från ersättningen avräknas självrisk 20 %, dock lägst 1 800 kr"*. Slutregleras mot försäkringen — klienten betalar självrisken, försäkringen resten.

## Ny domänlogik: golv-självrisk
- `rattsskyddSjalvriskMinOre` (matter-fält): zod + drizzle-kolumn + migration `0018`.
- `rattsskyddSplit`: självrisk = `min(täckt, max(golv, andel% × täckt))` — golvet "dock lägst 1 800 kr".
- Matas in end-to-end: `rattsskyddCoverage` → `computeCoverageSplit`, samt `matter.create` + `populate` + seed (även 100-tim-taket `rattsskyddMaxOre`).

## Verifierat
- `quality:fast` + `lint --max-warnings 0` / `knip` / `deps:check` / `jscpd` rena. Nya coverage-tester för golvet (binder / binder ej).
- `build:demo`: 2026-0020 har ansökan+avslag-dok; 2026-0021 självrisk = **2 250 kr incl (= 1 800 kr netto, golvet)** — inte de ~1 625 kr som 20 % ensamt gett — försäkringen betalar **6 693,65 kr**.

Closes #899

🤖 Generated with [Claude Code](https://claude.com/claude-code)