### PR TITLE
fix(billing): ta bort dom-bannern som aldrig renderades och kör KR-flödet skarpt i e2e

### DIFF
--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -8,8 +8,11 @@
  * "+ Skapa faktura"-knapp som öppnar rätt dialog beroende på matter:s
  * paymentMethod.
  *
- * KOSTNADSRAKNING i PENDING_VERDICT-state får en "Ange dom"-knapp som
- * öppnar verdict-dialogen (sätter prutning + skapar faktura).
+ * En kostnadsräkning som väntar på dom avvecklas i TVÅ steg via KR-kortet
+ * (`kostnadsrakning-flow.ts`): "Registrera beslut" (dömt belopp + ev. prutning)
+ * → "Skapa faktura", som öppnar verdict-dialogen (offentligt uppdrag) eller
+ * slutregleringen (rättshjälp). Servern läser prutningen ur beslutet; det finns
+ * ingen ett-stegs-knapp som gör båda (#996).
  */
 import type { inferRouterOutputs } from "@trpc/server";
 import { useEffect, useRef, useState } from "react";

--- a/src/lib/shared/billing-flow.ts
+++ b/src/lib/shared/billing-flow.ts
@@ -1,9 +1,14 @@
 /**
  * Faktureringsflöden per ärendetyp (#816/#817) — EN deklarativ sanningskälla för
  * vad som får faktureras NÄR, per `paymentMethod`. Driver både UI-panelen
- * (tillgängliga actions + dom-banner + vilken dialog en knapp öppnar) och
- * server-guards (att en action är laglig i ärendets nuvarande fas). Ren logik,
- * inga I/O — delas av server, klient och tester.
+ * (tillgängliga actions + vilken dialog en knapp öppnar) och server-guards (att
+ * en action är laglig i ärendets nuvarande fas). Ren logik, inga I/O — delas av
+ * server, klient och tester.
+ *
+ * Vad som händer EFTER att kostnadsräkningen skickats in — beslut, överklagande,
+ * faktura — modelleras per KR-körning i {@link file://./kostnadsrakning-flow.ts}
+ * och renderas av panelens KR-kort. Den här filen slutar vid fasen: flödet vet
+ * att ärendet VÄNTAR på dom, inte hur väntan avvecklas (#996).
  *
  * Designval (2026-06): **härledd fas** (stateless, ur billing-runs + matter —
  * ingen kolumn, ingen osynk), **in-kod-descriptors** (ändlig enum av flöden,
@@ -37,18 +42,10 @@ export interface BillingAction {
   dialog: BillingDialog;
 }
 
-/** "Väntar på dom"-bannern: när ärendet är i `phase`, vad domsknappen öppnar. */
-export interface PendingBanner {
-  phase: BillingPhase;
-  dialog: Extract<BillingDialog, "settlement" | "verdict">;
-  label: string;
-}
-
 export interface BillingFlow {
   initialPhase: BillingPhase;
   /** Lagliga actions per fas. Nycklarna = de faser flödet äger. */
   actionsByPhase: Partial<Record<BillingPhase, readonly BillingAction[]>>;
-  pendingBanner?: PendingBanner;
 }
 
 const aconto = (): BillingAction => ({ type: "ACCONTO", label: "Aconto till klient", toPhase: "ARBETE", recipient: "KLIENT", dialog: "billing" });
@@ -98,7 +95,6 @@ export const BILLING_FLOWS: Record<PaymentMethod, BillingFlow> = {
       ],
       SLUTREGLERAD: [],
     },
-    pendingBanner: { phase: "VANTAR_DOM", dialog: "settlement", label: "Slutreglera (dom)" },
   },
   // Offentligt uppdrag: kostnadsräkning till domstol → dom (prutning) via verdict.
   // Klienten kan dessutom faktureras (återbetalningsskyldighet enligt domen).
@@ -114,7 +110,6 @@ export const BILLING_FLOWS: Record<PaymentMethod, BillingFlow> = {
       ],
       SLUTREGLERAD: [],
     },
-    pendingBanner: { phase: "VANTAR_DOM", dialog: "verdict", label: "Ange dom + prutning" },
   },
 };
 
@@ -161,13 +156,6 @@ export function currentPhase(matter: FlowMatter, runs: ReadonlyArray<FlowRun>): 
 export function availableActions(matter: FlowMatter, runs: ReadonlyArray<FlowRun>): readonly BillingAction[] {
   const flow = BILLING_FLOWS[matter.paymentMethod];
   return flow.actionsByPhase[currentPhase(matter, runs)] ?? [];
-}
-
-/** Dom-bannern för ärendet, om flödet har en och ärendet är i dess fas. */
-export function pendingBannerFor(matter: FlowMatter, runs: ReadonlyArray<FlowRun>): PendingBanner | null {
-  const flow = BILLING_FLOWS[matter.paymentMethod];
-  if (flow.pendingBanner && currentPhase(matter, runs) === flow.pendingBanner.phase) return flow.pendingBanner;
-  return null;
 }
 
 /** Är `action` laglig i `phase` för flödet? (server-guard, fas 3.) */

--- a/test/e2e/_demo-test.ts
+++ b/test/e2e/_demo-test.ts
@@ -107,6 +107,19 @@ export interface DemoSeed {
   timeEntries: Array<{ id: string; matterId: string; description: string }>;
   expenses: Array<{ id: string; matterId: string; description: string }>;
   paymentPlans: Array<{ id: string; invoiceId: string; status: string }>;
+  billingRuns: Array<{ id: string; matterId: string; type: string; status: string }>;
+}
+
+/**
+ * Ärendet vars kostnadsräkning väntar på domstolens beslut (#996). Slås upp i
+ * datan i stället för att hårdkodas: VILKET brottmål som står kvar i väntan
+ * bestäms av scenariodispatchern (#882), och flyttas den dit hör ändringen
+ * hemma där — inte i en spec.
+ */
+export function matterAwaitingVerdict(seed: DemoSeed): string {
+  const hit = seed.billingRuns.find((r) => r.type === "KOSTNADSRAKNING" && r.status === "PENDING_VERDICT");
+  if (!hit) throw new Error("seeden saknar kostnadsräkning i PENDING_VERDICT — demons väntetillstånd är borta igen (#882)");
+  return hit.matterId;
 }
 
 /** Grupper som bär `matterId` — det e2e:t kan kräva att ett ärende har. */

--- a/test/e2e/demo-invoice-document.spec.ts
+++ b/test/e2e/demo-invoice-document.spec.ts
@@ -2,9 +2,8 @@
  * E2E (demo): exakt det rapporterade flödet, helt automatiserat.
  *
  *   Logga in som "Anna Advokat" → Ärenden → "Brottmål — ekobrott Carlsson"
- *   → "Ange dom + prutning" → "Skapa faktura" → klicka "Faktura"-länken i
- *   kostnadsräkningsraden → på fakturasidan, klicka dokumentnamnet
- *   "Faktura ….pdf" i Fakturadokument-panelen.
+ *   → klicka "Faktura"-länken i kostnadsräkningsraden → på fakturasidan,
+ *   klicka dokumentnamnet "Faktura ….pdf" i Fakturadokument-panelen.
  *
  * Förväntat: PDF:en öppnas i en SEPARAT FLIK. Buggen var att man istället
  * dirigerades in i ärendet (dokumentnamnet länkade till /matters) — ofta med
@@ -47,14 +46,12 @@ test("fakturadokument öppnas i ny flik — dirigeras INTE in i ärendet (+ inge
   await page.goto(`${base}/matters/${MATTER}/`, { waitUntil: "load" });
   await expect(page.getByRole("heading", { name: /ekobrott Carlsson/i })).toBeVisible({ timeout: 30_000 });
 
-  // "Ange dom + prutning" → "Skapa faktura" (om kostnadsräkningen väntar på dom).
-  const verdictBtn = page.getByRole("button", { name: /Ange dom \+ prutning/i });
-  if (await verdictBtn.count()) {
-    await verdictBtn.first().click();
-    await page.getByRole("button", { name: /^Skapa faktura$/ }).click();
-    // Fakturan + fakturadokumentet genereras + persisteras.
-    await page.waitForTimeout(6000);
-  }
+  // Ärendets kostnadsräkning är redan avgjord och fakturerad i seeden, så
+  // fakturan finns när sidan öppnas. Vägen dit — "Registrera beslut" → "Skapa
+  // faktura" — körs skarpt i `demo-kostnadsrakning-verdict.spec.ts` på det
+  // ärende som väntar på dom. (Här stod förr en gren som letade efter en knapp
+  // "Ange dom + prutning". Den etiketten renderades aldrig av något, så grenen
+  // hoppades tyst över vid varje körning — se #996.)
 
   // No-reload-markör: överlever en SPA-övergång men nollas vid sidomladdning.
   await page.evaluate(() => { (window as unknown as { __avaSpa?: string }).__avaSpa = "alive"; });

--- a/test/e2e/demo-kostnadsrakning-verdict.spec.ts
+++ b/test/e2e/demo-kostnadsrakning-verdict.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * E2E (demo): kostnadsräkningens väg från "väntar på dom" till faktura.
+ *
+ *   Ärendet vars KR väntar på dom → "Registrera beslut" (dömt belopp + prutning)
+ *   → "Skapa faktura" → domstolsfakturan finns, med sitt fakturadokument.
+ *
+ * Flödet är TVÅ steg, inte ett: servern läser prutningen ur beslutet, så
+ * verdict-dialogen bekräftar bara att fakturan ska skapas.
+ *
+ * Varför en egen spec (#996): `demo-invoice-document.spec.ts` hade en gren som
+ * skulle köra den här vägen, men letade efter en knapp `Ange dom + prutning` —
+ * en etikett som bara fanns i `BILLING_FLOWS.pendingBanner` och aldrig
+ * renderades av något. Grenen var villkorad (`if (count())`) och hoppades
+ * därför tyst över vid varje körning. Här är den ovillkorlig: hittas inte
+ * knappen FALLER testet.
+ *
+ * Ärendet slås upp ur seeden — vilket brottmål som står kvar i väntan bestäms
+ * av scenariodispatchern (#882), inte av den här filen.
+ */
+
+import { DEMO_BASE_URL, fetchDemoSeed, matterAwaitingVerdict, seedDemoLogin, test, expect } from "./_demo-test";
+
+/** Belopp domstolen dömer ut respektive prutar, i kronor. */
+const AWARDED_KR = 12_000;
+const PRUTNING_KR = 1_500;
+
+test("kostnadsräkning som väntar på dom: registrera beslut → skapa faktura", async ({ page, baseURL }) => {
+  const base = (baseURL ?? DEMO_BASE_URL).replace(/\/+$/, "");
+  await seedDemoLogin(page, base);
+
+  const seed = await fetchDemoSeed(page, base);
+  const matterId = matterAwaitingVerdict(seed);
+
+  await page.goto(`${base}/matters/${matterId}/`, { waitUntil: "load" });
+  // KR-kortet visar väntetillståndet — det som saknades i demon före #882.
+  await expect(page.getByText(/Väntar på dom/i).first()).toBeVisible({ timeout: 30_000 });
+
+  // Fakturor på ärendet INNAN flödet. Utan den här mätningen kunde slut-
+  // assertionen nedan gå igenom på en faktura som redan låg där.
+  const invoiceLinks = page.locator('main a[href*="/invoices/"]');
+  const invoicesBefore = await invoiceLinks.count();
+
+  // Ett steg räcker inte: fakturaknappen finns INTE förrän beslutet är
+  // registrerat. (Panelens egen "+ Skapa faktura" har plustecknet i namnet och
+  // matchas inte av det förankrade uttrycket.)
+  await expect(page.getByRole("button", { name: /^Skapa faktura$/ })).toHaveCount(0);
+
+  // Steg 1: domstolens beslut. Ovillkorligt — knappen SKA finnas i det här läget.
+  await page.getByRole("button", { name: /^Registrera beslut$/ }).click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog.getByText(/Registrera domstolens beslut/i)).toBeVisible();
+  await dialog.getByLabel(/Dömt belopp/i).fill(String(AWARDED_KR));
+  await dialog.getByLabel(/Prutning/i).fill(String(PRUTNING_KR));
+  await dialog.getByRole("button", { name: /^Spara beslut$/ }).click();
+  await expect(dialog).toBeHidden({ timeout: 15_000 });
+
+  // Steg 2: fakturan skapas ur beslutet (dialogen tar inget belopp — servern
+  // läser det ur KR:n). Att knappen dyker upp FÖRST nu är hela poängen med att
+  // flödet är tvådelat.
+  await page.getByRole("button", { name: /^Skapa faktura$/ }).click();
+  const verdict = page.getByRole("dialog");
+  await expect(verdict.getByText(/Skapa faktura från beslut/i)).toBeVisible({ timeout: 15_000 });
+  await expect(verdict.getByText(/Dömt belopp/i)).toBeVisible();
+  await verdict.getByRole("button", { name: /^Skapa faktura$/ }).click();
+  await expect(verdict).toBeHidden({ timeout: 20_000 });
+
+  // Resultatet: en NY faktura på ärendet, och kostnadsräkningen är inte längre
+  // i väntan.
+  await expect(async () => {
+    expect(await invoiceLinks.count()).toBeGreaterThan(invoicesBefore);
+  }).toPass({ timeout: 20_000 });
+  await expect(page.getByText(/Väntar på dom/i)).toHaveCount(0);
+});

--- a/test/unit/lib/shared/billing-flow.test.ts
+++ b/test/unit/lib/shared/billing-flow.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect } from "vitest-compat";
 import {
-  BILLING_FLOWS, availableActions, currentPhase, pendingBannerFor,
+  BILLING_FLOWS, availableActions, currentPhase,
   canBillingTransition, assertBillingTransition, type FlowRun,
 } from "@/lib/shared/billing-flow";
 
@@ -67,21 +67,6 @@ describe("availableActions — statemaskinens kanter", () => {
   it("SETTLE-action i rättshjälp öppnar settlement-dialogen", () => {
     const settle = availableActions({ paymentMethod: "RATTSHJALP" }, []).find((a) => a.type === "SETTLE");
     expect(settle?.dialog).toBe("settlement");
-  });
-});
-
-describe("pendingBannerFor — dom-banner-routing", () => {
-  it("rättshjälp i VANTAR_DOM → settlement-banner", () => {
-    expect(pendingBannerFor({ paymentMethod: "RATTSHJALP" }, [pendingKr])).toMatchObject({ dialog: "settlement" });
-  });
-
-  it("offentligt uppdrag i VANTAR_DOM → verdict-banner (annan modell)", () => {
-    expect(pendingBannerFor({ paymentMethod: "OFFENTLIGT_UPPDRAG" }, [pendingKr])).toMatchObject({ dialog: "verdict" });
-  });
-
-  it("ingen banner utan väntande kostnadsräkning", () => {
-    expect(pendingBannerFor({ paymentMethod: "RATTSHJALP" }, [])).toBeNull();
-    expect(pendingBannerFor({ paymentMethod: "PRIVAT" }, [])).toBeNull();
   });
 });
 

--- a/tooling/config/playwright-demo.config.ts
+++ b/tooling/config/playwright-demo.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
   // utanför tills de slutat hårdkoda seed-id:n; de slår upp sina fixtures i
   // `demo-seed.json` via `fetchDemoSeed`. Lägg inte till en spec här som pekar
   // på ett id den inte slagit upp — det var precis så de tystnade förra gången.
-  testMatch: /(demo-invoice-document|demo-login|demo-smoke|kebab-verify|matters-employee-filter)\.spec\.ts$/,
+  testMatch: /(demo-invoice-document|demo-kostnadsrakning-verdict|demo-login|demo-smoke|kebab-verify|matters-employee-filter)\.spec\.ts$/,
   timeout: 90_000,
   expect: { timeout: 15_000 },
   fullyParallel: false,


### PR DESCRIPTION
Stänger #996.

## Vägvalet: ta bort ytan

`pendingBannerFor` var exporterad och hade tre egna enhetstester — men **ingen komponent anropade den**. Bannern fanns inte i UI:t.

Avgörande för beslutet var att etiketten den bar beskriver en **äldre ett-stegs-modell**:

```ts
pendingBanner: { phase: "VANTAR_DOM", dialog: "verdict", label: "Ange dom + prutning" },
```

En knapp i väntefasen som öppnar verdict-dialogen och sätter prutningen. Men `setVerdict` tar inget belopp sedan #828 — dialogens egen doc-kommentar säger det rakt ut: *"Domstolens beslut … registreras redan på kostnadsräkningen (RecordBeslutDialog). Här bekräftar advokaten bara att fakturan ska skapas."*

Så bannern kunde inte fungera om den renderades. Den var inte en saknad yta utan en kvarglömd.

## Var flödet faktiskt bor

| Modell | Nivå | Renderas av |
|---|---|---|
| `billing-flow.ts` | fas per `paymentMethod` | panelens action-meny |
| `kostnadsrakning-flow.ts` | status per KR-körning | KR-kortet |

KR-kortet gör det i **två steg**: `INSKICKAD` → "Registrera beslut" (dömt belopp + ev. prutning) → `BESLUTAD` → "Skapa faktura" → verdict-dialogen (offentligt) eller slutregleringen (rättshjälp).

Faserna går inte ens att lägga ihop: `currentPhase` lämnar `VANTAR_DOM` i samma stund som beslutet registreras, alltså precis när fakturaknappen dyker upp. Bannern och kortet hörde till olika ögonblick.

`billing-flow.ts` slutar därför vid fasen — det vet att ärendet *väntar* på dom, inte hur väntan avvecklas. Det står nu i filens doc-kommentar, så nästa läsare inte lägger tillbaka en parallell modell.

Jag lät bli att göra det motsatta — att låta `pendingBannerFor` driva KR-kortets routing i stället för dess `paymentMethod`-ternär. Det är ett enda anropsställe; en datatabell läst av en plats är indirektion utan vinst.

## E2E:n körs nu skarpt

`demo-invoice-document.spec.ts` hade kopierat den aldrig-renderade etiketten till en villkorad gren:

```ts
const verdictBtn = page.getByRole("button", { name: /Ange dom \+ prutning/i });
if (await verdictBtn.count()) { … }   // 0 → hoppas tyst över, varje körning
```

Grenen är borta. Flödet körs i stället **ovillkorligt** i en egen spec, `demo-kostnadsrakning-verdict.spec.ts`, mot det ärende som väntar på dom — uppslaget ur `demo-seed.json` via en ny `matterAwaitingVerdict`, inte hårdkodat: vilket brottmål som står i väntan bestäms av scenariodispatchern (#882), och flyttas det hör ändringen hemma där.

Tre saker gör specen svår att lura:

1. **Fakturaknappen får INTE finnas före beslutet.** Annars kunde ett-stegs-modellen smyga tillbaka utan att något sa till.
2. **Antalet fakturor på ärendet ska ÖKA** — mätt före flödet. En ren "finns det en faktura-länk?"-assertion hade kunnat passera på något som redan låg där.
3. **Verifierat sensitiv:** jag tog bort beslutssteget och såg den falla, innan jag lade tillbaka det.

Specen är tillagd i `playwright-demo.config.ts:testMatch` — det var att ligga utanför configen som lät fixturerna i #972 tystna.

## Grindar

`typecheck` ✓ · `lint` ✓ · `lint:complexity-strict` ✓ · `knip` ✓ · `deps:check` ✓ (1119 moduler) · `jscpd` ✓ · `build:demo` ✓ · **`e2e:demo` 32/32** ✓ (31 + den nya) · `test/unit/lib/shared` 214/214 ✓

`test/unit/app` visar 21 fel i katalogkörning — identiska med `main` (känt mock-läckage, #92); verifierat genom att stasha ändringen.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_