### PR TITLE
docs: rätta CI- och testkommandon som inte längre finns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,14 +31,21 @@ The loop for every change:
    - `bun run quality:fast` — typecheck + type-aware lint + `test:fast`.
    - `bun run build:demo` — the GH Pages static export. **It fails silently in
      CI/Pages otherwise**, so always run it for app changes.
-   - `bun run round-trip` — for changes touching the git push/pull e2e path.
-5. **Open a PR** to `main`. CI runs four required checks that must be green
-   before merge: **Static analysis** (typecheck + ESLint + knip + dep-cruiser
-   + jscpd), **Unit / komponent / integration** (`bun test --parallel` + coverage floor),
-   **E2E (git round-trip)**, and **Commit messages** (commitlint).
+   - `bun run e2e:demo` — the browser suite against the built `out/`. Run it for
+     UI changes and for anything that moves demo-data.
+   - `bun run e2e:conflict` / `bun run e2e:oidc` — only when you touch the
+     conflict (keep-both) or login paths; both need docker up.
+5. **Open a PR** to `main`. CI runs the full matrix and every check must be green
+   before merge: **Commit messages** (commitlint), **Static analysis** (typecheck
+   + ESLint + knip + dep-cruiser + jscpd), **Unit / komponent / integration**
+   (`bun test --parallel` + coverage floor), **Repository (Postgres)**,
+   **Demo build** (static export + bundle-size ratchet), **Demo E2E**,
+   **Server-first (deploy E2E)**, **Keep-both konflikt-E2E**, **E2E (OIDC login)**,
+   **CodeQL** and **bun audit**.
 6. **Self-merge.** No approval is required (solo project, 0 required reviews),
-   but the PR itself is mandatory — merge your own PR once all four checks are
-   green. `gh pr merge --squash` works.
+   but the PR itself is mandatory — merge your own PR once CI is green.
+   `gh pr merge --squash` works. A check that fails on infrastructure (a runner
+   that disappears mid-job) is re-run, never merged past.
 
 `.github/CODEOWNERS` marks the architecture-critical paths (`tooling/config/`,
 `src/lib/shared/schemas/`, `.github/`) — review them with extra care.
@@ -67,9 +74,9 @@ overview. Then [`docs/auth.md`](docs/auth.md) for the self-hosted auth model.
   browser pushes to `http://localhost:8080/git/firma.git` with no CORS proxy.
 - **`rm -rf out` breaks the docker bind-mount** → restart with:
   `docker compose -f tooling/docker/docker-compose.yml restart web`.
-- Run the browser round-trip e2e with `bun run round-trip` (needs docker up +
-  `out/` built). Unit tests: `bun run test` (`bun test --parallel`, ~2334
-  tester). Per-fil-isolering krävs (annars läcker `mock.module`/stubbar
+- Run the browser e2e with `bun run e2e:demo` (needs `out/` built; the config
+  serves it itself — no docker required). Unit tests: `bun run test`
+  (`bun test --parallel`, ~2334 tester). Per-fil-isolering krävs (annars läcker `mock.module`/stubbar
   mellan filer); `--parallel` ger det via en worker-pool (`--isolate`
   kraschar på CI-linux, epoll). Se [[docs/quality.md]] + #92.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -87,7 +87,7 @@ bun run typecheck           # tsc --noEmit
 bun run lint                # eslint (flat config)
 bun run deps:check          # dependency-cruiser (lagergränser)
 bun run knip                # död kod / oanvända deps
-bun run round-trip          # E2E mot docker (kräver docker upp)
+bun run e2e:demo            # Playwright mot byggd out/ (configen serverar den)
 ```
 
 Se [`quality.md`](./quality.md) för verktyg och tröskelvärden, och

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -20,7 +20,7 @@ ava/
 │   ├── integration/     # seed-smoke + cross-router-tester
 │   ├── setup/           # bun:test-preloads (happy-dom + jest-dom + cleanup)
 │   ├── bun-compat.ts    # vitest→bun:test-shim (vi-API)
-│   └── e2e/             # Playwright (round-trip mot docker)
+│   └── e2e/             # Playwright (demo-svit, OIDC-login, keep-both)
 ├── tooling/
 │   ├── config/          # eslint, playwright, knip, jscpd, dependency-cruiser
 │   ├── docker/          # docker-compose, nginx, web-image, optional auth-server
@@ -48,7 +48,7 @@ lever som JSON i ett git-repo (se [`architecture.md`](./architecture.md)).
 | Bundle-size-budget | gzip-summa av klient-chunks + ratchet (körs i `demo-build`) | `tooling/scripts/check-bundle-size.ts` |
 | Arkitektur (SOLID/lager) | dependency-cruiser | `tooling/config/dependency-cruiser.cjs` |
 | Död kod / oanvända exports | knip | `tooling/config/knip.json` |
-| Säkerhet (SAST) | CodeQL (JS/TS) — `dependency-review` kräver GHAS, ej möjlig (#915) | `.github/workflows/security.yml` |
+| Säkerhet (SAST) | CodeQL (JS/TS). `dependency-review` saknas fortfarande — se noten nedan | `.github/workflows/security.yml` |
 | Sårbara beroenden (CVE) | `bun audit` + ratchet — `low` i båda arbetsytorna | `.github/workflows/security.yml`, `overrides` i båda `package.json` |
 | Beroende-uppdateringar | Dependabot (npm + github-actions) | `.github/dependabot.yml` |
 | Pre-commit | husky + lint-staged | `.husky/pre-commit`, `package.json` |
@@ -316,9 +316,8 @@ Jobben laddar upp sina rapporter som artefakter (coverage, jscpd, playwright-rep
 
 Övriga workflows: **`deploy-demo.yml`** (GH Pages på push till `main`),
 **`helper-ui-ci.yml`** (Electron-helperns logik + motor), **`security.yml`**
-(CodeQL/SAST + `bun audit`-grinden på push/PR + veckovis schema;
-`dependency-review` kräver GitHub Advanced Security och är därför inte möjlig,
-#915) och **`release.yml`**
+(CodeQL/SAST + `bun audit`-grinden på push/PR + veckovis schema) och
+**`release.yml`**
 (tag-triggad paket-release). Beroenden hålls uppdaterade av
 [`.github/dependabot.yml`](../.github/dependabot.yml) (npm root + helper-ui +
 github-actions).
@@ -327,6 +326,13 @@ github-actions).
 > ändring gjord). `demo-build` skyddar en tyst felmod → kandidat för required
 > check ([#911](https://github.com/ulrik-s/ava/issues/911)).
 
+> **Not:** `dependency-review` togs bort ur `security.yml` (PR #912) när den föll
+> på att repo:ts Dependency graph var av. [#915](https://github.com/ulrik-s/ava/issues/915)
+> skulle slå på grafen och återinföra jobbet — issuen är stängd, men **jobbet är
+> inte tillbaka**. Repo:t är numera publikt, så GHAS-blockeraren gäller inte
+> längre; det som återstår är att lägga tillbaka jobbet (SHA-pinnat som övriga
+> actions) och se att det kör grönt.
+
 ## Pre-commit
 
 `husky` + `lint-staged` kör endast på filer som faktiskt ändrats:
@@ -334,7 +340,7 @@ github-actions).
 - `eslint --fix` på alla `.ts`/`.tsx`
 - `tsc --noEmit` (snabb även på stora repos)
 
-Tunga checks (vitest, jscpd, depcruise) körs inte i pre-commit — de kör i CI istället.
+Tunga checks (`bun test`, jscpd, depcruise) körs inte i pre-commit — de kör i CI istället.
 
 ## När tröskelvärden behöver höjas
 


### PR DESCRIPTION
Sista punkten i #909. **Issuen förblir öppen** tills du tagit ställning till `dependency-review` — se nedan.

## Vad jag hittade när jag granskade om checklistan

Jag gick igenom #909 punkt för punkt mot koden i stället för att lita på att den var aktuell. **Åtta av nio punkter var redan gjorda** — men rutorna var aldrig bockade:

| Punkt | Bevis |
|---|---|
| Bundle-size-ratchet i CI | `ci.yml:216` — `bun run size` i `demo-build` |
| `concurrency` | `ci.yml:18` med `cancel-in-progress` |
| `permissions` | `ci.yml:11` — `contents: read` |
| Dependabot | npm-rot + helper-ui + github-actions, grupperade minor/patch |
| CodeQL/SAST | `security.yml` |
| Pinnade actions | **alla** `uses:` är SHA-pinnade med `# vN`; bun 1.3.14 i `bun-setup` |
| Beroende-cache | `bun-setup` cachar `~/.bun/install/cache` på `bun.lock` |
| Issue-/PR-mallar | `.github/ISSUE_TEMPLATE/` + `pull_request_template.md` |

Kvar var P2:n om dokumentationen — och den visade sig innehålla riktiga fel, inte bara inaktuell text.

## `bun run round-trip` finns inte

Kommandot stod på **tre ställen**, varav två i `AGENTS.md` — filen varje bidragsgivare (och varje agent) läser först. Git-round-trip-e2e:n pensionerades med git-vägen (#422); `docs/architecture.md` säger det redan, men instruktionerna gjorde det inte. Ersatt med kommandon som finns: `e2e:demo`, `e2e:conflict`, `e2e:oidc`.

`AGENTS.md` påstod dessutom **"fyra required checks"** och räknade upp *"E2E (git round-trip)"* som en av dem. Listan speglar nu vad `ci.yml` + `security.yml` faktiskt kör. Jag skrev "varje check måste vara grön" i stället för att påstå exakt vilka som är branch-protection-required — det kan jag inte läsa härifrån, och det är #911:s fråga.

Jag la också till en rad om att en check som faller på infrastruktur körs om, aldrig mergas förbi. Det inträffade på PR #999 igår (runnern fick en shutdown-signal mitt i ett docker-bygge) och regeln bör stå skriven.

## `dependency-review` — därför lämnar jag issuen öppen

`security.yml` har CodeQL och `bun audit`, men **inget `dependency-review`-jobb**. #915 skulle slå på Dependency graph och återinföra det, och är **stängd som completed** — men steg 2 gjordes aldrig.

Två saker till som ändrar bilden:

1. **Repo:t är publikt** (`visibility: public`). Den gamla texten i `quality.md` sa att jobbet "kräver GitHub Advanced Security och är därför inte möjlig" — det gäller privata repon. Blockeraren finns inte längre.
2. Jag la **inte** tillbaka jobbet själv. Repots konvention är att SHA-pinna varje action, och att hämta rätt SHA för `actions/dependency-review-action` kräver att jag läser ett repo utanför den här sessionens scope. Att skriva `@v4` hade brutit pinning-konventionen som #909 självt införde.

Det står nu som en explicit NOT i `quality.md` i stället för ett tyst hål. Säg till om du vill att jag lägger tillbaka jobbet — då behöver jag SHA:n, eller ditt ok att använda taggen.

## Grindar

Ren dokumentation. `typecheck` ✓ · `lint` ✓ · `test/unit/architecture` 8/8 ✓

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_