### PR TITLE
fix(billing): acontots moms bokförs en gång, inte två

### DIFF
--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -16,6 +16,7 @@
  */
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import { accontoCreditAmounts, accontoSplit, deductAcconto } from "@/lib/shared/acconto-vat";
 import type { VatBreakdownLine } from "@/lib/shared/accounting/semantic-voucher";
 import { assertBillingTransition, type BillingActionType } from "@/lib/shared/billing-flow";
 import { proposedAccontoOre } from "@/lib/shared/billing-proposal";
@@ -303,15 +304,6 @@ function sumKindValueOre(byKind: ReadonlyMap<TimeEntryKind, number>, settleDate:
  * TIMKOSTNADSNORMEN (staten ersätter bara normen, ej byråns taxa), tidsspillan på
  * tidsspillan-normen, rådgivningstimmen exkluderas. Utlägg ersätts brutto.
  */
-/** Fakturans exakta momsbelopp (öre) per sats: arvodets moms (25 %) +
- *  varje utläggs moms (dess sats). Lagras på fakturan för korrekt bokföring (#782). */
-function invoiceVatOre(work: UnfrozenWork): number {
-  const arvodeNet = arvodeNetOre(work);
-  const arvodeVat = arvodeInclVatOre(arvodeNet) - arvodeNet;
-  const expenseVat = work.expenses.filter((e) => e.billable).reduce((sum, e) => sum + expenseSplit(e).vat, 0);
-  return arvodeVat + expenseVat;
-}
-
 /** En arvode-breakdown-rad (25 % moms) ur ett netto-arvode; null om 0. */
 function arvodeLine(arvodeNet: number): VatBreakdownLine | null {
   if (arvodeNet <= 0) return null;
@@ -796,6 +788,39 @@ function vatLabel(netOre: number, vatOre: number): string {
   return netOre > 0 && vatOre === vatOnNet(netOre) ? "Moms 25 %" : "Moms";
 }
 
+/**
+ * Momsraden på klientfakturan, med ev. aconto-avdrag (#968).
+ *
+ * UTAN aconton: oförändrad ordning — moms, sedan inkl-moms-raden.
+ *
+ * MED aconton: avdragen läggs NETTO och FÖRE momsraden, som då bara visar momsen
+ * på det som återstår. Acontofakturorna har redan fakturerat sin egen moms;
+ * dokumentet får inte redovisa den en gång till. Förr låg avdragen brutto EFTER
+ * momsraden, så fakturan visade momsen på hela självrisken — 3 704,61 kr på ett
+ * belopp om 9 273,31 kr. Inkl-moms-raden utgår i det läget: den skulle peka på en
+ * summa som ingen ska betala.
+ */
+function clientVatRows(b: SettlementBreakdown, feeCap: string): SettlementRow[] {
+  const netOre = b.sjalvriskNetOre + b.clientExpensesNetOre;
+  const fullVatOre = b.sjalvriskGrossOre - b.sjalvriskNetOre + b.clientExpensesVatOre;
+  if (b.deductedAccontos.length === 0) {
+    return [
+      { label: vatLabel(netOre, fullVatOre), amountOre: fullVatOre, kind: "add" },
+      { label: `${feeCap} inkl utlägg (inkl moms)`, amountOre: b.sjalvriskGrossOre + b.clientExpensesGrossOre, kind: "add" },
+    ];
+  }
+  const rows: SettlementRow[] = [];
+  let restVatOre = fullVatOre;
+  for (const d of b.deductedAccontos) {
+    const { netOre: accNet, vatOre: accVat } = accontoSplit(d.amountOre);
+    restVatOre -= accVat;
+    const when = d.date ? ` (${svd(d.date)})` : "";
+    rows.push({ label: `Avgår aconto — faktura ${d.invoiceNumber}${when}, exkl moms`, amountOre: accNet, kind: "deduct" });
+  }
+  rows.push({ label: "Moms på återstående belopp", amountOre: restVatOre, kind: "add" });
+  return rows;
+}
+
 function buildClientView(b: SettlementBreakdown, isRattshjalp: boolean, feeTerm: string): SettlementView {
   const share = shareLabel(b.clientShareBips);
   const feeCap = feeTerm.charAt(0).toUpperCase() + feeTerm.slice(1);
@@ -812,10 +837,7 @@ function buildClientView(b: SettlementBreakdown, isRattshjalp: boolean, feeTerm:
   }
   // Samma moms-trappa för BÅDA metoderna (#935) — rättsskydd fick förr bara en enda
   // inkl-moms-rad, vilket gjorde klientfakturorna asymmetriska och svårlästa.
-  const clientVatOre = b.sjalvriskGrossOre - b.sjalvriskNetOre + b.clientExpensesVatOre;
-  rows.push({ label: vatLabel(b.sjalvriskNetOre + b.clientExpensesNetOre, clientVatOre), amountOre: clientVatOre, kind: "add" });
-  rows.push({ label: `${feeCap} inkl utlägg (inkl moms)`, amountOre: b.sjalvriskGrossOre + b.clientExpensesGrossOre, kind: "add" });
-  for (const d of b.deductedAccontos) rows.push({ label: `Avgår aconto — faktura ${d.invoiceNumber}${d.date ? ` (${svd(d.date)})` : ""}`, amountOre: d.amountOre, kind: "deduct" });
+  rows.push(...clientVatRows(b, feeCap));
   return { timeLines: b.clientArvodeLines.map(toViewLine), rows, totalLabel: "Att betala (inkl moms)", totalOre: b.clientPayableOre };
 }
 
@@ -866,6 +888,19 @@ function buildCreditView(clientView: SettlementView, creditNetOre: number): Sett
  *   - = 0 → FINAL 0 (exakt avräknad; ovanligt).
  * Utbrutet så settleCoverage-handlern håller sig ≤8 i komplexitet.
  */
+/**
+ * Kreditfakturans momsbelopp (#968), negativt som resten av krediten.
+ *
+ * INGEN `vatBreakdown` sätts: `buildPerRateRows` räknar brutto ur raderna och
+ * filtrerar bort icke-positiva belopp, så negativa rader skulle tappas. Krediten
+ * går därför via enkelrads-verifikatet, som hanterar tecknet via `amount < 0`.
+ * En per-sats-kreditering kräver att verifikatbyggaren först lär sig negativa
+ * rader — egen issue, inte en tyst halvmesyr här.
+ */
+function creditVatOre(clientLines: VatBreakdownLine[], deductionOre: number): number {
+  return -accontoCreditAmounts(clientLines, deductionOre).vatOre;
+}
+
 async function createClientSettlementInvoice(repos: Repositories, ctx: EmitCtx, orgId: OrganizationId, a: {
   matterId: MatterId; clientGrossOre: number; deductionOre: number;
   clientLines: VatBreakdownLine[]; clientView: SettlementView; method: PaymentMethod; invoiceDate?: Date | string; notes: string | null | undefined;
@@ -873,20 +908,25 @@ async function createClientSettlementInvoice(repos: Repositories, ctx: EmitCtx, 
   const clientNet = a.clientGrossOre - a.deductionOre; // kan vara negativt (överbetald)
   const isCredit = clientNet < 0;
   const feeTerm = a.method === "RATTSHJALP" ? "rättshjälpsavgift" : "självrisk";
-  const overpaidOre = -clientNet;
   const base = { matterId: a.matterId, amount: clientNet, ...(await invoiceNumbering(repos, orgId, "KLIENT")), invoiceDate: a.invoiceDate ? new Date(a.invoiceDate) : new Date() };
+  // #968 (modell A): acontona har redan bokfört sin intäkt och sin moms, så
+  // slutfakturan bär bara det som ÅTERSTÅR — annars bokförs acontot två gånger.
+  const rest = deductAcconto(a.clientLines, a.deductionOre);
   const payload = isCredit
     ? {
         ...base,
-        // Kredit-moms = 25 %-andelen av det överbetalda bruttot (arvode dominerar).
-        vatOre: -Math.round(overpaidOre - overpaidOre / 1.25),
+        // Krediteringen vänder exakt det som blev för mycket bokfört: acontonas
+        // intäkt och moms minus fakturans faktiska (#968). Förr räknades 25 % på
+        // mellanskillnaden rakt av, vilket blir fel så snart fakturan bär utlägg
+        // med andra satser — acontot är alltid 25 %.
+        vatOre: creditVatOre(a.clientLines, a.deductionOre),
         // #895: full spec (tidsspec + rättshjälpsavgift + avdragna aconton) → kredit-netto.
         settlementBreakdown: buildCreditView(a.clientView, clientNet),
         invoiceType: "CREDIT" as const, status: "SENT" as const,
         notes: `Rättshjälps-överfakturering: betalda aconton (${(a.deductionOre / 100).toLocaleString("sv-SE")} kr) översteg slutlig ${feeTerm} — mellanskillnaden krediteras klienten.`,
       }
     : {
-        ...base, vatOre: vatOreOf(a.clientLines), vatBreakdown: a.clientLines,
+        ...base, vatOre: vatOreOf(rest.lines), vatBreakdown: rest.lines,
         settlementBreakdown: a.clientView, invoiceType: "FINAL" as const, status: "DRAFT" as const, notes: a.notes,
       };
   const invoice = await repos.invoices.create(payload);
@@ -1188,9 +1228,12 @@ export const billingRunRouter = router({
         const deductedRuns = await fetchDeductedAccontoRuns(tx, input.matterId, input.deductedBillingRunIds);
         const deductionOre = deductedRuns.reduce((sum, r) => sum + (r.amountOre ?? 0), 0);
         const finalAmount = Math.max(0, grossValue - deductionOre);
+        // #968 (modell A): acontona har REDAN bokfört sin intäkt och sin moms.
+        // Slutfakturan bär bara resten — annars bokförs acontot två gånger.
+        const rest = deductAcconto(invoiceVatBreakdown(work), deductionOre);
         const invoice = await tx.invoices.create({
-          matterId: input.matterId, amount: finalAmount, vatOre: invoiceVatOre(work),
-          vatBreakdown: invoiceVatBreakdown(work),
+          matterId: input.matterId, amount: finalAmount, vatOre: vatOreOf(rest.lines),
+          vatBreakdown: rest.lines,
           invoiceType: "FINAL", status: "DRAFT",
           ...(await invoiceNumbering(tx, ctx.orgId, input.recipient)),
           ...invoiceMeta(input), notes: input.notes,

--- a/src/lib/shared/acconto-vat.ts
+++ b/src/lib/shared/acconto-vat.ts
@@ -1,0 +1,127 @@
+/**
+ * Aconto-avräkning mot slutfakturans momsuppdelning (#968).
+ *
+ * ## Problemet
+ *
+ * Ett aconto är i AVA en DELFAKTURERING av redan utfört arbete — beloppet räknas
+ * fram som `klientandel × upparbetat värde`. Acontofakturan bokför därför sin
+ * egen intäkt, sin egen moms och sin egen kundfordran när den skickas.
+ *
+ * Slutfakturan drog av acontobeloppen från `amount` men lämnade `vatBreakdown`
+ * orörd. Resultatet blev att acontot bokfördes TVÅ gånger — en gång på
+ * acontofakturan, en gång som del av slutfakturan. På demons F-2026-0039 gav det
+ * 1 910,20 kr för mycket utgående moms, 9 551,00 kr för mycket kundfordran och
+ * 7 640,80 kr för mycket intäkt.
+ *
+ * ## Modellen (modell A, beslutad)
+ *
+ * Acontot är en riktig faktura. Slutfakturan får därför bara bära det som ÅTERSTÅR:
+ * dess momsuppdelning minskas med exakt det acontona redan tagit, och `amount`,
+ * `vatOre` och verifikatet härleds ur samma reducerade rader. Summan över
+ * acontofakturorna + slutfakturan blir då precis ärendets faktiska intäkt och moms.
+ *
+ * ## Avräkningsordningen
+ *
+ * Acontot faktureras som rent arvode med 25 % moms, så det ska i första hand
+ * kvittas mot arvodesraden med samma sats. Ordningen är: arvode före utlägg,
+ * och inom varje grupp högsta momssats först. Ett aconto som överstiger
+ * arvodesraden spiller vidare — det måste minska något, och då ligger närmaste
+ * sats närmast till hands. Ordningen spelar roll: SIE-exporten bokför per sats på
+ * separata momskonton (#790), så fel val skulle förskjuta momsen mellan konton.
+ */
+
+import type { VatBreakdownLine } from "@/lib/shared/accounting/semantic-voucher";
+import { splitVat } from "@/lib/shared/vat";
+
+/** Momssatsen aconton faktureras med — rent arvode (#968). */
+const ACCONTO_VAT_RATE = 2500;
+
+export interface AccontoDeductionResult {
+  /** Raderna som ÅTERSTÅR att fakturera — slutfakturans `vatBreakdown`. */
+  lines: VatBreakdownLine[];
+  /** Netto som acontona redan fakturerat (och bokfört som intäkt). */
+  deductedNetOre: number;
+  /** Moms som acontona redan redovisat. */
+  deductedVatOre: number;
+  /** Brutto som INTE fick plats — acontona översteg fakturan → kreditering. */
+  overpaidGrossOre: number;
+}
+
+/** Netto/moms i ett acontobelopp (brutto, inkl 25 % moms). */
+export function accontoSplit(grossOre: number): { netOre: number; vatOre: number } {
+  const { exclVat } = splitVat({ amount: grossOre, vatRate: ACCONTO_VAT_RATE, vatIncluded: true });
+  return { netOre: exclVat, vatOre: grossOre - exclVat };
+}
+
+const grossOf = (l: VatBreakdownLine): number => l.netOre + l.vatOre;
+
+/**
+ * Index i den ordning raderna ska kvittas: arvode före utlägg, högsta momssats
+ * först. Returnerar index så att UTDATAN kan behålla radernas ursprungliga
+ * ordning (fakturan och verifikatet ska se likadana ut som förut).
+ */
+function deductionOrder(lines: readonly VatBreakdownLine[]): number[] {
+  return lines
+    .map((line, index) => ({ line, index }))
+    .sort((a, b) => (a.line.kind === b.line.kind
+      ? b.line.vatRate - a.line.vatRate
+      : (a.line.kind === "arvode" ? -1 : 1)))
+    .map((x) => x.index);
+}
+
+/** Rad med `takeGrossOre` bortdraget — momssatsen bevaras exakt. */
+function shrink(line: VatBreakdownLine, takeGrossOre: number): VatBreakdownLine {
+  const rest = grossOf(line) - takeGrossOre;
+  const netOre = Math.round((rest * 10_000) / (10_000 + line.vatRate));
+  return { ...line, netOre, vatOre: rest - netOre };
+}
+
+/**
+ * Dra av ett acontobelopp (BRUTTO) ur slutfakturans momsuppdelning.
+ *
+ * Rader som går till noll faller bort — de har inget kvar att fakturera och
+ * skulle bara bli tomma rader i verifikatet.
+ */
+export function deductAcconto(
+  lines: readonly VatBreakdownLine[],
+  deductionGrossOre: number,
+): AccontoDeductionResult {
+  const out = [...lines];
+  let remaining = Math.max(0, deductionGrossOre);
+
+  for (const i of deductionOrder(lines)) {
+    if (remaining <= 0) break;
+    const line = out[i];
+    if (!line) continue;
+    const take = Math.min(remaining, grossOf(line));
+    out[i] = shrink(line, take);
+    remaining -= take;
+  }
+
+  const kept = out.filter((l) => grossOf(l) > 0);
+  return {
+    lines: kept,
+    deductedNetOre: sumNet(lines) - sumNet(kept),
+    deductedVatOre: sumVat(lines) - sumVat(kept),
+    overpaidGrossOre: remaining,
+  };
+}
+
+const sumNet = (ls: readonly VatBreakdownLine[]): number => ls.reduce((s, l) => s + l.netOre, 0);
+const sumVat = (ls: readonly VatBreakdownLine[]): number => ls.reduce((s, l) => s + l.vatOre, 0);
+
+/**
+ * Kreditfakturans netto/moms när acontona ÖVERSTEG klientens slutliga andel.
+ *
+ * Krediteringen ska vända exakt det som blev för mycket bokfört: acontonas
+ * intäkt och moms minus fakturans faktiska. Att i stället räkna 25 % på
+ * mellanskillnaden (som förr) blir fel så snart fakturan bär utlägg med andra
+ * satser, eftersom acontot alltid är 25 %.
+ */
+export function accontoCreditAmounts(
+  lines: readonly VatBreakdownLine[],
+  deductionGrossOre: number,
+): { netOre: number; vatOre: number } {
+  const acconto = accontoSplit(deductionGrossOre);
+  return { netOre: acconto.netOre - sumNet(lines), vatOre: acconto.vatOre - sumVat(lines) };
+}

--- a/test/unit/lib/shared/acconto-vat.test.ts
+++ b/test/unit/lib/shared/acconto-vat.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Aconto-avräkning (#968, modell A).
+ *
+ * Testerna vaktar tre saker som drar åt olika håll:
+ *   • summan över acontofaktura + slutfaktura ska bli ärendets FAKTISKA moms
+ *     och intäkt — varken mer (dagens dubbelbokföring) eller mindre,
+ *   • momssatsen per rad får inte förskjutas (SIE bokför per sats, #790),
+ *   • netto + moms måste alltid vara exakt bruttot, även efter avrundning.
+ */
+import { describe, it, expect } from "vitest-compat";
+
+import { accontoCreditAmounts, accontoSplit, deductAcconto } from "@/lib/shared/acconto-vat";
+import type { VatBreakdownLine } from "@/lib/shared/accounting/semantic-voucher";
+
+const arvode = (netOre: number): VatBreakdownLine => ({ kind: "arvode", vatRate: 2500, netOre, vatOre: Math.round(netOre * 0.25) });
+const utlagg = (netOre: number, vatRate: number): VatBreakdownLine => ({ kind: "utlagg", vatRate, netOre, vatOre: Math.round((netOre * vatRate) / 10_000) });
+
+const gross = (ls: readonly VatBreakdownLine[]): number => ls.reduce((s, l) => s + l.netOre + l.vatOre, 0);
+
+/** Exakt uppsättningen från demons F-2026-0039 (öre) — fallet som fällde #968. */
+const F0039: VatBreakdownLine[] = [
+  { kind: "arvode", vatRate: 2500, netOre: 1_470_370, vatOre: 367_593 },
+  { kind: "utlagg", vatRate: 0, netOre: 18_000, vatOre: 0 },
+  { kind: "utlagg", vatRate: 600, netOre: 7_200, vatOre: 432 },
+  { kind: "utlagg", vatRate: 1200, netOre: 12_800, vatOre: 1_536 },
+  { kind: "utlagg", vatRate: 2500, netOre: 3_600, vatOre: 900 },
+];
+const F0039_ACCONTON = 955_100; // 6 299,00 + 3 252,00 kr
+
+describe("accontoSplit", () => {
+  it("delar ett acontobelopp i netto + 25 % moms", () => {
+    expect(accontoSplit(629_900)).toEqual({ netOre: 503_920, vatOre: 125_980 });
+  });
+
+  it("netto + moms är alltid exakt bruttot (avrundning får inte tappa ören)", () => {
+    for (const g of [1, 7, 99, 12_345, 629_900, 325_201]) {
+      const { netOre, vatOre } = accontoSplit(g);
+      expect(netOre + vatOre).toBe(g);
+    }
+  });
+});
+
+describe("deductAcconto", () => {
+  it("F-2026-0039: momsen blir den som ÅTERSTÅR, inte hela fakturans", () => {
+    // Kärnan i #968. Före fixen redovisade slutfakturan 3 704,61 kr moms trots
+    // att acontona redan redovisat 1 910,20 kr av den — 1 910,20 kr dubbelt.
+    const r = deductAcconto(F0039, F0039_ACCONTON);
+    expect(r.deductedVatOre).toBe(191_020);
+    expect(gross(r.lines)).toBe(gross(F0039) - F0039_ACCONTON);
+    expect(r.lines.reduce((s, l) => s + l.vatOre, 0)).toBe(370_461 - 191_020);
+    expect(r.overpaidGrossOre).toBe(0);
+  });
+
+  it("summan acontofaktura + slutfaktura = ärendets faktiska moms och intäkt", () => {
+    // Det är HELA poängen med modell A: ingen krona bokförs två gånger.
+    const acconto = accontoSplit(F0039_ACCONTON);
+    const r = deductAcconto(F0039, F0039_ACCONTON);
+    const restNet = r.lines.reduce((s, l) => s + l.netOre, 0);
+    const restVat = r.lines.reduce((s, l) => s + l.vatOre, 0);
+    expect(acconto.vatOre + restVat).toBe(370_461);
+    expect(acconto.netOre + restNet).toBe(1_511_970);
+  });
+
+  it("kvittar mot 25 %-ARVODET först — inte mot utläggen", () => {
+    // Acontot är rent arvode med 25 % moms. Att i stället nagga utläggsraderna
+    // skulle flytta moms mellan 2611/2621/2631 i SIE-exporten (#790).
+    const lines = [arvode(100_000), utlagg(50_000, 600)];
+    const r = deductAcconto(lines, 125_000); // hela arvodet brutto (100 000 + 25 000)
+    expect(r.lines).toEqual([utlagg(50_000, 600)]);
+    expect(r.deductedVatOre).toBe(25_000);
+  });
+
+  it("spiller vidare när acontot överstiger arvodet — högsta sats först", () => {
+    const lines = [arvode(10_000), utlagg(10_000, 600), utlagg(10_000, 2500)];
+    // 12 500 (arvodet) + 12 500 (25 %-utlägget) = 25 000 → bara 6 %-raden kvar.
+    const r = deductAcconto(lines, 25_000);
+    expect(r.lines).toEqual([utlagg(10_000, 600)]);
+  });
+
+  it("bevarar radernas URSPRUNGLIGA ordning i utdatan", () => {
+    // Avräkningsordningen är intern; fakturan och verifikatet ska se ut som förut.
+    const lines = [utlagg(10_000, 600), arvode(100_000), utlagg(10_000, 1200)];
+    const r = deductAcconto(lines, 12_500);
+    expect(r.lines.map((l) => [l.kind, l.vatRate])).toEqual([
+      ["utlagg", 600], ["arvode", 2500], ["utlagg", 1200],
+    ]);
+  });
+
+  it("varje rad behåller sin momssats efter avräkning", () => {
+    const r = deductAcconto(F0039, 500_000);
+    for (const l of r.lines) {
+      const expected = Math.round((l.netOre * l.vatRate) / 10_000);
+      expect(Math.abs(l.vatOre - expected)).toBeLessThanOrEqual(1); // ören
+    }
+  });
+
+  it("rader som går till noll faller bort — inga tomma verifikatrader", () => {
+    const lines = [arvode(10_000), utlagg(10_000, 0)];
+    const r = deductAcconto(lines, 12_500);
+    expect(r.lines).toEqual([utlagg(10_000, 0)]);
+  });
+
+  it("aconto som överstiger hela fakturan → allt kvittat + överskottet rapporterat", () => {
+    const lines = [arvode(10_000)]; // brutto 12 500
+    const r = deductAcconto(lines, 20_000);
+    expect(r.lines).toEqual([]);
+    expect(r.deductedNetOre).toBe(10_000);
+    expect(r.deductedVatOre).toBe(2_500);
+    expect(r.overpaidGrossOre).toBe(7_500);
+  });
+
+  it("inget aconto → raderna orörda (ingen regression utan aconton)", () => {
+    const r = deductAcconto(F0039, 0);
+    expect(r.lines).toEqual(F0039);
+    expect(r.deductedVatOre).toBe(0);
+  });
+
+  it("negativt avdrag behandlas som noll i stället för att blåsa upp fakturan", () => {
+    expect(deductAcconto(F0039, -1000).lines).toEqual(F0039);
+  });
+
+  it("momsfri rad (0 %) kvittas utan att få moms påhängd", () => {
+    const r = deductAcconto([utlagg(10_000, 0)], 4_000);
+    expect(r.lines).toEqual([{ kind: "utlagg", vatRate: 0, netOre: 6_000, vatOre: 0 }]);
+  });
+});
+
+describe("accontoCreditAmounts", () => {
+  it("krediterar exakt det som blev för mycket bokfört", () => {
+    const lines = [arvode(10_000)]; // netto 10 000, moms 2 500
+    const c = accontoCreditAmounts(lines, 20_000); // aconto: netto 16 000, moms 4 000
+    expect(c).toEqual({ netOre: 6_000, vatOre: 1_500 });
+    expect(c.netOre + c.vatOre).toBe(20_000 - 12_500); // = överbetalningen
+  });
+
+  it("räknar rätt även när fakturan bär andra momssatser än acontots 25 %", () => {
+    // Förr räknades krediteringens moms som 25 % av mellanskillnaden rakt av.
+    // Med ett momsfritt utlägg på fakturan blir det fel: acontot bar 25 % moms
+    // på HELA sitt belopp, fakturan bär mindre.
+    const lines = [utlagg(10_000, 0)]; // brutto 10 000, moms 0
+    const c = accontoCreditAmounts(lines, 20_000); // aconto: netto 16 000, moms 4 000
+    expect(c).toEqual({ netOre: 6_000, vatOre: 4_000 });
+    expect(c.netOre + c.vatOre).toBe(20_000 - 10_000);
+    // Den gamla formeln (25 % av 10 000) hade gett 2 000 kr moms — 2 000 för lite.
+  });
+});

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -634,6 +634,32 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
     expect(res.payerRun.recipient).toBe("DOMSTOL"); // slutfaktura till domstol
   });
 
+  it("aconto + slutfaktura bokför moms och intäkt EN gång tillsammans (#968)", async () => {
+    // Modell A: acontot är en delfakturering av utfört arbete och bokför sin egen
+    // intäkt + moms när det skickas. Slutfakturan får därför bara bära resten.
+    //
+    // Före fixen drogs acontot från slutfakturans `amount` men inte från dess
+    // `vatBreakdown`, så acontots moms och intäkt bokfördes två gånger — och
+    // eftersom verifikatet härleder bruttot ur raderna (semantic-voucher) drog
+    // det med sig kundfordran också.
+    const { caller: c } = caller({ paymentMethod: "RATTSHJALP", clientShareBips: 2000, taxaHasFTax: true }, 999999, 180);
+    const ac = await c.billingRun.createAcconto({ matterId: "m-1", clientShareBips: 2000, amountOre: 50_000 });
+    const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "DOMSTOL" });
+
+    const accontoInvoice = ac.invoice;
+    const sumVat = (accontoInvoice.vatOre ?? 0) + (res.clientInvoice.vatOre ?? 0);
+    const sumGross = accontoInvoice.amount + res.clientInvoice.amount;
+    // Klientens faktiska andel: självrisk 81 300 brutto = 65 040 netto + 16 260 moms.
+    expect(sumGross).toBe(81_300);
+    expect(sumVat).toBe(16_260);
+
+    // …och slutfakturans egna rader måste summera till dess belopp, annars
+    // spricker verifikatet (brutto = Σnetto + Σmoms ur samma breakdown).
+    const lines = res.clientInvoice.vatBreakdown ?? [];
+    expect(lines.reduce((s, l) => s + l.netOre + l.vatOre, 0)).toBe(res.clientInvoice.amount);
+    expect(lines.reduce((s, l) => s + l.vatOre, 0)).toBe(res.clientInvoice.vatOre);
+  });
+
   it("returnerar itemiserad nedbrytning som reconcilar mot båda beloppen (#858)", async () => {
     const { caller: c } = caller({ paymentMethod: "RATTSHJALP", clientShareBips: 2000, taxaHasFTax: true }, 999999, 180);
     await c.billingRun.createAcconto({ matterId: "m-1", clientShareBips: 2000, amountOre: 50000 });
@@ -666,8 +692,20 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
     expect(cv.totalOre).toBe(b.clientPayableOre);
     expect(cv.timeLines).toHaveLength(1);
     expect(cv.timeLines[0]!.amountOre).toBe(325_200);             // tidsspec-tabellen på klientfakturan
-    expect(cv.rows.find((r) => r.label === "Moms 25 %")?.amountOre).toBe(16_260);
-    expect(cv.rows.some((r) => r.kind === "deduct" && r.label.startsWith("Avgår aconto"))).toBe(true);
+    // #968 (modell A): acontot (50 000 brutto = 40 000 netto + 10 000 moms) har
+    // REDAN fakturerat sin egen moms. Klientfakturan visar därför bara momsen på
+    // det som återstår — 16 260 − 10 000 = 6 260 — och acontot dras av NETTO,
+    // före momsraden. Förr stod hela 16 260 här, vilket var momsen på ett belopp
+    // klienten aldrig skulle betala i sin helhet.
+    expect(cv.rows.find((r) => r.label === "Moms 25 %")).toBeUndefined();
+    expect(cv.rows.find((r) => r.label === "Moms på återstående belopp")?.amountOre).toBe(6_260);
+    const accontoRow = cv.rows.find((r) => r.kind === "deduct" && r.label.startsWith("Avgår aconto"));
+    expect(accontoRow?.amountOre).toBe(40_000);          // netto, inte 50 000 brutto
+    expect(accontoRow?.label).toContain("exkl moms");
+    // Fakturans egen moms måste stämma med dokumentet — det var att de INTE gjorde
+    // det som gjorde felet osynligt i #968.
+    expect(res.clientInvoice.vatOre).toBe(6_260);
+    expect(res.clientInvoice.amount).toBe(31_300);       // 25 040 netto + 6 260 moms
     const pv = res.payerInvoice.settlementBreakdown!;
     expect(pv.totalOre).toBe(b.payerPayableOre);
     // #876 — domstolsfakturan har SAMMA upplägg som klienten: tidsspec + andel-trappa.


### PR DESCRIPTION
## Vad & varför

Ett aconto är i AVA en **delfakturering av redan utfört arbete** — beloppet är `klientandel × upparbetat värde`. Acontofakturan bokför därför sin egen intäkt, sin egen moms och sin egen kundfordran när den skickas.

Slutfakturan drog av acontobeloppen från `amount` men lämnade `vatBreakdown` orörd. Eftersom verifikatet härleder bruttot ur **raderna** (`semantic-voucher`: `brutto = Σnetto + Σmoms`) bokfördes hela acontot en gång till. På demons **F-2026-0039**:

| | Före | Efter | Fel |
|---|---:|---:|---:|
| Kundfordran | 28 375,31 | **18 824,31** | 9 551,00 |
| Utgående moms | 5 614,81 | **3 704,61** | 1 910,20 |
| Intäkt | 22 760,50 | **15 119,70** | 7 640,80 |

**Modell A** (beslutad av @ulrik-s): acontot är en riktig faktura, slutfakturan bär bara det som återstår.

Stänger #968

## Typ

- [x] `fix` — buggfix

## Ändringen

Ny ren modul **`src/lib/shared/acconto-vat.ts`** drar av acontobeloppet ur momsuppdelningen: **arvode före utlägg, högsta sats först**, eftersom acontot faktureras som rent arvode med 25 % moms. Ordningen är inte kosmetisk — SIE bokför per sats på separata momskonton (#790), så fel val förskjuter moms mellan 2611/2621/2631.

Åtgärdat på **båda** ställena med samma fel: `settle` och `settleCoverage` via `createClientSettlementInvoice`. Den första hittade jag först när jag letade efter den andra.

**Kreditgrenen** räknade momsen som 25 % av mellanskillnaden rakt av. Det blir fel så snart fakturan bär utlägg med andra satser — acontot är alltid 25 %. `accontoCreditAmounts` vänder i stället exakt det som blev för mycket bokfört.

**Dokumentet stämde inte heller med fakturan.** Acontot drogs av brutto *efter* momsraden, så fakturan visade momsen på hela självrisken (3 704,61 kr på ett belopp om 9 273,31 kr). Avdragen ligger nu netto *före* momsraden, som visar momsen på det återstående. Utan aconton är radordningen oförändrad.

## Verifierat mot demons faktiska data

```
SLUTFAKTURA F-2026-0039
  amount   : 9 273,31      vatOre : 1 794,41
  Σ rader  : 9 273,31      (netto 7 478,90 + moms 1 794,41)
  balans   : amount == Σ rader -> True

BOKFÖRT TOTALT (aconton + slutfaktura)
  kundfordran: 18 824,31   moms: 3 704,61   intäkt: 15 119,70
  facit      : 18 824,31         3 704,61           15 119,70
```

Dokumentets momsrader (1 044,41 + 750,00 för prutningsomfördelningen) = fakturans `vatOre` (1 794,41). De två säger nu samma sak — att de inte gjorde det var vad som dolde felet.

## Verifierat lokalt (speglar CI)

- [x] `typecheck`, `lint` (`--max-warnings 0`), `lint:complexity-strict`, `knip`, `deps:check`, `jscpd` — rena
- [x] `bun run build:demo` + `bun run size` — 1169,7 KB av 3400 KB
- [x] `test/unit/server` — **1120 pass / 0 fail** (137 filer)
- [x] `test/integration` — 63 pass / 0 fail
- [x] `test/unit/lib` — 1029 pass / 43 fail, **identiskt före och efter** (känd mock-läckage vid katalogkörning, #92)
- [x] 15 nya enhetstester i `acconto-vat.test.ts` + 2 nya i `billingRun.test.ts`
- [x] Commits följer Conventional Commits

## Kvalitetsgrindar

- [x] Inga grindar lösgjorda
- [x] `src/lib/shared/schemas/` orörd; ingen migrering behövs — felet låg i beräkningen, inte i lagringen

## Övrigt

**En medveten begränsning, inte en glömska:** kreditfakturan sätter ingen `vatBreakdown`. `buildPerRateRows` filtrerar bort icke-positiva belopp och skulle tappa negativa rader, så krediten går via enkelrads-verifikatet som hanterar tecknet via `amount < 0`. Beloppet blir rätt; per-sats-kreditering kräver att verifikatbyggaren först lär sig negativa rader. Det är kommenterat i koden och förtjänar en egen issue snarare än en tyst halvmesyr här.

**Ett befintligt test ändrades:** `billingRun.test.ts` hävdade `Moms 25 % = 16 260` på en klientfaktura med ett aconto på 50 000. Det var precis buggen — momsen på ett belopp klienten aldrig skulle betala i sin helhet. Testet hävdar nu 6 260 (16 260 − acontots 10 000) och kontrollerar dessutom att fakturans `vatOre` stämmer med dokumentet.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_