### PR TITLE
docs(adr): beskriv kostnadsräkningens egen state-maskin i ADR 0034

### DIFF
--- a/docs/adr/0034-faktureringsfloden-per-arendetyp.md
+++ b/docs/adr/0034-faktureringsfloden-per-arendetyp.md
@@ -3,11 +3,15 @@
 - **Status:** Accepterad och **implementerad** (2026-06-28): fas 1 (modell, #818),
   fas 2 (UI, #821), fas 4 (denna ADR, #822) och fas 3 (hård API-enforcement +
   reconciliering av demo-generatorn/scenarierna).
+  **Reviderad 2026-08-12 (#828/#996):** kostnadsräkningens livscykel bröts ut till
+  en egen maskin per körning, och dom-bannern togs bort — se
+  [Två maskiner](#två-maskiner-fas-per-ärende-status-per-körning).
 - **Beslutsfattare:** Ulrik Sjölin
 - **Berör:** fakturapanelen (`_billing-panel.tsx`), billingRun-routern,
   betalningssätts-kortet.
 - **Knyter an:** [ADR 0015](0015-faktura-tillstandsmaskin.md) (fakturans
-  status-maskin — samma mönster, separat maskin).
+  status-maskin — samma mönster, separat maskin) och
+  `src/lib/shared/kostnadsrakning-flow.ts` (kostnadsräkningens livscykel, #828).
 
 ## Kontext
 
@@ -28,9 +32,9 @@ flexibla** (ingen generisk regelmotor, inga användardefinierade flöden).
 
 En **enda deklarativ sanningskälla**: `src/lib/shared/billing-flow.ts`.
 
-- `BILLING_FLOWS: Record<PaymentMethod, BillingFlow>` — per flöde: **faser**,
+- `BILLING_FLOWS: Record<PaymentMethod, BillingFlow>` — per flöde: **faser** och
   **lagliga actions per fas** (state-maskinens kanter; varje action har `toPhase`,
-  `recipient` och `dialog`-routing) och ev. **dom-banner**.
+  `recipient` och `dialog`-routing).
 - **Härledd fas** (`currentPhase`, stateless ur runs + matter): `NEKAD`
   (avslagsdatum) > `VANTAR_DOM` (kostnadsräkning väntar) > `SLUTREGLERAD`
   (utställd slutfaktura, inget väntar) > `ARBETE`. Ingen kolumn, ingen osynk.
@@ -45,15 +49,46 @@ En **enda deklarativ sanningskälla**: `src/lib/shared/billing-flow.ts`.
 |---|---|
 | **PRIVAT / MIX** | `ARBETE`: Faktura till klient (FINAL). Löpande, ingen besluts-/domslivscykel. |
 | **RÄTTSSKYDD** | `ARBETE`: Aconto · Faktura till försäkring (FINAL→`SLUTREGLERAD`) · Slutreglera (försäkringsbesked, SETTLE→`SLUTREGLERAD`). `NEKAD` (avslagsdatum satt): inga åtgärder — banner föreslår rättshjälp. |
-| **RÄTTSHJÄLP** | `ARBETE`: Aconto · Kostnadsräkning till domstol (KOSTNADSRAKNING→`VANTAR_DOM`) · Slutreglera (dom, SETTLE→`SLUTREGLERAD`). `VANTAR_DOM`: Slutreglera (dom). Dom-banner → settlement. |
-| **OFFENTLIGT_UPPDRAG** | `ARBETE`: Kostnadsräkning till domstol (→`VANTAR_DOM`). `VANTAR_DOM`: dom-banner → verdict (prutning), ej coverage-split. |
+| **RÄTTSHJÄLP** | `ARBETE`: Aconto · Kostnadsräkning till domstol (KOSTNADSRAKNING→`VANTAR_DOM`) · Slutreglera (dom, SETTLE→`SLUTREGLERAD`). `VANTAR_DOM`: Slutreglera (dom). |
+| **OFFENTLIGT_UPPDRAG** | `ARBETE`: Kostnadsräkning till domstol (→`VANTAR_DOM`) · Faktura till klient (återbetalningsskyldighet). `VANTAR_DOM`: klient-FINAL; domstolsfakturan skapas ur KR-maskinen, ej coverage-split. |
 | **PENDING** | Inga åtgärder förrän betalningssätt valts. |
+
+### Två maskiner: fas per ärende, status per körning
+
+`VANTAR_DOM` säger att ärendet **väntar** på domstolen — inte hur väntan
+avvecklas. Det senare är kostnadsräkningens egen livscykel (#828) och bor i
+`kostnadsrakning-flow.ts`, **per billing-run**:
+
+```
+INSKICKAD  ──registrera beslut (belopp + ev. prutning)──▶ BESLUTAD
+BESLUTAD   ──skapa faktura───────────────────────────────▶ FAKTURERAD
+BESLUTAD   ──överklaga (inlaga)──────────────────────────▶ ÖVERKLAGAD
+ÖVERKLAGAD ──hovrättens beslut (slutgiltigt)─────────────▶ BESLUTAD → bara faktura
+```
+
+Varför två och inte en: **ett ärende kan ha flera kostnadsräkningar**, så
+livscykeln kan inte hänga på ärendet. Faserna är dessutom härledda ur runs —
+`currentPhase` lämnar `VANTAR_DOM` i samma stund beslutet registreras, alltså
+precis när KR-maskinen får sitt intressanta liv. De två maskinerna beskriver
+olika ögonblick och går inte att slå ihop.
+
+Gränssnittet följer delningen: panelens **åtgärdsmeny** kommer ur
+`BILLING_FLOWS`, panelens **KR-kort** ur `availableKrActions`. Fakturan skapas
+i två steg — "Registrera beslut" (belopp + prutning sparas PÅ körningen) och
+sedan "Skapa faktura", som läser prutningen därifrån.
+
+**Dom-bannern är borttagen (#996).** `BILLING_FLOWS` bar ett `pendingBanner`-fält
+med en knapp ("Ange dom + prutning") som skulle öppna verdict-dialogen direkt ur
+väntefasen. Den renderades aldrig av någon komponent, och efter #828 kunde den
+inte fungera om den renderades: `setVerdict` tar inget belopp längre. KR-kortet
+är den enda vägen.
 
 ### Enforcement-nivåer
 
-1. **UI (fas 2, #821):** panelens meny + dom-banner härleds ur descriptorn —
-   panelen väljer inte längre per betalningssätt själv. Detta är den primära
-   styrningen användaren möter.
+1. **UI (fas 2, #821):** panelens åtgärdsmeny härleds ur descriptorn — panelen
+   väljer inte längre per betalningssätt själv. Detta är den primära styrningen
+   användaren möter. KR-kortets knappar kommer på samma sätt ur
+   `availableKrActions`.
 2. **Ren guard (fas 1):** `canBillingTransition`/`assertBillingTransition` finns
    som ren, testad funktion (server/klient/tester delar den).
 3. **Hård API-enforcement i mutationerna (fas 3): IMPLEMENTERAD.**
@@ -79,3 +114,17 @@ En **enda deklarativ sanningskälla**: `src/lib/shared/billing-flow.ts`.
   scenariotester är i praktiken ett andra "API-användare", och en hård spärr
   bryter dem direkt om descriptorn är fel/för snäv (vilket är poängen: spärren
   tvingar fram att modellen är korrekt, men varje ny övergång måste läggas till).
+- **−** Ett descriptor-fält utan konsument syns inte. `pendingBanner` låg kvar i
+  tabellen i månader — med egna enhetstester, utan renderare — och en e2e-spec
+  kopierade dessutom dess knapp-etikett till en villkorad gren som därför tyst
+  hoppades över vid varje körning (#996). Testerna gröna, ytan död. **Ett fält i
+  `BILLING_FLOWS` som ingen komponent läser ska tas bort, inte behållas "tills
+  vidare"** — och en test-gren som får hoppas över bevisar ingenting.
+
+## Demodata
+
+Båda maskinerna ska gå att *se*, inte bara nås genom att klicka sig framåt: ett
+brottmål vilar i vart och ett av KR-maskinens lägen (#828 steg 6, PR #998), och
+`simulate-orchestrate.test.ts` påstår om demons data att alla fyra finns
+samtidigt. Undantaget är `beslutSlutgiltigt: true`, som nås i ett steg från det
+överklagade ärendet och täcks av e2e i stället.


### PR DESCRIPTION
**#828 steg 7** — sista steget. Stänger epiken.

## Vad som var fel

ADR 0034 beskrev *ett* flöde per ärendetyp och nämnde på tre ställen en **"dom-banner"** som inte finns sedan #996. Den saknade dessutom hela kostnadsräkningens livscykel — trots att den byggdes i samma epic.

## Vad som står nu

Ett nytt avsnitt: **Två maskiner — fas per ärende, status per körning.**

| | Nivå | Fil | Driver |
|---|---|---|---|
| Faktureringsflöde | per ärende (`paymentMethod`) | `billing-flow.ts` | panelens åtgärdsmeny |
| Kostnadsräkning | per billing-run | `kostnadsrakning-flow.ts` | panelens KR-kort |

Och varför de inte går att slå ihop, vilket är den intressanta delen: **ett ärende kan ha flera kostnadsräkningar**, så livscykeln kan inte hänga på ärendet — och `currentPhase` lämnar `VANTAR_DOM` i samma stund beslutet registreras, alltså precis när KR-maskinen får sitt liv. De beskriver olika ögonblick.

Övrigt:

- **OFFENTLIGT_UPPDRAG-raden** stämmer nu med descriptorn: klient-FINAL i båda faserna, domstolsfakturan ur KR-maskinen. Den sa tidigare "dom-banner → verdict (prutning)", vilket var fel i båda leden efter #828 — prutningen registreras på kostnadsräkningen, inte i verdict-dialogen.
- **En konsekvens värd att minnas:** ett descriptor-fält utan konsument syns inte. `pendingBanner` låg kvar i månader med egna enhetstester och utan renderare, och en e2e-gren kopierade dess etikett och hoppades tyst över vid varje körning. Testerna gröna, ytan död.
- **Kort avsnitt om demodatan:** båda maskinernas lägen ska gå att *se*, inte bara nås genom att klicka sig framåt (#828 steg 6).

## Verifierat, inte antaget

Jag kontrollerade i koden att de påståenden jag lät stå kvar faktiskt stämmer — särskilt rättsskyddets NEKAD-rad, som också talar om en banner. Den skillnaden är att `RattsskyddNekadBanner` verkligen renderas (`_client.tsx:122`), till skillnad från dom-bannern. OFFENTLIGT-radens kanter är avlästa ur `BILLING_FLOWS`, inte ur minnet.

Ren dokumentation — ingen kod rörd. `typecheck` ✓ · `lint` ✓ · `test/unit/architecture` 8/8 ✓

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_