### PR TITLE
feat(billing): byråns standardåtgärder — samma beskrivning och tid i varje ärende

### DIFF
--- a/src/app/matters/[id]/_time-section.tsx
+++ b/src/app/matters/[id]/_time-section.tsx
@@ -8,6 +8,7 @@ import { trpc } from "@/lib/client/trpc";
 import { formatMinutes } from "@/lib/client/utils";
 import { TIME_ENTRY_KIND_LABELS, type PaymentMethod, type TimeEntryKind } from "@/lib/shared/schemas/enums";
 import type { InvoiceId, MatterId, TimeEntryId } from "@/lib/shared/schemas/ids";
+import { applicableStandardAtgarder, type StandardAtgard } from "@/lib/shared/standard-atgard";
 
 interface Props {
   matterId: MatterId;
@@ -23,6 +24,8 @@ interface EditForm {
   description: string;
   billable: boolean;
   kind: TimeEntryKind;
+  /** Byråns standardåtgärd posten kommer ur (#956). "" = fritext. */
+  standardAtgardId: string;
 }
 
 /** Kategorierna i dropdown-ordning — härledd ur labels-kartan (single source). */
@@ -35,6 +38,13 @@ function isCoverageMethod(method: PaymentMethod | undefined): boolean {
   return method !== undefined && COVERAGE_METHODS.has(method);
 }
 
+/** Byråns standardåtgärder (#956) som gäller ärendet — org-inställning, samma
+ *  lista för alla på byrån. Tom lista döljer väljaren helt. */
+function useStandardAtgarder(paymentMethod: PaymentMethod | undefined): StandardAtgard[] {
+  const settings = trpc.organization.getSettings.useQuery();
+  return applicableStandardAtgarder(settings.data?.standardAtgarder, paymentMethod);
+}
+
 interface TimeEntryRow {
   id: TimeEntryId;
   date: Date | string;
@@ -42,6 +52,7 @@ interface TimeEntryRow {
   description: string | null;
   billable: boolean;
   kind?: TimeEntryKind | null;
+  standardAtgardId?: string | null;
   hourlyRate?: number | null;
   user?: { name?: string | null } | null;
   invoiceId?: InvoiceId | null;
@@ -63,16 +74,36 @@ function toEditForm(entry: TimeEntryRow): EditForm {
     description: entry.description ?? "",
     billable: entry.billable,
     kind: entry.kind ?? "ARBETE",
+    standardAtgardId: entry.standardAtgardId ?? "",
   };
 }
 
 function emptyForm(): EditForm {
-  return { date: new Date().toISOString().split("T")[0]!, minutes: 30, description: "", billable: true, kind: "ARBETE" };
+  return { date: new Date().toISOString().split("T")[0]!, minutes: 30, description: "", billable: true, kind: "ARBETE", standardAtgardId: "" };
+}
+
+/**
+ * Fyll formuläret ur en av byråns standardåtgärder (#956): beskrivning, tid och
+ * kategori sätts till byråns huvudregel — allt förblir redigerbart, för avsteg
+ * måste vara lätt att göra. Tomt val nollar kopplingen men behåller texten, så
+ * man kan utgå från en standard och skriva om den.
+ */
+function applyStandardAtgard(form: EditForm, atgard: StandardAtgard | undefined): EditForm {
+  if (!atgard) return { ...form, standardAtgardId: "" };
+  return {
+    ...form,
+    standardAtgardId: atgard.id,
+    description: atgard.description,
+    minutes: atgard.minutes,
+    kind: atgard.kind,
+    billable: atgard.billable,
+  };
 }
 
 // eslint-disable-next-line max-lines-per-function -- TODO: refactor (struktur är tabular: kolumndefs + 2 modaler)
 export function TimeSection({ matterId, isTaxeArende, paymentMethod }: Props) {
   const isCoverage = isCoverageMethod(paymentMethod);
+  const atgarder = useStandardAtgarder(paymentMethod);
   const utils = trpc.useUtils();
   const timeEntries = trpc.timeEntry.list.useQuery({ matterId });
   const [showCreate, setShowCreate] = useState(false);
@@ -191,6 +222,7 @@ export function TimeSection({ matterId, isTaxeArende, paymentMethod }: Props) {
           isPending={createTimeEntry.isPending}
           isTaxeArende={isTaxeArende}
           isCoverage={isCoverage}
+          atgarder={atgarder}
           onSubmit={() => createTimeEntry.mutate({ ...createForm, matterId })}
           onCancel={() => setShowCreate(false)}
         />
@@ -205,6 +237,7 @@ export function TimeSection({ matterId, isTaxeArende, paymentMethod }: Props) {
             isPending={updateTimeEntry.isPending}
             isTaxeArende={isTaxeArende}
             isCoverage={isCoverage}
+            atgarder={atgarder}
             onSubmit={saveEdit}
             onCancel={() => { setEditingId(null); setEditForm(null); }}
           />
@@ -221,11 +254,12 @@ interface FormProps {
   isPending: boolean;
   isTaxeArende?: boolean | undefined;
   isCoverage?: boolean | undefined;
+  atgarder: StandardAtgard[];
   onSubmit: () => void;
   onCancel: () => void;
 }
 
-function TimeForm({ form, setForm, submitLabel, isPending, isTaxeArende, isCoverage, onSubmit, onCancel }: FormProps) {
+function TimeForm({ form, setForm, submitLabel, isPending, isTaxeArende, isCoverage, atgarder, onSubmit, onCancel }: FormProps) {
   return (
     <form onSubmit={(e) => { e.preventDefault(); onSubmit(); }}>
       {isTaxeArende && (
@@ -236,22 +270,39 @@ function TimeForm({ form, setForm, submitLabel, isPending, isTaxeArende, isCover
           om &quot;avsevärt mer arbete än normalt&quot; krävts.
         </div>
       )}
+      {atgarder.length > 0 && (
+        <div className="mb-3">
+          <label htmlFor="time-standard" className="block text-xs text-gray-500 mb-1">Standardåtgärd</label>
+          <select id="time-standard" value={form.standardAtgardId}
+            onChange={(e) => setForm(applyStandardAtgard(form, atgarder.find((a) => a.id === e.target.value)))}
+            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm">
+            <option value="">— egen beskrivning —</option>
+            {atgarder.map((a) => (
+              <option key={a.id} value={a.id}>{a.description} ({formatMinutes(a.minutes)})</option>
+            ))}
+          </select>
+          <p className="mt-1 text-xs text-gray-500">
+            Byråns standardåtgärder fyller beskrivning och tid. Tiden är en
+            huvudregel — justera den om ärendet krävde mer eller mindre.
+          </p>
+        </div>
+      )}
       <div className="grid grid-cols-2 gap-3">
         <div>
-          <label className="block text-xs text-gray-500 mb-1">Datum *</label>
-          <input type="date" required value={form.date}
+          <label htmlFor="time-date" className="block text-xs text-gray-500 mb-1">Datum *</label>
+          <input id="time-date" type="date" required value={form.date}
             onChange={(e) => setForm({ ...form, date: e.target.value })}
             className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm" />
         </div>
         <div>
-          <label className="block text-xs text-gray-500 mb-1">Tid (minuter) *</label>
-          <input type="text" inputMode="numeric" required value={form.minutes}
+          <label htmlFor="time-minutes" className="block text-xs text-gray-500 mb-1">Tid (minuter) *</label>
+          <input id="time-minutes" type="text" inputMode="numeric" required value={form.minutes}
             onChange={(e) => setForm({ ...form, minutes: parseInt(e.target.value) || 0 })}
             className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm" />
         </div>
         <div className="col-span-2">
-          <label className="block text-xs text-gray-500 mb-1">Beskrivning *</label>
-          <input type="text" required value={form.description}
+          <label htmlFor="time-description" className="block text-xs text-gray-500 mb-1">Beskrivning *</label>
+          <input id="time-description" type="text" required value={form.description}
             placeholder="Beskrivning *"
             onChange={(e) => setForm({ ...form, description: e.target.value })}
             className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm" />

--- a/src/app/settings/_standard-atgarder-section.tsx
+++ b/src/app/settings/_standard-atgarder-section.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+/**
+ * `StandardAtgarderSection` (#956) — byråns standardåtgärder: åtgärder som
+ * förekommer i varje ärende och ska registreras med SAMMA beskrivning och SAMMA
+ * tidsåtgång av alla på byrån, t.ex. "Inledande åtgärder och genomgång av
+ * handlingar" 30 min.
+ *
+ * Listan redigeras som en enhet (samma mönster som dokument-etiketterna, #621)
+ * och sparas via `organization.updateSettings`. Tidsåtgången är byråns
+ * HUVUDREGEL — juristen kan avvika per tidspost, annars håller den inte om
+ * domstolen frågar.
+ */
+
+import { useState } from "react";
+import { trpc } from "@/lib/client/trpc";
+import { formatMinutes } from "@/lib/client/utils";
+import { TIME_ENTRY_KIND_LABELS, type TimeEntryKind } from "@/lib/shared/schemas/enums";
+import {
+  STANDARD_ATGARD_STAGE_LABELS, type StandardAtgard, type StandardAtgardStage,
+} from "@/lib/shared/standard-atgard";
+
+const STAGE_OPTIONS = Object.entries(STANDARD_ATGARD_STAGE_LABELS) as Array<[StandardAtgardStage, string]>;
+const KIND_OPTIONS = Object.entries(TIME_ENTRY_KIND_LABELS) as Array<[TimeEntryKind, string]>;
+
+interface Draft {
+  description: string;
+  minutes: number;
+  stage: StandardAtgardStage;
+  kind: TimeEntryKind;
+}
+
+const emptyDraft = (): Draft => ({ description: "", minutes: 30, stage: "ANY", kind: "ARBETE" });
+
+/** Stabilt id ur beskrivningen (slug) — läsbart i git-diffen, till skillnad från
+ *  en uuid. Kollisioner bryts med ett löpnummer mot befintliga id:n. */
+function slugId(description: string, taken: ReadonlySet<string>): string {
+  const base = description.toLowerCase()
+    .replace(/[åä]/g, "a").replace(/ö/g, "o")
+    .replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")
+    .slice(0, 40) || "atgard";
+  if (!taken.has(base)) return base;
+  for (let n = 2; ; n++) if (!taken.has(`${base}-${n}`)) return `${base}-${n}`;
+}
+
+export function StandardAtgarderSection() {
+  const utils = trpc.useUtils();
+  const settings = trpc.organization.getSettings.useQuery();
+  const update = trpc.organization.updateSettings.useMutation({
+    onSuccess: () => void utils.organization.getSettings.invalidate(),
+  });
+
+  const list = settings.data?.standardAtgarder ?? [];
+  const save = (next: StandardAtgard[]): void => update.mutate({ standardAtgarder: next });
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-5 mb-5">
+      <p className="text-sm text-gray-500 mb-3">
+        Åtgärder som förekommer i varje ärende. De föreslås när tid registreras och
+        fyller beskrivning och tidsåtgång, så alla på byrån redovisar dem likadant.
+        Tiden är en <strong>huvudregel</strong> — handläggaren kan justera den i det
+        enskilda ärendet.
+      </p>
+
+      <AtgardTable list={list} isPending={update.isPending} onSave={save} />
+      <AddAtgardForm list={list} isPending={update.isPending} onSave={save} />
+
+      {update.error && (
+        <p className="mt-2 text-xs text-red-600">Kunde inte spara standardåtgärderna: {update.error.message}</p>
+      )}
+      <p className="mt-3 text-xs text-gray-400">
+        Skedet styr var åtgärden föreslås. <em>Avställ</em> behåller åtgärden för
+        historikens skull men slutar föreslå den — använd det i stället för att ta
+        bort en åtgärd som redan använts i ärenden.
+      </p>
+    </div>
+  );
+}
+
+interface ListProps {
+  list: StandardAtgard[];
+  isPending: boolean;
+  onSave: (next: StandardAtgard[]) => void;
+}
+
+function AtgardTable({ list, isPending, onSave }: ListProps) {
+  if (list.length === 0) {
+    return <p className="text-xs text-gray-400 italic mb-3">Inga standardåtgärder ännu.</p>;
+  }
+  return (
+    <table className="w-full text-sm mb-4">
+      <thead>
+        <tr className="text-left text-xs text-gray-500 border-b border-gray-200">
+          <th className="py-1.5">Beskrivning</th>
+          <th className="py-1.5 text-right">Tid</th>
+          <th className="py-1.5">Skede</th>
+          <th className="py-1.5">Kategori</th>
+          <th className="py-1.5"></th>
+        </tr>
+      </thead>
+      <tbody>
+        {list.map((a) => (
+          <tr key={a.id} className={`border-b border-gray-100 ${a.active ? "" : "text-gray-400"}`}>
+            <td className="py-1.5">{a.description}</td>
+            <td className="py-1.5 text-right font-mono">{formatMinutes(a.minutes)}</td>
+            <td className="py-1.5 text-xs">{STANDARD_ATGARD_STAGE_LABELS[a.stage]}</td>
+            <td className="py-1.5 text-xs">{TIME_ENTRY_KIND_LABELS[a.kind]}</td>
+            <td className="py-1.5 text-right whitespace-nowrap">
+              <button type="button" disabled={isPending}
+                onClick={() => onSave(list.map((x) => (x.id === a.id ? { ...x, active: !x.active } : x)))}
+                aria-label={`${a.active ? "Avställ" : "Aktivera"} ${a.description}`}
+                className="text-xs text-gray-500 hover:text-blue-600 hover:underline mr-3 disabled:opacity-50">
+                {a.active ? "Avställ" : "Aktivera"}
+              </button>
+              <button type="button" disabled={isPending}
+                onClick={() => onSave(list.filter((x) => x.id !== a.id))}
+                aria-label={`Ta bort ${a.description}`}
+                className="text-xs text-red-500 hover:underline disabled:opacity-50">
+                Ta bort
+              </button>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function AddAtgardForm({ list, isPending, onSave }: ListProps) {
+  const [draft, setDraft] = useState<Draft>(emptyDraft);
+  const description = draft.description.trim();
+
+  const add = (): void => {
+    if (!description || draft.minutes <= 0) return;
+    const id = slugId(description, new Set(list.map((a) => a.id)));
+    onSave([...list, { ...draft, description, id, paymentMethods: [], billable: true, active: true }]);
+    setDraft(emptyDraft());
+  };
+
+  return (
+    <div className="grid grid-cols-12 gap-2 items-end">
+      <div className="col-span-5">
+        <label htmlFor="sa-desc" className="block text-xs text-gray-500 mb-1">Beskrivning</label>
+        <input id="sa-desc" type="text" value={draft.description}
+          onChange={(e) => setDraft({ ...draft, description: e.target.value })}
+          onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); add(); } }}
+          placeholder="Inledande åtgärder och genomgång av handlingar"
+          className="w-full border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500" />
+      </div>
+      <div className="col-span-2">
+        <label htmlFor="sa-min" className="block text-xs text-gray-500 mb-1">Minuter</label>
+        <input id="sa-min" type="number" min={1} step={5} value={draft.minutes}
+          onChange={(e) => setDraft({ ...draft, minutes: Number.parseInt(e.target.value, 10) || 0 })}
+          className="w-full border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500" />
+      </div>
+      <div className="col-span-2">
+        <label htmlFor="sa-stage" className="block text-xs text-gray-500 mb-1">Skede</label>
+        <select id="sa-stage" value={draft.stage}
+          onChange={(e) => setDraft({ ...draft, stage: e.target.value as StandardAtgardStage })}
+          className="w-full border border-gray-300 rounded px-2 py-1 text-sm">
+          {STAGE_OPTIONS.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+        </select>
+      </div>
+      <div className="col-span-2">
+        <label htmlFor="sa-kind" className="block text-xs text-gray-500 mb-1">Kategori</label>
+        <select id="sa-kind" value={draft.kind}
+          onChange={(e) => setDraft({ ...draft, kind: e.target.value as TimeEntryKind })}
+          className="w-full border border-gray-300 rounded px-2 py-1 text-sm">
+          {KIND_OPTIONS.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+        </select>
+      </div>
+      <div className="col-span-1">
+        <button type="button" onClick={add} disabled={isPending || !description || draft.minutes <= 0}
+          className="w-full px-2 py-1 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50">
+          Lägg till
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -11,6 +11,7 @@ import { LedgerAccountsSection } from "@/components/settings/ledger-accounts-sec
 import { OrgDefaultsSection } from "@/components/settings/org-defaults-section";
 import { trpc } from "@/lib/client/trpc";
 import { DocumentTagsSection } from "./_document-tags-section";
+import { StandardAtgarderSection } from "./_standard-atgarder-section";
 
 // Zod vid parsegränsen (#187): logo-API:ts svar valideras.
 const logoResponseSchema = z.object({ logoUrl: z.string().nullable() });
@@ -571,6 +572,10 @@ export default function SettingsPage() {
       {/* 7. Dokument-etiketter */}
       <SectionHeader num={7} title="Dokument-etiketter (admin)" subtitle="Vokabulär av giltiga etiketter som dokument kan taggas med — av AI:n och handläggarna." />
       <DocumentTagsSection />
+
+      {/* 8. Standardåtgärder */}
+      <SectionHeader num={8} title="Standardåtgärder (admin)" subtitle="Åtgärder som förekommer i varje ärende — samma beskrivning och tidsåtgång för alla på byrån." />
+      <StandardAtgarderSection />
     </div>
   );
 }

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -31,6 +31,7 @@ import type {
   ServiceNoteId, TaskId, TimeEntryId, UserId, UserPreferenceId, WriteOffId,
 } from "@/lib/shared/schemas/ids";
 import type { SettlementView } from "@/lib/shared/settlement-view";
+import type { StandardAtgard } from "@/lib/shared/standard-atgard";
 import { baseColumns, boolDefault, orgScopedColumns } from "./columns";
 
 /** Monetärt öre-belopp (bigint → ingen int4-overflow för stora fakturor). */
@@ -54,6 +55,8 @@ export const organizations = pgTable("organizations", {
   /** Gränsbelopp (öre) för klientens ackumulerade självrisk innan ett aconto
    *  skickas (#885). NULL = använd default (SJALVRISK_ACCONTO_THRESHOLD_ORE). */
   accontoThresholdOre: integer("acconto_threshold_ore"),
+  /** Byråns standardåtgärder (#956) — samma beskrivning + tidsåtgång för alla. */
+  standardAtgarder: jsonb("standard_atgarder").notNull().default([]).$type<StandardAtgard[]>(),
 });
 
 export const offices = pgTable("offices", {
@@ -178,6 +181,9 @@ export const timeEntries = pgTable("time_entries", {
   hourlyRate: integer("hourly_rate").notNull(),
   /** ARBETE (default) eller TIDSSPILLAN (#891) — styr slutregleringens norm. */
   kind: text("kind").$type<"ARBETE" | "ARBETE_OBEKVAM_TID" | "TIDSSPILLAN" | "TIDSSPILLAN_OVRIG_TID">(),
+  /** Byråns standardåtgärd posten registrerades ur (#956) — spårbarhet: går att
+   *  se vilka poster som kommer ur en standard och om tiden justerats. */
+  standardAtgardId: text("standard_atgard_id"),
   billable: boolDefault("billable", true),
   invoiceId: uuid("invoice_id").$type<InvoiceId>(),
   frozenAt: timestamp("frozen_at", { withTimezone: true }),

--- a/src/lib/server/routers/organization.ts
+++ b/src/lib/server/routers/organization.ts
@@ -4,6 +4,7 @@ import { ledgerAccountMapSchema } from "@/lib/shared/accounting/account-map";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { officeIdSchema, organizationIdSchema, asId } from "@/lib/shared/schemas/ids";
 import type { Office, Organization } from "@/lib/shared/schemas/organization";
+import { normalizeStandardAtgarder, standardAtgardSchema } from "@/lib/shared/standard-atgard";
 import { router, protectedProcedure } from "../trpc";
 
 /** Nullbara org-fält (nullish → null). Utbruten så komplexiteten (många `??`)
@@ -30,6 +31,8 @@ function toOrgSettings(org: Organization) {
     documentTags: org.documentTags ?? [],
     /** Gränsbelopp (öre) för aconto-utskick (#885). */
     accontoThresholdOre: org.accontoThresholdOre ?? null,
+    /** Byråns standardåtgärder (#956) — samma beskrivning + tid för alla. */
+    standardAtgarder: org.standardAtgarder ?? [],
   };
 }
 
@@ -59,6 +62,9 @@ export const organizationRouter = router({
         documentTags: z.array(z.string()).optional(),
         /** Gränsbelopp (öre) för aconto-utskick (#885). */
         accontoThresholdOre: z.number().int().nonnegative().optional(),
+        /** Byråns standardåtgärder (#956). HELA listan ersätts — admin redigerar
+         *  den som en enhet, så en borttagen post försvinner. */
+        standardAtgarder: z.array(standardAtgardSchema).optional(),
       })
     )
     .mutation(({ ctx, input }) => {
@@ -67,6 +73,7 @@ export const organizationRouter = router({
       if (patch.documentTags) {
         patch.documentTags = [...new Set(patch.documentTags.map((t) => t.trim()).filter(Boolean))];
       }
+      if (patch.standardAtgarder) patch.standardAtgarder = normalizeStandardAtgarder(patch.standardAtgarder);
       return ctx.repos.organizations.update(asId<"OrganizationId">(ctx.user.organizationId), patch satisfies Partial<Organization>);
     }),
 
@@ -87,10 +94,14 @@ export const organizationRouter = router({
         email: z.string().optional(),
         bankgiro: z.string().optional(),
         accontoThresholdOre: z.number().int().nonnegative().optional(),
+        /** Byråns standardåtgärder (#956) — setup-/seed-väg (ADR 0003). */
+        standardAtgarder: z.array(standardAtgardSchema).optional(),
       })
     )
     .mutation(({ ctx, input }) =>
-      ctx.repos.organizations.create(input satisfies Partial<Organization>),
+      // omitUndefined: `exactOptionalPropertyTypes` tillåter inte explicit
+      // undefined på fält med default (standardAtgarder).
+      ctx.repos.organizations.create(omitUndefined(input) satisfies Partial<Organization>),
     ),
 
   // ── Offices ─────────────────────────────────────────────────────

--- a/src/lib/server/routers/timeEntry.ts
+++ b/src/lib/server/routers/timeEntry.ts
@@ -48,6 +48,8 @@ export const timeEntryRouter = router({
         billable: z.boolean().default(true),
         /** ARBETE (default) eller TIDSSPILLAN (#891). */
         kind: timeEntryKindSchema.optional(),
+        /** Byråns standardåtgärd posten registrerades ur (#956) — spårbarhet. */
+        standardAtgardId: z.string().optional(),
         // Valfria setup-fält (demo-generator/fixtures, ADR 0003).
         id: timeEntryIdSchema.optional(),
         userId: userIdSchema.optional(),
@@ -69,7 +71,8 @@ export const timeEntryRouter = router({
         minutes: input.minutes,
         description: input.description,
         hourlyRate: input.hourlyRate ?? user.hourlyRate ?? 0,
-        ...(input.kind ? { kind: input.kind } : {}),
+        kind: input.kind,
+        standardAtgardId: input.standardAtgardId,
         billable: input.billable,
         invoiceId: input.invoiceId ?? null,
         ...(input.createdAt ? { createdAt: new Date(input.createdAt) } : {}),
@@ -89,6 +92,8 @@ export const timeEntryRouter = router({
         /** Arvodeskategori (#953) — styr vilken årsnorm slutregleringen värderar
          *  posten på. Rättbar i efterhand: kategorin missas lätt vid inmatning. */
         kind: timeEntryKindSchema.optional(),
+        /** Byråns standardåtgärd (#956). Sätts när posten byter till/från en standard. */
+        standardAtgardId: z.string().nullable().optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -96,12 +101,13 @@ export const timeEntryRouter = router({
       // INNAN update. NOT_FOUND vid mismatch.
       const owned = await ctx.repos.timeEntries.getByIdInOrg(input.id, ctx.orgId);
       if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
-      const { id, date, minutes, description, billable, kind } = input;
+      const { id, date, minutes, description, billable, kind, standardAtgardId } = input;
       const updated = await ctx.repos.timeEntries.update(id, omitUndefined({
         minutes,
         description,
         billable,
         kind,
+        standardAtgardId,
         ...(date ? { date: new Date(date) } : {}),
       }) satisfies Partial<TimeEntry>);
       await emit.timeEntryUpdated(ctx, { id: updated.id, matterId: updated.matterId });

--- a/src/lib/shared/schemas/billing.ts
+++ b/src/lib/shared/schemas/billing.ts
@@ -45,6 +45,8 @@ export const timeEntrySchema = z.object({
   /** Arbete (null/undefined = ARBETE) eller TIDSSPILLAN — styr vilken norm
    *  slutregleringen värderar minuterna på för rättshjälp (#891). */
   kind: timeEntryKindSchema.nullish(),
+  /** Byråns standardåtgärd posten registrerades ur (#956). Null = fritext-post. */
+  standardAtgardId: z.string().nullish(),
   billable: z.boolean().default(true),
   /** @deprecated Använd `frozenByBillingRunId`. invoiceId behålls för
    *  bakåt­kompatibilitet med befintlig demo/billing — nya flöden ska

--- a/src/lib/shared/schemas/organization.ts
+++ b/src/lib/shared/schemas/organization.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { ledgerAccountMapSchema } from "../accounting/account-map";
+import { standardAtgardSchema } from "../standard-atgard";
 import { baseFields, dateLike } from "./common";
 import { organizationIdSchema, officeIdSchema } from "./ids";
 
@@ -27,6 +28,9 @@ export const organizationSchema = z.object({
   /** Gränsbelopp (öre) för klientens ackumulerade självrisk innan ett aconto
    *  skickas (#885). NULL = använd default (SJALVRISK_ACCONTO_THRESHOLD_ORE). */
   accontoThresholdOre: z.number().int().nonnegative().nullish(),
+  /** Byråns standardåtgärder (#956) — åtgärder som förekommer i varje ärende med
+   *  samma beskrivning och tidsåtgång för alla på byrån. Redigeras i org-inställningarna. */
+  standardAtgarder: z.array(standardAtgardSchema).default([]),
 }).passthrough();
 
 export type Organization = z.infer<typeof organizationSchema>;

--- a/src/lib/shared/standard-atgard.ts
+++ b/src/lib/shared/standard-atgard.ts
@@ -1,0 +1,97 @@
+/**
+ * Byråns STANDARDÅTGÄRDER (#956) — åtgärder som förekommer i varje ärende och
+ * som ska registreras med samma beskrivning och samma tidsåtgång av alla på
+ * byrån, t.ex. "Inledande åtgärder och genomgång av handlingar" 30 min.
+ *
+ * Listan är BYRÅKONFIGURATION: den bor på organisationen (samma mönster som
+ * `documentTags`, #621), så den synkar via git och är identisk för alla. Varje
+ * post har ett stabilt `id` så en tidspost kan referera den (`standardAtgardId`)
+ * — då syns det vilka poster som kommer ur en standard och om tiden justerats.
+ *
+ * Tidsåtgången är en HUVUDREGEL, inte ett lås: juristen ska kunna avvika i det
+ * enskilda ärendet (annars håller den inte om domstolen frågar).
+ */
+
+import { z } from "zod";
+import { paymentMethodSchema, timeEntryKindSchema, type PaymentMethod } from "./schemas/enums";
+
+/**
+ * När åtgärden normalt hör hemma i uppdraget. Styr var den FÖRESLÅS — den kan
+ * alltid registreras manuellt oavsett skede.
+ */
+export const STANDARD_ATGARD_STAGE_LABELS = {
+  OPENING: "Inledande — vid uppdragets början",
+  CLOSING: "Avslutande — vid dom eller avslut",
+  ANY: "Löpande — när som helst under uppdraget",
+} as const satisfies Record<string, string>;
+
+export const standardAtgardStageSchema = z.enum(["OPENING", "CLOSING", "ANY"]);
+export type StandardAtgardStage = z.infer<typeof standardAtgardStageSchema>;
+
+/**
+ * KRONOLOGISK ordning för presentation: inledande → löpande → avslutande.
+ * Egen konstant, inte enumets deklarationsordning — den grupperar de två
+ * livscykel-skedena och råkar därför sätta CLOSING före ANY.
+ */
+const STAGE_ORDER: Record<StandardAtgardStage, number> = { OPENING: 0, ANY: 1, CLOSING: 2 };
+
+export const standardAtgardSchema = z.object({
+  /** Stabilt id (slug eller uuid) — refereras av tidsposten. */
+  id: z.string().min(1),
+  /** Ordalydelsen som hamnar på tidsposten, och därmed i kostnadsräkningen. */
+  description: z.string().min(1),
+  /** Tidsåtgången som huvudregel. Redigerbar per tidspost. */
+  minutes: z.number().int().positive(),
+  /** Arvodeskategori (#953) — nästan alltid ARBETE, men helgtaxan kan förekomma. */
+  kind: timeEntryKindSchema.default("ARBETE"),
+  stage: standardAtgardStageSchema.default("ANY"),
+  /** Betalningssätt åtgärden gäller. TOM = alla (det normala). */
+  paymentMethods: z.array(paymentMethodSchema).default([]),
+  billable: z.boolean().default(true),
+  /** Avställd åtgärd behålls för historikens skull men föreslås inte längre. */
+  active: z.boolean().default(true),
+});
+
+export type StandardAtgard = z.infer<typeof standardAtgardSchema>;
+
+/**
+ * Byråns åtgärder som gäller ett ärende: aktiva, och antingen utan
+ * betalningssätts-begränsning eller med ärendets betalningssätt i listan.
+ * `stage` filtrerar valfritt (förslagsvägen); utan `stage` returneras alla
+ * tillämpliga (väljaren i tidsformuläret).
+ *
+ * Ordningen är skede-ordning (inledande → löpande → avslutande) och därefter
+ * beskrivning, så listan ser likadan ut för alla på byrån.
+ */
+export function applicableStandardAtgarder(
+  list: readonly StandardAtgard[] | null | undefined,
+  paymentMethod: PaymentMethod | null | undefined,
+  stage?: StandardAtgardStage,
+): StandardAtgard[] {
+  return (list ?? [])
+    .filter((a) => a.active)
+    .filter((a) => stage === undefined || a.stage === stage)
+    .filter((a) => appliesToMethod(a, paymentMethod))
+    .sort((a, b) => STAGE_ORDER[a.stage] - STAGE_ORDER[b.stage] || a.description.localeCompare(b.description, "sv"));
+}
+
+/** Tom `paymentMethods` = åtgärden gäller alla betalningssätt. */
+function appliesToMethod(a: StandardAtgard, paymentMethod: PaymentMethod | null | undefined): boolean {
+  if (a.paymentMethods.length === 0) return true;
+  return paymentMethod != null && a.paymentMethods.includes(paymentMethod);
+}
+
+/**
+ * Normalisera en inkommande lista (admin sparar hela listan): trimma texter,
+ * släng poster utan beskrivning, och dedupa på `id` — sista vinner, så en
+ * redigerad post ersätter sin tidigare version i stället för att dubbleras.
+ */
+export function normalizeStandardAtgarder(list: readonly StandardAtgard[]): StandardAtgard[] {
+  const byId = new Map<string, StandardAtgard>();
+  for (const a of list) {
+    const description = a.description.trim();
+    if (!description) continue;
+    byId.set(a.id, { ...a, id: a.id.trim(), description });
+  }
+  return [...byId.values()];
+}

--- a/test/unit/app/matters/time-section.test.tsx
+++ b/test/unit/app/matters/time-section.test.tsx
@@ -21,6 +21,17 @@ const timeQuery = {
   } as unknown,
   isLoading: false,
 };
+// Byråns standardåtgärder (#956) — org-inställning, samma lista för alla.
+const orgSettingsQuery = {
+  data: {
+    standardAtgarder: [
+      { id: "inledande-atgarder", description: "Inledande åtgärder och genomgång av handlingar", minutes: 30, kind: "ARBETE", stage: "OPENING", paymentMethods: [], billable: true, active: true },
+      { id: "avslutande-atgarder", description: "Avslutande åtgärder inklusive mottagande av dom och kontakt med huvudman", minutes: 45, kind: "ARBETE", stage: "CLOSING", paymentMethods: [], billable: true, active: true },
+      { id: "avstalld", description: "Avställd åtgärd", minutes: 15, kind: "ARBETE", stage: "ANY", paymentMethods: [], billable: true, active: false },
+    ],
+  } as unknown,
+  isLoading: false,
+};
 const createMutate = vi.fn();
 const updateMutate = vi.fn();
 const noopMut = () => ({ mutate: vi.fn(), isPending: false });
@@ -42,6 +53,7 @@ vi.mock("@/lib/client/trpc", () => ({
       clearOrgDefault: { useMutation: noopMut },
     },
     user: { current: { useQuery: () => ({ data: { id: "u1", role: "LAWYER" } }) } },
+    organization: { getSettings: { useQuery: () => orgSettingsQuery } },
   },
 }));
 
@@ -94,5 +106,65 @@ describe("TimeSection — arvodeskategori (#953)", () => {
     render(<TimeSection matterId={matterId} paymentMethod="RATTSSKYDD" />);
     fireEvent.click(screen.getByText("+ Registrera tid"));
     expect(screen.getByText(/slutregleringsårets normer/)).toBeInTheDocument();
+  });
+});
+
+/**
+ * Byråns standardåtgärder (#956): en standard ska fylla beskrivning OCH tid, så
+ * alla på byrån redovisar samma åtgärd likadant — men båda ska förbli
+ * redigerbara, för "som huvudregel" betyder att avsteg måste vara möjligt.
+ */
+describe("TimeSection — standardåtgärder (#956)", () => {
+  it("väljaren listar byråns AKTIVA åtgärder med tiden synlig", () => {
+    render(<TimeSection matterId={matterId} />);
+    fireEvent.click(screen.getByText("+ Registrera tid"));
+    const select = screen.getByLabelText("Standardåtgärd") as HTMLSelectElement;
+    const labels = Array.from(select.options).map((o) => o.textContent);
+    expect(labels[0]).toBe("— egen beskrivning —"); // fritext är default
+    // Tiden formateras med appens `formatMinutes` (0:30), samma som i tidslistan.
+    expect(labels).toContain("Inledande åtgärder och genomgång av handlingar (0:30)");
+    expect(labels).toContain("Avslutande åtgärder inklusive mottagande av dom och kontakt med huvudman (0:45)");
+    // Avställda åtgärder föreslås inte.
+    expect(labels.some((l) => l?.includes("Avställd"))).toBe(false);
+  });
+
+  it("val av åtgärd fyller beskrivning + tid och skickar standardAtgardId", () => {
+    render(<TimeSection matterId={matterId} />);
+    fireEvent.click(screen.getByText("+ Registrera tid"));
+    fireEvent.change(screen.getByLabelText("Standardåtgärd"), { target: { value: "avslutande-atgarder" } });
+
+    expect(screen.getByPlaceholderText("Beskrivning *")).toHaveValue("Avslutande åtgärder inklusive mottagande av dom och kontakt med huvudman");
+    expect(screen.getByLabelText("Tid (minuter) *")).toHaveValue("45");
+
+    fireEvent.click(screen.getByText("Spara"));
+    expect(createMutate).toHaveBeenCalledWith(expect.objectContaining({
+      matterId, standardAtgardId: "avslutande-atgarder", minutes: 45,
+      description: "Avslutande åtgärder inklusive mottagande av dom och kontakt med huvudman",
+    }));
+  });
+
+  it("tiden är en HUVUDREGEL — den går att justera efter att åtgärden valts", () => {
+    render(<TimeSection matterId={matterId} />);
+    fireEvent.click(screen.getByText("+ Registrera tid"));
+    fireEvent.change(screen.getByLabelText("Standardåtgärd"), { target: { value: "inledande-atgarder" } });
+    fireEvent.change(screen.getByLabelText("Tid (minuter) *"), { target: { value: "75" } });
+
+    fireEvent.click(screen.getByText("Spara"));
+    // Kopplingen behålls så byrån kan se att tiden avvikit från huvudregeln.
+    expect(createMutate).toHaveBeenCalledWith(expect.objectContaining({
+      standardAtgardId: "inledande-atgarder", minutes: 75,
+    }));
+  });
+
+  it("tillbaka till fritext nollar kopplingen men behåller texten", () => {
+    render(<TimeSection matterId={matterId} />);
+    fireEvent.click(screen.getByText("+ Registrera tid"));
+    const select = screen.getByLabelText("Standardåtgärd");
+    fireEvent.change(select, { target: { value: "inledande-atgarder" } });
+    fireEvent.change(select, { target: { value: "" } });
+
+    expect(screen.getByPlaceholderText("Beskrivning *")).toHaveValue("Inledande åtgärder och genomgång av handlingar");
+    fireEvent.click(screen.getByText("Spara"));
+    expect(createMutate).toHaveBeenCalledWith(expect.objectContaining({ standardAtgardId: "" }));
   });
 });

--- a/test/unit/app/settings/page.test.tsx
+++ b/test/unit/app/settings/page.test.tsx
@@ -170,7 +170,11 @@ describe("SettingsPage", () => {
   it("visar fetcher-fel från updateSettings", () => {
     updateSettingsState.error = { message: "Något fel" };
     render(<SettingsPage />);
-    expect(screen.getByText(/Något fel/i)).toBeInTheDocument();
+    // getAllByText: mocken delar ut SAMMA mutation-state till varje
+    // `useMutation`-anrop, så alla sektioner som lyssnar på updateSettings visar
+    // felet samtidigt. I drift har de separata instanser och bara den som
+    // faktiskt misslyckades visar sitt fel.
+    expect(screen.getAllByText(/Något fel/i).length).toBeGreaterThan(0);
   });
 
   it("uppdaterar byråns namn-input och auto-sparar med nytt värde", async () => {

--- a/test/unit/app/settings/standard-atgarder-section.test.tsx
+++ b/test/unit/app/settings/standard-atgarder-section.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * `StandardAtgarderSection` (#956) — admin underhåller byråns standardåtgärder.
+ * Listan är byråkonfiguration: den sparas som en ENHET, så en borttagen åtgärd
+ * försvinner ur den sparade listan. Avställning finns för åtgärder som redan
+ * använts i ärenden — de får inte bara raderas, då tappar historiken sin referens.
+ */
+
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest-compat";
+import { StandardAtgarderSection } from "@/app/settings/_standard-atgarder-section";
+
+const settingsQuery = {
+  data: {
+    standardAtgarder: [
+      { id: "inledande-atgarder", description: "Inledande åtgärder och genomgång av handlingar", minutes: 30, kind: "ARBETE", stage: "OPENING", paymentMethods: [], billable: true, active: true },
+      { id: "gammal", description: "Gammal åtgärd", minutes: 15, kind: "ARBETE", stage: "ANY", paymentMethods: [], billable: true, active: false },
+    ],
+  } as unknown,
+  isLoading: false,
+};
+const updateMutate = vi.fn();
+
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: {
+    useUtils: () => ({ organization: { getSettings: { invalidate: vi.fn() } } }),
+    organization: {
+      getSettings: { useQuery: () => settingsQuery },
+      updateSettings: { useMutation: () => ({ mutate: updateMutate, isPending: false, error: null }) },
+    },
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("StandardAtgarderSection", () => {
+  it("listar byråns åtgärder med tid, skede och kategori", () => {
+    render(<StandardAtgarderSection />);
+    // Skede-/kategori-etiketterna finns även i lägg-till-formulärets dropdowns,
+    // så tabellen frågas ut för sig.
+    const table = within(screen.getByRole("table"));
+    expect(table.getByText("Inledande åtgärder och genomgång av handlingar")).toBeInTheDocument();
+    expect(table.getByText("0:30")).toBeInTheDocument();
+    expect(table.getByText("Inledande — vid uppdragets början")).toBeInTheDocument();
+    // Avställda visas kvar (historiken refererar dem) men märks med Aktivera.
+    expect(table.getByText("Gammal åtgärd")).toBeInTheDocument();
+    expect(screen.getByLabelText("Aktivera Gammal åtgärd")).toBeInTheDocument();
+  });
+
+  it("ny åtgärd får ett läsbart slug-id ur beskrivningen", () => {
+    render(<StandardAtgarderSection />);
+    fireEvent.change(screen.getByLabelText("Beskrivning"), { target: { value: "Avslutande åtgärder inklusive dom" } });
+    fireEvent.change(screen.getByLabelText("Minuter"), { target: { value: "45" } });
+    fireEvent.change(screen.getByLabelText("Skede"), { target: { value: "CLOSING" } });
+    fireEvent.click(screen.getByText("Lägg till"));
+
+    expect(updateMutate).toHaveBeenCalledTimes(1);
+    const saved = updateMutate.mock.calls[0]![0] as { standardAtgarder: Array<Record<string, unknown>> };
+    expect(saved.standardAtgarder).toHaveLength(3); // befintliga bevarade
+    expect(saved.standardAtgarder[2]).toMatchObject({
+      id: "avslutande-atgarder-inklusive-dom", // å/ä/ö → a/a/o, inte bortkastade
+      description: "Avslutande åtgärder inklusive dom",
+      minutes: 45, stage: "CLOSING", active: true,
+    });
+  });
+
+  it("id-kollision bryts med löpnummer i stället för att skriva över", () => {
+    render(<StandardAtgarderSection />);
+    // "Gammal åtgärd" slug:as till "gammal-atgard"; skriv en beskrivning vars
+    // slug blir exakt ett BEFINTLIGT id ("gammal") → kollision.
+    fireEvent.change(screen.getByLabelText("Beskrivning"), { target: { value: "Gammal" } });
+    fireEvent.click(screen.getByText("Lägg till"));
+    const saved = updateMutate.mock.calls[0]![0] as { standardAtgarder: Array<{ id: string }> };
+    expect(saved.standardAtgarder.map((a) => a.id)).toEqual(["inledande-atgarder", "gammal", "gammal-2"]);
+  });
+
+  it("avställning växlar active utan att röra övriga åtgärder", () => {
+    render(<StandardAtgarderSection />);
+    fireEvent.click(screen.getByLabelText("Avställ Inledande åtgärder och genomgång av handlingar"));
+    const saved = updateMutate.mock.calls[0]![0] as { standardAtgarder: Array<{ id: string; active: boolean }> };
+    expect(saved.standardAtgarder).toEqual([
+      expect.objectContaining({ id: "inledande-atgarder", active: false }),
+      expect.objectContaining({ id: "gammal", active: false }),
+    ]);
+  });
+
+  it("borttagning sparar listan UTAN åtgärden (hela listan ersätts)", () => {
+    render(<StandardAtgarderSection />);
+    fireEvent.click(screen.getByLabelText("Ta bort Gammal åtgärd"));
+    const saved = updateMutate.mock.calls[0]![0] as { standardAtgarder: Array<{ id: string }> };
+    expect(saved.standardAtgarder.map((a) => a.id)).toEqual(["inledande-atgarder"]);
+  });
+
+  it("tom beskrivning eller 0 minuter går inte att spara", () => {
+    render(<StandardAtgarderSection />);
+    const button = screen.getByText("Lägg till");
+    expect(button).toBeDisabled();
+    fireEvent.change(screen.getByLabelText("Beskrivning"), { target: { value: "   " } });
+    expect(button).toBeDisabled();
+    fireEvent.change(screen.getByLabelText("Beskrivning"), { target: { value: "Åtgärd" } });
+    fireEvent.change(screen.getByLabelText("Minuter"), { target: { value: "0" } });
+    expect(button).toBeDisabled();
+  });
+});

--- a/test/unit/app/time-section-invoiced.test.tsx
+++ b/test/unit/app/time-section-invoiced.test.tsx
@@ -22,6 +22,9 @@ vi.mock("@/lib/client/trpc", () => {
         prefs: { get: { invalidate: vi.fn() }, listOrgDefaults: { invalidate: vi.fn() } },
       }),
       user: { current: { useQuery: () => ({ data: { id: "u-1", role: "LAWYER" } }) } },
+      // Byråns standardåtgärder (#956) — TimeSection läser dem för väljaren.
+      // Tom lista → ingen väljare renderas, vilket den här filens tester inte rör.
+      organization: { getSettings: { useQuery: () => ({ data: { standardAtgarder: [] }, isLoading: false }) } },
       prefs: {
         get: { useQuery: () => ({ data: null }) },
         save: { useMutation: () => noopMut },

--- a/test/unit/lib/standard-atgard.test.ts
+++ b/test/unit/lib/standard-atgard.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Byråns standardåtgärder (#956) — urvalslogiken. Poängen med hela funktionen är
+ * att ALLA på byrån ser samma lista i samma ordning; går urvalet isär mellan
+ * jurister får kostnadsräkningarna olika ordalydelse för samma åtgärd, vilket är
+ * precis det problem åtgärderna ska lösa.
+ */
+import { describe, it, expect } from "vitest-compat";
+import {
+  applicableStandardAtgarder, normalizeStandardAtgarder, type StandardAtgard,
+} from "@/lib/shared/standard-atgard";
+
+const atgard = (over: Partial<StandardAtgard> & { id: string }): StandardAtgard => ({
+  description: `Åtgärd ${over.id}`, minutes: 30, kind: "ARBETE", stage: "ANY",
+  paymentMethods: [], billable: true, active: true, ...over,
+});
+
+describe("applicableStandardAtgarder", () => {
+  it("returnerar bara AKTIVA åtgärder — avställda finns kvar men föreslås inte", () => {
+    const list = [atgard({ id: "a" }), atgard({ id: "b", active: false })];
+    expect(applicableStandardAtgarder(list, "PRIVAT").map((a) => a.id)).toEqual(["a"]);
+  });
+
+  it("tom paymentMethods = gäller ALLA betalningssätt (normalfallet)", () => {
+    const list = [atgard({ id: "alla" })];
+    for (const m of ["PRIVAT", "RATTSHJALP", "RATTSSKYDD", "OFFENTLIGT_UPPDRAG"] as const) {
+      expect(applicableStandardAtgarder(list, m).map((a) => a.id)).toEqual(["alla"]);
+    }
+    // Även utan känt betalningssätt (nytt ärende, PENDING) ska den föreslås.
+    expect(applicableStandardAtgarder(list, null).map((a) => a.id)).toEqual(["alla"]);
+  });
+
+  it("begränsad åtgärd gäller BARA sina betalningssätt", () => {
+    const list = [atgard({ id: "bara-rh", paymentMethods: ["RATTSHJALP"] })];
+    expect(applicableStandardAtgarder(list, "RATTSHJALP").map((a) => a.id)).toEqual(["bara-rh"]);
+    expect(applicableStandardAtgarder(list, "PRIVAT")).toEqual([]);
+    // Okänt betalningssätt får inte råka matcha en begränsad åtgärd.
+    expect(applicableStandardAtgarder(list, null)).toEqual([]);
+  });
+
+  it("filtrerar på skede när det anges — förslagsvägen", () => {
+    const list = [
+      atgard({ id: "start", stage: "OPENING" }),
+      atgard({ id: "slut", stage: "CLOSING" }),
+      atgard({ id: "lopande", stage: "ANY" }),
+    ];
+    expect(applicableStandardAtgarder(list, "PRIVAT", "CLOSING").map((a) => a.id)).toEqual(["slut"]);
+    // Utan skede: alla tillämpliga (väljaren i tidsformuläret).
+    expect(applicableStandardAtgarder(list, "PRIVAT")).toHaveLength(3);
+  });
+
+  it("ordnas i skede-ordning, därefter beskrivning på svenska", () => {
+    const list = [
+      atgard({ id: "3", stage: "CLOSING", description: "Avslutande åtgärder" }),
+      atgard({ id: "2", stage: "ANY", description: "Överklagande" }),
+      atgard({ id: "1", stage: "OPENING", description: "Inledande åtgärder" }),
+      atgard({ id: "2b", stage: "ANY", description: "Ändring av talan" }),
+    ];
+    // Skede först (inledande → löpande → avslutande); inom skedet svensk
+    // kollation, där Ä/Ö sorteras efter Z — inte som A/O.
+    expect(applicableStandardAtgarder(list, "PRIVAT").map((a) => a.id)).toEqual(["1", "2b", "2", "3"]);
+  });
+
+  it("tom/saknad lista ger tom lista (byrå som inte satt upp några)", () => {
+    expect(applicableStandardAtgarder([], "PRIVAT")).toEqual([]);
+    expect(applicableStandardAtgarder(null, "PRIVAT")).toEqual([]);
+    expect(applicableStandardAtgarder(undefined, "PRIVAT")).toEqual([]);
+  });
+});
+
+describe("normalizeStandardAtgarder", () => {
+  it("trimmar beskrivningen och slänger poster utan text", () => {
+    const out = normalizeStandardAtgarder([
+      atgard({ id: "a", description: "  Inledande åtgärder  " }),
+      atgard({ id: "b", description: "   " }),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.description).toBe("Inledande åtgärder");
+  });
+
+  it("dedupar på id — en redigerad post ERSÄTTER sin tidigare version", () => {
+    const out = normalizeStandardAtgarder([
+      atgard({ id: "inledande", minutes: 30 }),
+      atgard({ id: "inledande", minutes: 45 }),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.minutes).toBe(45);
+  });
+});

--- a/test/unit/server/routers/organization.test.ts
+++ b/test/unit/server/routers/organization.test.ts
@@ -325,4 +325,43 @@ describe("organization.updateSettings", () => {
       expect.objectContaining({ where: { id: "org-a" }, data: expect.objectContaining({ bankgiro: "999-8888" }) }),
     );
   });
+
+  /**
+   * Standardåtgärder (#956) — byråkonfiguration som ska vara identisk för alla.
+   * Listan sparas som en enhet och normaliseras server-side, så en dubblett eller
+   * en post med bara blanksteg inte hamnar i byråns lista.
+   */
+  it("normaliserar standardåtgärderna: trimmar, slänger tomma, dedupar på id", async () => {
+    mockPrisma.organization.findFirst.mockResolvedValue({ id: "org-a" });
+    mockPrisma.organization.update.mockResolvedValue({ id: "org-a", name: "Advokat AB" });
+
+    const atgard = (over: Record<string, unknown>) => ({
+      id: "x", description: "Åtgärd", minutes: 30, kind: "ARBETE" as const,
+      stage: "ANY" as const, paymentMethods: [], billable: true, active: true, ...over,
+    });
+    await makeCaller("org-a").updateSettings({
+      standardAtgarder: [
+        atgard({ id: "inledande", description: "  Inledande åtgärder  ", minutes: 30 }),
+        atgard({ id: "tom", description: "   " }),
+        atgard({ id: "inledande", description: "Inledande åtgärder", minutes: 45 }),
+      ],
+    });
+
+    const data = mockPrisma.organization.update.mock.calls[0]![0].data as {
+      standardAtgarder: Array<{ id: string; description: string; minutes: number }>;
+    };
+    expect(data.standardAtgarder).toHaveLength(1);
+    expect(data.standardAtgarder[0]).toMatchObject({ id: "inledande", description: "Inledande åtgärder", minutes: 45 });
+  });
+
+  it("avvisar en standardåtgärd med ogiltig tid (0 eller negativ)", async () => {
+    mockPrisma.organization.findFirst.mockResolvedValue({ id: "org-a" });
+    await expect(makeCaller("org-a").updateSettings({
+      standardAtgarder: [{
+        id: "noll", description: "Åtgärd utan tid", minutes: 0, kind: "ARBETE",
+        stage: "ANY", paymentMethods: [], billable: true, active: true,
+      }],
+    })).rejects.toThrow();
+    expect(mockPrisma.organization.update).not.toHaveBeenCalled();
+  });
 });

--- a/tooling/db/migrations/0020_standard_atgarder.sql
+++ b/tooling/db/migrations/0020_standard_atgarder.sql
@@ -1,0 +1,7 @@
+-- #956: byråns standardåtgärder — åtgärder som förekommer i varje ärende och som
+-- ska registreras med samma beskrivning och tidsåtgång av alla på byrån.
+-- Byråkonfiguration, samma mönster som organizations.document_tags (#621).
+ALTER TABLE organizations ADD COLUMN IF NOT EXISTS standard_atgarder jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+-- Spårbarhet: vilken standardåtgärd tidsposten registrerades ur (NULL = fritext).
+ALTER TABLE time_entries ADD COLUMN IF NOT EXISTS standard_atgard_id text;

--- a/tooling/demo-generator/populate.ts
+++ b/tooling/demo-generator/populate.ts
@@ -55,7 +55,7 @@ function pick(seed: SeedDataset, key: keyof SeedDataset): Row[] {
 async function createOrganizations(c: AnyCaller, rows: Row[]): Promise<void> {
   for (const o of rows) {
     await c.organization.create(
-      defined({ id: o.id, name: o.name, orgNumber: o.orgNumber, address: o.address, phone: o.phone, email: o.email, bankgiro: o.bankgiro, accontoThresholdOre: o.accontoThresholdOre }),
+      defined({ id: o.id, name: o.name, orgNumber: o.orgNumber, address: o.address, phone: o.phone, email: o.email, bankgiro: o.bankgiro, accontoThresholdOre: o.accontoThresholdOre, standardAtgarder: o.standardAtgarder }),
     );
   }
 }

--- a/tooling/scripts/seed-data.ts
+++ b/tooling/scripts/seed-data.ts
@@ -230,6 +230,20 @@ export function buildSeed(opts: BuildSeedOpts = {}): SeedDataset {
       email: `kontor@${emailDomain}`, phone: "08-100 100",
       address: "Storgatan 1, 111 11 Stockholm",
       accontoThresholdOre: 150_000, // 1500 kr — gränsbelopp för aconto-utskick (#885)
+      // Byråns standardåtgärder (#956): samma beskrivning + tidsåtgång för alla.
+      // Tiden är en huvudregel — handläggaren justerar per ärende vid behov.
+      standardAtgarder: [
+        {
+          id: "inledande-atgarder", stage: "OPENING", minutes: 30, kind: "ARBETE",
+          description: "Inledande åtgärder och genomgång av handlingar",
+          paymentMethods: [], billable: true, active: true,
+        },
+        {
+          id: "avslutande-atgarder", stage: "CLOSING", minutes: 45, kind: "ARBETE",
+          description: "Avslutande åtgärder inklusive mottagande av dom och kontakt med huvudman",
+          paymentMethods: [], billable: true, active: true,
+        },
+      ],
       createdAt: isoDate(-365), updatedAt: isoDate(-30),
     }],
     offices: [{


### PR DESCRIPTION
Steg 1 av #956.

## Problem

Åtgärder som förekommer i **varje** ärende skrevs på fritext av varje jurist:

- *"Inledande åtgärder och genomgång av handlingar"* — 30 min som huvudregel
- *"Avslutande åtgärder inklusive mottagande av dom och kontakt med huvudman"* — 45 min

Följden är olika formuleringar och olika tid för samma åtgärd i samma byrås kostnadsräkningar.

## Modell

Listan är byråkonfiguration och läggs som ett **validerat fält på organisationen** — samma mönster som `documentTags` (#621). Den synkar via git och är identisk för alla. Posterna redigeras som en enhet och refereras bara med sitt id, så en egen entitet med repo-trio (interface + in-memory + drizzle + wiring) skulle inte bära sin vikt här.

```ts
standardAtgardSchema = { id, description, minutes, kind, stage, paymentMethods, billable, active }
```

## Ändringar

- **Shared:** `standardAtgardSchema` + `applicableStandardAtgarder()` — aktiva åtgärder, filtrerade på betalningssätt (tom lista = alla) och valfritt på skede, sorterade kronologiskt (inledande → löpande → avslutande) och därefter på svensk kollation så listan ser likadan ut för alla.
- **Persistens:** `standardAtgarder` på organisationen + drizzle-kolumn + migration `0020`. `updateSettings` normaliserar server-side (trimmar, slänger tomma, dedupar på id — sista vinner).
- **Spårbarhet:** `standardAtgardId` på tidsposten (`create` + `update`), så byrån kan se vilka poster som kommer ur en standard och om tiden avvikit från huvudregeln.
- **Väljare i tidsformuläret:** fyller beskrivning, tid och kategori. Allt förblir redigerbart — tidsåtgången är en **huvudregel**, och avsteg måste vara lätt att göra.
- **Admin-sektion i `/settings`** med *avställning* för åtgärder som redan använts i ärenden; radering skulle bryta historikens referens.
- **Tillgänglighet:** tidsformulärets labels kopplas till sina inputs (`htmlFor`/`id`) och avställ-knappen får `aria-label`. De var otillgängliga för skärmläsare, och det blockerade också testbarheten.
- **Seed:** byråns två åtgärder, verifierade i byggd demodata.

## Medvetet val: förslag, inte automatik

Åtgärderna läggs **inte** in automatiskt, av två skäl:

1. **Datumet styr beloppet.** Tidsposten värderas på sin kategoris norm för slutregleringsåret (#951/#954), och "avslutande åtgärder inkl. mottagande av dom" kan inte dateras när ärendet öppnas. En autoinlagd post med fel datum ger fel belopp i acontot.
2. **"Som huvudregel" måste vara sant.** En domstol som ser exakt 30 minuter i varje kostnadsräkning kommer att ifrågasätta dem; avsteg måste vara aktivt möjligt.

Förslagsvägen per skede (`OPENING` när ärendet är nytt, `CLOSING` när domen registrerats) är steg 2 i #956.

## Verifiering

- `typecheck`, `lint`, `lint:complexity-strict`, `knip`, `deps:check`, `jscpd` rena; `size` 34,4 %; `build:demo` exit 0 och de två åtgärderna verifierade i `out/demo-seed.json`.
- 61 nya/berörda tester gröna i isolering: `standard-atgard.test.ts` (8), `standard-atgarder-section.test.tsx` (6), `time-section.test.tsx` (8), `organization.test.ts` (17), `timeEntry.test.ts` (22).
- Ett test fångade en riktig bugg: jag använde zod-enumets deklarationsordning (`OPENING, CLOSING, ANY`) som sorteringsordning, vilket satte avslutande åtgärder före löpande. Nu en explicit kronologisk `STAGE_ORDER`.
- En regression jag införde och åtgärdade: `SettingsPage`-testet för fetcher-fel bröts eftersom min sektion också visar `updateSettings`-felet. Testmocken delar ut samma mutation-state till alla `useMutation`-anrop; i drift har sektionerna separata instanser. Testet frågar nu efter minst en förekomst, med den förklaringen i en kommentar.
- Bred katalogkörning: 291 pass / 5 fail — de fem är känt mock-läckage i `KostnadsrakningModal` vid katalogkörning (#92), oförändrat mot `main`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_