### PR TITLE
feat(msgraph): ms:connect — consent-runda och token-utbyte mot Entra

### DIFF
--- a/docs/ms-graph.md
+++ b/docs/ms-graph.md
@@ -1,0 +1,89 @@
+# Microsoft Graph — anslutning och tokens
+
+Motsvarigheten till [`fortnox-e2e.md`](fortnox-e2e.md) för Graph-epicen (#1069).
+Den här sidan täcker **anslutningen** (#1071, #1072); e2e-flödet och CI-jobbet
+växer in här när #1073–#1075 landat.
+
+## Behörighetsmodellen: delegerad
+
+AVA använder **delegerade** behörigheter, inte applikationsbehörigheter. En
+app-only-token med `Mail.Read` ger läsrätt till **varje** brevlåda i tenanten,
+inklusive korrespondens i ärenden juristen inte arbetar med. För en advokatbyrå
+är det en sekretessfråga, inte en teknikdetalj — jfr byråjävet i VRGA 3.5, där
+det har betydelse att information *finns tillgänglig*.
+
+Priset är att consent kräver en människa en gång, och att refresh-token dör av
+inaktivitet. Fortnox visade att det priset går att betala i obevakad CI, så länge
+den roterade token:en skrivs tillbaka vid varje körning.
+
+Scopes (`MS_DEFAULT_SCOPES` i `src/lib/server/integrations/msgraph/schema.ts`):
+
+| Scope | Varför |
+|---|---|
+| `offline_access` | **utan den skickar Entra ingen refresh-token alls** |
+| `Mail.Read` | läsa mail → `mail.saveIncoming` |
+| `Mail.Send` | skicka från ärendet |
+| `User.Read` | identifiera den inloggade |
+
+## Ansluta
+
+```bash
+AVA_MS_CLIENT_ID=…  AVA_MS_CLIENT_SECRET=…  AVA_MS_TENANT_ID=… \
+AVA_MS_REDIRECT_URI=http://localhost:53682/callback \
+  bun run ms:connect --listen
+```
+
+`--listen` skriver ut authorize-URL:en, tar emot redirecten själv, jämför `state`
+och växlar in koden direkt. Koden lever ~60 sekunder — den marginalen räcker inte
+om något kommer emellan, vilket är hela skälet till flaggan.
+
+Pekar redirect-URI:n någon annanstans finns tvåstegsvarianten: kör utan flagga
+för att få URL:en, godkänn, och kör `--code <kod>` med koden ur adressfältet.
+
+Ut kommer en refresh-token. Den ska in som secret, inte i en fil.
+
+## Hur `redirect_uri` jämförs — tvärtom mot Fortnox
+
+Fortnox jämför parametern **före** URL-decode, vilket tvingade fram en rå,
+oencodad sträng (#1038). Microsoft kräver motsatsen: "It must exactly match one
+of the redirect URIs you registered … except it must be URL-encoded."
+
+Verifierat mot skarp authorize-endpoint 2026-09-06: percent-encodad → consent
+går igenom. Regressionstestet asserterar på **råsträngen** i URL:en, eftersom
+`url.searchParams.get(…)` decodar och skulle visa samma svar åt båda hållen —
+precis den blindhet som lät Fortnox-buggen ligga kvar.
+
+## Miljön `ms-graph` i CI
+
+| Secret | Innehåll |
+|---|---|
+| `AVA_MS_CLIENT_ID` | Application (client) ID |
+| `AVA_MS_CLIENT_SECRET` | klient-hemlighet ur Certificates & secrets |
+| `AVA_MS_TENANT_ID` | tenant-GUID |
+| `AVA_MS_REFRESH_TOKEN` | roterande — skrivs tillbaka av varje körning (#1073) |
+| `AVA_MS_ROTATE_PAT` | PAT som får skriva environment-secrets |
+
+| Variabel | Innehåll |
+|---|---|
+| `AVA_MS_TENANT_DOMAIN` | `*.onmicrosoft.com`, bara för felsökning |
+| `AVA_MS_CI_ENABLED` | avstängningsknapp — **repo**-variabel, inte environment |
+
+Fällorna från Fortnox gäller ordagrant här (se #1071): `gh secret set --body -`
+sparar strängen `-`; ett job-`if` på en *environment*-variabel utvärderas innan
+`environment:` resolvas och blir alltid tomt; PAT:en behöver behörigheten
+**Environments**, inte `Secrets`.
+
+## Vad som INTE går än: brevlådan
+
+Tenanten `ulriksjolingmail.onmicrosoft.com` har **noll M365-licenser**, alltså
+ingen Exchange-brevlåda. `GET /me` svarar 200 med `"mail": null`, och allt i
+`Mail.*` kommer att svara `MailboxNotEnabledForRESTAPI`.
+
+Microsoft 365 Developer Program ger inte längre en gratis E5-sandbox till alla —
+dashboarden svarar "You don't currently qualify" utan en Visual
+Studio-prenumeration (verifierat 2026-09-06). Det som återstår är en betald
+licens med Exchange Online i tenanten; en M365 Business Basic-prövotid räcker för
+att komma igång.
+
+Fram till dess är #1074 och #1075 blockerade. Anslutningen, rotationen och
+`ms:connect` är däremot verifierade mot skarp Entra och påverkas inte.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "ava": "bun tooling/ava-cli/ava.ts",
     "ava:mcp": "bun tooling/ava-cli/ava-mcp.ts",
     "fortnox:connect": "bun tooling/scripts/fortnox-connect.ts",
+    "ms:connect": "bun tooling/scripts/ms-connect.ts",
     "fortnox:e2e": "bun tooling/scripts/fortnox-e2e.ts",
     "fortnox:bookkeeping": "bun tooling/scripts/fortnox-bookkeeping-e2e.ts",
     "fortnox:series": "bun tooling/scripts/fortnox-series.ts",

--- a/src/lib/server/integrations/msgraph/oauth.ts
+++ b/src/lib/server/integrations/msgraph/oauth.ts
@@ -1,0 +1,129 @@
+/**
+ * Microsoft Entra OAuth2 — Authorization Code-flöde (#1072).
+ *
+ *   1. `buildAuthorizeUrl` → användaren skickas till Entra, godkänner,
+ *      redirectas tillbaka med `?code=…&state=…`.
+ *   2. `exchangeCodeForTokens` → byt code mot access+refresh-token.
+ *   3. `refreshTokens` → förnya access-token. Entra utfärdar en NY
+ *      refresh-token varje gång och den gamla ska kastas → spara alltid den
+ *      nya (samma fälla som Fortnox, se #1073).
+ *
+ * ## `redirect_uri` ska vara PERCENT-ENCODAD här — tvärtom mot Fortnox
+ *
+ * Fortnox jämför parametern mot registreringen INNAN URL-decode, vilket
+ * tvingade fram en rå sträng i `fortnox/oauth.ts`. Microsoft gör tvärtom:
+ * "It must exactly match one of the redirect URIs you registered … except it
+ * must be URL-encoded" (Microsoft Learn, v2-oauth2-auth-code-flow, hämtad
+ * 2026-09-06). Därför bygger vi hela query-strängen med `URLSearchParams` —
+ * och regressionstestet asserterar på RÅSTRÄNGEN, för `url.searchParams`
+ * decodar åt en och skulle dölja ett fel åt endera hållet.
+ *
+ * Allt nät via injicerad `fetch` (testbar utan riktig Entra).
+ */
+
+import {
+  msTokenResponseSchema,
+  type MsGraphConfig,
+  type MsStoredTokens,
+  type MsTokenResponse,
+} from "./schema";
+
+export type FetchFn = typeof globalThis.fetch;
+
+function authorizeEndpoint(config: MsGraphConfig): string {
+  return `${config.authBase}/${config.tenantId}/oauth2/v2.0/authorize`;
+}
+
+function tokenEndpoint(config: MsGraphConfig): string {
+  return `${config.authBase}/${config.tenantId}/oauth2/v2.0/token`;
+}
+
+/**
+ * Bygg authorize-URL:n användaren skickas till. `state` ska vara slumpad (CSRF).
+ *
+ * `response_mode=query` är explicit: default vore query ändå för enbart `code`,
+ * men den dagen någon lägger till `id_token` i `response_type` byter Entra tyst
+ * till `fragment` — och en fragment-del når aldrig en lokal callback-server.
+ */
+export function buildAuthorizeUrl(config: MsGraphConfig, state: string): string {
+  const url = new URL(authorizeEndpoint(config));
+  url.search = new URLSearchParams({
+    client_id: config.clientId,
+    response_type: "code",
+    redirect_uri: config.redirectUri,
+    response_mode: "query",
+    scope: config.scopes.join(" "),
+    state,
+  }).toString();
+  return url.toString();
+}
+
+/** Gemensam token-POST + strikt parsning. Kastar vid icke-2xx. */
+async function postToken(
+  config: MsGraphConfig,
+  body: Record<string, string>,
+  fetchFn: FetchFn,
+): Promise<MsTokenResponse> {
+  const res = await fetchFn(tokenEndpoint(config), {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: config.clientId,
+      client_secret: config.clientSecret,
+      scope: config.scopes.join(" "),
+      ...body,
+    }).toString(),
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    // AADSTS-koden i kroppen är det enda som säger VAD som var fel — ta med den.
+    throw new Error(`Entra token-fel ${res.status}: ${detail.slice(0, 300)}`);
+  }
+  return msTokenResponseSchema.parse(await res.json());
+}
+
+/**
+ * Persisterad token-shape (~30 s säkerhetsmarginal på utgången).
+ *
+ * Saknas `refresh_token` begärdes inte `offline_access` — säg det rakt ut i
+ * stället för att låta anropet lyckas och kedjan dö vid nästa körning.
+ */
+function toStoredTokens(resp: MsTokenResponse, nowMs: number): MsStoredTokens {
+  if (!resp.refresh_token) {
+    throw new Error("Entra returnerade ingen refresh_token — saknas scopet offline_access?");
+  }
+  return {
+    accessToken: resp.access_token,
+    refreshToken: resp.refresh_token,
+    accessTokenExpiresAt: nowMs + (resp.expires_in - 30) * 1000,
+  };
+}
+
+/** Steg 2: byt authorization-code mot tokens. */
+export async function exchangeCodeForTokens(
+  config: MsGraphConfig,
+  code: string,
+  fetchFn: FetchFn = globalThis.fetch,
+  nowMs: number = Date.now(),
+): Promise<MsStoredTokens> {
+  const resp = await postToken(config, {
+    grant_type: "authorization_code",
+    code,
+    redirect_uri: config.redirectUri,
+  }, fetchFn);
+  return toStoredTokens(resp, nowMs);
+}
+
+/** Steg 3: förnya access-token. Returnerar NYA tokens (refresh roterar!). */
+export async function refreshTokens(
+  config: MsGraphConfig,
+  refreshToken: string,
+  fetchFn: FetchFn = globalThis.fetch,
+  nowMs: number = Date.now(),
+): Promise<MsStoredTokens> {
+  const resp = await postToken(config, {
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+  }, fetchFn);
+  return toStoredTokens(resp, nowMs);
+}

--- a/src/lib/server/integrations/msgraph/schema.ts
+++ b/src/lib/server/integrations/msgraph/schema.ts
@@ -1,0 +1,70 @@
+/**
+ * Microsoft Graph-connector — zod-scheman (#1072).
+ *
+ * Samma form som Fortnox-motsvarigheten: ren config/data, inga hemligheter
+ * hårdkodade, strikt parsning av allt som kommer utifrån
+ * ([[feedback-zod-strict-parsing]]).
+ */
+
+import { z } from "zod";
+
+/** Entra-ID:s inloggningsvärd. Overridebar för test. */
+export const MS_AUTH_BASE = "https://login.microsoftonline.com";
+export const MS_GRAPH_BASE = "https://graph.microsoft.com";
+
+/**
+ * Minsta scope-uppsättningen för epicen (#1069): läsa och skicka mail som den
+ * inloggade juristen, plus refresh-token.
+ *
+ * `offline_access` är inte valfri kosmetik — utan den skickar Entra ingen
+ * refresh-token alls, och hela obevakade CI-kedjan faller.
+ */
+export const MS_DEFAULT_SCOPES = [
+  "offline_access",
+  `${MS_GRAPH_BASE}/Mail.Read`,
+  `${MS_GRAPH_BASE}/Mail.Send`,
+  `${MS_GRAPH_BASE}/User.Read`,
+] as const;
+
+export const msGraphConfigSchema = z.object({
+  clientId: z.string().min(1),
+  clientSecret: z.string().min(1),
+  /**
+   * Tenant-id (GUID) eller `common`/`organizations`. GUID för en enskild byrå:
+   * `common` släpper in vem som helst med ett Microsoft-konto.
+   */
+  tenantId: z.string().min(1),
+  /** Måste matcha en registrerad redirect-URI i app-registreringen. */
+  redirectUri: z.string().url(),
+  scopes: z.array(z.string().min(1)).min(1),
+  authBase: z.string().url().default(MS_AUTH_BASE),
+});
+export type MsGraphConfig = z.infer<typeof msGraphConfigSchema>;
+
+/**
+ * Råsvar från `POST /{tenant}/oauth2/v2.0/token`.
+ *
+ * `refresh_token` är VALFRI i schemat men obligatorisk i praktiken: Entra
+ * utelämnar den när `offline_access` inte begärts. Det felet ska synas som ett
+ * begripligt meddelande i `ms-connect`, inte som en zod-stacktrace.
+ */
+export const msTokenResponseSchema = z.object({
+  access_token: z.string().min(1),
+  refresh_token: z.string().min(1).optional(),
+  token_type: z.string(),
+  expires_in: z.number().int().positive(),
+  scope: z.string().optional(),
+});
+export type MsTokenResponse = z.infer<typeof msTokenResponseSchema>;
+
+/**
+ * Persisterade tokens. Entra utfärdar en NY refresh-token vid varje refresh och
+ * den gamla ska kastas — samma write-back-krav som Fortnox (#1073).
+ * `accessTokenExpiresAt` = epoch ms.
+ */
+export const msStoredTokensSchema = z.object({
+  accessToken: z.string().min(1),
+  refreshToken: z.string().min(1),
+  accessTokenExpiresAt: z.number().int(),
+});
+export type MsStoredTokens = z.infer<typeof msStoredTokensSchema>;

--- a/test/unit/server/integrations/msgraph/oauth.test.ts
+++ b/test/unit/server/integrations/msgraph/oauth.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest-compat";
+import {
+  buildAuthorizeUrl,
+  exchangeCodeForTokens,
+  refreshTokens,
+} from "@/lib/server/integrations/msgraph/oauth";
+import type { MsGraphConfig } from "@/lib/server/integrations/msgraph/schema";
+
+const config: MsGraphConfig = {
+  clientId: "cid",
+  clientSecret: "secret",
+  tenantId: "tenant-guid",
+  redirectUri: "http://localhost:53682/callback",
+  scopes: ["offline_access", "https://graph.microsoft.com/Mail.Read"],
+  authBase: "https://login.test",
+};
+
+interface Captured {
+  url: string;
+  init: RequestInit;
+}
+
+function fakeFetch(status: number, json: unknown, cap?: Captured) {
+  return (async (url: string | URL | Request, init?: RequestInit) => {
+    if (cap) {
+      cap.url = String(url);
+      cap.init = init ?? {};
+    }
+    return new Response(JSON.stringify(json), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof globalThis.fetch;
+}
+
+const TOKEN_JSON = {
+  access_token: "at-1",
+  refresh_token: "rt-2",
+  token_type: "Bearer",
+  expires_in: 3600,
+  scope: "Mail.Read",
+};
+
+function bodyOf(init: RequestInit): URLSearchParams {
+  return new URLSearchParams(String(init.body));
+}
+
+describe("buildAuthorizeUrl", () => {
+  it("bygger authorize-URL:en på tenant-scopad v2-endpoint", () => {
+    const u = new URL(buildAuthorizeUrl(config, "xyz-state"));
+    expect(u.origin + u.pathname).toBe("https://login.test/tenant-guid/oauth2/v2.0/authorize");
+    const p = u.searchParams;
+    expect(p.get("client_id")).toBe("cid");
+    expect(p.get("redirect_uri")).toBe("http://localhost:53682/callback");
+    expect(p.get("scope")).toBe("offline_access https://graph.microsoft.com/Mail.Read");
+    expect(p.get("state")).toBe("xyz-state");
+    expect(p.get("response_type")).toBe("code");
+  });
+
+  /**
+   * Fortnox-buggen (#1038) spegelvänd. Microsoft kräver att `redirect_uri` ÄR
+   * percent-encodad; Fortnox krävde att den INTE var det. Asserten måste därför
+   * gå på råsträngen — `u.searchParams.get(…)` decodar och visar samma svar i
+   * båda fallen, vilket är precis hur felet kunde ligga kvar hos Fortnox.
+   */
+  it("percent-encodar redirect_uri i RÅSTRÄNGEN (Microsoft jämför den encodad)", () => {
+    const raw = buildAuthorizeUrl(config, "s");
+    expect(raw).toContain("redirect_uri=http%3A%2F%2Flocalhost%3A53682%2Fcallback");
+    expect(raw).not.toContain("redirect_uri=http://localhost");
+  });
+
+  it("encodar scope-separatorn — mellanslag i en query-sträng är ett fel", () => {
+    expect(buildAuthorizeUrl(config, "s")).toContain("scope=offline_access+https%3A%2F%2Fgraph");
+  });
+
+  // Utan detta byter Entra tyst till fragment så fort någon lägger till
+  // id_token i response_type — och ett fragment når aldrig callback-servern.
+  it("sätter response_mode=query explicit", () => {
+    expect(new URL(buildAuthorizeUrl(config, "s")).searchParams.get("response_mode")).toBe("query");
+  });
+});
+
+describe("exchangeCodeForTokens", () => {
+  it("postar authorization_code mot token-endpointen", async () => {
+    const cap = {} as Captured;
+    await exchangeCodeForTokens(config, "the-code", fakeFetch(200, TOKEN_JSON, cap), 1_000_000);
+    expect(cap.url).toBe("https://login.test/tenant-guid/oauth2/v2.0/token");
+    const b = bodyOf(cap.init);
+    expect(b.get("grant_type")).toBe("authorization_code");
+    expect(b.get("code")).toBe("the-code");
+    expect(b.get("redirect_uri")).toBe("http://localhost:53682/callback");
+  });
+
+  // Entra tar client_secret i kroppen (Basic stöds också). Hamnar den fel
+  // svarar endpointen invalid_client, vilket är lätt att misstolka som fel secret.
+  it("skickar klientautentiseringen i kroppen", async () => {
+    const cap = {} as Captured;
+    await exchangeCodeForTokens(config, "c", fakeFetch(200, TOKEN_JSON, cap));
+    const b = bodyOf(cap.init);
+    expect(b.get("client_id")).toBe("cid");
+    expect(b.get("client_secret")).toBe("secret");
+  });
+
+  it("räknar utgången med 30 s marginal", async () => {
+    const t = await exchangeCodeForTokens(config, "c", fakeFetch(200, TOKEN_JSON), 1_000_000);
+    expect(t.accessTokenExpiresAt).toBe(1_000_000 + (3600 - 30) * 1000);
+    expect(t.refreshToken).toBe("rt-2");
+  });
+
+  // AADSTS-koden är det enda som säger vad som gick fel — tappas den bort står
+  // felsökaren med "400" och ingenting mer.
+  it("bär med sig felkroppen vid icke-2xx", async () => {
+    const err = { error: "invalid_grant", error_description: "AADSTS70008: expired" };
+    await expect(exchangeCodeForTokens(config, "c", fakeFetch(400, err)))
+      .rejects.toThrow(/AADSTS70008/);
+  });
+
+  /**
+   * Utan `offline_access` svarar Entra 200 UTAN refresh_token. Skulle det
+   * passera tyst vore anslutningen död vid nästa körning, långt från orsaken.
+   */
+  it("kräver refresh_token och pekar ut offline_access när den saknas", async () => {
+    const { refresh_token: _omitted, ...noRefresh } = TOKEN_JSON;
+    await expect(exchangeCodeForTokens(config, "c", fakeFetch(200, noRefresh)))
+      .rejects.toThrow(/offline_access/);
+  });
+});
+
+describe("refreshTokens", () => {
+  it("postar refresh_token-grant", async () => {
+    const cap = {} as Captured;
+    await refreshTokens(config, "old-rt", fakeFetch(200, TOKEN_JSON, cap));
+    const b = bodyOf(cap.init);
+    expect(b.get("grant_type")).toBe("refresh_token");
+    expect(b.get("refresh_token")).toBe("old-rt");
+  });
+
+  // Rotationen är hela poängen: returneras den gamla token:en tillbaka har
+  // write-backen inget nytt att spara och kedjan dör tyst efter en körning.
+  it("returnerar den NYA refresh-token:en", async () => {
+    const t = await refreshTokens(config, "old-rt", fakeFetch(200, TOKEN_JSON));
+    expect(t.refreshToken).toBe("rt-2");
+    expect(t.refreshToken).not.toBe("old-rt");
+  });
+});

--- a/test/unit/tooling/ms-connect.test.ts
+++ b/test/unit/tooling/ms-connect.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest-compat";
+import { codeFromCallbackUrl } from "../../../tooling/scripts/ms-connect";
+
+/**
+ * `--listen` (#1072) tar emot Entras redirect. Servern går inte att enhetstesta
+ * meningsfullt, men tolkningen av callbacken gör det — och det är där felen
+ * bor: en avbruten consent, ett svar från fel runda, en tom kod.
+ */
+const STATE = "the-state";
+
+describe("codeFromCallbackUrl", () => {
+  it("plockar ut koden när state stämmer", () => {
+    expect(codeFromCallbackUrl(`/callback?code=abc&state=${STATE}`, STATE)).toBe("abc");
+  });
+
+  // Utan detta blir en avbruten consent "callback saknar ?code=" — sant men
+  // oanvändbart. Entras error_description säger vad användaren faktiskt gjorde.
+  it("lyfter fram Entras fel i stället för att gissa", () => {
+    expect(() => codeFromCallbackUrl("/callback?error=access_denied&error_description=user+canceled", STATE))
+      .toThrow(/access_denied.*canceled/);
+  });
+
+  // Hela CSRF-skyddet: ett svar med fel state hör till någon annans runda.
+  it("vägrar när state inte stämmer", () => {
+    expect(() => codeFromCallbackUrl("/callback?code=abc&state=annat", STATE)).toThrow(/state/);
+  });
+
+  it("vägrar när state saknas helt", () => {
+    expect(() => codeFromCallbackUrl("/callback?code=abc", STATE)).toThrow(/state/);
+  });
+
+  it("vägrar en callback utan kod", () => {
+    expect(() => codeFromCallbackUrl(`/callback?state=${STATE}`, STATE)).toThrow(/code/);
+  });
+});

--- a/tooling/scripts/ms-connect.ts
+++ b/tooling/scripts/ms-connect.ts
@@ -1,0 +1,140 @@
+/**
+ * Microsoft Graph OAuth-anslutning (#1072) — de två stegen som kräver en människa.
+ *
+ * Samma verktyg som `fortnox:connect`, av samma skäl: consent-rundan behövs om
+ * och om igen (refresh-token dör av inaktivitet, och en misslyckad write-back i
+ * CI har samma effekt), och gjord för hand blir den fel.
+ *
+ * Enklast — `--listen` gör hela rundan i ett svep:
+ *   AVA_MS_CLIENT_ID=… AVA_MS_CLIENT_SECRET=… AVA_MS_TENANT_ID=… \
+ *     AVA_MS_REDIRECT_URI=http://localhost:53682/callback bun run ms:connect --listen
+ *
+ * Manuellt, om redirect-URI:n inte pekar på den här maskinen — steg 1 (INGEN
+ * hemlighet behövs) och steg 2 (client_secret behövs):
+ *   AVA_MS_CLIENT_ID=… AVA_MS_TENANT_ID=… AVA_MS_REDIRECT_URI=… bun run ms:connect
+ *   … bun run ms:connect --code <kod>
+ *
+ * Koden lever ~60 sekunder. Det räcker gott när man klistrar för hand, men
+ * inte när något annat kommer emellan — därför finns `--listen`, som tar emot
+ * redirecten själv och växlar in koden direkt (och jämför `state` åt en,
+ * i stället för att be en människa göra det med ögat).
+ *
+ * Kör det här LOKALT, inte i CI: `client_secret` ska aldrig lämna din maskin.
+ */
+
+import { randomUUID } from "node:crypto";
+import { createServer } from "node:http";
+import { buildAuthorizeUrl, exchangeCodeForTokens } from "@/lib/server/integrations/msgraph/oauth";
+import { msGraphConfigSchema, MS_DEFAULT_SCOPES, type MsGraphConfig } from "@/lib/server/integrations/msgraph/schema";
+
+function env(name: string, required = true): string {
+  const v = process.env[name];
+  if (!v && required) {
+    console.error(`✗ ${name} saknas.`);
+    process.exit(2);
+  }
+  return v ?? "";
+}
+
+function buildConfig(needSecret: boolean): MsGraphConfig {
+  return msGraphConfigSchema.parse({
+    clientId: env("AVA_MS_CLIENT_ID"),
+    // Authorize-steget signerar inget — secreten behövs först vid token-bytet.
+    clientSecret: needSecret ? env("AVA_MS_CLIENT_SECRET") : "ej-relevant-for-authorize",
+    tenantId: env("AVA_MS_TENANT_ID"),
+    redirectUri: env("AVA_MS_REDIRECT_URI"),
+    scopes: (process.env.AVA_MS_SCOPES ?? MS_DEFAULT_SCOPES.join(" ")).split(/[ ,]+/).filter(Boolean),
+  });
+}
+
+function printAuthorizeUrl(): void {
+  const config = buildConfig(false);
+  const state = randomUUID();
+  console.log("\nÖppna den här i en browser och godkänn:\n");
+  console.log(buildAuthorizeUrl(config, state));
+  console.log(`\nstate = ${state}`);
+  console.log("Kontrollera att samma state kommer tillbaka i redirecten (CSRF-skydd).");
+  console.log("\nRedirecten går till en port där inget lyssnar — browsern visar ett");
+  console.log("anslutningsfel, men adressfältet innehåller ?code=… . Kopiera den och kör:");
+  console.log("  … bun run ms:connect --code <kod>");
+  console.log("\nKoden är ENGÅNGS och lever ~60 sekunder — växla in den direkt.");
+}
+
+async function exchange(code: string): Promise<void> {
+  const config = buildConfig(true);
+  const tokens = await exchangeCodeForTokens(config, code);
+  console.log("\n✓ Anslutet. Lägg det här som secret AVA_MS_REFRESH_TOKEN:\n");
+  console.log(tokens.refreshToken);
+  console.log(`\n(access-token går ut ${new Date(tokens.accessTokenExpiresAt).toISOString()} — den behöver du inte spara.)`);
+  console.log("Refresh-token ROTERAR vid varje användning; skriv alltid tillbaka den nya.");
+}
+
+/**
+ * Plocka ut `code` ur en callback-URL och kontrollera `state`.
+ *
+ * Ren funktion, skild från servern, för att det är HÄR det kan gå fel:
+ * en avbruten consent ger `?error=…` i stället för `?code=…`, och ett `state`
+ * som inte stämmer betyder att svaret hör till någon annan runda.
+ */
+export function codeFromCallbackUrl(rawUrl: string, expectedState: string): string {
+  const p = new URL(rawUrl, "http://localhost").searchParams;
+  const error = p.get("error");
+  if (error) throw new Error(`${error}: ${p.get("error_description") ?? "(ingen beskrivning)"}`);
+  const state = p.get("state");
+  if (state !== expectedState) throw new Error(`state stämmer inte (fick ${state ?? "inget"}) — svaret hör till en annan runda`);
+  const code = p.get("code");
+  if (!code) throw new Error("callback saknar ?code=");
+  return code;
+}
+
+/** Ta emot redirecten själv och växla in koden direkt. */
+async function listen(): Promise<void> {
+  const config = buildConfig(true);
+  const state = randomUUID();
+  const { port, pathname } = new URL(config.redirectUri);
+
+  const received = Promise.withResolvers<string>();
+  const server = createServer((req, res) => {
+    const url = req.url ?? "/";
+    if (!url.startsWith(pathname)) {
+      res.writeHead(404).end("nej");
+      return;
+    }
+    try {
+      received.resolve(codeFromCallbackUrl(url, state));
+      res.writeHead(200, { "content-type": "text/plain; charset=utf-8" }).end("Klart — du kan stänga fliken.");
+    } catch (e: unknown) {
+      received.reject(e);
+      res.writeHead(400, { "content-type": "text/plain; charset=utf-8" }).end("Något gick fel — se terminalen.");
+    }
+  });
+  server.listen(Number(port));
+
+  console.log("\nÖppna den här i en browser och godkänn:\n");
+  console.log(buildAuthorizeUrl(config, state));
+  console.log(`\nLyssnar på ${config.redirectUri} …`);
+  try {
+    await exchange(await received.promise);
+  } finally {
+    server.close();
+  }
+}
+
+const codeIndex = process.argv.indexOf("--code");
+const code = codeIndex >= 0 ? process.argv[codeIndex + 1] : undefined;
+const fail = (e: unknown): void => {
+  console.error(`\n✗ Anslutningen misslyckades: ${e instanceof Error ? e.message : String(e)}`);
+  process.exitCode = 1;
+};
+
+// Bara när scriptet körs — `codeFromCallbackUrl` ska gå att importera i test
+// utan att en saknad env-variabel avslutar processen.
+if (import.meta.main) {
+  if (process.argv.includes("--listen")) {
+    listen().catch(fail);
+  } else if (code) {
+    exchange(code).catch(fail);
+  } else {
+    printAuthorizeUrl();
+  }
+}


### PR DESCRIPTION
Motsvarigheten till `fortnox:connect` (#1072). Verifierat **mot skarp Entra**, inte bara mot injicerad `fetch`:

```
authorize → code → tokens → refresh (roterade: true) → GET /me → 200
```

## Fortnox-fällan är spegelvänd här

Fortnox jämför `redirect_uri` **före** URL-decode och krävde en rå sträng (#1038). Microsoft kräver motsatsen — parametern ska vara percent-encodad. Regressionstestet asserterar därför på **råsträngen**: `url.searchParams.get(…)` decodar och skulle visa samma svar åt båda hållen, vilket är exakt den blindhet som lät Fortnox-buggen ligga kvar.

## `--listen`

Koden lever ~60 sekunder. Det räcker för en människa som klistrar direkt, inte om något kommer emellan. `--listen` tar emot redirecten själv, jämför `state` (i stället för att be någon göra det med ögat) och växlar in koden direkt.

## Vad som gjorts utanför repot

- App-registrering **AVA (dev)** i tenanten, delegerade scopes `Mail.Read` / `Mail.Send` / `offline_access` / `User.Read`, admin-consent givet
- GitHub-miljön `ms-graph` med `AVA_MS_CLIENT_ID`, `AVA_MS_CLIENT_SECRET`, `AVA_MS_TENANT_ID`, `AVA_MS_REFRESH_TOKEN` (den roterade)

## Vad som fortfarande blockerar #1074/#1075

Tenanten har **noll M365-licenser** → ingen brevlåda. `GET /me` svarar `"mail": null`, och `Mail.*` kommer att ge `MailboxNotEnabledForRESTAPI`. Microsoft 365 Developer Program ger inte längre en gratis E5-sandbox utan Visual Studio-prenumeration (verifierat 2026-09-06). Det krävs en betald Exchange-licens i tenanten. Se `docs/ms-graph.md`.

Refs #1072, #1071, #1069

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9UB9at5Tpr1A6sYEXomxB