### PR TITLE
ci(quality): mät AI-ytan — eget coverage-golv + dep-cruiser-scope för tooling/ava-cli

### DIFF
--- a/docs/quality.md
+++ b/docs/quality.md
@@ -74,18 +74,39 @@ funktioner per-fil-max av FNF/FNH) → eliminerar `--parallel`-flaken.
 > isolering men under-rapporterar coverage något (bun aggregerar löst över
 > workers) — deterministiskt, så golvet är giltigt.
 
-Ratchet-golvet lever i [`tooling/scripts/run-tests.ts`](../tooling/scripts/run-tests.ts)
-(`LINE_FLOOR` / `FUNC_FLOOR`) — flyttas BARA uppåt. Aktuell baslinje (ratchet,
-strax under faktisk):
+Ratchet-golven lever i [`tooling/scripts/run-tests.ts`](../tooling/scripts/run-tests.ts)
+(`COVERAGE_SCOPES`) — flyttas BARA uppåt. **Två mätområden med var sitt golv**
+(#1025): appen och AI-ytan skalar för olika för att dela en siffra — `src/` är
+~40 000 rader, `tooling/ava-cli/` ~540, så en gemensam procent skulle låta hela
+AI-ytan tappa sin täckning utan att totalen rörde sig mätbart.
 
-| Mått | Golv (`run-tests.ts`) | Faktisk (lcov, src/, --parallel) |
-|---|---|---|
-| Lines | 90.0 % | ~90.7 % |
-| Functions | 85.9 % | ~87.5 % |
+| Område | Golv rader | Golv funktioner | Faktisk (lcov, --parallel) |
+|---|---|---|---|
+| `src/` | 90.0 % | 85.9 % | ~90.7 % / ~87.5 % |
+| `tooling/ava-cli/` (CLI + MCP) | 93.0 % | 88.0 % | 95.6 % / 93.1 % (enprocess) |
+
+AI-ytans golv är ankrat under uppmätt med avsikt: siffran ovan är mätt
+enprocess, medan grinden kör pass A med `--parallel` (som underrapporterar,
+se OBS 2) — och med bara 58 funktioner är EN funktion 1,7 procentenheter.
+Dras åt mot den faktiska `--parallel`-siffran när den syns i CI-loggen.
 
 Coverage-rapporten skrivs till `coverage/` (lcov). `helper-ui` har en egen
 coverage-ratchet i [`helper-ui/bunfig.toml`](../helper-ui/bunfig.toml)
 (`coverageThreshold`, line 0.90 / function 0.85).
+
+#### Vilken grind ser vilken katalog
+
+Luckan som #1025 stängde var osynlig just för att omfånget inte stod skrivet
+någonstans. Håll tabellen aktuell när en ny katalog tillkommer:
+
+| Katalog | Coverage | `deps:check` | knip |
+|---|---|---|---|
+| `src/` | ✅ eget golv | ✅ | ✅ |
+| `tooling/ava-cli/` | ✅ eget golv | ✅ | ✅ (via `package.json`-scripten `ava` / `ava:mcp`) |
+| `tooling/scripts/` | ❌ | ❌ | ✅ (entry-mönster) |
+| `helper-ui/` | ✅ egen ratchet (`bunfig.toml`) | ✅ | ✅ |
+| `office-addin/` | ❌ | ✅ | ✅ |
+| `test/` | — | ✅ | ✅ |
 
 ### Komplexitet (`bun run lint`)
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:all": "bash tooling/scripts/test-all.sh",
     "duplicates": "jscpd --config tooling/config/jscpd.json src",
     "lint:complexity-strict": "bun tooling/scripts/check-complexity-strict.ts",
-    "deps:check": "depcruise --config tooling/config/dependency-cruiser.cjs --output-type err src test helper-ui office-addin",
+    "deps:check": "depcruise --config tooling/config/dependency-cruiser.cjs --output-type err src test helper-ui office-addin tooling/ava-cli",
     "deps:graph": "depcruise --config tooling/config/dependency-cruiser.cjs --output-type dot src | dot -Tsvg > reports/dependency-graph.svg",
     "deps:archi": "depcruise --config tooling/config/dependency-cruiser.cjs --output-type archi src | dot -Tsvg > reports/architecture.svg",
     "knip": "knip --config tooling/config/knip.json",

--- a/test/scripts/coverage-scopes.test.ts
+++ b/test/scripts/coverage-scopes.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Coverage-ratchet:ens MÄTOMRÅDEN (#1025).
+ *
+ * `run-tests-pass-error.test.ts` vaktar att ett fallerat pass klassas rätt.
+ * Det här vaktar det andra sättet grinden kan bli verkningslös: att den mäter
+ * fel filer. Före #1025 räknade `tally` bara `src/`, så hela AI-ytan
+ * (`tooling/ava-cli/` — CLI:t + MCP-servern) låg utanför trots sju testfiler.
+ * En sådan lucka syns inte i en grön körning; grinden var grön HELA tiden.
+ *
+ * Testerna är därför lika mycket regler som tester: områdena får inte tappas,
+ * och golven får bara flyttas uppåt (ratchet-principen, docs/quality.md).
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { COVERAGE_SCOPES, tally, type FileCov } from "../../tooling/scripts/run-tests";
+
+const scopeFor = (label: string) => COVERAGE_SCOPES.find((s) => s.label === label);
+
+/** En lcov-fil med `hit` täckta rader av `found`, och en täckt funktion. */
+function cov(found: number, hit: number): FileCov {
+  const lines = new Map<number, number>();
+  for (let i = 1; i <= found; i++) lines.set(i, i <= hit ? 1 : 0);
+  return { lines, fnf: 1, fnh: 1 };
+}
+
+describe("mätområden", () => {
+  it("AI-ytan mäts — annars kan CLI:t och MCP-servern förfalla obemärkt", () => {
+    const ai = scopeFor("tooling/ava-cli/");
+    expect(ai, "tooling/ava-cli/ måste vara ett eget mätområde (#1025)").toBeDefined();
+    expect(ai?.match("tooling/ava-cli/mcp.ts")).toBe(true);
+    expect(ai?.match("tooling/ava-cli/tool-outputs.ts")).toBe(true);
+  });
+
+  it("appen mäts fortfarande", () => {
+    const src = scopeFor("src/");
+    expect(src?.match("src/lib/server/routers/billingRun.ts")).toBe(true);
+  });
+
+  it("områdena överlappar inte — en fil hör hemma i exakt ett", () => {
+    // Överlapp vore värre än en lucka: AI-ytans dipp skulle delvis absorberas
+    // av app-golvet och delvis fälla det, utan att någon förstod varför.
+    for (const path of ["src/lib/shared/kostnadsrakning.ts", "tooling/ava-cli/cli.ts"]) {
+      expect(COVERAGE_SCOPES.filter((s) => s.match(path)).map((s) => s.label), path).toHaveLength(1);
+    }
+  });
+
+  it("verktygsskript utanför AI-ytan räknas inte in i den", () => {
+    expect(scopeFor("tooling/ava-cli/")?.match("tooling/scripts/seed-data.ts")).toBe(false);
+  });
+});
+
+describe("tally räknar bara sitt område", () => {
+  const merged = new Map<string, FileCov>([
+    ["src/a.ts", cov(10, 9)],
+    ["tooling/ava-cli/mcp.ts", cov(10, 5)],
+  ]);
+
+  it("app-området ser inte AI-ytans rader", () => {
+    const t = tally(merged, (p) => p.startsWith("src/"));
+    expect({ found: t.linesFound, hit: t.linesHit }).toEqual({ found: 10, hit: 9 });
+  });
+
+  it("AI-ytan ser inte appens rader", () => {
+    const t = tally(merged, (p) => p.includes("tooling/ava-cli/"));
+    expect({ found: t.linesFound, hit: t.linesHit }).toEqual({ found: 10, hit: 5 });
+  });
+});
+
+describe("golven är ratchets", () => {
+  // Siffrorna speglar docs/quality.md. Sänks ett golv ska DEN ändringen vara
+  // ett medvetet beslut som också uppdaterar det här testet — inte något som
+  // glider igenom för att få en röd körning grön (AGENTS.md: gates only tighten).
+  const FLOOR_BASELINE: Readonly<Record<string, { line: number; func: number }>> = {
+    "src/": { line: 0.900, func: 0.859 },
+    "tooling/ava-cli/": { line: 0.930, func: 0.880 },
+  };
+
+  for (const [label, base] of Object.entries(FLOOR_BASELINE)) {
+    it(`${label} — golvet är inte sänkt`, () => {
+      const scope = scopeFor(label);
+      expect(scope, `mätområdet ${label} saknas`).toBeDefined();
+      expect(scope?.lineFloor).toBeGreaterThanOrEqual(base.line);
+      expect(scope?.funcFloor).toBeGreaterThanOrEqual(base.func);
+    });
+  }
+});

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -135,6 +135,30 @@ const LINE_FLOOR = 0.900;
 const FUNC_FLOOR = 0.859;
 
 /**
+ * AI-ytans golv (#1025). `tooling/ava-cli/` — CLI:t + MCP-servern — mättes
+ * aldrig av ratchet:en: `tally` räknade bara `src/`, så de sju testfilerna där
+ * höjde inget golv och 95,6 % kunde falla fritt.
+ *
+ * EGET golv i st.f. att bredda `isSrc`: ytan är ~540 rader mot appens ~40 000,
+ * så en total-siffra skulle dränka den — hela AI-ytan kan tappa sin täckning
+ * utan att den gemensamma procenten rör sig mätbart. Två skalor, två golv.
+ *
+ * Uppmätt enprocess: 95,58 % rader / 93,10 % funktioner (519/543, 54/58).
+ * Golven ankras MEDVETET lägre än så, av två skäl:
+ *
+ *   1. Grinden kör pass A med `--parallel`, som underrapporterar täckning
+ *      något (bun aggregerar löst över workers — se OBS 2 i docs/quality.md).
+ *      Den siffran är inte känd förrän grinden kört skarpt.
+ *   2. Ytan har bara 58 funktioner → EN funktion är 1,7 procentenheter. Ett
+ *      snävt golv hade fällt på kvantiseringen i st.f. på en regression.
+ *
+ * Dras åt mot den faktiska `--parallel`-siffran när den syns i CI-loggen —
+ * ratchet:en flyttas bara uppåt, aldrig ned (AGENTS.md).
+ */
+const AI_LINE_FLOOR = 0.930;
+const AI_FUNC_FLOOR = 0.880;
+
+/**
  * SERIAL_FILES — testfiler som SYNKRONT spawnar en barnprocess via
  * `execFileSync`/`spawnSync`: antingen git-binären mot temp-repon, eller
  * bash/bun/node (installer-script, dep-cruiser, manifest-generator). Körs
@@ -234,7 +258,7 @@ function runPass(label: string, files: string[], workers: number | null, covDir:
 // för funktioner tas per-fil-MAX av FNF/FNH (en fils instrumentering är
 // identisk mellan passen → FNF lika; FNH-max är en konservativ union för de få
 // filer som rörs i båda passen).
-interface FileCov { lines: Map<number, number>; fnf: number; fnh: number }
+export interface FileCov { lines: Map<number, number>; fnf: number; fnh: number }
 interface Totals { linesFound: number; linesHit: number; funcsFound: number; funcsHit: number }
 
 /** DA:<rad>,<antal> → union (max) av radens träffräknare. */
@@ -265,6 +289,23 @@ function mergeLcov(into: Map<string, FileCov>, text: string): void {
 
 const isSrc = (path: string): boolean => path.includes("/src/") || path.startsWith("src/");
 
+/** AI-ytan: CLI:t + MCP-servern (#1025). Mäts för sig, se AI_LINE_FLOOR. */
+const isAiSurface = (path: string): boolean => path.includes("tooling/ava-cli/");
+
+/** Ett mätområde med eget golv — appen och AI-ytan skalar för olika för att
+ *  dela en siffra (se AI_LINE_FLOOR). */
+export interface CoverageScope {
+  label: string;
+  match: (path: string) => boolean;
+  lineFloor: number;
+  funcFloor: number;
+}
+
+export const COVERAGE_SCOPES: readonly CoverageScope[] = [
+  { label: "src/", match: isSrc, lineFloor: LINE_FLOOR, funcFloor: FUNC_FLOOR },
+  { label: "tooling/ava-cli/", match: isAiSurface, lineFloor: AI_LINE_FLOOR, funcFloor: AI_FUNC_FLOOR },
+];
+
 /** Läs + union-merge:a lcov från alla pass-kataloger. */
 function loadMerged(covDirs: string[]): Map<string, FileCov> {
   const merged = new Map<string, FileCov>();
@@ -275,11 +316,11 @@ function loadMerged(covDirs: string[]): Map<string, FileCov> {
   return merged;
 }
 
-/** Räkna rad-/funktions-täckning över src/-filer. */
-function tally(merged: Map<string, FileCov>): Totals {
+/** Räkna rad-/funktions-täckning över filerna ett mätområde omfattar. */
+export function tally(merged: Map<string, FileCov>, match: (path: string) => boolean): Totals {
   const t: Totals = { linesFound: 0, linesHit: 0, funcsFound: 0, funcsHit: 0 };
   for (const [path, cov] of merged) {
-    if (!isSrc(path)) continue;
+    if (!match(path)) continue;
     for (const cnt of cov.lines.values()) { t.linesFound++; if (cnt > 0) t.linesHit++; }
     t.funcsFound += cov.fnf;
     t.funcsHit += cov.fnh;
@@ -287,15 +328,24 @@ function tally(merged: Map<string, FileCov>): Totals {
   return t;
 }
 
-function checkCoverage(covDirs: string[]): void {
-  const t = tally(loadMerged(covDirs));
+const pct = (n: number): string => `${(n * 100).toFixed(2)}%`;
+
+/** Mät ETT område mot sina golv; returnera dess brister (tom = grönt). */
+function checkScope(merged: Map<string, FileCov>, scope: CoverageScope): string[] {
+  const t = tally(merged, scope.match);
+  if (t.linesFound === 0) return [`${scope.label}: inga mätta rader — hittade grinden ingen lcov-data?`];
   const lines = t.linesHit / t.linesFound;
   const funcs = t.funcsHit / t.funcsFound;
-  const pct = (n: number): string => `${(n * 100).toFixed(2)}%`;
-  console.log(`\nCoverage (src/): rader ${pct(lines)} (golv ${pct(LINE_FLOOR)}), funktioner ${pct(funcs)} (golv ${pct(FUNC_FLOOR)})`);
+  console.log(`\nCoverage (${scope.label}): rader ${pct(lines)} (golv ${pct(scope.lineFloor)}), funktioner ${pct(funcs)} (golv ${pct(scope.funcFloor)})`);
   const failures: string[] = [];
-  if (lines < LINE_FLOOR) failures.push(`rader ${pct(lines)} < ${pct(LINE_FLOOR)}`);
-  if (funcs < FUNC_FLOOR) failures.push(`funktioner ${pct(funcs)} < ${pct(FUNC_FLOOR)}`);
+  if (lines < scope.lineFloor) failures.push(`${scope.label} rader ${pct(lines)} < ${pct(scope.lineFloor)}`);
+  if (funcs < scope.funcFloor) failures.push(`${scope.label} funktioner ${pct(funcs)} < ${pct(scope.funcFloor)}`);
+  return failures;
+}
+
+function checkCoverage(covDirs: string[]): void {
+  const merged = loadMerged(covDirs);
+  const failures = COVERAGE_SCOPES.flatMap((scope) => checkScope(merged, scope));
   if (failures.length > 0) {
     console.error(`✗ Coverage under golvet: ${failures.join("; ")}`);
     process.exit(1);


### PR DESCRIPTION
Closes #1025.

## Problemet

`tooling/ava-cli/` — 1 087 rader som bär hela ytan AI:n möter AVA genom — låg utanför två av tre kvalitetsgrindar. Grindarna var **gröna hela tiden**, vilket är precis varför luckan aldrig syntes.

| Grind | Före | Efter |
|---|---|---|
| `deps:check` | Skannade `src test helper-ui office-addin` — inte `tooling/` | Skannar även `tooling/ava-cli` |
| Coverage-ratchet | Räknade bara `src/` → 95,58 % oskyddade | Eget mätområde med eget golv |
| knip | Täckte redan katalogen | Orörd |

## Ändringen

**dep-cruiser:** scan-roten utökad. Torrkörningen var ren redan (0 överträdelser, 1 134 moduler efter tillägget), så inkopplingen kostar inget — den låser fast dagens läge. Katalogen importerar `appRouter` rakt in i `src/`, så just den lager-riktningen dep-cruiser finns för att vakta var oövervakad.

**Coverage:** `MÄTOMRÅDEN` (`COVERAGE_SCOPES`) med var sitt golv, i stället för att bredda `isSrc`. Motivet står i koden: ytan är ~540 rader mot appens ~40 000, så en gemensam siffra skulle dränka den — hela AI-ytan kan tappa sin täckning utan att totalen rör sig mätbart.

| Område | Golv rader | Golv funktioner | Uppmätt (enprocess) |
|---|---:|---:|---:|
| `src/` | 90,0 % | 85,9 % | oförändrat |
| `tooling/ava-cli/` | 93,0 % | 88,0 % | **95,58 % / 93,10 %** (519/543, 54/58) |

AI-golvet är **medvetet ankrat under** uppmätt, av två skäl som står i kod och docs: mätningen är enprocess medan grinden kör pass A med `--parallel` (som underrapporterar — OBS 2 i `docs/quality.md`), och med 58 funktioner är EN funktion 1,7 procentenheter. Avsikten är att dra åt mot CI:s faktiska siffra när den syns i loggen — ratchet:en flyttas bara uppåt.

## Vaktat, inte bara ändrat

Nytt test (`test/scripts/coverage-scopes.test.ts`, 8 tester) vaktar mätområdet självt — det andra sättet en coverage-grind kan bli verkningslös är att den mäter fel filer:

- AI-ytan **är** ett eget område (fångar att omfånget tappas igen)
- områdena **överlappar inte** — en dipp får inte delvis absorberas av det andra golvet
- `tally` räknar bara sitt eget område
- **golven är inte sänkta** mot en baslinje i testet (AGENTS.md: gates only tighten)

Dessutom lade jag en vakt i `checkScope` mot det tysta felet: hittar området noll rader (t.ex. om lcov-sökvägarna ändrar format) **fäller** grinden i stället för att passera på `NaN < golv === false`.

**Känslighet verifierad:** en dipp till 500/543 rader (92,08 %) fäller grinden, dagens 519/543 passerar.

## Verifierat lokalt

`deps:check` ✅ (1 134 moduler, 0 överträdelser) · `typecheck` ✅ · `lint` ✅ · `knip` ✅ · nya + befintliga run-tests-tester ✅ (13/13). Det fulla coverage-passet kan inte köras i den här containern (parallell-passet timeoutar även på oförändrad main — miljö, inte diffen), så CI verifierar det skarpa golvet. Det är också där den faktiska `--parallel`-siffran syns för nästa åtdragning.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_