### PR TITLE
fix(deps): ersätt html-to-docx med en egen DOCX-skrivare

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -55,12 +55,14 @@ jobs:
   # nivån dras BARA åt.
   #
   # 2026-08-09 (#966): nivån skärptes `critical` → `moderate` sedan 27 av 30
-  # kända sårbarheter arbetats bort via `overrides` i package.json. Grinden fäller
-  # nu på varje ny moderate, high eller critical — i BÅDA arbetsytorna.
+  # kända sårbarheter arbetats bort via `overrides` i package.json.
+  # 2026-08-09 (#970): `moderate` → `low` sedan `html-to-docx` ersatts av en egen
+  # DOCX-skrivare. Grinden fäller nu på VARJE ny sårbarhet, oavsett allvarsgrad,
+  # i båda arbetsytorna.
   #
   # Undantagen nedan är namngivna per advisory, inte en uppmjukad nivå. Var och en
   # kräver en rad med skäl; utan skäl ska raden bort och sårbarheten åtgärdas.
-  # `helper-ui` har INGA undantag och gatas därför på `low`.
+  # `helper-ui` har INGA undantag.
   audit:
     name: Sårbara beroenden (bun audit)
     runs-on: ubuntu-latest
@@ -69,19 +71,16 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: ./.github/actions/bun-setup
 
-      # image-size (2× high): html-to-docx › image-size. INGEN fixad version
-      #   finns — senaste publicerade (2.0.2) ligger själv i advisory-intervallet
-      #   `<=2.0.2`, och html-to-docx@1.8.0 (senaste) kräver ^1.0.0. Går bara att
-      #   bli av med genom att byta ut html-to-docx → #970.
       # esbuild (moderate): esbuild@0.18.20 låst av det AVSOMNADE
       #   @esbuild-kit/core-utils (`~0.18.20`) via drizzle-kit, vars senaste
       #   version fortfarande drar in det. Advisoryn gäller esbuilds
       #   UTVECKLINGSSERVER, som vi aldrig startar; paketet är dessutom devDep.
+      #
+      # (De två image-size-undantagen är BORTA sedan #970 — html-to-docx är
+      # ersatt av en egen DOCX-skrivare, så paketet finns inte längre i trädet.)
       - name: bun audit (roten)
         run: |
-          bun audit --audit-level=moderate \
-            --ignore GHSA-w3rx-r6r6-pgpr \
-            --ignore GHSA-5p2g-fcmc-qvqq \
+          bun audit --audit-level=low \
             --ignore GHSA-67mh-4wv8-2f99
 
       # helper-ui har egen lockfil och låg helt UTANFÖR grinden fram till #966 —

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,6 @@
         "clsx": "^2.1.1",
         "cron-parser": "^5.5.0",
         "handlebars": "^4.7.9",
-        "html-to-docx": "^1.8.0",
         "jose": "^6.2.3",
         "json-logic-js": "^2.0.5",
         "lucide-react": "^1.17.0",
@@ -375,14 +374,6 @@
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
 
-    "@oozcitak/dom": ["@oozcitak/dom@1.15.6", "", { "dependencies": { "@oozcitak/infra": "1.0.5", "@oozcitak/url": "1.0.0", "@oozcitak/util": "8.3.4" } }, "sha512-k4uEIa6DI3FCrFJMGq/05U/59WnS9DjME0kaPqBRCJAqBTkmopbYV1Xs4qFKbDJ/9wOg8W97p+1E0heng/LH7g=="],
-
-    "@oozcitak/infra": ["@oozcitak/infra@1.0.5", "", { "dependencies": { "@oozcitak/util": "8.0.0" } }, "sha512-o+zZH7M6l5e3FaAWy3ojaPIVN5eusaYPrKm6MZQt0DKNdgXa2wDYExjpP0t/zx+GoQgQKzLu7cfD8rHCLt8JrQ=="],
-
-    "@oozcitak/url": ["@oozcitak/url@1.0.0", "", { "dependencies": { "@oozcitak/infra": "1.0.3", "@oozcitak/util": "1.0.2" } }, "sha512-LGrMeSxeLzsdaitxq3ZmBRVOrlRRQIgNNci6L0VRnOKlJFuRIkNm4B+BObXPCJA6JT5bEJtrrwjn30jueHJYZQ=="],
-
-    "@oozcitak/util": ["@oozcitak/util@8.3.4", "", {}, "sha512-6gH/bLQJSJEg7OEpkH4wGQdA8KXHRbzL1YkGyUO12YNAgV3jxKy4K9kvfXj4+9T0OLug5k58cnPCKSSIKzp7pg=="],
-
     "@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.133.0", "", { "os": "android", "cpu": "arm" }, "sha512-l/44caGse+VpnY9gx0yvvc5QnnG3yG1FO3KZgYvNL1GZrfK86zIwAOgGEVlxDyRymzrU/KHiblPFpevKOmJmUA=="],
 
     "@oxc-parser/binding-android-arm64": ["@oxc-parser/binding-android-arm64@0.133.0", "", { "os": "android", "cpu": "arm64" }, "sha512-KUHmPMziLBp4u+zbrLdB7iWS7KshuZe+RAp7ELnY9SI9nNXBZ+dp8fiBqWOxhXqn+FQg3a4UcQhwmsJOKV8Jjg=="],
@@ -685,8 +676,6 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "browser-split": ["browser-split@0.0.1", "", {}, "sha512-JhvgRb2ihQhsljNda3BI8/UcRHVzrVwo3Q+P8vDtSiyobXuFpuZ9mq+MbRGMnC22CjW3RrfXdg6j6ITX8M+7Ow=="],
-
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
@@ -704,8 +693,6 @@
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
-
-    "camelize": ["camelize@1.0.1", "", {}, "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001797", "", {}, "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w=="],
 
@@ -809,16 +796,6 @@
 
     "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
-    "dom-serializer": ["dom-serializer@0.2.2", "", { "dependencies": { "domelementtype": "^2.0.1", "entities": "^2.0.0" } }, "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g=="],
-
-    "dom-walk": ["dom-walk@0.1.2", "", {}, "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="],
-
-    "domelementtype": ["domelementtype@1.3.1", "", {}, "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="],
-
-    "domhandler": ["domhandler@2.4.2", "", { "dependencies": { "domelementtype": "1" } }, "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA=="],
-
-    "domutils": ["domutils@1.7.0", "", { "dependencies": { "dom-serializer": "0", "domelementtype": "1" } }, "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg=="],
-
     "dot-prop": ["dot-prop@5.3.0", "", { "dependencies": { "is-obj": "^2.0.0" } }, "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q=="],
 
     "drizzle-kit": ["drizzle-kit@0.31.10", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "tsx": "^4.21.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw=="],
@@ -839,15 +816,11 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.24.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw=="],
 
-    "ent": ["ent@2.2.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "punycode": "^1.4.1", "safe-regex-test": "^1.1.0" } }, "sha512-kKvD1tO6BM+oK9HzCPpUdRb4vKFQY/FPTFmurMvh6LlN68VMrdj77w8yp51/kDbpkFOS9J8w5W6zIzgM2H8/hw=="],
-
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
-
-    "error": ["error@4.4.0", "", { "dependencies": { "camelize": "^1.0.0", "string-template": "~0.2.0", "xtend": "~4.0.0" } }, "sha512-SNDKualLUtT4StGFP7xNfuFybL2f6iJujFtrWuvJqGbVQGaN+adE23veqzPz1hjUjTunLi2EnJ+0SJxtbJreKw=="],
 
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
@@ -914,8 +887,6 @@
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
-
-    "ev-store": ["ev-store@7.0.0", "", { "dependencies": { "individual": "^3.0.0" } }, "sha512-otazchNRnGzp2YarBJ+GXKVGvhxVATB1zmaStxJBYet0Dyq7A9VhH8IUEB/gRcL6Ch52lfpgPTRJ2m49epyMsQ=="],
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
@@ -993,8 +964,6 @@
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
-    "global": ["global@4.4.0", "", { "dependencies": { "min-document": "^2.19.0", "process": "^0.11.10" } }, "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w=="],
-
     "global-directory": ["global-directory@4.0.1", "", { "dependencies": { "ini": "4.1.1" } }, "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q=="],
 
     "globals": ["globals@16.4.0", "", {}, "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw=="],
@@ -1029,14 +998,6 @@
 
     "hono": ["hono@4.13.1", "", {}, "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw=="],
 
-    "html-entities": ["html-entities@2.6.0", "", {}, "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ=="],
-
-    "html-to-docx": ["html-to-docx@1.8.0", "", { "dependencies": { "@oozcitak/dom": "1.15.6", "@oozcitak/util": "8.3.4", "color-name": "^1.1.4", "html-entities": "^2.3.3", "html-to-vdom": "^0.7.0", "image-size": "^1.0.0", "image-to-base64": "^2.2.0", "jszip": "^3.7.1", "lodash": "^4.17.21", "mime-types": "^2.1.35", "nanoid": "^3.1.25", "virtual-dom": "^2.1.1", "xmlbuilder2": "2.1.2" } }, "sha512-IiMBWIqXM4+cEsW//RKoonWV7DlXAJBmmKI73XJSVWTIXjGUaxSr2ck1jqzVRZknpvO8xsFnVicldKVAWrBYBA=="],
-
-    "html-to-vdom": ["html-to-vdom@0.7.0", "", { "dependencies": { "ent": "^2.0.0", "htmlparser2": "^3.8.2" } }, "sha512-k+d2qNkbx0JO00KezQsNcn6k2I/xSBP4yXYFLvXbcasTTDh+RDLUJS3puxqyNnpdyXWRHFGoKU7cRmby8/APcQ=="],
-
-    "htmlparser2": ["htmlparser2@3.10.1", "", { "dependencies": { "domelementtype": "^1.3.1", "domhandler": "^2.3.0", "domutils": "^1.5.1", "entities": "^1.1.1", "inherits": "^2.0.1", "readable-stream": "^3.1.1" } }, "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ=="],
-
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
@@ -1045,10 +1006,6 @@
 
     "ignore": ["ignore@7.0.6", "", {}, "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw=="],
 
-    "image-size": ["image-size@1.2.1", "", { "dependencies": { "queue": "6.0.2" }, "bin": { "image-size": "bin/image-size.js" } }, "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw=="],
-
-    "image-to-base64": ["image-to-base64@2.2.0", "", { "dependencies": { "node-fetch": "^2.6.0" } }, "sha512-Z+aMwm/91UOQqHhrz7Upre2ytKhWejZlWV/JxUTD1sT7GWWKFDJUEV5scVQKnkzSgPHFuQBUEWcanO+ma0PSVw=="],
-
     "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
@@ -1056,8 +1013,6 @@
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
-
-    "individual": ["individual@3.0.0", "", {}, "sha512-rUY5vtT748NMRbEMrTNiFfy29BgGZwGXUi2NFUVMWQrogSLzlJvQV9eeMWi+g1aVaQ53tpyLAQtd5x/JH0Nh1g=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
@@ -1112,8 +1067,6 @@
     "is-number-object": ["is-number-object@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw=="],
 
     "is-obj": ["is-obj@2.0.0", "", {}, "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="],
-
-    "is-object": ["is-object@1.0.2", "", {}, "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA=="],
 
     "is-path-inside": ["is-path-inside@4.0.0", "", {}, "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA=="],
 
@@ -1225,8 +1178,6 @@
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
-    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
-
     "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
@@ -1257,13 +1208,11 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
-    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
-    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
-
-    "min-document": ["min-document@2.19.2", "", { "dependencies": { "dom-walk": "^0.1.0" } }, "sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A=="],
 
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
@@ -1285,11 +1234,7 @@
 
     "next": ["next@16.2.12", "", { "dependencies": { "@next/env": "16.2.12", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.12", "@next/swc-darwin-x64": "16.2.12", "@next/swc-linux-arm64-gnu": "16.2.12", "@next/swc-linux-arm64-musl": "16.2.12", "@next/swc-linux-x64-gnu": "16.2.12", "@next/swc-linux-x64-musl": "16.2.12", "@next/swc-win32-arm64-msvc": "16.2.12", "@next/swc-win32-x64-msvc": "16.2.12", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-iD59eYQWmbFcEbX7v/acG5DRym9iw1DdaPoD0WTA920naWsE25wShzJW4+UvAs8MK9EC2kBfIH6vtto1H1PHGw=="],
 
-    "next-tick": ["next-tick@0.2.2", "", {}, "sha512-f7h4svPtl+QidoBv4taKXUjJ70G2asaZ8G28nS0OkqaalX8dwwrtWtyxEDPK62AC00ur/+/E0pUwBwY5EPn15Q=="],
-
     "node-exports-info": ["node-exports-info@1.6.0", "", { "dependencies": { "array.prototype.flatmap": "^1.3.3", "es-errors": "^1.3.0", "object.entries": "^1.1.9", "semver": "^6.3.1" } }, "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw=="],
-
-    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "node-releases": ["node-releases@2.0.47", "", {}, "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og=="],
 
@@ -1401,8 +1346,6 @@
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
-    "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
-
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
 
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
@@ -1414,8 +1357,6 @@
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
-
-    "queue": ["queue@6.0.2", "", { "dependencies": { "inherits": "~2.0.3" } }, "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
@@ -1537,8 +1478,6 @@
 
     "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
 
-    "string-template": ["string-template@0.2.1", "", {}, "sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw=="],
-
     "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "string.prototype.includes": ["string.prototype.includes@2.0.1", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.3" } }, "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg=="],
@@ -1586,8 +1525,6 @@
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
-
-    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
@@ -1641,17 +1578,11 @@
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
-    "virtual-dom": ["virtual-dom@2.1.1", "", { "dependencies": { "browser-split": "0.0.1", "error": "^4.3.0", "ev-store": "^7.0.0", "global": "^4.3.0", "is-object": "^1.0.1", "next-tick": "^0.2.2", "x-is-array": "0.1.0", "x-is-string": "0.1.0" } }, "sha512-wb6Qc9Lbqug0kRqo/iuApfBpJJAq14Sk1faAnSmtqXiwahg7PVTvWMs9L02Z8nNIMqbwsxzBAA90bbtRLbw0zg=="],
-
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
 
     "watskeburt": ["watskeburt@6.0.0", "", { "bin": { "watskeburt": "dist/run-cli.js" } }, "sha512-jfiuDABaxSkC71T6oZ3vCS99roYkSHm/+As+G0Dz8taAHQb+SJBvLEm5RlsgG71XdfAj3rv7eudUBTgwcQUPlQ=="],
 
-    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
-
     "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
-
-    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -1673,13 +1604,7 @@
 
     "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
-    "x-is-array": ["x-is-array@0.1.0", "", {}, "sha512-goHPif61oNrr0jJgsXRfc8oqtYzvfiMJpTqwE7Z4y9uH+T3UozkGqQ4d2nX9mB9khvA8U2o/UbPOFjgC7hLWIA=="],
-
-    "x-is-string": ["x-is-string@0.1.0", "", {}, "sha512-GojqklwG8gpzOVEVki5KudKNoq7MbbjYZCbyWzEz7tyPA7eleiE0+ePwOWQQRb5fm86rD3S8Tc0tSFf3AOv50w=="],
-
     "xmlbuilder": ["xmlbuilder@10.1.1", "", {}, "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg=="],
-
-    "xmlbuilder2": ["xmlbuilder2@2.1.2", "", { "dependencies": { "@oozcitak/dom": "1.15.5", "@oozcitak/infra": "1.0.5", "@oozcitak/util": "8.3.3" } }, "sha512-PI710tmtVlQ5VmwzbRTuhmVhKnj9pM8Si+iOZCV2g2SNo3gCrpzR2Ka9wNzZtqfD+mnP+xkrqoNy0sjKZqP4Dg=="],
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
@@ -1729,12 +1654,6 @@
 
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
-    "@oozcitak/infra/@oozcitak/util": ["@oozcitak/util@8.0.0", "", {}, "sha512-+9Hq6yuoq/3TRV/n/xcpydGBq2qN2/DEDMqNTG7rm95K6ZE2/YY/sPyx62+1n8QsE9O26e5M1URlXsk+AnN9Jw=="],
-
-    "@oozcitak/url/@oozcitak/infra": ["@oozcitak/infra@1.0.3", "", { "dependencies": { "@oozcitak/util": "1.0.1" } }, "sha512-9O2wxXGnRzy76O1XUxESxDGsXT5kzETJPvYbreO4mv6bqe1+YSuux2cZTagjJ/T4UfEwFJz5ixanOqB0QgYAag=="],
-
-    "@oozcitak/url/@oozcitak/util": ["@oozcitak/util@1.0.2", "", {}, "sha512-4n8B1cWlJleSOSba5gxsMcN4tO8KkkcvXhNWW+ADqvq9Xj+Lrl9uCa90GRpjekqQJyt84aUX015DG81LFpZYXA=="],
-
     "@swc/helpers/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@tailwindcss/node/enhanced-resolve": ["enhanced-resolve@5.22.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww=="],
@@ -1765,8 +1684,6 @@
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
 
-    "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
     "acorn-loose/acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-walk/acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
@@ -1784,12 +1701,6 @@
     "cliui/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "cosmiconfig-typescript-loader/jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
-
-    "dom-serializer/domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
-
-    "dom-serializer/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
-
-    "ent/punycode": ["punycode@1.4.1", "", {}, "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="],
 
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -1819,15 +1730,9 @@
 
     "espree/acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
-    "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "happy-dom/@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
-
-    "htmlparser2/entities": ["entities@1.1.2", "", {}, "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="],
-
-    "htmlparser2/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
@@ -1857,8 +1762,6 @@
 
     "safe-push-apply/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
-    "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
     "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
@@ -1877,17 +1780,11 @@
 
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
-    "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
     "which-builtin-type/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "wrap-ansi/string-width": ["string-width@8.2.1", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA=="],
-
-    "xmlbuilder2/@oozcitak/dom": ["@oozcitak/dom@1.15.5", "", { "dependencies": { "@oozcitak/infra": "1.0.5", "@oozcitak/url": "1.0.0", "@oozcitak/util": "8.0.0" } }, "sha512-L6v3Mwb0TaYBYgeYlIeBaHnc+2ZEaDSbFiRm5KmqZQSoBlbPlf+l6aIH/sD5GUf2MYwULw00LT7+dOnEuAEC0A=="],
-
-    "xmlbuilder2/@oozcitak/util": ["@oozcitak/util@8.3.3", "", {}, "sha512-Ufpab7G5PfnEhQyy5kDg9C8ltWJjsVT1P/IYqacjstaqydG4Q21HAT2HUZQYBrC/a1ZLKCz87pfydlDvv8y97w=="],
 
     "@commitlint/config-validator/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -1943,15 +1840,11 @@
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
-    "@oozcitak/url/@oozcitak/infra/@oozcitak/util": ["@oozcitak/util@1.0.1", "", {}, "sha512-dFwFqcKrQnJ2SapOmRD1nQWEZUtbtIy9Y6TyJquzsalWNJsKIPxmTI0KG6Ypyl8j7v89L2wixH9fQDNrF78hKg=="],
-
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "@types/nodemailer/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "@types/ws/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
-
-    "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -1963,17 +1856,11 @@
 
     "eslint-plugin-import/tsconfig-paths/json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
 
-    "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
-
     "happy-dom/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
-
-    "htmlparser2/readable-stream/string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
     "log-update/slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "log-update/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
-
-    "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "tsconfig-paths-webpack-plugin/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -2030,11 +1917,5 @@
     "tsx/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
 
     "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
-
-    "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
-
-    "xmlbuilder2/@oozcitak/dom/@oozcitak/util": ["@oozcitak/util@8.0.0", "", {}, "sha512-+9Hq6yuoq/3TRV/n/xcpydGBq2qN2/DEDMqNTG7rm95K6ZE2/YY/sPyx62+1n8QsE9O26e5M1URlXsk+AnN9Jw=="],
-
-    "htmlparser2/readable-stream/string_decoder/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
   }
 }

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -49,7 +49,7 @@ lever som JSON i ett git-repo (se [`architecture.md`](./architecture.md)).
 | Arkitektur (SOLID/lager) | dependency-cruiser | `tooling/config/dependency-cruiser.cjs` |
 | Död kod / oanvända exports | knip | `tooling/config/knip.json` |
 | Säkerhet (SAST) | CodeQL (JS/TS) — `dependency-review` kräver GHAS, ej möjlig (#915) | `.github/workflows/security.yml` |
-| Sårbara beroenden (CVE) | `bun audit` + ratchet — roten `moderate`, `helper-ui` `low` | `.github/workflows/security.yml`, `overrides` i båda `package.json` |
+| Sårbara beroenden (CVE) | `bun audit` + ratchet — `low` i båda arbetsytorna | `.github/workflows/security.yml`, `overrides` i båda `package.json` |
 | Beroende-uppdateringar | Dependabot (npm + github-actions) | `.github/dependabot.yml` |
 | Pre-commit | husky + lint-staged | `.husky/pre-commit`, `package.json` |
 | CI | GitHub Actions (DRY toolchain-composite) | `.github/workflows/`, `.github/actions/bun-setup/` |
@@ -202,7 +202,7 @@ på loopback (`127.0.0.1:48761` / `localhost:48762`). Lägg nya demo-specar unde
 
 | Arbetsyta | `--audit-level` | Undantag |
 |---|---|---|
-| roten | `moderate` | 3 namngivna advisories (se nedan) |
+| roten | `low` | 1 namngiven advisory (se nedan) |
 | `helper-ui` | `low` | inga |
 
 Transitiva sårbarheter åtgärdas med **`overrides` i `package.json`**, inte genom
@@ -215,9 +215,15 @@ motiveras i kommentaren.
 
 Undantag skrivs som `--ignore <GHSA-id>` med ett skäl i workflowen — aldrig som
 en sänkt nivå. Ett undantag är legitimt bara när **ingen fixad version finns
-uppströms** eller när advisoryn bevisligen inte gäller vår användning. De tre
-nuvarande (två `image-size` utan fix alls, en `esbuild` som rör en dev-server vi
-aldrig startar) är dokumenterade i `security.yml`.
+uppströms** eller när advisoryn bevisligen inte gäller vår användning. Det enda
+nuvarande — `esbuild`, vars advisory rör en dev-server vi aldrig startar — är
+dokumenterat i `security.yml`.
+
+Går undantaget inte att motivera är svaret att ta bort BEROENDET. `html-to-docx`
+drog in ~13 transitiva paket — bl.a. `lodash`, `virtual-dom` och `image-size` med
+två high-CVE:er utan fix uppströms — för att rendera tre HTML-element i
+seed-datat. Det ersattes av `tooling/scripts/docx.ts`, ~120 rader OOXML (#970).
+Att äga lite kod är ibland billigare än att äga en beroendekedja.
 
 ### Arkitektur (`bun run deps:check`)
 

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "clsx": "^2.1.1",
     "cron-parser": "^5.5.0",
     "handlebars": "^4.7.9",
-    "html-to-docx": "^1.8.0",
     "jose": "^6.2.3",
     "json-logic-js": "^2.0.5",
     "lucide-react": "^1.17.0",

--- a/test/scripts/docx.test.ts
+++ b/test/scripts/docx.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Minimal DOCX-skrivare (#970) — ersatte `html-to-docx` och dess ~13 transitiva
+ * paket, däribland `image-size` med två high-CVE:er utan fix uppströms.
+ *
+ * När man äger filformatet själv räcker det inte att testa att funktionen
+ * returnerar bytes. Två saker måste hålla:
+ *
+ *   1. Filen ska vara en GILTIG ZIP med rätt delar — annars vägrar Word öppna den.
+ *   2. Innehållet ska gå att LÄSA TILLBAKA. Round-tripen går genom `mammoth`,
+ *      samma bibliotek som AVA själv extraherar DOCX-text med (`extract-text.ts`),
+ *      så testet bevisar att appen kan läsa det seeden skriver.
+ */
+import { describe, it, expect } from "vitest-compat";
+
+import { buildDocx, buildSimpleDocx, crc32, documentXml, escapeXml, zipStore } from "../../tooling/scripts/docx";
+
+/** Läs en ZIP-post ur bytes — bara det testet behöver (store-only, ingen inflate). */
+function readZipNames(bytes: Uint8Array): string[] {
+  const names: string[] = [];
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  for (let i = 0; i < bytes.length - 4; i++) {
+    if (view.getUint32(i, true) !== 0x04034b50) continue; // local file header
+    const nameLen = view.getUint16(i + 26, true);
+    names.push(new TextDecoder().decode(bytes.subarray(i + 30, i + 30 + nameLen)));
+  }
+  return names;
+}
+
+describe("crc32", () => {
+  it("matchar den kända checksumman för 'The quick brown fox jumps over the lazy dog'", () => {
+    // Referensvärde ur ZIP-/PNG-specarnas standardtestvektor. Fel CRC → Word
+    // säger att filen är skadad, och det syns inte förrän någon öppnar den.
+    const bytes = new TextEncoder().encode("The quick brown fox jumps over the lazy dog");
+    expect(crc32(bytes)).toBe(0x414fa339);
+  });
+
+  it("tom indata ger 0", () => {
+    expect(crc32(new Uint8Array(0))).toBe(0);
+  });
+});
+
+describe("escapeXml", () => {
+  it("escapar alla fem XML-tecknen", () => {
+    expect(escapeXml(`<a href="x">&'</a>`))
+      .toBe("&lt;a href=&quot;x&quot;&gt;&amp;&apos;&lt;/a&gt;");
+  });
+
+  it("escapar & FÖRST — annars dubbelescapas de andra", () => {
+    // Fel ordning ger "&amp;lt;" i stället för "&lt;".
+    expect(escapeXml("<")).toBe("&lt;");
+    expect(escapeXml("&lt;")).toBe("&amp;lt;");
+  });
+
+  it("rör inte svenska tecken (de bärs som UTF-8, inte entiteter)", () => {
+    expect(escapeXml("å ä ö Å Ä Ö")).toBe("å ä ö Å Ä Ö");
+  });
+});
+
+describe("documentXml", () => {
+  it("lägger fet stil och storlek som DIREKTformatering", () => {
+    const xml = documentXml([{ text: "Rubrik", bold: true, sizeHalfPoints: 36 }]);
+    expect(xml).toContain("<w:b/>");
+    expect(xml).toContain('<w:sz w:val="36"/>');
+  });
+
+  it("stycke utan formatering får ingen tom rPr", () => {
+    expect(documentXml([{ text: "Brödtext" }])).not.toContain("<w:rPr>");
+  });
+
+  it("bevarar blanksteg (xml:space) — annars äter Word dem", () => {
+    expect(documentXml([{ text: "  indraget" }])).toContain('xml:space="preserve"');
+  });
+
+  it("escapar styckets text", () => {
+    expect(documentXml([{ text: "Ärende <A & B>" }])).toContain("Ärende &lt;A &amp; B&gt;");
+  });
+});
+
+describe("zipStore", () => {
+  it("skriver en läsbar central directory med alla poster", () => {
+    const zip = zipStore([{ name: "a.xml", content: "<a/>" }, { name: "b/c.xml", content: "<c/>" }]);
+    expect(readZipNames(zip)).toEqual(["a.xml", "b/c.xml"]);
+  });
+
+  it("är deterministisk — samma indata ger byte-identisk utdata", () => {
+    // Fast tidsstämpel i posterna. Utan den skulle varje seed-körning ge nya
+    // bytes i `out/`, vilket bryter reproducerbara byggen.
+    const a = zipStore([{ name: "x.xml", content: "<x/>" }]);
+    const b = zipStore([{ name: "x.xml", content: "<x/>" }]);
+    expect(Array.from(a)).toEqual(Array.from(b));
+  });
+});
+
+describe("buildDocx", () => {
+  it("innehåller exakt de tre delar en .docx måste ha", () => {
+    expect(readZipNames(buildDocx([{ text: "hej" }]))).toEqual([
+      "[Content_Types].xml", "_rels/.rels", "word/document.xml",
+    ]);
+  });
+});
+
+describe("buildSimpleDocx — round-trip genom AVA:s egen DOCX-läsare", () => {
+  /** Samma bibliotek som `extract-text.ts` använder för docx. */
+  async function readBack(bytes: Uint8Array): Promise<string> {
+    const mammoth = await import("mammoth");
+    const res = await mammoth.extractRawText({ buffer: Buffer.from(bytes) });
+    return res.value;
+  }
+
+  it("texten kommer ut igen — rubrik, underrubrik och brödtext", async () => {
+    const bytes = buildSimpleDocx({ title: "Dom från tingsrätten", heading: "Dokument", body: "Brödtext." });
+    const text = await readBack(bytes);
+    expect(text).toContain("Dom från tingsrätten");
+    expect(text).toContain("Dokument");
+    expect(text).toContain("Brödtext.");
+  });
+
+  it("svenska tecken överlever hela vägen", async () => {
+    // UTF-8 i XML → ZIP → mammoth. Går encodingen fel syns det just här.
+    const bytes = buildSimpleDocx({ title: "Å", heading: "Ä", body: "å, ä, ö, Å, Ä, Ö" });
+    expect(await readBack(bytes)).toContain("å, ä, ö, Å, Ä, Ö");
+  });
+
+  it("XML-farliga tecken kommer tillbaka som sig själva, inte som entiteter", async () => {
+    // Escapningen ska vara osynlig för läsaren. Läcker den igenom ser klienten
+    // "&amp;" i dokumentet.
+    const body = `Kärande <A & B> sa "nej" — 5 > 3`;
+    const text = await readBack(buildSimpleDocx({ title: "T", heading: "H", body }));
+    expect(text).toContain(body);
+  });
+
+  it("tom brödtext kraschar inte", async () => {
+    expect(await readBack(buildSimpleDocx({ title: "T", heading: "H", body: "" }))).toContain("T");
+  });
+});

--- a/tooling/scripts/docx.ts
+++ b/tooling/scripts/docx.ts
@@ -1,0 +1,184 @@
+/**
+ * Minimal DOCX-skrivare för seed-dokumenten (#970).
+ *
+ * ## Varför den här finns
+ *
+ * Seed-datat genererade DOCX via `html-to-docx`. Det paketet drar in ~13
+ * transitiva beroenden — bl.a. `lodash`, `virtual-dom`, `jszip` och
+ * `image-size` — varav det sista har TVÅ high-CVE:er som saknar fix uppströms:
+ * senast publicerade `image-size` (2.0.2) ligger själv i advisory-intervallet, och
+ * `html-to-docx` kräver `^1.0.0`. De blockerade `bun audit`-grindens ratchet.
+ *
+ * AVA:s enda DOCX-generering är den här: en FAST mall (rubrik, underrubrik,
+ * brödtext) som vi själva bygger strängen till. Inga bilder, ingen användar-HTML.
+ * `image-size` var alltså aldrig nåbar hos oss — men den fanns i trädet ändå.
+ *
+ * Att äga ~120 rader OOXML är billigare än att äga den beroendekedjan.
+ *
+ * ## Vad en .docx är
+ *
+ * En ZIP med tre delar: `[Content_Types].xml` (vad filerna innehåller),
+ * `_rels/.rels` (var huvuddokumentet ligger) och `word/document.xml` (innehållet).
+ * Vi lagrar OKOMPRIMERAT (metod 0) — giltig ZIP, och Word bryr sig inte. Det gör
+ * skrivaren beroendefri: ingen zlib, bara CRC-32 och rätt headers.
+ *
+ * Formateringen är DIREKT (fet + storlek på runs) i stället för namngivna stilar,
+ * så vi slipper en `styles.xml` att hålla i synk för tre rubriknivåer.
+ */
+
+/** Fast tidsstämpel i ZIP-posterna → byte-stabil `out/` mellan seed-körningar. */
+const DOS_TIME = 0; // 00:00:00
+const DOS_DATE = ((2026 - 1980) << 9) | (1 << 5) | 1; // 2026-01-01
+
+const enc = new TextEncoder();
+
+// ── CRC-32 ────────────────────────────────────────────────────────────────
+const CRC_TABLE = ((): Uint32Array => {
+  const table = new Uint32Array(256);
+  for (let i = 0; i < 256; i++) {
+    let c = i;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    table[i] = c >>> 0;
+  }
+  return table;
+})();
+
+export function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const b of bytes) crc = (CRC_TABLE[(crc ^ b) & 0xff] ?? 0) ^ (crc >>> 8);
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+// ── XML ───────────────────────────────────────────────────────────────────
+
+/** Escapa text för XML. `&` först — annars dubbelescapas de andra. */
+export function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;").replace(/'/g, "&apos;");
+}
+
+const XML_HEAD = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+
+const CONTENT_TYPES = `${XML_HEAD}
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+<Default Extension="xml" ContentType="application/xml"/>
+<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`;
+
+const ROOT_RELS = `${XML_HEAD}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`;
+
+/** Ett stycke. `sizeHalfPoints`: Word mäter i halva punkter (28 = 14 pt). */
+export interface DocxParagraph {
+  text: string;
+  bold?: boolean;
+  /** Utelämnad → dokumentets standardstorlek. */
+  sizeHalfPoints?: number;
+}
+
+function paragraphXml(p: DocxParagraph): string {
+  const props = [
+    p.bold === true ? "<w:b/>" : "",
+    p.sizeHalfPoints === undefined ? "" : `<w:sz w:val="${p.sizeHalfPoints}"/><w:szCs w:val="${p.sizeHalfPoints}"/>`,
+  ].join("");
+  const rPr = props === "" ? "" : `<w:rPr>${props}</w:rPr>`;
+  // `xml:space="preserve"` — annars äter Word inledande/avslutande blanksteg.
+  return `<w:p><w:r>${rPr}<w:t xml:space="preserve">${escapeXml(p.text)}</w:t></w:r></w:p>`;
+}
+
+export function documentXml(paragraphs: readonly DocxParagraph[]): string {
+  return `${XML_HEAD}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+<w:body>${paragraphs.map(paragraphXml).join("")}<w:sectPr/></w:body>
+</w:document>`;
+}
+
+// ── ZIP (store-only) ──────────────────────────────────────────────────────
+
+interface ZipEntry { name: string; bytes: Uint8Array; crc: number; offset: number }
+
+/** Little-endian-skrivare — ZIP-formatet är LE genomgående. */
+function le(values: ReadonlyArray<[bytes: 2 | 4, value: number]>): Uint8Array {
+  const size = values.reduce((s, [n]) => s + n, 0);
+  const out = new Uint8Array(size);
+  const view = new DataView(out.buffer);
+  let at = 0;
+  for (const [n, v] of values) {
+    if (n === 2) view.setUint16(at, v, true);
+    else view.setUint32(at, v >>> 0, true);
+    at += n;
+  }
+  return out;
+}
+
+function localHeader(name: Uint8Array, crc: number, size: number): Uint8Array {
+  return concat([
+    le([[4, 0x04034b50], [2, 20], [2, 0x0800], [2, 0], [2, DOS_TIME], [2, DOS_DATE],
+      [4, crc], [4, size], [4, size], [2, name.length], [2, 0]]),
+    name,
+  ]);
+}
+
+function centralHeader(e: ZipEntry, name: Uint8Array): Uint8Array {
+  return concat([
+    le([[4, 0x02014b50], [2, 20], [2, 20], [2, 0x0800], [2, 0], [2, DOS_TIME], [2, DOS_DATE],
+      [4, e.crc], [4, e.bytes.length], [4, e.bytes.length],
+      [2, name.length], [2, 0], [2, 0], [2, 0], [2, 0], [4, 0], [4, e.offset]]),
+    name,
+  ]);
+}
+
+function concat(parts: ReadonlyArray<Uint8Array>): Uint8Array {
+  const out = new Uint8Array(parts.reduce((s, p) => s + p.length, 0));
+  let at = 0;
+  for (const p of parts) { out.set(p, at); at += p.length; }
+  return out;
+}
+
+/**
+ * Bygg en okomprimerad ZIP. Flaggan `0x0800` markerar UTF-8-namn — våra namn är
+ * rena ASCII, men flaggan är gratis och gör formatet entydigt.
+ */
+export function zipStore(files: ReadonlyArray<{ name: string; content: string }>): Uint8Array {
+  const local: Uint8Array[] = [];
+  const entries: ZipEntry[] = [];
+  let offset = 0;
+  for (const f of files) {
+    const bytes = enc.encode(f.content);
+    const name = enc.encode(f.name);
+    const crc = crc32(bytes);
+    const header = localHeader(name, crc, bytes.length);
+    local.push(header, bytes);
+    entries.push({ name: f.name, bytes, crc, offset });
+    offset += header.length + bytes.length;
+  }
+  const central = entries.map((e) => centralHeader(e, enc.encode(e.name)));
+  const centralSize = central.reduce((s, c) => s + c.length, 0);
+  const eocd = le([[4, 0x06054b50], [2, 0], [2, 0], [2, entries.length], [2, entries.length],
+    [4, centralSize], [4, offset], [2, 0]]);
+  return concat([...local, ...central, eocd]);
+}
+
+// ── Publik yta ────────────────────────────────────────────────────────────
+
+/** Bygg en .docx av stycken. Returnerar filens bytes. */
+export function buildDocx(paragraphs: readonly DocxParagraph[]): Uint8Array {
+  return zipStore([
+    { name: "[Content_Types].xml", content: CONTENT_TYPES },
+    { name: "_rels/.rels", content: ROOT_RELS },
+    { name: "word/document.xml", content: documentXml(paragraphs) },
+  ]);
+}
+
+/** Seed-dokumentets standardform: rubrik, underrubrik, brödtext. */
+export function buildSimpleDocx(a: { title: string; heading: string; body: string }): Uint8Array {
+  return buildDocx([
+    { text: a.title, bold: true, sizeHalfPoints: 36 },   // 18 pt
+    { text: a.heading, bold: true, sizeHalfPoints: 24 }, // 12 pt
+    { text: a.body },
+  ]);
+}

--- a/tooling/scripts/seed-data.ts
+++ b/tooling/scripts/seed-data.ts
@@ -25,6 +25,7 @@ import {
   type PaymentPlanStatus,
   type UserRole,
 } from "@/lib/shared/schemas";
+import { buildSimpleDocx } from "./docx";
 
 export const ORG_ID = "firma-ab";
 
@@ -938,24 +939,11 @@ export async function generateDocumentBytes(doc: {
     return pdf.save();
   }
 
-  // DOCX via html-to-docx. Paketet skeppar inga typings (otypat 3rd-party,
-  // endast build-time). Vi typar destruktureringen explicit (ingen `any`, ingen
-  // cast) och låter ETT smalt @ts-expect-error svälja TS7016 på importen — en
-  // ambient `declare module` skuggas under moduleResolution:bundler och en
-  // tsconfig-`paths` skulle bryta runtime-resolven (bun följer paths).
-  type HtmlToDocx = (
-    html: string,
-    headerHtml?: string | null,
-    options?: { table?: { row?: { cantSplit?: boolean } } } & Record<string, unknown>,
-  ) => Promise<Buffer>;
-  // @ts-expect-error — html-to-docx saknar .d.ts; default-exporten är callable.
-  const { default: htmlToDocx }: { default: HtmlToDocx } = await import("html-to-docx");
-  const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>${escapeXml(title)}</title></head>` +
-    `<body><h1>${escapeXml(title)}</h1><h2>${escapeXml(heading)}</h2><p>${escapeXml(body)}</p></body></html>`;
-  const buf = await htmlToDocx(html, undefined, { table: { row: { cantSplit: true } } });
-  // html-to-docx returnerar Buffer i Node. Buffer extends Uint8Array men
-  // TS-typerna är inte 1:1 — kopiera bytes över en ny Uint8Array.
-  return Uint8Array.from(buf);
+  // DOCX via egen minimal skrivare (#970). Ersatte `html-to-docx`, som drog in
+  // ~13 transitiva paket för att rendera tre element — däribland `image-size`
+  // med två high-CVE:er utan fix uppströms. Vår enda DOCX-väg är den här fasta
+  // mallen: inga bilder, ingen användar-HTML, så beroendet bar bara risk.
+  return buildSimpleDocx({ title, heading, body });
 }
 
 function wrapText(text: string, maxChars: number): string[] {
@@ -972,15 +960,6 @@ function wrapText(text: string, maxChars: number): string[] {
   }
   if (cur) lines.push(cur);
   return lines;
-}
-
-function escapeXml(s: string): string {
-  return s.replace(/[<>&"']/g, (c) => (
-    c === "<" ? "&lt;" :
-    c === ">" ? "&gt;" :
-    c === "&" ? "&amp;" :
-    c === '"' ? "&quot;" : "&apos;"
-  ));
 }
 
 /**


### PR DESCRIPTION
## Vad & varför

Issuens första punkt var *"kartlägg vilka DOCX-vägar som faktiskt bäddar in bilder — kanske ingen"*. Svaret visade sig avgöra hela valet.

`html-to-docx` används på **ett enda ställe**: `generateDocumentBytes` i seed-datat, med en **fast mall** (rubrik, underrubrik, brödtext) vars HTML vi själva bygger strängen till. Inga bilder, ingen användar-HTML. `image-size` var alltså aldrig nåbar hos oss — men fanns i trädet ändå och blockerade grindens ratchet.

För det drog paketet in **~13 transitiva beroenden**: `lodash`, `virtual-dom`, `jszip`, `xmlbuilder2`, `html-to-vdom`, `@oozcitak/dom`, `@oozcitak/util`, `html-entities`, `image-to-base64`, `color-name`, `mime-types`, `nanoid` och `image-size`.

Stänger #970

## Typ

- [x] `fix` — buggfix
- [x] `refactor` / `perf`

## Ändringen

`tooling/scripts/docx.ts` skriver formatet direkt — ~120 rader:

- Tre XML-delar (`[Content_Types].xml`, `_rels/.rels`, `word/document.xml`) i en **okomprimerad** ZIP (metod 0 — giltigt ZIP, och Word bryr sig inte). Det gör skrivaren beroendefri: ingen zlib, bara CRC-32 och rätt headers.
- **Direktformatering** (fet + storlek på runs) i stället för namngivna stilar, så vi slipper en `styles.xml` att hålla i synk.
- **Fast tidsstämpel** i ZIP-posterna → byte-stabil seed-utdata mellan körningar.

## Verifierat — inte bara att den returnerar bytes

När man äger filformatet själv räcker det inte att kolla att funktionen svarar. Tre oberoende kontroller:

1. **`unzip -l` och Pythons `zipfile.testzip()`** accepterar filen (`testzip() → None`, tre poster).
2. **Round-trip genom `mammoth`** — samma bibliotek som `extract-text.ts` använder för DOCX. Testet bevisar alltså att *appen kan läsa det seeden skriver*, inte bara att bytes finns.
3. **Alla 20 DOCX-dokument i `buildSeed`** genererade och lästa tillbaka: `20/20` med rätt titel.

```
exempel: Stämningsansökan 2026-0001.docx  1711 bytes
text: "Stämningsansökan 2026-0001\n\nStämningsansökan\n\nStämningsansökan för
       ärende 2026-0001 — Vårdnadstvist Andersson. … svenska tecken"
```

Testerna täcker också CRC-32 mot standardtestvektorn (`0x414fa339`), att `&` escapas **först** (annars dubbelescapas resten), att svenska tecken bärs som UTF-8 och att XML-farliga tecken kommer tillbaka som sig själva.

## Grinden dras åt igen

Med `image-size` borta finns **en** sårbarhet kvar i hela rot-trädet:

```
esbuild <=0.24.2   drizzle-kit › esbuild   moderate (dev-server, dev-only)
1 vulnerabilities (1 moderate)
```

Den är redan undantagen per GHSA-id, så audit-grinden går från `moderate` till **`low`** — samma nivå som `helper-ui`. Den fäller nu på **varje** ny sårbarhet oavsett allvarsgrad, i båda arbetsytorna. De två `image-size`-undantagen är borttagna.

Ratchet-historik: `critical` (#966 utgångsläge) → `moderate` (#966) → **`low`** (denna).

## Verifierat lokalt (speglar CI)

- [x] `typecheck`, `lint` (`--max-warnings 0`), `lint:complexity-strict`, `knip`, `deps:check`, `jscpd` — rena
- [x] `bun run build:demo` + `bun run size` — 1169,7 KB av 3400 KB
- [x] `test/unit/server` + `test/integration` — **1185 pass / 0 fail**
- [x] `test/scripts` 180/0 (16 nya i `docx.test.ts`) · `test/unit/shared` 205/0 · `test/unit/lib/jobs` 42/0
- [x] `test/unit/lib` 1046 pass / 43 fail — oförändrad baslinje (känd mock-läckage, #92)
- [x] Grind-kommandot kört exakt som workflowen kör det → exit 0

## Kvalitetsgrindar

- [x] **Ingen grind lösgjord — grinden dras åt** (`moderate` → `low`)
- [x] Inget nytt beroende tillagt; ett borttaget

## Övrigt

**Om alternativvalet.** Issuen listade tre vägar: byta till `docx` (dolanmiu), egen writer, eller shimma bort `image-size`. Kartläggningen gjorde valet enkelt — en fast mall utan bilder motiverar inte ett nytt runtime-beroende, och en shim hade betytt att vi äger en fejkad `image-size` i stället för den kod vi faktiskt behöver.

**Demon påverkas inte.** `build:demo` genererar bara PDF (simulatorn hårdkodar `application/pdf`); DOCX-vägen används av `seed-firma-local` för self-hosted. Båda verifierade.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_