### PR TITLE
feat(cli): ergonomic ava args — space paths and --&lt;field&gt; input

### DIFF
--- a/test/unit/ava-cli/cli.test.ts
+++ b/test/unit/ava-cli/cli.test.ts
@@ -56,6 +56,45 @@ describe("parseArgs", () => {
   });
 });
 
+describe("parseArgs — ergonomi (#913)", () => {
+  it("space-separerad path ≡ punktseparerad", () => {
+    expect(parseArgs(["invoice", "list"])).toEqual({ kind: "call", path: "invoice.list", input: {}, mode: "local" });
+    expect(parseArgs(["contacts", "getById", "--id", "c-1"])).toEqual({
+      kind: "call", path: "contacts.getById", input: { id: "c-1" }, mode: "local",
+    });
+  });
+
+  it("--<fält>-flaggor med JSON-koercering", () => {
+    expect(parseArgs(["contacts.list", "--page", "1", "--active", "true", "--q", "Ada"])).toEqual({
+      kind: "call", path: "contacts.list", input: { page: 1, active: true, q: "Ada" }, mode: "local",
+    });
+  });
+
+  it("--fält=värde och bar --fält (→ true)", () => {
+    expect(parseArgs(["x.y", "--id=c-1", "--dryRun"])).toEqual({
+      kind: "call", path: "x.y", input: { id: "c-1", dryRun: true }, mode: "local",
+    });
+  });
+
+  it("array-koercering via JSON", () => {
+    expect((parseArgs(["x.y", "--ids", '["a","b"]']) as { input: unknown }).input).toEqual({ ids: ["a", "b"] });
+  });
+
+  it("--<fält> slås ihop ovanpå --input", () => {
+    expect(parseArgs(["invoice.list", "--input", '{"a":1}', "--status", "SENT"])).toEqual({
+      kind: "call", path: "invoice.list", input: { a: 1, status: "SENT" }, mode: "local",
+    });
+  });
+
+  it("--<fält> + icke-objekt-input → error", () => {
+    expect(parseArgs(["x.y", "--input", "[1,2]", "--k", "v"]).kind).toBe("error");
+  });
+
+  it("describe med space-separerat prefix", () => {
+    expect(parseArgs(["describe", "invoice", "list"])).toEqual({ kind: "describe", prefix: "invoice.list" });
+  });
+});
+
 describe("runParsed", () => {
   it("help skriver USAGE", async () => {
     const { deps } = fakeDeps();

--- a/tooling/ava-cli/cli.ts
+++ b/tooling/ava-cli/cli.ts
@@ -21,25 +21,30 @@ export type Parsed =
 export const USAGE = `ava — CLI över AVA:s tRPC-API (auto-härlett ur appRouter)
 
 Användning:
-  ava describe [prefix]            Lista procedurer (+ JSON-schema för input)
-  ava <router.procedur> [flaggor]  Anropa en procedur, skriv resultatet som JSON
+  ava describe [prefix]              Lista procedurer (+ JSON-schema för input)
+  ava <router> <procedur> [flaggor]  Anropa en procedur (path via "." ELLER mellanslag)
 
 Flaggor:
-  --input <json>   Input som JSON (default {}). Bin stödjer även @fil och -.
-  --local          In-process mot seedad store (default; ingen server/auth)
-  --remote         Mot server-first över HTTP (AVA_SERVER_URL + AVA_TOKEN)
-  --help           Visa den här hjälpen
+  --input <json>     Hela input som JSON (default {}). Bin stödjer även @fil och -.
+  --<fält> <värde>   Sätt ett input-fält (JSON-koerceras: 1→tal, true→bool,
+                     '["a"]'→array; annars sträng). Slås ihop ovanpå --input.
+  --local            In-process mot seedad store (default; ingen server/auth)
+  --remote           Mot server-first över HTTP (AVA_SERVER_URL + AVA_TOKEN)
+  --help             Visa den här hjälpen
 
 Exempel:
   ava describe invoice
-  ava invoice.list --input '{"status":"SENT"}'
-  ava contacts.getById --input '{"id":"c-1"}'
-  ava --remote invoice.createRadgivning --input '{"matterId":"m-1"}'`;
+  ava invoice list --status SENT              # ≡ invoice.list --input '{"status":"SENT"}'
+  ava contacts getById --id c-1
+  ava contacts.list --page 1 --pageSize 20
+  ava --remote invoice createRadgivning --matterId m-1`;
 
 interface Flags {
   input: string | null;
   mode: Mode;
   help: boolean;
+  /** Godtyckliga --<fält> <värde> som slås ihop till input-objektet. */
+  fields: Record<string, unknown>;
 }
 
 /**
@@ -79,17 +84,48 @@ function matchFlag(a: string, next: string | undefined, flags: Flags): number | 
   return null;
 }
 
-/** Dela argv i positionella + flaggor. `--k v` och `--k=v` stöds. */
+/** JSON-koercera ett flagg-värde: "1"→1, "true"→true, '["a"]'→array; annars sträng. */
+function coerce(v: string): unknown {
+  try {
+    return JSON.parse(v);
+  } catch {
+    return v;
+  }
+}
+
+/**
+ * Hantera en godtycklig `--<fält>`-flagga (ej känd flagga) → skriv in i `fields`.
+ * `--k=v`, `--k v` (v ej en flagga) eller `--k` (→ boolean true). Returnerar
+ * antal extra argv-tokens som konsumerats.
+ */
+function addField(a: string, next: string | undefined, fields: Record<string, unknown>): number {
+  const eq = a.indexOf("=");
+  if (eq > 2) {
+    fields[a.slice(2, eq)] = coerce(a.slice(eq + 1));
+    return 0;
+  }
+  const key = a.slice(2);
+  if (next !== undefined && !next.startsWith("-")) {
+    fields[key] = coerce(next);
+    return 1;
+  }
+  fields[key] = true;
+  return 0;
+}
+
+/** Dela argv i positionella + flaggor. Kända flaggor först, annars --<fält>-input. */
 function splitArgs(argv: readonly string[]): { positionals: string[]; flags: Flags } {
   const positionals: string[] = [];
-  const flags: Flags = { input: null, mode: "local", help: false };
+  const flags: Flags = { input: null, mode: "local", help: false, fields: {} };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]!;
     const consumed = matchFlag(a, argv[i + 1], flags);
-    if (consumed === null) {
-      if (!a.startsWith("-")) positionals.push(a);
-    } else {
+    if (consumed !== null) {
       i += consumed;
+    } else if (a.startsWith("--")) {
+      i += addField(a, argv[i + 1], flags.fields);
+    } else {
+      positionals.push(a);
     }
   }
   return { positionals, flags };
@@ -105,15 +141,30 @@ function parseInput(raw: string | null): { ok: true; value: unknown } | { ok: fa
   }
 }
 
+/** Slå ihop --<fält>-flaggor ovanpå --input (som måste vara ett objekt då). */
+function mergeInput(
+  base: unknown,
+  fields: Record<string, unknown>,
+): { ok: true; value: unknown } | { ok: false; message: string } {
+  if (Object.keys(fields).length === 0) return { ok: true, value: base };
+  if (base === null || typeof base !== "object" || Array.isArray(base)) {
+    return { ok: false, message: "--<fält>-flaggor kan bara kombineras med ett objekt-input" };
+  }
+  return { ok: true, value: { ...base, ...fields } };
+}
+
 /** Ren parsning av `ava`-argv → diskriminerad union. */
 export function parseArgs(argv: readonly string[]): Parsed {
   const { positionals, flags } = splitArgs(argv);
   if (flags.help || positionals.length === 0) return { kind: "help" };
   const [cmd, ...rest] = positionals;
-  if (cmd === "describe") return { kind: "describe", prefix: rest[0] ?? null };
+  // Path via "." eller mellanslag: `contacts getById` ≡ `contacts.getById`.
+  if (cmd === "describe") return { kind: "describe", prefix: rest.length > 0 ? rest.join(".") : null };
   const parsed = parseInput(flags.input);
   if (!parsed.ok) return { kind: "error", message: parsed.message };
-  return { kind: "call", path: cmd!, input: parsed.value, mode: flags.mode };
+  const merged = mergeInput(parsed.value, flags.fields);
+  if (!merged.ok) return { kind: "error", message: merged.message };
+  return { kind: "call", path: positionals.join("."), input: merged.value, mode: flags.mode };
 }
 
 export interface RunDeps {


### PR DESCRIPTION
## Vad & varför

Sänker friktionen för både människor och en AI som anropar `ava` (uppföljning till #914, del av #913).

## Ändringar

- **Space-separerad path:** `ava invoice list` ≡ `ava invoice.list` (positionella joinas med `.`). `describe` tar space-prefix också (`ava describe invoice list`).
- **`--<fält> <värde>`** sätter ett input-fält med JSON-koercering: `1`→tal, `true`→bool, `'["a"]'`→array, annars sträng. Slås ihop ovanpå `--input`. Även `--k=v` och bar `--k` (→ `true`).
- Så `ava invoice list --status SENT` ≡ `ava invoice.list --input '{"status":"SENT"}'`.
- `--<fält>` + icke-objekt-`--input` → tydligt fel.

Ren parsning, inga transport-ändringar.

## Verifierat lokalt

- [x] `bun test test/unit/ava-cli/` — **32/32** (7 nya ergonomi-fall)
- [x] `bun run typecheck` grönt
- [x] `bun run lint --max-warnings 0` grönt (komplexitet ≤8)
- [x] End-to-end:
  ```
  $ bun run ava contacts list --page 1 --pageSize 2   → seedade kontakter
  $ bun run ava invoice list --status SENT            → 3 SENT-fakturor
  ```

## Kvarstår i #913
MCP → `@modelcontextprotocol/sdk` och headless remote-auth (OIDC) — separata uppföljningar.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_