### PR TITLE
docs(ci): demo-build och demo-e2e är required checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,8 +197,8 @@ jobs:
   # `bun run build:demo` (static export → out/) misslyckas TYST i CI/Pages om
   # något bryter den statiska exporten. Round-trip-jobbet som förr körde
   # build:demo togs bort i #422 → ingen PR-grind kvar för att demon BYGGER.
-  # Det här jobbet återinför grinden (kör på PR; INTE required check — ingen
-  # branch-protection-ändring). Speglar `bun run build:demo` lokalt. (#420)
+  # Det här jobbet återinför grinden (kör på PR; **required check** sedan #911).
+  # Speglar `bun run build:demo` lokalt. (#420)
   demo-build:
     name: Demo build
     runs-on: ubuntu-latest
@@ -222,7 +222,7 @@ jobs:
   # en deterministisk render-smoke (färsk besökare → /login renderar, fastnar
   # inte på platshållaren). Det tyngre faktura-flödet (demo-invoice-document)
   # körs i `test:all` lokalt — här hålls CI-gaten snabb + hermetisk. (Kör på PR;
-  # INTE required check — ingen branch-protection-ändring.)
+  # **required check** sedan #911.)
   #
   # "Hermetisk" var länge bara ett påstående (#932): `out/` serverades lokalt,
   # men APPEN hämtade sin data från live-demon på GH Pages, så jobbet blev rött
@@ -272,7 +272,8 @@ jobs:
   # → oauth2-proxy → server-first), och Playwright loggar in via Keycloak-
   # formuläret + bekräftar i UIt att ärendet har 2 filer (original + keep-both-
   # syskon). Regressionsskydd för ADR 0033 keep-both end-to-end mot deployad
-  # artefakt. (Kör på PR; INTE required check — ingen branch-protection-ändring.)
+  # artefakt. (Kör på PR; INTE required check — kräver docker-stacken och är
+  # långsammare än de andra; #911 befordrade demo-build + demo-e2e, inte den här.)
   conflict-e2e:
     name: Keep-both konflikt-E2E
     runs-on: ubuntu-latest

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -322,9 +322,18 @@ Jobben laddar upp sina rapporter som artefakter (coverage, jscpd, playwright-rep
 [`.github/dependabot.yml`](../.github/dependabot.yml) (npm root + helper-ui +
 github-actions).
 
-> **Not:** jobb 7–9 är i dag INTE required checks (ingen branch-protection-
-> ändring gjord). `demo-build` skyddar en tyst felmod → kandidat för required
-> check ([#911](https://github.com/ulrik-s/ava/issues/911)).
+**Required checks på `main`** (branch protection, [#911](https://github.com/ulrik-s/ava/issues/911)):
+Commit messages · Static analysis · Unit / komponent / integration ·
+Server-first (deploy E2E) · **Demo build** · **Demo E2E (browser-smoke)**.
+
+De två sista befordrades i #911: `demo-build` skyddar en *tyst* felmod (den
+statiska exporten fallerar utan att något annat jobb märker det — #550/#552 slank
+igenom just därför) och `demo-e2e` bevisar att demon LADDAR, inte bara bygger.
+
+> **Not:** övriga jobb (`Repository (Postgres)`, `E2E (OIDC login)`,
+> `Keep-both konflikt-E2E`, CodeQL, `bun audit`) kör på varje PR men är inte
+> required. De ska ändå vara gröna före merge (AGENTS.md) — skillnaden är bara
+> att GitHub inte blockerar merge-knappen på dem.
 
 > **Not:** `dependency-review` togs bort ur `security.yml` (PR #912) när den föll
 > på att repo:ts Dependency graph var av. [#915](https://github.com/ulrik-s/ava/issues/915)


### PR DESCRIPTION
Stänger #911. Du körde branch-protection-ändringen; det här är dokumentationen som följer med.

## Vad som ändrades i inställningen

Required-listan på `main` gick från fyra till sex:

| Före | Efter |
|---|---|
| Commit messages | Commit messages |
| Static analysis | Static analysis |
| Unit / komponent / integration | Unit / komponent / integration |
| Server-first (deploy E2E) | Server-first (deploy E2E) |
| | **Demo build** |
| | **Demo E2E (browser-smoke)** |

`strict: false` och övriga skydd orörda — PATCH:en byggdes ur den befintliga listan, så inget föll bort.

En detalj värd att notera: `AGENTS.md` påstod "fyra required checks" och räknade upp *E2E (git round-trip)* som en av dem. Antalet stämde, namnet gjorde det inte — den fjärde var `Server-first (deploy E2E)`. Den raden är redan rättad i #1000.

## Vad som ändras här

- **`ci.yml`** — tre kommentarer sa "INTE required check — ingen branch-protection-ändring". Två stämmer inte längre. Den tredje (`Keep-both konflikt-E2E`) står kvar utanför, och kommentaren säger nu varför den inte togs med i stället för att låta det se ut som en förbiseende.
- **`docs/quality.md`** — required-uppsättningen står nu explicit uppräknad i stället för som ett önskemål ("kandidat för required check"). Noten under säger att övriga jobb ändå ska vara gröna före merge; skillnaden är bara att GitHub inte blockerar merge-knappen på dem.

Jag lät bli att duplicera listan i `AGENTS.md` — den säger "every check must be green", vilket är sant oavsett, och två listor att hålla i synk är precis den sortens sak som blir fel med tiden.

## Om varför du fick köra kommandot

Sessionens GitHub-integration exponerar issues, PR:er och actions men har inget verktyg för branch protection, och direkta anrop mot `api.github.com` fencas av proxyn (`403 — GitHub access is not enabled for this session`). Det gällde oavsett behörighet på repo:t.

Ren dokumentation + kommentarer. `ci.yml` parsar (9 jobb oförändrade).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_