### PR TITLE
feat(mcp): beskrivningar, synliga scheman och utdatabudget på verktygsytan

### DIFF
--- a/test/integration/mcp-server.test.ts
+++ b/test/integration/mcp-server.test.ts
@@ -25,6 +25,7 @@ import { describe, it, expect } from "vitest-compat";
 import { createLocalCaller } from "../../tooling/ava-cli/caller";
 import { listProcedures } from "../../tooling/ava-cli/introspect";
 import { buildAvaMcpServer, MCP_SERVER_NAME, toolName } from "../../tooling/ava-cli/mcp";
+import { MCP_DEFAULT_PAGE_SIZE } from "../../tooling/ava-cli/tool-descriptions";
 
 type Era = "modern" | "legacy";
 
@@ -157,6 +158,71 @@ describe.each<Era>(["legacy", "modern"])("ava-mcp över %s-epoken", (era) => {
     const { client, close } = await connect(era);
     try {
       await expect(client.callTool({ name: "finns__inte", arguments: {} })).rejects.toThrow();
+    } finally {
+      await close();
+    }
+  });
+});
+
+/**
+ * Utdatabudget (#1008) — en RATCHET i samma anda som bundle-size.
+ *
+ * MCP-klienter kapar verktygssvar (Claude Code varnar över 10 000 tokens och
+ * kapar vid 25 000). Ett kapat svar är värre än ett kort: JSON:en huggs av mitt
+ * i och modellen läser en halv sanning. Före #1008 låg `timeEntry.list` på
+ * 61,7 KB — på demo-seedens 130 tidsposter.
+ *
+ * Golvet är satt strax över dagens värsta (`invoice.list`, 43 758 tecken) och
+ * ska BARA flyttas nedåt. De värsta kvarvarande är de listor som saknar
+ * paginering helt (`invoice.list`, `paymentPlan.list`, `task.list`) — se #1011.
+ */
+const OUTPUT_BUDGET_CHARS = 45_000;
+
+describe("verktygens utdatabudget", () => {
+  it("inget verktyg som går att anropa utan argument spränger budgeten", async () => {
+    const { client, close } = await connect("legacy");
+    try {
+      // Procedurer med obligatorisk input kan inte anropas blint — de mäts inte
+      // här. Antalet asserteras så urvalet inte kan krympa tyst.
+      const callable = listProcedures().filter((p) => {
+        const schema = p.inputSchema as { required?: string[] } | null;
+        return p.type === "query" && (schema === null || (schema.required ?? []).length === 0);
+      });
+      expect(callable.length).toBeGreaterThanOrEqual(22);
+
+      const oversized: string[] = [];
+      for (const p of callable) {
+        const res = await client.callTool({ name: toolName(p.path), arguments: {} });
+        const size = textOf(res).length;
+        if (size > OUTPUT_BUDGET_CHARS) oversized.push(`${p.path}: ${size}`);
+      }
+      expect(oversized, `över budget (${OUTPUT_BUDGET_CHARS} tecken): ${oversized.join(", ")}`).toEqual([]);
+    } finally {
+      await close();
+    }
+  }, 60_000);
+
+  it("paginerade verktyg får MCP-ytans sidstorlek, inte zods egen", async () => {
+    // `timeEntry.list` har pageSize-default 50 i zod → 61,7 KB. MCP-ytan
+    // begränsar till 10 rader när modellen inte sagt något.
+    const { client, close } = await connect("legacy");
+    try {
+      const res = await client.callTool({ name: "timeEntry__list", arguments: {} });
+      const data = JSON.parse(textOf(res)) as { entries: unknown[]; total: number };
+      expect(data.entries).toHaveLength(MCP_DEFAULT_PAGE_SIZE);
+      // Totalen ska fortfarande berätta hur mycket som finns — annars vet
+      // modellen inte att den bara sett en sida.
+      expect(data.total).toBeGreaterThan(MCP_DEFAULT_PAGE_SIZE);
+    } finally {
+      await close();
+    }
+  });
+
+  it("modellen kan begära fler rader själv", async () => {
+    const { client, close } = await connect("legacy");
+    try {
+      const res = await client.callTool({ name: "timeEntry__list", arguments: { pageSize: 30 } });
+      expect((JSON.parse(textOf(res)) as { entries: unknown[] }).entries).toHaveLength(30);
     } finally {
       await close();
     }

--- a/test/unit/ava-cli/tool-descriptions.test.ts
+++ b/test/unit/ava-cli/tool-descriptions.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Verktygsbeskrivningarnas drift-vakt (#1008).
+ *
+ * Beskrivningarna bor i en egen fil så de går att granska som prosa. Priset för
+ * det är att de kan hamna ur synk med `appRouter` — och det här testet är vad
+ * som betalar priset. Det fäller åt BÅDA håll:
+ *
+ *   - en NY procedur utan beskrivning → röd (annars faller den tyst tillbaka
+ *     till `"query foo.bar"`, precis det #1008 handlade om),
+ *   - en beskrivning vars procedur försvunnit → röd (annars ackumuleras
+ *     lögner om en yta som inte finns).
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { listProcedures } from "../../../tooling/ava-cli/introspect";
+import {
+  describedPaths, isPaginated, MCP_DEFAULT_PAGE_SIZE, toolDescription, withPageSizeDefault,
+} from "../../../tooling/ava-cli/tool-descriptions";
+
+const PROCS = listProcedures();
+const PATHS = new Set(PROCS.map((p) => p.path));
+
+describe("beskrivningarna täcker hela appRouter-ytan", () => {
+  it("varje procedur har en beskrivning", () => {
+    const described = new Set(describedPaths());
+    const missing = PROCS.map((p) => p.path).filter((p) => !described.has(p));
+    expect(missing, `saknar beskrivning: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  it("varje beskrivning hör till en procedur som finns", () => {
+    const orphans = describedPaths().filter((p) => !PATHS.has(p));
+    expect(orphans, `beskrivning utan procedur: ${orphans.join(", ")}`).toEqual([]);
+  });
+
+  it("ingen beskrivning är bara procedurnamnet", () => {
+    // Fallbacken `"<typ> <path>"` är exakt den innehållslösa formen vi kom
+    // ifrån — den får aldrig smyga tillbaka in via en tom sträng. Längdgolvet
+    // är lågt med flit: "Byråns kontor." är en fullgod beskrivning av
+    // `organization.listOffices`, och att kräva utfyllnad gör den sämre.
+    for (const p of PROCS) {
+      const d = toolDescription(p);
+      expect(d, p.path).not.toBe(`${p.type} ${p.path}`);
+      expect(d.length, `${p.path} har en misstänkt kort beskrivning`).toBeGreaterThan(12);
+      expect(d, `${p.path} ska vara en mening`).toMatch(/\.$/);
+    }
+  });
+});
+
+describe("sidstorlek på MCP-ytan", () => {
+  const paginated = PROCS.filter((p) => isPaginated(p.inputSchema));
+
+  it("de paginerade procedurerna känns igen", () => {
+    // Regressionsvakt för #1008:s rotorsak: `timeEntry.list` HADE paginering
+    // hela tiden, men schemat föll till null på ett date-fält → osynligt.
+    expect(paginated.map((p) => p.path)).toContain("timeEntry.list");
+    expect(paginated.length).toBeGreaterThan(4);
+  });
+
+  it("beskrivningen berättar om sidstorleken", () => {
+    for (const p of paginated) expect(toolDescription(p)).toMatch(/rader per sida/);
+  });
+
+  it("sidstorleken fylls i när modellen inte angett någon", () => {
+    const p = paginated.find((x) => x.path === "timeEntry.list")!;
+    expect(withPageSizeDefault(p.inputSchema, {})).toEqual({ pageSize: MCP_DEFAULT_PAGE_SIZE });
+    expect(withPageSizeDefault(p.inputSchema, undefined)).toEqual({ pageSize: MCP_DEFAULT_PAGE_SIZE });
+  });
+
+  it("modellens egen sidstorlek vinner", () => {
+    const p = paginated.find((x) => x.path === "timeEntry.list")!;
+    expect(withPageSizeDefault(p.inputSchema, { pageSize: 100 })).toEqual({ pageSize: 100 });
+  });
+
+  it("opaginerade procedurer rörs inte", () => {
+    const p = PROCS.find((x) => x.path === "invoice.list")!;
+    expect(isPaginated(p.inputSchema)).toBe(false);
+    expect(withPageSizeDefault(p.inputSchema, { matterId: "m-1" })).toEqual({ matterId: "m-1" });
+  });
+});
+
+describe("introspektionen tappar inte scheman på date-fält (#1008)", () => {
+  it("timeEntry.list annonserar sina filter och sin paginering", () => {
+    // Före fixen: `z.date()` fällde HELA schemat till null via
+    // `unrepresentable: "throw"`, och verktyget såg parameterlöst ut.
+    const props = Object.keys((PROCS.find((p) => p.path === "timeEntry.list")!.inputSchema as { properties: object }).properties);
+    expect(props).toEqual(expect.arrayContaining(["matterId", "userId", "from", "to", "page", "pageSize"]));
+  });
+
+  it("mutationer med datum annonserar sina fält", () => {
+    for (const path of ["calendar.create", "task.create", "document.updateMetadata"]) {
+      const schema = PROCS.find((p) => p.path === path)!.inputSchema as { properties?: object } | null;
+      expect(Object.keys(schema?.properties ?? {}).length, `${path} ska ha fält`).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tooling/ava-cli/introspect.ts
+++ b/tooling/ava-cli/introspect.ts
@@ -46,11 +46,24 @@ function lastZodInput(inputs: unknown): z.ZodType | null {
   return last instanceof z.ZodType ? last : null;
 }
 
-/** zod → JSON-schema; fail-soft till `null` för scheman zod inte kan serialisera. */
+/**
+ * zod → JSON-schema.
+ *
+ * `unrepresentable: "any"` är inte kosmetika (#1008): default:en är `"throw"`,
+ * och zod vägrar serialisera `z.date()`. Ett enda date-fält fällde alltså HELA
+ * schemat till `null` — och MCP annonserade verktyget som parameterlöst. Det
+ * drabbade 13 procedurer, bl.a. `timeEntry.list` (vars `matterId`/`from`/`to`/
+ * `page`/`pageSize` blev osynliga → modellen kunde bara begära ALLT) och
+ * `calendar.create`/`task.create`, som såg ut att inte ta några argument alls.
+ * Med `"any"` blir date-fältet ett otypat `{}` och resten av objektet överlever.
+ *
+ * Att date-fälten dessutom inte GÅR att fylla i över JSON (`z.date()` avvisar
+ * strängar) är en egen brist — se #1010.
+ */
 function toJsonSchema(schema: z.ZodType | null): unknown {
   if (!schema) return null;
   try {
-    return z.toJSONSchema(schema, { io: "input" });
+    return z.toJSONSchema(schema, { io: "input", unrepresentable: "any" });
   } catch {
     return null;
   }

--- a/tooling/ava-cli/mcp.ts
+++ b/tooling/ava-cli/mcp.ts
@@ -16,6 +16,7 @@
 import { fromJsonSchema, McpServer, type CallToolResult, type JsonSchemaType, type ToolAnnotations } from "@modelcontextprotocol/server";
 import type { AvaCaller } from "./caller";
 import type { ProcedureInfo, ProcedureType } from "./introspect";
+import { toolDescription, withPageSizeDefault } from "./tool-descriptions";
 
 export const MCP_SERVER_NAME = "ava";
 export const MCP_SERVER_VERSION = "0.2.0";
@@ -82,11 +83,12 @@ export function buildAvaMcpServer(procs: readonly ProcedureInfo[], caller: AvaCa
     server.registerTool(
       name,
       {
-        description: `${p.type} ${p.path}`,
+        description: toolDescription(p),
         inputSchema: fromJsonSchema(toolInputSchema(p.inputSchema)),
         annotations: toolAnnotations(p.type),
       },
-      (args: unknown): Promise<CallToolResult> => executeToolCall(name, args, caller) as Promise<CallToolResult>,
+      (args: unknown): Promise<CallToolResult> =>
+        executeToolCall(name, withPageSizeDefault(p.inputSchema, args), caller) as Promise<CallToolResult>,
     );
   }
   return server;

--- a/tooling/ava-cli/tool-descriptions.ts
+++ b/tooling/ava-cli/tool-descriptions.ts
@@ -1,0 +1,264 @@
+/**
+ * `tool-descriptions` — vad varje procedur GÖR, i klartext (#1008).
+ *
+ * För en AI är verktygets beskrivning hela upptäcktsytan: det är på den den
+ * väljer verktyg. Tidigare stod det `"mutation billingRun.appealKostnadsrakning"`
+ * — vilket i praktiken betyder att valet gjordes på procedurnamnet ensamt.
+ * `coverageSplit` säger ingenting om täckningsärenden och `setVerdict`
+ * ingenting om domstolsbeslut.
+ *
+ * Varför en egen fil och inte `.meta()` på varje procedur: beskrivningarna
+ * ska kunna GRANSKAS SOM PROSA — jämföras med varandra, hållas i samma ton,
+ * läsas i ett svep. Utspridda över 24 routrar går det inte. Drift-risken som
+ * annars följer med en sidoregister är stängd av `tool-descriptions.test.ts`,
+ * som fäller åt BÅDA håll: en procedur utan beskrivning, och en beskrivning
+ * utan procedur.
+ *
+ * Ton: en mening som säger vad det gör, plus en andra mening BARA när nyansen
+ * behövs för att välja rätt verktyg (idempotens, vilket tillstånd som krävs,
+ * vad som INTE händer).
+ */
+
+import type { ProcedureInfo } from "./introspect";
+
+/**
+ * Hur många rader ett paginerat verktyg returnerar när modellen inte säger
+ * något (#1008). Zods egna defaults (20–50) ger svar på 10 000–17 000 tokens
+ * på demo-seeden — över klientens varningströskel innan en riktig byrås data
+ * ens är inblandad. Modellen kan alltid höja `pageSize` själv.
+ */
+export const MCP_DEFAULT_PAGE_SIZE = 10;
+
+const DESCRIPTIONS: Readonly<Record<string, string>> = {
+  // ── Fakturerings- och kostnadsräkningskörningar ──────────────────
+  "billingRun.list": "Lista faktureringskörningar (aconto, slutfaktura, kostnadsräkning) i byrån, valfritt filtrerat på ärende.",
+  "billingRun.byId": "Hämta en enskild faktureringskörning med dess frysta arbetsvärde och status.",
+  "billingRun.proposal": "Avdragsmedvetet fakturaförslag för ett ärende: vilka tids- och utläggsposter som är ofakturerade, deras samlade upparbetade värde, och summan av tidigare aconton att dra av. Read-only — skapar ingen faktura.",
+  "billingRun.invoiceSpecification": "Fakturaspecifikation: de tids- och utläggsrader som är kopplade till en viss faktura, plus avdragna aconton och summering. Driver fakturadokumentet. En ren aconto-faktura får tomma rader.",
+  "billingRun.createAcconto": "Skapa en aconto-faktura (à conto) på ett ärende. Fryser inte arbetet — posterna kan faktureras igen på slutfakturan, med aconto-beloppet avdraget.",
+  "billingRun.createFinal": "Skapa slutfaktura på ett ärende: fakturerar allt ofakturerat arbete, drar av tidigare aconton och fryser posterna.",
+  "billingRun.createKostnadsrakning": "Skapa en kostnadsräkning till domstolen (offentligt uppdrag och rättshjälp). Status INSKICKAD — domstolens beslut registreras separat.",
+  "billingRun.recordKostnadsrakningBeslut": "Registrera domstolens beslut på en kostnadsräkning: dömt belopp och eventuell prutning. INSKICKAD → BESLUTAD (tingsrätten), ÖVERKLAGAD → BESLUTAD slutgiltigt (hovrätten). Skapar ingen faktura — det är ett eget steg.",
+  "billingRun.appealKostnadsrakning": "Överklaga domstolens prutning på en kostnadsräkning till hovrätten: BESLUTAD → ÖVERKLAGAD. Ingen ny kostnadsräkning skapas; hovrättens beslut registreras på samma körning.",
+  "billingRun.setVerdict": "Registrera domen på ett offentligt uppdrag och skapa domstolsfakturan ur den beslutade kostnadsräkningen.",
+  "billingRun.coverageSplit": "Räkna ut hur ett täckningsärende (rättshjälp eller rättsskydd) fördelas mellan klient, betalare och byråns egen förlust, värderat på det timarvode som gällde. Read-only — driver panelen; fakturorna skapas i slutregleringen.",
+  "billingRun.settleCoverage": "Slutreglera ett täckningsärende när betalaren svarat: skapar klientfaktura (självrisk och prutning), betalarfaktura (försäkring eller stat) och bokar byråns förlust. Fryser allt arbete.",
+  "billingRun.recordInsurerPruning": "Registrera försäkringsbolagets prutning efter slutreglering. Flyttar beloppet från försäkringsfakturan till klientfakturan — totalen är oförändrad och inga nya fakturor uppstår. Kräver befintliga slutregleringsfakturor.",
+
+  // ── Kalender ─────────────────────────────────────────────────────
+  "calendar.list": "Lista kalenderhändelser i byrån, valfritt inom ett datumintervall.",
+  "calendar.listForMatter": "Alla kalenderhändelser kopplade till ett visst ärende, kronologiskt.",
+  "calendar.listForUsers": "Kalenderhändelser för flera medarbetare i en enda fråga — underlag för gemensamma vyer.",
+  "calendar.getById": "Hämta en enskild kalenderhändelse.",
+  "calendar.create": "Skapa en kalenderhändelse (möte, förhandling, frist), valfritt kopplad till ett ärende.",
+  "calendar.update": "Uppdatera en kalenderhändelse.",
+  "calendar.delete": "Radera en kalenderhändelse.",
+  "calendar.setMirrorState": "Sätt speglingsstatus mot Outlook. Anropas av synk-workern — inte något en användare gör manuellt.",
+
+  // ── Jävskontroll ─────────────────────────────────────────────────
+  "conflict.check": "Kör en jävskontroll mot byråns kontakter och ärenden, och spara resultatet. Ska göras innan ett nytt uppdrag antas.",
+  "conflict.history": "Tidigare jävskontroller med sina träffar.",
+
+  // ── Kontakter ────────────────────────────────────────────────────
+  "contacts.list": "Lista och sök byråns kontakter (klienter, motparter, ombud, domstolar, försäkringsbolag).",
+  "contacts.getById": "Hämta en enskild kontakt.",
+  "contacts.create": "Lägg upp en ny kontakt.",
+  "contacts.update": "Uppdatera en kontakts uppgifter.",
+  "contacts.delete": "Radera en kontakt.",
+  "contacts.addChild": "Lägg till en kontaktperson under en organisationskontakt.",
+
+  // ── Dokument ─────────────────────────────────────────────────────
+  "document.list": "Paginerad lista över dokument och mappar i ett ärende eller en mapp.",
+  "document.tree": "Hela dokumentträdet (alla mappar och dokument) för ett ärende i en enda fråga.",
+  "document.search": "Fulltextsök bland byråns dokument.",
+  "document.listDocumentTypes": "Vilka dokumenttyper som förekommer i byrån, med antal per typ — underlag för filter.",
+  "document.register": "Registrera ett uppladdat dokument. Används av klienten efter att filen skrivits lokalt; i serverdrift går uppladdningen i stället via HTTP-endpointen.",
+  "document.delete": "Radera ett dokument.",
+  "document.updateMetadata": "Skriv dokumentets metadata (typ, datum, motpart) — AI-genererad eller manuellt överstyrd.",
+  "document.setTags": "Sätt dokumentets etiketter. Validerar mot byråns etikettvokabulär och bumpar inte versionen.",
+  "document.analyze": "Kör (eller kör om) AI-analys av ett dokument. Returnerar omedelbart; resultatet skrivs när analysen är klar.",
+  "document.suggestFromText": "Härled kontakt- och händelseförslag ur ett dokuments text. Idempotent — texten skickas in, routern läser inga filer.",
+  "document.uploadContent": "Ta emot dokumentets bytes och lagra dem innehållsadresserat. Ger en ny immutabel version och triggar omklassificering.",
+  "document.downloadContent": "Läs tillbaka dokumentets bytes ur innehållslagret.",
+  "document.missingContent": "Vilka innehållsadresserade sökvägar servern saknar — byte-synken frågar detta för att bara ladda upp det som fattas.",
+  "document.saveConflictCopy": "Spara användarens version som ett syskondokument när uppladdningen krockat med en nyare serverversion. Inget skrivs över, inget förloras.",
+  "document.markExternallyEdited": "Markera att dokumentet ändrats i en extern editor (Word, PDF-verktyg). Bumpar version och storlek så synk-pipelinen upptäcker ändringen.",
+  "document.createFolder": "Skapa en mapp i ett ärendes dokumentträd.",
+  "document.renameFolder": "Byt namn på en mapp.",
+  "document.deleteFolder": "Radera en mapp. Innehållet flyttas upp till föräldramappen — inget raderas med den.",
+  "document.moveDocument": "Flytta ett dokument till en annan mapp.",
+  "document.moveFolder": "Flytta en mapp. Cykler (mapp in i sig själv eller sin egen undermapp) blockeras.",
+  "document.breadcrumb": "Sökvägen från roten till en viss mapp.",
+  "document.acquireLease": "Ta redigeringslåset på ett dokument. Ledigt, utgånget eller redan ditt → du får det; annars returneras vem som håller det.",
+  "document.renewLease": "Förnya ditt redigeringslås (heartbeat). Falskt svar betyder att du inte håller det längre.",
+  "document.releaseLease": "Släpp ditt redigeringslås. Idempotent.",
+  "document.takeoverLease": "Ta över ett dött eller inaktuellt redigeringslås — permanent omtilldelning till anroparen.",
+  "document.getLease": "Vem som redigerar dokumentet just nu, sedan när, och om låset hunnit bli inaktuellt.",
+  "document.events": "Händelser (möten, frister, förhandlingar) som hittats i ett ärendes dokument, kronologiskt och utan de avvisade.",
+  "document.rejectEvent": "Avvisa en händelse som hittats i ett dokument.",
+  "document.markEventAdded": "Markera att en dokumenthändelse lagts in i kalendern.",
+  "document.pendingSuggestions": "Obehandlade kontaktförslag som härletts ur ett ärendes dokument.",
+  "document.pendingSuggestionsGrouped": "Samma obehandlade kontaktförslag, men grupperade per person eller organisation så samma individ i flera dokument blir en rad.",
+  "document.acceptSuggestion": "Acceptera ett kontaktförslag: länkar en befintlig kontakt eller skapar en ny, och kopplar den till ärendet med föreslagen roll.",
+  "document.rejectSuggestion": "Avvisa ett kontaktförslag.",
+  "document.acceptSuggestionGroup": "Acceptera hela gruppen av förslag som hör till samma person: skapar eller hittar kontakten och länkar den med alla distinkta roller.",
+  "document.rejectSuggestionGroup": "Avvisa hela gruppen av förslag för en person.",
+
+  // ── Dokumentmallar ───────────────────────────────────────────────
+  "documentTemplate.list": "Byråns dokumentmallar.",
+  "documentTemplate.getById": "Hämta en enskild dokumentmall.",
+  "documentTemplate.create": "Lägg upp en ny dokumentmall.",
+  "documentTemplate.update": "Uppdatera en dokumentmall.",
+  "documentTemplate.delete": "Radera en dokumentmall.",
+
+  // ── Förväntade domstolsbetalningar ───────────────────────────────
+  "expectedReceivable.list": "Förväntade domstolsbetalningar, valfritt filtrerat på ärende.",
+  "expectedReceivable.candidates": "Öppna fordringar berikade med ärende- och målnummer — matchningsunderlag vid avprickning mot bankfil.",
+  "expectedReceivable.create": "Registrera en förväntad domstolsbetalning (status PENDING).",
+  "expectedReceivable.settle": "Pricka av en fordran med det faktiskt utbetalda beloppet. Idempotent på betalningsreferensen — samma betalning bokförs aldrig två gånger.",
+  "expectedReceivable.update": "Ändra begärt belopp eller beskrivning medan fordran är öppen.",
+  "expectedReceivable.cancel": "Avbryt en fordran, t.ex. felregistrerad eller helt avslagen av domstolen.",
+
+  // ── Utlägg ───────────────────────────────────────────────────────
+  "expense.list": "Lista utlägg, valfritt filtrerat på ärende.",
+  "expense.create": "Registrera ett utlägg på ett ärende, med momssats och om det är debiterbart.",
+  "expense.update": "Uppdatera ett utlägg.",
+  "expense.delete": "Radera ett utlägg.",
+
+  // ── Fakturor ─────────────────────────────────────────────────────
+  "invoice.list": "Lista fakturor, valfritt filtrerat på ärende, typ eller status.",
+  "invoice.getById": "Hämta en enskild faktura med belopp, betalningar och utestående.",
+  "invoice.createRadgivning": "Fakturera den obligatoriska rådgivningstimmen. Hålls medvetet i DRAFT: den är en additiv klientkostnad och ska aldrig dras av på en slutfaktura. Idempotent — avvisar om den redan registrerats.",
+  "invoice.createCredit": "Kreditera en faktura: skapar en motfaktura med negativt belopp och annullerar originalet. En redan krediterad eller annullerad faktura kan inte krediteras igen.",
+  "invoice.recordPayment": "Bokför en inbetalning på en faktura.",
+  "invoice.writeOff": "Skriv av en faktura som konstaterad kundförlust, helt eller delvis. Endast utställda fakturor med utestående belopp; avskrivningen får inte överstiga det utestående.",
+  "invoice.setStatus": "Ändra fakturans status manuellt (DRAFT→SENT, SENT→CANCELLED). För kundförlust används writeOff, som skapar en daterad post.",
+  "invoice.createPaymentPlan": "Lägg upp en avbetalningsplan på en faktura.",
+  "invoice.cancelPaymentPlan": "Avbryt en aktiv avbetalningsplan.",
+  "invoice.markFortnoxBooked": "Märk fakturan som bokförd i Fortnox med sitt verifikatnummer. Skriver aldrig över ett redan satt id — det är dubbelbokföringsskyddet.",
+
+  // ── Fakturautskick ───────────────────────────────────────────────
+  "invoiceDispatch.list": "Utskickshistorik för fakturor.",
+  "invoiceDispatch.listQueued": "Köade fakturautskick som väntar på att skickas.",
+  "invoiceDispatch.queue": "Köa en faktura för utskick.",
+  "invoiceDispatch.recordManual": "Registrera ett utskick som redan gjorts för hand, t.ex. via advokatens egen mailklient. Skapas direkt som skickat, aldrig köat — annars skulle utskicks-workern skicka igen.",
+  "invoiceDispatch.updateStatus": "Uppdatera ett utskicks status (skickat, levererat, misslyckat).",
+
+  // ── Kostnadsräkning (dokument) ───────────────────────────────────
+  "kostnadsrakning.record": "Registrera ett genererat kostnadsräkningsdokument. Filen har redan skrivits av klienten; här sparas metadata och händelsen skickas vidare.",
+
+  // ── Mail ─────────────────────────────────────────────────────────
+  "mail.saveIncoming": "Spara ett inkommande mail som dokument på ett ärende, med valfri tidspost.",
+
+  // ── Ärenden ──────────────────────────────────────────────────────
+  "matter.list": "Lista och sök byråns ärenden, valfritt filtrerat på status eller handläggare.",
+  "matter.getById": "Hämta ett enskilt ärende med betalningssätt, klient och ekonomi.",
+  "matter.create": "Lägg upp ett nytt ärende med betalningssätt (privat, rättshjälp, rättsskydd eller offentligt uppdrag).",
+  "matter.update": "Uppdatera ett ärendes uppgifter.",
+  "matter.coverageUsage": "Hur mycket debiterbart arbete som är upparbetat i ärendet — underlag för varningen när täckningstaket närmar sig.",
+  "matter.addContact": "Koppla en befintlig kontakt till ärendet i en roll (klient, motpart, ombud, domstol).",
+  "matter.addNewContact": "Skapa en ny kontakt och koppla den till ärendet i ett steg.",
+  "matter.removeContact": "Ta bort en kontaktkoppling från ärendet.",
+
+  // ── Byrå och kontor ──────────────────────────────────────────────
+  "organization.create": "Lägg upp byrån.",
+  "organization.getSettings": "Byråns inställningar (namn, organisationsnummer, adress, momssatser, etikettvokabulär).",
+  "organization.updateSettings": "Uppdatera byråns inställningar.",
+  "organization.listOffices": "Byråns kontor.",
+  "organization.addOffice": "Lägg till ett kontor.",
+  "organization.updateOffice": "Uppdatera ett kontor.",
+  "organization.deleteOffice": "Ta bort ett kontor.",
+
+  // ── Avbetalningsplaner ───────────────────────────────────────────
+  "paymentPlan.list": "Avbetalningsplaner med sina fakturor och förfallodagar.",
+  "paymentPlan.getById": "Hämta en enskild avbetalningsplan.",
+  "paymentPlan.cancel": "Avbryt en aktiv avbetalningsplan.",
+  "paymentPlan.recordReminder": "Logga en utskickad påminnelse för en plan (förfallen eller försenad, för en viss månad).",
+  "paymentPlan.scanDueReminders": "Gå igenom alla planer och logga de påminnelser som förfallit. Idempotent — redan loggade månader hoppas över.",
+
+  // ── Inställningar (användare och byrå) ───────────────────────────
+  "prefs.get": "Hämta både användarens och byråns inställning för en nyckel; anroparen väljer vilken som vinner.",
+  "prefs.save": "Spara användarens egen inställning för en nyckel.",
+  "prefs.clear": "Nollställ användarens inställning så byråns eller komponentens default gäller igen.",
+  "prefs.setOrgDefault": "Sätt byråns default för en inställning. Endast administratör.",
+  "prefs.clearOrgDefault": "Ta bort byråns default för en inställning. Endast administratör.",
+  "prefs.listOrgDefaults": "Vilka inställningar som har en byrå-default satt.",
+
+  // ── Rapporter ────────────────────────────────────────────────────
+  "reports.perLawyer": "Advokatrapport för en period: vilka ärenden advokaten arbetat i, timdebitering per vecka, och upparbetat men ofakturerat arbete.",
+  "reports.billed": "Fakturerat per advokat och period, attribuerat mot advokatens andel av det frysta arbetsvärdet, netto efter avskrivningar.",
+  "reports.arSummary": "Kundfordringar över byråns livstid: brygga och åldersanalys, byggd på de daterade avskrivningsposterna.",
+
+  // ── Delgivningskvitton ───────────────────────────────────────────
+  "serviceNote.list": "Delgivningsanteckningar, valfritt filtrerat på ärende.",
+  "serviceNote.create": "Registrera en delgivning på ett ärende.",
+  "serviceNote.update": "Uppdatera en delgivningsanteckning.",
+  "serviceNote.delete": "Radera en delgivningsanteckning.",
+
+  // ── Synk ─────────────────────────────────────────────────────────
+  "sync.pull": "Hämta ändringar efter en viss markör (delta-synk). Maskinväg — inte något en användare anropar.",
+  "sync.push": "Skicka en köad klientmutation för serverauktoritativ tillämpning. Maskinväg.",
+
+  // ── System ───────────────────────────────────────────────────────
+  "system.capabilities": "Vad den här installationen kan (demo, self-hosted eller serverdrift) — styr vilka funktioner som är tillgängliga.",
+  "system.helperConfig": "Inloggningskonfiguration som webbappen pushar till den lokala hjälpprocessen. Null i demon.",
+
+  // ── Uppgifter ────────────────────────────────────────────────────
+  "task.list": "Lista uppgifter, valfritt filtrerat på status eller ärende.",
+  "task.create": "Skapa en uppgift, valfritt kopplad till ett ärende och med förfallodag.",
+  "task.update": "Uppdatera en uppgift.",
+  "task.complete": "Markera en uppgift som klar.",
+  "task.delete": "Radera en uppgift.",
+
+  // ── Tidsposter ───────────────────────────────────────────────────
+  "timeEntry.list": "Lista tidsposter, valfritt filtrerat på ärende, medarbetare och datumintervall.",
+  "timeEntry.create": "Registrera arbetad tid på ett ärende. Kategorin styr ersättningen: arbete, tidsspillan, arbete på obekväm tid, eller advokatberedskap som ersätts per dygn med noll minuter.",
+  "timeEntry.update": "Uppdatera en tidspost.",
+  "timeEntry.delete": "Radera en tidspost.",
+  "timeEntry.report": "Tidsrapport aggregerad över en period.",
+
+  // ── Att göra-vy ──────────────────────────────────────────────────
+  "todo.list": "Sammanställd att göra-lista: uppgifter, frister och kalenderhändelser som kräver åtgärd.",
+
+  // ── Användare ────────────────────────────────────────────────────
+  "user.list": "Byråns medarbetare.",
+  "user.getById": "Hämta en enskild medarbetare.",
+  "user.current": "Den inloggade användaren med roll och byråtillhörighet.",
+  "user.create": "Lägg upp en medarbetare med roll och timtaxa.",
+  "user.update": "Uppdatera en medarbetares uppgifter.",
+  "user.deactivate": "Avaktivera en medarbetare. Raden bevaras så historiken står kvar.",
+  "user.delete": "Radera en medarbetare.",
+};
+
+/** Alla paths som har en beskrivning — drift-testet läser den här. */
+export function describedPaths(): readonly string[] {
+  return Object.keys(DESCRIPTIONS);
+}
+
+/** Bär procedurens input ett `pageSize`-fält? Styr både default och not. */
+export function isPaginated(schema: unknown): boolean {
+  const props = (schema as { properties?: Record<string, unknown> } | null)?.properties;
+  return props !== undefined && "pageSize" in props;
+}
+
+/**
+ * Verktygsbeskrivningen som når modellen. Paginerade verktyg får en not om
+ * sidstorleken — annars ser modellen ett trunkerat svar utan att förstå varför.
+ */
+export function toolDescription(proc: ProcedureInfo): string {
+  const base = DESCRIPTIONS[proc.path] ?? `${proc.type} ${proc.path}`;
+  if (!isPaginated(proc.inputSchema)) return base;
+  return `${base} Returnerar ${MCP_DEFAULT_PAGE_SIZE} rader per sida om inget annat anges — höj pageSize eller stega med page för fler.`;
+}
+
+/**
+ * Fyll i sidstorleken när modellen inte angett någon. Zods egna defaults
+ * (20–50) ger svar som spränger klientens utdatabudget; MCP-ytan är snålare
+ * och modellen kan alltid begära mer.
+ */
+export function withPageSizeDefault(schema: unknown, args: unknown): unknown {
+  if (!isPaginated(schema)) return args;
+  const obj = args !== null && typeof args === "object" ? (args as Record<string, unknown>) : {};
+  if (obj.pageSize !== undefined) return args;
+  return { ...obj, pageSize: MCP_DEFAULT_PAGE_SIZE };
+}


### PR DESCRIPTION
## Vad & varför

Protokollet blev rätt i #1006; **innehållet** i verktygsytan var det inte. Tre delar — och den mittersta visade sig vara rotorsaken till den tredje.

### 1. Beskrivningar

Verktygen annonserades som `"mutation billingRun.appealKostnadsrakning"`. För en modell är beskrivningen hela upptäcktsytan, så valet gjordes i praktiken på procedurnamnet ensamt. Nu har alla **151 procedurer** en mening som säger vad de gör, plus en andra mening där nyansen behövs för att välja rätt verktyg:

> `billingRun.appealKostnadsrakning` — "Överklaga domstolens prutning på en kostnadsräkning till hovrätten: BESLUTAD → ÖVERKLAGAD. Ingen ny kostnadsräkning skapas; hovrättens beslut registreras på samma körning."
>
> `invoice.createRadgivning` — "Fakturera den obligatoriska rådgivningstimmen. Hålls medvetet i DRAFT: den är en additiv klientkostnad och ska aldrig dras av på en slutfaktura. Idempotent — avvisar om den redan registrerats."

De bor i `tool-descriptions.ts` och inte i `.meta()` på varje procedur, av ett skäl: de ska kunna **granskas som prosa** — jämföras med varandra, hållas i samma ton, läsas i ett svep. Utspridda över 24 routrar går det inte. Drift-risken som annars följer med ett sidoregister stängs av ett test som fäller åt **båda** håll: en procedur utan beskrivning, och en beskrivning utan procedur.

### 2. Scheman som föll tyst till null — rotorsaken

`introspect.ts` körde `z.toJSONSchema` med default:en `unrepresentable: "throw"`, och zod vägrar serialisera `z.date()`. Ett enda date-fält fällde alltså **hela** schemat till `null`, och `catch { return null }` svalde det. MCP annonserade då verktyget med tomt objekt-schema — **parameterlöst**.

Det drabbade 13 av 151 procedurer:

- `timeEntry.list` — `matterId`, `userId`, `from`, `to`, `page`, `pageSize` osynliga. Modellen kunde bara begära **allt**. Det här är varför utdatan var 61,7 KB.
- `calendar.create`, `task.create`, `calendar.update`, `task.update`, `document.updateMetadata` — mutationer som såg ut att inte ta några argument alls.

Med `unrepresentable: "any"` överlever resten av objektet. Antalet schemalösa procedurer går 21 → 10 (de tio har genuint ingen `.input()`).

### 3. Utdatabudget

Klienter kapar verktygssvar — Claude Code varnar över 10 000 tokens och kapar vid 25 000. Ett kapat svar är värre än ett kort: JSON:en huggs av mitt i och modellen läser en halv sanning.

MCP-ytan fyller nu i `pageSize: 10` när modellen inte angett något (zods egna defaults är 20–50), och beskrivningen säger att den kan höjas. Mätt genom servern mot demo-seeden:

| Verktyg | Före | Efter |
|---|---:|---:|
| `timeEntry.list` | 61,7 KB | **17,1 KB** |
| `expense.list` | 56,9 KB | **17,2 KB** |
| `matter.list` | 37,7 KB | **27,1 KB** |

Budgeten är ett **ratchet-test** satt strax över dagens värsta — `invoice.list` på 43 758 tecken, som saknar paginering helt. Det ska bara flyttas nedåt.

Stänger #1008

## Utbrutet till egna issues

- **#1012** — `outputSchema`/`structuredContent`. Punkten gick inte att göra här: den kräver `.output()` på procedurerna, och **ingen** har det (`grep -c "\.output(" src/lib/server/routers/*` → noll träffar). Utan det har tRPC ingen runtime-representation av svarsformen. Fällan att `content: []` blir tomt när `outputSchema` finns är dokumenterad där.
- **#1010** — `z.date()` går inte att uttrycka över JSON. `z.date().parse("2026-01-15")` kastar, så datumfälten är oanvändbara från CLI och MCP även nu när de syns. `calendar.create` och `task.create` går inte att använda för sitt syfte.
- **#1011** — listprocedurer utan paginering (`invoice.list`, `paymentPlan.list`, `task.list`), plus observationen att raderna är feta: `matter.list` kostar ~500 tokens per ärende, så fältprojektion skulle hjälpa mer än paginering.

## Typ

- [x] `feat` — ny funktion
- [ ] `fix` — buggfix
- [ ] `refactor` / `perf`
- [ ] `docs` / `test` / `chore` / `ci`

## Verifierat lokalt (speglar CI)

- [x] `typecheck` + `lint` + `knip` + `deps:check` + `duplicates` — rena
- [x] `bun run build:demo` — statisk export byggd, oförändrad
- [x] `bun run size` — 34,6 % av budget, oförändrat
- [x] Berörda testfiler körda var för sig (#92): tool-descriptions 10, mcp-server 17, mcp 7, cli 19, introspect 4, ava-mcp-stdio 2, fitness 8 — alla gröna
- [x] Nya rader har täckande tester
- [x] Commits följer Conventional Commits (commitlint)

## Kvalitetsgrindar

- [x] Inga gater lösgjorda. Utdatabudgeten är en NY grind, ankrad strax över dagens värsta värde enligt ratchet-konventionen
- [x] `tooling/ava-cli/` ligger utanför coverage-ratchet (mäts på `src/`) → nettoeffekt noll på golvet

## Övrigt

Beskrivningarna är skrivna ur routrarnas egen JSDoc där den finns — särskilt `billingRun`, `invoiceDispatch`, `expectedReceivable` och `document/*` var väldokumenterade, så domännyanserna (prutning, aconto-avdrag, idempotens på betalningsreferens, keep-both) kommer från koden och inte från minnet.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_