### PR TITLE
feat(billing): arvodeskategorier med egen årsnorm — obekväm tid och tidsspillan annan tid

### DIFF
--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -177,7 +177,7 @@ export const timeEntries = pgTable("time_entries", {
   description: text("description").notNull(),
   hourlyRate: integer("hourly_rate").notNull(),
   /** ARBETE (default) eller TIDSSPILLAN (#891) — styr slutregleringens norm. */
-  kind: text("kind").$type<"ARBETE" | "TIDSSPILLAN">(),
+  kind: text("kind").$type<"ARBETE" | "ARBETE_OBEKVAM_TID" | "TIDSSPILLAN" | "TIDSSPILLAN_OVRIG_TID">(),
   billable: boolDefault("billable", true),
   invoiceId: uuid("invoice_id").$type<InvoiceId>(),
   frozenAt: timestamp("frozen_at", { withTimezone: true }),

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -19,7 +19,10 @@ import { z } from "zod";
 import type { VatBreakdownLine } from "@/lib/shared/accounting/semantic-voucher";
 import { assertBillingTransition, type BillingActionType } from "@/lib/shared/billing-flow";
 import { proposedAccontoOre } from "@/lib/shared/billing-proposal";
-import { TIMKOSTNADSNORM_FTAX_ORE_PER_H, timkostnadsnormFtaxForDate, tidsspillanFtaxForDate } from "@/lib/shared/brottmalstaxa";
+import {
+  TIMKOSTNADSNORM_FTAX_ORE_PER_H, timkostnadsnormFtaxForDate, tidsspillanFtaxForDate,
+  tidsspillanOvrigFtaxForDate, arbeteObekvamFtaxForDate,
+} from "@/lib/shared/brottmalstaxa";
 import { computeCoverageSplit, partitionRattsskyddMinutes, type CoverageSplit, type RattsskyddClientParts } from "@/lib/shared/coverage-billing";
 import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
 import {
@@ -31,7 +34,7 @@ import { applyKrAction, type KostnadsrakningAction, type KostnadsrakningState, t
 import { ocrFromInvoiceNumber } from "@/lib/shared/ocr-reference";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { RADGIVNING_MINUTES } from "@/lib/shared/rattshjalp";
-import { settlementBreakdownSchema, type BillingRun, type Invoice } from "@/lib/shared/schemas/billing";
+import { settlementBreakdownSchema, type BillingRun, type Invoice, type TimeEntryKind } from "@/lib/shared/schemas/billing";
 import { billingRunRecipientSchema, type BillingRunRecipient, type ExpenseKind, type PaymentMethod } from "@/lib/shared/schemas/enums";
 import {
   matterIdSchema,
@@ -57,7 +60,7 @@ import type { Repositories } from "../repositories/repositories";
 import { router, orgProcedure } from "../trpc";
 
 interface UnfrozenWork {
-  timeEntries: Array<{ id: TimeEntryId; minutes: number; hourlyRate: number; billable: boolean; date: Date | string; description: string; kind?: "ARBETE" | "TIDSSPILLAN" | null | undefined }>;
+  timeEntries: Array<{ id: TimeEntryId; minutes: number; hourlyRate: number; billable: boolean; date: Date | string; description: string; kind?: TimeEntryKind | null | undefined }>;
   expenses: Array<{ id: ExpenseId; amount: number; billable: boolean; vatRate?: number | null; vatIncluded?: boolean | null }>;
 }
 
@@ -115,17 +118,40 @@ interface RattsskyddMatter {
  * (täckt del efter tvist/retro-tak) → `coveredOre`, samt försäkringens tak →
  * `capOre`. Tom för andra betalningssätt (då gäller standard-splitten).
  */
+/**
+ * Värdet (netto) av den TÄCKTA delen (#950). Minuterna kommer ur den kronologiska
+ * partitioneringen, men värdet måste räknas på posternas KATEGORINORMER — samma
+ * valuta som `settlementArvodeNet` — annars jämförs äpplen med päron. Fördelar de
+ * täckta minuterna över posterna i ordning (äldsta först).
+ */
+function coveredValueOre(
+  entries: ReadonlyArray<{ minutes: number; billable: boolean; kind?: TimeEntryKind | null | undefined }>,
+  coveredMinutes: number, settleDate: Date | string,
+): number {
+  let left = coveredMinutes;
+  let value = 0;
+  for (const t of entries.filter((e) => e.billable)) {
+    if (left <= 0) break;
+    const take = Math.min(left, t.minutes);
+    value += timeEntryValueOre(take, rattshjalpEntryRateOre(t.kind, settleDate));
+    left -= take;
+  }
+  return value;
+}
+
 function rattsskyddCoverage(
   matter: RattsskyddMatter,
-  entries: ReadonlyArray<{ date: Date | string; minutes: number; billable: boolean }>,
-  rateOre: number,
+  entries: ReadonlyArray<{ date: Date | string; minutes: number; billable: boolean; kind?: TimeEntryKind | null | undefined }>,
+  settleDate: Date | string,
   // `minSjalvriskOre` returneras också (självrisk-golvet, #899) — utan den i typen
   // trodde TS att den aldrig skickas till computeCoverageSplit, trots att den gör det.
 ): { coveredOre?: number; capOre?: number; minSjalvriskOre?: number } {
   if (matter.paymentMethod !== "RATTSSKYDD") return {};
   const p = partitionRattsskyddMinutes(entries, matter.tvistUppkomDatum ?? null, matter.rattsskyddBeslutDatum ?? null);
   return omitUndefined({
-    coveredOre: Math.round((p.coveredMinutes / 60) * rateOre),
+    // MÅSTE värderas på samma sätt som arvodesbasen (#950), annars jämförs täckt
+    // arbete mot en bas i en annan taxa och otäckt/självrisk blir fel.
+    coveredOre: coveredValueOre(entries, p.coveredMinutes, settleDate),
     capOre: matter.rattsskyddMaxOre ?? undefined,
     minSjalvriskOre: matter.rattsskyddSjalvriskMinOre ?? undefined,
   });
@@ -237,8 +263,13 @@ function invoiceGrossOre(work: UnfrozenWork): number {
 /** Timarvodet (öre/tim) för en tidspost vid slutreglering (#891): rättshjälp
  *  värderas retroaktivt på SLUTREGLERINGSÅRETS norm — arbete på timkostnadsnormen,
  *  tidsspillan på den (lägre) tidsspillan-normen. */
-function rattshjalpEntryRateOre(kind: "ARBETE" | "TIDSSPILLAN" | null | undefined, settleDate: Date | string): number {
-  return kind === "TIDSSPILLAN" ? tidsspillanFtaxForDate(settleDate) : timkostnadsnormFtaxForDate(settleDate);
+function rattshjalpEntryRateOre(kind: TimeEntryKind | null | undefined, settleDate: Date | string): number {
+  switch (kind) {
+    case "TIDSSPILLAN": return tidsspillanFtaxForDate(settleDate);
+    case "TIDSSPILLAN_OVRIG_TID": return tidsspillanOvrigFtaxForDate(settleDate);
+    case "ARBETE_OBEKVAM_TID": return arbeteObekvamFtaxForDate(settleDate);
+    default: return timkostnadsnormFtaxForDate(settleDate);
+  }
 }
 
 /**
@@ -248,14 +279,38 @@ function rattshjalpEntryRateOre(kind: "ARBETE" | "TIDSSPILLAN" | null | undefine
  * rådgivningstimmen), tidsspillan på tidsspillan-normen. Övriga metoder: platt
  * `flatRateOre` × alla debiterbara minuter (oförändrat).
  */
-function settlementArvodeNet(method: PaymentMethod, work: UnfrozenWork, settleDate: Date | string, flatRateOre: number): number {
+function settlementArvodeNet(method: PaymentMethod, work: UnfrozenWork, settleDate: Date | string): number {
   const billable = work.timeEntries.filter((t) => t.billable);
-  const billableMin = billable.reduce((s, t) => s + t.minutes, 0);
-  if (method !== "RATTSHJALP") return Math.round((billableMin / 60) * flatRateOre);
-  const tidsMin = billable.filter((t) => t.kind === "TIDSSPILLAN").reduce((s, t) => s + t.minutes, 0);
-  const arbeteMin = coverageBaseMinutes("RATTSHJALP", billableMin - tidsMin); // − rådgivningstimmen
-  return Math.round((arbeteMin / 60) * timkostnadsnormFtaxForDate(settleDate))
-    + Math.round((tidsMin / 60) * tidsspillanFtaxForDate(settleDate));
+  // Varje post värderas på SIN KATEGORIS norm för slutregleringsåret (#949/#950).
+  // Tidigare plattade icke-rättshjälp ut allt till ansvarig jurists timtaxa, vilket
+  // gjorde att sammanställningens taxerader inte summerade till fakturabeloppet.
+  // Alla ärenden använder Domstolsverkets nivåer, så logiken är gemensam.
+  // PRIVAT/offentligt debiterar byråns egen taxa (ligger på posten) — bara
+  // täckningsärenden ersätts enligt Domstolsverkets nivåer (#950).
+  if (method !== "RATTSHJALP" && method !== "RATTSSKYDD") return arvodeNetOre(work);
+  const byKind = minutesByKind(billable);
+  // Rådgivningstimmen carvas ur ARBETE (rättshjälp) — den faktureras klienten separat.
+  byKind.set("ARBETE", coverageBaseMinutes(method, byKind.get("ARBETE") ?? 0));
+  return sumKindValueOre(byKind, settleDate);
+}
+
+/** Debiterbara minuter grupperade per arvodeskategori (#950). */
+function minutesByKind(
+  billable: ReadonlyArray<{ minutes: number; kind?: TimeEntryKind | null | undefined }>,
+): Map<TimeEntryKind, number> {
+  const byKind = new Map<TimeEntryKind, number>();
+  for (const t of billable) {
+    const kind = t.kind ?? "ARBETE";
+    byKind.set(kind, (byKind.get(kind) ?? 0) + t.minutes);
+  }
+  return byKind;
+}
+
+/** Summera kategoriernas minuter på respektive årsnorm (#950). */
+function sumKindValueOre(byKind: ReadonlyMap<TimeEntryKind, number>, settleDate: Date | string): number {
+  let net = 0;
+  for (const [kind, minutes] of byKind) net += timeEntryValueOre(minutes, rattshjalpEntryRateOre(kind, settleDate));
+  return net;
 }
 
 /**
@@ -483,14 +538,30 @@ async function freezeWork(repos: Repositories, matterId: MatterId, billingRunId:
 // så faktura-mallen och demo-generatorn kan bygga samma shape (DRY).
 
 function specTimeLines(
-  method: PaymentMethod, normRateOre: number,
-  entries: ReadonlyArray<{ date: Date | string; description: string; minutes: number; hourlyRate: number; billable: boolean }>,
+  method: PaymentMethod,
+  entries: ReadonlyArray<{ date: Date | string; description: string; minutes: number; hourlyRate: number; billable: boolean; kind?: TimeEntryKind | null | undefined }>,
+  settleDate: Date | string,
 ): SpecTimeLine[] {
   return entries.filter((t) => t.billable).map((t) => ({
     date: t.date, description: t.description, minutes: t.minutes,
-    // Rättshjälp värderas enhetligt på timkostnadsnormen (#839); övriga per post-taxa.
-    amountOre: timeEntryValueOre(t.minutes, method === "RATTSHJALP" ? normRateOre : t.hourlyRate),
+    amountOre: timeEntryValueOre(t.minutes, specLineRateOre(method, t, settleDate)),
   }));
+}
+
+/**
+ * Taxan en spec-rad värderas på (#950). TÄCKNINGSÄRENDEN (rättshjälp/rättsskydd)
+ * ersätts enligt Domstolsverkets nivåer, så varje post värderas på SIN KATEGORIS
+ * norm för slutregleringsåret — samma regel som slutregleringen, vilket gör att
+ * sammanställningens taxerader alltid summerar till fakturabeloppet.
+ *
+ * PRIVAT/offentligt uppdrag debiterar byråns EGEN taxa, som ligger på posten —
+ * en privatklient ska inte faktureras statens norm.
+ */
+function specLineRateOre(
+  method: PaymentMethod, entry: { hourlyRate: number; kind?: TimeEntryKind | null | undefined }, settleDate: Date | string,
+): number {
+  const coverage = method === "RATTSHJALP" || method === "RATTSSKYDD";
+  return coverage ? rattshjalpEntryRateOre(entry.kind, settleDate) : entry.hourlyRate;
 }
 
 function specExpenseLines(
@@ -576,13 +647,11 @@ function buildClientArvodeLines(
 ): SpecTimeLine[] {
   const billable = work.timeEntries.filter((t) => t.billable);
   const entries = method === "RATTSHJALP" ? carveEarliestMinutes(billable, RADGIVNING_MINUTES) : billable;
-  // #891: rättshjälp värderar varje rad på slutregleringsårets norm per kategori
-  // (arbete vs tidsspillan); övriga metoder → den platta raten.
-  const lineRate = (kind: "ARBETE" | "TIDSSPILLAN" | null | undefined): number =>
-    method === "RATTSHJALP" ? rattshjalpEntryRateOre(kind, settleDate) : rateOre;
+  // #891/#950: varje rad värderas på sin KATEGORIS norm för slutregleringsåret —
+  // för alla betalningssätt, så raderna summerar till `totalArvodeNet`.
   const lines: SpecTimeLine[] = entries.map((t) => ({
     date: t.date, description: t.description, minutes: t.minutes,
-    amountOre: timeEntryValueOre(t.minutes, lineRate(t.kind)),
+    amountOre: timeEntryValueOre(t.minutes, rattshjalpEntryRateOre(t.kind, settleDate)),
   }));
   const sum = lines.reduce((s, l) => s + l.amountOre, 0);
   const last = lines[lines.length - 1];
@@ -1040,14 +1109,15 @@ export const billingRunRouter = router({
       if (!invoice) throw new TRPCError({ code: "NOT_FOUND", message: "Fakturan finns inte." });
       const matter = await ctx.repos.matters.getByIdInOrg(input.matterId, ctx.orgId);
       if (!matter) throw new TRPCError({ code: "NOT_FOUND", message: "Ärendet finns inte." });
-      const rateOre = await currentArvodeRateOre(ctx.repos, ctx.orgId, matter);
+      // Taxan hämtas inte längre ur juristen: varje post värderas på sin kategoris
+      // norm för fakturans år (#950), samma regel som slutregleringen använder.
       const [te, ex, deductions] = await Promise.all([
         ctx.repos.timeEntries.listByInvoice(input.invoiceId),
         ctx.repos.expenses.listByInvoice(input.invoiceId),
         fetchSpecDeductions(ctx.repos, ctx.orgId, input.invoiceId),
       ]);
       return buildInvoiceSpecification({
-        timeLines: specTimeLines(matter.paymentMethod, rateOre, te),
+        timeLines: specTimeLines(matter.paymentMethod, te, invoice.invoiceDate ?? new Date()),
         expenseLines: specExpenseLines(ex),
         deductions, payableOre: invoice.amount,
       });
@@ -1166,7 +1236,7 @@ export const billingRunRouter = router({
         // byråns privata timtaxa. Övriga (offentligt uppdrag/taxa): arvode inkl moms
         // + utlägg som tidigare. Brutto matchar kostnadsräkningens PDF (#782).
         const krArvodeNet = matter.paymentMethod === "RATTSHJALP"
-          ? settlementArvodeNet("RATTSHJALP", work, new Date(), 0) // #891: retroaktiv norm
+          ? settlementArvodeNet("RATTSHJALP", work, new Date()) // #891: retroaktiv norm
           : arvodeNetOre(work);
         const grossValue = krGrossOre(work, krArvodeNet);
         const run = await tx.billingRuns.create({
@@ -1249,8 +1319,9 @@ export const billingRunRouter = router({
       const { work } = await resolveSettlementWork(ctx.repos, ctx.orgId, input.matterId);
       const billableMinutes = work.timeEntries.filter((t) => t.billable).reduce((s, t) => s + t.minutes, 0);
       const currentRateOre = await currentArvodeRateOre(ctx.repos, ctx.orgId, matter);
-      const baseMinutes = coverageBaseMinutes(matter.paymentMethod, billableMinutes);
-      const totalOre = Math.round((baseMinutes / 60) * currentRateOre);
+      // Förhandsvisningen måste räkna EXAKT som slutregleringen (#950) — annars
+      // visar dialogen ett annat belopp än den faktura som sedan skapas.
+      const totalOre = settlementArvodeNet(matter.paymentMethod, work, new Date());
       // Utlägg bokas på betalaren i settlement-flödet (coverageInvoiceLines) →
       // måste med i förhandsvisningen (#849). Både netto OCH brutto returneras:
       // utläggen har BLANDADE momssatser (6/12/25 %), så bruttot kan inte räknas
@@ -1263,7 +1334,7 @@ export const billingRunRouter = router({
         clientShareBips: matter.clientShareBips ?? 0,
         ...(input.awardedOre != null ? { awardedOre: input.awardedOre } : {}),
         ...(input.insurerPrutningOre != null ? { insurerPrutningOre: input.insurerPrutningOre } : {}),
-        ...rattsskyddCoverage(matter, work.timeEntries, currentRateOre),
+        ...rattsskyddCoverage(matter, work.timeEntries, new Date()),
       });
       return { ...split, totalOre, expensesNetOre, expensesGrossOre, currentRateOre, billableMinutes };
     }),
@@ -1350,7 +1421,7 @@ export const billingRunRouter = router({
         // #891: rättshjälp räknas om på slutregleringsårets normer (retroaktiv höjning
         // över årsskifte + tidsspillan på egen norm); övriga metoder → platt rate.
         const settleDate = toDateOrNow(input.invoiceDate);
-        const totalArvodeNet = settlementArvodeNet(matter.paymentMethod, work, settleDate, rateOre);
+        const totalArvodeNet = settlementArvodeNet(matter.paymentMethod, work, settleDate);
         // Domstolens beslut avser det kostnadsräkningen YRKADE: arvode + utlägg,
         // inkl moms (#943). Härled nedsättningen som en andel av hela anspråket och
         // skala BÅDE arvodet och utläggsraderna med den — annars klampas nedsättningen
@@ -1363,7 +1434,7 @@ export const billingRunRouter = router({
           method: matter.paymentMethod, totalOre: totalArvodeNet, clientShareBips: matter.clientShareBips ?? 0,
           awardedOre: award.awardedArvodeNetOre,
           insurerPrutningOre: input.insurerPrutningOre ?? null,
-          ...rattsskyddCoverage(matter, work.timeEntries, rateOre),
+          ...rattsskyddCoverage(matter, work.timeEntries, settleDate),
         });
         // #945: går betalarfakturan till domstol debiteras utläggen 25 % oavsett sats.
         const courtPayer = isCourtRecipient(input.payerRecipient);

--- a/src/lib/shared/brottmalstaxa.ts
+++ b/src/lib/shared/brottmalstaxa.ts
@@ -63,8 +63,51 @@ const TIMKOSTNADSNORM_FTAX_BY_YEAR: Readonly<Record<number, number>> = {
  * norm än arvodet — Domstolsverkets tidsspillan-föreskrift, vardag 08–18 (dagtid).
  */
 const TIDSSPILLAN_FTAX_BY_YEAR: Readonly<Record<number, number>> = {
-  2025: 145_000, // 1 450 kr/h (DVFS 2024:15)
-  2026: 148_700, // 1 487 kr/h (DVFS 2025:4)
+  2025: 145_000, // 1 450 kr/h (DVFS 2024:15 § 4)
+  2026: 148_700, // 1 487 kr/h (DVFS 2025:4 § 4)
+};
+
+/**
+ * Tidsspillan ANNAN TID (F-skatt), öre/tim exkl moms (#950) — all tid utanför
+ * vardag 08–18. Egen, lägre norm än dagtaxan (DVFS 2025:4 § 4).
+ *
+ * OBS: vid helgförhandling och polisförhör utom kontorstid ersätts tidsspillan
+ * ändå med DAGTAXAN, även mellan 22.00 och 07.00 (DVFS 2025:7 § 1, 2025:8 § 3).
+ */
+const TIDSSPILLAN_OVRIG_FTAX_BY_YEAR: Readonly<Record<number, number>> = {
+  2025: 95_100,  //   951 kr/h (DVFS 2024:15 § 4)
+  2026: 97_500,  //   975 kr/h (DVFS 2025:4 § 4)
+};
+
+/**
+ * Arbete på OBEKVÄM TID (F-skatt), öre/tim exkl moms (#950): häktningsförhandling
+ * under helg (DVFS 2025:7 § 1) och polisförhör utanför ordinarie kontorstid
+ * (DVFS 2025:8 § 1) — söndag, allmän helgdag, lördag, midsommar-/jul-/nyårsafton,
+ * samt vardagar 00–07 och 18–24. Samma belopp i båda föreskrifterna.
+ */
+const ARBETE_OBEKVAM_FTAX_BY_YEAR: Readonly<Record<number, number>> = {
+  2025: 317_500, // 3 175 kr/h (DVFS 2024:18 § 1, 2024:19 § 1)
+  2026: 325_600, // 3 256 kr/h (DVFS 2025:7 § 1, 2025:8 § 1)
+};
+
+/**
+ * Advokatberedskap — garantiersättning per DAG (ej per timme), öre exkl moms
+ * (DVFS 2024:20 / 2025:7). Utgår INTE för dag då arvode enligt helg- eller
+ * polisförhörsföreskriften utgår.
+ */
+const ADVOKATBEREDSKAP_FTAX_BY_YEAR: Readonly<Record<number, number>> = {
+  2025: 248_700, // 2 487 kr/dag
+  2026: 255_000, // 2 550 kr/dag
+};
+
+/**
+ * Kvoten för biträde UTAN F-skatt är ÅRSBEROENDE (#950): timkostnadsnormen utan
+ * F-skatt delat med den med F-skatt, för samma år. Tidigare hårdkodades 2026-
+ * kvoten för alla år, vilket gav fel belopp på 2025-arbete.
+ */
+const NO_FTAX_QUOTIENT_BY_YEAR: Readonly<Record<number, { num: number; den: number }>> = {
+  2025: { num: 1207, den: 1586 },
+  2026: { num: 1237, den: 1626 },
 };
 
 /** Året ur ett datum (ISO-sträng eller Date). Ogiltigt → senaste kända året. */
@@ -82,6 +125,33 @@ export function timkostnadsnormFtaxForDate(date: Date | string): number {
 /** Tidsspillan-normen (F-skatt) som gäller ett givet datum (#891). */
 export function tidsspillanFtaxForDate(date: Date | string): number {
   return TIDSSPILLAN_FTAX_BY_YEAR[yearOf(date)] ?? TIDSSPILLAN_FTAX_BY_YEAR[2026] ?? TIMKOSTNADSNORM_FTAX_ORE_PER_H;
+}
+
+/** Tidsspillan ANNAN TID (F-skatt) som gäller ett givet datum (#950). */
+export function tidsspillanOvrigFtaxForDate(date: Date | string): number {
+  return TIDSSPILLAN_OVRIG_FTAX_BY_YEAR[yearOf(date)] ?? TIDSSPILLAN_OVRIG_FTAX_BY_YEAR[2026] ?? 0;
+}
+
+/** Arvode för arbete på OBEKVÄM TID (F-skatt) ett givet datum (#950). */
+export function arbeteObekvamFtaxForDate(date: Date | string): number {
+  return ARBETE_OBEKVAM_FTAX_BY_YEAR[yearOf(date)] ?? ARBETE_OBEKVAM_FTAX_BY_YEAR[2026] ?? 0;
+}
+
+/** Advokatberedskapens garantiersättning per DAG (F-skatt) ett givet datum (#950). */
+export function advokatberedskapFtaxForDate(date: Date | string): number {
+  return ADVOKATBEREDSKAP_FTAX_BY_YEAR[yearOf(date)] ?? ADVOKATBEREDSKAP_FTAX_BY_YEAR[2026] ?? 0;
+}
+
+/** Kvoten utan F-skatt för ett givet datum (#950) — årsberoende. */
+function noFTaxQuotientForDate(date: Date | string): { num: number; den: number } {
+  return NO_FTAX_QUOTIENT_BY_YEAR[yearOf(date)]
+    ?? { num: NO_FTAX_FACTOR_NUMERATOR, den: NO_FTAX_FACTOR_DENOMINATOR };
+}
+
+/** Justera ett belopp för biträde utan F-skatt med det ÅRETS kvot (#950). */
+export function applyNoFTaxFactorForDate(ersattningOre: number, date: Date | string): number {
+  const q = noFTaxQuotientForDate(date);
+  return Math.round((ersattningOre * q.num) / q.den);
 }
 
 /**

--- a/src/lib/shared/kostnadsrakning.ts
+++ b/src/lib/shared/kostnadsrakning.ts
@@ -19,6 +19,7 @@
 
 import { computeBrottmalstaxa, computeTimkostnadsnorm, TIMKOSTNADSNORM_NO_FTAX_ORE_PER_H, timkostnadsnormFtaxForDate, tidsspillanFtaxForDate, type TaxaLevel, type TaxaResult } from "./brottmalstaxa";
 import { RADGIVNING_MINUTES, radgivningTextRad } from "./rattshjalp";
+import type { TimeEntryKind } from "./schemas/billing";
 import { splitVat } from "./vat";
 
 export interface ExpenseInput {
@@ -80,7 +81,7 @@ export interface TimeEntryInput {
   minutes: number;
   billable?: boolean;
   /** ARBETE (default) eller TIDSSPILLAN — värderas på tidsspillan-normen (#891). */
-  kind?: "ARBETE" | "TIDSSPILLAN" | null;
+  kind?: TimeEntryKind | null;
 }
 
 export interface ExpenseLine {

--- a/src/lib/shared/schemas/billing.ts
+++ b/src/lib/shared/schemas/billing.ts
@@ -29,7 +29,19 @@ import {
 
 /** Tidspostens kategori (#891): vanligt arbete vs tidsspillan (restid/väntetid),
  *  som ersätts på en egen, lägre norm i statligt betalda ärenden. */
-export const timeEntryKindSchema = z.enum(["ARBETE", "TIDSSPILLAN"]);
+/**
+ * Arvodeskategori per tidspost (#950). Varje kategori har en EGEN årsnorm hos
+ * Domstolsverket, och slutregleringen värderar posten på kategorins norm för
+ * slutregleringsåret — så retroaktiva höjningar slår igenom (#891).
+ *   ARBETE                — timkostnadsnormen (DVFS 2025:6 § 8)
+ *   ARBETE_OBEKVAM_TID    — helgförhandling / polisförhör utom kontorstid
+ *                           (DVFS 2025:7 § 1, 2025:8 § 1)
+ *   TIDSSPILLAN           — vardag 08–18 (DVFS 2025:4 § 4)
+ *   TIDSSPILLAN_OVRIG_TID — all annan tid, lägre norm (DVFS 2025:4 § 4)
+ */
+export const timeEntryKindSchema = z.enum([
+  "ARBETE", "ARBETE_OBEKVAM_TID", "TIDSSPILLAN", "TIDSSPILLAN_OVRIG_TID",
+]);
 export type TimeEntryKind = z.infer<typeof timeEntryKindSchema>;
 
 /**

--- a/test/unit/lib/rattshjalp-taxor.test.ts
+++ b/test/unit/lib/rattshjalp-taxor.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Arvodeskategoriernas årsnormer (#950) — hämtade ur Domstolsverkets föreskrifter
+ * ("Rättshjälp och taxor" 2025 resp. 2026). Testet låser beloppen så en felaktig
+ * siffra inte kan smyga in, och verifierar att den RETROAKTIVA höjningen fungerar:
+ * ett datum i 2025 slår upp 2025-normen, slutregleringen använder sitt eget år.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import {
+  timkostnadsnormFtaxForDate, tidsspillanFtaxForDate,
+  tidsspillanOvrigFtaxForDate, arbeteObekvamFtaxForDate, advokatberedskapFtaxForDate,
+  applyNoFTaxFactorForDate,
+} from "@/lib/shared/brottmalstaxa";
+
+describe("arvodeskategoriernas årsnormer (#950)", () => {
+  it("2026 (DVFS 2025:4/:6/:7/:8)", () => {
+    expect(timkostnadsnormFtaxForDate("2026-06-01")).toBe(162_600);  // 1 626 kr
+    expect(tidsspillanFtaxForDate("2026-06-01")).toBe(148_700);      // 1 487 kr
+    expect(tidsspillanOvrigFtaxForDate("2026-06-01")).toBe(97_500);  //   975 kr
+    expect(arbeteObekvamFtaxForDate("2026-06-01")).toBe(325_600);    // 3 256 kr
+    expect(advokatberedskapFtaxForDate("2026-06-01")).toBe(255_000); // 2 550 kr/dag
+  });
+
+  it("2025 (DVFS 2024:14/:15/:18/:19/:20)", () => {
+    expect(timkostnadsnormFtaxForDate("2025-06-01")).toBe(158_600);  // 1 586 kr
+    expect(tidsspillanFtaxForDate("2025-06-01")).toBe(145_000);      // 1 450 kr
+    expect(tidsspillanOvrigFtaxForDate("2025-06-01")).toBe(95_100);  //   951 kr
+    expect(arbeteObekvamFtaxForDate("2025-06-01")).toBe(317_500);    // 3 175 kr
+    expect(advokatberedskapFtaxForDate("2025-06-01")).toBe(248_700); // 2 487 kr/dag
+  });
+
+  it("obekväm tid är alltid högre än ordinarie arvode, annan tid alltid lägre än dagtidsspillan", () => {
+    for (const d of ["2025-06-01", "2026-06-01"]) {
+      expect(arbeteObekvamFtaxForDate(d)).toBeGreaterThan(timkostnadsnormFtaxForDate(d));
+      expect(tidsspillanOvrigFtaxForDate(d)).toBeLessThan(tidsspillanFtaxForDate(d));
+      expect(tidsspillanFtaxForDate(d)).toBeLessThan(timkostnadsnormFtaxForDate(d));
+    }
+  });
+
+  it("kvoten utan F-skatt är ÅRSBEROENDE — 1207/1586 (2025) resp. 1237/1626 (2026)", () => {
+    // Normen utan F-skatt = normen med F-skatt × årets kvot.
+    expect(applyNoFTaxFactorForDate(158_600, "2025-06-01")).toBe(120_700); // 1 207 kr
+    expect(applyNoFTaxFactorForDate(162_600, "2026-06-01")).toBe(123_700); // 1 237 kr
+    // Fel år ger fel belopp — det var buggen: 2026-kvoten på 2025-arbete.
+    expect(applyNoFTaxFactorForDate(158_600, "2026-06-01")).not.toBe(120_700);
+  });
+
+  it("okänt år faller tillbaka på senaste kända normen (retroaktiv höjning landar där)", () => {
+    expect(timkostnadsnormFtaxForDate("2099-01-01")).toBe(162_600);
+    expect(arbeteObekvamFtaxForDate("2099-01-01")).toBe(325_600);
+  });
+});

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -408,13 +408,14 @@ describe("billingRun.coverageSplit — prutning/självrisk på aktuellt timarvod
     return appRouter.createCaller(buildContext({ dataStore: ds, ports: noopPorts, principal: PRINCIPAL }) as any);
   }
 
-  it("rättsskydd: värderar på juristens AKTUELLA timtaxa (ej snapshot) + klient tar prutningen", async () => {
-    // 2 tim × aktuell 3000 kr/h = 6000 kr total (INTE snapshot 2000 kr/h = 4000).
+  it("rättsskydd: värderar på timkostnadsnormen (#950) + klient tar prutningen", async () => {
+    // #950: rättsskydd ersätts enligt Domstolsverkets nivåer, inte byråns egen taxa
+    // — 2 tim × 1 626 kr = 325 200 öre (juristens 3 000 kr/h används inte längre).
     const c = caller({ paymentMethod: "RATTSSKYDD", clientShareBips: 2000 }, 300000);
     const r = await c.billingRun.coverageSplit({ matterId: "m-1", insurerPrutningOre: 50000 });
-    expect(r.totalOre).toBe(600000); // 2h × 3000 kr (aktuell taxa)
-    expect(r.clientOre).toBe(120000 + 50000); // självrisk 20 % (120000) + prutning 50000
-    expect(r.payerOre).toBe(600000 - 170000);
+    expect(r.totalOre).toBe(325_200);
+    expect(r.clientOre).toBe(65_040 + 50000); // självrisk 20 % (65 040) + prutning 50 000
+    expect(r.payerOre).toBe(325_200 - 115_040);
     expect(r.firmLossOre).toBe(0);
   });
 
@@ -453,7 +454,7 @@ describe("billingRun.coverageSplit — prutning/självrisk på aktuellt timarvod
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const c = appRouter.createCaller(buildContext({ dataStore: ds, ports: noopPorts, principal: PRINCIPAL }) as any);
     const r = await c.billingRun.coverageSplit({ matterId: "m-1" });
-    expect(r.totalOre).toBe(600000); // arvode 2h × 3000 kr
+    expect(r.totalOre).toBe(325_200); // #950: arvode 2h × timkostnadsnormen 1 626 kr
     expect(r.expensesNetOre).toBe(32065);
     expect(r.expensesGrossOre).toBe(39750); // exakt per sats — INTE 40081 (platt 25 %)
   });
@@ -527,10 +528,11 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
   it("rättsskydd: klient = (självrisk + prutning) inkl moms; försäkring = resten; ingen byrå-förlust", async () => {
     const { caller: c } = caller({ paymentMethod: "RATTSSKYDD", clientShareBips: 2000 }, 300000);
     const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "FORSAKRING", insurerPrutningOre: 50000 });
-    // total 600000; klient netto 170000 → ×1.25 = 212500; försäkring netto 430000 → 537500.
-    expect(res.split).toMatchObject({ clientOre: 170000, payerOre: 430000, firmLossOre: 0 });
-    expect(res.clientInvoice.amount).toBe(212500);
-    expect(res.payerInvoice.amount).toBe(537500);
+    // #950: bas 2 tim × 1 626 = 325 200. Klient = självrisk 20 % (65 040) + prutning
+    // 50 000 = 115 040 → ×1,25 = 143 800; försäkring 210 160 → 262 700.
+    expect(res.split).toMatchObject({ clientOre: 115_040, payerOre: 210_160, firmLossOre: 0 });
+    expect(res.clientInvoice.amount).toBe(143_800);
+    expect(res.payerInvoice.amount).toBe(262_700);
   });
 
   it("rättsskydd flöde B (#905): prutning EFTERÅT → kredit till försäkring + påfyllnadsfaktura till klient", async () => {
@@ -739,11 +741,12 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const c = appRouter.createCaller(buildContext({ dataStore: ds, ports: noopPorts, principal: PRINCIPAL }) as any);
     const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "FORSAKRING" });
-    // 6 tim × 3000 = 1 800 000 total; täckt 4 tim (retro 2 + efter 2) = 1 200 000.
-    // självrisk 20 % × 1 200 000 = 240 000; otäckt (2 tim före tvist) = 600 000.
-    expect(res.split).toMatchObject({ clientOre: 840_000, payerOre: 960_000, firmLossOre: 0 });
-    expect(res.clientInvoice.amount).toBe(1_050_000); // 840 000 × 1,25 moms
-    expect(res.payerInvoice.amount).toBe(1_200_000); // 960 000 × 1,25 moms
+    // #950: allt värderas på timkostnadsnormen. 6 tim × 1 626 = 975 600 total;
+    // täckt 4 tim (retro 2 + efter 2) = 650 400; otäckt (2 tim före tvist) = 325 200.
+    // Självrisk 20 % × 650 400 = 130 080 → klient 455 280, försäkring 520 320.
+    expect(res.split).toMatchObject({ clientOre: 455_280, payerOre: 520_320, firmLossOre: 0 });
+    expect(res.clientInvoice.amount).toBe(569_100); // 455 280 × 1,25 moms
+    expect(res.payerInvoice.amount).toBe(650_400); // 520 320 × 1,25 moms
     expect(res.breakdown.radgivningGrossOre).toBe(0); // #876 — rådgivning gäller bara rättshjälp
   });
 });


### PR DESCRIPTION
## Vad & varför

Grunden för att kunna visa en **komplett sammanställning med alla arvodestyper**. Beloppen är hämtade ur Domstolsverkets föreskrifter, inte ur minnet — jag laddade *Rättshjälp och taxor* för 2025 och 2026 och extraherade dem ur föreskrifterna.

De två kategorier AVA redan hade (timkostnadsnorm 1 586/1 626, tidsspillan 1 450/1 487) stämmer **exakt** mot källan, vilket bekräftar att de nya siffrorna är rätt lästa.

| Kategori | 2025 | 2026 | Föreskrift |
|---|---|---|---|
| `ARBETE` (timkostnadsnorm) | 1 586 | 1 626 | DVFS 2024:14 / 2025:6 § 8 — fanns |
| `TIDSSPILLAN` (vardag 08–18) | 1 450 | 1 487 | DVFS 2024:15 / 2025:4 § 4 — fanns |
| **`TIDSSPILLAN_OVRIG_TID`** | **951** | **975** | DVFS 2024:15 / 2025:4 § 4 |
| **`ARBETE_OBEKVAM_TID`** | **3 175** | **3 256** | DVFS 2024:18–19 / 2025:7–8 § 1 |
| **advokatberedskap** (per **dag**) | **2 487** | **2 550** | DVFS 2024:20 / 2025:7 |

Del av #950. Stänger #949.

## Löser #949 på vägen

`settlementArvodeNet` plattade ut **alla** taxor till ansvarig jurists timtaxa för allt utom rättshjälp, medan specifikationen använde posternas egna. Verifierat före fixen:

```
Ordinarie   2 tim × 2 500 =  5 000
Helg        2 tim × 3 500 =  7 000
Restid      2 tim × 1 250 =  2 500
summa spec-rader             14 500 kr
slutregleringens bas         15 000 kr   ← 6 tim × 2 500
```

Sammanställningens taxerader summerade alltså till ett annat belopp än fakturan. Efter fixen värderas varje post på **sin kategoris norm för slutregleringsåret** — verifierat med alla fyra kategorier plus en 2025-post som retroaktivt värderas om till 2026-normen:

```
 3 256,00/tim ×  2 tim =  6 512,00
 1 626,00/tim ×  5 tim =  8 130,00      (inkl. 2025-posten, omvärderad)
 1 487,00/tim ×  2 tim =  2 974,00
   975,00/tim ×  1 tim =    975,00
summa spec-rader          18 591,00
slutregleringens bas      18 591,00     STÄMMER ✓
```

**Avgränsning:** kategorinormerna gäller **täckningsärenden** (rättshjälp + rättsskydd), som ersätts enligt Domstolsverkets nivåer. `PRIVAT`/offentligt uppdrag debiterar fortsatt byråns **egen** taxa som ligger på posten — en privatklient ska inte faktureras statens norm. Ett befintligt test (`per-post-taxa`) fångade att jag först gick för brett här.

### Två följdfel som måste med

- **`rattsskyddCoverage`** värderade den täckta delen med den *platta* taxan medan basen bytte till kategorinormer → täckt arbete jämfördes mot en bas i en annan taxa, och otäckt/självrisk blev fel. Nu samma valuta.
- **`coverageSplit`-förhandsvisningen** räknade sin egen platta total. Den går nu via `settlementArvodeNet`, så dialogen visar samma belopp som den faktura som sedan skapas.

### Separat bugg: kvoten utan F-skatt var årsoberoende

`NO_FTAX_FACTOR_NUMERATOR/DENOMINATOR` hårdkodade **1237/1626** (2026) för alla år. För 2025 är kvoten **1207/1586**, så biträden utan F-skatt fick fel belopp på 2025-arbete. Kvoten ligger nu i årstabellen (`applyNoFTaxFactorForDate`).

## Typ

- [x] `feat` — ny funktion
- [x] `fix` — buggfix (#949 + F-skattekvoten)
- [ ] `refactor` / `perf`
- [ ] `docs` / `test` / `chore` / `ci`

## Verifierat lokalt (speglar CI)

- [x] `typecheck` + `lint` + `lint:complexity-strict` + `knip` + `deps:check` — rena
- [x] `bun run build:demo` grön; `bun run size` 34,3 % av budget
- [x] `test/unit/server/routers/` + `test/scripts/` + `test/unit/lib/kostnadsrakning/` — **645** gröna
- [x] Nytt `test/unit/lib/rattshjalp-taxor.test.ts` låser alla belopp per år, att obekväm tid alltid är högre än ordinarie och annan-tid alltid lägre än dagtidsspillan, samt att F-skattekvoten är årsberoende (inkl. ett `not.toBe` som fångar just den gamla buggen)
- [x] Fyra befintliga rättsskyddstester uppdaterade till DVFS-normerna, med uträkningen i kommentaren
- [ ] Kända lokala miljöfel (360 s-watchdog #327, katalogkörnings-läckage) — verifierade identiska på orörd `main`. CI avgör.

## Kvalitetsgrindar

- [x] Inga gater lösgjorda
- [x] Ändringen rör belopp på rättsskyddsfakturor — hela vägen (bas, täckt del, förhandsvisning, specifikation) är nu samma valuta, och det är testat

## Övrigt — kvar av #950

1. **Demo-ärende** som använder alla fyra kategorier + utlägg med flera momssatser och som sedan prutas, för både rättshjälp och rättsskydd.
2. **Advokatberedskap** finns som årsnorm men har ingen postmodell än (den är per dag, inte per timme).
3. **Rättsskyddsmodellen:** ingen kreditfaktura till försäkringsbolaget — fakturan är ställd till klienten, så prutningen ska omfördela mellan klientens två fakturor. Väl specificerat, tas härnäst.
4. Reglerna i DVFS 2025:4 som ännu inte modelleras: tidsspillan ersätts bara över 30 min, bara 07–22, måltidspaus räknas inte, och vid helg/polisförhör ersätts tidsspillan med dagtaxan även nattetid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_