### PR TITLE
docs(msgraph): testtenanten finns och brevlådan fungerar

### DIFF
--- a/docs/adr/0036-graph-behorighetsmodell-delegerad.md
+++ b/docs/adr/0036-graph-behorighetsmodell-delegerad.md
@@ -63,13 +63,13 @@ annat.
 
 Ursprungsplanen i #1070 var Microsoft 365 Developer Programs kostnadsfria
 E5-sandbox med 16 fiktiva användare och färdig mail-data. **Den finns inte att få
-längre** — dashboarden svarar "You don't currently qualify" utan en Visual
-Studio Enterprise/Professional-prenumeration (verifierat 2026-09-06).
+längre** — den kräver Visual Studio Professional eller Enterprise, och Dev
+Essentials (gratis) kvalificerar inte (verifierat 2026-09-06).
 
-Det som används i stället är en egen tenant med **betald Exchange-licens**
-(M365 Business Basic räcker). Tenanten som finns idag saknar licenser helt, vilket
-gör att `Mail.*` svarar `MailboxNotEnabledForRESTAPI` — anslutningen är klar, men
-brevlådan är en öppen post. Se [`docs/ms-graph.md`](../ms-graph.md).
+Det som används i stället är en egen tenant med **betald Exchange-licens**:
+`QnyxAB.onmicrosoft.com`, Microsoft 365 Business Basic, en licensierad
+testbrevlåda. Kedjan är verifierad mot skarp Graph — skickat mail, hittat i
+inkorgen, rå MIME hämtad via `$value`. Se [`docs/ms-graph.md`](../ms-graph.md).
 
 Kravet att **inte** använda en produktions-tenant står kvar och blir viktigare
 med delegerat consent: en admin-consent i arbetsgivarens tenant gäller riktiga

--- a/docs/ms-graph.md
+++ b/docs/ms-graph.md
@@ -73,17 +73,42 @@ sparar strängen `-`; ett job-`if` på en *environment*-variabel utvärderas inn
 `environment:` resolvas och blir alltid tomt; PAT:en behöver behörigheten
 **Environments**, inte `Secrets`.
 
-## Vad som INTE går än: brevlådan
+## Testtenanten
 
-Tenanten `ulriksjolingmail.onmicrosoft.com` har **noll M365-licenser**, alltså
-ingen Exchange-brevlåda. `GET /me` svarar 200 med `"mail": null`, och allt i
-`Mail.*` kommer att svara `MailboxNotEnabledForRESTAPI`.
+| | |
+|---|---|
+| Tenant | `QnyxAB.onmicrosoft.com` (Qnyx AB) |
+| Testbrevlåda | `UlrikSjolin@QnyxAB.onmicrosoft.com`, Microsoft 365 Business Basic |
+| App | AVA (dev), single tenant, redirect `http://localhost:53682/callback` |
 
-Microsoft 365 Developer Program ger inte längre en gratis E5-sandbox till alla —
-dashboarden svarar "You don't currently qualify" utan en Visual
-Studio-prenumeration (verifierat 2026-09-06). Det som återstår är en betald
-licens med Exchange Online i tenanten; en M365 Business Basic-prövotid räcker för
-att komma igång.
+Verifierat mot skarp Graph 2026-09-06, hela vägen:
 
-Fram till dess är #1074 och #1075 blockerade. Anslutningen, rotationen och
-`ms:connect` är däremot verifierade mot skarp Entra och påverkas inte.
+```
+refresh (roterade) → GET /me → sendMail 202 → hittad i inkorgen efter 3 s
+                   → GET /messages/{id}/$value → 200, 693 bytes rå MIME
+```
+
+Att `$value` faktiskt ger MIME och inte JSON är värt att ha bevisat: det är den
+byte-strömmen `mail.saveIncoming` ska skriva som `.eml`, och ett enhetstest mot
+injicerad `fetch` hade sagt ja oavsett vad Microsoft returnerade.
+
+### Varför inte den första tenanten
+
+Det första försöket gjordes i en tenant som Entra skapade automatiskt vid
+inloggning med ett gmail-konto. Den vägen är en återvändsgränd, och det är värt
+att veta innan någon provar igen:
+
+- `admin.microsoft.com` skickar `msafed=0` och **släpper inte in personliga
+  Microsoft-konton alls** — "You can't sign in here with a personal account"
+- ett gästkonto (`…#EXT#@…`) kan administrera Entra men aldrig äga en brevlåda
+- faktureringsprofilen gick inte att skapa: organisationsprofilen som en
+  köpflödet bygger på saknas i en tenant som uppstått som biprodukt
+
+Microsoft 365 Developer Programs kostnadsfria E5-sandbox är inte heller en väg
+ut: den kräver Visual Studio **Professional eller Enterprise**. Dev Essentials
+(gratis) kvalificerar inte — dashboarden svarar "You don't currently qualify"
+(verifierat 2026-09-06).
+
+Lösningen var att starta Business Basic-prövotiden från microsoft.com i stället
+för inifrån admin center. Det flödet **skapar en egen tenant** med riktig
+organisationsprofil, fungerande fakturering och en licensierad brevlåda direkt.


### PR DESCRIPTION
`docs/ms-graph.md` och ADR 0036 skrevs medan brevlådan var en öppen post. Den är det inte längre, och den delen är nu direkt felaktig på `main`.

## Verifierat mot skarp Graph 2026-09-06

```
refresh (roterade: true) → GET /me → sendMail 202
                         → hittad i inkorgen efter 3 s
                         → GET /messages/{id}/$value → 200, 693 bytes rå MIME
```

Att `$value` faktiskt ger MIME och inte JSON är värt att ha bevisat — det är den byte-strömmen `mail.saveIncoming` ska skriva som `.eml`, och ett enhetstest mot injicerad `fetch` hade sagt ja oavsett vad Microsoft returnerade.

## Testtenanten

| | |
|---|---|
| Tenant | `QnyxAB.onmicrosoft.com` (Qnyx AB) |
| Brevlåda | `UlrikSjolin@QnyxAB.onmicrosoft.com`, M365 Business Basic |
| App | AVA (dev), single tenant, fyra delegerade scopes, admin-consent givet |

`ms-graph`-miljön pekar om till den nya tenanten; refresh-token:en är den roterade.

## Varför den första tenanten var en återvändsgränd

Dokumenterat så att ingen provar samma väg igen:

- `admin.microsoft.com` skickar `msafed=0` och släpper **inte** in personliga Microsoft-konton
- ett gästkonto (`…#EXT#@…`) kan administrera Entra men aldrig äga en brevlåda
- faktureringsprofilen gick inte att skapa — organisationsprofilen som köpflödet bygger på saknas i en tenant som uppstått som biprodukt av en gmail-inloggning

Developer Programs gratis E5-sandbox är ingen väg ut heller: den kräver Visual Studio Professional eller Enterprise, och Dev Essentials kvalificerar inte.

Refs #1069, #1074

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9UB9at5Tpr1A6sYEXomxB