### PR TITLE
fix(reports): fullkrediterad faktura drogs av två gånger i kundfordringsbryggan

### DIFF
--- a/src/lib/shared/ar-summary.ts
+++ b/src/lib/shared/ar-summary.ts
@@ -23,6 +23,23 @@ type Row = Record<string, unknown>;
 /** Status som räknas som "utställd" (fakturerat). DRAFT/CANCELLED exkluderas. */
 const ISSUED_STATUSES = new Set(["SENT", "PAID", "BAD_DEBT", "INSTALLMENT_PLAN"]);
 
+/** Id:n på fakturor som har en kreditnota — de annullerades av krediteringen. */
+function creditedInvoiceIds(invoices: readonly Row[]): Set<string> {
+  const ids = new Set<string>();
+  for (const i of invoices) {
+    if (i.invoiceType !== "CREDIT") continue;
+    const target = String(i.creditedInvoiceId ?? "");
+    if (target) ids.add(target);
+  }
+  return ids;
+}
+
+/** Var fakturan utställd? Utställd status, eller annullerad AV en kreditering. */
+function wasIssued(inv: Row, creditedIds: ReadonlySet<string>): boolean {
+  if (ISSUED_STATUSES.has(String(inv.status))) return true;
+  return String(inv.status) === "CANCELLED" && creditedIds.has(String(inv.id ?? ""));
+}
+
 function num(v: unknown): number {
   return typeof v === "number" ? v : Number(v ?? 0);
 }
@@ -187,7 +204,13 @@ export function computeArBridge(
   writeOffs: readonly Row[],
   now: Date,
 ): ArBridge {
-  const issued = invoices.filter((i) => ISSUED_STATUSES.has(String(i.status)) && i.invoiceType !== "CREDIT");
+  // En fullkrediterad faktura är CANCELLED (createCredit annullerar originalet)
+  // men VAR utställd — den ska räknas i `fakturerat` så att `krediterat` gör
+  // avdraget EN gång. Utan undantaget dras krediteringen av två gånger och
+  // `utestaende` kan bli negativt (#1054). Annullerad UTAN kreditnota är något
+  // annat: den ställdes aldrig ut, och ska fortsatt vara exkluderad.
+  const creditedIds = creditedInvoiceIds(invoices);
+  const issued = invoices.filter((i) => i.invoiceType !== "CREDIT" && wasIssued(i, creditedIds));
   const fakturerat = issued.reduce((s, i) => s + num(i.amount), 0);
   const krediterat = invoices
     .filter((i) => i.invoiceType === "CREDIT")

--- a/test/unit/lib/ar-summary.test.ts
+++ b/test/unit/lib/ar-summary.test.ts
@@ -135,3 +135,44 @@ describe("computeAging", () => {
     expect(aging.every((b) => b.amount === 0)).toBe(true);
   });
 });
+
+/**
+ * #1054: `createCredit` annullerar originalet och skapar en kreditnota på hela
+ * beloppet. Fixturen överst i filen modellerar en DELkreditering där originalet
+ * förblir SENT — den formen produceras aldrig av flödet, och därför var bryggan
+ * grön mot en verklighet som inte finns. Rapport-E2E:t fällde på det.
+ */
+describe("computeArBridge — fullkreditering (#1054)", () => {
+  const NOW2 = new Date("2026-09-05T00:00:00Z");
+  const full = [
+    { id: "kvar", status: "SENT", invoiceType: "STANDARD", amount: 100_00 },
+    { id: "krd", status: "CANCELLED", invoiceType: "STANDARD", amount: 100_00 },
+    { id: "cn", status: "SENT", invoiceType: "CREDIT", creditedInvoiceId: "krd", amount: -100_00 },
+  ];
+
+  it("räknar den krediterade fakturan som fakturerad — den VAR utställd", () => {
+    expect(computeArBridge(full, [], [], NOW2).fakturerat).toBe(200_00);
+  });
+
+  // Kärnan: krediteringen ska dras av EN gång, inte två.
+  it("drar av krediteringen en gång — justerat = den kvarvarande fakturan", () => {
+    expect(computeArBridge(full, [], [], NOW2).justerat).toBe(100_00);
+  });
+
+  it("ger inte negativt utestående när allt krediteras bort", () => {
+    const allt = [
+      { id: "krd", status: "CANCELLED", invoiceType: "STANDARD", amount: 100_00 },
+      { id: "cn", status: "SENT", invoiceType: "CREDIT", creditedInvoiceId: "krd", amount: -100_00 },
+    ];
+    expect(computeArBridge(allt, [], [], NOW2).utestaende).toBe(0);
+  });
+
+  // Motsatsen måste fortsatt gälla: annullerad UTAN kreditnota ställdes aldrig ut.
+  it("räknar INTE annullerad faktura som saknar kreditnota", () => {
+    const avbruten = [
+      { id: "kvar", status: "SENT", invoiceType: "STANDARD", amount: 100_00 },
+      { id: "makulerad", status: "CANCELLED", invoiceType: "STANDARD", amount: 900_00 },
+    ];
+    expect(computeArBridge(avbruten, [], [], NOW2).fakturerat).toBe(100_00);
+  });
+});


### PR DESCRIPTION
Hittad av det nya rapport-E2E:t (#1053) vid **första körningen**.

## Felet

`invoice.createCredit` sätter originalet till `CANCELLED` och skapar en kreditnota på hela beloppet. `computeArBridge` gjorde då två avdrag för samma kreditering:

1. Originalet föll ur `fakturerat` — `CANCELLED` finns inte i `ISSUED_STATUSES`
2. Kreditnotan räknades i `krediterat`

Och `justerat = fakturerat − krediterat`.

```ts
{ id: "kvar", status: "SENT",      invoiceType: "STANDARD", amount:  100_00 }
{ id: "krd",  status: "CANCELLED", invoiceType: "STANDARD", amount:  100_00 }
{ id: "cn",   status: "SENT",      invoiceType: "CREDIT", creditedInvoiceId: "krd", amount: -100_00 }
```

`justerat` blev **0**. Det ska vara **100,00 kr** — den kvarvarande utställda fakturan.

## Konsekvens

Inte kosmetisk. Varje fullkrediterad faktura drar ned `justerat` med sitt eget belopp, och med tillräckligt många krediteringar blir **`utestaende` negativt** — negativa kundfordringar på delägarens instrumentpanel. `nettoRealiserat` är fel på samma sätt.

## Varför enhetstesterna var gröna

Fixturen i `ar-summary.test.ts` modellerar en **delkreditering** där originalet förblir `SENT` (`i1`, −100 av 1 000). Den formen produceras **aldrig** av `createCredit`, som alltid krediterar helt och annullerar originalet.

Testerna var alltså gröna mot en verklighet som inte finns. Det är exakt luckan rapport-E2E:t byggdes för — och den fälldes på första försöket.

## Fixen

`fakturerat` räknar med fakturor som är `CANCELLED` **för att de krediterats** (en kreditnota pekar på dem). Annullerad *utan* kreditnota är fortsatt exkluderad — den ställdes aldrig ut. Fyra nya tester, inklusive att den distinktionen håller.

3628 tester gröna.

Closes #1054

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9UB9at5Tpr1A6sYEXomxB