### PR TITLE
feat(taxa): advokatberedskapens garantiersättning per dygn

### DIFF
--- a/src/app/matters/[id]/_time-section.tsx
+++ b/src/app/matters/[id]/_time-section.tsx
@@ -6,6 +6,7 @@ import { Modal } from "@/components/ui/modal";
 import { TIME_ENTRY_KIND_SHORT } from "@/lib/client/labels";
 import { trpc } from "@/lib/client/trpc";
 import { formatMinutes } from "@/lib/client/utils";
+import { isPerDayKind } from "@/lib/shared/brottmalstaxa";
 import { TIME_ENTRY_KIND_LABELS, type MatterStatus, type PaymentMethod, type TimeEntryKind } from "@/lib/shared/schemas/enums";
 import type { InvoiceId, MatterId, TimeEntryId } from "@/lib/shared/schemas/ids";
 import { applicableStandardAtgarder, type StandardAtgard } from "@/lib/shared/standard-atgard";
@@ -51,7 +52,17 @@ const KIND_GUIDANCE: Partial<Record<TimeEntryKind, string>> = {
   TIDSSPILLAN: "Dagtaxan gäller vardag 08.00–18.00. Ersättning lämnas bara för tid mellan 07.00 och 22.00, och normal måltidspaus är inte tidsspillan (DVFS 2025:4 §§ 2–4).",
   TIDSSPILLAN_OVRIG_TID: "All tidsspillan utanför vardag 08.00–18.00 — men bara inom 07.00–22.00; tid mellan 22.00 och 07.00 ersätts inte alls. Vid övernattning på annan ort än tjänstestället ersätts 18.00–22.00 endast om den avser restid (DVFS 2025:4 §§ 2, 4).",
   ARBETE_OBEKVAM_TID: "Häktningsförhandling under helg (DVFS 2025:7) eller polisförhör utanför ordinarie kontorstid (DVFS 2025:8). Tidsspillan i samband med sådana ersätts med DAGTAXAN, även 22.00–07.00.",
+  ADVOKATBEREDSKAP: "Garantiersättning PER DAG för beredskap vid tingsrätten under helg (DVFS 2025:9 § 1) — ingen tid registreras. Blir du inkallad registrerar du arbetet som obekväm tid i stället: garantin utgår inte för dag då sådant arvode utgår (§ 2).",
 };
+
+/**
+ * Byt kategori på formuläret. Per-dygns-kategorier nollar minuterna (#950):
+ * beredskap är inte arbetad tid, och en kvarglömd halvtimme från förra posten
+ * hade följt med in i varje timbaserad summa.
+ */
+function withKind<T extends { kind: TimeEntryKind; minutes: number }>(form: T, kind: TimeEntryKind): T {
+  return { ...form, kind, minutes: isPerDayKind(kind) ? 0 : form.minutes };
+}
 
 /** Ärenden där kategorin styr vilken ÅRSNORM slutregleringen värderar posten på. */
 const COVERAGE_METHODS = new Set<PaymentMethod>(["RATTSHJALP", "RATTSSKYDD"]);
@@ -184,7 +195,11 @@ export function TimeSection({ matterId, isTaxeArende, paymentMethod, matterStatu
       render: (e) => <span className="text-sm text-gray-900">{e.user?.name ?? "—"}</span> },
     { key: "minutes", label: "Tid", sortable: true, align: "right", sortValue: (e) => e.minutes,
       summary: (rows) => <span className="font-mono">{formatMinutes(rows.reduce((sum, r) => sum + r.minutes, 0))}</span>,
-      render: (e) => <span className="text-sm text-gray-900">{formatMinutes(e.minutes)}</span> },
+      render: (e) => (
+        <span className="text-sm text-gray-900">
+          {isPerDayKind(e.kind) ? "1 dygn" : formatMinutes(e.minutes)}
+        </span>
+      ) },
     { key: "description", label: "Beskrivning", sortable: true, sortValue: (e) => e.description ?? "",
       render: (e) => <span className="text-sm text-gray-700">{e.description}</span> },
     // Kategorin styr vilken av Domstolsverkets normer posten värderas på vid
@@ -335,10 +350,20 @@ function TimeForm({ form, setForm, submitLabel, isPending, isTaxeArende, isCover
             className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm" />
         </div>
         <div>
-          <label htmlFor="time-minutes" className="block text-xs text-gray-500 mb-1">Tid (minuter) *</label>
-          <input id="time-minutes" type="text" inputMode="numeric" required value={form.minutes}
-            onChange={(e) => setForm({ ...form, minutes: parseInt(e.target.value) || 0 })}
-            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm" />
+          <label htmlFor="time-minutes" className="block text-xs text-gray-500 mb-1">
+            {isPerDayKind(form.kind) ? "Omfattning" : "Tid (minuter) *"}
+          </label>
+          {isPerDayKind(form.kind) ? (
+            // Beredskap ersätts per dygn (#950) — det finns ingen tid att mata in,
+            // och ett tomt minutfält hade sett ut som att något saknades.
+            <p id="time-minutes" className="rounded border border-gray-200 bg-gray-50 px-3 py-1.5 text-sm text-gray-600">
+              1 dygns beredskap
+            </p>
+          ) : (
+            <input id="time-minutes" type="text" inputMode="numeric" required value={form.minutes}
+              onChange={(e) => setForm({ ...form, minutes: parseInt(e.target.value) || 0 })}
+              className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm" />
+          )}
         </div>
         <div className="col-span-2">
           <label htmlFor="time-description" className="block text-xs text-gray-500 mb-1">Beskrivning *</label>
@@ -350,7 +375,7 @@ function TimeForm({ form, setForm, submitLabel, isPending, isTaxeArende, isCover
         <div className="col-span-2">
           <label htmlFor="time-kind" className="block text-xs text-gray-500 mb-1">Arvodeskategori *</label>
           <select id="time-kind" value={form.kind}
-            onChange={(e) => setForm({ ...form, kind: e.target.value as TimeEntryKind })}
+            onChange={(e) => setForm(withKind(form, e.target.value as TimeEntryKind))}
             className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm">
             {KIND_OPTIONS.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
           </select>

--- a/src/lib/client/labels.ts
+++ b/src/lib/client/labels.ts
@@ -137,6 +137,7 @@ export const TIME_ENTRY_KIND_SHORT: Record<TimeEntryKind, string> = {
   ARBETE_OBEKVAM_TID: "Obekväm tid",
   TIDSSPILLAN: "Tidsspillan",
   TIDSSPILLAN_OVRIG_TID: "Tidsspillan annan tid",
+  ADVOKATBEREDSKAP: "Beredskap (dag)",
 };
 
 export const CREDIT_RISK_LABELS: Record<CreditRisk, string> = {

--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -20,7 +20,7 @@ import { accontoCreditAmounts, accontoCreditLines, accontoSplit, deductAcconto }
 import type { VatBreakdownLine } from "@/lib/shared/accounting/semantic-voucher";
 import { assertBillingTransition, type BillingActionType } from "@/lib/shared/billing-flow";
 import { proposedAccontoOre } from "@/lib/shared/billing-proposal";
-import { TIMKOSTNADSNORM_FTAX_ORE_PER_H, coverageEntryRateOre } from "@/lib/shared/brottmalstaxa";
+import { TIMKOSTNADSNORM_FTAX_ORE_PER_H, coverageEntryRateOre, coverageEntryValueOre, isPerDayKind, payableCoverageEntries } from "@/lib/shared/brottmalstaxa";
 import { computeCoverageSplit, partitionRattsskyddMinutes, type CoverageSplit, type RattsskyddClientParts } from "@/lib/shared/coverage-billing";
 import { chargedExpenseLines } from "@/lib/shared/expense-vat";
 import { arvodeInclVatOre } from "@/lib/shared/invoice-calc";
@@ -91,6 +91,20 @@ interface BillingProposal {
 /** Värdet på en (debiterbar) tidspost i öre — speglar workValueOre:s ton. */
 function timeEntryValueOre(minutes: number, hourlyRate: number): number {
   return Math.round((minutes / 60) * hourlyRate);
+}
+
+/** Postens värde när det är postens EGEN taxa som gäller (privat/offentligt
+ *  uppdrag, fakturaförslaget) — i motsats till täckningsärendenas årsnormer.
+ *
+ *  Per-dygns-kategorier (#950) värderas ändå på Domstolsverkets dagbelopp för
+ *  postens datum: advokatberedskapens garantiersättning är en föreskriven norm
+ *  (DVFS 2025:9 § 1), inte byråns timtaxa. Utan undantaget blir de noll —
+ *  `minuter × taxa` med noll minuter — och försvinner tyst ur både
+ *  kostnadsräkningen och "Upparbetat ofakturerat". */
+function entryOwnValueOre(
+  t: { minutes: number; hourlyRate: number; date: Date | string; kind?: TimeEntryKind | null | undefined },
+): number {
+  return isPerDayKind(t.kind) ? coverageEntryValueOre(t, t.date) : timeEntryValueOre(t.minutes, t.hourlyRate);
 }
 
 /**
@@ -226,9 +240,8 @@ function resolveAwardedOre(krRun: BillingRunListRow | undefined, inputAwardedOre
 
 /** Arvode netto (exkl. moms) — summa av debiterbara tidsposter. */
 function arvodeNetOre(work: UnfrozenWork): number {
-  return work.timeEntries
-    .filter((t) => t.billable)
-    .reduce((sum, t) => sum + timeEntryValueOre(t.minutes, t.hourlyRate), 0);
+  return payableCoverageEntries(work.timeEntries.filter((t) => t.billable))
+    .reduce((sum, t) => sum + entryOwnValueOre(t), 0);
 }
 
 
@@ -272,10 +285,13 @@ function settlementArvodeNet(method: PaymentMethod, work: UnfrozenWork, settleDa
   // PRIVAT/offentligt debiterar byråns egen taxa (ligger på posten) — bara
   // täckningsärenden ersätts enligt Domstolsverkets nivåer (#950).
   if (method !== "RATTSHJALP" && method !== "RATTSSKYDD") return arvodeNetOre(work);
-  const byKind = minutesByKind(billable);
+  // DVFS 2025:9 § 2 (#950): beredskapsdagar som "förbrukats" av en helgförhandling
+  // eller ett polisförhör samma dag ersätts inte — arbetet betalas i stället.
+  const payable = payableCoverageEntries(billable);
+  const byKind = minutesByKind(payable);
   // Rådgivningstimmen carvas ur ARBETE (rättshjälp) — den faktureras klienten separat.
   byKind.set("ARBETE", coverageBaseMinutes(method, byKind.get("ARBETE") ?? 0));
-  return sumKindValueOre(byKind, settleDate);
+  return sumKindValueOre(byKind, settleDate) + perDayValueOre(payable, settleDate);
 }
 
 /** Debiterbara minuter grupperade per arvodeskategori (#950). */
@@ -285,9 +301,23 @@ function minutesByKind(
   const byKind = new Map<TimeEntryKind, number>();
   for (const t of billable) {
     const kind = t.kind ?? "ARBETE";
+    // Per-dygns-kategorier har inga minuter att gruppera (#950) — de värderas
+    // av `perDayValueOre` och ska inte belasta timbaserade tak eller carve-outs.
+    if (isPerDayKind(kind)) continue;
     byKind.set(kind, (byKind.get(kind) ?? 0) + t.minutes);
   }
   return byKind;
+}
+
+/** Summan av per-dygns-posternas garantiersättning på slutregleringsårets
+ *  belopp (#950). Anroparen har redan filtrerat bort dagar som § 2 tar. */
+function perDayValueOre(
+  entries: ReadonlyArray<{ date: Date | string; minutes: number; kind?: TimeEntryKind | null | undefined }>,
+  settleDate: Date | string,
+): number {
+  return entries
+    .filter((e) => isPerDayKind(e.kind))
+    .reduce((sum, e) => sum + coverageEntryValueOre(e, settleDate), 0);
 }
 
 /** Summera kategoriernas minuter på respektive årsnorm (#950). */
@@ -458,13 +488,15 @@ function krGrossOre(work: UnfrozenWork, arvodeNet: number): number {
 
 /** Bygg ett itemiserat fakturaförslag ur ofrysta tids-/utläggsrader (#397). */
 function buildProposal(
-  te: ReadonlyArray<{ id: string; description?: string | null; minutes: number; hourlyRate: number; billable: boolean }>,
+  te: ReadonlyArray<{ id: string; description?: string | null; minutes: number; hourlyRate: number; billable: boolean; date: Date | string; kind?: TimeEntryKind | null | undefined }>,
   ex: ReadonlyArray<{ id: string; description?: string | null; amount: number; billable: boolean; kind?: ExpenseKind }>,
   priorAccontoSumOre: number,
 ): BillingProposal {
-  const timeEntries: ProposalTimeEntry[] = te.map((t) => ({
+  // § 2-filtret först (#950): en beredskapsdag som förbrukats av helgförhandling
+  // ska inte ens synas som fakturerbar rad.
+  const timeEntries: ProposalTimeEntry[] = payableCoverageEntries(te).map((t) => ({
     id: t.id, description: t.description ?? "", minutes: t.minutes, hourlyRate: t.hourlyRate,
-    billable: t.billable, valueOre: timeEntryValueOre(t.minutes, t.hourlyRate),
+    billable: t.billable, valueOre: entryOwnValueOre(t),
   }));
   const expenses: ProposalExpense[] = ex
     .filter((e) => e.kind !== "PRUTNING")
@@ -605,13 +637,14 @@ export interface SettlementBreakdown {
 function buildClientArvodeLines(
   method: PaymentMethod, rateOre: number, work: UnfrozenWork, totalArvodeNet: number, settleDate: Date | string,
 ): SpecTimeLine[] {
-  const billable = work.timeEntries.filter((t) => t.billable);
+  const billable = payableCoverageEntries(work.timeEntries.filter((t) => t.billable));
   const entries = method === "RATTSHJALP" ? carveEarliestMinutes(billable, RADGIVNING_MINUTES) : billable;
   // #891/#950: varje rad värderas på sin KATEGORIS norm för slutregleringsåret —
-  // för alla betalningssätt, så raderna summerar till `totalArvodeNet`.
+  // för alla betalningssätt, så raderna summerar till `totalArvodeNet`. Per-dygns-
+  // kategorier (advokatberedskap) får sitt dagbelopp, inte minuter × norm.
   const lines: SpecTimeLine[] = entries.map((t) => ({
     date: t.date, description: t.description, minutes: t.minutes, kind: t.kind,
-    amountOre: timeEntryValueOre(t.minutes, coverageEntryRateOre(t.kind, settleDate)),
+    amountOre: coverageEntryValueOre(t, settleDate),
   }));
   const sum = lines.reduce((s, l) => s + l.amountOre, 0);
   const last = lines[lines.length - 1];

--- a/src/lib/server/routers/timeEntry.ts
+++ b/src/lib/server/routers/timeEntry.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
+import { advokatberedskapFtaxForDate, isPerDayKind } from "@/lib/shared/brottmalstaxa";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
 import { type TimeEntry } from "@/lib/shared/schemas/billing";
-import { timeEntryKindSchema } from "@/lib/shared/schemas/enums";
+import { timeEntryKindSchema, type TimeEntryKind } from "@/lib/shared/schemas/enums";
 import {
   asId,
   matterIdSchema,
@@ -11,6 +12,32 @@ import {
 } from "@/lib/shared/schemas/ids";
 import { emit } from "../events/emit";
 import { router, protectedProcedure, orgProcedure, TRPCError } from "../trpc";
+
+/** Vad `minutes`-regeln behöver veta om posten. */
+interface EntryShape {
+  minutes?: number | undefined;
+  kind?: TimeEntryKind | null | undefined;
+  date?: string | undefined;
+}
+
+/**
+ * Noll minuter är bara meningsfullt för per-dygns-kategorier (#950). Zod kan
+ * inte uttrycka beroendet mellan två fält lika läsbart som en guard, och
+ * felmeddelandet ska säga VILKEN kategori som gäller — inte bara "≥ 1".
+ */
+function assertMinutes(input: EntryShape): void {
+  if ((input.minutes ?? 0) > 0 || isPerDayKind(input.kind)) return;
+  throw new TRPCError({
+    code: "BAD_REQUEST",
+    message: "Tidsposten måste ha minst en minut. Noll minuter används bara för advokatberedskap, som ersätts per dag.",
+  });
+}
+
+/** Postens á-pris: dagbeloppet för beredskap, annars användarens timtaxa. */
+function rateForEntry(input: EntryShape & { hourlyRate?: number | undefined }, userRate: number): number {
+  if (isPerDayKind(input.kind)) return advokatberedskapFtaxForDate(input.date ?? new Date());
+  return input.hourlyRate ?? userRate;
+}
 
 export const timeEntryRouter = router({
   list: protectedProcedure
@@ -43,10 +70,16 @@ export const timeEntryRouter = router({
       z.object({
         matterId: matterIdSchema,
         date: z.string(), // ISO date string YYYY-MM-DD
-        minutes: z.number().min(1),
+        /**
+         * Arbetad tid i minuter. Noll är tillåtet BARA för per-dygns-kategorier
+         * (advokatberedskap, #950) — beredskap är inte arbetad tid, och att
+         * hitta på minuter för den hade förorenat varje timbaserad summa:
+         * upparbetat, rättsskyddets timtak, rapporterna.
+         */
+        minutes: z.number().min(0),
         description: z.string().min(1),
         billable: z.boolean().default(true),
-        /** ARBETE (default) eller TIDSSPILLAN (#891). */
+        /** ARBETE (default), TIDSSPILLAN (#891) eller ADVOKATBEREDSKAP (#950). */
         kind: timeEntryKindSchema.optional(),
         /** Byråns standardåtgärd posten registrerades ur (#956) — spårbarhet. */
         standardAtgardId: z.string().optional(),
@@ -59,6 +92,7 @@ export const timeEntryRouter = router({
       })
     )
     .mutation(async ({ ctx, input }) => {
+      assertMinutes(input);
       const userId = input.userId ?? asId<"UserId">(ctx.user.id);
       const user = await ctx.repos.users.getById(userId);
       if (!user) throw new TRPCError({ code: "NOT_FOUND", message: "Användare finns inte." });
@@ -70,7 +104,9 @@ export const timeEntryRouter = router({
         date: new Date(input.date),
         minutes: input.minutes,
         description: input.description,
-        hourlyRate: input.hourlyRate ?? user.hourlyRate ?? 0,
+        // Per-dygns-kategorier har ingen timtaxa; posten bär DAGBELOPPET så den
+        // råa raden är läsbar. Värderingen läser ändå alltid årstabellen (#950).
+        hourlyRate: rateForEntry(input, user.hourlyRate ?? 0),
         kind: input.kind,
         standardAtgardId: input.standardAtgardId,
         billable: input.billable,

--- a/src/lib/shared/brottmalstaxa.ts
+++ b/src/lib/shared/brottmalstaxa.ts
@@ -93,13 +93,21 @@ const ARBETE_OBEKVAM_FTAX_BY_YEAR: Readonly<Record<number, number>> = {
 };
 
 /**
- * Advokatberedskap — garantiersättning per DAG (ej per timme), öre exkl moms
- * (DVFS 2024:20 / 2025:7). Utgår INTE för dag då arvode enligt helg- eller
- * polisförhörsföreskriften utgår.
+ * Advokatberedskap — garantiersättning per DAG (ej per timme), öre exkl moms.
+ *
+ * Tingsrätten får tillerkänna den som åtagit sig att vid behov delta i
+ * häktningsförhandling under *söndag, annan allmän helgdag, lördag,
+ * midsommarafton, julafton eller nyårsafton* ersättning "för varje dag som
+ * beredskapen upprätthålls" (DVFS 2024:20 § 1 resp. DVFS 2025:9 § 1).
+ *
+ * § 2 i samma föreskrifter: garantiersättning utgår INTE för dag när biträdet
+ * är berättigat ersättning för arbete på grund av att en helgförhandling
+ * (DVFS 2025:7) eller ett polisförhör utanför ordinarie kontorstid
+ * (DVFS 2025:8) ägt rum — se {@link payableCoverageEntries}.
  */
 const ADVOKATBEREDSKAP_FTAX_BY_YEAR: Readonly<Record<number, number>> = {
-  2025: 248_700, // 2 487 kr/dag
-  2026: 255_000, // 2 550 kr/dag
+  2025: 248_700, // 2 487 kr/dag (DVFS 2024:20 § 1)
+  2026: 255_000, // 2 550 kr/dag (DVFS 2025:9 § 1)
 };
 
 /**
@@ -142,6 +150,72 @@ export function arbeteObekvamFtaxForDate(date: Date | string): number {
 /** Advokatberedskapens garantiersättning per DAG (F-skatt) ett givet datum (#950). */
 export function advokatberedskapFtaxForDate(date: Date | string): number {
   return ADVOKATBEREDSKAP_FTAX_BY_YEAR[yearOf(date)] ?? ADVOKATBEREDSKAP_FTAX_BY_YEAR[2026] ?? 0;
+}
+
+/**
+ * Ersätts kategorin per DAG i stället för per timme (#950)? Advokatberedskapens
+ * garantiersättning utgår "för varje dag som beredskapen upprätthålls"
+ * (DVFS 2025:9 § 1) — den har ingen timnorm, och en post är ett dygn.
+ *
+ * Egen predikat-funktion i st.f. en jämförelse på anropsplatsen: varje ställe
+ * som värderar tid måste veta skillnaden, och en bortglömd plats blir ett
+ * belopp som tyst räknas som noll (minuter × ingen norm).
+ */
+export function isPerDayKind(kind: TimeEntryKind | null | undefined): boolean {
+  return kind === "ADVOKATBEREDSKAP";
+}
+
+/** Det en tidspost behöver bära för att kunna värderas. */
+export interface CoverageEntryLike {
+  date: Date | string;
+  minutes: number;
+  kind?: TimeEntryKind | null | undefined;
+  /** Utelämnad → debiterbar (posterna som når hit är oftast redan filtrerade). */
+  billable?: boolean | undefined;
+}
+
+/**
+ * Värdet (öre, netto) av EN post i ett täckningsärende, på normerna som gäller
+ * `date` — postens eget datum när den registreras, slutregleringsdatumet när
+ * arbetet värderas om retroaktivt (#891).
+ *
+ * Den ENDA vägen att värdera en tidspost: per-dygns-kategorier har ingen
+ * timnorm, så `minuter × norm` ger noll för dem.
+ */
+export function coverageEntryValueOre(entry: CoverageEntryLike, date: Date | string): number {
+  if (isPerDayKind(entry.kind)) return advokatberedskapFtaxForDate(date);
+  return Math.round((entry.minutes / 60) * coverageEntryRateOre(entry.kind, date));
+}
+
+/** Dagnyckel (YYYY-MM-DD) — jämförelsen i § 2 gäller DAG, inte tidpunkt. */
+function dayKey(date: Date | string): string {
+  const d = new Date(date);
+  return Number.isNaN(d.getTime()) ? String(date) : (d.toISOString().split("T")[0] ?? "");
+}
+
+/**
+ * Posterna som faktiskt ersätts (#950, DVFS 2025:9 § 2).
+ *
+ * Garantiersättning för advokatberedskap utgår inte för en dag då biträdet är
+ * berättigat ersättning för ARBETE till följd av att en helgförhandling eller
+ * ett polisförhör utanför ordinarie kontorstid ägt rum — i AVA:s modell en
+ * debiterbar `ARBETE_OBEKVAM_TID`-post samma dag. Beredskapen ersätter att man
+ * stått till förfogande; blev man faktiskt inkallad betalas arbetet i stället.
+ *
+ * Icke-debiterbart arbete räknas inte: då är biträdet inte "berättigat
+ * ersättning", och garantin står kvar.
+ *
+ * Övriga poster passerar orörda, så funktionen kan läggas först i varje
+ * värderingsväg utan att förändra något annat.
+ */
+export function payableCoverageEntries<T extends CoverageEntryLike>(entries: readonly T[]): T[] {
+  const workedDays = new Set(
+    entries
+      .filter((e) => e.kind === "ARBETE_OBEKVAM_TID" && e.billable !== false)
+      .map((e) => dayKey(e.date)),
+  );
+  if (workedDays.size === 0) return [...entries];
+  return entries.filter((e) => !isPerDayKind(e.kind) || !workedDays.has(dayKey(e.date)));
 }
 
 /**

--- a/src/lib/shared/kostnadsrakning.ts
+++ b/src/lib/shared/kostnadsrakning.ts
@@ -17,7 +17,7 @@
  *   - `templateContext` — Handlebars-context (matchar default-mallen)
  */
 
-import { computeBrottmalstaxa, computeTimkostnadsnorm, TIMKOSTNADSNORM_NO_FTAX_ORE_PER_H, timkostnadsnormFtaxForDate, tidsspillanFtaxForDate, type TaxaLevel, type TaxaResult } from "./brottmalstaxa";
+import { applyNoFTaxFactorForDate, computeBrottmalstaxa, computeTimkostnadsnorm, coverageEntryRateOre, coverageEntryValueOre, isPerDayKind, payableCoverageEntries, timkostnadsnormFtaxForDate, type TaxaLevel, type TaxaResult } from "./brottmalstaxa";
 import { RADGIVNING_MINUTES, radgivningTextRad } from "./rattshjalp";
 import type { TimeEntryKind } from "./schemas/enums";
 import { splitVat } from "./vat";
@@ -165,6 +165,11 @@ function timkostnadsnormResult(totalArbetsMinutes: number, hasFTax: boolean): Ta
  * timmen är ärendets första timme, faktureras klienten separat och ligger utanför
  * domstolens kostnadsräkning. Hela poster utelämnas tills kvoten är uppfylld; en
  * post som delvis överlappar krymps med resterande minuter.
+ *
+ * Poster UTAN minuter passerar orörda (#950): en post som inte är arbetad tid —
+ * advokatberedskapens garantiersättning per dygn — kan inte vara en del av
+ * ärendets första timme. Utan undantaget hade `0 <= left` svalt hela posten och
+ * ersättningen försvunnit tyst, utan att ens konsumera en minut av kvoten.
  */
 export function carveEarliestMinutes<T extends { date: Date | string; minutes: number }>(
   entries: readonly T[],
@@ -174,7 +179,7 @@ export function carveEarliestMinutes<T extends { date: Date | string; minutes: n
   let left = carveMinutes;
   const out: T[] = [];
   for (const t of sorted) {
-    if (left <= 0) { out.push(t); continue; }
+    if (left <= 0 || t.minutes === 0) { out.push(t); continue; }
     if (t.minutes <= left) { left -= t.minutes; continue; } // hela posten är rådgivning → utelämna
     out.push({ ...t, minutes: t.minutes - left }); // delvis → krymp
     left = 0;
@@ -312,17 +317,33 @@ function valuateTimeLines(
 ): { timeLines: TimeLine[]; arvodeNorm: number } {
   const isTaxe = input.isTaxeArende ?? true;
   const hasFTax = input.hasFTax ?? true;
-  const arvodeNorm = hasFTax ? timkostnadsnormFtaxForDate(valDate) : TIMKOSTNADSNORM_NO_FTAX_ORE_PER_H;
-  const tidsNorm = hasFTax ? tidsspillanFtaxForDate(valDate) : TIMKOSTNADSNORM_NO_FTAX_ORE_PER_H;
-  const timeLines = entries.map((t): TimeLine => {
-    const isTids = t.kind === "TIDSSPILLAN";
-    const rateOrePerH = isTaxe ? 0 : (isTids ? tidsNorm : arvodeNorm);
-    return {
-      id: t.id, date: toIsoDate(t.date), description: t.description, minutes: t.minutes,
-      rateOrePerH, amountOre: Math.round((t.minutes / 60) * rateOrePerH), isTidsspillan: isTids,
-    };
-  });
+  const forFTax = (ore: number): number => (hasFTax ? ore : applyNoFTaxFactorForDate(ore, valDate));
+  const arvodeNorm = forFTax(timkostnadsnormFtaxForDate(valDate));
+  const timeLines = entries.map((t): TimeLine => valuateTimeLine(t, { isTaxe, valDate, forFTax }));
   return { timeLines, arvodeNorm };
+}
+
+/**
+ * En rad i tidsspecifikationen. Kategorin styr normen (#950/#953): arbete,
+ * obekväm tid och de två tidsspillan-nivåerna har var sin årsnorm, och
+ * advokatberedskapen ersätts per DAG — den har ingen timnorm alls, så `á-pris`
+ * står tomt (0) och beloppet är dagbeloppet.
+ *
+ * Taxa-ärenden: alla rader är informativa (0), beloppet styrs av brottmålstaxan.
+ * Det gäller även beredskapen — den ligger utanför taxans arvode och yrkas för
+ * sig; se noten i `buildKostnadsrakningContext`.
+ */
+function valuateTimeLine(
+  t: TimeEntryInput,
+  ctx: { isTaxe: boolean; valDate: Date; forFTax: (ore: number) => number },
+): TimeLine {
+  const perDay = isPerDayKind(t.kind);
+  const rateOrePerH = ctx.isTaxe || perDay ? 0 : ctx.forFTax(coverageEntryRateOre(t.kind, ctx.valDate));
+  const amountOre = ctx.isTaxe ? 0 : ctx.forFTax(coverageEntryValueOre(t, ctx.valDate));
+  return {
+    id: t.id, date: toIsoDate(t.date), description: t.description, minutes: t.minutes,
+    rateOrePerH, amountOre, isTidsspillan: t.kind === "TIDSSPILLAN" || t.kind === "TIDSSPILLAN_OVRIG_TID",
+  };
 }
 
 export function buildKostnadsrakningContext(input: BuildInput): KostnadsrakningResult {
@@ -335,7 +356,9 @@ export function buildKostnadsrakningContext(input: BuildInput): KostnadsrakningR
   // ligger HELT utanför kostnadsräkningen till domstolen (#868): den carvas bort
   // ur BÅDE tidsspecifikationen och arvodes-underlaget — annars ser det ut som att
   // domstolen debiteras för samma timme (dubbel-debitering). Notisen förklarar den.
-  const allBillable = (input.timeEntries ?? []).filter((t) => t.billable !== false);
+  // DVFS 2025:9 § 2 (#950): beredskapsdagar som förbrukats av en helgförhandling
+  // eller ett polisförhör samma dag yrkas inte — arbetet yrkas i stället.
+  const allBillable = payableCoverageEntries((input.timeEntries ?? []).filter((t) => t.billable !== false));
   const billableTimeEntries = input.matter.radgivningPaid
     ? carveEarliestMinutes(allBillable, RADGIVNING_MINUTES)
     : allBillable;

--- a/src/lib/shared/schemas/enums.ts
+++ b/src/lib/shared/schemas/enums.ts
@@ -61,12 +61,19 @@ export type PaymentMethod = z.infer<typeof paymentMethodSchema>;
  *                           (DVFS 2025:7 § 1, 2025:8 § 1)
  *   TIDSSPILLAN           — vardag 08–18 (DVFS 2025:4 § 4)
  *   TIDSSPILLAN_OVRIG_TID — all annan tid, lägre norm (DVFS 2025:4 § 4)
+ *   ADVOKATBEREDSKAP      — garantiersättning PER DAG (DVFS 2025:9 § 1)
+ *
+ * `ADVOKATBEREDSKAP` bryter mönstret: den ersätts per DAG, inte per timme, och
+ * en post är ett dygns beredskap (`minutes` = 0 — beredskap är inte arbetad
+ * tid). Värderingen går via `coverageEntryValueOre`, aldrig via minuter ×
+ * timnorm. Se `brottmalstaxa.ts`.
  */
 export const TIME_ENTRY_KIND_LABELS = {
   ARBETE: "Arvode",
   ARBETE_OBEKVAM_TID: "Arvode — obekväm tid (helg/kväll/natt)",
   TIDSSPILLAN: "Tidsspillan — vardag 08–18",
   TIDSSPILLAN_OVRIG_TID: "Tidsspillan — annan tid",
+  ADVOKATBEREDSKAP: "Advokatberedskap — garantiersättning per dag",
 } as const satisfies Record<string, string>;
 export const timeEntryKindSchema = enumFromLabels(TIME_ENTRY_KIND_LABELS);
 export type TimeEntryKind = z.infer<typeof timeEntryKindSchema>;

--- a/test/scripts/simulate-orchestrate.test.ts
+++ b/test/scripts/simulate-orchestrate.test.ts
@@ -217,6 +217,59 @@ describe("runSimulation (#880 integration)", () => {
   });
 
   /**
+   * #950: advokatberedskapens garantiersättning. Kategorin ersätts per DYGN och
+   * bär noll minuter, så varje väg som räknar `minuter × taxa` ger tyst noll —
+   * demon är därför den bästa grinden mot att den försvinner igen. Här påstås
+   * dessutom att BÅDA utfallen finns i datan: en beredskapsdag som ersätts, och
+   * en som förbrukats av en helgförhandling (DVFS 2025:9 § 2).
+   */
+  it("brottmålen har beredskapsdygn — både ersatta och förbrukade", async () => {
+    const { c } = await simulateDemo();
+    const matters = (await c.matter.list({})).matters as Any[];
+    const brottmal = matters.filter((m: Any) => m.paymentMethod === "OFFENTLIGT_UPPDRAG");
+    expect(brottmal.length, "seeden har brottmål").toBeGreaterThan(0);
+
+    const entries = (await Promise.all(brottmal.map(async (m: Any) => {
+      const res = await c.timeEntry.list({ matterId: m.id, pageSize: 100 });
+      return (res.entries ?? res.timeEntries ?? []) as Any[];
+    }))).flat();
+
+    const beredskap = entries.filter((t: Any) => t.kind === "ADVOKATBEREDSKAP");
+    expect(beredskap.length, "beredskapsdygn finns").toBeGreaterThan(0);
+    expect(beredskap.every((t: Any) => t.minutes === 0), "beredskap bär noll minuter").toBe(true);
+
+    // Minst ett dygn krockar med en helgförhandling → § 2 slår till någonstans.
+    const day = (d: unknown) => new Date(String(d)).toISOString().slice(0, 10);
+    const obekvamDays = new Set(entries.filter((t: Any) => t.kind === "ARBETE_OBEKVAM_TID").map((t: Any) => day(t.date)));
+    expect(beredskap.some((t: Any) => obekvamDays.has(day(t.date))), "en beredskapsdag är förbrukad av helgförhandling").toBe(true);
+    expect(beredskap.some((t: Any) => !obekvamDays.has(day(t.date))), "en beredskapsdag ersätts").toBe(true);
+  });
+
+  /**
+   * #950 steg 4: ett ärende ska visa HELA kategoribredden tillsammans med en
+   * prutning och utlägg med olika momssatser — annars går sammanställningens
+   * taxerader inte att granska mot verkligheten någonstans i demon.
+   */
+  it("ett brottmål använder alla arvodeskategorier + flera momssatser", async () => {
+    const { c } = await simulateDemo();
+    const matters = (await c.matter.list({})).matters as Any[];
+
+    const spreads = await Promise.all(matters.map(async (m: Any) => {
+      const te = await c.timeEntry.list({ matterId: m.id, pageSize: 100 });
+      const ex = await c.expense.list({ matterId: m.id, pageSize: 100 });
+      return {
+        kinds: new Set(((te.entries ?? te.timeEntries ?? []) as Any[]).map((t: Any) => t.kind ?? "ARBETE")),
+        vatRates: new Set(((ex.expenses ?? ex.items ?? ex) as Any[]).map((e: Any) => e.vatRate)),
+      };
+    }));
+
+    const ALL_KINDS = ["ARBETE", "ARBETE_OBEKVAM_TID", "TIDSSPILLAN", "TIDSSPILLAN_OVRIG_TID", "ADVOKATBEREDSKAP"];
+    const full = spreads.find((s) => ALL_KINDS.every((k) => s.kinds.has(k)));
+    expect(full, `inget ärende har alla kategorier: ${ALL_KINDS.join(", ")}`).toBeTruthy();
+    expect(full!.vatRates.size, "…och mer än en momssats bland utläggen").toBeGreaterThan(1);
+  });
+
+  /**
    * #828 steg 6: demodata i ALLA lägen. Kostnadsräkningens state-maskin har fyra
    * statusar, och panelen har en egen vy per status — men demon visade bara två
    * (inskickad och fakturerad). Överklagandespåret fanns bara i koden: varken

--- a/test/unit/app/matters/time-section.test.tsx
+++ b/test/unit/app/matters/time-section.test.tsx
@@ -78,19 +78,42 @@ describe("TimeSection — arvodeskategori (#953)", () => {
     expect(screen.getByText("Arbete")).toBeInTheDocument();
   });
 
-  it("formuläret erbjuder alla fyra kategorierna och skickar den valda", () => {
+  it("formuläret erbjuder alla arvodeskategorier och skickar den valda", () => {
     render(<TimeSection matterId={matterId} />);
     fireEvent.click(screen.getByText("+ Registrera tid"));
     const select = screen.getByLabelText("Arvodeskategori *");
     expect(select).toHaveValue("ARBETE"); // default
     const values = Array.from((select as HTMLSelectElement).options).map((o) => o.value);
-    expect(values).toEqual(["ARBETE", "ARBETE_OBEKVAM_TID", "TIDSSPILLAN", "TIDSSPILLAN_OVRIG_TID"]);
+    expect(values).toEqual([
+      "ARBETE", "ARBETE_OBEKVAM_TID", "TIDSSPILLAN", "TIDSSPILLAN_OVRIG_TID", "ADVOKATBEREDSKAP",
+    ]);
 
     fireEvent.change(select, { target: { value: "TIDSSPILLAN_OVRIG_TID" } });
     fireEvent.change(screen.getByPlaceholderText("Beskrivning *"), { target: { value: "Hemresa efter kvällssammanträde" } });
     fireEvent.click(screen.getByText("Spara"));
     expect(createMutate).toHaveBeenCalledWith(expect.objectContaining({
       matterId, kind: "TIDSSPILLAN_OVRIG_TID", description: "Hemresa efter kvällssammanträde",
+    }));
+  });
+
+  /**
+   * Advokatberedskap ersätts per dygn (#950): det finns ingen tid att mata in,
+   * och minuterna måste nollas när kategorin väljs — annars följer förra
+   * postens halvtimme med in i varje timbaserad summa.
+   */
+  it("beredskap byter ut minutfältet mot ett dygn och skickar noll minuter", () => {
+    render(<TimeSection matterId={matterId} />);
+    fireEvent.click(screen.getByText("+ Registrera tid"));
+    expect(screen.getByLabelText("Tid (minuter) *")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Arvodeskategori *"), { target: { value: "ADVOKATBEREDSKAP" } });
+    expect(screen.queryByLabelText("Tid (minuter) *")).not.toBeInTheDocument();
+    expect(screen.getByText("1 dygns beredskap")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText("Beskrivning *"), { target: { value: "Helgjour tingsrätten" } });
+    fireEvent.click(screen.getByText("Spara"));
+    expect(createMutate).toHaveBeenCalledWith(expect.objectContaining({
+      matterId, kind: "ADVOKATBEREDSKAP", minutes: 0,
     }));
   });
 

--- a/test/unit/lib/advokatberedskap.test.ts
+++ b/test/unit/lib/advokatberedskap.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Advokatberedskapens garantiersättning (#950) — DVFS 2024:20 / 2025:9.
+ *
+ * Två saker skiljer kategorin från alla andra, och båda testas här:
+ *
+ * 1. Den ersätts **per dag**, inte per timme. En post är ett dygns beredskap och
+ *    bär noll minuter — beredskap är inte arbetad tid. Värderas den med
+ *    `minuter × timnorm` blir den tyst noll, vilket är exakt den felmod
+ *    `coverageEntryValueOre` finns för att förhindra.
+ * 2. Den utgår **inte** för dag då biträdet är berättigat ersättning för arbete
+ *    efter helgförhandling eller polisförhör utom kontorstid (§ 2). Blev man
+ *    inkallad betalas arbetet i stället för garantin.
+ *
+ * Beloppen är avlästa ur föreskrifterna: 2 487 kr/dag (DVFS 2024:20 § 1, gäller
+ * 2025) och 2 550 kr/dag (DVFS 2025:9 § 1, gäller 2026).
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import {
+  advokatberedskapFtaxForDate, coverageEntryValueOre, isPerDayKind,
+  payableCoverageEntries, type CoverageEntryLike,
+} from "@/lib/shared/brottmalstaxa";
+
+const beredskap = (date: string): CoverageEntryLike => ({ date, minutes: 0, kind: "ADVOKATBEREDSKAP" });
+const obekvam = (date: string, minutes = 120): CoverageEntryLike => ({ date, minutes, kind: "ARBETE_OBEKVAM_TID" });
+
+describe("advokatberedskap — belopp per dag", () => {
+  it("2026 års belopp är 2 550 kr/dag, 2025 års 2 487", () => {
+    expect(advokatberedskapFtaxForDate("2026-06-01")).toBe(255_000);
+    expect(advokatberedskapFtaxForDate("2025-06-01")).toBe(248_700);
+  });
+
+  it("kategorin är per-dygn, övriga är per-timme", () => {
+    expect(isPerDayKind("ADVOKATBEREDSKAP")).toBe(true);
+    for (const k of ["ARBETE", "ARBETE_OBEKVAM_TID", "TIDSSPILLAN", "TIDSSPILLAN_OVRIG_TID", null, undefined] as const) {
+      expect(isPerDayKind(k), `${String(k)} ska inte vara per-dygn`).toBe(false);
+    }
+  });
+});
+
+describe("coverageEntryValueOre", () => {
+  it("beredskap värderas till dagbeloppet — oavsett minuter", () => {
+    expect(coverageEntryValueOre(beredskap("2026-05-02"), "2026-05-02")).toBe(255_000);
+    // Även om någon råkat registrera minuter ska dagbeloppet gälla: kategorin
+    // har ingen timnorm att multiplicera med.
+    expect(coverageEntryValueOre({ ...beredskap("2026-05-02"), minutes: 480 }, "2026-05-02")).toBe(255_000);
+  });
+
+  it("värderas på VÄRDERINGSDATUMETS år (retroaktiv höjning, #891)", () => {
+    // Posten är från 2025 men slutregleras 2026 → 2026 års belopp.
+    expect(coverageEntryValueOre(beredskap("2025-12-27"), "2026-03-01")).toBe(255_000);
+    expect(coverageEntryValueOre(beredskap("2025-12-27"), "2025-12-31")).toBe(248_700);
+  });
+
+  it("timbaserade kategorier räknas som förut", () => {
+    // 120 min arbete på obekväm tid 2026: 3 256 kr/h → 6 512 kr.
+    expect(coverageEntryValueOre(obekvam("2026-05-02"), "2026-05-02")).toBe(651_200);
+    // 30 min arbete 2026: 1 626 / 2 = 813 kr.
+    expect(coverageEntryValueOre({ date: "2026-05-02", minutes: 30, kind: "ARBETE" }, "2026-05-02")).toBe(81_300);
+  });
+});
+
+describe("payableCoverageEntries — DVFS 2025:9 § 2", () => {
+  it("beredskapen faller bort för dag med arbete på obekväm tid", () => {
+    const entries = [beredskap("2026-05-02"), obekvam("2026-05-02")];
+    const payable = payableCoverageEntries(entries);
+    expect(payable).toHaveLength(1);
+    expect(payable[0]!.kind).toBe("ARBETE_OBEKVAM_TID");
+  });
+
+  it("…men bara för DEN dagen — övriga beredskapsdagar står kvar", () => {
+    const entries = [beredskap("2026-05-02"), beredskap("2026-05-03"), obekvam("2026-05-02")];
+    const kept = payableCoverageEntries(entries).filter((e) => e.kind === "ADVOKATBEREDSKAP");
+    expect(kept.map((e) => e.date)).toEqual(["2026-05-03"]);
+  });
+
+  it("jämförelsen gäller DAGEN, inte tidpunkten", () => {
+    // Förhandlingen ligger kl 09 och beredskapen är daterad midnatt — samma dag.
+    const entries = [
+      { date: "2026-05-02T00:00:00.000Z", minutes: 0, kind: "ADVOKATBEREDSKAP" as const },
+      { date: "2026-05-02T09:30:00.000Z", minutes: 90, kind: "ARBETE_OBEKVAM_TID" as const },
+    ];
+    expect(payableCoverageEntries(entries).some((e) => e.kind === "ADVOKATBEREDSKAP")).toBe(false);
+  });
+
+  it("ICKE-debiterbart arbete tar inte garantin", () => {
+    // "Berättigad ersättning för arbete" — är arbetet inte debiterbart utgår
+    // ingen ersättning för det, och garantin står kvar.
+    const entries = [beredskap("2026-05-02"), { ...obekvam("2026-05-02"), billable: false }];
+    expect(payableCoverageEntries(entries).some((e) => e.kind === "ADVOKATBEREDSKAP")).toBe(true);
+  });
+
+  it("vanligt arbete samma dag tar INTE garantin", () => {
+    // Bara helgförhandling/polisförhör (ARBETE_OBEKVAM_TID) utlöser § 2.
+    const entries = [beredskap("2026-05-02"), { date: "2026-05-02", minutes: 60, kind: "ARBETE" as const }];
+    expect(payableCoverageEntries(entries).some((e) => e.kind === "ADVOKATBEREDSKAP")).toBe(true);
+  });
+
+  it("utan beredskapsposter är funktionen en identitet", () => {
+    const entries = [obekvam("2026-05-02"), { date: "2026-05-03", minutes: 60, kind: "ARBETE" as const }];
+    expect(payableCoverageEntries(entries)).toEqual(entries);
+  });
+});

--- a/test/unit/server/routers/advokatberedskap-flow.test.ts
+++ b/test/unit/server/routers/advokatberedskap-flow.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Advokatberedskapen genom faktureringsvägarna (#950).
+ *
+ * Enhetstesterna i `advokatberedskap.test.ts` täcker normen och § 2-regeln som
+ * ren logik. Här testas det som gör den lätt att tappa: kategorin bär NOLL
+ * minuter, och varje väg som räknar `minuter × taxa` ger då tyst noll. Det
+ * hände inte hypotetiskt — `carveEarliestMinutes` svalde hela posten och
+ * `arvodeNetOre` värderade den till 0 innan de fixades.
+ *
+ * Vägarna som måste bära beloppet:
+ *   - kostnadsräkningen till domstol (offentligt uppdrag — beredskapens hem)
+ *   - fakturaförslaget ("Upparbetat ofakturerat")
+ *   - slutregleringen i täckningsärenden (rättshjälp)
+ */
+import { describe, it, expect } from "vitest-compat";
+import { noopPorts } from "@/lib/server/adapters/noop-ports";
+import type { Principal } from "@/lib/server/auth/principal";
+import { buildContext } from "@/lib/server/build-context";
+import { DemoDataStore } from "@/lib/server/data-store/DemoDataStore";
+import { appRouter } from "@/lib/server/routers/_app";
+import { asId } from "@/lib/shared/schemas/ids";
+
+const PRINCIPAL: Principal = {
+  id: asId<"UserId">("u-1"), email: "a@x", name: "Anna", role: "ADMIN", organizationId: asId<"OrganizationId">("org-1"),
+};
+
+const DAG_2026 = 255_000; // 2 550 kr (DVFS 2025:9 § 1)
+const HELG = new Date("2026-05-02T09:00:00.000Z"); // beredskapsdag med förhandling
+const LUGN = new Date("2026-05-03T00:00:00.000Z"); // beredskapsdag utan arbete
+
+interface EntrySpec {
+  id: string;
+  date: Date;
+  minutes: number;
+  kind?: "ADVOKATBEREDSKAP" | "ARBETE_OBEKVAM_TID" | "TIDSSPILLAN";
+  hourlyRate?: number;
+  billable?: boolean;
+}
+
+function makeCaller(entries: readonly EntrySpec[], paymentMethod = "OFFENTLIGT_UPPDRAG") {
+  const ds = new DemoDataStore({
+    organizations: [{ id: "org-1", name: "X" }],
+    matters: [{ id: "m-1", organizationId: "org-1", matterNumber: "2026-0001", title: "Brottmål", status: "ACTIVE", paymentMethod, createdAt: new Date() }],
+    users: [{ id: "u-1", organizationId: "org-1", email: "a@x", name: "Anna", role: "ADMIN", hourlyRate: 250_000 }],
+    timeEntries: entries.map((e) => ({
+      id: e.id, organizationId: "org-1", userId: "u-1", matterId: "m-1",
+      date: e.date, minutes: e.minutes, description: "Post",
+      hourlyRate: e.hourlyRate ?? 250_000, billable: e.billable ?? true,
+      ...(e.kind ? { kind: e.kind } : {}),
+    })),
+    expenses: [],
+  }, async () => { /* writable: noop write-back */ });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return appRouter.createCaller(buildContext({ dataStore: ds, ports: noopPorts, principal: PRINCIPAL }) as any);
+}
+
+/** En beredskapsdag: noll minuter, dagbeloppet som á-pris. */
+const beredskap = (id: string, date: Date): EntrySpec =>
+  ({ id, date, minutes: 0, kind: "ADVOKATBEREDSKAP", hourlyRate: DAG_2026 });
+
+describe("advokatberedskap i kostnadsräkningen (offentligt uppdrag)", () => {
+  it("dagbeloppet kommer med i det yrkade — inte noll", async () => {
+    const caller = makeCaller([beredskap("te-1", LUGN)]);
+    const { run } = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
+    // Enda posten är beredskapen → arvodet är dagbeloppet, brutto inkl 25 % moms.
+    expect(run.workValueOreAtRun).toBe(Math.round(DAG_2026 * 1.25));
+  });
+
+  it("beredskapen läggs till arbetet, inte i stället för", async () => {
+    const caller = makeCaller([
+      beredskap("te-1", LUGN),
+      { id: "te-2", date: LUGN, minutes: 120, hourlyRate: 250_000 }, // 2 h × 2 500 kr
+    ]);
+    const { run } = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
+    expect(run.workValueOreAtRun).toBe(Math.round((DAG_2026 + 500_000) * 1.25));
+  });
+
+  it("§ 2: dag med helgförhandling ger arbetet — inte garantin", async () => {
+    const caller = makeCaller([
+      beredskap("te-1", HELG),
+      { id: "te-2", date: HELG, minutes: 90, kind: "ARBETE_OBEKVAM_TID", hourlyRate: 325_600 },
+    ]);
+    const { run } = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
+    // Bara arbetet: 90 min × 3 256 kr/h = 4 884 kr.
+    expect(run.workValueOreAtRun).toBe(Math.round(488_400 * 1.25));
+  });
+
+  it("två beredskapsdygn där ETT förbrukas → ett dygn kvar", async () => {
+    const caller = makeCaller([
+      beredskap("te-1", LUGN),
+      beredskap("te-2", HELG),
+      { id: "te-3", date: HELG, minutes: 90, kind: "ARBETE_OBEKVAM_TID", hourlyRate: 325_600 },
+    ]);
+    const { run } = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
+    expect(run.workValueOreAtRun).toBe(Math.round((DAG_2026 + 488_400) * 1.25));
+  });
+});
+
+describe("advokatberedskap i fakturaförslaget", () => {
+  it("syns som en rad med dagbeloppet i 'Upparbetat ofakturerat'", async () => {
+    const caller = makeCaller([beredskap("te-1", LUGN)]);
+    const proposal = await caller.billingRun.proposal({ matterId: "m-1" });
+    const row = proposal.timeEntries.find((t) => t.id === "te-1");
+    expect(row, "beredskapsposten ska finnas i förslaget").toBeDefined();
+    expect(row?.valueOre).toBe(DAG_2026);
+    expect(proposal.workValueOre).toBe(DAG_2026);
+  });
+
+  it("en förbrukad beredskapsdag erbjuds inte alls", async () => {
+    const caller = makeCaller([
+      beredskap("te-1", HELG),
+      { id: "te-2", date: HELG, minutes: 90, kind: "ARBETE_OBEKVAM_TID", hourlyRate: 325_600 },
+    ]);
+    const proposal = await caller.billingRun.proposal({ matterId: "m-1" });
+    expect(proposal.timeEntries.map((t) => t.id)).toEqual(["te-2"]);
+  });
+});
+
+describe("advokatberedskap i täckningsärenden (rättshjälp)", () => {
+  it("värderas på Domstolsverkets dagbelopp, inte på postens timtaxa", async () => {
+    // Posten bär medvetet en felaktig timtaxa: årstabellen ska vinna.
+    const caller = makeCaller(
+      [{ ...beredskap("te-1", LUGN), hourlyRate: 1 }],
+      "RATTSHJALP",
+    );
+    const proposal = await caller.billingRun.proposal({ matterId: "m-1" });
+    expect(proposal.workValueOre).toBe(DAG_2026);
+  });
+
+  it("överlever rådgivningstimmens carve-out (noll minuter äts inte upp)", async () => {
+    // Rättshjälpens första timme carvas bort ur kostnadsräkningen. En post utan
+    // minuter kan inte vara en del av den — men `0 <= 60` svalde den förut.
+    const caller = makeCaller([
+      beredskap("te-1", LUGN),
+      { id: "te-2", date: LUGN, minutes: 60, hourlyRate: 162_600 },
+    ], "RATTSHJALP");
+    const { run } = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
+    // Rådgivningstimmen (60 min) carvas → bara beredskapens dagbelopp kvar.
+    expect(run.workValueOreAtRun).toBe(Math.round(DAG_2026 * 1.25));
+  });
+});
+
+describe("tidsposten som bär beredskapen", () => {
+  it("noll minuter accepteras för beredskap", async () => {
+    const caller = makeCaller([]);
+    const entry = await caller.timeEntry.create({
+      matterId: "m-1", date: "2026-05-03", minutes: 0,
+      description: "Advokatberedskap", kind: "ADVOKATBEREDSKAP",
+    });
+    expect(entry.minutes).toBe(0);
+    // Á-priset sätts till dagbeloppet, inte användarens timtaxa.
+    expect((entry as { hourlyRate: number }).hourlyRate).toBe(DAG_2026);
+  });
+
+  it("noll minuter avvisas för vanliga kategorier", async () => {
+    const caller = makeCaller([]);
+    await expect(caller.timeEntry.create({
+      matterId: "m-1", date: "2026-05-03", minutes: 0, description: "Möte",
+    })).rejects.toThrow(/minst en minut/i);
+  });
+});

--- a/tooling/demo-generator/simulate/scenarios/index.ts
+++ b/tooling/demo-generator/simulate/scenarios/index.ts
@@ -26,7 +26,7 @@ import { buildRattsskyddPositivtScenario } from "./rattsskydd-positivt";
 const OFFENTLIGT_STOPS: Record<string, OffentligtOpts> = {
   "2026-0016": { stopAfter: "beslut", reducedByBips: 1000 },
   "2026-0017": { stopAfter: "kostnadsrakning" },
-  "2026-0019": { stopAfter: "overklaga", reducedByBips: 2500 },
+  "2026-0019": { stopAfter: "overklaga", reducedByBips: 2500, allCategories: true },
 };
 
 function offentligtOpts(matterNumber: string | undefined): OffentligtOpts {

--- a/tooling/demo-generator/simulate/scenarios/offentligt.ts
+++ b/tooling/demo-generator/simulate/scenarios/offentligt.ts
@@ -33,7 +33,26 @@ export interface OffentligtOpts {
    * begripligt: man överklagar prutningen, inte beslutet i stort.
    */
   reducedByBips?: number;
+  /**
+   * Lägg till de kategorier som annars inte förekommer på ett brottmål —
+   * tidsspillan dag/annan tid — plus ett utlägg med en ANNAN momssats (#950
+   * steg 4). Ett ärende ska visa hela kategoribredden tillsammans med en
+   * prutning, så att sammanställningen går att granska rad för rad.
+   */
+  allCategories?: boolean;
 }
+
+/**
+ * Kategorierna som saknas i grundmallen (#950 steg 4). Tidsspillan har två
+ * nivåer med olika årsnormer — 1 487 kr/h vardag 08–18 och 975 kr/h annan tid
+ * (DVFS 2025:4 § 4) — och utlägget bär 6 % moms så specifikationen får mer än
+ * en momssats att summera.
+ */
+const FULL_SPREAD: readonly SimEvent[] = [
+  { kind: "time", dayOffset: 18, minutes: 120, description: "Restid till häktet — vardag dagtid", entryKind: "TIDSSPILLAN" },
+  { kind: "time", dayOffset: 19, minutes: 90, description: "Väntetid inför förhandling — kvällstid", entryKind: "TIDSSPILLAN_OVRIG_TID" },
+  { kind: "expense", dayOffset: 19, amountOre: 24_000, description: "Tågbiljett till häktet", vatRate: 600 },
+];
 
 export function buildOffentligtScenario(parties: Parties, opts: OffentligtOpts = {}): SimEvent[] {
   const ev: SimEvent[] = [
@@ -46,6 +65,14 @@ export function buildOffentligtScenario(parties: Parties, opts: OffentligtOpts =
     { kind: "doc", dayOffset: 4, template: "brevTillOmbud" },
     { kind: "time", dayOffset: 12, minutes: 180, description: "Klientmöte + förberedelse inför huvudförhandling" },
     { kind: "time", dayOffset: 20, minutes: 120, description: "Huvudförhandling i tingsrätten" },
+    // Advokatberedskap (#950, DVFS 2025:9): två beredskapsdygn, varav det ena
+    // "förbrukas" av en häktningsförhandling — då utgår arbetet i stället för
+    // garantin (§ 2). Demon visar båda utfallen på samma ärende; annars syns
+    // regeln bara i koden.
+    { kind: "time", dayOffset: 14, minutes: 0, description: "Advokatberedskap — helgjour tingsrätten", entryKind: "ADVOKATBEREDSKAP" },
+    { kind: "time", dayOffset: 15, minutes: 0, description: "Advokatberedskap — helgjour tingsrätten", entryKind: "ADVOKATBEREDSKAP" },
+    { kind: "time", dayOffset: 15, minutes: 90, description: "Häktningsförhandling under helg", entryKind: "ARBETE_OBEKVAM_TID" },
+    ...(opts.allCategories ? FULL_SPREAD : []),
     { kind: "kostnadsrakning", dayOffset: 22 },
   );
   if (opts.stopAfter === "kostnadsrakning") return ev;


### PR DESCRIPTION
Stänger #950 — sista kategorin, efter avgränsningen i din kommentar.

## Problemet var inte beloppet

`ADVOKATBEREDSKAP_FTAX_BY_YEAR` fanns redan. Det som saknades var postmodellen: ersättningen utgår **per dygn**, inte per timme, och AVA:s tidspost är minuter × timtaxa hela vägen.

Kategorin bär därför **noll minuter** — beredskap *är* inte arbetad tid, och påhittade minuter hade förorenat varje timbaserad summa: upparbetat, rättsskyddets timtak, rapporterna. Priset för det valet är att varje väg som räknar `minuter × taxa` tyst ger noll, så värderingen går genom **en** funktion, `coverageEntryValueOre`, och `isPerDayKind` finns för att en bortglömd plats ska gå att hitta.

## Två tysta nollor som redan låg där

Båda hittade av de nya testerna, båda verifierade genom att köra testerna mot koden före fixen:

1. **`carveEarliestMinutes` åt upp posten.** Rättshjälpens rådgivningstimme carvas bort kronologiskt; `0 <= left` matchade beredskapsposten, som utelämnades **utan att ens konsumera en minut** av kvoten. Poster utan minuter passerar nu orörda.
2. **`arvodeNetOre` och fakturaförslaget värderade den till noll.** Det slog just där kategorin hör hemma — offentliga uppdrags kostnadsräkning — och i "Upparbetat ofakturerat".

## § 2 — regeln, inte bara taxan

> *Garantiersättning utgår inte för dag när advokaten eller juristen är berättigad ersättning för arbete i anledning av att en helgförhandling (jämför DVFS 2025:7) eller ett polisförhör utanför ordinarie kontorstid (jämför DVFS 2025:8), ägt rum.*

`payableCoverageEntries` filtrerar bort beredskapsdagar som krockar med en **debiterbar** `ARBETE_OBEKVAM_TID`-post, och läggs först i varje värderingsväg. Icke-debiterbart arbete tar inte garantin — då är man inte "berättigad ersättning".

## Källkontroll: föreskriftsreferensen var fel

Koden pekade på "DVFS 2024:20 / 2025:7". Rätt författning är **DVFS 2025:9** (och 2024:20 för 2025). Jag hämtade och avkodade Domstolsverkets PDF:er i stället för att lita på minnet:

| | Belopp | Kvot utan F-skatt |
|---|---|---|
| DVFS 2024:20 § 1 (2025) | 2 487 kr/dag | 1207/1586 |
| DVFS 2025:9 § 1 (2026) | 2 550 kr/dag | 1237/1626 |

Beloppen i tabellen stämde. Referensen och § 2:s ordalydelse gjorde det inte.

## Kostnadsräkningen blev kategori-medveten på köpet

`valuateTimeLines` delade in i "tidsspillan eller arbete" och missade därmed `TIDSSPILLAN_OVRIG_TID` och `ARBETE_OBEKVAM_TID` — de värderades som vanligt arbete. Den använder nu samma `coverageEntryRateOre` som slutregleringen, och kvoten utan F-skatt tillämpas **per kategori och år** i stället för en platt timkostnadsnorm.

## Demon

Åtta beredskapsdygn över de fyra brottmålen — varje ärende har ett dygn som ersätts och ett som förbrukats av en helgförhandling, så båda utfallen syns. De fyra KR:erna gick från 14 702,50 till 20 938,75 kr brutto (+2 550 beredskap +2 439 helgförhandling, netto).

**2026-0019** använder nu alla fem kategorier + utlägg med två momssatser och prutas med 25 % — issuens **steg 4**.

## Tester

- `advokatberedskap.test.ts` (11): normen, per-dygns-värderingen, retroaktiviteten och § 2 i alla riktningar — inklusive att vanligt arbete samma dag *inte* tar garantin.
- `advokatberedskap-flow.test.ts` (10): beloppet genom kostnadsräkningen, fakturaförslaget och täckningsärendenas väg, plus carve-outen och postens noll-minuters-regel. **Tre av dem failar mot koden före fixen** — verifierat.
- Två nya demodata-grindar: beredskapsdygn finns i båda utfallen, och ett ärende bär hela kategoribredden.

## Kvar (rapporterat, inte gjort)

`arvodeNetOre` värderar timbaserade poster på **postens egen taxa** för offentligt uppdrag. Domstolen ersätter enligt Domstolsverkets nivåer, så `ARBETE_OBEKVAM_TID` betalas där fortfarande på ärendets timtaxa i stället för 3 256 kr/h. Beredskapen är immun (den läser alltid årstabellen), men grannen är det inte. Det är #950:s steg 3-territorium för OFFENTLIGT_UPPDRAG och förtjänar en egen issue snarare än att smygas in här — säg till så lägger jag upp den.

## Grindar

`typecheck` ✓ · `lint` ✓ · `lint:complexity-strict` ✓ · `knip` ✓ · `deps:check` ✓ · `jscpd` ✓ · `build:demo` ✓ · **`e2e:demo` 33/33** ✓ · `test/unit/server` 1148/1148 ✓ · `test/scripts` 195/195 ✓

`test/unit/lib` och `test/unit/components` visar samma katalogkörnings-fel som `main` (43 resp. 38, känt mock-läckage #92) — jämfört rad för rad mot stashad ändring.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_