### PR TITLE
feat(mcp): kuvertform och smala listrader — listverktygen kostar 76 % mindre

### DIFF
--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -310,7 +310,8 @@ function TasksSection() {
 }
 
 function TaskList() {
-  const { data: tasks, isLoading } = trpc.task.list.useQuery();
+  const { data, isLoading } = trpc.task.list.useQuery();
+  const tasks = data?.items;
   const utils = trpc.useUtils();
   const complete = trpc.task.complete.useMutation({ onSuccess: () => utils.task.list.invalidate() });
   const del = trpc.task.delete.useMutation({ onSuccess: () => utils.task.list.invalidate() });

--- a/src/app/invoices/_sie-export-button.tsx
+++ b/src/app/invoices/_sie-export-button.tsx
@@ -36,7 +36,7 @@ export function SieExportButton() {
   const invoices = trpc.invoice.list.useQuery({});
   const org = trpc.organization.getSettings.useQuery();
 
-  const rows = (invoices.data ?? []) as ExportableInvoice[];
+  const rows = (invoices.data?.items ?? []) as ExportableInvoice[];
   const exportableCount = countExportable(rows);
 
   function handleExport(): void {

--- a/src/app/invoices/page.tsx
+++ b/src/app/invoices/page.tsx
@@ -104,7 +104,7 @@ export default function InvoicesPage() {
         <DataTable
           prefKey="list.invoices"
           columns={invoiceColumns}
-          data={(invoices.data ?? []) as InvoiceRow[]}
+          data={(invoices.data?.items ?? []) as InvoiceRow[]}
           rowKey={(i) => i.id}
           emptyMessage="Inga fakturor ännu."
         />

--- a/src/app/matters/[id]/_billing-panel.tsx
+++ b/src/app/matters/[id]/_billing-panel.tsx
@@ -90,6 +90,14 @@ function standaloneInvoices(invoices: StandaloneInvoiceRow[] | undefined, rows: 
   return (invoices ?? []).filter((i) => !runInvoiceIds.has(String(i.id)));
 }
 
+/** Fristående klientfakturor (#853) — t.ex. rådgivningstimmen (STANDARD, ingen
+ *  billing-run). Egen hook så att kuvertets `?.items` (#1014) inte belastar
+ *  `BillingPanel`:s komplexitetstak. */
+function useStandaloneInvoices(matterId: MatterId, rows: BillingRunRow[]): StandaloneInvoiceRow[] {
+  const invoices = trpc.invoice.list.useQuery({ matterId }).data;
+  return standaloneInvoices(invoices?.items as StandaloneInvoiceRow[] | undefined, rows);
+}
+
 interface KrDocInfo { id: DocumentId; fileName: string; storagePath: string | null }
 
 type DocumentListOutput = inferRouterOutputs<AppRouter>["document"]["list"];
@@ -389,9 +397,8 @@ export function BillingPanel({ matterId, matter }: Props) {
   const [verdictRunId, setVerdictRunId] = useState<BillingRunId | null>(null);
   const [beslutRunId, setBeslutRunId] = useState<BillingRunId | null>(null);
   const rows = (runs.data?.runs ?? []) as BillingRunRow[];
-  // Fristående klientfakturor (#853) — t.ex. rådgivningstimmen (STANDARD, ingen
-  // billing-run). Visas i faktura-listan utöver billing-runs.
-  const standalone = standaloneInvoices(trpc.invoice.list.useQuery({ matterId }).data as StandaloneInvoiceRow[] | undefined, rows);
+  // Visas i faktura-listan utöver billing-runs.
+  const standalone = useStandaloneInvoices(matterId, rows);
   // Aktiv kostnadsräkning (#828): KR vars livscykel inte är klar (≠ FAKTURERAD).
   const activeKr = rows.find((r) => r.type === "KOSTNADSRAKNING" && !!r.kostnadsrakningStatus && r.kostnadsrakningStatus !== "FAKTURERAD");
   // Flödesmodellen (#816) styr menyn + dom-bannern: fasen härleds ur runs+matter
@@ -576,7 +583,7 @@ function BillingSummary({ matterId }: { matterId: MatterId }) {
     ? d.timeEntries.filter((t) => t.billable).reduce((s, t) => s + t.valueOre, 0)
       + d.expenses.filter((e) => e.billable).reduce((s, e) => s + e.amount, 0)
     : 0;
-  const list = invoices.data ?? [];
+  const list = invoices.data?.items ?? [];
   const fakturerat = list.filter((i) => i.status !== "DRAFT" && i.status !== "CANCELLED").reduce((s, i) => s + i.amount, 0);
   const betalt = list.reduce((s, i) => s + (i.payments ?? []).reduce((p, pm) => p + pm.amount, 0), 0);
   return (

--- a/src/app/payment-plans/page.tsx
+++ b/src/app/payment-plans/page.tsx
@@ -193,7 +193,7 @@ export default function PaymentPlansPage() {
         <DataTable
           prefKey="list.payment-plans"
           columns={planColumns}
-          data={(list.data ?? []) as PlanRow[]}
+          data={(list.data?.items ?? []) as PlanRow[]}
           rowKey={(p) => p.id}
           emptyMessage={`Inga ${STATUS_LABEL[status].toLowerCase()} planer.`}
           onRowClick={(p) => router.push(shellPath("payment-plans", p.id))}

--- a/src/app/payments/import/page.tsx
+++ b/src/app/payments/import/page.tsx
@@ -79,7 +79,7 @@ export default function PaymentImportPage() {
 
   const outcome = useMemo((): MatchOutcome | null => {
     if (!parsed.file || !invoices.data) return null;
-    return matchTransactions(parsed.file.transactions, toCandidates(invoices.data as InvoiceRowData[]));
+    return matchTransactions(parsed.file.transactions, toCandidates(invoices.data.items as InvoiceRowData[]));
   }, [parsed.file, invoices.data]);
 
   const labels = useMemo((): Record<string, string> => {

--- a/src/app/payments/import/page.tsx
+++ b/src/app/payments/import/page.tsx
@@ -84,7 +84,7 @@ export default function PaymentImportPage() {
 
   const labels = useMemo((): Record<string, string> => {
     const out: Record<string, string> = {};
-    for (const r of (invoices.data ?? []) as InvoiceRowData[]) out[r.id] = r.invoiceNumber ?? r.id;
+    for (const r of (invoices.data?.items ?? []) as InvoiceRowData[]) out[r.id] = r.invoiceNumber ?? r.id;
     return out;
   }, [invoices.data]);
 

--- a/src/lib/server/routers/invoice.ts
+++ b/src/lib/server/routers/invoice.ts
@@ -19,7 +19,7 @@ import { arvodeInclVatOre, isPaymentPlanSettled } from "@/lib/shared/invoice-cal
 import { canTransition, transitionErrorMessage } from "@/lib/shared/invoice-state-machine";
 import { ocrFromInvoiceNumber } from "@/lib/shared/ocr-reference";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
-import { pageSlice } from "@/lib/shared/paginate";
+import { pageEnvelope } from "@/lib/shared/paginate";
 import { computeRadgivningsavgift } from "@/lib/shared/rattshjalp";
 import type { Invoice, Payment, PaymentPlan, WriteOff } from "@/lib/shared/schemas/billing";
 import { invoiceStatusSchema, invoiceTypeSchema, type InvoiceStatus } from "@/lib/shared/schemas/enums";
@@ -119,7 +119,7 @@ export const invoiceRouter = router({
     )
     // Migrerad till repository-sömmen (ADR 0020). listForOrg org-scopar +
     // hämtar listvyns include (matter-subset, plan, betalningar, aconto-avdrag).
-    .query(async ({ ctx, input }) => pageSlice(await ctx.repos.invoices.listForOrg(ctx.orgId, input), input)),
+    .query(async ({ ctx, input }) => pageEnvelope(await ctx.repos.invoices.listForOrg(ctx.orgId, input), input)),
 
   getById: orgProcedure
     .input(z.object({ id: invoiceIdSchema }))

--- a/src/lib/server/routers/paymentPlan.ts
+++ b/src/lib/server/routers/paymentPlan.ts
@@ -17,7 +17,7 @@
  */
 
 import { z } from "zod";
-import { pageSlice } from "@/lib/shared/paginate";
+import { pageEnvelope } from "@/lib/shared/paginate";
 import {
   computeDueReminders,
   type PlanForScan,
@@ -96,7 +96,7 @@ export const paymentPlanRouter = router({
       const plans = await ctx.repos.paymentPlans.listForOrg(ctx.orgId, input?.status);
       const needle = input?.search?.toLowerCase();
       // Sidningen sist — sök först, annars sidas bort träffar.
-      return pageSlice(needle ? plans.filter((p) => planHaystack(p).includes(needle)) : plans, input);
+      return pageEnvelope(needle ? plans.filter((p) => planHaystack(p).includes(needle)) : plans, input);
     }),
 
   getById: orgProcedure

--- a/src/lib/server/routers/task.ts
+++ b/src/lib/server/routers/task.ts
@@ -9,7 +9,7 @@
 
 import { z } from "zod";
 import { omitUndefined } from "@/lib/shared/omit-undefined";
-import { pageSlice } from "@/lib/shared/paginate";
+import { pageEnvelope } from "@/lib/shared/paginate";
 import { taskPrioritySchema, taskStatusSchema, type Task } from "@/lib/shared/schemas";
 import { asId, taskIdSchema, matterIdSchema, userIdSchema } from "@/lib/shared/schemas/ids";
 import { router, protectedProcedure, TRPCError } from "../trpc";
@@ -46,7 +46,7 @@ export const taskRouter = router({
     )
     // Migrerad till repository-sömmen (ADR 0020): ägar-/org-scopad listForUser.
     .query(async ({ ctx, input }) =>
-      pageSlice(
+      pageEnvelope(
         await ctx.repos.tasks.listForUser(ctx.user.id, ctx.user.organizationId, {
           status: input?.status,
           matterId: input?.matterId,

--- a/src/lib/shared/paginate.ts
+++ b/src/lib/shared/paginate.ts
@@ -21,3 +21,27 @@ export function pageSlice<T>(rows: readonly T[], opts: PageOpts | undefined): T[
   const page = opts?.page ?? 1;
   return rows.slice((page - 1) * pageSize, page * pageSize);
 }
+
+/** En sida plus antalet rader som fanns FÖRE sidningen. */
+export interface Page<T> {
+  items: T[];
+  /** Totalt antal träffar, inte sidans längd — se `pageEnvelope`. */
+  total: number;
+}
+
+/**
+ * Som `pageSlice`, men behåller antalet (#1014).
+ *
+ * `pageSlice` kastar bort hur många rader som fanns före snittet, och det
+ * antalet går inte att återskapa senare: en mottagare som får tio rader kan
+ * inte veta om det var allt eller första sidan av hundra. För ett UI spelade
+ * det ingen roll så länge listorna var osidade, men MCP-ytan sidar ALLTID
+ * (`withPageSizeDefault`) — så där blev tystnaden en felkälla: modellen
+ * rapporterade "byrån har 10 fakturor" när den sett en sida.
+ *
+ * `total` är därför alltid antalet FÖRE sidningen, även när `pageSize`
+ * utelämnas (då är det trivialt lika med `items.length`).
+ */
+export function pageEnvelope<T>(rows: readonly T[], opts: PageOpts | undefined): Page<T> {
+  return { items: pageSlice(rows, opts), total: rows.length };
+}

--- a/test/integration/mcp-server.test.ts
+++ b/test/integration/mcp-server.test.ts
@@ -27,6 +27,7 @@ import { listProcedures } from "../../tooling/ava-cli/introspect";
 import { buildAvaMcpServer, MCP_SERVER_NAME, toolName } from "../../tooling/ava-cli/mcp";
 import { MCP_DEFAULT_PAGE_SIZE } from "../../tooling/ava-cli/tool-descriptions";
 import { outputDescribedPaths } from "../../tooling/ava-cli/tool-outputs";
+import { projectedPaths, projectionFor } from "../../tooling/ava-cli/tool-projections";
 
 type Era = "modern" | "legacy";
 
@@ -266,11 +267,12 @@ describe("sidning av listor utan egen paginering (#1011)", () => {
   it("invoice.list får MCP-defaulten i stället för hela listan", async () => {
     const { client, close } = await connect("legacy");
     try {
-      const rows = JSON.parse(textOf(await client.callTool({ name: "invoice__list", arguments: {} }))) as unknown[];
+      // Kuvertform sedan #1014 — raderna bor under `items`.
+      const { items: rows } = JSON.parse(textOf(await client.callTool({ name: "invoice__list", arguments: {} }))) as { items: { id: string }[] };
       expect(rows).toHaveLength(MCP_DEFAULT_PAGE_SIZE);
-      const page2 = JSON.parse(textOf(await client.callTool({ name: "invoice__list", arguments: { page: 2, pageSize: 3 } }))) as { id: string }[];
+      const { items: page2 } = JSON.parse(textOf(await client.callTool({ name: "invoice__list", arguments: { page: 2, pageSize: 3 } }))) as { items: { id: string }[] };
       expect(page2).toHaveLength(3);
-      expect(page2[0]!.id).not.toBe((rows as { id: string }[])[0]!.id);
+      expect(page2[0]!.id).not.toBe(rows[0]!.id);
     } finally {
       await close();
     }
@@ -279,7 +281,7 @@ describe("sidning av listor utan egen paginering (#1011)", () => {
   it("task.list sidas på samma sätt", async () => {
     const { client, close } = await connect("legacy");
     try {
-      const rows = JSON.parse(textOf(await client.callTool({ name: "task__list", arguments: {} }))) as unknown[];
+      const { items: rows } = JSON.parse(textOf(await client.callTool({ name: "task__list", arguments: {} }))) as { items: unknown[] };
       expect(rows.length).toBeLessThanOrEqual(MCP_DEFAULT_PAGE_SIZE);
     } finally {
       await close();
@@ -340,7 +342,11 @@ describe("reports.firmOverview över MCP (#1016)", () => {
  * `invoice.list` — 10 rader à ~1 KB, join-feta rader. Nästa sänkning kräver
  * fältprojektion (#1014), inte mer sidning.
  */
-const OUTPUT_BUDGET_CHARS = 38_000;
+// Ratchet (#1014): 38 000 → 10 000 efter kuvertform + fältprojektion. Största
+// anropbara svaret på demo-seeden är nu `calendar.list` (6 795 tecken) mot
+// tidigare `invoice.list`/`matter.list` runt 26 000; taket ligger med marginal
+// över för att seeden ska kunna växa utan att grinden blir nyckfull.
+const OUTPUT_BUDGET_CHARS = 10_000;
 
 describe("verktygens utdatabudget", () => {
   it("inget verktyg som går att anropa utan argument spränger budgeten", async () => {
@@ -391,4 +397,78 @@ describe("verktygens utdatabudget", () => {
       await close();
     }
   });
+});
+
+describe("listornas kuvertform och radform (#1014)", () => {
+  it("de tidigare array-listorna bär { items, total }", async () => {
+    // Före #1014 returnerade de tre nakna arrayer: modellen kunde varken se
+    // hur många som fanns eller få ett svarskontrakt (MCP kräver objekt).
+    const { client, close } = await connect("legacy");
+    try {
+      for (const tool of ["invoice__list", "task__list", "paymentPlan__list"]) {
+        const data = JSON.parse(textOf(await client.callTool({ name: tool, arguments: {} }))) as
+          { items?: unknown[]; total?: number };
+        expect(Array.isArray(data.items), `${tool}.items`).toBe(true);
+        expect(typeof data.total, `${tool}.total`).toBe("number");
+      }
+    } finally {
+      await close();
+    }
+  });
+
+  it("`total` är antalet FÖRE sidningen, inte sidans längd", async () => {
+    // Den skillnaden är hela poängen: en modell som ser tio rader måste kunna
+    // avgöra om det var allt. Seedens fakturor är fler än MCP-sidan.
+    const { client, close } = await connect("legacy");
+    try {
+      const paged = JSON.parse(textOf(await client.callTool({ name: "invoice__list", arguments: {} }))) as
+        { items: unknown[]; total: number };
+      const all = JSON.parse(textOf(await client.callTool({ name: "invoice__list", arguments: { pageSize: 100 } }))) as
+        { items: unknown[]; total: number };
+      expect(paged.items).toHaveLength(MCP_DEFAULT_PAGE_SIZE);
+      expect(paged.total).toBeGreaterThan(paged.items.length);
+      expect(paged.total).toBe(all.items.length);
+    } finally {
+      await close();
+    }
+  });
+
+  it("raderna bär inte routerns join-fält", async () => {
+    // 74 % av en fakturarad var `matter` + `creditedInvoice` — fält UI:t
+    // behöver men modellen betalar för. Detaljer hämtas via getById.
+    const { client, close } = await connect("legacy");
+    try {
+      const data = JSON.parse(textOf(await client.callTool({ name: "invoice__list", arguments: {} }))) as
+        { items: Record<string, unknown>[] };
+      const row = data.items[0];
+      expect(row, "seeden ska ha minst en faktura").toBeDefined();
+      expect(row).not.toHaveProperty("matter");
+      expect(row).not.toHaveProperty("creditedInvoice");
+      expect(row).not.toHaveProperty("payments");
+      // Men det kontraktet lovar finns kvar.
+      expect(row).toHaveProperty("invoiceNumber");
+      expect(row).toHaveProperty("amount");
+    } finally {
+      await close();
+    }
+  });
+
+  it("projektionen gäller ALLA projicerade listverktyg", async () => {
+    const { client, close } = await connect("legacy");
+    try {
+      for (const path of projectedPaths()) {
+        const projection = projectionFor(path);
+        const data = JSON.parse(textOf(await client.callTool({ name: toolName(path), arguments: {} }))) as
+          Record<string, unknown>;
+        const rows = data[projection!.key] as Record<string, unknown>[];
+        expect(Array.isArray(rows), `${path}.${projection!.key}`).toBe(true);
+        for (const row of rows) {
+          const extra = Object.keys(row).filter((k) => !projection!.fields.includes(k));
+          expect(extra, `${path} läcker fält`).toEqual([]);
+        }
+      }
+    } finally {
+      await close();
+    }
+  }, 30_000);
 });

--- a/test/integration/scenario-civilmal.test.ts
+++ b/test/integration/scenario-civilmal.test.ts
@@ -383,7 +383,7 @@ describe("Scenario: civilmål (bostadsrättstvist) på löpande räkning", () =>
     const times = await state.caller.timeEntry.list({ matterId: state.matterId! });
     expect(times.totalMinutes).toBe(885); // 14 tim 45 min
 
-    const invoices = await state.caller.invoice.list({ matterId: state.matterId! });
+    const { items: invoices } = await state.caller.invoice.list({ matterId: state.matterId! });
     expect(invoices.length).toBe(2);
     const acconto = invoices.find((i) => i.invoiceType === "ACCONTO");
     const final = invoices.find((i) => i.invoiceType === "FINAL");

--- a/test/integration/seed-smoke.test.ts
+++ b/test/integration/seed-smoke.test.ts
@@ -71,7 +71,7 @@ describe("Seed-data smoke — varje meny-sida körs mot riktig DemoDataStore", (
     const trpc = makeCaller();
     const events = await trpc.calendar.list();
     expect(Array.isArray(events)).toBe(true);
-    const tasks = await trpc.task.list();
+    const { items: tasks } = await trpc.task.list();
     expect(Array.isArray(tasks)).toBe(true);
   });
 
@@ -222,10 +222,10 @@ describe("Seed-data smoke — varje meny-sida körs mot riktig DemoDataStore", (
 
   it("/payment-plans — paymentPlan.list + getById för varje plan", async () => {
     const trpc = makeCaller();
-    const list = await trpc.paymentPlan.list();
+    const { items: list } = await trpc.paymentPlan.list();
     expect(list.length).toBeGreaterThan(0);
     // Status-filter
-    const active = await trpc.paymentPlan.list({ status: "ACTIVE" });
+    const { items: active } = await trpc.paymentPlan.list({ status: "ACTIVE" });
     for (const p of active) expect((p as { status: string }).status).toBe("ACTIVE");
     // Detalj-vyn ska inkludera invoice + matter + klient + reminders
     for (const p of list) {
@@ -240,8 +240,8 @@ describe("Seed-data smoke — varje meny-sida körs mot riktig DemoDataStore", (
   // pekar tillbaka (UI:n skulle då visa olika antal i olika vyer).
   it("varje INSTALLMENT_PLAN-faktura har en motsvarande ACTIVE-plan", async () => {
     const trpc = makeCaller();
-    const invoices = await trpc.invoice.list({ status: "INSTALLMENT_PLAN" });
-    const activePlans = await trpc.paymentPlan.list({ status: "ACTIVE" });
+    const { items: invoices } = await trpc.invoice.list({ status: "INSTALLMENT_PLAN" });
+    const { items: activePlans } = await trpc.paymentPlan.list({ status: "ACTIVE" });
     const planInvoiceIds = new Set(activePlans.map((p: { invoiceId: string }) => p.invoiceId));
     expect(invoices.length).toBeGreaterThan(0);
     for (const inv of invoices) {
@@ -256,7 +256,7 @@ describe("Seed-data smoke — varje meny-sida körs mot riktig DemoDataStore", (
 
   it("payments-rader finns för aktiva planer (avbetalningarna är seedade)", async () => {
     const trpc = makeCaller();
-    const plans = await trpc.paymentPlan.list({ status: "ACTIVE" });
+    const { items: plans } = await trpc.paymentPlan.list({ status: "ACTIVE" });
     let totalPayments = 0;
     for (const p of plans) {
       const detail = await trpc.paymentPlan.getById({ id: (p as { id: string }).id });
@@ -268,7 +268,7 @@ describe("Seed-data smoke — varje meny-sida körs mot riktig DemoDataStore", (
 
   it("/invoices — invoice.list + getById för varje faktura", async () => {
     const trpc = makeCaller();
-    const list = await trpc.invoice.list({});
+    const { items: list } = await trpc.invoice.list({});
     expect(Array.isArray(list)).toBe(true);
     expect(list.length).toBeGreaterThan(0);
     for (const inv of list) {

--- a/test/scripts/demo-deployed-path-repro.test.ts
+++ b/test/scripts/demo-deployed-path-repro.test.ts
@@ -64,9 +64,9 @@ describe("deployed-path repro (prebakeJoins + ny store)", () => {
     const ctx = buildContext({ dataStore: store, ports: noopPorts, principal: ADMIN });
     const caller = appRouter.createCaller(ctx as never) as Any;
 
-    const inv = await caller.invoice.list({});
+    const { items: inv } = await caller.invoice.list({});
     const te = await caller.timeEntry.list({ pageSize: 100 });
-    const plans = await caller.paymentPlan.list({});
+    const { items: plans } = await caller.paymentPlan.list({});
      
     console.log("REPRO counts:", { invoices: inv.length, timeEntries: te.entries.length, paymentPlans: plans.length });
 

--- a/test/scripts/demo-generator-invoice-docs.test.ts
+++ b/test/scripts/demo-generator-invoice-docs.test.ts
@@ -26,7 +26,7 @@ describe("populateInvoiceDocs", () => {
     expect(n).toBeGreaterThan(0);
     expect(writes.every((p) => p.startsWith("documents/content/invdoc-") && p.endsWith(".html"))).toBe(true);
 
-    const invoices: Any[] = await (target.caller as Any).invoice.list({});
+    const { items: invoices } = (await (target.caller as Any).invoice.list({})) as { items: Any[] };
     const final = invoices.find((i: Any) => i.invoiceType === "FINAL");
     expect(final).toBeDefined();
     const inv = await (target.caller as Any).invoice.getById({ id: final.id });

--- a/test/scripts/simulate-orchestrate.test.ts
+++ b/test/scripts/simulate-orchestrate.test.ts
@@ -91,8 +91,8 @@ describe("runSimulation (#880 integration)", () => {
   it("privatärendenas livscykler ger planer i alla tre tillstånd + en kundförlust", async () => {
     const { c, res: simRes } = await simulateDemo();
 
-    const plans = await c.paymentPlan.list({});
-    const statuses = new Set((plans as Any[]).map((p) => p.status));
+    const { items: plans } = (await c.paymentPlan.list({})) as { items: Any[] };
+    const statuses = new Set(plans.map((p) => p.status));
     // Cykeln i `privat.ts` är sex lång och seeden har fler privatärenden än så,
     // så alla tre tillstånden ska förekomma. Slår detta fel har antingen cykeln
     // ändrats eller antalet privatärenden fallit under sex.
@@ -103,7 +103,7 @@ describe("runSimulation (#880 integration)", () => {
 
     // Kundförlusten stänger sin faktura som BAD_DEBT (ADR 0007).
     expect(simRes.writeOffs).toBeGreaterThan(0);
-    const invoices = await c.invoice.list({}) as Any[];
+    const { items: invoices } = (await c.invoice.list({})) as { items: Any[] };
     expect(invoices.some((i) => i.status === "BAD_DEBT"), "avskriven faktura").toBe(true);
     // …och en plan-faktura står som INSTALLMENT_PLAN, inte som vanlig SENT.
     expect(invoices.some((i) => i.status === "INSTALLMENT_PLAN"), "faktura med plan").toBe(true);

--- a/test/unit/app/calendar/calendar-forms.test.tsx
+++ b/test/unit/app/calendar/calendar-forms.test.tsx
@@ -27,7 +27,8 @@ const taskRows = [
     matter: { id: "m1", matterNumber: "2026-0001", title: "Tvist" } },
 ];
 const calListQuery = { data: eventRows as unknown[], isLoading: false };
-const taskListQuery = { data: taskRows as unknown[], isLoading: false };
+// Kuvertform sedan #1014.
+const taskListQuery = { data: { items: taskRows as unknown[], total: taskRows.length }, isLoading: false };
 
 vi.mock("@/lib/client/trpc", () => ({
   trpc: {
@@ -58,7 +59,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   localStorage.clear();
   calListQuery.data = eventRows;
-  taskListQuery.data = taskRows;
+  taskListQuery.data = { items: taskRows, total: taskRows.length };
 });
 
 describe("CalendarPage — lista + skapa-flöden", () => {

--- a/test/unit/app/invoices/page.test.tsx
+++ b/test/unit/app/invoices/page.test.tsx
@@ -6,9 +6,13 @@ import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
 import InvoicesPage from "@/app/invoices/page";
 
+// Kuvertform sedan #1014 — sidan läser `data.items`.
 const invoicesQuery = {
-  data: undefined as Array<Record<string, unknown>> | undefined,
+  data: undefined as { items: Array<Record<string, unknown>>; total: number } | undefined,
   isLoading: false,
+};
+const setInvoices = (rows: Array<Record<string, unknown>> | undefined): void => {
+  invoicesQuery.data = rows === undefined ? undefined : { items: rows, total: rows.length };
 };
 
 vi.mock("@/lib/client/trpc", () => ({
@@ -35,13 +39,13 @@ vi.mock("@/lib/client/trpc", () => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
-  invoicesQuery.data = undefined;
+  setInvoices(undefined);
   invoicesQuery.isLoading = false;
 });
 
 describe("InvoicesPage", () => {
   it("renderar rubrik", () => {
-    invoicesQuery.data = [];
+    setInvoices([]);
     render(<InvoicesPage />);
     expect(screen.getByRole("heading", { name: /Fakturor/i })).toBeInTheDocument();
   });
@@ -53,13 +57,13 @@ describe("InvoicesPage", () => {
   });
 
   it("visar tomt-läge när inga fakturor finns", () => {
-    invoicesQuery.data = [];
+    setInvoices([]);
     render(<InvoicesPage />);
     expect(screen.getByText(/Inga fakturor ännu/i)).toBeInTheDocument();
   });
 
   it("listar fakturor med status och typ", () => {
-    invoicesQuery.data = [
+    setInvoices([
       {
         id: "i1",
         invoiceDate: new Date("2026-02-01").toISOString(),
@@ -76,7 +80,7 @@ describe("InvoicesPage", () => {
         amount: 50000,
         matter: { id: "m2", matterNumber: "2026-0002", title: "Tvist" },
       },
-    ];
+    ]);
     render(<InvoicesPage />);
     expect(screen.getByText("Faktura")).toBeInTheDocument();
     expect(screen.getByText("Aconto")).toBeInTheDocument();
@@ -87,7 +91,7 @@ describe("InvoicesPage", () => {
   });
 
   it("länkar varje rad till faktura- och ärendesidor", () => {
-    invoicesQuery.data = [
+    setInvoices([
       {
         id: "i1",
         invoiceDate: new Date("2026-02-01").toISOString(),
@@ -96,7 +100,7 @@ describe("InvoicesPage", () => {
         amount: 1000,
         matter: { id: "m1", matterNumber: "2026-0001", title: "T" },
       },
-    ];
+    ]);
     render(<InvoicesPage />);
     const links = screen.getAllByRole("link");
     const hrefs = links.map((l) => l.getAttribute("href"));
@@ -111,13 +115,13 @@ describe("InvoicesPage", () => {
   });
 
   it("renderar alla statuser med rätt klass-färg", () => {
-    invoicesQuery.data = [
+    setInvoices([
       { id: "i1", invoiceDate: new Date().toISOString(), invoiceType: "STANDARD", status: "DRAFT", amount: 100, matter: { id: "m1", matterNumber: "1", title: "T" } },
       { id: "i2", invoiceDate: new Date().toISOString(), invoiceType: "STANDARD", status: "INSTALLMENT_PLAN", amount: 100, matter: { id: "m2", matterNumber: "2", title: "T" } },
       { id: "i3", invoiceDate: new Date().toISOString(), invoiceType: "STANDARD", status: "CANCELLED", amount: 100, matter: { id: "m3", matterNumber: "3", title: "T" } },
       { id: "i4", invoiceDate: new Date().toISOString(), invoiceType: "STANDARD", status: "BAD_DEBT", amount: 100, matter: { id: "m4", matterNumber: "4", title: "T" } },
       { id: "i5", invoiceDate: new Date().toISOString(), invoiceType: "FINAL", status: "SENT", amount: -100, matter: { id: "m5", matterNumber: "5", title: "T" } },
-    ];
+    ]);
     render(<InvoicesPage />);
     expect(screen.getByText("Utkast")).toBeInTheDocument();
     expect(screen.getByText("Avbetalningsplan")).toBeInTheDocument();

--- a/test/unit/app/matters/billing-panel.test.tsx
+++ b/test/unit/app/matters/billing-panel.test.tsx
@@ -64,7 +64,8 @@ vi.mock("@/lib/client/trpc", () => ({
       register: { useMutation: () => ({ mutateAsync: vi.fn(async () => {}) }) },
     },
     invoice: {
-      list: { useQuery: () => ({ data: invoiceListData }) },
+      // Kuvertform sedan #1014 — panelen läser `data.items`.
+      list: { useQuery: () => ({ data: { items: invoiceListData, total: invoiceListData.length } }) },
       createRadgivning: {
         useMutation: (opts?: { onSuccess?: () => void }) => {
           void opts;

--- a/test/unit/app/payment-plans/page.test.tsx
+++ b/test/unit/app/payment-plans/page.test.tsx
@@ -8,7 +8,12 @@ import { describe, it, expect, beforeEach, vi } from "vitest-compat";
 
 import PaymentPlansPage, { formatScanResult } from "@/app/payment-plans/page";
 
-const listQuery = { data: undefined as unknown[] | undefined, isLoading: false };
+// Kuvertform sedan #1014. `setRows` håller mockens form på ETT ställe, så
+// testerna fortsätter tilldela rader utan att upprepa kuvertet.
+const listQuery = { data: undefined as { items: unknown[]; total: number } | undefined, isLoading: false };
+const setRows = (rows: unknown[] | undefined): void => {
+  listQuery.data = rows === undefined ? undefined : { items: rows, total: rows.length };
+};
 type ScanResult = { scanned: number; planned: number; due: number; overdue: number };
 const scanMutate = vi.fn();
 const scanState = { isPending: false, error: null as null | { message: string } };
@@ -45,7 +50,7 @@ vi.mock("next/navigation", () => ({ useRouter: () => ({ push: pushSpy }) }));
 
 beforeEach(() => {
   vi.clearAllMocks();
-  listQuery.data = undefined;
+  setRows(undefined);
   listQuery.isLoading = false;
   scanState.isPending = false;
   scanState.error = null;
@@ -54,7 +59,7 @@ beforeEach(() => {
 
 describe("PaymentPlansPage — utestående", () => {
   it("visar utestående = total − inbetalt − avskrivet", () => {
-    listQuery.data = [
+    setRows([
       {
         id: "pp1", status: "ACTIVE", monthlyAmount: 10_000, dayOfMonth: 15,
         invoice: {
@@ -64,7 +69,7 @@ describe("PaymentPlansPage — utestående", () => {
           matter: { matterNumber: "2026-0001", title: "Tvist", contacts: [{ contact: { id: "c1", name: "Anna" } }] },
         },
       },
-    ];
+    ]);
     render(<PaymentPlansPage />);
     // 100 000 − 30 000 betalt − 20 000 avskrivet = 50 000 öre = 500 kr utestående
     expect(screen.getByText("Utestående")).toBeInTheDocument();
@@ -137,7 +142,7 @@ describe("PaymentPlansPage — filter, sök, rad-klick", () => {
   });
 
   it("rad-klick navigerar till plan-detaljen (router.push)", () => {
-    listQuery.data = [planRow];
+    setRows([planRow]);
     render(<PaymentPlansPage />);
     fireEvent.click(screen.getByText("Tvist"));
     expect(pushSpy).toHaveBeenCalled();

--- a/test/unit/app/payments/import-page.test.tsx
+++ b/test/unit/app/payments/import-page.test.tsx
@@ -15,14 +15,18 @@ const OCR = buildOcrReference("20260001");
 
 const mutateAsync = vi.fn().mockResolvedValue({});
 const invalidate = vi.fn();
+// Kuvertform sedan #1014 — sidan läser `data.items`.
 const invoiceList = {
-  data: [
-    {
-      id: "inv-1", invoiceNumber: "F-2026-0001", ocrReference: OCR,
-      amount: 10_000, payments: [],
-      matter: { id: "m1", matterNumber: "2026-0001", title: "T" },
-    },
-  ],
+  data: {
+    items: [
+      {
+        id: "inv-1", invoiceNumber: "F-2026-0001", ocrReference: OCR,
+        amount: 10_000, payments: [],
+        matter: { id: "m1", matterNumber: "2026-0001", title: "T" },
+      },
+    ],
+    total: 1,
+  },
   isLoading: false,
 };
 

--- a/test/unit/app/sie-export-button.test.tsx
+++ b/test/unit/app/sie-export-button.test.tsx
@@ -17,11 +17,15 @@ vi.mock("@/lib/client/trpc", () => ({
   trpc: {
     invoice: {
       list: {
+        // Kuvertform sedan #1014 — knappen läser `data.items`.
         useQuery: () => ({
-          data: [
-            { amount: 12_500, invoiceDate: "2026-05-25", invoiceNumber: "F-2026-0042", status: "SENT" },
-            { amount: 9_999, invoiceDate: "2026-05-01", invoiceNumber: "F-1", status: "DRAFT" },
-          ],
+          data: {
+            items: [
+              { amount: 12_500, invoiceDate: "2026-05-25", invoiceNumber: "F-2026-0042", status: "SENT" },
+              { amount: 9_999, invoiceDate: "2026-05-01", invoiceNumber: "F-1", status: "DRAFT" },
+            ],
+            total: 2,
+          },
         }),
       },
     },

--- a/test/unit/ava-cli/tool-outputs.test.ts
+++ b/test/unit/ava-cli/tool-outputs.test.ts
@@ -24,8 +24,11 @@ describe("svarskontraktens register", () => {
   it("läse-ytan är täckt", () => {
     // Scope-beslutet i #1012: listor + getById + user.current med OBJEKT-svar.
     // Krymper listan har någon tagit bort ett kontrakt — det ska synas här.
+    // #1014 lade till de tre som tidigare returnerade nakna arrayer och därför
+    // inte KUNDE bära kontrakt (MCP kräver objekt på toppnivån).
     expect([...outputDescribedPaths()].sort()).toEqual([
-      "contacts.list", "matter.getById", "matter.list", "reports.firmOverview", "timeEntry.list", "user.current", "user.list",
+      "contacts.list", "invoice.list", "matter.getById", "matter.list", "paymentPlan.list",
+      "reports.firmOverview", "task.list", "timeEntry.list", "user.current", "user.list",
     ]);
   });
 

--- a/test/unit/ava-cli/tool-projections.test.ts
+++ b/test/unit/ava-cli/tool-projections.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Fältprojektionen för MCP-ytans listverktyg (#1014).
+ *
+ * Poängen med tillåtlistan är att ett nytt join-fält i routern INTE ska läcka
+ * ut i modellens svar och tyst äta budgeten. Testerna vaktar båda riktningarna:
+ * att det som projiceras bort faktiskt försvinner, och att det svarskontrakten
+ * utlovar finns kvar (ett bortprojicerat kontraktsfält fäller anropet, eftersom
+ * SDK:n validerar `structuredContent` mot schemat).
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import { projectToolResult, projectedPaths, projectionFor } from "../../../tooling/ava-cli/tool-projections";
+
+describe("projectToolResult", () => {
+  it("behåller de vitlistade fälten och släpper join-fälten", () => {
+    const res = projectToolResult("invoice.list", {
+      items: [{
+        id: "inv-1", invoiceNumber: "F-2026-0001", status: "SENT", amount: 1000,
+        matter: { id: "m-1", title: "Ett långt ärende", contacts: [{ id: "c-1" }] },
+        creditedInvoice: { id: "inv-0", amount: 500 },
+      }],
+      total: 42,
+    }) as { items: Record<string, unknown>[]; total: number };
+
+    expect(Object.keys(res.items[0]!).sort()).toEqual(["amount", "id", "invoiceNumber", "status"]);
+    expect(res.items[0]).not.toHaveProperty("matter");
+    expect(res.items[0]).not.toHaveProperty("creditedInvoice");
+  });
+
+  it("rör inte kuvertets övriga fält — `total` är hela poängen", () => {
+    const res = projectToolResult("invoice.list", { items: [], total: 42 }) as { total: number };
+    expect(res.total).toBe(42);
+  });
+
+  it("bevarar extra kuvertfält (pages, totalAmount)", () => {
+    const res = projectToolResult("expense.list", {
+      expenses: [{ id: "e-1", amount: 5, matter: { title: "X" } }],
+      total: 3, totalAmount: 15, pages: 1,
+    }) as Record<string, unknown>;
+    expect({ total: res.total, totalAmount: res.totalAmount, pages: res.pages })
+      .toEqual({ total: 3, totalAmount: 15, pages: 1 });
+  });
+
+  it("läser rätt array-nyckel för de äldre kuvertlistorna", () => {
+    const res = projectToolResult("matter.list", {
+      matters: [{ id: "m-1", matterNumber: "2026-0001", title: "T", status: "ACTIVE", paymentMethod: "PRIVAT", contacts: [1, 2, 3] }],
+      total: 1,
+    }) as { matters: Record<string, unknown>[] };
+    expect(res.matters[0]).not.toHaveProperty("contacts");
+    expect(res.matters[0]?.matterNumber).toBe("2026-0001");
+  });
+
+  it("saknade fält utelämnas i stället för att null:as", () => {
+    // En null-rad ljuger: den påstår att fältet finns och är tomt.
+    const res = projectToolResult("task.list", { items: [{ id: "t-1" }], total: 1 }) as { items: Record<string, unknown>[] };
+    expect(res.items[0]).toEqual({ id: "t-1" });
+  });
+
+  it("passerar okända paths orörda", () => {
+    const data = { anything: [{ deep: { nested: true } }] };
+    expect(projectToolResult("matter.getById", data)).toBe(data);
+  });
+
+  it("passerar svar där nyckeln inte bär en array", () => {
+    const data = { items: "inte en array", total: 0 };
+    expect(projectToolResult("invoice.list", data)).toBe(data);
+  });
+
+  it("klarar null och primitiver utan att kasta", () => {
+    expect(projectToolResult("invoice.list", null)).toBeNull();
+    expect(projectToolResult("invoice.list", 5)).toBe(5);
+  });
+});
+
+describe("projektionerna och svarskontrakten hänger ihop", () => {
+  // Kontrakten valideras mot `structuredContent`; projiceras ett utlovat fält
+  // bort fäller anropet. Paren hålls därför ihop här i st.f. i två filer.
+  const CONTRACT_FIELDS: Readonly<Record<string, readonly string[]>> = {
+    "invoice.list": ["id", "invoiceNumber", "status", "amount", "matterId"],
+    "task.list": ["id", "title", "status"],
+    "paymentPlan.list": ["id", "invoiceId", "status"],
+    "matter.list": ["id", "matterNumber", "title", "status", "paymentMethod"],
+    "timeEntry.list": ["id", "matterId", "date", "minutes", "description", "billable"],
+  };
+
+  for (const [path, required] of Object.entries(CONTRACT_FIELDS)) {
+    it(`${path} projicerar inte bort sitt kontraktsfält`, () => {
+      const fields = projectionFor(path)?.fields;
+      expect(fields, `${path} saknar projektion`).toBeDefined();
+      for (const f of required) expect(fields, `${path}.${f}`).toContain(f);
+    });
+  }
+
+  it("alla projicerade paths är listverktyg", () => {
+    for (const p of projectedPaths()) expect(p).toMatch(/\.list$/);
+  });
+});

--- a/test/unit/server/routers/billingRun.test.ts
+++ b/test/unit/server/routers/billingRun.test.ts
@@ -569,7 +569,7 @@ describe("billingRun.settleCoverage — bokför prutnings-uppdelningen (#801)", 
     expect(res.payerInvoice.vatOre).toBe((settled.payerInvoice.vatOre ?? 0) - 25_000);
     expect(res.clientInvoice.vatOre).toBe((settled.clientInvoice.vatOre ?? 0) + 25_000);
     // Ingen ny faktura, och absolut ingen CREDIT mot försäkringsbolaget.
-    const invoices = await c.invoice.list({ matterId: "m-1" });
+    const { items: invoices } = await c.invoice.list({ matterId: "m-1" });
     expect(invoices.filter((i) => i.invoiceType === "CREDIT")).toHaveLength(0);
     expect(res.payerInvoice.id).toBe(settled.payerInvoice.id); // samma faktura, uppdaterad
     expect(res.clientInvoice.id).toBe(settled.clientInvoice.id);

--- a/test/unit/server/routers/paymentPlan.test.ts
+++ b/test/unit/server/routers/paymentPlan.test.ts
@@ -82,7 +82,7 @@ describe("paymentPlan.list", () => {
       ],
       paymentPlans: [plan(), plan({ id: "pp-2", invoiceId: "inv-2" })],
     });
-    expect(await caller.list({})).toHaveLength(2);
+    expect((await caller.list({})).items).toHaveLength(2);
   });
 
   it("filtrerar på status när angivet", async () => {
@@ -94,18 +94,18 @@ describe("paymentPlan.list", () => {
       paymentPlans: [plan(), plan({ id: "pp-2", invoiceId: "inv-2", status: "COMPLETED" })],
     });
     const res = await caller.list({ status: "COMPLETED" });
-    expect(res.map((p) => p.id)).toEqual(["pp-2"]);
+    expect(res.items.map((p) => p.id)).toEqual(["pp-2"]);
   });
 
   it("söker i ärendenr/titel/klient/anteckningar (planHaystack)", async () => {
     const { caller } = makeCaller({ paymentPlans: [plan()] });
-    expect(await caller.list({ search: "lindström" })).toHaveLength(1); // matchar matter-titel
-    expect(await caller.list({ search: "saknas-helt" })).toHaveLength(0);
+    expect((await caller.list({ search: "lindström" })).items).toHaveLength(1); // matchar matter-titel
+    expect((await caller.list({ search: "saknas-helt" })).items).toHaveLength(0);
   });
 
   it("matchar på klientnamn", async () => {
     const { caller } = makeCaller({ paymentPlans: [plan()] });
-    expect(await caller.list({ search: "andersson" })).toHaveLength(1);
+    expect((await caller.list({ search: "andersson" })).items).toHaveLength(1);
   });
 });
 

--- a/tooling/ava-cli/mcp.ts
+++ b/tooling/ava-cli/mcp.ts
@@ -18,6 +18,7 @@ import type { AvaCaller } from "./caller";
 import type { ProcedureInfo, ProcedureType } from "./introspect";
 import { toolDescription, withPageSizeDefault } from "./tool-descriptions";
 import { toolOutputJsonSchema } from "./tool-outputs";
+import { projectToolResult } from "./tool-projections";
 
 export const MCP_SERVER_NAME = "ava";
 export const MCP_SERVER_VERSION = "0.2.0";
@@ -87,7 +88,11 @@ export async function executeToolCall(
   opts: { structured?: boolean } = {},
 ): Promise<McpToolResult> {
   try {
-    const data = await caller.invoke(pathFromTool(name), args ?? {});
+    const path = pathFromTool(name);
+    // Projektionen (#1014) sitter HÄR och inte i routern: listraderna är
+    // join-tunga för att UI:t behöver dem så, medan modellen betalar för varje
+    // fält den inte bad om. Detaljer hämtas via `getById`.
+    const data = projectToolResult(path, await caller.invoke(path, args ?? {}));
     return toolResult(data, opts.structured === true);
   } catch (err) {
     return { content: [{ type: "text", text: err instanceof Error ? err.message : String(err) }], isError: true };

--- a/tooling/ava-cli/tool-outputs.ts
+++ b/tooling/ava-cli/tool-outputs.ts
@@ -13,9 +13,11 @@
  * inte allt som råkar finnas. `dateish` speglar att runtime-värdet är ett
  * `Date` som JSON-serialiseras till ISO-sträng.
  *
- * Scope: läse-ytan med OBJEKT-svar. `invoice.list`/`task.list` returnerar
- * arrayer, och MCP:s `outputSchema` kräver ett objekt på toppnivån — de får
- * sina kontrakt den dag listorna byter till kuvertform ({ items, total }, #1014).
+ * Scope: läse-ytan med OBJEKT-svar — vilket sedan #1014 är alla listor:
+ * `invoice.list`, `task.list` och `paymentPlan.list` bär kuvertform
+ * (`{ items, total }`) och kunde därmed få sina kontrakt. Deras `items` speglar
+ * den PROJICERADE raden (`tool-projections.ts`), inte routerns fulla rad — det
+ * är den formen modellen faktiskt får.
  */
 
 import { z } from "zod";
@@ -60,6 +62,26 @@ const TOOL_OUTPUTS: Readonly<Record<string, z.ZodType>> = {
     contacts: z.array(z.looseObject({ id: z.string(), name: z.string(), contactType: z.string() })),
     total: z.number(),
     pages: z.number(),
+  }),
+  // Kuvertlistorna (#1014). `total` är antalet FÖRE sidningen — utan det kan
+  // modellen inte skilja "tio fakturor" från "första sidan av hundra".
+  "invoice.list": z.looseObject({
+    items: z.array(z.looseObject({
+      id: z.string(),
+      invoiceNumber: z.string(),
+      status: z.string(),
+      amount: z.number(),
+      matterId: z.string(),
+    })),
+    total: z.number(),
+  }),
+  "task.list": z.looseObject({
+    items: z.array(z.looseObject({ id: z.string(), title: z.string(), status: z.string() })),
+    total: z.number(),
+  }),
+  "paymentPlan.list": z.looseObject({
+    items: z.array(z.looseObject({ id: z.string(), invoiceId: z.string(), status: z.string() })),
+    total: z.number(),
   }),
   "user.current": userRow,
   "user.list": z.looseObject({ users: z.array(userRow) }),

--- a/tooling/ava-cli/tool-projections.ts
+++ b/tooling/ava-cli/tool-projections.ts
@@ -1,0 +1,106 @@
+/**
+ * `tool-projections` — smala listrader för MCP-ytan (#1014).
+ *
+ * ## Varför bara här
+ *
+ * Listraderna är join-tunga för att UI:t behöver dem så: fakturalistan visar
+ * ärendets titel, planens status och betalningarna utan ett andra anrop. För
+ * en modell är samma join ren kostnad — en fakturarad på 2 292 tecken bestod
+ * till 74 % av två inbäddade objekt (`creditedInvoice` 1 086, `matter` 608),
+ * medan fakturans egna fält rymdes på ~600.
+ *
+ * Projektionen ligger därför på MCP-lagret och INTE i routern: UI:t behåller
+ * sina fält, AI:n får en rad den kan lista hundra av. Detaljerna hämtas med
+ * `getById`, som verktygsbeskrivningen påminner om.
+ *
+ * ## Varför en tillåtlista och inte en blocklista
+ *
+ * En blocklista ("ta bort `matter`, `creditedInvoice`, …") släpper igenom
+ * varje nytt join-fält som läggs till i routern, och budget-regressionen
+ * märks först när någon råkar mäta. Tillåtlistan gör det omvända felet: ett
+ * nytt fält syns inte för modellen förrän någon lägger till det här — vilket
+ * upptäcks direkt, av den som saknar fältet.
+ */
+
+/** Var raderna bor i svaret + vilka fält som behålls. */
+export interface ListProjection {
+  /** Kuvertets array-nyckel: `items` sedan #1014, domännamn i de äldre. */
+  key: string;
+  /** Fält som behålls per rad. Övriga hämtas via `getById`. */
+  fields: readonly string[];
+}
+
+/**
+ * Projicerade listverktyg. Fältlistorna måste rymma det svarskontraktet i
+ * `tool-outputs.ts` utlovar — kontraktet valideras mot `structuredContent`,
+ * så ett bortprojicerat kontraktsfält fäller anropet.
+ *
+ * `contacts.list` står medvetet utanför: dess rader är redan smala (id, namn,
+ * typ) och varje projektion är ett åtagande att hålla tillåtlistan aktuell.
+ */
+const LIST_PROJECTIONS: Readonly<Record<string, ListProjection>> = {
+  "invoice.list": {
+    key: "items",
+    fields: ["id", "invoiceNumber", "invoiceType", "status", "amount", "vatOre",
+      "matterId", "issuedAt", "dueAt", "paidAt", "ocrReference"],
+  },
+  "task.list": {
+    key: "items",
+    fields: ["id", "title", "status", "priority", "dueAt", "matterId", "assignedToId"],
+  },
+  "paymentPlan.list": {
+    key: "items",
+    fields: ["id", "invoiceId", "status", "monthlyAmount", "dayOfMonth", "startDate", "notes"],
+  },
+  // De två äldre kuvertlistorna bär sina rader under domännamn. `contacts`
+  // (1 103 tecken/rad) resp. `matter` + `user` (849) dominerade dem helt.
+  "matter.list": {
+    key: "matters",
+    fields: ["id", "matterNumber", "title", "status", "paymentMethod", "matterType",
+      "isTaxeArende", "createdAt"],
+  },
+  "timeEntry.list": {
+    key: "entries",
+    fields: ["id", "matterId", "userId", "date", "minutes", "description",
+      "billable", "hourlyRate", "kind", "invoiceId"],
+  },
+  "expense.list": {
+    key: "expenses",
+    fields: ["id", "matterId", "userId", "date", "description", "amount",
+      "billable", "vatRate", "vatIncluded", "kind", "invoiceId"],
+  },
+};
+
+/** Paths med projektion — integrationstesterna läser den här. */
+export function projectedPaths(): readonly string[] {
+  return Object.keys(LIST_PROJECTIONS);
+}
+
+/** Projektionen för ett listverktyg, eller null om ingen finns. */
+export function projectionFor(path: string): ListProjection | null {
+  return LIST_PROJECTIONS[path] ?? null;
+}
+
+/** Behåll de vitlistade nycklarna. Saknade fält utelämnas (inte null:as) —
+ *  `undefined` försvinner ändå i JSON, och en null-rad ljuger om innehåll. */
+function pickFields(row: unknown, fields: readonly string[]): unknown {
+  if (row === null || typeof row !== "object" || Array.isArray(row)) return row;
+  const src = row as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const f of fields) if (f in src) out[f] = src[f];
+  return out;
+}
+
+/**
+ * Projicera ett listverktygs kuvert-svar. Okända paths, och svar där nyckeln
+ * inte bär en array, passerar orörda — så funktionen kan läggas i varje
+ * verktygsväg utan att förändra något annat.
+ */
+export function projectToolResult(path: string, data: unknown): unknown {
+  const projection = projectionFor(path);
+  if (projection === null || data === null || typeof data !== "object") return data;
+  const env = data as Record<string, unknown>;
+  const rows = env[projection.key];
+  if (!Array.isArray(rows)) return data;
+  return { ...env, [projection.key]: rows.map((row) => pickFields(row, projection.fields)) };
+}

--- a/tooling/demo-generator/populate-invoice-docs.ts
+++ b/tooling/demo-generator/populate-invoice-docs.ts
@@ -93,7 +93,8 @@ async function renderDoc(c: Any, inv: Any, l: DocLookups): Promise<string> {
 
 export async function populateInvoiceDocs(caller: GeneratorCaller, sink?: BinarySink, idFor?: InvoiceDocIdFn): Promise<number> {
   const c = caller as Any;
-  const invoices: Any[] = await c.invoice.list({});
+  // Kuvertform sedan #1014 — raderna bor under `items`.
+  const { items: invoices } = (await c.invoice.list({})) as { items: Any[] };
   const lookups = await loadLookups(c);
   // Fakturadokumenten filas som allt annat (#985) — utan mapp hade 46 av demons
   // 121 dokument legat kvar i roten och trädet sett halvsorterat ut.


### PR DESCRIPTION
Closes #1014.

Två skilda problem, lösta på var sitt lager — det var den viktigaste designfrågan i issuen ("besluta nivå").

## Kuvertform → routern (inte MCP-lagret)

Issuen föreslog att lägga kuvertet enbart på MCP-lagret för att slippa röra routrarna. **Det går inte att göra ärligt:** `pageSlice` kastar bort antalet före snittet, så ett `total` beräknat på MCP-lagret hade blivit sidans längd — exakt den lögn issuen ville bort från ("efter sidningen kan den inte veta om 10 rader är allt eller en sida").

Därför `pageEnvelope` i routern. Det gör dessutom de tre lika sina fyra syskon: `matter.list`, `timeEntry.list`, `contacts.list` och `expense.list` bar redan kuvert med `total` — de tre array-listorna var undantagen, inte normen. Sju anropsplatser i UI:t följde med.

Nyckelnamnet blev `{ items, total }` enligt issuens ordalydelse. De äldre listorna behåller sina domännamn (`matters`, `entries`, …), så ytan är inte enhetlig ännu — säg till om du vill att jag lägger upp en uppföljning som förenar dem.

## Fältprojektion → MCP-lagret (inte routern)

Raderna är join-tunga **för att UI:t behöver dem så**. 74 % av en fakturarad (2 292 tecken) var `creditedInvoice` (1 086) + `matter` (608), medan fakturans egna fält rymdes på ~600. Projektionen ligger därför på MCP-lagret och rör inte routern: UI:t behåller sina fält, modellen får en rad den kan lista hundra av, detaljer via `getById`.

**Tillåtlista, inte blocklista** — motivet står i `tool-projections.ts`: en blocklista släpper igenom varje nytt join-fält som läggs till senare, och regressionen märks först när någon råkar mäta. Tillåtlistan gör det omvända felet, som upptäcks direkt av den som saknar fältet.

## Mätt på demo-seeden

| Verktyg | Före | Efter | |
|---|---:|---:|---:|
| `invoice.list` | 26 010 | 3 163 | −88 % |
| `paymentPlan.list` | 20 836 | 1 548 | −93 % |
| `task.list` | 9 603 | 2 192 | −77 % |
| `matter.list` | 27 122 | ~2 800 | −90 % |
| `expense.list` | 17 221 | 3 139 | −82 % |

`matter.list`, `timeEntry.list` och `expense.list` var inte i issuens uppräkning, men de blev taket så fort de tre namngivna krympt — och sista checkrutan (sänk budgeten) går inte att uppfylla utan dem.

**Utdatabudgeten**: taket faller 26 010 → **6 795** (nu `calendar.list`), och `OUTPUT_BUDGET_CHARS` dras **38 000 → 10 000** med marginal för att seeden ska kunna växa. `calendar.list` är den nya ettan och är osidad — värd en egen titt om budgeten ska ner mer.

## Svarskontrakt

De tre listorna fick sina kontrakt i `tool-outputs.ts` — de kunde inte ha några tidigare, eftersom MCP kräver objekt på toppnivån. Ett nytt test håller ihop projektion och kontrakt i samma fil: projiceras ett utlovat fält bort fäller anropet (SDK:n validerar `structuredContent` mot schemat), så paren får inte glida isär.

## En cast som dolde tre trasiga anropsplatser

`invoices/page`, `payment-plans/page` och `_sie-export-button` läste listan genom `as InvoiceRow[]`/`as PlanRow[]`. Casten tystade typcheckaren, så breakage:n dök upp i **demo-e2e:n** i stället för i kompilatorn. Rättade — och det är en illustration av varför `as` är dyrt i just den här kodbasen.

`BillingPanel` slog i komplexitetstaket (9 > 8) av kuvertets `?.`; utbruten till en `useStandaloneInvoices`-hook i stället för att röra gränsen.

## Verifierat lokalt

typecheck ✅ · lint ✅ · `deps:check` ✅ (1 136 moduler) · knip ✅ · `build:demo` ✅ · `size` ✅ (34,6 %) · `e2e:demo` ✅ **33/33** · berörda testfiler per fil ✅ (11 filer, inkl. 14 nya enhetstester + 4 nya integrationstester). Det fulla parallell-passet timeoutar i containern även på oförändrad main — CI verifierar coverage-golven, inklusive AI-ytans nya golv från #1027.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_