### PR TITLE
feat: "Att bevaka" — härledda påminnelser om det som närmar sig

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 /**
  * Dashboard — översikt för inloggad användare:
+ *   - "Att bevaka" — härledda påminnelser (#1062)
  *   - "Att göra" för vald dag (tasks + events)
  *   - Tidrapportering för vald dag (summa + lista)
  *   - Senaste 5 ärenden man jobbat i (timeEntry order desc, dedup)
@@ -13,6 +14,7 @@ import { Plus, Calendar as CalendarIcon, Clock, MapPin } from "lucide-react";
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import { Modal } from "@/components/ui/modal";
+import { WatchlistList } from "@/components/watchlist/watchlist-list";
 import { EntityLink } from "@/lib/client/demo/entity-link";
 import { trpc } from "@/lib/client/trpc";
 import { formatMinutes } from "@/lib/client/utils";
@@ -55,12 +57,47 @@ export default function Dashboard() {
         <DaySwitcher ymd={ymd} onChange={setYmd} />
       </div>
 
+      <WatchlistCard />
+
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
         <TodoCard ymd={ymd} />
         <TimeCard ymd={ymd} />
       </div>
 
       <RecentMattersCard />
+    </div>
+  );
+}
+
+/** Hur många poster som ryms på startsidan innan man skickas vidare. */
+const DASHBOARD_LIMIT = 5;
+
+/**
+ * Startsidans "Att bevaka". Visar de mest brådskande posterna och länkar
+ * vidare — kortet ska tala om ATT något behöver uppmärksamhet, inte ersätta
+ * hela listan. Self-gating: har man inget att bevaka renderas ingenting, så
+ * kortet aldrig blir tomt utfyllnad.
+ */
+function WatchlistCard() {
+  const q = trpc.watchlist.list.useQuery({ mine: true });
+  const items = q.data?.items ?? [];
+  if (items.length === 0) return null;
+
+  const passed = items.filter((i) => i.severity === "passed").length;
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-4 mb-6">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="font-semibold text-gray-900 flex items-center gap-2">
+          🔔 Att bevaka
+          <span className="text-xs font-normal text-gray-500">
+            ({items.length}{passed > 0 ? `, ${passed} passerade` : ""})
+          </span>
+        </h2>
+        <Link href="/watchlist" className="text-sm text-blue-600 hover:underline">
+          Visa alla →
+        </Link>
+      </div>
+      <WatchlistList items={items.slice(0, DASHBOARD_LIMIT)} emptyText="" />
     </div>
   );
 }

--- a/src/app/watchlist/page.tsx
+++ b/src/app/watchlist/page.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+/**
+ * "Att bevaka" (#1062) — allt som behöver uppmärksamhet, över alla ärenden.
+ *
+ * Varje signal syns redan någonstans i gränssnittet, men bara där man redan
+ * tittar: täckningsvarningen inne i ärendet, förfallodagen på fakturan,
+ * statusen på ett utskick. Poängen med den här sidan är motsatsen — att få veta
+ * utan att öppna något.
+ *
+ * Inget lagras och inget går att avfärda. Posterna är härledda och städar sig
+ * själva när man åtgärdat dem; se `@/lib/shared/watchlist`.
+ */
+
+import { useMemo, useState } from "react";
+import { WatchlistList } from "@/components/watchlist/watchlist-list";
+import { trpc } from "@/lib/client/trpc";
+import type { WatchlistKind } from "@/lib/shared/watchlist";
+
+const FILTERS: Array<{ key: WatchlistKind | "all"; label: string }> = [
+  { key: "all", label: "Allt" },
+  { key: "deadline", label: "Tidsfrister" },
+  { key: "coverageCap", label: "Täckningstak" },
+  { key: "unbilled", label: "Ofakturerat" },
+  { key: "overdueInvoice", label: "Förfallna fakturor" },
+  { key: "failedDispatch", label: "Misslyckade utskick" },
+];
+
+export default function WatchlistPage() {
+  const [mine, setMine] = useState(true);
+  const [kind, setKind] = useState<WatchlistKind | "all">("all");
+  const q = trpc.watchlist.list.useQuery({ mine });
+
+  const items = useMemo(() => {
+    const all = q.data?.items ?? [];
+    return kind === "all" ? all : all.filter((i) => i.kind === kind);
+  }, [q.data, kind]);
+
+  const passed = items.filter((i) => i.severity === "passed").length;
+
+  return (
+    <div>
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Att bevaka</h1>
+          <p className="text-sm text-gray-500">
+            {q.isLoading ? "Hämtar…"
+              : items.length === 0 ? "Inget behöver din uppmärksamhet."
+              : `${items.length} poster, varav ${passed} redan passerade.`}
+          </p>
+        </div>
+        <label className="flex items-center gap-2 text-sm text-gray-700">
+          <input
+            type="checkbox"
+            checked={mine}
+            onChange={(e) => setMine(e.target.checked)}
+            className="rounded border-gray-300"
+          />
+          Bara mina ärenden
+        </label>
+      </div>
+
+      <div className="flex flex-wrap gap-2 mb-4">
+        {FILTERS.map((f) => (
+          <button
+            key={f.key}
+            type="button"
+            onClick={() => setKind(f.key)}
+            aria-pressed={kind === f.key}
+            className={`rounded-full border px-3 py-1 text-xs ${
+              kind === f.key ? "border-blue-500 bg-blue-50 text-blue-700" : "border-gray-300 text-gray-600"
+            }`}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      <WatchlistList
+        items={items}
+        emptyText={kind === "all" ? "Inget att bevaka just nu." : "Inget att bevaka i den kategorin."}
+      />
+    </div>
+  );
+}

--- a/src/components/shell/sidebar.tsx
+++ b/src/components/shell/sidebar.tsx
@@ -32,6 +32,9 @@ const navigation = [
   { name: "Ärenden", href: "/matters", icon: "📁" },
   { name: "Startsida", href: "/", icon: "📊" },
   { name: "Att göra", href: "/todo", icon: "✅" },
+  // Att bevaka direkt under Att göra: båda svarar på "vad ska jag göra nu?",
+  // men den här räknas ut i st.f. att skrivas in (#1062).
+  { name: "Att bevaka", href: "/watchlist", icon: "🔔" },
   { name: "Kontakter", href: "/contacts", icon: "👤" },
   { name: "Dokumentsök", href: "/search", icon: "📄" },
   { name: "Dokumentmallar", href: "/templates", icon: "📝" },

--- a/src/components/watchlist/watchlist-list.tsx
+++ b/src/components/watchlist/watchlist-list.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+/**
+ * Presentation av "Att bevaka"-poster (#1062). Delas av startsidans kort och
+ * den fullständiga sidan — samma rad ska se likadan ut på båda ställena,
+ * annars börjar folk lita på det ena och inte det andra.
+ *
+ * Komponenten är ren presentation: all härledning sker i
+ * `@/lib/shared/watchlist` och all hämtning i anropande vy.
+ */
+
+import Link from "next/link";
+import { formatCurrency } from "@/lib/client/utils";
+import type { WatchlistItem, WatchlistKind } from "@/lib/shared/watchlist";
+
+/** Ikon + etikett per signaltyp. Etiketten behövs för att raden ska gå att
+ *  förstå utan att läsa hela texten när listan är lång. */
+const KIND_META: Record<WatchlistKind, { icon: string; label: string }> = {
+  coverageCap: { icon: "📊", label: "Täckningstak" },
+  unbilled: { icon: "💰", label: "Ofakturerat" },
+  deadline: { icon: "⏳", label: "Tidsfrist" },
+  overdueInvoice: { icon: "📄", label: "Förfallen faktura" },
+  failedDispatch: { icon: "✉️", label: "Utskick misslyckades" },
+};
+
+/**
+ * Passerat är rött, annalkande bärnsten. Färgen bär samma information som
+ * sorteringen, så att en snabb blick räcker — men den är aldrig den ENDA
+ * bäraren: allvarsgraden står också i klartext i rubriken.
+ */
+function severityClasses(severity: WatchlistItem["severity"]): string {
+  return severity === "passed"
+    ? "border-red-300 bg-red-50 text-red-900"
+    : "border-amber-300 bg-amber-50 text-amber-900";
+}
+
+export function WatchlistRow({ item }: { item: WatchlistItem }) {
+  const meta = KIND_META[item.kind];
+  return (
+    <li>
+      <Link
+        href={item.href}
+        className={`block rounded-lg border px-3 py-2 text-sm hover:brightness-95 ${severityClasses(item.severity)}`}
+      >
+        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+          <span aria-hidden="true">{meta.icon}</span>
+          <span className="font-semibold">{item.title}</span>
+          {item.matterNumber !== null && (
+            <span className="text-xs opacity-80">{item.matterNumber}</span>
+          )}
+          {item.amountOre !== null && (
+            <span className="ml-auto font-mono text-xs">{formatCurrency(item.amountOre)}</span>
+          )}
+        </div>
+        <p className="mt-0.5 text-xs opacity-90">
+          <span className="sr-only">{meta.label}: </span>
+          {item.detail}
+        </p>
+      </Link>
+    </li>
+  );
+}
+
+export function WatchlistList({ items, emptyText }: { items: readonly WatchlistItem[]; emptyText: string }) {
+  if (items.length === 0) {
+    return <p className="text-sm text-gray-500">{emptyText}</p>;
+  }
+  return (
+    <ul className="space-y-2">
+      {/* Index ingår i nyckeln: två poster kan dela sort, ärende OCH datum
+          (t.ex. två tidsfrister samma dag i samma ärende), och React tappar
+          då den ena tyst. Listan räknas om i sin helhet vid varje hämtning och
+          har ingen rad-lokal state, så indexet är stabilt nog. */}
+      {items.map((item, i) => (
+        <WatchlistRow key={`${item.kind}-${item.matterId ?? "-"}-${i}`} item={item} />
+      ))}
+    </ul>
+  );
+}

--- a/src/lib/server/repositories/drizzle-invoice-dispatch-repository.ts
+++ b/src/lib/server/repositories/drizzle-invoice-dispatch-repository.ts
@@ -1,10 +1,10 @@
 /**
  * Drizzle `InvoiceDispatchRepository` (ADR 0020) — server-impl. Org-scopar
- * `listQueuedForOrg` via join faktura→ärende.
+ * `listByStatusForOrg` via join faktura→ärende.
  */
 
 import { and, asc, desc, eq, isNull } from "drizzle-orm";
-import type { InvoiceDispatch } from "@/lib/shared/schemas/billing";
+import type { DispatchStatus, InvoiceDispatch } from "@/lib/shared/schemas/billing";
 import type { InvoiceId, OrganizationId } from "@/lib/shared/schemas/ids";
 import { invoiceDispatches, invoices, matters } from "../db/schema";
 import type { AppDb } from "../db/types";
@@ -32,7 +32,7 @@ export class DrizzleInvoiceDispatchRepository
     return rows;
   }
 
-  async listQueuedForOrg(organizationId: OrganizationId): Promise<InvoiceDispatchQueuedRow[]> {
+  async listByStatusForOrg(organizationId: OrganizationId, status: DispatchStatus): Promise<InvoiceDispatchQueuedRow[]> {
     const rows = await this.db
       .select({
         d: invoiceDispatches,
@@ -43,7 +43,7 @@ export class DrizzleInvoiceDispatchRepository
       .innerJoin(invoices, eq(invoiceDispatches.invoiceId, invoices.id))
       .innerJoin(matters, eq(invoices.matterId, matters.id))
       .where(and(
-        eq(invoiceDispatches.status, "queued"),
+        eq(invoiceDispatches.status, status),
         eq(matters.organizationId, organizationId),
         isNull(invoiceDispatches.deletedAt),
       ))

--- a/src/lib/server/repositories/in-memory-invoice-dispatch-repository.ts
+++ b/src/lib/server/repositories/in-memory-invoice-dispatch-repository.ts
@@ -2,7 +2,7 @@
  * In-memory `InvoiceDispatchRepository` (ADR 0020) — browser/offline-impl.
  */
 
-import type { InvoiceDispatch } from "@/lib/shared/schemas/billing";
+import type { DispatchStatus, InvoiceDispatch } from "@/lib/shared/schemas/billing";
 import type { InvoiceId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { IDataStore } from "../data-store/IDataStore";
 import { InMemoryRepository } from "./in-memory-repository";
@@ -24,9 +24,9 @@ export class InMemoryInvoiceDispatchRepository
     })) as InvoiceDispatch[];
   }
 
-  async listQueuedForOrg(organizationId: OrganizationId): Promise<InvoiceDispatchQueuedRow[]> {
+  async listByStatusForOrg(organizationId: OrganizationId, status: DispatchStatus): Promise<InvoiceDispatchQueuedRow[]> {
     return (await this.delegate.findMany({
-      where: { status: "queued", invoice: { matter: { organizationId } } },
+      where: { status, invoice: { matter: { organizationId } } },
       include: { invoice: { select: { id: true, invoiceNumber: true, amount: true, ocrReference: true, dueDate: true } } },
       orderBy: { queuedAt: "asc" },
     })) as InvoiceDispatchQueuedRow[];

--- a/src/lib/server/repositories/invoice-dispatch-repository.ts
+++ b/src/lib/server/repositories/invoice-dispatch-repository.ts
@@ -3,7 +3,7 @@
  * Org-scopas via faktura→ärende (posten saknar egen organizationId). Bas-CRUD ärvs.
  */
 
-import type { InvoiceDispatch } from "@/lib/shared/schemas/billing";
+import type { DispatchStatus, InvoiceDispatch } from "@/lib/shared/schemas/billing";
 import type { InvoiceId, OrganizationId } from "@/lib/shared/schemas/ids";
 import type { Repository } from "./types";
 
@@ -19,5 +19,8 @@ export interface InvoiceDispatchRepository extends Repository<InvoiceDispatch> {
   /** Alla utskick för en faktura (nyaste först). Org-koll görs av anroparen. */
   listByInvoice(invoiceId: InvoiceId): Promise<InvoiceDispatch[]>;
   /** Alla köade utskick i org:en (äldsta först), med faktura-subset för workern. */
-  listQueuedForOrg(organizationId: OrganizationId): Promise<InvoiceDispatchQueuedRow[]>;
+  /** Utskick i org:en med given status. `queued` driver workern (#180);
+   *  `failed` driver "Att bevaka" (#1062) — en faktura som aldrig kom fram
+   *  ser ut precis som en obetald ända tills någon undrar varför. */
+  listByStatusForOrg(organizationId: OrganizationId, status: DispatchStatus): Promise<InvoiceDispatchQueuedRow[]>;
 }

--- a/src/lib/server/routers/_app.ts
+++ b/src/lib/server/routers/_app.ts
@@ -23,6 +23,7 @@ import { taskRouter } from "./task";
 import { timeEntryRouter } from "./timeEntry";
 import { todoRouter } from "./todo";
 import { userRouter } from "./user";
+import { watchlistRouter } from "./watchlist";
 
 export const appRouter = router({
   contacts: contactRouter,
@@ -45,6 +46,7 @@ export const appRouter = router({
   task: taskRouter,
   serviceNote: serviceNoteRouter,
   todo: todoRouter,
+  watchlist: watchlistRouter,
   prefs: preferenceRouter,
   mail: mailRouter,
   sync: syncRouter,

--- a/src/lib/server/routers/invoiceDispatch.ts
+++ b/src/lib/server/routers/invoiceDispatch.ts
@@ -53,7 +53,7 @@ export const invoiceDispatchRouter = router({
 
   /** Alla köade utskick i org:en — server-runtime-dispatch-workern (#180) plockar dessa. */
   listQueued: orgProcedure.query(({ ctx }) =>
-    ctx.repos.invoiceDispatches.listQueuedForOrg(asId<"OrganizationId">(ctx.orgId)),
+    ctx.repos.invoiceDispatches.listByStatusForOrg(asId<"OrganizationId">(ctx.orgId), "queued"),
   ),
 
   queue: orgProcedure

--- a/src/lib/server/routers/watchlist.ts
+++ b/src/lib/server/routers/watchlist.ts
@@ -1,0 +1,194 @@
+/**
+ * "Att bevaka"-router (#1062) — samlar de fem signalerna i en enda fråga.
+ *
+ * Varje signal härleds ur data som redan finns; ingenting lagras. Se
+ * `@/lib/shared/watchlist` för varför (kort: en härledd påminnelse städar sig
+ * själv, en lagrad kräver att någon avfärdar den).
+ *
+ * Läsningarna görs org-brett och i EN omgång per entitetstyp i st.f. per
+ * ärende. Ett N+1-mönster hade betytt ett anrop per ärende varje gång
+ * startsidan laddas — och startsidan laddas hela dagen.
+ */
+
+import { z } from "zod";
+import type { PaymentMethod } from "@/lib/shared/schemas/enums";
+import { asId, type OrganizationId, userIdSchema } from "@/lib/shared/schemas/ids";
+import {
+  coverageItems, deadlineItems, failedDispatchItems, overdueInvoiceItems,
+  sortWatchlist, unbilledItems,
+  DEFAULT_THRESHOLDS, type CoverageMatter, type DeadlineTask, type FailedDispatch,
+  type OverdueInvoice, type UnbilledMatter, type WatchlistItem,
+} from "@/lib/shared/watchlist";
+import type { Repositories } from "../repositories/repositories";
+import { router, orgProcedure } from "../trpc";
+
+type Ctx = { repos: Repositories; orgId: OrganizationId; user: { id: string } };
+
+/** ISO-datum (YYYY-MM-DD) ur ett fält som kan vara Date eller sträng. */
+function isoDate(v: unknown): string | null {
+  if (v instanceof Date) return v.toISOString().slice(0, 10);
+  if (typeof v === "string" && v.length >= 10) return v.slice(0, 10);
+  return null;
+}
+
+interface MatterRow {
+  id: string;
+  matterNumber: string;
+  paymentMethod?: string | null;
+  rattsskyddMaxOre?: number | null;
+  rattshjalpMaxTimmar?: number | null;
+  responsibleLawyerId?: string | null;
+}
+
+/** Täckningsunderlag: ärendets tak + upparbetat, batchat i ETT repo-anrop. */
+async function coverageInput(ctx: Ctx, matters: readonly MatterRow[]): Promise<CoverageMatter[]> {
+  const usage = await ctx.repos.timeEntries.coverageUsageForMatters(
+    matters.map((m) => asId<"MatterId">(m.id)),
+  );
+  return matters.map((m) => ({
+    id: m.id,
+    matterNumber: m.matterNumber,
+    method: (m.paymentMethod ?? null) as PaymentMethod | null,
+    rattsskyddMaxOre: m.rattsskyddMaxOre ?? null,
+    rattshjalpMaxTimmar: m.rattshjalpMaxTimmar ?? null,
+    billableMinutes: usage[m.id]?.billableMinutes ?? 0,
+    billableValueOre: usage[m.id]?.billableValueOre ?? 0,
+  }));
+}
+
+/**
+ * Ofakturerat per ärende: debiterbara tidsposter som INTE frysts av en
+ * slutfaktura. `frozenAt` är gränsen — aconto fryser inte, så ett ärende med
+ * aconto har fortfarande upparbetat kvar att slutfakturera.
+ */
+async function unbilledInput(ctx: Ctx, matters: readonly MatterRow[]): Promise<UnbilledMatter[]> {
+  const entries = await ctx.repos.timeEntries.listBillableForOrg(ctx.orgId);
+  const known = new Map(matters.map((m) => [m.id, m]));
+  const acc = new Map<string, { ore: number; oldest: string | null }>();
+
+  for (const e of entries) {
+    if (e.frozenAt) continue;
+    const matterId = String(e.matterId);
+    if (!known.has(matterId)) continue;
+    const cur = acc.get(matterId) ?? { ore: 0, oldest: null };
+    cur.ore += Math.round((e.minutes / 60) * e.hourlyRate);
+    const d = isoDate(e.date);
+    if (d !== null && (cur.oldest === null || d < cur.oldest)) cur.oldest = d;
+    acc.set(matterId, cur);
+  }
+
+  return [...acc].map(([matterId, v]) => ({
+    id: matterId,
+    matterNumber: known.get(matterId)?.matterNumber ?? matterId,
+    unbilledOre: v.ore,
+    oldestEntryDate: v.oldest,
+  }));
+}
+
+/** Tidsfrister ur uppgifter — bara öppna, och bara de som har ett datum. */
+async function deadlineInput(ctx: Ctx, userId: string): Promise<DeadlineTask[]> {
+  const tasks = await ctx.repos.tasks.listForUser(
+    asId<"UserId">(userId), ctx.orgId, { status: "TODO" },
+  );
+  const out: DeadlineTask[] = [];
+  for (const t of tasks) {
+    const due = isoDate(t.dueAt);
+    if (due === null) continue;
+    out.push({
+      id: String(t.id), title: t.title, dueAt: due,
+      matterId: t.matter ? String(t.matter.id) : null,
+      matterNumber: t.matter?.matterNumber ?? null,
+    });
+  }
+  return out;
+}
+
+/** Statusar som betyder "fordran lever och kan förfalla". */
+const LIVE_INVOICE_STATUSES = new Set(["SENT", "INSTALLMENT_PLAN"]);
+
+/** Förfallna fakturor med utestående belopp. Betalt eller avskrivet räknas bort. */
+type InvoiceRow = Awaited<ReturnType<Repositories["invoices"]["listForOrg"]>>[number];
+
+/** Fakturaraden som bevakningspost, eller null om den inte kan förfalla. */
+function toOverdue(inv: InvoiceRow): OverdueInvoice | null {
+  if (!LIVE_INVOICE_STATUSES.has(String(inv.status))) return null;
+  const due = isoDate(inv.dueDate);
+  if (due === null) return null;
+  const paid = (inv.payments ?? []).reduce((s, p) => s + p.amount, 0);
+  return {
+    id: String(inv.id), invoiceNumber: inv.invoiceNumber ?? null, dueDate: due,
+    outstandingOre: inv.amount - paid,
+    matterId: inv.matter ? String(inv.matter.id) : null,
+    matterNumber: inv.matter?.matterNumber ?? null,
+  };
+}
+
+async function overdueInput(ctx: Ctx): Promise<OverdueInvoice[]> {
+  const rows = await ctx.repos.invoices.listForOrg(ctx.orgId, {});
+  return rows.map(toOverdue).filter((r): r is OverdueInvoice => r !== null);
+}
+
+/** Misslyckade fakturautskick — fakturan nådde aldrig mottagaren. */
+async function failedInput(ctx: Ctx): Promise<FailedDispatch[]> {
+  const rows = await ctx.repos.invoiceDispatches.listByStatusForOrg(ctx.orgId, "failed");
+  return rows.map((d) => ({
+    invoiceId: String(d.invoiceId),
+    invoiceNumber: d.invoice?.invoiceNumber ?? null,
+    recipient: d.recipient,
+    error: d.error ?? null,
+    failedAt: isoDate(d.failedAt),
+    matterId: null,
+    matterNumber: null,
+  }));
+}
+
+export const watchlistRouter = router({
+  /**
+   * Allt som behöver uppmärksamhet, sorterat efter hur bråttom det är.
+   *
+   * `mine` (default) begränsar ärendedrivna signaler till den egna
+   * ärendeportföljen — annars drunknar en delägare i kollegornas ärenden.
+   * Tidsfristerna är alltid den egna användarens: en uppgift har en ägare.
+   */
+  list: orgProcedure
+    .input(z.object({
+      mine: z.boolean().default(true),
+      userId: userIdSchema.optional(),
+    }).optional())
+    .query(async ({ ctx, input }): Promise<{ items: WatchlistItem[]; generatedAt: string }> => {
+      const userId = input?.userId ?? ctx.user.id;
+      const mine = input?.mine ?? true;
+      const now = new Date();
+      // Trösklarna är kodens defaults i v1. De VARIERAR mellan byråer (en byrå
+      // fakturerar vid 25 000 kr, en annan vid 50 000) och hör därför hemma i
+      // org-inställningarna — men det kräver en migration och hör inte hemma i
+      // samma ändring som signalerna själva. Se #1063.
+      const thresholds = DEFAULT_THRESHOLDS;
+
+      const all = (await ctx.repos.matters.listByOrg(ctx.orgId)) as MatterRow[];
+      const matters = mine ? all.filter((m) => String(m.responsibleLawyerId ?? "") === userId) : all;
+      const matterIds = new Set(matters.map((m) => m.id));
+
+      const [coverage, unbilled, deadlines, overdue, failed] = await Promise.all([
+        coverageInput(ctx, matters),
+        unbilledInput(ctx, matters),
+        deadlineInput(ctx, userId),
+        overdueInput(ctx),
+        failedInput(ctx),
+      ]);
+
+      // Faktura-signalerna är org-breda i datalagret; filtrera dem mot samma
+      // ärendeurval så "mina" betyder samma sak för alla fem signalerna.
+      const ownInvoice = (matterId: string | null): boolean => !mine || matterId === null || matterIds.has(matterId);
+
+      const items = sortWatchlist([
+        ...coverageItems(coverage),
+        ...unbilledItems(unbilled, now, thresholds),
+        ...deadlineItems(deadlines, now, thresholds),
+        ...overdueInvoiceItems(overdue.filter((i) => ownInvoice(i.matterId)), now),
+        ...failedDispatchItems(failed),
+      ]);
+
+      return { items, generatedAt: now.toISOString() };
+    }),
+});

--- a/src/lib/shared/watchlist.ts
+++ b/src/lib/shared/watchlist.ts
@@ -1,0 +1,296 @@
+/**
+ * "Att bevaka" (#1062) — ren logik, ingen I/O.
+ *
+ * Byrån har fem sorters signaler som var för sig redan syns någonstans i
+ * gränssnittet, men bara DÄR MAN REDAN TITTAR: täckningsvarningen inne i
+ * ärendet, förfallodatumet på fakturan, statusen på ett utskick. En påminnelse
+ * ska fungera tvärtom — man ska få veta utan att öppna något.
+ *
+ * ## Varför inget lagras
+ *
+ * Ingen `Reminder`-entitet, ingen avfärda-knapp. Varje post här är HÄRLEDD ur
+ * data som redan finns, och städar därför sig själv: fakturera ärendet och
+ * posten försvinner, betala fakturan och den försvinner. En lagrad påminnelse
+ * hade krävt att någon avfärdar den, och därmed skapat en andra sanningskälla
+ * som kan säga något annat än verkligheten.
+ *
+ * Priset är att man inte kan "snooza" en post. Det är rätt pris: en påminnelse
+ * som går att tysta utan att åtgärda är en påminnelse som kommer att tystas.
+ *
+ * Tidsfrister (dokument som ska in, överklagandetider) är INTE härledbara —
+ * de är uppgifter någon skrivit in, alltså `Task` med `dueAt`. De tas med här
+ * för att de hör hemma i samma vy, inte för att de räknas ut.
+ */
+
+import { coverageStatus, type CoverageCapInput } from "./coverage-cap";
+
+// ─── Trösklar ──────────────────────────────────────────────────────────────
+
+/** Ofakturerat över detta belopp (öre) är värt en påminnelse. Byrå-överstyrbart. */
+export const DEFAULT_UNBILLED_THRESHOLD_ORE = 2_500_000; // 25 000 kr
+
+/** …liksom arbete som legat ofakturerat längre än så här många dagar. */
+export const DEFAULT_UNBILLED_AGE_DAYS = 60;
+
+/** Tidsfrister inom så här många dagar räknas som "närmar sig". */
+export const DEADLINE_HORIZON_DAYS = 14;
+
+export interface WatchlistThresholds {
+  unbilledThresholdOre: number;
+  unbilledAgeDays: number;
+  deadlineHorizonDays: number;
+}
+
+export const DEFAULT_THRESHOLDS: WatchlistThresholds = {
+  unbilledThresholdOre: DEFAULT_UNBILLED_THRESHOLD_ORE,
+  unbilledAgeDays: DEFAULT_UNBILLED_AGE_DAYS,
+  deadlineHorizonDays: DEADLINE_HORIZON_DAYS,
+};
+
+// ─── Poster ────────────────────────────────────────────────────────────────
+
+/**
+ * Vad posten gäller. Sorteringen nedan bygger på `severity`, inte på `kind` —
+ * en passerad tidsfrist är mer akut än ett täckningstak som närmar sig, oavsett
+ * vilken sort de är.
+ */
+export type WatchlistKind =
+  | "coverageCap"      // täckningstaket nås — arbete däröver ersätts inte
+  | "unbilled"         // upparbetat som borde faktureras
+  | "deadline"         // tidsfrist ur en uppgift (dokument, överklagande)
+  | "overdueInvoice"   // förfallen faktura eller avbetalningspost
+  | "failedDispatch";  // fakturan nådde aldrig mottagaren
+
+/**
+ * `passed` = det har redan hänt (taket passerat, fristen ute, utskicket
+ * misslyckat). `approaching` = det kommer att hända om inget görs.
+ */
+export type WatchlistSeverity = "passed" | "approaching";
+
+export interface WatchlistItem {
+  kind: WatchlistKind;
+  severity: WatchlistSeverity;
+  /** Kort rubrik — vad som händer. */
+  title: string;
+  /** En rad om varför det spelar roll och vad man gör åt det. */
+  detail: string;
+  matterId: string | null;
+  matterNumber: string | null;
+  /** Datum posten hänger på (frist, förfallodag). Null för beloppsdrivna. */
+  at: string | null;
+  /** Belopp posten gäller (öre), när det finns ett. */
+  amountOre: number | null;
+  /** Vart man går för att åtgärda. */
+  href: string;
+}
+
+/** Passerat före annalkande; inom samma grupp: äldst datum först. */
+const SEVERITY_ORDER: Record<WatchlistSeverity, number> = { passed: 0, approaching: 1 };
+
+/**
+ * Sortera efter hur bråttom det är. Poster utan datum hamnar sist inom sin
+ * grupp — ett belopp är angeläget men inte tidsstyrt, och en lista som blandar
+ * "förfallen i förrgår" med "25 000 kr ofakturerat" ska visa det förfallna först.
+ */
+export function sortWatchlist(items: readonly WatchlistItem[]): WatchlistItem[] {
+  return [...items].sort((a, b) => {
+    const bySeverity = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
+    if (bySeverity !== 0) return bySeverity;
+    if (a.at !== null && b.at !== null) return a.at.localeCompare(b.at);
+    if (a.at !== null) return -1;
+    if (b.at !== null) return 1;
+    return (b.amountOre ?? 0) - (a.amountOre ?? 0);
+  });
+}
+
+// ─── Härledning per signal ─────────────────────────────────────────────────
+
+const DAY_MS = 86_400_000;
+
+/** Hela dagar mellan två datum (b − a). Negativt = b ligger före a. */
+export function daysBetween(from: Date, to: Date): number {
+  const a = Date.UTC(from.getUTCFullYear(), from.getUTCMonth(), from.getUTCDate());
+  const b = Date.UTC(to.getUTCFullYear(), to.getUTCMonth(), to.getUTCDate());
+  return Math.round((b - a) / DAY_MS);
+}
+
+const iso = (d: Date): string => d.toISOString().slice(0, 10);
+
+export interface CoverageMatter extends CoverageCapInput {
+  id: string;
+  matterNumber: string;
+}
+
+/**
+ * Täckningstaket. Arbete över taket ersätts inte av myndigheten/försäkringen —
+ * byrån får själv bära det om den inte hunnit begära utökning. Därför är det
+ * ANNALKANDE fallet det viktiga: passerat tak är redan en förlust.
+ */
+function coverageItem(m: CoverageMatter, status: NonNullable<ReturnType<typeof coverageStatus>>): WatchlistItem {
+  const pct = Math.round(status.ratio * 100);
+  const utokning = m.method === "RATTSHJALP" ? "utökad rättshjälp" : "utökat rättsskydd";
+  return {
+    kind: "coverageCap",
+    severity: status.overCap ? "passed" : "approaching",
+    title: status.overCap ? `Täckningstaket passerat (${pct} %)` : `Närmar sig täckningstaket (${pct} %)`,
+    detail: status.overCap
+      ? `Arbete över taket ersätts inte — begär ${utokning} omgående.`
+      : `Begär ${utokning} innan taket nås.`,
+    matterId: m.id, matterNumber: m.matterNumber, at: null,
+    amountOre: status.kind === "amount" ? status.usedOre : null,
+    href: `/matters/${m.id}`,
+  };
+}
+
+export function coverageItems(matters: readonly CoverageMatter[]): WatchlistItem[] {
+  const out: WatchlistItem[] = [];
+  for (const m of matters) {
+    const status = coverageStatus(m);
+    if (status?.nearCap) out.push(coverageItem(m, status));
+  }
+  return out;
+}
+
+export interface UnbilledMatter {
+  id: string;
+  matterNumber: string;
+  /** Ofakturerat arbete + utlägg (öre). */
+  unbilledOre: number;
+  /** Datum för den ÄLDSTA ofakturerade posten, eller null om inget finns. */
+  oldestEntryDate: string | null;
+}
+
+/**
+ * Vilken/vilka trösklar som slog till, som läsbart skäl. Null = ingen.
+ *
+ * Två OBEROENDE trösklar, och vilken som helst räcker: beloppet fångar de
+ * stora ärendena, åldern fångar de små som glider. Bara beloppsgränsen hade
+ * missat ett ärende med 8 000 kr som legat i ett halvår — och det är precis
+ * den sortens fordran som aldrig blir fakturerad.
+ */
+function unbilledReason(m: UnbilledMatter, now: Date, t: WatchlistThresholds): string | null {
+  if (m.unbilledOre <= 0) return null;
+  const ålder = m.oldestEntryDate === null ? 0 : daysBetween(new Date(m.oldestEntryDate), now);
+  const överBelopp = m.unbilledOre >= t.unbilledThresholdOre;
+  const förGammalt = m.oldestEntryDate !== null && ålder >= t.unbilledAgeDays;
+  if (överBelopp && förGammalt) return `över tröskeln och ${ålder} dagar gammalt`;
+  if (överBelopp) return "över tröskeln";
+  if (förGammalt) return `${ålder} dagar gammalt`;
+  return null;
+}
+
+/** Ofakturerat arbete som passerat någon av trösklarna. */
+export function unbilledItems(
+  matters: readonly UnbilledMatter[], now: Date, t: WatchlistThresholds = DEFAULT_THRESHOLDS,
+): WatchlistItem[] {
+  const out: WatchlistItem[] = [];
+  for (const m of matters) {
+    const skäl = unbilledReason(m, now, t);
+    if (skäl === null) continue;
+    out.push({
+      kind: "unbilled",
+      // Ofakturerat är aldrig "passerat" — det finns ingen tidpunkt att missa,
+      // bara pengar som står stilla längre och längre.
+      severity: "approaching",
+      title: "Bör faktureras",
+      detail: `Upparbetat ofakturerat ${skäl}.`,
+      matterId: m.id, matterNumber: m.matterNumber,
+      at: m.oldestEntryDate, amountOre: m.unbilledOre,
+      href: `/matters/${m.id}`,
+    });
+  }
+  return out;
+}
+
+export interface DeadlineTask {
+  id: string;
+  title: string;
+  dueAt: string;
+  matterId: string | null;
+  matterNumber: string | null;
+}
+
+/**
+ * Tidsfrister ur uppgifter — dokument som ska ges in, överklagandetider. De
+ * räknas inte ut; de är inskrivna. Det som saknades var att se dem sorterade
+ * efter frist över ALLA ärenden i stället för ett i taget.
+ */
+export function deadlineItems(
+  tasks: readonly DeadlineTask[], now: Date, t: WatchlistThresholds = DEFAULT_THRESHOLDS,
+): WatchlistItem[] {
+  const out: WatchlistItem[] = [];
+  for (const task of tasks) {
+    const kvar = daysBetween(now, new Date(task.dueAt));
+    if (kvar > t.deadlineHorizonDays) continue;
+    const passerad = kvar < 0;
+    out.push({
+      kind: "deadline",
+      severity: passerad ? "passed" : "approaching",
+      title: passerad ? `Tidsfrist passerad: ${task.title}` : `Tidsfrist om ${kvar} dagar: ${task.title}`,
+      detail: passerad
+        ? `Fristen gick ut för ${Math.abs(kvar)} dagar sedan.`
+        : `Förfaller ${iso(new Date(task.dueAt))}.`,
+      matterId: task.matterId, matterNumber: task.matterNumber,
+      at: iso(new Date(task.dueAt)), amountOre: null,
+      href: task.matterId ? `/matters/${task.matterId}` : "/tasks",
+    });
+  }
+  return out;
+}
+
+export interface OverdueInvoice {
+  id: string;
+  invoiceNumber: string | null;
+  dueDate: string;
+  outstandingOre: number;
+  matterId: string | null;
+  matterNumber: string | null;
+}
+
+/** Förfallna fakturor — fordran som glider. Bara obetalt räknas. */
+export function overdueInvoiceItems(invoices: readonly OverdueInvoice[], now: Date): WatchlistItem[] {
+  const out: WatchlistItem[] = [];
+  for (const inv of invoices) {
+    if (inv.outstandingOre <= 0) continue;
+    const dagar = daysBetween(new Date(inv.dueDate), now);
+    if (dagar <= 0) continue;
+    out.push({
+      kind: "overdueInvoice",
+      severity: "passed",
+      title: `Förfallen faktura ${inv.invoiceNumber ?? ""}`.trim(),
+      detail: `${dagar} dagar över förfallodag.`,
+      matterId: inv.matterId, matterNumber: inv.matterNumber,
+      at: inv.dueDate, amountOre: inv.outstandingOre,
+      href: `/invoices/${inv.id}`,
+    });
+  }
+  return out;
+}
+
+export interface FailedDispatch {
+  invoiceId: string;
+  invoiceNumber: string | null;
+  recipient: string;
+  error: string | null;
+  failedAt: string | null;
+  matterId: string | null;
+  matterNumber: string | null;
+}
+
+/**
+ * Misslyckade fakturautskick. Den här är listans viktigaste post trots att den
+ * sällan är den dyraste: alla andra signaler kan en människa snubbla över, men
+ * en faktura som aldrig nådde mottagaren ser ut precis som en obetald faktura
+ * ända tills någon undrar varför ingen betalat.
+ */
+export function failedDispatchItems(dispatches: readonly FailedDispatch[]): WatchlistItem[] {
+  return dispatches.map((d) => ({
+    kind: "failedDispatch" as const,
+    severity: "passed" as const,
+    title: `Fakturautskick misslyckades ${d.invoiceNumber ?? ""}`.trim(),
+    detail: `Nådde aldrig ${d.recipient}${d.error ? ` — ${d.error}` : ""}. Fakturan är obetald för att den inte kommit fram.`,
+    matterId: d.matterId, matterNumber: d.matterNumber,
+    at: d.failedAt, amountOre: null,
+    href: `/invoices/${d.invoiceId}`,
+  }));
+}

--- a/test/unit/app/page.test.tsx
+++ b/test/unit/app/page.test.tsx
@@ -10,6 +10,8 @@ import Dashboard from "@/app/page";
 const todoQuery: { data: unknown; isLoading: boolean } = { data: undefined, isLoading: false };
 const timeQuery: { data: unknown; isLoading: boolean } = { data: undefined, isLoading: false };
 const meQuery: { data: unknown } = { data: { id: "u1", name: "Anna" } };
+/** "Att bevaka" (#1062) — self-gating: tom lista → kortet renderar ingenting. */
+const watchlistQuery: { data: unknown; isLoading: boolean } = { data: { items: [] }, isLoading: false };
 
 vi.mock("@/lib/client/trpc", () => ({
   trpc: {
@@ -17,6 +19,7 @@ vi.mock("@/lib/client/trpc", () => ({
     todo: { list: { useQuery: () => todoQuery } },
     timeEntry: { list: { useQuery: () => timeQuery } },
     user: { current: { useQuery: () => meQuery } },
+    watchlist: { list: { useQuery: () => watchlistQuery } },
     task: {
       complete: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
       update: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
@@ -30,6 +33,7 @@ beforeEach(() => {
   todoQuery.isLoading = false;
   timeQuery.data = undefined;
   timeQuery.isLoading = false;
+  watchlistQuery.data = { items: [] };
 });
 
 describe("Dashboard", () => {

--- a/test/unit/app/watchlist-page.test.tsx
+++ b/test/unit/app/watchlist-page.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest-compat";
+import WatchlistPage from "@/app/watchlist/page";
+import type { WatchlistItem } from "@/lib/shared/watchlist";
+
+const query: { data: unknown; isLoading: boolean } = { data: undefined, isLoading: false };
+/** Senaste argumenten till useQuery — så filtret "bara mina" går att verifiera. */
+let lastArgs: unknown = null;
+
+vi.mock("@/lib/client/trpc", () => ({
+  trpc: {
+    watchlist: {
+      list: {
+        useQuery: (args: unknown) => {
+          lastArgs = args;
+          return query;
+        },
+      },
+    },
+  },
+}));
+
+function item(p: Partial<WatchlistItem> = {}): WatchlistItem {
+  return {
+    kind: "deadline", severity: "approaching", title: "Tidsfrist", detail: "d",
+    matterId: "m1", matterNumber: "2026-0001", at: "2026-09-08",
+    amountOre: null, href: "/matters/m1", ...p,
+  };
+}
+
+beforeEach(() => {
+  query.data = { items: [] };
+  query.isLoading = false;
+  lastArgs = null;
+});
+
+describe("Att bevaka-sidan", () => {
+  it("visar rubriken", () => {
+    render(<WatchlistPage />);
+    expect(screen.getByRole("heading", { name: /Att bevaka/i })).toBeInTheDocument();
+  });
+
+  it("säger ifrån när ingenting behöver uppmärksamhet", () => {
+    render(<WatchlistPage />);
+    expect(screen.getByText(/Inget behöver din uppmärksamhet/i)).toBeInTheDocument();
+  });
+
+  // Antalet passerade är det som avgör om man behöver agera NU.
+  it("räknar poster och hur många som passerat", () => {
+    query.data = { items: [item({ severity: "passed" }), item(), item()] };
+    render(<WatchlistPage />);
+    expect(screen.getByText(/3 poster, varav 1 redan passerade/)).toBeInTheDocument();
+  });
+
+  it("frågar efter bara egna ärenden som default", () => {
+    render(<WatchlistPage />);
+    expect(lastArgs).toEqual({ mine: true });
+  });
+
+  it("frågar org-brett när kryssrutan slås av", () => {
+    render(<WatchlistPage />);
+    fireEvent.click(screen.getByLabelText(/Bara mina ärenden/i));
+    expect(lastArgs).toEqual({ mine: false });
+  });
+
+  it("filtrerar på signaltyp", () => {
+    query.data = { items: [item({ kind: "deadline" }), item({ kind: "unbilled", title: "Bör faktureras" })] };
+    render(<WatchlistPage />);
+    fireEvent.click(screen.getByRole("button", { name: "Ofakturerat" }));
+    expect(screen.getByText("Bör faktureras")).toBeInTheDocument();
+    expect(screen.queryByText("Tidsfrist")).not.toBeInTheDocument();
+  });
+
+  it("markerar valt filter för skärmläsare", () => {
+    render(<WatchlistPage />);
+    fireEvent.click(screen.getByRole("button", { name: "Tidsfrister" }));
+    expect(screen.getByRole("button", { name: "Tidsfrister" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("säger till när kategorin är tom i st.f. att se trasig ut", () => {
+    query.data = { items: [item({ kind: "deadline" })] };
+    render(<WatchlistPage />);
+    fireEvent.click(screen.getByRole("button", { name: "Ofakturerat" }));
+    expect(screen.getByText(/Inget att bevaka i den kategorin/i)).toBeInTheDocument();
+  });
+
+  it("visar hämtningsläge", () => {
+    query.data = undefined;
+    query.isLoading = true;
+    render(<WatchlistPage />);
+    expect(screen.getByText("Hämtar…")).toBeInTheDocument();
+  });
+});

--- a/test/unit/components/watchlist-list.test.tsx
+++ b/test/unit/components/watchlist-list.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest-compat";
+import { WatchlistList } from "@/components/watchlist/watchlist-list";
+import type { WatchlistItem } from "@/lib/shared/watchlist";
+
+function item(p: Partial<WatchlistItem> = {}): WatchlistItem {
+  return {
+    kind: "deadline", severity: "approaching",
+    title: "Tidsfrist om 3 dagar: Ge in yttrande",
+    detail: "Förfaller 2026-09-08.",
+    matterId: "m1", matterNumber: "2026-0001",
+    at: "2026-09-08", amountOre: null, href: "/matters/m1", ...p,
+  };
+}
+
+describe("WatchlistList", () => {
+  it("visar tomt-text när inget behöver bevakas", () => {
+    render(<WatchlistList items={[]} emptyText="Inget att bevaka just nu." />);
+    expect(screen.getByText("Inget att bevaka just nu.")).toBeInTheDocument();
+  });
+
+  it("visar rubrik, detalj och ärendenummer", () => {
+    render(<WatchlistList items={[item()]} emptyText="" />);
+    expect(screen.getByText(/Ge in yttrande/)).toBeInTheDocument();
+    expect(screen.getByText(/Förfaller 2026-09-08/)).toBeInTheDocument();
+    expect(screen.getByText("2026-0001")).toBeInTheDocument();
+  });
+
+  it("länkar dit man åtgärdar posten", () => {
+    render(<WatchlistList items={[item()]} emptyText="" />);
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/matters/m1");
+  });
+
+  it("visar belopp när posten har ett", () => {
+    render(<WatchlistList items={[item({ amountOre: 2_500_000, kind: "unbilled" })]} emptyText="" />);
+    expect(screen.getByText(/25 000,00/)).toBeInTheDocument();
+  });
+
+  // Färgen bär samma information som sorteringen, men får inte vara den enda
+  // bäraren — allvarsgraden ska gå att uppfatta utan att se färg.
+  it("skiljer passerat från annalkande visuellt", () => {
+    const { container: passerat } = render(
+      <WatchlistList items={[item({ severity: "passed" })]} emptyText="" />,
+    );
+    expect(passerat.querySelector("a")?.className).toContain("red");
+
+    const { container: annalkande } = render(
+      <WatchlistList items={[item({ severity: "approaching" })]} emptyText="" />,
+    );
+    expect(annalkande.querySelector("a")?.className).toContain("amber");
+  });
+
+  it("namnger signaltypen för skärmläsare", () => {
+    render(<WatchlistList items={[item({ kind: "failedDispatch" })]} emptyText="" />);
+    expect(screen.getByText(/Utskick misslyckades:/)).toBeInTheDocument();
+  });
+
+  it("renderar flera poster utan nyckelkrock när ärende och datum saknas", () => {
+    render(
+      <WatchlistList
+        items={[
+          item({ matterId: null, matterNumber: null, at: null }),
+          item({ matterId: null, matterNumber: null, at: null }),
+        ]}
+        emptyText=""
+      />,
+    );
+    expect(screen.getAllByRole("link")).toHaveLength(2);
+  });
+});

--- a/test/unit/lib/watchlist.test.ts
+++ b/test/unit/lib/watchlist.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from "vitest-compat";
+import {
+  coverageItems, deadlineItems, failedDispatchItems, overdueInvoiceItems,
+  sortWatchlist, unbilledItems, daysBetween,
+  DEFAULT_THRESHOLDS, type WatchlistItem,
+} from "@/lib/shared/watchlist";
+
+const NOW = new Date("2026-09-05T00:00:00Z");
+
+describe("daysBetween", () => {
+  it("räknar hela dagar framåt", () => {
+    expect(daysBetween(NOW, new Date("2026-09-12T00:00:00Z"))).toBe(7);
+  });
+
+  it("ger negativt för datum som passerat", () => {
+    expect(daysBetween(NOW, new Date("2026-09-01T00:00:00Z"))).toBe(-4);
+  });
+
+  // Klockslag får inte påverka — annars flimrar "3 dagar kvar" beroende på
+  // när på dygnet sidan laddas.
+  it("bryr sig inte om klockslag", () => {
+    expect(daysBetween(new Date("2026-09-05T23:59:00Z"), new Date("2026-09-06T00:01:00Z"))).toBe(1);
+  });
+});
+
+describe("coverageItems", () => {
+  const rattshjalp = {
+    id: "m1", matterNumber: "2026-0001",
+    method: "RATTSHJALP" as const, rattshjalpMaxTimmar: 100, rattsskyddMaxOre: null,
+  };
+
+  it("tiger under varningsgränsen", () => {
+    // 50 h av 100 → inget att påminna om.
+    expect(coverageItems([{ ...rattshjalp, billableMinutes: 3000, billableValueOre: 0 }])).toEqual([]);
+  });
+
+  it("varnar när taket närmar sig", () => {
+    const [item] = coverageItems([{ ...rattshjalp, billableMinutes: 5_700, billableValueOre: 0 }]);
+    expect(item?.severity).toBe("approaching");
+    expect(item?.detail).toContain("utökad rättshjälp");
+  });
+
+  // Passerat tak är redan en förlust — det måste rangordnas högre än ett
+  // annalkande, annars hamnar det under i listan.
+  it("markerar passerat tak som passed", () => {
+    const [item] = coverageItems([{ ...rattshjalp, billableMinutes: 6_600, billableValueOre: 0 }]);
+    expect(item?.severity).toBe("passed");
+    expect(item?.title).toContain("passerat");
+  });
+
+  it("talar om utökat RÄTTSSKYDD för rättsskyddsärenden", () => {
+    const [item] = coverageItems([{
+      id: "m2", matterNumber: "2026-0002", method: "RATTSSKYDD",
+      rattsskyddMaxOre: 100_000_00, rattshjalpMaxTimmar: null,
+      billableMinutes: 0, billableValueOre: 95_000_00,
+    }]);
+    expect(item?.detail).toContain("utökat rättsskydd");
+  });
+});
+
+describe("unbilledItems", () => {
+  const bas = { id: "m1", matterNumber: "2026-0001" };
+
+  it("tiger under båda trösklarna", () => {
+    const items = unbilledItems([{ ...bas, unbilledOre: 500_00, oldestEntryDate: "2026-09-01" }], NOW);
+    expect(items).toEqual([]);
+  });
+
+  it("utlöser på BELOPP även när arbetet är färskt", () => {
+    const items = unbilledItems([{ ...bas, unbilledOre: 30_000_00, oldestEntryDate: "2026-09-04" }], NOW);
+    expect(items).toHaveLength(1);
+    expect(items[0]?.detail).toContain("över tröskeln");
+  });
+
+  // Den här fångar det beloppsgränsen missar: småärenden som glider bort.
+  it("utlöser på ÅLDER även när beloppet är litet", () => {
+    const items = unbilledItems([{ ...bas, unbilledOre: 800_00, oldestEntryDate: "2026-01-01" }], NOW);
+    expect(items).toHaveLength(1);
+    expect(items[0]?.detail).toContain("dagar gammalt");
+  });
+
+  it("nämner båda skälen när båda gäller", () => {
+    const items = unbilledItems([{ ...bas, unbilledOre: 30_000_00, oldestEntryDate: "2026-01-01" }], NOW);
+    expect(items[0]?.detail).toContain("över tröskeln och");
+  });
+
+  it("ignorerar ärenden utan ofakturerat", () => {
+    expect(unbilledItems([{ ...bas, unbilledOre: 0, oldestEntryDate: "2026-01-01" }], NOW)).toEqual([]);
+  });
+
+  it("respekterar överstyrda trösklar", () => {
+    const strängare = { ...DEFAULT_THRESHOLDS, unbilledThresholdOre: 100_00, unbilledAgeDays: 9999 };
+    const items = unbilledItems([{ ...bas, unbilledOre: 500_00, oldestEntryDate: "2026-09-01" }], NOW, strängare);
+    expect(items).toHaveLength(1);
+  });
+});
+
+describe("deadlineItems", () => {
+  const bas = { id: "t1", title: "Ge in yttrande", matterId: "m1", matterNumber: "2026-0001" };
+
+  it("ignorerar frister bortom horisonten", () => {
+    expect(deadlineItems([{ ...bas, dueAt: "2026-12-01" }], NOW)).toEqual([]);
+  });
+
+  it("tar med frister inom horisonten", () => {
+    const [item] = deadlineItems([{ ...bas, dueAt: "2026-09-10" }], NOW);
+    expect(item?.severity).toBe("approaching");
+    expect(item?.title).toContain("5 dagar");
+  });
+
+  it("markerar passerad frist och hur länge sedan", () => {
+    const [item] = deadlineItems([{ ...bas, dueAt: "2026-09-01" }], NOW);
+    expect(item?.severity).toBe("passed");
+    expect(item?.detail).toContain("4 dagar sedan");
+  });
+
+  it("länkar till uppgiftslistan när fristen saknar ärende", () => {
+    const [item] = deadlineItems([{ ...bas, matterId: null, matterNumber: null, dueAt: "2026-09-06" }], NOW);
+    expect(item?.href).toBe("/tasks");
+  });
+});
+
+describe("overdueInvoiceItems", () => {
+  const bas = { id: "i1", invoiceNumber: "F-2026-0001", matterId: "m1", matterNumber: "2026-0001" };
+
+  it("ignorerar fakturor som inte förfallit", () => {
+    expect(overdueInvoiceItems([{ ...bas, dueDate: "2026-10-01", outstandingOre: 1_000_00 }], NOW)).toEqual([]);
+  });
+
+  // En betald faktura kan ha passerat förfallodagen utan att vara ett problem.
+  it("ignorerar förfallna fakturor UTAN utestående", () => {
+    expect(overdueInvoiceItems([{ ...bas, dueDate: "2026-08-01", outstandingOre: 0 }], NOW)).toEqual([]);
+  });
+
+  it("räknar dagar över förfallodag", () => {
+    const [item] = overdueInvoiceItems([{ ...bas, dueDate: "2026-08-26", outstandingOre: 1_000_00 }], NOW);
+    expect(item?.severity).toBe("passed");
+    expect(item?.detail).toContain("10 dagar");
+  });
+});
+
+describe("failedDispatchItems", () => {
+  it("förklarar VARFÖR fakturan är obetald", () => {
+    const [item] = failedDispatchItems([{
+      invoiceId: "i1", invoiceNumber: "F-2026-0002", recipient: "klient@example.test",
+      error: "550 rejected", failedAt: "2026-09-01", matterId: "m1", matterNumber: "2026-0001",
+    }]);
+    expect(item?.severity).toBe("passed");
+    expect(item?.detail).toContain("550 rejected");
+    expect(item?.detail).toContain("inte kommit fram");
+  });
+
+  it("klarar utskick utan felmeddelande", () => {
+    const [item] = failedDispatchItems([{
+      invoiceId: "i1", invoiceNumber: null, recipient: "x@y.test",
+      error: null, failedAt: null, matterId: null, matterNumber: null,
+    }]);
+    expect(item?.detail).not.toContain("undefined");
+  });
+});
+
+describe("sortWatchlist", () => {
+  const item = (p: Partial<WatchlistItem>): WatchlistItem => ({
+    kind: "deadline", severity: "approaching", title: "t", detail: "d",
+    matterId: null, matterNumber: null, at: null, amountOre: null, href: "/", ...p,
+  });
+
+  it("sätter passerat före annalkande", () => {
+    const out = sortWatchlist([item({ severity: "approaching" }), item({ severity: "passed" })]);
+    expect(out[0]?.severity).toBe("passed");
+  });
+
+  it("sorterar äldst datum först inom samma allvarsgrad", () => {
+    const out = sortWatchlist([
+      item({ severity: "passed", at: "2026-09-03" }),
+      item({ severity: "passed", at: "2026-08-01" }),
+    ]);
+    expect(out[0]?.at).toBe("2026-08-01");
+  });
+
+  // Ett belopp är angeläget men inte tidsstyrt — det får inte tränga undan
+  // något som faktiskt har en förfallodag.
+  it("lägger datumlösa poster sist inom sin grupp", () => {
+    const out = sortWatchlist([
+      item({ severity: "approaching", at: null, amountOre: 99_000_00 }),
+      item({ severity: "approaching", at: "2026-09-10" }),
+    ]);
+    expect(out[0]?.at).toBe("2026-09-10");
+  });
+
+  it("sorterar datumlösa efter belopp, störst först", () => {
+    const out = sortWatchlist([
+      item({ severity: "approaching", amountOre: 100_00 }),
+      item({ severity: "approaching", amountOre: 900_00 }),
+    ]);
+    expect(out[0]?.amountOre).toBe(900_00);
+  });
+
+  it("muterar inte indata", () => {
+    const input = [item({ severity: "approaching" }), item({ severity: "passed" })];
+    sortWatchlist(input);
+    expect(input[0]?.severity).toBe("approaching");
+  });
+});

--- a/test/unit/server/repositories/invoice-dispatch-repository.test.ts
+++ b/test/unit/server/repositories/invoice-dispatch-repository.test.ts
@@ -1,6 +1,6 @@
 /**
  * InvoiceDispatchRepository-paritet (ADR 0020) — in-memory + Drizzle (pglite).
- * listByInvoice + listQueuedForOrg (org-scope via faktura→ärende, faktura-subset).
+ * listByInvoice + listByStatusForOrg (org-scope via faktura→ärende, faktura-subset).
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest-compat";
@@ -15,7 +15,7 @@ import { uuidv7 } from "@/lib/shared/uuid";
 import { createTestDb, type TestDbHandle } from "../db/pg-test-db";
 
 describe("InvoiceDispatchRepository — in-memory", () => {
-  it("listByInvoice + listQueuedForOrg (faktura-subset)", async () => {
+  it("listByInvoice + listByStatusForOrg (faktura-subset)", async () => {
     const mId = uuidv7();
     const invId = uuidv7();
     const d1 = uuidv7();
@@ -29,10 +29,17 @@ describe("InvoiceDispatchRepository — in-memory", () => {
     } as DemoSource);
     const repo = new InMemoryInvoiceDispatchRepository(new LocalStore(source, async () => {}));
     expect(await repo.listByInvoice(asId<"InvoiceId">(invId))).toHaveLength(2);
-    const queued = await repo.listQueuedForOrg(asId<"OrganizationId">("org-1"));
+    const queued = await repo.listByStatusForOrg(asId<"OrganizationId">("org-1"), "queued");
     expect(queued).toHaveLength(1);
     expect(queued[0]!.invoice?.invoiceNumber).toBe("F-1");
-    expect(await repo.listQueuedForOrg(asId<"OrganizationId">("org-2"))).toHaveLength(0);
+    expect(await repo.listByStatusForOrg(asId<"OrganizationId">("org-2"), "queued")).toHaveLength(0);
+
+    // Statusen är en parameter (#1062): "Att bevaka" listar failed på samma väg
+    // som workern listar queued. Filtrerar den inte får bevakningslistan alla
+    // utskick, inklusive de som gått bra.
+    const sent = await repo.listByStatusForOrg(asId<"OrganizationId">("org-1"), "sent");
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.recipient).toBe("b@x");
   });
 });
 
@@ -41,7 +48,7 @@ describe("InvoiceDispatchRepository — Drizzle (pglite)", () => {
   beforeAll(async () => { handle = await createTestDb(); });
   afterAll(async () => { await handle.close(); });
 
-  it("listByInvoice + listQueuedForOrg (join faktura/ärende)", async () => {
+  it("listByInvoice + listByStatusForOrg (join faktura/ärende)", async () => {
     const db = handle.db;
     const org = uuidv7();
     const mId = uuidv7();
@@ -55,9 +62,9 @@ describe("InvoiceDispatchRepository — Drizzle (pglite)", () => {
     await db.insert(invoiceDispatches).values(v({ id: uuidv7(), invoiceId: invId, channel: "email", recipient: "b@x", status: "sent", queuedAt: new Date(), recordedById: uuidv7() }));
     const repo = new DrizzleInvoiceDispatchRepository(handle.db);
     expect(await repo.listByInvoice(asId<"InvoiceId">(invId))).toHaveLength(2);
-    const queued = await repo.listQueuedForOrg(asId<"OrganizationId">(org));
+    const queued = await repo.listByStatusForOrg(asId<"OrganizationId">(org), "queued");
     expect(queued).toHaveLength(1);
     expect(queued[0]!.invoice?.invoiceNumber).toBe("F-1");
-    expect(await repo.listQueuedForOrg(asId<"OrganizationId">(uuidv7()))).toHaveLength(0);
+    expect(await repo.listByStatusForOrg(asId<"OrganizationId">(uuidv7()), "queued")).toHaveLength(0);
   });
 });

--- a/tooling/ava-cli/tool-descriptions.ts
+++ b/tooling/ava-cli/tool-descriptions.ts
@@ -220,6 +220,7 @@ const DESCRIPTIONS: Readonly<Record<string, string>> = {
 
   // ── Att göra-vy ──────────────────────────────────────────────────
   "todo.list": "Sammanställd att göra-lista: uppgifter, frister och kalenderhändelser som kräver åtgärd.",
+  "watchlist.list": "Att bevaka: härledda påminnelser över alla ärenden — täckningstak som nås, ofakturerat arbete över tröskel, tidsfrister, förfallna fakturor och misslyckade fakturautskick. Sorterat efter hur brådskande.",
 
   // ── Användare ────────────────────────────────────────────────────
   "user.list": "Byråns medarbetare.",


### PR DESCRIPTION
Från användare: påminnelser om ärenden som bör faktureras när upparbetad tid nått gränsen, dokument som ska ges in, tidsfrister.

## Vad som faktiskt saknades

Varje signal syns **redan** någonstans — men bara där man redan tittar. Täckningsvarningen finns inne i ärendet, förfallodagen på fakturan, statusen på ett utskick. En påminnelse ska fungera tvärtom: man ska få veta **utan** att öppna något.

Det var alltså inte signalerna som fattades, utan platsen som svarar på *"vad behöver min uppmärksamhet, över alla ärenden?"*

## Fem signaler

| Signal | Källa | Varför |
|---|---|---|
| Täckningstaket nås (≥ 90 %) | `coverageStatus` | arbete över taket ersätts inte |
| Ofakturerat över tröskel | ofrysta debiterbara tidsposter | pengar som står stilla |
| Tidsfrist närmar sig/passerad | `task.dueAt` | det enda som skrivs in i st.f. att räknas ut |
| Förfallen faktura | `dueDate` + utestående | fordran som glider |
| Misslyckat fakturautskick | `dispatch.status = failed` | fakturan nådde aldrig klienten |

## Inget lagras — och det är ett val

Ingen `Reminder`-entitet, ingen avfärda-knapp. Varje post härleds och **städar sig själv**: fakturera ärendet och den försvinner. En lagrad påminnelse hade krävt att någon avfärdar den, och därmed skapat en andra sanningskälla som kan säga något annat än verkligheten.

Priset är att man inte kan snooza. Det är rätt pris: **en påminnelse som går att tysta utan att åtgärda kommer att tystas.**

## Tröskeln för "bör faktureras"

Två **oberoende** villkor, vilket som helst räcker: belopp (25 000 kr) eller ålder (60 dagar). Bara beloppsgränsen hade missat ett ärende med 8 000 kr som legat ett halvår — precis den sortens fordran som aldrig blir fakturerad. Trösklarna är kodens defaults i v1; org-inställning ligger som #1063 (kräver migration, hör inte hemma här).

## Var det syns

Kort på startsidan (self-gating — inget att bevaka ⇒ inget kort) med de fem mest brådskande, plus sidan **Att bevaka** med filter per signaltyp och "bara mina ärenden".

## Sidoändring

`invoiceDispatches.listQueuedForOrg` generaliseras till `listByStatusForOrg(status)` i stället för att en nästan identisk metod dupliceras för `failed`. En anropare uppdaterad; nytt test som bevisar att statusen faktiskt filtrerar.

## Verifierat

`bun run test:fast` 3671 gröna (43 nya: 27 för härledningslogiken, 16 för vyerna), lint/knip/dep-cruiser rena, `build:demo` bygger 132 sidor.

Refs #1062

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9UB9at5Tpr1A6sYEXomxB