### PR TITLE
fix(fortnox): byt · mot bindestreck i verifikattexten — Fortnox avvisar tecknet

### DIFF
--- a/src/lib/shared/accounting/semantic-voucher.ts
+++ b/src/lib/shared/accounting/semantic-voucher.ts
@@ -155,10 +155,17 @@ export function buildSemanticVoucher(
   };
 }
 
-/** Verifikatets titel: AVA-ärendenumret först (#785), sedan ev. fakturanummer. */
+/**
+ * Verifikatets titel: AVA-ärendenumret först (#785), sedan ev. fakturanummer.
+ *
+ * Separatorn är ett vanligt bindestreck, INTE `·` (U+00B7). Fortnox avvisar
+ * mittpunkten med `400 … code 2000359 "Värdet innehåller ej tillåtna tecken"`
+ * — verifierat skarpt 2026-09-05 (#1043). Åäö går bra; det är just den
+ * exotiska interpunktionen som fälls. Byt inte tillbaka för snyggheten skull.
+ */
 function voucherDescription(invoice: SemanticVoucherInput): string {
   const faktura = invoice.invoiceNumber ? `Faktura ${invoice.invoiceNumber}` : "Kundfaktura (AVA)";
-  return invoice.matterNumber ? `Ärende ${invoice.matterNumber} · ${faktura}` : faktura;
+  return invoice.matterNumber ? `Ärende ${invoice.matterNumber} - ${faktura}` : faktura;
 }
 
 /**

--- a/test/unit/shared/accounting/semantic-voucher.test.ts
+++ b/test/unit/shared/accounting/semantic-voucher.test.ts
@@ -49,7 +49,16 @@ describe("buildSemanticVoucher", () => {
 
   it("titeln innehåller AVA-ärendenumret när det finns (#785)", () => {
     const v = buildSemanticVoucher({ amount: 12_500, invoiceDate: "2026-05-25", invoiceNumber: "F-2026-0042", matterNumber: "AA2026-0001" });
-    expect(v.description).toBe("Ärende AA2026-0001 · Faktura F-2026-0042");
+    expect(v.description).toBe("Ärende AA2026-0001 - Faktura F-2026-0042");
+  });
+
+  // #1043: Fortnox svarar 400 (code 2000359, "Värdet innehåller ej tillåtna
+  // tecken") på `·` U+00B7. Enhetstesterna kör med injicerad fetch och ser
+  // aldrig teckenvalideringen, så separatorn måste vaktas här — annars smyger
+  // mittpunkten tillbaka och VARJE bokföring fallerar skarpt.
+  it("använder ingen exotisk interpunktion Fortnox avvisar (#1043)", () => {
+    const v = buildSemanticVoucher({ amount: 12_500, invoiceDate: "2026-05-25", invoiceNumber: "F-2026-0042", matterNumber: "AA2026-0001" });
+    expect(v.description).not.toContain("\u00B7");
   });
 
   it("per-sats breakdown (#790): moms bokförs per sats + intäkt delas arvode/utlägg", () => {


### PR DESCRIPTION
Första skarpa e2e-körningen mot Fortnox Voucher API (möjlig först sedan #1039 fixat authorize-rundan) svarade:

```
400 {"ErrorInformation":{"error":1,"code":2000359,
  "message":"Värdet innehåller ej tillåtna tecken. (Ärende E2E-… · Faktura E2E-…)"}}
```

Tecknet är **U+00B7 MIDDLE DOT** i `voucherDescription`. Åäö går bra — det är den exotiska interpunktionen som fälls.

**Det här var inte ett testproblem.** `buildSemanticVoucher` är enda vägen till `POST /3/vouchers`, och varje faktura med ett ärendenummer fick den beskrivningen. Ingen bokföring mot Fortnox hade gått igenom.

Enhetstesterna kör med injicerad `fetch` och ser aldrig teckenvalideringen — precis den lucka e2e:t finns för att täcka. Separatorn vaktas nu av ett eget test.

## Verifierat

Skarp körning mot Fortnox efter fixen: teckenfelet borta (nästa steg fastnade på en kontoplansfråga i testföretaget, inte på koden). `bun run quality:fast` grön.

Closes #1043

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9UB9at5Tpr1A6sYEXomxB