### PR TITLE
ci: cve-grind med bun audit i stället för dependency-review

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,10 +6,10 @@ name: Security
 # OBS: kräver att "CodeQL default setup" är AVSTÄNGT i repo-inställningarna
 # (annars krockar detta advanced-workflow med default-setupen).
 #
-# `dependency-review` (license-/CVE-grind på nya deps i en PR) är MEDVETET
-# borttaget tills repo:ts Dependency graph är aktiverad (Settings → Security →
-# "Dependency graph") — utan den svarar action:en hårt fel ("Dependency review
-# is not supported on this repository"). Återinförs i #915.
+# `dependency-review` (license-/CVE-grind på nya deps i en PR) kräver att repo:ts
+# Dependency graph är aktiverad (Settings → Security → "Dependency graph") —
+# utan den svarar action:en hårt fel ("Dependency review is not supported on this
+# repository"). Den är påslagen sedan #915.
 
 on:
   push:
@@ -46,3 +46,23 @@ jobs:
         uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # v4
         with:
           category: "/language:javascript-typescript"
+
+  # ── Dependency review (license-/CVE-grind på nya beroenden i en PR) ────────
+  # Bara på PR: action:en jämför basens beroendegraf med PR:ens och fäller på
+  # nya sårbarheter eller förbjudna licenser. Kräver Dependency graph (#915).
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Granska nya beroenden
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+        with:
+          fail-on-severity: moderate
+          # Copyleft-licenser som inte är förenliga med en sluten byrå-produkt.
+          deny-licenses: GPL-2.0, GPL-3.0, AGPL-3.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,10 +6,13 @@ name: Security
 # OBS: kräver att "CodeQL default setup" är AVSTÄNGT i repo-inställningarna
 # (annars krockar detta advanced-workflow med default-setupen).
 #
-# `dependency-review` (license-/CVE-grind på nya deps i en PR) kräver att repo:ts
-# Dependency graph är aktiverad (Settings → Security → "Dependency graph") —
-# utan den svarar action:en hårt fel ("Dependency review is not supported on this
-# repository"). Den är påslagen sedan #915.
+# `dependency-review` (GitHubs license-/CVE-grind på nya deps i en PR) är INTE
+# möjlig här: API:et kräver GitHub Advanced Security på privata repon, och svarar
+# annars "Dependency review is not supported on this repository" även med
+# Dependency graph påslagen (verifierat i #915/PR #964).
+#
+# `bun audit` ger CVE-täckningen utan GHAS och mot samma beroendeträd som vi
+# faktiskt installerar. Licensgrinden (GPL/AGPL) saknar substitut — se #915.
 
 on:
   push:
@@ -47,22 +50,22 @@ jobs:
         with:
           category: "/language:javascript-typescript"
 
-  # ── Dependency review (license-/CVE-grind på nya beroenden i en PR) ────────
-  # Bara på PR: action:en jämför basens beroendegraf med PR:ens och fäller på
-  # nya sårbarheter eller förbjudna licenser. Kräver Dependency graph (#915).
-  dependency-review:
-    name: Dependency review
+  # ── Sårbara beroenden (CVE-grind) ─────────────────────────────────────────
+  # `bun audit` mot samma beroendeträd CI installerar. RATCHET (docs/quality.md):
+  # nivån ligger strax under dagens siffra och dras BARA åt.
+  #
+  # 2026-08-04: 18 kända sårbarheter (14 high, 4 moderate, 0 critical) → nivån
+  # `critical` är grön i dag och fäller på varje NY critical. Att arbeta ner de
+  # 18 och sedan skärpa till `high` → `moderate` spåras i #966.
+  audit:
+    name: Sårbara beroenden (bun audit)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: github.event_name == 'pull_request'
-    permissions:
-      contents: read
-      pull-requests: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - name: Granska nya beroenden
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
-        with:
-          fail-on-severity: moderate
-          # Copyleft-licenser som inte är förenliga med en sluten byrå-produkt.
-          deny-licenses: GPL-2.0, GPL-3.0, AGPL-3.0
+      - uses: ./.github/actions/bun-setup
+      - name: bun audit
+        run: bun audit --audit-level=critical
+      - name: Full rapport (informativ, fäller inte)
+        if: always()
+        run: bun audit || true

--- a/test/scripts/pin-actions.test.ts
+++ b/test/scripts/pin-actions.test.ts
@@ -188,6 +188,18 @@ describe("shaFromLsRemote", () => {
     expect(shaFromLsRemote(out, "v4")).toBeNull();
   });
 
+  it("BRANCH-ref löses också — en del actions publicerar majorn som branch", () => {
+    // actions/dependency-review-action@v4 är en branch, ingen tagg. `gh api
+    // repos/x/commits/v4` löser den, så git-vägen måste göra det också.
+    const out = `${SHA}\trefs/heads/v4\n`;
+    expect(shaFromLsRemote(out, "v4")).toBe(SHA);
+  });
+
+  it("tagg vinner över branch med samma namn — taggen är den avsedda utgåvan", () => {
+    const out = [`${SHA2}\trefs/heads/v4`, `${SHA}\trefs/tags/v4`, ""].join("\n");
+    expect(shaFromLsRemote(out, "v4")).toBe(SHA);
+  });
+
   it("tom eller skräpig utdata ger null i stället för en gissning", () => {
     expect(shaFromLsRemote("", "v7")).toBeNull();
     expect(shaFromLsRemote("fatal: repository not found\n", "v7")).toBeNull();

--- a/tooling/scripts/pin-actions.ts
+++ b/tooling/scripts/pin-actions.ts
@@ -123,22 +123,30 @@ export function applyPins(text: string, resolved: ReadonlyMap<string, string>): 
 }
 
 /**
- * Plocka commit-SHA:n ur `git ls-remote`-utdata för en tagg.
+ * Plocka commit-SHA:n ur `git ls-remote`-utdata för en ref.
  *
- * En ANNOTERAD tagg är ett eget objekt: `refs/tags/v3` pekar på tagg-objektet
- * och `refs/tags/v3^{}` på commiten. Vi måste ta den PEELADE raden — annars
- * pinnas actionen till ett tagg-objekt, vilket inte är en commit.
- * En lightweight-tagg saknar `^{}`-rad och pekar direkt på commiten.
+ * Tre fall, i prioritetsordning:
+ *
+ *  1. `refs/tags/<ref>^{}` — en ANNOTERAD tagg är ett eget objekt, där
+ *     `refs/tags/v3` pekar på tagg-objektet och `^{}` på commiten. Tas inte den
+ *     peelade raden pinnas actionen till ett tagg-objekt, inte en commit.
+ *  2. `refs/tags/<ref>` — lightweight-tagg, pekar direkt på commiten.
+ *  3. `refs/heads/<ref>` — en del actions publicerar sin major som en BRANCH i
+ *     stället för en tagg (`actions/dependency-review-action@v4`). `gh api
+ *     repos/x/commits/<ref>` löser båda, så git-vägen måste också göra det.
  */
-export function shaFromLsRemote(stdout: string, tag: string): string | null {
-  let plain: string | null = null;
+export function shaFromLsRemote(stdout: string, ref: string): string | null {
+  const byName = new Map<string, string>();
   for (const line of stdout.split("\n")) {
-    const [sha, ref] = line.split(/\s+/);
-    if (!sha || !ref || !isSha(sha)) continue;
-    if (ref === `refs/tags/${tag}^{}`) return sha; // peelad commit vinner alltid
-    if (ref === `refs/tags/${tag}`) plain = sha;
+    const [sha, name] = line.split(/\s+/);
+    if (sha && name && isSha(sha)) byName.set(name, sha);
   }
-  return plain;
+  // Prioritet: peelad tagg (commiten) → lightweight-tagg → branch-huvud.
+  // En tagg går före en branch med samma namn: taggen är den avsedda utgåvan.
+  return byName.get(`refs/tags/${ref}^{}`)
+    ?? byName.get(`refs/tags/${ref}`)
+    ?? byName.get(`refs/heads/${ref}`)
+    ?? null;
 }
 
 /** Referenser som ännu inte är SHA-pinnade — `--check` fäller på dessa. */
@@ -208,8 +216,9 @@ function shaViaGh(repo: string, tag: string): string | null {
 }
 
 function shaViaGit(repo: string, tag: string): string | null {
+  // --tags OCH --heads: majorversionen kan publiceras som antingen.
   const res = spawnSync(
-    "git", ["ls-remote", "--tags", `https://github.com/${repo}`, tag, `${tag}^{}`],
+    "git", ["ls-remote", "--tags", "--heads", `https://github.com/${repo}`, tag, `${tag}^{}`],
     { encoding: "utf8" },
   );
   if (res.status !== 0) return null;


### PR DESCRIPTION
Ersätter det ursprungliga försöket att återinföra `dependency-review` (#915). Följs upp av #966.

## Vad som hände

Jag lade tillbaka `dependency-review` när Dependency graph slagits på. Checken föll — med **exakt samma fel som förut**:

```
Dependency review is not supported on this repository.
Please ensure that Dependency graph is enabled
```

Felmeddelandet är missvisande. Dokumentationen för Dependency review-API:et är tydlig: på **privata** repon returnerar det 403 utan **GitHub Advanced Security**. Grafen var alltså påslagen; det som saknas är en licens.

Det är en licensvägg, inte en inställning som glömts. Jag hade fel som utgick från att toggeln räckte, och CI:n visade det.

## Vad jag gjorde i stället

`bun audit` ger CVE-täckningen utan GHAS, mot exakt det beroendeträd CI installerar:

```yaml
- name: bun audit
  run: bun audit --audit-level=critical
```

**Nivån är en ratchet, inte en ambition.** `bun audit` rapporterar i dag:

```
18 vulnerabilities (14 high, 4 moderate)
```

| nivå | utfall i dag |
|---|---|
| `moderate` | exit 1 — 18 fynd |
| `high` | exit 1 — 14 fynd |
| **`critical`** | **exit 0 — 0 fynd** |

Att sätta `moderate` direkt hade gjort CI röd, alltså att införa en grind som inte kan hållas. `critical` är grön i dag och fäller på varje **ny** critical — precis ratchet-doktrinen i [`docs/quality.md`](docs/quality.md). Att arbeta ner de 18 och sedan dra åt spåras i **#966**.

Ett andra steg kör full `bun audit` utan att fälla, så hela listan syns i loggen även när grinden är grön. Grinden tystnar inte om problemen.

## Kvar från #915

Licensgrinden (`deny-licenses: GPL-2.0, GPL-3.0, AGPL-3.0`) saknar substitut — `bun audit` täcker bara CVE:er. #915 står kvar öppen som din fråga: GHAS-licens, eller ett eget steg som läser licensfält ur beroendeträdet?

## Med följer: en lucka i pin-actions

`actions/dependency-review-action@v4` är en **branch**, inte en tagg. `git ls-remote --tags` hittade den inte, så skriptet lämnade raden opinnad — rätt beteende, det gissar aldrig, men det kunde inte göra sitt jobb. Nu frågas `--tags` och `--heads`, med prioritet peelad tagg → tagg → branch-huvud.

Fixen får stå kvar även om själva actionen försvann i den här PR:en: den gör git-vägen likvärdig med `gh api`, som löser båda. 2 nya tester.

## Verifiering

- `typecheck`, `lint`, `knip` rena; `pin:actions --check` grönt; `pin-actions.test.ts` 27 pass.
- `bun audit --audit-level=critical` verifierad exit 0 lokalt, `high`/`moderate` exit 1 — alltså är ankaret mätt, inte gissat.
- YAML-validerad.
