### PR TITLE
feat(billing): label each summary row and show its hourly rate

### DIFF
--- a/src/lib/client/kostnadsrakning/generate-faktura-doc.ts
+++ b/src/lib/client/kostnadsrakning/generate-faktura-doc.ts
@@ -12,6 +12,7 @@
 
 import type { inferRouterInputs, inferRouterOutputs } from "@trpc/server";
 import type { AppRouter } from "@/lib/server/routers/_app";
+import { tidsspillanFtaxForDate, timkostnadsnormFtaxForDate } from "@/lib/shared/brottmalstaxa";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { asId, type InvoiceId, type MatterId } from "@/lib/shared/schemas/ids";
 
@@ -74,9 +75,9 @@ const FAKTURA_TEMPLATE = `<!DOCTYPE html><html lang="sv"><head><meta charset="ut
 <h2 style="font-size:16px;margin-top:1.5rem;margin-bottom:.5rem">Sammanfattning</h2>
 {{#if arvodeSections.length}}
 <table cellpadding="6" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:14px;margin-bottom:1rem">
-<thead><tr style="border-bottom:1px solid #ccc;text-align:left"><th>Timtaxa</th><th style="text-align:right">Tim</th><th style="text-align:right">Belopp (exkl moms)</th></tr></thead>
-<tbody>{{#each arvodeSections}}<tr><td>{{this.rateLabel}}</td><td style="text-align:right">{{this.hours}}</td><td style="text-align:right">{{this.amount}}</td></tr>{{/each}}</tbody>
-<tfoot><tr style="border-top:1px solid #ccc"><td style="font-weight:bold">Summa (inkl moms)</td><td></td><td style="text-align:right;font-weight:bold">{{arvodeSumma}}</td></tr></tfoot>
+<thead><tr style="border-bottom:1px solid #ccc;text-align:left"><th>Benämning</th><th style="text-align:right">Timtaxa</th><th style="text-align:right">Tim</th><th style="text-align:right">Belopp</th></tr></thead>
+<tbody>{{#each arvodeSections}}<tr><td>{{this.label}}</td><td style="text-align:right">{{this.rateLabel}}</td><td style="text-align:right">{{this.hours}}</td><td style="text-align:right">{{this.amount}}</td></tr>{{/each}}</tbody>
+<tfoot><tr style="border-top:1px solid #ccc"><td style="font-weight:bold">Summa (inkl moms)</td><td></td><td></td><td style="text-align:right;font-weight:bold">{{arvodeSumma}}</td></tr></tfoot>
 </table>{{/if}}
 {{#if hasSplit}}<h3 style="font-size:14px;margin-top:1rem;margin-bottom:.25rem">Uppdelning klient / betalare</h3>{{/if}}
 <table cellpadding="6" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:14px">
@@ -167,19 +168,37 @@ function specContext(spec: InvoiceSpecification | null | undefined, fc: (ore: nu
  * tidsrader på den HÄRLEDDA taxan (amountOre / timmar — rättshjälp=norm/tidsspillan,
  * övrigt=post-taxa) → en rad per unik taxa (fallande). Ren + testbar.
  */
-interface SummarySection { rateLabel: string; hours: string; amount: string }
+interface SummarySection { label: string; rateLabel: string; hours: string; amount: string }
+
+/**
+ * Benämning för en taxegrupp (#925): rättshjälpsärenden värderar arbete på
+ * timkostnadsnormen och restid/väntetid på den lägre tidsspillan-normen — känns
+ * igen genom att jämföra taxan mot ÅRETS normer (posten bär sitt datum, så
+ * ärenden över ett årsskifte får rätt benämning per period). Övriga ärenden
+ * debiterar byråns timtaxa → "Arvode".
+ */
+function rateGroupLabel(rateOre: number, date: Date | string): string {
+  if (rateOre === tidsspillanFtaxForDate(date)) return "Tidsspillan";
+  if (rateOre === timkostnadsnormFtaxForDate(date)) return "Arvode (timkostnadsnorm)";
+  return "Arvode";
+}
 
 /** Gruppera arvodet på den härledda timtaxan → en rad per unik taxa (fallande). */
 function arvodeRateRows(spec: InvoiceSpecification, fc: (ore: number) => string): SummarySection[] {
-  const groups = new Map<number, { minutes: number; amountOre: number }>();
+  const groups = new Map<number, { minutes: number; amountOre: number; date: Date | string }>();
   for (const l of spec.timeLines) {
     const rate = l.minutes > 0 ? Math.round((l.amountOre * 60) / l.minutes) : 0;
-    const g = groups.get(rate) ?? { minutes: 0, amountOre: 0 };
-    groups.set(rate, { minutes: g.minutes + l.minutes, amountOre: g.amountOre + l.amountOre });
+    const g = groups.get(rate) ?? { minutes: 0, amountOre: 0, date: l.date };
+    groups.set(rate, { minutes: g.minutes + l.minutes, amountOre: g.amountOre + l.amountOre, date: g.date });
   }
   return [...groups.entries()]
     .sort((a, b) => b[0] - a[0])
-    .map(([rate, g]) => ({ rateLabel: `${fc(rate)}/tim`, hours: svHours(g.minutes), amount: fc(g.amountOre) }));
+    .map(([rate, g]) => ({
+      label: rateGroupLabel(rate, g.date),
+      rateLabel: `${fc(rate)}/tim`,
+      hours: svHours(g.minutes),
+      amount: fc(g.amountOre),
+    }));
 }
 
 /**
@@ -196,11 +215,11 @@ function arvodeSectionsContext(spec: InvoiceSpecification | null | undefined, fc
   // → summa (allt inkl moms). Momsraden är fakturans hela moms (arvode + utlägg),
   // så arvode-raderna (exkl moms) + utlägg exkl + moms = summan.
   if (hasExpenses) {
-    sections.push({ rateLabel: "Utlägg exkl moms", hours: "", amount: fc(spec.expensesNetOre) });
+    sections.push({ label: "Utlägg exkl moms", rateLabel: "", hours: "", amount: fc(spec.expensesNetOre) });
   }
-  sections.push({ rateLabel: "Moms", hours: "", amount: fc(spec.arvodeVatOre + spec.expensesVatOre) });
+  sections.push({ label: "Moms", rateLabel: "", hours: "", amount: fc(spec.arvodeVatOre + spec.expensesVatOre) });
   if (hasExpenses) {
-    sections.push({ rateLabel: "Utlägg inkl moms", hours: "", amount: fc(spec.expensesNetOre + spec.expensesVatOre) });
+    sections.push({ label: "Utlägg inkl moms", rateLabel: "", hours: "", amount: fc(spec.expensesNetOre + spec.expensesVatOre) });
   }
   const summaOre = spec.arvodeNetOre + spec.arvodeVatOre + spec.expensesNetOre + spec.expensesVatOre;
   return { arvodeSections: sections, arvodeSumma: fc(summaOre) };

--- a/test/unit/lib/kostnadsrakning/generate-faktura-from-template.test.ts
+++ b/test/unit/lib/kostnadsrakning/generate-faktura-from-template.test.ts
@@ -101,7 +101,7 @@ describe("generateFakturaFromTemplate", () => {
 
   it("sammanfattning: sektion per timtaxa + utlägg exkl/inkl + summa, spec efter (#925)", async () => {
     await generateFakturaFromTemplate({
-      invoice: { id: asId<"InvoiceId">("inv-s1"), amount: 1_062_250, vatOre: 194_450, invoiceNumber: "F-2026-0055", invoiceDate: "2026-06-30" },
+      invoice: { id: asId<"InvoiceId">("inv-s1"), amount: 1_071_500, vatOre: 196_300, invoiceNumber: "F-2026-0055", invoiceDate: "2026-06-30" },
       matterId: asId<"MatterId">("m1"),
       recipient: "Staten",
       meta: { matterNumber: "2026-0020", matterTitle: "Vårdnadstvist Falk" },
@@ -109,24 +109,30 @@ describe("generateFakturaFromTemplate", () => {
       utils,
       spec: {
         timeLines: [
+          // 2026: timkostnadsnorm 1 626 kr/tim, tidsspillan 1 487 kr/tim.
           { date: "2026-02-01", description: "Arbete på timkostnadsnormen", minutes: 60, amountOre: 162_600 },
           { date: "2026-02-02", description: "Mer arbete, samma norm", minutes: 120, amountOre: 325_200 },
-          { date: "2026-02-03", description: "Restid och väntetid", minutes: 120, amountOre: 290_000 },
+          { date: "2026-02-03", description: "Restid och väntetid", minutes: 120, amountOre: 297_400 },
         ],
         expenseLines: [{ date: "2026-01-20", description: "Ansökningsavgift", netOre: 90_000, grossOre: 90_000 }],
         totalMinutes: 300,
-        arvodeNetOre: 777_800, arvodeVatOre: 194_450,
+        arvodeNetOre: 785_200, arvodeVatOre: 196_300,
         expensesNetOre: 90_000, expensesVatOre: 0,
-        grossOre: 1_062_250,
-        deductions: [], deductionOre: 0, adjustmentOre: 0, payableOre: 1_062_250,
+        grossOre: 1_071_500,
+        deductions: [], deductionOre: 0, adjustmentOre: 0, payableOre: 1_071_500,
       },
     });
     const html = new TextDecoder().decode(persistGeneratedDoc.mock.calls[0]![0].bytes as Uint8Array);
-    // En sektion per unik timtaxa (norm 1 626 kr/tim + tidsspillan 1 450 kr/tim).
+    // En sektion per unik timtaxa (norm 1 626 kr/tim + tidsspillan 1 450 kr/tim),
+    // varje rad med BENÄMNING + timtaxa i egna kolumner.
     expect(html).toContain("Sammanfattning");
+    expect(html).toContain("Benämning");
     expect(html).toContain("Timtaxa");
-    expect(html).toContain(`${formatCurrency(162_600)}/tim`); // norm
-    expect(html).toContain(`${formatCurrency(145_000)}/tim`); // 290 000 / 2 tim = tidsspillan
+    expect(html).toContain(`${formatCurrency(162_600)}/tim`); // timkostnadsnorm 2026
+    expect(html).toContain(`${formatCurrency(148_700)}/tim`); // tidsspillan 2026 (297 400 / 2 tim)
+    // Benämningarna härleds ur taxan mot årets normer.
+    expect(html).toContain("Arvode (timkostnadsnorm)");
+    expect(html).toContain("Tidsspillan");
     // Ordning i utläggsdelen: utlägg exkl moms → moms → utlägg inkl moms → summa.
     expect(html).toContain("Utlägg exkl moms");
     expect(html).toContain("<td>Moms</td>");
@@ -137,8 +143,8 @@ describe("generateFakturaFromTemplate", () => {
     const iInkl = html.indexOf("Utlägg inkl moms");
     expect(iExkl).toBeLessThan(iMoms);
     expect(iMoms).toBeLessThan(iInkl);
-    expect(html).toContain(formatCurrency(194_450)); // momsraden = arvodeVat + expensesVat
-    expect(html).toContain(formatCurrency(1_062_250)); // summa = arvode inkl moms + utlägg inkl moms
+    expect(html).toContain(formatCurrency(196_300)); // momsraden = arvodeVat + expensesVat
+    expect(html).toContain(formatCurrency(1_071_500)); // summa = arvode inkl moms + utlägg inkl moms
     // Sammanfattningen står FÖRE specifikationen; specen har sidbrytning.
     expect(html.indexOf("Sammanfattning")).toBeLessThan(html.indexOf("Specifikation"));
     expect(html.indexOf("Sammanfattning")).toBeLessThan(html.indexOf("Tidsspecifikation"));


### PR DESCRIPTION
## Vad & varför

Varje rad i fakturasammanfattningen får en **benämning** och **timtaxan i egen kolumn** (uppföljning till #927, del av #925).

Sammanfattningens tabell är nu `Benämning | Timtaxa | Tim | Belopp`:

| Benämning | Timtaxa | Tim | Belopp |
|---|---:|---:|---:|
| Arvode (timkostnadsnorm) | 1 626,00 kr/tim | 10 | 16 260,00 kr |
| Tidsspillan | 1 487,00 kr/tim | 3 | 4 461,00 kr |
| Utlägg exkl moms | | | 900,00 kr |
| Moms | | | 5 405,25 kr |
| Utlägg inkl moms | | | 1 125,00 kr |
| **Summa (inkl moms)** | | | **27 026,25 kr** |

## Hur benämningen härleds

`rateGroupLabel` jämför gruppens taxa mot **det egna radens års** normer (`timkostnadsnormFtaxForDate` / `tidsspillanFtaxForDate`):
- matchar tidsspillan-normen → **"Tidsspillan"**
- matchar timkostnadsnormen → **"Arvode (timkostnadsnorm)"**
- annars (byråns egen timtaxa) → **"Arvode"**

Att datumet följer med per grupp betyder att ett ärende över ett **årsskifte** får rätt benämning per period (2025 norm 1 586 / tidsspillan 1 450 vs 2026 norm 1 626 / tidsspillan 1 487).

## Verifierat lokalt

- [x] `bun test test/unit/lib/kostnadsrakning/` — **39/39**
- [x] `bun run typecheck` + `bun run lint --max-warnings 0` grönt (komplexitet ≤8)
- [x] `bun run deps:check` grönt
- [x] Renderat exempel granskat (tabellen ovan är faktisk output)

> Rättade även testfixturen: den använde 1 450 kr/tim som tidsspillan för 2026, men det är **2025**-normen — 2026 är 1 487 kr. Koden var rätt, fixturen fel.

## Deploy
`deploy-demo.yml` kör på push till `main` → GH Pages-demon uppdateras automatiskt vid merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_