### PR TITLE
feat(documents): extrahera parter och händelser ur dokumenttext

### DIFF
--- a/src/lib/client/demo/demo-source-keys.ts
+++ b/src/lib/client/demo/demo-source-keys.ts
@@ -45,6 +45,11 @@ const MATCHERS: Matcher[] = [
   // fakturan stod tom oavsett hur många fakturor som skickats.
   { key: "documentFolders", owns: (p) => p.startsWith("document-folders/") },
   { key: "invoiceDispatches", owns: (p) => p.startsWith("invoice-dispatches/") },
+  // #988: kontakt- och händelseförslagen fick en producent (extraktion ur
+  // dokumenttexten) och kan därmed hydreras — panelerna var tomma i alla tier
+  // så länge ingenting skapade raderna.
+  { key: "documentAnalysisSuggestions", owns: (p) => p.startsWith("document-analysis-suggestions/") },
+  { key: "matterEventSuggestions", owns: (p) => p.startsWith("matter-event-suggestions/") },
   { key: "billingRuns", owns: (p) => p.startsWith("billing-runs/") },
   { key: "accontoDeductions", owns: (p) => p.startsWith("acconto-deductions/") },
   { key: "expectedReceivables", owns: (p) => p.startsWith("expected-receivables/") },

--- a/src/lib/server/documents/suggest-from-text.ts
+++ b/src/lib/server/documents/suggest-from-text.ts
@@ -1,0 +1,88 @@
+/**
+ * Skriv kontakt- och händelseförslag ur ett dokuments text (#988).
+ *
+ * Den här funktionen är den PRODUCENT som saknades. `SuggestionsPanel` och
+ * `EventsPanel` var fullt utbyggda — accept/reject per förslag och per grupp,
+ * repositories, routrar, relations, Postgres-tabeller — men ingenting skapade
+ * raderna, så panelerna stod tomma i alla tier.
+ *
+ * Extraktionen själv är ren och bor i `@/lib/shared/document-extraction`. Här
+ * ligger bara IO: dedup mot redan skapade förslag, och skrivningen.
+ *
+ * **Idempotent.** Samma dokument kan analyseras om hur många gånger som helst
+ * (uppladdning, manuell "Analysera", reconcile-replay) utan att förslagen
+ * dubbleras. Ett förslag som användaren redan AVFÄRDAT återuppstår inte heller
+ * — dedupen tittar på alla statusar, inte bara PENDING. Att få tillbaka ett
+ * bortvalt förslag vid varje omanalys vore värre än att inte få det alls.
+ */
+
+import {
+  extractEventSuggestions, extractPartySuggestions,
+} from "@/lib/shared/document-extraction";
+import type { DocumentAnalysisSuggestion, MatterEventSuggestion } from "@/lib/shared/schemas/document";
+import type { DocumentId } from "@/lib/shared/schemas/ids";
+import type { Repositories } from "../repositories/repositories";
+
+/**
+ * Bara de två repositories funktionen faktiskt rör. Smalare än `Repositories`
+ * med flit: anropare (och tester) slipper bygga hela sömmen, och beroendet
+ * syns i signaturen i stället för att gömma sig i kroppen.
+ */
+export type SuggestionRepos = Pick<Repositories, "documentAnalysisSuggestions" | "matterEventSuggestions">;
+
+export interface SuggestFromTextResult {
+  parties: number;
+  events: number;
+}
+
+/** Nyckel för ett kontaktförslag — samma part i samma roll är samma förslag. */
+function partyKey(p: { name: string; role: string }): string {
+  return `${p.name.trim().toLowerCase()}|${p.role}`;
+}
+
+/** Nyckel för ett händelseförslag — samma rubrik vid samma tidpunkt. */
+function eventKey(e: { title: string; startAt: Date | string }): string {
+  return `${e.title.trim().toLowerCase()}|${new Date(e.startAt).toISOString()}`;
+}
+
+/**
+ * Extrahera ur `text` och skapa de förslag som inte redan finns på dokumentet.
+ * Returnerar antalet NYA rader — noll vid omkörning på oförändrad text.
+ */
+export async function writeSuggestionsFromText(
+  repos: SuggestionRepos, documentId: DocumentId, text: string,
+): Promise<SuggestFromTextResult> {
+  if (text.trim().length === 0) return { parties: 0, events: 0 };
+
+  const [existingParties, existingEvents] = await Promise.all([
+    repos.documentAnalysisSuggestions.listForDocument(documentId),
+    repos.matterEventSuggestions.listForDocument(documentId),
+  ]);
+  const seenParties = new Set(existingParties.map(partyKey));
+  const seenEvents = new Set(existingEvents.map(eventKey));
+
+  let parties = 0;
+  for (const p of extractPartySuggestions(text)) {
+    if (seenParties.has(partyKey(p))) continue;
+    seenParties.add(partyKey(p));
+    await repos.documentAnalysisSuggestions.create({
+      documentId, name: p.name, role: p.role, contactType: p.contactType,
+      personalNumber: p.personalNumber, orgNumber: p.orgNumber,
+      notes: p.notes, status: "PENDING",
+    } satisfies Partial<DocumentAnalysisSuggestion>);
+    parties++;
+  }
+
+  let events = 0;
+  for (const e of extractEventSuggestions(text)) {
+    if (seenEvents.has(eventKey(e))) continue;
+    seenEvents.add(eventKey(e));
+    await repos.matterEventSuggestions.create({
+      documentId, title: e.title, description: e.description,
+      eventType: e.eventType, startAt: e.startAt, allDay: false, status: "PENDING",
+    } satisfies Partial<MatterEventSuggestion>);
+    events++;
+  }
+
+  return { parties, events };
+}

--- a/src/lib/server/repositories/document-suggestion-repository.ts
+++ b/src/lib/server/repositories/document-suggestion-repository.ts
@@ -22,6 +22,9 @@ export interface SuggestionListRow extends DocumentAnalysisSuggestion {
 export interface DocumentSuggestionRepository extends Repository<DocumentAnalysisSuggestion> {
   /** Förslag by id, org-scopat via dokument→ärende (med matterId). Null om saknas/annan org. */
   getByIdInOrg(id: DocumentAnalysisSuggestionId, organizationId: OrganizationId): Promise<SuggestionWithMatter | null>;
+  /** ALLA förslag på ett dokument, oavsett status (#988). Dedup vid omanalys
+   *  måste se även AVFÄRDADE förslag — annars återuppstår de vid varje körning. */
+  listForDocument(documentId: DocumentId): Promise<DocumentAnalysisSuggestion[]>;
   /** Pending-förslag för ett ärende (dokument-include), sorterade createdAt. */
   listPendingForMatter(matterId: MatterId, organizationId: OrganizationId, order: "asc" | "desc"): Promise<SuggestionListRow[]>;
   /** Pending-förslag med givna id:n, org-scopat (grupp-accept). */

--- a/src/lib/server/repositories/drizzle-document-suggestion-repository.ts
+++ b/src/lib/server/repositories/drizzle-document-suggestion-repository.ts
@@ -6,7 +6,7 @@
 import { and, asc, desc, eq, inArray, isNull } from "drizzle-orm";
 import type { DocumentAnalysisSuggestion } from "@/lib/shared/schemas/document";
 import type {
-  DocumentAnalysisSuggestionId, MatterId, OrganizationId,
+  DocumentAnalysisSuggestionId, DocumentId, MatterId, OrganizationId,
 } from "@/lib/shared/schemas/ids";
 import { documentAnalysisSuggestions, documents, matters } from "../db/schema";
 import type { AppDb } from "../db/types";
@@ -33,6 +33,11 @@ export class DrizzleDocumentSuggestionRepository
       .limit(1);
     const r = rows[0];
     return r ? ({ ...r.s, document: { matterId: r.matterId } }) : null;
+  }
+
+  async listForDocument(documentId: DocumentId): Promise<DocumentAnalysisSuggestion[]> {
+    return await this.db.select().from(S)
+      .where(and(eq(S.documentId, documentId), isNull(S.deletedAt))) as DocumentAnalysisSuggestion[];
   }
 
   async listPendingForMatter(matterId: MatterId, organizationId: OrganizationId, order: "asc" | "desc"): Promise<SuggestionListRow[]> {

--- a/src/lib/server/repositories/drizzle-matter-event-suggestion-repository.ts
+++ b/src/lib/server/repositories/drizzle-matter-event-suggestion-repository.ts
@@ -5,7 +5,7 @@
 
 import { and, asc, eq, isNull, ne } from "drizzle-orm";
 import type { MatterEventSuggestion } from "@/lib/shared/schemas/document";
-import type { MatterEventSuggestionId, MatterId, OrganizationId } from "@/lib/shared/schemas/ids";
+import type { DocumentId, MatterEventSuggestionId, MatterId, OrganizationId } from "@/lib/shared/schemas/ids";
 import { documents, matterEventSuggestions, matters } from "../db/schema";
 import type { AppDb } from "../db/types";
 import { DrizzleRepository, versionedTable } from "./drizzle-repository";
@@ -18,6 +18,14 @@ export class DrizzleMatterEventSuggestionRepository
   implements MatterEventSuggestionRepository {
   constructor(db: AppDb, now: () => Date = () => new Date()) {
     super(db, versionedTable(matterEventSuggestions), now);
+  }
+
+  async listForDocument(documentId: DocumentId): Promise<MatterEventSuggestion[]> {
+    return await this.db.select().from(matterEventSuggestions)
+      .where(and(
+        eq(matterEventSuggestions.documentId, documentId),
+        isNull(matterEventSuggestions.deletedAt),
+      )) as MatterEventSuggestion[];
   }
 
   async listForMatter(matterId: MatterId, organizationId: OrganizationId): Promise<MatterEventSuggestionRow[]> {

--- a/src/lib/server/repositories/in-memory-document-suggestion-repository.ts
+++ b/src/lib/server/repositories/in-memory-document-suggestion-repository.ts
@@ -5,7 +5,7 @@
 
 import type { DocumentAnalysisSuggestion } from "@/lib/shared/schemas/document";
 import type {
-  DocumentAnalysisSuggestionId, MatterId, OrganizationId,
+  DocumentAnalysisSuggestionId, DocumentId, MatterId, OrganizationId,
 } from "@/lib/shared/schemas/ids";
 import type { IDataStore } from "../data-store/IDataStore";
 import type {
@@ -27,6 +27,10 @@ export class InMemoryDocumentSuggestionRepository
       where: { id, document: { matter: { organizationId } } },
       include: { document: { select: { matterId: true } } },
     })) as SuggestionWithMatter | null;
+  }
+
+  async listForDocument(documentId: DocumentId): Promise<DocumentAnalysisSuggestion[]> {
+    return (await this.delegate.findMany({ where: { documentId } })) as DocumentAnalysisSuggestion[];
   }
 
   async listPendingForMatter(matterId: MatterId, organizationId: OrganizationId, order: "asc" | "desc"): Promise<SuggestionListRow[]> {

--- a/src/lib/server/repositories/in-memory-matter-event-suggestion-repository.ts
+++ b/src/lib/server/repositories/in-memory-matter-event-suggestion-repository.ts
@@ -4,7 +4,7 @@
  */
 
 import type { MatterEventSuggestion } from "@/lib/shared/schemas/document";
-import type { MatterEventSuggestionId, MatterId, OrganizationId } from "@/lib/shared/schemas/ids";
+import type { DocumentId, MatterEventSuggestionId, MatterId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
 import type {
@@ -18,6 +18,10 @@ export class InMemoryMatterEventSuggestionRepository
   implements MatterEventSuggestionRepository {
   constructor(store: MatterEventSuggestionRepoSource, now?: () => Date) {
     super(store.matterEventSuggestions, now ?? (() => new Date()));
+  }
+
+  async listForDocument(documentId: DocumentId): Promise<MatterEventSuggestion[]> {
+    return (await this.delegate.findMany({ where: { documentId } })) as MatterEventSuggestion[];
   }
 
   async listForMatter(matterId: MatterId, organizationId: OrganizationId): Promise<MatterEventSuggestionRow[]> {

--- a/src/lib/server/repositories/matter-event-suggestion-repository.ts
+++ b/src/lib/server/repositories/matter-event-suggestion-repository.ts
@@ -13,6 +13,8 @@ export interface MatterEventSuggestionRow extends MatterEventSuggestion {
 }
 
 export interface MatterEventSuggestionRepository extends Repository<MatterEventSuggestion> {
+  /** ALLA händelseförslag på ett dokument, oavsett status (#988) — dedup vid omanalys. */
+  listForDocument(documentId: DocumentId): Promise<MatterEventSuggestion[]>;
   /** Icke-avvisade händelser för ett ärende (startAt asc), org-scopat via dokumentet. */
   listForMatter(matterId: MatterId, organizationId: OrganizationId): Promise<MatterEventSuggestionRow[]>;
   /** Händelse by id, org-scopad via dokument→ärende. Null om saknas/annan org/raderad. */

--- a/src/lib/server/routers/document/core.ts
+++ b/src/lib/server/routers/document/core.ts
@@ -12,6 +12,7 @@ import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { documentAnalysisStatusSchema, documentDirectionSchema, documentRecipientSchema, type Document } from "@/lib/shared/schemas/document";
 import { asId, documentFolderIdSchema, documentIdSchema, invoiceIdSchema, matterIdSchema, userIdSchema } from "@/lib/shared/schemas/ids";
 import { uuidv7 } from "@/lib/shared/uuid";
+import { writeSuggestionsFromText } from "../../documents/suggest-from-text";
 import { orgProcedure } from "../../trpc";
 import { assertDocAccess } from "./shared";
 
@@ -160,6 +161,26 @@ export const coreProcedures = {
         console.error("analyze failed:", e),
       );
       return { ok: true };
+    }),
+
+  /**
+   * Skapa kontakt- och händelseförslag ur ett dokuments TEXT (#988).
+   *
+   * Sömmen som saknades: `SuggestionsPanel` och `EventsPanel` fanns fullt
+   * utbyggda, men ingenting skapade raderna — panelerna stod tomma i alla tier.
+   * Anroparen skickar texten (klienten har den i sin content-cache, seedningen
+   * har den när dokumentet genereras), extraktionen är ren och deterministisk
+   * (`@/lib/shared/document-extraction`), och skrivningen är idempotent.
+   *
+   * Texten skickas in i stället för att läsas här: var den finns skiljer sig
+   * mellan tier (OPFS/FSA i self-hosted, seed-filer i demon, content-store i
+   * server-first), och den skillnaden hör inte hemma i routern.
+   */
+  suggestFromText: orgProcedure
+    .input(z.object({ documentId: documentIdSchema, text: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      await assertDocAccess(ctx, input.documentId);
+      return await writeSuggestionsFromText(ctx.repos, input.documentId, input.text);
     }),
 
   /**

--- a/src/lib/shared/document-extraction.ts
+++ b/src/lib/shared/document-extraction.ts
@@ -1,0 +1,260 @@
+/**
+ * Extraktion av parter och händelser ur ett dokuments TEXT (#988).
+ *
+ * ## Varför den här finns
+ *
+ * `SuggestionsPanel` och `EventsPanel` fanns fullt utbyggda — med accept/reject
+ * per förslag och per grupp — men stod tomma i ALLA tier. Ingenting skapade
+ * raderna: `IDocumentAnalyzer.analyze` lovade i sin doc-kommentar att
+ * "eventuella suggestions postas via dataStore.documentAnalysisSuggestions",
+ * men classify-pipelinen skrev bara `document.updateMetadata`. Repositories,
+ * routrar, relations och Postgres-tabeller underhölls för data som aldrig uppstod.
+ *
+ * ## Varför heuristik och inte LLM
+ *
+ * ADR 0027 gör LLM till en SERVER-förmåga, och demon har ingen server. En
+ * LLM-baserad extraktion hade alltså lämnat panelerna tomma just där de syns
+ * mest, och gjort testerna beroende av en modell. Mönstren nedan är i stället
+ * rent deterministiska: samma text ger alltid samma förslag, i alla tier, och
+ * går att testa på exakta strängar.
+ *
+ * Heuristiken är medvetet FÖRSIKTIG. Ett förslag är inte ett faktum — det är en
+ * rad någon ska godkänna eller avfärda med ett klick. Falska positiver kostar
+ * ett avfärdande; falska negativer kostar bara det man redan har i dag (inget
+ * förslag alls). Därför krävs en tydlig markör — ett rollord, ett personnummer,
+ * ett kallelseord — och gissas aldrig fritt ur löptext.
+ */
+
+import type { ContactType, MatterRole } from "./schemas/enums";
+
+// ─── Parter ───────────────────────────────────────────────────────────────
+
+/** Ett kontaktförslag ur dokumenttexten — fälten `DocumentAnalysisSuggestion` bär. */
+export interface PartyCandidate {
+  name: string;
+  role: MatterRole;
+  contactType: ContactType;
+  personalNumber: string | null;
+  orgNumber: string | null;
+  /** Varför förslaget kom — visas för den som ska godkänna det. */
+  notes: string;
+}
+
+/**
+ * Rollord → roll. Ordningen spelar roll: mer specifika uttryck först, så
+ * "Motpartens ombud" inte fastnar på "Motpart".
+ */
+const ROLE_MARKERS: ReadonlyArray<readonly [RegExp, MatterRole]> = [
+  [/motpartens ombud|motpartsombud|ombud för motparten/i, "MOTPARTSOMBUD"],
+  [/\bombud\b|\bbiträde\b/i, "OMBUD"],
+  [/\bmotpart(en)?\b|\bsvarande(n)?\b/i, "MOTPART"],
+  [/\bkärande(n)?\b|\bmålsägande(n)?\b|\bklient(en)?\b|\btilltalad(e|en)?\b/i, "KLIENT"],
+  [/\båklagare(n)?\b/i, "AKLAGARE"],
+  [/\bvittne(t|n)?\b/i, "VITTNE"],
+  [/tingsrätt|hovrätt|högsta domstolen|förvaltningsrätt|kammarrätt/i, "DOMSTOL"],
+  [/försäkringsbolag|försäkringsaktiebolag/i, "FORSAKRINGSBOLAG"],
+];
+
+/** Bolagsformer → contactType COMPANY. Svenska suffix, inte namnlistor. */
+const COMPANY_SUFFIX = /\b(AB|HB|KB|aktiebolag|ekonomisk förening|stiftelse)\b\.?$/i;
+
+/**
+ * Personnummer respektive organisationsnummer, båda `NNNNNN-NNNN`.
+ *
+ * Skiljelinjen är TREDJE siffran: i ett personnummer är siffra 3–4 månaden
+ * (01–12), så siffra 3 är 0 eller 1. Ett organisationsnummer har alltid ≥ 2 där.
+ * Det är den officiella regeln och gör grupperna disjunkta utan checksumma.
+ */
+const PERSONAL_NUMBER = /\b(?:\d{2})?(\d{2}[01]\d{3})[-+](\d{4})\b/;
+const ORG_NUMBER = /\b(\d{2}[2-9]\d{3})-(\d{4})\b/;
+
+/** Rad + närmast föregående rad — rollordet står ofta på raden före namnet. */
+interface Line { text: string; prev: string }
+
+function toLines(text: string): Line[] {
+  const raw = text.split(/\r?\n/).map((l) => l.trim());
+  return raw.map((text, i) => ({ text, prev: raw[i - 1] ?? "" })).filter((l) => l.text.length > 0);
+}
+
+/** Meningsslut → raden är löptext, inte en partsrad. Partsblock skrivs
+ *  `Roll: Namn`, utan punkt. */
+const SENTENCE_END = /[.!?]$/;
+
+function markerIn(text: string): MatterRole | null {
+  for (const [pattern, role] of ROLE_MARKERS) {
+    if (pattern.test(text)) return role;
+  }
+  return null;
+}
+
+/**
+ * Rollen raden bär. Radens EGEN markör vinner alltid; först när den saknas
+ * ärvs raden ovanför.
+ *
+ * Båda begränsningarna är nödvändiga. Utan "egen vinner" fick
+ * "Svarande: Byggfirma Stenhammar AB" rollen OMBUD, eftersom raden ovanför var
+ * "Ombud: Advokat Erik Lundqvist". Utan kravet att den ärvande raden ser ut som
+ * ett ensamt namn ärvde varje mening i stycket föregående rads roll.
+ */
+function roleOf(line: Line): MatterRole | null {
+  const own = markerIn(line.text);
+  if (own) return own;
+  if (SENTENCE_END.test(line.text)) return null;
+  return markerIn(line.prev);
+}
+
+/**
+ * Namnet på raden: allt före ett ev. personnummer/organisationsnummer, med
+ * rollordet och skiljetecken bortskalade. Tom sträng → raden bär inget namn.
+ */
+function nameOf(line: string): string {
+  return line
+    .replace(PERSONAL_NUMBER, "").replace(ORG_NUMBER, "")
+    .replace(/^[^:]{0,30}:\s*/, "")     // "Kärande: Anna Andersson"
+    .replace(/[,;.\s]+$/, "")
+    .trim();
+}
+
+function contactTypeFor(role: MatterRole, name: string): ContactType {
+  if (COMPANY_SUFFIX.test(name)) return "COMPANY";
+  if (role === "DOMSTOL") return "COURT";
+  if (role === "FORSAKRINGSBOLAG") return "INSURANCE_COMPANY";
+  if (role === "MOTPARTSOMBUD" || role === "OMBUD") return "LAW_FIRM";
+  if (role === "AKLAGARE") return "AUTHORITY";
+  return "PERSON";
+}
+
+/**
+ * Raden är BARA ett rollord ("Svarande") → en rubrik för raden under, inte en
+ * part. Testas genom att stryka markören: blir inget kvar var raden en etikett.
+ * "Stockholms tingsrätt" behåller "Stockholms" och är alltså ett namn.
+ */
+function isBareRoleHeader(text: string): boolean {
+  for (const [pattern] of ROLE_MARKERS) {
+    if (pattern.test(text)) return !/\p{L}/u.test(text.replace(pattern, " ").replace(/[:\s]/g, ""));
+  }
+  return false;
+}
+
+/** Rimligt personnamn/bolagsnamn: 2–80 tecken, minst en bokstav, inte en mening. */
+function isPlausibleName(name: string): boolean {
+  if (name.length < 2 || name.length > 80) return false;
+  if (!/\p{L}/u.test(name)) return false;
+  return name.split(/\s+/).length <= 6;
+}
+
+/** `NNNNNN-NNNN` ur en träff, normaliserat till tio siffror med bindestreck. */
+function joined(match: RegExpMatchArray | null): string | null {
+  return match ? `${match[1]}-${match[2]}` : null;
+}
+
+/**
+ * Kontaktförslag ur dokumenttexten.
+ *
+ * En rad ger ett förslag när den bär BÅDE en rollmarkör och ett rimligt namn.
+ * Dubbletter (samma namn + roll) slås ihop — samma part nämns ofta flera gånger
+ * i samma handling.
+ */
+export function extractPartySuggestions(text: string): PartyCandidate[] {
+  const out = new Map<string, PartyCandidate>();
+  for (const line of toLines(text)) {
+    // Rader som slutar som en mening är löptext. "Käranden yrkar ersättning."
+    // bär ett rollord men är inget partsnamn — utan den här grinden blev varje
+    // sådan mening ett förslag att avfärda.
+    if (SENTENCE_END.test(line.text)) continue;
+    if (isBareRoleHeader(line.text)) continue;
+    const role = roleOf(line);
+    if (!role) continue;
+    const name = nameOf(line.text);
+    if (!isPlausibleName(name)) continue;
+    const personalNumber = joined(line.text.match(PERSONAL_NUMBER));
+    const orgNumber = joined(line.text.match(ORG_NUMBER));
+    const key = `${name.toLowerCase()}|${role}`;
+    if (out.has(key)) continue;
+    out.set(key, {
+      name, role, contactType: contactTypeFor(role, name),
+      personalNumber, orgNumber,
+      notes: `Föreslagen ur dokumentet: "${line.text.slice(0, 120)}"`,
+    });
+  }
+  return [...out.values()];
+}
+
+// ─── Händelser ────────────────────────────────────────────────────────────
+
+/** Ett händelseförslag — fälten `MatterEventSuggestion` bär. */
+export interface EventCandidate {
+  title: string;
+  startAt: Date;
+  eventType: string;
+  description: string;
+}
+
+/** Kallelseord → händelsetyp. Utan ett sådant ord skapas inget förslag. */
+const EVENT_MARKERS: ReadonlyArray<readonly [RegExp, string, string]> = [
+  [/huvudförhandling/i, "Huvudförhandling", "HUVUDFORHANDLING"],
+  [/muntlig förberedelse/i, "Muntlig förberedelse", "FORBEREDELSE"],
+  [/häktningsförhandling/i, "Häktningsförhandling", "FORHANDLING"],
+  [/sammanträde/i, "Sammanträde", "SAMMANTRADE"],
+  [/förhör/i, "Förhör", "FORHOR"],
+  [/\bfrist\b|senast den/i, "Frist", "FRIST"],
+];
+
+const MONTHS: Readonly<Record<string, number>> = {
+  januari: 0, februari: 1, mars: 2, april: 3, maj: 4, juni: 5,
+  juli: 6, augusti: 7, september: 8, oktober: 9, november: 10, december: 11,
+};
+
+const ISO_DATE = /\b(\d{4})-(\d{2})-(\d{2})\b/;
+const SV_DATE = new RegExp(String.raw`\b(\d{1,2})\s+(${Object.keys(MONTHS).join("|")})\s+(\d{4})\b`, "i");
+/** "kl. 09.00", "kl 09:00", "09.00". Minuterna är valfria. */
+const TIME = /\bkl\.?\s*(\d{1,2})[.:](\d{2})\b/i;
+
+/** Datumet på raden, om något — ISO först, annars svensk längdform. */
+function dateOf(line: string): { y: number; m: number; d: number } | null {
+  const iso = line.match(ISO_DATE);
+  if (iso) return { y: Number(iso[1]), m: Number(iso[2]) - 1, d: Number(iso[3]) };
+  const sv = line.match(SV_DATE);
+  if (!sv) return null;
+  const month = MONTHS[sv[2]!.toLowerCase()];
+  return month === undefined ? null : { y: Number(sv[3]), m: month, d: Number(sv[1]) };
+}
+
+/**
+ * Händelseförslag ur dokumenttexten.
+ *
+ * Kräver BÅDE ett kallelseord och ett datum på samma rad (eller raden före).
+ * Klockslag är valfritt — en kallelse utan tid är fortfarande en kallelse, och
+ * händelsen läggs då kl 00.00 för den som ska bekräfta den.
+ */
+export function extractEventSuggestions(text: string): EventCandidate[] {
+  const out = new Map<string, EventCandidate>();
+  for (const line of toLines(text)) {
+    const hit = eventOn(line);
+    if (hit && !out.has(hit.key)) out.set(hit.key, hit.event);
+  }
+  return [...out.values()];
+}
+
+/** Datum + ev. klockslag → tidpunkt. Utan tid läggs händelsen kl 00.00. */
+function startAtOf(d: { y: number; m: number; d: number }, time: RegExpMatchArray | null): Date {
+  return new Date(d.y, d.m, d.d, time ? Number(time[1]) : 0, time ? Number(time[2]) : 0, 0, 0);
+}
+
+/** Händelsen raden bär, eller null. Utbruten så `extractEventSuggestions` håller
+ *  komplexitet ≤ 8. */
+function eventOn(line: Line): { key: string; event: EventCandidate } | null {
+  const marker = EVENT_MARKERS.find(([p]) => p.test(`${line.prev}\n${line.text}`));
+  if (!marker) return null;
+  const date = dateOf(line.text) ?? dateOf(line.prev);
+  if (!date) return null;
+  const startAt = startAtOf(date, line.text.match(TIME) ?? line.prev.match(TIME));
+  if (Number.isNaN(startAt.getTime())) return null;
+  return {
+    key: `${marker[1]}|${startAt.toISOString()}`,
+    event: {
+      title: marker[1], startAt, eventType: marker[2],
+      description: `Föreslagen ur dokumentet: "${line.text.slice(0, 120)}"`,
+    },
+  };
+}

--- a/test/scripts/demo-prutning.test.ts
+++ b/test/scripts/demo-prutning.test.ts
@@ -24,6 +24,7 @@ function recordingCaller(): { c: Any; calls: Array<{ method: string; args: Any }
     if (method === "billingRun.createFinal") return { invoice: { id: "fin", amount: 100_000 } };
     if (method === "billingRun.settleCoverage") return { clientInvoice: {}, payerInvoice: {} };
     if (method === "document.tree") return { folders: [], documents: [] };
+    if (method === "document.suggestFromText") return { parties: 0, events: 0 };
     if (method === "document.createFolder") return { id: `folder-${calls.length}` };
     return {};
   };
@@ -32,7 +33,7 @@ function recordingCaller(): { c: Any; calls: Array<{ method: string; args: Any }
     timeEntry: { create: rec("timeEntry.create") },
     serviceNote: { create: rec("serviceNote.create") },
     expense: { create: rec("expense.create") },
-    document: { register: rec("document.register"), createFolder: rec("document.createFolder"), tree: rec("document.tree") },
+    document: { register: rec("document.register"), createFolder: rec("document.createFolder"), tree: rec("document.tree"), suggestFromText: rec("document.suggestFromText") },
     invoice: { createRadgivning: rec("invoice.createRadgivning"), setStatus: rec("invoice.setStatus"), recordPayment: rec("invoice.recordPayment") },
     billingRun: {
       createAcconto: rec("billingRun.createAcconto"), createKostnadsrakning: rec("billingRun.createKostnadsrakning"),

--- a/test/scripts/simulate-orchestrate.test.ts
+++ b/test/scripts/simulate-orchestrate.test.ts
@@ -153,4 +153,36 @@ describe("runSimulation (#880 integration)", () => {
     const rootListing = await c.document.list({ matterId: withCourt.id, folderId: null, pageSize: 100 });
     expect((rootListing.documents ?? rootListing).length, "rot-mappen är tom").toBe(0);
   });
+
+  /**
+   * #988: `SuggestionsPanel` och `EventsPanel` stod tomma i ALLA tier eftersom
+   * ingenting skapade raderna. Nu extraherar seedningen parter och kallelser ur
+   * dokumentens text. Testet påstår om DEMONS DATA att panelerna har något att
+   * visa — och att förslagen går att koppla till ett ärende, vilket är vad
+   * panelerna frågar efter.
+   */
+  it("dokumenttext ger kontakt- och händelseförslag som panelerna kan visa", async () => {
+    const seed = translateSeed(buildSeed(), createIdTranslator()) as Any;
+    const orgId = String(seed.organizations[0].id);
+    const admin = { id: asId<"UserId">("gen"), email: "g@a.se", name: "G", role: userRoleSchema.parse("ADMIN"), organizationId: asId<"OrganizationId">(orgId) };
+    const target = createGitTarget({ principal: admin, writeBack: async () => {} });
+    const coreSeed = { ...seed, matters: seed.matters.map((m: Any) => ({ ...m, status: "ACTIVE" })), timeEntries: [], expenses: [], matterContacts: [], documents: [], serviceNotes: [] };
+    await populate(target.caller, coreSeed);
+
+    const ctx: RunCtx = { c: target.caller, res: emptyRunResult() };
+    await runSimulation(ctx, seed);
+
+    expect(ctx.res.partySuggestions, "kontaktförslag skapade").toBeGreaterThan(0);
+    expect(ctx.res.eventSuggestions, "händelseförslag skapade").toBeGreaterThan(0);
+
+    // Panelerna läser per ÄRENDE — hittar de inget där spelar det ingen roll
+    // hur många rader som skapats.
+    const c = target.caller as Any;
+    const matters = (await c.matter.list({})).matters as Any[];
+    const groups = await Promise.all(matters.map((m: Any) => c.document.pendingSuggestionsGrouped({ matterId: m.id })));
+    expect(groups.some((g: Any) => (g.groups ?? g).length > 0), "något ärende har kontaktförslag").toBe(true);
+
+    const events = await Promise.all(matters.map((m: Any) => c.document.events({ matterId: m.id })));
+    expect(events.some((e: Any) => (e.events ?? e).length > 0), "något ärende har händelseförslag").toBe(true);
+  });
 });

--- a/test/scripts/simulate-runner.test.ts
+++ b/test/scripts/simulate-runner.test.ts
@@ -21,8 +21,9 @@ function recordingCaller() {
     if (method === "billingRun.createKostnadsrakning") return { run: { id: "kr", workValueOreAtRun: 1_544_700 } };
     if (method === "billingRun.createFinal") return { invoice: { id: "fin", amount: 100_000 } };
     if (method === "invoice.createPaymentPlan") return { id: "plan-1" };
-    // −1: raden är redan pushad ovan, så id:na blir 0-baserade i anropsordning.
     if (method === "document.tree") return { folders: [], documents: [] };
+    if (method === "document.suggestFromText") return { parties: 0, events: 0 };
+    // −1: raden är redan pushad ovan, så id:na blir 0-baserade i anropsordning.
     if (method === "document.createFolder") return { id: `folder-${calls.filter((c) => c.method === "document.createFolder").length - 1}` };
     if (method === "billingRun.settleCoverage") return { creditInvoice: { id: "cred", amount: -50_000 }, clientInvoice: {}, payerInvoice: {} };
     return {};
@@ -32,7 +33,7 @@ function recordingCaller() {
     timeEntry: { create: rec("timeEntry.create") },
     serviceNote: { create: rec("serviceNote.create") },
     expense: { create: rec("expense.create") },
-    document: { register: rec("document.register"), createFolder: rec("document.createFolder"), tree: rec("document.tree") },
+    document: { register: rec("document.register"), createFolder: rec("document.createFolder"), tree: rec("document.tree"), suggestFromText: rec("document.suggestFromText") },
     invoiceDispatch: { recordManual: rec("invoiceDispatch.recordManual") },
     invoice: {
       createRadgivning: rec("invoice.createRadgivning"), setStatus: rec("invoice.setStatus"),

--- a/test/unit/lib/demo/demo-source-keys.test.ts
+++ b/test/unit/lib/demo/demo-source-keys.test.ts
@@ -36,6 +36,9 @@ describe("pathToSourceKey", () => {
     // #985: utan dessa låg varje dokument i roten och utskickshistoriken var tom.
     expect(pathToSourceKey("document-folders/f1.json")).toBe("documentFolders");
     expect(pathToSourceKey("invoice-dispatches/d1.json")).toBe("invoiceDispatches");
+    // #988: förslagen fick en producent → de hydreras nu också.
+    expect(pathToSourceKey("document-analysis-suggestions/s1.json")).toBe("documentAnalysisSuggestions");
+    expect(pathToSourceKey("matter-event-suggestions/e1.json")).toBe("matterEventSuggestions");
     expect(pathToSourceKey(".ava/templates/t1.json")).toBe("documentTemplates");
     expect(pathToSourceKey(".ava/organizations/o1.json")).toBe("organizations");
     expect(pathToSourceKey(".ava/user-preferences/up1.json")).toBe("userPreferences");
@@ -64,19 +67,12 @@ describe("pathToSourceKey täcker ENTITY_REGISTRY", () => {
    * Entiteter som INTE hydreras i demon. Listan är en ratchet: den ska krympa,
    * aldrig växa, och varje rad kräver ett skäl.
    *
-   * De två som är kvar (#985) har INGEN producent någonstans i kodbasen —
-   * varken ett jobb eller en mutation skapar dem. `IDocumentAnalyzer.analyze`
-   * lovar att "eventuella suggestions postas via
-   * dataStore.documentAnalysisSuggestions", men ingen implementation gör det:
-   * classify-pipelinen skriver bara `document.updateMetadata`. Följden är att
-   * `SuggestionsPanel` och `EventsPanel` står tomma i ALLA tier, inte bara i
-   * demon. Att koppla på en matcher här hade varit meningslöst, och att seeda
-   * rader hade betytt data som appen själv aldrig kan producera. Gapet är
-   * uppströms — se #988.
+   * TOM sedan #988 — de två sista fick en producent (extraktion ur
+   * dokumenttexten) och kan därmed hydreras. Lägg inte till en rad här utan att
+   * samtidigt skriva VARFÖR entiteten inte ska synas i demon; "ingen har hunnit"
+   * är inget skäl, det var precis så write-offs tappades i #982.
    */
-  const NOT_YET_HYDRATED = new Set([
-    "documentAnalysisSuggestion", "matterEventSuggestion",
-  ]);
+  const NOT_YET_HYDRATED = new Set<string>();
 
   it("varje registrerad entitets gitPrefix mappar till sin sourceKey", () => {
     const gaps: string[] = [];

--- a/test/unit/lib/shared/document-extraction.test.ts
+++ b/test/unit/lib/shared/document-extraction.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Extraktion av parter och händelser ur dokumenttext (#988).
+ *
+ * Heuristiken är medvetet försiktig: ett förslag är en rad någon ska godkänna
+ * eller avfärda med ett klick, så en falsk positiv kostar ett avfärdande medan
+ * en falsk negativ bara kostar det vi redan hade (inget förslag alls). Testerna
+ * nedan vaktar båda riktningarna — att markörerna hittas, OCH att löptext utan
+ * markör lämnas ifred.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { extractEventSuggestions, extractPartySuggestions } from "@/lib/shared/document-extraction";
+
+describe("extractPartySuggestions", () => {
+  it("plockar roll, namn och personnummer ur ett partsblock", () => {
+    const [p] = extractPartySuggestions("Kärande: Anna Andersson 850312-4567");
+    expect(p).toMatchObject({
+      name: "Anna Andersson", role: "KLIENT", contactType: "PERSON",
+      personalNumber: "850312-4567", orgNumber: null,
+    });
+  });
+
+  it("skiljer organisationsnummer från personnummer på TREDJE siffran", () => {
+    // I ett personnummer är siffra 3–4 månaden (01–12) → siffra 3 är 0 eller 1.
+    // Ett organisationsnummer har alltid ≥ 2 där. Det är den officiella regeln
+    // och gör grupperna disjunkta utan checksumma.
+    const [company] = extractPartySuggestions("Svarande: Byggfirma Stenhammar AB 556677-8899");
+    expect(company).toMatchObject({ orgNumber: "556677-8899", personalNumber: null, contactType: "COMPANY" });
+
+    const [person] = extractPartySuggestions("Svarande: Karl Nilsson 720801-1234");
+    expect(person).toMatchObject({ personalNumber: "720801-1234", orgNumber: null, contactType: "PERSON" });
+  });
+
+  it("mer specifika rollord vinner — 'Motpartens ombud' är inte 'Motpart'", () => {
+    const [p] = extractPartySuggestions("Motpartens ombud: Advokat Sofia Grip");
+    expect(p?.role).toBe("MOTPARTSOMBUD");
+    expect(p?.contactType).toBe("LAW_FIRM");
+  });
+
+  it("rollordet får stå på raden FÖRE namnet", () => {
+    const [p] = extractPartySuggestions("Svarande\nByggfirma Stenhammar AB");
+    expect(p).toMatchObject({ name: "Byggfirma Stenhammar AB", role: "MOTPART" });
+  });
+
+  it("samma part i samma roll föreslås EN gång, hur ofta den än nämns", () => {
+    const text = [
+      "Kärande: Anna Andersson 850312-4567",
+      "Käranden yrkar ersättning.",
+      "Kärande: Anna Andersson 850312-4567",
+    ].join("\n");
+    expect(extractPartySuggestions(text)).toHaveLength(1);
+  });
+
+  it("löptext utan rollord ger INGA förslag", () => {
+    // Det viktiga negativa fallet: heuristiken får inte gissa namn ur prosa.
+    const text = "Parterna har diskuterat förlikning under våren och nått viss enighet.";
+    expect(extractPartySuggestions(text)).toEqual([]);
+  });
+
+  it("rollord utan rimligt namn ger inget förslag", () => {
+    // "Käranden yrkar att tingsrätten förpliktar svaranden att utge skadestånd"
+    // är en mening, inte ett namn — för många ord.
+    const text = "Käranden yrkar att tingsrätten förpliktar svaranden att utge skadestånd";
+    expect(extractPartySuggestions(text)).toEqual([]);
+  });
+
+  it("domstol och försäkringsbolag får sina egna kontakttyper", () => {
+    expect(extractPartySuggestions("Stockholms tingsrätt")[0]).toMatchObject({ role: "DOMSTOL", contactType: "COURT" });
+    expect(extractPartySuggestions("Försäkringsbolag: Folksam")[0]).toMatchObject({ contactType: "INSURANCE_COMPANY" });
+  });
+
+  it("bär med sig raden som motivering — den som godkänner ska se varifrån", () => {
+    const [p] = extractPartySuggestions("Vittne: Karl Nilsson 720801-1234");
+    expect(p?.notes).toContain("Vittne: Karl Nilsson");
+  });
+});
+
+describe("extractEventSuggestions", () => {
+  it("läser ISO-datum och klockslag ur en kallelse", () => {
+    const [e] = extractEventSuggestions("Muntlig förberedelse har satts ut till 2026-09-15 kl. 09.30.");
+    expect(e?.title).toBe("Muntlig förberedelse");
+    expect(e?.eventType).toBe("FORBEREDELSE");
+    expect(e?.startAt.getFullYear()).toBe(2026);
+    expect(e?.startAt.getMonth()).toBe(8); // september
+    expect(e?.startAt.getDate()).toBe(15);
+    expect(e?.startAt.getHours()).toBe(9);
+    expect(e?.startAt.getMinutes()).toBe(30);
+  });
+
+  it("läser svensk datumform i löptext", () => {
+    const [e] = extractEventSuggestions("Huvudförhandling hölls den 12 maj 2026 kl. 09.00.");
+    expect(e?.title).toBe("Huvudförhandling");
+    expect(e?.startAt.getMonth()).toBe(4);
+    expect(e?.startAt.getDate()).toBe(12);
+  });
+
+  it("datum utan klockslag ger ändå ett förslag — kl 00.00 att bekräfta", () => {
+    const [e] = extractEventSuggestions("Frist för överklagande: senast den 2026-06-02.");
+    expect(e?.eventType).toBe("FRIST");
+    expect(e?.startAt.getHours()).toBe(0);
+  });
+
+  it("kallelseord UTAN datum ger inget förslag", () => {
+    expect(extractEventSuggestions("Huvudförhandling kommer att hållas senare i vår.")).toEqual([]);
+  });
+
+  it("datum UTAN kallelseord ger inget förslag", () => {
+    // Ett datum i löptext är inte en händelse — annars hade varje handling
+    // producerat brus som någon måste avfärda.
+    expect(extractEventSuggestions("Avtalet undertecknades 2026-03-01.")).toEqual([]);
+  });
+
+  it("samma händelse vid samma tidpunkt föreslås en gång", () => {
+    const text = [
+      "Huvudförhandling 2026-05-12 kl. 09.00",
+      "Huvudförhandling 2026-05-12 kl. 09.00",
+    ].join("\n");
+    expect(extractEventSuggestions(text)).toHaveLength(1);
+  });
+});
+
+describe("hela partsblocket ur en stämningsansökan", () => {
+  const STAMNING = [
+    "STÄMNINGSANSÖKAN",
+    "Kärande: Anna Andersson 850312-4567",
+    "Ombud: Advokat Erik Lundqvist",
+    "Svarande: Byggfirma Stenhammar AB 556677-8899",
+    "Motpartens ombud: Advokat Sofia Grip",
+    "",
+    "Käranden yrkar att tingsrätten förpliktar svaranden att utge skadestånd.",
+    "Muntlig förberedelse har satts ut till 2026-09-15 kl. 09.30.",
+  ].join("\n");
+
+  it("ger en part per rad i blocket, med rätt roller", () => {
+    const roles = extractPartySuggestions(STAMNING).map((p) => `${p.role}:${p.name}`);
+    expect(roles).toEqual([
+      "KLIENT:Anna Andersson",
+      "OMBUD:Advokat Erik Lundqvist",
+      "MOTPART:Byggfirma Stenhammar AB",
+      "MOTPARTSOMBUD:Advokat Sofia Grip",
+    ]);
+  });
+
+  it("och exakt en händelse — sammanträdesraden, inte yrkanderaden", () => {
+    const events = extractEventSuggestions(STAMNING);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.title).toBe("Muntlig förberedelse");
+  });
+});

--- a/test/unit/server/suggest-from-text.test.ts
+++ b/test/unit/server/suggest-from-text.test.ts
@@ -1,0 +1,105 @@
+/**
+ * `writeSuggestionsFromText` (#988) — producenten som saknades.
+ *
+ * `SuggestionsPanel` och `EventsPanel` var fullt utbyggda men stod tomma i alla
+ * tier: ingenting skapade raderna. Här testas skrivningen mot in-memory-
+ * repositories — själva extraktionen har egna tester i
+ * `document-extraction.test.ts`.
+ *
+ * Idempotensen är det viktiga. Ett dokument analyseras om vid uppladdning,
+ * manuell "Analysera" och reconcile-replay; dubbletter vid varje körning hade
+ * gjort panelerna oanvändbara, och ett AVFÄRDAT förslag som återuppstår är
+ * värre än inget förslag alls.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import { writeSuggestionsFromText } from "@/lib/server/documents/suggest-from-text";
+import type { SuggestionRepos } from "@/lib/server/documents/suggest-from-text";
+import { InMemoryDocumentSuggestionRepository } from "@/lib/server/repositories/in-memory-document-suggestion-repository";
+import { InMemoryMatterEventSuggestionRepository } from "@/lib/server/repositories/in-memory-matter-event-suggestion-repository";
+import { prebakeJoins } from "@/lib/shared/demo-source";
+import { asId } from "@/lib/shared/schemas/ids";
+import { uuidv7 } from "@/lib/shared/uuid";
+
+const ORG = asId<"OrganizationId">("77777777-7777-7777-8777-777777777777");
+
+const TEXT = [
+  "STÄMNINGSANSÖKAN",
+  "Kärande: Anna Andersson 850312-4567",
+  "Svarande: Byggfirma Stenhammar AB 556677-8899",
+  "",
+  "Muntlig förberedelse har satts ut till 2026-09-15 kl. 09.30.",
+].join("\n");
+
+function setup() {
+  const matterId = asId<"MatterId">(uuidv7());
+  const documentId = asId<"DocumentId">(uuidv7());
+  const source = prebakeJoins({
+    matters: [{ id: matterId, organizationId: ORG, matterNumber: "2026-1", title: "T" }],
+    documents: [{ id: documentId, matterId, fileName: "stamning.pdf", title: "Stämning" }],
+    documentAnalysisSuggestions: [],
+    matterEventSuggestions: [],
+  } as DemoSource);
+  const store = new LocalStore(source, async () => {});
+  const repos: SuggestionRepos = {
+    documentAnalysisSuggestions: new InMemoryDocumentSuggestionRepository(store),
+    matterEventSuggestions: new InMemoryMatterEventSuggestionRepository(store),
+  };
+  return { repos, documentId, matterId };
+}
+
+describe("writeSuggestionsFromText", () => {
+  it("skapar kontakt- och händelseförslag ur texten", async () => {
+    const { repos, documentId } = setup();
+    const res = await writeSuggestionsFromText(repos, documentId, TEXT);
+    expect(res).toEqual({ parties: 2, events: 1 });
+
+    const parties = await repos.documentAnalysisSuggestions.listForDocument(documentId);
+    expect(parties.map((p) => p.name).sort()).toEqual(["Anna Andersson", "Byggfirma Stenhammar AB"]);
+    expect(parties.every((p) => p.status === "PENDING")).toBe(true);
+
+    const events = await repos.matterEventSuggestions.listForDocument(documentId);
+    expect(events[0]).toMatchObject({ title: "Muntlig förberedelse", eventType: "FORBEREDELSE" });
+  });
+
+  it("är idempotent — omkörning skapar inga dubbletter", async () => {
+    const { repos, documentId } = setup();
+    await writeSuggestionsFromText(repos, documentId, TEXT);
+    const second = await writeSuggestionsFromText(repos, documentId, TEXT);
+
+    expect(second, "andra körningen skapar noll nya").toEqual({ parties: 0, events: 0 });
+    expect(await repos.documentAnalysisSuggestions.listForDocument(documentId)).toHaveLength(2);
+    expect(await repos.matterEventSuggestions.listForDocument(documentId)).toHaveLength(1);
+  });
+
+  it("återuppväcker INTE ett förslag användaren avfärdat", async () => {
+    // Dedupen tittar på alla statusar, inte bara PENDING. Att få tillbaka ett
+    // bortvalt förslag vid varje omanalys vore värre än att inte få det alls.
+    const { repos, documentId } = setup();
+    await writeSuggestionsFromText(repos, documentId, TEXT);
+    const [first] = await repos.documentAnalysisSuggestions.listForDocument(documentId);
+    await repos.documentAnalysisSuggestions.update(first!.id, { status: "REJECTED" });
+
+    const again = await writeSuggestionsFromText(repos, documentId, TEXT);
+    expect(again.parties).toBe(0);
+    const after = await repos.documentAnalysisSuggestions.listForDocument(documentId);
+    expect(after).toHaveLength(2);
+    expect(after.filter((p) => p.status === "REJECTED")).toHaveLength(1);
+  });
+
+  it("nya förslag i en UPPDATERAD text läggs till, befintliga rörs inte", async () => {
+    const { repos, documentId } = setup();
+    await writeSuggestionsFromText(repos, documentId, TEXT);
+    const res = await writeSuggestionsFromText(repos, documentId, `${TEXT}\nVittne: Karl Nilsson 720801-1234`);
+    expect(res).toEqual({ parties: 1, events: 0 });
+    expect(await repos.documentAnalysisSuggestions.listForDocument(documentId)).toHaveLength(3);
+  });
+
+  it("tom text är en no-op", async () => {
+    const { repos, documentId } = setup();
+    expect(await writeSuggestionsFromText(repos, documentId, "   ")).toEqual({ parties: 0, events: 0 });
+    expect(await repos.documentAnalysisSuggestions.listForDocument(documentId)).toHaveLength(0);
+  });
+});

--- a/tooling/demo-generator/simulate/fake-content.ts
+++ b/tooling/demo-generator/simulate/fake-content.ts
@@ -21,6 +21,16 @@ export interface DocTemplate {
    * en platt mappstruktur hade sett ut som att funktionen saknas.
    */
   subFolder?: string;
+  /**
+   * Dokumentets BRÖDTEXT (#988), när den behöver se ut som en riktig handling.
+   * `summary` är metadata i en mening; `body` är det som faktiskt står i filen
+   * och det extraktionen läser.
+   *
+   * Bara handlingar som bär parter eller kallelser har en — resten klarar sig
+   * med sin summary. Poängen är inte att fylla demon med text, utan att
+   * `SuggestionsPanel` och `EventsPanel` ska ha något att visa.
+   */
+  body?: string;
 }
 
 /**
@@ -47,6 +57,18 @@ export const DOC_TEMPLATES: Record<string, DocTemplate> = {
   stamningsansokan: {
     documentType: "Stämningsansökan", direction: "UTGAENDE", recipient: "DOMSTOL",
     title: "Stämningsansökan", summary: "Ansökan om stämning ges in till tingsrätten med yrkanden och grunder.",
+    // Partsblocket är det extraktionen (#988) läser: rollord + namn + person-
+    // respektive organisationsnummer, precis som i en riktig ansökan.
+    body: [
+      "STÄMNINGSANSÖKAN",
+      "Kärande: Anna Andersson 850312-4567",
+      "Ombud: Advokat Erik Lundqvist",
+      "Svarande: Byggfirma Stenhammar AB 556677-8899",
+      "Motpartens ombud: Advokat Sofia Grip",
+      "",
+      "Käranden yrkar att tingsrätten förpliktar svaranden att utge skadestånd.",
+      "Muntlig förberedelse har satts ut till 2026-09-15 kl. 09.30.",
+    ].join("\n"),
   },
   inlaga: {
     documentType: "Inlaga", direction: "UTGAENDE", recipient: "DOMSTOL",
@@ -59,6 +81,14 @@ export const DOC_TEMPLATES: Record<string, DocTemplate> = {
   svaromal: {
     documentType: "Svaromål", direction: "INKOMMANDE", recipient: "MOTPART",
     title: "Svaromål från motpartsombud", summary: "Motparten bestrider käromålet och åberopar egen bevisning.",
+    body: [
+      "SVAROMÅL",
+      "Svarande: Byggfirma Stenhammar AB 556677-8899",
+      "Motpartens ombud: Advokat Sofia Grip",
+      "Vittne: Karl Nilsson 720801-1234",
+      "",
+      "Svaranden bestrider käromålet i dess helhet och åberopar egen bevisning.",
+    ].join("\n"),
   },
   brevFranOmbud: {
     documentType: "Korrespondens", direction: "INKOMMANDE", recipient: "MOTPART",
@@ -68,6 +98,15 @@ export const DOC_TEMPLATES: Record<string, DocTemplate> = {
     documentType: "Dom", direction: "INKOMMANDE", recipient: "DOMSTOL",
     title: "Dom från tingsrätten", summary: "Tingsrätten meddelar dom i målet. Se domslut och domskäl.",
     subFolder: "Domar",
+    body: [
+      "DOM",
+      "Huvudförhandling hölls den 12 maj 2026 kl. 09.00.",
+      "Kärande: Anna Andersson 850312-4567",
+      "Svarande: Byggfirma Stenhammar AB 556677-8899",
+      "",
+      "Tingsrätten förpliktar svaranden att utge skadestånd till käranden.",
+      "Frist för överklagande: senast den 2026-06-02.",
+    ].join("\n"),
   },
   beslutRattshjalp: {
     documentType: "Beslut", direction: "INKOMMANDE", recipient: "MYNDIGHET",

--- a/tooling/demo-generator/simulate/runner.ts
+++ b/tooling/demo-generator/simulate/runner.ts
@@ -25,14 +25,14 @@ export interface RunCtx {
   sink?: BinarySink;
   /** Gränsbelopp (öre) för tröskelstyrd aconto-utskick (#885); default = konstanten. */
   accontoThresholdOre?: number;
-  res: { invoices: number; documents: number; timeEntries: number; notes: number; credits: number; paymentPlans: number; reminders: number; writeOffs: number; folders: number; dispatches: number };
+  res: { invoices: number; documents: number; timeEntries: number; notes: number; credits: number; paymentPlans: number; reminders: number; writeOffs: number; folders: number; dispatches: number; partySuggestions: number; eventSuggestions: number };
 }
 
 /** Nollställda räknare. Factory i stället för ett objekt-literal per anropsplats:
  *  räknarna växer med simuleringens täckning (#982 lade till tre), och literalen
  *  fanns då på sex ställen — två i verktygen, fyra i testerna. */
 export function emptyRunResult(): RunCtx["res"] {
-  return { invoices: 0, documents: 0, timeEntries: 0, notes: 0, credits: 0, paymentPlans: 0, reminders: 0, writeOffs: 0, folders: 0, dispatches: 0 };
+  return { invoices: 0, documents: 0, timeEntries: 0, notes: 0, credits: 0, paymentPlans: 0, reminders: 0, writeOffs: 0, folders: 0, dispatches: 0, partySuggestions: 0, eventSuggestions: 0 };
 }
 
 interface SimState {
@@ -106,7 +106,11 @@ async function hDoc(ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimState
   const storagePath = `documents/content/${id}.pdf`;
   const fileName = `${t.title}.pdf`;
   const { generateDocumentBytes } = await import("../../scripts/seed-data");
-  const bytes = await generateDocumentBytes({ id, title: t.title, fileName, documentType: t.documentType, summary: t.summary, mimeType: "application/pdf", storagePath });
+  // `body` när mallen har en (#988) — det är den texten extraktionen läser, och
+  // den ska stå i FILEN också, annars visar demon förslag som inte går att
+  // härleda ur dokumentet man öppnar.
+  const text = t.body ?? t.summary;
+  const bytes = await generateDocumentBytes({ id, title: t.title, fileName, documentType: t.documentType, summary: text, mimeType: "application/pdf", storagePath });
   const size = ctx.sink ? ctx.sink(storagePath, bytes) : bytes.byteLength;
   // Filas efter mottagare (#985) — demon hade tidigare allt i roten, så
   // träd-vyns mapphantering gick varken att se eller prova.
@@ -118,6 +122,13 @@ async function hDoc(ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimState
     analysisStatus: "DONE", createdAt: iso,
   });
   ctx.res.documents++;
+  // Kontakt- och händelseförslag ur texten (#988). Bara mallar med `body` bär
+  // parter/kallelser; för övriga är det en no-op och kostar ett anrop.
+  if (t.body !== undefined) {
+    const res = await ctx.c.document.suggestFromText({ documentId: id, text: t.body }) as { parties: number; events: number };
+    ctx.res.partySuggestions += res.parties;
+    ctx.res.eventSuggestions += res.events;
+  }
 }
 
 async function hRadgivning(ctx: RunCtx, m: SimMatter, _e: Any, iso: string): Promise<void> {

--- a/tooling/scripts/build-demo-repo.ts
+++ b/tooling/scripts/build-demo-repo.ts
@@ -94,6 +94,7 @@ async function main(): Promise<void> {
   // avbetalningsplaner upptäcktes först av ett e2e-test, för inget steg sa något.
   console.log(`  • fakturalivscykler: ${result.sim.paymentPlans} avbetalningsplaner (${result.sim.reminders} påminnelser), ${result.sim.writeOffs} kundförluster`);
   console.log(`  • ${result.sim.folders} dokumentmappar, ${result.sim.dispatches} fakturautskick`);
+  console.log(`  • AI-förslag ur dokumenttext: ${result.sim.partySuggestions} parter, ${result.sim.eventSuggestions} händelser`);
   console.log(`  • ${result.calendarEvents} kalender-events, ${result.tasks} tasks`);
   console.log("");
   console.log("Nästa steg (om du vill pusha till ulrik-s/ava-demo):");


### PR DESCRIPTION
Del av #988 — **issuen förblir öppen**, se "Vad som återstår".

## Vägvalet

#988 hade två motsatta utfall i sin checklista: bygg extraktionen, eller ta bort ytan. Efter genomgång rekommenderade jag att bygga, och du valde det.

Argumentet för: hela mottagarsidan fanns redan — `SuggestionsPanel` (67 rader), `EventsPanel` (147), routrar (404), repositories (289), relations, Postgres-tabeller, 15 testfiler, och panelerna renderas i `_client.tsx`. Det enda som saknades var producenten. `classify-document-handler.ts` är dessutom byggd med injicerbara `classify?`/`suggestTags?` — arkitekturen hade uppenbart räknat med det här.

## Heuristik, inte LLM

ADR 0027 gör LLM till en **server**-förmåga och demon har ingen server. En LLM-baserad extraktion hade alltså lämnat panelerna tomma just där de syns mest, och gjort testerna beroende av en modell.

Mönstren är rent deterministiska:

| | Krav |
|---|---|
| Parter | rollord (`Kärande:`, `Motpartens ombud:`) + rimligt namn |
| Händelser | kallelseord (`Huvudförhandling`, `Frist`) + datum på samma rad eller raden före |

Person- och organisationsnummer skiljs på **tredje siffran**: i ett personnummer är siffra 3–4 månaden (01–12) så siffra 3 är 0 eller 1; ett organisationsnummer har alltid ≥ 2 där. Officiell regel, disjunkta grupper, ingen checksumma.

Heuristiken är medvetet försiktig. Ett förslag är en rad någon godkänner eller avfärdar med ett klick: en falsk positiv kostar ett avfärdande, en falsk negativ kostar bara det vi redan hade. Därför krävs en tydlig markör, och löptext utan sådan lämnas ifred — det finns explicita tester för båda riktningarna.

## Sömmen

`document.suggestFromText({ documentId, text })`. **Anroparen skickar texten**, eftersom var den finns skiljer sig mellan tier (OPFS/FSA i self-hosted, seed-filer i demon, content-store i server-first) och den skillnaden inte hör hemma i routern.

Skrivningen är idempotent och tittar på **alla** statusar, inte bara PENDING: ett förslag användaren avfärdat får inte återuppstå vid nästa omanalys. Det vore värre än att inte få förslaget alls.

## Två buggar som testerna hittade

Båda i radtolkningen, båda rättade:

1. **Raden ärvde föregående rads rollord även när den hade ett eget.** `Svarande: Byggfirma Stenhammar AB` fick rollen `OMBUD`, eftersom raden ovanför var `Ombud: Advokat Erik Lundqvist`. Nu vinner radens egen markör alltid.
2. **Varje mening i ett stycke ärvde blockets roll.** `Käranden yrkar ersättning.` blev ett partsförslag. Rader som slutar som en mening är nu löptext, inte partsrader.

## Resultat i demon

Tre av seed-mallarna har fått riktiga partsblock och kallelserader, så dokumenten i demon *innehåller* det förslagen härleds ur:

```
• AI-förslag ur dokumenttext: 23 parter, 8 händelser
```

Fördelningen: `MOTPART 8, MOTPARTSOMBUD 5, KLIENT 5, VITTNE 3, OMBUD 2` — 8 med personnummer, 8 med organisationsnummer. Händelser: `FRIST 3, HUVUDFORHANDLING 3, FORBEREDELSE 2`.

`NOT_YET_HYDRATED` i `demo-source-keys.test.ts` är därmed **tom** — listan gick från fyra rader (#985) till noll.

## Tester

- **`document-extraction.test.ts`** (17): en per mönster, plus de negativa fallen som är själva poängen — löptext utan rollord, rollord utan namn, datum utan kallelseord, kallelseord utan datum.
- **`suggest-from-text.test.ts`** (5): skrivningen, idempotensen, att ett avfärdat förslag inte återuppstår, att ny text ger nya förslag utan att röra befintliga.
- **`simulate-orchestrate.test.ts`**: påstår om **demons data** att `pendingSuggestionsGrouped` och `document.events` faktiskt returnerar något per ärende — panelerna frågar per ärende, så antal rader i databasen räcker inte som bevis.

## Vad som återstår (därför ingen `Closes`)

Extraktionen triggas i dag av seedningen. Kvar är att kalla `suggestFromText` från appen när text landar — vid uppladdning och vid manuell "Analysera". Sömmen finns, demon bevisar vägen, men i self-hosted fylls panelerna först när det steget är på plats. Jag lämnar #988 öppen med det som återstående punkt hellre än att stänga den på halva vägen.

## Grindar

`typecheck` ✓ · `lint` ✓ · `lint:complexity-strict` ✓ · `knip` ✓ · `deps:check` ✓ (1120 moduler) · `jscpd` ✓ · `build:demo` ✓ · **`e2e:demo` 31/31** ✓ · `test/unit/server` 1131 ✓ · `test/scripts` + `test/integration` 261/261 ✓

Lint fällde två saker under arbetet — en dubbel-cast i testet och komplexitet 10 i `extractEventSuggestions`. Båda åtgärdade i koden (smalare `SuggestionRepos`-typ respektive utbruten `eventOn`), inget undantag tillagt.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_