### PR TITLE
test(e2e): generera camt-filer så betalningar fångas hela vägen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,17 @@ jobs:
           AVA_DATABASE_URL: postgres://ava:ava@localhost:5433/ava_test
           AVA_ORGANIZATION_ID: "00000000-0000-0000-0000-000000000001"
         run: bun tooling/scripts/expected-receivable-e2e.ts
+      # Camt-betalnings-E2E: hela kedjan bankfil → parser → matchning →
+      # bokförd betalning. Parsern är testad mot riktiga SEB-filer och
+      # matcharna mot fixturer, men de riktiga filerna har FASTA referenser och
+      # kan aldrig matcha en faktura ett test just skapat — därför har
+      # XML-steget hoppats över. Här genereras filen med referenser som matchar.
+      - name: Camt-betalnings-E2E (bankfil → bokförd betalning)
+        env:
+          SERVER_URL: http://localhost:3001
+          AVA_DATABASE_URL: postgres://ava:ava@localhost:5433/ava_test
+          AVA_ORGANIZATION_ID: "00000000-0000-0000-0000-000000000001"
+        run: bun tooling/scripts/camt-payment-e2e.ts
       - name: Tear down docker
         if: always()
         run: docker compose -f tooling/docker/docker-compose.server-first.yml down -v

--- a/bun.lock
+++ b/bun.lock
@@ -55,6 +55,7 @@
         "eslint-config-next": "16.2.12",
         "eslint-plugin-import-x": "^4.16.2",
         "fake-indexeddb": "^6.2.5",
+        "happy-dom": "^20.10.2",
         "husky": "^9.1.7",
         "jscpd": "^5.0.4",
         "knip": "^6.16.1",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "e2e:conflict-check": "bash tooling/scripts/conflict-check-e2e.sh",
     "e2e:invoice-dispatch": "bash tooling/scripts/invoice-dispatch-e2e.sh",
     "e2e:expected-receivable": "bash tooling/scripts/expected-receivable-e2e.sh",
+    "e2e:camt-payment": "bash tooling/scripts/camt-payment-e2e.sh",
     "e2e:conflict": "bash tooling/scripts/conflict-e2e.sh",
     "selfhosted:local": "bash tooling/scripts/selfhosted-local.sh",
     "diagnose-ui": "bun tooling/scripts/diagnose-ui.ts",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "eslint-config-next": "16.2.12",
     "eslint-plugin-import-x": "^4.16.2",
     "fake-indexeddb": "^6.2.5",
+    "happy-dom": "^20.10.2",
     "husky": "^9.1.7",
     "jscpd": "^5.0.4",
     "knip": "^6.16.1",

--- a/test/unit/tooling/camt-builder.test.ts
+++ b/test/unit/tooling/camt-builder.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest-compat";
+import { parseCamtXml } from "@/lib/shared/payments/camt-parse";
+import { buildCamt054 } from "../../../tooling/scripts/camt-builder";
+
+/**
+ * Generatorn (#1067) är bara värd något om den RIKTIGA parsern läser den, och
+ * läser den rätt. Testet kör därför alltid `buildCamt054` → `parseCamtXml` —
+ * aldrig en påhittad mellanform.
+ *
+ * Det fångar också driften åt andra hållet: ändrar någon parsern så den slutar
+ * förstå SEB:s struktur failar det här innan en byrå upptäcker det genom att
+ * en importerad fil inte bokförs.
+ */
+const OPTS = { bookingDate: "2026-06-15" };
+
+describe("buildCamt054 → parseCamtXml", () => {
+  it("rundgår en enkel inbetalning", () => {
+    const xml = buildCamt054([{
+      reference: "REF-1", amountOre: 12_500, debtorName: "Klient AB",
+      structuredRefs: [{ ref: "1234567890" }],
+    }], OPTS);
+    const file = parseCamtXml(xml);
+    expect(file.transactions).toHaveLength(1);
+    const [tx] = file.transactions;
+    expect(tx?.amountOre).toBe(12_500);
+    expect(tx?.currency).toBe("SEK");
+    expect(tx?.creditDebit).toBe("CRDT");
+    expect(tx?.debtorName).toBe("Klient AB");
+    expect(tx?.valueDate).toBe("2026-06-15");
+  });
+
+  it("bär strukturerad OCR-referens", () => {
+    const xml = buildCamt054([{
+      reference: "REF-2", amountOre: 50_000, debtorName: "K",
+      structuredRefs: [{ ref: "9988776655" }],
+    }], OPTS);
+    const [tx] = parseCamtXml(xml).transactions;
+    expect(tx?.structuredRefs.map((r) => r.ref)).toEqual(["9988776655"]);
+  });
+
+  // En TxDtls kan betala flera fakturor med var sitt delbelopp — det är så
+  // bankgirot itemiserar en samlad insättning.
+  it("bär delbelopp per referens vid samlad betalning", () => {
+    const xml = buildCamt054([{
+      reference: "REF-3", amountOre: 30_000, debtorName: "K",
+      structuredRefs: [{ ref: "A1", amountOre: 10_000 }, { ref: "A2", amountOre: 20_000 }],
+    }], OPTS);
+    const [tx] = parseCamtXml(xml).transactions;
+    expect(tx?.structuredRefs).toEqual([
+      { ref: "A1", amountOre: 10_000 },
+      { ref: "A2", amountOre: 20_000 },
+    ]);
+  });
+
+  it("bär fri text — domstolsbetalningarnas väg", () => {
+    const xml = buildCamt054([{
+      reference: "REF-4", amountOre: 1_626_000, debtorName: "DOMSTOLSVERKET",
+      freeTexts: ["1154602 3288-26 ENOKSSON"],
+    }], OPTS);
+    const [tx] = parseCamtXml(xml).transactions;
+    expect(tx?.freeTexts).toEqual(["1154602 3288-26 ENOKSSON"]);
+  });
+
+  it("bygger flera kontohändelser i samma fil", () => {
+    const xml = buildCamt054([
+      { reference: "R1", amountOre: 100, debtorName: "A", freeTexts: ["x"] },
+      { reference: "R2", amountOre: 200, debtorName: "B", freeTexts: ["y"] },
+    ], OPTS);
+    expect(parseCamtXml(xml).transactions).toHaveLength(2);
+  });
+
+  // Öre → kronor sker bara i generatorn; ett avrundningsfel här skulle bokföra
+  // fel belopp utan att något annat märker det.
+  it("konverterar öre till kronor utan att tappa ören", () => {
+    const xml = buildCamt054([{
+      reference: "R", amountOre: 4_065_00, debtorName: "K", freeTexts: ["x"],
+    }], OPTS);
+    expect(xml).toContain('<Amt Ccy="SEK">4065.00</Amt>');
+    expect(parseCamtXml(xml).transactions[0]?.amountOre).toBe(4_065_00);
+  });
+
+  it("escapar tecken som annars spräcker filen", () => {
+    const xml = buildCamt054([{
+      reference: "R", amountOre: 100, debtorName: "Bolag & Söner <AB>",
+      freeTexts: ["a & b"],
+    }], OPTS);
+    expect(() => parseCamtXml(xml)).not.toThrow();
+    expect(parseCamtXml(xml).transactions[0]?.debtorName).toBe("Bolag & Söner <AB>");
+  });
+
+  it("summerar filens totalbelopp i TxsSummry", () => {
+    const xml = buildCamt054([
+      { reference: "R1", amountOre: 10_000, debtorName: "A", freeTexts: ["x"] },
+      { reference: "R2", amountOre: 15_000, debtorName: "B", freeTexts: ["y"] },
+    ], OPTS);
+    expect(xml).toContain("<NbOfNtries>2</NbOfNtries>");
+    expect(xml).toContain("<Sum>250.00</Sum>");
+  });
+
+  it("använder camt.054-namnrymden banken skickar", () => {
+    const xml = buildCamt054([{ reference: "R", amountOre: 1, debtorName: "A", freeTexts: ["x"] }], OPTS);
+    expect(xml).toContain("urn:iso:std:iso:20022:tech:xsd:camt.054.001.02");
+  });
+});

--- a/tooling/scripts/camt-builder.ts
+++ b/tooling/scripts/camt-builder.ts
@@ -1,0 +1,177 @@
+/**
+ * camt.054-generator för e2e (#1067) — ren strängbyggare, ingen I/O.
+ *
+ * ## Varför den behövs
+ *
+ * `camt-parse.ts` är väl testad mot RIKTIGA SEB-filer i `test/fixtures/camt-seb`.
+ * Men de filerna har fasta referenser och kan därför aldrig matcha fakturor
+ * ett e2e just skapat. Följden är att e2e:erna byggt camt-TRANSAKTIONER i
+ * minnet och matat matcharen direkt — vilket hoppar över hela XML-steget.
+ *
+ * Det är en verklig lucka: går parsern sönder, eller driver bankens format,
+ * märker ingen kontroll det förrän en byrå importerar en fil som inte
+ * bokförs. Med generatorn körs hela kedjan i CI: bankfil → parser → matchning
+ * → bokförd betalning.
+ *
+ * ## Varför den härmar fixturen elementvis
+ *
+ * Strukturen nedan följer `camt.054_SE_CRED_BGC.xml` från SEB:s Test Bench
+ * element för element — samma nästling, samma namnrymd, samma
+ * `Ntry → NtryDtls → TxDtls`-hierarki. Det är avsiktligt: en generator som
+ * bygger det VÅR parser råkar gilla bevisar ingenting. Den ska producera det
+ * en bank faktiskt skickar.
+ *
+ * Beloppen skrivs i kronor med två decimaler (camt räknar i valutaenheter),
+ * medan domänen räknar i öre. Konverteringen sker bara här.
+ */
+
+/** Belopp i öre → camt:s kron-representation ("125.00"). */
+function kronor(ore: number): string {
+  return (ore / 100).toFixed(2);
+}
+
+/** XML-escape för fri text — ett `&` i en klientreferens ska inte spräcka filen. */
+function esc(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/** En strukturerad referens (OCR/fakturanr) med valfritt eget delbelopp. */
+export interface StructuredRef {
+  /** OCR-nummer eller fakturanummer. */
+  ref: string;
+  /** Delbelopp i öre. Utelämnas → hela transaktionsbeloppet avser referensen. */
+  amountOre?: number;
+}
+
+export interface CamtTx {
+  /** Bankens transaktionsreferens — nyckeln för idempotent import. */
+  reference: string;
+  amountOre: number;
+  /** Betalarens namn (DOMSTOLSVERKET, klientens namn, …). */
+  debtorName: string;
+  /** Strukturerade referenser (`RmtInf/Strd`) — OCR-vägen. */
+  structuredRefs?: StructuredRef[];
+  /** Fri text (`RmtInf/Ustrd`) — målnummer/ärendereferens-vägen (#175). */
+  freeTexts?: string[];
+}
+
+export interface CamtFileOptions {
+  /** Bokförings-/valutadatum (YYYY-MM-DD). */
+  bookingDate: string;
+  /** Meddelande-id i GrpHdr. Default härleds ur datumet. */
+  messageId?: string;
+}
+
+function structuredBlock(r: StructuredRef): string {
+  const amt = r.amountOre === undefined ? "" : `
+								<RfrdDocAmt>
+									<RmtdAmt Ccy="SEK">${kronor(r.amountOre)}</RmtdAmt>
+								</RfrdDocAmt>`;
+  return `
+							<Strd>
+								<RfrdDocInf>
+									<Tp>
+										<CdOrPrtry>
+											<Cd>CINV</Cd>
+										</CdOrPrtry>
+									</Tp>
+									<Nb>${esc(r.ref)}</Nb>
+								</RfrdDocInf>${amt}
+							</Strd>`;
+}
+
+/** En `TxDtls` — bankens itemisering av EN betalning inom kontohändelsen. */
+function txDetails(tx: CamtTx): string {
+  const strd = (tx.structuredRefs ?? []).map(structuredBlock).join("");
+  const ustrd = (tx.freeTexts ?? []).map((t) => `
+							<Ustrd>${esc(t)}</Ustrd>`).join("");
+  return `
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>${esc(tx.reference)}</AcctSvcrRef>
+						</Refs>
+						<AmtDtls>
+							<TxAmt>
+								<Amt Ccy="SEK">${kronor(tx.amountOre)}</Amt>
+							</TxAmt>
+						</AmtDtls>
+						<RltdPties>
+							<Dbtr>
+								<Nm>${esc(tx.debtorName)}</Nm>
+							</Dbtr>
+						</RltdPties>
+						<RmtInf>${strd}${ustrd}
+						</RmtInf>
+					</TxDtls>`;
+}
+
+/**
+ * Bygg en camt.054-avisering med en kontohändelse per transaktion.
+ *
+ * En riktig bank kan slå ihop flera betalningar i EN `Ntry` med flera
+ * `TxDtls` — det fallet finns i fixturerna och parsern hanterar det. Här är
+ * det en `Ntry` per transaktion, vilket är det vanliga för bankgiro-
+ * inbetalningar och räcker för att bevisa kedjan.
+ */
+export function buildCamt054(txs: readonly CamtTx[], opts: CamtFileOptions): string {
+  const total = txs.reduce((s, t) => s + t.amountOre, 0);
+  const msgId = opts.messageId ?? `AVA-E2E-${opts.bookingDate.replace(/-/g, "")}`;
+  const entries = txs.map((tx) => `
+			<Ntry>
+				<NtryRef>${esc(tx.reference)}</NtryRef>
+				<Amt Ccy="SEK">${kronor(tx.amountOre)}</Amt>
+				<CdtDbtInd>CRDT</CdtDbtInd>
+				<Sts>BOOK</Sts>
+				<BookgDt>
+					<Dt>${opts.bookingDate}</Dt>
+				</BookgDt>
+				<ValDt>
+					<Dt>${opts.bookingDate}</Dt>
+				</ValDt>
+				<AcctSvcrRef>${esc(tx.reference)}</AcctSvcrRef>
+				<BkTxCd>
+					<Domn>
+						<Cd>PMNT</Cd>
+						<Fmly>
+							<Cd>RCDT</Cd>
+							<SubFmlyCd>ATXN</SubFmlyCd>
+						</Fmly>
+					</Domn>
+				</BkTxCd>
+				<NtryDtls>${txDetails(tx)}
+				</NtryDtls>
+			</Ntry>`).join("");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:camt.054.001.02 camt.054.001.02.xsd" xmlns="urn:iso:std:iso:20022:tech:xsd:camt.054.001.02">
+	<BkToCstmrDbtCdtNtfctn>
+		<GrpHdr>
+			<MsgId>${esc(msgId)}</MsgId>
+			<CreDtTm>${opts.bookingDate}T08:00:00</CreDtTm>
+			<AddtlInf>/CRED/</AddtlInf>
+		</GrpHdr>
+		<Ntfctn>
+			<Id>${esc(msgId)}-N1</Id>
+			<CreDtTm>${opts.bookingDate}T08:00:00</CreDtTm>
+			<Acct>
+				<Id>
+					<Othr>
+						<Id>54401060156</Id>
+						<SchmeNm>
+							<Cd>BBAN</Cd>
+						</SchmeNm>
+					</Othr>
+				</Id>
+				<Ccy>SEK</Ccy>
+			</Acct>
+			<TxsSummry>
+				<TtlCdtNtries>
+					<NbOfNtries>${txs.length}</NbOfNtries>
+					<Sum>${kronor(total)}</Sum>
+				</TtlCdtNtries>
+			</TxsSummry>${entries}
+		</Ntfctn>
+	</BkToCstmrDbtCdtNtfctn>
+</Document>
+`;
+}

--- a/tooling/scripts/camt-payment-e2e.sh
+++ b/tooling/scripts/camt-payment-e2e.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Självständig runner för camt-betalnings-E2E:n (server-first-stacken).
+#
+#   bash tooling/scripts/camt-payment-e2e.sh
+#
+# Kör hela kedjan bankfil → parser → matchning → bokförd betalning, för BÅDA
+# referensvägarna: OCR (strukturerad, klientens fakturabetalning) och fri text
+# (domstolens utbetalning mot en förväntad fordran). Sista steget importerar om
+# exakt samma fil och kräver att ingenting bokförs en andra gång.
+set -euo pipefail
+
+COMPOSE="tooling/docker/docker-compose.server-first.yml"
+DB_URL="postgres://ava:ava@localhost:5433/ava_test"
+ORG="00000000-0000-0000-0000-000000000001"
+
+cleanup() { docker compose -f "$COMPOSE" down -v >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "▸ Bygger server-first-binären…"
+bun run server-first:build
+
+echo "▸ Startar Postgres + server-first…"
+docker compose -f "$COMPOSE" up -d --build --wait --wait-timeout 180
+
+echo "▸ Applicerar schema…"
+AVA_DATABASE_URL="$DB_URL" bun run db:migrate
+
+echo "▸ Kör camt-betalnings-E2E…"
+SERVER_URL=http://localhost:3001 \
+AVA_DATABASE_URL="$DB_URL" \
+AVA_ORGANIZATION_ID="$ORG" \
+  bun tooling/scripts/camt-payment-e2e.ts

--- a/tooling/scripts/camt-payment-e2e.ts
+++ b/tooling/scripts/camt-payment-e2e.ts
@@ -32,6 +32,7 @@
  *   bun run e2e:camt-payment
  */
 
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { parseCamtXml } from "@/lib/shared/payments/camt-parse";
 import { matchTransactions, type InvoiceCandidate } from "@/lib/shared/payments/match-payments";
 import { matchReceivables, type ReceivableCandidate } from "@/lib/shared/payments/match-receivables";
@@ -40,6 +41,14 @@ import { buildCamt054, type CamtTx } from "./camt-builder";
 import {
   assert, clientFor, kr, seedUser, waitForServer, type Ava,
 } from "./e2e-harness";
+
+/**
+ * camt-parsern använder browser-nativ `DOMParser`, och det är INTE en
+ * eftergift för testet: importen sker i webbläsaren i AVA (importsidan parsar
+ * klient-sida). Bun saknar DOMParser, så e2e:t registrerar samma happy-dom som
+ * enhetstesterna använder — då körs parsern i den miljö den faktiskt lever i.
+ */
+GlobalRegistrator.register();
 
 const USER = "anna-camt@byra.se";
 const RATE_ORE = 250_000;

--- a/tooling/scripts/camt-payment-e2e.ts
+++ b/tooling/scripts/camt-payment-e2e.ts
@@ -147,7 +147,10 @@ interface Matched { invoicePayment: { amountOre: number; reference: string }; re
 async function matchAll(c: Ava, f: Fixture, file: ReturnType<typeof parseCamtXml>): Promise<Matched> {
   console.log("\n--- Steg 2: matcha mot fakturor och fordringar ---");
 
-  const invoices = await c.invoice.list.query({ pageSize: 200 });
+  // Utan pageSize = hela listan, precis som importsidan gör (`invoice.list`
+  // med tomt filter). Att skicka ett eget sidnummer hade testat en väg som
+  // ingen användare tar — och taket är 100, vilket e2e:t fick lära sig.
+  const invoices = await c.invoice.list.query({});
   const invoiceCands: InvoiceCandidate[] = invoices.items.map((r) => ({
     id: asId<"InvoiceId">(String(r.id)),
     invoiceNumber: r.invoiceNumber ?? null,
@@ -211,7 +214,7 @@ async function verifyReimport(c: Ava, f: Fixture, xml: string): Promise<void> {
   console.log("\n--- Steg 4: omimport av samma fil ---");
   const file = parseCamtXml(xml);
 
-  const invoices = await c.invoice.list.query({ pageSize: 200 });
+  const invoices = await c.invoice.list.query({});
   const cands: InvoiceCandidate[] = invoices.items.map((r) => ({
     id: asId<"InvoiceId">(String(r.id)),
     invoiceNumber: r.invoiceNumber ?? null,

--- a/tooling/scripts/camt-payment-e2e.ts
+++ b/tooling/scripts/camt-payment-e2e.ts
@@ -1,0 +1,245 @@
+#!/usr/bin/env bun
+/**
+ * CAMT-BETALNINGS-E2E (#1067) — bankfil → parser → matchning → bokförd betalning.
+ *
+ * ## Luckan som stängs
+ *
+ * `camt-parse.ts` är testad mot riktiga SEB-filer, och matcharna är testade
+ * mot fixturer. Men INGEN kontroll har kört hela kedjan: de riktiga filerna har
+ * fasta referenser och kan aldrig matcha en faktura ett test just skapat, så
+ * e2e:erna har byggt camt-TRANSAKTIONER i minnet och matat matcharen direkt.
+ *
+ * Det hoppar över XML-steget — och det är där en bankfil spretar. Går parsern
+ * sönder eller driver formatet märker ingen det förrän en byrå importerar en
+ * fil som inte bokförs, tyst.
+ *
+ * Här genereras filen (`camt-builder.ts`, modellerad element för element på
+ * SEB:s Test Bench-fil), parsas med den SKARPA parsern, matchas med de SKARPA
+ * matcharna och bokförs via det riktiga API:t.
+ *
+ * ## Två referensvägar, båda med pengar i sig
+ *
+ *   OCR (strukturerad)  klientens fakturabetalning → invoice.recordPayment
+ *   Fri text            domstolens utbetalning     → expectedReceivable.settle
+ *
+ * ## Och omimporten
+ *
+ * Banken skickar om filer, och en människa importerar samma fil två gånger.
+ * Sista steget kör därför exakt samma XML igen och kräver att INGENTING bokförs
+ * en andra gång. En dubbelbokförd inbetalning ser ut som en överbetalning och
+ * leder till att pengar betalas tillbaka som aldrig kommit in.
+ *
+ *   bun run e2e:camt-payment
+ */
+
+import { parseCamtXml } from "@/lib/shared/payments/camt-parse";
+import { matchTransactions, type InvoiceCandidate } from "@/lib/shared/payments/match-payments";
+import { matchReceivables, type ReceivableCandidate } from "@/lib/shared/payments/match-receivables";
+import { asId } from "@/lib/shared/schemas/ids";
+import { buildCamt054, type CamtTx } from "./camt-builder";
+import {
+  assert, clientFor, kr, seedUser, waitForServer, type Ava,
+} from "./e2e-harness";
+
+const USER = "anna-camt@byra.se";
+const RATE_ORE = 250_000;
+const BOOKING_DATE = "2026-06-15";
+const COURT_CASE = "4411-26";
+/** Domstolen prutar; utbetalningen är sällan det begärda. */
+const BEGART_ORE = 2_032_500;
+const UTBETALT_ORE = 1_626_000;
+
+// ─── Uppsättning ───────────────────────────────────────────────────────────
+
+interface Fixture {
+  invoiceId: string;
+  ocr: string;
+  invoiceAmount: number;
+  receivableId: string;
+  matterNumber: string;
+}
+
+/** Klientfaktura med OCR + domstolsfordran med målnummer — en per referensväg. */
+async function seed(c: Ava, userId: string, stamp: string): Promise<Fixture> {
+  console.log("\n--- Bygger upp en fakturerad klient och en domstolsfordran ---");
+
+  const klient = await c.contacts.create.mutate({
+    name: `Camt-klient ${stamp}`, contactType: "PERSON", email: `camt-${stamp}@klient.test`,
+  });
+  const m = await c.matter.create.mutate({
+    matterNumber: `CAMT-${stamp}`, title: `Camt-ärende ${stamp}`,
+    matterType: "Brottmål", paymentMethod: "PRIVAT", responsibleLawyerId: userId,
+    courtCaseNumber: COURT_CASE,
+  });
+  await c.matter.addContact.mutate({ matterId: m.id, contactId: klient.id, role: "KLIENT" });
+  await c.timeEntry.create.mutate({
+    matterId: m.id, userId, date: "2026-05-02", minutes: 300,
+    description: "Handläggning", billable: true, hourlyRate: RATE_ORE,
+  });
+
+  const { invoice } = await c.billingRun.createFinal.mutate({
+    matterId: m.id, recipient: "KLIENT", invoiceDate: "2026-05-20", dueDate: "2026-06-20",
+  });
+  await c.invoice.setStatus.mutate({ invoiceId: invoice.id, status: "SENT" });
+  const full = await c.invoice.getById.query({ id: invoice.id });
+  const ocr = full.ocrReference ?? "";
+  assert(ocr.length > 0, "fakturan saknar OCR — utan den finns ingen strukturerad referensväg");
+
+  const receivable = await c.expectedReceivable.create.mutate({
+    matterId: m.id, description: "Kostnadsräkning till tingsrätten", expectedAmount: BEGART_ORE,
+  });
+
+  console.log(`  Faktura ${full.invoiceNumber} · OCR ${ocr} · ${kr(invoice.amount)}`);
+  console.log(`  Fordran på domstolen ${kr(BEGART_ORE)}, målnr ${COURT_CASE}`);
+  return {
+    invoiceId: String(invoice.id), ocr, invoiceAmount: invoice.amount,
+    receivableId: String(receivable.id), matterNumber: m.matterNumber,
+  };
+}
+
+/** Bankfilen: en OCR-betalning från klienten, en fri-text-utbetalning från domstolen. */
+function bankFile(f: Fixture): string {
+  const txs: CamtTx[] = [
+    {
+      reference: "AVA-E2E-OCR-1", amountOre: f.invoiceAmount, debtorName: `Camt-klient`,
+      structuredRefs: [{ ref: f.ocr, amountOre: f.invoiceAmount }],
+    },
+    {
+      reference: "AVA-E2E-FRITEXT-1", amountOre: UTBETALT_ORE, debtorName: "DOMSTOLSVERKET",
+      freeTexts: [`${f.matterNumber} ${COURT_CASE} ENOKSSON`],
+    },
+  ];
+  return buildCamt054(txs, { bookingDate: BOOKING_DATE });
+}
+
+// ─── Kedjan ────────────────────────────────────────────────────────────────
+
+/** Steg 1: XML → transaktioner, med den skarpa parsern. */
+function parseBankFile(xml: string): ReturnType<typeof parseCamtXml> {
+  console.log("\n--- Steg 1: parsa bankfilen ---");
+  const file = parseCamtXml(xml);
+  assert(file.transactions.length === 2, `parsern hittade ${file.transactions.length} transaktioner, inte 2`);
+  const total = file.transactions.reduce((s, t) => s + t.amountOre, 0);
+  console.log(`  ✓ 2 transaktioner, ${kr(total)} totalt`);
+  return file;
+}
+
+interface Matched { invoicePayment: { amountOre: number; reference: string }; receivable: { amountOre: number; reference: string } }
+
+/**
+ * Steg 2: matcha. Kandidaterna hämtas från det RIKTIGA API:t och matas
+ * oförändrade in i matcharna — det är sömmen som annars aldrig prövas.
+ */
+async function matchAll(c: Ava, f: Fixture, file: ReturnType<typeof parseCamtXml>): Promise<Matched> {
+  console.log("\n--- Steg 2: matcha mot fakturor och fordringar ---");
+
+  const invoices = await c.invoice.list.query({ pageSize: 200 });
+  const invoiceCands: InvoiceCandidate[] = invoices.items.map((r) => ({
+    id: asId<"InvoiceId">(String(r.id)),
+    invoiceNumber: r.invoiceNumber ?? null,
+    ocrReference: r.ocrReference ?? null,
+    amount: r.amount,
+    paymentReferences: (r.payments ?? []).map((p) => p.reference).filter((x): x is string => Boolean(x)),
+  }));
+  const { bookable } = matchTransactions(file.transactions, invoiceCands);
+  const hit = bookable.find((b) => String(b.invoiceId) === f.invoiceId);
+  assert(hit !== undefined, "OCR-betalningen matchade inte fakturan");
+  assert(hit.matchedBy === "ocr", `matchades via ${hit.matchedBy}, inte ocr — OCR-vägen är den starkaste nyckeln`);
+  assert(hit.amountOre === f.invoiceAmount, `förslaget avser ${kr(hit.amountOre)} ≠ ${kr(f.invoiceAmount)}`);
+  console.log(`  ✓ OCR ${f.ocr} → faktura, ${kr(hit.amountOre)}`);
+
+  const raw = await c.expectedReceivable.candidates.query();
+  const recCands: ReceivableCandidate[] = raw.map((x) => ({
+    id: asId<"ExpectedReceivableId">(x.id), matterNumber: x.matterNumber,
+    courtCaseNumber: x.courtCaseNumber, expectedAmount: x.expectedAmount, settledReferences: [],
+  }));
+  const { suggestions } = matchReceivables(file.transactions, recCands);
+  const rec = suggestions.find((s) => String(s.receivableId) === f.receivableId);
+  assert(rec !== undefined, "fri-text-betalningen matchade inte domstolsfordran");
+  assert(rec.amountOre === UTBETALT_ORE, `förslaget avser ${kr(rec.amountOre)} ≠ ${kr(UTBETALT_ORE)}`);
+  console.log(`  ✓ Fri text "${f.matterNumber} ${COURT_CASE} …" → fordran, ${kr(rec.amountOre)}`);
+
+  return {
+    invoicePayment: { amountOre: hit.amountOre, reference: hit.reference },
+    receivable: { amountOre: rec.amountOre, reference: rec.reference },
+  };
+}
+
+/** Steg 3: bokför båda via det riktiga API:t och kontrollera utfallet. */
+async function book(c: Ava, f: Fixture, m: Matched): Promise<void> {
+  console.log("\n--- Steg 3: bokför betalningarna ---");
+
+  const res = await c.invoice.recordPayment.mutate({
+    invoiceId: f.invoiceId, amount: m.invoicePayment.amountOre,
+    paidAt: `${BOOKING_DATE}T12:00:00.000Z`, reference: m.invoicePayment.reference,
+    note: "Camt-import",
+  });
+  assert(res.settled, "fakturan slutreglerades inte trots full betalning");
+  const inv = await c.invoice.getById.query({ id: f.invoiceId });
+  assert(inv.status === "PAID", `faktura ${inv.status} ≠ PAID`);
+  console.log(`  ✓ Faktura betald ur bankfilen → ${inv.status}`);
+
+  const settled = await c.expectedReceivable.settle.mutate({
+    id: asId<"ExpectedReceivableId">(f.receivableId), settledAmount: m.receivable.amountOre,
+    settledAt: `${BOOKING_DATE}T12:00:00.000Z`, paymentReference: m.receivable.reference,
+  });
+  assert(settled.status === "SETTLED", `fordran ${settled.status} ≠ SETTLED`);
+  assert(settled.expectedAmount === BEGART_ORE, "det begärda beloppet skrevs över av utfallet");
+  console.log(`  ✓ Domstolsfordran avprickad: begärt ${kr(BEGART_ORE)}, utbetalt ${kr(UTBETALT_ORE)}`);
+}
+
+/**
+ * Steg 4: importera EXAKT samma fil igen. Banken skickar om filer och
+ * människor dubbelklickar. Bokförs betalningen två gånger ser det ut som en
+ * överbetalning, och byrån betalar tillbaka pengar som aldrig kommit in.
+ */
+async function verifyReimport(c: Ava, f: Fixture, xml: string): Promise<void> {
+  console.log("\n--- Steg 4: omimport av samma fil ---");
+  const file = parseCamtXml(xml);
+
+  const invoices = await c.invoice.list.query({ pageSize: 200 });
+  const cands: InvoiceCandidate[] = invoices.items.map((r) => ({
+    id: asId<"InvoiceId">(String(r.id)),
+    invoiceNumber: r.invoiceNumber ?? null,
+    ocrReference: r.ocrReference ?? null,
+    amount: r.amount,
+    paymentReferences: (r.payments ?? []).map((p) => p.reference).filter((x): x is string => Boolean(x)),
+  }));
+  const { bookable, unmatched } = matchTransactions(file.transactions, cands);
+  assert(!bookable.some((b) => String(b.invoiceId) === f.invoiceId),
+    "fakturan föreslogs för betalning IGEN — samma inbetalning skulle bokföras två gånger");
+  assert(unmatched.some((u) => u.reason === "dubblett"),
+    `omimporten flaggade inte transaktionen som dubblett (${unmatched.map((u) => u.reason).join(", ")})`);
+  console.log("  ✓ Fakturabetalningen känns igen som dubblett på betalningsreferensen");
+
+  const raw = await c.expectedReceivable.candidates.query();
+  assert(!raw.some((x) => x.id === f.receivableId),
+    "den avprickade fordran ligger kvar bland kandidaterna");
+  console.log("  ✓ Domstolsfordran är ur kandidatlistan — kan inte prickas av igen");
+}
+
+// ─── Körning ───────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const userId = await seedUser(USER, "Anna Camt");
+  const c = clientFor(USER);
+  await waitForServer(c);
+  const stamp = Date.now().toString(36);
+  console.log("Camt-betalnings-E2E: bankfil → parser → matchning → bokförd betalning");
+
+  const f = await seed(c, userId, stamp);
+  const xml = bankFile(f);
+  console.log(`\n  Genererad camt.054: ${xml.length} tecken, 2 kontohändelser`);
+
+  const file = parseBankFile(xml);
+  const matched = await matchAll(c, f, file);
+  await book(c, f, matched);
+  await verifyReimport(c, f, xml);
+
+  console.log("\n✓ Camt-betalnings-E2E klart: båda referensvägarna bokförda, omimport avvisad.");
+}
+
+main().catch((e: unknown) => {
+  console.error(`\n✗ Camt-betalnings-E2E misslyckades: ${e instanceof Error ? e.message : String(e)}`);
+  process.exitCode = 1;
+});

--- a/tooling/scripts/camt-payment-e2e.ts
+++ b/tooling/scripts/camt-payment-e2e.ts
@@ -32,7 +32,7 @@
  *   bun run e2e:camt-payment
  */
 
-import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { Window } from "happy-dom";
 import { parseCamtXml } from "@/lib/shared/payments/camt-parse";
 import { matchTransactions, type InvoiceCandidate } from "@/lib/shared/payments/match-payments";
 import { matchReceivables, type ReceivableCandidate } from "@/lib/shared/payments/match-receivables";
@@ -45,10 +45,15 @@ import {
 /**
  * camt-parsern använder browser-nativ `DOMParser`, och det är INTE en
  * eftergift för testet: importen sker i webbläsaren i AVA (importsidan parsar
- * klient-sida). Bun saknar DOMParser, så e2e:t registrerar samma happy-dom som
- * enhetstesterna använder — då körs parsern i den miljö den faktiskt lever i.
+ * klient-sida). Bun saknar DOMParser, så vi lånar happy-doms.
+ *
+ * ENBART `DOMParser` sätts — inte hela browsermiljön. `GlobalRegistrator`
+ * ersätter också `fetch`, och då slutar tRPC-klienten nå servern: första
+ * försöket föll på "server-first svarade inte inom 30s", inte på något
+ * camt-relaterat alls.
  */
-GlobalRegistrator.register();
+const { DOMParser } = new Window();
+Object.assign(globalThis, { DOMParser });
 
 const USER = "anna-camt@byra.se";
 const RATE_ORE = 250_000;


### PR DESCRIPTION
`camt-parse.ts` är väl testad mot **riktiga SEB-filer** och matcharna mot fixturer. Men ingen kontroll körde hela kedjan — av en praktisk orsak: de riktiga filerna har **fasta referenser** och kan aldrig matcha en faktura ett e2e just skapat. Så e2e:erna byggde camt-*transaktioner i minnet* och matade matcharen direkt.

Det hoppar över XML-steget, och det är där en bankfil spretar. Går parsern sönder eller driver formatet märker ingen det förrän en byrå importerar en fil som inte bokförs — tyst.

## Generatorn härmar banken, inte parsern

Modellerad **element för element** på SEB:s Test Bench-fil: samma nästling, samma namnrymd, samma `Ntry → NtryDtls → TxDtls`. En generator som bygger det *vår* parser råkar gilla bevisar ingenting.

Enhetstesterna kör alltid `buildCamt054` → `parseCamtXml`, aldrig en påhittad mellanform — så driften fångas åt båda hållen: ändrar någon parsern så den slutar förstå SEB:s struktur failar det innan en byrå gör det.

## Båda referensvägarna, båda med pengar i sig

| Väg | Referens | Bokförs som |
|---|---|---|
| Strukturerad (`RmtInf/Strd`) | OCR | `invoice.recordPayment` → `PAID` |
| Fri text (`RmtInf/Ustrd`) | `<ärendenr> <målnr> <advokat>` | `expectedReceivable.settle` → `SETTLED` |

Kandidaterna hämtas från det **riktiga API:t** och matas oförändrade in i matcharna — sömmen som annars aldrig prövas.

## Omimporten

Banken skickar om filer och människor dubbelklickar. Sista steget importerar exakt samma XML igen och kräver att **ingenting** bokförs en andra gång: fakturan ska flaggas som `dubblett` på betalningsreferensen, fordran ska vara ur kandidatlistan.

En dubbelbokförd inbetalning ser ut som en överbetalning — och byrån betalar tillbaka pengar som aldrig kommit in.

## Verifierat

9 nya enhetstester för generatorn (round-trip, delbelopp, escaping, öre→kronor utan avrundningsfel). 3686 gröna totalt.

Refs #1067

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9UB9at5Tpr1A6sYEXomxB