### PR TITLE
fix(billing): domstolens prutning ska träffa arvode OCH utlägg

### DIFF
--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -306,6 +306,11 @@ function vatOreOf(lines: VatBreakdownLine[]): number {
   return lines.reduce((s, l) => s + l.vatOre, 0);
 }
 
+/** Netto (öre) ur en breakdown. */
+function netOreOf(lines: VatBreakdownLine[]): number {
+  return lines.reduce((s, l) => s + l.netOre, 0);
+}
+
 /** Brutto (öre) ur en breakdown: netto + moms. */
 function grossOreOf(lines: VatBreakdownLine[]): number {
   return lines.reduce((s, l) => s + l.netOre + l.vatOre, 0);
@@ -352,13 +357,62 @@ function apportionExpenseLines(lines: VatBreakdownLine[], split: CoverageSplit):
 /** Faktura-rader (moms-breakdown) för klient- resp. betalar-fakturan ur en
  *  prutnings-/rättshjälpsavgifts-uppdelning (#801). Både arvode OCH utlägg delas
  *  per samma klient/betalar-andel (#878). */
-function coverageInvoiceLines(split: CoverageSplit, work: UnfrozenWork): { clientLines: VatBreakdownLine[]; payerLines: VatBreakdownLine[] } {
+function coverageInvoiceLines(split: CoverageSplit, expenseLines: VatBreakdownLine[]): { clientLines: VatBreakdownLine[]; payerLines: VatBreakdownLine[] } {
   const clientArvode = arvodeLine(split.clientOre);
   const payerArvode = arvodeLine(split.payerOre);
-  const exp = apportionExpenseLines(expenseBreakdownLines(work), split);
+  const exp = apportionExpenseLines(expenseLines, split);
   return {
     clientLines: [...(clientArvode ? [clientArvode] : []), ...exp.clientLines],
     payerLines: [...(payerArvode ? [payerArvode] : []), ...exp.payerLines],
+  };
+}
+
+/**
+ * Skala moms-rader proportionellt (#943). Domstolens nedsättning träffar hela
+ * anspråket — arvode OCH utlägg — så varje rad skalas med samma faktor och
+ * behåller sin momssats. Utan detta bokas nedsättningen som om utläggen vore
+ * oberörda, och per-sats-bokföringen (#790) blir fel.
+ */
+function scaleVatLines(lines: VatBreakdownLine[], factor: number): VatBreakdownLine[] {
+  if (factor >= 1) return lines;
+  return lines.map((l) => ({ ...l, netOre: Math.round(l.netOre * factor), vatOre: Math.round(l.vatOre * factor) }));
+}
+
+/**
+ * Domstolens nedsättning som andel av det YRKADE beloppet (#943). Kostnads-
+ * räkningen yrkar arvode + utlägg INKL moms och beslutet avser den summan, så
+ * jämförelsen måste ske brutto mot brutto. Tidigare mättes det beviljade
+ * bruttobeloppet mot arvodet NETTO, vilket fick `Math.min` att klampa bort hela
+ * nedsättningen. Utan beslut (null) → faktor 1, dvs ingen nedsättning.
+ */
+function awardFactor(awardedOre: number | null, claimGrossOre: number): number {
+  if (awardedOre == null || claimGrossOre <= 0) return 1;
+  return Math.min(1, Math.max(0, awardedOre / claimGrossOre));
+}
+
+/**
+ * Domstolens nedsättning applicerad på HELA anspråket (#943): kostnadsräkningen
+ * yrkar arvode + utlägg inkl moms, och beslutet avser den summan. Skala därför
+ * både arvodet och varje utläggsrad med samma faktor, och returnera arvodesdelen
+ * i NETTO så `computeCoverageSplit` (som räknar på nettoarvode) får rätt bas.
+ * Rättsskydd rör inte den här vägen — där är bolagets prutning en egen händelse
+ * som klienten bär (`recordInsurerPruning`).
+ */
+function resolveAward(method: PaymentMethod, totalArvodeNet: number, work: UnfrozenWork, awardedOre: number | null): {
+  awardedArvodeNetOre: number | null; expenseLines: VatBreakdownLine[]; expenseLossNetOre: number;
+} {
+  const rawExpenseLines = expenseBreakdownLines(work);
+  if (method !== "RATTSHJALP") {
+    return { awardedArvodeNetOre: awardedOre, expenseLines: rawExpenseLines, expenseLossNetOre: 0 };
+  }
+  const claimGrossOre = arvodeInclVatOre(totalArvodeNet) + grossOreOf(rawExpenseLines);
+  const factor = awardFactor(awardedOre, claimGrossOre);
+  const expenseLines = scaleVatLines(rawExpenseLines, factor);
+  return {
+    awardedArvodeNetOre: Math.round(totalArvodeNet * factor),
+    expenseLines,
+    // Byrån bär nedsättningen på utläggen också — arvodesdelen bärs via split.firmLossOre.
+    expenseLossNetOre: netOreOf(rawExpenseLines) - netOreOf(expenseLines),
   };
 }
 
@@ -508,11 +562,15 @@ async function buildSettlementBreakdown(repos: Repositories, orgId: Organization
   clientShareBips: number; totalArvodeNet: number; split: CoverageSplit; work: UnfrozenWork;
   payerGross: number; clientPayable: number; method: PaymentMethod; rateOre: number; settleDate: Date | string;
   deductedRuns: ReadonlyArray<{ invoiceId?: InvoiceId | null | undefined }>;
+  /** Utläggsrader EFTER domstolens nedsättning (#943) — samma rader som fakturorna. */
+  expenseLines: VatBreakdownLine[];
+  /** Nedsättningens utläggsdel (netto) — byrån bär den, jfr split.firmLossOre. */
+  expenseLossNetOre: number;
 }): Promise<SettlementBreakdown> {
   // Rådgivningstimmen ingår ALDRIG i domstolens arvode (#860) — arvodet värderas
   // på bas-minuterna (exkl rådgivning). Rådgivningen syns bara i kostnadsräkningen.
   // Utlägg delas per samma andel som arvodet (#878): klientens del + betalarens del.
-  const exp = apportionExpenseLines(expenseBreakdownLines(a.work), a.split);
+  const exp = apportionExpenseLines(a.expenseLines, a.split);
   const clientExpensesGrossOre = grossOreOf(exp.clientLines);
   const payerExpensesGrossOre = grossOreOf(exp.payerLines);
   const deductedAccontos: SpecDeduction[] = [];
@@ -636,7 +694,7 @@ function buildPayerView(b: SettlementBreakdown, payerLabel: string, payerNoun: s
   rows.push({ label: `${payerNoun} andel av arvodet (exkl moms)`, amountOre: b.payerArvodeNetOre, kind: "add" });
   rows.push({ label: "Moms 25 %", amountOre: payerArvodeGross - b.payerArvodeNetOre, kind: "add" });
   rows.push({ label: `${payerNoun} arvode (inkl moms)`, amountOre: payerArvodeGross, kind: "add" });
-  if (b.expensesGrossOre > 0) rows.push({ label: `Utlägg (${payerNoun.toLowerCase()} andel, inkl moms)`, amountOre: b.expensesGrossOre, kind: "add" });
+  if (b.expensesGrossOre > 0) rows.push({ label: `Utlägg (${payerNoun.toLowerCase()} andel${b.firmLossNetOre > 0 ? " efter nedsättning" : ""}, inkl moms)`, amountOre: b.expensesGrossOre, kind: "add" });
   for (const d of b.deductedAccontos) rows.push({ label: `Betalt via aconto — faktura ${d.invoiceNumber}${d.date ? ` (${svd(d.date)})` : ""}`, amountOre: d.amountOre, kind: "info" });
   return { timeLines: b.clientArvodeLines.map(toViewLine), rows, totalLabel: `${payerLabel} — att betala (inkl moms)`, totalOre: b.payerPayableOre };
 }
@@ -1206,12 +1264,21 @@ export const billingRunRouter = router({
         // över årsskifte + tidsspillan på egen norm); övriga metoder → platt rate.
         const settleDate = toDateOrNow(input.invoiceDate);
         const totalArvodeNet = settlementArvodeNet(matter.paymentMethod, work, settleDate, rateOre);
+        // Domstolens beslut avser det kostnadsräkningen YRKADE: arvode + utlägg,
+        // inkl moms (#943). Härled nedsättningen som en andel av hela anspråket och
+        // skala BÅDE arvodet och utläggsraderna med den — annars klampas nedsättningen
+        // bort (beviljat brutto > arvode netto) och byrån fakturerar som om domstolen
+        // beviljat allt. Rättsskydd rör inte den här vägen: där är bolagets prutning en
+        // egen händelse som klienten bär (`recordInsurerPruning`).
+        const award = resolveAward(matter.paymentMethod, totalArvodeNet, work, awardedOre);
+        const { expenseLines, expenseLossNetOre } = award;
         const split = computeCoverageSplit({
           method: matter.paymentMethod, totalOre: totalArvodeNet, clientShareBips: matter.clientShareBips ?? 0,
-          awardedOre, insurerPrutningOre: input.insurerPrutningOre ?? null,
+          awardedOre: award.awardedArvodeNetOre,
+          insurerPrutningOre: input.insurerPrutningOre ?? null,
           ...rattsskyddCoverage(matter, work.timeEntries, rateOre),
         });
-        const { clientLines, payerLines } = coverageInvoiceLines(split, work);
+        const { clientLines, payerLines } = coverageInvoiceLines(split, expenseLines);
 
         // Klient: självrisk (+ ev. prutning), moms 25 %, minus tidigare aconton.
         // Auto-dra av ALLA skickade klient-aconton (#856): de har redan betalats,
@@ -1230,6 +1297,7 @@ export const billingRunRouter = router({
           clientShareBips: matter.clientShareBips ?? 0, totalArvodeNet,
           split, work, payerGross, clientPayable: clientAmount,
           method: matter.paymentMethod, rateOre, settleDate, deductedRuns,
+          expenseLines, expenseLossNetOre,
         });
         const { clientView, payerView } = buildSettlementViews(breakdown, matter.paymentMethod);
 
@@ -1243,7 +1311,7 @@ export const billingRunRouter = router({
           settlementBreakdown: payerView,
           invoiceType: "FINAL", status: "DRAFT", ...(await invoiceNumbering(tx, ctx.orgId, input.payerRecipient)), invoiceDate: settleDate, notes: input.notes,
         });
-        await bookFirmLoss(tx, ctx.user.id, input.matterId, split.firmLossOre);
+        await bookFirmLoss(tx, ctx.user.id, input.matterId, split.firmLossOre + expenseLossNetOre);
         const clientRun = await tx.billingRuns.create({
           matterId: input.matterId, type: "FINAL", recipient: "KLIENT", status: "SENT",
           workValueOreAtRun: clientGross, proposedAmountOre: clientGross, amountOre: clientInvoice.amount,

--- a/test/scripts/demo-prutning.test.ts
+++ b/test/scripts/demo-prutning.test.ts
@@ -69,9 +69,10 @@ describe("prutning i demo-scenarierna (#936)", () => {
     // (85 % resp. 70 % av samma nettoarbete).
     expect(a30?.awardedOre).toBeLessThan(a15!.awardedOre);
     expect(a15!.awardedOre / a30!.awardedOre).toBeCloseTo(85 / 70, 2);
-    // Beloppet härleds ur NETTO-arvodet, inte ur KR:ns brutto-värde (5 000 000 i
-    // stubben) — annars skulle computeCoverageSplit klampa bort nedsättningen.
-    expect(a15?.awardedOre).not.toBe(5_000_000);
+    // Beloppet härleds ur KR:ns YRKADE belopp (arvode + utlägg inkl moms) — precis
+    // som en riktig domstol prutar. 85 % av stubbens 5 000 000 (#943).
+    expect(a15?.awardedOre).toBe(4_250_000);
+    expect(a30?.awardedOre).toBe(3_500_000);
   });
 
   it("2026-0010 väljs som rättshjälps-prutningsärende, 2026-0020 lämnas orört", async () => {

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -514,12 +514,16 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
     // 3 tim loggat − 1 tim rådgivning (#809) = 2 effektiva tim → bas 325 200.
     const { ds, caller: c } = caller({ paymentMethod: "RATTSHJALP", clientShareBips: 2000, taxaHasFTax: true }, 999999, 180);
     const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "RATTSHJALPSMYNDIGHET", awardedOre: 300000 });
-    // total 325200; dom 300000 → förlust 25200; klient 60000 → 75000; stat 240000 → 300000.
-    expect(res.split).toMatchObject({ clientOre: 60000, payerOre: 240000, firmLossOre: 25200 });
-    expect(res.clientInvoice.amount).toBe(75000);
-    expect(res.payerInvoice.amount).toBe(300000);
+    // #943: domsbeloppet är BRUTTO (det KR:n yrkade, inkl moms) — inte nettoarvode.
+    // Yrkat 325 200 netto = 406 500 brutto; dom 300 000 brutto → beviljat netto 240 000,
+    // byrån bär 85 200. Klient 20 % av 240 000 = 48 000 netto → 60 000 brutto; staten
+    // 192 000 → 240 000 brutto. Summa fakturerat = 300 000 = EXAKT det domstolen dömde.
+    expect(res.split).toMatchObject({ clientOre: 48000, payerOre: 192000, firmLossOre: 85200 });
+    expect(res.clientInvoice.amount).toBe(60000);
+    expect(res.payerInvoice.amount).toBe(240000);
+    expect(res.clientInvoice.amount + res.payerInvoice.amount).toBe(300000); // aldrig mer än domen
     const prutning = await ds.expenses.findFirst({ where: { matterId: "m-1", kind: "PRUTNING" } }) as { amount: number; billable: boolean };
-    expect(prutning.amount).toBe(-25200);
+    expect(prutning.amount).toBe(-85200);
     expect(prutning.billable).toBe(false);
   });
 
@@ -651,10 +655,11 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
     // Registrera domstolens beslut PÅ KR:n (dömt 300 000), sedan fakturera.
     await c.billingRun.recordKostnadsrakningBeslut({ billingRunId: kr.run.id, awardedOre: 300000 });
     const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "RATTSHJALPSMYNDIGHET" });
-    // Domsbeloppet (300 000) tas från KR:n → samma split.
-    expect(res.split).toMatchObject({ clientOre: 60000, payerOre: 240000, firmLossOre: 25200 });
-    expect(res.clientInvoice.amount).toBe(75000);
-    expect(res.payerInvoice.amount).toBe(300000);
+    // Domsbeloppet (300 000, brutto) tas från KR:n → samma split som ovan (#943).
+    expect(res.split).toMatchObject({ clientOre: 48000, payerOre: 192000, firmLossOre: 85200 });
+    expect(res.clientInvoice.amount).toBe(60000);
+    expect(res.payerInvoice.amount).toBe(240000);
+    expect(res.clientInvoice.amount + res.payerInvoice.amount).toBe(300000);
     // Betalar-körningen är en EGEN FINAL (ej KR:n) → KR:n förblir distinkt.
     expect(res.payerRun.id).not.toBe(kr.run.id);
     const krAfter = await ds.billingRuns.findFirst({ where: { id: kr.run.id } }) as { kostnadsrakningStatus: string; invoiceId: string | null };

--- a/tooling/demo-generator/simulate/runner.ts
+++ b/tooling/demo-generator/simulate/runner.ts
@@ -170,16 +170,17 @@ async function hKostnadsrakning(ctx: RunCtx, m: SimMatter, _e: Any, _iso: string
 async function hBeslut(ctx: RunCtx, _m: SimMatter, e: Any, _iso: string, st: SimState): Promise<void> {
   if (!st.krRunId) return;
   // Domstolen kan PRUTA (#936): `reducedByBips` sätter ned det beviljade beloppet mot
-  // det yrkade. Vid rättshjälp bär BYRÅN mellanskillnaden (får ej tas av klienten) —
+  // det YRKADE. Vid rättshjälp bär BYRÅN mellanskillnaden (får ej tas av klienten) —
   // settleCoverage bokar den som en PRUTNING-post via bookFirmLoss.
   //
-  // Nedsättningen räknas på det ackumulerade NETTO-arvodet, inte på KR:ns
-  // `workValueOreAtRun`: den senare är BRUTTO (inkl moms + utlägg), medan
-  // `computeCoverageSplit` jämför `awardedOre` mot netto-arvodet och klampar till
-  // totalen. En procentsats på bruttot skulle därför ofta inte bita alls.
+  // Nedsättningen räknas på KR:ns yrkade belopp (`workValueOreAtRun`) — arvode +
+  // utlägg inkl moms — precis som en riktig domstol gör. Tidigare räknades den på
+  // netto-arvodet för att kringgå #943 (motorn jämförde det beviljade bruttot mot
+  // netto-arvodet och klampade bort nedsättningen). Den buggen är fixad, så demon
+  // går nu samma väg som appen.
   const bips = Number(e.reducedByBips ?? 0);
   const awardedOre = bips > 0
-    ? Math.round((st.accruedNetOre * (10000 - bips)) / 10000)
+    ? Math.round((st.krWorkValueOre * (10000 - bips)) / 10000)
     : st.krWorkValueOre;
   await ctx.c.billingRun.recordKostnadsrakningBeslut({ billingRunId: st.krRunId, awardedOre });
 }


### PR DESCRIPTION
## Vad & varför

Kostnadsräkningen yrkar **arvode + utlägg inkl moms**, och domstolens beslut avser den summan. Men slutregleringen mätte det beviljade beloppet mot **arvode netto** — två enhetsfel i samma jämförelse (utläggen saknades, momsen saknades). Eftersom det beviljade bruttot nästan alltid överstiger nettoarvodet klampade `Math.min` i `clampReduction` bort hela nedsättningen.

**Repro före fixen** (riktiga routern, 11 tim + 5 000 kr utlägg, rättshjälpsavgift 40 %):

```
KR yrkar (arvode + utlägg, inkl moms):  26 575,00 kr
Domstolen beviljar (85 %):              22 588,75 kr
FÖRVÄNTAD prutning:                      3 986,25 kr
bas prutningen mättes mot (netto):      16 260,00 kr
byrå-buren prutning:                         0,00 kr
PRUTNINGEN SYNS: NEJ — den försvann
```

Byrån fakturerade alltså domstolen som om beslutet beviljat allt. Ett befintligt test visade samma fel från andra hållet: på en dom om **300 000 kr** fakturerades klient + domstol tillsammans **375 000 kr**, eftersom domsbeloppet tolkades som netto.

**Efter fixen** summerar fakturorna till exakt det domstolen beviljade:

```
byrå-buren prutning (netto): 3 189,00 kr
domstolen betalar:          13 553,25 kr
klienten betalar:            9 035,50 kr
summa:                      22 588,75 kr   = beviljat belopp ✓
klientens andel:                40,00 %    av det beviljade ✓
```

Stänger #943

### Ändringar

- **`resolveAward`** — nedsättningen härleds som en andel av hela anspråket (brutto mot brutto) och skalar **både** arvodet och varje utläggsrad. Rättshjälp only; rättsskydd rör inte vägen (där är bolagets prutning en egen händelse som klienten bär).
- **`scaleVatLines`** skalar **per momssats**, så utlägg med 0/6/12 % behåller sin sats och per-sats-bokföringen (#790, SIE) förblir riktig.
- Byrån bär nedsättningen på både arvode och utlägg (`bookFirmLoss`).
- Nedbrytningen och fakturorna läser **samma** nedsatta utläggsrader, så dokument och bokföring inte kan glida isär.

### Demons workaround borttaget

I #936 stötte jag på "prutningen biter inte" och löste det i **scenariot** genom att räkna fram `awardedOre` ur nettoarvodet i stället för ur KR:ns yrkade belopp. Det maskerade orsaken — demon såg rätt ut medan appen tappade nedsättningen. Scenariot går nu samma väg som appen, och `demo-prutning.test.ts` assertar exakta belopp i stället för en ratio.

### Trappan på fakturan (2026-0010, riktig demodata)

```
       70 731,00  Upparbetat arvode (exkl moms)
  −     1 626,00  Avgår rådgivningstimme (1 tim) — betald av klienten separat
       69 105,00  Underlag för kostnadsräkning (exkl moms)
  −    10 365,75  Avgår domstolens prutning — byrån bär (exkl moms)
       58 739,25  Beviljat arvode (exkl moms)
  −    23 495,70  Avgår klientens rättshjälpsavgift 40 % av beviljat arvode
       35 243,55  Domstolens andel av arvodet (exkl moms)
        8 810,89  Moms 25 %
       44 054,44  Domstolens arvode (inkl moms)
          841,50  Utlägg (domstolens andel efter nedsättning, inkl moms)
```

Utläggsandelen är nedsatt med samma faktor (990 × 0,85 = 841,50) och etiketten säger det.

## Typ

- [ ] `feat` — ny funktion
- [x] `fix` — buggfix
- [ ] `refactor` / `perf`
- [ ] `docs` / `test` / `chore` / `ci`

## Verifierat lokalt (speglar CI)

- [x] `typecheck` + `lint` + `lint:complexity-strict` + `knip` + `deps:check` — rena
- [x] `bun run build:demo` grön; `bun run size` 34,2 % av budget
- [x] `test/unit/server/routers/billingRun.test.ts` 56 gröna — två tester uppdaterade till de korrigerade beloppen, med ny assertion att klient + betalare **aldrig** överstiger domen
- [x] `test/scripts/` 128 gröna
- [ ] Kända lokala miljöfel: hela sviten slår i 360 s-watchdogen (#327) och 43 fall i `test/unit/lib/` + 7 socket-tester fallerar vid katalogkörning — **alla verifierade identiska på orörd `main`** och gröna isolerat. CI avgör.

## Kvalitetsgrindar

- [x] Inga gater lösgjorda
- [x] Ändringen rör belopp på fakturor — invarianten "klient + betalare = beviljat belopp" är nu testad

## Övrigt

**Nästa steg (ej i denna PR):** användarna vill se utläggen i basen, ovanför där avdragen börjar, så att trappan går på arvode + utlägg genomgående. Det stämmer med regeln här (klienten får redan 40 % av både arvode och utlägg via `apportionExpenseLines`), men kräver att `SettlementBreakdown` bär utläggsandelarna netto och att momsraden blir summan över flera satser i stället för platta 25 %.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_