### PR TITLE
fix(accounting): kreditnotan speglar originalet post för post

### DIFF
--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -16,7 +16,7 @@
  */
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { accontoCreditAmounts, accontoSplit, deductAcconto } from "@/lib/shared/acconto-vat";
+import { accontoCreditAmounts, accontoCreditLines, accontoSplit, deductAcconto } from "@/lib/shared/acconto-vat";
 import type { VatBreakdownLine } from "@/lib/shared/accounting/semantic-voucher";
 import { assertBillingTransition, type BillingActionType } from "@/lib/shared/billing-flow";
 import { proposedAccontoOre } from "@/lib/shared/billing-proposal";
@@ -872,16 +872,17 @@ function buildCreditView(clientView: SettlementView, creditNetOre: number): Sett
  * Utbrutet så settleCoverage-handlern håller sig ≤8 i komplexitet.
  */
 /**
- * Kreditfakturans momsbelopp (#968), negativt som resten av krediten.
- *
- * INGEN `vatBreakdown` sätts: `buildPerRateRows` räknar brutto ur raderna och
- * filtrerar bort icke-positiva belopp, så negativa rader skulle tappas. Krediten
- * går därför via enkelrads-verifikatet, som hanterar tecknet via `amount < 0`.
- * En per-sats-kreditering kräver att verifikatbyggaren först lär sig negativa
- * rader — egen issue, inte en tyst halvmesyr här.
+ * Kreditfakturans moms + uppdelning (#977). Uppdelningen bärs med TECKEN, så
+ * verifikatet kan bokföra arvode, utlägg och varje momskonto för sig — en
+ * kreditnota ska spegla originalet post för post, inte klumpas till ett netto.
  */
-function creditVatOre(clientLines: VatBreakdownLine[], deductionOre: number): number {
-  return -accontoCreditAmounts(clientLines, deductionOre).vatOre;
+function creditPayload(clientLines: VatBreakdownLine[], deductionOre: number): {
+  vatOre: number; vatBreakdown: VatBreakdownLine[];
+} {
+  return {
+    vatOre: -accontoCreditAmounts(clientLines, deductionOre).vatOre,
+    vatBreakdown: accontoCreditLines(clientLines, deductionOre),
+  };
 }
 
 async function createClientSettlementInvoice(repos: Repositories, ctx: EmitCtx, orgId: OrganizationId, a: {
@@ -902,7 +903,7 @@ async function createClientSettlementInvoice(repos: Repositories, ctx: EmitCtx, 
         // intäkt och moms minus fakturans faktiska (#968). Förr räknades 25 % på
         // mellanskillnaden rakt av, vilket blir fel så snart fakturan bär utlägg
         // med andra satser — acontot är alltid 25 %.
-        vatOre: creditVatOre(a.clientLines, a.deductionOre),
+        ...creditPayload(a.clientLines, a.deductionOre),
         // #895: full spec (tidsspec + rättshjälpsavgift + avdragna aconton) → kredit-netto.
         settlementBreakdown: buildCreditView(a.clientView, clientNet),
         invoiceType: "CREDIT" as const, status: "SENT" as const,

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -37,6 +37,24 @@ import type { Repositories } from "../repositories/repositories";
 import { router, orgProcedure } from "../trpc";
 
 
+/**
+ * Kreditnotans moms + uppdelning: originalets, med omvända tecken (#977).
+ *
+ * En kreditnota ska spegla den faktura den avser post för post — samma konton,
+ * samma momssatser, motsatt riktning. Saknar originalet uppdelning (rader från
+ * före #782) speglar vi bara `vatOre`; då får verifikatet falla tillbaka på
+ * enkelrads-vägen precis som originalet gjorde.
+ */
+function mirroredCreditAmounts(original: Pick<Invoice, "vatOre" | "vatBreakdown">): Partial<Invoice> {
+  const lines = original.vatBreakdown ?? [];
+  return omitUndefined({
+    vatOre: original.vatOre == null ? undefined : -original.vatOre,
+    vatBreakdown: lines.length === 0
+      ? undefined
+      : lines.map((l) => ({ ...l, netOre: -l.netOre, vatOre: -l.vatOre })),
+  });
+}
+
 // ─── writeOff-helpers (ADR 0007) — håller mutationen under complexity ≤ 8 ──
 
 /** Avvisa avskrivning av en faktura som inte är utställd. Returnerar den smala fakturan. */
@@ -210,6 +228,11 @@ export const invoiceRouter = router({
           matterId: original.matterId,
           invoiceNumber: await repos.invoices.nextInvoiceNumber(ctx.orgId),
           amount: -original.amount,
+          // Kreditnotan speglar originalet POST FÖR POST (#977): samma konton och
+          // momssatser, omvända tecken. Förr bar den bara ett negativt belopp, så
+          // verifikatet fick gissa fram en 25 %-split av bruttot — fel för varje
+          // faktura med utlägg, äkta utlägg eller flera satser.
+          ...mirroredCreditAmounts(original),
           invoiceType: "CREDIT",
           status: "SENT", // kreditfaktura är "färdig" direkt
           invoiceDate: new Date(),

--- a/src/lib/shared/acconto-vat.ts
+++ b/src/lib/shared/acconto-vat.ts
@@ -125,3 +125,28 @@ export function accontoCreditAmounts(
   const acconto = accontoSplit(deductionGrossOre);
   return { netOre: acconto.netOre - sumNet(lines), vatOre: acconto.vatOre - sumVat(lines) };
 }
+
+/**
+ * Kreditfakturans momsuppdelning (#977) — med TECKEN, så verifikatet kan bokföra
+ * varje konto för sig.
+ *
+ * Krediteringen är skillnaden mellan två dokumentuppsättningar: acontona (som
+ * bokförde arvode + 25 % moms) och slutfakturans rader (som är vad klienten
+ * faktiskt skulle ha betalat). Uppdelningen är därför slutfakturans rader
+ * PLUS acontot med omvänt tecken.
+ *
+ * Poängen är att posterna kan gå åt OLIKA håll samtidigt: arvodesintäkten ska
+ * minska (acontot vänds) medan utläggsintäkten ska öka (utlägget fanns inte i
+ * acontot). Ett enda nettobelopp kan inte uttrycka det, och den gamla vägen
+ * klumpade därför hela intäktsvändningen på arvodeskontot.
+ */
+export function accontoCreditLines(
+  lines: readonly VatBreakdownLine[],
+  deductionGrossOre: number,
+): VatBreakdownLine[] {
+  const { netOre, vatOre } = accontoSplit(deductionGrossOre);
+  return [
+    ...lines,
+    { kind: "arvode", vatRate: ACCONTO_VAT_RATE, netOre: -netOre, vatOre: -vatOre },
+  ];
+}

--- a/src/lib/shared/accounting/semantic-voucher.ts
+++ b/src/lib/shared/accounting/semantic-voucher.ts
@@ -90,10 +90,30 @@ function semanticRow(role: VoucherRole, ore: number, debit: boolean): SemanticVo
   return { role, debit: debit ? ore : 0, credit: debit ? 0 : ore };
 }
 
-/** Per-sats-verifikat (#790): intäkt delas arvode/utlägg, moms per momskonto.
- *  Balans följer av att brutto = Σnetto + Σmoms ur samma breakdown.
- *  `kundfordranDebit` = positiv faktura (kreditfaktura vänder debet/kredit). */
-function buildPerRateRows(breakdown: VatBreakdownLine[], kundfordranDebit: boolean): SemanticVoucherRow[] {
+/**
+ * Rad där BELOPPETS TECKEN avgör sidan (#977): positivt belopp hamnar på rollens
+ * naturliga sida, negativt på den motsatta.
+ *
+ * Det är vad som gör kreditfakturor till samma kod som debetfakturor. Förr
+ * vändes HELA verifikatet med en global flagga, vilket bara fungerar när alla
+ * poster går åt samma håll. En kreditering av en slutfaktura gör inte det: den
+ * kan samtidigt MINSKA arvodesintäkten (acontot vänds) och ÖKA utläggsintäkten
+ * (utlägget fanns inte i acontot). Med ett globalt tecken går den nyansen
+ * förlorad och beloppen klumpas ihop på fel konton.
+ */
+function signedRow(role: VoucherRole, ore: number, naturalDebit: boolean): SemanticVoucherRow {
+  const onDebit = ore >= 0 ? naturalDebit : !naturalDebit;
+  return semanticRow(role, Math.abs(ore), onDebit);
+}
+
+/**
+ * Per-sats-verifikat (#790): intäkt delas arvode/utlägg, moms per momskonto.
+ * Balans följer av att brutto = Σnetto + Σmoms ur samma breakdown.
+ *
+ * Hanterar NEGATIVA rader (#977) — en kreditfaktura bär sin uppdelning med
+ * omvända tecken, precis som en kreditnota ska spegla originalet post för post.
+ */
+function buildPerRateRows(breakdown: VatBreakdownLine[]): SemanticVoucherRow[] {
   const arvodeNet = breakdown.filter((l) => l.kind === "arvode").reduce((s, l) => s + l.netOre, 0);
   const utlaggNet = breakdown.filter((l) => l.kind === "utlagg").reduce((s, l) => s + l.netOre, 0);
   const momsByRole = new Map<VoucherRole, number>();
@@ -103,11 +123,11 @@ function buildPerRateRows(breakdown: VatBreakdownLine[], kundfordranDebit: boole
   }
   const brutto = arvodeNet + utlaggNet + breakdown.reduce((s, l) => s + l.vatOre, 0);
   const rows = [
-    semanticRow("kundfordran", brutto, kundfordranDebit),
-    semanticRow("intaktArvode", arvodeNet, !kundfordranDebit),
-    semanticRow("intaktUtlagg", utlaggNet, !kundfordranDebit),
+    semanticRow("kundfordran", Math.abs(brutto), brutto >= 0),
+    signedRow("intaktArvode", arvodeNet, false),
+    signedRow("intaktUtlagg", utlaggNet, false),
   ];
-  for (const [role, ore] of momsByRole) rows.push(semanticRow(role, ore, !kundfordranDebit));
+  for (const [role, ore] of momsByRole) rows.push(signedRow(role, ore, false));
   return rows.filter((r) => r.debit > 0 || r.credit > 0);
 }
 
@@ -122,10 +142,11 @@ export function buildSemanticVoucher(
   invoice: SemanticVoucherInput,
   vatRate: VatRate = 2500,
 ): SemanticVoucher {
-  const kundfordranDebit = invoice.amount >= 0; // kreditfaktura vänder debet/kredit
+  // Per-sats-vägen läser tecknet ur RADERNA (#977); enkelrads-vägen har bara
+  // `amount` att gå på och behöver därför fortfarande den globala flaggan.
   const rows = invoice.vatBreakdown && invoice.vatBreakdown.length > 0
-    ? buildPerRateRows(invoice.vatBreakdown, kundfordranDebit)
-    : buildSingleRateRows(invoice, vatRate, kundfordranDebit);
+    ? buildPerRateRows(invoice.vatBreakdown)
+    : buildSingleRateRows(invoice, vatRate, invoice.amount >= 0);
 
   return {
     date: invoice.invoiceDate,
@@ -140,7 +161,16 @@ function voucherDescription(invoice: SemanticVoucherInput): string {
   return invoice.matterNumber ? `Ärende ${invoice.matterNumber} · ${faktura}` : faktura;
 }
 
-/** Enkel-rads-verifikat (äldre fakturor/fixtures): moms ur vatOre, annars split. */
+/**
+ * Enkel-rads-verifikat för fakturor UTAN uppdelning: äldre rader från före #782
+ * och testfixturer. Momsen tas ur `vatOre` när den finns, annars ur en split.
+ *
+ * `Math.min` nedan är en fallback för INKONSISTENT ÄLDRE DATA — den klipper
+ * momsen så verifikatet åtminstone balanserar. Den får inte tolkas som en
+ * generell garanti: fram till #977 gick kreditfakturor den här vägen, och då
+ * kunde klippningen tyst svälja en riktig momsvändning. Krediter bär numera en
+ * egen uppdelning och tar per-sats-vägen.
+ */
 function buildSingleRateRows(invoice: SemanticVoucherInput, vatRate: VatRate, kundfordranDebit: boolean): SemanticVoucherRow[] {
   const bruttoOre = Math.abs(invoice.amount);
   const momsOre = invoice.vatOre != null

--- a/test/unit/lib/shared/acconto-vat.test.ts
+++ b/test/unit/lib/shared/acconto-vat.test.ts
@@ -9,7 +9,7 @@
  */
 import { describe, it, expect } from "vitest-compat";
 
-import { accontoCreditAmounts, accontoSplit, deductAcconto } from "@/lib/shared/acconto-vat";
+import { accontoCreditAmounts, accontoCreditLines, accontoSplit, deductAcconto } from "@/lib/shared/acconto-vat";
 import type { VatBreakdownLine } from "@/lib/shared/accounting/semantic-voucher";
 
 const arvode = (netOre: number): VatBreakdownLine => ({ kind: "arvode", vatRate: 2500, netOre, vatOre: Math.round(netOre * 0.25) });
@@ -142,5 +142,35 @@ describe("accontoCreditAmounts", () => {
     expect(c).toEqual({ netOre: 6_000, vatOre: 4_000 });
     expect(c.netOre + c.vatOre).toBe(20_000 - 10_000);
     // Den gamla formeln (25 % av 10 000) hade gett 2 000 kr moms — 2 000 för lite.
+  });
+});
+
+describe("accontoCreditLines", () => {
+  it("summerar till kreditbeloppet — annars balanserar inte verifikatet", () => {
+    const lines = [arvode(400_000)];
+    const credit = accontoCreditLines(lines, 900_000);
+    const amounts = accontoCreditAmounts(lines, 900_000);
+    expect(gross(credit)).toBe(-(amounts.netOre + amounts.vatOre));
+  });
+
+  it("behåller fakturans rader och lägger acontot med OMVÄNT tecken", () => {
+    // Det är den enda formen som kan uttrycka att arvodesintäkten minskar
+    // samtidigt som utläggsintäkten ökar (#977).
+    const lines = [arvode(400_000), utlagg(80_000, 2500)];
+    expect(accontoCreditLines(lines, 900_000)).toEqual([
+      ...lines,
+      { kind: "arvode", vatRate: 2500, netOre: -720_000, vatOre: -180_000 },
+    ]);
+  });
+
+  it("äkta utlägg (0 %) förblir momsfritt i krediteringen", () => {
+    const credit = accontoCreditLines([utlagg(90_000, 0)], 100_000);
+    expect(credit[0]).toEqual({ kind: "utlagg", vatRate: 0, netOre: 90_000, vatOre: 0 });
+    expect(credit[1]).toEqual({ kind: "arvode", vatRate: 2500, netOre: -80_000, vatOre: -20_000 });
+  });
+
+  it("utan aconton är krediteringen noll — inget att vända", () => {
+    const credit = accontoCreditLines([arvode(400_000)], 0);
+    expect(gross(credit)).toBe(gross([arvode(400_000)]));
   });
 });

--- a/test/unit/server/routers/invoice.test.ts
+++ b/test/unit/server/routers/invoice.test.ts
@@ -676,6 +676,57 @@ describe("invoice.createCredit", () => {
     );
   });
 
+  it("kreditnotan speglar originalets moms + uppdelning post för post (#977)", async () => {
+    // En kreditnota ska träffa SAMMA konton och satser som fakturan den avser.
+    // Förr bar den bara ett negativt belopp, så verifikatet gissade fram en
+    // 25 %-split av bruttot — fel för varje faktura med utlägg eller flera satser.
+    mockPrisma.invoice.findFirst.mockImplementation((args?: { where?: Record<string, unknown> }) =>
+      args?.where?.creditedInvoiceId || args?.where?.invoiceNumber
+        ? null
+        : {
+            id: "inv-1", matterId: "m1", invoiceType: "STANDARD", status: "SENT",
+            amount: 11_800, vatOre: 1_800,
+            vatBreakdown: [
+              { kind: "arvode", vatRate: 2500, netOre: 4_000, vatOre: 1_000 },
+              { kind: "utlagg", vatRate: 1200, netOre: 5_000, vatOre: 600 },
+              { kind: "utlagg", vatRate: 600, netOre: 1_000, vatOre: 200 },
+            ],
+          });
+    mockPrisma.invoice.create.mockResolvedValue({ id: "credit-1" });
+    mockPrisma.invoice.update.mockResolvedValue({});
+
+    await makeCaller().createCredit({ invoiceId: "inv-1" });
+
+    expect(mockPrisma.invoice.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          amount: -11_800,
+          vatOre: -1_800,
+          vatBreakdown: [
+            { kind: "arvode", vatRate: 2500, netOre: -4_000, vatOre: -1_000 },
+            { kind: "utlagg", vatRate: 1200, netOre: -5_000, vatOre: -600 },
+            { kind: "utlagg", vatRate: 600, netOre: -1_000, vatOre: -200 },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("original utan uppdelning (rader från före #782) speglas utan att uppfinna en", async () => {
+    mockPrisma.invoice.findFirst.mockImplementation((args?: { where?: Record<string, unknown> }) =>
+      args?.where?.creditedInvoiceId || args?.where?.invoiceNumber
+        ? null
+        : { id: "inv-1", matterId: "m1", invoiceType: "STANDARD", status: "SENT", amount: 1000 });
+    mockPrisma.invoice.create.mockResolvedValue({ id: "credit-1" });
+    mockPrisma.invoice.update.mockResolvedValue({});
+
+    await makeCaller().createCredit({ invoiceId: "inv-1" });
+
+    const data = mockPrisma.invoice.create.mock.calls[0]![0].data as Record<string, unknown>;
+    expect(data.vatBreakdown).toBeUndefined();
+    expect(data.vatOre).toBeUndefined();
+  });
+
   it("avbryter aktiv avbetalningsplan när originalet krediteras", async () => {
     mockPrisma.invoice.findFirst.mockImplementation((args?: { where?: Record<string, unknown> }) =>
       args?.where?.creditedInvoiceId || args?.where?.invoiceNumber

--- a/test/unit/shared/accounting/semantic-voucher.test.ts
+++ b/test/unit/shared/accounting/semantic-voucher.test.ts
@@ -90,6 +90,72 @@ describe("buildSemanticVoucher", () => {
     expect(sum(v.rows, "debit")).toBe(sum(v.rows, "credit"));
   });
 
+  it("kreditnota med uppdelning: poster kan gå åt OLIKA håll samtidigt (#977)", () => {
+    // En slutfaktura krediteras för att acontona (9 000 brutto = 7 200 arvode
+    // + 1 800 moms) översteg klientens andel (4 000 arvode + 1 000 moms + 800
+    // utlägg + 200 moms). Arvodesintäkten ska MINSKA med 3 200 medan
+    // utläggsintäkten ska ÖKA med 800 — utlägget fanns inte i acontot.
+    //
+    // Förr vändes hela verifikatet med en global flagga, så nettot (−2 400)
+    // klumpades på arvodeskontot och `intaktUtlagg` rördes aldrig.
+    const v = buildSemanticVoucher({
+      amount: -3_000,
+      vatOre: -600,
+      vatBreakdown: [
+        { kind: "arvode", vatRate: 2500, netOre: 4_000, vatOre: 1_000 },
+        { kind: "utlagg", vatRate: 2500, netOre: 800, vatOre: 200 },
+        { kind: "arvode", vatRate: 2500, netOre: -7_200, vatOre: -1_800 },
+      ],
+      invoiceDate: "2026-05-25",
+    });
+    expect(byRole(v.rows, "kundfordran")).toEqual({ role: "kundfordran", debit: 0, credit: 3_000 });
+    expect(byRole(v.rows, "intaktArvode")).toEqual({ role: "intaktArvode", debit: 3_200, credit: 0 });
+    expect(byRole(v.rows, "intaktUtlagg")).toEqual({ role: "intaktUtlagg", debit: 0, credit: 800 });
+    expect(byRole(v.rows, "momsUtgaende")).toEqual({ role: "momsUtgaende", debit: 600, credit: 0 });
+    expect(sum(v.rows, "debit")).toBe(sum(v.rows, "credit"));
+  });
+
+  it("negativ uppdelning per sats: varje momskonto vänds för sig (#977)", () => {
+    // Ren spegling av en faktura med tre satser — kreditnotan ska träffa
+    // 2611/2621/2631 var för sig, inte klumpa allt på 25 %-kontot.
+    const v = buildSemanticVoucher({
+      amount: -11_800,
+      vatOre: -1_800,
+      vatBreakdown: [
+        { kind: "arvode", vatRate: 2500, netOre: -4_000, vatOre: -1_000 },
+        { kind: "utlagg", vatRate: 1200, netOre: -5_000, vatOre: -600 },
+        { kind: "utlagg", vatRate: 600, netOre: -1_000, vatOre: -200 },
+      ],
+      invoiceDate: "2026-05-25",
+    });
+    expect(byRole(v.rows, "momsUtgaende")).toEqual({ role: "momsUtgaende", debit: 1_000, credit: 0 });
+    expect(byRole(v.rows, "momsUtgaende12")).toEqual({ role: "momsUtgaende12", debit: 600, credit: 0 });
+    expect(byRole(v.rows, "momsUtgaende06")).toEqual({ role: "momsUtgaende06", debit: 200, credit: 0 });
+    expect(byRole(v.rows, "intaktUtlagg")).toEqual({ role: "intaktUtlagg", debit: 6_000, credit: 0 });
+    expect(sum(v.rows, "debit")).toBe(sum(v.rows, "credit"));
+  });
+
+  it("gränsfall: momsvändningen är STÖRRE än kreditbeloppet (#977)", () => {
+    // Klientandelen är ett momsfritt äkta utlägg (900) medan acontot bar 25 %
+    // (800 + 200). Krediten blir bara 100 kr, men 200 kr moms ska vändas och
+    // utläggsintäkten öka med 900. Enkelrads-vägens `Math.min`-klippning gav
+    // förr 100 kr moms och ingen intäktsrad alls.
+    const v = buildSemanticVoucher({
+      amount: -100,
+      vatOre: -200,
+      vatBreakdown: [
+        { kind: "utlagg", vatRate: 0, netOre: 900, vatOre: 0 },
+        { kind: "arvode", vatRate: 2500, netOre: -800, vatOre: -200 },
+      ],
+      invoiceDate: "2026-05-25",
+    });
+    expect(byRole(v.rows, "momsUtgaende")).toEqual({ role: "momsUtgaende", debit: 200, credit: 0 });
+    expect(byRole(v.rows, "intaktUtlagg")).toEqual({ role: "intaktUtlagg", debit: 0, credit: 900 });
+    expect(byRole(v.rows, "intaktArvode")).toEqual({ role: "intaktArvode", debit: 800, credit: 0 });
+    expect(byRole(v.rows, "kundfordran")).toEqual({ role: "kundfordran", debit: 0, credit: 100 });
+    expect(sum(v.rows, "debit")).toBe(sum(v.rows, "credit"));
+  });
+
   it("0 % moms: moms-raden släpps (2 rader kvar, fortf. balanserat)", () => {
     const v = buildSemanticVoucher({ amount: 10_000, invoiceDate: "2026-01-01" }, 0);
     expect(v.rows).toHaveLength(2);


### PR DESCRIPTION
## Vad & varför

En kreditnota ska träffa **samma konton och momssatser** som fakturan den avser, med omvänd riktning. `buildSemanticVoucher` vände i stället hela verifikatet med en global flagga:

```ts
const kundfordranDebit = invoice.amount >= 0; // kreditfaktura vänder debet/kredit
```

Det fungerar bara när alla poster går åt samma håll. En kreditering av en slutfaktura gör inte det: acontot ska vändas (arvodesintäkten **minskar**) samtidigt som utlägget ska bokföras (utläggsintäkten **ökar**) — utlägget fanns aldrig i acontot. Därför satte #968 medvetet ingen `vatBreakdown` på krediten; negativa rader hade ändå filtrerats bort.

Stänger #977

## Typ

- [x] `fix` — buggfix

## Före / efter

Aconton om 9 000 (7 200 arvode + 1 800 moms) mot en klientandel om 4 000 arvode + 800 utlägg:

| Konto | Före | Efter |
|---|---:|---:|
| `kundfordran` | kredit 3 000 | kredit 3 000 |
| `intaktArvode` | debet **2 400** | debet **3 200** |
| `intaktUtlagg` | — | **kredit 800** |
| `momsUtgaende` | debet 600 | debet 600 |

**Gränsfallet var värre.** Är klientandelen ett momsfritt äkta utlägg (900) medan acontot bar 25 % (800 + 200):

| Konto | Före | Efter |
|---|---:|---:|
| `kundfordran` | kredit 100 | kredit 100 |
| `intaktArvode` | — | debet 800 |
| `intaktUtlagg` | — | kredit 900 |
| `momsUtgaende` | debet **100** | debet **200** |

200 kr moms ska vändas. Enkelrads-vägens `Math.min`-klampning gav 100 och ingen intäktsrad alls — numeriskt balanserat, sakligt fel. Fallet blev nåbart först i och med #975, eftersom det kräver en momsfri rad på en faktura vars aconton bar 25 %.

## Ändringen

`signedRow` lägger positiva belopp på rollens naturliga sida och negativa på den motsatta; `buildPerRateRows` läser tecknet ur **raderna** i stället för ur en global flagga. Samma kod bygger därmed både debet- och kreditverifikat — ett specialfall försvinner i stället för att ett läggs till.

`accontoCreditLines` ger krediten dess uppdelning: slutfakturans rader plus acontot med omvänt tecken. Det är den enda formen som kan uttrycka att två intäktskonton rör sig åt olika håll i samma verifikat.

## En andra kreditväg som aldrig speglat något

`invoice.createCredit` skapade kreditnotan med enbart `amount: -original.amount` — **ingen `vatOre`, ingen `vatBreakdown`** — så verifikatet gissade fram en 25 %-split av bruttot. Fel för varje faktura med utlägg, äkta utlägg eller flera satser, och det är den kreditväg en jurist använder oftast. Den speglar nu originalet post för post.

## Verifierat lokalt (speglar CI)

- [x] `typecheck`, `lint` (`--max-warnings 0`), `lint:complexity-strict`, `knip`, `deps:check`, `jscpd` — rena
- [x] `test/unit/server` + `test/integration` — **1185 pass / 0 fail**
- [x] `test/unit/shared` 205/0 · `test/scripts` 164/0 · `test/unit/lib` 1046 pass / 43 fail (oförändrad baslinje, känd mock-läckage #92)
- [x] 4 nya tester i `semantic-voucher.test.ts` (blandade tecken, tre momssatser, gränsfallet), 4 i `acconto-vat.test.ts`, 2 i `invoice.test.ts`
- [x] `bun run build:demo` — demons **sex** kreditfakturor balanserar allihop. Den sammansatta (`F-2026-0045`, fyra rader med blandade tecken) fördelas nu på arvode, utlägg och momskonto var för sig:

```
F-2026-0045   belopp -6 900,38   moms -1 389,07   rader 4   Σ = -6 900,38 ✓
    arvode@2500  netto  4 225,73   moms  1 056,43
    utlagg@2500  netto     72,50   moms     18,13
    utlagg@0     netto     45,00   moms      0,00
    arvode@2500  netto -9 854,54   moms -2 463,63
```

## Kvalitetsgrindar

- [x] Inga grindar lösgjorda
- [ ] **`semantic-voucher.ts` är kärnan i all bokföring** — ändringen rör hur varje verifikat byggs, inte bara krediter. Testerna täcker båda tecknen, men den förtjänar en extra genomläsning.

## Övrigt

**`Math.min`-klampen är kvar**, men bara på enkelrads-vägen för äldre rader utan uppdelning — och dokumenterad som vad den är: en fallback för inkonsistent data, inte en garanti. Krediter tar inte längre den vägen. Jag valde att inte låta den kasta: den renderar historiska fakturor, och ett undantag där hade brutit visningen av gamla rader utan att rätta något.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_