### PR TITLE
chore(ci): skript som SHA-pinnar GitHub Actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:demo": "DEMO_BASE_PATH=/ava bash tooling/scripts/build-demo.sh",
     "build:demo-repo": "bun tooling/scripts/build-demo-repo.ts",
     "size": "bun tooling/scripts/check-bundle-size.ts",
+    "pin:actions": "bun tooling/scripts/pin-actions.ts",
     "demo:generate": "bun tooling/demo-generator/generate.ts",
     "demo:serve": "bash tooling/scripts/demo-serve.sh",
     "demo:serve:fast": "SKIP_BUILD=1 bash tooling/scripts/demo-serve.sh",

--- a/test/scripts/pin-actions.test.ts
+++ b/test/scripts/pin-actions.test.ts
@@ -1,0 +1,161 @@
+/**
+ * `pin-actions` (#910) — SHA-pinning av GitHub Actions. Den rena logiken testas
+ * här; `gh`-uppslaget och filskrivningen är I/O-skalet.
+ *
+ * Varför det spelar roll att detaljerna är rätt: en FEL SHA ger röd CI och
+ * `main` kräver grön CI för merge, så ett slarvigt omskrivet `uses:` blockerar
+ * allt arbete. Och en rad som tystnar (lämnas opinnad utan att någon märker det)
+ * ger falsk trygghet — därför `--check`.
+ */
+import { describe, it, expect } from "vitest-compat";
+import {
+  actionRefsIn, applyPins, isSha, lookupTag, parseUsesLine, unpinned,
+} from "../../tooling/scripts/pin-actions";
+
+const SHA = "08c6903cd8c0fde910a37f88322edcfb5dd907a8";
+const SHA2 = "11bd71901bbe5b1630ceea73d27597364c9af683";
+
+describe("isSha", () => {
+  it("accepterar full 40-teckens SHA, inget annat", () => {
+    expect(isSha(SHA)).toBe(true);
+    expect(isSha("v7")).toBe(false);
+    expect(isSha(SHA.slice(0, 7))).toBe(false); // kort SHA räcker inte
+    expect(isSha(SHA.toUpperCase())).toBe(false); // gh ger gemener
+  });
+});
+
+describe("parseUsesLine", () => {
+  it("tolkar en vanlig taggad action", () => {
+    expect(parseUsesLine("      - uses: actions/checkout@v7")).toMatchObject({
+      repo: "actions/checkout", subpath: "", ref: "v7", comment: "",
+    });
+  });
+
+  it("bevarar underkatalogen för monorepo-actions", () => {
+    // github/codeql-action/init slås upp på github/codeql-action, men sökvägen
+    // måste tillbaka in i raden — annars pekar den på fel action.
+    expect(parseUsesLine("      - uses: github/codeql-action/init@v4")).toMatchObject({
+      repo: "github/codeql-action", subpath: "/init", ref: "v4",
+    });
+  });
+
+  it("läser versionskommentaren på en redan pinnad rad", () => {
+    expect(parseUsesLine(`      - uses: actions/checkout@${SHA} # v7`)).toMatchObject({
+      repo: "actions/checkout", ref: SHA, comment: "v7",
+    });
+  });
+
+  it("hoppar över LOKALA actions — de är vår egen kod", () => {
+    expect(parseUsesLine("      - uses: ./.github/actions/bun-setup")).toBeNull();
+    expect(parseUsesLine("      - uses: ./.github/workflows/reusable.yml")).toBeNull();
+  });
+
+  it("hoppar över docker-actions (pinnas med digest, annat format)", () => {
+    expect(parseUsesLine("      - uses: docker://alpine:3.19")).toBeNull();
+  });
+
+  it("hoppar över rader utan ref och rader som inte är uses:", () => {
+    expect(parseUsesLine("      - uses: actions/checkout")).toBeNull();
+    expect(parseUsesLine("      - name: Checkout")).toBeNull();
+    expect(parseUsesLine("  # uses: actions/checkout@v7")).toBeNull();
+  });
+
+  it("tolkar uses: utan inledande bindestreck (composite-actions)", () => {
+    expect(parseUsesLine("    uses: oven-sh/setup-bun@v2")).toMatchObject({
+      repo: "oven-sh/setup-bun", ref: "v2",
+    });
+  });
+});
+
+describe("lookupTag", () => {
+  it("opinnad rad slås upp på sin egen ref", () => {
+    expect(lookupTag(parseUsesLine("- uses: actions/cache@v4")!)).toBe("v4");
+  });
+
+  it("pinnad rad slås upp på VERSIONSKOMMENTAREN — så en bump blir möjlig", () => {
+    expect(lookupTag(parseUsesLine(`- uses: actions/cache@${SHA} # v4`)!)).toBe("v4");
+  });
+
+  it("pinnad rad UTAN kommentar lämnas orörd — vi får inte gissa versionen", () => {
+    expect(lookupTag(parseUsesLine(`- uses: actions/cache@${SHA}`)!)).toBeNull();
+  });
+});
+
+describe("actionRefsIn", () => {
+  it("plockar alla pinnbara referenser och bara dem", () => {
+    const yaml = [
+      "jobs:",
+      "  build:",
+      "    steps:",
+      "      - uses: actions/checkout@v7",
+      "      - uses: ./.github/actions/bun-setup",
+      "      - uses: github/codeql-action/init@v4",
+      "      - name: Bygg",
+      "        run: bun run build",
+    ].join("\n");
+    expect(actionRefsIn(yaml).map((r) => r.repo)).toEqual(["actions/checkout", "github/codeql-action"]);
+  });
+});
+
+describe("applyPins", () => {
+  const resolved = new Map([["actions/checkout@v7", SHA], ["github/codeql-action@v4", SHA2]]);
+
+  it("skriver om till SHA och behåller versionen som kommentar", () => {
+    const out = applyPins("      - uses: actions/checkout@v7", resolved);
+    expect(out).toBe(`      - uses: actions/checkout@${SHA} # v7`);
+  });
+
+  it("bevarar indentering och underkatalog", () => {
+    const out = applyPins("        - uses: github/codeql-action/init@v4", resolved);
+    expect(out).toBe(`        - uses: github/codeql-action/init@${SHA2} # v4`);
+  });
+
+  it("bumpar en redan pinnad rad när taggen flyttats", () => {
+    const stale = `      - uses: actions/checkout@${SHA2} # v7`;
+    expect(applyPins(stale, resolved)).toBe(`      - uses: actions/checkout@${SHA} # v7`);
+  });
+
+  it("är idempotent — samma SHA ger identisk fil", () => {
+    const pinned = `      - uses: actions/checkout@${SHA} # v7`;
+    expect(applyPins(pinned, resolved)).toBe(pinned);
+  });
+
+  it("lämnar en referens ORÖRD när uppslaget misslyckades", () => {
+    // Hellre kvar på taggen än pinnad till en gissad SHA: fel SHA = röd CI.
+    const line = "      - uses: softprops/action-gh-release@v3";
+    expect(applyPins(line, resolved)).toBe(line);
+  });
+
+  it("rör inte rader som inte är actions", () => {
+    const yaml = ["      - name: Checkout", "        run: echo uses: actions/checkout@v7"].join("\n");
+    expect(applyPins(yaml, resolved)).toBe(yaml);
+  });
+
+  it("skriver om alla rader i en hel fil utan att tappa struktur", () => {
+    const before = [
+      "name: CI",
+      "jobs:",
+      "  build:",
+      "    steps:",
+      "      - uses: actions/checkout@v7",
+      "      - uses: ./.github/actions/bun-setup",
+      "      - uses: github/codeql-action/init@v4",
+      "",
+    ].join("\n");
+    const after = applyPins(before, resolved);
+    expect(after.split("\n")).toHaveLength(before.split("\n").length);
+    expect(after).toContain(`actions/checkout@${SHA} # v7`);
+    expect(after).toContain("uses: ./.github/actions/bun-setup"); // lokal orörd
+    expect(after).toContain(`github/codeql-action/init@${SHA2} # v4`);
+  });
+});
+
+describe("unpinned", () => {
+  it("returnerar bara de referenser som ännu inte är SHA-pinnade", () => {
+    const refs = actionRefsIn([
+      "      - uses: actions/checkout@v7",
+      `      - uses: actions/cache@${SHA} # v4`,
+    ].join("\n"));
+    expect(unpinned(refs).map((r) => r.ref)).toEqual(["v7"]);
+  });
+});

--- a/tooling/config/knip.json
+++ b/tooling/config/knip.json
@@ -36,7 +36,8 @@
   "ignoreBinaries": [
     "dot",
     "tooling/scripts/generate-demo-manifest.ts",
-    "build.ts"
+    "build.ts",
+    "gh"
   ],
   "commitlint": {
     "config": ["tooling/config/commitlint.config.mjs"]

--- a/tooling/scripts/pin-actions.ts
+++ b/tooling/scripts/pin-actions.ts
@@ -1,0 +1,250 @@
+#!/usr/bin/env bun
+/**
+ * SHA-pinna GitHub Actions (#910) — supply-chain-härdning.
+ *
+ * En rörlig tagg (`@v7`) kan flyttas av action-ägaren till annan kod utan att
+ * något syns i vårt repo. Pinning till full commit-SHA gör byggen
+ * reproducerbara och gör en kompromitterad action synlig som en diff:
+ *
+ *     uses: actions/checkout@v7
+ *     uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v7
+ *
+ * Versionen behålls som kommentar, så Dependabot (`github-actions`-ekosystemet,
+ * `.github/dependabot.yml`) kan bumpa SHA:n och kommentaren tillsammans.
+ *
+ * Skriptet är BÅDE pinnare och bumpare: körs det igen slås taggen i kommentaren
+ * upp på nytt och SHA:n uppdateras. Kör det efter en action-uppgradering.
+ *
+ *     bun run pin:actions            # pinna/bumpa på plats
+ *     bun run pin:actions --check    # fäll om något är opinnat (CI-läge)
+ *     bun run pin:actions --dry-run  # visa vad som skulle ändras
+ *
+ * Kräver `gh` inloggad (`gh auth status`). Slår upp taggar via
+ * `gh api repos/<owner>/<repo>/commits/<ref>`, alltså inget extra beroende.
+ */
+
+import { spawnSync } from "node:child_process";
+import type { Dirent } from "node:fs";
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+/** Kataloger som innehåller `uses:`-referenser. */
+const SOURCE_DIRS = [".github/workflows", ".github/actions"] as const;
+
+/** En `uses:`-referens i en workflow-fil. */
+export interface ActionRef {
+  /** Hela raden, som den står i filen. */
+  line: string;
+  /** `owner/repo` — det som slås upp mot API:et (utan ev. underkatalog). */
+  repo: string;
+  /** Underkatalog för monorepo-actions (`github/codeql-action/init` → `/init`). */
+  subpath: string;
+  /** Nuvarande ref: en tagg (`v7`) eller en redan pinnad SHA. */
+  ref: string;
+  /** Versionskommentaren efter SHA:n, om raden redan är pinnad. */
+  comment: string;
+}
+
+const SHA_RE = /^[0-9a-f]{40}$/;
+
+/** Är ref:en redan en full commit-SHA? */
+export function isSha(ref: string): boolean {
+  return SHA_RE.test(ref);
+}
+
+/**
+ * Tolka en `uses:`-rad. Returnerar null för rader som inte ska pinnas:
+ *   - lokala actions (`./.github/actions/bun-setup`) — de är vår egen kod
+ *   - docker-actions (`docker://…`) — pinnas med digest, annat format
+ *   - reusable workflows i samma repo (`./.github/workflows/x.yml`)
+ */
+export function parseUsesLine(line: string): ActionRef | null {
+  const m = /^(\s*-?\s*uses:\s*)([^\s#]+)(?:\s*#\s*(.*))?$/.exec(line);
+  if (!m) return null;
+  const target = m[2] ?? "";
+  if (isLocalOrDocker(target)) return null;
+  const [path, ref] = splitRef(target);
+  if (!ref) return null;
+  const parts = path.split("/");
+  if (parts.length < 2) return null;
+  return {
+    line,
+    repo: `${parts[0]}/${parts[1]}`,
+    subpath: parts.length > 2 ? `/${parts.slice(2).join("/")}` : "",
+    ref,
+    comment: (m[3] ?? "").trim(),
+  };
+}
+
+/** Lokal action (vår egen kod) eller docker-action (annat pin-format) → hoppas över. */
+function isLocalOrDocker(target: string): boolean {
+  return target.startsWith("./") || target.startsWith("docker://");
+}
+
+/** `owner/repo@ref` → `[owner/repo, ref]`. Saknad `@` ger tom ref. */
+function splitRef(target: string): [string, string] {
+  const at = target.lastIndexOf("@");
+  if (at < 0) return [target, ""];
+  return [target.slice(0, at), target.slice(at + 1)];
+}
+
+/**
+ * Taggen som ska slås upp för en referens. En opinnad rad slås upp på sin ref;
+ * en redan pinnad rad slås upp på VERSIONSKOMMENTAREN, så skriptet kan bumpa
+ * SHA:n när taggen flyttats. Pinnad rad utan kommentar lämnas orörd (vi vet
+ * inte vilken version den avser och får inte gissa).
+ */
+export function lookupTag(ref: ActionRef): string | null {
+  if (!isSha(ref.ref)) return ref.ref;
+  return ref.comment || null;
+}
+
+/** Alla pinnbara referenser i en fil. */
+export function actionRefsIn(text: string): ActionRef[] {
+  return text.split("\n").map(parseUsesLine).filter((r): r is ActionRef => r !== null);
+}
+
+/**
+ * Skriv om filens `uses:`-rader till `owner/repo[/sub]@<sha> # <tagg>`.
+ * `resolved` mappar `owner/repo@tagg` → SHA. Referenser som saknas i mappen
+ * lämnas orörda (uppslaget misslyckades — hellre oförändrad än fel SHA).
+ */
+export function applyPins(text: string, resolved: ReadonlyMap<string, string>): string {
+  return text.split("\n").map((line) => {
+    const ref = parseUsesLine(line);
+    const tag = ref && lookupTag(ref);
+    if (!ref || !tag) return line;
+    const sha = resolved.get(`${ref.repo}@${tag}`);
+    if (!sha) return line;
+    const prefix = /^(\s*-?\s*uses:\s*)/.exec(line)?.[1] ?? "";
+    return `${prefix}${ref.repo}${ref.subpath}@${sha} # ${tag}`;
+  }).join("\n");
+}
+
+/** Referenser som ännu inte är SHA-pinnade — `--check` fäller på dessa. */
+export function unpinned(refs: readonly ActionRef[]): ActionRef[] {
+  return refs.filter((r) => !isSha(r.ref));
+}
+
+// ── I/O-skal ────────────────────────────────────────────────────────────────
+
+/** Alla workflow-/action-YAML-filer, rekursivt. */
+async function sourceFiles(): Promise<string[]> {
+  const out: string[] = [];
+  for (const dir of SOURCE_DIRS) out.push(...await yamlFilesIn(dir));
+  return out.sort();
+}
+
+async function yamlFilesIn(dir: string): Promise<string[]> {
+  let entries: Dirent[];
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return []; // katalogen finns inte i alla checkouts
+  }
+  const out: string[] = [];
+  for (const e of entries) {
+    const path = join(dir, e.name);
+    if (e.isDirectory()) out.push(...await yamlFilesIn(path));
+    else if (/\.ya?ml$/.test(e.name)) out.push(path);
+  }
+  return out;
+}
+
+/**
+ * `gh` måste finnas OCH vara inloggad innan vi rör en enda fil. Utan den
+ * kontrollen blir felet "Executable not found in $PATH" mitt i körningen, vilket
+ * inte säger vad man ska göra.
+ */
+function assertGh(): void {
+  const res = spawnSync("gh", ["auth", "status"], { encoding: "utf8" });
+  if (res.status === 0) return;
+  throw new Error(
+    "kräver GitHub CLI inloggad. Installera `gh` och kör `gh auth login`.\n"
+    + "  (Uppslaget görs mot api.github.com — kör skriptet lokalt, inte i en sandlåda utan nätåtkomst.)",
+  );
+}
+
+/** Slå upp en tagg → commit-SHA via `gh`. Null när uppslaget misslyckas — ett
+ *  enskilt fallerat uppslag får inte fälla hela körningen. */
+function resolveSha(repo: string, tag: string): string | null {
+  const res = spawnSync("gh", ["api", `repos/${repo}/commits/${tag}`, "--jq", ".sha"], { encoding: "utf8" });
+  const sha = (res.stdout ?? "").trim();
+  return res.status === 0 && isSha(sha) ? sha : null;
+}
+
+/** Alla unika `repo@tagg`-par att slå upp, i stabil ordning. */
+function lookupTargets(refs: readonly ActionRef[]): Array<{ repo: string; tag: string }> {
+  const seen = new Map<string, { repo: string; tag: string }>();
+  for (const ref of refs) {
+    const tag = lookupTag(ref);
+    if (tag) seen.set(`${ref.repo}@${tag}`, { repo: ref.repo, tag });
+  }
+  return [...seen.values()];
+}
+
+interface Options { check: boolean; dryRun: boolean }
+
+/** `--check`: rapportera opinnade referenser och fäll. Skriver inget. */
+async function runCheck(files: readonly string[]): Promise<void> {
+  const bad: string[] = [];
+  for (const file of files) {
+    for (const ref of unpinned(actionRefsIn(await readFile(file, "utf8")))) {
+      bad.push(`  ${file}: ${ref.repo}${ref.subpath}@${ref.ref}`);
+    }
+  }
+  if (bad.length === 0) {
+    process.stdout.write("pin:actions: alla actions är SHA-pinnade ✓\n");
+    return;
+  }
+  process.stderr.write(`pin:actions: ${bad.length} opinnade actions:\n${bad.join("\n")}\n`);
+  process.stderr.write("Kör `bun run pin:actions` för att pinna dem.\n");
+  process.exitCode = 1;
+}
+
+/** Slå upp alla taggar en gång och returnera `repo@tagg` → SHA. */
+async function resolveAll(files: readonly string[]): Promise<Map<string, string>> {
+  const refs: ActionRef[] = [];
+  for (const file of files) refs.push(...actionRefsIn(await readFile(file, "utf8")));
+  const resolved = new Map<string, string>();
+  for (const { repo, tag } of lookupTargets(refs)) {
+    const sha = resolveSha(repo, tag);
+    if (sha) resolved.set(`${repo}@${tag}`, sha);
+    else process.stderr.write(`pin:actions: kunde inte slå upp ${repo}@${tag} — lämnas orörd\n`);
+  }
+  return resolved;
+}
+
+async function main(): Promise<void> {
+  const args = new Set(process.argv.slice(2));
+  const opts: Options = { check: args.has("--check"), dryRun: args.has("--dry-run") };
+  const files = await sourceFiles();
+  if (files.length === 0) {
+    process.stderr.write("pin:actions: hittade inga workflow-filer\n");
+    process.exitCode = 1;
+    return;
+  }
+  if (opts.check) return runCheck(files);
+
+  assertGh();
+  const resolved = await resolveAll(files);
+  let changed = 0;
+  for (const file of files) {
+    const before = await readFile(file, "utf8");
+    const after = applyPins(before, resolved);
+    if (after === before) continue;
+    changed++;
+    if (opts.dryRun) process.stdout.write(`pin:actions: skulle ändra ${file}\n`);
+    else await writeFile(file, after, "utf8");
+  }
+  const verb = opts.dryRun ? "skulle ändras" : "uppdaterade";
+  process.stdout.write(`pin:actions: ${changed} av ${files.length} filer ${verb}\n`);
+}
+
+// Kör bara som script (inte vid import i tester).
+if (import.meta.main) {
+  main().catch((err: unknown) => {
+    process.stderr.write(`pin:actions: ${String(err)}\n`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
Del av #910.

## Varför ett skript

Uppslaget tagg → SHA kräver `api.github.com`, som är blockerad i agent-sandboxen (403 genom proxyn). Det var därför #910 låg still. Ett skript som körs lokalt med `gh` löser det permanent i stället för att jag klistrar in 29 SHA:er en gång och det ruttnar direkt.

Det är **både pinnare och bumpare**: en redan pinnad rad slås upp på sin versionskommentar, så SHA:n uppdateras när taggen flyttats. Kör om efter varje action-uppgradering.

```
bun run pin:actions            # pinna/bumpa på plats
bun run pin:actions --check    # fäll om något är opinnat (kräver INTE gh)
bun run pin:actions --dry-run  # visa vad som skulle ändras
```

Resultatet blir:

```yaml
- uses: actions/checkout@v7
+ uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v7
```

Versionen behålls som kommentar så Dependabot (`github-actions`-ekosystemet, redan konfigurerat) kan bumpa SHA och kommentar tillsammans.

## Detaljerna som gör skillnad

- **Lokala actions** (`./.github/actions/bun-setup`, 12 förekomster) och docker-actions hoppas över. Verifierat: `--check` listar 29 referenser och ingen av dem är den lokala.
- **Underkatalogen bevaras** för monorepo-actions. `github/codeql-action/init` slås upp på `github/codeql-action` men måste skrivas tillbaka *med* sin sökväg — annars pekar raden på fel action.
- **Ett fallerat uppslag lämnar raden orörd** i stället för att gissa. Fel SHA ger röd CI, och `main` kräver grön CI för merge.
- **Pinnad rad utan versionskommentar lämnas orörd** — vi vet inte vilken version den avser och får inte gissa.
- **`gh`-kontroll upp front** med ett handlingsbart felmeddelande. Utan den blev felet `Executable not found in $PATH: "gh"` mitt i körningen, vilket inte säger vad man ska göra.
- **`--check` fungerar utan `gh`**, så det kan bli en CI-grind när pinningen väl är gjord.

Skrivet i TypeScript i stället för bash så logiken kan enhetstestas (AGENTS.md kräver täckning per rad). `spawnSync` från `node:child_process` följer konventionen i `tooling/scripts/` — `Bun.spawn` finns inte i typerna (`"types": []` i tsconfig).

## Verifiering

- `typecheck`, `lint`, `lint:complexity-strict`, `knip`, `deps:check`, `jscpd` rena.
- 20 nya tester på den rena logiken: parsning (lokala/docker/monorepo/utan ref/utan bindestreck), tagg-uppslag inkl. bump-vägen, omskrivning (indentering, underkatalog, idempotens, orörd vid misslyckat uppslag) och `--check`-urvalet. `test/scripts/`: 148 pass / 0 fail.
- Kört mot repots riktiga workflows: `--check` hittar 29 opinnade och exit 1; `--dry-run` utan `gh` ger det tydliga felet och **rör ingen fil** (`git status .github/` tomt).
- `gh` läggs i knips `ignoreBinaries` — den är ett dokumenterat utvecklarkrav, inte ett paketberoende.

## Nästa steg

Kör `bun run pin:actions` lokalt och committa diffen — då är #910 stängd. Vill du därefter ha `--check` som CI-grind (så en ny opinnad action inte kan smyga in) säger du till, det är en rad i `static`-jobbet.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_