### PR TITLE
feat(fortnox): verktyg för OAuth-anslutningen — bygg URL + växla in kod

### DIFF
--- a/docs/fortnox-e2e.md
+++ b/docs/fortnox-e2e.md
@@ -60,11 +60,24 @@ Refresh-token:en dör efter 45 dygn utan användning, och en misslyckad
 write-back får samma effekt. Då krävs en ny consent-runda — den kan inte
 automatiseras, eftersom den kräver en människa som godkänner i Fortnox:
 
-1. Bygg authorize-URL:en med `buildAuthorizeUrl(config, state)`
-   (`src/lib/server/integrations/fortnox/oauth.ts`) och öppna den i en browser.
-2. Godkänn med ett konto som har rätt i den aktuella tenanten.
-3. Kopiera `?code=…` ur redirecten.
-4. `exchangeCodeForTokens(config, code)` → spara `refreshToken` i secreten.
+Kör **lokalt** (aldrig i CI — `client_secret` ska inte lämna din maskin, och
+`code` är engångs och kortlivad):
+
+```bash
+# 1. Bygg authorize-URL:en. Ingen hemlighet behövs i det här steget.
+AVA_FORTNOX_CLIENT_ID=… AVA_FORTNOX_REDIRECT_URI=… bun run fortnox:connect
+
+# 2. Godkänn i browsern. Kontrollera att `state` kommer tillbaka oförändrat
+#    (CSRF). Kopiera ?code=… ur adressfältet — landar du på en död sida är det
+#    väntat, koden står ändå i URL:en.
+
+# 3. Växla in koden → skriver ut refresh-token att lägga som secret.
+AVA_FORTNOX_CLIENT_ID=… AVA_FORTNOX_CLIENT_SECRET=… AVA_FORTNOX_REDIRECT_URI=… \
+  bun run fortnox:connect --code <kod>
+```
+
+`redirect_uri` måste matcha registreringen i Developer Portal **tecken för
+tecken** — annars avvisas anropet redan i steg 1.
 
 Modellen är **user-consent** (ingen `account_type`) — det är det flöde som
 verifierats mot sandbox. Service-konto är opt-in, se connector-README:n och

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "seed:local": "bun tooling/scripts/seed-firma-local.ts",
     "ava": "bun tooling/ava-cli/ava.ts",
     "ava:mcp": "bun tooling/ava-cli/ava-mcp.ts",
+    "fortnox:connect": "bun tooling/scripts/fortnox-connect.ts",
+    "fortnox:e2e": "bun tooling/scripts/fortnox-e2e.ts",
     "server-first": "bun src/bin/server-first.ts",
     "server-first:build": "bun tooling/scripts/build-server-first.ts",
     "install:server": "bun tooling/scripts/install-server.ts",

--- a/tooling/scripts/fortnox-connect.ts
+++ b/tooling/scripts/fortnox-connect.ts
@@ -1,0 +1,75 @@
+/**
+ * Fortnox OAuth-anslutning (#1030) — de två stegen som kräver en människa.
+ *
+ * README:n har sagt "kräver dig" sedan #82 utan att erbjuda ett verktyg, så
+ * consent-rundan har gjorts för hand varje gång. Den behövs om och om igen:
+ * refresh-token dör efter 45 dygn utan användning, och en misslyckad
+ * write-back i CI har samma effekt.
+ *
+ * Steg 1 — bygg authorize-URL:en (INGEN hemlighet behövs):
+ *   AVA_FORTNOX_CLIENT_ID=… AVA_FORTNOX_REDIRECT_URI=… bun tooling/scripts/fortnox-connect.ts
+ *
+ * Steg 2 — växla in koden ur redirecten (client_secret behövs):
+ *   AVA_FORTNOX_CLIENT_ID=… AVA_FORTNOX_CLIENT_SECRET=… AVA_FORTNOX_REDIRECT_URI=… \
+ *     bun tooling/scripts/fortnox-connect.ts --code <kod>
+ *
+ * Kör det här LOKALT, inte i CI: `client_secret` ska aldrig lämna din maskin,
+ * och `code` är kortlivad och engångs.
+ */
+
+import { randomUUID } from "node:crypto";
+import { buildAuthorizeUrl, exchangeCodeForTokens } from "@/lib/server/integrations/fortnox/oauth";
+import { fortnoxConfigSchema, type FortnoxConfig } from "@/lib/server/integrations/fortnox/schema";
+
+function env(name: string, required = true): string {
+  const v = process.env[name];
+  if (!v && required) {
+    console.error(`✗ ${name} saknas.`);
+    process.exit(2);
+  }
+  return v ?? "";
+}
+
+function buildConfig(needSecret: boolean): FortnoxConfig {
+  return fortnoxConfigSchema.parse({
+    clientId: env("AVA_FORTNOX_CLIENT_ID"),
+    // Authorize-steget signerar inget — secreten behövs först vid token-bytet.
+    clientSecret: needSecret ? env("AVA_FORTNOX_CLIENT_SECRET") : "ej-relevant-for-authorize",
+    redirectUri: env("AVA_FORTNOX_REDIRECT_URI"),
+    scopes: (process.env.AVA_FORTNOX_SCOPES ?? "bookkeeping").split(/[ ,]+/).filter(Boolean),
+    ...(process.env.AVA_FORTNOX_ACCOUNT_TYPE === "service" ? { accountType: "service" as const } : {}),
+  });
+}
+
+function printAuthorizeUrl(): void {
+  const config = buildConfig(false);
+  const state = randomUUID();
+  console.log("\nÖppna den här i en browser och godkänn:\n");
+  console.log(buildAuthorizeUrl(config, state));
+  console.log(`\nstate = ${state}`);
+  console.log("Kontrollera att samma state kommer tillbaka i redirecten (CSRF-skydd).");
+  console.log("\nKopiera sedan ?code=… ur adressfältet och kör:");
+  console.log("  … bun tooling/scripts/fortnox-connect.ts --code <kod>");
+  console.log("\nKoden är ENGÅNGS och kortlivad — växla in den direkt.");
+}
+
+async function exchange(code: string): Promise<void> {
+  const config = buildConfig(true);
+  const tokens = await exchangeCodeForTokens(config, code);
+  console.log("\n✓ Anslutet. Lägg det här som secret AVA_FORTNOX_REFRESH_TOKEN:\n");
+  console.log(tokens.refreshToken);
+  console.log(`\n(access-token går ut ${new Date(tokens.accessTokenExpiresAt).toISOString()} — den behöver du inte spara.)`);
+  console.log("Refresh-token ROTERAR vid varje användning; se docs/fortnox-e2e.md.");
+}
+
+const codeIndex = process.argv.indexOf("--code");
+const code = codeIndex >= 0 ? process.argv[codeIndex + 1] : undefined;
+
+if (!code) {
+  printAuthorizeUrl();
+} else {
+  exchange(code).catch((e: unknown) => {
+    console.error(`\n✗ Token-bytet misslyckades: ${e instanceof Error ? e.message : String(e)}`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
Refs #1030. Uppföljning på #1031.

## Varför

Consent-rundan har stått som *"kräver dig"* i connector-README:n sedan #82, utan verktyg. Den behövs **återkommande**, inte en gång: refresh-token dör efter 45 dygn utan användning, och en misslyckad write-back i CI får samma effekt. Utan skript görs den för hand med en `bun -e`-rad varje gång — vilket är precis varför den aktuella token:en tystnade i juli utan att någon märkte det.

## Vad

```bash
bun run fortnox:connect                 # skriver ut authorize-URL:en
bun run fortnox:connect --code <kod>    # växlar in koden → refresh-token
```

**Uppdelningen följer var hemligheten faktiskt behövs.** Authorize-steget signerar ingenting — `client_id` och `redirect_uri` går i klartext i URL:en som browsern öppnar. `client_secret` krävs först vid token-bytet (Basic auth). Steg 1 går därför att köra utan att ha secreten framme, och stegen kan göras av olika personer.

`state` slumpas per körning och skrivs ut, så CSRF-kontrollen går att göra på riktigt i stället för att hoppas över.

Avsett att köras **lokalt**: `client_secret` ska inte lämna maskinen, och `code` är engångs och kortlivad.

## Dokumentation

`docs/fortnox-e2e.md` pekade tidigare på funktionsnamn (`buildAuthorizeUrl`, `exchangeCodeForTokens`) som läsaren själv fick anropa. Nu står de tre stegen som körbara kommandon, med noten att `redirect_uri` måste matcha registreringen i Developer Portal tecken för tecken — annars avvisas anropet redan i steg 1.

## Verifierat

typecheck ✅ · lint ✅ · knip ✅ · `deps:check` ✅ (1 138 moduler). Skriptet är rökt-testat med platshållare och producerar en korrekt formad URL (`access_type=offline`, inget `account_type` → user-consent, det flöde som verifierats mot sandbox i #213).

Det är **inte** kört mot riktiga Fortnox — `client_secret`-halvan kan inte köras härifrån (bun:s `fetch` når inte igenom containerns proxy), vilket är rätt gräns: hemligheten hör hemma på din maskin.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_