### PR TITLE
feat(msgraph): delta-koll mot inkorgen + msal i web-appen

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "ava",
       "dependencies": {
+        "@azure/msal-browser": "^5.21.0",
         "@js-temporal/polyfill": "^0.5.1",
         "@modelcontextprotocol/server": "2.0.0",
         "@tanstack/react-query": "^5.101.0",
@@ -89,6 +90,10 @@
     "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
+
+    "@azure/msal-browser": ["@azure/msal-browser@5.21.0", "", { "dependencies": { "@azure/msal-common": "16.14.0" } }, "sha512-80OcuXDErmcEDAIH9pBtSqBsed2sPT/IWmbG3xHLoPMl5zc8TINd6SlJAbVSmN5huGa3xGAg5qR7VnpaIEK0Zw=="],
+
+    "@azure/msal-common": ["@azure/msal-common@16.14.0", "", {}, "sha512-A4rb55hI86Q9tBl/+jBj7TMz7iX2RFgQs/nExFzcAtoI/BFRVdaH5SL/MivrYD7qvweMpN8AgVvVMHV8UBYxew=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 

--- a/docs/ms-graph.md
+++ b/docs/ms-graph.md
@@ -65,10 +65,18 @@ Två steg i `ms-graph-e2e.yml`, i den ordningen med flit:
 Mail-E2E:t går hela vägen:
 
 ```
-sendMail → polla tills mailet landat → fetchMessageEml ($value, rå MIME)
-         → mail.saveIncoming mot en riktig AVA-stack
-         → läs tillbaka och jämför BYTE FÖR BYTE
+Funktion 1  sendMail → polla tills mailet landat → fetchMessageEml ($value)
+            → mail.saveIncoming mot en riktig AVA-stack
+            → läs tillbaka och jämför BYTE FÖR BYTE
+
+Funktion 2  mailDocument → polla → kontrollera att bilagan kom fram hel
 ```
+
+**Funktion 2 körs med CI-token, inte via MSAL.** MSAL:s popup går inte att köra
+obevakat — men Graph-anropen under den går, och det är den halvan som kan sluta
+fungera för att Microsoft ändrat sig. MSAL-inloggningen verifieras manuellt;
+`mailDocument` verifieras skarpt. `createDraft` går inte att täcka: att skapa
+ett utkast kräver `Mail.ReadWrite`.
 
 Sista steget är poängen. Att Graph svarade 200 säger inget om att rätt bytes
 hamnade i rätt ärende — `document.downloadContent` jämförs mot exakt de bytes
@@ -95,8 +103,9 @@ Att läsa tillbaka mailet man själv skickade svarar på *"landade det vi skicka
 rätt?"*. Den frågan kan strukturellt inte se att det landade något **mer** — en
 dubblett från en omkörning, ett halvskrivet mail från ett avbrutet jobb.
 
-Därför listas inkorgen före och efter, och skillnaden måste vara **exakt** det
-meddelande testet skapade. Två billiga listningar, inget som behöver nollställas.
+Därför listas inkorgen före och efter, och skillnaden måste vara **exakt** de
+meddelanden testet skapade (två: det inkommande och bilage-mailet från
+funktion 2). Två billiga listningar, inget som behöver nollställas.
 
 Tre detaljer som är avgörande för att kollen inte ska bli tyst:
 

--- a/docs/ms-graph.md
+++ b/docs/ms-graph.md
@@ -89,6 +89,31 @@ Tre detaljer som är lätta att få fel:
 - **`receivedAt` kommer från MAILET**, inte väggklockan, så körningen beter sig
   likadant oavsett när på dygnet den startar.
 
+### Delta-kollen
+
+Att läsa tillbaka mailet man själv skickade svarar på *"landade det vi skickade
+rätt?"*. Den frågan kan strukturellt inte se att det landade något **mer** — en
+dubblett från en omkörning, ett halvskrivet mail från ett avbrutet jobb.
+
+Därför listas inkorgen före och efter, och skillnaden måste vara **exakt** det
+meddelande testet skapade. Två billiga listningar, inget som behöver nollställas.
+
+Tre detaljer som är avgörande för att kollen inte ska bli tyst:
+
+- **Inkorgen, inte `/me/messages`.** `sendMail` sparar en kopia i Skickat, så
+  delta mot hela brevlådan hade gett två nya meddelanden varav vi bara känner
+  id:t på ett — och då är frestelsen att härleda det förväntade ur utfallet,
+  vilket gör kollen meningslös.
+- **`$top=2`.** Graph sidnumrerar med `@odata.nextLink`. Med normal sidstorlek
+  hade brevlådan behövt hundratals mail innan loopen kördes första gången —
+  månader av grönt utan att pagineringskoden någonsin testats. Två per sida
+  betyder att `nextLink` följs vid varje körning.
+- **`nextLink` följs ordagrant.** Den bär en skip-token; byggs URL:en om börjar
+  listningen om från sida ett, vilket ser ut som en hängning snarare än ett fel.
+
+Kollen tål ackumulerad historik: gamla testmail ligger i både före- och
+efter-mängden och tar ut sig själva.
+
 ### Städningen: testmailen ligger kvar, med flit
 
 Graph **kan** radera — till skillnad från Fortnox verifikat, vars avsaknad av

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     ]
   },
   "dependencies": {
+    "@azure/msal-browser": "^5.21.0",
     "@js-temporal/polyfill": "^0.5.1",
     "@modelcontextprotocol/server": "2.0.0",
     "@tanstack/react-query": "^5.101.0",

--- a/src/lib/client/integrations/office365-config.ts
+++ b/src/lib/client/integrations/office365-config.ts
@@ -1,0 +1,69 @@
+"use client";
+
+/**
+ * Konfiguration för Office 365-connectorn (#1076).
+ *
+ * Två källor, i den ordningen:
+ *
+ *  1. **localStorage** — byrån pekar ut sin EGEN app-registrering. Det är
+ *     normalfallet i self-hosted drift: varje byrå consentar i sin egen tenant,
+ *     ingen delad app-identitet över byråer.
+ *  2. **Build-time env** — bekvämlighet för dev och demo.
+ *
+ * Ingen tredje: ett hårdkodat klient-id hade betytt att alla byråer delade
+ * app-registrering, och därmed att en byrås admin-consent gällde en app någon
+ * annan också använder.
+ */
+
+import { z } from "zod";
+
+import { loadFromStorage } from "../load-from-storage";
+
+export const OFFICE365_CONFIG_KEY = "ava.office365.config";
+
+/**
+ * Scopes web-appen begär. Delmängd av ADR 0036:s lista — web-appen SKICKAR
+ * (funktion 2). Inkommande mail går via Outlook-add-in:en, som har sin egen
+ * token via `getCallbackTokenAsync` och inte behöver MSAL.
+ *
+ * `offline_access` ingår inte: MSAL sköter förnyelsen själv och begär den
+ * implicit. Att lista den skulle bara göra consent-dialogen längre.
+ */
+export const OFFICE365_SCOPES = [
+  "User.Read",
+  "Mail.Send",
+] as const;
+
+export const office365ConfigSchema = z.object({
+  /** Application (client) ID från byråns app-registrering. */
+  clientId: z.string().min(1),
+  /** Tenant-GUID, eller `organizations` för valfri arbetsplats-tenant. */
+  tenantId: z.string().min(1),
+});
+export type Office365Config = z.infer<typeof office365ConfigSchema>;
+
+/** Byggtids-defaults. Tomma strängar = inte konfigurerad. */
+function fromEnv(): Office365Config {
+  return {
+    clientId: process.env.NEXT_PUBLIC_AVA_MS_CLIENT_ID ?? "",
+    tenantId: process.env.NEXT_PUBLIC_AVA_MS_TENANT_ID ?? "",
+  };
+}
+
+/**
+ * Läs konfigurationen. Returnerar `null` när den inte är komplett — anroparen
+ * ska visa "konfigurera Office 365" i st.f. att starta ett OAuth-flöde som
+ * garanterat faller.
+ */
+export function loadOffice365Config(): Office365Config | null {
+  const env = fromEnv();
+  const stored = loadFromStorage(OFFICE365_CONFIG_KEY, office365ConfigSchema.partial(), {});
+  const merged = { clientId: stored.clientId ?? env.clientId, tenantId: stored.tenantId ?? env.tenantId };
+  const parsed = office365ConfigSchema.safeParse(merged);
+  return parsed.success ? parsed.data : null;
+}
+
+/** Authority-URL:en MSAL ska peka på. */
+export function authorityFor(config: Office365Config): string {
+  return `https://login.microsoftonline.com/${config.tenantId}`;
+}

--- a/src/lib/client/integrations/office365-connector.ts
+++ b/src/lib/client/integrations/office365-connector.ts
@@ -1,62 +1,165 @@
 "use client";
 
 /**
- * Office 365-connector. STUB tills `@azure/msal-browser` adderas som
- * dependency. När det är klart implementerar vi:
+ * Office 365-connector (#1076) — MSAL i web-appen.
  *
- *   1. MSAL `PublicClientApplication.acquireTokenPopup()` för connect
- *   2. `acquireTokenSilent()` i `getAccessToken()` med fallback till
- *      popup om refresh-token förfallit
- *   3. Token cache: MSAL hanterar själv via IndexedDB
+ * Låser upp **funktion 2** i ADR 0013: maila ut ett ärendedokument från
+ * web-appen. Funktion 1 (spara inkommande mail) går via Outlook-add-in:en och
+ * `getCallbackTokenAsync`, alltså utan MSAL.
  *
- * Konfiguration kommer från `loadOffice365Config()` som läser
- * localStorage (samma mönster som OAuth-config för GitHub).
+ * ## Två designval värda att förstå
+ *
+ * **MSAL laddas dynamiskt.** `@azure/msal-browser` är ett stort paket, och
+ * ingen som aldrig ansluter Office 365 ska betala för det i sin bundle. Därför
+ * `await import(...)` först i `connect()` — inte en toppnivå-import.
+ *
+ * **MSAL injiceras.** Popup-baserad auth går inte att enhetstesta, men allt
+ * runt omkring går: statusövergångar, tyst förnyelse med popup-fallback,
+ * felhantering. Sömmen (`MsalLike`) gör den delen testbar utan browser, och
+ * det är den delen som faktiskt kan gå sönder.
  */
 
+import { loadOffice365Config, authorityFor, OFFICE365_SCOPES } from "./office365-config";
 import { registerConnector } from "./registry";
 import type { IntegrationConnector, ConnectionStatus } from "./types";
 
-const SCOPES_DEFAULT = [
-  "User.Read",
-  "Mail.Read",
-  "Files.Read",
-  "offline_access",
-];
+/** Den delmängd av MSAL:s `PublicClientApplication` connectorn använder. */
+export interface MsalLike {
+  initialize(): Promise<void>;
+  acquireTokenPopup(req: { scopes: string[] }): Promise<MsalResult>;
+  acquireTokenSilent(req: { scopes: string[]; account: MsalAccount }): Promise<MsalResult>;
+  logoutPopup(req?: { account?: MsalAccount }): Promise<void>;
+}
 
-class Office365Connector implements IntegrationConnector {
+export interface MsalAccount {
+  readonly homeAccountId: string;
+  readonly username: string;
+  readonly name?: string;
+}
+
+export interface MsalResult {
+  readonly accessToken: string;
+  readonly account: MsalAccount | null;
+  readonly scopes?: readonly string[];
+}
+
+/** Skapar MSAL-instansen. Injicerbar; default laddar paketet dynamiskt. */
+export type MsalFactory = (opts: { clientId: string; authority: string }) => Promise<MsalLike>;
+
+/**
+ * Adaptern mot riktiga MSAL. Explicit metod för metod, inte en cast:
+ * `PublicClientApplication` är nästan strukturellt kompatibel med `MsalLike`,
+ * och "nästan" är precis vad en dubbel-cast hade dolt (ADR 0026).
+ *
+ * Skillnaden som gör adaptern nödvändig: MSAL:s `SilentRequest` vill ha en
+ * komplett `AccountInfo` (med `environment`, `tenantId`, `localAccountId` …),
+ * medan connectorn bara bär de tre fält den faktiskt läser. Det riktiga kontot
+ * slås därför upp i MSAL:s egen cache via `getAllAccounts()`.
+ */
+const defaultFactory: MsalFactory = async ({ clientId, authority }) => {
+  const msal = await import("@azure/msal-browser");
+  const app = new msal.PublicClientApplication({
+    auth: { clientId, authority, redirectUri: window.location.origin },
+    // MSAL cachar i sessionStorage som default. Tokens ska överleva en
+    // omladdning men INTE ligga kvar för nästa person vid datorn — och en
+    // advokatbyrås delade arbetsstation är inte ett påhittat fall.
+    cache: { cacheLocation: "sessionStorage" },
+  });
+  await app.initialize();
+
+  const resolve = (account: MsalAccount) => {
+    const real = app.getAllAccounts().find((a) => a.homeAccountId === account.homeAccountId);
+    if (!real) throw new Error("Kontot finns inte längre i MSAL:s cache — anslut Office 365 på nytt.");
+    return real;
+  };
+
+  return {
+    initialize: () => app.initialize(),
+    acquireTokenPopup: (req) => app.acquireTokenPopup(req),
+    acquireTokenSilent: (req) => app.acquireTokenSilent({ scopes: req.scopes, account: resolve(req.account) }),
+    logoutPopup: (req) => app.logoutPopup(req?.account ? { account: resolve(req.account) } : {}),
+  };
+};
+
+/** Översätt ett MSAL-resultat till connector-status. */
+export function statusFromResult(result: MsalResult): ConnectionStatus {
+  const acct = result.account;
+  if (!acct) return { kind: "error", message: "Microsoft returnerade ingen kontoinformation." };
+  return {
+    kind: "connected",
+    account: { id: acct.homeAccountId, displayName: acct.name ?? acct.username, email: acct.username },
+    scopes: [...(result.scopes ?? OFFICE365_SCOPES)],
+  };
+}
+
+export class Office365Connector implements IntegrationConnector {
   readonly id = "office365";
   readonly displayName = "Office 365";
-  readonly capabilities = ["mail", "files", "calendar"] as const;
+  readonly capabilities = ["mail"] as const;
 
   private status: ConnectionStatus = { kind: "disconnected" };
-  private listeners = new Set<(s: ConnectionStatus) => void>();
+  private readonly listeners = new Set<(s: ConnectionStatus) => void>();
+  private msal: MsalLike | null = null;
+  private account: MsalAccount | null = null;
+
+  constructor(private readonly factory: MsalFactory = defaultFactory) {}
 
   async getStatus(): Promise<ConnectionStatus> {
     return this.status;
   }
 
   async connect(): Promise<void> {
-    // TODO: implementera när @azure/msal-browser är installerat
-    //   const msal = await import("@azure/msal-browser");
-    //   const cfg = loadOffice365Config();
-    //   const app = new msal.PublicClientApplication({ ... });
-    //   const result = await app.acquireTokenPopup({ scopes: SCOPES_DEFAULT });
-    //   this.setStatus({ kind: "connected", account: ..., scopes: SCOPES_DEFAULT });
-    void SCOPES_DEFAULT;
-    throw new Error("Office 365-connector ej implementerad än — kräver @azure/msal-browser");
+    const config = loadOffice365Config();
+    if (!config) {
+      const message = "Office 365 är inte konfigurerad — ange klient-id och tenant under Inställningar.";
+      this.setStatus({ kind: "error", message });
+      throw new Error(message);
+    }
+    this.setStatus({ kind: "connecting" });
+    try {
+      this.msal = await this.factory({ clientId: config.clientId, authority: authorityFor(config) });
+      const result = await this.msal.acquireTokenPopup({ scopes: [...OFFICE365_SCOPES] });
+      this.account = result.account;
+      this.setStatus(statusFromResult(result));
+    } catch (e: unknown) {
+      // Statusen måste bära felet: UI:t renderas ur den, och ett kast som
+      // lämnar status på "connecting" ser ut som en evig spinner.
+      this.setStatus({ kind: "error", message: e instanceof Error ? e.message : String(e) });
+      throw e;
+    }
   }
 
   async disconnect(): Promise<void> {
-    // TODO: msal.logoutPopup() + clearCache
+    // Rensa lokalt FÖRST: går logoutPopup fel (blockerad popup, stängd flik)
+    // ska connectorn ändå sluta påstå att den är ansluten.
+    const { msal, account } = this;
+    this.msal = null;
+    this.account = null;
     this.setStatus({ kind: "disconnected" });
+    if (msal) await msal.logoutPopup(account ? { account } : {});
   }
 
+  /**
+   * Access-token, tyst om möjligt.
+   *
+   * `acquireTokenSilent` faller när MSAL:s egen refresh-token gått ut eller
+   * villkorsstyrd åtkomst kräver interaktion. Det är INTE ett fel — det är
+   * Microsofts sätt att säga "fråga användaren". Popup-fallbacken är därför
+   * en del av det normala flödet, inte en felhantering.
+   */
   async getAccessToken(): Promise<string> {
-    if (this.status.kind !== "connected") {
+    if (!this.msal || !this.account || this.status.kind !== "connected") {
       throw new Error("Office 365 är inte ansluten");
     }
-    // TODO: msal.acquireTokenSilent
-    throw new Error("Office 365-connector ej implementerad än");
+    const scopes = [...OFFICE365_SCOPES];
+    try {
+      return (await this.msal.acquireTokenSilent({ scopes, account: this.account })).accessToken;
+    } catch {
+      const result = await this.msal.acquireTokenPopup({ scopes });
+      this.account = result.account;
+      this.setStatus(statusFromResult(result));
+      return result.accessToken;
+    }
   }
 
   subscribe(listener: (s: ConnectionStatus) => void): () => void {

--- a/test/unit/client/integrations/office365-config.test.ts
+++ b/test/unit/client/integrations/office365-config.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from "vitest-compat";
+import {
+  authorityFor, loadOffice365Config, OFFICE365_CONFIG_KEY, OFFICE365_SCOPES,
+} from "@/lib/client/integrations/office365-config";
+
+/**
+ * Konfigurationen avgör VILKEN app-registrering byrån autentiserar mot. Blir
+ * den fel startar ett OAuth-flöde som faller hos Microsoft med ett fel ingen
+ * kan tolka — därför ska ofullständig config fångas här i stället.
+ */
+beforeEach(() => localStorage.removeItem(OFFICE365_CONFIG_KEY));
+
+describe("loadOffice365Config", () => {
+  it("läser byråns egen konfiguration ur localStorage", () => {
+    localStorage.setItem(OFFICE365_CONFIG_KEY, JSON.stringify({ clientId: "c", tenantId: "t" }));
+    expect(loadOffice365Config()).toEqual({ clientId: "c", tenantId: "t" });
+  });
+
+  // null, inte ett halvt objekt: anroparen ska visa "konfigurera" i st.f. att
+  // starta ett flöde som garanterat faller.
+  it("ger null när ingenting är konfigurerat", () => {
+    expect(loadOffice365Config()).toBeNull();
+  });
+
+  it("ger null när bara halva konfigurationen finns", () => {
+    localStorage.setItem(OFFICE365_CONFIG_KEY, JSON.stringify({ clientId: "c" }));
+    expect(loadOffice365Config()).toBeNull();
+  });
+
+  // En annan flik, en äldre version eller en handredigering kan ha skrivit
+  // vad som helst i localStorage.
+  it("ger null på trasig JSON i stället för att krascha", () => {
+    localStorage.setItem(OFFICE365_CONFIG_KEY, "{inte json");
+    expect(loadOffice365Config()).toBeNull();
+  });
+
+  it("ger null när värdena är tomma strängar", () => {
+    localStorage.setItem(OFFICE365_CONFIG_KEY, JSON.stringify({ clientId: "", tenantId: "" }));
+    expect(loadOffice365Config()).toBeNull();
+  });
+});
+
+describe("authorityFor", () => {
+  it("bygger tenant-scopad authority", () => {
+    expect(authorityFor({ clientId: "c", tenantId: "tid" }))
+      .toBe("https://login.microsoftonline.com/tid");
+  });
+});
+
+describe("OFFICE365_SCOPES", () => {
+  /**
+   * Web-appen SKICKAR (funktion 2). Läsning av inkommande mail går via
+   * Outlook-add-in:en med sin egen token. Skulle `Mail.Read` smyga in här
+   * växer consent-dialogen utan att någon funktion behöver det — precis den
+   * över-fråga ADR 0036 argumenterar emot.
+   */
+  it("begär bara det web-appen faktiskt använder", () => {
+    expect([...OFFICE365_SCOPES]).toEqual(["User.Read", "Mail.Send"]);
+  });
+});

--- a/test/unit/client/integrations/office365-connector.test.ts
+++ b/test/unit/client/integrations/office365-connector.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach } from "vitest-compat";
+import { OFFICE365_CONFIG_KEY } from "@/lib/client/integrations/office365-config";
+import {
+  Office365Connector, statusFromResult,
+  type MsalLike, type MsalResult, type MsalAccount,
+} from "@/lib/client/integrations/office365-connector";
+import type { ConnectionStatus } from "@/lib/client/integrations/types";
+
+/**
+ * MSAL:s popup går inte att enhetstesta — men allt runt omkring går, och det
+ * är där felen bor: statusövergångar som fastnar i "connecting", tyst
+ * förnyelse som inte faller tillbaka, en disconnect som lämnar connectorn
+ * påstående att den är ansluten.
+ */
+const ACCOUNT: MsalAccount = { homeAccountId: "h-1", username: "jurist@byra.se", name: "Jurist" };
+
+function result(token = "at-1", account: MsalAccount | null = ACCOUNT): MsalResult {
+  return { accessToken: token, account, scopes: ["User.Read", "Mail.Send"] };
+}
+
+class FakeMsal implements MsalLike {
+  popupCalls = 0;
+  silentCalls = 0;
+  logoutCalls = 0;
+  silentFails = false;
+  popupError: Error | null = null;
+
+  async initialize(): Promise<void> {}
+  async acquireTokenPopup(): Promise<MsalResult> {
+    this.popupCalls++;
+    if (this.popupError) throw this.popupError;
+    return result("at-popup");
+  }
+  async acquireTokenSilent(): Promise<MsalResult> {
+    this.silentCalls++;
+    if (this.silentFails) throw new Error("interaction_required");
+    return result("at-silent");
+  }
+  async logoutPopup(): Promise<void> {
+    this.logoutCalls++;
+  }
+}
+
+function connectorWith(msal: MsalLike): Office365Connector {
+  return new Office365Connector(async () => msal);
+}
+
+beforeEach(() => {
+  localStorage.setItem(OFFICE365_CONFIG_KEY, JSON.stringify({ clientId: "cid", tenantId: "tid" }));
+});
+
+describe("statusFromResult", () => {
+  it("mappar konto till connected", () => {
+    const s = statusFromResult(result());
+    expect(s.kind).toBe("connected");
+    if (s.kind !== "connected") throw new Error("fel status");
+    expect(s.account.email).toBe("jurist@byra.se");
+    expect(s.account.displayName).toBe("Jurist");
+  });
+
+  // Utan namn ska e-posten duga — ett tomt namn i UI:t är värre än en adress.
+  it("faller tillbaka på användarnamnet när name saknas", () => {
+    const s = statusFromResult(result("t", { homeAccountId: "h", username: "a@b.se" }));
+    if (s.kind !== "connected") throw new Error("fel status");
+    expect(s.account.displayName).toBe("a@b.se");
+  });
+
+  it("blir error när Microsoft inte gav något konto", () => {
+    expect(statusFromResult(result("t", null)).kind).toBe("error");
+  });
+});
+
+describe("connect", () => {
+  it("blir connected efter popup", async () => {
+    const c = connectorWith(new FakeMsal());
+    await c.connect();
+    expect((await c.getStatus()).kind).toBe("connected");
+  });
+
+  it("sänder statusövergångarna till prenumeranter", async () => {
+    const c = connectorWith(new FakeMsal());
+    const seen: ConnectionStatus["kind"][] = [];
+    c.subscribe((s) => seen.push(s.kind));
+    await c.connect();
+    expect(seen).toEqual(["disconnected", "connecting", "connected"]);
+  });
+
+  /**
+   * Ett kast som lämnar status på "connecting" ser ut som en evig spinner i
+   * UI:t. Felet måste hamna i statusen, inte bara i anropets rejection.
+   */
+  it("lämnar aldrig statusen på connecting när popupen faller", async () => {
+    const msal = new FakeMsal();
+    msal.popupError = new Error("user_cancelled");
+    const c = connectorWith(msal);
+    await expect(c.connect()).rejects.toThrow(/user_cancelled/);
+    const s = await c.getStatus();
+    expect(s.kind).toBe("error");
+    if (s.kind === "error") expect(s.message).toContain("user_cancelled");
+  });
+
+  // Att starta ett OAuth-flöde utan klient-id ger ett obegripligt Microsoft-fel.
+  it("vägrar när konfigurationen saknas, med ett läsbart fel", async () => {
+    localStorage.removeItem(OFFICE365_CONFIG_KEY);
+    const c = connectorWith(new FakeMsal());
+    await expect(c.connect()).rejects.toThrow(/inte konfigurerad/);
+  });
+});
+
+describe("getAccessToken", () => {
+  it("kastar när connectorn inte är ansluten", async () => {
+    await expect(connectorWith(new FakeMsal()).getAccessToken()).rejects.toThrow(/inte ansluten/);
+  });
+
+  it("hämtar tyst när det går", async () => {
+    const msal = new FakeMsal();
+    const c = connectorWith(msal);
+    await c.connect();
+    expect(await c.getAccessToken()).toBe("at-silent");
+    expect(msal.popupCalls).toBe(1); // bara connect-popupen
+  });
+
+  /**
+   * `interaction_required` är inte ett fel — det är Microsofts sätt att säga
+   * "fråga användaren". Utan fallbacken hade en utgången session sett ut som
+   * ett trasigt AVA.
+   */
+  it("faller tillbaka på popup när tyst förnyelse nekas", async () => {
+    const msal = new FakeMsal();
+    const c = connectorWith(msal);
+    await c.connect();
+    msal.silentFails = true;
+    expect(await c.getAccessToken()).toBe("at-popup");
+    expect(msal.popupCalls).toBe(2);
+  });
+});
+
+describe("disconnect", () => {
+  it("blir disconnected och loggar ut", async () => {
+    const msal = new FakeMsal();
+    const c = connectorWith(msal);
+    await c.connect();
+    await c.disconnect();
+    expect((await c.getStatus()).kind).toBe("disconnected");
+    expect(msal.logoutCalls).toBe(1);
+  });
+
+  /**
+   * Popup-blockerare finns. Faller utloggningen ska connectorn ändå ha slutat
+   * påstå att den är ansluten — annars visar UI:t ett konto användaren tror
+   * att hen loggat ut från.
+   */
+  it("nollställer status även när utloggningen faller", async () => {
+    const msal = new FakeMsal();
+    msal.logoutPopup = async () => { throw new Error("popup blocked"); };
+    const c = connectorWith(msal);
+    await c.connect();
+    await expect(c.disconnect()).rejects.toThrow(/popup blocked/);
+    expect((await c.getStatus()).kind).toBe("disconnected");
+  });
+
+  it("token kan inte hämtas efter disconnect", async () => {
+    const c = connectorWith(new FakeMsal());
+    await c.connect();
+    await c.disconnect().catch(() => {});
+    await expect(c.getAccessToken()).rejects.toThrow(/inte ansluten/);
+  });
+});

--- a/test/unit/lib/integrations/office365-connector.test.ts
+++ b/test/unit/lib/integrations/office365-connector.test.ts
@@ -1,7 +1,11 @@
 /**
- * Test för Office365Connector (stub tills @azure/msal-browser adderas).
- * Connectorn registrerar sig vid import; vi hämtar den via registry och
- * verifierar metadata, status-flöde, ej-implementerad-fel och pub/sub.
+ * Registry-sidan av Office365-connectorn: att den registrerar sig vid import,
+ * och att pub/sub-kontraktet UI:n läser status ur håller.
+ *
+ * Själva MSAL-logiken (connect, tyst förnyelse, disconnect) testas mot en
+ * injicerad söm i `test/unit/client/integrations/office365-connector.test.ts`
+ * — den kan inte nås genom registry-singletonen, som med flit bär den riktiga
+ * MSAL-fabriken.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest-compat";
@@ -15,25 +19,27 @@ function office365(): IntegrationConnector {
   return c;
 }
 
-describe("Office365Connector", () => {
+describe("Office365Connector (registry)", () => {
   beforeEach(async () => {
     // Återställ till disconnected mellan tester (delad singleton i registry).
     await office365().disconnect();
   });
 
-  it("metadata: id, displayName, capabilities", () => {
+  /**
+   * `capabilities` renderas i /settings. Den ska beskriva vad connectorn
+   * FAKTISKT kan — stubben listade "files" och "calendar" som ingen kod bakom
+   * den någonsin gjort, och scopen (`User.Read`, `Mail.Send`) räcker inte till
+   * dem. En capability-lista man inte kan lita på är sämre än en kort.
+   */
+  it("metadata: id, displayName, och bara de capabilities som finns", () => {
     const c = office365();
     expect(c.id).toBe("office365");
     expect(c.displayName).toBe("Office 365");
-    expect(c.capabilities).toEqual(expect.arrayContaining(["mail", "files", "calendar"]));
+    expect([...c.capabilities]).toEqual(["mail"]);
   });
 
   it("startar i disconnected", async () => {
     expect(await office365().getStatus()).toEqual({ kind: "disconnected" });
-  });
-
-  it("connect() kastar (ej implementerad än)", async () => {
-    await expect(office365().connect()).rejects.toThrow(/ej implementerad|msal-browser/i);
   });
 
   it("getAccessToken() kastar när disconnected", async () => {

--- a/test/unit/tooling/msgraph-delta.test.ts
+++ b/test/unit/tooling/msgraph-delta.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest-compat";
+import { assertMessageDelta, snapshotMessageIds, PAGE_SIZE } from "../../../tooling/scripts/msgraph-delta";
+
+/**
+ * Delta-kollen (#1075) är det enda som kan se att det landade något MER än
+ * testet skapade. Går pagineringen sönder rapporterar den "inget nytt" i
+ * stället för att fälla — en tyst delta-koll är värre än ingen alls, så det
+ * är pagineringen som testas hårdast här.
+ */
+function pagedFetch(pages: ReadonlyArray<{ ids: string[]; next?: string }>) {
+  const seen: string[] = [];
+  const fn = (async (url: string | URL) => {
+    seen.push(String(url));
+    const page = pages[seen.length - 1];
+    if (!page) return new Response("slut", { status: 500 });
+    return new Response(JSON.stringify({
+      value: page.ids.map((id) => ({ id })),
+      ...(page.next ? { "@odata.nextLink": page.next } : {}),
+    }), { status: 200, headers: { "content-type": "application/json" } });
+  }) as (input: string | URL, init?: RequestInit) => Promise<Response>;
+  return { fn, seen };
+}
+
+describe("snapshotMessageIds", () => {
+  it("samlar id:n från en enda sida", async () => {
+    const { fn } = pagedFetch([{ ids: ["a", "b"] }]);
+    expect([...await snapshotMessageIds(fn, "t", "/start")]).toEqual(["a", "b"]);
+  });
+
+  // Utan nextLink-loopen tystnar listningen vid sidbrytningen.
+  it("följer @odata.nextLink över flera sidor", async () => {
+    const { fn } = pagedFetch([
+      { ids: ["a"], next: "/s2" },
+      { ids: ["b"], next: "/s3" },
+      { ids: ["c"] },
+    ]);
+    expect([...await snapshotMessageIds(fn, "t", "/s1")].sort()).toEqual(["a", "b", "c"]);
+  });
+
+  /**
+   * `nextLink` bär en skip-token och ska följas ORDAGRANT. Byggs URL:en om av
+   * oss börjar listningen om från sida ett — en oändlig loop som ser ut som
+   * en hängning, inte som ett fel.
+   */
+  it("följer nextLink ordagrant, bygger inte om URL:en", async () => {
+    const { fn, seen } = pagedFetch([{ ids: ["a"], next: "https://graph.test/x?$skiptoken=ABC" }, { ids: ["b"] }]);
+    await snapshotMessageIds(fn, "t", "/start");
+    expect(seen[1]).toBe("https://graph.test/x?$skiptoken=ABC");
+  });
+
+  it("dedupliserar id:n som återkommer mellan sidor", async () => {
+    const { fn } = pagedFetch([{ ids: ["a", "b"], next: "/s2" }, { ids: ["b", "c"] }]);
+    expect((await snapshotMessageIds(fn, "t", "/s1")).size).toBe(3);
+  });
+
+  it("tål en sida utan value", async () => {
+    const fn = (async () => new Response("{}", { status: 200 })) as never;
+    expect((await snapshotMessageIds(fn, "t", "/start")).size).toBe(0);
+  });
+
+  it("kastar med Graphs felkropp vid icke-2xx", async () => {
+    const fn = (async () => new Response('{"error":{"code":"InvalidFilter"}}', { status: 400 })) as never;
+    await expect(snapshotMessageIds(fn, "t", "/start")).rejects.toThrow(/InvalidFilter/);
+  });
+
+  // Sidstorleken måste vara liten nog att loopen körs varje gång — annars är
+  // pagineringskoden otestad i praktiken tills brevlådan vuxit i månader.
+  it("har en sidstorlek som tvingar fram paginering", () => {
+    expect(PAGE_SIZE).toBeLessThanOrEqual(5);
+  });
+});
+
+describe("assertMessageDelta", () => {
+  const before = new Set(["gammal-1", "gammal-2"]);
+
+  it("accepterar exakt det testet skapade", () => {
+    expect(() => assertMessageDelta(before, new Set([...before, "ny"]), ["ny"])).not.toThrow();
+  });
+
+  // Poängen med hela kollen: en dubblett som read-back aldrig kan se.
+  it("fäller på ett meddelande testet inte skapade", () => {
+    expect(() => assertMessageDelta(before, new Set([...before, "ny", "främling"]), ["ny"]))
+      .toThrow(/inte skapade/);
+  });
+
+  it("fäller när det förväntade meddelandet saknas", () => {
+    expect(() => assertMessageDelta(before, new Set([...before]), ["ny"])).toThrow(/saknas/);
+  });
+
+  // Gammalt skräp i både före och efter tar ut sig självt — det är därför
+  // brevlådan aldrig behöver tömmas.
+  it("bryr sig inte om ackumulerad historik", () => {
+    const stort = new Set(Array.from({ length: 500 }, (_, i) => `g-${i}`));
+    expect(() => assertMessageDelta(stort, new Set([...stort, "ny"]), ["ny"])).not.toThrow();
+  });
+});

--- a/tooling/scripts/msgraph-delta.ts
+++ b/tooling/scripts/msgraph-delta.ts
@@ -87,5 +87,6 @@ export function assertMessageDelta(
       + missing.map((id) => id.slice(0, 24) + "…").join(", "),
     );
   }
-  console.log(`  ✓ Delta: exakt ${added.length} nytt meddelande — inget mer`);
+  const ord = added.length === 1 ? "nytt meddelande" : "nya meddelanden";
+  console.log(`  ✓ Delta: exakt ${added.length} ${ord} — inget mer`);
 }

--- a/tooling/scripts/msgraph-delta.ts
+++ b/tooling/scripts/msgraph-delta.ts
@@ -1,0 +1,91 @@
+/**
+ * Delta-koll mot Graph (#1075) — motsvarigheten till Fortnox `assertVoucherDelta`.
+ *
+ * Att läsa tillbaka mailet man själv skickade svarar på "landade det vi
+ * skickade rätt?". Den frågan kan strukturellt inte se att det landade något
+ * MER — en dubblett från en omkörning, ett halvskrivet mail från ett avbrutet
+ * jobb. Det kräver aggregat: lista brevlådan FÖRE och EFTER och kräv att
+ * skillnaden är exakt det testet skapade.
+ *
+ * Delta i st.f. absoluta tal är också det som gör att brevlådan ALDRIG behöver
+ * tömmas — gamla testmail ligger i både före- och efter-mängden och tar ut sig
+ * själva. Det är tur, för städning kräver `Mail.ReadWrite` som vi medvetet inte
+ * ber om (se docs/ms-graph.md).
+ */
+
+/** Minimal fetch-form, injicerbar i test. */
+export type GraphFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+/**
+ * Sidstorlek vid listning. AVSIKTLIGT liten.
+ *
+ * Graph sidnumrerar med `@odata.nextLink`, och utan loopen tystnar listningen
+ * vid sidbrytningen — en delta-koll som rapporterar "inget nytt" i stället för
+ * att fälla är värre än ingen alls. Med normal sidstorlek hade brevlådan
+ * behövt hundratals mail innan loopen kördes första gången, alltså månader av
+ * grönt utan att koden någonsin testats.
+ *
+ * Två per sida betyder att `nextLink` följs vid VARJE körning.
+ */
+export const PAGE_SIZE = 2;
+
+interface MessageListPage {
+  readonly value?: ReadonlyArray<{ readonly id: string }>;
+  readonly "@odata.nextLink"?: string;
+}
+
+/**
+ * Alla meddelande-id:n i brevlådan, över alla sidor.
+ *
+ * `nextLink` är en KOMPLETT URL från Graph (med skip-token) — den ska följas
+ * som den är, inte byggas om av oss.
+ */
+export async function snapshotMessageIds(
+  fetchFn: GraphFetch,
+  token: string,
+  firstUrl: string,
+): Promise<Set<string>> {
+  const ids = new Set<string>();
+  let url: string | undefined = firstUrl;
+  let pages = 0;
+  // Tak mot en trasig nextLink-kedja som annars hade snurrat i evighet.
+  const MAX_PAGES = 500;
+  while (url && pages < MAX_PAGES) {
+    const res = await fetchFn(url, { headers: { authorization: `Bearer ${token}` } });
+    if (!res.ok) throw new Error(`Graph listning misslyckades: HTTP ${res.status} ${(await res.text()).slice(0, 300)}`);
+    const page = (await res.json()) as MessageListPage;
+    for (const m of page.value ?? []) ids.add(m.id);
+    url = page["@odata.nextLink"];
+    pages++;
+  }
+  if (url) throw new Error(`Graph-listningen tog aldrig slut (${MAX_PAGES} sidor) — trasig nextLink-kedja?`);
+  return ids;
+}
+
+/**
+ * Jämför efter-läget mot före-läget. `expected` är de meddelanden körningen
+ * medvetet skapade — allt annat som tillkommit är ett fynd, inte brus.
+ */
+export function assertMessageDelta(
+  before: ReadonlySet<string>, after: ReadonlySet<string>, expected: readonly string[],
+): void {
+  const added = [...after].filter((id) => !before.has(id)).sort();
+  const want = [...expected].sort();
+
+  const unexpected = added.filter((id) => !want.includes(id));
+  if (unexpected.length > 0) {
+    throw new Error(
+      `Brevlådan fick ${unexpected.length} meddelanden som testet inte skapade: `
+      + `${unexpected.map((id) => id.slice(0, 24) + "…").join(", ")}. `
+      + "Dubblett från en omkörning, eller ett avbrutet jobb — kontrollera brevlådan innan nästa körning.",
+    );
+  }
+  const missing = want.filter((id) => !added.includes(id));
+  if (missing.length > 0) {
+    throw new Error(
+      `Meddelanden saknas i brevlådan trots att sendMail lyckades: `
+      + missing.map((id) => id.slice(0, 24) + "…").join(", "),
+    );
+  }
+  console.log(`  ✓ Delta: exakt ${added.length} nytt meddelande — inget mer`);
+}

--- a/tooling/scripts/msgraph-mail-e2e.ts
+++ b/tooling/scripts/msgraph-mail-e2e.ts
@@ -24,6 +24,7 @@
 import { fetchMessageEml, sendMail, GRAPH_BASE } from "@/lib/client/graph/graph-mail";
 import { asId } from "@/lib/shared/schemas/ids";
 import { assert, clientFor, seedUser, waitForServer, type Ava } from "./e2e-harness";
+import { assertMessageDelta, snapshotMessageIds, PAGE_SIZE } from "./msgraph-delta";
 import { connectGraph, required } from "./msgraph-harness";
 import { emitRotatedToken } from "./rotated-token";
 
@@ -35,6 +36,20 @@ const POLL_INTERVAL_MS = 3_000;
 /** Tidsposten mailet ska bokföra. Explicit, inte härledd — se `receivedAt`. */
 const MAIL_MINUTES = 6;
 
+/**
+ * Allt tittande sker i INKORGEN, inte i `/me/messages`.
+ *
+ * `/me/messages` spänner över hela brevlådan, och `sendMail` sparar en kopia i
+ * Skickat. Delta mot hela brevlådan hade därför gett TVÅ nya meddelanden varav
+ * vi bara känner id:t på det ena — och frestelsen att härleda det förväntade ur
+ * utfallet gör kollen tyst meningslös.
+ *
+ * `inbox` är ett well-known folder name; adresseras det fel svarar Graph 404,
+ * högljutt. `$top` är litet med flit — se PAGE_SIZE.
+ */
+const INBOX = `${GRAPH_BASE}/me/mailFolders/inbox/messages`;
+const MESSAGES_URL = `${INBOX}?$select=id&$top=${PAGE_SIZE}`;
+
 interface GraphMessageHead {
   readonly id: string;
   readonly subject: string;
@@ -44,7 +59,7 @@ interface GraphMessageHead {
 /** Sök upp mailet på ÄMNET. Unikt per körning → aldrig en träff från en tidigare. */
 async function findBySubject(token: string, subject: string): Promise<GraphMessageHead | null> {
   const filter = encodeURIComponent(`subject eq '${subject.replace(/'/g, "''")}'`);
-  const url = `${GRAPH_BASE}/me/messages?$filter=${filter}&$select=id,subject,receivedDateTime`;
+  const url = `${INBOX}?$filter=${filter}&$select=id,subject,receivedDateTime`;
   const res = await fetch(url, { headers: { authorization: `Bearer ${token}` } });
   if (!res.ok) throw new Error(`Graph sökning misslyckades: HTTP ${res.status} ${(await res.text()).slice(0, 300)}`);
   const json = (await res.json()) as { value?: GraphMessageHead[] };
@@ -136,6 +151,11 @@ async function main(): Promise<void> {
   const subject = `AVA E2E ${stamp}`;
   const bodyText = `Ärendet GRAPH-${stamp}. Genererat av msgraph-mail-e2e.`;
 
+  // FÖRE-läget. Delta mot det här är det enda som kan se att körningen
+  // producerade något MER än ett mail — read-back kan strukturellt inte det.
+  const before = await snapshotMessageIds(fetch, token, MESSAGES_URL);
+  console.log(`• Brevlådan före: ${before.size} meddelanden`);
+
   console.log(`▸ Skickar "${subject}" till ${mailbox} …`);
   await sendMail({ token, message: { subject, body: bodyText, to: [mailbox] } });
 
@@ -179,6 +199,12 @@ async function main(): Promise<void> {
   assert(saved.timeEntry !== null, "ingen tidspost skapades");
   assert(saved.timeEntry.minutes === MAIL_MINUTES, `fel antal minuter: ${saved.timeEntry.minutes}`);
   console.log(`• Tidspost: ${saved.timeEntry.minutes} min`);
+
+  // Delta SIST, när allt testet skapar hunnit landa. Det förväntade är EXAKT
+  // det meddelande vi läste — hårdkodat, inte härlett ur utfallet. Härledde vi
+  // det ur `after` hade kollen alltid passerat och tyst slutat betyda något.
+  const after = await snapshotMessageIds(fetch, token, MESSAGES_URL);
+  assertMessageDelta(before, after, [msg.id]);
 
   console.log("\n✓ Graph mail-E2E grön — skickat, läst som MIME, sparat och verifierat byte för byte.");
 }

--- a/tooling/scripts/msgraph-mail-e2e.ts
+++ b/tooling/scripts/msgraph-mail-e2e.ts
@@ -22,6 +22,7 @@
  */
 
 import { fetchMessageEml, sendMail, GRAPH_BASE } from "@/lib/client/graph/graph-mail";
+import { mailDocument } from "@/lib/client/graph/mail-document";
 import { asId } from "@/lib/shared/schemas/ids";
 import { assert, clientFor, seedUser, waitForServer, type Ava } from "./e2e-harness";
 import { assertMessageDelta, snapshotMessageIds, PAGE_SIZE } from "./msgraph-delta";
@@ -54,6 +55,19 @@ interface GraphMessageHead {
   readonly id: string;
   readonly subject: string;
   readonly receivedDateTime: string;
+}
+
+interface GraphAttachment {
+  readonly name: string;
+  readonly size: number;
+}
+
+/** Bilagorna på ett meddelande — det funktion 2 faktiskt lovar. */
+async function attachmentsOf(token: string, id: string): Promise<GraphAttachment[]> {
+  const url = `${GRAPH_BASE}/me/messages/${encodeURIComponent(id)}/attachments?$select=name,size`;
+  const res = await fetch(url, { headers: { authorization: `Bearer ${token}` } });
+  if (!res.ok) throw new Error(`Graph bilage-listning: HTTP ${res.status} ${(await res.text()).slice(0, 300)}`);
+  return ((await res.json()) as { value?: GraphAttachment[] }).value ?? [];
 }
 
 /** Sök upp mailet på ÄMNET. Unikt per körning → aldrig en träff från en tidigare. */
@@ -200,11 +214,39 @@ async function main(): Promise<void> {
   assert(saved.timeEntry.minutes === MAIL_MINUTES, `fel antal minuter: ${saved.timeEntry.minutes}`);
   console.log(`• Tidspost: ${saved.timeEntry.minutes} min`);
 
+  // ── Funktion 2 (#1076): maila ut dokumentet igen, nu som bilaga. ──
+  // MSAL:s popup går inte att köra i CI, men Graph-anropen under den gör det.
+  // Det är den halvan som kan sluta fungera för att Microsoft ändrat sig.
+  //
+  // `sendMail`, inte `createDraft`: att skapa ett utkast kräver Mail.ReadWrite,
+  // som vi medvetet inte ber om (docs/ms-graph.md).
+  const attachSubject = `${subject} bilaga`;
+  await mailDocument({
+    token,
+    doc: { fileName: saved.document.fileName, mimeType: "message/rfc822", bytes },
+    to: [mailbox],
+    subject: attachSubject,
+    body: `Vidarebefordrar ${saved.document.fileName} från ärendet.`,
+  });
+  const attached = await poll(
+    "Bilage-mailet landade", () => findBySubject(token, attachSubject),
+    "mailDocument returnerade utan fel men mailet kom aldrig fram.",
+  );
+  const atts = await attachmentsOf(token, attached.id);
+  assert(atts.length === 1, `förväntade en bilaga, fick ${atts.length}`);
+  assert(atts[0]!.name === saved.document.fileName, `fel bilagenamn: ${atts[0]!.name}`);
+  // Graph rapporterar bilagestorleken inklusive MIME-overhead, så exakt
+  // likhet vore fel att kräva — men en bilaga som är MINDRE än innehållet
+  // betyder att något trunkerats.
+  assert(atts[0]!.size >= bytes.byteLength, `bilagan krympte: ${atts[0]!.size} < ${bytes.byteLength}`);
+  console.log(`• Bilaga levererad: ${atts[0]!.name} (${atts[0]!.size} bytes)`);
+
   // Delta SIST, när allt testet skapar hunnit landa. Det förväntade är EXAKT
-  // det meddelande vi läste — hårdkodat, inte härlett ur utfallet. Härledde vi
-  // det ur `after` hade kollen alltid passerat och tyst slutat betyda något.
+  // de två meddelanden vi själva skickade — hårdkodat, inte härlett ur
+  // utfallet. Härledde vi det ur `after` hade kollen alltid passerat och tyst
+  // slutat betyda något.
   const after = await snapshotMessageIds(fetch, token, MESSAGES_URL);
-  assertMessageDelta(before, after, [msg.id]);
+  assertMessageDelta(before, after, [msg.id, attached.id]);
 
   console.log("\n✓ Graph mail-E2E grön — skickat, läst som MIME, sparat och verifierat byte för byte.");
 }


### PR DESCRIPTION
Två issues, en PR — de möts i e2e:t: delta-kollen förväntar sig exakt de meddelanden `mailDocument` skapar.

---

## #1075 — delta-koll

Att läsa tillbaka mailet man själv skickade svarar på *"landade det vi skickade rätt?"*. Den frågan kan **strukturellt** inte se att det landade något **mer** — en dubblett från en omkörning, ett halvskrivet mail från ett avbrutet jobb.

### Tre sätt att göra kollen tyst, alla undvikna

| | Varför det spelar roll |
|---|---|
| **Inkorgen, inte `/me/messages`** | `sendMail` sparar en kopia i Skickat → delta mot hela brevlådan ger nya meddelanden vi inte känner id:t på. Frestelsen blir att härleda det förväntade ur utfallet — och en delta-koll som jämför utfallet med sig självt **passerar alltid** |
| **`$top=2`** | Graph sidnumrerar med `@odata.nextLink`. Med normal sidstorlek hade brevlådan behövt hundratals mail innan loopen kördes första gången — månader av grönt utan att pagineringskoden någonsin testats |
| **`nextLink` följs ordagrant** | den bär en skip-token; byggs URL:en om börjar listningen om från sida ett, vilket ser ut som en hängning snarare än ett fel |

Jag skrev faktiskt den första varianten fel — härledde `expected` ur `after` — och fångade det innan commit. Precis den fällan issuen varnar för: *"en tyst delta-koll är värre än ingen"*.

**Ingen städning.** Den kräver `Mail.ReadWrite` (#1087). Delta-kollen behöver den inte: gammalt skräp ligger i både före- och efter-mängden och tar ut sig självt.

---

## #1076 — MSAL

Connectorn kastade `"ej implementerad än"`. Nu gör den inte det.

**MSAL laddas dynamiskt.** Paketet är stort; ingen som aldrig ansluter Office 365 ska betala för det i sin bundle. Ratchet: 37,4 % av budgeten, oförändrat.

**MSAL injiceras.** Popupen går inte att enhetstesta, men allt runt omkring går — och det är där felen bor: en status som fastnar på `connecting` är en evig spinner, en tyst förnyelse utan fallback ser ut som ett trasigt AVA, en disconnect som faller låter connectorn påstå att den fortfarande är ansluten. 20 tester mot sömmen täcker det.

**Adaptern är explicit, inte en dubbel-cast** (ADR 0026). `PublicClientApplication` är *nästan* strukturellt kompatibel — och "nästan" är exakt vad en cast hade dolt: `SilentRequest` vill ha en komplett `AccountInfo`.

**`capabilities` smalnas** från `["mail","files","calendar"]` till `["mail"]`. Stubben listade två förmågor det aldrig funnits kod bakom, och scopen räcker inte till dem.

**Scopes: `User.Read` + `Mail.Send`.** Inte `Mail.Read` — web-appen skickar, add-in:en läser.

### mailDocument mot skarp Graph

Som issuen föreslog: MSAL:s popup går inte obevakat, men Graph-anropen under den gör det, och det är den halvan som kan sluta fungera för att Microsoft ändrat sig. E2E:t skickar dokumentet som bilaga med CI-token och kontrollerar namn och storlek på det som faktiskt kom fram. `createDraft` går inte att täcka — utkast kräver `Mail.ReadWrite`.

---

Closes #1075
Closes #1076

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9UB9at5Tpr1A6sYEXomxB