### PR TITLE
feat(time): visa DVFS 2025:4:s tillämpningsregler vid kategorivalet

### DIFF
--- a/src/app/matters/[id]/_time-section.tsx
+++ b/src/app/matters/[id]/_time-section.tsx
@@ -35,6 +35,24 @@ interface EditForm {
 /** Kategorierna i dropdown-ordning — härledd ur labels-kartan (single source). */
 const KIND_OPTIONS = Object.entries(TIME_ENTRY_KIND_LABELS) as Array<[TimeEntryKind, string]>;
 
+/**
+ * Föreskriftens tillämpningsregler, visade VID kategorivalet (#969).
+ *
+ * DVFS 2025:4 avgränsar när tidsspillan över huvud taget ersätts. De
+ * avgränsningarna är bedömningar bara juristen kan göra — AVA vet varken
+ * klockslag, om du övernattat eller om du ätit — så reglerna hör hemma där valet
+ * görs, inte som en kontroll efteråt.
+ *
+ * Alternativet, start- och sluttid på VARJE tidspost, hade kostat vid varje
+ * registrering i systemet för att fånga något ovanligt som domstolen dessutom
+ * stryker om det blir fel.
+ */
+const KIND_GUIDANCE: Partial<Record<TimeEntryKind, string>> = {
+  TIDSSPILLAN: "Dagtaxan gäller vardag 08.00–18.00. Ersättning lämnas bara för tid mellan 07.00 och 22.00, och normal måltidspaus är inte tidsspillan (DVFS 2025:4 §§ 2–4).",
+  TIDSSPILLAN_OVRIG_TID: "All tidsspillan utanför vardag 08.00–18.00 — men bara inom 07.00–22.00; tid mellan 22.00 och 07.00 ersätts inte alls. Vid övernattning på annan ort än tjänstestället ersätts 18.00–22.00 endast om den avser restid (DVFS 2025:4 §§ 2, 4).",
+  ARBETE_OBEKVAM_TID: "Häktningsförhandling under helg (DVFS 2025:7) eller polisförhör utanför ordinarie kontorstid (DVFS 2025:8). Tidsspillan i samband med sådana ersätts med DAGTAXAN, även 22.00–07.00.",
+};
+
 /** Ärenden där kategorin styr vilken ÅRSNORM slutregleringen värderar posten på. */
 const COVERAGE_METHODS = new Set<PaymentMethod>(["RATTSHJALP", "RATTSSKYDD"]);
 
@@ -337,11 +355,16 @@ function TimeForm({ form, setForm, submitLabel, isPending, isTaxeArende, isCover
             {KIND_OPTIONS.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
           </select>
           {isCoverage && (
-            <p className="mt-1 text-xs text-gray-500">
-              Kategorin avgör vilken av Domstolsverkets normer posten ersätts på.
-              Hela ärendet räknas om på slutregleringsårets normer, så en taxehöjning
-              slår igenom retroaktivt.
-            </p>
+            <>
+              <p className="mt-1 text-xs text-gray-500">
+                Kategorin avgör vilken av Domstolsverkets normer posten ersätts på.
+                Hela ärendet räknas om på slutregleringsårets normer, så en taxehöjning
+                slår igenom retroaktivt.
+              </p>
+              {KIND_GUIDANCE[form.kind] !== undefined && (
+                <p className="mt-1 text-xs text-amber-700">{KIND_GUIDANCE[form.kind]}</p>
+              )}
+            </>
           )}
         </div>
       </div>

--- a/test/unit/app/matters/time-section.test.tsx
+++ b/test/unit/app/matters/time-section.test.tsx
@@ -115,6 +115,53 @@ describe("TimeSection — arvodeskategori (#953)", () => {
 });
 
 /**
+ * Föreskriftens tillämpningsregler vid kategorivalet (#969). AVA kan inte AVGÖRA
+ * om en post faller inom 07–22 eller om pausen var en måltidspaus — bara juristen
+ * vet det. Därför visas regeln VID valet; testet vaktar att den syns för rätt
+ * kategori, inte att någon kontroll körs.
+ */
+describe("TimeSection — DVFS-hjälptext vid kategorivalet (#969)", () => {
+  function openForm(paymentMethod: "PRIVAT" | "RATTSHJALP"): void {
+    render(<TimeSection matterId={matterId} paymentMethod={paymentMethod} />);
+    fireEvent.click(screen.getByText("+ Registrera tid"));
+  }
+
+  it("Arbete har ingen tillämpningsregel att visa", () => {
+    openForm("RATTSHJALP");
+    expect(screen.queryByText(/07\.00/)).not.toBeInTheDocument();
+  });
+
+  it("Tidsspillan visar 07–22-fönstret och måltidspausen", () => {
+    openForm("RATTSHJALP");
+    fireEvent.change(screen.getByLabelText("Arvodeskategori *"), { target: { value: "TIDSSPILLAN" } });
+    const text = screen.getByText(/måltidspaus/);
+    expect(text).toHaveTextContent("mellan 07.00 och 22.00");
+    expect(text).toHaveTextContent("DVFS 2025:4 §§ 2–4");
+  });
+
+  it("Tidsspillan annan tid visar övernattningsregeln — den gäller just 18–22", () => {
+    openForm("RATTSHJALP");
+    fireEvent.change(screen.getByLabelText("Arvodeskategori *"), { target: { value: "TIDSSPILLAN_OVRIG_TID" } });
+    const text = screen.getByText(/övernattning/);
+    expect(text).toHaveTextContent("18.00–22.00 endast om den avser restid");
+    // Natten är inte "lägre taxa" utan INGEN ersättning — lätt att tro fel.
+    expect(text).toHaveTextContent("22.00 och 07.00 ersätts inte alls");
+  });
+
+  it("Obekväm tid pekar på att TIDSSPILLAN då ersätts med dagtaxan", () => {
+    openForm("RATTSHJALP");
+    fireEvent.change(screen.getByLabelText("Arvodeskategori *"), { target: { value: "ARBETE_OBEKVAM_TID" } });
+    expect(screen.getByText(/Häktningsförhandling/)).toHaveTextContent("ersätts med DAGTAXAN");
+  });
+
+  it("privatärenden får ingen hjälptext — normerna styr inte deras arvode", () => {
+    openForm("PRIVAT");
+    fireEvent.change(screen.getByLabelText("Arvodeskategori *"), { target: { value: "TIDSSPILLAN" } });
+    expect(screen.queryByText(/måltidspaus/)).not.toBeInTheDocument();
+  });
+});
+
+/**
  * Byråns standardåtgärder (#956): en standard ska fylla beskrivning OCH tid, så
  * alla på byrån redovisar samma åtgärd likadant — men båda ska förbli
  * redigerbara, för "som huvudregel" betyder att avsteg måste vara möjligt.


### PR DESCRIPTION
Stänger #969.

## Problemet

AVA har haft tidsspillans **belopp** rätt sedan #950 (1 487 kr/h vardag 08–18, 975 kr/h annan tid, DVFS 2025:4 § 4), men ingenstans föreskriftens **avgränsningar**:

> **2 §** Tidsspillan ersätts för tid mellan kl. 07.00 och kl. 22.00. Om övernattning sker på annan ort än den där den ersättningsberättigade har sitt tjänsteställe, ersätts tidsspillan mellan kl. 18.00 och kl. 22.00 endast om den avser restid.
>
> **3 §** Normal måltidspaus utgör inte tidsspillan.

Juristen väljer kategori för hand och AVA multiplicerar minuter × norm. Att natten 22–07 inte ersätts **alls** — inte "till lägre taxa" — syntes inte någonstans.

## Varför inte klockslag i datamodellen

Det var alternativet #969 vägde. Det avfärdas här: AVA vet varken klockslag, om juristen övernattat, var tjänstestället ligger eller om pausen var en måltidspaus. Start- och sluttid på *varje* tidspost hade kostat vid varje registrering för att fånga något ovanligt — som domstolen dessutom stryker vid granskningen.

Reglerna hör därför hemma **vid valet**, där bedömningen faktiskt görs, inte som en kontroll efteråt.

## Ändringen

`KIND_GUIDANCE` i `_time-section.tsx` — en rad per kategori, visad under kategoriväljaren och bara i täckningsärenden (rättshjälp/rättsskydd), där normerna styr arvodet:

| Kategori | Regel |
|---|---|
| `TIDSSPILLAN` | Dagtaxa vardag 08–18; ersättning bara 07–22; måltidspaus räknas inte (§§ 2–4) |
| `TIDSSPILLAN_OVRIG_TID` | Allt utanför vardag 08–18, men bara inom 07–22; 22–07 ersätts inte alls; övernattningsregeln för 18–22 (§§ 2, 4) |
| `ARBETE_OBEKVAM_TID` | Helgförhandling / polisförhör utom kontorstid; tidsspillan då på **dagtaxan**, även 22–07 (DVFS 2025:7 § 1, 2025:8 § 3) |

`ARBETE` har ingen tillämpningsregel och får ingen text.

Föreskriftstexten är verifierad mot [DVFS 2025:4-PDF:en](https://www.domstol.se/globalassets/filer/gemensamt-innehall/for-professionella-aktorer/dvfs/2025/dvfs_2025-4.pdf), inte mot minnet.

## De två övriga gapen i #969 fanns inte

Verifierat mot koden och rättat i [issuen](https://github.com/ulrik-s/ava/issues/969#issuecomment-5233735645):

1. **"Normen slås upp på postens datum"** — nej. Alla fyra anropen till `coverageEntryRateOre` (`billingRun.ts` rad 135, 296, 517, 614) skickar `settleDate` (= `input.invoiceDate`). Hela ärendet värderas på ett års normer, precis som övergångsbestämmelse 3 kräver.
2. **"Tidsspillan läggs på oavsett brottmålstaxa"** — nej. `kostnadsrakning.ts:289` sätter `rateOrePerH = isTaxe ? 0 : …` för *varje* tidspost, så 1 § st. 2 är redan uppfylld.

Ett kvarvarande fynd är utbrutet till #980: kostnadsräkningen värderar på `hufEnd` medan övergångsbestämmelsen knyter an till när yrkandet framställs.

## Tester

Fem nya i `test/unit/app/matters/time-section.test.tsx` — en per kategori, plus att privatärenden inte får någon text. Assertionerna går på regelns innehåll (`"22.00 och 07.00 ersätts inte alls"`, `"18.00–22.00 endast om den avser restid"`), inte på att strängen finns.

## Grindar

`typecheck` ✓ · `lint` ✓ · `lint:complexity-strict` ✓ · `knip` ✓ · `deps:check` ✓ (inga brott, 1114 moduler) · `jscpd` ✓ (7 kloner, oförändrat) · `test/unit/app/matters/time-section.test.tsx` 18/18 ✓

De 5 fallerande testerna vid katalogkörning av `test/unit/app/matters/` är oförändrade mot `main` (mock-läckage vid katalogkörning, #92) — verifierat med samma körning på ostagead baseline.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_