### PR TITLE
ci: harden CI pipeline — bundle-size gate, permissions, concurrency, security scanning

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Buggrapport
+about: Något fungerar inte som det ska
+title: "fix: "
+labels: bug
+---
+
+## Vad händer
+
+<!-- Kort beskrivning av felet. -->
+
+## Steg att återskapa
+
+1.
+2.
+3.
+
+## Förväntat vs faktiskt
+
+- **Förväntat:**
+- **Faktiskt:**
+
+## Miljö
+
+- Deploy-mode: `demo` / `self-hosted`
+- Browser/OS:
+- Relevant commit/tag:
+
+## Övrigt
+
+<!-- Loggar, skärmdumpar, misstänkt kod (`fil:rad`). -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,3 @@
+# Issue-first-flöde (AGENTS.md): allt arbete börjar från en issue. Tomma issues
+# är avstängda för att styra in på en mall.
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,27 @@
+---
+name: Uppgift / förbättring
+about: Funktion, refaktorering, tech-debt eller tooling
+title: ""
+labels: ""
+---
+
+<!-- Välj label: architecture / tech-debt / tooling / documentation (+ ev. fler). -->
+
+## Mål
+
+<!-- Vad ska åstadkommas och varför. -->
+
+## Omfattning / acceptanskriterier
+
+- [ ]
+- [ ]
+
+## Kvalitetskrav
+
+- [ ] Täckande tester för ny kod (coverage-ratchet hålls/höjs)
+- [ ] Inga gater lösgjorda (lint/knip/dep-cruiser/bundle-size)
+- [ ] Docs uppdaterade om beteende/arkitektur ändras
+
+## Övrigt
+
+<!-- Länkade issues, ADR, avvägningar. -->

--- a/.github/actions/bun-setup/action.yml
+++ b/.github/actions/bun-setup/action.yml
@@ -1,0 +1,36 @@
+name: Bun setup
+description: >-
+  DRY toolchain-setup för alla jobb — Node 24 + pinnad Bun + cachead, frozen
+  install. Single source of truth för bun-versionen (byt här, gäller alla
+  workflows). Kör efter actions/checkout. Se #909.
+
+inputs:
+  install:
+    description: Kör `bun install --frozen-lockfile` (sätt "false" för jobb som installerar själva).
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v6
+      with:
+        node-version: 24
+    - uses: oven-sh/setup-bun@v2
+      with:
+        # Pinnad (ej `latest`) → reproducerbara byggen; matchar bun-types i
+        # package.json. Bumpas medvetet. SHA-pinning av actions: #910.
+        bun-version: 1.3.14
+    # setup-bun cachar INTE beroenden själv → cacha bun:s globala install-cache
+    # (nycklad på bun.lock). ~9 jobb installerar annars om allt varje körning.
+    - name: Cache bun install-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.bun/install/cache
+        key: bun-cache-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+        restore-keys: |
+          bun-cache-${{ runner.os }}-
+    - name: Install dependencies (frozen)
+      if: inputs.install == 'true'
+      shell: bash
+      run: bun install --frozen-lockfile

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+# Dependabot (#909) — automatiska säkerhets-/versions-PR:er.
+#
+# `bun` läser package.json via Dependabots `npm`-ekosystem (samma manifest).
+# Grupperade minor/patch → färre PR:er; major hålls separata (kan vara
+# breaking, ska granskas var för sig). Alla PR:er går genom samma gröna CI
+# som allt annat (AGENTS.md: issue → PR → merge). SHA-pinning av actions: #910.
+version: 2
+updates:
+  # ── App-beroenden (repo-roten) ────────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
+
+  # ── Helper-UI (Electron, ADR 0030) ────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: "/helper-ui"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      helper-npm-minor-patch:
+        update-types: ["minor", "patch"]
+
+  # ── GitHub Actions (workflows + composite actions) ────────────────────────
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions-all:
+        patterns: ["*"]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+<!-- Flöde: Issue → PR → grön CI → self-merge (AGENTS.md). `main` är skyddad. -->
+
+## Vad & varför
+
+<!-- Kort: vad ändras och varför. -->
+
+Stänger #
+
+## Typ
+
+- [ ] `feat` — ny funktion
+- [ ] `fix` — buggfix
+- [ ] `refactor` / `perf`
+- [ ] `docs` / `test` / `chore` / `ci`
+
+## Verifierat lokalt (speglar CI)
+
+- [ ] `bun run quality:fast` — typecheck + type-aware lint + `test:fast`
+- [ ] `bun run build:demo` — statisk export (fallerar annars TYST i CI/Pages)
+- [ ] Berörda E2E: `bun run round-trip` / `bun run e2e:oidc` / `bun run e2e:conflict` (om relevant)
+- [ ] Nya rader har täckande tester (coverage-ratchet hålls eller höjs)
+- [ ] Commits följer Conventional Commits (commitlint)
+
+## Kvalitetsgrindar
+
+- [ ] Inga gater lösgjorda (coverage/lint-cap/knip/bundle-size är ratchets — de tightnar bara)
+- [ ] Vid arkitektur-/tooling-kritiska paths (`tooling/config/`, `src/lib/shared/schemas/`, `.github/`): extra noggrant granskat (CODEOWNERS)
+
+## Övrigt
+
+<!-- Skärmdumpar, avvägningar, uppföljande issues (labels: architecture/tech-debt/tooling/documentation). -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,16 +4,30 @@ on:
   push:
     branches: [main, master]
   pull_request:
-  workflow_dispatch: # för on-demand e2e (git round-trip)
+  workflow_dispatch: # för on-demand e2e
 
-# Bun (#91) är pakethanterare + script-runner. setup-bun ger `bun` på PATH
-# (kör `bun install --frozen-lockfile` + `bun run X` + `bun *.ts`-scripten);
-# setup-node behålls för att tool-binärerna (tsc/eslint/vitest/next/playwright)
+# Least-privilege (#909): CI läser bara koden. Inget jobb behöver skriva till
+# repo:t — artefakt-uppladdning går via egen (skrivande) actions/*-token.
+permissions:
+  contents: read
+
+# En körning per ref åt gången (#909): en ny push till en PR avbryter den
+# pågående matrisen (postgres/server-first/oidc/conflict-e2e är tunga) i
+# stället för att köra flera parallellt. `main`-körningar skyddas av att
+# github.ref är unik per branch.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Toolchain-setupen (Node 24 + pinnad Bun + cachead frozen install) är DRY:ad
+# till ./.github/actions/bun-setup — single source of truth för bun-versionen.
+# setup-node behålls där för att tool-binärerna (tsc/eslint/next/playwright)
 # körs under Node via sin shebang.
 #
-# OBS: AVA är git-first — ingen Prisma, Postgres, NextAuth, Meilisearch
-# eller Tika i stacken. CI speglar därför bara den faktiska stacken:
-# statisk analys + vitest (+ git-round-trip-e2e mot docker).
+# OBS: AVA är git-first i demon (in-memory DemoDataStore) och server-first
+# self-hosted (Postgres via docker). CI speglar den faktiska stacken:
+# statisk analys + bun test (+ postgres-repo, server-first-deploy-E2E,
+# OIDC-login, demo-build/-smoke, keep-both-konflikt mot docker).
 
 jobs:
   # ───────────────── Commit-meddelanden ─────────────────
@@ -28,13 +42,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # commitlint behöver hela historiken för --from..--to
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/bun-setup
       - run: bun run commitlint --from "${{ github.event.pull_request.base.sha }}" --to "${{ github.event.pull_request.head.sha }}"
 
   # ───────────────── Statisk analys ─────────────────
@@ -44,13 +52,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/bun-setup
       - run: bun run typecheck
       # Ratchet med ventil (#41): struktur-reglerna (max-lines/-depth/-params/
       # -nested-callbacks + complexity) är `error`. Befintlig skuld ligger i
@@ -83,13 +85,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/bun-setup
       # bun test --isolate (#92) + coverage-ratchet (rader/funktioner).
       - run: bun run test:cov
       - name: Upload coverage
@@ -110,13 +106,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/bun-setup
       - name: Start Postgres (docker compose)
         run: docker compose -f tooling/docker/docker-compose.test.yml up -d --wait --wait-timeout 90
       - name: Repository-tester mot riktig Postgres
@@ -138,13 +128,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/bun-setup
       - name: Bygg server-first-binär
         run: bun run server-first:build
       - name: Starta Postgres + server-first (docker)
@@ -199,13 +183,7 @@ jobs:
       CI: "true"
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/bun-setup
       - run: bun run e2e:install
       - run: bun run e2e:oidc
       - name: Upload Playwright report
@@ -228,14 +206,14 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/bun-setup
       - run: bun run build:demo
+      # Bundle-size-ratchet (#14/#909): återanvänder out/ från build:demo ovan.
+      # check-bundle-size.ts summerar all klient-JS gzip:at och fäller om den
+      # sväller förbi budgeten (BUDGET_KB). Grinden var dokumenterad i
+      # docs/quality.md men kördes aldrig i CI → bundeln kunde svälla tyst.
+      - name: Bundle-size-budget (gzip)
+        run: bun run size
 
   # ───────────────── Demo E2E (browser-smoke) ─────────────────
   # `build:demo` ovan bevisar att demon BYGGER — men inte att den LADDAR i en
@@ -252,13 +230,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/bun-setup
       - run: bun run build:demo
       - run: bun run e2e:install
       - name: Servera out/ + kör demo render-smoke
@@ -295,13 +267,7 @@ jobs:
       CI: "true"
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/bun-setup
       - run: bun run e2e:install
       - run: bun run e2e:conflict
       - name: Upload Playwright report

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -26,22 +26,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
+      # DRY toolchain (Node 24 + pinnad Bun + cachead frozen install), #909.
+      - uses: ./.github/actions/bun-setup
 
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
 
       # Bygger appen som statisk export OCH seedar demo-data direkt i out/.
       # build-demo.sh kör:

--- a/.github/workflows/helper-ui-ci.yml
+++ b/.github/workflows/helper-ui-ci.yml
@@ -12,12 +12,18 @@ on:
       - "src/lib/shared/**"
       - "src/lib/server/routers/**" # helpern type-beror på AppRouter (ADR 0031)
       - ".github/workflows/helper-ui-ci.yml"
+      - ".github/actions/bun-setup/**" # delad toolchain-setup (#909)
   pull_request:
     paths:
       - "helper-ui/**"
       - "src/lib/shared/**"
       - "src/lib/server/routers/**" # helpern type-beror på AppRouter (ADR 0031)
       - ".github/workflows/helper-ui-ci.yml"
+      - ".github/actions/bun-setup/**" # delad toolchain-setup (#909)
+
+# Least-privilege (#909): jobbet läser bara koden.
+permissions:
+  contents: read
 
 jobs:
   build-test:
@@ -29,19 +35,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
+      # DRY toolchain (Node 24 + pinnad Bun + cachead frozen install), #909.
+      # Composite-stegen kör i repo-roten (ärver inte job-defaultens
+      # working-directory) → installerar ROOT-deps, vilket krävs för att typkolla
+      # den tunna tRPC-klienten: `AppRouter` (type-only, ADR 0031) drar in
+      # serverns typ-graf (zod, jose, @trpc/server …) från repo-rotens
+      # node_modules; tsc i helper-ui resolver uppåt dit.
+      - uses: ./.github/actions/bun-setup
 
-      # Root-deps krävs för att typkolla den tunna tRPC-klienten: `AppRouter`
-      # (type-only, ADR 0031) drar in serverns typ-graf (zod, jose, @trpc/server
-      # …) som bor i repo-rotens node_modules. tsc i helper-ui resolver uppåt dit.
-      - name: Install root deps
-        working-directory: ${{ github.workspace }}
-        run: bun install --frozen-lockfile
-
-      - name: Install
+      - name: Install (helper-ui)
         run: bun install --frozen-lockfile
 
       - name: Typecheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,9 @@ on:
       - "v*"
   workflow_dispatch: {}
 
+# Least-privilege (#909): default läs; bara release-jobbet får skriva (release).
 permissions:
-  contents: write # skapa release + ladda upp artefakter
+  contents: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -31,13 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-      - run: bun install --frozen-lockfile
+      # DRY toolchain (Node 24 + pinnad Bun + cachead frozen install), #909.
+      - uses: ./.github/actions/bun-setup
       - name: Build demo (app + seeded data)
         env:
           DEMO_BUILD: "1"
@@ -63,6 +59,8 @@ jobs:
     needs: [web]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # skapa release + ladda upp artefakter
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,12 +1,15 @@
 name: Security
 
-# Säkerhetsscanning (#909): statisk analys (CodeQL/SAST) + granskning av nya
-# beroenden på PR. Kompletterar Dependabot (som bumpar) med SAST + license-/
-# sårbarhetsgrind på det som faktiskt introduceras i en PR.
+# Säkerhetsscanning (#909): statisk analys (CodeQL/SAST) på push/PR/veckoschema.
+# Kompletterar Dependabot (som bumpar) med SAST på koden.
 #
 # OBS: kräver att "CodeQL default setup" är AVSTÄNGT i repo-inställningarna
-# (annars krockar detta advanced-workflow med default-setupen). dependency-
-# review kräver ett publikt repo eller GitHub Advanced Security.
+# (annars krockar detta advanced-workflow med default-setupen).
+#
+# `dependency-review` (license-/CVE-grind på nya deps i en PR) är MEDVETET
+# borttaget tills repo:ts Dependency graph är aktiverad (Settings → Security →
+# "Dependency graph") — utan den svarar action:en hårt fel ("Dependency review
+# is not supported on this repository"). Återinförs i #915.
 
 on:
   push:
@@ -43,19 +46,3 @@ jobs:
         uses: github/codeql-action/analyze@v3
         with:
           category: "/language:javascript-typescript"
-
-  # ── Dependency review (bara PR) ────────────────────────────────────────────
-  dependency-review:
-    name: Dependency review
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v6
-      - name: Granska nya/ändrade beroenden
-        uses: actions/dependency-review-action@v4
-        with:
-          # Fäll PR om ett nytt beroende har en känd sårbarhet (moderate+).
-          fail-on-severity: moderate
-          # Blockera kopvänstriga/okända licenser som inte passar MIT-projektet.
-          deny-licenses: GPL-2.0, GPL-3.0, AGPL-3.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,61 @@
+name: Security
+
+# Säkerhetsscanning (#909): statisk analys (CodeQL/SAST) + granskning av nya
+# beroenden på PR. Kompletterar Dependabot (som bumpar) med SAST + license-/
+# sårbarhetsgrind på det som faktiskt introduceras i en PR.
+#
+# OBS: kräver att "CodeQL default setup" är AVSTÄNGT i repo-inställningarna
+# (annars krockar detta advanced-workflow med default-setupen). dependency-
+# review kräver ett publikt repo eller GitHub Advanced Security.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "0 3 * * 1" # måndag 03:00 UTC — fångar nya CVE:er i orörd kod
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ── CodeQL (SAST) ──────────────────────────────────────────────────────────
+  codeql:
+    name: CodeQL (JS/TS)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write # ladda upp SARIF till Security-fliken
+    steps:
+      - uses: actions/checkout@v6
+      - name: Initiera CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          build-mode: none # ren JS/TS → ingen kompilering behövs
+          queries: security-and-quality
+      - name: Analysera
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"
+
+  # ── Dependency review (bara PR) ────────────────────────────────────────────
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - name: Granska nya/ändrade beroenden
+        uses: actions/dependency-review-action@v4
+        with:
+          # Fäll PR om ett nytt beroende har en känd sårbarhet (moderate+).
+          fail-on-severity: moderate
+          # Blockera kopvänstriga/okända licenser som inte passar MIT-projektet.
+          deny-licenses: GPL-2.0, GPL-3.0, AGPL-3.0

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -40,16 +40,18 @@ lever som JSON i ett git-repo (se [`architecture.md`](./architecture.md)).
 |---|---|---|
 | Statisk typkontroll | TypeScript `tsc --noEmit` | `tsconfig.json` |
 | Lint + komplexitet | ESLint + `complexity` / `max-depth` / `max-params` | `tooling/config/eslint.config.mjs` |
-| Enhetstester | `bun test --isolate` | `bunfig.toml`, `test/unit/`, `test/integration/`, `test/scripts/` |
+| Enhetstester | `bun test` (2 pass, `run-tests.ts`) | `bunfig.toml`, `test/unit/`, `test/integration/`, `test/scripts/` |
 | Komponenttester (DOM) | `bun test` + happy-dom + Testing Library | `test/setup/happy-dom-register.ts`, `test/setup/preload.ts` |
-| E2E-tester | Playwright (Chromium) | `tooling/config/playwright.config.ts`, `test/e2e/` |
+| E2E-tester | Playwright (Chromium) — OIDC-login, demo-smoke, keep-both-konflikt | `tooling/config/playwright*.config.ts`, `test/e2e/` |
 | Kodtäckning | `bun test --coverage` (lcov) + ratchet-skript | `tooling/scripts/run-tests.ts` (`--coverage`) |
 | Duplikatdetektering (DRY) | jscpd | `tooling/config/jscpd.json` |
-| Bundle-size-budget | gzip-summa av klient-chunks + ratchet-skript | `tooling/scripts/check-bundle-size.ts` |
+| Bundle-size-budget | gzip-summa av klient-chunks + ratchet (körs i `demo-build`) | `tooling/scripts/check-bundle-size.ts` |
 | Arkitektur (SOLID/lager) | dependency-cruiser | `tooling/config/dependency-cruiser.cjs` |
 | Död kod / oanvända exports | knip | `tooling/config/knip.json` |
+| Säkerhet (SAST + deps) | CodeQL + `dependency-review` | `.github/workflows/security.yml` |
+| Beroende-uppdateringar | Dependabot (npm + github-actions) | `.github/dependabot.yml` |
 | Pre-commit | husky + lint-staged | `.husky/pre-commit`, `package.json` |
-| CI | GitHub Actions | `.github/workflows/ci.yml` |
+| CI | GitHub Actions (DRY toolchain-composite) | `.github/workflows/`, `.github/actions/bun-setup/` |
 
 ## Mått och tröskelvärden
 
@@ -71,14 +73,18 @@ funktioner per-fil-max av FNF/FNH) → eliminerar `--parallel`-flaken.
 > isolering men under-rapporterar coverage något (bun aggregerar löst över
 > workers) — deterministiskt, så golvet är giltigt.
 
-Aktuell baslinje (~2334 tester över 258 filer; ratchet, strax under faktisk):
+Ratchet-golvet lever i [`tooling/scripts/run-tests.ts`](../tooling/scripts/run-tests.ts)
+(`LINE_FLOOR` / `FUNC_FLOOR`) — flyttas BARA uppåt. Aktuell baslinje (ratchet,
+strax under faktisk):
 
-| Mått | Golv (`check-coverage.ts`) | Faktisk (lcov, src/, --parallel) |
+| Mått | Golv (`run-tests.ts`) | Faktisk (lcov, src/, --parallel) |
 |---|---|---|
-| Lines | 76 % | ~78.0 % |
-| Functions | 77 % | ~78.3 % |
+| Lines | 90.0 % | ~90.7 % |
+| Functions | 85.9 % | ~87.5 % |
 
-Coverage-rapporten skrivs till `coverage/` (lcov).
+Coverage-rapporten skrivs till `coverage/` (lcov). `helper-ui` har en egen
+coverage-ratchet i [`helper-ui/bunfig.toml`](../helper-ui/bunfig.toml)
+(`coverageThreshold`, line 0.90 / function 0.85).
 
 ### Komplexitet (`bun run lint`)
 
@@ -217,7 +223,7 @@ bun run test:fast         # bara unit + komponenttester (~18s)
 bun run quality:fast      # typecheck + lint + test:fast
 
 # Hela testsviten — startar docker compose, kör allt inkl. E2E
-bun run test:full
+bun run test:all
 
 # Full kvalitetscheck som CI kör
 bun run quality           # typecheck + lint + coverage + duplicates + deps + knip
@@ -226,8 +232,8 @@ bun run quality           # typecheck + lint + coverage + duplicates + deps + kn
 bun run quality:report    # coverage + jscpd + dep-graph
 
 # Specifika verktyg
-bun run test:cov          # tester + coverage-rapport (HTML i coverage/)
-bun run test:ui           # interaktiv vitest-UI
+bun run test:cov          # tester + coverage-rapport (lcov i coverage/)
+bun run size              # bundle-size-budget (kräver bun run build:demo först)
 bun run e2e               # Playwright headless
 bun run e2e:ui            # interaktiv Playwright
 bun run duplicates        # jscpd, rapport i reports/jscpd/html/
@@ -238,14 +244,36 @@ bun run knip              # oanvända filer/exporter
 
 ## Pipeline (CI)
 
-`.github/workflows/ci.yml` definierar fyra parallella jobb (Node 24):
+Toolchain-setupen (Node 24 + **pinnad** Bun + cachead `--frozen-lockfile`) är
+DRY:ad till composite-actionen
+[`.github/actions/bun-setup`](../.github/actions/bun-setup/action.yml) — byt
+bun-versionen där, gäller alla workflows. `ci.yml` har `concurrency`
+(cancel-in-progress) + least-privilege `permissions: contents: read`.
+
+`.github/workflows/ci.yml` definierar (Node 24):
 
 1. **Commit messages** — commitlint mot Conventional Commits (endast på PR).
-2. **Static analysis** — typecheck, lint (`--max-warnings 0`), depcruise, knip, jscpd. Inga tjänster.
-3. **Unit / komponent / integration** — vitest med coverage mot in-memory `DemoDataStore`. Inga externa tjänster (git-first → ingen Postgres).
-4. **E2E (git round-trip)** — Playwright Chromium mot docker-stacken (web + git-http-backend); startar docker, hämtar bootstrappad admin-PAT, pushar från browsern.
+2. **Static analysis** — typecheck, lint (`--max-warnings 0`), `lint:complexity-strict`, depcruise, knip, jscpd. Inga tjänster.
+3. **Unit / komponent / integration** — `bun test` (två pass, se ovan) med coverage-ratchet mot in-memory `DemoDataStore`.
+4. **Repository (Postgres)** — Drizzle-repo-sviten mot RIKTIG Postgres i docker (fångar driver-/SQL-skillnader).
+5. **Server-first (deploy E2E)** — bygger server-first-binären, kör som docker-container mot Postgres, synkar push/pull + dokument-pipeline över HTTP.
+6. **E2E (OIDC login)** — browser-inloggning mot Keycloak via oauth2-proxy (Playwright).
+7. **Demo build** *(PR)* — statisk GH Pages-export + **bundle-size-ratchet** (`bun run size`).
+8. **Demo E2E (browser-smoke)** *(PR)* — serverar `out/` och verifierar att demon LADDAR (inte bara bygger).
+9. **Keep-both konflikt-E2E** *(PR)* — 2-användar-konflikt mot full self-hosted-stack.
 
 Jobben laddar upp sina rapporter som artefakter (coverage, jscpd, playwright-report).
+
+Övriga workflows: **`deploy-demo.yml`** (GH Pages på push till `main`),
+**`helper-ui-ci.yml`** (Electron-helperns logik + motor), **`security.yml`**
+(CodeQL/SAST + `dependency-review` på PR, veckovis schema) och **`release.yml`**
+(tag-triggad paket-release). Beroenden hålls uppdaterade av
+[`.github/dependabot.yml`](../.github/dependabot.yml) (npm root + helper-ui +
+github-actions).
+
+> **Not:** jobb 7–9 är i dag INTE required checks (ingen branch-protection-
+> ändring gjord). `demo-build` skyddar en tyst felmod → kandidat för required
+> check ([#911](https://github.com/ulrik-s/ava/issues/911)).
 
 ## Pre-commit
 
@@ -258,11 +286,15 @@ Tunga checks (vitest, jscpd, depcruise) körs inte i pre-commit — de kör i CI
 
 ## När tröskelvärden behöver höjas
 
-Lägg PR som höjer värdet i `vitest.config.ts` → `coverage.thresholds`. Stegvis höjning är poängen — varje testnoll-PR ska minst hålla nuvarande nivå.
+Höj `LINE_FLOOR` / `FUNC_FLOOR` i
+[`tooling/scripts/run-tests.ts`](../tooling/scripts/run-tests.ts) (coverage),
+`BUDGET_KB` i [`check-bundle-size.ts`](../tooling/scripts/check-bundle-size.ts)
+(bundle) resp. `coverageThreshold` i `helper-ui/bunfig.toml`. Stegvis höjning är
+poängen — varje test-PR ska minst hålla nuvarande nivå. Gater tightnar bara.
 
 ## Referenser
 
-- [Vitest coverage](https://vitest.dev/guide/coverage.html)
+- [bun test](https://bun.sh/docs/cli/test) / [bun coverage](https://bun.sh/docs/test/coverage)
 - [Testing Library](https://testing-library.com/docs/react-testing-library/intro/)
 - [Playwright](https://playwright.dev/)
 - [jscpd](https://github.com/kucherenko/jscpd)

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -48,7 +48,7 @@ lever som JSON i ett git-repo (se [`architecture.md`](./architecture.md)).
 | Bundle-size-budget | gzip-summa av klient-chunks + ratchet (körs i `demo-build`) | `tooling/scripts/check-bundle-size.ts` |
 | Arkitektur (SOLID/lager) | dependency-cruiser | `tooling/config/dependency-cruiser.cjs` |
 | Död kod / oanvända exports | knip | `tooling/config/knip.json` |
-| Säkerhet (SAST + deps) | CodeQL + `dependency-review` | `.github/workflows/security.yml` |
+| Säkerhet (SAST) | CodeQL (JS/TS) — `dependency-review` väntar på Dependency graph (#915) | `.github/workflows/security.yml` |
 | Beroende-uppdateringar | Dependabot (npm + github-actions) | `.github/dependabot.yml` |
 | Pre-commit | husky + lint-staged | `.husky/pre-commit`, `package.json` |
 | CI | GitHub Actions (DRY toolchain-composite) | `.github/workflows/`, `.github/actions/bun-setup/` |
@@ -266,7 +266,8 @@ Jobben laddar upp sina rapporter som artefakter (coverage, jscpd, playwright-rep
 
 Övriga workflows: **`deploy-demo.yml`** (GH Pages på push till `main`),
 **`helper-ui-ci.yml`** (Electron-helperns logik + motor), **`security.yml`**
-(CodeQL/SAST + `dependency-review` på PR, veckovis schema) och **`release.yml`**
+(CodeQL/SAST på push/PR + veckovis schema; `dependency-review` väntar på att
+Dependency graph aktiveras, #915) och **`release.yml`**
 (tag-triggad paket-release). Beroenden hålls uppdaterade av
 [`.github/dependabot.yml`](../.github/dependabot.yml) (npm root + helper-ui +
 github-actions).


### PR DESCRIPTION
## Vad & varför

Genomgång av CI-pipelinen mot vad `docs/quality.md` utlovar. Flera luckor hittades och åtgärdas här — inklusive en **dokumenterad kvalitetsgrind som aldrig kördes**.

Stänger #909. Uppföljning: #910 (full SHA-pinning), #911 (befordra `demo-build` till required check — kräver branch-protection-ändring, görs ej i kod).

## Typ

- [x] `ci` / `docs` / `chore`

## Ändringar

**P0 — buggfix + härdning**
- **Bundle-size-ratchet wire:ad i CI.** `docs/quality.md` sa *"CI kör `bun run size` direkt efter build:demo"* — men inget workflow anropade den. Grinden var **död**; bundeln kunde svälla tyst förbi budgeten. Nu körs `bun run size` i `demo-build` (återanvänder dess `out/`).
- **`concurrency` (cancel-in-progress) i `ci.yml`** — en ny push avbryter den pågående tunga matrisen istället för att köra dubbletter.
- **Least-privilege `permissions`** — `contents: read` på `ci.yml` + `helper-ui-ci.yml`; `release.yml` skrivrättighet nedskalad till enbart release-jobbet.

**P1 — härdning/säkerhet**
- **Composite action `.github/actions/bun-setup`** — DRY:ar toolchain-setupen (Node 24 + **pinnad Bun 1.3.14** + **cachead** `--frozen-lockfile`) och ersätter de upprepade setup-blocken i alla 9 `ci.yml`-jobb + deploy/release/helper-ui. Pinning (var `latest`) ger reproducerbar CI; caching sparar ominstallation i ~9 jobb.
- **Dependabot** (`.github/dependabot.yml`) — veckovisa npm-uppdateringar för root + helper-ui + github-actions, grupperade minor/patch.
- **Säkerhetsscanning** (`.github/workflows/security.yml`) — CodeQL (JS/TS, `security-and-quality`) på push/PR/veckoschema + `dependency-review` på PR (fäller på moderate CVE:er, nekar copyleft-licenser).

**P2 — polish**
- **`docs/quality.md` synkad** med verkligheten (sa `vitest`, "git round-trip"-E2E (borttaget #422), fel coverage-golv, obefintliga scripts).
- **Issue-/PR-mallar** som speglar issue→PR-flödet i AGENTS.md.

## Verifierat lokalt

- [x] All workflow-/action-YAML validerar (`yaml.safe_load`).
- [x] Alla 9 `ci.yml`-jobb har `checkout` + composite; `commitlint`-jobbets `fetch-depth: 0` bevarat.
- [x] Commits följer Conventional Commits (headers ≤75, body-rader ≤79 tecken).
- [x] `bun.lock` är text-lockfile v1 (bun 1.2+) → pin till 1.3.14 säker.

## Att verifiera vid review

- **CodeQL:** kräver att "CodeQL default setup" är **avstängt** i repo-inställningarna (annars krockar advanced-workflow:et). Dokumenterat i `security.yml`.
- **`dependency-review`:** kräver publikt repo eller GitHub Advanced Security.
- **Bun-pin 1.3.14:** bekräfta att det matchar er faktiska bun-version (single-source i composite-actionen — en rad att ändra).

## Kvalitetsgrindar

- [x] Inga gater lösgjorda — tvärtom, en tidigare icke-körd ratchet aktiveras.
- [x] `.github/` är CODEOWNERS-kritisk path — granska extra noggrant.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_