### PR TITLE
feat(reports): byråöversikt i ett anrop — reports.firmOverview för AI-ytan

### DIFF
--- a/src/lib/server/routers/reports.ts
+++ b/src/lib/server/routers/reports.ts
@@ -6,7 +6,8 @@ import {
   type FrozenWorkInput,
 } from "@/lib/shared/billed-per-lawyer";
 import type { InvoiceStatus, PaymentMethod } from "@/lib/shared/schemas/enums";
-import { asId, userIdSchema, type BillingRunId, type InvoiceId, type MatterId, type UserId } from "@/lib/shared/schemas/ids";
+import { asId, userIdSchema, type BillingRunId, type InvoiceId, type MatterId, type OrganizationId, type UserId } from "@/lib/shared/schemas/ids";
+import type { Repositories } from "../repositories/repositories";
 import { router, protectedProcedure } from "../trpc";
 
 /**
@@ -318,6 +319,84 @@ function sumMatterTotals(matters: MatterAgg[]) {
   );
 }
 
+// ─── Byråöversikt (#1016) ────────────────────────────────────────────
+
+/** En jurists rad i byråöversikten. Alla kronbelopp i öre. */
+interface FirmLawyerRow {
+  userId: string;
+  name: string;
+  title: string | null;
+  totalMinutes: number;
+  billableMinutes: number;
+  workValueOre: number;
+  expenseOre: number;
+  /** Upparbetat, ännu inte fakturerat (debiterbar tid + utlägg utan faktura). */
+  unbilledOre: number;
+  /** Fakturerat i perioden, attribuerat mot juristens andel av fryst arbete (#90). */
+  billedOre: number;
+  writeOffOre: number;
+  netOre: number;
+}
+
+/** Org-datat som hämtas EN gång och delas mellan jurist-raderna. */
+interface FirmShared {
+  invoiceInputs: BilledInvoiceInput[];
+  frozenWork: FrozenWorkInput[];
+  period: { from: Date; to: Date };
+  prevPeriod: { from: Date; to: Date };
+}
+
+/** En jurists rad: periodens arbete (samma delrapporter som perLawyer) + fakturerat. */
+async function firmLawyerRow(
+  repos: Repositories,
+  org: OrganizationId,
+  user: { id: UserId; name: string; title?: string | null | undefined },
+  shared: FirmShared,
+): Promise<FirmLawyerRow> {
+  const [timeEntries, expenses] = await Promise.all([
+    repos.timeEntries.listForLawyerInPeriod(org, user.id, shared.period.from, shared.period.to),
+    repos.expenses.listForLawyerInPeriod(org, user.id, shared.period.from, shared.period.to),
+  ]);
+  const totals = sumMatterTotals(buildMatters(timeEntries, expenses));
+  const billed = billedPerLawyer({
+    userId: user.id,
+    invoices: shared.invoiceInputs,
+    frozenWork: shared.frozenWork,
+    period: shared.period,
+    prevPeriod: shared.prevPeriod,
+  });
+  return {
+    userId: String(user.id),
+    name: user.name,
+    title: user.title ?? null,
+    ...totals,
+    unbilledOre: buildUnbilled(timeEntries, expenses).total,
+    billedOre: billed.billedOre,
+    writeOffOre: billed.writeOffOre,
+    netOre: billed.netOre,
+  };
+}
+
+type FirmTotals = Omit<FirmLawyerRow, "userId" | "name" | "title">;
+
+/** Byråtotalerna = summan av raderna, fält för fält. */
+function firmTotals(rows: readonly FirmLawyerRow[]): FirmTotals {
+  const zero: FirmTotals = {
+    totalMinutes: 0, billableMinutes: 0, workValueOre: 0, expenseOre: 0,
+    unbilledOre: 0, billedOre: 0, writeOffOre: 0, netOre: 0,
+  };
+  return rows.reduce<FirmTotals>((acc, r) => ({
+    totalMinutes: acc.totalMinutes + r.totalMinutes,
+    billableMinutes: acc.billableMinutes + r.billableMinutes,
+    workValueOre: acc.workValueOre + r.workValueOre,
+    expenseOre: acc.expenseOre + r.expenseOre,
+    unbilledOre: acc.unbilledOre + r.unbilledOre,
+    billedOre: acc.billedOre + r.billedOre,
+    writeOffOre: acc.writeOffOre + r.writeOffOre,
+    netOre: acc.netOre + r.netOre,
+  }), zero);
+}
+
 export const reportsRouter = router({
   /**
    * Advokatrapport: en advokat, en period, tre delrapporter.
@@ -431,6 +510,63 @@ export const reportsRouter = router({
         billedOre: result.billedOre,
         writeOffOre: result.writeOffOre,
         netOre: result.netOre,
+      };
+    }),
+
+  /**
+   * Byråöversikt (#1016): en rad per jurist + byråtotaler + fordringsläge,
+   * i ETT anrop. Finns för AI-ytan — utan den kostar "hur går det för byrån,
+   * per person?" 2N+1 verktygsanrop (user.list + perLawyer×N + billed×N) där
+   * varje perLawyer-svar dessutom drar veckotabeller översikten inte behöver.
+   * Komponerad ur samma rena delrapporter som perLawyer/billed; org-datat
+   * hämtas en gång och delas mellan raderna.
+   */
+  firmOverview: protectedProcedure
+    .input(z.object({ from: z.string(), to: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const fromDate = new Date(input.from);
+      const toDate = new Date(input.to);
+      toDate.setUTCHours(23, 59, 59, 999);
+      const org = ctx.user.organizationId;
+
+      const [users, invoices, billingRuns, frozenTime] = await Promise.all([
+        ctx.repos.users.listByOrg(asId<"OrganizationId">(org)),
+        ctx.repos.invoices.listForOrg(asId<"OrganizationId">(org)),
+        ctx.repos.billingRuns.listForOrg(org),
+        ctx.repos.timeEntries.listBillableForOrg(org),
+      ]);
+      const ids = (invoices as Array<{ id: InvoiceId }>).map((i) => i.id);
+      const [payments, writeOffs] = await Promise.all([
+        ctx.repos.payments.listByInvoiceIds(ids),
+        ctx.repos.writeOffs.listByInvoiceIds(ids),
+      ]);
+
+      const runToInvoice = new Map<string, string>();
+      for (const r of billingRuns as Array<{ id: string; invoiceId?: string | null }>) {
+        if (r.invoiceId) runToInvoice.set(r.id, r.invoiceId);
+      }
+      const shared: FirmShared = {
+        invoiceInputs: toInvoiceInputs(
+          invoices as RawInvoice[],
+          writtenOffDates(writeOffs as Array<{ invoiceId?: string; writtenOffAt?: unknown }>),
+        ),
+        frozenWork: buildFrozenWork(frozenTime as RawTimeEntry[], runToInvoice),
+        period: { from: fromDate, to: toDate },
+        prevPeriod: previousCalendarMonth(fromDate),
+      };
+
+      const lawyers = await Promise.all(users.map((u) => firmLawyerRow(ctx.repos, org, u, shared)));
+      const scoped = scopeArToPeriod(
+        invoices as Record<string, unknown>[],
+        payments as Record<string, unknown>[],
+        writeOffs as Record<string, unknown>[],
+        { from: fromDate, to: toDate },
+      );
+      return {
+        period: { from: input.from, to: input.to },
+        lawyers,
+        totals: firmTotals(lawyers),
+        ar: computeArBridge(scoped.invoices, scoped.payments, scoped.writeOffs, new Date()),
       };
     }),
 

--- a/test/integration/mcp-server.test.ts
+++ b/test/integration/mcp-server.test.ts
@@ -288,6 +288,40 @@ describe("sidning av listor utan egen paginering (#1011)", () => {
 });
 
 /**
+ * Byråöversikten över MCP (#1016) — verktyget som gör "hur går det för byrån,
+ * per person?" till ETT anrop i stället för 2N+1. Körs mot demo-seeden, så
+ * testet vaktar också att seeden faktiskt HAR siffror att visa.
+ */
+describe("reports.firmOverview över MCP (#1016)", () => {
+  it("ger en rad per jurist, byråtotaler och fordringsläge i ett anrop", async () => {
+    const { client, close } = await connect("legacy");
+    try {
+      const res = await client.callTool({
+        name: "reports__firmOverview",
+        arguments: { from: "2026-01-01", to: "2026-12-31" },
+      });
+      expect(res.isError, textOf(res)).toBeFalsy();
+      // Svarskontrakt: structuredContent + text, som resten av läse-ytan.
+      const data = res.structuredContent as {
+        lawyers: { name: string; totalMinutes: number; billedOre: number }[];
+        totals: { totalMinutes: number; billedOre: number; unbilledOre: number };
+        ar: { fakturerat: number; utestaende: number };
+      };
+      expect(data.lawyers.length).toBeGreaterThan(1);
+      expect(data.totals.totalMinutes).toBe(data.lawyers.reduce((s, l) => s + l.totalMinutes, 0));
+      expect(data.totals.billedOre).toBe(data.lawyers.reduce((s, l) => s + l.billedOre, 0));
+      // Demo-seeden bär riktig ekonomi — en översikt med bara nollor är trasig.
+      expect(data.totals.unbilledOre).toBeGreaterThan(0);
+      expect(data.ar.fakturerat).toBeGreaterThan(0);
+      // En aggregering ska vara LITEN: långt under budget-ratchet:en.
+      expect(textOf(res).length).toBeLessThan(15_000);
+    } finally {
+      await close();
+    }
+  });
+});
+
+/**
  * Utdatabudget (#1008) — en RATCHET i samma anda som bundle-size.
  *
  * MCP-klienter kapar verktygssvar (Claude Code varnar över 10 000 tokens och

--- a/test/unit/ava-cli/tool-outputs.test.ts
+++ b/test/unit/ava-cli/tool-outputs.test.ts
@@ -25,7 +25,7 @@ describe("svarskontraktens register", () => {
     // Scope-beslutet i #1012: listor + getById + user.current med OBJEKT-svar.
     // Krymper listan har någon tagit bort ett kontrakt — det ska synas här.
     expect([...outputDescribedPaths()].sort()).toEqual([
-      "contacts.list", "matter.getById", "matter.list", "timeEntry.list", "user.current", "user.list",
+      "contacts.list", "matter.getById", "matter.list", "reports.firmOverview", "timeEntry.list", "user.current", "user.list",
     ]);
   });
 

--- a/test/unit/server/routers/reports-firm-overview.test.ts
+++ b/test/unit/server/routers/reports-firm-overview.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Byråöversikten (#1016) — `reports.firmOverview`.
+ *
+ * Körs mot en riktig `DemoDataStore` med två jurister och känd ekonomi, så
+ * varje siffra i tabellen går att räkna för hand:
+ *
+ *   Anna:  120 min à 2 500 kr/h debiterbart OFAKTURERAT   → 5 000 kr upparbetat
+ *          60 min à 2 500 kr/h FRYST på faktura F1 (10 000 kr, SENT i perioden)
+ *   Bo:    90 min à 2 000 kr/h debiterbart ofakturerat    → 3 000 kr upparbetat
+ *          30 min icke-debiterbart (ska bara synas i totalMinutes)
+ *
+ * F1:s frysta arbete är 100 % Annas → hela fakturabeloppet attribueras henne.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { noopPorts } from "@/lib/server/adapters/noop-ports";
+import type { Principal } from "@/lib/server/auth/principal";
+import { buildContext } from "@/lib/server/build-context";
+import { DemoDataStore } from "@/lib/server/data-store/DemoDataStore";
+import { appRouter } from "@/lib/server/routers/_app";
+import { asId } from "@/lib/shared/schemas/ids";
+
+const PRINCIPAL: Principal = {
+  id: asId<"UserId">("u-anna"), email: "a@x", name: "Anna", role: "ADMIN", organizationId: asId<"OrganizationId">("org-1"),
+};
+
+function makeCaller() {
+  const ds = new DemoDataStore({
+    organizations: [{ id: "org-1", name: "Byrån" }],
+    users: [
+      { id: "u-anna", organizationId: "org-1", email: "a@x", name: "Anna", role: "ADMIN", hourlyRate: 250_000 },
+      { id: "u-bo", organizationId: "org-1", email: "b@x", name: "Bo", role: "LAWYER", hourlyRate: 200_000 },
+    ],
+    matters: [{
+      id: "m-1", organizationId: "org-1", matterNumber: "2026-0001", title: "Tvist",
+      status: "ACTIVE", paymentMethod: "PRIVAT", createdAt: new Date("2026-01-01"),
+    }],
+    timeEntries: [
+      // Annas ofakturerade arbete i perioden: 120 min × 2 500 kr/h = 5 000 kr.
+      { id: "te-a1", organizationId: "org-1", userId: "u-anna", matterId: "m-1", date: new Date("2026-03-10"), minutes: 120, description: "Inlaga", hourlyRate: 250_000, billable: true },
+      // Annas FRYSTA arbete → knyter F1 till henne (attributionen, #90).
+      { id: "te-a2", organizationId: "org-1", userId: "u-anna", matterId: "m-1", date: new Date("2026-02-01"), minutes: 60, description: "Möte", hourlyRate: 250_000, billable: true, invoiceId: "f-1" },
+      // Bos arbete: 90 min × 2 000 kr/h = 3 000 kr ofakturerat + 30 min internt.
+      { id: "te-b1", organizationId: "org-1", userId: "u-bo", matterId: "m-1", date: new Date("2026-03-12"), minutes: 90, description: "Utredning", hourlyRate: 200_000, billable: true },
+      { id: "te-b2", organizationId: "org-1", userId: "u-bo", matterId: "m-1", date: new Date("2026-03-13"), minutes: 30, description: "Internt", hourlyRate: 200_000, billable: false },
+    ],
+    invoices: [{
+      id: "f-1", organizationId: "org-1", matterId: "m-1", invoiceNumber: "F-2026-001", invoiceType: "FINAL",
+      status: "SENT", amount: 1_000_000, amountExclVat: 800_000, vat: 200_000, amountInclVat: 1_000_000,
+      invoiceDate: new Date("2026-03-01"), dueDate: new Date("2026-03-31"),
+      createdAt: new Date("2026-03-01"), updatedAt: new Date("2026-03-01"),
+    }],
+    payments: [{ id: "p-1", organizationId: "org-1", invoiceId: "f-1", amount: 400_000, paidAt: new Date("2026-03-20"), createdAt: new Date("2026-03-20") }],
+    expenses: [],
+  }, async () => { /* skrivbar store */ });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return appRouter.createCaller(buildContext({ dataStore: ds, ports: noopPorts, principal: PRINCIPAL }) as any);
+}
+
+const PERIOD = { from: "2026-01-01", to: "2026-06-30" };
+
+describe("reports.firmOverview (#1016)", () => {
+  it("en rad per jurist med handräknade siffror", async () => {
+    const res = await makeCaller().reports.firmOverview(PERIOD);
+    expect(res.lawyers.map((l) => l.name).sort()).toEqual(["Anna", "Bo"]);
+
+    const anna = res.lawyers.find((l) => l.name === "Anna")!;
+    // 120 ofakturerade + 60 frysta = 180 min arbete i perioden, allt debiterbart.
+    expect(anna.totalMinutes).toBe(180);
+    expect(anna.billableMinutes).toBe(180);
+    expect(anna.workValueOre).toBe(750_000);   // 3 h × 2 500 kr
+    expect(anna.unbilledOre).toBe(500_000);    // bara de 120 ofakturerade minuterna
+    expect(anna.billedOre).toBe(1_000_000);    // F1 attribueras 100 % Anna
+
+    const bo = res.lawyers.find((l) => l.name === "Bo")!;
+    expect(bo.totalMinutes).toBe(120);         // 90 debiterbara + 30 interna
+    expect(bo.billableMinutes).toBe(90);
+    expect(bo.unbilledOre).toBe(300_000);      // 1,5 h × 2 000 kr
+    expect(bo.billedOre).toBe(0);              // inget fryst arbete → ingen attribution
+  });
+
+  it("totalerna är summan av raderna", async () => {
+    const res = await makeCaller().reports.firmOverview(PERIOD);
+    const sum = (f: (l: (typeof res.lawyers)[number]) => number): number => res.lawyers.reduce((s, l) => s + f(l), 0);
+    expect(res.totals.totalMinutes).toBe(sum((l) => l.totalMinutes));
+    expect(res.totals.workValueOre).toBe(sum((l) => l.workValueOre));
+    expect(res.totals.unbilledOre).toBe(sum((l) => l.unbilledOre));
+    expect(res.totals.billedOre).toBe(sum((l) => l.billedOre));
+    expect(res.totals.unbilledOre).toBe(800_000); // 5 000 + 3 000 kr
+  });
+
+  it("fordringsläget scopas till perioden", async () => {
+    const res = await makeCaller().reports.firmOverview(PERIOD);
+    expect(res.ar.fakturerat).toBe(1_000_000);
+    expect(res.ar.inbetalt).toBe(400_000);
+    expect(res.ar.utestaende).toBe(600_000);
+    // Faktura utanför perioden ska inte synas: fråga en period före fakturan.
+    const before = await makeCaller().reports.firmOverview({ from: "2025-01-01", to: "2025-12-31" });
+    expect(before.ar.fakturerat).toBe(0);
+    expect(before.totals.totalMinutes).toBe(0);
+  });
+
+  it("perioden avgränsar juristernas rader, inte bara fordringarna", async () => {
+    // Bara mars: Annas frysta 60 min (februari) faller bort ur arbetet, men
+    // fakturan (utställd 1 mars) ligger kvar i fakturerat.
+    const res = await makeCaller().reports.firmOverview({ from: "2026-03-01", to: "2026-03-31" });
+    const anna = res.lawyers.find((l) => l.name === "Anna")!;
+    expect(anna.totalMinutes).toBe(120);
+    expect(anna.billedOre).toBe(1_000_000);
+  });
+});

--- a/tooling/ava-cli/tool-descriptions.ts
+++ b/tooling/ava-cli/tool-descriptions.ts
@@ -185,6 +185,7 @@ const DESCRIPTIONS: Readonly<Record<string, string>> = {
   "prefs.listOrgDefaults": "Vilka inställningar som har en byrå-default satt.",
 
   // ── Rapporter ────────────────────────────────────────────────────
+  "reports.firmOverview": "Byråöversikt för en period: en rad per jurist med arbetade timmar, debiterbart värde, upparbetat ofakturerat och fakturerat netto, plus byråtotaler och kundfordringsläget. Rätt startpunkt för hur det går för byrån; djupdyk per person med reports.perLawyer.",
   "reports.perLawyer": "Advokatrapport för en period: vilka ärenden advokaten arbetat i, timdebitering per vecka, och upparbetat men ofakturerat arbete.",
   "reports.billed": "Fakturerat per advokat och period, attribuerat mot advokatens andel av det frysta arbetsvärdet, netto efter avskrivningar.",
   "reports.arSummary": "Kundfordringar över byråns livstid: brygga och åldersanalys, byggd på de daterade avskrivningsposterna.",

--- a/tooling/ava-cli/tool-outputs.ts
+++ b/tooling/ava-cli/tool-outputs.ts
@@ -63,6 +63,21 @@ const TOOL_OUTPUTS: Readonly<Record<string, z.ZodType>> = {
   }),
   "user.current": userRow,
   "user.list": z.looseObject({ users: z.array(userRow) }),
+  "reports.firmOverview": z.looseObject({
+    period: z.looseObject({ from: z.string(), to: z.string() }),
+    lawyers: z.array(z.looseObject({
+      userId: z.string(),
+      name: z.string(),
+      totalMinutes: z.number(),
+      billableMinutes: z.number(),
+      workValueOre: z.number(),
+      unbilledOre: z.number(),
+      billedOre: z.number(),
+      netOre: z.number(),
+    })),
+    totals: z.looseObject({ workValueOre: z.number(), unbilledOre: z.number(), billedOre: z.number(), netOre: z.number() }),
+    ar: z.looseObject({ fakturerat: z.number(), inbetalt: z.number(), utestaende: z.number() }),
+  }),
 };
 
 /** Paths med svarskontrakt — drift-/integrationstesterna läser den här. */


### PR DESCRIPTION
## Vad & varför

Byråns siffror ska gå att hämta via Claude/MCP — både byrånivån och per jurist. Per-jurist-ytan fanns redan och fungerar över MCP i dag (`reports.perLawyer`, `reports.billed`, `reports.arSummary` — alla tar sträng-datum, verifierat mot demo-seeden). Det som saknades var **byrånivån**: "hur går det för byrån, per person?" kostade 2N+1 verktygsanrop (`user.list` + `perLawyer`×N + `billed`×N), där varje `perLawyer`-svar dessutom drar veckotabeller och ärendelistor en översikt inte behöver.

**`reports.firmOverview({ from, to })`** ger i ett anrop:

- en rad per jurist: arbetade/debiterbara minuter, arbetsvärde, utlägg, upparbetat ofakturerat, fakturerat/avskrivet/netto (attribuerat mot juristens andel av fryst arbete, samma modell som #90),
- byråtotaler = summan av raderna, fält för fält,
- kundfordringsläget för perioden (bryggan ur ADR 0007: fakturerat, inbetalt, utestående, förfallet).

Ingen ny beräkningslogik: allt komponeras ur de befintliga, redan testade rena delarna (`buildMatters`/`sumMatterTotals`/`buildUnbilled`, `billedPerLawyer`, `scopeArToPeriod`/`computeArBridge`). Org-datat hämtas **en** gång och delas mellan jurist-raderna.

På MCP-ytan: verktygsbeskrivning (drift-vakten kräver den) och svarskontrakt i `tool-outputs.ts` — objekt-svar som aldrig är null, så det annonseras som `outputSchema` och svarar med `structuredContent`.

Stänger #1016

## Typ

- [x] `feat` — ny funktion
- [ ] `fix` — buggfix
- [ ] `refactor` / `perf`
- [ ] `docs` / `test` / `chore` / `ci`

## Verifierat lokalt (speglar CI)

- [x] `typecheck` + `lint` + `knip` + `deps:check` + `duplicates` — rena
- [x] `bun run build:demo` — byggd, oförändrad (789 entiteter); `bun run size` 34,6 %
- [x] Berörda testfiler körda var för sig (#92): **reports-firm-overview 4** (nya), reports 7, reports-billed 6, reports-ar-summary 7, reports-work-value 5, billed-per-lawyer 10, ar-summary 12, mcp-server (integration) **25**, tool-outputs 6, tool-descriptions 14 — alla gröna
- [x] Nya rader har täckande tester — router-testet kör mot en riktig `DemoDataStore` med **handräknade siffror**: två jurister, fryst vs ofakturerat arbete, delbetald faktura, och periodavgränsning åt båda håll (period före fakturan → nollor; bara mars → februariarbetet faller bort ur minuterna men fakturan ligger kvar i fakturerat)
- [x] Commits följer Conventional Commits (commitlint)

## Kvalitetsgrindar

- [x] Inga gater lösgjorda. MCP-integrationstestet asserterar dessutom att översikten ligger **långt under** utdatabudgeten (< 15 000 tecken mot ratchet:ens 38 000) — en aggregering ska vara liten
- [x] `src/lib/shared/schemas/` orörd; ändringen är en ny procedur i `reports.ts` plus sidoregistren

## Övrigt

Användningen från Claude blir: `reports__firmOverview` för tabellen "hur går det?", sedan `reports__perLawyer`/`reports__billed` för djupdykning per person och `reports__arSummary` för fordringsanalysen — alla fyra nu med beskrivningar som förklarar just den arbetsdelningen.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_