### PR TITLE
refactor(faktura): mejlbilagan får sammanställning + specifikation

### DIFF
--- a/src/app/invoices/[id]/_client.tsx
+++ b/src/app/invoices/[id]/_client.tsx
@@ -28,7 +28,7 @@ import { InvoiceActions } from "./_invoice-actions";
 import { PaymentModal } from "./_payment-modal";
 import { PaymentsTable } from "./_payments-table";
 import { PlanModal } from "./_plan-modal";
-import { SendInvoiceModal } from "./_send-invoice-modal";
+import { SendInvoiceModal, type SendInvoiceModalProps } from "./_send-invoice-modal";
 import { WriteOffModal } from "./_write-off-modal";
 
 const STATUS_LABELS: Record<string, string> = {
@@ -257,10 +257,15 @@ function InvoiceModals({ inv, ledger, s }: { inv: Inv; ledger: LedgerView; s: In
       {s.show.send && (
         <SendInvoiceModal
           invoiceId={inv.id}
+          matterId={inv.matter.id}
           invoiceNumber={(inv as { invoiceNumber?: string | null }).invoiceNumber}
           amount={inv.amount}
+          vatOre={(inv as { vatOre?: number | null }).vatOre}
           ocrReference={(inv as { ocrReference?: string | null }).ocrReference}
           invoiceDate={inv.invoiceDate}
+          invoiceType={inv.invoiceType}
+          notes={inv.notes}
+          settlementBreakdown={(inv as { settlementBreakdown?: SendInvoiceModalProps["settlementBreakdown"] }).settlementBreakdown}
           matterNumber={inv.matter.matterNumber}
           matterTitle={inv.matter.title}
           onRecorded={() => {

--- a/src/app/invoices/[id]/_send-invoice-modal.tsx
+++ b/src/app/invoices/[id]/_send-invoice-modal.tsx
@@ -14,17 +14,25 @@ import { useState } from "react";
 import { bytesToBase64 } from "@/lib/client/bytes-base64";
 import { downloadBytes } from "@/lib/client/download-text";
 import { useHelper, composeMailViaHelper } from "@/lib/client/helper/use-helper";
-import { renderFakturaPdf } from "@/lib/client/kostnadsrakning/render-faktura-pdf";
+import type { FakturaBreakdown, InvoiceSpecification } from "@/lib/client/kostnadsrakning/faktura-template";
 import { trpc } from "@/lib/client/trpc";
 import { formatCurrency } from "@/lib/client/utils";
-import type { InvoiceId } from "@/lib/shared/schemas/ids";
+import type { InvoiceId, MatterId } from "@/lib/shared/schemas/ids";
 
 export interface SendInvoiceModalProps {
   invoiceId: InvoiceId;
+  /** Behövs för att hämta fakturaspecifikationen till bilagan (#938). */
+  matterId: MatterId;
   invoiceNumber?: string | null | undefined;
   amount: number;
+  /** Momsbelopp (öre) — utan spec/nedbrytning blir det netto/moms-raderna. */
+  vatOre?: number | null | undefined;
   ocrReference?: string | null | undefined;
   invoiceDate?: string | Date | null | undefined;
+  invoiceType?: string | null | undefined;
+  notes?: string | null | undefined;
+  /** Persisterad nedbrytning (#878) → uppdelningen klient/betalare i bilagan. */
+  settlementBreakdown?: FakturaBreakdown | null | undefined;
   matterNumber: string;
   matterTitle: string;
   onClose: () => void;
@@ -45,16 +53,35 @@ function pdfFileName(p: SendInvoiceModalProps): string {
   return `Faktura ${p.invoiceNumber ?? p.matterNumber}.pdf`;
 }
 
-async function buildPdf(p: SendInvoiceModalProps, recipient: string): Promise<Uint8Array> {
-  return renderFakturaPdf({
+/** Fakturaspecifikationen (#856) — tomt vid fel, bilagan faller då tillbaka på
+ *  netto/moms-raderna i st.f. att utskicket stoppas. */
+type SpecFetcher = (a: { matterId: MatterId; invoiceId: InvoiceId }) => Promise<InvoiceSpecification>;
+
+async function fetchSpec(fetcher: SpecFetcher, p: SendInvoiceModalProps): Promise<InvoiceSpecification | null> {
+  try {
+    return await fetcher({ matterId: p.matterId, invoiceId: p.invoiceId });
+  } catch { return null; }
+}
+
+/**
+ * Bilagan renderas ur SAMMA vy-modell som det arkiverade fakturadokumentet
+ * (#938) → sammanställning på sida 1, specifikation därefter.
+ */
+async function buildPdf(p: SendInvoiceModalProps, recipient: string, fetcher: SpecFetcher): Promise<Uint8Array> {
+  const { buildFakturaView } = await import("@/lib/client/kostnadsrakning/faktura-template");
+  const { renderFakturaPdf } = await import("@/lib/client/kostnadsrakning/render-faktura-pdf");
+  const spec = await fetchSpec(fetcher, p);
+  const view = buildFakturaView({
     invoice: {
-      amount: p.amount,
-      invoiceNumber: p.invoiceNumber ?? null,
-      ocrReference: p.ocrReference ?? null,
-      invoiceDate: p.invoiceDate ?? null,
+      id: p.invoiceId, amount: p.amount, vatOre: p.vatOre,
+      invoiceNumber: p.invoiceNumber, ocrReference: p.ocrReference, invoiceDate: p.invoiceDate,
+      invoiceType: p.invoiceType, notes: p.notes,
     },
-    meta: { matterNumber: p.matterNumber, matterTitle: p.matterTitle, ...(recipient ? { recipient } : {}) },
+    recipient: recipient || p.matterTitle,
+    meta: { matterNumber: p.matterNumber, matterTitle: p.matterTitle },
+    spec, breakdown: p.settlementBreakdown,
   });
+  return renderFakturaPdf(view);
 }
 
 interface SendInvoiceState {
@@ -80,6 +107,8 @@ function useSendInvoice(props: SendInvoiceModalProps): SendInvoiceState {
   const [note, setNote] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const helper = useHelper();
+  const utils = trpc.useUtils();
+  const fetchSpecification: SpecFetcher = (a) => utils.billingRun.invoiceSpecification.fetch(a);
 
   const record = trpc.invoiceDispatch.recordManual.useMutation({
     onSuccess: () => { props.onRecorded(); props.onClose(); },
@@ -112,7 +141,7 @@ function useSendInvoice(props: SendInvoiceModalProps): SendInvoiceState {
   };
 
   const onEmail = () => void run(async () => {
-    const bytes = await buildPdf(props, recipient);
+    const bytes = await buildPdf(props, recipient, fetchSpecification);
     const opened = Boolean(helper.version) && await composeMailViaHelper({
       ...(recipient ? { to: recipient } : {}),
       fileName: pdfFileName(props),
@@ -127,7 +156,7 @@ function useSendInvoice(props: SendInvoiceModalProps): SendInvoiceState {
   });
 
   const onDownload = () => void run(async () => {
-    const bytes = await buildPdf(props, recipient);
+    const bytes = await buildPdf(props, recipient, fetchSpecification);
     downloadBytes(pdfFileName(props), new Uint8Array(bytes), "application/pdf");
     return "PDF:en laddades ner.";
   });

--- a/src/lib/client/kostnadsrakning/faktura-template.ts
+++ b/src/lib/client/kostnadsrakning/faktura-template.ts
@@ -1,5 +1,5 @@
 /**
- * Faktura-mallen — EN renderare för ALLA fakturor (#937).
+ * Faktura-mallen — EN källa för ALLA fakturor (#937/#938).
  *
  * Upplägget är detsamma oavsett fakturatyp och betalningssätt:
  *   sida 1  Sammanställning — en rad per timtaxa (benämning + timtaxa + tim +
@@ -8,10 +8,10 @@
  *   sida 2+ Specifikation — tidsspecifikation + utläggsspecifikation, dvs
  *           underlaget till beloppen på sida 1.
  *
- * Bröts ut ur `generate-faktura-doc.ts` (#937) så BÅDE appen (fakturadokumentet
- * som skapas vid aconto/slutreglering/dom) och demo-generatorn renderar exakt
- * samma HTML — tidigare fanns tre parallella renderare och bara denna hade
- * upplägget ovan. Ren modul: in → argument, ut → HTML-sträng (inga sidoeffekter).
+ * `buildFakturaView` är den TYPADE vy-modellen (#938): färdigformaterade rader,
+ * inga öre kvar. Både HTML-mallen (`renderFakturaHtml`) och PDF-bilagan
+ * (`renderFakturaPdf`) läser den, så etiketter och belopp kan inte glida isär
+ * mellan det dokument som arkiveras och det som mejlas.
  *
  * KOSTNADSRÄKNINGEN till domstol har en EGEN mall (`buildKostnadsrakningContext`)
  * — den är en myndighetsblankett, inte en faktura, och berörs inte här.
@@ -78,6 +78,48 @@ export interface FakturaTemplateArgs {
   breakdown?: FakturaBreakdown | null | undefined;
 }
 
+// ── Vy-modellen (#938) ──────────────────────────────────────────────────────
+
+/** En rad i sammanställningen: taxegrupp, utlägg eller moms. Tomma sträng-fält
+ *  betyder "ingen kolumn-uppgift" (utlägg har ingen timtaxa). */
+export interface FakturaSummaryRow { label: string; rateLabel: string; hours: string; amount: string }
+
+/**
+ * En rad i uppdelningen klient/betalare. `style` är en CSS-färg för HTML;
+ * `muted` säger åt PDF:en att tona ned raden. `amount` bär redan sin dekoration
+ * (−avdrag, (parentes) för info-rader) så båda renderarna skriver den rakt av.
+ */
+export interface FakturaSplitRow { label: string; amount: string; style: string; muted: boolean }
+
+export interface FakturaTimeRow { date: string; description: string; hours: string; amount: string }
+export interface FakturaExpenseRow { date: string; description: string; net: string; gross: string }
+
+/** Färdigformaterad faktura — allt en renderare behöver, inga öre kvar. */
+export interface FakturaView {
+  heading: string;
+  invoiceNumber: string;
+  ocr: string;
+  date: string;
+  matterNumber: string;
+  matterTitle: string;
+  recipient: string;
+  organizationName: string;
+  organizationOrgNumber: string;
+  /** Rådgivningsnotisen (#870) — tom sträng när den inte gäller. */
+  footnote: string;
+  summary: FakturaSummaryRow[];
+  summaryTotal: string;
+  /** Visa rubriken "Uppdelning klient / betalare" (bara vid faktisk split). */
+  hasSplit: boolean;
+  splitRows: FakturaSplitRow[];
+  totalLabel: string;
+  total: string;
+  /** Finns underlag att specificera → egen sida efter sammanställningen. */
+  hasSpec: boolean;
+  timeLines: FakturaTimeRow[];
+  expenseLines: FakturaExpenseRow[];
+}
+
 /** Inbyggd faktura-mall (Handlebars) — används av template-motorn (#852) när
  *  ingen byrå-mall finns. HTML → öppningsbar + skrivbar. */
 const FAKTURA_TEMPLATE = `<!DOCTYPE html><html lang="sv"><head><meta charset="utf-8"><title>{{heading}} {{invoiceNumber}}</title>
@@ -88,27 +130,15 @@ const FAKTURA_TEMPLATE = `<!DOCTYPE html><html lang="sv"><head><meta charset="ut
 <p style="color:#555">Ärende {{matterNumber}} — {{matterTitle}}<br>Mottagare: {{recipient}}</p>
 
 <h2 style="font-size:16px;margin-top:1.5rem;margin-bottom:.5rem">Sammanställning</h2>
-{{#if arvodeSections.length}}
+{{#if summary.length}}
 <table cellpadding="6" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:14px;margin-bottom:1rem">
 <thead><tr style="border-bottom:1px solid #ccc;text-align:left"><th>Benämning</th><th style="text-align:right">Timtaxa</th><th style="text-align:right">Tim</th><th style="text-align:right">Belopp</th></tr></thead>
-<tbody>{{#each arvodeSections}}<tr><td>{{this.label}}</td><td style="text-align:right">{{this.rateLabel}}</td><td style="text-align:right">{{this.hours}}</td><td style="text-align:right">{{this.amount}}</td></tr>{{/each}}</tbody>
-<tfoot><tr style="border-top:1px solid #ccc"><td style="font-weight:bold">Summa (inkl moms)</td><td></td><td></td><td style="text-align:right;font-weight:bold">{{arvodeSumma}}</td></tr></tfoot>
+<tbody>{{#each summary}}<tr><td>{{this.label}}</td><td style="text-align:right">{{this.rateLabel}}</td><td style="text-align:right">{{this.hours}}</td><td style="text-align:right">{{this.amount}}</td></tr>{{/each}}</tbody>
+<tfoot><tr style="border-top:1px solid #ccc"><td style="font-weight:bold">Summa (inkl moms)</td><td></td><td></td><td style="text-align:right;font-weight:bold">{{summaryTotal}}</td></tr></tfoot>
 </table>{{/if}}
 {{#if hasSplit}}<h3 style="font-size:14px;margin-top:1rem;margin-bottom:.25rem">Uppdelning klient / betalare</h3>{{/if}}
 <table cellpadding="6" cellspacing="0" style="border-collapse:collapse;width:100%;font-size:14px">
-<tbody>
-{{#if useBreakdown}}
-{{#each breakdownRows}}<tr style="{{this.style}}"><td>{{this.label}}</td><td style="text-align:right;{{this.style}}">{{this.amount}}</td></tr>{{/each}}
-{{else}}
-{{#if useSpec}}
-{{#each deductions}}<tr style="color:#b45309"><td>Avgår aconto — faktura {{this.invoiceNumber}}{{#if this.date}} ({{this.date}}){{/if}}</td><td style="text-align:right">−{{this.amount}}</td></tr>{{/each}}
-{{#if hasAdjustment}}<tr style="color:#555"><td>{{adjustmentLabel}}</td><td style="text-align:right">{{adjustment}}</td></tr>{{/if}}
-{{else}}
-<tr><td>Netto (exkl moms)</td><td style="text-align:right">{{net}}</td></tr>
-<tr><td>Moms</td><td style="text-align:right">{{vat}}</td></tr>
-{{/if}}
-{{/if}}
-</tbody>
+<tbody>{{#each splitRows}}<tr style="{{this.style}}"><td>{{this.label}}</td><td style="text-align:right;{{this.style}}">{{this.amount}}</td></tr>{{/each}}</tbody>
 <tfoot><tr style="border-top:2px solid #333"><td style="font-weight:bold">{{totalLabel}}</td><td style="text-align:right;font-weight:bold">{{total}}</td></tr></tfoot>
 </table>
 {{#if footnote}}<p style="color:#555;font-size:13px;margin-top:1rem">{{footnote}}</p>{{/if}}
@@ -184,33 +214,6 @@ function specFromCarriedWork(carried: CarriedWork, spec: InvoiceSpecification | 
   });
 }
 
-/** Spec-delen av kontexten (tider/utlägg/avdrag + summering, #856). Tom när
- *  ingen spec finns → mallen (`useSpec`=false) faller tillbaka på netto/moms. */
-function specContext(spec: InvoiceSpecification | null, fc: Fc): Record<string, unknown> {
-  if (!spec) return { useSpec: false };
-  const vat = spec.arvodeVatOre + spec.expensesVatOre;
-  return {
-    useSpec: true,
-    hasSpec: spec.timeLines.length > 0 || spec.expenseLines.length > 0,
-    hasExpenses: spec.expenseLines.length > 0,
-    hoursTotal: spec.totalMinutes > 0 ? svHours(spec.totalMinutes) : "",
-    timeLines: spec.timeLines.map((l) => ({ date: svDate(l.date), description: l.description, hours: svHours(l.minutes), amount: fc(l.amountOre) })),
-    expenseLines: spec.expenseLines.map((l) => ({ date: svDate(l.date), description: l.description, net: fc(l.netOre), gross: fc(l.grossOre) })),
-    deductions: spec.deductions.map((d) => ({ invoiceNumber: d.invoiceNumber, date: svDate(d.date), amount: fc(d.amountOre) })),
-    arvodeNet: fc(spec.arvodeNetOre), expensesNet: fc(spec.expensesNetOre), vat: fc(vat), gross: fc(spec.grossOre),
-    hasAdjustment: spec.adjustmentOre !== 0,
-    adjustmentLabel: spec.adjustmentOre < 0 ? "Nedsättning" : "Justering",
-    adjustment: fc(spec.adjustmentOre),
-  };
-}
-
-/**
- * Arvode-sektioner per timtaxa (#925) för sammanställningen: grupperar spec:ens
- * tidsrader på den HÄRLEDDA taxan (amountOre / timmar — rättshjälp=norm/tidsspillan,
- * övrigt=post-taxa) → en rad per unik taxa (fallande). Ren + testbar.
- */
-interface SummarySection { label: string; rateLabel: string; hours: string; amount: string }
-
 /**
  * Benämning för en taxegrupp (#925): rättshjälpsärenden värderar arbete på
  * timkostnadsnormen och restid/väntetid på den lägre tidsspillan-normen — känns
@@ -225,7 +228,7 @@ function rateGroupLabel(rateOre: number, date: Date | string): string {
 }
 
 /** Gruppera arvodet på den härledda timtaxan → en rad per unik taxa (fallande). */
-function arvodeRateRows(spec: InvoiceSpecification, fc: Fc): SummarySection[] {
+function arvodeRateRows(spec: InvoiceSpecification, fc: Fc): FakturaSummaryRow[] {
   const groups = new Map<number, { minutes: number; amountOre: number; date: Date | string }>();
   for (const l of spec.timeLines) {
     const rate = l.minutes > 0 ? Math.round((l.amountOre * 60) / l.minutes) : 0;
@@ -243,86 +246,117 @@ function arvodeRateRows(spec: InvoiceSpecification, fc: Fc): SummarySection[] {
 }
 
 /**
- * Sammanställningens sektionstabell (#925): en rad per timtaxa (arvode exkl moms),
- * följt av utlägg exkl moms + utlägg inkl moms, och en summa (allt inkl moms).
- * Utlägg-raderna är avsiktligt informativa (både exkl och inkl) — summan är det
- * faktiska bruttot (arvode inkl moms + utlägg inkl moms). Ren + testbar.
+ * Sammanställningens rader (#925): en rad per timtaxa (arvode exkl moms), följt
+ * av utlägg exkl moms → moms → utlägg inkl moms. Summan är det faktiska bruttot
+ * (arvode inkl moms + utlägg inkl moms). Ren + testbar.
  */
-function arvodeSectionsContext(a: FakturaTemplateArgs, spec: InvoiceSpecification | null, fc: Fc): Record<string, unknown> {
+function summarySection(a: FakturaTemplateArgs, spec: InvoiceSpecification | null, fc: Fc): { summary: FakturaSummaryRow[]; summaryTotal: string } {
   if (!spec || spec.timeLines.length === 0) {
     // Fakturor helt utan itemiserat arbete (rådgivningstimmen, rena aconton) får
     // ändå en sammanställningsrad ur `notes` (#870) → beloppet är aldrig oförklarat.
     const label = a.invoice.notes?.trim() || "Arvode";
-    return { arvodeSections: [{ label, rateLabel: "", hours: "", amount: fc(a.invoice.amount) }], arvodeSumma: fc(a.invoice.amount) };
+    return { summary: [{ label, rateLabel: "", hours: "", amount: fc(a.invoice.amount) }], summaryTotal: fc(a.invoice.amount) };
   }
-  const sections = arvodeRateRows(spec, fc);
+  const summary = arvodeRateRows(spec, fc);
   const hasExpenses = spec.expensesNetOre > 0 || spec.expensesVatOre > 0;
   // Ordning (#925): momsfritt utlägg → momsraden (total moms) → utlägg inkl moms
   // → summa (allt inkl moms). Momsraden är fakturans hela moms (arvode + utlägg),
   // så arvode-raderna (exkl moms) + utlägg exkl + moms = summan.
-  if (hasExpenses) {
-    sections.push({ label: "Utlägg exkl moms", rateLabel: "", hours: "", amount: fc(spec.expensesNetOre) });
-  }
-  sections.push({ label: "Moms", rateLabel: "", hours: "", amount: fc(spec.arvodeVatOre + spec.expensesVatOre) });
-  if (hasExpenses) {
-    sections.push({ label: "Utlägg inkl moms", rateLabel: "", hours: "", amount: fc(spec.expensesNetOre + spec.expensesVatOre) });
-  }
+  if (hasExpenses) summary.push({ label: "Utlägg exkl moms", rateLabel: "", hours: "", amount: fc(spec.expensesNetOre) });
+  summary.push({ label: "Moms", rateLabel: "", hours: "", amount: fc(spec.arvodeVatOre + spec.expensesVatOre) });
+  if (hasExpenses) summary.push({ label: "Utlägg inkl moms", rateLabel: "", hours: "", amount: fc(spec.expensesNetOre + spec.expensesVatOre) });
   const summaOre = spec.arvodeNetOre + spec.arvodeVatOre + spec.expensesNetOre + spec.expensesVatOre;
-  return { arvodeSections: sections, arvodeSumma: fc(summaOre) };
+  return { summary, summaryTotal: fc(summaOre) };
 }
 
-/** Itemiserad summering (#858) → mall-rader. `deduct`=−, `info`=(parentes), färgad. */
-function breakdownContext(breakdown: FakturaBreakdown | null | undefined, fc: Fc): Record<string, unknown> {
-  if (!breakdown) return { useBreakdown: false };
+/** Itemiserad summering (#858) → uppdelningsrader. `deduct`=−, `info`=(parentes). */
+function breakdownSplitRows(breakdown: FakturaBreakdown, fc: Fc): FakturaSplitRow[] {
+  return breakdown.rows.map((r) => ({
+    label: r.label,
+    amount: r.kind === "deduct" ? `−${fc(r.amountOre)}` : r.kind === "info" ? `(${fc(r.amountOre)})` : fc(r.amountOre),
+    style: r.kind === "deduct" ? "color:#b45309" : r.kind === "info" ? "color:#9ca3af" : "",
+    muted: r.kind !== "add",
+  }));
+}
+
+/** Spec-summeringen (#856) → uppdelningsrader: avdragna aconton + ev. justering. */
+function specSplitRows(spec: InvoiceSpecification, fc: Fc): FakturaSplitRow[] {
+  const rows: FakturaSplitRow[] = spec.deductions.map((d) => ({
+    label: `Avgår aconto — faktura ${d.invoiceNumber}${d.date ? ` (${svDate(d.date)})` : ""}`,
+    amount: `−${fc(d.amountOre)}`,
+    style: "color:#b45309",
+    muted: true,
+  }));
+  if (spec.adjustmentOre !== 0) {
+    rows.push({
+      label: spec.adjustmentOre < 0 ? "Nedsättning" : "Justering",
+      amount: fc(spec.adjustmentOre), style: "color:#555", muted: true,
+    });
+  }
+  return rows;
+}
+
+/**
+ * Uppdelningen klient/betalare — EN lista oavsett källa (#938). Prioritet:
+ * itemiserad nedbrytning (#858) → spec-summeringen (#856) → netto/moms ur
+ * fakturan. Att vecka ihop grenarna här är det som gör att PDF:en och HTML:en
+ * kan dela renderingslogik.
+ */
+function splitRowsFor(a: FakturaTemplateArgs, spec: InvoiceSpecification | null, fc: Fc): FakturaSplitRow[] {
+  if (a.breakdown) return breakdownSplitRows(a.breakdown, fc);
+  if (spec) return specSplitRows(spec, fc);
+  const vatOre = a.invoice.vatOre ?? 0;
+  return [
+    { label: "Netto (exkl moms)", amount: fc(a.invoice.amount - vatOre), style: "", muted: false },
+    { label: "Moms", amount: fc(vatOre), style: "", muted: false },
+  ];
+}
+
+/** Specifikationens tabeller (tider + utlägg) ur den upplösta specifikationen. */
+function specTables(spec: InvoiceSpecification | null, fc: Fc): Pick<FakturaView, "hasSpec" | "timeLines" | "expenseLines"> {
+  if (!spec) return { hasSpec: false, timeLines: [], expenseLines: [] };
   return {
-    useBreakdown: true,
-    breakdownRows: breakdown.rows.map((r) => ({
-      label: r.label,
-      amount: r.kind === "deduct" ? `−${fc(r.amountOre)}` : r.kind === "info" ? `(${fc(r.amountOre)})` : fc(r.amountOre),
-      style: r.kind === "deduct" ? "color:#b45309" : r.kind === "info" ? "color:#9ca3af" : "",
-    })),
+    hasSpec: spec.timeLines.length > 0 || spec.expenseLines.length > 0,
+    timeLines: spec.timeLines.map((l) => ({ date: svDate(l.date), description: l.description, hours: svHours(l.minutes), amount: fc(l.amountOre) })),
+    expenseLines: spec.expenseLines.map((l) => ({ date: svDate(l.date), description: l.description, net: fc(l.netOre), gross: fc(l.grossOre) })),
   };
 }
 
-/** Belopps-kontexten (netto/moms/summa) — `total` följer breakdown om satt. */
-function amountContext(a: FakturaTemplateArgs, fc: Fc): Record<string, unknown> {
-  const { invoice, breakdown } = a;
-  const vatOre = invoice.vatOre ?? 0;
-  return {
-    net: fc(invoice.amount - vatOre), vat: fc(vatOre),
-    total: fc(breakdown ? breakdown.totalOre : invoice.amount),
-    totalLabel: breakdown?.totalLabel ?? "Att betala (inkl moms)",
-  };
-}
-
-/** Faktura-huvudets kontext (rubrik/nr/datum/mottagare/org + belopp). Utbruten →
- *  håller `fakturaTemplateContext` under param- och komplexitetsgränsen. */
-function headerContext(a: FakturaTemplateArgs, fc: Fc): Record<string, unknown> {
-  const { invoice, recipient, meta } = a;
+/** Faktura-huvudets fält (rubrik/nr/datum/mottagare/org). Utbrutet → håller
+ *  `buildFakturaView` under param- och komplexitetsgränsen. */
+function headerFields(a: FakturaTemplateArgs): Pick<FakturaView, "heading" | "footnote" | "invoiceNumber" | "ocr" | "date" | "matterNumber" | "matterTitle" | "recipient" | "organizationName" | "organizationOrgNumber"> {
+  const { invoice, meta } = a;
   return {
     heading: fakturaHeading(invoice),
     footnote: footnoteFor(invoice),
     invoiceNumber: invoice.invoiceNumber ?? "—",
     ocr: invoice.ocrReference ?? "",
     date: (invoice.invoiceDate ? new Date(invoice.invoiceDate) : new Date()).toLocaleDateString("sv-SE"),
-    matterNumber: meta.matterNumber, matterTitle: meta.matterTitle, recipient,
-    organizationName: meta.organizationName ?? "", organizationOrgNumber: meta.organizationOrgNumber ?? "",
-    ...amountContext(a, fc),
+    matterNumber: meta.matterNumber,
+    matterTitle: meta.matterTitle,
+    recipient: a.recipient,
+    organizationName: meta.organizationName ?? "",
+    organizationOrgNumber: meta.organizationOrgNumber ?? "",
   };
 }
 
-/** Handlebars-kontext för faktura-mallen (utbruten → håller generatorn ≤8). */
-export function fakturaTemplateContext(a: FakturaTemplateArgs, fc: Fc): Record<string, unknown> {
+/**
+ * Bygg den färdigformaterade vy-modellen (#938) — enda stället där öre blir
+ * text. HTML-mallen och PDF-bilagan renderar samma `FakturaView`.
+ */
+export function buildFakturaView(a: FakturaTemplateArgs, fc: Fc = formatCurrency): FakturaView {
   const spec = resolveSpec(a);
   return {
-    ...headerContext(a, fc),
-    ...specContext(spec, fc),
-    ...arvodeSectionsContext(a, spec, fc),
-    ...breakdownContext(a.breakdown, fc),
+    ...headerFields(a),
+    ...summarySection(a, spec, fc),
     // "Uppdelning klient / betalare"-rubriken (#925) visas bara när det finns en
     // faktisk split: en breakdown (självrisk/aconto/rättshjälpsavgift) ELLER
-    // spec-avdrag/justering. Total-tabellen renderas alltid (bär tfoot-totalen).
+    // spec-avdrag/justering. Total-raden renderas alltid.
     hasSplit: !!a.breakdown || (!!spec && (spec.deductions.length > 0 || spec.adjustmentOre !== 0)),
+    splitRows: splitRowsFor(a, spec, fc),
+    totalLabel: a.breakdown?.totalLabel ?? "Att betala (inkl moms)",
+    total: fc(a.breakdown ? a.breakdown.totalOre : a.invoice.amount),
+    ...specTables(spec, fc),
   };
 }
 
@@ -331,5 +365,5 @@ export function fakturaTemplateContext(a: FakturaTemplateArgs, fc: Fc): Record<s
  * Enda vägen till faktura-HTML i hela kodbasen (appen + demo-generatorn, #937).
  */
 export function renderFakturaHtml(args: FakturaTemplateArgs): string {
-  return renderHandlebars(FAKTURA_TEMPLATE, fakturaTemplateContext(args, formatCurrency));
+  return renderHandlebars(FAKTURA_TEMPLATE, { ...buildFakturaView(args, formatCurrency) });
 }

--- a/src/lib/client/kostnadsrakning/render-faktura-pdf.ts
+++ b/src/lib/client/kostnadsrakning/render-faktura-pdf.ts
@@ -1,96 +1,297 @@
 "use client";
 
 /**
- * `renderFakturaPdf` — bygger en enkel faktura-PDF client-side via pdf-lib.
+ * `renderFakturaPdf` (#938) — faktura-PDF client-side via pdf-lib, med SAMMA
+ * upplägg som det arkiverade HTML-dokumentet:
+ *   sida 1  Sammanställning (rad per timtaxa, utlägg, moms, summa) + uppdelning
+ *           klient/betalare + "att betala".
+ *   sida 2+ Specifikation — tidsspecifikation + utläggsspecifikation, med
+ *           automatisk sidbrytning när raderna inte får plats.
  *
- * Används BARA som bilaga vid manuellt fakturautskick (#179). Faktura-DOKUMENTEN
- * i ärendets fil-lista renderas sedan #937 av den delade mallen
- * (`faktura-template.ts`) → sammanställning + specifikation.
+ * Renderaren räknar INGENTING: den tar en färdig `FakturaView`
+ * (`buildFakturaView` i `faktura-template.ts`), så bilagan som mejlas och
+ * dokumentet som arkiveras aldrig kan visa olika belopp.
  *
- * TODO(#938): den här bilagan saknar det upplägget — kräver att vy-modellen
- * bryts ut ur mallen och att tabell-layout/sidbrytning implementeras i pdf-lib.
+ * Används av det manuella fakturautskicket (#179).
  */
 
-import { formatCurrency } from "@/lib/client/utils";
-import { DEFAULT_VAT_RATE, splitVat } from "@/lib/shared/vat";
+import type { PDFDocument, PDFFont, PDFPage, RGB } from "pdf-lib";
+import type { FakturaView } from "./faktura-template";
 
-export interface FakturaInput {
-  invoice: {
-    amount: number; // öre (brutto, inkl moms)
-    /** Momsbelopp (öre) i `amount`, exakt per sats (#782). Saknas → 25 %-split. */
-    vatOre?: number | null | undefined;
-    invoiceNumber?: string | null | undefined;
-    /** Bankgiro-OCR (#182). Null på kostnadsräkningar/CREDIT → raden utelämnas. */
-    ocrReference?: string | null | undefined;
-    invoiceDate?: string | Date | null | undefined;
-  };
-  meta: {
-    matterNumber: string;
-    matterTitle: string;
-    clientName?: string;
-    recipient?: string;
-    organizationName?: string;
-    organizationOrgNumber?: string;
-  };
+const A4: [number, number] = [595, 842];
+const M = 50;
+const RIGHT = 545;
+const TOP = 800;
+/** Under den här y:en får inget mer plats — bryt sidan. */
+const BOTTOM = 64;
+
+/**
+ * WinAnsi (pdf-lib:s standardkodning för StandardFonts) kan inte koda t.ex.
+ * U+2212 MINUS SIGN eller typografiska citattecken — pdf-lib KASTAR då i st.f.
+ * att ersätta. Vy-modellen använder "−" för avdrag, så texten måste tvättas.
+ * Svenska å/ä/ö ligger i Latin-1 och klarar sig.
+ */
+const WIN_ANSI_SUBST: Record<string, string> = {
+  "−": "-", "–": "-", "—": "-",
+  "‘": "'", "’": "'", "“": '"', "”": '"',
+  "…": "...", " ": " ",
+};
+
+export function toWinAnsi(s: string): string {
+  return [...s]
+    .map((c) => WIN_ANSI_SUBST[c] ?? c)
+    .map((c) => {
+      const cp = c.codePointAt(0) ?? 0;
+      // 0x00–0x1F och 0x7F–0x9F är styrtecken utan glyf i WinAnsi.
+      if (cp < 0x20 || (cp >= 0x7f && cp <= 0x9f) || cp > 0xff) return "?";
+      return c;
+    })
+    .join("");
 }
 
-type LineFn = (text: string, opts?: { size?: number; b?: boolean; gap?: number; gray?: boolean }) => void;
-
-/** Identitetsraderna under rubriken (fakturanr, datum, mottagare, klient). */
-function drawIdentityLines(line: LineFn, input: FakturaInput): void {
-  const date = input.invoice.invoiceDate ? new Date(input.invoice.invoiceDate).toLocaleDateString("sv-SE") : "";
-  if (input.invoice.invoiceNumber) line(`Fakturanr: ${input.invoice.invoiceNumber}`);
-  if (date) line(`Fakturadatum: ${date}`);
-  if (input.meta.recipient) line(`Mottagare: ${input.meta.recipient}`);
-  if (input.meta.clientName) line(`Klient: ${input.meta.clientName}`);
+interface Ctx {
+  pdf: PDFDocument;
+  font: PDFFont;
+  bold: PDFFont;
+  page: PDFPage;
+  y: number;
+  /** Färger — `rgb()` är en runtime-import ur pdf-lib, så de bärs i kontexten. */
+  gray: RGB;
+  rule: RGB;
 }
 
-export async function renderFakturaPdf(input: FakturaInput): Promise<Uint8Array> {
+interface TextOpts { x?: number; size?: number; b?: boolean; gray?: boolean }
+
+function addPage(c: Ctx): void {
+  c.page = c.pdf.addPage(A4);
+  c.y = TOP;
+}
+
+/** Bryt sidan om `needed` punkter inte får plats under markören. */
+function ensure(c: Ctx, needed: number): void {
+  if (c.y - needed < BOTTOM) addPage(c);
+}
+
+function font(c: Ctx, b: boolean): PDFFont {
+  return b ? c.bold : c.font;
+}
+
+/** Rita text vid markören (utan att flytta den). Returnerar textens bredd. */
+function draw(c: Ctx, s: string, o: TextOpts = {}): number {
+  const size = o.size ?? 10;
+  const f = font(c, o.b ?? false);
+  const t = toWinAnsi(s);
+  c.page.drawText(t, {
+    x: o.x ?? M, y: c.y, size, font: f,
+    ...(o.gray ? { color: c.gray } : {}),
+  });
+  return f.widthOfTextAtSize(t, size);
+}
+
+/** Rita högerjusterad text med `rightX` som högerkant. */
+function drawRight(c: Ctx, s: string, rightX: number, o: TextOpts = {}): void {
+  const size = o.size ?? 10;
+  const t = toWinAnsi(s);
+  const w = font(c, o.b ?? false).widthOfTextAtSize(t, size);
+  draw(c, s, { ...o, x: rightX - w });
+}
+
+/** Korta av texten så den ryms inom `maxWidth`. */
+function fit(c: Ctx, s: string, maxWidth: number, o: TextOpts = {}): string {
+  const size = o.size ?? 10;
+  const f = font(c, o.b ?? false);
+  let t = toWinAnsi(s);
+  if (f.widthOfTextAtSize(t, size) <= maxWidth) return t;
+  while (t.length > 1 && f.widthOfTextAtSize(`${t}...`, size) > maxWidth) t = t.slice(0, -1);
+  return `${t}...`;
+}
+
+function rule(c: Ctx, thickness = 0.5): void {
+  c.page.drawLine({ start: { x: M, y: c.y }, end: { x: RIGHT, y: c.y }, thickness, color: c.rule });
+}
+
+/** Ordbrytning — etiketter kan vara långa meningar (rådgivningsnotisen, info-
+ *  rader ur nedbrytningen) och ska INTE kapas bort, som i HTML-mallen. */
+function wrap(c: Ctx, s: string, maxWidth: number, size: number): string[] {
+  const words = toWinAnsi(s).split(" ");
+  const lines: string[] = [];
+  let cur = "";
+  for (const w of words) {
+    const next = cur ? `${cur} ${w}` : w;
+    if (c.font.widthOfTextAtSize(next, size) > maxWidth && cur) { lines.push(cur); cur = w; }
+    else cur = next;
+  }
+  if (cur) lines.push(cur);
+  return lines;
+}
+
+/**
+ * Tabellrad med (ev. flerradig) etikett till vänster. `cells` ritar radens
+ * övriga kolumner på FÖRSTA radens baslinje; markören flyttas sedan förbi hela
+ * etiketten. Håller beloppen på rad med etikettens början även när den bryts.
+ */
+function labelRow(c: Ctx, label: string, maxLabelWidth: number, cells: () => void, o: TextOpts = {}): void {
+  const size = o.size ?? 10;
+  const lineH = size + 5;
+  const lines = wrap(c, label, maxLabelWidth, size);
+  ensure(c, lineH * lines.length + 5);
+  cells();
+  for (const line of lines) { draw(c, line, o); c.y -= lineH; }
+}
+
+// ── Sida 1: huvud + sammanställning + uppdelning ────────────────────────────
+
+function drawHeader(c: Ctx, v: FakturaView): void {
+  draw(c, v.heading.toUpperCase(), { size: 20, b: true });
+  c.y -= 26;
+  if (v.organizationName) { draw(c, v.organizationName, { b: true }); c.y -= 13; }
+  if (v.organizationOrgNumber) { draw(c, `Org.nr ${v.organizationOrgNumber}`, { size: 9, gray: true }); c.y -= 13; }
+  c.y -= 6;
+  draw(c, `Ärende ${v.matterNumber} — ${v.matterTitle}`, { size: 11, b: true });
+  c.y -= 16;
+  draw(c, `Fakturanr: ${v.invoiceNumber}`);
+  c.y -= 14;
+  draw(c, `Fakturadatum: ${v.date}`);
+  c.y -= 14;
+  draw(c, `Mottagare: ${v.recipient}`);
+  c.y -= 14;
+  if (v.ocr) { draw(c, `OCR-referens: ${v.ocr}`, { b: true }); c.y -= 14; }
+  c.y -= 8;
+}
+
+/** Kolumnernas högerkanter i sammanställningen (benämning flödar från M). */
+const SUM_RATE_X = 385;
+const SUM_HOURS_X = 440;
+
+function drawSummary(c: Ctx, v: FakturaView): void {
+  ensure(c, 90);
+  draw(c, "Sammanställning", { size: 13, b: true });
+  c.y -= 18;
+  draw(c, "Benämning", { size: 9, b: true });
+  drawRight(c, "Timtaxa", SUM_RATE_X, { size: 9, b: true });
+  drawRight(c, "Tim", SUM_HOURS_X, { size: 9, b: true });
+  drawRight(c, "Belopp", RIGHT, { size: 9, b: true });
+  c.y -= 5;
+  rule(c);
+  c.y -= 13;
+  for (const row of v.summary) {
+    labelRow(c, row.label, SUM_RATE_X - M - 55, () => {
+      if (row.rateLabel) drawRight(c, row.rateLabel, SUM_RATE_X);
+      if (row.hours) drawRight(c, row.hours, SUM_HOURS_X);
+      drawRight(c, row.amount, RIGHT);
+    });
+  }
+  c.y += 3;
+  rule(c);
+  c.y -= 15;
+  draw(c, "Summa (inkl moms)", { b: true });
+  drawRight(c, v.summaryTotal, RIGHT, { b: true });
+  c.y -= 22;
+}
+
+function drawSplit(c: Ctx, v: FakturaView): void {
+  if (v.hasSplit) {
+    ensure(c, 40);
+    draw(c, "Uppdelning klient / betalare", { size: 11, b: true });
+    c.y -= 16;
+  }
+  for (const row of v.splitRows) {
+    const style: TextOpts = row.muted ? { gray: true } : {};
+    labelRow(c, row.label, RIGHT - M - 110, () => drawRight(c, row.amount, RIGHT, style), style);
+  }
+  ensure(c, 40);
+  c.y += 3;
+  rule(c, 1.2);
+  c.y -= 17;
+  draw(c, v.totalLabel, { size: 12, b: true });
+  drawRight(c, v.total, RIGHT, { size: 12, b: true });
+  c.y -= 20;
+  if (v.footnote) {
+    ensure(c, 30);
+    for (const line of wrap(c, v.footnote, RIGHT - M, 9)) { draw(c, line, { size: 9, gray: true }); c.y -= 12; }
+  }
+}
+
+// ── Sida 2+: specifikationen ────────────────────────────────────────────────
+
+const SPEC_DATE_W = 66;
+const SPEC_HOURS_X = 445;
+
+interface SpecCol { header: string; rightX: number }
+
+/** Rita en specifikationstabells rubrikrad (datum + beskrivning + två tal). */
+function specHead(c: Ctx, cols: [SpecCol, SpecCol]): void {
+  draw(c, "Datum", { size: 9, b: true });
+  draw(c, "Beskrivning", { size: 9, b: true, x: M + SPEC_DATE_W });
+  drawRight(c, cols[0].header, cols[0].rightX, { size: 9, b: true });
+  drawRight(c, cols[1].header, cols[1].rightX, { size: 9, b: true });
+  c.y -= 5;
+  rule(c);
+  c.y -= 13;
+}
+
+/** En specifikationsrad: datum, beskrivning och tabellens två talkolumner. */
+interface SpecRow { date: string; description: string; a: string; b: string }
+
+function specRow(c: Ctx, r: SpecRow, cols: [SpecCol, SpecCol]): void {
+  ensure(c, 20);
+  draw(c, r.date, { size: 9 });
+  draw(c, fit(c, r.description, cols[0].rightX - (M + SPEC_DATE_W) - 46, { size: 9 }), { size: 9, x: M + SPEC_DATE_W });
+  drawRight(c, r.a, cols[0].rightX, { size: 9 });
+  drawRight(c, r.b, cols[1].rightX, { size: 9 });
+  c.y -= 14;
+}
+
+function drawTimeSpec(c: Ctx, v: FakturaView): void {
+  if (v.timeLines.length === 0) return;
+  const cols: [SpecCol, SpecCol] = [{ header: "Tim", rightX: SPEC_HOURS_X }, { header: "Belopp", rightX: RIGHT }];
+  ensure(c, 60);
+  draw(c, "Tidsspecifikation", { size: 11, b: true });
+  c.y -= 16;
+  specHead(c, cols);
+  for (const l of v.timeLines) specRow(c, { date: l.date, description: l.description, a: l.hours, b: l.amount }, cols);
+  c.y -= 8;
+}
+
+function drawExpenseSpec(c: Ctx, v: FakturaView): void {
+  if (v.expenseLines.length === 0) return;
+  const cols: [SpecCol, SpecCol] = [{ header: "Netto", rightX: 470 }, { header: "Brutto", rightX: RIGHT }];
+  ensure(c, 60);
+  draw(c, "Utläggsspecifikation", { size: 11, b: true });
+  c.y -= 16;
+  specHead(c, cols);
+  for (const l of v.expenseLines) specRow(c, { date: l.date, description: l.description, a: l.net, b: l.gross }, cols);
+}
+
+/** Specifikationen börjar ALLTID på ny sida — speglar HTML-mallens sidbrytning. */
+function drawSpecification(c: Ctx, v: FakturaView): void {
+  if (!v.hasSpec) return;
+  addPage(c);
+  draw(c, "Specifikation", { size: 13, b: true });
+  c.y -= 15;
+  draw(c, "Underlag till beloppen i sammanställningen ovan.", { size: 9, gray: true });
+  c.y -= 20;
+  drawTimeSpec(c, v);
+  drawExpenseSpec(c, v);
+}
+
+export async function renderFakturaPdf(view: FakturaView): Promise<Uint8Array> {
   const { PDFDocument, StandardFonts, rgb } = await import("pdf-lib");
   const pdf = await PDFDocument.create();
-  pdf.setTitle(`Faktura ${input.meta.matterNumber}`);
+  pdf.setTitle(`${view.heading} ${view.invoiceNumber}`);
   pdf.setSubject("Faktura");
-  const page = pdf.addPage([595, 842]); // A4
-  const font = await pdf.embedFont(StandardFonts.Helvetica);
-  const bold = await pdf.embedFont(StandardFonts.HelveticaBold);
-  const M = 50;
-  const RIGHT = 545;
-  let y = 800;
-
-  const line = (text: string, opts: { size?: number; b?: boolean; gap?: number; gray?: boolean } = {}): void => {
-    page.drawText(text, {
-      x: M, y, size: opts.size ?? 10, font: opts.b ? bold : font,
-      color: opts.gray ? rgb(0.45, 0.45, 0.45) : rgb(0, 0, 0),
-    });
-    y -= opts.gap ?? 14;
+  const c: Ctx = {
+    pdf,
+    font: await pdf.embedFont(StandardFonts.Helvetica),
+    bold: await pdf.embedFont(StandardFonts.HelveticaBold),
+    page: pdf.addPage(A4),
+    y: TOP,
+    gray: rgb(0.45, 0.45, 0.45),
+    rule: rgb(0.72, 0.72, 0.72),
   };
-
-  line("FAKTURA", { size: 20, b: true, gap: 28 });
-  if (input.meta.organizationName) line(input.meta.organizationName, { b: true });
-  if (input.meta.organizationOrgNumber) line(`Org.nr ${input.meta.organizationOrgNumber}`, { size: 9 });
-  y -= 8;
-  line(`Mål ${input.meta.matterNumber} — ${input.meta.matterTitle}`, { size: 11, b: true, gap: 16 });
-  drawIdentityLines(line, input);
-  y -= 10;
-  page.drawLine({ start: { x: M, y }, end: { x: RIGHT, y }, thickness: 0.5, color: rgb(0.7, 0.7, 0.7) });
-  y -= 22;
-  // Moms-specifikation: netto + moms + att betala (brutto). Momsen är exakt per
-  // sats när vatOre finns (#782), annars 25 %-split av bruttot.
-  const bruttoOre = input.invoice.amount;
-  const momsOre = input.invoice.vatOre != null
-    ? input.invoice.vatOre
-    : bruttoOre - splitVat({ amount: bruttoOre, vatRate: DEFAULT_VAT_RATE, vatIncluded: true }).exclVat;
-  const amountRow = (label: string, ore: number, opts: { size?: number; b?: boolean } = {}): void => {
-    page.drawText(label, { x: M, y, size: opts.size ?? 10, font: opts.b ? bold : font });
-    page.drawText(formatCurrency(ore), { x: RIGHT - 130, y, size: opts.size ?? 10, font: opts.b ? bold : font });
-    y -= opts.b ? 22 : 16;
-  };
-  amountRow("Belopp exkl. moms", bruttoOre - momsOre);
-  amountRow("Moms", momsOre);
-  amountRow("Att betala (inkl. moms)", bruttoOre, { size: 12, b: true });
-  y -= 6;
-  if (input.invoice.ocrReference) line(`OCR-referens: ${input.invoice.ocrReference}`, { size: 11, b: true, gap: 16 });
-  line("Belopp enligt domstolens beslut / fakturaunderlag.", { size: 9, gray: true });
-
+  drawHeader(c, view);
+  drawSummary(c, view);
+  drawSplit(c, view);
+  drawSpecification(c, view);
   return pdf.save();
 }

--- a/test/unit/app/invoices/send-invoice-modal.test.tsx
+++ b/test/unit/app/invoices/send-invoice-modal.test.tsx
@@ -14,10 +14,13 @@ const queueMutate = vi.fn();
 const composeMail = vi.fn(async () => true);
 const downloadBytes = vi.fn();
 const renderFakturaPdf = vi.fn(async () => new Uint8Array([1, 2, 3]));
+const specFetch = vi.fn(async () => null);
 let helperVersion: string | undefined | null = "helper-v1.0.0";
 
 vi.mock("@/lib/client/trpc", () => ({
   trpc: {
+    // Bilagan hämtar fakturaspecifikationen (#938) via utils.
+    useUtils: () => ({ billingRun: { invoiceSpecification: { fetch: specFetch } } }),
     invoiceDispatch: {
       recordManual: { useMutation: (opts: { onSuccess?: () => void }) => ({ mutate: (...a: unknown[]) => { recordMutate(...a); opts.onSuccess?.(); }, isPending: false, error: null }) },
       queue: { useMutation: (opts: { onSuccess?: () => void }) => ({ mutate: (...a: unknown[]) => { queueMutate(...a); opts.onSuccess?.(); }, isPending: false, error: null }) },
@@ -33,6 +36,7 @@ vi.mock("@/lib/client/kostnadsrakning/render-faktura-pdf", () => ({ renderFaktur
 
 const baseProps = {
   invoiceId: asId<"InvoiceId">("inv-1"),
+  matterId: asId<"MatterId">("m-1"),
   invoiceNumber: "F-2026-0001",
   amount: 12_500,
   ocrReference: "1234567894",

--- a/test/unit/lib/kostnadsrakning/render-faktura-pdf.test.ts
+++ b/test/unit/lib/kostnadsrakning/render-faktura-pdf.test.ts
@@ -1,27 +1,96 @@
 /**
- * `renderFakturaPdf` — client-side faktura-PDF (pdf-lib). Verifierar giltig PDF
- * för både full och minimal input.
+ * `renderFakturaPdf` (#938) — bilagan vid manuellt fakturautskick. Samma upplägg
+ * som det arkiverade HTML-dokumentet: sammanställning på sida 1, specifikation
+ * på egen sida därefter. Renderaren tar en färdig `FakturaView` och räknar inget.
  */
 import { describe, it, expect } from "vitest-compat";
-import { renderFakturaPdf } from "@/lib/client/kostnadsrakning/render-faktura-pdf";
+import { buildFakturaView, type FakturaView } from "@/lib/client/kostnadsrakning/faktura-template";
+import { renderFakturaPdf, toWinAnsi } from "@/lib/client/kostnadsrakning/render-faktura-pdf";
+import { asId } from "@/lib/shared/schemas/ids";
 
 const head = (b: Uint8Array) => String.fromCharCode(b[0]!, b[1]!, b[2]!, b[3]!);
 
+async function pageCount(bytes: Uint8Array): Promise<number> {
+  const { PDFDocument } = await import("pdf-lib");
+  return (await PDFDocument.load(bytes)).getPageCount();
+}
+
+const view = (over: Partial<FakturaView> = {}): FakturaView => ({
+  heading: "Faktura", invoiceNumber: "F-2026-0001", ocr: "1234567894", date: "2026-05-12",
+  matterNumber: "B 2026-1234", matterTitle: "Brottmål Falk", recipient: "Domstolsverket",
+  organizationName: "Firma AB", organizationOrgNumber: "556677-8899", footnote: "",
+  summary: [{ label: "Arvode (timkostnadsnorm)", rateLabel: "1 626,00 kr/tim", hours: "4", amount: "6 504,00 kr" }],
+  summaryTotal: "8 130,00 kr",
+  hasSplit: false, splitRows: [{ label: "Netto (exkl moms)", amount: "6 504,00 kr", style: "", muted: false }],
+  totalLabel: "Att betala (inkl moms)", total: "8 130,00 kr",
+  hasSpec: false, timeLines: [], expenseLines: [], ...over,
+});
+
+describe("toWinAnsi", () => {
+  it("ersätter tecken som pdf-lib:s WinAnsi inte kan koda", () => {
+    // U+2212 MINUS SIGN används i avdragsrader — pdf-lib KASTAR på den.
+    expect(toWinAnsi("−1 000,00 kr")).toBe("-1 000,00 kr");
+    expect(toWinAnsi("…")).toBe("...");
+    expect(toWinAnsi("”citat”")).toBe('"citat"');
+    // Svenska tecken ligger i Latin-1 och ska överleva orörda.
+    expect(toWinAnsi("Utlägg för rättshjälp — å ä ö")).toBe("Utlägg för rättshjälp - å ä ö");
+  });
+});
+
 describe("renderFakturaPdf", () => {
-  it("producerar en faktura-PDF med alla fält", async () => {
-    const bytes = await renderFakturaPdf({
-      invoice: { amount: 1_047_500, invoiceNumber: "F-2026-1", invoiceDate: new Date("2026-05-12") },
-      meta: {
-        matterNumber: "B 2026-1234", matterTitle: "Brottmål Falk", clientName: "Fredrik Falk",
-        recipient: "Domstolsverket", organizationName: "Firma AB", organizationOrgNumber: "556677-8899",
-      },
-    });
+  it("producerar en giltig PDF på en sida när det saknas underlag", async () => {
+    const bytes = await renderFakturaPdf(view());
     expect(head(bytes)).toBe("%PDF");
     expect(bytes.byteLength).toBeGreaterThan(500);
+    expect(await pageCount(bytes)).toBe(1);
   });
 
-  it("klarar minimal input (bara belopp + mål)", async () => {
-    const bytes = await renderFakturaPdf({ invoice: { amount: 50_000 }, meta: { matterNumber: "B-2", matterTitle: "T" } });
+  it("specifikationen får en EGEN sida efter sammanställningen", async () => {
+    const bytes = await renderFakturaPdf(view({
+      hasSpec: true,
+      timeLines: [{ date: "2026-05-02", description: "Genomgång av handlingar", hours: "4", amount: "6 504,00 kr" }],
+      expenseLines: [{ date: "2026-05-03", description: "Ansökningsavgift", net: "900,00 kr", gross: "1 125,00 kr" }],
+    }));
+    expect(await pageCount(bytes)).toBe(2);
+  });
+
+  it("bryter sidan när tidsspecifikationen är längre än en sida", async () => {
+    const timeLines = Array.from({ length: 120 }, (_, i) => ({
+      date: "2026-05-02", description: `Post ${i} — genomgång av handlingar och underlag`,
+      hours: "1", amount: "1 626,00 kr",
+    }));
+    const bytes = await renderFakturaPdf(view({ hasSpec: true, timeLines }));
+    expect(await pageCount(bytes)).toBeGreaterThan(2);
+  });
+
+  it("avdragsrader (−) och rådgivningsnotisen kraschar inte renderaren", async () => {
+    const bytes = await renderFakturaPdf(view({
+      hasSplit: true,
+      splitRows: [
+        { label: "Upparbetat arvode (exkl moms)", amount: "6 504,00 kr", style: "", muted: false },
+        { label: "Avgår aconto — faktura F-2026-0000 (2026-04-01)", amount: "−1 000,00 kr", style: "color:#b45309", muted: true },
+        { label: "Betalt via aconto", amount: "(500,00 kr)", style: "color:#9ca3af", muted: true },
+      ],
+      footnote: "Rådgivningstimmen (1 tim enligt rättshjälpstaxan) faktureras klienten separat och ingår INTE i kostnadsräkningen till domstolen.",
+    }));
     expect(head(bytes)).toBe("%PDF");
+  });
+
+  it("renderar vy-modellen som byggs av buildFakturaView (samma källa som HTML:en)", async () => {
+    const v = buildFakturaView({
+      invoice: { id: asId<"InvoiceId">("inv-1"), amount: 203_250, vatOre: 40_650, invoiceNumber: "F-2026-0007", invoiceDate: "2026-06-30" },
+      recipient: "Cecilia Carlsson",
+      meta: { matterNumber: "2026-0010", matterTitle: "Umgängestvist Carlsson" },
+      spec: {
+        timeLines: [{ date: "2026-05-02", description: "Genomgång av handlingar", minutes: 60, amountOre: 162_600 }],
+        expenseLines: [], totalMinutes: 60,
+        arvodeNetOre: 162_600, arvodeVatOre: 40_650, expensesNetOre: 0, expensesVatOre: 0,
+        grossOre: 203_250, deductions: [], deductionOre: 0, adjustmentOre: 0, payableOre: 203_250,
+      },
+    });
+    expect(v.hasSpec).toBe(true);
+    const bytes = await renderFakturaPdf(v);
+    expect(head(bytes)).toBe("%PDF");
+    expect(await pageCount(bytes)).toBe(2);
   });
 });


### PR DESCRIPTION
## Vad & varför

#937 gjorde `renderFakturaHtml` till enda vägen till faktura-HTML, men **bilagan som mejlas** renderades fortfarande av en egen platt pdf-lib-sida (`Belopp exkl. moms / Moms / Att betala`). Det är den faktura klienten faktiskt får, så den ska ha samma upplägg som det arkiverade dokumentet.

Nu delar de vy-modell: `buildFakturaView` är enda stället där öre blir text, och både HTML-mallen och PDF:en renderar samma `FakturaView`. Beloppen kan därmed inte glida isär mellan det som arkiveras och det som skickas.

Stänger #938

### Ändringar

- **`buildFakturaView`** — typad, färdigformaterad vy (`FakturaView`) utbruten ur `faktura-template.ts`. Mallen renderar den rakt av.
- **Uppdelningen klient/betalare veckas till EN `splitRows`-lista** oavsett källa: itemiserad nedbrytning (#858) → spec-avdrag/justering (#856) → netto/moms ur fakturan. Det var de tre `{{#if}}`-grenarna i mallen som gjorde att PDF:en inte kunde återanvända logiken.
- **`renderFakturaPdf(view)`** räknar ingenting längre. Sammanställning på sida 1 (rad per timtaxa + utlägg + moms + summa), uppdelning + "att betala", och specifikationen på **egen sida** med automatisk sidbrytning när raderna tar slut. Långa etiketter **ordbryts** i st.f. att kapas — rådgivningsnotisen och nedbrytningens info-rader är hela meningar.
- **`toWinAnsi`** tvättar tecken som pdf-lib:s WinAnsi inte kan koda. Det här var en skarp bugg i väntan: vy-modellen använder U+2212 MINUS SIGN för avdrag, och pdf-lib **kastar** på oencodbara tecken — varje faktura med ett aconto-avdrag hade kraschat utskicket.
- **`SendInvoiceModal`** hämtar fakturaspecifikationen (ny `matterId`-prop) och tar emot `settlementBreakdown`/`vatOre`/`invoiceType`/`notes`. Misslyckas hämtningen faller bilagan tillbaka på netto/moms-raderna i st.f. att stoppa utskicket.

### Verifierat på riktig data

Renderade en faktura ur demo-seeden och läste ut textpositionerna ur PDF-strömmarna (ingen viewer i sandboxen):

```
========== SIDA 1 ==========
  y= 676.0  Sammanställning
  y= 658.0  Benämning | x351:Timtaxa | x424:Tim | x514:Belopp
  y= 640.0  Arvode (timkostnadsnorm) | 1 626,00 kr/tim | 10,5 | 17 073,00 kr
  y= 568.0  Summa (inkl moms) | 21 404,75 kr
  y= 546.0  Uppdelning klient / betalare
  y= 515.0  Avgår klientens rättshjälpsavgift (exkl moms) | -772,35 kr
  y= 440.0  Rådgivningstimme (1 tim) fakturerad och betald av klienten separat enligt | (2 032,50 kr)
  y= 425.0  rättshjälpstaxan - ingår ej i denna faktura.
  y= 351.0  Domstolen betalar - att betala (inkl moms) | 18 403,63 kr
========== SIDA 2 ==========
  y= 800.0  Specifikation
  y= 765.0  Tidsspecifikation
  ...
  y= 625.0  Utläggsspecifikation
```

Kolumnerna är högerjusterade, sidbrytningen ligger före specifikationen, `−` blev `-`, och den långa info-raden bryts över två rader med beloppet kvar på den första.

## Typ

- [ ] `feat` — ny funktion
- [ ] `fix` — buggfix
- [x] `refactor` / `perf`
- [ ] `docs` / `test` / `chore` / `ci`

## Verifierat lokalt (speglar CI)

- [x] `typecheck` + `lint` + `lint:complexity-strict` + `knip` + `deps:check` — rena
- [x] `bun run build:demo` — grön
- [x] `bun run size` — 1163,9 KB gzip av 3400 KB budget (34,2 %)
- [x] Nya rader har täckande tester — `render-faktura-pdf.test.ts` skriven om: sidantal ur den genererade PDF:en (1 utan underlag, 2 med, >2 vid 120 tidsrader), `toWinAnsi`-fallen, avdragsrader + notis, och en runda genom `buildFakturaView` så PDF:en bevisligen renderar samma modell som HTML:en
- [x] `test/unit/lib/kostnadsrakning/` (49) + `test/unit/app/invoices/` + demo-generatorns fakturatester — gröna
- [ ] `bun run test` (hela sviten) — pass A slår i sin egen 360 s-watchdog (#327) på den här sandboxen; **verifierat att orörd `main` gör exakt likadant**, så det är miljön och inte ändringen. 5 fall i `test/unit/app/matters/` fallerar lokalt vid katalogkörning men passerar isolerat — reproducerat identiskt på `main`. CI avgör.
- [x] Commits följer Conventional Commits

## Kvalitetsgrindar

- [x] Inga gater lösgjorda — coverage/lint-cap/knip/bundle-size orörda

## Övrigt

Kvar sedan tidigare (ej del av #937/#938): rådgivningstimmen ligger som tidspost på betalarfakturan och syns därför i domstolsfakturans tidsspecifikation, medan nedbrytningen korrekt exkluderar den och visar den som parentes-rad (#860).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_