### PR TITLE
test(fortnox): delta-koll mot Fortnox — bevisa att inget MER landade

### DIFF
--- a/src/lib/server/integrations/fortnox/client.ts
+++ b/src/lib/server/integrations/fortnox/client.ts
@@ -8,14 +8,17 @@
 
 import { refreshTokens, type FetchFn } from "./oauth";
 import {
+  fortnoxFinancialYearListSchema,
   fortnoxInboxResponseSchema,
   fortnoxVoucherFetchSchema,
+  fortnoxVoucherListSchema,
   fortnoxVoucherResponseSchema,
   fortnoxVoucherSeriesListSchema,
   fortnoxVoucherSeriesResponseSchema,
   type FortnoxConfig,
   type FortnoxVoucher,
   type FortnoxVoucherFetch,
+  type FortnoxVoucherHead,
   type FortnoxVoucherResponse,
   type FortnoxVoucherSeries,
 } from "./schema";
@@ -117,6 +120,39 @@ export class FortnoxClient {
   async listVoucherSeries(): Promise<FortnoxVoucherSeries[]> {
     const res = await this.withRetry((t) => this.apiGet("/3/voucherseries", t), "serielistning");
     return fortnoxVoucherSeriesListSchema.parse(await res.json()).VoucherSeriesCollection;
+  }
+
+  /**
+   * Räkenskapsårets `Id` för ett datum-intervall (#1050). `financialyear`-
+   * parametern vill ha Id:t, inte årtalet — slås upp här i st.f. att hårdkodas,
+   * så CI inte går sönder tyst när byrån lägger upp ytterligare ett år.
+   */
+  async financialYearIdFor(fromDate: string, toDate: string): Promise<number> {
+    const res = await this.withRetry((t) => this.apiGet("/3/financialyears", t), "räkenskapsårslistning");
+    const years = fortnoxFinancialYearListSchema.parse(await res.json()).FinancialYears;
+    const hit = years.find((y) => y.FromDate === fromDate && y.ToDate === toDate);
+    if (!hit) {
+      const known = years.map((y) => `${y.FromDate}..${y.ToDate}`).join(", ");
+      throw new Error(`Inget räkenskapsår ${fromDate}..${toDate} i Fortnox. Fanns: ${known || "inga"}`);
+    }
+    return hit.Id;
+  }
+
+  /**
+   * Alla verifikat i ett räkenskapsår — HUVUDEN, inte rader (`GET /3/vouchers`
+   * levererar inga `VoucherRows`). Sidorna hämtas till `@TotalPages` är slut;
+   * utan det hade delta-kollen tystnat så fort CI-året passerat en sidbredd,
+   * och en tyst delta-koll är värre än ingen.
+   */
+  async listVouchers(financialYearId: number, pageSize = 100): Promise<FortnoxVoucherHead[]> {
+    const all: FortnoxVoucherHead[] = [];
+    for (let page = 1; ; page++) {
+      const path = `/3/vouchers?financialyear=${financialYearId}&limit=${pageSize}&page=${page}`;
+      const res = await this.withRetry((t) => this.apiGet(path, t), "verifikatlistning");
+      const body = fortnoxVoucherListSchema.parse(await res.json());
+      all.push(...body.Vouchers);
+      if (page >= (body.MetaInformation?.["@TotalPages"] ?? 1)) return all;
+    }
   }
 
   /**

--- a/src/lib/server/integrations/fortnox/schema.ts
+++ b/src/lib/server/integrations/fortnox/schema.ts
@@ -198,6 +198,53 @@ export const fortnoxVoucherSeriesResponseSchema = z.object({
   VoucherSeries: fortnoxVoucherSeriesSchema,
 });
 
+// ─── Verifikatlistning + räkenskapsår (#1050) ───────────────────────────────
+
+/**
+ * Ett verifikat som det ser ut i LISTsvaret. Rader ingår INTE — `GET /3/vouchers`
+ * ger bara huvuden, raderna kräver `GET /3/vouchers/{serie}/{nr}` per verifikat
+ * (verifierat mot skarp sandbox 2026-09-05). Det duger för delta-kollen, som
+ * frågar VILKA verifikat som finns, inte vad de innehåller.
+ */
+export const fortnoxVoucherHeadSchema = z.looseObject({
+  VoucherSeries: z.string().min(1),
+  VoucherNumber: z.number().int(),
+  Description: z.string().nullish(),
+  TransactionDate: z.string().optional(),
+  Year: z.number().int().optional(),
+});
+export type FortnoxVoucherHead = z.infer<typeof fortnoxVoucherHeadSchema>;
+
+/** Fortnox pagineringshuvud. `@TotalPages` styr hur många sidor vi hämtar. */
+export const fortnoxMetaSchema = z.looseObject({
+  "@TotalResources": z.number().int().optional(),
+  "@TotalPages": z.number().int().optional(),
+  "@CurrentPage": z.number().int().optional(),
+});
+
+/** Svar från `GET /3/vouchers` (lista). */
+export const fortnoxVoucherListSchema = z.object({
+  MetaInformation: fortnoxMetaSchema.optional(),
+  Vouchers: z.array(fortnoxVoucherHeadSchema),
+});
+
+/**
+ * Ett räkenskapsår. `Id` är INTE årtalet — det är en löpande nyckel, och det är
+ * den `financialyear`-parametern vill ha. Att hårdkoda den (CI-året råkade bli
+ * `2`) hade gått sönder tyst dagen någon lägger upp ett år till, därför slås den
+ * upp mot datumintervallet i stället.
+ */
+export const fortnoxFinancialYearSchema = z.looseObject({
+  Id: z.number().int(),
+  FromDate: z.string().min(1),
+  ToDate: z.string().min(1),
+});
+
+/** Svar från `GET /3/financialyears` (lista). */
+export const fortnoxFinancialYearListSchema = z.object({
+  FinancialYears: z.array(fortnoxFinancialYearSchema),
+});
+
 // ─── Filbilaga (#785) ───────────────────────────────────────────────────────
 
 /** Svar från `POST /3/inbox` (fil-uppladdning) — vi behöver fil-id:t (GUID). */

--- a/test/unit/server/integrations/fortnox/client.test.ts
+++ b/test/unit/server/integrations/fortnox/client.test.ts
@@ -289,3 +289,60 @@ describe("FortnoxClient — verifikatserier (#1035)", () => {
     await expect(client.createVoucherSeries("A", "dubblett")).rejects.toThrow(/400/);
   });
 });
+
+describe("FortnoxClient — verifikatlistning + räkenskapsår (#1050)", () => {
+  /** fetch som svarar på financialyears och paginerade voucher-listor. */
+  function listFetch(pages: Array<{ vouchers: Array<{ s: string; n: number }>; totalPages: number }>) {
+    const seen: string[] = [];
+    const fn = (async (url: string | URL) => {
+      const u = String(url);
+      seen.push(u);
+      if (u.endsWith("/oauth-v1/token")) return json(200, ROTATED);
+      if (u.includes("/3/financialyears")) {
+        return json(200, { FinancialYears: [
+          { Id: 1, FromDate: "2026-01-01", ToDate: "2026-12-31" },
+          { Id: 2, FromDate: "2027-01-01", ToDate: "2027-12-31" },
+        ] });
+      }
+      const page = Number(new URL(u).searchParams.get("page") ?? "1");
+      const p = pages[page - 1] ?? { vouchers: [], totalPages: pages.length };
+      return json(200, {
+        MetaInformation: { "@TotalPages": p.totalPages, "@CurrentPage": page },
+        Vouchers: p.vouchers.map((v) => ({ VoucherSeries: v.s, VoucherNumber: v.n })),
+      });
+    }) as typeof globalThis.fetch;
+    return { fn, seen };
+  }
+
+  it("slår upp räkenskapsårets Id via datumintervallet, inte årtalet", async () => {
+    const { fn } = listFetch([{ vouchers: [], totalPages: 1 }]);
+    const client = new FortnoxClient(config, new InMemoryFortnoxTokenStore(fresh()), fn);
+    expect(await client.financialYearIdFor("2027-01-01", "2027-12-31")).toBe(2);
+  });
+
+  it("kastar med de kända åren när intervallet inte finns — tyst fel vore värre", async () => {
+    const { fn } = listFetch([{ vouchers: [], totalPages: 1 }]);
+    const client = new FortnoxClient(config, new InMemoryFortnoxTokenStore(fresh()), fn);
+    await expect(client.financialYearIdFor("2030-01-01", "2030-12-31")).rejects.toThrow(/2027-01-01\.\.2027-12-31/);
+  });
+
+  // Utan pagineringsloopen hade listan tystnat vid sidbrytningen, och en tyst
+  // delta-koll rapporterar "inget nytt" i stället för att fälla.
+  it("hämtar ALLA sidor, inte bara den första", async () => {
+    const { fn, seen } = listFetch([
+      { vouchers: [{ s: "A", n: 1 }, { s: "A", n: 2 }], totalPages: 2 },
+      { vouchers: [{ s: "A", n: 3 }], totalPages: 2 },
+    ]);
+    const client = new FortnoxClient(config, new InMemoryFortnoxTokenStore(fresh()), fn);
+    const all = await client.listVouchers(2, 2);
+    expect(all.map((v) => v.VoucherNumber)).toEqual([1, 2, 3]);
+    expect(seen.filter((u) => u.includes("/3/vouchers")).length).toBe(2);
+  });
+
+  it("skickar räkenskapsårets id som financialyear-parameter", async () => {
+    const { fn, seen } = listFetch([{ vouchers: [], totalPages: 1 }]);
+    const client = new FortnoxClient(config, new InMemoryFortnoxTokenStore(fresh()), fn);
+    await client.listVouchers(2);
+    expect(seen.some((u) => u.includes("financialyear=2"))).toBe(true);
+  });
+});

--- a/test/unit/tooling/fortnox-delta.test.ts
+++ b/test/unit/tooling/fortnox-delta.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest-compat";
+import { assertVoucherDelta, voucherKey } from "../../../tooling/scripts/fortnox-harness";
+
+/**
+ * Delta-kollen (#1050) är den enda kontrollen som kan se att det landade
+ * något MER i Fortnox än vad testet skickade. Per-verifikat-läsningen frågar
+ * efter verifikat vi själva känner till och kan därför aldrig upptäcka en
+ * dubblett — och en dubbelbokförd faktura går inte att ta tillbaka via API:t.
+ *
+ * Därför testas logiken här, mot mängder, utan nät: det är billigt och det
+ * fäller på exakt de fall som gör ont skarpt.
+ */
+describe("assertVoucherDelta (#1050)", () => {
+  const before = new Set(["A/1", "A/2"]);
+
+  it("släpper igenom när exakt de förväntade verifikaten tillkommit", () => {
+    const after = new Set([...before, "A/3", "A/4"]);
+    expect(() => assertVoucherDelta(before, after, ["A/3", "A/4"])).not.toThrow();
+  });
+
+  it("bryr sig inte om ordningen — Fortnox listar inte i skapandeordning", () => {
+    const after = new Set([...before, "A/4", "A/3"]);
+    expect(() => assertVoucherDelta(before, after, ["A/3", "A/4"])).not.toThrow();
+  });
+
+  // Det här är hela poängen: ett verifikat vi inte bad om.
+  it("fäller på ett OVÄNTAT verifikat och namnger det", () => {
+    const after = new Set([...before, "A/3", "A/4"]);
+    expect(() => assertVoucherDelta(before, after, ["A/3"]))
+      .toThrow(/A\/4/);
+  });
+
+  it("kallar det oväntade för dubblett/strökontering, inte bara \"fel\"", () => {
+    const after = new Set([...before, "A/3", "A/4"]);
+    expect(() => assertVoucherDelta(before, after, ["A/3"]))
+      .toThrow(/Dubblett eller strökontering/);
+  });
+
+  // Motsatta felet: pushen sa 200 men verifikatet finns inte.
+  it("fäller när ett förväntat verifikat SAKNAS trots lyckad push", () => {
+    const after = new Set([...before, "A/3"]);
+    expect(() => assertVoucherDelta(before, after, ["A/3", "A/4"]))
+      .toThrow(/saknas i Fortnox.*A\/4/s);
+  });
+
+  it("ignorerar verifikat som fanns redan före körningen", () => {
+    const fat = new Set(["A/1", "A/2", "A/3", "A/4", "A/5"]);
+    expect(() => assertVoucherDelta(fat, new Set([...fat, "A/6"]), ["A/6"])).not.toThrow();
+  });
+
+  // Ett tomt delta är giltigt (dry-run), men bara om inget förväntades.
+  it("accepterar tomt delta när inget förväntades", () => {
+    expect(() => assertVoucherDelta(before, new Set(before), [])).not.toThrow();
+  });
+
+  it("fäller på tomt delta när något förväntades", () => {
+    expect(() => assertVoucherDelta(before, new Set(before), ["A/3"])).toThrow(/saknas/);
+  });
+});
+
+describe("voucherKey", () => {
+  it("formar nyckeln som Fortnox externa id: serie/nummer", () => {
+    expect(voucherKey({ VoucherSeries: "A", VoucherNumber: 7 })).toBe("A/7");
+  });
+});

--- a/tooling/scripts/fortnox-bookkeeping-e2e.ts
+++ b/tooling/scripts/fortnox-bookkeeping-e2e.ts
@@ -42,7 +42,8 @@ import {
   assert, clientFor, kr, seedUser, waitForServer, type Ava,
 } from "./e2e-harness";
 import {
-  bookingWindow, buildConfig, buildMapping, ciBookingDate, connect, emitRotatedToken,
+  assertVoucherDelta, bookingWindow, buildConfig, buildMapping, ciBookingDate, connect,
+  emitRotatedToken, snapshotVouchers,
 } from "./fortnox-harness";
 
 const USER = "anna-bookkeeping@byra.se";
@@ -124,7 +125,7 @@ interface BookingCtx {
 }
 
 /** Bokför EN faktura och verifiera dess verifikat. */
-async function bookAndVerify(ctx: BookingCtx, invoiceId: string, label: string): Promise<void> {
+async function bookAndVerify(ctx: BookingCtx, invoiceId: string, label: string): Promise<string> {
   const { ava: c, client, connector, mapping, bookingDate } = ctx;
 
   // Ställ ut fakturan först. `settleCoverage` skapar den som DRAFT, och
@@ -161,6 +162,7 @@ async function bookAndVerify(ctx: BookingCtx, invoiceId: string, label: string):
 
   // Skriv tillbaka i AVA också — annars bokförs fakturan igen nästa körning.
   await c.invoice.markFortnoxBooked.mutate({ invoiceId, fortnoxId: outcome.externalId });
+  return outcome.externalId;
 }
 
 async function main(): Promise<void> {
@@ -194,9 +196,21 @@ async function main(): Promise<void> {
   assert(payer !== undefined, "hittade ingen betalarfaktura på ärendet");
 
   console.log("\n→ Steg 3: bokför BÅDA fakturorna mot Fortnox …");
+  // Före-läget tas FÖRE första pushen, annars är den första fakturan redan
+  // med i baslinjen och delta-kollen skulle inte kunna se en dubblett av den.
+  const yearId = await client.financialYearIdFor(period.from, period.to);
+  const before = await snapshotVouchers(client, yearId);
+
   const ctx: BookingCtx = { ava: c, client, connector, mapping, bookingDate };
-  await bookAndVerify(ctx, clientInvoiceId, "Klientens självrisk");
-  await bookAndVerify(ctx, String(payer?.id), "Försäkringsbolagets del");
+  const created = [
+    await bookAndVerify(ctx, clientInvoiceId, "Klientens självrisk"),
+    await bookAndVerify(ctx, String(payer?.id), "Försäkringsbolagets del"),
+  ];
+
+  // Två betalande ska ge exakt TVÅ verifikat. Landar det ett tredje har någon
+  // faktura bokförts dubbelt — och det går inte att ta tillbaka via API:t.
+  console.log("\n→ Steg 4: delta-koll mot Fortnox …");
+  assertVoucherDelta(before, await snapshotVouchers(client, yearId), created);
 
   console.log("\n✓ Bokförings-E2E klart: båda betalarnas fakturor bokförda och verifierade i Fortnox.");
 }

--- a/tooling/scripts/fortnox-e2e.ts
+++ b/tooling/scripts/fortnox-e2e.ts
@@ -36,7 +36,8 @@ import { bookUnbookedInvoices, type BookableInvoice } from "@/lib/server/integra
 import { withBookingWindow, type BookingWindow } from "@/lib/server/integrations/ledger/booking-window";
 import type { LedgerConnector } from "@/lib/server/integrations/ledger/port";
 import {
-  bookingWindow, buildConfig, buildMapping, ciBookingDate, connect, emitRotatedToken,
+  assertVoucherDelta, bookingWindow, buildConfig, buildMapping, ciBookingDate, connect,
+  emitRotatedToken, snapshotVouchers,
 } from "./fortnox-harness";
 
 /** En faktura att bokföra. Byggd i minnet: det som testas är LEDGER-vägen,
@@ -132,10 +133,22 @@ async function main(): Promise<void> {
   const invoice = testInvoice(stamp, bookingDate);
   const connector = withBookingWindow(new FortnoxLedgerConnector({ client, mapping }), period);
 
+  // Före-läget: allt som redan finns i CI-året. Delta mot det här efteråt är
+  // vad som gör att året aldrig behöver nollställas (#1050).
+  const yearId = await client.financialYearIdFor(period.from, period.to);
+  const before = await snapshotVouchers(client, yearId);
+  console.log(`  ✓ Räkenskapsår ${period.from}..${period.to} = Fortnox-id ${yearId} (${before.size} verifikat sedan tidigare)`);
+
   const externalId = await pushTestInvoice(connector, invoice);
   await verifyVoucher(client, externalId);
   await verifyIdempotens(connector, invoice, externalId);
   await verifyWindowGuard(connector, invoice, period);
+
+  // Steg 6: bokförde vi exakt ETT verifikat? Idempotens- och spärrstegen ovan
+  // ska inte ha lämnat något efter sig — men det är just det man inte ser
+  // genom att läsa tillbaka det verifikat man själv känner till.
+  console.log("→ Steg 6: delta-koll mot Fortnox …");
+  assertVoucherDelta(before, await snapshotVouchers(client, yearId), [externalId]);
 
   console.log(`\n✓ Fortnox-E2E klart. Verifikat ${externalId} i serie ${mapping.voucherSeries}, daterat ${bookingDate}.`);
 }

--- a/tooling/scripts/fortnox-harness.ts
+++ b/tooling/scripts/fortnox-harness.ts
@@ -83,6 +83,52 @@ export function connect(config: FortnoxConfig): { client: FortnoxClient; store: 
   return { client: new FortnoxClient(config, store), store };
 }
 
+/** Ett verifikat som "A/7" — nyckeln delta-kollen jämför på. */
+export function voucherKey(v: { VoucherSeries: string; VoucherNumber: number }): string {
+  return `${v.VoucherSeries}/${v.VoucherNumber}`;
+}
+
+/**
+ * Delta-koll mot Fortnox (#1050): vad fanns FÖRE körningen, vad finns EFTER?
+ *
+ * Per-verifikat-läsningen (`getVoucher`) svarar på "landade det vi skickade
+ * rätt?". Den kan strukturellt inte se att det landade något MER — en dubblett
+ * från en omkörning, ett halvskrivet verifikat från ett avbrutet jobb. Den
+ * frågan kräver aggregat, och det är dyrt att missa: Fortnox har ingen DELETE
+ * för verifikat.
+ *
+ * Delta i st.f. absoluta saldon är det som gör att CI-året ALDRIG behöver
+ * nollställas. Ett tomt år hade krävts för att påstå "konto 1510 = X"; för att
+ * påstå "exakt de här verifikaten tillkom" räcker två billiga listningar.
+ */
+export async function snapshotVouchers(client: FortnoxClient, yearId: number): Promise<Set<string>> {
+  return new Set((await client.listVouchers(yearId)).map(voucherKey));
+}
+
+/**
+ * Jämför efter-läget mot före-läget. `expected` är de verifikat körningen
+ * medvetet skapade — allt annat som tillkommit är ett fynd, inte brus.
+ */
+export function assertVoucherDelta(
+  before: Set<string>, after: Set<string>, expected: readonly string[],
+): void {
+  const added = [...after].filter((k) => !before.has(k)).sort();
+  const want = [...expected].sort();
+
+  const unexpected = added.filter((k) => !want.includes(k));
+  if (unexpected.length > 0) {
+    throw new Error(
+      `Fortnox fick ${unexpected.length} verifikat som testet inte skapade: ${unexpected.join(", ")}. `
+      + "Dubblett eller strökontering — kontrollera i GUI:t innan nästa körning.",
+    );
+  }
+  const missing = want.filter((k) => !added.includes(k));
+  if (missing.length > 0) {
+    throw new Error(`Verifikat saknas i Fortnox trots att pushen lyckades: ${missing.join(", ")}`);
+  }
+  console.log(`  ✓ Delta: exakt ${added.length} nya verifikat (${added.join(", ") || "inga"}) — inget mer`);
+}
+
 /**
  * Skriv den roterade refresh-token:en till `$GITHUB_OUTPUT`. ALDRIG till
  * stdout — GitHub maskerar bara det den känner till. Anropas direkt efter


### PR DESCRIPTION
Per-verifikat-läsningen (`getVoucher`) svarar på *"landade det vi skickade rätt?"*. Den kan strukturellt inte svara på *"landade det något MER?"* — den frågar efter verifikat vi själva känner till.

Det som kan smyga in oupptäckt: en dubblett från en omkörning, ett halvskrivet verifikat från ett avbrutet jobb, en strökontering. Fortnox har **ingen DELETE för verifikat**, så det som inte fångas i CI städas för hand i GUI:t, bakifrån i serien.

## Delta i stället för nollställning

```
lista verifikat i CI-året   →  före
kör E2E:t
lista verifikat i CI-året   →  efter
assert: efter − före == exakt de verifikat testet skapade
```

Det besvarar också frågan om CI-året måste nollställas mellan körningar: **nej**. Ett tomt år hade krävts för att påstå *"konto 1510 = X"*; för att påstå *"exakt de här verifikaten tillkom"* räcker delta, och det tål ackumulerad historik.

Syntet-e2e:t kräver 1 nytt verifikat, bokförings-e2e:t exakt 2 (två betalande). Landar det ett tredje har någon faktura bokförts dubbelt.

## Verifierat mot skarp sandbox 2026-09-05

Jag probade API:t i stället för att gissa — tre saker som hade blivit fel annars:

| Fynd | Konsekvens om gissat |
|---|---|
| `financialyear` är årets **`Id`**, inte årtalet (CI-året 2027 = `Id 2`) | hårdkodad `2` hade gått sönder tyst nästa år → slås nu upp via `/3/financialyears` på datumintervallet |
| Listsvaret har **bara huvuden**, inga `VoucherRows` | ett försök att summera belopp ur listan hade gett tomt |
| Paginering via `limit`/`page`/`@TotalPages` | utan loopen tystnar listan vid sidbrytningen — och en tyst delta-koll rapporterar "inget nytt" i stället för att fälla |

## Tester

9 enhetstester för delta-logiken (dubblett, saknat verifikat, ordning, tomt delta) och 4 för klienten (Id-uppslag, felmeddelande med kända år, paginering, rätt parameter). Kör utan nät — logiken ska fälla på exakt de fall som gör ont skarpt.

`bun run quality:fast` grön (3624 tester), lint/knip/dep-cruiser rena.

Closes #1050

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9UB9at5Tpr1A6sYEXomxB