### PR TITLE
feat(demo): bill every lawyer at the rättshjälp rate

### DIFF
--- a/tooling/scripts/seed-data.ts
+++ b/tooling/scripts/seed-data.ts
@@ -10,6 +10,7 @@
  * får två sourcer of truth.
  */
 
+import { TIMKOSTNADSNORM_FTAX_ORE_PER_H } from "@/lib/shared/brottmalstaxa";
 import {
   KOSTNADSRAKNING_TEMPLATE_NAME,
   KOSTNADSRAKNING_TEMPLATE_CATEGORY,
@@ -26,6 +27,13 @@ import {
 } from "@/lib/shared/schemas";
 
 export const ORG_ID = "firma-ab";
+
+/**
+ * Rättshjälpstaxan (timkostnadsnormen, F-skatt) — den taxa byråns jurister
+ * debiterar i seed-datan. Alias för `TIMKOSTNADSNORM_FTAX_ORE_PER_H` så
+ * seed-datan har EN referens att följa när normen räknas upp per år.
+ */
+const RATTSHJALPSTAXA_ORE_PER_H = TIMKOSTNADSNORM_FTAX_ORE_PER_H;
 
 /**
  * Options för `buildSeed()`. Default = docker-firma:n (`firma-ab` + current-user).
@@ -67,13 +75,15 @@ interface UserSeed {
 
 function buildUsers(currentUserId: string, emailDomain: string): UserSeed[] {
   return [
-    // Alla advokater debiterar timkostnadsnormen 1 626 kr/h (162 600 öre). David
-    // är biträdande jurist (ej advokat) och behåller sin lägre taxa.
-    { id: currentUserId, email: `user@${emailDomain}`, name: "Anna Advokat", role: "ADMIN", hourlyRate: 162_600, title: "Senior partner" },
-    { id: "u-bjorn", email: `bjorn@${emailDomain}`, name: "Björn Bauer", role: "LAWYER", hourlyRate: 162_600, title: "Advokat" },
-    { id: "u-cecilia", email: `cecilia@${emailDomain}`, name: "Cecilia Carlsson", role: "LAWYER", hourlyRate: 162_600, title: "Advokat" },
-    { id: "u-david", email: `david@${emailDomain}`, name: "David Dahl", role: "ASSISTANT", hourlyRate: 90_000, title: "Biträdande jurist" },
-    { id: "u-eva", email: `eva@${emailDomain}`, name: "Eva Eklund", role: "LAWYER", hourlyRate: 162_600, title: "Advokat" },
+    // ALLA debiterar rättshjälpstaxan (timkostnadsnormen, F-skatt) — även David
+    // som är biträdande jurist. Taxan läses ur `TIMKOSTNADSNORM_FTAX_ORE_PER_H`
+    // (single source of truth i brottmalstaxa.ts) så seed-datan följer med när
+    // normen räknas upp; inga hårdkodade ören här.
+    { id: currentUserId, email: `user@${emailDomain}`, name: "Anna Advokat", role: "ADMIN", hourlyRate: RATTSHJALPSTAXA_ORE_PER_H, title: "Senior partner" },
+    { id: "u-bjorn", email: `bjorn@${emailDomain}`, name: "Björn Bauer", role: "LAWYER", hourlyRate: RATTSHJALPSTAXA_ORE_PER_H, title: "Advokat" },
+    { id: "u-cecilia", email: `cecilia@${emailDomain}`, name: "Cecilia Carlsson", role: "LAWYER", hourlyRate: RATTSHJALPSTAXA_ORE_PER_H, title: "Advokat" },
+    { id: "u-david", email: `david@${emailDomain}`, name: "David Dahl", role: "ASSISTANT", hourlyRate: RATTSHJALPSTAXA_ORE_PER_H, title: "Biträdande jurist" },
+    { id: "u-eva", email: `eva@${emailDomain}`, name: "Eva Eklund", role: "LAWYER", hourlyRate: RATTSHJALPSTAXA_ORE_PER_H, title: "Advokat" },
   ];
 }
 


### PR DESCRIPTION
## Vad & varför

David Dahl (biträdande jurist) debiterade **900 kr/tim** i demo-datan medan alla andra låg på timkostnadsnormen. Nu debiterar **alla** seedade jurister **rättshjälpstaxan**.

## Ändring

`tooling/scripts/seed-data.ts` (single source of truth för seed):
- David 90 000 öre → rättshjälpstaxan.
- Taxan läses ur **`TIMKOSTNADSNORM_FTAX_ORE_PER_H`** (`brottmalstaxa.ts`) i stället för att upprepa `162_600` fem gånger → seed-datan följer automatiskt med när normen räknas upp per år.

Resultat i det byggda demo-seedet:
```
Anna Advokat (Senior partner)      → 1 626 kr/tim
Björn Bauer (Advokat)              → 1 626 kr/tim
Cecilia Carlsson (Advokat)         → 1 626 kr/tim
David Dahl (Biträdande jurist)     → 1 626 kr/tim   ← var 900 kr
Eva Eklund (Advokat)               → 1 626 kr/tim
```

## Verifierat lokalt

- [x] `bun run typecheck` grönt
- [x] `bun run lint --max-warnings 0` grönt
- [x] `bun run deps:check` grönt (tooling → `src/lib/shared`-importen är tillåten)
- [x] `bun test test/integration/` — **63/63** (seed-smoke + alla faktureringsscenarier)
- [x] `bun run build:demo` grönt; verifierat att taxan slår igenom i `out/demo-seed.json`

## Deploy
`deploy-demo.yml` kör på push till `main`, så GH Pages-demon uppdateras automatiskt när denna mergas.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_