### PR TITLE
fix(kostnadsrakning): värdera arbetet på yrkandedatumet, inte förhandlingens slut

### DIFF
--- a/src/app/matters/[id]/_kostnadsrakning-modal.tsx
+++ b/src/app/matters/[id]/_kostnadsrakning-modal.tsx
@@ -156,6 +156,11 @@ type HelperState = ReturnType<typeof useHelper>;
 function useKostnadsrakningModal(props: Props) {
   const [hufStart, setHufStart] = useState<string>(() => defaultStart(props.initialHufStart));
   const [hufEnd, setHufEnd] = useState<string>(() => toDatetimeLocalValue(new Date()));
+  // Yrkandedatumet (#980): när räkningen framställs — det är det som avgör vilket
+  // års normer arbetet värderas på, inte när förhandlingen slutade. Låst när
+  // modalen öppnas så att beloppen inte kryper medan man skriver, och skilt från
+  // `hufEnd` som är ett riktigt klockslag i rättssalen.
+  const [yrkandeDate] = useState<Date>(() => new Date());
   const [isTaxe, setIsTaxe] = useState<boolean>(props.initialIsTaxe ?? true);
   const [level, setLevel] = useState<TaxaLevel>(props.initialLevel ?? 1);
   // F-skatt antas alltid — alla advokater har F-skatt. Tidigare radio borttagen.
@@ -196,12 +201,13 @@ function useKostnadsrakningModal(props: Props) {
     ...omitUndefined({ courtName: props.courtName }),
     hufStart: new Date(hufStart),
     hufEnd: new Date(hufEnd),
+    yrkandeDate,
     taxaLevel: level,
     hasFTax,
     isTaxeArende: isTaxe,
     expenses: props.expenses,
     timeEntries: ((timeEntries.data?.entries ?? []) as Array<{ id: string; date: string | Date; description: string; minutes: number; billable: boolean }>),
-  }), [hufStart, hufEnd, level, isTaxe, hasFTax, props, timeEntries.data]);
+  }), [hufStart, hufEnd, yrkandeDate, level, isTaxe, hasFTax, props, timeEntries.data]);
 
   useEffect(() => {
     const h = (e: KeyboardEvent) => { if (e.key === "Escape") props.onClose(); };

--- a/src/lib/client/kostnadsrakning/generate-kr-doc.ts
+++ b/src/lib/client/kostnadsrakning/generate-kr-doc.ts
@@ -63,6 +63,10 @@ export async function generateKrDoc(args: GenerateKrDocArgs): Promise<void> {
     ...omitUndefined({ courtName: meta.courtName }),
     // Ingen huvudförhandling i rättshjälps-KR:n — arvodet kommer ur tidsposterna.
     hufStart: now, hufEnd: now,
+    // Yrkandet framställs när räkningen skapas (#980). Explicit trots att det är
+    // samma `now` som ovan: de två datumen betyder olika saker och ska inte
+    // följa med varandra om HUF-fälten någon gång får riktiga värden här.
+    yrkandeDate: now,
     isTaxeArende: false,
     expenses,
     timeEntries,

--- a/src/lib/shared/kostnadsrakning.ts
+++ b/src/lib/shared/kostnadsrakning.ts
@@ -59,6 +59,22 @@ export interface BuildInput {
   hufStart: Date | string;
   /** ISO-string eller Date — HUF slutade (just nu i rättssalen). */
   hufEnd: Date | string;
+  /**
+   * När YRKANDET framställs (#980) — datumet som avgör vilket års normer
+   * arbetet värderas på. Default: nu.
+   *
+   * Övergångsbestämmelserna knyter an till inlämningen, inte till arbetet eller
+   * förhandlingen: "Äldre föreskrifter gäller fortfarande i fråga om yrkande om
+   * ersättning … som framställs före den 1 januari 2026" (DVFS 2025:4 p. 3;
+   * samma lydelse i 2025:6 och 2025:10). Det är därför en taxehöjning slår
+   * igenom retroaktivt på gammalt arbete.
+   *
+   * Värderades tidigare på `hufEnd`. Skillnaden syns bara över ett årsskifte —
+   * huvudförhandling i december, räkning i januari — men då blev hela räkningen
+   * värderad på fjolårets normer, medan slutregleringen (`billingRun.ts`, som
+   * använder fakturadatumet) räknade på det nya året. Samma ärende, två belopp.
+   */
+  yrkandeDate?: Date | string;
   /** Brottmålstaxa-nivå (1-4). Default 1. Används bara när isTaxeArende=true. */
   taxaLevel?: TaxaLevel;
   /** F-skatt-flagga (DVFS 11 §). Default true. */
@@ -193,6 +209,8 @@ interface KrTemplateArgs {
   input: BuildInput;
   start: Date;
   end: Date;
+  /** Datumet räkningen framställs på — styr både headern och normvalet (#980). */
+  yrkandeDate: Date;
   huvudforhandlingMinutes: number;
   level: TaxaLevel;
   taxa: TaxaResult;
@@ -210,7 +228,9 @@ interface KrTemplateArgs {
 /** Bygg Handlebars-context (matchar default-mallen). Ren assemblering. */
 function buildKrTemplateContext(a: KrTemplateArgs): Record<string, unknown> {
   return {
-    today: toIsoDate(new Date()),
+    // Räkningens datum = yrkandedatumet (#980), inte "nu": headern och beloppen
+    // ska alltid tala om samma dag.
+    today: toIsoDate(a.yrkandeDate),
     matterNumber: a.input.matter.matterNumber,
     matterTitle: a.input.matter.title,
     clientName: a.input.matter.clientName ?? "",
@@ -272,16 +292,26 @@ function buildKrTemplateContext(a: KrTemplateArgs): Record<string, unknown> {
 }
 
 /**
+ * Datumet som avgör vilket års normer räkningen värderas på (#980) — och som
+ * skrivs som räkningens "Datum" i dokumentet. EN härledning, så headern och
+ * beloppen aldrig kan hamna på olika år.
+ */
+function yrkandeDateOf(input: BuildInput): Date {
+  return input.yrkandeDate === undefined ? new Date() : new Date(input.yrkandeDate);
+}
+
+/**
  * Värdera tidsraderna per kategori (#891): icke-taxa → arbete på timkostnadsnormen
- * och tidsspillan på tidsspillan-normen (vid KR-datumet `hufEnd`, retroaktivt), så
+ * och tidsspillan på tidsspillan-normen (vid YRKANDEDATUMET, retroaktivt — #980), så
  * olika taxor aldrig summeras till en gemensam timkostnad. Taxa-ärenden → rateOrePerH
  * = 0 (raderna är informativa; beloppet styrs av taxan). Utbruten så
  * `buildKostnadsrakningContext` håller komplexitet ≤ 8 (#199).
  */
-function valuateTimeLines(entries: readonly TimeEntryInput[], input: BuildInput): { timeLines: TimeLine[]; arvodeNorm: number } {
+function valuateTimeLines(
+  entries: readonly TimeEntryInput[], input: BuildInput, valDate: Date,
+): { timeLines: TimeLine[]; arvodeNorm: number } {
   const isTaxe = input.isTaxeArende ?? true;
   const hasFTax = input.hasFTax ?? true;
-  const valDate = new Date(input.hufEnd);
   const arvodeNorm = hasFTax ? timkostnadsnormFtaxForDate(valDate) : TIMKOSTNADSNORM_NO_FTAX_ORE_PER_H;
   const tidsNorm = hasFTax ? tidsspillanFtaxForDate(valDate) : TIMKOSTNADSNORM_NO_FTAX_ORE_PER_H;
   const timeLines = entries.map((t): TimeLine => {
@@ -309,7 +339,8 @@ export function buildKostnadsrakningContext(input: BuildInput): KostnadsrakningR
   const billableTimeEntries = input.matter.radgivningPaid
     ? carveEarliestMinutes(allBillable, RADGIVNING_MINUTES)
     : allBillable;
-  const { timeLines, arvodeNorm } = valuateTimeLines(billableTimeEntries, input);
+  const yrkandeDate = yrkandeDateOf(input);
+  const { timeLines, arvodeNorm } = valuateTimeLines(billableTimeEntries, input, yrkandeDate);
   const billableArbetsMinutes = billableTimeEntries.reduce((s, t) => s + t.minutes, 0);
   const totalArbetsMinutes = billableArbetsMinutes + huvudforhandlingMinutes;
 
@@ -353,7 +384,7 @@ export function buildKostnadsrakningContext(input: BuildInput): KostnadsrakningR
   const totalInclVat = arvodeInclVat + expenseSummary.inclVat;
 
   const templateContext = buildKrTemplateContext({
-    input, start, end, huvudforhandlingMinutes, level, taxa,
+    input, start, end, yrkandeDate, huvudforhandlingMinutes, level, taxa,
     arvodeExclVat, arvodeMoms, arvodeInclVat, totalInclVat,
     expenseLines, expenseSummary, timeLines, billableArbetsMinutes, totalArbetsMinutes,
   });

--- a/test/unit/lib/shared/kostnadsrakning-tidsspillan.test.ts
+++ b/test/unit/lib/shared/kostnadsrakning-tidsspillan.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, it, expect } from "vitest-compat";
+import { coverageEntryRateOre } from "@/lib/shared/brottmalstaxa";
 import { buildKostnadsrakningContext } from "@/lib/shared/kostnadsrakning";
 
 describe("kostnadsräkning per kategori (#891)", () => {
@@ -13,6 +14,7 @@ describe("kostnadsräkning per kategori (#891)", () => {
       matter: { matterNumber: "2026-0020", title: "Test", radgivningPaid: false },
       defender: { name: "Adv" },
       hufStart: "2026-05-01T09:00:00", hufEnd: "2026-05-01T09:00:00", // ingen HUF
+      yrkandeDate: "2026-05-01", // explicit: testet påstår 2026 års normer
       isTaxeArende: false, hasFTax: true,
       expenses: [],
       timeEntries: [
@@ -35,9 +37,65 @@ describe("kostnadsräkning per kategori (#891)", () => {
       matter: { matterNumber: "x", title: "T", radgivningPaid: false },
       defender: { name: "A" },
       hufStart: "2026-06-01T09:00:00", hufEnd: "2026-06-01T09:00:00",
+      yrkandeDate: "2026-06-01",
       isTaxeArende: false, hasFTax: true, expenses: [],
       timeEntries: [{ id: "t1", date: "2025-11-15", description: "Arbete 2025", minutes: 60, billable: true, kind: "ARBETE" }],
     });
-    expect(res.arvodeExclVat).toBe(162_600); // 2026 års norm, inte 2025 (160 200)
+    expect(res.arvodeExclVat).toBe(162_600); // 2026 års norm, inte 2025 (158 600)
+  });
+});
+
+/**
+ * Vilket DATUM som styr värderingen (#980).
+ *
+ * Övergångsbestämmelserna knyter an till när YRKANDET framställs — inte till när
+ * arbetet gjordes och inte till när huvudförhandlingen slutade. Räkningen
+ * värderades tidigare på `hufEnd`, vilket bara skiljer sig över ett årsskifte:
+ * förhandling i december, räkning i januari. Då fick hela räkningen fjolårets
+ * normer medan slutregleringen räknade på det nya året.
+ */
+describe("kostnadsräkningens värderingsdatum (#980)", () => {
+  const base = {
+    matter: { matterNumber: "2026-0001", title: "T", radgivningPaid: false },
+    defender: { name: "A" },
+    isTaxeArende: false as const, hasFTax: true, expenses: [],
+    timeEntries: [{ id: "t1", date: "2025-11-15", description: "Arbete", minutes: 60, billable: true, kind: "ARBETE" as const }],
+  };
+  /** Huvudförhandlingen hölls i december 2025 — ett riktigt klockslag. */
+  const huf = { hufStart: "2025-12-15T09:00:00", hufEnd: "2025-12-15T11:00:00" };
+
+  it("yrkande i januari 2026 → 2026 års norm, trots förhandling i december", () => {
+    const res = buildKostnadsrakningContext({ ...base, ...huf, yrkandeDate: "2026-01-10" });
+    const line = (res.templateContext.timeLines as Array<{ rateOrePerH: number }>)[0]!;
+    expect(line.rateOrePerH, "timkostnadsnormen för yrkandeåret").toBe(162_600);
+  });
+
+  it("yrkande FÖRE årsskiftet → 2025 års norm, samma förhandling", () => {
+    // Övergångsbestämmelsen p. 3: äldre föreskrifter gäller yrkanden framställda
+    // före den 1 januari 2026. Samma ärende, samma arbete — datumet avgör.
+    const res = buildKostnadsrakningContext({ ...base, ...huf, yrkandeDate: "2025-12-20" });
+    const line = (res.templateContext.timeLines as Array<{ rateOrePerH: number }>)[0]!;
+    expect(line.rateOrePerH).toBe(158_600);
+  });
+
+  it("förhandlingens sluttid påverkar INTE beloppet", () => {
+    // Regressionsskyddet: det var precis den kopplingen som var felet.
+    const dec = buildKostnadsrakningContext({ ...base, ...huf, yrkandeDate: "2026-01-10" });
+    const jun = buildKostnadsrakningContext({
+      ...base, hufStart: "2026-06-01T09:00:00", hufEnd: "2026-06-01T11:00:00", yrkandeDate: "2026-01-10",
+    });
+    const rate = (r: typeof dec): number => (r.templateContext.timeLines as Array<{ rateOrePerH: number }>)[0]!.rateOrePerH;
+    expect(rate(dec)).toBe(rate(jun));
+  });
+
+  it("samma norm som slutregleringen använder för samma datum", () => {
+    // Kostnadsräkningen och `billingRun`s slutreglering ska inte kunna ge två
+    // olika belopp för samma ärende. Slutregleringen slår upp normen via
+    // `coverageEntryRateOre(kind, settleDate)`; här jämförs de rakt av.
+    for (const date of ["2025-12-20", "2026-01-10"]) {
+      const res = buildKostnadsrakningContext({ ...base, ...huf, yrkandeDate: date });
+      const line = (res.templateContext.timeLines as Array<{ rateOrePerH: number }>)[0]!;
+      expect(line.rateOrePerH, `norm ${date}`).toBe(coverageEntryRateOre("ARBETE", date));
+    }
   });
 });

--- a/tooling/demo-generator/populate-kostnadsrakning-docs.ts
+++ b/tooling/demo-generator/populate-kostnadsrakning-docs.ts
@@ -113,6 +113,10 @@ async function krContextFor(c: Any, run: Any): Promise<Any> {
     matter: { matterNumber: matter.matterNumber, title: matter.title, clientName: matter.clientName ?? undefined, radgivningPaid: matter.paymentMethod === "RATTSHJALP" },
     defender: { name: matter.responsibleLawyerName ?? "Ansvarig jurist" },
     hufStart: date, hufEnd: date, // ingen huvudförhandling i dessa KR:er
+    // Yrkandet framställdes när KR-runnen skapades (#980) — det styr både
+    // normvalet och räkningens datum i dokumentet. Explicit, så det inte råkar
+    // följa med hufEnd om de fälten någon gång får riktiga förhandlingstider.
+    yrkandeDate: date,
     isTaxeArende: false, hasFTax: true,
     timeEntries: (te.entries ?? []) as Any,
     expenses: (ex.expenses ?? []) as Any,


### PR DESCRIPTION
Stänger #980.

## Regeln

Övergångsbestämmelserna knyter an till när **yrkandet framställs** — inte till när arbetet gjordes och inte till när förhandlingen hölls:

> **3.** Äldre föreskrifter gäller fortfarande i fråga om **yrkande** om ersättning för tidsspillan som **framställs** före den 1 januari 2026.

Samma lydelse i DVFS 2025:6 (brottmålstaxan) och 2025:10. Det är också därför en taxehöjning slår igenom retroaktivt på gammalt arbete.

## Vad koden gjorde

`kostnadsrakning.ts` slog upp normerna på `hufEnd` — huvudförhandlingens sluttid, ett fält vars egen dokumentation lyder *"HUF slutade (just nu i rättssalen)"*. Rätt värde för sitt syfte, fel som värderingsdatum.

Skillnaden syns bara över ett årsskifte: **förhandling i december, räkning i januari**. Då fick hela räkningen fjolårets normer, medan slutregleringen — som använder `settleDate` = fakturadatumet i alla fyra anropen till `coverageEntryRateOre` — räknade på det nya året. Samma ärende, två belopp, beroende på vilken väg man gick.

## Omfattning — smalare än issuen antydde

Tre villkor måste sammanfalla, och det är värt att skriva ut:

1. **Icke-taxa-ärende.** I taxeärenden är `rateOrePerH = isTaxe ? 0 : …` — varje tidspost värderas till noll och brottmålstaxan står ensam. Felet är osynligt där.
2. **Årsskifte mellan förhandling och räkning.**
3. Modalen defaultar dessutom `hufEnd` till *nu*, så den som skriver räkningen direkt efter förhandlingen fick rätt utan att veta om det. Den som fyllde i förhandlingens faktiska sluttid — vilket är vad fältet ber om — fick fel.

## Ändringen

`BuildInput` har fått `yrkandeDate` (default: nu). **Alla tre** anropsplatser skickar det explicit — även de två som redan råkade skicka rätt datum via `hufEnd`, eftersom de två fälten betyder olika saker och inte ska följa med varandra om HUF-fälten någon gång får riktiga värden:

| Anropsplats | Yrkandedatum |
|---|---|
| `_kostnadsrakning-modal.tsx` | låst när modalen öppnas — beloppen ska inte krypa medan man skriver |
| `generate-kr-doc.ts` | `now` |
| `populate-kostnadsrakning-docs.ts` (demo) | KR-runnens `createdAt` |

Dokumentets `Datum:`-rad härleddes tidigare ur ett eget `new Date()`. Den kommer nu ur samma värde, så headern och beloppen inte kan hamna på olika år.

## Tester

Fyra nya i `kostnadsrakning-tidsspillan.test.ts`, alla med samma förhandling (2025-12-15) och samma arbete:

| Test | Påstående |
|---|---|
| Yrkande 2026-01-10 | 162 600 (2026 års norm) |
| Yrkande 2025-12-20 | 158 600 (2025 års norm) |
| December- vs juni-förhandling, samma yrkandedatum | identiska belopp |
| Paritet | normen == `coverageEntryRateOre("ARBETE", date)` för båda datumen |

Det sista är det som håller ihop de två vägarna: slutregleringen slår upp normen via just den funktionen, så en framtida divergens fäller testet.

**Tre av de fyra fallerar mot koden före fixen** — verifierat genom att stasha källändringen och köra om, inte antaget. De befintliga testerna fick dessutom explicita yrkandedatum: ett test som påstår 2026 års normer ska säga 2026, inte förlita sig på när det råkar köras.

## Grindar

`typecheck` ✓ · `lint` ✓ · `lint:complexity-strict` ✓ · `knip` ✓ · `deps:check` ✓ (1116 moduler) · `jscpd` ✓ · `build:demo` ✓ · **`e2e:demo` 31/31** ✓ · `test/integration` + `test/scripts` 260/260 ✓ · `test/unit/shared` + `test/unit/lib/shared` 405/405 ✓

Vid katalogkörning av KR-testerna: 105 pass / 3 fail mot baslinjens 102 / 6 — samma tre kvarvarande fel som på `main` (#92), och tre färre eftersom mina nya nu passerar.

## Not vid sidan om

`computeBrottmalstaxa` har ingen årsdimension alls — `BROTTMALSTAXA_TABLE` är en enda tabell för DVFS 2025:6. Det gör ingen skada i dag men blir samma sorts fel när 2027 års belopp landar. Inte åtgärdat här; nämns så det inte upptäcks av en klient.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_