### PR TITLE
fix(billing): offentligt uppdrag värderas på Domstolsverkets kategorinormer i kostnadsräkningen

### DIFF
--- a/src/lib/server/routers/billingRun.ts
+++ b/src/lib/server/routers/billingRun.ts
@@ -270,21 +270,22 @@ function invoiceGrossOre(work: UnfrozenWork): number {
 }
 
 /**
- * Slutregleringens arvode-netto (#891). RÄTTSHJÄLP: räkna om HELA ärendet på
+ * Slutregleringens arvode-netto (#891). Domstolsersatta metoder (rättshjälp,
+ * rättsskydd, offentligt uppdrag — #1003): räkna om HELA ärendet på
  * SLUTREGLERINGSÅRETS normer — den retroaktiva höjningen över ett årsskifte (arbete
  * 2025 värderas på 2026 års norm). Arbete värderas på timkostnadsnormen (minus
- * rådgivningstimmen), tidsspillan på tidsspillan-normen. Övriga metoder: platt
- * `flatRateOre` × alla debiterbara minuter (oförändrat).
+ * rådgivningstimmen vid rättshjälp), tidsspillan på tidsspillan-normen, obekväm
+ * tid och beredskap på sina DVFS-belopp. PRIVAT/MIX: posternas egna á-priser.
  */
 function settlementArvodeNet(method: PaymentMethod, work: UnfrozenWork, settleDate: Date | string): number {
   const billable = work.timeEntries.filter((t) => t.billable);
   // Varje post värderas på SIN KATEGORIS norm för slutregleringsåret (#949/#950).
   // Tidigare plattade icke-rättshjälp ut allt till ansvarig jurists timtaxa, vilket
   // gjorde att sammanställningens taxerader inte summerade till fakturabeloppet.
-  // Alla ärenden använder Domstolsverkets nivåer, så logiken är gemensam.
-  // PRIVAT/offentligt debiterar byråns egen taxa (ligger på posten) — bara
-  // täckningsärenden ersätts enligt Domstolsverkets nivåer (#950).
-  if (method !== "RATTSHJALP" && method !== "RATTSSKYDD") return arvodeNetOre(work);
+  // Domstolsverkets nivåer gäller allt domstolen/staten ersätter: täckningsärenden
+  // (#950) OCH offentliga uppdrag (#1003) — domstolen betalar normen, inte vad
+  // byrån råkar ta. Bara PRIVAT/MIX debiterar byråns egen taxa (ligger på posten).
+  if (method === "PRIVAT" || method === "MIX") return arvodeNetOre(work);
   // DVFS 2025:9 § 2 (#950): beredskapsdagar som "förbrukats" av en helgförhandling
   // eller ett polisförhör samma dag ersätts inte — arbetet betalas i stället.
   const payable = payableCoverageEntries(billable);
@@ -1278,12 +1279,16 @@ export const billingRunRouter = router({
         const work = await fetchUnfrozenWork(tx, input.matterId);
         const matter = await tx.matters.getByIdInOrg(input.matterId, ctx.orgId);
         if (!matter) throw new TRPCError({ code: "NOT_FOUND", message: "Ärendet finns inte." });
-        // Rättshjälp värderas på timkostnadsnormen (#839) — staten ersätter inte
-        // byråns privata timtaxa. Övriga (offentligt uppdrag/taxa): arvode inkl moms
-        // + utlägg som tidigare. Brutto matchar kostnadsräkningens PDF (#782).
-        const krArvodeNet = matter.paymentMethod === "RATTSHJALP"
-          ? settlementArvodeNet("RATTSHJALP", work, new Date()) // #891: retroaktiv norm
-          : arvodeNetOre(work);
+        // Domstolen ersätter enligt Domstolsverkets normer — rättshjälp (#839)
+        // och offentligt uppdrag (#1003) värderas per kategori-norm på yrkande-
+        // dagen (retroaktiv norm, #891), inte på posternas egna á-priser.
+        // TAXA-ÄRENDEN undantas: där styr brottmålstaxan arvodet och posterna är
+        // informativa — en omvärdering per timnorm vore ett yrkande taxan aldrig
+        // ger. Deras körning behåller posternas värde (status quo; jfr #1003).
+        // Brutto matchar kostnadsräkningens PDF (#782).
+        const krArvodeNet = matter.paymentMethod === "OFFENTLIGT_UPPDRAG" && matter.isTaxeArende
+          ? arvodeNetOre(work)
+          : settlementArvodeNet(matter.paymentMethod, work, new Date());
         const grossValue = krGrossOre(work, krArvodeNet);
         const run = await tx.billingRuns.create({
           matterId: input.matterId, type: "KOSTNADSRAKNING", recipient: "DOMSTOL",

--- a/test/unit/server/routers/advokatberedskap-flow.test.ts
+++ b/test/unit/server/routers/advokatberedskap-flow.test.ts
@@ -37,10 +37,10 @@ interface EntrySpec {
   billable?: boolean;
 }
 
-function makeCaller(entries: readonly EntrySpec[], paymentMethod = "OFFENTLIGT_UPPDRAG") {
+function makeCaller(entries: readonly EntrySpec[], paymentMethod = "OFFENTLIGT_UPPDRAG", matterExtra: Record<string, unknown> = {}) {
   const ds = new DemoDataStore({
     organizations: [{ id: "org-1", name: "X" }],
-    matters: [{ id: "m-1", organizationId: "org-1", matterNumber: "2026-0001", title: "Brottmål", status: "ACTIVE", paymentMethod, createdAt: new Date() }],
+    matters: [{ id: "m-1", organizationId: "org-1", matterNumber: "2026-0001", title: "Brottmål", status: "ACTIVE", paymentMethod, createdAt: new Date(), ...matterExtra }],
     users: [{ id: "u-1", organizationId: "org-1", email: "a@x", name: "Anna", role: "ADMIN", hourlyRate: 250_000 }],
     timeEntries: entries.map((e) => ({
       id: e.id, organizationId: "org-1", userId: "u-1", matterId: "m-1",
@@ -69,10 +69,12 @@ describe("advokatberedskap i kostnadsräkningen (offentligt uppdrag)", () => {
   it("beredskapen läggs till arbetet, inte i stället för", async () => {
     const caller = makeCaller([
       beredskap("te-1", LUGN),
-      { id: "te-2", date: LUGN, minutes: 120, hourlyRate: 250_000 }, // 2 h × 2 500 kr
+      // Byråns 2 500 kr/h på posten är irrelevant: domstolen ersätter
+      // timkostnadsnormen (#1003) — 2 h × 1 626 kr.
+      { id: "te-2", date: LUGN, minutes: 120, hourlyRate: 250_000 },
     ]);
     const { run } = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
-    expect(run.workValueOreAtRun).toBe(Math.round((DAG_2026 + 500_000) * 1.25));
+    expect(run.workValueOreAtRun).toBe(Math.round((DAG_2026 + 325_200) * 1.25));
   });
 
   it("§ 2: dag med helgförhandling ger arbetet — inte garantin", async () => {
@@ -93,6 +95,46 @@ describe("advokatberedskap i kostnadsräkningen (offentligt uppdrag)", () => {
     ]);
     const { run } = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
     expect(run.workValueOreAtRun).toBe(Math.round((DAG_2026 + 488_400) * 1.25));
+  });
+});
+
+describe("offentligt uppdrag värderas på Domstolsverkets kategorinormer (#1003)", () => {
+  it("obekväm tid yrkas på DVFS-beloppet, inte på ärendets timtaxa", async () => {
+    // Posten bär medvetet byråns taxa (2 500 kr/h): domstolen ersätter ändå
+    // 3 256 kr/h (DVFS 2025:7 § 1) — 90 min × 3 256 kr = 4 884 kr netto.
+    const caller = makeCaller([
+      { id: "te-1", date: HELG, minutes: 90, kind: "ARBETE_OBEKVAM_TID", hourlyRate: 250_000 },
+    ]);
+    const { run } = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
+    expect(run.workValueOreAtRun).toBe(Math.round(488_400 * 1.25));
+  });
+
+  it("tidsspillan yrkas på sin (lägre) norm — normen vinner åt båda hållen", async () => {
+    // 2 h tidsspillan på byråns taxa vore 5 000 kr; normen är 1 487 kr/h → 2 974 kr.
+    const caller = makeCaller([
+      { id: "te-1", date: LUGN, minutes: 120, kind: "TIDSSPILLAN", hourlyRate: 250_000 },
+    ]);
+    const { run } = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
+    expect(run.workValueOreAtRun).toBe(Math.round(297_400 * 1.25));
+  });
+
+  it("ingen rådgivningstimme carvas ur offentligt uppdrag", async () => {
+    // Carve-outen är rättshjälpens (#868) — 60 min arbete ska yrkas fullt ut.
+    const caller = makeCaller([{ id: "te-1", date: LUGN, minutes: 60, hourlyRate: 250_000 }]);
+    const { run } = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
+    expect(run.workValueOreAtRun).toBe(Math.round(162_600 * 1.25));
+  });
+
+  it("taxa-ärenden omvärderas INTE — taxan styr arvodet, posterna är informativa", async () => {
+    // Att räkna om posterna per timnorm vore ett yrkande brottmålstaxan aldrig
+    // ger. Körningen behåller posternas eget värde (2 h × 2 500 kr), som före #1003.
+    const caller = makeCaller(
+      [{ id: "te-1", date: LUGN, minutes: 120, hourlyRate: 250_000 }],
+      "OFFENTLIGT_UPPDRAG",
+      { isTaxeArende: true, taxaLevel: 1 },
+    );
+    const { run } = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
+    expect(run.workValueOreAtRun).toBe(Math.round(500_000 * 1.25));
   });
 });
 

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -213,7 +213,9 @@ describe("billingRun.createKostnadsrakning", () => {
     expect(res.run.type).toBe("KOSTNADSRAKNING");
     expect(res.run.status).toBe("PENDING_VERDICT");
     expect(res.run.invoiceId).toBeFalsy();
-    expect(res.run.workValueOreAtRun).toBe(937500); // 3h × 2500 kr + 25 % moms (#782)
+    // Offentligt uppdrag värderas på timkostnadsnormen (#1003), inte byråns
+    // 2500 kr/h: 3h × 1626 kr + 25 % moms (#782).
+    expect(res.run.workValueOreAtRun).toBe(609750);
   });
 
   it("tilldelar en KR-referens KR-YYYY-NNNN (#889 — samma format som fakturornas F-nummer)", async () => {
@@ -277,17 +279,17 @@ describe("billingRun.setVerdict", () => {
   });
 
   it("invoice-beloppet är workValue + prutning (prutning negativ)", async () => {
-    const { caller } = makeCaller({ workMinutes: 120, paymentMethod: "OFFENTLIGT_UPPDRAG" }); // 5000 kr
+    const { caller } = makeCaller({ workMinutes: 120, paymentMethod: "OFFENTLIGT_UPPDRAG" }); // 2h på normen (#1003)
     const kr = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
-    await caller.billingRun.recordKostnadsrakningBeslut({ billingRunId: kr.run.id, awardedOre: 525000, prutningOre: -100000 });
+    await caller.billingRun.recordKostnadsrakningBeslut({ billingRunId: kr.run.id, awardedOre: 306500, prutningOre: -100000 });
     const res = await caller.billingRun.setVerdict({ billingRunId: kr.run.id });
-    expect(res.invoice.amount).toBe(525000); // arvode 5000 kr + moms = 625000, − prutning 1000 = 525000 (#782)
+    expect(res.invoice.amount).toBe(306500); // arvode 2×1626 kr + moms = 406500, − prutning 1000 kr (#782)
   });
 
   it("LÄNKAR poster + PRUTNING till fakturan → vyn reconciler mot beloppet (#732)", async () => {
-    const { ds, caller } = makeCaller({ workMinutes: 120, expenseOre: 5000, paymentMethod: "OFFENTLIGT_UPPDRAG" }); // 5000 kr + 50 kr utlägg
+    const { ds, caller } = makeCaller({ workMinutes: 120, expenseOre: 5000, paymentMethod: "OFFENTLIGT_UPPDRAG" }); // 2h på normen + 50 kr utlägg
     const kr = await caller.billingRun.createKostnadsrakning({ matterId: "m-1" });
-    await caller.billingRun.recordKostnadsrakningBeslut({ billingRunId: kr.run.id, awardedOre: 595000, prutningOre: -30000 });
+    await caller.billingRun.recordKostnadsrakningBeslut({ billingRunId: kr.run.id, awardedOre: 382750, prutningOre: -30000 });
     const res = await caller.billingRun.setVerdict({ billingRunId: kr.run.id });
     const te = await ds.timeEntries.findFirst({ where: { id: "te-1" } }) as { invoiceId?: string | null };
     const ex = await ds.expenses.findFirst({ where: { id: "ex-1" } }) as { invoiceId?: string | null };
@@ -295,11 +297,11 @@ describe("billingRun.setVerdict", () => {
     expect(te.invoiceId).toBe(res.invoice.id); // arvode länkad
     expect(ex.invoiceId).toBe(res.invoice.id); // utlägg länkad
     expect(prut.invoiceId).toBe(res.invoice.id); // PRUTNING länkad (reducerar totalen)
-    // Arvode 5000 kr + 25 % moms = 625000, + utlägg 50 kr − prutning 300 kr (#782).
+    // Arvode 2h × 1626 kr (#1003) + 25 % moms = 406500, + utlägg 50 kr − prutning 300 kr (#782).
     // #945: fakturan går till DOMSTOL → utlägget debiteras 25 % moms (6250) fastän
     // posten själv är momsfri. Prutningen är en justering av totalen, inte ett utlägg,
     // och momsas därför inte.
-    expect(res.invoice.amount).toBe(625000 + 6250 - 30000);
+    expect(res.invoice.amount).toBe(406500 + 6250 - 30000);
   });
 
   it("DOMSTOL-faktura får F-nummer men ingen OCR (#889 — samma format som övriga)", async () => {


### PR DESCRIPTION
Closes #1003.

## Symptomet

`createKostnadsrakning` värderade offentliga uppdrags kostnadsräkning med `arvodeNetOre` — posternas **egna** á-priser, dvs. byråns taxa. Men domstolen ersätter enligt Domstolsverkets nivåer: en häktningsförhandling under helg (`ARBETE_OBEKVAM_TID`) ska yrkas på **3 256 kr/h** (DVFS 2025:7 § 1) oavsett vad posten bär, och tidsspillan på sina (lägre) normer — 1 487 resp. 975 kr/h. Detta är #950:s steg 3 för `OFFENTLIGT_UPPDRAG`; #951 gjorde samma sak för rättshjälp/rättsskydd via `settlementArvodeNet`.

## Ändringen

- **`settlementArvodeNet`**: guarden vänd — bara `PRIVAT`/`MIX` behåller posternas egna á-priser; rättshjälp, rättsskydd **och offentligt uppdrag** värderas per kategori-norm på yrkandedagen (retroaktiv norm, #891). Rådgivnings-carven förblir rättshjälpens (`coverageBaseMinutes` är en no-op för övriga) och § 2-beredskapsfiltret är detsamma i båda vägarna.
- **`createKostnadsrakning`**: routar via `settlementArvodeNet(matter.paymentMethod, …)` — utom för **taxa-ärenden**, som uttryckligen undantas.

## Issue-checklistan

- [x] **Taxa-ärenden först** — kontrollerat: `resolveTaxa`-vägen i `kostnadsrakning.ts` är dokumentvägen och oberoende av körningens belopp; ingen stackning kan uppstå. Körningen för ett taxa-ärende behåller posternas värde (status quo) — en omvärdering per timnorm vore ett yrkande brottmålstaxan aldrig ger. Vaktas av nytt test.
- [x] **PRIVAT orörd** — guard i `settlementArvodeNet`; `settleCoverage` avvisar redan icke-täckningsärenden och `coverageSplit` nås bara för rättshjälp (`enabled: isRattshjalp`), så ändringen är observerbar enbart via `createKostnadsrakning`.
- [x] **Timbaserade poster på `coverageEntryRateOre`** — inkl. att normen vinner åt **båda** hållen (obekväm tid upp, tidsspillan ned).
- [x] **Demons brottmåls-KR:er, diff redovisad** (jfr #882) — se nedan.

## Demo-diff (yrkat brutto, öre)

| Ärende | Före | Efter | Varför |
|---|---:|---:|---|
| 2026-0016 (taxa) | 2 093 875 | 2 093 875 | taxa-ärende — undantaget, oförändrat |
| 2026-0017 | 2 093 875 | 2 399 500 | obekväm tid 90 min upp på 3 256 kr/h |
| 2026-0018 | 2 093 875 | 2 399 500 | samma poster som 0017 |
| 2026-0019 | 2 835 250 | 2 984 063 | obekväm tid upp; **båda tidsspillan-nivåerna NED** på sina normer |
| Rättshjälp (0001/0010/0020) | — | — | oförändrade (gick redan på normerna) |

Beslut/prutning i demon följer proportionellt (simuleringen räknar dem ur det yrkade).

## Tester

- 4 nya i `advokatberedskap-flow.test.ts`: obekväm tid på DVFS-beloppet trots fel á-pris på posten; tidsspillan på sin lägre norm; ingen rådgivnings-carve för offentligt; taxa-ärende omvärderas inte.
- Uppdaterade förväntningar i `billingRun.test.ts` (KR-beloppen ligger nu på timkostnadsnormen).
- Grönt lokalt: typecheck, lint, berörda testfiler per fil, `build:demo`, `size` (34,6 % av budget), `e2e:demo` 33/33. Den lokala parallell-passets 360s-timeout i containern reproducerar på **oförändrad main** (miljö, inte diffen) — filerna går gröna individuellt och i små pooler.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_