### PR TITLE
fix(billing): rättsskyddets prutning omfördelar i stället för att kreditera bolaget

### DIFF
--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -73,6 +73,9 @@ interface BillingRunRow {
   kostnadsrakningStatus?: KostnadsrakningStatus | null;
   awardedOre?: number | null;
   beslutSlutgiltigt?: boolean | null;
+  /** Registrerad prutning (negativt, netto). På rättsskyddets FORSAKRING-körning
+   *  betyder den att bolagets prutning omfördelats till klientfakturan (#952). */
+  prutningOre?: number | null;
 }
 
 /** Fristående klientfaktura (utan billing-run) som visas i faktura-listan (#853). */
@@ -520,22 +523,26 @@ function SjalvriskAccontoHint({ matterId, matter, rows }: { matterId: MatterId; 
 }
 
 /**
- * Försäkrings-prutnings-banner (#905, rättsskydd flöde B): efter slutregleringen mot
- * försäkringen kan bolaget PRUTA på arvodet. Byrån registrerar det prutade beloppet →
- * kredit till försäkringen + påfyllnadsfaktura till klienten. Visas bara när det finns
- * en FORSAKRING-slutfaktura och ingen prutning redan registrerats.
+ * Försäkrings-prutnings-banner (#905/#952, rättsskydd flöde B): efter slutregleringen
+ * mot försäkringen kan bolaget PRUTA på arvodet. Byrån registrerar det prutade beloppet
+ * → beloppet OMFÖRDELAS mellan klientens två fakturor (försäkringsfakturan ned,
+ * klientfakturan upp). Ingen kreditfaktura till bolaget: fakturan är ställd till
+ * klienten, så det gick aldrig ut någon faktura *till* bolaget att kreditera.
+ *
+ * Visas bara när det finns en FORSAKRING-slutfaktura och ingen prutning redan
+ * registrerats (`prutningOre` på betalar-körningen).
  */
 function InsurerPruningBanner({ matterId, matter, rows, onRecorded }: { matterId: MatterId; matter: MatterContext; rows: BillingRunRow[]; onRecorded: () => void }) {
   const [krStr, setKrStr] = useState("");
   const record = trpc.billingRun.recordInsurerPruning.useMutation({ onSuccess: onRecorded });
   const hasPayerFinal = rows.some((r) => r.type === "FINAL" && r.recipient === "FORSAKRING");
-  const alreadyPruned = rows.some((r) => r.type === "CREDIT" && r.recipient === "FORSAKRING");
+  const alreadyPruned = rows.some((r) => r.recipient === "FORSAKRING" && r.prutningOre != null);
   if (matter.paymentMethod !== "RATTSSKYDD" || !hasPayerFinal || alreadyPruned) return null;
   const netOre = Math.round(Number.parseFloat(krStr.replace(",", ".")) * 100);
   const valid = Number.isFinite(netOre) && netOre > 0;
   return (
     <div className="mx-6 mb-4 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900">
-      <div className="mb-1.5">Har försäkringsbolaget <strong>prutat</strong> på fakturan? Registrera det prutade arvodet (exkl moms) — mellanskillnaden krediteras försäkringen och faktureras klienten.</div>
+      <div className="mb-1.5">Har försäkringsbolaget <strong>prutat</strong> på fakturan? Registrera det prutade arvodet (exkl moms) — beloppet flyttas från försäkringsfakturan till klientens faktura. Totalen är oförändrad och ingen kreditfaktura skickas till bolaget (fakturan är ställd till klienten).</div>
       <div className="flex items-center gap-2">
         <input type="number" min={0} step={100} value={krStr} placeholder="Prutat belopp (kr, exkl moms)"
           onChange={(e) => setKrStr(e.target.value)}

--- a/src/lib/server/events/emit.ts
+++ b/src/lib/server/events/emit.ts
@@ -103,6 +103,11 @@ export const emit = {
   invoiceWrittenOff: (ctx: EmitCtx, invoiceId: InvoiceId, matterId: MatterId, amount: number) =>
     emitUser(ctx, "invoice.written_off", { invoiceId, amount }, matterId),
 
+  /** Beloppet på en BEFINTLIG faktura ändrades (#952) — t.ex. rättsskyddets prutning
+   *  som omfördelas mellan klientens två fakturor utan att någon ny faktura skapas. */
+  invoiceAdjusted: (ctx: EmitCtx, inv: { id: InvoiceId; matterId: MatterId; amount: number }, reason: string) =>
+    emitUser(ctx, "invoice.adjusted", { invoiceId: inv.id, amount: inv.amount, reason }, inv.matterId),
+
   // ── time-entry ─────────────────────────────────────────────────
   timeEntryAdded: (ctx: EmitCtx, entry: { id: TimeEntryId; matterId: MatterId; minutes: number }) =>
     emitUser(ctx, "time-entry.added", { entryId: entry.id, minutes: entry.minutes }, entry.matterId),

--- a/src/lib/server/events/schema.ts
+++ b/src/lib/server/events/schema.ts
@@ -41,6 +41,8 @@ export const EVENT_TYPES = [
   "invoice.payment_received",
   "invoice.overdue",
   "invoice.written_off",
+  /** Fakturans belopp omfördelades (rättsskyddets prutning, #952) — ingen ny faktura. */
+  "invoice.adjusted",
   // payment-plan (avbetalningsplaner) — driver av påminnelser
   "payment.due",
   "payment.overdue",

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -48,7 +48,7 @@ import {
   type TimeEntryId,
   type UserId,
 } from "@/lib/shared/schemas/ids";
-import type { SettlementRow, SettlementView, SettlementViewLine } from "@/lib/shared/settlement-view";
+import type { SettlementRow, SettlementRowKind, SettlementView, SettlementViewLine } from "@/lib/shared/settlement-view";
 import { splitVat, DEFAULT_VAT_RATE } from "@/lib/shared/vat";
 import { emit, type EmitCtx } from "../events/emit";
 import type { BillingRunDetailRow, BillingRunListRow } from "../repositories/billing-run-repository";
@@ -1482,72 +1482,137 @@ export const billingRunRouter = router({
     }),
 
   /**
-   * Registrera försäkringsbolagets PRUTNING efter slutregleringen (#905, rättsskydd,
-   * flöde B): försäkringen ersätter mindre än fakturerat. Prutningen bärs av KLIENTEN.
-   * Två fakturor (aldrig en delad): (1) en KREDIT till försäkringen på det prutade
-   * beloppet (deras nettofordran sänks till det de faktiskt betalar), (2) en påfyllnads-
-   * faktura till klienten på samma belopp. Byrån blir hel. Kräver en befintlig
-   * FORSAKRING-slutregleringsfaktura.
+   * Registrera försäkringsbolagets PRUTNING efter slutregleringen (#905/#952,
+   * rättsskydd, flöde B): bolaget ersätter mindre än fakturerat. Prutningen bärs
+   * av KLIENTEN — byrån blir hel.
+   *
+   * INGEN kreditfaktura till försäkringsbolaget. I rättsskydd GÅR fakturan till
+   * bolaget men är STÄLLD TILL KLIENTEN: det gick aldrig ut någon faktura *till*
+   * bolaget, och därmed finns inget att kreditera dem. Klienten har två fakturor
+   * efter slutregleringen — självrisk-fakturan och den som försäkringen betalar —
+   * och prutningen ändrar bara FÖRDELNINGEN mellan dem:
+   *
+   *   försäkringsfakturan  −prutningen (inkl moms)
+   *   klientfakturan       +prutningen (inkl moms)
+   *
+   * Totalen är oförändrad och inga nya fakturor uppstår. Kräver en befintlig
+   * FORSAKRING-slutregleringsfaktura + klientens slutregleringsfaktura.
    */
   recordInsurerPruning: orgProcedure
     .input(z.object({
       matterId: matterIdSchema,
       /** Prutat arvode NETTO (öre) — den del försäkringen inte ersätter. */
       prunedNetOre: z.number().int().positive(),
-      /** Fakturadatum (demo/fixtures) — annars idag. */
+      /** Bokföringsdatum för omfördelningen (demo/fixtures) — annars idag. */
       invoiceDate: z.string().optional(),
       notes: z.string().nullish(),
     }))
     .mutation(({ ctx, input }) =>
       ctx.repos.transaction(async (tx) => {
-        const when = toDateOrNow(input.invoiceDate);
-        const runs = await tx.billingRuns.listForOrg(ctx.orgId, input.matterId);
-        const payerRun = runs.find((r) => r.type === "FINAL" && r.recipient === "FORSAKRING" && r.invoiceId);
-        if (!payerRun?.invoiceId) {
-          throw new TRPCError({ code: "BAD_REQUEST", message: "Ingen försäkringsfaktura att pruta på — slutreglera mot försäkringen först." });
-        }
+        const t = await resolvePruningTargets(tx, ctx.orgId, input.matterId);
         const prunedGross = arvodeInclVatOre(input.prunedNetOre);
         const prunedVat = prunedGross - input.prunedNetOre;
-        const arvodeVatLine = [{ kind: "arvode" as const, vatRate: DEFAULT_VAT_RATE, netOre: input.prunedNetOre, vatOre: prunedVat }];
-        // (1) Kreditera försäkringen den prutade delen (negativ faktura, länkad till originalet).
-        const insurerCredit = await tx.invoices.create({
-          matterId: input.matterId, amount: -prunedGross, vatOre: -prunedVat,
-          vatBreakdown: arvodeVatLine.map((l) => ({ ...l, netOre: -l.netOre, vatOre: -l.vatOre })),
-          invoiceType: "CREDIT", status: "SENT", creditedInvoiceId: payerRun.invoiceId,
-          ...(await invoiceNumbering(tx, ctx.orgId, "FORSAKRING")), invoiceDate: when,
-          notes: "Försäkringens prutning — kreditering av den del försäkringen inte ersätter.",
+        if (prunedGross > t.payerInvoice.amount) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: `Prutningen (${prunedGross / 100} kr inkl moms) är större än försäkringsfakturan (${t.payerInvoice.amount / 100} kr).`,
+          });
+        }
+        const when = toDateOrNow(input.invoiceDate);
+        const payerInvoice = await tx.invoices.update(t.payerInvoice.id, shiftInvoiceAmount(t.payerInvoice, -input.prunedNetOre, -prunedVat, {
+          label: "Avgår försäkringens prutning — faktureras klienten (exkl moms)", kind: "deduct",
+        }));
+        const clientInvoice = await tx.invoices.update(t.clientInvoice.id, shiftInvoiceAmount(t.clientInvoice, input.prunedNetOre, prunedVat, {
+          label: "Försäkringens prutning — bärs av klienten (exkl moms)", kind: "add",
+        }));
+        // Körningarna följer sina fakturor så rapporter/AR summerar rätt, och
+        // prutningen märks på betalar-körningen (`prutningOre`) → UI:t vet att den
+        // är registrerad utan att det finns någon CREDIT att leta efter.
+        await tx.billingRuns.update(t.payerRun.id, {
+          amountOre: payerInvoice.amount, prutningOre: -input.prunedNetOre,
+          notes: input.notes ?? `Försäkringens prutning ${input.prunedNetOre / 100} kr (exkl moms) — omfördelad till klientfakturan ${clientInvoice.invoiceNumber ?? ""}`.trim(),
         });
-        // (2) Fakturera klienten samma belopp (klienten bär prutningen).
-        const clientView: SettlementView = {
-          timeLines: [],
-          rows: [
-            { label: "Försäkringens prutning (exkl moms)", amountOre: input.prunedNetOre, kind: "add" },
-            { label: "Moms 25 %", amountOre: prunedVat, kind: "add" },
-          ],
-          totalLabel: "Att betala (inkl moms)", totalOre: prunedGross,
-        };
-        const clientInvoice = await tx.invoices.create({
-          matterId: input.matterId, amount: prunedGross, vatOre: prunedVat, vatBreakdown: arvodeVatLine,
-          invoiceType: "FINAL", status: "SENT", settlementBreakdown: clientView,
-          ...(await invoiceNumbering(tx, ctx.orgId, "KLIENT")), invoiceDate: when,
-          notes: input.notes ?? "Försäkringens prutning — bärs av klienten (rättsskydd).",
-        });
-        await tx.billingRuns.create({
-          matterId: input.matterId, type: "CREDIT", recipient: "FORSAKRING", status: "SENT",
-          workValueOreAtRun: prunedGross, proposedAmountOre: -prunedGross, amountOre: -prunedGross,
-          invoiceId: insurerCredit.id, deductedBillingRunIds: [], periodTo: new Date(),
-        });
-        await tx.billingRuns.create({
-          matterId: input.matterId, type: "FINAL", recipient: "KLIENT", status: "SENT",
-          workValueOreAtRun: prunedGross, proposedAmountOre: prunedGross, amountOre: prunedGross,
-          invoiceId: clientInvoice.id, deductedBillingRunIds: [], periodTo: new Date(),
-        });
-        await emit.invoiceCreated(ctx, insurerCredit);
-        await emit.invoiceCreated(ctx, clientInvoice);
-        return { insurerCredit, clientInvoice };
+        await tx.billingRuns.update(t.clientRun.id, { amountOre: clientInvoice.amount });
+        await emit.invoiceAdjusted(ctx, payerInvoice, "insurer_pruning");
+        await emit.invoiceAdjusted(ctx, clientInvoice, "insurer_pruning");
+        return { payerInvoice, clientInvoice, prunedGross, adjustedAt: when };
       }),
     ),
 });
+
+/** Slutregleringens två fakturor i ett rättsskyddsärende — båda ställda till klienten. */
+interface PruningTargets {
+  payerRun: BillingRunListRow;
+  payerInvoice: Invoice;
+  clientRun: BillingRunListRow;
+  clientInvoice: Invoice;
+}
+
+/**
+ * Hitta de två fakturorna prutningen omfördelas mellan (#952). Båda måste finnas:
+ * utan försäkringsfakturan finns inget att pruta på, och utan klientfakturan finns
+ * ingen att flytta beloppet till (då vore prutningen en ren förlust, vilket den inte
+ * är i rättsskydd). Senaste körningen per mottagare vinner om flera finns.
+ */
+async function resolvePruningTargets(tx: Repositories, orgId: OrganizationId, matterId: MatterId): Promise<PruningTargets> {
+  const runs = await tx.billingRuns.listForOrg(orgId, matterId);
+  const finals = runs.filter((r) => r.type === "FINAL" && r.invoiceId);
+  const payerRun = finals.find((r) => r.recipient === "FORSAKRING");
+  if (!payerRun?.invoiceId) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: "Ingen försäkringsfaktura att pruta på — slutreglera mot försäkringen först." });
+  }
+  const clientRun = finals.find((r) => r.recipient === "KLIENT");
+  if (!clientRun?.invoiceId) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: "Ingen klientfaktura att omfördela prutningen till — slutreglera ärendet först." });
+  }
+  const [payerInvoice, clientInvoice] = await Promise.all([
+    tx.invoices.getByIdInOrg(payerRun.invoiceId, orgId),
+    tx.invoices.getByIdInOrg(clientRun.invoiceId, orgId),
+  ]);
+  if (!payerInvoice || !clientInvoice) throw new TRPCError({ code: "NOT_FOUND", message: "Slutregleringens fakturor kunde inte läsas." });
+  return { payerRun, payerInvoice, clientRun, clientInvoice };
+}
+
+/**
+ * Flytta ett arvode-belopp till/från en faktura (#952): `amount`, `vatOre`,
+ * moms-uppdelningen (arvodets 25 %-rad) och nedbrytningsvyn justeras tillsammans,
+ * så fakturan aldrig visar en moms som inte hör till dess belopp. `deltaNet` är
+ * signerat (negativt = avgår).
+ */
+function shiftInvoiceAmount(
+  invoice: Invoice, deltaNet: number, deltaVat: number, row: { label: string; kind: SettlementRowKind },
+): Partial<Invoice> {
+  return {
+    amount: invoice.amount + deltaNet + deltaVat,
+    vatOre: (invoice.vatOre ?? 0) + deltaVat,
+    vatBreakdown: shiftArvodeVatLine(invoice.vatBreakdown ?? [], deltaNet, deltaVat),
+    settlementBreakdown: appendBreakdownRow(invoice.settlementBreakdown, row.label, Math.abs(deltaNet), row.kind, deltaNet + deltaVat),
+  };
+}
+
+/** Justera arvodets 25 %-rad i moms-uppdelningen; saknas den läggs den till. */
+function shiftArvodeVatLine(lines: readonly VatBreakdownLine[], deltaNet: number, deltaVat: number): VatBreakdownLine[] {
+  const idx = lines.findIndex((l) => l.kind === "arvode" && l.vatRate === DEFAULT_VAT_RATE);
+  if (idx < 0) return [...lines, { kind: "arvode", vatRate: DEFAULT_VAT_RATE, netOre: deltaNet, vatOre: deltaVat }];
+  return lines.map((l, i) => (i === idx ? { ...l, netOre: l.netOre + deltaNet, vatOre: l.vatOre + deltaVat } : l));
+}
+
+/**
+ * Lägg en förklarande rad sist i nedbrytningsvyn och flytta totalen (#952), så
+ * fakturadokumentet visar VARFÖR beloppet ändrades. Momsraden får en egen rad
+ * eftersom trappan redovisar netto och moms separat.
+ */
+function appendBreakdownRow(
+  view: SettlementView | null | undefined, label: string, netOre: number, kind: SettlementRowKind, deltaGross: number,
+): SettlementView {
+  const base: SettlementView = view ?? { timeLines: [], rows: [], totalLabel: "Att betala (inkl moms)", totalOre: 0 };
+  const vatOre = Math.abs(deltaGross) - netOre;
+  return {
+    ...base,
+    rows: [...base.rows, { label, amountOre: netOre, kind }, { label: "Moms 25 % på omfördelningen", amountOre: vatOre, kind }],
+    totalOre: base.totalOre + deltaGross,
+  };
+}
 
 /**
  * Validera + hämta de avdragna ACCONTO-körningarna. Säkerhet (#60): de måste

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -535,15 +535,64 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
     expect(res.payerInvoice.amount).toBe(262_700);
   });
 
-  it("rättsskydd flöde B (#905): prutning EFTERÅT → kredit till försäkring + påfyllnadsfaktura till klient", async () => {
+  /**
+   * Rättsskydd flöde B (#905/#952): fakturan GÅR till försäkringsbolaget men är
+   * STÄLLD TILL KLIENTEN — det gick aldrig ut någon faktura *till* bolaget, så det
+   * finns inget att kreditera dem. Klienten har två fakturor och bolagets prutning
+   * ändrar bara fördelningen mellan dem. Totalen är oförändrad.
+   */
+  it("prutning EFTERÅT omfördelar mellan klientens två fakturor — INGEN kreditfaktura", async () => {
     const { caller: c } = caller({ paymentMethod: "RATTSSKYDD", clientShareBips: 2000 }, 300000);
-    await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "FORSAKRING" }); // ingen prutning uppfront
+    const settled = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "FORSAKRING" }); // ingen prutning uppfront
+    const before = settled.payerInvoice.amount + settled.clientInvoice.amount;
+
     const res = await c.billingRun.recordInsurerPruning({ matterId: "m-1", prunedNetOre: 100_000 });
-    // 100 000 netto → 125 000 brutto: kredit till försäkring (negativ) + klientfaktura (positiv).
-    expect(res.insurerCredit.invoiceType).toBe("CREDIT");
-    expect(res.insurerCredit.amount).toBe(-125_000);
-    expect(res.clientInvoice.invoiceType).toBe("FINAL");
-    expect(res.clientInvoice.amount).toBe(125_000);
+    // 100 000 netto → 125 000 brutto flyttas FRÅN försäkringsfakturan TILL klientens.
+    expect(res.prunedGross).toBe(125_000);
+    expect(res.payerInvoice.amount).toBe(settled.payerInvoice.amount - 125_000);
+    expect(res.clientInvoice.amount).toBe(settled.clientInvoice.amount + 125_000);
+    // Totalen (byråns fordran) är oförändrad — byrån blir hel.
+    expect(res.payerInvoice.amount + res.clientInvoice.amount).toBe(before);
+    // Momsen följer beloppet, så fakturan aldrig visar moms som inte hör till den.
+    expect(res.payerInvoice.vatOre).toBe((settled.payerInvoice.vatOre ?? 0) - 25_000);
+    expect(res.clientInvoice.vatOre).toBe((settled.clientInvoice.vatOre ?? 0) + 25_000);
+    // Ingen ny faktura, och absolut ingen CREDIT mot försäkringsbolaget.
+    const invoices = await c.invoice.list({ matterId: "m-1" });
+    expect(invoices.filter((i) => i.invoiceType === "CREDIT")).toHaveLength(0);
+    expect(res.payerInvoice.id).toBe(settled.payerInvoice.id); // samma faktura, uppdaterad
+    expect(res.clientInvoice.id).toBe(settled.clientInvoice.id);
+  });
+
+  it("prutningen märks på betalar-körningen så den inte kan registreras i blindo två gånger", async () => {
+    const { caller: c } = caller({ paymentMethod: "RATTSSKYDD", clientShareBips: 2000 }, 300000);
+    await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "FORSAKRING" });
+    await c.billingRun.recordInsurerPruning({ matterId: "m-1", prunedNetOre: 100_000 });
+    const { runs } = await c.billingRun.list({ matterId: "m-1" });
+    const payerRun = runs.find((r) => r.type === "FINAL" && r.recipient === "FORSAKRING");
+    expect(payerRun?.prutningOre).toBe(-100_000);
+    // Inga CREDIT-körningar mot försäkringsbolaget (det gamla spåret, #952).
+    expect(runs.filter((r) => r.type === "CREDIT" && r.recipient === "FORSAKRING")).toHaveLength(0);
+  });
+
+  it("nedbrytningsvyerna förklarar omfördelningen på BÅDA fakturorna", async () => {
+    const { caller: c } = caller({ paymentMethod: "RATTSSKYDD", clientShareBips: 2000 }, 300000);
+    await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "FORSAKRING" });
+    const res = await c.billingRun.recordInsurerPruning({ matterId: "m-1", prunedNetOre: 100_000 });
+    const labels = (inv: { settlementBreakdown?: { rows: Array<{ label: string }> } | null | undefined }): string[] =>
+      (inv.settlementBreakdown?.rows ?? []).map((r) => r.label);
+    expect(labels(res.payerInvoice).join(" | ")).toMatch(/Avgår försäkringens prutning/);
+    expect(labels(res.clientInvoice).join(" | ")).toMatch(/bärs av klienten/);
+    // Totalen i vyn följer fakturans faktiska belopp.
+    expect(res.payerInvoice.settlementBreakdown?.totalOre).toBe(res.payerInvoice.amount);
+    expect(res.clientInvoice.settlementBreakdown?.totalOre).toBe(res.clientInvoice.amount);
+  });
+
+  it("en prutning större än försäkringsfakturan avvisas (annars blir beloppet negativt)", async () => {
+    const { caller: c } = caller({ paymentMethod: "RATTSSKYDD", clientShareBips: 2000 }, 300000);
+    const settled = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "FORSAKRING" });
+    const forStort = Math.round(settled.payerInvoice.amount / 1.25) + 100_000;
+    await expect(c.billingRun.recordInsurerPruning({ matterId: "m-1", prunedNetOre: forStort }))
+      .rejects.toThrow(/större än försäkringsfakturan/i);
   });
 
   it("recordInsurerPruning kräver en försäkringsfaktura först (annars BAD_REQUEST)", async () => {

--- a/tooling/demo-generator/simulate/events.ts
+++ b/tooling/demo-generator/simulate/events.ts
@@ -40,8 +40,9 @@ export type SimEvent =
   | { kind: "verdict"; dayOffset: number }
   /** Slutreglering (rättshjälp/-skydd) — settleCoverage (→ klient FINAL/CREDIT + betalare). */
   | { kind: "settle"; dayOffset: number; payerRecipient: string }
-  /** Försäkringens prutning EFTER slutreglering (#905, rättsskydd flöde B) — kredit till
-   *  försäkringen + påfyllnadsfaktura till klienten på `prunedNetOre` (netto). */
+  /** Försäkringens prutning EFTER slutreglering (#905/#952, rättsskydd flöde B) —
+   *  `prunedNetOre` (netto) omfördelas från försäkringsfakturan till klientfakturan.
+   *  Inga nya fakturor: fakturan är ställd till klienten, så bolaget krediteras inte. */
   | { kind: "insurerPruning"; dayOffset: number; prunedNetOre: number }
   /** Vanlig slutfaktura (privat/offentligt) — createFinal + SENT. */
   | { kind: "final"; dayOffset: number; recipient: string }

--- a/tooling/demo-generator/simulate/runner.ts
+++ b/tooling/demo-generator/simulate/runner.ts
@@ -203,10 +203,9 @@ async function hSettle(ctx: RunCtx, m: SimMatter, e: Any, iso: string): Promise<
 }
 
 async function hInsurerPruning(ctx: RunCtx, m: SimMatter, e: Any, iso: string): Promise<void> {
-  // Försäkringen prutar EFTER slutregleringen (#905) → kredit till försäkringen +
-  // påfyllnadsfaktura till klienten på prutade beloppet.
+  // Försäkringen prutar EFTER slutregleringen (#905/#952): beloppet OMFÖRDELAS mellan
+  // klientens två fakturor — inga nya fakturor skapas, så räknaren rörs inte.
   await ctx.c.billingRun.recordInsurerPruning({ matterId: m.id, prunedNetOre: e.prunedNetOre, invoiceDate: iso });
-  ctx.res.invoices += 2;
 }
 
 async function hFinal(ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimState): Promise<void> {

--- a/tooling/demo-generator/simulate/scenarios/rattsskydd-positivt.ts
+++ b/tooling/demo-generator/simulate/scenarios/rattsskydd-positivt.ts
@@ -8,7 +8,8 @@
  *      några i 2026 (olika datum).
  *   3. Slutreglering mot försäkringen → försäkringsfaktura (deras andel) + klientens
  *      slutliga självrisk (minus betalda aconton).
- *   4. Försäkringen PRUTAR efteråt → klienten bär mellanskillnaden (#905, flöde B).
+ *   4. Försäkringen PRUTAR efteråt → beloppet omfördelas från försäkringsfakturan
+ *      till klientfakturan; klienten bär mellanskillnaden (#905/#952, flöde B).
  *
  * SKILLNAD mot rättshjälp: prutningen bärs av KLIENTEN (inte byrån). Arvodet
  * värderas på samma rättshjälpstaxenivåer som rättshjälpen (#950/#953) — alla fyra
@@ -61,7 +62,7 @@ export function buildRattsskyddPositivtScenario(parties: Parties): SimEvent[] {
     // ── Slutreglering mot försäkringen: försäkringsfaktura + klientens slutliga självrisk ──
     { kind: "settle", dayOffset: 230, payerRecipient: "FORSAKRING" },
     // ── Flöde B (#905): försäkringen PRUTAR → klienten bär mellanskillnaden ──
-    { kind: "note", dayOffset: 245, text: "Försäkringsbolaget prutar på arvodet — ersätter 3 000 kr mindre. Mellanskillnaden faktureras klienten." },
+    { kind: "note", dayOffset: 245, text: "Försäkringsbolaget prutar på arvodet — ersätter 3 000 kr mindre. Beloppet flyttas till klientens faktura (ingen kreditfaktura till bolaget)." },
     { kind: "insurerPruning", dayOffset: 245, prunedNetOre: 300_000 },
   );
   return ev;


### PR DESCRIPTION
Closes #952.

## Problem

I rättsskydd **går** fakturan till försäkringsbolaget men den är **ställd till klienten**. Det gick alltså aldrig ut någon faktura *till* bolaget — och därmed finns inget att kreditera dem.

`recordInsurerPruning` skapade ändå två nya fakturor: en `invoiceType: "CREDIT"` numrerad mot `FORSAKRING` (*"kreditering av den del försäkringen inte ersätter"*) plus en påfyllnadsfaktura till klienten.

## Rätt modell

Klienten har **två** fakturor efter slutregleringen — självrisken och den som försäkringen betalar. Bolagets prutning ändrar bara **fördelningen** mellan dem:

| | före | efter |
|---|---:|---:|
| försäkringsfakturan | 60 297,22 kr | **56 547,22 kr** |
| klientfakturan | 5 523,31 kr | **9 273,31 kr** |
| total | 65 820,53 kr | 65 820,53 kr |

3 750 kr (3 000 netto + 750 moms) flyttat, totalen oförändrad, byrån hel, inga nya fakturor.

## Ändringar

- `recordInsurerPruning` **uppdaterar** de två befintliga fakturorna. `shiftInvoiceAmount` justerar `amount`, `vatOre`, momsuppdelningens arvode-rad och nedbrytningsvyn *tillsammans* — en faktura ska aldrig visa moms som inte hör till dess belopp.
- Båda fakturorna får en förklarande rad, och vyns total följer fakturans faktiska belopp:
  ```
  Avgår försäkringens prutning — faktureras klienten (exkl moms)  −3 000,00 kr
  Moms 25 % på omfördelningen                                       −750,00 kr
  Försäkringen betalar — att betala (inkl moms)                   56 547,22 kr
  ```
- Prutningen märks som `prutningOre` på betalar-körningen. UI:t letade tidigare efter en `CREDIT` mot `FORSAKRING` för att veta att prutning registrerats; bannertexten är omskriven.
- Nya guards: prutning större än försäkringsfakturan avvisas, och saknad klientfaktura ger `BAD_REQUEST` — utan den vore prutningen en ren förlust, vilket den inte är i rättsskydd.
- Nytt event `invoice.adjusted`: beloppet på en befintlig faktura ändrades utan att någon ny faktura skapades.
- Demon: `hInsurerPruning` skapar inga fakturor längre (ärende 2026-0021 går från fyra till två).

## Verifiering

- `typecheck`, `lint`, `lint:complexity-strict`, `knip`, `deps:check`, `jscpd` rena; `size` 34,3 %; `build:demo` exit 0.
- Fyra nya tester i `billingRun.test.ts` (64 pass): totalen bevaras, momsen följer beloppet, **noll** `CREDIT`-fakturor och `CREDIT`-körningar mot `FORSAKRING`, samma faktura-id uppdateras, nedbrytningsraderna finns på båda fakturorna, guarden mot för stor prutning.
- Verifierat mot byggd demodata: `CREDIT mot FORSAKRING: INGA`, `prutningOre=-300000` på betalar-körningen, total 65 820,53 kr oförändrad.

## Not om bokföring

Att sänka en redan skickad faktura utan kreditnota är ovanligt, men här är båda fakturorna ställda till **samma** debitor (klienten) och byråns totala fordran är oförändrad — omfördelningen är alltså inte en nedsättning utan en omallokering mellan klientens egna fakturor. Vill du hellre ha ett korrigeringsunderlag till klienten för spårbarheten så lägger jag till det som ett eget steg.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_