### PR TITLE
fix(fortnox): ställ ut fakturan innan bokföring i e2e:t — DRAFT bokförs aldrig

### DIFF
--- a/tooling/scripts/fortnox-bookkeeping-e2e.ts
+++ b/tooling/scripts/fortnox-bookkeeping-e2e.ts
@@ -126,16 +126,35 @@ interface BookingCtx {
 /** Bokför EN faktura och verifiera dess verifikat. */
 async function bookAndVerify(ctx: BookingCtx, invoiceId: string, label: string): Promise<void> {
   const { ava: c, client, connector, mapping, bookingDate } = ctx;
+
+  // Ställ ut fakturan först. `settleCoverage` skapar den som DRAFT, och
+  // `isBookable` hoppar korrekt över utkast — ett utkast existerar inte
+  // bokföringsmässigt. Utan det här steget bokförs ingenting och drivrutinen
+  // returnerar en TOM lista, vilket inte är ett fel utan ett korrekt "nej"
+  // (#1046). Riktiga byråer skickar fakturan innan de bokför den.
+  const before = await c.invoice.getById.query({ id: invoiceId });
+  if (before.status === "DRAFT") {
+    await c.invoice.setStatus.mutate({ invoiceId, status: "SENT" });
+  }
+
   const raw = await c.invoice.getById.query({ id: invoiceId });
   const inv = toBookable(raw as Parameters<typeof toBookable>[0], bookingDate);
-  console.log(`  ${label}: ${inv.invoiceNumber} · ${kr(inv.amount)} (moms ${kr(inv.vatOre ?? 0)})`);
+  console.log(`  ${label}: ${inv.invoiceNumber} · ${kr(inv.amount)} (moms ${kr(inv.vatOre ?? 0)}) · status ${inv.status}`);
 
   const marked: Array<[string, string]> = [];
   const [outcome] = await bookUnbookedInvoices({
     invoices: [inv], connector, markBooked: async (id, ext) => { marked.push([id, ext]); },
   });
-  if (!outcome || outcome.error || !outcome.externalId) {
-    throw new Error(`bokföring av ${label} misslyckades: ${outcome?.error ?? "inget utfall"}`);
+  // Skilj på "drivrutinen sa nej" och "pushen gick fel". Utan den skillnaden
+  // rapporterades båda som "inget utfall", vilket dolde att fakturan var DRAFT.
+  if (!outcome) {
+    throw new Error(
+      `${label} var inte bokförbar: status ${inv.status}, fortnoxId ${inv.fortnoxId ?? "null"} `
+      + "— drivrutinen såg den inte som kandidat.",
+    );
+  }
+  if (outcome.error || !outcome.externalId) {
+    throw new Error(`bokföring av ${label} misslyckades: ${outcome.error ?? "pushen gav inget externt id"}`);
   }
   assert(marked.length === 1, `write-back uteblev för ${label}`);
   await verifyVoucher(client, mapping, outcome.externalId, inv);


### PR DESCRIPTION
Bokföringsläget (`bookkeeping=true`, det som push/schedule kör) föll på:

```
✗ bokföring av Klientens självrisk misslyckades: inget utfall
```

## Orsak — inte Fortnox

`settleCoverage` skapar fakturorna som `DRAFT`. `isBookable` hoppar korrekt över utkast (ett utkast är inte utställt och existerar inte bokföringsmässigt), så `bookUnbookedInvoices` returnerade en **tom lista** — ett korrekt "nej", inte ett fel.

Testet saknade alltså ett steg som varje riktig byrå gör: skicka fakturan innan den bokförs. Fixat med `invoice.setStatus` → `SENT`.

## Felmeddelandet dolde orsaken

"inget utfall" slog ihop *"drivrutinen såg den inte som kandidat"* med *"pushen gick fel"*. Nu namnger det första fallet status och `fortnoxId`, så nästa gång står orsaken i loggen.

## Läget i övrigt

Syntet-fakturan går grönt skarpt mot Fortnox: verifikat `A/1` i CI-året 2027, 3 rader, debet 125 = kredit 125, idempotens och bokföringsspärr verifierade. Token-rotationen är bevisad över flera körningar i rad.

Closes #1046

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9UB9at5Tpr1A6sYEXomxB