### PR TITLE
fix(e2e): slå upp seed-id:n i stället för att hårdkoda dem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,19 @@ jobs:
         # `serve-demo-static.ts` själv (`webServer`), så den lokala körningen och
         # CI gör exakt samma sak. Specarna bär dessutom en hermeticitets-vakt —
         # varje förfrågan utanför den egna originen fäller testet.
-        run: npx playwright test test/e2e/demo-login.spec.ts --config tooling/config/playwright-demo.config.ts
+        #
+        # `demo-smoke` + `kebab-verify` kom till i #972. De är billiga
+        # render-smokes (~1 min tillsammans) och slår upp sina fixtures ur
+        # seeden i stället för att hårdkoda id:n — det var just för att de låg
+        # utanför CI som de kunde ruttna i tysthet. Det TYNGRE faktura-flödet
+        # (demo-invoice-document) hålls fortfarande utanför; det körs i
+        # `test:all` lokalt.
+        run: >
+          npx playwright test
+          test/e2e/demo-login.spec.ts
+          test/e2e/demo-smoke.spec.ts
+          test/e2e/kebab-verify.spec.ts
+          --config tooling/config/playwright-demo.config.ts
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/src/components/documents/_document-row.tsx
+++ b/src/components/documents/_document-row.tsx
@@ -335,7 +335,12 @@ function DocumentNameButton({ doc, isAnalyzing, disabled, onOpen }: NameButtonPr
       type="button"
       onClick={() => { if (!disabled) onOpen(); }}
       disabled={disabled}
-      className="flex items-start gap-2 text-blue-600 hover:underline text-left disabled:opacity-50 disabled:cursor-not-allowed disabled:no-underline"
+      // `w-full min-w-0`: en `display:flex`-knapp är shrink-to-fit och växer
+      // annars till sitt max-content — 390 px i en 103 px-cell, alltså
+      // horisontell scroll på mobil trots table-fixed. `break-words` på
+      // text-spanen nedan hjälper inte så länge själva flex-containern är för
+      // bred; den måste först få krympa. Mätt i #972.
+      className="flex w-full min-w-0 items-start gap-2 text-blue-600 hover:underline text-left disabled:opacity-50 disabled:cursor-not-allowed disabled:no-underline"
       title={disabled ? "Laddar upp — vänta tills filen är registrerad" : (doc.summary || "Öppna i extern app (PDFGear för PDF)")}
     >
       <span className="text-lg leading-tight flex-shrink-0">📄</span>

--- a/test/e2e/_demo-test.ts
+++ b/test/e2e/_demo-test.ts
@@ -84,6 +84,64 @@ export async function seedDemoLogin(page: Page, baseUrl: string = DEMO_BASE_URL)
   });
 }
 
+// ── Seed-uppslagning (#972) ───────────────────────────────────────────────
+
+/**
+ * Den del av demons `demo-seed.json` som e2e:t behöver för att hitta sina
+ * fixtures. Samma fil appen själv hydrerar ur, så det testet slår upp är per
+ * definition det användaren ser.
+ *
+ * Bakgrund: specarna navigerade till `m-001-vardnad`, `inv-001` och liknande
+ * slugs. Seeden översätter numera allt till UUID:n (`translateSeed`), så de
+ * sidorna finns inte — och eftersom specarna låg utanför alla configar (#932)
+ * märktes det aldrig. Att slå upp id:t i stället för att hårdkoda det är samma
+ * mönster som `seedDemoLogin` redan använder för användaren: ett hårdkodat id
+ * TYSTNAR till "sidan renderar inte" nästa gång seeden ändras, medan en
+ * uppslagning som inte hittar något säger vad som saknas.
+ */
+export interface DemoSeed {
+  matters: Array<{ id: string; title: string }>;
+  contacts: Array<{ id: string; name: string }>;
+  invoices: Array<{ id: string; matterId: string }>;
+  documents: Array<{ id: string; matterId: string; title: string }>;
+  timeEntries: Array<{ id: string; matterId: string; description: string }>;
+  expenses: Array<{ id: string; matterId: string; description: string }>;
+}
+
+/** Grupper som bär `matterId` — det e2e:t kan kräva att ett ärende har. */
+export type MatterScopedKey = "documents" | "timeEntries" | "expenses" | "invoices";
+
+/** Hämta demons egen seed ur den serverade `out/`. */
+export async function fetchDemoSeed(page: Page, baseUrl: string = DEMO_BASE_URL): Promise<DemoSeed> {
+  const url = `${baseUrl}/demo-seed.json`;
+  const res = await page.request.get(url);
+  if (!res.ok()) {
+    throw new Error(`kunde inte läsa ${url}: HTTP ${res.status()} — är out/ byggd och serverad?`);
+  }
+  return await res.json() as DemoSeed;
+}
+
+/**
+ * Id:t för det första ärendet (id-sorterat → stabilt mellan körningar) som har
+ * rader i ALLA angivna grupper. Kravet skrivs ut i felmeddelandet, så en spec
+ * som tappar sin fixture säger vad seeden slutade producera i stället för att
+ * fälla på en tom sida.
+ */
+export function matterIdWith(seed: DemoSeed, ...required: MatterScopedKey[]): string {
+  const has = (key: MatterScopedKey, id: string): boolean => seed[key].some((r) => r.matterId === id);
+  const hit = seed.matters.map((m) => m.id).sort()
+    .find((id) => required.every((key) => has(key, id)));
+  if (hit === undefined) throw new Error(`seeden saknar ärende med ${required.join(" + ")}`);
+  return hit;
+}
+
+/** Seed-raderna som hör till ett ärende — det sidan ska visa. */
+export function rowsForMatter<K extends MatterScopedKey>(
+  seed: DemoSeed, key: K, matterId: string,
+): DemoSeed[K] {
+  return seed[key].filter((r) => r.matterId === matterId) as DemoSeed[K];
+}
+
 /** Icke-HTTP (`data:`, `blob:`, `about:`) är inte nätverk — släpp igenom. */
 function isNetworkUrl(url: string): boolean {
   return /^https?:\/\//i.test(url);

--- a/test/e2e/demo-smoke.spec.ts
+++ b/test/e2e/demo-smoke.spec.ts
@@ -14,7 +14,9 @@
  * själva verket det som redan låg publicerat, inte branchen man satt på.
  */
 
-import { DEMO_BASE_URL as BASE, seedDemoLogin, test, expect } from "./_demo-test";
+import {
+  DEMO_BASE_URL as BASE, fetchDemoSeed, matterIdWith, rowsForMatter, seedDemoLogin, test, expect,
+} from "./_demo-test";
 
 test.beforeEach(async ({ page }) => {
   // Tvinga demo-tier (localhost defaultar self-hosted → 401) OCH logga in:
@@ -70,43 +72,62 @@ test("dokumentmallar visas (data laddas från .ava/templates/)", async ({ page }
   await expect(page.getByRole("cell", { name: "Kostnadsräkning till rätten", exact: true })).toBeVisible({ timeout: 15_000 });
 });
 
-test("ärendelistan visar seed-data (Brottmål m-016)", async ({ page }) => {
+test("ärendelistan visar seedens egna ärenden", async ({ page }) => {
+  const seed = await fetchDemoSeed(page, BASE);
   await page.goto(`${BASE}/matters/`);
-  await expect(page.getByText(/Brottm/, { exact: false }).first()).toBeVisible({ timeout: 15_000 });
+  // Titeln kommer ur seeden, inte ur en hårdkodad sträng: listan ska visa det
+  // datat demon faktiskt bär, vad seeden än döpt ärendena till.
+  const title = seed.matters[0]?.title ?? "";
+  await expect(page.getByText(title, { exact: false }).first()).toBeVisible({ timeout: 15_000 });
 });
 
-test("kontaktlistan visar seed-data (Andersson)", async ({ page }) => {
+test("kontaktlistan visar seedens egna kontakter", async ({ page }) => {
+  const seed = await fetchDemoSeed(page, BASE);
   await page.goto(`${BASE}/contacts/`);
-  await expect(page.getByText("Andersson", { exact: false }).first()).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByText(seed.contacts[0]?.name ?? "", { exact: false }).first())
+    .toBeVisible({ timeout: 15_000 });
 });
 
-test("klick på matter öppnar detalj-sidan utan loop", async ({ page }) => {
+test("matter-detalj öppnas på sitt eget id utan loop", async ({ page }) => {
   const errors: string[] = [];
   page.on("pageerror", (err) => errors.push(`pageerror: ${err.message}`));
 
-  await page.goto(`${BASE}/matters/m-016-brottmal-rh/`);
-  await expect(page.locator("body")).toContainText(/Brottm|m-016/i, { timeout: 15_000 });
+  const seed = await fetchDemoSeed(page, BASE);
+  const matter = seed.matters[0];
+  if (!matter) throw new Error("seeden saknar ärenden");
 
-  // Vänta lite och försäkra oss om att vi inte loop:ar till en redirect-sida
+  await page.goto(`${BASE}/matters/${matter.id}/`);
+  await expect(page.locator("body")).toContainText(matter.title, { timeout: 15_000 });
+
+  // Vänta lite och försäkra oss om att vi inte loop:ar till en redirect-sida.
+  // Seed-ärenden ÄR pre-renderade (`demoStaticParams("matters/active")`), så
+  // URL:en ska stå kvar — ingen __shell__-omskrivning här.
   await page.waitForTimeout(1500);
-  expect(page.url(), "URL ska innehålla matter-id:t").toMatch(/m-016-brottmal-rh/);
+  expect(page.url(), "URL ska behålla ärendets id").toContain(matter.id);
   expect(errors, "inga script-errors").toEqual([]);
 });
 
-test("avbetalningsplaner-sidan listar seed-planerna", async ({ page }) => {
+test("avbetalningsplaner-sidan renderar", async ({ page }) => {
+  // Sidan hade förr en assertion om `pp-`-länkar. Demons simulering (#880)
+  // producerar inga avbetalningsplaner alls längre — se #982 — så ett test som
+  // kräver planrader skulle påstå något om data som inte finns. Kvar är att
+  // sidan renderar sitt tomläge utan att krascha.
+  const errors: string[] = [];
+  page.on("pageerror", (e) => errors.push(`pageerror: ${e.message}`));
   await page.goto(`${BASE}/payment-plans/`);
-  // Listan visar ärendenr (2026-XXXX) + klient-namn. Verifiera att åtminstone
-  // en avbetalningsplan-länk syns (pp-001..pp-007 i seed).
-  await expect(page.locator('a[href*="/payment-plans/pp-"]').first()).toBeVisible({ timeout: 15_000 });
+  await expect(page.locator("body")).toContainText(/Avbetalningsplaner/i, { timeout: 15_000 });
+  expect(errors, "inga script-errors").toEqual([]);
 });
 
 test("kontakt-detalj kraschar inte (c.children kan vara undefined)", async ({ page }) => {
   const errors: string[] = [];
   page.on("pageerror", (e) => errors.push("pageerror: " + e.message.slice(0, 250)));
 
-  // Testa flera olika kontakter med olika "shape"
-  for (const id of ["c-andersson", "c-byggfirma", "c-folksam", "c-skatteverket"]) {
-    await page.goto(`${BASE}/contacts/${id}/`);
+  // Flera kontakter — buggen satt i olika "shape" på seed-raderna, så det är
+  // bredden som är poängen, inte vilka fyra kontakter det råkar vara.
+  const seed = await fetchDemoSeed(page, BASE);
+  for (const contact of seed.contacts.slice(0, 4)) {
+    await page.goto(`${BASE}/contacts/${contact.id}/`);
     await page.waitForFunction(() => !document.body.innerText.includes("Laddar data"), { timeout: 30_000 });
     await page.waitForTimeout(1000);
   }
@@ -115,12 +136,22 @@ test("kontakt-detalj kraschar inte (c.children kan vara undefined)", async ({ pa
   expect(errors.filter((e) => e.includes("TypeError")), "inga TypeErrors").toEqual([]);
 });
 
-test("faktura-detalj öppnas utan loop (inv-001 + inv-005)", async ({ page }) => {
-  for (const id of ["inv-001", "inv-005"]) {
-    const response = await page.goto(`${BASE}/invoices/${id}/`, { waitUntil: "domcontentloaded" });
-    expect(response?.status(), `inv-${id} ska vara pre-renderad (200), inte SPA-fallback (404)`).toBe(200);
+test("faktura-detalj öppnas via __shell__-shimmen, utan loop", async ({ page }) => {
+  // Fakturor pre-renderas INTE per id (`static-params.ts` returnerar bara
+  // sentinellen): id:na skapas av demo-generatorn vid körning och kan inte
+  // enumereras vid build. Vägen dit är shimmen — okänd URL → 404.html →
+  // `/invoices/__shell__/#orig=…` → `useRouteId`. Testet fällde förr på
+  // `status === 200`, vilket krävde motsatsen till den arkitekturen.
+  const seed = await fetchDemoSeed(page, BASE);
+  for (const invoice of seed.invoices.slice(0, 2)) {
+    await page.goto(`${BASE}/invoices/${invoice.id}/`, { waitUntil: "domcontentloaded" });
     await page.waitForFunction(() => !document.body.innerText.includes("Laddar data"), { timeout: 30_000 });
-    expect(page.url(), "ingen redirect-loop").toContain(`/invoices/${id}`);
+    // Shimmen bär det riktiga id:t i hash:en; appen ska ha plockat upp det och
+    // renderat fakturan i stället för att fastna på sentinellen.
+    await expect(page.locator("body"), "fakturan ska ha laddats, inte 'kunde inte ladda'")
+      .not.toContainText(/kunde inte ladda/i);
+    expect(decodeURIComponent(page.url()), "id:t ska följa med genom shimmen")
+      .toContain(invoice.id);
   }
 });
 
@@ -128,35 +159,49 @@ test("matter-detalj visar seed-tider (regressionsskydd för org-id-bugen)", asyn
   const errors: string[] = [];
   page.on("console", (m) => { if (m.type() === "error" && m.text().includes("hydratisera")) errors.push(m.text()); });
 
-  await page.goto(`${BASE}/matters/m-001-vardnad/`);
+  const seed = await fetchDemoSeed(page, BASE);
+  const matterId = matterIdWith(seed, "timeEntries");
+  await page.goto(`${BASE}/matters/${matterId}/`);
   await page.waitForFunction(() => !document.body.innerText.includes("Laddar data"), { timeout: 30_000 });
 
-  // Tidregistrering-sektionens innehåll: seed har te-001 "Genomgång av handlingar"
-  await expect(page.getByText(/Genomgång av handlingar/)).toBeVisible({ timeout: 15_000 });
+  // Tidregistrerings-sektionen ska visa ärendets EGEN tidspost ur seeden.
+  const entry = rowsForMatter(seed, "timeEntries", matterId)[0];
+  await expect(page.getByText(entry?.description ?? "").first()).toBeVisible({ timeout: 15_000 });
 
   // Inga hydration-warnings i console
   expect(errors, "ProjectionHydrator får inte kasta ZodError för seed-data").toEqual([]);
 });
 
 test("matter-detalj visar tabell-rader för fakturor/utlägg/tider", async ({ page }) => {
-  await page.goto(`${BASE}/matters/m-001-vardnad/`);
+  const seed = await fetchDemoSeed(page, BASE);
+  const matterId = matterIdWith(seed, "timeEntries", "expenses");
+  await page.goto(`${BASE}/matters/${matterId}/`);
   await page.waitForFunction(() => !document.body.innerText.includes("Laddar data"), { timeout: 30_000 });
 
-  const body = await page.locator("body").textContent();
-  // Utlägg-summary syns (seed: Domstolsavgift, Parkeringsavgift)
-  expect(body, "Utlägg ska visas på matter-detalj").toMatch(/Domstolsavgift|Parkeringsavgift/);
-  // Tid-rad: HH:MM-format ("0:30" från te-001)
-  expect(body, "Tid-rader ska visas").toMatch(/\d+:\d{2}/);
+  // RETRY-matchers, inte ett `textContent()`-ögonblick: `waitForFunction` ovan
+  // väntar på "Laddar data", men appens första platshållare är "Laddar…" — en
+  // ögonblicksbild kan alltså tas medan sidan fortfarande bootar. `useInnerText`
+  // håller dessutom Next:s `__next_f`-script utanför matchningen, så en
+  // NaN-sträng i script-payloaden inte kan fälla (eller rädda) testet.
+  const body = page.locator("body");
+  const opts = { useInnerText: true, timeout: 15_000 } as const;
+  // Utlägget kommer ur seeden — samma rad som ska stå i tabellen.
+  const expense = rowsForMatter(seed, "expenses", matterId)[0];
+  await expect(body, "Utlägg ska visas på matter-detalj").toContainText(expense?.description ?? "", opts);
+  // Tid-rad: HH:MM-format
+  await expect(body, "Tid-rader ska visas").toContainText(/\d+:\d{2}/, opts);
   // Inga "NaN kr" eller "Invalid Date" från brutna fält
-  expect(body, "Inga NaN-belopp").not.toMatch(/NaN kr|Invalid Date/);
+  await expect(body, "Inga NaN-belopp").not.toContainText(/NaN kr|Invalid Date/, opts);
 });
 
 test("matter-detalj visar seed-dokument", async ({ page }) => {
-  await page.goto(`${BASE}/matters/m-001-vardnad/`);
+  const seed = await fetchDemoSeed(page, BASE);
+  const matterId = matterIdWith(seed, "documents");
+  await page.goto(`${BASE}/matters/${matterId}/`);
   await page.waitForFunction(() => !document.body.innerText.includes("Laddar data"), { timeout: 30_000 });
 
-  // Dokument från seed (Stämningsansökan / Förlikningsförslag etc.)
-  await expect(page.getByText(/\.pdf|\.docx/i).first()).toBeVisible({ timeout: 15_000 });
+  const doc = rowsForMatter(seed, "documents", matterId)[0];
+  await expect(page.getByText(doc?.title ?? "").first()).toBeVisible({ timeout: 15_000 });
 });
 
 test("SPA-fallback redirectar till app-shellen vid 404", async ({ page }) => {

--- a/test/e2e/kebab-verify.spec.ts
+++ b/test/e2e/kebab-verify.spec.ts
@@ -19,16 +19,36 @@
 
 import { type Page } from "@playwright/test";
 
-import { DEMO_BASE_URL as BASE, seedDemoLogin, test, expect } from "./_demo-test";
+import { DEMO_BASE_URL as BASE, fetchDemoSeed, matterIdWith, seedDemoLogin, test, expect } from "./_demo-test";
+
+/** `DocumentBrowser` läser vyläget härifrån — måste sättas FÖRE första render. */
+const VIEW_MODE_KEY = "ava.documents.viewMode";
 
 test.beforeEach(async ({ page }) => {
   // localhost defaultar till self-hosted (→ 401) → tvinga demo. Seedas även mot
   // live: `repo: ""` ger same-origin i båda lägena, så vägen är densamma.
   await seedDemoLogin(page, BASE);
+  // TRÄD-vyn, inte listvyn. Det är trädets tabell som bär fixarna specen
+  // granskar (`table-fixed` i document-browser.tsx, `hidden sm:table-cell` i
+  // _document-row/_folder-row) och dess kebab som har hela action-uppsättningen.
+  // Default är numera listvyn, som renderar den generiska `DataTable` med en
+  // annan, kortare meny och utan kolumn-döljning — specen mätte alltså fel
+  // tabell, vilket ingen såg eftersom den låg utanför alla configar (#932).
+  // Listvyns egna brister är EGEN sak: #983.
+  await page.addInitScript(([key, mode]) => {
+    try { localStorage.setItem(key!, mode!); } catch { /* privat läge */ }
+  }, [VIEW_MODE_KEY, "tree"]);
 });
 
+/**
+ * Ett ärende som FAKTISKT har dokument — annars finns ingen kebab att öppna och
+ * testet fäller på en tom tabell i stället för på menyn det granskar. Id:t slås
+ * upp i seeden (#972); det hårdkodade `m-001-vardnad` slutade existera när
+ * seeden gick över till UUID:n.
+ */
 async function gotoMatter(page: Page) {
-  await page.goto(`${BASE}/matters/m-001-vardnad/`);
+  const seed = await fetchDemoSeed(page, BASE);
+  await page.goto(`${BASE}/matters/${matterIdWith(seed, "documents")}/`);
   await page.getByLabel("Dokumentåtgärder").first().waitFor({ timeout: 25_000 });
   await page.waitForTimeout(1500); // demo-bootstrap invalidateQueries settle
 }
@@ -39,9 +59,14 @@ test("dokumentrad: kebab-meny öppnas med alla actions + Escape stänger", async
 
   const menu = page.getByRole("menu", { name: "Dokumentåtgärder" });
   await expect(menu).toBeVisible();
-  for (const label of ["Öppna i webbläsaren", "Editera externt", "Visa", "Ladda ner", "Analysera", "Ta bort"]) {
+  for (const label of ["Öppna i webbläsaren", "Editera externt", "Visa", "Ladda ner", "Ta bort"]) {
     await expect(menu.getByText(new RegExp(label))).toBeVisible();
   }
+  // "Analysera (AI)" ska INTE finnas här. ADR 0027: LLM-analys är en
+  // server-förmåga, och demon har ingen server — affordansen ska då döljas, inte
+  // visas och fela. Specen krävde tvärtom att den fanns, vilket bara gick att
+  // tro så länge den aldrig kördes (#932/#972).
+  await expect(menu.getByText(/Analysera/)).toHaveCount(0);
 
   await page.keyboard.press("Escape");
   await expect(menu).toBeHidden();

--- a/tooling/config/playwright-demo.config.ts
+++ b/tooling/config/playwright-demo.config.ts
@@ -26,14 +26,11 @@ export default defineConfig({
   // Specar som behöver en serverad `out/` hör hemma här — inte i
   // playwright.config.ts, som startar `next dev` på :3000 (#932).
   //
-  // `demo-smoke` och `kebab-verify` är UTELÄMNADE med flit: de hårdkodar seed-id:n
-  // i det gamla formatet (`m-001-vardnad`, `m-016-brottmal-rh`, `inv-001`) som
-  // seeden slutade producera för länge sedan — den kör UUID:er nu. Att ingen
-  // märkt det är samma sjuka som #932: specarna låg i ingens config och kördes
-  // för hand mot live-demon. De pekar numera på den lokala servern och bär
-  // hermeticitets-vakten, så den som lagar dem börjar från rätt utgångsläge; att
-  // ta in dem här innan dess vore bara att göra `e2e:demo` rött. Se #972.
-  testMatch: /(demo-invoice-document|demo-login|matters-employee-filter)\.spec\.ts$/,
+  // Alla demo-specar körs numera (#972). `demo-smoke` och `kebab-verify` låg
+  // utanför tills de slutat hårdkoda seed-id:n; de slår upp sina fixtures i
+  // `demo-seed.json` via `fetchDemoSeed`. Lägg inte till en spec här som pekar
+  // på ett id den inte slagit upp — det var precis så de tystnade förra gången.
+  testMatch: /(demo-invoice-document|demo-login|demo-smoke|kebab-verify|matters-employee-filter)\.spec\.ts$/,
   timeout: 90_000,
   expect: { timeout: 15_000 },
   fullyParallel: false,

--- a/tooling/scripts/serve-demo-static.ts
+++ b/tooling/scripts/serve-demo-static.ts
@@ -43,9 +43,13 @@ const server = createServer((req, res) => {
     const url = decodeURIComponent((req.url ?? "/").split("?")[0]!);
     const rel = url.startsWith("/ava") ? url.slice(4) : url; // strip GH-Pages-prefixet
     // Fil → annars 404.html (SPA-fallback, precis som GH Pages).
-    const file = (await resolveFile(join(ROOT, rel))) ?? (await resolveFile(join(ROOT, "404.html")));
+    const hit = await resolveFile(join(ROOT, rel));
+    const file = hit ?? (await resolveFile(join(ROOT, "404.html")));
     if (!file) { res.writeHead(404).end("not found"); return; }
-    res.writeHead(200, { "content-type": MIME[extname(file)] ?? "application/octet-stream" });
+    // STATUSEN speglas också, inte bara kroppen (#972): GH Pages svarar 404 på
+    // fallbacken. Servern svarade förr 200 oavsett, vilket gjorde varje
+    // assertion om shim-vägen meningslös lokalt och sann bara mot live.
+    res.writeHead(hit ? 200 : 404, { "content-type": MIME[extname(file)] ?? "application/octet-stream" });
     res.end(await readFile(file));
   })();
 });


### PR DESCRIPTION
Stänger #972.

## Vad som var fel

`demo-smoke.spec.ts` och `kebab-verify.spec.ts` navigerade till `m-001-vardnad`, `m-016-brottmal-rh`, `inv-001`. Seeden översätter allt till UUID:n (`translateSeed`) sedan länge — sidorna finns inte. Specarna låg dessutom utanför alla Playwright-configar (#932), så de kördes bara för hand mot live-demon och deras röda status nådde aldrig CI.

**Id:na var aldrig ett routing-krav.** `__shell__`-shimmen renderar vilket id som helst client-side, och det är just den som gör GH Pages och docker likvärdiga. Id:na var *fixtures* — specarna påstår saker om ett bestämt objekts innehåll — och de överlevde för att ingen körde dem.

## Fixen

`fetchDemoSeed` läser `demo-seed.json` från den serverade `out/` — samma fil appen själv hydrerar ur, så det testet slår upp är per definition det användaren ser. `matterIdWith(seed, "documents", "timeEntries")` väljer första id-sorterade ärende som uppfyller kraven, och kastar med kravet utskrivet om seeden slutar producera det. Assertionerna går på seedens egna rader (`entry.description`, `doc.title`, `expense.description`) i stället för hårdkodade strängar.

Samma mönster `seedDemoLogin` redan använder för användaren.

## Tre saker till, som inte var stale id:n

**1. En assertion krävde motsatsen till arkitekturen.**

```ts
expect(response?.status(), "ska vara pre-renderad (200), inte SPA-fallback (404)").toBe(200);
```

Fakturor pre-renderas inte per id — `static-params.ts:34` returnerar bara sentinellen, med flit. Testet går nu shimmens väg och verifierar att id:t överlever den.

**2. Den lokala statiska servern speglade inte GH Pages.**

`serve-demo-static.ts` svarade `200` även på 404.html-fallbacken, trots kommentaren om att den speglar GH Pages. Assertionen ovan var alltså *vakuös* lokalt och skulle bara ha fällt mot live. Statusen speglas nu också.

**3. Att köra specarna avslöjade två riktiga fel.**

**Horisontell scroll på mobil.** Dokumentnamnets knapp är `display:flex` utan `w-full min-w-0` → shrink-to-fit växte till max-content: 390 px i en 103 px-cell. `break-words` på text-spanen kan inte hjälpa så länge flex-containern själv inte får krympa. Mätt före/efter på 390 px-skärm:

| | wrap.scrollWidth − clientWidth |
|---|---|
| Före | 50 px |
| Efter | 0 px |

**Fel vy, fel förväntan.** Specen mätte listvyn (default sedan en tid) men granskade trädvyns fixar — `table-fixed`, `hidden sm:table-cell` — och krävde ett `Analysera`-val som ADR 0027 döljer utan LLM-förmåga. Den pekar nu på trädvyn och kräver tvärtom att valet **är** dolt i demon.

## Nya issues ur fyndet

- **#982** — demon har inga avbetalningsplaner eller avskrivningar sedan #880; simuleringen ersatte `populate-billing` utan att ta över dess livscykler. Testet `avbetalningsplaner-sidan listar seed-planerna` gick inte att laga med ett id-uppslag: datat finns inte. Det är nu en render-smoke. Blockerar #882, som annars raderar koden som vet hur planerna ska se ut.
- **#983** — listvyn (default) scrollar horisontellt på mobil och har en kortare kebab-meny än trädvyn. Listvyn är otäckt tills dess — medvetet, inte glömt.

## Grindar

`typecheck` ✓ · `lint` ✓ · `lint:complexity-strict` ✓ · `knip` ✓ · `deps:check` ✓ (1114 moduler) · `jscpd` ✓ (7 kloner, oförändrat) · `build:demo` ✓ · **`e2e:demo` 28/28** ✓

Båda specarna är intagna i `testMatch` **och** i `demo-e2e`-jobbet i CI, så de inte kan ruttna i tysthet igen. Det tyngre `demo-invoice-document` hålls fortfarande utanför CI-gaten.

Enhetstesterna för dokumentkomponenterna (`document-browser`, `document-row-upload-guard`, `styles`) är gröna; de 5 fallerande vid katalogkörning av `test/unit/app/matters/` är oförändrade mot `main` (#92).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_