### PR TITLE
feat(taxa): årsindexera brottmålstaxan och välj årgång på yrkandedatumet

### DIFF
--- a/src/lib/shared/brottmalstaxa.ts
+++ b/src/lib/shared/brottmalstaxa.ts
@@ -2,13 +2,23 @@
  * `brottmalstaxa` — Domstolsverkets föreskrifter om brottmålstaxa för
  * offentlig försvarare i tingsrätt och hovrätt.
  *
- * Bygger på **DVFS 2025:6** (gäller fr.o.m. 2026-01-01). Tabellen
- * är fastställd av Domstolsverket och uppdateras årligen — vid byte
- * av år: byt ut `BROTTMALSTAXA_TABLE` mot nya beloppen.
+ * Tabellerna är fastställda av Domstolsverket och ersätts årligen av en NY
+ * föreskrift. Ett år raderar inte det föregående (#1004): varje årgång ligger
+ * kvar i `BROTTMALSTAXA_TABLE_BY_YEAR` och väljs på YRKANDEDATUMET, eftersom
+ * övergångsbestämmelserna knyter ersättningen dit:
  *
- * Källa:
- *   https://www.domstol.se/globalassets/filer/gemensamt-innehall/for-
- *   professionella-aktorer/dvfs/2025/dvfs_2025-6.pdf
+ *   "Äldre föreskrifter gäller fortfarande i fråga om yrkande om ersättning
+ *    till offentlig försvarare som framställs före den 1 januari 2026."
+ *    (DVFS 2025:6 p. 3 — samma lydelse i 2024:17)
+ *
+ * En kostnadsräkning som lämnas in efter ett årsskifte ska alltså värderas på
+ * det nya årets taxa, och en äldre räkning måste gå att räkna om i efterhand.
+ *
+ * Källor (avlästa ur föreskrifternas bilagor, inte ur minnet):
+ *   2025: https://www.domstol.se/globalassets/filer/gemensamt-innehall/for-
+ *         professionella-aktorer/dvfs/2024/dvfs_2024-17.pdf
+ *   2026: https://www.domstol.se/globalassets/filer/gemensamt-innehall/for-
+ *         professionella-aktorer/dvfs/2025/dvfs_2025-6.pdf
  *
  * Tillämpning:
  *   - En tilltalad + en offentlig försvarare
@@ -287,12 +297,50 @@ interface TaxaRow {
 }
 
 /**
- * DVFS 2025:6 Bilaga. Belopp i öre (kr × 100). Källans tabell:
+ * DVFS 2024:17 Bilaga — gäller yrkanden som framställs under 2025. Belopp i öre
+ * (kr × 100); gränsvärdena står inom parentes i källan.
+ */
+const BROTTMALSTAXA_TABLE_2025: readonly TaxaRow[] = [
+  { fromMin:   0, toMin:  14, label: "0-14 min",
+    ersattning: [273900, 408100, 533400, 667600], gransvarde: [411500, 612300, 800300, 985100] },
+  { fromMin:  15, toMin:  29, label: "15-29 min",
+    ersattning: [290600, 424800, 550100, 684300], gransvarde: [435600, 636500, 824500, 1000200] },
+  { fromMin:  30, toMin:  44, label: "30-44 min",
+    ersattning: [342200, 476400, 601700, 735900], gransvarde: [514000, 714400, 919100, 1051700] },
+  { fromMin:  45, toMin:  59, label: "45-59 min",
+    ersattning: [394800, 529000, 654300, 788500], gransvarde: [591400, 791800, 970600, 1104900] },
+  { fromMin:  60, toMin:  74, label: "1 tim - 1 tim 14 min",
+    ersattning: [446900, 581100, 706400, 840600], gransvarde: [668700, 870700, 1022700, 1155900] },
+  { fromMin:  75, toMin:  89, label: "1 tim 15 min - 1 tim 29 min",
+    ersattning: [497900, 632100, 757400, 891600], gransvarde: [747200, 949700, 1074800, 1209100] },
+  { fromMin:  90, toMin: 104, label: "1 tim 30 min - 1 tim 44 min",
+    ersattning: [549500, 683700, 809000, 943200], gransvarde: [825100, 1000200, 1125900, 1259600] },
+  { fromMin: 105, toMin: 119, label: "1 tim 45 min - 1 tim 59 min",
+    ersattning: [601100, 735300, 860600, 994800], gransvarde: [919100, 1051700, 1178500, 1311200] },
+  { fromMin: 120, toMin: 134, label: "2 tim - 2 tim 14 min",
+    ersattning: [653700, 787900, 913200, 1047400], gransvarde: [970600, 1104900, 1229500, 1364300] },
+  { fromMin: 135, toMin: 149, label: "2 tim 15 min - 2 tim 29 min",
+    ersattning: [704700, 838900, 964200, 1098400], gransvarde: [1022700, 1155900, 1281600, 1415400] },
+  { fromMin: 150, toMin: 164, label: "2 tim 30 min - 2 tim 44 min",
+    ersattning: [757400, 891600, 1016900, 1151100], gransvarde: [1074800, 1209100, 1333700, 1467500] },
+  { fromMin: 165, toMin: 179, label: "2 tim 45 min - 2 tim 59 min",
+    ersattning: [809500, 943700, 1069000, 1203200], gransvarde: [1126400, 1260100, 1385300, 1519000] },
+  { fromMin: 180, toMin: 194, label: "3 tim - 3 tim 14 min",
+    ersattning: [860500, 994700, 1120000, 1254200], gransvarde: [1179000, 1311700, 1438500, 1571700] },
+  { fromMin: 195, toMin: 209, label: "3 tim 15 min - 3 tim 29 min",
+    ersattning: [913100, 1047300, 1172600, 1306800], gransvarde: [1229500, 1364300, 1489000, 1622700] },
+  { fromMin: 210, toMin: 225, label: "3 tim 30 min - 3 tim 45 min",
+    ersattning: [964200, 1098400, 1223700, 1357900], gransvarde: [1281600, 1415400, 1541100, 1674800] },
+];
+
+/**
+ * DVFS 2025:6 Bilaga — gäller yrkanden som framställs från 2026-01-01. Källans
+ * tabell:
  *
  *   Förhandlingstid | Nivå 1 | Nivå 2 | Nivå 3 | Nivå 4
  *   (gränsvärden inom parentes nedanför nivåbeloppen i källan)
  */
-export const BROTTMALSTAXA_TABLE: readonly TaxaRow[] = [
+const BROTTMALSTAXA_TABLE_2026: readonly TaxaRow[] = [
   { fromMin:   0, toMin:  14, label: "0-14 min",
     ersattning: [280900, 418500, 547000, 684600], gransvarde: [421900, 627900, 820700, 1010200] },
   { fromMin:  15, toMin:  29, label: "15-29 min",
@@ -325,13 +373,39 @@ export const BROTTMALSTAXA_TABLE: readonly TaxaRow[] = [
     ersattning: [988700, 1126300, 1254800, 1392400], gransvarde: [1314300, 1451400, 1580300, 1717500] },
 ];
 
+/** Brottmålstaxans årgångar. Nytt år → lägg till en rad; ta ALDRIG bort en. */
+export const BROTTMALSTAXA_TABLE_BY_YEAR: Readonly<Record<number, readonly TaxaRow[]>> = {
+  2025: BROTTMALSTAXA_TABLE_2025,
+  2026: BROTTMALSTAXA_TABLE_2026,
+};
+
+/** Senast kända årgången — fallback när yrkandedatumet saknas eller ligger
+ *  bortom tabellen (samma konvention som timkostnadsnormen, #891). */
+export const BROTTMALSTAXA_TABLE: readonly TaxaRow[] = BROTTMALSTAXA_TABLE_2026;
+
+/** Taxetabellen som gäller för ett yrkande framställt `date` (#1004). */
+export function brottmalstaxaTableForDate(date: Date | string | undefined): readonly TaxaRow[] {
+  if (date === undefined) return BROTTMALSTAXA_TABLE;
+  return BROTTMALSTAXA_TABLE_BY_YEAR[yearOf(date)] ?? BROTTMALSTAXA_TABLE;
+}
+
 export interface ComputeOpts {
   /** Sammanlagd förhandlingstid (minuter) — räknas från målets påropas. */
   huvudforhandlingMinutes: number;
   /** Ersättningsnivå (1-4). Se nivåförklaringarna i fil-toppen. */
   level: TaxaLevel;
-  /** Default true. False → multiplicera med 1237/1626. */
+  /** Default true. False → multiplicera med årets kvot (1207/1586 för 2025,
+   *  1237/1626 för 2026). */
   hasFTax?: boolean;
+  /**
+   * När yrkandet framställs (#1004) — avgör vilken ÅRGÅNG av taxan som gäller,
+   * och vilken F-skatte-kvot som tillämpas. Utelämnad → senast kända året.
+   *
+   * Samma parameternamn och samma regel som `kostnadsrakning.ts` (#980):
+   * övergångsbestämmelserna knyter ersättningen till inlämningen, inte till
+   * förhandlingen.
+   */
+  yrkandeDate?: Date | string;
 }
 
 export type TaxaResultKind = "taxa-applies" | "exceeds-max" | "invalid-input";
@@ -382,8 +456,8 @@ function validateTaxaInput(huf: number, level: number): TaxaResult | null {
 }
 
 /** Slå upp taxa-rad + ersättning/gränsvärde för nivån (defensiva not-found-fall). */
-function findTaxaCell(huf: number, level: TaxaLevel): CellResult {
-  const row = BROTTMALSTAXA_TABLE.find((r) => huf >= r.fromMin && huf <= r.toMin);
+function findTaxaCell(huf: number, level: TaxaLevel, table: readonly TaxaRow[]): CellResult {
+  const row = table.find((r) => huf >= r.fromMin && huf <= r.toMin);
   if (!row) return { ok: false, note: "Hittade inget matchande intervall i tabellen." };
   const idx = level - 1;
   const e = row.ersattning[idx];
@@ -392,14 +466,21 @@ function findTaxaCell(huf: number, level: TaxaLevel): CellResult {
   return { ok: true, row, e, g };
 }
 
-/** F-skatt-justering: oförändrat belopp med F-skatt, annars nedjusterat. */
-function adjustForFTax(value: number, hasFTax: boolean): number {
-  return hasFTax ? value : applyNoFTaxFactor(value);
+/** F-skatt-justering: oförändrat belopp med F-skatt, annars nedjusterat med
+ *  YRKANDEÅRETS kvot (#1004) — den står i samma föreskrift som taxan. */
+function adjustForFTax(value: number, hasFTax: boolean, date: Date | string | undefined): number {
+  if (hasFTax) return value;
+  return date === undefined ? applyNoFTaxFactor(value) : applyNoFTaxFactorForDate(value, date);
 }
 
-function buildNotes(hasFTax: boolean, huf: number, row: TaxaRow): string[] {
+function buildNotes(hasFTax: boolean, huf: number, row: TaxaRow, date: Date | string | undefined): string[] {
   const notes: string[] = [];
-  if (!hasFTax) notes.push("Justerat för advokat utan F-skatt (× 1237/1626).");
+  if (!hasFTax) {
+    const q = date === undefined
+      ? { num: NO_FTAX_FACTOR_NUMERATOR, den: NO_FTAX_FACTOR_DENOMINATOR }
+      : noFTaxQuotientForDate(date);
+    notes.push(`Justerat för advokat utan F-skatt (× ${q.num}/${q.den}).`);
+  }
   notes.push("Belopp exkl moms. För advokat med F-skatt lägger Domstolsverket 25 % moms ovanpå.");
   if (huf > row.toMin - 5) {
     notes.push("Nära intervallets övre gräns — verifiera faktiskt avslutsklockslag.");
@@ -414,7 +495,7 @@ export function computeBrottmalstaxa(opts: ComputeOpts): TaxaResult {
   const invalid = validateTaxaInput(huf, level);
   if (invalid) return invalid;
 
-  const cell = findTaxaCell(huf, level);
+  const cell = findTaxaCell(huf, level, brottmalstaxaTableForDate(opts.yrkandeDate));
   if (!cell.ok) {
     return {
       kind: "invalid-input", intervalLabel: "", level,
@@ -427,9 +508,9 @@ export function computeBrottmalstaxa(opts: ComputeOpts): TaxaResult {
     kind: "taxa-applies",
     intervalLabel: cell.row.label,
     level,
-    ersattningExclVat: adjustForFTax(cell.e, hasFTax),
-    gransvardeExclVat: adjustForFTax(cell.g, hasFTax),
-    notes: buildNotes(hasFTax, huf, cell.row),
+    ersattningExclVat: adjustForFTax(cell.e, hasFTax, opts.yrkandeDate),
+    gransvardeExclVat: adjustForFTax(cell.g, hasFTax, opts.yrkandeDate),
+    notes: buildNotes(hasFTax, huf, cell.row, opts.yrkandeDate),
   };
 }
 

--- a/src/lib/shared/kostnadsrakning.ts
+++ b/src/lib/shared/kostnadsrakning.ts
@@ -195,8 +195,11 @@ function resolveTaxa(
   level: TaxaLevel,
 ): TaxaResult {
   const isTaxe = input.isTaxeArende ?? true;
+  // Yrkandedatumet väljer taxans ÅRGÅNG (#1004), på samma sätt som det väljer
+  // timkostnadsnormens år (#980) — övergångsbestämmelserna knyter ersättningen
+  // till när räkningen framställs.
   return isTaxe
-    ? computeBrottmalstaxa({ huvudforhandlingMinutes, level, hasFTax: input.hasFTax ?? true })
+    ? computeBrottmalstaxa({ huvudforhandlingMinutes, level, hasFTax: input.hasFTax ?? true, yrkandeDate: yrkandeDateOf(input) })
     : timkostnadsnormResult(totalArbetsMinutes, input.hasFTax ?? true);
 }
 

--- a/test/unit/shared/brottmalstaxa.test.ts
+++ b/test/unit/shared/brottmalstaxa.test.ts
@@ -1,8 +1,10 @@
 /**
- * Tester för brottmålstaxa (DVFS 2025:6). Belopp jämförs i öre.
+ * Tester för brottmålstaxa. Belopp jämförs i öre.
  *
- * Källa: tabellen i DVFS 2025:6 Bilaga (sid 4-5). Spot-checks från
- * tabellen + edge cases.
+ * Källor: DVFS 2024:17 Bilaga (yrkanden under 2025) och DVFS 2025:6 Bilaga
+ * (yrkanden från 2026-01-01). Spot-checks från tabellerna + edge cases. Taxan
+ * är årsindexerad (#1004) — strukturtesterna körs därför mot VARJE årgång, inte
+ * bara den senaste.
  */
 
 import { describe, it, expect } from "vitest-compat";
@@ -10,10 +12,12 @@ import {
   computeBrottmalstaxa,
   computeTimkostnadsnorm,
   BROTTMALSTAXA_TABLE,
+  BROTTMALSTAXA_TABLE_BY_YEAR,
   TAXA_MAX_MINUTES,
   TIMKOSTNADSNORM_FTAX_ORE_PER_H,
   TIMKOSTNADSNORM_NO_FTAX_ORE_PER_H,
   applyNoFTaxFactor,
+  brottmalstaxaTableForDate,
 } from "@/lib/shared/brottmalstaxa";
 
 describe("computeBrottmalstaxa — spot checks från DVFS 2025:6", () => {
@@ -163,31 +167,96 @@ describe("Validering", () => {
   });
 });
 
-describe("Tabellintegritet", () => {
+/**
+ * Taxans ÅRSDIMENSION (#1004) — samma buggklass som #980.
+ *
+ * Övergångsbestämmelserna (DVFS 2025:6 p. 3, samma lydelse i 2024:17) knyter
+ * ersättningen till NÄR YRKANDET FRAMSTÄLLS, inte till när förhandlingen hölls:
+ *
+ *   "Äldre föreskrifter gäller fortfarande i fråga om yrkande om ersättning
+ *    … som framställs före den 1 januari 2026."
+ *
+ * Alltså måste varje årgång ligga kvar och väljas på yrkandedatumet.
+ */
+describe("brottmålstaxans årgångar (#1004)", () => {
+  /** Samma förhandling: 1 tim 30 min, nivå 1 — bara yrkandedatumet skiljer. */
+  const huf90 = { huvudforhandlingMinutes: 90, level: 1 } as const;
+
+  it("samma förhandling ger OLIKA belopp på var sin sida om årsskiftet", () => {
+    const yrkat2025 = computeBrottmalstaxa({ ...huf90, yrkandeDate: "2025-12-20" });
+    const yrkat2026 = computeBrottmalstaxa({ ...huf90, yrkandeDate: "2026-01-10" });
+    expect(yrkat2025.ersattningExclVat).toBe(549_500); // 5 495 kr (DVFS 2024:17)
+    expect(yrkat2026.ersattningExclVat).toBe(563_500); // 5 635 kr (DVFS 2025:6)
+    expect(yrkat2026.ersattningExclVat).toBeGreaterThan(yrkat2025.ersattningExclVat);
+    // Intervallindelningen är densamma — det är beloppen som byts.
+    expect(yrkat2025.intervalLabel).toBe(yrkat2026.intervalLabel);
+  });
+
+  it("gränsvärdet följer med årgången", () => {
+    expect(computeBrottmalstaxa({ ...huf90, yrkandeDate: "2025-12-20" }).gransvardeExclVat).toBe(825_100);
+    expect(computeBrottmalstaxa({ ...huf90, yrkandeDate: "2026-01-10" }).gransvardeExclVat).toBe(846_100);
+  });
+
+  it("spot-check 2025: 0 min nivå 1 → 2 739 kr, 3 tim 45 min nivå 1 → 9 642 kr", () => {
+    const kort = computeBrottmalstaxa({ huvudforhandlingMinutes: 0, level: 1, yrkandeDate: "2025-06-01" });
+    expect(kort.ersattningExclVat).toBe(273_900);
+    expect(kort.gransvardeExclVat).toBe(411_500);
+    const lang = computeBrottmalstaxa({ huvudforhandlingMinutes: 225, level: 4, yrkandeDate: "2025-06-01" });
+    expect(lang.ersattningExclVat).toBe(1_357_900); // 13 579 kr, nivå 4
+  });
+
+  it("utan F-skatt används ÅRETS kvot — 1207/1586 för 2025, 1237/1626 för 2026", () => {
+    const r2025 = computeBrottmalstaxa({ ...huf90, hasFTax: false, yrkandeDate: "2025-12-20" });
+    const r2026 = computeBrottmalstaxa({ ...huf90, hasFTax: false, yrkandeDate: "2026-01-10" });
+    expect(r2025.ersattningExclVat).toBe(Math.round((549_500 * 1207) / 1586));
+    expect(r2026.ersattningExclVat).toBe(Math.round((563_500 * 1237) / 1626));
+    expect(r2025.notes.join(" ")).toMatch(/1207\/1586/);
+    expect(r2026.notes.join(" ")).toMatch(/1237\/1626/);
+  });
+
+  it("utelämnat yrkandedatum → senaste årgången (bakåtkompatibelt)", () => {
+    expect(computeBrottmalstaxa(huf90).ersattningExclVat)
+      .toBe(computeBrottmalstaxa({ ...huf90, yrkandeDate: "2026-01-10" }).ersattningExclVat);
+  });
+
+  it("år bortom tabellen faller tillbaka på den senaste årgången", () => {
+    // 2027 års föreskrift finns inte ännu — då är senaste kända taxan bästa
+    // gissningen, precis som för timkostnadsnormen (#891).
+    expect(brottmalstaxaTableForDate("2027-03-01")).toBe(BROTTMALSTAXA_TABLE);
+    expect(brottmalstaxaTableForDate(undefined)).toBe(BROTTMALSTAXA_TABLE);
+    expect(brottmalstaxaTableForDate(new Date("2025-06-01"))).not.toBe(BROTTMALSTAXA_TABLE);
+  });
+
+  it("BROTTMALSTAXA_TABLE är 2026 års årgång", () => {
+    expect(BROTTMALSTAXA_TABLE).toBe(BROTTMALSTAXA_TABLE_BY_YEAR[2026]);
+  });
+});
+
+describe.each(Object.entries(BROTTMALSTAXA_TABLE_BY_YEAR))("Tabellintegritet — %s års taxa", (_year, table) => {
   it("har 15 intervaller (0-14 till 210-225)", () => {
-    expect(BROTTMALSTAXA_TABLE).toHaveLength(15);
+    expect(table).toHaveLength(15);
   });
 
   it("varje intervall är 15 min (utom sista som är 16 = 210-225)", () => {
-    for (const r of BROTTMALSTAXA_TABLE) {
+    for (const r of table) {
       const width = r.toMin - r.fromMin + 1;
       expect(width === 15 || (r.fromMin === 210 && width === 16)).toBe(true);
     }
   });
 
   it("intervallen är sammanhängande (ingen lucka)", () => {
-    for (let i = 1; i < BROTTMALSTAXA_TABLE.length; i++) {
-      expect(BROTTMALSTAXA_TABLE[i]!.fromMin).toBe(BROTTMALSTAXA_TABLE[i - 1]!.toMin + 1);
+    for (let i = 1; i < table.length; i++) {
+      expect(table[i]!.fromMin).toBe(table[i - 1]!.toMin + 1);
     }
   });
 
   it("täcker exakt 0 till TAXA_MAX_MINUTES", () => {
-    expect(BROTTMALSTAXA_TABLE[0]!.fromMin).toBe(0);
-    expect(BROTTMALSTAXA_TABLE[BROTTMALSTAXA_TABLE.length - 1]!.toMin).toBe(TAXA_MAX_MINUTES);
+    expect(table[0]!.fromMin).toBe(0);
+    expect(table[table.length - 1]!.toMin).toBe(TAXA_MAX_MINUTES);
   });
 
   it("ersättning ökar monotont per nivå inom varje intervall", () => {
-    for (const r of BROTTMALSTAXA_TABLE) {
+    for (const r of table) {
       expect(r.ersattning[1]).toBeGreaterThan(r.ersattning[0]);
       expect(r.ersattning[2]).toBeGreaterThan(r.ersattning[1]);
       expect(r.ersattning[3]).toBeGreaterThan(r.ersattning[2]);
@@ -195,16 +264,22 @@ describe("Tabellintegritet", () => {
   });
 
   it("ersättning ökar monotont mellan intervaller (nivå 1)", () => {
-    for (let i = 1; i < BROTTMALSTAXA_TABLE.length; i++) {
-      expect(BROTTMALSTAXA_TABLE[i]!.ersattning[0]).toBeGreaterThan(BROTTMALSTAXA_TABLE[i - 1]!.ersattning[0]!);
+    for (let i = 1; i < table.length; i++) {
+      expect(table[i]!.ersattning[0]).toBeGreaterThan(table[i - 1]!.ersattning[0]!);
     }
   });
 
   it("gränsvärdet är alltid större än ersättningen", () => {
-    for (const r of BROTTMALSTAXA_TABLE) {
+    for (const r of table) {
       for (let lvl = 0; lvl < 4; lvl++) {
         expect(r.gransvarde[lvl]).toBeGreaterThan(r.ersattning[lvl]!);
       }
     }
+  });
+
+  it("intervallindelningen är identisk med den senaste årgången", () => {
+    // Bara beloppen ändras mellan åren; skulle indelningen ändras måste
+    // uppslagningen göras om, inte bara tabellen bytas.
+    expect(table.map((r) => r.label)).toEqual(BROTTMALSTAXA_TABLE.map((r) => r.label));
   });
 });

--- a/test/unit/shared/kostnadsrakning.test.ts
+++ b/test/unit/shared/kostnadsrakning.test.ts
@@ -296,3 +296,40 @@ describe("buildKostnadsrakningContext — rådgivningstimme (#383)", () => {
     expect(withR.billableArbetsMinutes).toBe(90);
   });
 });
+
+/**
+ * Brottmålstaxans årgång i kostnadsräkningen (#1004).
+ *
+ * Taxebeloppet ska väljas på YRKANDEDATUMET, precis som timkostnadsnormen redan
+ * gjorde (#980) — övergångsbestämmelserna knyter ersättningen till när räkningen
+ * framställs, inte till när förhandlingen hölls. Testet räknar samma förhandling
+ * två gånger, med yrkandedatum på var sin sida om ett årsskifte.
+ */
+describe("buildKostnadsrakningContext — taxans årgång (#1004)", () => {
+  /** Huvudförhandling i december 2025: 95 min, nivå 1. Bara yrkandedatumet skiljer. */
+  const decemberHuf = {
+    ...baseInput,
+    hufStart: new Date("2025-12-15T09:00:00"),
+    hufEnd: new Date("2025-12-15T10:35:00"),
+    timeEntries: [],
+  };
+
+  it("yrkande före årsskiftet → 2025 års taxa (5 495 kr)", () => {
+    const r = buildKostnadsrakningContext({ ...decemberHuf, yrkandeDate: "2025-12-20" });
+    expect(r.taxa.kind).toBe("taxa-applies");
+    expect(r.arvodeExclVat).toBe(549_500);
+  });
+
+  it("yrkande efter årsskiftet → 2026 års taxa (5 635 kr), samma förhandling", () => {
+    const r = buildKostnadsrakningContext({ ...decemberHuf, yrkandeDate: "2026-01-10" });
+    expect(r.arvodeExclVat).toBe(563_500);
+  });
+
+  it("momsen räknas på årets belopp, inte på ett fastfruset", () => {
+    const r2025 = buildKostnadsrakningContext({ ...decemberHuf, yrkandeDate: "2025-12-20" });
+    const r2026 = buildKostnadsrakningContext({ ...decemberHuf, yrkandeDate: "2026-01-10" });
+    expect(r2025.arvodeMoms).toBe(Math.round(549_500 * 0.25));
+    expect(r2026.arvodeMoms).toBe(Math.round(563_500 * 0.25));
+    expect(r2026.totalInclVat).toBeGreaterThan(r2025.totalInclVat);
+  });
+});


### PR DESCRIPTION
## Vad & varför

Brottmålstaxan var den enda normen i `brottmalstaxa.ts` utan årsdimension: en enda `BROTTMALSTAXA_TABLE` (DVFS 2025:6, gäller 2026), och `computeBrottmalstaxa` tog inget datum alls. Att "byta ut tabellen" vid årsskiftet raderar föregående år.

Övergångsbestämmelserna knyter ersättningen till **när yrkandet framställs**, inte till när förhandlingen hölls:

> Äldre föreskrifter gäller fortfarande i fråga om yrkande om ersättning … som framställs före den 1 januari 2026.
> — DVFS 2025:6 p. 3 (samma lydelse i 2024:17)

Alltså måste varje årgång ligga kvar och väljas på yrkandedatumet — samma tysta buggklass som #980, där hela räkningen värderades på `hufEnd` i stället för på yrkandedatumet.

**Ändringar**

- `BROTTMALSTAXA_TABLE_BY_YEAR` med 2025 (DVFS 2024:17) och 2026 (DVFS 2025:6). Beloppen är avlästa ur föreskrifternas bilagor, inte ur minnet; 2026-tabellen reproducerar den befintliga **exakt**, så inga belopp ändras i dag.
- `computeBrottmalstaxa({ …, yrkandeDate })` väljer årgång — och samma års F-skattekvot (1207/1586 för 2025, 1237/1626 för 2026), som står i samma föreskrift som taxan. Utelämnat datum → senaste årgången, precis som timkostnadsnormen (#891).
- `kostnadsrakning.ts:resolveTaxa` skickar in `yrkandeDateOf(input)` — det datum den redan värderar timnormerna på.
- Strukturtesterna (15 intervall, sammanhängande, monotona belopp, gränsvärde > ersättning) körs nu mot **varje** årgång via `describe.each`, plus en ny kontroll att intervallindelningen är identisk mellan åren — ändras den måste uppslagningen göras om, inte bara tabellen bytas.

**Avvikelse från issuen:** den gissade DVFS 2024:14 som 2025 års brottmålstaxa. Den faktiska föreskriften är **DVFS 2024:17** — 2025:6 säger uttryckligen "Genom dessa föreskrifter upphävs Domstolsverkets föreskrifter (DVFS 2024:17)". 2024:14 är timkostnadsnormen, som redan ligger rätt i filen.

Stänger #1004

## Typ

- [x] `feat` — ny funktion
- [ ] `fix` — buggfix
- [ ] `refactor` / `perf`
- [ ] `docs` / `test` / `chore` / `ci`

## Verifierat lokalt (speglar CI)

- [x] `typecheck` + `lint` + `knip` + `deps:check` + `duplicates` — rena
- [x] `bun run build:demo` — statisk export byggd (786 sökvägar, 21 ärenden; identisk data, taxan är oförändrad för 2026)
- [x] `bun run e2e:demo` — 33 passed
- [x] Berörda testfiler körda var för sig (per-fil-isolering, #92): brottmalstaxa 46, kostnadsrakning 34, kostnadsrakning-tidsspillan 6, advokatberedskap 11, billingRun 65, scenario-brottmal 15, scenario-rattshjalp 10, rattshjalp-taxor 5, timkostnadsnorm-schedule 4, kostnadsrakning-flow 9, faktura-template 8, generate-kr-doc 2, template-integration 3, kostnadsrakning-record 3, kostnadsrakning-modal 5, billing-panel 21, simulate-orchestrate 9, KR-docs 3 — alla gröna
- [x] Nya rader har täckande tester (årsval, gränsvärde, F-skattekvot per år, fallback, KR-nivå över årsskiftet)
- [x] Commits följer Conventional Commits (commitlint)

**Testet som issuen efterfrågade** räknar samma förhandling (95 min, nivå 1, december 2025) två gånger — yrkande 2025-12-20 ger 5 495 kr, yrkande 2026-01-10 ger 5 635 kr. Känsligheten är verifierad: tas `yrkandeDate` bort ur `resolveTaxa` faller båda KR-testerna.

## Kvalitetsgrindar

- [x] Inga gater lösgjorda — inga suppressions, ingen tröskel rörd
- [x] `src/lib/shared/` är CODEOWNERS-path: den nya tabellen är avläst ur källan och kontrollerad rad för rad mot den befintliga 2026-tabellen

## Övrigt

Kvarstående i samma familj: #1003 (offentligt uppdrag värderas på byråns egen timtaxa i stället för timkostnadsnormen).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_