### PR TITLE
feat(matter): föreslå byråns standardåtgärder vid rätt tidpunkt i ärendet

### DIFF
--- a/src/app/matters/[id]/_client.tsx
+++ b/src/app/matters/[id]/_client.tsx
@@ -77,7 +77,7 @@ export default function MatterDetailClient({ id: paramId }: { id: string }) {
         <DocumentBrowser matterId={id} />
         <BillingPanel matterId={id} matter={m} />
         <ExpectedReceivablesSection matterId={id} courtCaseNumber={courtCaseOf(m)} isCourtMatter={isCourtMatter(m)} />
-        <TimeSection matterId={id} isTaxeArende={m.isTaxeArende} paymentMethod={m.paymentMethod} />
+        <TimeSection matterId={id} isTaxeArende={m.isTaxeArende} paymentMethod={m.paymentMethod} matterStatus={m.status} />
         <ExpenseSection matterId={id} isTaxeArende={m.isTaxeArende} />
         <ServiceNotesSection matterId={id} />
       </div>

--- a/src/app/matters/[id]/_standard-atgard-suggestions.tsx
+++ b/src/app/matters/[id]/_standard-atgard-suggestions.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+/**
+ * `StandardAtgardSuggestions` (#958) — påminner om byråns standardåtgärder vid
+ * rätt tidpunkt i ärendet. Just de här åtgärderna glöms i praktiken: "Avslutande
+ * åtgärder inklusive mottagande av dom och kontakt med huvudman" registreras när
+ * ärendet redan känns färdigt.
+ *
+ * Ett klick FÖRIFYLLER tidsformuläret — den sparar inget. Datumet måste vara
+ * handläggarens val: det styr vilken årsnorm posten värderas på (#951/#954), och
+ * en autoinlagd post med fel datum ger fel belopp i acontot.
+ */
+
+import { trpc } from "@/lib/client/trpc";
+import { formatMinutes } from "@/lib/client/utils";
+import type { MatterStatus, PaymentMethod } from "@/lib/shared/schemas/enums";
+import type { MatterId } from "@/lib/shared/schemas/ids";
+import { suggestedStandardAtgarder, type StandardAtgard } from "@/lib/shared/standard-atgard";
+
+interface Props {
+  matterId: MatterId;
+  paymentMethod?: PaymentMethod | undefined;
+  matterStatus?: MatterStatus | undefined;
+  /** Ärendets tidsposter (redan hämtade av TimeSection) — driver både
+   *  "uppdraget är nytt" och vilka standardåtgärder som redan är registrerade. */
+  entries: ReadonlyArray<{ standardAtgardId?: string | null }>;
+  /** Öppnar tidsformuläret förifyllt med åtgärden. */
+  onPick: (atgard: StandardAtgard) => void;
+}
+
+/** Billing-run-rader vi behöver för att veta var i uppdraget ärendet befinner sig. */
+interface RunRow {
+  type: string;
+  awardedOre?: number | null;
+}
+
+/** Domen/beslutet är registrerat när en kostnadsräkning fått sitt beslut (#828). */
+function verdictRegistered(runs: readonly RunRow[]): boolean {
+  return runs.some((r) => r.type === "KOSTNADSRAKNING" && r.awardedOre != null);
+}
+
+/** Slutreglerat = en FINAL finns. Då är arbetet fryst (`settleCoverage`/`createFinal`)
+ *  och en ny tidspost kan inte längre nå fakturan. */
+function isSettled(runs: readonly RunRow[]): boolean {
+  return runs.some((r) => r.type === "FINAL");
+}
+
+export function StandardAtgardSuggestions({ matterId, paymentMethod, matterStatus, entries, onPick }: Props) {
+  const settings = trpc.organization.getSettings.useQuery();
+  const runs = (trpc.billingRun.list.useQuery({ matterId }).data?.runs ?? []) as RunRow[];
+
+  const suggestions = suggestedStandardAtgarder(settings.data?.standardAtgarder, paymentMethod, {
+    hasTimeEntries: entries.length > 0,
+    verdictRegistered: verdictRegistered(runs),
+    matterClosed: matterStatus !== undefined && matterStatus !== "ACTIVE",
+    settled: isSettled(runs),
+    registeredIds: new Set(entries.map((e) => e.standardAtgardId).filter((id): id is string => !!id)),
+  });
+  if (suggestions.length === 0) return null;
+
+  return (
+    <div className="mx-4 mb-3 rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-900">
+      <div className="mb-1.5">
+        Byråns <strong>standardåtgärder</strong> som inte är registrerade i ärendet:
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {suggestions.map((a) => (
+          <button key={a.id} type="button" onClick={() => onPick(a)}
+            className="rounded border border-blue-300 bg-white px-2 py-1 text-left hover:bg-blue-100">
+            {a.description} <span className="font-mono text-blue-700">({formatMinutes(a.minutes)})</span>
+          </button>
+        ))}
+      </div>
+      <p className="mt-1.5 text-blue-700">
+        Klicket fyller formuläret — inget sparas förrän du valt datum och godkänt tiden.
+      </p>
+    </div>
+  );
+}

--- a/src/app/matters/[id]/_time-section.tsx
+++ b/src/app/matters/[id]/_time-section.tsx
@@ -6,9 +6,10 @@ import { Modal } from "@/components/ui/modal";
 import { TIME_ENTRY_KIND_SHORT } from "@/lib/client/labels";
 import { trpc } from "@/lib/client/trpc";
 import { formatMinutes } from "@/lib/client/utils";
-import { TIME_ENTRY_KIND_LABELS, type PaymentMethod, type TimeEntryKind } from "@/lib/shared/schemas/enums";
+import { TIME_ENTRY_KIND_LABELS, type MatterStatus, type PaymentMethod, type TimeEntryKind } from "@/lib/shared/schemas/enums";
 import type { InvoiceId, MatterId, TimeEntryId } from "@/lib/shared/schemas/ids";
 import { applicableStandardAtgarder, type StandardAtgard } from "@/lib/shared/standard-atgard";
+import { StandardAtgardSuggestions } from "./_standard-atgard-suggestions";
 
 interface Props {
   matterId: MatterId;
@@ -16,6 +17,9 @@ interface Props {
   /** Styr kategori-hjälptexten: rättshjälp/rättsskydd ersätts på Domstolsverkets
    *  normer per kategori, inte på byråns timpris (#953). */
   paymentMethod?: PaymentMethod | undefined;
+  /** Driver förslagen om avslutande standardåtgärder (#958) — ett stängt ärende
+   *  är i sitt avslutningsskede även utan kostnadsräkning. */
+  matterStatus?: MatterStatus | undefined;
 }
 
 interface EditForm {
@@ -101,11 +105,14 @@ function applyStandardAtgard(form: EditForm, atgard: StandardAtgard | undefined)
 }
 
 // eslint-disable-next-line max-lines-per-function -- TODO: refactor (struktur är tabular: kolumndefs + 2 modaler)
-export function TimeSection({ matterId, isTaxeArende, paymentMethod }: Props) {
+export function TimeSection({ matterId, isTaxeArende, paymentMethod, matterStatus }: Props) {
   const isCoverage = isCoverageMethod(paymentMethod);
   const atgarder = useStandardAtgarder(paymentMethod);
   const utils = trpc.useUtils();
   const timeEntries = trpc.timeEntry.list.useQuery({ matterId });
+  // EN källa för både tabellen och förslagsraden (#958) — annars kunde de visa
+  // olika bild av vilka standardåtgärder som redan är registrerade.
+  const rows = (timeEntries.data?.entries ?? []) as TimeEntryRow[];
   const [showCreate, setShowCreate] = useState(false);
   const [editingId, setEditingId] = useState<TimeEntryId | null>(null);
   const [editForm, setEditForm] = useState<EditForm | null>(null);
@@ -143,6 +150,13 @@ export function TimeSection({ matterId, isTaxeArende, paymentMethod }: Props) {
 
   function confirmDelete(id: TimeEntryId): void {
     if (confirm("Ta bort tidregistreringen?")) deleteTimeEntry.mutate({ id });
+  }
+
+  /** Föreslagen standardåtgärd (#958) → öppna formuläret FÖRIFYLLT. Sparar inget:
+   *  datumet är handläggarens val och styr postens årsnorm. */
+  function pickStandardAtgard(atgard: StandardAtgard): void {
+    setCreateForm(applyStandardAtgard(emptyForm(), atgard));
+    setShowCreate(true);
   }
 
   const columns: Column<TimeEntryRow>[] = [
@@ -204,11 +218,19 @@ export function TimeSection({ matterId, isTaxeArende, paymentMethod }: Props) {
         </button>
       </div>
 
+      <StandardAtgardSuggestions
+        matterId={matterId}
+        paymentMethod={paymentMethod}
+        matterStatus={matterStatus}
+        entries={rows}
+        onPick={pickStandardAtgard}
+      />
+
       <div className="p-4">
         <DataTable
           prefKey={`list.matter-time.${matterId}`}
           columns={columns}
-          data={(timeEntries.data?.entries ?? []) as TimeEntryRow[]}
+          data={rows}
           rowKey={(e) => e.id}
           emptyMessage="Inga tidsposter."
         />

--- a/src/lib/shared/standard-atgard.ts
+++ b/src/lib/shared/standard-atgard.ts
@@ -82,6 +82,45 @@ function appliesToMethod(a: StandardAtgard, paymentMethod: PaymentMethod | null 
 }
 
 /**
+ * Ärendets läge, för att avgöra VILKA standardåtgärder som är relevanta att
+ * föreslå just nu (#958). Rena fakta om ärendet — ingen I/O, ingen tRPC.
+ */
+export interface StandardAtgardContext {
+  /** Har ärendet några registrerade tidsposter? Nej → uppdraget är nyss påbörjat. */
+  hasTimeEntries: boolean;
+  /** Är domen/beslutet registrerat? Då hör de avslutande åtgärderna hemma nu. */
+  verdictRegistered: boolean;
+  /** Är ärendet stängt? Täcker avslut UTAN kostnadsräkning (rättsskydd, privat). */
+  matterClosed: boolean;
+  /** Är ärendet slutreglerat? Då är arbetet FRYST och en ny tidspost når aldrig
+   *  fakturan — att föreslå en åtgärd som inte kan faktureras vore vilseledande. */
+  settled: boolean;
+  /** Standardåtgärder som redan registrerats i ärendet (`standardAtgardId`). */
+  registeredIds: ReadonlySet<string>;
+}
+
+/**
+ * Standardåtgärder att FÖRESLÅ för ärendet just nu (#958) — de som hör till
+ * ärendets skede och ännu inte är registrerade.
+ *
+ * `ANY`-åtgärder föreslås aldrig: de gäller när som helst och skulle ligga kvar
+ * som en permanent uppmaning. De finns i väljaren i tidsformuläret i stället.
+ */
+export function suggestedStandardAtgarder(
+  list: readonly StandardAtgard[] | null | undefined,
+  paymentMethod: PaymentMethod | null | undefined,
+  ctx: StandardAtgardContext,
+): StandardAtgard[] {
+  if (ctx.settled) return [];
+  const stages: StandardAtgardStage[] = [];
+  if (!ctx.hasTimeEntries) stages.push("OPENING");
+  if (ctx.verdictRegistered || ctx.matterClosed) stages.push("CLOSING");
+  return stages
+    .flatMap((stage) => applicableStandardAtgarder(list, paymentMethod, stage))
+    .filter((a) => !ctx.registeredIds.has(a.id));
+}
+
+/**
  * Normalisera en inkommande lista (admin sparar hela listan): trimma texter,
  * släng poster utan beskrivning, och dedupa på `id` — sista vinner, så en
  * redigerad post ersätter sin tidigare version i stället för att dubbleras.

--- a/test/unit/app/matters/time-section.test.tsx
+++ b/test/unit/app/matters/time-section.test.tsx
@@ -32,6 +32,9 @@ const orgSettingsQuery = {
   } as unknown,
   isLoading: false,
 };
+// Ärendets billing-runs styr förslagen (#958): KOSTNADSRAKNING med awardedOre =
+// dom registrerad; FINAL = slutreglerat (arbetet fryst).
+const billingRunQuery = { data: { runs: [] as Array<Record<string, unknown>> }, isLoading: false };
 const createMutate = vi.fn();
 const updateMutate = vi.fn();
 const noopMut = () => ({ mutate: vi.fn(), isPending: false });
@@ -54,6 +57,7 @@ vi.mock("@/lib/client/trpc", () => ({
     },
     user: { current: { useQuery: () => ({ data: { id: "u1", role: "LAWYER" } }) } },
     organization: { getSettings: { useQuery: () => orgSettingsQuery } },
+    billingRun: { list: { useQuery: () => billingRunQuery } },
   },
 }));
 
@@ -61,6 +65,7 @@ const matterId = asId<"MatterId">("m1");
 
 beforeEach(() => {
   vi.clearAllMocks();
+  billingRunQuery.data.runs = [];
 });
 
 describe("TimeSection — arvodeskategori (#953)", () => {
@@ -166,5 +171,66 @@ describe("TimeSection — standardåtgärder (#956)", () => {
     expect(screen.getByPlaceholderText("Beskrivning *")).toHaveValue("Inledande åtgärder och genomgång av handlingar");
     fireEvent.click(screen.getByText("Spara"));
     expect(createMutate).toHaveBeenCalledWith(expect.objectContaining({ standardAtgardId: "" }));
+  });
+});
+
+/**
+ * Förslagsraden (#958): påminn om standardåtgärderna vid rätt tidpunkt, och
+ * FÖRIFYLL formuläret i stället för att spara. Datumet måste vara handläggarens
+ * val — det styr vilken årsnorm posten värderas på (#951/#954).
+ */
+describe("TimeSection — förslag om standardåtgärder (#958)", () => {
+  it("pågående ärende med registrerat arbete → ingen förslagsrad", () => {
+    render(<TimeSection matterId={matterId} paymentMethod="RATTSHJALP" matterStatus="ACTIVE" />);
+    expect(screen.queryByText(/standardåtgärder.*som inte är registrerade/i)).not.toBeInTheDocument();
+  });
+
+  it("registrerad dom → avslutande åtgärd föreslås med sin tid", () => {
+    billingRunQuery.data.runs = [{ type: "KOSTNADSRAKNING", awardedOre: 500_000 }];
+    render(<TimeSection matterId={matterId} paymentMethod="RATTSHJALP" matterStatus="ACTIVE" />);
+    expect(screen.getByText(/som inte är registrerade/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Avslutande åtgärder inklusive mottagande av dom/ })).toBeInTheDocument();
+  });
+
+  it("klicket FÖRIFYLLER formuläret — inget sparas", () => {
+    billingRunQuery.data.runs = [{ type: "KOSTNADSRAKNING", awardedOre: 500_000 }];
+    render(<TimeSection matterId={matterId} paymentMethod="RATTSHJALP" matterStatus="ACTIVE" />);
+    fireEvent.click(screen.getByRole("button", { name: /Avslutande åtgärder inklusive mottagande av dom/ }));
+
+    // Formuläret öppnas ifyllt med byråns huvudregel …
+    expect(screen.getByPlaceholderText("Beskrivning *")).toHaveValue("Avslutande åtgärder inklusive mottagande av dom och kontakt med huvudman");
+    expect(screen.getByLabelText("Tid (minuter) *")).toHaveValue("45");
+    expect(screen.getByLabelText("Standardåtgärd")).toHaveValue("avslutande-atgarder");
+    // … men INGET är sparat förrän användaren godkänner.
+    expect(createMutate).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText("Spara"));
+    expect(createMutate).toHaveBeenCalledWith(expect.objectContaining({
+      standardAtgardId: "avslutande-atgarder", minutes: 45,
+    }));
+  });
+
+  it("redan registrerad åtgärd föreslås inte igen — härleds ur ärendets tidsposter", () => {
+    billingRunQuery.data.runs = [{ type: "KOSTNADSRAKNING", awardedOre: 500_000 }];
+    const entries = (timeQuery.data as { entries: Array<Record<string, unknown>> }).entries;
+    entries.push({
+      id: "t4", date: "2026-07-01", minutes: 45, description: "Avslutande åtgärder …",
+      billable: true, user: { name: "Anna" }, hourlyRate: 162_600, standardAtgardId: "avslutande-atgarder",
+    });
+    try {
+      render(<TimeSection matterId={matterId} paymentMethod="RATTSHJALP" matterStatus="ACTIVE" />);
+      expect(screen.queryByText(/som inte är registrerade/i)).not.toBeInTheDocument();
+    } finally {
+      entries.pop();
+    }
+  });
+
+  it("slutreglerat ärende → inga förslag (arbetet är fryst)", () => {
+    billingRunQuery.data.runs = [
+      { type: "KOSTNADSRAKNING", awardedOre: 500_000 },
+      { type: "FINAL", awardedOre: null },
+    ];
+    render(<TimeSection matterId={matterId} paymentMethod="RATTSHJALP" matterStatus="CLOSED" />);
+    expect(screen.queryByText(/som inte är registrerade/i)).not.toBeInTheDocument();
   });
 });

--- a/test/unit/app/time-section-invoiced.test.tsx
+++ b/test/unit/app/time-section-invoiced.test.tsx
@@ -25,6 +25,8 @@ vi.mock("@/lib/client/trpc", () => {
       // Byråns standardåtgärder (#956) — TimeSection läser dem för väljaren.
       // Tom lista → ingen väljare renderas, vilket den här filens tester inte rör.
       organization: { getSettings: { useQuery: () => ({ data: { standardAtgarder: [] }, isLoading: false }) } },
+      // Ärendets billing-runs driver förslagsraden (#958). Tom lista → inga förslag.
+      billingRun: { list: { useQuery: () => ({ data: { runs: [] }, isLoading: false }) } },
       prefs: {
         get: { useQuery: () => ({ data: null }) },
         save: { useMutation: () => noopMut },

--- a/test/unit/lib/standard-atgard.test.ts
+++ b/test/unit/lib/standard-atgard.test.ts
@@ -6,7 +6,8 @@
  */
 import { describe, it, expect } from "vitest-compat";
 import {
-  applicableStandardAtgarder, normalizeStandardAtgarder, type StandardAtgard,
+  applicableStandardAtgarder, normalizeStandardAtgarder, suggestedStandardAtgarder,
+  type StandardAtgard, type StandardAtgardContext,
 } from "@/lib/shared/standard-atgard";
 
 const atgard = (over: Partial<StandardAtgard> & { id: string }): StandardAtgard => ({
@@ -84,5 +85,72 @@ describe("normalizeStandardAtgarder", () => {
     ]);
     expect(out).toHaveLength(1);
     expect(out[0]!.minutes).toBe(45);
+  });
+});
+
+/**
+ * Vilka åtgärder som FÖRESLÅS (#958). Poängen är att just de här åtgärderna glöms:
+ * "Avslutande åtgärder inklusive mottagande av dom" registreras i praktiken när
+ * ärendet redan känns färdigt. Förslaget måste därför komma vid rätt tidpunkt —
+ * och sluta komma när det inte längre är meningsfullt.
+ */
+describe("suggestedStandardAtgarder", () => {
+  const LIST = [
+    atgard({ id: "start", stage: "OPENING", description: "Inledande åtgärder" }),
+    atgard({ id: "slut", stage: "CLOSING", description: "Avslutande åtgärder" }),
+    atgard({ id: "lopande", stage: "ANY", description: "Löpande åtgärd" }),
+  ];
+  const ctx = (over: Partial<StandardAtgardContext> = {}): StandardAtgardContext => ({
+    hasTimeEntries: true, verdictRegistered: false, matterClosed: false, settled: false,
+    registeredIds: new Set(), ...over,
+  });
+
+  it("nytt ärende utan tidsposter → inledande åtgärder föreslås", () => {
+    const out = suggestedStandardAtgarder(LIST, "RATTSHJALP", ctx({ hasTimeEntries: false }));
+    expect(out.map((a) => a.id)).toEqual(["start"]);
+  });
+
+  it("registrerad dom → avslutande åtgärder föreslås", () => {
+    const out = suggestedStandardAtgarder(LIST, "RATTSHJALP", ctx({ verdictRegistered: true }));
+    expect(out.map((a) => a.id)).toEqual(["slut"]);
+  });
+
+  it("stängt ärende → avslutande åtgärder även UTAN kostnadsräkning (rättsskydd/privat)", () => {
+    const out = suggestedStandardAtgarder(LIST, "RATTSSKYDD", ctx({ matterClosed: true }));
+    expect(out.map((a) => a.id)).toEqual(["slut"]);
+  });
+
+  it("pågående ärende mitt i arbetet → inga förslag (ingen permanent uppmaning)", () => {
+    expect(suggestedStandardAtgarder(LIST, "PRIVAT", ctx())).toEqual([]);
+  });
+
+  it("ANY-åtgärder föreslås ALDRIG — de skulle ligga kvar för alltid", () => {
+    const out = suggestedStandardAtgarder(LIST, "PRIVAT", ctx({ hasTimeEntries: false, verdictRegistered: true }));
+    expect(out.map((a) => a.id)).toEqual(["start", "slut"]);
+    expect(out.map((a) => a.id)).not.toContain("lopande");
+  });
+
+  it("redan registrerad åtgärd föreslås inte igen", () => {
+    const out = suggestedStandardAtgarder(LIST, "RATTSHJALP",
+      ctx({ verdictRegistered: true, registeredIds: new Set(["slut"]) }));
+    expect(out).toEqual([]);
+  });
+
+  it("slutreglerat ärende ger INGA förslag — arbetet är fryst och når inte fakturan", () => {
+    // Utan den här spärren skulle vi föreslå en åtgärd som inte kan faktureras.
+    const out = suggestedStandardAtgarder(LIST, "RATTSHJALP",
+      ctx({ verdictRegistered: true, matterClosed: true, hasTimeEntries: false, settled: true }));
+    expect(out).toEqual([]);
+  });
+
+  it("betalningssätts-begränsning gäller även i förslagen", () => {
+    const list = [atgard({ id: "bara-rh", stage: "CLOSING", paymentMethods: ["RATTSHJALP"] })];
+    expect(suggestedStandardAtgarder(list, "RATTSHJALP", ctx({ verdictRegistered: true })).map((a) => a.id)).toEqual(["bara-rh"]);
+    expect(suggestedStandardAtgarder(list, "PRIVAT", ctx({ verdictRegistered: true }))).toEqual([]);
+  });
+
+  it("byrå utan standardåtgärder får inga förslag", () => {
+    expect(suggestedStandardAtgarder([], "RATTSHJALP", ctx({ hasTimeEntries: false }))).toEqual([]);
+    expect(suggestedStandardAtgarder(undefined, "RATTSHJALP", ctx({ hasTimeEntries: false }))).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes #958. Steg 2 av #956 (steg 1 landade i #957).

## Problem

Standardåtgärderna finns och går att välja, men handläggaren måste själv komma ihåg dem — och just de här glöms: *"Avslutande åtgärder inklusive mottagande av dom och kontakt med huvudman"* registreras i praktiken när ärendet redan känns färdigt.

## Lösning

En förslagsrad i tidsredovisningen:

> Byråns **standardåtgärder** som inte är registrerade i ärendet:
> `[ Avslutande åtgärder inklusive mottagande av dom … (0:45) ]`
> *Klicket fyller formuläret — inget sparas förrän du valt datum och godkänt tiden.*

`suggestedStandardAtgarder()` i shared avgör vad som är relevant nu:

| Trigger | Skede |
|---|---|
| Ärendet saknar tidsposter | `OPENING` |
| Domen registrerad (kostnadsräkning med beslut) | `CLOSING` |
| Ärendet stängt — täcker avslut **utan** kostnadsräkning (rättsskydd, privat) | `CLOSING` |

Tre spärrar som gör att raden inte blir brus:

- **`ANY`-åtgärder föreslås aldrig.** De gäller när som helst och skulle bli en permanent uppmaning. De finns i väljaren i tidsformuläret i stället.
- **Slutreglerade ärenden ger inga förslag.** Arbetet är fryst av `settleCoverage`/`createFinal`, så en ny tidspost når aldrig fakturan — att föreslå en åtgärd som inte kan faktureras vore vilseledande.
- **Redan registrerade åtgärder filtreras bort**, matchat på `standardAtgardId` och inte på beskrivningen (den är redigerbar).

Ett klick **förifyller** formuläret och sparar inget. Datumet måste vara handläggarens val: det styr vilken årsnorm posten värderas på (#951/#954), och en post med fel datum ger fel belopp i acontot.

Tabellen och förslagsraden läser samma `rows`, så de aldrig visar olika bild av vad som är registrerat.

## Verifiering

- `typecheck`, `lint`, `lint:complexity-strict`, `knip`, `deps:check`, `jscpd` rena; `size` 34,4 %; `build:demo` exit 0.
- 9 nya tester i `standard-atgard.test.ts` (17 totalt) för urvalslogiken, och 5 i `time-section.test.tsx` (12 totalt) för raden — inklusive att klicket förifyller men **inte** anropar `create.mutate`.
- Jag lade proaktivt in `billingRun.list` i `time-section-invoiced.test.tsx`:s mock. Exakt den fällan (en andra testfil för samma komponent med egen trpc-mock) bröt CI i #957, så den är nu förebyggd i stället för upptäckt.
- Hela `test/unit/app/`: 458 pass / 21 fail — samma 21 som på `main` (känt mock-läckage vid katalogkörning, #92), inga TimeSection-fel.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_