### PR TITLE
feat(documents): skapa kontakt-/händelseförslag när dokumenttext landar

### DIFF
--- a/src/bin/server-first.ts
+++ b/src/bin/server-first.ts
@@ -93,6 +93,10 @@ function main(): void {
     // läses bytes → text extraheras (PDF/DOCX) → ollama klassificerar.
     ...(contentStore ? { content: contentStore } : {}),
     ...(llm ? { llm } : {}),
+    // #988: klassificeringsjobbet skriver också kontakt-/händelseförslag ur
+    // dokumentets text. Deterministisk extraktion → kräver ingen LLM, bara
+    // content-store:n ovan.
+    suggestions: api.repos,
     // #621 B2: LLM föreslår taggar ur byråns vokabulär (läses lazy per jobb).
     vocabulary: async () => (await api.repos.organizations.getById(asId<"OrganizationId">(config.organizationId)))?.documentTags ?? [],
   });

--- a/src/components/documents/document-browser.tsx
+++ b/src/components/documents/document-browser.tsx
@@ -2,7 +2,9 @@
 
 import type { inferRouterInputs } from "@trpc/server";
 import { useState, useRef, useCallback, useMemo } from "react";
+import type { SuggestClient } from "@/lib/client/backend/suggest-from-bytes";
 import { useDocSyncStatus } from "@/lib/client/helper/use-helper";
+import { enqueueTextExtraction } from "@/lib/client/jobs/enqueue-text-extraction";
 import { trpc } from "@/lib/client/trpc";
 import type { AppRouter } from "@/lib/server/routers/_app";
 import { asId, type DocumentFolderId, type DocumentId, type MatterId } from "@/lib/shared/schemas/ids";
@@ -325,6 +327,21 @@ async function resolveUpload(file: File, matterId: MatterId): Promise<{ result: 
 }
 
 /**
+ * Best-effort-förslag ur just uppladdade bytes (#988). Uppladdningen är redan
+ * klar när det här körs — ett fel här loggas, det kastas aldrig vidare.
+ */
+async function suggestFromUpload(client: SuggestClient, doc: UploadResult, bytes: Uint8Array): Promise<void> {
+  try {
+    const { suggestFromBytes } = await import("@/lib/client/backend/suggest-from-bytes");
+    await suggestFromBytes(client, asId<"DocumentId">(doc.id), {
+      bytes, mimeType: doc.mimeType, fileName: doc.fileName,
+    });
+  } catch (err) {
+    console.warn("[suggest-from-text] misslyckades:", err);
+  }
+}
+
+/**
  * Uppladdnings-state + handler: optimistiska placeholder-rader, FSA-write,
  * tRPC-register, invalidate och bakgrundsjobb (klassificering + text-extraktion).
  */
@@ -398,12 +415,12 @@ function useFileUpload({ matterId, mutations, fileInputRef }: {
         fileName: result.fileName,
         storagePath: result.storagePath,
       });
-      jobQueue.enqueue("extract-text", `Extraherar text ur ${result.fileName}`, {
-        documentId: result.id,
-        fileName: result.fileName,
-        storagePath: result.storagePath,
-        mimeType: result.mimeType,
-      });
+      await enqueueTextExtraction(result);
+      // Utan working copy (demon, server-first i browsern) kan extract-text-
+      // jobbet aldrig läsa filen igen — bytes:en finns bara här. Extrahera nu
+      // så kontakt-/händelseförslagen uppstår även där (#988). Best-effort:
+      // uppladdningen är redan klar och får inte falla på det här.
+      if (serverBytes) void suggestFromUpload(utils.client, result, serverBytes);
     } catch (err) {
       removePlaceholder();
       const msg = err instanceof Error ? err.message : String(err);
@@ -645,6 +662,10 @@ function useDocumentMutations({
   const reanalyze = trpc.document.analyze.useMutation({
     onMutate: ({ documentId }) => {
       setAnalyzingIds((prev) => new Set(prev).add(documentId));
+      // "Analysera (AI)" ska ge samma resultat som en uppladdning — inklusive
+      // kontakt-/händelseförslag (#988). Porten köar bara klassificeringen, så
+      // text-extraktionen köas här där dokumentets filnamn och sökväg finns.
+      void enqueueTextExtraction(documents.find((d) => d.id === documentId));
     },
     onSuccess: (_data, { documentId }) => {
       pollAnalysis({

--- a/src/components/documents/extract-text-dispatcher-registrar.tsx
+++ b/src/components/documents/extract-text-dispatcher-registrar.tsx
@@ -3,31 +3,50 @@
 /**
  * Registrar för text-extraction-job:s dispatcher.
  *
- * Workern (i jobb-kön) extraherar PDF/DOCX → text. Den behöver skriva
- * text-filen till FSA. Vi gör det via en ny tRPC-mutation
- * `document.writeText` som routar genom DemoDataStore → writeBack →
- * `documents/text/<id>.txt`.
+ * Workern (i jobb-kön) extraherar PDF/DOCX → text. Två saker ska hända när
+ * texten landar, och båda görs här:
  *
- * För now: enkel direktskrivning till FSA via dataStore (eftersom
- * documentText inte är en entity i Prisma-modellen utan bara en
- * write-back-händelse). Vi använder createNotify för att triggea
- * fsa-write-back utan att ändra in-memory state.
+ * 1. **Texten skrivs till FSA** — via writeBack:s `documentText`-entity
+ *    (`documents/text/<id>.txt`), så innehållet blir sökbart. Vi går runt tRPC
+ *    med ett window-event eftersom documentText inte är en entity i
+ *    datamodellen utan bara en write-back-händelse.
+ * 2. **Kontakt- och händelseförslag skapas** ur texten (#988) via
+ *    `document.suggestFromText`. Det här är klient-tier:ernas väg in i
+ *    `SuggestionsPanel`/`EventsPanel`: i demo och self-hosted når dokumentets
+ *    bytes aldrig servern, så extraktionen måste utgå från texten browsern
+ *    just har läst. (Server-first gör motsvarande i `classify-document`-
+ *    jobbet, som läser bytes ur content-store:n.)
+ *
+ * Skrivningen är idempotent, så en omanalys av samma dokument ger inga
+ * dubbletter — se `writeSuggestionsFromText`.
  */
 
 import { useEffect } from "react";
 import { setExtractTextDispatcher } from "@/lib/client/jobs/extract-text-dispatch";
+import { trpc } from "@/lib/client/trpc";
 
 export function ExtractTextDispatcherRegistrar() {
+  const suggest = trpc.document.suggestFromText.useMutation();
+  const utils = trpc.useUtils();
+
   useEffect(() => {
     setExtractTextDispatcher(async ({ documentId, text }) => {
-      // Vi går runt tRPC och skriver direkt via writeBack:s 'documentText'-
-      // entity. writeBack mountas i demo-bootstrap och triggas av
-      // window-event för att inte koppla till React-trädet.
       window.dispatchEvent(new CustomEvent("ava:document-text-extracted", {
         detail: { documentId, text },
       }));
+      // Förslagen är en bonus ovanpå text-skrivningen: ett fel här får inte
+      // förlora texten (som redan är dispatchad ovan) eller fälla jobbet.
+      try {
+        await suggest.mutateAsync({ documentId, text });
+        await Promise.all([
+          utils.document.pendingSuggestionsGrouped.invalidate(),
+          utils.document.events.invalidate(),
+        ]);
+      } catch (err) {
+        console.warn("[suggest-from-text] misslyckades:", err);
+      }
     });
     return () => setExtractTextDispatcher(null);
-  }, []);
+  }, [suggest, utils]);
   return null;
 }

--- a/src/lib/client/backend/suggest-from-bytes.ts
+++ b/src/lib/client/backend/suggest-from-bytes.ts
@@ -1,0 +1,42 @@
+"use client";
+
+/**
+ * `suggestFromBytes` (#988) — skapa kontakt- och händelseförslag ur bytes vi
+ * håller i handen.
+ *
+ * Vanligtvis kommer texten ur `extract-text`-jobbet, som läser filen ur
+ * FSA-working-copy:n. Men utan working copy (demon, och server-first i
+ * browsern) finns filen aldrig på klientens disk — bytes:en passerar bara
+ * förbi vid uppladdningen. Extraherar vi inte texten då är tillfället borta,
+ * och panelerna förblir tomma i just den tier där de syns mest.
+ *
+ * Skrivningen på serversidan är idempotent, så en dubbelkörning (t.ex.
+ * server-first, där jobbet också analyserar) skapar inga dubbletter.
+ */
+
+import { extractText } from "@/lib/shared/extract-text";
+import type { DocumentId } from "@/lib/shared/schemas/ids";
+
+/** tRPC-ytan primitiven behöver (strukturell — samma mönster som `UploadClient`). */
+export interface SuggestClient {
+  document: {
+    suggestFromText: { mutate: (input: { documentId: DocumentId; text: string }) => Promise<unknown> };
+  };
+}
+
+export interface SuggestSource {
+  bytes: Uint8Array;
+  mimeType: string;
+  fileName: string;
+}
+
+/** Extraherar texten och skickar den vidare. Tom text (okänt format, tomt
+ *  dokument) → ingen mutation alls; det finns inget att föreslå ur. */
+export async function suggestFromBytes(
+  client: SuggestClient, documentId: DocumentId, src: SuggestSource,
+): Promise<boolean> {
+  const text = await extractText({ bytes: src.bytes, mimeType: src.mimeType, fileName: src.fileName });
+  if (text.trim().length === 0) return false;
+  await client.document.suggestFromText.mutate({ documentId, text });
+  return true;
+}

--- a/src/lib/client/jobs/enqueue-text-extraction.ts
+++ b/src/lib/client/jobs/enqueue-text-extraction.ts
@@ -1,0 +1,35 @@
+"use client";
+
+/**
+ * Köa `extract-text` för ett dokument (#988).
+ *
+ * Texten workern producerar gör två saker: den gör innehållet sökbart, och den
+ * är det ENDA `document.suggestFromText` har att gå på i klient-tier:erna —
+ * i demo och self-hosted når dokumentets bytes aldrig servern. Utan det här
+ * steget fylls `SuggestionsPanel`/`EventsPanel` aldrig.
+ *
+ * Egen modul för att uppladdningen och "Analysera (AI)" ska köa jobbet på
+ * exakt samma sätt: båda betyder "läs om det här dokumentet". Analyze-porten
+ * (`document.analyze`) köar bara klassificeringen och känner varken filnamn
+ * eller sökväg — de finns bara på klienten, i dokumentraden.
+ */
+
+/** Dokument-fälten workern behöver för att hitta och tolka filen. */
+export interface ExtractableDoc {
+  id: string;
+  fileName: string;
+  mimeType: string;
+  storagePath: string;
+}
+
+/** Köar jobbet. `undefined` (dokumentet hittades inte i vyn) → tyst no-op. */
+export async function enqueueTextExtraction(doc: ExtractableDoc | undefined): Promise<void> {
+  if (!doc) return;
+  const { jobQueue } = await import("./job-queue");
+  jobQueue.enqueue("extract-text", `Extraherar text ur ${doc.fileName}`, {
+    documentId: doc.id,
+    fileName: doc.fileName,
+    storagePath: doc.storagePath,
+    mimeType: doc.mimeType,
+  });
+}

--- a/src/lib/server/jobs/handlers/classify-document-handler.ts
+++ b/src/lib/server/jobs/handlers/classify-document-handler.ts
@@ -6,14 +6,19 @@
  * deterministisk, ingen LLM, ingen modell-nedladdning. Fas 3 injicerar en
  * LLM-backad `classify` (server-LLM via ollama) med samma signatur.
  *
- * Idempotent: kör om → samma kategori skrivs igen (ofarligt). Saknat dokument
- * (raderat innan jobbet kördes) → tyst no-op.
+ * Med en injicerad `suggestFromText` (#988) skriver jobbet dessutom kontakt-
+ * och händelseförslag ur dokumentets text — det är server-first-tier:ns väg in
+ * i `SuggestionsPanel`/`EventsPanel`.
+ *
+ * Idempotent: kör om → samma kategori skrivs igen (ofarligt), och
+ * förslagsskrivningen dedupar på sitt håll. Saknat dokument (raderat innan
+ * jobbet kördes) → tyst no-op.
  */
 
 import { z } from "zod";
 import { type DocumentKind, guessFromFilename } from "@/lib/shared/document-kind";
 import type { Document } from "@/lib/shared/schemas/document";
-import { documentIdSchema, organizationIdSchema } from "@/lib/shared/schemas/ids";
+import { type DocumentId, documentIdSchema, organizationIdSchema } from "@/lib/shared/schemas/ids";
 import type { DocumentRepository } from "../../repositories/document-repository";
 import type { JobHandler } from "../job-worker-runtime";
 
@@ -41,6 +46,15 @@ export interface ClassifyDocumentDeps {
    * taggar så manuellt satta taggar ALDRIG skrivs över. Saknas → taggar rörs ej.
    */
   suggestTags?: (doc: ClassifiableDoc) => Promise<string[]>;
+  /**
+   * Skapa kontakt- och händelseförslag ur dokumentets TEXT (#988). Körs EFTER
+   * metadata-skrivningen: misslyckas extraktionen får klassificeringen ändå
+   * behålla sitt resultat (jobbet är idempotent och kan köras om).
+   *
+   * Saknas → hoppas över. Så är det i klient-tier:erna, där bytes:en aldrig
+   * når servern och texten i stället kommer ur browserns `extract-text`-jobb.
+   */
+  suggestFromText?: (documentId: DocumentId, doc: ClassifiableDoc) => Promise<void>;
   /** Modell-etikett som sparas i `analysisModel`. */
   model?: string;
   /** Injicerbar nu-tid för deterministiska tester. */
@@ -70,5 +84,6 @@ export function createClassifyDocumentHandler(deps: ClassifyDocumentDeps): JobHa
       analysisStatus: "DONE",
       analysisModel: model,
     });
+    await deps.suggestFromText?.(documentId, fields);
   };
 }

--- a/src/lib/server/jobs/server-first-handlers.ts
+++ b/src/lib/server/jobs/server-first-handlers.ts
@@ -7,6 +7,7 @@
  * regelmotor-handlers slotas in här i takt med att deras config/triggers byggs.
  */
 
+import { type SuggestionRepos, writeSuggestionsFromText } from "@/lib/server/documents/suggest-from-text";
 import { createSmtpSender, type SmtpConfig } from "@/lib/server/integrations/email/smtp-sender";
 import { createOllamaClassifier, createOllamaTagSuggester, type LlmConfig } from "@/lib/server/llm/ollama-classifier";
 import type { IContentStore } from "@/lib/server/ports";
@@ -25,9 +26,44 @@ export interface JobHandlerConfig {
    *  (läs bytes → extrahera text → ollama); annars filnamns-heuristik. */
   content?: IContentStore;
   llm?: LlmConfig;
+  /**
+   * Repositories för kontakt-/händelseförslag (#988). Satt + content →
+   * klassificeringsjobbet skriver också förslag ur dokumentets text. Utan
+   * content finns ingen text att läsa server-side → steget hoppas över.
+   */
+  suggestions?: SuggestionRepos;
   /** Byråns etikett-vokabulär (#621 B2). Satt + content + llm → LLM föreslår
    *  taggar ur listan vid klassificeringen. Lazy så den läses per jobb. */
   vocabulary?: () => Promise<readonly string[]>;
+}
+
+/**
+ * Läs dokumentets bytes ur content-store:n och extrahera text (PDF/DOCX/text).
+ * Tom sträng när bytes saknas — anroparen faller tillbaka på filnamnet.
+ * Delad av LLM-klassificeringen och förslagsskrivningen (#988).
+ */
+function textReader(content: IContentStore): (doc: ClassifiableDoc) => Promise<string> {
+  return async (doc) => {
+    const bytes = await content.read(doc.storagePath);
+    return bytes ? await extractText({ bytes, mimeType: doc.mimeType, fileName: doc.fileName }) : "";
+  };
+}
+
+/**
+ * Bygg `suggestFromText` för dokumentjobbet (#988): läs texten och skriv
+ * kontakt-/händelseförslagen. Kräver content-store (texten) + repositories
+ * (skrivningen) — men INTE en LLM: extraktionen är deterministisk, så
+ * server-first ger förslag även utan ollama.
+ */
+function buildSuggest(cfg: JobHandlerConfig): Pick<ClassifyDocumentDeps, "suggestFromText"> {
+  const { content, suggestions } = cfg;
+  if (!content || !suggestions) return {};
+  const textOf = textReader(content);
+  return {
+    suggestFromText: async (documentId, doc) => {
+      await writeSuggestionsFromText(suggestions, documentId, await textOf(doc));
+    },
+  };
 }
 
 /**
@@ -38,14 +74,10 @@ export interface JobHandlerConfig {
  */
 function buildClassify(cfg: JobHandlerConfig): Pick<ClassifyDocumentDeps, "classify" | "suggestTags" | "model"> {
   if (!cfg.content || !cfg.llm) return {};
-  const content = cfg.content;
   const ollama = createOllamaClassifier(cfg.llm);
   const tagger = createOllamaTagSuggester(cfg.llm);
   const { vocabulary } = cfg;
-  const textOf = async (doc: ClassifiableDoc): Promise<string> => {
-    const bytes = await content.read(doc.storagePath);
-    return bytes ? await extractText({ bytes, mimeType: doc.mimeType, fileName: doc.fileName }) : "";
-  };
+  const textOf = textReader(cfg.content);
   return {
     model: `ollama:${cfg.llm.model}`,
     classify: async (doc: ClassifiableDoc) => ollama(await textOf(doc), doc.fileName),
@@ -65,6 +97,7 @@ export function buildServerFirstJobHandlers(cfg: JobHandlerConfig): JobHandlers 
     handlers[JOB_QUEUES.classifyDocument] = createClassifyDocumentHandler({
       documents: cfg.documents,
       ...buildClassify(cfg),
+      ...buildSuggest(cfg),
     });
   }
   return handlers;

--- a/src/lib/server/ports.ts
+++ b/src/lib/server/ports.ts
@@ -31,10 +31,21 @@ export interface IEmailSender {
 
 export interface IDocumentAnalyzer {
   /**
-   * Schemalägg analys av ett dokument. Implementation kan vara
-   * synkron eller asynkron — i prod körs det i bakgrunden via en
-   * job-kö. Returnerar void; eventuella suggestions postas via
-   * dataStore.documentAnalysisSuggestions.
+   * Schemalägg analys av ett dokument. Implementation kan vara synkron eller
+   * asynkron — i prod körs det i bakgrunden via en job-kö. Returnerar void;
+   * resultatet skrivs av jobbet, inte av anroparen.
+   *
+   * Vad analysen skriver beror på vad implementationen kommer åt (#988):
+   *   - **alltid** dokumentets metadata (`documentType`, `analysisStatus`, …)
+   *     via `document.updateMetadata`;
+   *   - **dessutom** kontakt- och händelseförslag när den kan läsa dokumentets
+   *     TEXT — server-first-jobbet läser bytes ur content-store:n och kallar
+   *     `writeSuggestionsFromText`. Klient-tier:erna (demo/self-hosted) har
+   *     inga bytes server-side; där kommer texten ur `extract-text`-jobbet i
+   *     browsern, som anropar `document.suggestFromText` direkt.
+   *
+   * Porten lovade tidigare att förslagen alltid postades här. Det stämde inte
+   * för någon implementation — se #988.
    */
   analyze(documentId: DocumentId): Promise<void>;
 }

--- a/test/unit/client/backend/suggest-from-bytes.test.ts
+++ b/test/unit/client/backend/suggest-from-bytes.test.ts
@@ -1,0 +1,53 @@
+/**
+ * `suggestFromBytes` (#988) — förslagsvägen för tier:er UTAN working copy.
+ *
+ * I demon (och server-first i browsern) skrivs filen aldrig till klientens
+ * disk: bytes:en passerar bara förbi vid uppladdningen. Missar vi tillfället
+ * där finns ingen text att extrahera senare, och panelerna förblir tomma.
+ */
+
+import { describe, it, expect, vi } from "vitest-compat";
+import { suggestFromBytes, type SuggestClient } from "@/lib/client/backend/suggest-from-bytes";
+import { asId } from "@/lib/shared/schemas/ids";
+
+const DOC_ID = asId<"DocumentId">("d-1");
+
+function clientSpy() {
+  const mutate = vi.fn(async () => ({ parties: 1, events: 0 }));
+  const client: SuggestClient = { document: { suggestFromText: { mutate } } };
+  return { client, mutate };
+}
+
+describe("suggestFromBytes", () => {
+  it("extraherar texten ur bytes:en och skickar den till suggestFromText", async () => {
+    const { client, mutate } = clientSpy();
+    const bytes = new TextEncoder().encode("Kärande: Anna Andersson 850312-4567");
+
+    const sent = await suggestFromBytes(client, DOC_ID, { bytes, mimeType: "text/plain", fileName: "a.txt" });
+
+    expect(sent).toBe(true);
+    expect(mutate).toHaveBeenCalledWith({
+      documentId: "d-1", text: "Kärande: Anna Andersson 850312-4567",
+    });
+  });
+
+  it("okänt format → extraktionen ger tom text → ingen mutation alls", async () => {
+    // `extractText` är fail-soft och svarar med tom sträng. Att posta den vore
+    // ett rundtursanrop som garanterat inte kan ge något förslag.
+    const { client, mutate } = clientSpy();
+    const bytes = new Uint8Array([0x00, 0x01, 0x02]);
+
+    const sent = await suggestFromBytes(client, DOC_ID, { bytes, mimeType: "application/octet-stream", fileName: "a.bin" });
+
+    expect(sent).toBe(false);
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it("tomt dokument räknas som ingen text", async () => {
+    const { client, mutate } = clientSpy();
+    const bytes = new TextEncoder().encode("   \n\t ");
+
+    expect(await suggestFromBytes(client, DOC_ID, { bytes, mimeType: "text/plain", fileName: "tom.txt" })).toBe(false);
+    expect(mutate).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/client/jobs/enqueue-text-extraction.test.ts
+++ b/test/unit/client/jobs/enqueue-text-extraction.test.ts
@@ -1,0 +1,55 @@
+/**
+ * `enqueueTextExtraction` (#988) — sömmen som gör att kontakt- och
+ * händelseförslag uppstår i klient-tier:erna.
+ *
+ * Kör mot den RIKTIGA jobb-kön (den är in-memory och lika lätt att inspektera
+ * som en mock). Det som testas är att jobbet får med sig `storagePath` och
+ * `mimeType`: utan dem hittar workern varken filen eller rätt tolkning, och
+ * texten — och därmed förslagen — uteblir tyst.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest-compat";
+import { enqueueTextExtraction } from "@/lib/client/jobs/enqueue-text-extraction";
+import { jobQueue } from "@/lib/client/jobs/job-queue";
+
+const DOC = {
+  id: "d-1",
+  fileName: "Stämning.pdf",
+  mimeType: "application/pdf",
+  storagePath: "documents/content/abc.pdf",
+};
+
+beforeEach(() => {
+  jobQueue.list().forEach((j) => {
+    if (j.status === "queued" || j.status === "running") jobQueue.cancel(j.id);
+  });
+  jobQueue.clearFinished();
+});
+
+function extractJobs() {
+  return jobQueue.list().filter((j) => j.kind === "extract-text");
+}
+
+describe("enqueueTextExtraction", () => {
+  it("köar extract-text med filnamn, sökväg och mime-typ", async () => {
+    await enqueueTextExtraction(DOC);
+    const jobs = extractJobs();
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]!.payload).toEqual({
+      documentId: "d-1",
+      fileName: "Stämning.pdf",
+      storagePath: "documents/content/abc.pdf",
+      mimeType: "application/pdf",
+    });
+  });
+
+  it("labeln nämner filen så användaren känner igen jobbet i /jobs", async () => {
+    await enqueueTextExtraction(DOC);
+    expect(extractJobs()[0]!.label).toContain("Stämning.pdf");
+  });
+
+  it("okänt dokument (hittades inte i vyn) → tyst no-op, inget jobb", async () => {
+    await enqueueTextExtraction(undefined);
+    expect(extractJobs()).toHaveLength(0);
+  });
+});

--- a/test/unit/components/document-browser.test.tsx
+++ b/test/unit/components/document-browser.test.tsx
@@ -6,7 +6,7 @@
  * etc.
  */
 
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
 import { DocumentBrowser } from "@/components/documents/document-browser";
 import { asId } from "@/lib/shared/schemas/ids";
@@ -32,7 +32,16 @@ const treeQuery = {
   isLoading: false,
 };
 
+/** Vanilla-klienten uppladdningen använder (uploadContent + suggestFromText). */
+const clientMock = {
+  document: {
+    uploadContent: { mutate: vi.fn(async () => ({})) },
+    suggestFromText: { mutate: vi.fn(async () => ({ parties: 1, events: 0 })) },
+  },
+};
+
 const utilsMock = {
+  client: clientMock,
   document: {
     tree: { invalidate: vi.fn(), fetch: vi.fn().mockResolvedValue({ folders: [], documents: [] }) },
     pendingSuggestionsGrouped: { invalidate: vi.fn() },
@@ -41,6 +50,25 @@ const utilsMock = {
   matter: { getById: { invalidate: vi.fn() } },
   prefs: { get: { invalidate: vi.fn() } },
 };
+
+/**
+ * "Analysera (AI)" ska köa text-extraktion (#988) — utan texten kan inga
+ * kontakt-/händelseförslag uppstå. Själva köandet testas i
+ * `enqueue-text-extraction.test.ts`; här testas att browsern hittar rätt
+ * dokument och skickar det vidare.
+ */
+const enqueueTextExtraction = vi.fn(async () => {});
+vi.mock("@/lib/client/jobs/enqueue-text-extraction", () => ({ enqueueTextExtraction }));
+
+// Byte-uppladdningen cachar innehållet i IndexedDB, som saknas i jsdom.
+// Uppladdningens senare steg (jobb + förslag) är det som testas här.
+vi.mock("@/lib/client/backend/save-document-content", () => ({
+  saveDocumentContent: vi.fn(async () => "sha"),
+}));
+
+/** Mutationens options fångas så `mutate` kan köra `onMutate` som React Query gör. */
+interface AnalyzeOptions { onMutate?: (vars: { documentId: string }) => void }
+let analyzeOptions: AnalyzeOptions = {};
 
 const mutationStubs = {
   createFolder: { mutate: vi.fn(), isPending: false },
@@ -64,7 +92,7 @@ vi.mock("@/lib/client/trpc", () => ({
       moveDocument: { useMutation: () => mutationStubs.moveDocument },
       moveFolder: { useMutation: () => mutationStubs.moveFolder },
       delete: { useMutation: () => mutationStubs.delete },
-      analyze: { useMutation: () => mutationStubs.analyze },
+      analyze: { useMutation: (opts?: AnalyzeOptions) => { analyzeOptions = opts ?? {}; return mutationStubs.analyze; } },
       register: { useMutation: () => mutationStubs.register },
       setTags: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
       takeoverLease: { useMutation: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }) },
@@ -93,7 +121,8 @@ beforeEach(() => {
   mutationStubs.moveDocument.mutate = vi.fn();
   mutationStubs.moveFolder.mutate = vi.fn();
   mutationStubs.delete.mutate = vi.fn();
-  mutationStubs.analyze.mutate = vi.fn();
+  // Som React Query: `mutate` kör mutationens `onMutate` innan anropet.
+  mutationStubs.analyze.mutate = vi.fn((vars: { documentId: string }) => analyzeOptions.onMutate?.(vars));
 });
 
 const baseDoc = (overrides: Partial<Doc> = {}): Doc => ({
@@ -325,6 +354,39 @@ describe("DocumentBrowser", () => {
     fireEvent.click(screen.getByLabelText("Dokumentåtgärder"));
     fireEvent.click(screen.getByRole("menuitem", { name: /Analysera/i }));
     expect(mutationStubs.analyze.mutate).toHaveBeenCalledWith({ documentId: "d1" });
+  });
+
+  it("uppladdning utan working copy skickar textens innehåll till suggestFromText (#988)", async () => {
+    // Utan FSA-handle (mockad till null överst) skrivs filen aldrig till
+    // klientens disk — extract-text-jobbet kan alltså aldrig läsa den igen.
+    // Bytes:en finns bara i den här uppladdningen; missas de blir panelerna
+    // permanent tomma i demon.
+    render(<DocumentBrowser matterId={asId<"MatterId">("m1")} />);
+    const file = new File(["Kärande: Anna Andersson 850312-4567"], "stamning.txt", { type: "text/plain" });
+    const input = document.querySelector("input[type=file]")!;
+    Object.defineProperty(input, "files", { value: [file], configurable: true });
+    fireEvent.change(input);
+
+    await waitFor(() => expect(clientMock.document.suggestFromText.mutate).toHaveBeenCalled());
+    expect(clientMock.document.suggestFromText.mutate.mock.calls[0]![0]).toMatchObject({
+      text: "Kärande: Anna Andersson 850312-4567",
+    });
+    // Den vanliga vägen (working copy finns) köas oavsett — jobbet är no-op
+    // utan handle, och tar över så fort en mapp är vald.
+    expect(enqueueTextExtraction).toHaveBeenCalled();
+  });
+
+  it("Analysera köar också text-extraktion → kontakt-/händelseförslag (#988)", () => {
+    // Analyze-porten köar bara klassificeringen och känner varken filnamn
+    // eller sökväg. Utan det här steget analyseras dokumentet om utan att
+    // panelerna någonsin fylls.
+    treeQuery.data = { folders: [], documents: [baseDoc({ storagePath: "documents/content/a.pdf" })] };
+    render(<DocumentBrowser matterId={asId<"MatterId">("m1")} />);
+    fireEvent.click(screen.getByLabelText("Dokumentåtgärder"));
+    fireEvent.click(screen.getByRole("menuitem", { name: /Analysera/i }));
+    expect(enqueueTextExtraction).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "d1", fileName: "test.pdf", mimeType: "application/pdf", storagePath: "documents/content/a.pdf" }),
+    );
   });
 
   it("dragstart + drop på mapp anropar moveDocument", () => {

--- a/test/unit/components/extract-text-dispatcher-registrar.test.tsx
+++ b/test/unit/components/extract-text-dispatcher-registrar.test.tsx
@@ -1,14 +1,35 @@
 /**
- * Test för `ExtractTextDispatcherRegistrar` (#27). Integrationstest mot den
- * RIKTIGA extract-text-dispatchern (ingen mock): mount registrerar en dispatcher
- * som dispatchar `ava:document-text-extracted`; unmount avregistrerar.
+ * Test för `ExtractTextDispatcherRegistrar` (#27, #988). Integrationstest mot
+ * den RIKTIGA extract-text-dispatchern (ingen mock av dispatch-modulen): mount
+ * registrerar en dispatcher som (1) dispatchar `ava:document-text-extracted`
+ * och (2) skapar kontakt-/händelseförslag ur texten; unmount avregistrerar.
+ *
+ * Punkt 2 är klient-tier:ernas enda väg in i `SuggestionsPanel`/`EventsPanel`
+ * — bytes:en når aldrig servern där, så förslagen måste utgå från texten
+ * browsern just läst.
  */
 import { render } from "@testing-library/react";
-import { describe, it, expect, afterEach } from "vitest-compat";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest-compat";
 import { ExtractTextDispatcherRegistrar } from "@/components/documents/extract-text-dispatcher-registrar";
 import { dispatchExtractText, setExtractTextDispatcher } from "@/lib/client/jobs/extract-text-dispatch";
 import { asId } from "@/lib/shared/schemas/ids";
 
+const mutateAsync = vi.fn(async () => ({ parties: 2, events: 1 }));
+const suggestionsInvalidate = vi.fn(async () => {});
+const eventsInvalidate = vi.fn(async () => {});
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: {
+    document: { suggestFromText: { useMutation: () => ({ mutateAsync }) } },
+    useUtils: () => ({
+      document: {
+        pendingSuggestionsGrouped: { invalidate: suggestionsInvalidate },
+        events: { invalidate: eventsInvalidate },
+      },
+    }),
+  },
+}));
+
+beforeEach(() => vi.clearAllMocks());
 afterEach(() => setExtractTextDispatcher(null));
 
 describe("ExtractTextDispatcherRegistrar", () => {
@@ -25,6 +46,32 @@ describe("ExtractTextDispatcherRegistrar", () => {
     unmount();
     await expect(dispatchExtractText({ documentId: asId<"DocumentId">("d2"), text: "x" }))
       .rejects.toThrow(/Ingen extract-text-dispatcher/);
+
+    window.removeEventListener("ava:document-text-extracted", listener);
+  });
+
+  it("texten skickas till document.suggestFromText → panelerna invalideras (#988)", async () => {
+    render(<ExtractTextDispatcherRegistrar />);
+    await dispatchExtractText({ documentId: asId<"DocumentId">("d1"), text: "Kärande: Anna Andersson" });
+
+    expect(mutateAsync).toHaveBeenCalledWith({ documentId: "d1", text: "Kärande: Anna Andersson" });
+    expect(suggestionsInvalidate).toHaveBeenCalled();
+    expect(eventsInvalidate).toHaveBeenCalled();
+  });
+
+  it("ett fel i förslagsskrivningen förlorar INTE den extraherade texten", async () => {
+    // Texten är huvudsaken — den dispatchas först och skrivs till FSA. Att
+    // förslagen misslyckas (offline, 500) får inte fälla jobbet med den.
+    const seen: CustomEvent[] = [];
+    const listener = (e: Event) => seen.push(e as CustomEvent);
+    window.addEventListener("ava:document-text-extracted", listener);
+    mutateAsync.mockRejectedValueOnce(new Error("nätverk nere"));
+
+    render(<ExtractTextDispatcherRegistrar />);
+    await dispatchExtractText({ documentId: asId<"DocumentId">("d1"), text: "text" });
+
+    expect(seen).toHaveLength(1);
+    expect(suggestionsInvalidate).not.toHaveBeenCalled();
 
     window.removeEventListener("ava:document-text-extracted", listener);
   });

--- a/test/unit/server/jobs/classify-document-handler.test.ts
+++ b/test/unit/server/jobs/classify-document-handler.test.ts
@@ -68,6 +68,41 @@ describe("createClassifyDocumentHandler", () => {
     });
   });
 
+  it("suggestFromText (#988) körs EFTER metadata-skrivningen, med dokumentets fält", async () => {
+    // Ordningen är poängen: en trasig textextraktion får inte kosta oss
+    // klassificeringen. Jobbet är idempotent och körs om.
+    const calls: string[] = [];
+    const documents = {
+      getById: vi.fn(async () => ({ id: "d1", fileName: "Stämning.pdf", storagePath: "documents/content/a.pdf", mimeType: "application/pdf" })),
+      updateMetadata: vi.fn(async () => { calls.push("updateMetadata"); return {}; }),
+    };
+    const suggestFromText = vi.fn(async () => { calls.push("suggestFromText"); });
+    const handler = createClassifyDocumentHandler({ documents: documents as never, suggestFromText });
+    await handler(jobFor("d1"));
+
+    expect(calls).toEqual(["updateMetadata", "suggestFromText"]);
+    expect(suggestFromText).toHaveBeenCalledWith("d1", {
+      fileName: "Stämning.pdf", storagePath: "documents/content/a.pdf", mimeType: "application/pdf",
+    });
+  });
+
+  it("utan suggestFromText hoppas förslagssteget över (klient-tier:erna)", async () => {
+    const documents = {
+      getById: vi.fn(async () => ({ id: "d1", fileName: "x.pdf" })),
+      updateMetadata: vi.fn(async () => ({})),
+    };
+    // Ska inte kasta trots att dep:en saknas — optional call, inte ett villkor.
+    await createClassifyDocumentHandler({ documents: documents as never })(jobFor("d1"));
+    expect(documents.updateMetadata).toHaveBeenCalled();
+  });
+
+  it("raderat dokument → varken metadata eller förslag skrivs", async () => {
+    const suggestFromText = vi.fn(async () => {});
+    const documents = { getById: vi.fn(async () => null), updateMetadata: vi.fn(async () => ({})) };
+    await createClassifyDocumentHandler({ documents: documents as never, suggestFromText })(jobFor("borta"));
+    expect(suggestFromText).not.toHaveBeenCalled();
+  });
+
   it("utan suggestTags rörs `tags` inte (ingen tags-nyckel i patchen)", async () => {
     const documents = {
       getById: vi.fn(async () => ({ id: "d1", fileName: "x.pdf", tags: ["Manuell"] })),

--- a/test/unit/server/jobs/server-first-suggestions.test.ts
+++ b/test/unit/server/jobs/server-first-suggestions.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Server-first-tier:ns väg till kontakt- och händelseförslag (#988).
+ *
+ * `writeSuggestionsFromText` testas för sig; det här testet påstår att
+ * `classify-document`-jobbet faktiskt NÅR den — hela vägen från
+ * `buildServerFirstJobHandlers` via content-store:n och textextraktionen.
+ * Det var precis den kopplingen som saknades: producenten fanns, men ingen
+ * runtime kallade den.
+ *
+ * Noterbart: förslagen kräver INTE en LLM. Extraktionen är deterministisk, så
+ * en server-first-deploy utan ollama får dem ändå — bara content-store:n måste
+ * finnas (annars finns ingen text att läsa server-side).
+ */
+
+import type { Job } from "pg-boss";
+import { describe, it, expect } from "vitest-compat";
+import type { DemoSource } from "@/lib/server/data-store/DemoDataStore";
+import { LocalStore } from "@/lib/server/data-store/in-memory/local-store";
+import type { SuggestionRepos } from "@/lib/server/documents/suggest-from-text";
+import { JOB_QUEUES } from "@/lib/server/jobs/job-queue";
+import { buildServerFirstJobHandlers } from "@/lib/server/jobs/server-first-handlers";
+import type { IContentStore } from "@/lib/server/ports";
+import { InMemoryDocumentSuggestionRepository } from "@/lib/server/repositories/in-memory-document-suggestion-repository";
+import { InMemoryMatterEventSuggestionRepository } from "@/lib/server/repositories/in-memory-matter-event-suggestion-repository";
+import { prebakeJoins } from "@/lib/shared/demo-source";
+import { asId } from "@/lib/shared/schemas/ids";
+import { uuidv7 } from "@/lib/shared/uuid";
+
+const ORG = asId<"OrganizationId">("77777777-7777-7777-8777-777777777777");
+const STORAGE_PATH = "documents/content/stamning.txt";
+
+const TEXT = [
+  "STÄMNINGSANSÖKAN",
+  "Kärande: Anna Andersson 850312-4567",
+  "Svarande: Byggfirma Stenhammar AB 556677-8899",
+  "",
+  "Muntlig förberedelse har satts ut till 2026-09-15 kl. 09.30.",
+].join("\n");
+
+/** Content-store som bara kan svara på ett dokument — resten saknas. */
+function contentWith(bytes: Uint8Array | null): IContentStore {
+  return {
+    write: async () => {},
+    read: async (path) => (path === STORAGE_PATH ? bytes : null),
+    exists: async (path) => path === STORAGE_PATH && bytes !== null,
+  };
+}
+
+function setup() {
+  const matterId = asId<"MatterId">(uuidv7());
+  const documentId = asId<"DocumentId">(uuidv7());
+  const source = prebakeJoins({
+    matters: [{ id: matterId, organizationId: ORG, matterNumber: "2026-1", title: "T" }],
+    documents: [{
+      id: documentId, matterId, fileName: "stamning.txt",
+      storagePath: STORAGE_PATH, mimeType: "text/plain",
+    }],
+    documentAnalysisSuggestions: [],
+    matterEventSuggestions: [],
+  } as DemoSource);
+  const store = new LocalStore(source, async () => {});
+  const suggestions: SuggestionRepos = {
+    documentAnalysisSuggestions: new InMemoryDocumentSuggestionRepository(store),
+    matterEventSuggestions: new InMemoryMatterEventSuggestionRepository(store),
+  };
+  // Bara de två metoderna handlern rör; resten av dokument-repo:t behövs inte.
+  const documents = {
+    getById: async () => ({ id: documentId, fileName: "stamning.txt", storagePath: STORAGE_PATH, mimeType: "text/plain" }),
+    updateMetadata: async () => ({}),
+  };
+  return { documentId, suggestions, documents };
+}
+
+/** Ett minimalt pg-boss-jobb — handlern läser bara `data`. */
+function jobFor(documentId: string): Job {
+  return {
+    id: "job-1", name: JOB_QUEUES.classifyDocument, data: { documentId },
+    expireInSeconds: 60, heartbeatSeconds: null, signal: AbortSignal.abort(),
+  };
+}
+
+function runClassify(handlers: ReturnType<typeof buildServerFirstJobHandlers>, documentId: string) {
+  const handler = handlers[JOB_QUEUES.classifyDocument];
+  if (!handler) throw new Error("ingen classify-handler registrerad");
+  return handler(jobFor(documentId));
+}
+
+describe("classify-document → kontakt-/händelseförslag (server-first)", () => {
+  it("skriver förslag ur dokumentets text, utan LLM", async () => {
+    const { documentId, suggestions, documents } = setup();
+    const handlers = buildServerFirstJobHandlers({
+      documents: documents as never,
+      content: contentWith(new TextEncoder().encode(TEXT)),
+      suggestions,
+    });
+    await runClassify(handlers, documentId);
+
+    const parties = await suggestions.documentAnalysisSuggestions.listForDocument(documentId);
+    expect(parties.map((p) => p.name).sort()).toEqual(["Anna Andersson", "Byggfirma Stenhammar AB"]);
+    const events = await suggestions.matterEventSuggestions.listForDocument(documentId);
+    expect(events.map((e) => e.title)).toEqual(["Muntlig förberedelse"]);
+  });
+
+  it("omkörning av jobbet ger inga dubbletter", async () => {
+    const { documentId, suggestions, documents } = setup();
+    const handlers = buildServerFirstJobHandlers({
+      documents: documents as never,
+      content: contentWith(new TextEncoder().encode(TEXT)),
+      suggestions,
+    });
+    await runClassify(handlers, documentId);
+    await runClassify(handlers, documentId);
+    expect(await suggestions.documentAnalysisSuggestions.listForDocument(documentId)).toHaveLength(2);
+  });
+
+  it("bytes saknas i content-store:n → inga förslag, inget fel", async () => {
+    const { documentId, suggestions, documents } = setup();
+    const handlers = buildServerFirstJobHandlers({
+      documents: documents as never, content: contentWith(null), suggestions,
+    });
+    await runClassify(handlers, documentId);
+    expect(await suggestions.documentAnalysisSuggestions.listForDocument(documentId)).toHaveLength(0);
+  });
+
+  it("utan content-store finns ingen text server-side → steget kopplas inte in", async () => {
+    const { documentId, suggestions, documents } = setup();
+    const handlers = buildServerFirstJobHandlers({ documents: documents as never, suggestions });
+    await runClassify(handlers, documentId);
+    expect(await suggestions.documentAnalysisSuggestions.listForDocument(documentId)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Stänger #988 — resten av issuen efter #993.

## Vad som saknades

#993 byggde producenten (`writeSuggestionsFromText` + `document.suggestFromText`), men den triggades bara av seedningen. I appen skapade ingenting förslag: demon visade 23 parter och 8 händelser för att seeden skrev dem, medan self-hosted och server-first hade tomma paneler precis som före.

Här kopplas producenten till de ställen där text faktiskt uppstår. De är olika per tier, och det är hela poängen med diffen:

| Tier | Var texten finns | Vem anropar |
|---|---|---|
| self-hosted (working copy) | `extract-text`-jobbet läser filen ur FSA | `ExtractTextDispatcherRegistrar` → `document.suggestFromText` |
| server-first | bytes i content-store:n | `classify-document`-jobbet, server-side |
| demo (ingen working copy) | bara i själva uppladdningen | `suggestFromBytes` direkt i upload-handlern |

## Server-first behöver ingen LLM

`buildClassify` byggde bara något när **både** content-store och `AVA_LLM_*` var satta. Förslagen kräver inte modellen — extraktionen är deterministisk — så `buildSuggest` villkoras bara på content-store:n. En deploy utan ollama får alltså förslagen ändå.

Steget körs **efter** metadata-skrivningen. En trasig textextraktion får inte kosta oss klassificeringen; jobbet är idempotent och körs om.

## Demo: bytes:en passerar bara förbi

Utan working copy skrivs filen aldrig till klientens disk — `extract-text`-jobbet hittar ingen fil och loggar en varning. Missar vi tillfället i uppladdningen finns ingen text att extrahera senare, och panelerna förblir tomma i just den tier där de syns mest. Därför extraheras texten där bytes:en ändå finns i handen.

Den vägen är best-effort och `void`:ad: uppladdningen är redan klar och får inte falla på förslagen. Samma sak i registrarn — texten dispatchas till write-back **först**, förslagsanropet efter, så ett fel där aldrig förlorar texten. Det finns ett test för varje riktning.

## "Analysera (AI)"

Köar nu samma text-extraktion som en uppladdning. Analyze-porten köar bara klassificeringen och känner varken filnamn eller sökväg — de finns bara i dokumentraden på klienten, så anropet hör hemma i `onMutate`.

Knappen är dold i demon (ADR 0027, ingen LLM-kapabilitet), så alla tier där den syns har en fungerande väg: self-hosted via jobbet, server-first via servern.

## Doc-kommentaren

`IDocumentAnalyzer.analyze` lovade att "eventuella suggestions postas via `dataStore.documentAnalysisSuggestions`". Det stämde inte för någon implementation — det var så #988 hittades. Den beskriver nu vad varje tier faktiskt gör.

## Tester

- **`server-first-suggestions.test.ts`** (4, ny): hela vägen från `buildServerFirstJobHandlers` genom content-store och textextraktion till skrivna förslag — plus omkörning utan dubbletter, saknade bytes, och att steget inte kopplas in utan content-store.
- **`suggest-from-bytes.test.ts`** (3, ny): texten når mutationen; okänt format och tomt dokument ger inget anrop alls.
- **`enqueue-text-extraction.test.ts`** (3, ny): jobbet får med sig `storagePath` och `mimeType` — utan dem hittar workern varken filen eller rätt tolkning, och texten uteblir tyst.
- **`classify-document-handler.test.ts`** (+3): ordningen `updateMetadata` → `suggestFromText`, att steget hoppas över utan dep:en, och att ett raderat dokument varken får metadata eller förslag.
- **`extract-text-dispatcher-registrar.test.tsx`** (+2): texten skickas vidare och panelerna invalideras; ett fel i förslagsskrivningen förlorar inte texten.
- **`document-browser.test.tsx`** (+2): uppladdning utan working copy skickar innehållet vidare, och "Analysera" köar text-extraktion för rätt dokument. `analyze`-mocken kör nu `onMutate` som React Query gör.

## Grindar

`typecheck` ✓ · `lint` ✓ · `lint:complexity-strict` ✓ · `knip` ✓ · `deps:check` ✓ (1125 moduler) · `jscpd` ✓ · `build:demo` ✓ (seeden oförändrad: 23 parter, 8 händelser) · **`e2e:demo` 31/31** ✓ · `test/unit/server/jobs` + `test/unit/client` ✓

Lint fällde en dubbel-cast i det nya jobb-testet (`as unknown as Job`); löst med ett riktigt `Job`-objekt i stället för ett undantag.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_