### PR TITLE
feat(billing): arvodeskategori går att registrera och benämns på fakturan

### DIFF
--- a/src/app/matters/[id]/_client.tsx
+++ b/src/app/matters/[id]/_client.tsx
@@ -77,7 +77,7 @@ export default function MatterDetailClient({ id: paramId }: { id: string }) {
         <DocumentBrowser matterId={id} />
         <BillingPanel matterId={id} matter={m} />
         <ExpectedReceivablesSection matterId={id} courtCaseNumber={courtCaseOf(m)} isCourtMatter={isCourtMatter(m)} />
-        <TimeSection matterId={id} isTaxeArende={m.isTaxeArende} />
+        <TimeSection matterId={id} isTaxeArende={m.isTaxeArende} paymentMethod={m.paymentMethod} />
         <ExpenseSection matterId={id} isTaxeArende={m.isTaxeArende} />
         <ServiceNotesSection matterId={id} />
       </div>

--- a/src/app/matters/[id]/_time-section.tsx
+++ b/src/app/matters/[id]/_time-section.tsx
@@ -3,13 +3,18 @@
 import { useState } from "react";
 import { DataTable, type Column } from "@/components/ui/data-table";
 import { Modal } from "@/components/ui/modal";
+import { TIME_ENTRY_KIND_SHORT } from "@/lib/client/labels";
 import { trpc } from "@/lib/client/trpc";
 import { formatMinutes } from "@/lib/client/utils";
+import { TIME_ENTRY_KIND_LABELS, type PaymentMethod, type TimeEntryKind } from "@/lib/shared/schemas/enums";
 import type { InvoiceId, MatterId, TimeEntryId } from "@/lib/shared/schemas/ids";
 
 interface Props {
   matterId: MatterId;
   isTaxeArende?: boolean;
+  /** Styr kategori-hjälptexten: rättshjälp/rättsskydd ersätts på Domstolsverkets
+   *  normer per kategori, inte på byråns timpris (#953). */
+  paymentMethod?: PaymentMethod | undefined;
 }
 
 interface EditForm {
@@ -17,6 +22,17 @@ interface EditForm {
   minutes: number;
   description: string;
   billable: boolean;
+  kind: TimeEntryKind;
+}
+
+/** Kategorierna i dropdown-ordning — härledd ur labels-kartan (single source). */
+const KIND_OPTIONS = Object.entries(TIME_ENTRY_KIND_LABELS) as Array<[TimeEntryKind, string]>;
+
+/** Ärenden där kategorin styr vilken ÅRSNORM slutregleringen värderar posten på. */
+const COVERAGE_METHODS = new Set<PaymentMethod>(["RATTSHJALP", "RATTSSKYDD"]);
+
+function isCoverageMethod(method: PaymentMethod | undefined): boolean {
+  return method !== undefined && COVERAGE_METHODS.has(method);
 }
 
 interface TimeEntryRow {
@@ -25,6 +41,7 @@ interface TimeEntryRow {
   minutes: number;
   description: string | null;
   billable: boolean;
+  kind?: TimeEntryKind | null;
   hourlyRate?: number | null;
   user?: { name?: string | null } | null;
   invoiceId?: InvoiceId | null;
@@ -45,15 +62,17 @@ function toEditForm(entry: TimeEntryRow): EditForm {
     minutes: entry.minutes,
     description: entry.description ?? "",
     billable: entry.billable,
+    kind: entry.kind ?? "ARBETE",
   };
 }
 
 function emptyForm(): EditForm {
-  return { date: new Date().toISOString().split("T")[0]!, minutes: 30, description: "", billable: true };
+  return { date: new Date().toISOString().split("T")[0]!, minutes: 30, description: "", billable: true, kind: "ARBETE" };
 }
 
 // eslint-disable-next-line max-lines-per-function -- TODO: refactor (struktur är tabular: kolumndefs + 2 modaler)
-export function TimeSection({ matterId, isTaxeArende }: Props) {
+export function TimeSection({ matterId, isTaxeArende, paymentMethod }: Props) {
+  const isCoverage = isCoverageMethod(paymentMethod);
   const utils = trpc.useUtils();
   const timeEntries = trpc.timeEntry.list.useQuery({ matterId });
   const [showCreate, setShowCreate] = useState(false);
@@ -105,6 +124,10 @@ export function TimeSection({ matterId, isTaxeArende }: Props) {
       render: (e) => <span className="text-sm text-gray-900">{formatMinutes(e.minutes)}</span> },
     { key: "description", label: "Beskrivning", sortable: true, sortValue: (e) => e.description ?? "",
       render: (e) => <span className="text-sm text-gray-700">{e.description}</span> },
+    // Kategorin styr vilken av Domstolsverkets normer posten värderas på vid
+    // slutreglering (#950/#953) — den påverkar beloppet och hör därför i default-vyn.
+    { key: "kind", label: "Kategori", sortable: true, sortValue: (e) => e.kind ?? "ARBETE",
+      render: (e) => <span className="text-sm text-gray-700">{TIME_ENTRY_KIND_SHORT[e.kind ?? "ARBETE"]}</span> },
     { key: "billable", label: "Deb.", sortable: true, sortValue: (e) => (e.billable ? 1 : 0),
       render: (e) => <span className="text-sm">{e.billable ? "Ja" : "Nej"}</span> },
     // Notera: kolumnerna "Fakturerad" + "Faktura" finns INTE här. Rättshjälp/
@@ -167,6 +190,7 @@ export function TimeSection({ matterId, isTaxeArende }: Props) {
           submitLabel={createTimeEntry.isPending ? "Sparar..." : "Spara"}
           isPending={createTimeEntry.isPending}
           isTaxeArende={isTaxeArende}
+          isCoverage={isCoverage}
           onSubmit={() => createTimeEntry.mutate({ ...createForm, matterId })}
           onCancel={() => setShowCreate(false)}
         />
@@ -180,6 +204,7 @@ export function TimeSection({ matterId, isTaxeArende }: Props) {
             submitLabel={updateTimeEntry.isPending ? "Sparar..." : "Spara"}
             isPending={updateTimeEntry.isPending}
             isTaxeArende={isTaxeArende}
+            isCoverage={isCoverage}
             onSubmit={saveEdit}
             onCancel={() => { setEditingId(null); setEditForm(null); }}
           />
@@ -195,11 +220,12 @@ interface FormProps {
   submitLabel: string;
   isPending: boolean;
   isTaxeArende?: boolean | undefined;
+  isCoverage?: boolean | undefined;
   onSubmit: () => void;
   onCancel: () => void;
 }
 
-function TimeForm({ form, setForm, submitLabel, isPending, isTaxeArende, onSubmit, onCancel }: FormProps) {
+function TimeForm({ form, setForm, submitLabel, isPending, isTaxeArende, isCoverage, onSubmit, onCancel }: FormProps) {
   return (
     <form onSubmit={(e) => { e.preventDefault(); onSubmit(); }}>
       {isTaxeArende && (
@@ -229,6 +255,21 @@ function TimeForm({ form, setForm, submitLabel, isPending, isTaxeArende, onSubmi
             placeholder="Beskrivning *"
             onChange={(e) => setForm({ ...form, description: e.target.value })}
             className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm" />
+        </div>
+        <div className="col-span-2">
+          <label htmlFor="time-kind" className="block text-xs text-gray-500 mb-1">Arvodeskategori *</label>
+          <select id="time-kind" value={form.kind}
+            onChange={(e) => setForm({ ...form, kind: e.target.value as TimeEntryKind })}
+            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm">
+            {KIND_OPTIONS.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+          </select>
+          {isCoverage && (
+            <p className="mt-1 text-xs text-gray-500">
+              Kategorin avgör vilken av Domstolsverkets normer posten ersätts på.
+              Hela ärendet räknas om på slutregleringsårets normer, så en taxehöjning
+              slår igenom retroaktivt.
+            </p>
+          )}
         </div>
       </div>
       <div className="mt-3 flex items-center gap-4">

--- a/src/lib/client/kostnadsrakning/faktura-template.ts
+++ b/src/lib/client/kostnadsrakning/faktura-template.ts
@@ -18,8 +18,9 @@
  */
 
 import { formatCurrency } from "@/lib/client/utils";
-import { tidsspillanFtaxForDate, timkostnadsnormFtaxForDate } from "@/lib/shared/brottmalstaxa";
+import { tidsspillanFtaxForDate, tidsspillanOvrigFtaxForDate } from "@/lib/shared/brottmalstaxa";
 import { buildInvoiceSpecification, type InvoiceSpecification } from "@/lib/shared/invoice-specification";
+import { TIME_ENTRY_KIND_LABELS, type TimeEntryKind } from "@/lib/shared/schemas/enums";
 import type { InvoiceId } from "@/lib/shared/schemas/ids";
 import { renderHandlebars } from "./render-handlebars";
 
@@ -40,7 +41,7 @@ export interface FakturaBreakdown {
   rows: BreakdownRow[];
   totalLabel: string;
   totalOre: number;
-  timeLines?: ReadonlyArray<{ date: string | Date; description: string; minutes: number; amountOre: number }> | undefined;
+  timeLines?: ReadonlyArray<{ date: string | Date; description: string; minutes: number; amountOre: number; kind?: TimeEntryKind | null | undefined }> | undefined;
 }
 
 export interface FakturaDocMeta {
@@ -207,7 +208,7 @@ function resolveSpec(a: FakturaTemplateArgs): InvoiceSpecification | null {
 /** Bygg specifikationen ur nedbrytningens arbete, med spec:ens utlägg/avdrag kvar. */
 function specFromCarriedWork(carried: CarriedWork, spec: InvoiceSpecification | null | undefined, payableOre: number): InvoiceSpecification {
   return buildInvoiceSpecification({
-    timeLines: carried.map((l) => ({ date: l.date, description: l.description, minutes: l.minutes, amountOre: l.amountOre })),
+    timeLines: carried.map((l) => ({ date: l.date, description: l.description, minutes: l.minutes, amountOre: l.amountOre, kind: l.kind })),
     expenseLines: spec?.expenseLines ?? [],
     deductions: spec?.deductions ?? [],
     payableOre,
@@ -215,35 +216,49 @@ function specFromCarriedWork(carried: CarriedWork, spec: InvoiceSpecification | 
 }
 
 /**
- * Benämning för en taxegrupp (#925): rättshjälpsärenden värderar arbete på
- * timkostnadsnormen och restid/väntetid på den lägre tidsspillan-normen — känns
- * igen genom att jämföra taxan mot ÅRETS normer (posten bär sitt datum, så
- * ärenden över ett årsskifte får rätt benämning per period). Övriga ärenden
- * debiterar byråns timtaxa → "Arvode".
+ * Benämning för en taxegrupp (#925/#953). Bär raden sin ARVODESKATEGORI används
+ * den — det är den enda uppgift som faktiskt avgör vilken norm posten ersätts på.
+ * Att gissa ur timtaxan räcker inte: efter en retroaktiv höjning värderas posten
+ * på slutregleringsårets norm men bär sitt eget datum, och två tidsspillan-normer
+ * kan inte skiljas från arvodet på beloppet.
+ *
+ * Äldre fakturor (persisterade före #953) saknar kategorin. För dem räddas de två
+ * tidsspillan-normerna ur taxan — resten är arvode.
  */
-function rateGroupLabel(rateOre: number, date: Date | string): string {
-  if (rateOre === tidsspillanFtaxForDate(date)) return "Tidsspillan";
-  if (rateOre === timkostnadsnormFtaxForDate(date)) return "Arvode (timkostnadsnorm)";
-  return "Arvode";
+function rateGroupLabel(kind: TimeEntryKind | null | undefined, rateOre: number, date: Date | string): string {
+  if (kind) return TIME_ENTRY_KIND_LABELS[kind];
+  if (rateOre === tidsspillanFtaxForDate(date)) return TIME_ENTRY_KIND_LABELS.TIDSSPILLAN;
+  if (rateOre === tidsspillanOvrigFtaxForDate(date)) return TIME_ENTRY_KIND_LABELS.TIDSSPILLAN_OVRIG_TID;
+  return TIME_ENTRY_KIND_LABELS.ARBETE;
 }
 
-/** Gruppera arvodet på den härledda timtaxan → en rad per unik taxa (fallande). */
+interface RateGroup { minutes: number; amountOre: number; date: Date | string; kind: TimeEntryKind | null | undefined; rateOre: number }
+
+/**
+ * Gruppera arvodet per KATEGORI + timtaxa → en rad per unik kombination. Taxan
+ * ingår i nyckeln så ärenden som debiterar byråns egen taxa (privat) fortfarande
+ * får en rad per taxa när den ändrats under ärendet.
+ */
 function arvodeRateRows(spec: InvoiceSpecification, fc: Fc): FakturaSummaryRow[] {
-  const groups = new Map<number, { minutes: number; amountOre: number; date: Date | string }>();
+  const groups = new Map<string, RateGroup>();
   for (const l of spec.timeLines) {
-    const rate = l.minutes > 0 ? Math.round((l.amountOre * 60) / l.minutes) : 0;
-    const g = groups.get(rate) ?? { minutes: 0, amountOre: 0, date: l.date };
-    groups.set(rate, { minutes: g.minutes + l.minutes, amountOre: g.amountOre + l.amountOre, date: g.date });
+    const rateOre = l.minutes > 0 ? Math.round((l.amountOre * 60) / l.minutes) : 0;
+    const key = `${l.kind ?? ""}|${rateOre}`;
+    const g = groups.get(key) ?? { minutes: 0, amountOre: 0, date: l.date, kind: l.kind, rateOre };
+    groups.set(key, { ...g, minutes: g.minutes + l.minutes, amountOre: g.amountOre + l.amountOre });
   }
-  return [...groups.entries()]
-    .sort((a, b) => b[0] - a[0])
-    .map(([rate, g]) => ({
-      label: rateGroupLabel(rate, g.date),
-      rateLabel: `${fc(rate)}/tim`,
+  return [...groups.values()]
+    .sort((a, b) => KIND_ORDER.indexOf(a.kind ?? "ARBETE") - KIND_ORDER.indexOf(b.kind ?? "ARBETE") || b.rateOre - a.rateOre)
+    .map((g) => ({
+      label: rateGroupLabel(g.kind, g.rateOre, g.date),
+      rateLabel: `${fc(g.rateOre)}/tim`,
       hours: svHours(g.minutes),
       amount: fc(g.amountOre),
     }));
 }
+
+/** Kategori-ordning i sammanställningen: arbete först, tidsspillan sist. */
+const KIND_ORDER = Object.keys(TIME_ENTRY_KIND_LABELS) as TimeEntryKind[];
 
 /**
  * Sammanställningens rader (#925): en rad per timtaxa (arvode exkl moms), följt

--- a/src/lib/client/labels.ts
+++ b/src/lib/client/labels.ts
@@ -28,6 +28,7 @@ import {
   PAYMENT_METHOD_LABELS,
   paymentMethodSchema,
   type PaymentMethod,
+  type TimeEntryKind,
 } from "@/lib/shared/schemas/enums";
 
 // MatterRole/ContactType/PaymentMethod — labels + schema + typ bor i
@@ -125,6 +126,18 @@ export function creditRiskFor(method: PaymentMethod): CreditRisk {
       return "UNKNOWN";
   }
 }
+
+/**
+ * KORT arvodeskategori-etikett för tabellceller (#953). Den fullständiga
+ * (`TIME_ENTRY_KIND_LABELS` i shared/schemas/enums.ts) är formulerad för en
+ * dropdown och blir för bred i en kolumn som upprepas på varje rad.
+ */
+export const TIME_ENTRY_KIND_SHORT: Record<TimeEntryKind, string> = {
+  ARBETE: "Arbete",
+  ARBETE_OBEKVAM_TID: "Obekväm tid",
+  TIDSSPILLAN: "Tidsspillan",
+  TIDSSPILLAN_OVRIG_TID: "Tidsspillan annan tid",
+};
 
 export const CREDIT_RISK_LABELS: Record<CreditRisk, string> = {
   LOW: "Låg",

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -19,10 +19,7 @@ import { z } from "zod";
 import type { VatBreakdownLine } from "@/lib/shared/accounting/semantic-voucher";
 import { assertBillingTransition, type BillingActionType } from "@/lib/shared/billing-flow";
 import { proposedAccontoOre } from "@/lib/shared/billing-proposal";
-import {
-  TIMKOSTNADSNORM_FTAX_ORE_PER_H, timkostnadsnormFtaxForDate, tidsspillanFtaxForDate,
-  tidsspillanOvrigFtaxForDate, arbeteObekvamFtaxForDate,
-} from "@/lib/shared/brottmalstaxa";
+import { TIMKOSTNADSNORM_FTAX_ORE_PER_H, coverageEntryRateOre } from "@/lib/shared/brottmalstaxa";
 import { computeCoverageSplit, partitionRattsskyddMinutes, type CoverageSplit, type RattsskyddClientParts } from "@/lib/shared/coverage-billing";
 import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
 import {
@@ -34,8 +31,8 @@ import { applyKrAction, type KostnadsrakningAction, type KostnadsrakningState, t
 import { ocrFromInvoiceNumber } from "@/lib/shared/ocr-reference";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { RADGIVNING_MINUTES } from "@/lib/shared/rattshjalp";
-import { settlementBreakdownSchema, type BillingRun, type Invoice, type TimeEntryKind } from "@/lib/shared/schemas/billing";
-import { billingRunRecipientSchema, type BillingRunRecipient, type ExpenseKind, type PaymentMethod } from "@/lib/shared/schemas/enums";
+import { settlementBreakdownSchema, type BillingRun, type Invoice } from "@/lib/shared/schemas/billing";
+import { billingRunRecipientSchema, type BillingRunRecipient, type ExpenseKind, type PaymentMethod, type TimeEntryKind } from "@/lib/shared/schemas/enums";
 import {
   matterIdSchema,
   billingRunIdSchema,
@@ -133,7 +130,7 @@ function coveredValueOre(
   for (const t of entries.filter((e) => e.billable)) {
     if (left <= 0) break;
     const take = Math.min(left, t.minutes);
-    value += timeEntryValueOre(take, rattshjalpEntryRateOre(t.kind, settleDate));
+    value += timeEntryValueOre(take, coverageEntryRateOre(t.kind, settleDate));
     left -= take;
   }
   return value;
@@ -260,18 +257,6 @@ function invoiceGrossOre(work: UnfrozenWork): number {
   return arvodeInclVatOre(arvodeNetOre(work)) + expenseGrossOre(work);
 }
 
-/** Timarvodet (öre/tim) för en tidspost vid slutreglering (#891): rättshjälp
- *  värderas retroaktivt på SLUTREGLERINGSÅRETS norm — arbete på timkostnadsnormen,
- *  tidsspillan på den (lägre) tidsspillan-normen. */
-function rattshjalpEntryRateOre(kind: TimeEntryKind | null | undefined, settleDate: Date | string): number {
-  switch (kind) {
-    case "TIDSSPILLAN": return tidsspillanFtaxForDate(settleDate);
-    case "TIDSSPILLAN_OVRIG_TID": return tidsspillanOvrigFtaxForDate(settleDate);
-    case "ARBETE_OBEKVAM_TID": return arbeteObekvamFtaxForDate(settleDate);
-    default: return timkostnadsnormFtaxForDate(settleDate);
-  }
-}
-
 /**
  * Slutregleringens arvode-netto (#891). RÄTTSHJÄLP: räkna om HELA ärendet på
  * SLUTREGLERINGSÅRETS normer — den retroaktiva höjningen över ett årsskifte (arbete
@@ -309,7 +294,7 @@ function minutesByKind(
 /** Summera kategoriernas minuter på respektive årsnorm (#950). */
 function sumKindValueOre(byKind: ReadonlyMap<TimeEntryKind, number>, settleDate: Date | string): number {
   let net = 0;
-  for (const [kind, minutes] of byKind) net += timeEntryValueOre(minutes, rattshjalpEntryRateOre(kind, settleDate));
+  for (const [kind, minutes] of byKind) net += timeEntryValueOre(minutes, coverageEntryRateOre(kind, settleDate));
   return net;
 }
 
@@ -543,7 +528,7 @@ function specTimeLines(
   settleDate: Date | string,
 ): SpecTimeLine[] {
   return entries.filter((t) => t.billable).map((t) => ({
-    date: t.date, description: t.description, minutes: t.minutes,
+    date: t.date, description: t.description, minutes: t.minutes, kind: t.kind,
     amountOre: timeEntryValueOre(t.minutes, specLineRateOre(method, t, settleDate)),
   }));
 }
@@ -561,7 +546,7 @@ function specLineRateOre(
   method: PaymentMethod, entry: { hourlyRate: number; kind?: TimeEntryKind | null | undefined }, settleDate: Date | string,
 ): number {
   const coverage = method === "RATTSHJALP" || method === "RATTSSKYDD";
-  return coverage ? rattshjalpEntryRateOre(entry.kind, settleDate) : entry.hourlyRate;
+  return coverage ? coverageEntryRateOre(entry.kind, settleDate) : entry.hourlyRate;
 }
 
 function specExpenseLines(
@@ -650,8 +635,8 @@ function buildClientArvodeLines(
   // #891/#950: varje rad värderas på sin KATEGORIS norm för slutregleringsåret —
   // för alla betalningssätt, så raderna summerar till `totalArvodeNet`.
   const lines: SpecTimeLine[] = entries.map((t) => ({
-    date: t.date, description: t.description, minutes: t.minutes,
-    amountOre: timeEntryValueOre(t.minutes, rattshjalpEntryRateOre(t.kind, settleDate)),
+    date: t.date, description: t.description, minutes: t.minutes, kind: t.kind,
+    amountOre: timeEntryValueOre(t.minutes, coverageEntryRateOre(t.kind, settleDate)),
   }));
   const sum = lines.reduce((s, l) => s + l.amountOre, 0);
   const last = lines[lines.length - 1];
@@ -718,7 +703,8 @@ async function buildSettlementBreakdown(repos: Repositories, orgId: Organization
 
 const svd = (d: Date | string | null | undefined): string => (d ? new Date(d).toLocaleDateString("sv-SE") : "");
 const toViewLine = (l: SpecTimeLine): SettlementViewLine => ({
-  date: new Date(l.date).toISOString().slice(0, 10), description: l.description, minutes: l.minutes, amountOre: l.amountOre,
+  date: new Date(l.date).toISOString().slice(0, 10), description: l.description, minutes: l.minutes,
+  amountOre: l.amountOre, kind: l.kind,
 });
 
 /**

--- a/src/lib/server/routers/timeEntry.ts
+++ b/src/lib/server/routers/timeEntry.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
-import { timeEntryKindSchema, type TimeEntry } from "@/lib/shared/schemas/billing";
+import { type TimeEntry } from "@/lib/shared/schemas/billing";
+import { timeEntryKindSchema } from "@/lib/shared/schemas/enums";
 import {
   asId,
   matterIdSchema,
@@ -85,6 +86,9 @@ export const timeEntryRouter = router({
         minutes: z.number().min(1).optional(),
         description: z.string().min(1).optional(),
         billable: z.boolean().optional(),
+        /** Arvodeskategori (#953) — styr vilken årsnorm slutregleringen värderar
+         *  posten på. Rättbar i efterhand: kategorin missas lätt vid inmatning. */
+        kind: timeEntryKindSchema.optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -92,11 +96,12 @@ export const timeEntryRouter = router({
       // INNAN update. NOT_FOUND vid mismatch.
       const owned = await ctx.repos.timeEntries.getByIdInOrg(input.id, ctx.orgId);
       if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
-      const { id, date, minutes, description, billable } = input;
+      const { id, date, minutes, description, billable, kind } = input;
       const updated = await ctx.repos.timeEntries.update(id, omitUndefined({
         minutes,
         description,
         billable,
+        kind,
         ...(date ? { date: new Date(date) } : {}),
       }) satisfies Partial<TimeEntry>);
       await emit.timeEntryUpdated(ctx, { id: updated.id, matterId: updated.matterId });

--- a/src/lib/shared/brottmalstaxa.ts
+++ b/src/lib/shared/brottmalstaxa.ts
@@ -27,6 +27,8 @@
  * Vid F-skatt-saknad: belopp × 1237/1626 (timkostnadsnorm utan/med F-skatt).
  */
 
+import type { TimeEntryKind } from "./schemas/enums";
+
 export type TaxaLevel = 1 | 2 | 3 | 4;
 
 /** Maxgräns för när taxan tillämpas (= 3 tim 45 min). */
@@ -140,6 +142,25 @@ export function arbeteObekvamFtaxForDate(date: Date | string): number {
 /** Advokatberedskapens garantiersättning per DAG (F-skatt) ett givet datum (#950). */
 export function advokatberedskapFtaxForDate(date: Date | string): number {
   return ADVOKATBEREDSKAP_FTAX_BY_YEAR[yearOf(date)] ?? ADVOKATBEREDSKAP_FTAX_BY_YEAR[2026] ?? 0;
+}
+
+/**
+ * Normen (öre/tim) en tidspost i ett TÄCKNINGSÄRENDE (rättshjälp/rättsskydd)
+ * ersätts på ett givet datum (#950/#953). Varje arvodeskategori har sin egen
+ * årsnorm; anropas med SLUTREGLERINGSDATUMET vid slutreglering (retroaktiv
+ * höjning) och med postens eget datum när den registreras.
+ *
+ * Delad av slutregleringen (`billingRun`) och demo-simuleringen så att
+ * tidsposternas snapshot-taxa och slutregleringens omvärdering aldrig glider
+ * ifrån varandra.
+ */
+export function coverageEntryRateOre(kind: TimeEntryKind | null | undefined, date: Date | string): number {
+  switch (kind) {
+    case "TIDSSPILLAN": return tidsspillanFtaxForDate(date);
+    case "TIDSSPILLAN_OVRIG_TID": return tidsspillanOvrigFtaxForDate(date);
+    case "ARBETE_OBEKVAM_TID": return arbeteObekvamFtaxForDate(date);
+    default: return timkostnadsnormFtaxForDate(date);
+  }
 }
 
 /** Kvoten utan F-skatt för ett givet datum (#950) — årsberoende. */

--- a/src/lib/shared/invoice-specification.ts
+++ b/src/lib/shared/invoice-specification.ts
@@ -7,9 +7,16 @@
  */
 
 import { arvodeInclVatOre } from "./invoice-calc";
+import type { TimeEntryKind } from "./schemas/enums";
 
 /** En rad i fakturans tidsspecifikation (belopp = timmar × gällande timarvode). */
-export interface SpecTimeLine { date: Date | string; description: string; minutes: number; amountOre: number }
+export interface SpecTimeLine {
+  date: Date | string; description: string; minutes: number; amountOre: number;
+  /** Arvodeskategori (#953) — sammanställningen grupperar och BENÄMNER raderna på
+   *  den. Utan kategorin måste benämningen gissas ur timtaxan, vilket ger "Arvode"
+   *  även för tidsspillan. Saknas på äldre/carried rader → gissning som förr. */
+  kind?: TimeEntryKind | null | undefined;
+}
 /** En rad i utläggsspecifikationen (netto + brutto, exakt per momssats). */
 export interface SpecExpenseLine { date: Date | string; description: string; netOre: number; grossOre: number }
 /** En avdragen (tidigare betald) aconto-faktura. */

--- a/src/lib/shared/kostnadsrakning.ts
+++ b/src/lib/shared/kostnadsrakning.ts
@@ -19,7 +19,7 @@
 
 import { computeBrottmalstaxa, computeTimkostnadsnorm, TIMKOSTNADSNORM_NO_FTAX_ORE_PER_H, timkostnadsnormFtaxForDate, tidsspillanFtaxForDate, type TaxaLevel, type TaxaResult } from "./brottmalstaxa";
 import { RADGIVNING_MINUTES, radgivningTextRad } from "./rattshjalp";
-import type { TimeEntryKind } from "./schemas/billing";
+import type { TimeEntryKind } from "./schemas/enums";
 import { splitVat } from "./vat";
 
 export interface ExpenseInput {

--- a/src/lib/shared/schemas/billing.ts
+++ b/src/lib/shared/schemas/billing.ts
@@ -10,6 +10,7 @@ import {
   invoiceTypeSchema,
   paymentPlanStatusSchema,
   reminderTypeSchema,
+  timeEntryKindSchema,
 } from "./enums";
 import {
   timeEntryIdSchema,
@@ -26,23 +27,6 @@ import {
   matterIdSchema,
   userIdSchema,
 } from "./ids";
-
-/** Tidspostens kategori (#891): vanligt arbete vs tidsspillan (restid/väntetid),
- *  som ersätts på en egen, lägre norm i statligt betalda ärenden. */
-/**
- * Arvodeskategori per tidspost (#950). Varje kategori har en EGEN årsnorm hos
- * Domstolsverket, och slutregleringen värderar posten på kategorins norm för
- * slutregleringsåret — så retroaktiva höjningar slår igenom (#891).
- *   ARBETE                — timkostnadsnormen (DVFS 2025:6 § 8)
- *   ARBETE_OBEKVAM_TID    — helgförhandling / polisförhör utom kontorstid
- *                           (DVFS 2025:7 § 1, 2025:8 § 1)
- *   TIDSSPILLAN           — vardag 08–18 (DVFS 2025:4 § 4)
- *   TIDSSPILLAN_OVRIG_TID — all annan tid, lägre norm (DVFS 2025:4 § 4)
- */
-export const timeEntryKindSchema = z.enum([
-  "ARBETE", "ARBETE_OBEKVAM_TID", "TIDSSPILLAN", "TIDSSPILLAN_OVRIG_TID",
-]);
-export type TimeEntryKind = z.infer<typeof timeEntryKindSchema>;
 
 /**
  * TimeEntry — tidsregistrering på ärende. Lagras i `time-entries/<id>.json`.
@@ -125,6 +109,9 @@ export const settlementBreakdownSchema = z.object({
     description: z.string(),
     minutes: z.number().int(),
     amountOre: z.number().int(),
+    /** Arvodeskategori (#953) — sammanställningen på klientens faktura benämner
+     *  raderna på den (arbete/obekväm tid/tidsspillan). Saknas på äldre fakturor. */
+    kind: timeEntryKindSchema.nullish(),
   })),
   rows: z.array(z.object({
     label: z.string(),

--- a/src/lib/shared/schemas/enums.ts
+++ b/src/lib/shared/schemas/enums.ts
@@ -47,6 +47,30 @@ export const PAYMENT_METHOD_LABELS = {
 export const paymentMethodSchema = enumFromLabels(PAYMENT_METHOD_LABELS);
 export type PaymentMethod = z.infer<typeof paymentMethodSchema>;
 
+// ─── Arvodeskategori (per tidspost) ───────────────────────────────────────
+
+/**
+ * Arvodeskategori per tidspost (#950/#953). Varje kategori har en EGEN årsnorm
+ * hos Domstolsverket, och slutregleringen värderar posten på kategorins norm för
+ * SLUTREGLERINGSÅRET — så en taxehöjning slår igenom retroaktivt (#891).
+ * Kategorierna gäller både rättshjälp och rättsskydd; helgtaxorna är ovanliga
+ * men ingår (DVFS-föreskrifterna i `brottmalstaxa.ts` är källan till beloppen).
+ *
+ *   ARBETE                — timkostnadsnormen (DVFS 2025:6 § 8)
+ *   ARBETE_OBEKVAM_TID    — helgförhandling / polisförhör utom kontorstid
+ *                           (DVFS 2025:7 § 1, 2025:8 § 1)
+ *   TIDSSPILLAN           — vardag 08–18 (DVFS 2025:4 § 4)
+ *   TIDSSPILLAN_OVRIG_TID — all annan tid, lägre norm (DVFS 2025:4 § 4)
+ */
+export const TIME_ENTRY_KIND_LABELS = {
+  ARBETE: "Arvode",
+  ARBETE_OBEKVAM_TID: "Arvode — obekväm tid (helg/kväll/natt)",
+  TIDSSPILLAN: "Tidsspillan — vardag 08–18",
+  TIDSSPILLAN_OVRIG_TID: "Tidsspillan — annan tid",
+} as const satisfies Record<string, string>;
+export const timeEntryKindSchema = enumFromLabels(TIME_ENTRY_KIND_LABELS);
+export type TimeEntryKind = z.infer<typeof timeEntryKindSchema>;
+
 // ─── Invoice status + type ────────────────────────────────────────────────
 
 export const INVOICE_STATUS_LABELS = {

--- a/src/lib/shared/settlement-view.ts
+++ b/src/lib/shared/settlement-view.ts
@@ -6,6 +6,8 @@
  * jsonb). Rena display-siffror i öre — ändrar inga belopp.
  */
 
+import type { TimeEntryKind } from "./schemas/enums";
+
 /** `add` = delbelopp/steg i trappan, `deduct` = avgår (−), `info` = spårbarhets-
  *  rad utan beloppspåverkan (visas i parentes/grått, t.ex. rådgivnings-omnämnandet). */
 export type SettlementRowKind = "add" | "deduct" | "info";
@@ -22,6 +24,9 @@ export interface SettlementViewLine {
   description: string;
   minutes: number;
   amountOre: number;
+  /** Arvodeskategori (#953) — sammanställningen benämner taxeraderna på den, så
+   *  klientens faktura skiljer arbete från tidsspillan. Saknas på äldre vyer. */
+  kind?: TimeEntryKind | null | undefined;
 }
 
 export interface SettlementView {

--- a/test/unit/app/matters/time-section.test.tsx
+++ b/test/unit/app/matters/time-section.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * `TimeSection` — tidsredovisningen i ett ärende. Fokus här är ARVODESKATEGORIN
+ * (#953): den avgör vilken av Domstolsverkets årsnormer posten ersätts på vid
+ * slutregleringen, så den måste både gå att VÄLJA och SYNAS. Utan väljaren kunde
+ * en advokat inte registrera tidsspillan eller obekväm tid alls.
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest-compat";
+import { TimeSection } from "@/app/matters/[id]/_time-section";
+import { asId } from "@/lib/shared/schemas/ids";
+
+const timeQuery = {
+  data: {
+    entries: [
+      { id: "t1", date: "2026-03-01", minutes: 120, description: "Genomgång av handlingar", billable: true, user: { name: "Anna" }, hourlyRate: 162_600 },
+      { id: "t2", date: "2026-03-02", minutes: 90, description: "Restid till sammanträde", billable: true, user: { name: "Anna" }, hourlyRate: 148_700, kind: "TIDSSPILLAN" },
+      { id: "t3", date: "2026-03-07", minutes: 60, description: "Jourärende under helg", billable: true, user: { name: "Anna" }, hourlyRate: 325_600, kind: "ARBETE_OBEKVAM_TID" },
+    ],
+    totalMinutes: 270,
+  } as unknown,
+  isLoading: false,
+};
+const createMutate = vi.fn();
+const updateMutate = vi.fn();
+const noopMut = () => ({ mutate: vi.fn(), isPending: false });
+
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: {
+    useUtils: () => ({ timeEntry: { list: { invalidate: vi.fn() } } }),
+    timeEntry: {
+      list: { useQuery: () => timeQuery },
+      create: { useMutation: () => ({ mutate: createMutate, isPending: false }) },
+      update: { useMutation: () => ({ mutate: updateMutate, isPending: false }) },
+      delete: { useMutation: noopMut },
+    },
+    prefs: {
+      get: { useQuery: () => ({ data: undefined, isLoading: false }) },
+      save: { useMutation: noopMut },
+      clear: { useMutation: noopMut },
+      setOrgDefault: { useMutation: noopMut },
+      clearOrgDefault: { useMutation: noopMut },
+    },
+    user: { current: { useQuery: () => ({ data: { id: "u1", role: "LAWYER" } }) } },
+  },
+}));
+
+const matterId = asId<"MatterId">("m1");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("TimeSection — arvodeskategori (#953)", () => {
+  it("visar kategorin per rad — inte bara för arbete", () => {
+    render(<TimeSection matterId={matterId} />);
+    expect(screen.getByText("Kategori")).toBeInTheDocument();
+    expect(screen.getByText("Tidsspillan")).toBeInTheDocument();
+    expect(screen.getByText("Obekväm tid")).toBeInTheDocument();
+    // Poster utan kind visas som Arbete (default), inte som tomt.
+    expect(screen.getByText("Arbete")).toBeInTheDocument();
+  });
+
+  it("formuläret erbjuder alla fyra kategorierna och skickar den valda", () => {
+    render(<TimeSection matterId={matterId} />);
+    fireEvent.click(screen.getByText("+ Registrera tid"));
+    const select = screen.getByLabelText("Arvodeskategori *");
+    expect(select).toHaveValue("ARBETE"); // default
+    const values = Array.from((select as HTMLSelectElement).options).map((o) => o.value);
+    expect(values).toEqual(["ARBETE", "ARBETE_OBEKVAM_TID", "TIDSSPILLAN", "TIDSSPILLAN_OVRIG_TID"]);
+
+    fireEvent.change(select, { target: { value: "TIDSSPILLAN_OVRIG_TID" } });
+    fireEvent.change(screen.getByPlaceholderText("Beskrivning *"), { target: { value: "Hemresa efter kvällssammanträde" } });
+    fireEvent.click(screen.getByText("Spara"));
+    expect(createMutate).toHaveBeenCalledWith(expect.objectContaining({
+      matterId, kind: "TIDSSPILLAN_OVRIG_TID", description: "Hemresa efter kvällssammanträde",
+    }));
+  });
+
+  it("kategorin är rättbar i efterhand — ändra-formuläret förifylls och skickar kind", () => {
+    render(<TimeSection matterId={matterId} />);
+    fireEvent.click(screen.getAllByText("Ändra")[1]!); // raden med TIDSSPILLAN
+    expect(screen.getByLabelText("Arvodeskategori *")).toHaveValue("TIDSSPILLAN");
+    fireEvent.click(screen.getByText("Spara"));
+    expect(updateMutate).toHaveBeenCalledWith(expect.objectContaining({ id: "t2", kind: "TIDSSPILLAN" }));
+  });
+
+  it("normhjälptexten visas bara för täckningsärenden (rättshjälp/rättsskydd)", () => {
+    const { unmount } = render(<TimeSection matterId={matterId} paymentMethod="PRIVAT" />);
+    fireEvent.click(screen.getByText("+ Registrera tid"));
+    expect(screen.queryByText(/slutregleringsårets normer/)).not.toBeInTheDocument();
+    unmount();
+
+    render(<TimeSection matterId={matterId} paymentMethod="RATTSSKYDD" />);
+    fireEvent.click(screen.getByText("+ Registrera tid"));
+    expect(screen.getByText(/slutregleringsårets normer/)).toBeInTheDocument();
+  });
+});

--- a/test/unit/lib/kostnadsrakning/faktura-template.test.ts
+++ b/test/unit/lib/kostnadsrakning/faktura-template.test.ts
@@ -68,9 +68,10 @@ describe("renderFakturaHtml — sammanställning + specifikation (#937)", () => 
     });
     expect(html).toContain("Tidsspecifikation");
     expect(html).toContain("Restid till sammanträde");
-    // Sammanställningen grupperar på härledd taxa → norm + tidsspillan i 2026.
-    expect(html).toContain("Arvode (timkostnadsnorm)");
-    expect(html).toContain("Tidsspillan");
+    // Äldre rader saknar arvodeskategori (#953) → tidsspillan-normerna räddas ur
+    // taxan, resten benämns arvode. Här: 1 626 = arvode, 1 487 = tidsspillan dagtid.
+    expect(html).toContain("<td>Arvode</td>");
+    expect(html).toContain("Tidsspillan — vardag 08–18");
     expect(html).toContain(`${formatCurrency(148_700)}/tim`);
     // Uppdelningen (klient/betalare) och fakturans faktiska belopp bevaras.
     expect(html).toContain("Klientens självrisk 20 % (exkl moms)");
@@ -98,6 +99,50 @@ describe("renderFakturaHtml — sammanställning + specifikation (#937)", () => 
     expect(html).toContain(formatCurrency(203_250 - 40_650));
     expect(html).toContain("Att betala (inkl moms)");
     expect(html).not.toContain("{{");
+  });
+
+  it("sammanställningen BENÄMNER varje arvodeskategori — inte 'Arvode' fyra gånger (#953)", () => {
+    // Efter en retroaktiv taxehöjning bär raden slutregleringsårets taxa men sitt
+    // eget datum, så benämningen KAN inte gissas ur beloppet — kategorin måste följa
+    // med. Alla fyra kategorierna, var och en på sin 2026-norm.
+    const html = renderFakturaHtml({
+      invoice: invoice(), recipient: "Domstol (kostnadsräkning)", meta: META,
+      spec: spec({
+        timeLines: [
+          { date: "2025-11-25", description: "Genomgång av handlingar", minutes: 240, amountOre: 650_400, kind: "ARBETE" },
+          { date: "2025-12-29", description: "Jourärende under helg", minutes: 120, amountOre: 651_200, kind: "ARBETE_OBEKVAM_TID" },
+          { date: "2025-12-17", description: "Restid till sammanträde", minutes: 180, amountOre: 446_100, kind: "TIDSSPILLAN" },
+          { date: "2026-05-16", description: "Hemresa efter kvällssammanträde", minutes: 90, amountOre: 146_250, kind: "TIDSSPILLAN_OVRIG_TID" },
+        ],
+        totalMinutes: 630, arvodeNetOre: 1_893_950, arvodeVatOre: 473_488, grossOre: 2_367_438, payableOre: 2_367_438,
+      }),
+    });
+    expect(html).toContain("<td>Arvode</td>");
+    expect(html).toContain("Arvode — obekväm tid (helg/kväll/natt)");
+    expect(html).toContain("Tidsspillan — vardag 08–18");
+    expect(html).toContain("Tidsspillan — annan tid");
+    // Varje kategori får sin egen taxa-rad, ingen sammanslagning.
+    expect(html).toContain(`${formatCurrency(325_600)}/tim`);
+    expect(html).toContain(`${formatCurrency(97_500)}/tim`);
+    // Ordningen är kategori-ordningen (arvode först, tidsspillan sist), inte taxan —
+    // annars hamnar helgtaxan (högst) överst.
+    expect(html.indexOf("<td>Arvode</td>")).toBeLessThan(html.indexOf("Tidsspillan — vardag"));
+    expect(html.indexOf("Tidsspillan — vardag")).toBeLessThan(html.indexOf("Tidsspillan — annan"));
+  });
+
+  it("samma kategori på TVÅ taxor (byråns egen taxa ändrad) ger en rad per taxa", () => {
+    const html = renderFakturaHtml({
+      invoice: invoice(), recipient: "Klient AB", meta: META,
+      spec: spec({
+        timeLines: [
+          { date: "2026-01-10", description: "Arbete före höjning", minutes: 60, amountOre: 250_000, kind: "ARBETE" },
+          { date: "2026-06-10", description: "Arbete efter höjning", minutes: 60, amountOre: 280_000, kind: "ARBETE" },
+        ],
+        totalMinutes: 120, arvodeNetOre: 530_000, arvodeVatOre: 132_500, grossOre: 662_500, payableOre: 662_500,
+      }),
+    });
+    expect(html).toContain(`${formatCurrency(250_000)}/tim`);
+    expect(html).toContain(`${formatCurrency(280_000)}/tim`);
   });
 
   it("organisationsuppgifter renderas i foten när de finns", () => {

--- a/test/unit/lib/kostnadsrakning/generate-faktura-from-template.test.ts
+++ b/test/unit/lib/kostnadsrakning/generate-faktura-from-template.test.ts
@@ -130,9 +130,10 @@ describe("generateFakturaFromTemplate", () => {
     expect(html).toContain("Timtaxa");
     expect(html).toContain(`${formatCurrency(162_600)}/tim`); // timkostnadsnorm 2026
     expect(html).toContain(`${formatCurrency(148_700)}/tim`); // tidsspillan 2026 (297 400 / 2 tim)
-    // Benämningarna härleds ur taxan mot årets normer.
-    expect(html).toContain("Arvode (timkostnadsnorm)");
-    expect(html).toContain("Tidsspillan");
+    // Utan arvodeskategori på raden (äldre faktura) räddas tidsspillan-normerna ur
+    // taxan; resten benämns arvode (#953).
+    expect(html).toContain("<td>Arvode</td>");
+    expect(html).toContain("Tidsspillan — vardag 08–18");
     // Ordning i utläggsdelen: utlägg exkl moms → moms → utlägg inkl moms → summa.
     expect(html).toContain("Utlägg exkl moms");
     expect(html).toContain("<td>Moms</td>");

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -794,3 +794,86 @@ describe("billingRun.invoiceSpecification (#856)", () => {
     expect(clientSpec.timeLines).toHaveLength(0); // arbetet ligger på betalar-fakturan
   });
 });
+
+/**
+ * "Vi behöver fakturor med alla typer av arvode så att man kan se en komplett
+ * sammanställning som sedan prutas" (#953). Gäller BÅDA regimerna: rättshjälp
+ * (domstolen prutar, byrån bär) och rättsskydd (bolaget prutar, klienten bär).
+ * Sammanställningens taxerader måste summera EXAKT till slutregleringens bas —
+ * annars går fakturan inte att stämma av mot underlaget.
+ */
+describe("slutreglering med ALLA arvodeskategorier (#953)", () => {
+  // 2026 års normer (DVFS 2025:4/6/7): arbete 1 626, obekväm 3 256,
+  // tidsspillan dagtid 1 487, tidsspillan annan tid 975 kr/tim.
+  const ALLA_KATEGORIER = [
+    { id: "te-1", minutes: 240, description: "Genomgång av handlingar", kind: undefined, expectOre: 650_400 },
+    { id: "te-2", minutes: 120, description: "Jourärende under helg", kind: "ARBETE_OBEKVAM_TID", expectOre: 651_200 },
+    { id: "te-3", minutes: 180, description: "Restid till sammanträde", kind: "TIDSSPILLAN", expectOre: 446_100 },
+    { id: "te-4", minutes: 90, description: "Hemresa efter kvällssammanträde", kind: "TIDSSPILLAN_OVRIG_TID", expectOre: 146_250 },
+  ] as const;
+
+  function coverageCaller(paymentMethod: "RATTSHJALP" | "RATTSSKYDD") {
+    const ds = new DemoDataStore({
+      organizations: [{ id: "org-1", name: "X" }],
+      matters: [{ id: "m-1", organizationId: "org-1", matterNumber: "2026-0001", title: "T", status: "ACTIVE", responsibleLawyerId: "u-1", paymentMethod, clientShareBips: 2000, taxaHasFTax: true, createdAt: new Date("2026-05-01") }],
+      users: [{ id: "u-1", organizationId: "org-1", email: "a@x", name: "Anna", role: "ADMIN", hourlyRate: 999_999 }],
+      timeEntries: ALLA_KATEGORIER.map((t) => ({
+        id: t.id, organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date("2026-05-02"),
+        minutes: t.minutes, description: t.description, hourlyRate: 200_000, billable: true,
+        ...(t.kind ? { kind: t.kind } : {}),
+      })),
+      // Utlägg med olika momssatser → sammanställningen visar netto + brutto per sats.
+      expenses: [
+        { id: "ex-1", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date("2026-05-02"), amount: 90_000, description: "Ansökningsavgift", billable: true, vatRate: 0, vatIncluded: false, kind: "EXPENSE" },
+        { id: "ex-2", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date("2026-05-03"), amount: 42_000, description: "Tågresa", billable: true, vatRate: 600, vatIncluded: false, kind: "EXPENSE" },
+        { id: "ex-3", organizationId: "org-1", userId: "u-1", matterId: "m-1", date: new Date("2026-05-04"), amount: 25_000, description: "Kopiering", billable: true, vatRate: 2500, vatIncluded: false, kind: "EXPENSE" },
+      ],
+    }, async () => {});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return appRouter.createCaller(buildContext({ dataStore: ds, ports: noopPorts, principal: PRINCIPAL }) as any);
+  }
+
+  it.each(["RATTSHJALP", "RATTSSKYDD"] as const)(
+    "%s: varje kategori får SIN årsnorm och raderna summerar till fakturans arvode",
+    async (method) => {
+      const c = coverageCaller(method);
+      const payer = method === "RATTSHJALP" ? "DOMSTOL" : "FORSAKRING";
+      const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: payer, invoiceDate: "2026-05-20" });
+      const spec = await c.billingRun.invoiceSpecification({ matterId: "m-1", invoiceId: res.payerInvoice.id });
+
+      // Alla fyra kategorierna är med, var och en på sin egen norm.
+      expect(spec.timeLines).toHaveLength(4);
+      for (const t of ALLA_KATEGORIER) {
+        const line = spec.timeLines.find((l) => l.description === t.description);
+        expect(line, t.description).toBeDefined();
+        expect(line!.amountOre, t.description).toBe(t.expectOre);
+      }
+      // Utläggen bär sina egna satser i specifikationen (momsen mot domstol
+      // flattas först på FAKTURAN, #945 — specifikationen visar underlaget).
+      expect(spec.expenseLines.map((l) => l.netOre).sort((a, b) => a - b)).toEqual([25_000, 42_000, 90_000]);
+
+      // Sammanställningen ska gå att stämma av: taxeraderna summerar till
+      // slutregleringens bas. Enda tillåtna differensen är rådgivningstimmen, som
+      // rättshjälpen carvar ur basen men fortfarande specificerar (#860).
+      const radSumma = spec.timeLines.reduce((s, l) => s + l.amountOre, 0);
+      expect(radSumma).toBe(650_400 + 651_200 + 446_100 + 146_250);
+      expect(res.breakdown.arvodeBaseNetOre).toBe(radSumma - res.breakdown.radgivningNetOre);
+      if (method === "RATTSSKYDD") expect(res.breakdown.radgivningNetOre).toBe(0); // ingen carve
+      else expect(res.breakdown.radgivningNetOre).toBe(162_600); // 1 tim på 2026 års norm
+    },
+  );
+
+  it("rättshjälp: prutningen räknas på HELA underlaget — alla kategorier + utlägg", async () => {
+    const c = coverageCaller("RATTSHJALP");
+    const kr = await c.billingRun.createKostnadsrakning({ matterId: "m-1" });
+    // Domstolen sätter ned till 80 % av det yrkade (arvode + utlägg, inkl moms).
+    const awardedOre = Math.round(kr.run.workValueOreAtRun * 0.8);
+    await c.billingRun.recordKostnadsrakningBeslut({ billingRunId: kr.run.id, awardedOre });
+    const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "DOMSTOL", invoiceDate: "2026-05-20" });
+    // Nedsättningen bärs av byrån (rättshjälp) och syns som en förlust — inte
+    // som ett tystnande av prutningen (#943).
+    expect(res.split.firmLossOre).toBeGreaterThan(0);
+    // Klientens avgift räknas på det NEDSATTA beloppet, inte på det yrkade.
+    expect(res.split.clientOre).toBeLessThan(Math.round(1_893_950 * 0.2));
+  });
+});

--- a/test/unit/server/routers/timeEntry.test.ts
+++ b/test/unit/server/routers/timeEntry.test.ts
@@ -143,6 +143,52 @@ describe("timeEntry.update", () => {
   });
 });
 
+/**
+ * Arvodeskategorin (#953) styr vilken av Domstolsverkets årsnormer
+ * slutregleringen värderar posten på. `create` har tagit emot den sedan #891,
+ * men `update` gjorde det inte — en post som registrerats i fel kategori (restid
+ * som arbete) kunde alltså aldrig rättas, och beloppet blev fel.
+ */
+describe("timeEntry — arvodeskategori (#953)", () => {
+  it("create sparar kategorin; utan kategori sätts inget fält (= ARBETE)", async () => {
+    mockPrisma.user.findFirst.mockResolvedValue({ hourlyRate: 3000 });
+    mockPrisma.timeEntry.create.mockResolvedValue({});
+    await makeCaller().create({
+      matterId: "m1", date: "2026-03-07", minutes: 60,
+      description: "Jourärende under helg", kind: "ARBETE_OBEKVAM_TID",
+    });
+    expect(mockPrisma.timeEntry.create.mock.calls[0]![0].data.kind).toBe("ARBETE_OBEKVAM_TID");
+
+    mockPrisma.timeEntry.create.mockClear();
+    await makeCaller().create({ matterId: "m1", date: "2026-03-08", minutes: 60, description: "Genomgång" });
+    expect(mockPrisma.timeEntry.create.mock.calls[0]![0].data.kind).toBeUndefined();
+  });
+
+  it("update rättar kategorin i efterhand (restid registrerad som arbete)", async () => {
+    mockPrisma.timeEntry.update.mockResolvedValue({});
+    await makeCaller().update({ id: "t1", kind: "TIDSSPILLAN" });
+    const data = mockPrisma.timeEntry.update.mock.calls[0]![0].data;
+    expect(data.kind).toBe("TIDSSPILLAN");
+    // Bara kategorin ändras — övriga fält lämnas orörda.
+    expect(data.minutes).toBeUndefined();
+    expect(data.description).toBeUndefined();
+  });
+
+  it("update utan kind rör INTE en redan satt kategori", async () => {
+    mockPrisma.timeEntry.update.mockResolvedValue({});
+    await makeCaller().update({ id: "t1", minutes: 120 });
+    expect(mockPrisma.timeEntry.update.mock.calls[0]![0].data.kind).toBeUndefined();
+  });
+
+  it("okänd kategori avvisas av schemat — inget skrivs", async () => {
+    await expect(makeCaller().update({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- avsiktligt ogiltigt värde
+      id: "t1", kind: "HELGARVODE" as any,
+    })).rejects.toThrow();
+    expect(mockPrisma.timeEntry.update).not.toHaveBeenCalled();
+  });
+});
+
 describe("timeEntry.delete", () => {
   it("tar bort entry", async () => {
     mockPrisma.timeEntry.delete.mockResolvedValue({});

--- a/tooling/demo-generator/simulate/events.ts
+++ b/tooling/demo-generator/simulate/events.ts
@@ -4,14 +4,15 @@
  * beror på ackumulerat arbete (aconto, slutreglering) HÄRLEDS i runnern, inte här.
  */
 
-import type { MatterRole } from "@/lib/shared/schemas/enums";
+import type { MatterRole, TimeEntryKind } from "@/lib/shared/schemas/enums";
 
 export type SimEvent =
   /** Länka en part (motpart/ombud/domstol) till ärendet — matter.addContact. */
   | { kind: "party"; dayOffset: number; contactId: string; role: MatterRole }
-  /** Debiterbar (eller ej) tidspost — timeEntry.create. `entryKind` = ARBETE (default)
-   *  eller TIDSSPILLAN (#891, egen norm vid rättshjälps-slutreglering). */
-  | { kind: "time"; dayOffset: number; minutes: number; description: string; billable?: boolean; entryKind?: "ARBETE" | "TIDSSPILLAN" }
+  /** Debiterbar (eller ej) tidspost — timeEntry.create. `entryKind` = arvodeskategori
+   *  (default ARBETE); varje kategori har en egen årsnorm vid slutregleringen av
+   *  rättshjälp/rättsskydd (#950/#953). */
+  | { kind: "time"; dayOffset: number; minutes: number; description: string; billable?: boolean; entryKind?: TimeEntryKind }
   /** Tjänsteanteckning (händelselogg) — serviceNote.create. */
   | { kind: "note"; dayOffset: number; text: string }
   /** Utlägg — expense.create. */

--- a/tooling/demo-generator/simulate/runner.ts
+++ b/tooling/demo-generator/simulate/runner.ts
@@ -5,7 +5,7 @@
  * arbete (aconto) härleds här ur `state`; dokumentbytes skrivs via `BinarySink`.
  */
 
-import { timkostnadsnormFtaxForDate, tidsspillanFtaxForDate } from "@/lib/shared/brottmalstaxa";
+import { coverageEntryRateOre } from "@/lib/shared/brottmalstaxa";
 import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
 import { SJALVRISK_ACCONTO_THRESHOLD_ORE } from "@/lib/shared/rattshjalp";
 import type { SettlementViewLine } from "@/lib/shared/settlement-view";
@@ -43,13 +43,13 @@ async function hParty(ctx: RunCtx, m: SimMatter, e: Any, iso: string): Promise<v
   await ctx.c.matter.addContact({ matterId: m.id, contactId: e.contactId, role: e.role, createdAt: iso });
 }
 
-/** Timarvodet (öre/tim) en tidspost värderas på i simuleringen. Rättshjälp: den
- *  norm som gällde postens DATUM (#891) — arbete på timkostnadsnormen, tidsspillan
- *  på tidsspillan-normen → 2025-poster får 2025-taxan, 2026-poster 2026-taxan, så
- *  aconton speglar tidpunkten och slutregleringens retroaktiva höjning syns. */
+/** Timarvodet (öre/tim) en tidspost värderas på i simuleringen. Täckningsärenden
+ *  (rättshjälp OCH rättsskydd, #953) värderas på KATEGORINS norm för postens eget
+ *  DATUM → 2025-poster får 2025-taxan, 2026-poster 2026-taxan, så aconton speglar
+ *  tidpunkten och slutregleringens retroaktiva höjning blir synlig som en skillnad. */
 function simTimeRateOre(m: SimMatter, e: Any, iso: string): number {
-  if (m.paymentMethod !== "RATTSHJALP") return m.arvodeRateOre;
-  return e.entryKind === "TIDSSPILLAN" ? tidsspillanFtaxForDate(iso) : timkostnadsnormFtaxForDate(iso);
+  if (m.paymentMethod !== "RATTSHJALP" && m.paymentMethod !== "RATTSSKYDD") return m.arvodeRateOre;
+  return coverageEntryRateOre(e.entryKind, iso);
 }
 
 async function hTime(ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimState): Promise<void> {
@@ -63,7 +63,7 @@ async function hTime(ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimStat
   if (isBillable(e)) {
     const amountOre = Math.round((e.minutes / 60) * rateOre);
     st.accruedNetOre += amountOre;
-    st.periodLines.push({ date: iso.slice(0, 10), description: e.description, minutes: e.minutes, amountOre });
+    st.periodLines.push({ date: iso.slice(0, 10), description: e.description, minutes: e.minutes, amountOre, kind: e.entryKind });
     await maybeAcconto(ctx, m, iso, st); // #885: skicka aconto när klientens andel nått tröskeln
   }
 }

--- a/tooling/demo-generator/simulate/scenarios/rattshjalp-arsskifte.ts
+++ b/tooling/demo-generator/simulate/scenarios/rattshjalp-arsskifte.ts
@@ -35,13 +35,21 @@ export function buildRattshjalpArsskifteScenario(parties: Parties): SimEvent[] {
     // Rättshjälp beviljas med 5 % avgift (arbetslös). Myndighetens beslut som dokument (#901).
     { kind: "doc", dayOffset: 10, template: "beslutRattshjalpAvgift5" },
     { kind: "note", dayOffset: 10, text: "Rättshjälp beviljad — rättshjälpsavgift 5 %." },
-    { kind: "expense", dayOffset: 8, amountOre: 90_000, description: "Ansökningsavgift tingsrätten" },
+    // Utlägg med OLIKA momssatser (#953) så sammanställningens utläggsrader visar
+    // både netto och brutto per sats — ansökningsavgiften är momsfri.
+    { kind: "expense", dayOffset: 8, amountOre: 90_000, description: "Ansökningsavgift tingsrätten", vatRate: 0 },
     // ── Period 1: arbetslös 5 %, HELA i 2025 (norm 1 586 / tidsspillan 1 450) ──
     { kind: "time", dayOffset: 6, minutes: 240, description: "Genomgång av handlingar och underlag" },
     { kind: "doc", dayOffset: 14, template: "svaromal" },
     { kind: "note", dayOffset: 14, text: "Svaromål inkommet från motpartsombudet." },
     { kind: "time", dayOffset: 16, minutes: 240, description: "Analys av svaromål och förhandlingsförberedelse" },
+    { kind: "expense", dayOffset: 27, amountOre: 42_000, description: "Tågresa till sammanträde i Göteborg", vatRate: 600 },
+    { kind: "expense", dayOffset: 27, amountOre: 78_000, description: "Hotellnatt före sammanträdet", vatRate: 1200 },
     { kind: "time", dayOffset: 28, minutes: 180, description: "Restid och väntetid — sammanträde i Göteborg", entryKind: "TIDSSPILLAN" },
+    // Helgtaxan är ovanlig men ingår i rättshjälpen (DVFS 2025:7 § 1) — akut
+    // umgängesfråga via socialjouren en lördag.
+    { kind: "note", dayOffset: 40, text: "Socialjouren larmar om akut umgängesfråga — kontakt och yttrande under lördagen." },
+    { kind: "time", dayOffset: 40, minutes: 120, description: "Jourärende under helg — akut umgängesfråga via socialjouren", entryKind: "ARBETE_OBEKVAM_TID" },
     { kind: "time", dayOffset: 35, minutes: 240, description: "Utkast till inlaga och yttrande" },
     { kind: "doc", dayOffset: 36, template: "inlaga" },
     { kind: "time", dayOffset: 45, minutes: 240, description: "Korrespondens med motpartsombud" },
@@ -58,6 +66,8 @@ export function buildRattshjalpArsskifteScenario(parties: Parties): SimEvent[] {
     // ── Period 3: arbetslös 5 %, 2026 ──
     { kind: "time", dayOffset: 160, minutes: 240, description: "Uppföljning efter sammanträde" },
     { kind: "time", dayOffset: 175, minutes: 120, description: "Restid — möte med klient och socialtjänst", entryKind: "TIDSSPILLAN" },
+    { kind: "time", dayOffset: 178, minutes: 90, description: "Hemresa efter kvällssammanträde", entryKind: "TIDSSPILLAN_OVRIG_TID" },
+    { kind: "expense", dayOffset: 180, amountOre: 25_000, description: "Kopiering och porto", vatRate: 2500 },
     { kind: "time", dayOffset: 185, minutes: 240, description: "Komplettering och inlaga" },
     { kind: "time", dayOffset: 200, minutes: 240, description: "Korrespondens och bevisgenomgång" },
     { kind: "time", dayOffset: 215, minutes: 240, description: "Förberedelse inför slutförhandling" },

--- a/tooling/demo-generator/simulate/scenarios/rattsskydd-positivt.ts
+++ b/tooling/demo-generator/simulate/scenarios/rattsskydd-positivt.ts
@@ -10,9 +10,10 @@
  *      slutliga självrisk (minus betalda aconton).
  *   4. Försäkringen PRUTAR efteråt → klienten bär mellanskillnaden (#905, flöde B).
  *
- * SKILLNAD mot rättshjälp: prutningen bärs av KLIENTEN (inte byrån). Rättsskydd
- * värderas på juristens timtaxa (ej timkostnadsnormen), så ingen retroaktiv taxa-
- * höjning över årsskiftet — men fakturorna får korrekta datum ur sina event (#907).
+ * SKILLNAD mot rättshjälp: prutningen bärs av KLIENTEN (inte byrån). Arvodet
+ * värderas på samma rättshjälpstaxenivåer som rättshjälpen (#950/#953) — alla fyra
+ * arvodeskategorierna förekommer här, och årsskiftet ger en RETROAKTIV höjning:
+ * 2025-timmarna räknas om på 2026 års normer vid slutregleringen.
  */
 
 import type { Parties, SimEvent } from "../events";
@@ -32,11 +33,15 @@ export function buildRattsskyddPositivtScenario(parties: Parties): SimEvent[] {
   ev.push(
     { kind: "doc", dayOffset: 10, template: "rattsskyddBeslutPositivt" },
     { kind: "note", dayOffset: 10, text: "Rättsskydd beviljat: högst 100 tim arvode, självrisk 20 % dock lägst 1 800 kr." },
-    { kind: "expense", dayOffset: 14, amountOre: 90_000, description: "Ansökningsavgift tingsrätten" },
+    // Utlägg med olika momssatser (#953) — sammanställningen visar utläggen både
+    // exkl och inkl moms per sats. Ansökningsavgiften är momsfri.
+    { kind: "expense", dayOffset: 14, amountOre: 90_000, description: "Ansökningsavgift tingsrätten", vatRate: 0 },
     // ── Löpande arbete 2025 → aconto på självrisken (klienten) ──
     { kind: "time", dayOffset: 15, minutes: 240, description: "Skriftväxling och kravbrev till motpart" },
     { kind: "doc", dayOffset: 18, template: "brevTillOmbud" },
+    { kind: "expense", dayOffset: 29, amountOre: 36_000, description: "Tågresa till sammanträde", vatRate: 600 },
     { kind: "time", dayOffset: 30, minutes: 240, description: "Förhandlingsförberedelse och bevisgenomgång" },
+    { kind: "time", dayOffset: 31, minutes: 150, description: "Restid och väntetid vid sammanträdet", entryKind: "TIDSSPILLAN" },
     { kind: "time", dayOffset: 45, minutes: 240, description: "Utredning av vårdnadsfrågan" },
     { kind: "acconto", dayOffset: 50, clientShareBips: 2000 }, // aconto #1 självrisk (dec 2025)
     // ── Årsskiftet passeras (~dag 60) ──
@@ -46,7 +51,12 @@ export function buildRattsskyddPositivtScenario(parties: Parties): SimEvent[] {
     { kind: "acconto", dayOffset: 125, clientShareBips: 2000 }, // aconto #2 självrisk (mars 2026)
     // ── Slutskede — arbete som INTE hunnit acconteras (blir kvar på slutfakturan) ──
     { kind: "time", dayOffset: 160, minutes: 240, description: "Förberedelse inför slutförhandling" },
+    // Helgtaxan är ovanlig men gäller även i rättsskydd (DVFS 2025:7 § 1).
+    { kind: "time", dayOffset: 168, minutes: 90, description: "Akut hantering av interimistiskt yrkande under helg", entryKind: "ARBETE_OBEKVAM_TID" },
+    { kind: "expense", dayOffset: 189, amountOre: 64_000, description: "Hotellnatt före slutförhandlingen", vatRate: 1200 },
     { kind: "time", dayOffset: 190, minutes: 240, description: "Slutförhandling och överenskommelse" },
+    { kind: "time", dayOffset: 190, minutes: 120, description: "Hemresa efter slutförhandlingen (kväll)", entryKind: "TIDSSPILLAN_OVRIG_TID" },
+    { kind: "expense", dayOffset: 195, amountOre: 18_000, description: "Kopiering och porto", vatRate: 2500 },
     { kind: "note", dayOffset: 200, text: "Förlikning nådd — tvisten avslutas." },
     // ── Slutreglering mot försäkringen: försäkringsfaktura + klientens slutliga självrisk ──
     { kind: "settle", dayOffset: 230, payerRecipient: "FORSAKRING" },


### PR DESCRIPTION
Closes #953. Del av #950.

## Problem

#951 gav domänen alla fyra arvodeskategorier med egen årsnorm och retroaktiv höjning. De gick ändå inte att **använda**:

1. Formuläret i `_time-section.tsx` satte aldrig `kind`, och `timeEntry.update` tog inte emot det → en advokat kunde inte registrera tidsspillan eller obekväm tid alls, och en post i fel kategori kunde aldrig rättas.
2. Sammanställningen **gissade benämningen ur timtaxan**. Efter en retroaktiv höjning värderas posten på slutregleringsårets norm men bär sitt eget datum, så gissningen kunde aldrig bli rätt — resultatet var fyra rader som alla hette "Arvode" på olika taxor:

```
Arvode | 3 256,00 kr/tim | 2   | 6 512,00 kr
Arvode | 1 626,00 kr/tim | 43,5| 70 731,00 kr
Arvode | 1 487,00 kr/tim | 5   | 7 435,00 kr
Arvode |   975,00 kr/tim | 1,5 | 1 462,50 kr
```

3. Demon nådde bara två av fyra kategorier (`entryKind` var typad `"ARBETE" | "TIDSSPILLAN"`), värderade rättsskydd på juristens timtaxa i stället för rättshjälpstaxenivåerna, och hade bara en momssats på utläggen.

## Ändringar

**Kategorin blir registrerbar**
- `TIME_ENTRY_KIND_LABELS` i `schemas/enums.ts` blir single source via `enumFromLabels`; `timeEntryKindSchema` flyttas dit och importörerna pekas om.
- Kategori-väljare i tidsformuläret + `Kategori`-kolumn i tidslistan. Normhjälptext visas för rättshjälp/rättsskydd.
- `timeEntry.update` tar emot `kind`.

**Kategorin följer med till fakturan**
- `SpecTimeLine`, `SettlementViewLine` (persisterad) och `FakturaBreakdown.timeLines` bär kategorin, så sammanställningen benämner raderna i stället för att gissa. Äldre fakturor utan kategori räddar de två tidsspillan-normerna ur taxan som förr.
- `coverageEntryRateOre` hoistas till `brottmalstaxa.ts` och delas av slutregleringen och demo-simuleringen (var duplicerad).

**Demon visar hela bilden**
- `entryKind` typas som `TimeEntryKind`; rättsskydd värderas på samma rättshjälpstaxenivåer som rättshjälpen.
- `rattshjalp-arsskifte` och `rattsskydd-positivt` får alla fyra kategorierna och utlägg med 0/6/12/25 % moms.

## Resultat

Domstolsfakturan (ärende 2026-0020) efter ändringen:

```
Arvode                                  | 1 626,00 kr/tim | 43,5 | 70 731,00 kr
Arvode — obekväm tid (helg/kväll/natt)  | 3 256,00 kr/tim | 2    |  6 512,00 kr
Tidsspillan — vardag 08–18              | 1 487,00 kr/tim | 5    |  7 435,00 kr
Tidsspillan — annan tid                 |   975,00 kr/tim | 1,5  |  1 462,50 kr
Utlägg exkl moms                        |                 |      |  2 350,00 kr
Moms                                    |                 |      | 21 716,43 kr
Utlägg inkl moms                        |                 |      |  2 531,30 kr
Summa (inkl moms)                       |                 |      |110 206,93 kr
```

Samma benämnda rader på klientfakturan, försäkringsfakturan och aconton. Aconton i samma ärenden står på **2025**-taxorna (1 586 / 1 450 / 3 175) och slutfakturorna på **2026** (1 626 / 1 487 / 3 256 / 975) — den retroaktiva höjningen syns som skillnaden.

## Verifiering

- `typecheck`, `lint`, `lint:complexity-strict`, `knip`, `deps:check`, `jscpd` rena; `size` 34,3 % av budget; `build:demo` exit 0.
- Nya tester: `test/unit/app/matters/time-section.test.tsx` (4), kategori-block i `timeEntry.test.ts` (4) och `billingRun.test.ts` (3 — båda regimerna via `it.each`), benämnings-tester i `faktura-template.test.ts` (2).
- Nyckelinvarianten som låses: taxeraderna summerar exakt till slutregleringens bas, med rådgivningstimmen som enda tillåtna differens för rättshjälp (#860).
- Alla berörda testfiler gröna i isolering. Bred katalogkörning: 1033 pass / 63 fail mot **1022 pass / 65 fail på orörd `main`** — de kvarvarande felen är känt mock-läckage vid katalogkörning (#92), inte nya.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_