### PR TITLE
fix(demo): positivt-rättsskydd-ärendet (2026-0021) speglar Falks vårdnadstvist (#903)

### DIFF
--- a/tooling/scripts/seed-data.ts
+++ b/tooling/scripts/seed-data.ts
@@ -153,10 +153,11 @@ export const MATTERS: MatterSeed[] = [
   // satserna; rättshjälpsmyndighetens SLUTLIGA helhetsbeslut blev 5 % → klienten
   // överfakturerades (särskilt via 40 %-acontot) → kreditfaktura. clientShareBips =
   // det slutliga helhetsbeslutet (5 %). Egen tidslogg (nedan) → deterministiskt arvode.
-  // 2026-0021 (#899): klienten söker FÖRST rättsskydd som BEVILJAS (positivt besked:
-  // högst 100 tim arvode, självrisk 20 % dock lägst 1 800 kr). Slutregleras mot
-  // försäkringen; självrisks-golvet (1 800 kr) slår in eftersom arbetet är litet.
-  { id: "m-021-rattsskydd-positivt", matterNumber: "2026-0021", title: "Fastighetstvist — rättsskydd beviljat Gustafsson", status: "ACTIVE", matterType: "Fastighetsrätt", paymentMethod: "RATTSSKYDD", description: "Klienten ansökte om rättsskydd som beviljades: försäkringen ersätter högst 100 tim arvode till eget ombud, från ersättningen avräknas självrisk 20 %, dock lägst 1 800 kr. Slutregleras mot försäkringsbolaget — klienten betalar självrisken (golvet 1 800 kr).", klientId: "c-gustafsson", motpartId: "c-brf-eken", domstolId: "c-tingsratten-sthlm", createdDaysAgo: 70, clientShareBips: 2000, rattsskyddMaxOre: 16_260_000, rattsskyddSjalvriskMinOre: 180_000 },
+  // 2026-0021 (#899/#903): SPEGLAR Fredrik Falks vårdnadstvist (2026-0020) men här
+  // BEVILJAR försäkringen rättsskydd (i st.f. rättshjälps-vägen efter avslag). Positivt
+  // besked: högst 100 tim arvode, självrisk 20 % dock lägst 1 800 kr → försäkringen tar
+  // merparten, klienten bara självrisken (golvet 1 800 kr slår in vid litet arbete).
+  { id: "m-021-rattsskydd-positivt", matterNumber: "2026-0021", title: "Vårdnadstvist — rättsskydd beviljat Falk", status: "ACTIVE", matterType: "Familjerätt", paymentMethod: "RATTSSKYDD", description: "Speglar Fredrik Falks vårdnadstvist (jfr 2026-0020, rättshjälp) men här BEVILJAR försäkringen rättsskydd: ersätter högst 100 tim arvode till eget ombud, från ersättningen avräknas självrisk 20 %, dock lägst 1 800 kr. Slutregleras mot försäkringsbolaget — försäkringen tar merparten av kostnaden, klienten bara självrisken.", klientId: "c-falk", motpartId: "c-bergman", domstolId: "c-tingsratten-sthlm", createdDaysAgo: 70, clientShareBips: 2000, rattsskyddMaxOre: 16_260_000, rattsskyddSjalvriskMinOre: 180_000 },
   { id: "m-020-rattshjalp-varierande", matterNumber: "2026-0020", title: "Vårdnadstvist — varierande rättshjälp Falk", status: "ACTIVE", matterType: "Familjerätt", paymentMethod: "RATTSHJALP", description: "Rättshjälp över ett årsskifte (start nov 2025, norm 1 586 kr → 2026 norm 1 626 kr) med varierande avgift (arbetslös 5 % → anställd 40 % → arbetslös 5 %) och tidsspillan. Vid slutregleringen räknas HELA ärendet om på 2026 års norm (retroaktiv höjning) — skillnaden regleras på slutfakturorna till klient + domstol. Myndighetens slutliga avgift: 5 %.", klientId: "c-falk", motpartId: "c-bergman", domstolId: "c-tingsratten-sthlm", createdDaysAgo: 255, clientShareBips: 500, rattshjalpMaxTimmar: 100 },
 ];
 


### PR DESCRIPTION
## Problem
2026-0021 (positivt rättsskyddsbesked) byggdes som en **Gustafsson-fastighetstvist** — därför gick den inte att hitta som "Falk-ärendet där försäkringen godkänner".

## Fix
2026-0021 speglar nu **Fredrik Falks vårdnadstvist** (2026-0020): klient c-falk, motpart c-bergman, Familjerätt, titel **"Vårdnadstvist — rättsskydd beviljat Falk"**. Samma fall som rättshjälps-ärendet MEN här **beviljar försäkringen rättsskydd** (i st.f. rättshjälps-vägen efter avslag). Självrisk 20 % (lägst 1 800 kr) behålls — försäkringen tar merparten av kostnaden.

Demonarrativ nu:
- **2026-0020** — Vårdnadstvist, rättsskydd NEKAT → rättshjälp (klient/domstol).
- **2026-0021** — Vårdnadstvist, rättsskydd BEVILJAT → försäkringen betalar, klient självrisk.

## Verifierat
- `quality:fast` grönt.
- `build:demo`: 2026-0021 = "Vårdnadstvist — rättsskydd beviljat Falk", klient **Fredrik Falk**, slutreglering **försäkring 6 693,65 kr + klient självrisk 2 561,35 kr**.

Closes #903

🤖 Generated with [Claude Code](https://claude.com/claude-code)