### PR TITLE
ci: pinna alla GitHub Actions till commit-SHA

### DIFF
--- a/.github/actions/bun-setup/action.yml
+++ b/.github/actions/bun-setup/action.yml
@@ -13,10 +13,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         node-version: 24
-    - uses: oven-sh/setup-bun@v2
+    - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       with:
         # Pinnad (ej `latest`) → reproducerbara byggen; matchar bun-types i
         # package.json. Bumpas medvetet. SHA-pinning av actions: #910.
@@ -24,7 +24,7 @@ runs:
     # setup-bun cachar INTE beroenden själv → cacha bun:s globala install-cache
     # (nycklad på bun.lock). ~9 jobb installerar annars om allt varje körning.
     - name: Cache bun install-cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/.bun/install/cache
         key: bun-cache-${{ runner.os }}-${{ hashFiles('bun.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     if: github.event_name == 'pull_request'
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0 # commitlint behöver hela historiken för --from..--to
       - uses: ./.github/actions/bun-setup
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: ./.github/actions/bun-setup
       - run: bun run typecheck
       # Ratchet med ventil (#41): struktur-reglerna (max-lines/-depth/-params/
@@ -71,7 +71,7 @@ jobs:
       - run: bun run duplicates
       - name: Upload jscpd report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: jscpd-report
           path: reports/jscpd/
@@ -84,13 +84,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: ./.github/actions/bun-setup
       # bun test --isolate (#92) + coverage-ratchet (rader/funktioner).
       - run: bun run test:cov
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage
           path: coverage/
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: ./.github/actions/bun-setup
       - name: Start Postgres (docker compose)
         run: docker compose -f tooling/docker/docker-compose.test.yml up -d --wait --wait-timeout 90
@@ -127,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: ./.github/actions/bun-setup
       - name: Bygg server-first-binär
         run: bun run server-first:build
@@ -182,13 +182,13 @@ jobs:
     env:
       CI: "true"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: ./.github/actions/bun-setup
       - run: bun run e2e:install
       - run: bun run e2e:oidc
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-oidc-report
           path: reports/playwright-oidc/
@@ -205,7 +205,7 @@ jobs:
     if: github.event_name == 'pull_request'
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: ./.github/actions/bun-setup
       - run: bun run build:demo
       # Bundle-size-ratchet (#14/#909): återanvänder out/ från build:demo ovan.
@@ -229,7 +229,7 @@ jobs:
     if: github.event_name == 'pull_request'
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: ./.github/actions/bun-setup
       - run: bun run build:demo
       - run: bun run e2e:install
@@ -245,7 +245,7 @@ jobs:
             --config tooling/config/playwright-demo.config.ts
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-demo-report
           path: reports/playwright-demo/
@@ -266,13 +266,13 @@ jobs:
     env:
       CI: "true"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: ./.github/actions/bun-setup
       - run: bun run e2e:install
       - run: bun run e2e:conflict
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-conflict-report
           path: reports/playwright-conflict/

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -24,14 +24,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # DRY toolchain (Node 24 + pinnad Bun + cachead frozen install), #909.
       - uses: ./.github/actions/bun-setup
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 
       # Bygger appen som statisk export OCH seedar demo-data direkt i out/.
       # build-demo.sh kör:
@@ -96,7 +96,7 @@ jobs:
       # hämta användare. Bumpa INTE utan att verifiera att dolda filer följer med
       # (post-deploy-kontrollen nedan fäller numera i så fall).
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: ./out
 
@@ -110,7 +110,7 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         # v4 hör till samma beprövade par som upload-pages-artifact@v3 (#933).
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
 
       # Post-deploy-grind (#933): verifiera mot den LEVANDE sajten att de DOLDA
       # filerna faktiskt serveras. Bygg-sanity-checken ovan tittar bara i `out/`

--- a/.github/workflows/helper-ui-ci.yml
+++ b/.github/workflows/helper-ui-ci.yml
@@ -33,7 +33,7 @@ jobs:
         working-directory: helper-ui
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # DRY toolchain (Node 24 + pinnad Bun + cachead frozen install), #909.
       # Composite-stegen kör i repo-roten (ärver inte job-defaultens

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
     name: Build web demo
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       # DRY toolchain (Node 24 + pinnad Bun + cachead frozen install), #909.
       - uses: ./.github/actions/bun-setup
       - name: Build demo (app + seeded data)
@@ -43,7 +43,7 @@ jobs:
         run: |
           cd out
           zip -r "../ava-web-demo_${{ github.ref_name }}.zip" .
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: web-demo
           path: ava-web-demo_*.zip
@@ -62,11 +62,11 @@ jobs:
     permissions:
       contents: write # skapa release + ladda upp artefakter
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
       - name: Publish release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           generate_release_notes: true
           fail_on_unmatched_files: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,14 +35,14 @@ jobs:
       contents: read
       security-events: write # ladda upp SARIF till Security-fliken
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Initiera CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # v4
         with:
           languages: javascript-typescript
           build-mode: none # ren JS/TS → ingen kompilering behövs
           queries: security-and-quality
       - name: Analysera
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # v4
         with:
           category: "/language:javascript-typescript"

--- a/test/scripts/pin-actions.test.ts
+++ b/test/scripts/pin-actions.test.ts
@@ -9,7 +9,7 @@
  */
 import { describe, it, expect } from "vitest-compat";
 import {
-  actionRefsIn, applyPins, isSha, lookupTag, parseUsesLine, unpinned,
+  actionRefsIn, applyPins, isSha, lookupTag, parseUsesLine, shaFromLsRemote, unpinned,
 } from "../../tooling/scripts/pin-actions";
 
 const SHA = "08c6903cd8c0fde910a37f88322edcfb5dd907a8";
@@ -157,5 +157,40 @@ describe("unpinned", () => {
       `      - uses: actions/cache@${SHA} # v4`,
     ].join("\n"));
     expect(unpinned(refs).map((r) => r.ref)).toEqual(["v7"]);
+  });
+});
+
+/**
+ * `git ls-remote`-vägen (fallback när `gh` saknas, t.ex. bakom en git-proxy där
+ * GitHub-API:et är blockerat). Den kritiska detaljen är PEELINGEN: en annoterad
+ * tagg är ett eget objekt, och pinnas actionen till tagg-objektets SHA i stället
+ * för commitens blir referensen fel. Två av repots actions har annoterade taggar
+ * (softprops/action-gh-release, github/codeql-action), så det är inte hypotetiskt.
+ */
+describe("shaFromLsRemote", () => {
+  it("lightweight-tagg → commiten direkt (ingen ^{}-rad finns)", () => {
+    const out = `${SHA}\trefs/tags/v7\n`;
+    expect(shaFromLsRemote(out, "v7")).toBe(SHA);
+  });
+
+  it("ANNOTERAD tagg → den PEELADE commiten, inte tagg-objektet", () => {
+    const out = [`${SHA}\trefs/tags/v3`, `${SHA2}\trefs/tags/v3^{}`, ""].join("\n");
+    expect(shaFromLsRemote(out, "v3")).toBe(SHA2);
+  });
+
+  it("peelad rad vinner även när den kommer FÖRST i utdatan", () => {
+    const out = [`${SHA2}\trefs/tags/v3^{}`, `${SHA}\trefs/tags/v3`, ""].join("\n");
+    expect(shaFromLsRemote(out, "v3")).toBe(SHA2);
+  });
+
+  it("matchar exakt tagg — v4 plockar inte v4.1 eller v40", () => {
+    const out = [`${SHA}\trefs/tags/v4.1`, `${SHA2}\trefs/tags/v40`, ""].join("\n");
+    expect(shaFromLsRemote(out, "v4")).toBeNull();
+  });
+
+  it("tom eller skräpig utdata ger null i stället för en gissning", () => {
+    expect(shaFromLsRemote("", "v7")).toBeNull();
+    expect(shaFromLsRemote("fatal: repository not found\n", "v7")).toBeNull();
+    expect(shaFromLsRemote("nothex\trefs/tags/v7\n", "v7")).toBeNull();
   });
 });

--- a/tooling/scripts/pin-actions.ts
+++ b/tooling/scripts/pin-actions.ts
@@ -19,8 +19,9 @@
  *     bun run pin:actions --check    # fäll om något är opinnat (CI-läge)
  *     bun run pin:actions --dry-run  # visa vad som skulle ändras
  *
- * Kräver `gh` inloggad (`gh auth status`). Slår upp taggar via
- * `gh api repos/<owner>/<repo>/commits/<ref>`, alltså inget extra beroende.
+ * Uppslaget görs via `gh api repos/<owner>/<repo>/commits/<ref>` när GitHub CLI
+ * finns inloggad, annars via `git ls-remote` — vilket fungerar överallt där git
+ * når github.com (t.ex. bakom en git-proxy där GitHub-API:et är blockerat).
  */
 
 import { spawnSync } from "node:child_process";
@@ -121,6 +122,25 @@ export function applyPins(text: string, resolved: ReadonlyMap<string, string>): 
   }).join("\n");
 }
 
+/**
+ * Plocka commit-SHA:n ur `git ls-remote`-utdata för en tagg.
+ *
+ * En ANNOTERAD tagg är ett eget objekt: `refs/tags/v3` pekar på tagg-objektet
+ * och `refs/tags/v3^{}` på commiten. Vi måste ta den PEELADE raden — annars
+ * pinnas actionen till ett tagg-objekt, vilket inte är en commit.
+ * En lightweight-tagg saknar `^{}`-rad och pekar direkt på commiten.
+ */
+export function shaFromLsRemote(stdout: string, tag: string): string | null {
+  let plain: string | null = null;
+  for (const line of stdout.split("\n")) {
+    const [sha, ref] = line.split(/\s+/);
+    if (!sha || !ref || !isSha(sha)) continue;
+    if (ref === `refs/tags/${tag}^{}`) return sha; // peelad commit vinner alltid
+    if (ref === `refs/tags/${tag}`) plain = sha;
+  }
+  return plain;
+}
+
 /** Referenser som ännu inte är SHA-pinnade — `--check` fäller på dessa. */
 export function unpinned(refs: readonly ActionRef[]): ActionRef[] {
   return refs.filter((r) => !isSha(r.ref));
@@ -151,26 +171,49 @@ async function yamlFilesIn(dir: string): Promise<string[]> {
   return out;
 }
 
+const GH_PROBE_URL = "https://github.com/actions/checkout";
+
+/** Finns GitHub CLI inloggad? Styr vilken uppslagsväg som används. */
+function hasGh(): boolean {
+  return spawnSync("gh", ["auth", "status"], { encoding: "utf8" }).status === 0;
+}
+
+/** Kan git nå github.com? Fallbacken när `gh` saknas. */
+function hasGitRemoteAccess(): boolean {
+  return spawnSync("git", ["ls-remote", GH_PROBE_URL, "HEAD"], { encoding: "utf8" }).status === 0;
+}
+
 /**
- * `gh` måste finnas OCH vara inloggad innan vi rör en enda fil. Utan den
- * kontrollen blir felet "Executable not found in $PATH" mitt i körningen, vilket
- * inte säger vad man ska göra.
+ * NÅGON uppslagsväg måste finnas innan vi rör en enda fil, annars blir felet
+ * obegripligt mitt i körningen.
  */
-function assertGh(): void {
-  const res = spawnSync("gh", ["auth", "status"], { encoding: "utf8" });
-  if (res.status === 0) return;
+function assertLookupAvailable(useGh: boolean): void {
+  if (useGh || hasGitRemoteAccess()) return;
   throw new Error(
-    "kräver GitHub CLI inloggad. Installera `gh` och kör `gh auth login`.\n"
-    + "  (Uppslaget görs mot api.github.com — kör skriptet lokalt, inte i en sandlåda utan nätåtkomst.)",
+    "hittade ingen väg att slå upp taggar.\n"
+    + "  Antingen `gh` inloggad (`gh auth login`) eller git-åtkomst till github.com krävs.",
   );
 }
 
-/** Slå upp en tagg → commit-SHA via `gh`. Null när uppslaget misslyckas — ett
- *  enskilt fallerat uppslag får inte fälla hela körningen. */
-function resolveSha(repo: string, tag: string): string | null {
+/** Slå upp en tagg → commit-SHA. Null när uppslaget misslyckas — ett enskilt
+ *  fallerat uppslag får inte fälla hela körningen. */
+function resolveSha(repo: string, tag: string, useGh: boolean): string | null {
+  return useGh ? shaViaGh(repo, tag) : shaViaGit(repo, tag);
+}
+
+function shaViaGh(repo: string, tag: string): string | null {
   const res = spawnSync("gh", ["api", `repos/${repo}/commits/${tag}`, "--jq", ".sha"], { encoding: "utf8" });
   const sha = (res.stdout ?? "").trim();
   return res.status === 0 && isSha(sha) ? sha : null;
+}
+
+function shaViaGit(repo: string, tag: string): string | null {
+  const res = spawnSync(
+    "git", ["ls-remote", "--tags", `https://github.com/${repo}`, tag, `${tag}^{}`],
+    { encoding: "utf8" },
+  );
+  if (res.status !== 0) return null;
+  return shaFromLsRemote(res.stdout ?? "", tag);
 }
 
 /** Alla unika `repo@tagg`-par att slå upp, i stabil ordning. */
@@ -203,12 +246,12 @@ async function runCheck(files: readonly string[]): Promise<void> {
 }
 
 /** Slå upp alla taggar en gång och returnera `repo@tagg` → SHA. */
-async function resolveAll(files: readonly string[]): Promise<Map<string, string>> {
+async function resolveAll(files: readonly string[], useGh: boolean): Promise<Map<string, string>> {
   const refs: ActionRef[] = [];
   for (const file of files) refs.push(...actionRefsIn(await readFile(file, "utf8")));
   const resolved = new Map<string, string>();
   for (const { repo, tag } of lookupTargets(refs)) {
-    const sha = resolveSha(repo, tag);
+    const sha = resolveSha(repo, tag, useGh);
     if (sha) resolved.set(`${repo}@${tag}`, sha);
     else process.stderr.write(`pin:actions: kunde inte slå upp ${repo}@${tag} — lämnas orörd\n`);
   }
@@ -226,8 +269,10 @@ async function main(): Promise<void> {
   }
   if (opts.check) return runCheck(files);
 
-  assertGh();
-  const resolved = await resolveAll(files);
+  const useGh = hasGh();
+  assertLookupAvailable(useGh);
+  process.stdout.write(`pin:actions: slår upp taggar via ${useGh ? "gh api" : "git ls-remote"}\n`);
+  const resolved = await resolveAll(files, useGh);
   let changed = 0;
   for (const file of files) {
     const before = await readFile(file, "utf8");


### PR DESCRIPTION
Closes #910. Du behöver inte göra något — jag kunde köra det själv.

## Jag hade fel om blockeringen

Jag har sagt att #910 krävde din dator eftersom `api.github.com` ger 403 genom sandboxens proxy. Det stämmer — men `git ls-remote` når github.com. Jag testade i stället för att fortsätta anta, och då gick hela jobbet att göra härifrån.

## Två commits

**1. `git ls-remote`-fallback i skriptet.** Uppslaget görs via `gh api` när GitHub CLI finns inloggad, annars via `git ls-remote`. Skriptet skriver ut vilken väg det använder och kräver bara att någon av dem finns.

Den kritiska detaljen är **peelingen**: en annoterad tagg är ett eget objekt, där `refs/tags/v3` pekar på tagg-objektet och `refs/tags/v3^{}` på commiten. Pinnas actionen till tagg-objektets SHA blir referensen fel. Två av repots actions har annoterade taggar — `softprops/action-gh-release` och `github/codeql-action` — så fallet var verkligt, inte hypotetiskt.

5 nya tester på `shaFromLsRemote`: lightweight vs annoterad, peelad rad först eller sist, exakt tagg-match (`v4` plockar inte `v4.1` eller `v40`), och skräpig utdata → null i stället för gissning.

**2. Själva pinningen.** 29 referenser i 6 filer:

| Action | Tagg | SHA |
|---|---|---|
| actions/checkout | v7 | `3d3c42e5…` |
| actions/upload-artifact | v7 | `043fb46d…` |
| actions/download-artifact | v8 | `3e5f45b2…` |
| actions/setup-node | v6 | `24997072…` |
| actions/cache | v4 | `0057852b…` |
| actions/configure-pages | v6 | `45bfe019…` |
| actions/upload-pages-artifact | v3 | `56afc609…` |
| actions/deploy-pages | v4 | `d6db9016…` |
| oven-sh/setup-bun | v2 | `0c5077e5…` |
| softprops/action-gh-release | v3 | `3d0d9888…` *(peelad)* |
| github/codeql-action/{init,analyze} | v4 | `d1ba80a1…` *(peelad)* |

De 12 referenserna till den lokala `./.github/actions/bun-setup` är orörda — det är vår egen kod. `bun run pin:actions --check` är grönt.

## Verifiering

- `typecheck`, `lint`, `knip` rena; `test/scripts/`: 153 pass / 0 fail.
- Diffen är exakt 29 rader in, 29 ut — ingen strukturell förändring i YAML:en.
- `codeql-action/init` och `/analyze` delar repo-SHA men behåller sina olika underkataloger, precis som de ska.
- **Att CI blir grön på den här PR:en är beviset att alla 29 SHA:er är rätt.** En felaktig SHA gör att steget inte kan hämtas och jobbet faller omedelbart.

## Efter merge

Vill du ha `pin:actions --check` som CI-grind (så en ny opinnad action inte kan smyga in) lägger jag det i `static`-jobbet — nu är det säkert, eftersom allt är pinnat.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_