### PR TITLE
feat(billing): rättsskydd flöde B — försäkringens prutning efteråt → klienten bär den (#905)

### DIFF
--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -418,6 +418,7 @@ export function BillingPanel({ matterId, matter }: Props) {
       <BillingSummary matterId={matterId} />
       <RadgivningBanner matterId={matterId} matter={matter} onRecorded={refetch} />
       <SjalvriskAccontoHint matterId={matterId} matter={matter} rows={rows} />
+      <InsurerPruningBanner matterId={matterId} matter={matter} rows={rows} onRecorded={refetch} />
       {activeKr && <KostnadsrakningCard matterId={matterId} run={activeKr}
         onRegistreraBeslut={() => setBeslutRunId(activeKr.id)}
         onOverklaga={() => appeal.mutate({ billingRunId: activeKr.id })}
@@ -508,6 +509,38 @@ function SjalvriskAccontoHint({ matterId, matter, rows }: { matterId: MatterId; 
       <span className="font-mono font-semibold">{formatCurrency(split.clientOre)}</span>{" "}
       (tröskel {formatCurrency(threshold)}) — dags att skicka ett självrisk-aconto via
       {" "}<strong>+ Skapa faktura → Aconto till klient</strong>.
+    </div>
+  );
+}
+
+/**
+ * Försäkrings-prutnings-banner (#905, rättsskydd flöde B): efter slutregleringen mot
+ * försäkringen kan bolaget PRUTA på arvodet. Byrån registrerar det prutade beloppet →
+ * kredit till försäkringen + påfyllnadsfaktura till klienten. Visas bara när det finns
+ * en FORSAKRING-slutfaktura och ingen prutning redan registrerats.
+ */
+function InsurerPruningBanner({ matterId, matter, rows, onRecorded }: { matterId: MatterId; matter: MatterContext; rows: BillingRunRow[]; onRecorded: () => void }) {
+  const [krStr, setKrStr] = useState("");
+  const record = trpc.billingRun.recordInsurerPruning.useMutation({ onSuccess: onRecorded });
+  const hasPayerFinal = rows.some((r) => r.type === "FINAL" && r.recipient === "FORSAKRING");
+  const alreadyPruned = rows.some((r) => r.type === "CREDIT" && r.recipient === "FORSAKRING");
+  if (matter.paymentMethod !== "RATTSSKYDD" || !hasPayerFinal || alreadyPruned) return null;
+  const netOre = Math.round(Number.parseFloat(krStr.replace(",", ".")) * 100);
+  const valid = Number.isFinite(netOre) && netOre > 0;
+  return (
+    <div className="mx-6 mb-4 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+      <div className="mb-1.5">Har försäkringsbolaget <strong>prutat</strong> på fakturan? Registrera det prutade arvodet (exkl moms) — mellanskillnaden krediteras försäkringen och faktureras klienten.</div>
+      <div className="flex items-center gap-2">
+        <input type="number" min={0} step={100} value={krStr} placeholder="Prutat belopp (kr, exkl moms)"
+          onChange={(e) => setKrStr(e.target.value)}
+          className="border border-amber-300 rounded px-2 py-1 w-56 focus:outline-none focus:ring-1 focus:ring-amber-500" />
+        <button type="button" disabled={!valid || record.isPending}
+          onClick={() => record.mutate({ matterId, prunedNetOre: netOre })}
+          className="rounded bg-amber-600 text-white px-2 py-1 font-medium disabled:opacity-50">
+          {record.isPending ? "Registrerar…" : "Registrera prutning"}
+        </button>
+        {record.error && <span className="text-red-600">{record.error.message}</span>}
+      </div>
     </div>
   );
 }

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -1242,6 +1242,70 @@ export const billingRunRouter = router({
         return { split, clientInvoice, payerInvoice, creditInvoice, clientRun, payerRun, breakdown };
       });
     }),
+
+  /**
+   * Registrera försäkringsbolagets PRUTNING efter slutregleringen (#905, rättsskydd,
+   * flöde B): försäkringen ersätter mindre än fakturerat. Prutningen bärs av KLIENTEN.
+   * Två fakturor (aldrig en delad): (1) en KREDIT till försäkringen på det prutade
+   * beloppet (deras nettofordran sänks till det de faktiskt betalar), (2) en påfyllnads-
+   * faktura till klienten på samma belopp. Byrån blir hel. Kräver en befintlig
+   * FORSAKRING-slutregleringsfaktura.
+   */
+  recordInsurerPruning: orgProcedure
+    .input(z.object({
+      matterId: matterIdSchema,
+      /** Prutat arvode NETTO (öre) — den del försäkringen inte ersätter. */
+      prunedNetOre: z.number().int().positive(),
+      notes: z.string().nullish(),
+    }))
+    .mutation(({ ctx, input }) =>
+      ctx.repos.transaction(async (tx) => {
+        const runs = await tx.billingRuns.listForOrg(ctx.orgId, input.matterId);
+        const payerRun = runs.find((r) => r.type === "FINAL" && r.recipient === "FORSAKRING" && r.invoiceId);
+        if (!payerRun?.invoiceId) {
+          throw new TRPCError({ code: "BAD_REQUEST", message: "Ingen försäkringsfaktura att pruta på — slutreglera mot försäkringen först." });
+        }
+        const prunedGross = arvodeInclVatOre(input.prunedNetOre);
+        const prunedVat = prunedGross - input.prunedNetOre;
+        const arvodeVatLine = [{ kind: "arvode" as const, vatRate: DEFAULT_VAT_RATE, netOre: input.prunedNetOre, vatOre: prunedVat }];
+        // (1) Kreditera försäkringen den prutade delen (negativ faktura, länkad till originalet).
+        const insurerCredit = await tx.invoices.create({
+          matterId: input.matterId, amount: -prunedGross, vatOre: -prunedVat,
+          vatBreakdown: arvodeVatLine.map((l) => ({ ...l, netOre: -l.netOre, vatOre: -l.vatOre })),
+          invoiceType: "CREDIT", status: "SENT", creditedInvoiceId: payerRun.invoiceId,
+          ...(await invoiceNumbering(tx, ctx.orgId, "FORSAKRING")), invoiceDate: new Date(),
+          notes: "Försäkringens prutning — kreditering av den del försäkringen inte ersätter.",
+        });
+        // (2) Fakturera klienten samma belopp (klienten bär prutningen).
+        const clientView: SettlementView = {
+          timeLines: [],
+          rows: [
+            { label: "Försäkringens prutning (exkl moms)", amountOre: input.prunedNetOre, kind: "add" },
+            { label: "Moms 25 %", amountOre: prunedVat, kind: "add" },
+          ],
+          totalLabel: "Att betala (inkl moms)", totalOre: prunedGross,
+        };
+        const clientInvoice = await tx.invoices.create({
+          matterId: input.matterId, amount: prunedGross, vatOre: prunedVat, vatBreakdown: arvodeVatLine,
+          invoiceType: "FINAL", status: "SENT", settlementBreakdown: clientView,
+          ...(await invoiceNumbering(tx, ctx.orgId, "KLIENT")), invoiceDate: new Date(),
+          notes: input.notes ?? "Försäkringens prutning — bärs av klienten (rättsskydd).",
+        });
+        await tx.billingRuns.create({
+          matterId: input.matterId, type: "CREDIT", recipient: "FORSAKRING", status: "SENT",
+          workValueOreAtRun: prunedGross, proposedAmountOre: -prunedGross, amountOre: -prunedGross,
+          invoiceId: insurerCredit.id, deductedBillingRunIds: [], periodTo: new Date(),
+        });
+        await tx.billingRuns.create({
+          matterId: input.matterId, type: "FINAL", recipient: "KLIENT", status: "SENT",
+          workValueOreAtRun: prunedGross, proposedAmountOre: prunedGross, amountOre: prunedGross,
+          invoiceId: clientInvoice.id, deductedBillingRunIds: [], periodTo: new Date(),
+        });
+        await emit.invoiceCreated(ctx, insurerCredit);
+        await emit.invoiceCreated(ctx, clientInvoice);
+        return { insurerCredit, clientInvoice };
+      }),
+    ),
 });
 
 /**

--- a/test/unit/app/matters/[id]/page.test.tsx
+++ b/test/unit/app/matters/[id]/page.test.tsx
@@ -94,6 +94,7 @@ vi.mock("@/lib/client/trpc", () => ({
       setVerdict: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
       appealKostnadsrakning: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
       recordKostnadsrakningBeslut: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      recordInsurerPruning: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
       coverageSplit: { useQuery: () => ({ data: undefined }) },
     },
     invoice: {

--- a/test/unit/app/matters/billing-panel.test.tsx
+++ b/test/unit/app/matters/billing-panel.test.tsx
@@ -50,6 +50,7 @@ vi.mock("@/lib/client/trpc", () => ({
       createKostnadsrakning: { useMutation: () => ({ mutate: krMutate, isPending: false }) },
       appealKostnadsrakning: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
       recordKostnadsrakningBeslut: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      recordInsurerPruning: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
       coverageSplit: { useQuery: () => ({ data: coverageSplitData }) },
     },
     organization: {

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -487,6 +487,22 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
     expect(res.payerInvoice.amount).toBe(537500);
   });
 
+  it("rättsskydd flöde B (#905): prutning EFTERÅT → kredit till försäkring + påfyllnadsfaktura till klient", async () => {
+    const { caller: c } = caller({ paymentMethod: "RATTSSKYDD", clientShareBips: 2000 }, 300000);
+    await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "FORSAKRING" }); // ingen prutning uppfront
+    const res = await c.billingRun.recordInsurerPruning({ matterId: "m-1", prunedNetOre: 100_000 });
+    // 100 000 netto → 125 000 brutto: kredit till försäkring (negativ) + klientfaktura (positiv).
+    expect(res.insurerCredit.invoiceType).toBe("CREDIT");
+    expect(res.insurerCredit.amount).toBe(-125_000);
+    expect(res.clientInvoice.invoiceType).toBe("FINAL");
+    expect(res.clientInvoice.amount).toBe(125_000);
+  });
+
+  it("recordInsurerPruning kräver en försäkringsfaktura först (annars BAD_REQUEST)", async () => {
+    const { caller: c } = caller({ paymentMethod: "RATTSSKYDD", clientShareBips: 2000 }, 300000);
+    await expect(c.billingRun.recordInsurerPruning({ matterId: "m-1", prunedNetOre: 100_000 })).rejects.toThrow(/försäkringsfaktura/i);
+  });
+
   it("rättshjälp: timkostnadsnorm; dom prutar → byrå-förlust bokas (icke-debiterbar PRUTNING), klient på reducerat", async () => {
     // 3 tim loggat − 1 tim rådgivning (#809) = 2 effektiva tim → bas 325 200.
     const { ds, caller: c } = caller({ paymentMethod: "RATTSHJALP", clientShareBips: 2000, taxaHasFTax: true }, 999999, 180);

--- a/tooling/demo-generator/simulate/events.ts
+++ b/tooling/demo-generator/simulate/events.ts
@@ -34,6 +34,9 @@ export type SimEvent =
   | { kind: "verdict"; dayOffset: number }
   /** Slutreglering (rättshjälp/-skydd) — settleCoverage (→ klient FINAL/CREDIT + betalare). */
   | { kind: "settle"; dayOffset: number; payerRecipient: string }
+  /** Försäkringens prutning EFTER slutreglering (#905, rättsskydd flöde B) — kredit till
+   *  försäkringen + påfyllnadsfaktura till klienten på `prunedNetOre` (netto). */
+  | { kind: "insurerPruning"; dayOffset: number; prunedNetOre: number }
   /** Vanlig slutfaktura (privat/offentligt) — createFinal + SENT. */
   | { kind: "final"; dayOffset: number; recipient: string }
   /** Betala den senast skapade slutfakturan — invoice.recordPayment. */

--- a/tooling/demo-generator/simulate/runner.ts
+++ b/tooling/demo-generator/simulate/runner.ts
@@ -189,6 +189,13 @@ async function hSettle(ctx: RunCtx, m: SimMatter, e: Any, _iso: string): Promise
   }
 }
 
+async function hInsurerPruning(ctx: RunCtx, m: SimMatter, e: Any, _iso: string): Promise<void> {
+  // Försäkringen prutar EFTER slutregleringen (#905) → kredit till försäkringen +
+  // påfyllnadsfaktura till klienten på prutade beloppet.
+  await ctx.c.billingRun.recordInsurerPruning({ matterId: m.id, prunedNetOre: e.prunedNetOre });
+  ctx.res.invoices += 2;
+}
+
 async function hFinal(ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimState): Promise<void> {
   const { invoice } = await ctx.c.billingRun.createFinal({ matterId: m.id, recipient: e.recipient, deductedBillingRunIds: [], invoiceDate: iso });
   await ctx.c.invoice.setStatus({ invoiceId: invoice.id, status: "SENT" });
@@ -204,7 +211,7 @@ async function hPayment(ctx: RunCtx, _m: SimMatter, _e: Any, iso: string, st: Si
 /** kind → handler. Håller runnern platt (undviker en stor switch = hög komplexitet). */
 const HANDLERS: Record<SimEvent["kind"], (ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimState) => Promise<void>> = {
   party: hParty, time: hTime, note: hNote, expense: hExpense, doc: hDoc, radgivning: hRadgivning,
-  acconto: hAcconto, rateChange: hRateChange, kostnadsrakning: hKostnadsrakning, beslut: hBeslut, verdict: hVerdict, settle: hSettle, final: hFinal, payment: hPayment,
+  acconto: hAcconto, rateChange: hRateChange, kostnadsrakning: hKostnadsrakning, beslut: hBeslut, verdict: hVerdict, settle: hSettle, insurerPruning: hInsurerPruning, final: hFinal, payment: hPayment,
 };
 
 /** Spela upp ett ärendes scenario kronologiskt. */

--- a/tooling/demo-generator/simulate/scenarios/rattsskydd-positivt.ts
+++ b/tooling/demo-generator/simulate/scenarios/rattsskydd-positivt.ts
@@ -35,6 +35,10 @@ export function buildRattsskyddPositivtScenario(parties: Parties): SimEvent[] {
     // Slutreglering mot försäkringen: klienten betalar självrisken (golvet 1 800 kr),
     // försäkringen resten. Klienten har inte betalat aconto → självrisken blir slutfakturan.
     { kind: "settle", dayOffset: 45, payerRecipient: "FORSAKRING" },
+    // Flöde B (#905): försäkringen PRUTAR efteråt (ersätter 1 000 kr mindre) → kredit till
+    // försäkringen + påfyllnadsfaktura till klienten på prutade beloppet.
+    { kind: "note", dayOffset: 60, text: "Försäkringsbolaget prutar på arvodet — ersätter 1 000 kr mindre. Mellanskillnaden faktureras klienten." },
+    { kind: "insurerPruning", dayOffset: 60, prunedNetOre: 100_000 },
   );
   return ev;
 }


### PR DESCRIPTION
## Frågan: en faktura som betalas av två entiteter
Svaret: **gör inte en delad faktura** — modellera **en faktura per betalare** + ett tvåstegsflöde för prutningen. Varje entitet får egen faktura, eget OCR, egen betalnings-/påminnelsehantering.

## Flöde B (valt)
1. **Slutreglering** (som förr): försäkringsfaktura (deras andel) + klientens självrisk-faktura. Ingen prutning uppfront.
2. **Prutning efteråt** — ny mutation `billingRun.recordInsurerPruning({ matterId, prunedNetOre })`: när försäkringen ersätter mindre än fakturerat
   - **krediteras försäkringen** det prutade beloppet (negativ faktura länkad till originalet via `creditedInvoiceId`),
   - **klienten faktureras** samma belopp (påfyllnadsfaktura).
   - Byrån blir hel.

**UI:** prutnings-banner i fakturapanelen (visas för rättsskydd med en försäkrings-slutfaktura, döljs när prutning redan registrerats) — belopp-fält (exkl moms) + "Registrera prutning".

**Demo (2026-0021):** försäkringen prutar 1 000 kr efter slutregleringen.

## Verifierat
- `test:fast` + `lint --max-warnings 0` / `knip` / `deps:check` rena. Nya tester: mutationen (kredit − / klient +) + kräver-försäkringsfaktura-guard + banner-mock.
- `build:demo` 2026-0021: försäkring **6 693,65** + klient självrisk **2 561,35** + försäkringskredit **−1 250** + klient-påfyllnad **+1 250** → försäkring betalar netto 5 443,65, klienten 3 811,35, byrån hel (9 255 kr).

Closes #905

🤖 Generated with [Claude Code](https://claude.com/claude-code)