### PR TITLE
feat(billing): invoice summary — expense rows and total in the rate table

### DIFF
--- a/src/lib/client/kostnadsrakning/generate-faktura-doc.ts
+++ b/src/lib/client/kostnadsrakning/generate-faktura-doc.ts
@@ -76,17 +76,11 @@ const FAKTURA_TEMPLATE = `<!DOCTYPE html><html lang="sv"><head><meta charset="ut
 <table cellpadding="6" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:14px;margin-bottom:1rem">
 <thead><tr style="border-bottom:1px solid #ccc;text-align:left"><th>Timtaxa</th><th style="text-align:right">Tim</th><th style="text-align:right">Belopp (exkl moms)</th></tr></thead>
 <tbody>{{#each arvodeSections}}<tr><td>{{this.rateLabel}}</td><td style="text-align:right">{{this.hours}}</td><td style="text-align:right">{{this.amount}}</td></tr>{{/each}}</tbody>
+<tfoot><tr style="border-top:1px solid #ccc"><td style="font-weight:bold">Summa (inkl moms)</td><td></td><td style="text-align:right;font-weight:bold">{{arvodeSumma}}</td></tr></tfoot>
 </table>{{/if}}
+{{#if hasSplit}}<h3 style="font-size:14px;margin-top:1rem;margin-bottom:.25rem">Uppdelning klient / betalare</h3>{{/if}}
 <table cellpadding="6" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:14px">
 <tbody>
-{{#if showSpecTotals}}
-{{#if hasSpec}}
-<tr><td>Arvode{{#if hoursTotal}} ({{hoursTotal}} tim){{/if}} (exkl moms)</td><td style="text-align:right">{{arvodeNet}}</td></tr>
-{{#if hasExpenses}}<tr><td>Utlägg (exkl moms)</td><td style="text-align:right">{{expensesNet}}</td></tr>{{/if}}
-<tr><td>Moms</td><td style="text-align:right">{{vat}}</td></tr>
-{{/if}}
-<tr style="border-top:1px solid #ccc"><td>Delsumma (inkl moms)</td><td style="text-align:right">{{gross}}</td></tr>
-{{/if}}
 {{#if useBreakdown}}
 {{#each breakdownRows}}<tr style="{{this.style}}"><td>{{this.label}}</td><td style="text-align:right;{{this.style}}">{{this.amount}}</td></tr>{{/each}}
 {{else}}
@@ -173,18 +167,37 @@ function specContext(spec: InvoiceSpecification | null | undefined, fc: (ore: nu
  * tidsrader på den HÄRLEDDA taxan (amountOre / timmar — rättshjälp=norm/tidsspillan,
  * övrigt=post-taxa) → en rad per unik taxa (fallande). Ren + testbar.
  */
-function arvodeSectionsContext(spec: InvoiceSpecification | null | undefined, fc: (ore: number) => string): Record<string, unknown> {
-  if (!spec || spec.timeLines.length === 0) return { arvodeSections: [] };
+interface SummarySection { rateLabel: string; hours: string; amount: string }
+
+/** Gruppera arvodet på den härledda timtaxan → en rad per unik taxa (fallande). */
+function arvodeRateRows(spec: InvoiceSpecification, fc: (ore: number) => string): SummarySection[] {
   const groups = new Map<number, { minutes: number; amountOre: number }>();
   for (const l of spec.timeLines) {
     const rate = l.minutes > 0 ? Math.round((l.amountOre * 60) / l.minutes) : 0;
     const g = groups.get(rate) ?? { minutes: 0, amountOre: 0 };
     groups.set(rate, { minutes: g.minutes + l.minutes, amountOre: g.amountOre + l.amountOre });
   }
-  const arvodeSections = [...groups.entries()]
+  return [...groups.entries()]
     .sort((a, b) => b[0] - a[0])
     .map(([rate, g]) => ({ rateLabel: `${fc(rate)}/tim`, hours: svHours(g.minutes), amount: fc(g.amountOre) }));
-  return { arvodeSections };
+}
+
+/**
+ * Sammanfattningens sektionstabell (#925): en rad per timtaxa (arvode exkl moms),
+ * följt av utlägg exkl moms + utlägg inkl moms, och en summa (allt inkl moms).
+ * Utlägg-raderna är avsiktligt informativa (både exkl och inkl) — summan är det
+ * faktiska bruttot (arvode inkl moms + utlägg inkl moms). Ren + testbar.
+ */
+function arvodeSectionsContext(spec: InvoiceSpecification | null | undefined, fc: (ore: number) => string): Record<string, unknown> {
+  if (!spec || spec.timeLines.length === 0) return { arvodeSections: [] };
+  const sections = arvodeRateRows(spec, fc);
+  const hasExpenses = spec.expensesNetOre > 0 || spec.expensesVatOre > 0;
+  if (hasExpenses) {
+    sections.push({ rateLabel: "Utlägg exkl moms", hours: "", amount: fc(spec.expensesNetOre) });
+    sections.push({ rateLabel: "Utlägg inkl moms", hours: "", amount: fc(spec.expensesNetOre + spec.expensesVatOre) });
+  }
+  const summaOre = spec.arvodeNetOre + spec.arvodeVatOre + spec.expensesNetOre + spec.expensesVatOre;
+  return { arvodeSections: sections, arvodeSumma: fc(summaOre) };
 }
 
 /** Itemiserad summering (#858) → mall-rader. `deduct`=−, `info`=(parentes), färgad. */
@@ -237,10 +250,10 @@ function fakturaTemplateContext(a: FakturaTemplateArgs, formatCurrency: (ore: nu
     ...specContext(a.spec, formatCurrency),
     ...arvodeSectionsContext(a.spec, formatCurrency),
     ...breakdownContext(a.breakdown, formatCurrency),
-    // Spec-summeringen (arvode/moms/delsumma) visas bara när spec körs UTAN breakdown
-    // (#876) — annars äger breakdown-trappan beloppen och summeringen skulle dubbleras.
-    // Tids-/utläggstabellerna renderas oberoende (på timeLines/expenseLines-längd).
-    showSpecTotals: !!a.spec && !a.breakdown,
+    // "Uppdelning klient / betalare"-rubriken (#925) visas bara när det finns en
+    // faktisk split: en breakdown (självrisk/aconto/rättshjälpsavgift) ELLER
+    // spec-avdrag/justering. Total-tabellen renderas alltid (bär tfoot-totalen).
+    hasSplit: !!a.breakdown || (!!a.spec && (a.spec.deductions.length > 0 || a.spec.adjustmentOre !== 0)),
   };
 }
 

--- a/src/lib/client/kostnadsrakning/generate-faktura-doc.ts
+++ b/src/lib/client/kostnadsrakning/generate-faktura-doc.ts
@@ -192,8 +192,14 @@ function arvodeSectionsContext(spec: InvoiceSpecification | null | undefined, fc
   if (!spec || spec.timeLines.length === 0) return { arvodeSections: [] };
   const sections = arvodeRateRows(spec, fc);
   const hasExpenses = spec.expensesNetOre > 0 || spec.expensesVatOre > 0;
+  // Ordning (#925): momsfritt utlägg → momsraden (total moms) → utlägg inkl moms
+  // → summa (allt inkl moms). Momsraden är fakturans hela moms (arvode + utlägg),
+  // så arvode-raderna (exkl moms) + utlägg exkl + moms = summan.
   if (hasExpenses) {
     sections.push({ rateLabel: "Utlägg exkl moms", hours: "", amount: fc(spec.expensesNetOre) });
+  }
+  sections.push({ rateLabel: "Moms", hours: "", amount: fc(spec.arvodeVatOre + spec.expensesVatOre) });
+  if (hasExpenses) {
     sections.push({ rateLabel: "Utlägg inkl moms", hours: "", amount: fc(spec.expensesNetOre + spec.expensesVatOre) });
   }
   const summaOre = spec.arvodeNetOre + spec.arvodeVatOre + spec.expensesNetOre + spec.expensesVatOre;

--- a/test/unit/lib/kostnadsrakning/generate-faktura-from-template.test.ts
+++ b/test/unit/lib/kostnadsrakning/generate-faktura-from-template.test.ts
@@ -99,9 +99,9 @@ describe("generateFakturaFromTemplate", () => {
     expect(html).not.toContain("Rådgivning"); // rådgivningstimmen syns ALDRIG på domstols-fakturan (#860)
   });
 
-  it("sammanfattning först (arvode per timtaxa + split), specifikationen efter (#925)", async () => {
+  it("sammanfattning: sektion per timtaxa + utlägg exkl/inkl + summa, spec efter (#925)", async () => {
     await generateFakturaFromTemplate({
-      invoice: { id: asId<"InvoiceId">("inv-s1"), amount: 565_000, vatOre: 113_000, invoiceNumber: "F-2026-0055", invoiceDate: "2026-06-30" },
+      invoice: { id: asId<"InvoiceId">("inv-s1"), amount: 1_062_250, vatOre: 194_450, invoiceNumber: "F-2026-0055", invoiceDate: "2026-06-30" },
       matterId: asId<"MatterId">("m1"),
       recipient: "Staten",
       meta: { matterNumber: "2026-0020", matterTitle: "Vårdnadstvist Falk" },
@@ -113,20 +113,25 @@ describe("generateFakturaFromTemplate", () => {
           { date: "2026-02-02", description: "Mer arbete, samma norm", minutes: 120, amountOre: 325_200 },
           { date: "2026-02-03", description: "Restid och väntetid", minutes: 120, amountOre: 290_000 },
         ],
-        expenseLines: [],
+        expenseLines: [{ date: "2026-01-20", description: "Ansökningsavgift", netOre: 90_000, grossOre: 90_000 }],
         totalMinutes: 300,
         arvodeNetOre: 777_800, arvodeVatOre: 194_450,
-        expensesNetOre: 0, expensesVatOre: 0,
-        grossOre: 972_250,
-        deductions: [], deductionOre: 0, adjustmentOre: 0, payableOre: 565_000,
+        expensesNetOre: 90_000, expensesVatOre: 0,
+        grossOre: 1_062_250,
+        deductions: [], deductionOre: 0, adjustmentOre: 0, payableOre: 1_062_250,
       },
     });
     const html = new TextDecoder().decode(persistGeneratedDoc.mock.calls[0]![0].bytes as Uint8Array);
-    // Två unika timtaxor → två sektioner (1 626 kr/tim och 1 450 kr/tim tidsspillan).
+    // En sektion per unik timtaxa (norm 1 626 kr/tim + tidsspillan 1 450 kr/tim).
     expect(html).toContain("Sammanfattning");
     expect(html).toContain("Timtaxa");
-    expect(html).toContain(`${formatCurrency(162_600)}/tim`); // 162 600 öre/tim (norm)
-    expect(html).toContain(`${formatCurrency(145_000)}/tim`); // 290 000 öre / 2 tim = 145 000 öre/tim (tidsspillan)
+    expect(html).toContain(`${formatCurrency(162_600)}/tim`); // norm
+    expect(html).toContain(`${formatCurrency(145_000)}/tim`); // 290 000 / 2 tim = tidsspillan
+    // + en rad utlägg exkl moms och en rad utlägg inkl moms, sedan en summa.
+    expect(html).toContain("Utlägg exkl moms");
+    expect(html).toContain("Utlägg inkl moms");
+    expect(html).toContain("Summa (inkl moms)");
+    expect(html).toContain(formatCurrency(1_062_250)); // arvode inkl moms + utlägg inkl moms
     // Sammanfattningen står FÖRE specifikationen; specen har sidbrytning.
     expect(html.indexOf("Sammanfattning")).toBeLessThan(html.indexOf("Specifikation"));
     expect(html.indexOf("Sammanfattning")).toBeLessThan(html.indexOf("Tidsspecifikation"));

--- a/test/unit/lib/kostnadsrakning/generate-faktura-from-template.test.ts
+++ b/test/unit/lib/kostnadsrakning/generate-faktura-from-template.test.ts
@@ -127,11 +127,18 @@ describe("generateFakturaFromTemplate", () => {
     expect(html).toContain("Timtaxa");
     expect(html).toContain(`${formatCurrency(162_600)}/tim`); // norm
     expect(html).toContain(`${formatCurrency(145_000)}/tim`); // 290 000 / 2 tim = tidsspillan
-    // + en rad utlägg exkl moms och en rad utlägg inkl moms, sedan en summa.
+    // Ordning i utläggsdelen: utlägg exkl moms → moms → utlägg inkl moms → summa.
     expect(html).toContain("Utlägg exkl moms");
+    expect(html).toContain("<td>Moms</td>");
     expect(html).toContain("Utlägg inkl moms");
     expect(html).toContain("Summa (inkl moms)");
-    expect(html).toContain(formatCurrency(1_062_250)); // arvode inkl moms + utlägg inkl moms
+    const iExkl = html.indexOf("Utlägg exkl moms");
+    const iMoms = html.indexOf("<td>Moms</td>");
+    const iInkl = html.indexOf("Utlägg inkl moms");
+    expect(iExkl).toBeLessThan(iMoms);
+    expect(iMoms).toBeLessThan(iInkl);
+    expect(html).toContain(formatCurrency(194_450)); // momsraden = arvodeVat + expensesVat
+    expect(html).toContain(formatCurrency(1_062_250)); // summa = arvode inkl moms + utlägg inkl moms
     // Sammanfattningen står FÖRE specifikationen; specen har sidbrytning.
     expect(html.indexOf("Sammanfattning")).toBeLessThan(html.indexOf("Specifikation"));
     expect(html.indexOf("Sammanfattning")).toBeLessThan(html.indexOf("Tidsspecifikation"));


### PR DESCRIPTION
## Vad & varför

Förfining av fakturasammanfattningen (uppföljning till #926, #925): sektionstabellen läses nu som **en lista**.

## Ändringar (`FAKTURA_TEMPLATE`, alla ärenden)

Sammanfattningens sektionstabell innehåller nu:
- en rad **per timtaxa** (arvode exkl moms),
- **Utlägg exkl moms**,
- **Utlägg inkl moms**,
- **Summa (inkl moms)** i footern (arvode inkl moms + utlägg inkl moms).

Det gamla dubblerande arvode/moms/delsumma-blocket är borttaget. Klient/betalar-**splitten** ligger nu under en egen rubrik **"Uppdelning klient / betalare"** (visas bara när det finns en split — breakdown eller aconto-avdrag), medan total-tabellen alltid bär "att betala".

## Verifierat lokalt

- [x] `bun test test/unit/lib/kostnadsrakning/generate-faktura-from-template.test.ts` — 5/5 (utökat #925-test: taxe-sektioner + utlägg exkl/inkl + summa + ordning)
- [x] `bun run typecheck` + `bun run lint --max-warnings 0` grönt
- [x] Renderat exempel granskat (rättshjälp, tre taxor + utlägg + split)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_