### PR TITLE
fix(msgraph): ta bort städningen — den kräver skrivrätt vi inte vill be om

### DIFF
--- a/docs/ms-graph.md
+++ b/docs/ms-graph.md
@@ -89,9 +89,21 @@ Tre detaljer som är lätta att få fel:
 - **`receivedAt` kommer från MAILET**, inte väggklockan, så körningen beter sig
   likadant oavsett när på dygnet den startar.
 
-Testet raderar sitt eget mail när det är klart. Graph **kan** radera — till
-skillnad från Fortnox verifikat, vars avsaknad av `DELETE` tvingade fram hela
-resonemanget om städbara serier och räkenskapsår.
+### Städningen: testmailen ligger kvar, med flit
+
+Graph **kan** radera — till skillnad från Fortnox verifikat, vars avsaknad av
+`DELETE` tvingade fram hela resonemanget om städbara serier och räkenskapsår.
+Men `DELETE /me/messages/{id}` kräver `Mail.ReadWrite`, och det är enligt
+Microsofts egen tabell den LÄGSTA behörighet som duger (verifierat 2026-09-06;
+första skarpa körningen svarade 403).
+
+AVA läser och skickar mail. Att be varje jurist om **skrivrätt** till sin egen
+brevlåda — för att ett testflöde ska kunna städa efter sig — är precis den
+sortens över-fråga ADR 0036 argumenterar emot. Consent-dialogen ska gå att läsa
+och säga ja till.
+
+Ett testmail per nattlig körning ackumuleras därför i testbrevlådan. Vad vi gör
+åt det hör hemma i #1075.
 
 Lokalt (startar stacken själv):
 

--- a/tooling/scripts/msgraph-mail-e2e.ts
+++ b/tooling/scripts/msgraph-mail-e2e.ts
@@ -68,16 +68,21 @@ async function waitForMail(token: string, subject: string): Promise<GraphMessage
   );
 }
 
-/** Städa bort testmailet. Graph KAN radera — till skillnad från Fortnox verifikat. */
-async function deleteMessage(token: string, id: string): Promise<void> {
-  const res = await fetch(`${GRAPH_BASE}/me/messages/${encodeURIComponent(id)}`, {
-    method: "DELETE",
-    headers: { authorization: `Bearer ${token}` },
-  });
-  // Städning får aldrig fälla en grön körning — men tystnad är värre än en rad.
-  if (!res.ok) console.log(`⚠ Kunde inte radera testmailet (HTTP ${res.status}) — städa manuellt.`);
-  else console.log("• Testmailet raderat");
-}
+/**
+ * Ingen städning här — och det är ett medvetet val, inte en lucka.
+ *
+ * `DELETE /me/messages/{id}` kräver `Mail.ReadWrite`, som enligt Microsofts
+ * egen tabell är den LÄGSTA behörighet som duger (verifierat mot
+ * graph/api/message-delete 2026-09-06; första försöket svarade 403).
+ *
+ * AVA läser och skickar mail. Att be varje jurist om SKRIVrätt till sin egen
+ * brevlåda — för att ett testflöde ska kunna städa efter sig — är precis den
+ * sortens över-fråga ADR 0036 argumenterar emot. Consent-dialogen ska gå att
+ * läsa och säga ja till.
+ *
+ * Testmailen ackumuleras därför, ett per nattlig körning. Vad vi gör åt det
+ * hör hemma i #1075, som äger både delta-kontroll och städning.
+ */
 
 async function createMatter(c: Ava, userId: string, matterNumber: string): Promise<string> {
   const m = await c.matter.create.mutate({
@@ -150,7 +155,6 @@ async function main(): Promise<void> {
   assert(saved.timeEntry.minutes === MAIL_MINUTES, `fel antal minuter: ${saved.timeEntry.minutes}`);
   console.log(`• Tidspost: ${saved.timeEntry.minutes} min`);
 
-  await deleteMessage(token, msg.id);
   console.log("\n✓ Graph mail-E2E grön — skickat, läst som MIME, sparat och verifierat byte för byte.");
 }
 


### PR DESCRIPTION
Första **skarpa** körningen av mail-e2e:t ([34056410326](https://github.com/ulrik-s/ava/actions/runs/34056410326)) var grön men svarade `403` på `DELETE /me/messages/{id}`.

Microsofts egen behörighetstabell säger varför:

| Permission type | Least privileged | Higher privileged |
|---|---|---|
| Delegated (work or school account) | **Mail.ReadWrite** | Not available. |

Det finns alltså inget lägre alternativ.

## Varför vi inte lägger till scopet

AVA **läser och skickar** mail. Att be varje jurist om *skrivrätt* till sin egen brevlåda — för att ett testflöde ska kunna städa efter sig — är precis den sortens över-fråga ADR 0036 argumenterar emot. Consent-dialogen ska gå att läsa och säga ja till.

Alternativet vore en ⚠-rad i varje nattlig grön körning. En varning som alltid står där lär man sig att inte läsa, och då är den värre än ingen.

Testmailen ackumuleras i stället, ett per nattlig körning, och **#1075** äger frågan om vad som ska göras åt det — den issuen har redan både delta-kontroll och städning i sitt uppdrag.

## Värt att notera

Felet hittades av den skarpa körningen, inte av ett enhetstest. Det var hela poängen med #1074.

Refs #1075, #1074

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9UB9at5Tpr1A6sYEXomxB