### PR TITLE
ci(quality): dra åt AI-ytans coverage-golv mot uppmätt — 93,0/88,0 → 95,0/92,0

### DIFF
--- a/docs/quality.md
+++ b/docs/quality.md
@@ -83,12 +83,15 @@ AI-ytan tappa sin täckning utan att totalen rörde sig mätbart.
 | Område | Golv rader | Golv funktioner | Faktisk (lcov, --parallel) |
 |---|---|---|---|
 | `src/` | 90.0 % | 85.9 % | ~90.7 % / ~87.5 % |
-| `tooling/ava-cli/` (CLI + MCP) | 93.0 % | 88.0 % | 95.6 % / 93.1 % (enprocess) |
+| `tooling/ava-cli/` (CLI + MCP) | 95.0 % | 92.0 % | 96.1 % / 93.7 % |
 
-AI-ytans golv är ankrat under uppmätt med avsikt: siffran ovan är mätt
-enprocess, medan grinden kör pass A med `--parallel` (som underrapporterar,
-se OBS 2) — och med bara 58 funktioner är EN funktion 1,7 procentenheter.
-Dras åt mot den faktiska `--parallel`-siffran när den syns i CI-loggen.
+AI-ytans golv ankrades först konservativt (93,0/88,0) eftersom det var okänt
+hur mycket pass A:s `--parallel` underrapporterar (OBS 2). Nu är det mätt: CI
+rapporterade **exakt** samma siffra som en enprocess-körning för det området
+(#1027) — underrapporteringen gäller inte en yta vars tester laddar samma
+moduler i samma worker. Golven är därför åtdragna mot uppmätt. Kvarvarande
+marginal är kvantiseringen: 63 funktioner betyder att EN funktion är 1,6
+procentenheter, och funktions-golvet lämnar plats för exakt en.
 
 Coverage-rapporten skrivs till `coverage/` (lcov). `helper-ui` har en egen
 coverage-ratchet i [`helper-ui/bunfig.toml`](../helper-ui/bunfig.toml)

--- a/test/scripts/coverage-scopes.test.ts
+++ b/test/scripts/coverage-scopes.test.ts
@@ -72,7 +72,7 @@ describe("golven är ratchets", () => {
   // glider igenom för att få en röd körning grön (AGENTS.md: gates only tighten).
   const FLOOR_BASELINE: Readonly<Record<string, { line: number; func: number }>> = {
     "src/": { line: 0.900, func: 0.859 },
-    "tooling/ava-cli/": { line: 0.930, func: 0.880 },
+    "tooling/ava-cli/": { line: 0.950, func: 0.920 },
   };
 
   for (const [label, base] of Object.entries(FLOOR_BASELINE)) {

--- a/tooling/scripts/run-tests.ts
+++ b/tooling/scripts/run-tests.ts
@@ -143,20 +143,21 @@ const FUNC_FLOOR = 0.859;
  * så en total-siffra skulle dränka den — hela AI-ytan kan tappa sin täckning
  * utan att den gemensamma procenten rör sig mätbart. Två skalor, två golv.
  *
- * Uppmätt enprocess: 95,58 % rader / 93,10 % funktioner (519/543, 54/58).
- * Golven ankras MEDVETET lägre än så, av två skäl:
+ * Uppmätt: **96,07 % rader / 93,65 % funktioner** (586/610, 59/63).
  *
- *   1. Grinden kör pass A med `--parallel`, som underrapporterar täckning
- *      något (bun aggregerar löst över workers — se OBS 2 i docs/quality.md).
- *      Den siffran är inte känd förrän grinden kört skarpt.
- *   2. Ytan har bara 58 funktioner → EN funktion är 1,7 procentenheter. Ett
- *      snävt golv hade fällt på kvantiseringen i st.f. på en regression.
+ * Golven sattes först konservativt (93,0/88,0) därför att grinden kör pass A
+ * med `--parallel`, som underrapporterar täckning något (OBS 2 i
+ * docs/quality.md) — hur mycket var okänt innan grinden kört skarpt. Nu är det
+ * mätt: CI rapporterade EXAKT samma siffra som en enprocess-körning för det
+ * här området (#1027, körning 32039590050). Underrapporteringen gäller alltså
+ * inte en yta där testerna laddar samma moduler i samma worker.
  *
- * Dras åt mot den faktiska `--parallel`-siffran när den syns i CI-loggen —
- * ratchet:en flyttas bara uppåt, aldrig ned (AGENTS.md).
+ * Därmed dras golven åt mot uppmätt. Kvarvarande marginal är kvantiseringen:
+ * ytan har 63 funktioner, så EN funktion är 1,6 procentenheter — funktions-
+ * golvet lämnar plats för exakt en, inte fler. Ratchet:en flyttas bara uppåt.
  */
-const AI_LINE_FLOOR = 0.930;
-const AI_FUNC_FLOOR = 0.880;
+const AI_LINE_FLOOR = 0.950;
+const AI_FUNC_FLOOR = 0.920;
 
 /**
  * SERIAL_FILES — testfiler som SYNKRONT spawnar en barnprocess via


### PR DESCRIPTION
Uppföljning på #1025 (PR #1027), som ankrade AI-ytans golv konservativt och lämnade åtdragningen till mätdata.

## Vad ankringen skyddade mot — och varför den kan tas bort

`docs/quality.md` OBS 2 säger att pass A:s `--parallel` underrapporterar täckning något. Hur mycket var okänt, så #1027 satte golven på 93,0/88,0 trots att enprocess-mätningen visade 95,58/93,10 — jag ville inte att den första skarpa körningen skulle fälla på mätmetoden i stället för på kvalitet.

Nu finns siffran. CI-körning `32039590050` rapporterade:

```
Coverage (tooling/ava-cli/): rader 95.58% (golv 93.00%), funktioner 93.10% (golv 88.00%)
```

**Exakt** samma som enprocess. Underrapporteringen gäller alltså inte ett område vars tester laddar samma moduler i samma worker — och marginalen som ankringen köpte behövs inte.

## Ny nivå

Efter #1014 ligger ytan på **96,07 % rader / 93,65 % funktioner** (586/610, 59/63) — `tool-projections.ts` kom in till 100 %.

| | Golv före | Golv nu | Uppmätt |
|---|---:|---:|---:|
| Rader | 93,0 % | **95,0 %** | 96,07 % |
| Funktioner | 88,0 % | **92,0 %** | 93,65 % |

Kvarvarande marginal är **kvantisering, inte mätosäkerhet**: 63 funktioner betyder att EN funktion är 1,6 procentenheter, så funktions-golvet lämnar plats för exakt en och inte fler. Rad-golvet har ~6 raders slack.

Ratchet-vakten i `test/scripts/coverage-scopes.test.ts` uppdateras i samma veva — den jämför mot en baslinje just för att en *sänkning* ska kräva ett medvetet beslut, så baslinjen måste följa med uppåt när golvet gör det.

## Verifierat

typecheck ✅ · lint ✅ · `coverage-scopes.test.ts` ✅ (8/8) · mätningen ovan gjord med samma metod som gav CI:s exakta siffra förra gången (95 tester över ava-cli-filerna + MCP-integrationssviten).

Ingen produktionskod rörd — bara golv, ratchet-baslinje och dokumentation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_