### PR TITLE
feat(billing): invoice summary first, specification after

### DIFF
--- a/src/lib/client/kostnadsrakning/generate-faktura-doc.ts
+++ b/src/lib/client/kostnadsrakning/generate-faktura-doc.ts
@@ -64,24 +64,20 @@ export interface GenerateFakturaDocArgs {
 
 /** Inbyggd faktura-mall (Handlebars) — används av template-motorn (#852) när
  *  ingen byrå-mall finns. HTML → öppningsbar + skrivbar. */
-const FAKTURA_TEMPLATE = `<!DOCTYPE html><html lang="sv"><head><meta charset="utf-8"><title>Faktura {{invoiceNumber}}</title></head>
+const FAKTURA_TEMPLATE = `<!DOCTYPE html><html lang="sv"><head><meta charset="utf-8"><title>Faktura {{invoiceNumber}}</title>
+<style>@media print{.page-break{page-break-before:always}}.page-break{border:0;border-top:1px dashed #ccc;margin:2rem 0}</style></head>
 <body style="font-family:system-ui,sans-serif;max-width:720px;margin:2rem auto;color:#111">
 <h1 style="margin-bottom:0">Faktura</h1>
 <p style="color:#555">Fakturanr: {{invoiceNumber}}{{#if ocr}} · OCR: {{ocr}}{{/if}}<br>Datum: {{date}}</p>
 <p style="color:#555">Ärende {{matterNumber}} — {{matterTitle}}<br>Mottagare: {{recipient}}</p>
-{{#if timeLines.length}}
-<h2 style="font-size:15px;margin-top:1.5rem;margin-bottom:.25rem">Tidsspecifikation</h2>
-<table cellpadding="5" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:13px">
-<thead><tr style="border-bottom:1px solid #ccc;text-align:left"><th>Datum</th><th>Beskrivning</th><th style="text-align:right">Tim</th><th style="text-align:right">Belopp</th></tr></thead>
-<tbody>{{#each timeLines}}<tr><td>{{this.date}}</td><td>{{this.description}}</td><td style="text-align:right">{{this.hours}}</td><td style="text-align:right">{{this.amount}}</td></tr>{{/each}}</tbody>
+
+<h2 style="font-size:16px;margin-top:1.5rem;margin-bottom:.5rem">Sammanfattning</h2>
+{{#if arvodeSections.length}}
+<table cellpadding="6" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:14px;margin-bottom:1rem">
+<thead><tr style="border-bottom:1px solid #ccc;text-align:left"><th>Timtaxa</th><th style="text-align:right">Tim</th><th style="text-align:right">Belopp (exkl moms)</th></tr></thead>
+<tbody>{{#each arvodeSections}}<tr><td>{{this.rateLabel}}</td><td style="text-align:right">{{this.hours}}</td><td style="text-align:right">{{this.amount}}</td></tr>{{/each}}</tbody>
 </table>{{/if}}
-{{#if expenseLines.length}}
-<h2 style="font-size:15px;margin-top:1.5rem;margin-bottom:.25rem">Utläggsspecifikation</h2>
-<table cellpadding="5" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:13px">
-<thead><tr style="border-bottom:1px solid #ccc;text-align:left"><th>Datum</th><th>Beskrivning</th><th style="text-align:right">Netto</th><th style="text-align:right">Brutto</th></tr></thead>
-<tbody>{{#each expenseLines}}<tr><td>{{this.date}}</td><td>{{this.description}}</td><td style="text-align:right">{{this.net}}</td><td style="text-align:right">{{this.gross}}</td></tr>{{/each}}</tbody>
-</table>{{/if}}
-<table cellpadding="6" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:14px;margin-top:1.5rem">
+<table cellpadding="6" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:14px">
 <tbody>
 {{#if showSpecTotals}}
 {{#if hasSpec}}
@@ -105,6 +101,23 @@ const FAKTURA_TEMPLATE = `<!DOCTYPE html><html lang="sv"><head><meta charset="ut
 </tbody>
 <tfoot><tr style="border-top:2px solid #333"><td style="font-weight:bold">{{totalLabel}}</td><td style="text-align:right;font-weight:bold">{{total}}</td></tr></tfoot>
 </table>
+{{#if hasSpec}}
+<hr class="page-break">
+<h2 style="font-size:16px;margin-bottom:.25rem">Specifikation</h2>
+<p style="color:#777;font-size:12px;margin-top:0">Underlag till beloppen i sammanfattningen ovan.</p>
+{{#if timeLines.length}}
+<h3 style="font-size:14px;margin-top:1rem;margin-bottom:.25rem">Tidsspecifikation</h3>
+<table cellpadding="5" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:13px">
+<thead><tr style="border-bottom:1px solid #ccc;text-align:left"><th>Datum</th><th>Beskrivning</th><th style="text-align:right">Tim</th><th style="text-align:right">Belopp</th></tr></thead>
+<tbody>{{#each timeLines}}<tr><td>{{this.date}}</td><td>{{this.description}}</td><td style="text-align:right">{{this.hours}}</td><td style="text-align:right">{{this.amount}}</td></tr>{{/each}}</tbody>
+</table>{{/if}}
+{{#if expenseLines.length}}
+<h3 style="font-size:14px;margin-top:1.5rem;margin-bottom:.25rem">Utläggsspecifikation</h3>
+<table cellpadding="5" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:13px">
+<thead><tr style="border-bottom:1px solid #ccc;text-align:left"><th>Datum</th><th>Beskrivning</th><th style="text-align:right">Netto</th><th style="text-align:right">Brutto</th></tr></thead>
+<tbody>{{#each expenseLines}}<tr><td>{{this.date}}</td><td>{{this.description}}</td><td style="text-align:right">{{this.net}}</td><td style="text-align:right">{{this.gross}}</td></tr>{{/each}}</tbody>
+</table>{{/if}}
+{{/if}}
 {{#if organizationName}}<p style="color:#777;font-size:13px;margin-top:1.5rem">{{organizationName}}{{#if organizationOrgNumber}} · {{organizationOrgNumber}}{{/if}}</p>{{/if}}
 </body></html>`;
 
@@ -155,6 +168,25 @@ function specContext(spec: InvoiceSpecification | null | undefined, fc: (ore: nu
   };
 }
 
+/**
+ * Arvode-sektioner per timtaxa (#925) för sammanfattningen: grupperar spec:ens
+ * tidsrader på den HÄRLEDDA taxan (amountOre / timmar — rättshjälp=norm/tidsspillan,
+ * övrigt=post-taxa) → en rad per unik taxa (fallande). Ren + testbar.
+ */
+function arvodeSectionsContext(spec: InvoiceSpecification | null | undefined, fc: (ore: number) => string): Record<string, unknown> {
+  if (!spec || spec.timeLines.length === 0) return { arvodeSections: [] };
+  const groups = new Map<number, { minutes: number; amountOre: number }>();
+  for (const l of spec.timeLines) {
+    const rate = l.minutes > 0 ? Math.round((l.amountOre * 60) / l.minutes) : 0;
+    const g = groups.get(rate) ?? { minutes: 0, amountOre: 0 };
+    groups.set(rate, { minutes: g.minutes + l.minutes, amountOre: g.amountOre + l.amountOre });
+  }
+  const arvodeSections = [...groups.entries()]
+    .sort((a, b) => b[0] - a[0])
+    .map(([rate, g]) => ({ rateLabel: `${fc(rate)}/tim`, hours: svHours(g.minutes), amount: fc(g.amountOre) }));
+  return { arvodeSections };
+}
+
 /** Itemiserad summering (#858) → mall-rader. `deduct`=−, `info`=(parentes), färgad. */
 function breakdownContext(breakdown: FakturaBreakdown | null | undefined, fc: (ore: number) => string): Record<string, unknown> {
   if (!breakdown) return { useBreakdown: false };
@@ -203,6 +235,7 @@ function fakturaTemplateContext(a: FakturaTemplateArgs, formatCurrency: (ore: nu
   return {
     ...headerContext(a, formatCurrency),
     ...specContext(a.spec, formatCurrency),
+    ...arvodeSectionsContext(a.spec, formatCurrency),
     ...breakdownContext(a.breakdown, formatCurrency),
     // Spec-summeringen (arvode/moms/delsumma) visas bara när spec körs UTAN breakdown
     // (#876) — annars äger breakdown-trappan beloppen och summeringen skulle dubbleras.

--- a/test/unit/lib/kostnadsrakning/generate-faktura-from-template.test.ts
+++ b/test/unit/lib/kostnadsrakning/generate-faktura-from-template.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
 import { generateFakturaFromTemplate } from "@/lib/client/kostnadsrakning/generate-faktura-doc";
+import { formatCurrency } from "@/lib/client/utils";
 import { asId } from "@/lib/shared/schemas/ids";
 
 const persistGeneratedDoc = vi.fn(async () => {});
@@ -96,6 +97,40 @@ describe("generateFakturaFromTemplate", () => {
     expect(html).toContain("Domstolen betalar — att betala");
     expect(html).not.toContain("Nedsättning"); // lumpen ersatt av itemiserade rader
     expect(html).not.toContain("Rådgivning"); // rådgivningstimmen syns ALDRIG på domstols-fakturan (#860)
+  });
+
+  it("sammanfattning först (arvode per timtaxa + split), specifikationen efter (#925)", async () => {
+    await generateFakturaFromTemplate({
+      invoice: { id: asId<"InvoiceId">("inv-s1"), amount: 565_000, vatOre: 113_000, invoiceNumber: "F-2026-0055", invoiceDate: "2026-06-30" },
+      matterId: asId<"MatterId">("m1"),
+      recipient: "Staten",
+      meta: { matterNumber: "2026-0020", matterTitle: "Vårdnadstvist Falk" },
+      register: { mutateAsync: registerMutateAsync },
+      utils,
+      spec: {
+        timeLines: [
+          { date: "2026-02-01", description: "Arbete på timkostnadsnormen", minutes: 60, amountOre: 162_600 },
+          { date: "2026-02-02", description: "Mer arbete, samma norm", minutes: 120, amountOre: 325_200 },
+          { date: "2026-02-03", description: "Restid och väntetid", minutes: 120, amountOre: 290_000 },
+        ],
+        expenseLines: [],
+        totalMinutes: 300,
+        arvodeNetOre: 777_800, arvodeVatOre: 194_450,
+        expensesNetOre: 0, expensesVatOre: 0,
+        grossOre: 972_250,
+        deductions: [], deductionOre: 0, adjustmentOre: 0, payableOre: 565_000,
+      },
+    });
+    const html = new TextDecoder().decode(persistGeneratedDoc.mock.calls[0]![0].bytes as Uint8Array);
+    // Två unika timtaxor → två sektioner (1 626 kr/tim och 1 450 kr/tim tidsspillan).
+    expect(html).toContain("Sammanfattning");
+    expect(html).toContain("Timtaxa");
+    expect(html).toContain(`${formatCurrency(162_600)}/tim`); // 162 600 öre/tim (norm)
+    expect(html).toContain(`${formatCurrency(145_000)}/tim`); // 290 000 öre / 2 tim = 145 000 öre/tim (tidsspillan)
+    // Sammanfattningen står FÖRE specifikationen; specen har sidbrytning.
+    expect(html.indexOf("Sammanfattning")).toBeLessThan(html.indexOf("Specifikation"));
+    expect(html.indexOf("Sammanfattning")).toBeLessThan(html.indexOf("Tidsspecifikation"));
+    expect(html).toContain('class="page-break"');
   });
 
   it("klientens självrisk-faktura (#876): tidsspec-TABELL + moms-trappa, spec-summeringen undertryckt", async () => {


### PR DESCRIPTION
## Vad & varför

Fakturamallen leder nu (för **alla ärenden**) med en sammanfattning och lägger underlaget efter — enligt önskemål med utgångspunkt i 2026-0020 (varierande rättshjälp Falk). Stänger #925.

## Ändringar (delad `FAKTURA_TEMPLATE`, `generate-faktura-doc.ts`)

- **Sida 1 — Sammanfattning:**
  - Arvode grupperat i **sektioner per timtaxa** (tim × taxa = belopp). Taxan härleds per tidsrad ur `amountOre / timmar`, så det funkar lika bra för rättshjälp (timkostnadsnorm + tidsspillan, olika normer över årsskifte) som för post-taxa.
  - **Summering** (arvode + moms + delsumma).
  - **Uppdelning klient/betalar** (rättshjälpsavgift/självrisk/aconton — split-raderna).
- **Följande sidor — Specifikation:** de itemiserade tids- + utläggstabellerna som härleder beloppen, efter en CSS-sidbrytning (`page-break-before` i print → separat PDF-sida).

Ren, testbar `arvodeSectionsContext`-hjälpare. Alla tidigare mall-tokens bevarade → befintliga mall-tester förblir gröna.

## Verifierat lokalt

- [x] `bun test test/unit/lib/kostnadsrakning/` — 39/39 (nytt test för taxe-sektioner + ordning sammanfattning→specifikation)
- [x] `bun run typecheck` grönt
- [x] `bun run lint --max-warnings 0` grönt (komplexitet ≤8)
- [x] `bun run knip` + `bun run duplicates` grönt
- [x] Renderat exempel (rättshjälp, tre taxor + klient/betalar-split) granskat

## Not
Layouten är HTML (öppningsbar + skrivbar). "Sida 1 / följande sidor" realiseras med `@media print { page-break-before: always }` → syns vid utskrift/PDF-export; på skärm visas en streckad avgränsare.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_