### PR TITLE
feat(cli): ava CLI + MCP server over appRouter (PoC)

### DIFF
--- a/docs/adr/0035-ava-cli-och-mcp-over-approuter.md
+++ b/docs/adr/0035-ava-cli-och-mcp-over-approuter.md
@@ -1,0 +1,74 @@
+# ADR 0035 — `ava`-CLI + MCP-server över appRouter
+
+**Status:** Föreslagen (PoC) · **Datum:** 2026-07-30 · **Issue:** #913
+
+## Kontext
+
+En AI (t.ex. Claude via Claude Code CLI) ska smidigt kunna jobba mot AVA —
+hämta data, skapa fakturor, registrera tid osv. Web-appen är byggd för en
+människa i en browser; en AI behöver en skriptbar, maskinläsbar yta.
+
+Nyckelobservation: **hela applikationen *är* `appRouter`** (tRPC, 24 routrar,
+`src/lib/server/routers/_app.ts`). All affärslogik, validering (zod) och
+org-scoping bor där. Det finns redan två bevisade sätt att köra `appRouter`
+utanför browsern:
+
+1. **In-process caller** — `appRouter.createCaller(ctx)` mot en seedad
+   in-memory-store. Används av web/demo-klienten (`in-process-link.ts`) och av
+   *alla* integrationstester (`seed-smoke.test.ts`).
+2. **Tunn tRPC-over-HTTP-klient** — `createTRPCClient<AppRouter>()` +
+   `httpBatchLink` + superjson + Bearer-token. Används av helper-ui (ADR 0031)
+   och Office-add-ins (ADR 0013). Servern accepterar Bearer-JWT för icke-browser-
+   klienter (`server-context.ts` → `bearerClaims`, ADR 0028).
+
+## Beslut
+
+Bygg ett `ava`-CLI **och** en MCP-server som båda är *tunna frontends över
+`appRouter`* — noll duplicerad affärslogik. Gemensam kärna i `tooling/ava-cli/`:
+
+- **`introspect.ts`** — härleder kommandoytan ur `appRouter._def.procedures`
+  (path + query/mutation + zod-input som JSON-schema via `z.toJSONSchema`).
+  Kommandolistan är därmed **auto-härledd** och alltid i synk när routrar växer.
+- **`caller.ts`** — `AvaCaller.invoke(path, input)` bakom två transporter:
+  - **local** (default): in-process mot seedad store — ingen server, ingen auth.
+    Offline-sandlåda för AI + CI.
+  - **remote**: server-first över HTTP, `AVA_SERVER_URL` + `AVA_TOKEN` (Bearer).
+- **`cli.ts`** — ren `parseArgs` + `runParsed` (I/O injiceras) → JSON in/ut.
+- **`mcp.ts`** — rena JSON-RPC-hanterare; varje procedur blir ett MCP-verktyg.
+
+Bin:ar: `ava.ts` (CLI) och `ava-mcp.ts` (MCP stdio-server). Scripts: `bun run
+ava …`, `bun run ava:mcp`.
+
+### Varför `tooling/` och inte `src/`
+
+CLI:t är en *tooling/server*-artefakt (får importera server-*värden* som
+`createCaller` + `buildSeed`), inte en klient. `tooling/` ligger utanför
+dependency-cruisers lager-regler (`src|test|helper-ui|office-addin`), så det
+undviker `ui-imports-server-by-type-only` m.fl. utan undantag.
+
+## Konsekvenser
+
+**Positivt**
+- Full API-yta gratis; växer automatiskt med routrarna.
+- `ava describe` (zod→JSON-schema) + MCP `tools/list` låter en AI *själv upptäcka*
+  ytan. JSON in/ut, icke-noll exit-koder → maskinvänligt.
+- Local-mode ger en säker sandlåda (och snabb CI-yta) utan server/auth.
+- Samma kärna driver både CLI och MCP.
+
+**Avvägningar / uppföljning**
+- Introspektionen rör tRPC:s otypa `_def` (defensivt narrowat) — kan behöva
+  justeras vid tRPC-major-uppgradering. Vaktas av enhetstester.
+- MCP-protokollet är handrollat i PoC:en (initialize/tools.list/tools.call/ping);
+  skarp version bör byta till `@modelcontextprotocol/sdk`.
+- Remote-auth i PoC:en är en färdig Bearer-token via env. Ett riktigt
+  headless-login-flöde (OIDC client-credentials/device-code, jfr helperns
+  PKCE, ADR 0028) är eget arbete.
+- Wiring till alla kvalitetsgrindar (knip-entries, `deps:check`-scope,
+  coverage-ratchet) tas stegvis (#913).
+
+## Alternativ som förkastades
+
+- **Egen REST/GraphQL-yta** — dubblerar kontrakt, drar isär från tRPC-typerna.
+- **Bara MCP eller bara CLI** — CLI:t är skriptbart/komponerbart; MCP är
+  smidigast för AI:n. Samma kärna ger båda billigt.
+- **Direkt mot Postgres/repos** — kringgår routrarnas validering + org-scoping.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "demo:serve": "bash tooling/scripts/demo-serve.sh",
     "demo:serve:fast": "SKIP_BUILD=1 bash tooling/scripts/demo-serve.sh",
     "seed:local": "bun tooling/scripts/seed-firma-local.ts",
+    "ava": "bun tooling/ava-cli/ava.ts",
+    "ava:mcp": "bun tooling/ava-cli/ava-mcp.ts",
     "server-first": "bun src/bin/server-first.ts",
     "server-first:build": "bun tooling/scripts/build-server-first.ts",
     "install:server": "bun tooling/scripts/install-server.ts",

--- a/test/unit/ava-cli/cli.test.ts
+++ b/test/unit/ava-cli/cli.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Ren argument-parsing + körning för `ava`-CLI:t. Fejkar callern så inga
+ * server-/store-beroenden behövs.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import type { AvaCaller } from "../../../tooling/ava-cli/caller";
+import { parseArgs, runParsed, USAGE, type Mode, type RunDeps } from "../../../tooling/ava-cli/cli";
+import type { ProcedureInfo } from "../../../tooling/ava-cli/introspect";
+
+const PROCS: ProcedureInfo[] = [
+  { path: "invoice.list", type: "query", inputSchema: null },
+  { path: "invoice.createRadgivning", type: "mutation", inputSchema: null },
+];
+
+function fakeDeps(overrides: Partial<RunDeps> = {}): { deps: RunDeps; calls: { path: string; input: unknown; mode: Mode }[] } {
+  const calls: { path: string; input: unknown; mode: Mode }[] = [];
+  const openCaller = (mode: Mode): AvaCaller => ({
+    invoke: (path, input) => {
+      calls.push({ path, input, mode });
+      return Promise.resolve({ echoed: input });
+    },
+    close: () => Promise.resolve(),
+  });
+  return { deps: { procedures: PROCS, openCaller, ...overrides }, calls };
+}
+
+describe("parseArgs", () => {
+  it("tom input → help", () => {
+    expect(parseArgs([])).toEqual({ kind: "help" });
+    expect(parseArgs(["--help"])).toEqual({ kind: "help" });
+  });
+
+  it("describe med och utan prefix", () => {
+    expect(parseArgs(["describe"])).toEqual({ kind: "describe", prefix: null });
+    expect(parseArgs(["describe", "invoice"])).toEqual({ kind: "describe", prefix: "invoice" });
+  });
+
+  it("call: default local, --input som JSON, --remote", () => {
+    expect(parseArgs(["invoice.list"])).toEqual({ kind: "call", path: "invoice.list", input: {}, mode: "local" });
+    expect(parseArgs(["invoice.list", "--input", '{"status":"SENT"}'])).toEqual({
+      kind: "call", path: "invoice.list", input: { status: "SENT" }, mode: "local",
+    });
+    expect(parseArgs(["--remote", "invoice.list"]).kind).toBe("call");
+    expect((parseArgs(["--remote", "invoice.list"]) as { mode: Mode }).mode).toBe("remote");
+  });
+
+  it("--input=json-formen stöds", () => {
+    expect(parseArgs(["invoice.list", '--input={"a":1}'])).toEqual({
+      kind: "call", path: "invoice.list", input: { a: 1 }, mode: "local",
+    });
+  });
+
+  it("ogiltig JSON → error", () => {
+    expect(parseArgs(["invoice.list", "--input", "{bad"]).kind).toBe("error");
+  });
+});
+
+describe("runParsed", () => {
+  it("help skriver USAGE", async () => {
+    const { deps } = fakeDeps();
+    const res = await runParsed({ kind: "help" }, deps);
+    expect(res.code).toBe(0);
+    expect(res.stdout).toBe(USAGE);
+  });
+
+  it("error → kod 2 + usage", async () => {
+    const { deps } = fakeDeps();
+    const res = await runParsed({ kind: "error", message: "trasig" }, deps);
+    expect(res.code).toBe(2);
+    expect(res.stderr).toContain("trasig");
+    expect(res.stderr).toContain("Användning");
+  });
+
+  it("describe filtrerar på prefix", async () => {
+    const { deps } = fakeDeps();
+    const all = await runParsed({ kind: "describe", prefix: null }, deps);
+    expect(JSON.parse(all.stdout)).toHaveLength(2);
+    const filtered = await runParsed({ kind: "describe", prefix: "invoice.create" }, deps);
+    expect(JSON.parse(filtered.stdout)).toHaveLength(1);
+  });
+
+  it("call: okänd procedur → kod 1", async () => {
+    const { deps } = fakeDeps();
+    const res = await runParsed({ kind: "call", path: "nope.x", input: {}, mode: "local" }, deps);
+    expect(res.code).toBe(1);
+    expect(JSON.parse(res.stderr).error).toContain("Okänd procedur");
+  });
+
+  it("call: lyckas → JSON-resultat + rätt caller-anrop", async () => {
+    const { deps, calls } = fakeDeps();
+    const res = await runParsed({ kind: "call", path: "invoice.list", input: { status: "SENT" }, mode: "local" }, deps);
+    expect(res.code).toBe(0);
+    expect(JSON.parse(res.stdout)).toEqual({ echoed: { status: "SENT" } });
+    expect(calls).toEqual([{ path: "invoice.list", input: { status: "SENT" }, mode: "local" }]);
+  });
+
+  it("call: caller kastar → kod 1 med fel-JSON", async () => {
+    const { deps } = fakeDeps({
+      openCaller: (): AvaCaller => ({
+        invoke: () => Promise.reject(new Error("boom")),
+        close: () => Promise.resolve(),
+      }),
+    });
+    const res = await runParsed({ kind: "call", path: "invoice.list", input: {}, mode: "local" }, deps);
+    expect(res.code).toBe(1);
+    expect(JSON.parse(res.stderr).error).toBe("boom");
+  });
+
+  it("call: openCaller kastar (t.ex. saknad remote-env) → kod 1", async () => {
+    const { deps } = fakeDeps({
+      openCaller: (): AvaCaller => {
+        throw new Error("AVA_SERVER_URL saknas");
+      },
+    });
+    const res = await runParsed({ kind: "call", path: "invoice.list", input: {}, mode: "remote" }, deps);
+    expect(res.code).toBe(1);
+    expect(JSON.parse(res.stderr).error).toContain("AVA_SERVER_URL");
+  });
+});

--- a/test/unit/ava-cli/introspect.test.ts
+++ b/test/unit/ava-cli/introspect.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Introspektion av appRouter → CLI/MCP-yta. Verifierar att kända procedurer
+ * dyker upp med rätt typ + att JSON-schema-serialiseringen är fail-soft.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { listProcedures, procedureTypeMap } from "../../../tooling/ava-cli/introspect";
+
+describe("listProcedures", () => {
+  it("hittar kända procedurer med rätt typ", () => {
+    const procs = listProcedures();
+    const byPath = new Map(procs.map((p) => [p.path, p]));
+    expect(byPath.get("invoice.list")?.type).toBe("query");
+    expect(byPath.get("invoice.createRadgivning")?.type).toBe("mutation");
+    expect(byPath.get("contacts.getById")?.type).toBe("query");
+  });
+
+  it("är sorterad på path och icke-tom", () => {
+    const procs = listProcedures();
+    expect(procs.length).toBeGreaterThan(20);
+    const paths = procs.map((p) => p.path);
+    expect([...paths].sort((a, b) => a.localeCompare(b))).toEqual(paths);
+  });
+
+  it("serialiserar input-schema utan att kasta (fail-soft)", () => {
+    const withInput = listProcedures().find((p) => p.path === "contacts.getById");
+    // getById tar { id }; schemat serialiseras till ett objekt-JSON-schema.
+    expect(withInput).toBeDefined();
+    expect(() => JSON.stringify(withInput?.inputSchema)).not.toThrow();
+  });
+});
+
+describe("procedureTypeMap", () => {
+  it("mappar path → typ", () => {
+    const map = procedureTypeMap(listProcedures());
+    expect(map.get("invoice.list")).toBe("query");
+    expect(map.get("invoice.createRadgivning")).toBe("mutation");
+  });
+});

--- a/test/unit/ava-cli/mcp.test.ts
+++ b/test/unit/ava-cli/mcp.test.ts
@@ -1,0 +1,97 @@
+/**
+ * MCP-meddelandehanterare. Fejkar callern → verifierar protokoll-formen
+ * (initialize/tools.list/tools.call) utan server.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import type { AvaCaller } from "../../../tooling/ava-cli/caller";
+import type { ProcedureInfo } from "../../../tooling/ava-cli/introspect";
+import {
+  handleMessage,
+  listTools,
+  MCP_PROTOCOL_VERSION,
+  pathFromTool,
+  toolName,
+  type McpDeps,
+} from "../../../tooling/ava-cli/mcp";
+
+const PROCS: ProcedureInfo[] = [
+  { path: "invoice.list", type: "query", inputSchema: { type: "object" } },
+  { path: "contacts.getById", type: "query", inputSchema: null },
+];
+
+function deps(overrides: Partial<AvaCaller> = {}): McpDeps {
+  const caller: AvaCaller = {
+    invoke: (path, input) => Promise.resolve({ path, input }),
+    close: () => Promise.resolve(),
+    ...overrides,
+  };
+  return { procedures: PROCS, caller, serverInfo: { name: "ava-mcp", version: "0.1.0" } };
+}
+
+describe("toolName/pathFromTool", () => {
+  it("kodar/avkodar path", () => {
+    expect(toolName("invoice.list")).toBe("invoice__list");
+    expect(pathFromTool("invoice__list")).toBe("invoice.list");
+  });
+});
+
+describe("listTools", () => {
+  it("mappar procedurer → verktyg (null-schema → tomt objekt-schema)", () => {
+    const tools = listTools(PROCS);
+    expect(tools[0]).toEqual({ name: "invoice__list", description: "query invoice.list", inputSchema: { type: "object" } });
+    expect(tools[1]?.inputSchema).toEqual({ type: "object" });
+  });
+});
+
+describe("handleMessage", () => {
+  it("initialize returnerar protokoll + serverInfo", async () => {
+    const res = await handleMessage({ jsonrpc: "2.0", id: 1, method: "initialize" }, deps());
+    expect(res).toEqual({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { protocolVersion: MCP_PROTOCOL_VERSION, capabilities: { tools: {} }, serverInfo: { name: "ava-mcp", version: "0.1.0" } },
+    });
+  });
+
+  it("tools/list listar alla procedurer", async () => {
+    const res = await handleMessage({ jsonrpc: "2.0", id: 2, method: "tools/list" }, deps());
+    const result = res?.result as { tools: unknown[] };
+    expect(result.tools).toHaveLength(2);
+  });
+
+  it("tools/call anropar callern och wrappar resultatet som text-content", async () => {
+    const res = await handleMessage(
+      { jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "invoice__list", arguments: { status: "SENT" } } },
+      deps(),
+    );
+    const result = res?.result as { content: { type: string; text: string }[]; isError?: boolean };
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content[0]!.text)).toEqual({ path: "invoice.list", input: { status: "SENT" } });
+  });
+
+  it("tools/call med caller-fel → isError-content (inte JSON-RPC-error)", async () => {
+    const res = await handleMessage(
+      { jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "invoice__list", arguments: {} } },
+      deps({ invoke: () => Promise.reject(new Error("nekad")) }),
+    );
+    const result = res?.result as { content: { text: string }[]; isError?: boolean };
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toBe("nekad");
+  });
+
+  it("notifikation (utan id) → inget svar", async () => {
+    const res = await handleMessage({ jsonrpc: "2.0", method: "notifications/initialized" }, deps());
+    expect(res).toBeNull();
+  });
+
+  it("okänd metod → -32601", async () => {
+    const res = await handleMessage({ jsonrpc: "2.0", id: 5, method: "does/not/exist" }, deps());
+    expect(res?.error?.code).toBe(-32601);
+  });
+
+  it("ping → tomt resultat", async () => {
+    const res = await handleMessage({ jsonrpc: "2.0", id: 6, method: "ping" }, deps());
+    expect(res?.result).toEqual({});
+  });
+});

--- a/tooling/ava-cli/ava-mcp.ts
+++ b/tooling/ava-cli/ava-mcp.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env bun
+/**
+ * `ava-mcp` — MCP-server-bin (stdio). Tunt skal runt `handleMessage` (mcp.ts):
+ * läser radavgränsade JSON-RPC-meddelanden från stdin, svarar på stdout.
+ * Registrera i Claude Code som en MCP-server (`command: bun`, `args:
+ * [tooling/ava-cli/ava-mcp.ts]`) → hela AVA-API:t blir verktyg.
+ *
+ * Läge: remote om AVA_SERVER_URL + AVA_TOKEN finns, annars local (sandlåda).
+ */
+
+import { createLocalCaller, createRemoteCaller, type AvaCaller } from "./caller";
+import { listProcedures, procedureTypeMap } from "./introspect";
+import { handleMessage, type McpDeps } from "./mcp";
+
+const VERSION = "0.1.0";
+
+function makeCaller(): AvaCaller {
+  const serverUrl = process.env.AVA_SERVER_URL;
+  const token = process.env.AVA_TOKEN;
+  if (serverUrl && token) return createRemoteCaller({ serverUrl, token }, procedureTypeMap(listProcedures()));
+  return createLocalCaller();
+}
+
+function main(): void {
+  const deps: McpDeps = { procedures: listProcedures(), caller: makeCaller(), serverInfo: { name: "ava-mcp", version: VERSION } };
+  let buf = "";
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk: string) => {
+    buf += chunk;
+    let nl = buf.indexOf("\n");
+    while (nl >= 0) {
+      const line = buf.slice(0, nl).trim();
+      buf = buf.slice(nl + 1);
+      if (line) void dispatch(line, deps);
+      nl = buf.indexOf("\n");
+    }
+  });
+  process.stdin.on("end", () => process.exit(0));
+}
+
+async function dispatch(line: string, deps: McpDeps): Promise<void> {
+  let msg: unknown;
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    return; // ignorera trasiga rader
+  }
+  const resp = await handleMessage(msg as Parameters<typeof handleMessage>[0], deps);
+  if (resp) process.stdout.write(`${JSON.stringify(resp)}\n`);
+}
+
+main();

--- a/tooling/ava-cli/ava.ts
+++ b/tooling/ava-cli/ava.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env bun
+/**
+ * `ava` — CLI-bin. Tunt skal runt `parseArgs`/`runParsed` (cli.ts): löser
+ * `--input @fil`/`-`, väljer local/remote-caller och skriver resultatet.
+ *
+ * Local (default): in-process mot seedad store — ingen server, ingen auth.
+ * Remote (`--remote`): server-first över HTTP; kräver AVA_SERVER_URL + AVA_TOKEN.
+ */
+
+import { readFileSync } from "node:fs";
+import { createLocalCaller, createRemoteCaller, type AvaCaller } from "./caller";
+import { parseArgs, runParsed, type Mode, type RunDeps } from "./cli";
+import { listProcedures, procedureTypeMap } from "./introspect";
+
+/** `-` → stdin, `@fil` → filens innehåll, annars värdet oförändrat. */
+function readInputValue(v: string): string {
+  if (v === "-") return readFileSync(0, "utf8");
+  if (v.startsWith("@")) return readFileSync(v.slice(1), "utf8");
+  return v;
+}
+
+/** Lös upp `--input`-värdet (fil/stdin) innan den rena parsern körs. */
+function preprocess(argv: readonly string[]): string[] {
+  return argv.map((a, i) => {
+    if (a.startsWith("--input=")) return `--input=${readInputValue(a.slice("--input=".length))}`;
+    if (i > 0 && argv[i - 1] === "--input") return readInputValue(a);
+    return a;
+  });
+}
+
+function openCaller(mode: Mode): AvaCaller {
+  if (mode === "remote") {
+    const serverUrl = process.env.AVA_SERVER_URL;
+    const token = process.env.AVA_TOKEN;
+    if (!serverUrl || !token) {
+      throw new Error("--remote kräver AVA_SERVER_URL och AVA_TOKEN i miljön.");
+    }
+    return createRemoteCaller({ serverUrl, token }, procedureTypeMap(listProcedures()));
+  }
+  return createLocalCaller();
+}
+
+async function main(): Promise<void> {
+  const deps: RunDeps = { procedures: listProcedures(), openCaller };
+  const res = await runParsed(parseArgs(preprocess(process.argv.slice(2))), deps);
+  if (res.stdout) process.stdout.write(`${res.stdout}\n`);
+  if (res.stderr) process.stderr.write(`${res.stderr}\n`);
+  process.exit(res.code);
+}
+
+void main();

--- a/tooling/ava-cli/caller.ts
+++ b/tooling/ava-cli/caller.ts
@@ -1,0 +1,160 @@
+/**
+ * `caller` — transport-agnostisk åtkomst till hela `appRouter`-ytan.
+ *
+ * Två impl:er bakom EN `invoke(path, input)`, precis de två bevisade sömmarna
+ * i kodbasen:
+ *   - LOCAL  — `appRouter.createCaller(ctx)` mot en seedad in-memory-store
+ *     (samma mönster som integrationstesterna, `seed-smoke.test.ts`). Ingen
+ *     server, ingen auth → offline-sandlåda för en AI + CI.
+ *   - REMOTE — `createTRPCClient<AppRouter>()` över HTTP med Bearer-token
+ *     (samma mönster som helper-ui/Office-add-ins, ADR 0031/0013) → mot en
+ *     körande server-first (Postgres), auktoritativt.
+ *
+ * All affärslogik bor i `appRouter`; det här är bara transport. Noll duplicering.
+ */
+
+import { createTRPCClient, httpBatchLink } from "@trpc/client";
+import superjson from "superjson";
+import { buildGitPorts } from "@/lib/server/adapters/git-ports";
+import type { Principal } from "@/lib/server/auth/principal";
+import { DemoDataStore, type DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import { buildInMemoryRepositories } from "@/lib/server/repositories/in-memory-repositories";
+import { appRouter, type AppRouter } from "@/lib/server/routers/_app";
+import { prebakeJoins } from "@/lib/shared/demo-source";
+import { asId } from "@/lib/shared/schemas/ids";
+import { buildSeed } from "../scripts/seed-data";
+import type { ProcedureType } from "./introspect";
+
+/** En anropbar vy av AVA-API:t. `invoke` tar dotted path + JSON-input. */
+export interface AvaCaller {
+  invoke(path: string, input: unknown): Promise<unknown>;
+  close(): Promise<void>;
+}
+
+/** Local-mode-principal (default = seed:ens admin, som i integrationstesterna). */
+export interface LocalPrincipal {
+  id: string;
+  email: string;
+  name: string;
+  role: "ADMIN" | "LAWYER";
+  organizationId: string;
+}
+
+const DEFAULT_PRINCIPAL: LocalPrincipal = {
+  id: "current-user",
+  email: "user@firma.local",
+  name: "Anna Advokat",
+  role: "ADMIN",
+  organizationId: "firma-ab",
+};
+
+/** Bygg en seedad `DemoSource` ur den delade seed-fabriken (`buildSeed`). */
+function seededSource(): DemoSource {
+  const seed = buildSeed();
+  return prebakeJoins({
+    organizations: seed.organizations,
+    offices: seed.offices,
+    users: seed.users,
+    contacts: seed.contacts,
+    matters: seed.matters,
+    matterContacts: seed.matterContacts,
+    documents: seed.documents,
+    timeEntries: seed.timeEntries,
+    expenses: seed.expenses,
+    invoices: seed.invoices,
+    calendarEvents: seed.calendarEvents,
+    tasks: seed.tasks,
+    documentTemplates: seed.documentTemplates,
+    conflictChecks: seed.conflictChecks,
+    paymentPlans: seed.paymentPlans,
+    paymentPlanReminders: seed.paymentPlanReminders,
+    payments: seed.payments,
+  } as DemoSource);
+}
+
+/** Procedurer/callers är callable-objekt → `object`-test räcker inte. */
+function isObjectLike(v: unknown): v is Record<string, unknown> {
+  return v !== null && (typeof v === "object" || typeof v === "function");
+}
+
+/**
+ * Gå ned i ett objekt via dotted path; kastar på okänd path. Direkt
+ * property-access (inte `in`) eftersom tRPC:s caller/klient är en Proxy utan
+ * `has`-trap → `"x" in proxy` ljuger.
+ */
+function resolveNode(root: unknown, path: string): unknown {
+  let cur: unknown = root;
+  for (const seg of path.split(".")) {
+    if (!isObjectLike(cur)) throw new Error(`Okänd procedur: ${path}`);
+    cur = cur[seg];
+    if (cur === undefined) throw new Error(`Okänd procedur: ${path}`);
+  }
+  return cur;
+}
+
+type ProcFn = (input: unknown) => Promise<unknown>;
+
+function asProcFn(node: unknown, path: string): ProcFn {
+  if (typeof node !== "function") throw new Error(`Okänd procedur: ${path}`);
+  return node as ProcFn;
+}
+
+/** Branda de plana id-strängarna till principal-formen routrarna kräver. */
+function toPrincipal(p: LocalPrincipal): Principal {
+  return {
+    id: asId<"UserId">(p.id),
+    email: p.email,
+    name: p.name,
+    role: p.role,
+    organizationId: asId<"OrganizationId">(p.organizationId),
+  };
+}
+
+/** LOCAL: in-process caller mot seedad store (ingen server/auth). */
+export function createLocalCaller(principal: LocalPrincipal = DEFAULT_PRINCIPAL): AvaCaller {
+  const dataStore = new DemoDataStore(seededSource(), async () => {
+    /* no-op write-back (mimikar prod:s FSA/OPFS så delegates är skrivbara) */
+  });
+  const caller = appRouter.createCaller({
+    user: toPrincipal(principal),
+    dataStore,
+    ports: buildGitPorts(dataStore),
+    repos: buildInMemoryRepositories(dataStore),
+  });
+  return {
+    invoke: (path, input) => asProcFn(resolveNode(caller, path), path)(input),
+    close: () => Promise.resolve(),
+  };
+}
+
+/** tRPC-endpointens suffix (matchar helper-ui/server-first `/api/trpc`). */
+export function trpcEndpoint(serverUrl: string): string {
+  return `${serverUrl.replace(/\/+$/, "")}/api/trpc`;
+}
+
+export interface RemoteOpts {
+  serverUrl: string;
+  token: string;
+}
+
+/** REMOTE: tunn tRPC-over-HTTP-klient mot server-first, Bearer-auth. */
+export function createRemoteCaller(opts: RemoteOpts, types: Map<string, ProcedureType>): AvaCaller {
+  const client = createTRPCClient<AppRouter>({
+    links: [
+      httpBatchLink({
+        url: trpcEndpoint(opts.serverUrl),
+        transformer: superjson,
+        headers: () => ({ authorization: `Bearer ${opts.token}` }),
+      }),
+    ],
+  });
+  return {
+    invoke: (path, input) => {
+      const node = resolveNode(client, path);
+      const method = types.get(path) === "mutation" ? "mutate" : "query";
+      if (node === null || typeof node !== "object") throw new Error(`Okänd procedur: ${path}`);
+      return asProcFn((node as Record<string, unknown>)[method], path)(input);
+    },
+    close: () => Promise.resolve(),
+  };
+}

--- a/tooling/ava-cli/cli.ts
+++ b/tooling/ava-cli/cli.ts
@@ -1,0 +1,180 @@
+/**
+ * `cli` — ren argument-parsing + körning för `ava`-CLI:t.
+ *
+ * `parseArgs` (ren) → en diskriminerad union; `runParsed` (I/O via injicerade
+ * deps) → `{ code, stdout, stderr }`. Bin:en (`ava.ts`) är ett tunt skal runt
+ * dessa två + `console`/`process.exit`, så all logik är enhetstestbar utan att
+ * spawna en process.
+ */
+
+import type { AvaCaller } from "./caller";
+import type { ProcedureInfo } from "./introspect";
+
+export type Mode = "local" | "remote";
+
+export type Parsed =
+  | { kind: "help" }
+  | { kind: "describe"; prefix: string | null }
+  | { kind: "call"; path: string; input: unknown; mode: Mode }
+  | { kind: "error"; message: string };
+
+export const USAGE = `ava — CLI över AVA:s tRPC-API (auto-härlett ur appRouter)
+
+Användning:
+  ava describe [prefix]            Lista procedurer (+ JSON-schema för input)
+  ava <router.procedur> [flaggor]  Anropa en procedur, skriv resultatet som JSON
+
+Flaggor:
+  --input <json>   Input som JSON (default {}). Bin stödjer även @fil och -.
+  --local          In-process mot seedad store (default; ingen server/auth)
+  --remote         Mot server-first över HTTP (AVA_SERVER_URL + AVA_TOKEN)
+  --help           Visa den här hjälpen
+
+Exempel:
+  ava describe invoice
+  ava invoice.list --input '{"status":"SENT"}'
+  ava contacts.getById --input '{"id":"c-1"}'
+  ava --remote invoice.createRadgivning --input '{"matterId":"m-1"}'`;
+
+interface Flags {
+  input: string | null;
+  mode: Mode;
+  help: boolean;
+}
+
+/**
+ * Matcha en flagga → mutera `flags`, returnera antal *extra* argv-tokens som
+ * konsumerats (0/1), eller `null` om `a` inte är en känd flagga.
+ */
+/** Value-lösa flaggor → mutator. Håller `matchFlag` under complexity-taket. */
+const SIMPLE_FLAGS: Record<string, (f: Flags) => void> = {
+  "--help": (f) => {
+    f.help = true;
+  },
+  "-h": (f) => {
+    f.help = true;
+  },
+  "--local": (f) => {
+    f.mode = "local";
+  },
+  "--remote": (f) => {
+    f.mode = "remote";
+  },
+};
+
+function matchFlag(a: string, next: string | undefined, flags: Flags): number | null {
+  const simple = SIMPLE_FLAGS[a];
+  if (simple) {
+    simple(flags);
+    return 0;
+  }
+  if (a === "--input" || a === "--input=") {
+    flags.input = next ?? "";
+    return 1;
+  }
+  if (a.startsWith("--input=")) {
+    flags.input = a.slice("--input=".length);
+    return 0;
+  }
+  return null;
+}
+
+/** Dela argv i positionella + flaggor. `--k v` och `--k=v` stöds. */
+function splitArgs(argv: readonly string[]): { positionals: string[]; flags: Flags } {
+  const positionals: string[] = [];
+  const flags: Flags = { input: null, mode: "local", help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]!;
+    const consumed = matchFlag(a, argv[i + 1], flags);
+    if (consumed === null) {
+      if (!a.startsWith("-")) positionals.push(a);
+    } else {
+      i += consumed;
+    }
+  }
+  return { positionals, flags };
+}
+
+/** Tolka --input-strängen till ett JSON-värde (default {}). */
+function parseInput(raw: string | null): { ok: true; value: unknown } | { ok: false; message: string } {
+  if (raw === null || raw.trim() === "") return { ok: true, value: {} };
+  try {
+    return { ok: true, value: JSON.parse(raw) };
+  } catch {
+    return { ok: false, message: `Ogiltig JSON i --input: ${raw}` };
+  }
+}
+
+/** Ren parsning av `ava`-argv → diskriminerad union. */
+export function parseArgs(argv: readonly string[]): Parsed {
+  const { positionals, flags } = splitArgs(argv);
+  if (flags.help || positionals.length === 0) return { kind: "help" };
+  const [cmd, ...rest] = positionals;
+  if (cmd === "describe") return { kind: "describe", prefix: rest[0] ?? null };
+  const parsed = parseInput(flags.input);
+  if (!parsed.ok) return { kind: "error", message: parsed.message };
+  return { kind: "call", path: cmd!, input: parsed.value, mode: flags.mode };
+}
+
+export interface RunDeps {
+  procedures: readonly ProcedureInfo[];
+  /** Öppna en caller för valt läge (bin läser env för remote; tester stubbar). */
+  openCaller: (mode: Mode) => AvaCaller;
+}
+
+export interface RunResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+const json = (v: unknown): string => JSON.stringify(v, null, 2);
+
+function runDescribe(prefix: string | null, procs: readonly ProcedureInfo[]): RunResult {
+  const hits = prefix ? procs.filter((p) => p.path.startsWith(prefix)) : procs;
+  return { code: 0, stdout: json(hits), stderr: "" };
+}
+
+const errResult = (err: unknown): RunResult => ({
+  code: 1,
+  stdout: "",
+  stderr: json({ error: err instanceof Error ? err.message : String(err) }),
+});
+
+async function invokeWith(caller: AvaCaller, call: Extract<Parsed, { kind: "call" }>): Promise<RunResult> {
+  try {
+    const result = await caller.invoke(call.path, call.input);
+    return { code: 0, stdout: json(result ?? null), stderr: "" };
+  } catch (err) {
+    return errResult(err);
+  } finally {
+    await caller.close();
+  }
+}
+
+async function runCall(call: Extract<Parsed, { kind: "call" }>, deps: RunDeps): Promise<RunResult> {
+  if (!deps.procedures.some((p) => p.path === call.path)) {
+    return { code: 1, stdout: "", stderr: json({ error: `Okänd procedur: ${call.path} (kör 'ava describe')` }) };
+  }
+  let caller: AvaCaller;
+  try {
+    caller = deps.openCaller(call.mode);
+  } catch (err) {
+    return errResult(err);
+  }
+  return invokeWith(caller, call);
+}
+
+/** Kör ett redan parsat kommando. I/O via `deps` → helt testbar. */
+export function runParsed(parsed: Parsed, deps: RunDeps): Promise<RunResult> {
+  switch (parsed.kind) {
+    case "help":
+      return Promise.resolve({ code: 0, stdout: USAGE, stderr: "" });
+    case "error":
+      return Promise.resolve({ code: 2, stdout: "", stderr: `${parsed.message}\n\n${USAGE}` });
+    case "describe":
+      return Promise.resolve(runDescribe(parsed.prefix, deps.procedures));
+    case "call":
+      return runCall(parsed, deps);
+  }
+}

--- a/tooling/ava-cli/introspect.ts
+++ b/tooling/ava-cli/introspect.ts
@@ -1,0 +1,89 @@
+/**
+ * `introspect` — härleder AVA:s kommandoyta ur `appRouter` (single source of
+ * truth). Går igenom tRPC-routerns procedurer och exponerar path + typ
+ * (query/mutation) + zod-input som JSON-schema. CLI:t (`describe`) och
+ * MCP-servern (`tools/list`) bygger båda sin yta härifrån → noll handkodad
+ * kommandolista, alltid i synk när routrar växer.
+ *
+ * Rör tRPC v11:s interna `_def`-form. Den är inte publikt typad, så vi läser
+ * den defensivt via `unknown`-narrowing (inga `any`, inga double-casts).
+ */
+
+import { z } from "zod";
+import { appRouter } from "@/lib/server/routers/_app";
+
+export type ProcedureType = "query" | "mutation" | "subscription";
+
+export interface ProcedureInfo {
+  /** Punktseparerad path, t.ex. `invoice.list`. */
+  path: string;
+  type: ProcedureType;
+  /** Input-schemat som JSON-schema, eller `null` om det saknas/inte kan serialiseras. */
+  inputSchema: unknown;
+}
+
+interface ProcedureDefLike {
+  type?: unknown;
+  inputs?: unknown;
+}
+
+function isProcedureType(v: unknown): v is ProcedureType {
+  return v === "query" || v === "mutation" || v === "subscription";
+}
+
+/** Läs `router._def.procedures` (flat map `"a.b" → procedure`) defensivt. */
+function readProcedures(): Record<string, unknown> {
+  // Enda beröringen med tRPC:s otypa interna form; `_def` finns i v11.
+  const def = (appRouter as { _def?: { procedures?: unknown } })._def;
+  const procs = def?.procedures;
+  return procs !== null && typeof procs === "object" ? (procs as Record<string, unknown>) : {};
+}
+
+/** Sista zod-schemat i procedurens input-kedja (tRPC mergear flera `.input()`). */
+function lastZodInput(inputs: unknown): z.ZodType | null {
+  if (!Array.isArray(inputs) || inputs.length === 0) return null;
+  const last: unknown = inputs[inputs.length - 1];
+  return last instanceof z.ZodType ? last : null;
+}
+
+/** zod → JSON-schema; fail-soft till `null` för scheman zod inte kan serialisera. */
+function toJsonSchema(schema: z.ZodType | null): unknown {
+  if (!schema) return null;
+  try {
+    return z.toJSONSchema(schema, { io: "input" });
+  } catch {
+    return null;
+  }
+}
+
+/** Procedurer är callable-objekt (funktioner) → `object`-test räcker inte. */
+function isObjectLike(v: unknown): v is Record<string, unknown> {
+  return v !== null && (typeof v === "object" || typeof v === "function");
+}
+
+function readDef(proc: unknown): ProcedureDefLike {
+  if (isObjectLike(proc) && "_def" in proc) {
+    const def = proc._def;
+    if (isObjectLike(def)) return def as ProcedureDefLike;
+  }
+  return {};
+}
+
+/** Hela procedur-ytan, sorterad på path. Ren funktion (deterministisk). */
+export function listProcedures(): ProcedureInfo[] {
+  const out: ProcedureInfo[] = [];
+  for (const [path, proc] of Object.entries(readProcedures())) {
+    const def = readDef(proc);
+    out.push({
+      path,
+      type: isProcedureType(def.type) ? def.type : "query",
+      inputSchema: toJsonSchema(lastZodInput(def.inputs)),
+    });
+  }
+  return out.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+/** Path → typ, för remote-callern (query vs mutate) och MCP. */
+export function procedureTypeMap(procs: readonly ProcedureInfo[]): Map<string, ProcedureType> {
+  return new Map(procs.map((p) => [p.path, p.type]));
+}

--- a/tooling/ava-cli/mcp.ts
+++ b/tooling/ava-cli/mcp.ts
@@ -1,0 +1,129 @@
+/**
+ * `mcp` — rena MCP-meddelandehanterare (Model Context Protocol, JSON-RPC 2.0).
+ *
+ * Exponerar hela `appRouter`-ytan som MCP-verktyg (`tools/list` + `tools/call`)
+ * så Claude kan anropa AVA som *verktyg* direkt — hämta data, skapa fakturor
+ * osv. Samma introspektion + samma `AvaCaller` som CLI:t; MCP är bara ett annat
+ * skal. `handleMessage` är ren (I/O görs i bin:en `ava-mcp.ts` via stdio).
+ *
+ * PoC: minimal handroll av protokollet (initialize/tools.list/tools.call/ping)
+ * utan SDK-beroende — logiken är testbar. Skarp version bör byta till
+ * `@modelcontextprotocol/sdk` (se ADR 0035).
+ */
+
+import type { AvaCaller } from "./caller";
+import type { ProcedureInfo } from "./introspect";
+
+export const MCP_PROTOCOL_VERSION = "2024-11-05";
+
+export interface JsonRpcMessage {
+  jsonrpc?: string;
+  id?: number | string | null;
+  method?: string;
+  params?: unknown;
+}
+
+export interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: number | string | null;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+export interface McpTool {
+  name: string;
+  description: string;
+  inputSchema: unknown;
+}
+
+export interface McpServerInfo {
+  name: string;
+  version: string;
+}
+
+export interface McpDeps {
+  procedures: readonly ProcedureInfo[];
+  caller: AvaCaller;
+  serverInfo: McpServerInfo;
+}
+
+/** Fel som mappas till JSON-RPC `-32601 Method not found`. */
+class MethodNotFound extends Error {
+  constructor(method: string) {
+    super(`Okänd metod: ${method}`);
+    this.name = "MethodNotFound";
+  }
+}
+
+/** MCP-verktygsnamn tillåter inte `.` → koda path som `router__proc`. */
+export function toolName(path: string): string {
+  return path.replace(/\./g, "__");
+}
+export function pathFromTool(name: string): string {
+  return name.replace(/__/g, ".");
+}
+
+/** Hela procedur-ytan som MCP-verktygsdefinitioner. */
+export function listTools(procs: readonly ProcedureInfo[]): McpTool[] {
+  return procs.map((p) => ({
+    name: toolName(p.path),
+    description: `${p.type} ${p.path}`,
+    inputSchema: p.inputSchema ?? { type: "object" },
+  }));
+}
+
+function callParams(params: unknown): { name: string; args: unknown } {
+  if (params !== null && typeof params === "object") {
+    const p = params as Record<string, unknown>;
+    if (typeof p.name === "string") return { name: p.name, args: p.arguments ?? {} };
+  }
+  throw new Error("tools/call kräver { name, arguments }");
+}
+
+async function callTool(params: unknown, deps: McpDeps): Promise<unknown> {
+  const { name, args } = callParams(params);
+  try {
+    const data = await deps.caller.invoke(pathFromTool(name), args);
+    return { content: [{ type: "text", text: JSON.stringify(data ?? null, null, 2) }] };
+  } catch (err) {
+    return { content: [{ type: "text", text: err instanceof Error ? err.message : String(err) }], isError: true };
+  }
+}
+
+function resultFor(method: string, params: unknown, deps: McpDeps): Promise<unknown> {
+  switch (method) {
+    case "initialize":
+      return Promise.resolve({ protocolVersion: MCP_PROTOCOL_VERSION, capabilities: { tools: {} }, serverInfo: deps.serverInfo });
+    case "tools/list":
+      return Promise.resolve({ tools: listTools(deps.procedures) });
+    case "tools/call":
+      return callTool(params, deps);
+    case "ping":
+      return Promise.resolve({});
+    default:
+      return Promise.reject(new MethodNotFound(method));
+  }
+}
+
+/** En request utan `id` är en notifikation (inget svar ska skickas). */
+function isNotification(msg: JsonRpcMessage): boolean {
+  return msg.id === undefined || msg.id === null;
+}
+
+/**
+ * Hantera ett inkommande JSON-RPC-meddelande → svar (eller `null` för
+ * notifikationer). Ren: all faktisk data hämtas via `deps.caller`.
+ */
+export async function handleMessage(msg: JsonRpcMessage, deps: McpDeps): Promise<JsonRpcResponse | null> {
+  if (typeof msg.method !== "string") return null;
+  const notification = isNotification(msg);
+  const id = msg.id ?? null;
+  try {
+    const result = await resultFor(msg.method, msg.params, deps);
+    return notification ? null : { jsonrpc: "2.0", id, result };
+  } catch (err) {
+    if (notification) return null;
+    const code = err instanceof MethodNotFound ? -32601 : -32603;
+    return { jsonrpc: "2.0", id, error: { code, message: err instanceof Error ? err.message : String(err) } };
+  }
+}


### PR DESCRIPTION
## Vad & varför

Ett kompletterande **CLI + MCP-server** så en AI (Claude via Claude Code CLI) smidigt kan jobba mot AVA — hämta data, skapa fakturor, registrera tid — genom att återanvända **hela `appRouter`-ytan** utan att duplicera en rad affärslogik.

PoC (draft) enligt design i **[ADR 0035](https://github.com/ulrik-s/ava/blob/claude/ava-cli-mcp-poc/docs/adr/0035-ava-cli-och-mcp-over-approuter.md)**. Stänger delvis #913.

## Typ

- [x] `feat` (+ `docs`)

## Kärninsikt

Hela appen *är* `appRouter` (tRPC, 24 routrar). Det finns redan två bevisade sömmar att köra den utanför browsern — CLI:t/MCP:n är bara tunna frontends över dem:

| Söm | Befintlig användare | CLI-läge |
|-----|--------------------|----------|
| `appRouter.createCaller(ctx)` (in-process, seedad store) | web/demo + alla integrationstester | `--local` (ingen server/auth) |
| `createTRPCClient<AppRouter>()` (HTTP + Bearer) | helper-ui (ADR 0031), add-ins (ADR 0013) | `--remote` (server-first) |

## Ändringar

`tooling/ava-cli/` (tooling-lager → får importera server-värden, rent mot dep-cruiser):
- **`introspect.ts`** — auto-härleder ytan ur `appRouter._def` (path + query/mutation + zod-input → JSON-schema via `z.toJSONSchema`).
- **`caller.ts`** — transport-agnostisk `AvaCaller.invoke(path, input)` (local/remote).
- **`cli.ts` + `ava.ts`** — `ava describe` + `ava <router.proc> --input <json>`, JSON in/ut.
- **`mcp.ts` + `ava-mcp.ts`** — MCP stdio-server, varje procedur = verktyg.
- 25 enhetstester för de rena modulerna. Scripts: `bun run ava` / `bun run ava:mcp`.

## Verifierat lokalt

- [x] `bun run typecheck` grönt
- [x] `bun run lint --max-warnings 0` grönt (komplexitet ≤8)
- [x] `bun run deps:check` + `bun run knip` grönt
- [x] 25/25 tester (`bun test test/unit/ava-cli/`)
- [x] `ava invoice.list` / `user.current` returnerar riktig seedad data (local)
- [x] MCP: `initialize` → `tools/list` (**150 verktyg**) → `tools/call` fungerar över stdio

Faktiska körningar:
```
$ bun run ava user.current
{ "id": "current-user", "name": "Anna Advokat", "role": "ADMIN", ... }

$ bun run ava describe invoice.createRadgivning
[ { "path": "...", "type": "mutation", "inputSchema": { ...matterId/hasFTax/invoiceDate... } } ]
```

## Draft — medvetet kvar (uppföljning i #913)

- MCP-protokollet är **handrollat** i PoC:en (initialize/tools.list/tools.call/ping) — skarp version bör byta till `@modelcontextprotocol/sdk`.
- Remote-auth är en färdig Bearer-token via env; ett headless OIDC-login-flöde är eget arbete.
- Ergonomiska alias + flagg→objekt-input utöver `--input`.

> Coverage-ratchet/jscpd/complexity-strict mäter bara `src/`, och koden ligger inte i klient-bundeln → dessa grindar är opåverkade.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_