### PR TITLE
fix(watchlist): pluralböjning och rubrik som räknade filtrerade poster

### DIFF
--- a/src/app/watchlist/page.tsx
+++ b/src/app/watchlist/page.tsx
@@ -31,12 +31,16 @@ export default function WatchlistPage() {
   const [kind, setKind] = useState<WatchlistKind | "all">("all");
   const q = trpc.watchlist.list.useQuery({ mine });
 
-  const items = useMemo(() => {
-    const all = q.data?.items ?? [];
-    return kind === "all" ? all : all.filter((i) => i.kind === kind);
-  }, [q.data, kind]);
+  const all = useMemo(() => q.data?.items ?? [], [q.data]);
+  const items = useMemo(
+    () => (kind === "all" ? all : all.filter((i) => i.kind === kind)),
+    [all, kind],
+  );
 
-  const passed = items.filter((i) => i.severity === "passed").length;
+  // Rubriken räknar ALLA poster, inte de filtrerade. Annars påstår sidan
+  // "inget behöver din uppmärksamhet" så fort man filtrerar till en tom
+  // kategori — vilket är falskt och farligt när något annat brinner.
+  const passed = all.filter((i) => i.severity === "passed").length;
 
   return (
     <div>
@@ -45,8 +49,8 @@ export default function WatchlistPage() {
           <h1 className="text-2xl font-bold text-gray-900">Att bevaka</h1>
           <p className="text-sm text-gray-500">
             {q.isLoading ? "Hämtar…"
-              : items.length === 0 ? "Inget behöver din uppmärksamhet."
-              : `${items.length} poster, varav ${passed} redan passerade.`}
+              : all.length === 0 ? "Inget behöver din uppmärksamhet."
+              : `${all.length} poster, varav ${passed} redan passerade.`}
           </p>
         </div>
         <label className="flex items-center gap-2 text-sm text-gray-700">

--- a/src/lib/shared/watchlist.ts
+++ b/src/lib/shared/watchlist.ts
@@ -116,6 +116,18 @@ export function daysBetween(from: Date, to: Date): number {
 
 const iso = (d: Date): string => d.toISOString().slice(0, 10);
 
+/** "1 dag" / "3 dagar" — svensk pluralböjning. "om 1 dagar" ser trasigt ut. */
+export function dagar(n: number): string {
+  return n === 1 ? "1 dag" : `${n} dagar`;
+}
+
+/** "idag" / "imorgon" / "om 3 dagar" — noll dagar kvar är inte "om 0 dagar". */
+function omDagar(n: number): string {
+  if (n === 0) return "idag";
+  if (n === 1) return "imorgon";
+  return `om ${dagar(n)}`;
+}
+
 export interface CoverageMatter extends CoverageCapInput {
   id: string;
   matterNumber: string;
@@ -173,9 +185,9 @@ function unbilledReason(m: UnbilledMatter, now: Date, t: WatchlistThresholds): s
   const ålder = m.oldestEntryDate === null ? 0 : daysBetween(new Date(m.oldestEntryDate), now);
   const överBelopp = m.unbilledOre >= t.unbilledThresholdOre;
   const förGammalt = m.oldestEntryDate !== null && ålder >= t.unbilledAgeDays;
-  if (överBelopp && förGammalt) return `över tröskeln och ${ålder} dagar gammalt`;
+  if (överBelopp && förGammalt) return `över tröskeln och ${dagar(ålder)} gammalt`;
   if (överBelopp) return "över tröskeln";
-  if (förGammalt) return `${ålder} dagar gammalt`;
+  if (förGammalt) return `${dagar(ålder)} gammalt`;
   return null;
 }
 
@@ -226,9 +238,9 @@ export function deadlineItems(
     out.push({
       kind: "deadline",
       severity: passerad ? "passed" : "approaching",
-      title: passerad ? `Tidsfrist passerad: ${task.title}` : `Tidsfrist om ${kvar} dagar: ${task.title}`,
+      title: passerad ? `Tidsfrist passerad: ${task.title}` : `Tidsfrist ${omDagar(kvar)}: ${task.title}`,
       detail: passerad
-        ? `Fristen gick ut för ${Math.abs(kvar)} dagar sedan.`
+        ? `Fristen gick ut för ${dagar(Math.abs(kvar))} sedan.`
         : `Förfaller ${iso(new Date(task.dueAt))}.`,
       matterId: task.matterId, matterNumber: task.matterNumber,
       at: iso(new Date(task.dueAt)), amountOre: null,
@@ -252,13 +264,13 @@ export function overdueInvoiceItems(invoices: readonly OverdueInvoice[], now: Da
   const out: WatchlistItem[] = [];
   for (const inv of invoices) {
     if (inv.outstandingOre <= 0) continue;
-    const dagar = daysBetween(new Date(inv.dueDate), now);
-    if (dagar <= 0) continue;
+    const dagarSen = daysBetween(new Date(inv.dueDate), now);
+    if (dagarSen <= 0) continue;
     out.push({
       kind: "overdueInvoice",
       severity: "passed",
       title: `Förfallen faktura ${inv.invoiceNumber ?? ""}`.trim(),
-      detail: `${dagar} dagar över förfallodag.`,
+      detail: `${dagar(dagarSen)} över förfallodag.`,
       matterId: inv.matterId, matterNumber: inv.matterNumber,
       at: inv.dueDate, amountOre: inv.outstandingOre,
       href: `/invoices/${inv.id}`,

--- a/test/unit/app/watchlist-page.test.tsx
+++ b/test/unit/app/watchlist-page.test.tsx
@@ -77,6 +77,17 @@ describe("Att bevaka-sidan", () => {
     expect(screen.getByRole("button", { name: "Tidsfrister" })).toHaveAttribute("aria-pressed", "true");
   });
 
+  // #1065: rubriken räknade filtrerade poster → sidan påstod "inget behöver
+  // din uppmärksamhet" så fort man filtrerade till en tom kategori, medan
+  // något annat brann.
+  it("räknar ALLA poster i rubriken, inte de filtrerade", () => {
+    query.data = { items: [item({ kind: "deadline", severity: "passed" })] };
+    render(<WatchlistPage />);
+    fireEvent.click(screen.getByRole("button", { name: "Ofakturerat" }));
+    expect(screen.getByText(/1 poster, varav 1 redan passerade/)).toBeInTheDocument();
+    expect(screen.queryByText(/Inget behöver din uppmärksamhet/i)).not.toBeInTheDocument();
+  });
+
   it("säger till när kategorin är tom i st.f. att se trasig ut", () => {
     query.data = { items: [item({ kind: "deadline" })] };
     render(<WatchlistPage />);

--- a/test/unit/lib/watchlist.test.ts
+++ b/test/unit/lib/watchlist.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest-compat";
 import {
-  coverageItems, deadlineItems, failedDispatchItems, overdueInvoiceItems,
+  coverageItems, dagar, deadlineItems, failedDispatchItems, overdueInvoiceItems,
   sortWatchlist, unbilledItems, daysBetween,
   DEFAULT_THRESHOLDS, type WatchlistItem,
 } from "@/lib/shared/watchlist";
@@ -200,5 +200,46 @@ describe("sortWatchlist", () => {
     const input = [item({ severity: "approaching" }), item({ severity: "passed" })];
     sortWatchlist(input);
     expect(input[0]?.severity).toBe("approaching");
+  });
+});
+
+/**
+ * Pluralböjningen (#1065). "Tidsfrist om 1 dagar" upptäcktes i den skarpa
+ * demon — en text som ser trasig ut får en användare att misstro hela vyn,
+ * även när siffran är rätt.
+ */
+describe("svensk böjning", () => {
+  it("böjer en dag i singular", () => {
+    expect(dagar(1)).toBe("1 dag");
+  });
+
+  it("böjer flera dagar i plural", () => {
+    expect(dagar(3)).toBe("3 dagar");
+  });
+
+  it("skriver inte \"om 1 dagar\" i en frist", () => {
+    const NOW2 = new Date("2026-09-05T00:00:00Z");
+    const [item] = deadlineItems(
+      [{ id: "t", title: "Ge in", dueAt: "2026-09-06", matterId: null, matterNumber: null }], NOW2,
+    );
+    expect(item?.title).toContain("imorgon");
+    expect(item?.title).not.toContain("1 dagar");
+  });
+
+  it("säger \"idag\" i st.f. \"om 0 dagar\"", () => {
+    const NOW2 = new Date("2026-09-05T00:00:00Z");
+    const [item] = deadlineItems(
+      [{ id: "t", title: "Ge in", dueAt: "2026-09-05", matterId: null, matterNumber: null }], NOW2,
+    );
+    expect(item?.title).toContain("idag");
+  });
+
+  it("böjer även dagar över förfallodag", () => {
+    const NOW2 = new Date("2026-09-05T00:00:00Z");
+    const [item] = overdueInvoiceItems(
+      [{ id: "i", invoiceNumber: "F-1", dueDate: "2026-09-04", outstandingOre: 100, matterId: null, matterNumber: null }],
+      NOW2,
+    );
+    expect(item?.detail).toBe("1 dag över förfallodag.");
   });
 });


### PR DESCRIPTION
Båda hittade genom att **titta på den skarpa demon** efter att #1064 gått grön i CI. Ingen av dem syns i ett test som inte redan letar efter dem.

## 1. "Tidsfrist om 1 dagar"

Svensk pluralböjning saknades i frister, ålder på ofakturerat och dagar över förfallodag. En text som ser trasig ut får användaren att misstro hela vyn — även när siffran är rätt.

`dagar(n)` böjer, och `omDagar` säger **"idag"** / **"imorgon"** i stället för "om 0 dagar" / "om 1 dagar".

## 2. Rubriken räknade filtrerade poster

Sidan skrev *"Inget behöver din uppmärksamhet"* så snart man filtrerade till en tom kategori — trots att andra kategorier hade poster.

Det är den farligaste sortens fel i just den här vyn: **den påstår lugn medan något brinner.** Rubriken räknar nu alltid alla poster.

## Verifierat

6 nya tester, ett per felläge inklusive gränsfallen 0 och 1 dagar. 3677 gröna totalt.

Refs #1065

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9UB9at5Tpr1A6sYEXomxB