### PR TITLE
fix(billing): 25 % moms på utlägg när fakturan går till domstol

### DIFF
--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -263,10 +263,6 @@ function settlementArvodeNet(method: PaymentMethod, work: UnfrozenWork, settleDa
  * TIMKOSTNADSNORMEN (staten ersätter bara normen, ej byråns taxa), tidsspillan på
  * tidsspillan-normen, rådgivningstimmen exkluderas. Utlägg ersätts brutto.
  */
-function rattshjalpKrGrossOre(work: UnfrozenWork, settleDate: Date | string): number {
-  return arvodeInclVatOre(settlementArvodeNet("RATTSHJALP", work, settleDate, 0)) + expenseGrossOre(work);
-}
-
 /** Fakturans exakta momsbelopp (öre) per sats: arvodets moms (25 %) +
  *  varje utläggs moms (dess sats). Lagras på fakturan för korrekt bokföring (#782). */
 function invoiceVatOre(work: UnfrozenWork): number {
@@ -357,13 +353,19 @@ function apportionExpenseLines(lines: VatBreakdownLine[], split: CoverageSplit):
 /** Faktura-rader (moms-breakdown) för klient- resp. betalar-fakturan ur en
  *  prutnings-/rättshjälpsavgifts-uppdelning (#801). Både arvode OCH utlägg delas
  *  per samma klient/betalar-andel (#878). */
-function coverageInvoiceLines(split: CoverageSplit, expenseLines: VatBreakdownLine[]): { clientLines: VatBreakdownLine[]; payerLines: VatBreakdownLine[] } {
+function coverageInvoiceLines(split: CoverageSplit, expenseLines: VatBreakdownLine[], courtPayer: boolean): {
+  clientLines: VatBreakdownLine[]; payerLines: VatBreakdownLine[];
+  clientExpenseLines: VatBreakdownLine[]; payerExpenseLines: VatBreakdownLine[];
+} {
   const clientArvode = arvodeLine(split.clientOre);
   const payerArvode = arvodeLine(split.payerOre);
   const exp = apportionExpenseLines(expenseLines, split);
+  // Betalaren är domstolen → dess utläggsandel debiteras 25 % oavsett ursprungssats (#945).
+  const payerExpenseLines = courtPayer ? courtExpenseLines(exp.payerLines) : exp.payerLines;
   return {
     clientLines: [...(clientArvode ? [clientArvode] : []), ...exp.clientLines],
-    payerLines: [...(payerArvode ? [payerArvode] : []), ...exp.payerLines],
+    payerLines: [...(payerArvode ? [payerArvode] : []), ...payerExpenseLines],
+    clientExpenseLines: exp.clientLines, payerExpenseLines,
   };
 }
 
@@ -414,6 +416,35 @@ function resolveAward(method: PaymentMethod, totalArvodeNet: number, work: Unfro
     // Byrån bär nedsättningen på utläggen också — arvodesdelen bärs via split.firmLossOre.
     expenseLossNetOre: netOreOf(rawExpenseLines) - netOreOf(expenseLines),
   };
+}
+
+/** Betalare som är domstol/rättshjälpsmyndighet (#945) — utlägg debiteras 25 %. */
+function isCourtRecipient(recipient: BillingRunRecipient): boolean {
+  return recipient === "DOMSTOL" || recipient === "RATTSHJALPSMYNDIGHET";
+}
+
+/** Moms (öre) på ett nettobelopp vid standardsatsen. */
+function vatOnNet(netOre: number): number {
+  return Math.round((netOre * DEFAULT_VAT_RATE) / 10000);
+}
+
+/**
+ * Utlägg mot DOMSTOL (#945): ett vidarefakturerat utlägg ingår i byråns egen
+ * skattepliktiga omsättning, så domstolen debiteras 25 % moms på utläggens NETTO
+ * oavsett vilken sats byrån själv betalade (domstolsavgift 0 %, tåg/taxi 6 %,
+ * restaurang 12 %). Alla utlägg kollapsar därför till EN 25 %-rad.
+ * Klientens och försäkringens fakturor behåller utläggens riktiga satser.
+ */
+function courtExpenseLines(lines: VatBreakdownLine[]): VatBreakdownLine[] {
+  const netOre = netOreOf(lines);
+  if (netOre === 0) return [];
+  return [{ kind: "utlagg", vatRate: DEFAULT_VAT_RATE, netOre, vatOre: vatOnNet(netOre) }];
+}
+
+/** Kostnadsräkningens yrkade brutto — den går ALLTID till domstol, så utläggen
+ *  värderas med 25 % moms (#945). `arvodeNet` skiljer sig per betalningssätt. */
+function krGrossOre(work: UnfrozenWork, arvodeNet: number): number {
+  return arvodeInclVatOre(arvodeNet) + grossOreOf(courtExpenseLines(expenseBreakdownLines(work)));
 }
 
 /** Bygg ett itemiserat fakturaförslag ur ofrysta tids-/utläggsrader (#397). */
@@ -562,17 +593,18 @@ async function buildSettlementBreakdown(repos: Repositories, orgId: Organization
   clientShareBips: number; totalArvodeNet: number; split: CoverageSplit; work: UnfrozenWork;
   payerGross: number; clientPayable: number; method: PaymentMethod; rateOre: number; settleDate: Date | string;
   deductedRuns: ReadonlyArray<{ invoiceId?: InvoiceId | null | undefined }>;
-  /** Utläggsrader EFTER domstolens nedsättning (#943) — samma rader som fakturorna. */
-  expenseLines: VatBreakdownLine[];
+  /** Utläggsrader per part EFTER nedsättning (#943) och ev. 25 %-omrating mot
+   *  domstol (#945) — exakt de rader fakturorna bär. */
+  clientExpenseLines: VatBreakdownLine[];
+  payerExpenseLines: VatBreakdownLine[];
   /** Nedsättningens utläggsdel (netto) — byrån bär den, jfr split.firmLossOre. */
   expenseLossNetOre: number;
 }): Promise<SettlementBreakdown> {
   // Rådgivningstimmen ingår ALDRIG i domstolens arvode (#860) — arvodet värderas
   // på bas-minuterna (exkl rådgivning). Rådgivningen syns bara i kostnadsräkningen.
   // Utlägg delas per samma andel som arvodet (#878): klientens del + betalarens del.
-  const exp = apportionExpenseLines(a.expenseLines, a.split);
-  const clientExpensesGrossOre = grossOreOf(exp.clientLines);
-  const payerExpensesGrossOre = grossOreOf(exp.payerLines);
+  const clientExpensesGrossOre = grossOreOf(a.clientExpenseLines);
+  const payerExpensesGrossOre = grossOreOf(a.payerExpenseLines);
   const deductedAccontos: SpecDeduction[] = [];
   for (const r of a.deductedRuns) {
     if (!r.invoiceId) continue;
@@ -1079,9 +1111,10 @@ export const billingRunRouter = router({
         // Rättshjälp värderas på timkostnadsnormen (#839) — staten ersätter inte
         // byråns privata timtaxa. Övriga (offentligt uppdrag/taxa): arvode inkl moms
         // + utlägg som tidigare. Brutto matchar kostnadsräkningens PDF (#782).
-        const grossValue = matter.paymentMethod === "RATTSHJALP"
-          ? rattshjalpKrGrossOre(work, new Date()) // #891: retroaktiv norm per slutregleringsdatum
-          : invoiceGrossOre(work);
+        const krArvodeNet = matter.paymentMethod === "RATTSHJALP"
+          ? settlementArvodeNet("RATTSHJALP", work, new Date(), 0) // #891: retroaktiv norm
+          : arvodeNetOre(work);
+        const grossValue = krGrossOre(work, krArvodeNet);
         const run = await tx.billingRuns.create({
           matterId: input.matterId, type: "KOSTNADSRAKNING", recipient: "DOMSTOL",
           status: "PENDING_VERDICT", kostnadsrakningStatus: "INSKICKAD", workValueOreAtRun: grossValue,
@@ -1278,7 +1311,10 @@ export const billingRunRouter = router({
           insurerPrutningOre: input.insurerPrutningOre ?? null,
           ...rattsskyddCoverage(matter, work.timeEntries, rateOre),
         });
-        const { clientLines, payerLines } = coverageInvoiceLines(split, expenseLines);
+        // #945: går betalarfakturan till domstol debiteras utläggen 25 % oavsett sats.
+        const courtPayer = isCourtRecipient(input.payerRecipient);
+        const { clientLines, payerLines, clientExpenseLines, payerExpenseLines } =
+          coverageInvoiceLines(split, expenseLines, courtPayer);
 
         // Klient: självrisk (+ ev. prutning), moms 25 %, minus tidigare aconton.
         // Auto-dra av ALLA skickade klient-aconton (#856): de har redan betalats,
@@ -1297,7 +1333,7 @@ export const billingRunRouter = router({
           clientShareBips: matter.clientShareBips ?? 0, totalArvodeNet,
           split, work, payerGross, clientPayable: clientAmount,
           method: matter.paymentMethod, rateOre, settleDate, deductedRuns,
-          expenseLines, expenseLossNetOre,
+          clientExpenseLines, payerExpenseLines, expenseLossNetOre,
         });
         const { clientView, payerView } = buildSettlementViews(breakdown, matter.paymentMethod);
 

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -294,7 +294,10 @@ describe("billingRun.setVerdict", () => {
     expect(ex.invoiceId).toBe(res.invoice.id); // utlägg länkad
     expect(prut.invoiceId).toBe(res.invoice.id); // PRUTNING länkad (reducerar totalen)
     // Arvode 5000 kr + 25 % moms = 625000, + utlägg 50 kr − prutning 300 kr (#782).
-    expect(res.invoice.amount).toBe(625000 + 5000 - 30000);
+    // #945: fakturan går till DOMSTOL → utlägget debiteras 25 % moms (6250) fastän
+    // posten själv är momsfri. Prutningen är en justering av totalen, inte ett utlägg,
+    // och momsas därför inte.
+    expect(res.invoice.amount).toBe(625000 + 6250 - 30000);
   });
 
   it("DOMSTOL-faktura får F-nummer men ingen OCR (#889 — samma format som övriga)", async () => {
@@ -463,6 +466,49 @@ describe("billingRun.coverageSplit — prutning/självrisk på aktuellt timarvod
     await caller.billingRun.createKostnadsrakning({ matterId: "m-1" }); // fryser tid + utlägg
     const r = await caller.billingRun.coverageSplit({ matterId: "m-1" });
     expect(r.expensesNetOre).toBe(90000); // frysta utlägg syns fortfarande
+  });
+});
+
+describe("moms mot DOMSTOL är alltid 25 % (#945)", () => {
+  /** Rättshjälpsärende med ETT momsfritt utlägg (900 kr) och ETT på 6 % (400 kr). */
+  function courtCaller() {
+    const ds = new DemoDataStore({
+      organizations: [{ id: "org-1", name: "X" }],
+      matters: [{ id: "m-1", organizationId: "org-1", matterNumber: "2026-0001", title: "T", status: "ACTIVE",
+        responsibleLawyerId: "u-1", paymentMethod: "RATTSHJALP", clientShareBips: 4000, taxaHasFTax: true, createdAt: new Date() }],
+      users: [{ id: "u-1", organizationId: "org-1", email: "a@x", name: "Anna", role: "ADMIN", hourlyRate: 250000 }],
+      timeEntries: [{ id: "te-1", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), minutes: 660, description: "Arbete", hourlyRate: 162600, billable: true }],
+      expenses: [
+        { id: "ex-1", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), amount: 90000, description: "Domstolsavgift", billable: true, vatRate: 0, vatIncluded: false, kind: "EXPENSE" },
+        { id: "ex-2", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date(), amount: 40000, description: "Tåg", billable: true, vatRate: 600, vatIncluded: false, kind: "EXPENSE" },
+      ],
+    }, async () => { /* writable */ });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return appRouter.createCaller(buildContext({ dataStore: ds, ports: noopPorts, principal: PRINCIPAL }) as any);
+  }
+
+  it("kostnadsräkningen yrkar 25 % på utläggens netto, inte posternas egna satser", async () => {
+    const c = courtCaller();
+    const kr = await c.billingRun.createKostnadsrakning({ matterId: "m-1" });
+    // Utlägg netto 1 300 kr → 1 625 kr mot domstol (25 %), inte 1 324 kr (0 % + 6 %).
+    const arvodeGross = 10 * 162600 * 1.25; // 10 tim (11 − 1 rådgivning) på timkostnadsnormen
+    expect(kr.run.workValueOreAtRun).toBe(Math.round(arvodeGross) + 162500);
+  });
+
+  it("domstolsfakturan får EN 25 %-utläggsrad; klientfakturan behåller 0 % och 6 %", async () => {
+    const c = courtCaller();
+    const kr = await c.billingRun.createKostnadsrakning({ matterId: "m-1" });
+    await c.billingRun.recordKostnadsrakningBeslut({ billingRunId: kr.run.id, awardedOre: kr.run.workValueOreAtRun });
+    const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "DOMSTOL" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const lines = (l: any): Array<{ vatRate: number; netOre: number; vatOre: number }> => l.vatBreakdown;
+    const payerUtlagg = lines(res.payerInvoice).filter((l) => (l as { kind?: string }).kind === "utlagg");
+    expect(payerUtlagg).toHaveLength(1);
+    expect(payerUtlagg[0]!.vatRate).toBe(2500);
+    expect(payerUtlagg[0]!.vatOre).toBe(Math.round(payerUtlagg[0]!.netOre * 0.25));
+    // Klienten är ingen domstol → posternas riktiga satser bevaras.
+    const clientRates = lines(res.clientInvoice).filter((l) => (l as { kind?: string }).kind === "utlagg").map((l) => l.vatRate).sort((a, b) => a - b);
+    expect(clientRates).toEqual([0, 600]);
   });
 });
 


### PR DESCRIPTION
## Vad & varför

Ett vidarefakturerat utlägg ingår i byråns egen skattepliktiga omsättning, så domstolen ska debiteras **25 % moms på utläggens netto** oavsett vilken sats byrån själv betalade. Tidigare följde posternas egna satser med rakt in i kostnadsräkningen och betalarfakturan — ett momsfritt utlägg om 900 kr yrkades som 900 kr i stället för 1 125 kr, och byrån blev inte hel.

Seeden har flera berörda satser: domstolsavgift 0 %, tåg/taxi 6 %, restaurang 12 %.

Stänger #945

## Verifierat på riktig data

Rättshjälpsärende med ett momsfritt utlägg (900 kr) och ett på 6 % (400 kr), rättshjälpsavgift 40 %:

```
utlägg netto:                1 300,00 kr
utlägg m. RIKTIGA satser:    1 324,00 kr   (0 % + 6 %)
utlägg m. 25 % mot domstol:  1 625,00 kr   ← yrkas nu

domstolsfakturans momsrader:
   arvode   25 %  netto  9 756,00 kr  moms 2 439,00 kr
   utlagg   25 %  netto    780,00 kr  moms   195,00 kr    ← EN rad

klientfakturans momsrader (oförändrade):
   arvode   25 %  netto  6 504,00 kr  moms 1 626,00 kr
   utlagg    0 %  netto    360,00 kr  moms     0,00 kr
   utlagg    6 %  netto    160,00 kr  moms     9,60 kr
```

### Ändringar

- **`krGrossOre`** — kostnadsräkningen går alltid till domstol, så utläggen värderas till netto × 1,25. Gäller **båda** betalningssätten (rättshjälp och offentligt uppdrag); `rattshjalpKrGrossOre` ersatt.
- **`courtExpenseLines`** — betalarfakturans utlägg kollapsar till **en** 25 %-rad när `payerRecipient` är `DOMSTOL` eller `RATTSHJALPSMYNDIGHET`.
- **Klientens och försäkringens fakturor är oförändrade.** Samma utlägg får därmed olika momssats på klientens respektive domstolens faktura i ett rättshjälpsärende — avsiktligt, enligt avstämning med användarna.
- Nedbrytningen läser nu **samma apportionerade rader** som fakturorna i stället för att räkna om dem, så dokument och per-sats-bokföring (#790, SIE) inte kan glida isär.

`setVerdict` bygger sitt belopp ur KR:ns `workValueOreAtRun` och ärver därför regeln automatiskt. PRUTNING-posten är en justering av totalen och momsas inte — verifierat i test.

## Typ

- [ ] `feat` — ny funktion
- [x] `fix` — buggfix
- [ ] `refactor` / `perf`
- [ ] `docs` / `test` / `chore` / `ci`

## Verifierat lokalt (speglar CI)

- [x] `typecheck` + `lint` + `lint:complexity-strict` + `knip` + `deps:check` — rena
- [x] `bun run build:demo` grön; `bun run size` 34,2 % av budget
- [x] `test/unit/server/routers/billingRun.test.ts` **58** gröna — två **nya** tester låser regeln: att KR:n yrkar 25 % på utläggsnettot, och att domstolsfakturan får en enda 25 %-rad medan klientfakturan behåller `[0, 600]`
- [x] `test/scripts/` gröna
- [x] Ett befintligt `setVerdict`-test uppdaterat: 625000 + **6250** − 30000 (utlägget momsas nu mot domstol; prutningen gör det inte)
- [ ] Kända lokala miljöfel (360 s-watchdog #327, katalogkörnings-läckage i `test/unit/lib/`, socket-portkontention) — verifierade identiska på orörd `main`. CI avgör.

## Kvalitetsgrindar

- [x] Inga gater lösgjorda
- [x] Ändringen rör momsbelopp och per-sats-bokföring — båda riktningarna (domstol → 25 %, klient → oförändrat) är testade

## Övrigt

Kvar sedan tidigare: användarnas layoutönskemål att lyfta upp utläggen i basen så trappan går på arvode + utlägg genomgående. Den blir enklare efter den här PR:en, eftersom domstolsfakturans utlägg nu har samma sats som arvodet och momsraden därför kan slås ihop utan att blanda satser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_