### PR TITLE
feat(demo): fryst arbete i seeden + incheckad MCP-konfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ fliken så är allt borta.
   ansökan, kostnadsräkning …) från byråns egna mallar.
 - **AI (helt valfritt)** — en språkmodell som körs *lokalt i webbläsaren* kan
   föreslå hur uppladdade dokument ska sorteras. Inget skickas vidare.
+- **Fråga Claude om byrån (MCP)** — hela API-ytan är exponerad som
+  MCP-verktyg, inklusive rapporterna: byråöversikt per jurist, timdebitering
+  per vecka, kundfordringar. Repot bär sin egen serverkonfiguration
+  (`.mcp.json`), så varje Claude Code-session på repot — i terminalen, på
+  [claude.ai/code](https://claude.ai/code) eller startad från mobilappen — kan
+  svara på *"hur går det för byrån i år?"* direkt mot en seedad sandlåda.
+  Lokalt: `git clone … && bun install && claude`. Mot riktig data: sätt
+  `AVA_SERVER_URL` + `AVA_TOKEN` (PAT) mot en server-first-instans.
 
 > Allt ovan är förifyllt med exempeldata i demon så att du kan se hur det
 > hänger ihop. I skarp drift sparas dina ändringar löpande i byråns arkiv.

--- a/test/e2e/_demo-test.ts
+++ b/test/e2e/_demo-test.ts
@@ -100,7 +100,7 @@ export async function seedDemoLogin(page: Page, baseUrl: string = DEMO_BASE_URL)
  * uppslagning som inte hittar något säger vad som saknas.
  */
 export interface DemoSeed {
-  matters: Array<{ id: string; title: string }>;
+  matters: Array<{ id: string; title: string; createdAt?: string }>;
   contacts: Array<{ id: string; name: string }>;
   invoices: Array<{ id: string; matterId: string }>;
   documents: Array<{ id: string; matterId: string; title: string }>;

--- a/test/e2e/demo-smoke.spec.ts
+++ b/test/e2e/demo-smoke.spec.ts
@@ -75,10 +75,15 @@ test("dokumentmallar visas (data laddas från .ava/templates/)", async ({ page }
 test("ärendelistan visar seedens egna ärenden", async ({ page }) => {
   const seed = await fetchDemoSeed(page, BASE);
   await page.goto(`${BASE}/matters/`);
-  // Titeln kommer ur seeden, inte ur en hårdkodad sträng: listan ska visa det
-  // datat demon faktiskt bär, vad seeden än döpt ärendena till.
-  const title = seed.matters[0]?.title ?? "";
-  await expect(page.getByText(title, { exact: false }).first()).toBeVisible({ timeout: 15_000 });
+  // Titeln kommer ur seeden, inte ur en hårdkodad sträng — men INTE
+  // `matters[0]`: seed-JSON:ens ordning är serialiseringsordning och varierar
+  // mellan byggen, medan listan sorterar `createdAt DESC` med 20 per sida.
+  // Seedens 21:a (äldsta) ärende ligger alltid på sida 2, så bygget som råkade
+  // serialisera det äldsta först föll — ett 1/21-lotteri per bygge. Det NYASTE
+  // ärendet ligger per definition överst på sida 1.
+  const newest = [...seed.matters]
+    .sort((a, b) => String(b.createdAt ?? "").localeCompare(String(a.createdAt ?? "")))[0];
+  await expect(page.getByText(newest?.title ?? "", { exact: false }).first()).toBeVisible({ timeout: 15_000 });
 });
 
 test("kontaktlistan visar seedens egna kontakter", async ({ page }) => {

--- a/test/integration/mcp-server.test.ts
+++ b/test/integration/mcp-server.test.ts
@@ -313,6 +313,12 @@ describe("reports.firmOverview över MCP (#1016)", () => {
       // Demo-seeden bär riktig ekonomi — en översikt med bara nollor är trasig.
       expect(data.totals.unbilledOre).toBeGreaterThan(0);
       expect(data.ar.fakturerat).toBeGreaterThan(0);
+      // #1018: attributionen kräver FRYST arbete (tidsposter med invoiceId).
+      // Seeden hade fakturor utan en enda länkad post → "Fakturerat per jurist"
+      // var 0 kr för alla trots fakturerat i bryggan. Minst två jurister ska
+      // ha attribuerat fakturerat, annars har länkarna tappats igen.
+      expect(data.lawyers.filter((l) => l.billedOre > 0).length).toBeGreaterThanOrEqual(2);
+      expect(data.totals.billedOre).toBeGreaterThan(0);
       // En aggregering ska vara LITEN: långt under budget-ratchet:en.
       expect(textOf(res).length).toBeLessThan(15_000);
     } finally {

--- a/tooling/scripts/seed-data.ts
+++ b/tooling/scripts/seed-data.ts
@@ -301,6 +301,10 @@ export function buildSeed(opts: BuildSeedOpts = {}): SeedDataset {
   out.paymentPlans = plan.paymentPlans;
   out.paymentPlanReminders = plan.paymentPlanReminders;
 
+  // Efter plan-bygget: statusarna är slutgiltiga, så fryst-länkningen ser
+  // fakturornas verkliga tillstånd.
+  linkFrozenWork(out.timeEntries, out.invoices);
+
   out.calendarEvents = buildCalendarEvents(orgId, ASSIGN_USERS);
   out.tasks = buildTasks(orgId, ASSIGN_USERS);
   out.documentTemplates = buildTemplates(orgId, currentUserId);
@@ -589,6 +593,39 @@ function buildInvoices(orgId: string): SeedDataset["invoices"] {
     });
   }
   return out;
+}
+
+/**
+ * Frys arbete mot fakturorna (#1018).
+ *
+ * "Fakturerat per jurist" (#90) fördelar fakturabelopp mot juristens andel av
+ * FRYST arbete — tidsposter med `invoiceId`. Utan länkarna var kolumnen 0 kr
+ * för alla trots 24 780 kr fakturerat i fordringsbryggan, och byråöversikten
+ * (#1016) gick inte att demo:a: fakturorna var föräldralösa.
+ *
+ * Länkar upp till 3 debiterbara, ännu olänkade poster per UTSTÄLLD faktura
+ * (ej DRAFT), daterade före fakturadatumet, på fakturans ärende. Posterna
+ * roterar författare, så attributionen sprids över flera jurister. De
+ * dedikerade tidsloggarna (m-010 #862, m-020 #878) lämnas orörda — deras
+ * berättelser äger sina fakturaflöden — och merparten av posterna förblir
+ * olänkade så "Upparbetat ofakturerat" lever (#882).
+ */
+/** Olänkad, debiterbar post på ärendet, daterad före fakturadatumet? */
+function isFreezable(te: SeedDataset["timeEntries"][number], inv: SeedDataset["invoices"][number]): boolean {
+  return te.matterId === inv.matterId
+    && te.invoiceId === null
+    && te.billable === true
+    && (te.date as Date).getTime() < (inv.invoiceDate as Date).getTime();
+}
+
+function linkFrozenWork(timeEntries: SeedDataset["timeEntries"], invoices: SeedDataset["invoices"]): void {
+  const DEDICATED = new Set(["m-010-vardnad-2", "m-020-rattshjalp-varierande"]);
+  for (const inv of invoices) {
+    if (inv.status === "DRAFT" || DEDICATED.has(inv.matterId as string)) continue;
+    for (const te of timeEntries.filter((t) => isFreezable(t, inv)).slice(0, 3)) {
+      te.invoiceId = inv.id;
+    }
+  }
 }
 
 interface PlanBundle {


### PR DESCRIPTION
## Vad & varför

Två delar som tillsammans gör AI-demon körbar utan setup — starta en Claude Code-session på repot och fråga *"hur går det för byrån?"*.

### #1018 — fryst arbete i seeden

Attributionen i "Fakturerat per jurist" (#90) fördelar fakturabelopp mot juristens andel av **fryst arbete** — tidsposter med `invoiceId`. `buildSeed()` hade inga: 91 poster, 0 med `invoiceId`, 0 billing-runs. Fakturorna var föräldralösa, och byråöversikten (#1016) visade **Fakturerat = 0 kr för alla** trots 24 780 kr i fordringsbryggan.

`linkFrozenWork()` knyter upp till 3 debiterbara poster per utställd faktura (ej DRAFT), daterade före fakturadatumet, på fakturans ärende. Före/efter mot samma sandlåda:

| Jurist | Fakturerat före | efter |
|---|---:|---:|
| Anna Advokat | 0 kr | 3 541 kr |
| Björn Bauer | 0 kr | 4 610 kr |
| Cecilia Carlsson | 0 kr | 4 614 kr |
| David Dahl | 0 kr | 2 803 kr |
| Eva Eklund | 0 kr | 2 442 kr |

Medvetet bevarat: de dedikerade tidsloggarna (m-010 #862, m-020 #878) rörs inte — deras berättelser äger sina fakturaflöden — och 110 773 kr förblir ofakturerat så "Upparbetat ofakturerat" lever (#882-lärdomen). **Vakt**: MCP-integrationstestet fäller nu om färre än två jurister har attribuerat fakturerat — länkarna kan inte tappas tyst igen.

### #1019 — MCP-konfiguration i repot

`.mcp.json` registrerar ava-servern (stdio, bun) och `.claude/settings.json` godkänner den via `enabledMcpjsonServers`. Varje Claude Code-session på repot — terminal, claude.ai/code, eller startad från mobilappen — får därmed verktygen utan manuellt `claude mcp add`. Local mode är medvetet default: seedad sandlåda, inga hemligheter, ofarlig demo-data. README fick demo-receptet.

**Kvarvarande verifiering:** att verktygen dyker upp i en molnsession går inte att bevisa inifrån den session som skapar konfigurationen (MCP-listan låses vid sessionsstart) — den verifieras av första nya sessionen på repot efter merge. Säg till om den inte gör det, så återöppnar vi #1019.

Stänger #1018
Stänger #1019

## Typ

- [x] `feat` — ny funktion
- [ ] `fix` — buggfix
- [ ] `refactor` / `perf`
- [ ] `docs` / `test` / `chore` / `ci`

## Verifierat lokalt (speglar CI)

- [x] `typecheck` + `lint` + `knip` + `deps:check` + `duplicates` — rena
- [x] `bun run build:demo` — byggd (789 entiteter, oförändrat antal — länkningen sätter fält, skapar inget); `bun run e2e:demo` — **33 passed**; `size` 34,6 %
- [x] Alla `buildSeed`-konsumenter körda var för sig (#92): seed-smoke 19, seed-hydration 2, seed-invoice-coherence 4, build-demo-repo 8, static-params 12, simulate-orchestrate 9, demo-generator-invoice-docs 4, demo-deployed-path-repro 1, KR-docs 3, **mcp-server (integration) 25** — alla gröna
- [x] Nya rader har täckande tester (länknings-vakten i integrationstestet)
- [x] Commits följer Conventional Commits (commitlint)

## Kvalitetsgrindar

- [x] Inga gater lösgjorda; `linkFrozenWork` hölls under komplexitetstaket genom utbruten `isFreezable`
- [x] Inga arkitektur-kritiska paths rörda (`.claude/settings.json` är ny, `.mcp.json` pekar på befintlig bin utan hemligheter)

## Övrigt

Demo-recept efter merge: **telefonen** — öppna Claude-appen → Claude Code → ny session på `ulrik-s/ava` → fråga. **Datorn** — `git clone && bun install && claude`. Mot riktig data: `AVA_SERVER_URL` + `AVA_TOKEN` mot server-first (auth/scoping-täckning på den vägen är fortfarande öppen, se ADR 0035).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_