### PR TITLE
fix(ci): restore Pages upload that keeps hidden files + make demo smoke hermetic

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -89,8 +89,14 @@ jobs:
           done
           echo "✓ Sanity check OK — $docs dokumentfiler, manifest finns, route-HTML:er finns."
 
+      # OBS: PINNAD till v3 MEDVETET (#933). v5 utesluter DOLDA filer (ärvt från
+      # upload-artifact v4+:s `include-hidden-files: false`) → `.nojekyll` och HELA
+      # `.ava/`-trädet försvann ur Pages-artefakten. Deployen rapporterade ändå
+      # "success", men live-demon 404:ade på `.ava/meta.json` → /login kunde inte
+      # hämta användare. Bumpa INTE utan att verifiera att dolda filer följer med
+      # (post-deploy-kontrollen nedan fäller numera i så fall).
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./out
 
@@ -103,4 +109,31 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        # v4 hör till samma beprövade par som upload-pages-artifact@v3 (#933).
+        uses: actions/deploy-pages@v4
+
+      # Post-deploy-grind (#933): verifiera mot den LEVANDE sajten att de DOLDA
+      # filerna faktiskt serveras. Bygg-sanity-checken ovan tittar bara i `out/`
+      # och missade därför att artefakt-uppladdningen tappade `.ava/`. Utan detta
+      # steg är en trasig demo tyst — deployen "lyckas" men appen får 404 på sin data.
+      - name: Verifiera deployad demo (dolda filer serveras)
+        env:
+          BASE: ${{ steps.deployment.outputs.page_url }}
+        run: |
+          set -euo pipefail
+          base="${BASE%/}"
+          echo "Verifierar $base"
+          for path in ".nojekyll" ".ava/meta.json" "manifest.json"; do
+            for attempt in 1 2 3 4 5; do
+              code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 "$base/$path" || echo 000)
+              [ "$code" = "200" ] && break
+              echo "  $path → $code (försök $attempt/5, Pages-CDN kan släpa)"
+              sleep 10
+            done
+            if [ "$code" != "200" ]; then
+              echo "✗ $base/$path svarade $code — demons data serveras inte (dolda filer tappade?)"
+              exit 1
+            fi
+            echo "  ✓ $path"
+          done
+          echo "✓ Deployad demo serverar både dolda och vanliga filer."

--- a/test/e2e/demo-login.spec.ts
+++ b/test/e2e/demo-login.spec.ts
@@ -17,14 +17,22 @@ test("färsk besökare (ingen principal) → /login renderar inloggningen, fastn
 
   // Färsk demo-besökare: tier=demo, INGEN principalId (deterministiskt oavsett
   // build-defaults). Detta är exakt vad en ny besökare på live-demon har.
-  await context.addInitScript(() => {
+  //
+  // `repo` sätts till testets EGEN baseURL (#932): `resolveGhPagesUrl` returnerar
+  // en full URL som-är, så datan (`.ava/meta.json` m.m.) hämtas från samma origin
+  // som sidan serveras från. Förr stod här "ulrik-s/ava", vilket fick den lokalt
+  // serverade `out/` att ändå hämta data från LIVE-demon → jobbet var inte
+  // hermetiskt och blev rött när live-demon var nere (#933), med ett missvisande
+  // fel (saknad "Logga in"-knapp, eftersom formuläret väntar på användarlistan).
+  // Mot live-demon (default baseURL) är beteendet oförändrat.
+  await context.addInitScript((repo) => {
     try {
       localStorage.setItem("ava.firma", JSON.stringify({
-        tier: "demo", repo: "ulrik-s/ava", token: "",
+        tier: "demo", repo, token: "",
         principalId: "", organizationId: "", authorName: "", authorEmail: "",
       }));
     } catch { /* ignore */ }
-  });
+  }, base.replace(/\/+$/, ""));
 
   await page.goto(`${base}/`, { waitUntil: "domcontentloaded" });
 


### PR DESCRIPTION
## Vad & varför

**Live-demon är trasig just nu** — `/login` kan inte hämta användare. Stänger **#933** och **#932**.

### 1. Roten: dolda filer tappas ur Pages-artefakten (#933)

`upload-pages-artifact` bumpades **v3 → v5** i #928 (min PR). Nyare versioner utesluter **dolda filer** (ärvt från `upload-artifact` v4+:s `include-hidden-files: false`) → `.nojekyll` och hela `.ava/`-trädet försvann. Deployen rapporterade ändå "success".

Verifierat mot live-sajten:

| URL | Status |
|---|---|
| `manifest.json` | 200 ✓ |
| `acconto-deductions/…json` (icke-dold) | 200 ✓ |
| `.nojekyll` | **404** |
| `.ava/meta.json` | **404** |

**Fix:** pinna tillbaka `upload-pages-artifact@v3` + `deploy-pages@v4` (beprövat par) + **ny post-deploy-grind** som hämtar `.nojekyll`, `.ava/meta.json` och `manifest.json` från den deployade URL:en → en trasig demo kan inte gå tyst igen (bygg-checken tittade bara i `out/`).

### 2. Dödläget: `Demo E2E` var inte hermetiskt (#932)

`Demo E2E` är en **required** check, men den hämtade data från **live-demon** — så den kunde inte bli grön medan demon var nere, och fixen för utfallet kunde därför inte mergas. Jag försökte deploya om från branchen; `github-pages`-miljön tillåter bara `main`.

Orsaken låg i specen: den pinnade `firma-config.repo` till `"ulrik-s/ava"`, så även den lokalt serverade `out/` hämtade data från github.io. Nu skickas testets **egen baseURL** som `repo` (`resolveGhPagesUrl` returnerar full URL som-är).

Verifierat lokalt (serverad `out/`, förinstallerad Chromium):
```
rubrik: true | KNAPP: true
body: "AVA — Logga in  Demo Advokatbyrå AB  Konto  Anna Advokat — Senior partner (ADMIN) …"
externa requests (ska vara 0): 0 []
```
Noll externa requests → verkligt hermetiskt. Mot live-demon (default baseURL) är beteendet oförändrat.

## Verifierat

- [x] `deploy-demo.yml` validerar som YAML
- [x] Rotorsaken bekräftad mot live-sajten (tabellen ovan)
- [x] Hermetiskt demo-smoke bevisat lokalt: knapp renderas, användare laddas, 0 externa requests
- [ ] Post-deploy-grinden bevisas först vid merge (kan bara köras mot en riktig deploy) — poängen är att den då fäller i stället för att gå tyst

## Följdeffekt
`Demo E2E` på #931 var röd av samma rotorsak → körs om när detta landat.