### PR TITLE
feat(demo): show court pruning on a rättshjälp matter

### DIFF
--- a/test/scripts/demo-prutning.test.ts
+++ b/test/scripts/demo-prutning.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Demon ska visa PRUTNING i BÅDA regimerna (#936) — de skiljer sig i vem som bär den:
+ *   • rättshjälp  — domstolen sätter ned beloppet, BYRÅN bär mellanskillnaden
+ *   • rättsskydd  — försäkringen prutar, KLIENTEN bär den (byrån blir hel)
+ * Utan detta test kan nedsättningen tyst falla ur scenarierna igen.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import type { SimMatter } from "../../tooling/demo-generator/simulate/events";
+import { runScenario, type RunCtx } from "../../tooling/demo-generator/simulate/runner";
+import { buildScenario } from "../../tooling/demo-generator/simulate/scenarios";
+import { buildRattshjalpScenario } from "../../tooling/demo-generator/simulate/scenarios/rattshjalp";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+/** Caller-stub som spelar in mutationerna (samma mönster som simulate-runner-testet). */
+function recordingCaller(): { c: Any; calls: Array<{ method: string; args: Any }> } {
+  const calls: Array<{ method: string; args: Any }> = [];
+  const rec = (method: string) => async (args: Any) => {
+    calls.push({ method, args });
+    if (method === "billingRun.createAcconto") return { run: { id: "run" }, invoice: { id: `inv-${calls.length}` } };
+    if (method === "billingRun.createKostnadsrakning") return { run: { id: "kr", workValueOreAtRun: 5_000_000 } };
+    if (method === "billingRun.createFinal") return { invoice: { id: "fin", amount: 100_000 } };
+    if (method === "billingRun.settleCoverage") return { clientInvoice: {}, payerInvoice: {} };
+    return {};
+  };
+  const c = {
+    matter: { addContact: rec("matter.addContact"), update: rec("matter.update") },
+    timeEntry: { create: rec("timeEntry.create") },
+    serviceNote: { create: rec("serviceNote.create") },
+    expense: { create: rec("expense.create") },
+    document: { register: rec("document.register") },
+    invoice: { createRadgivning: rec("invoice.createRadgivning"), setStatus: rec("invoice.setStatus"), recordPayment: rec("invoice.recordPayment") },
+    billingRun: {
+      createAcconto: rec("billingRun.createAcconto"), createKostnadsrakning: rec("billingRun.createKostnadsrakning"),
+      recordKostnadsrakningBeslut: rec("billingRun.recordKostnadsrakningBeslut"), settleCoverage: rec("billingRun.settleCoverage"),
+      recordInsurerPruning: rec("billingRun.recordInsurerPruning"), setVerdict: rec("billingRun.setVerdict"),
+      createFinal: rec("billingRun.createFinal"),
+    },
+  };
+  return { c, calls };
+}
+
+const PARTIES = { klient: "c-k", motpart: "c-m", motpartsombud: "c-o", domstol: "c-d" };
+const rhMatter = (nr: string): SimMatter => ({
+  id: `m-${nr}`, matterNumber: nr, paymentMethod: "RATTSHJALP", clientShareBips: 4000,
+  lawyerId: "u-1", startDaysAgo: 200, arvodeRateOre: 162_600,
+});
+
+async function beslutArgs(events: Any[], matter: SimMatter): Promise<Any> {
+  const { c, calls } = recordingCaller();
+  const ctx: RunCtx = { c, res: { invoices: 0, documents: 0, timeEntries: 0, notes: 0, credits: 0 } };
+  await runScenario(ctx, matter, events);
+  return calls.find((x) => x.method === "billingRun.recordKostnadsrakningBeslut")?.args;
+}
+
+describe("prutning i demo-scenarierna (#936)", () => {
+  it("rättshjälp UTAN prutning: domstolen beviljar hela det yrkade beloppet", async () => {
+    const args = await beslutArgs(buildRattshjalpScenario(PARTIES), rhMatter("2026-0002"));
+    expect(args?.awardedOre).toBe(5_000_000); // = KR:ns workValueOreAtRun
+  });
+
+  it("rättshjälp MED prutning: nedsättningen räknas på nettoarbetet och skalar med satsen", async () => {
+    const a15 = await beslutArgs(buildRattshjalpScenario(PARTIES, { courtPrutningBips: 1500 }), rhMatter("2026-0010"));
+    const a30 = await beslutArgs(buildRattshjalpScenario(PARTIES, { courtPrutningBips: 3000 }), rhMatter("2026-0010"));
+    expect(a15?.awardedOre).toBeGreaterThan(0);
+    // Större nedsättning → lägre beviljat belopp, och förhållandet följer satserna
+    // (85 % resp. 70 % av samma nettoarbete).
+    expect(a30?.awardedOre).toBeLessThan(a15!.awardedOre);
+    expect(a15!.awardedOre / a30!.awardedOre).toBeCloseTo(85 / 70, 2);
+    // Beloppet härleds ur NETTO-arvodet, inte ur KR:ns brutto-värde (5 000 000 i
+    // stubben) — annars skulle computeCoverageSplit klampa bort nedsättningen.
+    expect(a15?.awardedOre).not.toBe(5_000_000);
+  });
+
+  it("2026-0010 väljs som rättshjälps-prutningsärende, 2026-0020 lämnas orört", async () => {
+    const withPrutning = buildScenario(rhMatter("2026-0010"), PARTIES, 0);
+    const beslut = withPrutning.find((e) => e.kind === "beslut") as Any;
+    expect(beslut?.reducedByBips).toBe(1500);
+
+    // Årsskiftes-ärendet (taxe-showcase) ska INTE prutas — annars blandas exemplen.
+    const arsskifte = buildScenario({ ...rhMatter("2026-0020") }, PARTIES, 0);
+    expect((arsskifte.find((e) => e.kind === "beslut") as Any)?.reducedByBips).toBeUndefined();
+  });
+
+  it("rättsskydd 2026-0021 prutas av försäkringen → klienten bär (insurerPruning)", async () => {
+    const events = buildScenario(
+      { id: "m-21", matterNumber: "2026-0021", paymentMethod: "RATTSSKYDD", clientShareBips: 2000, lawyerId: "u-1", startDaysAgo: 200, arvodeRateOre: 162_600 },
+      PARTIES, 0,
+    );
+    const pruning = events.find((e) => e.kind === "insurerPruning") as Any;
+    expect(pruning?.prunedNetOre).toBeGreaterThan(0);
+    // Ingen dom-nedsättning i rättsskydd — bolagets prutning går via egen händelse.
+    expect(events.some((e) => e.kind === "beslut")).toBe(false);
+  });
+});

--- a/tooling/demo-generator/simulate/events.ts
+++ b/tooling/demo-generator/simulate/events.ts
@@ -28,8 +28,13 @@ export type SimEvent =
   | { kind: "rateChange"; dayOffset: number; clientShareBips: number }
   /** Kostnadsräkning till domstol — createKostnadsrakning. */
   | { kind: "kostnadsrakning"; dayOffset: number }
-  /** Domstolens beslut på KR:n — recordKostnadsrakningBeslut. */
-  | { kind: "beslut"; dayOffset: number }
+  /**
+   * Domstolens beslut på KR:n — recordKostnadsrakningBeslut. Utan `reducedByBips`
+   * beviljas hela det yrkade beloppet. Med `reducedByBips` PRUTAR domstolen (1500 =
+   * 15 % nedsättning): rättshjälpens prutning bärs av BYRÅN — klientens avgift räknas
+   * om på det nedsatta beloppet och mellanskillnaden bokas som en förlust (#936).
+   */
+  | { kind: "beslut"; dayOffset: number; reducedByBips?: number }
   /** Skapa domstolsfakturan EFTER beslut (offentligt uppdrag) — setVerdict. */
   | { kind: "verdict"; dayOffset: number }
   /** Slutreglering (rättshjälp/-skydd) — settleCoverage (→ klient FINAL/CREDIT + betalare). */

--- a/tooling/demo-generator/simulate/runner.ts
+++ b/tooling/demo-generator/simulate/runner.ts
@@ -167,9 +167,21 @@ async function hKostnadsrakning(ctx: RunCtx, m: SimMatter, _e: Any, _iso: string
   st.krWorkValueOre = run.workValueOreAtRun ?? 0;
 }
 
-async function hBeslut(ctx: RunCtx, _m: SimMatter, _e: Any, _iso: string, st: SimState): Promise<void> {
+async function hBeslut(ctx: RunCtx, _m: SimMatter, e: Any, _iso: string, st: SimState): Promise<void> {
   if (!st.krRunId) return;
-  await ctx.c.billingRun.recordKostnadsrakningBeslut({ billingRunId: st.krRunId, awardedOre: st.krWorkValueOre });
+  // Domstolen kan PRUTA (#936): `reducedByBips` sätter ned det beviljade beloppet mot
+  // det yrkade. Vid rättshjälp bär BYRÅN mellanskillnaden (får ej tas av klienten) —
+  // settleCoverage bokar den som en PRUTNING-post via bookFirmLoss.
+  //
+  // Nedsättningen räknas på det ackumulerade NETTO-arvodet, inte på KR:ns
+  // `workValueOreAtRun`: den senare är BRUTTO (inkl moms + utlägg), medan
+  // `computeCoverageSplit` jämför `awardedOre` mot netto-arvodet och klampar till
+  // totalen. En procentsats på bruttot skulle därför ofta inte bita alls.
+  const bips = Number(e.reducedByBips ?? 0);
+  const awardedOre = bips > 0
+    ? Math.round((st.accruedNetOre * (10000 - bips)) / 10000)
+    : st.krWorkValueOre;
+  await ctx.c.billingRun.recordKostnadsrakningBeslut({ billingRunId: st.krRunId, awardedOre });
 }
 
 async function hVerdict(ctx: RunCtx, _m: SimMatter, _e: Any, _iso: string, st: SimState): Promise<void> {

--- a/tooling/demo-generator/simulate/scenarios/index.ts
+++ b/tooling/demo-generator/simulate/scenarios/index.ts
@@ -13,9 +13,13 @@ import { buildRattsskyddPositivtScenario } from "./rattsskydd-positivt";
 export function buildScenario(matter: SimMatter, parties: Parties, index: number): SimEvent[] {
   switch (matter.paymentMethod) {
     // 2026-0020 spänner över ett årsskifte + tidsspillan + retroaktiv höjning (#891).
-    case "RATTSHJALP": return matter.matterNumber === "2026-0020"
-      ? buildRattshjalpArsskifteScenario(parties)
-      : buildRattshjalpScenario(parties);
+    // 2026-0010 visar domstolens PRUTNING (#936): 15 % nedsättning som BYRÅN bär.
+    // Valt just det ärendet för att det OCKSÅ har en rättshjälpsavgift (40 %) → båda
+    // avdragen syns på domstolsfakturan. Motstycket är rättsskyddets prutning i
+    // 2026-0021, där KLIENTEN bär den.
+    case "RATTSHJALP":
+      if (matter.matterNumber === "2026-0020") return buildRattshjalpArsskifteScenario(parties);
+      return buildRattshjalpScenario(parties, matter.matterNumber === "2026-0010" ? { courtPrutningBips: 1500 } : {});
     // 2026-0021 = positivt rättsskyddsbesked (100 tim, självrisk 20 % lägst 1 800 kr, #899).
     case "RATTSSKYDD": return matter.matterNumber === "2026-0021"
       ? buildRattsskyddPositivtScenario(parties)

--- a/tooling/demo-generator/simulate/scenarios/rattshjalp.ts
+++ b/tooling/demo-generator/simulate/scenarios/rattshjalp.ts
@@ -10,7 +10,17 @@
 
 import type { Parties, SimEvent } from "../events";
 
-export function buildRattshjalpScenario(parties: Parties): SimEvent[] {
+export interface RattshjalpScenarioOpts {
+  /**
+   * Domstolens prutning i bips (1500 = 15 % nedsättning av det yrkade arvodet), #936.
+   * Vid rättshjälp bär BYRÅN nedsättningen — klientens rättshjälpsavgift räknas om på
+   * det nedsatta beloppet och mellanskillnaden bokas som en PRUTNING-post. Utan värde
+   * beviljar domstolen hela beloppet.
+   */
+  courtPrutningBips?: number;
+}
+
+export function buildRattshjalpScenario(parties: Parties, opts: RattshjalpScenarioOpts = {}): SimEvent[] {
   const ev: SimEvent[] = [
     { kind: "note", dayOffset: 0, text: "Klientbesök — första möte i ärendet. Rådgivning enligt rättshjälpstaxan." },
     { kind: "rateChange", dayOffset: 0, clientShareBips: 500 }, // klient arbetslös → 5 %
@@ -54,7 +64,12 @@ export function buildRattshjalpScenario(parties: Parties): SimEvent[] {
     // Kostnadsräkning → myndighetens/domstolens beslut → slutreglering.
     { kind: "kostnadsrakning", dayOffset: 105 },
     { kind: "doc", dayOffset: 106, template: "beslutRattshjalp" },
-    { kind: "beslut", dayOffset: 107 },
+    ...(opts.courtPrutningBips
+      ? [
+        { kind: "note" as const, dayOffset: 107, text: `Domstolen satte ned det yrkade arvodet med ${opts.courtPrutningBips / 100} % — nedsättningen bärs av byrån, klientens rättshjälpsavgift räknas om på det beviljade beloppet.` },
+        { kind: "beslut" as const, dayOffset: 107, reducedByBips: opts.courtPrutningBips },
+      ]
+      : [{ kind: "beslut" as const, dayOffset: 107 }]),
     { kind: "settle", dayOffset: 110, payerRecipient: "DOMSTOL" },
   );
   return ev;


### PR DESCRIPTION
## Vad & varför

Demon visade bara **en** av de två prutnings-regimerna. Rättsskydd hade redan försäkringens prutning efter slutregleringen (2026-0021, **klienten** bär den), men rättshjälps-sidan saknades helt: `hBeslut` beviljade alltid exakt det yrkade beloppet och `beslut`-eventet kunde inte uttrycka en nedsättning.

## Ändringar

- **`beslut`-eventet** tar valfri `reducedByBips` → ett scenario kan säga att domstolen beviljade mindre än yrkat.
- **Nedsättningen räknas på det ackumulerade NETTO-arvodet**, inte på kostnadsräkningens `workValueOreAtRun`. Den senare är **brutto** (inkl moms + utlägg) medan `computeCoverageSplit` jämför `awardedOre` mot netto-arvodet och klampar till totalen — en procentsats på bruttot hade därför oftast **inte bitit alls** (verifierat: 85 % av bruttot > nettot → nedsättningen nollades).
- **Applicerat på 2026-0010**, som också har 40 % rättshjälpsavgift, så domstolsfakturan visar **båda** avdragen sida vid sida. 2026-0020 lämnas oprutat så det förblir ett renodlat taxe-exempel.

## Resultat (verifierat end-to-end)

**Rättshjälp 2026-0010 — byrån bär:**
```
PRUTNING-post bokad:  −10 365,75 kr  "Prutning — byrån bär (rättshjälp)"

Domstolsfakturan F-2026-0026:
  Upparbetat arvode (exkl moms)                69 105,00
  − Avgår klientens rättshjälpsavgift          23 495,70   ← 40 % av det NEDSATTA beloppet
  − Avgår prutning (byrån bär)                 10 365,75   ← byråns förlust
  = Domstolens andel av arvodet                35 243,55
```

**Rättsskydd 2026-0021 — klienten bär:** påfyllnadsfaktura F-2026-0042 på försäkringens prutning 3 000 + moms = 3 750 kr. **Ingen** PRUTNING-post bokas — byrån blir hel.

## Verifierat

- [x] **269 tester** gröna (`test/scripts/` + `test/integration/` + billing/coverage-sviterna), varav **4 nya** i `demo-prutning.test.ts` som vaktar att båda regimerna finns kvar i scenarierna
- [x] `bun run typecheck` + `lint --max-warnings 0` gröna
- [x] `bun run build:demo` grönt (615 entiteter)

## Not
Nedsättningen appliceras på **aggregatet**, inte per taxekategori — de per-timtaxa-sektioner i sammanfattningen visar fortsatt fullt arvode, och prutningen redovisas som en egen avdragsrad. Det gäller lika för arbete och tidsspillan.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_