### PR TITLE
feat(demo): flytta faktura-livscyklerna in i den kronologiska simuleringen

### DIFF
--- a/src/lib/client/demo/demo-source-keys.ts
+++ b/src/lib/client/demo/demo-source-keys.ts
@@ -33,6 +33,13 @@ const MATCHERS: Matcher[] = [
   { key: "paymentPlans", owns: (p) => p.startsWith("payment-plans/") },
   { key: "payments", owns: (p) => p.startsWith("payments/") },
   { key: "paymentPlanReminders", owns: (p) => p.startsWith("payment-plan-reminders/") },
+  // `write-offs/` saknade matcher fram till #982, så VARJE avskrivning tappades
+  // tyst av demon. Att det inte syntes beror på migrate-on-read (ADR 0007):
+  // `synthesizeBadDebtWriteOffs` byggde en ERSÄTTNINGSPOST ur fakturans
+  // BAD_DEBT-status, med gissat datum (`updatedAt`) och reason "Migrerad …".
+  // Ledgern summerade alltså rätt belopp av fel skäl, och den riktiga postens
+  // datum och orsak nådde aldrig fram.
+  { key: "writeOffs", owns: (p) => p.startsWith("write-offs/") },
   { key: "billingRuns", owns: (p) => p.startsWith("billing-runs/") },
   { key: "accontoDeductions", owns: (p) => p.startsWith("acconto-deductions/") },
   { key: "expectedReceivables", owns: (p) => p.startsWith("expected-receivables/") },

--- a/test/e2e/_demo-test.ts
+++ b/test/e2e/_demo-test.ts
@@ -106,6 +106,7 @@ export interface DemoSeed {
   documents: Array<{ id: string; matterId: string; title: string }>;
   timeEntries: Array<{ id: string; matterId: string; description: string }>;
   expenses: Array<{ id: string; matterId: string; description: string }>;
+  paymentPlans: Array<{ id: string; invoiceId: string; status: string }>;
 }
 
 /** Grupper som bär `matterId` — det e2e:t kan kräva att ett ärende har. */

--- a/test/e2e/demo-smoke.spec.ts
+++ b/test/e2e/demo-smoke.spec.ts
@@ -107,15 +107,22 @@ test("matter-detalj öppnas på sitt eget id utan loop", async ({ page }) => {
   expect(errors, "inga script-errors").toEqual([]);
 });
 
-test("avbetalningsplaner-sidan renderar", async ({ page }) => {
-  // Sidan hade förr en assertion om `pp-`-länkar. Demons simulering (#880)
-  // producerar inga avbetalningsplaner alls längre — se #982 — så ett test som
-  // kräver planrader skulle påstå något om data som inte finns. Kvar är att
-  // sidan renderar sitt tomläge utan att krascha.
+test("avbetalningsplaner-sidan listar seedens aktiva planer", async ({ page }) => {
+  // Sidan var tom mellan #880 och #982: simuleringen ersatte populate-billing men
+  // tog inte över dess faktura-livscykler. Assertionen går på ÄRENDETS titel via
+  // planens faktura — så testet fäller om kedjan plan → faktura → ärende brister,
+  // inte bara om tabellen råkar ha rader.
   const errors: string[] = [];
   page.on("pageerror", (e) => errors.push(`pageerror: ${e.message}`));
+  const seed = await fetchDemoSeed(page, BASE);
+  const active = seed.paymentPlans.find((p) => p.status === "ACTIVE");
+  if (!active) throw new Error("seeden saknar aktiv avbetalningsplan — se #982");
+  const matterId = seed.invoices.find((i) => i.id === active.invoiceId)?.matterId;
+  const title = seed.matters.find((m) => m.id === matterId)?.title ?? "";
+
   await page.goto(`${BASE}/payment-plans/`);
-  await expect(page.locator("body")).toContainText(/Avbetalningsplaner/i, { timeout: 15_000 });
+  // Sidan öppnar på fliken Aktiva, så den aktiva planens ärende ska synas direkt.
+  await expect(page.locator("body")).toContainText(title, { timeout: 15_000 });
   expect(errors, "inga script-errors").toEqual([]);
 });
 

--- a/test/scripts/demo-prutning.test.ts
+++ b/test/scripts/demo-prutning.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect } from "vitest-compat";
 import type { SimMatter } from "../../tooling/demo-generator/simulate/events";
-import { runScenario, type RunCtx } from "../../tooling/demo-generator/simulate/runner";
+import { emptyRunResult, runScenario, type RunCtx } from "../../tooling/demo-generator/simulate/runner";
 import { buildScenario } from "../../tooling/demo-generator/simulate/scenarios";
 import { buildRattshjalpScenario } from "../../tooling/demo-generator/simulate/scenarios/rattshjalp";
 
@@ -50,7 +50,7 @@ const rhMatter = (nr: string): SimMatter => ({
 
 async function beslutArgs(events: Any[], matter: SimMatter): Promise<Any> {
   const { c, calls } = recordingCaller();
-  const ctx: RunCtx = { c, res: { invoices: 0, documents: 0, timeEntries: 0, notes: 0, credits: 0 } };
+  const ctx: RunCtx = { c, res: emptyRunResult() };
   await runScenario(ctx, matter, events);
   return calls.find((x) => x.method === "billingRun.recordKostnadsrakningBeslut")?.args;
 }

--- a/test/scripts/simulate-orchestrate.test.ts
+++ b/test/scripts/simulate-orchestrate.test.ts
@@ -12,7 +12,7 @@ import { createGitTarget } from "../../tooling/demo-generator/backend-target";
 import { createIdTranslator, translateSeed } from "../../tooling/demo-generator/id-translator";
 import { populate } from "../../tooling/demo-generator/populate";
 import { runSimulation } from "../../tooling/demo-generator/simulate/orchestrate";
-import type { RunCtx } from "../../tooling/demo-generator/simulate/runner";
+import { emptyRunResult, type RunCtx } from "../../tooling/demo-generator/simulate/runner";
 import { buildSeed } from "../../tooling/scripts/seed-data";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -27,7 +27,7 @@ describe("runSimulation (#880 integration)", () => {
     const coreSeed = { ...seed, matters: seed.matters.map((m: Any) => ({ ...m, status: "ACTIVE" })), timeEntries: [], expenses: [], matterContacts: [], documents: [], serviceNotes: [] };
     await populate(target.caller, coreSeed);
 
-    const ctx: RunCtx = { c: target.caller, res: { invoices: 0, documents: 0, timeEntries: 0, notes: 0, credits: 0 } };
+    const ctx: RunCtx = { c: target.caller, res: emptyRunResult() };
     await runSimulation(ctx, seed);
 
     // Simuleringen skapade faktiskt saker (fångar "0 av allt"-regressionen).
@@ -73,5 +73,42 @@ describe("runSimulation (#880 integration)", () => {
     const recips = new Set(settlementRuns.filter((r) => r.type === "FINAL").map((r) => r.recipient));
     expect(recips.has("KLIENT")).toBe(true);
     expect(recips.has("DOMSTOL")).toBe(true);
+  });
+
+  /**
+   * #982: simuleringen ersatte `populate-billing.ts` men tog inte över dess
+   * faktura-livscykler, så demon hade noll avbetalningsplaner och noll
+   * avskrivningar. Det upptäcktes först av ett e2e-test — inget steg sa något.
+   * Testet nedan är den saknade grinden: det påstår om DEMONS DATA, inte om
+   * scenariomallen, att varje tillstånd faktiskt uppstår.
+   */
+  it("privatärendenas livscykler ger planer i alla tre tillstånd + en kundförlust", async () => {
+    const seed = translateSeed(buildSeed(), createIdTranslator()) as Any;
+    const orgId = String(seed.organizations[0].id);
+    const admin = { id: asId<"UserId">("gen"), email: "g@a.se", name: "G", role: userRoleSchema.parse("ADMIN"), organizationId: asId<"OrganizationId">(orgId) };
+    const target = createGitTarget({ principal: admin, writeBack: async () => {} });
+    const coreSeed = { ...seed, matters: seed.matters.map((m: Any) => ({ ...m, status: "ACTIVE" })), timeEntries: [], expenses: [], matterContacts: [], documents: [], serviceNotes: [] };
+    await populate(target.caller, coreSeed);
+
+    const ctx: RunCtx = { c: target.caller, res: emptyRunResult() };
+    await runSimulation(ctx, seed);
+
+    const c = target.caller as Any;
+    const plans = await c.paymentPlan.list({});
+    const statuses = new Set((plans as Any[]).map((p) => p.status));
+    // Cykeln i `privat.ts` är sex lång och seeden har fler privatärenden än så,
+    // så alla tre tillstånden ska förekomma. Slår detta fel har antingen cykeln
+    // ändrats eller antalet privatärenden fallit under sex.
+    expect(statuses.has("ACTIVE"), "aktiv plan").toBe(true);
+    expect(statuses.has("COMPLETED"), "slutförd plan").toBe(true);
+    expect(statuses.has("CANCELLED"), "avbruten plan").toBe(true);
+    expect(ctx.res.reminders, "påminnelser skickade").toBeGreaterThan(0);
+
+    // Kundförlusten stänger sin faktura som BAD_DEBT (ADR 0007).
+    expect(ctx.res.writeOffs).toBeGreaterThan(0);
+    const invoices = await c.invoice.list({}) as Any[];
+    expect(invoices.some((i) => i.status === "BAD_DEBT"), "avskriven faktura").toBe(true);
+    // …och en plan-faktura står som INSTALLMENT_PLAN, inte som vanlig SENT.
+    expect(invoices.some((i) => i.status === "INSTALLMENT_PLAN"), "faktura med plan").toBe(true);
   });
 });

--- a/test/scripts/simulate-runner.test.ts
+++ b/test/scripts/simulate-runner.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect } from "vitest-compat";
 import type { SimMatter } from "../../tooling/demo-generator/simulate/events";
-import { runScenario, type RunCtx } from "../../tooling/demo-generator/simulate/runner";
+import { emptyRunResult, runScenario, type RunCtx } from "../../tooling/demo-generator/simulate/runner";
 import { buildRattshjalpScenario } from "../../tooling/demo-generator/simulate/scenarios/rattshjalp";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -20,6 +20,7 @@ function recordingCaller() {
     if (method === "billingRun.createAcconto") return { run: { id: "run" }, invoice: { id: `inv-${calls.length}` } };
     if (method === "billingRun.createKostnadsrakning") return { run: { id: "kr", workValueOreAtRun: 1_544_700 } };
     if (method === "billingRun.createFinal") return { invoice: { id: "fin", amount: 100_000 } };
+    if (method === "invoice.createPaymentPlan") return { id: "plan-1" };
     if (method === "billingRun.settleCoverage") return { creditInvoice: { id: "cred", amount: -50_000 }, clientInvoice: {}, payerInvoice: {} };
     return {};
   };
@@ -29,7 +30,12 @@ function recordingCaller() {
     serviceNote: { create: rec("serviceNote.create") },
     expense: { create: rec("expense.create") },
     document: { register: rec("document.register") },
-    invoice: { createRadgivning: rec("invoice.createRadgivning"), setStatus: rec("invoice.setStatus"), recordPayment: rec("invoice.recordPayment") },
+    invoice: {
+      createRadgivning: rec("invoice.createRadgivning"), setStatus: rec("invoice.setStatus"),
+      recordPayment: rec("invoice.recordPayment"), createPaymentPlan: rec("invoice.createPaymentPlan"),
+      cancelPaymentPlan: rec("invoice.cancelPaymentPlan"), writeOff: rec("invoice.writeOff"),
+    },
+    paymentPlan: { recordReminder: rec("paymentPlan.recordReminder") },
     billingRun: {
       createAcconto: rec("billingRun.createAcconto"), createKostnadsrakning: rec("billingRun.createKostnadsrakning"),
       recordKostnadsrakningBeslut: rec("billingRun.recordKostnadsrakningBeslut"), settleCoverage: rec("billingRun.settleCoverage"),
@@ -47,7 +53,7 @@ const MATTER: SimMatter = {
 describe("runScenario (#880)", () => {
   it("spelar upp rättshjälps-scenariot kronologiskt med härledda aconto-belopp", async () => {
     const { c, calls } = recordingCaller();
-    const ctx: RunCtx = { c, res: { invoices: 0, documents: 0, timeEntries: 0, notes: 0, credits: 0 } };
+    const ctx: RunCtx = { c, res: emptyRunResult() };
     const events = buildRattshjalpScenario({ klient: "c-klient", motpart: "c-mot", motpartsombud: "c-omb", domstol: "c-dom" });
     await runScenario(ctx, MATTER, events);
 
@@ -100,12 +106,90 @@ describe("runScenario (#880)", () => {
   it("skickar INGA aconton om byråns gränsbelopp ligger över det upparbetade (#885)", async () => {
     const { c, calls } = recordingCaller();
     // Gränsbelopp långt över klientens totala andel → tröskeln nås aldrig.
-    const ctx: RunCtx = { c, accontoThresholdOre: 50_000_000, res: { invoices: 0, documents: 0, timeEntries: 0, notes: 0, credits: 0 } };
+    const ctx: RunCtx = { c, accontoThresholdOre: 50_000_000, res: emptyRunResult() };
     const events = buildRattshjalpScenario({ motpart: "c-mot", motpartsombud: "c-omb", domstol: "c-dom" });
     await runScenario(ctx, MATTER, events);
     expect(calls.filter((x) => x.method === "billingRun.createAcconto")).toHaveLength(0);
     // Rådgivning + kostnadsräkning + slutreglering körs fortfarande.
     expect(calls.some((x) => x.method === "invoice.createRadgivning")).toBe(true);
     expect(calls.some((x) => x.method === "billingRun.settleCoverage")).toBe(true);
+  });
+});
+
+/**
+ * Fakturans livscykler (#982). De låg i `populate-billing.ts` och slutade köras
+ * när simuleringen tog över (#880) — `/payment-plans` stod tom i demon och
+ * avskrivningsvägen visades aldrig. Testerna nedan vaktar de tre plan-tillstånden
+ * och kundförlusten var för sig, mot inspelningsstubben.
+ */
+describe("fakturans livscykler i simuleringen (#982)", () => {
+  const PRIVAT: SimMatter = { id: "m-p", paymentMethod: "PRIVAT", lawyerId: "u-1", startDaysAgo: 300, arvodeRateOre: 250_000 };
+
+  /** Kör bara `final` + de livscykel-event testet gäller. */
+  async function run(events: Any[]) {
+    const { c, calls } = recordingCaller();
+    const ctx: RunCtx = { c, res: emptyRunResult() };
+    await runScenario(ctx, PRIVAT, [{ kind: "final", dayOffset: 0, recipient: "KLIENT" }, ...events]);
+    return { calls, ctx };
+  }
+
+  it("ACTIVE-plan: månadsbeloppet härleds ur fakturan och delbetalningarna dateras framåt", async () => {
+    const { calls, ctx } = await run([{ kind: "paymentPlan", dayOffset: 1, installments: 5, paidInstallments: 2, reminders: 2 }]);
+
+    const plan = calls.find((x) => x.method === "invoice.createPaymentPlan")!;
+    expect(plan.args.invoiceId).toBe("fin");
+    expect(plan.args.monthlyAmount).toBe(20_000); // 100 000 / 5
+    expect(ctx.res.paymentPlans).toBe(1);
+
+    // Två påminnelser, i månadsformat, och två delbetalningar — inte fler.
+    const reminders = calls.filter((x) => x.method === "paymentPlan.recordReminder");
+    expect(reminders).toHaveLength(2);
+    expect(reminders.every((r) => /^\d{4}-\d{2}$/.test(String(r.args.dueMonth)))).toBe(true);
+    const pays = calls.filter((x) => x.method === "invoice.recordPayment");
+    expect(pays.map((p) => p.args.amount)).toEqual([20_000, 20_000]);
+    // Planen lämnas ACTIVE: varken avbruten eller fullbetald.
+    expect(calls.some((x) => x.method === "invoice.cancelPaymentPlan")).toBe(false);
+  });
+
+  it("COMPLETED-plan: summan av delbetalningarna är EXAKT fakturabeloppet", async () => {
+    // 100 000 / 3 avrundas UPP till 33 334 — tre sådana blir 100 002, vilket
+    // routerns partitionsvakt (ADR 0007) avvisar. Sista posten måste kapas.
+    const { calls } = await run([{ kind: "paymentPlan", dayOffset: 1, installments: 3, paidInstallments: 3 }]);
+    const amounts = calls.filter((x) => x.method === "invoice.recordPayment").map((p) => Number(p.args.amount));
+    expect(amounts).toEqual([33_334, 33_334, 33_332]);
+    expect(amounts.reduce((s, a) => s + a, 0)).toBe(100_000);
+  });
+
+  it("CANCELLED-plan: avbryts EFTER inbetalningarna, så gjorda betalningar ligger kvar", async () => {
+    const { calls } = await run([{ kind: "paymentPlan", dayOffset: 1, installments: 6, paidInstallments: 1, cancel: true }]);
+    const payIdx = calls.findIndex((x) => x.method === "invoice.recordPayment");
+    const cancelIdx = calls.findIndex((x) => x.method === "invoice.cancelPaymentPlan");
+    expect(payIdx).toBeGreaterThanOrEqual(0);
+    expect(cancelIdx).toBeGreaterThan(payIdx);
+    expect(calls[cancelIdx]!.args.planId).toBe("plan-1");
+  });
+
+  it("kundförlust: delbetalning först, sedan avskrivning UTAN belopp (routern räknar återstoden)", async () => {
+    const { calls, ctx } = await run([{ kind: "writeOff", dayOffset: 1, partialBips: 2500 }]);
+    const pay = calls.find((x) => x.method === "invoice.recordPayment")!;
+    expect(pay.args.amount).toBe(25_000); // 25 % av 100 000
+    const wo = calls.find((x) => x.method === "invoice.writeOff")!;
+    expect(wo.args.invoiceId).toBe("fin");
+    // Inget `amount`: återstoden härleds ur ledgern, så simuleringen inte
+    // duplicerar den matematiken (och inte kan komma ur synk med den).
+    expect(wo.args.amount).toBeUndefined();
+    expect(ctx.res.writeOffs).toBe(1);
+  });
+
+  it("utan slutfaktura händer ingenting — inga anrop mot en faktura som inte finns", async () => {
+    const { c, calls } = recordingCaller();
+    const ctx: RunCtx = { c, res: emptyRunResult() };
+    await runScenario(ctx, PRIVAT, [
+      { kind: "paymentPlan", dayOffset: 1, installments: 3, paidInstallments: 1 },
+      { kind: "writeOff", dayOffset: 2 },
+    ]);
+    expect(calls).toHaveLength(0);
+    expect(ctx.res.paymentPlans).toBe(0);
+    expect(ctx.res.writeOffs).toBe(0);
   });
 });

--- a/test/unit/lib/demo/demo-source-keys.test.ts
+++ b/test/unit/lib/demo/demo-source-keys.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, it, expect } from "vitest-compat";
 import { pathToSourceKey } from "@/lib/client/demo/demo-source-keys";
+import { ENTITY_REGISTRY } from "@/lib/shared/schemas";
 
 describe("pathToSourceKey", () => {
   it("mappar kärnentiteter till sina plural-nycklar", () => {
@@ -29,6 +30,9 @@ describe("pathToSourceKey", () => {
     expect(pathToSourceKey("calendar/e1.json")).toBe("calendarEvents");
     expect(pathToSourceKey("payment-plans/p1.json")).toBe("paymentPlans");
     expect(pathToSourceKey("payment-plan-reminders/r1.json")).toBe("paymentPlanReminders");
+    // #982: saknades helt → varje avskrivning tappades tyst av demon, och
+    // migrate-on-read (ADR 0007) täckte över det med en gissad ersättningspost.
+    expect(pathToSourceKey("write-offs/w1.json")).toBe("writeOffs");
     expect(pathToSourceKey(".ava/templates/t1.json")).toBe("documentTemplates");
     expect(pathToSourceKey(".ava/organizations/o1.json")).toBe("organizations");
     expect(pathToSourceKey(".ava/user-preferences/up1.json")).toBe("userPreferences");
@@ -39,5 +43,46 @@ describe("pathToSourceKey", () => {
     expect(pathToSourceKey(".ava/meta.json")).toBeNull();
     expect(pathToSourceKey("manifest.json")).toBeNull();
     expect(pathToSourceKey("README.md")).toBeNull();
+  });
+});
+
+/**
+ * Strukturell grind (#982). Listan ovan räknar upp entiteter en och en, och
+ * missar därför den entitet ingen kom ihåg att lägga till — precis vad som hände
+ * `write-offs/`: filerna skrevs, hamnade i manifestet, och släpptes sedan tyst av
+ * loadern. Ingenting sa ifrån, eftersom migrate-on-read syntetiserade en
+ * ersättningspost som fick ledgern att summera rätt.
+ *
+ * Testet nedan härleder i stället kravet ur `ENTITY_REGISTRY`, som redan bär
+ * både `gitPrefix` och `sourceKey`. Ny entitet utan matcher → rött.
+ */
+describe("pathToSourceKey täcker ENTITY_REGISTRY", () => {
+  /**
+   * Entiteter som medvetet INTE hydreras i demon ännu. Var och en är ett känt
+   * glapp av samma sort som write-offs, inte ett designbeslut — de tas in när
+   * någon avgör vad de ska visa (#985). Att de står här och inte i tystnad är
+   * hela poängen: listan måste krympa, aldrig växa.
+   */
+  const NOT_YET_HYDRATED = new Set([
+    "documentFolder", "documentAnalysisSuggestion", "matterEventSuggestion", "invoiceDispatch",
+  ]);
+
+  it("varje registrerad entitets gitPrefix mappar till sin sourceKey", () => {
+    const gaps: string[] = [];
+    for (const [name, entry] of Object.entries(ENTITY_REGISTRY)) {
+      if (NOT_YET_HYDRATED.has(name)) continue;
+      const got = pathToSourceKey(`${entry.gitPrefix}/x.json`);
+      if (got !== entry.sourceKey) gaps.push(`${name}: ${entry.gitPrefix}/ → ${got} (väntat ${entry.sourceKey})`);
+    }
+    expect(gaps, "entiteter vars filer loadern skulle släppa tyst").toEqual([]);
+  });
+
+  it("undantagslistan innehåller bara entiteter som faktiskt finns", () => {
+    // Skydd mot att en rad blir kvar efter att entiteten tagits in eller bytt namn.
+    for (const name of NOT_YET_HYDRATED) {
+      const entry = ENTITY_REGISTRY[name as keyof typeof ENTITY_REGISTRY] as { gitPrefix: string } | undefined;
+      expect(entry, `${name} finns i registret`).toBeDefined();
+      expect(pathToSourceKey(`${entry?.gitPrefix ?? "saknas"}/x.json`)).toBeNull();
+    }
   });
 });

--- a/tooling/demo-generator/generate-into.ts
+++ b/tooling/demo-generator/generate-into.ts
@@ -23,7 +23,7 @@ import { populate, type PopulateResult } from "./populate";
 import { populateInvoiceDocs } from "./populate-invoice-docs";
 import { populateKostnadsrakningDocs } from "./populate-kostnadsrakning-docs";
 import { runSimulation } from "./simulate/orchestrate";
-import type { RunCtx } from "./simulate/runner";
+import { emptyRunResult, type RunCtx } from "./simulate/runner";
 
 export interface GenerateResult extends PopulateResult {
   /** Narrativa dokument (in/ut) skapade av simuleringen. */
@@ -71,7 +71,7 @@ export async function generateInto(outDir: string, seedOpts: BuildSeedOpts = {})
   };
   // Kronologisk simulering per ärende (#880): parter → rådgivning → arbete/dokument
   // (in/ut) → aconton → kostnadsräkning/slutreglering, i tidsordning.
-  const ctx: RunCtx = { c: target.caller, sink, res: { invoices: 0, documents: 0, timeEntries: 0, notes: 0, credits: 0 } };
+  const ctx: RunCtx = { c: target.caller, sink, res: emptyRunResult() };
   await runSimulation(ctx, seed);
 
   // Faktura-/KR-HTML-dokument som EFTER-pass (läser skapade fakturor/runs; renderar

--- a/tooling/demo-generator/simulate/clock.ts
+++ b/tooling/demo-generator/simulate/clock.ts
@@ -10,10 +10,14 @@
 /** ISO-datum för ett event: ärendestart (startDaysAgo sedan) + dayOffset dagar. */
 export function eventIso(startDaysAgo: number, dayOffset: number, hour = 10): string {
   const daysAgo = Math.max(0, startDaysAgo - dayOffset);
-  const d = new Date();
+  const now = new Date();
+  const d = new Date(now);
   d.setHours(hour, 0, 0, 0);
   d.setDate(d.getDate() - daysAgo);
-  return d.toISOString();
+  // Dag-klampningen ovan räcker inte: `hour` sätts EFTERÅT, så ett event i ett
+  // färskt ärende landade på "idag kl 11" även när bygget kördes kl 06 — en
+  // betalning eller avskrivning daterad i framtiden. Klampa hela tidpunkten.
+  return (d > now ? now : d).toISOString();
 }
 
 /** Klockslag (HH:MM) för en tjänsteanteckning, härlett ur timmen. */

--- a/tooling/demo-generator/simulate/events.ts
+++ b/tooling/demo-generator/simulate/events.ts
@@ -47,7 +47,27 @@ export type SimEvent =
   /** Vanlig slutfaktura (privat/offentligt) — createFinal + SENT. */
   | { kind: "final"; dayOffset: number; recipient: string }
   /** Betala den senast skapade slutfakturan — invoice.recordPayment. */
-  | { kind: "payment"; dayOffset: number };
+  | { kind: "payment"; dayOffset: number }
+  /**
+   * Avbetalningsplan på den senast skapade slutfakturan (#982) —
+   * `invoice.createPaymentPlan`. Månadsbeloppet HÄRLEDS ur fakturan
+   * (`amount / installments`), som i appens eget flöde.
+   *
+   * Planens sluttillstånd följer av vad som händer efteråt, inte av en flagga:
+   *   • `paidInstallments < installments` → planen förblir ACTIVE
+   *   • `paidInstallments >= installments` → sista betalningen stänger fakturan,
+   *     och routern sätter planen till COMPLETED
+   *   • `cancel` → CANCELLED, och fakturan går tillbaka till SENT
+   *
+   * `reminders` skickar N månatliga DUE-påminnelser bakåt i tiden.
+   */
+  | { kind: "paymentPlan"; dayOffset: number; installments: number; paidInstallments: number; dayOfMonth?: number; reminders?: number; cancel?: boolean; notes?: string }
+  /**
+   * Konstaterad kundförlust på den senaste slutfakturan (ADR 0007) —
+   * `invoice.writeOff`. `partialBips` betalar först en del (2500 = 25 %); resten
+   * skrivs av, vilket stänger fakturan som BAD_DEBT.
+   */
+  | { kind: "writeOff"; dayOffset: number; partialBips?: number; reason?: string };
 
 /** Det runnern behöver veta om ärendet för att spela upp dess scenario. */
 export interface SimMatter {

--- a/tooling/demo-generator/simulate/orchestrate.ts
+++ b/tooling/demo-generator/simulate/orchestrate.ts
@@ -46,14 +46,31 @@ function deriveParties(matterId: string, seedContacts: Any[]): Parties {
   return { klient: byRole("KLIENT"), motpart: byRole("MOTPART"), motpartsombud: byRole("MOTPARTSOMBUD"), domstol: byRole("DOMSTOL") };
 }
 
-/** Kör ett ärendes scenario + stäng det om seedens status inte är ACTIVE. */
-async function simulateMatter(ctx: RunCtx, m: Any, users: { id: string; rateOre: number }[], seedContacts: Any[], index: number): Promise<void> {
+/**
+ * Kör ett ärendes scenario + stäng det om seedens status inte är ACTIVE.
+ *
+ * Två index, med olika jobb: `index` är ärendets globala ordning (styr vilken
+ * jurist som blir ansvarig), `variantIndex` räknar ärenden PER betalningssätt
+ * och väljer scenariovariant. Skillnaden spelar roll sedan #982: privatärendenas
+ * livscykel-cykel är sex lång, och med det globala indexet hade urvalet berott på
+ * hur många rättshjälps- och rättsskyddsärenden som råkade ligga före i seeden.
+ */
+interface MatterSlot {
+  /** Ärendets globala ordning i seeden — round-robin för ansvarig jurist. */
+  index: number;
+  /** Löpnummer inom betalningssättet — scenariovariant. */
+  variantIndex: number;
+}
+
+async function simulateMatter(
+  ctx: RunCtx, m: Any, users: { id: string; rateOre: number }[], seedContacts: Any[], slot: MatterSlot,
+): Promise<void> {
   // Seed-ärenden saknar responsibleLawyerId → välj ansvarig jurist deterministiskt ur
   // användarlistan (som gamla buildTimeEntries: round-robin per ärende-index).
-  const u = users[index % Math.max(1, users.length)];
+  const u = users[slot.index % Math.max(1, users.length)];
   if (!u) return;
   const sim = deriveSim(m, u.id, u.rateOre);
-  await runScenario(ctx, sim, buildScenario(sim, deriveParties(String(m.id), seedContacts), index));
+  await runScenario(ctx, sim, buildScenario(sim, deriveParties(String(m.id), seedContacts), slot.variantIndex));
   if (String(m.status) !== "ACTIVE") await ctx.c.matter.update({ id: sim.id, status: String(m.status) });
 }
 
@@ -68,8 +85,19 @@ export async function runSimulation(ctx: RunCtx, seed: Any): Promise<void> {
   // Parterna länkas kronologiskt ur seedens matterContacts (klient/motpart/ombud/domstol).
   const seedContacts: Any[] = seed.matterContacts ?? [];
   let index = 0;
+  const variants = new Map<string, number>();
   for (const m of seed.matters ?? []) {
-    await simulateMatter(ctx, m, users, seedContacts, index);
+    await simulateMatter(ctx, m, users, seedContacts, {
+      index, variantIndex: nextVariant(variants, String(m.paymentMethod)),
+    });
     index++;
   }
+}
+
+/** Löpnummer per betalningssätt — scenariovariantens index. Egen funktion så
+ *  `runSimulation` håller sig under komplexitetstaket (8). */
+function nextVariant(counters: Map<string, number>, key: string): number {
+  const n = counters.get(key) ?? 0;
+  counters.set(key, n + 1);
+  return n;
 }

--- a/tooling/demo-generator/simulate/runner.ts
+++ b/tooling/demo-generator/simulate/runner.ts
@@ -10,6 +10,7 @@ import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
 import { SJALVRISK_ACCONTO_THRESHOLD_ORE } from "@/lib/shared/rattshjalp";
 import type { SettlementViewLine } from "@/lib/shared/settlement-view";
 import { AVA_NAMESPACE, uuidv5 } from "@/lib/shared/uuid-derive";
+import { demoPaymentPlanId } from "../../scripts/demo-billing-ids";
 import type { BinarySink } from "../populate-documents";
 import { eventIso, eventTime } from "./clock";
 import type { SimEvent, SimMatter } from "./events";
@@ -23,7 +24,14 @@ export interface RunCtx {
   sink?: BinarySink;
   /** Gränsbelopp (öre) för tröskelstyrd aconto-utskick (#885); default = konstanten. */
   accontoThresholdOre?: number;
-  res: { invoices: number; documents: number; timeEntries: number; notes: number; credits: number };
+  res: { invoices: number; documents: number; timeEntries: number; notes: number; credits: number; paymentPlans: number; reminders: number; writeOffs: number };
+}
+
+/** Nollställda räknare. Factory i stället för ett objekt-literal per anropsplats:
+ *  räknarna växer med simuleringens täckning (#982 lade till tre), och literalen
+ *  fanns då på sex ställen — två i verktygen, fyra i testerna. */
+export function emptyRunResult(): RunCtx["res"] {
+  return { invoices: 0, documents: 0, timeEntries: 0, notes: 0, credits: 0, paymentPlans: 0, reminders: 0, writeOffs: 0 };
 }
 
 interface SimState {
@@ -220,10 +228,97 @@ async function hPayment(ctx: RunCtx, _m: SimMatter, _e: Any, iso: string, st: Si
   await ctx.c.invoice.recordPayment({ invoiceId: st.lastFinal.id, amount: st.lastFinal.amount, paidAt: iso, note: "Full betalning" });
 }
 
+/** `iso` förskjuten `n` månader (negativt = bakåt), aldrig senare än nu — en
+ *  betalning daterad i framtiden vore inte demodata utan en bugg. */
+function shiftMonths(iso: string, n: number): Date {
+  const d = new Date(iso);
+  d.setMonth(d.getMonth() + n);
+  const now = new Date();
+  return d > now ? now : d;
+}
+
+/** Månad `n` bakåt från `iso` som "YYYY-MM" — påminnelsernas `dueMonth`. */
+function monthsBack(iso: string, n: number): string {
+  const d = shiftMonths(iso, -n);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+}
+
+/** En avbetalningsplans inbetalningar: vad, hur mycket, hur många, från när. */
+interface InstallmentRun { invoiceId: string; monthly: number; total: number; count: number; iso: string }
+
+/** Månadsvisa delbetalningar. Sista posten kapas till ÅTERSTODEN — annars
+ *  översumerar den fakturan och routerns partitionsvakt (ADR 0007) avvisar den. */
+async function payInstallments(ctx: RunCtx, run: InstallmentRun): Promise<void> {
+  let paid = 0;
+  for (let m = 0; m < run.count; m++) {
+    const amount = Math.min(run.monthly, run.total - paid);
+    if (amount <= 0) return;
+    await ctx.c.invoice.recordPayment({
+      invoiceId: run.invoiceId, amount,
+      paidAt: shiftMonths(run.iso, m + 1).toISOString(), note: `Avbetalning ${m + 1}`,
+    });
+    paid += amount;
+  }
+}
+
+/** N månatliga DUE-påminnelser bakåt från `iso`. */
+async function sendPlanReminders(ctx: RunCtx, planId: string, iso: string, count: number): Promise<void> {
+  for (let n = count; n >= 1; n--) {
+    await ctx.c.paymentPlan.recordReminder({ planId, dueMonth: monthsBack(iso, n), type: "DUE" });
+    ctx.res.reminders++;
+  }
+}
+
+interface PlanArgs {
+  installments: number; paidInstallments: number; dayOfMonth: number;
+  reminders: number; cancel: boolean; notes?: string;
+}
+
+/** Eventets fält med defaults. Egen funktion för att hålla `hPaymentPlan` under
+ *  komplexitetstaket (8) — varje default räknas som en gren. */
+function planArgs(e: Any): PlanArgs {
+  const { installments = 3, paidInstallments = 0, dayOfMonth = 15, reminders = 0, cancel = false, notes } = e as Partial<PlanArgs>;
+  return { installments, paidInstallments, dayOfMonth, reminders, cancel, ...(notes === undefined ? {} : { notes }) };
+}
+
+/** Avbetalningsplan (#982) på den senaste slutfakturan. */
+async function hPaymentPlan(ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimState): Promise<void> {
+  const inv = st.lastFinal;
+  if (!inv || inv.amount <= 0) return;
+  const { installments, paidInstallments, dayOfMonth, reminders, cancel, notes } = planArgs(e);
+  const monthly = Math.ceil(inv.amount / Math.max(1, installments));
+  const plan = await ctx.c.invoice.createPaymentPlan({
+    id: demoPaymentPlanId(m.id), invoiceId: inv.id, monthlyAmount: monthly,
+    dayOfMonth, startDate: iso, ...(notes === undefined ? {} : { notes }),
+  });
+  ctx.res.paymentPlans++;
+  await sendPlanReminders(ctx, plan.id, iso, reminders);
+  await payInstallments(ctx, { invoiceId: inv.id, monthly, total: inv.amount, count: paidInstallments, iso });
+  // Avbryt EFTER betalningarna: en avbruten plan lämnar fakturan som SENT igen,
+  // och de inbetalningar som hann göras ligger kvar — precis som i verkligheten.
+  if (cancel) await ctx.c.invoice.cancelPaymentPlan({ planId: plan.id });
+}
+
+/** Konstaterad kundförlust (ADR 0007) på den senaste slutfakturan (#982). */
+async function hWriteOff(ctx: RunCtx, _m: SimMatter, e: Any, iso: string, st: SimState): Promise<void> {
+  const inv = st.lastFinal;
+  if (!inv || inv.amount <= 0) return;
+  const bips = Number(e.partialBips ?? 0);
+  if (bips > 0) {
+    const part = Math.floor((inv.amount * bips) / 10000);
+    if (part > 0) await ctx.c.invoice.recordPayment({ invoiceId: inv.id, amount: part, paidAt: iso, note: "Delbetalning" });
+  }
+  // Utan `amount` skrivs hela ÅTERSTODEN av — routern räknar ut den ur ledgern,
+  // så simuleringen slipper spegla den matematiken.
+  await ctx.c.invoice.writeOff({ invoiceId: inv.id, reason: String(e.reason ?? "Klient försatt i konkurs"), writtenOffAt: iso });
+  ctx.res.writeOffs++;
+}
+
 /** kind → handler. Håller runnern platt (undviker en stor switch = hög komplexitet). */
 const HANDLERS: Record<SimEvent["kind"], (ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimState) => Promise<void>> = {
   party: hParty, time: hTime, note: hNote, expense: hExpense, doc: hDoc, radgivning: hRadgivning,
   acconto: hAcconto, rateChange: hRateChange, kostnadsrakning: hKostnadsrakning, beslut: hBeslut, verdict: hVerdict, settle: hSettle, insurerPruning: hInsurerPruning, final: hFinal, payment: hPayment,
+  paymentPlan: hPaymentPlan, writeOff: hWriteOff,
 };
 
 /** Spela upp ett ärendes scenario kronologiskt. */

--- a/tooling/demo-generator/simulate/scenarios/privat.ts
+++ b/tooling/demo-generator/simulate/scenarios/privat.ts
@@ -1,10 +1,36 @@
 /**
  * Scenariomall för PRIVAT (#880): uppdrag → löpande arbete/utlägg/dokument →
- * slutfaktura till klienten → (oftast) betalning. Variation ur `index` så demon
- * får både betalda och obetalda slutfakturor.
+ * slutfaktura till klienten → en av fakturans livscykler.
+ *
+ * Livscyklerna (#982) fanns förr i `populate-billing.ts`, som slutade kallas när
+ * den kronologiska simuleringen tog över (#880). Fakturering och tid följde med;
+ * avbetalningsplanerna och avskrivningarna gjorde det inte, så `/payment-plans`
+ * stod tom i demon och avskrivningsvägen visades aldrig — trots att
+ * `computeInvoiceLedger` räknar med båda.
  */
 
 import type { Parties, SimEvent } from "../events";
+
+/**
+ * Slutfakturans livscykler, en per variant-index. Cykeln är sex lång och
+ * ordningen är avsiktlig: med sex eller fler privatärenden förekommer VARJE
+ * tillstånd minst en gång, så demon visar betald, utestående, alla tre
+ * plan-tillstånden och en kundförlust utan att något behöver slumpas.
+ */
+const LIFECYCLES: ReadonlyArray<(day: number) => SimEvent[]> = [
+  // Betald i sin helhet.
+  (d) => [{ kind: "payment", dayOffset: d }],
+  // Utestående — ingen händelse alls efter fakturan.
+  () => [],
+  // ACTIVE plan: 5 poster, 2 betalda, påminnelser utskickade.
+  (d) => [{ kind: "paymentPlan", dayOffset: d, installments: 5, paidInstallments: 2, reminders: 2 }],
+  // COMPLETED plan: alla poster betalda → sista betalningen stänger fakturan.
+  (d) => [{ kind: "paymentPlan", dayOffset: d, installments: 3, paidInstallments: 3, dayOfMonth: 1, reminders: 3 }],
+  // CANCELLED plan: avbruten utan inbetalningar → fakturan tillbaka som SENT.
+  (d) => [{ kind: "paymentPlan", dayOffset: d, installments: 6, paidInstallments: 0, dayOfMonth: 28, cancel: true, notes: "Avbruten på klientens begäran" }],
+  // Kundförlust (ADR 0007): delbetalning, resten avskriven.
+  (d) => [{ kind: "writeOff", dayOffset: d, partialBips: 2500 }],
+];
 
 export function buildPrivatScenario(parties: Parties, index: number): SimEvent[] {
   const ev: SimEvent[] = [
@@ -24,7 +50,6 @@ export function buildPrivatScenario(parties: Parties, index: number): SimEvent[]
     { kind: "time", dayOffset: 24, minutes: 90, description: "Förhandling och uppföljning" },
     { kind: "final", dayOffset: 30, recipient: "KLIENT" },
   );
-  // ~2 av 3 slutfakturor betalas; resten lämnas utestående (varierad demo).
-  if (index % 3 !== 2) ev.push({ kind: "payment", dayOffset: 44 });
+  ev.push(...(LIFECYCLES[index % LIFECYCLES.length] ?? LIFECYCLES[0]!)(44));
   return ev;
 }

--- a/tooling/scripts/build-demo-repo.ts
+++ b/tooling/scripts/build-demo-repo.ts
@@ -90,6 +90,9 @@ async function main(): Promise<void> {
   console.log(`  • ${result.users} användare, ${result.contacts} kontakter, ${result.matters} ärenden`);
   console.log(`  • simulering: ${result.sim.timeEntries} tidsposter, ${result.sim.notes} tjänsteanteckningar, ${result.documents} inkommande/utgående dokument`);
   console.log(`  • fakturering: ${result.sim.invoices} fakturor (${result.sim.credits} kreditfakturor), ${result.invoiceDocs} faktura-dok, ${result.kostnadsrakningDocs} kostnadsräkning-dok`);
+  // Räknas ut för att gapet i #982 ska SYNAS i loggen. Att demon tappade sina
+  // avbetalningsplaner upptäcktes först av ett e2e-test, för inget steg sa något.
+  console.log(`  • fakturalivscykler: ${result.sim.paymentPlans} avbetalningsplaner (${result.sim.reminders} påminnelser), ${result.sim.writeOffs} kundförluster`);
   console.log(`  • ${result.calendarEvents} kalender-events, ${result.tasks} tasks`);
   console.log("");
   console.log("Nästa steg (om du vill pusha till ulrik-s/ava-demo):");

--- a/tooling/scripts/seed-demo-into-server.ts
+++ b/tooling/scripts/seed-demo-into-server.ts
@@ -39,7 +39,7 @@ import { bootstrapOrgUsers, populate } from "../demo-generator/populate";
 import { populateInvoiceDocs } from "../demo-generator/populate-invoice-docs";
 import { populateKostnadsrakningDocs } from "../demo-generator/populate-kostnadsrakning-docs";
 import { runSimulation } from "../demo-generator/simulate/orchestrate";
-import type { RunCtx } from "../demo-generator/simulate/runner";
+import { emptyRunResult, type RunCtx } from "../demo-generator/simulate/runner";
 import { buildSeed, type SeedDataset } from "./seed-data";
 
 const DB_URL = process.env.AVA_DATABASE_URL ?? "postgres://ava:ava@localhost:5433/ava_test";
@@ -154,7 +154,7 @@ async function runRest(caller: GeneratorCaller, seed: SeedDataset, loginIds: Log
   const core = await populate(caller, coreSeed, { skipOrgUsers });
   // Kronologisk simulering — SAMMA motor som GH Pages-demon; doc-bytes → content-katalogen.
   const sink = contentSink();
-  const ctx: RunCtx = { c: caller, res: { invoices: 0, documents: 0, timeEntries: 0, notes: 0, credits: 0 }, ...(sink ? { sink } : {}) };
+  const ctx: RunCtx = { c: caller, res: emptyRunResult(), ...(sink ? { sink } : {}) };
   await runSimulation(ctx, seed);
   await addTodayTimeEntries(caller, seed.timeEntries as Row[], seed.matters as Row[], loginIds); // "idag"-tid för dashboarden
   const kostnadsrakningDocs = await seedKostnadsrakningDocs(caller);


### PR DESCRIPTION
Stänger #982.

## Problemet

Demon hade **noll** avbetalningsplaner och **noll** avskrivningar. `/payment-plans` var permanent tom, och avskrivningsvägen visades aldrig — trots att `computeInvoiceLedger` räknar med båda.

Simuleringen (#880) ersatte `populate-billing.ts` och tog över fakturering och tid, men inte faktura-livscyklerna. `lcActivePlan`, `lcCompletedPlan`, `lcCancelledPlan` och `lcWriteOff` låg kvar, oanropade; `grep -rn paymentPlan tooling/demo-generator/simulate/` gav noll träffar. Ingenting sa ifrån, eftersom inget steg räknade det som saknades.

## Livscyklerna som scenariosteg

Två nya `SimEvent`-varianter: `paymentPlan` och `writeOff`. Planens **sluttillstånd följer av vad som händer efteråt**, inte av en flagga — samma väg som appens eget flöde:

| Utfall | Hur |
|---|---|
| `ACTIVE` | färre betalda poster än planerade |
| `COMPLETED` | alla betalda → sista betalningen stänger fakturan och routern sätter planen |
| `CANCELLED` | `cancel: true`, **efter** inbetalningarna, så gjorda betalningar ligger kvar |

Sista delbetalningen kapas till återstoden: `100 000 / 3` avrundas upp till 33 334, och tre sådana blir 100 002 — vilket partitionsvakten (ADR 0007) med rätta avvisar. Avskrivningen skickas utan `amount`, så återstoden härleds ur ledgern i stället för att simuleringen speglar den matematiken.

Privatärendets variant väljs nu på ett **löpnummer per betalningssätt** i stället för ärendets globala index. Cykeln är sex lång; med det globala indexet hade urvalet berott på hur många rättshjälps- och rättsskyddsärenden som råkade ligga före i seeden.

## Två fynd på vägen

**1. `write-offs/` saknade matcher i `pathToSourceKey`** — demon tappade varje avskrivning, tyst. Att det aldrig märktes beror på migrate-on-read (ADR 0007): `synthesizeBadDebtWriteOffs` byggde en ersättningspost ur fakturans `BAD_DEBT`-status, med gissat datum (`updatedAt`) och reason `"Migrerad …"`. Ledgern summerade alltså rätt belopp av fel skäl.

Före fixen, i `demo-seed.json`:
```json
{"id": "wo-migrated-…", "reason": "Migrerad från BAD_DEBT-status (ADR 0007)", "migrated": true}
```
Efter:
```json
{"id": "msmvmwt2-qrt4hw", "reason": "Klient försatt i konkurs", "recordedById": "e1c7d494-…"}
```

Den strukturella grinden som lades till — härledd ur `ENTITY_REGISTRY`, som redan bär både `gitPrefix` och `sourceKey` — hittade **fyra entiteter till**. De är utbrutna till #985 med en dokumenterad `NOT_YET_HYDRATED`-lista, eftersom var och en är ett produktbeslut (dokumentmappar byter dokumentvyns form) och inte en mekanisk fix. Listan är en ratchet: den ska bara krympa.

**2. `eventIso` satte klockslaget efter dag-klampningen**, så ett event i ett färskt ärende kunde dateras i framtiden — jag såg en avskrivning stämplad 11:00 av ett bygge som kördes 06:49. Klampar nu hela tidpunkten.

## Resultat

`bun run build:demo` skriver nu ut räknarna, så nästa gap syns i loggen i stället för att upptäckas av ett e2e-test:

```
• fakturalivscykler: 4 avbetalningsplaner (7 påminnelser), 1 kundförluster
```

I `demo-seed.json`: `paymentPlans=4` (2 ACTIVE, 1 COMPLETED, 1 CANCELLED), `paymentPlanReminders=7`, `writeOffs=1`, `payments=10`. Fakturastatusarna har fått tillbaka `INSTALLMENT_PLAN=2` och `BAD_DEBT=1`.

## Tester

- **Enhet** (`simulate-runner.test.ts`, 5 nya): ett per plan-tillstånd + kundförlusten + "ingen slutfaktura → inga anrop". COMPLETED-fallet assertar `[33 334, 33 334, 33 332]` — exakt det avrundningsfel som partitionsvakten skulle ha fällt.
- **Integration** (`simulate-orchestrate.test.ts`): påstår om **demons data**, inte om scenariomallen, att alla tre plan-tillstånden uppstår och att en faktura står som `BAD_DEBT` respektive `INSTALLMENT_PLAN`. Det är den grind som saknades.
- **Strukturell** (`demo-source-keys.test.ts`): varje registrerad entitets `gitPrefix` måste mappa till sin `sourceKey`. Uppräkningen ovanför missade den entitet ingen kom ihåg — det var precis det som hände.
- **E2E**: `avbetalningsplaner-sidan listar seedens aktiva planer` går på ärendets titel via planens faktura, så kedjan plan → faktura → ärende testas, inte bara att tabellen har rader.

## Grindar

`typecheck` ✓ · `lint` ✓ · `lint:complexity-strict` ✓ · `knip` ✓ · `deps:check` ✓ (1114 moduler) · `jscpd` ✓ (7 kloner, oförändrat) · `build:demo` ✓ · **`e2e:demo` 28/28** ✓ · `test/scripts` + `test/integration` 249/249 ✓

Lint fällde tre av mina egna funktioner på komplexitet och parameterantal under arbetet. De är refaktorerade (`planArgs`, `sendPlanReminders`, `InstallmentRun`, `MatterSlot`, `nextVariant`) — inget undantag tillagt.

`test/unit/lib/demo` + `test/unit/components` vid katalogkörning: 412 pass / 42 fail mot `main`s 410 / 42 — samma fel, två nya gröna tester (#92).

#882 är avblockerad; kommenterad där med hur man kontrollerar att de återstående modulerna inte bär samma sorts oöverförda ansvar.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_