### PR TITLE
feat(demo): kostnadsräkningens alla livscykel-lägen i demodatan

### DIFF
--- a/test/e2e/_demo-test.ts
+++ b/test/e2e/_demo-test.ts
@@ -107,18 +107,21 @@ export interface DemoSeed {
   timeEntries: Array<{ id: string; matterId: string; description: string }>;
   expenses: Array<{ id: string; matterId: string; description: string }>;
   paymentPlans: Array<{ id: string; invoiceId: string; status: string }>;
-  billingRuns: Array<{ id: string; matterId: string; type: string; status: string }>;
+  billingRuns: Array<{ id: string; matterId: string; type: string; status: string; kostnadsrakningStatus?: string }>;
 }
 
+/** Kostnadsräkningens livscykel-status (#828). */
+export type KrStatus = "INSKICKAD" | "BESLUTAD" | "OVERKLAGAD" | "FAKTURERAD";
+
 /**
- * Ärendet vars kostnadsräkning väntar på domstolens beslut (#996). Slås upp i
- * datan i stället för att hårdkodas: VILKET brottmål som står kvar i väntan
- * bestäms av scenariodispatchern (#882), och flyttas den dit hör ändringen
- * hemma där — inte i en spec.
+ * Ärendet vars kostnadsräkning står i `status` (#996/#828). Slås upp i datan i
+ * stället för att hårdkodas: VILKET brottmål som vilar i vilket läge bestäms av
+ * scenariodispatchern (#882), och flyttas det hör ändringen hemma där — inte i
+ * en spec. Saknas läget är det demodatan som tappat det, och felet säger så.
  */
-export function matterAwaitingVerdict(seed: DemoSeed): string {
-  const hit = seed.billingRuns.find((r) => r.type === "KOSTNADSRAKNING" && r.status === "PENDING_VERDICT");
-  if (!hit) throw new Error("seeden saknar kostnadsräkning i PENDING_VERDICT — demons väntetillstånd är borta igen (#882)");
+export function matterWithKrStatus(seed: DemoSeed, status: KrStatus): string {
+  const hit = seed.billingRuns.find((r) => r.type === "KOSTNADSRAKNING" && r.kostnadsrakningStatus === status);
+  if (!hit) throw new Error(`seeden saknar kostnadsräkning i ${status} — demons livscykel-lägen är ofullständiga (#828 steg 6)`);
   return hit.matterId;
 }
 

--- a/test/e2e/demo-kostnadsrakning-verdict.spec.ts
+++ b/test/e2e/demo-kostnadsrakning-verdict.spec.ts
@@ -18,7 +18,7 @@
  * av scenariodispatchern (#882), inte av den här filen.
  */
 
-import { DEMO_BASE_URL, fetchDemoSeed, matterAwaitingVerdict, seedDemoLogin, test, expect } from "./_demo-test";
+import { DEMO_BASE_URL, fetchDemoSeed, matterWithKrStatus, seedDemoLogin, test, expect } from "./_demo-test";
 
 /** Belopp domstolen dömer ut respektive prutar, i kronor. */
 const AWARDED_KR = 12_000;
@@ -29,7 +29,7 @@ test("kostnadsräkning som väntar på dom: registrera beslut → skapa faktura"
   await seedDemoLogin(page, base);
 
   const seed = await fetchDemoSeed(page, base);
-  const matterId = matterAwaitingVerdict(seed);
+  const matterId = matterWithKrStatus(seed, "INSKICKAD");
 
   await page.goto(`${base}/matters/${matterId}/`, { waitUntil: "load" });
   // KR-kortet visar väntetillståndet — det som saknades i demon före #882.
@@ -70,4 +70,36 @@ test("kostnadsräkning som väntar på dom: registrera beslut → skapa faktura"
     expect(await invoiceLinks.count()).toBeGreaterThan(invoicesBefore);
   }).toPass({ timeout: 20_000 });
   await expect(page.getByText(/Väntar på dom/i)).toHaveCount(0);
+});
+
+/**
+ * Överklagandespåret (#828 steg 6). Ärendet vilar i ÖVERKLAGAD, så knappen
+ * "Registrera hovrättens beslut" — den enda vägen till ett SLUTGILTIGT beslut —
+ * går att köra. Före det här fanns spåret bara i koden: ingen KR i demon lämnade
+ * någonsin BESLUTAD, så varken överklagandet eller hovrättsbeslutet syntes.
+ */
+test("överklagad kostnadsräkning: hovrättens beslut är slutgiltigt", async ({ page, baseURL }) => {
+  const base = (baseURL ?? DEMO_BASE_URL).replace(/\/+$/, "");
+  await seedDemoLogin(page, base);
+
+  const seed = await fetchDemoSeed(page, base);
+  const matterId = matterWithKrStatus(seed, "OVERKLAGAD");
+
+  await page.goto(`${base}/matters/${matterId}/`, { waitUntil: "load" });
+  // Ett överklagande är inte avgjort: varken fakturering eller ett nytt
+  // överklagande ska erbjudas medan hovrätten har målet.
+  await expect(page.getByRole("button", { name: /^Registrera hovrättens beslut$/ })).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByRole("button", { name: /^Skapa faktura$/ })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: /^Överklaga prutning$/ })).toHaveCount(0);
+
+  await page.getByRole("button", { name: /^Registrera hovrättens beslut$/ }).click();
+  const dialog = page.getByRole("dialog");
+  await dialog.getByLabel(/Dömt belopp/i).fill(String(AWARDED_KR));
+  await dialog.getByRole("button", { name: /^Spara beslut$/ }).click();
+  await expect(dialog).toBeHidden({ timeout: 15_000 });
+
+  // Hovrättens beslut är slutgiltigt: fakturering öppnas, och det finns inget
+  // mer att överklaga.
+  await expect(page.getByRole("button", { name: /^Skapa faktura$/ })).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByRole("button", { name: /^Överklaga prutning$/ })).toHaveCount(0);
 });

--- a/test/scripts/simulate-orchestrate.test.ts
+++ b/test/scripts/simulate-orchestrate.test.ts
@@ -121,23 +121,27 @@ describe("runSimulation (#880 integration)", () => {
     expect(simRes.folders, "mappar skapade").toBeGreaterThan(0);
     expect(simRes.dispatches, "utskick registrerade").toBeGreaterThan(0);
 
-    // Ett ärende med domstolsdokument ska ha Domstol/ med Domar under sig, och
-    // inga dokument kvar i roten.
+    // Trädet ska vara NÄSTLAT någonstans i demon (t.ex. Domstol/Domar) — annars
+    // ser mapphanteringen ut som en platt lista. Ärendet letas fram i stället för
+    // att pekas ut: vilka handlingar ett enskilt ärende får beror på var i sin
+    // livscykel det vilar (#828 steg 6), och det hör hemma i scenariot.
     const matters = (await c.matter.list({})).matters as Any[];
-    const withCourt = matters.find((m: Any) => String(m.paymentMethod) === "OFFENTLIGT_UPPDRAG") ?? matters[0];
-    const tree = await c.document.tree({ matterId: withCourt.id });
-    const folders = tree.folders as Array<{ id: string; name: string; parentId: string | null }>;
-    expect(folders.length, "ärendet har mappar").toBeGreaterThan(0);
-    const nested = folders.find((f) => f.parentId !== null);
-    expect(nested, "minst en nästlad mapp — annars ser trädet ut som en platt lista").toBeTruthy();
-    expect(folders.some((f) => f.id === nested?.parentId), "den nästlade mappens förälder finns").toBe(true);
+    const trees = await Promise.all(matters.map(async (m: Any) => ({
+      matterId: String(m.id), tree: await c.document.tree({ matterId: m.id }),
+    })));
+    type Folder = { id: string; name: string; parentId: string | null };
+    const nestedHit = trees
+      .map((t) => ({ ...t, folders: t.tree.folders as Folder[] }))
+      .find((t) => t.folders.some((f) => f.parentId !== null));
+    expect(nestedHit, "något ärende har en nästlad mapp").toBeTruthy();
+    const nested = nestedHit!.folders.find((f) => f.parentId !== null)!;
+    expect(nestedHit!.folders.some((f) => f.id === nested.parentId), "den nästlade mappens förälder finns").toBe(true);
 
-    // Varje dokument har en mapp — och rot-listningen är följaktligen tom.
-    const all = tree.documents as Array<{ folderId: string | null }>;
-    expect(all.length, "ärendet har dokument").toBeGreaterThan(0);
-    expect(all.every((d) => d.folderId !== null), "inget dokument ligger kvar i roten").toBe(true);
-    const rootListing = await c.document.list({ matterId: withCourt.id, folderId: null, pageSize: 100 });
-    expect((rootListing.documents ?? rootListing).length, "rot-mappen är tom").toBe(0);
+    // Och INGET dokument ligger kvar i roten — i något ärende.
+    const loose = trees.flatMap((t) => (t.tree.documents as Array<{ folderId: string | null }>)
+      .filter((d) => d.folderId === null));
+    expect(trees.some((t) => (t.tree.documents as unknown[]).length > 0), "demon har dokument").toBe(true);
+    expect(loose, "inget dokument ligger kvar i roten").toHaveLength(0);
   });
 
   /**
@@ -210,5 +214,30 @@ describe("runSimulation (#880 integration)", () => {
     expect(kr.some((r) => r.status === "PENDING_VERDICT"), "en KR väntar på dom").toBe(true);
     // …och de övriga har fått sitt beslut, så båda tillstånden syns.
     expect(kr.some((r) => r.status !== "PENDING_VERDICT"), "en KR är avgjord").toBe(true);
+  });
+
+  /**
+   * #828 steg 6: demodata i ALLA lägen. Kostnadsräkningens state-maskin har fyra
+   * statusar, och panelen har en egen vy per status — men demon visade bara två
+   * (inskickad och fakturerad). Överklagandespåret fanns bara i koden: varken
+   * "Överklaga prutning" eller "Registrera hovrättens beslut" gick att se.
+   *
+   * Testet påstår om DEMONS DATA att varje status finns som ett VILANDE
+   * tillstånd. Att kunna klicka sig fram till dem räcker inte — då syns de
+   * först efter att man ändrat data som ändå inte sparas.
+   */
+  it("kostnadsräkningens alla fyra statusar finns i demon samtidigt", async () => {
+    const { c } = await simulateDemo();
+    const runs = (await c.billingRun.list({})).runs as Any[];
+    const kr = runs.filter((r) => r.type === "KOSTNADSRAKNING");
+    const statuses = new Set(kr.map((r) => r.kostnadsrakningStatus));
+    for (const s of ["INSKICKAD", "BESLUTAD", "OVERKLAGAD", "FAKTURERAD"]) {
+      expect(statuses.has(s), `KR-status ${s} saknas i demon`).toBe(true);
+    }
+    // Den beslutade ska bära domstolens prutning — annars går det inte att se
+    // VARFÖR man skulle överklaga, och prutningen är hela poängen med spåret.
+    const beslutad = kr.find((r) => r.kostnadsrakningStatus === "BESLUTAD");
+    expect(beslutad?.prutningOre, "beslutet bär en registrerad prutning").toBeLessThan(0);
+    expect(beslutad?.awardedOre, "…och ett dömt belopp").toBeGreaterThan(0);
   });
 });

--- a/tooling/demo-generator/simulate/events.ts
+++ b/tooling/demo-generator/simulate/events.ts
@@ -36,6 +36,12 @@ export type SimEvent =
    * om på det nedsatta beloppet och mellanskillnaden bokas som en förlust (#936).
    */
   | { kind: "beslut"; dayOffset: number; reducedByBips?: number }
+  /**
+   * Överklaga domstolens prutning (#828) — `appealKostnadsrakning`. BESLUTAD →
+   * ÖVERKLAGAD; hovrättens beslut registreras sedan på SAMMA körning med ett
+   * nytt `beslut`-event (servern väljer övergången ur KR:ns status).
+   */
+  | { kind: "overklaga"; dayOffset: number }
   /** Skapa domstolsfakturan EFTER beslut (offentligt uppdrag) — setVerdict. */
   | { kind: "verdict"; dayOffset: number }
   /** Slutreglering (rättshjälp/-skydd) — settleCoverage (→ klient FINAL/CREDIT + betalare). */
@@ -96,6 +102,28 @@ export interface SimMatter {
    *  påhittad adress i demodatat. */
   clientEmail?: string | undefined;
 }
+
+/** Rollen varje part länkas in med. Fast mappning — scenariot väljer bara DAGEN. */
+const PARTY_ROLE = {
+  klient: "KLIENT", motpart: "MOTPART", motpartsombud: "MOTPARTSOMBUD", domstol: "DOMSTOL",
+} as const satisfies Record<keyof Parties, MatterRole>;
+
+/**
+ * `party`-events för de roller ärendet faktiskt har, på de dagar scenariot
+ * anger. Fanns förr som fyra identiska `if`-rader i fem scenariofiler — och
+ * kostade dessutom komplexitetsbudget i varje.
+ */
+export function partyEvents(parties: Parties, days: Partial<Record<keyof Parties, number>>): SimEvent[] {
+  return Object.entries(days).flatMap(([key, dayOffset]) => {
+    const contactId = parties[key as keyof Parties];
+    return contactId === undefined
+      ? []
+      : [{ kind: "party" as const, dayOffset, contactId, role: PARTY_ROLE[key as keyof Parties] }];
+  });
+}
+
+/** Vanligaste upplägget: klienten dag 0, övriga när ärendet tagit form. */
+export const STANDARD_PARTY_DAYS = { klient: 0, motpart: 2, motpartsombud: 2, domstol: 2 } as const;
 
 /** Parter att länka in via `party`-events (översatta UUID:n) — ur seedens
  *  matterContacts, så klient/motpart/ombud/domstol får riktiga kontakter. */

--- a/tooling/demo-generator/simulate/fake-content.ts
+++ b/tooling/demo-generator/simulate/fake-content.ts
@@ -108,6 +108,21 @@ export const DOC_TEMPLATES: Record<string, DocTemplate> = {
       "Frist för överklagande: senast den 2026-06-02.",
     ].join("\n"),
   },
+  // Kostnadsräkningens överklagandespår (#828 steg 6). Utan de här två ligger
+  // ett ärende i BESLUTAD/ÖVERKLAGAD utan en enda handling som förklarar varför —
+  // panelen visar en prutning och en pågående överklagan, akten är tom.
+  arvodesbeslut: {
+    documentType: "Beslut", direction: "INKOMMANDE", recipient: "DOMSTOL",
+    title: "Beslut om ersättning till offentlig försvarare",
+    summary: "Tingsrätten sätter ned det yrkade arvodet. Beslutet får överklagas särskilt.",
+    subFolder: "Beslut",
+  },
+  overklagandeInlaga: {
+    documentType: "Inlaga", direction: "UTGAENDE", recipient: "DOMSTOL",
+    title: "Överklagande av arvodesbeslut",
+    summary: "Överklagande till hovrätten av tingsrättens nedsättning av arvodet, med begäran om full ersättning.",
+    subFolder: "Överklaganden",
+  },
   beslutRattshjalp: {
     documentType: "Beslut", direction: "INKOMMANDE", recipient: "MYNDIGHET",
     title: "Beslut om rättshjälp", summary: "Rättshjälpsmyndighetens beslut om rättshjälpsavgiftens procentsats för ärendet.",

--- a/tooling/demo-generator/simulate/runner.ts
+++ b/tooling/demo-generator/simulate/runner.ts
@@ -216,7 +216,19 @@ async function hBeslut(ctx: RunCtx, _m: SimMatter, e: Any, _iso: string, st: Sim
   const awardedOre = bips > 0
     ? Math.round((st.krWorkValueOre * (10000 - bips)) / 10000)
     : st.krWorkValueOre;
-  await ctx.c.billingRun.recordKostnadsrakningBeslut({ billingRunId: st.krRunId, awardedOre });
+  // Nedsättningen registreras också SOM prutning på körningen (#828) — det är
+  // det fältet KR-kortet visar, och det appens egen beslutsdialog skickar.
+  // Utan det syntes en prutad kostnadsräkning som obeskuren i panelen.
+  await ctx.c.billingRun.recordKostnadsrakningBeslut({
+    billingRunId: st.krRunId, awardedOre,
+    ...(bips > 0 ? { prutningOre: awardedOre - st.krWorkValueOre } : {}),
+  });
+}
+
+/** Överklaga prutningen (#828): BESLUTAD → ÖVERKLAGAD på samma körning. */
+async function hOverklaga(ctx: RunCtx, _m: SimMatter, _e: Any, _iso: string, st: SimState): Promise<void> {
+  if (!st.krRunId) return;
+  await ctx.c.billingRun.appealKostnadsrakning({ billingRunId: st.krRunId });
 }
 
 async function hVerdict(ctx: RunCtx, _m: SimMatter, _e: Any, _iso: string, st: SimState): Promise<void> {
@@ -357,7 +369,7 @@ async function hWriteOff(ctx: RunCtx, _m: SimMatter, e: Any, iso: string, st: Si
 /** kind → handler. Håller runnern platt (undviker en stor switch = hög komplexitet). */
 const HANDLERS: Record<SimEvent["kind"], (ctx: RunCtx, m: SimMatter, e: Any, iso: string, st: SimState) => Promise<void>> = {
   party: hParty, time: hTime, note: hNote, expense: hExpense, doc: hDoc, radgivning: hRadgivning,
-  acconto: hAcconto, rateChange: hRateChange, kostnadsrakning: hKostnadsrakning, beslut: hBeslut, verdict: hVerdict, settle: hSettle, insurerPruning: hInsurerPruning, final: hFinal, payment: hPayment,
+  acconto: hAcconto, rateChange: hRateChange, kostnadsrakning: hKostnadsrakning, beslut: hBeslut, overklaga: hOverklaga, verdict: hVerdict, settle: hSettle, insurerPruning: hInsurerPruning, final: hFinal, payment: hPayment,
   paymentPlan: hPaymentPlan, writeOff: hWriteOff,
 };
 

--- a/tooling/demo-generator/simulate/scenarios/index.ts
+++ b/tooling/demo-generator/simulate/scenarios/index.ts
@@ -3,12 +3,35 @@
  */
 
 import type { Parties, SimEvent, SimMatter } from "../events";
-import { buildOffentligtScenario } from "./offentligt";
+import { buildOffentligtScenario, type OffentligtOpts } from "./offentligt";
 import { buildPrivatScenario } from "./privat";
 import { buildRattshjalpScenario } from "./rattshjalp";
 import { buildRattshjalpArsskifteScenario } from "./rattshjalp-arsskifte";
 import { buildRattsskyddScenario } from "./rattsskydd";
 import { buildRattsskyddPositivtScenario } from "./rattsskydd-positivt";
+
+/**
+ * Var varje brottmål vilar i kostnadsräkningens livscykel (#828 steg 6). Ett
+ * ärende per tillstånd, så demon visar alla fyra samtidigt i st.f. att bara
+ * kunna nås genom att klicka sig framåt:
+ *
+ * - **2026-0017** INSKICKAD — väntar på dom (#882). `demo-kostnadsrakning-
+ *   verdict.spec.ts` kör beslut → faktura härifrån, uppslaget ur seeden.
+ * - **2026-0016** BESLUTAD — beslutat men ofakturerat, med en prutning att
+ *   antingen acceptera (Skapa faktura) eller överklaga.
+ * - **2026-0019** ÖVERKLAGAD — prutningen överklagad, väntar på hovrätten.
+ * - **2026-0018** FAKTURERAD — hela kedjan gången; det ärende
+ *   `demo-invoice-document.spec.ts` hämtar sitt fakturadokument ur.
+ */
+const OFFENTLIGT_STOPS: Record<string, OffentligtOpts> = {
+  "2026-0016": { stopAfter: "beslut", reducedByBips: 1000 },
+  "2026-0017": { stopAfter: "kostnadsrakning" },
+  "2026-0019": { stopAfter: "overklaga", reducedByBips: 2500 },
+};
+
+function offentligtOpts(matterNumber: string | undefined): OffentligtOpts {
+  return (matterNumber && OFFENTLIGT_STOPS[matterNumber]) || {};
+}
 
 export function buildScenario(matter: SimMatter, parties: Parties, index: number): SimEvent[] {
   switch (matter.paymentMethod) {
@@ -24,14 +47,8 @@ export function buildScenario(matter: SimMatter, parties: Parties, index: number
     case "RATTSSKYDD": return matter.matterNumber === "2026-0021"
       ? buildRattsskyddPositivtScenario(parties)
       : buildRattsskyddScenario(parties);
-    // 2026-0017 (omfattande utredning Davidsson, hovrätten) stannar efter
-    // kostnadsräkningen: demon behöver ETT ärende i "väntar på dom" för att
-    // fakturapanelens väntetillstånd ska synas alls (#882). De övriga två får sitt
-    // beslut, så båda sidor av flödet finns. Just 0017 och inte 0018 — Carlsson-
-    // ärendet är det `demo-invoice-document.spec.ts` kör hela kedjan KR → beslut →
-    // faktura → fakturadokument på.
     case "OFFENTLIGT_UPPDRAG":
-      return buildOffentligtScenario(parties, { awaitVerdict: matter.matterNumber === "2026-0017" });
+      return buildOffentligtScenario(parties, offentligtOpts(matter.matterNumber));
     default: return buildPrivatScenario(parties, index, matter.status === "ACTIVE");
   }
 }

--- a/tooling/demo-generator/simulate/scenarios/offentligt.ts
+++ b/tooling/demo-generator/simulate/scenarios/offentligt.ts
@@ -3,21 +3,36 @@
  * förundersökning → klientmöte + huvudförhandling → kostnadsräkning till domstol →
  * domstolens beslut → domstolsfaktura (setVerdict). Taxa vs frångång styrs av
  * matterns fält; flödet (KR → beslut → verdict) är detsamma.
+ *
+ * Kostnadsräkningens livscykel (#828) har fyra tillstånd, och demon ska visa dem
+ * alla SAMTIDIGT — annars går de bara att nå genom att själv klicka sig framåt,
+ * och panelens vyer för dem syns aldrig i en färsk demo. Därför `stopAfter`:
+ * varje brottmål vilar på sin punkt i kedjan.
  */
 
+import { partyEvents } from "../events";
 import type { Parties, SimEvent } from "../events";
 
+/**
+ * Var scenariot ska STANNA — vilket KR-tillstånd ärendet vilar i (#828 steg 6).
+ *
+ * | värde | KR-status | vad panelen visar |
+ * |---|---|---|
+ * | `kostnadsrakning` | INSKICKAD | "Väntar på dom" + "Registrera beslut" |
+ * | `beslut` | BESLUTAD | "Skapa faktura" + "Överklaga prutning" |
+ * | `overklaga` | ÖVERKLAGAD | "Registrera hovrättens beslut" |
+ * | *(utelämnad)* | FAKTURERAD | domstolsfakturan med sitt dokument |
+ */
+export type OffentligtStop = "kostnadsrakning" | "beslut" | "overklaga";
+
 export interface OffentligtOpts {
+  stopAfter?: OffentligtStop;
   /**
-   * Stanna EFTER kostnadsräkningen: ingen `beslut`, ingen `verdict`. Ärendet
-   * blir kvar i "kostnadsräkning väntar på dom" — fakturapanelens tillstånd
-   * mellan inlämnad KR och domstolens beslut (#882).
-   *
-   * Utan detta får varje offentligt uppdrag beslut samma vecka och demon visar
-   * aldrig väntetillståndet, trots att panelen har en egen vy för det. Det låg
-   * förr i `populate-billing.ts`; simuleringen tog aldrig över det.
+   * Domstolens nedsättning av det yrkade beloppet (bips). Registreras som
+   * prutning PÅ kostnadsräkningen — det är den som gör ett överklagande
+   * begripligt: man överklagar prutningen, inte beslutet i stort.
    */
-  awaitVerdict?: boolean;
+  reducedByBips?: number;
 }
 
 export function buildOffentligtScenario(parties: Parties, opts: OffentligtOpts = {}): SimEvent[] {
@@ -25,8 +40,7 @@ export function buildOffentligtScenario(parties: Parties, opts: OffentligtOpts =
     { kind: "note", dayOffset: 0, text: "Förordnad som offentlig försvarare." },
     { kind: "time", dayOffset: 1, minutes: 120, description: "Genomgång av förundersökningsprotokoll" },
   ];
-  if (parties.klient) ev.push({ kind: "party", dayOffset: 0, contactId: parties.klient, role: "KLIENT" });
-  if (parties.domstol) ev.push({ kind: "party", dayOffset: 2, contactId: parties.domstol, role: "DOMSTOL" });
+  ev.push(...partyEvents(parties, { klient: 0, domstol: 2 }));
   ev.push(
     { kind: "expense", dayOffset: 6, amountOre: 38_000, description: "Reskostnad häktesbesök" },
     { kind: "doc", dayOffset: 4, template: "brevTillOmbud" },
@@ -34,9 +48,27 @@ export function buildOffentligtScenario(parties: Parties, opts: OffentligtOpts =
     { kind: "time", dayOffset: 20, minutes: 120, description: "Huvudförhandling i tingsrätten" },
     { kind: "kostnadsrakning", dayOffset: 22 },
   );
-  if (opts.awaitVerdict) return ev;
+  if (opts.stopAfter === "kostnadsrakning") return ev;
+
+  ev.push({
+    kind: "beslut", dayOffset: 30,
+    ...(opts.reducedByBips ? { reducedByBips: opts.reducedByBips } : {}),
+  });
+  // Nedsättningen kommer med ett beslut i akten — annars visar panelen en
+  // prutning som ingen handling förklarar.
+  if (opts.reducedByBips) ev.push({ kind: "doc", dayOffset: 30, template: "arvodesbeslut" });
+  if (opts.stopAfter === "beslut") return ev;
+
+  if (opts.stopAfter === "overklaga") {
+    ev.push(
+      { kind: "note", dayOffset: 33, text: "Tingsrättens nedsättning av arvodet överklagas till hovrätten." },
+      { kind: "doc", dayOffset: 33, template: "overklagandeInlaga" },
+      { kind: "overklaga", dayOffset: 33 },
+    );
+    return ev;
+  }
+
   ev.push(
-    { kind: "beslut", dayOffset: 30 },
     { kind: "doc", dayOffset: 31, template: "dom" },
     { kind: "verdict", dayOffset: 32 },
   );

--- a/tooling/demo-generator/simulate/scenarios/privat.ts
+++ b/tooling/demo-generator/simulate/scenarios/privat.ts
@@ -9,7 +9,7 @@
  * `computeInvoiceLedger` räknar med båda.
  */
 
-import type { MatterRole } from "@/lib/shared/schemas/enums";
+import { partyEvents } from "../events";
 import type { Parties, SimEvent } from "../events";
 
 /**
@@ -51,23 +51,6 @@ const FRESH_UNBILLED: ReadonlyArray<{ dayOffset: number; minutes: number; descri
   { dayOffset: 55, minutes: 90, description: "Granskning inkommande material" },
 ];
 
-/** När varje part länkas in — roll → dag. Ett par per roll seeden faktiskt har. */
-const PARTY_DAYS: ReadonlyArray<{ key: keyof Parties; role: MatterRole; dayOffset: number }> = [
-  { key: "klient", role: "KLIENT", dayOffset: 0 },
-  { key: "motpart", role: "MOTPART", dayOffset: 2 },
-  { key: "motpartsombud", role: "MOTPARTSOMBUD", dayOffset: 2 },
-  { key: "domstol", role: "DOMSTOL", dayOffset: 3 },
-];
-
-/** Parts-events för de roller ärendet har. Datadrivet i st.f. fyra `if`-rader —
- *  scenariot ligger annars över komplexitetstaket (8). */
-function partyEvents(parties: Parties): SimEvent[] {
-  return PARTY_DAYS.flatMap(({ key, role, dayOffset }) => {
-    const contactId = parties[key];
-    return contactId ? [{ kind: "party" as const, dayOffset, contactId, role }] : [];
-  });
-}
-
 /**
  * `active` = ärendet är öppet i seeden. Bara då läggs ofakturerat arbete på:
  * upparbetad tid på ett avslutat ärende vore inte demodata utan en bugg —
@@ -79,7 +62,7 @@ export function buildPrivatScenario(parties: Parties, index: number, active = fa
     { kind: "time", dayOffset: 0, minutes: 90, description: "Inledande rådgivning och uppdragsbekräftelse" },
     { kind: "doc", dayOffset: 1, template: "fullmakt" },
   ];
-  ev.push(...partyEvents(parties));
+  ev.push(...partyEvents(parties, { klient: 0, motpart: 2, motpartsombud: 2, domstol: 3 }));
   ev.push(
     { kind: "doc", dayOffset: 4, template: parties.domstol ? "stamningsansokan" : "brevTillOmbud" },
     { kind: "time", dayOffset: 10, minutes: 120, description: "Utredning och skriftväxling" },

--- a/tooling/demo-generator/simulate/scenarios/rattshjalp-arsskifte.ts
+++ b/tooling/demo-generator/simulate/scenarios/rattshjalp-arsskifte.ts
@@ -11,6 +11,7 @@
  * Dag 0 ≈ nov 2025; årsgränsen (31 dec 2025) infaller runt dag 60.
  */
 
+import { partyEvents, STANDARD_PARTY_DAYS } from "../events";
 import type { Parties, SimEvent } from "../events";
 
 export function buildRattshjalpArsskifteScenario(parties: Parties): SimEvent[] {
@@ -20,10 +21,7 @@ export function buildRattshjalpArsskifteScenario(parties: Parties): SimEvent[] {
     { kind: "radgivning", dayOffset: 0 },
     { kind: "doc", dayOffset: 1, template: "fullmakt" },
   ];
-  if (parties.klient) ev.push({ kind: "party", dayOffset: 0, contactId: parties.klient, role: "KLIENT" });
-  if (parties.motpart) ev.push({ kind: "party", dayOffset: 2, contactId: parties.motpart, role: "MOTPART" });
-  if (parties.motpartsombud) ev.push({ kind: "party", dayOffset: 2, contactId: parties.motpartsombud, role: "MOTPARTSOMBUD" });
-  if (parties.domstol) ev.push({ kind: "party", dayOffset: 2, contactId: parties.domstol, role: "DOMSTOL" });
+  ev.push(...partyEvents(parties, STANDARD_PARTY_DAYS));
 
   ev.push(
     // Normalflödet: klienten söker FÖRST rättsskydd hos försäkringsbolaget; först

--- a/tooling/demo-generator/simulate/scenarios/rattshjalp.ts
+++ b/tooling/demo-generator/simulate/scenarios/rattshjalp.ts
@@ -8,6 +8,7 @@
  * Avslutas med kostnadsräkning → beslut → slutreglering (→ kredit vid överfakturering).
  */
 
+import { partyEvents, STANDARD_PARTY_DAYS } from "../events";
 import type { Parties, SimEvent } from "../events";
 
 export interface RattshjalpScenarioOpts {
@@ -29,10 +30,7 @@ export function buildRattshjalpScenario(parties: Parties, opts: RattshjalpScenar
     { kind: "radgivning", dayOffset: 0 },
     { kind: "doc", dayOffset: 1, template: "fullmakt" },
   ];
-  if (parties.klient) ev.push({ kind: "party", dayOffset: 0, contactId: parties.klient, role: "KLIENT" });
-  if (parties.motpart) ev.push({ kind: "party", dayOffset: 2, contactId: parties.motpart, role: "MOTPART" });
-  if (parties.motpartsombud) ev.push({ kind: "party", dayOffset: 2, contactId: parties.motpartsombud, role: "MOTPARTSOMBUD" });
-  if (parties.domstol) ev.push({ kind: "party", dayOffset: 2, contactId: parties.domstol, role: "DOMSTOL" });
+  ev.push(...partyEvents(parties, STANDARD_PARTY_DAYS));
 
   ev.push(
     // Utlägg i ärendet (ersätts av domstolen via kostnadsräkningen).

--- a/tooling/demo-generator/simulate/scenarios/rattsskydd-positivt.ts
+++ b/tooling/demo-generator/simulate/scenarios/rattsskydd-positivt.ts
@@ -17,6 +17,7 @@
  * 2025-timmarna räknas om på 2026 års normer vid slutregleringen.
  */
 
+import { partyEvents, STANDARD_PARTY_DAYS } from "../events";
 import type { Parties, SimEvent } from "../events";
 
 export function buildRattsskyddPositivtScenario(parties: Parties): SimEvent[] {
@@ -27,10 +28,7 @@ export function buildRattsskyddPositivtScenario(parties: Parties): SimEvent[] {
     { kind: "doc", dayOffset: 2, template: "rattsskyddsansokan" },
     { kind: "note", dayOffset: 2, text: "Ansökan om rättsskydd inskickad till försäkringsbolaget." },
   ];
-  if (parties.klient) ev.push({ kind: "party", dayOffset: 0, contactId: parties.klient, role: "KLIENT" });
-  if (parties.motpart) ev.push({ kind: "party", dayOffset: 2, contactId: parties.motpart, role: "MOTPART" });
-  if (parties.motpartsombud) ev.push({ kind: "party", dayOffset: 2, contactId: parties.motpartsombud, role: "MOTPARTSOMBUD" });
-  if (parties.domstol) ev.push({ kind: "party", dayOffset: 2, contactId: parties.domstol, role: "DOMSTOL" });
+  ev.push(...partyEvents(parties, STANDARD_PARTY_DAYS));
   ev.push(
     { kind: "doc", dayOffset: 10, template: "rattsskyddBeslutPositivt" },
     { kind: "note", dayOffset: 10, text: "Rättsskydd beviljat: högst 100 tim arvode, självrisk 20 % dock lägst 1 800 kr." },

--- a/tooling/demo-generator/simulate/scenarios/rattsskydd.ts
+++ b/tooling/demo-generator/simulate/scenarios/rattsskydd.ts
@@ -5,6 +5,7 @@
  * gäller domstol/rättshjälp).
  */
 
+import { partyEvents, STANDARD_PARTY_DAYS } from "../events";
 import type { Parties, SimEvent } from "../events";
 
 export function buildRattsskyddScenario(parties: Parties): SimEvent[] {
@@ -13,10 +14,7 @@ export function buildRattsskyddScenario(parties: Parties): SimEvent[] {
     { kind: "time", dayOffset: 0, minutes: 60, description: "Inledande genomgång och rättsskyddsansökan" },
     { kind: "doc", dayOffset: 1, template: "fullmakt" },
   ];
-  if (parties.klient) ev.push({ kind: "party", dayOffset: 0, contactId: parties.klient, role: "KLIENT" });
-  if (parties.motpart) ev.push({ kind: "party", dayOffset: 2, contactId: parties.motpart, role: "MOTPART" });
-  if (parties.motpartsombud) ev.push({ kind: "party", dayOffset: 2, contactId: parties.motpartsombud, role: "MOTPARTSOMBUD" });
-  if (parties.domstol) ev.push({ kind: "party", dayOffset: 2, contactId: parties.domstol, role: "DOMSTOL" });
+  ev.push(...partyEvents(parties, STANDARD_PARTY_DAYS));
   ev.push(
     { kind: "doc", dayOffset: 5, template: "brevTillOmbud" },
     { kind: "time", dayOffset: 12, minutes: 120, description: "Skriftväxling och förhandlingsförberedelse" },

--- a/tooling/scripts/seed-data.ts
+++ b/tooling/scripts/seed-data.ts
@@ -159,6 +159,11 @@ export const MATTERS: MatterSeed[] = [
   { id: "m-016-brottmal-rh", matterNumber: "2026-0016", title: "Brottmål — rattfylleri Falk", status: "ACTIVE", matterType: "Brottmål", paymentMethod: "OFFENTLIGT_UPPDRAG", description: "Förordnad offentlig försvarare vid Stockholms tingsrätt.", klientId: "c-falk", domstolId: "c-tingsratten-sthlm", createdDaysAgo: 18, isTaxeArende: true, taxaLevel: 1, taxaHuvudforhandlingMin: 95, taxaHasFTax: true },
   { id: "m-017-brottmal-omf", matterNumber: "2026-0017", title: "Brottmål — omfattande utredning Davidsson", status: "ACTIVE", matterType: "Brottmål", paymentMethod: "OFFENTLIGT_UPPDRAG", description: "Frångångstaxa pga väsentligt mer arbete (komplex bevisning).", klientId: "c-davidsson", domstolId: "c-hovratten-svea", createdDaysAgo: 35, isTaxeArende: false },
   { id: "m-018-brottmal-ekobrott", matterNumber: "2026-0018", title: "Brottmål — ekobrott Carlsson", status: "ACTIVE", matterType: "Brottmål", paymentMethod: "OFFENTLIGT_UPPDRAG", description: "Misstanke om grovt bokföringsbrott. Omfattande material — kostnadsräkning skickas till domstol istället för enligt taxa.", klientId: "c-carlsson", domstolId: "c-tingsratten-sthlm", createdDaysAgo: 28, isTaxeArende: false },
+  // Överklagandespåret (#828 steg 6): tingsrätten satte ned arvodet, nedsättningen
+  // är överklagad och ärendet väntar på hovrätten. Utan ett ärende som VILAR i det
+  // läget syns varken ÖVERKLAGAD-statusen eller knappen "Registrera hovrättens
+  // beslut" i demon — trots att hela state-maskinen finns i koden.
+  { id: "m-019-brottmal-overklagad", matterNumber: "2026-0019", title: "Brottmål — nedsatt arvode Bergman", status: "ACTIVE", matterType: "Brottmål", paymentMethod: "OFFENTLIGT_UPPDRAG", description: "Tingsrätten satte ned det yrkade arvodet med 25 %. Nedsättningen är överklagad till hovrätten.", klientId: "c-bergman", domstolId: "c-hovratten-svea", createdDaysAgo: 60, isTaxeArende: false },
   // Rättshjälp med TIDSVARIERANDE avgift (#878): klienten var arbetslös (5 %), fick
   // jobb (40 %) och blev arbetslös igen (5 %). Aconton ställdes ut vid de löpande
   // satserna; rättshjälpsmyndighetens SLUTLIGA helhetsbeslut blev 5 % → klienten


### PR DESCRIPTION
**#828 steg 6** — demodata i alla lägen. Issuen förblir öppen; steg 7 (ADR 0034) återstår.

## Läget före

KR-state-maskinen har fyra statusar och fakturapanelen en vy per status. Demon visade två:

| Status | Före | Efter |
|---|---|---|
| INSKICKAD | 1 (sedan #882) | 1 — 2026-0017 |
| BESLUTAD | **0** | 1 — 2026-0016 |
| ÖVERKLAGAD | **0** | 1 — **2026-0019** (nytt ärende) |
| FAKTURERAD | 5 | 4 — 2026-0018 m.fl. |

Ingen KR lämnade någonsin BESLUTAD, så varken **"Överklaga prutning"** eller **"Registrera hovrättens beslut"** gick att se i en färsk demo — knappar som finns i panelen och transitioner som finns i `kostnadsrakning-flow.ts`, men som ingen data nådde.

## Simuleringen

Ett nytt event: `overklaga` → `appealKostnadsrakning`. Hovrättens beslut behövde inget eget — `recordKostnadsrakningBeslut` väljer övergången ur KR:ns status, precis som appen.

`hBeslut` registrerar nu också nedsättningen **som prutning på körningen**. Det är fältet KR-kortet visar och det appens beslutsdialog skickar; utan det syns en prutad kostnadsräkning som obeskuren, och ett överklagande blir obegripligt.

Det rörde en befintlig post — 2026-0010 (rättshjälpsärendet med domstolens prutning, #936) — så jag verifierade den empiriskt i stället för att resonera mig fram: byggde demon före och efter och jämförde ärendets fakturor och dess `PRUTNING`-post. **Identiska.** Kodvägen säger samma sak: `settleCoverage` läser `awardedOre` (via `resolveAwardedOre`), aldrig `prutningOre`; det senare används bara av `setVerdict` (offentligt uppdrag) och försäkringsprutningen.

Två handlingar följer spåret — tingsrättens arvodesbeslut och överklagandeinlagan. Utan dem visar panelen en prutning och en pågående överklagan med tom akt.

## Räknare

matters 20 → 21, billingRuns 46 → 47, timeEntries 113 → 116, serviceNotes 38 → 40, documents 122, mappar 79 → 82 (`Domstol/Beslut`, `Domstol/Överklaganden`).

Kostnaden: 2026-0016 fakturerar inte längre sin kostnadsräkning → en `Dom`-handling och en domstolsfaktura mindre (invoices 45 → 44, `Dom` 2 → 1), och därmed två förslag av varje slag ur dom-mallens text. 2026-0018 kör fortfarande hela kedjan.

## Tester

- **`simulate-orchestrate.test.ts`**: ny grind som påstår om demons data att alla fyra statusarna finns *samtidigt*, och att den beslutade bär både prutning och dömt belopp. Att kunna klicka sig fram räcker inte — då syns lägena först efter att man ändrat data som ändå inte sparas.
- **`demo-kostnadsrakning-verdict.spec.ts`**: nytt e2e för överklagandespåret. Medan hovrätten har målet erbjuds varken fakturering eller ett nytt överklagande; efter beslutet öppnas fakturering och överklagandet är uttömt. Verifierad sensitiv (tog bort sparandet, såg den falla).
- Ärendena slås upp via `matterWithKrStatus(seed, …)` ur seeden — inte hårdkodade id:n (#972).
- Mapp-testet i #985 pekade ut "första offentliga uppdraget" och råkade därmed kräva en `Dom`-handling. Det letar nu upp ett ärende med nästlad mapp och kontrollerar dessutom att *inget* dokument i *något* ärende ligger kvar i roten — starkare påstående, oberoende av var ett enskilt ärende vilar.

## DRY

Party-eventen låg som fyra identiska `if`-rader i **fem** scenariofiler och kostade komplexitetsbudget i varje (`buildOffentligtScenario` slog i taket när `stopAfter` tillkom). De delar nu `partyEvents(parties, days)` i `events.ts`. Inget suppress tillagt.

## Grindar

`typecheck` ✓ · `lint` ✓ · `lint:complexity-strict` ✓ · `knip` ✓ · `deps:check` ✓ · `jscpd` ✓ · `build:demo` ✓ · **`e2e:demo` 33/33** ✓ · `test/scripts` 193/193 ✓ · `test/unit/lib/demo` + `architecture` + `integration` 140/140 ✓

## Vad som återstår i #828

Steg 7 — uppdatera ADR 0034. Och `beslutSlutgiltigt: true` finns inte som ett *vilande* läge i demon: det nås i ett klick från 2026-0019 och täcks av e2e:t, men vill du ha ett femte brottmål som vilar där säger du till.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_