### PR TITLE
feat(ledger): drivrutin faktura → verifikat + e2e mot riktiga Fortnox

### DIFF
--- a/.github/workflows/fortnox-e2e.yml
+++ b/.github/workflows/fortnox-e2e.yml
@@ -1,0 +1,82 @@
+name: Fortnox E2E (manuell)
+
+# E2E mot RIKTIGA Fortnox Voucher API (#1030).
+#
+# ## Varför manuell och inte i CI-matrisen
+#
+# Varje körning skapar ett verifikat i Fortnox som INTE går att ta tillbaka.
+# Att köra den på varje PR skulle bränna verifikatnummer i en riktig bokföring.
+# Kör den när connector-koden ändras, före release, eller när du vill veta att
+# anslutningen fortfarande lever.
+#
+# ## Roterande refresh-token — läs det här innan du felsöker
+#
+# Fortnox ogiltigförklarar den gamla refresh-token:en vid VARJE refresh. Ett
+# token i en secret räcker därför till EN körning om vi inte skriver tillbaka
+# det nya. Jobbet gör det (steget "Spara roterad refresh-token"), och det körs
+# med `if: always()` eftersom token:en roterar redan i första anropet — även om
+# verifikat-pushen senare fallerar är den gamla token:en död.
+#
+# Går write-back:en fel måste du göra om consent-rundan manuellt:
+#   1. bun -e 'console.log(buildAuthorizeUrl(config, "state"))' → öppna i browser
+#   2. godkänn → kopiera ?code= ur redirecten
+#   3. exchangeCodeForTokens(config, code) → spara refresh_token i secreten
+# Se src/lib/server/integrations/fortnox/README.md och docs/fortnox-e2e.md.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Bara auth + anslutningskoll (skapar INGET verifikat)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+# Aldrig två samtidiga körningar: de skulle refresha parallellt och slå ut
+# varandras tokens (den ena rotationen ogiltigförklarar den andras).
+concurrency:
+  group: fortnox-e2e
+  cancel-in-progress: false
+
+jobs:
+  fortnox-e2e:
+    name: Fortnox E2E (sandbox)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: fortnox-sandbox
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ./.github/actions/bun-setup
+
+      - name: Kör Fortnox-E2E
+        id: e2e
+        env:
+          AVA_FORTNOX_CLIENT_ID: ${{ secrets.AVA_FORTNOX_CLIENT_ID }}
+          AVA_FORTNOX_CLIENT_SECRET: ${{ secrets.AVA_FORTNOX_CLIENT_SECRET }}
+          AVA_FORTNOX_REFRESH_TOKEN: ${{ secrets.AVA_FORTNOX_REFRESH_TOKEN }}
+          AVA_FORTNOX_VOUCHER_SERIES: ${{ vars.AVA_FORTNOX_VOUCHER_SERIES }}
+          AVA_FORTNOX_KONTO_KUNDFORDRAN: ${{ vars.AVA_FORTNOX_KONTO_KUNDFORDRAN }}
+          AVA_FORTNOX_KONTO_ARVODE: ${{ vars.AVA_FORTNOX_KONTO_ARVODE }}
+          AVA_FORTNOX_KONTO_MOMS: ${{ vars.AVA_FORTNOX_KONTO_MOMS }}
+          AVA_FORTNOX_DRY_RUN: ${{ inputs.dry_run && '1' || '' }}
+        run: bun tooling/scripts/fortnox-e2e.ts
+
+      # Måste köras även när e2e:t fallerade: token:en roterade i det FÖRSTA
+      # anropet, så den gamla är död oavsett hur körningen slutade. Hoppar över
+      # sig själv om scriptet inte hann emitta något (t.ex. saknad secret).
+      - name: Spara roterad refresh-token
+        if: always() && steps.e2e.outputs.refresh_token != ''
+        env:
+          GH_TOKEN: ${{ secrets.AVA_FORTNOX_ROTATE_PAT }}
+          NEW_TOKEN: ${{ steps.e2e.outputs.refresh_token }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::AVA_FORTNOX_ROTATE_PAT saknas — den roterade token:en kan inte sparas."
+            echo "::error::Nästa körning kommer att misslyckas. Uppdatera AVA_FORTNOX_REFRESH_TOKEN manuellt."
+            exit 1
+          fi
+          printf '%s' "$NEW_TOKEN" | gh secret set AVA_FORTNOX_REFRESH_TOKEN \
+            --repo "${{ github.repository }}" --env fortnox-sandbox --body -
+          echo "✓ AVA_FORTNOX_REFRESH_TOKEN uppdaterad med den roterade token:en."

--- a/docs/fortnox-e2e.md
+++ b/docs/fortnox-e2e.md
@@ -1,0 +1,82 @@
+# Fortnox-E2E — köra mot riktiga Voucher API
+
+Enhetstesterna för connectorn kör med injicerad `fetch` och bevisar att VÅR kod
+är konsekvent. De kan inte upptäcka att Fortnox ändrat sig. Det här flödet går
+hela vägen: OAuth-refresh → semantiskt verifikat → `POST /3/vouchers` → läs
+tillbaka verifikatet → kontrollera balans och idempotens.
+
+Kör: **Actions → “Fortnox E2E (manuell)” → Run workflow**.
+Lokalt: `bun tooling/scripts/fortnox-e2e.ts` med env satt (se nedan).
+
+## Varför den inte ligger i PR-matrisen
+
+Varje körning skapar ett verifikat som **inte går att ta tillbaka**. En grind
+som bränner verifikatnummer på varje PR vore fel sorts grind. Kör den när
+connectorn ändras, före release, eller för att bekräfta att anslutningen lever.
+
+`dry_run`-inputen kör allt utom själva pushen — bra för att bara verifiera att
+tokens fortfarande fungerar.
+
+## Secrets och variabler
+
+Ligger på environment **`fortnox-sandbox`** (Settings → Environments), inte som
+repo-secrets — så åtkomsten kan begränsas separat.
+
+| Secret | Vad |
+|---|---|
+| `AVA_FORTNOX_CLIENT_ID` | ur Developer Portal |
+| `AVA_FORTNOX_CLIENT_SECRET` | ur Developer Portal |
+| `AVA_FORTNOX_REFRESH_TOKEN` | från consent-rundan — **roterar vid varje körning**, se nedan |
+| `AVA_FORTNOX_ROTATE_PAT` | PAT med `secrets: write` på repot, så jobbet kan spara den roterade token:en |
+
+| Variable (`vars`) | Default | Vad |
+|---|---|---|
+| `AVA_FORTNOX_VOUCHER_SERIES` | `A` | verifikatserie |
+| `AVA_FORTNOX_KONTO_KUNDFORDRAN` | `1510` | kundfordran (debet) |
+| `AVA_FORTNOX_KONTO_ARVODE` | `3041` | arvodesintäkt (kredit) |
+| `AVA_FORTNOX_KONTO_MOMS` | `2611` | utgående moms 25 % (kredit) |
+
+Kontona är ett **bokföringsbeslut per byrå** — defaults är BAS-standard och
+ingen rekommendation.
+
+## Det roterande refresh-token:et
+
+Fortnox ogiltigförklarar den gamla refresh-token:en vid varje refresh
+(access-token 1 h, refresh-token 45 dygn). Konsekvensen är kontraintuitiv:
+
+> Ett refresh-token i en secret räcker till **exakt en körning** om inte det nya
+> skrivs tillbaka.
+
+Därför emitterar scriptet den roterade token:en till `GITHUB_OUTPUT` **direkt
+efter första anropet**, före allt som kan fela, och workflow:et sparar den med
+`if: always()`. Token:en skrivs aldrig till stdout.
+
+Saknas `AVA_FORTNOX_ROTATE_PAT` fäller jobbet med ett tydligt fel — hellre det
+än en tyst död token som visar sig först vid nästa körning.
+
+## När token:en dött ändå
+
+Refresh-token:en dör efter 45 dygn utan användning, och en misslyckad
+write-back får samma effekt. Då krävs en ny consent-runda — den kan inte
+automatiseras, eftersom den kräver en människa som godkänner i Fortnox:
+
+1. Bygg authorize-URL:en med `buildAuthorizeUrl(config, state)`
+   (`src/lib/server/integrations/fortnox/oauth.ts`) och öppna den i en browser.
+2. Godkänn med ett konto som har rätt i den aktuella tenanten.
+3. Kopiera `?code=…` ur redirecten.
+4. `exchangeCodeForTokens(config, code)` → spara `refreshToken` i secreten.
+
+Modellen är **user-consent** (ingen `account_type`) — det är det flöde som
+verifierats mot sandbox. Service-konto är opt-in, se connector-README:n och
+[#213](https://github.com/ulrik-s/ava/issues/213).
+
+## Kända begränsningar
+
+- **Går inte att köra från Claude Code-containern.** `bun`:s `fetch` når inte
+  igenom containerns proxy till Fortnox (`socket connection was closed
+  unexpectedly`) medan `curl` gör det. GitHub-runnern har ingen sådan proxy.
+- **Testfakturan är syntetisk** (125,00 kr inkl moms, `E2E-<tidsstämpel>`) och
+  byggs i minnet. Det som testas är ledger-vägen, inte repo-lagret — det har
+  egna tester.
+- **Bilagor (#785) täcks inte** av e2e:t ännu; `uploadInboxFile` +
+  `connectFileToVoucher` är enhetstestade men inte körda skarpt.

--- a/src/lib/server/integrations/fortnox/client.ts
+++ b/src/lib/server/integrations/fortnox/client.ts
@@ -9,9 +9,11 @@
 import { refreshTokens, type FetchFn } from "./oauth";
 import {
   fortnoxInboxResponseSchema,
+  fortnoxVoucherFetchSchema,
   fortnoxVoucherResponseSchema,
   type FortnoxConfig,
   type FortnoxVoucher,
+  type FortnoxVoucherFetch,
   type FortnoxVoucherResponse,
 } from "./schema";
 import type { FortnoxTokenStore } from "./token-store";
@@ -60,6 +62,13 @@ export class FortnoxClient {
     return next.accessToken;
   }
 
+  private apiGet(path: string, token: string): Promise<Response> {
+    return this.fetchFn(new URL(path, this.config.apiBase).toString(), {
+      method: "GET",
+      headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
+    });
+  }
+
   private apiPost(path: string, token: string, body: unknown): Promise<Response> {
     return this.fetchFn(new URL(path, this.config.apiBase).toString(), {
       method: "POST",
@@ -81,6 +90,24 @@ export class FortnoxClient {
       throw new Error(`Fortnox ${what} ${res.status}: ${detail.slice(0, 300)}`);
     }
     return res;
+  }
+
+  /**
+   * Hämta ett verifikat. Finns för att kunna VERIFIERA att en push landade
+   * (e2e, #1030) — utan den vägen får man bara veta att Fortnox svarade 200 på
+   * skrivningen, inte att verifikatet går att läsa tillbaka och balanserar.
+   */
+  async getVoucher(voucherSeries: string, voucherNumber: string): Promise<FortnoxVoucherFetch> {
+    const res = await this.withRetry((t) => this.apiGet(`/3/vouchers/${voucherSeries}/${voucherNumber}`, t), "verifikat-hämtning");
+    return fortnoxVoucherFetchSchema.parse(await res.json());
+  }
+
+  /**
+   * Röktest av anslutningen: refreshar vid behov och slår mot en billig,
+   * biverkningsfri endpoint. Skapar INGET — säker att köra före en skarp push.
+   */
+  async checkConnection(): Promise<void> {
+    await this.withRetry((t) => this.apiGet("/3/voucherseries", t), "anslutningskoll");
   }
 
   /** Skapa ett verifikat. Returnerar serie + nummer (för idempotens/spårning). */

--- a/src/lib/server/integrations/fortnox/schema.ts
+++ b/src/lib/server/integrations/fortnox/schema.ts
@@ -149,6 +149,26 @@ export const fortnoxVoucherResponseSchema = z.object({
 });
 export type FortnoxVoucherResponse = z.infer<typeof fortnoxVoucherResponseSchema>;
 
+/**
+ * Svar från `GET /3/vouchers/{serie}/{nr}` (#1030). Skilt från POST-svaret för
+ * att det MÅSTE bära raderna: hela poängen med att läsa tillbaka är att kunna
+ * kontrollera att verifikatet balanserar hos Fortnox, inte bara att skrivningen
+ * gav 200. Löst (`looseObject`) — GET returnerar fler fält än vi bryr oss om,
+ * och de ska inte fälla en läsning.
+ */
+export const fortnoxVoucherFetchSchema = z.object({
+  Voucher: z.looseObject({
+    VoucherSeries: z.string(),
+    VoucherNumber: z.number().int(),
+    VoucherRows: z.array(z.looseObject({
+      Account: z.number().int(),
+      Debit: z.number().default(0),
+      Credit: z.number().default(0),
+    })).min(1),
+  }),
+});
+export type FortnoxVoucherFetch = z.infer<typeof fortnoxVoucherFetchSchema>;
+
 // ─── Filbilaga (#785) ───────────────────────────────────────────────────────
 
 /** Svar från `POST /3/inbox` (fil-uppladdning) — vi behöver fil-id:t (GUID). */

--- a/src/lib/server/integrations/ledger/book-invoices.ts
+++ b/src/lib/server/integrations/ledger/book-invoices.ts
@@ -1,0 +1,136 @@
+/**
+ * `bookUnbookedInvoices` — drivrutinen som gör bokföring till ett FLÖDE (#1030).
+ *
+ * Delarna fanns sedan #82/#233: `buildSemanticVoucher` (faktura → balanserat
+ * verifikat), `LedgerConnector.pushVoucher` (verifikat → bokföringssystem) och
+ * `invoice.markFortnoxBooked` (write-back). Ingenting band ihop dem, så det gick
+ * inte att e2e-testa mot riktiga Fortnox — man kunde bara enhetstesta bitarna.
+ *
+ * ## Idempotens
+ *
+ * Kandidaten ÄR "saknar externt id". Drivrutinen håller därför inget eget
+ * state: en omkörning ser en redan bokförd faktura som icke-kandidat och rör
+ * den inte. Det är samma invariant som `markExternalId` vaktar på sin sida
+ * (skriver aldrig över ett satt id) — bälte och hängslen, med avsikt: en
+ * dubbelbokföring i en huvudbok går inte att ångra.
+ *
+ * ## Varför utkast och annullerade hoppas över
+ *
+ * Ett utkast är inte utställt och existerar inte bokföringsmässigt; en
+ * annullerad faktura ska inte bokföras alls (krediteringen är en EGEN faktura
+ * med eget verifikat). Kundförlust bokförs däremot — den är en verklig
+ * affärshändelse (ADR 0007).
+ */
+
+import { buildSemanticVoucher, type VatBreakdownLine } from "@/lib/shared/accounting/semantic-voucher";
+import type { InvoiceStatus } from "@/lib/shared/schemas/enums";
+import type { LedgerAttachment, LedgerConnector } from "./port";
+
+/** Fakturaraden drivrutinen behöver — en delmängd av listvyns rad. */
+export interface BookableInvoice {
+  id: string;
+  amount: number;
+  vatOre: number | null;
+  vatBreakdown: VatBreakdownLine[] | null;
+  invoiceDate: Date | string;
+  invoiceNumber: string | null;
+  status: string;
+  /** Satt = redan bokförd → aldrig kandidat. */
+  fortnoxId: string | null;
+  matter: { matterNumber: string | null } | null;
+}
+
+/** Statusar som INTE bokförs. Se modulens header för varför. */
+const SKIPPED_STATUSES: ReadonlySet<string> = new Set<InvoiceStatus>(["DRAFT", "CANCELLED"]);
+
+/** Är fakturan en kandidat för bokföring? */
+export function isBookable(inv: BookableInvoice): boolean {
+  return !inv.fortnoxId && !SKIPPED_STATUSES.has(inv.status);
+}
+
+/** Utfallet per faktura — `error` sätts i st.f. att kasta, se `bookUnbookedInvoices`. */
+export interface BookingOutcome {
+  invoiceId: string;
+  invoiceNumber: string | null;
+  /** Satt vid lyckad push (t.ex. "A/42"). Ömsesidigt uteslutande med `error`. */
+  externalId: string | null;
+  error: string | null;
+}
+
+export interface BookInvoicesDeps {
+  /** Kandidaterna (anroparen org-scopar och hämtar). */
+  invoices: readonly BookableInvoice[];
+  connector: Pick<LedgerConnector, "pushVoucher" | "capabilities">;
+  /** Write-back av externt id. Måste vara idempotent på sin sida. */
+  markBooked: (invoiceId: string, externalId: string) => Promise<unknown>;
+  /** Faktura-PDF att arkivera med verifikatet (#785); utelämnas → ingen bilaga. */
+  attachmentFor?: (inv: BookableInvoice) => Promise<LedgerAttachment | undefined>;
+}
+
+/** Bilagan för en faktura, eller undefined. Fel här får INTE stoppa bokföringen:
+ *  ett saknat PDF är ett arkiveringsproblem, inte ett bokföringsproblem. */
+async function attachmentOrNone(
+  inv: BookableInvoice,
+  fetcher: BookInvoicesDeps["attachmentFor"],
+): Promise<LedgerAttachment | undefined> {
+  if (!fetcher) return undefined;
+  try {
+    return await fetcher(inv);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Verifikat-push:aren, eller ett tydligt fel. Porten gör metoden valfri och
+ *  kapabiliteten är sanningen — den kopplingen löses EN gång, här. */
+type PushFn = NonNullable<LedgerConnector["pushVoucher"]>;
+function pushFnOf(connector: BookInvoicesDeps["connector"]): PushFn {
+  const push = connector.pushVoucher;
+  if (!connector.capabilities().pushVoucher || !push) {
+    throw new Error("Ledger-connectorn saknar pushVoucher-kapabilitet.");
+  }
+  return push.bind(connector) as PushFn;
+}
+
+/** Bokför EN faktura. Utbruten så `bookUnbookedInvoices` håller komplexitet ≤ 8. */
+async function bookOne(inv: BookableInvoice, deps: BookInvoicesDeps, push: PushFn): Promise<BookingOutcome> {
+  const base = { invoiceId: inv.id, invoiceNumber: inv.invoiceNumber };
+  try {
+    const voucher = buildSemanticVoucher({
+      amount: inv.amount,
+      vatOre: inv.vatOre,
+      vatBreakdown: inv.vatBreakdown,
+      invoiceDate: inv.invoiceDate,
+      invoiceNumber: inv.invoiceNumber,
+      matterNumber: inv.matter?.matterNumber ?? null,
+    });
+    const attachment = await attachmentOrNone(inv, deps.attachmentFor);
+    const res = await push(voucher, {
+      idempotencyKey: inv.id,
+      ...(attachment ? { attachment } : {}),
+    });
+    // Write-back FÖRST efter lyckad push: kraschar vi mellan dem är fakturan
+    // bokförd men omärkt → nästa körning dubbelbokför. Därför är det här den
+    // enda riskfönstret, och det loggas som fel i st.f. att sväljas.
+    await deps.markBooked(inv.id, res.externalId);
+    return { ...base, externalId: res.externalId, error: null };
+  } catch (e) {
+    return { ...base, externalId: null, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+/**
+ * Bokför alla obokförda fakturor. Returnerar utfallet per faktura i st.f. att
+ * kasta vid första felet: en trasig faktura ska inte hindra de övriga från att
+ * bokföras, och anroparen behöver hela bilden för att kunna rapportera.
+ */
+export async function bookUnbookedInvoices(deps: BookInvoicesDeps): Promise<BookingOutcome[]> {
+  const push = pushFnOf(deps.connector);
+  const outcomes: BookingOutcome[] = [];
+  // Sekventiellt med flit: verifikatnummer serialiseras hos mottagaren, och
+  // parallella pushar mot samma serie ger ingen vinst men svårlästa loggar.
+  for (const inv of deps.invoices.filter(isBookable)) {
+    outcomes.push(await bookOne(inv, deps, push));
+  }
+  return outcomes;
+}

--- a/test/unit/server/integrations/fortnox/client.test.ts
+++ b/test/unit/server/integrations/fortnox/client.test.ts
@@ -145,3 +145,89 @@ describe("FortnoxClient fil-bilaga (#785)", () => {
     expect(body).toEqual({ VoucherFileConnection: { FileId: "guid-9", VoucherSeries: "A", VoucherNumber: "7" } });
   });
 });
+
+/**
+ * Läs-vägen (#1030) — tillagd för att e2e:t ska kunna VERIFIERA att en push
+ * landade, inte bara att skrivningen gav 200. Testerna vaktar två saker:
+ * att GET-svarets rader överlever parsningen (POST-schemat strippar dem), och
+ * att läs-vägen har samma token-livscykel som skriv-vägen.
+ */
+/**
+ * Typad fetch-fake. `globalThis.fetch` bär `preconnect` i bun:s typer, så en
+ * naken lambda matchar inte — och dubbel-cast är förbjuden (#562, ADR 0026).
+ * `Object.assign` ger fakern den saknade egenskapen på riktigt i st.f. att
+ * tysta typcheckaren.
+ */
+function fetchFake(handler: (url: string, init?: RequestInit) => Promise<Response>): typeof globalThis.fetch {
+  const fn = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => handler(String(input), init);
+  return Object.assign(fn, { preconnect: (): void => {} });
+}
+
+describe("FortnoxClient — läsa tillbaka (#1030)", () => {
+  const FETCHED = {
+    Voucher: {
+      VoucherSeries: "A", VoucherNumber: 17, Year: 1,
+      VoucherRows: [
+        { Account: 1510, Debit: 125, Credit: 0 },
+        { Account: 3041, Debit: 0, Credit: 100 },
+        { Account: 2611, Debit: 0, Credit: 25 },
+      ],
+    },
+  };
+
+  it("getVoucher behåller raderna — annars går balansen inte att kontrollera", async () => {
+    const store = new InMemoryFortnoxTokenStore({ accessToken: "at", refreshToken: "rt", accessTokenExpiresAt: Date.now() + 3_600_000 });
+    const client = new FortnoxClient(config, store, fetchFake(async () => json(200, FETCHED)));
+    const res = await client.getVoucher("A", "17");
+    expect(res.Voucher.VoucherRows).toHaveLength(3);
+    const debit = res.Voucher.VoucherRows.reduce((s, r) => s + r.Debit, 0);
+    const credit = res.Voucher.VoucherRows.reduce((s, r) => s + r.Credit, 0);
+    expect(debit).toBe(credit);
+  });
+
+  it("getVoucher går mot rätt path och skickar Bearer", async () => {
+    const store = new InMemoryFortnoxTokenStore({ accessToken: "at", refreshToken: "rt", accessTokenExpiresAt: Date.now() + 3_600_000 });
+    let seenUrl = ""; let seenAuth = "";
+    const client = new FortnoxClient(config, store, fetchFake(async (url, init) => {
+      seenUrl = url;
+      seenAuth = ((init?.headers ?? {}) as Record<string, string>).Authorization ?? "";
+      return json(200, FETCHED);
+    }));
+    await client.getVoucher("A", "17");
+    expect(seenUrl).toBe("https://api.test/3/vouchers/A/17");
+    expect(seenAuth).toBe("Bearer at");
+  });
+
+  it("getVoucher refreshar och gör om vid 401 — samma livscykel som skriv-vägen", async () => {
+    const store = new InMemoryFortnoxTokenStore({ accessToken: "at-gammal", refreshToken: "rt", accessTokenExpiresAt: Date.now() + 3_600_000 });
+    let calls = 0;
+    const client = new FortnoxClient(config, store, fetchFake(async (url) => {
+      if (url.endsWith("/oauth-v1/token")) return json(200, ROTATED);
+      calls++;
+      return calls === 1 ? json(401, { error: "expired" }) : json(200, FETCHED);
+    }));
+    const res = await client.getVoucher("A", "17");
+    expect(res.Voucher.VoucherNumber).toBe(17);
+    expect(calls).toBe(2);
+    expect((await store.load())?.accessToken).toBe("at-new");
+  });
+
+  it("checkConnection slår mot voucherseries och skapar ingenting", async () => {
+    const store = new InMemoryFortnoxTokenStore({ accessToken: "at", refreshToken: "rt", accessTokenExpiresAt: Date.now() + 3_600_000 });
+    const seen: Array<{ url: string; method: string }> = [];
+    const client = new FortnoxClient(config, store, fetchFake(async (url, init) => {
+      seen.push({ url, method: init?.method ?? "GET" });
+      return json(200, { VoucherSeries: [] });
+    }));
+    await client.checkConnection();
+    expect(seen).toEqual([{ url: "https://api.test/3/voucherseries", method: "GET" }]);
+  });
+
+  it("checkConnection kastar med statusen när anslutningen är död", async () => {
+    const store = new InMemoryFortnoxTokenStore({ accessToken: "at", refreshToken: "rt", accessTokenExpiresAt: Date.now() + 3_600_000 });
+    const client = new FortnoxClient(config, store, fetchFake(async (url) =>
+      url.endsWith("/oauth-v1/token") ? json(200, ROTATED) : json(403, { Message: "access-token saknas" })
+    ));
+    await expect(client.checkConnection()).rejects.toThrow(/403/);
+  });
+});

--- a/test/unit/server/integrations/ledger/book-invoices.test.ts
+++ b/test/unit/server/integrations/ledger/book-invoices.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Bokförings-drivrutinen (#1030).
+ *
+ * Connectorn och verifikat-byggaren är testade var för sig sedan #82/#235.
+ * Det här testar LIMMET, och särskilt de egenskaper som inte går att ångra i
+ * en huvudbok: att en redan bokförd faktura aldrig bokförs igen, och att ett
+ * fel på en faktura inte tar med sig de andra.
+ */
+
+import { describe, it, expect } from "vitest-compat";
+import {
+  bookUnbookedInvoices,
+  isBookable,
+  type BookableInvoice,
+} from "@/lib/server/integrations/ledger/book-invoices";
+import type { LedgerCapabilities, SemanticVoucher } from "@/lib/server/integrations/ledger/port";
+
+const CAPS: LedgerCapabilities = { pushVoucher: true, pushInvoice: false, pullPayments: false, exportSie: false };
+
+function invoice(over: Partial<BookableInvoice> = {}): BookableInvoice {
+  return {
+    id: "inv-1", amount: 125_000, vatOre: 25_000, vatBreakdown: null,
+    invoiceDate: "2026-05-02", invoiceNumber: "F-2026-0001", status: "SENT",
+    fortnoxId: null, matter: { matterNumber: "2026-0001" },
+    ...over,
+  };
+}
+
+/** Connector som räknar pushar och kan fås att faila. */
+function fakeConnector(opts: { failOn?: string } = {}) {
+  const pushed: Array<{ voucher: SemanticVoucher; key: string }> = [];
+  let seq = 0;
+  return {
+    pushed,
+    capabilities: () => CAPS,
+    pushVoucher: async (voucher: SemanticVoucher, ctx: { idempotencyKey: string }) => {
+      if (opts.failOn === ctx.idempotencyKey) throw new Error("Fortnox: 400 Felaktig datastruktur");
+      pushed.push({ voucher, key: ctx.idempotencyKey });
+      return { externalId: `A/${++seq}` };
+    },
+  };
+}
+
+describe("isBookable", () => {
+  it("en utställd faktura utan externt id är kandidat", () => {
+    expect(isBookable(invoice())).toBe(true);
+  });
+
+  it("redan bokförd faktura är ALDRIG kandidat", () => {
+    expect(isBookable(invoice({ fortnoxId: "A/17" }))).toBe(false);
+  });
+
+  it("utkast bokförs inte — det är inte utställt", () => {
+    expect(isBookable(invoice({ status: "DRAFT" }))).toBe(false);
+  });
+
+  it("annullerad bokförs inte — krediteringen är en egen faktura", () => {
+    expect(isBookable(invoice({ status: "CANCELLED" }))).toBe(false);
+  });
+
+  it("kundförlust bokförs — den är en verklig affärshändelse (ADR 0007)", () => {
+    expect(isBookable(invoice({ status: "BAD_DEBT" }))).toBe(true);
+  });
+});
+
+describe("bookUnbookedInvoices", () => {
+  it("bokför kandidaten, skriver tillbaka externt id", async () => {
+    const c = fakeConnector();
+    const marked: Array<[string, string]> = [];
+    const res = await bookUnbookedInvoices({
+      invoices: [invoice()], connector: c,
+      markBooked: async (id, ext) => { marked.push([id, ext]); },
+    });
+    expect(res).toEqual([{ invoiceId: "inv-1", invoiceNumber: "F-2026-0001", externalId: "A/1", error: null }]);
+    expect(marked).toEqual([["inv-1", "A/1"]]);
+  });
+
+  it("IDEMPOTENT: en omkörning rör inte redan bokförda fakturor", async () => {
+    // Det här är hela poängen — en dubbelbokföring går inte att ångra.
+    const c = fakeConnector();
+    const first = await bookUnbookedInvoices({
+      invoices: [invoice()], connector: c, markBooked: async () => {},
+    });
+    // Andra körningen ser fakturan som den nu ÄR: med externt id.
+    const second = await bookUnbookedInvoices({
+      invoices: [invoice({ fortnoxId: first[0]!.externalId })], connector: c, markBooked: async () => {},
+    });
+    expect(second).toEqual([]);
+    expect(c.pushed).toHaveLength(1);
+  });
+
+  it("ett fel på en faktura stoppar inte de övriga", async () => {
+    const c = fakeConnector({ failOn: "inv-2" });
+    const res = await bookUnbookedInvoices({
+      invoices: [invoice({ id: "inv-1" }), invoice({ id: "inv-2" }), invoice({ id: "inv-3" })],
+      connector: c, markBooked: async () => {},
+    });
+    expect(res.map((r) => r.invoiceId)).toEqual(["inv-1", "inv-2", "inv-3"]);
+    expect(res[1]?.error).toMatch(/Felaktig datastruktur/);
+    expect(res[1]?.externalId).toBeNull();
+    expect(res.filter((r) => r.externalId !== null)).toHaveLength(2);
+  });
+
+  it("markerar INTE som bokförd när pushen fallerar", async () => {
+    // Annars vore fakturan omöjlig att boka om — märkt men obokförd.
+    const c = fakeConnector({ failOn: "inv-1" });
+    const marked: string[] = [];
+    await bookUnbookedInvoices({
+      invoices: [invoice()], connector: c, markBooked: async (id) => { marked.push(id); },
+    });
+    expect(marked).toEqual([]);
+  });
+
+  it("verifikatet bär ärendenumret (#785)", async () => {
+    const c = fakeConnector();
+    await bookUnbookedInvoices({
+      invoices: [invoice()], connector: c, markBooked: async () => {},
+    });
+    expect(JSON.stringify(c.pushed[0]?.voucher)).toContain("2026-0001");
+  });
+
+  it("idempotens-nyckeln är fakturans id", async () => {
+    const c = fakeConnector();
+    await bookUnbookedInvoices({ invoices: [invoice()], connector: c, markBooked: async () => {} });
+    expect(c.pushed[0]?.key).toBe("inv-1");
+  });
+
+  it("bilaga skickas med när den finns (#785)", async () => {
+    const seen: unknown[] = [];
+    const c = {
+      capabilities: () => CAPS,
+      pushVoucher: async (_v: SemanticVoucher, ctx: { attachment?: unknown }) => {
+        seen.push(ctx.attachment); return { externalId: "A/1" };
+      },
+    };
+    await bookUnbookedInvoices({
+      invoices: [invoice()], connector: c, markBooked: async () => {},
+      attachmentFor: async () => ({ fileName: "F-2026-0001.pdf", bytes: new Uint8Array([1, 2]) }),
+    });
+    expect((seen[0] as { fileName: string }).fileName).toBe("F-2026-0001.pdf");
+  });
+
+  it("en trasig bilaga stoppar INTE bokföringen", async () => {
+    // Arkivering är ett separat problem från att bokföra rätt belopp.
+    const c = fakeConnector();
+    const res = await bookUnbookedInvoices({
+      invoices: [invoice()], connector: c, markBooked: async () => {},
+      attachmentFor: async () => { throw new Error("PDF saknas"); },
+    });
+    expect(res[0]?.externalId).toBe("A/1");
+    expect(res[0]?.error).toBeNull();
+  });
+
+  it("kastar om connectorn saknar pushVoucher-kapabilitet", async () => {
+    const noPush = { capabilities: () => ({ ...CAPS, pushVoucher: false }) };
+    await expect(bookUnbookedInvoices({
+      invoices: [invoice()], connector: noPush, markBooked: async () => {},
+    })).rejects.toThrow(/pushVoucher/);
+  });
+});

--- a/tooling/scripts/fortnox-e2e.ts
+++ b/tooling/scripts/fortnox-e2e.ts
@@ -1,0 +1,178 @@
+/**
+ * E2E mot RIKTIGA Fortnox Voucher API (#1030).
+ *
+ * Till skillnad från enhetstesterna (injicerad `fetch`) går det här hela vägen:
+ * OAuth-refresh → bygg semantiskt verifikat → POST /3/vouchers → läs tillbaka
+ * verifikatet → verifiera balans och write-back. Det är den enda kontrollen
+ * som fångar att wire-formatet fortfarande stämmer med vad Fortnox faktiskt
+ * accepterar (jfr `client.ts`: fel nesting ger 400/2002381).
+ *
+ * ## Körs INTE i PR-matrisen
+ *
+ * Varje körning bränner ett verifikatnummer som inte går att ta tillbaka, och
+ * refresh-token roterar (se nedan). Därför `workflow_dispatch` — manuellt, mot
+ * sandbox.
+ *
+ * ## Roterande refresh-token
+ *
+ * Fortnox ogiltigförklarar den gamla refresh-token:en vid varje refresh. Ett
+ * token i en GitHub-secret räcker alltså till EN körning om inte det nya
+ * skrivs tillbaka. Scriptet skriver därför den roterade token:en till
+ * `$GITHUB_OUTPUT` (`refresh_token`) så workflow:et kan uppdatera secreten.
+ * Token:en skrivs ALDRIG till stdout — GitHub maskerar bara det den känner.
+ *
+ * Env:
+ *   AVA_FORTNOX_CLIENT_ID / _CLIENT_SECRET / _REFRESH_TOKEN   (obligatoriska)
+ *   AVA_FORTNOX_VOUCHER_SERIES  (default "A")
+ *   AVA_FORTNOX_KONTO_*         kontomappning, se DEFAULT_MAPPING
+ *   AVA_FORTNOX_DRY_RUN=1       kör allt UTOM POST (rök-test av auth)
+ */
+
+import { appendFileSync } from "node:fs";
+import { FortnoxClient } from "@/lib/server/integrations/fortnox/client";
+import { FortnoxLedgerConnector } from "@/lib/server/integrations/fortnox/connector";
+import { fortnoxConfigSchema, fortnoxKontoMappningSchema, type FortnoxConfig, type FortnoxKontoMappning } from "@/lib/server/integrations/fortnox/schema";
+import { InMemoryFortnoxTokenStore } from "@/lib/server/integrations/fortnox/token-store";
+import { bookUnbookedInvoices, type BookableInvoice } from "@/lib/server/integrations/ledger/book-invoices";
+
+function required(name: string): string {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`✗ ${name} saknas. Se docs/fortnox-e2e.md för vilka secrets som krävs.`);
+    process.exit(2);
+  }
+  return v;
+}
+
+/** BAS-kontoplanens standardkonton — byrån överstyr via env. */
+const DEFAULT_MAPPING = { voucherSeries: "A", kundfordran: "1510", intaktArvode: "3041", momsUtgaende: "2611" };
+
+function buildConfig(): FortnoxConfig {
+  return fortnoxConfigSchema.parse({
+    clientId: required("AVA_FORTNOX_CLIENT_ID"),
+    clientSecret: required("AVA_FORTNOX_CLIENT_SECRET"),
+    // Redirect-URI:n används bara i authorize-steget (som redan är gjort) —
+    // refresh bryr sig inte om den, men schemat kräver ett giltigt värde.
+    redirectUri: process.env.AVA_FORTNOX_REDIRECT_URI ?? "https://localhost/callback",
+    scopes: ["bookkeeping"],
+  });
+}
+
+/** En faktura att bokföra. Byggd i minnet: det som testas är LEDGER-vägen,
+ *  inte repo-lagret (det har sina egna tester). Beloppen är avsiktligt små och
+ *  udda så raden går att känna igen i sandboxen. */
+function testInvoice(stamp: string): BookableInvoice {
+  return {
+    id: `e2e-${stamp}`,
+    amount: 12_500,      // 125,00 kr inkl moms
+    vatOre: 2_500,       // 25,00 kr moms
+    vatBreakdown: null,
+    invoiceDate: new Date().toISOString().slice(0, 10),
+    invoiceNumber: `E2E-${stamp}`,
+    status: "SENT",
+    fortnoxId: null,
+    matter: { matterNumber: `E2E-${stamp}` },
+  };
+}
+
+/** Skriv den roterade refresh-token:en till GITHUB_OUTPUT (aldrig till stdout). */
+function emitRotatedToken(token: string): void {
+  const out = process.env.GITHUB_OUTPUT;
+  if (!out) return;
+  appendFileSync(out, `refresh_token=${token}\n`);
+  console.log("• Roterad refresh-token skriven till GITHUB_OUTPUT (maskerad).");
+}
+
+/** Kontomappning ur env, med BAS-defaults. Egen funktion: fyra valfria
+ *  overrides är fyra grenar, och de hör inte hemma i flödet. */
+function buildMapping(): FortnoxKontoMappning {
+  const overrides: Record<string, string | undefined> = {
+    voucherSeries: process.env.AVA_FORTNOX_VOUCHER_SERIES,
+    kundfordran: process.env.AVA_FORTNOX_KONTO_KUNDFORDRAN,
+    intaktArvode: process.env.AVA_FORTNOX_KONTO_ARVODE,
+    momsUtgaende: process.env.AVA_FORTNOX_KONTO_MOMS,
+  };
+  const set = Object.fromEntries(Object.entries(overrides).filter(([, v]) => v !== undefined));
+  return fortnoxKontoMappningSchema.parse({ ...DEFAULT_MAPPING, ...set });
+}
+
+/** Steg 2: bokför testfakturan och verifiera write-back. */
+async function pushTestInvoice(connector: FortnoxLedgerConnector, invoice: BookableInvoice): Promise<string> {
+  console.log(`→ Steg 2: bokför testfaktura ${invoice.invoiceNumber} (125,00 kr inkl moms) …`);
+  const marked: Array<[string, string]> = [];
+  const [outcome] = await bookUnbookedInvoices({
+    invoices: [invoice], connector,
+    markBooked: async (id, ext) => { marked.push([id, ext]); },
+  });
+  if (!outcome || outcome.error || !outcome.externalId) {
+    throw new Error(`Bokföring misslyckades: ${outcome?.error ?? "inget utfall"}`);
+  }
+  console.log(`  ✓ Verifikat skapat: ${outcome.externalId}`);
+  if (marked.length !== 1) throw new Error(`Write-back uteblev — markBooked anropades ${marked.length} gånger.`);
+  console.log(`  ✓ fortnoxId skrevs tillbaka: ${marked[0]![1]}`);
+  return outcome.externalId;
+}
+
+/** Steg 3: läs tillbaka verifikatet och kontrollera att det balanserar. */
+async function verifyVoucher(client: FortnoxClient, externalId: string): Promise<void> {
+  console.log("→ Steg 3: läser tillbaka verifikatet ur Fortnox …");
+  const [series, number] = externalId.split("/");
+  const back = await client.getVoucher(series ?? "", number ?? "");
+  const rows = back.Voucher.VoucherRows;
+  const debit = rows.reduce((sum, r) => sum + r.Debit, 0);
+  const credit = rows.reduce((sum, r) => sum + r.Credit, 0);
+  if (Math.abs(debit - credit) > 0.001) {
+    throw new Error(`Verifikatet balanserar inte: debet ${debit} ≠ kredit ${credit}`);
+  }
+  console.log(`  ✓ ${rows.length} rader, debet ${debit} = kredit ${credit}`);
+}
+
+/** Steg 4: samma faktura MED externt id får inte bokföras igen. */
+async function verifyIdempotens(connector: FortnoxLedgerConnector, invoice: BookableInvoice, externalId: string): Promise<void> {
+  const second = await bookUnbookedInvoices({
+    invoices: [{ ...invoice, fortnoxId: externalId }], connector, markBooked: async () => {},
+  });
+  if (second.length !== 0) throw new Error("Idempotens bruten — en bokförd faktura bokfördes igen.");
+  console.log("  ✓ Idempotens: omkörning skapade inget nytt verifikat");
+}
+
+async function main(): Promise<void> {
+  const config = buildConfig();
+  const mapping = buildMapping();
+
+  // accessToken tomt + utgånget → klienten tvingas refresha direkt, vilket är
+  // precis vad vi vill verifiera (och det som roterar token:en).
+  const store = new InMemoryFortnoxTokenStore({
+    accessToken: "utgången", refreshToken: required("AVA_FORTNOX_REFRESH_TOKEN"), accessTokenExpiresAt: 0,
+  });
+  const client = new FortnoxClient(config, store);
+
+  console.log("→ Steg 1: OAuth-refresh + anslutningskoll mot Fortnox …");
+  await client.checkConnection();
+  console.log("  ✓ Ansluten (GET /3/voucherseries → 200)");
+
+  // Token:en roterade i refreshen ovan — ut med den DIREKT, före allt som kan
+  // fela. Annars är den nya token:en förlorad och nästa körning kan inte auth:a.
+  const rotated = await store.load();
+  if (rotated) emitRotatedToken(rotated.refreshToken);
+
+  if (process.env.AVA_FORTNOX_DRY_RUN === "1") {
+    console.log("→ DRY_RUN: hoppar över verifikat-push. Auth och anslutning verifierade.");
+    return;
+  }
+
+  const stamp = new Date().toISOString().replace(/[^0-9]/g, "").slice(0, 14);
+  const invoice = testInvoice(stamp);
+  const connector = new FortnoxLedgerConnector({ client, mapping });
+
+  const externalId = await pushTestInvoice(connector, invoice);
+  await verifyVoucher(client, externalId);
+  await verifyIdempotens(connector, invoice, externalId);
+
+  console.log(`\n✓ Fortnox-E2E klart. Verifikat ${externalId} i serie ${mapping.voucherSeries}.`);
+}
+
+main().catch((e: unknown) => {
+  console.error(`\n✗ Fortnox-E2E misslyckades: ${e instanceof Error ? e.message : String(e)}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Refs #1030.

## Vad som saknades

Connectorn var byggd och sandbox-verifierad sedan #82/#213 — men **ingenting band ihop delarna**. Inget sökte upp obokförda fakturor, byggde verifikatet, pushade och skrev tillbaka `fortnoxId`. Bitarna gick att enhetstesta, kedjan gick inte att köra. `server-first-handlers.ts` sa det rakt ut: *"Fortnox-sync … slotas in här i takt med att deras config/triggers byggs"*.

Utan drivrutin fanns inget att e2e-testa, så den är förutsättningen — inte en detalj.

## Drivrutinen

`bookUnbookedInvoices` — kandidater → `buildSemanticVoucher` → `connector.pushVoucher` → write-back.

**Idempotensen ägs av urvalet:** "saknar externt id" *är* villkoret, så en omkörning ser en bokförd faktura som icke-kandidat. Drivrutinen håller inget eget state. Bälte och hängslen med avsikt — `markExternalId` vaktar samma sak från sitt håll, för en dubbelbokföring i en huvudbok går inte att ångra.

Utkast och annullerade hoppas över (inte utställd resp. krediteras via en egen faktura); **kundförlust bokförs** — den är en verklig affärshändelse (ADR 0007). Ett fel på en faktura fäller inte de övriga; utfallet returneras per faktura så anroparen får hela bilden.

## E2E-scriptet

Går hela vägen mot riktiga Voucher API: OAuth-refresh → anslutningskoll → `POST /3/vouchers` → **läs tillbaka verifikatet** → kontrollera att debet = kredit → verifiera att en omkörning inte skapar ett nytt.

Läs-tillbaka-steget är poängen: utan det vet man bara att Fortnox svarade 200 på skrivningen. Det är den enda kontrollen som fångar att wire-formatet fortfarande stämmer — jfr `client.ts`, där fel nesting ger `400`/`2002381`.

## Två begränsningar som styrde designen

**1. Refresh-token roterar.** Fortnox dödar den gamla vid varje refresh. Konsekvensen är kontraintuitiv: *ett token i en GitHub-secret räcker till exakt en körning.* Scriptet emitterar därför det roterade token:et till `GITHUB_OUTPUT` **direkt efter första anropet — före allt som kan fela** — och workflow:et sparar det med `if: always()`. Saknas rotations-PAT:en fäller jobbet hellre än att lämna en tyst död token som visar sig först nästa gång.

**2. Verifikat går inte att ångra.** Varje körning bränner ett verifikatnummer. Därför `workflow_dispatch` med en `dry_run`-input (auth + anslutning, ingen push), inte PR-matrisen.

## Klientens nya metoder

`getVoucher` med **eget schema** — POST-svaret är ett delsvar utan rader, och raderna behövs för balanskontrollen (`z.object` hade strippat dem). `checkConnection` — biverkningsfritt röktest mot `/3/voucherseries`.

## Vad jag INTE kunde verifiera

**Jag har inga Fortnox-credentials i den här miljön** — inget `AVA_SECRETS_KEY`, ingen valv-fil (ADR 0008 lägger valvet utanför git-working-copy:n, som det ska vara). Scriptet är alltså **inte kört skarpt**. Nätverket är öppet (`api.fortnox.se` svarar med Fortnox eget 403), men `bun`:s `fetch` når inte igenom containerns proxy medan `curl` gör det — dokumenterat under "Kända begränsningar".

> ⚠️ **Anslutningen i #213 gjordes 2026-06-11.** Refresh-token lever 45 dygn → den är sannolikt död sedan mitten av juli. En ny consent-runda krävs innan första körningen; stegen står i `docs/fortnox-e2e.md`.

## Verifierat lokalt

typecheck ✅ · lint ✅ · `deps:check` ✅ (1 138 moduler) · knip ✅ · jscpd ✅ · **hela sviten fil för fil: 468 filer, 0 fallerade** · AI-ytans coverage 96,07 % / 93,65 % (golv 95,0/92,0). 19 nya tester (14 drivrutin + 5 klientens läs-väg).

En sak värd att notera: lint-regeln mot dubbel-cast (#562) fångade mig när jag typade fetch-fakerna. Löst med en riktigt typad `fetchFake` i stället för att tysta typcheckaren — samma sorts skuld som `as`-cast:arna i #1014.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_