### PR TITLE
feat(mcp): datum över JSON, sidade listor och svarskontrakt på läse-ytan

### DIFF
--- a/src/lib/server/routers/calendar.ts
+++ b/src/lib/server/routers/calendar.ts
@@ -28,8 +28,8 @@ const createInput = z.object({
   title: z.string().min(1),
   description: z.string().nullish(),
   location: z.string().nullish(),
-  startAt: z.date(),
-  endAt: z.date().nullish(),
+  startAt: z.coerce.date(),
+  endAt: z.coerce.date().nullish(),
   allDay: z.boolean().default(false),
   matterId: matterIdSchema.nullish(),
   visibility: calendarEventVisibilitySchema.default("normal"),
@@ -41,7 +41,7 @@ const createInput = z.object({
   // Valfria setup-fält (demo-generator/fixtures, ADR 0003).
   id: calendarEventIdSchema.optional(),
   userId: userIdSchema.optional(),
-  createdAt: z.date().nullish(),
+  createdAt: z.coerce.date().nullish(),
 });
 
 // OBS: separat schema utan `.default()` — annars fyller Zod i defaults för
@@ -53,8 +53,8 @@ const updateInput = z.object({
   title: z.string().min(1).optional(),
   description: z.string().nullish(),
   location: z.string().nullish(),
-  startAt: z.date().optional(),
-  endAt: z.date().nullish(),
+  startAt: z.coerce.date().optional(),
+  endAt: z.coerce.date().nullish(),
   allDay: z.boolean().optional(),
   matterId: matterIdSchema.nullish(),
   visibility: calendarEventVisibilitySchema.optional(),
@@ -92,8 +92,8 @@ export const calendarRouter = router({
   list: protectedProcedure
     .input(
       z.object({
-        from: z.date().optional(),
-        to: z.date().optional(),
+        from: z.coerce.date().optional(),
+        to: z.coerce.date().optional(),
       }).optional(),
     )
     .query(async ({ ctx, input }) => {
@@ -122,8 +122,8 @@ export const calendarRouter = router({
   listForUsers: protectedProcedure
     .input(z.object({
       userIds: z.array(userIdSchema),
-      from: z.date().optional(),
-      to: z.date().optional(),
+      from: z.coerce.date().optional(),
+      to: z.coerce.date().optional(),
     }))
     .query(async ({ ctx, input }) => {
       if (input.userIds.length === 0) return [];
@@ -212,7 +212,7 @@ export const calendarRouter = router({
         outlookEventId: z.string().nullish(),
         mirrorStatus: calendarMirrorStatusSchema.nullable(),
         mirrorError: z.string().nullish(),
-        mirrorLastSyncedAt: z.date().nullish(),
+        mirrorLastSyncedAt: z.coerce.date().nullish(),
       }),
     )
     .mutation(async ({ ctx, input }) => {

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -19,6 +19,7 @@ import { arvodeInclVatOre, isPaymentPlanSettled } from "@/lib/shared/invoice-cal
 import { canTransition, transitionErrorMessage } from "@/lib/shared/invoice-state-machine";
 import { ocrFromInvoiceNumber } from "@/lib/shared/ocr-reference";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
+import { pageSlice } from "@/lib/shared/paginate";
 import { computeRadgivningsavgift } from "@/lib/shared/rattshjalp";
 import type { Invoice, Payment, PaymentPlan, WriteOff } from "@/lib/shared/schemas/billing";
 import { invoiceStatusSchema, invoiceTypeSchema, type InvoiceStatus } from "@/lib/shared/schemas/enums";
@@ -111,11 +112,14 @@ export const invoiceRouter = router({
         matterId: matterIdSchema.optional(),
         invoiceType: invoiceTypeSchema.optional(),
         status: invoiceStatusSchema.optional(),
+        // Frivillig sidning (#1011): utelämnad pageSize = hela listan, som förut.
+        page: z.number().min(1).optional(),
+        pageSize: z.number().min(1).max(100).optional(),
       }),
     )
     // Migrerad till repository-sömmen (ADR 0020). listForOrg org-scopar +
     // hämtar listvyns include (matter-subset, plan, betalningar, aconto-avdrag).
-    .query(({ ctx, input }) => ctx.repos.invoices.listForOrg(ctx.orgId, input)),
+    .query(async ({ ctx, input }) => pageSlice(await ctx.repos.invoices.listForOrg(ctx.orgId, input), input)),
 
   getById: orgProcedure
     .input(z.object({ id: invoiceIdSchema }))

--- a/src/lib/server/routers/paymentPlan.ts
+++ b/src/lib/server/routers/paymentPlan.ts
@@ -17,6 +17,7 @@
  */
 
 import { z } from "zod";
+import { pageSlice } from "@/lib/shared/paginate";
 import {
   computeDueReminders,
   type PlanForScan,
@@ -84,15 +85,18 @@ export const paymentPlanRouter = router({
       z.object({
         status: paymentPlanStatusSchema.optional(),
         search: z.string().optional(),
+        // Frivillig sidning (#1011): utelämnad pageSize = hela listan, som förut.
+        page: z.number().min(1).optional(),
+        pageSize: z.number().min(1).max(100).optional(),
       }).optional(),
     )
     // Migrerad till repository-sömmen (ADR 0020): listForOrg kapslar in
     // org-scoping + den joinade faktura/ärende/KLIENT/betalnings-formen.
     .query(async ({ ctx, input }) => {
       const plans = await ctx.repos.paymentPlans.listForOrg(ctx.orgId, input?.status);
-      if (!input?.search) return plans;
-      const needle = input.search.toLowerCase();
-      return plans.filter((p) => planHaystack(p).includes(needle));
+      const needle = input?.search?.toLowerCase();
+      // Sidningen sist — sök först, annars sidas bort träffar.
+      return pageSlice(needle ? plans.filter((p) => planHaystack(p).includes(needle)) : plans, input);
     }),
 
   getById: orgProcedure

--- a/src/lib/server/routers/task.ts
+++ b/src/lib/server/routers/task.ts
@@ -9,6 +9,7 @@
 
 import { z } from "zod";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
+import { pageSlice } from "@/lib/shared/paginate";
 import { taskPrioritySchema, taskStatusSchema, type Task } from "@/lib/shared/schemas";
 import { asId, taskIdSchema, matterIdSchema, userIdSchema } from "@/lib/shared/schemas/ids";
 import { router, protectedProcedure, TRPCError } from "../trpc";
@@ -17,14 +18,14 @@ const createInput = z.object({
   title: z.string().min(1),
   description: z.string().nullish(),
   priority: taskPrioritySchema.default("MEDIUM"),
-  dueAt: z.date().nullish(),
+  dueAt: z.coerce.date().nullish(),
   matterId: matterIdSchema.nullish(),
   // Valfria setup-fält (demo-generator/fixtures, ADR 0003).
   id: taskIdSchema.optional(),
   userId: userIdSchema.optional(),
   status: taskStatusSchema.optional(),
-  completedAt: z.date().nullish(),
-  createdAt: z.date().nullish(),
+  completedAt: z.coerce.date().nullish(),
+  createdAt: z.coerce.date().nullish(),
 });
 
 const updateInput = createInput.partial().extend({
@@ -38,14 +39,20 @@ export const taskRouter = router({
       z.object({
         status: taskStatusSchema.optional(),
         matterId: matterIdSchema.optional(),
+        // Frivillig sidning (#1011): utelämnad pageSize = hela listan, som förut.
+        page: z.number().min(1).optional(),
+        pageSize: z.number().min(1).max(100).optional(),
       }).optional(),
     )
     // Migrerad till repository-sömmen (ADR 0020): ägar-/org-scopad listForUser.
-    .query(({ ctx, input }) =>
-      ctx.repos.tasks.listForUser(ctx.user.id, ctx.user.organizationId, {
-        status: input?.status,
-        matterId: input?.matterId,
-      }),
+    .query(async ({ ctx, input }) =>
+      pageSlice(
+        await ctx.repos.tasks.listForUser(ctx.user.id, ctx.user.organizationId, {
+          status: input?.status,
+          matterId: input?.matterId,
+        }),
+        input,
+      ),
     ),
 
   create: protectedProcedure

--- a/src/lib/server/routers/timeEntry.ts
+++ b/src/lib/server/routers/timeEntry.ts
@@ -45,8 +45,8 @@ export const timeEntryRouter = router({
       z.object({
         matterId: matterIdSchema.optional(),
         userId: userIdSchema.optional(),
-        from: z.date().optional(),
-        to: z.date().optional(),
+        from: z.coerce.date().optional(),
+        to: z.coerce.date().optional(),
         page: z.number().min(1).default(1),
         pageSize: z.number().min(1).max(100).default(50),
       })

--- a/src/lib/server/routers/todo.ts
+++ b/src/lib/server/routers/todo.ts
@@ -34,8 +34,8 @@ export interface TodoItem {
 export const todoRouter = router({
   list: orgProcedure
     .input(z.object({
-      from: z.date(),
-      to: z.date(),
+      from: z.coerce.date(),
+      to: z.coerce.date(),
       /** Default = anropande user; annars måste user:n vara i samma org. */
       userId: userIdSchema.optional(),
     }))

--- a/src/lib/shared/paginate.ts
+++ b/src/lib/shared/paginate.ts
@@ -1,0 +1,23 @@
+/**
+ * Frivillig sidning av list-svar (#1011).
+ *
+ * De stora listorna (`invoice.list`, `paymentPlan.list`, `task.list`) har
+ * historiskt returnerat ALLT — hanterbart i UI:t, men en MCP-klient kapar
+ * verktygssvar, och `invoice.list` låg över varningströskeln redan på
+ * demo-seeden. Sidningen är frivillig med flit: utelämnad `pageSize` beter
+ * sig exakt som förut, så inga UI-anropare påverkas; MCP-ytan skickar alltid
+ * in sin snåla default (`withPageSizeDefault`).
+ */
+
+export interface PageOpts {
+  page?: number | undefined;
+  pageSize?: number | undefined;
+}
+
+/** Skär ut begärd sida; utan `pageSize` returneras listan orörd. */
+export function pageSlice<T>(rows: readonly T[], opts: PageOpts | undefined): T[] {
+  const pageSize = opts?.pageSize;
+  if (pageSize === undefined) return [...rows];
+  const page = opts?.page ?? 1;
+  return rows.slice((page - 1) * pageSize, page * pageSize);
+}

--- a/test/integration/mcp-server.test.ts
+++ b/test/integration/mcp-server.test.ts
@@ -26,6 +26,7 @@ import { createLocalCaller } from "../../tooling/ava-cli/caller";
 import { listProcedures } from "../../tooling/ava-cli/introspect";
 import { buildAvaMcpServer, MCP_SERVER_NAME, toolName } from "../../tooling/ava-cli/mcp";
 import { MCP_DEFAULT_PAGE_SIZE } from "../../tooling/ava-cli/tool-descriptions";
+import { outputDescribedPaths } from "../../tooling/ava-cli/tool-outputs";
 
 type Era = "modern" | "legacy";
 
@@ -165,6 +166,128 @@ describe.each<Era>(["legacy", "modern"])("ava-mcp över %s-epoken", (era) => {
 });
 
 /**
+ * Datumfält över JSON (#1010). Före `z.coerce.date()` avvisade dessa
+ * procedurer varje ISO-sträng — `calendar.create` och `task.create` gick
+ * bokstavligen inte att använda från en JSON-klient, och `timeEntry.list`
+ * kunde inte begränsas till en period.
+ */
+describe("datum över MCP (#1010)", () => {
+  it("calendar.create tar ISO-strängar och skapar händelsen", async () => {
+    const { client, close } = await connect("legacy");
+    try {
+      const created = await client.callTool({
+        name: "calendar__create",
+        arguments: { title: "Huvudförhandling", startAt: "2026-09-01T09:00:00.000Z", endAt: "2026-09-01T11:00:00.000Z" },
+      });
+      expect(created.isError, textOf(created)).toBeFalsy();
+      const ev = JSON.parse(textOf(created)) as { id: string; startAt: string };
+      expect(new Date(ev.startAt).toISOString()).toBe("2026-09-01T09:00:00.000Z");
+      // Skrivningen är verklig: händelsen syns i listan.
+      const listed = await client.callTool({ name: "calendar__list", arguments: {} });
+      expect(textOf(listed)).toContain(ev.id);
+    } finally {
+      await close();
+    }
+  });
+
+  it("task.create tar en ISO-förfallodag", async () => {
+    const { client, close } = await connect("legacy");
+    try {
+      const created = await client.callTool({
+        name: "task__create",
+        arguments: { title: "Överklaga prutningen", dueAt: "2026-09-15T12:00:00.000Z" },
+      });
+      expect(created.isError, textOf(created)).toBeFalsy();
+      expect(new Date((JSON.parse(textOf(created)) as { dueAt: string }).dueAt).getUTCDate()).toBe(15);
+    } finally {
+      await close();
+    }
+  });
+
+  it("timeEntry.list kan begränsas till en period med ISO-strängar", async () => {
+    const { client, close } = await connect("legacy");
+    try {
+      const all = JSON.parse(textOf(await client.callTool({ name: "timeEntry__list", arguments: { pageSize: 100 } }))) as { total: number };
+      const none = JSON.parse(textOf(await client.callTool({
+        name: "timeEntry__list",
+        arguments: { from: "1990-01-01T00:00:00.000Z", to: "1990-12-31T00:00:00.000Z" },
+      }))) as { total: number };
+      expect(none.total).toBe(0);
+      expect(all.total).toBeGreaterThan(0);
+    } finally {
+      await close();
+    }
+  });
+});
+
+/**
+ * Svarskontrakt (#1012). Verktyg med kontrakt annonserar `outputSchema` och
+ * svarar med BÅDE `structuredContent` och text-`content` — SDK:n lämnar annars
+ * `content` tom när `outputSchema` finns, och en klient som bara läser text
+ * ser då ingenting. SDK:n validerar dessutom `structuredContent` mot schemat
+ * vid varje anrop, så kontraktet är en levande grind, inte dokumentation.
+ */
+describe("svarskontrakt (#1012)", () => {
+  it("läse-ytan annonserar outputSchema, resten inte", async () => {
+    const { client, close } = await connect("legacy");
+    try {
+      const { tools } = await client.listTools();
+      const byName = new Map(tools.map((t) => [t.name, t]));
+      for (const path of outputDescribedPaths()) {
+        expect(byName.get(toolName(path))?.outputSchema?.type, path).toBe("object");
+      }
+      expect(byName.get("billingRun__list")?.outputSchema).toBeUndefined();
+    } finally {
+      await close();
+    }
+  });
+
+  it("svaret bär både structuredContent och samma data som text", async () => {
+    const { client, close } = await connect("legacy");
+    try {
+      const res = await client.callTool({ name: "matter__list", arguments: {} });
+      expect(res.isError, textOf(res)).toBeFalsy();
+      const structured = res.structuredContent as { matters: { id: string }[]; total: number };
+      expect(structured.matters.length).toBeGreaterThan(0);
+      // Texten är samma data — klienter som bara läser content förlorar inget.
+      expect(JSON.parse(textOf(res))).toEqual(structured);
+    } finally {
+      await close();
+    }
+  });
+});
+
+/**
+ * Sidning av de tidigare osidade listorna (#1011). Frivillig i routern —
+ * utelämnad pageSize är dagens beteende, så UI:t påverkas inte — men MCP-ytan
+ * skickar alltid sin snåla default.
+ */
+describe("sidning av listor utan egen paginering (#1011)", () => {
+  it("invoice.list får MCP-defaulten i stället för hela listan", async () => {
+    const { client, close } = await connect("legacy");
+    try {
+      const rows = JSON.parse(textOf(await client.callTool({ name: "invoice__list", arguments: {} }))) as unknown[];
+      expect(rows).toHaveLength(MCP_DEFAULT_PAGE_SIZE);
+      const page2 = JSON.parse(textOf(await client.callTool({ name: "invoice__list", arguments: { page: 2, pageSize: 3 } }))) as { id: string }[];
+      expect(page2).toHaveLength(3);
+      expect(page2[0]!.id).not.toBe((rows as { id: string }[])[0]!.id);
+    } finally {
+      await close();
+    }
+  });
+
+  it("task.list sidas på samma sätt", async () => {
+    const { client, close } = await connect("legacy");
+    try {
+      const rows = JSON.parse(textOf(await client.callTool({ name: "task__list", arguments: {} }))) as unknown[];
+      expect(rows.length).toBeLessThanOrEqual(MCP_DEFAULT_PAGE_SIZE);
+    } finally {
+      await close();
+    }
+  });
+});
+
+/**
  * Utdatabudget (#1008) — en RATCHET i samma anda som bundle-size.
  *
  * MCP-klienter kapar verktygssvar (Claude Code varnar över 10 000 tokens och
@@ -172,11 +295,12 @@ describe.each<Era>(["legacy", "modern"])("ava-mcp över %s-epoken", (era) => {
  * i och modellen läser en halv sanning. Före #1008 låg `timeEntry.list` på
  * 61,7 KB — på demo-seedens 130 tidsposter.
  *
- * Golvet är satt strax över dagens värsta (`invoice.list`, 43 758 tecken) och
- * ska BARA flyttas nedåt. De värsta kvarvarande är de listor som saknar
- * paginering helt (`invoice.list`, `paymentPlan.list`, `task.list`) — se #1011.
+ * Golvet flyttas BARA nedåt: 45 000 → 38 000 när #1011 gav de sista listorna
+ * sidning (`invoice.list` 43,8 → 37,2 KB). Kvarvarande värsting är
+ * `invoice.list` — 10 rader à ~1 KB, join-feta rader. Nästa sänkning kräver
+ * fältprojektion (#1014), inte mer sidning.
  */
-const OUTPUT_BUDGET_CHARS = 45_000;
+const OUTPUT_BUDGET_CHARS = 38_000;
 
 describe("verktygens utdatabudget", () => {
   it("inget verktyg som går att anropa utan argument spränger budgeten", async () => {

--- a/test/unit/ava-cli/tool-descriptions.test.ts
+++ b/test/unit/ava-cli/tool-descriptions.test.ts
@@ -72,9 +72,15 @@ describe("sidstorlek på MCP-ytan", () => {
   });
 
   it("opaginerade procedurer rörs inte", () => {
-    const p = PROCS.find((x) => x.path === "invoice.list")!;
+    const p = PROCS.find((x) => x.path === "billingRun.list")!;
     expect(isPaginated(p.inputSchema)).toBe(false);
     expect(withPageSizeDefault(p.inputSchema, { matterId: "m-1" })).toEqual({ matterId: "m-1" });
+  });
+
+  it("de tidigare opaginerade listorna sidas nu (#1011)", () => {
+    for (const path of ["invoice.list", "paymentPlan.list", "task.list"]) {
+      expect(isPaginated(PROCS.find((x) => x.path === path)!.inputSchema), path).toBe(true);
+    }
   });
 });
 
@@ -91,5 +97,47 @@ describe("introspektionen tappar inte scheman på date-fält (#1008)", () => {
       const schema = PROCS.find((p) => p.path === path)!.inputSchema as { properties?: object } | null;
       expect(Object.keys(schema?.properties ?? {}).length, `${path} ska ha fält`).toBeGreaterThan(0);
     }
+  });
+});
+
+/**
+ * Datumfältens JSON-form (#1010). `z.coerce.date()` i routrarna + override:n i
+ * `introspect.ts` ger `{ type: "string", format: "date-time" }` — det en
+ * JSON-klient faktiskt kan skicka. Vakten sist är den generella: ett HELT
+ * otypat fält (`{}`) är alltid ett hål i annonseringen, oavsett orsak.
+ */
+describe("datumfält är typade i annonserade scheman (#1010)", () => {
+  it("calendar.create.startAt är en date-time-sträng", () => {
+    const s = PROCS.find((p) => p.path === "calendar.create")!.inputSchema as { properties: Record<string, unknown> };
+    expect(s.properties.startAt).toEqual({ type: "string", format: "date-time" });
+  });
+
+  it("timeEntry.list.from/to är date-time-strängar", () => {
+    const s = PROCS.find((p) => p.path === "timeEntry.list")!.inputSchema as { properties: Record<string, unknown> };
+    expect(s.properties.from).toEqual({ type: "string", format: "date-time" });
+    expect(s.properties.to).toEqual({ type: "string", format: "date-time" });
+  });
+
+  it("inget fält i något annonserat schema är helt otypat", () => {
+    const untyped: string[] = [];
+    const walk = (path: string, node: unknown): void => {
+      if (node === null || typeof node !== "object") return;
+      const s = node as Record<string, unknown>;
+      const props = s.properties as Record<string, unknown> | undefined;
+      if (props) {
+        for (const [key, value] of Object.entries(props)) {
+          const rest = Object.keys(value as object).filter((k) => k !== "description" && k !== "default");
+          if (rest.length === 0) untyped.push(`${path}.${key}`);
+          walk(`${path}.${key}`, value);
+        }
+      }
+      for (const branch of ["items", "anyOf", "allOf", "oneOf"]) {
+        const v = s[branch];
+        if (Array.isArray(v)) v.forEach((x, i) => walk(`${path}[${i}]`, x));
+        else if (v) walk(path, v);
+      }
+    };
+    for (const p of PROCS) walk(p.path, p.inputSchema);
+    expect(untyped, `otypade fält: ${untyped.join(", ")}`).toEqual([]);
   });
 });

--- a/test/unit/ava-cli/tool-outputs.test.ts
+++ b/test/unit/ava-cli/tool-outputs.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Svarskontrakten på MCP-lagret (#1012).
+ *
+ * Kontrakten bor i ett sidoregister (`tool-outputs.ts`), inte som `.output()`
+ * på procedurerna — tRPC:s `.output()` ersätter klient-typen och ett löst
+ * schema smalnar då av hela UI:t. Priset för sidoregistret är drift-risk, och
+ * det här testet betalar det: varje kontrakt måste peka på en procedur som
+ * finns, och varje kontrakt måste vara ett objekt (MCP:s krav på
+ * `outputSchema`-toppnivån).
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { listProcedures } from "../../../tooling/ava-cli/introspect";
+import { outputDescribedPaths, toolOutputJsonSchema } from "../../../tooling/ava-cli/tool-outputs";
+
+const PATHS = new Set(listProcedures().map((p) => p.path));
+
+describe("svarskontraktens register", () => {
+  it("varje kontrakt hör till en procedur som finns", () => {
+    const orphans = outputDescribedPaths().filter((p) => !PATHS.has(p));
+    expect(orphans, `kontrakt utan procedur: ${orphans.join(", ")}`).toEqual([]);
+  });
+
+  it("läse-ytan är täckt", () => {
+    // Scope-beslutet i #1012: listor + getById + user.current med OBJEKT-svar.
+    // Krymper listan har någon tagit bort ett kontrakt — det ska synas här.
+    expect([...outputDescribedPaths()].sort()).toEqual([
+      "contacts.list", "matter.getById", "matter.list", "timeEntry.list", "user.current", "user.list",
+    ]);
+  });
+
+  it("varje kontrakt är ett objekt på toppnivån (MCP-kravet)", () => {
+    for (const path of outputDescribedPaths()) {
+      expect(toolOutputJsonSchema(path)?.type, path).toBe("object");
+    }
+  });
+
+  it("procedurer utan kontrakt → null, inte ett tomt schema", () => {
+    expect(toolOutputJsonSchema("billingRun.list")).toBeNull();
+    expect(toolOutputJsonSchema("finns.inte")).toBeNull();
+  });
+
+  it("datumfält annonseras som ISO-sträng — formen structuredContent bär", () => {
+    const schema = toolOutputJsonSchema("timeEntry.list") as {
+      properties: { entries: { items: { properties: { date: unknown } } } };
+    };
+    // dateish = union(Date, string): date-grenen får string/date-time av
+    // override:n, sträng-grenen är redan string.
+    expect(JSON.stringify(schema.properties.entries.items.properties.date)).toContain('"date-time"');
+  });
+
+  it("kontrakten är lösa — extra fält är tillåtna", () => {
+    // Ett strippande kontrakt vore en lögn: structuredContent bär HELA svaret.
+    const schema = toolOutputJsonSchema("matter.getById") as { additionalProperties?: unknown };
+    expect(schema.additionalProperties).not.toBe(false);
+  });
+});

--- a/test/unit/server/routers/timeEntry.test.ts
+++ b/test/unit/server/routers/timeEntry.test.ts
@@ -65,8 +65,10 @@ describe("timeEntry.list", () => {
     const to = new Date("2026-12-31");
     await makeCaller().list({ from, to });
     const w = mockPrisma.timeEntry.findMany.mock.calls[0]![0].where;
-    expect(w.date.gte).toBe(from);
-    expect(w.date.lte).toBe(to);
+    // Värde, inte referens: `z.coerce.date()` (#1010) klonar inkommande Date
+    // — filtret ska vara SAMMA TIDPUNKT, inte samma objekt.
+    expect(w.date.gte).toEqual(from);
+    expect(w.date.lte).toEqual(to);
   });
 
   it("returnerar totalMinutes från aggregate", async () => {

--- a/test/unit/shared/paginate.test.ts
+++ b/test/unit/shared/paginate.test.ts
@@ -1,0 +1,33 @@
+/**
+ * `pageSlice` (#1011) — frivillig sidning: utelämnad pageSize ÄR dagens
+ * beteende (hela listan), allt annat är opt-in. Det är kontraktet som gör att
+ * routrarna kunde få sidning utan att någon UI-anropare påverkas.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { pageSlice } from "@/lib/shared/paginate";
+
+const ROWS = ["a", "b", "c", "d", "e"];
+
+describe("pageSlice", () => {
+  it("utan pageSize returneras hela listan (dagens beteende)", () => {
+    expect(pageSlice(ROWS, undefined)).toEqual(ROWS);
+    expect(pageSlice(ROWS, {})).toEqual(ROWS);
+    expect(pageSlice(ROWS, { page: 3 })).toEqual(ROWS); // page utan pageSize = meningslös → orörd
+  });
+
+  it("returnerar en kopia, aldrig samma referens", () => {
+    // Routern får inte läcka ut repo:ts interna array till mutation.
+    expect(pageSlice(ROWS, undefined)).not.toBe(ROWS);
+  });
+
+  it("skär ut begärd sida, page defaultar till 1", () => {
+    expect(pageSlice(ROWS, { pageSize: 2 })).toEqual(["a", "b"]);
+    expect(pageSlice(ROWS, { pageSize: 2, page: 2 })).toEqual(["c", "d"]);
+    expect(pageSlice(ROWS, { pageSize: 2, page: 3 })).toEqual(["e"]);
+  });
+
+  it("sida bortom slutet → tom lista, inget fel", () => {
+    expect(pageSlice(ROWS, { pageSize: 2, page: 4 })).toEqual([]);
+  });
+});

--- a/tooling/ava-cli/introspect.ts
+++ b/tooling/ava-cli/introspect.ts
@@ -47,6 +47,19 @@ function lastZodInput(inputs: unknown): z.ZodType | null {
 }
 
 /**
+ * Datumfält → `{ type: "string", format: "date-time" }` (#1010).
+ *
+ * zod kan inte själv uttrycka `date` i JSON Schema; utan denna override blev
+ * fältet ett otypat `{}` — modellen såg ett fält utan typ, format eller
+ * ledtråd. Routrarnas datum-inputs är `z.coerce.date()`, så en ISO-sträng är
+ * exakt vad en JSON-klient SKA skicka: override:n annonserar den formen.
+ */
+function overrideDateFields(ctx: { zodSchema: unknown; jsonSchema: Record<string, unknown> }): void {
+  const def = (ctx.zodSchema as { _zod?: { def?: { type?: string } } })._zod?.def;
+  if (def?.type === "date") Object.assign(ctx.jsonSchema, { type: "string", format: "date-time" });
+}
+
+/**
  * zod → JSON-schema.
  *
  * `unrepresentable: "any"` är inte kosmetika (#1008): default:en är `"throw"`,
@@ -55,15 +68,13 @@ function lastZodInput(inputs: unknown): z.ZodType | null {
  * drabbade 13 procedurer, bl.a. `timeEntry.list` (vars `matterId`/`from`/`to`/
  * `page`/`pageSize` blev osynliga → modellen kunde bara begära ALLT) och
  * `calendar.create`/`task.create`, som såg ut att inte ta några argument alls.
- * Med `"any"` blir date-fältet ett otypat `{}` och resten av objektet överlever.
- *
- * Att date-fälten dessutom inte GÅR att fylla i över JSON (`z.date()` avvisar
- * strängar) är en egen brist — se #1010.
+ * `"any"` låter resten av objektet överleva; `overrideDateFields` ger sedan
+ * date-fälten en riktig typ (#1010).
  */
 function toJsonSchema(schema: z.ZodType | null): unknown {
   if (!schema) return null;
   try {
-    return z.toJSONSchema(schema, { io: "input", unrepresentable: "any" });
+    return z.toJSONSchema(schema, { io: "input", unrepresentable: "any", override: overrideDateFields });
   } catch {
     return null;
   }

--- a/tooling/ava-cli/mcp.ts
+++ b/tooling/ava-cli/mcp.ts
@@ -17,6 +17,7 @@ import { fromJsonSchema, McpServer, type CallToolResult, type JsonSchemaType, ty
 import type { AvaCaller } from "./caller";
 import type { ProcedureInfo, ProcedureType } from "./introspect";
 import { toolDescription, withPageSizeDefault } from "./tool-descriptions";
+import { toolOutputJsonSchema } from "./tool-outputs";
 
 export const MCP_SERVER_NAME = "ava";
 export const MCP_SERVER_VERSION = "0.2.0";
@@ -52,6 +53,7 @@ export function toolAnnotations(type: ProcedureType): ToolAnnotations {
 
 export interface McpToolResult {
   content: { type: "text"; text: string }[];
+  structuredContent?: Record<string, unknown>;
   isError?: boolean;
 }
 
@@ -60,11 +62,33 @@ export interface McpToolResult {
  * callern. Fel returneras som `isError`-content (MCP-konvention), inte som ett
  * protokoll-fel — spec:en är uttrycklig om att valideringsfel ska nå modellen
  * som verktygsfel så den kan rätta sig själv.
+ *
+ * Verktyg med svarskontrakt (#1012) fyller BÅDE `structuredContent` (samma
+ * data, JSON-serialiserad så `Date` blir ISO-sträng) och text-`content` — SDK:n
+ * lämnar annars `content` tom när `outputSchema` finns, och en klient som bara
+ * läser text ser då ingenting.
  */
-export async function executeToolCall(name: string, args: unknown, caller: AvaCaller): Promise<McpToolResult> {
+/** Bygg verktygssvaret ur callerns data (utbruten: complexity ≤ 8). */
+function toolResult(data: unknown, structured: boolean): McpToolResult {
+  const text = JSON.stringify(data ?? null, null, 2);
+  const result: McpToolResult = { content: [{ type: "text", text }] };
+  if (structured && data !== null && typeof data === "object" && !Array.isArray(data)) {
+    // JSON-rundresan är serialiseringen: Date → ISO-sträng, undefined faller
+    // bort — exakt det annonserade kontraktets form.
+    result.structuredContent = JSON.parse(text) as Record<string, unknown>;
+  }
+  return result;
+}
+
+export async function executeToolCall(
+  name: string,
+  args: unknown,
+  caller: AvaCaller,
+  opts: { structured?: boolean } = {},
+): Promise<McpToolResult> {
   try {
     const data = await caller.invoke(pathFromTool(name), args ?? {});
-    return { content: [{ type: "text", text: JSON.stringify(data ?? null, null, 2) }] };
+    return toolResult(data, opts.structured === true);
   } catch (err) {
     return { content: [{ type: "text", text: err instanceof Error ? err.message : String(err) }], isError: true };
   }
@@ -80,15 +104,17 @@ export function buildAvaMcpServer(procs: readonly ProcedureInfo[], caller: AvaCa
   const server = new McpServer({ name: MCP_SERVER_NAME, version: MCP_SERVER_VERSION }, { capabilities: { tools: {} } });
   for (const p of procs) {
     const name = toolName(p.path);
+    const outputSchema = toolOutputJsonSchema(p.path);
     server.registerTool(
       name,
       {
         description: toolDescription(p),
         inputSchema: fromJsonSchema(toolInputSchema(p.inputSchema)),
+        ...(outputSchema ? { outputSchema: fromJsonSchema(outputSchema as JsonSchemaType) } : {}),
         annotations: toolAnnotations(p.type),
       },
       (args: unknown): Promise<CallToolResult> =>
-        executeToolCall(name, withPageSizeDefault(p.inputSchema, args), caller) as Promise<CallToolResult>,
+        executeToolCall(name, withPageSizeDefault(p.inputSchema, args), caller, { structured: outputSchema !== null }) as Promise<CallToolResult>,
     );
   }
   return server;

--- a/tooling/ava-cli/tool-outputs.ts
+++ b/tooling/ava-cli/tool-outputs.ts
@@ -1,0 +1,89 @@
+/**
+ * `tool-outputs` — svarskontrakt för läse-ytan, på MCP-lagret (#1012).
+ *
+ * Varför HÄR och inte som `.output()` på procedurerna: tRPC:s `.output()`
+ * ersätter procedurens klient-typ med schemats output-typ. Ett partiellt
+ * (löst) schema smalnar då av typerna i hela UI:t — provat, bröt dussintals
+ * sidor — och ett exakt schema är runtime-validering i produktionens väg där
+ * en enda missad nullbarhet fäller anropet för alla klienter. Sidoregistret
+ * ger AI:n svarsformen utan att röra vare sig UI-typer eller produktions-
+ * validering; SDK:n validerar `structuredContent` mot schemat vid anropet.
+ *
+ * Schemana är LÖSA (`looseObject`): de dokumenterar vad som garanterat finns,
+ * inte allt som råkar finnas. `dateish` speglar att runtime-värdet är ett
+ * `Date` som JSON-serialiseras till ISO-sträng.
+ *
+ * Scope: läse-ytan med OBJEKT-svar. `invoice.list`/`task.list` returnerar
+ * arrayer, och MCP:s `outputSchema` kräver ett objekt på toppnivån — de får
+ * sina kontrakt den dag listorna byter till kuvertform ({ items, total }, #1014).
+ */
+
+import { z } from "zod";
+
+/** Datum i svar: `Date` i processen, ISO-sträng efter JSON-serialisering. */
+const dateish = z.union([z.date(), z.string()]);
+
+/** Essensen av ett ärende — det som alltid finns, oavsett join-djup. */
+const matterRow = z.looseObject({
+  id: z.string(),
+  matterNumber: z.string(),
+  title: z.string(),
+  status: z.string(),
+  paymentMethod: z.string(),
+});
+
+const userRow = z.looseObject({
+  id: z.string(),
+  email: z.string(),
+  name: z.string(),
+  role: z.string(),
+});
+
+/** Svarskontrakt per procedur-path. Bara objekt-svar (MCP-kravet). */
+const TOOL_OUTPUTS: Readonly<Record<string, z.ZodType>> = {
+  "matter.list": z.looseObject({ matters: z.array(matterRow), total: z.number() }),
+  "matter.getById": matterRow,
+  "timeEntry.list": z.looseObject({
+    entries: z.array(z.looseObject({
+      id: z.string(),
+      matterId: z.string(),
+      date: dateish,
+      minutes: z.number(),
+      description: z.string(),
+      billable: z.boolean(),
+    })),
+    total: z.number(),
+    totalMinutes: z.number(),
+    pages: z.number(),
+  }),
+  "contacts.list": z.looseObject({
+    contacts: z.array(z.looseObject({ id: z.string(), name: z.string(), contactType: z.string() })),
+    total: z.number(),
+    pages: z.number(),
+  }),
+  "user.current": userRow,
+  "user.list": z.looseObject({ users: z.array(userRow) }),
+};
+
+/** Paths med svarskontrakt — drift-/integrationstesterna läser den här. */
+export function outputDescribedPaths(): readonly string[] {
+  return Object.keys(TOOL_OUTPUTS);
+}
+
+/**
+ * Svarskontraktet som JSON Schema, eller `null` för procedurer utan.
+ * Datumfält annonseras som `{ type: "string", format: "date-time" }` — det är
+ * formen `structuredContent` faktiskt bär efter JSON-serialiseringen.
+ */
+export function toolOutputJsonSchema(path: string): Record<string, unknown> | null {
+  const schema = TOOL_OUTPUTS[path];
+  if (!schema) return null;
+  return z.toJSONSchema(schema, {
+    io: "output",
+    unrepresentable: "any",
+    override: (ctx) => {
+      const def = (ctx.zodSchema as { _zod?: { def?: { type?: string } } })._zod?.def;
+      if (def?.type === "date") Object.assign(ctx.jsonSchema, { type: "string", format: "date-time" });
+    },
+  }) as Record<string, unknown>;
+}


### PR DESCRIPTION
## Vad & varför

Tre syskon ur #1008, som tillsammans gör verktygsytan **användbar** och inte bara synlig. En PR eftersom de rör samma fil-yta och samma tester.

### #1010 — datum över JSON

Routrarnas datum-inputs var `z.date()`, som avvisar strängar — och JSON har inga `Date`. `calendar.create` och `task.create` gick bokstavligen inte att använda från en JSON-klient; `timeEntry.list` kunde inte begränsas till en period.

- `z.date()` → `z.coerce.date()` i `timeEntry`/`calendar`/`task`/`todo`-routrarna. Verifierat före ändringen: coerce tar både `Date` (browservägen via superjson, oförändrad) och ISO-sträng; `nullish()` kortsluter före koercionen så `null` **inte** blir 1970; skräpsträngar avvisas fortfarande.
- Override i `introspect.ts`: datumfält annonseras som `{ type: "string", format: "date-time" }` i stället för otypade `{}`.
- Regressionsvakt: inget fält i något av de 151 verktygens scheman får vara helt otypat.
- `document/core`:s två kvarvarande `z.date()` ligger i unioner med en strängsgren — redan JSON-användbara; override:n typar date-grenen.

### #1011 — sidade listor

`invoice.list`, `paymentPlan.list`, `task.list` returnerade allt. Frivillig `page`/`pageSize` via ny `pageSlice` — **utelämnad `pageSize` är dagens beteende**, så ingen UI-anropare påverkas; MCP-ytans default (10) gör resten. `invoice.list` 43,8 → 37,2 KB; budget-ratchet:en sänkt 45 000 → 38 000. Raderna är join-feta (~1 KB/faktura) — nästa sänkning är fältprojektion, utbruten till **#1014** tillsammans med kuvertformen.

### #1012 — svarskontrakt

Läse-ytan (`matter.list`/`getById`, `timeEntry.list`, `contacts.list`, `user.current`/`list`) annonserar `outputSchema` och svarar med **både** `structuredContent` och text-`content` — SDK:n lämnar annars `content` tomt, och en klient som bara läser text ser ingenting. SDK:n validerar `structuredContent` mot schemat vid varje anrop, så kontraktet är en levande grind.

**Viktig avvikelse från issuens ursprungsplan:** kontrakten bor i ett sidoregister på MCP-lagret (`tool-outputs.ts`), inte som `.output()` på procedurerna. Jag provade `.output()`-vägen först: tRPC:s `.output()` **ersätter procedurens klient-typ**, och ett löst partiellt schema smalnar då av typerna i hela UI:t — det bröt dussintals sidor i typecheck. Ett exakt schema vore alternativet, men det är runtime-validering i produktionens väg där en enda missad nullbarhet fäller anropet för alla klienter (och ett strikt `z.object` dessutom *strippar* okända nycklar tyst). Sidoregistret ger AI:n svarsformen med noll risk för UI och produktion. Motiverat i filens huvudkommentar.

Array-svaren (`invoice.list`, `task.list`, `paymentPlan.list`) står utanför — MCP:s `outputSchema` kräver ett objekt på toppnivån. Kuvertformen `{ items, total }` som låser upp dem: **#1014**.

Stänger #1010
Stänger #1011
Stänger #1012

## Typ

- [x] `feat` — ny funktion
- [ ] `fix` — buggfix
- [ ] `refactor` / `perf`
- [ ] `docs` / `test` / `chore` / `ci`

## Verifierat lokalt (speglar CI)

- [x] `typecheck` + `lint` + `knip` + `deps:check` + `duplicates` — rena
- [x] `bun run build:demo` — byggd; `bun run e2e:demo` — **33 passed** (routrarna som fick sidning driver fakturasidan m.fl.)
- [x] `bun run size` — 34,6 % av budget, oförändrat
- [x] Berörda testfiler körda var för sig (#92): mcp-server (integration) **24**, tool-outputs 6, tool-descriptions 14, paginate 4, mcp 7, introspect 4, cli 19, ava-mcp-stdio 2, samt routrarna calendar 22, contact 15, invoice 45+5, invoiceDispatch 10, matter 29, paymentPlan 16, task 12, **timeEntry 22**, todo 7, user 24, todo-views 22 — alla gröna
- [x] Nya rader har täckande tester (`pageSlice` fullt, datumvägar över MCP end-to-end, kontraktsregistrets drift-vakt)
- [x] Commits följer Conventional Commits (commitlint)

En befintlig assertion justerad: `timeEntry.test.ts` jämförde datumfiltret med `toBe` (referens) — `z.coerce.date()` klonar inkommande `Date`, och avsikten är samma tidpunkt, inte samma objekt → `toEqual`.

## Kvalitetsgrindar

- [x] Inga gater lösgjorda — budget-ratchet:en **sänkt** (45 000 → 38 000), komplexitet hölls ≤ 8 genom utbrytning (`toolResult`)
- [x] `src/lib/shared/schemas/` orörd (kontrakten bor i tooling); routeränringarna är additiva optionella fält

## Övrigt

Nya integrationstester som är värda att känna till: `calendar.create` + `task.create` anropas **över MCP med ISO-strängar** och skrivningarna verifieras i efterföljande listor — det är exakt de anrop som var omöjliga före #1010.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_