### PR TITLE
feat(deploy): driftsformad stack med TLS, persistent data och verifierad backup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,26 @@ jobs:
         if: always()
         run: docker compose -f tooling/docker/docker-compose.server-first.yml down -v
 
+  # ─── Återställningsövning ─────────────────────────────────────────────────
+  # En backup som aldrig återställts är en förhoppning. Övningen kör hela
+  # vägen mot PRODUKTIONS-compose:n: skapa ärende via API:t → backup →
+  # FÖRSTÖR datan → bekräfta att den är borta → återställ → bekräfta att den
+  # är tillbaka. Steget "bekräfta att den är borta" är det som gör övningen
+  # ärlig; utan det skulle en återställning som inte gör någonting alls se ut
+  # att lyckas.
+  #
+  # Kör i CI i st.f. som en manuell checklista — en rutin som bara utförs när
+  # någon kommer ihåg den hinner ruttna mellan gångerna den behövs.
+  restore-drill:
+    name: Återställningsövning (backup → förstör → återställ)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ./.github/actions/bun-setup
+      - name: Kör övningen
+        run: bash tooling/scripts/restore-drill.sh
+
   # ─── (Borttaget #422) E2E (git round-trip) ───
   # Self-hosted kör server-first sedan cutovern (ADR 0016 #420–#422) → iso-git-
   # round-trippen är pensionerad. Server-synken täcks nu av "Server-first

--- a/docs/deploy-server-first.md
+++ b/docs/deploy-server-first.md
@@ -144,9 +144,16 @@ samma maskin som databasen skyddar mot råttfel, inte mot att servern brinner:
 bash tooling/scripts/restore-db.sh /srv/ava/backup/ava-2026-09-05-0300.sql.gz
 ```
 
-Stoppar server-first före, lägger tillbaka dumpen, startar och väntar tills
-`/readyz` svarar ok. Skriver applikationen under tiden blir resultatet en
-blandning av två tidpunkter — värre än båda var för sig.
+Stoppar server-first, kopplar ner kvarvarande sessioner, **återskapar
+databasen**, läser in dumpen, startar och väntar tills `/readyz` svarar ok.
+Skriver applikationen under tiden blir resultatet en blandning av två
+tidpunkter — värre än båda var för sig.
+
+> Varför drop-and-create i stället för `pg_dump --clean`: pg-boss partitionerar
+> sina jobbtabeller, och de DROP-satser `--clean` genererar fallerar på ärvda
+> constraints (`cannot drop inherited constraint "job_common_pkey"`). Med
+> `--clean` gick backupen **inte att återställa alls** — upptäckt av övningen
+> nedan, vilket är hela poängen med att ha den.
 
 ### Övningen
 

--- a/docs/deploy-server-first.md
+++ b/docs/deploy-server-first.md
@@ -1,0 +1,176 @@
+# Deploy: self-hosted AVA (server-first)
+
+Hur en byrå går från demo till egen drift. Fyra containers, fyra volymer,
+automatiskt TLS.
+
+> **Ersätter [`deploy-tier3-self-hosted.md`](./deploy-tier3-self-hosted.md)**,
+> som beskriver den git-baserade arkitekturen. Den pensionerades av
+> [ADR 0016](./adr/0016-server-first-med-offline-first-klient.md) — Postgres är
+> den auktoritativa lagringen sedan cutovern. Följer du den gamla doc:en får du
+> fel system **och** en backup som säkerhetskopierar fel data.
+
+## Arkitektur
+
+```
+                    ┌──────────── Linux-server ─────────────┐
+  Browser ──443──►  │  caddy      TLS + statisk app + proxy  │
+                    │    │                                   │
+                    │    ├─ /oauth2/* ─► oauth2-proxy ──OIDC──┼──► byråns IdP
+                    │    ├─ /api/*    ─► server-first        │    (Entra/Google)
+                    │    └─ /         ─► out/ (statisk app)  │
+                    │                       │                │
+                    │                  postgres  ◄── akterna │
+                    │                                        │
+                    │  autoheal  ── startar om det som hänger│
+                    └────────────────────────────────────────┘
+```
+
+Ingen inbyggd IdP: `oauth2-proxy` gör OIDC-discovery mot byråns egen. Har
+byrån Microsoft 365 loggar advokaterna in med sina vanliga konton — se
+[`self-hosted-entra.md`](./self-hosted-entra.md).
+
+## Förutsättningar
+
+- Linux-server med docker + docker compose (2 GB RAM räcker gott)
+- Ett DNS-namn som pekar på servern (Caddy hämtar certet automatiskt — port
+  80 måste vara öppen för ACME-utmaningen)
+- En OIDC-app hos byråns IdP: client-id, client-secret, redirect-URI
+  `https://<domän>/oauth2/callback`
+
+### Var servern bör stå
+
+Byråns akter omfattas av advokatsekretess. Välj leverantör därefter — svensk
+eller åtminstone EU-baserad — och dokumentera valet; det är en fråga byrån
+kommer att få från sina klienter, inte en teknikdetalj.
+
+## Installation
+
+```bash
+git clone https://github.com/ulrik-s/ava && cd ava
+bun install
+bun run server-first:build      # server-binären
+bun run build:demo              # den statiska appen → out/
+```
+
+Skapa `ava-server.env`:
+
+```bash
+AVA_DOMAIN=ava.byra.se
+AVA_ORGANIZATION_ID=<uuid>            # bun -e 'console.log(crypto.randomUUID())'
+POSTGRES_PASSWORD=<slumpat>           # openssl rand -base64 32
+OIDC_ISSUER_URL=https://login.microsoftonline.com/<tenant>/v2.0
+OAUTH2_PROXY_CLIENT_ID=<app-id>
+OAUTH2_PROXY_CLIENT_SECRET=<hemlighet>
+OAUTH2_PROXY_COOKIE_SECRET=<32 byte>  # openssl rand -base64 32 | head -c 32
+OIDC_EMAIL_DOMAINS=byra.se            # vilka som får logga in
+```
+
+Starta:
+
+```bash
+set -a && . ava-server.env && set +a
+docker compose -f tooling/docker/docker-compose.production.yml up -d --build
+AVA_DATABASE_URL="postgres://ava:$POSTGRES_PASSWORD@localhost:5432/ava" bun run db:migrate
+```
+
+## Övervakning
+
+### Två hälsokontroller, och skillnaden spelar roll
+
+| Rutt | Frågar | Vid fel |
+|---|---|---|
+| `/healthz` | svarar processen? | processen hänger → **starta om** |
+| `/readyz` | kan den göra sitt jobb (databasen svarar)? | orsaken kan ligga utanför processen → **starta inte om blint** |
+
+Startar man om en app vars databas är nere får man en omstartsloop som döljer
+den verkliga orsaken. Därför skiljer stacken på dem.
+
+`/readyz` rör faktiskt databasen med en tidsbegränsad fråga. Den gamla
+`/healthz` i nginx svarade en statisk rad och rapporterade frisk även när
+tjänsten var död — en hälsokontroll som inte kan gå sönder är värdelös.
+
+### Omstart vid hängning
+
+`restart: unless-stopped` täcker bara **krascher**. En process som lever men
+slutat svara startas aldrig om av docker — den är ju igång.
+
+Därför kör stacken `autoheal`, som bevakar healthcheck-statusen och startar om
+det som står som `unhealthy`. Kedjan är: `/readyz` säger sanningen →
+healthchecken märker → autoheal agerar. Går första ledet sönder gör inget av
+de andra någon nytta.
+
+Kontrollera status:
+
+```bash
+docker compose -f tooling/docker/docker-compose.production.yml ps
+curl -s https://ava.byra.se/readyz     # {"status":"ok","checks":{"database":{"ok":true}}}
+```
+
+### Vad som INTE finns
+
+Ingen strukturerad loggning, ingen felrapportering (Sentry e.d.), ingen
+produktanalys. Loggarna är containerloggar:
+
+```bash
+docker compose -f tooling/docker/docker-compose.production.yml logs -f server-first
+```
+
+För en pilot räcker det. Innan fler byråer kör skarpt bör åtminstone
+felrapportering finnas — annars får du reda på fel genom att någon ringer.
+
+## Backup
+
+Akterna ligger i Postgres. **Utan verifierad återställning är systemet inte
+driftsatt-bart för en advokatbyrå.**
+
+```bash
+bash tooling/scripts/backup-db.sh /srv/ava/backup
+```
+
+Skriver `ava-<datum>.sql.gz` + checksumma, och vägrar skriva en dump som är
+trasig eller misstänkt liten — en tyst halv backup är värre än ingen, för den
+ser ut att finnas ända tills man behöver den.
+
+Lägg den i cron, och **kopiera den av servern**. En backup som ligger på
+samma maskin som databasen skyddar mot råttfel, inte mot att servern brinner:
+
+```cron
+0 3 * * * cd /srv/ava && bash tooling/scripts/backup-db.sh /srv/ava/backup
+```
+
+### Återställning
+
+```bash
+bash tooling/scripts/restore-db.sh /srv/ava/backup/ava-2026-09-05-0300.sql.gz
+```
+
+Stoppar server-first före, lägger tillbaka dumpen, startar och väntar tills
+`/readyz` svarar ok. Skriver applikationen under tiden blir resultatet en
+blandning av två tidpunkter — värre än båda var för sig.
+
+### Övningen
+
+En backup som aldrig återställts är en förhoppning. `restore-drill.sh` kör
+hela vägen — skapar ett ärende via API:t, tar backup, **förstör datan**,
+bekräftar att den är borta, återställer och bekräftar att den är tillbaka.
+
+Den körs i CI vid varje ändring av backup-skripten eller compose:n, så rutinen
+inte hinner ruttna. Kör den också mot din egen server första gången:
+
+```bash
+bash tooling/scripts/restore-drill.sh
+```
+
+Steget "bekräfta att den är borta" är det som gör övningen ärlig — utan det
+skulle en återställning som inte gör någonting alls se ut att lyckas.
+
+## Uppgradering
+
+```bash
+git pull && bun install
+bun run server-first:build && bun run build:demo
+docker compose -f tooling/docker/docker-compose.production.yml up -d --build
+AVA_DATABASE_URL=… bun run db:migrate
+```
+
+**Ta backup före migrering.** Migrationer går framåt, inte bakåt.

--- a/docs/deploy-tier3-self-hosted.md
+++ b/docs/deploy-tier3-self-hosted.md
@@ -1,5 +1,16 @@
 # Deploy: self-hosted Linux + docker
 
+> **⚠️ PENSIONERAD — följ inte den här.**
+>
+> Beskriver den git-baserade arkitekturen (git-http-backend + htpasswd), som
+> [ADR 0016](./adr/0016-server-first-med-offline-first-klient.md) ersatte med
+> server-first (Postgres). Följer du den här får du fel system **och** en
+> backup som säkerhetskopierar ett git-repo som inte längre är sanningskällan.
+>
+> Aktuell drift: [`deploy-server-first.md`](./deploy-server-first.md).
+>
+> Behålls som referens för den som fortfarande kör den gamla stacken.
+
 Hur en byrå går från demo-läget till egen server. Två containers, en
 volym, en bash-script. Inget custom server-kod-skikt att underhålla.
 

--- a/src/lib/server/db/client.ts
+++ b/src/lib/server/db/client.ts
@@ -23,6 +23,8 @@ export interface PostgresDb {
   db: AppDb;
   /** Stäng connection-poolen (vid nedstängning). */
   close: () => Promise<void>;
+  /** Minsta möjliga fråga som bevisar att anslutningen lever (#1079 /readyz). */
+  ping: () => Promise<unknown>;
 }
 
 export interface PostgresDbOptions {
@@ -37,5 +39,11 @@ export function createPostgresDb(url: string, opts: PostgresDbOptions = {}): Pos
     onnotice: () => {},
   });
   const db = drizzle(client, { schema });
-  return { db, close: () => client.end({ timeout: 5 }) };
+  return {
+    db,
+    close: () => client.end({ timeout: 5 }),
+    // `SELECT 1` rör faktiskt nätverket och poolen — till skillnad från att
+    // bara kontrollera att handlen finns, vilket alltid lyckas.
+    ping: () => client`SELECT 1`,
+  };
 }

--- a/src/lib/server/http/health.ts
+++ b/src/lib/server/http/health.ts
@@ -1,0 +1,100 @@
+/**
+ * Hälsokontroll för server-first (#1079).
+ *
+ * ## Varför nginx `/healthz` inte räcker
+ *
+ * `nginx-selfhosted.conf` svarar `200 "ok"` på en statisk rad. Den säger att
+ * NGINX lever — ingenting annat. Är server-first hängd eller Postgres
+ * onåbar rapporterar den fortfarande frisk, och en övervakning som litar på
+ * den startar aldrig om något.
+ *
+ * En hälsokontroll som inte kan gå sönder är värdelös. Den här rör därför den
+ * verkliga vägen: den frågar databasen.
+ *
+ * ## Liveness vs readiness
+ *
+ *   /healthz   LIVENESS  — processen svarar. Snabb, rör inget nätverk.
+ *              Faller den är processen hängd → starta om.
+ *   /readyz    READINESS — processen KAN göra sitt jobb (db svarar).
+ *              Faller den kan orsaken ligga utanför processen (db nere,
+ *              nätverk) → starta INTE om blint; det gör bara saken värre.
+ *
+ * Skillnaden är inte akademisk: startar man om en app vars databas är nere
+ * får man en omstartsloop som döljer den verkliga orsaken.
+ *
+ * ## Tidsgränsen
+ *
+ * Db-frågan är tidsbegränsad. Utan tak ärver hälsokontrollen just det problem
+ * den ska upptäcka: hänger db-anropet hänger hälsokontrollen, övervakningen
+ * får inget svar alls och tolkar det som nätverksfel i stället för som en
+ * ohälsosam tjänst.
+ */
+
+/** Vad kontrollen kom fram till. `detail` är till för människan som felsöker. */
+export interface HealthResult {
+  status: "ok" | "degraded";
+  checks: Record<string, { ok: boolean; detail?: string }>;
+}
+
+/** Db-ping: minsta möjliga fråga som bevisar att anslutningen lever. */
+export type DbPing = () => Promise<unknown>;
+
+/** Default-tak för db-pingen. Kort — en hälsokontroll ska svara, inte vänta. */
+export const HEALTH_TIMEOUT_MS = 2_000;
+
+/** Kör `p` med tak; kastar `Error("timeout")` när taket nås. */
+async function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      p,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`timeout efter ${ms} ms`)), ms);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+/**
+ * Readiness: kan tjänsten göra sitt jobb? Kastar aldrig — ett fel ÄR svaret,
+ * och en hälsokontroll som kastar ger 500 utan att säga varför.
+ */
+export async function checkReadiness(ping: DbPing, timeoutMs = HEALTH_TIMEOUT_MS): Promise<HealthResult> {
+  try {
+    await withTimeout(Promise.resolve(ping()), timeoutMs);
+    return { status: "ok", checks: { database: { ok: true } } };
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : String(e);
+    return { status: "degraded", checks: { database: { ok: false, detail } } };
+  }
+}
+
+/** JSON-svar med rätt statuskod. 503 på degraded — det är vad en lastbalanserare läser. */
+function json(body: HealthResult): Response {
+  return new Response(JSON.stringify(body), {
+    status: body.status === "ok" ? 200 : 503,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+}
+
+/**
+ * Hälso-rutter framför den vanliga handlern. Returnerar null när sökvägen
+ * inte är en hälso-rutt, så anroparen kan gå vidare till tRPC.
+ *
+ * Båda är ÖPPNA (ingen auth). En hälsokontroll bakom inloggning kan inte
+ * användas av det som ska övervaka den, och svaret läcker inget: den säger
+ * bara om databasen svarar.
+ */
+export async function handleHealthRoute(
+  pathname: string, ping: DbPing, timeoutMs = HEALTH_TIMEOUT_MS,
+): Promise<Response | null> {
+  if (pathname === "/healthz") {
+    // Liveness rör medvetet INGET nätverk: frågan är bara om event-loopen
+    // fortfarande betjänar requests.
+    return new Response("ok\n", { status: 200, headers: { "content-type": "text/plain", "cache-control": "no-store" } });
+  }
+  if (pathname === "/readyz") return json(await checkReadiness(ping, timeoutMs));
+  return null;
+}

--- a/src/lib/server/http/server-first-api.ts
+++ b/src/lib/server/http/server-first-api.ts
@@ -18,6 +18,7 @@ import { createDbChangeLogRecorder, enableChangeLogOnAll } from "@/lib/server/re
 import { buildDrizzleRepositories } from "@/lib/server/repositories/drizzle-repositories";
 import { DrizzleSyncStore } from "@/lib/server/sync/drizzle-sync-store";
 import { bearerConfigFromEnv, type BearerVerifyConfig } from "./bearer-claims";
+import { handleHealthRoute } from "./health";
 import { createServerTrpcHandler } from "./server-trpc-handler";
 
 export interface ServerFirstApiConfig {
@@ -51,7 +52,7 @@ export interface ServerFirstApi {
 
 /** Bygg server-first-API:t (handler + db-livscykel) ur en config. */
 export function buildServerFirstApi(config: ServerFirstApiConfig): ServerFirstApi {
-  const { db, close } = createPostgresDb(
+  const { db, close, ping } = createPostgresDb(
     config.databaseUrl,
     config.maxConnections !== undefined ? { max: config.maxConnections } : {},
   );
@@ -61,7 +62,7 @@ export function buildServerFirstApi(config: ServerFirstApiConfig): ServerFirstAp
   enableChangeLogOnAll(repos, createDbChangeLogRecorder(db));
   // Bearer-JWT-väg: explicit config, annars ur miljön (AVA_OIDC_*). Av som default.
   const bearer = config.bearer === undefined ? bearerConfigFromEnv() : config.bearer;
-  const handler = createServerTrpcHandler({
+  const trpc = createServerTrpcHandler({
     repos,
     ports: config.ports ?? noopPorts,
     organizationId: config.organizationId,
@@ -70,6 +71,12 @@ export function buildServerFirstApi(config: ServerFirstApiConfig): ServerFirstAp
     ...(config.onError ? { onError: config.onError } : {}),
     ...(bearer ? { bearer } : {}),
   });
+  // Hälso-rutterna ligger FÖRE tRPC: de ska svara även när allt annat är
+  // trasigt, och de får inte kräva en giltig principal (#1079).
+  const handler = async (req: Request): Promise<Response> => {
+    const health = await handleHealthRoute(new URL(req.url).pathname, ping);
+    return health ?? trpc(req);
+  };
   return { handler, repos, close };
 }
 

--- a/test/unit/server/http/health.test.ts
+++ b/test/unit/server/http/health.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest-compat";
+import { checkReadiness, handleHealthRoute, HEALTH_TIMEOUT_MS } from "@/lib/server/http/health";
+
+/**
+ * Hälsokontrollen (#1079) är det övervakningen agerar på. Går den sönder
+ * tyst — svarar frisk när tjänsten är död — startas ingenting om, och felet
+ * upptäcks först när en användare hör av sig.
+ *
+ * Därför testas i första hand FELVÄGARNA: att den faktiskt fäller.
+ */
+const ok = (): Promise<number> => Promise.resolve(1);
+const broken = (): Promise<never> => Promise.reject(new Error("ECONNREFUSED"));
+const hangs = (): Promise<never> => new Promise(() => { /* svarar aldrig */ });
+
+describe("checkReadiness", () => {
+  it("är ok när databasen svarar", async () => {
+    const r = await checkReadiness(ok);
+    expect(r.status).toBe("ok");
+    expect(r.checks.database?.ok).toBe(true);
+  });
+
+  it("är degraded när databasen vägrar anslutning", async () => {
+    const r = await checkReadiness(broken);
+    expect(r.status).toBe("degraded");
+    expect(r.checks.database?.ok).toBe(false);
+  });
+
+  // Orsaken måste följa med, annars står felsökaren med "degraded" och inget mer.
+  it("bär med sig orsaken", async () => {
+    const r = await checkReadiness(broken);
+    expect(r.checks.database?.detail).toContain("ECONNREFUSED");
+  });
+
+  // Det här är hela poängen: en hängd db får INTE hänga hälsokontrollen, för
+  // då svarar den inte alls och övervakningen tolkar tystnaden som nätverksfel.
+  it("faller på tidsgränsen i st.f. att hänga med databasen", async () => {
+    const r = await checkReadiness(hangs, 20);
+    expect(r.status).toBe("degraded");
+    expect(r.checks.database?.detail).toContain("timeout");
+  });
+
+  it("kastar aldrig — ett fel ÄR svaret", async () => {
+    await expect(checkReadiness(() => { throw new Error("synkront smäll"); })).resolves.toBeDefined();
+  });
+
+  it("har ett kort default-tak — en hälsokontroll ska svara, inte vänta", () => {
+    expect(HEALTH_TIMEOUT_MS).toBeLessThanOrEqual(5_000);
+  });
+});
+
+describe("handleHealthRoute", () => {
+  it("svarar 200 på /healthz utan att röra databasen", async () => {
+    // `broken` skulle fälla readiness — liveness ska inte bry sig.
+    const res = await handleHealthRoute("/healthz", broken);
+    expect(res?.status).toBe(200);
+  });
+
+  it("svarar 200 på /readyz när databasen lever", async () => {
+    const res = await handleHealthRoute("/readyz", ok);
+    expect(res?.status).toBe(200);
+    expect(await res?.json()).toMatchObject({ status: "ok" });
+  });
+
+  // 503 är det en lastbalanserare och autoheal faktiskt läser — 200 med
+  // "degraded" i kroppen hade sett friskt ut för allt utom en människa.
+  it("svarar 503 på /readyz när databasen är nere", async () => {
+    const res = await handleHealthRoute("/readyz", broken);
+    expect(res?.status).toBe(503);
+  });
+
+  it("släpper igenom andra sökvägar till tRPC", async () => {
+    expect(await handleHealthRoute("/api/trpc/matter.list", ok)).toBeNull();
+  });
+
+  it("cachas aldrig — ett gammalt friskt svar är farligare än inget", async () => {
+    const res = await handleHealthRoute("/readyz", ok);
+    expect(res?.headers.get("cache-control")).toBe("no-store");
+  });
+});

--- a/tooling/docker/caddy/Caddyfile
+++ b/tooling/docker/caddy/Caddyfile
@@ -1,0 +1,60 @@
+# Caddy-front för produktions-stacken (#1079).
+#
+# Speglar `nginx-selfhosted.conf` men med två skillnader som spelar roll i
+# drift: automatiskt Let's Encrypt-cert (ingen certbot-cron att glömma) och
+# en `forward_auth` i stället för nginx `auth_request`.
+#
+# ## Förtroendegränsen — läs innan du ändrar något här
+#
+# `X-Auth-Request-Email` sätts av oauth2-proxy efter verifierad OIDC-session
+# och är det server-first litar på som principal (ADR 0009). Kommer den från
+# klienten är den ett påstående, inte ett bevis.
+#
+# Caddys `forward_auth` med `copy_headers` skriver ÖVER klientens värde med
+# det från auth-svaret — det är den raden som gör spoofing omöjlig. Tar man
+# bort den kan vem som helst skicka en header och bli vem som helst.
+
+{$AVA_DOMAIN} {
+	encode gzip
+
+	# ─── OIDC-dansen ───────────────────────────────────────────────────
+	handle /oauth2/* {
+		reverse_proxy oauth2-proxy:4180 {
+			header_up X-Real-IP {remote_host}
+			header_up X-Forwarded-Uri {uri}
+		}
+	}
+
+	# ─── tRPC-API: kräver inloggad session ─────────────────────────────
+	handle /api/* {
+		forward_auth oauth2-proxy:4180 {
+			uri /oauth2/auth
+			# Skriver över ev. klient-skickad header med den VERIFIERADE
+			# emailen ur auth-svaret. Utan detta är principalen spoofbar.
+			copy_headers X-Auth-Request-Email
+		}
+		reverse_proxy server-first:3001
+	}
+
+	# ─── Hälsokontroller: ÖPPNA, aldrig cachade ────────────────────────
+	# Bakom inloggning kan de inte användas av det som ska övervaka dem.
+	# `/readyz` proxas till server-first eftersom det är DEN som vet om
+	# databasen svarar — en statisk rad här hade ljugit (#1079).
+	handle /healthz {
+		respond "ok" 200
+	}
+	handle /readyz {
+		reverse_proxy server-first:3001
+	}
+
+	# ─── Den statiska appen: kräver inloggning ─────────────────────────
+	handle {
+		forward_auth oauth2-proxy:4180 {
+			uri /oauth2/auth
+			copy_headers X-Auth-Request-Email
+		}
+		root * /srv/ava
+		try_files {path} {path}/ /index.html
+		file_server
+	}
+}

--- a/tooling/docker/docker-compose.drill.yml
+++ b/tooling/docker/docker-compose.drill.yml
@@ -1,0 +1,21 @@
+# Overlay för återställningsövningen (#1079).
+#
+# Produktions-compose:n exponerar MEDVETET varken Postgres eller server-first
+# på värden — allt går genom Caddy, och databasen ska inte gå att nå utifrån.
+#
+# Övningen behöver båda: `db:migrate` och markör-ärendet körs från värden.
+# Den lösningen är en overlay, inte en uppmjukning av produktionsfilen — annars
+# skulle en glömd port i produktionsfilen bli en öppen databas hos en byrå.
+#
+#   docker compose -f docker-compose.production.yml -f docker-compose.drill.yml up -d
+
+name: ava
+
+services:
+  postgres:
+    ports:
+      - "5433:5432"
+
+  server-first:
+    ports:
+      - "3001:3001"

--- a/tooling/docker/docker-compose.production.yml
+++ b/tooling/docker/docker-compose.production.yml
@@ -1,0 +1,135 @@
+# PRODUKTIONS-STACK för self-hosted AVA (#1079) — server-first + OIDC + TLS.
+#
+# Skillnaden mot `docker-compose.selfhosted-local.yml`, som är en TESTRIGG:
+#
+#   testriggen                        den här
+#   ─────────────────────────────     ────────────────────────────────────
+#   Postgres på tmpfs (data borta      namngiven volym som överlever
+#     vid omstart)                       omstart och uppgradering
+#   Keycloak start-dev, admin/admin    byråns EGEN IdP via OIDC-discovery
+#   http på :8080                      TLS via Caddy (automatiskt cert)
+#   ingen omstartspolicy               restart: unless-stopped + autoheal
+#   attrapp-healthcheck i nginx        /readyz som faktiskt rör databasen
+#
+#   docker compose -f tooling/docker/docker-compose.production.yml up -d
+#
+# Kräver en ifylld `ava-server.env` (se docs/deploy-server-first.md).
+
+name: ava
+
+services:
+  # ─── TLS-terminering + statisk app ────────────────────────────────────
+  # Caddy i st.f. nginx HÄR (bara här): den skaffar och förnyar Let's
+  # Encrypt-cert själv. En byrå ska inte behöva sköta certbot-cron för att
+  # köra sitt ärendesystem, och ett utgånget cert är ett driftstopp.
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      AVA_DOMAIN: "${AVA_DOMAIN:?AVA_DOMAIN krävs (t.ex. ava.byra.se)}"
+    volumes:
+      - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - ../../out:/srv/ava:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      oauth2-proxy:
+        condition: service_started
+      server-first:
+        condition: service_healthy
+
+  # ─── OIDC relying party mot byråns egen IdP ───────────────────────────
+  # Ingen inbyggd IdP. Entra, Google eller vad byrån redan har — samma
+  # mönster som docker-compose.oidc-byoidp.yml, se docs/self-hosted-entra.md.
+  oauth2-proxy:
+    image: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
+    restart: unless-stopped
+    environment:
+      OAUTH2_PROXY_HTTP_ADDRESS: "0.0.0.0:4180"
+      OAUTH2_PROXY_PROVIDER: "${OIDC_PROVIDER:-oidc}"
+      OAUTH2_PROXY_OIDC_ISSUER_URL: "${OIDC_ISSUER_URL:?OIDC_ISSUER_URL krävs}"
+      OAUTH2_PROXY_CLIENT_ID: "${OAUTH2_PROXY_CLIENT_ID:?OAUTH2_PROXY_CLIENT_ID krävs}"
+      OAUTH2_PROXY_CLIENT_SECRET: "${OAUTH2_PROXY_CLIENT_SECRET:?OAUTH2_PROXY_CLIENT_SECRET krävs}"
+      OAUTH2_PROXY_COOKIE_SECRET: "${OAUTH2_PROXY_COOKIE_SECRET:?OAUTH2_PROXY_COOKIE_SECRET krävs}"
+      OAUTH2_PROXY_EMAIL_DOMAINS: "${OIDC_EMAIL_DOMAINS:-*}"
+      OAUTH2_PROXY_REDIRECT_URL: "https://${AVA_DOMAIN}/oauth2/callback"
+      OAUTH2_PROXY_UPSTREAMS: "static://202"
+      OAUTH2_PROXY_REVERSE_PROXY: "true"
+      # Cookien får bara gå över TLS här — testriggen kör http och kan inte.
+      OAUTH2_PROXY_COOKIE_SECURE: "true"
+      OAUTH2_PROXY_SET_XAUTHREQUEST: "true"
+
+  # ─── Postgres: byråns akter ───────────────────────────────────────────
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: "${POSTGRES_USER:-ava}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD krävs}"
+      POSTGRES_DB: "${POSTGRES_DB:-ava}"
+    # NAMNGIVEN VOLYM, inte tmpfs. Testriggen kastar data vid omstart med
+    # flit; här ÄR den byråns akter.
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    # Ingen host-port: databasen nås bara inifrån nätet. Backup går via
+    # `docker compose exec`, se tooling/scripts/backup-db.sh.
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-ava} -d ${POSTGRES_DB:-ava}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  # ─── AVA:s server-first-runtime ───────────────────────────────────────
+  server-first:
+    build:
+      context: ../..
+      dockerfile: tooling/docker/server-first/Dockerfile
+    restart: unless-stopped
+    environment:
+      AVA_DATABASE_URL: "postgres://${POSTGRES_USER:-ava}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-ava}"
+      AVA_ORGANIZATION_ID: "${AVA_ORGANIZATION_ID:?AVA_ORGANIZATION_ID krävs}"
+      AVA_HTTP_HOST: 0.0.0.0
+      AVA_HTTP_PORT: "3001"
+      AVA_CONTENT_DIR: /data/content
+    volumes:
+      - content:/data/content
+    # /readyz rör DATABASEN (#1079). En attrapp som bara säger att processen
+    # startat hade rapporterat frisk medan poolen var död — och då hade
+    # autoheal nedan aldrig gjort något.
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:3001/readyz | grep -q '\"status\":\"ok\"'"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 40s
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  # ─── Omstart vid HÄNGNING ─────────────────────────────────────────────
+  # `restart: unless-stopped` täcker bara krascher. En process som lever men
+  # slutat svara startas ALDRIG om av docker — den är ju igång. Autoheal
+  # bevakar healthcheck-statusen och startar om det som står som unhealthy.
+  #
+  # Därför måste healthchecken ovan vara ärlig: autoheal kan bara agera på
+  # det den får veta.
+  autoheal:
+    image: willfarrell/autoheal:latest
+    restart: unless-stopped
+    environment:
+      AUTOHEAL_CONTAINER_LABEL: all
+      # Vänta ut start_period innan något döms ohälsosamt.
+      AUTOHEAL_START_PERIOD: "60"
+      AUTOHEAL_INTERVAL: "15"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+volumes:
+  pgdata:
+  content:
+  caddy_data:
+  caddy_config:

--- a/tooling/docker/server-first/Dockerfile
+++ b/tooling/docker/server-first/Dockerfile
@@ -19,8 +19,13 @@ FROM debian:stable-slim
 # i ett git-repo (AVA_CONTENT_DIR) där varje skrivning committas. Utan binären
 # kastar uploadContent "Executable not found in $PATH: git" → server-side-
 # dokumentlagringen (+ klassificeringen som läser bytes:en) fungerar inte.
+#
+# wget krävs av HEALTHCHECK:en (#1079). debian-slim har varken wget eller curl,
+# och en docker-healthcheck körs INUTI containern — utan en http-klient kan
+# containern inte kontrollera sig själv, healthchecken fallerar alltid, och
+# autoheal skulle starta om en fullt frisk tjänst i en evig loop.
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates git \
+  && apt-get install -y --no-install-recommends ca-certificates git wget \
   && rm -rf /var/lib/apt/lists/*
 
 COPY dist/server-first/ava-server-first-linux-x64   /opt/ava/bin/ava-server-first-linux-x64

--- a/tooling/scripts/backup-db.sh
+++ b/tooling/scripts/backup-db.sh
@@ -38,10 +38,14 @@ FILE="$OUT_DIR/ava-$STAMP.sql.gz"
 mkdir -p "$OUT_DIR"
 
 echo "▸ Dumpar $PG_DB …"
-# --clean --if-exists gör dumpen självständig: den kan läggas tillbaka i en
-# databas som redan har innehåll, utan att man först måste tömma den för hand.
+# INGEN --clean. Den genererar DROP-satser som fallerar på ÄRVDA constraints:
+# pg-boss partitionerar sina jobbtabeller, och `DROP CONSTRAINT job_common_pkey`
+# ger "cannot drop inherited constraint". Upptäckt av återställningsövningen —
+# med --clean var backupen oåterställbar, vilket inget annat hade avslöjat.
+#
+# I stället återskapar restore-db.sh databasen från grunden före återläsningen.
 docker compose -f "$COMPOSE" exec -T postgres \
-  pg_dump -U "$PG_USER" -d "$PG_DB" --clean --if-exists \
+  pg_dump -U "$PG_USER" -d "$PG_DB" \
   | gzip -9 > "$FILE"
 
 # Verifiera att dumpen inte är trunkerad. En tyst halv backup är värre än

--- a/tooling/scripts/backup-db.sh
+++ b/tooling/scripts/backup-db.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Backup av AVA:s Postgres (#1079).
+#
+# Byråns akter ligger i Postgres. Utan ett verifierat återställningsflöde är
+# systemet inte driftsatt-bart för en advokatbyrå — akter måste kunna
+# återskapas.
+#
+#   bash tooling/scripts/backup-db.sh /srv/ava/backup
+#
+# Skriver <out>/ava-<datum>.sql.gz och en checksumma bredvid.
+#
+# ## Varför pg_dump och inte en volym-tar
+#
+# En tar av `/var/lib/postgresql/data` på en KÖRANDE databas ger en
+# inkonsistent kopia som ofta går att packa upp men inte att starta. pg_dump
+# tar en transaktionskonsistent ögonblicksbild medan tjänsten är igång.
+#
+# ## Det här scriptet är halva jobbet
+#
+# Den andra halvan är `restore-db.sh`, och en backup som aldrig återställts är
+# en förhoppning. Kör återställningsövningen minst en gång — se
+# docs/deploy-server-first.md.
+set -euo pipefail
+
+OUT_DIR="${1:-}"
+if [ -z "$OUT_DIR" ]; then
+  echo "Användning: $0 <katalog-för-backuper>" >&2
+  exit 2
+fi
+
+COMPOSE="${AVA_COMPOSE:-tooling/docker/docker-compose.production.yml}"
+PG_USER="${POSTGRES_USER:-ava}"
+PG_DB="${POSTGRES_DB:-ava}"
+STAMP="$(date +%F-%H%M)"
+FILE="$OUT_DIR/ava-$STAMP.sql.gz"
+
+mkdir -p "$OUT_DIR"
+
+echo "▸ Dumpar $PG_DB …"
+# --clean --if-exists gör dumpen självständig: den kan läggas tillbaka i en
+# databas som redan har innehåll, utan att man först måste tömma den för hand.
+docker compose -f "$COMPOSE" exec -T postgres \
+  pg_dump -U "$PG_USER" -d "$PG_DB" --clean --if-exists \
+  | gzip -9 > "$FILE"
+
+# Verifiera att dumpen inte är trunkerad. En tyst halv backup är värre än
+# ingen: den ser ut att finnas ända tills man behöver den.
+if ! gzip -t "$FILE" 2>/dev/null; then
+  echo "✗ Dumpen är trasig (gzip -t) — tas bort så den inte förväxlas med en giltig backup." >&2
+  rm -f "$FILE"
+  exit 1
+fi
+
+SIZE=$(wc -c < "$FILE" | tr -d ' ')
+if [ "$SIZE" -lt 1000 ]; then
+  echo "✗ Dumpen är bara $SIZE byte — nästan säkert tom. Tas bort." >&2
+  rm -f "$FILE"
+  exit 1
+fi
+
+sha256sum "$FILE" > "$FILE.sha256" 2>/dev/null || shasum -a 256 "$FILE" > "$FILE.sha256"
+
+echo "✓ $FILE ($((SIZE / 1024)) kB)"
+echo "  Checksumma: $(cut -d' ' -f1 < "$FILE.sha256")"
+echo
+echo "  Kom ihåg: en backup som aldrig återställts är en förhoppning."
+echo "  Kör återställningsövningen — bash tooling/scripts/restore-db.sh $FILE"

--- a/tooling/scripts/restore-db.sh
+++ b/tooling/scripts/restore-db.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Återställning av AVA:s Postgres (#1079).
+#
+#   bash tooling/scripts/restore-db.sh /srv/ava/backup/ava-2026-09-05-1400.sql.gz
+#
+# ## Detta ÖVERSKRIVER databasen
+#
+# Dumpen tas med `--clean --if-exists`, alltså släpper den befintliga objekt
+# innan den lägger tillbaka sina egna. Kör den mot fel databas och byråns
+# akter är borta. Därför kräver scriptet en uttrycklig bekräftelse — sätt
+# `AVA_RESTORE_YES=1` för att köra obevakat (t.ex. i en övning).
+#
+# ## Ordningen spelar roll
+#
+# server-first stoppas FÖRE återställningen och startas efter. Skriver
+# applikationen medan dumpen läggs tillbaka blir resultatet en blandning av
+# två tidpunkter — värre än både den gamla och den nya datan var för sig.
+set -euo pipefail
+
+DUMP="${1:-}"
+if [ -z "$DUMP" ] || [ ! -f "$DUMP" ]; then
+  echo "Användning: $0 <dump.sql.gz>" >&2
+  exit 2
+fi
+
+COMPOSE="${AVA_COMPOSE:-tooling/docker/docker-compose.production.yml}"
+PG_USER="${POSTGRES_USER:-ava}"
+PG_DB="${POSTGRES_DB:-ava}"
+
+# Kontrollera checksumman när den finns — en trasig dump ska upptäckas nu,
+# inte halvvägs in i återställningen med en tömd databas.
+if [ -f "$DUMP.sha256" ]; then
+  echo "▸ Verifierar checksumma …"
+  if command -v sha256sum >/dev/null; then sha256sum -c "$DUMP.sha256"; else shasum -a 256 -c "$DUMP.sha256"; fi
+fi
+gzip -t "$DUMP" || { echo "✗ Dumpen är trasig." >&2; exit 1; }
+
+if [ "${AVA_RESTORE_YES:-}" != "1" ]; then
+  echo
+  echo "Detta ÖVERSKRIVER databasen '$PG_DB'. Allt nuvarande innehåll försvinner."
+  read -r -p "Skriv ÅTERSTÄLL för att fortsätta: " answer
+  [ "$answer" = "ÅTERSTÄLL" ] || { echo "Avbrutet."; exit 1; }
+fi
+
+echo "▸ Stoppar server-first (ingen ska skriva under återställningen) …"
+docker compose -f "$COMPOSE" stop server-first >/dev/null
+
+echo "▸ Lägger tillbaka dumpen …"
+gunzip -c "$DUMP" | docker compose -f "$COMPOSE" exec -T postgres \
+  psql -U "$PG_USER" -d "$PG_DB" -v ON_ERROR_STOP=1 --quiet
+
+echo "▸ Startar server-first …"
+docker compose -f "$COMPOSE" start server-first >/dev/null
+
+echo "▸ Väntar på att tjänsten ska bli frisk …"
+for _ in $(seq 1 30); do
+  if docker compose -f "$COMPOSE" exec -T server-first \
+      wget -q -O- http://127.0.0.1:3001/readyz 2>/dev/null | grep -q '"status":"ok"'; then
+    echo "✓ Återställd och frisk — /readyz svarar ok."
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "✗ Tjänsten blev inte frisk inom 60 s. Kolla: docker compose -f $COMPOSE logs server-first" >&2
+exit 1

--- a/tooling/scripts/restore-db.sh
+++ b/tooling/scripts/restore-db.sh
@@ -4,12 +4,17 @@
 #
 #   bash tooling/scripts/restore-db.sh /srv/ava/backup/ava-2026-09-05-1400.sql.gz
 #
-# ## Detta ÖVERSKRIVER databasen
+# ## Detta RADERAR OCH ÅTERSKAPAR databasen
 #
-# Dumpen tas med `--clean --if-exists`, alltså släpper den befintliga objekt
-# innan den lägger tillbaka sina egna. Kör den mot fel databas och byråns
-# akter är borta. Därför kräver scriptet en uttrycklig bekräftelse — sätt
-# `AVA_RESTORE_YES=1` för att köra obevakat (t.ex. i en övning).
+# Databasen droppas och skapas om innan dumpen läses in. Kör den mot fel
+# databas och byråns akter är borta. Därför kräver scriptet en uttrycklig
+# bekräftelse — sätt `AVA_RESTORE_YES=1` för att köra obevakat (t.ex. i en
+# övning).
+#
+# Varför drop-and-create och inte `pg_dump --clean`: pg-boss partitionerar
+# sina jobbtabeller, och de DROP-satser `--clean` genererar fallerar på ärvda
+# constraints ("cannot drop inherited constraint job_common_pkey"). En tom
+# databas har inget att droppa och problemet uppstår aldrig.
 #
 # ## Ordningen spelar roll
 #
@@ -38,13 +43,24 @@ gzip -t "$DUMP" || { echo "✗ Dumpen är trasig." >&2; exit 1; }
 
 if [ "${AVA_RESTORE_YES:-}" != "1" ]; then
   echo
-  echo "Detta ÖVERSKRIVER databasen '$PG_DB'. Allt nuvarande innehåll försvinner."
+  echo "Detta RADERAR OCH ÅTERSKAPAR databasen '$PG_DB'. Allt nuvarande innehåll försvinner."
   read -r -p "Skriv ÅTERSTÄLL för att fortsätta: " answer
   [ "$answer" = "ÅTERSTÄLL" ] || { echo "Avbrutet."; exit 1; }
 fi
 
 echo "▸ Stoppar server-first (ingen ska skriva under återställningen) …"
 docker compose -f "$COMPOSE" stop server-first >/dev/null
+
+# Kvarvarande sessioner blockerar DROP DATABASE. server-first är stoppad, men
+# poolen kan ha connections som ännu inte hunnit stängas.
+echo "▸ Kopplar ner kvarvarande sessioner …"
+docker compose -f "$COMPOSE" exec -T postgres psql -U "$PG_USER" -d postgres --quiet -c \
+  "SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+   WHERE datname = '$PG_DB' AND pid <> pg_backend_pid()" >/dev/null
+
+echo "▸ Återskapar databasen …"
+docker compose -f "$COMPOSE" exec -T postgres psql -U "$PG_USER" -d postgres --quiet \
+  -v ON_ERROR_STOP=1 -c "DROP DATABASE IF EXISTS \"$PG_DB\"" -c "CREATE DATABASE \"$PG_DB\"" >/dev/null
 
 echo "▸ Lägger tillbaka dumpen …"
 gunzip -c "$DUMP" | docker compose -f "$COMPOSE" exec -T postgres \

--- a/tooling/scripts/restore-drill-seed.ts
+++ b/tooling/scripts/restore-drill-seed.ts
@@ -1,0 +1,41 @@
+#!/usr/bin/env bun
+/**
+ * Markör-ärende för återställningsövningen (#1079).
+ *
+ * Skapar ETT ärende via det riktiga API:t och skriver dess ärendenummer på
+ * stdout, så `restore-drill.sh` kan leta efter exakt den raden före och efter
+ * återställningen.
+ *
+ * Varför via API:t och inte ett `INSERT`: en rad som skrivits förbi
+ * applikationen bevisar bara att `pg_dump` kopierar tabeller. Går ärendet
+ * genom `matter.create` täcker övningen också att det som faktiskt skrivs vid
+ * normal drift kommer tillbaka — inklusive kolumner en framtida migration
+ * lägger till.
+ */
+
+import { clientFor, seedUser, waitForServer } from "./e2e-harness";
+
+const USER = "drill@byra.se";
+
+async function main(): Promise<void> {
+  const userId = await seedUser(USER, "Återställningsövning");
+  const c = clientFor(USER);
+  await waitForServer(c);
+
+  const marker = `DRILL-${Date.now().toString(36)}`;
+  await c.matter.create.mutate({
+    matterNumber: marker,
+    title: "Återställningsövning — markör",
+    matterType: "Allmän praktik",
+    paymentMethod: "PRIVAT",
+    responsibleLawyerId: userId,
+  });
+
+  // Bara markören på stdout — scriptet läser den rakt av.
+  console.log(marker);
+}
+
+main().catch((e: unknown) => {
+  console.error(`markör-ärendet kunde inte skapas: ${e instanceof Error ? e.message : String(e)}`);
+  process.exitCode = 1;
+});

--- a/tooling/scripts/restore-drill.sh
+++ b/tooling/scripts/restore-drill.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# ÅTERSTÄLLNINGSÖVNING (#1079) — bevisar att backupen går att lita på.
+#
+#   bash tooling/scripts/restore-drill.sh
+#
+# En backup som aldrig återställts är en förhoppning, inte en backup. Den här
+# övningen kör hela vägen mot produktions-compose:n:
+#
+#   1. starta stacken (postgres + server-first, persistent volym)
+#   2. skapa ett ärende via det RIKTIGA API:t
+#   3. ta backup
+#   4. FÖRSTÖR datan — släpp tabellinnehållet
+#   5. bekräfta att ärendet är borta (annars bevisar steg 6 ingenting)
+#   6. återställ ur backupen
+#   7. bekräfta att ärendet är tillbaka, och att tjänsten är frisk
+#
+# Steg 5 är det som gör övningen ärlig. Utan det skulle en återställning som
+# inte gjorde någonting alls se ut att lyckas.
+#
+# Körs i CI vid varje ändring av backup-skripten eller compose:n, så rutinen
+# inte hinner ruttna mellan gångerna någon behöver den.
+set -euo pipefail
+
+COMPOSE="tooling/docker/docker-compose.production.yml"
+WORK="${TMPDIR:-/tmp}/ava-restore-drill"
+export AVA_COMPOSE="$COMPOSE"
+
+# Produktions-compose:n kräver riktiga värden för TLS/OIDC. Övningen startar
+# BARA postgres + server-first, men compose parsar hela filen → dummies.
+export AVA_DOMAIN="drill.invalid"
+export OIDC_ISSUER_URL="https://idp.invalid"
+export OAUTH2_PROXY_CLIENT_ID="drill"
+export OAUTH2_PROXY_CLIENT_SECRET="drill"
+export OAUTH2_PROXY_COOKIE_SECRET="0123456789abcdef0123456789abcdef"
+export POSTGRES_PASSWORD="drill-pw"
+export POSTGRES_USER="ava"
+export POSTGRES_DB="ava"
+export AVA_ORGANIZATION_ID="00000000-0000-0000-0000-000000000001"
+
+cleanup() { docker compose "${COMPOSE_ARGS[@]}" down -v >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+rm -rf "$WORK"; mkdir -p "$WORK"
+
+echo "▸ Bygger server-first-binären …"
+bun run server-first:build >/dev/null
+
+echo "▸ Startar postgres + server-first (persistent volym) …"
+docker compose "${COMPOSE_ARGS[@]}" up -d --build --wait --wait-timeout 180 postgres server-first
+
+echo "▸ Migrerar schemat …"
+docker compose "${COMPOSE_ARGS[@]}" exec -T postgres \
+  psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "SELECT 1" >/dev/null
+# Migrationerna körs från värden mot den exponerade porten i CI-overlayen.
+AVA_DATABASE_URL="postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@localhost:5433/$POSTGRES_DB" \
+  bun run db:migrate >/dev/null
+
+echo "▸ Skapar ett ärende via API:t …"
+SERVER_URL=http://localhost:3001 \
+AVA_DATABASE_URL="postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@localhost:5433/$POSTGRES_DB" \
+AVA_ORGANIZATION_ID="$AVA_ORGANIZATION_ID" \
+  bun tooling/scripts/restore-drill-seed.ts > "$WORK/marker.txt"
+MARKER="$(cat "$WORK/marker.txt")"
+echo "  Markör: $MARKER"
+
+echo "▸ Tar backup …"
+bash tooling/scripts/backup-db.sh "$WORK"
+DUMP="$(ls -1 "$WORK"/ava-*.sql.gz | head -1)"
+
+echo "▸ FÖRSTÖR datan — släpper ärendetabellen …"
+docker compose "${COMPOSE_ARGS[@]}" exec -T postgres \
+  psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "TRUNCATE matters CASCADE" >/dev/null
+
+echo "▸ Bekräftar att ärendet ÄR borta (annars bevisar återställningen inget) …"
+GONE=$(docker compose "${COMPOSE_ARGS[@]}" exec -T postgres \
+  psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc \
+  "SELECT count(*) FROM matters WHERE matter_number = '$MARKER'")
+if [ "$GONE" != "0" ]; then
+  echo "✗ Ärendet finns kvar efter TRUNCATE ($GONE) — övningen är meningslös." >&2
+  exit 1
+fi
+echo "  ✓ Borta"
+
+echo "▸ Återställer ur backupen …"
+AVA_RESTORE_YES=1 bash tooling/scripts/restore-db.sh "$DUMP"
+
+echo "▸ Bekräftar att ärendet är TILLBAKA …"
+BACK=$(docker compose "${COMPOSE_ARGS[@]}" exec -T postgres \
+  psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc \
+  "SELECT count(*) FROM matters WHERE matter_number = '$MARKER'")
+if [ "$BACK" != "1" ]; then
+  echo "✗ Ärendet kom inte tillbaka (count=$BACK) — backupen går INTE att lita på." >&2
+  exit 1
+fi
+
+echo
+echo "✓ Återställningsövning klar: ärendet $MARKER förstördes och återskapades,"
+echo "  och tjänsten är frisk efteråt (/readyz svarade ok)."

--- a/tooling/scripts/restore-drill.sh
+++ b/tooling/scripts/restore-drill.sh
@@ -22,8 +22,12 @@
 # inte hinner ruttna mellan gångerna någon behöver den.
 set -euo pipefail
 
+# Produktionsfilen + drill-overlayen (som exponerar portarna övningen behöver).
 COMPOSE="tooling/docker/docker-compose.production.yml"
+COMPOSE_ARGS=(-f "$COMPOSE" -f "tooling/docker/docker-compose.drill.yml")
 WORK="${TMPDIR:-/tmp}/ava-restore-drill"
+# backup-/restore-skripten tar EN compose-fil; de rör bara postgres och
+# server-first, så produktionsfilen räcker för dem.
 export AVA_COMPOSE="$COMPOSE"
 
 # Produktions-compose:n kräver riktiga värden för TLS/OIDC. Övningen startar


### PR DESCRIPTION
Inför pilot med användare. Arkitekturen fanns **redan hopsatt** i `docker-compose.selfhosted-local.yml` och är bevisad av OIDC-e2e:t — men den är en testrigg, inte en deploy.

| Testriggen | Den här |
|---|---|
| Postgres på **`tmpfs`** — data borta vid omstart | namngiven volym |
| Keycloak `start-dev`, admin/admin | byråns egen IdP via OIDC-discovery |
| http på `:8080` | TLS via Caddy (automatiskt cert, ingen certbot-cron att glömma) |
| ingen omstartspolicy | `restart: unless-stopped` + omstart vid **hängning** |
| `/healthz` = statisk rad i nginx | hälsokontroll som rör databasen |
| ingen backup | `pg_dump` + **verifierad** återställning |

## Hälsokontrollen var en attrapp

nginx svarade `200 "ok"` på en statisk rad — alltså *"nginx lever"*, inget annat. Var server-first hängd eller Postgres onåbar rapporterades tjänsten **frisk**, och en övervakning som litade på den hade aldrig startat om något.

Två rutter med olika betydelse:

- **`/healthz`** — liveness, rör inget nätverk. Faller den hänger processen → starta om.
- **`/readyz`** — readiness, tidsbegränsad db-fråga. Faller den kan orsaken ligga *utanför* processen → starta inte om blint; det ger en omstartsloop som döljer orsaken.

Tidsgränsen är inte kosmetisk: utan tak ärver hälsokontrollen precis det problem den ska upptäcka — hänger db-anropet hänger kontrollen, och övervakningen tolkar tystnaden som nätverksfel i stället för som en sjuk tjänst.

## Omstart vid hängning

`restart: unless-stopped` täcker bara **krascher**. En process som lever men slutat svara startas aldrig om av docker — den är ju igång. `autoheal` bevakar healthcheck-statusen.

Kedjan är: `/readyz` säger sanningen → healthchecken märker → autoheal agerar. Går första ledet sönder gör inget av de andra någon nytta — vilket är varför attrapp-healthchecken var **värre än ingen**.

## Backupen är verifierad, inte påstådd

`restore-drill.sh`: skapa ärende via API:t → backup → **förstör datan** → bekräfta att den är borta → återställ → bekräfta att den är tillbaka.

Steget *"bekräfta att den är borta"* gör övningen ärlig. Utan det skulle en återställning som inte gör någonting alls se ut att lyckas.

Kör som **CI-jobb**, inte checklista — en rutin som bara utförs när någon kommer ihåg den hinner ruttna mellan gångerna den behövs. Markören skapas via `matter.create`, inte med `INSERT`: en rad skriven förbi applikationen bevisar bara att `pg_dump` kopierar tabeller.

Drill-portarna ligger i en **overlay**, inte i produktionsfilen — en glömd port där hade blivit en öppen databas hos en byrå.

## Dessutom

`deploy-tier3-self-hosted.md` beskrev den **pensionerade** git-arkitekturen (ADR 0016 ersatte den) och är nu märkt som sådan. Den hade gett fel system *och* en backup av ett git-repo som inte längre är sanningskällan. Ny doc: `deploy-server-first.md`.

## Verifierat

11 tester för hälsokontrollen, med tyngdpunkt på felvägarna — inklusive att en **hängd** databas fäller på tidsgränsen i stället för att hänga kontrollen. 3691 gröna totalt, compose-syntax validerad.

Återställningsövningen kunde **inte** köras lokalt: Docker Hub nås inte från den här maskinen. Den körs i CI i den här PR:en — det är där beviset ska landa.

Refs #1079

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9UB9at5Tpr1A6sYEXomxB