### PR TITLE
feat(billing): itemise the client's share on rättsskydd invoices

### DIFF
--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -20,7 +20,7 @@ import type { VatBreakdownLine } from "@/lib/shared/accounting/semantic-voucher"
 import { assertBillingTransition, type BillingActionType } from "@/lib/shared/billing-flow";
 import { proposedAccontoOre } from "@/lib/shared/billing-proposal";
 import { TIMKOSTNADSNORM_FTAX_ORE_PER_H, timkostnadsnormFtaxForDate, tidsspillanFtaxForDate } from "@/lib/shared/brottmalstaxa";
-import { computeCoverageSplit, partitionRattsskyddMinutes, type CoverageSplit } from "@/lib/shared/coverage-billing";
+import { computeCoverageSplit, partitionRattsskyddMinutes, type CoverageSplit, type RattsskyddClientParts } from "@/lib/shared/coverage-billing";
 import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
 import { carveEarliestMinutes } from "@/lib/shared/kostnadsrakning";
 import { applyKrAction, type KostnadsrakningAction, type KostnadsrakningState, type KostnadsrakningStatus } from "@/lib/shared/kostnadsrakning-flow";
@@ -115,7 +115,9 @@ function rattsskyddCoverage(
   matter: RattsskyddMatter,
   entries: ReadonlyArray<{ date: Date | string; minutes: number; billable: boolean }>,
   rateOre: number,
-): { coveredOre?: number; capOre?: number } {
+  // `minSjalvriskOre` returneras också (självrisk-golvet, #899) — utan den i typen
+  // trodde TS att den aldrig skickas till computeCoverageSplit, trots att den gör det.
+): { coveredOre?: number; capOre?: number; minSjalvriskOre?: number } {
   if (matter.paymentMethod !== "RATTSSKYDD") return {};
   const p = partitionRattsskyddMinutes(entries, matter.tvistUppkomDatum ?? null, matter.rattsskyddBeslutDatum ?? null);
   return omitUndefined({
@@ -511,6 +513,9 @@ export interface SettlementBreakdown {
   // är carvade (rättshjälp: rådgivningstimmen bort) + avstämda så summan = arvodeBaseNetOre.
   clientArvodeLines: SpecTimeLine[];
   deductedAccontos: SpecDeduction[];
+  /** Rättsskydd: varför klientens del blev som den blev (#935) — otäckt arbete,
+   *  självrisk, bolagets prutning, belopp över taket. Utelämnad för övriga metoder. */
+  clientParts?: RattsskyddClientParts;
 }
 
 /** Klientfakturans tidsspec (#876): arbetad tid, rådgivningstimmen carvad bort
@@ -570,6 +575,7 @@ async function buildSettlementBreakdown(repos: Repositories, orgId: Organization
     clientPayableOre: a.clientPayable,
     clientArvodeLines: buildClientArvodeLines(a.method, a.rateOre, a.work, a.totalArvodeNet, a.settleDate),
     deductedAccontos,
+    ...(a.split.clientParts ? { clientParts: a.split.clientParts } : {}),
   };
 }
 
@@ -587,18 +593,39 @@ const toViewLine = (l: SpecTimeLine): SettlementViewLine => ({
  * moms → inkl) + klientens utläggsandel (#878). `feeTerm` = "rättshjälpsavgift"
  * (rättshjälp) eller "självrisk" (rättsskydd).
  */
+/**
+ * Rättsskyddets fyra klient-poster → rader (#935), i den ordning de uppstår:
+ * otäckt arbete → självrisk på täckt del → bolagets prutning → över taket.
+ * Nollposter utelämnas. Summan = klientens netto (invariant, testad i
+ * `coverage-billing.test.ts`).
+ */
+function rattsskyddClientRows(p: RattsskyddClientParts, share: string): SettlementRow[] {
+  const rows: SettlementRow[] = [];
+  if (p.uncoveredOre > 0) rows.push({ label: "Arbete utanför försäkringens täckning — klienten betalar 100 % (exkl moms)", amountOre: p.uncoveredOre, kind: "add" });
+  if (p.sjalvriskOre > 0) rows.push({ label: `Självrisk ${share} % av täckt arbete (exkl moms)`, amountOre: p.sjalvriskOre, kind: "add" });
+  if (p.prutningOre > 0) rows.push({ label: "Försäkringens prutning — klienten bär (exkl moms)", amountOre: p.prutningOre, kind: "add" });
+  if (p.overCapOre > 0) rows.push({ label: "Belopp över försäkringens maxbelopp (exkl moms)", amountOre: p.overCapOre, kind: "add" });
+  return rows;
+}
+
 function buildClientView(b: SettlementBreakdown, isRattshjalp: boolean, feeTerm: string): SettlementView {
   const share = (b.clientShareBips / 100).toLocaleString("sv-SE", { maximumFractionDigits: 2 });
   const feeCap = feeTerm.charAt(0).toUpperCase() + feeTerm.slice(1);
-  const rows: SettlementRow[] = [];
-  if (isRattshjalp) {
-    rows.push({ label: "Upparbetat arvode (exkl moms)", amountOre: b.arvodeBaseNetOre, kind: "add" });
-    rows.push({ label: `Klientens ${feeTerm} ${share} % (exkl moms)`, amountOre: b.sjalvriskNetOre, kind: "add" });
-    rows.push({ label: "Moms 25 %", amountOre: b.sjalvriskGrossOre - b.sjalvriskNetOre, kind: "add" });
-    rows.push({ label: `${feeCap} (inkl moms)`, amountOre: b.sjalvriskGrossOre, kind: "add" });
+  const rows: SettlementRow[] = [
+    { label: "Upparbetat arvode (exkl moms)", amountOre: b.arvodeBaseNetOre, kind: "add" },
+  ];
+  // Rättsskydd (#935): klientens del är summan av FYRA poster — särredovisa dem i
+  // stället för ett lumpet belopp, så klienten ser varför den ska betala. Rättshjälp
+  // har bara avgiftsandelen (prutningen bärs av byrån, inte klienten).
+  if (!isRattshjalp && b.clientParts) {
+    rows.push(...rattsskyddClientRows(b.clientParts, share));
   } else {
-    rows.push({ label: "Klientens del / självrisk (inkl moms)", amountOre: b.sjalvriskGrossOre, kind: "add" });
+    rows.push({ label: `Klientens ${feeTerm} ${share} % (exkl moms)`, amountOre: b.sjalvriskNetOre, kind: "add" });
   }
+  // Samma moms-trappa för BÅDA metoderna (#935) — rättsskydd fick förr bara en enda
+  // inkl-moms-rad, vilket gjorde klientfakturorna asymmetriska och svårlästa.
+  rows.push({ label: "Moms 25 %", amountOre: b.sjalvriskGrossOre - b.sjalvriskNetOre, kind: "add" });
+  rows.push({ label: `${feeCap} (inkl moms)`, amountOre: b.sjalvriskGrossOre, kind: "add" });
   if (b.clientExpensesGrossOre > 0) rows.push({ label: "Utlägg (klientens andel, inkl moms)", amountOre: b.clientExpensesGrossOre, kind: "add" });
   for (const d of b.deductedAccontos) rows.push({ label: `Avgår aconto — faktura ${d.invoiceNumber}${d.date ? ` (${svd(d.date)})` : ""}`, amountOre: d.amountOre, kind: "deduct" });
   return { timeLines: b.clientArvodeLines.map(toViewLine), rows, totalLabel: "Att betala (inkl moms)", totalOre: b.clientPayableOre };

--- a/src/lib/shared/coverage-billing.ts
+++ b/src/lib/shared/coverage-billing.ts
@@ -48,6 +48,24 @@ export interface CoverageSplitInput {
   minSjalvriskOre?: number | null;
 }
 
+/**
+ * Rättsskydd: VARFÖR klientens del blev som den blev (#935). Klientens andel är
+ * inte bara "självrisken" — den är summan av fyra poster. Delarna returneras här
+ * så klientfakturan kan itemisera dem i stället för att visa ett lumpet belopp.
+ *
+ * Invariant: `uncoveredOre + sjalvriskOre + prutningOre + overCapOre === clientOre`.
+ */
+export interface RattsskyddClientParts {
+  /** Otäckt arbete: före tvistdatum + retroaktivt utöver 6 h — klienten betalar 100 %. */
+  uncoveredOre: number;
+  /** Självrisk på den TÄCKTA delen (andel%, golv-justerad). */
+  sjalvriskOre: number;
+  /** Försäkringsbolagets prutning — klienten bär den (byrån blir hel). */
+  prutningOre: number;
+  /** Belopp över försäkringens maxbelopp — faller på klienten. */
+  overCapOre: number;
+}
+
 export interface CoverageSplit {
   /** Vad klienten ska betala (netto, öre). */
   clientOre: number;
@@ -57,6 +75,8 @@ export interface CoverageSplit {
   firmLossOre: number;
   /** Den faktiska total som fördelas (efter ev. rättshjälps-reduktion). */
   effectiveTotalOre: number;
+  /** Rättsskydd: nedbrytning av `clientOre`. Utelämnad för andra betalningssätt. */
+  clientParts?: RattsskyddClientParts;
 }
 
 function shareOf(ore: number, bips: number): number {
@@ -92,7 +112,21 @@ function rattsskyddSplit(total: number, input: CoverageSplitInput): CoverageSpli
   const insurerRaw = Math.max(0, covered - sjalvrisk - prutning);
   const overCap = input.capOre != null ? Math.max(0, insurerRaw - input.capOre) : 0;
   const payerOre = insurerRaw - overCap;
-  return { clientOre: total - payerOre, payerOre, firmLossOre: 0, effectiveTotalOre: total };
+  const clientOre = total - payerOre;
+  // Delarna av klientens andel (#935). `prutning`/`sjalvrisk` klampas till det som
+  // faktiskt bars av den täckta delen (insurerRaw kan ha nollats), så summan alltid
+  // stämmer med clientOre — resten hamnar i `uncoveredOre`.
+  const carried = Math.min(covered, sjalvrisk + prutning);
+  const sjalvriskPart = Math.min(carried, sjalvrisk);
+  return {
+    clientOre, payerOre, firmLossOre: 0, effectiveTotalOre: total,
+    clientParts: {
+      uncoveredOre: clientOre - carried - overCap,
+      sjalvriskOre: sjalvriskPart,
+      prutningOre: carried - sjalvriskPart,
+      overCapOre: overCap,
+    },
+  };
 }
 
 /** Rättsskyddets retroaktiva tak: arbete före det positiva beslutet får ingå

--- a/test/unit/lib/shared/coverage-billing.test.ts
+++ b/test/unit/lib/shared/coverage-billing.test.ts
@@ -10,7 +10,9 @@ describe("computeCoverageSplit — rättsskydd (försäkring prutar)", () => {
   it("utan prutning: klient = självrisk, försäkring = resten, byrå hel", () => {
     // Total 100 000 kr, självrisk 20 % = 20 000 → försäkring 80 000.
     const r = computeCoverageSplit({ method: "RATTSSKYDD", totalOre: 10_000_000, clientShareBips: 2000, insurerPrutningOre: 0 });
-    expect(r).toEqual({ clientOre: 2_000_000, payerOre: 8_000_000, firmLossOre: 0, effectiveTotalOre: 10_000_000 });
+    // toMatchObject: beloppen är kontraktet — rättsskydd bär numera även en
+    // additiv `clientParts`-nedbrytning (#935) som testas separat.
+    expect(r).toMatchObject({ clientOre: 2_000_000, payerOre: 8_000_000, firmLossOre: 0, effectiveTotalOre: 10_000_000 });
   });
 
   it("med prutning: klienten tar mellanskillnaden (självrisk + prutning), byrå hel", () => {
@@ -95,7 +97,7 @@ describe("computeCoverageSplit — rättsskydd med täckt del + tak (#810)", () 
 
   it("bakåtkompatibelt: utan coveredOre/capOre = allt täckt (gamla beteendet)", () => {
     const r = computeCoverageSplit({ method: "RATTSSKYDD", totalOre: 1_000_000, clientShareBips: 2000 });
-    expect(r).toEqual({ clientOre: 200_000, payerOre: 800_000, firmLossOre: 0, effectiveTotalOre: 1_000_000 });
+    expect(r).toMatchObject({ clientOre: 200_000, payerOre: 800_000, firmLossOre: 0, effectiveTotalOre: 1_000_000 });
   });
 });
 
@@ -129,5 +131,63 @@ describe("partitionRattsskyddMinutes — tidsuppdelning (#810)", () => {
     // retro = 120 + 300 + 180 = 600 → kapas 360, överskott 240; efter beslut 240.
     expect(p.retroExcessMinutes).toBe(240);
     expect(p.coveredMinutes).toBe(360 + 240);
+  });
+});
+
+describe("rättsskydd: nedbrytning av klientens andel (#935)", () => {
+  const base = { method: "RATTSSKYDD" as const, totalOre: 1_000_000, clientShareBips: 2000 };
+
+  /** Invarianten som gör itemiseringen trovärdig på fakturan. */
+  const expectPartsSumToClient = (s: ReturnType<typeof computeCoverageSplit>): void => {
+    const p = s.clientParts!;
+    expect(p.uncoveredOre + p.sjalvriskOre + p.prutningOre + p.overCapOre).toBe(s.clientOre);
+  };
+
+  it("allt täckt: bara självrisk (20 %)", () => {
+    const s = computeCoverageSplit(base);
+    expect(s.clientParts).toEqual({ uncoveredOre: 0, sjalvriskOre: 200_000, prutningOre: 0, overCapOre: 0 });
+    expectPartsSumToClient(s);
+  });
+
+  it("otäckt arbete särredovisas — klienten betalar 100 % av det", () => {
+    const s = computeCoverageSplit({ ...base, coveredOre: 600_000 });
+    expect(s.clientParts?.uncoveredOre).toBe(400_000);   // 1 000 000 − 600 000
+    expect(s.clientParts?.sjalvriskOre).toBe(120_000);   // 20 % av täckt
+    expectPartsSumToClient(s);
+  });
+
+  it("försäkringens prutning hamnar på egen rad", () => {
+    const s = computeCoverageSplit({ ...base, insurerPrutningOre: 50_000 });
+    expect(s.clientParts?.prutningOre).toBe(50_000);
+    expect(s.clientParts?.sjalvriskOre).toBe(200_000);
+    expectPartsSumToClient(s);
+  });
+
+  it("belopp över taket särredovisas", () => {
+    const s = computeCoverageSplit({ ...base, capOre: 500_000 });
+    // Försäkringen skulle betalat 800 000, taket 500 000 → 300 000 över taket.
+    expect(s.clientParts?.overCapOre).toBe(300_000);
+    expect(s.payerOre).toBe(500_000);
+    expectPartsSumToClient(s);
+  });
+
+  it("golv-självrisk (dock lägst) speglas i nedbrytningen", () => {
+    const s = computeCoverageSplit({ ...base, minSjalvriskOre: 300_000 });
+    expect(s.clientParts?.sjalvriskOre).toBe(300_000); // golvet slår andel% (200 000)
+    expectPartsSumToClient(s);
+  });
+
+  it("allt otäckt: självrisk/prutning kan inte överstiga täckt del", () => {
+    const s = computeCoverageSplit({ ...base, coveredOre: 0, insurerPrutningOre: 50_000 });
+    expect(s.payerOre).toBe(0);
+    expect(s.clientOre).toBe(1_000_000);
+    expect(s.clientParts).toEqual({ uncoveredOre: 1_000_000, sjalvriskOre: 0, prutningOre: 0, overCapOre: 0 });
+    expectPartsSumToClient(s);
+  });
+
+  it("rättshjälp har ingen sådan nedbrytning (byrån bär prutningen)", () => {
+    const s = computeCoverageSplit({ method: "RATTSHJALP", totalOre: 1_000_000, clientShareBips: 500, awardedOre: 800_000 });
+    expect(s.clientParts).toBeUndefined();
+    expect(s.firmLossOre).toBe(200_000);
   });
 });


### PR DESCRIPTION
## Vad & varför

Klientfakturan vid **rättsskydd** visade en enda klumpad rad — `Klientens del / självrisk (inkl moms)` — medan **rättshjälp** fick en full moms-trappa. Men klientens andel är summan av **fyra olika saker**, och fakturan sa aldrig vilka:

1. Arbete **utanför försäkringens täckning** (före tvistdatum, eller retroaktivt utöver 6 h-taket) — klienten betalar 100 %
2. **Självrisken** på den täckta delen (andel %, golv-justerad)
3. Försäkringens **prutning** — klienten bär den
4. Belopp **över försäkringens maxbelopp**

## Ändringar

- **`coverage-billing.ts`**: `rattsskyddSplit` returnerar nu `clientParts` med de fyra komponenterna. Den **rena modulen äger siffrorna** — routern räknar inte om dem. Invariant (testad): `uncovered + självrisk + prutning + överTak === clientOre`.
- **`buildClientView`**: samma moms-trappa för båda metoderna, plus en rad per nollskild komponent. Itemiseringen bröts ut till `rattsskyddClientRows` för att hålla complexity ≤ 8.
- **Typfix**: `rattsskyddCoverage` deklarerar nu `minSjalvriskOre` i sin returtyp — den returnerades och konsumerades i runtime, men saknades i typen, så TS trodde att självrisk-golvet aldrig skickades vidare.

## Före / efter (verklig data, ärende 2026-0021, rättsskydd 20 %)

**Före:** `Klientens del / självrisk (inkl moms) 11 991,75` + utlägg − aconton

**Efter:**
| Rad | Belopp |
|---|---:|
| Upparbetat arvode (exkl moms) | 47 967,00 |
| Självrisk 20 % av täckt arbete (exkl moms) | 9 593,40 |
| Moms 25 % | 2 398,35 |
| Självrisk (inkl moms) | 11 991,75 |
| Utlägg (klientens andel, inkl moms) | 225,00 |
| − aconton (2 st) | −8 739,75 |
| **Att betala** | **3 477,00** |

## Verifierat

- [x] **142 tester** gröna (`coverage-billing` + `billingRun` + hela `test/integration/`), varav **7 nya** invariant-tester för nedbrytningen
- [x] `bun run typecheck`, `lint --max-warnings 0`, `lint:complexity-strict`, `deps:check` gröna
- [x] Kört genom **hela den riktiga kedjan** (simulering → `settleCoverage` → persisterad vy → fakturamallen) för 2026-0020 (rättshjälp 5 %) och 2026-0021 (rättsskydd 20 %); beloppen matchar den deployade demon

> Två befintliga tester bytte från `toEqual` till `toMatchObject` — deras avsikt är de fyra beloppen, och `clientParts` är ett additivt fält. Beloppen är oförändrade.

## Not om demo-datan (ej i denna PR)
Fyra av fem rättsskyddsärenden i seeden saknar `clientShareBips` → självrisk 0,00 och en degenererad uppdelning (försäkringen betalar allt). Bara 2026-0021 visar en riktig split. Kan åtgärdas separat om du vill att demon ska visa realistiska självrisker.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_