### PR TITLE
feat(msgraph): e2e mot riktig Graph — skicka, läs MIME, spara, verifiera

### DIFF
--- a/.github/workflows/ms-graph-e2e.yml
+++ b/.github/workflows/ms-graph-e2e.yml
@@ -3,7 +3,8 @@
 # Enhetstesterna för Graph-koden kör med injicerad `fetch` och bevisar att VÅR
 # kod är konsekvent. De kan inte upptäcka att Microsoft ändrat sig, att ett fält
 # heter något annat, eller att `$value` slutat ge MIME. Det här flödet går mot
-# skarp Graph.
+# skarp Graph: sendMail → polla → $value → mail.saveIncoming → läs tillbaka och
+# jämför byte för byte (#1074).
 #
 # ## Rotationen — hela skälet till att jobbet ser ut som det gör
 #
@@ -11,7 +12,7 @@
 # token i en secret räcker därför till EXAKT EN körning om vi inte skriver
 # tillbaka den nya. Steget "Spara roterad refresh-token" gör det, och det körs
 # med `if: always()` eftersom token:en roterar redan i första anropet — även om
-# smoken senare fallerar är den gamla token:en död.
+# något senare i körningen fallerar är den gamla token:en död.
 #
 # Går write-back:en fel måste consent-rundan göras om:
 #   AVA_MS_CLIENT_ID=… AVA_MS_CLIENT_SECRET=… AVA_MS_TENANT_ID=… \
@@ -26,6 +27,8 @@ on:
     paths:
       - "src/lib/server/integrations/msgraph/**"
       - "src/lib/server/integrations/token-store.ts"
+      - "src/lib/client/graph/**"
+      - "src/lib/server/routers/mail.ts"
       - "tooling/scripts/msgraph-*.ts"
       - "tooling/scripts/rotated-token.ts"
       - ".github/workflows/ms-graph-e2e.yml"
@@ -54,7 +57,7 @@ jobs:
     # jobbet hade aldrig kört. Det kostade Fortnox ett CI-varv (#1038).
     if: vars.AVA_MS_CI_ENABLED == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     environment: ms-graph
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -70,14 +73,45 @@ jobs:
           AVA_MS_TEST_MAILBOX: ${{ vars.AVA_MS_TEST_MAILBOX }}
         run: bun run ms:smoke
 
+      # Mail-e2e:t behöver en körande AVA-stack: det sparar mailet på ett
+      # riktigt ärende och läser tillbaka bytes:en därifrån. Smoken ovan har
+      # redan fällt om auth är trasig — då byggs ingen container i onödan.
+      - name: Starta server-first-stacken
+        run: |
+          bun run server-first:build
+          docker compose -f tooling/docker/docker-compose.server-first.yml up -d --build --wait --wait-timeout 180
+          AVA_DATABASE_URL=postgres://ava:ava@localhost:5433/ava_test bun run db:migrate
+
+      # Refresh-token:en är redan förbrukad av smoken — därför den roterade
+      # från dess output, inte secreten. Faller det här steget skrivs ändå
+      # smokens token tillbaka av write-back-steget nedan.
+      - name: Mail-E2E (skicka → läs MIME → spara → verifiera)
+        id: mail
+        env:
+          AVA_MS_CLIENT_ID: ${{ secrets.AVA_MS_CLIENT_ID }}
+          AVA_MS_CLIENT_SECRET: ${{ secrets.AVA_MS_CLIENT_SECRET }}
+          AVA_MS_TENANT_ID: ${{ secrets.AVA_MS_TENANT_ID }}
+          AVA_MS_REFRESH_TOKEN: ${{ steps.smoke.outputs.refresh_token || secrets.AVA_MS_REFRESH_TOKEN }}
+          AVA_MS_TEST_MAILBOX: ${{ vars.AVA_MS_TEST_MAILBOX }}
+          SERVER_URL: http://localhost:3001
+          AVA_DATABASE_URL: postgres://ava:ava@localhost:5433/ava_test
+          AVA_ORGANIZATION_ID: "00000000-0000-0000-0000-000000000001"
+        run: bun tooling/scripts/msgraph-mail-e2e.ts
+
+      - name: Riv ner stacken
+        if: always()
+        run: docker compose -f tooling/docker/docker-compose.server-first.yml down -v
+
       # Måste köras även när smoken fallerade: token:en roterade i det FÖRSTA
       # anropet, så den gamla är död oavsett hur körningen slutade. Hoppar över
       # sig själv om scriptet inte hann emitta något (t.ex. saknad secret).
       - name: Spara roterad refresh-token
-        if: always() && steps.smoke.outputs.refresh_token != ''
+        if: always() && (steps.mail.outputs.refresh_token != '' || steps.smoke.outputs.refresh_token != '')
         env:
           GH_TOKEN: ${{ secrets.AVA_MS_ROTATE_PAT }}
-          NEW_TOKEN: ${{ steps.smoke.outputs.refresh_token }}
+          # Mail-e2e:t refreshar en gång till — dess token är den färskaste.
+          # Föll det steget är smokens token den sista giltiga.
+          NEW_TOKEN: ${{ steps.mail.outputs.refresh_token || steps.smoke.outputs.refresh_token }}
         run: |
           if [ -z "$GH_TOKEN" ]; then
             echo "::error::AVA_MS_ROTATE_PAT saknas — den roterade token:en kan inte sparas."

--- a/docs/ms-graph.md
+++ b/docs/ms-graph.md
@@ -53,6 +53,56 @@ går igenom. Regressionstestet asserterar på **råsträngen** i URL:en, efterso
 `url.searchParams.get(…)` decodar och skulle visa samma svar åt båda hållen —
 precis den blindhet som lät Fortnox-buggen ligga kvar.
 
+## E2E-flödet
+
+Två steg i `ms-graph-e2e.yml`, i den ordningen med flit:
+
+| Steg | Bevisar | Varför före/efter |
+|---|---|---|
+| `ms:smoke` | att token-kedjan håller | fäller på 10 sekunder om auth är trasig — då byggs ingen container i onödan |
+| mail-E2E | att integrationen fungerar | behöver en körande AVA-stack |
+
+Mail-E2E:t går hela vägen:
+
+```
+sendMail → polla tills mailet landat → fetchMessageEml ($value, rå MIME)
+         → mail.saveIncoming mot en riktig AVA-stack
+         → läs tillbaka och jämför BYTE FÖR BYTE
+```
+
+Sista steget är poängen. Att Graph svarade 200 säger inget om att rätt bytes
+hamnade i rätt ärende — `document.downloadContent` jämförs mot exakt de bytes
+`$value` gav.
+
+Flödet använder de RIKTIGA funktionerna ur `src/lib/client/graph/graph-mail.ts`,
+inte egna kopior. Ett e2e som återimplementerar det det ska bevisa bevisar
+ingenting — och `graph-mail.ts` är just den fil vars enhetstester kör mot
+injicerad `fetch` och därför är blinda för att Microsoft ändrat sig.
+
+Tre detaljer som är lätta att få fel:
+
+- **Eventuell konsistens.** Ett skickat mail syns inte omedelbart. Testet pollar
+  med tak (30 × 3 s) och ett felmeddelande som pekar på `AVA_MS_TEST_MAILBOX` —
+  inte en fast `sleep`, som blir flakig.
+- **Unikt ämne per körning.** Annars kan testet plocka upp ett mail från en
+  tidigare körning och bli grönt på fel bevis.
+- **`receivedAt` kommer från MAILET**, inte väggklockan, så körningen beter sig
+  likadant oavsett när på dygnet den startar.
+
+Testet raderar sitt eget mail när det är klart. Graph **kan** radera — till
+skillnad från Fortnox verifikat, vars avsaknad av `DELETE` tvingade fram hela
+resonemanget om städbara serier och räkenskapsår.
+
+Lokalt (startar stacken själv):
+
+```bash
+AVA_MS_CLIENT_ID=… AVA_MS_CLIENT_SECRET=… AVA_MS_TENANT_ID=… \
+AVA_MS_REFRESH_TOKEN=… AVA_MS_TEST_MAILBOX=… bun run ms:mail
+```
+
+Refresh-token:en roterar i första anropet — din lokala kopia är förbrukad efter
+körningen. Hämta en ny med `bun run ms:connect --listen`.
+
 ## Miljön `ms-graph` i CI
 
 | Secret | Innehåll |

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "fortnox:connect": "bun tooling/scripts/fortnox-connect.ts",
     "ms:connect": "bun tooling/scripts/ms-connect.ts",
     "ms:smoke": "bun tooling/scripts/msgraph-smoke.ts",
+    "ms:mail": "bash tooling/scripts/msgraph-mail-e2e.sh",
     "fortnox:e2e": "bun tooling/scripts/fortnox-e2e.ts",
     "fortnox:bookkeeping": "bun tooling/scripts/fortnox-bookkeeping-e2e.ts",
     "fortnox:series": "bun tooling/scripts/fortnox-series.ts",

--- a/tooling/scripts/msgraph-mail-e2e.sh
+++ b/tooling/scripts/msgraph-mail-e2e.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Självständig runner för Graph mail-E2E:n (#1074).
+#
+#   AVA_MS_CLIENT_ID=… AVA_MS_CLIENT_SECRET=… AVA_MS_TENANT_ID=… \
+#   AVA_MS_REFRESH_TOKEN=… AVA_MS_TEST_MAILBOX=… \
+#     bash tooling/scripts/msgraph-mail-e2e.sh
+#
+# Kör hela kedjan sendMail → polla → $value (rå MIME) → mail.saveIncoming mot
+# en riktig AVA-stack → läs tillbaka och jämför byte för byte.
+#
+# OBS: refresh-token:en ROTERAR i första anropet. Kör du det här lokalt är
+# secreten i `ms-graph`-miljön oförändrad, men DIN lokala token är förbrukad —
+# använd `bun run ms:connect --listen` för att hämta en ny.
+set -euo pipefail
+
+COMPOSE="tooling/docker/docker-compose.server-first.yml"
+DB_URL="postgres://ava:ava@localhost:5433/ava_test"
+ORG="00000000-0000-0000-0000-000000000001"
+
+cleanup() { docker compose -f "$COMPOSE" down -v >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "▸ Bygger server-first-binären…"
+bun run server-first:build
+
+echo "▸ Startar Postgres + server-first…"
+docker compose -f "$COMPOSE" up -d --build --wait --wait-timeout 180
+
+echo "▸ Applicerar schema…"
+AVA_DATABASE_URL="$DB_URL" bun run db:migrate
+
+echo "▸ Kör Graph mail-E2E…"
+SERVER_URL=http://localhost:3001 \
+AVA_DATABASE_URL="$DB_URL" \
+AVA_ORGANIZATION_ID="$ORG" \
+  bun tooling/scripts/msgraph-mail-e2e.ts

--- a/tooling/scripts/msgraph-mail-e2e.ts
+++ b/tooling/scripts/msgraph-mail-e2e.ts
@@ -1,0 +1,160 @@
+#!/usr/bin/env bun
+/**
+ * Mail-E2E mot riktig Graph (#1074) — kärnan i epicen #1069.
+ *
+ * `graph-mail.ts` är enhetstestad mot injicerad `fetch`. Den kan därför inte
+ * upptäcka att Microsoft ändrat sig, att ett fält heter något annat, eller att
+ * `$value` returnerar något annat än vi tror. Det är exakt luckan där Fortnox
+ * `·`-buggen bodde: full täckning, grönt, och ändå gick INGEN bokföring igenom.
+ *
+ * Därför använder det här flödet de RIKTIGA funktionerna ur `graph-mail.ts` —
+ * inte egna kopior. Ett e2e som återimplementerar det det ska bevisa bevisar
+ * ingenting.
+ *
+ *   sendMail → polla tills mailet landat → fetchMessageEml ($value)
+ *            → mail.saveIncoming mot en riktig AVA-stack
+ *            → läs tillbaka och jämför BYTE FÖR BYTE
+ *
+ * Sista steget är poängen. Att Graph svarade 200 säger inget om att rätt bytes
+ * hamnade i rätt ärende.
+ *
+ * Kör via tooling/scripts/msgraph-mail-e2e.sh (startar stacken) eller i CI.
+ */
+
+import { fetchMessageEml, sendMail, GRAPH_BASE } from "@/lib/client/graph/graph-mail";
+import { asId } from "@/lib/shared/schemas/ids";
+import { assert, clientFor, seedUser, waitForServer, type Ava } from "./e2e-harness";
+import { connectGraph, required } from "./msgraph-harness";
+import { emitRotatedToken } from "./rotated-token";
+
+const USER = "graf@byra.se";
+/** Tak för hur länge vi väntar på att mailet ska landa. Graph är eventuellt
+ *  konsistent — en fast `sleep` blir flakig, en obegränsad väntan hänger CI. */
+const POLL_ATTEMPTS = 30;
+const POLL_INTERVAL_MS = 3_000;
+/** Tidsposten mailet ska bokföra. Explicit, inte härledd — se `receivedAt`. */
+const MAIL_MINUTES = 6;
+
+interface GraphMessageHead {
+  readonly id: string;
+  readonly subject: string;
+  readonly receivedDateTime: string;
+}
+
+/** Sök upp mailet på ÄMNET. Unikt per körning → aldrig en träff från en tidigare. */
+async function findBySubject(token: string, subject: string): Promise<GraphMessageHead | null> {
+  const filter = encodeURIComponent(`subject eq '${subject.replace(/'/g, "''")}'`);
+  const url = `${GRAPH_BASE}/me/messages?$filter=${filter}&$select=id,subject,receivedDateTime`;
+  const res = await fetch(url, { headers: { authorization: `Bearer ${token}` } });
+  if (!res.ok) throw new Error(`Graph sökning misslyckades: HTTP ${res.status} ${(await res.text()).slice(0, 300)}`);
+  const json = (await res.json()) as { value?: GraphMessageHead[] };
+  return json.value?.[0] ?? null;
+}
+
+/** Vänta tills mailet dyker upp. Fel efter taket säger VAD som saknades. */
+async function waitForMail(token: string, subject: string): Promise<GraphMessageHead> {
+  for (let i = 1; i <= POLL_ATTEMPTS; i++) {
+    const hit = await findBySubject(token, subject);
+    if (hit) {
+      console.log(`• Mailet landade efter ~${i * (POLL_INTERVAL_MS / 1000)} s`);
+      return hit;
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+  throw new Error(
+    `Mailet med ämnet "${subject}" dök aldrig upp inom ` +
+    `${(POLL_ATTEMPTS * POLL_INTERVAL_MS) / 1000} s. Kontrollera att ` +
+    `AVA_MS_TEST_MAILBOX är brevlådan token:en tillhör.`,
+  );
+}
+
+/** Städa bort testmailet. Graph KAN radera — till skillnad från Fortnox verifikat. */
+async function deleteMessage(token: string, id: string): Promise<void> {
+  const res = await fetch(`${GRAPH_BASE}/me/messages/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+    headers: { authorization: `Bearer ${token}` },
+  });
+  // Städning får aldrig fälla en grön körning — men tystnad är värre än en rad.
+  if (!res.ok) console.log(`⚠ Kunde inte radera testmailet (HTTP ${res.status}) — städa manuellt.`);
+  else console.log("• Testmailet raderat");
+}
+
+async function createMatter(c: Ava, userId: string, matterNumber: string): Promise<string> {
+  const m = await c.matter.create.mutate({
+    matterNumber,
+    title: "Graph mail-E2E",
+    matterType: "Allmän praktik",
+    paymentMethod: "PRIVAT",
+    responsibleLawyerId: userId,
+  });
+  return m.id;
+}
+
+async function main(): Promise<void> {
+  const mailbox = required("AVA_MS_TEST_MAILBOX");
+  const { store } = await connectGraph();
+
+  // FÖRST av allt: den gamla refresh-token:en är död sedan refreshen ovan.
+  await emitRotatedToken(store);
+  const tokens = await store.load();
+  assert(tokens !== null, "token-store tom efter connectGraph");
+  const token = tokens.accessToken;
+
+  const userId = await seedUser(USER, "Graph-testare");
+  const c = clientFor(USER);
+  await waitForServer(c);
+
+  const stamp = Date.now().toString(36).toUpperCase();
+  const matterId = await createMatter(c, userId, `GRAPH-${stamp}`);
+  // Unikt ämne per körning — annars kan testet plocka upp ett mail från en
+  // tidigare körning och bli grönt på fel bevis.
+  const subject = `AVA E2E ${stamp}`;
+  const bodyText = `Ärendet GRAPH-${stamp}. Genererat av msgraph-mail-e2e.`;
+
+  console.log(`▸ Skickar "${subject}" till ${mailbox} …`);
+  await sendMail({ token, message: { subject, body: bodyText, to: [mailbox] } });
+
+  const msg = await waitForMail(token, subject);
+
+  const { bytes, base64 } = await fetchMessageEml({ token, restId: msg.id });
+  assert(bytes.byteLength > 0, "$value gav noll bytes");
+  const head = new TextDecoder().decode(bytes.slice(0, 200));
+  // Att `$value` ger MIME och inte JSON är en av de saker en mock aldrig kan
+  // avslöja. En RFC822-header i början är det billigaste beviset.
+  assert(/^[A-Za-z-]+:/.test(head), `$value gav inte MIME — började med: ${head.slice(0, 60)}`);
+  console.log(`• Rå MIME hämtad: ${bytes.byteLength} bytes`);
+
+  // `receivedAt` från MAILET, inte väggklockan — körningen ska bete sig likadant
+  // oavsett när på dygnet den startar.
+  const saved = await c.mail.saveIncoming.mutate({
+    matterId: asId<"MatterId">(matterId),
+    emlBase64: base64,
+    subject,
+    receivedAt: msg.receivedDateTime,
+    time: { minutes: MAIL_MINUTES, description: `E-post: ${subject}` },
+  });
+  console.log(`• Sparat på ärendet: ${saved.document.fileName}`);
+
+  // ── Läs TILLBAKA. Att mutationen svarade säger inget om vad som ligger där. ──
+  const listed = await c.document.list.query({ matterId: asId<"MatterId">(matterId) });
+  const doc = listed.documents.find((d) => d.id === saved.document.id);
+  assert(doc !== undefined, "dokumentet finns inte i ärendets dokumentlista");
+  assert(doc.mimeType === "message/rfc822", `fel mimeType: ${doc.mimeType}`);
+  assert(doc.sizeBytes === bytes.byteLength, `fel storlek: ${doc.sizeBytes} ≠ ${bytes.byteLength}`);
+
+  const back = await c.document.downloadContent.query({ documentId: asId<"DocumentId">(saved.document.id) });
+  assert(back.contentBase64 === base64, "innehållet på servern är INTE samma bytes som Graph gav");
+  console.log("• Bytes identiska hela vägen: Graph → AVA → tillbaka");
+
+  assert(saved.timeEntry !== null, "ingen tidspost skapades");
+  assert(saved.timeEntry.minutes === MAIL_MINUTES, `fel antal minuter: ${saved.timeEntry.minutes}`);
+  console.log(`• Tidspost: ${saved.timeEntry.minutes} min`);
+
+  await deleteMessage(token, msg.id);
+  console.log("\n✓ Graph mail-E2E grön — skickat, läst som MIME, sparat och verifierat byte för byte.");
+}
+
+main().catch((e: unknown) => {
+  console.error(`\n✗ ${e instanceof Error ? e.message : String(e)}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Kärnan i epicen #1069.

`graph-mail.ts` är enhetstestad mot injicerad `fetch` och kan därför **inte** upptäcka att Microsoft ändrat sig, att ett fält heter något annat, eller att `$value` returnerar något annat än vi tror. Det är exakt luckan där Fortnox `·`-buggen bodde: full täckning, grönt, och ändå gick *ingen* bokföring igenom.

## Flödet

```
sendMail → polla tills mailet landat → fetchMessageEml ($value, rå MIME)
         → mail.saveIncoming mot en riktig AVA-stack
         → läs tillbaka och jämför BYTE FÖR BYTE
```

Sista steget är poängen. Att Graph svarade 200 säger inget om att rätt bytes hamnade i rätt ärende — `document.downloadContent` jämförs mot exakt de bytes `$value` gav, och `sizeBytes` mot deras längd.

Flödet använder de **riktiga** funktionerna ur `graph-mail.ts`, inte egna kopior. Ett e2e som återimplementerar det det ska bevisa bevisar ingenting.

## Tre detaljer issuen förutsåg

| | Hur |
|---|---|
| Eventuell konsistens | poll med tak (30 × 3 s) och ett fel som pekar på `AVA_MS_TEST_MAILBOX` — inte en fast `sleep`, som blir flakig |
| Unikt ämne per körning | annars kan testet plocka upp ett mail från en tidigare körning och bli grönt på fel bevis |
| Explicita datum | `receivedAt` kommer från **mailet**, inte väggklockan |

Testet raderar sitt eget mail. Graph **kan** radera — till skillnad från Fortnox verifikat, vars avsaknad av `DELETE` tvingade fram hela resonemanget om städbara serier och räkenskapsår.

## Ordningen i workflowet

Smoken (#1073) körs **före** stacken byggs. Är auth trasig fälls det på tio sekunder i stället för efter en container-build. Write-back tar mail-stegets roterade token när den finns, annars smokens.

Refs #1074, #1069, #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9UB9at5Tpr1A6sYEXomxB