### PR TITLE
feat(demo): fila dokument i mappar och registrera fakturautskick

### DIFF
--- a/src/lib/client/demo/demo-source-keys.ts
+++ b/src/lib/client/demo/demo-source-keys.ts
@@ -40,6 +40,11 @@ const MATCHERS: Matcher[] = [
   // Ledgern summerade alltså rätt belopp av fel skäl, och den riktiga postens
   // datum och orsak nådde aldrig fram.
   { key: "writeOffs", owns: (p) => p.startsWith("write-offs/") },
+  // #985: samma sorts glapp som write-offs. Mapparna gjorde träd-vyns hela
+  // poäng osynlig i demon (allt låg i roten), och utskickshistoriken på
+  // fakturan stod tom oavsett hur många fakturor som skickats.
+  { key: "documentFolders", owns: (p) => p.startsWith("document-folders/") },
+  { key: "invoiceDispatches", owns: (p) => p.startsWith("invoice-dispatches/") },
   { key: "billingRuns", owns: (p) => p.startsWith("billing-runs/") },
   { key: "accontoDeductions", owns: (p) => p.startsWith("acconto-deductions/") },
   { key: "expectedReceivables", owns: (p) => p.startsWith("expected-receivables/") },

--- a/test/e2e/kebab-verify.spec.ts
+++ b/test/e2e/kebab-verify.spec.ts
@@ -59,6 +59,22 @@ async function tableOverflow(page: Page): Promise<number | null> {
   });
 }
 
+/**
+ * Kebab-knappen, centrerad i vyn innan den klickas.
+ *
+ * Utan centreringen ligger första dokumentraden precis vid nederkanten sedan
+ * dokumenten filats i mappar (#985) — mapp-raderna tar plats — och Playwrights
+ * implicita scroll-then-click svälde då FÖRSTA klicket: menyn öppnades först på
+ * andra försöket. `scrollIntoViewIfNeeded` räcker inte, den lämnar elementet
+ * kvar vid kanten. Artefakt av hur testet klickar, inte av appen: en användare
+ * scrollar och klickar sedan på en knapp som står stilla.
+ */
+async function clickKebab(page: Page): Promise<void> {
+  const btn = page.getByLabel("Dokumentåtgärder").first();
+  await btn.evaluate((el) => { el.scrollIntoView({ block: "center" }); });
+  await btn.click();
+}
+
 // Båda vyerna granskas, och med SAMMA krav (#983). Listvyn är default och var
 // otäckt fram till dess: den byggde en egen, kortare kebab och saknade
 // kolumn-döljning, så den överflödade med 456 px på en 390 px-skärm.
@@ -66,7 +82,7 @@ for (const mode of ["tree", "list"] as const) {
   test(`dokumentrad (${mode}-vy): kebab-meny öppnas med alla actions + Escape stänger`, async ({ page }) => {
     await useViewMode(page, mode);
     await gotoMatter(page);
-    await page.getByLabel("Dokumentåtgärder").first().click();
+    await clickKebab(page);
 
     const menu = page.getByRole("menu", { name: "Dokumentåtgärder" });
     await expect(menu).toBeVisible();

--- a/test/scripts/demo-generator-kostnadsrakning-docs.test.ts
+++ b/test/scripts/demo-generator-kostnadsrakning-docs.test.ts
@@ -20,8 +20,10 @@ type Any = any;
 
 const CARLSSON_MATTER = "m-018-brottmal-ekobrott";
 
+/** `document.tree`, inte rot-listningen: KR-dokumenten filas i
+ *  Domstol/Kostnadsräkningar sedan #985, och trädet är dessutom vad UI:t läser. */
 async function krDocsFor(caller: Any, matterId: string): Promise<Any[]> {
-  const { documents } = await caller.document.list({ matterId, folderId: null, pageSize: 100 });
+  const { documents } = await caller.document.tree({ matterId });
   return (documents as Any[]).filter((d) => d.documentType === "Kostnadsräkning");
 }
 

--- a/test/scripts/demo-prutning.test.ts
+++ b/test/scripts/demo-prutning.test.ts
@@ -23,6 +23,8 @@ function recordingCaller(): { c: Any; calls: Array<{ method: string; args: Any }
     if (method === "billingRun.createKostnadsrakning") return { run: { id: "kr", workValueOreAtRun: 5_000_000 } };
     if (method === "billingRun.createFinal") return { invoice: { id: "fin", amount: 100_000 } };
     if (method === "billingRun.settleCoverage") return { clientInvoice: {}, payerInvoice: {} };
+    if (method === "document.tree") return { folders: [], documents: [] };
+    if (method === "document.createFolder") return { id: `folder-${calls.length}` };
     return {};
   };
   const c = {
@@ -30,7 +32,7 @@ function recordingCaller(): { c: Any; calls: Array<{ method: string; args: Any }
     timeEntry: { create: rec("timeEntry.create") },
     serviceNote: { create: rec("serviceNote.create") },
     expense: { create: rec("expense.create") },
-    document: { register: rec("document.register") },
+    document: { register: rec("document.register"), createFolder: rec("document.createFolder"), tree: rec("document.tree") },
     invoice: { createRadgivning: rec("invoice.createRadgivning"), setStatus: rec("invoice.setStatus"), recordPayment: rec("invoice.recordPayment") },
     billingRun: {
       createAcconto: rec("billingRun.createAcconto"), createKostnadsrakning: rec("billingRun.createKostnadsrakning"),

--- a/test/scripts/folder-filing.test.ts
+++ b/test/scripts/folder-filing.test.ts
@@ -1,0 +1,86 @@
+/**
+ * `ensureFolderPath` (#985) — mappstrukturen för demons dokument.
+ *
+ * Tre olika pass filar dokument: den kronologiska simuleringen, faktura-
+ * dokumenten och kostnadsräkningarna. De kör efter varandra och delar inte
+ * state, så helpern måste fråga SERVERN vad som redan finns. Utan det steget
+ * skapade kostnadsräkningspasset en andra "Domstol"-mapp i sex av demons
+ * ärenden — samma namn, samma nivå, två mappar.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { ensureFolderPath, type FolderCache } from "../../tooling/demo-generator/folder-filing";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+interface Folder { id: string; name: string; parentId: string | null }
+
+/** Minimal server-stub: håller mappar per ärende, som de riktiga procedurerna. */
+function serverStub(initial: Record<string, Folder[]> = {}) {
+  const store = new Map<string, Folder[]>(Object.entries(initial));
+  const created: Array<{ matterId: string; name: string; parentId: string | null }> = [];
+  let seq = 0;
+  const caller = {
+    document: {
+      tree: async ({ matterId }: Any) => ({ folders: store.get(matterId) ?? [], documents: [] }),
+      createFolder: async ({ matterId, name, parentId }: Any) => {
+        created.push({ matterId, name, parentId });
+        const folder: Folder = { id: `srv-${seq++}`, name, parentId: parentId ?? null };
+        store.set(matterId, [...(store.get(matterId) ?? []), folder]);
+        return folder;
+      },
+    },
+  };
+  return { caller, created, store };
+}
+
+describe("ensureFolderPath", () => {
+  it("skapar sökvägen uppifrån och ned och returnerar den innersta mappen", async () => {
+    const { caller, created } = serverStub();
+    const cache: FolderCache = new Map();
+    const id = await ensureFolderPath(caller, "m1", ["Domstol", "Domar"], cache);
+    expect(created.map((c) => c.name)).toEqual(["Domstol", "Domar"]);
+    expect(created[0]!.parentId).toBeNull();
+    expect(created[1]!.parentId).toBe("srv-0");
+    expect(id).toBe("srv-1");
+  });
+
+  it("återanvänder en mapp som ETT ANNAT PASS redan skapat — inga dubbletter", async () => {
+    // Simuleringen har lagt "Domstol" på ärendet; kostnadsräkningspasset kommer
+    // efteråt med en TOM cache. Det var precis här dubbletterna uppstod.
+    const { caller, created } = serverStub({
+      m1: [{ id: "sim-1", name: "Domstol", parentId: null }],
+    });
+    const freshCache: FolderCache = new Map();
+    const id = await ensureFolderPath(caller, "m1", ["Domstol", "Kostnadsräkningar"], freshCache);
+
+    expect(created.map((c) => c.name), "bara barnet skapas").toEqual(["Kostnadsräkningar"]);
+    expect(created[0]!.parentId, "barnet hänger under den befintliga mappen").toBe("sim-1");
+    expect(id).toBe("srv-0");
+  });
+
+  it("läser serverns mappar EN gång per ärende, inte per dokument", async () => {
+    const { caller } = serverStub();
+    let reads = 0;
+    const counting = { document: { ...caller.document, tree: async (a: Any) => { reads++; return caller.document.tree(a); } } };
+    const cache: FolderCache = new Map();
+    for (let i = 0; i < 5; i++) await ensureFolderPath(counting, "m1", ["Klient"], cache);
+    expect(reads).toBe(1);
+  });
+
+  it("olika ärenden får egna mappar trots samma namn", async () => {
+    const { caller, created } = serverStub();
+    const cache: FolderCache = new Map();
+    const a = await ensureFolderPath(caller, "m1", ["Klient"], cache);
+    const b = await ensureFolderPath(caller, "m2", ["Klient"], cache);
+    expect(created).toHaveLength(2);
+    expect(a).not.toBe(b);
+  });
+
+  it("tom sökväg → roten, ingen mapp skapas och ingen läsning görs", async () => {
+    const { caller, created } = serverStub();
+    expect(await ensureFolderPath(caller, "m1", [], new Map())).toBeNull();
+    expect(created).toHaveLength(0);
+  });
+});

--- a/test/scripts/simulate-orchestrate.test.ts
+++ b/test/scripts/simulate-orchestrate.test.ts
@@ -42,8 +42,10 @@ describe("runSimulation (#880 integration)", () => {
     const matters = mres.matters ?? mres.items ?? mres;
     const rh = matters.find((m: Any) => m.paymentMethod === "RATTSHJALP" && m.matterNumber === "2026-0020");
     expect(rh, "varierande-rättshjälp-ärendet finns").toBeTruthy();
-    const docs = await c.document.list({ matterId: rh.id, folderId: null, pageSize: 100 });
-    const list = docs.documents ?? docs;
+    // `document.tree`, inte `document.list({folderId: null})`: sedan #985 filas
+    // varje dokument i en mapp, så ROT-listningen är tom. Trädet är dessutom vad
+    // UI:t faktiskt läser — båda dokumentvyerna bygger på `tree.data`.
+    const list = (await c.document.tree({ matterId: rh.id })).documents as Any[];
     expect(list.some((d: Any) => d.direction === "INKOMMANDE")).toBe(true);
     expect(list.some((d: Any) => d.direction === "UTGAENDE")).toBe(true);
 
@@ -110,5 +112,45 @@ describe("runSimulation (#880 integration)", () => {
     expect(invoices.some((i) => i.status === "BAD_DEBT"), "avskriven faktura").toBe(true);
     // …och en plan-faktura står som INSTALLMENT_PLAN, inte som vanlig SENT.
     expect(invoices.some((i) => i.status === "INSTALLMENT_PLAN"), "faktura med plan").toBe(true);
+  });
+
+  /**
+   * #985: dokumentmappar och utskickshistorik. Loadern saknade matchers för
+   * båda, men bakom det låg att simuleringen aldrig skapade dem — varje dokument
+   * låg i roten och fakturans utskickshistorik var tom. Testet påstår om DEMONS
+   * DATA att strukturen finns, inte om scenariomallen.
+   */
+  it("dokument filas i mappar (inkl. nästlade) och skickade fakturor får utskickshistorik", async () => {
+    const seed = translateSeed(buildSeed(), createIdTranslator()) as Any;
+    const orgId = String(seed.organizations[0].id);
+    const admin = { id: asId<"UserId">("gen"), email: "g@a.se", name: "G", role: userRoleSchema.parse("ADMIN"), organizationId: asId<"OrganizationId">(orgId) };
+    const target = createGitTarget({ principal: admin, writeBack: async () => {} });
+    const coreSeed = { ...seed, matters: seed.matters.map((m: Any) => ({ ...m, status: "ACTIVE" })), timeEntries: [], expenses: [], matterContacts: [], documents: [], serviceNotes: [] };
+    await populate(target.caller, coreSeed);
+
+    const ctx: RunCtx = { c: target.caller, res: emptyRunResult() };
+    await runSimulation(ctx, seed);
+
+    const c = target.caller as Any;
+    expect(ctx.res.folders, "mappar skapade").toBeGreaterThan(0);
+    expect(ctx.res.dispatches, "utskick registrerade").toBeGreaterThan(0);
+
+    // Ett ärende med domstolsdokument ska ha Domstol/ med Domar under sig, och
+    // inga dokument kvar i roten.
+    const matters = (await c.matter.list({})).matters as Any[];
+    const withCourt = matters.find((m: Any) => String(m.paymentMethod) === "OFFENTLIGT_UPPDRAG") ?? matters[0];
+    const tree = await c.document.tree({ matterId: withCourt.id });
+    const folders = tree.folders as Array<{ id: string; name: string; parentId: string | null }>;
+    expect(folders.length, "ärendet har mappar").toBeGreaterThan(0);
+    const nested = folders.find((f) => f.parentId !== null);
+    expect(nested, "minst en nästlad mapp — annars ser trädet ut som en platt lista").toBeTruthy();
+    expect(folders.some((f) => f.id === nested?.parentId), "den nästlade mappens förälder finns").toBe(true);
+
+    // Varje dokument har en mapp — och rot-listningen är följaktligen tom.
+    const all = tree.documents as Array<{ folderId: string | null }>;
+    expect(all.length, "ärendet har dokument").toBeGreaterThan(0);
+    expect(all.every((d) => d.folderId !== null), "inget dokument ligger kvar i roten").toBe(true);
+    const rootListing = await c.document.list({ matterId: withCourt.id, folderId: null, pageSize: 100 });
+    expect((rootListing.documents ?? rootListing).length, "rot-mappen är tom").toBe(0);
   });
 });

--- a/test/scripts/simulate-runner.test.ts
+++ b/test/scripts/simulate-runner.test.ts
@@ -21,6 +21,9 @@ function recordingCaller() {
     if (method === "billingRun.createKostnadsrakning") return { run: { id: "kr", workValueOreAtRun: 1_544_700 } };
     if (method === "billingRun.createFinal") return { invoice: { id: "fin", amount: 100_000 } };
     if (method === "invoice.createPaymentPlan") return { id: "plan-1" };
+    // −1: raden är redan pushad ovan, så id:na blir 0-baserade i anropsordning.
+    if (method === "document.tree") return { folders: [], documents: [] };
+    if (method === "document.createFolder") return { id: `folder-${calls.filter((c) => c.method === "document.createFolder").length - 1}` };
     if (method === "billingRun.settleCoverage") return { creditInvoice: { id: "cred", amount: -50_000 }, clientInvoice: {}, payerInvoice: {} };
     return {};
   };
@@ -29,7 +32,8 @@ function recordingCaller() {
     timeEntry: { create: rec("timeEntry.create") },
     serviceNote: { create: rec("serviceNote.create") },
     expense: { create: rec("expense.create") },
-    document: { register: rec("document.register") },
+    document: { register: rec("document.register"), createFolder: rec("document.createFolder"), tree: rec("document.tree") },
+    invoiceDispatch: { recordManual: rec("invoiceDispatch.recordManual") },
     invoice: {
       createRadgivning: rec("invoice.createRadgivning"), setStatus: rec("invoice.setStatus"),
       recordPayment: rec("invoice.recordPayment"), createPaymentPlan: rec("invoice.createPaymentPlan"),
@@ -191,5 +195,75 @@ describe("fakturans livscykler i simuleringen (#982)", () => {
     expect(calls).toHaveLength(0);
     expect(ctx.res.paymentPlans).toBe(0);
     expect(ctx.res.writeOffs).toBe(0);
+  });
+});
+
+/**
+ * Dokumentmappar och utskickshistorik (#985). Båda entiteterna tappades tyst av
+ * demons loader, men bakom den bristen låg en till: simuleringen skapade dem
+ * aldrig. Varje dokument låg i roten — träd-vyns mapphantering gick varken att
+ * se eller prova — och fakturans utskickshistorik var tom oavsett hur många
+ * fakturor som skickats.
+ */
+describe("mappar + utskick i simuleringen (#985)", () => {
+  const PRIVAT: SimMatter = {
+    id: "m-p", paymentMethod: "PRIVAT", lawyerId: "u-1", startDaysAgo: 300,
+    arvodeRateOre: 250_000, clientEmail: "klient@example.se",
+  };
+
+  async function run(events: Any[], matter: SimMatter = PRIVAT) {
+    const { c, calls } = recordingCaller();
+    const ctx: RunCtx = { c, res: emptyRunResult() };
+    await runScenario(ctx, matter, events);
+    return { calls, ctx };
+  }
+
+  it("dokument filas i mottagarens mapp — och mappen skapas EN gång", async () => {
+    const { calls, ctx } = await run([
+      { kind: "doc", dayOffset: 0, template: "stamningsansokan" }, // DOMSTOL
+      { kind: "doc", dayOffset: 1, template: "inlaga" },           // DOMSTOL igen
+      { kind: "doc", dayOffset: 2, template: "brevTillOmbud" },    // MOTPART
+    ]);
+
+    const folders = calls.filter((x) => x.method === "document.createFolder");
+    // Två domstolsdokument → EN "Domstol"-mapp, inte två.
+    expect(folders.map((f) => f.args.name)).toEqual(["Domstol", "Korrespondens"]);
+    expect(ctx.res.folders).toBe(2);
+
+    const regs = calls.filter((x) => x.method === "document.register");
+    expect(regs[0]!.args.folderId).toBe(regs[1]!.args.folderId); // samma mapp
+    expect(regs[2]!.args.folderId).not.toBe(regs[0]!.args.folderId);
+    expect(regs.every((r) => r.args.folderId !== null)).toBe(true);
+  });
+
+  it("nästlade mappar skapas uppifrån och ned, med rätt förälder", async () => {
+    // `dom` har subFolder "Domar" → Domstol/Domar. Utan nästling hade demon
+    // sett ut som att träd-vyn bara klarar en nivå.
+    const { calls } = await run([{ kind: "doc", dayOffset: 0, template: "dom" }]);
+    const folders = calls.filter((x) => x.method === "document.createFolder");
+    expect(folders.map((f) => f.args.name)).toEqual(["Domstol", "Domar"]);
+    expect(folders[0]!.args.parentId).toBeNull();
+    expect(folders[1]!.args.parentId).toBe("folder-0"); // barnet pekar på föräldern
+  });
+
+  it("slutfaktura till klienten registreras som utskick till klientens e-post", async () => {
+    const { calls, ctx } = await run([{ kind: "final", dayOffset: 0, recipient: "KLIENT" }]);
+    const dispatch = calls.find((x) => x.method === "invoiceDispatch.recordManual");
+    expect(dispatch?.args).toMatchObject({ invoiceId: "fin", channel: "email", recipient: "klient@example.se" });
+    expect(ctx.res.dispatches).toBe(1);
+  });
+
+  it("utan klient-e-post registreras inget utskick — hellre tomt än påhittat", async () => {
+    const { calls, ctx } = await run(
+      [{ kind: "final", dayOffset: 0, recipient: "KLIENT" }],
+      { ...PRIVAT, clientEmail: undefined },
+    );
+    expect(calls.filter((x) => x.method === "invoiceDispatch.recordManual")).toHaveLength(0);
+    expect(ctx.res.dispatches).toBe(0);
+  });
+
+  it("fakturor till DOMSTOL får inget klient-utskick", async () => {
+    const { calls } = await run([{ kind: "final", dayOffset: 0, recipient: "DOMSTOL" }]);
+    expect(calls.filter((x) => x.method === "invoiceDispatch.recordManual")).toHaveLength(0);
   });
 });

--- a/test/unit/lib/demo/demo-source-keys.test.ts
+++ b/test/unit/lib/demo/demo-source-keys.test.ts
@@ -33,6 +33,9 @@ describe("pathToSourceKey", () => {
     // #982: saknades helt → varje avskrivning tappades tyst av demon, och
     // migrate-on-read (ADR 0007) täckte över det med en gissad ersättningspost.
     expect(pathToSourceKey("write-offs/w1.json")).toBe("writeOffs");
+    // #985: utan dessa låg varje dokument i roten och utskickshistoriken var tom.
+    expect(pathToSourceKey("document-folders/f1.json")).toBe("documentFolders");
+    expect(pathToSourceKey("invoice-dispatches/d1.json")).toBe("invoiceDispatches");
     expect(pathToSourceKey(".ava/templates/t1.json")).toBe("documentTemplates");
     expect(pathToSourceKey(".ava/organizations/o1.json")).toBe("organizations");
     expect(pathToSourceKey(".ava/user-preferences/up1.json")).toBe("userPreferences");
@@ -58,13 +61,21 @@ describe("pathToSourceKey", () => {
  */
 describe("pathToSourceKey täcker ENTITY_REGISTRY", () => {
   /**
-   * Entiteter som medvetet INTE hydreras i demon ännu. Var och en är ett känt
-   * glapp av samma sort som write-offs, inte ett designbeslut — de tas in när
-   * någon avgör vad de ska visa (#985). Att de står här och inte i tystnad är
-   * hela poängen: listan måste krympa, aldrig växa.
+   * Entiteter som INTE hydreras i demon. Listan är en ratchet: den ska krympa,
+   * aldrig växa, och varje rad kräver ett skäl.
+   *
+   * De två som är kvar (#985) har INGEN producent någonstans i kodbasen —
+   * varken ett jobb eller en mutation skapar dem. `IDocumentAnalyzer.analyze`
+   * lovar att "eventuella suggestions postas via
+   * dataStore.documentAnalysisSuggestions", men ingen implementation gör det:
+   * classify-pipelinen skriver bara `document.updateMetadata`. Följden är att
+   * `SuggestionsPanel` och `EventsPanel` står tomma i ALLA tier, inte bara i
+   * demon. Att koppla på en matcher här hade varit meningslöst, och att seeda
+   * rader hade betytt data som appen själv aldrig kan producera. Gapet är
+   * uppströms — se #988.
    */
   const NOT_YET_HYDRATED = new Set([
-    "documentFolder", "documentAnalysisSuggestion", "matterEventSuggestion", "invoiceDispatch",
+    "documentAnalysisSuggestion", "matterEventSuggestion",
   ]);
 
   it("varje registrerad entitets gitPrefix mappar till sin sourceKey", () => {

--- a/tooling/demo-generator/folder-filing.ts
+++ b/tooling/demo-generator/folder-filing.ts
@@ -1,0 +1,81 @@
+/**
+ * Mappstruktur för demons dokument (#985).
+ *
+ * Demon hade inga mappar alls: varje dokument låg i ärendets rot, så träd-vyns
+ * hela poäng — mappar, drag-and-drop, nästling — gick varken att se eller prova.
+ *
+ * Filerna skapas av tre olika pass (den kronologiska simuleringen, faktura-
+ * dokumenten och kostnadsräkningarna) som körs efter varandra och inte delar
+ * state. Därför bor både SCHEMAT och "skapa-om-den-saknas"-logiken här, i st.f.
+ * en kopia per pass som skulle hinna glida isär.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+/** Nyckeln är `<matterId>/<sökväg>` — samma mappnamn i två ärenden är två mappar. */
+export type FolderCache = Map<string, string>;
+
+/** Ärenden vars befintliga mappar redan lästs in i cachen (en läsning per ärende). */
+const HYDRATED = new WeakMap<FolderCache, Set<string>>();
+
+interface ServerFolder { id: string; name: string; parentId: string | null }
+
+/** Sökvägen till en mapp ("Domstol/Domar") genom att gå uppåt via parentId. */
+function pathOf(folder: ServerFolder, byId: Map<string, ServerFolder>): string {
+  const parts = [folder.name];
+  let parent = folder.parentId === null ? undefined : byId.get(folder.parentId);
+  while (parent) {
+    parts.unshift(parent.name);
+    parent = parent.parentId === null ? undefined : byId.get(parent.parentId);
+  }
+  return parts.join("/");
+}
+
+/**
+ * Läs in ärendets BEFINTLIGA mappar i cachen, en gång per ärende.
+ *
+ * Utan det här steget ser varje pass bara sina egna mappar: simuleringen skapade
+ * "Domstol", kostnadsräkningspasset hittade den inte i sin egen cache och skapade
+ * en ANDRA mapp med samma namn. Sex dubbletter i demodatat innan detta fanns.
+ */
+async function hydrate(caller: Any, matterId: string, cache: FolderCache): Promise<void> {
+  const seen = HYDRATED.get(cache) ?? new Set<string>();
+  HYDRATED.set(cache, seen);
+  if (seen.has(matterId)) return;
+  seen.add(matterId);
+  const { folders } = await caller.document.tree({ matterId }) as { folders: ServerFolder[] };
+  const byId = new Map(folders.map((f) => [f.id, f] as const));
+  for (const f of folders) cache.set(`${matterId}/${pathOf(f, byId)}`, f.id);
+}
+
+/** Fakturadokumenten samlas för sig, oavsett vem fakturan ställts till. */
+export const INVOICE_FOLDER = ["Fakturor"];
+
+/** Kostnadsräkningen går till domstolen men förtjänar en egen hylla där. */
+export const KOSTNADSRAKNING_FOLDER = ["Domstol", "Kostnadsräkningar"];
+
+/**
+ * Mapp-id:t för en sökväg i ett ärende — skapar de led som saknas, uppifrån och
+ * ned. Cachen gör att en mapp skapas EN gång oavsett hur många dokument som
+ * hamnar i den, även när anropen kommer utspridda över ett helt pass.
+ *
+ * Returnerar `null` för en tom sökväg (dokumentet hamnar i roten).
+ */
+export async function ensureFolderPath(
+  caller: Any, matterId: string, path: readonly string[], cache: FolderCache,
+): Promise<string | null> {
+  if (path.length > 0) await hydrate(caller, matterId, cache);
+  let parentId: string | null = null;
+  let sofar = "";
+  for (const name of path) {
+    sofar = sofar ? `${sofar}/${name}` : name;
+    const key = `${matterId}/${sofar}`;
+    const known = cache.get(key);
+    if (known !== undefined) { parentId = known; continue; }
+    const folder = await caller.document.createFolder({ matterId, name, parentId }) as { id: string };
+    cache.set(key, folder.id);
+    parentId = folder.id;
+  }
+  return parentId;
+}

--- a/tooling/demo-generator/populate-invoice-docs.ts
+++ b/tooling/demo-generator/populate-invoice-docs.ts
@@ -13,6 +13,7 @@
 import { fakturaHeading, renderFakturaHtml, type FakturaBreakdown } from "@/lib/client/kostnadsrakning/faktura-template";
 import { BILLING_RUN_RECIPIENT_LABELS } from "@/lib/shared/schemas/enums";
 import type { GeneratorCaller } from "./backend-target";
+import { ensureFolderPath, INVOICE_FOLDER, type FolderCache } from "./folder-filing";
 import type { BinarySink } from "./populate-documents";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -95,6 +96,9 @@ export async function populateInvoiceDocs(caller: GeneratorCaller, sink?: Binary
   const c = caller as Any;
   const invoices: Any[] = await c.invoice.list({});
   const lookups = await loadLookups(c);
+  // Fakturadokumenten filas som allt annat (#985) — utan mapp hade 46 av demons
+  // 121 dokument legat kvar i roten och trädet sett halvsorterat ut.
+  const folders: FolderCache = new Map();
   let count = 0;
   for (const summary of invoices) {
     if (!shouldGenerateDoc(summary)) continue;
@@ -107,8 +111,9 @@ export async function populateInvoiceDocs(caller: GeneratorCaller, sink?: Binary
     // Tydlig etikett per fakturatyp så den inte förväxlas i fil-listan (#870/#878)
     // — samma rubrik som mallen sätter i dokumentet.
     const label = fakturaHeading(inv);
+    const folderId = await ensureFolderPath(c, String(inv.matter.id), INVOICE_FOLDER, folders);
     await c.document.register({
-      id, matterId: inv.matter.id, invoiceId: inv.id,
+      id, matterId: inv.matter.id, invoiceId: inv.id, folderId,
       fileName: `${label} ${inv.matter.matterNumber}.html`,
       mimeType: "text/html; charset=utf-8", sizeBytes: size, storagePath,
       title: `${label} — ${inv.matter.matterNumber}`,

--- a/tooling/demo-generator/populate-kostnadsrakning-docs.ts
+++ b/tooling/demo-generator/populate-kostnadsrakning-docs.ts
@@ -19,6 +19,7 @@
 
 import { buildKostnadsrakningContext } from "@/lib/shared/kostnadsrakning";
 import type { GeneratorCaller } from "./backend-target";
+import { ensureFolderPath, KOSTNADSRAKNING_FOLDER, type FolderCache } from "./folder-filing";
 import type { BinarySink } from "./populate-documents";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -126,6 +127,8 @@ export type KrDocIdFn = (runId: string) => string;
 export async function populateKostnadsrakningDocs(caller: GeneratorCaller, sink?: BinarySink, idFor?: KrDocIdFn): Promise<number> {
   const c = caller as Any;
   const { runs } = await c.billingRun.list({});
+  // Kostnadsräkningen går till domstolen men får en egen hylla där (#985).
+  const folders: FolderCache = new Map();
   let count = 0;
   for (const summary of runs as Any[]) {
     if (summary.type !== "KOSTNADSRAKNING") continue;
@@ -136,8 +139,9 @@ export async function populateKostnadsrakningDocs(caller: GeneratorCaller, sink?
     const storagePath = `documents/content/${id}.html`;
     const bytes = new TextEncoder().encode(html);
     const size = sink ? sink(storagePath, bytes) : bytes.byteLength;
+    const folderId = await ensureFolderPath(c, String(run.matter.id), KOSTNADSRAKNING_FOLDER, folders);
     await c.document.register({
-      id, matterId: run.matter.id,
+      id, matterId: run.matter.id, folderId,
       invoiceId: run.invoiceId ?? undefined,
       fileName: `Kostnadsräkning ${run.matter.matterNumber}.html`,
       mimeType: "text/html; charset=utf-8", sizeBytes: size, storagePath,

--- a/tooling/demo-generator/simulate/events.ts
+++ b/tooling/demo-generator/simulate/events.ts
@@ -84,6 +84,10 @@ export interface SimMatter {
   /** Arvode-sats (öre/tim) som ackumulerat arbete värderas på — driver aconto-belopp
    *  (rättshjälp: timkostnadsnormen; annars ansvarig jurists timtaxa). */
   arvodeRateOre: number;
+  /** Klientens e-post ur seedens kontakter (#985) — mottagare för fakturans
+   *  utskickshistorik. Saknas den registreras inget utskick, hellre det än en
+   *  påhittad adress i demodatat. */
+  clientEmail?: string | undefined;
 }
 
 /** Parter att länka in via `party`-events (översatta UUID:n) — ur seedens

--- a/tooling/demo-generator/simulate/fake-content.ts
+++ b/tooling/demo-generator/simulate/fake-content.ts
@@ -15,7 +15,28 @@ export interface DocTemplate {
   /** Titel/filnamnsbas. `{m}` ersätts med ärende-titel av anroparen om önskat. */
   title: string;
   summary: string;
+  /**
+   * Undermapp inom mottagarens mapp (#985). Utelämnad → dokumentet läggs direkt
+   * i mottagarmappen. Finns för att demon ska visa att träd-vyn kan NÄSTLA —
+   * en platt mappstruktur hade sett ut som att funktionen saknas.
+   */
+  subFolder?: string;
 }
+
+/**
+ * Mottagare → mapp (#985). Byrån filar efter vem dokumentet gick till eller kom
+ * från; det är den indelning träd-vyns drag-and-drop är gjord för. Demon hade
+ * inga mappar alls — varje dokument låg i roten, så mapphanteringen gick varken
+ * att se eller prova.
+ */
+export const FOLDER_BY_RECIPIENT: Record<DocumentRecipient, string> = {
+  KLIENT: "Klient",
+  DOMSTOL: "Domstol",
+  MOTPART: "Korrespondens",
+  MYNDIGHET: "Myndighetsbeslut",
+  FORSAKRING: "Försäkring",
+  OVRIGT: "Övrigt",
+};
 
 /** Fördefinierade dokument-mallar (nyckel → mall). Utökas per scenariobehov. */
 export const DOC_TEMPLATES: Record<string, DocTemplate> = {
@@ -46,6 +67,7 @@ export const DOC_TEMPLATES: Record<string, DocTemplate> = {
   dom: {
     documentType: "Dom", direction: "INKOMMANDE", recipient: "DOMSTOL",
     title: "Dom från tingsrätten", summary: "Tingsrätten meddelar dom i målet. Se domslut och domskäl.",
+    subFolder: "Domar",
   },
   beslutRattshjalp: {
     documentType: "Beslut", direction: "INKOMMANDE", recipient: "MYNDIGHET",

--- a/tooling/demo-generator/simulate/orchestrate.ts
+++ b/tooling/demo-generator/simulate/orchestrate.ts
@@ -25,7 +25,7 @@ function daysSince(iso: unknown): number {
   return Number.isFinite(t) ? Math.max(0, Math.round((Date.now() - t) / MS_DAY)) : 30;
 }
 
-function deriveSim(m: Any, lawyerId: string, rateOre: number): SimMatter {
+function deriveSim(m: Any, lawyerId: string, rateOre: number, clientEmail: string | undefined): SimMatter {
   const isRh = String(m.paymentMethod) === "RATTSHJALP";
   return {
     id: String(m.id),
@@ -33,7 +33,16 @@ function deriveSim(m: Any, lawyerId: string, rateOre: number): SimMatter {
     paymentMethod: String(m.paymentMethod), clientShareBips: m.clientShareBips ?? null,
     lawyerId, startDaysAgo: daysSince(m.createdAt),
     arvodeRateOre: isRh ? TIMKOSTNADSNORM_FTAX_ORE_PER_H : (rateOre || DEFAULT_RATE_ORE),
+    clientEmail,
   };
+}
+
+/** Klientens e-post ur seedens kontakter (#985) — mottagare i utskickshistoriken. */
+function clientEmailOf(parties: Parties, contacts: Any[]): string | undefined {
+  if (!parties.klient) return undefined;
+  const hit = contacts.find((c) => String(c.id) === parties.klient);
+  const email = hit?.email;
+  return typeof email === "string" && email.length > 0 ? email : undefined;
 }
 
 /** Parter ur seedens matterContacts (klient/motpart/ombud/domstol) → party-events. */
@@ -62,15 +71,32 @@ interface MatterSlot {
   variantIndex: number;
 }
 
-async function simulateMatter(
-  ctx: RunCtx, m: Any, users: { id: string; rateOre: number }[], seedContacts: Any[], slot: MatterSlot,
-): Promise<void> {
+/** Seedens uppslagstabeller. Ett objekt i st.f. tre parametrar — `simulateMatter`
+ *  ligger annars över parameter-taket (5), och listorna hör ihop. */
+interface SeedLookup {
+  users: { id: string; rateOre: number }[];
+  /** matterContacts — vilka kontakter som är knutna till ärendet, med roll. */
+  matterContacts: Any[];
+  /** contacts — kontakternas egna fält (e-post till utskickshistoriken, #985). */
+  contacts: Any[];
+}
+
+/** Plocka ut uppslagstabellerna ur den översatta seeden. */
+function buildLookup(seed: Any): SeedLookup {
+  const users = (seed.users ?? [])
+    .filter((u: Any) => typeof u.id === "string")
+    .map((u: Any) => ({ id: String(u.id), rateOre: Number(u.hourlyRate ?? 0) || 0 }));
+  return { users, matterContacts: seed.matterContacts ?? [], contacts: seed.contacts ?? [] };
+}
+
+async function simulateMatter(ctx: RunCtx, m: Any, seed: SeedLookup, slot: MatterSlot): Promise<void> {
   // Seed-ärenden saknar responsibleLawyerId → välj ansvarig jurist deterministiskt ur
   // användarlistan (som gamla buildTimeEntries: round-robin per ärende-index).
-  const u = users[slot.index % Math.max(1, users.length)];
+  const u = seed.users[slot.index % Math.max(1, seed.users.length)];
   if (!u) return;
-  const sim = deriveSim(m, u.id, u.rateOre);
-  await runScenario(ctx, sim, buildScenario(sim, deriveParties(String(m.id), seedContacts), slot.variantIndex));
+  const parties = deriveParties(String(m.id), seed.matterContacts);
+  const sim = deriveSim(m, u.id, u.rateOre, clientEmailOf(parties, seed.contacts));
+  await runScenario(ctx, sim, buildScenario(sim, parties, slot.variantIndex));
   if (String(m.status) !== "ACTIVE") await ctx.c.matter.update({ id: sim.id, status: String(m.status) });
 }
 
@@ -79,15 +105,12 @@ export async function runSimulation(ctx: RunCtx, seed: Any): Promise<void> {
   // Byråns aconto-gränsbelopp (#885) driver tröskelstyrda aconton i runnern.
   const orgThreshold = seed.organizations?.[0]?.accontoThresholdOre;
   if (typeof orgThreshold === "number") ctx.accontoThresholdOre = orgThreshold;
-  const users: { id: string; rateOre: number }[] = (seed.users ?? [])
-    .filter((u: Any) => typeof u.id === "string")
-    .map((u: Any) => ({ id: String(u.id), rateOre: Number(u.hourlyRate ?? 0) || 0 }));
   // Parterna länkas kronologiskt ur seedens matterContacts (klient/motpart/ombud/domstol).
-  const seedContacts: Any[] = seed.matterContacts ?? [];
+  const lookup = buildLookup(seed);
   let index = 0;
   const variants = new Map<string, number>();
   for (const m of seed.matters ?? []) {
-    await simulateMatter(ctx, m, users, seedContacts, {
+    await simulateMatter(ctx, m, lookup, {
       index, variantIndex: nextVariant(variants, String(m.paymentMethod)),
     });
     index++;

--- a/tooling/demo-generator/simulate/runner.ts
+++ b/tooling/demo-generator/simulate/runner.ts
@@ -11,10 +11,11 @@ import { SJALVRISK_ACCONTO_THRESHOLD_ORE } from "@/lib/shared/rattshjalp";
 import type { SettlementViewLine } from "@/lib/shared/settlement-view";
 import { AVA_NAMESPACE, uuidv5 } from "@/lib/shared/uuid-derive";
 import { demoPaymentPlanId } from "../../scripts/demo-billing-ids";
+import { ensureFolderPath } from "../folder-filing";
 import type { BinarySink } from "../populate-documents";
 import { eventIso, eventTime } from "./clock";
 import type { SimEvent, SimMatter } from "./events";
-import { DOC_TEMPLATES } from "./fake-content";
+import { DOC_TEMPLATES, FOLDER_BY_RECIPIENT } from "./fake-content";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Any = any;
@@ -24,14 +25,14 @@ export interface RunCtx {
   sink?: BinarySink;
   /** Gränsbelopp (öre) för tröskelstyrd aconto-utskick (#885); default = konstanten. */
   accontoThresholdOre?: number;
-  res: { invoices: number; documents: number; timeEntries: number; notes: number; credits: number; paymentPlans: number; reminders: number; writeOffs: number };
+  res: { invoices: number; documents: number; timeEntries: number; notes: number; credits: number; paymentPlans: number; reminders: number; writeOffs: number; folders: number; dispatches: number };
 }
 
 /** Nollställda räknare. Factory i stället för ett objekt-literal per anropsplats:
  *  räknarna växer med simuleringens täckning (#982 lade till tre), och literalen
  *  fanns då på sex ställen — två i verktygen, fyra i testerna. */
 export function emptyRunResult(): RunCtx["res"] {
-  return { invoices: 0, documents: 0, timeEntries: 0, notes: 0, credits: 0, paymentPlans: 0, reminders: 0, writeOffs: 0 };
+  return { invoices: 0, documents: 0, timeEntries: 0, notes: 0, credits: 0, paymentPlans: 0, reminders: 0, writeOffs: 0, folders: 0, dispatches: 0 };
 }
 
 interface SimState {
@@ -43,6 +44,8 @@ interface SimState {
   krWorkValueOre: number;
   lastFinal: { id: string; amount: number } | null;
   docSeq: number;
+  /** Skapade mappar per ärende: sökväg ("Domstol" / "Domstol/Domar") → id (#985). */
+  folders: Map<string, string>;
 }
 
 const isBillable = (e: { billable?: boolean }): boolean => e.billable !== false;
@@ -88,6 +91,14 @@ async function hExpense(ctx: RunCtx, m: SimMatter, e: Any, iso: string): Promise
   });
 }
 
+/** Mappen dokumentet filas i (#985) — skapas vid första behovet, räknas en gång. */
+async function folderFor(ctx: RunCtx, m: SimMatter, path: string[], st: SimState): Promise<string | null> {
+  const before = st.folders.size;
+  const id = await ensureFolderPath(ctx.c, m.id, path, st.folders);
+  ctx.res.folders += st.folders.size - before;
+  return id;
+}
+
 async function hDoc(ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimState): Promise<void> {
   const t = DOC_TEMPLATES[e.template];
   if (!t) return;
@@ -97,8 +108,12 @@ async function hDoc(ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimState
   const { generateDocumentBytes } = await import("../../scripts/seed-data");
   const bytes = await generateDocumentBytes({ id, title: t.title, fileName, documentType: t.documentType, summary: t.summary, mimeType: "application/pdf", storagePath });
   const size = ctx.sink ? ctx.sink(storagePath, bytes) : bytes.byteLength;
+  // Filas efter mottagare (#985) — demon hade tidigare allt i roten, så
+  // träd-vyns mapphantering gick varken att se eller prova.
+  const folderPath = [FOLDER_BY_RECIPIENT[t.recipient], ...(t.subFolder ? [t.subFolder] : [])];
+  const folderId = await folderFor(ctx, m, folderPath, st);
   await ctx.c.document.register({
-    id, matterId: m.id, fileName, mimeType: "application/pdf", sizeBytes: size, storagePath,
+    id, matterId: m.id, fileName, mimeType: "application/pdf", sizeBytes: size, storagePath, folderId,
     documentType: t.documentType, direction: t.direction, recipient: t.recipient, title: t.title, summary: t.summary,
     analysisStatus: "DONE", createdAt: iso,
   });
@@ -216,11 +231,25 @@ async function hInsurerPruning(ctx: RunCtx, m: SimMatter, e: Any, iso: string): 
   await ctx.c.billingRun.recordInsurerPruning({ matterId: m.id, prunedNetOre: e.prunedNetOre, invoiceDate: iso });
 }
 
+/**
+ * Utskickshistorik (#985): en faktura som satts till SENT har i verkligheten
+ * lämnat byrån på något sätt. `recordManual` — inte `queue` — eftersom demon
+ * inte har någon dispatch-worker som skulle plocka upp en köad rad och "skicka"
+ * den igen. Utan klientens e-post hoppas steget över; en påhittad adress i
+ * demodatat vore sämre än en tom historik.
+ */
+async function recordDispatch(ctx: RunCtx, m: SimMatter, invoiceId: string, recipient: string): Promise<void> {
+  if (recipient !== "KLIENT" || !m.clientEmail) return;
+  await ctx.c.invoiceDispatch.recordManual({ invoiceId, channel: "email", recipient: m.clientEmail });
+  ctx.res.dispatches++;
+}
+
 async function hFinal(ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimState): Promise<void> {
   const { invoice } = await ctx.c.billingRun.createFinal({ matterId: m.id, recipient: e.recipient, deductedBillingRunIds: [], invoiceDate: iso });
   await ctx.c.invoice.setStatus({ invoiceId: invoice.id, status: "SENT" });
   st.lastFinal = { id: invoice.id, amount: invoice.amount };
   ctx.res.invoices++;
+  await recordDispatch(ctx, m, invoice.id, String(e.recipient));
 }
 
 async function hPayment(ctx: RunCtx, _m: SimMatter, _e: Any, iso: string, st: SimState): Promise<void> {
@@ -323,7 +352,7 @@ const HANDLERS: Record<SimEvent["kind"], (ctx: RunCtx, m: SimMatter, e: Any, iso
 
 /** Spela upp ett ärendes scenario kronologiskt. */
 export async function runScenario(ctx: RunCtx, matter: SimMatter, events: SimEvent[]): Promise<void> {
-  const st: SimState = { accruedNetOre: 0, billedNetOre: 0, currentRateBips: matter.clientShareBips ?? 0, periodLines: [], krRunId: null, krWorkValueOre: 0, lastFinal: null, docSeq: 0 };
+  const st: SimState = { accruedNetOre: 0, billedNetOre: 0, currentRateBips: matter.clientShareBips ?? 0, periodLines: [], krRunId: null, krWorkValueOre: 0, lastFinal: null, docSeq: 0, folders: new Map() };
   const sorted = [...events].sort((a, b) => a.dayOffset - b.dayOffset);
   for (const e of sorted) {
     const iso = eventIso(matter.startDaysAgo, e.dayOffset, 9 + (e.dayOffset % 6));

--- a/tooling/scripts/build-demo-repo.ts
+++ b/tooling/scripts/build-demo-repo.ts
@@ -93,6 +93,7 @@ async function main(): Promise<void> {
   // Räknas ut för att gapet i #982 ska SYNAS i loggen. Att demon tappade sina
   // avbetalningsplaner upptäcktes först av ett e2e-test, för inget steg sa något.
   console.log(`  • fakturalivscykler: ${result.sim.paymentPlans} avbetalningsplaner (${result.sim.reminders} påminnelser), ${result.sim.writeOffs} kundförluster`);
+  console.log(`  • ${result.sim.folders} dokumentmappar, ${result.sim.dispatches} fakturautskick`);
   console.log(`  • ${result.calendarEvents} kalender-events, ${result.tasks} tasks`);
   console.log("");
   console.log("Nästa steg (om du vill pusha till ulrik-s/ava-demo):");


### PR DESCRIPTION
Stänger #985.

## Två av fyra — och varför bara två

#985 listade fyra entiteter som saknade matcher i `pathToSourceKey`. Undersökningen delade dem i två högar:

| Entitet | Åtgärd |
|---|---|
| `documentFolders` | matcher **+** mappar skapas nu i seedningen |
| `invoiceDispatches` | matcher **+** utskick registreras vid skickad faktura |
| `documentAnalysisSuggestions` | **inget** — ingen producent finns |
| `matterEventSuggestions` | **inget** — ingen producent finns |

En matcher ensam hade inte hjälpt någon av dem: **simuleringen skapade aldrig datat.** Varje dokument låg i ärendets rot, så träd-vyns mappar, drag-and-drop och nästling gick varken att se eller prova, och fakturans utskickshistorik var tom oavsett hur många fakturor som skickats.

För de två sista är gapet uppströms och de seedas därför inte: `grep` visar att **ingenting i kodbasen** skapar dem. `IDocumentAnalyzer.analyze` lovar i sin doc-kommentar att "eventuella suggestions postas via `dataStore.documentAnalysisSuggestions`", men ingen implementation gör det — classify-pipelinen skriver bara `document.updateMetadata`. `SuggestionsPanel` och `EventsPanel` står alltså tomma i **alla** tier, inte bara i demon. Att seeda rader hade betytt data appen själv aldrig kan producera. Utbrutet till **#988**; de två raderna står kvar i `NOT_YET_HYDRATED` med det som skäl i stället för "inte beslutat".

## Mappstrukturen

Dokumenten filas efter mottagare — det är den indelning träd-vyns drag-and-drop är gjord för:

```
Domstol/            (+ Domar/, Kostnadsräkningar/)
Korrespondens/
Klient/
Myndighetsbeslut/
Försäkring/
Fakturor/
```

## Buggen som uppstod på vägen

**Tre** pass filar dokument — den kronologiska simuleringen, fakturadokumenten och kostnadsräkningarna — och de delar inte state. Första versionen gav varje pass en egen cache, och kostnadsräkningarna skapade då en **andra** `Domstol`-mapp i sex ärenden:

```
DUBBLETT: 36229f21 Domstol 2
DUBBLETT: cdb7aee6 Domstol 2
… sex ärenden
```

`ensureFolderPath` läser nu ärendets befintliga mappar ur `document.tree` en gång per ärende, så vilket pass som kommer först är likgiltigt. Det är också därför logiken bor i en egen modul i stället för en kopia per pass.

| | Före | Efter |
|---|---|---|
| Mappar | 0 | 80 |
| Dubblettnamn | 6 | 0 |
| Dokument i roten | 121 av 121 | **0** av 121 |
| Fakturautskick | 0 | 9 |

## Följdändringar i tester

`document.list({ folderId: null })` returnerar numera inget — allt ligger i mappar. Två tester som antog rot-listning pekar om till `document.tree`, vilket dessutom är vad UI:t faktiskt läser (`DocumentBrowser` bygger båda vyerna på `tree.data`, så användaren ser alla dokument oavsett mapp).

Ett e2e-fall behövde också justeras: med mapp-rader blev tabellen högre, första dokumentradens kebab hamnade flush mot vyns nederkant, och Playwrights implicita scroll-then-click svalde då första klicket. Knappen centreras nu före klick. Verifierat att det är ett artefakt av testets klick och inte av appen — med högre viewport öppnas menyn på första klicket utan någon ändring i produktionskoden.

## Tester

- **`folder-filing.test.ts`** (ny): nästling uppifrån och ned, återanvändning av en mapp **ett annat pass** skapat (dubblettbuggen), en läsning per ärende och inte per dokument, samma mappnamn i olika ärenden.
- **`simulate-runner.test.ts`**: dokument hamnar i mottagarens mapp och mappen skapas en gång; nästlad sökväg får rätt förälder; utskick med klientens e-post; **inget** utskick utan e-post; inget klient-utskick för domstolsfakturor.
- **`simulate-orchestrate.test.ts`**: påstår om demons data att mappar finns, att minst en är nästlad, att dess förälder existerar och att rot-listningen är tom.
- **`demo-source-keys.test.ts`**: matchers för båda nya entiteterna, och `NOT_YET_HYDRATED` krympt från fyra till två.

## Grindar

`typecheck` ✓ · `lint` ✓ · `lint:complexity-strict` ✓ · `knip` ✓ · `deps:check` ✓ (1115 moduler) · `jscpd` ✓ · `build:demo` ✓ · **`e2e:demo` 31/31** ✓ · `test/scripts` + `test/integration` 255/255 ✓ · `test/unit/server` 1126 ✓

`test/unit/lib/demo` + `test/unit/components` vid katalogkörning: 417 pass / 42 fail — samma 42 som `main` (#92); filerna var för sig är gröna.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_