### PR TITLE
test(billing): e2e mot riktig Postgres — fakturering, avbetalningsplan, försenad betalning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,16 @@ jobs:
           AVA_DATABASE_URL: postgres://ava:ava@localhost:5433/ava_test
           AVA_ORGANIZATION_ID: "00000000-0000-0000-0000-000000000001"
         run: bun tooling/scripts/document-pipeline-e2e.ts
+      # Fakturerings-E2E: tid → slutfaktura (frysning, moms, OCR) → avbetalnings-
+      # plan → försenad avbetalning (DUE/OVERDUE). Försenings-delen styrs av
+      # `asOf` i st.f. väggklockan, så jobbet beter sig likadant alla dagar i
+      # månaden — annars hade det varit ett datumberoende flake.
+      - name: Fakturerings-E2E (fakturering → plan → försenad betalning)
+        env:
+          SERVER_URL: http://localhost:3001
+          AVA_DATABASE_URL: postgres://ava:ava@localhost:5433/ava_test
+          AVA_ORGANIZATION_ID: "00000000-0000-0000-0000-000000000001"
+        run: bun tooling/scripts/billing-pipeline-e2e.ts
       - name: Tear down docker
         if: always()
         run: docker compose -f tooling/docker/docker-compose.server-first.yml down -v

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -330,7 +330,7 @@ bun-versionen där, gäller alla workflows. `ci.yml` har `concurrency`
 2. **Static analysis** — typecheck, lint (`--max-warnings 0`), `lint:complexity-strict`, depcruise, knip, jscpd. Inga tjänster.
 3. **Unit / komponent / integration** — `bun test` (två pass, se ovan) med coverage-ratchet mot in-memory `DemoDataStore`.
 4. **Repository (Postgres)** — Drizzle-repo-sviten mot RIKTIG Postgres i docker (fångar driver-/SQL-skillnader).
-5. **Server-first (deploy E2E)** — bygger server-first-binären, kör som docker-container mot Postgres, synkar push/pull + dokument-pipeline över HTTP.
+5. **Server-first (deploy E2E)** — bygger server-first-binären, kör som docker-container mot Postgres, synkar push/pull + dokument-pipeline + **faktureringskedjan** över HTTP. Faktureringsdelen (`billing-pipeline-e2e.ts`) täcker tid → slutfaktura (frysning, moms, OCR), avbetalning enligt plan (`INSTALLMENT_PLAN` → `PAID` + `COMPLETED`) och avbetalning som inte kommer i tid (DUE → OVERDUE, idempotent scan). Försenings-delen styrs av `asOf` i st.f. väggklockan, så jobbet är datum-oberoende. Kör lokalt med `bun run e2e:billing`.
 6. **E2E (OIDC login)** — browser-inloggning mot Keycloak via oauth2-proxy (Playwright).
 7. **Demo build** *(PR)* — statisk GH Pages-export + **bundle-size-ratchet** (`bun run size`).
 8. **Demo E2E (browser-smoke)** *(PR)* — serverar `out/` och verifierar att demon LADDAR (inte bara bygger). Hermetiskt: specarna blockerar varje förfrågan utanför sin egen origin (#932), så jobbet kan inte längre bli rött för att GH Pages ligger nere.

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "e2e:install": "playwright install --with-deps chromium",
     "e2e:oidc": "bash tooling/scripts/e2e-oidc.sh",
     "e2e:doc-pipeline": "bash tooling/scripts/document-pipeline-e2e.sh",
+    "e2e:billing": "bash tooling/scripts/billing-pipeline-e2e.sh",
     "e2e:conflict": "bash tooling/scripts/conflict-e2e.sh",
     "selfhosted:local": "bash tooling/scripts/selfhosted-local.sh",
     "diagnose-ui": "bun tooling/scripts/diagnose-ui.ts",

--- a/tooling/scripts/billing-pipeline-e2e.sh
+++ b/tooling/scripts/billing-pipeline-e2e.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Självständig runner för fakturerings-E2E:n (server-first-stacken).
+# Bygger binären, startar Postgres + server-first i docker, migrerar, kör
+# `billing-pipeline-e2e.ts` och river ner. Speglar `document-pipeline-e2e.sh`
+# och CI:s server-first-jobb (docker-compose.server-first.yml).
+#
+#   bash tooling/scripts/billing-pipeline-e2e.sh
+#
+# Täcker: fakturering (tid → slutfaktura, frysning, moms, OCR), avbetalning
+# enligt plan (INSTALLMENT_PLAN → PAID + COMPLETED) och avbetalning som inte
+# kommer i tid (DUE → OVERDUE, idempotent scan).
+set -euo pipefail
+
+COMPOSE="tooling/docker/docker-compose.server-first.yml"
+DB_URL="postgres://ava:ava@localhost:5433/ava_test"
+ORG="00000000-0000-0000-0000-000000000001"
+
+cleanup() { docker compose -f "$COMPOSE" down -v >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "▸ Bygger server-first-binären…"
+bun run server-first:build
+
+echo "▸ Startar Postgres + server-first…"
+docker compose -f "$COMPOSE" up -d --build --wait --wait-timeout 180
+
+echo "▸ Applicerar schema…"
+AVA_DATABASE_URL="$DB_URL" bun run db:migrate
+
+echo "▸ Kör fakturerings-E2E…"
+SERVER_URL=http://localhost:3001 \
+AVA_DATABASE_URL="$DB_URL" \
+AVA_ORGANIZATION_ID="$ORG" \
+  bun tooling/scripts/billing-pipeline-e2e.ts

--- a/tooling/scripts/billing-pipeline-e2e.ts
+++ b/tooling/scripts/billing-pipeline-e2e.ts
@@ -1,0 +1,260 @@
+#!/usr/bin/env bun
+/**
+ * Server-first FAKTURERINGS-E2E — kör mot en KÖRANDE server-first-container
+ * (docker-compose.server-first.yml), dvs. riktig Postgres över riktig HTTP.
+ *
+ * Enhetstesterna täcker matematiken och tillståndsmaskinen var för sig. Det här
+ * bevisar KEDJAN mot den deployade artefakten, i tre delar:
+ *
+ *   1. FAKTURERING — tid + utlägg → slutfaktura. Arbetet fryses (kan inte
+ *      faktureras igen), momsen är exakt 25 % av arvodet (#782), och fakturan
+ *      får nummer + OCR (ADR 0012).
+ *   2. AVBETALNING ENLIGT PLAN — plan på en SENT-faktura → INSTALLMENT_PLAN,
+ *      månadsbetalningar minskar utestående exakt, och SISTA betalningen
+ *      stänger både fakturan (PAID) och planen (COMPLETED).
+ *   3. AVBETALNING SOM INTE KOMMER I TID — `scanDueReminders` med `asOf` ger
+ *      DUE när förfallodagen passerat, OVERDUE nästa månad när inget betalats,
+ *      och är IDEMPOTENT (samma scan igen ger inga nya påminnelser).
+ *
+ * Determinism: hela försenings-delen styrs av `asOf` i st.f. väggklockan, så
+ * testet beter sig likadant den 1:a och den 31:a. Utan den parametern hade
+ * del 3 varit ett test som passerar eller fallerar beroende på dagens datum.
+ *
+ *   bun run server-first:build
+ *   docker compose -f tooling/docker/docker-compose.server-first.yml up -d --build --wait
+ *   AVA_DATABASE_URL=postgres://ava:ava@localhost:5433/ava_test bun run db:migrate
+ *   SERVER_URL=http://localhost:3001 \
+ *   AVA_DATABASE_URL=postgres://ava:ava@localhost:5433/ava_test \
+ *   AVA_ORGANIZATION_ID=00000000-0000-0000-0000-000000000001 \
+ *     bun tooling/scripts/billing-pipeline-e2e.ts
+ */
+
+import { createTRPCClient, httpBatchLink, type TRPCClient } from "@trpc/client";
+import postgres from "postgres";
+import superjson from "superjson";
+import type { AppRouter } from "@/lib/server/routers/_app";
+import { uuidv7 } from "@/lib/shared/uuid";
+
+const SERVER_URL = process.env.SERVER_URL ?? "http://localhost:3001";
+const DB_URL = process.env.AVA_DATABASE_URL ?? "postgres://ava:ava@localhost:5433/ava_test";
+const ORG = process.env.AVA_ORGANIZATION_ID ?? "00000000-0000-0000-0000-000000000001";
+const USER = "anna-billing@byra.se";
+
+/** Timtaxa och tid valda så arvodet blir jämnt: 2 h × 2 500 kr = 5 000 kr. */
+const HOURLY_RATE_ORE = 250_000;
+const WORK_MINUTES = 120;
+const ARVODE_NET_ORE = Math.round((WORK_MINUTES / 60) * HOURLY_RATE_ORE);
+const ARVODE_VAT_ORE = Math.round(ARVODE_NET_ORE * 0.25);
+
+function assert(cond: boolean, msg: string): void { if (!cond) throw new Error(`assert: ${msg}`); }
+function sleep(ms: number): Promise<void> { return new Promise((r) => setTimeout(r, ms)); }
+function kr(ore: number): string { return `${(ore / 100).toLocaleString("sv-SE")} kr`; }
+
+/** Seeda en allowlistad användare (orgProcedure släpper bara igenom dessa). */
+async function seedUser(email: string, name: string): Promise<string> {
+  const sql = postgres(DB_URL, { max: 1, onnotice: () => {} });
+  try {
+    const existing = await sql<Array<{ id: string }>>`SELECT id FROM users WHERE email = ${email} LIMIT 1`;
+    if (existing[0]) return existing[0].id;
+    const id = uuidv7();
+    await sql`INSERT INTO users (id, organization_id, email, name, role, active)
+              VALUES (${id}, ${ORG}, ${email}, ${name}, 'LAWYER', true)`;
+    return id;
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+function clientFor(email: string): TRPCClient<AppRouter> {
+  return createTRPCClient<AppRouter>({
+    links: [httpBatchLink({
+      url: `${SERVER_URL}/api/trpc`,
+      transformer: superjson,
+      headers: () => ({ "X-Auth-Request-Email": email }),
+    })],
+  });
+}
+
+async function waitForServer(client: TRPCClient<AppRouter>): Promise<void> {
+  for (let i = 0; i < 30; i++) {
+    try { await client.documentTemplate.list.query(); return; } catch { await sleep(1000); }
+  }
+  throw new Error(`server-first svarade inte på ${SERVER_URL} inom 30s`);
+}
+
+/** Ett ärende med klient — grunden för allt nedan. */
+async function setupMatter(c: TRPCClient<AppRouter>, userId: string, label: string): Promise<string> {
+  const client = await c.contacts.create.mutate({
+    name: `Klient ${label}`, contactType: "PERSON", email: `klient-${label}@example.test`,
+  });
+  const matter = await c.matter.create.mutate({
+    matterNumber: `E2E-${label}`, title: `Fakturerings-E2E ${label}`,
+    matterType: "Tvistemål", paymentMethod: "PRIVAT", responsibleLawyerId: userId,
+  });
+  await c.matter.addContact.mutate({ matterId: matter.id, contactId: client.id, role: "KLIENT" });
+  return matter.id;
+}
+
+/** Registrera debiterbart arbete på ärendet. */
+async function logWork(c: TRPCClient<AppRouter>, matterId: string, userId: string): Promise<void> {
+  await c.timeEntry.create.mutate({
+    matterId, userId, date: new Date().toISOString().slice(0, 10),
+    minutes: WORK_MINUTES, description: "Genomgång och skrivelse",
+    billable: true, hourlyRate: HOURLY_RATE_ORE,
+  });
+}
+
+// ─── Del 1: fakturering ────────────────────────────────────────────────────
+
+async function phaseInvoicing(c: TRPCClient<AppRouter>, matterId: string, userId: string): Promise<string> {
+  console.log("\n=== Del 1: fakturering ===");
+  await logWork(c, matterId, userId);
+
+  const proposal = await c.billingRun.proposal.query({ matterId });
+  assert(proposal.workValueOre === ARVODE_NET_ORE,
+    `upparbetat ${kr(proposal.workValueOre)} ≠ förväntat ${kr(ARVODE_NET_ORE)}`);
+  console.log(`  ✓ Upparbetat ofakturerat: ${kr(proposal.workValueOre)}`);
+
+  const { invoice } = await c.billingRun.createFinal.mutate({ matterId, recipient: "KLIENT" });
+  const expected = ARVODE_NET_ORE + ARVODE_VAT_ORE;
+  assert(invoice.amount === expected, `fakturabelopp ${kr(invoice.amount)} ≠ ${kr(expected)}`);
+  assert(invoice.vatOre === ARVODE_VAT_ORE, `moms ${kr(invoice.vatOre ?? 0)} ≠ ${kr(ARVODE_VAT_ORE)} (25 %, #782)`);
+  assert(/^F-\d{4}-\d+$/.test(String(invoice.invoiceNumber)), `fakturanummer saknar F-format: ${invoice.invoiceNumber}`);
+  assert(Boolean(invoice.ocrReference), "klientfaktura ska ha OCR (ADR 0012)");
+  console.log(`  ✓ Slutfaktura ${invoice.invoiceNumber}: ${kr(invoice.amount)} (moms ${kr(invoice.vatOre ?? 0)}), OCR satt`);
+
+  // Arbetet ska vara FRYST — annars kan samma timmar faktureras två gånger.
+  const after = await c.billingRun.proposal.query({ matterId });
+  assert(after.workValueOre === 0, `arbetet frystes inte: ${kr(after.workValueOre)} kvar som ofakturerat`);
+  console.log("  ✓ Arbetet fryst — kan inte faktureras igen");
+
+  // Överbetalning ska avvisas (partitionsvakten, ADR 0007).
+  await c.invoice.setStatus.mutate({ invoiceId: invoice.id, status: "SENT" });
+  let rejected = false;
+  try {
+    await c.invoice.recordPayment.mutate({
+      invoiceId: invoice.id, amount: invoice.amount + 100,
+      paidAt: new Date().toISOString(), note: "Överbetalning (ska avvisas)",
+    });
+  } catch { rejected = true; }
+  assert(rejected, "en betalning större än fakturan accepterades — partitionsvakten läcker");
+  console.log("  ✓ Överbetalning avvisas (ADR 0007)");
+
+  return invoice.id;
+}
+
+// ─── Del 2: avbetalning enligt plan ────────────────────────────────────────
+
+async function phaseInstallmentsOnTime(c: TRPCClient<AppRouter>, invoiceId: string): Promise<void> {
+  console.log("\n=== Del 2: avbetalning enligt plan ===");
+  const total = ARVODE_NET_ORE + ARVODE_VAT_ORE;
+  const installments = 3;
+  const monthly = Math.ceil(total / installments);
+
+  const plan = await c.invoice.createPaymentPlan.mutate({
+    invoiceId, monthlyAmount: monthly, dayOfMonth: 15,
+    startDate: new Date().toISOString().slice(0, 10), notes: "E2E-plan",
+  });
+  const withPlan = await c.invoice.getById.query({ id: invoiceId });
+  assert(withPlan.status === "INSTALLMENT_PLAN", `status ${withPlan.status} ≠ INSTALLMENT_PLAN`);
+  console.log(`  ✓ Plan skapad: ${installments} × ${kr(monthly)}, faktura → INSTALLMENT_PLAN`);
+
+  let paid = 0;
+  for (let n = 1; n <= installments; n++) {
+    // Sista posten kapas till ÅTERSTODEN — annars översumerar den fakturan.
+    const amount = Math.min(monthly, total - paid);
+    const res = await c.invoice.recordPayment.mutate({
+      invoiceId, amount, paidAt: new Date().toISOString(), note: `Månadsbetalning ${n}`,
+    });
+    paid += amount;
+    assert(res.paidSum === paid, `paidSum ${kr(res.paidSum)} ≠ ${kr(paid)}`);
+    const last = n === installments;
+    assert(res.settled === last, `settled=${res.settled} vid betalning ${n} av ${installments}`);
+    console.log(`  ✓ Betalning ${n}: ${kr(amount)} → betalt ${kr(paid)} av ${kr(total)}${last ? " (slutreglerad)" : ""}`);
+  }
+
+  const done = await c.invoice.getById.query({ id: invoiceId });
+  assert(done.status === "PAID", `faktura ${done.status} ≠ PAID efter full betalning`);
+  const plans = await c.paymentPlan.list.query({});
+  const updated = plans.items.find((p) => p.id === plan.id);
+  assert(updated?.status === "COMPLETED", `plan ${updated?.status} ≠ COMPLETED`);
+  console.log("  ✓ Sista betalningen stängde både fakturan (PAID) och planen (COMPLETED)");
+}
+
+// ─── Del 3: avbetalning som inte kommer i tid ──────────────────────────────
+
+/** `YYYY-MM` för ett datum — påminnelsernas nyckel. */
+function monthKey(d: Date): string {
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+async function phaseLateInstallments(c: TRPCClient<AppRouter>, matterId: string, userId: string): Promise<void> {
+  console.log("\n=== Del 3: avbetalning som inte kommer i tid ===");
+  await logWork(c, matterId, userId);
+  const { invoice } = await c.billingRun.createFinal.mutate({ matterId, recipient: "KLIENT" });
+  await c.invoice.setStatus.mutate({ invoiceId: invoice.id, status: "SENT" });
+
+  // Planen startar i en KÄND månad så scan-datumen blir deterministiska.
+  const start = new Date(Date.UTC(2026, 0, 10)); // 2026-01-10
+  const dayOfMonth = 15;
+  const plan = await c.invoice.createPaymentPlan.mutate({
+    invoiceId: invoice.id, monthlyAmount: Math.ceil(invoice.amount / 4), dayOfMonth,
+    startDate: start.toISOString().slice(0, 10), notes: "E2E-plan (försenad)",
+  });
+
+  // Förfallodagen i startmånaden har passerat → DUE, ingen OVERDUE ännu.
+  const afterFirstDue = new Date(Date.UTC(2026, 0, 20)).toISOString();
+  const first = await c.paymentPlan.scanDueReminders.mutate({ asOf: afterFirstDue });
+  assert(first.due >= 1, `ingen DUE-påminnelse vid ${afterFirstDue} (due=${first.due})`);
+  assert(first.overdue === 0, `OVERDUE för tidigt (overdue=${first.overdue})`);
+  console.log(`  ✓ Förfallodagen passerad → DUE (${first.due} st), ingen OVERDUE`);
+
+  // IDEMPOTENS: samma scan igen ska inte skapa något nytt.
+  const again = await c.paymentPlan.scanDueReminders.mutate({ asOf: afterFirstDue });
+  assert(again.planned === 0, `scan är inte idempotent — ${again.planned} nya påminnelser vid omkörning`);
+  console.log("  ✓ Omkörd scan skapar inga dubbletter (idempotent)");
+
+  // Nästa månad, fortfarande obetalt → OVERDUE för föregående månad.
+  const nextMonth = new Date(Date.UTC(2026, 1, 20)).toISOString();
+  const late = await c.paymentPlan.scanDueReminders.mutate({ asOf: nextMonth });
+  assert(late.overdue >= 1, `ingen OVERDUE trots obetald föregående månad (overdue=${late.overdue})`);
+  console.log(`  ✓ Obetald månad → OVERDUE (${late.overdue} st) — eskalering före vänlig DUE`);
+
+  // Påminnelseloggen ska bära bägge, nycklade per månad.
+  const detail = await c.paymentPlan.getById.query({ id: plan.id });
+  const kinds = new Set((detail.reminders ?? []).map((r) => `${r.type}:${r.dueMonth}`));
+  assert(kinds.has(`DUE:${monthKey(start)}`), `DUE för ${monthKey(start)} saknas i loggen: ${[...kinds].join(", ")}`);
+  assert([...kinds].some((k) => k.startsWith("OVERDUE:")), `ingen OVERDUE i loggen: ${[...kinds].join(", ")}`);
+  console.log(`  ✓ Påminnelseloggen: ${[...kinds].sort().join(", ")}`);
+
+  // En betalning stoppar eskaleringen: remaining ≤ 0 → inga fler påminnelser.
+  await c.invoice.recordPayment.mutate({
+    invoiceId: invoice.id, amount: invoice.amount,
+    paidAt: nextMonth, note: "Full betalning (stoppar eskalering)",
+  });
+  const settled = await c.paymentPlan.scanDueReminders.mutate({ asOf: new Date(Date.UTC(2026, 2, 20)).toISOString() });
+  assert(settled.planned === 0, `påminnelser skickades för en betald plan (planned=${settled.planned})`);
+  console.log("  ✓ Fullbetald plan påminns inte längre");
+}
+
+async function main(): Promise<void> {
+  const userId = await seedUser(USER, "Anna Billing");
+  const c = clientFor(USER);
+  await waitForServer(c);
+  console.log(`Fakturerings-E2E mot ${SERVER_URL}`);
+
+  const stamp = Date.now().toString(36);
+  const invoiceMatter = await setupMatter(c, userId, `fakt-${stamp}`);
+  const invoiceId = await phaseInvoicing(c, invoiceMatter, userId);
+  await phaseInstallmentsOnTime(c, invoiceId);
+
+  const lateMatter = await setupMatter(c, userId, `sen-${stamp}`);
+  await phaseLateInstallments(c, lateMatter, userId);
+
+  console.log("\n✓ Fakturerings-E2E klart: fakturering, avbetalning enligt plan, försenad avbetalning.");
+}
+
+main().catch((e: unknown) => {
+  console.error(`\n✗ Fakturerings-E2E misslyckades: ${e instanceof Error ? e.message : String(e)}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Refs #1030. De tre områdena du efterfrågade, utan Fortnox-beroende.

## Vad som testas

Enhetstesterna täcker matematiken och tillståndsmaskinen var för sig. Det som saknades var beviset att **kedjan** håller mot den deployade artefakten — riktig Postgres, riktig HTTP, samma binär som driftas. Körs i det befintliga `Server-first (deploy E2E)`-jobbet, som redan har stacken uppe.

**1. Fakturering** — tid → slutfaktura. Assertar att
- arbetet **fryses** (samma timmar kan inte faktureras igen — proposal går till 0),
- momsen är **exakt 25 % av arvodet** (#782),
- fakturan får F-nummer + OCR (ADR 0012),
- en **överbetalning avvisas** av partitionsvakten (ADR 0007).

**2. Avbetalning enligt plan** — plan på en `SENT`-faktura → `INSTALLMENT_PLAN`. Månadsbetalningarna minskar utestående exakt, sista posten kapas till återstoden, och den sista betalningen stänger **båda**: fakturan (`PAID`) och planen (`COMPLETED`).

**3. Avbetalning som inte kommer i tid** — `DUE` när förfallodagen passerat, `OVERDUE` nästa månad när inget betalats, och scan:en är **idempotent** (omkörning ger noll nya). Avslutas med att en full betalning stoppar eskaleringen.

## Determinismen ligger i `asOf`

Hela försenings-delen styrs av ett injicerat datum i stället för väggklockan. Utan det hade testet passerat eller fallerat beroende på vilken dag i månaden CI råkade köra — ett datumberoende flake, och just den sortens test man slutar lita på. `scanDueReminders` hade redan parametern; den här PR:en använder den.

## Verifierat skarpt, inte bara skrivet

Jag startade docker-daemonen i sessionen och körde hela stacken:

```
=== Del 1: fakturering ===
  ✓ Upparbetat ofakturerat: 5 000 kr
  ✓ Slutfaktura F-2026-0001: 6 250 kr (moms 1 250 kr), OCR satt
  ✓ Arbetet fryst — kan inte faktureras igen
  ✓ Överbetalning avvisas (ADR 0007)

=== Del 2: avbetalning enligt plan ===
  ✓ Plan skapad: 3 × 2 083,34 kr, faktura → INSTALLMENT_PLAN
  ✓ Betalning 3: 2 083,32 kr → betalt 6 250 kr av 6 250 kr (slutreglerad)
  ✓ Sista betalningen stängde både fakturan (PAID) och planen (COMPLETED)

=== Del 3: avbetalning som inte kommer i tid ===
  ✓ Förfallodagen passerad → DUE (1 st), ingen OVERDUE
  ✓ Omkörd scan skapar inga dubbletter (idempotent)
  ✓ Obetald månad → OVERDUE (1 st) — eskalering före vänlig DUE
  ✓ Påminnelseloggen: DUE:2026-01, OVERDUE:2026-01
  ✓ Fullbetald plan påminns inte längre
```

**Körd två gånger** (grön båda, inga rester mellan körningar — varje körning skapar egna ärenden), plus en **känslighets-probe** som visar att DUE-assertionen inte är vakuös: scan *före* förfallodagen ger `due=0`, efter ger `due=1`.

## Övrigt

`bun run e2e:billing` kör hela stacken lokalt (bygger, startar docker, migrerar, kör, river ner) — samma mönster som `e2e:doc-pipeline`. Dokumenterat i `docs/quality.md` under jobb 5.

typecheck ✅ · lint ✅ · knip ✅ · YAML-validerad.

## Fortnox

Orörd i den här PR:en. `fortnox-e2e.ts` väntar på att du lägger secrets och gör en ny consent-runda — inget här beror på det.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRuanL89iejCSJuud9WHA4)_