### PR TITLE
fix(documents): listvyn tappade halva kebab-menyn och scrollade på mobil

### DIFF
--- a/src/components/documents/_document-row.tsx
+++ b/src/components/documents/_document-row.tsx
@@ -221,7 +221,14 @@ function buildActionItems(o: ActionItemsOpts): ActionMenuItem[] {
   ];
 }
 
-function DocumentActions({
+/**
+ * Dokumentets kebab-meny. EXPORTERAD sedan #983: listvyn byggde tidigare en
+ * egen, kortare meny (Editera externt / Analysera igen / Ta bort) och tappade
+ * därmed Öppna, Visa och Ladda ner så fort användaren växlade vy — samma
+ * dokument, samma sida, olika möjligheter. Nu äger den här komponenten
+ * uppsättningen, så de två vyerna inte kan glida isär igen.
+ */
+export function DocumentActions({
   doc,
   disabled,
   onReanalyze,

--- a/src/components/documents/_documents-list-view.tsx
+++ b/src/components/documents/_documents-list-view.tsx
@@ -9,11 +9,10 @@
  */
 
 import { useState } from "react";
-import { ActionMenu, type ActionMenuItem } from "@/components/ui/action-menu";
 import { DataTable, type Column } from "@/components/ui/data-table";
 import { trpc } from "@/lib/client/trpc";
 import type { DocumentFolderId, MatterId } from "@/lib/shared/schemas/ids";
-import type { DocumentRecord } from "./_document-row";
+import { DocumentActions, type DocumentRecord } from "./_document-row";
 import { formatFileSize } from "./_drag-helpers";
 import type { FolderRecord } from "./_folder-row";
 import { SyncStatusBadge, type SyncStatus } from "./_sync-badge";
@@ -50,11 +49,15 @@ export function DocumentsListView({ matterId, documents, folders, docSync = NO_S
   const { openDocument, leaseModal } = useLeaseAwareOpen();
 
   const columns: Column<DocumentRecord>[] = [
-    { key: "fileName", label: "Filnamn", sortable: true, sortValue: (d) => d.fileName,
+    // `wrap`: filnamnet är det enda som ALLTID visas, så det måste få bryta
+    // rader i stället för att tvinga fram horisontell scroll. `min-w-0` på både
+    // flex-containern och knappen — en flex-container är shrink-to-fit och
+    // växer annars till sitt max-content, vilket `break-words` inte hjälper mot.
+    { key: "fileName", label: "Filnamn", sortable: true, wrap: true, sortValue: (d) => d.fileName,
       render: (d) => (
         <span className="flex items-center gap-2 min-w-0">
           <button type="button" onClick={() => void openDocument(d, setModal)}
-            className="text-sm font-medium text-blue-600 hover:underline text-left"
+            className="min-w-0 break-words text-sm font-medium text-blue-600 hover:underline text-left"
             title="PDF/Word/Excel → öppnas i extern editor om du har valt en lokal mapp">
             {d.fileName}
           </button>
@@ -62,35 +65,38 @@ export function DocumentsListView({ matterId, documents, folders, docSync = NO_S
         </span>
       ),
     },
-    { key: "documentType", label: "Typ", sortable: true,
+    // `hideBelow` (#983): listvyn visade sex kolumner även på 390 px och
+    // överflödade med 456 px. Träd-vyn dolde sina sekundära kolumner < sm hela
+    // tiden; nu gör listvyn det också. Kolumnerna finns kvar i sortering,
+    // filtrering och kolumnmenyn — bara `display` växlar.
+    { key: "documentType", label: "Typ", sortable: true, hideBelow: "sm",
       sortValue: (d) => d.documentType ?? "",
       render: (d) => <span className="text-sm text-gray-500">{d.documentType ?? "—"}</span> },
-    { key: "folder", label: "Mapp", sortable: true,
+    { key: "folder", label: "Mapp", sortable: true, hideBelow: "lg",
       sortValue: (d) => folderPath(d.folderId ?? null, folders),
       render: (d) => <span className="text-sm text-gray-500 font-mono">{folderPath(d.folderId ?? null, folders)}</span> },
-    { key: "uploadedBy", label: "Uppladdad av", sortable: true,
+    { key: "uploadedBy", label: "Uppladdad av", sortable: true, hideBelow: "lg",
       sortValue: (d) => d.uploadedBy?.name ?? "",
       render: (d) => <span className="text-sm text-gray-500">{d.uploadedBy?.name ?? "—"}</span> },
-    { key: "createdAt", label: "Datum", sortable: true,
+    { key: "createdAt", label: "Datum", sortable: true, hideBelow: "sm",
       sortValue: (d) => new Date(d.createdAt),
       render: (d) => <span className="text-sm text-gray-500">{new Date(d.createdAt).toLocaleDateString("sv-SE")}</span> },
-    { key: "sizeBytes", label: "Storlek", sortable: true, align: "right",
+    { key: "sizeBytes", label: "Storlek", sortable: true, align: "right", hideBelow: "md",
       sortValue: (d) => d.sizeBytes,
       render: (d) => <span className="text-sm font-mono text-gray-500">{formatFileSize(d.sizeBytes)}</span> },
     { key: "actions", label: "", sortable: false, align: "right", hideable: false,
-      render: (d) => {
-        const items: ActionMenuItem[] = [
-          { key: "external", label: "Editera externt", onSelect: () => void openDocument(d, setModal) },
-          { key: "reanalyze", label: "Analysera igen", onSelect: () => onReanalyze(d.id) },
-          {
-            key: "delete",
-            label: "Ta bort",
-            danger: true,
-            onSelect: () => { if (confirm(`Ta bort "${d.fileName}"?`)) onDelete(d.id); },
-          },
-        ];
-        return <ActionMenu items={items} label="Dokumentåtgärder" />;
-      },
+      // Samma meny som träd-vyn (#983) — se `DocumentActions`. `reanalyzePending`
+      // är false här: listvyn har ingen egen mutation-status att spegla, och en
+      // felaktigt disabled rad vore värre än en knapp som kan tryckas två gånger.
+      render: (d) => (
+        <DocumentActions
+          doc={d}
+          onExternalEdit={() => openDocument(d, setModal)}
+          onReanalyze={() => onReanalyze(d.id)}
+          onDelete={() => { if (confirm(`Ta bort "${d.fileName}"?`)) onDelete(d.id); }}
+          reanalyzePending={false}
+        />
+      ),
     },
   ];
 

--- a/src/components/ui/data-table-logic.ts
+++ b/src/components/ui/data-table-logic.ts
@@ -31,6 +31,19 @@ export interface Column<T> {
   /** Låt cellens innehåll wrappa över flera rader (annars `nowrap`). Använd
    *  för fri-text-kolumner (t.ex. tjänsteanteckningar) som annars trunkeras. */
   wrap?: boolean;
+  /**
+   * Dölj kolumnen under angiven brytpunkt (#983). RENT visuellt — kolumnen
+   * finns kvar i prefs, sortering och summering; bara `display` växlar.
+   *
+   * Skiljer sig från `defaultHidden`, som gäller ALLA skärmar tills användaren
+   * ber om kolumnen. Det här handlar om att en bred tabell annars tvingar fram
+   * horisontell scroll på mobil: träd-vyns dokumenttabell löste det med
+   * `hidden sm:table-cell` direkt i markupen, medan alla `DataTable`-tabeller
+   * saknade motsvarighet.
+   *
+   * Utelämnad → kolumnen visas på alla skärmar (oförändrat beteende).
+   */
+  hideBelow?: "sm" | "md" | "lg";
   hideable?: boolean;
   /** Kolumnen finns i katalogen men är inte visad förrän användaren explicit
    *  väljer "+ Visa kolumn → <denna>". Använd för fält som är intressanta
@@ -153,6 +166,23 @@ export function isColumnHidden<T>(col: Column<T>, prefs: DataTablePrefs): boolea
   const override = (prefs.columns ?? []).find((c) => c.key === col.key);
   if (override?.hidden !== undefined) return override.hidden;
   return Boolean(col.defaultHidden);
+}
+
+/**
+ * Tailwind-klasser för `hideBelow` (#983). Statiska strängar, inte
+ * interpolerade — Tailwind scannar källkoden och genererar bara klasser den
+ * SER, så `` `hidden ${bp}:table-cell` `` hade gett en klass som inte finns i
+ * bundlen och en kolumn som aldrig kom tillbaka på stora skärmar.
+ */
+const HIDE_BELOW_CLASS = {
+  sm: "hidden sm:table-cell",
+  md: "hidden md:table-cell",
+  lg: "hidden lg:table-cell",
+} as const satisfies Record<NonNullable<Column<unknown>["hideBelow"]>, string>;
+
+/** Responsiv döljningsklass för en kolumn — tom sträng när `hideBelow` saknas. */
+export function hideBelowClass<T>(col: Column<T>): string {
+  return col.hideBelow ? HIDE_BELOW_CLASS[col.hideBelow] : "";
 }
 
 export function visibleColumns<T>(columns: Column<T>[], prefs: DataTablePrefs): Column<T>[] {

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -24,13 +24,13 @@ import { trpc } from "@/lib/client/trpc";
 import type { SortDir, Column, DataTablePrefs, RowGroup } from "./data-table-logic";
 import {
   isFilterable, isGroupable, mergePrefs, sortRows, filterRows, groupRows,
-  isColumnHidden, visibleColumns, hasOverrides, hasSummary, buildSummaryContent,
+  isColumnHidden, visibleColumns, hasOverrides, hasSummary, buildSummaryContent, hideBelowClass,
 } from "./data-table-logic";
 
 export type { SortDir, Column, DataTablePrefs, RowGroup } from "./data-table-logic";
 export {
   isFilterable, isGroupable, mergePrefs, sortRows, filterRows, groupRows,
-  isColumnHidden, visibleColumns, hasOverrides, hasSummary, buildSummaryContent,
+  isColumnHidden, visibleColumns, hasOverrides, hasSummary, buildSummaryContent, hideBelowClass,
 } from "./data-table-logic";
 
 type FooterFn<T> = (rows: T[]) => Partial<Record<string, React.ReactNode>>;
@@ -54,7 +54,8 @@ function widthOf<T>(col: Column<T>, prefs: DataTablePrefs): number | undefined {
 /** Cell-klass för data-rader: wrappande kolumner bryter text över flera rader,
  *  övriga håller `nowrap` (default). */
 function cellClass<T>(col: Column<T>): string {
-  return `px-3 py-2 ${col.wrap ? "whitespace-normal break-words" : "whitespace-nowrap"}`;
+  const wrap = col.wrap ? "whitespace-normal break-words" : "whitespace-nowrap";
+  return `px-3 py-2 ${wrap} ${hideBelowClass(col)}`.trimEnd();
 }
 
 export function DataTable<T>({ prefKey, columns, data, rowKey, onRowClick, emptyMessage, footer }: Props<T>) {
@@ -366,7 +367,8 @@ function GroupSummaryRow<T>({ vCols, prefs, content }: { vCols: Column<T>[]; pre
   return (
     <tr className="bg-gray-100 border-t border-gray-300 text-xs font-semibold text-gray-800">
       {vCols.map((c) => (
-        <td key={c.key} style={{ width: widthOf(c, prefs), textAlign: c.align ?? "left" }} className="px-3 py-1.5 whitespace-nowrap">
+        <td key={c.key} style={{ width: widthOf(c, prefs), textAlign: c.align ?? "left" }}
+          className={`px-3 py-1.5 whitespace-nowrap ${hideBelowClass(c)}`.trimEnd()}>
           {content[c.key] ?? ""}
         </td>
       ))}
@@ -415,7 +417,7 @@ function FooterRow<T>({ vCols, prefs, content }: FooterProps<T>) {
       <tr className="bg-gray-50 border-t-2 border-gray-200 font-semibold">
         {vCols.map((c) => (
           <td key={c.key} style={{ width: widthOf(c, prefs), textAlign: c.align ?? "left" }}
-            className="px-3 py-2 whitespace-nowrap text-sm text-gray-900">
+            className={`px-3 py-2 whitespace-nowrap text-sm text-gray-900 ${hideBelowClass(c)}`.trimEnd()}>
             {content[c.key] ?? ""}
           </td>
         ))}
@@ -512,7 +514,7 @@ function HeaderCell<T>({ col, prefs, width, actions }: HeaderCellProps<T>) {
   return (
     <th
       style={{ width, textAlign: col.align ?? "left" }}
-      className="relative px-3 py-2 text-xs font-semibold text-gray-700 select-none"
+      className={`relative px-3 py-2 text-xs font-semibold text-gray-700 select-none ${hideBelowClass(col)}`.trimEnd()}
       draggable
       onDragStart={(e) => e.dataTransfer.setData("text/x-col", col.key)}
       onDragOver={(e) => e.preventDefault()}

--- a/test/e2e/kebab-verify.spec.ts
+++ b/test/e2e/kebab-verify.spec.ts
@@ -28,17 +28,14 @@ test.beforeEach(async ({ page }) => {
   // localhost defaultar till self-hosted (→ 401) → tvinga demo. Seedas även mot
   // live: `repo: ""` ger same-origin i båda lägena, så vägen är densamma.
   await seedDemoLogin(page, BASE);
-  // TRÄD-vyn, inte listvyn. Det är trädets tabell som bär fixarna specen
-  // granskar (`table-fixed` i document-browser.tsx, `hidden sm:table-cell` i
-  // _document-row/_folder-row) och dess kebab som har hela action-uppsättningen.
-  // Default är numera listvyn, som renderar den generiska `DataTable` med en
-  // annan, kortare meny och utan kolumn-döljning — specen mätte alltså fel
-  // tabell, vilket ingen såg eftersom den låg utanför alla configar (#932).
-  // Listvyns egna brister är EGEN sak: #983.
-  await page.addInitScript(([key, mode]) => {
-    try { localStorage.setItem(key!, mode!); } catch { /* privat läge */ }
-  }, [VIEW_MODE_KEY, "tree"]);
 });
+
+/** Sätt vyläget FÖRE första render — `DocumentBrowser` läser det i sin initState. */
+async function useViewMode(page: Page, mode: "tree" | "list"): Promise<void> {
+  await page.addInitScript(([key, m]) => {
+    try { localStorage.setItem(key!, m!); } catch { /* privat läge */ }
+  }, [VIEW_MODE_KEY, mode]);
+}
 
 /**
  * Ett ärende som FAKTISKT har dokument — annars finns ingen kebab att öppna och
@@ -53,34 +50,58 @@ async function gotoMatter(page: Page) {
   await page.waitForTimeout(1500); // demo-bootstrap invalidateQueries settle
 }
 
-test("dokumentrad: kebab-meny öppnas med alla actions + Escape stänger", async ({ page }) => {
-  await gotoMatter(page);
-  await page.getByLabel("Dokumentåtgärder").first().click();
-
-  const menu = page.getByRole("menu", { name: "Dokumentåtgärder" });
-  await expect(menu).toBeVisible();
-  for (const label of ["Öppna i webbläsaren", "Editera externt", "Visa", "Ladda ner", "Ta bort"]) {
-    await expect(menu.getByText(new RegExp(label))).toBeVisible();
-  }
-  // "Analysera (AI)" ska INTE finnas här. ADR 0027: LLM-analys är en
-  // server-förmåga, och demon har ingen server — affordansen ska då döljas, inte
-  // visas och fela. Specen krävde tvärtom att den fanns, vilket bara gick att
-  // tro så länge den aldrig kördes (#932/#972).
-  await expect(menu.getByText(/Analysera/)).toHaveCount(0);
-
-  await page.keyboard.press("Escape");
-  await expect(menu).toBeHidden();
-});
-
-test("dokumenttabellen scrollar inte horisontellt på mobil (390px)", async ({ page }) => {
-  await page.setViewportSize({ width: 390, height: 800 });
-  await gotoMatter(page);
-
-  const overflow = await page.evaluate(() => {
+/** Överflödet i dokumenttabellens scroll-wrapper — 0 betyder "ingen scroll". */
+async function tableOverflow(page: Page): Promise<number | null> {
+  return await page.evaluate(() => {
     const kebab = document.querySelector('[aria-label="Dokumentåtgärder"]');
     const wrap = kebab?.closest("div.overflow-x-auto") as HTMLElement | null;
     return wrap ? wrap.scrollWidth - wrap.clientWidth : null;
   });
-  expect(overflow, "dok-tabellens overflow-wrapper hittades").not.toBeNull();
-  expect(overflow!, "ingen horisontell scroll i dokumenttabellen på mobil").toBeLessThanOrEqual(2);
+}
+
+// Båda vyerna granskas, och med SAMMA krav (#983). Listvyn är default och var
+// otäckt fram till dess: den byggde en egen, kortare kebab och saknade
+// kolumn-döljning, så den överflödade med 456 px på en 390 px-skärm.
+for (const mode of ["tree", "list"] as const) {
+  test(`dokumentrad (${mode}-vy): kebab-meny öppnas med alla actions + Escape stänger`, async ({ page }) => {
+    await useViewMode(page, mode);
+    await gotoMatter(page);
+    await page.getByLabel("Dokumentåtgärder").first().click();
+
+    const menu = page.getByRole("menu", { name: "Dokumentåtgärder" });
+    await expect(menu).toBeVisible();
+    for (const label of ["Öppna i webbläsaren", "Editera externt", "Visa", "Ladda ner", "Ta bort"]) {
+      await expect(menu.getByText(new RegExp(label))).toBeVisible();
+    }
+    // "Analysera (AI)" ska INTE finnas här. ADR 0027: LLM-analys är en
+    // server-förmåga, och demon har ingen server — affordansen ska då döljas, inte
+    // visas och fela. Specen krävde tvärtom att den fanns, vilket bara gick att
+    // tro så länge den aldrig kördes (#932/#972).
+    await expect(menu.getByText(/Analysera/)).toHaveCount(0);
+
+    await page.keyboard.press("Escape");
+    await expect(menu).toBeHidden();
+  });
+
+  test(`dokumenttabellen (${mode}-vy) scrollar inte horisontellt på mobil (390px)`, async ({ page }) => {
+    await useViewMode(page, mode);
+    await page.setViewportSize({ width: 390, height: 800 });
+    await gotoMatter(page);
+
+    const overflow = await tableOverflow(page);
+    expect(overflow, "dok-tabellens overflow-wrapper hittades").not.toBeNull();
+    expect(overflow!, "ingen horisontell scroll i dokumenttabellen på mobil").toBeLessThanOrEqual(2);
+  });
+}
+
+test("listvyns dolda kolumner kommer tillbaka på desktop", async ({ page }) => {
+  // Halva `hideBelow`-kontraktet är att kolumnen ÅTERKOMMER. En trasig klass
+  // (t.ex. interpolerad så Tailwind aldrig genererat den) hade gett en tabell
+  // som ser smal och fin ut på mobil och sedan saknar kolumner överallt.
+  await useViewMode(page, "list");
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await gotoMatter(page);
+  for (const label of ["Typ", "Mapp", "Uppladdad av", "Datum", "Storlek"]) {
+    await expect(page.getByRole("columnheader", { name: new RegExp(label) }).first()).toBeVisible();
+  }
 });

--- a/test/unit/components/data-table-logic.test.ts
+++ b/test/unit/components/data-table-logic.test.ts
@@ -18,6 +18,7 @@ import {
   hasOverrides,
   hasSummary,
   buildSummaryContent,
+  hideBelowClass,
 } from "@/components/ui/data-table-logic";
 
 interface Row { name: string; n: number; when: Date | null; type: string }
@@ -142,5 +143,27 @@ describe("summary", () => {
     expect(hasSummary(sumCols)).toBe(true);
     expect(hasSummary(cols)).toBe(false);
     expect(buildSummaryContent(sumCols, rows)).toEqual({ n: 6 });
+  });
+});
+
+/**
+ * `hideBelow` (#983) — responsiv kolumndöljning. Klasserna måste vara STATISKA
+ * strängar: Tailwind genererar bara det den ser i källkoden, så en interpolerad
+ * `` `hidden ${bp}:table-cell` `` hade gett en klass som saknas i bundlen — och
+ * en kolumn som försvinner på mobil utan att komma tillbaka på desktop.
+ */
+describe("hideBelowClass", () => {
+  const col = (hideBelow?: Column<Row>["hideBelow"]): Column<Row> =>
+    ({ key: "k", label: "K", render: () => "", ...(hideBelow ? { hideBelow } : {}) });
+
+  it("utelämnad → tom sträng (kolumnen syns på alla skärmar)", () => {
+    expect(hideBelowClass(col())).toBe("");
+  });
+
+  it("varje brytpunkt ger sin döljning OCH sin återställning", () => {
+    // Båda halvorna behövs: utan `<bp>:table-cell` blir kolumnen borta överallt.
+    expect(hideBelowClass(col("sm"))).toBe("hidden sm:table-cell");
+    expect(hideBelowClass(col("md"))).toBe("hidden md:table-cell");
+    expect(hideBelowClass(col("lg"))).toBe("hidden lg:table-cell");
   });
 });

--- a/test/unit/components/documents-list-view.test.tsx
+++ b/test/unit/components/documents-list-view.test.tsx
@@ -2,7 +2,7 @@
  * DocumentsListView — flat-vy för dokument med folder-path-kolumn.
  */
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest-compat";
 import { DocumentsListView } from "@/components/documents/_documents-list-view";
 import { asId } from "@/lib/shared/schemas/ids";
@@ -133,5 +133,74 @@ describe("DocumentsListView", () => {
     expect(
       screen.getByRole("button", { name: "minnesanteckning (din ändring 2027-03-14 09:15).txt" }),
     ).toBeInTheDocument();
+  });
+});
+
+/**
+ * #983: listvyn byggde en EGEN, kortare kebab-meny. Samma dokument på samma
+ * sida gav alltså olika möjligheter beroende på vilken vy man råkade stå i —
+ * Öppna, Visa och Ladda ner fanns bara i trädet. Båda vyerna renderar nu
+ * `DocumentActions`, och testerna nedan vaktar att de inte glider isär igen.
+ */
+describe("DocumentsListView — kebab-menyn (#983)", () => {
+  function renderRow() {
+    render(
+      <DocumentsListView
+        matterId={asId<"MatterId">("m1")} documents={[baseDoc()]} folders={[]}
+        onDelete={() => {}} onReanalyze={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Dokumentåtgärder"));
+    return screen.getByRole("menu", { name: "Dokumentåtgärder" });
+  }
+
+  it("erbjuder hela dokumentuppsättningen, inte bara redigera/analysera/ta bort", () => {
+    const menu = renderRow();
+    for (const label of ["Öppna i webbläsaren", "Editera externt", "Visa", "Ladda ner", "Ta bort"]) {
+      expect(menu.textContent, `${label} saknas i listvyns meny`).toContain(label);
+    }
+  });
+
+  it("Ta bort kräver bekräftelse och anropar onDelete med dokumentets id", () => {
+    const onDelete = vi.fn();
+    const confirmSpy = vi.spyOn(globalThis, "confirm").mockReturnValue(true);
+    try {
+      render(
+        <DocumentsListView
+          matterId={asId<"MatterId">("m1")} documents={[baseDoc()]} folders={[]}
+          onDelete={onDelete} onReanalyze={() => {}}
+        />,
+      );
+      fireEvent.click(screen.getByLabelText("Dokumentåtgärder"));
+      fireEvent.click(screen.getByText("Ta bort"));
+      expect(confirmSpy).toHaveBeenCalled();
+      expect(onDelete).toHaveBeenCalledWith("d1");
+    } finally {
+      confirmSpy.mockRestore();
+    }
+  });
+});
+
+/**
+ * Mobil-bredd (#983). Listvyn visade sex kolumner även på 390 px och överflödade
+ * med 456 px, medan träd-vyn dolde sina sekundära kolumner. jsdom räknar inte
+ * layout, så testet granskar KLASSERNA — själva överflödet mäts i e2e:t.
+ */
+describe("DocumentsListView — kolumner på små skärmar (#983)", () => {
+  it("sekundära kolumner bär responsiv döljning; filnamnet gör det inte", () => {
+    render(
+      <DocumentsListView
+        matterId={asId<"MatterId">("m1")} documents={[baseDoc()]} folders={[]}
+        onDelete={() => {}} onReanalyze={() => {}}
+      />,
+    );
+    const headerFor = (label: string): HTMLElement =>
+      screen.getByText(new RegExp(`^${label}`)).closest("th")!;
+
+    // Filnamnet är det enda som alltid måste synas — det får inte döljas.
+    expect(headerFor("Filnamn").className).not.toContain("hidden");
+    for (const label of ["Typ", "Datum", "Storlek", "Mapp", "Uppladdad av"]) {
+      expect(headerFor(label).className, `${label} ska döljas på små skärmar`).toContain("hidden");
+    }
   });
 });


### PR DESCRIPTION
Stänger #983.

## Problemet

Dokumentvyn har två lägen och defaultar till **listvyn** (`document-browser.tsx:34-37`). Träd-vyn bar fixarna; listvyn renderade den generiska `DataTable` och hade varken kolumn-döljning eller hela action-uppsättningen:

| | Trädvy | Listvy (default) |
|---|---|---|
| Kebab-actions | 6 | 3 — saknade Öppna, Visa, Ladda ner |
| Kolumn-döljning < sm | `hidden sm:table-cell` | ingen |
| Överflöd på 390 px | 0 px | **456 px** |

Samma dokument, samma sida, olika möjligheter beroende på vilket läge man råkade stå i.

## Bedömningen om action-menyn

Issuen frågade om skillnaden var avsiktlig ("listvyn = översikt, trädet = arbetsvy"). Jag har gjort bedömningen att den inte är det, och unifierat. Argumentet: det är samma rader på samma sida, växlade med en knapp — en användare som byter vy förlorar inte rimligen förmågan att öppna eller ladda ner sina filer. Om avsikten faktiskt var ett reducerat översiktsläge är det lätt att backa, men då bör det stå i koden.

Fixen är strukturell, inte en kopiering: `DocumentActions` exporteras nu ur `_document-row.tsx` och renderas av båda vyerna, så de inte kan glida isär igen. Listvyns egen `ActionMenuItem[]`-lista är borta.

`reanalyzePending={false}` i listvyn — den har ingen egen mutation-status att spegla, och en felaktigt disabled rad vore värre än en knapp som kan tryckas två gånger.

## `hideBelow` på DataTable

Ny valfri kolumn-egenskap: `hideBelow?: "sm" | "md" | "lg"`. Opt-in, så ingen befintlig tabell påverkas. Kolumnen finns kvar i sortering, filtrering, summering och kolumnmenyn — bara `display` växlar. Applicerad på `<th>`, data-`<td>`, gruppsummerad rad och `<tfoot>`.

Skiljer sig från `defaultHidden`, som gäller alla skärmar tills användaren ber om kolumnen.

Klasserna är **statiska strängar i en karta**, inte interpolerade:

```ts
const HIDE_BELOW_CLASS = { sm: "hidden sm:table-cell", md: "hidden md:table-cell", lg: "hidden lg:table-cell" }
```

Tailwind genererar bara det den ser i källkoden. En `` `hidden ${bp}:table-cell` `` hade gett en klass som saknas i bundlen — kolumnen försvinner på mobil och kommer aldrig tillbaka. Verifierat i den byggda CSS:en: `sm\:table-cell`, `md\:table-cell` och `lg\:table-cell` finns alla.

Fördelningen i dokumentlistan: Typ och Datum < sm, Storlek < md, Mapp och Uppladdad av < lg. Filnamn och actions visas alltid.

## Filnamnskolumnen

`wrap: true` plus `min-w-0` på knappen — exakt samma fälla som träd-vyn hade i #972: en `display:flex`-knapp är shrink-to-fit och växer till sitt max-content, vilket `break-words` på texten inte hjälper mot så länge containern inte får krympa.

**Överflöd på 390 px: 456 px → 0.**

## Tester

- **`hideBelowClass`** (enhet): varje brytpunkt ger både döljningen *och* återställningen — utan `<bp>:table-cell` blir kolumnen borta överallt.
- **Listvyns kebab** (komponent): hela uppsättningen finns, och Ta bort bekräftar innan `onDelete`.
- **Kolumnklasser** (komponent): sekundära kolumner bär `hidden`, filnamnet inte. jsdom räknar ingen layout, så själva överflödet mäts i e2e.
- **E2E**: `kebab-verify` kör nu båda vyerna genom **samma** krav i stället för bara trädet, plus ett fall som kräver att de dolda kolumnerna kommer tillbaka på desktop — halva `hideBelow`-kontraktet, och den halva som tyst går sönder.

## Grindar

`typecheck` ✓ · `lint` ✓ · `lint:complexity-strict` ✓ · `knip` ✓ · `deps:check` ✓ (1114 moduler) · `jscpd` ✓ · `size` ✓ (34,5 % av budget) · `build:demo` ✓ · **`e2e:demo` 31/31** ✓

`test/unit/components` vid katalogkörning: 354 pass / 36 fail mot `main`s 349 / 36 — samma fel, fem nya gröna tester (#92). Filerna var för sig är gröna.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_