### PR TITLE
feat(msgraph): token-store med rotation och write-back

### DIFF
--- a/.github/workflows/ms-graph-e2e.yml
+++ b/.github/workflows/ms-graph-e2e.yml
@@ -1,0 +1,91 @@
+# Microsoft Graph E2E — mot riktig Entra + riktig brevlåda (#1073, #1074).
+#
+# Enhetstesterna för Graph-koden kör med injicerad `fetch` och bevisar att VÅR
+# kod är konsekvent. De kan inte upptäcka att Microsoft ändrat sig, att ett fält
+# heter något annat, eller att `$value` slutat ge MIME. Det här flödet går mot
+# skarp Graph.
+#
+# ## Rotationen — hela skälet till att jobbet ser ut som det gör
+#
+# Entra utfärdar en NY refresh-token vid varje refresh och dödar den gamla. En
+# token i en secret räcker därför till EXAKT EN körning om vi inte skriver
+# tillbaka den nya. Steget "Spara roterad refresh-token" gör det, och det körs
+# med `if: always()` eftersom token:en roterar redan i första anropet — även om
+# smoken senare fallerar är den gamla token:en död.
+#
+# Går write-back:en fel måste consent-rundan göras om:
+#   AVA_MS_CLIENT_ID=… AVA_MS_CLIENT_SECRET=… AVA_MS_TENANT_ID=… \
+#     AVA_MS_REDIRECT_URI=http://localhost:53682/callback bun run ms:connect --listen
+# Se docs/ms-graph.md.
+
+name: MS Graph E2E
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/lib/server/integrations/msgraph/**"
+      - "src/lib/server/integrations/token-store.ts"
+      - "tooling/scripts/msgraph-*.ts"
+      - "tooling/scripts/rotated-token.ts"
+      - ".github/workflows/ms-graph-e2e.yml"
+  schedule:
+    # 04:41 UTC — udda minut, och skild från Fortnox 04:17 så de inte konkurrerar
+    # om runners. Nattlig körning håller också refresh-token:en vid liv:
+    # Entra dödar den efter en tids inaktivitet.
+    - cron: "41 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Aldrig två samtidiga körningar: de skulle refresha parallellt och slå ut
+# varandras tokens (den ena rotationen ogiltigförklarar den andras).
+concurrency:
+  group: ms-graph-e2e
+  cancel-in-progress: false
+
+jobs:
+  ms-graph-e2e:
+    name: MS Graph E2E (Qnyx-tenant)
+    # Avstängningsknapp utan att redigera workflowen. MÅSTE ligga på REPO-nivå
+    # (`gh variable set` utan `--env`): ett job-`if` utvärderas INNAN
+    # `environment:` resolvas, så en environment-variabel är alltid tom här och
+    # jobbet hade aldrig kört. Det kostade Fortnox ett CI-varv (#1038).
+    if: vars.AVA_MS_CI_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: ms-graph
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ./.github/actions/bun-setup
+
+      - name: Graph-smoke (refresh → /me → brevlåda)
+        id: smoke
+        env:
+          AVA_MS_CLIENT_ID: ${{ secrets.AVA_MS_CLIENT_ID }}
+          AVA_MS_CLIENT_SECRET: ${{ secrets.AVA_MS_CLIENT_SECRET }}
+          AVA_MS_TENANT_ID: ${{ secrets.AVA_MS_TENANT_ID }}
+          AVA_MS_REFRESH_TOKEN: ${{ secrets.AVA_MS_REFRESH_TOKEN }}
+          AVA_MS_TEST_MAILBOX: ${{ vars.AVA_MS_TEST_MAILBOX }}
+        run: bun run ms:smoke
+
+      # Måste köras även när smoken fallerade: token:en roterade i det FÖRSTA
+      # anropet, så den gamla är död oavsett hur körningen slutade. Hoppar över
+      # sig själv om scriptet inte hann emitta något (t.ex. saknad secret).
+      - name: Spara roterad refresh-token
+        if: always() && steps.smoke.outputs.refresh_token != ''
+        env:
+          GH_TOKEN: ${{ secrets.AVA_MS_ROTATE_PAT }}
+          NEW_TOKEN: ${{ steps.smoke.outputs.refresh_token }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::AVA_MS_ROTATE_PAT saknas — den roterade token:en kan inte sparas."
+            echo "::error::Nästa körning kommer att misslyckas. Uppdatera AVA_MS_REFRESH_TOKEN manuellt."
+            exit 1
+          fi
+          # INTE `--body -`: gh har ingen "-"-konvention för --body (bara för
+          # --env-file), så värdet hade lagrats literalt som "-" och nästa
+          # körning dött i auth. Utan --body läser gh stdin.
+          printf '%s' "$NEW_TOKEN" | gh secret set AVA_MS_REFRESH_TOKEN \
+            --repo "${{ github.repository }}" --env ms-graph

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "ava:mcp": "bun tooling/ava-cli/ava-mcp.ts",
     "fortnox:connect": "bun tooling/scripts/fortnox-connect.ts",
     "ms:connect": "bun tooling/scripts/ms-connect.ts",
+    "ms:smoke": "bun tooling/scripts/msgraph-smoke.ts",
     "fortnox:e2e": "bun tooling/scripts/fortnox-e2e.ts",
     "fortnox:bookkeeping": "bun tooling/scripts/fortnox-bookkeeping-e2e.ts",
     "fortnox:series": "bun tooling/scripts/fortnox-series.ts",

--- a/src/lib/server/integrations/fortnox/token-store.ts
+++ b/src/lib/server/integrations/fortnox/token-store.ts
@@ -1,38 +1,24 @@
 /**
  * Persistens för Fortnox-tokens (#82).
  *
- * Refresh-token roterar vid varje refresh, så den MÅSTE överleva
- * server-omstarter — annars tappar vi kopplingen och byrån måste re-autha.
- * Lagringen är abstraherad: in-memory (test/dev) eller `VaultFortnoxTokenStore`
- * backad av secrets-valvet (#79) i skarp drift — samma interface, resten av
- * connectorn oförändrad.
+ * Formen är gemensam med Graph (#1073) — samma roterande refresh-token, samma
+ * krav på att överleva omstart — så mekaniken bor i `../token-store`. Här
+ * återstår bara att binda den till Fortnox token-schema och valv-nyckel.
+ *
+ * Klassnamnen behålls: `FortnoxClient` och hela e2e-riggen konstruerar dem, och
+ * ett namnbyte hade rört kod som inte har med #1073 att göra.
  */
 
 import type { SecretsVault } from "../../secrets/vault";
+import { InMemoryTokenStore, VaultTokenStore, type TokenStore } from "../token-store";
 import { fortnoxStoredTokensSchema, type FortnoxStoredTokens } from "./schema";
 
-export interface FortnoxTokenStore {
-  /** Hämta sparade tokens, eller null om byrån inte auth:at än. */
-  load(): Promise<FortnoxStoredTokens | null>;
-  /** Spara (skriv över) tokens — anropas efter varje refresh (rotation!). */
-  save(tokens: FortnoxStoredTokens): Promise<void>;
-}
+export type FortnoxTokenStore = TokenStore<FortnoxStoredTokens>;
 
 /** In-memory-store för tester och engångskörningar. Persisterar inget. */
-export class InMemoryFortnoxTokenStore implements FortnoxTokenStore {
-  private tokens: FortnoxStoredTokens | null;
-
+export class InMemoryFortnoxTokenStore extends InMemoryTokenStore<FortnoxStoredTokens> {
   constructor(initial?: FortnoxStoredTokens) {
-    this.tokens = initial ?? null;
-  }
-
-  async load(): Promise<FortnoxStoredTokens | null> {
-    return this.tokens;
-  }
-
-  async save(tokens: FortnoxStoredTokens): Promise<void> {
-    // Strikt parsning även internt — fångar trasig data tidigt.
-    this.tokens = fortnoxStoredTokensSchema.parse(tokens);
+    super(fortnoxStoredTokensSchema, initial);
   }
 }
 
@@ -40,19 +26,8 @@ export class InMemoryFortnoxTokenStore implements FortnoxTokenStore {
  * Persistent store backad av secrets-valvet (#79). Tokens (inkl. den roterande
  * refresh-token:en) lagras krypterat och överlever omstart.
  */
-export class VaultFortnoxTokenStore implements FortnoxTokenStore {
-  constructor(
-    private readonly vault: SecretsVault,
-    private readonly key: string = "fortnox.tokens",
-  ) {}
-
-  async load(): Promise<FortnoxStoredTokens | null> {
-    const raw = await this.vault.get(this.key);
-    if (!raw) return null;
-    return fortnoxStoredTokensSchema.parse(JSON.parse(raw));
-  }
-
-  async save(tokens: FortnoxStoredTokens): Promise<void> {
-    await this.vault.set(this.key, JSON.stringify(fortnoxStoredTokensSchema.parse(tokens)));
+export class VaultFortnoxTokenStore extends VaultTokenStore<FortnoxStoredTokens> {
+  constructor(vault: SecretsVault, key = "fortnox.tokens") {
+    super(vault, fortnoxStoredTokensSchema, key);
   }
 }

--- a/src/lib/server/integrations/msgraph/token-store.ts
+++ b/src/lib/server/integrations/msgraph/token-store.ts
@@ -1,0 +1,25 @@
+/**
+ * Persistens för Graph-tokens (#1073).
+ *
+ * Entra utfärdar en ny refresh-token vid varje refresh och den gamla ska
+ * kastas. Utan write-back räcker ett token i en secret till **exakt en
+ * körning** — samma failure-mode som Fortnox, och samma lösning.
+ */
+
+import type { SecretsVault } from "../../secrets/vault";
+import { InMemoryTokenStore, VaultTokenStore } from "../token-store";
+import { msStoredTokensSchema, type MsStoredTokens } from "./schema";
+
+/** In-memory-store för tester och engångskörningar (t.ex. CI). */
+export class InMemoryGraphTokenStore extends InMemoryTokenStore<MsStoredTokens> {
+  constructor(initial?: MsStoredTokens) {
+    super(msStoredTokensSchema, initial);
+  }
+}
+
+/** Persistent store backad av secrets-valvet (#79, ADR 0008). */
+export class VaultGraphTokenStore extends VaultTokenStore<MsStoredTokens> {
+  constructor(vault: SecretsVault, key = "msgraph.tokens") {
+    super(vault, msStoredTokensSchema, key);
+  }
+}

--- a/src/lib/server/integrations/token-store.ts
+++ b/src/lib/server/integrations/token-store.ts
@@ -1,0 +1,67 @@
+/**
+ * Persistens för OAuth-tokens (#1073).
+ *
+ * Fortnox och Microsoft Graph har samma problem och samma lösning: refresh-
+ * token roterar vid varje användning, så den MÅSTE överleva en omstart —
+ * annars tappar vi kopplingen och byrån får autentisera om. Lagringen är
+ * abstraherad: in-memory (test/engångskörningar) eller valv-backad (#79,
+ * ADR 0008) i skarp drift, med samma interface.
+ *
+ * Generisk över token-formen i stället för en kopia per integration. Schemat
+ * skickas in så att strikt parsning sker även internt
+ * ([[feedback-zod-strict-parsing]]) — en korrupt blob i valvet ska fälla vid
+ * läsning, inte flöda vidare som feltypad data.
+ */
+
+import type { ZodType } from "zod";
+
+import type { SecretsVault } from "../secrets/vault";
+
+export interface TokenStore<T> {
+  /** Hämta sparade tokens, eller null om ingen anslutning gjorts än. */
+  load(): Promise<T | null>;
+  /** Spara (skriv över) tokens — anropas efter varje refresh (rotation!). */
+  save(tokens: T): Promise<void>;
+}
+
+/** In-memory-store för tester och engångskörningar. Persisterar inget. */
+export class InMemoryTokenStore<T> implements TokenStore<T> {
+  private tokens: T | null;
+
+  constructor(
+    private readonly schema: ZodType<T>,
+    initial?: T,
+  ) {
+    this.tokens = initial ?? null;
+  }
+
+  async load(): Promise<T | null> {
+    return this.tokens;
+  }
+
+  async save(tokens: T): Promise<void> {
+    this.tokens = this.schema.parse(tokens);
+  }
+}
+
+/**
+ * Persistent store backad av secrets-valvet. Tokens (inkl. den roterande
+ * refresh-token:en) lagras krypterat och överlever omstart.
+ */
+export class VaultTokenStore<T> implements TokenStore<T> {
+  constructor(
+    private readonly vault: SecretsVault,
+    private readonly schema: ZodType<T>,
+    private readonly key: string,
+  ) {}
+
+  async load(): Promise<T | null> {
+    const raw = await this.vault.get(this.key);
+    if (!raw) return null;
+    return this.schema.parse(JSON.parse(raw));
+  }
+
+  async save(tokens: T): Promise<void> {
+    await this.vault.set(this.key, JSON.stringify(this.schema.parse(tokens)));
+  }
+}

--- a/test/unit/server/integrations/msgraph/token-store.test.ts
+++ b/test/unit/server/integrations/msgraph/token-store.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest-compat";
+import type { MsStoredTokens } from "@/lib/server/integrations/msgraph/schema";
+import { InMemoryGraphTokenStore, VaultGraphTokenStore } from "@/lib/server/integrations/msgraph/token-store";
+import type { SecretsVault } from "@/lib/server/secrets/vault";
+
+class MemVault implements SecretsVault {
+  readonly m = new Map<string, string>();
+  async get(k: string) {
+    return this.m.get(k) ?? null;
+  }
+  async set(k: string, v: string) {
+    this.m.set(k, v);
+  }
+  async delete(k: string) {
+    this.m.delete(k);
+  }
+}
+
+const tokens = (rt: string): MsStoredTokens => ({
+  accessToken: "at",
+  refreshToken: rt,
+  accessTokenExpiresAt: 1_000,
+});
+
+describe("VaultGraphTokenStore", () => {
+  it("save/load roundtrip via valvet", async () => {
+    const store = new VaultGraphTokenStore(new MemVault());
+    await store.save(tokens("rt-1"));
+    expect((await store.load())?.refreshToken).toBe("rt-1");
+  });
+
+  // Rotationen ÄR skrivningen. Skrev save inte över hade nästa körning
+  // autentiserat med en död token.
+  it("save skriver över (rotation)", async () => {
+    const store = new VaultGraphTokenStore(new MemVault());
+    await store.save(tokens("rt-1"));
+    await store.save(tokens("rt-2"));
+    expect((await store.load())?.refreshToken).toBe("rt-2");
+  });
+
+  it("load → null när valvet är tomt", async () => {
+    expect(await new VaultGraphTokenStore(new MemVault()).load()).toBeNull();
+  });
+
+  // Egen nyckel — annars hade Graph och Fortnox skrivit över varandra i samma valv.
+  it("använder en egen valv-nyckel, skild från Fortnox", async () => {
+    const vault = new MemVault();
+    await new VaultGraphTokenStore(vault).save(tokens("rt-x"));
+    expect(vault.m.has("msgraph.tokens")).toBe(true);
+    expect(vault.m.has("fortnox.tokens")).toBe(false);
+  });
+
+  // En manipulerad eller trasig blob ska fälla vid LÄSNING, inte flöda vidare
+  // som feltypad data och smälla någon annanstans.
+  it("kastar på korrupt innehåll i valvet", async () => {
+    const vault = new MemVault();
+    await vault.set("msgraph.tokens", JSON.stringify({ accessToken: "at" }));
+    await expect(new VaultGraphTokenStore(vault).load()).rejects.toThrow();
+  });
+});
+
+describe("InMemoryGraphTokenStore", () => {
+  it("börjar tom", async () => {
+    expect(await new InMemoryGraphTokenStore().load()).toBeNull();
+  });
+
+  it("bär initiala tokens", async () => {
+    expect((await new InMemoryGraphTokenStore(tokens("rt-0")).load())?.refreshToken).toBe("rt-0");
+  });
+
+  it("parsar strikt även internt", async () => {
+    const store = new InMemoryGraphTokenStore();
+    await expect(store.save({ accessToken: "", refreshToken: "r", accessTokenExpiresAt: 1 })).rejects.toThrow();
+  });
+});

--- a/test/unit/tooling/rotated-token.test.ts
+++ b/test/unit/tooling/rotated-token.test.ts
@@ -1,0 +1,66 @@
+import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest-compat";
+import { InMemoryGraphTokenStore } from "@/lib/server/integrations/msgraph/token-store";
+import { emitRotatedToken } from "../../../tooling/scripts/rotated-token";
+
+/**
+ * Write-back:en (#1073) är det som gör obevakad drift möjlig. Går den sönder
+ * tyst räcker refresh-token:en till EN körning, och nästa dör i auth långt från
+ * orsaken. Därför testas den — inte för att koden är svår, utan för att felet
+ * är dyrt och osynligt.
+ */
+const tokens = (rt: string) => ({ accessToken: "at", refreshToken: rt, accessTokenExpiresAt: 1_000 });
+
+let dir: string;
+let out: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "ava-rot-"));
+  out = join(dir, "github_output");
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("emitRotatedToken", () => {
+  it("skriver refresh_token i GITHUB_OUTPUT-format", async () => {
+    const store = new InMemoryGraphTokenStore(tokens("rt-ny"));
+    await emitRotatedToken(store, out);
+    expect(readFileSync(out, "utf8")).toBe("refresh_token=rt-ny\n");
+  });
+
+  /**
+   * Step-outputs maskeras INTE automatiskt av GitHub. Utan `::add-mask::` kan
+   * ett senare steg som ekar sin env läcka token:en i klartext i loggen.
+   */
+  it("maskerar token:en innan den skrivs", async () => {
+    const lines: string[] = [];
+    const original = console.log;
+    console.log = (m: unknown) => void lines.push(String(m));
+    try {
+      await emitRotatedToken(new InMemoryGraphTokenStore(tokens("hemlig")), out);
+    } finally {
+      console.log = original;
+    }
+    expect(lines[0]).toBe("::add-mask::hemlig");
+  });
+
+  // Lokala körningar har ingen $GITHUB_OUTPUT och ska inte behöva bry sig.
+  it("är en no-op utan GITHUB_OUTPUT", async () => {
+    await emitRotatedToken(new InMemoryGraphTokenStore(tokens("rt")), undefined);
+    expect(existsSync(out)).toBe(false);
+  });
+
+  // Tomt store = ingen refresh hann ske. Att skriva en tom rad hade fått
+  // write-back-steget att köra och skriva över secreten med ingenting.
+  it("skriver inget när storen är tom", async () => {
+    await emitRotatedToken(new InMemoryGraphTokenStore(), out);
+    expect(existsSync(out)).toBe(false);
+  });
+
+  it("lägger till, skriver inte över befintlig output", async () => {
+    await emitRotatedToken(new InMemoryGraphTokenStore(tokens("a")), out);
+    await emitRotatedToken(new InMemoryGraphTokenStore(tokens("b")), out);
+    expect(readFileSync(out, "utf8")).toBe("refresh_token=a\nrefresh_token=b\n");
+  });
+});

--- a/tooling/scripts/fortnox-harness.ts
+++ b/tooling/scripts/fortnox-harness.ts
@@ -14,7 +14,6 @@
  *   AVA_FORTNOX_ACCOUNT_TYPE     "service" → service-konto i st.f. användarsamtycke
  */
 
-import { appendFileSync } from "node:fs";
 import { FortnoxClient } from "@/lib/server/integrations/fortnox/client";
 import {
   fortnoxConfigSchema, fortnoxKontoMappningSchema,
@@ -129,20 +128,5 @@ export function assertVoucherDelta(
   console.log(`  ✓ Delta: exakt ${added.length} nya verifikat (${added.join(", ") || "inga"}) — inget mer`);
 }
 
-/**
- * Skriv den roterade refresh-token:en till `$GITHUB_OUTPUT`. ALDRIG till
- * stdout — GitHub maskerar bara det den känner till. Anropas direkt efter
- * första refreshen: den gamla token:en är död från den sekunden, så tappas den
- * nya kan nästa körning inte auth:a alls.
- */
-export async function emitRotatedToken(store: InMemoryFortnoxTokenStore): Promise<void> {
-  const out = process.env.GITHUB_OUTPUT;
-  if (!out) return;
-  const rotated = await store.load();
-  if (!rotated) return;
-  // Step-outputs maskeras INTE automatiskt — ::add-mask:: gör att token:en
-  // redigeras bort ur loggen om ett senare steg råkar eka sin env.
-  console.log(`::add-mask::${rotated.refreshToken}`);
-  appendFileSync(out, `refresh_token=${rotated.refreshToken}\n`);
-  console.log("• Roterad refresh-token skriven till GITHUB_OUTPUT (maskerad).");
-}
+// `emitRotatedToken` bor i ./rotated-token — Graph behöver exakt samma sak (#1073).
+export { emitRotatedToken } from "./rotated-token";

--- a/tooling/scripts/msgraph-harness.ts
+++ b/tooling/scripts/msgraph-harness.ts
@@ -1,0 +1,79 @@
+/**
+ * Gemensam uppsättning för Graph-skripten (#1073).
+ *
+ * Speglar `fortnox-harness.ts`: samma env-läsning, samma "starta med utgången
+ * access-token så att FÖRSTA anropet tvingas refresha", samma write-back av
+ * den roterade token:en.
+ *
+ * Env (se docs/ms-graph.md):
+ *   AVA_MS_CLIENT_ID / _CLIENT_SECRET / _TENANT_ID / _REFRESH_TOKEN  obligatoriska
+ *   AVA_MS_TEST_MAILBOX   brevlådan e2e:t skickar till och läser ur
+ *   AVA_MS_REDIRECT_URI   bara för schemat; token-bytet använder den inte
+ */
+
+import { refreshTokens } from "@/lib/server/integrations/msgraph/oauth";
+import {
+  msGraphConfigSchema, MS_DEFAULT_SCOPES, MS_GRAPH_BASE,
+  type MsGraphConfig,
+} from "@/lib/server/integrations/msgraph/schema";
+import { InMemoryGraphTokenStore } from "@/lib/server/integrations/msgraph/token-store";
+
+/** Obligatorisk env — avbryter med exit 2 och en läsbar hänvisning. */
+export function required(name: string): string {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`✗ ${name} saknas. Se docs/ms-graph.md för vilka secrets som krävs.`);
+    process.exit(2);
+  }
+  return v;
+}
+
+export function buildConfig(): MsGraphConfig {
+  return msGraphConfigSchema.parse({
+    clientId: required("AVA_MS_CLIENT_ID"),
+    clientSecret: required("AVA_MS_CLIENT_SECRET"),
+    tenantId: required("AVA_MS_TENANT_ID"),
+    // Token-endpointen bryr sig inte om redirect_uri vid refresh_token-grant,
+    // men schemat kräver en giltig URL. Loopbacken är den registrerade.
+    redirectUri: process.env.AVA_MS_REDIRECT_URI ?? "http://localhost:53682/callback",
+    scopes: [...MS_DEFAULT_SCOPES],
+  });
+}
+
+/**
+ * En minimal Graph-klient. Inte en generell SDK — bara det e2e:t behöver, med
+ * `Authorization` och bas-URL på ETT ställe så att ingen anropsplats kan glömma
+ * dem.
+ */
+export class GraphSmokeClient {
+  constructor(
+    private readonly accessToken: string,
+    private readonly base: string = MS_GRAPH_BASE,
+  ) {}
+
+  /** GET som JSON. Kastar med Graphs egen felkropp — den säger vad som var fel. */
+  async get<T>(path: string): Promise<T> {
+    const res = await fetch(`${this.base}/v1.0${path}`, {
+      headers: { Authorization: `Bearer ${this.accessToken}` },
+    });
+    if (!res.ok) throw new Error(`Graph GET ${path} → ${res.status}: ${(await res.text()).slice(0, 300)}`);
+    return (await res.json()) as T;
+  }
+}
+
+/**
+ * Refresha OMEDELBART och returnera klient + store.
+ *
+ * Refreshen görs här, inte lat vid första anropet, av ett skäl som kostade
+ * Fortnox en körning: den roterade token:en måste kunna skrivas tillbaka även
+ * om resten av körningen faller. Anroparen ska kunna göra
+ * `emitRotatedToken(store)` som allra första sak efter det här.
+ */
+export async function connectGraph(
+  config: MsGraphConfig = buildConfig(),
+): Promise<{ client: GraphSmokeClient; store: InMemoryGraphTokenStore }> {
+  const store = new InMemoryGraphTokenStore();
+  const tokens = await refreshTokens(config, required("AVA_MS_REFRESH_TOKEN"));
+  await store.save(tokens);
+  return { client: new GraphSmokeClient(tokens.accessToken), store };
+}

--- a/tooling/scripts/msgraph-smoke.ts
+++ b/tooling/scripts/msgraph-smoke.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env bun
+/**
+ * Graph-smoke: bevisar att token-kedjan håller (#1073).
+ *
+ * Det här är INTE mail-e2e:t (#1074). Det enda den här körningen ska visa är
+ * att rotationen fungerar obevakat — och det bevisas inte av en grön körning,
+ * utan av **två i rad** där den andra autentiserar med token:en den första
+ * skrev tillbaka. Därför är den avsiktligt liten: allt som kan fela av andra
+ * skäl hör hemma i #1074.
+ *
+ * Två kontroller, båda med ett syfte:
+ *
+ *  - `GET /me` — att access-token:en faktiskt DUGER. Att token-endpointen
+ *    svarade 200 säger inget om att Graph accepterar resultatet.
+ *  - att brevlådan finns — `mail` är `null` för ett konto utan
+ *    Exchange-licens, och då kommer #1074 att dö på `MailboxNotEnabledForRESTAPI`
+ *    med ett felmeddelande som inte pekar på licensen. Bättre att fälla här.
+ *
+ * Kör i CI via .github/workflows/ms-graph-e2e.yml. Lokalt:
+ *   AVA_MS_CLIENT_ID=… AVA_MS_CLIENT_SECRET=… AVA_MS_TENANT_ID=… \
+ *     AVA_MS_REFRESH_TOKEN=… bun run ms:smoke
+ */
+
+import { connectGraph } from "./msgraph-harness";
+import { emitRotatedToken } from "./rotated-token";
+
+interface GraphMe {
+  readonly userPrincipalName: string;
+  readonly mail: string | null;
+}
+
+async function main(): Promise<void> {
+  const { client, store } = await connectGraph();
+
+  // FÖRST av allt, före något som kan fela: den gamla token:en är redan död.
+  await emitRotatedToken(store);
+
+  const me = await client.get<GraphMe>("/me");
+  console.log(`• Inloggad som ${me.userPrincipalName}`);
+
+  if (!me.mail) {
+    console.error(`✗ ${me.userPrincipalName} har ingen brevlåda (mail = null).`);
+    console.error("  Kontot saknar Exchange-licens. Se docs/ms-graph.md.");
+    process.exit(1);
+  }
+  console.log(`• Brevlåda: ${me.mail}`);
+
+  const expected = process.env.AVA_MS_TEST_MAILBOX;
+  if (expected && expected.toLowerCase() !== me.mail.toLowerCase()) {
+    // Inte ett fel: consent-rundan kan medvetet ha gjorts som någon annan.
+    // Men det är värt att synas, för #1074 skickar TILL AVA_MS_TEST_MAILBOX.
+    console.log(`⚠ AVA_MS_TEST_MAILBOX är ${expected}, men token:en tillhör ${me.mail}.`);
+  }
+
+  console.log("✓ Token-kedjan håller. Kör igen för att bevisa rotationen.");
+}
+
+main().catch((e: unknown) => {
+  console.error(`✗ ${e instanceof Error ? e.message : String(e)}`);
+  process.exitCode = 1;
+});

--- a/tooling/scripts/rotated-token.ts
+++ b/tooling/scripts/rotated-token.ts
@@ -1,0 +1,46 @@
+/**
+ * Write-back av en roterad refresh-token till `$GITHUB_OUTPUT` (#1073).
+ *
+ * Både Fortnox och Entra utfärdar en NY refresh-token vid varje refresh och
+ * dödar den gamla. En secret utan write-back räcker därför till exakt en
+ * körning — och nästa körning dör i auth, långt från orsaken.
+ *
+ * Tre saker Fortnox lärde oss, och som gäller ordagrant för Graph:
+ *
+ *  1. **Emitta direkt efter FÖRSTA refreshen.** Den gamla token:en är död från
+ *     den sekunden. Faller något senare i körningen är den nya förlorad om den
+ *     inte redan skrivits ut.
+ *  2. **Write-back-steget i workflowet måste köras med `if: always()`**, av
+ *     samma skäl.
+ *  3. **Step-outputs maskeras INTE automatiskt.** `::add-mask::` måste skrivas
+ *     innan värdet går till `$GITHUB_OUTPUT`, annars kan ett senare steg eka
+ *     det i klartext.
+ */
+
+import { appendFileSync } from "node:fs";
+
+import type { TokenStore } from "@/lib/server/integrations/token-store";
+
+/** Det enda vi behöver av en token-shape här. */
+interface HasRefreshToken {
+  readonly refreshToken: string;
+}
+
+/**
+ * Skriv storens nuvarande refresh-token till `$GITHUB_OUTPUT` som `refresh_token`.
+ *
+ * Tyst no-op utanför GitHub Actions (ingen `$GITHUB_OUTPUT`) och när storen är
+ * tom — lokala körningar ska inte behöva bry sig, och ett tomt store betyder
+ * att ingen refresh hunnit ske.
+ */
+export async function emitRotatedToken<T extends HasRefreshToken>(
+  store: TokenStore<T>,
+  outPath: string | undefined = process.env.GITHUB_OUTPUT,
+): Promise<void> {
+  if (!outPath) return;
+  const rotated = await store.load();
+  if (!rotated) return;
+  console.log(`::add-mask::${rotated.refreshToken}`);
+  appendFileSync(outPath, `refresh_token=${rotated.refreshToken}\n`);
+  console.log("• Roterad refresh-token skriven till GITHUB_OUTPUT (maskerad).");
+}


### PR DESCRIPTION
Entra utfärdar en ny refresh-token vid varje refresh och dödar den gamla. **Utan write-back räcker ett token i en secret till exakt en körning**, och nästa dör i auth långt från orsaken.

## Mindre kod, inte mer

Mekaniken var redan bevisad i drift för Fortnox men låg inbakad i Fortnox-modulen. Den lyfts ut generisk i stället för att kopieras:

- `src/lib/server/integrations/token-store.ts` — `TokenStore<T>` + in-memory och valv-backad impl, parametriserad på zod-schema och valv-nyckel
- Fortnox egna klasser blir **tunna subklasser** som binder schema och nyckel → `FortnoxClient` och hela e2e-riggen är oförändrade, och deras befintliga tester är gröna utan ändring
- `emitRotatedToken` flyttar till `tooling/scripts/rotated-token.ts`; Fortnox re-exporterar den

## Smoke-scriptet är avsiktligt litet

Det ska bevisa EN sak — att rotationen håller obevakat. Och det bevisas inte av en grön körning, utan av **två i rad** där den andra autentiserar med token:en den första skrev tillbaka. Allt som kan fela av andra skäl hör hemma i #1074.

Två kontroller, båda med syfte:

| Kontroll | Varför |
|---|---|
| `GET /me` | att access-token:en faktiskt **duger** — att token-endpointen svarade 200 säger inget om att Graph accepterar resultatet |
| `mail != null` | fäller tidigt när kontot saknar Exchange-licens; annars dyker det upp i #1074 som `MailboxNotEnabledForRESTAPI`, ett fel som inte pekar på licensen |

## Workflowet bär Fortnox tre dyrköpta lärdomar

1. Emitta token:en **direkt efter första refreshen** — den gamla är död från den sekunden
2. Write-back-steget med **`if: always()`** — av samma skäl
3. **`::add-mask::`** före `$GITHUB_OUTPUT` — step-outputs maskeras inte automatiskt

Plus enable-flaggan som **repo**-variabel, inte environment: ett job-`if` utvärderas innan `environment:` resolvas och hade alltid varit tom.

## Miljön är förberedd

`ms-graph` har `AVA_MS_ROTATE_PAT` satt och verifierad med probe-kommandot ur #1071 (skriv + ta bort en env-secret). `AVA_MS_CI_ENABLED` sätts när den här landat, och då körs workflowet två gånger som acceptansbevis.

Refs #1073, #1069

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9UB9at5Tpr1A6sYEXomxB