### PR TITLE
fix(seed): koherent tidslinje i sandlådan — betalningar, paidAt, KR-körningar, utskick

### DIFF
--- a/test/unit/lib/seed-timeline-coherence.test.ts
+++ b/test/unit/lib/seed-timeline-coherence.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Seedens TIDSLINJE (#1021).
+ *
+ * `seed-invoice-coherence.test.ts` vaktar att beloppen går ihop — att en PAID
+ * faktura är täckt av betalningar. Det här testet vaktar den andra halvan:
+ * att händelserna kan ha inträffat i den ordning datan påstår.
+ *
+ * Bakgrunden är en granskning via MCP där varje fynd blev tvetydigt: en
+ * betalning daterad tre månader före sin faktura, en fullbetald faktura utan
+ * realiseringsdatum, och tomma `invoiceDispatch`/`billingRun` som inte gick
+ * att skilja från verkliga luckor i byråns arbete. `buildSeed()` byggde
+ * fakturor, planer och betalningar från var sin datumserie som aldrig möttes.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { buildSeed } from "@/../tooling/scripts/seed-data";
+
+const seed = buildSeed();
+const asDate = (v: unknown): Date => (v instanceof Date ? v : new Date(String(v)));
+const invoiceById = new Map(seed.invoices.map((i) => [String(i.id), i]));
+const label = (row: Record<string, unknown>): string => `${String(row.id)} (${String(row.invoiceId ?? "")})`;
+
+describe("betalningarnas tidslinje", () => {
+  it("ingen betalning är daterad före sin fakturas utställning", () => {
+    // Rotfyndet: pay-012 låg 2026-03-01 på en faktura utställd 2026-06-21.
+    const tooEarly = seed.payments.filter((p) => {
+      const inv = invoiceById.get(String(p.invoiceId));
+      return inv !== undefined && asDate(p.paidAt).getTime() < asDate(inv.issuedAt).getTime();
+    });
+    expect(tooEarly.map(label), "betalning före sin faktura").toEqual([]);
+  });
+
+  it("ingen betalning ligger i framtiden", () => {
+    const now = Date.now();
+    const future = seed.payments.filter((p) => asDate(p.paidAt).getTime() > now);
+    expect(future.map(label)).toEqual([]);
+  });
+
+  it("varje avbetalningsplan startar efter sin fakturas utställning", () => {
+    for (const plan of seed.paymentPlans) {
+      const inv = invoiceById.get(String(plan.invoiceId));
+      if (!inv) continue;
+      expect(
+        asDate(plan.startDate).getTime(),
+        `plan ${String(plan.id)} startar före faktura ${String(plan.invoiceId)}`,
+      ).toBeGreaterThanOrEqual(asDate(inv.issuedAt).getTime());
+    }
+  });
+
+  it("månadsbetalningarna är numrerade i kronologisk ordning", () => {
+    // Numreringen gick förut baklänges: "Månadsbetalning 6" låg först.
+    for (const plan of seed.paymentPlans) {
+      const rows = seed.payments
+        .filter((p) => p.invoiceId === plan.invoiceId && String(p.note).startsWith("Månadsbetalning"))
+        .sort((a, b) => asDate(a.paidAt).getTime() - asDate(b.paidAt).getTime())
+        .map((p) => Number(/Månadsbetalning (\d+)/.exec(String(p.note))?.[1] ?? 0));
+      expect(rows, `plan ${String(plan.id)}`).toEqual([...rows].sort((a, b) => a - b));
+    }
+  });
+});
+
+describe("fullbetalda fakturor bär sitt realiseringsdatum", () => {
+  const paid = seed.invoices.filter((i) => i.status === "PAID");
+
+  it("seeden har fullbetalda fakturor att vakta", () => {
+    expect(paid.length).toBeGreaterThan(0);
+  });
+
+  it("varje PAID-faktura har paidAt satt", () => {
+    // Utan datum faller fakturan ur åldersanalysen (ADR 0007).
+    expect(paid.filter((i) => !i.paidAt).map((i) => String(i.id))).toEqual([]);
+  });
+
+  it("paidAt ligger på eller efter utställningen, aldrig i framtiden", () => {
+    const now = Date.now();
+    for (const inv of paid) {
+      const at = asDate(inv.paidAt).getTime();
+      expect(at, `${String(inv.id)} betald före utställning`).toBeGreaterThanOrEqual(asDate(inv.issuedAt).getTime());
+      expect(at, `${String(inv.id)} betald i framtiden`).toBeLessThanOrEqual(now);
+    }
+  });
+
+  it("paidAt sammanfaller med en faktisk betalning på fakturan", () => {
+    for (const inv of paid) {
+      const dates = seed.payments
+        .filter((p) => p.invoiceId === inv.id)
+        .map((p) => asDate(p.paidAt).getTime());
+      expect(dates, `${String(inv.id)} saknar betalning på sitt paidAt`).toContain(asDate(inv.paidAt).getTime());
+    }
+  });
+});
+
+describe("kostnadsräkningarnas livscykel finns i datan (#828)", () => {
+  it("de offentliga uppdragen har faktureringskörningar", () => {
+    // Var noll före #1021 — KR-panelen var tom i hela sandlådan, trots att
+    // 2026-0019:s beskrivning lovar en överklagad prutning.
+    expect(seed.billingRuns.length).toBeGreaterThanOrEqual(4);
+    for (const run of seed.billingRuns) {
+      expect(run.type).toBe("KOSTNADSRAKNING");
+      expect(run.recipient).toBe("DOMSTOL");
+    }
+  });
+
+  it("flera KR-lägen vilar samtidigt", () => {
+    const states = new Set(seed.billingRuns.map((r) => String(r.kostnadsrakningStatus)));
+    expect(states.has("INSKICKAD")).toBe(true);
+    expect(states.has("OVERKLAGAD")).toBe(true);
+  });
+
+  it("2026-0019 bär den överklagade 25-procentiga nedsättningen", () => {
+    const run = seed.billingRuns.find((r) => r.matterId === "m-019-brottmal-overklagad");
+    expect(run, "ärendets beskrivning lovar en överklagad prutning").toBeDefined();
+    expect(run?.kostnadsrakningStatus).toBe("OVERKLAGAD");
+    // Prutningen är negativ per schemat, och dömt = yrkat − prutning.
+    expect(Number(run?.prutningOre)).toBe(-Math.round(Number(run?.workValueOreAtRun) * 0.25));
+    expect(Number(run?.awardedOre)).toBe(Number(run?.workValueOreAtRun) + Number(run?.prutningOre));
+    // Hovrätten har inte sagt sitt — annars vore överklagandet avgjort.
+    expect(run?.beslutSlutgiltigt).toBe(false);
+  });
+
+  it("en inskickad KR har varken beslut eller prutning", () => {
+    for (const run of seed.billingRuns.filter((r) => r.kostnadsrakningStatus === "INSKICKAD")) {
+      expect(run.awardedOre, `${String(run.id)}`).toBeNull();
+      expect(run.prutningOre, `${String(run.id)}`).toBeNull();
+    }
+  });
+});
+
+describe("utskickshistoriken skiljer skickad från oskickad", () => {
+  const issued = seed.invoices.filter((i) => ["SENT", "PAID", "INSTALLMENT_PLAN"].includes(String(i.status)));
+
+  it("varje utställd faktura har ett utskick", () => {
+    // Poängen: en tom dispatch-lista ska betyda "aldrig skickad", inte
+    // "seeden saknar utskick". Före #1021 var den tom även för BETALDA.
+    const dispatched = new Set(seed.invoiceDispatches.map((d) => String(d.invoiceId)));
+    const missing = issued.filter((i) => !dispatched.has(String(i.id))).map((i) => String(i.id));
+    expect(missing).toEqual([]);
+  });
+
+  it("utkast skickas aldrig", () => {
+    const drafts = new Set(seed.invoices.filter((i) => i.status === "DRAFT").map((i) => String(i.id)));
+    const wrong = seed.invoiceDispatches.filter((d) => drafts.has(String(d.invoiceId)));
+    expect(wrong.map((d) => String(d.id))).toEqual([]);
+  });
+
+  it("utskicket ligger efter fakturans utställning", () => {
+    for (const d of seed.invoiceDispatches) {
+      const inv = invoiceById.get(String(d.invoiceId));
+      if (!inv) continue;
+      expect(asDate(d.queuedAt).getTime(), `${String(d.id)}`).toBeGreaterThanOrEqual(asDate(inv.issuedAt).getTime());
+    }
+  });
+});

--- a/tooling/ava-cli/caller.ts
+++ b/tooling/ava-cli/caller.ts
@@ -69,6 +69,10 @@ function seededSource(): DemoSource {
     paymentPlans: seed.paymentPlans,
     paymentPlanReminders: seed.paymentPlanReminders,
     payments: seed.payments,
+    // Utan de här två är kostnadsräkningarnas livscykel och utskickshistoriken
+    // osynliga för CLI:t och MCP-ytan, hur väl seeden än fyller dem (#1021).
+    billingRuns: seed.billingRuns,
+    invoiceDispatches: seed.invoiceDispatches,
   } as DemoSource);
 }
 

--- a/tooling/scripts/seed-data.ts
+++ b/tooling/scripts/seed-data.ts
@@ -199,6 +199,10 @@ export interface SeedDataset {
   paymentPlans: Record<string, unknown>[];
   paymentPlanReminders: Record<string, unknown>[];
   serviceNotes: Record<string, unknown>[];
+  /** Faktureringskörningar — kostnadsräkningarnas livscykel (#828, #1021). */
+  billingRuns: Record<string, unknown>[];
+  /** Utskickshistorik per utställd faktura (#1021). */
+  invoiceDispatches: Record<string, unknown>[];
 }
 
 /** Nullbara matter-fält som defaultar till null i seed-raden. */
@@ -284,6 +288,8 @@ export function buildSeed(opts: BuildSeedOpts = {}): SeedDataset {
     paymentPlans: [],
     paymentPlanReminders: [],
     serviceNotes: [],
+    billingRuns: [],
+    invoiceDispatches: [],
   };
 
   out.matterContacts = buildMatterContacts(orgId);
@@ -304,6 +310,12 @@ export function buildSeed(opts: BuildSeedOpts = {}): SeedDataset {
   // Efter plan-bygget: statusarna är slutgiltiga, så fryst-länkningen ser
   // fakturornas verkliga tillstånd.
   linkFrozenWork(out.timeEntries, out.invoices);
+
+  // Tidslinjen knyts ihop sist (#1021): `paidAt` härleds ur den betalning som
+  // fullbordar täckningen, och utskicken dateras ur fakturornas utställning.
+  stampPaidAt(out.invoices, out.payments);
+  out.billingRuns = buildBillingRuns(orgId);
+  out.invoiceDispatches = buildInvoiceDispatches(out.invoices, currentUserId);
 
   out.calendarEvents = buildCalendarEvents(orgId, ASSIGN_USERS);
   out.tasks = buildTasks(orgId, ASSIGN_USERS);
@@ -679,6 +691,70 @@ function planReminders(p: PlanTarget, planId: string): SeedDataset["paymentPlanR
   return out;
 }
 
+/**
+ * Avbetalningens k:te datum: `months` månader efter planstarten, snappat till
+ * planens `dayOfMonth` och klämt inom [planstart, igår] (#1021) — en betalning
+ * får varken ligga före sin plan eller i framtiden.
+ */
+function installmentDate(planStart: Date, months: number, dayOfMonth: number): Date {
+  const d = new Date(planStart);
+  d.setMonth(d.getMonth() + months);
+  d.setDate(dayOfMonth);
+  d.setHours(9, 0, 0, 0);
+  const latest = isoDate(-1);
+  if (d.getTime() < planStart.getTime()) return new Date(planStart);
+  return d.getTime() > latest.getTime() ? latest : d;
+}
+
+/**
+ * Backa fakturans datum så den föregår sin avbetalningsplan (#1021).
+ *
+ * Fakturorna dateras på index och planerna på `startsDaysAgo` — två serier som
+ * aldrig möttes, så en plan kunde skapas tio månader innan sin faktura fanns.
+ * Fakturan ställs nu ut en vecka före planstarten (planen förhandlas efter att
+ * kravet gått ut) med 30 dagars förfallotid.
+ */
+function backdateInvoiceBeforePlan(inv: Record<string, unknown>, planStart: Date): void {
+  const issued = new Date(planStart);
+  issued.setDate(issued.getDate() - 7);
+  const due = new Date(issued);
+  due.setDate(due.getDate() + 30);
+  inv.issuedAt = issued;
+  inv.invoiceDate = issued;
+  inv.dueAt = due;
+  inv.dueDate = due;
+  inv.createdAt = issued;
+  inv.updatedAt = issued;
+}
+
+/** Datumfält → Date (seed-rader bär Date, projektionen ISO-strängar). */
+function asDate(v: unknown): Date {
+  return v instanceof Date ? v : new Date(String(v));
+}
+
+/**
+ * Sätt `paidAt` på varje PAID-faktura ur den betalning som fullbordar
+ * täckningen (#1021). Statusen sattes förut utan datum, så en fullbetald
+ * faktura saknade realiseringstidpunkt och föll ur åldersanalysen (ADR 0007).
+ */
+function stampPaidAt(invoices: SeedDataset["invoices"], payments: SeedDataset["payments"]): void {
+  for (const inv of invoices) {
+    if (inv.status !== "PAID") continue;
+    const total = Number(inv.amountInclVat ?? inv.amount ?? 0);
+    const rows = payments
+      .filter((p) => p.invoiceId === inv.id)
+      .sort((a, b) => asDate(a.paidAt).getTime() - asDate(b.paidAt).getTime());
+    let covered = 0;
+    for (const r of rows) {
+      covered += Number(r.amount ?? 0);
+      if (covered >= total) {
+        inv.paidAt = r.paidAt;
+        break;
+      }
+    }
+  }
+}
+
 /** Invoice-status som matchar planens livscykel. */
 function invoiceStatusForPlan(planStatus: PlanTarget["status"]): InvoiceStatus {
   if (planStatus === "ACTIVE") return "INSTALLMENT_PLAN";
@@ -721,19 +797,23 @@ function buildPaymentPlans({ currentUserId, invoices }: {
     const p = PLAN_TARGETS[i];
     if (!p) continue;
     const planId = `pp-${String(i + 1).padStart(3, "0")}`;
+    const planStart = isoDate(-p.startsDaysAgo);
     paymentPlans.push({
       id: planId, invoiceId: p.invoiceId, monthlyAmount: p.monthlyAmount,
-      dayOfMonth: p.dayOfMonth, startDate: isoDate(-p.startsDaysAgo), status: p.status,
+      dayOfMonth: p.dayOfMonth, startDate: planStart, status: p.status,
       notes: p.status === "CANCELLED" ? "Avbruten på klientens begäran" : null,
       createdAt: isoDate(-p.startsDaysAgo - 1), updatedAt: isoDate(-1),
     });
     paymentPlanReminders.push(...planReminders(p, planId));
 
-    // Patcha invoice-statusen så den matchar planen.
+    // Patcha invoice-statusen OCH datumen så den matchar planen (#1021).
     const inv = invoices.find((x) => (x as { id: string }).id === p.invoiceId) as Record<string, unknown> | undefined;
-    if (inv) inv.status = invoiceStatusForPlan(p.status);
+    if (inv) {
+      inv.status = invoiceStatusForPlan(p.status);
+      backdateInvoiceBeforePlan(inv, planStart);
+    }
 
-    const rows = planPaymentRows(p, inv, paymentSeq, currentUserId);
+    const rows = planPaymentRows(p, inv, planStart, paymentSeq, currentUserId);
     payments.push(...rows);
     paymentSeq += rows.length;
   }
@@ -745,33 +825,139 @@ function buildPaymentPlans({ currentUserId, invoices }: {
 /** Payment-rader för en plan: en per "inkommen" månad + (för COMPLETED) en
  *  slutbetalning som täcker resten av fakturan (#350: PAID ⇒ ledger-koherent). */
 function planPaymentRows(
-  p: PlanTarget, inv: Record<string, unknown> | undefined, startSeq: number, currentUserId: string,
+  p: PlanTarget, inv: Record<string, unknown> | undefined, planStart: Date, startSeq: number, currentUserId: string,
 ): SeedDataset["payments"] {
   const rows: SeedDataset["payments"] = [];
   let seq = startSeq;
-  for (let m = p.paymentsMade; m >= 1; m--) {
-    const due = new Date();
-    due.setMonth(due.getMonth() - m + 1);
-    due.setDate(p.dayOfMonth);
+  // Betalning k ligger k−1 månader efter planstarten — kronologiskt, och
+  // numrerad i samma riktning (#1021: numreringen gick förut baklänges).
+  for (let k = 1; k <= p.paymentsMade; k++) {
+    const paidAt = installmentDate(planStart, k - 1, p.dayOfMonth);
     seq++;
     rows.push({
       id: `pay-${String(seq).padStart(3, "0")}`,
-      invoiceId: p.invoiceId, amount: p.monthlyAmount, paidAt: due,
-      note: `Månadsbetalning ${m} av planen`, recordedById: currentUserId, createdAt: due,
+      invoiceId: p.invoiceId, amount: p.monthlyAmount, paidAt,
+      note: `Månadsbetalning ${k} av planen`, recordedById: currentUserId, createdAt: paidAt,
     });
   }
   const remainder = inv ? Number(inv.amountInclVat ?? inv.amount ?? 0) - p.paymentsMade * p.monthlyAmount : 0;
   if (p.status === "COMPLETED" && remainder > 0) {
-    const due = new Date();
-    due.setDate(p.dayOfMonth);
+    const paidAt = installmentDate(planStart, p.paymentsMade, p.dayOfMonth);
     seq++;
     rows.push({
       id: `pay-${String(seq).padStart(3, "0")}`,
-      invoiceId: p.invoiceId, amount: remainder, paidAt: due,
-      note: "Slutbetalning (planen fullföljd)", recordedById: currentUserId, createdAt: due,
+      invoiceId: p.invoiceId, amount: remainder, paidAt,
+      note: "Slutbetalning (planen fullföljd)", recordedById: currentUserId, createdAt: paidAt,
     });
   }
   return rows;
+}
+
+/**
+ * Kostnadsräkningarnas livscykel för de offentliga uppdragen (#828, #1021).
+ *
+ * Sandlådan hade NOLL faktureringskörningar, så KR-panelen var tom och
+ * 2026-0019:s beskrivning — "tingsrätten satte ned arvodet 25 %, nedsättningen
+ * är överklagad" — hade ingen data bakom sig. Nu vilar de fyra brottmålen på
+ * var sin punkt i kedjan, precis som demo-generatorns rikare data gör (#828
+ * steg 6): inskickad, beslutad, överklagad.
+ *
+ * Beloppen speglar ärendets upparbetade arbete; prutningen är negativ per
+ * schemat och `awardedOre` är det domstolen faktiskt dömde ut.
+ */
+interface BillingRunSeed {
+  id: string;
+  matterId: string;
+  reference: string;
+  workValueOre: number;
+  kostnadsrakningStatus: "INSKICKAD" | "BESLUTAD" | "OVERKLAGAD";
+  daysAgo: number;
+  /** Domstolens nedsättning i bips — 0 = ingen prutning. */
+  prutningBips?: number;
+}
+
+const BILLING_RUN_SEEDS: readonly BillingRunSeed[] = [
+  // Väntar på tingsrättens beslut.
+  { id: "br-016", matterId: "m-016-brottmal-rh", reference: "KR-2026-0016", workValueOre: 731_700, kostnadsrakningStatus: "INSKICKAD", daysAgo: 9 },
+  { id: "br-017", matterId: "m-017-brottmal-omf", reference: "KR-2026-0017", workValueOre: 731_700, kostnadsrakningStatus: "INSKICKAD", daysAgo: 21 },
+  // Beslutad med en mindre nedsättning som byrån accepterat.
+  { id: "br-018", matterId: "m-018-brottmal-ekobrott", reference: "KR-2026-0018", workValueOre: 934_950, kostnadsrakningStatus: "BESLUTAD", daysAgo: 14, prutningBips: 1000 },
+  // Ärendets egen berättelse: 25 % nedsättning, överklagad till hovrätten.
+  { id: "br-019", matterId: "m-019-brottmal-overklagad", reference: "KR-2026-0019", workValueOre: 731_700, kostnadsrakningStatus: "OVERKLAGAD", daysAgo: 45, prutningBips: 2500 },
+];
+
+function buildBillingRuns(orgId: string): SeedDataset["billingRuns"] {
+  return BILLING_RUN_SEEDS.map((r) => {
+    const prutning = Math.round((r.workValueOre * (r.prutningBips ?? 0)) / 10_000);
+    const decided = r.kostnadsrakningStatus !== "INSKICKAD";
+    return {
+      id: r.id,
+      organizationId: orgId,
+      matterId: r.matterId,
+      type: "KOSTNADSRAKNING",
+      recipient: "DOMSTOL",
+      // Ingen faktura förrän kostnadsräkningen är FAKTURERAD — alla fyra
+      // vilar före den punkten, så körningen väntar fortfarande på dom.
+      status: "PENDING_VERDICT",
+      workValueOreAtRun: r.workValueOre,
+      clientShareBips: null,
+      proposedAmountOre: r.workValueOre,
+      amountOre: r.workValueOre,
+      prutningOre: decided && prutning > 0 ? -prutning : null,
+      kostnadsrakningStatus: r.kostnadsrakningStatus,
+      reference: r.reference,
+      awardedOre: decided ? r.workValueOre - prutning : null,
+      // Hovrätten har inte sagt sitt än — överklagandet är öppet.
+      beslutSlutgiltigt: false,
+      invoiceId: null,
+      deductedBillingRunIds: [],
+      periodFrom: null,
+      periodTo: isoDate(-r.daysAgo),
+      notes: null,
+      createdAt: isoDate(-r.daysAgo),
+      updatedAt: isoDate(-Math.max(1, r.daysAgo - 5)),
+    };
+  });
+}
+
+/** Fakturastatusar som betyder att fakturan har gått ut till mottagaren. */
+const ISSUED_INVOICE_STATUSES = new Set(["SENT", "PAID", "INSTALLMENT_PLAN"]);
+
+/**
+ * Utskickshistorik per utställd faktura (#1021).
+ *
+ * Utan den går "aldrig skickad" inte att skilja från "skickad men obetald" —
+ * exakt den fråga man ställer om en förfallen faktura. Utskicket dateras ur
+ * fakturans egen utställning, så tidslinjen håller.
+ */
+function buildInvoiceDispatches(invoices: SeedDataset["invoices"], currentUserId: string): SeedDataset["invoiceDispatches"] {
+  const out: SeedDataset["invoiceDispatches"] = [];
+  let seq = 0;
+  for (const inv of invoices) {
+    if (!ISSUED_INVOICE_STATUSES.has(String(inv.status))) continue;
+    const issued = asDate(inv.issuedAt);
+    const sentAt = new Date(issued.getTime() + 3600_000);
+    // Betald faktura bevisar att den kom fram; övriga stannar på "sent" —
+    // AVA kan inte veta mer än att den lämnade huset.
+    const delivered = inv.status === "PAID";
+    seq++;
+    out.push({
+      id: `disp-${String(seq).padStart(3, "0")}`,
+      invoiceId: inv.id,
+      channel: "email",
+      recipient: `faktura+${String(inv.id)}@example.se`,
+      status: delivered ? "delivered" : "sent",
+      queuedAt: issued,
+      sentAt,
+      deliveredAt: delivered ? new Date(sentAt.getTime() + 7200_000) : null,
+      failedAt: null,
+      messageId: `<${String(inv.id)}@firma.local>`,
+      error: null,
+      recordedById: currentUserId,
+      createdAt: issued,
+    });
+  }
+  return out;
 }
 
 function buildCalendarEvents(orgId: string, ASSIGN_USERS: string[]): SeedDataset["calendarEvents"] {


### PR DESCRIPTION
## Vad & varför

En granskning av byråns öppna ärenden via MCP gjorde varje fynd tvetydigt: *är det här byråns problem eller datans?* `buildSeed()` byggde fakturor, planer, betalningar och körningar från var sin datumserie som aldrig möttes.

### 1. Betalningar daterade före fakturan existerade

Plan `pp-006` skapades 2025-08-13 och första betalningen låg 2026-03-01 — på en faktura utställd **2026-06-21**. Beloppen balanserade, tidslinjen var omöjlig.

Planens datum ankras nu i fakturan: `backdateInvoiceBeforePlan` ställer ut fakturan en vecka före planstarten (planen förhandlas efter att kravet gått ut), och `installmentDate` lägger betalning *k* exakt *k−1* månader efter planstarten, klämd inom [planstart, igår]. Numreringen följer kronologin — den gick förut **baklänges**, "Månadsbetalning 6" först.

Efter fixen, `inv-008`: utställd 2025-08-07 → betalningar 1–6 från 2025-08-14 till 2026-01-01 → slutbetalning 2026-02-01.

### 2. PAID utan realiseringsdatum

`invoiceStatusForPlan` satte PAID utan `paidAt`, så en fullbetald faktura föll ur åldersanalysen (ADR 0007). `stampPaidAt` härleder datumet ur den betalning som fullbordar täckningen.

### 3. Noll kostnadsräkningar i hela byrån

KR-panelen (#828) var tom i sandlådan, och 2026-0019:s beskrivning — *"tingsrätten satte ned arvodet 25 %, nedsättningen är överklagad till hovrätten"* — hade **ingen data bakom sig**. Nu vilar fyra brottmål på var sin punkt i kedjan:

```
KR-2026-0016  INSKICKAD   prutning: null      dömt: null
KR-2026-0017  INSKICKAD   prutning: null      dömt: null
KR-2026-0018  BESLUTAD    prutning: −93 495   dömt: 841 455
KR-2026-0019  OVERKLAGAD  prutning: −182 925  dömt: 548 775
```

### 4. Ingen utskickshistorik

`invoiceDispatch` var tom **även för betalda fakturor**, så "aldrig skickad" gick inte att skilja från "skickad men obetald" — exakt den fråga man ställer om en förfallen faktura. Under granskningen kostade det tre extra verktygsanrop att bevisa att tomheten var ett seed-hål. Utställda fakturor får nu ett utskick daterat ur sin egen utställning; utkast får inget.

**Båda nya samlingarna wire:as in i `caller.ts`** — utan det förblir de osynliga för CLI:t och MCP-ytan hur väl seeden än fyller dem. (Samma fälla som #1018.)

Stänger #1021

## Typ

- [ ] `feat` — ny funktion
- [x] `fix` — buggfix
- [ ] `refactor` / `perf`
- [ ] `docs` / `test` / `chore` / `ci`

## Verifierat lokalt (speglar CI)

- [x] `typecheck` + `lint` + `knip` + `deps:check` + `duplicates` — rena
- [x] `bun run build:demo` (789 entiteter, oförändrat) · `bun run e2e:demo` **33 passed** · `size` 34,6 %
- [x] Testfiler körda var för sig (#92): **seed-timeline-coherence 15** (ny), seed-invoice-coherence 4, seed-smoke 19, seed-hydration 2, build-demo-repo 8, static-params 12, mcp-server 25, tool-descriptions 14, simulate-orchestrate 9, invoice-docs 4, KR-docs 3, deployed-path 1, reports-firm-overview 4, invoice 45, paymentPlan 16, billingRun 65 — alla gröna
- [x] Nya rader har täckande tester
- [x] Commits följer Conventional Commits (commitlint)

**Känsligheten är bevisad:** tar man bort de två fixarna (`backdateInvoiceBeforePlan` och `paidAt`-stämplingen) faller **5 av 15** tester i den nya vakten — exakt de som beskriver de ursprungliga defekterna.

## Kvalitetsgrindar

- [x] Inga gater lösgjorda, inga suppressions
- [x] `src/lib/shared/schemas/` orörd — ändringen ligger i `tooling/scripts/seed-data.ts` plus två fält i `caller.ts`s DemoSource-mappning

## Övrigt

`seed-timeline-coherence.test.ts` vaktar tidslinjen på samma sätt som `seed-invoice-coherence.test.ts` (#350) vaktar beloppen — de två testerna täcker nu båda halvorna av "kan den här datan ha inträffat".

Kvarstående från granskningen, men **verkliga affärshändelser och inte datafel**: 2026-0012 Skadestånd Trygg-Hansa (3 330 kr förfallen sedan 23 juni, avbetalningsplan avbruten utan en enda betalning) och 2026-0006 Entreprenadtvist (1 950 kr, 10 dagar). De hör hemma i byråns kravrutin, inte i en PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_