### PR TITLE
fix(demo): härled demons datakälla ur var appen kör, inte ur repo-strängen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,12 @@ jobs:
   # inte på platshållaren). Det tyngre faktura-flödet (demo-invoice-document)
   # körs i `test:all` lokalt — här hålls CI-gaten snabb + hermetisk. (Kör på PR;
   # INTE required check — ingen branch-protection-ändring.)
+  #
+  # "Hermetisk" var länge bara ett påstående (#932): `out/` serverades lokalt,
+  # men APPEN hämtade sin data från live-demon på GH Pages, så jobbet blev rött
+  # när Pages låg nere — med ett fel som såg ut som en UI-regression. Nu härleds
+  # datakällan ur var appen kör (`demoDataBaseUrl`), och specarna blockerar +
+  # rapporterar varje förfrågan utanför den egna originen.
   demo-e2e:
     name: Demo E2E (browser-smoke)
     runs-on: ubuntu-latest
@@ -233,16 +239,13 @@ jobs:
       - uses: ./.github/actions/bun-setup
       - run: bun run build:demo
       - run: bun run e2e:install
-      - name: Servera out/ + kör demo render-smoke
-        run: |
-          bun tooling/scripts/serve-demo-static.ts &
-          for i in $(seq 1 30); do
-            curl -sf http://localhost:8799/ava/login/ >/dev/null && break
-            sleep 1
-          done
-          AVA_DEMO_BASE_URL=http://localhost:8799/ava \
-            npx playwright test test/e2e/demo-login.spec.ts \
-            --config tooling/config/playwright-demo.config.ts
+      - name: Demo render-smoke mot lokalt serverad out/
+        # Ingen `AVA_DEMO_BASE_URL` och ingen egen server-start längre (#932):
+        # playwright-demo.config.ts defaultar till localhost och startar
+        # `serve-demo-static.ts` själv (`webServer`), så den lokala körningen och
+        # CI gör exakt samma sak. Specarna bär dessutom en hermeticitets-vakt —
+        # varje förfrågan utanför den egna originen fäller testet.
+        run: npx playwright test test/e2e/demo-login.spec.ts --config tooling/config/playwright-demo.config.ts
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -176,6 +176,25 @@ strax över dagens siffra. Höj `BUDGET_KB` BARA när en ökning är medveten �
 lazy-loada annars tunga libs. CI kör `bun run size` direkt efter `build:demo`
 (återanvänder samma `out/`, ingen extra build).
 
+### Demo-E2E är hermetiskt (#932)
+
+Demo-specarna (`demo-login`, `demo-invoice-document`, `demo-smoke`,
+`kebab-verify`, `matters-employee-filter`) kör mot en **lokalt serverad `out/`**
+som `playwright-demo.config.ts` startar själv. Live-demon nås bara på uttrycklig
+begäran (`AVA_DEMO_BASE_URL=https://…`).
+
+Att bara peka Playwright mot localhost räckte inte: appen HÄRLEDDE sin datakälla
+ur repo-strängen (`ulrik-s/ava` → `https://ulrik-s.github.io/ava`), så en lokalt
+serverad demo navigerade lokalt men hämtade data över nätet. Numera avgör
+`demoDataBaseUrl` basen utifrån var appen faktiskt kör.
+
+Vakten i [`test/e2e/_demo-test.ts`](../test/e2e/_demo-test.ts) gör antagandet
+testbart: **varje HTTP-förfrågan utanför testets egen origin blockeras och fäller
+testet**, med hela listan i felmeddelandet. Enda undantaget är AVA Helper-proben
+på loopback (`127.0.0.1:48761` / `localhost:48762`). Lägg nya demo-specar under
+`playwright-demo.config.ts` och importera `test` från `_demo-test` — inte från
+`@playwright/test`.
+
 ### Sårbara beroenden (`bun audit`)
 
 `security.yml` kör `bun audit` mot **båda** arbetsytorna — roten och
@@ -284,7 +303,7 @@ bun-versionen där, gäller alla workflows. `ci.yml` har `concurrency`
 5. **Server-first (deploy E2E)** — bygger server-first-binären, kör som docker-container mot Postgres, synkar push/pull + dokument-pipeline över HTTP.
 6. **E2E (OIDC login)** — browser-inloggning mot Keycloak via oauth2-proxy (Playwright).
 7. **Demo build** *(PR)* — statisk GH Pages-export + **bundle-size-ratchet** (`bun run size`).
-8. **Demo E2E (browser-smoke)** *(PR)* — serverar `out/` och verifierar att demon LADDAR (inte bara bygger).
+8. **Demo E2E (browser-smoke)** *(PR)* — serverar `out/` och verifierar att demon LADDAR (inte bara bygger). Hermetiskt: specarna blockerar varje förfrågan utanför sin egen origin (#932), så jobbet kan inte längre bli rött för att GH Pages ligger nere.
 9. **Keep-both konflikt-E2E** *(PR)* — 2-användar-konflikt mot full self-hosted-stack.
 
 Jobben laddar upp sina rapporter som artefakter (coverage, jscpd, playwright-report).

--- a/src/components/shell/demo-bootstrap.tsx
+++ b/src/components/shell/demo-bootstrap.tsx
@@ -30,6 +30,7 @@ import { GitBackendRuntime } from "@/lib/client/backend/git-backend-runtime";
 import type { OidcLoginOutcome, OidcClaims } from "@/lib/client/backend/oidc-principal";
 import { StaticContentStore } from "@/lib/client/backend/static-content-store";
 import { CapabilitiesProvider } from "@/lib/client/capabilities/use-capabilities";
+import { demoDataBaseUrl } from "@/lib/client/demo/demo-data-base";
 import { DemoModeProvider } from "@/lib/client/demo/demo-mode-context";
 import { loadFirmaConfig, patchFirmaConfig, type FirmaConfig } from "@/lib/client/firma/firma-config";
 import { SyncProviderRoot } from "@/lib/client/sync/sync-context";
@@ -38,7 +39,6 @@ import { buildGitPorts } from "@/lib/server/adapters/git-ports";
 import { GitAuthProvider } from "@/lib/server/auth/git-auth-provider";
 import type { IDataStore } from "@/lib/server/data-store/IDataStore";
 import type { CachingSyncDataStore } from "@/lib/server/data-store/in-memory/caching-sync-data-store";
-import { resolveGhPagesUrl } from "@/lib/shared/gh-pages-url";
 import { asId } from "@/lib/shared/schemas/ids";
 import { AppShell } from "./app-shell";
 import { AuthStatusBanner } from "./auth-status-banner";
@@ -103,7 +103,7 @@ function createDemoTrpcClient(dataStore: IDataStore, firmaConfig: FirmaConfig) {
   // `read → null` → seed-dokument gick aldrig att öppna).
   const ports = {
     ...buildGitPorts(dataStore),
-    content: new StaticContentStore(resolveGhPagesUrl(firmaConfig.repo)),
+    content: new StaticContentStore(demoDataBaseUrl(firmaConfig.repo)),
   };
   return trpc.createClient({
     links: [
@@ -144,8 +144,7 @@ interface BootstrapArgs {
 async function preloadDocs(firmaConfig: FirmaConfig, store: CachingSyncDataStore): Promise<void> {
   try {
     const { preloadDocumentContents } = await import("@/lib/client/demo/document-content-cache");
-    const { resolveGhPagesUrl } = await import("@/lib/shared/gh-pages-url");
-    const baseUrl = resolveGhPagesUrl(firmaConfig.repo);
+    const baseUrl = demoDataBaseUrl(firmaConfig.repo);
     const source = store.store.currentSource as { documents?: Array<{ id: string; fileName?: string; storagePath?: string; mimeType?: string }> };
     await preloadDocumentContents(source.documents ?? [], baseUrl);
   } catch (e) {

--- a/src/lib/client/auth/github-auth.ts
+++ b/src/lib/client/auth/github-auth.ts
@@ -154,11 +154,13 @@ export async function detectAuthMode(args: DetectArgs): Promise<AuthMode> {
   const parsed = parseRepoUrl(args.repoUrl);
   if (!parsed) return detectSelfHostedMode(args.repoUrl, args.token);
 
-  if (!args.token) {
-    // Anonymt + GitHub-repo: bekräfta att det är publikt (kan läsas).
-    const perms = await getRepoPermissions("", parsed.owner, parsed.repo);
-    return perms?.canRead ? "anonymous" : "anonymous";
-  }
+  // Anonymt + GitHub-repo → alltid "anonymous". Här låg förr ett
+  // `getRepoPermissions("", …)`-anrop mot api.github.com vars resultat kastades
+  // bort: BÅDA grenarna i ternären returnerade "anonymous". Anropet kostade
+  // varje demo-besökare en onödig, oautentiserad GitHub-request (60/h per IP,
+  // och avslöjar vilket repo besökaren tittar på) — och gjorde demo-e2e:t
+  // nätverksberoende (#932). Returvärdet är oförändrat.
+  if (!args.token) return "anonymous";
 
   return detectGithubAuthedMode(args.token, parsed.owner, parsed.repo);
 }

--- a/src/lib/client/demo/bundled-seed-loader.ts
+++ b/src/lib/client/demo/bundled-seed-loader.ts
@@ -13,7 +13,8 @@
  */
 
 import { type DemoSource, prebakeJoins } from "@/lib/shared/demo-source";
-import { resolveGhPagesUrl } from "@/lib/shared/gh-pages-url";
+
+import { demoDataBaseUrl } from "./demo-data-base";
 
 export const DEMO_SEED_FILE = "demo-seed.json";
 
@@ -27,7 +28,7 @@ export interface BundledSeedLoaderOpts {
 /** Ladda den bundlade `demo-seed.json` → `DemoSource`. */
 export async function loadBundledSeed(repo: string, opts: BundledSeedLoaderOpts = {}): Promise<DemoSource> {
   const fetchFn = opts.fetchFn ?? globalThis.fetch.bind(globalThis);
-  const baseUrl = opts.baseUrl ?? resolveGhPagesUrl(repo);
+  const baseUrl = opts.baseUrl ?? demoDataBaseUrl(repo);
   const url = `${baseUrl}/${DEMO_SEED_FILE}`;
   const res = await fetchFn(url, { method: "GET", cache: "no-store" });
   if (!res.ok) {

--- a/src/lib/client/demo/demo-data-base.ts
+++ b/src/lib/client/demo/demo-data-base.ts
@@ -1,0 +1,91 @@
+/**
+ * `demoDataBaseUrl` — var demons DATA ligger (`.ava/meta.json`, `manifest.json`,
+ * seed-JSON, dokument-blobbar).
+ *
+ * ## Varför den här funktionen finns (#932)
+ *
+ * `build-demo.sh` seedar datan **direkt in i `out/`**, så appen och dess data
+ * serveras alltid från samma origin — på GH Pages såväl som från en lokalt
+ * serverad `out/`. Trots det KONSTRUERADE alla laddare sin bas-URL ur
+ * firma-config:ens repo-sträng via `resolveGhPagesUrl`, dvs. `ulrik-s/ava` →
+ * `https://ulrik-s.github.io/ava`.
+ *
+ * Konsekvensen: en `out/` som serverades på `localhost:8799` NAVIGERADE lokalt
+ * men HÄMTADE data över nätet från live-demon. Demo-e2e:t kallade sig hermetiskt
+ * utan att vara det, och blev rött när GH Pages låg nere — med ett missvisande
+ * fel (`/login` saknade sin knapp, eftersom formuläret väntar på användarlistan
+ * som aldrig kom).
+ *
+ * ## Regeln
+ *
+ * 1. Inte en demo-build (t.ex. `next dev`, server-builden) → oförändrat
+ *    beteende: gissa fram GH Pages-URL:en ur repo-strängen.
+ * 2. Config:en pekar på ett ANNAT repo än det bundlen byggdes för → användaren
+ *    vill uttryckligen se någon annans demo → GH Pages-URL för det repot.
+ * 3. Annars → **same-origin**. Datan ligger bredvid appen; att hämta den över
+ *    nätet vore fel även när det råkar fungera.
+ *
+ * På GH Pages ger regel 3 exakt samma URL som den gamla konstruktionen
+ * (`origin` + `basePath` = `https://ulrik-s.github.io` + `/ava`), så
+ * produktionsbeteendet är oförändrat — skillnaden är att URL:en nu HÄRLEDS ur
+ * var appen faktiskt kör i stället för att gissas fram ur en sträng.
+ */
+
+import { DEMO_REPO } from "@/lib/client/firma/firma-config";
+import { resolveGhPagesUrl } from "@/lib/shared/gh-pages-url";
+
+/** Injicerbara byggtids-/runtime-fakta — gör funktionen ren och testbar. */
+export interface DemoDataBaseEnv {
+  /** `window.location.origin`, t.ex. `http://localhost:8799`. */
+  origin?: string | undefined;
+  /** Next:s `basePath`, t.ex. `/ava`. */
+  basePath?: string | undefined;
+  /** Repot bundlen byggdes för (`NEXT_PUBLIC_DEMO_REPO` vid build). */
+  buildRepo?: string | undefined;
+  /** Är det här en statisk demo-build (data seedad i `out/`)? */
+  isDemoBuild?: boolean | undefined;
+}
+
+/** Samma fält som `DemoDataBaseEnv`, men allt ifyllt (inget `undefined` kvar). */
+interface ResolvedEnv {
+  origin: string;
+  basePath: string;
+  buildRepo: string;
+  isDemoBuild: boolean;
+}
+
+const stripTrailingSlash = (s: string): string => s.replace(/\/+$/, "");
+
+/** Tom sträng under SSR/prerender — där finns ingen origin att utgå från. */
+const currentOrigin = (): string => (typeof window === "undefined" ? "" : window.location.origin);
+const buildBasePath = (): string => process.env.NEXT_PUBLIC_DEMO_BASE_PATH ?? "";
+/** Satt av `build-demo.sh`, som ALLTID seedar datan in i `out/`. */
+const isStaticDemoBuild = (): boolean => process.env.NEXT_PUBLIC_DEMO_BUILD === "1";
+
+function readEnv(env: DemoDataBaseEnv = {}): ResolvedEnv {
+  const {
+    origin = currentOrigin(),
+    basePath = buildBasePath(),
+    buildRepo = DEMO_REPO,
+    isDemoBuild = isStaticDemoBuild(),
+  } = env;
+  return { origin, basePath, buildRepo, isDemoBuild };
+}
+
+/**
+ * Bas-URL (utan avslutande `/`) att hämta demons data från.
+ *
+ * @param repo firma-config:ens `repo` — kortform (`user/repo`), full
+ *   github.com-URL, eller en färdig bas-URL som returneras som-är.
+ */
+export function demoDataBaseUrl(repo: string, env?: DemoDataBaseEnv): string {
+  const { origin, basePath, buildRepo, isDemoBuild } = readEnv(env);
+  const wanted = stripTrailingSlash(repo || buildRepo);
+
+  // Regel 1 + skyddsnät för SSR (inget `window` → inget origin att utgå från).
+  if (!isDemoBuild || !origin) return resolveGhPagesUrl(wanted);
+  // Regel 2: uttryckligen pekad mot ett annat repos demo.
+  if (wanted !== stripTrailingSlash(buildRepo)) return resolveGhPagesUrl(wanted);
+  // Regel 3: datan ligger bredvid appen.
+  return stripTrailingSlash(`${origin}${basePath}`);
+}

--- a/src/lib/client/demo/demo-meta.ts
+++ b/src/lib/client/demo/demo-meta.ts
@@ -9,9 +9,10 @@
  */
 import { z } from "zod";
 
-import { resolveGhPagesUrl } from "@/lib/shared/gh-pages-url";
 import { assertRepoSchemaCompatible } from "@/lib/shared/schema-version";
+
 import { DEMO_META_PATH } from "../../../../tooling/demo-config";
+import { demoDataBaseUrl } from "./demo-data-base";
 
 // Zod vid parsegränsen (#187): meta.json är extern nätverksdata — valideras
 // strikt här i stället för handrullade typeof-helpers. Felmeddelandena är
@@ -43,8 +44,7 @@ let cache: { url: string; data: DemoMeta } | null = null;
 
 /** Bygg URL till meta.json från firma-config:s repo (samma origin som datan). */
 export function demoMetaUrl(repo: string): string {
-  const base = resolveGhPagesUrl(repo).replace(/\/+$/, "");
-  return `${base}/${DEMO_META_PATH}`;
+  return `${demoDataBaseUrl(repo)}/${DEMO_META_PATH}`;
 }
 
 export async function loadDemoMeta(

--- a/src/lib/client/demo/demo-seed-loader.ts
+++ b/src/lib/client/demo/demo-seed-loader.ts
@@ -21,10 +21,10 @@
  */
 
 import { type DemoSource, prebakeJoins } from "@/lib/shared/demo-source";
-import { resolveGhPagesUrl } from "@/lib/shared/gh-pages-url";
 import { schemaVersionFromMetaJson } from "@/lib/shared/meta-json";
 import { assertRepoSchemaCompatible } from "@/lib/shared/schema-version";
 import { DEMO_META_PATH } from "../../../../tooling/demo-config";
+import { demoDataBaseUrl } from "./demo-data-base";
 import { pathToSourceKey } from "./demo-source-keys";
 
 export interface DemoSeedLoaderOpts {
@@ -219,7 +219,7 @@ function resolveOpts(repo: string, opts: DemoSeedLoaderOpts): ResolvedOpts {
   const maxRetries = opts.maxRetries ?? 4;
   const sleepFn = opts.sleepFn ?? defaultSleep;
   return {
-    baseUrl: opts.baseUrl ?? resolveGhPagesUrl(repo),
+    baseUrl: opts.baseUrl ?? demoDataBaseUrl(repo),
     concurrency: opts.concurrency ?? 12,
     maxRetries,
     retryFetch: makeRetryFetch(fetchFn, maxRetries, sleepFn),

--- a/src/lib/client/firma/firma-config.ts
+++ b/src/lib/client/firma/firma-config.ts
@@ -61,7 +61,7 @@ const STORAGE_KEY = "ava.firma";
  *   - Saknas variabeln → fall tillbaka på publika referensdemon
  *     `ulrik-s/ava-demo` för utvecklare som bygger lokalt utan att seeda.
  */
-const DEMO_REPO = process.env.NEXT_PUBLIC_DEMO_REPO || "ulrik-s/ava-demo";
+export const DEMO_REPO = process.env.NEXT_PUBLIC_DEMO_REPO || "ulrik-s/ava-demo";
 
 const DEMO_DEFAULT: FirmaConfig = {
   tier: "demo",
@@ -130,19 +130,34 @@ const storedFirmaConfigSchema = z.object({
   corsProxy: z.string().optional(),
 }).passthrough();
 
+/**
+ * Default som hör ihop med en LAGRAD tier — inte med hostnamnet.
+ *
+ * Skillnaden är inte akademisk (#932): på localhost ger `defaultConfigForHost`
+ * self-hosted, så en lagrad `tier: "demo"` med tomt `repo` ärvde den
+ * SJÄLVHOSTADE git-URL:en. Demo-laddarna försökte då hämta `.ava/meta.json`
+ * från `http://localhost:8080/git/firma.git/…` — en URL som varken finns eller
+ * betyder något i demo-läge. Tiern måste avgöra vilket repo som är default.
+ */
+function defaultForTier(tier: FirmaTier): FirmaConfig {
+  return tier === "demo" ? DEMO_DEFAULT : SELF_HOSTED_LOCALHOST_DEFAULT;
+}
+
 export function loadFirmaConfig(): FirmaConfig {
   if (typeof window === "undefined") return DEMO_DEFAULT;
-  const fallback = defaultConfigForHost(window.location.hostname);
+  const hostDefault = defaultConfigForHost(window.location.hostname);
   try {
     const parsed = loadFromStorage(STORAGE_KEY, storedFirmaConfigSchema, {});
+    // Lagrad tier vinner över hostens gissning; utan lagrad tier gäller hosten.
+    const fallback = parsed.tier ? defaultForTier(parsed.tier) : hostDefault;
     return {
       ...fallback,
       ...omitUndefined(parsed),
-      // Tomt repo → fall tillbaka till hostens default
+      // Tomt repo → fall tillbaka till den valda tierns default
       repo: parsed.repo || fallback.repo,
     };
   } catch {
-    return fallback;
+    return hostDefault;
   }
 }
 

--- a/src/lib/client/firma/open-document-externally.ts
+++ b/src/lib/client/firma/open-document-externally.ts
@@ -19,6 +19,7 @@
  */
 
 import type { ModalState } from "@/components/documents/external-edit-modal";
+import { demoDataBaseUrl } from "@/lib/client/demo/demo-data-base";
 import { isDemoTier } from "@/lib/client/firma/firma-config";
 import { openViaHelper } from "@/lib/client/helper/use-helper";
 import type { HelperOpenRequest } from "@/lib/shared/helper/protocol";
@@ -87,24 +88,26 @@ function helperTrpcUrl(): string {
   return new URL("/api/trpc", window.location.origin).toString();
 }
 
+/**
+ * Bas-URL för demons dokument. Delad med `openDocument` via `demoDataBaseUrl`
+ * (#932) — här stod förr en tredje kopia av github.io-konstruktionen, som
+ * skickade helpern ut mot LIVE-demon även när `out/` serverades lokalt.
+ */
+function demoBase(): string {
+  return demoDataBaseUrl(
+    process.env.NEXT_PUBLIC_DEMO_REPO || process.env.NEXT_PUBLIC_DEFAULT_DEMO_REPO || DEFAULT_DEMO_REPO_FALLBACK,
+  );
+}
+
 function demoUrl(doc: Doc): string {
-  const repo = process.env.NEXT_PUBLIC_DEMO_REPO || process.env.NEXT_PUBLIC_DEFAULT_DEMO_REPO || DEFAULT_DEMO_REPO_FALLBACK;
-  const m = repo.match(/^([^/\s]+)\/([^/\s]+)$/);
-  const base = m ? `https://${m[1]}.github.io/${m[2]}` : repo.replace(/\/+$/, "");
-  return `${base}/${doc.storagePath}`;
+  return `${demoBase()}/${doc.storagePath}`;
 }
 
 export async function runExternalEdit(doc: Doc): Promise<ModalState> {
   const { openInFinder } = await import("@/lib/client/fsa/open-in-finder");
   const { getExternalEditTracker } = await import("@/lib/client/fsa/external-edit-tracker");
 
-  const fallbackBase = isDemoTier()
-    ? (() => {
-        const repo = process.env.NEXT_PUBLIC_DEMO_REPO || process.env.NEXT_PUBLIC_DEFAULT_DEMO_REPO || DEFAULT_DEMO_REPO_FALLBACK;
-        const m = repo.match(/^([^/\s]+)\/([^/\s]+)$/);
-        return m ? `https://${m[1]}.github.io/${m[2]}` : repo;
-      })()
-    : undefined;
+  const fallbackBase = isDemoTier() ? demoBase() : undefined;
 
   const r = await openInFinder(doc.storagePath, omitUndefined({ downloadFallbackBase: fallbackBase }));
   if (r.kind === "unsupported") {

--- a/src/lib/client/firma/open-document.ts
+++ b/src/lib/client/firma/open-document.ts
@@ -13,6 +13,8 @@
  *   3. Annars: visa felmeddelande (filsystemet saknas, dokumentet finns ej).
  */
 
+import { demoDataBaseUrl } from "@/lib/client/demo/demo-data-base";
+
 export interface OpenDocumentDeps {
   doc: { id: string; storagePath?: string | null; fileName?: string };
   /** Demo-flagga från env. Bygg-tid: NEXT_PUBLIC_DEMO_BUILD === "1". */
@@ -55,10 +57,11 @@ export async function openDocument(deps: OpenDocumentDeps): Promise<"opened-gh-p
   }
 
   if (isDemo) {
-    const repo = demoRepo ?? "ulrik-s/ava-demo";
-    const m = repo.match(/^([^/\s]+)\/([^/\s]+)$/);
-    const base = m ? `https://${m[1]}.github.io/${m[2]}` : repo.replace(/\/+$/, "");
-    openUrl(`${base}/${storagePath}`);
+    // Datan (och därmed dokumenten) ligger bredvid appen — `demoDataBaseUrl`
+    // ger same-origin när så är fallet. Här stod förr en egen kopia av
+    // github.io-konstruktionen, vilket öppnade dokument mot LIVE-demon även när
+    // man körde en lokalt serverad `out/` (#932).
+    openUrl(`${demoDataBaseUrl(demoRepo ?? "")}/${storagePath}`);
     return "opened-gh-pages";
   }
 

--- a/test/e2e/_demo-test.ts
+++ b/test/e2e/_demo-test.ts
@@ -1,0 +1,137 @@
+/**
+ * Delad `test` för demo-e2e:t — med en HERMETICITETS-VAKT (#932).
+ *
+ * Jobbet kallade sig "snabb + hermetisk" utan att vara det: `out/` serverades
+ * på localhost, men appen hämtade sin data från live-demon på GH Pages. När
+ * Pages låg nere blev PR:er röda av skäl som inte hade med diffen att göra, och
+ * felet såg ut som en UI-regression (`/login` saknade sin knapp) i stället för
+ * ett nätverksfel.
+ *
+ * Vakten gör antagandet till ett PÅSTÅENDE som testas: varje HTTP-förfrågan
+ * utanför testets egen origin BLOCKERAS och samlas in, och testet fälls efteråt
+ * med hela listan. Att blockera i stället för att bara logga är avsiktligt —
+ * annars kan ett test passera på data det inte borde ha haft tillgång till, och
+ * vi skulle inte veta att hermeticiteten gått sönder förrän Pages nästa gång
+ * låg nere.
+ *
+ * Vakten är `auto: true` → gäller varje test som importerar `test` härifrån,
+ * utan att specen behöver be om den. Den gäller även mot live-demon
+ * (`AVA_DEMO_BASE_URL=https://…`): då är datan same-origin ändå, så kravet är
+ * detsamma.
+ */
+import { type BrowserContext, type Page, test as base, expect } from "@playwright/test";
+
+/**
+ * Bas-URL för demo-e2e — lokalt serverad `out/` som default, live bara på
+ * uttrycklig begäran. Specarna delar konstanten så defaultet finns på ETT
+ * ställe; förr bar varje spec sin egen `?? "https://ulrik-s.github.io/ava"`.
+ */
+export const DEMO_BASE_URL = (
+  process.env.AVA_DEMO_BASE_URL ?? `http://localhost:${process.env.DEMO_PORT ?? 8799}/ava`
+).replace(/\/+$/, "");
+
+/**
+ * Seeda `ava.firma` INNAN sidan laddas — motsvarar vad `/login` skriver.
+ *
+ * `repo: ""` med flit: då härleder `demoDataBaseUrl` basen ur bundlets eget
+ * repo → same-origin (#932). Att i stället stoppa in testets baseURL här skulle
+ * tvinga fram same-origin i testet men dölja att APPEN gör fel för en riktig
+ * besökare på en lokalt serverad `out/`.
+ *
+ * Behövs även för att localhost defaultar till `self-hosted` (→ 401):
+ * `defaultConfigForHost` känner inte till att vi serverar en demo-`out/`.
+ */
+export async function seedDemoConfig(
+  target: Page | BrowserContext,
+  overrides: Record<string, string> = {},
+): Promise<void> {
+  await target.addInitScript((cfg) => {
+    try {
+      localStorage.setItem("ava.firma", JSON.stringify(cfg));
+    } catch { /* privat läge e.d. — testet failar i så fall på annat sätt */ }
+  }, {
+    tier: "demo", repo: "", token: "",
+    principalId: "", organizationId: "",
+    authorName: "AVA Demo", authorEmail: "demo@ava.local",
+    ...overrides,
+  });
+}
+
+/**
+ * Som `seedDemoConfig`, men INLOGGAD — sidor bakom auth (ärenden, kontakter,
+ * fakturor) dirigerar annars till `/login` och specen ser bara inloggningen.
+ *
+ * Användaren läses ur den serverade `.ava/meta.json` i stället för att
+ * hårdkodas: seed-datat genereras om vid varje `build:demo`, och en hårdkodad
+ * UUID hade tystnat till "sidan renderar inte" nästa gång seeden ändras.
+ */
+export async function seedDemoLogin(page: Page, baseUrl: string = DEMO_BASE_URL): Promise<void> {
+  const url = `${baseUrl}/.ava/meta.json`;
+  const res = await page.request.get(url);
+  if (!res.ok()) {
+    throw new Error(`kunde inte läsa ${url}: HTTP ${res.status()} — är out/ byggd och serverad?`);
+  }
+  const meta = await res.json() as {
+    organizationId: string;
+    users: Array<{ id: string; name: string; role: string }>;
+  };
+  const user = meta.users.find((u) => u.role === "ADMIN") ?? meta.users[0];
+  if (!user) throw new Error(`${url} saknar users — build-demo-repo har inte seedat klart`);
+  await seedDemoConfig(page, {
+    principalId: user.id,
+    organizationId: meta.organizationId,
+    authorName: user.name,
+  });
+}
+
+/** Icke-HTTP (`data:`, `blob:`, `about:`) är inte nätverk — släpp igenom. */
+function isNetworkUrl(url: string): boolean {
+  return /^https?:\/\//i.test(url);
+}
+
+/**
+ * Den enda tillåtna trafiken utanför sidans origin: AVA Helper-proben, som
+ * demon kör för att upptäcka om skrivbordshelpern finns. Den lyssnar på två
+ * transporter (ADR 0006) — HTTP på 127.0.0.1 och HTTPS på localhost — och båda
+ * är loopback, alltså oförmögna att nå internet.
+ *
+ * Vi släpper igenom exakt de två origins:en, inte loopback i allmänhet: en
+ * generös regel hade missat att demon hämtade sin data från
+ * `http://localhost:8080/git/firma.git`, vilket är precis vad den här vakten
+ * fann. Speglar `HELPER_BASE` / `HELPER_HTTPS_BASE` i
+ * `src/lib/shared/helper/protocol.ts` (duplicerat med flit — testet ska inte
+ * importera produktionskonstanter det är satt att granska).
+ */
+const HELPER_PROBE_ORIGINS = ["http://127.0.0.1:48761", "https://localhost:48762"];
+
+export const test = base.extend<{ offsiteRequests: string[] }>({
+  offsiteRequests: [
+    async ({ page, baseURL }, use) => {
+      const offsite: string[] = [];
+      const ownOrigin = new URL(baseURL ?? "http://localhost:8799").origin;
+
+      await page.route("**/*", async (route) => {
+        const url = route.request().url();
+        const origin = isNetworkUrl(url) ? new URL(url).origin : ownOrigin;
+        if (origin !== ownOrigin && !HELPER_PROBE_ORIGINS.includes(origin)) {
+          offsite.push(url);
+          // `blockedbyclient` speglar vad en offline-miljö gör, så appen ser
+          // samma felläge som i CI utan nät.
+          await route.abort("blockedbyclient");
+          return;
+        }
+        await route.continue();
+      });
+
+      await use(offsite);
+
+      expect(
+        offsite,
+        `demon gick utanför sin egen origin (${ownOrigin}) — testet är inte hermetiskt`,
+      ).toEqual([]);
+    },
+    { auto: true },
+  ],
+});
+
+export { expect };

--- a/test/e2e/demo-invoice-document.spec.ts
+++ b/test/e2e/demo-invoice-document.spec.ts
@@ -11,11 +11,17 @@
  * React #418 på köpet. Testet failar om man navigeras till /matters eller om
  * #418 dyker upp.
  *
- * Kör mot live-demon (default) eller en lokalt serverad out/:
- *   bun run e2e:demo
- *   AVA_DEMO_BASE_URL=http://localhost:8080/ava bun run e2e:demo
+ * Kör mot en lokalt serverad `out/` (default — configen startar servern) eller
+ * mot den deployade demon:
+ *   bun run build:demo && bun run e2e:demo
+ *   AVA_DEMO_BASE_URL=https://ulrik-s.github.io/ava bun run e2e:demo
+ *
+ * `test` kommer från `_demo-test` → varje förfrågan utanför testets egen origin
+ * blockeras och fäller testet (#932).
  */
-import { test, expect, type ConsoleMessage } from "@playwright/test";
+import { type ConsoleMessage } from "@playwright/test";
+
+import { DEMO_BASE_URL, seedDemoConfig, test, expect } from "./_demo-test";
 
 // Seed-identiteter (ur .ava/meta.json). "Logga in som Anna" = seedad config.
 const ANNA = "e1c7d494-c148-5998-b717-df386937d5a1";
@@ -23,18 +29,13 @@ const ORG = "83f68f9a-5f27-5199-b54b-e4b2fa380e14";
 const MATTER = "92d63776-c955-54dc-8430-3573bed7829b"; // Brottmål — ekobrott Carlsson
 
 test("fakturadokument öppnas i ny flik — dirigeras INTE in i ärendet (+ ingen #418)", async ({ page, context, baseURL }) => {
-  const base = baseURL ?? "https://ulrik-s.github.io/ava";
+  const base = (baseURL ?? DEMO_BASE_URL).replace(/\/+$/, "");
 
   // "Logga in som Anna Advokat" — seeda demo-config (samma som /login skriver).
-  await context.addInitScript(([anna, org]) => {
-    try {
-      localStorage.setItem("ava.firma", JSON.stringify({
-        tier: "demo", repo: "ulrik-s/ava", token: "",
-        principalId: anna, organizationId: org,
-        authorName: "Anna Advokat", authorEmail: "user@ava.demo",
-      }));
-    } catch { /* ignore */ }
-  }, [ANNA, ORG]);
+  await seedDemoConfig(context, {
+    principalId: ANNA, organizationId: ORG,
+    authorName: "Anna Advokat", authorEmail: "user@ava.demo",
+  });
 
   const hydrationErrors: string[] = [];
   page.on("console", (m: ConsoleMessage) => {
@@ -69,15 +70,20 @@ test("fakturadokument öppnas i ny flik — dirigeras INTE in i ärendet (+ inge
   const survivedNav = await page.evaluate(() => (window as unknown as { __avaSpa?: string }).__avaSpa);
   expect(survivedNav, "navigering till fakturan ska vara soft (ingen sidomladdning)").toBe("alive");
 
-  // Fakturadokument-panelen: dokumentnamnet "Faktura ….pdf". Lokalisera via TEXT
+  // Fakturadokument-panelen: dokumentnamnet "Faktura ….html". Lokalisera via TEXT
   // så det fångar både den BUGGIGA varianten (en <a>-länk till /matters) och den
   // FIXADE (en <button> som öppnar dokumentet).
-  const docEl = page.getByText(/Faktura .*\.pdf/i).first();
+  //
+  // Filändelsen är `.html` sedan #937/#939 (en enda fakturarenderare). Att testet
+  // fortfarande letade efter `.pdf` MÄRKTES INTE, eftersom det kördes mot den
+  // DEPLOYADE demon — där låg en äldre build vars fakturor var PDF:er. Grönt mot
+  // gammal data, fel mot koden i repot: precis det #932 handlar om.
+  const docEl = page.getByText(/Faktura .*\.html/i).first();
   await expect(docEl).toBeVisible({ timeout: 15_000 });
 
   const urlBeforeClick = page.url();
 
-  // Klick ska öppna PDF:en i NY FLIK (popup) — inte navigera huvudsidan in i
+  // Klick ska öppna dokumentet i NY FLIK (popup) — inte navigera huvudsidan in i
   // ärendet. (Buggen: namnet var en länk till /matters → hård-nav dit.)
   const popupPromise = context.waitForEvent("page", { timeout: 8000 }).catch(() => null);
   await docEl.click();
@@ -87,7 +93,7 @@ test("fakturadokument öppnas i ny flik — dirigeras INTE in i ärendet (+ inge
   // 1) Huvudsidan ska INTE ha navigerat in i ärendet.
   expect(page.url(), "huvudsidan ska stanna på fakturasidan, inte gå till /matters").not.toMatch(/\/matters\//);
   expect(page.url()).toBe(urlBeforeClick);
-  // 2) En ny flik (PDF) ska ha öppnats.
+  // 2) En ny flik (dokumentet) ska ha öppnats.
   expect(popup, "dokumentet ska öppnas i en ny flik").not.toBeNull();
   // 3) Ingen hydrerings-#418.
   expect(hydrationErrors, `React #418 / hydrerings-fel: ${hydrationErrors.join(" | ")}`).toEqual([]);

--- a/test/e2e/demo-login.spec.ts
+++ b/test/e2e/demo-login.spec.ts
@@ -7,32 +7,22 @@
  * returnerar tidigt). En ny besökare utan `principalId` dirigeras till /login
  * → som aldrig renderade → ingen kunde logga in (#498-regression).
  *
- * Testet kör mot den deployade demon (default) eller en lokalt serverad out/:
- *   AVA_DEMO_BASE_URL=http://localhost:8080/ava bun run e2e:demo
+ * Kör mot en lokalt serverad `out/` (default — configen startar servern) eller
+ * mot den deployade demon:
+ *   bun run e2e:demo
+ *   AVA_DEMO_BASE_URL=https://ulrik-s.github.io/ava bun run e2e:demo
+ *
+ * `test` kommer från `_demo-test` → varje förfrågan utanför testets egen origin
+ * blockeras och fäller testet (#932).
  */
-import { test, expect } from "@playwright/test";
+import { DEMO_BASE_URL, seedDemoConfig, test, expect } from "./_demo-test";
 
 test("färsk besökare (ingen principal) → /login renderar inloggningen, fastnar inte på 'Laddar…'", async ({ page, context, baseURL }) => {
-  const base = baseURL ?? "https://ulrik-s.github.io/ava";
+  const base = (baseURL ?? DEMO_BASE_URL).replace(/\/+$/, "");
 
   // Färsk demo-besökare: tier=demo, INGEN principalId (deterministiskt oavsett
   // build-defaults). Detta är exakt vad en ny besökare på live-demon har.
-  //
-  // `repo` sätts till testets EGEN baseURL (#932): `resolveGhPagesUrl` returnerar
-  // en full URL som-är, så datan (`.ava/meta.json` m.m.) hämtas från samma origin
-  // som sidan serveras från. Förr stod här "ulrik-s/ava", vilket fick den lokalt
-  // serverade `out/` att ändå hämta data från LIVE-demon → jobbet var inte
-  // hermetiskt och blev rött när live-demon var nere (#933), med ett missvisande
-  // fel (saknad "Logga in"-knapp, eftersom formuläret väntar på användarlistan).
-  // Mot live-demon (default baseURL) är beteendet oförändrat.
-  await context.addInitScript((repo) => {
-    try {
-      localStorage.setItem("ava.firma", JSON.stringify({
-        tier: "demo", repo, token: "",
-        principalId: "", organizationId: "", authorName: "", authorEmail: "",
-      }));
-    } catch { /* ignore */ }
-  }, base.replace(/\/+$/, ""));
+  await seedDemoConfig(context);
 
   await page.goto(`${base}/`, { waitUntil: "domcontentloaded" });
 

--- a/test/e2e/demo-smoke.spec.ts
+++ b/test/e2e/demo-smoke.spec.ts
@@ -1,18 +1,27 @@
 /**
- * Smoke-tester mot demo-bygget på GitHub Pages. Verifierar att alla
- * sidor i sidopanelen returnerar 200 + renderar utan render-fel,
- * istället för att 404:a eller krascha.
+ * Smoke-tester mot demo-bygget: alla sidor i sidopanelen ska svara 200 och
+ * rendera utan render-fel, i stället för att 404:a eller krascha.
  *
- * Kör mot live-demon (read-only check): `npx playwright test
- * test/e2e/demo-smoke.spec.ts`
+ * Kör mot en lokalt serverad `out/` (default):
+ *   bun run build:demo
+ *   bun tooling/scripts/serve-demo-static.ts &
+ *   npx playwright test test/e2e/demo-smoke.spec.ts
  *
- * För lokal kör först `bash scripts/build-demo.sh && cd out &&
- * python3 -m http.server 8765`, sen sätt BASE_URL=http://localhost:8765/ava
+ * …eller mot live-demon (read-only check), på uttrycklig begäran:
+ *   AVA_DEMO_BASE_URL=https://ulrik-s.github.io/ava npx playwright test test/e2e/demo-smoke.spec.ts
+ *
+ * Defaultet pekade förr på live-demon (#932): en "lokal" körning testade i
+ * själva verket det som redan låg publicerat, inte branchen man satt på.
  */
 
-import { test, expect } from "@playwright/test";
+import { DEMO_BASE_URL as BASE, seedDemoLogin, test, expect } from "./_demo-test";
 
-const BASE = process.env.AVA_DEMO_BASE_URL ?? "https://ulrik-s.github.io/ava";
+test.beforeEach(async ({ page }) => {
+  // Tvinga demo-tier (localhost defaultar self-hosted → 401) OCH logga in:
+  // sidorna bakom auth dirigerar annars till /login, och specen hade bara
+  // verifierat inloggningsskärmen om och om igen.
+  await seedDemoLogin(page, BASE);
+});
 
 const ROUTES = [
   { path: "/", expectText: /Startsida|AVA/i },

--- a/test/e2e/kebab-verify.spec.ts
+++ b/test/e2e/kebab-verify.spec.ts
@@ -11,25 +11,20 @@
  *   2. Auto-table-layout lät namn-kolumnen växa → tabellen överflödade
  *      containern (fixat med table-fixed + break-words + kolumn-döljning).
  *
- * Kör mot live GH Pages (default) eller lokalt demo-bygge:
- *   AVA_DEMO_BASE_URL=http://localhost:8099/ava npx playwright test kebab-verify
- * Mot localhost måste demo-läge tvingas (localhost defaultar self-hosted).
+ * Kör mot lokalt serverad `out/` (default) eller mot live GH Pages:
+ *   bun run build:demo && bun tooling/scripts/serve-demo-static.ts &
+ *   npx playwright test kebab-verify --config tooling/config/playwright-demo.config.ts
+ *   AVA_DEMO_BASE_URL=https://ulrik-s.github.io/ava npx playwright test kebab-verify
  */
 
-import { test, expect, type Page } from "@playwright/test";
+import { type Page } from "@playwright/test";
 
-const BASE = process.env.AVA_DEMO_BASE_URL ?? "https://ulrik-s.github.io/ava";
-const isLocal = /localhost|127\.0\.0\.1/.test(BASE);
+import { DEMO_BASE_URL as BASE, seedDemoLogin, test, expect } from "./_demo-test";
 
 test.beforeEach(async ({ page }) => {
-  if (!isLocal) return;
-  // localhost defaultar till self-hosted (→ 401). Tvinga demo mot samma-origin.
-  await page.addInitScript((origin) => {
-    localStorage.setItem("ava.firma", JSON.stringify({
-      tier: "demo", repo: origin, token: "",
-      organizationId: "demo-firma-ab", authorName: "AVA Demo", authorEmail: "demo@ava.local",
-    }));
-  }, BASE);
+  // localhost defaultar till self-hosted (→ 401) → tvinga demo. Seedas även mot
+  // live: `repo: ""` ger same-origin i båda lägena, så vägen är densamma.
+  await seedDemoLogin(page, BASE);
 });
 
 async function gotoMatter(page: Page) {

--- a/test/e2e/matters-employee-filter.spec.ts
+++ b/test/e2e/matters-employee-filter.spec.ts
@@ -6,23 +6,16 @@
  * hela stacken: user.list fyller dropdown:en + valet filtrerar listan
  * (matter.list där timeEntries.some.userId).
  *
- * Kör mot live GH Pages (default) eller lokalt demo-bygge:
- *   AVA_DEMO_BASE_URL=http://localhost:8099/ava npx playwright test matters-employee-filter
+ * Kör mot lokalt serverad `out/` (default) eller mot live GH Pages:
+ *   AVA_DEMO_BASE_URL=https://ulrik-s.github.io/ava npx playwright test matters-employee-filter
  */
 
-import { test, expect } from "@playwright/test";
-
-const BASE = process.env.AVA_DEMO_BASE_URL ?? "https://ulrik-s.github.io/ava";
-const isLocal = /localhost|127\.0\.0\.1/.test(BASE);
+import { DEMO_BASE_URL as BASE, seedDemoLogin, test, expect } from "./_demo-test";
 
 test.beforeEach(async ({ page }) => {
-  if (!isLocal) return;
-  await page.addInitScript((origin) => {
-    localStorage.setItem("ava.firma", JSON.stringify({
-      tier: "demo", repo: origin, token: "",
-      organizationId: "demo-firma-ab", authorName: "AVA Demo", authorEmail: "demo@ava.local",
-    }));
-  }, BASE);
+  // localhost defaultar till self-hosted (→ 401) → tvinga demo. `repo: ""` ger
+  // same-origin både lokalt och mot live (#932).
+  await seedDemoLogin(page, BASE);
 });
 
 test("medarbetar-dropdown fylls och filtrerar ärendelistan", async ({ page }) => {

--- a/test/unit/lib/auth/github-auth.test.tsx
+++ b/test/unit/lib/auth/github-auth.test.tsx
@@ -100,10 +100,13 @@ describe("getRepoPermissions", () => {
 });
 
 describe("detectAuthMode", () => {
-  it("ingen token + publika repo → anonymous", async () => {
-    fetchMock.mockResolvedValueOnce(ok({ name: "ava-demo" })); // GET repo
+  it("ingen token + GitHub-repo → anonymous UTAN nätverksanrop (#932)", async () => {
+    // Förr gjordes ett `GET /repos/:owner/:repo` här vars svar kastades bort
+    // (båda grenarna gav "anonymous"). Att räkna anropen är hela poängen: en
+    // ren `expect(m).toBe("anonymous")` passerade lika glatt med anropet kvar.
     const m: AuthMode = await detectAuthMode({ token: "", repoUrl: "ulrik-s/ava-demo" });
     expect(m).toBe("anonymous");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
   it("token + push → identified-write", async () => {
     fetchMock.mockResolvedValueOnce(ok({ login: "anna", id: 1 })); // GET user

--- a/test/unit/lib/client/demo/demo-data-base.test.ts
+++ b/test/unit/lib/client/demo/demo-data-base.test.ts
@@ -1,0 +1,81 @@
+/**
+ * `demoDataBaseUrl` (#932) — var demons data hämtas ifrån.
+ *
+ * Buggen som testerna vaktar: en `out/` som serverades lokalt NAVIGERADE till
+ * localhost men HÄMTADE data från live-demon på GH Pages, eftersom bas-URL:en
+ * konstruerades ur repo-STRÄNGEN i stället för ur var appen faktiskt kör. Det
+ * gjorde demo-e2e:t nätverksberoende och rött när GH Pages låg nere.
+ *
+ * Två egenskaper är lika viktiga och drar åt olika håll:
+ *   • same-origin när datan ligger bredvid appen (hermetiskt), OCH
+ *   • oförändrat beteende när användaren uttryckligen pekar på NÅGON ANNANS
+ *     demo — då MÅSTE vi fortsatt gå ut på nätet.
+ */
+import { describe, it, expect } from "vitest-compat";
+
+import { demoDataBaseUrl } from "@/lib/client/demo/demo-data-base";
+
+/** Bunden till "det här bundlet byggdes för ulrik-s/ava och kör under /ava". */
+const pages = {
+  origin: "https://ulrik-s.github.io",
+  basePath: "/ava",
+  buildRepo: "ulrik-s/ava",
+  isDemoBuild: true,
+} as const;
+
+const local = { ...pages, origin: "http://localhost:8799" } as const;
+
+describe("demoDataBaseUrl — same-origin (regel 3)", () => {
+  it("lokalt serverad out/ hämtar från LOCALHOST, inte från github.io", () => {
+    // Kärnan i #932. Före fixen gav det här "https://ulrik-s.github.io/ava".
+    expect(demoDataBaseUrl("ulrik-s/ava", local)).toBe("http://localhost:8799/ava");
+  });
+
+  it("på GH Pages blir URL:en IDENTISK med den gamla konstruktionen", () => {
+    // Regressionsvakt: produktionsbeteendet får inte ändras av den här fixen.
+    expect(demoDataBaseUrl("ulrik-s/ava", pages)).toBe("https://ulrik-s.github.io/ava");
+  });
+
+  it("tomt repo faller tillbaka på bundlets eget → same-origin", () => {
+    expect(demoDataBaseUrl("", local)).toBe("http://localhost:8799/ava");
+  });
+
+  it("hanterar tom basePath (demo utan bas-sökväg)", () => {
+    expect(demoDataBaseUrl("ulrik-s/ava", { ...local, basePath: "" }))
+      .toBe("http://localhost:8799");
+  });
+
+  it("avslutande snedstreck i repo:t hindrar inte matchningen", () => {
+    expect(demoDataBaseUrl("ulrik-s/ava/", local)).toBe("http://localhost:8799/ava");
+  });
+});
+
+describe("demoDataBaseUrl — annat repo (regel 2)", () => {
+  it("pekar config:en på NÅGON ANNANS demo går vi ut på nätet", () => {
+    expect(demoDataBaseUrl("ulrik-s/ava-demo", local))
+      .toBe("https://ulrik-s.github.io/ava-demo");
+  });
+
+  it("full github.com-URL översätts fortfarande till GH Pages", () => {
+    expect(demoDataBaseUrl("https://github.com/annan/byra", local))
+      .toBe("https://annan.github.io/byra");
+  });
+
+  it("en färdig bas-URL returneras som-är", () => {
+    expect(demoDataBaseUrl("http://localhost:8080/ava", local))
+      .toBe("http://localhost:8080/ava");
+  });
+});
+
+describe("demoDataBaseUrl — icke-demo-build (regel 1)", () => {
+  it("server-/dev-build behåller det gamla beteendet", () => {
+    expect(demoDataBaseUrl("ulrik-s/ava", { ...local, isDemoBuild: false }))
+      .toBe("https://ulrik-s.github.io/ava");
+  });
+
+  it("utan origin (SSR/prerender) gissas GH Pages-URL:en — ingen krasch", () => {
+    // Under statisk export körs koden utan `window`; den får inte kasta.
+    expect(demoDataBaseUrl("ulrik-s/ava", { ...local, origin: "" }))
+      .toBe("https://ulrik-s.github.io/ava");
+  });
+});

--- a/test/unit/lib/firma/firma-config.test.tsx
+++ b/test/unit/lib/firma/firma-config.test.tsx
@@ -75,6 +75,23 @@ describe("firma-config", () => {
       expect(cfg.repo).toBe("http://localhost:8080/git/firma.git");
     });
 
+    it("lagrad tier=demo på LOCALHOST ärver demo-repot — inte git-URL:en (#932)", () => {
+      // Regressionsvakt: förr styrde HOSTNAMNET fallbacken, så en demo-config
+      // med tomt repo fick `http://localhost:8080/git/firma.git`. Demo-laddarna
+      // hämtade då `.ava/meta.json` därifrån — en URL utan mening i demo-läge,
+      // vilket bl.a. gjorde en lokalt serverad `out/` omöjlig att smoke-testa.
+      localStorage.setItem(KEY, JSON.stringify({ tier: "demo", repo: "" }));
+      const cfg = loadFirmaConfig();
+      expect(cfg.tier).toBe("demo");
+      expect(cfg.repo).toBe("ulrik-s/ava-demo");
+    });
+
+    it("lagrad tier=self-hosted på en PUBLIK domän ärver git-defaulten", () => {
+      // Spegelvänt fall — tiern, inte hosten, ska avgöra vilken default som ärvs.
+      localStorage.setItem(KEY, JSON.stringify({ tier: "self-hosted", repo: "" }));
+      expect(loadFirmaConfig().repo).toBe("http://localhost:8080/git/firma.git");
+    });
+
     it("ignorerar korrupt JSON och returnerar host-default", () => {
       localStorage.setItem(KEY, "{kaos");
       const cfg = loadFirmaConfig();

--- a/tooling/config/playwright-demo.config.ts
+++ b/tooling/config/playwright-demo.config.ts
@@ -4,17 +4,36 @@ import { defineConfig, devices } from "@playwright/test";
 const projectRoot = path.resolve(__dirname, "..", "..");
 
 /**
- * Demo-e2e: kör HELA demo-flöden mot den deployade GH-Pages-demon (eller en
- * lokalt serverad `out/` via AVA_DEMO_BASE_URL). Till skillnad från den
- * vanliga playwright.config.ts startar denna INGEN dev-server — den pekar på
- * en redan körande demo. Default = live-sajten.
+ * Demo-e2e: kör HELA demo-flöden mot den byggda `out/`.
  *
- *   bun run e2e:demo
- *   AVA_DEMO_BASE_URL=http://localhost:8080/ava bun run e2e:demo   # lokal out/
+ * Default är en LOKALT SERVERAD `out/` som configen startar själv — inte
+ * live-demon (#932). Det gamla defaultet (`https://ulrik-s.github.io/ava`)
+ * gjorde varje körning nätverksberoende: PR:er blev röda när GH Pages låg nere,
+ * och ett grönt resultat sa ingenting om koden i diffen.
+ *
+ *   bun run build:demo && bun run e2e:demo                        # lokalt (default)
+ *   AVA_DEMO_BASE_URL=https://ulrik-s.github.io/ava bun run e2e:demo   # mot live
+ *
+ * Sätts `AVA_DEMO_BASE_URL` startas ingen server — då pekar man med flit på
+ * något som redan kör.
  */
+const DEMO_PORT = Number(process.env.DEMO_PORT ?? 8799);
+const LOCAL_BASE_URL = `http://localhost:${DEMO_PORT}/ava`;
+const baseURL = process.env.AVA_DEMO_BASE_URL ?? LOCAL_BASE_URL;
+
 export default defineConfig({
   testDir: path.join(projectRoot, "test/e2e"),
-  testMatch: /demo-(invoice-document|login)\.spec\.ts$/,
+  // Specar som behöver en serverad `out/` hör hemma här — inte i
+  // playwright.config.ts, som startar `next dev` på :3000 (#932).
+  //
+  // `demo-smoke` och `kebab-verify` är UTELÄMNADE med flit: de hårdkodar seed-id:n
+  // i det gamla formatet (`m-001-vardnad`, `m-016-brottmal-rh`, `inv-001`) som
+  // seeden slutade producera för länge sedan — den kör UUID:er nu. Att ingen
+  // märkt det är samma sjuka som #932: specarna låg i ingens config och kördes
+  // för hand mot live-demon. De pekar numera på den lokala servern och bär
+  // hermeticitets-vakten, så den som lagar dem börjar från rätt utgångsläge; att
+  // ta in dem här innan dess vore bara att göra `e2e:demo` rött. Se #972.
+  testMatch: /(demo-invoice-document|demo-login|matters-employee-filter)\.spec\.ts$/,
   timeout: 90_000,
   expect: { timeout: 15_000 },
   fullyParallel: false,
@@ -23,9 +42,22 @@ export default defineConfig({
   reporter: [["list"]],
   outputDir: path.join(projectRoot, "reports/playwright-demo"),
   use: {
-    baseURL: process.env.AVA_DEMO_BASE_URL ?? "https://ulrik-s.github.io/ava",
+    baseURL,
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
   },
+  // Bara när vi kör mot vår egen `out/`. `serve-demo-static.ts` är beroendefri
+  // (node:http) och läser `out/` relativt cwd → därav `cwd: projectRoot`.
+  ...(process.env.AVA_DEMO_BASE_URL ? {} : {
+    webServer: {
+      command: `bun tooling/scripts/serve-demo-static.ts`,
+      url: `${LOCAL_BASE_URL}/login/`,
+      cwd: projectRoot,
+      timeout: 60_000,
+      reuseExistingServer: !process.env.CI,
+      stdout: "ignore" as const,
+      stderr: "pipe" as const,
+    },
+  }),
   projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
 });

--- a/tooling/config/playwright.config.ts
+++ b/tooling/config/playwright.config.ts
@@ -13,10 +13,10 @@ const projectRoot = path.resolve(__dirname, "..", "..");
  */
 export default defineConfig({
   testDir: path.join(projectRoot, "test/e2e"),
-  // demo-invoice-document.spec.ts körs mot den deployade demon via
-  // playwright-demo.config.ts (ingen dev-server) — uteslut den här så
-  // `bun run e2e` inte kör den mot :3000. (demo-smoke.spec.ts lämnas orörd.)
-  testIgnore: /demo-invoice-document\.spec\.ts$/,
+  // Demo-specarna kräver en serverad `out/` och körs via
+  // playwright-demo.config.ts, som startar `serve-demo-static.ts` själv.
+  // Uteslut dem här så `bun run e2e` inte kör dem mot dev-servern på :3000.
+  testIgnore: /(demo-invoice-document|demo-login|demo-smoke|kebab-verify|matters-employee-filter)\.spec\.ts$/,
   timeout: 30_000,
   expect: { timeout: 5_000 },
   fullyParallel: false, // delar DB; håll det sekventiellt tills tester är isolerade


### PR DESCRIPTION
## Vad & varför

Demo-e2e:t kallade sig hermetiskt utan att vara det. `out/` serverades på localhost och Playwright navigerade dit — men **appen** konstruerade sin datakälla ur firma-config:ens repo-sträng (`ulrik-s/ava` → `https://ulrik-s.github.io/ava`) och hämtade `.ava/meta.json`, seed-JSON och dokument från **live-demon**. PR:er blev röda när GH Pages låg nere, med ett fel som såg ut som en UI-regression.

`build-demo.sh` seedar datan direkt in i `out/`, så appen och datan delar alltid origin. Nya `demoDataBaseUrl` uttrycker det:

| Regel | Utfall |
|---|---|
| Inte en demo-build (dev/server) | oförändrat — GH Pages-URL ur repo-strängen |
| Config pekar på ett **annat** repo | GH Pages-URL för det repot |
| Annars | **same-origin** (`origin` + `basePath`) |

På GH Pages ger regel 3 exakt samma URL som förr (`https://ulrik-s.github.io` + `/ava`) — produktionsbeteendet är oförändrat, skillnaden är att URL:en härleds i stället för gissas.

Ersätter fem `resolveGhPagesUrl(repo)`-anrop plus två handrullade kopior av samma github.io-konstruktion.

Stänger #932

## Typ

- [x] `fix` — buggfix
- [x] `refactor` / `perf`
- [x] `docs` / `test` / `chore` / `ci`

## Vakten hittade tre fel ingen letade efter

Hermeticitets-vakten i `test/e2e/_demo-test.ts` blockerar och rapporterar varje förfrågan utanför testets egen origin. Den gjorde antagandet till ett påstående som testas — och tre saker föll ut:

1. **`loadFirmaConfig` ärvde default från HOSTNAMNET.** En lagrad `tier: "demo"` på localhost fick den självhostade git-URL:en, så demo-laddarna sökte `.ava/meta.json` i `http://localhost:8080/git/firma.git/`. Tiern avgör nu vilken default som ärvs. Regressionstest tillagt.
2. **`detectAuthMode` anropade `api.github.com` och kastade bort svaret** — `return perms?.canRead ? "anonymous" : "anonymous"`, båda grenarna identiska. Varje demo-besökare betalade en oautentiserad GitHub-request (60/h per IP) som dessutom avslöjade vilket repo hen tittade på. Borttagen; returvärdet oförändrat. Testet **räknar anropen** nu — en ren `expect(m).toBe("anonymous")` passerade lika glatt med buggen kvar.
3. **`openDocument` öppnade dokument mot live-demon** från en lokalt serverad `out/`. Samma i `open-document-externally`, som skickade *helpern* ut på nätet.

Enda tillåtna undantaget är AVA Helper-proben på loopback (`127.0.0.1:48761` / `localhost:48762`) — inte loopback i allmänhet, för då hade fel 1 aldrig upptäckts.

## Ett fynd som sammanfattar hela problemet

`demo-invoice-document` letade efter `Faktura ….pdf`. Fakturadokumenten är `.html` sedan #937/#939. Testet var **grönt ändå** — det kördes mot den deployade demon, där en äldre build fortfarande hade PDF:er. Grönt mot gammal data, fel mot koden i repot.

## Verifierat lokalt (speglar CI)

- [x] `typecheck`, `lint` (`--max-warnings 0`), `lint:complexity-strict`, `knip`, `deps:check`, `jscpd` — rena
- [x] `bun run build:demo` + `bun run size` — 1169,7 KB gzip av 3400 KB
- [x] **`bun run e2e:demo` — 3/3 gröna, hermetiskt** (vakten passerar, inga blockerade förfrågningar)
- [x] Nya enhetstester: `demo-data-base.test.ts` (10), `firma-config` tier-fallback (2), `github-auth` anropsräkning
- [x] Berörda enhetstester i isolering: `documents-list-view`, `use-lease-aware-open`, `invoices/[id]/page`, `billing-panel`, `seed-smoke`, `no-hardcoded-demo-ids`, `lib/firma`, `lib/auth`, `lib/client/demo` — alla gröna
- [x] `test/unit/components/` katalogkört: 349 pass / 36 fail **identiskt före och efter** (känd mock-läckage, #92)
- [x] Commits följer Conventional Commits

## Kvalitetsgrindar

- [x] **Ingen grind lösgjord** — demo-e2e:t går från ett påstående om hermeticitet till ett kontrollerat krav. Testet fångar fortfarande #550/#552 (demon fastnar på "AVA Laddar…").
- [x] Arkitektur-/tooling-kritisk path (`.github/`, `tooling/config/`) — CI-jobbet tappar sin manuella server-dans; `playwright-demo.config.ts` startar `serve-demo-static.ts` via `webServer`, så CI och lokal körning gör exakt samma sak.

## Övrigt

**Uppföljning: #972.** `demo-smoke` och `kebab-verify` hårdkodar seed-id:n i det gamla slug-formatet (`m-001-vardnad`, `inv-001`) som seeden slutade producera för länge sedan — den kör UUID:er nu. 8 tester fäller på det. Att ingen märkt det är samma sjuka som #932: specarna låg i **ingens** config och kördes för hand mot live-demon. De pekar numera på den lokala servern, bär vakten och loggar in via `seedDemoLogin`, men är utelämnade ur `testMatch` tills id:na är lagade — att ta in dem nu vore bara att göra `e2e:demo` rött.

Inloggningsfixen (`seedDemoLogin`, som läser användaren ur `.ava/meta.json` i stället för att hårdkoda en UUID) tog sviten från 8 gröna/20 röda till 20 gröna/8 röda. `matters-employee-filter` blev grön av den och är intagen i `testMatch`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_