### PR TITLE
fix(billing): 25 % moms på utlägg gäller alla betalare, inte bara domstol

### DIFF
--- a/src/app/matters/[id]/_expense-section.tsx
+++ b/src/app/matters/[id]/_expense-section.tsx
@@ -6,6 +6,7 @@ import { Modal } from "@/components/ui/modal";
 import { EntityLink } from "@/lib/client/demo/entity-link";
 import { trpc } from "@/lib/client/trpc";
 import { formatCurrency } from "@/lib/client/utils";
+import { chargedVatOre, expenseNetOre } from "@/lib/shared/expense-vat";
 import type { ExpenseId, InvoiceId, MatterId } from "@/lib/shared/schemas/ids";
 import { splitVat, VAT_RATES, VAT_RATE_LABELS, type VatRate } from "@/lib/shared/vat";
 
@@ -20,7 +21,10 @@ interface ExpenseForm {
   amount: number;
   description: string;
   billable: boolean;
+  /** Satsen BYRÅN betalade — styr avräkningen, inte vad klienten debiteras (#975). */
   vatRate: VatRate;
+  /** Äkta utlägg: faktura ställd till klienten → vidarefaktureras utan moms. */
+  passThrough: boolean;
 }
 
 interface Expense {
@@ -32,6 +36,7 @@ interface Expense {
   user?: { name: string };
   vatRate?: number;
   vatIncluded?: boolean;
+  passThrough?: boolean;
   invoiceId?: InvoiceId | null;
   invoice?: { id: InvoiceId; invoiceNumber?: string | null } | null;
 }
@@ -43,6 +48,7 @@ function initialForm(): ExpenseForm {
     description: "",
     billable: true,
     vatRate: 2500,
+    passThrough: false,
   };
 }
 
@@ -55,6 +61,7 @@ function toForm(e: Expense): ExpenseForm {
     description: e.description,
     billable: e.billable,
     vatRate: (e.vatRate ?? 2500) as VatRate,
+    passThrough: e.passThrough ?? false,
   };
 }
 
@@ -65,6 +72,7 @@ function payloadOf(f: ExpenseForm): {
   billable: boolean;
   vatRate: VatRate;
   vatIncluded: boolean;
+  passThrough: boolean;
 } {
   // Advokaten matar in exkl. moms; utlägg lagras netto (#782) och AVA lägger
   // på momsen vid fakturering.
@@ -75,22 +83,29 @@ function payloadOf(f: ExpenseForm): {
     billable: f.billable,
     vatRate: f.vatRate,
     vatIncluded: false,
+    passThrough: f.passThrough,
   };
 }
 
 function computeTotals(expenses: Expense[]): { exclVat: number; vat: number; inclVat: number } {
   return expenses.reduce(
     (acc, e) => {
-      const r = splitVat({ amount: e.amount, vatRate: e.vatRate ?? 2500, vatIncluded: e.vatIncluded ?? true });
+      const r = vatOf(e);
       return { exclVat: acc.exclVat + r.exclVat, vat: acc.vat + r.vat, inclVat: acc.inclVat + r.inclVat };
     },
     { exclVat: 0, vat: 0, inclVat: 0 },
   );
 }
 
- 
-function vatOf(e: Expense) {
-  return splitVat({ amount: e.amount, vatRate: e.vatRate ?? 2500, vatIncluded: e.vatIncluded ?? true });
+/**
+ * Vad utlägget DEBITERAS med (#975) — inte vad byrån betalade. Listan visade förr
+ * byråns egen sats, vilket gjorde att summan i tabellen inte gick ihop med
+ * fakturan. Äkta utlägg vidarefaktureras utan moms.
+ */
+function vatOf(e: Expense): { exclVat: number; vat: number; inclVat: number } {
+  const exclVat = expenseNetOre({ amount: e.amount, vatRate: e.vatRate ?? 2500, vatIncluded: e.vatIncluded ?? true, passThrough: e.passThrough ?? false });
+  const vat = e.passThrough ? 0 : chargedVatOre(exclVat);
+  return { exclVat, vat, inclVat: exclVat + vat };
 }
 function invoiceLabel(e: Expense): string {
   return e.invoice?.invoiceNumber ?? (e.invoiceId ? "(faktura)" : "Ej fakturerad");
@@ -275,10 +290,23 @@ function ExpenseForm({ form, setForm, submitLabel, isPending, isTaxeArende, onSu
           {VAT_RATES.map((r) => <option key={r} value={r}>Moms: {VAT_RATE_LABELS[r]}</option>)}
         </select>
         <p className="mt-1 text-[11px] text-gray-400">
-          Ange beloppet exkl. moms — AVA lägger på momsen. Default 25 %; välj 0 % för momsfritt (t.ex. domstolsavgift).
+          Satsen <strong>du betalade</strong> — den räknas av innan utlägget debiteras vidare
+          med 25 % (NJA 2005 s. 606). Ange beloppet exkl. moms.
         </p>
       </div>
-      <VatPreview amount={form.amount} vatRate={form.vatRate} />
+      <VatPreview amount={form.amount} vatRate={form.vatRate} passThrough={form.passThrough} />
+      <label className="flex items-start gap-2 text-sm">
+        <input type="checkbox" checked={form.passThrough} className="mt-0.5"
+          onChange={(e) => setForm({ ...form, passThrough: e.target.checked })} />
+        <span>
+          Äkta utlägg
+          <span className="block text-[11px] text-gray-400">
+            Fakturan är ställd till klienten och du har bara förmedlat betalningen.
+            Vidarefaktureras då utan moms. Annars är utlägget ett kostnadselement i
+            uppdraget och bär 25 %.
+          </span>
+        </span>
+      </label>
       <label className="flex items-center gap-2 text-sm">
         <input type="checkbox" checked={form.billable}
           onChange={(e) => setForm({ ...form, billable: e.target.checked })} />
@@ -298,13 +326,19 @@ function ExpenseForm({ form, setForm, submitLabel, isPending, isTaxeArende, onSu
   );
 }
 
-function VatPreview({ amount, vatRate }: { amount: number; vatRate: number }) {
+/**
+ * Vad KLIENTEN kommer att debiteras (#975) — inte vad byrån betalade. Ett utlägg
+ * med 6 % ingående moms debiteras vidare med 25 % på nettot, så förhandsvisningen
+ * måste visa den satsen; annars ser juristen ett belopp som inte hamnar på fakturan.
+ */
+function VatPreview({ amount, vatRate, passThrough }: { amount: number; vatRate: number; passThrough: boolean }) {
   if (!amount) return <span className="text-xs text-gray-400">Förhandsvisning</span>;
-  // Inmatat belopp är exkl. moms → räkna fram moms + inkl.
-  const r = splitVat({ amount: Math.round(amount * 100), vatRate, vatIncluded: false });
+  const netOre = expenseNetOre({ amount: Math.round(amount * 100), vatRate, vatIncluded: false, passThrough });
+  const vatOre = passThrough ? 0 : chargedVatOre(netOre);
   return (
     <span className="text-xs text-gray-600 font-mono">
-      Exkl: {formatCurrency(r.exclVat)} · moms: {formatCurrency(r.vat)} · inkl: {formatCurrency(r.inclVat)}
+      Debiteras: {formatCurrency(netOre)} · moms {passThrough ? "0 %" : "25 %"}: {formatCurrency(vatOre)}
+      {" · inkl: "}{formatCurrency(netOre + vatOre)}
     </span>
   );
 }

--- a/src/lib/client/kostnadsrakning/faktura-template.ts
+++ b/src/lib/client/kostnadsrakning/faktura-template.ts
@@ -273,13 +273,18 @@ function summarySection(a: FakturaTemplateArgs, spec: InvoiceSpecification | nul
     return { summary: [{ label, rateLabel: "", hours: "", amount: fc(a.invoice.amount) }], summaryTotal: fc(a.invoice.amount) };
   }
   const summary = arvodeRateRows(spec, fc);
-  const hasExpenses = spec.expensesNetOre > 0 || spec.expensesVatOre > 0;
-  // Ordning (#925): momsfritt utlägg → momsraden (total moms) → utlägg inkl moms
+  // Ordning (#925): utlägg exkl moms → momsraden (total moms) → utlägg inkl moms
   // → summa (allt inkl moms). Momsraden är fakturans hela moms (arvode + utlägg),
   // så arvode-raderna (exkl moms) + utlägg exkl + moms = summan.
-  if (hasExpenses) summary.push({ label: "Utlägg exkl moms", rateLabel: "", hours: "", amount: fc(spec.expensesNetOre) });
+  //
+  // Äkta utlägg (#975) redovisas som EGEN rad: de är vidarefakturerade utan moms
+  // och ingår därför inte i momsunderlaget. Klienten ska kunna se skillnaden.
+  const passThroughOre = spec.expenseLines.filter((l) => l.passThrough).reduce((s, l) => s + l.grossOre, 0);
+  const chargedNetOre = spec.expensesNetOre - passThroughOre;
+  if (chargedNetOre > 0) summary.push({ label: "Utlägg exkl moms", rateLabel: "", hours: "", amount: fc(chargedNetOre) });
   summary.push({ label: "Moms", rateLabel: "", hours: "", amount: fc(spec.arvodeVatOre + spec.expensesVatOre) });
-  if (hasExpenses) summary.push({ label: "Utlägg inkl moms", rateLabel: "", hours: "", amount: fc(spec.expensesNetOre + spec.expensesVatOre) });
+  if (chargedNetOre > 0) summary.push({ label: "Utlägg inkl moms", rateLabel: "", hours: "", amount: fc(chargedNetOre + spec.expensesVatOre) });
+  if (passThroughOre > 0) summary.push({ label: "Äkta utlägg (utan moms)", rateLabel: "", hours: "", amount: fc(passThroughOre) });
   const summaOre = spec.arvodeNetOre + spec.arvodeVatOre + spec.expensesNetOre + spec.expensesVatOre;
   return { summary, summaryTotal: fc(summaOre) };
 }

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -200,9 +200,13 @@ export const expenses = pgTable("expenses", {
   description: text("description").notNull(),
   billable: boolDefault("billable", true),
   invoiceId: uuid("invoice_id").$type<InvoiceId>(),
+  // Satsen BYRÅN betalade — styr hur mycket ingående moms som räknas av innan
+  // utlägget debiteras vidare med 25 % (#975).
   vatRate: integer("vat_rate").notNull().default(2500),
   // Utlägg lagras netto (exkl moms) — AVA lägger på momsen (#782).
   vatIncluded: boolDefault("vat_included", false),
+  // Äkta utlägg (#975): faktura ställd till klienten → vidarefaktureras utan moms.
+  passThrough: boolDefault("pass_through", false),
   kind: text("kind").notNull().default("EXPENSE").$type<ExpenseKind>(),
   frozenAt: timestamp("frozen_at", { withTimezone: true }),
   frozenByBillingRunId: uuid("frozen_by_billing_run_id").$type<BillingRunId>(),

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -22,6 +22,7 @@ import { assertBillingTransition, type BillingActionType } from "@/lib/shared/bi
 import { proposedAccontoOre } from "@/lib/shared/billing-proposal";
 import { TIMKOSTNADSNORM_FTAX_ORE_PER_H, coverageEntryRateOre } from "@/lib/shared/brottmalstaxa";
 import { computeCoverageSplit, partitionRattsskyddMinutes, type CoverageSplit, type RattsskyddClientParts } from "@/lib/shared/coverage-billing";
+import { chargedExpenseLines } from "@/lib/shared/expense-vat";
 import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
 import {
   buildInvoiceSpecification,
@@ -230,20 +231,17 @@ function arvodeNetOre(work: UnfrozenWork): number {
     .reduce((sum, t) => sum + timeEntryValueOre(t.minutes, t.hourlyRate), 0);
 }
 
-/** Ett utläggs moms-split (#782). Utlägg lagras netto (vatIncluded=false); äldre
- *  brutto-rader (vatIncluded=true) hanteras via flaggan så bruttot bevaras. */
-function expenseSplit(e: { amount: number; vatRate?: number | null; vatIncluded?: boolean | null }) {
-  return splitVat({ amount: e.amount, vatRate: e.vatRate ?? DEFAULT_VAT_RATE, vatIncluded: e.vatIncluded ?? false });
-}
 
 /** Debiterbara utlägg, netto (exkl. moms). */
 function expenseNetOre(work: UnfrozenWork): number {
-  return work.expenses.filter((e) => e.billable).reduce((sum, e) => sum + expenseSplit(e).exclVat, 0);
+  return netOreOf(expenseBreakdownLines(work));
 }
 
-/** Debiterbara utlägg, brutto (inkl. moms) — det klienten/domstolen betalar. */
+/** Debiterbara utlägg, brutto — det klienten/domstolen betalar. Härleds ur de
+ *  DEBITERADE raderna (25 % enligt NJA 2005 s. 606, #975), inte ur de satser
+ *  byrån själv betalade. */
 function expenseGrossOre(work: UnfrozenWork): number {
-  return work.expenses.filter((e) => e.billable).reduce((sum, e) => sum + expenseSplit(e).inclVat, 0);
+  return grossOreOf(expenseBreakdownLines(work));
 }
 
 /** Nettovärde på arbetet: arvode (exkl moms) + utlägg (exkl moms). Bas för
@@ -310,16 +308,10 @@ function arvodeLine(arvodeNet: number): VatBreakdownLine | null {
   return { kind: "arvode", vatRate: DEFAULT_VAT_RATE, netOre: arvodeNet, vatOre: arvodeInclVatOre(arvodeNet) - arvodeNet };
 }
 
-/** Utläggens moms-uppdelning, en rad per förekommande momssats. */
+/** Utläggens moms-uppdelning: en 25 %-rad (kostnadselement) + en 0 %-rad (äkta
+ *  utlägg), enligt NJA 2005 s. 606 (#975). Gäller ALLA betalare. */
 function expenseBreakdownLines(work: UnfrozenWork): VatBreakdownLine[] {
-  const byRate = new Map<number, { netOre: number; vatOre: number }>();
-  for (const e of work.expenses.filter((x) => x.billable)) {
-    const rate = e.vatRate ?? DEFAULT_VAT_RATE;
-    const s = expenseSplit(e);
-    const acc = byRate.get(rate) ?? { netOre: 0, vatOre: 0 };
-    byRate.set(rate, { netOre: acc.netOre + s.exclVat, vatOre: acc.vatOre + s.vat });
-  }
-  return [...byRate].map(([vatRate, v]) => ({ kind: "utlagg" as const, vatRate, netOre: v.netOre, vatOre: v.vatOre }));
+  return chargedExpenseLines(work.expenses.filter((x) => x.billable));
 }
 
 /** Fakturans moms-uppdelning per sats (#790): en arvode-rad (25 %) + en utläggs-
@@ -385,19 +377,21 @@ function apportionExpenseLines(lines: VatBreakdownLine[], split: CoverageSplit):
 /** Faktura-rader (moms-breakdown) för klient- resp. betalar-fakturan ur en
  *  prutnings-/rättshjälpsavgifts-uppdelning (#801). Både arvode OCH utlägg delas
  *  per samma klient/betalar-andel (#878). */
-function coverageInvoiceLines(split: CoverageSplit, expenseLines: VatBreakdownLine[], courtPayer: boolean): {
+function coverageInvoiceLines(split: CoverageSplit, expenseLines: VatBreakdownLine[]): {
   clientLines: VatBreakdownLine[]; payerLines: VatBreakdownLine[];
   clientExpenseLines: VatBreakdownLine[]; payerExpenseLines: VatBreakdownLine[];
 } {
   const clientArvode = arvodeLine(split.clientOre);
   const payerArvode = arvodeLine(split.payerOre);
+  // Raderna bär redan de DEBITERADE satserna (#975) — 25 % på kostnadselement,
+  // 0 % på äkta utlägg — så andelarna ärver dem. Förr räknades betalarens andel
+  // om till 25 % bara när betalaren var domstol (#945); regeln följer biträdets
+  // omsättning, inte mottagaren, så det specialfallet är borta.
   const exp = apportionExpenseLines(expenseLines, split);
-  // Betalaren är domstolen → dess utläggsandel debiteras 25 % oavsett ursprungssats (#945).
-  const payerExpenseLines = courtPayer ? courtExpenseLines(exp.payerLines) : exp.payerLines;
   return {
     clientLines: [...(clientArvode ? [clientArvode] : []), ...exp.clientLines],
-    payerLines: [...(payerArvode ? [payerArvode] : []), ...payerExpenseLines],
-    clientExpenseLines: exp.clientLines, payerExpenseLines,
+    payerLines: [...(payerArvode ? [payerArvode] : []), ...exp.payerLines],
+    clientExpenseLines: exp.clientLines, payerExpenseLines: exp.payerLines,
   };
 }
 
@@ -451,33 +445,15 @@ function resolveAward(method: PaymentMethod, totalArvodeNet: number, work: Unfro
   };
 }
 
-/** Betalare som är domstol/rättshjälpsmyndighet (#945) — utlägg debiteras 25 %. */
-function isCourtRecipient(recipient: BillingRunRecipient): boolean {
-  return recipient === "DOMSTOL" || recipient === "RATTSHJALPSMYNDIGHET";
-}
-
 /** Moms (öre) på ett nettobelopp vid standardsatsen. */
 function vatOnNet(netOre: number): number {
   return Math.round((netOre * DEFAULT_VAT_RATE) / 10000);
 }
 
-/**
- * Utlägg mot DOMSTOL (#945): ett vidarefakturerat utlägg ingår i byråns egen
- * skattepliktiga omsättning, så domstolen debiteras 25 % moms på utläggens NETTO
- * oavsett vilken sats byrån själv betalade (domstolsavgift 0 %, tåg/taxi 6 %,
- * restaurang 12 %). Alla utlägg kollapsar därför till EN 25 %-rad.
- * Klientens och försäkringens fakturor behåller utläggens riktiga satser.
- */
-function courtExpenseLines(lines: VatBreakdownLine[]): VatBreakdownLine[] {
-  const netOre = netOreOf(lines);
-  if (netOre === 0) return [];
-  return [{ kind: "utlagg", vatRate: DEFAULT_VAT_RATE, netOre, vatOre: vatOnNet(netOre) }];
-}
-
 /** Kostnadsräkningens yrkade brutto — den går ALLTID till domstol, så utläggen
  *  värderas med 25 % moms (#945). `arvodeNet` skiljer sig per betalningssätt. */
 function krGrossOre(work: UnfrozenWork, arvodeNet: number): number {
-  return arvodeInclVatOre(arvodeNet) + grossOreOf(courtExpenseLines(expenseBreakdownLines(work)));
+  return arvodeInclVatOre(arvodeNet) + grossOreOf(expenseBreakdownLines(work));
 }
 
 /** Bygg ett itemiserat fakturaförslag ur ofrysta tids-/utläggsrader (#397). */
@@ -542,11 +518,18 @@ function specLineRateOre(
 }
 
 function specExpenseLines(
-  expenses: ReadonlyArray<{ date: Date | string; description: string; amount: number; billable: boolean; vatRate?: number | null; vatIncluded?: boolean | null }>,
+  expenses: ReadonlyArray<{ date: Date | string; description: string; amount: number; billable: boolean; vatRate?: number | null; vatIncluded?: boolean | null; passThrough?: boolean | null }>,
 ): SpecExpenseLine[] {
+  // Bruttot är det DEBITERADE (25 % enligt NJA 2005 s. 606, #975), inte satsen
+  // byrån betalade — annars stämmer inte specifikationen med fakturabeloppet.
   return expenses.filter((e) => e.billable).map((e) => {
-    const s = expenseSplit(e);
-    return { date: e.date, description: e.description, netOre: s.exclVat, grossOre: s.exclVat + s.vat };
+    const [line] = chargedExpenseLines([e]);
+    const netOre = line?.netOre ?? 0;
+    return {
+      date: e.date, description: e.description,
+      netOre, grossOre: netOre + (line?.vatOre ?? 0),
+      passThrough: e.passThrough === true,
+    };
   });
 }
 
@@ -1465,10 +1448,8 @@ export const billingRunRouter = router({
           insurerPrutningOre: input.insurerPrutningOre ?? null,
           ...rattsskyddCoverage(matter, work.timeEntries, settleDate),
         });
-        // #945: går betalarfakturan till domstol debiteras utläggen 25 % oavsett sats.
-        const courtPayer = isCourtRecipient(input.payerRecipient);
         const { clientLines, payerLines, clientExpenseLines, payerExpenseLines } =
-          coverageInvoiceLines(split, expenseLines, courtPayer);
+          coverageInvoiceLines(split, expenseLines);
 
         // Klient: självrisk (+ ev. prutning), moms 25 %, minus tidigare aconton.
         // Auto-dra av ALLA skickade klient-aconton (#856): de har redan betalats,

--- a/src/lib/server/routers/expense.ts
+++ b/src/lib/server/routers/expense.ts
@@ -42,10 +42,13 @@ export const expenseRouter = router({
         amount: z.number().min(1),
         description: z.string().min(1),
         billable: z.boolean().default(true),
-        /** Moms-sats i basis points (0/600/1200/2500). Default 25 %. */
+        /** Satsen BYRÅN betalade, i basis points (0/600/1200/2500). Default 25 %.
+         *  Räknas av innan utlägget debiteras vidare med 25 % (#975). */
         vatRate: z.number().int().nonnegative().max(10000).default(2500),
         /** True om `amount` är inkl moms. Default false — utlägg lagras netto (#782). */
         vatIncluded: z.boolean().default(false),
+        /** Äkta utlägg — faktura ställd till klienten → utan moms (#975). */
+        passThrough: z.boolean().default(false),
         // Valfria setup-fält (demo-generator/fixtures, ADR 0003).
         id: expenseIdSchema.optional(),
         userId: userIdSchema.optional(),
@@ -64,6 +67,7 @@ export const expenseRouter = router({
         billable: input.billable,
         vatRate: input.vatRate,
         vatIncluded: input.vatIncluded,
+        passThrough: input.passThrough,
         invoiceId: input.invoiceId ?? null,
         ...(input.createdAt ? { createdAt: new Date(input.createdAt) } : {}),
       }) satisfies Partial<Expense>);
@@ -79,6 +83,7 @@ export const expenseRouter = router({
         billable: z.boolean().optional(),
         vatRate: z.number().int().nonnegative().max(10000).optional(),
         vatIncluded: z.boolean().optional(),
+        passThrough: z.boolean().optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -86,13 +91,14 @@ export const expenseRouter = router({
       // `list`) INNAN update. NOT_FOUND vid mismatch — läcker inte existens.
       const owned = await ctx.repos.expenses.getByIdInOrg(input.id, ctx.orgId);
       if (!owned) throw new TRPCError({ code: "NOT_FOUND" });
-      const { id, date, amount, description, billable, vatRate, vatIncluded } = input;
+      const { id, date, amount, description, billable, vatRate, vatIncluded, passThrough } = input;
       return ctx.repos.expenses.update(id, omitUndefined({
         amount,
         description,
         billable,
         vatRate,
         vatIncluded,
+        passThrough,
         ...(date ? { date: new Date(date) } : {}),
       }) satisfies Partial<Expense>);
     }),

--- a/src/lib/shared/expense-vat.ts
+++ b/src/lib/shared/expense-vat.ts
@@ -1,0 +1,97 @@
+/**
+ * Momsen på utlägg som biträdet debiterar vidare (#975).
+ *
+ * ## Regeln
+ *
+ * NJA 2005 s. 606: ett rättsligt biträde som är skyldigt att redovisa
+ * mervärdesskatt ska lägga **25 %** på samtliga kostnadselement som ingår i
+ * utförandet av tjänsten. Resa, hotell och liknande är omkostnader i byråns egen
+ * verksamhet — inte ett momsfritt genomflöde — och ingår därför i byråns
+ * skattepliktiga omsättning.
+ *
+ * Domstolsverkets praxis ger mekaniken i två steg:
+ *
+ *   1. Räkna AV den ingående moms byrån själv betalade (den lyfts som avdrag).
+ *   2. Debitera 25 % på det som blir kvar.
+ *
+ * En tågbiljett för 1 060 kr inkl. 6 % moms blir alltså 1 000 kr netto som
+ * debiteras med 250 kr moms — inte 60 kr.
+ *
+ * ## Undantaget
+ *
+ * **Äkta utlägg** — fakturan är ställd direkt till klienten och byrån har bara
+ * förmedlat betalningen — vidarefaktureras utan moms. Det är undantaget, inte
+ * huvudregeln, och kräver att någon aktivt intygar det. Därför är `passThrough`
+ * default `false`: ett utlägg är ett kostnadselement tills motsatsen är sagd.
+ *
+ * ## Varför modulen finns
+ *
+ * Logiken låg förr i `billingRun.ts` som `courtExpenseLines` och tillämpades BARA
+ * när betalaren var en domstol (#945). Men regeln följer biträdets omsättning,
+ * inte vem som betalar — klientens och försäkringens fakturor ska hanteras
+ * likadant. I demons data gav den avgränsningen 782,80 kr för lite utgående moms.
+ */
+
+import type { VatBreakdownLine } from "@/lib/shared/accounting/semantic-voucher";
+import { splitVat } from "@/lib/shared/vat";
+
+/** Satsen biträdet debiterar vidare med, oavsett vad byrån själv betalade. */
+export const CHARGED_EXPENSE_VAT_RATE = 2500;
+
+/** Det som behövs för att momsberäkna ett utlägg. */
+export interface ChargeableExpense {
+  /** Belopp i öre — netto om `vatIncluded` är falskt (default sedan #782). */
+  amount: number;
+  /** Momssatsen BYRÅN BETALADE (basis points). Styr avräkningen i steg 1. */
+  vatRate?: number | null | undefined;
+  vatIncluded?: boolean | null | undefined;
+  /** Äkta utlägg — faktura ställd till klienten. Vidarefaktureras utan moms. */
+  passThrough?: boolean | null | undefined;
+}
+
+/** Är utlägget ett äkta utlägg (vidarefaktureras utan moms)? */
+const isPassThrough = (e: ChargeableExpense): boolean => e.passThrough === true;
+
+/**
+ * Underlaget som debiteras vidare (steg 1).
+ *
+ * Kostnadselement: byråns ingående moms räknas av — den lyfts som avdrag och ska
+ * inte vidarefaktureras. Äkta utlägg: beloppet as-is, eftersom byrån inte har
+ * betalat momsen för egen räkning och därför inte heller kan lyfta den.
+ */
+export function expenseNetOre(e: ChargeableExpense): number {
+  if (isPassThrough(e)) return e.amount;
+  return splitVat({
+    amount: e.amount,
+    vatRate: e.vatRate ?? CHARGED_EXPENSE_VAT_RATE,
+    vatIncluded: e.vatIncluded ?? false,
+  }).exclVat;
+}
+
+/** 25 % på ett netto, avrundat till hela ören. */
+export function chargedVatOre(netOre: number): number {
+  return Math.round((netOre * CHARGED_EXPENSE_VAT_RATE) / 10_000);
+}
+
+/**
+ * Fakturans utläggsrader: **en** 25 %-rad för kostnadselementen och **en** 0 %-rad
+ * för de äkta utläggen. Att hålla dem isär är inte kosmetika — klienten ska kunna
+ * se vad som vidarefakturerats obeskattat, och SIE bokför per sats (#790).
+ *
+ * Tomma grupper utelämnas så fakturan inte bär nollrader.
+ */
+export function chargedExpenseLines(expenses: readonly ChargeableExpense[]): VatBreakdownLine[] {
+  let chargedNetOre = 0;
+  let passThroughOre = 0;
+  for (const e of expenses) {
+    if (isPassThrough(e)) passThroughOre += expenseNetOre(e);
+    else chargedNetOre += expenseNetOre(e);
+  }
+  const lines: VatBreakdownLine[] = [];
+  if (chargedNetOre !== 0) {
+    lines.push({ kind: "utlagg", vatRate: CHARGED_EXPENSE_VAT_RATE, netOre: chargedNetOre, vatOre: chargedVatOre(chargedNetOre) });
+  }
+  // Äkta utlägg: beloppet är vad klienten ska betala; ingen moms läggs på.
+  if (passThroughOre !== 0) lines.push({ kind: "utlagg", vatRate: 0, netOre: passThroughOre, vatOre: 0 });
+  return lines;
+}

--- a/src/lib/shared/invoice-calc.ts
+++ b/src/lib/shared/invoice-calc.ts
@@ -10,7 +10,7 @@
  */
 
 import { Temporal } from "@js-temporal/polyfill";
-import { splitVat } from "./vat";
+import { chargedExpenseLines } from "./expense-vat";
 
 export interface TimeEntryForInvoice {
   minutes: number;
@@ -20,10 +20,15 @@ export interface TimeEntryForInvoice {
 export interface ExpenseForInvoice {
   amount: number; // öre (netto om vatIncluded=false, annars brutto)
   billable: boolean;
-  /** Moms-sats i bips. Default 25 %. */
+  /** Satsen BYRÅN betalade, i bips. Default 25 %. Räknas av innan utlägget
+   *  debiteras vidare med 25 % (#975). */
   vatRate?: number;
-  /** Är `amount` redan inkl moms? Default true (bakåtkompat; netto-rader sätter false). */
+  /** Är `amount` redan inkl moms? Default FALSE — utlägg lagras netto sedan #782.
+   *  (Defaulten var `true` innan #975; anropare som utelämnar fältet fick då ett
+   *  netto som var 20 % för lågt.) */
   vatIncluded?: boolean;
+  /** Äkta utlägg — vidarefaktureras utan moms (#975). */
+  passThrough?: boolean;
 }
 
 export interface AccontoForDeduction {
@@ -75,10 +80,13 @@ export function computeFinalInvoiceBreakdown(
     (sum, t) => sum + Math.round((t.minutes * t.hourlyRate) / 60),
     0,
   );
-  const expenseTotal = expenses
-    .filter((e) => e.billable)
-    .reduce((sum, e) => sum + splitVat({ amount: e.amount, vatRate: e.vatRate ?? 2500, vatIncluded: e.vatIncluded ?? true }).inclVat, 0);
-  // Arvodet (timmar × timpris) är exkl. moms → lägg på 25 % (#782); utlägg är brutto (inkl moms).
+  // Utläggen debiteras vidare med 25 % på nettot enligt NJA 2005 s. 606 (#975) —
+  // byråns egen sats räknas av först. Äkta utlägg går utan moms. Delad regel med
+  // faktureringen (`chargedExpenseLines`); två uträkningar av samma sak var just
+  // vad som gjorde att den här helpern kunde glida isär från fakturan.
+  const expenseTotal = chargedExpenseLines(expenses.filter((e) => e.billable))
+    .reduce((sum, l) => sum + l.netOre + l.vatOre, 0);
+  // Arvodet (timmar × timpris) är exkl. moms → lägg på 25 % (#782).
   const arvodeInclVat = arvodeInclVatOre(timeTotal);
   const arvodeVatOre = arvodeInclVat - timeTotal;
   const grossAmount = arvodeInclVat + expenseTotal;

--- a/src/lib/shared/invoice-specification.ts
+++ b/src/lib/shared/invoice-specification.ts
@@ -18,7 +18,11 @@ export interface SpecTimeLine {
   kind?: TimeEntryKind | null | undefined;
 }
 /** En rad i utläggsspecifikationen (netto + brutto, exakt per momssats). */
-export interface SpecExpenseLine { date: Date | string; description: string; netOre: number; grossOre: number }
+export interface SpecExpenseLine {
+  date: Date | string; description: string; netOre: number; grossOre: number;
+  /** Äkta utlägg — vidarefakturerat utan moms (#975). Redovisas som egen grupp. */
+  passThrough?: boolean;
+}
 /** En avdragen (tidigare betald) aconto-faktura. */
 export interface SpecDeduction { invoiceNumber: string; date: Date | string | null; amountOre: number }
 

--- a/src/lib/shared/schemas/billing.ts
+++ b/src/lib/shared/schemas/billing.ts
@@ -87,10 +87,21 @@ export const expenseSchema = z.object({
   billable: z.boolean().default(true),
   /** @deprecated Se motsvarande not på timeEntry.invoiceId. */
   invoiceId: invoiceIdSchema.nullish(),
-  /** Moms-sats i basis points (0/600/1200/2500). Default 25 %. */
+  /** Momssatsen BYRÅN BETALADE, i basis points (0/600/1200/2500). Default 25 %.
+   *  Styr hur mycket ingående moms som räknas av innan utlägget debiteras vidare
+   *  med 25 % (#975) — den är alltså inte satsen klienten ser på fakturan. */
   vatRate: z.number().int().nonnegative().max(10000).default(2500),
   /** Är `amount` redan inkl moms? Default false — utlägg lagras netto (#782). */
   vatIncluded: z.boolean().default(false),
+  /**
+   * ÄKTA UTLÄGG (#975): fakturan är ställd direkt till klienten och byrån har
+   * bara förmedlat betalningen → vidarefaktureras UTAN moms.
+   *
+   * Default `false`, med flit: enligt NJA 2005 s. 606 är huvudregeln att ett
+   * utlägg är ett kostnadselement i biträdets tjänst och ska bära 25 % moms.
+   * Äkta utlägg är undantaget och kräver att någon aktivt intygar det.
+   */
+  passThrough: z.boolean().default(false),
   /** Skiljer vanligt utlägg (EXPENSE) från PRUTNING (domstols-justering).
    *  PRUTNING har negativt amount, vatRate=0, vatIncluded=false. Default
    *  EXPENSE för bakåtkompatibilitet med befintliga rader. */

--- a/test/integration/scenario-civilmal.test.ts
+++ b/test/integration/scenario-civilmal.test.ts
@@ -317,13 +317,20 @@ describe("Scenario: civilmål (bostadsrättstvist) på löpande räkning", () =>
     // Verifiera pure-helpern (samma som routern använder)
     const breakdown = computeFinalInvoiceBreakdown(
       times.entries.map((t) => ({ minutes: t.minutes, hourlyRate: HOURLY_RATE })),
-      exps.expenses.map((e) => ({ amount: e.amount, billable: e.billable })),
+      // #975: momsfälten MÅSTE med — utan dem antar helpern 25 %/netto och
+      // räknar fram ett annat underlag än routern, vilket dolde att de två
+      // vägarna hade glidit isär.
+      exps.expenses.map((e) => ({ amount: e.amount, billable: e.billable, vatRate: e.vatRate, vatIncluded: e.vatIncluded, passThrough: e.passThrough })),
       [{ id: state.accontoInvoiceId!, amount: 1_500_000 }],
     );
-    // Arvode 36 875 kr + 25 % moms = 46 093,75 kr + utlägg 562,50 kr = 46 656,25 kr (#782).
-    expect(breakdown.grossAmount).toBe(4_609_375 + 56_250); // 4 665 625 öre
+    // Arvode 36 875 kr + 25 % moms = 46 093,75 kr.
+    // Utlägget (562,50 kr inkl 6 % moms) är ett kostnadselement i uppdraget:
+    // byråns 6 % räknas av → 530,66 kr netto, som debiteras vidare med 25 %
+    // → 663,33 kr (NJA 2005 s. 606, #975). Förr vidarefakturerades det med
+    // byråns egen sats, dvs. 562,50 kr, vilket gav 100,83 kr för lite moms.
+    expect(breakdown.grossAmount).toBe(4_609_375 + 66_333); // 4 675 708 öre
     expect(breakdown.accontoDeductionTotal).toBe(1_500_000);
-    expect(breakdown.netAmount).toBe(4_665_625 - 1_500_000); // 3 165 625 öre = 31 656,25 kr
+    expect(breakdown.netAmount).toBe(4_675_708 - 1_500_000); // 3 175 708 öre
 
     // Skapa slutfaktura via billing-run (acconto-körningen dras av).
     const result = await state.caller.billingRun.createFinal({
@@ -355,7 +362,7 @@ describe("Scenario: civilmål (bostadsrättstvist) på löpande räkning", () =>
     const inv = await state.caller.invoice.getById({ id: state.finalInvoiceId! });
     // billing-run: invoice.amount är redan NETTO (acconto avräknat) → klienten
     // betalar hela beloppet och fakturan blir PAID (inget separat avdrag i ledgern).
-    expect(inv.amount).toBe(3_165_625);
+    expect(inv.amount).toBe(3_175_708);
 
     const pay = await state.caller.invoice.recordPayment({
       invoiceId: state.finalInvoiceId!,
@@ -363,8 +370,8 @@ describe("Scenario: civilmål (bostadsrättstvist) på löpande räkning", () =>
       paidAt: D.slutPayment.toISOString(),
       note: "Bankgiro — slutbetalning (netto efter acconto-avräkning)",
     });
-    expect(pay.payment.amount).toBe(3_165_625);
-    expect(pay.paidSum).toBe(3_165_625);
+    expect(pay.payment.amount).toBe(3_175_708);
+    expect(pay.paidSum).toBe(3_175_708);
     expect(pay.settled).toBe(true);
 
     const after = await state.caller.invoice.getById({ id: state.finalInvoiceId! });
@@ -381,12 +388,13 @@ describe("Scenario: civilmål (bostadsrättstvist) på löpande räkning", () =>
     const acconto = invoices.find((i) => i.invoiceType === "ACCONTO");
     const final = invoices.find((i) => i.invoiceType === "FINAL");
     expect(acconto?.amount).toBe(1_500_000);
-    // billing-run: FINAL-beloppet är NETTO (brutto 4 665 625 − acconto 1 500 000).
-    expect(final?.amount).toBe(3_165_625);
+    // billing-run: FINAL-beloppet är NETTO (brutto 4 675 708 − acconto 1 500 000).
+    expect(final?.amount).toBe(3_175_708);
 
-    // Total fakturerat klient = acconto (15 000) + netto-slutfaktura (31 656,25)
-    // = 46 656,25 kr = brutto-arbetet (arvode inkl moms + utlägg). Ingen dubbelräkning.
+    // Total fakturerat klient = acconto (15 000) + netto-slutfaktura (31 757,08)
+    // = 46 757,08 kr = brutto-arbetet (arvode inkl moms + utlägg inkl 25 %).
+    // Ingen dubbelräkning.
     const totalBilled = (acconto!.amount) + (final!.amount);
-    expect(totalBilled).toBe(4_665_625);
+    expect(totalBilled).toBe(4_675_708);
   });
 });

--- a/test/unit/app/matters/expense-section.test.tsx
+++ b/test/unit/app/matters/expense-section.test.tsx
@@ -96,12 +96,13 @@ describe("ExpenseSection", () => {
     fireEvent.change(dateInput, { target: { value: "2026-03-15" } });
     fireEvent.change(screen.getByPlaceholderText("0,00"), { target: { value: "150" } });
     fireEvent.change(screen.getByPlaceholderText("Beskrivning *"), { target: { value: "Parkering" } });
-    // VatPreview-grenen (amount>0) renderar moms-uppdelningen (exkl-inmatning).
-    expect(screen.getByText(/Exkl:.*moms:.*inkl:/)).toBeInTheDocument();
+    // VatPreview visar vad KLIENTEN debiteras (#975), inte vad byrån betalade.
+    expect(screen.getByText(/Debiteras:.*moms 25 %:.*inkl:/)).toBeInTheDocument();
     fireEvent.click(screen.getByText("Spara"));
     // Inmatat exkl. 150 kr → lagras NETTO 150 kr, vatIncluded=false (#782).
+    // passThrough=false: utlägget är ett kostnadselement tills motsatsen sägs (#975).
     expect(createMutate).toHaveBeenCalledWith(
-      expect.objectContaining({ matterId: "m1", description: "Parkering", amount: 15000, vatRate: 2500, vatIncluded: false }),
+      expect.objectContaining({ matterId: "m1", description: "Parkering", amount: 15000, vatRate: 2500, vatIncluded: false, passThrough: false }),
     );
   });
 
@@ -111,8 +112,24 @@ describe("ExpenseSection", () => {
     // Incl/excl-radions är borttagen — inmatning är alltid exkl. moms (#781).
     expect(screen.queryByRole("radio")).not.toBeInTheDocument();
     fireEvent.change(screen.getByRole("combobox"), { target: { value: "1200" } });
-    fireEvent.click(screen.getByRole("checkbox")); // Debiterbar av
+    // Två kryssrutor sedan #975: "Äkta utlägg" och "Debiterbar".
+    const boxes = screen.getAllByRole("checkbox");
+    expect(boxes).toHaveLength(2);
+    fireEvent.click(boxes[1]!); // Debiterbar av
     expect(screen.getByText("Spara")).toBeInTheDocument();
+  });
+
+  it("'Äkta utlägg' → passThrough=true och momsen faller bort (#975)", () => {
+    render(<ExpenseSection matterId={asId<"MatterId">("m1")} />);
+    fireEvent.click(screen.getByText("+ Nytt utlägg"));
+    fireEvent.change(screen.getByPlaceholderText("0,00"), { target: { value: "900" } });
+    fireEvent.change(screen.getByPlaceholderText("Beskrivning *"), { target: { value: "Ansökningsavgift" } });
+    // Default: kostnadselement → 25 % läggs på.
+    expect(screen.getByText(/moms 25 %/)).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole("checkbox")[0]!); // Äkta utlägg på
+    expect(screen.getByText(/moms 0 %/)).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Spara"));
+    expect(createMutate).toHaveBeenCalledWith(expect.objectContaining({ passThrough: true }));
   });
 
   it("'Ändra' öppnar förifyllt edit-formulär → Spara ändring → update.mutate med id", () => {

--- a/test/unit/lib/invoice-calc.test.ts
+++ b/test/unit/lib/invoice-calc.test.ts
@@ -27,7 +27,12 @@ describe("computeFinalInvoiceBreakdown", () => {
       ],
       [],
     );
-    expect(r.grossAmount).toBe(50_000);
+    // #975: det debiterbara utlägget (500 kr netto) är ett kostnadselement i
+    // uppdraget och debiteras vidare med 25 % → 625 kr. Det icke-debiterbara
+    // utelämnas, vilket är vad testet vaktar. Förr gav helpern 50 000 rakt av,
+    // eftersom `vatIncluded` defaultade till `true` — en kvarleva från före #782,
+    // då utlägg lagrades brutto.
+    expect(r.grossAmount).toBe(62_500);
   });
 
   it("drar av accontos från brutto", () => {

--- a/test/unit/lib/shared/expense-vat.test.ts
+++ b/test/unit/lib/shared/expense-vat.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Utläggsmoms enligt NJA 2005 s. 606 (#975).
+ *
+ * Regeln har två steg som är lätta att blanda ihop: räkna AV byråns ingående
+ * moms, debitera SEDAN 25 % på det som blir kvar. Att bara byta sats till 25 %
+ * utan avräkning ger fel belopp; att bara räkna av utan påslag ger också fel.
+ * Testerna låser båda stegen — och undantaget för äkta utlägg.
+ */
+import { describe, it, expect } from "vitest-compat";
+
+import { chargedExpenseLines, chargedVatOre, expenseNetOre } from "@/lib/shared/expense-vat";
+
+describe("expenseNetOre — steg 1: räkna av byråns ingående moms", () => {
+  it("tågbiljett lagrad netto behåller sitt netto", () => {
+    expect(expenseNetOre({ amount: 100_000, vatRate: 600, vatIncluded: false })).toBe(100_000);
+  });
+
+  it("belopp lagrat INKL moms räknas ned till netto", () => {
+    // 1 060 kr inkl 6 % → 1 000 kr netto.
+    expect(expenseNetOre({ amount: 106_000, vatRate: 600, vatIncluded: true })).toBe(100_000);
+  });
+
+  it("saknad sats behandlas som 25 % (default sedan #782)", () => {
+    expect(expenseNetOre({ amount: 100_000 })).toBe(100_000);
+  });
+});
+
+describe("chargedVatOre — steg 2: 25 % på nettot", () => {
+  it("lägger 25 % oavsett vad byrån betalade", () => {
+    expect(chargedVatOre(100_000)).toBe(25_000);
+  });
+
+  it("avrundar till hela ören", () => {
+    expect(chargedVatOre(3)).toBe(1);
+  });
+});
+
+describe("chargedExpenseLines", () => {
+  it("tågbiljett med 6 % debiteras 25 % på nettot — inte 6 %", () => {
+    // Kärnan i #975: 1 000 kr netto ger 250 kr moms, inte 60 kr.
+    expect(chargedExpenseLines([{ amount: 100_000, vatRate: 600 }])).toEqual([
+      { kind: "utlagg", vatRate: 2500, netOre: 100_000, vatOre: 25_000 },
+    ]);
+  });
+
+  it("blandade satser kollapsar till EN 25 %-rad på summan av nettona", () => {
+    // Tåg 6 %, hotell 12 %, kopior 25 % → ett gemensamt underlag.
+    const lines = chargedExpenseLines([
+      { amount: 100_000, vatRate: 600 },
+      { amount: 50_000, vatRate: 1200 },
+      { amount: 10_000, vatRate: 2500 },
+    ]);
+    expect(lines).toEqual([{ kind: "utlagg", vatRate: 2500, netOre: 160_000, vatOre: 40_000 }]);
+  });
+
+  it("momsfritt utlägg (0 %) debiteras ändå 25 % — det är byråns omkostnad", () => {
+    // Ansökningsavgiften är momsfri för DOMSTOLEN. Betalar byrån den som del av
+    // uppdraget blir den ett kostnadselement och ska bära 25 % vidare.
+    expect(chargedExpenseLines([{ amount: 90_000, vatRate: 0 }])).toEqual([
+      { kind: "utlagg", vatRate: 2500, netOre: 90_000, vatOre: 22_500 },
+    ]);
+  });
+
+  it("ÄKTA utlägg vidarefaktureras utan moms, på egen rad", () => {
+    const lines = chargedExpenseLines([
+      { amount: 100_000, vatRate: 600 },
+      { amount: 90_000, vatRate: 0, passThrough: true },
+    ]);
+    expect(lines).toEqual([
+      { kind: "utlagg", vatRate: 2500, netOre: 100_000, vatOre: 25_000 },
+      { kind: "utlagg", vatRate: 0, netOre: 90_000, vatOre: 0 },
+    ]);
+  });
+
+  it("äkta utlägg tar beloppet som-är — ingen ingående moms lyfts", () => {
+    // Byrån har inte betalat momsen för egen räkning, så det finns inget att
+    // räkna av. Hade vi kört `expenseNetOre` här hade beloppet krympt felaktigt.
+    expect(chargedExpenseLines([{ amount: 106_000, vatRate: 600, passThrough: true }])).toEqual([
+      { kind: "utlagg", vatRate: 0, netOre: 106_000, vatOre: 0 },
+    ]);
+  });
+
+  it("passThrough=false är huvudregeln — undantaget måste sägas ut", () => {
+    expect(chargedExpenseLines([{ amount: 100_000, vatRate: 600, passThrough: false }])[0]?.vatRate).toBe(2500);
+    expect(chargedExpenseLines([{ amount: 100_000, vatRate: 600 }])[0]?.vatRate).toBe(2500);
+  });
+
+  it("inga utlägg → inga rader (fakturan ska inte bära nollrader)", () => {
+    expect(chargedExpenseLines([])).toEqual([]);
+    expect(chargedExpenseLines([{ amount: 0, vatRate: 600 }])).toEqual([]);
+  });
+
+  it("demons utläggsmoms: 3 182,20 kr → 3 965,00 kr", () => {
+    // Regressionsvakt för hela datamängden. Sammansättningen är seedens:
+    // 2 × 0 %, 2 × 6 %, 2 × 12 %, 22 × 25 % (netto ur demo-seed.json).
+    const seed = [
+      { amount: 90_000, vatRate: 0 }, { amount: 90_000, vatRate: 0 },
+      { amount: 39_000, vatRate: 600 }, { amount: 39_000, vatRate: 600 },
+      { amount: 71_000, vatRate: 1200 }, { amount: 71_000, vatRate: 1200 },
+    ];
+    const lines = chargedExpenseLines(seed);
+    expect(lines[0]?.vatOre).toBe(100_000); // 400 000 netto × 25 %
+    // Gamla modellen: 0 + 0 + 2 340 + 2 340 + 8 520 + 8 520 = 21 720 öre.
+    expect(lines[0]?.vatOre).toBeGreaterThan(21_720);
+  });
+});

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -103,7 +103,9 @@ describe("billingRun.createFinal", () => {
       matterId: "m-1", recipient: "KLIENT",
     });
     expect(res.run.type).toBe("FINAL");
-    expect(res.run.amountOre).toBe(312500 + 12500); // 1h × 2500 + 25 % moms + 125 utlägg (#782)
+    // #975: utlägget (125 kr, momsfritt för byrån) är ett kostnadselement i
+    // tjänsten och debiteras vidare med 25 % — 125 × 1,25 = 156,25.
+    expect(res.run.amountOre).toBe(312500 + 15625); // 1h × 2500 inkl moms + utlägg inkl 25 %
     const te = await ds.timeEntries.findFirst({ where: { id: "te-1" } }) as { frozenAt?: Date | null; frozenByBillingRunId?: string | null };
     expect(te.frozenAt).toBeInstanceOf(Date);
     expect(te.frozenByBillingRunId).toBe(res.run.id);
@@ -173,7 +175,7 @@ describe("billingRun.createFinal", () => {
   it("utan per-post-val → fakturerar allt ofryst (default oförändrat)", async () => {
     const { ds, caller } = makeCaller({ workMinutes: 60, expenseOre: 5000 });
     const res = await caller.billingRun.createFinal({ matterId: "m-1", recipient: "KLIENT" });
-    expect(res.invoice.amount).toBe(312500 + 5000); // arvode inkl 25 % moms + utlägg (#782)
+    expect(res.invoice.amount).toBe(312500 + 6250); // arvode inkl moms + utlägg inkl 25 % (#975)
     const t1 = await ds.timeEntries.findFirst({ where: { id: "te-1" } }) as { frozenAt?: Date | null };
     expect(t1.frozenAt).toBeInstanceOf(Date);
   });
@@ -456,7 +458,9 @@ describe("billingRun.coverageSplit — prutning/självrisk på aktuellt timarvod
     const r = await c.billingRun.coverageSplit({ matterId: "m-1" });
     expect(r.totalOre).toBe(325_200); // #950: arvode 2h × timkostnadsnormen 1 626 kr
     expect(r.expensesNetOre).toBe(32065);
-    expect(r.expensesGrossOre).toBe(39750); // exakt per sats — INTE 40081 (platt 25 %)
+    // #975 (NJA 2005 s. 606): utläggen debiteras 25 % på NETTOT oavsett vilken
+    // sats byrån betalade. Förr räknades de per byråns egen sats → 39 750.
+    expect(r.expensesGrossOre).toBe(40081); // 32 065 × 1,25
   });
 
   it("KR inskickad (rader frysta) → utläggen räknas ändå (Carlsson-regression, #849)", async () => {
@@ -496,20 +500,26 @@ describe("moms mot DOMSTOL är alltid 25 % (#945)", () => {
     expect(kr.run.workValueOreAtRun).toBe(Math.round(arvodeGross) + 162500);
   });
 
-  it("domstolsfakturan får EN 25 %-utläggsrad; klientfakturan behåller 0 % och 6 %", async () => {
+  it("BÅDA fakturorna får EN 25 %-utläggsrad — regeln följer biträdet, inte betalaren (#975)", async () => {
+    // NJA 2005 s. 606: utlägg är kostnadselement i biträdets tjänst och bär 25 %
+    // oavsett vem som betalar. Förr gällde det bara mot domstol (#945) och
+    // klientfakturan behöll posternas egna satser ([0, 600]) — vilket gav för
+    // lite utgående moms på varje klient- och försäkringsfaktura.
     const c = courtCaller();
     const kr = await c.billingRun.createKostnadsrakning({ matterId: "m-1" });
     await c.billingRun.recordKostnadsrakningBeslut({ billingRunId: kr.run.id, awardedOre: kr.run.workValueOreAtRun });
     const res = await c.billingRun.settleCoverage({ matterId: "m-1", payerRecipient: "DOMSTOL" });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const lines = (l: any): Array<{ vatRate: number; netOre: number; vatOre: number }> => l.vatBreakdown;
-    const payerUtlagg = lines(res.payerInvoice).filter((l) => (l as { kind?: string }).kind === "utlagg");
-    expect(payerUtlagg).toHaveLength(1);
-    expect(payerUtlagg[0]!.vatRate).toBe(2500);
-    expect(payerUtlagg[0]!.vatOre).toBe(Math.round(payerUtlagg[0]!.netOre * 0.25));
-    // Klienten är ingen domstol → posternas riktiga satser bevaras.
-    const clientRates = lines(res.clientInvoice).filter((l) => (l as { kind?: string }).kind === "utlagg").map((l) => l.vatRate).sort((a, b) => a - b);
-    expect(clientRates).toEqual([0, 600]);
+    const utlagg = (inv: unknown): Array<{ vatRate: number; netOre: number; vatOre: number }> =>
+      lines(inv).filter((l) => (l as { kind?: string }).kind === "utlagg");
+
+    for (const [who, inv] of [["domstolen", res.payerInvoice], ["klienten", res.clientInvoice]] as const) {
+      const rows = utlagg(inv);
+      expect(rows, `${who}: en enda utläggsrad`).toHaveLength(1);
+      expect(rows[0]!.vatRate, `${who}: 25 %`).toBe(2500);
+      expect(rows[0]!.vatOre, `${who}: moms på nettot`).toBe(Math.round(rows[0]!.netOre * 0.25));
+    }
   });
 });
 
@@ -851,12 +861,13 @@ describe("billingRun.invoiceSpecification (#856)", () => {
     expect(spec.expenseLines[0]!.netOre).toBe(5000);
     expect(spec.arvodeNetOre).toBe(500000);
     expect(spec.arvodeVatOre).toBe(125000); // 25 %
-    expect(spec.grossOre).toBe(630000); // 625000 arvode inkl moms + 5000 utlägg
+    // #975: utlägget (50 kr, momsfritt för byrån) debiteras vidare med 25 % → 62,50.
+    expect(spec.grossOre).toBe(631250); // 625 000 arvode inkl moms + 6 250 utlägg inkl 25 %
     expect(spec.deductions).toHaveLength(1);
     expect(spec.deductions[0]!.amountOre).toBe(100000);
     expect(spec.deductionOre).toBe(100000);
     expect(spec.adjustmentOre).toBe(0); // brutto − avdrag == fakturerat
-    expect(spec.payableOre).toBe(530000); // 630000 − 100000
+    expect(spec.payableOre).toBe(531250); // 631 250 − 100 000
   });
 
   it("rättshjälp settlement: betalar-fakturan bär tidsraderna (timkostnadsnorm), klientfakturan aconto-avdraget", async () => {

--- a/tooling/db/migrations/0021_expense_pass_through.sql
+++ b/tooling/db/migrations/0021_expense_pass_through.sql
@@ -1,0 +1,13 @@
+-- #975: äkta utlägg (NJA 2005 s. 606).
+--
+-- Huvudregeln är att ett utlägg är ett KOSTNADSELEMENT i biträdets tjänst och
+-- ska bära 25 % moms när det debiteras vidare — oavsett vilken sats byrån själv
+-- betalade, och oavsett om betalaren är domstol, försäkring eller klient.
+--
+-- Undantaget är ÄKTA utlägg, där fakturan är ställd direkt till klienten och
+-- byrån bara förmedlat betalningen. De vidarefaktureras utan moms.
+--
+-- DEFAULT false med flit: undantaget ska sägas ut aktivt. Befintliga rader
+-- ändrar därmed inte betydelse — men de ändrar BELOPP, eftersom 6/12/0 %-utlägg
+-- nu debiteras 25 % på nettot. Det är själva rättelsen.
+ALTER TABLE expenses ADD COLUMN IF NOT EXISTS pass_through boolean NOT NULL DEFAULT false;

--- a/tooling/demo-generator/simulate/events.ts
+++ b/tooling/demo-generator/simulate/events.ts
@@ -16,7 +16,7 @@ export type SimEvent =
   /** Tjänsteanteckning (händelselogg) — serviceNote.create. */
   | { kind: "note"; dayOffset: number; text: string }
   /** Utlägg — expense.create. */
-  | { kind: "expense"; dayOffset: number; amountOre: number; description: string; vatRate?: number }
+  | { kind: "expense"; dayOffset: number; amountOre: number; description: string; vatRate?: number; passThrough?: boolean }
   /** Dokument (in/ut) ur DOC_TEMPLATES — document.register + bytes via sink. */
   | { kind: "doc"; dayOffset: number; template: string }
   /** Rådgivningstimmen faktureras — invoice.createRadgivning. */

--- a/tooling/demo-generator/simulate/runner.ts
+++ b/tooling/demo-generator/simulate/runner.ts
@@ -76,7 +76,7 @@ async function hNote(ctx: RunCtx, m: SimMatter, e: Any, iso: string): Promise<vo
 async function hExpense(ctx: RunCtx, m: SimMatter, e: Any, iso: string): Promise<void> {
   await ctx.c.expense.create({
     matterId: m.id, date: iso, amount: e.amountOre, description: e.description,
-    billable: true, vatRate: e.vatRate ?? 2500, vatIncluded: false, userId: m.lawyerId, createdAt: iso,
+    billable: true, vatRate: e.vatRate ?? 2500, vatIncluded: false, passThrough: e.passThrough ?? false, userId: m.lawyerId, createdAt: iso,
   });
 }
 

--- a/tooling/demo-generator/simulate/scenarios/rattshjalp-arsskifte.ts
+++ b/tooling/demo-generator/simulate/scenarios/rattshjalp-arsskifte.ts
@@ -37,7 +37,7 @@ export function buildRattshjalpArsskifteScenario(parties: Parties): SimEvent[] {
     { kind: "note", dayOffset: 10, text: "Rättshjälp beviljad — rättshjälpsavgift 5 %." },
     // Utlägg med OLIKA momssatser (#953) så sammanställningens utläggsrader visar
     // både netto och brutto per sats — ansökningsavgiften är momsfri.
-    { kind: "expense", dayOffset: 8, amountOre: 90_000, description: "Ansökningsavgift tingsrätten", vatRate: 0 },
+    { kind: "expense", dayOffset: 8, amountOre: 90_000, description: "Ansökningsavgift tingsrätten", vatRate: 0, passThrough: true },
     // ── Period 1: arbetslös 5 %, HELA i 2025 (norm 1 586 / tidsspillan 1 450) ──
     { kind: "time", dayOffset: 6, minutes: 240, description: "Genomgång av handlingar och underlag" },
     { kind: "doc", dayOffset: 14, template: "svaromal" },

--- a/tooling/demo-generator/simulate/scenarios/rattshjalp.ts
+++ b/tooling/demo-generator/simulate/scenarios/rattshjalp.ts
@@ -36,7 +36,7 @@ export function buildRattshjalpScenario(parties: Parties, opts: RattshjalpScenar
 
   ev.push(
     // Utlägg i ärendet (ersätts av domstolen via kostnadsräkningen).
-    { kind: "expense", dayOffset: 8, amountOre: 90_000, description: "Ansökningsavgift tingsrätten" },
+    { kind: "expense", dayOffset: 8, amountOre: 90_000, description: "Ansökningsavgift tingsrätten", vatRate: 0, passThrough: true },
     { kind: "expense", dayOffset: 60, amountOre: 42_000, description: "Reskostnad till sammanträde" },
     // Period 1 (arbetslös, 5 %) — löpande arbete tills klientens andel når tröskeln (→ aconto).
     { kind: "time", dayOffset: 6, minutes: 240, description: "Genomgång av handlingar och underlag" },

--- a/tooling/demo-generator/simulate/scenarios/rattsskydd-positivt.ts
+++ b/tooling/demo-generator/simulate/scenarios/rattsskydd-positivt.ts
@@ -36,7 +36,7 @@ export function buildRattsskyddPositivtScenario(parties: Parties): SimEvent[] {
     { kind: "note", dayOffset: 10, text: "Rättsskydd beviljat: högst 100 tim arvode, självrisk 20 % dock lägst 1 800 kr." },
     // Utlägg med olika momssatser (#953) — sammanställningen visar utläggen både
     // exkl och inkl moms per sats. Ansökningsavgiften är momsfri.
-    { kind: "expense", dayOffset: 14, amountOre: 90_000, description: "Ansökningsavgift tingsrätten", vatRate: 0 },
+    { kind: "expense", dayOffset: 14, amountOre: 90_000, description: "Ansökningsavgift tingsrätten", vatRate: 0, passThrough: true },
     // ── Löpande arbete 2025 → aconto på självrisken (klienten) ──
     { kind: "time", dayOffset: 15, minutes: 240, description: "Skriftväxling och kravbrev till motpart" },
     { kind: "doc", dayOffset: 18, template: "brevTillOmbud" },

--- a/tooling/demo-generator/simulate/scenarios/rattsskydd.ts
+++ b/tooling/demo-generator/simulate/scenarios/rattsskydd.ts
@@ -20,7 +20,7 @@ export function buildRattsskyddScenario(parties: Parties): SimEvent[] {
   ev.push(
     { kind: "doc", dayOffset: 5, template: "brevTillOmbud" },
     { kind: "time", dayOffset: 12, minutes: 120, description: "Skriftväxling och förhandlingsförberedelse" },
-    { kind: "expense", dayOffset: 14, amountOre: 90_000, description: "Ansökningsavgift tingsrätten" },
+    { kind: "expense", dayOffset: 14, amountOre: 90_000, description: "Ansökningsavgift tingsrätten", vatRate: 0, passThrough: true },
     { kind: "doc", dayOffset: 18, template: "brevFranOmbud" },
     { kind: "acconto", dayOffset: 30, clientShareBips: 2000 }, // 20 % självrisk
     { kind: "time", dayOffset: 45, minutes: 90, description: "Sammanträde och uppföljning" },

--- a/tooling/scripts/seed-data.ts
+++ b/tooling/scripts/seed-data.ts
@@ -497,11 +497,16 @@ function appendVardnad2TimeEntries(out: SeedDataset["timeEntries"], orgId: strin
 function buildExpenses(orgId: string, users: UserSeed[]): SeedDataset["expenses"] {
   const out: SeedDataset["expenses"] = [];
   // expenses
-  // Moms-modellen följer Skatteverket: persontransporter 6 %, restaurang 12 %,
-  // myndighetsavgifter 0 %, övrigt 25 %. `amount` nedan är kvitto-beloppet inkl
-  // moms — lagras dock NETTO (exkl moms) per #782; AVA lägger på momsen.
-  const cats: Array<{ amount: number; description: string; vatRate: number }> = [
-    { amount: 12500, description: "Domstolsavgift", vatRate: 0 },         // momsfritt
+  // `vatRate` är satsen BYRÅN BETALADE (persontransport 6 %, restaurang 12 %,
+  // myndighetsavgift 0 %, övrigt 25 %). Den räknas av innan utlägget debiteras
+  // vidare med 25 % enligt NJA 2005 s. 606 (#975) — den är alltså inte satsen
+  // klienten ser. `amount` är kvitto-beloppet inkl moms; lagras NETTO per #782.
+  //
+  // `passThrough` markerar ÄKTA utlägg: fakturan ställd till klienten, byrån har
+  // bara förmedlat betalningen → vidarefaktureras utan moms. Domstolsavgiften är
+  // det typiska fallet; allt annat här är omkostnader i byråns egen verksamhet.
+  const cats: Array<{ amount: number; description: string; vatRate: number; passThrough?: boolean }> = [
+    { amount: 12500, description: "Domstolsavgift", vatRate: 0, passThrough: true }, // äkta utlägg
     { amount: 4500, description: "Tåg Stockholm-Göteborg", vatRate: 600 }, // 6 % persontransport
     { amount: 1850, description: "Taxi domstol", vatRate: 600 },           // 6 %
     { amount: 28000, description: "Översättningskostnad", vatRate: 2500 }, // 25 %
@@ -527,7 +532,7 @@ function buildExpenses(orgId: string, users: UserSeed[]): SeedDataset["expenses"
         organizationId: orgId,
         userId: user.id, matterId: matter.id, date: isoDate(-daysAgo, 12),
         amount: netAmount, description: cat.description,
-        vatRate: cat.vatRate, vatIncluded: false,
+        vatRate: cat.vatRate, vatIncluded: false, passThrough: cat.passThrough ?? false,
         billable: true, invoiceId: null,
         createdAt: isoDate(-daysAgo, 12), updatedAt: isoDate(-daysAgo, 12),
       });


### PR DESCRIPTION
## Vad & varför

[NJA 2005 s. 606](https://lagen.nu/dom/nja/2005s606): ett rättsligt biträde som redovisar mervärdesskatt ska lägga **25 % på samtliga kostnadselement** som ingår i utförandet av tjänsten. Resa och hotell är omkostnader i byråns egen verksamhet, inte momsfritt genomflöde. [Domstolsverkets praxis](``https://www.domstol.se/om-sveriges-domstolar/for-dig-som-aktor-i-domstol/stod-for-aktorer-i-domstol/rattshjalp-och-taxor/utlagg-och-mervardesskatt/utlagg/``) ger mekaniken i två steg: räkna **av** den ingående moms byrån betalade, debitera **sedan** 25 % på det som blir kvar.

AVA gjorde exakt rätt sak — men bara mot domstol (#945). Kommentaren i `courtExpenseLines` sade det rakt ut:

> `Klientens och försäkringens fakturor behåller utläggens riktiga satser.`

Regeln följer biträdets omsättning, inte vem som betalar.

| Byråns sats | Antal | Moms idag | Moms enl. NJA | Diff |
|---:|---:|---:|---:|---:|
| 0 % | 2 | 0,00 | 450,00 | +450,00 |
| 6 % | 2 | 46,80 | 195,00 | +148,20 |
| 12 % | 2 | 170,40 | 355,00 | +184,60 |
| 25 % | 22 | 2 965,00 | 2 965,00 | 0,00 |
| **Summa** | | **3 182,20** | **3 965,00** | **+782,80** |

782,80 kr utgående moms som inte debiterats — momsen ska ändå redovisas, så mellanskillnaden betalades ur byråns egen ficka.

Stänger #975

## Typ

- [x] `fix` — buggfix

## Ändringen

Ny ren modul **`src/lib/shared/expense-vat.ts`** bär regeln. `courtExpenseLines` och `isCourtRecipient` utgår — specialfallet är nu huvudregeln.

**Undantaget** får ett eget fält: `passThrough` (äkta utlägg — faktura ställd till klienten), **default `false`**. Huvudregeln gäller tills någon aktivt intygar undantaget. Äkta utlägg redovisas som egen 0 %-rad på fakturan så klienten ser skillnaden.

**`vatRate` betyder nu uttryckligen satsen byrån betalade** — den behövs för avräkningen i steg 1, inte för vad klienten debiteras. Fältet fanns redan och användes redan så; det som saknades var att någon gjorde avräkningen mot alla betalare. Både schema, tRPC-input, UI-hjälptext och seed-kommentarer säger det nu.

## Ett fynd på vägen

En **andra beräkningsväg hade glidit isär.** `computeFinalInvoiceBreakdown` räknade utlägg med byråns egen sats *och* defaultade `vatIncluded` till `true` — kvar sedan före #782, då lagringen gick över till netto. Den delar nu modul med faktureringen.

Scenariotestet dolde skillnaden genom att mappa bort momsfälten (`{ amount, billable }`), så helpern och routern räknade på olika underlag utan att någon märkte det. Testet skickar fälten nu.

## Verifierat lokalt (speglar CI)

- [x] `typecheck`, `lint` (`--max-warnings 0`), `lint:complexity-strict`, `knip`, `deps:check`, `jscpd` — rena
- [x] `bun run build:demo` + `bun run size` — 1169,7 KB av 3400 KB
- [x] `test/unit/server` + `test/integration` — **1183 pass / 0 fail**
- [x] 13 nya enhetstester i `expense-vat.test.ts`, 1 nytt i `expense-section.test.tsx`
- [x] `expense-section.test.tsx` i isolering — 10/10
- [x] Mot demons byggda data: **alla** utläggsrader är 0 % eller 25 %, och varje fakturas belopp = summan av dess rader (0 obalanserade)
- [x] Commits följer Conventional Commits

## Kvalitetsgrindar

- [x] Inga grindar lösgjorda
- [ ] **`src/lib/shared/schemas/` + `src/lib/server/db/schema.ts` är CODEOWNERS-markerade** — nytt fält `passThrough` + migrering `0021_expense_pass_through.sql`. Ändringen påverkar **beloppet på varje faktura som bär utlägg**; den förtjänar en extra genomläsning.

## Övrigt

**Sju befintliga tester ändrades**, alla för att de hävdade den gamla regeln — t.ex. `"domstolsfakturan får EN 25 %-utläggsrad; klientfakturan behåller 0 % och 6 %"`, som nu kräver samma behandling av båda. Ett test hade till och med det nya värdet i sin kommentar: `expect(r.expensesGrossOre).toBe(39750); // exakt per sats — INTE 40081 (platt 25 %)`. Det är 40081 nu.

**Seed-datat rättat:** ansökningsavgiften låg inkonsekvent på 0 % i två scenarier och 25 % i sex. Den är nu `passThrough: true` överallt — avgiften betalas i klientens namn, vilket är det typiska äkta utlägget. Säg till om den bedömningen är fel, så är det en enradsändring.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_