### PR TITLE
fix(billing): visa arvodestrappan i den ordning den faktiskt räknas

### DIFF
--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -30,7 +30,7 @@ import { carveEarliestMinutes } from "@/lib/shared/kostnadsrakning";
 import { applyKrAction, type KostnadsrakningAction, type KostnadsrakningState, type KostnadsrakningStatus } from "@/lib/shared/kostnadsrakning-flow";
 import { ocrFromInvoiceNumber } from "@/lib/shared/ocr-reference";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
-import { RADGIVNING_MINUTES, radgivningTextRad } from "@/lib/shared/rattshjalp";
+import { RADGIVNING_MINUTES } from "@/lib/shared/rattshjalp";
 import { settlementBreakdownSchema, type BillingRun, type Invoice } from "@/lib/shared/schemas/billing";
 import { billingRunRecipientSchema, type BillingRunRecipient, type ExpenseKind, type PaymentMethod } from "@/lib/shared/schemas/enums";
 import {
@@ -463,6 +463,7 @@ export interface SettlementBreakdown {
   prutningGrossOre: number;      // byrå-förlust/prutning brutto
   payerArvodeNetOre: number;     // domstolens/försäkringens andel av arvodet NETTO — trappan (#876)
   radgivningGrossOre: number;    // klient-betald rådgivningstimme brutto — omnämns på domstolsfakturan, ej i totalen (#876)
+  radgivningNetOre: number;      // samma timme NETTO — första avdraget i arvodestrappan (#941)
   payerPayableOre: number;       // domstolen att betala
   clientPayableOre: number;      // klienten att betala (självrisk − aconton)
   // Klientens självrisk-faktura specificeras med den arbetade tiden (#876). Raderna
@@ -496,6 +497,13 @@ function buildClientArvodeLines(
   return lines;
 }
 
+/** Rådgivningstimmen (1 h) betalas av klienten separat; värdet = en timme på samma
+ *  norm som arvodesbasen (jfr coverageBaseMinutes −60). 0 för icke-rättshjälp. */
+function radgivningOre(method: PaymentMethod, rateOre: number): { radgivningGrossOre: number; radgivningNetOre: number } {
+  if (method !== "RATTSHJALP") return { radgivningGrossOre: 0, radgivningNetOre: 0 };
+  return { radgivningGrossOre: arvodeInclVatOre(rateOre), radgivningNetOre: rateOre };
+}
+
 async function buildSettlementBreakdown(repos: Repositories, orgId: OrganizationId, a: {
   clientShareBips: number; totalArvodeNet: number; split: CoverageSplit; work: UnfrozenWork;
   payerGross: number; clientPayable: number; method: PaymentMethod; rateOre: number; settleDate: Date | string;
@@ -524,9 +532,7 @@ async function buildSettlementBreakdown(repos: Repositories, orgId: Organization
     firmLossNetOre: a.split.firmLossOre,
     prutningGrossOre: arvodeInclVatOre(a.split.firmLossOre),
     payerArvodeNetOre: a.split.payerOre,
-    // Rådgivningstimmen (1 h) betalas av klienten separat; värdet = en timme på samma
-    // norm som arvodesbasen (jfr coverageBaseMinutes −60). 0 för icke-rättshjälp.
-    radgivningGrossOre: a.method === "RATTSHJALP" ? arvodeInclVatOre(a.rateOre) : 0,
+    ...radgivningOre(a.method, a.rateOre),
     payerPayableOre: a.payerGross,
     clientPayableOre: a.clientPayable,
     clientArvodeLines: buildClientArvodeLines(a.method, a.rateOre, a.work, a.totalArvodeNet, a.settleDate),
@@ -564,19 +570,49 @@ function rattsskyddClientRows(p: RattsskyddClientParts, share: string): Settleme
   return rows;
 }
 
-function buildClientView(b: SettlementBreakdown, isRattshjalp: boolean, feeTerm: string): SettlementView {
-  const share = (b.clientShareBips / 100).toLocaleString("sv-SE", { maximumFractionDigits: 2 });
-  const feeCap = feeTerm.charAt(0).toUpperCase() + feeTerm.slice(1);
+const shareLabel = (bips: number): string => (bips / 100).toLocaleString("sv-SE", { maximumFractionDigits: 2 });
+
+/**
+ * Arvodestrappan ned till det BEVILJADE beloppet (#941) — samma på klientens och
+ * betalarens faktura, och i den ordning beräkningen faktiskt sker:
+ *   1. rådgivningstimmen av FÖRST (klienten har redan betalat den separat),
+ *   2. därefter domstolens prutning (byrån bär den),
+ *   3. först då är basen för klientens rättshjälpsavgift klar.
+ * Mellanstegen renderas bara när de har ett belopp, så rättsskydd (ingen
+ * rådgivning, ingen byrå-buren prutning) får samma enda rad som tidigare.
+ */
+function arvodeLadderRows(b: SettlementBreakdown, payerNoun: string): SettlementRow[] {
   const rows: SettlementRow[] = [
-    { label: "Upparbetat arvode (exkl moms)", amountOre: b.arvodeBaseNetOre, kind: "add" },
+    { label: "Upparbetat arvode (exkl moms)", amountOre: b.arvodeBaseNetOre + b.radgivningNetOre, kind: "add" },
   ];
+  if (b.radgivningNetOre > 0) {
+    rows.push({ label: "Avgår rådgivningstimme (1 tim) — betald av klienten separat (exkl moms)", amountOre: b.radgivningNetOre, kind: "deduct" });
+    rows.push({ label: "Underlag för kostnadsräkning (exkl moms)", amountOre: b.arvodeBaseNetOre, kind: "add" });
+  }
+  if (b.firmLossNetOre > 0) {
+    rows.push({ label: `Avgår ${payerNoun.toLowerCase()} prutning — byrån bär (exkl moms)`, amountOre: b.firmLossNetOre, kind: "deduct" });
+    rows.push({ label: "Beviljat arvode (exkl moms)", amountOre: b.arvodeBaseNetOre - b.firmLossNetOre, kind: "add" });
+  }
+  return rows;
+}
+
+/** Klientens andel räknas på det BEVILJADE beloppet när domstolen prutat (#941)
+ *  — säg det i etiketten, annars går procenten inte att stämma av mot raden ovan. */
+function feeBaseSuffix(b: SettlementBreakdown): string {
+  return b.firmLossNetOre > 0 ? " av beviljat arvode" : "";
+}
+
+function buildClientView(b: SettlementBreakdown, isRattshjalp: boolean, feeTerm: string): SettlementView {
+  const share = shareLabel(b.clientShareBips);
+  const feeCap = feeTerm.charAt(0).toUpperCase() + feeTerm.slice(1);
+  const rows: SettlementRow[] = arvodeLadderRows(b, isRattshjalp ? "Domstolens" : "Försäkringens");
   // Rättsskydd (#935): klientens del är summan av FYRA poster — särredovisa dem i
   // stället för ett lumpet belopp, så klienten ser varför den ska betala. Rättshjälp
   // har bara avgiftsandelen (prutningen bärs av byrån, inte klienten).
   if (!isRattshjalp && b.clientParts) {
     rows.push(...rattsskyddClientRows(b.clientParts, share));
   } else {
-    rows.push({ label: `Klientens ${feeTerm} ${share} % (exkl moms)`, amountOre: b.sjalvriskNetOre, kind: "add" });
+    rows.push({ label: `Klientens ${feeTerm} ${share} %${feeBaseSuffix(b)} (exkl moms)`, amountOre: b.sjalvriskNetOre, kind: "add" });
   }
   // Samma moms-trappa för BÅDA metoderna (#935) — rättsskydd fick förr bara en enda
   // inkl-moms-rad, vilket gjorde klientfakturorna asymmetriska och svårlästa.
@@ -595,16 +631,12 @@ function buildClientView(b: SettlementBreakdown, isRattshjalp: boolean, feeTerm:
  */
 function buildPayerView(b: SettlementBreakdown, payerLabel: string, payerNoun: string, feeTerm: string): SettlementView {
   const payerArvodeGross = arvodeInclVatOre(b.payerArvodeNetOre);
-  const rows: SettlementRow[] = [
-    { label: "Upparbetat arvode (exkl moms)", amountOre: b.arvodeBaseNetOre, kind: "add" },
-    { label: `Avgår klientens ${feeTerm} (exkl moms)`, amountOre: b.sjalvriskNetOre, kind: "deduct" },
-  ];
-  if (b.firmLossNetOre > 0) rows.push({ label: "Avgår prutning (byrån bär) (exkl moms)", amountOre: b.firmLossNetOre, kind: "deduct" });
+  const rows: SettlementRow[] = arvodeLadderRows(b, payerNoun);
+  rows.push({ label: `Avgår klientens ${feeTerm} ${shareLabel(b.clientShareBips)} %${feeBaseSuffix(b)} (exkl moms)`, amountOre: b.sjalvriskNetOre, kind: "deduct" });
   rows.push({ label: `${payerNoun} andel av arvodet (exkl moms)`, amountOre: b.payerArvodeNetOre, kind: "add" });
   rows.push({ label: "Moms 25 %", amountOre: payerArvodeGross - b.payerArvodeNetOre, kind: "add" });
   rows.push({ label: `${payerNoun} arvode (inkl moms)`, amountOre: payerArvodeGross, kind: "add" });
   if (b.expensesGrossOre > 0) rows.push({ label: `Utlägg (${payerNoun.toLowerCase()} andel, inkl moms)`, amountOre: b.expensesGrossOre, kind: "add" });
-  if (b.radgivningGrossOre > 0) rows.push({ label: radgivningTextRad("faktura"), amountOre: b.radgivningGrossOre, kind: "info" });
   for (const d of b.deductedAccontos) rows.push({ label: `Betalt via aconto — faktura ${d.invoiceNumber}${d.date ? ` (${svd(d.date)})` : ""}`, amountOre: d.amountOre, kind: "info" });
   return { timeLines: b.clientArvodeLines.map(toViewLine), rows, totalLabel: `${payerLabel} — att betala (inkl moms)`, totalOre: b.payerPayableOre };
 }

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -574,7 +574,20 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
     expect(pv.timeLines[0]!.amountOre).toBe(325_200);
     expect(pv.rows.find((r) => r.label.includes("andel av arvodet"))?.amountOre).toBe(260_160); // 325 200 − 65 040 självrisk
     expect(pv.rows.find((r) => r.label === "Moms 25 %")?.amountOre).toBe(65_040);               // moms på domstolens andel
-    expect(pv.rows.some((r) => r.kind === "info" && r.label.includes("Rådgivningstimme"))).toBe(true);
+    // #941 — trappan ska läsas uppifrån och ned i den ordning beräkningen sker:
+    // rådgivningstimmen av FÖRST, sedan prutningen, och först därefter klientens
+    // andel (som räknas på det som återstår). Rådgivningen är ett EXPLICIT avdrag,
+    // inte längre en info-rad längst ned.
+    const labels = pv.rows.map((r) => r.label);
+    const iRadgivning = labels.findIndex((l) => l.toLowerCase().includes("rådgivningstimme"));
+    const iAvgift = labels.findIndex((l) => l.includes("Avgår klientens"));
+    expect(iRadgivning).toBeGreaterThan(-1);
+    expect(pv.rows[iRadgivning]!.kind).toBe("deduct");
+    expect(iRadgivning).toBeLessThan(iAvgift);
+    expect(labels[0]).toBe("Upparbetat arvode (exkl moms)");
+    // Upparbetat inkluderar rådgivningstimmen; underlaget är det som återstår.
+    expect(pv.rows[0]!.amountOre).toBe(b.arvodeBaseNetOre + b.radgivningNetOre);
+    expect(labels).toContain("Underlag för kostnadsräkning (exkl moms)");
   });
 
   it("rättshjälp (#878): utlägg delas per andel; klientens del heter 'rättshjälpsavgift'", async () => {


### PR DESCRIPTION
## Vad & varför

Fakturan redovisade uppdelningen i en annan ordning än den som faktiskt används, vilket gjorde beloppen omöjliga att stämma av.

**Beräkningen var redan rätt.** `computeCoverageSplit` gör `shareOf(clampReduction(awardedOre, total), bips)` — klientens andel räknas alltså på det *prutade* beloppet — och `coverageBaseMinutes` drar bort rådgivningstimmen först. Verifierat numeriskt på demons 2026-0010: 23 495,70 är **40,00 %** av det beviljade (58 739,25), inte 34 % av basen.

Det som var fel var **presentationen**:

| Före | Problem |
|---|---|
| `Upparbetat arvode 69 105,00` | basen *efter* rådgivningsavdraget, medan sammanställningen ovanför visar 70 731 → oförklarad differens på 1 626 kr |
| avgiftsraden **före** prutningsraden | läses som att avgiften räknats på det oprutade beloppet |
| `Avgår klientens rättshjälpsavgift` | ingen procentsats, ingen bas → 23 495,70 går inte att härleda |
| rådgivningstimmen som grå info-rad längst ned | långt från det steg där den faktiskt drogs av |

Stänger #941

## Efter

Klient- och betalarfakturan renderar nu **samma** trappa, i räkneordning (verkligt utdrag ur demons 2026-0010):

```
       70 731,00  Upparbetat arvode (exkl moms)
  -     1 626,00  Avgår rådgivningstimme (1 tim) — betald av klienten separat (exkl moms)
       69 105,00  Underlag för kostnadsräkning (exkl moms)
  -    10 365,75  Avgår domstolens prutning — byrån bär (exkl moms)
       58 739,25  Beviljat arvode (exkl moms)
  -    23 495,70  Avgår klientens rättshjälpsavgift 40 % av beviljat arvode (exkl moms)
       35 243,55  Domstolens andel av arvodet (exkl moms)
        8 810,89  Moms 25 %
       44 054,44  Domstolens arvode (inkl moms)
```

Varje steg går nu att räkna efter, och toppraden matchar sammanställningen på samma sida.

### Ändringar

- `arvodeLadderRows` — delad trappa för klient- och betalarvyn (DRY; de gled isär förr).
- **Mellanstegen renderas bara när de har ett belopp** → rättsskydd (ingen rådgivningstimme, ingen byrå-buren prutning) är oförändrat, bara `Upparbetat arvode` + självrisksposterna.
- Avgiftsraden bär procentsats och, när prutning finns, basen (`… 40 % av beviljat arvode`).
- Rådgivningstimmen är ett explicit avdrag i trappan → info-raden längst ned tas bort (nämndes dubbelt).
- Nytt fält `radgivningNetOre` på nedbrytningen (nettot behövdes för trappan; bara bruttot fanns).

**Inga belopp ändras** — bara vilka rader som visas och i vilken ordning. Totalerna är identiska före och efter.

## Typ

- [ ] `feat` — ny funktion
- [x] `fix` — buggfix
- [ ] `refactor` / `perf`
- [ ] `docs` / `test` / `chore` / `ci`

## Verifierat lokalt (speglar CI)

- [x] `typecheck` + `lint` + `lint:complexity-strict` + `knip` + `deps:check` — rena
- [x] `bun run build:demo` — grön; `bun run size` 34,2 % av budget
- [x] `test/unit/server/routers/` + `test/unit/lib/kostnadsrakning/` + `test/scripts/` — 643 gröna
- [x] `test/unit/app/invoices/` — 40 gröna
- [x] Testet för nedbrytningen (#858) skärpt: assertar nu **ordningen** (rådgivningsavdraget före avgiftsraden), att toppraden är `arvodeBaseNetOre + radgivningNetOre`, och att `Underlag för kostnadsräkning` finns — inte bara att raderna existerar
- [ ] `bun run test` (hela sviten) — pass A slår i sin 360 s-watchdog (#327) på den här sandboxen, verifierat identiskt på orörd `main`. CI avgör.
- [x] Commits följer Conventional Commits

## Kvalitetsgrindar

- [x] Inga gater lösgjorda

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_